### PR TITLE
fix(terrain): true-scale Matterhorn exaggeration + align backend clamp to frontend

### DIFF
--- a/backend/app/modules/catalog/maps/schemas.py
+++ b/backend/app/modules/catalog/maps/schemas.py
@@ -230,7 +230,11 @@ class MapVisibility(str, Enum):
 class TerrainConfig(BaseModel):
     enabled: bool = Field(default=False)
     source_dataset_id: uuid.UUID | None = Field(default=None)
-    exaggeration: float = Field(default=1.0, ge=0.0, le=10.0)
+    # Upper bound matches the frontend TERRAIN_EXAGGERATION_MAX (map-sync.ts) and the
+    # DEM editor slider cap. The frontend clamps the rendered value to [0, 3], so a
+    # stored value > 3 silently rendered as 3 — accept only what the client can
+    # actually render to keep the stored value and the mesh in agreement.
+    exaggeration: float = Field(default=1.0, ge=0.0, le=3.0)
 
     model_config = ConfigDict(extra="forbid")
 

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -14658,7 +14658,7 @@
           },
           "exaggeration": {
             "default": 1.0,
-            "maximum": 10.0,
+            "maximum": 3.0,
             "minimum": 0.0,
             "title": "Exaggeration",
             "type": "number"

--- a/backend/tests/test_terrain_config_exaggeration_bound.py
+++ b/backend/tests/test_terrain_config_exaggeration_bound.py
@@ -1,0 +1,26 @@
+"""TerrainConfig.exaggeration upper bound parity with the frontend.
+
+The frontend clamps the rendered terrain exaggeration to [0, 3]
+(TERRAIN_EXAGGERATION_MAX in map-sync.ts; the DEM editor slider caps there too).
+The backend bound must match so a stored value can never exceed what the mesh
+actually renders. Guards against the silent "stored 10, renders 3" divergence.
+"""
+
+import pytest
+from pydantic import ValidationError
+
+from app.modules.catalog.maps.schemas import TerrainConfig
+
+
+def test_exaggeration_at_upper_bound_accepted():
+    assert TerrainConfig(exaggeration=3.0).exaggeration == 3.0
+
+
+def test_exaggeration_above_three_rejected():
+    # Previously le=10.0 accepted this; the frontend would silently render it as 3.
+    with pytest.raises(ValidationError):
+        TerrainConfig(exaggeration=3.5)
+
+
+def test_exaggeration_default_is_true_scale():
+    assert TerrainConfig().exaggeration == 1.0

--- a/scripts/seed-showcase.py
+++ b/scripts/seed-showcase.py
@@ -839,14 +839,18 @@ def build_matterhorn(api: Api, force: bool = False) -> str:
         )
         print(f"  + {len(peaks_fc['features'])} named peaks labeled")
     # Camera tightened onto the summit so the DEM-footprint edge (and its -10000 m
-    # void) stays out of frame; terrain exaggeration 1.6x.
+    # void) stays out of frame. Exaggeration is 1.0 (true vertical scale): the DEM
+    # has a small ~3 km footprint, so anything above 1.0 amplifies the "pedestal"
+    # (an isolated tower over the 0 m out-of-footprint plane) the moment the camera
+    # zooms out past this framing. The durable fix is a global base DEM (see the
+    # terrain pedestal plan); true scale is the correct interim default.
     api.set_view(
         map_id,
         visibility="public",
         terrain_config={
             "enabled": True,
             "source_dataset_id": vrt_ds,
-            "exaggeration": 1.6,
+            "exaggeration": 1.0,
         },
         center_lng=7.6586,
         center_lat=45.9750,


### PR DESCRIPTION
## Phase 0 of the small-DEM "pedestal" remediation

The Matterhorn 3D-terrain map renders as an isolated vertical **tower** when zoomed out: the swissALTI3D DEM has a ~3 km footprint, and MapLibre reads elevation **0 everywhere outside the DEM bounds**, so the mountain stands on a sea-level plane. `exaggeration: 1.6` amplified it.

This is **Phase 0** — interim mitigation + a latent contract fix. It does **not** fully remove the pedestal (that needs a global base DEM; tracked separately).

### Changes
- **`scripts/seed-showcase.py`** — Matterhorn terrain `exaggeration: 1.6 → 1.0` (true vertical scale). Anything >1.0 amplifies the pedestal past the tight default camera.
- **`TerrainConfig.exaggeration`** — `le=10.0 → le=3.0` to match the frontend `TERRAIN_EXAGGERATION_MAX` (`map-sync.ts`) and the DEM editor slider cap. The frontend clamps the rendered value to `[0, 3]`, so a stored value >3 silently rendered as 3. Now the stored value and the mesh agree.
- **New unit test** for the bound (≤3 accepted, >3 rejected, default 1.0).

### Notes
- Seeder change takes effect on the next demo reseed.
- Backend bound is a write-time tightening; the UI never allowed >3, so no real data is affected.
- Durable fix (composite the high-res DEM over a global base so the mesh is grounded everywhere) is the follow-up.

https://claude.ai/code/session_01ATqNfJXvg3zXfktncsNUdf