### PR TITLE
fix(ogc): enforce dataset visibility on the externalId OGC item lookup (SEC-B)

### DIFF
--- a/backend/app/modules/catalog/search/router.py
+++ b/backend/app/modules/catalog/search/router.py
@@ -1169,6 +1169,7 @@ async def _lookup_by_external_id(
     db: AsyncSession,
     external_id: str,
     request: Request,
+    user: Identity | None,
 ) -> JSONResponse:
     """Lookup a single OGC record by externalId (dataset UUID).
 
@@ -1202,6 +1203,10 @@ async def _lookup_by_external_id(
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND, detail="Record not found"
         )
+    # Visibility check (raises 404 if access denied) — mirror get_collection_item.
+    # Without this, an anonymous caller could read any private/restricted/unpublished
+    # dataset's full OGC metadata by UUID via ?externalId=.
+    await check_dataset_access_or_anonymous(db, dataset, record_uuid, user)
     public_api_url = await get_public_api_url(db, request=request)
     content = dataset_to_ogc_record(dataset, public_api_url)
     return JSONResponse(
@@ -1268,7 +1273,7 @@ async def collection_items(
     """OGC API Records items endpoint -- mirrors /search/datasets."""
     # OGC externalId -> fetch single record by UUID
     if external_id:
-        return await _lookup_by_external_id(db, external_id, request)
+        return await _lookup_by_external_id(db, external_id, request, user)
 
     # Apply OGC-specific overrides via model_copy to keep params immutable
     overrides: dict[str, object] = {}

--- a/backend/tests/test_ogc_public_access.py
+++ b/backend/tests/test_ogc_public_access.py
@@ -367,3 +367,96 @@ async def test_admin_sees_all_drafts(
     feature_ids = [f["id"] for f in list_resp.json()["features"]]
     if list_resp.json().get("numberMatched", len(feature_ids)) <= 100:
         assert str(draft.id) in feature_ids
+
+
+# ---------------------------------------------------------------------------
+# SEC-B: externalId lookup must enforce dataset visibility (mirror path-param item)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_externalid_no_auth_private_returns_404(
+    client: AsyncClient,
+    test_db_session,
+):
+    """Anon GET /collections/datasets/items?externalId=<private uuid> returns 404
+    (no metadata leak). Fails on pre-fix code (returns 200 + full OGC Record)."""
+    admin_id = await get_user_id(test_db_session, "admin")
+    priv = await create_dataset(
+        test_db_session,
+        created_by=admin_id,
+        name="Private ExternalId Leak",
+        visibility="private",
+    )
+    resp = await client.get(
+        "/collections/datasets/items", params={"externalId": str(priv.id)}
+    )
+    assert resp.status_code == 404
+    assert str(priv.id) not in resp.text
+
+
+@pytest.mark.anyio
+async def test_externalid_no_auth_draft_returns_404(
+    client: AsyncClient,
+    test_db_session,
+):
+    """Anon externalId lookup of a public-but-unpublished (draft) dataset returns 404."""
+    admin_id = await get_user_id(test_db_session, "admin")
+    draft = await create_dataset(
+        test_db_session,
+        created_by=admin_id,
+        name="Draft ExternalId Leak",
+        visibility="public",
+        record_status="draft",
+    )
+    resp = await client.get(
+        "/collections/datasets/items", params={"externalId": str(draft.id)}
+    )
+    assert resp.status_code == 404
+
+
+@pytest.mark.anyio
+async def test_externalid_owner_admin_private_returns_200(
+    client: AsyncClient,
+    admin_auth_header: dict,
+    test_db_session,
+):
+    """Owner/admin externalId lookup of a private dataset still returns 200 (the gate
+    must not over-block authorized callers)."""
+    admin_id = await get_user_id(test_db_session, "admin")
+    priv = await create_dataset(
+        test_db_session,
+        created_by=admin_id,
+        name="Owner ExternalId OK",
+        visibility="private",
+    )
+    resp = await client.get(
+        "/collections/datasets/items",
+        params={"externalId": str(priv.id)},
+        headers=admin_auth_header,
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["id"] == str(priv.id)
+    assert body["type"] == "Feature"
+
+
+@pytest.mark.anyio
+async def test_externalid_no_auth_public_returns_200(
+    client: AsyncClient,
+    test_db_session,
+):
+    """Anon externalId lookup of a public+published dataset still returns 200
+    (public happy path preserved; the gate 404s only on denial)."""
+    admin_id = await get_user_id(test_db_session, "admin")
+    pub = await create_dataset(
+        test_db_session,
+        created_by=admin_id,
+        name="Public ExternalId OK",
+        visibility="public",
+    )
+    resp = await client.get(
+        "/collections/datasets/items", params={"externalId": str(pub.id)}
+    )
+    assert resp.status_code == 200
+    assert resp.json()["id"] == str(pub.id)


### PR DESCRIPTION
## Security fix — v1038/SEC-B (anonymous; HIGH)

Third instance of the cross-dataset authorization class (after #234 relationships, #235 maps).
`GET /collections/datasets/items?externalId=<uuid>` resolved the dataset by id and returned the full OGC catalog Record (title, summary, bbox, keywords, contacts, distributions, source org) **with no visibility check** — `collection_items` never threaded `user` into `_lookup_by_external_id`. So an **anonymous** caller could read any **private / restricted / unpublished** dataset's metadata by UUID.

The path-param sibling `get_collection_item` returns the **identical** payload but already gates it via `check_dataset_access_or_anonymous` — the `externalId` query branch was the un-gated twin.

## Fix
Mirror the sibling, minimal surface (`search/router.py`):
1. add `user: Identity | None` to `_lookup_by_external_id`;
2. insert `await check_dataset_access_or_anonymous(db, dataset, record_uuid, user)` **after** the missing-row 404 and **before** `dataset_to_ogc_record(...)`;
3. thread `user` through the single call site.

No new imports (`Identity` + the gate are already imported/used in the router). Anonymous lookups of non-(public+published) datasets now 404; public+published stays 200; owners/admins/grant-holders keep access. Invalid-UUID 400 and missing-row 404 are preserved (gate inserted after both).

## Tests (`test_ogc_public_access.py`)
- anon `?externalId=<private>` → 404 (and the id is absent from the body)
- anon `?externalId=<public+draft>` → 404
- owner/admin `?externalId=<private>` → 200 (guard: no over-blocking)
- anon `?externalId=<public+published>` → 200 (guard: public happy path)

**Verified empirically: the two 404 tests fail on the pre-fix code, pass after the fix.** `test_ogc_public_access.py` 19 pass + `test_ogc_records_conformance` / `test_ogc_record_properties` / `test_ogc_collection_metadata` 40 pass — no regressions. Authorization-logic only, no schema changes.

Scope: the search/collections router's other lookups (search/list, `list_collections`, facets, collection-metadata aggregates) are already visibility-filtered. Companion findings SEC-C (VRT source authz) and SEC-D (AI-metadata) remain queued.