### PR TITLE
docs: point `geolens login` at the /api base URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ The repo ships a small `city-parks.geojson`. Upload and publish it in one comman
 
 ```bash
 pip install geolens-cli                              # installs the `geolens` command
-geolens login http://localhost:8080                  # admin / admin
+geolens login http://localhost:8080/api              # admin / admin
 geolens publish examples/manifests/first-catalog/city-parks.geojson --name "City Parks"
 ```
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -10,7 +10,7 @@ See [docs.getgeolens.com](https://docs.getgeolens.com/) for the full command ref
 
 ```bash
 pip install geolens-cli
-geolens login https://geolens.example.com
+geolens login https://geolens.example.com/api
 geolens scan ./data
 geolens init
 geolens validate geolens.yaml


### PR DESCRIPTION
Addresses Codex's review on #175 (confirmed valid — and reproduced live).

The quickstart told users `geolens login http://localhost:8080`, which stores the **bare frontend origin**. The Docker Compose frontend only proxies `/api/*` to the backend, so `geolens publish` then posts SDK routes like `/ingest/upload` to **Vite**, which returns HTML → `JSONDecodeError`. `config.normalize_instance_url()` only `rstrip("/")`s — it does **not** append `/api`.

**Fix:** use `http://localhost:8080/api` (the documented API surface — the README's own curl examples already use `/api`). Also fixed the generic `cli/README.md` example.

**Verified live against the running stack:**
- `geolens login http://localhost:8080` → `geolens publish` → ❌ `JSONDecodeError`
- `geolens login http://localhost:8080/api` → `geolens publish` → ✅ creates a dataset (cleaned up after)

This bug pre-dated #175 (it only swapped `apply`→`publish` and inherited the wrong login URL).

Follow-up worth considering (not in this PR): `geolens login` could detect/normalize a bare origin (probe `/api`) so users don't hit a cryptic `JSONDecodeError`.