### PR TITLE
[codex] Address open issue adoption quick wins

### DIFF
--- a/.env.test.example
+++ b/.env.test.example
@@ -31,9 +31,10 @@ POSTGRES_USER=geolens
 POSTGRES_PASSWORD=geolens
 POSTGRES_DB=geolens
 
-# --- Test database name ---
-# conftest.py reads settings.postgres_db_test; defaults to `${POSTGRES_DB}_test`.
-# Override here if you need to run multiple parallel test suites.
+# --- Test database name base ---
+# conftest.py reads settings.postgres_db_test, then appends a short per-session
+# suffix so concurrent pytest runs do not drop each other's databases.
+# Override this base only when you need a different naming prefix.
 # POSTGRES_DB_TEST=geolens_test
 
 # --- Required for Settings() construction ---

--- a/README.md
+++ b/README.md
@@ -114,6 +114,27 @@ Every dataset is also a standard OGC API Features endpoint:
 curl 'http://localhost:8080/api/collections/ne_10m_admin_0_countries/items?bbox=-10,35,30,60&limit=5'
 ```
 
+Use PostGIS + pgvector together when you need semantic ranking inside a spatial window. The sample vector below is only a runnable placeholder; replace it with an embedding from the same model configured for GeoLens:
+
+```sql
+WITH query_embedding AS (
+  SELECT ('[' || array_to_string(array_fill(0.001::float8, ARRAY[1536]), ',') || ']')::vector AS value
+)
+SELECT
+  d.id,
+  r.title,
+  1 - (e.embedding <=> query_embedding.value) AS semantic_score
+FROM catalog.datasets d
+JOIN catalog.records r ON r.id = d.record_id
+JOIN catalog.record_embeddings e ON e.record_id = r.id
+CROSS JOIN query_embedding
+WHERE r.spatial_extent && ST_MakeEnvelope(-125, 24, -66, 50, 4326)
+ORDER BY e.embedding <=> query_embedding.value
+LIMIT 5;
+```
+
+The result is the five catalog records whose metadata embeddings are nearest to the query vector, limited to records intersecting the bounding box.
+
 Connect directly from QGIS: **Layer > Add WFS / OGC API Features** and point at `http://localhost:8080/api/`.
 
 ## Features
@@ -200,6 +221,13 @@ Verify all services are healthy:
 ```bash
 docker compose ps
 ```
+
+First-run troubleshooting:
+
+- If ports are already taken, change `DB_PORT`, `API_PORT`, or `FRONTEND_PORT` in `.env`; the default quickstart uses 5434 for Postgres, 8001 for the API, and 8080 for the frontend.
+- If startup looks stuck, run `docker compose ps` and wait until `db`, `api`, `worker`, and `frontend` are healthy or running.
+- Check logs with `docker compose logs api`, `docker compose logs frontend`, and `docker compose logs worker`.
+- Slow first builds and health delays are usually image build, migration, or raster dependency startup work; rerun `docker compose ps` after a minute before restarting services.
 
 For production deployment, see the [Install Guide](https://docs.getgeolens.com/guides/quickstart/install/). For upgrading, see the [Upgrade Guide](https://docs.getgeolens.com/guides/quickstart/upgrade/).
 

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -57,6 +57,17 @@ def enterprise_edition(monkeypatch):
     init_edition([])
 
 
+def _quote_database_identifier(db_name: str) -> str:
+    return '"' + db_name.replace('"', '""') + '"'
+
+
+def _session_test_database_name(base_name: str) -> str:
+    suffix = uuid.uuid4().hex[:8]
+    max_base_len = 63 - len(suffix) - 1
+    safe_base = (base_name or "geolens_test")[:max_base_len].rstrip("_")
+    return f"{safe_base or 'geolens'}_{suffix}"
+
+
 def _drop_test_database_if_exists(db_name: str) -> None:
     teardown_engine = sqlalchemy.create_engine(
         settings.database_url_sync, isolation_level="AUTOCOMMIT"
@@ -65,11 +76,14 @@ def _drop_test_database_if_exists(db_name: str) -> None:
         with teardown_engine.connect() as conn:
             conn.execute(
                 text(
-                    f"SELECT pg_terminate_backend(pid) FROM pg_stat_activity "
-                    f"WHERE datname = '{db_name}' AND pid <> pg_backend_pid()"
-                )
+                    "SELECT pg_terminate_backend(pid) FROM pg_stat_activity "
+                    "WHERE datname = :db_name AND pid <> pg_backend_pid()"
+                ),
+                {"db_name": db_name},
             )
-            conn.execute(text(f"DROP DATABASE IF EXISTS {db_name}"))
+            conn.execute(
+                text(f"DROP DATABASE IF EXISTS {_quote_database_identifier(db_name)}")
+            )
     except Exception:
         pass
     finally:
@@ -87,158 +101,177 @@ def _test_db_lifecycle():
     unit test runs outside Docker). Tests that require DB will fail with a
     clear connection error; DB-independent tests will run normally.
     """
-    db_name = settings.postgres_db_test
+    original_test_db_name = settings.postgres_db_test
+    db_name = _session_test_database_name(original_test_db_name)
+    settings.postgres_db_test = db_name
+    should_drop_db = False
 
-    # --- Setup: create test database ---
-    dev_engine = sqlalchemy.create_engine(
-        settings.database_url_sync, isolation_level="AUTOCOMMIT"
-    )
     try:
-        with dev_engine.connect() as conn:
-            # Drop if exists for a clean slate
-            conn.execute(text(f"DROP DATABASE IF EXISTS {db_name}"))
-            conn.execute(text(f"CREATE DATABASE {db_name}"))
-        dev_engine.dispose()
-    except Exception:
-        # DB host unreachable — skip full setup; unit tests unaffected
-        dev_engine.dispose()
-        yield
-        return
-
-    # --- Init: extensions, schemas, roles ---
-    test_engine_sync = sqlalchemy.create_engine(settings.test_database_url_sync)
-    try:
-        with test_engine_sync.connect() as conn:
-            conn.execute(text("CREATE EXTENSION IF NOT EXISTS postgis"))
-            conn.execute(text("CREATE EXTENSION IF NOT EXISTS pg_trgm"))
-            conn.execute(text("CREATE EXTENSION IF NOT EXISTS vector"))
-            conn.execute(text("CREATE EXTENSION IF NOT EXISTS unaccent"))
-            conn.execute(text("CREATE SCHEMA IF NOT EXISTS catalog"))
-            conn.execute(text("CREATE SCHEMA IF NOT EXISTS data"))
-
-            # Idempotent role grants
-            conn.execute(
-                text(
-                    "DO $$ BEGIN "
-                    "IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'geolens_reader') THEN "
-                    "CREATE ROLE geolens_reader NOLOGIN; "
-                    "END IF; END $$"
-                )
-            )
-            conn.execute(text("GRANT USAGE ON SCHEMA data TO geolens_reader"))
-            conn.execute(
-                text("GRANT SELECT ON ALL TABLES IN SCHEMA data TO geolens_reader")
-            )
-            conn.execute(
-                text(
-                    "ALTER DEFAULT PRIVILEGES IN SCHEMA data "
-                    "GRANT SELECT ON TABLES TO geolens_reader"
-                )
-            )
-            conn.commit()
-    except SQLAlchemyError:
-        # DB is reachable but missing required extensions (for example pgvector).
-        # Let DB-light tests run; DB-backed tests will fail when they request DB fixtures.
-        test_engine_sync.dispose()
-        _drop_test_database_if_exists(db_name)
-        yield
-        return
-    test_engine_sync.dispose()
-
-    # --- Migrate: run alembic against the test database ---
-    from alembic import command
-    from alembic.config import Config as AlembicConfig
-
-    alembic_cfg = AlembicConfig("alembic.ini")
-    alembic_cfg.set_main_option("sqlalchemy.url", settings.test_database_url)
-    # Pre-set version_locations from the geolens.migrations entry-point group
-    # before invoking command.upgrade. The env.py also performs this discovery,
-    # but ScriptDirectory is constructed before env.py runs and caches the
-    # version_locations from the cfg at construction time -- so an env.py-time
-    # mutation does not propagate to the upgrade walk. Setting here ensures
-    # enterprise branch heads (e.g. e002_add_saml_columns) participate in
-    # `heads` (plural) discovery alongside the core head.
-    import pathlib as _pathlib
-    from importlib.metadata import entry_points as _entry_points
-
-    _enterprise_paths: list[str] = []
-    for _ep in _entry_points(group="geolens.migrations"):
+        # --- Setup: create test database ---
+        dev_engine = sqlalchemy.create_engine(
+            settings.database_url_sync, isolation_level="AUTOCOMMIT"
+        )
         try:
-            _fn = _ep.load()
-            if callable(_fn):
-                for _p in _fn():
-                    if _pathlib.Path(_p).is_dir():
-                        _enterprise_paths.append(_p)
+            with dev_engine.connect() as conn:
+                # Drop if exists for a clean slate
+                quoted_db_name = _quote_database_identifier(db_name)
+                conn.execute(text(f"DROP DATABASE IF EXISTS {quoted_db_name}"))
+                conn.execute(text(f"CREATE DATABASE {quoted_db_name}"))
+            should_drop_db = True
         except Exception:
-            pass  # Non-fatal; core migrations still run.
-    if _enterprise_paths:
-        _base_versions = (
-            alembic_cfg.get_main_option("version_locations") or "alembic/versions"
-        )
-        alembic_cfg.set_main_option(
-            "version_locations",
-            _base_versions + " " + " ".join(_enterprise_paths),
-        )
+            # DB host unreachable — skip full setup; unit tests unaffected
+            yield
+            return
+        finally:
+            dev_engine.dispose()
 
-    # Use "heads" (plural) so any enterprise migration branches discovered
-    # above are upgraded alongside core. With community-only installs, "heads"
-    # behaves identically to "head" because there is only one head; with
-    # enterprise installed, this picks up the enterprise branch.
-    command.upgrade(alembic_cfg, "heads")
+        # --- Init: extensions, schemas, roles ---
+        test_engine_sync = sqlalchemy.create_engine(settings.test_database_url_sync)
+        try:
+            with test_engine_sync.connect() as conn:
+                conn.execute(text("CREATE EXTENSION IF NOT EXISTS postgis"))
+                conn.execute(text("CREATE EXTENSION IF NOT EXISTS pg_trgm"))
+                conn.execute(text("CREATE EXTENSION IF NOT EXISTS vector"))
+                conn.execute(text("CREATE EXTENSION IF NOT EXISTS unaccent"))
+                conn.execute(text("CREATE SCHEMA IF NOT EXISTS catalog"))
+                conn.execute(text("CREATE SCHEMA IF NOT EXISTS data"))
 
-    # --- SAML column bridge (community-only test environments) ---
-    # The four SAML columns on catalog.oauth_providers are normally added by the
-    # enterprise migration e002_add_saml_columns. When geolens-enterprise is NOT
-    # installed, those columns are absent from the test DB. SQLAlchemy still
-    # includes them in INSERTs (deferred=True only suppresses SELECT loading,
-    # not INSERT column lists), causing UndefinedColumnError in any test that
-    # seeds an OAuthProvider row directly.
-    #
-    # This bridge detects the missing columns and adds them idempotently,
-    # mirroring what e002_add_saml_columns does. It only fires when the enterprise
-    # package is absent (i.e. _enterprise_paths is empty), so enterprise CI is
-    # unaffected.
-    if not _enterprise_paths:
-        _saml_bridge_engine = sqlalchemy.create_engine(settings.test_database_url_sync)
-        with _saml_bridge_engine.connect() as _conn:
-            # Check whether idp_entity_id already exists; if not, add all four.
-            _result = _conn.execute(
-                text(
-                    "SELECT column_name FROM information_schema.columns "
-                    "WHERE table_schema = 'catalog' "
-                    "AND table_name = 'oauth_providers' "
-                    "AND column_name = 'idp_entity_id'"
-                )
-            )
-            if _result.fetchone() is None:
-                _conn.execute(
+                # Idempotent role grants
+                conn.execute(
                     text(
-                        "ALTER TABLE catalog.oauth_providers "
-                        "ADD COLUMN IF NOT EXISTS idp_entity_id VARCHAR(512), "
-                        "ADD COLUMN IF NOT EXISTS idp_sso_url VARCHAR(512), "
-                        "ADD COLUMN IF NOT EXISTS idp_certificate TEXT, "
-                        "ADD COLUMN IF NOT EXISTS sp_entity_id VARCHAR(512)"
+                        "DO $$ BEGIN "
+                        "IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'geolens_reader') THEN "
+                        "CREATE ROLE geolens_reader NOLOGIN; "
+                        "END IF; END $$"
                     )
                 )
-                _conn.commit()
-        _saml_bridge_engine.dispose()
+                conn.execute(text("GRANT USAGE ON SCHEMA data TO geolens_reader"))
+                conn.execute(
+                    text("GRANT SELECT ON ALL TABLES IN SCHEMA data TO geolens_reader")
+                )
+                conn.execute(
+                    text(
+                        "ALTER DEFAULT PRIVILEGES IN SCHEMA data "
+                        "GRANT SELECT ON TABLES TO geolens_reader"
+                    )
+                )
+                conn.commit()
+        except SQLAlchemyError:
+            # DB is reachable but missing required extensions (for example pgvector).
+            # Let DB-light tests run; DB-backed tests will fail when they request DB fixtures.
+            test_engine_sync.dispose()
+            _drop_test_database_if_exists(db_name)
+            should_drop_db = False
+            yield
+            return
+        test_engine_sync.dispose()
 
-    yield
+        # --- Migrate: run alembic against the test database ---
+        from alembic import command
+        from alembic.config import Config as AlembicConfig
 
-    # --- Teardown: drop the test database ---
-    teardown_engine = sqlalchemy.create_engine(
-        settings.database_url_sync, isolation_level="AUTOCOMMIT"
-    )
-    with teardown_engine.connect() as conn:
-        # Terminate active connections before dropping
-        conn.execute(
-            text(
-                f"SELECT pg_terminate_backend(pid) FROM pg_stat_activity "
-                f"WHERE datname = '{db_name}' AND pid <> pg_backend_pid()"
+        alembic_cfg = AlembicConfig("alembic.ini")
+        alembic_cfg.set_main_option("sqlalchemy.url", settings.test_database_url)
+        # Pre-set version_locations from the geolens.migrations entry-point group
+        # before invoking command.upgrade. The env.py also performs this discovery,
+        # but ScriptDirectory is constructed before env.py runs and caches the
+        # version_locations from the cfg at construction time -- so an env.py-time
+        # mutation does not propagate to the upgrade walk. Setting here ensures
+        # enterprise branch heads (e.g. e002_add_saml_columns) participate in
+        # `heads` (plural) discovery alongside the core head.
+        import pathlib as _pathlib
+        from importlib.metadata import entry_points as _entry_points
+
+        _enterprise_paths: list[str] = []
+        for _ep in _entry_points(group="geolens.migrations"):
+            try:
+                _fn = _ep.load()
+                if callable(_fn):
+                    for _p in _fn():
+                        if _pathlib.Path(_p).is_dir():
+                            _enterprise_paths.append(_p)
+            except Exception:
+                pass  # Non-fatal; core migrations still run.
+        if _enterprise_paths:
+            _base_versions = (
+                alembic_cfg.get_main_option("version_locations") or "alembic/versions"
             )
-        )
-        conn.execute(text(f"DROP DATABASE IF EXISTS {db_name}"))
-    teardown_engine.dispose()
+            alembic_cfg.set_main_option(
+                "version_locations",
+                _base_versions + " " + " ".join(_enterprise_paths),
+            )
+
+        # Use "heads" (plural) so any enterprise migration branches discovered
+        # above are upgraded alongside core. With community-only installs, "heads"
+        # behaves identically to "head" because there is only one head; with
+        # enterprise installed, this picks up the enterprise branch.
+        command.upgrade(alembic_cfg, "heads")
+
+        # --- SAML column bridge (community-only test environments) ---
+        # The four SAML columns on catalog.oauth_providers are normally added by the
+        # enterprise migration e002_add_saml_columns. When geolens-enterprise is NOT
+        # installed, those columns are absent from the test DB. SQLAlchemy still
+        # includes them in INSERTs (deferred=True only suppresses SELECT loading,
+        # not INSERT column lists), causing UndefinedColumnError in any test that
+        # seeds an OAuthProvider row directly.
+        #
+        # This bridge detects the missing columns and adds them idempotently,
+        # mirroring what e002_add_saml_columns does. It only fires when the enterprise
+        # package is absent (i.e. _enterprise_paths is empty), so enterprise CI is
+        # unaffected.
+        if not _enterprise_paths:
+            _saml_bridge_engine = sqlalchemy.create_engine(
+                settings.test_database_url_sync
+            )
+            with _saml_bridge_engine.connect() as _conn:
+                # Check whether idp_entity_id already exists; if not, add all four.
+                _result = _conn.execute(
+                    text(
+                        "SELECT column_name FROM information_schema.columns "
+                        "WHERE table_schema = 'catalog' "
+                        "AND table_name = 'oauth_providers' "
+                        "AND column_name = 'idp_entity_id'"
+                    )
+                )
+                if _result.fetchone() is None:
+                    _conn.execute(
+                        text(
+                            "ALTER TABLE catalog.oauth_providers "
+                            "ADD COLUMN IF NOT EXISTS idp_entity_id VARCHAR(512), "
+                            "ADD COLUMN IF NOT EXISTS idp_sso_url VARCHAR(512), "
+                            "ADD COLUMN IF NOT EXISTS idp_certificate TEXT, "
+                            "ADD COLUMN IF NOT EXISTS sp_entity_id VARCHAR(512)"
+                        )
+                    )
+                    _conn.commit()
+            _saml_bridge_engine.dispose()
+
+        yield
+
+    finally:
+        if should_drop_db:
+            # --- Teardown: drop the test database ---
+            teardown_engine = sqlalchemy.create_engine(
+                settings.database_url_sync, isolation_level="AUTOCOMMIT"
+            )
+            try:
+                with teardown_engine.connect() as conn:
+                    # Terminate active connections before dropping
+                    conn.execute(
+                        text(
+                            "SELECT pg_terminate_backend(pid) FROM pg_stat_activity "
+                            "WHERE datname = :db_name AND pid <> pg_backend_pid()"
+                        ),
+                        {"db_name": db_name},
+                    )
+                    conn.execute(
+                        text(
+                            f"DROP DATABASE IF EXISTS {_quote_database_identifier(db_name)}"
+                        )
+                    )
+            finally:
+                teardown_engine.dispose()
+        settings.postgres_db_test = original_test_db_name
 
 
 @pytest.fixture
@@ -463,11 +496,10 @@ async def test_db_session(client: AsyncClient):
 # Both are large changes deferred to a dedicated PR. The opt-in ``clean_tables``
 # fixture below is provided for tests that need extra determinism today.
 #
-# Concurrent session hazard: the test DB name (``geolens_test``) is fixed, and
-# the session-scoped lifecycle drops + recreates it at start. Running two
-# pytest sessions in parallel against the same target (e.g. an interactive run
-# plus a background regression check) causes cascading fixture errors in the
-# slower session as the DB is dropped out from under it. Serialize runs.
+# Concurrent pytest sessions are isolated by suffixing the configured
+# ``POSTGRES_DB_TEST`` base name once per session. Each run drops only its own
+# physical database during teardown, so background and interactive runs can
+# target the same Postgres server without cross-contamination.
 
 
 @pytest.fixture(autouse=True)

--- a/backend/tests/test_ingest_column_preservation.py
+++ b/backend/tests/test_ingest_column_preservation.py
@@ -31,7 +31,7 @@ from sqlalchemy import text
 #   2. ``pytest.mark.requires_ogr2ogr`` opts into the autouse
 #      ``_point_ogr2ogr_at_test_db`` fixture in ``conftest.py`` (K2-PRE),
 #      which monkey-patches ``build_pg_conn_str`` so tables land in the
-#      ``geolens_test`` database instead of dev/prod.
+#      per-session test database instead of dev/prod.
 pytestmark = [
     pytest.mark.skipif(
         shutil.which("ogr2ogr") is None,

--- a/examples/manifests/public-cog/README.md
+++ b/examples/manifests/public-cog/README.md
@@ -1,0 +1,11 @@
+# Public COG Manifest Example
+
+This example registers a public Sentinel-2 Cloud-Optimized GeoTIFF without requiring local sample data.
+
+```bash
+geolens validate examples/manifests/public-cog/geolens.yaml
+geolens apply examples/manifests/public-cog/geolens.yaml --dry-run
+geolens apply examples/manifests/public-cog/geolens.yaml
+```
+
+The COG URL returns `Content-Type: image/tiff; application=geotiff; profile=cloud-optimized` and supports HTTP byte ranges. Attribution: contains modified Copernicus Sentinel data 2023, hosted by the public `sentinel-cogs` AWS Open Data dataset.

--- a/examples/manifests/public-cog/geolens.yaml
+++ b/examples/manifests/public-cog/geolens.yaml
@@ -1,0 +1,26 @@
+manifest_version: "1"
+catalog:
+  title: Public COG starter catalog
+  description: Example manifest that registers a public Cloud-Optimized GeoTIFF.
+  organization: GeoLens Examples
+datasets:
+  - key: sentinel-2-uluru-true-color
+    title: Sentinel-2 true color near Uluru
+    description: Public Sentinel-2 L2A true-color Cloud-Optimized GeoTIFF for testing raster catalog ingestion.
+    sources:
+      - type: raster_cog
+        uri: https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/52/J/FS/2023/5/S2A_52JFS_20230501_0_L2A/TCI.tif
+        format: geotiff
+    metadata:
+      tags:
+        - sentinel-2
+        - cog
+        - raster
+        - example
+      organization: Copernicus Sentinel-2
+      crs: EPSG:32752
+      license: Copernicus Sentinel data terms
+      attribution: Contains modified Copernicus Sentinel data 2023, hosted by the public sentinel-cogs AWS Open Data dataset.
+      bbox: [130.7, -25.8, 132.0, -24.8]
+    publication:
+      intent: ready

--- a/examples/postman/README.md
+++ b/examples/postman/README.md
@@ -1,0 +1,15 @@
+# GeoLens OGC API Postman Collection
+
+Import `geolens-ogc-api.postman_collection.json` into Postman, then set:
+
+- `baseUrl`: `http://localhost:8080/api` for the Docker Compose frontend proxy, or `http://localhost:8001` when calling the API port from `.env.example` directly.
+- `datasetId`: a dataset UUID from the `List collections` response.
+
+The collection covers:
+
+- OGC landing page
+- OGC collections list
+- OGC API Features items query with `bbox`
+- OGC API Records search over the `datasets` collection
+
+No tokens or secrets are stored in the collection. Public records work anonymously; private records require adding your normal `Authorization` or `X-API-Key` header in Postman.

--- a/examples/postman/geolens-ogc-api.postman_collection.json
+++ b/examples/postman/geolens-ogc-api.postman_collection.json
@@ -1,0 +1,132 @@
+{
+  "info": {
+    "_postman_id": "20b92514-7b32-4c58-bbd0-d81813bca39c",
+    "name": "GeoLens OGC API Smoke",
+    "description": "Local Docker Compose smoke requests for GeoLens OGC API Features and Records endpoints.",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+  },
+  "variable": [
+    {
+      "key": "baseUrl",
+      "value": "http://localhost:8080/api"
+    },
+    {
+      "key": "datasetId",
+      "value": "replace-with-dataset-uuid"
+    },
+    {
+      "key": "bbox",
+      "value": "-10,35,30,60"
+    },
+    {
+      "key": "recordQuery",
+      "value": "parks"
+    }
+  ],
+  "item": [
+    {
+      "name": "OGC landing page",
+      "request": {
+        "method": "GET",
+        "header": [
+          {
+            "key": "Accept",
+            "value": "application/json"
+          }
+        ],
+        "url": {
+          "raw": "{{baseUrl}}/?f=json",
+          "host": ["{{baseUrl}}"],
+          "path": [""],
+          "query": [
+            {
+              "key": "f",
+              "value": "json"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "name": "List collections",
+      "request": {
+        "method": "GET",
+        "header": [
+          {
+            "key": "Accept",
+            "value": "application/json"
+          }
+        ],
+        "url": {
+          "raw": "{{baseUrl}}/collections?limit=10",
+          "host": ["{{baseUrl}}"],
+          "path": ["collections"],
+          "query": [
+            {
+              "key": "limit",
+              "value": "10"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "name": "Feature items with bbox",
+      "request": {
+        "method": "GET",
+        "header": [
+          {
+            "key": "Accept",
+            "value": "application/geo+json"
+          }
+        ],
+        "url": {
+          "raw": "{{baseUrl}}/collections/{{datasetId}}/items?bbox={{bbox}}&limit=10",
+          "host": ["{{baseUrl}}"],
+          "path": ["collections", "{{datasetId}}", "items"],
+          "query": [
+            {
+              "key": "bbox",
+              "value": "{{bbox}}"
+            },
+            {
+              "key": "limit",
+              "value": "10"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "name": "Records search",
+      "request": {
+        "method": "GET",
+        "header": [
+          {
+            "key": "Accept",
+            "value": "application/geo+json"
+          }
+        ],
+        "url": {
+          "raw": "{{baseUrl}}/collections/datasets/items?q={{recordQuery}}&bbox={{bbox}}&limit=5",
+          "host": ["{{baseUrl}}"],
+          "path": ["collections", "datasets", "items"],
+          "query": [
+            {
+              "key": "q",
+              "value": "{{recordQuery}}"
+            },
+            {
+              "key": "bbox",
+              "value": "{{bbox}}"
+            },
+            {
+              "key": "limit",
+              "value": "5"
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/examples/sdk/python/upload_shapefile_publish_map.py
+++ b/examples/sdk/python/upload_shapefile_publish_map.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""Upload a zipped Shapefile with the GeoLens SDK client and publish a map.
+
+Expected output:
+  dataset_id=<uuid>
+  map_id=<uuid>
+  share_url=/m/<token>
+
+Environment:
+  GEOLENS_BASE_URL defaults to http://localhost:8080/api
+  GEOLENS_TOKEN or GEOLENS_API_KEY authenticates the request
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+import httpx
+from geolens import GeolensClient
+
+
+def build_client(base_url: str) -> GeolensClient:
+    bearer_token = os.environ.get("GEOLENS_TOKEN")
+    api_key = os.environ.get("GEOLENS_API_KEY")
+    if bearer_token:
+        return GeolensClient(base_url=base_url, bearer_token=bearer_token)
+    if api_key:
+        return GeolensClient(base_url=base_url, api_key=api_key)
+    raise SystemExit("Set GEOLENS_TOKEN or GEOLENS_API_KEY before running this example.")
+
+
+def request_json(response: httpx.Response) -> dict[str, Any]:
+    response.raise_for_status()
+    data = response.json()
+    if not isinstance(data, dict):
+        raise RuntimeError(f"Expected JSON object, got {type(data).__name__}")
+    return data
+
+
+def wait_for_ingest(http: httpx.Client, job_id: str, timeout_seconds: int) -> dict[str, Any]:
+    deadline = time.monotonic() + timeout_seconds
+    while time.monotonic() < deadline:
+        status = request_json(http.get(f"/jobs/{job_id}"))
+        if status["status"] == "complete":
+            return status
+        if status["status"] == "failed":
+            raise RuntimeError(status.get("error_message") or f"Ingest job {job_id} failed")
+        time.sleep(3)
+    raise TimeoutError(f"Ingest job {job_id} did not complete within {timeout_seconds}s")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("shapefile_zip", type=Path, help="Path to a zipped Shapefile")
+    parser.add_argument("--title", default="SDK uploaded Shapefile")
+    parser.add_argument("--summary", default="Uploaded through examples/sdk/python/upload_shapefile_publish_map.py")
+    parser.add_argument("--map-name", default="SDK Shapefile Map")
+    parser.add_argument("--base-url", default=os.environ.get("GEOLENS_BASE_URL", "http://localhost:8080/api"))
+    parser.add_argument("--layer-name", default=None, help="Optional layer name for multi-layer archives")
+    parser.add_argument("--timeout-seconds", type=int, default=300)
+    args = parser.parse_args()
+
+    if not args.shapefile_zip.is_file():
+        raise SystemExit(f"File not found: {args.shapefile_zip}")
+
+    sdk = build_client(args.base_url)
+    http = sdk.client.get_httpx_client()
+
+    with args.shapefile_zip.open("rb") as source:
+        upload = request_json(
+            http.post(
+                "/ingest/upload",
+                files={"file": (args.shapefile_zip.name, source, "application/zip")},
+            )
+        )
+    job_id = upload["job_id"]
+
+    preview = request_json(http.post(f"/ingest/preview/{job_id}"))
+    commit_body: dict[str, Any] = {
+        "title": args.title,
+        "summary": args.summary,
+        "visibility": "public",
+    }
+    if args.layer_name:
+        commit_body["layer_name"] = args.layer_name
+    elif preview.get("layer_name"):
+        commit_body["layer_name"] = preview["layer_name"]
+
+    request_json(http.post(f"/ingest/commit/{job_id}", json=commit_body))
+    completed = wait_for_ingest(http, job_id, args.timeout_seconds)
+    dataset_id = completed["dataset_id"]
+    if not dataset_id:
+        raise RuntimeError(f"Ingest job {job_id} completed without a dataset_id")
+
+    created_map = request_json(
+        http.post(
+            "/maps/",
+            json={
+                "name": args.map_name,
+                "description": f"Published map for {args.title}",
+            },
+        )
+    )
+    map_id = created_map["id"]
+
+    request_json(
+        http.post(
+            f"/maps/{map_id}/layers/",
+            json={
+                "dataset_id": dataset_id,
+                "display_name": args.title,
+                "sort_order": 0,
+                "visible": True,
+                "opacity": 1.0,
+            },
+        )
+    )
+    request_json(http.put(f"/maps/{map_id}", json={"visibility": "public"}))
+    share = request_json(http.post(f"/maps/{map_id}/share/", json={}))
+
+    print(f"dataset_id={dataset_id}")
+    print(f"map_id={map_id}")
+    print(f"share_url={share.get('share_url')}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- add a public COG manifest example and validation notes
- add a Postman OGC API collection and Python SDK shapefile-to-map example
- document README quick-start snippets for pgvector/spatial filters and Docker Compose first-run troubleshooting
- isolate pytest database names per test session to reduce DB-backed test contention

Refs #78, #81, #82, #83, #84, #85.

## Validation
- node JSON parse for examples/postman/geolens-ogc-api.postman_collection.json
- python -m py_compile examples/sdk/python/upload_shapefile_publish_map.py
- cd cli && uv run geolens validate ../examples/manifests/public-cog/geolens.yaml
- cd backend && uv run ruff check .
- cd backend && uv run ruff format --check .
- cd backend && JWT_SECRET_KEY=test-secret-key-for-ci-padding-32chars GEOLENS_ADMIN_USERNAME=admin GEOLENS_ADMIN_PASSWORD=admin POSTGRES_PASSWORD=geolens_test uv run pytest tests/test_config.py
- git diff --check origin/main...HEAD