### PR TITLE
[codex] docs: start milestone v13.7 manifest automation

### DIFF
--- a/.planning/PROJECT.md
+++ b/.planning/PROJECT.md
@@ -8,7 +8,7 @@ Shipped 48 milestones (v1.0-v1.6, v1.8-v1.9, v2.0-v2.6, v3.0-v7.0, v7.2-v7.3, v8
 
 ## Current State
 
-48 milestones delivered (v1.0-v1.6, v1.8-v1.9, v2.0-v2.6, v3.0-v7.0, v7.2-v7.3, v8.0-v8.2, v9.0-v9.1, v10.0-v13.6; plus v14.0 marketing site shipped from `getgeolens.com` repo on 2026-04-13). v1.7 Marketplace & Distribution paused at Phase 40 (AWS AMI Build). Open-core architecture is **A-grade ship-ready** — Apache 2.0 licensed core, enterprise extensions register via `importlib.metadata` entry_points, auto-generated Python + TypeScript SDKs from `backend/openapi.json`, Apache-2.0 `geolens` CLI on PyPI (login/scan/publish/export-stac), SAML enterprise overlay with SP-initiated SSO + JIT provisioning + audited attribute→role mapping, documented + tested edition lifecycle (operator runbooks, admin SAML→local conversion endpoint, round-trip symmetry test), **fully extensible audit + billing + AI + governance seams** (`AuditSink`, `BillingExtension`, `AIProviderExtension`, `EmbeddingProviderExtension`, `PermissionExtension`, `WorkflowExtension`), bidirectional catalog/processing boundaries enforced through `ProcessingPort` + `CatalogPort` architecture guards, and maps/search service facades protected by private-module import guards plus size-budget checks. Latest v13.6 milestone audit passed with 21/21 requirements satisfied and no unresolved P0/P1 findings.
+48 milestones delivered (v1.0-v1.6, v1.8-v1.9, v2.0-v2.6, v3.0-v7.0, v7.2-v7.3, v8.0-v8.2, v9.0-v9.1, v10.0-v13.6; plus v14.0 marketing site shipped from `getgeolens.com` repo on 2026-04-13). v1.7 Marketplace & Distribution paused at Phase 40 (AWS AMI Build). Open-core architecture is **A-grade ship-ready** — Apache 2.0 licensed core, enterprise extensions register via `importlib.metadata` entry_points, auto-generated Python + TypeScript SDKs from `backend/openapi.json`, Apache-2.0 `geolens` CLI on PyPI (login/scan/publish/export-stac), SAML enterprise overlay with SP-initiated SSO + JIT provisioning + audited attribute→role mapping, documented + tested edition lifecycle (operator runbooks, admin SAML→local conversion endpoint, round-trip symmetry test), **fully extensible audit + billing + AI + governance seams** (`AuditSink`, `BillingExtension`, `AIProviderExtension`, `EmbeddingProviderExtension`, `PermissionExtension`, `WorkflowExtension`), bidirectional catalog/processing boundaries enforced through `ProcessingPort` + `CatalogPort` architecture guards, and maps/search service facades protected by private-module import guards plus size-budget checks. Latest v13.6 milestone audit passed with 21/21 requirements satisfied and no unresolved P0/P1 findings. Current v13.7 work targets the remaining P1 open-core adoption wedge: declarative `geolens.yaml` manifests plus CLI/backend apply workflows.
 
 The marketing and documentation web properties (v14.0 + v15.0 + 999.5 cross-repo style alignment) and their planning artifacts moved to the `getgeolens.com` repo on 2026-04-26 — see `~/Code/getgeolens.com/.planning/` for active docs-site work.
 
@@ -24,9 +24,15 @@ The marketing and documentation web properties (v14.0 + v15.0 + 999.5 cross-repo
 
 **Known close note:** Full backend coverage and Playwright smoke are not fully green locally; Phase 240 records exact outcomes and blockers. The focused v13.6-owned maps/search backend suite and touched-module lint/format gates passed.
 
-## Next Milestone Goals
+## Current Milestone: v13.7 Manifest-Driven Catalog Automation
 
-Fresh requirements are intentionally not defined yet. Use `$gsd-new-milestone` to choose the next milestone scope and regenerate `.planning/REQUIREMENTS.md`.
+**Goal:** Let a new organization describe datasets, sources, metadata, and publication intent in `geolens.yaml`, validate it locally, and apply it through the CLI/backend path into a browsable GeoLens catalog.
+
+**Target features:**
+- Versioned `geolens.yaml` manifest schema with good/bad fixtures and compatibility tests.
+- `geolens init`, `geolens validate`, and `geolens apply` CLI workflows with dry-run summaries and stable exit codes.
+- Backend manifest ingestion/apply service that reuses existing auth, storage validation, ingest jobs, catalog metadata, search, and map-preview contracts.
+- Examples and docs that prove the "docker compose up to browsable catalog in 10 minutes" adoption path.
 
 <details>
 <summary>Earlier milestone — v13.5 Enterprise Governance Seams (shipped 2026-05-03)</summary>
@@ -395,14 +401,20 @@ Users can find any dataset in the catalog in seconds — search, see it on a map
 
 ### Active
 
-- [ ] Next milestone requirements to be defined by `$gsd-new-milestone`
+- [ ] v13.7 requirements defined in `.planning/REQUIREMENTS.md` (19/19 mapped to phases 241-245)
+- [ ] Phase 241: manifest-spec-and-schema — versioned `geolens.yaml` schema, examples, and validation fixtures
+- [ ] Phase 242: cli-init-validate — `geolens init` and offline `geolens validate`
+- [ ] Phase 243: backend-manifest-apply-ingest — typed backend apply boundary and idempotent ingest orchestration
+- [ ] Phase 244: cli-apply-and-adoption-docs — `geolens apply`, dry-run summaries, and first-catalog examples
+- [ ] Phase 245: contract-gates-and-close-audit — OpenAPI/SDK/CLI drift gates, CI coverage, architecture checks, and milestone audit
 
 ### Out of Scope
 
-- New map-builder features, visual styling controls, layer editing behavior, or sharing semantics — v13.6 preserved behavior while restructuring service code; future changes need their own milestone scope
-- Search relevance changes, new filters, connector work, or index redesign — v13.6 kept the existing search contract and ranking behavior intact
-- Frontend UI changes beyond test/type updates required by backend response-contract preservation
-- Tenant scoping, `geolens.yaml` manifests, persistent connector registry, Helm/AMI/SBOM distribution, and `geolens-schemas` extraction — still backlog candidates for later milestones
+- Persistent connector registry, scheduled mirroring, encrypted credential vault, and connector UI — still Phase 999.13 / Enterprise backlog
+- Tenant scoping for the future Cloud tier — still Phase 999.6 and not needed for single-tenant self-hosted manifest apply
+- Helm/AMI distribution, SBOM/signed image pipeline, and `geolens-schemas` extraction — still separate P2 distribution/package milestones
+- New map-builder features, search ranking changes, visual styling controls, layer editing behavior, or sharing semantics — v13.7 publishes existing catalog capabilities through manifests, not new viewer/editor features
+- Enterprise-only publishing policies or approval workflows — manifests may declare Community-safe publication state, but advanced governance remains overlay scope
 
 - New map authoring capabilities (3D, live collaboration, time sliders) — still separate future scope from service decomposition and builder hardening
 - AI capability expansion — AI chat and map generation stay as-is until a dedicated AI milestone changes scope
@@ -433,7 +445,7 @@ Users can find any dataset in the catalog in seconds — search, see it on a map
 
 ## Context
 
-- **Current state**: v13.5 shipped. 47 milestones delivered. Full-featured GIS catalog supporting vector, raster, and VRT datasets with faceted search (FTS + pgvector + keyword/org/CRS facets + ranking boosts), map preview, export, collections, layer creation/editing, AI-assisted map building, related dataset discovery, STAC 1.1 export for raster/VRT interop, publication lifecycle, VRT lifecycle management, and i18n (en/es/fr/de). Open-core extension seams now cover identity, audit, billing, AI providers, embeddings, permissions, workflows, and catalog/processing boundaries.
+- **Current state**: v13.7 active after v13.6 shipped. 48 milestones delivered. Full-featured GIS catalog supporting vector, raster, and VRT datasets with faceted search (FTS + pgvector + keyword/org/CRS facets + ranking boosts), map preview, export, collections, layer creation/editing, AI-assisted map building, related dataset discovery, STAC 1.1 export for raster/VRT interop, publication lifecycle, VRT lifecycle management, and i18n (en/es/fr/de). Open-core extension seams now cover identity, audit, billing, AI providers, embeddings, permissions, workflows, catalog/processing boundaries, and maps/search service facades. v13.7 adds declarative catalog manifests and apply automation on top of those existing contracts.
 - **Architecture**: Database-first. PostgreSQL 17 + PostGIS 3.5 is the system of record. FastAPI serves vector tiles (ST_AsMVT with signed URL tokens), raster tiles (via Titiler with RBAC-gated token endpoint), features (paginated GeoJSON with bbox/property filtering), catalog metadata, search, auth, OGC discovery, and job orchestration. Background worker runs Procrastinate ingestion tasks. Titiler serves XYZ raster tiles from COG files. Frontend is a static SPA served by nginx with reverse proxy to the API.
 - **OGC Compliance**: OGC API Common Core, OGC API Records Core, OGC API Features Part 3 (Filtering/CQL2). Conformance classes declared at `/api/conformance`.
 - **Users**: Mix of GIS analysts (power users), data engineers (API consumers), and non-technical staff (browsing/downloading). Search-first UI serves all three. Machine clients (QGIS, GDAL, scripts) can now consume the catalog programmatically.

--- a/.planning/REQUIREMENTS.md
+++ b/.planning/REQUIREMENTS.md
@@ -1,0 +1,80 @@
+# Requirements: v13.7 Manifest-Driven Catalog Automation
+
+## Goal
+
+Let a new organization describe datasets, sources, metadata, and publication intent in `geolens.yaml`, validate it locally, and apply it through the CLI/backend path into a browsable GeoLens catalog.
+
+## In Scope
+
+### Manifest Schema
+
+- [ ] **MAN-01**: User can define manifest version, catalog metadata, and stable dataset identity fields in `geolens.yaml`.
+- [ ] **MAN-02**: User can define vector, raster COG, and VRT source entries using relative paths, URLs, or storage URIs.
+- [ ] **MAN-03**: User can declare per-dataset metadata including title, description, tags, organization, CRS, license, attribution, and bbox hints.
+- [ ] **MAN-04**: User can declare Community-safe publication intent such as draft, ready, internal, or published without depending on Enterprise-only controls.
+- [ ] **MAN-05**: Maintainer can verify manifest schema compatibility with committed good/bad fixtures and versioned validation errors.
+
+### CLI Workflow
+
+- [ ] **CLI-01**: User can run `geolens init` to create a minimal `geolens.yaml` without overwriting an existing manifest unless explicitly forced.
+- [ ] **CLI-02**: User can run `geolens validate` and receive deterministic exit codes plus path-specific validation errors without needing a running API.
+- [ ] **CLI-03**: User can run `geolens apply` against a configured GeoLens API to create or update datasets from a manifest.
+- [ ] **CLI-04**: User can run `geolens apply --dry-run` to preview create, update, skip, and error outcomes without writing data.
+
+### Backend Apply And Ingest
+
+- [ ] **INGEST-01**: Backend can accept a validated manifest through a typed service/API boundary and enqueue existing ingest jobs per dataset entry.
+- [ ] **INGEST-02**: Manifest apply is idempotent by stable dataset key and reports create, update, skip, and error outcomes per entry.
+- [ ] **INGEST-03**: Manifest ingestion preserves existing auth, RBAC, storage validation, file-safety, and edition-boundary checks.
+- [ ] **INGEST-04**: Vector, raster COG, and VRT manifest entries round-trip through existing catalog metadata, search, and map-preview contracts.
+
+### Docs And Examples
+
+- [ ] **DOCS-01**: New user can follow docs/examples from `docker compose up` to a browsable catalog using sample `geolens.yaml` within 10 minutes.
+- [ ] **DOCS-02**: Operator can adapt sample manifests for local paths, HTTP/S3 sources, and publication states without reading GeoLens source code.
+
+### Quality And Contracts
+
+- [ ] **QUAL-01**: OpenAPI snapshot, Python/TypeScript SDKs, and CLI docs reflect any new manifest/apply API surface.
+- [ ] **QUAL-02**: CI runs focused backend, CLI, and schema-fixture tests for manifest validation and apply behavior.
+- [ ] **QUAL-03**: Architecture guards prevent manifest support from coupling CLI directly to backend internals or introducing Enterprise-only dependencies into Community.
+- [ ] **QUAL-04**: Formal close audit verifies all v13.7 requirements, examples, CI evidence, and adoption-path evidence.
+
+## Future Requirements
+
+- Persistent connector registry, stored credentials, scheduled mirroring, and connector UI (Phase 999.13).
+- Tenant scoping for future Cloud multi-tenant isolation (Phase 999.6).
+- Helm chart, AMI Packer pipeline, SBOM generation, signed images, and `geolens-schemas` extraction (Phases 999.14-999.16).
+- Enterprise-only manifest extensions for approval workflows, custom governance, and scheduled connector sync.
+
+## Out Of Scope
+
+- New map-builder, layer editing, visual styling, search ranking, or sharing semantics.
+- Full catalog federation or harvesting from remote catalogs.
+- Enterprise credential vault or scheduled connector orchestration.
+- Cloud multi-tenant org isolation.
+- Distribution packaging work outside the existing CLI/backend/API surface.
+
+## Traceability
+
+| Requirement | Phase |
+|-------------|-------|
+| MAN-01 | 241 manifest-spec-and-schema |
+| MAN-02 | 241 manifest-spec-and-schema |
+| MAN-03 | 241 manifest-spec-and-schema |
+| MAN-04 | 241 manifest-spec-and-schema |
+| MAN-05 | 241 manifest-spec-and-schema |
+| CLI-01 | 242 cli-init-validate |
+| CLI-02 | 242 cli-init-validate |
+| INGEST-01 | 243 backend-manifest-apply-ingest |
+| INGEST-02 | 243 backend-manifest-apply-ingest |
+| INGEST-03 | 243 backend-manifest-apply-ingest |
+| INGEST-04 | 243 backend-manifest-apply-ingest |
+| CLI-03 | 244 cli-apply-and-adoption-docs |
+| CLI-04 | 244 cli-apply-and-adoption-docs |
+| DOCS-01 | 244 cli-apply-and-adoption-docs |
+| DOCS-02 | 244 cli-apply-and-adoption-docs |
+| QUAL-01 | 245 contract-gates-and-close-audit |
+| QUAL-02 | 245 contract-gates-and-close-audit |
+| QUAL-03 | 245 contract-gates-and-close-audit |
+| QUAL-04 | 245 contract-gates-and-close-audit |

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -47,8 +47,116 @@
 - ✅ **v13.4 Boundary Closeout** — Phases 225-231 (shipped 2026-05-03) — see [archive](milestones/v13.4-ROADMAP.md)
 - ✅ **v13.5 Enterprise Governance Seams** — Phases 232-235 (shipped 2026-05-03) — see [archive](milestones/v13.5-ROADMAP.md)
 - ✅ **v13.6 Catalog Maps/Search Service Decomposition** — Phases 236-240 (shipped 2026-05-04) — see [archive](milestones/v13.6-ROADMAP.md)
+- **v13.7 Manifest-Driven Catalog Automation** — Phases 241-245 (active)
 
 ## Phases
+
+### Active Phase Details — v13.7 Manifest-Driven Catalog Automation
+
+- [ ] **Phase 241: manifest-spec-and-schema** — Define the versioned `geolens.yaml` schema, examples, validation fixtures, and compatibility contract.
+- [ ] **Phase 242: cli-init-validate** — Add `geolens init` and offline `geolens validate` with deterministic errors and exit codes.
+- [ ] **Phase 243: backend-manifest-apply-ingest** — Add typed backend apply ingestion that preserves auth, storage safety, idempotency, and existing catalog contracts.
+- [ ] **Phase 244: cli-apply-and-adoption-docs** — Add `geolens apply`, dry-run summaries, and docs/examples for the first-catalog path.
+- [ ] **Phase 245: contract-gates-and-close-audit** — Update OpenAPI/SDK/CLI contracts, add CI coverage, enforce architecture boundaries, and run the milestone audit.
+
+19/19 v13.7 requirements mapped. Requirements live in `.planning/REQUIREMENTS.md`.
+
+#### Phase 241: manifest-spec-and-schema
+
+**Goal:** Define the Apache-2.0 `geolens.yaml` catalog manifest format as a versioned, testable contract for dataset identity, sources, metadata, and Community-safe publication intent.
+
+**Source:** Promoted from backlog Phase 999.12 (`geolens.yaml catalog manifest spec`, P1), identified by the open-core audits as the largest unshipped adoption wedge.
+
+**Requirements:** MAN-01, MAN-02, MAN-03, MAN-04, MAN-05
+
+**Depends on:** v13.6 archived and merged; existing CLI and catalog/processing boundaries from v13.1-v13.6.
+
+**Success Criteria** (what must be TRUE):
+1. A versioned manifest schema exists with documented fields for catalog metadata, dataset identity, source entries, metadata, and publication intent.
+2. Good and bad fixture manifests cover vector, raster COG, VRT, relative path, URL, and storage URI examples.
+3. Validation produces stable, path-specific errors that can be consumed by the CLI without importing backend internals.
+4. Compatibility tests lock the schema versioning behavior and prevent accidental breaking changes.
+
+**Plans:**
+- [ ] TBD
+
+#### Phase 242: cli-init-validate
+
+**Goal:** Make the public `geolens` CLI able to scaffold and validate manifests locally before any backend apply path exists.
+
+**Source:** Backlog Phase 999.12 required `geolens init` and `geolens validate` as part of the open-core manifest workflow.
+
+**Requirements:** CLI-01, CLI-02
+
+**Depends on:** Phase 241 manifest schema.
+
+**Success Criteria** (what must be TRUE):
+1. `geolens init` creates a minimal `geolens.yaml` without overwriting an existing file unless an explicit force flag is used.
+2. `geolens validate` validates manifests without a running API and exits deterministically for valid, invalid, and unreadable inputs.
+3. CLI validation output includes manifest-path locations and human-readable remediation text.
+4. CLI tests run without network or service dependencies.
+
+**Plans:**
+- [ ] TBD
+
+#### Phase 243: backend-manifest-apply-ingest
+
+**Goal:** Add a typed backend apply service/API boundary that consumes validated manifests and reuses existing catalog, storage, auth, and ingest behavior.
+
+**Source:** Backlog Phase 999.12 required the backend ingest path to consume `geolens.yaml` rather than leaving manifests as CLI-only metadata.
+
+**Requirements:** INGEST-01, INGEST-02, INGEST-03, INGEST-04
+
+**Depends on:** Phase 241 manifest schema; existing catalog/processing ports and ingest jobs.
+
+**Success Criteria** (what must be TRUE):
+1. Backend manifest apply accepts a typed payload and enqueues existing ingest work per dataset rather than creating a parallel ingestion stack.
+2. Apply runs are idempotent by stable dataset key and report create/update/skip/error per entry.
+3. Auth, RBAC, storage validation, file-safety checks, and edition boundaries remain in force for manifest-driven ingestion.
+4. Vector, raster COG, and VRT manifest entries round-trip into existing search, metadata, and map-preview contracts.
+
+**Plans:**
+- [ ] TBD
+
+#### Phase 244: cli-apply-and-adoption-docs
+
+**Goal:** Complete the user-facing manifest workflow with `geolens apply`, dry-run summaries, and examples that prove the first-catalog path.
+
+**Source:** Backlog Phase 999.12 tied manifests to the falsifiable adoption target: a new user can publish a working geospatial catalog in 10 minutes.
+
+**Requirements:** CLI-03, CLI-04, DOCS-01, DOCS-02
+
+**Depends on:** Phase 242 CLI validation; Phase 243 backend apply ingestion.
+
+**Success Criteria** (what must be TRUE):
+1. `geolens apply` uses the configured GeoLens API to create or update datasets from a manifest.
+2. `geolens apply --dry-run` previews create/update/skip/error outcomes without writing data.
+3. Docs and examples cover local paths, URL/storage sources, and Community-safe publication states.
+4. A documented path takes a clean local user from `docker compose up` to a browsable catalog with a sample manifest.
+
+**Plans:**
+- [ ] TBD
+
+#### Phase 245: contract-gates-and-close-audit
+
+**Goal:** Lock the manifest surface into CI, update generated contracts, and run the formal v13.7 close audit.
+
+**Source:** GSD close-gate discipline from v13.1-v13.6 plus Backlog Phase 999.12's open-core adoption requirement.
+
+**Requirements:** QUAL-01, QUAL-02, QUAL-03, QUAL-04
+
+**Depends on:** Phases 241-244.
+
+**Success Criteria** (what must be TRUE):
+1. OpenAPI snapshot, SDK drift checks, and CLI docs reflect any manifest/apply API changes.
+2. Focused backend, CLI, and schema-fixture tests run in CI for manifest validation and apply behavior.
+3. Architecture checks prevent CLI-to-backend-internal coupling and Enterprise-only dependencies in Community manifest support.
+4. Formal milestone audit verifies 19/19 requirements, examples, CI evidence, and the adoption path.
+
+**Plans:**
+- [ ] TBD
+
+---
 
 ### Archived Phase Details — v13.6 Catalog Maps/Search Service Decomposition
 
@@ -363,7 +471,7 @@ Inlined into Phase 225 (`processing-port-protocol-cycle-inversion`) because addi
 
 ---
 
-### Phase 999.12: geolens.yaml catalog manifest spec (BACKLOG — P1)
+### ~~Phase 999.12: geolens.yaml catalog manifest spec~~ — PROMOTED to v13.7 Phases 241-245 (2026-05-04)
 
 **Goal:** Define and ship the `geolens.yaml` catalog manifest format (Apache-2.0) — declarative descriptor for datasets, sources, and publishing rules. Implement `geolens init` / `geolens apply` / `geolens validate` CLI commands; backend ingest path consumes the manifest. The largest unshipped open-core enabler per the strategic guidance.
 **Source:** `oc-separation-audit-20260430-b.md` §6 (FAIL — zero source-tree hits) → confirmed unchanged in `oc-separation-audit-20260502.md` §6.6 (still missing) / §7 P2 (action item #11). v13.1 close audit and v13.2 audit both flagged this as biggest unshipped OC adoption wedge.
@@ -371,7 +479,11 @@ Inlined into Phase 225 (`processing-port-protocol-cycle-inversion`) because addi
 **Why this matters:** "A new user should be able to publish a working geospatial catalog in 10 minutes — from `docker compose up` to a browsable, shareable catalog of their own data" is the GTM falsifiable adoption target. Without a declarative manifest + `apply` workflow, that target is hand-wavy.
 
 Plans:
-- [ ] TBD
+- [ ] Promoted into Phase 241 `manifest-spec-and-schema`
+- [ ] Promoted into Phase 242 `cli-init-validate`
+- [ ] Promoted into Phase 243 `backend-manifest-apply-ingest`
+- [ ] Promoted into Phase 244 `cli-apply-and-adoption-docs`
+- [ ] Promoted into Phase 245 `contract-gates-and-close-audit`
 
 ---
 

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -1,45 +1,47 @@
 ---
 gsd_state_version: 1.0
-milestone: v13.6
-milestone_name: Catalog Maps/Search Service Decomposition
-status: milestone_archived
-stopped_at: v13.6 archived; ready to define next milestone
-last_updated: "2026-05-04T11:43:20Z"
+milestone: v13.7
+milestone_name: Manifest-Driven Catalog Automation
+status: roadmap_defined
+stopped_at: v13.7 initialized; ready to discuss or plan Phase 241
+last_updated: "2026-05-04T13:00:42Z"
 last_activity: 2026-05-04
 progress:
   total_phases: 5
-  completed_phases: 5
-  total_plans: 18
-  completed_plans: 18
-  percent: 100
+  completed_phases: 0
+  total_plans: 0
+  completed_plans: 0
+  percent: 0
 ---
 
 # Project State
 
 ## Project Reference
 
-See: .planning/PROJECT.md (updated 2026-05-04 after v13.6 milestone completion)
+See: .planning/PROJECT.md (updated 2026-05-04 after v13.7 milestone initialization)
 
 **Core value:** Users can find any dataset in the catalog in seconds — search, see it on a map, understand what it is, and get it out in the format they need.
-**Current focus:** Planning next milestone
+**Current focus:** v13.7 Manifest-Driven Catalog Automation
 
 ## Current Position
 
-Milestone: v13.6 — Catalog Maps/Search Service Decomposition
-Status: Archived and tagged locally
-Last activity: 2026-05-04 — v13.6 archived to `.planning/milestones/`, roadmap collapsed to an archive link, requirements archived, and project state updated for next-milestone planning.
+Milestone: v13.7 — Manifest-Driven Catalog Automation
+Phase: 241 — manifest-spec-and-schema (not started)
+Plan: —
+Status: Roadmap defined; ready for `$gsd-discuss-phase 241` or `$gsd-plan-phase 241`
+Last activity: 2026-05-04 — v13.7 initialized from the remaining P1 open-core backlog item 999.12 (`geolens.yaml` manifest spec) with requirements and phases 241-245.
 
 ## Roadmap Snapshot
 
-v13.6 Catalog Maps/Search Service Decomposition contains 5 phases:
+v13.7 Manifest-Driven Catalog Automation contains 5 phases:
 
-- **Phase 236: maps-service-decomposition** — split `backend/app/modules/catalog/maps/service.py` behind a stable public façade while preserving map CRUD, layers, sharing, thumbnails, and public viewer behavior. Requirements: MAPS-01..06.
-- **Phase 237: search-service-decomposition** — split `backend/app/modules/catalog/search/service.py` behind a stable public façade while preserving dataset search, facets, collections, OGC/STAC/AI contracts, and semantic/hybrid search behavior. Requirements: SRCH-01..06.
-- **Phase 238: boundary-guards-and-contract-stabilization** — add architecture guards and source-introspection-safe contract checks for the new maps/search module boundaries. Requirements: BOUND-01..04.
-- **Phase 239: close-audit-and-verification** — run focused map/search verification, ruff/format checks, and the v13.6 close audit. Requirements: QUAL-01..03.
-- **Phase 240: full-gate-and-deprecation-cleanup** — run broader CI-style confidence gates and resolve or document remaining deprecation warnings from the v13.6 milestone audit. Requirements: DEBT-01..02.
+- **Phase 241: manifest-spec-and-schema** — define the versioned `geolens.yaml` schema, examples, validation fixtures, and compatibility contract. Requirements: MAN-01..05.
+- **Phase 242: cli-init-validate** — add `geolens init` and offline `geolens validate` with deterministic errors and exit codes. Requirements: CLI-01..02.
+- **Phase 243: backend-manifest-apply-ingest** — add typed backend apply ingestion that preserves auth, storage safety, idempotency, and existing catalog contracts. Requirements: INGEST-01..04.
+- **Phase 244: cli-apply-and-adoption-docs** — add `geolens apply`, dry-run summaries, and docs/examples for the first-catalog path. Requirements: CLI-03..04, DOCS-01..02.
+- **Phase 245: contract-gates-and-close-audit** — update OpenAPI/SDK/CLI contracts, add CI coverage, enforce architecture boundaries, and run the milestone audit. Requirements: QUAL-01..04.
 
-Coverage: 21/21 v13.6 requirements mapped, 0 unmapped, 21 satisfied after Phase 240 warning cleanup, 0 pending.
+Coverage: 19/19 v13.7 requirements mapped, 0 unmapped, 0 satisfied, 19 pending.
 
 ## v13.3 Close-Out Summary (shipped 2026-05-01)
 
@@ -52,7 +54,7 @@ Coverage: 21/21 v13.6 requirements mapped, 0 unmapped, 21 satisfied after Phase 
 
 ## Next Action
 
-Next GSD action: Start the next milestone with `$gsd-new-milestone`.
+Next GSD action: `$gsd-discuss-phase 241` to gather implementation context, or `$gsd-plan-phase 241` to plan the manifest schema phase directly.
 
 ## Historical /oc-audit Queue (from Phase 224)
 
@@ -61,7 +63,8 @@ The audit produced 16 findings. Three trivial fixes were applied inline (env-var
 - **Phase 224 (P0):** catalog-god-module-split — Split `backend/app/modules/catalog/datasets/domain/service.py` (1407 LOC) into 4 cohesive modules (`service_create.py`, `service_query.py`, `service_lifecycle.py`, `service_grants.py`) behind a thin façade. Largest enterprise-overlay obstacle. ✅ shipped 2026-05-01.
 - **v13.4 (shipped):** Phases 225 (999.7 → 225 ProcessingPort), 226 (999.10 → 226 AIProviderExtension), 227 (999.18 → 227 SAML fixture tmp_path), 228 (999.17 → 228 cold publish), 230 (999.20 → 230 CatalogPort), 231 (999.19 → 231 EmbeddingProviderExtension), plus inlined architecture guard (former 999.11 → folded into 225) and milestone audit gate (229).
 - **v13.5 (complete):** Phase 232 (999.8 → PermissionExtension), Phase 233 (999.9 → WorkflowExtension), Phase 234 (advanced-sharing contract verification), Phase 235 (close audit).
-- **Backlog (remaining):** Phase 999.6 (tenant scoping — Cloud prereq), 999.12 (geolens.yaml manifest), 999.13 (persistent connector registry), 999.14 (Helm + AMI), 999.15 (SBOM + signed images), 999.16 (geolens-schemas extraction).
+- **v13.7 (active):** Phase 241-245 promoted from 999.12 (`geolens.yaml` manifest) to define the manifest schema, CLI init/validate/apply, backend apply ingestion, adoption docs, and close gates.
+- **Backlog (remaining):** Phase 999.6 (tenant scoping — Cloud prereq), 999.13 (persistent connector registry), 999.14 (Helm + AMI), 999.15 (SBOM + signed images), 999.16 (geolens-schemas extraction).
 
 ## /oc-audit follow-ups (2026-05-02 audit run)
 
@@ -82,7 +85,7 @@ Tier B — 5 backlog entries added 2026-05-02; 2 immediately promoted to v13.4 p
 - 999.22 (split catalog/search/service.py) → **Phase 237** (search-service-decomposition) — shipped in v13.6
 - 999.23 (share/embed token expiration gating) — resolved by Branch A on 2026-05-03 per `docs-internal/audits/oc-separation-audit-20260503.md`; v13.5 keeps a verification phase to prevent GTM/API/UI drift from recurring.
 
-Existing 999.12/14/16 remain cross-referenced to the 2026-05-02 audit with no promotion.
+Existing 999.14/16 remain cross-referenced to the 2026-05-02 audit with no promotion; 999.12 is now v13.7.
 
 Tier C — external blocker resolved: Phase 228 completed 2026-05-03. SDK and CLI packages are live and clean-machine verification passed.
 


### PR DESCRIPTION
## Summary

- Initializes v13.7 as Manifest-Driven Catalog Automation, promoted from backlog item 999.12.
- Defines 19 requirements for `geolens.yaml`, CLI init/validate/apply, backend manifest ingestion, docs/examples, and close gates.
- Adds phases 241-245 to the roadmap and updates project/state planning context for the next GSD action.

## Validation

- `git diff --check HEAD^ HEAD`
- `node /Users/ishiland/.codex/get-shit-done/bin/gsd-tools.cjs roadmap analyze`

## Notes

This is planning-only. No product code or runtime behavior changes.