### PR TITLE
chore(release): prepare v1.2.3 — security patch (SEC-A..E)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and releases use semantic versioning.
 
 ## [Unreleased]
 
+## [1.2.3] - 2026-06-10
+
 ### Security
 
 - Map read endpoints, including anonymous and shared-map views, now re-authorize

--- a/backend/app/api/main.py
+++ b/backend/app/api/main.py
@@ -442,7 +442,7 @@ _is_production = settings.log_json
 
 app = FastAPI(
     title="GeoLens API",
-    version="1.2.0",
+    version="1.2.3",
     summary="PostGIS-native geospatial data catalog with OGC API Features compliance",
     description=_DESCRIPTION,
     root_path="/api",

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -15516,7 +15516,7 @@
     "summary": "PostGIS-native geospatial data catalog with OGC API Features compliance",
     "termsOfService": "https://github.com/geolens-io/geolens/blob/main/LICENSE",
     "title": "GeoLens API",
-    "version": "1.2.0"
+    "version": "1.2.3"
   },
   "openapi": "3.1.0",
   "paths": {

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geolens-backend"
-version = "1.2.0"
+version = "1.2.3"
 description = "PostGIS-native GIS data catalog"
 # Docker image (Dockerfile) ships python:3.14.3-slim as the project's tested
 # runtime. requires-python>=3.13 is the backward-compat floor for adopters

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -824,7 +824,7 @@ wheels = [
 
 [[package]]
 name = "geolens-backend"
-version = "1.2.0"
+version = "1.2.3"
 source = { virtual = "." }
 dependencies = [
     { name = "alembic" },

--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "geolens-cli"
-version = "1.2.0"
+version = "1.2.3"
 description = "Apache-2.0 command-line interface for the GeoLens API. Login, scan, publish, and export STAC against any GeoLens instance."
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.2.0",
+  "version": "1.2.3",
   "type": "module",
   "license": "Apache-2.0",
   "scripts": {

--- a/sdks/python/.openapi-python-client.yaml
+++ b/sdks/python/.openapi-python-client.yaml
@@ -4,7 +4,7 @@ project_name_override: geolens
 package_name_override: geolens
 # Rewritten on every `make sdks` run by scripts/sync_sdk_versions.py to match
 # backend/openapi.json info.version. Do not edit by hand.
-package_version_override: 1.2.0
+package_version_override: 1.2.3
 
 # Cleaner enum output (matches our pydantic v2 backend's enum emission).
 literal_enums: true

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "geolens"
-version = "1.2.0"
+version = "1.2.3"
 description = "Auto-generated Python SDK for the GeoLens API. Typed clients with Bearer + API-key auth helpers."
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/sdks/typescript/package-lock.json
+++ b/sdks/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@geolens/sdk",
-  "version": "1.2.0",
+  "version": "1.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@geolens/sdk",
-      "version": "1.2.0",
+      "version": "1.2.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@hey-api/client-fetch": "0.13.1"

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@geolens/sdk",
-  "version": "1.2.0",
+  "version": "1.2.3",
   "description": "Auto-generated TypeScript SDK for the GeoLens API. Typed clients with Bearer + API-key auth helpers.",
   "license": "Apache-2.0",
   "homepage": "https://github.com/geolens-io/geolens",


### PR DESCRIPTION
**Release-prep for v1.2.3 — a SECURITY PATCH.** Staged for review; does **not** cut the tag or publish packages (manual operator steps — see the runbook).

## Why this is needed (urgent)
The cross-dataset authorization fixes #234–#239 merged **after** the latest release **v1.2.2 (2026-06-07)**, and the published PyPI/npm packages are still at **1.2.0**. Both predate the fixes, so the published software is **vulnerable to SEC-A..E** — including two *anonymous*-reachable HIGHs (SEC-A signed-tile replay → private vector-tile data; SEC-B OGC `externalId` private-record disclosure). The repo is public, so the fix diffs are visible: this is a disclosed-but-unpatched window. The publish workflows read the package version from the source tree and gate against PyPI, so shipping the fix **requires** this version bump.

## Contents (version-only — verified no spec/client drift)
- `backend/app/api/main.py` FastAPI version, `backend/pyproject.toml`, `frontend/package.json` → **1.2.3**
- `backend/openapi.json` regenerated via `make openapi` (version-only; `openapi-check` clean)
- `sdks/python`, `sdks/typescript`, `cli` synced via `make sdks` → 1.2.3 (`sdks-check` reproduces identical output once merged)
- `CHANGELOG.md`: `[Unreleased] → Security` promoted to **`## [1.2.3] - 2026-06-10`** (so `release.yml` extracts the right notes for the tag)
- `cli`'s `geolens>=1.2.0,<2.0.0` dependency floor left as-is (1.2.3 satisfies it)

## After merge (operator — NOT done here)
1. **Re-clone** (the local working clone carries stale `v1.2.x` tags — known hazard) or cut the tag via the **GitHub API at the merged commit SHA**, never `git push --tags`.
2. Tag `v1.2.3` → auto-runs `release.yml` (GitHub release from the CHANGELOG `[1.2.3]` section) + `publish.yml` (multi-arch GHCR images).
3. **Manually** dispatch `publish-sdks.yml` (target=both) + `publish-cli.yml` to publish PyPI `geolens`/`geolens-cli` + npm `@geolens/sdk` at 1.2.3.
4. Publish the **GHSA advisory** for SEC-A..E.
5. `verify-published.yml`, then close the v1038 milestone.