### PR TITLE
Public-readiness prep: gitignore, CI hardening, /docs reconciliation, i18n stubs, domain fixes

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -4,8 +4,8 @@
 
 | Version | Supported |
 |---------|-----------|
-| Latest release | Yes |
-| Older releases | No |
+| 2.x     | Yes       |
+| < 2.0   | No        |
 
 We only patch the latest release. If you're running an older version, please upgrade before reporting.
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,11 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+# Least-privilege default for every job. The `changes` job widens to add
+# pull-requests:read; no job needs write (publishing lives in publish*.yml).
+permissions:
+  contents: read
+
 jobs:
   # ---------- detect changed paths for conditional jobs ----------
   changes:

--- a/.github/workflows/dep-audit.yml
+++ b/.github/workflows/dep-audit.yml
@@ -76,8 +76,8 @@ jobs:
       matrix:
         image:
           - "node:26.3.0-alpine"
-          - "python:3.14.3-slim"
-          - "nginxinc/nginx-unprivileged:1.29.8-alpine"
+          - "python:3.14.5-slim"
+          - "nginxinc/nginx-unprivileged:1.31.1-alpine"
           - "postgis/postgis:17-3.5"
     steps:
       - uses: actions/checkout@v6
@@ -88,7 +88,7 @@ jobs:
       # To enforce as a hard gate: set exit-code "1" (ideally after switching to
       # scan the built images, not the upstream refs).
       - name: Trivy scan (report-only)
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@v0.36.0
         with:
           image-ref: ${{ matrix.image }}
           format: "table"

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ __pycache__/
 .pytest_cache/
 *.egg-info/
 .venv/
+venv/
 .ruff_cache/
 .mypy_cache/
 
@@ -35,6 +36,7 @@ coverage.xml
 coverage/
 
 # Build output
+build/
 dist/
 
 # Playwright

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ __pycache__/
 *.egg-info/
 .venv/
 .ruff_cache/
+.mypy_cache/
 
 # Node
 node_modules/
@@ -25,11 +26,16 @@ Thumbs.db
 .vscode/
 *.swp
 *.swo
+*.code-workspace
 
 # Coverage reports
 htmlcov/
 coverage.xml
 .coverage
+coverage/
+
+# Build output
+dist/
 
 # Playwright
 playwright/.auth/
@@ -45,7 +51,7 @@ tests/load/results/*.txt
 
 # Internal development / assistant state (not for public release)
 .planning/
-.gsd/
+.gsd
 .gsd-id
 .mcp.json
 .bg-shell/
@@ -69,25 +75,17 @@ docs-internal/
 # Product docs live in the getgeolens.com repo.
 docs/
 
-# Stray screenshots
+# Images: ignore stray screenshots, keep curated assets
 *.png
 !.github/assets/*.png
 !frontend/public/*.png
+!frontend/src/assets/**/*.png
 
-# ── GSD baseline (auto-generated) ──
-.gsd
-*~
-*.code-workspace
-.next/
-dist/
-build/
-venv/
-target/
-vendor/
+# Logs / temp
 *.log
-coverage/
-.cache/
+*~
 tmp/
+.cache/
 
 # Marketing data working dir (raw downloads, mosaicked COGs)
 # Used by scripts/marketing-data/*/ — outputs land in .scratch/<topic>/.

--- a/BRANDING-VERSION
+++ b/BRANDING-VERSION
@@ -1,5 +1,5 @@
 Brand assets synced from geolens-io/branding v0.1.0
 Sync date: 2026-05-08
-Source path at sync: /Users/ishiland/Code/branding @ tag v0.1.0
+Source: geolens-io/branding @ tag v0.1.0
 Files synced: see .planning/quick/260508-bv1-sync-v0-1-0-branding/260508-bv1-SUMMARY.md
 Unmanaged assets: frontend/public/og-image.png (predates v0.1.0; refresh on next branding bump that ships an OG image)

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,5 @@
+GeoLens
+Copyright 2026 Carto Concepts, LLC
+
+This product is licensed under the Apache License, Version 2.0.
+See the LICENSE file for the full license text.

--- a/README.de.md
+++ b/README.de.md
@@ -6,7 +6,7 @@
 
 Laden Sie Shapefiles, GeoTIFFs, GeoPackages oder CSVs hoch. GeoLens speichert alles in PostGIS, indexiert Metadaten mit pgvector + pg_trgm für semantische und unscharfe Suche und stellt OGC APIs bereit, die QGIS, ArcGIS und MapLibre Clients direkt nutzen können. Gebaut mit FastAPI und React, bereitgestellt mit einem einzigen Befehl.
 
-> Diese Übersetzung folgt dem englischen README als kanonischer Quelle. Wenn eine Übersetzung ungenau ist, öffnen Sie bitte eine Issue oder Pull Request.
+> Dies ist eine gekürzte Übersetzung. Das englische [README](README.md) ist die kanonische Quelle; die vollständige, stets aktuelle deutschsprachige Dokumentation finden Sie unter **[docs.getgeolens.com/de](https://docs.getgeolens.com/de)**.
 
 [![CI](https://github.com/geolens-io/geolens/actions/workflows/ci.yml/badge.svg)](https://github.com/geolens-io/geolens/actions/workflows/ci.yml)
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
@@ -28,15 +28,14 @@ bash scripts/install.sh
 
 ## Dokumentation
 
-Die Benutzer-, Admin- und API-Dokumentation finden Sie unter **[docs.getgeolens.com](https://docs.getgeolens.com)**.
+Vollständige Benutzer-, Admin- und API-Dokumentation:
 
+- **Auf Deutsch:** [docs.getgeolens.com/de](https://docs.getgeolens.com/de)
 - **Installation und Quickstart:** [docs.getgeolens.com/guides/quickstart](https://docs.getgeolens.com/guides/quickstart/)
 - **Admin-Handbuch:** [docs.getgeolens.com/guides/admin](https://docs.getgeolens.com/guides/admin/)
 - **API-Referenz:** [docs.getgeolens.com/guides/api](https://docs.getgeolens.com/guides/api/)
 
 ## Veröffentlichte Artefakte
-
-GeoLens wird über die Standard-Paketregister veröffentlicht:
 
 ```bash
 pip install geolens          # Python SDK
@@ -44,186 +43,17 @@ pip install geolens-cli      # CLI; installiert den Befehl `geolens`
 npm install @geolens/sdk     # TypeScript/JavaScript SDK
 ```
 
-Öffentliche API- und Frontend-Images in GitHub Container Registry:
+Öffentliche API- und Frontend-Images in der GitHub Container Registry:
 
 ```bash
 docker pull ghcr.io/geolens-io/geolens-api:latest
 docker pull ghcr.io/geolens-io/geolens-frontend:latest
 ```
 
-Die Tags `1.0`, `1` und `latest` folgen der aktuellen 1.x Release-Linie.
+## Mehr erfahren
 
-## Warum GeoLens?
-
-Raumbezogene Daten landen oft verstreut: Shapefiles auf Netzlaufwerken, Tabellen in Datenbankschemas, Raster in Buckets und Metadaten in Tabellenkalkulationen. Den richtigen Datensatz zu finden bedeutet häufig, in Slack zu fragen oder Dateiserver zu durchsuchen. Teilen heißt exportieren, per E-Mail versenden und hoffen, dass das CRS passt.
-
-GeoLens ersetzt diesen Ablauf:
-
-- **Ein Katalog**: Shapefiles, GeoPackages, GeoTIFFs oder CSVs hochladen und in Minuten durchsuchbar, voranschaubar und exportierbar machen.
-- **Kompatibel mit Ihren Werkzeugen**: OGC API Features/Records mit CQL2-Filterung, STAC 1.0 und direkte Tile-URLs für QGIS, ArcGIS und MapLibre.
-- **Semantische + räumliche Suche**: Datensätze nach Bedeutung finden, nicht nur nach Schlagworten, mit pgvector und pg_trgm.
-- **Integrierter Map Builder**: Mehrschichtige Karten zusammenstellen, stylen und per öffentlichem Link oder eingebettetem iframe teilen.
-- **Optionale KI**: Mit Karten chatten, Beschreibungen generieren und natürliche Sprache für Suche nutzen. Verwenden Sie jede OpenAI-kompatible API oder lassen Sie KI deaktiviert.
-
-## In Aktion
-
-Suchen Sie Datensätze nach Bedeutung, nicht nur nach Schlagworten:
-
-```bash
-# Semantische Suche: findet "hydrology"-Datensätze auch bei der Suche nach "rivers"
-curl 'http://localhost:8080/api/search/datasets/?q=rivers+near+mountains&limit=3' \
-  -H 'Authorization: Bearer <token>' | jq '.features[].properties.title'
-```
-
-Jeder Datensatz ist auch ein standardmäßiger OGC API Features Endpoint:
-
-```bash
-# GeoJSON-Features mit bbox-Filter: funktioniert in QGIS, ArcGIS und jedem OGC-Client
-curl 'http://localhost:8080/api/collections/ne_10m_admin_0_countries/items?bbox=-10,35,30,60&limit=5'
-```
-
-Aus QGIS verbinden Sie sich über **Layer > Add WFS / OGC API Features** und verwenden `http://localhost:8080/api/`.
-
-## Funktionen
-
-### Map Builder und Teilen
-
-- Interaktive Karten mit mehreren Layern, Drag-and-drop-Reihenfolge, Styling und Layer-Filtern.
-- Punkt-, Linien- und Polygonstile mit Farbskalen und Kategorieklassen.
-- Öffentliche Links und einbettbare `<iframe>` Snippets.
-- Raster-COG- und Vektor-Layer nebeneinander.
-
-### KI-gestützt (optional)
-
-- Mit Karten chatten: Fragen in natürlicher Sprache stellen; die KI fügt Layer hinzu und stylt sie.
-- Semantische Vektorsuche über Metadaten mit pgvector und HNSW-Indexierung.
-- Automatisch generierte Datensatzbeschreibungen und Tags beim Import.
-- Funktioniert mit jeder OpenAI-kompatiblen API (OpenAI, Anthropic, Ollama); GeoLens ist auch ohne sie voll funktionsfähig.
-
-### Suche und Discovery
-
-- Volltext- und Trigramm-Suche über Namen, Beschreibungen und Metadaten.
-- Räumliche Suche mit Bounding Boxes und auf der Karte gezeichneten Filtern.
-- Facettierte Filter nach Format, Tags, Sammlungen und Record-Typ.
-- Optionale semantische Suche mit pgvector.
-- Gespeicherte Suchen für wiederkehrende Abläufe.
-
-### Datenimport und Export
-
-- **Vektor:** Shapefile, GeoPackage, GeoJSON, CSV und XLSX.
-- **Raster:** GeoTIFF und Cloud-Optimized GeoTIFF mit automatischer Konvertierung.
-- **Mosaike:** VRT-basierte Rastermosaike.
-- **Export:** GeoJSON, Shapefile, GeoPackage und CSV mit CRS-Reprojektion.
-- Provenienzverfolgung und Metadatenbearbeitung.
-
-### Standards und Interoperabilität
-
-- Kompatibel mit OGC API - Features und OGC API - Records.
-- STAC 1.0 Katalog-Endpoint.
-- Direkte Tile-URLs für QGIS, ArcGIS, MapLibre und OGC Clients.
-- API-Key-Authentifizierung für externe Werkzeuge.
-- JWT + OAuth 2.0/OIDC und RBAC mit Berechtigungen pro Datensatz.
-
-<details>
-<summary>Enterprise und Sicherheit</summary>
-
-- JWT-Authentifizierung mit Refresh Tokens.
-- API-Key-Verwaltung pro Benutzer.
-- OAuth 2.0 / OIDC-Unterstützung (Google, Microsoft und generische Anbieter).
-- Rollenbasierte Zugriffskontrolle (RBAC) mit Berechtigungen pro Datensatz.
-- Audit Logging für alle administrativen Aktionen.
-- Internationalisierung: Englisch, Spanisch, Französisch, Deutsch.
-
-</details>
-
-## Screenshots
-
-<p align="center">
-  <img src=".github/assets/geolens-catalog.png" alt="GeoLens Katalogansicht" width="900" />
-  <br />
-  <em>Katalogansicht mit Suche, räumlichen Filtern und Datensatzkarten</em>
-</p>
-
-<p align="center">
-  <img src=".github/assets/geolens-dataset.png" alt="GeoLens Datensatzdetail" width="900" />
-  <br />
-  <em>Datensatzdetail mit Kartenvorschau, Metadaten und Attributtabelle</em>
-</p>
-
-## Schnellstart
-
-**Voraussetzungen:** Docker Engine 24+ und Docker Compose v2.
-
-```bash
-git clone https://github.com/geolens-io/geolens.git
-cd geolens
-bash scripts/install.sh
-```
-
-`scripts/install.sh` kopiert `.env.example` nach `.env`, generiert ein
-JWT-Signing-Secret, fragt nach Admin-Anmeldedaten (Standard: `admin` / `admin`)
-und führt `docker compose up -d` aus. Für unbeaufsichtigte Installationen können
-Sie `GEOLENS_ADMIN_USERNAME` und `GEOLENS_ADMIN_PASSWORD` als Umgebungsvariablen
-setzen, dann werden die Eingabeaufforderungen übersprungen. Erneutes Ausführen
-des Skripts ist idempotent — vorhandene Werte in `.env` bleiben erhalten.
-
-Warten Sie etwa 60 Sekunden, öffnen Sie [http://localhost:8080](http://localhost:8080), und melden Sie sich mit den gewählten Admin-Anmeldedaten an.
-
-Prüfen Sie, dass alle Services fehlerfrei laufen:
-
-```bash
-docker compose ps
-```
-
-Zur Produktionsbereitstellung siehe den [Install Guide](https://docs.getgeolens.com/guides/quickstart/install/). Für Upgrades siehe den [Upgrade Guide](https://docs.getgeolens.com/guides/quickstart/upgrade/).
-
-### Seed Data
-
-Befüllen Sie den Katalog mit [Natural Earth](https://www.naturalearthdata.com/) 1:10m Datensätzen:
-
-```bash
-pip install httpx  # einmalige Abhängigkeit auf dem Host
-python scripts/seed-natural-earth.py --username admin --password admin
-```
-
-Das Skript meldet sich an, erstellt einen temporären API-Key für den Lauf, ingestiert die Datensätze und löscht den Key beim Beenden. Es lädt vom [NACIS CDN](https://naciscdn.org/naturalearth/) herunter, überspringt Duplikate bei erneuter Ausführung und erstellt zwei Sammlungen (Cultural 10m, Physical 10m). Nutzen Sie `--dry-run` zur Vorschau oder `--theme cultural` zum Filtern nach Thema.
-
-Wenn Sie bereits einen API-Key haben (Admin > API Keys > Create New, oder via `POST /api/auth/api-keys/`), übergeben Sie `--api-key <plaintext>` anstelle von `--username/--password`.
-
-## Architektur
-
-| Komponente | Technologie |
-|------------|-------------|
-| Frontend | React 19, Vite, MapLibre GL v5, TanStack Query, Tailwind CSS |
-| Backend API | FastAPI (Python), GDAL/ogr2ogr, Procrastinate (Task Queue) |
-| Raster Tiles | Titiler (COG Tile Server) |
-| Object Storage | MinIO (S3-kompatibel, lokale Entwicklung) oder jeder S3-Anbieter |
-| Cache | Valkey (Tile- und Query-Cache) |
-| Datenbank | PostgreSQL 17 + PostGIS 3.5 + pgvector + pg_trgm |
-| Reverse Proxy | Nginx (Produktion) / Vite Dev Proxy (Entwicklung) |
-
-## Konfiguration
-
-Die gesamte Konfiguration wird über Umgebungsvariablen in `.env` verwaltet. Siehe die [Configuration Reference](https://docs.getgeolens.com/guides/quickstart/configuration/) für die vollständige Optionsliste mit Standardwerten und Beschreibungen.
-
-## Referenz
-
-| Guide | Beschreibung |
-|------|--------------|
-| [Install Guide](https://docs.getgeolens.com/guides/quickstart/install/) | Schrittweise Bereitstellung mit Docker Compose |
-| [Upgrade Guide](https://docs.getgeolens.com/guides/quickstart/upgrade/) | Upgrades zwischen Versionen mit Rollback |
-| [Configuration Reference](https://docs.getgeolens.com/guides/quickstart/configuration/) | Umgebungsvariablen und Standardwerte |
-| [Admin Guide](https://docs.getgeolens.com/guides/admin/) | Benutzerverwaltung, Datensätze und Systemzustand |
-| [Cloud Deployment](https://docs.getgeolens.com/guides/quickstart/cloud-deployment/) | AWS-, GCP- und DigitalOcean-Bereitstellungsanleitungen |
-| [Developer Docs](https://docs.getgeolens.com/) | Eigene Map-Builder-Widgets bauen |
-| [API Reference](https://docs.getgeolens.com/guides/api/) | Auto-generierte Referenz auf docs.getgeolens.com; interaktive Swagger UI unter `/api/docs` |
-| [Manifest-Beispiele](examples/manifests/) | Funktionierende `geolens.yaml`-Beispiele — first-catalog, public-cog (entferntes COG), s3-source, url-source |
-
-## Community
-
-- [GitHub Discussions](https://github.com/geolens-io/geolens/discussions): Fragen, Ideen, Show and Tell.
-- [Beitragsleitfaden](.github/CONTRIBUTING.md): Entwicklungsumgebung, Codestil und Pull Requests.
+Dieses README ist eine Kurzfassung. Den vollständigen Funktionsüberblick, die Konfiguration, die Architektur und den Beitragsleitfaden finden Sie im **[englischen README](README.md)** und in der **[vollständigen Dokumentation](https://docs.getgeolens.com/de)**.
 
 ## Lizenz
 
-GeoLens ist unter der [Apache License 2.0](LICENSE) lizenziert.
+Apache-2.0 — siehe [LICENSE](LICENSE) und [NOTICE](NOTICE).

--- a/README.es.md
+++ b/README.es.md
@@ -6,7 +6,7 @@
 
 Sube Shapefiles, GeoTIFFs, GeoPackages o CSVs. GeoLens guarda todo en PostGIS, indexa los metadatos con pgvector + pg_trgm para búsqueda semántica y difusa, y sirve APIs OGC que QGIS, ArcGIS y clientes MapLibre pueden usar de forma nativa. Está construido con FastAPI y React, y se despliega con un solo comando.
 
-> Esta traducción sigue el README en inglés como fuente canónica. Si encuentras una traducción imprecisa, abre una issue o una pull request.
+> Esta es una traducción resumida. El [README en inglés](README.md) es la fuente canónica; la documentación completa y actualizada en español está en **[docs.getgeolens.com/es](https://docs.getgeolens.com/es)**.
 
 [![CI](https://github.com/geolens-io/geolens/actions/workflows/ci.yml/badge.svg)](https://github.com/geolens-io/geolens/actions/workflows/ci.yml)
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
@@ -28,15 +28,14 @@ bash scripts/install.sh
 
 ## Documentación
 
-La documentación de usuario, administración y API vive en **[docs.getgeolens.com](https://docs.getgeolens.com)**.
+Documentación completa de usuario, administración y API:
 
+- **En español:** [docs.getgeolens.com/es](https://docs.getgeolens.com/es)
 - **Instalación y quickstart:** [docs.getgeolens.com/guides/quickstart](https://docs.getgeolens.com/guides/quickstart/)
 - **Guía de administración:** [docs.getgeolens.com/guides/admin](https://docs.getgeolens.com/guides/admin/)
 - **Referencia de API:** [docs.getgeolens.com/guides/api](https://docs.getgeolens.com/guides/api/)
 
 ## Artefactos publicados
-
-GeoLens se publica en los registros de paquetes habituales:
 
 ```bash
 pip install geolens          # SDK de Python
@@ -51,180 +50,10 @@ docker pull ghcr.io/geolens-io/geolens-api:latest
 docker pull ghcr.io/geolens-io/geolens-frontend:latest
 ```
 
-Las etiquetas `1.0`, `1` y `latest` siguen la línea actual de releases 1.x.
+## Más información
 
-## ¿Por qué GeoLens?
-
-Los datos espaciales terminan dispersos: shapefiles en unidades compartidas, tablas en esquemas de base de datos, rasters en buckets y metadatos en hojas de cálculo. Encontrar el dataset correcto suele significar preguntar en Slack o buscar en servidores de archivos. Compartirlo implica exportar, enviar por correo y esperar que el CRS coincida.
-
-GeoLens reemplaza ese flujo:
-
-- **Un catálogo**: sube Shapefiles, GeoPackages, GeoTIFFs o CSVs y quedan buscables, previsualizables y exportables en minutos.
-- **Funciona con tus herramientas**: OGC API Features/Records con filtrado CQL2, STAC 1.0 y URLs directas de tiles para QGIS, ArcGIS y MapLibre.
-- **Búsqueda semántica + espacial**: encuentra datasets por significado, no solo por palabras clave, con pgvector y pg_trgm.
-- **Constructor de mapas integrado**: compone mapas multicapa, estilízalos y compártelos por enlace público o iframe embebible.
-- **IA opcional**: conversa con tus mapas, genera descripciones y busca con lenguaje natural. Usa cualquier API compatible con OpenAI o no uses IA.
-
-## En acción
-
-Busca datasets por significado, no solo por palabras clave:
-
-```bash
-# Búsqueda semántica: encuentra datasets de "hydrology" aunque busques "rivers"
-curl 'http://localhost:8080/api/search/datasets/?q=rivers+near+mountains&limit=3' \
-  -H 'Authorization: Bearer <token>' | jq '.features[].properties.title'
-```
-
-Cada dataset también es un endpoint OGC API Features estándar:
-
-```bash
-# Features GeoJSON con filtro bbox: funciona en QGIS, ArcGIS y cualquier cliente OGC
-curl 'http://localhost:8080/api/collections/ne_10m_admin_0_countries/items?bbox=-10,35,30,60&limit=5'
-```
-
-Conecta desde QGIS con **Layer > Add WFS / OGC API Features** y apunta a `http://localhost:8080/api/`.
-
-## Funciones
-
-### Constructor de mapas y uso compartido
-
-- Mapas interactivos multicapa con ordenamiento por arrastrar y soltar, estilos y filtros por capa.
-- Estilos para puntos, líneas y polígonos con rampas de color y cortes por categoría.
-- Enlaces públicos e iframes embebibles.
-- Capas raster COG y vectoriales lado a lado.
-
-### IA asistida (opcional)
-
-- Conversa con tus mapas: haz preguntas en lenguaje natural y la IA agrega y estiliza capas.
-- Búsqueda vectorial semántica en metadatos con pgvector e índices HNSW.
-- Descripciones y tags de datasets generados automáticamente durante la ingestión.
-- Funciona con cualquier API compatible con OpenAI (OpenAI, Anthropic, Ollama); GeoLens funciona por completo sin ella.
-
-### Búsqueda y descubrimiento
-
-- Búsqueda de texto completo y trigramas en nombres, descripciones y metadatos.
-- Búsqueda espacial con bounding boxes y filtros dibujados en el mapa.
-- Facetas por formato, tags, colecciones y tipo de registro.
-- Búsqueda semántica opcional con pgvector.
-- Búsquedas guardadas para flujos repetidos.
-
-### Ingestión y exportación
-
-- **Vector:** Shapefile, GeoPackage, GeoJSON, CSV y XLSX.
-- **Raster:** GeoTIFF y Cloud-Optimized GeoTIFF con conversión automática.
-- **Mosaicos:** mosaicos raster basados en VRT.
-- **Exportación:** GeoJSON, Shapefile, GeoPackage y CSV con reproyección CRS.
-- Trazabilidad de procedencia y edición de metadatos.
-
-### Estándares e interoperabilidad
-
-- Compatible con OGC API - Features y OGC API - Records.
-- Endpoint de catálogo STAC 1.0.
-- URLs directas de tiles para QGIS, ArcGIS, MapLibre y clientes OGC.
-- Autenticación por API key para herramientas externas.
-- JWT + OAuth 2.0/OIDC y RBAC con permisos por dataset.
-
-<details>
-<summary>Empresa y seguridad</summary>
-
-- Autenticación JWT con refresh tokens.
-- Gestión de API keys por usuario.
-- Soporte OAuth 2.0 / OIDC (Google, Microsoft y proveedores genéricos).
-- Control de acceso basado en roles (RBAC) con permisos por dataset.
-- Audit logging para todas las acciones administrativas.
-- Internacionalización: inglés, español, francés, alemán.
-
-</details>
-
-## Capturas de pantalla
-
-<p align="center">
-  <img src=".github/assets/geolens-catalog.png" alt="Vista de catálogo de GeoLens" width="900" />
-  <br />
-  <em>Vista de catálogo con búsqueda, filtros espaciales y tarjetas de dataset</em>
-</p>
-
-<p align="center">
-  <img src=".github/assets/geolens-dataset.png" alt="Detalle de dataset de GeoLens" width="900" />
-  <br />
-  <em>Detalle de dataset con previsualización de mapa, metadatos y tabla de atributos</em>
-</p>
-
-## Inicio rápido
-
-**Requisitos:** Docker Engine 24+ y Docker Compose v2.
-
-```bash
-git clone https://github.com/geolens-io/geolens.git
-cd geolens
-bash scripts/install.sh
-```
-
-`scripts/install.sh` copia `.env.example` a `.env`, genera un secreto de
-firma JWT, solicita las credenciales de administrador (por defecto:
-`admin` / `admin`) y ejecuta `docker compose up -d`. Para instalaciones no
-interactivas, define `GEOLENS_ADMIN_USERNAME` y `GEOLENS_ADMIN_PASSWORD` como
-variables de entorno antes de ejecutar y se omitirán los prompts. Volver a
-ejecutar el script es idempotente — se conservan los valores existentes en
-`.env`.
-
-Espera unos 60 segundos, abre [http://localhost:8080](http://localhost:8080) e inicia sesión con las credenciales de administrador que configuraste.
-
-Verifica que todos los servicios estén sanos:
-
-```bash
-docker compose ps
-```
-
-Para despliegue en producción, consulta la [Install Guide](https://docs.getgeolens.com/guides/quickstart/install/). Para actualizar, consulta la [Upgrade Guide](https://docs.getgeolens.com/guides/quickstart/upgrade/).
-
-### Seed Data
-
-Puebla el catálogo con datasets 1:10m de [Natural Earth](https://www.naturalearthdata.com/):
-
-```bash
-pip install httpx  # dependencia única en el host
-python scripts/seed-natural-earth.py --username admin --password admin
-```
-
-El script inicia sesión, crea una API key temporal para la ejecución, ingesta los datasets y elimina la clave al salir. Descarga desde el [NACIS CDN](https://naciscdn.org/naturalearth/), omite duplicados al volver a ejecutarse y crea dos colecciones (Cultural 10m, Physical 10m). Usa `--dry-run` para previsualizar o `--theme cultural` para filtrar por tema.
-
-Si ya tienes una API key existente (Admin > API Keys > Create New, o vía `POST /api/auth/api-keys/`), pasa `--api-key <plaintext>` en lugar de `--username/--password`.
-
-## Arquitectura
-
-| Componente | Tecnología |
-|-----------|------------|
-| Frontend | React 19, Vite, MapLibre GL v5, TanStack Query, Tailwind CSS |
-| Backend API | FastAPI (Python), GDAL/ogr2ogr, Procrastinate (cola de tareas) |
-| Tiles raster | Titiler (servidor de tiles COG) |
-| Almacenamiento | MinIO (compatible S3, dev local) o cualquier proveedor S3 |
-| Cache | Valkey (cache de tiles y consultas) |
-| Base de datos | PostgreSQL 17 + PostGIS 3.5 + pgvector + pg_trgm |
-| Proxy inverso | Nginx (producción) / proxy Vite dev (desarrollo) |
-
-## Configuración
-
-Toda la configuración se gestiona con variables de entorno en `.env`. Consulta la [Configuration Reference](https://docs.getgeolens.com/guides/quickstart/configuration/) para la lista completa de opciones con valores por defecto y descripciones.
-
-## Referencia
-
-| Guía | Descripción |
-|-----|-------------|
-| [Install Guide](https://docs.getgeolens.com/guides/quickstart/install/) | Despliegue paso a paso con Docker Compose |
-| [Upgrade Guide](https://docs.getgeolens.com/guides/quickstart/upgrade/) | Actualizaciones entre versiones con rollback |
-| [Configuration Reference](https://docs.getgeolens.com/guides/quickstart/configuration/) | Variables de entorno y valores por defecto |
-| [Admin Guide](https://docs.getgeolens.com/guides/admin/) | Usuarios, datasets y salud del sistema |
-| [Cloud Deployment](https://docs.getgeolens.com/guides/quickstart/cloud-deployment/) | Guías de despliegue en AWS, GCP y DigitalOcean |
-| [Developer Docs](https://docs.getgeolens.com/) | Crear widgets personalizados para el map builder |
-| [API Reference](https://docs.getgeolens.com/guides/api/) | Referencia generada automáticamente en docs.getgeolens.com; Swagger UI interactivo en `/api/docs` |
-| [Ejemplos de manifiestos](examples/manifests/) | Ejemplos `geolens.yaml` listos para usar — first-catalog, public-cog (COG remoto), s3-source, url-source |
-
-## Comunidad
-
-- [GitHub Discussions](https://github.com/geolens-io/geolens/discussions): preguntas, ideas, show and tell.
-- [Guía de contribución](.github/CONTRIBUTING.md): entorno de desarrollo, estilo de código y pull requests.
+Este README es una versión resumida. Encontrarás el resumen completo de funcionalidades, la configuración, la arquitectura y la guía de contribución en el **[README en inglés](README.md)** y en la **[documentación completa](https://docs.getgeolens.com/es)**.
 
 ## Licencia
 
-GeoLens está licenciado bajo [Apache License 2.0](LICENSE).
+Apache-2.0 — consulta [LICENSE](LICENSE) y [NOTICE](NOTICE).

--- a/README.fr.md
+++ b/README.fr.md
@@ -6,7 +6,7 @@
 
 Importez des Shapefiles, GeoTIFFs, GeoPackages ou CSVs. GeoLens stocke tout dans PostGIS, indexe les métadonnées avec pgvector + pg_trgm pour la recherche sémantique et approximative, et expose des APIs OGC utilisables directement par QGIS, ArcGIS et les clients MapLibre. L'application est construite avec FastAPI et React, et se déploie avec une seule commande.
 
-> Cette traduction suit le README anglais comme source canonique. Si une traduction vous semble incorrecte, ouvrez une issue ou une pull request.
+> Ceci est une traduction abrégée. Le [README anglais](README.md) est la source canonique ; la documentation complète et à jour en français est disponible sur **[docs.getgeolens.com/fr](https://docs.getgeolens.com/fr)**.
 
 [![CI](https://github.com/geolens-io/geolens/actions/workflows/ci.yml/badge.svg)](https://github.com/geolens-io/geolens/actions/workflows/ci.yml)
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
@@ -28,15 +28,14 @@ bash scripts/install.sh
 
 ## Documentation
 
-La documentation utilisateur, administrateur et API est disponible sur **[docs.getgeolens.com](https://docs.getgeolens.com)**.
+Documentation complète utilisateur, administrateur et API :
 
+- **En français :** [docs.getgeolens.com/fr](https://docs.getgeolens.com/fr)
 - **Installation et démarrage rapide :** [docs.getgeolens.com/guides/quickstart](https://docs.getgeolens.com/guides/quickstart/)
 - **Guide d'administration :** [docs.getgeolens.com/guides/admin](https://docs.getgeolens.com/guides/admin/)
 - **Référence API :** [docs.getgeolens.com/guides/api](https://docs.getgeolens.com/guides/api/)
 
 ## Artefacts publiés
-
-GeoLens est publié sur les registres de paquets standards :
 
 ```bash
 pip install geolens          # SDK Python
@@ -51,180 +50,10 @@ docker pull ghcr.io/geolens-io/geolens-api:latest
 docker pull ghcr.io/geolens-io/geolens-frontend:latest
 ```
 
-Les tags `1.0`, `1` et `latest` suivent la ligne de release 1.x actuelle.
+## En savoir plus
 
-## Pourquoi GeoLens ?
-
-Les données spatiales finissent dispersées : shapefiles sur des partages réseau, tables dans des schémas de base de données, rasters dans des buckets et métadonnées dans des feuilles de calcul. Trouver le bon jeu de données revient souvent à demander sur Slack ou à fouiller des serveurs de fichiers. Le partager signifie exporter, envoyer par e-mail et espérer que le CRS corresponde.
-
-GeoLens remplace ce flux :
-
-- **Un catalogue** : importez Shapefiles, GeoPackages, GeoTIFFs ou CSVs et rendez-les consultables, prévisualisables et exportables en quelques minutes.
-- **Compatible avec vos outils** : OGC API Features/Records avec filtrage CQL2, STAC 1.0 et URLs directes de tuiles pour QGIS, ArcGIS et MapLibre.
-- **Recherche sémantique + spatiale** : trouvez les jeux de données par sens, pas seulement par mot-clé, avec pgvector et pg_trgm.
-- **Constructeur de cartes intégré** : composez des cartes multicouches, appliquez des styles et partagez-les par lien public ou iframe.
-- **IA optionnelle** : discutez avec vos cartes, générez des descriptions et recherchez en langage naturel. Utilisez toute API compatible OpenAI ou ignorez l'IA.
-
-## En action
-
-Recherchez des jeux de données par sens, pas seulement par mot-clé :
-
-```bash
-# Recherche sémantique : trouve les jeux de données "hydrology" même avec "rivers"
-curl 'http://localhost:8080/api/search/datasets/?q=rivers+near+mountains&limit=3' \
-  -H 'Authorization: Bearer <token>' | jq '.features[].properties.title'
-```
-
-Chaque jeu de données est aussi un endpoint OGC API Features standard :
-
-```bash
-# Features GeoJSON avec filtre bbox : fonctionne dans QGIS, ArcGIS et tout client OGC
-curl 'http://localhost:8080/api/collections/ne_10m_admin_0_countries/items?bbox=-10,35,30,60&limit=5'
-```
-
-Depuis QGIS, utilisez **Layer > Add WFS / OGC API Features** et pointez vers `http://localhost:8080/api/`.
-
-## Fonctionnalités
-
-### Constructeur de cartes et partage
-
-- Cartes interactives multicouches avec ordre par glisser-déposer, styles et filtres par couche.
-- Styles pour points, lignes et polygones avec rampes de couleurs et classes par catégorie.
-- Liens publics et snippets `<iframe>` embarquables.
-- Couches raster COG et vectorielles côte à côte.
-
-### IA assistée (optionnelle)
-
-- Discutez avec vos cartes : posez des questions en langage naturel, l'IA ajoute et stylise des couches.
-- Recherche vectorielle sémantique dans les métadonnées avec pgvector et index HNSW.
-- Descriptions et tags de jeux de données générés automatiquement à l'ingestion.
-- Compatible avec toute API compatible OpenAI (OpenAI, Anthropic, Ollama) ; GeoLens fonctionne entièrement sans elle.
-
-### Recherche et découverte
-
-- Recherche plein texte et trigrammes sur noms, descriptions et métadonnées.
-- Recherche spatiale par bounding box et filtres dessinés sur la carte.
-- Facettes par format, tags, collections et type d'enregistrement.
-- Recherche sémantique optionnelle avec pgvector.
-- Recherches sauvegardées pour les flux répétés.
-
-### Ingestion et export
-
-- **Vecteur :** Shapefile, GeoPackage, GeoJSON, CSV et XLSX.
-- **Raster :** GeoTIFF et Cloud-Optimized GeoTIFF avec conversion automatique.
-- **Mosaïques :** mosaïques raster basées sur VRT.
-- **Export :** GeoJSON, Shapefile, GeoPackage et CSV avec reprojection CRS.
-- Suivi de provenance et édition de métadonnées.
-
-### Standards et interopérabilité
-
-- Conforme à OGC API - Features et OGC API - Records.
-- Endpoint de catalogue STAC 1.0.
-- URLs directes de tuiles pour QGIS, ArcGIS, MapLibre et clients OGC.
-- Authentification par API key pour les outils externes.
-- JWT + OAuth 2.0/OIDC et RBAC avec permissions par jeu de données.
-
-<details>
-<summary>Entreprise et sécurité</summary>
-
-- Authentification JWT avec refresh tokens.
-- Gestion des API keys par utilisateur.
-- Prise en charge OAuth 2.0 / OIDC (Google, Microsoft et fournisseurs génériques).
-- Contrôle d'accès basé sur les rôles (RBAC) avec permissions par jeu de données.
-- Audit logging pour toutes les actions administratives.
-- Internationalisation : anglais, espagnol, français, allemand.
-
-</details>
-
-## Captures d'écran
-
-<p align="center">
-  <img src=".github/assets/geolens-catalog.png" alt="Vue catalogue de GeoLens" width="900" />
-  <br />
-  <em>Vue catalogue avec recherche, filtres spatiaux et cartes de jeux de données</em>
-</p>
-
-<p align="center">
-  <img src=".github/assets/geolens-dataset.png" alt="Détail de jeu de données GeoLens" width="900" />
-  <br />
-  <em>Détail de jeu de données avec aperçu cartographique, métadonnées et table attributaire</em>
-</p>
-
-## Démarrage rapide
-
-**Prérequis :** Docker Engine 24+ et Docker Compose v2.
-
-```bash
-git clone https://github.com/geolens-io/geolens.git
-cd geolens
-bash scripts/install.sh
-```
-
-`scripts/install.sh` copie `.env.example` vers `.env`, génère un secret de
-signature JWT, demande les identifiants administrateur (par défaut :
-`admin` / `admin`), puis exécute `docker compose up -d`. Pour une installation
-non interactive, définissez `GEOLENS_ADMIN_USERNAME` et `GEOLENS_ADMIN_PASSWORD`
-dans l'environnement avant de lancer le script et les invites seront ignorées.
-Relancer le script est idempotent — les valeurs existantes dans `.env` sont
-préservées.
-
-Attendez environ 60 secondes, ouvrez [http://localhost:8080](http://localhost:8080), puis connectez-vous avec les identifiants administrateur que vous avez définis.
-
-Vérifiez que tous les services sont sains :
-
-```bash
-docker compose ps
-```
-
-Pour un déploiement en production, consultez l'[Install Guide](https://docs.getgeolens.com/guides/quickstart/install/). Pour les mises à niveau, consultez l'[Upgrade Guide](https://docs.getgeolens.com/guides/quickstart/upgrade/).
-
-### Seed Data
-
-Remplissez le catalogue avec des jeux de données [Natural Earth](https://www.naturalearthdata.com/) 1:10m :
-
-```bash
-pip install httpx  # dépendance unique sur l'hôte
-python scripts/seed-natural-earth.py --username admin --password admin
-```
-
-Le script se connecte, crée une API key temporaire pour l'exécution, ingère les jeux de données et supprime la clé à la sortie. Il télécharge depuis le [NACIS CDN](https://naciscdn.org/naturalearth/), ignore les doublons lors d'une nouvelle exécution et crée deux collections (Cultural 10m, Physical 10m). Utilisez `--dry-run` pour prévisualiser ou `--theme cultural` pour filtrer par thème.
-
-Si vous avez déjà une API key (Admin > API Keys > Create New, ou via `POST /api/auth/api-keys/`), passez `--api-key <plaintext>` au lieu de `--username/--password`.
-
-## Architecture
-
-| Composant | Technologie |
-|-----------|-------------|
-| Frontend | React 19, Vite, MapLibre GL v5, TanStack Query, Tailwind CSS |
-| Backend API | FastAPI (Python), GDAL/ogr2ogr, Procrastinate (queue de tâches) |
-| Tuiles raster | Titiler (serveur de tuiles COG) |
-| Stockage objet | MinIO (compatible S3, dev local) ou tout fournisseur S3 |
-| Cache | Valkey (cache de tuiles et requêtes) |
-| Base de données | PostgreSQL 17 + PostGIS 3.5 + pgvector + pg_trgm |
-| Proxy inverse | Nginx (production) / proxy Vite dev (développement) |
-
-## Configuration
-
-Toute la configuration est gérée par variables d'environnement dans `.env`. Consultez la [Configuration Reference](https://docs.getgeolens.com/guides/quickstart/configuration/) pour la liste complète des options avec valeurs par défaut et descriptions.
-
-## Référence
-
-| Guide | Description |
-|------|-------------|
-| [Install Guide](https://docs.getgeolens.com/guides/quickstart/install/) | Déploiement pas à pas avec Docker Compose |
-| [Upgrade Guide](https://docs.getgeolens.com/guides/quickstart/upgrade/) | Mises à niveau avec procédures de rollback |
-| [Configuration Reference](https://docs.getgeolens.com/guides/quickstart/configuration/) | Variables d'environnement et valeurs par défaut |
-| [Admin Guide](https://docs.getgeolens.com/guides/admin/) | Gestion des utilisateurs, datasets et santé système |
-| [Cloud Deployment](https://docs.getgeolens.com/guides/quickstart/cloud-deployment/) | Guides de déploiement AWS, GCP et DigitalOcean |
-| [Developer Docs](https://docs.getgeolens.com/) | Créer des widgets personnalisés pour le map builder |
-| [API Reference](https://docs.getgeolens.com/guides/api/) | Référence générée automatiquement sur docs.getgeolens.com ; Swagger UI interactif sur `/api/docs` |
-| [Exemples de manifestes](examples/manifests/) | Exemples `geolens.yaml` opérationnels — first-catalog, public-cog (COG distant), s3-source, url-source |
-
-## Communauté
-
-- [GitHub Discussions](https://github.com/geolens-io/geolens/discussions) : questions, idées, show and tell.
-- [Guide de contribution](.github/CONTRIBUTING.md) : environnement de développement, style de code et pull requests.
+Ce README est une version abrégée. Vous trouverez l'aperçu complet des fonctionnalités, la configuration, l'architecture et le guide de contribution dans le **[README anglais](README.md)** et dans la **[documentation complète](https://docs.getgeolens.com/fr)**.
 
 ## Licence
 
-GeoLens est sous [Apache License 2.0](LICENSE).
+Apache-2.0 — voir [LICENSE](LICENSE) et [NOTICE](NOTICE).

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ docker pull ghcr.io/geolens-io/geolens-api:latest
 docker pull ghcr.io/geolens-io/geolens-frontend:latest
 ```
 
-The image tags `1.0`, `1`, and `latest` track the current 1.x release line.
+The `latest` tag tracks the newest published stable release.
 
 ## Why GeoLens?
 

--- a/backend/app/modules/catalog/maps/router.py
+++ b/backend/app/modules/catalog/maps/router.py
@@ -943,7 +943,8 @@ async def patch_map_layers_endpoint(
     header, which would leak the in-container ``api:8000`` hostname
     through Vite's dev proxy on a 307 redirect. The canonical
     (OpenAPI-published) form is the no-slash sub-collection convention
-    from ``docs/api-style.md``; the trailing-slash form is a hidden alias.
+    documented in the GeoLens API guide (https://docs.getgeolens.com/guides/api/);
+    the trailing-slash form is a hidden alias.
     """
     map_obj = await get_map(db, map_id)
     if map_obj is None:
@@ -1637,7 +1638,8 @@ async def add_layer_endpoint(
     header that resolves against the request's Host header, leaking the
     in-container ``api:8000`` hostname through Vite's dev proxy. The
     canonical (OpenAPI-published) form is the no-slash sub-collection
-    convention from ``docs/api-style.md``; the trailing-slash form is a
+    convention documented in the GeoLens API guide
+    (https://docs.getgeolens.com/guides/api/); the trailing-slash form is a
     hidden alias for callers that send the slash.
     """
     map_obj = await get_map(db, map_id)

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -34893,7 +34893,7 @@
     },
     "/maps/{map_id}/layers": {
       "patch": {
-        "description": "Apply incremental layer additions, patches, removals, and ordering.\n\nv13.14 fixup: declared on both slash variants directly (mirrors the\nPhase 280 fix on POST). FastAPI's default redirect_slashes builds a\nrelative Location header that resolves against the request's Host\nheader, which would leak the in-container ``api:8000`` hostname\nthrough Vite's dev proxy on a 307 redirect. The canonical\n(OpenAPI-published) form is the no-slash sub-collection convention\nfrom ``docs/api-style.md``; the trailing-slash form is a hidden alias.",
+        "description": "Apply incremental layer additions, patches, removals, and ordering.\n\nv13.14 fixup: declared on both slash variants directly (mirrors the\nPhase 280 fix on POST). FastAPI's default redirect_slashes builds a\nrelative Location header that resolves against the request's Host\nheader, which would leak the in-container ``api:8000`` hostname\nthrough Vite's dev proxy on a 307 redirect. The canonical\n(OpenAPI-published) form is the no-slash sub-collection convention\ndocumented in the GeoLens API guide (https://docs.getgeolens.com/guides/api/);\nthe trailing-slash form is a hidden alias.",
         "operationId": "patch_map_layers_endpoint_maps__map_id__layers_patch",
         "parameters": [
           {
@@ -35017,7 +35017,7 @@
         ]
       },
       "post": {
-        "description": "Add a layer to a map.\n\nPhase 280: declared on both slash variants directly so neither emits a\n307. FastAPI's default redirect_slashes builds a relative Location\nheader that resolves against the request's Host header, leaking the\nin-container ``api:8000`` hostname through Vite's dev proxy. The\ncanonical (OpenAPI-published) form is the no-slash sub-collection\nconvention from ``docs/api-style.md``; the trailing-slash form is a\nhidden alias for callers that send the slash.",
+        "description": "Add a layer to a map.\n\nPhase 280: declared on both slash variants directly so neither emits a\n307. FastAPI's default redirect_slashes builds a relative Location\nheader that resolves against the request's Host header, leaking the\nin-container ``api:8000`` hostname through Vite's dev proxy. The\ncanonical (OpenAPI-published) form is the no-slash sub-collection\nconvention documented in the GeoLens API guide\n(https://docs.getgeolens.com/guides/api/); the trailing-slash form is a\nhidden alias for callers that send the slash.",
         "operationId": "add_layer_endpoint_maps__map_id__layers_post",
         "parameters": [
           {

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -72,6 +72,11 @@ dependencies = [
     "starlette>=1.2.1",
 ]
 
+[project.urls]
+Homepage = "https://github.com/geolens-io/geolens"
+Repository = "https://github.com/geolens-io/geolens"
+Documentation = "https://docs.getgeolens.com"
+
 [dependency-groups]
 dev = [
     "pytest>=9.0.3",

--- a/backend/tests/test_maps.py
+++ b/backend/tests/test_maps.py
@@ -2374,8 +2374,8 @@ class TestMapLayersTrailingSlash:
     Location header against the in-container ``api:8000`` Host.
 
     The canonical OpenAPI form is the no-slash sub-collection convention
-    from ``docs/api-style.md``; the trailing-slash form is a hidden alias
-    declared on the same handler. The trailing-slash regression guard
+    documented in the GeoLens API guide; the trailing-slash form is a hidden
+    alias declared on the same handler. The trailing-slash regression guard
     below is the load-bearing one — it would have caught the 260508-d6i
     smoke failure (#5, #6). The parity guard ensures both decorators
     stay wired to the same handler with the same response contract.

--- a/cli/geolens_cli/manifest/schemas/geolens-manifest-v1.schema.json
+++ b/cli/geolens_cli/manifest/schemas/geolens-manifest-v1.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://schemas.geolens.io/geolens-manifest/v1/schema.json",
+  "$id": "https://schemas.getgeolens.com/geolens-manifest/v1/schema.json",
   "title": "GeoLens Manifest v1",
   "description": "Versioned geolens.yaml catalog manifest contract.",
   "type": "object",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -113,7 +113,7 @@ services:
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
     ports:
       # Host-port fallback (5434 from .env, 5432 bare) — see
-      # docs/docker-compose-architecture.md#host-port-fallback
+      # docs-internal/docker-compose-architecture.md#host-port-fallback
       - "127.0.0.1:${DB_PORT:-5432}:5432"
     volumes:
       - pgdata:/var/lib/postgresql/data
@@ -135,7 +135,7 @@ services:
       dockerfile: Dockerfile
       target: api
     # Empty entrypoint suppresses Dockerfile-inherited api-entrypoint.sh on this
-    # one-shot service — see docs/docker-compose-architecture.md#migrate-empty-entrypoint
+    # one-shot service — see docs-internal/docker-compose-architecture.md#migrate-empty-entrypoint
     entrypoint: []
     command: sh -c "uv run --no-dev alembic upgrade head"
     # One-shot: alembic upgrade is idempotent (re-running is safe). Failure
@@ -186,7 +186,7 @@ services:
     entrypoint: ["/app/scripts/api-entrypoint.sh"]
     ports:
       # Host-port fallback (8001 from .env, 8000 bare) — see
-      # docs/docker-compose-architecture.md#host-port-fallback
+      # docs-internal/docker-compose-architecture.md#host-port-fallback
       - "127.0.0.1:${API_PORT:-8000}:8000"
     volumes:
       - ./.dockerignore:/app/.dockerignore:ro
@@ -314,7 +314,7 @@ services:
 
   titiler:
     # Pinned to 2.x stable (held back from 3.x without contract testing) — see
-    # docs/docker-compose-architecture.md#titiler-image-version
+    # docs-internal/docker-compose-architecture.md#titiler-image-version
     image: ghcr.io/developmentseed/titiler:2.0.2
     init: true
     restart: unless-stopped
@@ -438,7 +438,7 @@ services:
   # not for sharing on a LAN or exposing through Docker port forwarding.
   minio:
     # Pinned by SHA256 digest (tag is documentation); bump procedure at
-    # docs/docker-compose-architecture.md#minio-image-version-bump
+    # docs-internal/docker-compose-architecture.md#minio-image-version-bump
     image: quay.io/minio/minio:RELEASE.2025-09-07T16-13-09Z@sha256:14cea493d9a34af32f524e538b8346cf79f3321eff8e708c1e2960462bd8936e
     profiles: ["cloud-dev"]
     command: server /data --console-address ":9001"
@@ -447,7 +447,7 @@ services:
       - "127.0.0.1:9001:9001"
     environment:
       # Fail-closed creds (no var-default fallback) — see
-      # docs/docker-compose-architecture.md#minio-fail-closed-creds
+      # docs-internal/docker-compose-architecture.md#minio-fail-closed-creds
       MINIO_ROOT_USER: "${MINIO_ROOT_USER:?MINIO_ROOT_USER is required for --profile cloud-dev (set in .env)}"
       MINIO_ROOT_PASSWORD: "${MINIO_ROOT_PASSWORD:?MINIO_ROOT_PASSWORD is required for --profile cloud-dev}"
     volumes:
@@ -461,13 +461,13 @@ services:
 
   minio-setup:
     # Paired digest pin with the minio service above — see
-    # docs/docker-compose-architecture.md#minio-image-version-bump
+    # docs-internal/docker-compose-architecture.md#minio-image-version-bump
     image: quay.io/minio/mc:RELEASE.2025-08-13T08-35-41Z@sha256:a7fe349ef4bd8521fb8497f55c6042871b2ae640607cf99d9bede5e9bdf11727
     profiles: ["cloud-dev"]
     depends_on:
       minio:
         condition: service_healthy
-    # Fail-closed creds; see docs/docker-compose-architecture.md#minio-fail-closed-creds
+    # Fail-closed creds; see docs-internal/docker-compose-architecture.md#minio-fail-closed-creds
     # The `$$VAR` (double-dollar) in entrypoint below is load-bearing — it passes
     # the literal $VAR to the in-container shell, which then expands it.
     environment:
@@ -496,7 +496,7 @@ services:
 
   valkey:
     # 8.x line tip; cloud-dev profile only — see
-    # docs/docker-compose-architecture.md#valkey-image-version
+    # docs-internal/docker-compose-architecture.md#valkey-image-version
     image: valkey/valkey:8.1.7-alpine
     profiles: ["cloud-dev"]
     ports:

--- a/scripts/marketing-data/adk-high-peaks/README.md
+++ b/scripts/marketing-data/adk-high-peaks/README.md
@@ -23,7 +23,7 @@ Locked bbox (WGS84): `-74.05, 44.08, -73.85, 44.32` — roughly 12 mi east-west 
 ## Run order
 
 ```bash
-cd /Users/ishiland/Code/geolens
+cd /path/to/geolens
 
 # 1. Download DEM tiles (~2.3 GB, 9 tiles)
 .venv/bin/python scripts/marketing-data/adk-high-peaks/fetch_dem.py

--- a/sdks/python/geolens/api/maps/add_layer_endpoint_maps_map_id_layers_post.py
+++ b/sdks/python/geolens/api/maps/add_layer_endpoint_maps_map_id_layers_post.py
@@ -111,7 +111,8 @@ def sync_detailed(
     header that resolves against the request's Host header, leaking the
     in-container ``api:8000`` hostname through Vite's dev proxy. The
     canonical (OpenAPI-published) form is the no-slash sub-collection
-    convention from ``docs/api-style.md``; the trailing-slash form is a
+    convention documented in the GeoLens API guide
+    (https://docs.getgeolens.com/guides/api/); the trailing-slash form is a
     hidden alias for callers that send the slash.
 
     Args:
@@ -153,7 +154,8 @@ def sync(
     header that resolves against the request's Host header, leaking the
     in-container ``api:8000`` hostname through Vite's dev proxy. The
     canonical (OpenAPI-published) form is the no-slash sub-collection
-    convention from ``docs/api-style.md``; the trailing-slash form is a
+    convention documented in the GeoLens API guide
+    (https://docs.getgeolens.com/guides/api/); the trailing-slash form is a
     hidden alias for callers that send the slash.
 
     Args:
@@ -190,7 +192,8 @@ async def asyncio_detailed(
     header that resolves against the request's Host header, leaking the
     in-container ``api:8000`` hostname through Vite's dev proxy. The
     canonical (OpenAPI-published) form is the no-slash sub-collection
-    convention from ``docs/api-style.md``; the trailing-slash form is a
+    convention documented in the GeoLens API guide
+    (https://docs.getgeolens.com/guides/api/); the trailing-slash form is a
     hidden alias for callers that send the slash.
 
     Args:
@@ -230,7 +233,8 @@ async def asyncio(
     header that resolves against the request's Host header, leaking the
     in-container ``api:8000`` hostname through Vite's dev proxy. The
     canonical (OpenAPI-published) form is the no-slash sub-collection
-    convention from ``docs/api-style.md``; the trailing-slash form is a
+    convention documented in the GeoLens API guide
+    (https://docs.getgeolens.com/guides/api/); the trailing-slash form is a
     hidden alias for callers that send the slash.
 
     Args:

--- a/sdks/python/geolens/api/maps/patch_map_layers_endpoint_maps_map_id_layers_patch.py
+++ b/sdks/python/geolens/api/maps/patch_map_layers_endpoint_maps_map_id_layers_patch.py
@@ -112,7 +112,8 @@ def sync_detailed(
     header, which would leak the in-container ``api:8000`` hostname
     through Vite's dev proxy on a 307 redirect. The canonical
     (OpenAPI-published) form is the no-slash sub-collection convention
-    from ``docs/api-style.md``; the trailing-slash form is a hidden alias.
+    documented in the GeoLens API guide (https://docs.getgeolens.com/guides/api/);
+    the trailing-slash form is a hidden alias.
 
     Args:
         map_id (UUID):
@@ -154,7 +155,8 @@ def sync(
     header, which would leak the in-container ``api:8000`` hostname
     through Vite's dev proxy on a 307 redirect. The canonical
     (OpenAPI-published) form is the no-slash sub-collection convention
-    from ``docs/api-style.md``; the trailing-slash form is a hidden alias.
+    documented in the GeoLens API guide (https://docs.getgeolens.com/guides/api/);
+    the trailing-slash form is a hidden alias.
 
     Args:
         map_id (UUID):
@@ -191,7 +193,8 @@ async def asyncio_detailed(
     header, which would leak the in-container ``api:8000`` hostname
     through Vite's dev proxy on a 307 redirect. The canonical
     (OpenAPI-published) form is the no-slash sub-collection convention
-    from ``docs/api-style.md``; the trailing-slash form is a hidden alias.
+    documented in the GeoLens API guide (https://docs.getgeolens.com/guides/api/);
+    the trailing-slash form is a hidden alias.
 
     Args:
         map_id (UUID):
@@ -231,7 +234,8 @@ async def asyncio(
     header, which would leak the in-container ``api:8000`` hostname
     through Vite's dev proxy on a 307 redirect. The canonical
     (OpenAPI-published) form is the no-slash sub-collection convention
-    from ``docs/api-style.md``; the trailing-slash form is a hidden alias.
+    documented in the GeoLens API guide (https://docs.getgeolens.com/guides/api/);
+    the trailing-slash form is a hidden alias.
 
     Args:
         map_id (UUID):

--- a/sdks/typescript/src/client/sdk.gen.ts
+++ b/sdks/typescript/src/client/sdk.gen.ts
@@ -2298,7 +2298,8 @@ export const getMapHistoryEndpointMapsMapIdHistoryGet = <ThrowOnError extends bo
  * header, which would leak the in-container ``api:8000`` hostname
  * through Vite's dev proxy on a 307 redirect. The canonical
  * (OpenAPI-published) form is the no-slash sub-collection convention
- * from ``docs/api-style.md``; the trailing-slash form is a hidden alias.
+ * documented in the GeoLens API guide (https://docs.getgeolens.com/guides/api/);
+ * the trailing-slash form is a hidden alias.
  */
 export const patchMapLayersEndpointMapsMapIdLayersPatch = <ThrowOnError extends boolean = false>(options: Options<PatchMapLayersEndpointMapsMapIdLayersPatchData, ThrowOnError>) => (options.client ?? client).patch<PatchMapLayersEndpointMapsMapIdLayersPatchResponses, PatchMapLayersEndpointMapsMapIdLayersPatchErrors, ThrowOnError>({
     security: [{ scheme: 'bearer', type: 'http' }],
@@ -2320,7 +2321,8 @@ export const patchMapLayersEndpointMapsMapIdLayersPatch = <ThrowOnError extends 
  * header that resolves against the request's Host header, leaking the
  * in-container ``api:8000`` hostname through Vite's dev proxy. The
  * canonical (OpenAPI-published) form is the no-slash sub-collection
- * convention from ``docs/api-style.md``; the trailing-slash form is a
+ * convention documented in the GeoLens API guide
+ * (https://docs.getgeolens.com/guides/api/); the trailing-slash form is a
  * hidden alias for callers that send the slash.
  */
 export const addLayerEndpointMapsMapIdLayersPost = <ThrowOnError extends boolean = false>(options: Options<AddLayerEndpointMapsMapIdLayersPostData, ThrowOnError>) => (options.client ?? client).post<AddLayerEndpointMapsMapIdLayersPostResponses, AddLayerEndpointMapsMapIdLayersPostErrors, ThrowOnError>({


### PR DESCRIPTION
Prepares the repo for public open-core release. Derived from a full public-readiness audit; applies the in-repo punch-list items. No true blockers were found — these are the should-fix-before-public items.

## What's in here (7 commits)

- **chore: streamline .gitignore** — drop dead/duplicate patterns (`.next/`, `build/`, `venv/`, `target/`, `vendor/`, duplicate `.gsd`), add `.mypy_cache/`, and add `!frontend/src/assets/**/*.png` so new basemap icons aren't silently ignored. Kept `coverage/` (real `frontend/coverage/` output).
- **ci: harden GitHub Actions** — least-privilege top-level `permissions` on `ci.yml`; pin `trivy-action@master` → `@v0.36.0`; sync `dep-audit` scan images to the Dockerfile (python 3.14.5, nginx 1.31.1).
- **fix(cli): domain** — manifest schema `$id` `schemas.geolens.io` → `schemas.getgeolens.com` (the `.io` was a typo shipped in the published CLI package).
- **docs: compose anchors** — `/docs` maintainer notes reconciled into `docs-internal/` (both gitignored → disk-only); the 9 `docker-compose.yml` rationale anchors are the only tracked reference and now point at the new location.
- **docs(api): api-style.md leak** — map-layer endpoint descriptions cited `docs/api-style.md`, which leaked into the published OpenAPI snapshot + SDK docstrings. Repointed to `docs.getgeolens.com/guides/api/` and regenerated `openapi.json` + SDKs.
- **docs(readme): i18n stubs** — de/es/fr READMEs had drifted 3 commits behind English (German still showed a removed Enterprise section). Reduced to quickstart stubs that defer to `docs.getgeolens.com/{de,es,fr}`. Also dropped a stale "1.x release line" note from the English README.
- **chore: hygiene** — add Apache-2.0 `NOTICE`; add `[project.urls]` to `backend/pyproject.toml`; concrete supported-version range in `SECURITY.md`; scrub two `/Users/ishiland` absolute paths.

## Validation
- All 13 pre-commit hooks pass per commit (ruff, gitleaks, json/yaml/toml).
- `make openapi-check` green; SDK regen diff is exactly the api-style description (no drift).
- `test_phase_275_api_style` + `test_phase_275_runbooks` pass (6/6).
- No residual `geolens.io`; basemap PNGs still tracked; no surprise untracked files.

## Not included — maintainer-only follow-ups
- Legal sign-off that **Carto Concepts, LLC** is the correct copyright holder.
- GitHub repo settings before going public: secret scanning + push protection, branch protection, `good first issue`/`help wanted` labels, social preview, topics — and **withhold the local `v1027`–`v1036` internal tags** (push only `v2.0.0`).
- Confirm **PyPI Trusted Publishing** + npm token (dry-run) before the first publish.