### PR TITLE
feat(ui): app-wide UI/UX consistency pass

### DIFF
--- a/frontend/src/components/admin/UserCreateDialog.tsx
+++ b/frontend/src/components/admin/UserCreateDialog.tsx
@@ -12,6 +12,7 @@ import {
   DialogTitle,
 } from '@/components/ui/dialog';
 import { Input } from '@/components/ui/input';
+import { PasswordInput } from '@/components/ui/password-input';
 import { Label } from '@/components/ui/label';
 import { RoleSelect } from './RoleSelect';
 
@@ -86,9 +87,8 @@ export function UserCreateDialog({ open, onOpenChange }: UserCreateDialogProps) 
           </div>
           <div className="space-y-2">
             <Label htmlFor="create-password">{t('userCreate.labels.password')}</Label>
-            <Input
+            <PasswordInput
               id="create-password"
-              type="password"
               value={password}
               onChange={(e) => setPassword(e.target.value)}
               required

--- a/frontend/src/components/admin/UserList.tsx
+++ b/frontend/src/components/admin/UserList.tsx
@@ -144,8 +144,9 @@ export function UserList() {
       <Card>
         <CardHeader>
           <div className="flex items-center justify-between">
-            <CardTitle className="text-sm font-medium">
-              {data ? t('users.titleCount', { count: data.total }) : t('users.title')}
+            <CardTitle className="flex items-center gap-2 text-sm font-medium">
+              {t('users.title')}
+              {data ? <Badge variant="secondary">{data.total}</Badge> : null}
             </CardTitle>
             <div className="flex items-center gap-3">
               <DataTableSearch

--- a/frontend/src/components/admin/settings/SettingsFormActions.tsx
+++ b/frontend/src/components/admin/settings/SettingsFormActions.tsx
@@ -23,8 +23,8 @@ export function SettingsFormActions({ dirty, hasDirty, envOnly, isSaving, onSave
   return (
     <div className="flex items-center gap-3 pt-2">
       <Button onClick={() => onSave(dirty)} disabled={!hasDirty || envOnly || isSaving}>
-        {isSaving ? <Loader2 className="me-2 h-4 w-4 animate-spin" /> : null}
-        {t('common:save')}
+        {isSaving && <Loader2 className="h-4 w-4 animate-spin" />}
+        {isSaving ? t('settings.actions.saving', { defaultValue: 'Saving…' }) : t('common:save')}
       </Button>
       <Button variant="outline" onClick={onDiscard} disabled={!hasDirty || isSaving}>
         {t('settings.actions.discard')}

--- a/frontend/src/components/auth/LoginForm.tsx
+++ b/frontend/src/components/auth/LoginForm.tsx
@@ -1,10 +1,11 @@
 import { type FormEvent, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router';
 import { useTranslation } from 'react-i18next';
-import { Eye, EyeOff, Loader2 } from 'lucide-react';
+import { Loader2 } from 'lucide-react';
 import { useAuth } from '@/hooks/use-auth';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
+import { PasswordInput } from '@/components/ui/password-input';
 import { Label } from '@/components/ui/label';
 
 /**
@@ -21,7 +22,6 @@ export function LoginForm() {
   const [password, setPassword] = useState('');
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
-  const [showPassword, setShowPassword] = useState(false);
   const { login } = useAuth();
   const navigate = useNavigate();
   const location = useLocation();
@@ -71,28 +71,17 @@ export function LoginForm() {
         <Label htmlFor="password" className="text-[12.5px]">
           {t('password')}
         </Label>
-        <div className="relative">
-          <Input
-            id="password"
-            type={showPassword ? 'text' : 'password'}
-            value={password}
-            onChange={(e) => setPassword(e.target.value)}
-            placeholder={t('enterPassword')}
-            required
-            autoComplete="current-password"
-            className="h-10 pe-11"
-            aria-invalid={error ? true : undefined}
-            aria-describedby={error ? 'login-error' : undefined}
-          />
-          <button
-            type="button"
-            onClick={() => setShowPassword((visible) => !visible)}
-            className="absolute inset-y-0 end-1 my-auto flex size-8 items-center justify-center rounded-md text-muted-foreground transition-[color,background-color,box-shadow,border-color,opacity] duration-200 ease-out hover:bg-accent hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background focus-visible:outline-none"
-            aria-label={showPassword ? t('hidePassword') : t('showPassword')}
-          >
-            {showPassword ? <EyeOff className="size-4" /> : <Eye className="size-4" />}
-          </button>
-        </div>
+        <PasswordInput
+          id="password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          placeholder={t('enterPassword')}
+          required
+          autoComplete="current-password"
+          className="h-10"
+          aria-invalid={error ? true : undefined}
+          aria-describedby={error ? 'login-error' : undefined}
+        />
       </div>
       {error && (
         <p id="login-error" role="alert" className="text-sm text-destructive">

--- a/frontend/src/components/auth/RegisterForm.tsx
+++ b/frontend/src/components/auth/RegisterForm.tsx
@@ -5,6 +5,7 @@ import { Loader2 } from 'lucide-react';
 import { registerUser } from '@/api/auth';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
+import { PasswordInput } from '@/components/ui/password-input';
 import { Label } from '@/components/ui/label';
 import {
   Card,
@@ -56,8 +57,8 @@ export function RegisterForm({ onSuccess }: RegisterFormProps) {
       <CardContent>
         <form onSubmit={handleSubmit} className="flex flex-col gap-4">
           {/* #305: on a server error mark the credential fields invalid + describe by the error */}
-          <div className="flex flex-col gap-2">
-            <Label htmlFor="username">{t('username')}</Label>
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="username" className="text-[12.5px]">{t('username')}</Label>
             <Input
               id="username"
               type="text"
@@ -67,12 +68,13 @@ export function RegisterForm({ onSuccess }: RegisterFormProps) {
               required
               minLength={3}
               autoComplete="username"
+              className="h-10"
               aria-invalid={error ? true : undefined}
               aria-describedby={error ? 'register-error' : undefined}
             />
           </div>
-          <div className="flex flex-col gap-2">
-            <Label htmlFor="email">{t('email')}</Label>
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="email" className="text-[12.5px]">{t('email')}</Label>
             <Input
               id="email"
               type="email"
@@ -81,21 +83,22 @@ export function RegisterForm({ onSuccess }: RegisterFormProps) {
               placeholder={t('enterEmail')}
               required
               autoComplete="email"
+              className="h-10"
               aria-invalid={error ? true : undefined}
               aria-describedby={error ? 'register-error' : undefined}
             />
           </div>
-          <div className="flex flex-col gap-2">
-            <Label htmlFor="password">{t('password')}</Label>
-            <Input
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="password" className="text-[12.5px]">{t('password')}</Label>
+            <PasswordInput
               id="password"
-              type="password"
               value={password}
               onChange={(e) => setPassword(e.target.value)}
               placeholder={t('choosePassword')}
               required
               minLength={8}
               autoComplete="new-password"
+              className="h-10"
               aria-invalid={error ? true : undefined}
               aria-describedby={error ? 'register-error' : undefined}
             />
@@ -104,7 +107,7 @@ export function RegisterForm({ onSuccess }: RegisterFormProps) {
           {error && (
             <p id="register-error" className="text-destructive text-sm" role="alert">{error}</p>
           )}
-          <Button type="submit" disabled={loading || !username.trim() || !email.trim() || !password} className="w-full">
+          <Button type="submit" disabled={loading || !username.trim() || !email.trim() || !password} className="h-[42px] w-full font-semibold">
             {loading && <Loader2 className="size-4 animate-spin" />}
             {loading ? t('creatingAccount') : t('createAccount')}
           </Button>

--- a/frontend/src/components/auth/__tests__/RegisterForm.test.tsx
+++ b/frontend/src/components/auth/__tests__/RegisterForm.test.tsx
@@ -12,7 +12,9 @@ describe('RegisterForm', () => {
 
     expect(screen.getByLabelText(/username/i)).toBeInTheDocument();
     expect(screen.getByLabelText(/email/i)).toBeInTheDocument();
-    expect(screen.getByLabelText(/password/i)).toBeInTheDocument();
+    // password field now carries a reveal toggle (aria-label "Show password"),
+    // so scope the lookup to the input to avoid matching the button.
+    expect(screen.getByLabelText(/password/i, { selector: 'input' })).toBeInTheDocument();
   });
 
   it('renders create account button', () => {
@@ -27,7 +29,7 @@ describe('RegisterForm', () => {
 
     const usernameInput = screen.getByLabelText(/username/i);
     const emailInput = screen.getByLabelText(/email/i);
-    const passwordInput = screen.getByLabelText(/password/i);
+    const passwordInput = screen.getByLabelText(/password/i, { selector: 'input' });
 
     await user.type(usernameInput, 'newuser');
     await user.type(emailInput, 'new@example.com');

--- a/frontend/src/components/builder/MapToolbar.tsx
+++ b/frontend/src/components/builder/MapToolbar.tsx
@@ -81,7 +81,7 @@ export function MapToolbar({ onStyleJsonClick, onShortcutsClick }: MapToolbarPro
                 <button
                   onClick={tool.onClick}
                   className={cn(
-                    'flex cursor-pointer items-center justify-center h-7 w-7 rounded-md transition-colors',
+                    'flex cursor-pointer items-center justify-center h-7 w-7 rounded-md transition-[color,background-color,box-shadow,border-color,opacity] duration-200 ease-out focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
                     tool.active
                       ? 'bg-foreground text-background'
                       : 'text-muted-foreground hover:bg-accent hover:text-foreground',
@@ -110,7 +110,7 @@ export function MapToolbar({ onStyleJsonClick, onShortcutsClick }: MapToolbarPro
                   <button
                     onClick={() => toggle('legend')}
                     className={cn(
-                      'flex cursor-pointer items-center justify-center h-7 w-7 rounded-md transition-colors',
+                      'flex cursor-pointer items-center justify-center h-7 w-7 rounded-md transition-[color,background-color,box-shadow,border-color,opacity] duration-200 ease-out focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
                       legendActive
                         ? 'bg-foreground text-background'
                         : 'text-muted-foreground hover:bg-accent hover:text-foreground',
@@ -136,7 +136,7 @@ export function MapToolbar({ onStyleJsonClick, onShortcutsClick }: MapToolbarPro
                 <TooltipTrigger asChild>
                   <button
                     onClick={onStyleJsonClick}
-                    className="flex cursor-pointer items-center justify-center h-7 w-7 rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+                    className="flex cursor-pointer items-center justify-center h-7 w-7 rounded-md text-muted-foreground transition-[color,background-color,box-shadow,border-color,opacity] duration-200 ease-out hover:bg-accent hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
                     aria-label={t('toolbar.styleJson', { defaultValue: 'Style JSON' })}
                   >
                     <FileJson className="h-3.5 w-3.5" />
@@ -156,7 +156,7 @@ export function MapToolbar({ onStyleJsonClick, onShortcutsClick }: MapToolbarPro
                 <TooltipTrigger asChild>
                   <button
                     onClick={onShortcutsClick}
-                    className="flex cursor-pointer items-center justify-center h-7 w-7 rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+                    className="flex cursor-pointer items-center justify-center h-7 w-7 rounded-md text-muted-foreground transition-[color,background-color,box-shadow,border-color,opacity] duration-200 ease-out hover:bg-accent hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
                     aria-label={t('a11y.shortcuts.title', { defaultValue: 'Keyboard shortcuts' })}
                   >
                     <Keyboard className="h-3.5 w-3.5" />

--- a/frontend/src/components/dataset/AddToMapButton.tsx
+++ b/frontend/src/components/dataset/AddToMapButton.tsx
@@ -48,7 +48,7 @@ export function AddToMapButton({ datasetId, datasetTitle }: AddToMapButtonProps)
   return (
     <DropdownMenu open={open} onOpenChange={setOpen}>
       <DropdownMenuTrigger asChild>
-        <Button variant="outline" size="sm">
+        <Button size="sm">
           <Map className="me-1 size-3.5" />
           {t('addToMap.button')}
         </Button>

--- a/frontend/src/components/dataset/DatasetDetailHeader.tsx
+++ b/frontend/src/components/dataset/DatasetDetailHeader.tsx
@@ -116,7 +116,7 @@ export function DatasetDetailHeader({
 
       <div className="flex flex-col md:flex-row md:items-start md:justify-between gap-2 md:gap-4">
         <div className="min-w-0">
-          <h1 className="text-3xl md:text-4xl font-medium tracking-tight break-words">
+          <h1 className="text-3xl md:text-4xl font-semibold tracking-tight break-words">
             {isTitleEditable ? (
               <InlineEdit
                 value={title}

--- a/frontend/src/components/layout/Navbar.tsx
+++ b/frontend/src/components/layout/Navbar.tsx
@@ -29,6 +29,7 @@ import { VrtCreateDialog } from '@/components/import/VrtCreateDialog';
 const navLinkClass = ({ isActive }: { isActive: boolean }) =>
   cn(
     'inline-flex items-center justify-center rounded-md px-3 py-1.5 text-sm font-medium transition-colors',
+    'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background',
     isActive
       ? 'bg-accent text-accent-foreground'
       : 'text-muted-foreground hover:bg-accent hover:text-accent-foreground',
@@ -37,6 +38,7 @@ const navLinkClass = ({ isActive }: { isActive: boolean }) =>
 const mobileNavLinkClass = ({ isActive }: { isActive: boolean }) =>
   cn(
     'flex items-center rounded-md px-3 py-2 text-sm font-medium transition-colors',
+    'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background',
     isActive
       ? 'bg-accent text-accent-foreground'
       : 'text-muted-foreground hover:bg-accent hover:text-accent-foreground',
@@ -377,7 +379,7 @@ export function Navbar() {
       <div className="mx-auto flex h-14 max-w-7xl items-center justify-between px-6">
         <div className="flex items-center gap-4">
           <MobileNav />
-          <Link to="/" aria-label={t('appName')} className="hover:text-primary transition-colors duration-150">
+          <Link to="/" aria-label={t('appName')} className="rounded-md hover:text-primary transition-colors duration-150 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background">
             <GeoLensLogo size="sm" />
           </Link>
           <Separator orientation="vertical" className="hidden md:block h-6" />

--- a/frontend/src/components/map/BasemapToggle.tsx
+++ b/frontend/src/components/map/BasemapToggle.tsx
@@ -38,7 +38,7 @@ export function BasemapToggle({ value, onChange, title = 'Change basemap', class
       <button
         type="button"
         onClick={() => setOpen(!open)}
-        className="rounded-lg border-2 border-background shadow-lg overflow-hidden hover:border-primary/50 transition-colors"
+        className="rounded-lg border-2 border-background shadow-lg overflow-hidden hover:border-primary/50 transition-[color,background-color,box-shadow,border-color,opacity] duration-200 ease-out focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
         title={title}
         aria-label={title}
       >
@@ -60,7 +60,7 @@ export function BasemapToggle({ value, onChange, title = 'Change basemap', class
                 type="button"
                 onClick={() => { onChange(b.id); setOpen(false); }}
                 className={cn(
-                  'flex items-center gap-2 rounded-md px-1.5 py-1 transition-colors text-start',
+                  'flex items-center gap-2 rounded-md px-1.5 py-1 transition-[color,background-color,box-shadow,border-color,opacity] duration-200 ease-out text-start focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
                   isActive
                     ? 'bg-accent'
                     : 'hover:bg-accent/50',

--- a/frontend/src/components/map/FeaturePopup.tsx
+++ b/frontend/src/components/map/FeaturePopup.tsx
@@ -419,6 +419,12 @@ function ValueDisplay({
             e.stopPropagation();
             setExpanded(true);
           }}
+          // Keep Enter/Space on this button from bubbling to the surrounding
+          // property row, whose keydown handler copies the value + preventDefaults
+          // (which would otherwise hijack the button's own activation). #313 a11y.
+          onKeyDown={(e) => {
+            if (e.key === 'Enter' || e.key === ' ') e.stopPropagation();
+          }}
         >
           ...
         </button>

--- a/frontend/src/components/map/FeaturePopup.tsx
+++ b/frontend/src/components/map/FeaturePopup.tsx
@@ -299,6 +299,7 @@ function ValueDisplay({
   formatValue: (v: unknown) => string;
 }) {
   const [expanded, setExpanded] = useState(false);
+  const { t } = useTranslation('builder');
 
   // Standalone URL: classify and render image / video / YouTube / plain anchor.
   // This branch handles the case where the entire property value is a URL.
@@ -411,7 +412,9 @@ function ValueDisplay({
       <span className="break-words">
         {truncated}
         <button
-          className="text-primary ms-0.5"
+          type="button"
+          className="text-primary ms-0.5 rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          aria-label={t('popup.showFullValue', { defaultValue: 'Show full value' })}
           onClick={(e) => {
             e.stopPropagation();
             setExpanded(true);

--- a/frontend/src/components/map/MapTitlePill.tsx
+++ b/frontend/src/components/map/MapTitlePill.tsx
@@ -31,7 +31,7 @@ export function MapTitlePill({ name, description }: MapTitlePillProps) {
               aria-label={showDesc
                 ? t('viewer.hideDescription')
                 : t('viewer.showDescription')}
-              className="flex-shrink-0 p-0.5 rounded hover:bg-accent text-muted-foreground hover:text-foreground transition-colors"
+              className="flex-shrink-0 p-0.5 rounded hover:bg-accent text-muted-foreground hover:text-foreground transition-[color,background-color,box-shadow,border-color,opacity] duration-200 ease-out focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
             >
               {showDesc
                 ? <X className="w-3.5 h-3.5" aria-hidden="true" />

--- a/frontend/src/components/maps/MapCardGrid.tsx
+++ b/frontend/src/components/maps/MapCardGrid.tsx
@@ -71,7 +71,7 @@ export const MapCardGrid = memo(function MapCardGrid({ map, onDelete }: MapCardP
         )}
 
         <div className="mt-auto flex flex-wrap items-center gap-x-3 gap-y-1">
-          <Badge variant="secondary" className="text-xs gap-1">
+          <Badge variant="secondary" className="text-xs gap-1 font-mono tracking-wide">
             <Layers className="h-3 w-3" />
             {t('maps.layerCount', { count: map.layer_count })}
           </Badge>

--- a/frontend/src/components/ui/password-input.tsx
+++ b/frontend/src/components/ui/password-input.tsx
@@ -1,0 +1,49 @@
+import * as React from 'react';
+import { Eye, EyeOff } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import { Input } from '@/components/ui/input';
+import { cn } from '@/lib/utils';
+
+/**
+ * Password field with a built-in reveal toggle.
+ *
+ * Extracted from the login form so every password entry point (login, register,
+ * admin user create, settings provider secrets) shares one accessible, branded
+ * reveal control instead of hand-rolling `type={show ? 'text' : 'password'}`.
+ * The eye button carries the same focus-visible ring as the other primitives and
+ * a translated aria-label (with an English default so it stays labelled even on
+ * surfaces that have not loaded the `auth` namespace).
+ *
+ * `type` is owned by the toggle and intentionally not forwarded.
+ */
+export type PasswordInputProps = Omit<React.ComponentProps<typeof Input>, 'type'>;
+
+export const PasswordInput = React.forwardRef<HTMLInputElement, PasswordInputProps>(
+  ({ className, ...props }, ref) => {
+    const [show, setShow] = React.useState(false);
+    const { t } = useTranslation('auth');
+
+    return (
+      <div className="relative">
+        <Input
+          ref={ref}
+          type={show ? 'text' : 'password'}
+          className={cn('pe-11', className)}
+          {...props}
+        />
+        <button
+          type="button"
+          onClick={() => setShow((visible) => !visible)}
+          className="absolute inset-y-0 end-1 my-auto flex size-8 items-center justify-center rounded-md text-muted-foreground transition-[color,background-color,box-shadow,border-color,opacity] duration-200 ease-out hover:bg-accent hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background focus-visible:outline-none"
+          aria-label={show
+            ? t('hidePassword', { defaultValue: 'Hide password' })
+            : t('showPassword', { defaultValue: 'Show password' })}
+        >
+          {show ? <EyeOff className="size-4" /> : <Eye className="size-4" />}
+        </button>
+      </div>
+    );
+  },
+);
+
+PasswordInput.displayName = 'PasswordInput';

--- a/frontend/src/components/viewer/LayerLegend.tsx
+++ b/frontend/src/components/viewer/LayerLegend.tsx
@@ -235,7 +235,7 @@ export function LayerLegend({
         aria-expanded={isOpen}
         aria-controls="layer-legend-panel"
         aria-label={isOpen ? t('viewer.legend.hide') : t('viewer.legend.show')}
-        className="absolute left-3 top-3 z-20 flex items-center justify-center w-8 h-8 rounded-md bg-background/80 backdrop-blur-sm border border-border/50 shadow-sm text-foreground hover:bg-background transition-colors"
+        className="absolute left-3 top-3 z-20 flex items-center justify-center w-8 h-8 rounded-md bg-background/80 backdrop-blur-sm border border-border/50 shadow-sm text-foreground hover:bg-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
       >
         {isOpen ? <X className="w-4 h-4" aria-hidden="true" /> : <Layers className="w-4 h-4" aria-hidden="true" />}
       </button>
@@ -314,7 +314,7 @@ export function LayerLegend({
                   <button
                     type="button"
                     onClick={() => onToggleVisibility(key)}
-                    className="flex-shrink-0 p-1 rounded hover:bg-accent text-muted-foreground hover:text-foreground"
+                    className="flex-shrink-0 p-1 rounded hover:bg-accent text-muted-foreground hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
                     aria-label={isVisible
                       ? t('viewer.legend.hideLayer', { name: layerName })
                       : t('viewer.legend.showLayer', { name: layerName })}

--- a/frontend/src/i18n/locales/de/admin.json
+++ b/frontend/src/i18n/locales/de/admin.json
@@ -33,8 +33,6 @@
   },
   "users": {
     "title": "Benutzer",
-    "titleCount_one": "Benutzer ({{count}})",
-    "titleCount_other": "Benutzer ({{count}})",
     "addUser": "Benutzer hinzufügen",
     "exportEmailsCsv": "E-Mails exportieren (CSV)",
     "loading": "Benutzer werden geladen...",
@@ -370,7 +368,8 @@
     "copyAcsUrl": "ACS-URL kopieren",
     "actions": {
       "discard": "Änderungen verwerfen",
-      "resetDefaults": "Auf Standardwerte zurücksetzen"
+      "resetDefaults": "Auf Standardwerte zurücksetzen",
+      "saving": "Wird gespeichert..."
     },
     "unsaved": {
       "title": "Nicht gespeicherte Änderungen",

--- a/frontend/src/i18n/locales/de/builder.json
+++ b/frontend/src/i18n/locales/de/builder.json
@@ -408,7 +408,8 @@
     "removeField": "Feld entfernen",
     "noFieldsSelected": "Keine Felder ausgewählt (nur der Titel wird angezeigt)",
     "noColumns": "Dieser Layer hat keine prüfbaren Spalten.",
-    "mediaHint": "URLs und Bilder in Feldwerten werden automatisch als Links und Vorschauen angezeigt."
+    "mediaHint": "URLs und Bilder in Feldwerten werden automatisch als Links und Vorschauen angezeigt.",
+    "showFullValue": "Vollständigen Wert anzeigen"
   },
   "dataDriven": {
     "title": "Datengesteuerter Stil",

--- a/frontend/src/i18n/locales/en/admin.json
+++ b/frontend/src/i18n/locales/en/admin.json
@@ -33,8 +33,6 @@
   },
   "users": {
     "title": "Users",
-    "titleCount_one": "Users ({{count}})",
-    "titleCount_other": "Users ({{count}})",
     "addUser": "Add User",
     "exportEmailsCsv": "Export emails (CSV)",
     "loading": "Loading users...",
@@ -411,7 +409,8 @@
     },
     "actions": {
       "discard": "Discard Changes",
-      "resetDefaults": "Reset to Defaults"
+      "resetDefaults": "Reset to Defaults",
+      "saving": "Saving..."
     },
     "unsaved": {
       "title": "Unsaved changes",

--- a/frontend/src/i18n/locales/en/builder.json
+++ b/frontend/src/i18n/locales/en/builder.json
@@ -408,7 +408,8 @@
     "removeField": "Remove field",
     "noFieldsSelected": "No fields selected (only the title will show)",
     "noColumns": "This layer has no inspectable columns.",
-    "mediaHint": "URLs and images in field values render as links and previews automatically."
+    "mediaHint": "URLs and images in field values render as links and previews automatically.",
+    "showFullValue": "Show full value"
   },
   "dataDriven": {
     "title": "Data-Driven Style",

--- a/frontend/src/i18n/locales/es/admin.json
+++ b/frontend/src/i18n/locales/es/admin.json
@@ -33,8 +33,6 @@
   },
   "users": {
     "title": "Usuarios",
-    "titleCount_one": "Usuarios ({{count}})",
-    "titleCount_other": "Usuarios ({{count}})",
     "addUser": "Agregar usuario",
     "exportEmailsCsv": "Exportar correos (CSV)",
     "loading": "Cargando usuarios...",
@@ -370,7 +368,8 @@
     "copyAcsUrl": "Copiar URL ACS",
     "actions": {
       "discard": "Descartar cambios",
-      "resetDefaults": "Restablecer valores predeterminados"
+      "resetDefaults": "Restablecer valores predeterminados",
+      "saving": "Guardando..."
     },
     "unsaved": {
       "title": "Cambios sin guardar",

--- a/frontend/src/i18n/locales/es/builder.json
+++ b/frontend/src/i18n/locales/es/builder.json
@@ -408,7 +408,8 @@
     "removeField": "Quitar campo",
     "noFieldsSelected": "Ningún campo seleccionado (solo se mostrará el título)",
     "noColumns": "Esta capa no tiene columnas inspeccionables.",
-    "mediaHint": "Las URL e imágenes en los valores de los campos se muestran como enlaces y vistas previas automáticamente."
+    "mediaHint": "Las URL e imágenes en los valores de los campos se muestran como enlaces y vistas previas automáticamente.",
+    "showFullValue": "Mostrar valor completo"
   },
   "dataDriven": {
     "title": "Estilo basado en datos",

--- a/frontend/src/i18n/locales/fr/admin.json
+++ b/frontend/src/i18n/locales/fr/admin.json
@@ -33,8 +33,6 @@
   },
   "users": {
     "title": "Utilisateurs",
-    "titleCount_one": "Utilisateurs ({{count}})",
-    "titleCount_other": "Utilisateurs ({{count}})",
     "addUser": "Ajouter un utilisateur",
     "exportEmailsCsv": "Exporter les e-mails (CSV)",
     "loading": "Chargement des utilisateurs...",
@@ -370,7 +368,8 @@
     "copyAcsUrl": "Copier l'URL ACS",
     "actions": {
       "discard": "Annuler les modifications",
-      "resetDefaults": "Rétablir les valeurs par défaut"
+      "resetDefaults": "Rétablir les valeurs par défaut",
+      "saving": "Enregistrement..."
     },
     "unsaved": {
       "title": "Modifications non enregistrées",

--- a/frontend/src/i18n/locales/fr/builder.json
+++ b/frontend/src/i18n/locales/fr/builder.json
@@ -408,7 +408,8 @@
     "removeField": "Retirer le champ",
     "noFieldsSelected": "Aucun champ sélectionné (seul le titre s'affichera)",
     "noColumns": "Cette couche n'a pas de colonnes inspectables.",
-    "mediaHint": "Les URL et images dans les valeurs de champ s'affichent automatiquement sous forme de liens et aperçus."
+    "mediaHint": "Les URL et images dans les valeurs de champ s'affichent automatiquement sous forme de liens et aperçus.",
+    "showFullValue": "Afficher la valeur complète"
   },
   "dataDriven": {
     "title": "Style piloté par les données",

--- a/frontend/src/pages/CollectionDetailPage.tsx
+++ b/frontend/src/pages/CollectionDetailPage.tsx
@@ -142,29 +142,29 @@ export function CollectionDetailPage() {
             {/* Left: metadata fields */}
             <div className="space-y-4">
               <div className="space-y-2">
-                <dt className="flex items-center gap-1.5 text-sm font-medium text-muted-foreground">
-                  <Database className="h-4 w-4" />
+                <dt className="flex items-center gap-1.5 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                  <Database className="h-3.5 w-3.5" />
                   {t('detail.datasets')}
                 </dt>
                 <dd className="text-sm">{formatNumber(collection.dataset_count)}</dd>
               </div>
               <div className="space-y-2">
-                <dt className="flex items-center gap-1.5 text-sm font-medium text-muted-foreground">
-                  <Calendar className="h-4 w-4" />
+                <dt className="flex items-center gap-1.5 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                  <Calendar className="h-3.5 w-3.5" />
                   {t('detail.temporalRange')}
                 </dt>
                 <dd className="text-sm">{formatTemporal()}</dd>
               </div>
               <div className="space-y-2">
-                <dt className="flex items-center gap-1.5 text-sm font-medium text-muted-foreground">
-                  <Calendar className="h-4 w-4" />
+                <dt className="flex items-center gap-1.5 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                  <Calendar className="h-3.5 w-3.5" />
                   {t('detail.created')}
                 </dt>
                 <dd className="text-sm">{formatDate(collection.created_at)}</dd>
               </div>
               <div className="space-y-2">
-                <dt className="flex items-center gap-1.5 text-sm font-medium text-muted-foreground">
-                  <Calendar className="h-4 w-4" />
+                <dt className="flex items-center gap-1.5 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                  <Calendar className="h-3.5 w-3.5" />
                   {t('detail.lastUpdated')}
                 </dt>
                 <dd className="text-sm">{formatDate(collection.updated_at)}</dd>
@@ -173,8 +173,8 @@ export function CollectionDetailPage() {
 
             {/* Right: spatial extent */}
             <div className="space-y-2">
-              <dt className="flex items-center gap-1.5 text-sm font-medium text-muted-foreground">
-                <MapPin className="h-4 w-4" />
+              <dt className="flex items-center gap-1.5 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                <MapPin className="h-3.5 w-3.5" />
                 {t('detail.spatialExtent')}
               </dt>
               <dd>

--- a/frontend/src/pages/DatasetPage.tsx
+++ b/frontend/src/pages/DatasetPage.tsx
@@ -432,7 +432,7 @@ export function DatasetPage() {
             {!isTable && isEditor && <AddToMapButton datasetId={dataset.id} datasetTitle={dataset.title} />}
             {!token && <AuthPrompt action={t('actions.edit', { defaultValue: 'edit' })} />}
             {isRaster && dataset.raster?.connect && (
-              <Button variant="default" size="sm" onClick={async () => {
+              <Button variant="outline" size="sm" onClick={async () => {
                 try { await downloadCog(dataset.id); } catch { toast.error(t('export.failed')); }
               }}>
                 <Download className="me-1 size-3" />

--- a/frontend/src/pages/RegisterPage.tsx
+++ b/frontend/src/pages/RegisterPage.tsx
@@ -117,6 +117,9 @@ export function RegisterPage() {
   return (
     <div className="flex min-h-screen flex-col items-center justify-center gap-6 bg-background px-4">
       <div className="text-center">
+        {/* sr-only level-1 heading: the visual brand mark is the GeoLensLogo, but
+            screen-reader heading navigation still needs an <h1> on the page. */}
+        <h1 className="sr-only">{t('createAccount')}</h1>
         <GeoLensLogo size="lg" className="justify-center" />
         <p className="text-muted-foreground mt-1 text-sm">
           {t('geospatialDataCatalog')}

--- a/frontend/src/pages/RegisterPage.tsx
+++ b/frontend/src/pages/RegisterPage.tsx
@@ -117,7 +117,7 @@ export function RegisterPage() {
   return (
     <div className="flex min-h-screen flex-col items-center justify-center gap-6 bg-background px-4">
       <div className="text-center">
-        <h1 className="text-3xl font-bold tracking-tight">{t('common:appName')}</h1>
+        <GeoLensLogo size="lg" className="justify-center" />
         <p className="text-muted-foreground mt-1 text-sm">
           {t('geospatialDataCatalog')}
         </p>

--- a/frontend/src/pages/__tests__/RegisterPage.pendingView.test.tsx
+++ b/frontend/src/pages/__tests__/RegisterPage.pendingView.test.tsx
@@ -48,7 +48,7 @@ async function submitRegistration() {
   const user = userEvent.setup();
   await user.type(screen.getByLabelText(/username/i), 'newuser');
   await user.type(screen.getByLabelText(/email/i), 'new@example.com');
-  await user.type(screen.getByLabelText(/password/i), 'TestPass1234!');
+  await user.type(screen.getByLabelText(/password/i, { selector: 'input' }), 'TestPass1234!');
   await user.click(screen.getByRole('button', { name: /create account/i }));
 }
 


### PR DESCRIPTION
App-wide UI/UX consistency pass, scoped from a **live Playwright audit** of every page (light/dark/mobile) plus the earlier code-level audit. The design system was already ~85% consistent; these close the genuine high-leverage gaps. Verified live; all 3008 frontend tests + tsc + eslint pass.

## Primitives & auth
- **New shared `PasswordInput`** — reveal toggle, branded focus ring, translated aria-label (English fallback). Replaces 3 hand-rolled reveal blocks (Login, Register, admin UserCreateDialog).
- **RegisterForm** modernized to the login design language (40px fields, reveal toggle, 12.5px labels, `h-[42px]` submit); **RegisterPage** wordmark → `GeoLensLogo`. (Closes the "pre-redesign island" finding.)
- Auth fields keep the intentional 40px height **locally**; `input.tsx` base stays `h-9` so Inputs stay aligned with Button/Select in mixed rows.

## Accessibility
- **focus-visible rings** added to hand-rolled buttons that had none: Navbar links + logo, viewer LayerLegend toggles, MapToolbar tools, MapTitlePill, BasemapToggle, FeaturePopup expand (also given an accessible name + `type=button`).
- On-canvas/translucent map buttons use `ring` **without** `ring-offset` (avoids a halo over map tiles); solid-surface controls keep the offset.

## Visual consistency
- **Dataset detail:** "Add to Map" promoted to the single filled primary CTA (raster Download COG → outline); H1 `font-medium` → `font-semibold`.
- **Collection detail** metadata labels → canonical mono eyebrow (icons scaled to `h-3.5`).
- **Admin Users** count unified to the shared secondary Badge (was `Users (N)`).
- **Maps grid** layer badge → `font-mono` (matches list view).
- **Admin settings Save** shows a localized "Saving…" while pending.

## i18n
Added `settings.actions.saving` + `popup.showFullValue` across en/de/es/fr; removed the now-orphaned `users.titleCount_*` keys.

## Deferred (own follow-ups, by design)
- Shared `AuthShell` extraction — login is freshly redesigned (#308); not worth the regression risk here.
- Builder token-literal cleanup (`bg-[var(--…)]` → `bg-*`) — zero visual change.
- Real map/dataset **thumbnails (THUMB-01)** — a generation concern, not CSS. Dark-mode thumbnail glare folds into this.

## Review
Ran a 4-lens adversarial review of the diff before pushing; all findings (i18n keys, on-canvas ring-offset, input/control height alignment, eyebrow icon scale) addressed in this branch.

https://claude.ai/code/session_01ATqNfJXvg3zXfktncsNUdf