### PR TITLE
chore(deps): dep-audit remediation — Node 26 LTS, httpx promotion, phantom deps, CI gaps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,19 +1,59 @@
 version: 2
+# Dependency update automation. Covers all three JS surfaces (frontend, root
+# e2e, SDK), the uv-managed Python backend, and every Dockerfile location.
+# Reworked 2026-06-02 (dep-audit): switched backend from "pip" to "uv" so it
+# reads backend/uv.lock; added root + sdks/typescript npm; fixed the docker
+# directories to point at the actual Dockerfile locations (/, /db, /frontend).
 updates:
-  - package-ecosystem: "pip"
+  # --- Python backend (uv) ---
+  - package-ecosystem: "uv"        # was "pip" — uv reads backend/uv.lock
     directory: "/backend"
     schedule:
       interval: "weekly"
     labels: ["dependencies", "backend"]
     open-pull-requests-limit: 10
+    groups:
+      fastapi-ecosystem:
+        patterns: ["fastapi", "uvicorn", "starlette", "pydantic*", "sse-starlette"]
+      sqlalchemy-ecosystem:
+        patterns: ["sqlalchemy*", "alembic", "asyncpg", "psycopg*"]
+      geo-stack:
+        patterns: ["geoalchemy2", "shapely", "pgvector", "rasterio"]
+    ignore:
+      # Major bumps reviewed individually, not auto-grouped.
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
 
+  # --- Frontend React app (npm) ---
   - package-ecosystem: "npm"
     directory: "/frontend"
     schedule:
       interval: "weekly"
     labels: ["dependencies", "frontend"]
     open-pull-requests-limit: 10
+    groups:
+      react-ecosystem:
+        patterns: ["react", "react-dom", "@types/react*"]
+      tanstack:
+        patterns: ["@tanstack/*"]
 
+  # --- Root E2E (Playwright) — was untracked ---
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels: ["dependencies", "e2e"]
+    open-pull-requests-limit: 5
+
+  # --- TypeScript SDK — was untracked ---
+  - package-ecosystem: "npm"
+    directory: "/sdks/typescript"
+    schedule:
+      interval: "weekly"
+    labels: ["dependencies", "sdk"]
+    open-pull-requests-limit: 5
+
+  # --- GitHub Actions ---
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
@@ -21,14 +61,23 @@ updates:
     labels: ["dependencies", "ci"]
     open-pull-requests-limit: 5
 
+  # --- Docker images ---
+  # Root multi-stage Dockerfile (python + node + nginx) — was MISSING; this is
+  # the gap that left the root frontend-build node image untracked.
   - package-ecosystem: "docker"
-    directory: "/backend"
+    directory: "/"
     schedule:
-      interval: "monthly"
+      interval: "weekly"
     labels: ["dependencies", "docker"]
-
+  # DB image (postgis + pgvector build) — was MISSING.
+  - package-ecosystem: "docker"
+    directory: "/db"
+    schedule:
+      interval: "weekly"
+    labels: ["dependencies", "docker"]
+  # Frontend Vite dev-server image.
   - package-ecosystem: "docker"
     directory: "/frontend"
     schedule:
-      interval: "monthly"
+      interval: "weekly"
     labels: ["dependencies", "docker"]

--- a/.github/workflows/dep-audit.yml
+++ b/.github/workflows/dep-audit.yml
@@ -1,0 +1,97 @@
+name: Dependency audit
+
+# Added 2026-06-02 (dep-audit). Fails PRs on high/critical CVEs and strong
+# copyleft; runs Trivy OS-CVE scans the local audit could not (trivy is not on
+# dev machines). Weekly cron catches newly-disclosed CVEs in unchanged deps.
+on:
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: "0 8 * * 1" # Monday 08:00 UTC
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  python-audit:
+    name: Python audit (uv)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: backend
+    steps:
+      - uses: actions/checkout@v6
+      - uses: astral-sh/setup-uv@v8.1.0
+        with:
+          version: "0.11.11"
+          enable-cache: true
+          cache-dependency-glob: "backend/uv.lock"
+      - name: Verify lockfile in sync
+        run: uv lock --check
+      - name: Export locked prod requirements
+        run: uv export --locked --no-dev --format requirements-txt -o /tmp/reqs.txt
+      - name: pip-audit (OSV + PyPI advisory DB)
+        run: uv run --with pip-audit pip-audit -r /tmp/reqs.txt --strict
+      - name: License gate (block strong/network copyleft)
+        run: uv run --with pip-licenses pip-licenses --fail-on="GPL-3.0-only;GPL-3.0;GPL-2.0;AGPL-3.0;SSPL-1.0;BSL-1.1"
+
+  js-audit:
+    name: JS audit (${{ matrix.directory }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        directory: [".", "frontend", "sdks/typescript"]
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "24" # CI tooling runner (LTS); build image is node 26
+          cache: "npm"
+          cache-dependency-path: ${{ matrix.directory }}/package-lock.json
+      - name: Install
+        working-directory: ${{ matrix.directory }}
+        run: npm ci
+      - name: npm audit (block high+)
+        working-directory: ${{ matrix.directory }}
+        run: npm audit --audit-level=high
+      - name: License report (advisory — tune allowlist before enforcing)
+        working-directory: ${{ matrix.directory }}
+        continue-on-error: true
+        run: |
+          npx --yes license-checker --production --summary || true
+          # Hard-gate candidate once the compound-SPDX allowlist is validated:
+          # npx license-checker --production --onlyAllow \
+          #   'MIT;ISC;BSD-2-Clause;BSD-3-Clause;Apache-2.0;CC0-1.0;Unlicense;Python-2.0;PSF-2.0;BlueOak-1.0.0;0BSD;OFL-1.1;MPL-2.0;CUSTOM'
+
+  docker-audit:
+    name: Docker image scan (Trivy)
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        image:
+          - "node:26.3.0-alpine"
+          - "python:3.14.3-slim"
+          - "nginxinc/nginx-unprivileged:1.29.8-alpine"
+          - "postgis/postgis:17-3.5"
+    steps:
+      - uses: actions/checkout@v6
+      # Report-only on introduction: Trivy prints CRITICAL/HIGH findings to the
+      # job log but exits 0, so the check stays green while the base-image CVE
+      # baseline is triaged. NOTE these scan the UPSTREAM base images; the built
+      # images run `apt-get upgrade`/`apk upgrade`, so real exposure is lower.
+      # To enforce as a hard gate: set exit-code "1" (ideally after switching to
+      # scan the built images, not the upstream refs).
+      - name: Trivy scan (report-only)
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: ${{ matrix.image }}
+          format: "table"
+          severity: "CRITICAL,HIGH"
+          exit-code: "0"
+          ignore-unfixed: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -119,7 +119,7 @@ USER appuser
 ENTRYPOINT ["/app/scripts/worker-entrypoint.sh"]
 CMD ["sh", "-c", "uv run --no-dev python -m app.worker"]
 
-FROM node:25.9.0-alpine AS frontend-build
+FROM node:26.3.0-alpine AS frontend-build
 
 WORKDIR /app
 COPY frontend/package.json frontend/package-lock.json ./

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -47,6 +47,11 @@ dependencies = [
     "prometheus-fastapi-instrumentator>=8.0.0",
     "authlib>=1.7.1",  # CVE-2026-44681 (GHSA-r95x-qfjj-fjj2) — OIDC Implicit/Hybrid open redirect, fixed in 1.6.12 / 1.7.1
     "python-multipart>=0.0.27",
+    # httpx: promoted from [dependency-groups].dev to prod (dep-audit 2026-06-02).
+    # Imported directly by 12 production modules (catalog source adapters,
+    # processing/ai/llm_loop.py, processing/tiles/router.py); previously resolved
+    # only transitively via fastapi[standard]. Pin keeps it a first-class dep.
+    "httpx>=0.27",
     "sse-starlette>=3.3.2",
     "sqlglot>=29.0.0",
     "itsdangerous>=2.2.0",
@@ -72,7 +77,6 @@ dev = [
     "pytest>=9.0.3",
     "pytest-asyncio",
     "pytest-xdist>=3.6.0",
-    "httpx",
     "ruff",
     "pytest-cov",
     "bandit>=1.8",

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -837,6 +837,7 @@ dependencies = [
     { name = "defusedxml" },
     { name = "fastapi", extra = ["standard"] },
     { name = "geoalchemy2" },
+    { name = "httpx" },
     { name = "idna" },
     { name = "itsdangerous" },
     { name = "jsonschema" },
@@ -871,7 +872,6 @@ dependencies = [
 dev = [
     { name = "bandit" },
     { name = "fakeredis" },
-    { name = "httpx" },
     { name = "moto", extra = ["s3"] },
     { name = "pip-audit" },
     { name = "pystac" },
@@ -894,6 +894,7 @@ requires-dist = [
     { name = "defusedxml", specifier = ">=0.7.1" },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.115.0" },
     { name = "geoalchemy2", specifier = ">=0.15.0" },
+    { name = "httpx", specifier = ">=0.27" },
     { name = "idna", specifier = ">=3.15" },
     { name = "itsdangerous", specifier = ">=2.2.0" },
     { name = "jsonschema", specifier = ">=4.19" },
@@ -928,7 +929,6 @@ requires-dist = [
 dev = [
     { name = "bandit", specifier = ">=1.8" },
     { name = "fakeredis", specifier = ">=2.21.0" },
-    { name = "httpx" },
     { name = "moto", extras = ["s3"], specifier = ">=5.0.0" },
     { name = "pip-audit", specifier = ">=2.7" },
     { name = "pystac", specifier = ">=1.14" },

--- a/frontend/Dockerfile.dev
+++ b/frontend/Dockerfile.dev
@@ -2,7 +2,7 @@
 # Vite dev server image — runs as non-root `node` user (uid 1000) per INF-16.
 # Uses BuildKit npm cache mount per INF-09.
 
-FROM node:25.9.0-alpine
+FROM node:26.3.0-alpine
 
 WORKDIR /app
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -14,6 +14,8 @@
         "@dnd-kit/utilities": "^3.2.2",
         "@fontsource-variable/ibm-plex-sans": "^5.2.8",
         "@fontsource/ibm-plex-mono": "^5.2.7",
+        "@maplibre/maplibre-gl-style-spec": "^19.3.3",
+        "@radix-ui/react-collapsible": "^1.1.12",
         "@tailwindcss/vite": "^4.3.0",
         "@tanstack/react-query": "^5.100.9",
         "@tanstack/react-table": "^8.21.3",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -28,6 +28,8 @@
     "@dnd-kit/utilities": "^3.2.2",
     "@fontsource-variable/ibm-plex-sans": "^5.2.8",
     "@fontsource/ibm-plex-mono": "^5.2.7",
+    "@maplibre/maplibre-gl-style-spec": "^19.3.3",
+    "@radix-ui/react-collapsible": "^1.1.12",
     "@tailwindcss/vite": "^4.3.0",
     "@tanstack/react-query": "^5.100.9",
     "@tanstack/react-table": "^8.21.3",


### PR DESCRIPTION
## Dependency-audit remediation (2026-06-02)

Closes the actionable findings from the full `/dep-audit` run. The dependency tree was already **CVE-clean** (0 vulnerabilities across Python + all 3 JS surfaces) and **license-clean** — these are correctness, EOL, and CI-coverage fixes, not security patches.

### Changes (4 atomic commits)

1. **`fix(docker)` — Node 25 → 26.3.0-alpine** (both Dockerfiles)
   Node 25 is a non-LTS (odd) line that hit **EOL on 2026-06-01** (no more security patches). Pinned the production frontend-build stage *and* the Vite dev image to `node:26.3.0-alpine` (even/LTS-bound: Active LTS 2026-10-28, EOL 2029-04-30). **Supersedes #128**, which bumped only `frontend/Dockerfile.dev` and missed the root `Dockerfile` build stage.

2. **`fix(deps)` — promote `httpx` to a prod dependency**
   Imported directly by 12 production modules but declared dev-only; it resolved at runtime solely via the transitive `fastapi[standard]` dep (supply-chain fragility). Now `httpx>=0.27` in `project.dependencies`; resolution unchanged (0.28.1).

3. **`fix(deps)` — declare 2 phantom frontend deps**
   `@radix-ui/react-collapsible` and `@maplibre/maplibre-gl-style-spec` were imported but undeclared (resolved via hoisting). Declared at current resolutions → **zero lockfile version deltas**, typecheck clean, targeted tests pass. (Validator-version-skew alignment to spec v24 deferred as a QA-gated follow-up.)

4. **`chore(ci)` — fix dependabot gaps + add `dep-audit.yml`**
   dependabot: `pip`→`uv`, added root + SDK npm surfaces, corrected docker dirs (`/`, `/db`, `/frontend`), added groups. New `dep-audit.yml`: pip-audit + copyleft license gate + npm-audit (×3) + Trivy image scans.

### Verification
- `uv lock` in sync (150 pkgs); `httpx==0.28.1` now in `uv export --no-dev`
- frontend `tsc -b --noEmit` exit 0; 115 targeted tests pass; 0 npm-audit vulns
- all YAML/TOML validated; pre-commit hooks green on every commit

### Follow-ups (not in this PR)
- **#128** → close as superseded by commit 1.
- **9 dependabot freshness PRs** (#129–132, #134–138) are all CI-green safe merges — merge after this lands (dependabot will auto-rebase).
- **#133** (eslint-plugin-react-hooks 7.1.x) → **hold**: its new `error-boundaries` rule fails CI on existing `LegendPlugin.tsx` (12 errors). Needs a refactor or rule scoping first.
- Deferred freshness: ESLint 9→10, Python freshness batch, floating `postgis:17-3.5` tag, maplibre validator v24 alignment.

Full report: `docs-internal/audits/dep-audit-20260602.md` (disk-only).
