### PR TITLE
feat(import): upload progress, larger batch limit, batch quota banner

### DIFF
--- a/backend/app/processing/ingest/router.py
+++ b/backend/app/processing/ingest/router.py
@@ -84,7 +84,7 @@ from app.core.persistent_config import (
     UPLOAD_MAX_SIZE_MB,
     get_allowed_extensions_list,
 )
-from app.modules.quota.service import check_upload_quota
+from app.modules.quota.service import check_upload_quota, get_user_quota_usage
 from app.processing.raster.validation import validate_sources
 from app.platform.storage import get_storage
 from app.standards.ogc.errors import ERROR_RESPONSES_WRITE
@@ -136,6 +136,14 @@ async def get_upload_config(
     """Return upload configuration including presigned upload availability."""
     max_size_mb = await UPLOAD_MAX_SIZE_MB.get(db)
     allowed_exts = await UPLOAD_ALLOWED_EXTENSIONS.get(db)
+
+    # Advisory remaining-quota hint so the client can cap a batch at what the
+    # user can actually create. None when no count cap is set (unlimited).
+    usage = await get_user_quota_usage(db, user.id)
+    remaining = (
+        max(0, usage.count_cap - usage.dataset_count) if usage.count_cap > 0 else None
+    )
+
     return UploadConfigResponse(
         presigned_uploads=settings.storage_provider == "s3",
         presigned_threshold_bytes=settings.presigned_multipart_threshold_mb
@@ -143,6 +151,7 @@ async def get_upload_config(
         * 1024,
         max_file_size_bytes=max_size_mb * 1024 * 1024,
         allowed_extensions=allowed_exts,
+        remaining_dataset_quota=remaining,
     )
 
 

--- a/backend/app/processing/ingest/schemas.py
+++ b/backend/app/processing/ingest/schemas.py
@@ -436,6 +436,14 @@ class UploadConfigResponse(BaseModel):
     allowed_extensions: str = Field(
         description="Comma-separated list of allowed file extensions."
     )
+    remaining_dataset_quota: int | None = Field(
+        default=None,
+        description=(
+            "Datasets the caller may still create before hitting the per-user "
+            "count cap, or null when no count cap is configured (unlimited). "
+            "Advisory UX hint only — the cap is enforced server-side at upload."
+        ),
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -14873,6 +14873,18 @@
             "description": "Whether presigned S3 uploads are enabled (requires `STORAGE_PROVIDER=s3`).",
             "title": "Presigned Uploads",
             "type": "boolean"
+          },
+          "remaining_dataset_quota": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Datasets the caller may still create before hitting the per-user count cap, or null when no count cap is configured (unlimited). Advisory UX hint only \u2014 the cap is enforced server-side at upload.",
+            "title": "Remaining Dataset Quota"
           }
         },
         "required": [

--- a/backend/tests/test_1224_ingest_quota_enforcement.py
+++ b/backend/tests/test_1224_ingest_quota_enforcement.py
@@ -271,6 +271,58 @@ class TestUploadCountCap:
         assert status_code == 201, f"Default unlimited must pass; got {status_code}"
 
 
+class TestUploadConfigRemainingQuota:
+    async def test_config_reports_remaining_when_cap_set(
+        self,
+        client: AsyncClient,
+        admin_auth_header: dict,
+        test_db_session: AsyncSession,
+    ) -> None:
+        """GET /ingest/upload/config returns remaining = cap - current count.
+
+        Lets the client cap a batch at what the user can actually create.
+        """
+        from app.modules.quota.service import get_user_quota_usage
+
+        user_id = await _get_test_user_id(
+            test_db_session, settings.geolens_admin_username
+        )
+        await _create_record(test_db_session, user_id=user_id)
+
+        # Order-independent: derive expected from the actual count (other tests
+        # in this file leave committed records on the same admin user).
+        with (
+            patch(
+                "app.modules.quota.service.MAX_STORAGE_BYTES_PER_USER.get",
+                new_callable=AsyncMock,
+                return_value=0,
+            ),
+            patch(
+                "app.modules.quota.service.MAX_DATASETS_PER_USER.get",
+                new_callable=AsyncMock,
+                return_value=10,
+            ),
+        ):
+            usage = await get_user_quota_usage(test_db_session, user_id)
+            resp = await client.get("/ingest/upload/config", headers=admin_auth_header)
+
+        assert resp.status_code == 200, resp.text
+        assert usage.dataset_count >= 1  # our inserted record is counted
+        assert resp.json()["remaining_dataset_quota"] == max(
+            0, 10 - usage.dataset_count
+        )
+
+    async def test_config_remaining_is_null_when_unlimited(
+        self,
+        client: AsyncClient,
+        admin_auth_header: dict,
+    ) -> None:
+        """Default config (cap=0) → remaining is null (unlimited)."""
+        resp = await client.get("/ingest/upload/config", headers=admin_auth_header)
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["remaining_dataset_quota"] is None
+
+
 class TestReuploadQuota:
     async def test_reupload_byte_cap_also_enforced(
         self,

--- a/frontend/src/api/_presignedUpload.test.ts
+++ b/frontend/src/api/_presignedUpload.test.ts
@@ -68,6 +68,19 @@ describe('uploadChunks', () => {
     expect(mockFetch).toHaveBeenCalledTimes(3);
   });
 
+  it('reports cumulative progress (0–1) after each chunk completes', async () => {
+    mockFetch
+      .mockResolvedValueOnce(putResponse('"e1"'))
+      .mockResolvedValueOnce(putResponse('"e2"'))
+      .mockResolvedValueOnce(putResponse('"e3"'));
+
+    const file = new Blob(['aaaabbbbccc']); // 11 bytes, partSize 4 → 4/11, 8/11, 11/11
+    const progress: number[] = [];
+    await uploadChunks(['u1', 'u2', 'u3'], file, 4, (p) => progress.push(p));
+
+    expect(progress).toEqual([4 / 11, 8 / 11, 1]);
+  });
+
   it('falls back to empty string when ETag header is missing', async () => {
     mockFetch.mockResolvedValueOnce(putResponse(null));
 

--- a/frontend/src/api/_presignedUpload.ts
+++ b/frontend/src/api/_presignedUpload.ts
@@ -17,6 +17,9 @@
  * @param urls     Ordered list of presigned PUT URLs (one per part).
  * @param file     The File or Blob to slice and upload.
  * @param partSize Byte size of each chunk; the final part may be shorter.
+ * @param onProgress Optional callback invoked with the cumulative fraction
+ *                 (0–1) after each chunk completes. Coarse (per-chunk), not
+ *                 per-byte, but enough for a progress bar.
  * @returns        ETag header values in the same order as `urls`.
  *                 An empty string is returned for any part whose response
  *                 omitted the ETag header (preserves prior behaviour).
@@ -27,6 +30,7 @@ export async function uploadChunks(
   urls: string[],
   file: File | Blob,
   partSize: number,
+  onProgress?: (fraction: number) => void,
 ): Promise<string[]> {
   const etags: string[] = [];
 
@@ -39,6 +43,7 @@ export async function uploadChunks(
       throw new Error(`S3 part ${i + 1} upload failed: ${resp.status}`);
     }
     etags.push(resp.headers.get('ETag') ?? '');
+    onProgress?.(end / file.size);
   }
 
   return etags;

--- a/frontend/src/api/ingest.ts
+++ b/frontend/src/api/ingest.ts
@@ -1,5 +1,8 @@
-import { apiFetch } from './client';
+import { apiFetch, ApiError, tryRefresh } from './client';
 import { uploadChunks } from './_presignedUpload';
+import { API_BASE } from '@/lib/constants';
+import { translateError } from '@/lib/error-map';
+import { useAuthStore } from '@/stores/auth-store';
 import type {
   UploadResponse,
   JobStatusResponse,
@@ -18,14 +21,75 @@ import type {
   VrtCreateResponse,
 } from '@/types/api';
 
-export async function uploadFile(file: File): Promise<UploadResponse> {
+/** Byte-transfer progress callback (0–1). */
+export type UploadProgress = (fraction: number) => void;
+
+/**
+ * XHR-based POST so we can report upload-byte progress — `fetch()` cannot.
+ * Mirrors authenticatedRawFetch's proactive-refresh + single 401 retry so a
+ * first-after-idle upload doesn't hard-fail on a stale JWT.
+ * ponytail: a 401 retry re-sends the whole body — acceptable, refresh makes it rare.
+ */
+async function xhrUpload<T>(
+  path: string,
+  formData: FormData,
+  onProgress?: UploadProgress,
+): Promise<T> {
+  const { token, expiresAt } = useAuthStore.getState();
+  if (token && expiresAt && Date.now() > expiresAt - 30_000) {
+    await tryRefresh();
+  }
+
+  const attempt = (): Promise<{ status: number; body: string }> =>
+    new Promise((resolve, reject) => {
+      const xhr = new XMLHttpRequest();
+      xhr.open('POST', `${API_BASE}${path}`);
+      const jwt = useAuthStore.getState().token;
+      if (jwt) xhr.setRequestHeader('Authorization', `Bearer ${jwt}`);
+      if (onProgress) {
+        xhr.upload.onprogress = (e) => {
+          if (e.lengthComputable) onProgress(e.loaded / e.total);
+        };
+      }
+      xhr.onload = () => resolve({ status: xhr.status, body: xhr.responseText });
+      xhr.onerror = () =>
+        reject(new ApiError('Network unavailable — check your connection', 0));
+      xhr.send(formData);
+    });
+
+  let res = await attempt();
+  if (res.status === 401 && (await tryRefresh())) {
+    res = await attempt();
+  }
+
+  if (res.status < 200 || res.status >= 300) {
+    let detail = `HTTP ${res.status}`;
+    try {
+      const parsed = JSON.parse(res.body);
+      if (parsed?.detail !== undefined) {
+        detail =
+          typeof parsed.detail === 'string'
+            ? parsed.detail
+            : JSON.stringify(parsed.detail);
+      }
+    } catch {
+      // non-JSON body — keep the HTTP status fallback
+    }
+    if (res.status === 401) useAuthStore.getState().logout();
+    throw new ApiError(translateError(detail), res.status);
+  }
+
+  return JSON.parse(res.body) as T;
+}
+
+export async function uploadFile(
+  file: File,
+  onProgress?: UploadProgress,
+): Promise<UploadResponse> {
   const formData = new FormData();
   formData.append('file', file);
 
-  return apiFetch<UploadResponse>('/ingest/upload', {
-    method: 'POST',
-    body: formData,
-  });
+  return xhrUpload<UploadResponse>('/ingest/upload', formData, onProgress);
 }
 
 export async function getJobStatus(
@@ -130,7 +194,10 @@ export async function completePresignedUpload(
  * 3. Notify backend of completion
  * Returns the same UploadResponse as the regular upload endpoint.
  */
-export async function uploadPresigned(file: File): Promise<UploadResponse> {
+export async function uploadPresigned(
+  file: File,
+  onProgress?: UploadProgress,
+): Promise<UploadResponse> {
   const { job_id, urls, upload_id, part_size } = await requestPresignedUpload(
     file.name,
     file.size,
@@ -138,14 +205,17 @@ export async function uploadPresigned(file: File): Promise<UploadResponse> {
   );
 
   if (urls.length === 1 && !upload_id) {
-    // Simple PUT upload
+    // Simple PUT upload. ponytail: single-PUT is only used for small files —
+    // coarse 0→1 instead of an extra XHR-with-progress path.
+    onProgress?.(0);
     const resp = await fetch(urls[0], { method: 'PUT', body: file });
     if (!resp.ok) throw new Error(`S3 upload failed: ${resp.status} ${resp.statusText}`);
+    onProgress?.(1);
     return completePresignedUpload(job_id);
   }
 
-  // Multipart upload
-  const etags = await uploadChunks(urls, file, part_size!);
+  // Multipart upload — progress reported per completed chunk.
+  const etags = await uploadChunks(urls, file, part_size!, onProgress);
   const completedParts = etags.map((etag, i) => ({ etag, part_number: i + 1 }));
 
   return completePresignedUpload(job_id, completedParts);

--- a/frontend/src/components/import/BulkUploadProgress.tsx
+++ b/frontend/src/components/import/BulkUploadProgress.tsx
@@ -27,6 +27,10 @@ export function BulkUploadProgress({ entries }: BulkUploadProgressProps) {
       {entries.map((entry, i) => {
         const ext = fileExt(entry.fileName);
         const kind = kindFromEntry(entry);
+        const pct =
+          entry.status === 'uploading' && entry.progress != null
+            ? Math.round(entry.progress * 100)
+            : null;
 
         return (
           <div
@@ -42,11 +46,26 @@ export function BulkUploadProgress({ entries }: BulkUploadProgressProps) {
                 {entry.fileName.replace(/\.[^.]+$/, '')}
                 <span className="font-mono font-normal text-muted-foreground">{ext}</span>
               </div>
+              {pct != null && (
+                <div className="mt-1.5 h-1 w-full overflow-hidden rounded-full bg-surface-2">
+                  <div
+                    className="h-full rounded-full bg-primary transition-[width] duration-150 ease-out"
+                    style={{ width: `${pct}%` }}
+                  />
+                </div>
+              )}
               {entry.status === 'upload-failed' && entry.error && (
                 <p className="mt-0.5 text-xs text-destructive">{entry.error}</p>
               )}
             </div>
-            <StatusPill status={entry.status} />
+            <div className="flex items-center gap-2">
+              {pct != null && (
+                <span className="font-mono text-[11px] tabular-nums text-muted-foreground">
+                  {pct}%
+                </span>
+              )}
+              <StatusPill status={entry.status} />
+            </div>
           </div>
         );
       })}

--- a/frontend/src/components/import/FileDropzone.tsx
+++ b/frontend/src/components/import/FileDropzone.tsx
@@ -16,6 +16,9 @@ interface FileDropzoneProps {
   disabled?: boolean;
   allowedExtensions?: string[];
   maxSizeMb?: number;
+  /** Remaining per-user dataset quota; null = unlimited. Caps the batch so the
+   *  UI never offers more files than the user can actually create. */
+  remainingQuota?: number | null;
 }
 
 /** Group deduped extensions by data kind for the format pills */
@@ -39,8 +42,16 @@ function groupByKind(extensions: string[]): { kind: DataKind; ext: string }[] {
   return result;
 }
 
-export function FileDropzone({ onFilesAccepted, disabled, allowedExtensions, maxSizeMb }: FileDropzoneProps) {
+export function FileDropzone({ onFilesAccepted, disabled, allowedExtensions, maxSizeMb, remainingQuota }: FileDropzoneProps) {
   const { t } = useTranslation('import');
+
+  // Cap the batch at the smaller of the UX limit and remaining quota. Floor at
+  // 1 (not 0 — react-dropzone treats maxFiles:0 as unlimited) so an at-cap user
+  // can still drop one file and get the explicit server quota error + banner.
+  // ponytail: client-side UX guard only; the cap is enforced server-side at
+  // upload. Atomic batch enforcement is a deferred worker-side concern.
+  const effectiveMaxFiles =
+    remainingQuota != null ? Math.min(MAX_BATCH_FILES, Math.max(1, remainingQuota)) : MAX_BATCH_FILES;
 
   const accept = useMemo(() => {
     if (!allowedExtensions || allowedExtensions.length === 0) return undefined;
@@ -62,7 +73,7 @@ export function FileDropzone({ onFilesAccepted, disabled, allowedExtensions, max
   const { getRootProps, getInputProps, isDragActive, isDragReject } =
     useDropzone({
       accept,
-      maxFiles: MAX_BATCH_FILES,
+      maxFiles: effectiveMaxFiles,
       maxSize: maxSizeMb ? maxSizeMb * 1024 * 1024 : undefined,
       multiple: true,
       disabled,
@@ -116,7 +127,7 @@ export function FileDropzone({ onFilesAccepted, disabled, allowedExtensions, max
 
       <p className="mb-5 text-[13px] text-muted-foreground">
         {t('dropzone.subtext', {
-          max: MAX_BATCH_FILES,
+          max: effectiveMaxFiles,
           defaultValue: 'GeoLens will detect geometry, CRS, and schema before committing to the catalog. Batches up to {{max}} files.',
         })}
       </p>
@@ -134,7 +145,7 @@ export function FileDropzone({ onFilesAccepted, disabled, allowedExtensions, max
         {maxSizeMb != null
           ? t('dropzone.sizeLimitDynamic', { size: maxSizeMb, defaultValue: `Max ${maxSizeMb} MB per file` })
           : t('dropzone.sizeLimit')}{' '}
-        · {t('dropzone.batchLimit', { max: MAX_BATCH_FILES, defaultValue: 'Up to {{max}} files per batch' })}
+        · {t('dropzone.batchLimit', { max: effectiveMaxFiles, defaultValue: 'Up to {{max}} files per batch' })}
       </p>
     </div>
   );

--- a/frontend/src/components/import/FileDropzone.tsx
+++ b/frontend/src/components/import/FileDropzone.tsx
@@ -8,6 +8,9 @@ import { buildAcceptMap, deriveFormatBadges } from '@/lib/file-utils';
 import { FormatPill, kindFromExtension } from './TypeTag';
 import type { DataKind } from '@/types/api';
 
+/** Client-side batch guard. Real caps (per-file size, dataset quota) are server-enforced. */
+const MAX_BATCH_FILES = 25;
+
 interface FileDropzoneProps {
   onFilesAccepted: (files: File[]) => void;
   disabled?: boolean;
@@ -59,7 +62,7 @@ export function FileDropzone({ onFilesAccepted, disabled, allowedExtensions, max
   const { getRootProps, getInputProps, isDragActive, isDragReject } =
     useDropzone({
       accept,
-      maxFiles: 10,
+      maxFiles: MAX_BATCH_FILES,
       maxSize: maxSizeMb ? maxSizeMb * 1024 * 1024 : undefined,
       multiple: true,
       disabled,
@@ -113,7 +116,8 @@ export function FileDropzone({ onFilesAccepted, disabled, allowedExtensions, max
 
       <p className="mb-5 text-[13px] text-muted-foreground">
         {t('dropzone.subtext', {
-          defaultValue: 'GeoLens will detect geometry, CRS, and schema before committing to the catalog. Batches up to 10 files.',
+          max: MAX_BATCH_FILES,
+          defaultValue: 'GeoLens will detect geometry, CRS, and schema before committing to the catalog. Batches up to {{max}} files.',
         })}
       </p>
 
@@ -130,7 +134,7 @@ export function FileDropzone({ onFilesAccepted, disabled, allowedExtensions, max
         {maxSizeMb != null
           ? t('dropzone.sizeLimitDynamic', { size: maxSizeMb, defaultValue: `Max ${maxSizeMb} MB per file` })
           : t('dropzone.sizeLimit')}{' '}
-        · {t('dropzone.batchLimit', { defaultValue: 'Up to 10 files per batch' })}
+        · {t('dropzone.batchLimit', { max: MAX_BATCH_FILES, defaultValue: 'Up to {{max}} files per batch' })}
       </p>
     </div>
   );

--- a/frontend/src/components/import/UploadForm.tsx
+++ b/frontend/src/components/import/UploadForm.tsx
@@ -1,8 +1,10 @@
 import { useState, useCallback, useMemo, useRef, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
+import { useQueryClient } from '@tanstack/react-query';
 import { uploadFile, previewFile, commitImport, uploadPresigned } from '@/api/ingest';
 import { commitFanOut } from '@/api/datasets';
 import { useUploadConfig } from '@/components/import/hooks/use-ingest';
+import { queryKeys } from '@/lib/query-keys';
 import { toast } from 'sonner';
 import { Button } from '@/components/ui/button';
 import {
@@ -67,6 +69,7 @@ interface UploadFormProps {
 
 export function UploadForm({ onPhaseChange }: UploadFormProps) {
   const { t } = useTranslation('import');
+  const queryClient = useQueryClient();
   const [phase, _setPhase] = useState<BatchPhase>('idle');
   const onPhaseChangeRef = useRef(onPhaseChange);
   onPhaseChangeRef.current = onPhaseChange;
@@ -102,7 +105,11 @@ export function UploadForm({ onPhaseChange }: UploadFormProps) {
     setEntries([]);
     setAutoOpenVrt(false);
     setQuotaNotice(null);
-  }, [setPhase]);
+    // Refresh remaining_dataset_quota so "Upload More" after an import reflects
+    // the new dataset count instead of the cached pre-import value (Codex P2 on
+    // PR #274). invalidate matches the user-scoped key by prefix.
+    queryClient.invalidateQueries({ queryKey: queryKeys.ingest.uploadConfig });
+  }, [setPhase, queryClient]);
 
   // IMPORT-03 (Phase 1054): phase transitions were inlined inside setEntries
   // updaters, which violates React 19's "no setState during another
@@ -457,9 +464,9 @@ export function UploadForm({ onPhaseChange }: UploadFormProps) {
 
   // idle. Disable until the config query settles so we never treat an
   // unresolved quota (uploadConfig === undefined → null) as "unlimited" and
-  // offer the full 25-file batch on a capped deployment (Codex P2). After it
-  // settles, success carries the real remaining quota; an error degrades to
-  // permissive — consistent with allowedExtensions/maxSizeMb.
+  // offer the full 25-file batch on a capped deployment (Codex P2 on PR #274).
+  // After it settles, success carries the real remaining quota; an error
+  // degrades to permissive — consistent with allowedExtensions/maxSizeMb.
   return (
     <FileDropzone
       onFilesAccepted={handleFilesAccepted}

--- a/frontend/src/components/import/UploadForm.tsx
+++ b/frontend/src/components/import/UploadForm.tsx
@@ -83,7 +83,7 @@ export function UploadForm({ onPhaseChange }: UploadFormProps) {
     entryId: string;
     results: FanOutResult[];
   } | null>(null);
-  const { data: uploadConfig } = useUploadConfig();
+  const { data: uploadConfig, isPending: configPending } = useUploadConfig();
 
   const allowedExtensions = useMemo(
     () => uploadConfig?.allowed_extensions?.split(',').map(e => e.trim()).filter(Boolean),
@@ -455,13 +455,18 @@ export function UploadForm({ onPhaseChange }: UploadFormProps) {
     return <BulkTrackingList entries={entries} onReset={reset} autoOpenVrt={autoOpenVrt} />;
   }
 
-  // idle
+  // idle. Disable until the config query settles so we never treat an
+  // unresolved quota (uploadConfig === undefined → null) as "unlimited" and
+  // offer the full 25-file batch on a capped deployment (Codex P2). After it
+  // settles, success carries the real remaining quota; an error degrades to
+  // permissive — consistent with allowedExtensions/maxSizeMb.
   return (
     <FileDropzone
       onFilesAccepted={handleFilesAccepted}
       allowedExtensions={allowedExtensions}
       maxSizeMb={maxSizeMb}
       remainingQuota={uploadConfig?.remaining_dataset_quota ?? null}
+      disabled={configPending}
     />
   );
 }

--- a/frontend/src/components/import/UploadForm.tsx
+++ b/frontend/src/components/import/UploadForm.tsx
@@ -86,7 +86,10 @@ export function UploadForm({ onPhaseChange }: UploadFormProps) {
     entryId: string;
     results: FanOutResult[];
   } | null>(null);
-  const { data: uploadConfig, isPending: configPending } = useUploadConfig();
+  // isFetching (not just isPending) so the dropzone is also disabled during the
+  // refetchOnMount background refresh — otherwise the cached-but-stale quota is
+  // briefly usable on remount before the live GET lands (Codex P2 on PR #274).
+  const { data: uploadConfig, isFetching: configFetching } = useUploadConfig();
 
   const allowedExtensions = useMemo(
     () => uploadConfig?.allowed_extensions?.split(',').map(e => e.trim()).filter(Boolean),
@@ -462,18 +465,19 @@ export function UploadForm({ onPhaseChange }: UploadFormProps) {
     return <BulkTrackingList entries={entries} onReset={reset} autoOpenVrt={autoOpenVrt} />;
   }
 
-  // idle. Disable until the config query settles so we never treat an
-  // unresolved quota (uploadConfig === undefined → null) as "unlimited" and
-  // offer the full 25-file batch on a capped deployment (Codex P2 on PR #274).
-  // After it settles, success carries the real remaining quota; an error
-  // degrades to permissive — consistent with allowedExtensions/maxSizeMb.
+  // idle. Disable while the quota query is fetching (initial load OR the
+  // refetch-on-mount refresh) so we never act on an unresolved/stale quota:
+  // treating undefined→null as "unlimited" would offer the full 25-file batch
+  // on a capped deployment (Codex P2 on PR #274). Once a fetch settles, success
+  // carries the live remaining quota; an error degrades to permissive —
+  // consistent with allowedExtensions/maxSizeMb.
   return (
     <FileDropzone
       onFilesAccepted={handleFilesAccepted}
       allowedExtensions={allowedExtensions}
       maxSizeMb={maxSizeMb}
       remainingQuota={uploadConfig?.remaining_dataset_quota ?? null}
-      disabled={configPending}
+      disabled={configFetching}
     />
   );
 }

--- a/frontend/src/components/import/UploadForm.tsx
+++ b/frontend/src/components/import/UploadForm.tsx
@@ -457,6 +457,11 @@ export function UploadForm({ onPhaseChange }: UploadFormProps) {
 
   // idle
   return (
-    <FileDropzone onFilesAccepted={handleFilesAccepted} allowedExtensions={allowedExtensions} maxSizeMb={maxSizeMb} />
+    <FileDropzone
+      onFilesAccepted={handleFilesAccepted}
+      allowedExtensions={allowedExtensions}
+      maxSizeMb={maxSizeMb}
+      remainingQuota={uploadConfig?.remaining_dataset_quota ?? null}
+    />
   );
 }

--- a/frontend/src/components/import/UploadForm.tsx
+++ b/frontend/src/components/import/UploadForm.tsx
@@ -46,6 +46,14 @@ function buildErrorDisplay(err: unknown, fallbackKey: string, t: (key: string) =
   return hint ? `${msg}\n${hint}` : msg;
 }
 
+// Quota (422) errors are identical across every file in a batch — surface them
+// once as a banner instead of repeating the same red line on each row.
+function quotaMessage(err: unknown): string | null {
+  return err instanceof ApiError && err.message.startsWith('Dataset quota exceeded')
+    ? err.message
+    : null;
+}
+
 // GPKG-03 Phase 1058: per-layer result shape for the fan-out results modal.
 type FanOutResult = {
   layerName: string;
@@ -68,6 +76,8 @@ export function UploadForm({ onPhaseChange }: UploadFormProps) {
   }, []);
   const [entries, setEntries] = useState<FileEntry[]>([]);
   const [autoOpenVrt, setAutoOpenVrt] = useState(false);
+  // Batch-level quota notice (the "X of Y datasets used" detail), shown once.
+  const [quotaNotice, setQuotaNotice] = useState<string | null>(null);
   // GPKG-03 Phase 1058: results modal state for the multi-layer fan-out
   const [fanOutResults, setFanOutResults] = useState<{
     entryId: string;
@@ -91,6 +101,7 @@ export function UploadForm({ onPhaseChange }: UploadFormProps) {
     setPhase('idle');
     setEntries([]);
     setAutoOpenVrt(false);
+    setQuotaNotice(null);
   }, [setPhase]);
 
   // IMPORT-03 (Phase 1054): phase transitions were inlined inside setEntries
@@ -119,6 +130,7 @@ export function UploadForm({ onPhaseChange }: UploadFormProps) {
 
   const handleFilesAccepted = async (files: File[]) => {
     if (phase !== 'idle') return;
+    setQuotaNotice(null);
 
     // Duplicate detection against existing entries
     const existing = new Set(
@@ -144,6 +156,7 @@ export function UploadForm({ onPhaseChange }: UploadFormProps) {
       jobId: null,
       previewData: null,
       error: null,
+      progress: 0,
       submittedTitle: null,
       submittedVisibility: null,
       submittedKind: null,
@@ -154,11 +167,12 @@ export function UploadForm({ onPhaseChange }: UploadFormProps) {
 
     await Promise.allSettled(
       newEntries.map(async (entry) => {
+        const onProgress = (p: number) => updateEntry(entry.id, { progress: p });
         try {
           const result = uploadConfig?.presigned_uploads
-            ? await uploadPresigned(entry.file!)
-            : await uploadFile(entry.file!);
-          updateEntry(entry.id, { jobId: result.job_id, status: 'previewing' });
+            ? await uploadPresigned(entry.file!, onProgress)
+            : await uploadFile(entry.file!, onProgress);
+          updateEntry(entry.id, { jobId: result.job_id, status: 'previewing', progress: null });
 
           const preview = await previewFile(result.job_id);
           updateEntry(entry.id, {
@@ -167,10 +181,13 @@ export function UploadForm({ onPhaseChange }: UploadFormProps) {
             file: null,
           });
         } catch (err) {
+          const quota = quotaMessage(err);
+          if (quota) setQuotaNotice(quota);
           updateEntry(entry.id, {
             status: 'upload-failed',
-            error: buildErrorDisplay(err, 'upload.uploadFailed', t),
+            error: quota ? t('upload.quotaShort') : buildErrorDisplay(err, 'upload.uploadFailed', t),
             file: null,
+            progress: null,
           });
         }
       }),
@@ -205,7 +222,12 @@ export function UploadForm({ onPhaseChange }: UploadFormProps) {
       // dep'd on `entries`; no inline setPhase call here (IMPORT-03).
       toast.success(t('upload.importStarted'));
     } catch (err) {
-      updateEntry(entryId, { status: 'commit-failed', error: buildErrorDisplay(err, 'upload.commitFailed', t) });
+      const quota = quotaMessage(err);
+      if (quota) setQuotaNotice(quota);
+      updateEntry(entryId, {
+        status: 'commit-failed',
+        error: quota ? t('upload.quotaShort') : buildErrorDisplay(err, 'upload.commitFailed', t),
+      });
     }
   };
 
@@ -239,7 +261,12 @@ export function UploadForm({ onPhaseChange }: UploadFormProps) {
             submittedKind: inferImportedKind(entry),
           });
         } catch (err) {
-          updateEntry(entry.id, { status: 'commit-failed', error: buildErrorDisplay(err, 'upload.bulkCommitFailed', t) });
+          const quota = quotaMessage(err);
+          if (quota) setQuotaNotice(quota);
+          updateEntry(entry.id, {
+            status: 'commit-failed',
+            error: quota ? t('upload.quotaShort') : buildErrorDisplay(err, 'upload.bulkCommitFailed', t),
+          });
         }
       }),
     );
@@ -336,13 +363,30 @@ export function UploadForm({ onPhaseChange }: UploadFormProps) {
     // useEffect dep'd on `entries` (IMPORT-03).
   };
 
+  const quotaBanner = quotaNotice ? (
+    <div className="flex items-start gap-2.5 rounded-xl border border-destructive/30 bg-destructive/10 px-4 py-3 text-sm text-destructive">
+      <AlertCircle className="mt-0.5 size-4 shrink-0" />
+      <div>
+        <p className="font-medium">{t('upload.quotaBannerTitle')}</p>
+        <p className="mt-0.5 text-destructive/90">{quotaNotice}</p>
+        <p className="mt-0.5 text-xs text-destructive/80">{t('upload.quotaBannerHint')}</p>
+      </div>
+    </div>
+  ) : null;
+
   if (phase === 'uploading') {
-    return <BulkUploadProgress entries={entries} />;
+    return (
+      <div className="space-y-4">
+        {quotaBanner}
+        <BulkUploadProgress entries={entries} />
+      </div>
+    );
   }
 
   if (phase === 'reviewing') {
     return (
       <div className="space-y-4">
+        {quotaBanner}
         <BulkReviewList
           entries={entries}
           onCommitSingle={handleCommitSingle}

--- a/frontend/src/components/import/hooks/__tests__/use-ingest.test.ts
+++ b/frontend/src/components/import/hooks/__tests__/use-ingest.test.ts
@@ -63,7 +63,9 @@ describe('useUploadFile', () => {
     const file = new File(['{}'], 'test.geojson', { type: 'application/json' });
     await result.current.mutateAsync(file);
 
-    expect(mockUploadFile).toHaveBeenCalledWith(file, expect.anything());
+    // Hook wraps uploadFile so TanStack's injected context isn't passed as
+    // the (onProgress) 2nd arg — uploadFile receives the file only.
+    expect(mockUploadFile).toHaveBeenCalledWith(file);
   });
 
   it('returns error state on upload failure', async () => {

--- a/frontend/src/components/import/hooks/use-ingest.ts
+++ b/frontend/src/components/import/hooks/use-ingest.ts
@@ -100,15 +100,20 @@ export function useBulkRegister() {
 }
 
 export function useUploadConfig() {
-  // The payload carries per-user `remaining_dataset_quota`, so scope the cache
-  // by user id — otherwise a stale entry leaks across an account switch on the
-  // SPA (logout only clears auth.me). The static config fields are identical
-  // across users, so the extra fetch on switch is cheap. (Codex P2 on PR #274)
+  // The payload carries per-user `remaining_dataset_quota`, which changes on any
+  // import or delete — so it is NOT static config and must not be cached like
+  // it. (Codex P2 on PR #274)
+  //   - key scoped by user id: a stale per-user value can't leak across an
+  //     account switch (logout only clears auth.me).
+  //   - staleTime 0 + refetchOnMount 'always': returning to Import after a
+  //     delete/import elsewhere re-reads the live count (a same-mount "Upload
+  //     More" is additionally handled by invalidate-on-reset in UploadForm).
   const userId = useAuthStore((s) => s.user?.id);
   return useQuery({
     queryKey: [...queryKeys.ingest.uploadConfig, userId ?? 'anon'],
     queryFn: getUploadConfig,
-    staleTime: 300_000, // 5 minutes -- storage provider changes rarely
+    staleTime: 0,
+    refetchOnMount: 'always',
   });
 }
 

--- a/frontend/src/components/import/hooks/use-ingest.ts
+++ b/frontend/src/components/import/hooks/use-ingest.ts
@@ -7,7 +7,8 @@ import type { BulkRegisterRequest, VrtCreateRequest, SearchResponse } from '@/ty
 
 export function useUploadFile() {
   return useMutation({
-    mutationFn: uploadFile,
+    // Wrap so TanStack's injected 2nd arg (context) isn't passed as onProgress.
+    mutationFn: (file: File) => uploadFile(file),
   });
 }
 

--- a/frontend/src/components/import/hooks/use-ingest.ts
+++ b/frontend/src/components/import/hooks/use-ingest.ts
@@ -100,8 +100,13 @@ export function useBulkRegister() {
 }
 
 export function useUploadConfig() {
+  // The payload carries per-user `remaining_dataset_quota`, so scope the cache
+  // by user id — otherwise a stale entry leaks across an account switch on the
+  // SPA (logout only clears auth.me). The static config fields are identical
+  // across users, so the extra fetch on switch is cheap. (Codex P2 on PR #274)
+  const userId = useAuthStore((s) => s.user?.id);
   return useQuery({
-    queryKey: queryKeys.ingest.uploadConfig,
+    queryKey: [...queryKeys.ingest.uploadConfig, userId ?? 'anon'],
     queryFn: getUploadConfig,
     staleTime: 300_000, // 5 minutes -- storage provider changes rarely
   });

--- a/frontend/src/i18n/locales/de/import.json
+++ b/frontend/src/i18n/locales/de/import.json
@@ -67,7 +67,10 @@
     "multiLayerPartialFailed": "{{succeeded}} Ebenen importiert, {{failed}} fehlgeschlagen.",
     "multiLayerResultsTitle": "Mehrebenige Import-Ergebnisse",
     "multiLayerResultsSummary": "{{succeeded}} erfolgreich, {{failed}} fehlgeschlagen.",
-    "multiLayerRetryClose": "Schließen (erneut auf 'Alle Ebenen importieren' klicken)"
+    "multiLayerRetryClose": "Schließen (erneut auf 'Alle Ebenen importieren' klicken)",
+    "quotaShort": "Übersprungen – Datensatzlimit erreicht",
+    "quotaBannerTitle": "Datensatzlimit erreicht",
+    "quotaBannerHint": "Löschen Sie vorhandene Datensätze, um Platz zu schaffen, oder bitten Sie einen Administrator, das Limit zu erhöhen."
   },
   "warnings": {
     "bannerTitle": "Import mit Warnungen abgeschlossen",
@@ -94,11 +97,11 @@
     "unsupportedType": "Dieser Dateityp wird nicht unterstützt",
     "sizeLimit": "Maximal 500 MB pro Datei",
     "sizeLimitDynamic": "Maximal {{size}} MB pro Datei",
-    "batchLimit": "Bis zu 10 Dateien pro Stapel",
+    "batchLimit": "Bis zu {{max}} Dateien pro Stapel",
     "fileRejected": "{{filename}}: {{reason}}",
     "browse": "Durchsuchen",
     "toUpload": "zum Hochladen",
-    "subtext": "GeoLens erkennt Geometrie, KRS und Schema, bevor es in den Katalog übernommen wird. Stapel bis zu 10 Dateien."
+    "subtext": "GeoLens erkennt Geometrie, KRS und Schema, bevor es in den Katalog übernommen wird. Stapel bis zu {{max}} Dateien."
   },
   "stac": {
     "label": "STAC-API-URL — Katalog-Stammendpunkt einfügen",

--- a/frontend/src/i18n/locales/en/import.json
+++ b/frontend/src/i18n/locales/en/import.json
@@ -67,7 +67,10 @@
     "multiLayerPartialFailed": "{{succeeded}} layers imported, {{failed}} failed.",
     "multiLayerResultsTitle": "Multi-layer ingest results",
     "multiLayerResultsSummary": "{{succeeded}} succeeded, {{failed}} failed.",
-    "multiLayerRetryClose": "Close (retry by re-clicking Ingest all layers)"
+    "multiLayerRetryClose": "Close (retry by re-clicking Ingest all layers)",
+    "quotaShort": "Skipped — dataset limit reached",
+    "quotaBannerTitle": "Dataset limit reached",
+    "quotaBannerHint": "Delete existing datasets to free space, or ask an administrator to raise the limit."
   },
   "warnings": {
     "bannerTitle": "Import completed with warnings",
@@ -103,12 +106,12 @@
     "instructions": "Drag and drop files here, or click to browse",
     "browse": "browse",
     "toUpload": "to upload",
-    "subtext": "GeoLens will detect geometry, CRS, and schema before committing to the catalog. Batches up to 10 files.",
+    "subtext": "GeoLens will detect geometry, CRS, and schema before committing to the catalog. Batches up to {{max}} files.",
     "dropHere": "Drop files here",
     "unsupportedType": "This file type is not supported",
     "sizeLimit": "Max 500 MB per file",
     "sizeLimitDynamic": "Max {{size}} MB per file",
-    "batchLimit": "Up to 10 files per batch",
+    "batchLimit": "Up to {{max}} files per batch",
     "fileRejected": "{{filename}}: {{reason}}"
   },
   "stac": {

--- a/frontend/src/i18n/locales/es/import.json
+++ b/frontend/src/i18n/locales/es/import.json
@@ -67,7 +67,10 @@
     "multiLayerPartialFailed": "{{succeeded}} capas importadas, {{failed}} fallidas.",
     "multiLayerResultsTitle": "Resultados de ingesta multicapa",
     "multiLayerResultsSummary": "{{succeeded}} correctas, {{failed}} fallidas.",
-    "multiLayerRetryClose": "Cerrar (volver a hacer clic en 'Ingerir todas las capas')"
+    "multiLayerRetryClose": "Cerrar (volver a hacer clic en 'Ingerir todas las capas')",
+    "quotaShort": "Omitido: límite de conjuntos de datos alcanzado",
+    "quotaBannerTitle": "Límite de conjuntos de datos alcanzado",
+    "quotaBannerHint": "Elimina conjuntos de datos existentes para liberar espacio o pide a un administrador que aumente el límite."
   },
   "warnings": {
     "bannerTitle": "Importación completada con advertencias",
@@ -94,11 +97,11 @@
     "unsupportedType": "Este tipo de archivo no es compatible",
     "sizeLimit": "Máximo 500 MB por archivo",
     "sizeLimitDynamic": "Máximo {{size}} MB por archivo",
-    "batchLimit": "Hasta 10 archivos por lote",
+    "batchLimit": "Hasta {{max}} archivos por lote",
     "fileRejected": "{{filename}}: {{reason}}",
     "browse": "Examinar",
     "toUpload": "para cargar",
-    "subtext": "GeoLens detectará geometría, CRS y esquema antes de enviarlo al catálogo. Lotes de hasta 10 archivos."
+    "subtext": "GeoLens detectará geometría, CRS y esquema antes de enviarlo al catálogo. Lotes de hasta {{max}} archivos."
   },
   "stac": {
     "label": "URL de API STAC — pegue el endpoint raíz del catálogo",

--- a/frontend/src/i18n/locales/fr/import.json
+++ b/frontend/src/i18n/locales/fr/import.json
@@ -67,7 +67,10 @@
     "multiLayerPartialFailed": "{{succeeded}} couches importées, {{failed}} échouées.",
     "multiLayerResultsTitle": "Résultats d'ingestion multicouche",
     "multiLayerResultsSummary": "{{succeeded}} réussies, {{failed}} échouées.",
-    "multiLayerRetryClose": "Fermer (recliquer sur 'Ingérer toutes les couches')"
+    "multiLayerRetryClose": "Fermer (recliquer sur 'Ingérer toutes les couches')",
+    "quotaShort": "Ignoré — limite de jeux de données atteinte",
+    "quotaBannerTitle": "Limite de jeux de données atteinte",
+    "quotaBannerHint": "Supprimez des jeux de données existants pour libérer de l'espace, ou demandez à un administrateur d'augmenter la limite."
   },
   "warnings": {
     "bannerTitle": "Importation terminée avec des avertissements",
@@ -94,11 +97,11 @@
     "unsupportedType": "Ce type de fichier n'est pas pris en charge",
     "sizeLimit": "500 Mo maximum par fichier",
     "sizeLimitDynamic": "{{size}} Mo maximum par fichier",
-    "batchLimit": "Jusqu'à 10 fichiers par lot",
+    "batchLimit": "Jusqu'à {{max}} fichiers par lot",
     "fileRejected": "{{filename}} : {{reason}}",
     "browse": "Parcourir",
     "toUpload": "pour charger",
-    "subtext": "GeoLens détectera la géométrie, le SCR et le schéma avant de valider dans le catalogue. Lots jusqu'à 10 fichiers."
+    "subtext": "GeoLens détectera la géométrie, le SCR et le schéma avant de valider dans le catalogue. Lots jusqu'à {{max}} fichiers."
   },
   "stac": {
     "label": "URL de l'API STAC — collez le point d'accès racine du catalogue",

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -1538,6 +1538,8 @@ export interface UploadConfig {
   presigned_threshold_bytes: number;
   max_file_size_bytes: number;
   allowed_extensions: string;
+  /** Datasets the user may still create before the count cap; null = unlimited. */
+  remaining_dataset_quota: number | null;
 }
 
 export interface PresignedUploadRequest {

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -1411,6 +1411,8 @@ export interface FileEntry {
   jobId: string | null;
   previewData: FilePreviewResponse | RasterPreviewResponse | null;
   error: string | null;
+  /** Byte-transfer progress (0–1) during the `uploading` phase; null when unknown/done. */
+  progress?: number | null;
   submittedTitle?: string | null;
   submittedVisibility?: string | null;
   submittedKind?: DataKind | null;

--- a/sdks/python/geolens/models/upload_config_response.py
+++ b/sdks/python/geolens/models/upload_config_response.py
@@ -6,6 +6,10 @@ from typing import Any, TypeVar
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
 
+from ..types import UNSET, Unset
+
+from typing import cast
+
 
 T = TypeVar("T", bound="UploadConfigResponse")
 
@@ -18,12 +22,16 @@ class UploadConfigResponse:
         max_file_size_bytes (int): Maximum allowed upload size in bytes.
         presigned_threshold_bytes (int): File size threshold (bytes) above which multipart presigned URLs are used.
         presigned_uploads (bool): Whether presigned S3 uploads are enabled (requires `STORAGE_PROVIDER=s3`).
+        remaining_dataset_quota (int | None | Unset): Datasets the caller may still create before hitting the per-user
+            count cap, or null when no count cap is configured (unlimited). Advisory UX hint only — the cap is enforced
+            server-side at upload.
     """
 
     allowed_extensions: str
     max_file_size_bytes: int
     presigned_threshold_bytes: int
     presigned_uploads: bool
+    remaining_dataset_quota: int | None | Unset = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
@@ -35,6 +43,12 @@ class UploadConfigResponse:
 
         presigned_uploads = self.presigned_uploads
 
+        remaining_dataset_quota: int | None | Unset
+        if isinstance(self.remaining_dataset_quota, Unset):
+            remaining_dataset_quota = UNSET
+        else:
+            remaining_dataset_quota = self.remaining_dataset_quota
+
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
@@ -45,6 +59,8 @@ class UploadConfigResponse:
                 "presigned_uploads": presigned_uploads,
             }
         )
+        if remaining_dataset_quota is not UNSET:
+            field_dict["remaining_dataset_quota"] = remaining_dataset_quota
 
         return field_dict
 
@@ -59,11 +75,23 @@ class UploadConfigResponse:
 
         presigned_uploads = d.pop("presigned_uploads")
 
+        def _parse_remaining_dataset_quota(data: object) -> int | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(int | None | Unset, data)
+
+        remaining_dataset_quota = _parse_remaining_dataset_quota(
+            d.pop("remaining_dataset_quota", UNSET)
+        )
+
         upload_config_response = cls(
             allowed_extensions=allowed_extensions,
             max_file_size_bytes=max_file_size_bytes,
             presigned_threshold_bytes=presigned_threshold_bytes,
             presigned_uploads=presigned_uploads,
+            remaining_dataset_quota=remaining_dataset_quota,
         )
 
         upload_config_response.additional_properties = d

--- a/sdks/typescript/src/client/types.gen.ts
+++ b/sdks/typescript/src/client/types.gen.ts
@@ -8825,6 +8825,12 @@ export type UploadConfigResponse = {
      * Whether presigned S3 uploads are enabled (requires `STORAGE_PROVIDER=s3`).
      */
     presigned_uploads: boolean;
+    /**
+     * Remaining Dataset Quota
+     *
+     * Datasets the caller may still create before hitting the per-user count cap, or null when no count cap is configured (unlimited). Advisory UX hint only — the cap is enforced server-side at upload.
+     */
+    remaining_dataset_quota?: number | null;
 };
 
 /**


### PR DESCRIPTION
Three import-flow improvements surfaced while importing rasters on the demo (the screenshot showed `.tif` files failing with "Dataset quota exceeded: 12 of 10 datasets used" and no upload feedback).

## What changed

**1. Upload progress for large files (rasters)**
`fetch()` can't report upload-byte progress, so `uploadFile` now uses `XMLHttpRequest` and emits a 0–1 progress fraction; presigned multipart reports per-chunk. `BulkUploadProgress` renders a per-file bar + percent. The XHR path mirrors the existing `authenticatedRawFetch` proactive-refresh + single 401-retry so a first-after-idle upload doesn't hard-fail on a stale JWT.

**2. Batch file limit raised 10 → 25**
The 10-file cap was client-only (`react-dropzone`). Bumped to 25 and parametrized the copy via `{{max}}` so the number lives in one place. Deliberately **not** size-based: the meaningful caps (per-file 500MB via `body_limit` + the per-user dataset quota) are already server-enforced, so a client size-limiter would just duplicate them.

**3. Batch-level quota banner**
A quota (422) error is identical across every file in a batch, so the old UI repeated the same red line on each row. Now it surfaces **once** as a banner with the "X of Y datasets used" detail; each affected row just shows a short "limit reached" label.

## Notes
- The "12 of 10" itself is working-as-designed (demo `max_datasets_per_user=10` DB override). This PR only improves how it's communicated — it does not change quota enforcement.
- i18n keys added to all four locales (en/de/fr/es); parity + source-key gates pass.

## Verification
- `npm run typecheck` — clean
- `npm run test:i18n` + `check:i18n:changed` — pass
- `eslint` on touched files — clean
- `vitest run src/components/import src/api` — 138 passed (incl. new uploadChunks progress test + updated use-ingest test)

@codex review

https://claude.ai/code/session_01N1zmPNRxcyq7UyMJnzEbwC