### PR TITLE
ci(release): decouple publish approval gate from OIDC identity (fixes #245 review)

### DIFF
--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -34,10 +34,25 @@ permissions:
   id-token: write  # for PyPI Trusted Publishing
 
 jobs:
-  publish-cli:
-    name: Publish geolens-cli to PyPI
+  # Approval checkpoint. This is the ONLY job that targets the `publish`
+  # environment, so it alone pauses for required-reviewer approval. The publish
+  # job depends on it but deliberately does NOT set `environment:` itself —
+  # that keeps its OIDC token free of an `environment` claim, so it continues to
+  # match the PyPI trusted publisher (configured with no environment).
+  gate:
+    if: ${{ !inputs.dry_run }}
+    name: Approve release publish
     runs-on: ubuntu-latest
     environment: publish  # required-reviewer approval gate (see repo Settings → Environments)
+    steps:
+      - run: echo "Release publish approved (ref ${GITHUB_REF_NAME})"
+
+  publish-cli:
+    needs: [gate]
+    # Run after approval (gate success) or on a build-only dry run (gate skipped).
+    if: ${{ needs.gate.result == 'success' || needs.gate.result == 'skipped' }}
+    name: Publish geolens-cli to PyPI
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
 

--- a/.github/workflows/publish-sdks.yml
+++ b/.github/workflows/publish-sdks.yml
@@ -44,12 +44,26 @@ permissions:
   id-token: write  # for PyPI Trusted Publishing
 
 jobs:
-  publish-python:
-    # Tag push → always (target defaults to both). Manual dispatch → honor target.
-    if: ${{ github.event_name == 'push' || inputs.target == 'python' || inputs.target == 'both' }}
-    name: Publish Python SDK to PyPI
+  # Approval checkpoint. This is the ONLY job that targets the `publish`
+  # environment, so it alone pauses for required-reviewer approval. The publish
+  # jobs depend on it but deliberately do NOT set `environment:` themselves —
+  # that keeps their OIDC tokens free of an `environment` claim, so they continue
+  # to match the PyPI/npm trusted publishers (configured with no environment).
+  gate:
+    if: ${{ !inputs.dry_run }}
+    name: Approve release publish
     runs-on: ubuntu-latest
     environment: publish  # required-reviewer approval gate (see repo Settings → Environments)
+    steps:
+      - run: echo "Release publish approved (ref ${GITHUB_REF_NAME})"
+
+  publish-python:
+    needs: [gate]
+    # Run after approval (gate success) or on a build-only dry run (gate skipped).
+    # Tag push → always (target defaults to both). Manual dispatch → honor target.
+    if: ${{ (needs.gate.result == 'success' || needs.gate.result == 'skipped') && (github.event_name == 'push' || inputs.target == 'python' || inputs.target == 'both') }}
+    name: Publish Python SDK to PyPI
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
 
@@ -132,11 +146,12 @@ jobs:
         run: uv publish --trusted-publishing automatic
 
   publish-typescript:
+    needs: [gate]
+    # Run after approval (gate success) or on a build-only dry run (gate skipped).
     # Tag push → always (target defaults to both). Manual dispatch → honor target.
-    if: ${{ github.event_name == 'push' || inputs.target == 'typescript' || inputs.target == 'both' }}
+    if: ${{ (needs.gate.result == 'success' || needs.gate.result == 'skipped') && (github.event_name == 'push' || inputs.target == 'typescript' || inputs.target == 'both') }}
     name: Publish TypeScript SDK to npm
     runs-on: ubuntu-latest
-    environment: publish  # required-reviewer approval gate (see repo Settings → Environments)
     steps:
       - uses: actions/checkout@v6
 


### PR DESCRIPTION
## Context

Follow-up to #245. The review flagged a **P1**: putting `environment: publish` directly on the publish jobs gates them, but a GitHub deployment environment adds an `environment` claim to the job's OIDC token. npm's trusted publisher for `@geolens/sdk` is configured with **no environment** and matches the claim strictly — so the next tag release would pass approval and then **fail authentication at `npm publish`**. (PyPI is lenient about the environment claim, so the Python/CLI paths would have survived, but the npm path breaks.)

## Fix

Move the gate into a dedicated **`gate` job** — the only job that targets the `publish` environment. The publish jobs `needs: [gate]` so they still wait for approval, but no longer set `environment:` themselves, so their OIDC tokens carry **no environment claim** and keep matching the trusted publishers exactly as configured. **No PyPI/npm settings change required.**

```
gate (environment: publish)  ← pauses for required-reviewer approval
  └── publish-python   needs: [gate]   (no environment → clean OIDC)
  └── publish-typescript needs: [gate] (no environment → clean OIDC)
```

## Behavior preserved

| Path | gate | publish jobs |
|------|------|--------------|
| tag push | runs → approval required | run on approval (`gate.result == success`) |
| dispatch, real | runs → approval required | run on approval |
| dispatch, `dry_run=true` | skipped | run build-only (`gate.result == skipped`), publish steps `if: !dry_run` skip |
| approval rejected | failure | skipped (not `success`/`skipped`) |

Same one-click-per-workflow approval UX; the only change is *which* job carries the environment. actionlint clean; `bash -n` on all run blocks.