### PR TITLE
fix(ci): run overlay image probe via 'uv run' (venv on path)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1274,6 +1274,13 @@ jobs:
           #
           # Note: the probe uses the OSS image (no enterprise secret needed).
           # The dummy overlay is part of the backend source tree baked into the image.
+          #
+          # Invoke via `uv run --no-dev python` (the image's production launch
+          # pattern — see the api/worker CMD). The runtime image does NOT put the
+          # /app/.venv on PATH, so a bare `--entrypoint python` runs the base-image
+          # system interpreter with no project dependencies and the probe dies at
+          # the first third-party import (`import structlog`). uv run activates the
+          # baked /app/.venv so the probe exercises the real runtime.
           docker run \
             --rm \
             --no-healthcheck \
@@ -1282,9 +1289,9 @@ jobs:
             -e GEOLENS_ADMIN_USERNAME=probe \
             -e GEOLENS_ADMIN_PASSWORD=probe \
             -e POSTGRES_PASSWORD=probe \
-            --entrypoint python \
+            --entrypoint uv \
             geolens-probe-${{ matrix.target }}:ci \
-            scripts/probe_overlay_resolution.py --with-dummy-overlay
+            run --no-dev python scripts/probe_overlay_resolution.py --with-dummy-overlay
 
   # ---------- E2E (LOCAL-ONLY GATE — see .github/CONTRIBUTING.md "End-to-end (Playwright)") ----------
   # Disabled to save CI minutes: the dockerized stack + browser fixtures push the per-PR runtime


### PR DESCRIPTION
## Problem
The **Overlay Image Probe** (`api` + `worker`) has failed on **every push to `main` since v1046** (`01879bc5`). It's separate from the SDK-drift gate (fixed in #270) and from the dependabot bumps — it just never surfaced because **the probe only runs on push, never on PRs**.

## Root cause
The step ran the probe with `--entrypoint python`, which invokes the **base-image system interpreter**. The runtime image keeps project dependencies in `/app/.venv` and activates it via `uv run` (the `api`/`worker` `CMD`) — the venv is **not** on `PATH`. So the probe ran a Python with no project deps and died at the first third-party import:

```
File "/app/app/platform/extensions/__init__.py", line 13, in <module>
    import structlog
ModuleNotFoundError: No module named 'structlog'
```

## Fix
Invoke the probe via `uv run --no-dev python` — the image's production launch pattern — so the baked `/app/.venv` is active and the probe exercises the real runtime.

## Verification (local — the job is push-only, so PR CI can't run it)
Built the `api` image locally:
- `--entrypoint python` → reproduces `ModuleNotFoundError: No module named 'structlog'`
- `--entrypoint uv … run --no-dev python …` → **`PROBE PASSED: overlay resolution is correct.`**

`worker` shares the identical Dockerfile venv layout (`/app/.venv`, `uv run --no-dev` CMD), so the same fix applies to both matrix targets. The push-to-main run after merge will confirm green.