### PR TITLE
docs(readme): hero reflects catalog + map builder positioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 [English](README.md) | [Español](README.es.md) | [Français](README.fr.md) | [Deutsch](README.de.md)
 
-**Your team's spatial data, searchable in one place.**
+**Your team's spatial data — searchable, mappable, and shareable in one place.**
 
-Upload Shapefiles, GeoTIFFs, GeoPackages, or CSVs. GeoLens stores everything in PostGIS, indexes it with pgvector + pg_trgm for semantic and fuzzy search, and serves OGC APIs that QGIS, ArcGIS, and MapLibre clients connect to natively. Built on FastAPI and React. Deployed with one command.
+Upload Shapefiles, GeoTIFFs, GeoPackages, or CSVs. GeoLens stores everything in PostGIS, indexes it with pgvector + pg_trgm for semantic and fuzzy search, and serves OGC APIs that QGIS, ArcGIS, and MapLibre clients connect to natively. Compose, style, and share multi-layer maps right in the browser. Built on FastAPI and React. Deployed with one command.
 
 [![CI](https://github.com/geolens-io/geolens/actions/workflows/ci.yml/badge.svg)](https://github.com/geolens-io/geolens/actions/workflows/ci.yml)
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)


### PR DESCRIPTION
## What

Updates the README hero + subhead to match the product's actual scope.

- Headline: **"Your team's spatial data — searchable, mappable, and shareable in one place."** (was "searchable in one place")
- Subhead gains one clause: *"Compose, style, and share multi-layer maps right in the browser."*

## Why

An alignment review of the README, docs-site, and original PRD found the README hero was **catalog-only** ("searchable in one place") while:
- the README's own lead image is the **3D map builder** (a direct text/visual mismatch), and
- the docs-site hero already positions GeoLens as the **"catalog and map builder,"** and ~90% of recent product investment (v1008–v1037) went into the map builder.

This raises the README to the canonical **find · map · serve** positioning shared by the docs site, without losing the sticky "in one place" framing.

## Scope

README copy only — no image or code changes. Internal planning docs (PROJECT.md Core Value + audience) were de-staled separately to match.
