### PR TITLE
fix(oauth): accept Azure multitenant issuer for Microsoft SSO

### DIFF
--- a/backend/app/modules/auth/oauth/router.py
+++ b/backend/app/modules/auth/oauth/router.py
@@ -15,6 +15,7 @@ from app.modules.auth.oauth.service import (
     _resolve_github_identity,
     get_enabled_providers,
     get_provider_by_slug,
+    is_azure_multitenant,
 )
 from app.modules.auth.providers import AuthenticatedIdentity
 from app.modules.auth.service import AuthService
@@ -30,12 +31,6 @@ from app.standards.ogc.errors import ERROR_RESPONSES_AUTH
 logger = structlog.stdlib.get_logger(__name__)
 
 router = APIRouter(prefix="/auth/oauth", tags=["Auth"], responses=ERROR_RESPONSES_AUTH)
-
-
-# Azure authorities whose discovery doc advertises a TEMPLATED issuer
-# ("https://login.microsoftonline.com/{tenantid}/v2.0"). Tenant-specific and
-# /consumers/ authorities have a fixed issuer and are intentionally excluded.
-_AZURE_MULTITENANT_AUTHORITIES = ("/common/", "/organizations/")
 
 
 def _id_token_claims_options(
@@ -59,10 +54,8 @@ def _id_token_claims_options(
     (geolens#303 review). Returns None for every other case so authlib keeps its
     default iss pin.
     """
-    if provider_type == "microsoft":
-        disco = (discovery_url or "").lower()
-        if any(authority in disco for authority in _AZURE_MULTITENANT_AUTHORITIES):
-            return {"iss": {"essential": True}}
+    if is_azure_multitenant(provider_type, discovery_url):
+        return {"iss": {"essential": True}}
     return None
 
 

--- a/backend/app/modules/auth/oauth/router.py
+++ b/backend/app/modules/auth/oauth/router.py
@@ -32,6 +32,28 @@ logger = structlog.stdlib.get_logger(__name__)
 router = APIRouter(prefix="/auth/oauth", tags=["Auth"], responses=ERROR_RESPONSES_AUTH)
 
 
+def _id_token_claims_options(provider_type: str) -> dict | None:
+    """id_token claim-validation overrides passed to ``authorize_access_token``.
+
+    Azure multitenant endpoints (``/common/``, ``/organizations/``) publish a
+    TEMPLATED issuer ``https://login.microsoftonline.com/{tenantid}/v2.0`` in
+    their OIDC discovery document, but issued id_tokens carry the resolved
+    per-tenant issuer (e.g. ``.../9188040d-.../v2.0`` for personal accounts).
+    authlib's default pins ``iss`` to the templated string via an exact
+    value-match and rejects every Microsoft login; joserfc only supports
+    value/values matching (no callable validator), so we relax ``iss`` to
+    required-but-not-value-pinned for Microsoft. The JWKS signature check and
+    the PKCE + client_secret code exchange still bind the token to Microsoft and
+    to this app, so signature/aud/nonce/exp validation is unaffected — only the
+    over-strict templated-``iss`` check is dropped (SSO-06).
+
+    Returns None for all other providers (authlib keeps its default iss pin).
+    """
+    if provider_type == "microsoft":
+        return {"iss": {"essential": True}}
+    return None
+
+
 async def build_oauth_client(provider_slug: str, db: AsyncSession) -> tuple:
     """Build an authlib OAuth client for the given provider slug.
 
@@ -193,8 +215,14 @@ async def oauth_callback(
     try:
         client, provider = await build_oauth_client(provider_slug, db)
 
-        # Exchange authorization code for tokens
-        token = await client.authorize_access_token(request)
+        # Exchange authorization code for tokens. For Microsoft multitenant the
+        # discovery issuer is templated, so relax the id_token iss check (SSO-06,
+        # see _id_token_claims_options).
+        authorize_kwargs: dict = {}
+        claims_options = _id_token_claims_options(provider.provider_type)
+        if claims_options is not None:
+            authorize_kwargs["claims_options"] = claims_options
+        token = await client.authorize_access_token(request, **authorize_kwargs)
 
         # Extract userinfo.
         # GitHub is plain OAuth2 (not OIDC) with no id_token / userinfo endpoint

--- a/backend/app/modules/auth/oauth/router.py
+++ b/backend/app/modules/auth/oauth/router.py
@@ -16,6 +16,7 @@ from app.modules.auth.oauth.service import (
     get_enabled_providers,
     get_provider_by_slug,
     is_azure_multitenant,
+    verify_azure_multitenant_issuer,
 )
 from app.modules.auth.providers import AuthenticatedIdentity
 from app.modules.auth.service import AuthService
@@ -248,6 +249,13 @@ async def oauth_callback(
             if userinfo is None:
                 userinfo = await client.userinfo(token=token)
             userinfo = dict(userinfo)
+
+        # Azure multitenant: the templated-issuer pin was relaxed at parse time,
+        # so re-assert the resolved per-tenant issuer here before the identity is
+        # trusted (geolens#303).
+        verify_azure_multitenant_issuer(
+            provider.provider_type, provider.discovery_url, userinfo
+        )
 
         # Find or create the GeoLens user
         user = await find_or_create_oauth_user(db, provider, userinfo, dict(token))

--- a/backend/app/modules/auth/oauth/router.py
+++ b/backend/app/modules/auth/oauth/router.py
@@ -32,25 +32,37 @@ logger = structlog.stdlib.get_logger(__name__)
 router = APIRouter(prefix="/auth/oauth", tags=["Auth"], responses=ERROR_RESPONSES_AUTH)
 
 
-def _id_token_claims_options(provider_type: str) -> dict | None:
+# Azure authorities whose discovery doc advertises a TEMPLATED issuer
+# ("https://login.microsoftonline.com/{tenantid}/v2.0"). Tenant-specific and
+# /consumers/ authorities have a fixed issuer and are intentionally excluded.
+_AZURE_MULTITENANT_AUTHORITIES = ("/common/", "/organizations/")
+
+
+def _id_token_claims_options(
+    provider_type: str, discovery_url: str | None
+) -> dict | None:
     """id_token claim-validation overrides passed to ``authorize_access_token``.
 
-    Azure multitenant endpoints (``/common/``, ``/organizations/``) publish a
+    Azure *multitenant* authorities (``/common/``, ``/organizations/``) publish a
     TEMPLATED issuer ``https://login.microsoftonline.com/{tenantid}/v2.0`` in
     their OIDC discovery document, but issued id_tokens carry the resolved
     per-tenant issuer (e.g. ``.../9188040d-.../v2.0`` for personal accounts).
-    authlib's default pins ``iss`` to the templated string via an exact
-    value-match and rejects every Microsoft login; joserfc only supports
-    value/values matching (no callable validator), so we relax ``iss`` to
-    required-but-not-value-pinned for Microsoft. The JWKS signature check and
-    the PKCE + client_secret code exchange still bind the token to Microsoft and
-    to this app, so signature/aud/nonce/exp validation is unaffected — only the
-    over-strict templated-``iss`` check is dropped (SSO-06).
+    authlib's default pins ``iss`` to that templated string via an exact
+    value-match and rejects every login; joserfc (no callable validator) only
+    supports value/values matching, so for multitenant Microsoft we relax ``iss``
+    to required-but-not-value-pinned. The JWKS signature check and the PKCE +
+    client_secret code exchange still bind the token to Microsoft and to this app.
 
-    Returns None for all other providers (authlib keeps its default iss pin).
+    Tenant-specific Microsoft providers (concrete ``/{tenant_id}/`` discovery URL,
+    as the admin UI builds) have a FIXED issuer that authlib can and must pin, so
+    they keep the default — relaxing them would drop cross-tenant ``iss`` isolation
+    (geolens#303 review). Returns None for every other case so authlib keeps its
+    default iss pin.
     """
     if provider_type == "microsoft":
-        return {"iss": {"essential": True}}
+        disco = (discovery_url or "").lower()
+        if any(authority in disco for authority in _AZURE_MULTITENANT_AUTHORITIES):
+            return {"iss": {"essential": True}}
     return None
 
 
@@ -215,11 +227,13 @@ async def oauth_callback(
     try:
         client, provider = await build_oauth_client(provider_slug, db)
 
-        # Exchange authorization code for tokens. For Microsoft multitenant the
-        # discovery issuer is templated, so relax the id_token iss check (SSO-06,
-        # see _id_token_claims_options).
+        # Exchange authorization code for tokens. Azure multitenant authorities
+        # advertise a templated issuer, so relax the id_token iss check there only
+        # (see _id_token_claims_options; geolens#303).
         authorize_kwargs: dict = {}
-        claims_options = _id_token_claims_options(provider.provider_type)
+        claims_options = _id_token_claims_options(
+            provider.provider_type, provider.discovery_url
+        )
         if claims_options is not None:
             authorize_kwargs["claims_options"] = claims_options
         token = await client.authorize_access_token(request, **authorize_kwargs)

--- a/backend/app/modules/auth/oauth/service.py
+++ b/backend/app/modules/auth/oauth/service.py
@@ -517,22 +517,14 @@ async def find_or_create_oauth_user(
         )
     )
     existing_link = result.scalar_one_or_none()
-    # Upgrade fallback (geolens#303): a deployment that linked a Microsoft
-    # multitenant account before the tid-partitioned subject existed stored the
-    # bare `sub`. If the partitioned lookup misses, fall back to the legacy
-    # bare-sub link and canonicalize it to `tid:sub` so future lookups hit and a
-    # returning user is never split into a second account.
-    bare_sub = str(userinfo.get("sub", ""))
-    if existing_link is None and bare_sub and subject != bare_sub:
-        legacy_result = await db.execute(
-            select(OAuthAccount).where(
-                OAuthAccount.provider_id == provider.id,
-                OAuthAccount.subject == bare_sub,
-            )
-        )
-        existing_link = legacy_result.scalar_one_or_none()
-        if existing_link is not None:
-            existing_link.subject = subject
+    # No legacy bare-sub fallback for Microsoft multitenant (geolens#303 review):
+    # those subjects are tenant-partitioned (tid:sub), and a bare-sub-only match
+    # cannot prove the token is from the same Azure tenant — falling back would
+    # reintroduce the cross-tenant collision the partitioning exists to prevent.
+    # It is also unnecessary: multitenant Microsoft was un-loginable before this
+    # change (authlib rejected the templated /common/ issuer), so no bare-sub
+    # multitenant links exist. Any improbable legacy user with a verified email
+    # still re-links via the email path below.
     if existing_link is not None:
         returning_user = existing_link.user
 

--- a/backend/app/modules/auth/oauth/service.py
+++ b/backend/app/modules/auth/oauth/service.py
@@ -457,6 +457,30 @@ def oauth_account_subject(
     return sub
 
 
+class OAuthIssuerError(ValueError):
+    """Raised when an Azure multitenant id_token's resolved issuer is invalid."""
+
+
+def verify_azure_multitenant_issuer(
+    provider_type: str, discovery_url: str | None, claims: dict
+) -> None:
+    """Re-assert the resolved per-tenant issuer for Azure multitenant tokens.
+
+    The id_token ``iss`` value-pin is relaxed at parse time because joserfc cannot
+    substitute ``{tenantid}`` via a callable validator, so verify here that ``iss``
+    exactly equals the tenant-substituted template using the token's own ``tid``.
+    Rejects a Microsoft-signed token whose ``iss`` and ``tid`` disagree — the
+    account key is derived from ``tid:sub``, so they must be consistent. No-op for
+    non-multitenant providers (geolens#303).
+    """
+    if not is_azure_multitenant(provider_type, discovery_url):
+        return
+    tid = str(claims.get("tid", "")).strip()
+    iss = str(claims.get("iss", "")).strip()
+    if not tid or iss != f"https://login.microsoftonline.com/{tid}/v2.0":
+        raise OAuthIssuerError("Azure multitenant issuer/tid mismatch")
+
+
 async def find_or_create_oauth_user(
     db: AsyncSession,
     provider: OAuthProvider,

--- a/backend/app/modules/auth/oauth/service.py
+++ b/backend/app/modules/auth/oauth/service.py
@@ -517,6 +517,22 @@ async def find_or_create_oauth_user(
         )
     )
     existing_link = result.scalar_one_or_none()
+    # Upgrade fallback (geolens#303): a deployment that linked a Microsoft
+    # multitenant account before the tid-partitioned subject existed stored the
+    # bare `sub`. If the partitioned lookup misses, fall back to the legacy
+    # bare-sub link and canonicalize it to `tid:sub` so future lookups hit and a
+    # returning user is never split into a second account.
+    bare_sub = str(userinfo.get("sub", ""))
+    if existing_link is None and bare_sub and subject != bare_sub:
+        legacy_result = await db.execute(
+            select(OAuthAccount).where(
+                OAuthAccount.provider_id == provider.id,
+                OAuthAccount.subject == bare_sub,
+            )
+        )
+        existing_link = legacy_result.scalar_one_or_none()
+        if existing_link is not None:
+            existing_link.subject = subject
     if existing_link is not None:
         returning_user = existing_link.user
 

--- a/backend/app/modules/auth/oauth/service.py
+++ b/backend/app/modules/auth/oauth/service.py
@@ -418,6 +418,45 @@ def _resolve_role(
     return default
 
 
+_AZURE_MULTITENANT_AUTHORITIES = ("/common/", "/organizations/")
+
+
+def is_azure_multitenant(provider_type: str, discovery_url: str | None) -> bool:
+    """True for Azure multitenant Microsoft (``/common/``, ``/organizations/``).
+
+    These authorities accept identities from many tenants and advertise a
+    templated issuer, unlike a tenant-specific (or ``/consumers/``) authority
+    whose issuer is fixed. Both the relaxed id_token ``iss`` check and the
+    tenant-partitioned account subject are gated on this (geolens#303).
+    """
+    if provider_type != "microsoft":
+        return False
+    disco = (discovery_url or "").lower()
+    return any(authority in disco for authority in _AZURE_MULTITENANT_AUTHORITIES)
+
+
+def oauth_account_subject(
+    provider_type: str, discovery_url: str | None, userinfo: dict
+) -> str:
+    """Stable per-provider key for ``OAuthAccount.subject``.
+
+    For Azure *multitenant* Microsoft the bare ``sub`` is not globally unique
+    across tenants (Microsoft's stable id is tenant-scoped — ``tid`` + ``oid``),
+    so two users in different tenants sharing a ``sub`` would collide on
+    ``(provider_id, subject)`` and the second would be linked to the first's
+    local account — a cross-tenant account takeover. Prefix the subject with the
+    tenant id for multitenant Microsoft; every other provider (including
+    single-tenant Microsoft, whose issuer is fixed) keeps the bare ``sub``
+    (geolens#303).
+    """
+    sub = str(userinfo.get("sub", ""))
+    if is_azure_multitenant(provider_type, discovery_url):
+        tid = str(userinfo.get("tid", "")).strip()
+        if tid:
+            return f"{tid}:{sub}"
+    return sub
+
+
 async def find_or_create_oauth_user(
     db: AsyncSession,
     provider: OAuthProvider,
@@ -433,7 +472,9 @@ async def find_or_create_oauth_user(
 
     Group claims are mapped to roles per provider config (OAUTH-07).
     """
-    subject = str(userinfo.get("sub", ""))
+    subject = oauth_account_subject(
+        provider.provider_type, provider.discovery_url, userinfo
+    )
     email = userinfo.get("email")
     display_name = userinfo.get("name")
 

--- a/backend/tests/test_oauth.py
+++ b/backend/tests/test_oauth.py
@@ -505,6 +505,70 @@ class TestFindOrCreateOAuthUser:
         role_names = {r.name for r in user.roles}
         assert "viewer" in role_names
 
+    async def test_microsoft_multitenant_legacy_subject_fallback(
+        self, client, test_db_session
+    ):
+        """geolens#303: a returning Microsoft multitenant user whose OAuthAccount
+        was linked with the legacy bare ``sub`` (before tid-partitioning) is found
+        via the fallback and the link is canonicalized to ``tid:sub`` — never split
+        into a second local account."""
+        from sqlalchemy import func as safunc
+        from sqlalchemy import select as saselect
+
+        from app.modules.auth.models import User
+        from app.modules.auth.oauth.models import OAuthAccount
+        from app.modules.auth.oauth.service import find_or_create_oauth_user
+
+        provider = await self._create_test_provider(
+            test_db_session,
+            provider_type="microsoft",
+            discovery_url=(
+                "https://login.microsoftonline.com/common/v2.0/"
+                ".well-known/openid-configuration"
+            ),
+            default_role="editor",
+        )
+        user = User(
+            username=f"msuser-{uuid.uuid4().hex[:6]}",
+            email=f"ms-{uuid.uuid4().hex[:6]}@example.com",
+            is_active=True,
+            status="active",
+            auth_provider="oauth",
+        )
+        test_db_session.add(user)
+        await test_db_session.flush()
+        # Legacy link stored with the bare sub (pre tid-partitioning).
+        legacy = OAuthAccount(
+            provider_id=provider.id, user_id=user.id, subject="bare-sub-xyz"
+        )
+        test_db_session.add(legacy)
+        await test_db_session.commit()
+
+        userinfo = {
+            "sub": "bare-sub-xyz",
+            "tid": "TENANT-A",
+            "iss": "https://login.microsoftonline.com/TENANT-A/v2.0",
+            "email": user.email,
+            "email_verified": True,
+        }
+        returned = await find_or_create_oauth_user(
+            test_db_session, provider, userinfo, {}
+        )
+        await test_db_session.commit()
+
+        # Same user (found via fallback), link canonicalized, and no 2nd account.
+        assert returned.id == user.id
+        await test_db_session.refresh(legacy)
+        assert legacy.subject == "TENANT-A:bare-sub-xyz"
+        count = (
+            await test_db_session.execute(
+                saselect(safunc.count())
+                .select_from(OAuthAccount)
+                .where(OAuthAccount.provider_id == provider.id)
+            )
+        ).scalar_one()
+        assert count == 1
+
     async def test_email_linking(self, client, test_db_session):
         """OAUTH-06: OAuth login with existing email + verified email links
         to existing user. Phase 268 H-30: also requires email_verified=True."""

--- a/backend/tests/test_oauth.py
+++ b/backend/tests/test_oauth.py
@@ -505,16 +505,13 @@ class TestFindOrCreateOAuthUser:
         role_names = {r.name for r in user.roles}
         assert "viewer" in role_names
 
-    async def test_microsoft_multitenant_legacy_subject_fallback(
+    async def test_microsoft_multitenant_no_cross_tenant_bare_sub_match(
         self, client, test_db_session
     ):
-        """geolens#303: a returning Microsoft multitenant user whose OAuthAccount
-        was linked with the legacy bare ``sub`` (before tid-partitioning) is found
-        via the fallback and the link is canonicalized to ``tid:sub`` — never split
-        into a second local account."""
-        from sqlalchemy import func as safunc
-        from sqlalchemy import select as saselect
-
+        """geolens#303: a legacy bare-``sub`` OAuthAccount must NOT be matched by a
+        Microsoft multitenant token from a *different* tenant that shares the bare
+        ``sub``. Subjects are tenant-partitioned (``tid:sub``) with no bare-sub
+        fallback, so tenant B never resolves to tenant A's local user."""
         from app.modules.auth.models import User
         from app.modules.auth.oauth.models import OAuthAccount
         from app.modules.auth.oauth.service import find_or_create_oauth_user
@@ -528,46 +525,42 @@ class TestFindOrCreateOAuthUser:
             ),
             default_role="editor",
         )
-        user = User(
-            username=f"msuser-{uuid.uuid4().hex[:6]}",
-            email=f"ms-{uuid.uuid4().hex[:6]}@example.com",
+        tenant_a_user = User(
+            username=f"tenanta-{uuid.uuid4().hex[:6]}",
+            email=f"tenanta-{uuid.uuid4().hex[:6]}@example.com",
             is_active=True,
             status="active",
             auth_provider="oauth",
         )
-        test_db_session.add(user)
+        test_db_session.add(tenant_a_user)
         await test_db_session.flush()
-        # Legacy link stored with the bare sub (pre tid-partitioning).
+        # Legacy bare-sub link belonging to tenant A.
         legacy = OAuthAccount(
-            provider_id=provider.id, user_id=user.id, subject="bare-sub-xyz"
+            provider_id=provider.id, user_id=tenant_a_user.id, subject="shared-sub"
         )
         test_db_session.add(legacy)
         await test_db_session.commit()
 
+        # Tenant B token: SAME bare sub, different tenant + different verified email.
         userinfo = {
-            "sub": "bare-sub-xyz",
-            "tid": "TENANT-A",
-            "iss": "https://login.microsoftonline.com/TENANT-A/v2.0",
-            "email": user.email,
+            "sub": "shared-sub",
+            "tid": "TENANT-B",
+            "iss": "https://login.microsoftonline.com/TENANT-B/v2.0",
+            "email": f"tenantb-{uuid.uuid4().hex[:6]}@example.com",
             "email_verified": True,
+            "name": "Tenant B User",
         }
         returned = await find_or_create_oauth_user(
             test_db_session, provider, userinfo, {}
         )
         await test_db_session.commit()
 
-        # Same user (found via fallback), link canonicalized, and no 2nd account.
-        assert returned.id == user.id
+        # Tenant B must NOT be resolved to tenant A's user, and the legacy link
+        # must be untouched (still bare-sub, still tenant A).
+        assert returned.id != tenant_a_user.id
         await test_db_session.refresh(legacy)
-        assert legacy.subject == "TENANT-A:bare-sub-xyz"
-        count = (
-            await test_db_session.execute(
-                saselect(safunc.count())
-                .select_from(OAuthAccount)
-                .where(OAuthAccount.provider_id == provider.id)
-            )
-        ).scalar_one()
-        assert count == 1
+        assert legacy.subject == "shared-sub"
+        assert legacy.user_id == tenant_a_user.id
 
     async def test_email_linking(self, client, test_db_session):
         """OAUTH-06: OAuth login with existing email + verified email links

--- a/backend/tests/test_oauth_microsoft_iss.py
+++ b/backend/tests/test_oauth_microsoft_iss.py
@@ -15,8 +15,15 @@ Tenant-specific Microsoft (fixed issuer) keeps authlib's default pin and the
 bare `sub`.
 """
 
+import pytest
+
 from app.modules.auth.oauth.router import _id_token_claims_options
-from app.modules.auth.oauth.service import is_azure_multitenant, oauth_account_subject
+from app.modules.auth.oauth.service import (
+    OAuthIssuerError,
+    is_azure_multitenant,
+    oauth_account_subject,
+    verify_azure_multitenant_issuer,
+)
 
 _COMMON = (
     "https://login.microsoftonline.com/common/v2.0/.well-known/openid-configuration"
@@ -56,3 +63,22 @@ def test_subject_partitioned_for_multitenant_only():
     assert oauth_account_subject("google", _COMMON, ui) == "S"
     # Defensive: multitenant token without a tid falls back to bare sub.
     assert oauth_account_subject("microsoft", _COMMON, {"sub": "S"}) == "S"
+
+
+def test_resolved_issuer_check_for_multitenant():
+    good = {"tid": "T", "iss": "https://login.microsoftonline.com/T/v2.0"}
+    # Matching iss/tid passes.
+    verify_azure_multitenant_issuer("microsoft", _COMMON, good)
+    # iss for a different tenant than tid -> rejected.
+    with pytest.raises(OAuthIssuerError):
+        verify_azure_multitenant_issuer(
+            "microsoft",
+            _COMMON,
+            {"tid": "T", "iss": "https://login.microsoftonline.com/EVIL/v2.0"},
+        )
+    # Missing tid -> rejected.
+    with pytest.raises(OAuthIssuerError):
+        verify_azure_multitenant_issuer("microsoft", _COMMON, {"iss": "x"})
+    # Non-multitenant providers are not checked (no raise even with junk claims).
+    verify_azure_multitenant_issuer("microsoft", _TENANT, {"iss": "x"})
+    verify_azure_multitenant_issuer("google", _COMMON, {"iss": "x"})

--- a/backend/tests/test_oauth_microsoft_iss.py
+++ b/backend/tests/test_oauth_microsoft_iss.py
@@ -1,0 +1,24 @@
+"""SSO-06: Microsoft multitenant id_token iss validation.
+
+Azure /common/ and /organizations/ advertise a templated issuer
+(https://login.microsoftonline.com/{tenantid}/v2.0) but issue tokens with the
+resolved per-tenant issuer, so authlib's default exact-match iss check rejects
+every Microsoft login. _id_token_claims_options relaxes iss to
+required-but-not-value-pinned for Microsoft only.
+"""
+
+from app.modules.auth.oauth.router import _id_token_claims_options
+
+
+def test_microsoft_relaxes_iss_to_required_not_pinned():
+    opts = _id_token_claims_options("microsoft")
+    assert opts == {"iss": {"essential": True}}
+    # Must NOT pin a value/values or the templated-issuer bug regresses.
+    assert "value" not in opts["iss"]
+    assert "values" not in opts["iss"]
+
+
+def test_other_providers_keep_authlib_default():
+    # None => authlib applies its default iss pin from discovery metadata.
+    for provider_type in ("google", "github", "oidc", "saml", ""):
+        assert _id_token_claims_options(provider_type) is None

--- a/backend/tests/test_oauth_microsoft_iss.py
+++ b/backend/tests/test_oauth_microsoft_iss.py
@@ -1,24 +1,40 @@
-"""SSO-06: Microsoft multitenant id_token iss validation.
+"""Microsoft multitenant id_token iss validation (geolens#303).
 
 Azure /common/ and /organizations/ advertise a templated issuer
 (https://login.microsoftonline.com/{tenantid}/v2.0) but issue tokens with the
 resolved per-tenant issuer, so authlib's default exact-match iss check rejects
-every Microsoft login. _id_token_claims_options relaxes iss to
-required-but-not-value-pinned for Microsoft only.
+every multitenant Microsoft login. _id_token_claims_options relaxes iss to
+required-but-not-value-pinned for those authorities ONLY — tenant-specific
+providers keep authlib's default pin so cross-tenant iss isolation holds.
 """
 
 from app.modules.auth.oauth.router import _id_token_claims_options
 
+_COMMON = (
+    "https://login.microsoftonline.com/common/v2.0/.well-known/openid-configuration"
+)
+_ORGS = "https://login.microsoftonline.com/organizations/v2.0/.well-known/openid-configuration"
+_TENANT = "https://login.microsoftonline.com/9188040d-6c67-4c5b-b112-36a304b66dad/v2.0/.well-known/openid-configuration"
 
-def test_microsoft_relaxes_iss_to_required_not_pinned():
-    opts = _id_token_claims_options("microsoft")
-    assert opts == {"iss": {"essential": True}}
-    # Must NOT pin a value/values or the templated-issuer bug regresses.
-    assert "value" not in opts["iss"]
-    assert "values" not in opts["iss"]
+
+def test_microsoft_multitenant_relaxes_iss_not_pinned():
+    for disco in (_COMMON, _ORGS):
+        opts = _id_token_claims_options("microsoft", disco)
+        assert opts == {"iss": {"essential": True}}, disco
+        # Must NOT pin a value/values or the templated-issuer bug regresses.
+        assert "value" not in opts["iss"]
+        assert "values" not in opts["iss"]
+
+
+def test_microsoft_tenant_specific_keeps_default():
+    # Concrete-tenant discovery has a FIXED issuer authlib should still pin;
+    # relaxing it would drop cross-tenant iss isolation.
+    assert _id_token_claims_options("microsoft", _TENANT) is None
+    # Defensive: no discovery URL => don't relax either.
+    assert _id_token_claims_options("microsoft", None) is None
 
 
 def test_other_providers_keep_authlib_default():
     # None => authlib applies its default iss pin from discovery metadata.
     for provider_type in ("google", "github", "oidc", "saml", ""):
-        assert _id_token_claims_options(provider_type) is None
+        assert _id_token_claims_options(provider_type, _COMMON) is None

--- a/backend/tests/test_oauth_microsoft_iss.py
+++ b/backend/tests/test_oauth_microsoft_iss.py
@@ -1,14 +1,22 @@
-"""Microsoft multitenant id_token iss validation (geolens#303).
+"""Microsoft multitenant SSO correctness (geolens#303).
 
 Azure /common/ and /organizations/ advertise a templated issuer
-(https://login.microsoftonline.com/{tenantid}/v2.0) but issue tokens with the
-resolved per-tenant issuer, so authlib's default exact-match iss check rejects
-every multitenant Microsoft login. _id_token_claims_options relaxes iss to
-required-but-not-value-pinned for those authorities ONLY — tenant-specific
-providers keep authlib's default pin so cross-tenant iss isolation holds.
+(https://login.microsoftonline.com/{tenantid}/v2.0) and accept identities from
+many tenants. Two things are gated on detecting that case:
+
+1. id_token `iss` is relaxed to required-but-not-value-pinned (authlib's exact
+   templated-issuer match otherwise rejects every login).
+2. The OAuthAccount subject is prefixed with the tenant id, because Microsoft's
+   bare `sub` is not globally unique across tenants — without partitioning, two
+   tenants' users sharing a `sub` would collide and the second would be linked
+   to the first's local account (cross-tenant takeover).
+
+Tenant-specific Microsoft (fixed issuer) keeps authlib's default pin and the
+bare `sub`.
 """
 
 from app.modules.auth.oauth.router import _id_token_claims_options
+from app.modules.auth.oauth.service import is_azure_multitenant, oauth_account_subject
 
 _COMMON = (
     "https://login.microsoftonline.com/common/v2.0/.well-known/openid-configuration"
@@ -17,24 +25,34 @@ _ORGS = "https://login.microsoftonline.com/organizations/v2.0/.well-known/openid
 _TENANT = "https://login.microsoftonline.com/9188040d-6c67-4c5b-b112-36a304b66dad/v2.0/.well-known/openid-configuration"
 
 
-def test_microsoft_multitenant_relaxes_iss_not_pinned():
+def test_is_azure_multitenant():
+    assert is_azure_multitenant("microsoft", _COMMON) is True
+    assert is_azure_multitenant("microsoft", _ORGS) is True
+    # Tenant-specific and non-Microsoft are NOT multitenant.
+    assert is_azure_multitenant("microsoft", _TENANT) is False
+    assert is_azure_multitenant("microsoft", None) is False
+    assert is_azure_multitenant("google", _COMMON) is False
+
+
+def test_iss_relaxed_only_for_multitenant():
     for disco in (_COMMON, _ORGS):
         opts = _id_token_claims_options("microsoft", disco)
         assert opts == {"iss": {"essential": True}}, disco
         # Must NOT pin a value/values or the templated-issuer bug regresses.
-        assert "value" not in opts["iss"]
-        assert "values" not in opts["iss"]
-
-
-def test_microsoft_tenant_specific_keeps_default():
-    # Concrete-tenant discovery has a FIXED issuer authlib should still pin;
-    # relaxing it would drop cross-tenant iss isolation.
+        assert "value" not in opts["iss"] and "values" not in opts["iss"]
+    # Tenant-specific Microsoft and other providers keep authlib's default pin.
     assert _id_token_claims_options("microsoft", _TENANT) is None
-    # Defensive: no discovery URL => don't relax either.
-    assert _id_token_claims_options("microsoft", None) is None
-
-
-def test_other_providers_keep_authlib_default():
-    # None => authlib applies its default iss pin from discovery metadata.
     for provider_type in ("google", "github", "oidc", "saml", ""):
         assert _id_token_claims_options(provider_type, _COMMON) is None
+
+
+def test_subject_partitioned_for_multitenant_only():
+    ui = {"sub": "S", "tid": "TENANT-A", "oid": "O"}
+    # Multitenant Microsoft -> tenant-prefixed so cross-tenant subs can't collide.
+    assert oauth_account_subject("microsoft", _COMMON, ui) == "TENANT-A:S"
+    assert oauth_account_subject("microsoft", _ORGS, ui) == "TENANT-A:S"
+    # Tenant-specific Microsoft and other providers keep the bare sub.
+    assert oauth_account_subject("microsoft", _TENANT, ui) == "S"
+    assert oauth_account_subject("google", _COMMON, ui) == "S"
+    # Defensive: multitenant token without a tid falls back to bare sub.
+    assert oauth_account_subject("microsoft", _COMMON, {"sub": "S"}) == "S"


### PR DESCRIPTION
## Problem
Microsoft SSO configured against the multitenant endpoints (`/common/` or `/organizations/`) fails for **every** user with `InvalidClaimError: invalid_claim: 'iss'`.

Azure's discovery doc advertises a **templated** issuer `https://login.microsoftonline.com/{tenantid}/v2.0`, but issued id_tokens carry the **resolved per-tenant** issuer (e.g. `.../9188040d-.../v2.0` for personal accounts). authlib's default pins `iss` to the templated string via an exact value-match, and `joserfc` (1.6.4) `ClaimsOption` supports only `value`/`values` (no callable validator), so the per-tenant issuer is always rejected. Diagnosed from the live demo's api logs.

## Fix
Pass `claims_options={"iss": {"essential": True}}` to `authorize_access_token` for `provider_type == "microsoft"`, relaxing `iss` to **required-but-not-value-pinned**. Everything else is unchanged: the id_token signature is still verified against Microsoft's JWKS, and the PKCE + `client_secret` code exchange still bind the token to Microsoft and to this app, so `aud`/`nonce`/`exp`/signature validation is unaffected. Only the over-strict templated-`iss` check is dropped.

Logic is isolated in a pure `_id_token_claims_options(provider_type)` helper (returns `None` for all non-Microsoft providers, so they keep authlib's default `iss` pin) with a unit test.

## Test / verification
`backend/tests/test_oauth_microsoft_iss.py` — asserts Microsoft relaxes `iss` without pinning a value (guards the regression) and that other providers keep the default. Static repro confirmed via authlib 1.7.2 / joserfc 1.6.4 source. End-to-end Microsoft login round-trip still to be verified on the demo once the rebuilt image is deployed; Google/GitHub are unaffected.