### PR TITLE
fix(deps): bump pyjwt 2.12.1 → 2.13.0 (PYSEC-2026-175/177/178/179)

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -17,7 +17,9 @@ dependencies = [
     "geoalchemy2>=0.15.0",
     "pydantic[email]>=2.6.0",
     "pydantic-settings>=2.0.0",
-    "pyjwt>=2.12.0",
+    # >=2.13.0: fixes PYSEC-2026-175/177/178/179 (PyJWKClient SSRF + unbounded
+    # JWKS fetch, HMAC key-confusion, detached-JWS DoS). Do not lower this floor.
+    "pyjwt>=2.13.0",
     "pwdlib[bcrypt]>=0.3.0",
     "procrastinate>=3.0.0",
     "psycopg>=3.1.0",

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -909,7 +909,7 @@ requires-dist = [
     { name = "pydantic", extras = ["email"], specifier = ">=2.6.0" },
     { name = "pydantic-settings", specifier = ">=2.0.0" },
     { name = "pygeofilter", extras = ["backend-sqlalchemy"], specifier = ">=0.3.3" },
-    { name = "pyjwt", specifier = ">=2.12.0" },
+    { name = "pyjwt", specifier = ">=2.13.0" },
     { name = "python-multipart", specifier = ">=0.0.27" },
     { name = "python-slugify", specifier = ">=8.0.4" },
     { name = "rasterio", specifier = ">=1.4.0" },
@@ -1847,11 +1847,11 @@ wheels = [
 
 [[package]]
 name = "pyjwt"
-version = "2.12.1"
+version = "2.13.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c2/27/a3b6e5bf6ff856d2509292e95c8f57f0df7017cf5394921fc4e4ef40308a/pyjwt-2.12.1.tar.gz", hash = "sha256:c74a7a2adf861c04d002db713dd85f84beb242228e671280bf709d765b03672b", size = 102564, upload-time = "2026-03-13T19:27:37.25Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3b/81/58d0ac84e1ef3a3843791d6954d94c0b33d526c75eeb1efbce9d0a4c4077/pyjwt-2.13.0.tar.gz", hash = "sha256:41571c89ca91598c79e8ef18a2d07367d4810fbbd6f637794879baf1b7703423", size = 107515, upload-time = "2026-05-21T19:54:36.618Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e5/7a/8dd906bd22e79e47397a61742927f6747fe93242ef86645ee9092e610244/pyjwt-2.12.1-py3-none-any.whl", hash = "sha256:28ca37c070cad8ba8cd9790cd940535d40274d22f80ab87f3ac6a713e6e8454c", size = 29726, upload-time = "2026-03-13T19:27:35.677Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/5e/ecf12fdb62546d64385c158514e9b2b671f7832108ef2ecd2020ce0af2d1/pyjwt-2.13.0-py3-none-any.whl", hash = "sha256:66adcc2aff09b3f1bbd95fc1e1577df8ac8723c978552fd43304c8a290ac5728", size = 31274, upload-time = "2026-05-21T19:54:35.362Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
`pip-audit` (the **Security Scan** CI gate) flags 4 vulnerabilities in **pyjwt 2.12.1**, all fixed in **2.13.0**:

| Advisory | Issue |
|---|---|
| PYSEC-2026-175 | `PyJWKClient` SSRF — `jku` URL passed to `urlopen()` with no scheme allowlist (`file://`, `ftp://`, `data://`) |
| PYSEC-2026-177 | unbounded JWKS refetch on unknown `kid` (DoS) |
| PYSEC-2026-178 | detached-JWS (`b64:false`) payload work-amplification DoS |
| PYSEC-2026-179 | HMAC key-confusion — issuer public key usable as the HMAC secret |

These advisories were published after the last green `main` Security Scan, so they affect `main` as well — this PR fixes it at the source.

## Change
- `backend/pyproject.toml`: raise floor `pyjwt>=2.12.0` → `>=2.13.0` (with a comment so it can't be lowered) so the fixed version cannot be re-resolved away.
- `backend/uv.lock`: regenerated (`uv lock --upgrade-package pyjwt`), pyjwt `2.12.1` → `2.13.0`. No other packages changed.

## Verification
- `uv run pip-audit --strict --desc` (the exact CI command) → **"No known vulnerabilities found", exit 0** after a fresh `uv sync --locked --dev`.
- JWT auth/token suite passes: **230 passed** (`test_auth`, download/embed tokens, all `jwt.`-using tests). The app's HS256 access tokens are unaffected by the HMAC-confusion hardening.
- No application code changes; 2.13.0 is a backward-compatible security release.

Separate from (and unblocks the Security Scan gate that was red on) #139.