### PR TITLE
fix(installer): use 'docker compose up -d' not '--detach'

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -224,7 +224,10 @@ check_port "$api_port"
 check_port "$fe_port"
 
 say "Starting GeoLens..."
-docker compose up --detach
+# Use the short `-d` flag, not `--detach`: `-d` is accepted by every Docker
+# Compose version, while some older Compose builds reject the `--detach` long
+# form with "unknown flag: --detach".
+docker compose up -d
 
 # Wait up to 90s for the stack to become healthy. The migrate one-shot must
 # exit 0; every healthcheck-having service must report (healthy). If migrate


### PR DESCRIPTION
Follow-up to #208. A user's test machine aborted right after `Starting GeoLens…` with:

```
unknown flag: --detach

Usage:  docker [OPTIONS] COMMAND [ARG...]
```

Some older Docker Compose builds reject the `--detach` long form (the install had already cloned v1.2.2, pinned the release, and generated secrets — only the final `up` failed). The short `-d` flag is accepted by **every** Compose version (v1 and v2). This reverts the earlier 'avoid detach shorthand' change that introduced the incompatibility.

The public `getgeolens.com/install.sh` copy will be re-synced to match.