### PR TITLE
fix(migrations): exclude runtime-managed HNSW index from alembic drift check

### DIFF
--- a/backend/alembic/env.py
+++ b/backend/alembic/env.py
@@ -252,8 +252,20 @@ def include_object(obj, name, type_, reflected, compare_to):
     installed. When no overlay is present, those columns are intentional
     schema/model drift and would be reported by ``alembic check`` on every
     OSS deployment — see migration-audit H-21.
+
+    ``ix_record_embeddings_hnsw`` is a pgvector HNSW index created and dropped
+    at runtime by ``embeddings/service.py`` (``rebuild_embedding_column``) once
+    an embedding dimension is configured. It cannot be a static model index —
+    the ``embedding`` column starts dimensionless — so it is intentionally
+    absent from the metadata. Without skipping it, autogenerate emits a phantom
+    ``remove_index`` whenever the index exists in the DB but not the model; under
+    ``pytest -n4`` a sibling test that built it on the shared worker DB before
+    ``alembic check`` ran turned this into a high-rate flake in
+    ``test_alembic_check_no_drift``.
     """
     if name and name.startswith("procrastinate_"):
+        return False
+    if type_ == "index" and name == "ix_record_embeddings_hnsw":
         return False
     if (
         type_ == "column"

--- a/backend/tests/test_tenant_rls_migration.py
+++ b/backend/tests/test_tenant_rls_migration.py
@@ -462,6 +462,55 @@ class TestAlembicCheckNoDrift:
         )
 
 
+class TestAlembicDriftIgnoresRuntimeHnswIndex:
+    """Regression (drift flake): env.include_object must exclude the
+    runtime-managed ``ix_record_embeddings_hnsw`` pgvector index from
+    autogenerate, so ``alembic check`` stays clean even when the index exists in
+    the DB but not the model.
+
+    ``embeddings/service.py`` creates and drops this HNSW index imperatively
+    once an embedding dimension is configured — it is intentionally absent from
+    the SQLAlchemy metadata. Under ``pytest -n4`` a sibling test that built it on
+    the shared worker DB before the drift check ran turned
+    ``TestAlembicCheckNoDrift.test_alembic_check_no_drift`` into a high-rate
+    flake. This deterministically reproduces that pollution and asserts the
+    drift gate ignores the index.
+    """
+
+    async def test_alembic_check_ignores_runtime_hnsw_index(self):
+        from sqlalchemy.ext.asyncio import create_async_engine
+
+        from app.core.config import settings
+
+        idx = "ix_record_embeddings_hnsw"
+        engine = create_async_engine(
+            settings.test_database_url,
+            isolation_level="AUTOCOMMIT",
+        )
+        try:
+            # A plain btree under the runtime index's name reproduces the
+            # name-keyed autogenerate ``remove_index`` drift without needing a
+            # dimensioned vector column (a real HNSW index requires a fixed dim).
+            async with engine.begin() as conn:
+                await conn.execute(
+                    sa.text(
+                        f"CREATE INDEX IF NOT EXISTS {idx} "
+                        "ON catalog.record_embeddings (record_id)"
+                    )
+                )
+            r = _run_alembic("check")
+            combined = r.stdout + r.stderr
+            assert r.returncode == 0, (
+                f"alembic check flagged the runtime-managed {idx} as drift — "
+                f"env.include_object exclusion missing or broken:\n{combined}"
+            )
+            assert "No new upgrade operations detected." in combined, combined
+        finally:
+            async with engine.begin() as conn:
+                await conn.execute(sa.text(f"DROP INDEX IF EXISTS catalog.{idx}"))
+            await engine.dispose()
+
+
 # ---------------------------------------------------------------------------
 # Tests F/G/H: apply_tenancy_rls() behaviour
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## The flake
`test_alembic_check_no_drift` (in `test_tenant_rls_migration.py`) is a high-rate `pytest -n4` isolation flake. It blocked the entire dependabot `uv.lock` tail (#223–#231 + #255) — those PRs failed it 20/20 across reruns while `main` passed it on a lucky single run.

## Root cause
`ix_record_embeddings_hnsw` is a pgvector HNSW index created and dropped **at runtime** by `embeddings/service.py` (`rebuild_embedding_column`) once an embedding dimension is configured. It can't be a static model index — the `embedding` column starts dimensionless — so it's intentionally absent from the SQLAlchemy metadata.

Under `-n 4`, a sibling test that configured an embedding dimension built the index on the shared worker DB *before* the drift-check test ran. `alembic check` then reflected the index, found it missing from the model, and emitted a phantom `remove_index` → drift → failure.

## Fix
Skip `ix_record_embeddings_hnsw` in `env.include_object`, mirroring the existing `procrastinate_*` and SAML-column exclusions. The index is runtime-managed and must never be considered by autogenerate.

Adds a **deterministic** regression test (`TestAlembicDriftIgnoresRuntimeHnswIndex`) that creates the index, runs `alembic check`, and asserts it stays clean — so this can't silently regress (unlike the timing-dependent original).

## Verification (local, against the test DB)
- A/B with the index present: **without** the skip → `remove_index ix_record_embeddings_hnsw` drift; **with** the skip → `No new upgrade operations detected.`
- `TestAlembicDriftIgnoresRuntimeHnswIndex` + `TestAlembicCheckNoDrift` → `2 passed`.

Unblocks the remaining dependabot `uv.lock` PRs (they'll merge once rebased onto this).