### PR TITLE
fix(readme): restore connection-pool budget facts dropped in #198 trim

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,8 +265,10 @@ All configuration is managed through environment variables in `.env`. See the [C
 
 ### Connection Pool Budget
 
-GeoLens ships tuned for a **single PostgreSQL** instance — its pool defaults fit
-`max_connections = 30` (API + worker + admin) out of the box. See
+GeoLens ships tuned for a **single PostgreSQL** instance: the API, worker, and admin
+pools fit within **30 of 30 max_connections** out of the box (PERF-05 — Postgres
+`max_connections` lowered from 50 → 30), sized by `DB_POOL_SIZE` (`pool_size`) and
+`DB_MAX_OVERFLOW` (`max_overflow`, default 3). See
 [Connection Pool Tuning](https://docs.getgeolens.com/guides/quickstart/configuration/#connection-pool-tuning)
 for the per-process budget and how to raise the ceiling.
 


### PR DESCRIPTION
## Problem

`main` CI is red. The #198 README trim removed two operational facts from the **Connection Pool Budget** section, breaking two requirement-traceability guards:

- `test_phase_271_pool_config.py::test_readme_documents_connection_pool_budget` — asserts the README references `max_overflow` / `DB_MAX_OVERFLOW`.
- `test_phase_274_caches_and_pool.py::test_readme_documents_perf_05_in_effect` — asserts the README shows the PERF-05 envelope (`30 of 30 max_connections` / `50 → 30`).

(These two failures were the entirety of the `Backend Tests` + `Pytest Parallel Isolation` failures — `2 failed, 3184 passed`. Not flaky; deterministic README-content coupling.)

## Fix

Restore both facts compactly into the existing section — no re-bloat. The values match the code under test: `db_max_overflow = 3` (`config.py`, DBM-04) and `max_connections = 30` (`postgresql.conf`, PERF-05).

Verified both assertions pass against the edited README.

## Note

#198 merged with red CI only because `main` has **no required status checks**. Recommend enabling required checks + PR review on `main` so this can't recur (separate from this PR).
