### PR TITLE
ci(publish): add workflow_dispatch scan-only dry run for the multi-arch gate

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,6 +4,16 @@ on:
   push:
     tags:
       - "v*.*.*"
+  # Manual trigger to exercise the build + multi-arch Trivy gate on demand.
+  # Default is a SCAN-ONLY dry run (no push) — the amd64 + arm64 images are
+  # built and Trivy-scanned, but the push/SBOM/attest steps are skipped. Set
+  # push_images=true only to perform a real manual publish.
+  workflow_dispatch:
+    inputs:
+      push_images:
+        description: "Also push images to GHCR (real publish). Leave false for a scan-only dry run."
+        type: boolean
+        default: false
 
 env:
   REGISTRY: ghcr.io
@@ -106,9 +116,12 @@ jobs:
           severity: CRITICAL,HIGH
           ignore-unfixed: true
 
-      # Push multi-arch images (only runs if BOTH scans pass)
+      # Push multi-arch images — only on a tag push, or a manual run with
+      # push_images=true. Skipped on the scan-only dry run (both scans above
+      # still execute, so the gate is exercised without publishing).
       - name: Build and push
         id: push
+        if: ${{ github.event_name == 'push' || github.event.inputs.push_images == 'true' }}
         uses: docker/build-push-action@v7
         with:
           context: .
@@ -123,8 +136,9 @@ jobs:
           cache-from: type=gha,scope=${{ matrix.image }}
           cache-to: type=gha,mode=max,scope=${{ matrix.image }}
 
-      # Generate SBOM from pushed image
+      # Generate SBOM from pushed image (only when we actually pushed)
       - name: Generate SBOM
+        if: ${{ github.event_name == 'push' || github.event.inputs.push_images == 'true' }}
         uses: anchore/sbom-action@v0
         with:
           image: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ matrix.image }}:${{ steps.meta.outputs.version }}
@@ -132,9 +146,9 @@ jobs:
           upload-artifact: false
           upload-release-assets: false
 
-      # Attest SBOM to the published image
+      # Attest SBOM to the published image (only when we pushed AND repo is public)
       - name: Attest SBOM
-        if: ${{ !github.event.repository.private }}
+        if: ${{ (github.event_name == 'push' || github.event.inputs.push_images == 'true') && !github.event.repository.private }}
         uses: actions/attest-sbom@v4
         with:
           subject-name: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ matrix.image }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,12 +6,15 @@ on:
       - "v*.*.*"
   # Manual trigger to exercise the build + multi-arch Trivy gate on demand.
   # Default is a SCAN-ONLY dry run (no push) — the amd64 + arm64 images are
-  # built and Trivy-scanned, but the push/SBOM/attest steps are skipped. Set
-  # push_images=true only to perform a real manual publish.
+  # built and Trivy-scanned, but the push/SBOM/attest steps are skipped.
+  # push_images=true performs a real manual publish and MUST be run from a tag
+  # ref (the metadata step emits only type=semver tags, which require a semver
+  # Git tag): `gh workflow run publish.yml --ref vX.Y.Z -f push_images=true`.
+  # A guard step below fails fast if push_images=true is dispatched off a branch.
   workflow_dispatch:
     inputs:
       push_images:
-        description: "Also push images to GHCR (real publish). Leave false for a scan-only dry run."
+        description: "Real publish to GHCR — REQUIRES a tag ref (--ref vX.Y.Z). Leave false for a scan-only dry run."
         type: boolean
         default: false
 
@@ -43,6 +46,16 @@ jobs:
             description: "PostGIS-native GIS data catalog frontend"
 
     steps:
+      # Fail fast (with guidance) if a real manual publish is dispatched off a
+      # branch — type=semver emits no tags there, so the push would otherwise
+      # fail later with a cryptic empty-tags buildx error. Tag pushes and the
+      # scan-only dry run (push_images=false) are unaffected.
+      - name: Require a tag ref for manual publishes
+        if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.push_images == 'true' && github.ref_type != 'tag' }}
+        run: |
+          echo "::error::push_images=true requires a tag ref so metadata-action can emit semver tags. Re-run as: gh workflow run publish.yml --ref vX.Y.Z -f push_images=true"
+          exit 1
+
       - name: Checkout
         uses: actions/checkout@v6
 


### PR DESCRIPTION
Follow-up to #183. The multi-arch Trivy gate added there (per-arch amd64+arm64 build + scan before the multi-arch push) can't be exercised until a real `v*.*.*` release, because `publish.yml` only triggers on tags. This adds a manual trigger so it can be dry-run on demand.

## Change
- **`workflow_dispatch` trigger** with a `push_images` boolean input (**default `false`**).
- **Default dry run** (`push_images=false`): builds and Trivy-scans **both** arches (those steps are unconditional), but **skips** `Build and push` / `Generate SBOM` / `Attest SBOM`. So it exercises the gate with **zero publish side-effects**.
- **`push_images=true`**: escape hatch for a manual real publish (push/SBOM/attest run, attest still only when the repo is public).
- **Tag-push behavior is unchanged** — `github.event_name == 'push'` keeps the full publish path intact.

## How to use after merge
```
# scan-only dry run (validates the arm64 gate, no push):
gh workflow run publish.yml
# or explicitly:
gh workflow run publish.yml -f push_images=false
```

## Caveat
`push_images=true` is intended to be run against a **tag ref** (`gh workflow run publish.yml --ref vX.Y.Z -f push_images=true`). On a non-tag ref the `metadata-action` `type=semver` patterns emit no tags, so a manual push would have no semver tag — it fails closed (no bad publish), but isn't a substitute for the tag-driven release path. The default dry run is unaffected (it doesn't push).

## Validation
`publish.yml` YAML parses; triggers = `push` + `workflow_dispatch`; gating verified on the three publish steps; arm64 build+scan left unconditional.