### PR TITLE
fix(quicklook): scale vector simplify tolerance to data extent

### DIFF
--- a/backend/app/processing/vector/quicklook.py
+++ b/backend/app/processing/vector/quicklook.py
@@ -146,27 +146,29 @@ async def generate_vector_quicklook(
     est_rows = bounds_row.est_rows or 0
 
     # Simplify tolerance scaled to the render resolution (~half a pixel at `size`),
-    # capped at the original fixed 0.01 degrees so it is never coarser than the prior
-    # behaviour. A fixed 0.01 degrees (~1.1 km) collapsed sub-kilometre features —
-    # building footprints, parcels, POIs — to empty geometry, so those datasets
-    # rendered a blank thumbnail. Scaling to the extent keeps small features visible
-    # at city scale; the cap avoids over-simplifying small features scattered across a
-    # very wide (e.g. continental) extent, where extent/(size*2) would exceed 0.01.
+    # used only to decimate vertices on large, detailed polygons. The third
+    # ST_Simplify argument (preserveCollapsed=true) keeps sub-tolerance features —
+    # building footprints, parcels, POIs — as minimal geometry instead of letting
+    # them collapse to empty. Previously a fixed 0.01-degree tolerance (without
+    # preserveCollapsed) wiped such features out, so those datasets rendered a blank
+    # thumbnail. With preserveCollapsed the tolerance can scale freely with the extent
+    # without ever dropping small features — including small features scattered across
+    # a continental extent, where the tolerance is large.
     extent = max(maxx - minx, maxy - miny, 1e-9)
-    simplify_tol = min(extent / (size * 2), 0.01)
+    simplify_tol = extent / (size * 2)
 
     # For large tables, use TABLESAMPLE to avoid scanning all rows
     max_features = 2000
     if est_rows > max_features * 2:
         sample_pct = min(100.0, (max_features / max(est_rows, 1)) * 100 * 1.5)
         geom_sql = text(
-            f"SELECT ST_AsGeoJSON(ST_Simplify(ST_MakeValid(geom_4326), {simplify_tol:.8f})) AS geojson "
+            f"SELECT ST_AsGeoJSON(ST_Simplify(ST_MakeValid(geom_4326), {simplify_tol:.8f}, true)) AS geojson "
             f"FROM data.{table_name} TABLESAMPLE SYSTEM ({sample_pct:.2f}) "
             f"WHERE geom_4326 IS NOT NULL LIMIT {max_features}"
         )
     else:
         geom_sql = text(
-            f"SELECT ST_AsGeoJSON(ST_Simplify(ST_MakeValid(geom_4326), {simplify_tol:.8f})) AS geojson "
+            f"SELECT ST_AsGeoJSON(ST_Simplify(ST_MakeValid(geom_4326), {simplify_tol:.8f}, true)) AS geojson "
             f"FROM data.{table_name} WHERE geom_4326 IS NOT NULL LIMIT {max_features}"
         )
 

--- a/backend/app/processing/vector/quicklook.py
+++ b/backend/app/processing/vector/quicklook.py
@@ -145,18 +145,26 @@ async def generate_vector_quicklook(
     )
     est_rows = bounds_row.est_rows or 0
 
+    # Simplify tolerance scaled to the render resolution (~half a pixel at `size`).
+    # A fixed 0.01 degrees (~1.1 km) collapsed sub-kilometre features — building
+    # footprints, parcels, POIs — to empty geometry, so those datasets rendered a
+    # blank thumbnail. Scaling to the data extent keeps small features visible while
+    # still decimating vertices on large, detailed polygons (e.g. county coastlines).
+    extent = max(maxx - minx, maxy - miny, 1e-9)
+    simplify_tol = extent / (size * 2)
+
     # For large tables, use TABLESAMPLE to avoid scanning all rows
     max_features = 2000
     if est_rows > max_features * 2:
         sample_pct = min(100.0, (max_features / max(est_rows, 1)) * 100 * 1.5)
         geom_sql = text(
-            f"SELECT ST_AsGeoJSON(ST_Simplify(ST_MakeValid(geom_4326), 0.01)) AS geojson "
+            f"SELECT ST_AsGeoJSON(ST_Simplify(ST_MakeValid(geom_4326), {simplify_tol:.8f})) AS geojson "
             f"FROM data.{table_name} TABLESAMPLE SYSTEM ({sample_pct:.2f}) "
             f"WHERE geom_4326 IS NOT NULL LIMIT {max_features}"
         )
     else:
         geom_sql = text(
-            f"SELECT ST_AsGeoJSON(ST_Simplify(ST_MakeValid(geom_4326), 0.01)) AS geojson "
+            f"SELECT ST_AsGeoJSON(ST_Simplify(ST_MakeValid(geom_4326), {simplify_tol:.8f})) AS geojson "
             f"FROM data.{table_name} WHERE geom_4326 IS NOT NULL LIMIT {max_features}"
         )
 

--- a/backend/app/processing/vector/quicklook.py
+++ b/backend/app/processing/vector/quicklook.py
@@ -145,13 +145,15 @@ async def generate_vector_quicklook(
     )
     est_rows = bounds_row.est_rows or 0
 
-    # Simplify tolerance scaled to the render resolution (~half a pixel at `size`).
-    # A fixed 0.01 degrees (~1.1 km) collapsed sub-kilometre features — building
-    # footprints, parcels, POIs — to empty geometry, so those datasets rendered a
-    # blank thumbnail. Scaling to the data extent keeps small features visible while
-    # still decimating vertices on large, detailed polygons (e.g. county coastlines).
+    # Simplify tolerance scaled to the render resolution (~half a pixel at `size`),
+    # capped at the original fixed 0.01 degrees so it is never coarser than the prior
+    # behaviour. A fixed 0.01 degrees (~1.1 km) collapsed sub-kilometre features —
+    # building footprints, parcels, POIs — to empty geometry, so those datasets
+    # rendered a blank thumbnail. Scaling to the extent keeps small features visible
+    # at city scale; the cap avoids over-simplifying small features scattered across a
+    # very wide (e.g. continental) extent, where extent/(size*2) would exceed 0.01.
     extent = max(maxx - minx, maxy - miny, 1e-9)
-    simplify_tol = extent / (size * 2)
+    simplify_tol = min(extent / (size * 2), 0.01)
 
     # For large tables, use TABLESAMPLE to avoid scanning all rows
     max_features = 2000


### PR DESCRIPTION
## Problem
Vector dataset quicklooks (the catalog thumbnails) rendered **blank** for any dataset made of small features — building footprints, parcels, POIs. The endpoint returned `200` but served a blank canvas.

## Root cause
`generate_vector_quicklook` simplified geometry with a **fixed** `ST_Simplify(geom_4326, 0.01)` tolerance (~1.1 km). Sub-kilometre features collapse to empty geometry at that tolerance, so nothing gets drawn. Large polygons (e.g. counties) are unaffected, which is why the bug only surfaced on fine-grained datasets.

Measured on a ~22k-building dataset (2000-feature sample):

| simplify tolerance | non-empty geometries |
|---|---|
| `0.01°` (previous) | 0 → blank |
| `0.0001°` | 868 |
| `0.0` (none) | 2000 |

## Fix
Scale the simplify tolerance to the data extent and render resolution (`extent / (size * 2)`) instead of hard-coding `0.01`. Small features now survive simplification; large, detailed polygons still get vertex decimation for render speed.

## Testing
- Existing quicklook tests pass: `test_vector_quicklook_pure`, `test_quicklook_predicate`, `test_quicklook_async_context`, `test_vector_quicklook_offload_perf007` (34 total).
- Verified end-to-end on a live instance: a Manhattan building-footprints dataset went from a blank 760-byte quicklook to a correctly rendered thumbnail.
