### PR TITLE
docs(changelog): record v1038 cross-dataset authorization fixes (SEC-A..E)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and releases use semantic versioning.
 
 ## [Unreleased]
 
+### Security
+
+- Map read endpoints, including anonymous and shared-map views, now re-authorize
+  each layer's dataset. Layers backed by datasets the caller cannot access are
+  omitted, and their signed vector-tile URLs no longer expose private tile data.
+- OGC API – Records item lookup by `externalId` now enforces dataset visibility,
+  so private catalog records are no longer disclosed to unauthenticated requests.
+- Virtual raster (VRT) creation and source addition now authorize each source
+  dataset against the caller, preventing one user from compositing another user's
+  private raster into a VRT they own and reading its pixels back. VRT
+  source-listing and status responses now omit members the caller cannot access.
+- AI metadata-assist endpoints now authorize the requested dataset, preventing a
+  user from generating drafts against another user's private dataset, which
+  previously exposed that dataset's metadata, source, schema, and sample values.
+
 ## [1.2.0] - 2026-06-02
 
 ### Added


### PR DESCRIPTION
Closes the documentation step of the v1038 Security Close-Gate (Phase 1174).

Adds an **Unreleased → Security** section to `CHANGELOG.md` documenting the four authorization-boundary fixes already merged to `main`:

| Fix | PR |
|-----|-----|
| Maps read endpoints re-authorize each layer's dataset (anonymous/shared views; signed vector-tile URLs no longer expose private tile data) | #235 |
| OGC API – Records `externalId` lookup enforces dataset visibility | #236 |
| VRT creation/source-add authorize each source dataset; source-listing/status omit inaccessible members | #237 |
| AI metadata-assist endpoints authorize the requested dataset | #238 |

**Framing is intentionally decision-neutral** — entries sit under `## [Unreleased]` so they don't presuppose a release. At release time, move them under a version header (e.g. a `1.2.1` patch) as part of the GHSA / patch-release decision (owner's call; repo is still private so public disclosure is not yet forced).

Prose style matches the existing CHANGELOG (no PR refs in the entry text). Docs-only change.