### PR TITLE
feat(license): signed offline entitlement layer for enterprise edition

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -94,3 +94,8 @@ tmp/
 # Scripts + manifest YAML + curated GeoJSONs ARE committed; raw .tif/.zip/.geojson
 # downloads + mosaicked COGs are NOT.
 .scratch/
+
+# License signing keys — NEVER commit the private key
+license-keys/
+*license_private_key.pem
+*.license-key

--- a/backend/app/core/edition.py
+++ b/backend/app/core/edition.py
@@ -1,19 +1,28 @@
 """Edition detection singleton.
 
-Determines whether the running instance is community or enterprise based
-on loaded extensions and an optional GEOLENS_EDITION environment override.
+The authoritative enterprise signal is a **signed offline license**
+(:mod:`app.core.license`). For backward compatibility, the legacy
+``GEOLENS_EDITION`` override and loaded-extension auto-detection still apply
+*unless* strict enforcement (``GEOLENS_LICENSE_ENFORCE``) is enabled.
 """
 
 from __future__ import annotations
 
 import os
 from dataclasses import dataclass
+from datetime import datetime
 
 import structlog
+
+from app.core.license import LicenseInfo, load_license
 
 logger = structlog.stdlib.get_logger(__name__)
 
 _info: EditionInfo | None = None
+
+
+def _is_truthy(value: str | None) -> bool:
+    return (value or "").strip().lower() in ("1", "true", "yes", "on")
 
 
 @dataclass(frozen=True)
@@ -22,21 +31,83 @@ class EditionInfo:
 
     edition: str
     features: tuple[str, ...] = ()
+    # True only when a signed license verified. False for legacy
+    # env/extension-detected "enterprise" so ops can tell the two apart.
+    licensed: bool = False
+    customer: str | None = None
+    expires_at: datetime | None = None
 
 
 def init_edition(loaded_extensions: list[str]) -> None:
-    """Initialize edition based on env var or auto-detection."""
+    """Initialize the edition from a signed license, with backward-compatible
+    env/extension auto-detection.
+
+    Resolution order:
+
+    1. A **valid signed license** (``GEOLENS_LICENSE_KEY``) → enterprise. This
+       is the real entitlement and the only path that should grant enterprise
+       in production.
+    2. Else, if ``GEOLENS_LICENSE_ENFORCE`` is truthy (**strict mode**), the
+       instance is community regardless of ``GEOLENS_EDITION`` / loaded
+       extensions — the honor-system bypass is closed.
+    3. Else (**default, backward-compatible**): the legacy signal —
+       ``GEOLENS_EDITION`` override, else enterprise if any extension loaded.
+       A warning is logged when this grants enterprise without a license,
+       because strict mode will reject it.
+    """
     global _info
 
+    license_info: LicenseInfo | None = load_license()
+    enforce = _is_truthy(os.environ.get("GEOLENS_LICENSE_ENFORCE"))
+
+    if license_info is not None:
+        _info = EditionInfo(
+            edition="enterprise",
+            features=tuple(loaded_extensions),
+            licensed=True,
+            customer=license_info.customer,
+            expires_at=license_info.expires_at,
+        )
+        logger.info(
+            "Edition: enterprise (licensed)",
+            customer=license_info.customer,
+            extensions=loaded_extensions,
+        )
+        return
+
+    # No valid license from here on.
     env_val = os.environ.get("GEOLENS_EDITION", "").lower().strip()
 
+    if enforce:
+        if env_val == "enterprise" or loaded_extensions:
+            logger.warning(
+                "GEOLENS_LICENSE_ENFORCE is on and no valid license is present; "
+                "running as community despite GEOLENS_EDITION/extensions."
+            )
+        _info = EditionInfo(
+            edition="community", features=tuple(loaded_extensions), licensed=False
+        )
+        logger.debug(
+            "Edition initialized", edition="community", extensions=loaded_extensions
+        )
+        return
+
+    # Backward-compatible (default) path.
     if env_val in ("community", "enterprise"):
         edition = env_val
     else:
-        # Auto-detect: enterprise if any extensions are loaded
         edition = "enterprise" if loaded_extensions else "community"
 
-    _info = EditionInfo(edition=edition, features=tuple(loaded_extensions))
+    if edition == "enterprise":
+        logger.warning(
+            "Running enterprise edition WITHOUT a verified license "
+            "(legacy env/extension detection). Configure GEOLENS_LICENSE_KEY; "
+            "this becomes mandatory once GEOLENS_LICENSE_ENFORCE is enabled."
+        )
+
+    _info = EditionInfo(
+        edition=edition, features=tuple(loaded_extensions), licensed=False
+    )
     logger.debug("Edition initialized", edition=edition, extensions=loaded_extensions)
 
 

--- a/backend/app/core/edition.py
+++ b/backend/app/core/edition.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 import os
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import UTC, datetime
 
 import structlog
 
@@ -112,9 +112,21 @@ def init_edition(loaded_extensions: list[str]) -> None:
 
 
 def get_edition() -> EditionInfo:
-    """Return the current edition info, defaulting to community."""
+    """Return the current edition info, defaulting to community.
+
+    A *licensed* enterprise edition is re-checked against the license's
+    ``expires_at`` on every read, so a long-running / always-on process stops
+    unlocking enterprise once the license expires — without needing a restart.
+    The legacy env/extension path carries no ``expires_at`` and is unaffected.
+    """
     if _info is None:
         return EditionInfo(edition="community", features=())
+    if (
+        _info.licensed
+        and _info.expires_at is not None
+        and datetime.now(UTC) >= _info.expires_at
+    ):
+        return EditionInfo(edition="community", features=_info.features, licensed=False)
     return _info
 
 

--- a/backend/app/core/license.py
+++ b/backend/app/core/license.py
@@ -9,27 +9,35 @@ cryptographically **signed, offline** license token.
 Design:
 
 - The token is an EdDSA (Ed25519) JWT carrying ``edition`` + ``exp`` (+ optional
-  ``customer``, ``seats``, ``features``, ``license_id``).
-- It is verified against an Ed25519 **public** key bundled/configured in the
-  deployment. The matching **private** signing key never ships with the product
-  — it lives only with the vendor's license-minting tooling
-  (``scripts/license_tool.py``). Shipping the public key in the (soon Apache-2.0)
-  core is safe: that is the whole point of asymmetric signatures.
-- Verification is fully **offline** — no phone-home — so it works air-gapped.
+  ``customer``, ``seats``, ``features``, ``license_id``, ``aud``).
+- It is verified against the **bundled, immutable** Ed25519 public key at
+  ``app/core/license_public_key.pem``. The matching **private** signing key
+  never ships — it lives only with the vendor's minting tooling
+  (``scripts/license_tool.py``). Shipping the public key in the (soon
+  Apache-2.0) core is safe — that is the point of asymmetric signatures.
+- The verifier key is deliberately **NOT** environment-configurable. The party
+  that supplies the license token (the operator) must not also be able to
+  choose the key it is checked against — otherwise they could mint their own
+  enterprise token against their own key and the entitlement check is moot
+  (it would just re-create the env-only bypass it is meant to close).
+- Verification is fully **offline** — no phone-home — so it works air-gapped,
+  with a small ``leeway`` to tolerate clock skew between signer and verifier.
 - It is **graceful**: a missing / malformed / expired / forged token, or a
-  missing public key, yields ``None`` (→ community). It never raises into the
+  missing bundled key, yields ``None`` (→ community). It never raises into the
   app lifespan.
 
 Inputs (all optional; absence → no license → community):
 
-- ``GEOLENS_LICENSE_KEY``        — the signed license token (preferred), or
-- ``GEOLENS_LICENSE_FILE``       — path to a file containing the token.
-- ``GEOLENS_LICENSE_PUBLIC_KEY`` — the verifying Ed25519 public key (PEM), or
-- ``GEOLENS_LICENSE_PUBLIC_KEY_FILE`` — path to the public-key PEM, else the
-  bundled default at ``app/core/license_public_key.pem`` if present.
+- ``GEOLENS_LICENSE_KEY``      — the signed license token (preferred), or
+- ``GEOLENS_LICENSE_FILE``     — path to a file containing the token.
+- ``GEOLENS_LICENSE_AUDIENCE`` — optional deployment identifier. When set, the
+  token's ``aud`` claim MUST match it, binding a license to this deployment so a
+  token issued for one customer cannot be replayed on another.
 
 This module owns verification only; :mod:`app.core.edition` owns the policy of
-how a verified (or absent) license maps to the running edition.
+how a verified (or absent) license maps to the running edition, including the
+**runtime** re-check of ``expires_at`` (a token valid at startup must stop
+unlocking enterprise once it expires, without a restart).
 """
 
 from __future__ import annotations
@@ -49,7 +57,14 @@ logger = structlog.stdlib.get_logger(__name__)
 # HMAC secret (the classic "alg confusion" attack).
 _ALGORITHM = "EdDSA"
 
-_DEFAULT_PUBLIC_KEY_PATH = Path(__file__).with_name("license_public_key.pem")
+# The bundled, immutable verifier trust root. The vendor commits THEIR public
+# key here in the enterprise build. Intentionally a code/asset constant, never
+# an env var (see module docstring).
+_TRUSTED_PUBLIC_KEY_PATH = Path(__file__).with_name("license_public_key.pem")
+
+# Tolerate modest clock skew between the signer and the verifying host for the
+# time-based claims (exp / nbf / iat). Small relative to a multi-month license.
+_LEEWAY_SECONDS = 300
 
 
 @dataclass(frozen=True)
@@ -73,26 +88,21 @@ def _read_first(*candidates: str | None) -> str | None:
     return None
 
 
-def _load_public_key() -> str | None:
-    """Resolve the verifying Ed25519 public key (PEM), or None if unconfigured.
+def _load_trusted_public_key() -> str | None:
+    """Return the bundled verifier public key (PEM), or None if not present.
 
-    Order: explicit PEM env > explicit file env > bundled default file. A
-    deployment with no public key configured can never be enterprise — the safe
-    default — so this returns None silently in that case.
+    Read ONLY from the committed trust-root path — never from the environment.
+    A build with no bundled key can never grant enterprise via a license (the
+    safe default), so this returns None silently in that case.
     """
-    inline = _read_first(os.environ.get("GEOLENS_LICENSE_PUBLIC_KEY"))
-    if inline:
-        return inline
-
-    file_env = _read_first(os.environ.get("GEOLENS_LICENSE_PUBLIC_KEY_FILE"))
-    candidates = [Path(file_env)] if file_env else []
-    candidates.append(_DEFAULT_PUBLIC_KEY_PATH)
-    for path in candidates:
-        try:
-            if path.is_file():
-                return path.read_text()
-        except OSError:
-            logger.warning("Could not read license public key", path=str(path))
+    try:
+        if _TRUSTED_PUBLIC_KEY_PATH.is_file():
+            return _TRUSTED_PUBLIC_KEY_PATH.read_text()
+    except OSError:
+        logger.warning(
+            "Could not read bundled license public key",
+            path=str(_TRUSTED_PUBLIC_KEY_PATH),
+        )
     return None
 
 
@@ -114,24 +124,35 @@ def _load_token() -> str | None:
     return None
 
 
-def verify_license_token(token: str, public_key_pem: str) -> LicenseInfo | None:
+def verify_license_token(
+    token: str, public_key_pem: str, *, audience: str | None = None
+) -> LicenseInfo | None:
     """Verify a token against the public key. Return LicenseInfo or None.
 
     Returns None (never raises) for any verification failure: bad signature,
-    expired, missing required claims, wrong algorithm, or a non-enterprise
-    edition claim. ``exp`` is enforced by PyJWT; ``edition`` is required and
-    must be ``"enterprise"`` (the only paid edition today).
+    expired, immature, missing required claims, wrong algorithm, audience
+    mismatch, or a non-enterprise edition claim. ``exp`` and ``edition`` are
+    always required. When ``audience`` is given, ``aud`` is required and must
+    match (binds the license to this deployment); otherwise ``aud`` is not
+    checked. ``_LEEWAY_SECONDS`` of clock skew is tolerated.
     """
+    required = ["exp", "edition"]
+    options: dict = {"require": required}
+    decode_kwargs: dict = {"algorithms": [_ALGORITHM], "leeway": _LEEWAY_SECONDS}
+    if audience:
+        decode_kwargs["audience"] = audience
+        required.append("aud")
+    else:
+        # No audience configured for this deployment: don't reject tokens that
+        # happen to carry an `aud` claim (PyJWT verifies aud by default).
+        options["verify_aud"] = False
+
     try:
-        claims = jwt.decode(
-            token,
-            public_key_pem,
-            algorithms=[_ALGORITHM],
-            options={"require": ["exp", "edition"]},
-        )
+        claims = jwt.decode(token, public_key_pem, options=options, **decode_kwargs)
     except jwt.PyJWTError as exc:
-        # Includes ExpiredSignatureError, InvalidSignatureError,
-        # MissingRequiredClaimError, InvalidAlgorithmError, etc.
+        # Includes ExpiredSignatureError, ImmatureSignatureError,
+        # InvalidSignatureError, MissingRequiredClaimError, InvalidAudienceError,
+        # InvalidAlgorithmError, etc.
         logger.warning("License token rejected", reason=type(exc).__name__)
         return None
 
@@ -162,24 +183,26 @@ def verify_license_token(token: str, public_key_pem: str) -> LicenseInfo | None:
 def load_license() -> LicenseInfo | None:
     """Load + verify the license from the environment. None if absent/invalid.
 
-    Fully graceful: any problem (no token, no public key, bad signature,
-    expired) returns None so the caller falls back to community. Never raises.
+    Fully graceful: any problem (no token, no bundled key, bad signature,
+    expired, audience mismatch) returns None so the caller falls back to
+    community. Never raises.
     """
     token = _load_token()
     if not token:
         return None
 
-    public_key = _load_public_key()
+    public_key = _load_trusted_public_key()
     if not public_key:
-        # A token is present but the deployment has no verifying key configured.
-        # We cannot trust an unverifiable token -> community.
+        # A token is present but this build bundles no verifying key. We cannot
+        # trust an unverifiable token -> community.
         logger.warning(
-            "GEOLENS_LICENSE_KEY is set but no license public key is configured; "
-            "set GEOLENS_LICENSE_PUBLIC_KEY(_FILE). Treating as unlicensed."
+            "GEOLENS_LICENSE_KEY is set but this build bundles no license "
+            "public key; treating as unlicensed."
         )
         return None
 
-    info = verify_license_token(token, public_key)
+    audience = _read_first(os.environ.get("GEOLENS_LICENSE_AUDIENCE"))
+    info = verify_license_token(token, public_key, audience=audience)
     if info is not None:
         logger.info(
             "Enterprise license verified",

--- a/backend/app/core/license.py
+++ b/backend/app/core/license.py
@@ -1,0 +1,190 @@
+"""Signed offline license verification (entitlement layer).
+
+The community/enterprise edition is currently decided by ``GEOLENS_EDITION`` or
+the mere presence of a loaded extension (see :mod:`app.core.edition`), which is
+an honor-system boundary: anyone who installs the overlay or sets one env var
+unlocks every paid feature. This module adds the real entitlement check — a
+cryptographically **signed, offline** license token.
+
+Design:
+
+- The token is an EdDSA (Ed25519) JWT carrying ``edition`` + ``exp`` (+ optional
+  ``customer``, ``seats``, ``features``, ``license_id``).
+- It is verified against an Ed25519 **public** key bundled/configured in the
+  deployment. The matching **private** signing key never ships with the product
+  — it lives only with the vendor's license-minting tooling
+  (``scripts/license_tool.py``). Shipping the public key in the (soon Apache-2.0)
+  core is safe: that is the whole point of asymmetric signatures.
+- Verification is fully **offline** — no phone-home — so it works air-gapped.
+- It is **graceful**: a missing / malformed / expired / forged token, or a
+  missing public key, yields ``None`` (→ community). It never raises into the
+  app lifespan.
+
+Inputs (all optional; absence → no license → community):
+
+- ``GEOLENS_LICENSE_KEY``        — the signed license token (preferred), or
+- ``GEOLENS_LICENSE_FILE``       — path to a file containing the token.
+- ``GEOLENS_LICENSE_PUBLIC_KEY`` — the verifying Ed25519 public key (PEM), or
+- ``GEOLENS_LICENSE_PUBLIC_KEY_FILE`` — path to the public-key PEM, else the
+  bundled default at ``app/core/license_public_key.pem`` if present.
+
+This module owns verification only; :mod:`app.core.edition` owns the policy of
+how a verified (or absent) license maps to the running edition.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from pathlib import Path
+
+import jwt
+import structlog
+
+logger = structlog.stdlib.get_logger(__name__)
+
+# Ed25519 -> EdDSA in JOSE terms. Pinned to a single asymmetric algorithm so a
+# forged token cannot downgrade to HS* and have the public key treated as an
+# HMAC secret (the classic "alg confusion" attack).
+_ALGORITHM = "EdDSA"
+
+_DEFAULT_PUBLIC_KEY_PATH = Path(__file__).with_name("license_public_key.pem")
+
+
+@dataclass(frozen=True)
+class LicenseInfo:
+    """A verified, non-expired enterprise license."""
+
+    edition: str
+    expires_at: datetime | None = None
+    customer: str | None = None
+    seats: int | None = None
+    features: tuple[str, ...] = ()
+    license_id: str | None = None
+    claims: dict = field(default_factory=dict)
+
+
+def _read_first(*candidates: str | None) -> str | None:
+    """Return the first non-empty value, stripped; else None."""
+    for value in candidates:
+        if value and value.strip():
+            return value.strip()
+    return None
+
+
+def _load_public_key() -> str | None:
+    """Resolve the verifying Ed25519 public key (PEM), or None if unconfigured.
+
+    Order: explicit PEM env > explicit file env > bundled default file. A
+    deployment with no public key configured can never be enterprise — the safe
+    default — so this returns None silently in that case.
+    """
+    inline = _read_first(os.environ.get("GEOLENS_LICENSE_PUBLIC_KEY"))
+    if inline:
+        return inline
+
+    file_env = _read_first(os.environ.get("GEOLENS_LICENSE_PUBLIC_KEY_FILE"))
+    candidates = [Path(file_env)] if file_env else []
+    candidates.append(_DEFAULT_PUBLIC_KEY_PATH)
+    for path in candidates:
+        try:
+            if path.is_file():
+                return path.read_text()
+        except OSError:
+            logger.warning("Could not read license public key", path=str(path))
+    return None
+
+
+def _load_token() -> str | None:
+    """Resolve the license token from env or file, or None."""
+    inline = _read_first(os.environ.get("GEOLENS_LICENSE_KEY"))
+    if inline:
+        return inline
+
+    file_env = _read_first(os.environ.get("GEOLENS_LICENSE_FILE"))
+    if file_env:
+        try:
+            path = Path(file_env)
+            if path.is_file():
+                return path.read_text().strip()
+            logger.warning("GEOLENS_LICENSE_FILE does not exist", path=file_env)
+        except OSError:
+            logger.warning("Could not read GEOLENS_LICENSE_FILE", path=file_env)
+    return None
+
+
+def verify_license_token(token: str, public_key_pem: str) -> LicenseInfo | None:
+    """Verify a token against the public key. Return LicenseInfo or None.
+
+    Returns None (never raises) for any verification failure: bad signature,
+    expired, missing required claims, wrong algorithm, or a non-enterprise
+    edition claim. ``exp`` is enforced by PyJWT; ``edition`` is required and
+    must be ``"enterprise"`` (the only paid edition today).
+    """
+    try:
+        claims = jwt.decode(
+            token,
+            public_key_pem,
+            algorithms=[_ALGORITHM],
+            options={"require": ["exp", "edition"]},
+        )
+    except jwt.PyJWTError as exc:
+        # Includes ExpiredSignatureError, InvalidSignatureError,
+        # MissingRequiredClaimError, InvalidAlgorithmError, etc.
+        logger.warning("License token rejected", reason=type(exc).__name__)
+        return None
+
+    if claims.get("edition") != "enterprise":
+        logger.warning(
+            "License token edition is not enterprise", edition=claims.get("edition")
+        )
+        return None
+
+    exp = claims.get("exp")
+    expires_at = (
+        datetime.fromtimestamp(exp, tz=UTC) if isinstance(exp, (int, float)) else None
+    )
+    seats = claims.get("seats")
+    features = claims.get("features") or ()
+
+    return LicenseInfo(
+        edition="enterprise",
+        expires_at=expires_at,
+        customer=claims.get("customer") or claims.get("sub"),
+        seats=int(seats) if isinstance(seats, (int, float)) else None,
+        features=tuple(features) if isinstance(features, (list, tuple)) else (),
+        license_id=claims.get("license_id") or claims.get("jti"),
+        claims=claims,
+    )
+
+
+def load_license() -> LicenseInfo | None:
+    """Load + verify the license from the environment. None if absent/invalid.
+
+    Fully graceful: any problem (no token, no public key, bad signature,
+    expired) returns None so the caller falls back to community. Never raises.
+    """
+    token = _load_token()
+    if not token:
+        return None
+
+    public_key = _load_public_key()
+    if not public_key:
+        # A token is present but the deployment has no verifying key configured.
+        # We cannot trust an unverifiable token -> community.
+        logger.warning(
+            "GEOLENS_LICENSE_KEY is set but no license public key is configured; "
+            "set GEOLENS_LICENSE_PUBLIC_KEY(_FILE). Treating as unlicensed."
+        )
+        return None
+
+    info = verify_license_token(token, public_key)
+    if info is not None:
+        logger.info(
+            "Enterprise license verified",
+            customer=info.customer,
+            expires_at=info.expires_at.isoformat() if info.expires_at else None,
+            license_id=info.license_id,
+        )
+    return info

--- a/backend/scripts/license_tool.py
+++ b/backend/scripts/license_tool.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+"""GeoLens license tooling — vendor-side keygen and license minting.
+
+This script is for the **vendor** (whoever sells GeoLens Enterprise). It is not
+needed to run GeoLens.
+
+  # 1. One-time: generate the signing keypair.
+  python scripts/license_tool.py keygen --out-dir ./license-keys
+  #   -> license-keys/license_private_key.pem   (SECRET — never commit/ship)
+  #   -> license-keys/license_public_key.pem    (ship this with the product)
+
+  # Install the PUBLIC key where deployments verify against it, e.g.:
+  cp license-keys/license_public_key.pem backend/app/core/license_public_key.pem
+  #   (or distribute via GEOLENS_LICENSE_PUBLIC_KEY / _FILE)
+
+  # 2. Per customer: mint a signed license token.
+  python scripts/license_tool.py mint \
+      --private-key license-keys/license_private_key.pem \
+      --customer "Acme Water District" --days 365 --seats 250
+
+The minted token is what a customer sets as GEOLENS_LICENSE_KEY. Verification is
+offline (no phone-home) against the public key — see app/core/license.py.
+
+SECURITY: anyone holding the private key can mint licenses. Keep it in a secrets
+manager / HSM, not in the repo.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+import uuid
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import jwt
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+_ALGORITHM = "EdDSA"
+
+
+def _cmd_keygen(args: argparse.Namespace) -> int:
+    private_key = Ed25519PrivateKey.generate()
+
+    private_pem = private_key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+    public_pem = private_key.public_key().public_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+
+    if args.out_dir:
+        out = Path(args.out_dir)
+        out.mkdir(parents=True, exist_ok=True)
+        priv_path = out / "license_private_key.pem"
+        pub_path = out / "license_public_key.pem"
+        priv_path.write_bytes(private_pem)
+        priv_path.chmod(0o600)
+        pub_path.write_bytes(public_pem)
+        print(f"Wrote private key (SECRET): {priv_path}", file=sys.stderr)
+        print(f"Wrote public key (ship this): {pub_path}", file=sys.stderr)
+        print(
+            "Keep the private key out of version control and in a secrets "
+            "manager — anyone with it can mint licenses.",
+            file=sys.stderr,
+        )
+    else:
+        sys.stdout.write(private_pem.decode())
+        sys.stdout.write(public_pem.decode())
+    return 0
+
+
+def _cmd_mint(args: argparse.Namespace) -> int:
+    private_pem = Path(args.private_key).read_bytes()
+    key = serialization.load_pem_private_key(private_pem, password=None)
+    if not isinstance(key, Ed25519PrivateKey):
+        print("Private key is not an Ed25519 key.", file=sys.stderr)
+        return 1
+
+    now = datetime.now(UTC)
+    claims: dict = {
+        "edition": "enterprise",
+        "iat": now,
+        "exp": now + timedelta(days=args.days),
+        "license_id": uuid.uuid4().hex,
+    }
+    if args.customer:
+        claims["customer"] = args.customer
+    if args.seats is not None:
+        claims["seats"] = args.seats
+    if args.features:
+        claims["features"] = args.features
+
+    token = jwt.encode(claims, key, algorithm=_ALGORITHM)
+    print(token)
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="GeoLens license tooling (vendor-side)."
+    )
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    kg = sub.add_parser("keygen", help="Generate an Ed25519 signing keypair.")
+    kg.add_argument(
+        "--out-dir",
+        help="Directory to write license_{private,public}_key.pem. "
+        "If omitted, both PEMs are printed to stdout.",
+    )
+    kg.set_defaults(func=_cmd_keygen)
+
+    mt = sub.add_parser("mint", help="Mint a signed enterprise license token.")
+    mt.add_argument(
+        "--private-key", required=True, help="Path to the Ed25519 private-key PEM."
+    )
+    mt.add_argument(
+        "--customer", help="Customer name (stored as the `customer` claim)."
+    )
+    mt.add_argument(
+        "--days", type=int, default=365, help="Validity in days (default 365)."
+    )
+    mt.add_argument("--seats", type=int, default=None, help="Optional seat cap.")
+    mt.add_argument(
+        "--features",
+        nargs="*",
+        default=None,
+        help="Optional entitled feature/seam names.",
+    )
+    mt.set_defaults(func=_cmd_mint)
+
+    args = parser.parse_args(argv)
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/scripts/license_tool.py
+++ b/backend/scripts/license_tool.py
@@ -9,9 +9,10 @@ needed to run GeoLens.
   #   -> license-keys/license_private_key.pem   (SECRET — never commit/ship)
   #   -> license-keys/license_public_key.pem    (ship this with the product)
 
-  # Install the PUBLIC key where deployments verify against it, e.g.:
+  # Bundle the PUBLIC key as the verifier trust root in the enterprise build.
+  # It is read ONLY from this committed path (never an env var), so an operator
+  # cannot swap in their own key:
   cp license-keys/license_public_key.pem backend/app/core/license_public_key.pem
-  #   (or distribute via GEOLENS_LICENSE_PUBLIC_KEY / _FILE)
 
   # 2. Per customer: mint a signed license token.
   python scripts/license_tool.py mint \
@@ -94,6 +95,11 @@ def _cmd_mint(args: argparse.Namespace) -> int:
         claims["seats"] = args.seats
     if args.features:
         claims["features"] = args.features
+    if args.audience:
+        # Binds the license to a deployment: the customer sets
+        # GEOLENS_LICENSE_AUDIENCE to the same value so the token can't be
+        # replayed on another instance.
+        claims["aud"] = args.audience
 
     token = jwt.encode(claims, key, algorithm=_ALGORITHM)
     print(token)
@@ -130,6 +136,11 @@ def main(argv: list[str] | None = None) -> int:
         nargs="*",
         default=None,
         help="Optional entitled feature/seam names.",
+    )
+    mt.add_argument(
+        "--audience",
+        help="Optional deployment id bound into the `aud` claim. The customer "
+        "sets GEOLENS_LICENSE_AUDIENCE to the same value to enforce it.",
     )
     mt.set_defaults(func=_cmd_mint)
 

--- a/backend/tests/test_license.py
+++ b/backend/tests/test_license.py
@@ -1,0 +1,236 @@
+"""Tests for the signed-license entitlement layer (app.core.license + edition).
+
+Hermetic: each test generates an ephemeral Ed25519 keypair, mints tokens
+in-process, and verifies against the matching public key. No DB, no network.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import jwt
+import pytest
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+from app.core.license import load_license, verify_license_token
+
+
+@pytest.fixture(autouse=True)
+def _isolate_edition(monkeypatch):
+    """Clear license/edition env and restore the edition singleton per test."""
+    import app.core.edition as edition_mod
+
+    for var in (
+        "GEOLENS_EDITION",
+        "GEOLENS_LICENSE_ENFORCE",
+        "GEOLENS_LICENSE_KEY",
+        "GEOLENS_LICENSE_FILE",
+        "GEOLENS_LICENSE_PUBLIC_KEY",
+        "GEOLENS_LICENSE_PUBLIC_KEY_FILE",
+    ):
+        monkeypatch.delenv(var, raising=False)
+    saved = edition_mod._info
+    yield
+    edition_mod._info = saved
+
+
+@pytest.fixture(scope="module")
+def keypair() -> tuple[Ed25519PrivateKey, str]:
+    """An Ed25519 (private key object, public-key PEM string)."""
+    key = Ed25519PrivateKey.generate()
+    pub_pem = (
+        key.public_key()
+        .public_bytes(
+            serialization.Encoding.PEM,
+            serialization.PublicFormat.SubjectPublicKeyInfo,
+        )
+        .decode()
+    )
+    return key, pub_pem
+
+
+def _mint(
+    private_key, *, exp_delta=timedelta(days=30), edition="enterprise", **extra
+) -> str:
+    payload = {"edition": edition, "exp": datetime.now(UTC) + exp_delta}
+    payload.update(extra)
+    return jwt.encode(payload, private_key, algorithm="EdDSA")
+
+
+# --------------------------------------------------------------------------- #
+# verify_license_token
+# --------------------------------------------------------------------------- #
+
+
+def test_verify_valid_token(keypair):
+    key, pub = keypair
+    token = _mint(
+        key, customer="Acme", seats=250, license_id="lic-1", features=["scim"]
+    )
+    info = verify_license_token(token, pub)
+    assert info is not None
+    assert info.edition == "enterprise"
+    assert info.customer == "Acme"
+    assert info.seats == 250
+    assert info.license_id == "lic-1"
+    assert info.features == ("scim",)
+    assert info.expires_at is not None and info.expires_at > datetime.now(UTC)
+
+
+def test_verify_expired_token(keypair):
+    key, pub = keypair
+    token = _mint(key, exp_delta=timedelta(days=-1))
+    assert verify_license_token(token, pub) is None
+
+
+def test_verify_non_enterprise_edition(keypair):
+    key, pub = keypair
+    token = _mint(key, edition="community")
+    assert verify_license_token(token, pub) is None
+
+
+def test_verify_tampered_signature(keypair):
+    key, pub = keypair
+    token = _mint(key)
+    header, payload, signature = token.split(".")
+    # Flip the FIRST signature char (top 6 bits of byte 0 — always significant).
+    # The LAST base64url char can carry unused padding bits, so flipping it may
+    # decode to the same signature bytes and be a no-op.
+    flipped = ("A" if signature[0] != "A" else "B") + signature[1:]
+    tampered = f"{header}.{payload}.{flipped}"
+    assert verify_license_token(tampered, pub) is None
+
+
+def test_verify_forged_with_other_key(keypair):
+    _key, pub = keypair
+    attacker = Ed25519PrivateKey.generate()
+    token = _mint(attacker)  # signed by a key the deployment doesn't trust
+    assert verify_license_token(token, pub) is None
+
+
+def test_verify_missing_exp(keypair):
+    key, pub = keypair
+    token = jwt.encode({"edition": "enterprise"}, key, algorithm="EdDSA")  # no exp
+    assert verify_license_token(token, pub) is None
+
+
+def test_verify_rejects_non_eddsa_algorithm(keypair):
+    """Any non-EdDSA token must be rejected because the verifier pins
+    algorithms=['EdDSA']. This is what defeats the classic alg-confusion
+    downgrade (where an attacker re-signs with HS256 using the public key as an
+    HMAC secret so the verifier validates it). PyJWT additionally refuses to
+    *encode* with an asymmetric key as an HMAC secret, but the decisive control
+    is our decode-side pinning — verified here with a plain HS256 token."""
+    _key, pub = keypair
+    hs_token = jwt.encode(
+        {"edition": "enterprise", "exp": datetime.now(UTC) + timedelta(days=30)},
+        "any-shared-secret",
+        algorithm="HS256",
+    )
+    assert verify_license_token(hs_token, pub) is None
+
+
+# --------------------------------------------------------------------------- #
+# load_license (env / file resolution)
+# --------------------------------------------------------------------------- #
+
+
+def test_load_license_no_token(monkeypatch):
+    assert load_license() is None
+
+
+def test_load_license_token_but_no_public_key(monkeypatch, keypair):
+    key, _pub = keypair
+    monkeypatch.setenv("GEOLENS_LICENSE_KEY", _mint(key))
+    # No public key configured -> cannot verify -> None (community).
+    monkeypatch.setattr(
+        "app.core.license._DEFAULT_PUBLIC_KEY_PATH", _nonexistent_path()
+    )
+    assert load_license() is None
+
+
+def test_load_license_valid_via_env(monkeypatch, keypair):
+    key, pub = keypair
+    monkeypatch.setenv("GEOLENS_LICENSE_KEY", _mint(key, customer="EnvCo"))
+    monkeypatch.setenv("GEOLENS_LICENSE_PUBLIC_KEY", pub)
+    info = load_license()
+    assert info is not None and info.customer == "EnvCo"
+
+
+def test_load_license_from_files(monkeypatch, tmp_path, keypair):
+    key, pub = keypair
+    token_file = tmp_path / "license.key"
+    token_file.write_text(_mint(key, customer="FileCo"))
+    pub_file = tmp_path / "pub.pem"
+    pub_file.write_text(pub)
+    monkeypatch.setenv("GEOLENS_LICENSE_FILE", str(token_file))
+    monkeypatch.setenv("GEOLENS_LICENSE_PUBLIC_KEY_FILE", str(pub_file))
+    info = load_license()
+    assert info is not None and info.customer == "FileCo"
+
+
+# --------------------------------------------------------------------------- #
+# init_edition integration
+# --------------------------------------------------------------------------- #
+
+
+def _init(extensions):
+    import app.core.edition as edition_mod
+
+    edition_mod.init_edition(extensions)
+    return edition_mod
+
+
+def test_init_licensed_grants_enterprise(monkeypatch, keypair):
+    key, pub = keypair
+    monkeypatch.setenv("GEOLENS_LICENSE_KEY", _mint(key, customer="Licensed Inc"))
+    monkeypatch.setenv("GEOLENS_LICENSE_PUBLIC_KEY", pub)
+    ed = _init([])
+    assert ed.is_enterprise() is True
+    info = ed.get_edition()
+    assert info.licensed is True
+    assert info.customer == "Licensed Inc"
+
+
+def test_init_backcompat_extensions_enterprise_unlicensed(monkeypatch):
+    """No license, no enforce: loaded extension still flips enterprise (legacy),
+    but licensed=False marks it as honor-system."""
+    ed = _init(["enterprise"])
+    assert ed.is_enterprise() is True
+    assert ed.get_edition().licensed is False
+
+
+def test_init_enforce_blocks_extensions(monkeypatch):
+    monkeypatch.setenv("GEOLENS_LICENSE_ENFORCE", "true")
+    ed = _init(["enterprise"])
+    assert ed.is_enterprise() is False  # bypass closed
+
+
+def test_init_enforce_blocks_env_edition(monkeypatch):
+    monkeypatch.setenv("GEOLENS_LICENSE_ENFORCE", "1")
+    monkeypatch.setenv("GEOLENS_EDITION", "enterprise")
+    ed = _init([])
+    assert ed.is_enterprise() is False
+
+
+def test_init_enforce_allows_valid_license(monkeypatch, keypair):
+    key, pub = keypair
+    monkeypatch.setenv("GEOLENS_LICENSE_ENFORCE", "true")
+    monkeypatch.setenv("GEOLENS_LICENSE_KEY", _mint(key))
+    monkeypatch.setenv("GEOLENS_LICENSE_PUBLIC_KEY", pub)
+    ed = _init([])
+    assert ed.is_enterprise() is True
+    assert ed.get_edition().licensed is True
+
+
+def test_init_env_community_override(monkeypatch):
+    monkeypatch.setenv("GEOLENS_EDITION", "community")
+    ed = _init(["enterprise"])  # extension present but env forces community
+    assert ed.is_enterprise() is False
+
+
+def _nonexistent_path():
+    from pathlib import Path
+
+    return Path("/nonexistent/geolens-license-public-key-should-not-exist.pem")

--- a/backend/tests/test_license.py
+++ b/backend/tests/test_license.py
@@ -2,6 +2,8 @@
 
 Hermetic: each test generates an ephemeral Ed25519 keypair, mints tokens
 in-process, and verifies against the matching public key. No DB, no network.
+The verifier trust root is the BUNDLED key file; tests pin it via the
+``install_trusted_key`` fixture (a code-level override), never an env var.
 """
 
 from __future__ import annotations
@@ -26,6 +28,9 @@ def _isolate_edition(monkeypatch):
         "GEOLENS_LICENSE_ENFORCE",
         "GEOLENS_LICENSE_KEY",
         "GEOLENS_LICENSE_FILE",
+        "GEOLENS_LICENSE_AUDIENCE",
+        # No longer trusted (verifier key is bundled, not env) — clear anyway so
+        # a stray value in the ambient env can't influence a test.
         "GEOLENS_LICENSE_PUBLIC_KEY",
         "GEOLENS_LICENSE_PUBLIC_KEY_FILE",
     ):
@@ -35,19 +40,32 @@ def _isolate_edition(monkeypatch):
     edition_mod._info = saved
 
 
-@pytest.fixture(scope="module")
-def keypair() -> tuple[Ed25519PrivateKey, str]:
-    """An Ed25519 (private key object, public-key PEM string)."""
-    key = Ed25519PrivateKey.generate()
-    pub_pem = (
-        key.public_key()
+def _pub_pem(private_key: Ed25519PrivateKey) -> str:
+    return (
+        private_key.public_key()
         .public_bytes(
             serialization.Encoding.PEM,
             serialization.PublicFormat.SubjectPublicKeyInfo,
         )
         .decode()
     )
-    return key, pub_pem
+
+
+@pytest.fixture(scope="module")
+def keypair() -> tuple[Ed25519PrivateKey, str]:
+    """An Ed25519 (private key object, public-key PEM string)."""
+    key = Ed25519PrivateKey.generate()
+    return key, _pub_pem(key)
+
+
+@pytest.fixture
+def install_trusted_key(keypair, tmp_path, monkeypatch):
+    """Pin the test keypair's public key as the bundled verifier trust root."""
+    _key, pub = keypair
+    path = tmp_path / "license_public_key.pem"
+    path.write_text(pub)
+    monkeypatch.setattr("app.core.license._TRUSTED_PUBLIC_KEY_PATH", path)
+    return path
 
 
 def _mint(
@@ -132,7 +150,74 @@ def test_verify_rejects_non_eddsa_algorithm(keypair):
 
 
 # --------------------------------------------------------------------------- #
-# load_license (env / file resolution)
+# Audience binding (P2: prevent cross-deployment token replay)
+# --------------------------------------------------------------------------- #
+
+
+def test_verify_audience_match(keypair):
+    key, pub = keypair
+    token = _mint(key, aud="deploy-123")
+    assert verify_license_token(token, pub, audience="deploy-123") is not None
+
+
+def test_verify_audience_mismatch(keypair):
+    key, pub = keypair
+    token = _mint(key, aud="deploy-123")
+    assert verify_license_token(token, pub, audience="other-deploy") is None
+
+
+def test_verify_audience_required_when_configured(keypair):
+    key, pub = keypair
+    token = _mint(key)  # no aud claim
+    # Deployment expects an audience but the token carries none -> reject.
+    assert verify_license_token(token, pub, audience="deploy-123") is None
+
+
+def test_verify_no_audience_ignores_aud_claim(keypair):
+    key, pub = keypair
+    token = _mint(key, aud="deploy-123")  # token has aud; deployment sets none
+    # Back-compat: a token with aud still passes when audience isn't enforced.
+    assert verify_license_token(token, pub) is not None
+
+
+# --------------------------------------------------------------------------- #
+# Clock-skew leeway (P2)
+# --------------------------------------------------------------------------- #
+
+
+def test_verify_tolerates_clock_skew_within_leeway(keypair):
+    key, pub = keypair
+    now = datetime.now(UTC)
+    # nbf 2 min in the future: within the 300s leeway, must still verify.
+    token = jwt.encode(
+        {
+            "edition": "enterprise",
+            "nbf": now + timedelta(seconds=120),
+            "exp": now + timedelta(days=30),
+        },
+        key,
+        algorithm="EdDSA",
+    )
+    assert verify_license_token(token, pub) is not None
+
+
+def test_verify_rejects_beyond_leeway(keypair):
+    key, pub = keypair
+    now = datetime.now(UTC)
+    token = jwt.encode(
+        {
+            "edition": "enterprise",
+            "nbf": now + timedelta(seconds=900),  # 15 min > 300s leeway
+            "exp": now + timedelta(days=30),
+        },
+        key,
+        algorithm="EdDSA",
+    )
+    assert verify_license_token(token, pub) is None
+
+
+# --------------------------------------------------------------------------- #
+# load_license (token from env/file; key from the BUNDLED trust root only)
 # --------------------------------------------------------------------------- #
 
 
@@ -140,34 +225,59 @@ def test_load_license_no_token(monkeypatch):
     assert load_license() is None
 
 
-def test_load_license_token_but_no_public_key(monkeypatch, keypair):
+def test_load_license_token_but_no_bundled_key(monkeypatch, keypair):
     key, _pub = keypair
     monkeypatch.setenv("GEOLENS_LICENSE_KEY", _mint(key))
-    # No public key configured -> cannot verify -> None (community).
+    # Trust root absent -> cannot verify -> None (community).
     monkeypatch.setattr(
-        "app.core.license._DEFAULT_PUBLIC_KEY_PATH", _nonexistent_path()
+        "app.core.license._TRUSTED_PUBLIC_KEY_PATH", _nonexistent_path()
     )
     assert load_license() is None
 
 
-def test_load_license_valid_via_env(monkeypatch, keypair):
-    key, pub = keypair
+def test_load_license_valid(monkeypatch, keypair, install_trusted_key):
+    key, _pub = keypair
     monkeypatch.setenv("GEOLENS_LICENSE_KEY", _mint(key, customer="EnvCo"))
-    monkeypatch.setenv("GEOLENS_LICENSE_PUBLIC_KEY", pub)
     info = load_license()
     assert info is not None and info.customer == "EnvCo"
 
 
-def test_load_license_from_files(monkeypatch, tmp_path, keypair):
-    key, pub = keypair
+def test_load_license_token_from_file(
+    monkeypatch, tmp_path, keypair, install_trusted_key
+):
+    key, _pub = keypair
     token_file = tmp_path / "license.key"
     token_file.write_text(_mint(key, customer="FileCo"))
-    pub_file = tmp_path / "pub.pem"
-    pub_file.write_text(pub)
     monkeypatch.setenv("GEOLENS_LICENSE_FILE", str(token_file))
-    monkeypatch.setenv("GEOLENS_LICENSE_PUBLIC_KEY_FILE", str(pub_file))
     info = load_license()
     assert info is not None and info.customer == "FileCo"
+
+
+def test_load_license_with_audience(monkeypatch, keypair, install_trusted_key):
+    key, _pub = keypair
+    monkeypatch.setenv("GEOLENS_LICENSE_KEY", _mint(key, aud="prod-eu"))
+    monkeypatch.setenv("GEOLENS_LICENSE_AUDIENCE", "prod-eu")
+    assert load_license() is not None
+    # Wrong audience configured -> rejected.
+    monkeypatch.setenv("GEOLENS_LICENSE_AUDIENCE", "prod-us")
+    assert load_license() is None
+
+
+def test_public_key_is_not_env_configurable(monkeypatch, install_trusted_key):
+    """P1 regression: the verifier key is the bundled trust root only. An
+    operator who supplies their own keypair via GEOLENS_LICENSE_PUBLIC_KEY(_FILE)
+    plus a self-signed token must NOT reach enterprise — even with enforce on.
+    """
+    attacker = Ed25519PrivateKey.generate()  # NOT the installed trusted key
+    monkeypatch.setenv("GEOLENS_LICENSE_KEY", _mint(attacker, customer="Pirate"))
+    monkeypatch.setenv("GEOLENS_LICENSE_PUBLIC_KEY", _pub_pem(attacker))  # ignored
+    monkeypatch.setenv(
+        "GEOLENS_LICENSE_PUBLIC_KEY_FILE", "/tmp/whatever.pem"
+    )  # ignored
+    monkeypatch.setenv("GEOLENS_LICENSE_ENFORCE", "true")
+    assert load_license() is None
+    ed = _init([])
+    assert ed.is_enterprise() is False
 
 
 # --------------------------------------------------------------------------- #
@@ -182,10 +292,9 @@ def _init(extensions):
     return edition_mod
 
 
-def test_init_licensed_grants_enterprise(monkeypatch, keypair):
-    key, pub = keypair
+def test_init_licensed_grants_enterprise(monkeypatch, keypair, install_trusted_key):
+    key, _pub = keypair
     monkeypatch.setenv("GEOLENS_LICENSE_KEY", _mint(key, customer="Licensed Inc"))
-    monkeypatch.setenv("GEOLENS_LICENSE_PUBLIC_KEY", pub)
     ed = _init([])
     assert ed.is_enterprise() is True
     info = ed.get_edition()
@@ -214,11 +323,10 @@ def test_init_enforce_blocks_env_edition(monkeypatch):
     assert ed.is_enterprise() is False
 
 
-def test_init_enforce_allows_valid_license(monkeypatch, keypair):
-    key, pub = keypair
+def test_init_enforce_allows_valid_license(monkeypatch, keypair, install_trusted_key):
+    key, _pub = keypair
     monkeypatch.setenv("GEOLENS_LICENSE_ENFORCE", "true")
     monkeypatch.setenv("GEOLENS_LICENSE_KEY", _mint(key))
-    monkeypatch.setenv("GEOLENS_LICENSE_PUBLIC_KEY", pub)
     ed = _init([])
     assert ed.is_enterprise() is True
     assert ed.get_edition().licensed is True
@@ -228,6 +336,33 @@ def test_init_env_community_override(monkeypatch):
     monkeypatch.setenv("GEOLENS_EDITION", "community")
     ed = _init(["enterprise"])  # extension present but env forces community
     assert ed.is_enterprise() is False
+
+
+# --------------------------------------------------------------------------- #
+# Runtime expiry (P1: a token valid at startup must stop unlocking at exp)
+# --------------------------------------------------------------------------- #
+
+
+def test_runtime_expiry_downgrades_to_community():
+    import app.core.edition as edition_mod
+
+    past = datetime.now(UTC) - timedelta(seconds=1)
+    edition_mod._info = edition_mod.EditionInfo(
+        edition="enterprise", licensed=True, expires_at=past
+    )
+    # No restart / re-init: is_enterprise() must reflect expiry on read.
+    assert edition_mod.is_enterprise() is False
+    assert edition_mod.get_edition().edition == "community"
+
+
+def test_runtime_unexpired_license_stays_enterprise():
+    import app.core.edition as edition_mod
+
+    future = datetime.now(UTC) + timedelta(days=1)
+    edition_mod._info = edition_mod.EditionInfo(
+        edition="enterprise", licensed=True, expires_at=future
+    )
+    assert edition_mod.is_enterprise() is True
 
 
 def _nonexistent_path():


### PR DESCRIPTION
## What

Adds the **entitlement layer** — the #1 release blocker from the readiness audit. Today `is_enterprise()` flips on any loaded extension **or** `GEOLENS_EDITION=enterprise` with zero verification, so anyone who installs the overlay or sets one env var unlocks every paid feature, forever. There's nothing to *sell* as a tier. This makes enterprise contingent on a cryptographically **signed, offline** license.

### How it works
- **`app/core/license.py`** — verifies an **EdDSA (Ed25519) JWT** license token against a configured public key. Offline (no phone-home → air-gap friendly). Fully **graceful**: missing/invalid/expired/forged token, or no public key → `None` → community; it never raises into the lifespan. Algorithm pinned to `EdDSA` (defeats alg-confusion); `exp` + `edition` required.
- **`app/core/edition.py`** — a valid license → enterprise (`licensed=True`, with `customer`/`expires_at`). The honor-system bypass is closed **only** under strict mode (`GEOLENS_LICENSE_ENFORCE`). Default is **backward-compatible**: legacy env/extension detection still works, but logs a warning when it grants enterprise without a license.
- **`scripts/license_tool.py`** — vendor-side `keygen` + per-customer `mint` CLI. The **private** signing key never ships; only the public key is bundled/configured. (Safe to bundle the public key in the soon-Apache-2.0 core — that's the point of asymmetric signatures, and it resolves the "verifier-in-public-repo" chicken-and-egg the audit flagged.)

### Config (all optional; absence → community)
`GEOLENS_LICENSE_KEY` / `GEOLENS_LICENSE_FILE` (the token) · `GEOLENS_LICENSE_PUBLIC_KEY` / `_FILE` (verifying key) · `GEOLENS_LICENSE_ENFORCE` (strict mode).

## Verification
- **17 hermetic tests** (`tests/test_license.py`): valid / expired / forged / tampered / non-EdDSA / missing-exp verification, env+file loading, and `init_edition` policy (licensed → enterprise, legacy back-compat, enforce closes the bypass). Ran 5× for determinism.
- Backward-compat: **63 passing** across `test_extensions` / `test_branding_settings` / `test_embed_tokens` (no license + no enforce ⇒ identical to today).
- Full CLI roundtrip (`keygen` → `mint` → verify) confirmed: customer/seats/expiry decode correctly.

## ⚠️ Decisions for you (intentionally not baked in)
1. **Enforcement default.** This ships **non-breaking**: `GEOLENS_LICENSE_ENFORCE` defaults **off**, so existing deployments/dev/tests keep working. Flipping it on (and eventually making it the default) is the product call — that's the moment the bypass actually closes. Recommend: ship off, turn on for the enterprise distribution.
2. **Key distribution.** No key is committed. Run `scripts/license_tool.py keygen`, safeguard the private key (secrets manager/HSM — anyone with it can mint licenses), and bundle/point at the public key in your enterprise build. `.gitignore` now blocks `*license_private_key.pem`.
3. **Seats/features are carried but not enforced** yet (claims exist; no seat-counting). Future work.

Context: `geolens-enterprise:docs/ENTERPRISE-READINESS-AND-ROADMAP.md` (Now horizon, top blocker).

---

## Update — Codex review addressed (commit `a7a81c91`)

Codex flagged 4 real issues; all fixed + tested (license tests now **27**, run 3× for determinism; 19 extension tests still green):

- **🔴 P1 — verifier key was env-configurable.** An operator could supply their own key via `GEOLENS_LICENSE_PUBLIC_KEY` + a self-signed token and reach enterprise even under enforce. **Removed the env override**; the verifier key is now read **only** from the bundled trust root `app/core/license_public_key.pem`. Regression test asserts an env key is ignored.
- **🔴 P1 — expiry only checked at startup.** `get_edition()` now **re-checks `expires_at` at runtime**, so an always-on process downgrades to community at `exp` without a restart.
- **🟡 P2 — bearer-token replay.** Added optional **`aud` binding** (`mint --audience` + `GEOLENS_LICENSE_AUDIENCE`).
- **🟡 P2 — zero clock-skew tolerance.** Added a **300s `leeway`** on `exp`/`nbf`/`iat`.

**Corrected config** (supersedes the list above): `GEOLENS_LICENSE_KEY` / `GEOLENS_LICENSE_FILE` (token) · `GEOLENS_LICENSE_AUDIENCE` (optional) · `GEOLENS_LICENSE_ENFORCE` (strict mode). The verifier **public key is bundled, not env-configurable** — `keygen`, then commit the public key to `app/core/license_public_key.pem` in the enterprise build.