### PR TITLE
[codex] harden GeoLens installer startup checks

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -119,7 +119,7 @@ services:
       - ./scripts/init-db.sh:/docker-entrypoint-initdb.d/10-init.sh
       - ./db/postgresql.conf:/etc/postgresql/custom.conf:ro
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER} -d ${POSTGRES_DB}"]
+      test: ["CMD-SHELL", "pg_isready -h 127.0.0.1 -p 5432 -U ${POSTGRES_USER} -d ${POSTGRES_DB}"]
       interval: 5s
       timeout: 5s
       retries: 5

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -179,6 +179,18 @@ else
   say ".env already has admin credentials; leaving unchanged."
 fi
 
+# Docker Compose interpolates required MinIO variables even when the cloud-dev
+# profile is inactive, so populate generated values unless the operator already
+# supplied them for local S3 testing.
+existing_minio_user="$(get_env_value MINIO_ROOT_USER)"
+existing_minio_pass="$(get_env_value MINIO_ROOT_PASSWORD)"
+if [ -z "$existing_minio_user" ]; then
+  update_env_value MINIO_ROOT_USER "$(generate_jwt_secret)"
+fi
+if [ -z "$existing_minio_pass" ]; then
+  update_env_value MINIO_ROOT_PASSWORD "$(generate_jwt_secret)"
+fi
+
 # Read the configured ports from .env so the in-use check matches what compose
 # will actually bind, even if the user changed DB_PORT/API_PORT/FRONTEND_PORT.
 db_port="$(get_env_value DB_PORT)"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -136,7 +136,7 @@ say "Install directory: $INSTALL_DIR"
 need_command git
 need_command docker
 
-docker compose up --detach --help >/dev/null 2>&1 || fail "Docker Compose v2 is required. Install Docker Desktop or the docker compose plugin."
+docker compose up --help >/dev/null 2>&1 || fail "Docker Compose v2 is required. Install Docker Desktop or the docker compose plugin."
 
 # If the user already cd'd into a checkout, use it. Otherwise honor INSTALL_DIR.
 PROJECT_HINT=""

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -136,7 +136,7 @@ say "Install directory: $INSTALL_DIR"
 need_command git
 need_command docker
 
-docker compose --version >/dev/null 2>&1 || fail "Docker Compose v2 is required. Install Docker Desktop or the docker compose plugin."
+docker compose up --detach --help >/dev/null 2>&1 || fail "Docker Compose v2 is required. Install Docker Desktop or the docker compose plugin."
 
 # If the user already cd'd into a checkout, use it. Otherwise honor INSTALL_DIR.
 PROJECT_HINT=""
@@ -193,7 +193,7 @@ check_port "$api_port"
 check_port "$fe_port"
 
 say "Starting GeoLens..."
-docker compose up -d
+docker compose up --detach
 
 # Wait up to 90s for the stack to become healthy. The migrate one-shot must
 # exit 0; every healthcheck-having service must report (healthy). If migrate


### PR DESCRIPTION
## Summary

- Replace `docker compose up -d` with `docker compose up --detach` in `scripts/install.sh`.
- Relax the Docker Compose prerequisite probe to `docker compose up --help`; the real startup command still uses `--detach`, but some Compose builds reject option-bearing help probes such as `docker compose up --detach --help`.
- Generate `MINIO_ROOT_USER` and `MINIO_ROOT_PASSWORD` when missing so default installs satisfy Docker Compose interpolation for inactive `cloud-dev` profile services.
- Make the Postgres healthcheck verify TCP readiness on `127.0.0.1:5432`, matching how `migrate` connects, instead of passing against the transient local socket during database initialization.

## Root Cause

The installer had two separate Compose-time failure modes:

1. Some Docker Compose builds reject `docker compose up --detach --help`, producing a false "Docker Compose v2 is required" failure before install starts. Probing `docker compose up --help` still verifies Compose v2 subcommand support without relying on parser behavior for flags before help.
2. Docker Compose interpolates `${MINIO_ROOT_USER:?…}` and `${MINIO_ROOT_PASSWORD:?…}` while parsing the Compose file, even when the profiled `cloud-dev` services are inactive. Missing values in `.env` can abort startup before services are created.

The real-stack QA also exposed a startup race: `pg_isready` without `-h` can pass against Postgres' temporary local-socket init server before the final TCP listener is ready. `migrate` connects over TCP to `db:5432`, so the healthcheck now waits on TCP readiness too.

## QA

- `sh -n scripts/install.sh`
- `bash -n scripts/install.sh`
- `docker compose up --help >/dev/null 2>&1`
- `DB_PORT=15446 API_PORT=18013 FRONTEND_PORT=18092 JWT_SECRET_KEY=0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef GEOLENS_ADMIN_USERNAME=qa GEOLENS_ADMIN_PASSWORD='Abcd1234!xyz' MINIO_ROOT_USER=minioqa MINIO_ROOT_PASSWORD=minioqa123 docker compose config >/tmp/geolens-compose-config.out`
- Real local installer run from this branch: `COMPOSE_PROJECT_NAME=geolens_installer_qa4 sh scripts/install.sh`
- Verified resulting stack: `docker compose ps` showed `api`, `db`, `frontend`, `titiler`, and `worker` healthy.
- Verified HTTP reachability: `curl http://localhost:18092/` returned `200`; `curl http://localhost:18013/health` returned `200`.
- Cleaned up QA stack with `COMPOSE_PROJECT_NAME=geolens_installer_qa4 docker compose down -v`.
- Commit-time pre-commit hooks passed.

`shellcheck` is not installed in the local environment, so it was not run.