### PR TITLE
docs(agents): reference geolens-io/branding for brand assets

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,6 +34,10 @@ History follows a Conventional Commit-like pattern, for example `feat(234-01): a
 
 Pull requests should describe the change, call out schema/API/config impacts, link issues or phases, include screenshots for UI work, and list verification commands. Commit `backend/openapi.json` or SDK output only when the source change requires it.
 
+## Cross-Repo Brand Assets
+
+Brand assets (logos, color tokens, font references, brand-usage rules, press materials) live in the sibling [`geolens-io/branding`](https://github.com/geolens-io/branding) repository — not here. When an app feature needs a logo, palette token, or identity element, copy from a tagged branding release rather than re-authoring locally. The propagation order for any change that touches brand identity is **branding → this repo → marketing → docs**. The internal design guide at `docs-internal/repository/DESIGN-GUIDE.md` covers app-internal patterns only (component conventions, surface ladder, density); cross-surface canon lives in branding's `BRAND-GUIDE.md`.
+
 ## Security & Configuration Tips
 
 Use `.env.example` and `.env.test.example` as templates. Never commit secrets, coverage output, Playwright reports, virtual environments, or dependency directories.


### PR DESCRIPTION
## Summary

Adds a *Cross-Repo Brand Assets* section to `AGENTS.md` so contributors and AI agents working in this repo know that logos, color tokens, font references, brand-usage rules, and press materials live in the sibling [`geolens-io/branding`](https://github.com/geolens-io/branding) repository rather than here.

Establishes the propagation order for any change that touches brand identity: **branding → this repo → marketing → docs**.

## Why

`geolens-io/branding` was published on 2026-05-06 (private) at `v0.1.0` as the source of truth for the GeoLens visual identity. Consumer repos (`geolens-io/getgeolens.com`, this repo) copy from there at tagged releases. Without this reference in `AGENTS.md`, future contributors and agents have no signal that the canonical home moved out of the app repo.

## Notes

- The internal design guide at `docs-internal/repository/DESIGN-GUIDE.md` also picks up an inline scope blockquote pointing at branding's `BRAND-GUIDE.md`, but `docs-internal/` is gitignored per the *Security & Configuration Tips* policy in this same `AGENTS.md`. That edit ships only to local working trees and is not part of this PR.
- Marketing/docs side of the brand-canon migration landed in `geolens-io/getgeolens.com` PRs #3 and #4 (already merged).
- Supersedes #98 (which had base-SHA scope drift and bundled 30 unrelated commits).

## Test plan

- [x] `git diff origin/main..HEAD --stat` shows `AGENTS.md | 4 ++++ | 1 file changed, 4 insertions(+)`.
- [x] New section sits between *Commit & Pull Request Guidelines* and *Security & Configuration Tips*.
- [x] Section does not contradict the gitignored-paths policy.
- [ ] No code changes; CI is documentation-only.