### PR TITLE
fix(viewer): stop public map page from scrolling under the footer

### DIFF
--- a/frontend/src/components/layout/AppLayout.tsx
+++ b/frontend/src/components/layout/AppLayout.tsx
@@ -6,6 +6,7 @@ import { useEdition } from '@/hooks/use-edition';
 import { useBranding } from '@/hooks/use-settings';
 import { SkipToContent } from './SkipToContent';
 import { useAuthStore } from '@/stores/auth-store';
+import { cn } from '@/lib/utils';
 
 export function AppLayout() {
   const hasAuthToken = useAuthStore((state) => !!state.token);
@@ -21,7 +22,14 @@ export function AppLayout() {
       <SkipToContent />
       <Navbar />
       <DemoBanner />
-      <main id="main-content" tabIndex={-1} className="flex-1 animate-fade-in focus:outline-none">
+      <main
+        id="main-content"
+        tabIndex={-1}
+        // ponytail: on map routes, become a flex column so the map fills the space
+        // the navbar/banner/footer leave — fixes the public-map scroll where the
+        // page hardcoded `100dvh-navbar` and ignored the footer below it.
+        className={cn('flex-1 animate-fade-in focus:outline-none', isMapRoute && 'flex flex-col')}
+      >
         <Outlet />
       </main>
       {!isAuthenticatedMapRoute && <AppFooter showBranding={showFooterBranding} />}

--- a/frontend/src/pages/PublicMapViewerPage.tsx
+++ b/frontend/src/pages/PublicMapViewerPage.tsx
@@ -72,7 +72,7 @@ export function PublicMapViewerPage() {
 
   if (isLoading) {
     return (
-      <div className="flex items-center justify-center w-full h-screen bg-muted">
+      <div className="flex flex-1 items-center justify-center w-full bg-muted">
         <LoadingState message={t('viewer.loading')} />
       </div>
     );
@@ -82,7 +82,7 @@ export function PublicMapViewerPage() {
     const is403 = error instanceof ApiError && error.status === 403;
     const is404 = error instanceof ApiError && error.status === 404;
     return (
-      <div className="flex min-h-screen items-center justify-center bg-[radial-gradient(circle_at_top,_hsl(var(--muted))_0,_transparent_55%),linear-gradient(180deg,hsl(var(--background)),hsl(var(--muted))/0.45)] px-6">
+      <div className="flex flex-1 items-center justify-center bg-[radial-gradient(circle_at_top,_hsl(var(--muted))_0,_transparent_55%),linear-gradient(180deg,hsl(var(--background)),hsl(var(--muted))/0.45)] px-6">
         <div className="flex w-full max-w-xl flex-col items-center rounded-2xl border bg-background/95 p-8 text-center shadow-xl backdrop-blur">
           <MapPinOff className="size-10 text-muted-foreground" />
           <div className="mt-4 space-y-2 text-center">
@@ -128,7 +128,7 @@ export function PublicMapViewerPage() {
   };
 
   return (
-    <main id="map-viewport" className="w-full h-[calc(100dvh-3.5rem-1px)] relative overflow-hidden">
+    <main id="map-viewport" className="w-full flex-1 min-h-0 relative overflow-hidden">
       <MapErrorBoundary>
         <Suspense fallback={<LoadingState message={t('viewer.loading')} />}>
           <ViewerMap


### PR DESCRIPTION
## Problem
The **public** (anonymous) map page at `/maps/:id` scrolled — a stray scrollbar from the footer pushing content past the viewport.

## Root cause
`PublicMapViewerPage`'s `<main>` hardcoded its height as `h-[calc(100dvh-3.5rem-1px)]` — viewport minus the navbar (`h-14` + `border-b`) **only**. In `AppLayout`'s flex column the map is a sibling of two things that calc ignored:

- **`AppFooter`** (~2.5rem) — rendered only when `!isAuthenticatedMapRoute`, i.e. the anonymous viewer. Signed-in viewers/editors hide it, which is why only the *public* map scrolled.
- **`DemoBanner`** (~2rem) — present on the live demo, would compound it.

The outer wrapper is `min-h-screen`, so the children summed to `navbar + (100dvh − navbar) + footer = 100dvh + footer` → the body overflowed by the footer's height.

## Fix
Replace the magic-number height with flex-fill (footer kept for lead-gen branding):
- `AppLayout.tsx` — `#main-content` becomes `flex flex-col` on map routes (scoped; other pages untouched).
- `PublicMapViewerPage.tsx` — map / loading / error containers use `flex-1` instead of `100dvh-navbar` / `h-screen` / `min-h-screen`.

The map now takes exactly the space the navbar/banner/footer leave — robust to the demo banner and footer wrapping, with no hardcoded subtraction.

## Verification
- `tsc --noEmit` clean
- `AppLayout.test.tsx` + `PublicMapViewerPage.test.tsx` — 11/11 pass (incl. "renders footer on anonymous map viewer pages")

https://claude.ai/code/session_0172k2YPgRv8L2SeGw18kv6n