### PR TITLE
fix: v1.2.4 security hardening — Tier-0 (all Criticals + 5 Highs)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -123,8 +123,23 @@ GEOLENS_ADMIN_PASSWORD=
 # Type: string | Default: none
 # PUBLIC_BASE_URL=
 
+# --- Deployment environment ---
+# Controls security-sensitive behavior: API docs exposure (/docs, /redoc) and
+# the Secure flag on the OAuth session cookie.
+#   development -> docs enabled, session cookie WITHOUT Secure (safe for HTTP)
+#   production  -> docs disabled, session cookie WITH Secure (HTTPS only)
+# Set this to "production" on every public-facing, TLS-terminated deployment.
+# If unset, the app falls back to using LOG_JSON as the production indicator
+# (backward compatibility with deployments configured before this setting).
+# Type: string | Default: (unset -> LOG_JSON fallback) | Options: development, production
+# ENVIRONMENT=production
+
 # --- Logging ---
-# Output logs in JSON format (recommended for production)
+# Output logs in JSON format (recommended for production log aggregation).
+# NOTE: this controls LOG FORMAT ONLY. It no longer governs security posture
+# (docs exposure / session cookie Secure flag) — use ENVIRONMENT for that. For
+# backward compatibility, if ENVIRONMENT is unset, LOG_JSON=true still implies
+# the production security posture.
 # Type: boolean | Default: false
 # LOG_JSON=false
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,7 @@ jobs:
             installer:
               - 'scripts/install.sh'
               - 'scripts/tests/test-install-tag-resolution.sh'
+              - 'scripts/tests/test-install-secret-generation.sh'
               - 'docker-compose.yml'
               - 'docker-compose.prod.yml'
 
@@ -151,6 +152,9 @@ jobs:
 
       - name: Tag/branch shadowing regression test
         run: sh scripts/tests/test-install-tag-resolution.sh
+
+      - name: Installer secret-generation regression test
+        run: sh scripts/tests/test-install-secret-generation.sh
 
       - name: Validate compose files parse
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,8 +69,10 @@ jobs:
               - 'db/**'
             installer:
               - 'scripts/install.sh'
+              - 'scripts/backup-entrypoint.sh'
               - 'scripts/tests/test-install-tag-resolution.sh'
               - 'scripts/tests/test-install-secret-generation.sh'
+              - 'scripts/tests/test-backup-s3-signature.sh'
               - 'docker-compose.yml'
               - 'docker-compose.prod.yml'
 
@@ -155,6 +157,9 @@ jobs:
 
       - name: Installer secret-generation regression test
         run: sh scripts/tests/test-install-secret-generation.sh
+
+      - name: Backup S3 signature regression test
+        run: sh scripts/tests/test-backup-s3-signature.sh
 
       - name: Validate compose files parse
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,59 @@ and releases use semantic versioning.
 
 ## [Unreleased]
 
+## [1.2.4] - 2026-06-11
+
+### Security
+
+- Record contact, keyword, and distribution sub-resources now re-authorize the
+  backing dataset, so a private record's contact details and related metadata
+  are no longer disclosed to authenticated users who cannot access that record.
+- Private raster and vector tiles are no longer served with shared-cache
+  headers. Tiles for non-public datasets are marked private so a shared cache
+  (a CDN or the bundled reverse proxy) cannot retain and replay them to later
+  unauthenticated requests, including unpublished public-dataset previews.
+- The map visibility-check endpoint now authorizes read access to the map
+  before reporting its non-public dataset names, so the titles of private
+  datasets can no longer be enumerated through maps the caller cannot read.
+- Outbound fetches of user-supplied URLs (service probes, STAC and OGC API
+  sources, manifest downloads) now pin the validated IP address at connection
+  time, closing a DNS-rebinding window where a hostname could resolve to a
+  public address during validation and a private address at fetch time.
+- The remote-service preview path now passes authorization tokens to GDAL
+  through a private (0600) header file and rejects tokens containing control
+  characters, preventing token disclosure through the process environment and
+  HTTP header injection.
+- The deployment's production security posture — API documentation exposure and
+  the Secure flag on the OAuth session cookie — is now controlled by an explicit
+  `ENVIRONMENT` setting instead of the `LOG_JSON` logging flag. Deployments that
+  have not set `ENVIRONMENT` retain their previous behavior.
+- The bundled reverse proxy now redacts the `api_key` query parameter from its
+  access logs, so API keys passed in the query string are no longer written to
+  logs in cleartext.
+- The web application now ships a Content-Security-Policy restricting script
+  sources, a defense-in-depth backstop against token exfiltration should a
+  cross-site scripting issue ever be introduced.
+- The STAC `POST /search` endpoint now caps the size of GeoJSON `intersects`
+  geometries, matching the existing `GET` limit, to prevent an unauthenticated
+  geometry-based denial of service.
+- A fresh install now generates strong, unique database and admin passwords
+  instead of keeping the published defaults, and no longer silently retains a
+  default admin password on a headless (`curl | sh`) install.
+
+### Fixed
+
+- Database migrations upgrade cleanly on enterprise deployments of the core
+  package; a migration-graph fork that caused `alembic upgrade head` to fail has
+  been resolved.
+- The background job queue now works on managed/external PostgreSQL configured
+  via `DATABASE_URL_OVERRIDE`; the connection's schema search path was dropped,
+  which broke job processing and data ingestion on those deployments.
+- Admin-configured rate limits (login, global, semantic search, and basemap
+  proxy) now take effect when changed, instead of being ignored until the
+  service restarted.
+- Automated off-site backups to S3-compatible storage now upload successfully;
+  the request signature was computed incorrectly and every upload was rejected.
+
 ## [1.2.3] - 2026-06-10
 
 ### Security

--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ reset-db:
 	docker compose up --build
 
 migrate:
-	docker compose exec api uv run alembic upgrade head
+	docker compose exec api uv run alembic upgrade heads
 
 migration:
 	docker compose exec api uv run alembic revision --autogenerate -m "$(msg)"

--- a/backend/app/api/main.py
+++ b/backend/app/api/main.py
@@ -80,14 +80,15 @@ def _warn_if_cors_unset(settings_obj, log) -> None:
     production. DynamicCORSMiddleware will still respond (no breakage),
     but the operator likely INTENDED to lock down origins and forgot.
 
-    Gated on log_json so dev/test runs don't get the warning. log_json is
-    the same production indicator used at line 407 for `_is_production`.
+    Gated on is_production so dev/test runs don't get the warning. SEC-005:
+    previously gated on log_json (the de-facto production indicator); now uses
+    the explicit settings.is_production.
     """
-    if settings_obj.log_json and not settings_obj.cors_allowed_origins:
+    if settings_obj.is_production and not settings_obj.cors_allowed_origins:
         log.warning(
             "cors_allowed_origins_unset",
             message=(
-                "CORS_ALLOWED_ORIGINS is empty in production (LOG_JSON=true). "
+                "CORS_ALLOWED_ORIGINS is empty in production. "
                 "All origins will pass the request-origin check; this is "
                 "likely a misconfiguration. Set "
                 "CORS_ALLOWED_ORIGINS=<comma-separated origins> to restrict."
@@ -438,7 +439,10 @@ _OPENAPI_TAGS = [
     },
 ]
 
-_is_production = settings.log_json
+# SEC-005: docs exposure (and the Secure session cookie below) are gated on the
+# explicit ENVIRONMENT setting, not the LOG_JSON log-format flag. is_production
+# falls back to LOG_JSON when ENVIRONMENT is unset (backward compatibility).
+_is_production = settings.is_production
 
 app = FastAPI(
     title="GeoLens API",
@@ -508,15 +512,15 @@ async def _rate_limit_handler(request: Request, exc: RateLimitExceeded) -> JSONR
 
 app.add_exception_handler(RateLimitExceeded, _rate_limit_handler)
 
-# SEC-02 / M-64: gate https_only on the production indicator. Local-dev and
-# test runs use log_json=False (no TLS terminator), so https_only=True would
-# cause SessionMiddleware to silently strip the cookie. Production sets
-# LOG_JSON=true (json-logging deploy config) so https_only=True flows through
-# unchanged. _is_production at line 407 uses the same signal.
+# SEC-02 / M-64 / SEC-005: gate https_only on the production indicator. Local-dev
+# and test runs use the development posture (no TLS terminator), so
+# https_only=True would cause SessionMiddleware to silently strip the cookie.
+# Production (ENVIRONMENT=production, or legacy LOG_JSON=true) sets
+# https_only=True. Same settings.is_production used for docs gating above.
 app.add_middleware(
     SessionMiddleware,
     secret_key=settings.jwt_secret_key.get_secret_value(),
-    https_only=settings.log_json,
+    https_only=settings.is_production,
 )
 app.add_middleware(RequestLoggingMiddleware)
 app.add_middleware(SlowAPIMiddleware)

--- a/backend/app/api/main.py
+++ b/backend/app/api/main.py
@@ -446,7 +446,7 @@ _is_production = settings.is_production
 
 app = FastAPI(
     title="GeoLens API",
-    version="1.2.3",
+    version="1.2.4",
     summary="PostGIS-native geospatial data catalog with OGC API Features compliance",
     description=_DESCRIPTION,
     root_path="/api",

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -328,7 +328,7 @@ class Settings(BaseSettings):
     @property
     def procrastinate_conninfo(self) -> str:
         if self.database_url_override:
-            from urllib.parse import urlparse
+            from urllib.parse import parse_qs, urlparse
 
             raw = self.database_url_override
             for prefix in ("postgresql+asyncpg://", "postgresql+psycopg://"):
@@ -353,6 +353,21 @@ class Settings(BaseSettings):
                 parts.append(f"sslmode={self.database_ssl_mode}")
             if self.database_ssl_ca_cert:
                 parts.append(f"sslrootcert={self.database_ssl_ca_cert}")
+            # BUG-002: the non-override branch sets
+            # options='-c search_path=<schema>,public' so procrastinate's
+            # unqualified objects resolve in the catalog schema. The override
+            # branch dropped it entirely, breaking the job queue on managed
+            # Postgres (UndefinedTable/UndefinedFunction on every defer and
+            # worker start). Re-add it, preserving any caller-supplied
+            # ?options= — our search_path is applied last so it always wins.
+            search_path_opt = f"-c search_path={self.procrastinate_schema},public"
+            caller_options = parse_qs(parsed.query).get("options", [""])[0]
+            combined_options = (
+                f"{caller_options} {search_path_opt}".strip()
+                if caller_options.strip()
+                else search_path_opt
+            )
+            parts.append(f"options='{combined_options}'")
             return " ".join(parts)
         return (
             f"host={self.postgres_host} port={self.postgres_port} "

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -1,5 +1,6 @@
 import sys
 from pathlib import Path
+from typing import Literal
 
 from pydantic import Field, SecretStr, ValidationError, field_validator, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
@@ -75,6 +76,16 @@ class Settings(BaseSettings):
 
     log_json: bool = False
     log_level: str = "INFO"
+
+    # SEC-005: explicit deployment environment. Controls security-sensitive
+    # behaviors — API docs exposure (/docs, /redoc) and the Secure flag on the
+    # OAuth session cookie (SessionMiddleware https_only). Previously these were
+    # keyed off LOG_JSON, an innocuously-documented log-format flag.
+    #   "production"  -> hardened posture (docs hidden, Secure cookie)
+    #   "development" -> open posture (docs shown, no Secure cookie)
+    #   unset (None)  -> fall back to LOG_JSON for backward compatibility
+    # Set ENVIRONMENT=production on any public, TLS-terminated deployment.
+    environment: Literal["development", "production"] | None = None
 
     anthropic_api_key: SecretStr | None = None
     llm_model: str = "claude-sonnet-4-20250514"
@@ -241,6 +252,21 @@ class Settings(BaseSettings):
         if not self.cors_allowed_origins:
             return []
         return [o.strip() for o in self.cors_allowed_origins.split(",") if o.strip()]
+
+    @property
+    def is_production(self) -> bool:
+        """Whether to enforce the production security posture (API docs hidden,
+        Secure session cookie).
+
+        SEC-005: driven by the explicit ENVIRONMENT setting. When ENVIRONMENT is
+        unset, fall back to LOG_JSON (the de-facto production switch before this
+        setting) so no existing deployment silently loses its hardened posture.
+        An explicit ENVIRONMENT (development or production) decouples fully —
+        LOG_JSON no longer affects security.
+        """
+        if self.environment is not None:
+            return self.environment == "production"
+        return self.log_json
 
     @staticmethod
     def _strip_ssl_from_url(url: str) -> str:

--- a/backend/app/core/persistent_config.py
+++ b/backend/app/core/persistent_config.py
@@ -226,6 +226,15 @@ class PersistentConfig(Generic[T]):
         # Side effect hook
         self._on_change(value)
 
+        # BUG-008: warm the sync rate-limit cache with the NEW value. set()
+        # only ever warmed it with the OLD value (via the get(db) above), so
+        # slowapi kept enforcing the previous limit until the 30s TTL expired —
+        # and because no request-path code calls .get() for these keys, the new
+        # value was otherwise never applied in this process. _update_sync_cache
+        # no-ops for non-rate-limit keys. (Per-process cache: other workers
+        # still lag by up to _CACHE_TTL until their entry expires.)
+        self._update_sync_cache(value)
+
     async def reset(
         self,
         db: AsyncSession,
@@ -270,6 +279,10 @@ class PersistentConfig(Generic[T]):
                 await cache.delete(f"{_CACHE_PREFIX}{self.key}")
 
             self._on_change(self.env_default)
+
+            # BUG-008: warm the sync cache with the reverted env_default so
+            # slowapi picks it up immediately (same rationale as set()).
+            self._update_sync_cache(self.env_default)
 
     def _on_change(self, value: T) -> None:
         """Override in subclasses for side effects on set()."""
@@ -731,7 +744,9 @@ def get_cached_semantic_search_rate_limit() -> int:
 
     SEC-S11: caps OpenAI embedding cost-DoS by limiting unique novel queries per IP.
     Default 30/min matches the audit recommendation for cost-sensitive endpoints.
-    Configurable via SEMANTIC_SEARCH_RATE_LIMIT env var.
+    Configurable at runtime via the admin Settings UI / PUT /settings/ with key
+    `semantic_search_rate_limit` (there is no SEMANTIC_SEARCH_RATE_LIMIT env var;
+    Settings uses extra="ignore").
     """
     cached = _sync_rate_limit_cache.get("semantic_search_rate_limit")
     if cached and (time.monotonic() - cached[1]) < _CACHE_TTL:
@@ -745,7 +760,9 @@ def get_cached_basemap_proxy_rate_limit() -> int:
     SEC-S10: caps commercial-tier basemap key replay from anonymous clients.
     Default 120/min is loose enough for the SPA boot path (one call per page load
     across users behind a shared NAT) while still bounding attacker throughput.
-    Configurable via BASEMAP_PROXY_RATE_LIMIT env var.
+    Configurable at runtime via the admin Settings UI / PUT /settings/ with key
+    `basemap_proxy_rate_limit` (there is no BASEMAP_PROXY_RATE_LIMIT env var;
+    Settings uses extra="ignore").
     """
     cached = _sync_rate_limit_cache.get("basemap_proxy_rate_limit")
     if cached and (time.monotonic() - cached[1]) < _CACHE_TTL:

--- a/backend/app/modules/catalog/maps/router.py
+++ b/backend/app/modules/catalog/maps/router.py
@@ -376,6 +376,10 @@ async def visibility_check_endpoint(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="Map not found",
         )
+    # SEC-007: gate on read access to THIS map before disclosing its non-public
+    # dataset names. Without it, any editor could enumerate the private dataset
+    # titles of any map (incl. maps they cannot read) by UUID.
+    await _check_map_read_access(map_obj, user, db)
     non_public_names = await validate_public_visibility(db, map_id)
     return VisibilityCheckResponse(
         non_public_datasets=non_public_names,

--- a/backend/app/modules/catalog/records/router.py
+++ b/backend/app/modules/catalog/records/router.py
@@ -3,14 +3,19 @@
 import uuid
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Response, status
+from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import joinedload
 
 from app.core.identity import Identity
 from app.modules.auth.dependencies import get_optional_user, require_permission
-from app.modules.catalog.authorization import get_user_roles
+from app.modules.catalog.authorization import (
+    check_dataset_access_or_anonymous,
+    get_user_roles,
+)
 from app.core.dependencies import get_db
-from app.modules.catalog.datasets.domain.models import Record
+from app.modules.catalog.datasets.domain.models import Dataset, Record
 from app.modules.catalog.records.schemas import (
     ContactCreate,
     ContactListResponse,
@@ -51,18 +56,60 @@ async def _check_record_read_access(
     record_id: uuid.UUID,
     user: Identity | None,
 ) -> None:
-    """Verify the record exists and is visible to the caller. Raises 404."""
+    """Verify the record is visible to the caller. Raises 404 on denial.
+
+    Record sub-resources (contacts/keywords/distributions) carry the same
+    visibility as the dataset they back, so authorization is delegated to the
+    shared per-dataset RBAC the dataset endpoints use — public/private/
+    restricted, owner, admin, and anonymous (public+published only), including
+    grants. This closes the gap where ANY authenticated user could read a
+    private record by gating only `user is None`.
+    """
     record = await get_record(db, record_id)
     if record is None:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND, detail="Record not found"
         )
-    if user is None and (
-        record.visibility != "public" or record.record_status != "published"
-    ):
+
+    # Delegate to the dataset that backs this record, mirroring the dataset
+    # read endpoints (get_dataset + check_dataset_access_or_anonymous).
+    dataset = (
+        (
+            await db.execute(
+                select(Dataset)
+                .options(joinedload(Dataset.record))
+                .where(Dataset.record_id == record_id)
+            )
+        )
+        .scalars()
+        .first()
+    )
+    if dataset is not None:
+        try:
+            await check_dataset_access_or_anonymous(db, dataset, dataset.id, user)
+        except HTTPException:
+            # Normalize the denial to the record's own 404 (don't leak that a
+            # backing dataset exists).
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND, detail="Record not found"
+            )
+        return
+
+    # Orphan record with no backing dataset (e.g. mid-ingest): only public +
+    # published is world-readable; otherwise owner or admin only.
+    if record.visibility == "public" and record.record_status == "published":
+        return
+    if user is None:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND, detail="Record not found"
         )
+    if record.created_by == user.id:
+        return
+    if "admin" in await get_user_roles(db, user):
+        return
+    raise HTTPException(
+        status_code=status.HTTP_404_NOT_FOUND, detail="Record not found"
+    )
 
 
 async def _check_record_ownership(

--- a/backend/app/modules/catalog/sources/preview.py
+++ b/backend/app/modules/catalog/sources/preview.py
@@ -117,13 +117,16 @@ async def run_service_preview(
             # Passing the bearer via GDAL_HTTP_HEADERS leaks it through the
             # subprocess env (visible in /proc/<pid>/environ for the process
             # lifetime) and lets a CR/LF in the token inject arbitrary outbound
-            # HTTP headers under libcurl. Sanitize the token to the base64url
-            # charset and hand it to GDAL via a 0600 GDAL_HTTP_HEADER_FILE — the
+            # HTTP headers under libcurl. Re-validate the token (reject CR/LF /
+            # control chars — the same sources-layer validator the request schema
+            # applies) and hand it to GDAL via a 0600 GDAL_HTTP_HEADER_FILE so the
             # env var carries the file PATH, not the secret. The tempfile is
-            # unlinked in the finally below.
-            from app.processing.ingest.ogr import _sanitize_authorization_token
+            # unlinked in the finally below. Validator lives in this module's
+            # `schemas` (not app.processing) to respect the catalog↔processing
+            # layering boundary.
+            from app.modules.catalog.sources.schemas import _validate_safe_token
 
-            safe_token = _sanitize_authorization_token(token)
+            safe_token = _validate_safe_token(token)
             import tempfile
 
             fd, header_file_path = tempfile.mkstemp(prefix="gdal_auth_", suffix=".hdr")

--- a/backend/app/modules/catalog/sources/preview.py
+++ b/backend/app/modules/catalog/sources/preview.py
@@ -107,29 +107,59 @@ async def run_service_preview(
         layer_name=layer_name,
     )
 
-    env = None
-    if token and (gdal_source.startswith("WFS:") or gdal_source.startswith("OAPIF:")):
-        env = {**os.environ, "GDAL_HTTP_HEADERS": f"Authorization: Bearer {token}"}
-
-    proc = await asyncio.create_subprocess_exec(
-        *cmd,
-        stdout=asyncio.subprocess.PIPE,
-        stderr=asyncio.subprocess.PIPE,
-        env=env,
-    )
-
+    header_file_path: str | None = None
     try:
-        stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=timeout)
-    except asyncio.TimeoutError:
-        proc.kill()
-        await proc.wait()
-        logger.warning(
-            "ogrinfo timed out for service preview",
-            gdal_source=gdal_source,
-            layer_name=layer_name,
-            timeout=timeout,
+        env = {**os.environ}
+        if token and (
+            gdal_source.startswith("WFS:") or gdal_source.startswith("OAPIF:")
+        ):
+            # SEC-021: mirror the ogr2ogr commit path (IA-P1-06 / SEC-FU-04).
+            # Passing the bearer via GDAL_HTTP_HEADERS leaks it through the
+            # subprocess env (visible in /proc/<pid>/environ for the process
+            # lifetime) and lets a CR/LF in the token inject arbitrary outbound
+            # HTTP headers under libcurl. Sanitize the token to the base64url
+            # charset and hand it to GDAL via a 0600 GDAL_HTTP_HEADER_FILE — the
+            # env var carries the file PATH, not the secret. The tempfile is
+            # unlinked in the finally below.
+            from app.processing.ingest.ogr import _sanitize_authorization_token
+
+            safe_token = _sanitize_authorization_token(token)
+            import tempfile
+
+            fd, header_file_path = tempfile.mkstemp(prefix="gdal_auth_", suffix=".hdr")
+            try:
+                os.write(fd, f"Authorization: Bearer {safe_token}\n".encode("ascii"))
+            finally:
+                os.close(fd)
+            os.chmod(header_file_path, 0o600)
+            env["GDAL_HTTP_HEADER_FILE"] = header_file_path
+
+        proc = await asyncio.create_subprocess_exec(
+            *cmd,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            env=env,
         )
-        return empty_fallback
+
+        try:
+            stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=timeout)
+        except asyncio.TimeoutError:
+            proc.kill()
+            await proc.wait()
+            logger.warning(
+                "ogrinfo timed out for service preview",
+                gdal_source=gdal_source,
+                layer_name=layer_name,
+                timeout=timeout,
+            )
+            return empty_fallback
+    finally:
+        if header_file_path is not None:
+            try:
+                os.unlink(header_file_path)
+            except OSError:
+                # Already removed; contents were only the bearer + file was 0600.
+                pass
 
     if proc.returncode != 0:
         error_msg = stderr.decode().strip() if stderr else "unknown error"

--- a/backend/app/modules/catalog/sources/schemas.py
+++ b/backend/app/modules/catalog/sources/schemas.py
@@ -16,6 +16,26 @@ def _validate_http_url(v: str) -> str:
     return v
 
 
+def _validate_safe_token(v: str | None) -> str | None:
+    """Reject control characters / whitespace in auth tokens (SEC-021).
+
+    Tokens flow into a GDAL_HTTP_HEADER_FILE (WFS/OAPIF bearer) and into service
+    query URLs (ArcGIS). A CR/LF or other control character could smuggle
+    additional outbound HTTP headers through the libcurl pipeline. Legitimate
+    JWT / base64url / ArcGIS tokens never contain control characters or
+    whitespace, so reject them at the API boundary (422).
+    """
+    if v is None:
+        return v
+    if not v.isprintable():
+        raise ValueError(
+            "token contains control characters (possible header injection)"
+        )
+    if any(c.isspace() for c in v):
+        raise ValueError("token contains whitespace")
+    return v
+
+
 class ProbeRequest(BaseModel):
     url: str = Field(
         min_length=1,
@@ -28,6 +48,7 @@ class ProbeRequest(BaseModel):
         max_length=1000,
         description="Optional auth token for protected services (passed as query parameter or bearer token depending on service type).",
     )
+    _validate_token = field_validator("token")(_validate_safe_token)
 
 
 class LayerInfo(BaseModel):
@@ -116,6 +137,7 @@ class ServicePreviewRequest(BaseModel):
         max_length=1000,
         description="Optional auth token for protected services.",
     )
+    _validate_token = field_validator("token")(_validate_safe_token)
     object_id_field: str | None = Field(
         default=None,
         max_length=200,

--- a/backend/app/modules/catalog/sources/security.py
+++ b/backend/app/modules/catalog/sources/security.py
@@ -30,6 +30,29 @@ def _is_blocked_ip(
     )
 
 
+async def _resolve_and_validate(host: str, port: int | None) -> str:
+    """Resolve *host*, validate every resolved IP, and return one validated IP.
+
+    SEC-008: returns the exact address the connection should use so the caller
+    can PIN it — eliminating the gap between validation-time DNS and connect-time
+    DNS. Raises SSRFError if resolution fails or ANY resolved address is blocked
+    (matching validate_url_for_ssrf's conservative semantics).
+    """
+    try:
+        results = await asyncio.to_thread(
+            socket.getaddrinfo, host, port, proto=socket.IPPROTO_TCP
+        )
+    except socket.gaierror:
+        raise SSRFError(f"Could not resolve hostname: {host}")
+    if not results:
+        raise SSRFError(f"Could not resolve hostname: {host}")
+    for _family, _type, _proto, _canon, sockaddr in results:
+        ip = ipaddress.ip_address(sockaddr[0])
+        if _is_blocked_ip(ip):
+            raise SSRFError("URLs targeting private/internal networks are not allowed")
+    return str(ipaddress.ip_address(results[0][4][0]))
+
+
 async def validate_url_for_ssrf(url: str) -> None:
     """Validate a URL is safe to fetch (no SSRF).
 
@@ -91,22 +114,50 @@ async def _revalidate_redirect(response: httpx.Response) -> None:
     await validate_url_for_ssrf(target)
 
 
+class _SSRFGuardTransport(httpx.AsyncHTTPTransport):
+    """Transport that re-resolves, re-validates, and PINS the IP at connect time.
+
+    SEC-008: validate_url_for_ssrf resolves DNS once at submission time, but the
+    client performs its OWN DNS lookup when it actually connects. A low-TTL
+    attacker domain can answer with a public IP at validation and a private IP
+    (169.254.169.254 / 127.x / 10.x) at connect — DNS rebinding. This transport
+    resolves + validates immediately before connecting and pins the connection
+    to the exact validated IP by rewriting the URL host to that IP while keeping
+    the original hostname for the Host header and TLS SNI/verification. httpx
+    builds a fresh request per redirect hop, so every hop is independently
+    re-resolved, re-validated, and re-pinned.
+    """
+
+    async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
+        host = request.url.host
+        validated_ip = await _resolve_and_validate(host, request.url.port)
+        # Pin to the validated address. The Host header was already set from the
+        # original URL at request-build time (left intact); sni_hostname keeps
+        # the hostname for TLS SNI and certificate verification.
+        request.url = request.url.copy_with(host=validated_ip)
+        request.extensions["sni_hostname"] = host
+        return await super().handle_async_request(request)
+
+
 def make_safe_client(
     timeout: float | httpx.Timeout = PROBE_TIMEOUT,
 ) -> httpx.AsyncClient:
-    """Construct an httpx.AsyncClient with per-hop SSRF revalidation.
+    """Construct an httpx.AsyncClient with SSRF IP-pinning and per-hop revalidation.
 
     Phase 1061 SEC-S04: use this factory instead of `httpx.AsyncClient(
     follow_redirects=True, ...)` for any request handler that fetches
     user-supplied URLs (service probes, STAC adapters, OGC API adapters).
 
-    The response hook _revalidate_redirect intercepts every 3xx hop and
-    re-validates the Location against validate_url_for_ssrf — the same gate
-    that runs at submission time.
+    SEC-008: the client uses _SSRFGuardTransport, which re-resolves and validates
+    the host at connect time and pins the connection to the validated IP — so a
+    DNS-rebinding answer between submission-time validation and connect cannot
+    reach an internal IP. The response hook _revalidate_redirect additionally
+    re-validates each 3xx Location, and the transport re-pins each redirect hop.
     """
     return httpx.AsyncClient(
         timeout=timeout,
         follow_redirects=True,
         max_redirects=5,
         event_hooks={"response": [_revalidate_redirect]},
+        transport=_SSRFGuardTransport(),
     )

--- a/backend/app/modules/embed_tokens/service.py
+++ b/backend/app/modules/embed_tokens/service.py
@@ -316,30 +316,6 @@ async def validate_embed_token_access(
     if str(dataset_id) not in scoped_dataset_ids:
         return False
 
-    # SEC-022: re-check the dataset's CURRENT visibility on every request.
-    # scoped_dataset_ids is a frozen snapshot captured at token-create time; the
-    # dataset may since have been made private/restricted or unpublished. An
-    # embed token grants anonymous access, so mirror the anonymous predicate
-    # every other serving path enforces (can_access_dataset / _resolve_raster_
-    # access / _authorize_vector_tile_request): public AND published only. This
-    # runs on the cache-hit path too — the token-level cache stores only token
-    # metadata, never the dataset's live visibility, and there is no mechanism
-    # to invalidate it when a dataset is unpublished.
-    from app.modules.catalog.datasets.domain.models import Dataset, Record
-
-    visibility_row = (
-        await db.execute(
-            select(Record.visibility, Record.record_status)
-            .join(Dataset, Dataset.record_id == Record.id)
-            .where(Dataset.id == dataset_id)
-        )
-    ).first()
-    if visibility_row is None:
-        return False
-    current_visibility, current_status = visibility_row
-    if current_visibility != "public" or current_status != "published":
-        return False
-
     if token is not None:
         async with db.begin_nested():
             await db.execute(

--- a/backend/app/modules/embed_tokens/service.py
+++ b/backend/app/modules/embed_tokens/service.py
@@ -316,6 +316,30 @@ async def validate_embed_token_access(
     if str(dataset_id) not in scoped_dataset_ids:
         return False
 
+    # SEC-022: re-check the dataset's CURRENT visibility on every request.
+    # scoped_dataset_ids is a frozen snapshot captured at token-create time; the
+    # dataset may since have been made private/restricted or unpublished. An
+    # embed token grants anonymous access, so mirror the anonymous predicate
+    # every other serving path enforces (can_access_dataset / _resolve_raster_
+    # access / _authorize_vector_tile_request): public AND published only. This
+    # runs on the cache-hit path too — the token-level cache stores only token
+    # metadata, never the dataset's live visibility, and there is no mechanism
+    # to invalidate it when a dataset is unpublished.
+    from app.modules.catalog.datasets.domain.models import Dataset, Record
+
+    visibility_row = (
+        await db.execute(
+            select(Record.visibility, Record.record_status)
+            .join(Dataset, Dataset.record_id == Record.id)
+            .where(Dataset.id == dataset_id)
+        )
+    ).first()
+    if visibility_row is None:
+        return False
+    current_visibility, current_status = visibility_row
+    if current_visibility != "public" or current_status != "published":
+        return False
+
     if token is not None:
         async with db.begin_nested():
             await db.execute(

--- a/backend/app/processing/ingest/ogr.py
+++ b/backend/app/processing/ingest/ogr.py
@@ -694,6 +694,14 @@ async def run_ogr2ogr_service(
     # HTTP; GDAL_HTTP_FOLLOWLOCATION=NO is the only way to disable
     # redirect-following in libcurl under GDAL.
     #
+    # SEC-008: unlike the httpx path (make_safe_client pins the validated IP via
+    # _SSRFGuardTransport), libcurl under GDAL resolves DNS itself with no
+    # per-request pin hook, so a connect-time DNS-rebinding TOCTOU between
+    # submission-time validation and this subprocess fetch remains. It is
+    # bounded by GDAL_HTTP_FOLLOWLOCATION=NO (no redirect rebinding) and must be
+    # mitigated operationally (egress firewall / blocking link-local metadata
+    # IPs at the network layer).
+    #
     # IA-P1-06 (Phase 1068): Authorization headers MUST NOT pass through the
     # subprocess env (visible via /proc/<pid>/environ for the lifetime of the
     # process). Switch to GDAL_HTTP_HEADER_FILE pointed at a 0600 tempfile

--- a/backend/app/processing/tiles/router.py
+++ b/backend/app/processing/tiles/router.py
@@ -643,6 +643,10 @@ async def raster_tile_proxy(
         )
 
     render_params = auth_resp.headers.get("X-GeoLens-Render-Params", "")
+    # SEC-002: carry the dataset's public/private cache scope through to the tile
+    # response so private rasters are never stored by a shared cache. Default to
+    # "private" if the header is somehow absent (fail safe).
+    cache_status = auth_resp.headers.get("X-GeoLens-Cache-Status", "private")
 
     # Read band_count from the auth response header (emitted by raster_auth_check).
     # Absent / non-numeric → fall back to 1. Cap at 3 for Titiler RGB rendering.
@@ -778,10 +782,17 @@ async def raster_tile_proxy(
         )
         raise HTTPException(status_code=resp.status_code, detail="Tile fetch failed")
 
+    # SEC-002: private/restricted rasters must never be retained by the shared
+    # nginx cache (its key carries no auth). Emit `no-store` so nginx skips
+    # caching (frontend/nginx.conf honors it); only public datasets are cacheable.
+    if cache_status == "public":
+        cache_control = "public, max-age=3600"
+    else:
+        cache_control = "private, no-store"
     return Response(
         content=resp.content,
         media_type=resp.headers.get("content-type", "image/png"),
-        headers={"Cache-Control": "public, max-age=3600"},
+        headers={"Cache-Control": cache_control},
     )
 
 
@@ -1100,21 +1111,27 @@ async def _authorize_vector_tile_request(
                 status_code=status.HTTP_403_FORBIDDEN,
                 detail="Invalid or expired signature",
             )
-    else:
-        # Public dataset: still block non-published for unauthenticated users
-        if meta.record_status != "published":
-            # Unauthenticated users cannot see unpublished public datasets
-            if user is None:
-                raise HTTPException(
-                    status_code=status.HTTP_404_NOT_FOUND, detail="Dataset not found"
-                )
-            # Authenticated non-owners cannot see unpublished
-            port = get_processing_port()
-            user_roles = await port.get_user_roles(db, user)
-            if "admin" not in user_roles and meta.created_by != user.id:
-                raise HTTPException(
-                    status_code=status.HTTP_404_NOT_FOUND, detail="Dataset not found"
-                )
+        # SEC-009: a valid signature authorizes a single caller for this
+        # non-public dataset; the tile bytes must not be retained by a shared
+        # cache. Return "private" so _tile_headers emits Cache-Control: private
+        # (previously this fell through to "public", letting shared caches store
+        # private vector tiles under an auth-less key).
+        return "private"
+
+    # Public dataset: still block non-published for unauthenticated users
+    if meta.record_status != "published":
+        # Unauthenticated users cannot see unpublished public datasets
+        if user is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND, detail="Dataset not found"
+            )
+        # Authenticated non-owners cannot see unpublished
+        port = get_processing_port()
+        user_roles = await port.get_user_roles(db, user)
+        if "admin" not in user_roles and meta.created_by != user.id:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND, detail="Dataset not found"
+            )
 
     return "public"
 

--- a/backend/app/processing/tiles/router.py
+++ b/backend/app/processing/tiles/router.py
@@ -353,6 +353,19 @@ def _apply_stretch_rescale(render_params: str, rescale_parts: list[str]) -> str:
     return "&".join(kept + rescale_parts)
 
 
+def _is_publicly_cacheable(visibility: str | None, record_status: str | None) -> bool:
+    """Whether a tile may be stored in the shared (auth-less) cache.
+
+    Only datasets that are BOTH public AND published are safe to cache publicly.
+    A public-but-unpublished dataset is an owner/admin-only preview: anonymous
+    callers are rejected, but if its tiles were marked `public` they would
+    populate the auth-less nginx cache key and replay to later anonymous
+    requests (SEC-002; raised as a Codex P1 on PR #243). Non-public datasets are
+    never publicly cacheable.
+    """
+    return visibility == "public" and record_status == "published"
+
+
 async def _resolve_raster_access(
     db: AsyncSession,
     dataset_id: uuid.UUID,
@@ -514,7 +527,11 @@ async def raster_auth_check(
     else:
         open_path = f"{settings.upload_staging_dir}/{asset_uri}"
 
-    cache_status = "public" if row["visibility"] == "public" else "private"
+    cache_status = (
+        "public"
+        if _is_publicly_cacheable(row["visibility"], row["record_status"])
+        else "private"
+    )
     if row.get("is_dem"):
         # DEM terrain: use terrainrgb algorithm with NO rescale — the algorithm
         # reads raw elevation values and encodes them into RGB channels directly.
@@ -1132,6 +1149,10 @@ async def _authorize_vector_tile_request(
             raise HTTPException(
                 status_code=status.HTTP_404_NOT_FOUND, detail="Dataset not found"
             )
+        # Owner/admin previewing an UNPUBLISHED public dataset: authorized, but
+        # the tiles must not enter the shared (auth-less) cache or they would
+        # replay to anonymous callers. (Codex P1 on PR #243.)
+        return "private"
 
     return "public"
 

--- a/backend/app/standards/stac/router.py
+++ b/backend/app/standards/stac/router.py
@@ -16,7 +16,7 @@ from urllib.parse import urlencode
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
 from fastapi.responses import JSONResponse
 from starlette.responses import Response
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
@@ -1165,6 +1165,22 @@ class StacSearchBody(BaseModel):
         ge=0,
         description="Number of items to skip for pagination.",
     )
+
+    @field_validator("intersects")
+    @classmethod
+    def _cap_intersects_size(cls, v: dict | None) -> dict | None:
+        # SEC-023 (sibling of SEC-FU-05): the GET `intersects` query param is
+        # capped at max_length=10000, but the POST body `intersects` dict
+        # bypassed any bound and reached the same anonymous ST_GeomFromGeoJSON
+        # predicate — a multi-megabyte GeoJSON could pin CPU/memory + a DB
+        # connection. Cap the serialized size to match the GET handler.
+        max_serialized = 10000
+        if v is not None and len(json.dumps(v)) > max_serialized:
+            raise ValueError(
+                f"intersects GeoJSON too large (max {max_serialized} "
+                "serialized characters)"
+            )
+        return v
 
 
 @stac_router.post(

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -15516,7 +15516,7 @@
     "summary": "PostGIS-native geospatial data catalog with OGC API Features compliance",
     "termsOfService": "https://github.com/geolens-io/geolens/blob/main/LICENSE",
     "title": "GeoLens API",
-    "version": "1.2.3"
+    "version": "1.2.4"
   },
   "openapi": "3.1.0",
   "paths": {

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geolens-backend"
-version = "1.2.3"
+version = "1.2.4"
 description = "PostGIS-native GIS data catalog"
 # Docker image (Dockerfile) ships python:3.14.3-slim as the project's tested
 # runtime. requires-python>=3.13 is the backward-compat floor for adopters

--- a/backend/scripts/api-entrypoint.sh
+++ b/backend/scripts/api-entrypoint.sh
@@ -63,12 +63,12 @@ echo "Running database migrations..."
 migration_rc=0
 if [ "$(id -u)" -eq 0 ]; then
     setpriv --reuid="${APP_UID}" --regid="${APP_GID}" --clear-groups \
-        uv run --no-dev alembic upgrade head 2>&1 || migration_rc=$?
+        uv run --no-dev alembic upgrade heads 2>&1 || migration_rc=$?
 else
-    uv run --no-dev alembic upgrade head 2>&1 || migration_rc=$?
+    uv run --no-dev alembic upgrade heads 2>&1 || migration_rc=$?
 fi
 if [ "${migration_rc}" -ne 0 ]; then
-    echo "WARNING: alembic upgrade head exited with code ${migration_rc} — migrations may already be applied by the migrate service, or a real error occurred. Check migrate service logs if the API fails to start." >&2
+    echo "WARNING: alembic upgrade heads exited with code ${migration_rc} — migrations may already be applied by the migrate service, or a real error occurred. Check migrate service logs if the API fails to start." >&2
 fi
 
 if [ "$#" -eq 0 ]; then

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -111,6 +111,29 @@ class TestProcrastinateConninfo:
         assert "sslrootcert=/path/to/ca.pem" in conninfo
         assert "sslmode=verify-full" in conninfo
 
+    def test_override_includes_search_path(self):
+        # BUG-002: the override branch previously dropped the search_path
+        # option, so procrastinate could not resolve its unqualified objects on
+        # managed Postgres (DATABASE_URL_OVERRIDE) and the job queue broke. The
+        # override branch must mirror the default branch and pin the catalog
+        # schema. (Fails on main — the override conninfo had no search_path.)
+        s = _make_settings(database_url_override="postgresql://u:p@host:5432/db")
+        conninfo = s.procrastinate_conninfo
+        assert "options='-c search_path=catalog,public'" in conninfo
+
+    def test_override_preserves_caller_options(self):
+        # An operator can still pass extra libpq options via ?options=; our
+        # search_path is appended (and applied last so procrastinate's schema
+        # always wins) rather than discarding the caller's value.
+        s = _make_settings(
+            database_url_override=(
+                "postgresql://u:p@host/db?options=-c%20statement_timeout%3D5000"
+            )
+        )
+        conninfo = s.procrastinate_conninfo
+        assert "statement_timeout=5000" in conninfo
+        assert "search_path=catalog,public" in conninfo
+
 
 class TestOgrConnectionString:
     """Test ogr_connection_string property."""

--- a/backend/tests/test_csp_sec020.py
+++ b/backend/tests/test_csp_sec020.py
@@ -1,0 +1,56 @@
+"""Regression tests for SEC-020: a real Content-Security-Policy backstops the
+JWT-in-localStorage exfil risk if a future XSS lands.
+
+On main the only CSP was `frame-ancestors 'self'` (no script-src/default-src), so
+an injected or inline script could run unrestricted and exfiltrate the access +
+refresh tokens from the geolens-auth localStorage key. These assert the SPA HTML
+now ships a script-src/default-src CSP and that the FOUC script is externalized
+(so no inline <script> exists for script-src 'self' to block). Fail on main.
+
+The CSP was verified live against the production build: the app, login, and the
+MapLibre map builder (external basemap tiles, web workers, inline styles) all
+render with zero CSP violations.
+"""
+
+import re
+
+from tests.repo_paths import repo_root
+
+ROOT = repo_root(__file__)
+NGINX_CONF = ROOT / "frontend" / "nginx.conf"
+INDEX_HTML = ROOT / "frontend" / "index.html"
+THEME_INIT = ROOT / "frontend" / "public" / "theme-init.js"
+
+_CSP_RE = re.compile(r'Content-Security-Policy\s+"([^"]+)"')
+
+
+def test_csp_has_script_and_default_src():
+    csps = _CSP_RE.findall(NGINX_CONF.read_text())
+    assert csps, (
+        "nginx.conf must set a Content-Security-Policy on HTML responses (SEC-020)"
+    )
+    for csp in csps:
+        assert "default-src 'self'" in csp, f"CSP missing default-src 'self': {csp}"
+        assert "script-src 'self'" in csp, f"CSP missing script-src 'self': {csp}"
+        assert "object-src 'none'" in csp, f"CSP missing object-src 'none': {csp}"
+        assert "base-uri 'self'" in csp, f"CSP missing base-uri 'self': {csp}"
+
+
+def test_main_app_csp_has_frame_ancestors():
+    # The main `location /` CSP must include frame-ancestors 'self'; the /m/ embed
+    # variant intentionally omits it so per-token cross-origin framing still works.
+    csps = _CSP_RE.findall(NGINX_CONF.read_text())
+    assert any("frame-ancestors 'self'" in c for c in csps), (
+        "the main-app CSP must include frame-ancestors 'self' (SEC-020)"
+    )
+
+
+def test_fouc_script_externalized():
+    html = INDEX_HTML.read_text()
+    # The FOUC logic must be referenced as an external file (script-src 'self'),
+    # and there must be no inline <script> body for the CSP to block.
+    assert "/theme-init.js" in html, "index.html must load /theme-init.js (SEC-020)"
+    assert not re.search(r"<script>\s*\S", html), (
+        "index.html must not contain an inline <script> block (SEC-020 / script-src 'self')"
+    )
+    assert THEME_INIT.exists(), "frontend/public/theme-init.js must exist"

--- a/backend/tests/test_embed_tokens.py
+++ b/backend/tests/test_embed_tokens.py
@@ -24,15 +24,11 @@ from httpx import AsyncClient
 from sqlalchemy import select, text, update
 
 from app.core.config import settings
-from app.modules.catalog.datasets.domain.models import Dataset, Record
+from app.modules.catalog.datasets.domain.models import Dataset
 from app.modules.catalog.maps.models import Map, MapLayer
 from app.modules.embed_tokens.models import EmbedToken
 from app.modules.embed_tokens.schemas import ADVANCED_SHARING_ERROR
-from app.modules.embed_tokens.service import (
-    create_embed_token,
-    update_embed_token,
-    validate_embed_token_access,
-)
+from app.modules.embed_tokens.service import create_embed_token, update_embed_token
 from app.platform.cache.provider import get_cache
 
 from tests.conftest import _run_with_too_many_clients_retry
@@ -1437,107 +1433,3 @@ class TestUpdateEmbedToken:
             assert tile_resp_new.status_code in (200, 204)
         finally:
             await _cleanup_data_table(test_db_session, table_name)
-
-
-class TestEmbedTokenVisibilityReauth:
-    """SEC-022: embed token must re-check the dataset's LIVE visibility on every
-    request, not trust the frozen scoped_dataset_ids snapshot from create time."""
-
-    async def _public_published_dataset(self, session, *, created_by) -> Dataset:
-        dataset = await _create_private_dataset(session, created_by=created_by)
-        # Promote to the precondition for a legitimate anonymous embed.
-        await session.execute(
-            update(Record)
-            .where(Record.id == dataset.record_id)
-            .values(visibility="public", record_status="published")
-        )
-        await session.commit()
-        return dataset
-
-    async def test_access_denied_after_dataset_made_private(
-        self, client: AsyncClient, admin_auth_header: dict, test_db_session
-    ):
-        """Token minted over a public+published dataset is denied once the
-        dataset is later made private. Fails on main (frozen snapshot trusted)."""
-        user_id = await get_user_id(test_db_session, settings.geolens_admin_username)
-        dataset = await self._public_published_dataset(
-            test_db_session, created_by=user_id
-        )
-        map_obj, _ = await _create_map_with_layer(
-            test_db_session, client, admin_auth_header, dataset, created_by=user_id
-        )
-        resp = await client.post(
-            f"/maps/{map_obj.id}/embed-tokens/",
-            json={"name": "SEC-022"},
-            headers=admin_auth_header,
-        )
-        assert resp.status_code == 201, resp.text
-        raw_token = resp.json()["raw_token"]
-        token_hash = hashlib.sha256(raw_token.encode()).hexdigest()
-        cache = get_cache()
-
-        # Baseline: granted while the dataset is public+published.
-        await cache.delete(f"embed_token:{token_hash}")
-        assert (
-            await validate_embed_token_access(raw_token, dataset.id, test_db_session)
-            is True
-        )
-
-        # Owner makes the dataset private AFTER the token was minted.
-        await test_db_session.execute(
-            update(Record)
-            .where(Record.id == dataset.record_id)
-            .values(visibility="private")
-        )
-        await test_db_session.commit()
-
-        # Re-read from DB (token still active+unexpired, dataset still in scope).
-        await cache.delete(f"embed_token:{token_hash}")
-        assert (
-            await validate_embed_token_access(raw_token, dataset.id, test_db_session)
-            is False
-        ), "SEC-022: embed access must be revoked after the dataset is made private"
-
-    async def test_access_denied_on_cache_hit_after_unpublish(
-        self, client: AsyncClient, admin_auth_header: dict, test_db_session
-    ):
-        """The re-check must run even on the positive-cache-hit path (the token
-        cache stores only token metadata, never live dataset visibility)."""
-        user_id = await get_user_id(test_db_session, settings.geolens_admin_username)
-        dataset = await self._public_published_dataset(
-            test_db_session, created_by=user_id
-        )
-        map_obj, _ = await _create_map_with_layer(
-            test_db_session, client, admin_auth_header, dataset, created_by=user_id
-        )
-        resp = await client.post(
-            f"/maps/{map_obj.id}/embed-tokens/",
-            json={"name": "SEC-022-cache"},
-            headers=admin_auth_header,
-        )
-        assert resp.status_code == 201, resp.text
-        raw_token = resp.json()["raw_token"]
-        cache = get_cache()
-        token_hash = hashlib.sha256(raw_token.encode()).hexdigest()
-
-        # Prime the positive cache.
-        await cache.delete(f"embed_token:{token_hash}")
-        assert (
-            await validate_embed_token_access(raw_token, dataset.id, test_db_session)
-            is True
-        )
-
-        # Unpublish the dataset; deliberately do NOT clear the cache.
-        await test_db_session.execute(
-            update(Record)
-            .where(Record.id == dataset.record_id)
-            .values(record_status="draft")
-        )
-        await test_db_session.commit()
-
-        # On main the cache-hit path returns True without re-checking; the fix
-        # re-queries live visibility/status and denies.
-        assert (
-            await validate_embed_token_access(raw_token, dataset.id, test_db_session)
-            is False
-        ), "SEC-022: cache-hit path must still re-check live dataset visibility"

--- a/backend/tests/test_embed_tokens.py
+++ b/backend/tests/test_embed_tokens.py
@@ -24,11 +24,15 @@ from httpx import AsyncClient
 from sqlalchemy import select, text, update
 
 from app.core.config import settings
-from app.modules.catalog.datasets.domain.models import Dataset
+from app.modules.catalog.datasets.domain.models import Dataset, Record
 from app.modules.catalog.maps.models import Map, MapLayer
 from app.modules.embed_tokens.models import EmbedToken
 from app.modules.embed_tokens.schemas import ADVANCED_SHARING_ERROR
-from app.modules.embed_tokens.service import create_embed_token, update_embed_token
+from app.modules.embed_tokens.service import (
+    create_embed_token,
+    update_embed_token,
+    validate_embed_token_access,
+)
 from app.platform.cache.provider import get_cache
 
 from tests.conftest import _run_with_too_many_clients_retry
@@ -1433,3 +1437,107 @@ class TestUpdateEmbedToken:
             assert tile_resp_new.status_code in (200, 204)
         finally:
             await _cleanup_data_table(test_db_session, table_name)
+
+
+class TestEmbedTokenVisibilityReauth:
+    """SEC-022: embed token must re-check the dataset's LIVE visibility on every
+    request, not trust the frozen scoped_dataset_ids snapshot from create time."""
+
+    async def _public_published_dataset(self, session, *, created_by) -> Dataset:
+        dataset = await _create_private_dataset(session, created_by=created_by)
+        # Promote to the precondition for a legitimate anonymous embed.
+        await session.execute(
+            update(Record)
+            .where(Record.id == dataset.record_id)
+            .values(visibility="public", record_status="published")
+        )
+        await session.commit()
+        return dataset
+
+    async def test_access_denied_after_dataset_made_private(
+        self, client: AsyncClient, admin_auth_header: dict, test_db_session
+    ):
+        """Token minted over a public+published dataset is denied once the
+        dataset is later made private. Fails on main (frozen snapshot trusted)."""
+        user_id = await get_user_id(test_db_session, settings.geolens_admin_username)
+        dataset = await self._public_published_dataset(
+            test_db_session, created_by=user_id
+        )
+        map_obj, _ = await _create_map_with_layer(
+            test_db_session, client, admin_auth_header, dataset, created_by=user_id
+        )
+        resp = await client.post(
+            f"/maps/{map_obj.id}/embed-tokens/",
+            json={"name": "SEC-022"},
+            headers=admin_auth_header,
+        )
+        assert resp.status_code == 201, resp.text
+        raw_token = resp.json()["raw_token"]
+        token_hash = hashlib.sha256(raw_token.encode()).hexdigest()
+        cache = get_cache()
+
+        # Baseline: granted while the dataset is public+published.
+        await cache.delete(f"embed_token:{token_hash}")
+        assert (
+            await validate_embed_token_access(raw_token, dataset.id, test_db_session)
+            is True
+        )
+
+        # Owner makes the dataset private AFTER the token was minted.
+        await test_db_session.execute(
+            update(Record)
+            .where(Record.id == dataset.record_id)
+            .values(visibility="private")
+        )
+        await test_db_session.commit()
+
+        # Re-read from DB (token still active+unexpired, dataset still in scope).
+        await cache.delete(f"embed_token:{token_hash}")
+        assert (
+            await validate_embed_token_access(raw_token, dataset.id, test_db_session)
+            is False
+        ), "SEC-022: embed access must be revoked after the dataset is made private"
+
+    async def test_access_denied_on_cache_hit_after_unpublish(
+        self, client: AsyncClient, admin_auth_header: dict, test_db_session
+    ):
+        """The re-check must run even on the positive-cache-hit path (the token
+        cache stores only token metadata, never live dataset visibility)."""
+        user_id = await get_user_id(test_db_session, settings.geolens_admin_username)
+        dataset = await self._public_published_dataset(
+            test_db_session, created_by=user_id
+        )
+        map_obj, _ = await _create_map_with_layer(
+            test_db_session, client, admin_auth_header, dataset, created_by=user_id
+        )
+        resp = await client.post(
+            f"/maps/{map_obj.id}/embed-tokens/",
+            json={"name": "SEC-022-cache"},
+            headers=admin_auth_header,
+        )
+        assert resp.status_code == 201, resp.text
+        raw_token = resp.json()["raw_token"]
+        cache = get_cache()
+        token_hash = hashlib.sha256(raw_token.encode()).hexdigest()
+
+        # Prime the positive cache.
+        await cache.delete(f"embed_token:{token_hash}")
+        assert (
+            await validate_embed_token_access(raw_token, dataset.id, test_db_session)
+            is True
+        )
+
+        # Unpublish the dataset; deliberately do NOT clear the cache.
+        await test_db_session.execute(
+            update(Record)
+            .where(Record.id == dataset.record_id)
+            .values(record_status="draft")
+        )
+        await test_db_session.commit()
+
+        # On main the cache-hit path returns True without re-checking; the fix
+        # re-queries live visibility/status and denies.
+        assert (
+            await validate_embed_token_access(raw_token, dataset.id, test_db_session)
+            is False
+        ), "SEC-022: cache-hit path must still re-check live dataset visibility"

--- a/backend/tests/test_environment_posture_sec005.py
+++ b/backend/tests/test_environment_posture_sec005.py
@@ -1,0 +1,84 @@
+"""SEC-005: the deployment security posture (API docs exposure + Secure session
+cookie) is driven by the explicit ENVIRONMENT setting, decoupled from the
+LOG_JSON log-format flag.
+
+On main these behaviors were keyed directly off settings.log_json, so a
+production deploy that left LOG_JSON at its default served /docs publicly and
+emitted the OAuth session cookie without Secure, while a dev shipping JSON logs
+over HTTP had its cookie silently stripped.
+
+Settings() re-reads the environment at instantiation, so monkeypatching env vars
+and constructing a fresh cfg.Settings() exercises the property without reloading
+app.core.config (which would replace the singleton conftest points at the test
+DB). See test_phase_273_session_https_only.py for the same pattern.
+
+Every test here fails on main: Settings had no `is_production` property
+(AttributeError), and the decoupling assertions contradict the old log_json
+coupling.
+"""
+
+import pytest
+
+
+def _settings(monkeypatch, *, environment=None, log_json=None):
+    if environment is None:
+        monkeypatch.delenv("ENVIRONMENT", raising=False)
+    else:
+        monkeypatch.setenv("ENVIRONMENT", environment)
+    if log_json is None:
+        monkeypatch.delenv("LOG_JSON", raising=False)
+    else:
+        monkeypatch.setenv("LOG_JSON", "true" if log_json else "false")
+    from app.core import config as cfg
+
+    return cfg.Settings()
+
+
+def test_explicit_production_sets_posture_even_without_log_json(monkeypatch):
+    """ENVIRONMENT=production hardens the posture even when LOG_JSON is false —
+    the exact case that left /docs open and the cookie insecure on main."""
+    s = _settings(monkeypatch, environment="production", log_json=False)
+    assert s.log_json is False
+    assert s.is_production is True
+
+
+def test_explicit_development_overrides_log_json(monkeypatch):
+    """The decoupling: a dev/CI cluster shipping JSON logs no longer inherits
+    the production posture (https_only=True over HTTP would strip the cookie)."""
+    s = _settings(monkeypatch, environment="development", log_json=True)
+    assert s.log_json is True
+    assert s.is_production is False
+
+
+def test_backward_compat_log_json_without_environment(monkeypatch):
+    """Unset ENVIRONMENT + LOG_JSON=true keeps the hardened posture existing
+    deployments relied on — no silent downgrade."""
+    s = _settings(monkeypatch, environment=None, log_json=True)
+    assert s.environment is None
+    assert s.is_production is True
+
+
+def test_default_dev_posture(monkeypatch):
+    s = _settings(monkeypatch, environment=None, log_json=False)
+    assert s.is_production is False
+
+
+def test_docs_gating_follows_is_production(monkeypatch):
+    """The FastAPI docs_url expression in main.py keys off is_production."""
+    prod = _settings(monkeypatch, environment="production", log_json=False)
+    dev = _settings(monkeypatch, environment="development", log_json=True)
+    assert (None if prod.is_production else "/docs") is None
+    assert (None if dev.is_production else "/docs") == "/docs"
+
+
+def test_invalid_environment_rejected(monkeypatch):
+    """ENVIRONMENT is a Literal — typos fail fast instead of silently mapping to
+    a posture."""
+    from pydantic import ValidationError
+
+    from app.core import config as cfg
+
+    monkeypatch.setenv("ENVIRONMENT", "staging")
+    monkeypatch.delenv("LOG_JSON", raising=False)
+    with pytest.raises(ValidationError):
+        cfg.Settings()

--- a/backend/tests/test_maps_visibility_check_authz_sec007.py
+++ b/backend/tests/test_maps_visibility_check_authz_sec007.py
@@ -1,0 +1,82 @@
+"""Regression tests for SEC-007: /maps/{id}/visibility-check/ authorization.
+
+The endpoint loaded the map and checked existence but never called
+`_check_map_read_access`, so any editor (the `edit_metadata` permission) could
+enumerate the non-public dataset names of ANY map by UUID — including PRIVATE
+maps owned by other users they cannot read. The fix gates on read access to the
+map before disclosing its non-public datasets.
+
+The ATTACK test fails on main (a non-owner editor gets 200); the owner/admin
+GUARD tests pass before and after.
+
+Requirements:
+  - Docker database must be running (docker compose up db)
+  - Alembic migrations must be applied
+"""
+
+import pytest
+from httpx import AsyncClient
+
+from .conftest import _create_test_user
+
+
+async def _create_private_map(
+    client: AsyncClient, headers: dict, name: str = "Owner private map"
+) -> str:
+    resp = await client.post("/maps/", json={"name": name}, headers=headers)
+    assert resp.status_code == 201, f"create map failed: {resp.text}"
+    body = resp.json()
+    assert body["visibility"] == "private"
+    return body["id"]
+
+
+@pytest.mark.anyio
+async def test_visibility_check_rejects_non_owner_editor(
+    client: AsyncClient, admin_auth_header: dict
+):
+    """ATTACK: a non-owner editor cannot read another user's private map's
+    visibility-check. Fails on main (200)."""
+    owner_headers, _ = await _create_test_user(client, admin_auth_header, "editor")
+    attacker_headers, _ = await _create_test_user(client, admin_auth_header, "editor")
+    map_id = await _create_private_map(client, owner_headers)
+
+    resp = await client.get(
+        f"/maps/{map_id}/visibility-check/", headers=attacker_headers
+    )
+
+    assert resp.status_code == 404, (
+        f"a non-owner editor read another user's PRIVATE map visibility-check, "
+        f"got {resp.status_code}: {resp.text}"
+    )
+
+
+@pytest.mark.anyio
+async def test_visibility_check_allows_owner(
+    client: AsyncClient, admin_auth_header: dict
+):
+    """GUARD: the owner reads their OWN map's visibility-check (200)."""
+    owner_headers, _ = await _create_test_user(client, admin_auth_header, "editor")
+    map_id = await _create_private_map(client, owner_headers)
+
+    resp = await client.get(f"/maps/{map_id}/visibility-check/", headers=owner_headers)
+
+    assert resp.status_code == 200, (
+        f"owner blocked from their OWN map visibility-check, got "
+        f"{resp.status_code}: {resp.text}"
+    )
+    assert "has_non_public" in resp.json()
+
+
+@pytest.mark.anyio
+async def test_visibility_check_allows_admin(
+    client: AsyncClient, admin_auth_header: dict
+):
+    """GUARD: admin reads any map's visibility-check (200)."""
+    owner_headers, _ = await _create_test_user(client, admin_auth_header, "editor")
+    map_id = await _create_private_map(client, owner_headers)
+
+    resp = await client.get(
+        f"/maps/{map_id}/visibility-check/", headers=admin_auth_header
+    )
+
+    assert resp.status_code == 200

--- a/backend/tests/test_migration_discovery.py
+++ b/backend/tests/test_migration_discovery.py
@@ -8,8 +8,11 @@ the algorithm independently.
 from __future__ import annotations
 
 import pathlib
+import re
 from importlib.metadata import entry_points as iter_entry_points
 from unittest.mock import MagicMock, patch
+
+import pytest
 
 
 def _discover_migration_paths() -> list[str]:
@@ -81,3 +84,45 @@ def test_discover_migration_paths_handles_failure():
         result = _discover_migration_paths()
 
     assert result == []
+
+
+# Repo root: backend/tests/test_migration_discovery.py -> parents[2] == repo root.
+_REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+
+# Files that invoke `alembic upgrade`. With the enterprise overlay installed the
+# revision graph forks into two heads (core 0003 + enterprise e002), so a bare
+# `alembic upgrade head` raises "Multiple head revisions are present" and the
+# stack never boots. Every invocation must use `heads` (plural). See BUG-001.
+_MIGRATION_INVOCATION_FILES = (
+    "docker-compose.yml",
+    "docker-compose.prod.yml",
+    "Makefile",
+    "backend/scripts/api-entrypoint.sh",
+)
+
+# Matches `alembic upgrade head` NOT followed by `s` — i.e. the buggy singular.
+_BARE_HEAD_RE = re.compile(r"alembic upgrade head(?!s)")
+
+
+def test_migration_invocations_use_heads_plural():
+    """Every `alembic upgrade` site uses `heads`, never bare `head` (BUG-001).
+
+    Bare `head` is ambiguous once the enterprise overlay adds a second head and
+    aborts the migrate one-shot, so api/worker never start. Robust in-container:
+    skips files that aren't present rather than failing on the missing tree.
+    """
+    checked = []
+    for rel in _MIGRATION_INVOCATION_FILES:
+        path = _REPO_ROOT / rel
+        if not path.is_file():
+            continue
+        text = path.read_text()
+        offenders = _BARE_HEAD_RE.findall(text)
+        assert not offenders, (
+            f"{rel} invokes `alembic upgrade head` (singular); use `heads` so the "
+            f"enterprise two-head graph upgrades both branches (BUG-001)."
+        )
+        checked.append(rel)
+
+    if not checked:
+        pytest.skip("migration invocation files not present (e.g. in-container run)")

--- a/backend/tests/test_nginx_apikey_log_scrub_sec006.py
+++ b/backend/tests/test_nginx_apikey_log_scrub_sec006.py
@@ -1,0 +1,41 @@
+"""Regression test for SEC-006: nginx must scrub the api_key query-param
+credential from its access log.
+
+The ?api_key=<secret> fallback is a documented auth path (header > query > JWT >
+anon). nginx logs the full request line ($request) by default, so on main —
+where frontend/nginx.conf defined no scrubbing log_format — these long-lived,
+non-expiring keys were persisted verbatim in the access log and any downstream
+aggregation. These tests fail on main (no scrubbing map / no custom log_format).
+"""
+
+import re
+
+from tests.repo_paths import repo_root
+
+NGINX_CONF = repo_root(__file__) / "frontend" / "nginx.conf"
+
+
+def test_nginx_defines_api_key_scrubbing_map():
+    text = NGINX_CONF.read_text()
+    # A `map $request $... { }` block redacts the api_key value from the logged
+    # request line. Verified behaviorally to emit `api_key=REDACTED`.
+    assert re.search(r"map\s+\$request\s+\$\w+\s*\{", text), (
+        "expected a `map $request $... {` block scrubbing api_key (SEC-006)"
+    )
+    assert "api_key=REDACTED" in text, (
+        "frontend/nginx.conf must redact the api_key value from the access log "
+        "(SEC-006)"
+    )
+
+
+def test_nginx_wires_scrubbed_log_format_to_access_log():
+    text = NGINX_CONF.read_text()
+    # The scrubbed log_format must actually be referenced by an access_log
+    # directive, otherwise the default $request (carrying the secret) is logged.
+    m = re.search(r"log_format\s+(\w+)\s", text)
+    assert m, "expected a custom log_format for api_key scrubbing (SEC-006)"
+    fmt_name = m.group(1)
+    assert re.search(rf"access_log\s+\S+\s+{re.escape(fmt_name)}\s*;", text), (
+        f"the scrubbed log_format '{fmt_name}' must be wired to an access_log "
+        f"directive (SEC-006)"
+    )

--- a/backend/tests/test_persistent_config.py
+++ b/backend/tests/test_persistent_config.py
@@ -34,6 +34,13 @@ async def _clean_settings(client: AsyncClient):
     except RuntimeError:
         pass
 
+    # BUG-008: the per-process sync rate-limit cache is now warmed on
+    # set()/reset(); clear it between tests so a warmed value never leaks into
+    # an unrelated case.
+    from app.core.persistent_config import _sync_rate_limit_cache
+
+    _sync_rate_limit_cache.clear()
+
 
 # ---------------------------------------------------------------------------
 # Unit / Integration tests for PersistentConfig class
@@ -273,6 +280,41 @@ async def test_sync_rate_limit_accessor(client: AsyncClient):
         # Sync accessor should return same value
         sync_val = get_cached_login_rate_limit()
         assert sync_val == val
+
+
+@pytest.mark.anyio
+async def test_set_warms_sync_cache_with_new_value(client: AsyncClient):
+    """BUG-008: set() must warm the sync rate-limit cache with the NEW value.
+
+    On main, set() warmed the sync cache only with the OLD value (via the
+    get(db) at the top of set()) and never the new one, so slowapi kept
+    enforcing the previous limit until the 30s TTL expired — and because no
+    request-path code ever calls .get() for these keys, the admin's new value
+    was effectively never applied in this process. This test fails on main (the
+    accessor still returns the old default right after set()).
+    """
+    from app.core.persistent_config import (
+        _DEFAULT_LOGIN_RATE_LIMIT,
+        _sync_rate_limit_cache,
+        LOGIN_RATE_LIMIT,
+        get_cached_login_rate_limit,
+    )
+
+    from app.api.main import app
+    from app.core.dependencies import get_db
+
+    _sync_rate_limit_cache.pop("login_rate_limit", None)
+    new_value = _DEFAULT_LOGIN_RATE_LIMIT + 7
+
+    async for db in app.dependency_overrides[get_db]():
+        await LOGIN_RATE_LIMIT.set(db, new_value)
+        # Immediately (well within the TTL) the slowapi accessor must observe
+        # the value just set, not the old default.
+        assert get_cached_login_rate_limit() == new_value
+
+        # reset() must warm the sync cache back to env_default.
+        await LOGIN_RATE_LIMIT.reset(db)
+        assert get_cached_login_rate_limit() == _DEFAULT_LOGIN_RATE_LIMIT
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_phase_273_startup_warnings.py
+++ b/backend/tests/test_phase_273_startup_warnings.py
@@ -17,10 +17,10 @@ from unittest.mock import MagicMock
 
 
 def test_cors_warning_fires_in_production_with_empty_cors():
-    """log_json=True + cors_allowed_origins='' → cors_allowed_origins_unset warning."""
+    """is_production=True + cors_allowed_origins='' → cors_allowed_origins_unset warning."""
     from app.api import main as main_module
 
-    fake_settings = SimpleNamespace(log_json=True, cors_allowed_origins="")
+    fake_settings = SimpleNamespace(is_production=True, cors_allowed_origins="")
     fake_logger = MagicMock()
 
     main_module._warn_if_cors_unset(fake_settings, fake_logger)
@@ -31,7 +31,7 @@ def test_cors_warning_fires_in_production_with_empty_cors():
     fake_logger.warning.assert_called_once_with(
         "cors_allowed_origins_unset",
         message=(
-            "CORS_ALLOWED_ORIGINS is empty in production (LOG_JSON=true). "
+            "CORS_ALLOWED_ORIGINS is empty in production. "
             "All origins will pass the request-origin check; this is "
             "likely a misconfiguration. Set "
             "CORS_ALLOWED_ORIGINS=<comma-separated origins> to restrict."
@@ -40,10 +40,10 @@ def test_cors_warning_fires_in_production_with_empty_cors():
 
 
 def test_cors_warning_silent_in_dev():
-    """log_json=False (dev) → no CORS warning fires regardless of value."""
+    """is_production=False (dev) → no CORS warning fires regardless of value."""
     from app.api import main as main_module
 
-    fake_settings = SimpleNamespace(log_json=False, cors_allowed_origins="")
+    fake_settings = SimpleNamespace(is_production=False, cors_allowed_origins="")
     fake_logger = MagicMock()
 
     main_module._warn_if_cors_unset(fake_settings, fake_logger)
@@ -54,11 +54,11 @@ def test_cors_warning_silent_in_dev():
 
 
 def test_cors_warning_silent_with_origins_configured():
-    """log_json=True + cors_allowed_origins='https://app.example.com' → no warning."""
+    """is_production=True + cors_allowed_origins='https://app.example.com' → no warning."""
     from app.api import main as main_module
 
     fake_settings = SimpleNamespace(
-        log_json=True, cors_allowed_origins="https://app.example.com"
+        is_production=True, cors_allowed_origins="https://app.example.com"
     )
     fake_logger = MagicMock()
 

--- a/backend/tests/test_preview_token_sec021.py
+++ b/backend/tests/test_preview_token_sec021.py
@@ -1,0 +1,113 @@
+"""Regression tests for SEC-021: service-preview GDAL bearer-token handling.
+
+run_service_preview passed the auth token verbatim into GDAL_HTTP_HEADERS (the
+subprocess env), leaking the bearer via /proc/<pid>/environ and allowing CRLF
+header injection through the libcurl pipeline — the exact issue the ogr2ogr
+commit path already fixed (SEC-FU-04 / IA-P1-06). This mirrors that fix: a
+base64url-sanitized token written to a 0600 GDAL_HTTP_HEADER_FILE, plus an
+API-boundary field validator that rejects control/whitespace tokens.
+"""
+
+import json
+import os
+import stat
+
+import pytest
+from pydantic import ValidationError
+
+from app.modules.catalog.sources.schemas import ProbeRequest, ServicePreviewRequest
+
+
+def _base_kwargs(model) -> dict:
+    """Minimal VALID fields per model (everything except the token under test),
+    so a ValidationError can only originate from the token validator."""
+    if model is ServicePreviewRequest:
+        return {
+            "url": "https://example.com/wfs",
+            "service_type": "WFS 2.0.0",
+            "layer_name": "layer",
+        }
+    return {"url": "https://example.com/wfs"}
+
+
+@pytest.mark.parametrize("model", [ProbeRequest, ServicePreviewRequest])
+def test_token_with_crlf_rejected(model):
+    """A CRLF-bearing token (the header-injection payload) is rejected at the
+    schema boundary. Fails on main — no token validator existed, so a valid
+    request with a CRLF token was accepted."""
+    with pytest.raises(ValidationError):
+        model(**_base_kwargs(model), token="abc\r\nX-Injected: evil")
+
+
+@pytest.mark.parametrize("model", [ProbeRequest, ServicePreviewRequest])
+def test_token_with_control_char_rejected(model):
+    with pytest.raises(ValidationError):
+        model(**_base_kwargs(model), token="abc\x00def")
+
+
+@pytest.mark.parametrize("model", [ProbeRequest, ServicePreviewRequest])
+def test_normal_token_accepted(model):
+    m = model(**_base_kwargs(model), token="eyJhbGciOi.JIUzI1NiIs.in9-_=")
+    assert m.token == "eyJhbGciOi.JIUzI1NiIs.in9-_="
+
+
+@pytest.mark.parametrize("model", [ProbeRequest, ServicePreviewRequest])
+def test_none_token_accepted(model):
+    m = model(**_base_kwargs(model), token=None)
+    assert m.token is None
+
+
+@pytest.mark.anyio
+async def test_preview_passes_bearer_via_header_file_not_env(monkeypatch, client):
+    """The WFS/OAPIF bearer must travel through a 0600 GDAL_HTTP_HEADER_FILE,
+    never GDAL_HTTP_HEADERS (env). Fails on main (token placed in env)."""
+    import asyncio as aio
+
+    from app.modules.catalog.sources import preview as preview_mod
+
+    captured: dict = {}
+
+    class _FakeProc:
+        returncode = 0
+
+        async def communicate(self):
+            return (
+                json.dumps(
+                    {
+                        "layers": [
+                            {
+                                "name": "l",
+                                "fields": [],
+                                "features": [],
+                                "geometryFields": [],
+                            }
+                        ]
+                    }
+                ).encode(),
+                b"",
+            )
+
+    async def _fake_exec(*cmd, **kwargs):
+        env = kwargs.get("env") or {}
+        captured["env"] = dict(env)
+        hf = env.get("GDAL_HTTP_HEADER_FILE")
+        if hf and os.path.exists(hf):
+            captured["mode"] = stat.S_IMODE(os.stat(hf).st_mode)
+            with open(hf) as f:
+                captured["content"] = f.read()
+        return _FakeProc()
+
+    monkeypatch.setattr(aio, "create_subprocess_exec", _fake_exec)
+
+    token = "averylongbearertoken1234567890"
+    await preview_mod.run_service_preview(
+        "WFS:https://example.com/wfs", "layer", token=token
+    )
+
+    env = captured["env"]
+    assert "GDAL_HTTP_HEADERS" not in env, (
+        "SEC-021: bearer token must not be passed via the GDAL_HTTP_HEADERS env var"
+    )
+    assert "GDAL_HTTP_HEADER_FILE" in env, "expected the 0600 header-file pattern"
+    assert captured.get("mode") == 0o600
+    assert f"Authorization: Bearer {token}" in captured.get("content", "")

--- a/backend/tests/test_records_authz_sec001.py
+++ b/backend/tests/test_records_authz_sec001.py
@@ -1,0 +1,179 @@
+"""DB-backed regression tests for record sub-resource read authorization (SEC-001).
+
+SEC-001 (HIGH; public-repo Critical): the three `GET /records/{id}/{contacts,
+keywords,distributions}` endpoints gated read access only on `user is None`, so
+ANY authenticated user — including the lowest-privilege viewer — could read any
+PRIVATE record's contact PII (name/email/phone/organization), keywords, and
+distribution URLs by record UUID. The fix delegates to the dataset's per-dataset
+RBAC (`check_dataset_access_or_anonymous`), mirroring the dataset read endpoints.
+
+The ATTACK tests fail on main (a non-owner viewer gets 200 + the seeded PII); the
+anonymous CONTROL and the owner/admin/public GUARD tests pass before and after.
+
+Requirements:
+  - Docker database must be running (docker compose up db)
+  - Alembic migrations must be applied
+"""
+
+import uuid
+
+import pytest
+from httpx import AsyncClient
+
+from app.modules.catalog.datasets.domain.models import RecordContact
+from tests.factories import create_dataset
+
+from .conftest import _create_test_user
+
+_SUBRESOURCES = ["contacts", "keywords", "distributions"]
+_LEAK_EMAIL = "jane.private@internal.example"
+
+
+async def _seed_contact(session, record_id: uuid.UUID) -> None:
+    session.add(
+        RecordContact(
+            record_id=record_id,
+            role="owner",
+            name="Jane Confidential",
+            email=_LEAK_EMAIL,
+            phone="+1-555-0100",
+            organization="Internal Only Org",
+        )
+    )
+    await session.flush()
+
+
+async def _private_record(test_db_session, owner_id: str) -> uuid.UUID:
+    ds = await create_dataset(
+        test_db_session,
+        created_by=uuid.UUID(owner_id),
+        name="Owner private dataset",
+        visibility="private",
+        record_status="draft",
+    )
+    return ds.record_id
+
+
+# ---------------------------------------------------------------------------
+# ATTACK — a non-owner authenticated user cannot read a private record
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("sub", _SUBRESOURCES)
+async def test_private_record_subresource_rejects_non_owner(
+    client: AsyncClient, admin_auth_header: dict, test_db_session, sub: str
+):
+    """A `viewer` who is not the owner is denied (404). Fails on main (200)."""
+    _owner_headers, owner_id = await _create_test_user(
+        client, admin_auth_header, "editor"
+    )
+    attacker_headers, _ = await _create_test_user(client, admin_auth_header, "viewer")
+    record_id = await _private_record(test_db_session, owner_id)
+    await _seed_contact(test_db_session, record_id)
+
+    resp = await client.get(f"/records/{record_id}/{sub}/", headers=attacker_headers)
+
+    assert resp.status_code == 404, (
+        f"{sub}: a non-owner viewer read another user's PRIVATE record, got "
+        f"{resp.status_code}: {resp.text}"
+    )
+    assert _LEAK_EMAIL not in resp.text
+
+
+@pytest.mark.anyio
+async def test_private_record_contacts_does_not_leak_pii(
+    client: AsyncClient, admin_auth_header: dict, test_db_session
+):
+    """Concrete PII-leak guard: the seeded contact email never reaches a
+    non-owner. Mirrors the live SEC-001 reproduction."""
+    _owner_headers, owner_id = await _create_test_user(
+        client, admin_auth_header, "editor"
+    )
+    attacker_headers, _ = await _create_test_user(client, admin_auth_header, "viewer")
+    record_id = await _private_record(test_db_session, owner_id)
+    await _seed_contact(test_db_session, record_id)
+
+    resp = await client.get(f"/records/{record_id}/contacts/", headers=attacker_headers)
+
+    assert resp.status_code == 404
+    assert _LEAK_EMAIL not in resp.text
+    assert "Internal Only Org" not in resp.text
+
+
+# ---------------------------------------------------------------------------
+# CONTROL + GUARDs — anon stays denied; owner/admin/public stay allowed
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("sub", _SUBRESOURCES)
+async def test_private_record_subresource_rejects_anonymous(
+    client: AsyncClient, admin_auth_header: dict, test_db_session, sub: str
+):
+    """CONTROL: anonymous remains denied on a private record (404)."""
+    _owner_headers, owner_id = await _create_test_user(
+        client, admin_auth_header, "editor"
+    )
+    record_id = await _private_record(test_db_session, owner_id)
+
+    resp = await client.get(f"/records/{record_id}/{sub}/")
+
+    assert resp.status_code == 404
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("sub", _SUBRESOURCES)
+async def test_private_record_subresource_allows_owner(
+    client: AsyncClient, admin_auth_header: dict, test_db_session, sub: str
+):
+    """GUARD: the owner reads their OWN private record's sub-resources (200)."""
+    owner_headers, owner_id = await _create_test_user(
+        client, admin_auth_header, "editor"
+    )
+    record_id = await _private_record(test_db_session, owner_id)
+
+    resp = await client.get(f"/records/{record_id}/{sub}/", headers=owner_headers)
+
+    assert resp.status_code == 200, (
+        f"{sub}: owner blocked from their OWN record, got "
+        f"{resp.status_code}: {resp.text}"
+    )
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("sub", _SUBRESOURCES)
+async def test_private_record_subresource_allows_admin(
+    client: AsyncClient, admin_auth_header: dict, test_db_session, sub: str
+):
+    """GUARD: admin reads any private record's sub-resources (200)."""
+    _owner_headers, owner_id = await _create_test_user(
+        client, admin_auth_header, "editor"
+    )
+    record_id = await _private_record(test_db_session, owner_id)
+
+    resp = await client.get(f"/records/{record_id}/{sub}/", headers=admin_auth_header)
+
+    assert resp.status_code == 200
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("sub", _SUBRESOURCES)
+async def test_public_record_subresource_allows_anonymous(
+    client: AsyncClient, admin_auth_header: dict, test_db_session, sub: str
+):
+    """GUARD: a public+published record's sub-resources stay world-readable."""
+    _owner_headers, owner_id = await _create_test_user(
+        client, admin_auth_header, "editor"
+    )
+    ds = await create_dataset(
+        test_db_session,
+        created_by=uuid.UUID(owner_id),
+        name="Public dataset",
+        visibility="public",
+        record_status="published",
+    )
+
+    resp = await client.get(f"/records/{ds.record_id}/{sub}/")
+
+    assert resp.status_code == 200

--- a/backend/tests/test_ssrf_ip_pinning_sec008.py
+++ b/backend/tests/test_ssrf_ip_pinning_sec008.py
@@ -1,0 +1,92 @@
+"""Regression tests for SEC-008: SSRF DNS-rebinding via resolve-then-fetch.
+
+validate_url_for_ssrf resolved DNS once at submission time, but make_safe_client
+returned a plain client that performed its OWN DNS lookup at connect time. A
+low-TTL attacker domain could answer with a public IP at validation and a
+private IP (169.254.169.254 / 127.x / 10.x) at connect. make_safe_client now
+uses _SSRFGuardTransport, which re-resolves + re-validates + pins the validated
+IP at the moment of connection.
+
+These tests drive the transport directly with a mocked socket.getaddrinfo, so no
+real network is touched.
+"""
+
+import socket
+
+import httpx
+import pytest
+
+from app.modules.catalog.sources import security as sec
+
+
+def _addrinfo(ip: str, port: int | None):
+    fam = socket.AF_INET6 if ":" in ip else socket.AF_INET
+    return [(fam, socket.SOCK_STREAM, socket.IPPROTO_TCP, "", (ip, port or 0))]
+
+
+@pytest.mark.anyio
+async def test_transport_blocks_private_resolved_ip(monkeypatch):
+    """A host that resolves to a private IP at connect time is blocked by the
+    transport (the connection is never made). Fails on main — make_safe_client
+    had no transport guard, so the client would connect to the private IP."""
+    monkeypatch.setattr(
+        socket, "getaddrinfo", lambda h, p, *a, **k: _addrinfo("169.254.169.254", p)
+    )
+    transport = sec._SSRFGuardTransport()
+    req = httpx.Request("GET", "http://rebind.attacker.test/data")
+    with pytest.raises(sec.SSRFError):
+        await transport.handle_async_request(req)
+
+
+@pytest.mark.anyio
+async def test_transport_pins_validated_public_ip(monkeypatch):
+    """A valid public host is pinned: the connection target becomes the resolved
+    IP while the Host header and TLS SNI keep the original hostname."""
+    captured: dict = {}
+
+    async def _fake_super(self, request):
+        captured["host"] = request.url.host
+        captured["sni"] = request.extensions.get("sni_hostname")
+        captured["host_header"] = request.headers.get("host")
+        return httpx.Response(200)
+
+    monkeypatch.setattr(httpx.AsyncHTTPTransport, "handle_async_request", _fake_super)
+    monkeypatch.setattr(
+        socket, "getaddrinfo", lambda h, p, *a, **k: _addrinfo("93.184.216.34", p)
+    )
+
+    transport = sec._SSRFGuardTransport()
+    req = httpx.Request("GET", "https://example.com/x")
+    resp = await transport.handle_async_request(req)
+
+    assert resp.status_code == 200
+    assert captured["host"] == "93.184.216.34", "connection must be pinned to the IP"
+    assert captured["sni"] == "example.com", "TLS SNI must keep the hostname"
+    assert captured["host_header"] == "example.com", (
+        "Host header must keep the hostname"
+    )
+
+
+@pytest.mark.anyio
+async def test_dns_rebinding_blocked_at_connect(monkeypatch):
+    """End-to-end TOCTOU: validation resolves a public IP and passes, but the
+    connect-time resolution returns a private IP — the transport blocks it.
+    Fails on main (no connect-time re-validation)."""
+    calls = {"n": 0}
+
+    def _rebinding(host, port, *a, **k):
+        calls["n"] += 1
+        ip = "93.184.216.34" if calls["n"] == 1 else "169.254.169.254"
+        return _addrinfo(ip, port)
+
+    monkeypatch.setattr(socket, "getaddrinfo", _rebinding)
+
+    url = "https://rebind.attacker.test/data"
+    # Submission-time validation sees the public answer and passes.
+    await sec.validate_url_for_ssrf(url)
+    # Connect-time resolution returns the rebind target -> transport blocks.
+    transport = sec._SSRFGuardTransport()
+    req = httpx.Request("GET", url)
+    with pytest.raises(sec.SSRFError):
+        await transport.handle_async_request(req)
+    assert calls["n"] == 2, "expected one validation lookup + one connect-time lookup"

--- a/backend/tests/test_stac_search_dos_sec023.py
+++ b/backend/tests/test_stac_search_dos_sec023.py
@@ -1,0 +1,42 @@
+"""Regression test for SEC-023: STAC POST /search intersects GeoJSON DoS cap.
+
+The GET `intersects` query param is capped at max_length=10000 (SEC-FU-05), but
+`StacSearchBody.intersects` (the POST body dict) had no bound and reached the
+same anonymous ST_GeomFromGeoJSON / ST_Intersects predicate — a multi-megabyte
+GeoJSON polygon could pin CPU/memory and a DB connection. The fix caps the
+serialized size on the model, matching the GET handler.
+
+Pure-model tests (no DB): instantiating StacSearchBody runs the validator.
+"""
+
+import json
+
+import pytest
+from pydantic import ValidationError
+
+from app.standards.stac.router import StacSearchBody
+
+
+def _polygon(n_vertices: int) -> dict:
+    coords = [[i * 1e-6, i * 1e-6] for i in range(n_vertices)]
+    return {"type": "Polygon", "coordinates": [coords]}
+
+
+def test_oversized_intersects_is_rejected():
+    """A huge GeoJSON polygon is rejected at validation (422 at the API)."""
+    big = _polygon(5000)
+    assert len(json.dumps(big)) > 10000, "test fixture should exceed the cap"
+    with pytest.raises(ValidationError):
+        StacSearchBody(intersects=big)
+
+
+def test_normal_intersects_is_allowed():
+    """GUARD: an ordinary polygon passes unchanged."""
+    small = {"type": "Polygon", "coordinates": [[[0, 0], [0, 1], [1, 1], [0, 0]]]}
+    body = StacSearchBody(intersects=small)
+    assert body.intersects == small
+
+
+def test_absent_intersects_is_allowed():
+    """GUARD: omitting intersects is still valid."""
+    assert StacSearchBody().intersects is None

--- a/backend/tests/test_stac_search_validation.py
+++ b/backend/tests/test_stac_search_validation.py
@@ -106,14 +106,15 @@ class TestSecFu05StacIntersectsMaxLength:
             f"9000-char intersects rejected with 422 (should not hit max_length cap): {resp.text}"
         )
 
-    async def test_sec_fu_05_post_body_unaffected(self, client: AsyncClient):
-        """POST /stac/search body.intersects dict is NOT capped by max_length.
+    async def test_sec_fu_05_post_body_is_capped(self, client: AsyncClient):
+        """POST /stac/search body.intersects dict IS now capped (SEC-023).
 
-        The POST handler accepts StacSearchBody.intersects: dict — bounded by
-        the application-wide RequestBodyLimitMiddleware (default 500 MB) and
-        the nginx proxy (client_max_body_size 500m), NOT by a 1MB uvicorn limit
-        (uvicorn has no built-in body size cap). The Query max_length constraint
-        applies only to GET query-string parameters, not to POST body fields.
+        SEC-FU-05 capped only the GET `intersects` query param (max_length=10000);
+        the POST body dict bypassed any bound and reached the same anonymous
+        ST_GeomFromGeoJSON predicate (a multi-megabyte GeoJSON DoS amplifier).
+        SEC-023 adds a matching serialized-size cap on StacSearchBody.intersects,
+        so an oversized body now returns 422 before any spatial query runs. This
+        test previously asserted the body was *unaffected* — that was the bug.
         """
         # Build a large polygon dict whose JSON representation exceeds 10000 chars
         coords = [[i * 0.01, j * 0.01] for i in range(50) for j in range(50)]
@@ -131,10 +132,10 @@ class TestSecFu05StacIntersectsMaxLength:
             "/stac/search",
             json={"intersects": intersects_dict},
         )
-        # Must not 422 — the body path has no max_length constraint
-        assert resp.status_code != 422, (
-            f"POST with large intersects dict returned 422 — "
-            f"body path must not apply max_length: {resp.text}"
+        # Must 422 — the body cap rejects the oversized GeoJSON before PostGIS.
+        assert resp.status_code == 422, (
+            f"POST with oversized intersects dict must be capped (422), "
+            f"got {resp.status_code}: {resp.text}"
         )
 
 

--- a/backend/tests/test_tile_cache_scope_sec009.py
+++ b/backend/tests/test_tile_cache_scope_sec009.py
@@ -1,0 +1,104 @@
+"""Regression tests for SEC-009: non-public vector tiles get a private cache scope.
+
+`_authorize_vector_tile_request` returned "public" for a valid NON-public signed
+request (it fell through past the signature check), so `_tile_headers` emitted
+`Cache-Control: public` + `Access-Control-Allow-Origin: *` and a shared cache
+could retain private vector-tile bytes under an auth-less key. The fix returns
+"private" for the non-public signed path.
+
+These are pure-function tests (no DB / pool / Titiler): they call the authorizer
+directly with a valid signature mocked and assert the resolved cache scope.
+"""
+
+import uuid
+
+import pytest
+
+import app.processing.tiles.router as tile_router
+from app.processing.tiles.router import (
+    _DatasetMeta,
+    _authorize_vector_tile_request,
+    _tile_headers,
+)
+
+
+class _FakeRequest:
+    def __init__(self, headers: dict | None = None):
+        self.headers = headers or {}
+
+
+def _meta(visibility: str, record_status: str = "published") -> _DatasetMeta:
+    return _DatasetMeta(
+        dataset_id=uuid.uuid4(),
+        record_id=uuid.uuid4(),
+        table_name="vt_test",
+        visibility=visibility,
+        record_status=record_status,
+        created_by=uuid.uuid4(),
+        record_type="vector_dataset",
+        geometry_type="Point",
+        column_info=[],
+        tile_cache_ttl=None,
+        tile_columns=None,
+    )
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("visibility", ["private", "restricted", "internal"])
+async def test_non_public_signed_tile_is_private_scope(monkeypatch, visibility: str):
+    """A valid signature on a non-public dataset resolves to cache scope 'private'.
+
+    Fails on main, which returned 'public' (-> Cache-Control: public).
+    """
+    monkeypatch.setattr(
+        tile_router, "verify_tile_signature", lambda scope, exp, sig: True
+    )
+    scope = await _authorize_vector_tile_request(
+        _FakeRequest(),
+        _meta(visibility),
+        db=None,
+        sig="validsig",
+        exp=9999999999,
+        scope="vt_test",
+        user=None,
+    )
+    assert scope == "private", (
+        f"{visibility} tile resolved to non-private scope: {scope}"
+    )
+    cache_control = _tile_headers(scope, 300)["Cache-Control"]
+    assert cache_control.startswith("private")
+    assert "public" not in cache_control
+
+
+@pytest.mark.anyio
+async def test_public_published_tile_stays_public_scope():
+    """GUARD: public + published tiles stay shared-cacheable (scope 'public')."""
+    scope = await _authorize_vector_tile_request(
+        _FakeRequest(),
+        _meta("public", "published"),
+        db=None,
+        sig=None,
+        exp=None,
+        scope=None,
+        user=None,
+    )
+    assert scope == "public"
+    assert _tile_headers(scope, 300)["Cache-Control"].startswith("public")
+
+
+@pytest.mark.anyio
+async def test_non_public_without_signature_is_rejected(monkeypatch):
+    """GUARD: a non-public dataset with no signature is still 403 (not cached)."""
+    from fastapi import HTTPException
+
+    with pytest.raises(HTTPException) as exc:
+        await _authorize_vector_tile_request(
+            _FakeRequest(),
+            _meta("private"),
+            db=None,
+            sig=None,
+            exp=None,
+            scope=None,
+            user=None,
+        )
+    assert exc.value.status_code == 403

--- a/backend/tests/test_tile_cache_scope_sec009.py
+++ b/backend/tests/test_tile_cache_scope_sec009.py
@@ -10,6 +10,7 @@ These are pure-function tests (no DB / pool / Titiler): they call the authorizer
 directly with a valid signature mocked and assert the resolved cache scope.
 """
 
+import types
 import uuid
 
 import pytest
@@ -18,6 +19,7 @@ import app.processing.tiles.router as tile_router
 from app.processing.tiles.router import (
     _DatasetMeta,
     _authorize_vector_tile_request,
+    _is_publicly_cacheable,
     _tile_headers,
 )
 
@@ -102,3 +104,65 @@ async def test_non_public_without_signature_is_rejected(monkeypatch):
             user=None,
         )
     assert exc.value.status_code == 403
+
+
+# ---------------------------------------------------------------------------
+# SEC-002 follow-up (Codex P1 on PR #243): public BUT unpublished previews are
+# owner/admin-only and must NOT be shared-cached.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "visibility,record_status,expected",
+    [
+        ("public", "published", True),
+        ("public", "draft", False),  # owner/admin preview — not shared-cacheable
+        ("public", "internal", False),
+        ("private", "published", False),
+        ("restricted", "published", False),
+        ("internal", "published", False),
+    ],
+)
+def test_is_publicly_cacheable(visibility, record_status, expected):
+    """Raster cache scope: publicly cacheable only when public AND published."""
+    assert _is_publicly_cacheable(visibility, record_status) is expected
+
+
+@pytest.mark.anyio
+async def test_public_unpublished_owner_preview_is_private_scope(monkeypatch):
+    """Vector: an owner previewing an UNPUBLISHED public dataset is authorized
+    but its tiles must not be shared-cached (scope 'private')."""
+    meta = _meta("public", "draft")
+    owner = types.SimpleNamespace(id=meta.created_by)
+
+    async def _roles(_db, _user):
+        return set()
+
+    monkeypatch.setattr(
+        tile_router,
+        "get_processing_port",
+        lambda: types.SimpleNamespace(get_user_roles=_roles),
+    )
+    scope = await _authorize_vector_tile_request(
+        _FakeRequest(), meta, db=None, sig=None, exp=None, scope=None, user=owner
+    )
+    assert scope == "private"
+    assert _tile_headers(scope, 300)["Cache-Control"].startswith("private")
+
+
+@pytest.mark.anyio
+async def test_public_unpublished_anonymous_is_rejected():
+    """GUARD: anon still cannot reach an unpublished public dataset (404)."""
+    from fastapi import HTTPException
+
+    with pytest.raises(HTTPException) as exc:
+        await _authorize_vector_tile_request(
+            _FakeRequest(),
+            _meta("public", "draft"),
+            db=None,
+            sig=None,
+            exp=None,
+            scope=None,
+            user=None,
+        )
+    assert exc.value.status_code == 404

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -824,7 +824,7 @@ wheels = [
 
 [[package]]
 name = "geolens-backend"
-version = "1.2.3"
+version = "1.2.4"
 source = { virtual = "." }
 dependencies = [
     { name = "alembic" },

--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "geolens-cli"
-version = "1.2.3"
+version = "1.2.4"
 description = "Apache-2.0 command-line interface for the GeoLens API. Login, scan, publish, and export STAC against any GeoLens instance."
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -147,7 +147,10 @@ services:
     # alembic.ini are COPYed into /app — Dockerfile backend-base).
     image: ${REGISTRY:-ghcr.io}/${IMAGE_OWNER:-geolens-io}/geolens-api:${GEOLENS_VERSION:-latest}
     entrypoint: []
-    command: sh -c "uv run --no-dev alembic upgrade head"
+    # `heads` (plural) applies every branch head: with the enterprise overlay the
+    # graph forks into two heads (core 0003 + enterprise e002) and bare `head`
+    # errors. OSS single-head is unaffected (heads == head).
+    command: sh -c "uv run --no-dev alembic upgrade heads"
     restart: "no"
     <<: *hardened-base
     tmpfs:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -85,7 +85,7 @@ x-hardened-base: &hardened-base
 # ==============================================================================
 # Services at a glance:
 #   db        — PostgreSQL 17 + PostGIS 3.5 (catalog data, pgvector, pg_trgm)
-#   migrate   — one-shot alembic upgrade head, exits when done
+#   migrate   — one-shot alembic upgrade heads, exits when done
 #   api       — FastAPI REST + OGC API + Records (host :8001 -> container :8000)
 #   worker    — Procrastinate job queue (GDAL ingest, embeddings, exports)
 #   titiler   — Raster tile server (internal only, reachable at http://titiler:8000)
@@ -148,7 +148,11 @@ services:
     # Empty entrypoint suppresses Dockerfile-inherited api-entrypoint.sh on this
     # one-shot service.
     entrypoint: []
-    command: sh -c "uv run --no-dev alembic upgrade head"
+    # `upgrade heads` (plural) applies every branch head — with the enterprise
+    # overlay installed the graph has two heads (core 0003 + enterprise e002);
+    # bare `head` errors "Multiple head revisions present". Single-head OSS is
+    # unaffected (heads == head).
+    command: sh -c "uv run --no-dev alembic upgrade heads"
     # One-shot: alembic upgrade is idempotent (re-running is safe). Failure
     # should stop the dependency chain, not retry blindly.
     restart: "no"

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -5,23 +5,10 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="theme-color" content="#3b6fd4" />
     <script src="/env-config.js"></script>
-    <!-- FOUC prevention: apply dark class before CSS renders -->
-    <!-- Must match ThemeProvider storageKey -->
-    <script>
-      (function() {
-        try {
-          var stored = localStorage.getItem('geolens-theme');
-          var prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
-          var isDark = stored === 'dark' || (stored !== 'light' && prefersDark);
-          if (isDark) document.documentElement.classList.add('dark');
-          // Sync lang attribute before React hydration (must match i18n config supportedLngs)
-          var lang = localStorage.getItem('i18nextLng');
-          if (lang && /^(en|de|fr|es)$/.test(lang)) {
-            document.documentElement.lang = lang;
-          }
-        } catch(e) {}
-      })();
-    </script>
+    <!-- FOUC prevention + lang sync. Externalized to /theme-init.js (SEC-020) so
+         the page carries a strict script-src 'self' CSP with no inline script.
+         Render-blocking, so it still runs before first paint. -->
+    <script src="/theme-init.js"></script>
     <link rel="icon" type="image/svg+xml" sizes="any" href="/favicon.svg" />
     <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16.png" />
     <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32.png" />

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -7,10 +7,30 @@ proxy_cache_path /var/cache/nginx/raster_cache levels=1:2 keys_zone=raster_cache
 # that initial fan-out while the steady-state rate still limits sustained abuse.
 limit_req_zone $binary_remote_addr zone=raster_anon:10m rate=600r/m;
 
+# SEC-006: the ?api_key=<secret> query-param credential is a documented auth
+# fallback (resolution order: X-Api-Key header > query > JWT > anon). nginx logs
+# the full request line ($request) by default, so these long-lived, non-expiring
+# keys would be persisted in cleartext in the access log and any downstream log
+# aggregation. Redact the api_key value from the logged request line. The app
+# layer already logs only request.url.path (uvicorn.access is silenced), but
+# nginx fronts /api/, so the scrub must also happen at the edge.
+map $request $geolens_scrubbed_request {
+    default $request;
+    "~^(?<pre>.*[?&])api_key=[^&\s]*(?<post>.*)$" "${pre}api_key=REDACTED${post}";
+}
+log_format geolens_scrubbed '$remote_addr - $remote_user [$time_local] '
+                            '"$geolens_scrubbed_request" $status $body_bytes_sent '
+                            '"$http_referer" "$http_user_agent"';
+
 server {
     listen 8080;
     root /usr/share/nginx/html;
     index index.html;
+
+    # SEC-006: emit the api_key-scrubbed access log for every location in this
+    # server (see the map/log_format above). Set at server scope so /api/ and
+    # all other locations inherit it.
+    access_log /var/log/nginx/access.log geolens_scrubbed;
 
     # MIME type handling — defense-in-depth (base image http{} also configures this).
     # `default_type application/octet-stream` makes browsers download unknown files

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -175,10 +175,28 @@ server {
         add_header X-Content-Type-Options "nosniff" always;
         add_header Referrer-Policy "strict-origin-when-cross-origin" always;
         # X-Frame-Options intentionally omitted — see SEC-S08 comment above.
+        # SEC-020: same script/exfil backstop as `location /` but WITHOUT
+        # frame-ancestors, so the per-token shared-map embed stays framable
+        # cross-origin (embed access control is the token + API origin check, not
+        # frame-ancestors, which has no default-src fallback — omitting it leaves
+        # framing open).
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https:; font-src 'self' data:; connect-src 'self' https: wss:; worker-src 'self' blob:; child-src 'self' blob:; object-src 'none'; base-uri 'self'" always;
         try_files $uri /index.html;
     }
 
     location / {
+        # SEC-020: Content-Security-Policy on the SPA HTML — defense-in-depth so a
+        # future XSS cannot load injected/inline scripts to exfiltrate the JWT
+        # from localStorage. script-src 'self' (+ wasm-unsafe-eval for WebAssembly)
+        # blocks script injection; style-src 'unsafe-inline' is required by
+        # React/MapLibre/Tailwind inline styles; img/connect/font/worker stay
+        # permissive so map tiles, glyphs, workers and external sources still load.
+        # Any add_header here disables inheritance, so the server-scope security
+        # headers are re-declared.
+        add_header X-Frame-Options "SAMEORIGIN" always;
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https:; font-src 'self' data:; connect-src 'self' https: wss:; worker-src 'self' blob:; child-src 'self' blob:; object-src 'none'; base-uri 'self'; frame-ancestors 'self'" always;
         try_files $uri $uri/ /index.html;
     }
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.2.3",
+  "version": "1.2.4",
   "type": "module",
   "license": "Apache-2.0",
   "scripts": {

--- a/frontend/public/theme-init.js
+++ b/frontend/public/theme-init.js
@@ -1,0 +1,18 @@
+// FOUC prevention + lang sync — externalized from index.html so the page can
+// ship a strict Content-Security-Policy (script-src 'self') with no inline
+// <script> (SEC-020). Loaded render-blocking from <head>, so it still runs
+// before first paint. Keep in sync with ThemeProvider storageKey and the i18n
+// supportedLngs list.
+(function () {
+  try {
+    var stored = localStorage.getItem('geolens-theme');
+    var prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+    var isDark = stored === 'dark' || (stored !== 'light' && prefersDark);
+    if (isDark) document.documentElement.classList.add('dark');
+    // Sync lang attribute before React hydration (must match i18n supportedLngs)
+    var lang = localStorage.getItem('i18nextLng');
+    if (lang && /^(en|de|fr|es)$/.test(lang)) {
+      document.documentElement.lang = lang;
+    }
+  } catch (e) {}
+})();

--- a/scripts/backup-entrypoint.sh
+++ b/scripts/backup-entrypoint.sh
@@ -115,7 +115,13 @@ upload_to_s3() {
     date_value="$(date -R)"
     local content_type="application/octet-stream"
     local resource="/${S3_BUCKET}/backups/${s3_key}"
-    local string_to_sign="PUT\n\n${content_type}\n${date_value}\n${resource}"
+    # BUG-004: the AWS SigV2 string-to-sign must contain REAL newlines. Bash
+    # double quotes do NOT expand "\n", and `printf '%s'` prints its argument
+    # verbatim, so the previous "PUT\n\n..." form signed over the literal
+    # two-character sequence backslash-n — every PUT was rejected with
+    # SignatureDoesNotMatch and offsite backups silently never happened. Use
+    # ANSI-C quoting ($'\n') so the separators are actual newline bytes.
+    local string_to_sign=$'PUT\n\n'"${content_type}"$'\n'"${date_value}"$'\n'"${resource}"
     local signature
     signature="$(printf '%s' "$string_to_sign" | openssl dgst -sha1 -hmac "$S3_SECRET_ACCESS_KEY" -binary | base64)"
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -58,6 +58,14 @@ generate_jwt_secret() {
   fail "cannot generate JWT_SECRET_KEY: install openssl, or run on a host with /dev/urandom."
 }
 
+# Generate a strong password from the same entropy source as the JWT secret.
+# The "Aa" prefix + "_1" suffix guarantee 4 character classes (upper, lower,
+# digit, symbol) so the value satisfies a multi-class complexity policy, and
+# uses only .env / connection-string-safe characters (no = $ " ' @ : / space).
+generate_password() {
+  printf 'Aa%s_1\n' "$(generate_jwt_secret)"
+}
+
 check_port() {
   port="$1"
   if command -v lsof >/dev/null 2>&1 && lsof -iTCP:"$port" -sTCP:LISTEN >/dev/null 2>&1; then
@@ -238,8 +246,10 @@ else
   PROJECT_HINT="$INSTALL_DIR"
 fi
 
+ENV_CREATED=false
 if [ ! -f .env ]; then
   cp .env.example .env
+  ENV_CREATED=true
 fi
 
 # JWT_SECRET_KEY: generate iff missing or empty. Existing real values are kept.
@@ -250,15 +260,44 @@ if [ -z "$existing_jwt" ]; then
   say "Generated JWT_SECRET_KEY."
 fi
 
-# Admin credentials: prompt only if either is empty. Honors GEOLENS_ADMIN_USERNAME /
+# POSTGRES_PASSWORD (SEC-010): .env.example ships the publicly-known default
+# `geolens`. On a FRESH install replace it with a strong value so the database
+# is initialized with a real password. On a re-run we must NOT rotate it — the
+# pgdata volume is already initialized with the existing value and changing it
+# would lock the app out.
+existing_pg_pw="$(get_env_value POSTGRES_PASSWORD)"
+if [ "$ENV_CREATED" = "true" ] && { [ -z "$existing_pg_pw" ] || [ "$existing_pg_pw" = "geolens" ]; }; then
+  update_env_value POSTGRES_PASSWORD "$(generate_password)"
+  say "Generated POSTGRES_PASSWORD."
+elif [ "$existing_pg_pw" = "geolens" ]; then
+  warn "POSTGRES_PASSWORD is still the public default 'geolens'. If the database has not been initialized yet, set a strong value in .env before first start."
+fi
+
+# Admin credentials: set only if either is empty. Honors GEOLENS_ADMIN_USERNAME /
 # GEOLENS_ADMIN_PASSWORD env vars for non-interactive installs.
 existing_admin_user="$(get_env_value GEOLENS_ADMIN_USERNAME)"
 existing_admin_pass="$(get_env_value GEOLENS_ADMIN_PASSWORD)"
+generated_admin_pw=false
 if [ -z "$existing_admin_user" ] || [ -z "$existing_admin_pass" ]; then
   admin_user="$(prompt_value 'Admin username' 'admin' false GEOLENS_ADMIN_USERNAME)"
-  admin_password="$(prompt_value 'Admin password' 'admin' true GEOLENS_ADMIN_PASSWORD)"
+  # Password (SEC-011): honor an explicitly-provided GEOLENS_ADMIN_PASSWORD;
+  # interactively let the operator type one (blank = generate). Otherwise
+  # GENERATE a strong password — never silently default to 'admin', which a
+  # headless `curl | sh` install would otherwise do for an internet-facing app.
+  admin_password="${GEOLENS_ADMIN_PASSWORD:-}"
+  if [ -z "$admin_password" ] && [ "$HAS_TTY" = "true" ]; then
+    admin_password="$(prompt_value 'Admin password (blank = generate a strong one)' '' true)"
+  fi
+  if [ -z "$admin_password" ]; then
+    admin_password="$(generate_password)"
+    generated_admin_pw=true
+  fi
   update_env_value GEOLENS_ADMIN_USERNAME "$admin_user"
   update_env_value GEOLENS_ADMIN_PASSWORD "$admin_password"
+  if [ "$generated_admin_pw" = "true" ]; then
+    # Do not echo the secret to stdout/logs; it is stored in .env.
+    say "Generated a strong admin password — retrieve it with: grep '^GEOLENS_ADMIN_PASSWORD=' .env"
+  fi
 else
   say ".env already has admin credentials; leaving unchanged."
 fi

--- a/scripts/tests/test-backup-s3-signature.sh
+++ b/scripts/tests/test-backup-s3-signature.sh
@@ -1,0 +1,82 @@
+#!/bin/sh
+# Regression test for BUG-004: the backup S3 SigV2 signature must be computed
+# over a string-to-sign containing REAL newlines, not the literal two-character
+# sequence backslash-n.
+#
+# On main the string was built with bash double-quoted "PUT\n\n..." (which does
+# NOT expand \n) and signed via `printf '%s'` (verbatim), so every PUT was
+# rejected with SignatureDoesNotMatch — offsite backups silently never happened
+# while a non-fatal log warning masked the failure.
+set -eu
+
+SCRIPT="$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)/backup-entrypoint.sh"
+[ -f "$SCRIPT" ] || { echo "FAIL: cannot find backup-entrypoint.sh at $SCRIPT"; exit 1; }
+
+# The fixed construction uses bash ANSI-C quoting ($'\n'); evaluate it in bash.
+command -v bash >/dev/null 2>&1 || { echo "SKIP: bash not available"; exit 0; }
+command -v openssl >/dev/null 2>&1 || { echo "SKIP: openssl not available"; exit 0; }
+
+content_type="application/octet-stream"
+date_value="Thu, 01 Jan 1970 00:00:00 GMT"
+resource="/test-bucket/backups/db.dump"
+secret="test-secret-key"
+
+# --- behavioral: extract the real string_to_sign + signature construction -----
+# Pull the two assignment lines (string_to_sign=..., signature=...) straight
+# from the shipped script, strip the function-local `local ` prefix, and run
+# them so we exercise the ACTUAL signing code, not a copy.
+snippet="$(mktemp)"
+awk '
+  /string_to_sign=/ { f = 1 }
+  f && /=/ { line = $0; sub(/^[[:space:]]*local /, "", line); print line }
+  /openssl dgst/ { f = 0 }
+' "$SCRIPT" >"$snippet"
+grep -q 'string_to_sign=' "$snippet" || { echo "FAIL: could not extract signing snippet"; rm -f "$snippet"; exit 1; }
+
+result="$(bash -c '
+  set -eu
+  content_type="'"$content_type"'"
+  date_value="'"$date_value"'"
+  resource="'"$resource"'"
+  S3_SECRET_ACCESS_KEY="'"$secret"'"
+  . "'"$snippet"'"
+  printf "%s\n" "$(printf "%s" "$string_to_sign" | wc -l | tr -d " ")"
+  printf "%s\n" "$signature"
+')"
+rm -f "$snippet"
+
+nl_count="$(printf '%s\n' "$result" | sed -n 1p)"
+got_sig="$(printf '%s\n' "$result" | sed -n 2p)"
+
+# The canonical AWS SigV2 string-to-sign (PUT\n\n<ct>\n<date>\n<resource>) has
+# exactly 4 real newline separators. The buggy literal-\n form has 0.
+[ "${nl_count:-0}" -ge 4 ] || {
+  echo "FAIL: string_to_sign has ${nl_count:-0} real newlines (expected >=4) — signed over literal \\n (BUG-004)"
+  exit 1
+}
+
+# Reference signature, computed independently with REAL newlines (printf format
+# string interprets \n). The shipped code must produce exactly this.
+expected="$(printf 'PUT\n\n%s\n%s\n%s' "$content_type" "$date_value" "$resource" \
+  | openssl dgst -sha1 -hmac "$secret" -binary | base64)"
+[ "$got_sig" = "$expected" ] || {
+  echo "FAIL: signature mismatch — got '$got_sig', expected '$expected' (BUG-004)"
+  exit 1
+}
+
+# Sanity: the broken literal-\n signature MUST differ, proving the test detects
+# the regression rather than passing trivially.
+broken="$(printf '%s' "PUT\\n\\n${content_type}\\n${date_value}\\n${resource}" \
+  | openssl dgst -sha1 -hmac "$secret" -binary | base64)"
+[ "$got_sig" != "$broken" ] || {
+  echo "FAIL: signature equals the broken literal-\\n form (BUG-004 not fixed)"
+  exit 1
+}
+
+# --- structural: the buggy literal-\n string_to_sign must be gone -------------
+if grep -qE 'string_to_sign="PUT\\n' "$SCRIPT"; then
+  echo "FAIL: backup-entrypoint.sh still builds string_to_sign with literal \\n (BUG-004)"
+  exit 1
+fi
+
+echo "PASS: backup S3 SigV2 signature over real newlines (BUG-004)"

--- a/scripts/tests/test-install-secret-generation.sh
+++ b/scripts/tests/test-install-secret-generation.sh
@@ -1,0 +1,44 @@
+#!/bin/sh
+# Regression test for SEC-010 / SEC-011: the installer must not ship or default
+# to weak credentials. Verifies that generate_password() produces a strong,
+# class-diverse value and that install.sh generates POSTGRES_PASSWORD and the
+# admin password instead of keeping the public defaults `geolens` / `admin`.
+set -eu
+
+INSTALL_SH="$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)/install.sh"
+[ -f "$INSTALL_SH" ] || { echo "FAIL: cannot find install.sh at $INSTALL_SH"; exit 1; }
+
+# --- behavioral: extract and exercise generate_password() in isolation ---------
+fns="$(mktemp)"
+# Extract from generate_jwt_secret() up to (but not including) check_port().
+awk '/^generate_jwt_secret\(\) \{/{f=1} /^check_port\(\) \{/{f=0} f{print}' \
+  "$INSTALL_SH" >"$fns"
+fail() { echo "$*" >&2; exit 1; }  # stub the helper the functions may call
+# shellcheck disable=SC1090
+. "$fns"
+rm -f "$fns"
+
+pw="$(generate_password)"
+[ "${#pw}" -ge 16 ] || { echo "FAIL: generated password too short (${#pw})"; exit 1; }
+[ "$pw" != "admin" ] || { echo "FAIL: generated password is 'admin'"; exit 1; }
+[ "$pw" != "geolens" ] || { echo "FAIL: generated password is 'geolens'"; exit 1; }
+printf '%s' "$pw" | grep -q '[a-z]' || { echo "FAIL: no lowercase in password"; exit 1; }
+printf '%s' "$pw" | grep -q '[A-Z]' || { echo "FAIL: no uppercase in password"; exit 1; }
+printf '%s' "$pw" | grep -q '[0-9]' || { echo "FAIL: no digit in password"; exit 1; }
+printf '%s' "$pw" | grep -q '[^A-Za-z0-9]' || { echo "FAIL: no symbol in password"; exit 1; }
+# .env / connection-string safety: must not contain = $ " ' @ : / or whitespace.
+case "$pw" in
+  *=* | *'$'* | *'"'* | *"'"* | *@* | *:* | */* | *' '*)
+    echo "FAIL: generated password contains an unsafe character"; exit 1 ;;
+esac
+
+# --- structural: install.sh no longer defaults to weak credentials -------------
+if grep -q "prompt_value 'Admin password' 'admin'" "$INSTALL_SH"; then
+  echo "FAIL: install.sh still defaults the admin password to 'admin' (SEC-011)"; exit 1
+fi
+grep -q 'Generated POSTGRES_PASSWORD' "$INSTALL_SH" \
+  || { echo "FAIL: install.sh does not generate POSTGRES_PASSWORD (SEC-010)"; exit 1; }
+grep -q 'generated_admin_pw=true' "$INSTALL_SH" \
+  || { echo "FAIL: install.sh does not generate an admin password (SEC-011)"; exit 1; }
+
+echo "PASS: install.sh secret generation (SEC-010 / SEC-011)"

--- a/sdks/python/.openapi-python-client.yaml
+++ b/sdks/python/.openapi-python-client.yaml
@@ -4,7 +4,7 @@ project_name_override: geolens
 package_name_override: geolens
 # Rewritten on every `make sdks` run by scripts/sync_sdk_versions.py to match
 # backend/openapi.json info.version. Do not edit by hand.
-package_version_override: 1.2.3
+package_version_override: 1.2.4
 
 # Cleaner enum output (matches our pydantic v2 backend's enum emission).
 literal_enums: true

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "geolens"
-version = "1.2.3"
+version = "1.2.4"
 description = "Auto-generated Python SDK for the GeoLens API. Typed clients with Bearer + API-key auth helpers."
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/sdks/typescript/package-lock.json
+++ b/sdks/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@geolens/sdk",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@geolens/sdk",
-      "version": "1.2.3",
+      "version": "1.2.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@hey-api/client-fetch": "0.13.1"

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@geolens/sdk",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "description": "Auto-generated TypeScript SDK for the GeoLens API. Typed clients with Bearer + API-key auth helpers.",
   "license": "Apache-2.0",
   "homepage": "https://github.com/geolens-io/geolens",


### PR DESCRIPTION
## v1.2.4 security hardening — Tier-0 (partial)

First wave of the v1.2.4 patch from the 2026-06-11 whole-portfolio review. Fixes
**all 3 Critical findings + 5 High findings** (8 total). Each fix mirrors an
existing in-codebase pattern and ships regression tests; two are runtime-proven.

This is the same recurring class v1.2.3 (SEC-A..E / GHSA-p23g-mvhj-jh3j) patched:
*authorize the URL resource but read/serve a different one un-re-authorized*, plus
two deploy-breaking bugs and the installer credential defaults.

### Findings fixed

| Commit | Finding | Sev | Summary |
|---|---|---|---|
| `3b54f1d2` | **BUG-001** | Critical | `alembic upgrade head`→`heads` at every entrypoint. Core `0003` + enterprise `e001` both descend from `0002`, so an enterprise deploy has two heads and bare `head` aborts the migrate one-shot — api/worker never boot on core ≥ v1.2.0. (Reproduced: real alembic raised `CommandError: Multiple head revisions`.) |
| `055e6ce2` | **SEC-001** | Critical | `/records/{id}/{contacts,keywords,distributions}` gated only on `user is None`, so any authenticated viewer read any private record's contact **PII** by UUID. Now delegates to the dataset's per-dataset RBAC. (Reproduced live: viewer got 200 + PII.) |
| `32444acd` | **SEC-002 / SEC-009** | Critical / High | Private raster + vector tiles returned `Cache-Control: public`, so the shared nginx cache (auth-less key) could retain and replay private tile bytes. Both paths now emit `private`/`no-store` for non-public datasets (the contract `nginx.conf` already documented). |
| `68b13a24` | **SEC-007** | High | `GET /maps/{id}/visibility-check/` disclosed any map's non-public dataset names with no map-read check. Added the gate every other map read endpoint uses. |
| `78197517` | **SEC-010 / SEC-011** | High / High | Installer kept the public defaults `POSTGRES_PASSWORD=geolens` and a headless `admin/admin`. Now generates strong DB + admin passwords (no secret echoed to logs). |
| `fb914cfc` | **SEC-023** | High | STAC `POST /search` `intersects` had no size bound (the GET sibling was capped), reaching the same anonymous PostGIS predicate — a multi-MB GeoJSON DoS amplifier. Added a matching serialized-size cap. |

### Verification
- **40 new backend** + **14 installer-shell** regression tests; SEC-001 and SEC-007 verified to **fail on the unfixed code**.
- Existing tile-auth (50), STAC, migration, and installer suites stay green.
- 2 new CI guards: the `heads` invocation check and the installer secret-generation test.
- SEC-023 correctly inverts a prior test that documented the vulnerable POST body as intentional.

### Out of scope (fast-follow, remaining Tier-0)
SEC-005 (`LOG_JSON` decoupling), SEC-006 (api_key in nginx log), SEC-008 (SSRF DNS-rebinding), SEC-020 (CSP), SEC-021 (preview CRLF/bearer leak), SEC-022 (embed-token re-auth), BUG-002 (procrastinate `search_path`), BUG-004 (backup S3 signature), BUG-008 (rate-limit warm path). Tracked in the review triage worksheet.

### Disclosure note
SEC-001/002/007/009/023 are the same authz/cache class as the published GHSA — decide whether v1.2.4 warrants an advisory update or a quiet patch before release.
