### PR TITLE
feat(report): user-menu entry point + error-only floating button

### DIFF
--- a/frontend/src/components/layout/Navbar.tsx
+++ b/frontend/src/components/layout/Navbar.tsx
@@ -1,8 +1,9 @@
 import { useState, useEffect } from 'react';
 import { Link, NavLink, useLocation } from 'react-router';
 import { useTranslation } from 'react-i18next';
-import { ChevronDown, User, LogOut, Settings, Shield, Plus, Database, FolderOpen, Map, Menu, Layers, Upload, LogIn } from 'lucide-react';
+import { ChevronDown, User, LogOut, Settings, Shield, Plus, Database, FolderOpen, Map, Menu, Layers, Upload, LogIn, LifeBuoy } from 'lucide-react';
 import { useAuth } from '@/hooks/use-auth';
+import { useReportDialog } from '@/lib/report';
 import { usePermissions } from '@/hooks/use-permissions';
 import { useFeatureFlags } from '@/hooks/use-settings';
 import { Button } from '@/components/ui/button';
@@ -117,6 +118,8 @@ function UserMenu() {
   const { can } = usePermissions();
   const { t } = useTranslation();
   const { t: tAuth } = useTranslation('auth');
+  const { t: tReport } = useTranslation('report');
+  const openReport = useReportDialog((s) => s.openReport);
 
   // Anonymous: show sign-in button instead of user dropdown
   if (!user) {
@@ -191,6 +194,14 @@ function UserMenu() {
             </DropdownMenuItem>
           </>
         )}
+
+        <DropdownMenuSeparator />
+
+        {/* Report a problem — opens the in-app problem reporter */}
+        <DropdownMenuItem onClick={openReport}>
+          <LifeBuoy className="h-4 w-4" />
+          {tReport('title')}
+        </DropdownMenuItem>
 
         <DropdownMenuSeparator />
 

--- a/frontend/src/components/report/ReportProblemHost.tsx
+++ b/frontend/src/components/report/ReportProblemHost.tsx
@@ -1,26 +1,27 @@
-import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { LifeBuoy } from 'lucide-react';
 import { useAuthStore } from '@/stores/auth-store';
-import { useReportEntries } from '@/lib/report';
+import { useReportDialog, useReportEntries } from '@/lib/report';
 import { cn } from '@/lib/utils';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { ReportProblemWizard } from './ReportProblemWizard';
 
 /**
- * App-wide entry point for the in-app problem reporter. Renders a quiet
- * bottom-right button that stays out of the way until something is captured,
- * then surfaces an error count. Gated to authenticated users — the public
- * login / shared-map views never show it.
+ * App-wide host for the in-app problem reporter. Owns the report wizard, which
+ * is opened from two entry points:
+ *   - the user-menu "Report a problem" item (always available — see Navbar), and
+ *   - a floating button that appears ONLY once errors are captured, surfacing a
+ *     count badge so a user notices a problem the moment it happens.
  *
- * Capture itself runs app-wide via initReportCapture() (main.tsx); this only
- * owns the affordance and the wizard.
+ * Gated to authenticated users. Capture runs app-wide via initReportCapture()
+ * (main.tsx); this only owns the affordance + wizard.
  */
 export function ReportProblemHost() {
   const token = useAuthStore((s) => s.token);
   const entries = useReportEntries();
   const { t } = useTranslation('report');
-  const [open, setOpen] = useState(false);
+  const open = useReportDialog((s) => s.open);
+  const setOpen = useReportDialog((s) => s.setOpen);
 
   if (!token) return null;
 
@@ -30,22 +31,22 @@ export function ReportProblemHost() {
 
   return (
     <>
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <button
-            type="button"
-            aria-label={hasErrors ? t('button.ariaWithCount', { count: errorCount }) : t('button.aria')}
-            onClick={() => setOpen(true)}
-            className={cn(
-              // bottom-10 (not bottom-4) clears the MapLibre attribution bar that
-              // hugs the bottom-right corner of every map view — attribution must
-              // stay unobstructed, and its compact toggle sits exactly here.
-              'fixed bottom-10 right-4 z-40 inline-flex size-10 items-center justify-center rounded-full border bg-background/90 text-muted-foreground shadow-sm backdrop-blur transition-all duration-200 hover:text-foreground hover:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
-              hasErrors ? 'border-destructive/50 text-destructive opacity-100' : 'opacity-60',
-            )}
-          >
-            <LifeBuoy className="size-5" aria-hidden />
-            {hasErrors && (
+      {/* Floating button: only present when something is captured, so the idle
+          UI footprint is zero and a real problem still surfaces proactively. */}
+      {hasErrors && (
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              type="button"
+              aria-label={t('button.ariaWithCount', { count: errorCount })}
+              onClick={() => setOpen(true)}
+              className={cn(
+                // bottom-10 (not bottom-4) clears the MapLibre attribution bar
+                // that hugs the bottom-right corner of every map view.
+                'fixed bottom-10 right-4 z-40 inline-flex size-10 items-center justify-center rounded-full border border-destructive/50 bg-background/90 text-destructive shadow-sm backdrop-blur transition-all duration-200 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
+              )}
+            >
+              <LifeBuoy className="size-5" aria-hidden />
               <span
                 aria-live="polite"
                 aria-atomic="true"
@@ -53,11 +54,11 @@ export function ReportProblemHost() {
               >
                 {badge}
               </span>
-            )}
-          </button>
-        </TooltipTrigger>
-        <TooltipContent side="left">{t('button.tooltip')}</TooltipContent>
-      </Tooltip>
+            </button>
+          </TooltipTrigger>
+          <TooltipContent side="left">{t('button.tooltip')}</TooltipContent>
+        </Tooltip>
+      )}
       <ReportProblemWizard open={open} onOpenChange={setOpen} entries={entries} />
     </>
   );

--- a/frontend/src/components/report/__tests__/ReportProblemHost.test.tsx
+++ b/frontend/src/components/report/__tests__/ReportProblemHost.test.tsx
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach } from 'vitest';
 import { render, screen, fireEvent } from '@/test/test-utils';
 import { ReportProblemHost } from '../ReportProblemHost';
 import { useAuthStore } from '@/stores/auth-store';
-import { clearReportEntries, pushReportEntry } from '@/lib/report';
+import { clearReportEntries, pushReportEntry, useReportDialog } from '@/lib/report';
 
 function signIn() {
   useAuthStore.setState({ token: 'tok', refreshToken: 'r', expiresAt: Date.now() + 1_000_000, user: null });
@@ -10,32 +10,42 @@ function signIn() {
 
 beforeEach(() => {
   clearReportEntries();
+  useReportDialog.setState({ open: false });
   useAuthStore.setState({ token: null, refreshToken: null, expiresAt: null, user: null });
 });
 
 describe('ReportProblemHost', () => {
   it('renders nothing for unauthenticated users', () => {
     render(<ReportProblemHost />);
-    expect(screen.queryByRole('button', { name: 'Report a problem' })).toBeNull();
+    expect(screen.queryByRole('button', { name: /report a problem/i })).toBeNull();
   });
 
-  it('shows a quiet report button when authenticated', () => {
+  it('shows no floating button when authenticated and idle (no errors)', () => {
     signIn();
     render(<ReportProblemHost />);
-    expect(screen.getByRole('button', { name: 'Report a problem' })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /report a problem/i })).toBeNull();
   });
 
-  it('surfaces an error count badge when errors are captured', async () => {
+  it('shows the floating button with a count badge once errors are captured', async () => {
     signIn();
     render(<ReportProblemHost />);
     pushReportEntry({ severity: 'error', source: 'console', message: 'boom' });
-    expect(await screen.findByText('1')).toBeInTheDocument();
+    expect(await screen.findByRole('button', { name: /report a problem/i })).toBeInTheDocument();
+    expect(screen.getByText('1')).toBeInTheDocument();
   });
 
-  it('opens the report wizard when clicked', async () => {
+  it('opens the wizard from the floating button', async () => {
     signIn();
     render(<ReportProblemHost />);
-    fireEvent.click(screen.getByRole('button', { name: 'Report a problem' }));
+    pushReportEntry({ severity: 'error', source: 'console', message: 'boom' });
+    fireEvent.click(await screen.findByRole('button', { name: /report a problem/i }));
+    expect(await screen.findByText('What happened?')).toBeInTheDocument();
+  });
+
+  it('opens the wizard via the shared store (user-menu entry point) with no errors', async () => {
+    signIn();
+    render(<ReportProblemHost />);
+    useReportDialog.getState().openReport();
     expect(await screen.findByText('What happened?')).toBeInTheDocument();
   });
 });

--- a/frontend/src/lib/report/index.ts
+++ b/frontend/src/lib/report/index.ts
@@ -13,6 +13,7 @@ export type {
   ReportSource,
 } from './report-buffer';
 export { initReportCapture } from './capture';
+export { useReportDialog } from './use-report-dialog';
 export {
   ISSUE_AREAS,
   mapAreaFromPath,

--- a/frontend/src/lib/report/use-report-dialog.ts
+++ b/frontend/src/lib/report/use-report-dialog.ts
@@ -1,0 +1,19 @@
+import { create } from 'zustand';
+
+// Shared open-state for the "Report a problem" wizard so multiple entry points
+// can trigger it: the user-menu item (always available, discoverable) and the
+// floating button that only appears once errors are captured. ReportProblemHost
+// owns the wizard and reads `open` from here.
+interface ReportDialogState {
+  open: boolean;
+  setOpen: (open: boolean) => void;
+  openReport: () => void;
+  closeReport: () => void;
+}
+
+export const useReportDialog = create<ReportDialogState>((set) => ({
+  open: false,
+  setOpen: (open) => set({ open }),
+  openReport: () => set({ open: true }),
+  closeReport: () => set({ open: false }),
+}));


### PR DESCRIPTION
## Summary

Follow-up to #191. Adds a second, discoverable entry point to the in-app problem reporter and makes the idle UI truly zero-footprint.

The reporter now has **two entry points sharing one wizard**:
- **User menu → "Report a problem"** — always available and discoverable (sits with Settings/Admin/Logout). The primary home; works even when nothing has been captured.
- **Floating button — only when errors are captured.** Previously a persistent quiet button; now it renders *only* once `errorCount > 0`, so the idle builder/app has no corner element, while a real problem still surfaces the proactive red count badge the moment it happens.

This resolves the tension between "minimal / out of the way" and "discoverable + proactive": the menu item gives a permanent home with no clutter, and the badge preserves the feature's core value (a non-technical user notices a problem right when it occurs).

## Implementation
- `lib/report/use-report-dialog.ts` — small zustand store holding the wizard's open-state so both entry points can trigger it. Capture and the wizard itself are unchanged.
- `ReportProblemHost.tsx` — reads open-state from the store; renders the floating button only when there are captured errors.
- `Navbar.tsx` — "Report a problem" item in `UserMenu` calling `openReport()` (covers desktop + mobile, which share the avatar dropdown).
- Host tests rewritten for the new behavior: idle = no FAB, FAB appears on error with a badge, and the wizard opens via the shared store (the user-menu path).

## Verification
- typecheck + eslint + **2763 frontend tests** green.
- Live MCP check on the running app: idle shows **no floating button**; the user menu has "Report a problem" which opens the wizard (area auto-defaults to "Map Builder"); injecting a console error makes the floating button appear with `aria-label "Report a problem (1 errors detected)"` + badge `1`.
