### PR TITLE
fix(builder+seed): casing = second layer on one dataset (with the map-sync fix that renders it)

### DIFF
--- a/frontend/src/components/builder/__tests__/map-sync.dedupe.test.ts
+++ b/frontend/src/components/builder/__tests__/map-sync.dedupe.test.ts
@@ -210,6 +210,40 @@ describe('syncLayersToMap dedupes addSource by dataset_table_name', () => {
     expect(map.removeSource).not.toHaveBeenCalledWith('source-data-reefs');
   });
 
+  it('two non-cluster vector layers on the SAME dataset BOTH render (2nd layer on a shared source still gets added)', () => {
+    // Regression for #311: casing modeled as a second line layer on one dataset.
+    // The shared source is created by the first layer; the second layer hits the
+    // "source already exists" branch — which previously only ran syncPaint, and
+    // syncPaint no-ops when the layer is missing (line-adapter.ts:212). Result:
+    // the casing layer was never added on a fresh load.
+    const layers: SyncLayerInput[] = [
+      makeLayer({
+        id: 'base',
+        dataset_id: 'ds-rivers',
+        dataset_table_name: 'rivers',
+        dataset_geometry_type: 'LineString',
+      }),
+      makeLayer({
+        id: 'casing',
+        dataset_id: 'ds-rivers',
+        dataset_table_name: 'rivers',
+        dataset_geometry_type: 'LineString',
+      }),
+    ];
+    const tokenMap = new Map<string, TileToken>([
+      ['ds-rivers', makeVectorToken()],
+    ]);
+
+    syncLayersToMap(map, layers, tokenMap, undefined, managedSourcesRef, {
+      current: '',
+    });
+
+    // One shared source, but BOTH layers must be on the map.
+    expect(map.addSource).toHaveBeenCalledTimes(1);
+    expect(map.getLayer('layer-base')).toBeTruthy();
+    expect(map.getLayer('layer-casing')).toBeTruthy();
+  });
+
   it('removeStaleSourcesAndLayers DOES remove a source when no remaining layer references it', () => {
     const layers: SyncLayerInput[] = [
       makeLayer({ id: 'l1', dataset_id: 'ds-reefs', dataset_table_name: 'reefs' }),

--- a/frontend/src/components/builder/map-sync.ts
+++ b/frontend/src/components/builder/map-sync.ts
@@ -846,7 +846,11 @@ function syncVectorLayer(
     } else {
       const src = map.getSource(sourceId);
       if (src && src.type === 'geojson') (src as GeoJSONSource).setData(geojsonData);
-      adapter.syncPaint(map, adapterInput);
+      // A second layer sharing this dataset's source (the SF-04 dedupe) hits this
+      // branch even though its own layer was never added. syncPaint no-ops when the
+      // layer is missing, so add it here instead. See #311.
+      if (!map.getLayer(layerId)) adapter.addLayers(map, adapterInput);
+      else adapter.syncPaint(map, adapterInput);
     }
     adapter.syncVisibility(map, adapterInput);
     syncLayerZoomRange(map, adapter.getLayerIds(layerId), layerMinzoom, layerMaxzoom);
@@ -896,7 +900,11 @@ function syncVectorLayer(
         signatureMap.set(tileUrlKey, adapterInput.tileUrl);
       }
     }
-    adapter.syncPaint(map, adapterInput);
+    // A second layer sharing this dataset's source (the SF-04 dedupe) reaches this
+    // branch with its own layer never added — the shared source was created by the
+    // first layer. syncPaint no-ops when the layer is missing, so add it here. #311.
+    if (!map.getLayer(layerId)) adapter.addLayers(map, adapterInput);
+    else adapter.syncPaint(map, adapterInput);
   }
 
   // Per-layer zoom range from custom layout props (main + outline companion)

--- a/scripts/seed-showcase.py
+++ b/scripts/seed-showcase.py
@@ -59,9 +59,10 @@ GOTCHAS this script encodes (learned the hard way):
     MapLibre fills the mesh at the mapbox-encoding floor (-10000 m), so a small
     DEM looks like a floating slab. Keep draped vectors clipped to the DEM bbox
     and frame the camera inside it (both done for the Matterhorn below).
-  * GeoLens renders ONE MapLibre layer per dataset, so a colored line + a wide
-    casing line must come from TWO datasets (the same geometry ingested twice -
-    done for the Matterhorn route below).
+  * A line + a wider casing under it = TWO LAYERS on the SAME dataset. Map-sync
+    dedupes the tile source per dataset (SF-04), so two layers off one dataset
+    render as two MapLibre lines sharing one source - no need to ingest twice.
+    Done for the Matterhorn route and World Rivers below.
   * The live viewer's layer stack draws LOWER sort_order ON TOP (the inverse of
     the backend style order), so the line you want on top gets the LOWER
     sort_order: route=1 over casing=2, with peaks=3 underneath.
@@ -759,23 +760,16 @@ def build_matterhorn(api: Api, force: bool = False) -> str:
     if routes_fc["features"]:
         routes_bytes = json.dumps(routes_fc).encode()
         # A white casing under the red route makes it pop on the busy hillshade.
-        # GeoLens renders ONE MapLibre layer per dataset, so the casing must be the
-        # SAME geometry ingested as a SECOND dataset (one layer each). And the live
-        # viewer's stack draws LOWER sort_order ON TOP, so the route (wanted on top)
-        # takes the lower sort_order and the casing the higher.
+        # The casing is a second LAYER on the SAME dataset (map-sync dedupes the
+        # tile source per dataset), not a duplicate dataset. The live viewer's
+        # stack draws LOWER sort_order ON TOP, so the route (wanted on top) takes
+        # the lower sort_order and the casing the higher.
         routes_ds = api.ingest_geojson(
             "matterhorn_routes.geojson",
             routes_bytes,
             "Matterhorn Climbing Routes",
             "OSM alpine routes clipped to the swissALTI3D DEM footprint (incl. the "
             "Lion Ridge / cresta Leone Cervino). Source: OpenStreetMap contributors.",
-        )
-        casing_ds = api.ingest_geojson(
-            "matterhorn_route_casing.geojson",
-            routes_bytes,
-            "Matterhorn Route Casing",
-            "White casing under the climbing-route line (same geometry as the routes "
-            "dataset; separate so MapLibre renders it as its own layer).",
         )
         api.add_layer(
             map_id,
@@ -795,7 +789,7 @@ def build_matterhorn(api: Api, force: bool = False) -> str:
         api.add_layer(
             map_id,
             {
-                "dataset_id": casing_ds,
+                "dataset_id": routes_ds,
                 "sort_order": 2,
                 "opacity": 1.0,
                 "display_name": "Route casing",
@@ -1284,20 +1278,14 @@ def build_rivers(api: Api, force: bool = False) -> str:
     print("\n[rivers] World Rivers (line + casing, width by scalerank)")
     print("  downloading Natural Earth rivers...")
     rivers = fetch(NE_RIVERS)
-    # One MapLibre layer per dataset -> ingest the SAME geometry twice (line + casing).
+    # Casing = a second LAYER on the SAME dataset (a wider, darker line drawn
+    # underneath), not a duplicate dataset.
     line_ds = api.ingest_geojson(
         "world_rivers.geojson",
         rivers,
         "World Rivers & Lake Centerlines (Natural Earth 10m)",
         "Major rivers and lake centerlines worldwide, ranked by prominence. "
         "Source: Natural Earth, 1:10m (public domain).",
-    )
-    casing_ds = api.ingest_geojson(
-        "world_rivers_casing.geojson",
-        rivers,
-        "World Rivers - Casing",
-        "Wider casing under the river line (same geometry as the rivers dataset; "
-        "separate so MapLibre renders it as its own layer).",
     )
     map_id = api.create_map(
         "World Rivers",
@@ -1334,7 +1322,7 @@ def build_rivers(api: Api, force: bool = False) -> str:
     api.add_layer(
         map_id,
         {
-            "dataset_id": casing_ds,
+            "dataset_id": line_ds,
             "sort_order": 2,
             "opacity": 1.0,
             "display_name": "River casing",


### PR DESCRIPTION
## What

Models river/Matterhorn casing as a **second line layer on a single dataset** (base + casing) instead of duplicating the dataset, and fixes the renderer bug that made that model not work.

## The renderer fix (the reason the first version was broken)

`map-sync`'s SF-04 dedupe gives two non-cluster vector layers on the same `dataset_table_name` **one shared MapLibre source**. The first layer creates the source and adds its layer; the second layer reaches the "source already exists" branch, which only ran `adapter.syncPaint` — and `syncPaint` no-ops when the layer is missing (`line-adapter.ts:212`). So the **casing layer was never added on a fresh load** (Codex caught this on the prior revision — correctly).

Fix: in both the vector and geojson "source exists" branches, call `adapter.addLayers` when the layer is missing, else `syncPaint`. This also fixes a latent bug where a user-duplicated vector layer on the same dataset wouldn't survive a reload.

## Tests

`map-sync.dedupe.test.ts`: renders two same-dataset line layers and asserts **both** reach the map with **one** shared `addSource`. Verified fail-before / pass-after.

## Seeder

`scripts/seed-showcase.py`: rivers + Matterhorn casing collapse to one dataset + two layers (−12 net lines).

https://claude.ai/code/session_01ATqNfJXvg3zXfktncsNUdf