### PR TITLE
feat(search): true semantic retrieval — surface vector-only matches (visibility-aware RRF)

### DIFF
--- a/backend/app/modules/catalog/search/service_datasets.py
+++ b/backend/app/modules/catalog/search/service_datasets.py
@@ -212,7 +212,9 @@ async def search_datasets(
     # -- Hybrid semantic search with RRF --
     semantic_enabled = await SEMANTIC_SEARCH_ENABLED.get(session)
     if semantic_enabled and has_text_search and filters.q and filters.q.strip():
-        if rrf_result := await _run_rrf_merge(session, filters, stmt, rank_col, total):
+        if rrf_result := await _run_rrf_merge(
+            session, filters, stmt, rank_col, total, user, user_roles
+        ):
             return rrf_result
     # 6. Sort (standard FTS-only path or semantic=False)
     stmt = _resolve_sort_order(stmt, filters, has_text_search, rank_col)

--- a/backend/app/modules/catalog/search/service_datasets.py
+++ b/backend/app/modules/catalog/search/service_datasets.py
@@ -212,8 +212,24 @@ async def search_datasets(
     # -- Hybrid semantic search with RRF --
     semantic_enabled = await SEMANTIC_SEARCH_ENABLED.get(session)
     if semantic_enabled and has_text_search and filters.q and filters.q.strip():
+        # Vetting query for semantic vector-only candidates: identical visibility +
+        # common + search-only filters as the FTS `stmt`, but WITHOUT the text
+        # clause (vector-only hits match by meaning, not lexically). _run_rrf_merge
+        # constrains it to the candidate ids so a surfaced vector-only match
+        # satisfies every active filter (visibility, bbox, geometry_type, srid,
+        # keywords, dates, CQL) -- never leaking or violating a filter.
+        vet_stmt = (
+            select(Record.id)
+            .select_from(Dataset)
+            .join(Record, Dataset.record_id == Record.id)
+        )
+        vet_stmt = apply_visibility_filter(
+            vet_stmt, user, user_roles, Record, DatasetGrant
+        )
+        vet_stmt = _apply_common_filters(vet_stmt, filters, skip_text=True)
+        vet_stmt = _apply_search_only_filters(vet_stmt, filters)
         if rrf_result := await _run_rrf_merge(
-            session, filters, stmt, rank_col, total, user, user_roles
+            session, filters, stmt, rank_col, total, vet_stmt
         ):
             return rrf_result
     # 6. Sort (standard FTS-only path or semantic=False)

--- a/backend/app/modules/catalog/search/service_semantic.py
+++ b/backend/app/modules/catalog/search/service_semantic.py
@@ -13,9 +13,11 @@ from sqlalchemy.orm import selectinload
 from sqlalchemy.sql.elements import Label
 from sqlalchemy.sql.selectable import Select
 
+from app.core.identity import Identity
 from app.core.persistent_config import EMBEDDING_MODEL
 from app.modules.auth.models import User
-from app.modules.catalog.datasets.domain.models import Dataset, Record
+from app.modules.catalog.authorization import apply_visibility_filter
+from app.modules.catalog.datasets.domain.models import Dataset, DatasetGrant, Record
 from app.modules.catalog.search.service_filters import SearchFilters
 from app.platform.extensions import get_catalog_port
 
@@ -205,8 +207,17 @@ async def _run_rrf_merge(
     stmt: Select,
     rank_col: Label[float],
     total: int,
+    user: Identity | None,
+    user_roles: set[str],
 ) -> tuple[list[Dataset], int] | None:
     """Execute hybrid FTS+vector RRF merge and return paginated results.
+
+    Surfaces vector-only matches (records that are semantically similar but do
+    not lexically match the FTS query) IN ADDITION to re-ranking FTS hits. Since
+    ``_get_vector_ranks`` does not apply RBAC visibility filtering, vector-only
+    candidates are run through the SAME ``apply_visibility_filter`` the FTS path
+    uses before being surfaced, so private/restricted datasets are never leaked
+    into a semantic match.
 
     Returns ``None`` when RRF doesn't apply (vector backend empty/failed).
     Caller falls through to the standard sort path on None.
@@ -242,15 +253,37 @@ async def _run_rrf_merge(
     fts_result = await session.execute(fts_stmt)
     fts_ids = [str(row[0]) for row in fts_result.all()]
 
-    # Compute RRF-ranked order (only includes IDs from FTS results + vector results)
-    # Filter vector_ranks to only include IDs that appear in FTS results
-    # (vector-only results are excluded to keep it simple per plan)
+    # RRF over FTS results UNION visibility-filtered vector-only results.
+    # FTS ids already passed apply_visibility_filter (via the inherited `stmt`).
+    # Vector-only ids did NOT — _get_vector_ranks queries record_embeddings with
+    # no RBAC filter — so they MUST be run through the same visibility filter
+    # before surfacing, or a semantic match would leak a private/restricted
+    # dataset (e.g. an embed-token-scoped one). The check is bounded to the small
+    # vector candidate set (<= filters.limit ids).
     fts_id_set = set(fts_ids)
-    filtered_vector_ranks = {
-        rid: rank for rid, rank in vector_ranks.items() if rid in fts_id_set
-    }
+    vector_only_ids = [rid for rid in vector_ranks if rid not in fts_id_set]
+    visible_vector_only: set[str] = set()
+    if vector_only_ids:
+        vis_stmt = select(Record.id).where(
+            Record.id.in_([uuid_mod.UUID(rid) for rid in vector_only_ids])
+        )
+        vis_stmt = apply_visibility_filter(
+            vis_stmt, user, user_roles, Record, DatasetGrant
+        )
+        vis_result = await session.execute(vis_stmt)
+        visible_vector_only = {str(rid) for rid in vis_result.scalars().all()}
 
-    rrf_ordered = _compute_rrf_scores(fts_ids, filtered_vector_ranks)
+    safe_vector_ranks = {
+        rid: rank
+        for rid, rank in vector_ranks.items()
+        if rid in fts_id_set or rid in visible_vector_only
+    }
+    # Surfaced vector-only matches are additional results beyond the FTS count.
+    # (A record that both vector-matches and FTS-matches below the fts_cap is a
+    # rare overlap; the resulting +1 overcount is acceptable for pagination.)
+    total += len(visible_vector_only)
+
+    rrf_ordered = _compute_rrf_scores(fts_ids, safe_vector_ranks)
 
     # Apply pagination to RRF-ordered list
     page_ids = rrf_ordered[filters.skip : filters.skip + filters.limit]

--- a/backend/app/modules/catalog/search/service_semantic.py
+++ b/backend/app/modules/catalog/search/service_semantic.py
@@ -238,11 +238,14 @@ async def _run_rrf_merge(
     if filters.q is None:
         raise ValueError("_run_rrf_merge requires filters.q to be non-None")
     q_stripped = filters.q.strip()
+    # The RRF-ordered list is sliced [skip:skip+limit], so both candidate pools must
+    # reach at least skip+limit deep or a later page comes back empty.
+    page_end = filters.skip + filters.limit
     # Vector similarity ranks, restricted to the visibility/filter-vetted set so the
     # cosine top-k contains only records the caller may see that satisfy every active
     # filter (empty dict on any failure = FTS-only).
     vector_ranks = await _get_vector_ranks(
-        session, q_stripped, filters.limit, restrict_stmt=vet_stmt
+        session, q_stripped, page_end, restrict_stmt=vet_stmt
     )
 
     if not vector_ranks:
@@ -255,8 +258,9 @@ async def _run_rrf_merge(
     # Get FTS-ranked record IDs (up to a reasonable cap for merging).
     # Strip the inherited eager-loads -- only record_id is needed at
     # this stage, so 4 wasted selectinload queries per request are
-    # avoided (PERF-8).
-    fts_cap = max(filters.limit * 3, 100)
+    # avoided (PERF-8). Cap must cover the requested page end (skip+limit) so
+    # offset pages aren't truncated, plus headroom for RRF re-ranking.
+    fts_cap = max(page_end * 3, 100)
     fts_stmt = (
         stmt.with_only_columns(Dataset.record_id)
         .order_by(rank_col.desc())

--- a/backend/app/modules/catalog/search/service_semantic.py
+++ b/backend/app/modules/catalog/search/service_semantic.py
@@ -117,8 +117,14 @@ async def _get_vector_ranks(
     session: AsyncSession,
     query_text: str,
     limit: int,
+    restrict_stmt: Select | None = None,
 ) -> dict[str, int]:
     """Run vector similarity search and return {record_id_hex: rank} mapping.
+
+    ``restrict_stmt`` is a ``select(Record.id)`` carrying the active visibility +
+    search filters; when provided, the cosine top-k is computed ONLY over records
+    in that set, so a nearer but non-visible / filtered-out embedding cannot crowd
+    a valid match out of the top ``limit`` rows.
 
     Returns an empty dict on any failure (silent fallback).
     """
@@ -147,20 +153,21 @@ async def _get_vector_ranks(
         RecordEmbedding = get_catalog_port().record_embedding_orm_class()
 
         # Vector similarity query: cosine distance <= 0.7 means similarity >= 0.3
-        vector_stmt = (
-            select(
-                RecordEmbedding.record_id,
-                RecordEmbedding.embedding.cosine_distance(query_vector).label(
-                    "distance"
-                ),
-            )
-            .where(
-                RecordEmbedding.model_name == model_name,
-                RecordEmbedding.embedding.cosine_distance(query_vector) <= 0.7,
-            )
-            .order_by("distance")
-            .limit(limit)
+        vector_stmt = select(
+            RecordEmbedding.record_id,
+            RecordEmbedding.embedding.cosine_distance(query_vector).label("distance"),
+        ).where(
+            RecordEmbedding.model_name == model_name,
+            RecordEmbedding.embedding.cosine_distance(query_vector) <= 0.7,
         )
+        if restrict_stmt is not None:
+            # Restrict candidates to the visibility/filter-vetted record set BEFORE
+            # the top-k cut, so private/filtered nearer neighbours can't displace a
+            # valid visible match out of the limit.
+            vector_stmt = vector_stmt.where(
+                RecordEmbedding.record_id.in_(restrict_stmt)
+            )
+        vector_stmt = vector_stmt.order_by("distance").limit(limit)
 
         result = await session.execute(vector_stmt)
         rows = result.all()
@@ -212,11 +219,13 @@ async def _run_rrf_merge(
     Surfaces vector-only matches (records that are semantically similar but do
     not lexically match the FTS query) IN ADDITION to re-ranking FTS hits. Since
     ``_get_vector_ranks`` applies neither RBAC visibility nor the active search
-    filters, vector-only candidates are vetted through ``vet_stmt`` -- the same
-    visibility + bbox/geometry_type/srid/keywords/date/CQL filters as the FTS
-    query, minus the text clause -- before being surfaced. This prevents both
-    leaking private/restricted datasets and returning records that violate an
-    active filter (e.g. a polygon under ``geometry_type=Point``).
+    filters, ``vet_stmt`` (a ``select(Record.id)`` with the same visibility +
+    bbox/geometry_type/srid/keywords/date/CQL filters as the FTS query, minus the
+    text clause) is passed as the vector query's ``restrict_stmt`` so the cosine
+    top-k is taken only over records the caller may see that satisfy every active
+    filter. This prevents leaking private/restricted datasets, returning records
+    that violate an active filter (e.g. a polygon under ``geometry_type=Point``),
+    AND a nearer non-visible neighbour displacing a valid match out of the top-k.
 
     Returns ``None`` when RRF doesn't apply (vector backend empty/failed).
     Caller falls through to the standard sort path on None.
@@ -229,8 +238,12 @@ async def _run_rrf_merge(
     if filters.q is None:
         raise ValueError("_run_rrf_merge requires filters.q to be non-None")
     q_stripped = filters.q.strip()
-    # Get vector similarity ranks (empty dict on any failure = FTS-only)
-    vector_ranks = await _get_vector_ranks(session, q_stripped, filters.limit)
+    # Vector similarity ranks, restricted to the visibility/filter-vetted set so the
+    # cosine top-k contains only records the caller may see that satisfy every active
+    # filter (empty dict on any failure = FTS-only).
+    vector_ranks = await _get_vector_ranks(
+        session, q_stripped, filters.limit, restrict_stmt=vet_stmt
+    )
 
     if not vector_ranks:
         logger.info(
@@ -252,36 +265,31 @@ async def _run_rrf_merge(
     fts_result = await session.execute(fts_stmt)
     fts_ids = [str(row[0]) for row in fts_result.all()]
 
-    # RRF over FTS results UNION vetted vector-only results.
-    # FTS ids already passed visibility + every active filter (via the inherited
-    # `stmt`). Vector-only ids did NOT — _get_vector_ranks queries
-    # record_embeddings with neither RBAC nor the active search filters — so they
-    # MUST be vetted through `vet_stmt` (same visibility + bbox/geometry_type/
-    # srid/keywords/date/CQL filters, minus the text clause) before surfacing.
-    # Otherwise a semantic match could leak a private/restricted dataset OR
-    # violate an active filter. Bounded to the small vector candidate set.
+    # RRF over FTS results UNION the (already vetted) vector matches. vector_ranks
+    # is pre-filtered for visibility + every active filter via restrict_stmt, so it
+    # can be unioned directly.
     fts_id_set = set(fts_ids)
     vector_only_ids = [rid for rid in vector_ranks if rid not in fts_id_set]
-    vetted_vector_only: set[str] = set()
+
+    # `total` is the full FTS match count. A vector-only id (absent from the capped
+    # fts_ids) may STILL be a full FTS match that ranked below fts_cap and is already
+    # counted -- so only count vector matches that are NOT FTS matches as additional,
+    # to avoid inflating numberMatched into empty trailing pages.
     if vector_only_ids:
-        vetted = await session.execute(
-            vet_stmt.where(
-                Record.id.in_([uuid_mod.UUID(rid) for rid in vector_only_ids])
-            )
+        candidate_uuids = [uuid_mod.UUID(rid) for rid in vector_only_ids]
+        fts_match_stmt = (
+            select(Record.id)
+            .select_from(Dataset)
+            .join(Record, Dataset.record_id == Record.id)
+            .where(stmt.whereclause)
+            .where(Record.id.in_(candidate_uuids))
         )
-        vetted_vector_only = {str(rid) for rid in vetted.scalars().all()}
+        fts_matching = {
+            str(rid) for rid in (await session.execute(fts_match_stmt)).scalars().all()
+        }
+        total += sum(1 for rid in vector_only_ids if rid not in fts_matching)
 
-    safe_vector_ranks = {
-        rid: rank
-        for rid, rank in vector_ranks.items()
-        if rid in fts_id_set or rid in vetted_vector_only
-    }
-    # Surfaced vector-only matches are additional results beyond the FTS count.
-    # (A record that both vector-matches and FTS-matches below the fts_cap is a
-    # rare overlap; the resulting +1 overcount is acceptable for pagination.)
-    total += len(vetted_vector_only)
-
-    rrf_ordered = _compute_rrf_scores(fts_ids, safe_vector_ranks)
+    rrf_ordered = _compute_rrf_scores(fts_ids, vector_ranks)
 
     # Apply pagination to RRF-ordered list
     page_ids = rrf_ordered[filters.skip : filters.skip + filters.limit]

--- a/backend/app/modules/catalog/search/service_semantic.py
+++ b/backend/app/modules/catalog/search/service_semantic.py
@@ -13,11 +13,9 @@ from sqlalchemy.orm import selectinload
 from sqlalchemy.sql.elements import Label
 from sqlalchemy.sql.selectable import Select
 
-from app.core.identity import Identity
 from app.core.persistent_config import EMBEDDING_MODEL
 from app.modules.auth.models import User
-from app.modules.catalog.authorization import apply_visibility_filter
-from app.modules.catalog.datasets.domain.models import Dataset, DatasetGrant, Record
+from app.modules.catalog.datasets.domain.models import Dataset, Record
 from app.modules.catalog.search.service_filters import SearchFilters
 from app.platform.extensions import get_catalog_port
 
@@ -207,17 +205,18 @@ async def _run_rrf_merge(
     stmt: Select,
     rank_col: Label[float],
     total: int,
-    user: Identity | None,
-    user_roles: set[str],
+    vet_stmt: Select,
 ) -> tuple[list[Dataset], int] | None:
     """Execute hybrid FTS+vector RRF merge and return paginated results.
 
     Surfaces vector-only matches (records that are semantically similar but do
     not lexically match the FTS query) IN ADDITION to re-ranking FTS hits. Since
-    ``_get_vector_ranks`` does not apply RBAC visibility filtering, vector-only
-    candidates are run through the SAME ``apply_visibility_filter`` the FTS path
-    uses before being surfaced, so private/restricted datasets are never leaked
-    into a semantic match.
+    ``_get_vector_ranks`` applies neither RBAC visibility nor the active search
+    filters, vector-only candidates are vetted through ``vet_stmt`` -- the same
+    visibility + bbox/geometry_type/srid/keywords/date/CQL filters as the FTS
+    query, minus the text clause -- before being surfaced. This prevents both
+    leaking private/restricted datasets and returning records that violate an
+    active filter (e.g. a polygon under ``geometry_type=Point``).
 
     Returns ``None`` when RRF doesn't apply (vector backend empty/failed).
     Caller falls through to the standard sort path on None.
@@ -253,35 +252,34 @@ async def _run_rrf_merge(
     fts_result = await session.execute(fts_stmt)
     fts_ids = [str(row[0]) for row in fts_result.all()]
 
-    # RRF over FTS results UNION visibility-filtered vector-only results.
-    # FTS ids already passed apply_visibility_filter (via the inherited `stmt`).
-    # Vector-only ids did NOT — _get_vector_ranks queries record_embeddings with
-    # no RBAC filter — so they MUST be run through the same visibility filter
-    # before surfacing, or a semantic match would leak a private/restricted
-    # dataset (e.g. an embed-token-scoped one). The check is bounded to the small
-    # vector candidate set (<= filters.limit ids).
+    # RRF over FTS results UNION vetted vector-only results.
+    # FTS ids already passed visibility + every active filter (via the inherited
+    # `stmt`). Vector-only ids did NOT — _get_vector_ranks queries
+    # record_embeddings with neither RBAC nor the active search filters — so they
+    # MUST be vetted through `vet_stmt` (same visibility + bbox/geometry_type/
+    # srid/keywords/date/CQL filters, minus the text clause) before surfacing.
+    # Otherwise a semantic match could leak a private/restricted dataset OR
+    # violate an active filter. Bounded to the small vector candidate set.
     fts_id_set = set(fts_ids)
     vector_only_ids = [rid for rid in vector_ranks if rid not in fts_id_set]
-    visible_vector_only: set[str] = set()
+    vetted_vector_only: set[str] = set()
     if vector_only_ids:
-        vis_stmt = select(Record.id).where(
-            Record.id.in_([uuid_mod.UUID(rid) for rid in vector_only_ids])
+        vetted = await session.execute(
+            vet_stmt.where(
+                Record.id.in_([uuid_mod.UUID(rid) for rid in vector_only_ids])
+            )
         )
-        vis_stmt = apply_visibility_filter(
-            vis_stmt, user, user_roles, Record, DatasetGrant
-        )
-        vis_result = await session.execute(vis_stmt)
-        visible_vector_only = {str(rid) for rid in vis_result.scalars().all()}
+        vetted_vector_only = {str(rid) for rid in vetted.scalars().all()}
 
     safe_vector_ranks = {
         rid: rank
         for rid, rank in vector_ranks.items()
-        if rid in fts_id_set or rid in visible_vector_only
+        if rid in fts_id_set or rid in vetted_vector_only
     }
     # Surfaced vector-only matches are additional results beyond the FTS count.
     # (A record that both vector-matches and FTS-matches below the fts_cap is a
     # rare overlap; the resulting +1 overcount is acceptable for pagination.)
-    total += len(visible_vector_only)
+    total += len(vetted_vector_only)
 
     rrf_ordered = _compute_rrf_scores(fts_ids, safe_vector_ranks)
 

--- a/backend/app/modules/catalog/search/service_semantic.py
+++ b/backend/app/modules/catalog/search/service_semantic.py
@@ -7,7 +7,7 @@ import uuid as uuid_mod
 from collections import OrderedDict
 
 import structlog
-from sqlalchemy import select
+from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 from sqlalchemy.sql.elements import Label
@@ -118,31 +118,33 @@ async def _get_vector_ranks(
     query_text: str,
     limit: int,
     restrict_stmt: Select | None = None,
-) -> dict[str, int]:
-    """Run vector similarity search and return {record_id_hex: rank} mapping.
+) -> tuple[dict[str, int], list[float] | None]:
+    """Run vector similarity search.
 
     ``restrict_stmt`` is a ``select(Record.id)`` carrying the active visibility +
     search filters; when provided, the cosine top-k is computed ONLY over records
     in that set, so a nearer but non-visible / filtered-out embedding cannot crowd
     a valid match out of the top ``limit`` rows.
 
-    Returns an empty dict on any failure (silent fallback).
+    Returns ``({record_id_hex: rank}, query_vector)``. The query vector is returned
+    so the caller can run an accurate total-match COUNT (which the ``limit``-bounded
+    ranks cannot provide). Returns ``({}, None)`` on any failure (silent fallback).
     """
     # Check if any embeddings exist at all
     if not await get_catalog_port().has_embeddings(session):
-        return {}
+        return {}, None
 
     # Generate query embedding
     try:
         query_vector = await generate_embedding(query_text.strip(), session)
     except EmbeddingUnavailableError:
         logger.warning("Embedding unavailable for semantic search, falling back to FTS")
-        return {}
+        return {}, None
     except Exception:  # broad: third-party embedding SDK can throw provider-specific errors; fall back to FTS
         logger.warning(
             "Failed to generate query embedding, falling back to FTS", exc_info=True
         )
-        return {}
+        return {}, None
 
     try:
         # Get current model name for filtering
@@ -177,10 +179,10 @@ async def _get_vector_ranks(
         logger.warning(
             "Vector similarity query failed, falling back to FTS", exc_info=True
         )
-        return {}
+        return {}, None
 
     # Assign positional ranks (1-based)
-    return {str(row.record_id): rank + 1 for rank, row in enumerate(rows)}
+    return {str(row.record_id): rank + 1 for rank, row in enumerate(rows)}, query_vector
 
 
 def _compute_rrf_scores(
@@ -243,8 +245,9 @@ async def _run_rrf_merge(
     page_end = filters.skip + filters.limit
     # Vector similarity ranks, restricted to the visibility/filter-vetted set so the
     # cosine top-k contains only records the caller may see that satisfy every active
-    # filter (empty dict on any failure = FTS-only).
-    vector_ranks = await _get_vector_ranks(
+    # filter (empty dict on any failure = FTS-only). The query vector is returned for
+    # the total-match count below.
+    vector_ranks, query_vector = await _get_vector_ranks(
         session, q_stripped, page_end, restrict_stmt=vet_stmt
     )
 
@@ -271,27 +274,33 @@ async def _run_rrf_merge(
 
     # RRF over FTS results UNION the (already vetted) vector matches. vector_ranks
     # is pre-filtered for visibility + every active filter via restrict_stmt, so it
-    # can be unioned directly.
-    fts_id_set = set(fts_ids)
-    vector_only_ids = [rid for rid in vector_ranks if rid not in fts_id_set]
-
-    # `total` is the full FTS match count. A vector-only id (absent from the capped
-    # fts_ids) may STILL be a full FTS match that ranked below fts_cap and is already
-    # counted -- so only count vector matches that are NOT FTS matches as additional,
-    # to avoid inflating numberMatched into empty trailing pages.
-    if vector_only_ids:
-        candidate_uuids = [uuid_mod.UUID(rid) for rid in vector_only_ids]
-        fts_match_stmt = (
-            select(Record.id)
-            .select_from(Dataset)
-            .join(Record, Dataset.record_id == Record.id)
-            .where(stmt.whereclause)
-            .where(Record.id.in_(candidate_uuids))
+    # can be unioned directly. (Only the top page_end ranks are fetched -- enough to
+    # fill the requested page; the accurate match total is computed separately.)
+    #
+    # numberMatched must count ALL semantic matches, not just the page_end window, or
+    # a semantic-only search drops its `next` link (offset+limit >= total) while later
+    # pages still have results. Count vetted vector matches that are NOT also FTS
+    # matches (those are already in `total`) via a single COUNT -- record_embeddings
+    # holds one row per record, so this scans the catalog, not feature rows.
+    fts_match_subq = (
+        select(Record.id)
+        .select_from(Dataset)
+        .join(Record, Dataset.record_id == Record.id)
+        .where(stmt.whereclause)
+    )
+    model_name = await EMBEDDING_MODEL.get(session)
+    RecordEmbedding = get_catalog_port().record_embedding_orm_class()
+    new_count_stmt = (
+        select(func.count())
+        .select_from(RecordEmbedding)
+        .where(
+            RecordEmbedding.model_name == model_name,
+            RecordEmbedding.embedding.cosine_distance(query_vector) <= 0.7,
+            RecordEmbedding.record_id.in_(vet_stmt),
+            RecordEmbedding.record_id.notin_(fts_match_subq),
         )
-        fts_matching = {
-            str(rid) for rid in (await session.execute(fts_match_stmt)).scalars().all()
-        }
-        total += sum(1 for rid in vector_only_ids if rid not in fts_matching)
+    )
+    total += (await session.execute(new_count_stmt)).scalar_one()
 
     rrf_ordered = _compute_rrf_scores(fts_ids, vector_ranks)
 

--- a/backend/tests/test_hybrid_search.py
+++ b/backend/tests/test_hybrid_search.py
@@ -704,3 +704,59 @@ async def test_semantic_visible_match_not_crowded_out_by_nearer_private(
     assert "Open Transit Hub Index" in titles
     for i in range(3):
         assert f"Private Near Neighbour {i}" not in titles
+
+
+@pytest.mark.anyio
+async def test_semantic_vector_only_pagination(
+    client: AsyncClient,
+    test_db_session,
+):
+    """Later pages of semantic-only matches must not be empty (Codex round-3 P2).
+
+    With five vector-only matches and limit=2, page 2 (offset=2) must return
+    results distinct from page 1 — the vector fetch must reach skip+limit deep.
+    """
+    session = test_db_session
+    admin_id = await get_user_id(session, "admin")
+    dim = await _get_embedding_dim(session)
+    await _set_semantic_search(session, True)
+
+    # Five public datasets in an isolated vector band (lo=70), decreasing similarity.
+    for i, base in enumerate((0.99, 0.95, 0.90, 0.85, 0.80)):
+        ds = await _create_search_dataset(
+            session,
+            created_by=admin_id,
+            name=f"Band Catalog Layer {i}",  # no lexical overlap with the query
+            description="public",
+        )
+        session.add(
+            RecordEmbedding(
+                record_id=ds.record_id,
+                embedding=_make_vector_band(base, dim=dim, lo=70),
+                model_name="text-embedding-3-small",
+                content_hash=f"page_band_{i}",
+            )
+        )
+    await session.commit()
+
+    async def _page(offset: int) -> list[str]:
+        with patch(
+            "app.modules.catalog.search.service_semantic.generate_embedding",
+            new_callable=AsyncMock,
+            return_value=_make_vector_band(1.0, dim=dim, lo=70),
+        ):
+            r = await client.get(
+                "/search/datasets/",
+                params={"q": "zzznolexicalmatchxyz", "limit": 2, "offset": offset},
+            )
+        assert r.status_code == 200
+        return [
+            f["properties"]["title"]
+            for f in r.json()["features"]
+            if f.get("properties")
+        ]
+
+    page1 = await _page(0)
+    page2 = await _page(2)
+    assert len(page2) >= 1, "second page of semantic-only results must not be empty"
+    assert set(page1).isdisjoint(set(page2)), "pages must not overlap"

--- a/backend/tests/test_hybrid_search.py
+++ b/backend/tests/test_hybrid_search.py
@@ -88,6 +88,19 @@ def _make_vector(base_value: float, dim: int = 1536) -> list[float]:
     return [v / magnitude for v in vec]
 
 
+def _make_vector_band(base_value: float, dim: int = 1536, lo: int = 40) -> list[float]:
+    """Vector with its signal in dims [lo, lo+10) and ZEROS elsewhere.
+
+    Orthogonal to ``_make_vector`` (dims 0..9), so a query built here matches only
+    records embedded here — isolating a test from other tests' committed vectors.
+    """
+    vec = [0.0] * dim
+    for i in range(lo, min(lo + 10, dim)):
+        vec[i] = base_value + ((i - lo) * 0.01)
+    magnitude = sum(v * v for v in vec) ** 0.5
+    return [v / magnitude for v in vec]
+
+
 async def _get_embedding_dim(session) -> int:
     """Return the current fixed vector dimension for record embeddings."""
     result = await session.execute(
@@ -623,3 +636,71 @@ async def test_semantic_vector_only_respects_active_filters(
     # ...but the MultiPolygon vector matches are excluded by geometry_type=Point.
     assert "Roads and Highways Network" not in titles
     assert "Railway Network Lines" not in titles
+
+
+@pytest.mark.anyio
+async def test_semantic_visible_match_not_crowded_out_by_nearer_private(
+    client: AsyncClient,
+    test_db_session,
+):
+    """A visible vector match must not be displaced from the top-k by nearer private ones.
+
+    With limit=2 and three PRIVATE records embedded nearer the query than the one
+    PUBLIC record, the public record must still surface — the cosine top-k is taken
+    over the visibility/filter-vetted set, not all embeddings (Codex P2a).
+    """
+    session = test_db_session
+    admin_id = await get_user_id(session, "admin")
+    dim = await _get_embedding_dim(session)
+    await _set_semantic_search(session, True)
+
+    public_ds = await _create_search_dataset(
+        session,
+        created_by=admin_id,
+        name="Open Transit Hub Index",  # no lexical overlap with the query
+        description="public",
+    )
+    session.add(
+        RecordEmbedding(
+            record_id=public_ds.record_id,
+            embedding=_make_vector_band(0.85, dim=dim),
+            model_name="text-embedding-3-small",
+            content_hash="p2a_public",
+        )
+    )
+    for i, base in enumerate((0.99, 0.98, 0.97)):
+        priv = await _create_search_dataset(
+            session,
+            created_by=admin_id,
+            name=f"Private Near Neighbour {i}",
+            description="private",
+            visibility="private",
+        )
+        session.add(
+            RecordEmbedding(
+                record_id=priv.record_id,
+                embedding=_make_vector_band(
+                    base, dim=dim
+                ),  # nearer than the public 0.85
+                model_name="text-embedding-3-small",
+                content_hash=f"p2a_priv_{i}",
+            )
+        )
+    await session.commit()
+
+    with patch(
+        "app.modules.catalog.search.service_semantic.generate_embedding",
+        new_callable=AsyncMock,
+        return_value=_make_vector_band(1.0, dim=dim),
+    ):
+        resp = await client.get(
+            "/search/datasets/",
+            params={"q": "zzznolexicalmatchxyz", "limit": 2},
+        )
+    assert resp.status_code == 200
+    titles = {
+        f["properties"]["title"] for f in resp.json()["features"] if f.get("properties")
+    }
+    assert "Open Transit Hub Index" in titles
+    for i in range(3):
+        assert f"Private Near Neighbour {i}" not in titles

--- a/backend/tests/test_hybrid_search.py
+++ b/backend/tests/test_hybrid_search.py
@@ -38,13 +38,14 @@ async def _create_search_dataset(
     name: str,
     keywords: list[str] | None = None,
     description: str | None = None,
+    visibility: str = "public",
 ) -> Dataset:
     """Insert a Record + Dataset pair for hybrid search tests."""
     table_name = f"ds_{uuid.uuid4().hex[:12]}"
     record = Record(
         title=name,
         summary=description or f"Description for {name}",
-        visibility="public",
+        visibility=visibility,
         record_status="published",
         created_by=created_by,
     )
@@ -473,3 +474,96 @@ def test_compute_rrf_scores_basic():
     assert result[2] == "a", f"Expected 'a' third, got {result}"
     # d has lowest score
     assert result[3] == "d", f"Expected 'd' last, got {result}"
+
+
+# ---------------------------------------------------------------------------
+# Tests: true semantic retrieval — vector-only matches are surfaced, but
+# never leak non-visible datasets (visibility-aware RRF union)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_semantic_surfaces_vector_only_match(
+    client: AsyncClient,
+    admin_auth_header: dict,
+    hybrid_datasets_with_embeddings: dict,
+    hybrid_vectors: dict[str, list[float]],
+):
+    """A record that matches by MEANING but not by keyword is surfaced.
+
+    Query text that matches NO dataset lexically, with the query embedding close
+    to the 'roads'/'railways' vectors -> those vector-only matches must appear
+    (previously the RRF merge excluded vector-only ids and returned nothing).
+    """
+    with patch(
+        "app.modules.catalog.search.service_semantic.generate_embedding",
+        new_callable=AsyncMock,
+        return_value=hybrid_vectors["transport"],
+    ):
+        resp = await client.get(
+            "/search/datasets/",
+            params={"q": "zzznolexicalmatchxyz"},
+            headers=admin_auth_header,
+        )
+    assert resp.status_code == 200
+    titles = {
+        f["properties"]["title"] for f in resp.json()["features"] if f.get("properties")
+    }
+    # transport (1.0) is close to roads (0.95) + railways (0.90); far from
+    # population (-0.5) / rivers (-0.8) which exceed the 0.7 distance cutoff.
+    assert "Roads and Highways Network" in titles
+    assert "Railway Network Lines" in titles
+
+
+@pytest.mark.anyio
+async def test_semantic_vector_only_does_not_leak_private(
+    client: AsyncClient,
+    hybrid_datasets_with_embeddings: dict,
+    hybrid_vectors: dict[str, list[float]],
+    test_db_session,
+):
+    """A PRIVATE vector-only match must never surface to an anonymous caller.
+
+    The vector query (_get_vector_ranks) is not visibility-filtered, so the RRF
+    union must run vector-only candidates through apply_visibility_filter. A
+    private record with a near-perfect embedding match + a non-lexical title is
+    the exact leak this guards against.
+    """
+    session = test_db_session
+    admin_id = await get_user_id(session, "admin")
+
+    private_ds = await _create_search_dataset(
+        session,
+        created_by=admin_id,
+        name="Classified Restricted Layer",  # no lexical overlap with the query
+        description="Sensitive private dataset",
+        visibility="private",
+    )
+    session.add(
+        RecordEmbedding(
+            record_id=private_ds.record_id,
+            embedding=hybrid_vectors["transport"],  # ~identical to the query vector
+            model_name="text-embedding-3-small",
+            content_hash="test_hash_private_leak",
+        )
+    )
+    await session.commit()
+
+    # Anonymous request (no auth header) — filter_visible restricts to public.
+    with patch(
+        "app.modules.catalog.search.service_semantic.generate_embedding",
+        new_callable=AsyncMock,
+        return_value=hybrid_vectors["transport"],
+    ):
+        resp = await client.get(
+            "/search/datasets/",
+            params={"q": "zzznolexicalmatchxyz"},
+        )
+    assert resp.status_code == 200
+    titles = {
+        f["properties"]["title"] for f in resp.json()["features"] if f.get("properties")
+    }
+    # The private record must NOT leak, even though its embedding is the closest match.
+    assert "Classified Restricted Layer" not in titles
+    # ...but a PUBLIC vector-only match still surfaces (semantic retrieval works for anon).
+    assert "Roads and Highways Network" in titles

--- a/backend/tests/test_hybrid_search.py
+++ b/backend/tests/test_hybrid_search.py
@@ -39,6 +39,7 @@ async def _create_search_dataset(
     keywords: list[str] | None = None,
     description: str | None = None,
     visibility: str = "public",
+    geometry_type: str = "MultiPolygon",
 ) -> Dataset:
     """Insert a Record + Dataset pair for hybrid search tests."""
     table_name = f"ds_{uuid.uuid4().hex[:12]}"
@@ -61,7 +62,7 @@ async def _create_search_dataset(
         record_id=record.id,
         table_name=table_name,
         srid=4326,
-        geometry_type="MultiPolygon",
+        geometry_type=geometry_type,
         feature_count=10,
         source_format="geojson",
         source_filename="test.geojson",
@@ -567,3 +568,58 @@ async def test_semantic_vector_only_does_not_leak_private(
     assert "Classified Restricted Layer" not in titles
     # ...but a PUBLIC vector-only match still surfaces (semantic retrieval works for anon).
     assert "Roads and Highways Network" in titles
+
+
+@pytest.mark.anyio
+async def test_semantic_vector_only_respects_active_filters(
+    client: AsyncClient,
+    admin_auth_header: dict,
+    hybrid_datasets_with_embeddings: dict,
+    hybrid_vectors: dict[str, list[float]],
+    test_db_session,
+):
+    """A vector-only match must still satisfy the OTHER active filters.
+
+    With geometry_type=Point, a semantically similar POLYGON (vector-only, no
+    lexical hit) must NOT surface; only a Point dataset that also matches by
+    meaning may. Guards the filter-bypass the visibility-only check missed.
+    """
+    session = test_db_session
+    admin_id = await get_user_id(session, "admin")
+
+    point_ds = await _create_search_dataset(
+        session,
+        created_by=admin_id,
+        name="Transit Stops Inventory",  # no lexical overlap with the query
+        description="Point inventory",
+        geometry_type="Point",
+    )
+    session.add(
+        RecordEmbedding(
+            record_id=point_ds.record_id,
+            embedding=hybrid_vectors["transport"],
+            model_name="text-embedding-3-small",
+            content_hash="test_hash_point_geom",
+        )
+    )
+    await session.commit()
+
+    with patch(
+        "app.modules.catalog.search.service_semantic.generate_embedding",
+        new_callable=AsyncMock,
+        return_value=hybrid_vectors["transport"],
+    ):
+        resp = await client.get(
+            "/search/datasets/",
+            params={"q": "zzznolexicalmatchxyz", "geometry_type": "Point"},
+            headers=admin_auth_header,
+        )
+    assert resp.status_code == 200
+    titles = {
+        f["properties"]["title"] for f in resp.json()["features"] if f.get("properties")
+    }
+    # The Point vector-only match surfaces...
+    assert "Transit Stops Inventory" in titles
+    # ...but the MultiPolygon vector matches are excluded by geometry_type=Point.
+    assert "Roads and Highways Network" not in titles
+    assert "Railway Network Lines" not in titles

--- a/backend/tests/test_hybrid_search.py
+++ b/backend/tests/test_hybrid_search.py
@@ -739,7 +739,7 @@ async def test_semantic_vector_only_pagination(
         )
     await session.commit()
 
-    async def _page(offset: int) -> list[str]:
+    async def _page(offset: int) -> tuple[list[str], int]:
         with patch(
             "app.modules.catalog.search.service_semantic.generate_embedding",
             new_callable=AsyncMock,
@@ -750,13 +750,18 @@ async def test_semantic_vector_only_pagination(
                 params={"q": "zzznolexicalmatchxyz", "limit": 2, "offset": offset},
             )
         assert r.status_code == 200
-        return [
-            f["properties"]["title"]
-            for f in r.json()["features"]
-            if f.get("properties")
+        body = r.json()
+        titles = [
+            f["properties"]["title"] for f in body["features"] if f.get("properties")
         ]
+        return titles, body.get("numberMatched", 0)
 
-    page1 = await _page(0)
-    page2 = await _page(2)
+    page1, matched = await _page(0)
+    page2, _ = await _page(2)
     assert len(page2) >= 1, "second page of semantic-only results must not be empty"
     assert set(page1).isdisjoint(set(page2)), "pages must not overlap"
+    # numberMatched must reflect ALL five semantic matches, not just the page window,
+    # or the router omits the `next` link (Codex round-4 count fix).
+    assert matched >= 5, (
+        f"numberMatched should count all semantic matches, got {matched}"
+    )


### PR DESCRIPTION
## Problem
GeoLens "semantic search" only **re-ranked keyword (FTS) hits** — `_run_rrf_merge` intersected vector ranks with the FTS id set, so a record matching by **meaning** but not lexically never surfaced. Measured live on the demo: `skyscrapers` → `Manhattan Building Heights` is a cosine distance of **0.58** (well within the 0.7 cutoff), yet returned nothing.

## Why it was excluded (the security constraint)
`_get_vector_ranks` queries `catalog.record_embeddings` with **no RBAC visibility filter**. Blindly unioning its results would **leak private/restricted datasets** (e.g. embed-token-scoped data) into search.

## Fix
Union FTS hits with vector-only matches, but run the **small** (`<= limit`) set of vector-only candidate ids through the **same `apply_visibility_filter`** the FTS path already uses, before surfacing them:
- FTS ids are already visibility-filtered (inherited `stmt`).
- Vector-only ids are checked explicitly against `Record` visibility + grants.
- `total` is adjusted by the number of surfaced vector-only matches.

`_compute_rrf_scores` already supported the union; the only change is *which* vector ids are passed to it + the visibility gate.

## Tests (`test_hybrid_search.py`)
- `test_semantic_surfaces_vector_only_match` — a meaning-only match now appears.
- `test_semantic_vector_only_does_not_leak_private` — a private record with a near-perfect embedding match is **not** surfaced to an anonymous caller.

Full `test_hybrid_search.py` (8) + `test_search.py` (34) pass locally.

## Context
Found while wiring Azure OpenAI embeddings into the public demo (the "search by meaning" pitch didn't work). Pairs with the demo seeder work (#306, merged).

https://claude.ai/code/session_01ATqNfJXvg3zXfktncsNUdf