### PR TITLE
v1041 follow-ups: enable Standard-Deviation classification (σ) + DEM band-unit capture

### DIFF
--- a/backend/app/modules/catalog/datasets/domain/column_stats.py
+++ b/backend/app/modules/catalog/datasets/domain/column_stats.py
@@ -194,7 +194,8 @@ async def get_column_stats(
         f"SELECT MIN({col_q}::numeric), MAX({col_q}::numeric), "
         f"COUNT({col_q}), AVG({col_q}::numeric), "
         f"percentile_cont(ARRAY[{fractions_str}]) "
-        f"WITHIN GROUP (ORDER BY {col_q}::numeric) "
+        f"WITHIN GROUP (ORDER BY {col_q}::numeric), "
+        f"stddev_samp({col_q}::numeric) "
         f"FROM {tbl_q} "
         f"WHERE {col_q} IS NOT NULL"
     )
@@ -207,4 +208,5 @@ async def get_column_stats(
         "count": int(row[2]) if row[2] is not None else 0,
         "mean": float(row[3]) if row[3] is not None else None,
         "quantiles": [float(v) for v in row[4]] if row[4] is not None else [],
+        "stddev": float(row[5]) if row[5] is not None else None,
     }

--- a/backend/app/modules/catalog/datasets/domain/schemas.py
+++ b/backend/app/modules/catalog/datasets/domain/schemas.py
@@ -541,6 +541,7 @@ class ColumnStatsResponse(BaseModel):
     count: int = 0
     mean: float | None = None
     quantiles: list[float] = []
+    stddev: float | None = None
 
 
 class AttributeMetadataResponse(BaseModel):

--- a/backend/app/processing/raster/cog.py
+++ b/backend/app/processing/raster/cog.py
@@ -72,15 +72,18 @@ def extract_raster_metadata(file_path: str) -> dict:
         overview_levels = src.overviews(1) if src.count >= 1 else []
 
         band_info = []
+        src_units = src.units or ()
         for i in range(1, src.count + 1):
-            band_info.append(
-                {
-                    "index": i,
-                    "dtype": src.dtypes[i - 1],
-                    "nodata": str(src.nodata) if src.nodata is not None else None,
-                    "color_interp": src.colorinterp[i - 1].name,
-                }
-            )
+            entry: dict = {
+                "index": i,
+                "dtype": src.dtypes[i - 1],
+                "nodata": str(src.nodata) if src.nodata is not None else None,
+                "color_interp": src.colorinterp[i - 1].name,
+            }
+            unit = src_units[i - 1] if i - 1 < len(src_units) else None
+            if unit and isinstance(unit, str) and unit.strip():
+                entry["unit"] = unit.strip()
+            band_info.append(entry)
 
         is_dem_candidate = src.count == 1 and _is_float_dtype(src.dtypes[0])
 

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -2969,6 +2969,17 @@
             },
             "title": "Quantiles",
             "type": "array"
+          },
+          "stddev": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Stddev"
           }
         },
         "title": "ColumnStatsResponse",

--- a/backend/tests/test_cog_band_unit_capture.py
+++ b/backend/tests/test_cog_band_unit_capture.py
@@ -1,0 +1,210 @@
+"""RHYD-01 (v1041 follow-up): band unit capture in extract_raster_metadata.
+
+COG ingest was writing band_info entries without a ``unit`` key, so
+``_extract_dem_vertical_units`` always returned None even for rasters that
+carry GDAL-level band unit strings (``src.units``).  This module pins:
+
+1. When ``src.units`` contains a non-empty unit string, the corresponding
+   band_info entry includes ``"unit": <value>`` and
+   ``_extract_dem_vertical_units`` returns it.
+2. When ``src.units`` is empty / all blank, no ``unit`` key is written to
+   band_info (no None litter).
+3. When ``src.units`` is shorter than ``src.count`` (partial tuple), the
+   missing bands don't get a ``unit`` key.
+"""
+
+from unittest import mock
+
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_fake_src(
+    *,
+    count: int = 1,
+    dtypes: tuple = ("float32",),
+    nodata: float | None = None,
+    units: tuple = (),
+    colorinterp=None,
+    crs=None,
+    bounds=None,
+    transform=None,
+    overviews: list | None = None,
+    profile: dict | None = None,
+    tags: dict | None = None,
+) -> mock.MagicMock:
+    """Build a minimal rasterio dataset mock for extract_raster_metadata."""
+    import rasterio
+    from rasterio.crs import CRS
+
+    if crs is None:
+        crs = CRS.from_epsg(4326)
+    if bounds is None:
+        from rasterio.coords import BoundingBox
+
+        bounds = BoundingBox(left=-74.1, bottom=40.6, right=-73.9, top=40.8)
+    if colorinterp is None:
+        colorinterp = [rasterio.enums.ColorInterp.gray] * count
+    if profile is None:
+        profile = {
+            "compress": "deflate",
+            "blockxsize": 512,
+            "blockysize": 512,
+            "tiled": True,
+            "driver": "GTiff",
+        }
+    if overviews is None:
+        overviews = [2, 4, 8]
+
+    # Build a plain mock for the affine transform so we can set .a/.e/.b/.d
+    # freely — rasterio.Affine is a named tuple and its attributes are
+    # read-only, so we cannot assign to a real Affine instance.
+    fake_transform = mock.MagicMock()
+    fake_transform.a = (bounds.right - bounds.left) / 256
+    fake_transform.e = -(bounds.top - bounds.bottom) / 256
+    fake_transform.b = 0.0
+    fake_transform.d = 0.0
+
+    src = mock.MagicMock()
+    src.crs = crs
+    src.count = count
+    src.dtypes = dtypes
+    src.nodata = nodata
+    src.units = units
+    src.colorinterp = colorinterp
+    src.bounds = bounds
+    src.transform = fake_transform
+    src.width = 256
+    src.height = 256
+    src.profile = profile
+    src.overviews = mock.Mock(return_value=overviews)
+    src.tags = mock.Mock(return_value=tags or {})
+    return src
+
+
+def _run_extract(fake_src, monkeypatch) -> dict:
+    """Patch rasterio.open and run extract_raster_metadata."""
+    import rasterio
+    from app.processing.raster.cog import extract_raster_metadata
+
+    ctx = mock.MagicMock()
+    ctx.__enter__.return_value = fake_src
+    ctx.__exit__.return_value = False
+    monkeypatch.setattr(rasterio, "open", lambda *_a, **_kw: ctx)
+    return extract_raster_metadata("/fake/path.tif")
+
+
+# ---------------------------------------------------------------------------
+# tests
+# ---------------------------------------------------------------------------
+
+
+class TestBandUnitCaptureWithUnits:
+    def test_unit_key_present_when_src_units_nonempty(self, monkeypatch):
+        """Band entry has ``unit`` when src.units carries a non-empty string."""
+        fake_src = _make_fake_src(units=("metre",))
+        meta = _run_extract(fake_src, monkeypatch)
+        band_info = meta["band_info"]
+        assert len(band_info) == 1
+        assert band_info[0]["unit"] == "metre"
+
+    def test_unit_key_present_for_feet(self, monkeypatch):
+        """'feet' (US customary) is captured faithfully."""
+        fake_src = _make_fake_src(units=("feet",))
+        meta = _run_extract(fake_src, monkeypatch)
+        assert meta["band_info"][0]["unit"] == "feet"
+
+    def test_unit_value_is_stripped(self, monkeypatch):
+        """Leading/trailing whitespace in the unit string is stripped."""
+        fake_src = _make_fake_src(units=("  meter  ",))
+        meta = _run_extract(fake_src, monkeypatch)
+        assert meta["band_info"][0]["unit"] == "meter"
+
+    def test_multi_band_units(self, monkeypatch):
+        """Each band gets its own unit when the units tuple is multi-valued."""
+        import rasterio
+
+        fake_src = _make_fake_src(
+            count=2,
+            dtypes=("float32", "float32"),
+            units=("metre", "metre"),
+            colorinterp=[
+                rasterio.enums.ColorInterp.gray,
+                rasterio.enums.ColorInterp.gray,
+            ],
+        )
+        meta = _run_extract(fake_src, monkeypatch)
+        band_info = meta["band_info"]
+        assert band_info[0]["unit"] == "metre"
+        assert band_info[1]["unit"] == "metre"
+
+
+class TestBandUnitCaptureWithoutUnits:
+    def test_no_unit_key_when_units_empty_tuple(self, monkeypatch):
+        """Empty units tuple → no ``unit`` key in band_info (no None litter)."""
+        fake_src = _make_fake_src(units=())
+        meta = _run_extract(fake_src, monkeypatch)
+        band_info = meta["band_info"]
+        assert len(band_info) == 1
+        assert "unit" not in band_info[0]
+
+    def test_no_unit_key_when_unit_is_blank_string(self, monkeypatch):
+        """Blank unit string → no ``unit`` key (guards against GDAL empty-string noise)."""
+        fake_src = _make_fake_src(units=("",))
+        meta = _run_extract(fake_src, monkeypatch)
+        assert "unit" not in meta["band_info"][0]
+
+    def test_no_unit_key_when_unit_is_whitespace(self, monkeypatch):
+        """Whitespace-only unit string → no ``unit`` key."""
+        fake_src = _make_fake_src(units=("   ",))
+        meta = _run_extract(fake_src, monkeypatch)
+        assert "unit" not in meta["band_info"][0]
+
+    def test_no_unit_key_when_units_is_none(self, monkeypatch):
+        """``src.units = None`` → no ``unit`` key (rasterio may return None)."""
+        fake_src = _make_fake_src(units=None)
+        meta = _run_extract(fake_src, monkeypatch)
+        assert "unit" not in meta["band_info"][0]
+
+    def test_partial_units_tuple_shorter_than_band_count(self, monkeypatch):
+        """Units tuple shorter than band count: only bands with a unit get the key."""
+        import rasterio
+
+        fake_src = _make_fake_src(
+            count=2,
+            dtypes=("float32", "float32"),
+            units=("metre",),  # only 1 entry for 2 bands
+            colorinterp=[
+                rasterio.enums.ColorInterp.gray,
+                rasterio.enums.ColorInterp.gray,
+            ],
+        )
+        meta = _run_extract(fake_src, monkeypatch)
+        band_info = meta["band_info"]
+        assert band_info[0]["unit"] == "metre"
+        assert "unit" not in band_info[1]
+
+
+class TestExtractDemVerticalUnitsRoundTrip:
+    """End-to-end: band_info produced by cog.py flows correctly into
+    _extract_dem_vertical_units (service_shared.py)."""
+
+    def test_round_trip_unit_metre(self, monkeypatch):
+        """Units written at ingest are read back by _extract_dem_vertical_units."""
+        from app.modules.catalog.maps.service_shared import _extract_dem_vertical_units
+
+        fake_src = _make_fake_src(units=("metre",))
+        meta = _run_extract(fake_src, monkeypatch)
+        result = _extract_dem_vertical_units(meta["band_info"])
+        assert result == "metre"
+
+    def test_round_trip_no_units_returns_none(self, monkeypatch):
+        """No units at ingest → _extract_dem_vertical_units returns None."""
+        from app.modules.catalog.maps.service_shared import _extract_dem_vertical_units
+
+        fake_src = _make_fake_src(units=())
+        meta = _run_extract(fake_src, monkeypatch)
+        result = _extract_dem_vertical_units(meta["band_info"])
+        assert result is None

--- a/backend/tests/test_column_stats_stddev.py
+++ b/backend/tests/test_column_stats_stddev.py
@@ -1,0 +1,81 @@
+"""Tests for stddev in get_column_stats (v1041 ENH-04).
+
+The data-driven "Standard Deviation" classification method needs the backend
+column-stats endpoint to return sigma. These tests run against a real database.
+
+Requirements:
+  - Docker database must be running (docker compose up db)
+  - Alembic migrations must be applied
+"""
+
+import uuid
+
+import pytest
+from sqlalchemy import text
+
+from app.modules.catalog.datasets.domain.column_stats import get_column_stats
+
+TEST_TABLE_NAME = f"test_stddev_{uuid.uuid4().hex[:8]}"
+
+
+@pytest.fixture
+async def stddev_table(test_db_session):
+    """Create a small test table with a numeric and a text column."""
+    await test_db_session.execute(
+        text(
+            f"CREATE TABLE IF NOT EXISTS data.{TEST_TABLE_NAME} "
+            "(gid serial PRIMARY KEY, label text, value integer)"
+        )
+    )
+    # values 1..5: sample stddev = sqrt(2.5) ~= 1.5811
+    await test_db_session.execute(
+        text(
+            f"INSERT INTO data.{TEST_TABLE_NAME} (label, value) VALUES "
+            "('a', 1), ('b', 2), ('c', 3), ('d', 4), ('e', 5)"
+        )
+    )
+    await test_db_session.execute(text(f"ANALYZE data.{TEST_TABLE_NAME}"))
+    await test_db_session.commit()
+
+    yield TEST_TABLE_NAME
+
+    await test_db_session.execute(text(f"DROP TABLE IF EXISTS data.{TEST_TABLE_NAME}"))
+    await test_db_session.commit()
+
+
+@pytest.fixture
+async def empty_stddev_table(test_db_session):
+    """Create an empty test table with a numeric column."""
+    name = f"{TEST_TABLE_NAME}_empty"
+    await test_db_session.execute(
+        text(
+            f"CREATE TABLE IF NOT EXISTS data.{name} "
+            "(gid serial PRIMARY KEY, value integer)"
+        )
+    )
+    await test_db_session.commit()
+
+    yield name
+
+    await test_db_session.execute(text(f"DROP TABLE IF EXISTS data.{name}"))
+    await test_db_session.commit()
+
+
+async def test_get_column_stats_returns_numeric_stddev(test_db_session, stddev_table):
+    """A numeric column returns a numeric (non-None) sample stddev."""
+    stats = await get_column_stats(test_db_session, stddev_table, "value")
+
+    assert "stddev" in stats
+    assert isinstance(stats["stddev"], float)
+    # sample stddev of 1..5 is sqrt(2.5) ~= 1.5811
+    assert stats["stddev"] == pytest.approx(1.5811, abs=1e-3)
+
+
+async def test_get_column_stats_stddev_none_for_empty_column(
+    test_db_session, empty_stddev_table
+):
+    """An empty column (no rows) yields stddev=None, not an error."""
+    stats = await get_column_stats(test_db_session, empty_stddev_table, "value")
+
+    assert stats["count"] == 0
+    assert stats["stddev"] is None

--- a/sdks/python/geolens/models/column_stats_response.py
+++ b/sdks/python/geolens/models/column_stats_response.py
@@ -23,6 +23,7 @@ class ColumnStatsResponse:
         mean (float | None | Unset):
         min_ (float | None | Unset):
         quantiles (list[float] | Unset):
+        stddev (float | None | Unset):
     """
 
     count: int | Unset = 0
@@ -30,6 +31,7 @@ class ColumnStatsResponse:
     mean: float | None | Unset = UNSET
     min_: float | None | Unset = UNSET
     quantiles: list[float] | Unset = UNSET
+    stddev: float | None | Unset = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
@@ -57,6 +59,12 @@ class ColumnStatsResponse:
         if not isinstance(self.quantiles, Unset):
             quantiles = self.quantiles
 
+        stddev: float | None | Unset
+        if isinstance(self.stddev, Unset):
+            stddev = UNSET
+        else:
+            stddev = self.stddev
+
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
@@ -70,6 +78,8 @@ class ColumnStatsResponse:
             field_dict["min"] = min_
         if quantiles is not UNSET:
             field_dict["quantiles"] = quantiles
+        if stddev is not UNSET:
+            field_dict["stddev"] = stddev
 
         return field_dict
 
@@ -107,12 +117,22 @@ class ColumnStatsResponse:
 
         quantiles = cast(list[float], d.pop("quantiles", UNSET))
 
+        def _parse_stddev(data: object) -> float | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(float | None | Unset, data)
+
+        stddev = _parse_stddev(d.pop("stddev", UNSET))
+
         column_stats_response = cls(
             count=count,
             max_=max_,
             mean=mean,
             min_=min_,
             quantiles=quantiles,
+            stddev=stddev,
         )
 
         column_stats_response.additional_properties = d

--- a/sdks/typescript/src/client/types.gen.ts
+++ b/sdks/typescript/src/client/types.gen.ts
@@ -1775,6 +1775,10 @@ export type ColumnStatsResponse = {
      * Quantiles
      */
     quantiles?: Array<number>;
+    /**
+     * Stddev
+     */
+    stddev?: number | null;
 };
 
 /**


### PR DESCRIPTION
## v1041 follow-ups — complete two shipped-but-inert features

Small backend completions of v1041 carry-forward items (off `main`, post-PR-#251).

- **ENH-04 Standard Deviation classification** — was shipped in the frontend but disabled because the column-stats endpoint didn't return σ. `get_column_stats` now returns `stddev` (`stddev_samp`, NULL-safe), added to `ColumnStatsResponse` + OpenAPI/SDK (additive-only). The frontend already gates on `statsData.stddev`, so the option **auto-enables**. Test: numeric σ ≈ √2.5 / None on empty.
- **RHYD-01 `dem_vertical_units`** — the add-layer response hydrates it, but COG ingest never captured a band unit, so it was always None. `cog.py` now writes `band_info[*].unit` from `src.units` when present (additive; key omitted when absent — no `None` litter). Round-trip test via `_extract_dem_vertical_units`. **Honest scope:** most DEMs don't carry band units; the complete fix derives the vertical unit from the CRS vertical axis (`crs_wkt`) — that remains a follow-up.

### Gates
Backend 13 new tests pass · OpenAPI no-drift (additive `stddev` only) · SDKs regenerated + committed · frontend typecheck 0.

### Still deferred (not loose ends — future scope)
ENH-06 legend entry-reorder (feature: persisted order + drag UI + viewer parity); FUT-01 undo/redo; FUT-02 aggregation renderers; FUT-03 contour re-enable; i18n ~160 inline-default backfill; STACK-02 persisted basemap-hidden. Release tag (v1.2.5/v1.3.0) remains the user's call.
