### PR TITLE
fix(raster): default missing band index to 1-based position

### DIFF
--- a/backend/app/modules/catalog/datasets/domain/helpers.py
+++ b/backend/app/modules/catalog/datasets/domain/helpers.py
@@ -48,10 +48,13 @@ def _build_raster_metadata(
     # Build bands list from band_info JSONB
     bands = []
     if raster_asset.band_info:
-        for b in raster_asset.band_info:
+        # Default a missing "index" to the 1-based position, not 0, so legacy
+        # band_info rows without the key get unique, correct band numbers
+        # instead of every band collapsing onto 0.
+        for position, b in enumerate(raster_asset.band_info, start=1):
             bands.append(
                 RasterBandInfo(
-                    index=b.get("index", 0),
+                    index=b.get("index", position),
                     dtype=b.get("dtype", ""),
                     nodata=b.get("nodata"),
                     color_interp=b.get("color_interp"),

--- a/backend/tests/test_vrt_catalog_175.py
+++ b/backend/tests/test_vrt_catalog_175.py
@@ -184,6 +184,36 @@ class TestRasterMetadataVrtFields:
         assert result is not None
         assert result.source_count == 0
 
+    def test_band_info_without_index_gets_unique_positions(self):
+        """Legacy band_info rows lacking 'index' default to 1-based positions,
+        not all 0 (which made every band collide on React key 0 + show '#'=0)."""
+        from app.modules.catalog.datasets.domain.helpers import _build_raster_metadata
+
+        dataset = _make_mock_dataset("raster_dataset")
+        asset = _make_mock_raster_asset()
+        asset.band_info = [{"dtype": "uint8"}, {"dtype": "uint8"}, {"dtype": "uint8"}]
+
+        result = _build_raster_metadata(dataset, asset, source_count=None)
+
+        assert result is not None
+        assert [b.index for b in result.bands] == [1, 2, 3]
+
+    def test_band_info_preserves_explicit_index(self):
+        """An explicit 'index' is preserved (not overwritten by position)."""
+        from app.modules.catalog.datasets.domain.helpers import _build_raster_metadata
+
+        dataset = _make_mock_dataset("raster_dataset")
+        asset = _make_mock_raster_asset()
+        asset.band_info = [
+            {"index": 1, "dtype": "uint8"},
+            {"index": 2, "dtype": "uint8"},
+        ]
+
+        result = _build_raster_metadata(dataset, asset, source_count=None)
+
+        assert result is not None
+        assert [b.index for b in result.bands] == [1, 2]
+
 
 # ---------------------------------------------------------------------------
 # TestDatasetToResponseVrt

--- a/frontend/src/components/dataset/tabs/OverviewTab.tsx
+++ b/frontend/src/components/dataset/tabs/OverviewTab.tsx
@@ -453,9 +453,9 @@ export function OverviewTab({
                           </TableRow>
                         </TableHeader>
                         <TableBody>
-                          {dataset.raster.bands.map((band) => (
-                            <TableRow key={band.index}>
-                              <TableCell>{band.index}</TableCell>
+                          {dataset.raster.bands.map((band, i) => (
+                            <TableRow key={i}>
+                              <TableCell>{band.index || i + 1}</TableCell>
                               <TableCell>{band.dtype}</TableCell>
                               <TableCell title={band.nodata != null ? String(band.nodata) : undefined}>{formatNodata(band.nodata)}</TableCell>
                               <TableCell>{band.color_interp && band.color_interp !== 'undefined' ? band.color_interp : t('common:notSpecified', { defaultValue: 'Not specified' })}</TableCell>


### PR DESCRIPTION
## Summary

The raster dataset page logged a React warning — `Encountered two children with the same key, \`0\`` — and the **Band Details** table showed `#` = 0 for every band.

**Root cause:** `_build_raster_metadata` (`backend/.../datasets/domain/helpers.py`) reconstructs bands from the `band_info` JSONB with `index=b.get("index", 0)`. Any band dict lacking an `index` key (legacy / non-cog ingestion) defaults to **0**, so every band collapses onto index `0` — duplicate React keys *and* a wrong `#` column. Reconstruction runs per request, so this corrects existing datasets without re-ingestion.

## Changes

- **Backend** `helpers.py`: default a missing `index` to the 1-based `enumerate` position instead of `0` (unique, correct band numbers). Adds 2 regression tests.
- **Frontend** `OverviewTab.tsx`: key the band table on the array position (stable/unique) and render `band.index || i + 1` as a graceful `#` fallback.

## Area
- [x] Backend (API, services, models)
- [x] Frontend (UI, components, hooks)
- [x] Tiles / Rendering

## Testing
- [x] `pytest tests/test_vrt_catalog_175.py -k band_info` (2 new tests pass)
- [x] eslint + tsc clean on OverviewTab

https://claude.ai/code/session_01ATqNfJXvg3zXfktncsNUdf