### PR TITLE
fix(catalog): authorize relationship targets in related-record endpoints

### DIFF
--- a/backend/app/modules/catalog/datasets/api/router_metadata.py
+++ b/backend/app/modules/catalog/datasets/api/router_metadata.py
@@ -10,6 +10,7 @@ from fastapi import (
     Response,
     status,
 )
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.modules.audit.service import AuditEvent, audit_emit
@@ -356,11 +357,13 @@ async def list_dataset_relationships(
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND, detail="Dataset not found"
         )
-    await check_dataset_access_or_anonymous(db, dataset, dataset_id, user)
+    user_roles = await check_dataset_access_or_anonymous(db, dataset, dataset_id, user)
 
     from app.modules.catalog.datasets.domain.service import list_relationships
 
-    items = await list_relationships(db, dataset.record_id, skip=skip, limit=limit)
+    items = await list_relationships(
+        db, dataset.record_id, user=user, user_roles=user_roles, skip=skip, limit=limit
+    )
     return [DatasetRelationshipResponse(**item) for item in items]
 
 
@@ -384,6 +387,21 @@ async def create_dataset_relationship(
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND, detail="Dataset not found"
         )
+    user_roles = await check_dataset_access(db, dataset, dataset_id, current_user)
+
+    from app.modules.catalog.datasets.domain.models import Dataset
+
+    target_result = await db.execute(
+        select(Dataset).where(Dataset.record_id == body.target_dataset_id)
+    )
+    target_dataset = target_result.scalar_one_or_none()
+    if target_dataset is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Target dataset not found"
+        )
+    await check_dataset_access(
+        db, target_dataset, target_dataset.id, current_user, user_roles=user_roles
+    )
 
     rel = await create_relationship(db, dataset.record_id, body)
     await db.commit()
@@ -397,7 +415,23 @@ async def delete_dataset_relationship(
     current_user: Identity = Depends(require_permission("edit_metadata")),
 ) -> Response:
     """Delete a FK relationship. Editor+ required."""
-    from app.modules.catalog.datasets.domain.service import delete_relationship
+    from app.modules.catalog.datasets.domain.service import (
+        delete_relationship,
+        get_relationship_datasets,
+    )
+
+    relationship = await get_relationship_datasets(db, relationship_id)
+    if relationship is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Relationship not found"
+        )
+    _rel, source_dataset, target_dataset = relationship
+    user_roles = await check_dataset_access(
+        db, source_dataset, source_dataset.id, current_user
+    )
+    await check_dataset_access(
+        db, target_dataset, target_dataset.id, current_user, user_roles=user_roles
+    )
 
     try:
         await delete_relationship(db, relationship_id)
@@ -430,11 +464,32 @@ async def get_feature_related_records(
         )
     await check_dataset_access_or_anonymous(db, dataset, dataset_id, user)
 
-    from app.modules.catalog.datasets.domain.service import get_related_records
+    from app.modules.catalog.datasets.domain.service import (
+        get_related_records,
+        get_relationship_datasets,
+    )
+
+    relationship = await get_relationship_datasets(db, relationship_id)
+    if relationship is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Relationship not found"
+        )
+    rel, _source_dataset, target_dataset = relationship
+    if rel.source_dataset_id != dataset.record_id:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Relationship not found"
+        )
+    await check_dataset_access_or_anonymous(db, target_dataset, target_dataset.id, user)
 
     try:
         result = await get_related_records(
-            db, dataset_id, gid, relationship_id, limit=limit, after=after
+            db,
+            dataset_id,
+            gid,
+            relationship_id,
+            source_record_id=dataset.record_id,
+            limit=limit,
+            after=after,
         )
     except ValueError as exc:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc))

--- a/backend/app/modules/catalog/datasets/domain/service.py
+++ b/backend/app/modules/catalog/datasets/domain/service.py
@@ -57,6 +57,7 @@ from app.modules.catalog.datasets.domain.service_relationships import (
     delete_relationship,
     get_related_datasets,
     get_related_records,
+    get_relationship_datasets,
     list_relationships,
 )
 
@@ -77,6 +78,7 @@ __all__ = [
     "get_datasets_list",
     "get_related_datasets",
     "get_related_records",
+    "get_relationship_datasets",
     "list_attributes",
     "list_datasets",
     "list_relationships",

--- a/backend/app/modules/catalog/datasets/domain/service_relationships.py
+++ b/backend/app/modules/catalog/datasets/domain/service_relationships.py
@@ -27,7 +27,7 @@ from app.modules.catalog.datasets.domain.models import (
     Record,
 )
 from app.modules.catalog.datasets.domain.service_query import get_dataset
-from app.platform.extensions import get_catalog_port
+from app.platform.extensions import get_catalog_port, get_permission_extension
 
 logger = structlog.stdlib.get_logger(__name__)
 
@@ -37,6 +37,7 @@ __all__ = [
     "delete_relationship",
     "get_related_datasets",
     "get_related_records",
+    "get_relationship_datasets",
     "list_relationships",
 ]
 
@@ -175,32 +176,44 @@ async def list_relationships(
     session: AsyncSession,
     dataset_id: uuid.UUID,
     *,
+    user: Identity | None = None,
+    user_roles: set[str] | None = None,
     skip: int = 0,
     limit: int | None = None,
 ) -> list:
     """List FK relationships where this dataset is the source.
 
-    Joins with records table to include target_dataset_title. Supports
-    optional ``skip``/``limit`` pagination (PERF-N16) to bound response
-    size for datasets with hundreds of auto-detected relationships.
+    Joins with records table to include target_dataset_title. Each relationship's
+    target dataset is filtered through the permission policy so that callers never
+    see relationships (or target metadata) for datasets they cannot access — a
+    public source dataset must not leak the id/title of a private target. Because
+    visibility is enforced per-row, ``skip``/``limit`` pagination (PERF-N16) is
+    applied to the *visible* subset after filtering.
     """
     from app.modules.catalog.datasets.domain.models import DatasetRelationship
 
+    user_roles = user_roles or set()
+    # Inner-join Dataset (and its Record, eager-loaded via lazy="joined") so the
+    # target dataset object is available for the access check below. Relationships
+    # whose target has no backing Dataset are dropped (fail-closed).
     stmt = (
-        select(DatasetRelationship, Record.title)
-        .outerjoin(Record, DatasetRelationship.target_dataset_id == Record.id)
+        select(DatasetRelationship, Dataset, Record.title)
+        .join(Dataset, DatasetRelationship.target_dataset_id == Dataset.record_id)
+        .join(Record, Dataset.record_id == Record.id)
         .where(DatasetRelationship.source_dataset_id == dataset_id)
         .order_by(DatasetRelationship.created_at)
     )
-    if skip:
-        stmt = stmt.offset(skip)
-    if limit is not None:
-        stmt = stmt.limit(limit)
     result = await session.execute(stmt)
     rows = result.all()
-    items = []
-    for rel, title in rows:
-        items.append(
+
+    permission_ext = get_permission_extension()
+    visible_items = []
+    for rel, target_ds, title in rows:
+        if not await permission_ext.can_access_dataset(
+            session, target_ds, target_ds.id, user, user_roles=user_roles
+        ):
+            continue
+        visible_items.append(
             {
                 "id": rel.id,
                 "source_dataset_id": rel.source_dataset_id,
@@ -212,7 +225,44 @@ async def list_relationships(
                 "target_dataset_title": title,
             }
         )
-    return items
+
+    if skip:
+        visible_items = visible_items[skip:]
+    if limit is not None:
+        visible_items = visible_items[:limit]
+    return visible_items
+
+
+async def get_relationship_datasets(
+    session: AsyncSession,
+    relationship_id: uuid.UUID,
+) -> tuple["DatasetRelationship", Dataset, Dataset] | None:
+    """Load a relationship together with its source and target Dataset objects.
+
+    Returns ``None`` if the relationship is missing or either endpoint has no
+    backing Dataset. Used by the API layer to enforce source-binding and
+    target-visibility checks before exposing related records.
+    """
+    from app.modules.catalog.datasets.domain.models import DatasetRelationship
+
+    result = await session.execute(
+        select(DatasetRelationship).where(DatasetRelationship.id == relationship_id)
+    )
+    rel = result.scalar_one_or_none()
+    if rel is None:
+        return None
+
+    source_result = await session.execute(
+        select(Dataset).where(Dataset.record_id == rel.source_dataset_id)
+    )
+    source_ds = source_result.scalar_one_or_none()
+    target_result = await session.execute(
+        select(Dataset).where(Dataset.record_id == rel.target_dataset_id)
+    )
+    target_ds = target_result.scalar_one_or_none()
+    if source_ds is None or target_ds is None:
+        return None
+    return rel, source_ds, target_ds
 
 
 async def delete_relationship(
@@ -256,18 +306,40 @@ async def _detect_fk_candidates(
     if not candidates:
         return {}
 
-    match_result = await session.execute(
+    # A public source dataset must not auto-link to private/unpublished targets:
+    # the resulting relationship would let anonymous callers reach the private
+    # target's rows via the related-records endpoint. Restrict matches to
+    # public+published targets when the source itself is public+published.
+    source_visibility_result = await session.execute(
+        select(Record.visibility, Record.record_status).where(Record.id == record_id)
+    )
+    source_visibility = source_visibility_result.one_or_none()
+    source_is_public = (
+        source_visibility is not None
+        and source_visibility[0] == "public"
+        and source_visibility[1] == "published"
+    )
+
+    match_stmt = (
         select(
             AttributeMetadata.field_name,
             Dataset.record_id,
         )
         .join(Dataset, AttributeMetadata.dataset_id == Dataset.id)
+        .join(Record, Dataset.record_id == Record.id)
         .where(
             AttributeMetadata.field_name.in_(candidates),
             AttributeMetadata.semantic_role == "identifier",
             Dataset.record_id != record_id,  # skip self-references
         )
     )
+    if source_is_public:
+        match_stmt = match_stmt.where(
+            Record.visibility == "public",
+            Record.record_status == "published",
+        )
+
+    match_result = await session.execute(match_stmt)
 
     matches_by_col: dict[str, list[uuid.UUID]] = {}
     for field_name, target_record_id in match_result.all():
@@ -401,6 +473,7 @@ async def get_related_records(
     feature_gid: int,
     relationship_id: uuid.UUID,
     *,
+    source_record_id: uuid.UUID | None = None,
     limit: int = 50,
     after: int = 0,
 ) -> dict:
@@ -408,6 +481,12 @@ async def get_related_records(
 
     Looks up the FK value in the source table, then queries the target table
     for matching rows.
+
+    ``source_record_id`` binds the relationship to the source dataset in the
+    URL: a relationship id cannot be replayed through an unrelated source
+    dataset to read its target. Callers (the API layer) must pass the
+    authorized source record id; access to the target dataset is authorized
+    separately at the call site.
     """
     from app.modules.catalog.datasets.domain.models import DatasetRelationship
 
@@ -418,11 +497,15 @@ async def get_related_records(
     rel = result.scalar_one_or_none()
     if rel is None:
         raise ValueError("Relationship not found")
+    if source_record_id is not None and rel.source_dataset_id != source_record_id:
+        raise ValueError("Relationship not found")
 
     # 2. Load source dataset to get table_name
     source_ds = await get_dataset(session, dataset_id)
     if source_ds is None:
         raise ValueError("Source dataset not found")
+    if rel.source_dataset_id != source_ds.record_id:
+        raise ValueError("Relationship not found")
 
     # 3. Load target dataset to get table_name
     # target_dataset_id points to a Record, need to find its Dataset

--- a/backend/tests/test_fk_relationships.py
+++ b/backend/tests/test_fk_relationships.py
@@ -8,7 +8,13 @@ import uuid
 
 import pytest
 from httpx import AsyncClient
+from sqlalchemy import select, text
 
+from app.modules.catalog.datasets.domain.models import (
+    AttributeMetadata,
+    DatasetRelationship,
+)
+from app.modules.catalog.datasets.domain.service import auto_detect_relationships
 from tests.factories import create_dataset, get_user_id
 
 
@@ -87,6 +93,196 @@ class TestFKRelationships:
         assert isinstance(items, list)
         assert len(items) >= 1
         assert any(r["source_column"] == "ref_id" for r in items)
+
+    async def test_list_relationships_hides_private_targets_from_anonymous(
+        self,
+        client: AsyncClient,
+        admin_auth_header: dict,
+        test_db_session,
+    ):
+        """Anonymous source access must not reveal private target metadata."""
+        admin_id = await get_user_id(test_db_session, "admin")
+        source = await create_dataset(
+            test_db_session,
+            created_by=admin_id,
+            name="Public Relationship Source",
+            visibility="public",
+            record_status="published",
+        )
+        target = await create_dataset(
+            test_db_session,
+            created_by=admin_id,
+            name="Private Relationship Target",
+            visibility="private",
+            record_status="published",
+        )
+
+        create_resp = await client.post(
+            f"/datasets/{source.id}/relationships/",
+            json={
+                "target_dataset_id": str(target.record_id),
+                "source_column": "private_ref_id",
+            },
+            headers=admin_auth_header,
+        )
+        assert create_resp.status_code == 201, create_resp.text
+
+        resp = await client.get(f"/datasets/{source.id}/relationships/")
+
+        assert resp.status_code == 200, resp.text
+        assert resp.json() == []
+
+    async def test_related_records_rejects_private_target_for_anonymous(
+        self,
+        client: AsyncClient,
+        admin_auth_header: dict,
+        test_db_session,
+    ):
+        """Related-record reads require access to both source and target datasets."""
+        admin_id = await get_user_id(test_db_session, "admin")
+        source = await create_dataset(
+            test_db_session,
+            created_by=admin_id,
+            name="Public Related Source",
+            visibility="public",
+            record_status="published",
+        )
+        target = await create_dataset(
+            test_db_session,
+            created_by=admin_id,
+            name="Private Related Target",
+            visibility="private",
+            record_status="published",
+        )
+        await test_db_session.execute(
+            text(
+                f"CREATE TABLE data.{source.table_name} "
+                "(gid integer PRIMARY KEY, private_ref_id integer)"
+            )
+        )
+        await test_db_session.execute(
+            text(
+                f"CREATE TABLE data.{target.table_name} "
+                "(gid integer PRIMARY KEY, private_ref_id integer, secret text)"
+            )
+        )
+        await test_db_session.execute(
+            text(
+                f"INSERT INTO data.{source.table_name} "
+                "(gid, private_ref_id) VALUES (1, 7)"
+            )
+        )
+        await test_db_session.execute(
+            text(
+                f"INSERT INTO data.{target.table_name} "
+                "(gid, private_ref_id, secret) VALUES (1, 7, 'hidden')"
+            )
+        )
+        await test_db_session.commit()
+
+        create_resp = await client.post(
+            f"/datasets/{source.id}/relationships/",
+            json={
+                "target_dataset_id": str(target.record_id),
+                "source_column": "private_ref_id",
+                "target_column": "private_ref_id",
+            },
+            headers=admin_auth_header,
+        )
+        assert create_resp.status_code == 201, create_resp.text
+        rel_id = create_resp.json()["id"]
+
+        resp = await client.get(f"/datasets/{source.id}/features/1/related/{rel_id}/")
+
+        assert resp.status_code == 404, resp.text
+
+    async def test_related_records_rejects_relationship_for_different_source(
+        self,
+        client: AsyncClient,
+        admin_auth_header: dict,
+        test_db_session,
+    ):
+        """Relationship ids cannot be replayed through a different source dataset URL."""
+        admin_id = await get_user_id(test_db_session, "admin")
+        source = await create_dataset(
+            test_db_session, created_by=admin_id, name="Bound Source"
+        )
+        other_source = await create_dataset(
+            test_db_session, created_by=admin_id, name="Wrong Source"
+        )
+        target = await create_dataset(
+            test_db_session, created_by=admin_id, name="Bound Target"
+        )
+
+        create_resp = await client.post(
+            f"/datasets/{source.id}/relationships/",
+            json={
+                "target_dataset_id": str(target.record_id),
+                "source_column": "target_id",
+                "target_column": "target_id",
+            },
+            headers=admin_auth_header,
+        )
+        assert create_resp.status_code == 201, create_resp.text
+        rel_id = create_resp.json()["id"]
+
+        resp = await client.get(
+            f"/datasets/{other_source.id}/features/1/related/{rel_id}/",
+            headers=admin_auth_header,
+        )
+
+        assert resp.status_code == 404, resp.text
+
+    async def test_auto_detect_relationships_skips_private_targets_for_public_source(
+        self,
+        test_db_session,
+    ):
+        """Auto-detection must not create public-to-private relationships."""
+        admin_id = await get_user_id(test_db_session, "admin")
+        source = await create_dataset(
+            test_db_session,
+            created_by=admin_id,
+            name="Public Auto Source",
+            visibility="public",
+            record_status="published",
+        )
+        target = await create_dataset(
+            test_db_session,
+            created_by=admin_id,
+            name="Private Auto Target",
+            visibility="private",
+            record_status="published",
+        )
+        test_db_session.add(
+            AttributeMetadata(
+                dataset_id=target.id,
+                field_name="private_ref_id",
+                semantic_role="identifier",
+            )
+        )
+        await test_db_session.commit()
+
+        created = await auto_detect_relationships(
+            test_db_session,
+            source.id,
+            source.record_id,
+            [{"name": "private_ref_id"}],
+        )
+        await test_db_session.commit()
+
+        relationships = (
+            (
+                await test_db_session.execute(
+                    select(DatasetRelationship).where(
+                        DatasetRelationship.source_dataset_id == source.record_id
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+        assert created == []
+        assert relationships == []
 
     async def test_delete_relationship(
         self,

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -780,7 +780,11 @@ def test_decomposed_service_modules_stay_within_size_budgets() -> None:
         # time. Caps set ~20-30 LOC above current size to allow modest growth
         # while still tripping CI on substantial regrowth back toward the
         # original 1407-LOC god module.
-        "backend/app/modules/catalog/datasets/domain/service_relationships.py": 480,
+        # Security fix (relationship target authz): +83 LOC for target-visibility
+        # filtering in list_relationships, the get_relationship_datasets loader,
+        # source/target binding in get_related_records, and the public-source
+        # auto-detect guard. Cap raised 480 -> 580 for ~30 LOC headroom.
+        "backend/app/modules/catalog/datasets/domain/service_relationships.py": 580,
         "backend/app/modules/catalog/datasets/domain/service_metadata.py": 460,
         "backend/app/modules/catalog/datasets/domain/service_query.py": 390,
         # Phase 276 CODE-02: chat_*.py sub-modules are all under the 350


### PR DESCRIPTION
## Security fix — high severity (codex finding 5c7af0bc, attack-path: high)

Dataset FK-relationship endpoints authorized only the **source** dataset from the URL and never the relationship **target**. A public dataset with a relationship to a private dataset let an anonymous caller:

1. `GET /datasets/{public_id}/relationships/` → leak the private target's id + title and the relationship id, then
2. `GET /datasets/{public_id}/features/{gid}/related/{rel_id}/` → read rows from the private target's backing table.

Additional gaps: `get_related_records` never bound the relationship to the URL source dataset (replayable through any accessible source); auto-detection scanned all datasets' attribute metadata with no visibility filter (could auto-create public→private links); editor create/delete performed no resource-level check on source or target.

## Fix (defense in depth; read paths fail-closed)

**`api/router_metadata.py`**
- `list` — capture `user_roles`, pass user/roles into `list_relationships` for per-target visibility filtering.
- `create` — `check_dataset_access` on **both** source and resolved target.
- `delete` — load the relationship's source + target, `check_dataset_access` on both.
- `related` — load the relationship, reject when `rel.source_dataset_id != source.record_id`, `check_dataset_access_or_anonymous` on the target, and pass `source_record_id` down.

**`domain/service_relationships.py`**
- `list_relationships(user, user_roles)` — join the target `Dataset` (its `Record` eager-loaded via `lazy="joined"`), drop targets failing `can_access_dataset`, paginate the visible subset.
- new `get_relationship_datasets()` — load a relationship with its source + target `Dataset` objects.
- `_detect_fk_candidates` — when the source is public+published, restrict matches to public+published targets.
- `get_related_records(source_record_id=...)` — bind the relationship to the source (unconditional service-layer binding, independent of the router check).

**`domain/service.py`** — re-export `get_relationship_datasets` via the façade.

### Why layered
A private source auto-linked to a private target is already safe (read paths gate each target independently), so the auto-detect guard only blocks the public-source enumeration case. The read-path checks also cover the *source-published-later* scenario, where a pre-existing private→private relationship's source is promoted to public.

## Tests
New regression tests in `test_fk_relationships.py` (each fails without the fix):
- list hides private targets from anonymous
- related rejects a private target for anonymous
- related rejects relationship replay through a different source
- auto-detect skips private targets for a public source

`test_layering.py` LOC budget for `service_relationships.py` raised 480→580 (+83 LOC of authz logic, justified inline).

## Verification (local, live Postgres)
- `test_fk_relationships.py` — 10 passed (6 existing + 4 new)
- `test_layering.py` — 23 passed
- regression sweep — 139 passed (dataset router, ingestion, metadata IDOR, related-datasets)
- `ruff check` + `ruff format --check` clean; pre-commit hooks pass incl. the repo "Visibility Rule 1" route-auth guard