### PR TITLE
fix(installer): pin to latest release tag + tolerate exited one-shots in health gate

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -149,7 +149,26 @@ elif [ -d "$INSTALL_DIR/.git" ]; then
 elif [ -e "$INSTALL_DIR" ]; then
   fail "$INSTALL_DIR exists but is not a Git checkout. Move it or set GEOLENS_INSTALL_DIR."
 else
-  git clone --depth 1 "$REPO_URL" "$INSTALL_DIR"
+  # Install the latest published release tag for a reproducible build. Resolve it
+  # from the remote so no full clone is needed first; semver tags are sorted
+  # numerically (not lexically, so v1.10.0 > v1.9.0). Fall back to the default
+  # branch when no release tag resolves (offline, or a fork with no releases).
+  # Override with GEOLENS_REF=<tag|branch> to pin a specific ref or track main.
+  ref="${GEOLENS_REF:-}"
+  if [ -z "$ref" ]; then
+    ref="$(git ls-remote --tags --refs "$REPO_URL" 2>/dev/null \
+      | awk -F/ '{print $NF}' \
+      | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' \
+      | sort -t. -k1.2,1n -k2,2n -k3,3n \
+      | tail -n 1)"
+  fi
+  if [ -n "$ref" ]; then
+    say "Installing release $ref"
+    git clone --depth 1 --branch "$ref" "$REPO_URL" "$INSTALL_DIR"
+  else
+    warn "Could not resolve a release tag; cloning the default branch."
+    git clone --depth 1 "$REPO_URL" "$INSTALL_DIR"
+  fi
   cd "$INSTALL_DIR"
   PROJECT_HINT="$INSTALL_DIR"
 fi
@@ -233,7 +252,11 @@ wait_for_healthy() {
       fi
     fi
 
-    unhealthy=$(docker compose ps --format '{{.Service}}|{{.Status}}' 2>/dev/null | grep -v '|.*(healthy)' | grep -v '^$' || true)
+    # Treat as unhealthy any service that is neither reporting (healthy) nor a
+    # successfully-exited one-shot. The migrate one-shot exits 0 (its failure is
+    # caught above); some Compose versions list exited containers in `ps` without
+    # `-a`, so exclude `Exited (0)` explicitly rather than relying on that.
+    unhealthy=$(docker compose ps --format '{{.Service}}|{{.Status}}' 2>/dev/null | grep -v '|.*(healthy)' | grep -v '|Exited (0)' | grep -v '^$' || true)
     if [ -z "$unhealthy" ]; then
       printf '\n'
       return 0


### PR DESCRIPTION
## Two installer robustness fixes

### 1. Pin fresh clones to the latest release tag
Now that public releases are tagged (`v1.2.0`, `v1.2.2`), `curl … | sh` users currently land on **tip-of-`main`** rather than the released build. Since the app services build from the cloned source tree (only titiler/minio/valkey are pinned external images), the checked-out ref *is* the version — so a fresh install today builds bleeding-edge `main`.

This resolves the latest semver tag via `git ls-remote` (no pre-clone needed), sorts numerically (so `v1.10.0` > `v1.9.0`, not lexical), and `git clone --depth 1 --branch <tag>`. Falls back to the default branch when no tag resolves (offline / fork with no releases). Override with `GEOLENS_REF=<tag|branch>` to pin a specific ref or track `main`. The existing-checkout reuse paths are unchanged.

### 2. Tolerate successfully-exited one-shots in the health gate
Flagged by Codex review on the getgeolens.com installer copy. The `migrate` one-shot exits `0` (its *non-zero* failure is already caught earlier in `wait_for_healthy`), but some Docker Compose versions list exited containers in `docker compose ps` **without** `-a`. The previous `grep -v '(healthy)'` kept such a line in `unhealthy`, so the installer would wait the full 90s and then **falsely report failure even though migration succeeded**.

Empirically this does *not* manifest on Compose v2+ here (exited one-shots are hidden from `ps` by default), so it's a cross-version fragility rather than a live bug on current Docker — but the explicit `grep -v 'Exited (0)'` guard is cheap and makes the gate correct regardless of version.

## Verification
- `sh -n` clean.
- Tag selector resolves `v1.2.2` against the live remote.
- Health-gate grep with a simulated `migrate|Exited (0)` row now yields an empty `unhealthy` set.

## Related
The public installer served at `getgeolens.com/install.sh` is a byte-identical copy of this script (getgeolens.com#20 adds the drift contract). That PR will be re-synced to match this one.