### PR TITLE
fix(vrt): authorize VRT source datasets at link time + filter unauthorized members on read (SEC-C/SEC-E)

### DIFF
--- a/backend/app/modules/catalog/datasets/api/router_vrt.py
+++ b/backend/app/modules/catalog/datasets/api/router_vrt.py
@@ -28,7 +28,7 @@ from app.modules.catalog.datasets.domain.schemas import (
 )
 from app.modules.catalog.datasets.domain.service import get_dataset
 from app.core.dependencies import get_db
-from app.platform.extensions import get_catalog_port
+from app.platform.extensions import get_catalog_port, get_permission_extension
 from app.standards.ogc.errors import ERROR_RESPONSES_WRITE
 
 router = APIRouter(
@@ -55,7 +55,7 @@ async def list_vrt_sources(
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND, detail="Dataset not found"
         )
-    await check_dataset_access(db, dataset, dataset_id, user)
+    user_roles = await check_dataset_access(db, dataset, dataset_id, user)
     rows = await db.execute(
         text("""
             SELECT vsl.source_dataset_id AS dataset_id, rec.title, vsl.position,
@@ -70,8 +70,20 @@ async def list_vrt_sources(
         """),
         {"vrt_id": str(dataset_id)},
     )
+    # SEC-E: SEC-C authorizes sources only at link time and there is no
+    # migration re-authorizing pre-existing vrt_source_links, so a VRT may hold
+    # member rows the caller cannot access (created before the fix, or a source
+    # later flipped private / lost a grant). Drop those members here so their
+    # title/CRS/resolution/extent never leak. Non-raising (can_access_dataset)
+    # — a 404 would abort the whole listing.
+    ext = get_permission_extension()
     sources = []
     for row in rows.all():
+        src_dataset = await get_dataset(db, row.dataset_id)
+        if src_dataset is None or not await ext.can_access_dataset(
+            db, src_dataset, row.dataset_id, user, user_roles=user_roles
+        ):
+            continue
         extent_bbox = None
         if row.extent_wkt:
             try:
@@ -112,7 +124,7 @@ async def get_vrt_status(
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND, detail="Dataset not found"
         )
-    await check_dataset_access(db, dataset, dataset_id, user)
+    user_roles = await check_dataset_access(db, dataset, dataset_id, user)
 
     # Load VRT RasterAsset
     asset_result = await db.execute(
@@ -139,7 +151,10 @@ async def get_vrt_status(
     last_gen = gen_result.scalar_one_or_none()
     last_generation_at = last_gen.completed_at if last_gen else None
 
-    # Source count
+    # Source count — raw total link count. This intentionally reflects ALL
+    # links, while source_health below reflects only members the caller can
+    # access (SEC-E). Recomputing the count from the filtered set would leak
+    # the size of the unauthorized delta, so the totals are allowed to diverge.
     count_result = await db.execute(
         text(
             "SELECT COUNT(*) FROM catalog.vrt_source_links WHERE vrt_dataset_id = :id"
@@ -190,12 +205,17 @@ async def get_vrt_status(
     )
     source_health_list = []
     storage = get_storage()
+    # SEC-E: drop members the caller cannot access (legacy links / authz drift)
+    # before probing storage, so their existence/health never leaks.
+    ext = get_permission_extension()
 
     # Collect sources and their URIs for parallel checks
     sources_to_check = []
     for row in source_rows.all():
         if row.ds_id is None:
-            # Source dataset was deleted
+            # Source dataset was deleted. Keep this "missing" health branch and
+            # the None-guard below so can_access_dataset never deref's
+            # None.record for a source whose dataset row no longer exists.
             source_health_list.append(
                 VrtSourceHealth(
                     dataset_id=row.source_dataset_id,
@@ -203,8 +223,14 @@ async def get_vrt_status(
                     status="missing",
                 )
             )
-        else:
-            sources_to_check.append(row)
+            continue
+        src_dataset = await get_dataset(db, row.source_dataset_id)
+        if src_dataset is None or not await ext.can_access_dataset(
+            db, src_dataset, row.source_dataset_id, user, user_roles=user_roles
+        ):
+            # SEC-E: omit unauthorized members before any storage.exists probe.
+            continue
+        sources_to_check.append(row)
 
     # Parallel storage.exists() checks for non-missing sources
     if sources_to_check:

--- a/backend/app/processing/ingest/router.py
+++ b/backend/app/processing/ingest/router.py
@@ -995,6 +995,26 @@ async def add_vrt_source(
             detail=f"Source dataset {request.source_dataset_id} not found or not a raster dataset",
         )
 
+    # 3b. SEC-C: authorize the new source against the caller before linking it
+    # into the VRT mosaic. VRT member pixels are compiled into one served asset
+    # and cannot be filtered at read time, so authorize at link time (mirrors
+    # #234). On denial, check_dataset_access raises 404. Defense-in-depth: also
+    # require the caller to access the parent VRT itself. This runs BEFORE the
+    # duplicate-link check so a foreign source 404s rather than leaking a 409.
+    from app.modules.catalog.authorization import (
+        check_dataset_access,
+        get_user_roles,
+    )
+    from app.modules.catalog.datasets.domain.service import get_dataset
+
+    user_roles = await get_user_roles(db, user)
+    source_dataset = await get_dataset(db, request.source_dataset_id)
+    await check_dataset_access(
+        db, source_dataset, request.source_dataset_id, user, user_roles=user_roles
+    )
+    vrt_dataset = await get_dataset(db, dataset_id)
+    await check_dataset_access(db, vrt_dataset, dataset_id, user, user_roles=user_roles)
+
     # 4. Check for duplicate link
     dup_result = await db.execute(
         text(

--- a/backend/app/processing/ingest/service.py
+++ b/backend/app/processing/ingest/service.py
@@ -486,6 +486,24 @@ async def create_vrt_job(
                 detail=f"Source dataset {sid} not found or not a raster dataset",
             )
 
+    # 3b. SEC-C: authorize EVERY source dataset against the caller before
+    # mosaicking. The worker compiles all source pixels into a single served
+    # asset, so a foreign private source cannot be filtered at read time —
+    # authorize at write/link time (mirrors #234's create_relationship). On
+    # denial, check_dataset_access raises 404. This runs BEFORE
+    # validate_sources so a foreign source 404s rather than leaking a 422
+    # compatibility error about a dataset the caller cannot see.
+    from app.modules.catalog.authorization import (
+        check_dataset_access,
+        get_user_roles,
+    )
+    from app.modules.catalog.datasets.domain.service import get_dataset
+
+    user_roles = await get_user_roles(db, user)
+    for sid in request.source_dataset_ids:
+        src_dataset = await get_dataset(db, sid)  # existence proven above; non-None
+        await check_dataset_access(db, src_dataset, sid, user, user_roles=user_roles)
+
     # 4. Validate source compatibility
     errors = validate_sources(request.vrt_type, list(found_assets))
     if errors:

--- a/backend/tests/test_defer_orphan_guard.py
+++ b/backend/tests/test_defer_orphan_guard.py
@@ -360,6 +360,33 @@ def _make_vrt_asset(status: str = "ready") -> MagicMock:
 class TestVrtSourceOrphanGuard:
     """Verify VRT add/remove defer failures revert asset state + mark job failed."""
 
+    @pytest.fixture(autouse=True)
+    def _stub_vrt_source_authz(self):
+        """SEC-C (Phase 1172): add_vrt_source now authorizes the new source and
+        the parent VRT (check_dataset_access + get_user_roles + get_dataset),
+        each of which issues its own ``db.execute`` calls that would shift the
+        call-count-ordered mock ``db`` sequence in the add test. Stub them to
+        make ZERO db.execute calls (and always allow) so the sequence stays
+        valid; the authorization behavior is covered by
+        ``tests/test_vrt_source_authz_1172.py``. Harmless for the
+        remove_vrt_source test (which never invokes these helpers).
+        """
+        with (
+            patch(
+                "app.modules.catalog.authorization.get_user_roles",
+                new=AsyncMock(return_value=set()),
+            ),
+            patch(
+                "app.modules.catalog.authorization.check_dataset_access",
+                new=AsyncMock(return_value=set()),
+            ),
+            patch(
+                "app.modules.catalog.datasets.domain.service.get_dataset",
+                new=AsyncMock(return_value=MagicMock()),
+            ),
+        ):
+            yield
+
     def test_add_vrt_source_defer_failure_reverts_state_and_raises_503(self):
         """VRT add_source defer crash must revert ``vrt_asset.status``, delete
         the inserted source link, mark the IngestJob failed, and raise 503."""

--- a/backend/tests/test_vrt_catalog_175.py
+++ b/backend/tests/test_vrt_catalog_175.py
@@ -364,6 +364,24 @@ class TestQuicklookVrt:
 class TestVrtSourcesEndpoint:
     """list_vrt_sources returns ordered VrtSourceItems; 404 for non-VRT / non-existent."""
 
+    @pytest.fixture(autouse=True)
+    def _stub_vrt_member_authz(self):
+        """SEC-E (Phase 1172): list_vrt_sources now drops members the caller
+        cannot access via get_permission_extension().can_access_dataset(per
+        member). These unit tests mock the SQL rows and ``check_dataset_access``
+        (which they set to return None), then assert the FULL returned list, so
+        stub the per-member check to allow-all — otherwise can_access_dataset
+        would run for real against a None user_roles and raise. The filtering
+        behavior itself is covered by tests/test_vrt_source_authz_1172.py.
+        """
+        ext = MagicMock()
+        ext.can_access_dataset = AsyncMock(return_value=True)
+        with patch(
+            "app.modules.catalog.datasets.api.router_vrt.get_permission_extension",
+            return_value=ext,
+        ):
+            yield
+
     @pytest.mark.asyncio
     async def test_returns_ordered_source_list_for_vrt_dataset(self):
         """list_vrt_sources returns VrtSourceListResponse with correct fields."""

--- a/backend/tests/test_vrt_creation_173.py
+++ b/backend/tests/test_vrt_creation_173.py
@@ -42,6 +42,38 @@ def _make_subprocess_result(returncode: int = 0, stderr: str = "") -> MagicMock:
     return result
 
 
+@pytest.fixture(autouse=True)
+def _stub_vrt_source_authz():
+    """SEC-C (Phase 1172): ``create_vrt_job`` now authorizes every source
+    dataset against the caller (check_dataset_access + get_user_roles +
+    get_dataset). Those helpers issue their own ``db.execute`` calls, which
+    would shift the call-count-ordered / single-return mock ``db`` sequences
+    these pure unit tests rely on. Stub them to make ZERO ``db.execute`` calls
+    (and always allow) so the existing sequences stay valid. The authorization
+    behavior itself is covered by the DB-backed
+    ``tests/test_vrt_source_authz_1172.py``. The stubs no-op when the function
+    under test never reaches the authz block (e.g. the <2-sources guard), so
+    this is safe to apply module-wide.
+    """
+    from unittest.mock import AsyncMock, MagicMock, patch
+
+    with (
+        patch(
+            "app.modules.catalog.authorization.get_user_roles",
+            new=AsyncMock(return_value=set()),
+        ),
+        patch(
+            "app.modules.catalog.authorization.check_dataset_access",
+            new=AsyncMock(return_value=set()),
+        ),
+        patch(
+            "app.modules.catalog.datasets.domain.service.get_dataset",
+            new=AsyncMock(return_value=MagicMock()),
+        ),
+    ):
+        yield
+
+
 # ---------------------------------------------------------------------------
 # TestVrtSchemas
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_vrt_source_authz_1172.py
+++ b/backend/tests/test_vrt_source_authz_1172.py
@@ -1,0 +1,389 @@
+"""DB-backed regression tests for VRT source authorization (Phase 1172).
+
+SEC-C (HIGH) — write-time hole: an editor (default ``upload`` permission) could
+mosaic ANOTHER user's PRIVATE raster into a VRT they own, then read the victim's
+pixels back through raster tile/quicklook/COG endpoints that authorize only the
+attacker-owned VRT. VRT member pixels are compiled into ONE served asset and
+cannot be filtered at read time, so the fix authorizes every source dataset at
+write/link time (``create_vrt_job`` + ``add_vrt_source``).
+
+SEC-E (MED) — read-time backstop: SEC-C only authorizes at link time and there
+is no migration re-authorizing existing ``vrt_source_links``, so legacy / authz-
+drift links still leak member title/CRS/resolution/extent/health via
+``list_vrt_sources`` / ``get_vrt_status``. A per-member non-raising filter drops
+those rows.
+
+Attack + SEC-E tests fail on main ``407c0688`` (no per-source authz); the GUARD
+tests (owned sources → 202) pass before and after the fix.
+
+Requirements:
+  - Docker database must be running (docker compose up db)
+  - Alembic migrations must be applied
+"""
+
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from httpx import AsyncClient
+from sqlalchemy import select, text
+
+from app.core.config import settings
+from app.modules.auth.models import User
+from app.modules.catalog.datasets.domain.models import Dataset, Record
+from app.processing.raster.models import RasterAsset
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+async def _get_admin_id(session) -> uuid.UUID:
+    result = await session.execute(
+        select(User).where(User.username == settings.geolens_admin_username)
+    )
+    return result.scalar_one().id
+
+
+async def _make_editor(
+    client: AsyncClient, admin_headers: dict
+) -> tuple[dict[str, str], uuid.UUID]:
+    """Create a non-admin editor user; return (auth_header, user_id).
+
+    The editor role carries the ``upload`` permission (so it clears
+    ``require_permission("upload")`` on the VRT endpoints) but is NOT admin —
+    exactly the threat actor for SEC-C.
+    """
+    unique = uuid.uuid4().hex[:8]
+    username = f"editor_{unique}"
+    password = "TestPass1234!"  # 12-char + 3-class policy
+    resp = await client.post(
+        "/admin/users/",
+        json={"username": username, "password": password, "role": "editor"},
+        headers=admin_headers,
+    )
+    assert resp.status_code == 201, f"create editor failed: {resp.text}"
+    user_id = uuid.UUID(resp.json()["id"])
+    login = await client.post(
+        "/auth/login", data={"username": username, "password": password}
+    )
+    assert login.status_code == 200, f"editor login failed: {login.text}"
+    headers = {"Authorization": f"Bearer {login.json()['access_token']}"}
+    return headers, user_id
+
+
+async def _create_raster_dataset(
+    session,
+    *,
+    created_by: uuid.UUID,
+    visibility: str = "private",
+    record_status: str = "published",
+) -> uuid.UUID:
+    """Create a raster_dataset Record + Dataset + RasterAsset.
+
+    Metadata is mosaic-compatible (crs_wkt=None so ``_check_crs`` skips it,
+    identical dtype, single band, matching resolution) so ``validate_sources``
+    returns [] for a pair of these — letting the GUARD tests reach 202.
+    """
+    record = Record(
+        title=f"VRT Authz Raster {uuid.uuid4().hex[:6]}",
+        summary="raster source for VRT authz tests",
+        theme_category=["test"],
+        visibility=visibility,
+        record_status=record_status,
+        record_type="raster_dataset",
+        created_by=created_by,
+    )
+    session.add(record)
+    await session.flush()
+
+    dataset = Dataset(
+        record_id=record.id,
+        table_name=f"vrt_authz_src_{uuid.uuid4().hex[:8]}",
+        source_format="geotiff",
+        source_filename="test.tif",
+    )
+    session.add(dataset)
+    await session.flush()
+
+    asset = RasterAsset(
+        dataset_id=dataset.id,
+        asset_uri=f"rasters/{dataset.id}/abc123/source.cog.tif",
+        storage_backend="local",
+        status="ready",
+        epsg=4326,
+        crs_wkt=None,
+        dtype="uint8",
+        nodata=None,
+        band_count=1,
+        res_x=0.001,
+        res_y=0.001,
+        width=100,
+        height=100,
+        is_rotated=False,
+    )
+    session.add(asset)
+    await session.flush()
+    await session.commit()
+    return dataset.id
+
+
+async def _create_vrt_dataset(
+    session,
+    *,
+    created_by: uuid.UUID,
+    visibility: str = "private",
+    record_status: str = "published",
+) -> uuid.UUID:
+    """Create a ready vrt_dataset Record + Dataset + RasterAsset."""
+    record = Record(
+        title=f"VRT Authz VRT {uuid.uuid4().hex[:6]}",
+        summary="VRT for authz tests",
+        theme_category=["test"],
+        visibility=visibility,
+        record_status=record_status,
+        record_type="vrt_dataset",
+        created_by=created_by,
+    )
+    session.add(record)
+    await session.flush()
+
+    dataset = Dataset(
+        record_id=record.id,
+        table_name=f"vrt_authz_vrt_{uuid.uuid4().hex[:8]}",
+        # VRT datasets carry no source_format (avoids chk_datasets_source_format);
+        # mirrors app/processing/ingest/tasks_vrt.py.
+        source_format=None,
+        source_filename=None,
+    )
+    session.add(dataset)
+    await session.flush()
+
+    asset = RasterAsset(
+        dataset_id=dataset.id,
+        asset_uri=f"rasters/{dataset.id}/vrt/source.vrt",
+        storage_backend="local",
+        status="ready",
+        vrt_type="mosaic",
+        resolution_strategy="finest",
+        epsg=4326,
+        band_count=1,
+    )
+    session.add(asset)
+    await session.flush()
+    await session.commit()
+    return dataset.id
+
+
+async def _link_source(
+    session, vrt_id: uuid.UUID, source_id: uuid.UUID, position: int
+) -> None:
+    """Raw-insert a vrt_source_links row (mirrors add_vrt_source's INSERT) to
+    simulate a legacy / pre-authz link."""
+    await session.execute(
+        text(
+            "INSERT INTO catalog.vrt_source_links"
+            "(vrt_dataset_id, source_dataset_id, position) "
+            "VALUES (:vrt, :src, :pos)"
+        ),
+        {"vrt": str(vrt_id), "src": str(source_id), "pos": position},
+    )
+    await session.commit()
+
+
+def _patch_defer():
+    """Patch both VRT defer tasks so the success path returns 202 without a
+    live Procrastinate connection. Used by GUARD tests (and the attack tests so
+    they cleanly return 202 on unfixed main rather than a 503 defer failure)."""
+    create_task = MagicMock()
+    create_task.defer_async = AsyncMock(return_value=None)
+    regen_task = MagicMock()
+    regen_task.defer_async = AsyncMock(return_value=None)
+    return (
+        patch("app.processing.ingest.tasks.ingest_vrt", create_task),
+        patch("app.processing.ingest.router.regenerate_vrt", regen_task),
+    )
+
+
+# ---------------------------------------------------------------------------
+# SEC-C — write-time authorization (create_vrt_job)
+# ---------------------------------------------------------------------------
+
+
+async def test_create_vrt_rejects_foreign_private_sources(
+    client: AsyncClient, admin_auth_header: dict, test_db_session
+):
+    """Editor POSTs create with two admin-owned PRIVATE rasters → 403/404.
+
+    Fails on main (202): create_vrt_job authorizes no source.
+    """
+    admin_id = await _get_admin_id(test_db_session)
+    src_a = await _create_raster_dataset(test_db_session, created_by=admin_id)
+    src_b = await _create_raster_dataset(test_db_session, created_by=admin_id)
+
+    editor_headers, _ = await _make_editor(client, admin_auth_header)
+
+    p_create, p_regen = _patch_defer()
+    with p_create, p_regen:
+        resp = await client.post(
+            "/ingest/vrt/create",
+            json={
+                "source_dataset_ids": [str(src_a), str(src_b)],
+                "vrt_type": "mosaic",
+                "resolution_strategy": "finest",
+                "title": "Attack VRT",
+            },
+            headers=editor_headers,
+        )
+
+    assert resp.status_code in (403, 404), (
+        f"expected 403/404 denying foreign private sources, got "
+        f"{resp.status_code}: {resp.text}"
+    )
+
+
+async def test_add_vrt_source_rejects_foreign_private_source(
+    client: AsyncClient, admin_auth_header: dict, test_db_session
+):
+    """Editor owns a ready VRT, POSTs add-source with an admin-owned PRIVATE
+    raster → 403/404.
+
+    Fails on main: add_vrt_source authorizes no source.
+    """
+    admin_id = await _get_admin_id(test_db_session)
+    editor_headers, editor_id = await _make_editor(client, admin_auth_header)
+
+    vrt_id = await _create_vrt_dataset(test_db_session, created_by=editor_id)
+    foreign_src = await _create_raster_dataset(test_db_session, created_by=admin_id)
+
+    p_create, p_regen = _patch_defer()
+    with p_create, p_regen:
+        resp = await client.post(
+            f"/ingest/vrt/{vrt_id}/sources/",
+            json={"source_dataset_id": str(foreign_src)},
+            headers=editor_headers,
+        )
+
+    assert resp.status_code in (403, 404), (
+        f"expected 403/404 denying a foreign private source, got "
+        f"{resp.status_code}: {resp.text}"
+    )
+
+
+async def test_create_vrt_allows_owned_sources(
+    client: AsyncClient, admin_auth_header: dict, test_db_session
+):
+    """GUARD: admin owns two private rasters, POSTs create → 202. Passes both
+    on main and after the fix (admin is always authorized)."""
+    admin_id = await _get_admin_id(test_db_session)
+    src_a = await _create_raster_dataset(test_db_session, created_by=admin_id)
+    src_b = await _create_raster_dataset(test_db_session, created_by=admin_id)
+
+    p_create, p_regen = _patch_defer()
+    with p_create, p_regen:
+        resp = await client.post(
+            "/ingest/vrt/create",
+            json={
+                "source_dataset_ids": [str(src_a), str(src_b)],
+                "vrt_type": "mosaic",
+                "resolution_strategy": "finest",
+                "title": "Owned VRT (admin)",
+            },
+            headers=admin_auth_header,
+        )
+
+    assert resp.status_code == 202, (
+        f"admin VRT creation from owned sources must succeed, got "
+        f"{resp.status_code}: {resp.text}"
+    )
+
+
+async def test_create_vrt_allows_editor_owned_sources(
+    client: AsyncClient, admin_auth_header: dict, test_db_session
+):
+    """GUARD: editor owns two private rasters → 202. Proves authorization is by
+    ownership, not admin-ness (the fix must not over-block non-admin owners)."""
+    editor_headers, editor_id = await _make_editor(client, admin_auth_header)
+    src_a = await _create_raster_dataset(test_db_session, created_by=editor_id)
+    src_b = await _create_raster_dataset(test_db_session, created_by=editor_id)
+
+    p_create, p_regen = _patch_defer()
+    with p_create, p_regen:
+        resp = await client.post(
+            "/ingest/vrt/create",
+            json={
+                "source_dataset_ids": [str(src_a), str(src_b)],
+                "vrt_type": "mosaic",
+                "resolution_strategy": "finest",
+                "title": "Owned VRT (editor)",
+            },
+            headers=editor_headers,
+        )
+
+    assert resp.status_code == 202, (
+        f"editor VRT creation from its OWN sources must succeed, got "
+        f"{resp.status_code}: {resp.text}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# SEC-E — read-time per-member filter (legacy / authz-drift links)
+# ---------------------------------------------------------------------------
+
+
+async def test_list_vrt_sources_omits_unauthorized_members(
+    client: AsyncClient, admin_auth_header: dict, test_db_session
+):
+    """Editor-owned VRT with a legacy link to an admin-owned PRIVATE raster:
+    GET /datasets/{vrt}/vrt-sources/ omits the unauthorized member.
+
+    Fails on main: list_vrt_sources returns every linked member.
+    """
+    admin_id = await _get_admin_id(test_db_session)
+    editor_headers, editor_id = await _make_editor(client, admin_auth_header)
+
+    vrt_id = await _create_vrt_dataset(test_db_session, created_by=editor_id)
+    owned_src = await _create_raster_dataset(test_db_session, created_by=editor_id)
+    foreign_src = await _create_raster_dataset(test_db_session, created_by=admin_id)
+    await _link_source(test_db_session, vrt_id, owned_src, 0)
+    await _link_source(test_db_session, vrt_id, foreign_src, 1)
+
+    resp = await client.get(f"/datasets/{vrt_id}/vrt-sources/", headers=editor_headers)
+    assert resp.status_code == 200, resp.text
+    listed = {s["dataset_id"] for s in resp.json()["sources"]}
+
+    assert str(foreign_src) not in listed, (
+        "SEC-E: unauthorized private member must be omitted from vrt-sources"
+    )
+    assert str(owned_src) in listed, "authorized member must still be listed"
+
+
+async def test_get_vrt_status_omits_unauthorized_members(
+    client: AsyncClient, admin_auth_header: dict, test_db_session
+):
+    """Same setup: GET /datasets/{vrt}/vrt/status/ omits the unauthorized
+    member from source_health (source_count stays the raw total).
+
+    Fails on main: get_vrt_status reports health for every linked member.
+    """
+    admin_id = await _get_admin_id(test_db_session)
+    editor_headers, editor_id = await _make_editor(client, admin_auth_header)
+
+    vrt_id = await _create_vrt_dataset(test_db_session, created_by=editor_id)
+    owned_src = await _create_raster_dataset(test_db_session, created_by=editor_id)
+    foreign_src = await _create_raster_dataset(test_db_session, created_by=admin_id)
+    await _link_source(test_db_session, vrt_id, owned_src, 0)
+    await _link_source(test_db_session, vrt_id, foreign_src, 1)
+
+    resp = await client.get(f"/datasets/{vrt_id}/vrt/status/", headers=editor_headers)
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    health_ids = {h["dataset_id"] for h in body["source_health"]}
+
+    assert str(foreign_src) not in health_ids, (
+        "SEC-E: unauthorized private member must be omitted from source_health"
+    )
+    assert str(owned_src) in health_ids, "authorized member must still be reported"
+    # source_count intentionally reflects the raw total link count (documented
+    # divergence) — both links are counted even though one is filtered out.
+    assert body["source_count"] == 2

--- a/backend/tests/test_vrt_source_management_174.py
+++ b/backend/tests/test_vrt_source_management_174.py
@@ -57,6 +57,36 @@ def _make_mock_source_asset(band_count: int = 1, epsg: int = 4326) -> MagicMock:
     return asset
 
 
+@pytest.fixture(autouse=True)
+def _stub_vrt_source_authz():
+    """SEC-C (Phase 1172): ``add_vrt_source`` now authorizes the new source (and
+    the parent VRT) against the caller (check_dataset_access + get_user_roles +
+    get_dataset). Those helpers issue their own ``db.execute`` calls, which
+    would shift the call-count-ordered mock ``db`` sequences these pure unit
+    tests rely on. Stub them to make ZERO ``db.execute`` calls (and always
+    allow) so the existing sequences stay valid. The authorization behavior
+    itself is covered by the DB-backed ``tests/test_vrt_source_authz_1172.py``.
+    The stubs no-op when the function never reaches the authz block (e.g. the
+    404/409/422 guards before it) and are unused by the regenerate-task tests
+    (tasks_vrt uses only get_dataset_orm_class), so this is safe module-wide.
+    """
+    with (
+        patch(
+            "app.modules.catalog.authorization.get_user_roles",
+            new=AsyncMock(return_value=set()),
+        ),
+        patch(
+            "app.modules.catalog.authorization.check_dataset_access",
+            new=AsyncMock(return_value=set()),
+        ),
+        patch(
+            "app.modules.catalog.datasets.domain.service.get_dataset",
+            new=AsyncMock(return_value=MagicMock()),
+        ),
+    ):
+        yield
+
+
 # ---------------------------------------------------------------------------
 # TestAddSourceSchemas
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Closes the VRT source-authorization hole (phase 1172, follows #234/#235/#236 in the v1038 authorization-boundary sweep).

**SEC-C (HIGH) — write-time hole.** `POST /ingest/vrt/create` (`create_vrt_job`) and `POST /ingest/vrt/{id}/sources/` (`add_vrt_source`) were gated only by `require_permission("upload")` (the default editor role has it) plus a `record_type=="raster_dataset"` filter — neither authorized the *source* datasets against the caller. An editor could mosaic another user's **private** raster into a VRT they own; the worker compiles the source pixels into the VRT's own served asset, and the raster tile/quicklook/COG endpoints authorize only the requested (attacker-owned) VRT — so the editor reads the victim's pixels back. VRT mosaic bytes **cannot** be filtered at read time (member pixels are baked into one dataset), so the authoritative fix is **write-time**: authorize every source dataset at link time.

- `create_vrt_job` (`processing/ingest/service.py`): authorize each `source_dataset_id` **before** `validate_sources`, so a foreign source 404s rather than leaking a 422 compatibility error about a dataset the caller can't see.
- `add_vrt_source` (`processing/ingest/router.py`): authorize the new source **before** the duplicate-link check; also re-check access to the parent VRT (defense-in-depth).
- Denial raises 404 (mirrors `check_dataset_access` / #234), avoiding existence disclosure.

**SEC-E (MED) — read-time backstop.** SEC-C only authorizes at link time and there is no migration re-authorizing existing `vrt_source_links`, so VRTs created before the fix (or where a source later flips private / loses a grant) keep member rows whose title/CRS/resolution/extent/health leak via `list_vrt_sources` / `get_vrt_status`. Added a per-member **non-raising** filter (`can_access_dataset`) that drops unauthorized members — a 404 would abort the whole listing. The deleted-source `"missing"` branch + a `None`-guard are kept so `can_access_dataset` never deref's `None.record`. `source_count` stays the raw total link count (documented divergence — recomputing would leak the size of the unauthorized delta).

## Tests

New DB-backed `backend/tests/test_vrt_source_authz_1172.py`:
- `test_create_vrt_rejects_foreign_private_sources` — editor + 2 admin-private rasters → 404 *(red on main)*
- `test_add_vrt_source_rejects_foreign_private_source` — editor VRT + foreign private source → 404 *(red on main)*
- `test_create_vrt_allows_owned_sources` (GUARD) — admin owns sources → 202
- `test_create_vrt_allows_editor_owned_sources` (GUARD) — editor owns sources → 202 *(authz by ownership, not admin-ness)*
- `test_list_vrt_sources_omits_unauthorized_members` (SEC-E) — legacy link to admin-private → absent *(red on main)*
- `test_get_vrt_status_omits_unauthorized_members` (SEC-E) — same, absent from `source_health` *(red on main)*

**Fail-on-main gate:** reverting only the 3 source files to `407c0688` turns the 4 attack/SEC-E tests RED and keeps the 2 GUARDs GREEN. With the fix: all 6 pass.

The new authz calls would otherwise break the call-count-ordered mock `db` sequences in `test_vrt_creation_173.py` / `test_vrt_source_management_174.py`; an autouse stub patches `get_user_roles`/`check_dataset_access`/`get_dataset` to make zero `db.execute` calls, preserving those sequences. Full VRT suite: **106 passed**.

## Verification
- `ruff check` + `ruff format --check` clean on the 3 edited source files (pre-commit gate passed).
- `pytest tests/test_vrt_source_authz_1172.py tests/test_vrt_creation_173.py tests/test_vrt_source_management_174.py tests/test_vrt_lifecycle_188.py` → 106 passed.