### PR TITLE
UI/UX launch polish: contrast, toasts, touch targets, catalog, shell, a11y, admin

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -2,8 +2,10 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <meta name="theme-color" content="#3b6fd4" />
+    <!-- v1047 SAFEAREA-01: dark-mode browser-chrome color so PWA chrome tracks dark theme -->
+    <meta name="theme-color" media="(prefers-color-scheme: dark)" content="#1a1f2e" />
     <script src="/env-config.js"></script>
     <!-- FOUC prevention + lang sync. Externalized to /theme-init.js (SEC-020) so
          the page carries a strict script-src 'self' CSP with no inline script.

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <meta name="theme-color" content="#3b6fd4" />
-    <!-- v1047 SAFEAREA-01: dark-mode browser-chrome color so PWA chrome tracks dark theme -->
+    <!-- #305: dark-mode browser-chrome color so PWA chrome tracks dark theme -->
     <meta name="theme-color" media="(prefers-color-scheme: dark)" content="#1a1f2e" />
     <script src="/env-config.js"></script>
     <!-- FOUC prevention + lang sync. Externalized to /theme-init.js (SEC-020) so

--- a/frontend/src/components/admin/ApiKeySection.tsx
+++ b/frontend/src/components/admin/ApiKeySection.tsx
@@ -146,7 +146,12 @@ export function ApiKeySection({ userId }: ApiKeySectionProps) {
                       activeDotColor[String(key.is_active) as keyof typeof activeDotColor]
                     }`}
                     title={key.is_active ? t('apiKeys.active') : t('apiKeys.revoked')}
+                    aria-hidden="true"
                   />
+                  {/* v1047 A11Y-COLOR-01: state was conveyed by dot color + non-announced title only; add a text alt for assistive tech */}
+                  <span className="sr-only">
+                    {key.is_active ? t('apiKeys.active') : t('apiKeys.revoked')}
+                  </span>
                 </div>
                 <div className="text-xs text-muted-foreground">
                   {t('apiKeys.created', { date: formatDate(key.created_at) })} · {t('apiKeys.lastUsed')} {relativeTime(key.last_used_at, t)}

--- a/frontend/src/components/admin/ApiKeySection.tsx
+++ b/frontend/src/components/admin/ApiKeySection.tsx
@@ -148,7 +148,7 @@ export function ApiKeySection({ userId }: ApiKeySectionProps) {
                     title={key.is_active ? t('apiKeys.active') : t('apiKeys.revoked')}
                     aria-hidden="true"
                   />
-                  {/* v1047 A11Y-COLOR-01: state was conveyed by dot color + non-announced title only; add a text alt for assistive tech */}
+                  {/* #305: state was conveyed by dot color + non-announced title only; add a text alt for assistive tech */}
                   <span className="sr-only">
                     {key.is_active ? t('apiKeys.active') : t('apiKeys.revoked')}
                   </span>

--- a/frontend/src/components/admin/settings/SettingsAuthTab.tsx
+++ b/frontend/src/components/admin/settings/SettingsAuthTab.tsx
@@ -46,6 +46,8 @@ import {
   deleteOAuthProvider,
 } from '@/api/settings';
 import { queryKeys } from '@/lib/query-keys';
+import { useTileConfig } from '@/hooks/use-settings';
+import { getPublicApiBaseUrl } from '@/lib/dataset-access';
 
 interface TabProps {
   settings: SettingItem[];
@@ -171,6 +173,12 @@ function OAuthProvidersSection({ envOnly }: { envOnly: boolean }) {
   const [editingProvider, setEditingProvider] = useState<OAuthProviderConfig | null>(null);
   const [deleteTarget, setDeleteTarget] = useState<OAuthProviderConfig | null>(null);
   const [form, setForm] = useState<ProviderFormData>(EMPTY_FORM);
+  const { data: tileConfig } = useTileConfig();
+  // v1047 OAUTH-01 (Codex P2): derive the callback from the CONFIGURED public
+  // API URL (what the backend builds redirect_uri from, same as SAML settings),
+  // NOT the browser origin — split frontend/API hosts, reverse proxies, or a
+  // custom API root would otherwise hand admins the wrong redirect URI.
+  const oauthCallbackUrl = `${getPublicApiBaseUrl(tileConfig) ?? `${window.location.origin}/api`}/auth/oauth/${form.slug || '<provider>'}/callback`;
 
   function openAddDialog() {
     setEditingProvider(null);
@@ -472,7 +480,7 @@ function OAuthProvidersSection({ envOnly }: { envOnly: boolean }) {
               <div className="flex items-center gap-2">
                 <Input
                   id="callback-url"
-                  value={`${window.location.origin}/api/auth/oauth/${form.slug || '<provider>'}/callback`}
+                  value={oauthCallbackUrl}
                   readOnly
                   className="font-mono text-xs"
                 />
@@ -483,7 +491,7 @@ function OAuthProvidersSection({ envOnly }: { envOnly: boolean }) {
                   aria-label={t('settings.oauth.copyCallbackUrl', { defaultValue: 'Copy callback URL' })}
                   onClick={() => {
                     navigator.clipboard.writeText(
-                      `${window.location.origin}/api/auth/oauth/${form.slug || '<provider>'}/callback`,
+                      oauthCallbackUrl,
                     );
                     toast.success(
                       t('settings.oauth.callbackUrlCopied', { defaultValue: 'Callback URL copied to clipboard' }),

--- a/frontend/src/components/admin/settings/SettingsAuthTab.tsx
+++ b/frontend/src/components/admin/settings/SettingsAuthTab.tsx
@@ -179,14 +179,19 @@ function OAuthProvidersSection({ envOnly, settings }: { envOnly: boolean; settin
   // NOT the browser origin — split frontend/API hosts, reverse proxies, or a
   // custom API root would otherwise hand admins the wrong redirect URI.
   const oauthCallbackUrl = `${getPublicApiBaseUrl(tileConfig) ?? `${window.location.origin}/api`}/auth/oauth/${form.slug || '<provider>'}/callback`;
-  // #305: the OAuth login path only builds a redirect_uri from an EXPLICITLY
-  // configured public URL (for_external_use), whereas tile-config returns a
-  // request-derived one. If neither public_app_url nor public_api_url is set,
-  // the shown URL is provisional and the backend won't use it — block copy so
-  // an admin can't register a dead callback.
+  // #305: the OAuth login path only builds a redirect_uri from an explicitly
+  // configured public URL (for_external_use); tile-config returns a
+  // request-derived one. Treat the callback as ready when public_api_url or
+  // public_app_url has a non-empty effective VALUE — this covers BOTH DB
+  // overrides and env vars (env-set rows report source 'default' but still
+  // carry the value), unlike a source check. Block copy otherwise so an admin
+  // can't register a dead callback.
+  const hasSettingValue = (key: string) => {
+    const v = findSetting(settings, key)?.value;
+    return typeof v === 'string' && v.trim().length > 0;
+  };
   const publicUrlConfigured =
-    (findSetting(settings, 'public_api_url')?.source ?? 'default') !== 'default' ||
-    (findSetting(settings, 'public_app_url')?.source ?? 'default') !== 'default';
+    hasSettingValue('public_api_url') || hasSettingValue('public_app_url');
 
   function openAddDialog() {
     setEditingProvider(null);

--- a/frontend/src/components/admin/settings/SettingsAuthTab.tsx
+++ b/frontend/src/components/admin/settings/SettingsAuthTab.tsx
@@ -125,7 +125,7 @@ const EMPTY_FORM: ProviderFormData = {
 
 // --- OAuth Provider Management Section ---
 
-function OAuthProvidersSection({ envOnly }: { envOnly: boolean }) {
+function OAuthProvidersSection({ envOnly, settings }: { envOnly: boolean; settings: SettingItem[] }) {
   const { t } = useTranslation('admin');
   const PROVIDER_TYPE_LABELS = useProviderTypeLabels();
   const queryClient = useQueryClient();
@@ -179,6 +179,14 @@ function OAuthProvidersSection({ envOnly }: { envOnly: boolean }) {
   // NOT the browser origin — split frontend/API hosts, reverse proxies, or a
   // custom API root would otherwise hand admins the wrong redirect URI.
   const oauthCallbackUrl = `${getPublicApiBaseUrl(tileConfig) ?? `${window.location.origin}/api`}/auth/oauth/${form.slug || '<provider>'}/callback`;
+  // #305: the OAuth login path only builds a redirect_uri from an EXPLICITLY
+  // configured public URL (for_external_use), whereas tile-config returns a
+  // request-derived one. If neither public_app_url nor public_api_url is set,
+  // the shown URL is provisional and the backend won't use it — block copy so
+  // an admin can't register a dead callback.
+  const publicUrlConfigured =
+    (findSetting(settings, 'public_api_url')?.source ?? 'default') !== 'default' ||
+    (findSetting(settings, 'public_app_url')?.source ?? 'default') !== 'default';
 
   function openAddDialog() {
     setEditingProvider(null);
@@ -491,7 +499,7 @@ function OAuthProvidersSection({ envOnly }: { envOnly: boolean }) {
                   // #305: until tile-config resolves, the URL may still be the
                   // origin fallback (wrong on split-host deployments) — block
                   // copying so an admin can't register a premature value.
-                  disabled={tileConfigLoading}
+                  disabled={tileConfigLoading || !publicUrlConfigured}
                   aria-label={t('settings.oauth.copyCallbackUrl', { defaultValue: 'Copy callback URL' })}
                   onClick={() => {
                     navigator.clipboard.writeText(
@@ -916,7 +924,7 @@ export function SettingsAuthTab({ settings, envOnly, onSave, onReset, isSaving, 
       <hr className="border-border" />
 
       {/* OAuth Providers */}
-      <OAuthProvidersSection envOnly={envOnly} />
+      <OAuthProvidersSection envOnly={envOnly} settings={settings} />
     </div>
   );
 }

--- a/frontend/src/components/admin/settings/SettingsAuthTab.tsx
+++ b/frontend/src/components/admin/settings/SettingsAuthTab.tsx
@@ -500,13 +500,22 @@ function OAuthProvidersSection({ envOnly }: { envOnly: boolean }) {
                   // copying so an admin can't register a premature value.
                   disabled={tileConfigLoading}
                   aria-label={t('settings.oauth.copyCallbackUrl', { defaultValue: 'Copy callback URL' })}
-                  onClick={() => {
-                    navigator.clipboard.writeText(
-                      oauthCallbackUrl,
-                    );
-                    toast.success(
-                      t('settings.oauth.callbackUrlCopied', { defaultValue: 'Callback URL copied to clipboard' }),
-                    );
+                  onClick={async () => {
+                    // #305: the Clipboard API is unavailable on non-secure
+                    // (HTTP) origins and can reject — await + catch so a failure
+                    // surfaces an error toast instead of a false success / throw.
+                    try {
+                      await navigator.clipboard.writeText(oauthCallbackUrl);
+                      toast.success(
+                        t('settings.oauth.callbackUrlCopied', { defaultValue: 'Callback URL copied to clipboard' }),
+                      );
+                    } catch {
+                      toast.error(
+                        t('settings.oauth.callbackUrlCopyFailed', {
+                          defaultValue: 'Could not copy — copy the URL manually.',
+                        }),
+                      );
+                    }
                   }}
                 >
                   <Copy className="h-4 w-4" />

--- a/frontend/src/components/admin/settings/SettingsAuthTab.tsx
+++ b/frontend/src/components/admin/settings/SettingsAuthTab.tsx
@@ -125,7 +125,7 @@ const EMPTY_FORM: ProviderFormData = {
 
 // --- OAuth Provider Management Section ---
 
-function OAuthProvidersSection({ envOnly, settings }: { envOnly: boolean; settings: SettingItem[] }) {
+function OAuthProvidersSection({ envOnly }: { envOnly: boolean }) {
   const { t } = useTranslation('admin');
   const PROVIDER_TYPE_LABELS = useProviderTypeLabels();
   const queryClient = useQueryClient();
@@ -179,19 +179,13 @@ function OAuthProvidersSection({ envOnly, settings }: { envOnly: boolean; settin
   // NOT the browser origin — split frontend/API hosts, reverse proxies, or a
   // custom API root would otherwise hand admins the wrong redirect URI.
   const oauthCallbackUrl = `${getPublicApiBaseUrl(tileConfig) ?? `${window.location.origin}/api`}/auth/oauth/${form.slug || '<provider>'}/callback`;
-  // #305: the OAuth login path only builds a redirect_uri from an explicitly
-  // configured public URL (for_external_use); tile-config returns a
-  // request-derived one. Treat the callback as ready when public_api_url or
-  // public_app_url has a non-empty effective VALUE — this covers BOTH DB
-  // overrides and env vars (env-set rows report source 'default' but still
-  // carry the value), unlike a source check. Block copy otherwise so an admin
-  // can't register a dead callback.
-  const hasSettingValue = (key: string) => {
-    const v = findSetting(settings, key)?.value;
-    return typeof v === 'string' && v.trim().length > 0;
-  };
-  const publicUrlConfigured =
-    hasSettingValue('public_api_url') || hasSettingValue('public_app_url');
+  // #305: the OAuth login path resolves redirect_uri from an EXPLICITLY
+  // configured public URL (for_external_use) and raises if none is set, but
+  // both /settings/all and tile-config return a request-derived value — so the
+  // client cannot reliably tell "configured" from "derived" (neither source nor
+  // value is authoritative). Rather than gate copy on an unreliable heuristic,
+  // the field is informational and the hint states the hard requirement that
+  // the deployment's Public API URL (PUBLIC_API_URL) be configured to match.
 
   function openAddDialog() {
     setEditingProvider(null);
@@ -504,7 +498,7 @@ function OAuthProvidersSection({ envOnly, settings }: { envOnly: boolean; settin
                   // #305: until tile-config resolves, the URL may still be the
                   // origin fallback (wrong on split-host deployments) — block
                   // copying so an admin can't register a premature value.
-                  disabled={tileConfigLoading || !publicUrlConfigured}
+                  disabled={tileConfigLoading}
                   aria-label={t('settings.oauth.copyCallbackUrl', { defaultValue: 'Copy callback URL' })}
                   onClick={() => {
                     navigator.clipboard.writeText(
@@ -929,7 +923,7 @@ export function SettingsAuthTab({ settings, envOnly, onSave, onReset, isSaving, 
       <hr className="border-border" />
 
       {/* OAuth Providers */}
-      <OAuthProvidersSection envOnly={envOnly} settings={settings} />
+      <OAuthProvidersSection envOnly={envOnly} />
     </div>
   );
 }

--- a/frontend/src/components/admin/settings/SettingsAuthTab.tsx
+++ b/frontend/src/components/admin/settings/SettingsAuthTab.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
-import { Pencil, Trash2, Plus } from 'lucide-react';
+import { Pencil, Trash2, Plus, Copy } from 'lucide-react';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Button } from '@/components/ui/button';
@@ -461,6 +461,43 @@ function OAuthProvidersSection({ envOnly }: { envOnly: boolean }) {
               />
               <p className="text-xs text-muted-foreground">
                 {t('settings.oauth.slugHint')}
+              </p>
+            </div>
+
+            {/* v1047 OAUTH-01: read-only redirect/callback URL admins must register with the provider. */}
+            <div className="space-y-2">
+              <Label htmlFor="callback-url">
+                {t('settings.oauth.callbackUrl', { defaultValue: 'Redirect / Callback URL' })}
+              </Label>
+              <div className="flex items-center gap-2">
+                <Input
+                  id="callback-url"
+                  value={`${window.location.origin}/api/auth/oauth/${form.slug || '<provider>'}/callback`}
+                  readOnly
+                  className="font-mono text-xs"
+                />
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="icon"
+                  aria-label={t('settings.oauth.copyCallbackUrl', { defaultValue: 'Copy callback URL' })}
+                  onClick={() => {
+                    navigator.clipboard.writeText(
+                      `${window.location.origin}/api/auth/oauth/${form.slug || '<provider>'}/callback`,
+                    );
+                    toast.success(
+                      t('settings.oauth.callbackUrlCopied', { defaultValue: 'Callback URL copied to clipboard' }),
+                    );
+                  }}
+                >
+                  <Copy className="h-4 w-4" />
+                </Button>
+              </div>
+              <p className="text-xs text-muted-foreground">
+                {t('settings.oauth.callbackUrlHint', {
+                  defaultValue:
+                    'Register this exact URL as the authorized redirect / callback URL with your provider (Google, Microsoft, or GitHub).',
+                })}
               </p>
             </div>
 

--- a/frontend/src/components/admin/settings/SettingsAuthTab.tsx
+++ b/frontend/src/components/admin/settings/SettingsAuthTab.tsx
@@ -174,7 +174,7 @@ function OAuthProvidersSection({ envOnly }: { envOnly: boolean }) {
   const [deleteTarget, setDeleteTarget] = useState<OAuthProviderConfig | null>(null);
   const [form, setForm] = useState<ProviderFormData>(EMPTY_FORM);
   const { data: tileConfig } = useTileConfig();
-  // v1047 OAUTH-01 (Codex P2): derive the callback from the CONFIGURED public
+  // #305: derive the callback from the CONFIGURED public
   // API URL (what the backend builds redirect_uri from, same as SAML settings),
   // NOT the browser origin — split frontend/API hosts, reverse proxies, or a
   // custom API root would otherwise hand admins the wrong redirect URI.
@@ -472,7 +472,7 @@ function OAuthProvidersSection({ envOnly }: { envOnly: boolean }) {
               </p>
             </div>
 
-            {/* v1047 OAUTH-01: read-only redirect/callback URL admins must register with the provider. */}
+            {/* #305: read-only redirect/callback URL admins must register with the provider. */}
             <div className="space-y-2">
               <Label htmlFor="callback-url">
                 {t('settings.oauth.callbackUrl', { defaultValue: 'Redirect / Callback URL' })}

--- a/frontend/src/components/admin/settings/SettingsAuthTab.tsx
+++ b/frontend/src/components/admin/settings/SettingsAuthTab.tsx
@@ -173,7 +173,7 @@ function OAuthProvidersSection({ envOnly }: { envOnly: boolean }) {
   const [editingProvider, setEditingProvider] = useState<OAuthProviderConfig | null>(null);
   const [deleteTarget, setDeleteTarget] = useState<OAuthProviderConfig | null>(null);
   const [form, setForm] = useState<ProviderFormData>(EMPTY_FORM);
-  const { data: tileConfig } = useTileConfig();
+  const { data: tileConfig, isLoading: tileConfigLoading } = useTileConfig();
   // #305: derive the callback from the CONFIGURED public
   // API URL (what the backend builds redirect_uri from, same as SAML settings),
   // NOT the browser origin — split frontend/API hosts, reverse proxies, or a
@@ -488,6 +488,10 @@ function OAuthProvidersSection({ envOnly }: { envOnly: boolean }) {
                   type="button"
                   variant="outline"
                   size="icon"
+                  // #305: until tile-config resolves, the URL may still be the
+                  // origin fallback (wrong on split-host deployments) — block
+                  // copying so an admin can't register a premature value.
+                  disabled={tileConfigLoading}
                   aria-label={t('settings.oauth.copyCallbackUrl', { defaultValue: 'Copy callback URL' })}
                   onClick={() => {
                     navigator.clipboard.writeText(

--- a/frontend/src/components/auth/LoginForm.tsx
+++ b/frontend/src/components/auth/LoginForm.tsx
@@ -65,6 +65,7 @@ export function LoginForm() {
         <form onSubmit={handleSubmit} className="flex flex-col gap-4">
           <div className="flex flex-col gap-2">
             <Label htmlFor="username">{t('username')}</Label>
+            {/* v1047 A11Y-FORM-01: on a server error both credentials are suspect; mark fields invalid + describe by the error */}
             <Input
               id="username"
               type="text"
@@ -73,6 +74,8 @@ export function LoginForm() {
               placeholder={t('enterUsername')}
               required
               autoComplete="username"
+              aria-invalid={error ? true : undefined}
+              aria-describedby={error ? 'login-error' : undefined}
             />
           </div>
           <div className="flex flex-col gap-2">
@@ -87,6 +90,8 @@ export function LoginForm() {
                 required
                 autoComplete="current-password"
                 className="pe-11"
+                aria-invalid={error ? true : undefined}
+                aria-describedby={error ? 'login-error' : undefined}
               />
               <button
                 type="button"
@@ -103,7 +108,7 @@ export function LoginForm() {
             </div>
           </div>
           {error && (
-            <p role="alert" className="text-destructive text-sm">{error}</p>
+            <p id="login-error" role="alert" className="text-destructive text-sm">{error}</p>
           )}
           <Button
             type="submit"

--- a/frontend/src/components/auth/LoginForm.tsx
+++ b/frontend/src/components/auth/LoginForm.tsx
@@ -65,7 +65,7 @@ export function LoginForm() {
         <form onSubmit={handleSubmit} className="flex flex-col gap-4">
           <div className="flex flex-col gap-2">
             <Label htmlFor="username">{t('username')}</Label>
-            {/* v1047 A11Y-FORM-01: on a server error both credentials are suspect; mark fields invalid + describe by the error */}
+            {/* #305: on a server error both credentials are suspect; mark fields invalid + describe by the error */}
             <Input
               id="username"
               type="text"

--- a/frontend/src/components/auth/RegisterForm.tsx
+++ b/frontend/src/components/auth/RegisterForm.tsx
@@ -55,7 +55,7 @@ export function RegisterForm({ onSuccess }: RegisterFormProps) {
       </CardHeader>
       <CardContent>
         <form onSubmit={handleSubmit} className="flex flex-col gap-4">
-          {/* v1047 A11Y-FORM-01: on a server error mark the credential fields invalid + describe by the error */}
+          {/* #305: on a server error mark the credential fields invalid + describe by the error */}
           <div className="flex flex-col gap-2">
             <Label htmlFor="username">{t('username')}</Label>
             <Input

--- a/frontend/src/components/auth/RegisterForm.tsx
+++ b/frontend/src/components/auth/RegisterForm.tsx
@@ -55,6 +55,7 @@ export function RegisterForm({ onSuccess }: RegisterFormProps) {
       </CardHeader>
       <CardContent>
         <form onSubmit={handleSubmit} className="flex flex-col gap-4">
+          {/* v1047 A11Y-FORM-01: on a server error mark the credential fields invalid + describe by the error */}
           <div className="flex flex-col gap-2">
             <Label htmlFor="username">{t('username')}</Label>
             <Input
@@ -66,6 +67,8 @@ export function RegisterForm({ onSuccess }: RegisterFormProps) {
               required
               minLength={3}
               autoComplete="username"
+              aria-invalid={error ? true : undefined}
+              aria-describedby={error ? 'register-error' : undefined}
             />
           </div>
           <div className="flex flex-col gap-2">
@@ -78,6 +81,8 @@ export function RegisterForm({ onSuccess }: RegisterFormProps) {
               placeholder={t('enterEmail')}
               required
               autoComplete="email"
+              aria-invalid={error ? true : undefined}
+              aria-describedby={error ? 'register-error' : undefined}
             />
           </div>
           <div className="flex flex-col gap-2">
@@ -91,11 +96,13 @@ export function RegisterForm({ onSuccess }: RegisterFormProps) {
               required
               minLength={8}
               autoComplete="new-password"
+              aria-invalid={error ? true : undefined}
+              aria-describedby={error ? 'register-error' : undefined}
             />
             <p className="text-xs text-muted-foreground">{t('passwordRequirement')}</p>
           </div>
           {error && (
-            <p className="text-destructive text-sm" role="alert">{error}</p>
+            <p id="register-error" className="text-destructive text-sm" role="alert">{error}</p>
           )}
           <Button type="submit" disabled={loading || !username.trim() || !email.trim() || !password} className="w-full">
             {loading && <Loader2 className="size-4 animate-spin" />}

--- a/frontend/src/components/builder/BuilderDialogs.tsx
+++ b/frontend/src/components/builder/BuilderDialogs.tsx
@@ -143,7 +143,7 @@ export function BuilderDialogs({
             <div className="flex justify-between items-center">
               <span className="text-muted-foreground">{t('info.visibility')}</span>
               <Badge variant="outline" className="flex items-center gap-1 text-xs">
-                <VisibilityIcon visibility={mapData.visibility ?? 'private'} />
+                <VisibilityIcon visibility={mapData.visibility ?? 'private'} withLabel={false} />
                 {getVisibilityLabel(t, mapData.visibility ?? 'private')}
               </Badge>
             </div>

--- a/frontend/src/components/collections/CollectionDeleteDialog.tsx
+++ b/frontend/src/components/collections/CollectionDeleteDialog.tsx
@@ -60,11 +60,13 @@ export function CollectionDeleteDialog({ collection, open, onOpenChange }: Colle
         </AlertDialogHeader>
 
         <div className="space-y-2">
-          <p className="text-sm font-medium">{t('deleteDialog.confirmPrompt')}</p>
+          {/* v1047 A11Y-FORM-01: link the confirm input to the prompt; placeholder is not an accessible name */}
+          <p id="collection-delete-confirm-prompt" className="text-sm font-medium">{t('deleteDialog.confirmPrompt')}</p>
           <Input
             value={confirmName}
             onChange={(e) => setConfirmName(e.target.value)}
             placeholder={collection.name}
+            aria-labelledby="collection-delete-confirm-prompt"
           />
         </div>
 

--- a/frontend/src/components/collections/CollectionDeleteDialog.tsx
+++ b/frontend/src/components/collections/CollectionDeleteDialog.tsx
@@ -60,7 +60,7 @@ export function CollectionDeleteDialog({ collection, open, onOpenChange }: Colle
         </AlertDialogHeader>
 
         <div className="space-y-2">
-          {/* v1047 A11Y-FORM-01: link the confirm input to the prompt; placeholder is not an accessible name */}
+          {/* #305: link the confirm input to the prompt; placeholder is not an accessible name */}
           <p id="collection-delete-confirm-prompt" className="text-sm font-medium">{t('deleteDialog.confirmPrompt')}</p>
           <Input
             value={confirmName}

--- a/frontend/src/components/dataset/DatasetDeleteDialog.tsx
+++ b/frontend/src/components/dataset/DatasetDeleteDialog.tsx
@@ -73,11 +73,13 @@ export function DatasetDeleteDialog({ dataset, open, onOpenChange }: DatasetDele
         </AlertDialogHeader>
 
         <div className="space-y-2">
-          <p className="text-sm font-medium">{t('deleteDialog.confirmPrompt')}</p>
+          {/* v1047 A11Y-FORM-01: link the confirm input to the prompt; placeholder is not an accessible name */}
+          <p id="dataset-delete-confirm-prompt" className="text-sm font-medium">{t('deleteDialog.confirmPrompt')}</p>
           <Input
             value={confirmName}
             onChange={(e) => setConfirmName(e.target.value)}
             placeholder={dataset.title}
+            aria-labelledby="dataset-delete-confirm-prompt"
           />
         </div>
 

--- a/frontend/src/components/dataset/DatasetDeleteDialog.tsx
+++ b/frontend/src/components/dataset/DatasetDeleteDialog.tsx
@@ -73,7 +73,7 @@ export function DatasetDeleteDialog({ dataset, open, onOpenChange }: DatasetDele
         </AlertDialogHeader>
 
         <div className="space-y-2">
-          {/* v1047 A11Y-FORM-01: link the confirm input to the prompt; placeholder is not an accessible name */}
+          {/* #305: link the confirm input to the prompt; placeholder is not an accessible name */}
           <p id="dataset-delete-confirm-prompt" className="text-sm font-medium">{t('deleteDialog.confirmPrompt')}</p>
           <Input
             value={confirmName}

--- a/frontend/src/components/dataset/DatasetStatsBar.tsx
+++ b/frontend/src/components/dataset/DatasetStatsBar.tsx
@@ -13,7 +13,9 @@ interface StatCellProps {
 
 function StatCell({ label, value, mono }: StatCellProps) {
   return (
-    <div className="px-4 py-3 border-r border-border last:border-r-0 min-w-0">
+    // v1047 STATS-01: cell borders drawn on top/left so they read correctly
+    // whether cells sit in one desktop row or wrap onto multiple mobile rows.
+    <div className="px-4 py-3 border-t border-l border-border min-w-0">
       <div className="text-[10.5px] font-mono uppercase tracking-widest text-muted-foreground mb-1">
         {label}
       </div>
@@ -122,16 +124,20 @@ export function DatasetStatsBar({ dataset, className }: DatasetStatsBarProps) {
   // Limit to 6 cells max
   const displayCells = cells.slice(0, 6);
 
+  // v1047 STATS-01: reflow responsively so stats never get crushed/truncated on
+  // small screens — 2 cols on mobile, 3 on sm, then the original N-up desktop row.
   const gridColsClass: Record<number, string> = {
-    1: 'grid-cols-1', 2: 'grid-cols-2', 3: 'grid-cols-3',
-    4: 'grid-cols-4', 5: 'grid-cols-5', 6: 'grid-cols-6',
+    1: 'md:grid-cols-1', 2: 'md:grid-cols-2', 3: 'md:grid-cols-3',
+    4: 'md:grid-cols-4', 5: 'md:grid-cols-5', 6: 'md:grid-cols-6',
   };
 
   return (
     <div
       className={cn(
-        'grid border-y border-border',
-        gridColsClass[displayCells.length] ?? 'grid-cols-6',
+        // Outer right/bottom borders complete the frame the per-cell top/left
+        // borders start, keeping the desktop row visually equivalent to before.
+        'grid grid-cols-2 sm:grid-cols-3 border-r border-b border-border',
+        gridColsClass[displayCells.length] ?? 'md:grid-cols-6',
         className,
       )}
     >

--- a/frontend/src/components/dataset/DatasetStatsBar.tsx
+++ b/frontend/src/components/dataset/DatasetStatsBar.tsx
@@ -13,7 +13,7 @@ interface StatCellProps {
 
 function StatCell({ label, value, mono }: StatCellProps) {
   return (
-    // v1047 STATS-01: cell borders drawn on top/left so they read correctly
+    // #305: cell borders drawn on top/left so they read correctly
     // whether cells sit in one desktop row or wrap onto multiple mobile rows.
     <div className="px-4 py-3 border-t border-l border-border min-w-0">
       <div className="text-[10.5px] font-mono uppercase tracking-widest text-muted-foreground mb-1">
@@ -124,7 +124,7 @@ export function DatasetStatsBar({ dataset, className }: DatasetStatsBarProps) {
   // Limit to 6 cells max
   const displayCells = cells.slice(0, 6);
 
-  // v1047 STATS-01: reflow responsively so stats never get crushed/truncated on
+  // #305: reflow responsively so stats never get crushed/truncated on
   // small screens — 2 cols on mobile, 3 on sm, then the original N-up desktop row.
   const gridColsClass: Record<number, string> = {
     1: 'md:grid-cols-1', 2: 'md:grid-cols-2', 3: 'md:grid-cols-3',

--- a/frontend/src/components/dataset/DatasetStatsBar.tsx
+++ b/frontend/src/components/dataset/DatasetStatsBar.tsx
@@ -124,11 +124,16 @@ export function DatasetStatsBar({ dataset, className }: DatasetStatsBarProps) {
   // Limit to 6 cells max
   const displayCells = cells.slice(0, 6);
 
-  // #305: reflow responsively so stats never get crushed/truncated on
-  // small screens — 2 cols on mobile, 3 on sm, then the original N-up desktop row.
+  // #305: reflow responsively so stats never get crushed/truncated on small
+  // screens, and cap columns to the number of rendered cells at every
+  // breakpoint so a sparse dataset (1-2 stats) leaves no empty grid columns.
   const gridColsClass: Record<number, string> = {
-    1: 'md:grid-cols-1', 2: 'md:grid-cols-2', 3: 'md:grid-cols-3',
-    4: 'md:grid-cols-4', 5: 'md:grid-cols-5', 6: 'md:grid-cols-6',
+    1: 'grid-cols-1',
+    2: 'grid-cols-2',
+    3: 'grid-cols-2 sm:grid-cols-3 md:grid-cols-3',
+    4: 'grid-cols-2 sm:grid-cols-3 md:grid-cols-4',
+    5: 'grid-cols-2 sm:grid-cols-3 md:grid-cols-5',
+    6: 'grid-cols-2 sm:grid-cols-3 md:grid-cols-6',
   };
 
   return (
@@ -136,8 +141,8 @@ export function DatasetStatsBar({ dataset, className }: DatasetStatsBarProps) {
       className={cn(
         // Outer right/bottom borders complete the frame the per-cell top/left
         // borders start, keeping the desktop row visually equivalent to before.
-        'grid grid-cols-2 sm:grid-cols-3 border-r border-b border-border',
-        gridColsClass[displayCells.length] ?? 'md:grid-cols-6',
+        'grid border-r border-b border-border',
+        gridColsClass[displayCells.length] ?? 'grid-cols-2 sm:grid-cols-3 md:grid-cols-6',
         className,
       )}
     >

--- a/frontend/src/components/dataset/tabs/AccessTab.tsx
+++ b/frontend/src/components/dataset/tabs/AccessTab.tsx
@@ -280,7 +280,7 @@ export function AccessTab({ dataset }: AccessTabProps) {
                 'bg-muted text-muted-foreground border-border'
               }
             >
-              <VisibilityIcon visibility={dataset.visibility} />
+              <VisibilityIcon visibility={dataset.visibility} withLabel={false} />
               <span className="ms-1">{getVisibilityLabel(t, dataset.visibility)}</span>
             </Badge>
           </div>

--- a/frontend/src/components/import/IngestWarningsBanner.tsx
+++ b/frontend/src/components/import/IngestWarningsBanner.tsx
@@ -85,14 +85,17 @@ export function IngestWarningsBanner({
     <div
       role="status"
       className={[
-        'rounded-md border border-yellow-500/40 bg-yellow-500/10 p-3 text-sm text-yellow-900 dark:text-yellow-100',
+        'rounded-md border border-warning/30 bg-warning/10 p-3 text-sm text-foreground',
         className ?? '',
       ]
         .join(' ')
         .trim()}
     >
       <div className="flex items-start gap-2">
-        <AlertTriangle className="mt-0.5 size-4 shrink-0" aria-hidden="true" />
+        <AlertTriangle
+          className="mt-0.5 size-4 shrink-0 text-warning"
+          aria-hidden="true"
+        />
         <div className="flex-1 space-y-3">
           <p className="font-semibold">{t('warnings.bannerTitle')}</p>
           {warnings.map((warning, idx) => {

--- a/frontend/src/components/layout/AppLayout.tsx
+++ b/frontend/src/components/layout/AppLayout.tsx
@@ -28,8 +28,8 @@ export function AppLayout() {
         // Always a flex column so flex-1 page content fills the space the
         // navbar/banner/footer leave — fixes the public-map scroll (was a
         // hardcoded 100dvh-navbar that ignored the footer) AND lets standalone
-        // pages (404) center vertically in the available viewport (v1047
-        // STANDALONE-01). isMapRoute retained for any map-specific tweaks.
+        // pages (404) center vertically in the available viewport (#305).
+        // isMapRoute retained for any map-specific tweaks.
         className={cn('flex flex-1 flex-col animate-fade-in focus:outline-none', isMapRoute && 'flex-col')}
       >
         <Outlet />

--- a/frontend/src/components/layout/AppLayout.tsx
+++ b/frontend/src/components/layout/AppLayout.tsx
@@ -30,7 +30,9 @@ export function AppLayout() {
         // hardcoded 100dvh-navbar that ignored the footer) AND lets standalone
         // pages (404) center vertically in the available viewport (#305).
         // isMapRoute retained for any map-specific tweaks.
-        className={cn('flex flex-1 flex-col animate-fade-in focus:outline-none', isMapRoute && 'flex-col')}
+        // scroll-mt clears the now-sticky navbar when the skip-link scrolls
+        // #main-content into view, so the heading isn't hidden under it (#305).
+        className={cn('flex flex-1 flex-col scroll-mt-16 animate-fade-in focus:outline-none', isMapRoute && 'flex-col')}
       >
         <Outlet />
       </main>

--- a/frontend/src/components/layout/AppLayout.tsx
+++ b/frontend/src/components/layout/AppLayout.tsx
@@ -25,10 +25,12 @@ export function AppLayout() {
       <main
         id="main-content"
         tabIndex={-1}
-        // ponytail: on map routes, become a flex column so the map fills the space
-        // the navbar/banner/footer leave — fixes the public-map scroll where the
-        // page hardcoded `100dvh-navbar` and ignored the footer below it.
-        className={cn('flex-1 animate-fade-in focus:outline-none', isMapRoute && 'flex flex-col')}
+        // Always a flex column so flex-1 page content fills the space the
+        // navbar/banner/footer leave — fixes the public-map scroll (was a
+        // hardcoded 100dvh-navbar that ignored the footer) AND lets standalone
+        // pages (404) center vertically in the available viewport (v1047
+        // STANDALONE-01). isMapRoute retained for any map-specific tweaks.
+        className={cn('flex flex-1 flex-col animate-fade-in focus:outline-none', isMapRoute && 'flex-col')}
       >
         <Outlet />
       </main>

--- a/frontend/src/components/layout/DemoBanner.tsx
+++ b/frontend/src/components/layout/DemoBanner.tsx
@@ -36,7 +36,7 @@ function DemoBannerInner() {
     <div
       role="status"
       aria-live="polite"
-      className="border-b border-amber-500/30 bg-amber-500/10 px-4 py-1.5 text-center text-sm text-amber-900 dark:text-amber-200"
+      className="border-b border-warning/30 bg-warning/10 px-4 py-1.5 text-center text-sm text-warning"
     >
       {t('demoBanner')}
     </div>

--- a/frontend/src/components/layout/Navbar.tsx
+++ b/frontend/src/components/layout/Navbar.tsx
@@ -121,7 +121,7 @@ function UserMenu() {
   const { t: tAuth } = useTranslation('auth');
   const { t: tReport } = useTranslation('report');
   const openReport = useReportDialog((s) => s.openReport);
-  // v1047 THEME-01: explicit light/dark override (default stays 'system', which
+  // #305: explicit light/dark override (default stays 'system', which
   // already honors prefers-color-scheme). resolvedTheme drives the icon/label.
   const { setTheme, resolvedTheme } = useTheme();
 
@@ -186,7 +186,7 @@ function UserMenu() {
           </Link>
         </DropdownMenuItem>
 
-        {/* v1047 THEME-01: light/dark toggle (no UI affordance existed before) */}
+        {/* #305: light/dark toggle (no UI affordance existed before) */}
         <DropdownMenuItem
           onClick={(e) => {
             e.preventDefault();

--- a/frontend/src/components/layout/Navbar.tsx
+++ b/frontend/src/components/layout/Navbar.tsx
@@ -352,8 +352,8 @@ export function Navbar() {
   const { t } = useTranslation();
 
   return (
-    <header className="border-b bg-background">
-      <div className="mx-auto flex h-14 max-w-6xl items-center justify-between px-6">
+    <header className="sticky top-0 z-40 border-b bg-background">
+      <div className="mx-auto flex h-14 max-w-7xl items-center justify-between px-6">
         <div className="flex items-center gap-4">
           <MobileNav />
           <Link to="/" aria-label={t('appName')} className="hover:text-primary transition-colors duration-150">

--- a/frontend/src/components/layout/Navbar.tsx
+++ b/frontend/src/components/layout/Navbar.tsx
@@ -373,7 +373,7 @@ export function Navbar() {
   const { t } = useTranslation();
 
   return (
-    <header className="sticky top-0 z-40 border-b bg-background">
+    <header className="sticky top-0 z-40 border-b bg-background pt-[env(safe-area-inset-top)]">
       <div className="mx-auto flex h-14 max-w-7xl items-center justify-between px-6">
         <div className="flex items-center gap-4">
           <MobileNav />

--- a/frontend/src/components/layout/Navbar.tsx
+++ b/frontend/src/components/layout/Navbar.tsx
@@ -1,7 +1,8 @@
 import { useState, useEffect } from 'react';
 import { Link, NavLink, useLocation } from 'react-router';
 import { useTranslation } from 'react-i18next';
-import { ChevronDown, User, LogOut, Settings, Shield, Plus, Database, FolderOpen, Map, Menu, Layers, Upload, LogIn, LifeBuoy } from 'lucide-react';
+import { ChevronDown, User, LogOut, Settings, Shield, Plus, Database, FolderOpen, Map, Menu, Layers, Upload, LogIn, LifeBuoy, Sun, Moon } from 'lucide-react';
+import { useTheme } from '@/components/theme-provider';
 import { useAuth } from '@/hooks/use-auth';
 import { useReportDialog } from '@/lib/report';
 import { usePermissions } from '@/hooks/use-permissions';
@@ -120,6 +121,9 @@ function UserMenu() {
   const { t: tAuth } = useTranslation('auth');
   const { t: tReport } = useTranslation('report');
   const openReport = useReportDialog((s) => s.openReport);
+  // v1047 THEME-01: explicit light/dark override (default stays 'system', which
+  // already honors prefers-color-scheme). resolvedTheme drives the icon/label.
+  const { setTheme, resolvedTheme } = useTheme();
 
   // Anonymous: show sign-in button instead of user dropdown
   if (!user) {
@@ -180,6 +184,23 @@ function UserMenu() {
             <Settings className="h-4 w-4" />
             {t('nav.settings')}
           </Link>
+        </DropdownMenuItem>
+
+        {/* v1047 THEME-01: light/dark toggle (no UI affordance existed before) */}
+        <DropdownMenuItem
+          onClick={(e) => {
+            e.preventDefault();
+            setTheme(resolvedTheme === 'dark' ? 'light' : 'dark');
+          }}
+        >
+          {resolvedTheme === 'dark' ? (
+            <Sun className="h-4 w-4" />
+          ) : (
+            <Moon className="h-4 w-4" />
+          )}
+          {resolvedTheme === 'dark'
+            ? t('nav.lightMode', { defaultValue: 'Light mode' })
+            : t('nav.darkMode', { defaultValue: 'Dark mode' })}
         </DropdownMenuItem>
 
         {/* Admin (admin users only) */}

--- a/frontend/src/components/map/FeaturePopup.tsx
+++ b/frontend/src/components/map/FeaturePopup.tsx
@@ -51,12 +51,12 @@ export function FeaturePopup({
   const [activeIndex, setActiveIndex] = useState(0);
   const [copiedKey, setCopiedKey] = useState<string | null>(null);
   const timerRef = useRef<ReturnType<typeof setTimeout>>(undefined);
-  // v1047 A11Y-POPUP-01: close button ref for soft focus move-in on open.
+  // #305: close button ref for soft focus move-in on open.
   const closeButtonRef = useRef<HTMLButtonElement>(null);
 
   useEffect(() => () => clearTimeout(timerRef.current), []);
 
-  // v1047 A11Y-POPUP-01: on open, soft-move focus to the close button so
+  // #305: on open, soft-move focus to the close button so
   // keyboard users land inside the popup; on close/unmount, restore focus to
   // the map canvas (or container) so the map stays keyboard-operable. This is a
   // soft move + restore, NOT a focus trap — map interaction is preserved.
@@ -75,7 +75,7 @@ export function FeaturePopup({
     };
   }, []);
 
-  // v1047 A11Y-POPUP-01: Escape closes the popup (focus is restored by the
+  // #305: Escape closes the popup (focus is restored by the
   // unmount effect above). Document-level listener so it fires regardless of
   // which element inside the popup holds focus, without putting a keyboard
   // handler on the non-interactive dialog container.
@@ -175,7 +175,7 @@ export function FeaturePopup({
       closeOnClick={false}
       maxWidth="360px"
     >
-      {/* v1047 A11Y-POPUP-01: labelled dialog container with focus management.
+      {/* #305: labelled dialog container with focus management.
           aria-label uses the feature title when present, else the layer name. */}
       <div
         role="dialog"

--- a/frontend/src/components/map/FeaturePopup.tsx
+++ b/frontend/src/components/map/FeaturePopup.tsx
@@ -51,8 +51,44 @@ export function FeaturePopup({
   const [activeIndex, setActiveIndex] = useState(0);
   const [copiedKey, setCopiedKey] = useState<string | null>(null);
   const timerRef = useRef<ReturnType<typeof setTimeout>>(undefined);
+  // v1047 A11Y-POPUP-01: close button ref for soft focus move-in on open.
+  const closeButtonRef = useRef<HTMLButtonElement>(null);
 
   useEffect(() => () => clearTimeout(timerRef.current), []);
+
+  // v1047 A11Y-POPUP-01: on open, soft-move focus to the close button so
+  // keyboard users land inside the popup; on close/unmount, restore focus to
+  // the map canvas (or container) so the map stays keyboard-operable. This is a
+  // soft move + restore, NOT a focus trap — map interaction is preserved.
+  useEffect(() => {
+    const previouslyFocused = document.activeElement as HTMLElement | null;
+    closeButtonRef.current?.focus();
+    return () => {
+      // Restore focus to the map so the keyboard context returns to the map
+      // (canvas carries tabindex=0); fall back to the map container, then to
+      // wherever focus was before the popup opened.
+      const restoreTarget =
+        document.querySelector<HTMLElement>('.maplibregl-canvas') ??
+        document.querySelector<HTMLElement>('.maplibregl-map') ??
+        previouslyFocused;
+      restoreTarget?.focus?.();
+    };
+  }, []);
+
+  // v1047 A11Y-POPUP-01: Escape closes the popup (focus is restored by the
+  // unmount effect above). Document-level listener so it fires regardless of
+  // which element inside the popup holds focus, without putting a keyboard
+  // handler on the non-interactive dialog container.
+  useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        onClose();
+      }
+    };
+    document.addEventListener('keydown', onKeyDown);
+    return () => document.removeEventListener('keydown', onKeyDown);
+  }, [onClose]);
 
   // Clamp activeIndex if features shrinks while popup is open (e.g. layer toggle race).
   useEffect(() => {
@@ -139,7 +175,17 @@ export function FeaturePopup({
       closeOnClick={false}
       maxWidth="360px"
     >
-      <div className="text-xs">
+      {/* v1047 A11Y-POPUP-01: labelled dialog container with focus management.
+          aria-label uses the feature title when present, else the layer name. */}
+      <div
+        role="dialog"
+        aria-label={
+          title ||
+          layerName ||
+          t('featurePopup.dialogLabel', { defaultValue: 'Feature details' })
+        }
+        className="text-xs"
+      >
         {/* Header: layer name (left) + pager + close (right) */}
         <div className="flex items-center justify-between gap-2 mb-2 pb-2 border-b border-border">
           <span className="font-semibold font-mono text-xs uppercase tracking-wide text-muted-foreground truncate">
@@ -175,6 +221,7 @@ export function FeaturePopup({
               </>
             )}
             <Button
+              ref={closeButtonRef}
               type="button"
               variant="ghost"
               size="icon-xs"

--- a/frontend/src/components/maps/VisibilityIcon.tsx
+++ b/frontend/src/components/maps/VisibilityIcon.tsx
@@ -1,8 +1,18 @@
 import { Globe, Lock, ShieldAlert, Users } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import { getVisibilityLabel } from '@/i18n/labels';
 
 export function VisibilityIcon({ visibility }: { visibility: string }) {
-  if (visibility === 'public') return <Globe className="h-3.5 w-3.5 text-success" />;
-  if (visibility === 'internal') return <Users className="h-3.5 w-3.5 text-warning" />;
-  if (visibility === 'restricted') return <ShieldAlert className="h-3.5 w-3.5 text-warning" />;
-  return <Lock className="h-3.5 w-3.5 text-muted-foreground" />;
+  const { t } = useTranslation();
+  // v1047 A11Y-COLOR-01: meaning was conveyed by icon/color alone; give each
+  // icon an accessible name so screen readers announce the visibility (and
+  // internal vs restricted are differentiated by text, not just shared color).
+  const label = getVisibilityLabel(t, visibility);
+  if (visibility === 'public')
+    return <Globe className="h-3.5 w-3.5 text-success" role="img" aria-label={label} />;
+  if (visibility === 'internal')
+    return <Users className="h-3.5 w-3.5 text-warning" role="img" aria-label={label} />;
+  if (visibility === 'restricted')
+    return <ShieldAlert className="h-3.5 w-3.5 text-warning" role="img" aria-label={label} />;
+  return <Lock className="h-3.5 w-3.5 text-muted-foreground" role="img" aria-label={label} />;
 }

--- a/frontend/src/components/maps/VisibilityIcon.tsx
+++ b/frontend/src/components/maps/VisibilityIcon.tsx
@@ -1,10 +1,18 @@
 import { Globe, Lock, ShieldAlert, Users } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import { getVisibilityLabel } from '@/i18n/labels';
 
-export function VisibilityIcon({ visibility }: { visibility: string }) {
-  // #305: purely decorative (aria-hidden). Every call site renders the
-  // visibility label as visible text right next to this icon (MapCard,
-  // AccessTab, BuilderDialogs, …), so an sr-only label here only
-  // double-announces ("Public Public") — the adjacent text already conveys it.
+export function VisibilityIcon({
+  visibility,
+  withLabel = true,
+}: {
+  visibility: string;
+  /** Include an sr-only text label. Default true (icon-only uses like the map
+   *  cards need it). Pass false where the visibility is already rendered as
+   *  adjacent VISIBLE text to avoid double-announcing ("Public Public"). #305 */
+  withLabel?: boolean;
+}) {
+  const { t } = useTranslation();
   const Icon =
     visibility === 'public'
       ? Globe
@@ -19,5 +27,10 @@ export function VisibilityIcon({ visibility }: { visibility: string }) {
       : visibility === 'internal' || visibility === 'restricted'
         ? 'text-warning'
         : 'text-muted-foreground';
-  return <Icon className={`h-3.5 w-3.5 ${colorClass}`} aria-hidden="true" />;
+  return (
+    <>
+      <Icon className={`h-3.5 w-3.5 ${colorClass}`} aria-hidden="true" />
+      {withLabel && <span className="sr-only">{getVisibilityLabel(t, visibility)}</span>}
+    </>
+  );
 }

--- a/frontend/src/components/maps/VisibilityIcon.tsx
+++ b/frontend/src/components/maps/VisibilityIcon.tsx
@@ -1,16 +1,10 @@
 import { Globe, Lock, ShieldAlert, Users } from 'lucide-react';
-import { useTranslation } from 'react-i18next';
-import { getVisibilityLabel } from '@/i18n/labels';
 
 export function VisibilityIcon({ visibility }: { visibility: string }) {
-  const { t } = useTranslation();
-  // #305: meaning was conveyed by icon/color alone. Render the
-  // glyph as decorative (aria-hidden) and add an sr-only text label so the
-  // visibility is announced to screen readers — and internal vs restricted,
-  // which share the warning color, are differentiated by text. An sr-only span
-  // (rather than role="img" on the icon) keeps the icon out of by-role image
-  // queries used for dataset/map thumbnails.
-  const label = getVisibilityLabel(t, visibility);
+  // #305: purely decorative (aria-hidden). Every call site renders the
+  // visibility label as visible text right next to this icon (MapCard,
+  // AccessTab, BuilderDialogs, …), so an sr-only label here only
+  // double-announces ("Public Public") — the adjacent text already conveys it.
   const Icon =
     visibility === 'public'
       ? Globe
@@ -25,10 +19,5 @@ export function VisibilityIcon({ visibility }: { visibility: string }) {
       : visibility === 'internal' || visibility === 'restricted'
         ? 'text-warning'
         : 'text-muted-foreground';
-  return (
-    <>
-      <Icon className={`h-3.5 w-3.5 ${colorClass}`} aria-hidden="true" />
-      <span className="sr-only">{label}</span>
-    </>
-  );
+  return <Icon className={`h-3.5 w-3.5 ${colorClass}`} aria-hidden="true" />;
 }

--- a/frontend/src/components/maps/VisibilityIcon.tsx
+++ b/frontend/src/components/maps/VisibilityIcon.tsx
@@ -4,15 +4,31 @@ import { getVisibilityLabel } from '@/i18n/labels';
 
 export function VisibilityIcon({ visibility }: { visibility: string }) {
   const { t } = useTranslation();
-  // v1047 A11Y-COLOR-01: meaning was conveyed by icon/color alone; give each
-  // icon an accessible name so screen readers announce the visibility (and
-  // internal vs restricted are differentiated by text, not just shared color).
+  // v1047 A11Y-COLOR-01: meaning was conveyed by icon/color alone. Render the
+  // glyph as decorative (aria-hidden) and add an sr-only text label so the
+  // visibility is announced to screen readers — and internal vs restricted,
+  // which share the warning color, are differentiated by text. An sr-only span
+  // (rather than role="img" on the icon) keeps the icon out of by-role image
+  // queries used for dataset/map thumbnails.
   const label = getVisibilityLabel(t, visibility);
-  if (visibility === 'public')
-    return <Globe className="h-3.5 w-3.5 text-success" role="img" aria-label={label} />;
-  if (visibility === 'internal')
-    return <Users className="h-3.5 w-3.5 text-warning" role="img" aria-label={label} />;
-  if (visibility === 'restricted')
-    return <ShieldAlert className="h-3.5 w-3.5 text-warning" role="img" aria-label={label} />;
-  return <Lock className="h-3.5 w-3.5 text-muted-foreground" role="img" aria-label={label} />;
+  const Icon =
+    visibility === 'public'
+      ? Globe
+      : visibility === 'internal'
+        ? Users
+        : visibility === 'restricted'
+          ? ShieldAlert
+          : Lock;
+  const colorClass =
+    visibility === 'public'
+      ? 'text-success'
+      : visibility === 'internal' || visibility === 'restricted'
+        ? 'text-warning'
+        : 'text-muted-foreground';
+  return (
+    <>
+      <Icon className={`h-3.5 w-3.5 ${colorClass}`} aria-hidden="true" />
+      <span className="sr-only">{label}</span>
+    </>
+  );
 }

--- a/frontend/src/components/maps/VisibilityIcon.tsx
+++ b/frontend/src/components/maps/VisibilityIcon.tsx
@@ -4,7 +4,7 @@ import { getVisibilityLabel } from '@/i18n/labels';
 
 export function VisibilityIcon({ visibility }: { visibility: string }) {
   const { t } = useTranslation();
-  // v1047 A11Y-COLOR-01: meaning was conveyed by icon/color alone. Render the
+  // #305: meaning was conveyed by icon/color alone. Render the
   // glyph as decorative (aria-hidden) and add an sr-only text label so the
   // visibility is announced to screen readers — and internal vs restricted,
   // which share the warning color, are differentiated by text. An sr-only span

--- a/frontend/src/components/settings/MyApiKeySection.tsx
+++ b/frontend/src/components/settings/MyApiKeySection.tsx
@@ -141,7 +141,7 @@ export function MyApiKeySection() {
                     title={key.is_active ? t('admin:apiKeys.active') : t('admin:apiKeys.revoked')}
                     aria-hidden="true"
                   />
-                  {/* v1047 A11Y-COLOR-01: state was conveyed by dot color + non-announced title only; add a text alt for assistive tech */}
+                  {/* #305: state was conveyed by dot color + non-announced title only; add a text alt for assistive tech */}
                   <span className="sr-only">
                     {key.is_active ? t('admin:apiKeys.active') : t('admin:apiKeys.revoked')}
                   </span>

--- a/frontend/src/components/settings/MyApiKeySection.tsx
+++ b/frontend/src/components/settings/MyApiKeySection.tsx
@@ -139,7 +139,12 @@ export function MyApiKeySection() {
                       activeDotColor[String(key.is_active) as keyof typeof activeDotColor]
                     }`}
                     title={key.is_active ? t('admin:apiKeys.active') : t('admin:apiKeys.revoked')}
+                    aria-hidden="true"
                   />
+                  {/* v1047 A11Y-COLOR-01: state was conveyed by dot color + non-announced title only; add a text alt for assistive tech */}
+                  <span className="sr-only">
+                    {key.is_active ? t('admin:apiKeys.active') : t('admin:apiKeys.revoked')}
+                  </span>
                 </div>
                 <div className="text-xs text-muted-foreground">
                   {t('admin:apiKeys.created', { date: formatDate(key.created_at) })} · {t('admin:apiKeys.lastUsed')} {relativeTime(key.last_used_at, t)}

--- a/frontend/src/components/ui/badge.tsx
+++ b/frontend/src/components/ui/badge.tsx
@@ -18,6 +18,11 @@ const badgeVariants = cva(
           "border-border text-foreground [a&]:hover:bg-accent [a&]:hover:text-accent-foreground",
         ghost: "[a&]:hover:bg-accent [a&]:hover:text-accent-foreground",
         link: "text-primary underline-offset-4 [a&]:hover:underline",
+        // v1047 BADGE-01: token-driven soft status variants (AA after CONTRAST-01).
+        // Replaces ad-hoc per-call `bg-success/10 text-success text-[10px]` recipes.
+        success: "border-success/30 bg-success/10 text-success [a&]:hover:bg-success/15",
+        warning: "border-warning/30 bg-warning/10 text-warning [a&]:hover:bg-warning/15",
+        info: "border-info/30 bg-info/10 text-info [a&]:hover:bg-info/15",
       },
     },
     defaultVariants: {

--- a/frontend/src/components/ui/badge.tsx
+++ b/frontend/src/components/ui/badge.tsx
@@ -18,7 +18,7 @@ const badgeVariants = cva(
           "border-border text-foreground [a&]:hover:bg-accent [a&]:hover:text-accent-foreground",
         ghost: "[a&]:hover:bg-accent [a&]:hover:text-accent-foreground",
         link: "text-primary underline-offset-4 [a&]:hover:underline",
-        // v1047 BADGE-01: token-driven soft status variants (AA after CONTRAST-01).
+        // #305: token-driven soft status variants (AA after CONTRAST-01).
         // Replaces ad-hoc per-call `bg-success/10 text-success text-[10px]` recipes.
         success: "border-success/30 bg-success/10 text-success [a&]:hover:bg-success/15",
         warning: "border-warning/30 bg-warning/10 text-warning [a&]:hover:bg-warning/15",

--- a/frontend/src/components/ui/badge.tsx
+++ b/frontend/src/components/ui/badge.tsx
@@ -18,7 +18,7 @@ const badgeVariants = cva(
           "border-border text-foreground [a&]:hover:bg-accent [a&]:hover:text-accent-foreground",
         ghost: "[a&]:hover:bg-accent [a&]:hover:text-accent-foreground",
         link: "text-primary underline-offset-4 [a&]:hover:underline",
-        // #305: token-driven soft status variants (AA after CONTRAST-01).
+        // #305: token-driven soft status variants (AA-compliant).
         // Replaces ad-hoc per-call `bg-success/10 text-success text-[10px]` recipes.
         success: "border-success/30 bg-success/10 text-success [a&]:hover:bg-success/15",
         warning: "border-warning/30 bg-warning/10 text-warning [a&]:hover:bg-warning/15",

--- a/frontend/src/components/ui/button.tsx
+++ b/frontend/src/components/ui/button.tsx
@@ -20,15 +20,19 @@ const buttonVariants = cva(
           "hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50",
         link: "text-primary underline-offset-4 hover:underline",
       },
+      // v1047 TOUCH-01: pointer-coarse: bumps the primary action sizes to a
+      // >=44px tap target on touch devices only — desktop (fine pointer)
+      // density is unchanged. xs / icon-xs stay compact for dense lists
+      // (they already meet the 24px WCAG 2.2 AA minimum target size).
       size: {
-        default: "h-9 px-4 py-2 has-[>svg]:px-3",
+        default: "h-9 px-4 py-2 has-[>svg]:px-3 pointer-coarse:min-h-11",
         xs: "h-6 gap-1 rounded-md px-2 text-xs has-[>svg]:px-1.5 [&_svg:not([class*='size-'])]:size-3",
-        sm: "h-8 rounded-md gap-1.5 px-3 has-[>svg]:px-2.5",
-        lg: "h-10 rounded-md px-6 has-[>svg]:px-4",
-        icon: "size-9",
+        sm: "h-8 rounded-md gap-1.5 px-3 has-[>svg]:px-2.5 pointer-coarse:min-h-11",
+        lg: "h-10 rounded-md px-6 has-[>svg]:px-4 pointer-coarse:min-h-11",
+        icon: "size-9 pointer-coarse:size-11",
         "icon-xs": "size-6 rounded-md [&_svg:not([class*='size-'])]:size-3",
-        "icon-sm": "size-8",
-        "icon-lg": "size-10",
+        "icon-sm": "size-8 pointer-coarse:size-11",
+        "icon-lg": "size-10 pointer-coarse:size-11",
       },
     },
     defaultVariants: {

--- a/frontend/src/components/ui/button.tsx
+++ b/frontend/src/components/ui/button.tsx
@@ -20,7 +20,7 @@ const buttonVariants = cva(
           "hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50",
         link: "text-primary underline-offset-4 hover:underline",
       },
-      // v1047 TOUCH-01: pointer-coarse: bumps the primary action sizes to a
+      // #305: pointer-coarse: bumps the primary action sizes to a
       // >=44px tap target on touch devices only — desktop (fine pointer)
       // density is unchanged. xs / icon-xs stay compact for dense lists
       // (they already meet the 24px WCAG 2.2 AA minimum target size).

--- a/frontend/src/i18n/locales/de/admin.json
+++ b/frontend/src/i18n/locales/de/admin.json
@@ -600,7 +600,8 @@
       "callbackUrl": "Weiterleitungs-/Callback-URL",
       "copyCallbackUrl": "Callback-URL kopieren",
       "callbackUrlCopied": "Callback-URL in die Zwischenablage kopiert",
-      "callbackUrlHint": "Registrieren Sie diese URL bei Ihrem Anbieter (Google, Microsoft oder GitHub) als autorisierte Weiterleitungs-/Callback-URL. Sie muss der konfigurierten öffentlichen API-URL der Installation entsprechen (PUBLIC_API_URL bzw. die öffentliche API-URL in den allgemeinen Einstellungen setzen), sonst schlägt die OAuth-Anmeldung mit einem Redirect-Fehler fehl."
+      "callbackUrlHint": "Registrieren Sie diese URL bei Ihrem Anbieter (Google, Microsoft oder GitHub) als autorisierte Weiterleitungs-/Callback-URL. Sie muss der konfigurierten öffentlichen API-URL der Installation entsprechen (PUBLIC_API_URL bzw. die öffentliche API-URL in den allgemeinen Einstellungen setzen), sonst schlägt die OAuth-Anmeldung mit einem Redirect-Fehler fehl.",
+      "callbackUrlCopyFailed": "Konnte nicht kopiert werden — kopieren Sie die URL manuell."
     },
     "notifications": {
       "title": "Ausgehende Benachrichtigungen",

--- a/frontend/src/i18n/locales/de/admin.json
+++ b/frontend/src/i18n/locales/de/admin.json
@@ -600,7 +600,7 @@
       "callbackUrl": "Weiterleitungs-/Callback-URL",
       "copyCallbackUrl": "Callback-URL kopieren",
       "callbackUrlCopied": "Callback-URL in die Zwischenablage kopiert",
-      "callbackUrlHint": "Registrieren Sie genau diese URL als autorisierte Weiterleitungs-/Callback-URL bei Ihrem Anbieter (Google, Microsoft oder GitHub)."
+      "callbackUrlHint": "Registrieren Sie diese URL bei Ihrem Anbieter (Google, Microsoft oder GitHub) als autorisierte Weiterleitungs-/Callback-URL. Sie muss der konfigurierten öffentlichen API-URL der Installation entsprechen (PUBLIC_API_URL bzw. die öffentliche API-URL in den allgemeinen Einstellungen setzen), sonst schlägt die OAuth-Anmeldung mit einem Redirect-Fehler fehl."
     },
     "notifications": {
       "title": "Ausgehende Benachrichtigungen",

--- a/frontend/src/i18n/locales/de/admin.json
+++ b/frontend/src/i18n/locales/de/admin.json
@@ -596,7 +596,11 @@
         "editor": "Bearbeiter",
         "admin": "Administrator"
       },
-      "loadFailed": "OAuth-Anbieter konnten nicht geladen werden"
+      "loadFailed": "OAuth-Anbieter konnten nicht geladen werden",
+      "callbackUrl": "Weiterleitungs-/Callback-URL",
+      "copyCallbackUrl": "Callback-URL kopieren",
+      "callbackUrlCopied": "Callback-URL in die Zwischenablage kopiert",
+      "callbackUrlHint": "Registrieren Sie genau diese URL als autorisierte Weiterleitungs-/Callback-URL bei Ihrem Anbieter (Google, Microsoft oder GitHub)."
     },
     "notifications": {
       "title": "Ausgehende Benachrichtigungen",

--- a/frontend/src/i18n/locales/de/builder.json
+++ b/frontend/src/i18n/locales/de/builder.json
@@ -678,7 +678,8 @@
     "copyFailed": "Kopieren fehlgeschlagen",
     "prev": "Vorheriges Objekt",
     "next": "Nächstes Objekt",
-    "close": "Popup schließen"
+    "close": "Popup schließen",
+    "dialogLabel": "Objektdetails"
   },
   "descriptionPlaceholder": "Beschreibung hinzufügen...",
   "titleBar": {

--- a/frontend/src/i18n/locales/de/common.json
+++ b/frontend/src/i18n/locales/de/common.json
@@ -38,7 +38,9 @@
     "virtualRaster": "Virtueller Raster",
     "skipToContent": "Zum Hauptinhalt springen",
     "mainNavigation": "Hauptnavigation",
-    "github": "Auf GitHub markieren"
+    "github": "Auf GitHub markieren",
+    "lightMode": "Heller Modus",
+    "darkMode": "Dunkler Modus"
   },
   "theme": {
     "toggle": "Design umschalten",

--- a/frontend/src/i18n/locales/de/search.json
+++ b/frontend/src/i18n/locales/de/search.json
@@ -9,7 +9,10 @@
   "empty": {
     "title": "Keine Datensätze gefunden",
     "description": "Passen Sie Ihre Suchanfrage oder Filter an",
-    "cta": "Importieren Sie Ihren ersten Datensatz"
+    "cta": "Importieren Sie Ihren ersten Datensatz",
+    "catalogTitle": "Ihr Katalog ist leer",
+    "catalogDescription": "Importieren Sie ein Dataset, um Ihren Geodatenkatalog aufzubauen.",
+    "clear": "Suche und Filter zurücksetzen"
   },
   "error": {
     "message": "Ergebnisse konnten nicht geladen werden: {{message}}"

--- a/frontend/src/i18n/locales/en/admin.json
+++ b/frontend/src/i18n/locales/en/admin.json
@@ -637,7 +637,8 @@
       "callbackUrl": "Redirect / Callback URL",
       "copyCallbackUrl": "Copy callback URL",
       "callbackUrlCopied": "Callback URL copied to clipboard",
-      "callbackUrlHint": "Register this URL with your provider (Google, Microsoft, or GitHub) as the authorized redirect / callback URL. It must match the deployment’s configured Public API URL (set PUBLIC_API_URL, or the Public API URL in General settings), or OAuth sign-in fails with a redirect mismatch."
+      "callbackUrlHint": "Register this URL with your provider (Google, Microsoft, or GitHub) as the authorized redirect / callback URL. It must match the deployment’s configured Public API URL (set PUBLIC_API_URL, or the Public API URL in General settings), or OAuth sign-in fails with a redirect mismatch.",
+      "callbackUrlCopyFailed": "Could not copy — copy the URL manually."
     }
   },
   "saml": {

--- a/frontend/src/i18n/locales/en/admin.json
+++ b/frontend/src/i18n/locales/en/admin.json
@@ -637,7 +637,7 @@
       "callbackUrl": "Redirect / Callback URL",
       "copyCallbackUrl": "Copy callback URL",
       "callbackUrlCopied": "Callback URL copied to clipboard",
-      "callbackUrlHint": "Register this exact URL as the authorized redirect / callback URL with your provider (Google, Microsoft, or GitHub)."
+      "callbackUrlHint": "Register this URL with your provider (Google, Microsoft, or GitHub) as the authorized redirect / callback URL. It must match the deployment’s configured Public API URL (set PUBLIC_API_URL, or the Public API URL in General settings), or OAuth sign-in fails with a redirect mismatch."
     }
   },
   "saml": {

--- a/frontend/src/i18n/locales/en/admin.json
+++ b/frontend/src/i18n/locales/en/admin.json
@@ -633,7 +633,11 @@
         "viewer": "Viewer",
         "editor": "Editor",
         "admin": "Admin"
-      }
+      },
+      "callbackUrl": "Redirect / Callback URL",
+      "copyCallbackUrl": "Copy callback URL",
+      "callbackUrlCopied": "Callback URL copied to clipboard",
+      "callbackUrlHint": "Register this exact URL as the authorized redirect / callback URL with your provider (Google, Microsoft, or GitHub)."
     }
   },
   "saml": {

--- a/frontend/src/i18n/locales/en/builder.json
+++ b/frontend/src/i18n/locales/en/builder.json
@@ -678,7 +678,8 @@
     "copyFailed": "Failed to copy",
     "prev": "Previous feature",
     "next": "Next feature",
-    "close": "Close popup"
+    "close": "Close popup",
+    "dialogLabel": "Feature details"
   },
   "descriptionPlaceholder": "Add a description...",
   "titleBar": {

--- a/frontend/src/i18n/locales/en/common.json
+++ b/frontend/src/i18n/locales/en/common.json
@@ -38,7 +38,9 @@
     "virtualRaster": "Virtual Raster",
     "skipToContent": "Skip to main content",
     "mainNavigation": "Main navigation",
-    "github": "Star on GitHub"
+    "github": "Star on GitHub",
+    "lightMode": "Light mode",
+    "darkMode": "Dark mode"
   },
   "theme": {
     "toggle": "Toggle theme",

--- a/frontend/src/i18n/locales/en/dataset.json
+++ b/frontend/src/i18n/locales/en/dataset.json
@@ -40,7 +40,7 @@
   "affordances": {
     "sectionHint": {
       "editable": "Editors can update fields in this section.",
-      "readOnlyPassive": "This section is read-only. Attempt an edit for role guidance."
+      "readOnlyPassive": "This section is read-only. Editing requires additional access."
     },
     "pending": {
       "saved": "All pending edits saved.",

--- a/frontend/src/i18n/locales/en/search.json
+++ b/frontend/src/i18n/locales/en/search.json
@@ -9,7 +9,10 @@
   "empty": {
     "title": "No results found",
     "description": "Try adjusting your search query or filters",
-    "cta": "Import your first dataset"
+    "cta": "Import your first dataset",
+    "catalogTitle": "Your catalog is empty",
+    "catalogDescription": "Import a dataset to start building your geospatial catalog.",
+    "clear": "Clear search & filters"
   },
   "error": {
     "message": "Failed to load results: {{message}}"

--- a/frontend/src/i18n/locales/es/admin.json
+++ b/frontend/src/i18n/locales/es/admin.json
@@ -596,7 +596,11 @@
         "editor": "Editor",
         "admin": "Administrador"
       },
-      "loadFailed": "No se pudieron cargar los proveedores OAuth"
+      "loadFailed": "No se pudieron cargar los proveedores OAuth",
+      "callbackUrl": "URL de redirección / devolución de llamada",
+      "copyCallbackUrl": "Copiar URL de devolución de llamada",
+      "callbackUrlCopied": "URL de devolución de llamada copiada al portapapeles",
+      "callbackUrlHint": "Registra esta URL exacta como la URL de redirección / devolución de llamada autorizada con tu proveedor (Google, Microsoft o GitHub)."
     },
     "notifications": {
       "title": "Notificaciones salientes",

--- a/frontend/src/i18n/locales/es/admin.json
+++ b/frontend/src/i18n/locales/es/admin.json
@@ -600,7 +600,7 @@
       "callbackUrl": "URL de redirección / devolución de llamada",
       "copyCallbackUrl": "Copiar URL de devolución de llamada",
       "callbackUrlCopied": "URL de devolución de llamada copiada al portapapeles",
-      "callbackUrlHint": "Registra esta URL exacta como la URL de redirección / devolución de llamada autorizada con tu proveedor (Google, Microsoft o GitHub)."
+      "callbackUrlHint": "Registra esta URL en tu proveedor (Google, Microsoft o GitHub) como la URL de redirección / devolución autorizada. Debe coincidir con la URL pública de la API configurada en el despliegue (define PUBLIC_API_URL o la URL pública de la API en Configuración general); de lo contrario, el inicio de sesión OAuth fallará por una redirección no coincidente."
     },
     "notifications": {
       "title": "Notificaciones salientes",

--- a/frontend/src/i18n/locales/es/admin.json
+++ b/frontend/src/i18n/locales/es/admin.json
@@ -600,7 +600,8 @@
       "callbackUrl": "URL de redirección / devolución de llamada",
       "copyCallbackUrl": "Copiar URL de devolución de llamada",
       "callbackUrlCopied": "URL de devolución de llamada copiada al portapapeles",
-      "callbackUrlHint": "Registra esta URL en tu proveedor (Google, Microsoft o GitHub) como la URL de redirección / devolución autorizada. Debe coincidir con la URL pública de la API configurada en el despliegue (define PUBLIC_API_URL o la URL pública de la API en Configuración general); de lo contrario, el inicio de sesión OAuth fallará por una redirección no coincidente."
+      "callbackUrlHint": "Registra esta URL en tu proveedor (Google, Microsoft o GitHub) como la URL de redirección / devolución autorizada. Debe coincidir con la URL pública de la API configurada en el despliegue (define PUBLIC_API_URL o la URL pública de la API en Configuración general); de lo contrario, el inicio de sesión OAuth fallará por una redirección no coincidente.",
+      "callbackUrlCopyFailed": "No se pudo copiar; copia la URL manualmente."
     },
     "notifications": {
       "title": "Notificaciones salientes",

--- a/frontend/src/i18n/locales/es/builder.json
+++ b/frontend/src/i18n/locales/es/builder.json
@@ -678,7 +678,8 @@
     "copyFailed": "Error al copiar",
     "prev": "Elemento anterior",
     "next": "Elemento siguiente",
-    "close": "Cerrar popup"
+    "close": "Cerrar popup",
+    "dialogLabel": "Detalles del elemento"
   },
   "descriptionPlaceholder": "Agregar una descripción...",
   "titleBar": {

--- a/frontend/src/i18n/locales/es/common.json
+++ b/frontend/src/i18n/locales/es/common.json
@@ -38,7 +38,9 @@
     "virtualRaster": "Ráster Virtual",
     "skipToContent": "Ir al contenido principal",
     "mainNavigation": "Navegación principal",
-    "github": "Dar estrella en GitHub"
+    "github": "Dar estrella en GitHub",
+    "lightMode": "Modo claro",
+    "darkMode": "Modo oscuro"
   },
   "theme": {
     "toggle": "Cambiar tema",

--- a/frontend/src/i18n/locales/es/search.json
+++ b/frontend/src/i18n/locales/es/search.json
@@ -9,7 +9,10 @@
   "empty": {
     "title": "No se encontraron conjuntos de datos",
     "description": "Intente ajustar su consulta de búsqueda o los filtros",
-    "cta": "Importe su primer conjunto de datos"
+    "cta": "Importe su primer conjunto de datos",
+    "catalogTitle": "Tu catálogo está vacío",
+    "catalogDescription": "Importa un conjunto de datos para empezar a crear tu catálogo geoespacial.",
+    "clear": "Borrar búsqueda y filtros"
   },
   "error": {
     "message": "Error al cargar resultados: {{message}}"

--- a/frontend/src/i18n/locales/fr/admin.json
+++ b/frontend/src/i18n/locales/fr/admin.json
@@ -600,7 +600,7 @@
       "callbackUrl": "URL de redirection / de rappel",
       "copyCallbackUrl": "Copier l'URL de rappel",
       "callbackUrlCopied": "URL de rappel copiée dans le presse-papiers",
-      "callbackUrlHint": "Enregistrez cette URL exacte comme URL de redirection / de rappel autorisée auprès de votre fournisseur (Google, Microsoft ou GitHub)."
+      "callbackUrlHint": "Enregistrez cette URL auprès de votre fournisseur (Google, Microsoft ou GitHub) comme URL de redirection / de rappel autorisée. Elle doit correspondre à l’URL publique de l’API configurée pour le déploiement (définissez PUBLIC_API_URL ou l’URL publique de l’API dans les paramètres généraux), sinon la connexion OAuth échouera avec une redirection non concordante."
     },
     "notifications": {
       "title": "Notifications sortantes",

--- a/frontend/src/i18n/locales/fr/admin.json
+++ b/frontend/src/i18n/locales/fr/admin.json
@@ -600,7 +600,8 @@
       "callbackUrl": "URL de redirection / de rappel",
       "copyCallbackUrl": "Copier l'URL de rappel",
       "callbackUrlCopied": "URL de rappel copiée dans le presse-papiers",
-      "callbackUrlHint": "Enregistrez cette URL auprès de votre fournisseur (Google, Microsoft ou GitHub) comme URL de redirection / de rappel autorisée. Elle doit correspondre à l’URL publique de l’API configurée pour le déploiement (définissez PUBLIC_API_URL ou l’URL publique de l’API dans les paramètres généraux), sinon la connexion OAuth échouera avec une redirection non concordante."
+      "callbackUrlHint": "Enregistrez cette URL auprès de votre fournisseur (Google, Microsoft ou GitHub) comme URL de redirection / de rappel autorisée. Elle doit correspondre à l’URL publique de l’API configurée pour le déploiement (définissez PUBLIC_API_URL ou l’URL publique de l’API dans les paramètres généraux), sinon la connexion OAuth échouera avec une redirection non concordante.",
+      "callbackUrlCopyFailed": "Impossible de copier — copiez l’URL manuellement."
     },
     "notifications": {
       "title": "Notifications sortantes",

--- a/frontend/src/i18n/locales/fr/admin.json
+++ b/frontend/src/i18n/locales/fr/admin.json
@@ -596,7 +596,11 @@
         "editor": "Éditeur",
         "admin": "Administrateur"
       },
-      "loadFailed": "Impossible de charger les fournisseurs OAuth"
+      "loadFailed": "Impossible de charger les fournisseurs OAuth",
+      "callbackUrl": "URL de redirection / de rappel",
+      "copyCallbackUrl": "Copier l'URL de rappel",
+      "callbackUrlCopied": "URL de rappel copiée dans le presse-papiers",
+      "callbackUrlHint": "Enregistrez cette URL exacte comme URL de redirection / de rappel autorisée auprès de votre fournisseur (Google, Microsoft ou GitHub)."
     },
     "notifications": {
       "title": "Notifications sortantes",

--- a/frontend/src/i18n/locales/fr/builder.json
+++ b/frontend/src/i18n/locales/fr/builder.json
@@ -678,7 +678,8 @@
     "copyFailed": "Échec de la copie",
     "prev": "Entité précédente",
     "next": "Entité suivante",
-    "close": "Fermer la popup"
+    "close": "Fermer la popup",
+    "dialogLabel": "Détails de l'entité"
   },
   "descriptionPlaceholder": "Ajouter une description...",
   "titleBar": {

--- a/frontend/src/i18n/locales/fr/common.json
+++ b/frontend/src/i18n/locales/fr/common.json
@@ -38,7 +38,9 @@
     "virtualRaster": "Raster Virtuel",
     "skipToContent": "Aller au contenu principal",
     "mainNavigation": "Navigation principale",
-    "github": "Donner une étoile sur GitHub"
+    "github": "Donner une étoile sur GitHub",
+    "lightMode": "Mode clair",
+    "darkMode": "Mode sombre"
   },
   "theme": {
     "toggle": "Changer le thème",

--- a/frontend/src/i18n/locales/fr/search.json
+++ b/frontend/src/i18n/locales/fr/search.json
@@ -9,7 +9,10 @@
   "empty": {
     "title": "Aucun jeu de données trouvé",
     "description": "Essayez d'ajuster votre recherche ou vos filtres",
-    "cta": "Importez votre premier jeu de données"
+    "cta": "Importez votre premier jeu de données",
+    "catalogTitle": "Votre catalogue est vide",
+    "catalogDescription": "Importez un jeu de données pour commencer à constituer votre catalogue géospatial.",
+    "clear": "Effacer la recherche et les filtres"
   },
   "error": {
     "message": "Échec du chargement des résultats : {{message}}"

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -644,12 +644,19 @@ div:has(> [data-group-drop-target="true"]) > [id^="folder-group-children"] {
   .maplibregl-ctrl-bottom-left {
     padding-bottom: env(safe-area-inset-bottom);
   }
-  /* Left-edge mobile Sheet (shadcn) clears the notch on landscape / its content
-     clears the home indicator at the bottom. */
+  /* Mobile Sheet (shadcn) clears the notch on landscape — both edges, since a
+     right-anchored drawer (report wizard, builder/editor) hits the right notch
+     and a left-anchored one hits the left. env()-left/right are each non-zero
+     only on the side that actually has an unsafe area, so padding both sides is
+     side-correct. Content also clears the home indicator at the bottom. */
   [data-slot="sheet-content"] {
     padding-left: max(
       var(--sheet-padding-left, 0px),
       env(safe-area-inset-left)
+    );
+    padding-right: max(
+      var(--sheet-padding-right, 0px),
+      env(safe-area-inset-right)
     );
     padding-bottom: max(
       var(--sheet-padding-bottom, 0px),

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -405,6 +405,17 @@
   background-size: 16px 16px;
 }
 
+/* ── v1047 STANDALONE-01 standalone-page surface gradient ──────────────────
+   Subtle branded depth for full-page surfaces (login, public viewers). The
+   prior inline gradients wrapped OKLCH tokens in hsl() — invalid CSS that
+   computed to `none` (flat/sparse first impression). color-mix(in oklab, …)
+   resolves correctly in both light and dark. */
+.app-surface-gradient {
+  background-image:
+    radial-gradient(circle at top, color-mix(in oklab, var(--primary) 10%, transparent), transparent 42%),
+    linear-gradient(180deg, var(--background), color-mix(in oklab, var(--muted) 45%, var(--background)));
+}
+
 /* ── Base Layer ─────────────────────────────────────── */
 @layer base {
   * {

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -79,15 +79,16 @@
   --elevation-lg: 0 10px 15px -3px oklch(0 0 0 / 8%), 0 4px 6px -4px oklch(0 0 0 / 5%);
 
   /* ─ Semantic status colors ─
-   * v1047 CONTRAST-01: light fg darkened so text-warning/info/success clear
-   * WCAG AA (>=4.5:1) on card AND soft 10-percent-tint surfaces. Measured
-   * ratios: warning 6.01 and 5.05, info 5.41 and 4.54, success 5.5 and 4.64
-   * (was 2.19, 4.07, 4.07). --warning is now dark so --warning-foreground
-   * flips to light (white-on-warning 6.02:1). */
+   * #305: light fg darkened so text-warning/info/success clear WCAG AA
+   * (>=4.5:1) on card AND soft 10-percent-tint surfaces. Measured ratios:
+   * warning 6.01 and 5.05, info 5.41 and 4.54, success 5.5 and 4.64 (was
+   * 2.19, 4.07, 4.07). --warning-foreground stays DARK: it is used as text
+   * on light/soft surfaces (e.g. BulkReviewList, LayerStyleEditor), not on a
+   * solid warning fill, so a dark foreground keeps those readable. */
   --success: oklch(0.49 0.16 150);
   --success-foreground: oklch(0.985 0 0);
   --warning: oklch(0.50 0.13 68);
-  --warning-foreground: oklch(0.985 0 0);
+  --warning-foreground: oklch(0.28 0.07 46);
   --info: oklch(0.49 0.13 205);
   --info-foreground: oklch(0.985 0 0);
 
@@ -405,7 +406,7 @@
   background-size: 16px 16px;
 }
 
-/* ── v1047 STANDALONE-01 standalone-page surface gradient ──────────────────
+/* ── #305 standalone-page surface gradient ──────────────────
    Subtle branded depth for full-page surfaces (login, public viewers). The
    prior inline gradients wrapped OKLCH tokens in hsl() — invalid CSS that
    computed to `none` (flat/sparse first impression). color-mix(in oklab, …)
@@ -603,7 +604,7 @@ html.dragging-active {
   }
 }
 
-/* ── v1047 TOUCH-01 coarse-pointer tap targets ───────────────────────────
+/* ── #305 coarse-pointer tap targets ───────────────────────────
    On touch devices ensure map controls and form fields reach a ~44px hit
    target. Scoped to pointer:coarse so fine-pointer desktop density is
    unchanged (mirrors the existing maplibre popup-close 44px treatment). */
@@ -630,7 +631,7 @@ div:has(> [data-group-drop-target="true"]) > [id^="folder-group-children"] {
   border-radius: var(--radius-md);
 }
 
-/* ── v1047 SAFEAREA-01 notch / home-indicator safe-area padding ───────────
+/* ── #305 notch / home-indicator safe-area padding ───────────
    With viewport-fit=cover the page draws under the iOS notch and home
    indicator, so full-bleed mobile chrome gets clipped. Pad those surfaces by
    the relevant env(safe-area-inset-*) so controls clear the unsafe zone.

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -78,12 +78,17 @@
   --elevation-md: 0 4px 6px -1px oklch(0 0 0 / 7%), 0 2px 4px -2px oklch(0 0 0 / 5%);
   --elevation-lg: 0 10px 15px -3px oklch(0 0 0 / 8%), 0 4px 6px -4px oklch(0 0 0 / 5%);
 
-  /* ─ Semantic status colors ─ */
-  --success: oklch(0.53 0.19 145);
+  /* ─ Semantic status colors ─
+   * v1047 CONTRAST-01: light fg darkened so text-warning/info/success clear
+   * WCAG AA (>=4.5:1) on card AND soft 10-percent-tint surfaces. Measured
+   * ratios: warning 6.01 and 5.05, info 5.41 and 4.54, success 5.5 and 4.64
+   * (was 2.19, 4.07, 4.07). --warning is now dark so --warning-foreground
+   * flips to light (white-on-warning 6.02:1). */
+  --success: oklch(0.49 0.16 150);
   --success-foreground: oklch(0.985 0 0);
-  --warning: oklch(0.75 0.15 85);
-  --warning-foreground: oklch(0.28 0.07 46);
-  --info: oklch(0.55 0.15 195);
+  --warning: oklch(0.50 0.13 68);
+  --warning-foreground: oklch(0.985 0 0);
+  --info: oklch(0.49 0.13 205);
   --info-foreground: oklch(0.985 0 0);
 
   /* ─ Record-type colors (import, catalog badges) ─ */

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -629,3 +629,30 @@ div:has(> [data-group-drop-target="true"]) > [id^="folder-group-children"] {
   background: oklch(0.97 0.02 250 / 60%);
   border-radius: var(--radius-md);
 }
+
+/* ── v1047 SAFEAREA-01 notch / home-indicator safe-area padding ───────────
+   With viewport-fit=cover the page draws under the iOS notch and home
+   indicator, so full-bleed mobile chrome gets clipped. Pad those surfaces by
+   the relevant env(safe-area-inset-*) so controls clear the unsafe zone.
+   Gated on @supports so non-notch / desktop browsers are unaffected (env()
+   resolves to 0 there anyway, but the guard keeps the rules from applying at
+   all where they're not needed). */
+@supports (padding: env(safe-area-inset-bottom)) {
+  /* Bottom maplibre controls (attribution + zoom/scale) clear the home indicator. */
+  .maplibregl-ctrl-bottom-right,
+  .maplibregl-ctrl-bottom-left {
+    padding-bottom: env(safe-area-inset-bottom);
+  }
+  /* Left-edge mobile Sheet (shadcn) clears the notch on landscape / its content
+     clears the home indicator at the bottom. */
+  [data-slot="sheet-content"] {
+    padding-left: max(
+      var(--sheet-padding-left, 0px),
+      env(safe-area-inset-left)
+    );
+    padding-bottom: max(
+      var(--sheet-padding-bottom, 0px),
+      env(safe-area-inset-bottom)
+    );
+  }
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -592,6 +592,23 @@ html.dragging-active {
   }
 }
 
+/* ── v1047 TOUCH-01 coarse-pointer tap targets ───────────────────────────
+   On touch devices ensure map controls and form fields reach a ~44px hit
+   target. Scoped to pointer:coarse so fine-pointer desktop density is
+   unchanged (mirrors the existing maplibre popup-close 44px treatment). */
+@media (pointer: coarse) {
+  .maplibregl-ctrl-group button {
+    min-width: 44px;
+    min-height: 44px;
+  }
+  [data-slot="input"],
+  [data-slot="select-trigger"],
+  textarea,
+  select {
+    min-height: 2.75rem;
+  }
+}
+
 /* Phase 1042: folder group-children wash when parent is drop target (1040 carry-over) */
 /* Use :has() to select the children container when a sibling carries data-group-drop-target.
    The keyed outer wrapper div contains both FolderGroupRowWrapper (which bears the attribute)

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -62,7 +62,7 @@ const queryClient = new QueryClient({
 
 function ThemedToaster() {
   const { resolvedTheme } = useTheme();
-  // v1047 TOAST-01: richColors differentiates success/error/warning/info by
+  // #305: richColors differentiates success/error/warning/info by
   // hue (was a single neutral surface for all 183 call sites); closeButton
   // makes every toast dismissable.
   return <Toaster theme={resolvedTheme} richColors closeButton />;

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -62,7 +62,10 @@ const queryClient = new QueryClient({
 
 function ThemedToaster() {
   const { resolvedTheme } = useTheme();
-  return <Toaster theme={resolvedTheme} />;
+  // v1047 TOAST-01: richColors differentiates success/error/warning/info by
+  // hue (was a single neutral surface for all 183 call sites); closeButton
+  // makes every toast dismissable.
+  return <Toaster theme={resolvedTheme} richColors closeButton />;
 }
 
 const router = createBrowserRouter(createRoutesFromElements(appRoutes));

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -83,7 +83,7 @@ export function LoginPage() {
   }
 
   return (
-    <div className="min-h-screen bg-[radial-gradient(circle_at_top,_hsl(var(--primary)/0.12),_transparent_38%),linear-gradient(180deg,_hsl(var(--background)),_hsl(var(--muted)/0.2))] px-4 py-10">
+    <div className="app-surface-gradient min-h-screen px-4 py-10">
       <div className="mx-auto grid min-h-[calc(100vh-5rem)] max-w-5xl gap-8 lg:grid-cols-[1.1fr_0.9fr] lg:items-center">
         <section className="flex flex-col justify-center text-center lg:text-start">
           <Link

--- a/frontend/src/pages/MapBuilderPage.tsx
+++ b/frontend/src/pages/MapBuilderPage.tsx
@@ -1207,7 +1207,7 @@ export function MapBuilderPage() {
 
   if (isLoading) {
     return (
-      <div className="flex items-center justify-center h-[calc(100vh-3.5rem)]">
+      <div className="flex items-center justify-center h-[calc(100vh-3.5rem-env(safe-area-inset-top))]">
         <LoadingState message={t('loadingMap')} />
       </div>
     );
@@ -1222,7 +1222,7 @@ export function MapBuilderPage() {
           ? t('common:errors.loadFailed', { defaultValue: 'Failed to load map' })
           : t('common:errors.mapNotFound');
     return (
-      <div className="flex items-center justify-center h-[calc(100vh-3.5rem)]">
+      <div className="flex items-center justify-center h-[calc(100vh-3.5rem-env(safe-area-inset-top))]">
         <div className="text-center space-y-4">
           <ErrorState message={msg} />
           <Link to="/maps" className="text-sm text-primary hover:underline">
@@ -1248,7 +1248,7 @@ export function MapBuilderPage() {
   );
 
   return (
-    <div className="flex flex-col h-[calc(100vh-3.5rem)]">
+    <div className="flex flex-col h-[calc(100vh-3.5rem-env(safe-area-inset-top))]">
       {/* Phase 1040 Plan 04: sr-only aria-live region for keyboard/mouse catalog drag announcements.
           Renders at root of the builder so screen readers in any panel can read it.
           Zero-width-space + timestamp suffix in dragAnnouncement forces aria-live re-fire on

--- a/frontend/src/pages/PublicMapViewerPage.tsx
+++ b/frontend/src/pages/PublicMapViewerPage.tsx
@@ -82,7 +82,7 @@ export function PublicMapViewerPage() {
     const is403 = error instanceof ApiError && error.status === 403;
     const is404 = error instanceof ApiError && error.status === 404;
     return (
-      <div className="flex flex-1 items-center justify-center bg-[radial-gradient(circle_at_top,_hsl(var(--muted))_0,_transparent_55%),linear-gradient(180deg,hsl(var(--background)),hsl(var(--muted))/0.45)] px-6">
+      <div className="app-surface-gradient flex flex-1 items-center justify-center px-6">
         <div className="flex w-full max-w-xl flex-col items-center rounded-2xl border bg-background/95 p-8 text-center shadow-xl backdrop-blur">
           <MapPinOff className="size-10 text-muted-foreground" />
           <div className="mt-4 space-y-2 text-center">

--- a/frontend/src/pages/PublicViewerPage.tsx
+++ b/frontend/src/pages/PublicViewerPage.tsx
@@ -77,7 +77,7 @@ export function PublicViewerPage() {
   if (isError || !data) {
     const isExpired = error instanceof ApiError && error.status === 410;
     return (
-      <div className="flex min-h-screen items-center justify-center bg-[radial-gradient(circle_at_top,_hsl(var(--muted))_0,_transparent_55%),linear-gradient(180deg,hsl(var(--background)),hsl(var(--muted))/0.45)] px-6">
+      <div className="app-surface-gradient flex min-h-screen items-center justify-center px-6">
         <div className="flex w-full max-w-xl flex-col items-center rounded-2xl border bg-background/95 p-8 text-center shadow-xl backdrop-blur">
           {isExpired ? (
             <>

--- a/frontend/src/pages/SearchPage.tsx
+++ b/frontend/src/pages/SearchPage.tsx
@@ -1,5 +1,5 @@
-import { type ReactNode } from 'react';
-import { Loader2, SearchX, Upload } from 'lucide-react';
+import { type ReactNode, useRef } from 'react';
+import { Database, Loader2, SearchX, Upload, X } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router';
 import { PageShell } from '@/components/layout/PageShell';
@@ -42,10 +42,6 @@ function SearchControls({ totalResults, children }: SearchControlsProps) {
   );
 }
 
-function handlePageChange(offset: number) {
-  useSearchStore.getState().setPage(offset);
-}
-
 export function SearchPage() {
   const { t } = useTranslation('search');
   useDocumentTitle(t('common:pageTitle.search'));
@@ -53,6 +49,22 @@ export function SearchPage() {
   const offset = useSearchStore((s) => s.offset);
   const limit = useSearchStore((s) => s.limit);
   const token = useAuthStore((s) => s.token);
+  const resetFilters = useSearchStore((s) => s.resetFilters);
+  // EMPTY-01: distinguish an empty catalog from a no-match query. toParams()
+  // only emits non-default values, so any key beyond pagination means the user
+  // has an active query / filter / sort.
+  const hasActiveSearch = useSearchStore((s) =>
+    Object.keys(s.toParams()).some((k) => k !== 'offset' && k !== 'limit'),
+  );
+  const resultsRef = useRef<HTMLDivElement>(null);
+  // PAGE-01: return to the top of the results (and move focus there for screen
+  // readers) on page change — previously the user stayed at the footer.
+  const handlePageChange = (newOffset: number) => {
+    useSearchStore.getState().setPage(newOffset);
+    const reduce = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+    resultsRef.current?.scrollIntoView({ behavior: reduce ? 'auto' : 'smooth', block: 'start' });
+    resultsRef.current?.focus({ preventScroll: true });
+  };
   const { can } = usePermissions();
   // Require a token as well: usePermissions() keeps the cached ['auth','permissions']
   // query after logout (it's disabled, not cleared), so can('upload') can briefly stay
@@ -108,29 +120,54 @@ export function SearchPage() {
             )}
 
             {data && data.features.length === 0 && (
-              <EmptyState
-                icon={SearchX}
-                title={t('empty.title')}
-                description={t('empty.description')}
-                action={
-                  canImport ? (
-                    <Button asChild>
-                      <Link to="/import">
-                        <Upload className="h-4 w-4 me-1" />
-                        {t('empty.cta')}
-                      </Link>
+              hasActiveSearch ? (
+                <EmptyState
+                  icon={SearchX}
+                  title={t('empty.title')}
+                  description={t('empty.description')}
+                  action={
+                    <Button variant="outline" onClick={() => resetFilters()}>
+                      <X className="h-4 w-4 me-1" />
+                      {t('empty.clear', { defaultValue: 'Clear search & filters' })}
                     </Button>
-                  ) : undefined
-                }
-              />
+                  }
+                />
+              ) : (
+                <EmptyState
+                  icon={Database}
+                  title={t('empty.catalogTitle', { defaultValue: 'Your catalog is empty' })}
+                  description={t('empty.catalogDescription', {
+                    defaultValue: 'Import a dataset to start building your geospatial catalog.',
+                  })}
+                  action={
+                    canImport ? (
+                      <Button asChild>
+                        <Link to="/import">
+                          <Upload className="h-4 w-4 me-1" />
+                          {t('empty.cta')}
+                        </Link>
+                      </Button>
+                    ) : undefined
+                  }
+                />
+              )
             )}
 
             {data && data.features.length > 0 && (
-              <section className="scroll-mt-24 space-y-3" aria-label={t('results', { defaultValue: 'Search results' })}>
-                {data.features.map((feature) => (
-                  <SearchResultCard key={feature.id} feature={feature} />
-                ))}
-              </section>
+              <div ref={resultsRef} tabIndex={-1} className="scroll-mt-24 space-y-3 outline-none">
+                {/* CATALOG-01: in-context results header — visible at all widths,
+                    unlike the count that previously lived only in the desktop rail. */}
+                <div className="flex items-center justify-between gap-3 px-0.5">
+                  <h2 className="text-sm font-medium text-foreground">
+                    {t('resultCount', { count: totalMatched })}
+                  </h2>
+                </div>
+                <section className="space-y-3" aria-label={t('results', { defaultValue: 'Search results' })}>
+                  {data.features.map((feature) => (
+                    <SearchResultCard key={feature.id} feature={feature} />
+                  ))}
+                </section>
+              </div>
             )}
 
             {data && totalMatched > 0 && (

--- a/frontend/src/pages/SearchPage.tsx
+++ b/frontend/src/pages/SearchPage.tsx
@@ -83,7 +83,7 @@ export function SearchPage() {
       <PageShell maxWidth="wide" className="pb-8 pt-5 sm:pt-6">
         <div className="grid gap-5 lg:grid-cols-[18rem_minmax(0,1fr)] xl:grid-cols-[20rem_minmax(0,1fr)]">
           <aside className="hidden lg:block">
-            <div className="sticky top-24 max-h-[calc(100vh-6rem)] overflow-y-auto">
+            <div className="sticky top-16 max-h-[calc(100vh-5rem)] overflow-y-auto">
               <FilterPanel
                 totalResults={totalMatched > 0 ? totalMatched : undefined}
                 showMobile={false}
@@ -154,7 +154,7 @@ export function SearchPage() {
             )}
 
             {data && data.features.length > 0 && (
-              <div ref={resultsRef} tabIndex={-1} className="scroll-mt-24 space-y-3 outline-none">
+              <div ref={resultsRef} tabIndex={-1} className="scroll-mt-20 space-y-3 outline-none">
                 {/* CATALOG-01: in-context results header — visible at all widths,
                     unlike the count that previously lived only in the desktop rail. */}
                 <div className="flex items-center justify-between gap-3 px-0.5">

--- a/frontend/src/pages/SearchPage.tsx
+++ b/frontend/src/pages/SearchPage.tsx
@@ -50,14 +50,14 @@ export function SearchPage() {
   const limit = useSearchStore((s) => s.limit);
   const token = useAuthStore((s) => s.token);
   const resetFilters = useSearchStore((s) => s.resetFilters);
-  // EMPTY-01: distinguish an empty catalog from a no-match query. toParams()
+  // #305: distinguish an empty catalog from a no-match query. toParams()
   // only emits non-default values, so any key beyond pagination means the user
   // has an active query / filter / sort.
   const hasActiveSearch = useSearchStore((s) =>
     Object.keys(s.toParams()).some((k) => k !== 'offset' && k !== 'limit'),
   );
   const resultsRef = useRef<HTMLDivElement>(null);
-  // PAGE-01: return to the top of the results (and move focus there for screen
+  // #305: return to the top of the results (and move focus there for screen
   // readers) on page change — previously the user stayed at the footer.
   const handlePageChange = (newOffset: number) => {
     useSearchStore.getState().setPage(newOffset);
@@ -159,7 +159,7 @@ export function SearchPage() {
 
             {data && data.features.length > 0 && (
               <div ref={resultsRef} tabIndex={-1} className="scroll-mt-20 space-y-3 outline-none">
-                {/* CATALOG-01: in-context results header — visible at all widths,
+                {/* #305: in-context results header — visible at all widths,
                     unlike the count that previously lived only in the desktop rail. */}
                 <div className="flex items-center justify-between gap-3 px-0.5">
                   <h2 className="text-sm font-medium text-foreground">

--- a/frontend/src/pages/SearchPage.tsx
+++ b/frontend/src/pages/SearchPage.tsx
@@ -120,7 +120,11 @@ export function SearchPage() {
             )}
 
             {data && data.features.length === 0 && (
-              hasActiveSearch ? (
+              // #305: only the true empty-catalog case (no matches at all, no
+              // query) gets onboarding. A positive totalMatched with an empty
+              // page means an out-of-range offset (e.g. stale /?offset=1000) —
+              // show the no-results state (Clear resets offset to page 1).
+              hasActiveSearch || totalMatched > 0 ? (
                 <EmptyState
                   icon={SearchX}
                   title={t('empty.title')}


### PR DESCRIPTION
## Pre-launch UI/UX audit & polish pass

A **system-level polish pass** (not a redesign) to make GeoLens feel cohesive, intuitive, trustworthy, and aesthetically pleasing on desktop + mobile before public launch. Product identity, IA, behaviour, and APIs are preserved.

**Method:** live browser audit (Playwright, light + dark, anon + admin, across 375/390/768/1366/1440/1920) paired with an 8-agent source-level map of the frontend. The app is already mature (strong OKLCH token system, semantic landmarks, full map attribution), so the fixes target token edges, shared primitives, and a few real bugs — fix once, cascade everywhere.

### What changed (by audit dimension)

**Visual design & design system**
- **WCAG-AA status colours** — light `--warning`/`--info`/`--success` failed AA as text (e.g. `text-warning` 2.19:1 on soft surfaces). Darkened to clear ≥4.5:1 on card *and* soft backgrounds; dark mode already passed. Ratios measured in-browser (canvas → sRGB), not estimated.
- **Badge status variants** — added token-driven `success`/`warning`/`info` variants to replace ad-hoc `bg-success/10 text-success text-[10px]` recipes; the demo + ingest-warning banners now use the `--warning` token (were raw amber/yellow, two hues for one semantic).
- **Restored standalone-page gradients** — login + both public viewers set their background via `hsl(var(--primary)…)`, but the tokens are OKLCH, so `hsl(oklch(…))` is invalid CSS and computed to `none` (flat/sparse). Replaced with a shared `.app-surface-gradient` (`color-mix(in oklab,…)`, theme-correct).

**Layout & responsive**
- **Sticky navbar** + tightened filter-rail offset (no more dead gap); **width alignment** (navbar `max-w-6xl`→`7xl` to match content).
- **404 centers** in the available viewport (AppLayout `main` is now a flex column).
- **DatasetStatsBar reflows** on mobile (~6 stats no longer crush/truncate at 375–390px).
- **Safe-area / notch** — `viewport-fit=cover`, dark-mode `theme-color`, `env(safe-area-inset-*)` on full-bleed mobile chrome.

**Interaction & feedback**
- **Toasts** now `richColors` (success/error/warning/info differentiated by hue) + `closeButton` — fixes all 183 toast call sites.
- **44px touch targets** on coarse pointers for primary buttons, map controls, and form fields (desktop density unchanged; `xs`/`icon-xs` stay ≥24px AA).
- **Theme toggle** in the user menu (none existed; default stays `system`, honouring `prefers-color-scheme`).

**Catalog / search**
- **Two-state empty** — empty-catalog onboarding vs no-match "Clear search & filters" (was always "Import your first dataset").
- **Visible results header** (count at every width, not just the desktop rail) + **paginate-to-top** with focus move for SR.

**Map & geospatial**
- **Feature popup** is now `role=dialog` with focus move-in/restore and Escape-to-close (no focus trap).

**Accessibility (WCAG 2.2 AA)**
- VisibilityIcon + API-key status dots get accessible names (meaning no longer colour/icon-only).
- Delete-confirm inputs get real accessible names; login/register fields get `aria-invalid` + `aria-describedby` on error.

**Admin & content**
- **OAuth provider dialog** shows a read-only, copy-to-clipboard **redirect/callback URL** (the most error-prone SSO step had no on-screen value).
- Reworded the awkward dataset read-only hint.

### Validation
- Full local gate green: **typecheck ✓ · eslint ✓ · vitest 3005/3005 ✓ · i18n parity ✓ · `vite build` ✓**.
- Live re-verification on the running stack across the viewport matrix; **console clean (0 errors) on every journey**.
- Touch targets confirmed via coarse-pointer simulation; contrast confirmed via in-browser ratio measurement.
- Before/after screenshots captured.

### Deferred (documented, not silently dropped)
- **THUMB-01** — the "blank" Manhattan thumbnail is a **backend quicklook-generation** issue (verified: the quicklook is a uniform opaque slate-100 image, 0% non-white; NY renders fine). The frontend fallback is solid; likely resolved by the pending demo reseed.
- **LEGEND-01** (legend overlay on mobile maps), **mobile Map Builder rework**, **admin user-table responsive**, **admin hardcoded-English i18n sweep**, **in-content settings tabs**, **native-select focus-ring primitive** — medium/large or IA-touching; tracked for a follow-up.

Each commit is atomic and scoped; see the commit list for the per-area breakdown.
