### PR TITLE
fix(legend): viewer graduated-size color + raster swatch

### DIFF
--- a/frontend/src/components/viewer/LayerLegend.tsx
+++ b/frontend/src/components/viewer/LayerLegend.tsx
@@ -119,6 +119,10 @@ function GraduatedLegend({
   const rawColor = paint[colorPaintKey(layer.geometry_type)];
   const parsedColor = parsePaintColors(rawColor);
   const colorColumn = expressionColumn(rawColor);
+  // parsePaintColors only handles data-driven expressions; a constant fill is a
+  // plain string, so fall back to it (the layer's real color) before gray.
+  const constantColor =
+    (typeof rawColor === 'string' ? rawColor : undefined) ?? MAP_COLORS.fallback;
 
   if (styleConfig.target === 'radius' && styleConfig.sizes) {
     return (
@@ -129,7 +133,7 @@ function GraduatedLegend({
         <GraduatedRadiusLegend
           sizes={styleConfig.sizes}
           breaks={breaks}
-          circleColor={parsedColor?.colors[0] ?? MAP_COLORS.fallback}
+          circleColor={parsedColor?.colors[0] ?? constantColor}
           style={swatchStyle}
         />
         {parsedColor && colorColumn && colorColumn !== styleConfig.column && (

--- a/frontend/src/components/viewer/LayerLegend.tsx
+++ b/frontend/src/components/viewer/LayerLegend.tsx
@@ -11,9 +11,10 @@ import {
   HeatmapLegend,
 } from '@/components/map/LegendEntries';
 import type { SwatchStyle } from '@/components/map/LegendEntries';
-import { Eye, EyeOff, Layers, Mountain, X } from 'lucide-react';
+import { Eye, EyeOff, Grid3x3, Layers, Mountain, X } from 'lucide-react';
 import { parseStepOrInterpolate } from '@/lib/normalize-style-config';
 import { MAP_COLORS } from '@/lib/map-colors';
+import { getLayerCapabilities } from '@/lib/layer-capabilities';
 import { createViewerLayerEntries } from '@/components/viewer/layer-identity';
 import {
   deriveTerrainLegendEntry,
@@ -280,7 +281,15 @@ export function LayerLegend({
             const isVisible = visibleLayers.has(key);
             const sc = layer.style_config;
             const isHeatmap = sc?.render_mode === 'heatmap';
-            const color = isHeatmap ? null : getLayerColors({
+            // Raster/VRT layers have no vector fill — show a raster icon (as the
+            // builder does), not the colored point/polygon swatch + default color.
+            const caps = getLayerCapabilities({
+              layer_type: layer.layer_type,
+              dataset_record_type: layer.dataset_record_type,
+              dataset_geometry_type: layer.geometry_type,
+            });
+            const isRasterLike = caps.kind === 'raster' || caps.kind === 'vrt';
+            const color = isHeatmap || isRasterLike ? null : getLayerColors({
               dataset_geometry_type: layer.geometry_type ?? null,
               paint: layer.paint ?? {},
               style_config: sc,
@@ -290,9 +299,15 @@ export function LayerLegend({
             return (
               <li key={key} className="px-3 py-2 hover:bg-accent/50">
                 <div className="flex items-center gap-2">
-                  {color && (
+                  {isRasterLike ? (
+                    caps.kind === 'vrt' ? (
+                      <Layers className="w-3.5 h-3.5 shrink-0 text-muted-foreground" aria-hidden="true" />
+                    ) : (
+                      <Grid3x3 className="w-3.5 h-3.5 shrink-0 text-muted-foreground" aria-hidden="true" />
+                    )
+                  ) : color ? (
                     <GeometrySwatch geometryType={layer.geometry_type} color={color} />
-                  )}
+                  ) : null}
                   <span className="text-sm text-foreground flex-1 line-clamp-2" title={layerName}>
                     {layerName}
                   </span>

--- a/frontend/src/components/viewer/__tests__/LayerLegend.test.tsx
+++ b/frontend/src/components/viewer/__tests__/LayerLegend.test.tsx
@@ -84,6 +84,43 @@ describe('LayerLegend', () => {
     expect(screen.getByText(/50.*200/)).toBeInTheDocument();
   });
 
+  it('colors graduated-size swatches with a constant fill, not the gray fallback', () => {
+    // Regression: a constant (string) circle-color is not an expression, so
+    // parsePaintColors returns null — the radius legend must still use the real
+    // color instead of falling back to gray (#cccccc).
+    const constColorLayer = layer({
+      id: 'layer-const',
+      display_name: 'Magnitude (graduated)',
+      paint: {
+        'circle-radius': ['step', ['get', 'mag'], 4, 5, 7, 6, 11, 7, 16],
+        'circle-color': '#ef4444',
+      },
+      style_config: {
+        mode: 'graduated',
+        column: 'mag',
+        target: 'radius',
+        ramp: 'YlOrRd',
+        breaks: [5, 6, 7],
+        sizes: [4, 7, 11, 16],
+        sizeLabel: 'Magnitude',
+      },
+    });
+
+    const { container } = render(
+      <LayerLegend
+        layers={[constColorLayer]}
+        visibleLayers={new Set(['layer-const'])}
+        onToggleVisibility={vi.fn()}
+        isOpen
+        onToggle={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText('Size: Magnitude')).toBeInTheDocument();
+    expect(container.querySelectorAll('circle[fill="#ef4444"]').length).toBeGreaterThanOrEqual(1);
+    expect(container.querySelector('circle[fill="#cccccc"]')).toBeNull();
+  });
+
   it('uses stable layer keys for duplicate sort orders', () => {
     const onToggleVisibility = vi.fn();
     render(

--- a/frontend/src/components/viewer/__tests__/LayerLegend.test.tsx
+++ b/frontend/src/components/viewer/__tests__/LayerLegend.test.tsx
@@ -121,6 +121,35 @@ describe('LayerLegend', () => {
     expect(container.querySelector('circle[fill="#cccccc"]')).toBeNull();
   });
 
+  it('shows a raster icon, not a colored point swatch, for raster layers', () => {
+    // Regression: raster layers (no vector fill) were given the #6366f1 default
+    // color + a point swatch. They should render a raster icon like the builder.
+    const rasterLayer = layer({
+      id: 'raster-1',
+      display_name: 'Sentinel-2 scene 1',
+      layer_type: 'raster_geolens',
+      dataset_record_type: 'raster_dataset',
+      // geometry_type stays 'POINT' (as real raster layers report) so the bug —
+      // a purple circle swatch — is what we assert is gone.
+      paint: {},
+      style_config: null,
+    });
+
+    const { container } = render(
+      <LayerLegend
+        layers={[rasterLayer]}
+        visibleLayers={new Set(['raster-1'])}
+        onToggleVisibility={vi.fn()}
+        isOpen
+        onToggle={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText('Sentinel-2 scene 1')).toBeInTheDocument();
+    expect(container.querySelector('[fill="#6366f1"]')).toBeNull();
+    expect(container.querySelector('circle[fill="#6366f1"]')).toBeNull();
+  });
+
   it('uses stable layer keys for duplicate sort orders', () => {
     const onToggleVisibility = vi.fn();
     render(


### PR DESCRIPTION
## Summary

Two related viewer-legend swatch bugs (saved-map viewer `LayerLegend`):

1. **Graduated-size swatches were gray.** The radius branch sourced its color from `parsePaintColors(circle-color)`, which only parses data-driven color *expressions* and returns `null` for a **constant** color — so a normal layer (e.g. earthquakes `circle-color: "#ef4444"`) fell to the gray `MAP_COLORS.fallback`. The width branch + builder legend already handle constants; the radius branch dropped it. → fall back to the constant string before gray.

2. **Raster layers showed a purple point dot.** `getLayerColors` returns a `#6366f1` indigo default for layers with no color, and the viewer drew a geometry swatch with it — meaningless for raster imagery (e.g. Sentinel-2 true-color scenes). The builder's `ColorizedGeometryIcon` already special-cases rasters; the viewer didn't. → detect raster/VRT via `getLayerCapabilities` and render a raster/VRT icon (`Grid3x3` / `Layers`), matching the builder.

## Area
- [x] Frontend (UI, components, hooks)
- [x] Tiles / Rendering

## Testing
- [x] `vitest LayerLegend.test.tsx` — 10 pass incl. 2 new regression tests (each verified to fail before its fix)
- [x] eslint + tsc clean

https://claude.ai/code/session_01ATqNfJXvg3zXfktncsNUdf