### PR TITLE
fix: large uploads wrongly capped at 10 MB behind the /api proxy

### DIFF
--- a/backend/app/api/middleware/body_limit.py
+++ b/backend/app/api/middleware/body_limit.py
@@ -11,9 +11,18 @@ admin-raised UPLOAD_MAX_SIZE_MB takes effect without a process restart.
 GAP-001 (Phase 1184): Per-route body cap. Non-upload routes get a small
 default cap (DEFAULT_BODY_LIMIT_BYTES = 10 MB). Upload/reupload routes use
 the admin-configurable UPLOAD_MAX_SIZE_MB (500 MB default) resolved via
-_get_upload_limit(). The upload route paths are detected by path-prefix match
-against UPLOAD_PATH_PREFIXES — any request whose path starts with one of
-those prefixes uses the large upload limit; all others use the small default.
+_get_upload_limit(). Upload routes are detected by path-prefix match against
+UPLOAD_PATH_PREFIXES; any request whose normalised path starts with one of
+those prefixes uses the large upload limit, all others use the small default.
+
+GAP-001 fix: the app runs with root_path="/api", but every deployment fronts
+it with a proxy that STRIPS the /api prefix before the request reaches the
+ASGI app (prod nginx `rewrite ^/api/(.*) /$1`; dev Vite proxy
+`rewrite: p.replace(/^\\/api/, '')`). So scope["path"] is the un-prefixed
+form (/ingest/upload) in real deployments, and matching against a literal
+/api/ingest/upload prefix never fired — every upload was silently capped at
+the 10 MB default. _is_upload_route now normalises away the optional /api
+prefix so the large-upload limit applies whether or not the proxy stripped it.
 
 The resolution helper `_get_upload_limit` accepts a `route_override` seam:
 
@@ -41,16 +50,33 @@ _FALLBACK_LIMIT_BYTES = 500 * 1024 * 1024  # 500 MB
 # from large-body DoS while leaving file-upload paths unrestricted).
 DEFAULT_BODY_LIMIT_BYTES = 10 * 1024 * 1024  # 10 MB
 
-# GAP-001: path prefixes that should receive the large upload limit.
-# Matches:
-#   /api/ingest/upload          — new-file upload (router prefix /ingest, path /upload*)
-#   /api/ingest/upload/presigned — presigned upload initiation
-#   /api/datasets/{id}/reupload — reupload (router prefix /datasets, path /{id}/reupload*)
-# Use lowercase; comparison below also lowercases the request path.
-UPLOAD_PATH_PREFIXES: tuple[str, ...] = (
-    "/api/ingest/upload",
-    "/api/datasets/",  # covers /{dataset_id}/reupload* paths
-)
+# GAP-001: route prefixes — AFTER the /api proxy prefix is stripped (see
+# _strip_api_prefix) — that should receive the large upload limit. Matched as
+# prefixes against the normalised request path:
+#   /ingest/upload           — new-file upload (router prefix /ingest, path /upload*)
+#   /ingest/upload/presigned — presigned upload initiation + completion
+# Reupload paths (/datasets/{id}/reupload*) carry an embedded {id} segment that a
+# plain prefix can't express, so they are matched separately in _is_upload_route.
+# Lowercase; _is_upload_route lowercases the request path before comparing.
+UPLOAD_PATH_PREFIXES: tuple[str, ...] = ("/ingest/upload",)
+
+
+def _strip_api_prefix(path: str) -> str:
+    """Strip the optional ``/api`` root_path prefix from *path*.
+
+    The app is mounted with ``root_path="/api"``, but every deployment fronts it
+    with a proxy that removes ``/api`` before the request reaches the ASGI app
+    (prod nginx ``rewrite ^/api/(.*) /$1``; dev Vite proxy
+    ``rewrite: p.replace(/^\\/api/, '')``). So ``scope["path"]`` is the
+    un-prefixed form in production, while a direct hit on the API container keeps
+    the prefix. Normalising both to the un-prefixed form lets the upload-route
+    classifier fire in every case. Expects an already-lowercased path.
+    """
+    if path.startswith("/api/"):
+        return path[len("/api") :]  # drop "/api", keep the leading slash
+    if path == "/api":
+        return "/"
+    return path
 
 
 def _is_upload_route(path: str) -> bool:
@@ -58,19 +84,22 @@ def _is_upload_route(path: str) -> bool:
 
     GAP-001: upload routes need the large UPLOAD_MAX_SIZE_MB limit; all other
     routes get DEFAULT_BODY_LIMIT_BYTES.  The match is deliberately liberal on
-    /api/datasets/ — only reupload paths POST a large body, but the other
-    dataset paths post small JSON.  Restricting /api/datasets/ further would
-    require parsing the path segments; accepting a slightly wider match is safe
-    because the body check is still bounded by UPLOAD_MAX_SIZE_MB (500 MB).
-    We keep the match simple and correct for the actual upload paths.
+    /datasets/ — only reupload paths POST a large body, but the other dataset
+    paths post small JSON.  Restricting /datasets/ further would require parsing
+    the path segments; accepting a slightly wider match is safe because the body
+    check is still bounded by UPLOAD_MAX_SIZE_MB (500 MB).
+
+    The optional ``/api`` prefix is normalised away first (see _strip_api_prefix)
+    so the classifier fires on the proxy-stripped paths real deployments produce,
+    not just on a direct hit against the API container.
     """
-    lower = path.lower()
-    # /api/ingest/upload* — all upload-initiation paths
-    if lower.startswith("/api/ingest/upload"):
+    norm = _strip_api_prefix(path.lower())
+    # /ingest/upload* — all upload-initiation paths (new upload, presigned, complete)
+    if any(norm.startswith(prefix) for prefix in UPLOAD_PATH_PREFIXES):
         return True
-    # /api/datasets/{id}/reupload* — dataset reupload paths
+    # /datasets/{id}/reupload* — dataset reupload paths
     # Match the literal "/reupload" segment inside a /datasets/... path.
-    if lower.startswith("/api/datasets/") and "/reupload" in lower:
+    if norm.startswith("/datasets/") and "/reupload" in norm:
         return True
     return False
 

--- a/backend/app/api/middleware/body_limit.py
+++ b/backend/app/api/middleware/body_limit.py
@@ -34,6 +34,7 @@ The resolution helper `_get_upload_limit` accepts a `route_override` seam:
 """
 
 import time
+import uuid
 from typing import Any
 
 from starlette.responses import JSONResponse
@@ -62,13 +63,24 @@ def _strip_api_prefix(path: str) -> str:
     ``rewrite: p.replace(/^\\/api/, '')``). So ``scope["path"]`` is the
     un-prefixed form in production, while a direct hit on the API container keeps
     the prefix. Normalising both to the un-prefixed form lets the upload-route
-    classifier fire in every case. Expects an already-lowercased path.
+    classifier fire in every case. The prefix match is case-sensitive, mirroring
+    the proxy rewrites and FastAPI's case-sensitive routing.
     """
     if path.startswith("/api/"):
         return path[len("/api") :]  # drop "/api", keep the leading slash
     if path == "/api":
         return "/"
     return path
+
+
+def _is_uuid(value: str) -> bool:
+    """True if *value* parses as a UUID — mirrors the ``dataset_id: uuid.UUID``
+    path parameter on the reupload route (FastAPI 422s a non-UUID segment)."""
+    try:
+        uuid.UUID(value)
+    except ValueError:
+        return False
+    return True
 
 
 def _is_upload_route(path: str, method: str = "POST") -> bool:
@@ -94,22 +106,30 @@ def _is_upload_route(path: str, method: str = "POST") -> bool:
 
     The optional ``/api`` prefix is normalised away first (see _strip_api_prefix)
     so the classifier fires on the proxy-stripped paths real deployments produce,
-    not just on a direct hit against the API container. The match is exact: both
-    routes are registered WITHOUT a trailing slash and the app runs with
-    redirect_slashes=False plus no trailing-slash alias, so a trailing-slash
-    variant (/ingest/upload/) 404s — it must stay on the default cap, not be
-    handed the large allowance ahead of that 404 (PR #249 review).
+    not just on a direct hit against the API container. The match mirrors FastAPI
+    routing EXACTLY so the large cap is never handed to a request routing will
+    reject anyway: case-sensitive, no trailing slash (the routes are registered
+    no-slash with redirect_slashes=False and no reverse alias), and the reupload
+    dataset_id must parse as a UUID (the path param is typed uuid.UUID). Each
+    otherwise let a variant that 404s/422s receive the large allowance (PR #249
+    review rounds).
     """
     if method.upper() != "POST":
         return False
-    norm = _strip_api_prefix(path.lower())
+    norm = _strip_api_prefix(path)
     # POST /ingest/upload — the multipart new-file upload (NOT /upload/presigned*).
     if norm == "/ingest/upload":
         return True
     # POST /datasets/{dataset_id}/reupload — the multipart reupload. Match exactly
-    # /datasets/<one-segment>/reupload, excluding the JSON sub-routes beneath it.
+    # /datasets/<uuid>/reupload: a non-UUID segment 422s and the JSON sub-routes
+    # beneath it (presigned/commit/preview) carry only small JSON.
     segments = norm.split("/")
-    if len(segments) == 4 and segments[1] == "datasets" and segments[3] == "reupload":
+    if (
+        len(segments) == 4
+        and segments[1] == "datasets"
+        and segments[3] == "reupload"
+        and _is_uuid(segments[2])
+    ):
         return True
     return False
 

--- a/backend/app/api/middleware/body_limit.py
+++ b/backend/app/api/middleware/body_limit.py
@@ -71,8 +71,8 @@ def _strip_api_prefix(path: str) -> str:
     return path
 
 
-def _is_upload_route(path: str) -> bool:
-    """Return True only for the endpoints that actually receive file BYTES.
+def _is_upload_route(path: str, method: str = "POST") -> bool:
+    """Return True only for the two POST endpoints that receive file BYTES.
 
     GAP-001: file-upload routes need the large UPLOAD_MAX_SIZE_MB limit; every
     other route gets DEFAULT_BODY_LIMIT_BYTES so a large body cannot slip past
@@ -87,11 +87,18 @@ def _is_upload_route(path: str) -> bool:
     prefix and "/reupload"-substring match let a 500 MB JSON body through on
     those routes).
 
+    Both upload endpoints are POST-only, so the method is part of the match: a
+    non-POST request to the same path (e.g. PUT /ingest/upload) would otherwise
+    get the large cap and be rejected only as 405 *after* the large body was
+    allowed through (PR #249 review).
+
     The optional ``/api`` prefix is normalised away first (see _strip_api_prefix)
     so the classifier fires on the proxy-stripped paths real deployments produce,
     not just on a direct hit against the API container. A trailing slash is
     ignored — FastAPI resolves both shapes (redirect_slashes=False).
     """
+    if method.upper() != "POST":
+        return False
     norm = _strip_api_prefix(path.lower()).rstrip("/")
     # POST /ingest/upload — the multipart new-file upload (NOT /upload/presigned*).
     if norm == "/ingest/upload":
@@ -188,7 +195,8 @@ class RequestBodyLimitMiddleware:
         await _refresh_limit_cache()
 
         path = scope.get("path", "")
-        if _is_upload_route(path):
+        method = scope.get("method", "")
+        if _is_upload_route(path, method):
             # Upload/reupload: use the admin-configurable limit (500 MB default)
             max_bytes = _get_upload_limit()
         else:

--- a/backend/app/api/middleware/body_limit.py
+++ b/backend/app/api/middleware/body_limit.py
@@ -9,11 +9,13 @@ cached PersistentConfig value instead of the boot-time env value, so an
 admin-raised UPLOAD_MAX_SIZE_MB takes effect without a process restart.
 
 GAP-001 (Phase 1184): Per-route body cap. Non-upload routes get a small
-default cap (DEFAULT_BODY_LIMIT_BYTES = 10 MB). Upload/reupload routes use
-the admin-configurable UPLOAD_MAX_SIZE_MB (500 MB default) resolved via
-_get_upload_limit(). Upload routes are detected by path-prefix match against
-UPLOAD_PATH_PREFIXES; any request whose normalised path starts with one of
-those prefixes uses the large upload limit, all others use the small default.
+default cap (DEFAULT_BODY_LIMIT_BYTES = 10 MB). Only the two endpoints that
+stream a multipart file body — POST /ingest/upload and POST
+/datasets/{id}/reupload — get the admin-configurable UPLOAD_MAX_SIZE_MB
+(500 MB default) resolved via _get_upload_limit(). Everything else, including
+the JSON-only presigned / commit / preview sub-routes of those flows, stays on
+the small default so a large JSON body cannot slip past the DoS cap (PR #249
+review).
 
 GAP-001 fix: the app runs with root_path="/api", but every deployment fronts
 it with a proxy that STRIPS the /api prefix before the request reaches the
@@ -21,8 +23,8 @@ ASGI app (prod nginx `rewrite ^/api/(.*) /$1`; dev Vite proxy
 `rewrite: p.replace(/^\\/api/, '')`). So scope["path"] is the un-prefixed
 form (/ingest/upload) in real deployments, and matching against a literal
 /api/ingest/upload prefix never fired — every upload was silently capped at
-the 10 MB default. _is_upload_route now normalises away the optional /api
-prefix so the large-upload limit applies whether or not the proxy stripped it.
+the 10 MB default. _is_upload_route normalises away the optional /api prefix
+so the limit applies whether or not the proxy stripped it.
 
 The resolution helper `_get_upload_limit` accepts a `route_override` seam:
 
@@ -50,16 +52,6 @@ _FALLBACK_LIMIT_BYTES = 500 * 1024 * 1024  # 500 MB
 # from large-body DoS while leaving file-upload paths unrestricted).
 DEFAULT_BODY_LIMIT_BYTES = 10 * 1024 * 1024  # 10 MB
 
-# GAP-001: route prefixes — AFTER the /api proxy prefix is stripped (see
-# _strip_api_prefix) — that should receive the large upload limit. Matched as
-# prefixes against the normalised request path:
-#   /ingest/upload           — new-file upload (router prefix /ingest, path /upload*)
-#   /ingest/upload/presigned — presigned upload initiation + completion
-# Reupload paths (/datasets/{id}/reupload*) carry an embedded {id} segment that a
-# plain prefix can't express, so they are matched separately in _is_upload_route.
-# Lowercase; _is_upload_route lowercases the request path before comparing.
-UPLOAD_PATH_PREFIXES: tuple[str, ...] = ("/ingest/upload",)
-
 
 def _strip_api_prefix(path: str) -> str:
     """Strip the optional ``/api`` root_path prefix from *path*.
@@ -80,26 +72,34 @@ def _strip_api_prefix(path: str) -> str:
 
 
 def _is_upload_route(path: str) -> bool:
-    """Return True if *path* is an upload or reupload endpoint.
+    """Return True only for the endpoints that actually receive file BYTES.
 
-    GAP-001: upload routes need the large UPLOAD_MAX_SIZE_MB limit; all other
-    routes get DEFAULT_BODY_LIMIT_BYTES.  The match is deliberately liberal on
-    /datasets/ — only reupload paths POST a large body, but the other dataset
-    paths post small JSON.  Restricting /datasets/ further would require parsing
-    the path segments; accepting a slightly wider match is safe because the body
-    check is still bounded by UPLOAD_MAX_SIZE_MB (500 MB).
+    GAP-001: file-upload routes need the large UPLOAD_MAX_SIZE_MB limit; every
+    other route gets DEFAULT_BODY_LIMIT_BYTES so a large body cannot slip past
+    the DoS cap. Exactly two endpoints stream a multipart file body:
+
+        POST /ingest/upload                   (ingest.upload_file)
+        POST /datasets/{dataset_id}/reupload  (datasets.reupload_dataset)
+
+    The presigned initiate/complete, commit and preview sub-routes of those two
+    flows carry only small JSON — the bytes go straight to object storage — so
+    they stay on the default cap (PR #249 review: the previous /ingest/upload*
+    prefix and "/reupload"-substring match let a 500 MB JSON body through on
+    those routes).
 
     The optional ``/api`` prefix is normalised away first (see _strip_api_prefix)
     so the classifier fires on the proxy-stripped paths real deployments produce,
-    not just on a direct hit against the API container.
+    not just on a direct hit against the API container. A trailing slash is
+    ignored — FastAPI resolves both shapes (redirect_slashes=False).
     """
-    norm = _strip_api_prefix(path.lower())
-    # /ingest/upload* — all upload-initiation paths (new upload, presigned, complete)
-    if any(norm.startswith(prefix) for prefix in UPLOAD_PATH_PREFIXES):
+    norm = _strip_api_prefix(path.lower()).rstrip("/")
+    # POST /ingest/upload — the multipart new-file upload (NOT /upload/presigned*).
+    if norm == "/ingest/upload":
         return True
-    # /datasets/{id}/reupload* — dataset reupload paths
-    # Match the literal "/reupload" segment inside a /datasets/... path.
-    if norm.startswith("/datasets/") and "/reupload" in norm:
+    # POST /datasets/{dataset_id}/reupload — the multipart reupload. Match exactly
+    # /datasets/<one-segment>/reupload, excluding the JSON sub-routes beneath it.
+    segments = norm.split("/")
+    if len(segments) == 4 and segments[1] == "datasets" and segments[3] == "reupload":
         return True
     return False
 

--- a/backend/app/api/middleware/body_limit.py
+++ b/backend/app/api/middleware/body_limit.py
@@ -94,12 +94,15 @@ def _is_upload_route(path: str, method: str = "POST") -> bool:
 
     The optional ``/api`` prefix is normalised away first (see _strip_api_prefix)
     so the classifier fires on the proxy-stripped paths real deployments produce,
-    not just on a direct hit against the API container. A trailing slash is
-    ignored — FastAPI resolves both shapes (redirect_slashes=False).
+    not just on a direct hit against the API container. The match is exact: both
+    routes are registered WITHOUT a trailing slash and the app runs with
+    redirect_slashes=False plus no trailing-slash alias, so a trailing-slash
+    variant (/ingest/upload/) 404s — it must stay on the default cap, not be
+    handed the large allowance ahead of that 404 (PR #249 review).
     """
     if method.upper() != "POST":
         return False
-    norm = _strip_api_prefix(path.lower()).rstrip("/")
+    norm = _strip_api_prefix(path.lower())
     # POST /ingest/upload — the multipart new-file upload (NOT /upload/presigned*).
     if norm == "/ingest/upload":
         return True

--- a/backend/tests/test_1184_body_limit_per_route.py
+++ b/backend/tests/test_1184_body_limit_per_route.py
@@ -77,6 +77,49 @@ class TestIsUploadRoute:
         assert _is_upload_route("/API/DATASETS/ABC/REUPLOAD") is True
 
 
+class TestIsUploadRouteProxyStripped:
+    """The /api prefix is stripped by both proxies before the app sees the path.
+
+    Regression for the GAP-001 fix: prod nginx (`rewrite ^/api/(.*) /$1`) and the
+    dev Vite proxy (`rewrite: p.replace(/^\\/api/, '')`) both remove `/api`, so
+    in every real deployment scope["path"] is the un-prefixed form. Matching only
+    the `/api/...` prefix never fired, silently capping uploads at 10 MB. The
+    classifier must recognise the stripped form too.
+    """
+
+    def test_stripped_ingest_upload_is_upload(self):
+        assert _is_upload_route("/ingest/upload") is True
+
+    def test_stripped_ingest_upload_presigned_is_upload(self):
+        assert _is_upload_route("/ingest/upload/presigned") is True
+
+    def test_stripped_ingest_upload_complete_is_upload(self):
+        assert _is_upload_route("/ingest/upload/presigned/some-job-id/complete") is True
+
+    def test_stripped_datasets_reupload_is_upload(self):
+        assert _is_upload_route("/datasets/abc123/reupload") is True
+
+    def test_stripped_datasets_reupload_presigned_is_upload(self):
+        assert _is_upload_route("/datasets/abc123/reupload/presigned") is True
+
+    def test_stripped_case_insensitive(self):
+        assert _is_upload_route("/INGEST/UPLOAD") is True
+        assert _is_upload_route("/DATASETS/ABC/REUPLOAD") is True
+
+    # Stripped non-upload paths must NOT over-match (still get the 10 MB cap).
+    def test_stripped_datasets_list_is_not_upload(self):
+        assert _is_upload_route("/datasets/") is False
+
+    def test_stripped_datasets_detail_is_not_upload(self):
+        assert _is_upload_route("/datasets/abc123") is False
+
+    def test_stripped_maps_is_not_upload(self):
+        assert _is_upload_route("/maps") is False
+
+    def test_stripped_ingest_non_upload_is_not_upload(self):
+        assert _is_upload_route("/ingest/commit/some-job-id") is False
+
+
 # ---------------------------------------------------------------------------
 # Unit tests: _get_upload_limit with route_override
 # ---------------------------------------------------------------------------
@@ -155,6 +198,35 @@ class TestGap001PerRouteBodyCap:
         assert resp.status_code != 413, (
             "GAP-001: upload route with 11 MB body must not be 413 from body limit; "
             f"got {resp.status_code}. Upload routes use UPLOAD_MAX_SIZE_MB (500 MB)."
+        )
+
+    @pytest.mark.anyio
+    async def test_proxy_stripped_upload_route_over_10mb_is_not_413(
+        self, client: AsyncClient
+    ):
+        """The /api-stripped upload path must ALSO get the large upload limit.
+
+        Deployment regression for the GAP-001 fix: both the prod nginx and the
+        dev Vite proxy strip /api, so the app receives /ingest/upload (not
+        /api/ingest/upload). Before the fix this missed the upload allowlist and
+        an 11 MB body → 413, silently capping every real-deployment upload at
+        10 MB. It must now pass the body limit (downstream auth may still reject
+        with 401/422 — but not 413). This test FAILS pre-fix, PASSES post-fix.
+        """
+        high_limit = 500 * 1024 * 1024  # 500 MB
+        with patch(
+            "app.api.middleware.body_limit._limit_cache",
+            (float("inf"), high_limit),
+        ):
+            resp = await client.post(
+                "/ingest/upload",
+                content=b"x",
+                headers={"Content-Length": str(_11MB)},
+            )
+        assert resp.status_code != 413, (
+            "GAP-001 fix: proxy-stripped upload path (/ingest/upload) with 11 MB "
+            f"body must not be 413; got {resp.status_code}. Both proxies strip "
+            "/api, so this is the path real deployments actually produce."
         )
 
     @pytest.mark.anyio

--- a/backend/tests/test_1184_body_limit_per_route.py
+++ b/backend/tests/test_1184_body_limit_per_route.py
@@ -47,9 +47,11 @@ class TestIsUploadRoute:
     def test_datasets_reupload_is_upload(self):
         assert _is_upload_route("/api/datasets/abc123/reupload") is True
 
-    def test_trailing_slash_ignored(self):
-        assert _is_upload_route("/api/ingest/upload/") is True
-        assert _is_upload_route("/api/datasets/abc123/reupload/") is True
+    def test_trailing_slash_is_not_upload(self):
+        # Registered no-slash with redirect_slashes=False (no alias), so the
+        # trailing-slash variant 404s — it must NOT get the large cap (PR #249).
+        assert _is_upload_route("/api/ingest/upload/") is False
+        assert _is_upload_route("/api/datasets/abc123/reupload/") is False
 
     def test_case_insensitive(self):
         assert _is_upload_route("/API/INGEST/UPLOAD") is True
@@ -130,9 +132,9 @@ class TestIsUploadRouteProxyStripped:
     def test_stripped_datasets_reupload_is_upload(self):
         assert _is_upload_route("/datasets/abc123/reupload") is True
 
-    def test_stripped_trailing_slash_ignored(self):
-        assert _is_upload_route("/ingest/upload/") is True
-        assert _is_upload_route("/datasets/abc123/reupload/") is True
+    def test_stripped_trailing_slash_is_not_upload(self):
+        assert _is_upload_route("/ingest/upload/") is False
+        assert _is_upload_route("/datasets/abc123/reupload/") is False
 
     def test_stripped_case_insensitive(self):
         assert _is_upload_route("/INGEST/UPLOAD") is True
@@ -299,6 +301,28 @@ class TestGap001PerRouteBodyCap:
         assert resp.status_code == 413, (
             "PR #249: non-POST to an upload path with 11 MB must hit the 10 MB "
             f"default cap (413), not the large upload cap; got {resp.status_code}"
+        )
+
+    @pytest.mark.anyio
+    async def test_trailing_slash_upload_path_over_10mb_is_413(
+        self, client: AsyncClient
+    ):
+        """A trailing-slash upload path (which 404s) must hit the default cap.
+
+        PR #249 review: /ingest/upload/ is not a registered route
+        (redirect_slashes=False, no trailing-slash alias). Before the exact match
+        it got the 500 MB cap and the body was allowed through ahead of the 404;
+        now it falls back to the 10 MB default. FAILS pre-fix (404), PASSES
+        post-fix (413).
+        """
+        resp = await client.post(
+            "/ingest/upload/",
+            content=b"x",
+            headers={"Content-Length": str(_11MB)},
+        )
+        assert resp.status_code == 413, (
+            "PR #249: trailing-slash upload path with 11 MB must hit the 10 MB "
+            f"default cap (413), not the large cap ahead of a 404; got {resp.status_code}"
         )
 
     @pytest.mark.anyio

--- a/backend/tests/test_1184_body_limit_per_route.py
+++ b/backend/tests/test_1184_body_limit_per_route.py
@@ -26,6 +26,10 @@ from app.api.middleware.body_limit import (
 
 _11MB = 11 * 1024 * 1024  # 11 MB — over the 10 MB default cap
 
+# A valid dataset UUID for the reupload route (dataset_id: uuid.UUID). A non-UUID
+# segment is NOT matched — FastAPI 422s it — see the non_uuid_reupload tests.
+_UUID = "12345678-1234-5678-1234-567812345678"
+
 
 # ---------------------------------------------------------------------------
 # Unit tests: _is_upload_route path classifier
@@ -35,9 +39,12 @@ _11MB = 11 * 1024 * 1024  # 11 MB — over the 10 MB default cap
 class TestIsUploadRoute:
     """_is_upload_route matches ONLY the two multipart file-byte endpoints.
 
-    POST /ingest/upload and POST /datasets/{id}/reupload stream file bytes and get
-    the large cap; the JSON-only presigned/commit/preview sub-routes of those
-    flows — and everything else — stay on the default 10 MB cap (PR #249 review).
+    POST /ingest/upload and POST /datasets/{uuid}/reupload stream file bytes and
+    get the large cap. Everything else — the JSON-only presigned/commit/preview
+    sub-routes, non-POST methods, trailing-slash or wrong-case variants, and
+    non-UUID dataset segments — stays on the default 10 MB cap. The match mirrors
+    FastAPI routing exactly so the large cap never reaches a request routing will
+    reject (PR #249 review rounds).
     """
 
     # --- the two real file-upload endpoints get the large cap ---
@@ -45,33 +52,40 @@ class TestIsUploadRoute:
         assert _is_upload_route("/api/ingest/upload") is True
 
     def test_datasets_reupload_is_upload(self):
-        assert _is_upload_route("/api/datasets/abc123/reupload") is True
-
-    def test_trailing_slash_is_not_upload(self):
-        # Registered no-slash with redirect_slashes=False (no alias), so the
-        # trailing-slash variant 404s — it must NOT get the large cap (PR #249).
-        assert _is_upload_route("/api/ingest/upload/") is False
-        assert _is_upload_route("/api/datasets/abc123/reupload/") is False
-
-    def test_case_insensitive(self):
-        assert _is_upload_route("/API/INGEST/UPLOAD") is True
-        assert _is_upload_route("/API/DATASETS/ABC/REUPLOAD") is True
-
-    # --- the upload endpoints are POST-only; a non-POST request to the same path
-    # is NOT a file upload and must fall back to the default cap (PR #249 review,
-    # else a large body slips past the cap before the 405). ---
-    def test_non_post_method_is_not_upload(self):
-        assert _is_upload_route("/api/ingest/upload", "GET") is False
-        assert _is_upload_route("/api/ingest/upload", "PUT") is False
-        assert _is_upload_route("/api/datasets/abc123/reupload", "GET") is False
-        assert _is_upload_route("/api/datasets/abc123/reupload", "HEAD") is False
+        assert _is_upload_route(f"/api/datasets/{_UUID}/reupload") is True
 
     def test_post_method_is_upload(self):
         assert _is_upload_route("/api/ingest/upload", "POST") is True
-        assert _is_upload_route("/api/datasets/abc123/reupload", "POST") is True
-        assert (
-            _is_upload_route("/api/ingest/upload", "post") is True
-        )  # case-insensitive
+        assert _is_upload_route(f"/api/datasets/{_UUID}/reupload", "POST") is True
+        # HTTP methods are upper-case over ASGI; tolerate any case defensively.
+        assert _is_upload_route("/api/ingest/upload", "post") is True
+
+    # --- trailing slash: routes are registered no-slash (redirect_slashes=False,
+    # no reverse alias), so the slash variant 404s and stays on the default cap. ---
+    def test_trailing_slash_is_not_upload(self):
+        assert _is_upload_route("/api/ingest/upload/") is False
+        assert _is_upload_route(f"/api/datasets/{_UUID}/reupload/") is False
+
+    # --- case-sensitive, like FastAPI routing: an upper-case variant 404s, so it
+    # must NOT get the large cap (PR #249 review). ---
+    def test_uppercase_path_is_not_upload(self):
+        assert _is_upload_route("/API/INGEST/UPLOAD") is False
+        assert _is_upload_route(f"/api/datasets/{_UUID}/REUPLOAD") is False
+        assert _is_upload_route("/api/INGEST/upload") is False
+
+    # --- non-POST methods 405 on these paths, so they stay on the default cap. ---
+    def test_non_post_method_is_not_upload(self):
+        assert _is_upload_route("/api/ingest/upload", "GET") is False
+        assert _is_upload_route("/api/ingest/upload", "PUT") is False
+        assert _is_upload_route(f"/api/datasets/{_UUID}/reupload", "GET") is False
+        assert _is_upload_route(f"/api/datasets/{_UUID}/reupload", "HEAD") is False
+
+    # --- reupload dataset_id is typed uuid.UUID: a non-UUID segment 422s, so it
+    # must stay on the default cap (PR #249 review). ---
+    def test_non_uuid_reupload_is_not_upload(self):
+        assert _is_upload_route("/api/datasets/not-a-uuid/reupload") is False
+        assert _is_upload_route("/api/datasets/abc123/reupload") is False
+        assert _is_upload_route("/api/datasets//reupload") is False
 
     # --- JSON-only sub-routes of the upload/reupload flows are NOT file uploads
     # (PR #249 review): the bytes go straight to object storage, so a large JSON
@@ -86,14 +100,16 @@ class TestIsUploadRoute:
         )
 
     def test_datasets_reupload_presigned_is_not_upload(self):
-        assert _is_upload_route("/api/datasets/abc123/reupload/presigned") is False
+        assert _is_upload_route(f"/api/datasets/{_UUID}/reupload/presigned") is False
 
     def test_datasets_reupload_commit_is_not_upload(self):
-        assert _is_upload_route("/api/datasets/abc123/reupload/job-id/commit") is False
+        assert (
+            _is_upload_route(f"/api/datasets/{_UUID}/reupload/job-id/commit") is False
+        )
 
     def test_datasets_reupload_service_preview_is_not_upload(self):
         assert (
-            _is_upload_route("/api/datasets/abc123/reupload/service/preview") is False
+            _is_upload_route(f"/api/datasets/{_UUID}/reupload/service/preview") is False
         )
 
     # --- other non-upload routes ---
@@ -105,7 +121,7 @@ class TestIsUploadRoute:
         assert _is_upload_route("/api/datasets/") is False
 
     def test_api_datasets_detail_is_not_upload(self):
-        assert _is_upload_route("/api/datasets/abc123") is False
+        assert _is_upload_route(f"/api/datasets/{_UUID}") is False
 
     def test_api_maps_is_not_upload(self):
         assert _is_upload_route("/api/maps") is False
@@ -130,20 +146,25 @@ class TestIsUploadRouteProxyStripped:
         assert _is_upload_route("/ingest/upload") is True
 
     def test_stripped_datasets_reupload_is_upload(self):
-        assert _is_upload_route("/datasets/abc123/reupload") is True
+        assert _is_upload_route(f"/datasets/{_UUID}/reupload") is True
 
+    # --- same exact-match exclusions on the stripped form ---
     def test_stripped_trailing_slash_is_not_upload(self):
         assert _is_upload_route("/ingest/upload/") is False
-        assert _is_upload_route("/datasets/abc123/reupload/") is False
+        assert _is_upload_route(f"/datasets/{_UUID}/reupload/") is False
 
-    def test_stripped_case_insensitive(self):
-        assert _is_upload_route("/INGEST/UPLOAD") is True
-        assert _is_upload_route("/DATASETS/ABC/REUPLOAD") is True
+    def test_stripped_uppercase_is_not_upload(self):
+        assert _is_upload_route("/INGEST/UPLOAD") is False
+        assert _is_upload_route(f"/datasets/{_UUID}/REUPLOAD") is False
 
     def test_stripped_non_post_method_is_not_upload(self):
         assert _is_upload_route("/ingest/upload", "GET") is False
         assert _is_upload_route("/ingest/upload", "PUT") is False
-        assert _is_upload_route("/datasets/abc123/reupload", "DELETE") is False
+        assert _is_upload_route(f"/datasets/{_UUID}/reupload", "DELETE") is False
+
+    def test_stripped_non_uuid_reupload_is_not_upload(self):
+        assert _is_upload_route("/datasets/not-a-uuid/reupload") is False
+        assert _is_upload_route("/datasets/abc123/reupload") is False
 
     # --- stripped JSON sub-routes must NOT get the large cap (PR #249 review) ---
     def test_stripped_ingest_upload_presigned_is_not_upload(self):
@@ -155,17 +176,17 @@ class TestIsUploadRouteProxyStripped:
         )
 
     def test_stripped_datasets_reupload_presigned_is_not_upload(self):
-        assert _is_upload_route("/datasets/abc123/reupload/presigned") is False
+        assert _is_upload_route(f"/datasets/{_UUID}/reupload/presigned") is False
 
     def test_stripped_datasets_reupload_commit_is_not_upload(self):
-        assert _is_upload_route("/datasets/abc123/reupload/job-id/commit") is False
+        assert _is_upload_route(f"/datasets/{_UUID}/reupload/job-id/commit") is False
 
     # --- stripped non-upload paths must NOT over-match (still get the 10 MB cap) ---
     def test_stripped_datasets_list_is_not_upload(self):
         assert _is_upload_route("/datasets/") is False
 
     def test_stripped_datasets_detail_is_not_upload(self):
-        assert _is_upload_route("/datasets/abc123") is False
+        assert _is_upload_route(f"/datasets/{_UUID}") is False
 
     def test_stripped_maps_is_not_upload(self):
         assert _is_upload_route("/maps") is False
@@ -323,6 +344,25 @@ class TestGap001PerRouteBodyCap:
         assert resp.status_code == 413, (
             "PR #249: trailing-slash upload path with 11 MB must hit the 10 MB "
             f"default cap (413), not the large cap ahead of a 404; got {resp.status_code}"
+        )
+
+    @pytest.mark.anyio
+    async def test_non_uuid_reupload_path_over_10mb_is_413(self, client: AsyncClient):
+        """A non-UUID reupload path (which 422s) must hit the default cap.
+
+        PR #249 review: dataset_id is typed uuid.UUID, so
+        /datasets/not-a-uuid/reupload 422s. Before the UUID check it got the
+        500 MB cap; now it falls back to the 10 MB default. FAILS pre-fix (422),
+        PASSES post-fix (413).
+        """
+        resp = await client.post(
+            "/datasets/not-a-uuid/reupload",
+            content=b"x",
+            headers={"Content-Length": str(_11MB)},
+        )
+        assert resp.status_code == 413, (
+            "PR #249: non-UUID reupload path with 11 MB must hit the 10 MB default "
+            f"cap (413), not the large cap ahead of a 422; got {resp.status_code}"
         )
 
     @pytest.mark.anyio

--- a/backend/tests/test_1184_body_limit_per_route.py
+++ b/backend/tests/test_1184_body_limit_per_route.py
@@ -55,6 +55,22 @@ class TestIsUploadRoute:
         assert _is_upload_route("/API/INGEST/UPLOAD") is True
         assert _is_upload_route("/API/DATASETS/ABC/REUPLOAD") is True
 
+    # --- the upload endpoints are POST-only; a non-POST request to the same path
+    # is NOT a file upload and must fall back to the default cap (PR #249 review,
+    # else a large body slips past the cap before the 405). ---
+    def test_non_post_method_is_not_upload(self):
+        assert _is_upload_route("/api/ingest/upload", "GET") is False
+        assert _is_upload_route("/api/ingest/upload", "PUT") is False
+        assert _is_upload_route("/api/datasets/abc123/reupload", "GET") is False
+        assert _is_upload_route("/api/datasets/abc123/reupload", "HEAD") is False
+
+    def test_post_method_is_upload(self):
+        assert _is_upload_route("/api/ingest/upload", "POST") is True
+        assert _is_upload_route("/api/datasets/abc123/reupload", "POST") is True
+        assert (
+            _is_upload_route("/api/ingest/upload", "post") is True
+        )  # case-insensitive
+
     # --- JSON-only sub-routes of the upload/reupload flows are NOT file uploads
     # (PR #249 review): the bytes go straight to object storage, so a large JSON
     # body on these routes must be stopped by the default cap. ---
@@ -121,6 +137,11 @@ class TestIsUploadRouteProxyStripped:
     def test_stripped_case_insensitive(self):
         assert _is_upload_route("/INGEST/UPLOAD") is True
         assert _is_upload_route("/DATASETS/ABC/REUPLOAD") is True
+
+    def test_stripped_non_post_method_is_not_upload(self):
+        assert _is_upload_route("/ingest/upload", "GET") is False
+        assert _is_upload_route("/ingest/upload", "PUT") is False
+        assert _is_upload_route("/datasets/abc123/reupload", "DELETE") is False
 
     # --- stripped JSON sub-routes must NOT get the large cap (PR #249 review) ---
     def test_stripped_ingest_upload_presigned_is_not_upload(self):
@@ -258,6 +279,26 @@ class TestGap001PerRouteBodyCap:
             "GAP-001 fix: proxy-stripped upload path (/ingest/upload) with 11 MB "
             f"body must not be 413; got {resp.status_code}. Both proxies strip "
             "/api, so this is the path real deployments actually produce."
+        )
+
+    @pytest.mark.anyio
+    async def test_non_post_to_upload_path_over_10mb_is_413(self, client: AsyncClient):
+        """A non-POST request to an upload PATH must hit the 10 MB default cap.
+
+        PR #249 review: the upload endpoints are POST-only. Before the method
+        gate, PUT /ingest/upload with 11 MB got the 500 MB cap and was rejected
+        only as 405 *after* the body was allowed through; now it falls back to the
+        10 MB default and is stopped at the body limit. FAILS pre-fix (405),
+        PASSES post-fix (413).
+        """
+        resp = await client.put(
+            "/ingest/upload",
+            content=b"x",
+            headers={"Content-Length": str(_11MB)},
+        )
+        assert resp.status_code == 413, (
+            "PR #249: non-POST to an upload path with 11 MB must hit the 10 MB "
+            f"default cap (413), not the large upload cap; got {resp.status_code}"
         )
 
     @pytest.mark.anyio

--- a/backend/tests/test_1184_body_limit_per_route.py
+++ b/backend/tests/test_1184_body_limit_per_route.py
@@ -4,8 +4,9 @@ GAP-001: Non-upload routes must enforce a small default cap (10 MB);
          upload/reupload routes must allow up to the configured upload max.
 
 Design:
-  - The middleware now detects upload routes by path-prefix and applies either
-    DEFAULT_BODY_LIMIT_BYTES (10 MB) or the cached UPLOAD_MAX_SIZE_MB limit.
+  - The middleware grants the large UPLOAD_MAX_SIZE_MB limit to exactly the two
+    multipart file endpoints (/ingest/upload, /datasets/{id}/reupload) and the
+    small DEFAULT_BODY_LIMIT_BYTES (10 MB) to everything else.
   - We verify the RED case (non-upload with 11 MB → 413) and the GREEN case
     (upload path with 11 MB → NOT 413) without needing a real file upload.
 """
@@ -32,29 +33,52 @@ _11MB = 11 * 1024 * 1024  # 11 MB — over the 10 MB default cap
 
 
 class TestIsUploadRoute:
-    """_is_upload_route must correctly classify upload vs non-upload paths."""
+    """_is_upload_route matches ONLY the two multipart file-byte endpoints.
 
+    POST /ingest/upload and POST /datasets/{id}/reupload stream file bytes and get
+    the large cap; the JSON-only presigned/commit/preview sub-routes of those
+    flows — and everything else — stay on the default 10 MB cap (PR #249 review).
+    """
+
+    # --- the two real file-upload endpoints get the large cap ---
     def test_ingest_upload_is_upload(self):
         assert _is_upload_route("/api/ingest/upload") is True
-
-    def test_ingest_upload_presigned_is_upload(self):
-        assert _is_upload_route("/api/ingest/upload/presigned") is True
-
-    def test_ingest_upload_complete_is_upload(self):
-        assert (
-            _is_upload_route("/api/ingest/upload/presigned/some-job-id/complete")
-            is True
-        )
 
     def test_datasets_reupload_is_upload(self):
         assert _is_upload_route("/api/datasets/abc123/reupload") is True
 
-    def test_datasets_reupload_presigned_is_upload(self):
-        assert _is_upload_route("/api/datasets/abc123/reupload/presigned") is True
+    def test_trailing_slash_ignored(self):
+        assert _is_upload_route("/api/ingest/upload/") is True
+        assert _is_upload_route("/api/datasets/abc123/reupload/") is True
 
-    def test_datasets_reupload_commit_is_upload(self):
-        assert _is_upload_route("/api/datasets/abc123/reupload/job-id/commit") is True
+    def test_case_insensitive(self):
+        assert _is_upload_route("/API/INGEST/UPLOAD") is True
+        assert _is_upload_route("/API/DATASETS/ABC/REUPLOAD") is True
 
+    # --- JSON-only sub-routes of the upload/reupload flows are NOT file uploads
+    # (PR #249 review): the bytes go straight to object storage, so a large JSON
+    # body on these routes must be stopped by the default cap. ---
+    def test_ingest_upload_presigned_is_not_upload(self):
+        assert _is_upload_route("/api/ingest/upload/presigned") is False
+
+    def test_ingest_upload_presigned_complete_is_not_upload(self):
+        assert (
+            _is_upload_route("/api/ingest/upload/presigned/some-job-id/complete")
+            is False
+        )
+
+    def test_datasets_reupload_presigned_is_not_upload(self):
+        assert _is_upload_route("/api/datasets/abc123/reupload/presigned") is False
+
+    def test_datasets_reupload_commit_is_not_upload(self):
+        assert _is_upload_route("/api/datasets/abc123/reupload/job-id/commit") is False
+
+    def test_datasets_reupload_service_preview_is_not_upload(self):
+        assert (
+            _is_upload_route("/api/datasets/abc123/reupload/service/preview") is False
+        )
+
+    # --- other non-upload routes ---
     def test_health_is_not_upload(self):
         assert _is_upload_route("/health") is False
 
@@ -72,10 +96,6 @@ class TestIsUploadRoute:
         # /api/ingest/commit is not an upload route
         assert _is_upload_route("/api/ingest/commit/some-job-id") is False
 
-    def test_case_insensitive(self):
-        assert _is_upload_route("/API/INGEST/UPLOAD") is True
-        assert _is_upload_route("/API/DATASETS/ABC/REUPLOAD") is True
-
 
 class TestIsUploadRouteProxyStripped:
     """The /api prefix is stripped by both proxies before the app sees the path.
@@ -84,29 +104,40 @@ class TestIsUploadRouteProxyStripped:
     dev Vite proxy (`rewrite: p.replace(/^\\/api/, '')`) both remove `/api`, so
     in every real deployment scope["path"] is the un-prefixed form. Matching only
     the `/api/...` prefix never fired, silently capping uploads at 10 MB. The
-    classifier must recognise the stripped form too.
+    classifier must recognise the stripped form too — for the file endpoints only.
     """
 
+    # --- the two file endpoints, stripped, get the large cap ---
     def test_stripped_ingest_upload_is_upload(self):
         assert _is_upload_route("/ingest/upload") is True
-
-    def test_stripped_ingest_upload_presigned_is_upload(self):
-        assert _is_upload_route("/ingest/upload/presigned") is True
-
-    def test_stripped_ingest_upload_complete_is_upload(self):
-        assert _is_upload_route("/ingest/upload/presigned/some-job-id/complete") is True
 
     def test_stripped_datasets_reupload_is_upload(self):
         assert _is_upload_route("/datasets/abc123/reupload") is True
 
-    def test_stripped_datasets_reupload_presigned_is_upload(self):
-        assert _is_upload_route("/datasets/abc123/reupload/presigned") is True
+    def test_stripped_trailing_slash_ignored(self):
+        assert _is_upload_route("/ingest/upload/") is True
+        assert _is_upload_route("/datasets/abc123/reupload/") is True
 
     def test_stripped_case_insensitive(self):
         assert _is_upload_route("/INGEST/UPLOAD") is True
         assert _is_upload_route("/DATASETS/ABC/REUPLOAD") is True
 
-    # Stripped non-upload paths must NOT over-match (still get the 10 MB cap).
+    # --- stripped JSON sub-routes must NOT get the large cap (PR #249 review) ---
+    def test_stripped_ingest_upload_presigned_is_not_upload(self):
+        assert _is_upload_route("/ingest/upload/presigned") is False
+
+    def test_stripped_ingest_upload_complete_is_not_upload(self):
+        assert (
+            _is_upload_route("/ingest/upload/presigned/some-job-id/complete") is False
+        )
+
+    def test_stripped_datasets_reupload_presigned_is_not_upload(self):
+        assert _is_upload_route("/datasets/abc123/reupload/presigned") is False
+
+    def test_stripped_datasets_reupload_commit_is_not_upload(self):
+        assert _is_upload_route("/datasets/abc123/reupload/job-id/commit") is False
+
+    # --- stripped non-upload paths must NOT over-match (still get the 10 MB cap) ---
     def test_stripped_datasets_list_is_not_upload(self):
         assert _is_upload_route("/datasets/") is False
 

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -143,6 +143,44 @@ export default defineConfig({
               )
             }
           });
+          // Dev-proxy resilience for large request bodies. In production nginx
+          // buffers the full request body (`proxy_request_buffering on`) before
+          // forwarding, so when the API rejects a large upload early — 413 (body
+          // too large) or 401 (auth) — the browser still receives that real
+          // status. Vite's dev proxy STREAMS the body instead, so an early
+          // upstream response + socket close races the still-uploading body and
+          // http-proxy raises ECONNRESET. With no 'error' listener that surfaces
+          // as an opaque 502 (and an unhandled error in the dev console). Convert
+          // it into a clean, explained response. The true upstream status is not
+          // recoverable once the socket resets mid-upload — this only affects
+          // requests the API was already going to reject, and only in dev.
+          proxy.on('error', (err, _req, res) => {
+            const code = (err as NodeJS.ErrnoException)?.code
+            // For proxied WebSocket upgrades `res` is a raw Socket (no writeHead).
+            if (res && 'writeHead' in res) {
+              if (!res.headersSent) {
+                res.writeHead(502, { 'Content-Type': 'application/json' })
+                res.end(
+                  JSON.stringify({
+                    error: 'dev_proxy_upstream_reset',
+                    detail:
+                      'The API closed the connection before the request body ' +
+                      'finished uploading (usually an early rejection of a large ' +
+                      'body: size limit or auth). This streaming dev proxy cannot ' +
+                      'recover the real status code; production buffers the body ' +
+                      'and returns it directly.',
+                  }),
+                )
+              }
+            } else if (res && typeof res.destroy === 'function') {
+              res.destroy()
+            }
+            console.warn(
+              `[vite] /api proxy upstream error${code ? ` (${code})` : ''}: ${
+                err?.message ?? String(err)
+              }`,
+            )
+          });
         },
       },
       '/raster-tiles': {


### PR DESCRIPTION
## Summary

Two related fixes for large file uploads through the `/api` proxy.

### 1. Backend — uploads silently capped at 10 MB in every deployment (`440969c5`)

`RequestBodyLimitMiddleware._is_upload_route()` granted the 500 MB upload limit
only to paths starting with `/api/ingest/upload` or `/api/datasets/{id}/reupload`.
But **both** deployment proxies strip the `/api` prefix before the request reaches
the ASGI app:

- prod nginx: `rewrite ^/api/(.*) /$1 break` (`frontend/nginx.conf`)
- dev Vite: `rewrite: (p) => p.replace(/^\/api/, '')` (`frontend/vite.config.ts`)

So `scope["path"]` is the un-prefixed form (`/ingest/upload`) in every real
deployment, the upload allowlist never matched, and the configurable
`UPLOAD_MAX_SIZE_MB` (500 MB) was dead code — every upload was capped at the 10 MB
`DEFAULT_BODY_LIMIT_BYTES` and returned **413**. (nginx itself allows
`client_max_body_size 500m`, so nginx and the app's intent agreed on 500 MB; the
middleware's route detection defeated it.)

**Fix:** normalize away the optional `/api` prefix before classifying, so the
upload limit applies whether or not the proxy stripped it.

**Blast radius:** `POST /api/ingest/upload` and `/datasets/{id}/reupload` for
bodies > 10 MB — the seed script, SDK/CLI, raw API clients, and the frontend's
direct-upload fallback when presigned/object-storage isn't configured.
Interactive uploads with presigned enabled PUT straight to object storage and
bypass the API body, which is why this went unnoticed.

### 2. Frontend — opaque 502 on the dev proxy when a large upload is rejected early (`17f95f84`)

Production nginx buffers the full request body before forwarding, so the API's
early rejection (413/401) still reaches the browser with its real status. Vite's
dev proxy streams the body, so an early upstream close races the in-flight upload
→ `http-proxy` raises `ECONNRESET`, and with no `error` listener that surfaced as
an opaque 502 (plus an unhandled error in the dev console).

**Fix:** add a `proxy.on('error')` handler to the `/api` route that returns a
clean, explained JSON `502 dev_proxy_upstream_reset` and logs the upstream error.
In practice the real status now usually flows through; when the reset wins the
race the dev gets a documented response instead of an opaque failure. Dev-only —
prod (buffered nginx) is unaffected.

## Testing

- **New regression tests** (`test_1184_body_limit_per_route.py`): unit cases for
  the proxy-stripped paths (`/ingest/upload`, `/datasets/{id}/reupload`, plus
  negative controls) and an integration test that POSTs to the stripped path.
  Verified RED→GREEN — revert the source fix and 7 fail; restore and all pass.
- **Full backend suite** (`pytest -n 4`): **3517 passed, 23 skipped**. One
  unrelated local-only failure (`test_no_geolens_io_typos`) trips on a gitignored
  `graphify-out/` artifact present in the working tree; it passes on a clean
  checkout / in CI and is untouched by this PR.
- **Full frontend suite**: typecheck + lint clean, **vitest 2789 passed**.
- **Live-verified** against a running stack: upload route → 401 (was 413);
  non-upload → 413 (10 MB cap holds); rejected large bodies via the dev proxy →
  real status or clean `dev_proxy_upstream_reset`.
