### PR TITLE
fix(maps): re-authorize each layer's dataset on anonymous map read endpoints (SEC-A)

### DIFF
--- a/backend/app/modules/catalog/maps/router.py
+++ b/backend/app/modules/catalog/maps/router.py
@@ -81,6 +81,7 @@ from app.modules.catalog.maps.service import (
     create_map,
     create_share_token,
     delete_map,
+    filter_layer_rows_by_dataset_visibility,
     get_active_share_token,
     get_dataset_meta,
     duplicate_map,
@@ -632,6 +633,7 @@ async def get_map_endpoint(
         )
 
     await _check_map_read_access(map_obj, user, db)
+    layer_tuples = await filter_layer_rows_by_dataset_visibility(db, layer_tuples, user)
     layers = _layers_from_tuples(layer_tuples)
     return _build_map_response(
         map_obj,
@@ -700,6 +702,7 @@ async def export_map_style_endpoint(
             detail="Map not found",
         )
     await _check_map_read_access(map_obj, user, db)
+    layer_tuples = await filter_layer_rows_by_dataset_visibility(db, layer_tuples, user)
     style = build_maplibre_style(map_obj, _layers_from_tuples(layer_tuples))
     return JSONResponse(
         content=style,

--- a/backend/app/modules/catalog/maps/service.py
+++ b/backend/app/modules/catalog/maps/service.py
@@ -46,6 +46,7 @@ from app.modules.catalog.maps.service_shared import (
     _fetch_layer_rows_ordered,
     _infer_layer_type,
     _resolve_save_response_metadata,
+    filter_layer_rows_by_dataset_visibility,
     generate_default_style,
     get_dataset_meta,
 )
@@ -82,6 +83,7 @@ __all__ = [
     "revoke_share_token_by_map",
     "_fetch_layer_rows_ordered",
     "_resolve_save_response_metadata",
+    "filter_layer_rows_by_dataset_visibility",
     "_apply_map_visibility_filter",
     "_infer_layer_type",
     "_validate_share_token",

--- a/backend/app/modules/catalog/maps/service_shared.py
+++ b/backend/app/modules/catalog/maps/service_shared.py
@@ -9,8 +9,10 @@ from sqlalchemy import Select, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import aliased
 
+from app.core.identity import Identity
 from app.modules.auth.models import User
-from app.modules.catalog.datasets.domain.models import Dataset, Record
+from app.modules.catalog.authorization import apply_visibility_filter, get_user_roles
+from app.modules.catalog.datasets.domain.models import Dataset, DatasetGrant, Record
 from app.modules.catalog.maps.models import Map, MapLayer
 from app.platform.extensions import get_catalog_port
 
@@ -222,6 +224,36 @@ async def _fetch_layer_rows_ordered(
         )
         for row in result.all()
     ]
+
+
+async def filter_layer_rows_by_dataset_visibility(
+    session: AsyncSession,
+    layer_rows: list[LayerRow],
+    user: Identity | None,
+) -> list[LayerRow]:
+    """Drop layer rows whose backing dataset is not visible to ``user``.
+
+    SEC-A: ``GET /maps/{id}`` and ``/style.json`` gate only the MAP, so a public
+    map referencing a private dataset would otherwise leak that dataset's metadata
+    (and, via the signed tile URL in style.json, its actual tiles) to anonymous
+    callers. This mirrors ``get_shared_map`` (service_public.py), which filters each
+    layer's dataset through ``apply_visibility_filter``. Layer order is preserved.
+
+    Do NOT swap this for ``bulk_check_dataset_access``: that dereferences ``user.id``
+    (crashes on anonymous ``user is None``) and lacks the published-status nuance.
+    """
+    if not layer_rows:
+        return layer_rows
+    user_roles = await get_user_roles(session, user) if user is not None else set()
+    layer_dataset_ids = {row.layer.dataset_id for row in layer_rows}
+    stmt = (
+        select(Dataset.id)
+        .join(Record, Dataset.record_id == Record.id)
+        .where(Dataset.id.in_(layer_dataset_ids))
+    )
+    stmt = apply_visibility_filter(stmt, user, user_roles, Record, DatasetGrant)
+    visible_ids = set((await session.execute(stmt)).scalars().all())
+    return [row for row in layer_rows if row.layer.dataset_id in visible_ids]
 
 
 async def _resolve_save_response_metadata(

--- a/backend/tests/test_maps.py
+++ b/backend/tests/test_maps.py
@@ -20,7 +20,7 @@ from sqlalchemy import select
 from app.modules.audit.models import AuditLog
 from app.modules.auth.models import User
 from app.modules.catalog.datasets.domain.models import Dataset, Record
-from app.modules.catalog.maps.models import MapLayer
+from app.modules.catalog.maps.models import Map, MapLayer
 from app.modules.catalog.maps.schemas import MapLayerDiffRequest
 from app.processing.raster.models import RasterAsset
 
@@ -417,6 +417,112 @@ class TestGetMap:
         """GET /maps/{id} without auth returns 404 (anonymous access allowed, map not found)."""
         resp = await client.get(f"/maps/{uuid.uuid4()}")
         assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# SEC-A: map READ endpoints must re-authorize each layer's dataset
+# ---------------------------------------------------------------------------
+
+
+class TestMapLayerDatasetVisibilityLeak:
+    """SEC-A (Phase 1170): a public map referencing a PRIVATE dataset must not
+    leak that dataset's metadata or a replayable signed tile URL to anonymous
+    callers. The map READ endpoints must filter layers by per-caller dataset
+    visibility, mirroring get_shared_map.
+    """
+
+    async def _public_map_with_layer(
+        self,
+        client: AsyncClient,
+        admin_auth_header: dict,
+        test_db_session,
+        *,
+        dataset_visibility: str,
+    ) -> tuple[str, Dataset]:
+        """Build a PUBLIC map whose single layer references a dataset of the given
+        visibility. The map is flipped public via a direct DB write — the add-layer
+        guard now blocks adding a non-public dataset to an already-public map, so the
+        leaked state is constructed deterministically (add to a private map, then flip).
+        """
+        admin_id = await get_user_id(test_db_session, "admin")
+        ds = await create_dataset(
+            test_db_session,
+            created_by=admin_id,
+            name=f"SEC-A {dataset_visibility} DS {uuid.uuid4().hex[:6]}",
+            visibility=dataset_visibility,
+        )
+        created = await _create_map(client, admin_auth_header)
+        map_id = created["id"]
+        # Map is private here, so add-layer is allowed for any dataset visibility.
+        resp = await client.post(
+            f"/maps/{map_id}/layers",
+            json={"dataset_id": str(ds.id)},
+            headers=admin_auth_header,
+        )
+        assert resp.status_code == 201, resp.text
+        m = await test_db_session.get(Map, uuid.UUID(map_id))
+        m.visibility = "public"
+        await test_db_session.commit()
+        return map_id, ds
+
+    async def test_anon_get_map_hides_private_dataset_layer(
+        self, client: AsyncClient, admin_auth_header: dict, test_db_session
+    ):
+        """REG-1: anon GET /maps/{id} omits a private-dataset layer (no table_name/
+        column_info/sample_values leak). Fails on main (unfiltered fetch)."""
+        map_id, ds = await self._public_map_with_layer(
+            client, admin_auth_header, test_db_session, dataset_visibility="private"
+        )
+        resp = await client.get(f"/maps/{map_id}")  # anonymous (no headers)
+        assert resp.status_code == 200, resp.text
+        assert all(
+            layer["dataset_id"] != str(ds.id) for layer in resp.json()["layers"]
+        ), "private dataset layer leaked to anonymous caller"
+
+    async def test_anon_style_json_omits_private_dataset_source(
+        self, client: AsyncClient, admin_auth_header: dict, test_db_session
+    ):
+        """REG-2: anon GET /maps/{id}/style.json omits the private dataset's source
+        (and its replayable signed .pbf URL). Fails on main."""
+        map_id, ds = await self._public_map_with_layer(
+            client, admin_auth_header, test_db_session, dataset_visibility="private"
+        )
+        resp = await client.get(f"/maps/{map_id}/style.json")  # anonymous
+        assert resp.status_code == 200, resp.text
+        assert f"geolens-{ds.id}" not in resp.json()["sources"], (
+            "private dataset source with replayable signed tile URL leaked anonymously"
+        )
+
+    async def test_anon_keeps_public_dataset_layer(
+        self, client: AsyncClient, admin_auth_header: dict, test_db_session
+    ):
+        """REG-3 (control): a PUBLIC dataset layer is STILL visible to anon on both
+        endpoints — guards against over-filtering."""
+        map_id, ds = await self._public_map_with_layer(
+            client, admin_auth_header, test_db_session, dataset_visibility="public"
+        )
+        map_resp = await client.get(f"/maps/{map_id}")
+        assert map_resp.status_code == 200, map_resp.text
+        assert any(
+            layer["dataset_id"] == str(ds.id) for layer in map_resp.json()["layers"]
+        ), "public dataset layer wrongly filtered for anonymous caller"
+        style_resp = await client.get(f"/maps/{map_id}/style.json")
+        assert style_resp.status_code == 200, style_resp.text
+        assert f"geolens-{ds.id}" in style_resp.json()["sources"]
+
+    async def test_owner_still_sees_own_private_layer(
+        self, client: AsyncClient, admin_auth_header: dict, test_db_session
+    ):
+        """REG-4: the owner/admin STILL sees their own private layer (the filter must
+        honor the owner/admin bypass, not strip legitimate access)."""
+        map_id, ds = await self._public_map_with_layer(
+            client, admin_auth_header, test_db_session, dataset_visibility="private"
+        )
+        resp = await client.get(f"/maps/{map_id}", headers=admin_auth_header)
+        assert resp.status_code == 200, resp.text
+        assert any(
+            layer["dataset_id"] == str(ds.id) for layer in resp.json()["layers"]
+        ), "owner lost visibility of their own private layer"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Security fix — Phase 1038/SEC-A (anonymous; HIGH)

Second instance of the cross-dataset authorization class fixed in #234 (the relationship endpoints). `GET /maps/{id}` and `GET /maps/{id}/style.json` authorized only the **map**, never each **layer's backing dataset**. A public map referencing a private dataset therefore leaked, to **anonymous** callers:

- via `GET /maps/{id}`: the private dataset's `table_name`, `column_info`, `feature_count`, `extent`, and **`sample_values`** (real sampled rows);
- via `GET /maps/{id}/style.json`: the table name **plus** a tile URL carrying an HMAC signature. The signature is `HMAC(table_name:exp)` — bound to **neither user nor map** — and `_authorize_vector_tile_request` accepts a valid signature for a non-public dataset **with no user check**, so it is **replayable** to read the private dataset's actual vector tiles.

**Reachability:** maps default private; `validate_public_visibility` runs only on publish (PUT). Adding a layer to an already-public map does not re-validate, so an owner can attach their own private dataset to a public map (the existing `duplicate_map`/`get_shared_map` RBAC filtering exists precisely because this state is reachable).

## Fix
`filter_layer_rows_by_dataset_visibility` (`maps/service_shared.py`) mirrors `get_shared_map`: it filters the fetched layer rows through `apply_visibility_filter`, dropping layers whose dataset is not visible to the caller (admin/owner keep their own; anonymous see only public+published). Both GET handlers call it after the map-level access check and before building the response. Filtering the layer list before `build_maplibre_style` drops the excluded layer's source **and** its signed tile URL in one move — no `style_json.py` change needed. Re-exported through the maps service facade (in `__all__`, per the ruff-strips-reexports guard).

Follows the codebase's established **filter-at-read** design (`get_shared_map`, `duplicate_map` RBAC) rather than blocking writes — so public maps may still contain non-public layers, now hidden from unauthorized readers.

### Dropped from the plan: a "block-at-write" add-layer guard
The plan included an optional defense-in-depth task to reject adding a non-public dataset to a public map. It was **dropped**: the full test suite showed it breaks `TestDuplicateMap` (which constructs exactly that state to verify duplication's RBAC filtering) and it contradicts the codebase's filter-at-read philosophy. The read-path filter is the authoritative fix and fully closes SEC-A.

## Tests (`test_maps.py::TestMapLayerDatasetVisibilityLeak`)
- **REG-1** anon `GET /maps/{id}` omits a private-dataset layer (no metadata/sample-values leak)
- **REG-2** anon `style.json` omits the private dataset's source + replayable signed URL
- **REG-3** (control) public-dataset layers stay visible to anon — guards against over-filtering
- **REG-4** owner/admin still sees their own private layer — guards against breaking legitimate access

**Verified empirically: REG-1 and REG-2 fail on the pre-fix code, pass after the fix.** Full `test_maps.py` green (150), plus `test_maps_style_json.py` / `test_export_access.py` / `test_dataset_metadata_idor.py` / `test_stac_visibility.py` (57) — no regressions. Authorization-logic only, no schema changes.

Origin: adversarial sweep after #234. Companion findings SEC-B/C/D queued (OGC `externalId`, VRT source authz, AI-metadata).