### PR TITLE
fix(sdks): revert @hey-api/openapi-ts bump (#145) — broke SDKs Drift Gate

### DIFF
--- a/sdks/typescript/package-lock.json
+++ b/sdks/typescript/package-lock.json
@@ -12,7 +12,7 @@
         "@hey-api/client-fetch": "0.13.1"
       },
       "devDependencies": {
-        "@hey-api/openapi-ts": "0.98.1",
+        "@hey-api/openapi-ts": "0.96.1",
         "typescript": "^5.6.0"
       },
       "engines": {
@@ -33,9 +33,9 @@
       }
     },
     "node_modules/@hey-api/codegen-core": {
-      "version": "0.8.4",
-      "resolved": "https://registry.npmjs.org/@hey-api/codegen-core/-/codegen-core-0.8.4.tgz",
-      "integrity": "sha512-IF8/+midxK0Hu0wL/yMUfBL4+MSiRV5hziKMjKOXXqknUYE8gkf0BKW4XPsPo0DTzNDEV9qBAENaa3PRTduupQ==",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@hey-api/codegen-core/-/codegen-core-0.8.0.tgz",
+      "integrity": "sha512-OuF/jenX9wz7AWHRBfb37v+jLkrfCt0FJXQuALNH2UsW6+bdZBmoibHl0K778SiHwneotJbAaEvX2S05wEqUQw==",
       "license": "MIT",
       "dependencies": {
         "@hey-api/types": "0.1.4",
@@ -44,41 +44,40 @@
         "color-support": "1.1.3"
       },
       "engines": {
-        "node": ">=22.18.0"
+        "node": ">=22.13.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/hey-api"
       }
     },
     "node_modules/@hey-api/json-schema-ref-parser": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/@hey-api/json-schema-ref-parser/-/json-schema-ref-parser-1.4.3.tgz",
-      "integrity": "sha512-UzGSDzh3QUhrnwl4atnHc2YqDO6KemYVEOwl1Ynowm/tcr0XlpdHOpyWr5UaWIJfiXTXdYRIC9k2Yxm19pcPzQ==",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@hey-api/json-schema-ref-parser/-/json-schema-ref-parser-1.4.1.tgz",
+      "integrity": "sha512-DoPJGxVApDlktP1yYLjmOrF0YBEqb32ieCbx1S1i09n8TyCgdoh4yQaQ3kp0sMTauH+bwNKPsFh7S8qiWCoKZA==",
       "license": "MIT",
       "dependencies": {
         "@jsdevtools/ono": "7.1.3",
         "@types/json-schema": "7.0.15",
-        "js-yaml": "4.1.1"
+        "yaml": "2.8.3"
       },
       "engines": {
-        "node": ">=22.18.0"
+        "node": ">=22.13.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/hey-api"
       }
     },
     "node_modules/@hey-api/openapi-ts": {
-      "version": "0.98.1",
-      "resolved": "https://registry.npmjs.org/@hey-api/openapi-ts/-/openapi-ts-0.98.1.tgz",
-      "integrity": "sha512-TTQQwiOTPK23kVykuMDMz2ko1dTcrJb9uA3BA7pY8vrPRGtKchLfegzl3IwqHAg4Ay0p8ByguVUdZrqe+OpLIQ==",
+      "version": "0.96.1",
+      "resolved": "https://registry.npmjs.org/@hey-api/openapi-ts/-/openapi-ts-0.96.1.tgz",
+      "integrity": "sha512-EnH+6ncaVC1yNvYWcsO7MoeBSqCvYZaKvRDRqh+S7dsfb9lhe2mKUR2+7sDacGUBm7VDZZ7hg4q4egxlpZaf0g==",
       "license": "MIT",
       "dependencies": {
-        "@hey-api/codegen-core": "0.8.4",
-        "@hey-api/json-schema-ref-parser": "1.4.3",
-        "@hey-api/shared": "0.4.7",
+        "@hey-api/codegen-core": "0.8.0",
+        "@hey-api/json-schema-ref-parser": "1.4.1",
+        "@hey-api/shared": "0.4.1",
         "@hey-api/spec-types": "0.2.0",
         "@hey-api/types": "0.1.4",
-        "@lukeed/ms": "2.0.2",
         "ansi-colors": "4.1.3",
         "color-support": "1.1.3",
         "commander": "14.0.3",
@@ -88,7 +87,7 @@
         "openapi-ts": "bin/run.js"
       },
       "engines": {
-        "node": ">=22.18.0"
+        "node": ">=22.13.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/hey-api"
@@ -98,13 +97,13 @@
       }
     },
     "node_modules/@hey-api/shared": {
-      "version": "0.4.7",
-      "resolved": "https://registry.npmjs.org/@hey-api/shared/-/shared-0.4.7.tgz",
-      "integrity": "sha512-ujMNKbSswtrj6mCWnoFzf8HjFJ8lt/yqQObHqMtwPXH7/KOjKe2SXtea9Si+FeYUIhJ3VpOkV5eeFCPk1LXn7g==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@hey-api/shared/-/shared-0.4.1.tgz",
+      "integrity": "sha512-EDAjvGpEamn2fOB7W87ZStyDSv5mEpnQCciVbiZ+Ll4EfawwIjHMMtDtRQOYol0YjTkAeEm274GFPAtg3xfPGA==",
       "license": "MIT",
       "dependencies": {
-        "@hey-api/codegen-core": "0.8.4",
-        "@hey-api/json-schema-ref-parser": "1.4.3",
+        "@hey-api/codegen-core": "0.8.0",
+        "@hey-api/json-schema-ref-parser": "1.4.1",
         "@hey-api/spec-types": "0.2.0",
         "@hey-api/types": "0.1.4",
         "ansi-colors": "4.1.3",
@@ -113,7 +112,7 @@
         "semver": "7.7.4"
       },
       "engines": {
-        "node": ">=22.18.0"
+        "node": ">=22.13.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/hey-api"
@@ -143,15 +142,6 @@
       "integrity": "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg==",
       "license": "MIT"
     },
-    "node_modules/@lukeed/ms": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@lukeed/ms/-/ms-2.0.2.tgz",
-      "integrity": "sha512-9I2Zn6+NJLfaGoz9jN3lpwDgAYvfGeNYdbAIjJOqzs4Tpc+VU3Jqq4IofSUBKajiDS8k9fZIg18/z13mpk1bsA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
@@ -166,12 +156,6 @@
       "engines": {
         "node": ">=6"
       }
-    },
-    "node_modules/argparse": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "license": "Python-2.0"
     },
     "node_modules/bundle-name": {
       "version": "4.1.0",
@@ -427,24 +411,12 @@
       "license": "ISC"
     },
     "node_modules/jiti": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
-      "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
+      "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
-      }
-    },
-    "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^2.0.1"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/ohash": {
@@ -636,6 +608,21 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/yaml": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
       }
     }
   }

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -35,7 +35,7 @@
     "@hey-api/client-fetch": "0.13.1"
   },
   "devDependencies": {
-    "@hey-api/openapi-ts": "0.98.1",
+    "@hey-api/openapi-ts": "0.96.1",
     "typescript": "^5.6.0"
   },
   "publishConfig": {


### PR DESCRIPTION
**Reverts #145** (`@hey-api/openapi-ts` 0.96.1 → 0.98.1 in `sdks/typescript`), which turned **main red**.

### Why it broke
`make sdks` (the drift gate) regenerates the TS client, but the Makefile pins `@hey-api/openapi-ts@0.96.1` (line 123). #145 bumped the *package.json* devDep to 0.98.1 without bumping that pin or regenerating the committed SDK. The gate's `npm install` then made `npx` resolve 0.98.1, whose codegen **drops the `.js` extension** from relative imports (`./bodySerializer.gen.js` → `./bodySerializer.gen`) and reorders exports — so the regenerated `src/client/*.gen.ts` no longer matched the committed (0.96.1-generated) files. Drift confirmed scoped to `sdks/typescript/src/client/` only; `backend/openapi.json` and the Python SDK were unaffected (so #152's fastapi/pydantic bump is clean).

### Fix
Restore 0.96.1 so regen matches the committed SDK. It's a dev-only, pre-1.0 codegen tool — the bump had no runtime value, and dropping `.js` from ESM relative imports is also suspect for module resolution.

### To adopt 0.98.x later (separate, deliberate change)
Bump the `Makefile:123` pin to 0.98.x **and** run `make sdks` to regenerate + commit the new client, **and** verify the `.js`-less imports still resolve for SDK consumers.