### PR TITLE
docs(quota): clarify storage byte-accounting covers raster file bytes only

### DIFF
--- a/backend/app/modules/quota/service.py
+++ b/backend/app/modules/quota/service.py
@@ -31,6 +31,16 @@ async def get_user_quota_usage(
     to sum the byte size of the user's owned dataset files.  Only dataset record
     types are counted (maps, services, and collections are excluded).
 
+    Byte-coverage caveat: ``bytes_used`` sums ONLY the ``key='data'`` file asset,
+    so in practice it tracks *raster file bytes*.  Vector and ``table`` datasets are
+    PostGIS-resident and ``vrt_dataset`` is definition-only, so they carry no
+    ``data`` asset and contribute 0 bytes; ``overview``/``thumbnail`` (and any other
+    asset key) are also excluded.  The dataset-COUNT cap is therefore the cross-type
+    fence, and ``check_upload_quota`` still gates each upload on the actual incoming
+    ``file.size`` regardless of type.  A true cross-type storage total (e.g.
+    ``pg_total_relation_size`` per vector table + VRT source attribution) is
+    intentionally deferred to the metered/per-tenant (cloud) quota work.
+
     T-1224-01 mitigation: user_id is bound via SQLAlchemy parameterisation —
     never string-formatted into the SQL text.
     """


### PR DESCRIPTION
Documents a known limitation of `get_user_quota_usage` surfaced while smoke-testing the v1044 quota.

`bytes_used` sums only the `key='data'` asset, so it effectively tracks **raster file bytes**:
- **vector** + **table** datasets are PostGIS-resident → no `data` asset → 0 bytes
- **vrt_dataset** is definition-only → 0 bytes
- `overview`/`thumbnail` (and any non-`data` key) are excluded

This is **not an abuse hole**: the dataset-**count** cap is the cross-type fence, and `check_upload_quota` still gates every upload on the actual incoming `file.size` regardless of type. A true cross-type storage total (`pg_total_relation_size` per vector table + VRT source attribution) is intentionally deferred to the metered/per-tenant (cloud) quota work.

Docstring-only — no behavior change.

https://claude.ai/code/session_01TGHeioMPuSeyoWGiovwCPN