### PR TITLE
docs: fix first-catalog quickstart to use geolens publish

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,17 +222,17 @@ For production deployment, see the [Install Guide](https://docs.getgeolens.com/g
 
 ### Add Your First Dataset
 
-The fastest way from a freshly-started stack to data in the catalog is the **manifest CLI**. A manifest is a YAML file describing one or more datasets and their sources; `geolens apply` validates it locally and uploads the work to the API in one step.
+The repo ships a small `city-parks.geojson`. Upload and publish it in one command with the **GeoLens CLI**:
 
 ```bash
 pip install geolens-cli                              # installs the `geolens` command
 geolens login http://localhost:8080                  # admin / admin
-geolens apply examples/manifests/first-catalog/geolens.yaml
+geolens publish examples/manifests/first-catalog/city-parks.geojson --name "City Parks"
 ```
 
-The example at [`examples/manifests/first-catalog/`](examples/manifests/first-catalog/) ships a small `city-parks.geojson` and a ready-to-apply `geolens.yaml` so the round trip from clone to first dataset is one command.
+`geolens publish` runs the upload → preview → commit ingest flow and prints the new dataset's URL — clone to first dataset in one command.
 
-To start your own catalog, scaffold a fresh manifest with `geolens init` and edit it for your sources:
+For repeatable, multi-dataset catalogs, describe your sources in a **manifest** (`geolens.yaml`) and apply it with `geolens apply`. Manifest sources are referenced by HTTP(S) URL, S3 URI, or a path already staged on the server; the examples in [`examples/manifests/`](examples/manifests/) are templates to adapt. Scaffold a fresh one with `geolens init` and edit it for your sources:
 
 ```bash
 geolens init                       # writes geolens.yaml in the current directory
@@ -335,7 +335,7 @@ is deferred until a real-world adopter request makes it concrete.
 | [Cloud Deployment](https://docs.getgeolens.com/guides/quickstart/cloud-deployment/) | AWS, GCP, and DigitalOcean deployment guides |
 | [Developer Docs](https://docs.getgeolens.com/) | Build custom map builder plugins |
 | [API Reference](https://docs.getgeolens.com/guides/api/) | Auto-generated reference at docs.getgeolens.com; interactive Swagger UI at `/api/docs` when running |
-| [Manifest examples](examples/manifests/) | Working `geolens.yaml` examples — first-catalog, public-cog (remote COG), s3-source, url-source |
+| [Manifest examples](examples/manifests/) | Template `geolens.yaml` manifests to adapt — public-cog (remote COG), url-source, s3-source, publication-states |
 
 ## Community
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -20,6 +20,6 @@ geolens publish ./data/cities.geojson
 geolens export stac <dataset-id> -o cities.stac.json
 ```
 
-For the Docker Compose first-catalog walkthrough using `examples/manifests/first-catalog/geolens.yaml`, see [docs.getgeolens.com](https://docs.getgeolens.com/).
+For a one-command quickstart, run `geolens publish examples/manifests/first-catalog/city-parks.geojson` against a running stack. See the full walkthrough at [docs.getgeolens.com](https://docs.getgeolens.com/).
 
 The CLI consumes the [`geolens`](https://pypi.org/project/geolens/) Python SDK package. Manifest apply posts to the generated `POST /ingest/manifest/apply` contract through the SDK-owned client transport; there is no hand-rolled HTTP client.

--- a/examples/manifests/first-catalog/README.md
+++ b/examples/manifests/first-catalog/README.md
@@ -1,0 +1,24 @@
+# First Catalog — sample data
+
+Sample dataset used by the README quickstart.
+
+## One-command local ingest (recommended)
+
+`city-parks.geojson` is a small GeoJSON FeatureCollection. Publish it directly:
+
+```bash
+geolens publish city-parks.geojson --name "City Parks"
+```
+
+`geolens publish` uploads the file and runs the ingest (upload → preview → commit) in a single step.
+
+## Manifest structure (`geolens.yaml`)
+
+`geolens.yaml` shows the shape of a catalog manifest for use with `geolens apply`.
+
+> **Note:** `geolens apply` submits a manifest to the API but does **not** upload local
+> files — its `staging/city-parks.geojson` source resolves against the server's staging
+> area, so applying this manifest against a fresh stack queues an ingest job that fails
+> (nothing was staged). For local files use `geolens publish` (above). For `geolens apply`,
+> point sources at a reachable HTTP(S)/S3 URI — see the sibling [`url-source.yaml`](../url-source.yaml)
+> and [`s3-source.yaml`](../s3-source.yaml) — or pre-stage the file on the server.


### PR DESCRIPTION
The README's "Add Your First Dataset" quickstart was **broken**: it told users to `geolens apply examples/manifests/first-catalog/geolens.yaml`, but `geolens apply` only POSTs the manifest — it never uploads local files. The bundled `city-parks.geojson` is referenced via a `staging/` source the server can't resolve, so the ingest job fails (verified live: `/app/staging/staging/city-parks.geojson: No such file or directory`).

**Fix:** switch the quickstart to `geolens publish examples/manifests/first-catalog/city-parks.geojson` — the genuine one-command local round-trip (verified live: creates a dataset, which I then cleaned up).

Also:
- Reframe the manifest examples as **templates** (they reference remote/S3/pre-staged sources; `url-source.yaml` is itself a placeholder to adapt). Updated the manifest-examples table + `cli/README.md`.
- Add `examples/manifests/first-catalog/README.md` documenting `publish` (local, one-command) vs `apply` (remote/staged) and the `staging/` caveat, so the manifest isn't a silent trap.

**No manifest or test changes** — the manifests are valid templates and `test_manifest_examples` still passes 3/3. This is a docs-only fix.