### PR TITLE
fix(vrt): flag DEM-tile mosaics as is_dem so terrain/hillshade work

### DIFF
--- a/backend/app/modules/catalog/datasets/domain/helpers.py
+++ b/backend/app/modules/catalog/datasets/domain/helpers.py
@@ -95,6 +95,7 @@ def _build_raster_metadata(
         res_x=raster_asset.res_x,
         res_y=raster_asset.res_y,
         band_count=raster_asset.band_count,
+        is_dem=raster_asset.is_dem,
         nodata=raster_asset.nodata,
         compression=raster_asset.compression,
         width=raster_asset.width,

--- a/backend/app/modules/catalog/datasets/domain/schemas.py
+++ b/backend/app/modules/catalog/datasets/domain/schemas.py
@@ -118,6 +118,10 @@ class RasterMetadata(BaseModel):
         default=None, description="Pixel resolution in Y (CRS units)"
     )
     band_count: int | None = None
+    is_dem: bool | None = Field(
+        default=None,
+        description="True if this raster is a DEM (single-band float) usable for 3D terrain/hillshade",
+    )
     nodata: str | None = Field(default=None, description="Global nodata sentinel value")
     compression: str | None = Field(
         default=None, description="Internal compression, e.g. DEFLATE, LZW"

--- a/backend/app/processing/ingest/tasks_vrt.py
+++ b/backend/app/processing/ingest/tasks_vrt.py
@@ -101,6 +101,10 @@ async def create_vrt_dataset(
         epsg=meta.get("epsg"),
         band_count=meta.get("band_count"),
         dtype=meta.get("dtype"),
+        # A VRT mosaic of single-band float DEM tiles is itself a DEM. Mirror the
+        # raster ingest path (tasks_raster) so terrain + hillshade light up; without
+        # this the mosaic lands is_dem=false and is unusable as terrain (#185).
+        is_dem=meta.get("is_dem_candidate", False),
         nodata=nodata_str,
         res_x=meta.get("res_x"),
         res_y=meta.get("res_y"),
@@ -602,6 +606,9 @@ async def regenerate_vrt(
                 vrt_asset.epsg = meta.get("epsg")
                 vrt_asset.band_count = meta.get("band_count")
                 vrt_asset.dtype = meta.get("dtype")
+                # Recompute the DEM flag on regenerate so adding/removing a source
+                # flips it correctly when the band/dtype profile changes (#185).
+                vrt_asset.is_dem = meta.get("is_dem_candidate", False)
                 vrt_asset.nodata = str(nodata_val) if nodata_val is not None else None
                 vrt_asset.res_x = meta.get("res_x")
                 vrt_asset.res_y = meta.get("res_y")

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -11400,6 +11400,18 @@
             "description": "Raster height in pixels",
             "title": "Height"
           },
+          "is_dem": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "True if this raster is a DEM (single-band float) usable for 3D terrain/hillshade",
+            "title": "Is Dem"
+          },
           "nodata": {
             "anyOf": [
               {

--- a/backend/tests/test_vrt_ingest_tasks.py
+++ b/backend/tests/test_vrt_ingest_tasks.py
@@ -49,3 +49,65 @@ class TestCreateVrtDataset:
         assert record.record_status == "published"
         assert dataset.record_id == record.id
         assert raster_asset.dataset_id == dataset.id
+
+    async def test_vrt_mosaic_of_dem_tiles_is_flagged_is_dem(self, test_db_session):
+        """A VRT mosaic of single-band float DEM tiles must itself be flagged
+        as a DEM, so map terrain + hillshade can use it (#185). Without this the
+        mosaic lands is_dem=false and is unusable as a terrain source."""
+        admin_id = await _get_admin_id(test_db_session)
+
+        _, _, raster_asset = await create_vrt_dataset(
+            test_db_session,
+            meta={
+                "epsg": 2056,
+                "band_count": 1,
+                "dtype": "float32",
+                "width": 256,
+                "height": 256,
+                "is_dem_candidate": True,
+            },
+            asset_sha256="b" * 64,
+            vrt_size=512,
+            source_filename="dem-mosaic.vrt",
+            created_by=admin_id,
+            title=f"DEM VRT {uuid.uuid4().hex[:6]}",
+            summary="is_dem propagation",
+            visibility="public",
+            vrt_type="mosaic",
+            resolution_strategy="finest",
+            source_dataset_ids=[],
+        )
+
+        await test_db_session.commit()
+        await test_db_session.refresh(raster_asset)
+        assert raster_asset.is_dem is True
+
+    async def test_vrt_not_flagged_is_dem_when_multiband(self, test_db_session):
+        """A multi-band (band-stack) VRT is not a DEM."""
+        admin_id = await _get_admin_id(test_db_session)
+
+        _, _, raster_asset = await create_vrt_dataset(
+            test_db_session,
+            meta={
+                "epsg": 4326,
+                "band_count": 3,
+                "dtype": "uint8",
+                "width": 256,
+                "height": 256,
+                "is_dem_candidate": False,
+            },
+            asset_sha256="c" * 64,
+            vrt_size=512,
+            source_filename="rgb-stack.vrt",
+            created_by=admin_id,
+            title=f"RGB VRT {uuid.uuid4().hex[:6]}",
+            summary="is_dem negative case",
+            visibility="public",
+            vrt_type="band_stack",
+            resolution_strategy="finest",
+            source_dataset_ids=[],
+        )
+
+        await test_db_session.commit()
+        await test_db_session.refresh(raster_asset)
+        assert raster_asset.is_dem is False

--- a/sdks/python/geolens/models/raster_metadata.py
+++ b/sdks/python/geolens/models/raster_metadata.py
@@ -28,6 +28,7 @@ class RasterMetadata:
         connect (None | RasterConnect | Unset):
         epsg (int | None | Unset): EPSG code of the raster CRS
         height (int | None | Unset): Raster height in pixels
+        is_dem (bool | None | Unset): True if this raster is a DEM (single-band float) usable for 3D terrain/hillshade
         nodata (None | str | Unset): Global nodata sentinel value
         res_x (float | None | Unset): Pixel resolution in X (CRS units)
         res_y (float | None | Unset): Pixel resolution in Y (CRS units)
@@ -46,6 +47,7 @@ class RasterMetadata:
     connect: None | RasterConnect | Unset = UNSET
     epsg: int | None | Unset = UNSET
     height: int | None | Unset = UNSET
+    is_dem: bool | None | Unset = UNSET
     nodata: None | str | Unset = UNSET
     res_x: float | None | Unset = UNSET
     res_y: float | None | Unset = UNSET
@@ -99,6 +101,12 @@ class RasterMetadata:
             height = UNSET
         else:
             height = self.height
+
+        is_dem: bool | None | Unset
+        if isinstance(self.is_dem, Unset):
+            is_dem = UNSET
+        else:
+            is_dem = self.is_dem
 
         nodata: None | str | Unset
         if isinstance(self.nodata, Unset):
@@ -175,6 +183,8 @@ class RasterMetadata:
             field_dict["epsg"] = epsg
         if height is not UNSET:
             field_dict["height"] = height
+        if is_dem is not UNSET:
+            field_dict["is_dem"] = is_dem
         if nodata is not UNSET:
             field_dict["nodata"] = nodata
         if res_x is not UNSET:
@@ -266,6 +276,15 @@ class RasterMetadata:
             return cast(int | None | Unset, data)
 
         height = _parse_height(d.pop("height", UNSET))
+
+        def _parse_is_dem(data: object) -> bool | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(bool | None | Unset, data)
+
+        is_dem = _parse_is_dem(d.pop("is_dem", UNSET))
 
         def _parse_nodata(data: object) -> None | str | Unset:
             if data is None:
@@ -366,6 +385,7 @@ class RasterMetadata:
             connect=connect,
             epsg=epsg,
             height=height,
+            is_dem=is_dem,
             nodata=nodata,
             res_x=res_x,
             res_y=res_y,

--- a/sdks/typescript/src/client/types.gen.ts
+++ b/sdks/typescript/src/client/types.gen.ts
@@ -6568,6 +6568,12 @@ export type RasterMetadata = {
      */
     height?: number | null;
     /**
+     * Is Dem
+     *
+     * True if this raster is a DEM (single-band float) usable for 3D terrain/hillshade
+     */
+    is_dem?: boolean | null;
+    /**
      * Nodata
      *
      * Global nodata sentinel value


### PR DESCRIPTION
Closes #185.

## Problem

A VRT mosaic of single-band float DEM tiles landed with `is_dem = false`: `tasks_vrt.py` built the VRT's `RasterAsset` without running the DEM detection that the raster ingest path uses (`tasks_raster.py:156` ← `cog.py:85` `is_dem_candidate`). Terrain (`TerrainControls.tsx:30`) and the hillshade render mode (`renderAs.ts:333`) both gate on `is_dem === true`, and there is no UI control to set it — so mosaicking DEM tiles (the documented way to build a seamless high-res terrain surface) produced a layer that could not be used as terrain at all.

## Fix

- **Create + regenerate paths** (`tasks_vrt.py`): set `is_dem` from `meta["is_dem_candidate"]` (computed by `extract_raster_metadata` on the assembled VRT), mirroring the raster ingest path. A single-band float mosaic → DEM; a multi-band band-stack → not a DEM. Regenerate recomputes it so add/remove-source flips it correctly.
- **Response** (`RasterMetadata` schema + `helpers.py` serializer): surface `is_dem` on `GET /api/datasets/{id}` so clients can read DEM status (previously it was never exposed, even when set).
- Regenerated `backend/openapi.json` + Python/TS SDKs (field-only diff).

## Testing

- New unit tests in `test_vrt_ingest_tasks.py`: a single-band float mosaic is flagged `is_dem=true`; a multi-band stack stays `is_dem=false`.
- `test_vrt_ingest_tasks.py`, `test_regenerate_vrt_integration.py`, `test_raster_ingest.py` → 24 passed.
- Manually reproduced before the fix (single swissALTI3D tile `is_dem=true`, mosaic `is_dem=false`); after the fix the mosaic is auto-flagged, so terrain + hillshade work without the manual `PATCH /datasets/{id} {"is_dem":true}` workaround.

Does not address the small-AOI terrain "pedestal" UX (#186), which is tracked separately.

@codex review
