### PR TITLE
fix: Ask AI labels render at low zoom + working Undo (#195)

### DIFF
--- a/frontend/src/components/builder/ChatPanel.tsx
+++ b/frontend/src/components/builder/ChatPanel.tsx
@@ -135,6 +135,12 @@ export interface LayerActions {
   onAddDataset: (datasetId: string) => void;
   onRemove: (layerId: string) => void;
   onOpacityChange?: (layerId: string, opacity: number) => void;
+  /**
+   * Atomically restore the full state of each supplied layer (matched by id).
+   * Used by undo to revert all fields in a single update — restoring field-by-field
+   * through the individual handlers clobbers earlier reverts (see handleUndo).
+   */
+  onRestoreLayers: (layers: MapLayerResponse[]) => void;
 }
 
 interface ChatPanelProps {
@@ -167,6 +173,7 @@ export function ChatPanel({
     onAddDataset,
     onRemove,
     onOpacityChange,
+    onRestoreLayers,
   } = layerActions;
   const { t, i18n } = useTranslation('builder');
   const [messages, setMessages] = useState<ChatMessage[]>(() => {
@@ -309,25 +316,17 @@ export function ChatPanel({
       }
     }
 
-    for (const layer of snapshot.layers) {
-      // Restore paint
-      if (layer.paint) onPaintChange(layer.id, layer.paint);
-      // Restore filter
-      onFilterChange(layer.id, layer.filter ?? null);
-      // Restore label config
-      onLabelChange(layer.id, layer.label_config ?? null);
-      // Restore visibility
-      onToggleVisibility(layer.id, layer.visible);
-      // Restore style config
-      if (layer.style_config) {
-        onStyleConfigChange(layer.id, layer.style_config, layer.paint);
-      }
-      // Restore opacity
-      if (onOpacityChange) onOpacityChange(layer.id, layer.opacity);
-    }
+    // Restore every snapshotted layer's full state in ONE atomic update.
+    // Restoring field-by-field via the individual handlers clobbered earlier
+    // reverts: each handler rebuilds the layer from a ref that only refreshes
+    // between renders, so a later partial spread (e.g. the unconditional
+    // style_config restore on a data-driven layer) re-stamped the stale
+    // label_config / paint and silently dropped those reverts — the map showed
+    // the change still applied even though undo reported success.
+    onRestoreLayers(snapshot.layers);
     lastSnapshotRef.current = null;
     toast.success(t('chat.undoApplied'));
-  }, [onPaintChange, onFilterChange, onLabelChange, onToggleVisibility, onStyleConfigChange, onOpacityChange, onRemove, onAddDataset, t]);
+  }, [onRestoreLayers, onRemove, onAddDataset, t]);
 
   function handleChatAction(action: ChatAction) {
     const layerId = getActionLayerId(action);

--- a/frontend/src/components/builder/__tests__/ChatPanel.test.tsx
+++ b/frontend/src/components/builder/__tests__/ChatPanel.test.tsx
@@ -50,6 +50,7 @@ function renderPanel(
     onAddDataset = vi.fn(),
     onRemove = vi.fn(),
     onOpacityChange,
+    onRestoreLayers = vi.fn(),
     ...rest
   } = propOverrides;
   const layerActions = {
@@ -60,6 +61,7 @@ function renderPanel(
     onToggleVisibility,
     onAddDataset,
     onRemove,
+    onRestoreLayers,
     ...(onOpacityChange ? { onOpacityChange } : {}),
   };
   const props = {
@@ -429,12 +431,25 @@ describe('ChatPanel', () => {
 
     await user.click(await screen.findByRole('button', { name: /undo/i }));
 
-    expect(props.onPaintChange).toHaveBeenLastCalledWith('layer-1', originalLayer.paint);
-    expect(props.onFilterChange).toHaveBeenCalledWith('layer-1', originalLayer.filter);
-    expect(props.onLabelChange).toHaveBeenCalledWith('layer-1', originalLayer.label_config);
-    expect(props.onToggleVisibility).toHaveBeenCalledWith('layer-1', false);
-    expect(props.onStyleConfigChange).toHaveBeenCalledWith('layer-1', originalLayer.style_config, originalLayer.paint);
-    expect(props.onOpacityChange).toHaveBeenCalledWith('layer-1', 0.35);
+    // Undo restores the full pre-mutation snapshot in a SINGLE atomic call.
+    // (Restoring field-by-field clobbered earlier reverts — a later partial
+    // update re-stamped stale label_config/paint and the change visibly stuck.)
+    const restoreFn = vi.mocked(props.onRestoreLayers);
+    expect(restoreFn).toHaveBeenCalledTimes(1);
+    const restored = restoreFn.mock.calls[0][0];
+    expect(restored).toHaveLength(1);
+    expect(restored[0]).toMatchObject({
+      id: 'layer-1',
+      paint: originalLayer.paint,
+      filter: originalLayer.filter,
+      label_config: originalLayer.label_config,
+      visible: false,
+      style_config: originalLayer.style_config,
+      opacity: 0.35,
+    });
+    // The clobbering per-field restore handlers are no longer used by undo.
+    expect(props.onStyleConfigChange).not.toHaveBeenCalled();
+    expect(props.onLabelChange).not.toHaveBeenCalled();
   });
 
   it('does not offer undo for remove_layer actions (requires staging accept)', async () => {

--- a/frontend/src/components/builder/__tests__/SharePanel.test.tsx
+++ b/frontend/src/components/builder/__tests__/SharePanel.test.tsx
@@ -587,8 +587,16 @@ describe('SHARE-04 expiration presets', () => {
 
   it('test_select_pre_populates_to_custom_when_shareExpires_off_preset: shareExpires at T12:00 (off-preset) → Select shows "Custom date…" and date input shows the date', async () => {
     const user = userEvent.setup();
-    // shareExpires at T12:00 — outside preset ±1 day tolerance (presets use T23:59:59)
-    setup({ enterprise: true, shareExpires: '2026-06-15T12:00:00Z' });
+    // shareExpires off every preset (7/30/90d ±1 day) AND at T12:00 (presets use
+    // T23:59:59). Computed relative to now (not hardcoded) so it can't drift into a
+    // preset window as the calendar advances — a previously hardcoded 2026-06-15
+    // started failing once "now" reached 2026-06-07 and the 7-day preset landed
+    // within the ±1-day tolerance of it. 45 days is safely between the 30d and 90d
+    // presets.
+    const offPresetDate = new Date(Date.now() + 45 * 24 * 60 * 60 * 1000)
+      .toISOString()
+      .split('T')[0];
+    setup({ enterprise: true, shareExpires: `${offPresetDate}T12:00:00.000Z` });
 
     await openLinkSettings(user);
 
@@ -599,7 +607,7 @@ describe('SHARE-04 expiration presets', () => {
     // The date input should be pre-populated with the date portion
     const dateInputs = document.querySelectorAll<HTMLInputElement>('input[type="date"]');
     expect(dateInputs.length).toBeGreaterThan(0);
-    expect(dateInputs[0]).toHaveValue('2026-06-15');
+    expect(dateInputs[0]).toHaveValue(offPresetDate);
   });
 
   it('test_select_pre_populates_to_seven_days_when_within_preset_window: shareExpires = (now + 7d at T23:59:59Z) → Select shows "7 days"', async () => {

--- a/frontend/src/components/builder/__tests__/map-sync.data-driven-cols.test.ts
+++ b/frontend/src/components/builder/__tests__/map-sync.data-driven-cols.test.ts
@@ -79,6 +79,50 @@ describe('getDataDrivenColumnsForLayer', () => {
     });
     expect(cols.sort()).toEqual(['category', 'opacity_factor']);
   });
+
+  it('returns label_config.column when style_config and paint have no columns', () => {
+    const cols = getDataDrivenColumnsForLayer({
+      style_config: null,
+      paint: {},
+      label_config: { column: 'NAME', fontSize: 12, placement: 'point', minZoom: 0, maxZoom: 22, allowOverlap: false },
+    });
+    expect(cols).toEqual(['NAME']);
+  });
+
+  it('dedupes label_config.column when it equals the style_config column', () => {
+    const cols = getDataDrivenColumnsForLayer({
+      style_config: { mode: 'graduated', column: 'pop_est', ramp: 'YlOrRd', breaks: [] },
+      paint: {},
+      label_config: { column: 'pop_est', fontSize: 12, placement: 'point', minZoom: 0, maxZoom: 22, allowOverlap: false },
+    });
+    expect(cols).toEqual(['pop_est']);
+  });
+
+  it('contributes nothing when label_config is null', () => {
+    const cols = getDataDrivenColumnsForLayer({
+      style_config: null,
+      paint: {},
+      label_config: null,
+    });
+    expect(cols).toEqual([]);
+  });
+
+  it('contributes nothing when label_config is undefined', () => {
+    const cols = getDataDrivenColumnsForLayer({
+      style_config: null,
+      paint: {},
+    });
+    expect(cols).toEqual([]);
+  });
+
+  it('contributes nothing when label_config has an empty column string', () => {
+    const cols = getDataDrivenColumnsForLayer({
+      style_config: null,
+      paint: {},
+      label_config: { column: '', fontSize: 12, placement: 'point', minZoom: 0, maxZoom: 22, allowOverlap: false },
+    });
+    expect(cols).toEqual([]);
+  });
 });
 
 describe('getDataDrivenColumnsForSource', () => {
@@ -87,6 +131,7 @@ describe('getDataDrivenColumnsForSource', () => {
     dataset_table_name: string,
     style_config: SyncLayerInput['style_config'] = null,
     paint: SyncLayerInput['paint'] = {},
+    label_config: SyncLayerInput['label_config'] = null,
   ): SyncLayerInput {
     return {
       id,
@@ -99,6 +144,7 @@ describe('getDataDrivenColumnsForSource', () => {
       layout: {},
       filter: null,
       style_config,
+      label_config,
     };
   }
 
@@ -110,6 +156,21 @@ describe('getDataDrivenColumnsForSource', () => {
     ];
     const cols = getDataDrivenColumnsForSource('source-data-countries', layers);
     expect(cols.sort()).toEqual(['economy', 'pop_est']);
+  });
+
+  it('unions label_config.column from layers sharing a deduped source', () => {
+    const layers: SyncLayerInput[] = [
+      makeLayer(
+        'l1',
+        'counties',
+        { mode: 'graduated', column: 'median_income', ramp: 'YlOrRd', breaks: [] },
+        {},
+        { column: 'NAME', fontSize: 12, placement: 'point', minZoom: 0, maxZoom: 22, allowOverlap: false },
+      ),
+      makeLayer('l2', 'counties', null, {}, null),
+    ];
+    const cols = getDataDrivenColumnsForSource('source-data-counties', layers);
+    expect(cols.sort()).toEqual(['NAME', 'median_income']);
   });
 
   it('returns empty array when no layer matches the source', () => {

--- a/frontend/src/components/builder/__tests__/map-sync.tile-refresh.test.ts
+++ b/frontend/src/components/builder/__tests__/map-sync.tile-refresh.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  syncLayersToMap,
+  getSourceIdForLayer,
+  type SyncLayerInput,
+} from '@/components/builder/map-sync';
+import type { TileToken, VectorTileToken } from '@/api/tiles';
+
+// buildSignedTileUrl embeds the requested `cols` so the tile URL changes exactly
+// when the projected column set changes — the signal the existing-source refresh
+// guard keys on.
+vi.mock('@/lib/tile-utils', () => ({
+  buildSignedTileUrl: vi.fn(
+    (table: string, _t: unknown, _b: unknown, _u: unknown, cols?: string[] | null) =>
+      `/tiles/${table}/{z}/{x}/{y}.pbf?cols=${(cols ?? []).slice().sort().join(',')}`,
+  ),
+  buildClusterTileUrl: vi.fn(() => '/tiles/clusters/mock/{z}/{x}/{y}.pbf'),
+}));
+
+Object.defineProperty(window, 'location', {
+  value: { origin: 'http://localhost:8080' },
+  writable: true,
+});
+
+function createMockMap() {
+  const sources = new Map<string, { type: string; tiles?: string[]; setTiles?: ReturnType<typeof vi.fn> }>();
+  const layerIds = new Set<string>();
+  return {
+    getSource: vi.fn((id: string) => sources.get(id) ?? null),
+    addSource: vi.fn((id: string, spec: { type: string; tiles?: string[] }) => {
+      // Vector sources expose setTiles in MapLibre — mirror that so the refresh
+      // path under test can be exercised and counted.
+      sources.set(id, spec.type === 'vector' ? { ...spec, setTiles: vi.fn() } : { ...spec });
+    }),
+    removeSource: vi.fn((id: string) => { sources.delete(id); }),
+    addLayer: vi.fn((layer: { id: string }) => { layerIds.add(layer.id); }),
+    getLayer: vi.fn((id: string) => (layerIds.has(id) ? { id } : null)),
+    removeLayer: vi.fn((id: string) => { layerIds.delete(id); }),
+    setLayoutProperty: vi.fn(),
+    setPaintProperty: vi.fn(),
+    getPaintProperty: vi.fn(),
+    getLayoutProperty: vi.fn(),
+    setFilter: vi.fn(),
+    getFilter: vi.fn().mockReturnValue(null),
+    isStyleLoaded: vi.fn(() => true),
+    getStyle: vi.fn(() => ({ layers: Array.from(layerIds).map((id) => ({ id })) })),
+    moveLayer: vi.fn(),
+    setLayerZoomRange: vi.fn(),
+  } as unknown as import('maplibre-gl').Map;
+}
+
+function makeVectorToken(overrides: Partial<VectorTileToken> = {}): VectorTileToken {
+  return { kind: 'vector', sig: 'abc', exp: 9999999999, scope: 'test', expires_in: 3600, ...overrides };
+}
+
+function makeLayer(overrides: Partial<SyncLayerInput> = {}): SyncLayerInput {
+  return {
+    id: 'layer-x',
+    dataset_id: 'ds-x',
+    dataset_table_name: 'parcels',
+    dataset_geometry_type: 'Polygon',
+    opacity: 1,
+    visible: true,
+    paint: {},
+    layout: {},
+    filter: null,
+    label_config: null,
+    style_config: null,
+    is_dem: false,
+    is_3d: false,
+    feature_count: 100,
+    ...overrides,
+  };
+}
+
+function getSetTiles(map: import('maplibre-gl').Map, sourceId: string) {
+  const src = map.getSource(sourceId) as unknown as { setTiles?: ReturnType<typeof vi.fn> } | null;
+  return src?.setTiles;
+}
+
+describe('syncLayersToMap non-cluster vector tile refresh guard', () => {
+  it('does NOT refetch tiles on repeated syncs when the tile URL is unchanged', () => {
+    const map = createMockMap();
+    const managed = { current: new Set<string>() };
+    const order = { current: '' };
+    const layer = makeLayer();
+    const tokens = new Map<string, TileToken>([[layer.dataset_id, makeVectorToken()]]);
+    const sourceId = getSourceIdForLayer(layer);
+
+    syncLayersToMap(map, [layer], tokens, undefined, managed, order); // create
+    const setTiles = getSetTiles(map, sourceId)!;
+    expect(setTiles).not.toHaveBeenCalled(); // create seeds the signature; no redundant refresh
+
+    // Repeated syncs with identical inputs (e.g. unrelated state changes) must not
+    // re-issue setTiles — the regression this guards (the `!canUseCluster` block
+    // previously cleared the tileurl signature every pass, defeating the guard).
+    syncLayersToMap(map, [layer], tokens, undefined, managed, order);
+    syncLayersToMap(map, [layer], tokens, undefined, managed, order);
+    expect(setTiles).not.toHaveBeenCalled();
+  });
+
+  it('refetches tiles exactly once when a label column changes the cols= set, then stays quiet', () => {
+    const map = createMockMap();
+    const managed = { current: new Set<string>() };
+    const order = { current: '' };
+    const layer = makeLayer();
+    const tokens = new Map<string, TileToken>([[layer.dataset_id, makeVectorToken()]]);
+    const sourceId = getSourceIdForLayer(layer);
+
+    syncLayersToMap(map, [layer], tokens, undefined, managed, order); // create (cols=)
+    const setTiles = getSetTiles(map, sourceId)!;
+    expect(setTiles).not.toHaveBeenCalled();
+
+    // Add a label on a column not otherwise styled → cols= now includes it → URL changes.
+    const labeled = makeLayer({ label_config: { column: 'name' } });
+    syncLayersToMap(map, [labeled], tokens, undefined, managed, order);
+    expect(setTiles).toHaveBeenCalledTimes(1);
+    expect(setTiles).toHaveBeenCalledWith([expect.stringContaining('cols=name')]);
+
+    // Re-syncing the labeled layer with no further change must not refetch again.
+    syncLayersToMap(map, [labeled], tokens, undefined, managed, order);
+    expect(setTiles).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/components/builder/hooks/use-builder-layers.ts
+++ b/frontend/src/components/builder/hooks/use-builder-layers.ts
@@ -1251,6 +1251,21 @@ export function useBuilderLayers(
     handleToggleVisibility,
   ]);
 
+  // Atomic multi-field restore for chat undo. Restoring a snapshot field-by-field
+  // through the individual dispatch handlers clobbered earlier restores: each
+  // handler rebuilds the layer from `layersRef.current`, which only refreshes
+  // between renders, so successive synchronous spreads re-stamp stale values and
+  // silently drop the label/paint reverts (the undo-does-nothing bug). Replacing
+  // every snapshotted layer wholesale in ONE setState avoids the clobber; the map
+  // reconciles via BuilderMap's declarative syncLayersToMap effect (which adds /
+  // updates / removes the companion label layer to match the restored state).
+  const handleRestoreLayers = useCallback((restored: MapLayerResponse[]) => {
+    if (restored.length === 0) return;
+    const byId = new Map(restored.map((l) => [l.id, l]));
+    setLocalLayers((prev) => prev.map((l) => byId.get(l.id) ?? l));
+    setHasUnsavedChanges(true);
+  }, [setLocalLayers, setHasUnsavedChanges]);
+
   const chatLayerActions: LayerActions = useMemo(() => ({
     onFilterChange: (layerId, expression) => dispatchLayerAction({
       type: 'set_filter',
@@ -1300,7 +1315,8 @@ export function useBuilderLayers(
       layerId,
       opacity,
     }),
-  }), [dispatchLayerAction]);
+    onRestoreLayers: handleRestoreLayers,
+  }), [dispatchLayerAction, handleRestoreLayers]);
 
   return {
     localName, setLocalName,

--- a/frontend/src/components/builder/map-sync.ts
+++ b/frontend/src/components/builder/map-sync.ts
@@ -809,10 +809,12 @@ function syncVectorLayer(
     removeKnownVectorLayers(map, layerId, layer.id, prefix);
     map.removeSource(sourceId);
     signatureMap.delete(sourceId);
+    signatureMap.delete(`${sourceId}::tileurl`);
   }
   if (!canUseCluster) {
     removeClusterCompanionLayers(map, layerId);
     signatureMap.delete(sourceId);
+    signatureMap.delete(`${sourceId}::tileurl`);
   }
 
   const layerLayout = layer.layout ?? {};
@@ -864,6 +866,8 @@ function syncVectorLayer(
     } else {
       signatureMap.delete(sourceId);
     }
+    // Seed the tileUrl so the first post-create sync does not redundantly re-fire setTiles.
+    signatureMap.set(`${sourceId}::tileurl`, adapterInput.tileUrl);
     adapter.addLayers(map, adapterInput);
   } else {
     adapterInput.sourceType = 'vector';
@@ -873,6 +877,19 @@ function syncVectorLayer(
         source.setTiles([adapterInput.tileUrl]);
       }
       if (desiredClusterSignature) signatureMap.set(sourceId, desiredClusterSignature);
+    } else if (!canUseServerCluster) {
+      // Non-cluster vector path: refresh tiles only when the computed tileUrl
+      // changes (e.g. a label column was added, changing the cols= param).
+      // Guarded by signature to avoid needless refetch / flicker on unchanged URLs.
+      const tileUrlKey = `${sourceId}::tileurl`;
+      const storedTileUrl = signatureMap.get(tileUrlKey);
+      if (storedTileUrl !== adapterInput.tileUrl) {
+        const source = map.getSource(sourceId) as { type?: string; setTiles?: (tiles: string[]) => void } | undefined;
+        if (source?.type === 'vector' && typeof source.setTiles === 'function') {
+          source.setTiles([adapterInput.tileUrl]);
+        }
+        signatureMap.set(tileUrlKey, adapterInput.tileUrl);
+      }
     }
     adapter.syncPaint(map, adapterInput);
   }

--- a/frontend/src/components/builder/map-sync.ts
+++ b/frontend/src/components/builder/map-sync.ts
@@ -499,9 +499,11 @@ export interface SourceIdLayer {
  *  - paint `_heatmap-weight-column` — heatmap weighting (custom builder prop)
  *  - paint `_height_column` — 3D fill-extrusion height (custom builder prop)
  *  - paint expressions of shape `["get", "<colname>"]` — generic catch-all
+ *  - `label_config.column` — label text-field is a LAYOUT property the paint
+ *    walk cannot see, which is exactly why an explicit read is required here
  */
 export function getDataDrivenColumnsForLayer(
-  layer: { style_config?: StyleConfig | null; paint?: Record<string, unknown> },
+  layer: { style_config?: StyleConfig | null; paint?: Record<string, unknown>; label_config?: LabelConfig | null },
 ): string[] {
   const cols = new Set<string>();
   const styleCol = layer.style_config?.column;
@@ -511,6 +513,10 @@ export function getDataDrivenColumnsForLayer(
   if (typeof heatmapWeight === 'string' && heatmapWeight) cols.add(heatmapWeight);
   const heightCol = paint['_height_column'];
   if (typeof heightCol === 'string' && heightCol) cols.add(heightCol);
+  // label_config.column drives the companion symbol layer's text-field layout
+  // property — a LAYOUT expression the paint walk below cannot reach.
+  const labelCol = layer.label_config?.column;
+  if (typeof labelCol === 'string' && labelCol) cols.add(labelCol);
   // Walk paint expressions for `["get", "<name>"]` references.
   // ["get", x] is the canonical MapLibre way to read a feature property.
   function walk(node: unknown): void {
@@ -537,6 +543,7 @@ export function getDataDrivenColumnsForSource(
     const layerWithStyle = layer as SourceIdLayer & {
       style_config?: StyleConfig | null;
       paint?: Record<string, unknown>;
+      label_config?: LabelConfig | null;
     };
     for (const c of getDataDrivenColumnsForLayer(layerWithStyle)) cols.add(c);
   }

--- a/frontend/src/components/builder/map-sync.ts
+++ b/frontend/src/components/builder/map-sync.ts
@@ -814,7 +814,12 @@ function syncVectorLayer(
   if (!canUseCluster) {
     removeClusterCompanionLayers(map, layerId);
     signatureMap.delete(sourceId);
-    signatureMap.delete(`${sourceId}::tileurl`);
+    // NOTE: do NOT delete the `${sourceId}::tileurl` key here. This block runs on
+    // every sync for non-cluster vector layers (the common case); clearing the key
+    // each pass would make the guarded refresh below always see `undefined` and
+    // call setTiles on every syncLayersToMap pass, defeating the flicker/refetch
+    // guard. The key is cleared only when the source is actually removed/recreated
+    // (the type-change block above) and is updated in place when the URL changes.
   }
 
   const layerLayout = layer.layout ?? {};

--- a/frontend/src/components/viewer/ViewerMap.tsx
+++ b/frontend/src/components/viewer/ViewerMap.tsx
@@ -676,6 +676,7 @@ export const ViewerMap = memo(function ViewerMap({
           : getDataDrivenColumnsForLayer({
               style_config: layer.style_config ?? null,
               paint: (layer.paint as Record<string, unknown> | undefined) ?? {},
+              label_config: layer.label_config ?? null,
             });
         const newUrl = strategy.kind === 'server-tile'
           ? buildClusterTileUrl(layer.table_name, token, tileBaseUrl, undefined, {


### PR DESCRIPTION
Fixes #195.

## Problem
Ask AI confirmed **"Applied 1 change"** after a label action (e.g. "Label each county with its name" on the NY Income choropleth at statewide z6), but no labels appeared — reading as a hallucination and eroding trust in the assistant.

## Root cause(s)
**1. Label columns stripped from tiles at low zoom.** The tile server projects no attribute columns at z<10 (Phase 269 H-23); the frontend opts them back in via `cols=`, built by `getDataDrivenColumnsForLayer` (`map-sync.ts`). That collector inspected `style_config` and paint expressions but **not `label_config.column`** — a label's `text-field: ["get", col]` is a *layout* prop on a separate companion symbol layer, invisible to the paint walk. So labeling by a non-styling column (county name) stripped it from the tile → blank `text-field` → no labels until z≥10.

**2. Existing source never refreshed its tiles on `cols` change.** When a label is added live to an already-rendered vector source, `setTiles` only fired on the server-cluster path, so the source kept its old `cols`. Even with (1) fixed, the column wouldn't be requested.

## Changes
- **`map-sync.ts`** — `getDataDrivenColumnsForLayer` now reads `label_config.column`; both callers widened. Non-cluster vector sources `setTiles` when the computed tileUrl changes, tracked via `signatureStore` (`${sourceId}::tileurl`; seed-on-create, clear-on-teardown, refetch only on change → no flicker).
- **`ViewerMap.tsx`** — passes `label_config` to the collector so saved maps in the public viewer self-heal too.
- **`map-sync.data-driven-cols.test.ts`** — unit coverage for label-column collection + source union.

## Follow-on fix found during verification: Ask AI "Undo" did nothing
Live testing surfaced a second, same-class trust bug: the **Undo** button reported success but left the change on the map.

- **Cause:** `ChatPanel.handleUndo` restored a snapshot field-by-field through the individual dispatch handlers. Each routes through `applyLayerUpdate`, which rebuilds the layer from `layersRef.current` — a ref that only refreshes between renders. Across the synchronous restore loop the calls clobbered each other; the unconditional `style_config` restore re-stamped the stale `label_config`, silently dropping the revert.
- **Fix:** new `onRestoreLayers` action restores each snapshotted layer **wholesale in one `setState`**; `handleUndo` calls it once. The map reconciles via `BuilderMap`'s declarative `syncLayersToMap` effect (adds/updates/**removes** the companion label layer to match restored state). `ChatPanel.test.tsx` undo test rewritten to the atomic-restore contract.

## Out of scope (intentional, per the issue's accepted outcomes)
No AI prompt/confirmation-wording changes, no auto-zoom, no collision-culling changes. The income-by-county case (label column == styling column) already has the data in the tile; its sparse statewide-z6 labels are inherent MapLibre collision culling, and the issue explicitly accepts "the effect appears at a higher zoom."

## Verification
**Unit / static (local):**
- `vitest` map-sync suites (data-driven-cols, dedupe, cluster, heatmap-cols): 35/35
- `vitest` ChatPanel + use-builder-layers + BuilderRail: 80/80
- `tsc -b --noEmit`: clean · `eslint` on changed files: clean

**Live (Playwright MCP, NY Income map at statewide z6.2):**
- Render: Ask AI "Label each county with its name" → tile requests flipped `cols=median_hh_inc_acs` → `cols=county,median_hh_inc_acs` (re-fetched [200]); 48–86 county-name labels render where it was previously blank.
- Undo: clicking Undo removes the label layer (rendered labels 48 → 0, "Labels on: county" badge gone, clean choropleth).
