### PR TITLE
chore(deps): bump react-router to 7.16.0 (CVE-2026-42342)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -36,7 +36,7 @@
         "react-dom": "^19.2.7",
         "react-dropzone": "^15.0.0",
         "react-i18next": "^17.0.8",
-        "react-router": "^7.14.2",
+        "react-router": "^7.16.0",
         "sonner": "^2.0.7",
         "tailwind-merge": "^3.6.0",
         "tailwindcss": "^4.1.18",
@@ -7792,9 +7792,9 @@
       }
     },
     "node_modules/react-router": {
-      "version": "7.14.2",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.14.2.tgz",
-      "integrity": "sha512-yCqNne6I8IB6rVCH7XUvlBK7/QKyqypBFGv+8dj4QBFJiiRX+FG7/nkdAvGElyvVZ/HQP5N19wzteuTARXi5Gw==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.16.0.tgz",
+      "integrity": "sha512-wArC8lVyJb3+jM9OpDyW6hLCizACWkvQR/sSGqSs+o5uEXEtGlqdZ4v8hENR3Jad6i+LRkK93q/+bQAcvl6V1A==",
       "license": "MIT",
       "dependencies": {
         "cookie": "^1.0.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -50,7 +50,7 @@
     "react-dom": "^19.2.7",
     "react-dropzone": "^15.0.0",
     "react-i18next": "^17.0.8",
-    "react-router": "^7.14.2",
+    "react-router": "^7.16.0",
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.6.0",
     "tailwindcss": "^4.1.18",


### PR DESCRIPTION
Clears Dependabot alert #41 — `react-router` DoS via unbounded path expansion in the Framework Mode `__manifest` endpoint (GHSA-8x6r-g9mw-2r78 / CVE-2026-42342, **high**).

### Impact: not exploitable here
The app runs in **Data Mode** (`createBrowserRouter` / `RouterProvider`, `frontend/src/main.tsx:25,44`) — no Framework Mode, no `@react-router/*` packages, no SSR server, no `__manifest` endpoint. The advisory explicitly exempts Data Mode. Bumping to the patched line zeroes out the alert before public release.

### Change
`react-router` `7.14.2` → `7.16.0` (4-line lock diff, no transitive churn).

### Verification
- `tsc -b --noEmit` **clean** against 7.16.0.
- `npm audit`: **0 vulnerabilities**.