### PR TITLE
fix(jobs): shared defer_async orphan guard for 6 unguarded sites (Theme H)

### DIFF
--- a/backend/app/datasets/router_reupload.py
+++ b/backend/app/datasets/router_reupload.py
@@ -386,9 +386,7 @@ async def reupload_commit(
                     user_id=str(user.id),
                 )
 
-            await defer_with_orphan_guard(
-                _defer_priority, rollback=rollback, db=db
-            )
+            await defer_with_orphan_guard(_defer_priority, rollback=rollback, db=db)
         else:
 
             async def _defer_default() -> None:
@@ -399,9 +397,7 @@ async def reupload_commit(
                     user_id=str(user.id),
                 )
 
-            await defer_with_orphan_guard(
-                _defer_default, rollback=rollback, db=db
-            )
+            await defer_with_orphan_guard(_defer_default, rollback=rollback, db=db)
 
     return ReuploadCommitResponse(
         job_id=job.id,

--- a/backend/app/datasets/router_reupload.py
+++ b/backend/app/datasets/router_reupload.py
@@ -47,8 +47,12 @@ from app.ingest.service import (
 )
 from app.ingest.tasks import reupload_file, reupload_service
 from app.ingest.validation import validate_file_content
-from app.persistent_config import UPLOAD_MAX_SIZE_MB, get_allowed_extensions_list
+from app.jobs.defer_guard import (
+    defer_with_orphan_guard,
+    make_ingest_job_failed_rollback,
+)
 from app.jobs.models import IngestJob
+from app.persistent_config import UPLOAD_MAX_SIZE_MB, get_allowed_extensions_list
 from app.services.preview import build_gdal_source, run_service_preview
 from app.services.security import SSRFError, validate_url_for_ssrf
 from app.storage import get_storage
@@ -330,41 +334,73 @@ async def reupload_commit(
     job.user_metadata = existing_meta
     await db.commit()
 
+    # Each defer_async path is wrapped in the shared orphan guard
+    # (Theme H) so a Procrastinate outage flips the committed pending
+    # job to ``failed`` and returns HTTP 503 instead of leaving a ghost
+    # pending row for 60 minutes until stale-cleanup catches it.
+    rollback = make_ingest_job_failed_rollback(
+        job, message_prefix="Failed to queue reupload task"
+    )
+
     if job.source_url and not job.file_path:
-        await reupload_service.defer_async(
-            job_id=str(job.id),
-            dataset_id=str(dataset_id),
-            source_url=job.source_url,
-            source_layer=job.source_layer or "",
-            user_id=str(user.id),
-            token=request.token,
-        )
+        source_url = job.source_url
+
+        async def _defer_service() -> None:
+            await reupload_service.defer_async(
+                job_id=str(job.id),
+                dataset_id=str(dataset_id),
+                source_url=source_url,
+                source_layer=job.source_layer or "",
+                user_id=str(user.id),
+                token=request.token,
+            )
+
+        await defer_with_orphan_guard(_defer_service, rollback=rollback, db=db)
     else:
         # Route small files to priority queue
         import os
 
+        if job.file_path is None:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Job has no file_path and no source_url — cannot queue reupload",
+            )
+        file_path = job.file_path
+
         file_size = 0
         # Only check local files; S3 paths (no leading /) use default queue
-        if job.file_path and job.file_path.startswith("/"):
+        if file_path.startswith("/"):
             try:
-                if Path(job.file_path).exists():
-                    file_size = os.path.getsize(job.file_path)
+                if Path(file_path).exists():
+                    file_size = os.path.getsize(file_path)
             except OSError:
                 pass  # If we can't stat, use default queue
 
         if file_size > 0 and file_size <= PRIORITY_QUEUE_THRESHOLD_BYTES:
-            await reupload_file.configure(queue="priority").defer_async(
-                job_id=str(job.id),
-                dataset_id=str(dataset_id),
-                file_path=job.file_path,
-                user_id=str(user.id),
+
+            async def _defer_priority() -> None:
+                await reupload_file.configure(queue="priority").defer_async(
+                    job_id=str(job.id),
+                    dataset_id=str(dataset_id),
+                    file_path=file_path,
+                    user_id=str(user.id),
+                )
+
+            await defer_with_orphan_guard(
+                _defer_priority, rollback=rollback, db=db
             )
         else:
-            await reupload_file.defer_async(
-                job_id=str(job.id),
-                dataset_id=str(dataset_id),
-                file_path=job.file_path,
-                user_id=str(user.id),
+
+            async def _defer_default() -> None:
+                await reupload_file.defer_async(
+                    job_id=str(job.id),
+                    dataset_id=str(dataset_id),
+                    file_path=file_path,
+                    user_id=str(user.id),
+                )
+
+            await defer_with_orphan_guard(
+                _defer_default, rollback=rollback, db=db
             )
 
     return ReuploadCommitResponse(

--- a/backend/app/datasets/router_vrt.py
+++ b/backend/app/datasets/router_vrt.py
@@ -286,6 +286,7 @@ async def regenerate_vrt_endpoint(
     from app.ingest.schemas import VrtMutationResponse
     from app.ingest.service import create_ingest_job
     from app.ingest.tasks import regenerate_vrt
+    from app.jobs.defer_guard import defer_with_orphan_guard
     from app.raster.models import RasterAsset, VrtGeneration
 
     dataset = await get_dataset(db, dataset_id)
@@ -345,7 +346,11 @@ async def regenerate_vrt_endpoint(
     db.add(generation)
     await db.flush()
 
-    # Update RasterAsset
+    # Update RasterAsset — capture pre-mutation values so the orphan
+    # guard rollback (Theme H) can restore them if Procrastinate is
+    # unreachable.
+    previous_status = vrt_asset.status
+    previous_generation_id = vrt_asset.current_generation_id
     vrt_asset.status = "regenerating"
     vrt_asset.current_generation_id = generation.id
 
@@ -355,12 +360,36 @@ async def regenerate_vrt_endpoint(
 
     await db.commit()
 
-    # Dispatch task
-    await regenerate_vrt.defer_async(
-        job_id=str(job.id),
-        vrt_dataset_id=str(dataset_id),
-        triggered_by=str(user.id),
-    )
+    # Dispatch task with orphan guard.
+    # No stale-cleanup sweep exists for VRT ``status="regenerating"``
+    # or for ``VrtGeneration`` rows — a Procrastinate outage would
+    # leave the VRT permanently stuck and the generation row dangling
+    # until manual operator intervention.
+    async def _defer() -> None:
+        await regenerate_vrt.defer_async(
+            job_id=str(job.id),
+            vrt_dataset_id=str(dataset_id),
+            triggered_by=str(user.id),
+        )
+
+    async def _rollback(defer_exc: BaseException) -> None:
+        # Mark the VrtGeneration record failed so listings reflect
+        # reality (the row was already committed via db.flush +
+        # db.commit above).
+        generation.status = "failed"
+        generation.completed_at = datetime.now(timezone.utc)
+        generation.error_message = (
+            f"Failed to queue VRT regeneration: {defer_exc}"
+        )
+        # Revert VRT asset state to pre-mutation values.
+        vrt_asset.status = previous_status
+        vrt_asset.current_generation_id = previous_generation_id
+        # Mark the IngestJob failed.
+        job.status = "failed"
+        job.error_message = f"Failed to queue VRT regeneration: {defer_exc}"
+        job.completed_at = datetime.now(timezone.utc)
+
+    await defer_with_orphan_guard(_defer, rollback=_rollback, db=db)
 
     return VrtMutationResponse(
         job_id=job.id,

--- a/backend/app/datasets/router_vrt.py
+++ b/backend/app/datasets/router_vrt.py
@@ -378,9 +378,7 @@ async def regenerate_vrt_endpoint(
         # db.commit above).
         generation.status = "failed"
         generation.completed_at = datetime.now(timezone.utc)
-        generation.error_message = (
-            f"Failed to queue VRT regeneration: {defer_exc}"
-        )
+        generation.error_message = f"Failed to queue VRT regeneration: {defer_exc}"
         # Revert VRT asset state to pre-mutation values.
         vrt_asset.status = previous_status
         vrt_asset.current_generation_id = previous_generation_id

--- a/backend/app/ingest/metadata.py
+++ b/backend/app/ingest/metadata.py
@@ -368,7 +368,7 @@ async def compute_quality_score(
     ]
     if non_geom_cols:
         col_exprs = ", ".join(
-            f'COUNT({_sql_quote_ident(col["name"])}) '
+            f"COUNT({_sql_quote_ident(col['name'])}) "
             f'* 100.0 / NULLIF(COUNT(*), 0) AS "s_{i}"'
             for i, col in enumerate(non_geom_cols)
         )

--- a/backend/app/ingest/ogr.py
+++ b/backend/app/ingest/ogr.py
@@ -134,7 +134,13 @@ def _extract_common_layer_metadata(
 
     Returns ``(target_layer, metadata_dict)`` where metadata_dict carries
     the fields common to both ``run_ogrinfo`` and ``run_ogrinfo_preview``:
-    srid, geometry_type, layer_name, feature_count, all_layers.
+    srid, geometry_type, layer_name, feature_count, columns, all_layers.
+
+    ``columns`` is a list of ``{"name": str, "type": str}`` mirroring the
+    field definitions from the target layer. Populating it in the shared
+    helper (rather than only in ``run_ogrinfo_preview``) lets shapefile
+    ingest reuse the DBF-collision detector without spawning a second
+    ogrinfo subprocess (PERF-1).
 
     Raises KeyError if the JSON has no ``layers`` entry so callers can
     fall through to their fallback path. KISS-12.
@@ -160,6 +166,11 @@ def _extract_common_layer_metadata(
             coord_system = geom_fields[0].get("coordinateSystem", {})
     srid = _extract_srid_from_json(coord_system or {})
 
+    columns = [
+        {"name": f.get("name", ""), "type": f.get("type", "")}
+        for f in target_layer.get("fields", [])
+    ]
+
     all_layers = None
     if len(layers) > 1 and not layer_name:
         all_layers = [
@@ -176,6 +187,7 @@ def _extract_common_layer_metadata(
         "geometry_type": geometry_type,
         "layer_name": target_layer.get("name", ""),
         "feature_count": target_layer.get("featureCount"),
+        "columns": columns,
         "all_layers": all_layers,
     }
 
@@ -247,6 +259,7 @@ async def run_ogrinfo(file_path: str, layer_name: str | None = None) -> dict:
                 "geometry_type": None,
                 "layer_name": "",
                 "feature_count": None,
+                "columns": [],
                 "all_layers": None,
             }
         except json.JSONDecodeError:
@@ -271,6 +284,10 @@ async def run_ogrinfo(file_path: str, layer_name: str | None = None) -> dict:
         )
 
     result = _parse_text_ogrinfo(stdout.decode())
+    # Text-fallback parse doesn't extract field definitions, so the DBF
+    # collision detector will still have to fall back to ogrinfo_preview
+    # on GDAL < 3.7. Keep the key present so callers can rely on it.
+    result["columns"] = []
     result["all_layers"] = None
     return result
 
@@ -304,11 +321,8 @@ async def run_ogrinfo_preview(
         try:
             data = json.loads(stdout.decode())
             target_layer, metadata = _extract_common_layer_metadata(data, layer_name)
-            # Preview also extracts columns and sample rows.
-            metadata["columns"] = [
-                {"name": f["name"], "type": f["type"]}
-                for f in target_layer.get("fields", [])
-            ]
+            # Preview also extracts sample rows; columns come from the
+            # shared helper (PERF-1).
             metadata["sample_rows"] = [
                 feat.get("properties", {}) for feat in target_layer.get("features", [])
             ]
@@ -329,7 +343,7 @@ async def run_ogrinfo_preview(
 
     # Fallback: summary only (no sample rows)
     info = await run_ogrinfo(file_path, layer_name=layer_name)
-    info["columns"] = []
+    info.setdefault("columns", [])
     info["sample_rows"] = []
     return info
 
@@ -393,8 +407,14 @@ async def run_ogr2ogr(
             [
                 "-nlt",
                 "PROMOTE_TO_MULTI",
+                # Use a non-colliding target name so that source attributes
+                # named `geom` or `geometry` (valid GeoJSON/Shapefile/GeoPackage
+                # property names) do not clash with the pipeline geometry
+                # column at CREATE TABLE time. `rename_reserved_columns` will
+                # rename the source attribute to `src_<name>` afterwards, and
+                # `ensure_geom_column` renames this placeholder to `geom`.
                 "-lco",
-                "GEOMETRY_NAME=geom",
+                "GEOMETRY_NAME=_geolens_geom",
                 "-lco",
                 "SPATIAL_INDEX=NONE",
             ]
@@ -480,12 +500,17 @@ async def run_ogr2ogr_service(
     ]
 
     if not is_non_spatial:
-        # Spatial layers: promote to multi-geometry and reproject to WGS84
+        # Spatial layers: promote to multi-geometry and reproject to WGS84.
+        # GEOMETRY_NAME=_geolens_geom avoids a CREATE TABLE collision when the
+        # remote service publishes an attribute named `geom`/`geometry`. The
+        # post-ingest `ensure_geom_column` step renames the placeholder to
+        # `geom` after `rename_reserved_columns` has moved any source
+        # attribute to `src_<name>`.
         cmd += [
             "-nlt",
             "PROMOTE_TO_MULTI",
             "-lco",
-            "GEOMETRY_NAME=geom",
+            "GEOMETRY_NAME=_geolens_geom",
             "-lco",
             "SPATIAL_INDEX=NONE",
             "-t_srs",

--- a/backend/app/ingest/ogr.py
+++ b/backend/app/ingest/ogr.py
@@ -310,8 +310,7 @@ async def run_ogrinfo_preview(
                 for f in target_layer.get("fields", [])
             ]
             metadata["sample_rows"] = [
-                feat.get("properties", {})
-                for feat in target_layer.get("features", [])
+                feat.get("properties", {}) for feat in target_layer.get("features", [])
             ]
             return metadata
         except KeyError:

--- a/backend/app/ingest/router.py
+++ b/backend/app/ingest/router.py
@@ -1,7 +1,6 @@
 """Ingest API endpoints: file upload, preview, commit, and table registration."""
 
 import asyncio
-import json
 import math
 import uuid
 
@@ -53,11 +52,9 @@ from app.ingest.service import (
     save_upload_file,
     validate_file_extension,
 )
-from app.ingest.tasks import (
-    ingest_vrt,
-    regenerate_vrt,
-)
+from app.ingest.tasks import regenerate_vrt
 from app.ingest.validation import validate_file_content
+from app.jobs.defer_guard import defer_with_orphan_guard
 from app.persistent_config import (
     UPLOAD_ALLOWED_EXTENSIONS,
     UPLOAD_MAX_SIZE_MB,
@@ -372,6 +369,12 @@ async def upload_file(
             status="pending",
             message="File uploaded and ready for preview",
         )
+    # N4: except clause order matters. HTTPException must be caught and
+    # re-raised BEFORE the bare `except Exception`, otherwise a deliberate
+    # 4xx raised by a downstream helper (persistent config, validation,
+    # etc.) would be rewritten as a generic 500 by the fallback branch.
+    # Do not reorder these clauses without understanding the 4xx→500
+    # regression it would introduce.
     except HTTPException:
         raise
     except (IngestionError, ValueError) as exc:
@@ -526,7 +529,9 @@ async def commit_import(
     await db.commit()
 
     # Dispatch routing lives in the service layer (KISS-9).
-    await queue_ingest_job(job, str(user.id), token=token)
+    # queue_ingest_job now owns the orphan-guard: a defer failure will
+    # flip the committed pending job to failed and raise 503 (RESILIENCE-2).
+    await queue_ingest_job(job, str(user.id), db=db, token=token)
 
     return CommitResponse(
         job_id=job.id,
@@ -669,66 +674,12 @@ async def create_vrt(
     """Create a VRT dataset by combining existing raster datasets.
 
     Validates sources synchronously, then defers VRT assembly to an async task.
-    Returns a job_id for polling.
+    Returns a job_id for polling. Validation + queuing logic lives in
+    ``ingest.service.create_vrt_job`` (K5 extraction).
     """
-    from app.datasets.models import Dataset, Record
-    from app.raster.models import RasterAsset
+    from app.ingest.service import create_vrt_job
 
-    # 1. Validate minimum source count
-    if len(request.source_dataset_ids) < 2:
-        raise HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
-            detail="At least 2 source datasets are required to create a VRT",
-        )
-
-    # 2. Load RasterAsset rows for each source dataset
-    result = await db.execute(
-        select(RasterAsset)
-        .join(Dataset, RasterAsset.dataset_id == Dataset.id)
-        .join(Record, Dataset.record_id == Record.id)
-        .where(
-            Dataset.id.in_(request.source_dataset_ids),
-            Record.record_type == "raster_dataset",
-        )
-    )
-    found_assets = result.scalars().all()
-
-    # 3. Check all requested IDs were found and are raster_datasets
-    found_dataset_ids = {asset.dataset_id for asset in found_assets}
-    for sid in request.source_dataset_ids:
-        if sid not in found_dataset_ids:
-            raise HTTPException(
-                status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
-                detail=f"Source dataset {sid} not found or not a raster dataset",
-            )
-
-    # 4. Validate source compatibility
-    errors = validate_sources(request.vrt_type, list(found_assets))
-    if errors:
-        raise HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
-            detail=[e.model_dump() for e in errors],
-        )
-
-    # 5. Create IngestJob
-    job = await create_ingest_job(db, f"vrt_{request.vrt_type}", "", user.id)
-    job.user_metadata = {
-        "vrt_type": request.vrt_type,
-        "title": request.title,
-        "summary": request.summary,
-        "visibility": request.visibility,
-    }
-    await db.commit()
-
-    # 6. Defer async VRT assembly task
-    await ingest_vrt.defer_async(
-        job_id=str(job.id),
-        user_id=str(user.id),
-        source_dataset_ids=json.dumps([str(sid) for sid in request.source_dataset_ids]),
-        vrt_type=request.vrt_type,
-        resolution_strategy=request.resolution_strategy,
-    )
-
+    job = await create_vrt_job(db, request, user)
     return VrtCreateResponse(job_id=job.id, message="VRT creation queued")
 
 
@@ -850,6 +801,7 @@ async def add_vrt_source(
         max_position = -1
 
     # 7. Insert new source link
+    new_link_position = max_position + 1
     await db.execute(
         text(
             "INSERT INTO catalog.vrt_source_links(vrt_dataset_id, source_dataset_id, position) "
@@ -858,11 +810,15 @@ async def add_vrt_source(
         {
             "vrt_id": dataset_id,
             "src_id": request.source_dataset_id,
-            "pos": max_position + 1,
+            "pos": new_link_position,
         },
     )
 
-    # 8. Set VRT status to regenerating
+    # 8. Set VRT status to regenerating — capture pre-mutation values so
+    # the orphan-guard rollback (Theme H) can restore them if Procrastinate
+    # is unreachable.
+    previous_status = vrt_asset.status
+    previous_generation_id = vrt_asset.current_generation_id
     vrt_asset.status = "regenerating"
     vrt_asset.current_generation_id = uuid.uuid4()
 
@@ -870,13 +826,45 @@ async def add_vrt_source(
     job = await create_ingest_job(db, "vrt_regenerate", "", user.id)
     job.dataset_id = dataset_id
 
-    # 10. Commit + dispatch
+    # 10. Commit + dispatch.
+    # Unlike IngestJob orphans (rescued by 60-minute stale-cleanup), there
+    # is NO sweep for VRT assets stuck in ``status="regenerating"``. If
+    # Procrastinate is unreachable, the rollback below reverts the VRT
+    # asset state, deletes the inserted source link, and marks the job
+    # failed before re-raising as HTTP 503 — otherwise the VRT would be
+    # permanently stuck until an operator manually intervenes.
     await db.commit()
-    await regenerate_vrt.defer_async(
-        job_id=str(job.id),
-        vrt_dataset_id=str(dataset_id),
-        triggered_by=str(user.id),
-    )
+
+    inserted_source_id = request.source_dataset_id
+
+    async def _defer() -> None:
+        await regenerate_vrt.defer_async(
+            job_id=str(job.id),
+            vrt_dataset_id=str(dataset_id),
+            triggered_by=str(user.id),
+        )
+
+    async def _rollback(defer_exc: BaseException) -> None:
+        from datetime import datetime, timezone
+
+        # Revert VRT asset state to what it was before step 8.
+        vrt_asset.status = previous_status
+        vrt_asset.current_generation_id = previous_generation_id
+        # Delete the source link we just inserted so the VRT matches
+        # its pre-mutation source set.
+        await db.execute(
+            text(
+                "DELETE FROM catalog.vrt_source_links "
+                "WHERE vrt_dataset_id = :vrt_id AND source_dataset_id = :src_id"
+            ),
+            {"vrt_id": dataset_id, "src_id": inserted_source_id},
+        )
+        # Mark the IngestJob failed so /jobs listings reflect reality.
+        job.status = "failed"
+        job.error_message = f"Failed to queue VRT regeneration: {defer_exc}"
+        job.completed_at = datetime.now(timezone.utc)
+
+    await defer_with_orphan_guard(_defer, rollback=_rollback, db=db)
 
     return VrtMutationResponse(
         job_id=job.id, message="Source added, VRT regeneration started"
@@ -941,19 +929,23 @@ async def remove_vrt_source(
             detail="Removing this source would leave fewer than 2 sources. A VRT requires at least 2 sources.",
         )
 
-    # 4. Check source link exists
+    # 4. Check source link exists — also capture its position so the
+    # orphan-guard rollback (Theme H) can re-insert it with the original
+    # ordering if the defer fails.
     link_result = await db.execute(
         text(
-            "SELECT 1 FROM catalog.vrt_source_links "
+            "SELECT position FROM catalog.vrt_source_links "
             "WHERE vrt_dataset_id = :vrt_id AND source_dataset_id = :src_id"
         ),
         {"vrt_id": dataset_id, "src_id": source_dataset_id},
     )
-    if link_result.fetchone() is None:
+    link_row = link_result.fetchone()
+    if link_row is None:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="Source not linked to this VRT",
         )
+    deleted_link_position = link_row.position
 
     # 5. Delete the source link
     await db.execute(
@@ -964,7 +956,9 @@ async def remove_vrt_source(
         {"vrt_id": dataset_id, "src_id": source_dataset_id},
     )
 
-    # 6. Set VRT status to regenerating
+    # 6. Set VRT status to regenerating — capture pre-mutation values.
+    previous_status = vrt_asset.status
+    previous_generation_id = vrt_asset.current_generation_id
     vrt_asset.status = "regenerating"
     vrt_asset.current_generation_id = uuid.uuid4()
 
@@ -972,13 +966,46 @@ async def remove_vrt_source(
     job = await create_ingest_job(db, "vrt_regenerate", "", user.id)
     job.dataset_id = dataset_id
 
-    # 8. Commit + dispatch
+    # 8. Commit + dispatch with orphan guard (Theme H).
+    # No stale-cleanup sweep exists for VRT ``status="regenerating"``, so
+    # a Procrastinate outage would leave the VRT permanently stuck and
+    # the deleted source link gone until manual operator intervention.
+    # The rollback below re-inserts the link with its original position,
+    # reverts the VRT asset state, and marks the job failed.
     await db.commit()
-    await regenerate_vrt.defer_async(
-        job_id=str(job.id),
-        vrt_dataset_id=str(dataset_id),
-        triggered_by=str(user.id),
-    )
+
+    async def _defer() -> None:
+        await regenerate_vrt.defer_async(
+            job_id=str(job.id),
+            vrt_dataset_id=str(dataset_id),
+            triggered_by=str(user.id),
+        )
+
+    async def _rollback(defer_exc: BaseException) -> None:
+        from datetime import datetime, timezone
+
+        # Re-insert the deleted source link with its original position.
+        await db.execute(
+            text(
+                "INSERT INTO catalog.vrt_source_links("
+                "vrt_dataset_id, source_dataset_id, position) "
+                "VALUES (:vrt_id, :src_id, :pos)"
+            ),
+            {
+                "vrt_id": dataset_id,
+                "src_id": source_dataset_id,
+                "pos": deleted_link_position,
+            },
+        )
+        # Revert VRT asset state.
+        vrt_asset.status = previous_status
+        vrt_asset.current_generation_id = previous_generation_id
+        # Mark the IngestJob failed.
+        job.status = "failed"
+        job.error_message = f"Failed to queue VRT regeneration: {defer_exc}"
+        job.completed_at = datetime.now(timezone.utc)
+
+    await defer_with_orphan_guard(_defer, rollback=_rollback, db=db)
 
     return VrtMutationResponse(
         job_id=job.id, message="Source removed, VRT regeneration started"

--- a/backend/app/ingest/service.py
+++ b/backend/app/ingest/service.py
@@ -25,7 +25,11 @@ from app.ingest.metadata import (
     get_table_srid,
     grant_reader_access,
 )
-from app.ingest.schemas import DiscoveredTable, RegisterRequest
+from app.ingest.schemas import DiscoveredTable, RegisterRequest, VrtCreateRequest
+from app.jobs.defer_guard import (
+    defer_with_orphan_guard,
+    make_ingest_job_failed_rollback,
+)
 from app.jobs.models import IngestJob
 
 
@@ -343,10 +347,109 @@ async def register_existing_table(
     return dataset
 
 
+async def create_vrt_job(
+    db: AsyncSession,
+    request: VrtCreateRequest,
+    user: User,
+) -> IngestJob:
+    """Validate source raster datasets, then create + defer a VRT creation job.
+
+    K5/KISS-10 extraction: this was inline in ``router.create_vrt``. Moving it
+    here keeps the router handler to "receive request, call service, return
+    response" and gives the logic a place to be unit-tested without spinning
+    up FastAPI.
+
+    Raises:
+        HTTPException 422: Fewer than 2 sources, a source was not found or
+            is not a raster dataset, or source compatibility validation
+            failed (mismatched CRS, band counts, etc.).
+    """
+    import json
+
+    from app.datasets.models import Dataset, Record
+    from app.ingest.tasks import ingest_vrt
+    from app.raster.models import RasterAsset
+    from app.raster.validation import validate_sources
+
+    # 1. Validate minimum source count
+    if len(request.source_dataset_ids) < 2:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail="At least 2 source datasets are required to create a VRT",
+        )
+
+    # 2. Load RasterAsset rows for each source dataset
+    result = await db.execute(
+        select(RasterAsset)
+        .join(Dataset, RasterAsset.dataset_id == Dataset.id)
+        .join(Record, Dataset.record_id == Record.id)
+        .where(
+            Dataset.id.in_(request.source_dataset_ids),
+            Record.record_type == "raster_dataset",
+        )
+    )
+    found_assets = result.scalars().all()
+
+    # 3. Check all requested IDs were found and are raster_datasets
+    found_dataset_ids = {asset.dataset_id for asset in found_assets}
+    for sid in request.source_dataset_ids:
+        if sid not in found_dataset_ids:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+                detail=f"Source dataset {sid} not found or not a raster dataset",
+            )
+
+    # 4. Validate source compatibility
+    errors = validate_sources(request.vrt_type, list(found_assets))
+    if errors:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail=[e.model_dump() for e in errors],
+        )
+
+    # 5. Create IngestJob
+    job = await create_ingest_job(db, f"vrt_{request.vrt_type}", "", user.id)
+    job.user_metadata = {
+        "vrt_type": request.vrt_type,
+        "title": request.title,
+        "summary": request.summary,
+        "visibility": request.visibility,
+    }
+    await db.commit()
+
+    # 6. Defer async VRT assembly task.
+    # If Procrastinate is unreachable, the job row was already committed
+    # as ``pending`` above — the orphan guard flips it to ``failed``
+    # before propagating so stale-cleanup and /jobs listings reflect the
+    # real state instead of waiting 60 minutes for PENDING_TIMEOUT
+    # (RESILIENCE-2).
+    async def _defer_vrt() -> None:
+        await ingest_vrt.defer_async(
+            job_id=str(job.id),
+            user_id=str(user.id),
+            source_dataset_ids=json.dumps(
+                [str(sid) for sid in request.source_dataset_ids]
+            ),
+            vrt_type=request.vrt_type,
+            resolution_strategy=request.resolution_strategy,
+        )
+
+    await defer_with_orphan_guard(
+        _defer_vrt,
+        rollback=make_ingest_job_failed_rollback(
+            job, message_prefix="Failed to queue VRT task"
+        ),
+        db=db,
+    )
+
+    return job
+
+
 async def queue_ingest_job(
     job: IngestJob,
     user_id: str,
     *,
+    db: AsyncSession,
     token: str | None = None,
 ) -> None:
     """Route a committed ingest job to the right Procrastinate task.
@@ -356,8 +459,15 @@ async def queue_ingest_job(
     `ingest_raster` (file_type=raster), and `ingest_file` (default
     vector path), and sends small vector files to the priority queue.
 
+    Each ``defer_async`` call is wrapped in ``defer_with_orphan_guard``
+    (from ``app.jobs.defer_guard``) so a queue outage flips the committed
+    pending job to ``failed`` and surfaces HTTP 503, matching the
+    RESILIENCE-2 fix in ``create_vrt_job`` (Theme H in
+    ``post-impl-20260410-HANDOFF-REMAINING.md``).
+
     Raises ``HTTPException 400`` when the job has no file_path and no
     source_url so the route handler surfaces a clear error.
+    Raises ``HTTPException 503`` when Procrastinate is unreachable.
     """
     import os
 
@@ -365,13 +475,24 @@ async def queue_ingest_job(
     from app.ingest.tasks import ingest_file, ingest_raster, ingest_service
 
     if job.source_url and not job.file_path:
-        # Service job — route to ingest_service
-        await ingest_service.defer_async(
-            job_id=str(job.id),
-            source_url=job.source_url,
-            source_layer=job.source_layer or "",
-            user_id=user_id,
-            token=token,
+        # Service job — route to ingest_service. Capture source_url into
+        # a local so mypy preserves the ``str`` narrowing inside the
+        # nested closure (the attribute access reverts to ``str | None``).
+        source_url = job.source_url
+
+        async def _defer_service() -> None:
+            await ingest_service.defer_async(
+                job_id=str(job.id),
+                source_url=source_url,
+                source_layer=job.source_layer or "",
+                user_id=user_id,
+                token=token,
+            )
+
+        await defer_with_orphan_guard(
+            _defer_service,
+            rollback=make_ingest_job_failed_rollback(job),
+            db=db,
         )
         return
 
@@ -384,10 +505,17 @@ async def queue_ingest_job(
 
     if (job.user_metadata or {}).get("file_type") == "raster":
         # Raster file job — route to dedicated raster queue
-        await ingest_raster.defer_async(
-            job_id=str(job.id),
-            file_path=file_path,
-            user_id=user_id,
+        async def _defer_raster() -> None:
+            await ingest_raster.defer_async(
+                job_id=str(job.id),
+                file_path=file_path,
+                user_id=user_id,
+            )
+
+        await defer_with_orphan_guard(
+            _defer_raster,
+            rollback=make_ingest_job_failed_rollback(job),
+            db=db,
         )
         return
 
@@ -401,14 +529,30 @@ async def queue_ingest_job(
             pass  # If we can't stat, use default queue
 
     if 0 < file_size <= PRIORITY_QUEUE_THRESHOLD_BYTES:
-        await ingest_file.configure(queue="priority").defer_async(
-            job_id=str(job.id),
-            file_path=file_path,
-            user_id=user_id,
+
+        async def _defer_priority() -> None:
+            await ingest_file.configure(queue="priority").defer_async(
+                job_id=str(job.id),
+                file_path=file_path,
+                user_id=user_id,
+            )
+
+        await defer_with_orphan_guard(
+            _defer_priority,
+            rollback=make_ingest_job_failed_rollback(job),
+            db=db,
         )
     else:
-        await ingest_file.defer_async(
-            job_id=str(job.id),
-            file_path=file_path,
-            user_id=user_id,
+
+        async def _defer_default() -> None:
+            await ingest_file.defer_async(
+                job_id=str(job.id),
+                file_path=file_path,
+                user_id=user_id,
+            )
+
+        await defer_with_orphan_guard(
+            _defer_default,
+            rollback=make_ingest_job_failed_rollback(job),
+            db=db,
         )

--- a/backend/app/ingest/tasks.py
+++ b/backend/app/ingest/tasks.py
@@ -1583,7 +1583,9 @@ async def ingest_raster(job_id: str, file_path: str, user_id: str, **kwargs) -> 
                 nodata=user_nodata,
                 assign_crs=assign_crs if assign_crs and crs_missing else None,
             )
-            assert local_cog_path is not None  # check_and_prepare_cog always returns a path
+            assert (
+                local_cog_path is not None
+            )  # check_and_prepare_cog always returns a path
 
             # 7. Hash COG
             asset_sha256 = await asyncio.to_thread(sha256_file, local_cog_path)

--- a/backend/app/jobs/defer_guard.py
+++ b/backend/app/jobs/defer_guard.py
@@ -1,0 +1,132 @@
+"""Procrastinate defer-async orphan guard (Theme H).
+
+Callers of ``task.defer_async(...)`` in the route/service layer commit
+DB state (pending ``IngestJob``, VRT ``regenerating`` status, etc.)
+*before* dispatching the background task. If the Procrastinate queue is
+unreachable, the exception propagates out, the already-committed state
+leaks as an orphan, and the client sees a generic 500.
+
+For ``IngestJob`` rows, stale-cleanup picks the orphan up after 60
+minutes. For VRT asset state (``status="regenerating"``) there is **no**
+cleanup sweep — a Procrastinate outage leaves the VRT permanently stuck
+until an operator manually resets the status. This gap is what Theme H
+in ``docs-internal/audits/post-impl-20260410-HANDOFF-REMAINING.md``
+tracks.
+
+This module provides a generic guard that wraps the defer call in a
+try/except and invokes a caller-supplied rollback closure to revert the
+committed state before re-raising as HTTP 503. Each site supplies its
+own rollback because the exact state to revert differs:
+
+- Reupload paths: mark the ``IngestJob`` row failed.
+- VRT regeneration paths: revert ``vrt_asset.status`` /
+  ``current_generation_id`` to their pre-mutation values AND mark the
+  associated ``IngestJob`` / ``VrtGeneration`` failed.
+
+The original RESILIENCE-2 fix (``create_vrt_job`` /
+``queue_ingest_job``) used an ingest-local ``_defer_with_orphan_guard``
+helper that hard-coded the IngestJob rollback. This module generalizes
+that pattern so the non-ingest callers (``datasets/router_reupload.py``
+and ``datasets/router_vrt.py``) can reuse it without depending on the
+ingest service module.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, Awaitable, Callable
+
+import structlog
+from fastapi import HTTPException, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.jobs.models import IngestJob
+
+logger = structlog.get_logger()
+
+
+DeferCallable = Callable[[], Awaitable[Any]]
+"""0-arg async callable that invokes ``task.defer_async(...)``."""
+
+RollbackCallable = Callable[[BaseException], Awaitable[None]]
+"""Async callable that reverts committed DB state after a defer failure.
+
+Receives the defer exception so the rollback can embed its details in
+error messages (matches the ``f"Failed to queue ...: {exc}"`` format the
+pre-existing regression tests assert on). Must *not* commit the session
+— ``defer_with_orphan_guard`` commits after invoking the rollback.
+"""
+
+
+async def defer_with_orphan_guard(
+    defer_call: DeferCallable,
+    *,
+    rollback: RollbackCallable,
+    db: AsyncSession,
+) -> None:
+    """Run a ``defer_async`` call with rollback-on-failure semantics.
+
+    On success: no-op wrapper around ``defer_call``.
+
+    On failure:
+        1. Invoke ``rollback(defer_exc)`` to revert committed state.
+        2. Commit the rollback on ``db``.
+        3. If the rollback itself raises, log the rollback error plus
+           the original defer error (so operators see both) but still
+           re-raise the 503 below so the client retries.
+        4. Raise ``HTTPException 503`` chained from the defer error.
+
+    Args:
+        defer_call: 0-arg async closure that calls ``task.defer_async``.
+        rollback: async closure that reverts committed state. Receives
+            the defer exception for error-message embedding.
+        db: session used to commit the rollback.
+
+    Raises:
+        HTTPException 503: always, when ``defer_call`` raises.
+    """
+    try:
+        await defer_call()
+    except Exception as defer_exc:
+        try:
+            await rollback(defer_exc)
+            await db.commit()
+        except Exception:
+            # Rollback itself failed — log the rollback error plus the
+            # defer context so operators can diagnose both. Still raise
+            # 503 so the client retry flow stays consistent.
+            logger.exception(
+                "Orphan-guard rollback failed after defer error",
+                defer_error=str(defer_exc),
+            )
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Task queue unavailable, please retry",
+        ) from defer_exc
+
+
+def make_ingest_job_failed_rollback(
+    job: IngestJob,
+    *,
+    message_prefix: str = "Failed to queue ingest task",
+) -> RollbackCallable:
+    """Build a rollback closure that marks an ``IngestJob`` failed.
+
+    Convenience for the common case where the only committed state to
+    revert is a pending ``IngestJob`` row (reupload, vanilla ingest).
+    The returned closure captures ``job`` and mutates it in-place when
+    invoked — the caller is responsible for supplying ``job`` bound to
+    the same session that will commit the rollback.
+
+    The ``message_prefix`` is embedded before the defer exception string
+    so ``job.error_message`` reads like
+    ``"Failed to queue ingest task: <exc>"``. This format matches the
+    existing ``test_queue_ingest_job_*`` regression tests.
+    """
+
+    async def _rollback(defer_exc: BaseException) -> None:
+        job.status = "failed"
+        job.error_message = f"{message_prefix}: {defer_exc}"
+        job.completed_at = datetime.now(timezone.utc)
+
+    return _rollback

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -69,6 +69,7 @@ testpaths = ["tests"]
 addopts = "-m 'not perf'"
 markers = [
     "perf: performance regression tests (deselected by default)",
+    "requires_ogr2ogr: tests that invoke ogr2ogr and need build_pg_conn_str redirected to the test database (K2-PRE; fixture lives in tests/conftest.py)",
 ]
 
 [tool.coverage.run]

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -345,6 +345,41 @@ async def test_db_session(client: AsyncClient):
 # fixture below is provided for tests that need extra determinism today.
 
 
+@pytest.fixture(autouse=True)
+def _point_ogr2ogr_at_test_db(request, monkeypatch):
+    """Redirect ``ogr2ogr``'s PG connection string to the test database.
+
+    ``app.ingest.ogr.build_pg_conn_str()`` defaults to the dev/prod
+    settings. Any test that invokes ``run_ogr2ogr`` /
+    ``run_ogr2ogr_service`` without this redirect would write to the
+    wrong database and collide with non-test data. The original fixture
+    lived locally in ``test_ingest_column_preservation.py`` (K2-PRE) —
+    lifting it to ``conftest.py`` behind the ``requires_ogr2ogr`` marker
+    means any future test that opts in automatically inherits the
+    safety redirect.
+
+    Opt-in: only tests marked with ``@pytest.mark.requires_ogr2ogr``
+    (or a class-level ``pytestmark``) trigger the monkeypatch. All
+    other tests are unaffected.
+    """
+    if "requires_ogr2ogr" not in request.keywords:
+        return
+
+    from app.config import settings as _settings
+    from app.ingest import ogr as _ogr
+
+    def _test_pg_conn_str() -> str:
+        return (
+            f"PG:host={_settings.postgres_host} "
+            f"port={_settings.postgres_port} "
+            f"dbname={_settings.postgres_db_test} "
+            f"user={_settings.postgres_user} "
+            f"password={_settings.postgres_password}"
+        )
+
+    monkeypatch.setattr(_ogr, "build_pg_conn_str", _test_pg_conn_str)
+
+
 @pytest.fixture
 async def clean_tables(test_db_session):
     """Opt-in fixture: truncate user-level tables after the test.

--- a/backend/tests/fixtures/ingest/reserved_names.geojson
+++ b/backend/tests/fixtures/ingest/reserved_names.geojson
@@ -11,6 +11,7 @@
       "geometry": { "type": "Point", "coordinates": [2.3522, 48.8566] },
       "properties": {
         "gid": 100,
+        "geom": "not-actually-a-geometry",
         "geom_4326": "also-not-a-geom",
         "fid": 200,
         "ogc_fid": 300,
@@ -22,6 +23,7 @@
       "geometry": { "type": "Point", "coordinates": [-0.1278, 51.5074] },
       "properties": {
         "gid": 101,
+        "geom": "also-text",
         "geom_4326": "nope",
         "fid": 201,
         "ogc_fid": 301,

--- a/backend/tests/test_defer_orphan_guard.py
+++ b/backend/tests/test_defer_orphan_guard.py
@@ -1,0 +1,637 @@
+"""Theme H — Procrastinate defer-async orphan-guard regression tests.
+
+Covers ``app.jobs.defer_guard.defer_with_orphan_guard`` and its
+application to the six ``defer_async`` call sites that commit DB state
+*before* dispatching a Procrastinate task:
+
+- ``datasets/router_reupload.py``: reupload_service, reupload_file
+  priority, reupload_file default (3 sites)
+- ``ingest/router.py``: add_vrt_source, remove_vrt_source (2 sites)
+- ``datasets/router_vrt.py``: regenerate_vrt_endpoint (1 site)
+
+Each test simulates Procrastinate being unreachable by patching the
+task's ``defer_async`` to raise, then asserts the handler:
+  1. Invokes the caller-supplied rollback to revert committed state.
+  2. Marks the relevant ``IngestJob`` row ``failed`` (or, for VRT,
+     reverts ``vrt_asset.status`` + ``current_generation_id`` too).
+  3. Raises ``HTTPException 503``.
+
+Pure-unit style: no DB, no real files, no network. Mirrors the pattern
+in ``test_ingest.py::test_queue_ingest_job_*_defer_failure_marks_job_failed``
+and ``test_vrt_creation_173.py::test_defer_failure_marks_job_failed_and_raises_503``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import HTTPException
+
+
+# ---------------------------------------------------------------------------
+# Helper unit tests — defer_with_orphan_guard contract
+# ---------------------------------------------------------------------------
+
+
+class TestDeferWithOrphanGuard:
+    """Unit tests for the generic ``defer_with_orphan_guard`` helper."""
+
+    def test_success_path_does_not_invoke_rollback(self):
+        """On a successful defer, rollback must not run and db.commit stays untouched."""
+
+        async def _check():
+            from app.jobs.defer_guard import defer_with_orphan_guard
+
+            mock_db = AsyncMock()
+            mock_db.commit = AsyncMock()
+
+            defer_called = []
+            rollback_called = []
+
+            async def _defer() -> None:
+                defer_called.append(True)
+
+            async def _rollback(exc: BaseException) -> None:
+                rollback_called.append(exc)
+
+            await defer_with_orphan_guard(_defer, rollback=_rollback, db=mock_db)
+
+            assert defer_called == [True]
+            assert rollback_called == []
+            mock_db.commit.assert_not_called()
+
+        asyncio.run(_check())
+
+    def test_defer_failure_invokes_rollback_and_raises_503(self):
+        """Defer raising must: run rollback, commit it, and propagate as HTTP 503."""
+
+        async def _check():
+            from app.jobs.defer_guard import defer_with_orphan_guard
+
+            mock_db = AsyncMock()
+            mock_db.commit = AsyncMock()
+
+            received_exc: list[BaseException] = []
+
+            async def _defer() -> None:
+                raise RuntimeError("procrastinate unreachable")
+
+            async def _rollback(exc: BaseException) -> None:
+                received_exc.append(exc)
+
+            with pytest.raises(HTTPException) as exc_info:
+                await defer_with_orphan_guard(
+                    _defer, rollback=_rollback, db=mock_db
+                )
+
+            assert exc_info.value.status_code == 503
+            assert "retry" in str(exc_info.value.detail).lower()
+            # Rollback received the underlying exception
+            assert len(received_exc) == 1
+            assert isinstance(received_exc[0], RuntimeError)
+            assert "procrastinate unreachable" in str(received_exc[0])
+            # Helper committed the rollback before raising
+            mock_db.commit.assert_awaited_once()
+
+        asyncio.run(_check())
+
+    def test_rollback_failure_still_raises_503(self):
+        """If rollback itself raises, helper still surfaces the 503 to the client."""
+
+        async def _check():
+            from app.jobs.defer_guard import defer_with_orphan_guard
+
+            mock_db = AsyncMock()
+            mock_db.commit = AsyncMock()
+
+            async def _defer() -> None:
+                raise RuntimeError("defer failure")
+
+            async def _rollback(exc: BaseException) -> None:
+                raise ValueError("rollback crashed")
+
+            with pytest.raises(HTTPException) as exc_info:
+                await defer_with_orphan_guard(
+                    _defer, rollback=_rollback, db=mock_db
+                )
+
+            # 503 is always raised — rollback failure is logged, not swallowed.
+            assert exc_info.value.status_code == 503
+
+        asyncio.run(_check())
+
+    def test_make_ingest_job_failed_rollback_marks_job_failed(self):
+        """Convenience rollback helper mutates the IngestJob in-place."""
+
+        async def _check():
+            from app.jobs.defer_guard import make_ingest_job_failed_rollback
+
+            job = MagicMock()
+            job.status = "pending"
+            job.error_message = None
+            job.completed_at = None
+
+            rollback = make_ingest_job_failed_rollback(
+                job, message_prefix="Failed to queue custom task"
+            )
+            exc = RuntimeError("queue dead")
+            await rollback(exc)
+
+            assert job.status == "failed"
+            assert "Failed to queue custom task" in job.error_message
+            assert "queue dead" in job.error_message
+            assert job.completed_at is not None
+
+        asyncio.run(_check())
+
+
+# ---------------------------------------------------------------------------
+# Reupload router — 3 defer sites
+# ---------------------------------------------------------------------------
+
+
+def _make_reupload_job(
+    *,
+    source_url: str | None = None,
+    file_path: str | None = None,
+) -> MagicMock:
+    job = MagicMock()
+    job.id = uuid.uuid4()
+    job.status = "pending"
+    job.error_message = None
+    job.completed_at = None
+    job.source_url = source_url
+    job.file_path = file_path
+    job.source_layer = "layer1" if source_url else None
+    job.user_metadata = {}
+    job.dataset_id = None
+    return job
+
+
+def _make_reupload_db(job: MagicMock) -> AsyncMock:
+    mock_db = AsyncMock()
+    mock_db.commit = AsyncMock()
+    # First execute returns the dataset (not-None), second returns the job.
+    # The reupload_commit handler does: get_dataset + select(IngestJob).
+    # get_dataset is patched separately; the job select returns the job.
+    result_mock = MagicMock()
+    result_mock.scalar_one_or_none.return_value = job
+    mock_db.execute = AsyncMock(return_value=result_mock)
+    return mock_db
+
+
+class TestReuploadOrphanGuard:
+    """Verify reupload defer sites flip the job to ``failed`` on defer failure."""
+
+    def test_reupload_service_defer_failure_marks_job_failed(self):
+        """RESILIENCE-2 extension: service reupload defer crash → 503 + failed job."""
+
+        async def _check():
+            from app.datasets.router_reupload import reupload_commit
+            from app.datasets.schemas import ReuploadCommitRequest
+
+            dataset_id = uuid.uuid4()
+            job = _make_reupload_job(source_url="https://example.com/arcgis/0")
+            mock_db = _make_reupload_db(job)
+            mock_user = MagicMock()
+            mock_user.id = uuid.uuid4()
+
+            mock_dataset = MagicMock()
+
+            request = ReuploadCommitRequest(token=None)
+
+            failing_defer = AsyncMock(
+                side_effect=RuntimeError("reupload_service queue down")
+            )
+
+            with (
+                patch(
+                    "app.datasets.router_reupload.get_dataset",
+                    new=AsyncMock(return_value=mock_dataset),
+                ),
+                patch("app.datasets.router_reupload.reupload_service") as mock_task,
+            ):
+                mock_task.defer_async = failing_defer
+                with pytest.raises(HTTPException) as exc_info:
+                    await reupload_commit(
+                        dataset_id, job.id, request, mock_user, mock_db
+                    )
+
+            assert exc_info.value.status_code == 503
+            assert job.status == "failed"
+            assert "reupload_service queue down" in job.error_message
+            assert job.completed_at is not None
+
+        asyncio.run(_check())
+
+    def test_reupload_file_priority_defer_failure_marks_job_failed(self, tmp_path):
+        """Priority-queue reupload defer crash → 503 + failed job."""
+
+        async def _check():
+            from app.datasets.router_reupload import reupload_commit
+            from app.datasets.schemas import ReuploadCommitRequest
+
+            upload_file = tmp_path / "tiny.geojson"
+            upload_file.write_text('{"type":"FeatureCollection","features":[]}')
+
+            dataset_id = uuid.uuid4()
+            job = _make_reupload_job(file_path=str(upload_file))
+            mock_db = _make_reupload_db(job)
+            mock_user = MagicMock()
+            mock_user.id = uuid.uuid4()
+
+            mock_dataset = MagicMock()
+            request = ReuploadCommitRequest(token=None)
+
+            failing_defer = AsyncMock(
+                side_effect=RuntimeError("priority queue dead")
+            )
+
+            with (
+                patch(
+                    "app.datasets.router_reupload.get_dataset",
+                    new=AsyncMock(return_value=mock_dataset),
+                ),
+                patch("app.datasets.router_reupload.reupload_file") as mock_task,
+            ):
+                priority_task = MagicMock()
+                priority_task.defer_async = failing_defer
+                mock_task.configure.return_value = priority_task
+                mock_task.defer_async = failing_defer
+                with pytest.raises(HTTPException) as exc_info:
+                    await reupload_commit(
+                        dataset_id, job.id, request, mock_user, mock_db
+                    )
+
+            assert exc_info.value.status_code == 503
+            assert job.status == "failed"
+            assert "priority queue dead" in job.error_message
+
+        asyncio.run(_check())
+
+    def test_reupload_file_default_defer_failure_marks_job_failed(self):
+        """Default-queue reupload (no local file) defer crash → 503 + failed job."""
+
+        async def _check():
+            from app.datasets.router_reupload import reupload_commit
+            from app.datasets.schemas import ReuploadCommitRequest
+
+            # Non-local path (S3-ish) — triggers the default-queue branch.
+            dataset_id = uuid.uuid4()
+            job = _make_reupload_job(file_path="s3://bucket/path/file.geojson")
+            mock_db = _make_reupload_db(job)
+            mock_user = MagicMock()
+            mock_user.id = uuid.uuid4()
+
+            mock_dataset = MagicMock()
+            request = ReuploadCommitRequest(token=None)
+
+            failing_defer = AsyncMock(
+                side_effect=RuntimeError("default queue dead")
+            )
+
+            with (
+                patch(
+                    "app.datasets.router_reupload.get_dataset",
+                    new=AsyncMock(return_value=mock_dataset),
+                ),
+                patch("app.datasets.router_reupload.reupload_file") as mock_task,
+            ):
+                mock_task.defer_async = failing_defer
+                with pytest.raises(HTTPException) as exc_info:
+                    await reupload_commit(
+                        dataset_id, job.id, request, mock_user, mock_db
+                    )
+
+            assert exc_info.value.status_code == 503
+            assert job.status == "failed"
+            assert "default queue dead" in job.error_message
+
+        asyncio.run(_check())
+
+
+# ---------------------------------------------------------------------------
+# VRT source add/remove — ingest/router.py
+# ---------------------------------------------------------------------------
+
+
+def _make_vrt_asset(status: str = "ready") -> MagicMock:
+    asset = MagicMock()
+    asset.status = status
+    asset.vrt_type = "mosaic"
+    asset.current_generation_id = uuid.uuid4()
+    asset.dataset_id = uuid.uuid4()
+    return asset
+
+
+class TestVrtSourceOrphanGuard:
+    """Verify VRT add/remove defer failures revert asset state + mark job failed."""
+
+    def test_add_vrt_source_defer_failure_reverts_state_and_raises_503(self):
+        """VRT add_source defer crash must revert ``vrt_asset.status``, delete
+        the inserted source link, mark the IngestJob failed, and raise 503."""
+
+        async def _check():
+            from app.ingest.router import add_vrt_source
+            from app.ingest.schemas import VrtAddSourceRequest
+
+            dataset_id = uuid.uuid4()
+            source_id = uuid.uuid4()
+            request = VrtAddSourceRequest(source_dataset_id=source_id)
+            mock_user = MagicMock()
+            mock_user.id = uuid.uuid4()
+
+            vrt_asset = _make_vrt_asset(status="ready")
+            original_status = vrt_asset.status
+            original_generation_id = vrt_asset.current_generation_id
+
+            source_asset = MagicMock()
+            existing_source_asset = MagicMock()
+
+            job_id = uuid.uuid4()
+            mock_job = MagicMock()
+            mock_job.id = job_id
+            mock_job.status = "pending"
+            mock_job.error_message = None
+            mock_job.completed_at = None
+
+            mock_db = AsyncMock()
+            mock_db.commit = AsyncMock()
+
+            call_count = [0]
+
+            def execute_side_effect(query, params=None):
+                call_count[0] += 1
+                n = call_count[0]
+                result_mock = MagicMock()
+                if n == 1:
+                    # 1. Load VRT RasterAsset
+                    result_mock.scalar_one_or_none.return_value = vrt_asset
+                elif n == 2:
+                    # 3. Validate source exists
+                    result_mock.scalar_one_or_none.return_value = source_asset
+                elif n == 3:
+                    # 4. Duplicate check — not found
+                    result_mock.fetchone.return_value = None
+                elif n == 4:
+                    # 5. Existing source links
+                    result_mock.fetchall.return_value = [
+                        MagicMock(source_dataset_id=uuid.uuid4())
+                    ]
+                elif n == 5:
+                    # 5. Existing assets
+                    result_mock.scalars.return_value.all.return_value = [
+                        existing_source_asset
+                    ]
+                elif n == 6:
+                    # 6. Max position
+                    result_mock.scalar.return_value = 0
+                # n == 7: INSERT (no return needed)
+                # n == 8: DELETE (rollback re-deletes)
+                return result_mock
+
+            mock_db.execute = AsyncMock(side_effect=execute_side_effect)
+
+            async def mock_create_ingest_job(db, *args, **kwargs):
+                return mock_job
+
+            failing_defer = AsyncMock(
+                side_effect=RuntimeError("vrt add_source queue dead")
+            )
+
+            with (
+                patch(
+                    "app.ingest.router.create_ingest_job",
+                    new=mock_create_ingest_job,
+                ),
+                patch("app.ingest.router.validate_sources", return_value=[]),
+                patch("app.ingest.router.regenerate_vrt") as mock_task,
+            ):
+                mock_task.defer_async = failing_defer
+                with pytest.raises(HTTPException) as exc_info:
+                    await add_vrt_source(dataset_id, request, mock_user, mock_db)
+
+            assert exc_info.value.status_code == 503
+            # VRT asset state reverted
+            assert vrt_asset.status == original_status
+            assert vrt_asset.current_generation_id == original_generation_id
+            # IngestJob marked failed
+            assert mock_job.status == "failed"
+            assert "vrt add_source queue dead" in mock_job.error_message
+            # At least one DELETE must have been issued for the inserted link
+            # (call index 8 onwards corresponds to the rollback DELETE).
+            assert call_count[0] >= 8
+
+        asyncio.run(_check())
+
+    def test_remove_vrt_source_defer_failure_reverts_state_and_raises_503(self):
+        """VRT remove_source defer crash must revert state, re-insert the
+        deleted source link with its original position, mark the job failed,
+        and raise 503."""
+
+        async def _check():
+            from app.ingest.router import remove_vrt_source
+
+            dataset_id = uuid.uuid4()
+            source_dataset_id = uuid.uuid4()
+            mock_user = MagicMock()
+            mock_user.id = uuid.uuid4()
+
+            vrt_asset = _make_vrt_asset(status="ready")
+            original_status = vrt_asset.status
+            original_generation_id = vrt_asset.current_generation_id
+
+            job_id = uuid.uuid4()
+            mock_job = MagicMock()
+            mock_job.id = job_id
+            mock_job.status = "pending"
+            mock_job.error_message = None
+            mock_job.completed_at = None
+
+            mock_db = AsyncMock()
+            mock_db.commit = AsyncMock()
+
+            call_count = [0]
+            rollback_insert_params: dict = {}
+
+            def execute_side_effect(query, params=None):
+                call_count[0] += 1
+                n = call_count[0]
+                result_mock = MagicMock()
+                if n == 1:
+                    # 1. Load VRT RasterAsset
+                    result_mock.scalar_one_or_none.return_value = vrt_asset
+                elif n == 2:
+                    # 3. Source count
+                    result_mock.scalar.return_value = 3
+                elif n == 3:
+                    # 4. Link existence check — found with position=5
+                    link_row = MagicMock()
+                    link_row.position = 5
+                    result_mock.fetchone.return_value = link_row
+                elif n == 4:
+                    # 5. DELETE link
+                    pass
+                elif n == 5:
+                    # Rollback: INSERT link
+                    rollback_insert_params.update(params or {})
+                return result_mock
+
+            mock_db.execute = AsyncMock(side_effect=execute_side_effect)
+
+            async def mock_create_ingest_job(db, *args, **kwargs):
+                return mock_job
+
+            failing_defer = AsyncMock(
+                side_effect=RuntimeError("vrt remove_source queue dead")
+            )
+
+            with (
+                patch(
+                    "app.ingest.router.create_ingest_job",
+                    new=mock_create_ingest_job,
+                ),
+                patch("app.ingest.router.regenerate_vrt") as mock_task,
+            ):
+                mock_task.defer_async = failing_defer
+                with pytest.raises(HTTPException) as exc_info:
+                    await remove_vrt_source(
+                        dataset_id, source_dataset_id, mock_user, mock_db
+                    )
+
+            assert exc_info.value.status_code == 503
+            # VRT asset state reverted
+            assert vrt_asset.status == original_status
+            assert vrt_asset.current_generation_id == original_generation_id
+            # IngestJob marked failed
+            assert mock_job.status == "failed"
+            assert "vrt remove_source queue dead" in mock_job.error_message
+            # Rollback re-inserted the link with the captured position=5
+            assert rollback_insert_params.get("pos") == 5
+            assert rollback_insert_params.get("src_id") == source_dataset_id
+
+        asyncio.run(_check())
+
+
+# ---------------------------------------------------------------------------
+# VRT datasets router — regenerate_vrt_endpoint
+# ---------------------------------------------------------------------------
+
+
+class TestDatasetsVrtOrphanGuard:
+    """Verify datasets/router_vrt.py::regenerate_vrt_endpoint defer-failure path."""
+
+    def test_regenerate_vrt_defer_failure_reverts_state_and_marks_generation_failed(
+        self,
+    ):
+        """Defer crash during manual VRT regen must: revert ``vrt_asset``
+        state, mark ``VrtGeneration`` + ``IngestJob`` failed, raise 503."""
+
+        async def _check():
+            from app.datasets.router_vrt import regenerate_vrt_endpoint
+
+            dataset_id = uuid.uuid4()
+            mock_user = MagicMock()
+            mock_user.id = uuid.uuid4()
+
+            vrt_asset = _make_vrt_asset(status="ready")
+            original_status = vrt_asset.status
+            original_generation_id = vrt_asset.current_generation_id
+
+            generation = MagicMock()
+            generation.id = uuid.uuid4()
+            generation.status = "pending"
+            generation.completed_at = None
+            generation.error_message = None
+
+            job_id = uuid.uuid4()
+            mock_job = MagicMock()
+            mock_job.id = job_id
+            mock_job.status = "pending"
+            mock_job.error_message = None
+            mock_job.completed_at = None
+
+            # Mock dataset with vrt_dataset record_type
+            mock_record = MagicMock()
+            mock_record.record_type = "vrt_dataset"
+            mock_dataset = MagicMock()
+            mock_dataset.record = mock_record
+
+            mock_db = AsyncMock()
+            mock_db.commit = AsyncMock()
+            mock_db.flush = AsyncMock()
+            mock_db.add = MagicMock()
+
+            call_count = [0]
+
+            def execute_side_effect(query, params=None):
+                call_count[0] += 1
+                n = call_count[0]
+                result_mock = MagicMock()
+                if n == 1:
+                    # Load VRT RasterAsset
+                    result_mock.scalar_one_or_none.return_value = vrt_asset
+                elif n == 2:
+                    # Advisory lock acquired
+                    result_mock.scalar.return_value = True
+                elif n == 3:
+                    # Source count
+                    result_mock.scalar.return_value = 3
+                return result_mock
+
+            mock_db.execute = AsyncMock(side_effect=execute_side_effect)
+
+            async def mock_create_ingest_job(db, *args, **kwargs):
+                return mock_job
+
+            # Patch VrtGeneration constructor to return our tracked mock
+            # so we can assert its fields were updated in rollback.
+            def mock_vrt_generation_ctor(**kwargs):
+                generation.vrt_dataset_id = kwargs.get("vrt_dataset_id")
+                generation.source_count = kwargs.get("source_count")
+                generation.triggered_by = kwargs.get("triggered_by")
+                return generation
+
+            failing_defer = AsyncMock(
+                side_effect=RuntimeError("regenerate_vrt queue dead")
+            )
+
+            with (
+                patch(
+                    "app.datasets.router_vrt.get_dataset",
+                    new=AsyncMock(return_value=mock_dataset),
+                ),
+                patch(
+                    "app.datasets.router_vrt.check_dataset_access",
+                    new=AsyncMock(),
+                ),
+                patch(
+                    "app.ingest.service.create_ingest_job",
+                    new=mock_create_ingest_job,
+                ),
+                patch(
+                    "app.raster.models.VrtGeneration",
+                    side_effect=mock_vrt_generation_ctor,
+                ),
+                patch("app.ingest.tasks.regenerate_vrt") as mock_task,
+            ):
+                mock_task.defer_async = failing_defer
+                with pytest.raises(HTTPException) as exc_info:
+                    await regenerate_vrt_endpoint(dataset_id, mock_user, mock_db)
+
+            assert exc_info.value.status_code == 503
+            # VRT asset state reverted
+            assert vrt_asset.status == original_status
+            assert vrt_asset.current_generation_id == original_generation_id
+            # VrtGeneration marked failed
+            assert generation.status == "failed"
+            assert "regenerate_vrt queue dead" in (generation.error_message or "")
+            assert generation.completed_at is not None
+            # IngestJob marked failed
+            assert mock_job.status == "failed"
+            assert "regenerate_vrt queue dead" in mock_job.error_message
+
+        asyncio.run(_check())

--- a/backend/tests/test_defer_orphan_guard.py
+++ b/backend/tests/test_defer_orphan_guard.py
@@ -83,9 +83,7 @@ class TestDeferWithOrphanGuard:
                 received_exc.append(exc)
 
             with pytest.raises(HTTPException) as exc_info:
-                await defer_with_orphan_guard(
-                    _defer, rollback=_rollback, db=mock_db
-                )
+                await defer_with_orphan_guard(_defer, rollback=_rollback, db=mock_db)
 
             assert exc_info.value.status_code == 503
             assert "retry" in str(exc_info.value.detail).lower()
@@ -114,9 +112,7 @@ class TestDeferWithOrphanGuard:
                 raise ValueError("rollback crashed")
 
             with pytest.raises(HTTPException) as exc_info:
-                await defer_with_orphan_guard(
-                    _defer, rollback=_rollback, db=mock_db
-                )
+                await defer_with_orphan_guard(_defer, rollback=_rollback, db=mock_db)
 
             # 503 is always raised — rollback failure is logged, not swallowed.
             assert exc_info.value.status_code == 503
@@ -246,9 +242,7 @@ class TestReuploadOrphanGuard:
             mock_dataset = MagicMock()
             request = ReuploadCommitRequest(token=None)
 
-            failing_defer = AsyncMock(
-                side_effect=RuntimeError("priority queue dead")
-            )
+            failing_defer = AsyncMock(side_effect=RuntimeError("priority queue dead"))
 
             with (
                 patch(
@@ -289,9 +283,7 @@ class TestReuploadOrphanGuard:
             mock_dataset = MagicMock()
             request = ReuploadCommitRequest(token=None)
 
-            failing_defer = AsyncMock(
-                side_effect=RuntimeError("default queue dead")
-            )
+            failing_defer = AsyncMock(side_effect=RuntimeError("default queue dead"))
 
             with (
                 patch(

--- a/backend/tests/test_ingest.py
+++ b/backend/tests/test_ingest.py
@@ -34,7 +34,9 @@ def mock_ingest_task():
     impl audit KISS-9). Mock that single entry point so every commit_import
     path becomes a no-op.
     """
-    with patch("app.ingest.router.queue_ingest_job", new_callable=AsyncMock) as mock_task:
+    with patch(
+        "app.ingest.router.queue_ingest_job", new_callable=AsyncMock
+    ) as mock_task:
         yield mock_task
 
 

--- a/backend/tests/test_ingest_column_preservation.py
+++ b/backend/tests/test_ingest_column_preservation.py
@@ -23,37 +23,24 @@ from pathlib import Path
 import pytest
 from sqlalchemy import text
 
-pytestmark = pytest.mark.skipif(
-    shutil.which("ogr2ogr") is None,
-    reason="ogr2ogr binary not available on host (runs in backend Docker image / CI)",
-)
+# All tests in this file invoke ogr2ogr against PostGIS. Two module-level
+# guards apply:
+#
+#   1. ``pytest.mark.skipif`` bails out when the ogr2ogr binary is missing
+#      (common on dev hosts outside the backend Docker image / CI).
+#   2. ``pytest.mark.requires_ogr2ogr`` opts into the autouse
+#      ``_point_ogr2ogr_at_test_db`` fixture in ``conftest.py`` (K2-PRE),
+#      which monkey-patches ``build_pg_conn_str`` so tables land in the
+#      ``geolens_test`` database instead of dev/prod.
+pytestmark = [
+    pytest.mark.skipif(
+        shutil.which("ogr2ogr") is None,
+        reason="ogr2ogr binary not available on host (runs in backend Docker image / CI)",
+    ),
+    pytest.mark.requires_ogr2ogr,
+]
 
 FIXTURES = Path(__file__).parent / "fixtures" / "ingest"
-
-
-@pytest.fixture(autouse=True)
-def _point_ogr2ogr_at_test_db(monkeypatch):
-    """Redirect ogr2ogr's PG connection string to the test database.
-
-    `build_pg_conn_str()` defaults to the dev/prod settings, which writes
-    to the WRONG database under pytest — the test_db_session fixture uses
-    a dedicated `geolens_test` schema. Without this patch the table lands
-    in dev/prod and `get_column_info(test_db_session, table)` returns no
-    rows, which is the root cause of the "0 >= 1" failures.
-    """
-    from app.config import settings
-    from app.ingest import ogr as _ogr
-
-    def _test_pg_conn_str() -> str:
-        return (
-            f"PG:host={settings.postgres_host} "
-            f"port={settings.postgres_port} "
-            f"dbname={settings.postgres_db_test} "
-            f"user={settings.postgres_user} "
-            f"password={settings.postgres_password}"
-        )
-
-    monkeypatch.setattr(_ogr, "build_pg_conn_str", _test_pg_conn_str)
 
 
 # ---------------------------------------------------------------------------
@@ -215,15 +202,24 @@ class TestReservedNameAutoRename:
         the source attribute with reprojected geometry via UPDATE.
 
         After fix: rename_reserved_columns() runs first, renaming the source
-        geom_4326 to src_geom_4326. add_4326_column() then creates a fresh
-        geom_4326 geometry column without collision.
+        geom_4326 to src_geom_4326. ensure_geom_column() then renames the
+        pipeline placeholder (`_geolens_geom`, per S1 fix) to `geom`. Finally
+        add_4326_column() creates a fresh geom_4326 geometry column without
+        collision.
         """
-        from app.ingest.metadata import add_4326_column, rename_reserved_columns
+        from app.ingest.metadata import (
+            add_4326_column,
+            ensure_geom_column,
+            rename_reserved_columns,
+        )
 
         table = _table_id("tst_add4326")
         try:
             result = await _load_fixture(test_db_session, "reserved_names.geojson", table)
             await rename_reserved_columns(test_db_session, table)
+            # Mirror _finalize_ingest: ensure_geom_column must run before
+            # add_4326_column so the pipeline placeholder becomes `geom`.
+            await ensure_geom_column(test_db_session, table)
 
             # This previously would either crash or silently clobber the source attr.
             await add_4326_column(test_db_session, table, result["srid"] or 4326)
@@ -265,6 +261,77 @@ class TestReservedNameAutoRename:
                     f"Renamed column {target!r} not visible in get_column_info output. "
                     f"Available: {col_names}"
                 )
+        finally:
+            await _drop_table(test_db_session, table)
+
+    async def test_source_geom_attribute_renamed_to_src_geom(self, test_db_session):
+        """S1 regression: source `geom` attribute does not collide with pipeline geom.
+
+        Before fix: ogr2ogr used GEOMETRY_NAME=geom and crashed at CREATE TABLE
+        because the source file also had a `geom` attribute. Both columns would
+        be declared as `"geom" VARCHAR` and `"geom" geometry(...)`.
+
+        After fix: ogr2ogr uses GEOMETRY_NAME=_geolens_geom (placeholder),
+        rename_reserved_columns() moves the source `geom` attribute to `src_geom`,
+        then ensure_geom_column() renames the placeholder to `geom`. Both the
+        source attribute and the pipeline geometry column coexist.
+        """
+        from app.ingest.metadata import ensure_geom_column, rename_reserved_columns
+
+        table = _table_id("tst_srcgeom")
+        try:
+            # _load_fixture runs ogrinfo + ogr2ogr. Pre-fix, ogr2ogr crashes here.
+            await _load_fixture(test_db_session, "reserved_names.geojson", table)
+
+            # Apply the post-ingest normalization pipeline in order.
+            renames = await rename_reserved_columns(test_db_session, table)
+            has_geom = await ensure_geom_column(test_db_session, table)
+
+            assert has_geom is True, "Pipeline geometry column should exist"
+
+            rename_originals = {r["original"] for r in renames}
+            assert "geom" in rename_originals, (
+                f"Source `geom` attribute should have been renamed, "
+                f"got originals: {rename_originals}"
+            )
+
+            # Verify both columns exist and have the expected types.
+            result = await test_db_session.execute(
+                text(
+                    "SELECT column_name, data_type, udt_name "
+                    "FROM information_schema.columns "
+                    "WHERE table_schema='data' AND table_name=:t "
+                    "AND column_name IN ('geom', 'src_geom')"
+                ).bindparams(t=table),
+            )
+            cols_by_name = {r[0]: (r[1], r[2]) for r in result.all()}
+
+            assert "geom" in cols_by_name, (
+                "Pipeline `geom` geometry column missing after rename"
+            )
+            pipeline_type, pipeline_udt = cols_by_name["geom"]
+            assert pipeline_udt == "geometry", (
+                f"`geom` should be a PostGIS geometry column, got "
+                f"data_type={pipeline_type!r} udt_name={pipeline_udt!r}"
+            )
+
+            assert "src_geom" in cols_by_name, (
+                "Source `geom` attribute was not preserved as `src_geom`"
+            )
+            src_type, src_udt = cols_by_name["src_geom"]
+            assert src_udt != "geometry", (
+                f"`src_geom` should be the source VARCHAR/text column, got "
+                f"udt_name={src_udt!r}"
+            )
+
+            # Confirm the source values survived the rename.
+            value_result = await test_db_session.execute(
+                text(f'SELECT src_geom FROM data.{table} ORDER BY gid')
+            )
+            values = [r[0] for r in value_result.all()]
+            assert values == ["not-actually-a-geometry", "also-text"], (
+                f"Source `geom` values lost or reordered: {values}"
+            )
         finally:
             await _drop_table(test_db_session, table)
 

--- a/backend/tests/test_ingest_column_preservation.py
+++ b/backend/tests/test_ingest_column_preservation.py
@@ -89,9 +89,7 @@ async def _load_fixture(
 
 
 async def _drop_table(test_db_session, table: str) -> None:
-    await test_db_session.execute(
-        text(f"DROP TABLE IF EXISTS data.{table} CASCADE")
-    )
+    await test_db_session.execute(text(f"DROP TABLE IF EXISTS data.{table} CASCADE"))
     await test_db_session.commit()
 
 
@@ -113,7 +111,13 @@ class TestBasicAttrsRoundTrip:
         try:
             result = await _load_fixture(test_db_session, "basic_attrs.geojson", table)
             names = {c["name"] for c in result["filtered_column_info"]}
-            assert {"name", "population", "area_km2", "is_capital", "founded"} <= names, (
+            assert {
+                "name",
+                "population",
+                "area_km2",
+                "is_capital",
+                "founded",
+            } <= names, (
                 f"Expected source columns missing from column_info. Got: {names}"
             )
         finally:
@@ -215,7 +219,9 @@ class TestReservedNameAutoRename:
 
         table = _table_id("tst_add4326")
         try:
-            result = await _load_fixture(test_db_session, "reserved_names.geojson", table)
+            result = await _load_fixture(
+                test_db_session, "reserved_names.geojson", table
+            )
             await rename_reserved_columns(test_db_session, table)
             # Mirror _finalize_ingest: ensure_geom_column must run before
             # add_4326_column so the pipeline placeholder becomes `geom`.
@@ -326,7 +332,7 @@ class TestReservedNameAutoRename:
 
             # Confirm the source values survived the rename.
             value_result = await test_db_session.execute(
-                text(f'SELECT src_geom FROM data.{table} ORDER BY gid')
+                text(f"SELECT src_geom FROM data.{table} ORDER BY gid")
             )
             values = [r[0] for r in value_result.all()]
             assert values == ["not-actually-a-geometry", "also-text"], (
@@ -361,8 +367,7 @@ class TestUnicodeSampleValues:
             samples = await get_sample_values(test_db_session, table, cols)
 
             non_geom_cols = [
-                c for c in cols
-                if "geometry" not in c.get("type", "").lower()
+                c for c in cols if "geometry" not in c.get("type", "").lower()
             ]
             assert len(non_geom_cols) >= 1, "Expected at least one non-geometry column"
 

--- a/backend/tests/test_ingest_ogr_pure.py
+++ b/backend/tests/test_ingest_ogr_pure.py
@@ -332,9 +332,7 @@ class TestExtractCommonLayerMetadata:
                 {
                     "name": "roads",
                     "featureCount": 100,
-                    "coordinateSystem": {
-                        "wkt": 'PROJCS["X",AUTHORITY["EPSG","3857"]]'
-                    },
+                    "coordinateSystem": {"wkt": 'PROJCS["X",AUTHORITY["EPSG","3857"]]'},
                     "geometryFields": [{"type": "LineString"}],
                 }
             ]
@@ -486,9 +484,7 @@ class TestRunServiceImportWithWfsFallback:
         async def import_fn(layer_name: str) -> None:
             calls.append(layer_name)
 
-        asyncio.run(
-            _run_service_import_with_wfs_fallback(import_fn, "workspace:roads")
-        )
+        asyncio.run(_run_service_import_with_wfs_fallback(import_fn, "workspace:roads"))
         assert calls == ["workspace:roads"]
 
     def test_retries_with_unqualified_layer_on_ingestion_error(self):
@@ -501,9 +497,7 @@ class TestRunServiceImportWithWfsFallback:
             if ":" in layer_name:
                 raise IngestionError("WFS layer not found")
 
-        asyncio.run(
-            _run_service_import_with_wfs_fallback(import_fn, "workspace:roads")
-        )
+        asyncio.run(_run_service_import_with_wfs_fallback(import_fn, "workspace:roads"))
         assert calls == ["workspace:roads", "roads"]
 
     def test_reraises_when_layer_has_no_namespace(self):


### PR DESCRIPTION
## Summary

Closes **Theme H** + **K2-PRE** from `docs-internal/audits/post-impl-20260410-HANDOFF-REMAINING.md`.

Extracts and generalizes the earlier RESILIENCE-2 orphan-guard pattern (local `_defer_with_orphan_guard` in `app/ingest/service.py`) into a shared helper at `app/jobs/defer_guard.py`, then applies it to **six previously-unguarded `defer_async` call sites** that commit DB state before dispatching a Procrastinate task. Unlike IngestJob orphans (rescued by 60-minute stale-cleanup), there is **no sweep for VRT `status="regenerating"`** — a Procrastinate outage on a VRT site leaves the VRT permanently stuck until manual operator intervention. VRT sites are therefore effectively **P1**.

### New shared helper (`app/jobs/defer_guard.py`)

- `defer_with_orphan_guard(defer_call, *, rollback, db)` — generic wrapper that invokes a caller-supplied rollback closure if the defer raises, commits the rollback, and re-raises as HTTP 503. Rollback failures are logged but still surface the 503 so the client retry loop stays consistent.
- `make_ingest_job_failed_rollback(job, *, message_prefix)` — convenience for the common IngestJob-only case.

### Migrated sites (Theme H)

| Site | File | Rollback behavior |
|---|---|---|
| `create_vrt_job` | `ingest/service.py` | Mark IngestJob failed (replaces inline try/except) |
| `queue_ingest_job` × 4 | `ingest/service.py` | Mark IngestJob failed (migrated from local helper) |
| `reupload_commit` service | `datasets/router_reupload.py` | Mark IngestJob failed |
| `reupload_commit` priority | `datasets/router_reupload.py` | Mark IngestJob failed |
| `reupload_commit` default | `datasets/router_reupload.py` | Mark IngestJob failed |
| `add_vrt_source` | `ingest/router.py` | Revert `vrt_asset.status` + `current_generation_id`, **delete inserted source link**, mark IngestJob failed |
| `remove_vrt_source` | `ingest/router.py` | Revert asset state, **re-insert deleted link with captured position**, mark IngestJob failed |
| `regenerate_vrt_endpoint` | `datasets/router_vrt.py` | Revert asset state, **mark VrtGeneration row failed**, mark IngestJob failed |

Also fixes a latent mypy error in `router_reupload.py` where `job.file_path: str | None` was passed to `defer_async` without narrowing; now raises 400 if neither `source_url` nor `file_path` is set.

### K2-PRE (fixture lift)

Lifted `_point_ogr2ogr_at_test_db` from `tests/test_ingest_column_preservation.py` to `tests/conftest.py` behind a new `@pytest.mark.requires_ogr2ogr` marker (registered in `pyproject.toml`). Any future test that invokes `run_ogr2ogr` can opt in via the marker instead of duplicating the fixture.

### Regression tests (`tests/test_defer_orphan_guard.py`, 10 tests)

- 4 helper unit tests (success, defer failure with rollback, rollback failure still raises 503, `make_ingest_job_failed_rollback` convenience).
- 3 reupload router tests (service / priority / default defer failures).
- 2 VRT ingest router tests (`add_source` / `remove_source` — asset state revert + link insert/delete).
- 1 datasets VRT router test (`regenerate_vrt_endpoint` — asset + VrtGeneration + IngestJob revert).

## Test plan

- [x] `ruff check app/` — clean
- [x] `mypy app/ingest/ app/jobs/ app/datasets/router_reupload.py app/datasets/router_vrt.py` — Theme H code clean (pre-existing errors in unrelated reupload upload endpoints untouched)
- [x] `tests/test_defer_orphan_guard.py` — 10/10 pass
- [x] Full test subset from `HANDOFF-REMAINING.md` baseline — 488 passed locally
- [ ] CI green on this branch

## Notes

- VRT regeneration sites are flagged as **effectively P1** in the updated handoff doc. Unlike IngestJob orphans (rescued by 60-minute stale-cleanup), there is no sweep for VRT `status="regenerating"`; without this fix, a Procrastinate outage leaves the VRT permanently stuck.
- See `docs-internal/audits/post-impl-20260410-HANDOFF-REMAINING.md` for the full audit trail and remaining backlog (M1 = this PR; M2 = image rebuild done locally; S4 = CI log inspection below).