### PR TITLE
ci(release): run dry-run publish jobs past the skipped gate (fixes #246 review)

### DIFF
--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -50,7 +50,9 @@ jobs:
   publish-cli:
     needs: [gate]
     # Run after approval (gate success) or on a build-only dry run (gate skipped).
-    if: ${{ needs.gate.result == 'success' || needs.gate.result == 'skipped' }}
+    # `!cancelled()` is REQUIRED: without a status-check function the `if` gets an
+    # implicit success() that skips this job whenever a `needs` is skipped (dry run).
+    if: ${{ !cancelled() && (needs.gate.result == 'success' || needs.gate.result == 'skipped') }}
     name: Publish geolens-cli to PyPI
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/publish-sdks.yml
+++ b/.github/workflows/publish-sdks.yml
@@ -60,8 +60,10 @@ jobs:
   publish-python:
     needs: [gate]
     # Run after approval (gate success) or on a build-only dry run (gate skipped).
+    # `!cancelled()` is REQUIRED: without a status-check function the `if` gets an
+    # implicit success() that skips this job whenever gate is skipped (dry run).
     # Tag push → always (target defaults to both). Manual dispatch → honor target.
-    if: ${{ (needs.gate.result == 'success' || needs.gate.result == 'skipped') && (github.event_name == 'push' || inputs.target == 'python' || inputs.target == 'both') }}
+    if: ${{ !cancelled() && (needs.gate.result == 'success' || needs.gate.result == 'skipped') && (github.event_name == 'push' || inputs.target == 'python' || inputs.target == 'both') }}
     name: Publish Python SDK to PyPI
     runs-on: ubuntu-latest
     steps:
@@ -148,8 +150,10 @@ jobs:
   publish-typescript:
     needs: [gate]
     # Run after approval (gate success) or on a build-only dry run (gate skipped).
+    # `!cancelled()` is REQUIRED: without a status-check function the `if` gets an
+    # implicit success() that skips this job whenever gate is skipped (dry run).
     # Tag push → always (target defaults to both). Manual dispatch → honor target.
-    if: ${{ (needs.gate.result == 'success' || needs.gate.result == 'skipped') && (github.event_name == 'push' || inputs.target == 'typescript' || inputs.target == 'both') }}
+    if: ${{ !cancelled() && (needs.gate.result == 'success' || needs.gate.result == 'skipped') && (github.event_name == 'push' || inputs.target == 'typescript' || inputs.target == 'both') }}
     name: Publish TypeScript SDK to npm
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Context

Follow-up to #246 — addresses two **P2** review comments on the dry-run path.

The gate job is intentionally skipped on a build-only `dry_run=true` dispatch, and the publish jobs were meant to still run via `if: needs.gate.result == 'success' || 'skipped'`. But an `if` **without a status-check function** gets an implicit `success()` over `needs`, and a **skipped** `gate` fails that implicit check — so the publish jobs were silently **skipped** on a dry run instead of building the artifacts.

The **real release path is unaffected**: on a tag push the gate runs and succeeds after approval, so `success()` passes (that's why this is P2, not P1).

## Fix

Add `!cancelled()` to each publish job's `if`. A status-check function disables the implicit `success()`, so the explicit `needs.gate.result` logic governs:

```
if: ${{ !cancelled() && (needs.gate.result == 'success' || needs.gate.result == 'skipped') && (<target conditions>) }}
```

| Scenario | gate.result | runs? |
|----------|-------------|-------|
| tag push (approved) | success | ✅ publish |
| dispatch, real (approved) | success | ✅ publish |
| dispatch, `dry_run=true` | **skipped** | ✅ **build-only (fixed — was skipping)** |
| approval rejected | failure | ❌ skip |
| workflow cancelled | — | ❌ skip (`!cancelled()`) |

actionlint clean. Post-merge validation: `gh workflow run publish-sdks.yml --ref main -f dry_run=true` should now run the build jobs (and not require approval).