### PR TITLE
[codex] fix DEM render-mode persistence

### DIFF
--- a/backend/alembic/versions/0003_normalize_dem_hillshade_style.py
+++ b/backend/alembic/versions/0003_normalize_dem_hillshade_style.py
@@ -1,0 +1,45 @@
+"""Normalize persisted DEM hillshade render modes.
+
+Revision ID: 0003_normalize_dem_hillshade_style
+Revises: 0002_procrastinate
+Create Date: 2026-06-05
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+revision: str = "0003_normalize_dem_hillshade_style"
+down_revision: Union[str, None] = "0002_procrastinate"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        UPDATE catalog.map_layers AS ml
+        SET style_config =
+            (
+                CASE
+                    WHEN jsonb_typeof(ml.style_config) = 'object' THEN ml.style_config
+                    ELSE '{}'::jsonb
+                END
+            )
+            || jsonb_build_object('render_mode', 'hillshade')
+        FROM catalog.raster_assets AS ra
+        WHERE ra.dataset_id = ml.dataset_id
+          AND ra.is_dem IS TRUE
+          AND (
+              ml.style_config IS NULL
+              OR jsonb_typeof(ml.style_config) <> 'object'
+              OR ml.style_config->>'render_mode' IS NULL
+              OR ml.style_config->>'render_mode' = 'image'
+          )
+        """
+    )
+
+
+def downgrade() -> None:
+    # Data-only normalization; intentionally not reversible.
+    pass

--- a/backend/app/modules/catalog/maps/_router_helpers.py
+++ b/backend/app/modules/catalog/maps/_router_helpers.py
@@ -85,7 +85,7 @@ def _meta_to_kwargs(meta) -> DatasetMetaKwargs:
         sample_values=meta.sample_values,
         record_type=meta.record_type,
         is_3d=meta.is_3d,
-        is_dem=None,
+        is_dem=meta.is_dem,
         dem_vertical_units=None,
         band_count=None,
     )

--- a/backend/app/modules/catalog/maps/service_diff.py
+++ b/backend/app/modules/catalog/maps/service_diff.py
@@ -27,7 +27,9 @@ from app.modules.catalog.maps.service_shared import (
     _infer_layer_type,
     _resolve_save_response_metadata,
     generate_default_style,
+    normalize_dem_style_config,
 )
+from app.platform.extensions import get_catalog_port
 
 _NULLABLE_PATCH_FIELDS = {
     "display_name",
@@ -40,10 +42,10 @@ _NULLABLE_PATCH_FIELDS = {
 
 def _prepare_layer_storage(
     layer_data: dict,
-    ds_meta: dict[uuid.UUID, tuple[str | None, str | None]],
+    ds_meta: dict[uuid.UUID, tuple[str | None, str | None, bool | None]],
 ) -> dict:
     dataset_id = layer_data["dataset_id"]
-    record_type, geometry_type = ds_meta.get(dataset_id, (None, None))
+    record_type, geometry_type, is_dem = ds_meta.get(dataset_id, (None, None, None))
 
     explicit_lt = layer_data.get("layer_type")
     if explicit_lt is not None:
@@ -70,6 +72,7 @@ def _prepare_layer_storage(
             style_config = defaults.get("style_config")
 
     paint, style_config = split_legacy_builder_paint(paint, style_config)
+    style_config = normalize_dem_style_config(style_config, is_dem=is_dem)
 
     return {
         **layer_data,
@@ -137,6 +140,24 @@ async def apply_layer_diff(
             )
         )
 
+    style_patch_dataset_ids = {
+        existing_by_id[layer_data["id"]].dataset_id
+        for layer_data in updated
+        if "style_config" in layer_data
+    }
+    dem_by_dataset_id: dict[uuid.UUID, bool | None] = {}
+    if style_patch_dataset_ids:
+        RasterAsset = get_catalog_port().raster_asset_orm_class()
+        dem_result = await session.execute(
+            select(RasterAsset.dataset_id, RasterAsset.is_dem).where(
+                RasterAsset.dataset_id.in_(style_patch_dataset_ids)
+            )
+        )
+        dem_by_dataset_id = {
+            row[0]: bool(row[1]) if row[1] is not None else None
+            for row in dem_result.all()
+        }
+
     for layer_data in updated:
         layer = existing_by_id[layer_data["id"]]
         patch = {
@@ -150,16 +171,31 @@ async def apply_layer_diff(
             popup_config = patch["popup_config"]
             if hasattr(popup_config, "model_dump"):
                 patch["popup_config"] = popup_config.model_dump()
+        if "style_config" in patch:
+            patch["style_config"] = normalize_dem_style_config(
+                patch["style_config"],
+                is_dem=dem_by_dataset_id.get(layer.dataset_id),
+            )
         for key, value in patch.items():
             setattr(layer, key, value)
 
     if added:
+        RasterAsset = get_catalog_port().raster_asset_orm_class()
         ds_meta_result = await session.execute(
-            select(Dataset.id, Record.record_type, Dataset.geometry_type)
+            select(
+                Dataset.id,
+                Record.record_type,
+                Dataset.geometry_type,
+                RasterAsset.is_dem,
+            )
             .join(Record, Record.id == Dataset.record_id)
+            .outerjoin(RasterAsset, RasterAsset.dataset_id == Dataset.id)
             .where(Dataset.id.in_(added_dataset_ids))
         )
-        ds_meta = {row[0]: (row[1], row[2]) for row in ds_meta_result.all()}
+        ds_meta = {
+            row[0]: (row[1], row[2], bool(row[3]) if row[3] is not None else None)
+            for row in ds_meta_result.all()
+        }
 
         for layer_data in added:
             prepared = _prepare_layer_storage(layer_data, ds_meta)
@@ -222,12 +258,22 @@ async def _replace_layers(
 
     # Bulk-fetch record_type + geometry_type for all datasets in one query
     dataset_ids = [ld["dataset_id"] for ld in layers]
+    RasterAsset = get_catalog_port().raster_asset_orm_class()
     ds_meta_result = await session.execute(
-        select(Dataset.id, Record.record_type, Dataset.geometry_type)
+        select(
+            Dataset.id,
+            Record.record_type,
+            Dataset.geometry_type,
+            RasterAsset.is_dem,
+        )
         .join(Record, Record.id == Dataset.record_id)
+        .outerjoin(RasterAsset, RasterAsset.dataset_id == Dataset.id)
         .where(Dataset.id.in_(dataset_ids))
     )
-    ds_meta = {row[0]: (row[1], row[2]) for row in ds_meta_result.all()}
+    ds_meta = {
+        row[0]: (row[1], row[2], bool(row[3]) if row[3] is not None else None)
+        for row in ds_meta_result.all()
+    }
 
     for layer_data in layers:
         prepared = _prepare_layer_storage(layer_data, ds_meta)

--- a/backend/app/modules/catalog/maps/service_layers.py
+++ b/backend/app/modules/catalog/maps/service_layers.py
@@ -14,6 +14,7 @@ from app.modules.catalog.maps.service_shared import (
     _infer_layer_type,
     generate_default_style,
     get_dataset_meta,
+    normalize_dem_style_config,
 )
 
 
@@ -98,6 +99,10 @@ async def add_layer(
             style_config = defaults.get("style_config")
 
     paint, style_config = split_legacy_builder_paint(paint, style_config)
+    style_config = normalize_dem_style_config(
+        style_config,
+        is_dem=meta.is_dem if meta else None,
+    )
     sort_order = body.sort_order
     if "sort_order" not in body.model_fields_set:
         result = await session.execute(

--- a/backend/app/modules/catalog/maps/service_shared.py
+++ b/backend/app/modules/catalog/maps/service_shared.py
@@ -29,6 +29,7 @@ class DatasetMeta(NamedTuple):
     feature_count: int | None
     sample_values: dict | None
     is_3d: bool | None
+    is_dem: bool | None
 
 
 class LayerRow(NamedTuple):
@@ -72,6 +73,7 @@ async def get_dataset_meta(
     dataset_id: uuid.UUID,
 ) -> DatasetMeta | None:
     """Fetch dataset metadata for building a layer response. Single query."""
+    RasterAsset = get_catalog_port().raster_asset_orm_class()
     result = await session.execute(
         select(
             Record.record_type,
@@ -83,12 +85,38 @@ async def get_dataset_meta(
             Dataset.feature_count,
             Dataset.sample_values,
             Dataset.is_3d,
+            RasterAsset.is_dem,
         )
         .join(Record, Dataset.record_id == Record.id)
+        .outerjoin(RasterAsset, RasterAsset.dataset_id == Dataset.id)
         .where(Dataset.id == dataset_id)
     )
     row = result.one_or_none()
-    return DatasetMeta(*row) if row else None
+    if row is None:
+        return None
+    values = list(row)
+    values[9] = bool(values[9]) if values[9] is not None else None
+    return DatasetMeta(*values)
+
+
+def normalize_dem_style_config(
+    style_config: dict | None,
+    *,
+    is_dem: bool | None,
+) -> dict | None:
+    """Persist canonical DEM render modes so backend exports match the builder UI."""
+    if is_dem is not True:
+        return style_config
+    if not isinstance(style_config, dict):
+        return {"render_mode": "hillshade"}
+
+    render_mode = style_config.get("render_mode")
+    if render_mode in {"terrain", "hillshade"}:
+        return style_config
+
+    normalized = dict(style_config)
+    normalized["render_mode"] = "hillshade"
+    return normalized
 
 
 def generate_default_style(geometry_type: str | None) -> dict[str, dict | None]:

--- a/backend/tests/test_maps.py
+++ b/backend/tests/test_maps.py
@@ -22,6 +22,7 @@ from app.modules.auth.models import User
 from app.modules.catalog.datasets.domain.models import Dataset, Record
 from app.modules.catalog.maps.models import MapLayer
 from app.modules.catalog.maps.schemas import MapLayerDiffRequest
+from app.processing.raster.models import RasterAsset
 
 from tests.factories import create_dataset, get_user_id
 
@@ -143,6 +144,31 @@ def test_maps_service_facade_exports_public_api() -> None:
 
 def _future_expires_at() -> datetime:
     return datetime.now(timezone.utc) + timedelta(days=7)
+
+
+async def _create_dem_dataset(test_db_session, *, created_by: uuid.UUID) -> Dataset:
+    ds = await create_dataset(
+        test_db_session,
+        created_by=created_by,
+        name="DEM Layer",
+        geometry_type=None,
+        source_format="geotiff",
+        source_filename="dem.tif",
+    )
+    record = await test_db_session.get(Record, ds.record_id)
+    assert record is not None
+    record.record_type = "raster_dataset"
+    test_db_session.add(
+        RasterAsset(
+            dataset_id=ds.id,
+            asset_uri=f"rasters/{ds.id}/source.cog.tif",
+            storage_backend="local",
+            is_dem=True,
+            band_count=1,
+        )
+    )
+    await test_db_session.commit()
+    return ds
 
 
 def test_layer_diff_schema_rejects_duplicate_layer_ids() -> None:
@@ -1794,6 +1820,74 @@ class TestMapLayers:
         assert data["visible"] is True
         assert data["opacity"] == 1.0
         assert "id" in data
+
+    async def test_add_dem_layer_persists_hillshade_render_mode(
+        self,
+        client: AsyncClient,
+        admin_auth_header: dict,
+        test_db_session,
+    ):
+        """POST /maps/{id}/layers stores DEMs as hillshade, not raw raster image."""
+        admin_id = await get_user_id(test_db_session, "admin")
+        ds = await _create_dem_dataset(test_db_session, created_by=admin_id)
+
+        created = await _create_map(client, admin_auth_header)
+        map_id = created["id"]
+
+        resp = await client.post(
+            f"/maps/{map_id}/layers",
+            json={"dataset_id": str(ds.id)},
+            headers=admin_auth_header,
+        )
+
+        assert resp.status_code == 201, resp.text
+        data = resp.json()
+        assert data["is_dem"] is True
+        assert data["style_config"] == {"render_mode": "hillshade"}
+
+        stored = await test_db_session.get(MapLayer, uuid.UUID(data["id"]))
+        assert stored is not None
+        assert stored.style_config == {"render_mode": "hillshade"}
+
+        style_resp = await client.get(
+            f"/maps/{map_id}/style.json",
+            headers=admin_auth_header,
+        )
+        assert style_resp.status_code == 200, style_resp.text
+        source = style_resp.json()["sources"][f"geolens-{ds.id}"]
+        assert source["type"] == "raster-dem"
+
+    async def test_patch_add_dem_layer_persists_hillshade_render_mode(
+        self,
+        client: AsyncClient,
+        admin_auth_header: dict,
+        test_db_session,
+    ):
+        """PATCH /maps/{id}/layers stores added DEMs as hillshade."""
+        admin_id = await get_user_id(test_db_session, "admin")
+        ds = await _create_dem_dataset(test_db_session, created_by=admin_id)
+        created = await _create_map(client, admin_auth_header)
+        map_id = created["id"]
+
+        resp = await client.patch(
+            f"/maps/{map_id}/layers",
+            json={
+                "added": [{"dataset_id": str(ds.id), "sort_order": 0}],
+                "updated": [],
+                "removed": [],
+                "order": None,
+            },
+            headers=admin_auth_header,
+        )
+
+        assert resp.status_code == 200, resp.text
+        layer = resp.json()["layers"][0]
+        assert layer["is_dem"] is True
+        assert layer["style_config"] == {"render_mode": "hillshade"}
+
+        stored = await test_db_session.get(MapLayer, uuid.UUID(layer["id"]))
+        assert stored is not None
+        assert stored.style_config == {"render_mode": "hillshade"}
 
     async def test_add_layer_assigns_next_sort_order_when_omitted(
         self,

--- a/frontend/src/api/maps.ts
+++ b/frontend/src/api/maps.ts
@@ -55,7 +55,9 @@ export async function getMap(id: string): Promise<MapResponse> {
   const resp = await apiFetch<MapResponse>(`/maps/${id}`);
   if (resp.layers) {
     for (const l of resp.layers) {
-      const normalized = normalizeLayerStyleState(l.style_config, l.paint, l.dataset_geometry_type);
+      const normalized = normalizeLayerStyleState(l.style_config, l.paint, l.dataset_geometry_type, {
+        isDem: l.is_dem,
+      });
       l.style_config = normalized.style_config;
       l.paint = normalized.paint;
     }
@@ -115,7 +117,9 @@ export async function patchMapLayers(
   });
   if (resp.layers) {
     for (const l of resp.layers) {
-      const normalized = normalizeLayerStyleState(l.style_config, l.paint, l.dataset_geometry_type);
+      const normalized = normalizeLayerStyleState(l.style_config, l.paint, l.dataset_geometry_type, {
+        isDem: l.is_dem,
+      });
       l.style_config = normalized.style_config;
       l.paint = normalized.paint;
     }
@@ -139,10 +143,16 @@ export async function addLayerToMapApi(
   mapId: string,
   data: MapLayerInput,
 ): Promise<MapLayerResponse> {
-  return apiFetch<MapLayerResponse>(`/maps/${mapId}/layers`, {
+  const layer = await apiFetch<MapLayerResponse>(`/maps/${mapId}/layers`, {
     method: 'POST',
     body: JSON.stringify(data),
   });
+  const normalized = normalizeLayerStyleState(layer.style_config, layer.paint, layer.dataset_geometry_type, {
+    isDem: layer.is_dem,
+  });
+  layer.style_config = normalized.style_config;
+  layer.paint = normalized.paint;
+  return layer;
 }
 
 export async function removeLayerFromMapApi(
@@ -197,7 +207,9 @@ export async function getSharedMap(token: string, apiKey?: string): Promise<Shar
   }
   if (resp.layers) {
     for (const l of resp.layers) {
-      const normalized = normalizeLayerStyleState(l.style_config, l.paint, l.geometry_type);
+      const normalized = normalizeLayerStyleState(l.style_config, l.paint, l.geometry_type, {
+        isDem: l.is_dem,
+      });
       l.style_config = normalized.style_config;
       l.paint = normalized.paint;
     }

--- a/frontend/src/components/builder/DEMEditorScene.tsx
+++ b/frontend/src/components/builder/DEMEditorScene.tsx
@@ -17,15 +17,17 @@ import {
   TERRAIN_EXAGGERATION_MIN,
   normalizeTerrainExaggeration,
 } from './map-sync';
+import { effectiveDemRenderMode } from '@/lib/dem-render-mode';
 import type { MapLayerResponse, StyleConfig } from '@/types/api';
 
 /** DEM render mode union. Assignable to StyleConfig['render_mode'] without cast. */
-export type DemRenderMode = 'image' | 'hillshade' | 'terrain';
+export type DemRenderMode = 'hillshade' | 'terrain';
 
 export interface DEMEditorSceneProps {
   layer: MapLayerResponse;
-  // Render mode is derived from layer.style_config.render_mode by the component
-  // (image when null/undefined or any non-DEM value)
+  // Render mode is derived from layer.style_config.render_mode by the component.
+  // Missing/legacy image DEM modes are treated as hillshade because raw DEM
+  // image tiles are encoded elevation data, not inspectable imagery.
   onPaintChange: (paint: Record<string, unknown>) => void;
   onStyleConfigChange: (config: StyleConfig | null, paint: Record<string, unknown>) => void;
   onOpacityChange: (opacity: number) => void;
@@ -51,10 +53,9 @@ export interface DEMEditorSceneProps {
 }
 
 function currentMode(layer: MapLayerResponse): DemRenderMode {
-  const m = (layer.style_config as Record<string, unknown> | null | undefined)?.render_mode;
-  if (m === 'hillshade') return 'hillshade';
-  if (m === 'terrain') return 'terrain';
-  return 'image';
+  return effectiveDemRenderMode(layer.style_config, layer.is_dem) === 'terrain'
+    ? 'terrain'
+    : 'hillshade';
 }
 
 function getNumber(paint: Record<string, unknown>, key: string, fallback: number): number {
@@ -167,11 +168,7 @@ export const DEMEditorScene = memo(function DEMEditorScene({
     if (current === nextMode) return;
 
     const nextConfig: Record<string, unknown> = { ...(layer.style_config ?? {}) };
-    if (nextMode === 'image') {
-      delete nextConfig.render_mode;
-    } else {
-      nextConfig.render_mode = nextMode;
-    }
+    nextConfig.render_mode = nextMode;
 
     // Source binding (the layer dataset_id + paint object) is intentionally preserved unchanged
     // across mode switches. Mode-specific paint values stay in layer.paint; reading the paint dict
@@ -196,7 +193,6 @@ export const DEMEditorScene = memo(function DEMEditorScene({
   }, [paint, onPaintChange]);
 
   const pills: { id: DemRenderMode; label: string }[] = [
-    { id: 'image', label: t('demEditor.renderAsImage', { defaultValue: '▦ Image' }) },
     { id: 'hillshade', label: t('demEditor.renderAsHillshade', { defaultValue: '⛰ Hillshade' }) },
     { id: 'terrain', label: t('demEditor.renderAsTerrain', { defaultValue: '◬ Terrain' }) },
   ];
@@ -267,12 +263,6 @@ export const DEMEditorScene = memo(function DEMEditorScene({
           >
             {t('layerEditor.section.appearance', { defaultValue: 'Appearance' })}
           </p>
-
-          {mode === 'image' && (
-            <p className="text-xs text-muted-foreground">
-              {t('demEditor.imageHint', { defaultValue: 'No additional appearance controls for image mode' })}
-            </p>
-          )}
 
           {mode === 'hillshade' && (
             <div className="space-y-4">
@@ -415,56 +405,53 @@ export const DEMEditorScene = memo(function DEMEditorScene({
       </section>
 
       {/* 3. HYPSOMETRIC TINT section — hillshade (full control) and terrain (hint only) modes */}
-      {/* Image mode: section not rendered at all (UI-SPEC A-01 / A-02 / critical_constraint) */}
-      {(mode === 'hillshade' || mode === 'terrain') && (
-        <section
-          aria-labelledby={`section-hypso-dem-${layer.id}`}
-          className="border-b"
-        >
-          <div className="px-4 py-2">
-            <p
-              id={`section-hypso-dem-${layer.id}`}
-              className="text-[10px] font-semibold uppercase tracking-[0.08em] text-muted-foreground mb-2"
-            >
-              {t('demEditor.sectionHypsometricTint', { defaultValue: 'HYPSOMETRIC TINT' })}
+      <section
+        aria-labelledby={`section-hypso-dem-${layer.id}`}
+        className="border-b"
+      >
+        <div className="px-4 py-2">
+          <p
+            id={`section-hypso-dem-${layer.id}`}
+            className="text-[10px] font-semibold uppercase tracking-[0.08em] text-muted-foreground mb-2"
+          >
+            {t('demEditor.sectionHypsometricTint', { defaultValue: 'HYPSOMETRIC TINT' })}
+          </p>
+
+          {/* Terrain mode: inline hint only — color-relief requires hillshade mode */}
+          {mode === 'terrain' && (
+            <p className="text-xs text-muted-foreground">
+              {t('demEditor.hypsometricTerrainHint', {
+                defaultValue: 'Elevation tint is not available in Terrain mode',
+              })}
             </p>
+          )}
 
-            {/* Terrain mode: inline hint only — color-relief requires hillshade mode */}
-            {mode === 'terrain' && (
-              <p className="text-xs text-muted-foreground">
-                {t('demEditor.hypsometricTerrainHint', {
-                  defaultValue: 'Elevation tint is not available in Terrain mode',
-                })}
-              </p>
-            )}
-
-            {/* Hillshade mode: full toggle + ramp picker */}
-            {mode === 'hillshade' && (
-              <div className="space-y-3">
-                {/* Enable toggle */}
-                <div className="flex items-center justify-between">
-                  <Label className="text-xs text-muted-foreground">
-                    {t('demEditor.hypsometricEnable', { defaultValue: 'Elevation tint' })}
-                  </Label>
-                  <Switch
-                    checked={paint['_hypso-enabled'] === true}
-                    onCheckedChange={(next) => handlePaintValue('_hypso-enabled', next)}
-                    aria-label={t('demEditor.hypsometricEnable', { defaultValue: 'Elevation tint' })}
-                  />
-                </div>
-                {/* Ramp picker — conditionally rendered (mount/unmount) when enabled */}
-                {paint['_hypso-enabled'] === true && (
-                  <ColorRampPicker
-                    mode="graduated"
-                    rampName={getString(paint, '_hypso-ramp', 'Viridis')}
-                    onChange={(name) => handlePaintValue('_hypso-ramp', name)}
-                  />
-                )}
+          {/* Hillshade mode: full toggle + ramp picker */}
+          {mode === 'hillshade' && (
+            <div className="space-y-3">
+              {/* Enable toggle */}
+              <div className="flex items-center justify-between">
+                <Label className="text-xs text-muted-foreground">
+                  {t('demEditor.hypsometricEnable', { defaultValue: 'Elevation tint' })}
+                </Label>
+                <Switch
+                  checked={paint['_hypso-enabled'] === true}
+                  onCheckedChange={(next) => handlePaintValue('_hypso-enabled', next)}
+                  aria-label={t('demEditor.hypsometricEnable', { defaultValue: 'Elevation tint' })}
+                />
               </div>
-            )}
-          </div>
-        </section>
-      )}
+              {/* Ramp picker — conditionally rendered (mount/unmount) when enabled */}
+              {paint['_hypso-enabled'] === true && (
+                <ColorRampPicker
+                  mode="graduated"
+                  rampName={getString(paint, '_hypso-ramp', 'Viridis')}
+                  onChange={(name) => handlePaintValue('_hypso-ramp', name)}
+                />
+              )}
+            </div>
+          )}
+        </div>
+      </section>
 
       {/* 5. VISIBILITY section — always expanded */}
       <section

--- a/frontend/src/components/builder/RasterLayerControls.tsx
+++ b/frontend/src/components/builder/RasterLayerControls.tsx
@@ -52,11 +52,9 @@ export function RasterLayerControls({
   onOpacityChange,
   isDem = false,
   bandCount = null,
-  styleConfig = null,
-  onStyleConfigChange,
 }: RasterLayerControlsProps) {
   const { t } = useTranslation('builder');
-  const renderMode = isDem && styleConfig?.render_mode === 'hillshade' ? 'hillshade' : 'raster';
+  const renderMode = isDem ? 'hillshade' : 'raster';
   const brightnessMin = getNumber('raster-brightness-min', 0);
   const brightnessMax = getNumber('raster-brightness-max', 1);
   const hasBrightnessRangeError = renderMode === 'raster' && brightnessMin > brightnessMax;
@@ -74,16 +72,6 @@ export function RasterLayerControls({
       ? normalizeHillshadeExaggeration(value)
       : value;
     onPaintChange({ ...paint, [key]: nextValue });
-  }
-
-  function setRenderMode(mode: 'raster' | 'hillshade') {
-    const nextConfig = { ...(styleConfig ?? {}) } as Record<string, unknown>;
-    if (mode === 'hillshade') {
-      nextConfig.render_mode = 'hillshade';
-    } else {
-      delete nextConfig.render_mode;
-    }
-    onStyleConfigChange?.(Object.keys(nextConfig).length > 0 ? nextConfig as StyleConfig : null, paint);
   }
 
   function handleReset() {
@@ -120,33 +108,6 @@ export function RasterLayerControls({
           ? t('style.hillshade.help', { defaultValue: 'Tune the relief overlay generated from this DEM layer.' })
           : t('style.raster.help', { defaultValue: 'Adjust imagery appearance for this layer only.' })}
       </p>
-
-      {isDem && (
-        <div className="flex items-center gap-2">
-          <span className="w-28 shrink-0 text-xs text-muted-foreground">
-            {t('style.raster.renderMode', { defaultValue: 'Render' })}
-          </span>
-          <Select
-            value={renderMode}
-            onValueChange={(v) => setRenderMode(v as 'raster' | 'hillshade')}
-          >
-            <SelectTrigger
-              aria-label={t('style.raster.renderMode', { defaultValue: 'Render' })}
-              className="h-8 flex-1 text-xs"
-            >
-              <SelectValue />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="raster" className="text-xs">
-                {t('style.raster.renderRaster', { defaultValue: 'Raster' })}
-              </SelectItem>
-              <SelectItem value="hillshade" className="text-xs">
-                {t('style.raster.renderHillshade', { defaultValue: 'Hillshade' })}
-              </SelectItem>
-            </SelectContent>
-          </Select>
-        </div>
-      )}
 
       {renderMode === 'hillshade' ? (
         <>

--- a/frontend/src/components/builder/__tests__/DEMEditorScene.test.tsx
+++ b/frontend/src/components/builder/__tests__/DEMEditorScene.test.tsx
@@ -151,40 +151,36 @@ function defaultProps(
 }
 
 describe('DEMEditorScene', () => {
-  // Test 1: Renders RENDER AS pill strip with 3 pills
-  it('renders RENDER AS pill strip with 3 pills (▦ Image, ⛰ Hillshade, ◬ Terrain) with radiogroup role', () => {
+  // Test 1: Renders RENDER AS pill strip with DEM-safe modes
+  it('renders RENDER AS pill strip with Hillshade and Terrain pills with radiogroup role', () => {
     render(<DEMEditorScene {...defaultProps()} />);
 
     const group = screen.getByRole('radiogroup');
     expect(group).toBeInTheDocument();
 
-    // All three pills should be present
-    expect(screen.getByText(/Image/)).toBeInTheDocument();
+    expect(screen.queryByText(/Image/)).not.toBeInTheDocument();
     expect(screen.getByText(/Hillshade/)).toBeInTheDocument();
     expect(screen.getByText(/Terrain/)).toBeInTheDocument();
   });
 
   // Test 2: Active pill matches layer's render mode
-  it('active pill matches layer render_mode: null/undefined → Image, hillshade → Hillshade, terrain → Terrain', () => {
-    // No render_mode → Image active
+  it('active pill matches layer render_mode: null/image → Hillshade, terrain → Terrain', () => {
+    // No render_mode → Hillshade active
     const { rerender } = render(
       <DEMEditorScene {...defaultProps({ layer: makeDEMLayer({ style_config: null }) })} />,
     );
-    let imagePill = screen.getByRole('radio', { name: /Image/i });
-    expect(imagePill).toHaveAttribute('aria-checked', 'true');
+    const hillshadePill = screen.getByRole('radio', { name: /Hillshade/i });
+    expect(hillshadePill).toHaveAttribute('aria-checked', 'true');
 
-    // Hillshade
+    // Legacy image render_mode → Hillshade active
     rerender(
       <DEMEditorScene
         {...defaultProps({
-          layer: makeDEMLayer({ style_config: { render_mode: 'hillshade' } }),
+          layer: makeDEMLayer({ style_config: { render_mode: 'image' } as unknown as MapLayerResponse['style_config'] }),
         })}
       />,
     );
-    const hillshadePill = screen.getByRole('radio', { name: /Hillshade/i });
     expect(hillshadePill).toHaveAttribute('aria-checked', 'true');
-    imagePill = screen.getByRole('radio', { name: /Image/i });
-    expect(imagePill).toHaveAttribute('aria-checked', 'false');
 
     // Terrain
     rerender(
@@ -198,14 +194,16 @@ describe('DEMEditorScene', () => {
     expect(terrainPill).toHaveAttribute('aria-checked', 'true');
   });
 
-  // Test 3: Clicking Hillshade pill calls onStyleConfigChange with render_mode='hillshade'
-  it('clicking Hillshade pill calls onStyleConfigChange with render_mode=hillshade and shows Hillshade appearance', () => {
+  // Test 3: Clicking Hillshade from Terrain calls onStyleConfigChange with render_mode='hillshade'
+  it('clicking Hillshade from Terrain calls onStyleConfigChange with render_mode=hillshade', () => {
     const onStyleConfigChange = vi.fn();
+    const onTerrainUnbind = vi.fn();
     render(
       <DEMEditorScene
         {...defaultProps({
-          layer: makeDEMLayer({ style_config: null }),
+          layer: makeDEMLayer({ id: 'dem-terrain-test', style_config: { render_mode: 'terrain' } as unknown as MapLayerResponse['style_config'] }),
           onStyleConfigChange,
+          onTerrainUnbind,
         })}
       />,
     );
@@ -216,6 +214,7 @@ describe('DEMEditorScene', () => {
     expect(onStyleConfigChange).toHaveBeenCalledOnce();
     const [config] = onStyleConfigChange.mock.calls[0] as [{ render_mode: string } | null, Record<string, unknown>];
     expect(config?.render_mode).toBe('hillshade');
+    expect(onTerrainUnbind).toHaveBeenCalledWith('dem-terrain-test');
   });
 
   // Test 4: Clicking Terrain pill calls onTerrainBind AND onStyleConfigChange
@@ -258,16 +257,16 @@ describe('DEMEditorScene', () => {
     expect(onTerrainUnbind).toHaveBeenCalledWith('dem-terrain-test');
   });
 
-  // Test 5: Image mode shows image hint only
-  it('in Image mode, Appearance section shows image hint and no compass/colors', () => {
+  // Test 5: Missing/legacy Image mode falls back to Hillshade controls
+  it('in missing/legacy Image mode, Appearance section shows Hillshade controls', () => {
     render(
       <DEMEditorScene
-        {...defaultProps({ layer: makeDEMLayer({ style_config: null }) })}
+        {...defaultProps({ layer: makeDEMLayer({ style_config: { render_mode: 'image' } as unknown as MapLayerResponse['style_config'] }) })}
       />,
     );
 
-    expect(screen.getByText('No additional appearance controls for image mode')).toBeInTheDocument();
-    expect(screen.queryByRole('img', { name: /Sun azimuth/i })).not.toBeInTheDocument();
+    expect(screen.queryByText('No additional appearance controls for image mode')).not.toBeInTheDocument();
+    expect(screen.getByRole('img', { name: /Sun azimuth/i })).toBeInTheDocument();
   });
 
   // Test 6: Hillshade mode shows Sun Position and Shading Colors
@@ -500,10 +499,10 @@ describe('DEMEditorScene', () => {
   // section never renders in any DEM render mode.
 
   describe('CONTOUR LINES section (removed — stays gone)', () => {
-    it('section is absent in image mode (always absent regardless of gate)', () => {
+    it('section is absent in legacy image mode after hillshade fallback', () => {
       render(
         <DEMEditorScene
-          {...defaultProps({ layer: makeDEMLayer({ style_config: null }) })}
+          {...defaultProps({ layer: makeDEMLayer({ style_config: { render_mode: 'image' } as unknown as MapLayerResponse['style_config'] }) })}
         />,
       );
       expect(screen.queryByText('CONTOUR LINES')).not.toBeInTheDocument();
@@ -538,13 +537,14 @@ describe('DEMEditorScene', () => {
   // --- HYPSOMETRIC TINT section tests (EDITOR-DEM-05) ---
 
   describe('HYPSOMETRIC TINT section', () => {
-    it('section is absent in image mode', () => {
+    it('section is present in legacy image mode after hillshade fallback', () => {
       render(
         <DEMEditorScene
-          {...defaultProps({ layer: makeDEMLayer({ style_config: null }) })}
+          {...defaultProps({ layer: makeDEMLayer({ style_config: { render_mode: 'image' } as unknown as MapLayerResponse['style_config'] }) })}
         />,
       );
-      expect(screen.queryByText('HYPSOMETRIC TINT')).not.toBeInTheDocument();
+      expect(screen.getByText('HYPSOMETRIC TINT')).toBeInTheDocument();
+      expect(screen.getByRole('switch', { name: 'Elevation tint' })).toBeInTheDocument();
     });
 
     it('section is present in hillshade mode with toggle + no picker when disabled', () => {
@@ -653,10 +653,10 @@ describe('DEMEditorScene', () => {
   });
 
   // Test 14: Switching render mode preserves style_config keys not under current mode
-  it('switching image→hillshade→image preserves other style_config keys', () => {
+  it('switching terrain→hillshade preserves other style_config keys', () => {
     const onStyleConfigChange = vi.fn();
     const layer = makeDEMLayer({
-      style_config: { render_mode: 'hillshade', some_other_key: 'preserved' } as unknown as MapLayerResponse['style_config'],
+      style_config: { render_mode: 'terrain', some_other_key: 'preserved' } as unknown as MapLayerResponse['style_config'],
     });
 
     render(
@@ -665,14 +665,12 @@ describe('DEMEditorScene', () => {
       />,
     );
 
-    // Switch to Image (removes render_mode, but other keys stay)
-    const imagePill = screen.getByRole('radio', { name: /Image/i });
-    fireEvent.click(imagePill);
+    const hillshadePill = screen.getByRole('radio', { name: /Hillshade/i });
+    fireEvent.click(hillshadePill);
 
     expect(onStyleConfigChange).toHaveBeenCalledOnce();
     const [config] = onStyleConfigChange.mock.calls[0] as [Record<string, unknown> | null, Record<string, unknown>];
-    // render_mode should be absent; other keys should remain
-    expect(config?.render_mode).toBeUndefined();
+    expect(config?.render_mode).toBe('hillshade');
     expect(config?.some_other_key).toBe('preserved');
   });
 });

--- a/frontend/src/components/builder/__tests__/RasterLayerControls.test.tsx
+++ b/frontend/src/components/builder/__tests__/RasterLayerControls.test.tsx
@@ -170,9 +170,8 @@ describe('RasterLayerControls', () => {
     expect(onOpacityChange).toHaveBeenCalledWith(1);
   });
 
-  it('shows DEM render mode and hillshade controls', () => {
+  it('shows DEM hillshade controls without a raw raster render switch', () => {
     const onPaintChange = vi.fn();
-    const onStyleConfigChange = vi.fn();
     render(
       <RasterLayerControls
         paint={{
@@ -185,10 +184,10 @@ describe('RasterLayerControls', () => {
         styleConfig={{ render_mode: 'hillshade' }}
         onPaintChange={onPaintChange}
         onOpacityChange={vi.fn()}
-        onStyleConfigChange={onStyleConfigChange}
       />,
     );
 
+    expect(screen.queryByRole('combobox', { name: 'Render' })).not.toBeInTheDocument();
     expect(screen.getByRole('slider', { name: 'Direction' })).toBeInTheDocument();
     expect(screen.getByRole('slider', { name: 'Relief' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Shadow' })).toBeInTheDocument();
@@ -205,8 +204,7 @@ describe('RasterLayerControls', () => {
     }));
   });
 
-  it('writes DEM render mode changes to style config', () => {
-    const onStyleConfigChange = vi.fn();
+  it('treats DEMs with no style config as hillshade', () => {
     render(
       <RasterLayerControls
         paint={{}}
@@ -215,12 +213,11 @@ describe('RasterLayerControls', () => {
         styleConfig={null}
         onPaintChange={vi.fn()}
         onOpacityChange={vi.fn()}
-        onStyleConfigChange={onStyleConfigChange}
       />,
     );
 
-    fireEvent.change(screen.getAllByRole('combobox')[0], { target: { value: 'hillshade' } });
-
-    expect(onStyleConfigChange).toHaveBeenCalledWith({ render_mode: 'hillshade' }, {});
+    expect(screen.queryByRole('combobox', { name: 'Render' })).not.toBeInTheDocument();
+    expect(screen.getByRole('slider', { name: 'Direction' })).toBeInTheDocument();
+    expect(screen.queryByRole('slider', { name: 'Brightness min' })).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/components/builder/__tests__/map-sync.raster.test.ts
+++ b/frontend/src/components/builder/__tests__/map-sync.raster.test.ts
@@ -168,6 +168,7 @@ describe('syncLayersToMap', () => {
   let managedSourcesRef: { current: Set<string> };
 
   beforeEach(() => {
+    mockSyncColorReliefLayer.mockClear();
     map = createMockMap();
     managedSourcesRef = { current: new Set() };
   });
@@ -752,6 +753,49 @@ describe('syncLayersToMap', () => {
     expect(map.removeSource).toHaveBeenCalledWith('source-dem-wr01');
   });
 
+  it('removes color-relief before replacing a DEM hillshade source', () => {
+    const layer = makeLayer({
+      id: 'dem-source-swap',
+      layer_type: 'raster_geolens',
+      dataset_geometry_type: null,
+      is_dem: true,
+      style_config: null,
+    });
+    const sourceId = 'source-dem-source-swap';
+    const baseLayerId = 'layer-dem-source-swap';
+    const colorReliefId = `${baseLayerId}-colorrelief`;
+    const tokenMap = new Map<string, TileToken>([['ds-1', makeRasterToken()]]);
+
+    (map.getLayer as ReturnType<typeof vi.fn>).mockImplementation((id: string) => {
+      if (id === baseLayerId) return { id, type: 'hillshade' };
+      if (id === colorReliefId) return { id, type: 'color-relief' };
+      return null;
+    });
+    (map.getSource as ReturnType<typeof vi.fn>).mockImplementation((id: string) => {
+      if (id === sourceId) {
+        return {
+          type: 'raster-dem',
+          tiles: ['http://localhost:8080/tiles/old-dem/{z}/{x}/{y}.png'],
+          tileSize: 256,
+          minzoom: 0,
+          maxzoom: 18,
+        };
+      }
+      return null;
+    });
+
+    syncLayersToMap(map, [layer], tokenMap, undefined, managedSourcesRef, { current: '' });
+
+    expect(map.removeLayer).toHaveBeenCalledWith(colorReliefId);
+    expect(map.removeLayer).toHaveBeenCalledWith(baseLayerId);
+    expect(map.removeSource).toHaveBeenCalledWith(sourceId);
+    const colorReliefRemoveOrder = (map.removeLayer as ReturnType<typeof vi.fn>).mock.invocationCallOrder[
+      (map.removeLayer as ReturnType<typeof vi.fn>).mock.calls.findIndex(([id]) => id === colorReliefId)
+    ];
+    const sourceRemoveOrder = (map.removeSource as ReturnType<typeof vi.fn>).mock.invocationCallOrder[0];
+    expect(colorReliefRemoveOrder).toBeLessThan(sourceRemoveOrder);
+  });
+
   it('polygon layer with non-prefixed outline-width strips it from fill paint', () => {
     const layer = makeLayer({
       id: 'legacy1',
@@ -856,6 +900,7 @@ describe('POLISH-02 syncRasterLayer hillshade skip guard', () => {
   }
 
   beforeEach(() => {
+    mockSyncColorReliefLayer.mockClear();
     map = createMockMap();
     managedSourcesRef = { current: new Set() };
   });
@@ -886,6 +931,38 @@ describe('POLISH-02 syncRasterLayer hillshade skip guard', () => {
     expect((map.addSource as ReturnType<typeof vi.fn>).mock.calls.length).toBeGreaterThan(0);
     const addSourceIds = (map.addSource as ReturnType<typeof vi.fn>).mock.calls.map(([id]) => id);
     expect(addSourceIds).toContain('source-dem-layer-1');
+    const addLayerCall = (map.addLayer as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(addLayerCall.type).toBe('hillshade');
+  });
+
+  it('normalizes legacy DEM image mode to hillshade before rendering', () => {
+    const layer = makeDEMLayer({
+      style_config: { render_mode: 'image' } as unknown as MapLayerResponse['style_config'],
+    });
+    const tokenMap = new Map<string, TileToken>([
+      ['dem-ds-1', makeRasterToken({ tile_url: '/tiles/dem/{z}/{x}/{y}.png' })],
+    ]);
+
+    syncLayersToMap(map, [layer], tokenMap, undefined, managedSourcesRef, { current: '' });
+
+    const addLayerCall = (map.addLayer as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(addLayerCall.type).toBe('hillshade');
+    expect(mockSyncColorReliefLayer).toHaveBeenCalledWith(
+      map,
+      expect.objectContaining({
+        style_config: expect.objectContaining({ render_mode: 'hillshade' }),
+      }),
+    );
+  });
+
+  it('normalizes missing DEM render mode to hillshade before rendering', () => {
+    const layer = makeDEMLayer({ style_config: null });
+    const tokenMap = new Map<string, TileToken>([
+      ['dem-ds-1', makeRasterToken({ tile_url: '/tiles/dem/{z}/{x}/{y}.png' })],
+    ]);
+
+    syncLayersToMap(map, [layer], tokenMap, undefined, managedSourcesRef, { current: '' });
+
     const addLayerCall = (map.addLayer as ReturnType<typeof vi.fn>).mock.calls[0][0];
     expect(addLayerCall.type).toBe('hillshade');
   });

--- a/frontend/src/components/builder/__tests__/renderAs.test.ts
+++ b/frontend/src/components/builder/__tests__/renderAs.test.ts
@@ -168,7 +168,7 @@ describe('renderAs view model', () => {
     }))).toBe('extrusion-3d');
   });
 
-  it('offers image for raster layers and image plus hillshade for DEM rasters', () => {
+  it('offers image for raster layers and hillshade for DEM rasters', () => {
     const raster = layer({
       dataset_geometry_type: null,
       dataset_record_type: 'raster_dataset',
@@ -187,7 +187,8 @@ describe('renderAs view model', () => {
     expect(getCurrentRenderAs(raster)).toBe('image');
 
     expect(getRenderAsSource(dem)).toBe('raster-dem');
-    expect(optionIds(dem)).toEqual(['image', 'hillshade']);
+    expect(optionIds(dem)).toEqual(['hillshade']);
+    expect(getCurrentRenderAs(dem)).toBe('hillshade');
     expect(getCurrentRenderAs({
       ...dem,
       style_config: { render_mode: 'hillshade' } as StyleConfig,
@@ -349,7 +350,13 @@ describe('renderAs view model', () => {
     });
   });
 
-  it('builds raster DEM image and hillshade patches', () => {
+  it('builds raster image and DEM hillshade patches', () => {
+    const raster = layer({
+      dataset_geometry_type: null,
+      dataset_record_type: 'raster_dataset',
+      layer_type: 'raster_geolens',
+      is_dem: false,
+    });
     const dem = layer({
       dataset_geometry_type: null,
       dataset_record_type: 'raster_dataset',
@@ -357,12 +364,13 @@ describe('renderAs view model', () => {
       is_dem: true,
     });
 
-    expect(buildRenderAsPatch(dem, 'image')).toMatchObject({
+    expect(buildRenderAsPatch(raster, 'image')).toMatchObject({
       adapterType: 'raster',
       patch: {
         layer_type: 'raster_geolens',
       },
     });
+    expect(buildRenderAsPatch(dem, 'image')).toBeNull();
     expect(buildRenderAsPatch(dem, 'hillshade')).toMatchObject({
       adapterType: 'hillshade',
       patch: {

--- a/frontend/src/components/builder/__tests__/reorder-data-layers.test.ts
+++ b/frontend/src/components/builder/__tests__/reorder-data-layers.test.ts
@@ -56,6 +56,36 @@ describe('reorderDataLayers', () => {
     expect(calls).toEqual(['layer-a', 'layer-a-extrusion']);
   });
 
+  it('keeps DEM color relief immediately below its hillshade layer when reordering', () => {
+    const map = createMockMap(['layer-dem-colorrelief', 'layer-dem']);
+    const layers = [{ id: 'dem' }];
+
+    reorderDataLayers(map, layers);
+
+    const calls = (map.moveLayer as ReturnType<typeof vi.fn>).mock.calls.map(
+      (c: string[]) => c[0],
+    );
+    expect(calls).toEqual(['layer-dem-colorrelief', 'layer-dem']);
+  });
+
+  it('moves color-relief companions with each DEM layer in reverse layer order', () => {
+    const map = createMockMap([
+      'layer-a-colorrelief', 'layer-a',
+      'layer-b-colorrelief', 'layer-b',
+    ]);
+    const layers = [{ id: 'a' }, { id: 'b' }];
+
+    reorderDataLayers(map, layers);
+
+    const calls = (map.moveLayer as ReturnType<typeof vi.fn>).mock.calls.map(
+      (c: string[]) => c[0],
+    );
+    expect(calls).toEqual([
+      'layer-b-colorrelief', 'layer-b',
+      'layer-a-colorrelief', 'layer-a',
+    ]);
+  });
+
   it('does nothing for empty layers array', () => {
     const map = createMockMap([]);
 

--- a/frontend/src/components/builder/hooks/__tests__/builder-layer-mutations.test.ts
+++ b/frontend/src/components/builder/hooks/__tests__/builder-layer-mutations.test.ts
@@ -2,7 +2,7 @@
  * Phase 1134 Plan 02 — removePerLayerCompanions per-render-mode regression tests (MAP-17).
  *
  * Verifies that removePerLayerCompanions uses the LayerAdapter registry (getLayerIds)
- * when a renderModeByLayerId map is provided, and falls back to the 7-suffix sweep
+ * when a renderModeByLayerId map is provided, and falls back to the suffix sweep
  * when it is not.
  */
 
@@ -95,10 +95,11 @@ describe('removePerLayerCompanions — per-render-mode regression (MAP-17)', () 
 
     // 'arrow' is not a registry key → getAdapter('arrow') returns circleAdapter fallback
     // whose type === 'circle', not 'arrow', so the type guard fails and the code falls
-    // through to the FALLBACK_SUFFIXES sweep (7 calls including the -arrow companion).
-    expect(removeLayer).toHaveBeenCalledTimes(7);
+    // through to the FALLBACK_SUFFIXES sweep (8 calls including optional companions).
+    expect(removeLayer).toHaveBeenCalledTimes(8);
     expect(removeLayer).toHaveBeenCalledWith('layer-l1');
     expect(removeLayer).toHaveBeenCalledWith('layer-l1-arrow');
+    expect(removeLayer).toHaveBeenCalledWith('layer-l1-colorrelief');
     expect(removeLayer).toHaveBeenCalledWith('layer-l1-outline');
     expect(removeLayer).toHaveBeenCalledWith('layer-l1-label');
     expect(removeLayer).toHaveBeenCalledWith('layer-l1-extrusion');
@@ -114,15 +115,28 @@ describe('removePerLayerCompanions — per-render-mode regression (MAP-17)', () 
     // Called WITHOUT renderModeByLayerId — falls back to suffix list
     removePerLayerCompanions(map as never, ['l1']);
 
-    // 7 suffixes: '', -outline, -label, -extrusion, -arrow, -cluster, -cluster-count
-    expect(removeLayer).toHaveBeenCalledTimes(7);
+    // Fallback suffixes: base + optional companions.
+    expect(removeLayer).toHaveBeenCalledTimes(8);
     expect(removeLayer).toHaveBeenCalledWith('layer-l1');
     expect(removeLayer).toHaveBeenCalledWith('layer-l1-outline');
     expect(removeLayer).toHaveBeenCalledWith('layer-l1-label');
     expect(removeLayer).toHaveBeenCalledWith('layer-l1-extrusion');
     expect(removeLayer).toHaveBeenCalledWith('layer-l1-arrow');
+    expect(removeLayer).toHaveBeenCalledWith('layer-l1-colorrelief');
     expect(removeLayer).toHaveBeenCalledWith('layer-l1-cluster');
     expect(removeLayer).toHaveBeenCalledWith('layer-l1-cluster-count');
+  });
+
+  it('Test 4b: hillshade render mode removes optional color-relief companion', () => {
+    const removeLayer = vi.fn();
+    const map = makeMap({ removeLayer });
+    const renderModeByLayerId = new Map([['l1', 'hillshade']]);
+
+    removePerLayerCompanions(map as never, ['l1'], renderModeByLayerId);
+
+    expect(removeLayer).toHaveBeenCalledTimes(2);
+    expect(removeLayer).toHaveBeenCalledWith('layer-l1');
+    expect(removeLayer).toHaveBeenCalledWith('layer-l1-colorrelief');
   });
 
   it('Test 5: getLayer returns null for some companions → skipped without error', () => {

--- a/frontend/src/components/builder/hooks/__tests__/use-builder-save.test.ts
+++ b/frontend/src/components/builder/hooks/__tests__/use-builder-save.test.ts
@@ -301,6 +301,25 @@ describe('buildLayerDiff', () => {
     expect(result.diff).toEqual({});
   });
 
+  it('normalizes legacy DEM image mode to hillshade before comparing save diffs', () => {
+    const baseline = makeLayer({
+      id: 'dem-1',
+      layer_type: 'raster_geolens',
+      dataset_geometry_type: null,
+      dataset_record_type: 'raster_dataset',
+      is_dem: true,
+      style_config: { render_mode: 'hillshade' } as MapLayerResponse['style_config'],
+    });
+    const current = makeLayer({
+      ...baseline,
+      style_config: { render_mode: 'image' } as unknown as MapLayerResponse['style_config'],
+    });
+
+    const result = buildLayerDiff([baseline], [current]);
+
+    expect(result.diff.updated).toBeUndefined();
+  });
+
   it('ignores dataset metadata changes that are not saved on map layers', () => {
     const baseline = makeLayer({ id: 'layer-1', dataset_name: 'Old name', dataset_feature_count: 10 });
     const current = makeLayer({ id: 'layer-1', dataset_name: 'New name', dataset_feature_count: 25 });

--- a/frontend/src/components/builder/hooks/__tests__/use-layer-map-sync.test.ts
+++ b/frontend/src/components/builder/hooks/__tests__/use-layer-map-sync.test.ts
@@ -4,8 +4,8 @@
  * Asserts that `handleToggleVisibility` from `useLayerMapSync` dispatches the
  * expected `map.setLayoutProperty(...)` calls on every click — both on the main
  * layer id AND on each companion suffix layer (`-outline`, `-label`,
- * `-extrusion`, `-arrow`, `-cluster`, `-cluster-count`) when those companion
- * layers exist in the MapLibre style. (`-arrow` added for builder-audit B-004.)
+ * `-extrusion`, `-arrow`, `-colorrelief`, `-cluster`, `-cluster-count`) when
+ * those companion layers exist in the MapLibre style.
  *
  * Mirrors the test setup pattern from `use-layer-map-sync.raf.test.ts` (vi.mock
  * for layer-adapters + map-sync + label-utils + filter-utils, minimal MaplibreMap
@@ -53,7 +53,7 @@ vi.mock('@/components/builder/label-layer-utils', () => ({
 // Fixtures
 // ---------------------------------------------------------------------------
 const LAYER_ID = 'layer-uuid-123';
-const COMPANION_SUFFIXES = ['', '-outline', '-label', '-extrusion', '-arrow', '-cluster', '-cluster-count'] as const;
+const COMPANION_SUFFIXES = ['', '-outline', '-label', '-extrusion', '-arrow', '-colorrelief', '-cluster', '-cluster-count'] as const;
 const ALL_COMPANION_IDS = COMPANION_SUFFIXES.map((suffix) => `layer-${LAYER_ID}${suffix}`);
 
 const makeLayer = (overrides: Partial<MapLayerResponse> = {}): MapLayerResponse => ({
@@ -197,7 +197,7 @@ describe('useLayerMapSync — handleToggleVisibility (BUG-01 regression)', () =>
     for (const cid of ALL_COMPANION_IDS) {
       expect(mapStub.setLayoutProperty).toHaveBeenCalledWith(cid, 'visibility', 'none');
     }
-    // Exactly 6 calls — one per companion that exists
+    // Exactly one call per layer id that exists.
     expect(mapStub.setLayoutProperty).toHaveBeenCalledTimes(ALL_COMPANION_IDS.length);
   });
 
@@ -315,7 +315,7 @@ describe('useLayerMapSync — handleToggleVisibility (BUG-01 regression)', () =>
       is_dem: true,
       style_config: { render_mode: 'hillshade' } as MapLayerResponse['style_config'],
     });
-    const mapStub = makeMapStub([`layer-${LAYER_ID}`]);
+    const mapStub = makeMapStub([`layer-${LAYER_ID}`, `layer-${LAYER_ID}-colorrelief`]);
     (mapStub.getSource as ReturnType<typeof vi.fn>).mockImplementation((id: string) => (
       id === `source-${LAYER_ID}`
         ? { type: 'raster-dem', tiles: ['http://localhost:8080/raster-tiles/dem/{z}/{x}/{y}.png'] }
@@ -334,8 +334,13 @@ describe('useLayerMapSync — handleToggleVisibility (BUG-01 regression)', () =>
       );
     });
 
+    expect(mapStub.removeLayer).toHaveBeenCalledWith(`layer-${LAYER_ID}-colorrelief`);
     expect(mapStub.removeLayer).toHaveBeenCalledWith(`layer-${LAYER_ID}`);
     expect(mapStub.removeSource).toHaveBeenCalledWith(`source-${LAYER_ID}`);
+    const removeLayerCalls = (mapStub.removeLayer as ReturnType<typeof vi.fn>).mock.calls.map(([id]) => id);
+    expect(removeLayerCalls.indexOf(`layer-${LAYER_ID}-colorrelief`)).toBeLessThan(
+      removeLayerCalls.indexOf(`layer-${LAYER_ID}`),
+    );
     expect(mockAdapter.addLayers).not.toHaveBeenCalled();
   });
 

--- a/frontend/src/components/builder/hooks/builder-layer-mutations.ts
+++ b/frontend/src/components/builder/hooks/builder-layer-mutations.ts
@@ -40,9 +40,11 @@ export function shouldClearTerrainOnDelete(
  * for the 3 existing call sites in use-builder-layers.ts that do not yet pass
  * renderModeByLayerId). The label companion is intentionally kept here because
  * no current adapter declares it in getLayerIds — labels are managed by
- * map-sync.ts syncLayersToMap, not by adapters.
+ * map-sync.ts syncLayersToMap, not by adapters. Color-relief is included because
+ * DEM hillshade layers can create it as a conditional companion on the same
+ * raster-dem source.
  */
-const FALLBACK_SUFFIXES = ['', '-outline', '-label', '-extrusion', '-arrow', '-cluster', '-cluster-count'];
+const FALLBACK_SUFFIXES = ['', '-outline', '-label', '-extrusion', '-arrow', '-colorrelief', '-cluster', '-cluster-count'];
 
 /**
  * Derive the full set of MapLibre layer ids that the adapter owns for a given
@@ -68,7 +70,10 @@ function deriveCompanionIds(prefixedLayerId: string, renderMode: string | null |
       // the adapter only when its registered type matches exactly.
       const adapter = getAdapter(renderMode);
       if (adapter.type === renderMode) {
-        return adapter.getLayerIds(prefixedLayerId);
+        const ids = adapter.getLayerIds(prefixedLayerId);
+        return renderMode === 'hillshade'
+          ? [...ids, `${prefixedLayerId}-colorrelief`]
+          : ids;
       }
     } catch {
       // Defensive — getAdapter should never throw, but fall through to suffix list

--- a/frontend/src/components/builder/hooks/use-builder-layers.ts
+++ b/frontend/src/components/builder/hooks/use-builder-layers.ts
@@ -16,6 +16,7 @@ import {
 import { buildSignedTileUrl } from '@/lib/tile-utils';
 import { buildLabelLayerSpec } from '@/components/builder/label-layer-utils';
 import { resolveBasemapId } from '@/lib/basemap-utils';
+import { normalizeDemStyleConfig } from '@/lib/dem-render-mode';
 import type { MapBasemapConfig, MapLayerResponse, MapResponse, MapTerrainConfig, StyleConfig } from '@/types/api';
 import type { useAddLayer, useRemoveLayer } from '@/hooks/use-maps';
 import { useEphemeralLayers } from '@/components/builder/hooks/use-ephemeral-layers';
@@ -908,8 +909,12 @@ export function useBuilderLayers(
     const mapLayerId = `layer-${layer.id}`;
     const sourceId = getSourceIdForLayer(layer);
     const labelId = `layer-${layer.id}-label`;
+    const colorReliefId = `layer-${layer.id}-colorrelief`;
 
     // Remove old layer
+    if (map.getLayer(colorReliefId)) {
+      map.removeLayer(colorReliefId);
+    }
     if (map.getLayer(mapLayerId)) {
       map.removeLayer(mapLayerId);
     }
@@ -1005,7 +1010,10 @@ export function useBuilderLayers(
       ...mutation.patch,
       paint: mutation.patch.paint ?? layer.paint,
       layout: mutation.patch.layout ?? layer.layout,
-      style_config: mutation.patch.style_config ?? layer.style_config,
+      style_config: normalizeDemStyleConfig(
+        'style_config' in mutation.patch ? mutation.patch.style_config : layer.style_config,
+        layer.is_dem,
+      ),
       layer_type: mutation.patch.layer_type ?? layer.layer_type,
     };
 

--- a/frontend/src/components/builder/hooks/use-builder-save.ts
+++ b/frontend/src/components/builder/hooks/use-builder-save.ts
@@ -19,6 +19,7 @@ import { usePluginStore } from '@/stores/map-plugin-store';
 import { useAuthStore } from '@/stores/auth-store';
 import { getDefaultPluginIds, resolveAvailablePluginIds, samePluginIds } from '@/components/map-plugins';
 import { prepareLayersForPersistence, type FolderGroupMeta } from '@/components/builder/folder-groups';
+import { normalizeDemStyleConfig } from '@/lib/dem-render-mode';
 
 /** Center-crop `srcCanvas` to the given target dimensions and return the
  *  resulting offscreen canvas. Crops from the center without distortion
@@ -290,7 +291,7 @@ function toLayerInput(layer: MapLayerResponse): MapLayerInput {
     filter: layer.filter ?? null,
     label_config: layer.label_config ?? null,
     popup_config: layer.popup_config ?? null,
-    style_config: layer.style_config ?? null,
+    style_config: normalizeDemStyleConfig(layer.style_config, layer.is_dem),
     layer_type: layer.layer_type ?? null,
     show_in_legend: layer.show_in_legend ?? true,
   };
@@ -309,7 +310,7 @@ function toLayerSnapshot(layer: MapLayerResponse): LayerSnapshot {
     filter: layer.filter ?? null,
     label_config: layer.label_config ?? null,
     popup_config: layer.popup_config ?? null,
-    style_config: layer.style_config ?? null,
+    style_config: normalizeDemStyleConfig(layer.style_config, layer.is_dem),
     layer_type: layer.layer_type ?? null,
     show_in_legend: layer.show_in_legend ?? true,
   };

--- a/frontend/src/components/builder/hooks/use-layer-map-sync.ts
+++ b/frontend/src/components/builder/hooks/use-layer-map-sync.ts
@@ -3,6 +3,7 @@ import type { Map as MaplibreMap, FilterSpecification } from 'maplibre-gl';
 import { getLayerType, getSourceIdForLayer, resolveAdapterType, getCompoundOpacity, isDemTerrainVisualSuppressed } from '@/components/builder/map-sync';
 import { getAdapter } from '@/components/builder/layer-adapters/registry';
 import { coalesceFrame } from '@/lib/builder/raf-coalesce';
+import { effectiveDemRenderMode, normalizeDemStyleConfig } from '@/lib/dem-render-mode';
 import type { AdapterLayerInput } from '@/components/builder/layer-adapters/types';
 import { buildLabelLayerSpec, syncLabelLayer } from '@/components/builder/label-layer-utils';
 import type { MapLayerResponse, LabelConfig, PopupConfig, StyleConfig } from '@/types/api';
@@ -11,9 +12,16 @@ import { sanitizeNullableNumericFilter } from '@/lib/maplibre-filter-utils';
 type LayerUpdater = (layer: MapLayerResponse) => MapLayerResponse;
 type LayerSideEffect = (map: MaplibreMap, updated: MapLayerResponse) => void;
 
+function removeColorReliefLayer(map: MaplibreMap, layerId: string) {
+  const colorReliefId = `${layerId}-colorrelief`;
+  if (map.getLayer(colorReliefId)) map.removeLayer(colorReliefId);
+}
+
 function resolveLayerAdapterType(layer: MapLayerResponse, paint: Record<string, unknown>, styleConfig?: StyleConfig | null): string {
   if (layer.layer_type === 'raster_geolens') {
-    return layer.is_dem === true && styleConfig?.render_mode === 'hillshade' ? 'hillshade' : 'raster';
+    return layer.is_dem === true && effectiveDemRenderMode(styleConfig, layer.is_dem) === 'hillshade'
+      ? 'hillshade'
+      : 'raster';
   }
   return resolveAdapterType(layer.dataset_geometry_type, styleConfig ?? layer.style_config, paint);
 }
@@ -79,6 +87,7 @@ export function useLayerMapSync(
           const labelId = `layer-${layerId}-label`;
           const extrusionId = `layer-${layerId}-extrusion`;
           const arrowId = `layer-${layerId}-arrow`;
+          const colorReliefId = `layer-${layerId}-colorrelief`;
           const clusterId = `layer-${layerId}-cluster`;
           const clusterCountId = `layer-${layerId}-cluster-count`;
           if (map.getLayer(mapLayerId)) map.setLayoutProperty(mapLayerId, 'visibility', newVis);
@@ -86,6 +95,7 @@ export function useLayerMapSync(
           if (map.getLayer(labelId)) map.setLayoutProperty(labelId, 'visibility', newVis);
           if (map.getLayer(extrusionId)) map.setLayoutProperty(extrusionId, 'visibility', newVis);
           if (map.getLayer(arrowId)) map.setLayoutProperty(arrowId, 'visibility', newVis);
+          if (map.getLayer(colorReliefId)) map.setLayoutProperty(colorReliefId, 'visibility', newVis);
           if (map.getLayer(clusterId)) map.setLayoutProperty(clusterId, 'visibility', newVis);
           if (map.getLayer(clusterCountId)) map.setLayoutProperty(clusterCountId, 'visibility', newVis);
         },
@@ -137,9 +147,8 @@ export function useLayerMapSync(
     (layerId: string, config: StyleConfig | null, paint: Record<string, unknown>) => {
       applyLayerUpdate(
         layerId,
-        (l) => ({
-          ...l,
-          style_config: config
+        (l) => {
+          const mergedConfig = config
             ? {
                 ...config,
                 ...(config.builder === undefined && l.style_config?.builder
@@ -148,15 +157,20 @@ export function useLayerMapSync(
               }
             : l.style_config?.builder
               ? ({ builder: l.style_config.builder } as StyleConfig)
-              : null,
-          paint,
-        }),
+              : null;
+          return {
+            ...l,
+            style_config: normalizeDemStyleConfig(mergedConfig, l.is_dem),
+            paint,
+          };
+        },
         (map, layer) => {
           const mapLayerId = `layer-${layerId}`;
           const nextConfig = layer.style_config;
           const sourceId = getSourceIdForLayer(layer);
 
           if (isDemTerrainVisualSuppressed({ is_dem: layer.is_dem, style_config: nextConfig })) {
+            removeColorReliefLayer(map, mapLayerId);
             if (map.getLayer(mapLayerId)) map.removeLayer(mapLayerId);
             if (map.getSource(sourceId)) map.removeSource(sourceId);
             return;
@@ -191,6 +205,7 @@ export function useLayerMapSync(
           input.style_config = nextConfig;
 
           if (layer.layer_type === 'raster_geolens' && tileUrl) {
+            removeColorReliefLayer(map, mapLayerId);
             if (map.getLayer(mapLayerId)) map.removeLayer(mapLayerId);
             if (map.getSource(sourceId)) map.removeSource(sourceId);
             adapter.addLayers(map, input);

--- a/frontend/src/components/builder/map-sync.ts
+++ b/frontend/src/components/builder/map-sync.ts
@@ -8,6 +8,7 @@ import { buildClusterTileUrl, buildSignedTileUrl } from '@/lib/tile-utils';
 import { applyBasemapConfigToStyle, isLandLayer, isWaterLayer } from '@/lib/basemap-utils';
 import { sanitizeNullableNumericFilter } from '@/lib/maplibre-filter-utils';
 import { isFolderGroupLayer } from '@/lib/layer-capabilities';
+import { effectiveDemRenderMode, normalizeDemStyleConfig } from '@/lib/dem-render-mode';
 import { getAdapter } from './layer-adapters/registry';
 import type { AdapterLayerInput } from './layer-adapters/types';
 import { buildLabelLayerSpec, syncLabelLayer } from './label-layer-utils';
@@ -421,6 +422,11 @@ function removeClusterCompanionLayers(map: MaplibreMap, layerId: string) {
   if (map.getLayer(clusterCircleId)) map.removeLayer(clusterCircleId);
 }
 
+function removeColorReliefCompanionLayer(map: MaplibreMap, layerId: string) {
+  const colorReliefId = `${layerId}-colorrelief`;
+  if (map.getLayer(colorReliefId)) map.removeLayer(colorReliefId);
+}
+
 function signatureStore(map: MaplibreMap) {
   let store = clusterSourceSignatures.get(map);
   if (!store) {
@@ -666,7 +672,8 @@ function syncRasterLayer(
   datasetId?: string,
   terrainSourceTileSize?: number | null,
 ) {
-  const renderMode = adapterInput.style_config?.render_mode;
+  adapterInput.style_config = normalizeDemStyleConfig(adapterInput.style_config, adapterInput.is_dem);
+  const renderMode = effectiveDemRenderMode(adapterInput.style_config, adapterInput.is_dem);
   const useHillshade = adapterInput.is_dem === true && renderMode === 'hillshade';
 
   // POLISH-02 (narrowed by 999.17 D-07): when this DEM is already powering the
@@ -725,6 +732,7 @@ function syncRasterLayer(
       !sameNumberArray(currentSourceSpec.bounds, desiredBounds)
     ))
   ) {
+    removeColorReliefCompanionLayer(map, adapterInput.layerId);
     if (map.getLayer(adapterInput.layerId)) map.removeLayer(adapterInput.layerId);
     if (map.getSource(adapterInput.sourceId)) map.removeSource(adapterInput.sourceId);
   }
@@ -923,8 +931,7 @@ function removeStaleSourcesAndLayers(
     // EDITOR-DEM-05: color-relief companion has no own source (it reuses the
     // raster-dem source), so it is not found by the source-keyed loop and must
     // be removed explicitly here.
-    const colorReliefId = `${layerId}-colorrelief`;
-    if (map.getLayer(colorReliefId)) map.removeLayer(colorReliefId);
+    removeColorReliefCompanionLayer(map, layerId);
     if (map.getLayer(labelId)) map.removeLayer(labelId);
     if (map.getLayer(arrowId)) map.removeLayer(arrowId);
     if (map.getLayer(extrusionId)) map.removeLayer(extrusionId);
@@ -1069,10 +1076,12 @@ function reorderDataGeometry(
     const oid = prefixed('outline', layers[i].id, idPrefix);
     const eid = prefixed('extrusion', layers[i].id, idPrefix);
     const aid = prefixed('arrow', layers[i].id, idPrefix);
+    const colorReliefId = `${lid}-colorrelief`;
     const cid = clusterCircleLayerId(lid);
     const ccid = clusterCountLayerId(lid);
     if (map.getLayer(cid)) map.moveLayer(cid);
     if (map.getLayer(ccid)) map.moveLayer(ccid);
+    if (map.getLayer(colorReliefId)) map.moveLayer(colorReliefId);
     if (map.getLayer(lid)) map.moveLayer(lid);
     if (map.getLayer(aid)) map.moveLayer(aid);
     if (map.getLayer(eid)) map.moveLayer(eid);

--- a/frontend/src/components/builder/renderAs.ts
+++ b/frontend/src/components/builder/renderAs.ts
@@ -187,13 +187,6 @@ export const RENDERER_CAPABILITIES: readonly RendererCapability[] = [
     viewerSupport: 'native',
     styleJsonSupport: 'native',
   }),
-  capability('image', 'Image', 'raster-dem', {
-    backend: 'maplibre',
-    sourceRequirement: 'raster-dem',
-    companionLayers: [],
-    viewerSupport: 'native',
-    styleJsonSupport: 'native',
-  }),
   capability('hillshade', 'Hillshade', 'raster-dem', {
     backend: 'maplibre',
     sourceRequirement: 'raster-dem',
@@ -368,7 +361,7 @@ export function getCurrentRenderAs(layer: RenderAsLayer): RenderAsId | null {
   const renderMode = layer.style_config?.render_mode;
 
   if (source === 'raster-dem') {
-    return renderMode === 'hillshade' ? 'hillshade' : 'image';
+    return 'hillshade';
   }
 
   if (source === 'raster') {

--- a/frontend/src/components/viewer/ViewerMap.tsx
+++ b/frontend/src/components/viewer/ViewerMap.tsx
@@ -37,6 +37,7 @@ import type { SyncLayerInput } from '@/components/builder/map-sync';
 import { asFeatureCollection, fetchBoundedGeoJson } from '@/api/geojson-z';
 import { createViewerLayerEntries } from '@/components/viewer/layer-identity';
 import { getClusterSourceEligibility, getClusterSourceStrategy, isClusterRenderMode, shouldFetchClusterGeoJson } from '@/components/builder/cluster-source';
+import { effectiveDemRenderMode } from '@/lib/dem-render-mode';
 import 'maplibre-gl/dist/maplibre-gl.css';
 
 /**
@@ -702,7 +703,7 @@ export const ViewerMap = memo(function ViewerMap({
       const isVisible = visibleLayers.has(key);
       if (wasVisible === isVisible) continue;
 
-      const type = layer.is_dem === true && layer.style_config?.render_mode === 'hillshade'
+      const type = layer.is_dem === true && effectiveDemRenderMode(layer.style_config, layer.is_dem) === 'hillshade'
         ? 'hillshade'
         : resolveAdapterType(layer.geometry_type, layer.style_config, layer.paint as Record<string, unknown>);
       const adapter = getAdapter(type);

--- a/frontend/src/lib/__tests__/normalize-style-config.test.ts
+++ b/frontend/src/lib/__tests__/normalize-style-config.test.ts
@@ -108,25 +108,39 @@ describe('normalizeLayerStyleState', () => {
     });
   });
 
-  it('preserves render_mode terrain for DEM/raster adapters', () => {
+  it('preserves render_mode terrain for DEM adapters', () => {
     const normalized = normalizeLayerStyleState(
       { render_mode: 'terrain' },
       {},
       null,
+      { isDem: true },
     );
 
     expect(normalized.paint).toEqual({});
     expect(normalized.style_config).toEqual({ render_mode: 'terrain' });
   });
 
-  it('preserves render_mode image for DEM/raster adapters', () => {
+  it('normalizes missing and image DEM render modes to hillshade', () => {
+    const missing = normalizeLayerStyleState(null, {}, null, { isDem: true });
+    const normalized = normalizeLayerStyleState(
+      { render_mode: 'image' },
+      {},
+      null,
+      { isDem: true },
+    );
+
+    expect(missing.style_config).toEqual({ render_mode: 'hillshade' });
+    expect(normalized.paint).toEqual({});
+    expect(normalized.style_config).toEqual({ render_mode: 'hillshade' });
+  });
+
+  it('preserves render_mode image for non-DEM raster adapters', () => {
     const normalized = normalizeLayerStyleState(
       { render_mode: 'image' },
       {},
       null,
     );
 
-    expect(normalized.paint).toEqual({});
     expect(normalized.style_config).toEqual({ render_mode: 'image' });
   });
 });
@@ -236,10 +250,12 @@ describe('normalizeLayerStyleState — raster stretch/colormap round-trip (v1034
       { builder: { hypso_enabled: true, hypso_ramp: 'Inferno' } },
       { 'raster-opacity': 1 },
       null,
+      { isDem: true },
     );
     expect(paint['_hypso-enabled']).toBe(true);
     expect(paint['_hypso-ramp']).toBe('Inferno');
     // The builder values survive in style_config too.
+    expect(style_config?.render_mode).toBe('hillshade');
     expect(style_config?.builder?.hypso_enabled).toBe(true);
     expect(style_config?.builder?.hypso_ramp).toBe('Inferno');
   });

--- a/frontend/src/lib/dem-render-mode.ts
+++ b/frontend/src/lib/dem-render-mode.ts
@@ -1,0 +1,27 @@
+import type { StyleConfig } from '@/types/api';
+
+type LayerStyle = {
+  render_mode?: StyleConfig['render_mode'];
+  [key: string]: unknown;
+};
+
+export function effectiveDemRenderMode(
+  styleConfig: LayerStyle | null | undefined,
+  isDem?: boolean | null,
+): StyleConfig['render_mode'] | undefined {
+  const renderMode = styleConfig?.render_mode;
+  if (isDem !== true) return renderMode;
+  return renderMode === 'terrain' ? 'terrain' : 'hillshade';
+}
+
+export function normalizeDemStyleConfig<TStyle extends LayerStyle>(
+  styleConfig: TStyle | null | undefined,
+  isDem?: boolean | null,
+): TStyle | null {
+  if (isDem !== true) return styleConfig ?? null;
+
+  return {
+    ...(styleConfig ?? {}),
+    render_mode: effectiveDemRenderMode(styleConfig, true),
+  } as TStyle;
+}

--- a/frontend/src/lib/normalize-style-config.ts
+++ b/frontend/src/lib/normalize-style-config.ts
@@ -1,6 +1,7 @@
 import type { StyleConfig } from '@/types/api';
 import { getColorProperty, getSizeProperty } from './color-ramps';
 import { inferGeometryType } from './geo-utils';
+import { normalizeDemStyleConfig } from './dem-render-mode';
 
 /**
  * Extract breaks and values from a MapLibre "step" or "interpolate" expression.
@@ -323,8 +324,12 @@ export function normalizeLayerStyleState(
   raw: Record<string, unknown> | null | undefined,
   paint: Record<string, unknown> | null | undefined,
   geometryType: string | null,
+  options: { isDem?: boolean | null } = {},
 ): NormalizedLayerStyleState {
-  const style_config = normalizeStyleConfig(raw, paint, geometryType);
+  const style_config = normalizeDemStyleConfig(
+    normalizeStyleConfig(raw, paint, geometryType),
+    options.isDem,
+  );
   const cleanPaint = stripLegacyBuilderPaint(paint);
   // Re-hydrate the raster colormap/stretch builder-private keys back onto the
   // in-memory paint view. The backend stores them in style_config.builder (the


### PR DESCRIPTION
## What changed

- Normalizes DEM render modes through backend persistence so DEM layers with null or legacy image state store `render_mode: "hillshade"`.
- Removes raw `Image` rendering from DEM builder controls and keeps DEM adapter selection consistent across builder/viewer paths.
- Tears down the color-relief companion layer before DEM source replacement/removal so Hillshade <-> Terrain toggles do not hit MapLibre source-in-use errors.
- Adds a data migration to repair existing DEM map layers with SQL null, JSON null, missing render mode, or legacy `image` render mode.

## Why

The UI normalized legacy DEM state client-side, but backend state could remain `style_config: null`. That made backend-only exports like `/maps/{id}/style.json` diverge from the builder and export DEMs as raw raster imagery instead of raster-dem hillshade sources.

## Validation

- `cd frontend && npm run typecheck`
- `cd frontend && npm run test -- src/api/__tests__/maps.normalize.test.ts src/lib/__tests__/normalize-style-config.test.ts src/components/builder/hooks/__tests__/use-builder-save.test.ts`
- `cd backend && POSTGRES_HOST=localhost POSTGRES_PORT=5434 uv run pytest tests/test_maps.py::TestMapLayers::test_add_dem_layer_persists_hillshade_render_mode tests/test_maps.py::TestMapLayers::test_patch_add_dem_layer_persists_hillshade_render_mode tests/test_maps_style_json.py::test_build_maplibre_style_emits_raster_dem_source_for_hillshade -q`
- `cd backend && uv run ruff check app/modules/catalog/maps/service_shared.py app/modules/catalog/maps/service_layers.py app/modules/catalog/maps/service_diff.py app/modules/catalog/maps/_router_helpers.py tests/test_maps.py alembic/versions/0003_normalize_dem_hillshade_style.py`
- `cd backend && uv run ruff format --check app/modules/catalog/maps/service_shared.py app/modules/catalog/maps/service_layers.py app/modules/catalog/maps/service_diff.py app/modules/catalog/maps/_router_helpers.py tests/test_maps.py alembic/versions/0003_normalize_dem_hillshade_style.py`
- Playwright MCP: opened the Matterhorn builder, verified DEM controls only show Hillshade/Terrain, toggled Hillshade -> Terrain -> Hillshade with zero console errors.
- Live local API check after data repair: Matterhorn map returned DEM `hillshade`; `/style.json` returned source type `raster-dem`.

## Notes

This PR is stacked on `chore/single-seed-script` because that branch already has open PR #189 and was the current local base when these changes were made.