### PR TITLE
[codex] fix installer Docker Compose version check

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -136,7 +136,7 @@ say "Install directory: $INSTALL_DIR"
 need_command git
 need_command docker
 
-docker compose version >/dev/null 2>&1 || fail "Docker Compose v2 is required. Install Docker Desktop or the docker compose plugin."
+docker compose --version >/dev/null 2>&1 || fail "Docker Compose v2 is required. Install Docker Desktop or the docker compose plugin."
 
 # If the user already cd'd into a checkout, use it. Otherwise honor INSTALL_DIR.
 PROJECT_HINT=""


### PR DESCRIPTION
## Summary

- Update `scripts/install.sh` to probe Docker Compose with `docker compose --version`.
- Keep the existing failure message and v2 plugin requirement unchanged.

## Why

The installer currently checks Docker Compose with `docker compose version`, but the reported CLI path expects the version check to use the `--version` flag. This keeps the installer prerequisite check aligned with that form.

## Validation

- `bash -n scripts/install.sh`
- `sh -n scripts/install.sh`
- `docker compose --version >/dev/null 2>&1`
- pre-commit hooks run during commit