### PR TITLE
ci: run backend introspection tests on docs/config PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,16 @@ jobs:
               - 'backend/**'
               - 'docker-compose*.yml'
               - 'Dockerfile*'
+              # Files the backend introspection tests (test_phase_27*) assert
+              # against — a change here can break Backend Tests, so they must
+              # run on PRs that touch these even with no backend/** change.
+              - 'README.md'
+              - 'frontend/README.md'
+              - 'CHANGELOG.md'
+              - '.env.example'
+              - '.dockerignore'
+              - 'nginx.conf'
+              - 'db/**'
             frontend:
               - 'frontend/**'
             e2e:


### PR DESCRIPTION
## Problem

The backend introspection guards (`backend/tests/test_phase_27*`) assert content in repo-root docs/config files — `README.md`, `frontend/README.md`, `CHANGELOG.md`, `.env.example`, `.dockerignore`, `nginx.conf`, `db/postgresql.conf`.

But the `Detect Changes` **`backend` paths-filter** only watched `backend/**`, `docker-compose*.yml`, and `Dockerfile*`. Since every backend job gates on `needs.changes.outputs.backend == 'true' || github.event_name == 'push'`, a **docs-only PR skips Backend Tests on the PR** — but **push-to-main always runs them**.

That asymmetry is exactly how **#198 went green on the PR and red on the merge to `main`** (it trimmed README content the guards require; #200 restored it).

## Fix

Add the introspected files to the `backend` filter so the guards run on the PR that can break them. Now a README/CHANGELOG/.env.example change runs Backend Tests on the PR, catching introspection breaks before merge.

## Scope

`ci.yml` only — one paths-filter list. No job logic changed.
