### PR TITLE
feat(builder): in-app problem reporter for filing GitHub issues

### DIFF
--- a/frontend/src/@types/build-globals.d.ts
+++ b/frontend/src/@types/build-globals.d.ts
@@ -1,0 +1,5 @@
+// Build-time constants injected by Vite's `define` (see vite.config.ts).
+// __APP_VERSION__ is the frontend package.json version, stamped at build so
+// the in-app "Report a problem" flow can auto-fill the GitHub issue version
+// field without an extra runtime fetch.
+declare const __APP_VERSION__: string;

--- a/frontend/src/components/builder/BuilderMap.tsx
+++ b/frontend/src/components/builder/BuilderMap.tsx
@@ -14,6 +14,7 @@ import {
 import { buildClusterTileUrl, buildSignedTileUrl } from '@/lib/tile-utils';
 import { useTileTokens } from '@/hooks/use-tile-token';
 import { getEnvConfig } from '@/lib/env';
+import { pushReportEntry } from '@/lib/report';
 import { useAuthStore } from '@/stores/auth-store';
 import { useWebGLRecovery } from '@/hooks/use-webgl-recovery';
 import i18n from '@/i18n/i18n';
@@ -485,6 +486,18 @@ export const BuilderMap = memo(function BuilderMap({
       // real error has occurred (RES-3). Previously silenced in production.
       errorHandlerRef.current = (e: { error: { message?: string; status?: number }; sourceId?: string }) => {
         const status = e.error?.status;
+        // Capture EVERY map error into the problem-reporter buffer before the
+        // suppression/early-return logic below — suppressed errors (expected
+        // no-data tiles, terrain/DEM mismatches) are frequently the actual bug
+        // an engineer needs, so we flag rather than drop them here.
+        const isClientError = Boolean(status && status >= 400 && status < 500);
+        pushReportEntry({
+          severity: isClientError ? 'warning' : 'error',
+          source: 'maplibre',
+          message: e.error?.message || (status ? `Map error (HTTP ${status})` : 'Map error'),
+          detail: e.sourceId ? `source: ${e.sourceId}` : undefined,
+          suppressed: isClientError || shouldSuppressBuilderMapError(e.error),
+        });
         // Suppress expected no-data tiles (404) and other client errors
         if (status && status >= 400 && status < 500) {
           if (status === 401 || status === 403) {

--- a/frontend/src/components/error/AppErrorBoundary.tsx
+++ b/frontend/src/components/error/AppErrorBoundary.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { AlertCircle } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { logger } from '@/lib/logger';
+import { pushReportEntry } from '@/lib/report';
 import { ErrorReportButton } from './ErrorReportButton';
 
 interface AppErrorBoundaryState {
@@ -59,6 +60,12 @@ export class AppErrorBoundary extends Component<AppErrorBoundaryProps, AppErrorB
 
   componentDidCatch(error: Error, errorInfo: ErrorInfo): void {
     logger.error('[AppErrorBoundary]', error, errorInfo);
+    pushReportEntry({
+      severity: 'error',
+      source: 'react',
+      message: error.message || 'Application crash',
+      detail: errorInfo.componentStack ?? error.stack ?? undefined,
+    });
   }
 
   render() {

--- a/frontend/src/components/error/MapErrorBoundary.tsx
+++ b/frontend/src/components/error/MapErrorBoundary.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { AlertCircle } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { logger } from '@/lib/logger';
+import { pushReportEntry } from '@/lib/report';
 
 interface MapErrorBoundaryState {
   hasError: boolean;
@@ -56,6 +57,12 @@ export class MapErrorBoundary extends Component<MapErrorBoundaryProps, MapErrorB
 
   componentDidCatch(error: Error, errorInfo: ErrorInfo): void {
     logger.error('[MapErrorBoundary]', error, errorInfo);
+    pushReportEntry({
+      severity: 'error',
+      source: 'react',
+      message: error.message || 'Map crash',
+      detail: errorInfo.componentStack ?? error.stack ?? undefined,
+    });
   }
 
   private handleReset = () => {

--- a/frontend/src/components/report/ReportEntryList.tsx
+++ b/frontend/src/components/report/ReportEntryList.tsx
@@ -1,0 +1,82 @@
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { AlertCircle, AlertTriangle, ChevronRight, Info } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import type { ReportEntry, ReportSeverity } from '@/lib/report';
+
+function SeverityIcon({ severity }: { severity: ReportSeverity }) {
+  if (severity === 'error') return <AlertCircle className="size-3.5 shrink-0 text-destructive" aria-hidden />;
+  if (severity === 'warning') return <AlertTriangle className="size-3.5 shrink-0 text-warning" aria-hidden />;
+  return <Info className="size-3.5 shrink-0 text-muted-foreground" aria-hidden />;
+}
+
+function formatRelative(ts: number, language: string): string {
+  const seconds = Math.round((ts - Date.now()) / 1000);
+  const abs = Math.abs(seconds);
+  try {
+    const rtf = new Intl.RelativeTimeFormat(language, { numeric: 'auto' });
+    if (abs < 60) return rtf.format(seconds, 'second');
+    if (abs < 3600) return rtf.format(Math.round(seconds / 60), 'minute');
+    return rtf.format(Math.round(seconds / 3600), 'hour');
+  } catch {
+    return '';
+  }
+}
+
+function EntryRow({ entry, language }: { entry: ReportEntry; language: string }) {
+  const [expanded, setExpanded] = useState(false);
+  const canExpand = Boolean(entry.detail);
+
+  return (
+    <li className="border-b border-border/60 last:border-0">
+      <button
+        type="button"
+        onClick={() => canExpand && setExpanded((v) => !v)}
+        className={cn(
+          'flex w-full items-start gap-2 px-2 py-1.5 text-left text-xs',
+          canExpand ? 'cursor-pointer hover:bg-muted/50' : 'cursor-default',
+        )}
+        aria-expanded={canExpand ? expanded : undefined}
+      >
+        <SeverityIcon severity={entry.severity} />
+        <span className="shrink-0 rounded bg-muted px-1 py-0.5 font-mono text-[10px] uppercase text-muted-foreground">
+          {entry.source}
+        </span>
+        <span className="min-w-0 flex-1 break-words font-mono text-foreground/90">
+          {entry.message}
+          {entry.count > 1 && <span className="ml-1 text-muted-foreground">×{entry.count}</span>}
+          {entry.suppressed && <span className="ml-1 italic text-muted-foreground">(suppressed)</span>}
+        </span>
+        <span className="shrink-0 text-[10px] text-muted-foreground">{formatRelative(entry.ts, language)}</span>
+        {canExpand && (
+          <ChevronRight
+            className={cn('size-3 shrink-0 text-muted-foreground transition-transform', expanded && 'rotate-90')}
+            aria-hidden
+          />
+        )}
+      </button>
+      {expanded && entry.detail && (
+        <pre className="mb-1.5 ml-7 max-h-40 overflow-auto whitespace-pre-wrap break-words rounded bg-muted/70 p-2 text-[10px] leading-relaxed text-muted-foreground">
+          {entry.detail}
+        </pre>
+      )}
+    </li>
+  );
+}
+
+/** Read-only list of captured signals, newest first. */
+export function ReportEntryList({ entries }: { entries: ReportEntry[] }) {
+  const { t, i18n } = useTranslation('report');
+
+  if (entries.length === 0) {
+    return <p className="px-2 py-3 text-xs text-muted-foreground">{t('technicalEmpty')}</p>;
+  }
+
+  return (
+    <ul className="max-h-56 overflow-auto rounded-md border bg-card/40">
+      {entries.map((entry) => (
+        <EntryRow key={entry.id} entry={entry} language={i18n.language} />
+      ))}
+    </ul>
+  );
+}

--- a/frontend/src/components/report/ReportProblemHost.tsx
+++ b/frontend/src/components/report/ReportProblemHost.tsx
@@ -1,0 +1,64 @@
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { LifeBuoy } from 'lucide-react';
+import { useAuthStore } from '@/stores/auth-store';
+import { useReportEntries } from '@/lib/report';
+import { cn } from '@/lib/utils';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
+import { ReportProblemWizard } from './ReportProblemWizard';
+
+/**
+ * App-wide entry point for the in-app problem reporter. Renders a quiet
+ * bottom-right button that stays out of the way until something is captured,
+ * then surfaces an error count. Gated to authenticated users — the public
+ * login / shared-map views never show it.
+ *
+ * Capture itself runs app-wide via initReportCapture() (main.tsx); this only
+ * owns the affordance and the wizard.
+ */
+export function ReportProblemHost() {
+  const token = useAuthStore((s) => s.token);
+  const entries = useReportEntries();
+  const { t } = useTranslation('report');
+  const [open, setOpen] = useState(false);
+
+  if (!token) return null;
+
+  const errorCount = entries.reduce((count, entry) => count + (entry.severity === 'error' ? 1 : 0), 0);
+  const hasErrors = errorCount > 0;
+  const badge = errorCount > 9 ? '9+' : String(errorCount);
+
+  return (
+    <>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <button
+            type="button"
+            aria-label={hasErrors ? t('button.ariaWithCount', { count: errorCount }) : t('button.aria')}
+            onClick={() => setOpen(true)}
+            className={cn(
+              // bottom-10 (not bottom-4) clears the MapLibre attribution bar that
+              // hugs the bottom-right corner of every map view — attribution must
+              // stay unobstructed, and its compact toggle sits exactly here.
+              'fixed bottom-10 right-4 z-40 inline-flex size-10 items-center justify-center rounded-full border bg-background/90 text-muted-foreground shadow-sm backdrop-blur transition-all duration-200 hover:text-foreground hover:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
+              hasErrors ? 'border-destructive/50 text-destructive opacity-100' : 'opacity-60',
+            )}
+          >
+            <LifeBuoy className="size-5" aria-hidden />
+            {hasErrors && (
+              <span
+                aria-live="polite"
+                aria-atomic="true"
+                className="absolute -right-1 -top-1 inline-flex h-4 min-w-4 items-center justify-center rounded-full bg-destructive px-1 text-[10px] font-semibold leading-none text-destructive-foreground"
+              >
+                {badge}
+              </span>
+            )}
+          </button>
+        </TooltipTrigger>
+        <TooltipContent side="left">{t('button.tooltip')}</TooltipContent>
+      </Tooltip>
+      <ReportProblemWizard open={open} onOpenChange={setOpen} entries={entries} />
+    </>
+  );
+}

--- a/frontend/src/components/report/ReportProblemWizard.tsx
+++ b/frontend/src/components/report/ReportProblemWizard.tsx
@@ -116,13 +116,19 @@ export function ReportProblemWizard({ open, onOpenChange, entries }: ReportProbl
     });
   }
 
-  async function handleOpenIssue() {
+  function handleOpenIssue() {
     const context = assembleContext();
     const version = includeVersion ? APP_VERSION : '';
     const { url, truncated } = buildIssueUrl({ title, description, steps, expected, area, version, context });
     if (truncated) {
-      await copyToClipboard(buildClipboardReport({ title, description, steps, expected, area, version, context }));
-      toast.message(t('step3.truncatedToast'));
+      // Initiate the clipboard copy within the user gesture but do NOT await it
+      // before window.open — an await boundary here drops the gesture context,
+      // so a popup blocker can kill the GitHub issue tab (the primary action).
+      // The write is kicked off in-gesture (while this tab still has focus),
+      // then the tab opens synchronously.
+      void copyToClipboard(
+        buildClipboardReport({ title, description, steps, expected, area, version, context }),
+      ).then(() => toast.message(t('step3.truncatedToast')));
     }
     window.open(url, '_blank', 'noopener,noreferrer');
     onOpenChange(false);

--- a/frontend/src/components/report/ReportProblemWizard.tsx
+++ b/frontend/src/components/report/ReportProblemWizard.tsx
@@ -1,0 +1,339 @@
+import { useEffect, useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { toast } from 'sonner';
+import { AlertTriangle, ChevronDown, ShieldCheck } from 'lucide-react';
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetFooter,
+  SheetHeader,
+  SheetTitle,
+} from '@/components/ui/sheet';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Checkbox } from '@/components/ui/checkbox';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible';
+import { GitHubIcon } from '@/components/icons/GitHubIcon';
+import { cn } from '@/lib/utils';
+import type { ReportEntry } from '@/lib/report';
+import {
+  ISSUE_AREAS,
+  buildClipboardReport,
+  buildContext,
+  buildIssueUrl,
+  mapAreaFromPath,
+} from '@/lib/report';
+import { ReportEntryList } from './ReportEntryList';
+
+// `__APP_VERSION__` is replaced at build by Vite's `define`. The typeof guard
+// keeps this safe in any environment where the define isn't applied.
+const APP_VERSION = typeof __APP_VERSION__ !== 'undefined' ? __APP_VERSION__ : '0.0.0';
+const STEP_PLACEHOLDER = '1. \n2. \n3. ';
+const TOTAL_STEPS = 3;
+
+const textareaClass =
+  'flex w-full min-h-20 rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-xs outline-none transition-[color,box-shadow] duration-200 placeholder:text-muted-foreground focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50';
+
+async function copyToClipboard(text: string): Promise<void> {
+  try {
+    await navigator.clipboard.writeText(text);
+    return;
+  } catch {
+    // Fall through to the legacy execCommand path (e.g. non-secure context).
+  }
+  const textarea = document.createElement('textarea');
+  textarea.value = text;
+  textarea.style.position = 'fixed';
+  textarea.style.opacity = '0';
+  document.body.appendChild(textarea);
+  textarea.select();
+  try {
+    document.execCommand('copy');
+  } catch {
+    // Best effort — nothing more we can do.
+  }
+  document.body.removeChild(textarea);
+}
+
+interface ReportProblemWizardProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  entries: ReportEntry[];
+}
+
+export function ReportProblemWizard({ open, onOpenChange, entries }: ReportProblemWizardProps) {
+  const { t, i18n } = useTranslation('report');
+  const [step, setStep] = useState(1);
+  const [area, setArea] = useState<string>('Other');
+  const [title, setTitle] = useState('');
+  const [description, setDescription] = useState('');
+  const [steps, setSteps] = useState('');
+  const [expected, setExpected] = useState('');
+  const [includeErrors, setIncludeErrors] = useState(true);
+  const [includePage, setIncludePage] = useState(true);
+  const [includeEnv, setIncludeEnv] = useState(true);
+  const [includeVersion, setIncludeVersion] = useState(true);
+  const [detailsOpen, setDetailsOpen] = useState(false);
+
+  const problemCount = useMemo(() => entries.filter((e) => e.severity !== 'info').length, [entries]);
+
+  // Start each session from a clean wizard; default the Area from the route.
+  useEffect(() => {
+    if (!open) return;
+    setStep(1);
+    setArea(mapAreaFromPath(window.location.pathname));
+    setTitle('');
+    setDescription('');
+    setSteps('');
+    setExpected('');
+    setIncludeErrors(true);
+    setIncludePage(true);
+    setIncludeEnv(true);
+    setIncludeVersion(true);
+    setDetailsOpen(false);
+  }, [open]);
+
+  function assembleContext(): string {
+    return buildContext({
+      entries,
+      includeErrors,
+      includeEnv,
+      includePage,
+      pageUrl: window.location.href,
+      userAgent: navigator.userAgent,
+      screen: `${window.innerWidth}×${window.innerHeight}`,
+      language: i18n.language,
+    });
+  }
+
+  async function handleOpenIssue() {
+    const context = assembleContext();
+    const version = includeVersion ? APP_VERSION : '';
+    const { url, truncated } = buildIssueUrl({ title, description, steps, expected, area, version, context });
+    if (truncated) {
+      await copyToClipboard(buildClipboardReport({ title, description, steps, expected, area, version, context }));
+      toast.message(t('step3.truncatedToast'));
+    }
+    window.open(url, '_blank', 'noopener,noreferrer');
+    onOpenChange(false);
+  }
+
+  async function handleCopy() {
+    const context = assembleContext();
+    const version = includeVersion ? APP_VERSION : '';
+    await copyToClipboard(buildClipboardReport({ title, description, steps, expected, area, version, context }));
+    toast.success(t('step3.copied'));
+  }
+
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent side="right" className="w-full gap-0 sm:max-w-md">
+        <SheetHeader className="border-b">
+          <SheetTitle>{t('title')}</SheetTitle>
+          <SheetDescription>{t('description')}</SheetDescription>
+          <p className="text-xs font-medium text-muted-foreground">
+            {t('stepIndicator', { current: step, total: TOTAL_STEPS })}
+          </p>
+        </SheetHeader>
+
+        <div className="flex-1 space-y-4 overflow-y-auto px-4 py-4">
+          {step === 1 && (
+            <>
+              <h3 className="text-sm font-semibold">{t('step1.heading')}</h3>
+
+              <div className="space-y-1.5">
+                <Label htmlFor="rp-area">{t('step1.areaLabel')}</Label>
+                <Select value={area} onValueChange={setArea}>
+                  <SelectTrigger id="rp-area" className="w-full">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {ISSUE_AREAS.map((option) => (
+                      <SelectItem key={option} value={option}>
+                        {option}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+
+              <div className="space-y-1.5">
+                <Label htmlFor="rp-title">{t('step1.titleLabel')}</Label>
+                <Input
+                  id="rp-title"
+                  value={title}
+                  onChange={(e) => setTitle(e.target.value)}
+                  placeholder={t('step1.titlePlaceholder')}
+                />
+              </div>
+
+              <div className="space-y-1.5">
+                <Label htmlFor="rp-description">{t('step1.descriptionLabel')}</Label>
+                <textarea
+                  id="rp-description"
+                  className={textareaClass}
+                  value={description}
+                  onChange={(e) => setDescription(e.target.value)}
+                  placeholder={t('step1.descriptionPlaceholder')}
+                />
+              </div>
+
+              <div className="space-y-1.5">
+                <Label htmlFor="rp-steps">{t('step1.stepsLabel')}</Label>
+                <textarea
+                  id="rp-steps"
+                  className={textareaClass}
+                  value={steps}
+                  onChange={(e) => setSteps(e.target.value)}
+                  placeholder={STEP_PLACEHOLDER}
+                />
+              </div>
+
+              <div className="space-y-1.5">
+                <Label htmlFor="rp-expected">{t('step1.expectedLabel')}</Label>
+                <textarea
+                  id="rp-expected"
+                  className={textareaClass}
+                  value={expected}
+                  onChange={(e) => setExpected(e.target.value)}
+                  placeholder={t('step1.expectedPlaceholder')}
+                />
+              </div>
+
+              <div
+                className={cn(
+                  'flex items-start gap-2 rounded-md border px-3 py-2 text-xs',
+                  problemCount > 0
+                    ? 'border-warning/40 bg-warning/5 text-foreground'
+                    : 'border-border bg-muted/40 text-muted-foreground',
+                )}
+              >
+                {problemCount > 0 && <AlertTriangle className="mt-0.5 size-3.5 shrink-0 text-warning" aria-hidden />}
+                <span>{problemCount > 0 ? t('noticed', { count: problemCount }) : t('noticedNone')}</span>
+              </div>
+
+              <Collapsible open={detailsOpen} onOpenChange={setDetailsOpen}>
+                <CollapsibleTrigger className="flex w-full items-center gap-1 text-xs font-medium text-muted-foreground hover:text-foreground">
+                  <ChevronDown className={cn('size-3.5 transition-transform', detailsOpen && 'rotate-180')} aria-hidden />
+                  {t('technicalDetails', { count: entries.length })}
+                </CollapsibleTrigger>
+                <CollapsibleContent className="pt-2">
+                  <ReportEntryList entries={entries} />
+                </CollapsibleContent>
+              </Collapsible>
+            </>
+          )}
+
+          {step === 2 && (
+            <>
+              <div>
+                <h3 className="text-sm font-semibold">{t('step2.heading')}</h3>
+                <p className="mt-1 text-xs text-muted-foreground">{t('step2.subtitle')}</p>
+              </div>
+
+              <div className="space-y-3">
+                <div className="flex items-center gap-2">
+                  <Checkbox
+                    id="rp-inc-errors"
+                    checked={includeErrors}
+                    onCheckedChange={(v) => setIncludeErrors(v === true)}
+                    disabled={entries.length === 0}
+                  />
+                  <Label htmlFor="rp-inc-errors" className="font-normal">
+                    {t('step2.includeErrors', { count: entries.length })}
+                  </Label>
+                </div>
+                <div className="flex items-center gap-2">
+                  <Checkbox id="rp-inc-page" checked={includePage} onCheckedChange={(v) => setIncludePage(v === true)} />
+                  <Label htmlFor="rp-inc-page" className="font-normal">
+                    {t('step2.includePage')}
+                  </Label>
+                </div>
+                <div className="flex items-center gap-2">
+                  <Checkbox id="rp-inc-env" checked={includeEnv} onCheckedChange={(v) => setIncludeEnv(v === true)} />
+                  <Label htmlFor="rp-inc-env" className="font-normal">
+                    {t('step2.includeEnv')}
+                  </Label>
+                </div>
+                <div className="flex items-center gap-2">
+                  <Checkbox
+                    id="rp-inc-version"
+                    checked={includeVersion}
+                    onCheckedChange={(v) => setIncludeVersion(v === true)}
+                  />
+                  <Label htmlFor="rp-inc-version" className="font-normal">
+                    {t('step2.includeVersion', { version: APP_VERSION })}
+                  </Label>
+                </div>
+              </div>
+
+              <div className="flex items-start gap-2 rounded-md border bg-muted/40 px-3 py-2 text-xs text-muted-foreground">
+                <ShieldCheck className="mt-0.5 size-4 shrink-0 text-primary" aria-hidden />
+                <div className="space-y-1">
+                  <p>{t('step2.privacyNote')}</p>
+                  <Popover>
+                    <PopoverTrigger className="font-medium text-foreground underline underline-offset-2 hover:text-primary">
+                      {t('step2.privacyMore')}
+                    </PopoverTrigger>
+                    <PopoverContent side="top" className="w-72 text-xs">
+                      {t('step2.privacyDetail')}
+                    </PopoverContent>
+                  </Popover>
+                </div>
+              </div>
+            </>
+          )}
+
+          {step === 3 && (
+            <>
+              <div>
+                <h3 className="text-sm font-semibold">{t('step3.heading')}</h3>
+                <p className="mt-1 text-xs text-muted-foreground">{t('step3.subtitle')}</p>
+              </div>
+
+              <div className="space-y-2">
+                <Button className="w-full" onClick={handleOpenIssue}>
+                  <GitHubIcon className="size-4" />
+                  {t('step3.openIssue')}
+                </Button>
+                <Button variant="outline" className="w-full" onClick={handleCopy}>
+                  {t('step3.copyReport')}
+                </Button>
+              </div>
+            </>
+          )}
+        </div>
+
+        <SheetFooter className="flex-row items-center justify-between gap-2 border-t">
+          <div>
+            {step > 1 && (
+              <Button variant="ghost" size="sm" onClick={() => setStep((s) => s - 1)}>
+                {t('nav.back')}
+              </Button>
+            )}
+          </div>
+          <div className="flex gap-2">
+            <Button variant="outline" size="sm" onClick={() => onOpenChange(false)}>
+              {t('nav.cancel')}
+            </Button>
+            {step < TOTAL_STEPS && (
+              <Button size="sm" onClick={() => setStep((s) => s + 1)} disabled={step === 1 && !description.trim()}>
+                {t('nav.next')}
+              </Button>
+            )}
+          </div>
+        </SheetFooter>
+      </SheetContent>
+    </Sheet>
+  );
+}

--- a/frontend/src/components/report/__tests__/ReportProblemHost.test.tsx
+++ b/frontend/src/components/report/__tests__/ReportProblemHost.test.tsx
@@ -1,0 +1,41 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@/test/test-utils';
+import { ReportProblemHost } from '../ReportProblemHost';
+import { useAuthStore } from '@/stores/auth-store';
+import { clearReportEntries, pushReportEntry } from '@/lib/report';
+
+function signIn() {
+  useAuthStore.setState({ token: 'tok', refreshToken: 'r', expiresAt: Date.now() + 1_000_000, user: null });
+}
+
+beforeEach(() => {
+  clearReportEntries();
+  useAuthStore.setState({ token: null, refreshToken: null, expiresAt: null, user: null });
+});
+
+describe('ReportProblemHost', () => {
+  it('renders nothing for unauthenticated users', () => {
+    render(<ReportProblemHost />);
+    expect(screen.queryByRole('button', { name: 'Report a problem' })).toBeNull();
+  });
+
+  it('shows a quiet report button when authenticated', () => {
+    signIn();
+    render(<ReportProblemHost />);
+    expect(screen.getByRole('button', { name: 'Report a problem' })).toBeInTheDocument();
+  });
+
+  it('surfaces an error count badge when errors are captured', async () => {
+    signIn();
+    render(<ReportProblemHost />);
+    pushReportEntry({ severity: 'error', source: 'console', message: 'boom' });
+    expect(await screen.findByText('1')).toBeInTheDocument();
+  });
+
+  it('opens the report wizard when clicked', async () => {
+    signIn();
+    render(<ReportProblemHost />);
+    fireEvent.click(screen.getByRole('button', { name: 'Report a problem' }));
+    expect(await screen.findByText('What happened?')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/i18n/config.ts
+++ b/frontend/src/i18n/config.ts
@@ -13,6 +13,7 @@ export const namespaces = [
   'collections',
   'admin',
   'builder',
+  'report',
 ] as const;
 export type Namespace = (typeof namespaces)[number];
 

--- a/frontend/src/i18n/locales/de/report.json
+++ b/frontend/src/i18n/locales/de/report.json
@@ -1,0 +1,50 @@
+{
+  "button": {
+    "tooltip": "Ein Problem melden",
+    "aria": "Ein Problem melden",
+    "ariaWithCount": "Ein Problem melden ({{count}} Fehler erkannt)"
+  },
+  "title": "Ein Problem melden",
+  "description": "Sagen Sie uns, was schiefgelaufen ist — die technischen Details fügen wir für Sie hinzu.",
+  "stepIndicator": "Schritt {{current}} von {{total}}",
+  "noticed": "Erkannte Probleme: {{count}}. Die Details werden Ihrer Meldung beigefügt.",
+  "noticedNone": "Es wurde nichts automatisch erkannt — Ihre Beschreibung ist am wichtigsten.",
+  "technicalDetails": "Technische Details ({{count}})",
+  "technicalEmpty": "Es wurde noch nichts erfasst.",
+  "step1": {
+    "heading": "Was ist passiert?",
+    "areaLabel": "Wo ist das passiert?",
+    "titleLabel": "Kurze Zusammenfassung",
+    "titlePlaceholder": "z. B. Ebenen verschwinden beim Hineinzoomen",
+    "descriptionLabel": "Was ist schiefgelaufen?",
+    "descriptionPlaceholder": "Beschreiben Sie, was Sie gesehen haben…",
+    "stepsLabel": "Was haben Sie gerade getan?",
+    "stepsPlaceholder": "1. \n2. \n3. ",
+    "expectedLabel": "Was hatten Sie erwartet?",
+    "expectedPlaceholder": "z. B. Die Ebene sollte sichtbar bleiben"
+  },
+  "step2": {
+    "heading": "Prüfen Sie, was wir senden",
+    "subtitle": "Alles Folgende ist optional — entfernen Sie das Häkchen bei allem, was Sie nicht senden möchten.",
+    "includeErrors": "Erfasste Fehler ({{count}})",
+    "includePage": "Auf welcher Seite Sie sind",
+    "includeEnv": "Ihr Browser und Ihre Bildschirmgröße",
+    "includeVersion": "App-Version ({{version}})",
+    "privacyNote": "Wir entfernen automatisch Ihr Anmeldetoken und Ihre persönlichen Daten, bevor irgendetwas Ihren Browser verlässt.",
+    "privacyMore": "Was wird entfernt?",
+    "privacyDetail": "Anmeldetokens, API-Schlüssel und E-Mail-Adressen werden vor dem Senden aus der Meldung entfernt."
+  },
+  "step3": {
+    "heading": "Senden Sie Ihre Meldung",
+    "subtitle": "Wir öffnen ein vorausgefülltes GitHub-Issue. Prüfen Sie es und senden Sie es ab.",
+    "openIssue": "GitHub-Issue öffnen",
+    "copyReport": "Bericht kopieren",
+    "copied": "Bericht in die Zwischenablage kopiert",
+    "truncatedToast": "Die Protokolle waren zu lang für den Link — der vollständige Bericht wurde in Ihre Zwischenablage kopiert. Fügen Sie ihn in das Issue ein."
+  },
+  "nav": {
+    "back": "Zurück",
+    "next": "Weiter",
+    "cancel": "Abbrechen"
+  }
+}

--- a/frontend/src/i18n/locales/en/report.json
+++ b/frontend/src/i18n/locales/en/report.json
@@ -1,0 +1,50 @@
+{
+  "button": {
+    "tooltip": "Report a problem",
+    "aria": "Report a problem",
+    "ariaWithCount": "Report a problem ({{count}} errors detected)"
+  },
+  "title": "Report a problem",
+  "description": "Tell us what went wrong — we'll attach the technical details for you.",
+  "stepIndicator": "Step {{current}} of {{total}}",
+  "noticed": "Problems detected: {{count}}. The details will be attached to your report.",
+  "noticedNone": "Nothing was detected automatically — your description is what matters most.",
+  "technicalDetails": "Technical details ({{count}})",
+  "technicalEmpty": "Nothing has been captured yet.",
+  "step1": {
+    "heading": "What happened?",
+    "areaLabel": "Where did this happen?",
+    "titleLabel": "Short summary",
+    "titlePlaceholder": "e.g. Layers disappear when I zoom in",
+    "descriptionLabel": "What went wrong?",
+    "descriptionPlaceholder": "Describe what you saw…",
+    "stepsLabel": "What were you doing?",
+    "stepsPlaceholder": "1. \n2. \n3. ",
+    "expectedLabel": "What did you expect to happen?",
+    "expectedPlaceholder": "e.g. The layer should stay visible"
+  },
+  "step2": {
+    "heading": "Review what we'll send",
+    "subtitle": "Everything below is optional — uncheck anything you'd rather not include.",
+    "includeErrors": "Captured errors ({{count}})",
+    "includePage": "Which page you're on",
+    "includeEnv": "Your browser and screen size",
+    "includeVersion": "App version ({{version}})",
+    "privacyNote": "We automatically remove your login token and personal info before anything leaves your browser.",
+    "privacyMore": "What gets removed?",
+    "privacyDetail": "Login tokens, API keys, and email addresses are stripped from the report before it is sent."
+  },
+  "step3": {
+    "heading": "Send your report",
+    "subtitle": "We'll open a pre-filled GitHub issue. Review it, then submit.",
+    "openIssue": "Open a GitHub issue",
+    "copyReport": "Copy report",
+    "copied": "Report copied to clipboard",
+    "truncatedToast": "The logs were too long for the link — the full report was copied to your clipboard. Paste it into the issue."
+  },
+  "nav": {
+    "back": "Back",
+    "next": "Next",
+    "cancel": "Cancel"
+  }
+}

--- a/frontend/src/i18n/locales/es/report.json
+++ b/frontend/src/i18n/locales/es/report.json
@@ -1,0 +1,50 @@
+{
+  "button": {
+    "tooltip": "Informar de un problema",
+    "aria": "Informar de un problema",
+    "ariaWithCount": "Informar de un problema ({{count}} errores detectados)"
+  },
+  "title": "Informar de un problema",
+  "description": "Cuéntanos qué ha fallado: adjuntaremos los detalles técnicos por ti.",
+  "stepIndicator": "Paso {{current}} de {{total}}",
+  "noticed": "Problemas detectados: {{count}}. Los detalles se adjuntarán a tu informe.",
+  "noticedNone": "No se detectó nada automáticamente: lo que más importa es tu descripción.",
+  "technicalDetails": "Detalles técnicos ({{count}})",
+  "technicalEmpty": "Todavía no se ha capturado nada.",
+  "step1": {
+    "heading": "¿Qué ha ocurrido?",
+    "areaLabel": "¿Dónde ha ocurrido?",
+    "titleLabel": "Resumen breve",
+    "titlePlaceholder": "p. ej. Las capas desaparecen al acercar el zoom",
+    "descriptionLabel": "¿Qué ha fallado?",
+    "descriptionPlaceholder": "Describe lo que has visto…",
+    "stepsLabel": "¿Qué estabas haciendo?",
+    "stepsPlaceholder": "1. \n2. \n3. ",
+    "expectedLabel": "¿Qué esperabas que ocurriera?",
+    "expectedPlaceholder": "p. ej. La capa debería seguir visible"
+  },
+  "step2": {
+    "heading": "Revisa lo que vamos a enviar",
+    "subtitle": "Todo lo siguiente es opcional: desmarca lo que prefieras no incluir.",
+    "includeErrors": "Errores capturados ({{count}})",
+    "includePage": "En qué página estás",
+    "includeEnv": "Tu navegador y tamaño de pantalla",
+    "includeVersion": "Versión de la app ({{version}})",
+    "privacyNote": "Eliminamos automáticamente tu token de inicio de sesión y tus datos personales antes de que nada salga de tu navegador.",
+    "privacyMore": "¿Qué se elimina?",
+    "privacyDetail": "Los tokens de inicio de sesión, las claves de API y las direcciones de correo se eliminan del informe antes de enviarlo."
+  },
+  "step3": {
+    "heading": "Envía tu informe",
+    "subtitle": "Abriremos una incidencia de GitHub ya rellenada. Revísala y envíala.",
+    "openIssue": "Abrir una incidencia en GitHub",
+    "copyReport": "Copiar informe",
+    "copied": "Informe copiado al portapapeles",
+    "truncatedToast": "Los registros eran demasiado largos para el enlace: el informe completo se copió a tu portapapeles. Pégalo en la incidencia."
+  },
+  "nav": {
+    "back": "Atrás",
+    "next": "Siguiente",
+    "cancel": "Cancelar"
+  }
+}

--- a/frontend/src/i18n/locales/fr/report.json
+++ b/frontend/src/i18n/locales/fr/report.json
@@ -1,0 +1,50 @@
+{
+  "button": {
+    "tooltip": "Signaler un problème",
+    "aria": "Signaler un problème",
+    "ariaWithCount": "Signaler un problème ({{count}} erreurs détectées)"
+  },
+  "title": "Signaler un problème",
+  "description": "Dites-nous ce qui n'a pas fonctionné — nous joindrons les détails techniques pour vous.",
+  "stepIndicator": "Étape {{current}} sur {{total}}",
+  "noticed": "Problèmes détectés : {{count}}. Les détails seront joints à votre signalement.",
+  "noticedNone": "Rien n'a été détecté automatiquement — c'est votre description qui compte le plus.",
+  "technicalDetails": "Détails techniques ({{count}})",
+  "technicalEmpty": "Rien n'a encore été capturé.",
+  "step1": {
+    "heading": "Que s'est-il passé ?",
+    "areaLabel": "Où cela s'est-il produit ?",
+    "titleLabel": "Résumé court",
+    "titlePlaceholder": "ex. Les couches disparaissent quand je zoome",
+    "descriptionLabel": "Qu'est-ce qui n'a pas fonctionné ?",
+    "descriptionPlaceholder": "Décrivez ce que vous avez vu…",
+    "stepsLabel": "Que faisiez-vous ?",
+    "stepsPlaceholder": "1. \n2. \n3. ",
+    "expectedLabel": "À quoi vous attendiez-vous ?",
+    "expectedPlaceholder": "ex. La couche devrait rester visible"
+  },
+  "step2": {
+    "heading": "Vérifiez ce que nous allons envoyer",
+    "subtitle": "Tout ce qui suit est facultatif — décochez ce que vous préférez ne pas inclure.",
+    "includeErrors": "Erreurs capturées ({{count}})",
+    "includePage": "La page sur laquelle vous êtes",
+    "includeEnv": "Votre navigateur et la taille de l'écran",
+    "includeVersion": "Version de l'application ({{version}})",
+    "privacyNote": "Nous supprimons automatiquement votre jeton de connexion et vos informations personnelles avant que quoi que ce soit ne quitte votre navigateur.",
+    "privacyMore": "Qu'est-ce qui est supprimé ?",
+    "privacyDetail": "Les jetons de connexion, les clés d'API et les adresses e-mail sont retirés du rapport avant son envoi."
+  },
+  "step3": {
+    "heading": "Envoyez votre signalement",
+    "subtitle": "Nous ouvrirons un ticket GitHub pré-rempli. Vérifiez-le, puis envoyez-le.",
+    "openIssue": "Ouvrir un ticket GitHub",
+    "copyReport": "Copier le rapport",
+    "copied": "Rapport copié dans le presse-papiers",
+    "truncatedToast": "Les journaux étaient trop longs pour le lien — le rapport complet a été copié dans votre presse-papiers. Collez-le dans le ticket."
+  },
+  "nav": {
+    "back": "Retour",
+    "next": "Suivant",
+    "cancel": "Annuler"
+  }
+}

--- a/frontend/src/lib/report/__tests__/build-issue.test.ts
+++ b/frontend/src/lib/report/__tests__/build-issue.test.ts
@@ -65,6 +65,37 @@ describe('buildIssueUrl', () => {
     expect(url).not.toContain('context=');
     expect(url).toContain('description=D');
   });
+
+  it('redacts secrets pasted into the user-provided fields', () => {
+    const { url } = buildIssueUrl({
+      title: 'crash',
+      description: 'failing call api_key=PASTEDSECRET happened',
+      steps: '',
+      expected: '',
+      area: 'Other',
+      version: '',
+      context: '',
+    });
+    const decoded = decodeURIComponent(url);
+    expect(decoded).not.toContain('PASTEDSECRET');
+    expect(decoded).toContain('api_key=[redacted]');
+  });
+
+  it('stays under the limit even when the user text alone is too long', () => {
+    const huge = 'A'.repeat(9000);
+    const { url, truncated } = buildIssueUrl({
+      title: 'T',
+      description: huge,
+      steps: '',
+      expected: '',
+      area: 'Other',
+      version: '',
+      context: '',
+    });
+    expect(truncated).toBe(true);
+    expect(url.length).toBeLessThanOrEqual(7000);
+    expect(url).toContain('template=bug_report.yml');
+  });
 });
 
 describe('buildContext', () => {

--- a/frontend/src/lib/report/__tests__/build-issue.test.ts
+++ b/frontend/src/lib/report/__tests__/build-issue.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect } from 'vitest';
+import {
+  buildClipboardReport,
+  buildContext,
+  buildIssueUrl,
+  mapAreaFromPath,
+  summarizeEntries,
+} from '../build-issue';
+import type { ReportEntry } from '../report-buffer';
+
+function entry(partial: Partial<ReportEntry> = {}): ReportEntry {
+  return { id: '1', ts: 0, severity: 'error', source: 'console', message: 'x', count: 1, ...partial };
+}
+
+describe('mapAreaFromPath', () => {
+  it('maps map routes to Map Builder', () => {
+    expect(mapAreaFromPath('/maps/abc123')).toBe('Map Builder');
+  });
+  it('maps share routes to Sharing / Embed', () => {
+    expect(mapAreaFromPath('/m/sometoken')).toBe('Sharing / Embed');
+  });
+  it('maps the catalog root to Search / Catalog', () => {
+    expect(mapAreaFromPath('/')).toBe('Search / Catalog');
+  });
+  it('falls back to Other', () => {
+    expect(mapAreaFromPath('/settings')).toBe('Other');
+  });
+});
+
+describe('buildIssueUrl', () => {
+  it('prefills GitHub Issue Form field ids, never &body=', () => {
+    const { url, truncated } = buildIssueUrl({
+      title: 'T',
+      description: 'D',
+      steps: 'S',
+      expected: 'E',
+      area: 'Map Builder',
+      version: '2.0.0',
+      context: 'C',
+    });
+    expect(truncated).toBe(false);
+    expect(url).toContain('template=bug_report.yml');
+    expect(url).toContain('title=T');
+    expect(url).toContain('description=D');
+    expect(url).toContain('steps=S');
+    expect(url).toContain('expected=E');
+    expect(url).toContain('area=Map+Builder');
+    expect(url).toContain('version=2.0.0');
+    expect(url).toContain('context=C');
+    expect(url).not.toContain('body=');
+  });
+
+  it('drops the context block and flags truncation when the URL is too long', () => {
+    const context = 'x'.repeat(9000);
+    const { url, truncated } = buildIssueUrl({
+      title: 'T',
+      description: 'D',
+      steps: '',
+      expected: '',
+      area: 'Other',
+      version: '',
+      context,
+    });
+    expect(truncated).toBe(true);
+    expect(url).not.toContain('context=');
+    expect(url).toContain('description=D');
+  });
+});
+
+describe('buildContext', () => {
+  it('redacts credentials in the page URL', () => {
+    const ctx = buildContext({
+      entries: [],
+      includeErrors: false,
+      includeEnv: false,
+      includePage: true,
+      pageUrl: 'https://app.example/maps/1?api_key=SUPERSECRET',
+      userAgent: '',
+      screen: '',
+      language: 'en',
+    });
+    expect(ctx).not.toContain('SUPERSECRET');
+    expect(ctx).toContain('[redacted]');
+  });
+
+  it('includes a captured-signals table when errors are present', () => {
+    const ctx = buildContext({
+      entries: [entry({ message: 'kaboom', source: 'maplibre' })],
+      includeErrors: true,
+      includeEnv: false,
+      includePage: false,
+      pageUrl: '',
+      userAgent: '',
+      screen: '',
+      language: 'en',
+    });
+    expect(ctx).toContain('Captured signals');
+    expect(ctx).toContain('kaboom');
+    expect(ctx).toContain('maplibre');
+  });
+
+  it('omits the signals table when includeErrors is off', () => {
+    const ctx = buildContext({
+      entries: [entry({ message: 'hidden' })],
+      includeErrors: false,
+      includeEnv: false,
+      includePage: false,
+      pageUrl: '',
+      userAgent: '',
+      screen: '',
+      language: 'en',
+    });
+    expect(ctx).not.toContain('hidden');
+  });
+});
+
+describe('summarizeEntries', () => {
+  it('returns a placeholder when there are no entries', () => {
+    expect(summarizeEntries([])).toContain('No console');
+  });
+  it('marks suppressed entries and collapses counts', () => {
+    const summary = summarizeEntries([entry({ message: 'tile 404', suppressed: true, count: 3 })]);
+    expect(summary).toContain('(suppressed)');
+    expect(summary).toContain('×3');
+  });
+});
+
+describe('buildClipboardReport', () => {
+  it('assembles a full markdown report', () => {
+    const md = buildClipboardReport({
+      title: 'Bug',
+      description: 'D',
+      steps: 'S',
+      expected: 'E',
+      area: 'Map Builder',
+      version: '2.0.0',
+      context: 'CTX',
+    });
+    expect(md).toContain('# Bug');
+    expect(md).toContain('Map Builder');
+    expect(md).toContain('## Describe the bug');
+    expect(md).toContain('## Steps to reproduce');
+    expect(md).toContain('CTX');
+  });
+});

--- a/frontend/src/lib/report/__tests__/redact.test.ts
+++ b/frontend/src/lib/report/__tests__/redact.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest';
+import { redact } from '../redact';
+
+const SAMPLE_JWT =
+  'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c';
+
+describe('redact', () => {
+  it('strips JWTs', () => {
+    expect(redact(SAMPLE_JWT)).toBe('[redacted-token]');
+    expect(redact(`Authorization header carried ${SAMPLE_JWT} oops`)).not.toContain(SAMPLE_JWT);
+  });
+
+  it('strips Authorization: Bearer tokens', () => {
+    expect(redact('Authorization: Bearer abc.def-ghi123')).toContain('Bearer [redacted]');
+  });
+
+  it('strips key=value credentials with or without a query separator', () => {
+    expect(redact('https://x/y?api_key=supersecret&z=1')).not.toContain('supersecret');
+    expect(redact('request failed api_key=supersecret')).toContain('api_key=[redacted]');
+    expect(redact('access_token=abc123def')).toContain('access_token=[redacted]');
+  });
+
+  it('strips JSON-style secret fields', () => {
+    expect(redact('{"password":"hunter2","ok":true}')).not.toContain('hunter2');
+  });
+
+  it('strips unquoted / object-literal secret fields', () => {
+    expect(redact('{ token: "secret_token_123", apiKey: "key_456" }')).not.toContain('secret_token_123');
+    expect(redact('{ token: "secret_token_123", apiKey: "key_456" }')).not.toContain('key_456');
+  });
+
+  it('strips signed-tile sig= parameters', () => {
+    const out = redact('/api/tiles/data.table/3/2/1.pbf?sig=abc123HMACxyz&exp=1700000000&scope=Dataset:1');
+    expect(out).not.toContain('abc123HMACxyz');
+    expect(out).toContain('sig=[redacted]');
+  });
+
+  it('strips session identifiers', () => {
+    expect(redact('JSESSIONID=ABC123DEF456GHI')).not.toContain('ABC123DEF456GHI');
+    expect(redact('session_id=secretvalue')).not.toContain('secretvalue');
+  });
+
+  it('strips share/embed tokens that live in the URL path', () => {
+    const out = redact('https://geolens.io/m/2fXkR9m3pL8qW4vN7tY');
+    expect(out).not.toContain('2fXkR9m3pL8qW4vN7tY');
+    expect(out).toContain('/m/[redacted]');
+  });
+
+  it('does not redact the /maps/:id builder route', () => {
+    expect(redact('https://geolens.io/maps/42')).toContain('/maps/42');
+  });
+
+  it('strips email addresses', () => {
+    expect(redact('contact jane.doe@example.com please')).toContain('[redacted-email]');
+  });
+
+  it('does not over-redact unrelated key names', () => {
+    expect(redact('csrf_token=keepme')).toContain('keepme');
+  });
+
+  it('coerces non-string input safely', () => {
+    expect(redact(null)).toBe('');
+    expect(redact(undefined)).toBe('');
+    expect(redact(42)).toBe('42');
+  });
+});

--- a/frontend/src/lib/report/__tests__/redact.test.ts
+++ b/frontend/src/lib/report/__tests__/redact.test.ts
@@ -24,6 +24,13 @@ describe('redact', () => {
     expect(redact('{"password":"hunter2","ok":true}')).not.toContain('hunter2');
   });
 
+  it('strips the full quoted value even when it contains spaces', () => {
+    expect(redact('password="correct horse battery staple"')).toBe('password="[redacted]"');
+    expect(redact("token: 'a b c d e'")).not.toContain('a b c d e');
+    // surrounding text must survive
+    expect(redact('{"password":"correct horse","ok":true}')).toContain('"ok":true');
+  });
+
   it('strips unquoted / object-literal secret fields', () => {
     expect(redact('{ token: "secret_token_123", apiKey: "key_456" }')).not.toContain('secret_token_123');
     expect(redact('{ token: "secret_token_123", apiKey: "key_456" }')).not.toContain('key_456');

--- a/frontend/src/lib/report/__tests__/report-buffer.test.ts
+++ b/frontend/src/lib/report/__tests__/report-buffer.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  clearReportEntries,
+  getReportEntries,
+  pushReportEntry,
+  reportNetworkError,
+} from '../report-buffer';
+
+beforeEach(() => {
+  clearReportEntries();
+});
+
+describe('report buffer', () => {
+  it('stores entries newest-first', () => {
+    pushReportEntry({ severity: 'error', source: 'console', message: 'first' });
+    pushReportEntry({ severity: 'warning', source: 'console', message: 'second' });
+    const entries = getReportEntries();
+    expect(entries).toHaveLength(2);
+    expect(entries[0].message).toBe('second');
+  });
+
+  it('collapses consecutive duplicates into a count', () => {
+    pushReportEntry({ severity: 'error', source: 'console', message: 'dup' });
+    pushReportEntry({ severity: 'error', source: 'console', message: 'dup' });
+    const entries = getReportEntries();
+    expect(entries).toHaveLength(1);
+    expect(entries[0].count).toBe(2);
+  });
+
+  it('does not collapse across different sources', () => {
+    pushReportEntry({ severity: 'error', source: 'console', message: 'same' });
+    pushReportEntry({ severity: 'error', source: 'network', message: 'same' });
+    expect(getReportEntries()).toHaveLength(2);
+  });
+
+  it('redacts credentials at capture time', () => {
+    pushReportEntry({ severity: 'error', source: 'network', message: 'failed api_key=SUPERSECRET' });
+    expect(getReportEntries()[0].message).not.toContain('SUPERSECRET');
+  });
+
+  it('caps the buffer at 200 entries', () => {
+    for (let i = 0; i < 250; i += 1) {
+      pushReportEntry({ severity: 'info', source: 'console', message: `m${i}` });
+    }
+    expect(getReportEntries().length).toBeLessThanOrEqual(200);
+  });
+
+  it('classifies network severity by status', () => {
+    reportNetworkError({ status: 503 });
+    reportNetworkError({ status: 404 });
+    reportNetworkError({ status: 0 });
+    const [offline, notFound, serverError] = getReportEntries();
+    expect(offline.severity).toBe('error'); // status 0
+    expect(notFound.severity).toBe('warning'); // 4xx
+    expect(serverError.severity).toBe('error'); // 5xx
+  });
+});

--- a/frontend/src/lib/report/build-issue.ts
+++ b/frontend/src/lib/report/build-issue.ts
@@ -1,0 +1,187 @@
+// Assembles a captured report into a pre-filled GitHub issue.
+//
+// The repo's bug template (.github/ISSUE_TEMPLATE/bug_report.yml) is a GitHub
+// *Issue Form*. Issue Forms ignore the legacy &body= param — fields prefill
+// ONLY by query params matching their field ids (description / steps / expected
+// / area / version / context). &title= still sets the issue title. Get this
+// wrong and the form opens blank.
+//
+// GitHub caps issue-create URLs (~8KB before the server rejects). We keep the
+// link comfortably under that; if the technical context pushes it over, we drop
+// &context= from the link and the caller copies the full report to the clipboard
+// instead, so the link always opens.
+
+import { GEOLENS_BUG_REPORT_URL } from '@/lib/external-links';
+import { redact } from './redact';
+import type { ReportEntry } from './report-buffer';
+
+/** Exact option strings from the bug_report.yml `area` dropdown. */
+export const ISSUE_AREAS = [
+  'Search / Catalog',
+  'Dataset Detail',
+  'Map Builder',
+  'Collections',
+  'Import / Ingestion',
+  'Admin Panel',
+  'Sharing / Embed',
+  'Tiles / Rendering',
+  'Auth / Permissions',
+  'API / OGC',
+  'Other',
+] as const;
+export type IssueArea = (typeof ISSUE_AREAS)[number];
+
+/** Keep the deep link well under GitHub's ~8KB ceiling. */
+const MAX_URL_LENGTH = 7000;
+
+const SEVERITY_ICON: Record<ReportEntry['severity'], string> = {
+  error: '🔴',
+  warning: '🟡',
+  info: '🔵',
+};
+
+/** Best-effort default for the Area dropdown from the current route. */
+export function mapAreaFromPath(pathname: string): IssueArea {
+  const path = pathname.toLowerCase();
+  if (path.startsWith('/m/')) return 'Sharing / Embed';
+  if (path.startsWith('/maps')) return 'Map Builder';
+  if (path.startsWith('/datasets')) return 'Dataset Detail';
+  if (path.startsWith('/collections')) return 'Collections';
+  if (path.startsWith('/import')) return 'Import / Ingestion';
+  if (path.startsWith('/admin')) return 'Admin Panel';
+  if (path.startsWith('/settings')) return 'Other';
+  if (path === '/' || path.startsWith('/search')) return 'Search / Catalog';
+  return 'Other';
+}
+
+function escapePipes(text: string): string {
+  return text.replace(/\|/g, '\\|').replace(/\n/g, ' ');
+}
+
+/** Human-readable markdown table of the most recent captured entries. */
+export function summarizeEntries(entries: ReportEntry[], limit = 12): string {
+  if (entries.length === 0) {
+    return '_No console, network, or map errors were captured automatically._';
+  }
+  const rows = entries.slice(0, limit).map((entry) => {
+    const count = entry.count > 1 ? ` ×${entry.count}` : '';
+    const flag = entry.suppressed ? ' _(suppressed)_' : '';
+    return `| ${SEVERITY_ICON[entry.severity]} | \`${entry.source}\` | ${escapePipes(entry.message)}${count}${flag} |`;
+  });
+  const more =
+    entries.length > limit ? `\n\n_…and ${entries.length - limit} more captured ${entries.length - limit === 1 ? 'entry' : 'entries'}._` : '';
+  return `| | Source | Message |\n| --- | --- | --- |\n${rows.join('\n')}${more}`;
+}
+
+function entriesDetailBlock(entries: ReportEntry[], limit = 30): string {
+  return entries
+    .slice(0, limit)
+    .map((entry) => {
+      const count = entry.count > 1 ? ` ×${entry.count}` : '';
+      const flag = entry.suppressed ? ' (suppressed)' : '';
+      const head = `[${entry.severity}] (${entry.source}) ${entry.message}${count}${flag}`;
+      return entry.detail ? `${head}\n${entry.detail}` : head;
+    })
+    .join('\n\n');
+}
+
+export interface ReportContextOptions {
+  entries: ReportEntry[];
+  includeErrors: boolean;
+  includeEnv: boolean;
+  includePage: boolean;
+  pageUrl: string;
+  userAgent: string;
+  screen: string;
+  language: string;
+}
+
+/** Builds the markdown for the issue's "Additional context" field. */
+export function buildContext(options: ReportContextOptions): string {
+  const env: string[] = [];
+  if (options.includePage && options.pageUrl) {
+    env.push(`- **Page:** ${redact(options.pageUrl)}`);
+  }
+  if (options.includeEnv) {
+    if (options.userAgent) env.push(`- **Browser:** ${options.userAgent}`);
+    if (options.screen) env.push(`- **Viewport:** ${options.screen}`);
+    if (options.language) env.push(`- **Language:** ${options.language}`);
+  }
+
+  const parts: string[] = [];
+  if (env.length) parts.push(env.join('\n'));
+
+  if (options.includeErrors && options.entries.length) {
+    parts.push(`**Captured signals (${options.entries.length})**\n\n${summarizeEntries(options.entries)}`);
+    const detail = entriesDetailBlock(options.entries);
+    if (detail) {
+      parts.push(`<details>\n<summary>Full technical detail</summary>\n\n\`\`\`\n${detail}\n\`\`\`\n</details>`);
+    }
+  }
+
+  return parts.join('\n\n');
+}
+
+export interface BuildIssueParams {
+  title: string;
+  description: string;
+  steps: string;
+  expected: string;
+  area: string;
+  version: string;
+  context: string;
+  baseUrl?: string;
+}
+
+/**
+ * Build the pre-filled GitHub Issue Form URL. Returns `truncated: true` when the
+ * context block had to be dropped to keep the URL under GitHub's limit — the
+ * caller should then copy the full report to the clipboard.
+ */
+export function buildIssueUrl(params: BuildIssueParams): { url: string; truncated: boolean } {
+  const base = params.baseUrl ?? GEOLENS_BUG_REPORT_URL;
+
+  const compose = (includeContext: boolean): string => {
+    const search = new URLSearchParams();
+    if (params.title) search.set('title', params.title);
+    if (params.description) search.set('description', params.description);
+    if (params.steps) search.set('steps', params.steps);
+    if (params.expected) search.set('expected', params.expected);
+    if (params.area) search.set('area', params.area);
+    if (params.version) search.set('version', params.version);
+    if (includeContext && params.context) search.set('context', params.context);
+    // base already carries `?template=bug_report.yml`, so append with `&`.
+    return `${base}&${search.toString()}`;
+  };
+
+  const full = compose(true);
+  if (full.length <= MAX_URL_LENGTH) {
+    return { url: full, truncated: false };
+  }
+  return { url: compose(false), truncated: true };
+}
+
+export interface ClipboardReportParams {
+  title: string;
+  description: string;
+  steps: string;
+  expected: string;
+  area: string;
+  version: string;
+  context: string;
+}
+
+/** Full markdown report for the "Copy report" action and the truncation fallback. */
+export function buildClipboardReport(params: ClipboardReportParams): string {
+  const sections: string[] = [];
+  sections.push(`# ${params.title || 'Bug report'}`);
+  const meta: string[] = [];
+  if (params.area) meta.push(`**Area:** ${params.area}`);
+  if (params.version) meta.push(`**GeoLens version:** ${params.version}`);
+  if (meta.length) sections.push(meta.join('  \n'));
+  if (params.description) sections.push(`## Describe the bug\n\n${params.description}`);
+  if (params.steps) sections.push(`## Steps to reproduce\n\n${params.steps}`);
+  if (params.expected) sections.push(`## Expected behavior\n\n${params.expected}`);
+  if (params.context) sections.push(`## Additional context\n\n${params.context}`);
+  return sections.join('\n\n');
+}

--- a/frontend/src/lib/report/build-issue.ts
+++ b/frontend/src/lib/report/build-issue.ts
@@ -141,24 +141,42 @@ export interface BuildIssueParams {
 export function buildIssueUrl(params: BuildIssueParams): { url: string; truncated: boolean } {
   const base = params.baseUrl ?? GEOLENS_BUG_REPORT_URL;
 
-  const compose = (includeContext: boolean): string => {
+  // Scrub the user's OWN typed fields too — a token/email pasted into the
+  // description must not reach the public issue URL. The captured-entry and
+  // page-URL redaction doesn't cover free text, but the privacy note promises
+  // it does, so run these through redact() as well.
+  const title = redact(params.title);
+  const description = redact(params.description);
+  const steps = redact(params.steps);
+  const expected = redact(params.expected);
+
+  // Progressively shed payload until the URL fits under GitHub's ceiling:
+  // level 0 = everything, 1 = drop context, 2 = drop the long free-text fields.
+  // If even the minimal form is too long, fall back to the bare template URL.
+  // Whenever anything is shed, `truncated` tells the caller to copy the full
+  // report to the clipboard instead — so the link ALWAYS opens.
+  const compose = (level: 0 | 1 | 2): string => {
     const search = new URLSearchParams();
-    if (params.title) search.set('title', params.title);
-    if (params.description) search.set('description', params.description);
-    if (params.steps) search.set('steps', params.steps);
-    if (params.expected) search.set('expected', params.expected);
+    if (title) search.set('title', title);
     if (params.area) search.set('area', params.area);
     if (params.version) search.set('version', params.version);
-    if (includeContext && params.context) search.set('context', params.context);
+    if (level < 2) {
+      if (description) search.set('description', description);
+      if (steps) search.set('steps', steps);
+      if (expected) search.set('expected', expected);
+    }
+    if (level < 1 && params.context) search.set('context', params.context);
     // base already carries `?template=bug_report.yml`, so append with `&`.
     return `${base}&${search.toString()}`;
   };
 
-  const full = compose(true);
-  if (full.length <= MAX_URL_LENGTH) {
-    return { url: full, truncated: false };
-  }
-  return { url: compose(false), truncated: true };
+  const full = compose(0);
+  if (full.length <= MAX_URL_LENGTH) return { url: full, truncated: false };
+  const withoutContext = compose(1);
+  if (withoutContext.length <= MAX_URL_LENGTH) return { url: withoutContext, truncated: true };
+  const minimal = compose(2);
+  if (minimal.length <= MAX_URL_LENGTH) return { url: minimal, truncated: true };
+  return { url: base, truncated: true };
 }
 
 export interface ClipboardReportParams {
@@ -173,15 +191,17 @@ export interface ClipboardReportParams {
 
 /** Full markdown report for the "Copy report" action and the truncation fallback. */
 export function buildClipboardReport(params: ClipboardReportParams): string {
+  // User-typed fields are scrubbed here too (the clipboard report is shared as
+  // well); context is already redacted at build time.
   const sections: string[] = [];
-  sections.push(`# ${params.title || 'Bug report'}`);
+  sections.push(`# ${redact(params.title) || 'Bug report'}`);
   const meta: string[] = [];
   if (params.area) meta.push(`**Area:** ${params.area}`);
   if (params.version) meta.push(`**GeoLens version:** ${params.version}`);
   if (meta.length) sections.push(meta.join('  \n'));
-  if (params.description) sections.push(`## Describe the bug\n\n${params.description}`);
-  if (params.steps) sections.push(`## Steps to reproduce\n\n${params.steps}`);
-  if (params.expected) sections.push(`## Expected behavior\n\n${params.expected}`);
+  if (params.description) sections.push(`## Describe the bug\n\n${redact(params.description)}`);
+  if (params.steps) sections.push(`## Steps to reproduce\n\n${redact(params.steps)}`);
+  if (params.expected) sections.push(`## Expected behavior\n\n${redact(params.expected)}`);
   if (params.context) sections.push(`## Additional context\n\n${params.context}`);
   return sections.join('\n\n');
 }

--- a/frontend/src/lib/report/capture.ts
+++ b/frontend/src/lib/report/capture.ts
@@ -1,0 +1,81 @@
+// Global capture installer for the in-app problem reporter.
+//
+// Patches console.error / console.warn (preserving the original devtools output)
+// and adds window 'error' / 'unhandledrejection' listeners — the two signal
+// sources that have no existing hook in the codebase. The other sources
+// (TanStack Query failures, MapLibre errors, React error boundaries) push into
+// the buffer from their own call sites.
+//
+// Idempotent: safe to call multiple times (StrictMode, Vite HMR re-exec).
+
+import { pushReportEntry } from './report-buffer';
+
+let installed = false;
+
+function formatArgs(args: unknown[]): string {
+  return args
+    .map((arg) => {
+      if (typeof arg === 'string') return arg;
+      if (arg instanceof Error) return arg.message;
+      try {
+        return JSON.stringify(arg);
+      } catch {
+        return String(arg);
+      }
+    })
+    .join(' ')
+    .trim();
+}
+
+function firstStack(args: unknown[]): string | undefined {
+  const err = args.find((arg): arg is Error => arg instanceof Error);
+  return err?.stack;
+}
+
+export function initReportCapture(): void {
+  if (installed || typeof window === 'undefined') return;
+  installed = true;
+
+  // Intercept console.error/warn so they feed the report buffer while still
+  // printing to devtools as usual.
+  const originalError = console.error.bind(console);
+  const originalWarn = console.warn.bind(console);
+
+  console.error = (...args: unknown[]) => {
+    originalError(...args);
+    pushReportEntry({
+      severity: 'error',
+      source: 'console',
+      message: formatArgs(args) || 'console.error',
+      detail: firstStack(args),
+    });
+  };
+
+  console.warn = (...args: unknown[]) => {
+    originalWarn(...args);
+    pushReportEntry({
+      severity: 'warning',
+      source: 'console',
+      message: formatArgs(args) || 'console.warn',
+    });
+  };
+
+  window.addEventListener('error', (event: ErrorEvent) => {
+    pushReportEntry({
+      severity: 'error',
+      source: 'runtime',
+      message: event.message || event.error?.message || 'Uncaught error',
+      detail: event.error?.stack,
+    });
+  });
+
+  window.addEventListener('unhandledrejection', (event: PromiseRejectionEvent) => {
+    const reason = event.reason;
+    pushReportEntry({
+      severity: 'error',
+      source: 'runtime',
+      message: reason instanceof Error ? reason.message : `Unhandled rejection: ${String(reason)}`,
+      detail: reason instanceof Error ? reason.stack : undefined,
+    });
+  });
+}

--- a/frontend/src/lib/report/index.ts
+++ b/frontend/src/lib/report/index.ts
@@ -1,0 +1,29 @@
+export { redact } from './redact';
+export {
+  pushReportEntry,
+  reportNetworkError,
+  clearReportEntries,
+  getReportEntries,
+  useReportEntries,
+} from './report-buffer';
+export type {
+  ReportEntry,
+  ReportEntryInput,
+  ReportSeverity,
+  ReportSource,
+} from './report-buffer';
+export { initReportCapture } from './capture';
+export {
+  ISSUE_AREAS,
+  mapAreaFromPath,
+  summarizeEntries,
+  buildContext,
+  buildIssueUrl,
+  buildClipboardReport,
+} from './build-issue';
+export type {
+  IssueArea,
+  ReportContextOptions,
+  BuildIssueParams,
+  ClipboardReportParams,
+} from './build-issue';

--- a/frontend/src/lib/report/redact.ts
+++ b/frontend/src/lib/report/redact.ts
@@ -48,12 +48,20 @@ const RULES: RedactionRule[] = [
   // would otherwise leak the part after the space.
   { pattern: /Bearer\s+[A-Za-z0-9._~+/=-]+/gi, replacement: 'Bearer [redacted]' },
   { pattern: /Basic\s+[A-Za-z0-9+/=]+/gi, replacement: 'Basic [redacted]' },
-  // <sensitive-key>=value or <sensitive-key>: value (value optionally quoted).
-  // The \b before the key keeps `token=` from matching the tail of unrelated
-  // keys like csrf_token=; alternation order lets access_token/signature win
-  // over their token/sig prefixes.
+  // <sensitive-key> = "quoted value" / : 'quoted value' — redact the WHOLE
+  // quoted value, which may contain spaces (e.g. a passphrase or JSON string).
+  // Must run before the unquoted rule. Group 3 captures the quote char so the
+  // matching closing quote is preserved.
   {
-    pattern: new RegExp(`\\b(${SENSITIVE_KEYS})(["']?\\s*[:=]\\s*["']?)[^\\s"'\`&,}\\])]+`, 'gi'),
+    pattern: new RegExp(`\\b(${SENSITIVE_KEYS})(["']?\\s*[:=]\\s*)(["'])(?:\\\\.|(?!\\3).)*\\3`, 'gi'),
+    replacement: '$1$2$3[redacted]$3',
+  },
+  // <sensitive-key>=value (unquoted: query strings, log lines). The \b before
+  // the key keeps `token=` from matching the tail of unrelated keys like
+  // csrf_token=; alternation order lets access_token/signature win over their
+  // token/sig prefixes.
+  {
+    pattern: new RegExp(`\\b(${SENSITIVE_KEYS})(["']?\\s*[:=]\\s*)[^\\s"'\`&,}\\])]+`, 'gi'),
     replacement: '$1$2[redacted]',
   },
   // Share / embed tokens that live in the URL PATH, not a query param:

--- a/frontend/src/lib/report/redact.ts
+++ b/frontend/src/lib/report/redact.ts
@@ -1,0 +1,81 @@
+// Capture-time redaction for the in-app problem reporter.
+//
+// Everything that enters the report ring buffer passes through redact() FIRST,
+// so a leaked credential never reaches the buffer, the on-screen technical
+// details, the clipboard, or a (public) GitHub issue body. Redacting at capture
+// time — not at send time — means there is no live, un-redacted copy a user
+// could accidentally copy out of the panel.
+//
+// This is defense-in-depth scrubbing of the common credential/PII shapes that
+// show up in console/network/maplibre noise. It is intentionally conservative
+// (over-redact rather than leak); it is NOT a guarantee that no sensitive value
+// can ever appear, so the review step still tells the user what is attached.
+
+interface RedactionRule {
+  pattern: RegExp;
+  replacement: string;
+}
+
+// Keys whose values are credentials / session secrets. Matched case-insensitively
+// as either `key=value` (query strings, log lines) or `key: value` (JSON / object
+// literals), with the value optionally quoted. `sig` covers signed-tile URLs;
+// the session names cover server-set cookies that surface in error bodies.
+const SENSITIVE_KEYS = [
+  'password',
+  'passwd',
+  'pwd',
+  'api_key',
+  'apikey',
+  'access_token',
+  'refresh_token',
+  'token',
+  'secret',
+  'sig',
+  'signature',
+  'sessionid',
+  'session_id',
+  'jsessionid',
+  'phpsessid',
+  'sid',
+  'cookie',
+].join('|');
+
+const RULES: RedactionRule[] = [
+  // JWTs (header.payload.signature, base64url). Auth tokens are this shape.
+  { pattern: /\beyJ[A-Za-z0-9_-]{5,}\.[A-Za-z0-9_-]{5,}\.[A-Za-z0-9_-]{5,}/g, replacement: '[redacted-token]' },
+  // Authorization headers: `Bearer <token>` / `Basic <base64>`. Handled before
+  // the key=value rule because the scheme + space-separated credential shape
+  // would otherwise leak the part after the space.
+  { pattern: /Bearer\s+[A-Za-z0-9._~+/=-]+/gi, replacement: 'Bearer [redacted]' },
+  { pattern: /Basic\s+[A-Za-z0-9+/=]+/gi, replacement: 'Basic [redacted]' },
+  // <sensitive-key>=value or <sensitive-key>: value (value optionally quoted).
+  // The \b before the key keeps `token=` from matching the tail of unrelated
+  // keys like csrf_token=; alternation order lets access_token/signature win
+  // over their token/sig prefixes.
+  {
+    pattern: new RegExp(`\\b(${SENSITIVE_KEYS})(["']?\\s*[:=]\\s*["']?)[^\\s"'\`&,}\\])]+`, 'gi'),
+    replacement: '$1$2[redacted]',
+  },
+  // Share / embed tokens that live in the URL PATH, not a query param:
+  // /m/<token>, /embed/<token>, /share/<token>. These are bearer-equivalent
+  // access secrets for public/shared maps.
+  { pattern: /\/(m|embed|share)\/[A-Za-z0-9._~-]+/gi, replacement: '/$1/[redacted]' },
+  // Email addresses.
+  { pattern: /[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}/g, replacement: '[redacted-email]' },
+];
+
+/**
+ * Strip credentials and PII from an arbitrary string. Safe on any input —
+ * non-string values are coerced, and a throwing regex never propagates.
+ */
+export function redact(value: unknown): string {
+  let text = typeof value === 'string' ? value : String(value ?? '');
+  try {
+    for (const rule of RULES) {
+      text = text.replace(rule.pattern, rule.replacement);
+    }
+  } catch {
+    // A malformed input should never break capture — fall back to the raw text.
+  }
+  return text;
+}

--- a/frontend/src/lib/report/report-buffer.ts
+++ b/frontend/src/lib/report/report-buffer.ts
@@ -1,0 +1,151 @@
+// In-memory ring buffer for the in-app problem reporter.
+//
+// A single app-wide buffer that capture sources (console, window errors,
+// network/TanStack Query failures, MapLibre errors, React error boundaries)
+// push into, and the ReportProblemHost UI reads from. Framework-agnostic on the
+// write side (capture happens outside React, e.g. window.onerror) and exposed to
+// React via useSyncExternalStore on the read side.
+//
+// Always-on: it starts buffering at app load so that when a user notices a bug
+// and opens the reporter, the history that led up to it is already captured.
+// Bounded to MAX_ENTRIES (oldest dropped) and in-memory only — nothing is
+// persisted, so a reload clears it.
+
+import { useSyncExternalStore } from 'react';
+import { redact } from './redact';
+
+export type ReportSeverity = 'error' | 'warning' | 'info';
+export type ReportSource = 'console' | 'network' | 'maplibre' | 'react' | 'runtime';
+
+export interface ReportEntry {
+  id: string;
+  ts: number;
+  severity: ReportSeverity;
+  source: ReportSource;
+  message: string;
+  detail?: string;
+  /** True when the source deliberately hides this from the user (e.g. a
+   * suppressed MapLibre tile error) — still captured because it's often the
+   * actual bug, shown tagged in the technical-details view. */
+  suppressed?: boolean;
+  /** Number of consecutive identical occurrences collapsed into this entry. */
+  count: number;
+}
+
+export interface ReportEntryInput {
+  severity: ReportSeverity;
+  source: ReportSource;
+  message: string;
+  detail?: string;
+  suppressed?: boolean;
+}
+
+const MAX_ENTRIES = 200;
+const DEDUP_WINDOW_MS = 15_000;
+const MAX_MESSAGE_LEN = 2000;
+const MAX_DETAIL_LEN = 8000;
+
+let entries: ReportEntry[] = [];
+let seq = 0;
+const listeners = new Set<() => void>();
+
+function emit(): void {
+  for (const listener of listeners) listener();
+}
+
+/**
+ * Append an entry to the buffer (newest first). Redacts message + detail at
+ * capture time, collapses consecutive duplicates, and trims to MAX_ENTRIES.
+ * Swallows all errors — capture must never throw into the host code path.
+ */
+export function pushReportEntry(input: ReportEntryInput): void {
+  try {
+    const message = redact(input.message).slice(0, MAX_MESSAGE_LEN);
+    const detail = input.detail ? redact(input.detail).slice(0, MAX_DETAIL_LEN) : undefined;
+    const now = Date.now();
+
+    const last = entries[0];
+    if (
+      last &&
+      last.source === input.source &&
+      last.severity === input.severity &&
+      last.suppressed === input.suppressed &&
+      last.message === message &&
+      now - last.ts < DEDUP_WINDOW_MS
+    ) {
+      const merged: ReportEntry = {
+        ...last,
+        count: last.count + 1,
+        ts: now,
+        detail: detail ?? last.detail,
+      };
+      entries = [merged, ...entries.slice(1)];
+      emit();
+      return;
+    }
+
+    const entry: ReportEntry = {
+      id: `${now}-${(seq += 1)}`,
+      ts: now,
+      severity: input.severity,
+      source: input.source,
+      message,
+      detail,
+      suppressed: input.suppressed,
+      count: 1,
+    };
+    entries = [entry, ...entries].slice(0, MAX_ENTRIES);
+    emit();
+  } catch {
+    // Capture is best-effort; never destabilize the app to log a problem.
+  }
+}
+
+/** Convenience tap for network / TanStack Query failures. */
+export function reportNetworkError(opts: {
+  status: number;
+  url?: string;
+  detail?: unknown;
+}): void {
+  const { status, url, detail } = opts;
+  const severity: ReportSeverity = status === 0 || status >= 500 ? 'error' : 'warning';
+  const label = status === 0 ? 'Network unavailable' : `HTTP ${status}`;
+  const where = url ? ` — ${url}` : '';
+  pushReportEntry({
+    severity,
+    source: 'network',
+    message: `${label}${where}`,
+    detail: stringifyDetail(detail),
+  });
+}
+
+function stringifyDetail(detail: unknown): string | undefined {
+  if (detail == null) return undefined;
+  if (typeof detail === 'string') return detail;
+  try {
+    return JSON.stringify(detail);
+  } catch {
+    return String(detail);
+  }
+}
+
+export function clearReportEntries(): void {
+  entries = [];
+  emit();
+}
+
+export function getReportEntries(): ReportEntry[] {
+  return entries;
+}
+
+function subscribe(listener: () => void): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+/** React hook: subscribe to the live buffer (newest first). */
+export function useReportEntries(): ReportEntry[] {
+  return useSyncExternalStore(subscribe, getReportEntries, getReportEntries);
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -14,7 +14,7 @@ import { TooltipProvider } from '@/components/ui/tooltip';
 import { initializeI18n } from '@/i18n';
 import { AppErrorBoundary } from '@/components/error';
 import { ApiError } from '@/api/client';
-import { initReportCapture, pushReportEntry, reportNetworkError } from '@/lib/report';
+import { initReportCapture, pushReportEntry, redact, reportNetworkError } from '@/lib/report';
 import { ReportProblemHost } from '@/components/report/ReportProblemHost';
 import { appRoutes } from './App';
 import './index.css';
@@ -24,9 +24,17 @@ import './index.css';
 initReportCapture();
 
 function reportQueryKey(key: unknown): string | undefined {
-  if (Array.isArray(key)) return key.map((part) => String(part)).join('/');
-  if (key == null) return undefined;
-  return String(key);
+  // Surface only the query's namespace (the first string segment, e.g.
+  // 'shared-map'). Later segments are parameters — ids, share tokens, api keys —
+  // that can carry secrets and aren't reliably distinguishable from safe ids by
+  // shape, so they're dropped rather than serialized into the report. redact()
+  // is a belt-and-suspenders pass in case a namespace ever becomes dynamic.
+  if (Array.isArray(key)) {
+    const namespace = key.find((part) => typeof part === 'string');
+    return typeof namespace === 'string' ? redact(namespace) : undefined;
+  }
+  if (typeof key === 'string') return redact(key);
+  return undefined;
 }
 
 function captureQueryError(error: unknown, key: unknown): void {

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -72,17 +72,22 @@ async function bootstrap() {
   container.__glRoot = root;
   root.render(
     <React.StrictMode>
-      <AppErrorBoundary>
-        <QueryClientProvider client={queryClient}>
-          <ThemeProvider defaultTheme="system" storageKey="geolens-theme">
-            <TooltipProvider>
+      <QueryClientProvider client={queryClient}>
+        <ThemeProvider defaultTheme="system" storageKey="geolens-theme">
+          <TooltipProvider>
+            <AppErrorBoundary>
               <RouterProvider router={router} />
-              <ThemedToaster />
-              <ReportProblemHost />
-            </TooltipProvider>
-          </ThemeProvider>
-        </QueryClientProvider>
-      </AppErrorBoundary>
+            </AppErrorBoundary>
+            {/* Mounted OUTSIDE AppErrorBoundary (but inside the shared
+                providers) so the problem reporter and its toasts survive an
+                app-level crash: componentDidCatch records the crash in the
+                buffer, and the floating button overlays the error fallback so
+                the user can still open a pre-filled report. */}
+            <ThemedToaster />
+            <ReportProblemHost />
+          </TooltipProvider>
+        </ThemeProvider>
+      </QueryClientProvider>
     </React.StrictMode>,
   );
 }

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,20 +1,55 @@
 import React from 'react';
 import ReactDOM, { type Root } from 'react-dom/client';
 import { createBrowserRouter, createRoutesFromElements, RouterProvider } from 'react-router';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import {
+  MutationCache,
+  QueryCache,
+  QueryClient,
+  QueryClientProvider,
+} from '@tanstack/react-query';
 import { Toaster } from 'sonner';
 import { ThemeProvider } from '@/components/theme-provider';
 import { useTheme } from '@/components/theme-provider';
 import { TooltipProvider } from '@/components/ui/tooltip';
 import { initializeI18n } from '@/i18n';
 import { AppErrorBoundary } from '@/components/error';
+import { ApiError } from '@/api/client';
+import { initReportCapture, pushReportEntry, reportNetworkError } from '@/lib/report';
+import { ReportProblemHost } from '@/components/report/ReportProblemHost';
 import { appRoutes } from './App';
 import './index.css';
+
+// Start capturing console/network/error signal at app load so the in-app
+// problem reporter has history ready the moment a user opens it.
+initReportCapture();
+
+function reportQueryKey(key: unknown): string | undefined {
+  if (Array.isArray(key)) return key.map((part) => String(part)).join('/');
+  if (key == null) return undefined;
+  return String(key);
+}
+
+function captureQueryError(error: unknown, key: unknown): void {
+  if (error instanceof ApiError) {
+    // Skip the expected 401 the client throws while a session is being
+    // refreshed/expired — it would just be noise in a bug report.
+    if (error.status === 401) return;
+    reportNetworkError({ status: error.status, url: reportQueryKey(key), detail: error.body ?? error.message });
+  } else if (error instanceof Error) {
+    pushReportEntry({ severity: 'error', source: 'runtime', message: error.message, detail: error.stack });
+  }
+}
 
 const queryClient = new QueryClient({
   defaultOptions: {
     queries: { staleTime: 30_000, retry: 1, refetchOnWindowFocus: false },
   },
+  queryCache: new QueryCache({
+    onError: (error, query) => captureQueryError(error, query.queryKey),
+  }),
+  mutationCache: new MutationCache({
+    onError: (error, _vars, _ctx, mutation) => captureQueryError(error, mutation.options.mutationKey),
+  }),
 });
 
 function ThemedToaster() {
@@ -43,6 +78,7 @@ async function bootstrap() {
             <TooltipProvider>
               <RouterProvider router={router} />
               <ThemedToaster />
+              <ReportProblemHost />
             </TooltipProvider>
           </ThemeProvider>
         </QueryClientProvider>

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -13,6 +13,14 @@ const apiProxyTarget =
   process.env.API_PROXY_TARGET ||
   'http://localhost:8000'
 
+// Stamp the frontend package version into the bundle at build time so the
+// in-app "Report a problem" flow can auto-fill the GitHub issue version field
+// without a runtime fetch. Exposed as the `__APP_VERSION__` global (see
+// src/@types/build-globals.d.ts).
+const appVersion = JSON.parse(
+  fs.readFileSync(path.resolve(__dirname, 'package.json'), 'utf-8'),
+).version as string
+
 function resolveExistingPath(target: string): string[] {
   if (!fs.existsSync(target)) return []
 
@@ -62,6 +70,9 @@ function manualChunks(id: string) {
 
 export default defineConfig({
   plugins: [react(), tailwindcss()],
+  define: {
+    __APP_VERSION__: JSON.stringify(appVersion),
+  },
   resolve: {
     alias: {
       '@': path.resolve(__dirname, './src'),


### PR DESCRIPTION
## Summary

Adds an in-app **"Report a problem"** debug console (primarily for the Map Builder, but app-wide) that lets non-technical users file a pre-filled GitHub issue with captured console / network / MapLibre / React errors attached — scrubbed of credentials and PII **at capture time**.

The UX is **report-first** (a guided 3-step wizard), not a raw DevTools console — chosen via a judge-panel design pass because a log-viewer scores poorly on non-technical-user clarity.

### What it does
- **Always-on 200-entry ring buffer** feeding a quiet, auth-gated LifeBuoy button (bottom-right) that surfaces an error count only when something is captured.
- **5 capture taps:** `console.error/warn` + `window.onerror`/`unhandledrejection`; TanStack Query/Mutation cache `onError` (decoupled — no `client.ts` edit); MapLibre `map.on('error')` (incl. *suppressed* errors, captured before the suppress logic); React error boundaries (`componentDidCatch`).
- **3-step wizard:** describe what happened → review exactly what will be sent (trust/consent step) → open a pre-filled GitHub issue / copy report.
- **GitHub Issue Form prefill by field id** (`description`/`steps`/`expected`/`area`/`version`/`context`) — Issue Forms ignore `&body=`; `&title=` works. URL-length guard drops `context` over 7 KB and copies the full report to the clipboard so the link always opens.
- `__APP_VERSION__` Vite `define` (auto-stamps the version); new `report` i18n namespace (en/es/fr/de, parity-tested).

### Redaction (logs land in a public repo)
Capture-time `redact()` strips JWTs, `Bearer`/`Basic` headers, `key=value`/`key: value` secrets (incl. tile `sig=`, session ids), **`/m/<token>` share-token URL paths**, and emails — before anything reaches the buffer, the on-screen list, the clipboard, or the issue body.

## Adversarial review — 6 findings fixed
A multi-dimension review (privacy / correctness / react-perf-a11y / integration) surfaced 6 real issues (9 others verified as false positives). All fixed in this PR:
1. **HIGH** — `/m/:token` share token in the URL **path** wasn't redacted (only query params were).
2. **HIGH** — signed-tile `sig=` HMAC param missing from the redaction allowlist.
3. **MED** — session ids (`JSESSIONID`, `session_id`, …) not redacted.
4. **LOW** — unquoted / object-literal JSON secret keys not redacted.
5. **LOW** — (same root as #2).
6. **LOW** — error-count badge not announced to screen readers (now dynamic `aria-label` + `aria-live`).

## Verification
- **2759 frontend tests pass** (16 new across redaction, ring buffer, issue-URL assembly, host component), `tsc` typecheck, eslint, and production `vite build` all green; `__APP_VERSION__` confirmed substituted in the bundle.
- **Live MCP smoke check on the Manhattan 3D builder** (admin): button renders app-wide/auth-gated; badge reacts live; **zero credential leaks** in the on-screen list *and* the outgoing GitHub URL; URL prefilled by field id (no `&body=`); version `2.0.0`; **area auto-defaults to "Map Builder"** on `/maps/:id`; MapLibre tap fires before suppress (`source=maplibre`).
- **Fix applied during smoke check:** button moved `bottom-4` → `bottom-10` to clear the MapLibre attribution bar (verified: 7px gap, no overlap; no collision with the top-right plugin toolbar).

### Known tradeoff
Patching `console` reroutes DevTools source links to `capture.ts` (the standard cost of console capture; messages/args still print, and the shared report buffer is the redacted copy).

### Deferred (by design)
Proactive nudge, searchable log viewer, screenshot attach, sessionStorage crash snapshot.
