### PR TITLE
ci(release): gate SDK/CLI publishing on tag behind a one-click approval environment

### DIFF
--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -1,4 +1,11 @@
-# Manual-trigger publish workflow for the GeoLens CLI.
+# Publish workflow for the GeoLens CLI (PyPI `geolens-cli`).
+#
+# Triggers:
+#   - push a `v*.*.*` tag → publish job queues behind the `publish` environment
+#     and pauses for required-reviewer approval (one click) before publishing.
+#   - workflow_dispatch → same gate; for ad-hoc / re-publish, run from a tag ref:
+#     `gh workflow run publish-cli.yml --ref vX.Y.Z`
+#
 # One-time cold-start credentials required before the first publish:
 #   1. PyPI Trusted Publishing configured for `geolens-cli` at https://pypi.org/manage/account/publishing/
 #   2. The maintainer claims the `geolens-cli` PyPI name (one-time, automatic on first publish via pending-publisher OIDC)
@@ -6,6 +13,9 @@
 name: Publish CLI
 
 on:
+  push:
+    tags:
+      - 'v*.*.*'
   workflow_dispatch:
     inputs:
       dry_run:
@@ -27,6 +37,7 @@ jobs:
   publish-cli:
     name: Publish geolens-cli to PyPI
     runs-on: ubuntu-latest
+    environment: publish  # required-reviewer approval gate (see repo Settings → Environments)
     steps:
       - uses: actions/checkout@v6
 
@@ -37,6 +48,23 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: "3.13"
+
+      - name: Assert tag matches package version (tag push only)
+        if: ${{ github.event_name == 'push' }}
+        working-directory: cli
+        run: |
+          TAG="${GITHUB_REF_NAME#v}"
+          PKG=$(python - <<'PY'
+          import tomllib
+          with open("pyproject.toml", "rb") as f:
+              print(tomllib.load(f)["project"]["version"])
+          PY
+          )
+          if [ "${TAG}" != "${PKG}" ]; then
+            echo "::error::tag v${TAG} != cli version ${PKG} — refusing to publish a mismatched version"
+            exit 1
+          fi
+          echo "tag v${TAG} matches cli version ${PKG}"
 
       - name: Build wheel + sdist
         working-directory: cli

--- a/.github/workflows/publish-sdks.yml
+++ b/.github/workflows/publish-sdks.yml
@@ -1,12 +1,22 @@
-# Manual-trigger publish workflow for the GeoLens SDKs.
+# Publish workflow for the GeoLens SDKs (PyPI `geolens` + npm `@geolens/sdk`).
+#
+# Triggers:
+#   - push a `v*.*.*` tag → publish jobs queue behind the `publish` environment
+#     and pause for required-reviewer approval (one click) before publishing.
+#   - workflow_dispatch → same gate; for ad-hoc / re-publish, run from a tag ref:
+#     `gh workflow run publish-sdks.yml --ref vX.Y.Z -f target=both`
+#
 # One-time cold-start credentials required before the first publish:
 #   1. PyPI Trusted Publishing configured for `geolens` at https://pypi.org/manage/account/publishing/
-#   2. npm granular token (Bypass 2FA + Read/Write) in repo secret NPM_TOKEN
+#   2. npm Trusted Publisher (OIDC) configured for `@geolens/sdk` (NPM_TOKEN secret is a fallback)
 #   3. The @geolens npm org claimed by the maintainer (one-time)
 # See docs.getgeolens.com for the full first-publish runbook.
 name: Publish SDKs
 
 on:
+  push:
+    tags:
+      - 'v*.*.*'
   workflow_dispatch:
     inputs:
       target:
@@ -35,9 +45,11 @@ permissions:
 
 jobs:
   publish-python:
-    if: inputs.target == 'python' || inputs.target == 'both'
+    # Tag push → always (target defaults to both). Manual dispatch → honor target.
+    if: ${{ github.event_name == 'push' || inputs.target == 'python' || inputs.target == 'both' }}
     name: Publish Python SDK to PyPI
     runs-on: ubuntu-latest
+    environment: publish  # required-reviewer approval gate (see repo Settings → Environments)
     steps:
       - uses: actions/checkout@v6
 
@@ -48,6 +60,23 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: "3.13"
+
+      - name: Assert tag matches package version (tag push only)
+        if: ${{ github.event_name == 'push' }}
+        working-directory: sdks/python
+        run: |
+          TAG="${GITHUB_REF_NAME#v}"
+          PKG=$(python - <<'PY'
+          import tomllib
+          with open("pyproject.toml", "rb") as f:
+              print(tomllib.load(f)["project"]["version"])
+          PY
+          )
+          if [ "${TAG}" != "${PKG}" ]; then
+            echo "::error::tag v${TAG} != sdks/python version ${PKG} — refusing to publish a mismatched version"
+            exit 1
+          fi
+          echo "tag v${TAG} matches sdks/python version ${PKG}"
 
       - name: Build wheel + sdist
         working-directory: sdks/python
@@ -103,9 +132,11 @@ jobs:
         run: uv publish --trusted-publishing automatic
 
   publish-typescript:
-    if: inputs.target == 'typescript' || inputs.target == 'both'
+    # Tag push → always (target defaults to both). Manual dispatch → honor target.
+    if: ${{ github.event_name == 'push' || inputs.target == 'typescript' || inputs.target == 'both' }}
     name: Publish TypeScript SDK to npm
     runs-on: ubuntu-latest
+    environment: publish  # required-reviewer approval gate (see repo Settings → Environments)
     steps:
       - uses: actions/checkout@v6
 
@@ -119,6 +150,17 @@ jobs:
       # OIDC Trusted Publishing requires npm >= 11.5.1; Node 22 ships an older npm.
       - name: Upgrade npm (OIDC trusted publishing support)
         run: npm install -g npm@latest
+
+      - name: Assert tag matches package version (tag push only)
+        if: ${{ github.event_name == 'push' }}
+        run: |
+          TAG="${GITHUB_REF_NAME#v}"
+          PKG=$(node -p "require('./sdks/typescript/package.json').version")
+          if [ "${TAG}" != "${PKG}" ]; then
+            echo "::error::tag v${TAG} != @geolens/sdk version ${PKG} — refusing to publish a mismatched version"
+            exit 1
+          fi
+          echo "tag v${TAG} matches @geolens/sdk version ${PKG}"
 
       - name: Pre-flight version gate (@geolens/sdk on npm)
         if: ${{ !inputs.dry_run }}

--- a/.github/workflows/verify-published.yml
+++ b/.github/workflows/verify-published.yml
@@ -1,18 +1,19 @@
 # Clean-machine smoke verification of published GeoLens packages.
 #
-# Run this AFTER a release is fully published — including the *manual* PyPI/npm
-# SDK + CLI publishes (publish-sdks.yml / publish-cli.yml), which do NOT run on
-# tag push. Jobs run inside fresh Docker images (python:3.13-slim, node:22-slim)
-# — no repo context, no runner pollution; mimics what a downstream user gets.
-# Each check polls with a bounded retry to absorb registry/CDN propagation lag.
+# Runs automatically after the gated SDK/CLI publishes complete (workflow_run,
+# below), and can be run manually any time. Jobs run inside fresh Docker images
+# (python:3.13-slim, node:22-slim) — no repo context, no runner pollution; mimics
+# what a downstream user gets. Each check polls with a bounded retry to absorb
+# registry/CDN propagation lag.
 #
-# Usage:
+# Manual usage:
 #   gh workflow run verify-published.yml -f version=vX.Y.Z
 # Omit version (or pass 'latest') to verify whatever each registry calls latest.
 #
 # This intentionally does NOT trigger on `push: tags`. On a tag push the GHCR
-# images are still building and the PyPI/npm packages are not published at all
-# (manual workflow_dispatch), so an automatic run would always race and fail.
+# images are still building and the PyPI/npm publishes are still waiting on the
+# `publish` environment's approval gate, so a tag-triggered run would always
+# race/expire. Triggering after the publishes finish is the correct ordering.
 # See docs.getgeolens.com for the release runbook.
 name: Verify Published Packages
 
@@ -24,12 +25,27 @@ on:
         required: false
         type: string
         default: 'latest'
+  # Auto-run after a gated publish completes. The two publish workflows finish at
+  # different times; the concurrency group below collapses the duplicate triggers
+  # into a single verify run once both are done.
+  workflow_run:
+    workflows: ["Publish SDKs", "Publish CLI"]
+    types: [completed]
 
 permissions:
   contents: read
 
+# Collapse the two publish-completion triggers (and any manual run) for the same
+# version into one in-flight verify; a later trigger supersedes an earlier one.
+concurrency:
+  group: verify-published-${{ inputs.version || github.event.workflow_run.head_branch || github.run_id }}
+  cancel-in-progress: true
+
 env:
-  VERIFY_VERSION: ${{ inputs.version || 'latest' }}
+  # Manual dispatch → the version input. workflow_run after a tag publish →
+  # head_branch is the tag (e.g. v1.2.4), used only when it looks like a version
+  # tag; a non-tag publish (e.g. dispatched from a branch) falls back to 'latest'.
+  VERIFY_VERSION: ${{ inputs.version || (startsWith(github.event.workflow_run.head_branch, 'v') && github.event.workflow_run.head_branch) || 'latest' }}
   # Bounded retry to absorb registry/CDN propagation lag after a publish.
   # 20 × 15s ≈ 5 min ceiling per check.
   MAX_ATTEMPTS: '20'
@@ -37,6 +53,8 @@ env:
 
 jobs:
   verify-python:
+    # Manual dispatch always runs; an auto-trigger only runs if the publish succeeded.
+    if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
     name: Verify Python packages on python:3.13-slim
     runs-on: ubuntu-latest
     steps:
@@ -76,6 +94,7 @@ jobs:
           done
 
   verify-typescript:
+    if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
     name: Verify TypeScript package on node:22-slim
     runs-on: ubuntu-latest
     steps:
@@ -114,6 +133,7 @@ jobs:
           done
 
   verify-ghcr:
+    if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
     name: Verify GHCR images
     runs-on: ubuntu-latest
     steps:
@@ -145,6 +165,7 @@ jobs:
           done
 
   verify-github-release:
+    if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
     name: Verify GitHub Release
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Why

Publishing the packages (`geolens`/`geolens-cli` → PyPI, `@geolens/sdk` → npm) was a manual `workflow_dispatch` step decoupled from the tag. That's exactly what broke in v1.2.4: the Docker images + GitHub release shipped on the tag, but the packages sat a version behind until the miss surfaced as red verification checks. A release step that depends on *remembering to run four workflows* will keep biting a fast-cadence project.

Naive full-automation (auto-publish every tag) isn't the answer either — PyPI/npm versions are **write-once**, so a stray tag would permanently burn a version.

## What

Tag push fans out the publishes, but each publish job is **gated behind the `publish` environment** (required-reviewer approval). One click before anything hits a write-once registry.

|  | Forget to publish? | Accidental version burn? | Checkpoint |
|---|---|---|---|
| Before (manual) | ❌ happened in v1.2.4 | ✅ safe | 4 dispatches to remember |
| Naive auto | ✅ | ❌ stray tag = burned | none |
| **This PR** | ✅ | ✅ nothing ships without approval | **one click** |

**Changes:**
- `publish-sdks.yml` / `publish-cli.yml`: add `push: tags: v*.*.*`; add `environment: publish` to each publish job; add a **tag == manifest version guard** (refuses to publish if the tag doesn't match `pyproject.toml`/`package.json`). The existing pre-flight gate still refuses to re-publish an already-published version. `workflow_dispatch` is retained as a manual escape hatch (also gated).
- `verify-published.yml`: auto-run via `workflow_run` after the publishes complete (the approval gate makes timing unpredictable, so `push: tags` can't work — it'd expire waiting on approval). A `concurrency` group collapses the two publish-completion triggers into a single verify run; a success guard skips verification if a publish failed. Manual dispatch + bounded retry retained.

**Deliberately *not* gated:** `release.yml` (GitHub release) and `publish.yml` (GHCR images) — those artifacts are reversible/re-pushable, so they keep auto-running on tag. Only the write-once PyPI/npm publishes get the approval gate.

## New release flow

1. `git push origin vX.Y.Z` → images + GitHub release build automatically; SDK/CLI publishes **pause for approval**.
2. Approve the pending deployments (one click per publish run).
3. Verify runs automatically once the publishes finish → confirms all four artifact types.

No more manual `gh workflow run …` for publish or verify.

## Setup / reviewer notes

- ✅ The **`publish` environment** is already created with `@ishiland` as required reviewer (self-review allowed, so you can approve your own releases). Without a required reviewer the gate is a no-op, so this must stay configured: **Settings → Environments → publish**.
- ⚠️ **Untestable pre-merge:** the `push: tags` and `workflow_run` paths only activate once this is on `main`. Statically validated (actionlint clean, `bash -n` on every run block, all GHA expressions/contexts checked). The first real exercise is the next release tag — worth watching that one.
- Behavior change: a *manual* `gh workflow run publish-sdks.yml` now also pauses for approval (one extra click). Intentional — every publish goes through the gate.
- Failure modes are fail-closed: if the tag path misbehaves, it either skips publishing (degrades to today's manual dispatch) or the guard/pre-flight blocks a bad publish. Nothing publishes ungated.