### PR TITLE
fix(ai): authorize the requested dataset on AI metadata endpoints (SEC-D)

### DIFF
--- a/backend/app/processing/ai/router.py
+++ b/backend/app/processing/ai/router.py
@@ -465,6 +465,37 @@ async def _call_metadata_ai(coro: Awaitable[_T], error_prefix: str) -> _T:
     return await _call_llm_endpoint(coro, error_prefix=error_prefix)
 
 
+async def _authorize_metadata_dataset(
+    db: AsyncSession, dataset_id: str, user: Identity
+) -> None:
+    """SEC-D: authorize the attacker-controlled body.dataset_id before AI metadata
+    generation. Without this, an editor (the default role has ``use_ai_chat``) can
+    read ANY user's PRIVATE dataset — its metadata, source_url/filename, column
+    schema, and sample values — because ``_build_dataset_context`` loads the dataset
+    with no visibility filter and renders it into the LLM prompt, which is echoed in
+    the response. Authorize in the handler (NOT inside ``_build_dataset_context``:
+    that has a ``dataset_id``-keyed TTL cache and no ``user`` param, so a cache hit
+    would bypass an in-service check). On denial ``check_dataset_access`` raises 404
+    — same response as a nonexistent dataset, so this is not an existence oracle.
+    """
+    from app.modules.catalog.authorization import check_dataset_access
+    from app.modules.catalog.datasets.domain.service import get_dataset
+
+    try:
+        dsid = uuid_mod.UUID(dataset_id)
+    except (ValueError, AttributeError, TypeError):
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail="Invalid dataset_id",
+        )
+    dataset = await get_dataset(db, dsid)
+    if dataset is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Dataset not found"
+        )
+    await check_dataset_access(db, dataset, dsid, user)
+
+
 @router.post("/metadata/summary/", response_model=SummaryDraftResponse)
 @limiter.limit(_AI_METADATA_LIMIT)
 async def generate_metadata_summary(
@@ -476,6 +507,7 @@ async def generate_metadata_summary(
 ) -> SummaryDraftResponse:
     """Generate an AI-drafted summary for a dataset."""
     await _check_ai_available(db)
+    await _authorize_metadata_dataset(db, body.dataset_id, user)  # SEC-D
     return await _call_metadata_ai(
         generate_summary_draft(db, body.dataset_id, port=port),
         "AI metadata summary generation",
@@ -493,6 +525,7 @@ async def generate_metadata_keywords(
 ) -> KeywordSuggestionsResponse:
     """Generate AI-suggested keywords for a dataset."""
     await _check_ai_available(db)
+    await _authorize_metadata_dataset(db, body.dataset_id, user)  # SEC-D
     return await _call_metadata_ai(
         generate_keyword_suggestions(db, body.dataset_id, port=port),
         "AI metadata keyword generation",
@@ -510,6 +543,7 @@ async def generate_metadata_lineage(
 ) -> LineageDraftResponse:
     """Generate an AI-drafted lineage summary for a dataset."""
     await _check_ai_available(db)
+    await _authorize_metadata_dataset(db, body.dataset_id, user)  # SEC-D
     return await _call_metadata_ai(
         generate_lineage_draft(db, body.dataset_id, port=port),
         "AI metadata lineage generation",
@@ -529,6 +563,7 @@ async def generate_metadata_quality_statement(
 ) -> QualityStatementDraftResponse:
     """Generate an AI-drafted quality statement for a dataset."""
     await _check_ai_available(db)
+    await _authorize_metadata_dataset(db, body.dataset_id, user)  # SEC-D
     return await _call_metadata_ai(
         generate_quality_statement_draft(db, body.dataset_id, port=port),
         "AI metadata quality statement generation",

--- a/backend/tests/test_ai_metadata.py
+++ b/backend/tests/test_ai_metadata.py
@@ -311,23 +311,23 @@ async def test_returns_401_unauthenticated(client: AsyncClient):
 
 
 @pytest.mark.anyio
-async def test_returns_422_invalid_dataset(
+async def test_returns_404_nonexistent_dataset(
     client: AsyncClient,
     admin_auth_header: dict,
 ):
-    """POST with nonexistent dataset_id returns 422."""
+    """POST with a nonexistent dataset_id returns 404 (SEC-D, Phase 1173).
+
+    The endpoint now authorizes the requested dataset (``_authorize_metadata_dataset``)
+    before invoking the generation service: a well-formed UUID that maps to no dataset
+    is loaded as ``None`` and rejected with 404 — the SAME response a caller gets for a
+    dataset they may not access, so existence is not disclosed. (Pre-1173 this surfaced
+    as 422 from the service's ``ValueError``; the authz check now fires first.)
+    """
     fake_id = str(uuid.uuid4())
 
-    with (
-        patch(
-            "app.processing.ai.router._check_ai_available",
-            new_callable=AsyncMock,
-        ),
-        patch(
-            "app.processing.ai.router.generate_summary_draft",
-            new_callable=AsyncMock,
-            side_effect=ValueError("Dataset not found"),
-        ),
+    with patch(
+        "app.processing.ai.router._check_ai_available",
+        new_callable=AsyncMock,
     ):
         resp = await client.post(
             "/ai/metadata/summary/",
@@ -335,5 +335,5 @@ async def test_returns_422_invalid_dataset(
             headers=admin_auth_header,
         )
 
-    assert resp.status_code == 422
+    assert resp.status_code == 404
     assert "not found" in resp.json()["detail"].lower()

--- a/backend/tests/test_ai_metadata_authz_1173.py
+++ b/backend/tests/test_ai_metadata_authz_1173.py
@@ -1,0 +1,212 @@
+"""DB-backed regression tests for AI metadata endpoint authorization (Phase 1173, SEC-D).
+
+SEC-D (HIGH): the four `POST /ai/metadata/{summary,keywords,lineage,quality-statement}/`
+endpoints are gated only by `require_permission("use_ai_chat")` — which the default
+editor role has (`core/permissions.py:42`). The attacker-controlled `body.dataset_id`
+flowed to `_build_dataset_context` with no visibility filter, rendering ANY dataset's
+title/summary/source_url/filename/columns/sample-values into the LLM prompt (echoed in
+the response). The fix authorizes the requested dataset in each handler
+(`_authorize_metadata_dataset` → `check_dataset_access` → 404 on denial) before the
+generation service runs.
+
+The four ATTACK tests fail on main `2c031da8` (an editor gets a 200 draft for another
+user's private dataset); the owner/admin GUARD tests pass before and after.
+
+In every test `_check_ai_available` is patched (so the AI-availability gate never 503s)
+and the generation service is patched to a valid response (so no real LLM call, and so
+UNFIXED main returns a clean 200 to demonstrate the leak; the fix 404s before the
+service is reached).
+
+Requirements:
+  - Docker database must be running (docker compose up db)
+  - Alembic migrations must be applied
+"""
+
+import uuid
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from httpx import AsyncClient
+
+from .conftest import _create_test_user
+from tests.factories import create_dataset
+from app.processing.ai.metadata_schemas import (
+    KeywordSuggestion,
+    KeywordSuggestionsResponse,
+    LineageDraftResponse,
+    QualityStatementDraftResponse,
+    SummaryDraftResponse,
+)
+
+
+# (url, router service attr to patch, valid mock response for that endpoint)
+_ENDPOINTS = [
+    (
+        "/ai/metadata/summary/",
+        "generate_summary_draft",
+        SummaryDraftResponse(draft="A drafted summary."),
+    ),
+    (
+        "/ai/metadata/keywords/",
+        "generate_keyword_suggestions",
+        KeywordSuggestionsResponse(
+            keywords=[KeywordSuggestion(keyword="parks", keyword_type="theme")]
+        ),
+    ),
+    (
+        "/ai/metadata/lineage/",
+        "generate_lineage_draft",
+        LineageDraftResponse(draft="A drafted lineage."),
+    ),
+    (
+        "/ai/metadata/quality-statement/",
+        "generate_quality_statement_draft",
+        QualityStatementDraftResponse(draft="A drafted quality statement."),
+    ),
+]
+_IDS = ["summary", "keywords", "lineage", "quality-statement"]
+
+
+def _patches(generate_fn_name: str, mock_response):
+    """Patch the AI-availability gate (no 503) and the generation service (no real
+    LLM, valid 200 body). The service is what UNFIXED main reaches after the missing
+    authz; the fix 404s in `_authorize_metadata_dataset` before it is ever invoked."""
+    return (
+        patch("app.processing.ai.router._check_ai_available", new=AsyncMock()),
+        patch(
+            f"app.processing.ai.router.{generate_fn_name}",
+            new=AsyncMock(return_value=mock_response),
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# SEC-D — attack: non-admin editor cannot read another user's private dataset
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("url,fn,mock_resp", _ENDPOINTS, ids=_IDS)
+async def test_metadata_rejects_foreign_private_dataset(
+    client: AsyncClient,
+    admin_auth_header: dict,
+    test_db_session,
+    url: str,
+    fn: str,
+    mock_resp,
+):
+    """Editor B requests AI metadata for editor A's PRIVATE dataset → 403/404.
+
+    Fails on main (200): the handler authorizes no dataset.
+    """
+    _owner_headers, owner_id = await _create_test_user(
+        client, admin_auth_header, "editor"
+    )
+    attacker_headers, _ = await _create_test_user(client, admin_auth_header, "editor")
+    private = await create_dataset(
+        test_db_session,
+        created_by=uuid.UUID(owner_id),
+        name="Owner private dataset",
+        visibility="private",
+    )
+
+    p_avail, p_svc = _patches(fn, mock_resp)
+    with p_avail, p_svc:
+        resp = await client.post(
+            url, json={"dataset_id": str(private.id)}, headers=attacker_headers
+        )
+
+    assert resp.status_code in (403, 404), (
+        f"{url}: editor read ANOTHER user's private dataset metadata, got "
+        f"{resp.status_code}: {resp.text}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# GUARDs — owner and admin must NOT be over-blocked
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("url,fn,mock_resp", _ENDPOINTS, ids=_IDS)
+async def test_metadata_allows_owner(
+    client: AsyncClient,
+    admin_auth_header: dict,
+    test_db_session,
+    url: str,
+    fn: str,
+    mock_resp,
+):
+    """GUARD: the owning editor CAN draft metadata for their OWN private dataset —
+    authorization is by ownership, not admin-ness. Must stay 200 after the fix."""
+    owner_headers, owner_id = await _create_test_user(
+        client, admin_auth_header, "editor"
+    )
+    private = await create_dataset(
+        test_db_session,
+        created_by=uuid.UUID(owner_id),
+        name="Owner private dataset",
+        visibility="private",
+    )
+
+    p_avail, p_svc = _patches(fn, mock_resp)
+    with p_avail, p_svc:
+        resp = await client.post(
+            url, json={"dataset_id": str(private.id)}, headers=owner_headers
+        )
+
+    assert resp.status_code == 200, (
+        f"{url}: owner blocked from their OWN dataset, got "
+        f"{resp.status_code}: {resp.text}"
+    )
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("url,fn,mock_resp", _ENDPOINTS, ids=_IDS)
+async def test_metadata_allows_admin(
+    client: AsyncClient,
+    admin_auth_header: dict,
+    test_db_session,
+    url: str,
+    fn: str,
+    mock_resp,
+):
+    """GUARD: admin is never over-blocked (admins access all datasets)."""
+    _owner_headers, owner_id = await _create_test_user(
+        client, admin_auth_header, "editor"
+    )
+    private = await create_dataset(
+        test_db_session,
+        created_by=uuid.UUID(owner_id),
+        name="Owner private dataset",
+        visibility="private",
+    )
+
+    p_avail, p_svc = _patches(fn, mock_resp)
+    with p_avail, p_svc:
+        resp = await client.post(
+            url, json={"dataset_id": str(private.id)}, headers=admin_auth_header
+        )
+
+    assert resp.status_code == 200, (
+        f"{url}: admin over-blocked, got {resp.status_code}: {resp.text}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Malformed input
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_metadata_invalid_uuid_returns_422(
+    client: AsyncClient, admin_auth_header: dict
+):
+    """A non-UUID dataset_id is rejected with 422 (not a 500 from the loader)."""
+    with patch("app.processing.ai.router._check_ai_available", new=AsyncMock()):
+        resp = await client.post(
+            "/ai/metadata/summary/",
+            json={"dataset_id": "not-a-uuid"},
+            headers=admin_auth_header,
+        )
+    assert resp.status_code == 422, f"got {resp.status_code}: {resp.text}"


### PR DESCRIPTION
## Summary

Closes the AI-metadata authorization hole (phase 1173, SEC-D — last of the v1038 cross-dataset-authz batch, following #234/#235/#236/#237).

**SEC-D (HIGH).** The four `POST /ai/metadata/{summary,keywords,lineage,quality-statement}/` endpoints (`ai/router.py`) were gated only by `require_permission("use_ai_chat")` — which the **default editor role has** (`core/permissions.py:42`). The attacker-controlled `body.dataset_id` flowed straight to `_build_dataset_context` (`ai/metadata_service.py`), which loads the dataset with **no visibility filter** and renders its title, summary, **source_url/source_filename**, SRID, bbox, **column schema**, and **sample values** into the LLM prompt — echoed back in the draft response. So a non-admin editor could read any user's **private** dataset's metadata + backing source + schema + sample data just by passing its UUID. (Contrast: AI chat / generate-map already gate via `build_table_allowlist`.) Same systemic class as #234 (FK relationships), #235 (anon maps), #236 (OGC externalId), #237 (VRT sources).

## Fix

Add `_authorize_metadata_dataset(db, dataset_id, user)`, called in each handler **after** `_check_ai_available` and **before** the generation service:
- parse the UUID (422 on malformed — previously a bare `UUID()` in the service 500'd on garbage),
- load via `get_dataset` (eager-loads `.record`),
- `check_dataset_access` → **404** on denial (same response as a nonexistent dataset, so not an existence oracle).

**Authorize in the handler, not inside `_build_dataset_context`** — that function has a `dataset_id`-keyed TTL cache (`_dataset_context_cache`) and takes no `user`, so an in-service check would be bypassed on a cache hit. Handler-level authz is cache-independent and runs before the service is ever invoked.

## Tests

New DB-backed `backend/tests/test_ai_metadata_authz_1173.py` (parametrized over all 4 endpoints):
- `test_metadata_rejects_foreign_private_dataset` — editor B requests metadata for editor A's private dataset → 403/404 *(red on main)*
- `test_metadata_allows_owner` (GUARD) — owning editor → 200 *(authz by ownership, not admin-ness)*
- `test_metadata_allows_admin` (GUARD) — admin → 200
- `test_metadata_invalid_uuid_returns_422`

`_check_ai_available` and the generation service are patched so the tests don't need a live LLM, and so unfixed `main` reaches the mocked service and returns a clean 200 (demonstrating the leak) while the fix 404s first.

**Fail-on-main gate:** reverting only `ai/router.py` to `2c031da8` turns the 4 attack tests RED and keeps the GUARDs GREEN. With the fix: all pass.

Also updates one existing test: `test_ai_metadata.py::test_returns_422_invalid_dataset` → `test_returns_404_nonexistent_dataset`. A nonexistent dataset now 404s via authz (before the service's `ValueError`→422 path) — an intentional, IDOR-safe contract change consistent with `check_dataset_access`.

## Verification
- `ruff check` + `ruff format --check` clean (pre-commit gate passed).
- Plan adversarially plan-checked before implementation (3 grounded reviewers): confirmed editor has `use_ai_chat`, attack surface is exactly these 4 endpoints, handler-vs-cache placement correct.
- Full backend suite `-n 4`: **3217 passed** (the lone failure is the known host-only `test_no_geolens_io_typos` transient — a concurrent test's temp file; passes on a clean checkout and is unrelated to this diff).