### PR TITLE
fix(installer): detect Compose plugin via 'docker compose version' subcommand

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -136,7 +136,14 @@ say "Install directory: $INSTALL_DIR"
 need_command git
 need_command docker
 
-docker compose up --help >/dev/null 2>&1 || fail "Docker Compose v2 is required. Install Docker Desktop or the docker compose plugin."
+# Verify the Compose v2 plugin via the `version` SUBCOMMAND, not a `--version`/
+# `--help` flag. `docker --version` and `docker --help` are answered by the
+# docker root command and exit 0 even when no `compose` plugin is installed, so
+# flag-based checks false-pass — then the install dies cryptically at the first
+# real `docker compose` call ("unknown flag" / "unknown shorthand flag" with
+# docker's root usage). `docker compose version` only exits 0 when the plugin is
+# actually present.
+docker compose version >/dev/null 2>&1 || fail "Docker Compose v2 is required. Install Docker Desktop or the docker compose plugin."
 
 # If the user already cd'd into a checkout, use it. Otherwise honor INSTALL_DIR.
 PROJECT_HINT=""


### PR DESCRIPTION
Follow-up to #209. A user's machine has the `docker` CLI but **no Docker Compose v2 plugin**. The installer's guard used `docker compose up --help`, but `--help` (like `--version`) is answered by the `docker` **root** command and exits 0 even with no plugin — a false pass. So the install cloned the repo, generated secrets, and only then died cryptically:

```
unknown shorthand flag: 'd' in -d
Usage:  docker [OPTIONS] COMMAND [ARG...]
```

(The user confirmed: `docker compose --version` works — it's the docker root flag printing the *Docker* version — but `docker compose version` fails.)

The `version` **subcommand** only exits 0 when the plugin is actually present, so this fails fast with the existing `Docker Compose v2 is required. Install Docker Desktop or the docker compose plugin.` message. Note this also corrects the original intent of the `codex/fix-install-compose-version` work — the right token is the subcommand, not the `--version` flag.

Public `getgeolens.com/install.sh` will be re-synced.