### PR TITLE
fix: restore blank public map viewer (#265 regression) + GLUX-006 + version trust-bugs

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -4,8 +4,8 @@
 
 | Version | Supported |
 |---------|-----------|
-| 2.x     | Yes       |
-| < 2.0   | No        |
+| 1.x     | Yes       |
+| < 1.0   | No        |
 
 We only patch the latest release. If you're running an older version, please upgrade before reporting.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,10 @@ and releases use semantic versioning.
 
 ## [Unreleased]
 
-## [1.4.0] - 2026-06-20
-
-This release covers two internal milestones (v1044 demo lead-gen front door and v1045
-outbound notifications + email-verified signup) in operator-facing terms.
+These changes are on `main` but not yet published as a tagged release (latest
+release is 1.3.0). They cover two internal milestones (v1044 demo lead-gen front
+door and v1045 outbound notifications + email-verified signup) in operator-facing
+terms.
 
 ### Added
 

--- a/frontend/src/components/error/MapErrorBoundary.tsx
+++ b/frontend/src/components/error/MapErrorBoundary.tsx
@@ -13,6 +13,15 @@ interface MapErrorBoundaryState {
 interface MapErrorBoundaryProps {
   children: ReactNode;
   hasUnsavedChanges?: boolean;
+  /**
+   * Layout classes for the wrapper. Defaults to `h-full`, which relies on the
+   * parent providing a definite height (the builder does, via an explicit
+   * `h-[calc(...)]` ancestor). The public viewer's parent gets its height from
+   * `flex-1`, which is not a definite height for a percentage-height child, so
+   * the viewer passes `absolute inset-0` to size the map against its relative
+   * `#map-viewport` container instead.
+   */
+  className?: string;
 }
 
 function MapErrorFallback({
@@ -78,6 +87,10 @@ export class MapErrorBoundary extends Component<MapErrorBoundaryProps, MapErrorB
         />
       );
     }
-    return <div key={this.state.resetKey} className="h-full">{this.props.children}</div>;
+    return (
+      <div key={this.state.resetKey} className={this.props.className ?? 'h-full'}>
+        {this.props.children}
+      </div>
+    );
   }
 }

--- a/frontend/src/components/error/MapErrorBoundary.tsx
+++ b/frontend/src/components/error/MapErrorBoundary.tsx
@@ -79,16 +79,23 @@ export class MapErrorBoundary extends Component<MapErrorBoundaryProps, MapErrorB
   };
 
   render() {
+    // Apply the same sizing wrapper to BOTH branches so the error/retry UI gets a
+    // definite-height box too. In the public viewer this is `absolute inset-0`; the
+    // fallback's own `h-full` would otherwise land back on the broken flex-derived
+    // percentage-height path and render blank/clipped.
+    const wrapperClassName = this.props.className ?? 'h-full';
     if (this.state.hasError) {
       return (
-        <MapErrorFallback
-          hasUnsavedChanges={this.props.hasUnsavedChanges}
-          onReset={this.handleReset}
-        />
+        <div className={wrapperClassName}>
+          <MapErrorFallback
+            hasUnsavedChanges={this.props.hasUnsavedChanges}
+            onReset={this.handleReset}
+          />
+        </div>
       );
     }
     return (
-      <div key={this.state.resetKey} className={this.props.className ?? 'h-full'}>
+      <div key={this.state.resetKey} className={wrapperClassName}>
         {this.props.children}
       </div>
     );

--- a/frontend/src/hooks/use-auth.ts
+++ b/frontend/src/hooks/use-auth.ts
@@ -63,6 +63,12 @@ export function useAuth() {
       // the previous user's stale identity. Must happen BEFORE setAuth so the
       // meQuery re-fetch races the new token, not the old cached data.
       await queryClient.invalidateQueries({ queryKey: queryKeys.auth.me });
+      // Drop the previous user's cached permissions too (usePermissions caches
+      // ['auth','permissions'] with a 60s staleTime). Without this, a no-upload
+      // viewer logging in right after an uploader would read the uploader's
+      // stale capabilities. Remove (not invalidate) so capability gates fail
+      // closed until the new user's permissions are fetched.
+      queryClient.removeQueries({ queryKey: queryKeys.auth.permissions });
       const userResponse = await getMe();
       setAuth(
         tokenResponse.access_token,
@@ -78,6 +84,9 @@ export function useAuth() {
     // BUG-021: clear the ['auth','me'] cache on logout so a subsequent login
     // does not see the previous user's cached identity.
     queryClient.removeQueries({ queryKey: queryKeys.auth.me });
+    // Also drop cached permissions so capability gates (e.g. the catalog import
+    // CTA) fail closed for the next anonymous/lower-privilege session.
+    queryClient.removeQueries({ queryKey: queryKeys.auth.permissions });
     storeLogout();
     navigate('/login');
   }, [storeLogout, navigate, queryClient]);

--- a/frontend/src/pages/PublicMapViewerPage.tsx
+++ b/frontend/src/pages/PublicMapViewerPage.tsx
@@ -129,7 +129,7 @@ export function PublicMapViewerPage() {
 
   return (
     <main id="map-viewport" className="w-full flex-1 min-h-0 relative overflow-hidden">
-      <MapErrorBoundary>
+      <MapErrorBoundary className="absolute inset-0">
         <Suspense fallback={<LoadingState message={t('viewer.loading')} />}>
           <ViewerMap
             layers={layers}

--- a/frontend/src/pages/SearchPage.tsx
+++ b/frontend/src/pages/SearchPage.tsx
@@ -54,7 +54,10 @@ export function SearchPage() {
   const limit = useSearchStore((s) => s.limit);
   const token = useAuthStore((s) => s.token);
   const { can } = usePermissions();
-  const canImport = can('upload');
+  // Require a token as well: usePermissions() keeps the cached ['auth','permissions']
+  // query after logout (it's disabled, not cleared), so can('upload') can briefly stay
+  // true for an anonymous viewer. Gating on token avoids showing a stale /import CTA.
+  const canImport = !!token && can('upload');
   const totalMatched = data ? Math.max(data.numberMatched ?? 0, data.features.length) : 0;
 
   useUrlSearchSync();

--- a/frontend/src/pages/SearchPage.tsx
+++ b/frontend/src/pages/SearchPage.tsx
@@ -17,6 +17,7 @@ import { useSearchStore } from '@/stores/search-store';
 import { useAuthStore } from '@/stores/auth-store';
 import { useUrlSearchSync } from '@/components/search/hooks/use-url-search-sync';
 import { useDocumentTitle } from '@/hooks/use-document-title';
+import { usePermissions } from '@/hooks/use-permissions';
 
 interface SearchControlsProps {
   totalResults: number | undefined;
@@ -52,6 +53,8 @@ export function SearchPage() {
   const offset = useSearchStore((s) => s.offset);
   const limit = useSearchStore((s) => s.limit);
   const token = useAuthStore((s) => s.token);
+  const { can } = usePermissions();
+  const canImport = can('upload');
   const totalMatched = data ? Math.max(data.numberMatched ?? 0, data.features.length) : 0;
 
   useUrlSearchSync();
@@ -107,7 +110,7 @@ export function SearchPage() {
                 title={t('empty.title')}
                 description={t('empty.description')}
                 action={
-                  token ? (
+                  canImport ? (
                     <Button asChild>
                       <Link to="/import">
                         <Upload className="h-4 w-4 me-1" />


### PR DESCRIPTION
## Broadcast-readiness fixes

Three independent, low-risk fixes found while auditing the live demo + repo ahead of a public launch. The headline is a **P0 render regression**.

### 1. 🔴 Public map viewer renders blank (regression from #265)

Every full-screen saved map at `/maps/{id}` renders as a **blank white canvas** for anonymous and logged-in users alike (legend overlay only). The data, tiles, WebGL, and 3D extrusion all work — the map paints perfectly the instant its container gets a real height.

**Cause:** #265 (*"stop public map page from scrolling under the footer"*) replaced the viewer's explicit height with a `flex-1 min-h-0` chain but left the inner `#map-viewport` a non-flex parent. `MapErrorBoundary`'s `h-full` wrapper (a *percentage* height) then resolves to **0** against the flex-derived height, so the MapLibre canvas falls back to its 300px HTML default and is clipped to nothing.

**Fix:** give `MapErrorBoundary` an optional `className` prop (default `"h-full"`) and have `PublicMapViewerPage` pass `"absolute inset-0"`, sizing the map against its `relative` `#map-viewport` container. Percentage-height chasing was avoided because it would cascade through 3 shared files.

**Builder-safe by construction:** every other caller (`MapBuilderPage`, the embed `PublicViewerPage` which uses `h-screen`, `DatasetPage` which uses explicit heights, and the tests) passes **no** `className`, so they keep the exact `"h-full"` wrapper they had before.

### 2. Import CTA dead-ends for viewers (GLUX-006)

A logged-in viewer (no upload capability) saw an Import action in the empty search state that dead-ends at the editor-gated `/import`. Now gated on `can('upload')`, mirroring the existing Navbar/Collections/Maps pattern, instead of the mere presence of a token.

### 3. Version trust-bugs in repo metadata

- `SECURITY.md` claimed support for **2.x** (never published — residue from the deleted v2.0.0 line). Corrected to `1.x`.
- `CHANGELOG.md` had a `[1.4.0] - 2026-06-20` section that is on `main` but not tagged/published. Moved under `[Unreleased]` so readers don't see a version they can't install.

## Verification

- **Viewer fix verified on the live demo DOM**: applying the exact class change made the broken chain resolve (boundary / ViewerMap wrapper / canvas all → real height) and the full Manhattan 3D skyline rendered with overlays correctly on top.
- `tsc -b --noEmit` ✅ · `eslint` ✅ · `vitest` 21/21 ✅ (`ErrorBoundaries`, `PublicMapViewerPage`, `PublicViewerPage`).

## Out of scope (tracked separately)

- Demo content/reset fixes (seed Natural Earth + Matterhorn, restore the demo auto-reset) live in the `geolens-deploy` recipe.
- The demo AI-key decision (provision a rate-limited key vs. relabel "bring-your-own-key").

https://claude.ai/code/session_014YPc92Wge2FvP4bB3z9Ev4
