### PR TITLE
docs(readme): add a "Try the live demo" call-to-action

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,12 @@
 
 GeoLens is an open-source, self-hosted catalog and map builder for GIS and data teams — a single home for spatial data that you run on infrastructure you control, with no telemetry and nothing leaving your network. Upload Shapefiles, GeoTIFFs, GeoPackages, or CSVs (or register data you already have); GeoLens stores everything in PostGIS, indexes it with pgvector + pg_trgm for semantic and fuzzy search, and serves OGC/STAC APIs that QGIS, ArcGIS, and MapLibre clients connect to natively. Compose, style, and share multi-layer maps right in the browser. Built on FastAPI and React. Deployed with one command.
 
+<p align="center">
+  <a href="https://demo.getgeolens.com"><img src="https://img.shields.io/badge/%E2%96%B6%20Try%20the%20live%20demo-demo.getgeolens.com-2563eb?style=for-the-badge" alt="Try the live demo" /></a>
+  <br />
+  <sub>No install required — explore the map builder with sample maps. Sign in as <code>guest</code> / <code>GeoLensDemo1!</code></sub>
+</p>
+
 [![CI](https://github.com/geolens-io/geolens/actions/workflows/ci.yml/badge.svg)](https://github.com/geolens-io/geolens/actions/workflows/ci.yml)
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![Python: backend 3.13 / SDK 3.10+](https://img.shields.io/badge/python-3.13_backend_%7C_3.10%2B_SDK-blue.svg)]()


### PR DESCRIPTION
Adds a prominent **▶ Try the live demo** call-to-action to the top of the README, between the value proposition and the badges (above the `curl … | sh` install line).

### Why
At 0 stars the biggest conversion gap for a self-hosted tool is that a visitor can't *try it* without installing Docker. A one-click hosted demo is the single most-cited friction-killer — it turns a 30-second skim into a star. The demo (https://demo.getgeolens.com) is now live, hardened (registration off, AI off, read-only-ish), and self-healing nightly.

### What
- A `for-the-badge` button linking to the demo
- A sub-caption noting it's zero-install and the shared guest login (`guest` / `GeoLensDemo1!` — an intentionally-public editor account on a nightly-reset instance)

Verified the demo URL returns 200 over valid TLS and the badge renders. Docs-only change.

### Follow-up (not in this PR)
A 5–10s GIF of the drag-to-style / "Ask AI" flow — best captured with a real screen recording rather than generated; happy to do that next.
