### PR TITLE
fix(api): smoke-check backlog — OGC raster hardening, search pagination, column stats, param validation

### DIFF
--- a/backend/app/api/main.py
+++ b/backend/app/api/main.py
@@ -460,6 +460,14 @@ app.state.limiter = limiter
 
 
 async def _rate_limit_handler(request: Request, exc: RateLimitExceeded) -> JSONResponse:
+    # B5b: advertise the window so clients can back off. slowapi knows the
+    # window via exc.limit.limit.get_expiry() (seconds). Guard the lookup so a
+    # surprise in slowapi internals can never turn the 429 into a 500.
+    headers = {}
+    try:
+        headers["Retry-After"] = str(int(exc.limit.limit.get_expiry()))
+    except Exception:
+        pass
     return JSONResponse(
         status_code=status.HTTP_429_TOO_MANY_REQUESTS,
         content=ProblemDetail(
@@ -468,6 +476,7 @@ async def _rate_limit_handler(request: Request, exc: RateLimitExceeded) -> JSONR
             detail=str(exc.detail),
         ).model_dump(),
         media_type="application/problem+json",
+        headers=headers,
     )
 
 

--- a/backend/app/api/main.py
+++ b/backend/app/api/main.py
@@ -460,7 +460,7 @@ app.state.limiter = limiter
 
 
 async def _rate_limit_handler(request: Request, exc: RateLimitExceeded) -> JSONResponse:
-    # B5b: advertise the retry window (exc.limit.limit.get_expiry(), seconds).
+    # fix(#315): advertise the retry window (exc.limit.limit.get_expiry(), seconds).
     headers = {}
     try:
         headers["Retry-After"] = str(int(exc.limit.limit.get_expiry()))

--- a/backend/app/api/main.py
+++ b/backend/app/api/main.py
@@ -460,13 +460,11 @@ app.state.limiter = limiter
 
 
 async def _rate_limit_handler(request: Request, exc: RateLimitExceeded) -> JSONResponse:
-    # B5b: advertise the window so clients can back off. slowapi knows the
-    # window via exc.limit.limit.get_expiry() (seconds). Guard the lookup so a
-    # surprise in slowapi internals can never turn the 429 into a 500.
+    # B5b: advertise the retry window (exc.limit.limit.get_expiry(), seconds).
     headers = {}
     try:
         headers["Retry-After"] = str(int(exc.limit.limit.get_expiry()))
-    except Exception:
+    except Exception:  # broad: never let the optional Retry-After lookup 500 a 429
         pass
     return JSONResponse(
         status_code=status.HTTP_429_TOO_MANY_REQUESTS,

--- a/backend/app/modules/catalog/datasets/api/router_metadata.py
+++ b/backend/app/modules/catalog/datasets/api/router_metadata.py
@@ -400,10 +400,18 @@ async def create_dataset_relationship(
 
     from app.modules.catalog.datasets.domain.models import Dataset
 
+    # Accept either a Dataset.id (what list/create responses return) or the
+    # underlying record_id (the original input contract) so a relationship id
+    # round-trips back into a create call. fix(#315)
     target_result = await db.execute(
-        select(Dataset).where(Dataset.record_id == body.target_dataset_id)
+        select(Dataset).where(Dataset.id == body.target_dataset_id)
     )
     target_dataset = target_result.scalar_one_or_none()
+    if target_dataset is None:
+        target_result = await db.execute(
+            select(Dataset).where(Dataset.record_id == body.target_dataset_id)
+        )
+        target_dataset = target_result.scalar_one_or_none()
     if target_dataset is None:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND, detail="Target dataset not found"
@@ -412,14 +420,14 @@ async def create_dataset_relationship(
         db, target_dataset, target_dataset.id, current_user, user_roles=user_roles
     )
 
+    # Normalize the target to its record_id (the FK column references
+    # catalog.records.id) regardless of which id form the client supplied.
+    body = body.model_copy(update={"target_dataset_id": target_dataset.record_id})
     rel = await create_relationship(db, dataset.record_id, body)
     await db.commit()
-    # The relationship FK columns store catalog.records.id, but the response must
-    # carry dereferenceable Dataset.id values so /collections/{id} resolves them,
-    # matching the LIST path (_visible_relationships, B5d). We already resolved
-    # both endpoints to Dataset objects above. The create INPUT still accepts a
-    # record_id target (DatasetRelationshipCreate.target_dataset_id) — that input
-    # asymmetry is intentional and unchanged; only the RESPONSE ids change here.
+    # The relationship FK columns store catalog.records.id, but the response
+    # carries dereferenceable Dataset.id values so /collections/{id} resolves
+    # them, matching the LIST path (_visible_relationships). fix(#315)
     return DatasetRelationshipResponse(
         id=rel.id,
         source_dataset_id=dataset.id,

--- a/backend/app/modules/catalog/datasets/api/router_metadata.py
+++ b/backend/app/modules/catalog/datasets/api/router_metadata.py
@@ -414,7 +414,24 @@ async def create_dataset_relationship(
 
     rel = await create_relationship(db, dataset.record_id, body)
     await db.commit()
-    return DatasetRelationshipResponse.model_validate(rel)
+    # The relationship FK columns store catalog.records.id, but the response must
+    # carry dereferenceable Dataset.id values so /collections/{id} resolves them,
+    # matching the LIST path (_visible_relationships, B5d). We already resolved
+    # both endpoints to Dataset objects above. The create INPUT still accepts a
+    # record_id target (DatasetRelationshipCreate.target_dataset_id) — that input
+    # asymmetry is intentional and unchanged; only the RESPONSE ids change here.
+    return DatasetRelationshipResponse(
+        id=rel.id,
+        source_dataset_id=dataset.id,
+        target_dataset_id=target_dataset.id,
+        source_column=rel.source_column,
+        target_column=rel.target_column,
+        relationship_type=rel.relationship_type,
+        label=rel.label,
+        target_dataset_title=target_dataset.record.title
+        if target_dataset.record
+        else None,
+    )
 
 
 @router.delete("/relationships/{relationship_id}/", status_code=204)

--- a/backend/app/modules/catalog/datasets/domain/column_stats.py
+++ b/backend/app/modules/catalog/datasets/domain/column_stats.py
@@ -7,6 +7,21 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 _IDENTIFIER_RE = re.compile(r"^[a-z][a-z0-9_]*$", re.IGNORECASE)
 
+# Postgres data_type values (from information_schema.columns) on which the
+# numeric MIN/MAX/AVG/percentile/stddev aggregation is valid. Anything else
+# (text, varchar, uuid, bool, etc.) is treated categorically so a stats request
+# on a text column returns a valid response instead of a 500.
+_NUMERIC_TYPES = {
+    "smallint",
+    "integer",
+    "bigint",
+    "decimal",
+    "numeric",
+    "real",
+    "double precision",
+    "money",
+}
+
 
 def _validate_identifier(name: str, label: str) -> None:
     """Validate a SQL identifier to prevent injection.
@@ -183,13 +198,49 @@ async def get_column_stats(
     if allowed_tables is not None and table_name not in allowed_tables:
         raise PermissionError(f"Access denied to table: {table_name!r}")
 
+    # Detect the column's data type so we never cast a text column ::numeric
+    # (which raises a DataError -> 500). Reuses the information_schema lookup
+    # pattern from get_column_null_cardinality.
+    type_result = await session.execute(
+        text(
+            "SELECT data_type FROM information_schema.columns "
+            "WHERE table_schema = 'data' AND table_name = :t "
+            "AND column_name = :c"
+        ).bindparams(t=table_name, c=column_name)
+    )
+    data_type = type_result.scalar_one_or_none()
+    if data_type is None:
+        raise ValueError(f"Column not found: {column_name!r}")
+
+    col_q = _sql_quote_ident(column_name)
+    tbl_q = _qtable(table_name)
+
+    if data_type not in _NUMERIC_TYPES:
+        # Non-numeric column: numeric aggregates are undefined, so return a
+        # categorical summary (row count + distinct count) instead of casting
+        # to ::numeric. Numeric fields are null/empty.
+        cat_sql = text(
+            f"SELECT COUNT({col_q}), COUNT(DISTINCT {col_q}) "
+            f"FROM {tbl_q} "
+            f"WHERE {col_q} IS NOT NULL"
+        )
+        cat_row = (await session.execute(cat_sql)).one()
+        return {
+            "min": None,
+            "max": None,
+            "count": int(cat_row[0]) if cat_row[0] is not None else 0,
+            "mean": None,
+            "quantiles": [],
+            "stddev": None,
+            "data_type": "categorical",
+            "distinct_count": int(cat_row[1]) if cat_row[1] is not None else 0,
+        }
+
     # Compute quantile fractions dynamically based on class_count
     fractions = [round(i / class_count, 4) for i in range(1, class_count)]
     fractions_str = ", ".join(str(f) for f in fractions)
 
     # Combined stats + quantiles in a single query (single table scan)
-    col_q = _sql_quote_ident(column_name)
-    tbl_q = _qtable(table_name)
     combined_sql = text(
         f"SELECT MIN({col_q}::numeric), MAX({col_q}::numeric), "
         f"COUNT({col_q}), AVG({col_q}::numeric), "

--- a/backend/app/modules/catalog/datasets/domain/schemas.py
+++ b/backend/app/modules/catalog/datasets/domain/schemas.py
@@ -542,6 +542,14 @@ class ColumnStatsResponse(BaseModel):
     mean: float | None = None
     quantiles: list[float] = []
     stddev: float | None = None
+    data_type: str | None = Field(
+        default=None,
+        description="'categorical' for non-numeric columns; null for numeric.",
+    )
+    distinct_count: int | None = Field(
+        default=None,
+        description="Distinct non-null value count (categorical columns only).",
+    )
 
 
 class AttributeMetadataResponse(BaseModel):

--- a/backend/app/modules/catalog/datasets/domain/service_relationships.py
+++ b/backend/app/modules/catalog/datasets/domain/service_relationships.py
@@ -218,7 +218,7 @@ async def _visible_relationships(
         visible_items.append(
             {
                 "id": rel.id,
-                # B5d: emit dereferenceable Dataset.id, not the stored record_id.
+                # fix(#315): emit dereferenceable Dataset.id, not the stored record_id.
                 "source_dataset_id": source_dataset_id,
                 "target_dataset_id": target_ds.id,
                 "source_column": rel.source_column,

--- a/backend/app/modules/catalog/datasets/domain/service_relationships.py
+++ b/backend/app/modules/catalog/datasets/domain/service_relationships.py
@@ -187,14 +187,10 @@ async def _visible_relationships(
     """
     from app.modules.catalog.datasets.domain.models import DatasetRelationship
 
-    # The relationship FK columns store catalog.records.id (record_id), but every
-    # dereferenceable endpoint (e.g. /collections/{id}) resolves by Dataset.id.
-    # Resolve the source dataset's Dataset.id once (dataset_id is the source's
-    # record_id, passed down from the router) so the response carries
-    # dereferenceable ids. NOTE: the create-input side
-    # (create_dataset_relationship / DatasetRelationshipCreate) still resolves
-    # target_dataset_id by record_id — that asymmetry is intentional in this
-    # minimal fix and is not changed here.
+    # FK columns store record_id, but dereferenceable endpoints resolve by
+    # Dataset.id, so resolve the source's Dataset.id (dataset_id is its record_id)
+    # for the response. (Create-input still takes target_dataset_id as a
+    # record_id — intentional asymmetry, unchanged here.)
     source_dataset_id = (
         await session.execute(select(Dataset.id).where(Dataset.record_id == dataset_id))
     ).scalar_one_or_none()
@@ -222,8 +218,7 @@ async def _visible_relationships(
         visible_items.append(
             {
                 "id": rel.id,
-                # Emit Dataset.id (dereferenceable) instead of the stored
-                # record_id so /collections/{id} resolves these (B5d fix).
+                # B5d: emit dereferenceable Dataset.id, not the stored record_id.
                 "source_dataset_id": source_dataset_id,
                 "target_dataset_id": target_ds.id,
                 "source_column": rel.source_column,

--- a/backend/app/modules/catalog/datasets/domain/service_relationships.py
+++ b/backend/app/modules/catalog/datasets/domain/service_relationships.py
@@ -187,6 +187,18 @@ async def _visible_relationships(
     """
     from app.modules.catalog.datasets.domain.models import DatasetRelationship
 
+    # The relationship FK columns store catalog.records.id (record_id), but every
+    # dereferenceable endpoint (e.g. /collections/{id}) resolves by Dataset.id.
+    # Resolve the source dataset's Dataset.id once (dataset_id is the source's
+    # record_id, passed down from the router) so the response carries
+    # dereferenceable ids. NOTE: the create-input side
+    # (create_dataset_relationship / DatasetRelationshipCreate) still resolves
+    # target_dataset_id by record_id — that asymmetry is intentional in this
+    # minimal fix and is not changed here.
+    source_dataset_id = (
+        await session.execute(select(Dataset.id).where(Dataset.record_id == dataset_id))
+    ).scalar_one_or_none()
+
     # Inner-join Dataset (and its Record, eager-loaded via lazy="joined") so the
     # target dataset object is available for the access check below. Relationships
     # whose target has no backing Dataset are dropped (fail-closed).
@@ -210,8 +222,10 @@ async def _visible_relationships(
         visible_items.append(
             {
                 "id": rel.id,
-                "source_dataset_id": rel.source_dataset_id,
-                "target_dataset_id": rel.target_dataset_id,
+                # Emit Dataset.id (dereferenceable) instead of the stored
+                # record_id so /collections/{id} resolves these (B5d fix).
+                "source_dataset_id": source_dataset_id,
+                "target_dataset_id": target_ds.id,
                 "source_column": rel.source_column,
                 "target_column": rel.target_column,
                 "relationship_type": rel.relationship_type,

--- a/backend/app/modules/catalog/features/router.py
+++ b/backend/app/modules/catalog/features/router.py
@@ -68,6 +68,18 @@ async def get_features_geojson_z_endpoint(
 
     await check_dataset_access(db, dataset, dataset_id, user)
 
+    # B1: raster/VRT datasets have no backing PostGIS feature table, so a feature
+    # query would raise UndefinedTableError -> 500 (and hold a DB connection).
+    # Return a fast 404 before any feature query is attempted (mirrors OGC contract).
+    if dataset.record.record_type in ("raster_dataset", "vrt_dataset"):
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=(
+                f"Dataset '{dataset_id}' is a raster collection and has no "
+                "feature items; use the tile/coverage endpoints instead."
+            ),
+        )
+
     if dataset.geometry_type is None:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
@@ -144,6 +156,19 @@ async def list_features(
 
     # RBAC check
     await check_dataset_access(db, dataset, dataset_id, user)
+
+    # B1: raster/VRT datasets have no backing PostGIS feature table, so a feature
+    # query would raise UndefinedTableError. Return a fast 404 before any query
+    # (mirrors OGC contract). The ProgrammingError->503 catch below remains a
+    # backstop for genuinely-missing tables on non-raster datasets.
+    if dataset.record.record_type in ("raster_dataset", "vrt_dataset"):
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=(
+                f"Dataset '{dataset_id}' is a raster collection and has no "
+                "feature items; use the tile/coverage endpoints instead."
+            ),
+        )
 
     # Parse bbox
     parsed_bbox: list[float] | None = None
@@ -283,6 +308,19 @@ async def get_single_feature(
 
     # RBAC check
     await check_dataset_access(db, dataset, dataset_id, user)
+
+    # B1: raster/VRT datasets have no backing PostGIS feature table, so
+    # get_feature_by_id would raise UndefinedTableError -> unhandled 500 (a DoS
+    # reachable by any authenticated user). Return a fast 404 before any query
+    # (mirrors OGC contract).
+    if dataset.record.record_type in ("raster_dataset", "vrt_dataset"):
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=(
+                f"Dataset '{dataset_id}' is a raster collection and has no "
+                "feature items; use the tile/coverage endpoints instead."
+            ),
+        )
 
     has_geometry = dataset.geometry_type is not None
 

--- a/backend/app/modules/catalog/features/router.py
+++ b/backend/app/modules/catalog/features/router.py
@@ -68,7 +68,7 @@ async def get_features_geojson_z_endpoint(
 
     await check_dataset_access(db, dataset, dataset_id, user)
 
-    # B1: raster/VRT datasets have no backing PostGIS feature table, so a feature
+    # fix(#315): raster/VRT datasets have no backing PostGIS feature table, so a feature
     # query would raise UndefinedTableError -> 500 (and hold a DB connection).
     # Return a fast 404 before any feature query is attempted (mirrors OGC contract).
     if dataset.record.record_type in ("raster_dataset", "vrt_dataset"):
@@ -157,7 +157,7 @@ async def list_features(
     # RBAC check
     await check_dataset_access(db, dataset, dataset_id, user)
 
-    # B1: raster/VRT datasets have no backing PostGIS feature table, so a feature
+    # fix(#315): raster/VRT datasets have no backing PostGIS feature table, so a feature
     # query would raise UndefinedTableError. Return a fast 404 before any query
     # (mirrors OGC contract). The ProgrammingError->503 catch below remains a
     # backstop for genuinely-missing tables on non-raster datasets.
@@ -309,7 +309,7 @@ async def get_single_feature(
     # RBAC check
     await check_dataset_access(db, dataset, dataset_id, user)
 
-    # B1: raster/VRT datasets have no backing PostGIS feature table, so
+    # fix(#315): raster/VRT datasets have no backing PostGIS feature table, so
     # get_feature_by_id would raise UndefinedTableError -> unhandled 500 (a DoS
     # reachable by any authenticated user). Return a fast 404 before any query
     # (mirrors OGC contract).

--- a/backend/app/modules/catalog/search/router.py
+++ b/backend/app/modules/catalog/search/router.py
@@ -419,7 +419,7 @@ async def _handle_search(
         and not params.collection_id
     )
 
-    # B5c/OGC-4: count matching collections on EVERY page so numberMatched stays
+    # fix(#315): count matching collections on EVERY page so numberMatched stays
     # stable; ``total`` (dataset-only) still drives the next-link, since appended
     # collections are a page-0-only augmentation that is never paginated. Cap the
     # count at the page-0 display limit so numberMatched never claims more
@@ -529,7 +529,7 @@ async def _handle_search(
         timeStamp=datetime.now(timezone.utc)
         .isoformat(timespec="seconds")
         .replace("+00:00", "Z"),
-        # B5c/OGC-4: dataset total + full collection count = stable across pages
+        # fix(#315): dataset total + full collection count = stable across pages
         # and always >= numberReturned (page 0 shows <=5 collections; later none).
         numberMatched=total + collection_total,
         numberReturned=len(features),
@@ -1045,8 +1045,9 @@ async def list_collections(
                 ]
             }
 
-        # B1/OGC-1: raster/VRT have no feature table -> mirror the detail endpoint
-        # (itemType=coverage, omit rel=items) so crawlers skip the dead /items.
+        # fix(#315): raster/VRT have no feature table -> mirror the detail
+        # endpoint (itemType=coverage, omit rel=items, add rel=tiles) so crawlers
+        # starting from the list skip the dead /items and still find the data.
         is_raster = ds.record.record_type in ("raster_dataset", "vrt_dataset")
 
         links: list[dict] = [
@@ -1068,6 +1069,17 @@ async def list_collections(
                         base_url=public_api_url,
                     ),
                     "type": "application/geo+json",
+                }
+            )
+        else:
+            links.append(
+                {
+                    "rel": "tiles",
+                    "href": build_url(
+                        f"/raster-tiles/{ds.id}/tiles/{{z}}/{{x}}/{{y}}.png",
+                        base_url=public_api_url,
+                    ),
+                    "type": "image/png",
                 }
             )
         links.append(

--- a/backend/app/modules/catalog/search/router.py
+++ b/backend/app/modules/catalog/search/router.py
@@ -46,7 +46,7 @@ from app.standards.ogc.utils import (
     content_language_for_record_languages,
     normalize_language_tag,
 )
-from app.core.public_urls import get_public_api_url
+from app.core.public_urls import get_public_api_url, get_public_app_url
 from geoalchemy2.shape import to_shape
 from app.modules.catalog.search.schemas import (
     FacetCountResponse,
@@ -991,6 +991,9 @@ async def list_collections(
 ) -> OGCCollectionsResponse:
     """List available OGC collections (catalog + per-dataset feature collections)."""
     public_api_url = await get_public_api_url(db, request=request)
+    # Raster tiles are served at the public APP origin (/raster-tiles/...), not
+    # the /api origin (which has no such route). fix(#315)
+    public_app_url = await get_public_app_url(db, request=request)
 
     # "datasets" catalog collection (OGC Records)
     catalog_collection = await _build_collection_metadata(db, user, public_api_url)
@@ -1077,7 +1080,7 @@ async def list_collections(
                     "rel": "tiles",
                     "href": build_url(
                         f"/raster-tiles/{ds.id}/tiles/{{z}}/{{x}}/{{y}}.png",
-                        base_url=public_api_url,
+                        base_url=public_app_url,
                     ),
                     "type": "image/png",
                 }

--- a/backend/app/modules/catalog/search/router.py
+++ b/backend/app/modules/catalog/search/router.py
@@ -66,6 +66,7 @@ from app.modules.catalog.search.service import (
     search_collections,
     search_datasets,
 )
+from app.modules.catalog.search.service_collections import count_collections
 from app.core.persistent_config import (
     SEMANTIC_SEARCH_ENABLED,
     get_cached_semantic_search_rate_limit,
@@ -409,15 +410,28 @@ async def _handle_search(
         for d in datasets
     ]
 
-    # Append collection results on first page when text search is active
-    # Skip when filtering by a specific collection
-    if (
+    # Collections are surfaced alongside datasets only for text searches that
+    # are not scoped to a specific record_type or collection.
+    collections_applicable = bool(
         params.q
         and params.q.strip()
-        and params.offset == 0
         and not params.record_type
         and not params.collection_id
-    ):
+    )
+
+    # B5c/OGC-4: numberMatched must be STABLE across pages and include the full
+    # count of matching collections (not just the <=5 shown on page 0). Compute
+    # the page-independent collection total on EVERY page so numberMatched does
+    # not change between pages. ``total`` (dataset-only count) is left untouched
+    # so it continues to drive the next-link decision below -- appended
+    # collections are a page-0-only display augmentation and are never paginated,
+    # so they must NOT inflate the dataset next-link math.
+    collection_total = 0
+    if collections_applicable:
+        collection_total = await count_collections(db, params.q)
+
+    # Append collection results on the first page only (display augmentation).
+    if collections_applicable and params.offset == 0:
         coll_results = await search_collections(db, params.q, user, user_roles, limit=5)
         for coll in coll_results:
             features.append(
@@ -474,7 +488,10 @@ async def _handle_search(
         ),
     ]
 
-    # Next link: more results beyond current page
+    # Next link: more results beyond current page. Driven by DATASET pagination
+    # only (``total`` is the dataset-only count) -- collections are a page-0
+    # display augmentation and are never paginated, so they must not produce a
+    # phantom next-link to an empty page (B5c).
     if params.offset + params.limit < total:
         links.append(
             OGCRecordLink(
@@ -511,7 +528,11 @@ async def _handle_search(
         timeStamp=datetime.now(timezone.utc)
         .isoformat(timespec="seconds")
         .replace("+00:00", "Z"),
-        numberMatched=total,
+        # B5c/OGC-4: stable across pages -- dataset total plus the full
+        # (page-independent) count of matching collections. >= numberReturned on
+        # every page because page 0 shows at most ``collection_total`` (capped at
+        # 5) collections and later pages show none.
+        numberMatched=total + collection_total,
         numberReturned=len(features),
         features=features,
         links=links,
@@ -639,6 +660,18 @@ async def search_datasets_endpoint(
     raw_keywords = request.query_params.getlist("keywords")
     if raw_keywords and not params.keywords:
         params = params.model_copy(update={"keywords": raw_keywords})
+    # Validate/apply the OGC CQL2 filter-lang param from the raw query string
+    # (hyphenated "filter-lang" is not resolved by Pydantic model Depends
+    # binding). Mirrors the collection_items handler so a bogus value 400s
+    # instead of being silently ignored.
+    raw_filter_lang = request.query_params.get("filter-lang")
+    if raw_filter_lang:
+        if raw_filter_lang not in ("cql2-text", "cql2-json"):
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"Unsupported filter-lang: {raw_filter_lang}. Use cql2-text or cql2-json.",
+            )
+        params = params.model_copy(update={"cql2_filter_lang": raw_filter_lang})
     return await _handle_search(db, user, request, params)
 
 
@@ -1015,21 +1048,25 @@ async def list_collections(
                 ]
             }
 
-        entry: dict = {
-            "id": str(ds.id),
-            "title": ds.record.title,
-            "description": ds.record.summary,
-            "itemType": "feature",
-            "crs": ["http://www.opengis.net/def/crs/OGC/1.3/CRS84"],
-            "links": [
-                {
-                    "rel": "self",
-                    "href": build_url(
-                        f"/collections/{ds.id}",
-                        base_url=public_api_url,
-                    ),
-                    "type": "application/json",
-                },
+        # B1/OGC-1: raster/VRT datasets have no backing feature table, so they
+        # expose no feature items. Mirror the detail endpoint (standards/ogc):
+        # advertise itemType=coverage and omit the rel=items link so crawlers
+        # are not led into the dead /items endpoint (which 404s). record_type is
+        # eager-loaded via joinedload(Dataset.record) above (no extra query).
+        is_raster = ds.record.record_type in ("raster_dataset", "vrt_dataset")
+
+        links: list[dict] = [
+            {
+                "rel": "self",
+                "href": build_url(
+                    f"/collections/{ds.id}",
+                    base_url=public_api_url,
+                ),
+                "type": "application/json",
+            },
+        ]
+        if not is_raster:
+            links.append(
                 {
                     "rel": "items",
                     "href": build_url(
@@ -1037,13 +1074,23 @@ async def list_collections(
                         base_url=public_api_url,
                     ),
                     "type": "application/geo+json",
-                },
-                {
-                    "rel": "root",
-                    "href": build_url("/", base_url=public_api_url),
-                    "type": "application/json",
-                },
-            ],
+                }
+            )
+        links.append(
+            {
+                "rel": "root",
+                "href": build_url("/", base_url=public_api_url),
+                "type": "application/json",
+            }
+        )
+
+        entry: dict = {
+            "id": str(ds.id),
+            "title": ds.record.title,
+            "description": ds.record.summary,
+            "itemType": "coverage" if is_raster else "feature",
+            "crs": ["http://www.opengis.net/def/crs/OGC/1.3/CRS84"],
+            "links": links,
         }
         if extent:
             entry["extent"] = extent

--- a/backend/app/modules/catalog/search/router.py
+++ b/backend/app/modules/catalog/search/router.py
@@ -61,12 +61,12 @@ from app.modules.catalog.search.schemas import (
 from app.modules.catalog.search import cache as search_cache
 from app.modules.catalog.search.service import (
     SearchFilters,
+    count_collections,
     dataset_to_ogc_record,
     get_facet_counts,
     search_collections,
     search_datasets,
 )
-from app.modules.catalog.search.service_collections import count_collections
 from app.core.persistent_config import (
     SEMANTIC_SEARCH_ENABLED,
     get_cached_semantic_search_rate_limit,
@@ -419,20 +419,23 @@ async def _handle_search(
         and not params.collection_id
     )
 
-    # B5c/OGC-4: numberMatched must be STABLE across pages and include the full
-    # count of matching collections (not just the <=5 shown on page 0). Compute
-    # the page-independent collection total on EVERY page so numberMatched does
-    # not change between pages. ``total`` (dataset-only count) is left untouched
-    # so it continues to drive the next-link decision below -- appended
-    # collections are a page-0-only display augmentation and are never paginated,
-    # so they must NOT inflate the dataset next-link math.
+    # B5c/OGC-4: count matching collections on EVERY page so numberMatched stays
+    # stable; ``total`` (dataset-only) still drives the next-link, since appended
+    # collections are a page-0-only augmentation that is never paginated. Cap the
+    # count at the page-0 display limit so numberMatched never claims more
+    # collections than are actually retrievable (only the first 5 are ever shown).
+    page0_collection_cap = 5
     collection_total = 0
     if collections_applicable:
-        collection_total = await count_collections(db, params.q)
+        collection_total = min(
+            await count_collections(db, params.q), page0_collection_cap
+        )
 
     # Append collection results on the first page only (display augmentation).
     if collections_applicable and params.offset == 0:
-        coll_results = await search_collections(db, params.q, user, user_roles, limit=5)
+        coll_results = await search_collections(
+            db, params.q, user, user_roles, limit=page0_collection_cap
+        )
         for coll in coll_results:
             features.append(
                 {
@@ -488,10 +491,8 @@ async def _handle_search(
         ),
     ]
 
-    # Next link: more results beyond current page. Driven by DATASET pagination
-    # only (``total`` is the dataset-only count) -- collections are a page-0
-    # display augmentation and are never paginated, so they must not produce a
-    # phantom next-link to an empty page (B5c).
+    # Next link driven by the dataset-only ``total`` (page-0 collections are not
+    # paginated, so they must not produce a phantom next-link to an empty page).
     if params.offset + params.limit < total:
         links.append(
             OGCRecordLink(
@@ -528,10 +529,8 @@ async def _handle_search(
         timeStamp=datetime.now(timezone.utc)
         .isoformat(timespec="seconds")
         .replace("+00:00", "Z"),
-        # B5c/OGC-4: stable across pages -- dataset total plus the full
-        # (page-independent) count of matching collections. >= numberReturned on
-        # every page because page 0 shows at most ``collection_total`` (capped at
-        # 5) collections and later pages show none.
+        # B5c/OGC-4: dataset total + full collection count = stable across pages
+        # and always >= numberReturned (page 0 shows <=5 collections; later none).
         numberMatched=total + collection_total,
         numberReturned=len(features),
         features=features,
@@ -660,10 +659,8 @@ async def search_datasets_endpoint(
     raw_keywords = request.query_params.getlist("keywords")
     if raw_keywords and not params.keywords:
         params = params.model_copy(update={"keywords": raw_keywords})
-    # Validate/apply the OGC CQL2 filter-lang param from the raw query string
-    # (hyphenated "filter-lang" is not resolved by Pydantic model Depends
-    # binding). Mirrors the collection_items handler so a bogus value 400s
-    # instead of being silently ignored.
+    # Validate the raw hyphenated "filter-lang" (not bound by Pydantic Depends);
+    # mirrors collection_items so a bogus value 400s instead of being ignored.
     raw_filter_lang = request.query_params.get("filter-lang")
     if raw_filter_lang:
         if raw_filter_lang not in ("cql2-text", "cql2-json"):
@@ -1048,11 +1045,8 @@ async def list_collections(
                 ]
             }
 
-        # B1/OGC-1: raster/VRT datasets have no backing feature table, so they
-        # expose no feature items. Mirror the detail endpoint (standards/ogc):
-        # advertise itemType=coverage and omit the rel=items link so crawlers
-        # are not led into the dead /items endpoint (which 404s). record_type is
-        # eager-loaded via joinedload(Dataset.record) above (no extra query).
+        # B1/OGC-1: raster/VRT have no feature table -> mirror the detail endpoint
+        # (itemType=coverage, omit rel=items) so crawlers skip the dead /items.
         is_raster = ds.record.record_type in ("raster_dataset", "vrt_dataset")
 
         links: list[dict] = [

--- a/backend/app/modules/catalog/search/service.py
+++ b/backend/app/modules/catalog/search/service.py
@@ -7,7 +7,10 @@ AI, platform defaults, and test callers.
 
 from __future__ import annotations
 
-from app.modules.catalog.search.service_collections import search_collections
+from app.modules.catalog.search.service_collections import (
+    count_collections,
+    search_collections,
+)
 from app.modules.catalog.search.service_datasets import search_datasets
 from app.modules.catalog.search.service_facets import get_facet_counts
 from app.modules.catalog.search.service_filters import (
@@ -30,6 +33,7 @@ __all__ = [
     "FacetCounts",
     "SearchFilters",
     "get_facet_counts",
+    "count_collections",
     "search_collections",
     "search_datasets",
     "build_assets",

--- a/backend/app/modules/catalog/search/service_collections.py
+++ b/backend/app/modules/catalog/search/service_collections.py
@@ -68,3 +68,30 @@ async def search_collections(
         }
         for c in collections
     ]
+
+
+async def count_collections(
+    session: AsyncSession,
+    q: str,
+) -> int:
+    """Count collections matching the text filter used by ``search_collections``.
+
+    Page-independent total of all matching collections (not just the <=5 shown
+    on page 0). Used to compute a stable ``numberMatched`` that includes the
+    page-0 collection augmentation. Mirrors the text filter in
+    ``search_collections`` exactly (no LIMIT, no visibility filter on the
+    Collection rows themselves — consistent with the search). Returns 0 when
+    ``q`` is empty.
+    """
+    if not q or not q.strip():
+        return 0
+
+    count_stmt = select(func.count()).select_from(Collection)
+    q_like = f"%{q.strip().lower()}%"
+    count_stmt = count_stmt.where(
+        or_(
+            func.lower(Collection.name).like(q_like),
+            func.lower(func.coalesce(Collection.description, "")).like(q_like),
+        )
+    )
+    return (await session.execute(count_stmt)).scalar_one()

--- a/backend/app/modules/catalog/search/service_datasets.py
+++ b/backend/app/modules/catalog/search/service_datasets.py
@@ -156,6 +156,11 @@ def _resolve_sort_order(
         )
     else:
         stmt = stmt.order_by(Record.created_at.desc())
+    # Deterministic final tiebreaker: Record.id is the UUID PK and is unique, so
+    # rows tying on every other key get a stable order. SQLAlchemy appends this
+    # after the per-branch ORDER BY, keeping OFFSET/LIMIT pagination stable
+    # (no dupes / dropped rows across pages).
+    stmt = stmt.order_by(Record.id.desc())
     return stmt
 
 

--- a/backend/app/modules/catalog/search/service_filters.py
+++ b/backend/app/modules/catalog/search/service_filters.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass
 from datetime import date
 from typing import Literal, TypedDict
 
+from fastapi import HTTPException, status
 from sqlalchemy import exists, func, literal_column, or_, select
 from sqlalchemy.orm import aliased
 
@@ -200,15 +201,24 @@ def parse_ogc_datetime(datetime_str: str) -> tuple[date | None, date | None]:
     - Bounded interval: "2024-01-01/2024-12-31"
     - Open start: "../2024-12-31"
     - Open end: "2024-01-01/.."
+
+    A malformed value raises HTTP 400 (not a generic 500); this is the single
+    chokepoint for collection_items, search_datasets, and facets.
     """
-    if "/" in datetime_str:
-        left, right = datetime_str.split("/", 1)
-        dt_start = None if left == ".." else date.fromisoformat(left[:10])
-        dt_end = None if right == ".." else date.fromisoformat(right[:10])
-        return dt_start, dt_end
-    # Single instant
-    instant = date.fromisoformat(datetime_str[:10])
-    return instant, instant
+    try:
+        if "/" in datetime_str:
+            left, right = datetime_str.split("/", 1)
+            dt_start = None if left == ".." else date.fromisoformat(left[:10])
+            dt_end = None if right == ".." else date.fromisoformat(right[:10])
+            return dt_start, dt_end
+        # Single instant
+        instant = date.fromisoformat(datetime_str[:10])
+        return instant, instant
+    except ValueError as e:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Invalid datetime value: {e}",
+        )
 
 
 def _apply_common_filters(stmt, filters: SearchFilters, *, skip_text: bool = False):

--- a/backend/app/modules/catalog/search/service_semantic.py
+++ b/backend/app/modules/catalog/search/service_semantic.py
@@ -169,13 +169,7 @@ async def _get_vector_ranks(
             vector_stmt = vector_stmt.where(
                 RecordEmbedding.record_id.in_(restrict_stmt)
             )
-        # OGC-7/TQ-1: add a unique secondary sort so the top-k window is
-        # deterministic on cosine-distance ties (otherwise which record falls
-        # inside the limit is arbitrary on equal distances, mirroring the
-        # FTS-pool tiebreaker on Dataset.record_id above).
-        vector_stmt = vector_stmt.order_by(
-            "distance", RecordEmbedding.record_id.desc()
-        ).limit(limit)
+        vector_stmt = vector_stmt.order_by("distance").limit(limit)
 
         result = await session.execute(vector_stmt)
         rows = result.all()
@@ -210,11 +204,8 @@ def _compute_rrf_scores(
     for record_id, v_rank in vector_ranks.items():
         scores[record_id] = scores.get(record_id, 0.0) + 1.0 / (k + v_rank)
 
-    # Sort by RRF score descending; tie-break on record id so equal-score rows
-    # get a deterministic order for a fixed candidate pool. (Cross-page pool
-    # growth -- the candidate set changing as page_end grows per page -- is a
-    # pre-existing limitation not addressed here.)
-    return sorted(scores.keys(), key=lambda rid: (scores[rid], rid), reverse=True)
+    # Sort by RRF score descending
+    return sorted(scores.keys(), key=lambda rid: scores[rid], reverse=True)
 
 
 async def _run_rrf_merge(
@@ -275,7 +266,7 @@ async def _run_rrf_merge(
     fts_cap = max(page_end * 3, 100)
     fts_stmt = (
         stmt.with_only_columns(Dataset.record_id)
-        .order_by(rank_col.desc(), Dataset.record_id.desc())
+        .order_by(rank_col.desc())
         .limit(fts_cap)
     )
     fts_result = await session.execute(fts_stmt)

--- a/backend/app/modules/catalog/search/service_semantic.py
+++ b/backend/app/modules/catalog/search/service_semantic.py
@@ -169,7 +169,13 @@ async def _get_vector_ranks(
             vector_stmt = vector_stmt.where(
                 RecordEmbedding.record_id.in_(restrict_stmt)
             )
-        vector_stmt = vector_stmt.order_by("distance").limit(limit)
+        # OGC-7/TQ-1: add a unique secondary sort so the top-k window is
+        # deterministic on cosine-distance ties (otherwise which record falls
+        # inside the limit is arbitrary on equal distances, mirroring the
+        # FTS-pool tiebreaker on Dataset.record_id above).
+        vector_stmt = vector_stmt.order_by(
+            "distance", RecordEmbedding.record_id.desc()
+        ).limit(limit)
 
         result = await session.execute(vector_stmt)
         rows = result.all()
@@ -204,8 +210,11 @@ def _compute_rrf_scores(
     for record_id, v_rank in vector_ranks.items():
         scores[record_id] = scores.get(record_id, 0.0) + 1.0 / (k + v_rank)
 
-    # Sort by RRF score descending
-    return sorted(scores.keys(), key=lambda rid: scores[rid], reverse=True)
+    # Sort by RRF score descending; tie-break on record id so equal-score rows
+    # get a deterministic order for a fixed candidate pool. (Cross-page pool
+    # growth -- the candidate set changing as page_end grows per page -- is a
+    # pre-existing limitation not addressed here.)
+    return sorted(scores.keys(), key=lambda rid: (scores[rid], rid), reverse=True)
 
 
 async def _run_rrf_merge(
@@ -266,7 +275,7 @@ async def _run_rrf_merge(
     fts_cap = max(page_end * 3, 100)
     fts_stmt = (
         stmt.with_only_columns(Dataset.record_id)
-        .order_by(rank_col.desc())
+        .order_by(rank_col.desc(), Dataset.record_id.desc())
         .limit(fts_cap)
     )
     fts_result = await session.execute(fts_stmt)

--- a/backend/app/standards/ogc/router.py
+++ b/backend/app/standards/ogc/router.py
@@ -5,6 +5,7 @@ import structlog
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
 from fastapi.responses import JSONResponse
 from sqlalchemy import select
+from sqlalchemy.exc import OperationalError, ProgrammingError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.db.tenant_session import current_tenant_var
@@ -317,21 +318,25 @@ async def get_dataset_collection(
             ]
         }
 
-    metadata = OGCCollectionMetadata(
-        id=str(dataset.id),
-        title=dataset.record.title,
-        description=dataset.record.summary,
-        extent=extent if extent else None,
-        links=[
-            OGCLink(
-                rel="self",
-                href=build_url(
-                    f"/collections/{dataset.id}",
-                    base_url=public_api_url,
-                ),
-                type="application/json",
-                title="This collection",
+    # B1: raster/VRT datasets have no backing feature table, so they expose no
+    # feature items. Advertise itemType=coverage and omit the rel=items link so
+    # clients are not led into the dead /items endpoint (which 404s, see
+    # get_collection_items).
+    is_raster = dataset.record.record_type in ("raster_dataset", "vrt_dataset")
+
+    links = [
+        OGCLink(
+            rel="self",
+            href=build_url(
+                f"/collections/{dataset.id}",
+                base_url=public_api_url,
             ),
+            type="application/json",
+            title="This collection",
+        ),
+    ]
+    if not is_raster:
+        links.append(
             OGCLink(
                 rel="items",
                 href=build_url(
@@ -340,14 +345,41 @@ async def get_dataset_collection(
                 ),
                 type="application/geo+json",
                 title="Features",
-            ),
+            )
+        )
+    else:
+        # OGC-6: a coverage collection has no rel=items, so without a
+        # replacement link the body would only carry self+root and be a
+        # dead-end. Advertise the raster tile endpoint so coverage clients have
+        # something to dereference. Mirrors the STAC raster_tiles asset href in
+        # search/service_records.py (the stable public tile URL).
+        links.append(
             OGCLink(
-                rel="root",
-                href=build_url("/", base_url=public_api_url),
-                type="application/json",
-                title="Landing page",
-            ),
-        ],
+                rel="tiles",
+                href=build_url(
+                    f"/raster-tiles/{dataset.id}/tiles/{{z}}/{{x}}/{{y}}.png",
+                    base_url=public_api_url,
+                ),
+                type="image/png",
+                title="Raster tiles",
+            )
+        )
+    links.append(
+        OGCLink(
+            rel="root",
+            href=build_url("/", base_url=public_api_url),
+            type="application/json",
+            title="Landing page",
+        )
+    )
+
+    metadata = OGCCollectionMetadata(
+        id=str(dataset.id),
+        title=dataset.record.title,
+        description=dataset.record.summary,
+        extent=extent if extent else None,
+        itemType="coverage" if is_raster else "feature",
+        links=links,
     )
 
     # METER-03 (Phase 1213-06): emit OGC collection-serve usage event through the
@@ -438,6 +470,31 @@ async def get_collection_items(
     public_api_url = await get_public_api_url(db, request=request)
     dataset = await _get_visible_dataset(db, user, dataset_id)
 
+    # B1: raster/VRT datasets have no backing PostGIS feature table, so a feature
+    # query would raise UndefinedTableError -> 500 (and hold a DB connection).
+    # Return a fast 404 before any feature query is attempted.
+    if dataset.record.record_type in ("raster_dataset", "vrt_dataset"):
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=(
+                f"Collection '{dataset_id}' is a raster collection and has no "
+                "feature items; use the tile/coverage endpoints instead."
+            ),
+        )
+
+    # B4: CQL2 filtering is only supported on the datasets (records) collection,
+    # which has a dedicated handler. On per-dataset feature collections a filter
+    # would otherwise be silently dropped (or a malformed one return 200), so
+    # reject it explicitly with 400 — matching the records-path reject contract.
+    if request.query_params.get("filter") is not None:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=(
+                "CQL2 filter is not supported on feature collections; use the "
+                "datasets (records) collection for catalog-level CQL2 filtering."
+            ),
+        )
+
     # Parse bbox
     bbox_parsed = None
     if bbox:
@@ -461,6 +518,10 @@ async def get_collection_items(
         "crs",
         "api_key",
         "include_geometry",
+        # B4: filter/filter-lang are rejected above on feature collections; keep
+        # them out of property_filters so they never leak into the SQL WHERE.
+        "filter",
+        "filter-lang",
     }
     property_filters = {
         k: v for k, v in request.query_params.items() if k not in ogc_reserved
@@ -492,19 +553,30 @@ async def get_collection_items(
     # ST_AsGeoJSON cost (PERF-N1).
     # H-24: when after_gid is provided, the service uses keyset pagination and
     # ignores offset.
-    rows, total = await get_features(
-        db,
-        dataset.table_name,
-        limit=limit,
-        offset=offset,
-        after_gid=after_gid,
-        bbox=bbox_parsed,
-        has_geometry=has_geometry,
-        property_filters=property_filters,
-        allowed_columns=allowed_columns,
-        include_geometry=include_geometry,
-        cached_feature_count=dataset.feature_count,
-    )
+    # B1: the raster/VRT guard above handles datasets that never had a backing
+    # table. A genuinely-missing VECTOR table (cold-evicted / partial ingest)
+    # still raises ProgrammingError/OperationalError here; mirror the native
+    # list_features handler and return 503 rather than an unhandled 500 that
+    # holds a DB connection.
+    try:
+        rows, total = await get_features(
+            db,
+            dataset.table_name,
+            limit=limit,
+            offset=offset,
+            after_gid=after_gid,
+            bbox=bbox_parsed,
+            has_geometry=has_geometry,
+            property_filters=property_filters,
+            allowed_columns=allowed_columns,
+            include_geometry=include_geometry,
+            cached_feature_count=dataset.feature_count,
+        )
+    except (ProgrammingError, OperationalError):
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Dataset table is temporarily unavailable",
+        )
 
     # Convert rows to GeoJSON features
     features = []
@@ -637,6 +709,19 @@ async def get_collection_item_feature(
     _validate_f_param(f)
     public_api_url = await get_public_api_url(db, request=request)
     dataset = await _get_visible_dataset(db, user, dataset_id)
+
+    # B1: raster/VRT datasets have no backing PostGIS feature table, so a
+    # feature-by-id query would raise UndefinedTableError -> 500. Return 404
+    # before any query is attempted.
+    if dataset.record.record_type in ("raster_dataset", "vrt_dataset"):
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=(
+                f"Collection '{dataset_id}' is a raster collection and has no "
+                "feature items; use the tile/coverage endpoints instead."
+            ),
+        )
+
     has_geometry = dataset.geometry_type is not None
 
     # COLD-02 (Phase 1214-04): cold-rehydrate seam — BEFORE feature-by-id query.
@@ -650,9 +735,19 @@ async def get_collection_item_feature(
         if _item_cold_result is not None:
             return _item_cold_result
 
-    row = await get_feature_by_id(
-        db, dataset.table_name, feature_id, has_geometry=has_geometry
-    )
+    # B1: as with get_collection_items, a genuinely-missing VECTOR table
+    # (cold-evicted / partial ingest) raises ProgrammingError/OperationalError;
+    # return 503 rather than an unhandled 500. The raster/VRT 404 guard above
+    # handles datasets that never had a backing table.
+    try:
+        row = await get_feature_by_id(
+            db, dataset.table_name, feature_id, has_geometry=has_geometry
+        )
+    except (ProgrammingError, OperationalError):
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Dataset table is temporarily unavailable",
+        )
     if row is None:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,

--- a/backend/app/standards/ogc/router.py
+++ b/backend/app/standards/ogc/router.py
@@ -12,7 +12,7 @@ from app.core.db.tenant_session import current_tenant_var
 from app.core.dependencies import get_db
 from app.core.geo import extent_to_bbox
 from app.core.identity import Identity
-from app.core.public_urls import get_public_api_url
+from app.core.public_urls import get_public_api_url, get_public_app_url
 from app.core.tenancy import is_multi_tenant
 from app.modules.auth.dependencies import get_optional_user
 from app.modules.catalog.authorization import apply_visibility_filter, get_user_roles
@@ -351,14 +351,16 @@ async def get_dataset_collection(
         # fix(#315): a coverage collection has no rel=items, so without a
         # replacement link the body would only carry self+root and be a
         # dead-end. Advertise the raster tile endpoint so coverage clients have
-        # something to dereference. Mirrors the STAC raster_tiles asset href in
-        # search/service_records.py (the stable public tile URL).
+        # something to dereference. NOTE: raster tiles are served at the public
+        # APP origin (/raster-tiles/...), which nginx rewrites to the internal
+        # tile proxy; the /api origin has no such route, so use public_app_url.
+        public_app_url = await get_public_app_url(db, request=request)
         links.append(
             OGCLink(
                 rel="tiles",
                 href=build_url(
                     f"/raster-tiles/{dataset.id}/tiles/{{z}}/{{x}}/{{y}}.png",
-                    base_url=public_api_url,
+                    base_url=public_app_url,
                 ),
                 type="image/png",
                 title="Raster tiles",

--- a/backend/app/standards/ogc/router.py
+++ b/backend/app/standards/ogc/router.py
@@ -318,7 +318,7 @@ async def get_dataset_collection(
             ]
         }
 
-    # B1: raster/VRT datasets have no backing feature table, so they expose no
+    # fix(#315): raster/VRT datasets have no backing feature table, so they expose no
     # feature items. Advertise itemType=coverage and omit the rel=items link so
     # clients are not led into the dead /items endpoint (which 404s, see
     # get_collection_items).
@@ -348,7 +348,7 @@ async def get_dataset_collection(
             )
         )
     else:
-        # OGC-6: a coverage collection has no rel=items, so without a
+        # fix(#315): a coverage collection has no rel=items, so without a
         # replacement link the body would only carry self+root and be a
         # dead-end. Advertise the raster tile endpoint so coverage clients have
         # something to dereference. Mirrors the STAC raster_tiles asset href in
@@ -470,7 +470,7 @@ async def get_collection_items(
     public_api_url = await get_public_api_url(db, request=request)
     dataset = await _get_visible_dataset(db, user, dataset_id)
 
-    # B1: raster/VRT datasets have no backing PostGIS feature table, so a feature
+    # fix(#315): raster/VRT datasets have no backing PostGIS feature table, so a feature
     # query would raise UndefinedTableError -> 500 (and hold a DB connection).
     # Return a fast 404 before any feature query is attempted.
     if dataset.record.record_type in ("raster_dataset", "vrt_dataset"):
@@ -482,7 +482,7 @@ async def get_collection_items(
             ),
         )
 
-    # B4: CQL2 filtering is only supported on the datasets (records) collection,
+    # fix(#315): CQL2 filtering is only supported on the datasets (records) collection,
     # which has a dedicated handler. On per-dataset feature collections a filter
     # would otherwise be silently dropped (or a malformed one return 200), so
     # reject it explicitly with 400 — matching the records-path reject contract.
@@ -518,7 +518,7 @@ async def get_collection_items(
         "crs",
         "api_key",
         "include_geometry",
-        # B4: filter/filter-lang are rejected above on feature collections; keep
+        # fix(#315): filter/filter-lang are rejected above on feature collections; keep
         # them out of property_filters so they never leak into the SQL WHERE.
         "filter",
         "filter-lang",
@@ -553,7 +553,7 @@ async def get_collection_items(
     # ST_AsGeoJSON cost (PERF-N1).
     # H-24: when after_gid is provided, the service uses keyset pagination and
     # ignores offset.
-    # B1: the raster/VRT guard above handles datasets that never had a backing
+    # fix(#315): the raster/VRT guard above handles datasets that never had a backing
     # table. A genuinely-missing VECTOR table (cold-evicted / partial ingest)
     # still raises ProgrammingError/OperationalError here; mirror the native
     # list_features handler and return 503 rather than an unhandled 500 that
@@ -710,7 +710,7 @@ async def get_collection_item_feature(
     public_api_url = await get_public_api_url(db, request=request)
     dataset = await _get_visible_dataset(db, user, dataset_id)
 
-    # B1: raster/VRT datasets have no backing PostGIS feature table, so a
+    # fix(#315): raster/VRT datasets have no backing PostGIS feature table, so a
     # feature-by-id query would raise UndefinedTableError -> 500. Return 404
     # before any query is attempted.
     if dataset.record.record_type in ("raster_dataset", "vrt_dataset"):
@@ -735,7 +735,7 @@ async def get_collection_item_feature(
         if _item_cold_result is not None:
             return _item_cold_result
 
-    # B1: as with get_collection_items, a genuinely-missing VECTOR table
+    # fix(#315): as with get_collection_items, a genuinely-missing VECTOR table
     # (cold-evicted / partial ingest) raises ProgrammingError/OperationalError;
     # return 503 rather than an unhandled 500. The raster/VRT 404 guard above
     # handles datasets that never had a backing table.

--- a/backend/app/standards/ogc/schemas.py
+++ b/backend/app/standards/ogc/schemas.py
@@ -52,7 +52,11 @@ class OGCCollectionMetadata(BaseModel):
     )
     itemType: str = Field(
         default="feature",
-        description="Type of items in the collection. Always 'feature' for OGC API Features.",
+        description=(
+            "Type of items in the collection: 'feature' for vector feature "
+            "collections, 'coverage' for raster/VRT collections (which expose "
+            "tiles instead of feature items)."
+        ),
     )
     crs: list[str] = Field(
         default=["http://www.opengis.net/def/crs/OGC/1.3/CRS84"],

--- a/backend/app/standards/stac/router.py
+++ b/backend/app/standards/stac/router.py
@@ -1230,7 +1230,7 @@ def _apply_datetime_filter(stmt, datetime_str: str):
 
     Delegates parsing to the canonical ``parse_ogc_datetime`` helper in
     search/service.py so STAC and OGC Records share one implementation.
-    Malformed inputs raise ValueError (was silently ignored before — that
+    Malformed inputs raise HTTP 400 (was silently ignored before — that
     masked client mistakes).
     """
     from app.modules.catalog.search.service import parse_ogc_datetime

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -2929,6 +2929,30 @@
             "title": "Count",
             "type": "integer"
           },
+          "data_type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "'categorical' for non-numeric columns; null for numeric.",
+            "title": "Data Type"
+          },
+          "distinct_count": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Distinct non-null value count (categorical columns only).",
+            "title": "Distinct Count"
+          },
           "max": {
             "anyOf": [
               {
@@ -10199,7 +10223,7 @@
           },
           "itemType": {
             "default": "feature",
-            "description": "Type of items in the collection. Always 'feature' for OGC API Features.",
+            "description": "Type of items in the collection: 'feature' for vector feature collections, 'coverage' for raster/VRT collections (which expose tiles instead of feature items).",
             "title": "Itemtype",
             "type": "string"
           },

--- a/backend/tests/test_column_stats_stddev.py
+++ b/backend/tests/test_column_stats_stddev.py
@@ -11,9 +11,11 @@ Requirements:
 import uuid
 
 import pytest
+from httpx import AsyncClient
 from sqlalchemy import text
 
 from app.modules.catalog.datasets.domain.column_stats import get_column_stats
+from tests.factories import create_dataset, get_user_id
 
 TEST_TABLE_NAME = f"test_stddev_{uuid.uuid4().hex[:8]}"
 
@@ -79,3 +81,127 @@ async def test_get_column_stats_stddev_none_for_empty_column(
 
     assert stats["count"] == 0
     assert stats["stddev"] is None
+
+
+async def test_get_column_stats_text_column_is_categorical(
+    test_db_session, stddev_table
+):
+    """B3: a text column returns a categorical summary, not a 500 (::numeric cast).
+
+    Numeric aggregates are None, count/distinct_count are populated, and
+    data_type is 'categorical' so the endpoint maps to a 200 ColumnStatsResponse.
+    """
+    stats = await get_column_stats(test_db_session, stddev_table, "label")
+
+    assert stats["data_type"] == "categorical"
+    assert stats["min"] is None
+    assert stats["max"] is None
+    assert stats["mean"] is None
+    assert stats["stddev"] is None
+    assert stats["quantiles"] == []
+    # 5 distinct non-null labels ('a'..'e').
+    assert stats["count"] == 5
+    assert stats["distinct_count"] == 5
+
+
+async def test_get_column_stats_numeric_column_has_no_categorical_marker(
+    test_db_session, stddev_table
+):
+    """Regression: numeric columns keep the byte-identical numeric shape."""
+    stats = await get_column_stats(test_db_session, stddev_table, "value")
+
+    # data_type is only set for categorical columns; numeric stays null.
+    assert stats.get("data_type") is None
+    assert stats["min"] == 1.0
+    assert stats["max"] == 5.0
+    assert stats["count"] == 5
+    assert stats["mean"] == pytest.approx(3.0)
+
+
+async def test_get_column_stats_nonexistent_column_raises_value_error(
+    test_db_session, stddev_table
+):
+    """B3: a missing column raises ValueError (endpoint maps to 400)."""
+    with pytest.raises(ValueError):
+        await get_column_stats(test_db_session, stddev_table, "no_such_col")
+
+
+# ---------------------------------------------------------------------------
+# TQ-5: HTTP-layer coverage for /datasets/{id}/columns/{col}/stats/
+# The tests above exercise the domain function directly; these drive the
+# endpoint so the ValueError->400 mapping and ColumnStatsResponse shape are
+# also covered.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+async def stats_dataset(test_db_session):
+    """A dataset backed by a real physical table with a numeric + text column."""
+    admin_id = await get_user_id(test_db_session, "admin")
+    table_name = f"http_stats_{uuid.uuid4().hex[:8]}"
+    dataset = await create_dataset(
+        test_db_session,
+        created_by=admin_id,
+        name="Column Stats HTTP DS",
+        table_name=table_name,
+    )
+    await test_db_session.execute(
+        text(
+            f"CREATE TABLE data.{table_name} "
+            "(gid serial PRIMARY KEY, label text, value integer)"
+        )
+    )
+    await test_db_session.execute(
+        text(
+            f"INSERT INTO data.{table_name} (label, value) VALUES "
+            "('a', 1), ('b', 2), ('c', 3), ('d', 4), ('e', 5)"
+        )
+    )
+    await test_db_session.commit()
+
+    yield dataset
+
+    await test_db_session.execute(text(f"DROP TABLE IF EXISTS data.{table_name}"))
+    await test_db_session.commit()
+
+
+async def test_column_stats_endpoint_text_column_is_categorical(
+    client: AsyncClient, admin_auth_header: dict, stats_dataset
+):
+    """GET on a text column returns 200 with categorical data_type + distinct_count."""
+    resp = await client.get(
+        f"/datasets/{stats_dataset.id}/columns/label/stats/",
+        headers=admin_auth_header,
+    )
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    assert data["data_type"] == "categorical"
+    assert data["distinct_count"] == 5
+    assert data["min"] is None
+    assert data["max"] is None
+
+
+async def test_column_stats_endpoint_numeric_column_has_min_max(
+    client: AsyncClient, admin_auth_header: dict, stats_dataset
+):
+    """GET on a numeric column returns 200 with null data_type and min/max set."""
+    resp = await client.get(
+        f"/datasets/{stats_dataset.id}/columns/value/stats/",
+        headers=admin_auth_header,
+    )
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    assert data["data_type"] is None
+    assert data["min"] == 1.0
+    assert data["max"] == 5.0
+
+
+async def test_column_stats_endpoint_nonexistent_column_returns_400(
+    client: AsyncClient, admin_auth_header: dict, stats_dataset
+):
+    """GET on a missing column maps the domain ValueError to HTTP 400."""
+    resp = await client.get(
+        f"/datasets/{stats_dataset.id}/columns/no_such_col/stats/",
+        headers=admin_auth_header,
+    )
+    assert resp.status_code == 400, resp.text

--- a/backend/tests/test_column_stats_stddev.py
+++ b/backend/tests/test_column_stats_stddev.py
@@ -86,7 +86,7 @@ async def test_get_column_stats_stddev_none_for_empty_column(
 async def test_get_column_stats_text_column_is_categorical(
     test_db_session, stddev_table
 ):
-    """B3: a text column returns a categorical summary, not a 500 (::numeric cast).
+    """(#315) a text column returns a categorical summary, not a 500 (::numeric cast).
 
     Numeric aggregates are None, count/distinct_count are populated, and
     data_type is 'categorical' so the endpoint maps to a 200 ColumnStatsResponse.
@@ -121,13 +121,13 @@ async def test_get_column_stats_numeric_column_has_no_categorical_marker(
 async def test_get_column_stats_nonexistent_column_raises_value_error(
     test_db_session, stddev_table
 ):
-    """B3: a missing column raises ValueError (endpoint maps to 400)."""
+    """(#315) a missing column raises ValueError (endpoint maps to 400)."""
     with pytest.raises(ValueError):
         await get_column_stats(test_db_session, stddev_table, "no_such_col")
 
 
 # ---------------------------------------------------------------------------
-# TQ-5: HTTP-layer coverage for /datasets/{id}/columns/{col}/stats/
+# fix(#315): HTTP-layer coverage for /datasets/{id}/columns/{col}/stats/
 # The tests above exercise the domain function directly; these drive the
 # endpoint so the ValueError->400 mapping and ColumnStatsResponse shape are
 # also covered.

--- a/backend/tests/test_features_crud.py
+++ b/backend/tests/test_features_crud.py
@@ -76,6 +76,43 @@ async def _create_test_table_and_dataset(
     return dataset
 
 
+async def _create_raster_dataset(
+    session,
+    *,
+    created_by: uuid.UUID,
+    visibility: str = "public",
+    record_type: str = "raster_dataset",
+) -> Dataset:
+    """Register a raster/VRT dataset with NO backing PostGIS feature table.
+
+    Raster records carry a table_name (NOT NULL on the model) but no data.<table>
+    is ever created — this is exactly the B1 bug-trigger condition where a feature
+    query would raise UndefinedTableError -> 500.
+    """
+    table_name = f"test_crud_raster_{uuid.uuid4().hex[:8]}"
+    record = Record(
+        title=f"Test Raster Layer {table_name}",
+        visibility=visibility,
+        record_status="published",
+        record_type=record_type,
+        created_by=created_by,
+    )
+    session.add(record)
+    await session.flush()
+    dataset = Dataset(
+        record_id=record.id,
+        table_name=table_name,
+        srid=4326,
+        geometry_type=None,
+        feature_count=None,
+        source_format="geotiff",
+    )
+    session.add(dataset)
+    await session.commit()
+    await session.refresh(dataset)
+    return dataset
+
+
 async def _cleanup_table(session, table_name: str) -> None:
     """Drop a test data table."""
     await session.execute(text(f"DROP TABLE IF EXISTS data.{table_name}"))
@@ -141,6 +178,24 @@ async def multipolygon_layer(client: AsyncClient, test_db_session, admin_auth_he
     rec_id = dataset.record_id
     yield dataset
     await _cleanup_table(test_db_session, tbl)
+    await test_db_session.execute(
+        text("DELETE FROM catalog.records WHERE id = :id"),
+        {"id": rec_id},
+    )
+    await test_db_session.commit()
+
+
+@pytest.fixture
+async def raster_layer(client: AsyncClient, test_db_session, admin_auth_header):
+    """Create a raster dataset with no backing feature table (B1 guard)."""
+    admin_id = await get_user_id(test_db_session, "admin")
+    dataset = await _create_raster_dataset(
+        test_db_session,
+        created_by=admin_id,
+    )
+    rec_id = dataset.record_id
+    # No data.<table> exists, so nothing to drop on teardown.
+    yield dataset
     await test_db_session.execute(
         text("DELETE FROM catalog.records WHERE id = :id"),
         {"id": rec_id},
@@ -883,3 +938,61 @@ class TestBboxFiltering:
         assert data["numberReturned"] == 0, (
             "Mid-globe features must not match antimeridian bbox"
         )
+
+
+# ---------------------------------------------------------------------------
+# B1: raster/VRT datasets have no feature table — must 404, never 500
+# ---------------------------------------------------------------------------
+
+
+class TestRasterDatasetFeatureGuard:
+    """A raster/VRT dataset has a table_name but no backing data.<table>.
+
+    Before the guard, a feature query raised UndefinedTableError. The native
+    features router previously diverged: list_features -> 503,
+    features.geojson -> 400, and get_single_feature -> an UNHANDLED 500 (a DoS
+    reachable by any authenticated user). All three read paths must now return a
+    uniform fast 404 before any table query, matching the OGC contract.
+    """
+
+    async def test_single_feature_on_raster_returns_404(
+        self,
+        client: AsyncClient,
+        admin_auth_header: dict,
+        raster_layer: Dataset,
+    ):
+        """GET /datasets/{raster_id}/features/{gid} returns 404 (was 500 DoS)."""
+        resp = await client.get(
+            f"/datasets/{raster_layer.id}/features/1",
+            headers=admin_auth_header,
+        )
+        assert resp.status_code == 404, resp.text
+        assert "raster collection" in resp.json()["detail"].lower()
+
+    async def test_list_features_on_raster_returns_404(
+        self,
+        client: AsyncClient,
+        admin_auth_header: dict,
+        raster_layer: Dataset,
+    ):
+        """GET /datasets/{raster_id}/features/ returns 404 (was 503)."""
+        resp = await client.get(
+            f"/datasets/{raster_layer.id}/features/",
+            headers=admin_auth_header,
+        )
+        assert resp.status_code == 404, resp.text
+        assert "raster collection" in resp.json()["detail"].lower()
+
+    async def test_geojson_tile_on_raster_returns_404(
+        self,
+        client: AsyncClient,
+        admin_auth_header: dict,
+        raster_layer: Dataset,
+    ):
+        """GET /datasets/{raster_id}/features.geojson returns 404 (was 400)."""
+        resp = await client.get(
+            f"/datasets/{raster_layer.id}/features.geojson",
+            headers=admin_auth_header,
+        )
+        assert resp.status_code == 404, resp.text
+        assert "raster collection" in resp.json()["detail"].lower()

--- a/backend/tests/test_features_crud.py
+++ b/backend/tests/test_features_crud.py
@@ -86,7 +86,7 @@ async def _create_raster_dataset(
     """Register a raster/VRT dataset with NO backing PostGIS feature table.
 
     Raster records carry a table_name (NOT NULL on the model) but no data.<table>
-    is ever created — this is exactly the B1 bug-trigger condition where a feature
+    is ever created — this is exactly the (#315) bug-trigger condition where a feature
     query would raise UndefinedTableError -> 500.
     """
     table_name = f"test_crud_raster_{uuid.uuid4().hex[:8]}"
@@ -187,7 +187,7 @@ async def multipolygon_layer(client: AsyncClient, test_db_session, admin_auth_he
 
 @pytest.fixture
 async def raster_layer(client: AsyncClient, test_db_session, admin_auth_header):
-    """Create a raster dataset with no backing feature table (B1 guard)."""
+    """Create a raster dataset with no backing feature table (#315 guard)."""
     admin_id = await get_user_id(test_db_session, "admin")
     dataset = await _create_raster_dataset(
         test_db_session,
@@ -941,7 +941,7 @@ class TestBboxFiltering:
 
 
 # ---------------------------------------------------------------------------
-# B1: raster/VRT datasets have no feature table — must 404, never 500
+# fix(#315): raster/VRT datasets have no feature table — must 404, never 500
 # ---------------------------------------------------------------------------
 
 

--- a/backend/tests/test_fk_relationships.py
+++ b/backend/tests/test_fk_relationships.py
@@ -57,8 +57,8 @@ class TestFKRelationships:
         assert data["label"] == "Links to target"
         assert "id" in data
 
-        # TQ-3: the CREATE response must carry dereferenceable Dataset.id values,
-        # NOT the stored record_ids, matching the LIST contract (B5d). The DB
+        # fix(#315): the CREATE response must carry dereferenceable Dataset.id values,
+        # NOT the stored record_ids, matching the LIST contract (#315). The DB
         # still stores record_ids and the create INPUT still takes a record_id
         # target — only the RESPONSE ids are Dataset.id.
         assert data["source_dataset_id"] == str(source.id)
@@ -72,6 +72,38 @@ class TestFKRelationships:
             headers=admin_auth_header,
         )
         assert deref.status_code == 200, deref.text
+
+    async def test_create_relationship_accepts_dataset_id_input(
+        self,
+        client: AsyncClient,
+        admin_auth_header: dict,
+        test_db_session,
+    ):
+        """fix(#315): a relationship target id round-trips back into create.
+
+        Responses serialize target_dataset_id as Dataset.id, so the create input
+        must accept a Dataset.id too (not just the underlying record_id).
+        """
+        admin_id = await get_user_id(test_db_session, "admin")
+        source = await create_dataset(
+            test_db_session, created_by=admin_id, name="RT Source"
+        )
+        target = await create_dataset(
+            test_db_session, created_by=admin_id, name="RT Target"
+        )
+
+        resp = await client.post(
+            f"/datasets/{source.id}/relationships/",
+            json={
+                "target_dataset_id": str(target.id),  # Dataset.id, not record_id
+                "source_column": "fk_col",
+                "target_column": "gid",
+            },
+            headers=admin_auth_header,
+        )
+        assert resp.status_code == 201, resp.text
+        data = resp.json()
+        assert data["target_dataset_id"] == str(target.id)
 
     async def test_list_relationships(
         self,
@@ -115,7 +147,7 @@ class TestFKRelationships:
         assert body["total"] >= 1
         rel = next(r for r in items if r["source_column"] == "ref_id")
 
-        # B5d: the response ids are Dataset.id (dereferenceable), NOT the stored
+        # fix(#315): the response ids are Dataset.id (dereferenceable), NOT the stored
         # record_id. Clients fetch /collections/{id} which resolves by Dataset.id.
         assert rel["target_dataset_id"] == str(target.id)
         assert rel["target_dataset_id"] != str(target.record_id)

--- a/backend/tests/test_fk_relationships.py
+++ b/backend/tests/test_fk_relationships.py
@@ -57,6 +57,22 @@ class TestFKRelationships:
         assert data["label"] == "Links to target"
         assert "id" in data
 
+        # TQ-3: the CREATE response must carry dereferenceable Dataset.id values,
+        # NOT the stored record_ids, matching the LIST contract (B5d). The DB
+        # still stores record_ids and the create INPUT still takes a record_id
+        # target — only the RESPONSE ids are Dataset.id.
+        assert data["source_dataset_id"] == str(source.id)
+        assert data["target_dataset_id"] == str(target.id)
+        assert data["target_dataset_id"] != str(target.record_id)
+
+        # The returned target id dereferences via /collections/{id} (was a
+        # non-resolvable record_id pre-fix).
+        deref = await client.get(
+            f"/collections/{data['target_dataset_id']}",
+            headers=admin_auth_header,
+        )
+        assert deref.status_code == 200, deref.text
+
     async def test_list_relationships(
         self,
         client: AsyncClient,
@@ -97,7 +113,21 @@ class TestFKRelationships:
         assert isinstance(items, list)
         assert len(items) >= 1
         assert body["total"] >= 1
-        assert any(r["source_column"] == "ref_id" for r in items)
+        rel = next(r for r in items if r["source_column"] == "ref_id")
+
+        # B5d: the response ids are Dataset.id (dereferenceable), NOT the stored
+        # record_id. Clients fetch /collections/{id} which resolves by Dataset.id.
+        assert rel["target_dataset_id"] == str(target.id)
+        assert rel["target_dataset_id"] != str(target.record_id)
+        assert rel["source_dataset_id"] == str(source.id)
+
+        # The returned target id dereferences via /collections/{id} (was 404
+        # pre-fix because the record_id is not a Dataset.id).
+        deref = await client.get(
+            f"/collections/{rel['target_dataset_id']}",
+            headers=admin_auth_header,
+        )
+        assert deref.status_code == 200, deref.text
 
     async def test_list_relationships_envelope_total_reflects_full_count(
         self,

--- a/backend/tests/test_hybrid_search.py
+++ b/backend/tests/test_hybrid_search.py
@@ -683,6 +683,11 @@ async def test_semantic_visible_match_not_crowded_out_by_nearer_private(
     dim = await _get_embedding_dim(session)
     await _set_semantic_search(session, True)
 
+    # Use a dedicated vector band (lo=110) orthogonal to every other test's
+    # records so a concurrent -n4 worker's public lo=40 embedding can't pollute
+    # this test's restricted top-k (same-band vectors are near-cosine-identical,
+    # so an unrelated public record would otherwise tie-break into the limit).
+    band_lo = 110
     public_ds = await _create_search_dataset(
         session,
         created_by=admin_id,
@@ -692,7 +697,7 @@ async def test_semantic_visible_match_not_crowded_out_by_nearer_private(
     session.add(
         RecordEmbedding(
             record_id=public_ds.record_id,
-            embedding=_make_vector_band(0.85, dim=dim),
+            embedding=_make_vector_band(0.85, dim=dim, lo=band_lo),
             model_name="text-embedding-3-small",
             content_hash="p2a_public",
         )
@@ -709,7 +714,7 @@ async def test_semantic_visible_match_not_crowded_out_by_nearer_private(
             RecordEmbedding(
                 record_id=priv.record_id,
                 embedding=_make_vector_band(
-                    base, dim=dim
+                    base, dim=dim, lo=band_lo
                 ),  # nearer than the public 0.85
                 model_name="text-embedding-3-small",
                 content_hash=f"p2a_priv_{i}",
@@ -720,7 +725,7 @@ async def test_semantic_visible_match_not_crowded_out_by_nearer_private(
     with patch(
         "app.modules.catalog.search.service_semantic.generate_embedding",
         new_callable=AsyncMock,
-        return_value=_make_vector_band(1.0, dim=dim),
+        return_value=_make_vector_band(1.0, dim=dim, lo=band_lo),
     ):
         resp = await client.get(
             "/search/datasets/",

--- a/backend/tests/test_hybrid_search.py
+++ b/backend/tests/test_hybrid_search.py
@@ -490,6 +490,35 @@ def test_compute_rrf_scores_basic():
     assert result[3] == "d", f"Expected 'd' last, got {result}"
 
 
+def test_compute_rrf_scores_equal_score_deterministic_tiebreak():
+    """OGC-7/TQ-1: equal RRF scores get a stable, deterministic order.
+
+    Two ids with the SAME vector rank (and no FTS contribution) earn an
+    identical RRF score. Without a tiebreaker, their relative order would be
+    arbitrary (and could differ between runs / processes), which is what made
+    semantic-only matches drop or dupe across pages. The tiebreak is on the
+    record id string. Production coerces ids to str before merging, so this
+    uses str ids (not UUIDs).
+    """
+    from app.modules.catalog.search.service import _compute_rrf_scores
+
+    fts_ids: list[str] = []
+    # Identical rank => identical RRF score for both ids.
+    vector_ranks = {"id_aaa": 1, "id_zzz": 1}
+
+    result = _compute_rrf_scores(fts_ids, vector_ranks, k=60)
+
+    assert set(result) == {"id_aaa", "id_zzz"}
+    # Deterministic: sorted by (score, rid) descending, so the lexicographically
+    # larger id wins the tie. Stable across repeated calls regardless of dict
+    # insertion order.
+    assert result == ["id_zzz", "id_aaa"]
+
+    # Reversed insertion order yields the SAME deterministic result.
+    result_reversed = _compute_rrf_scores(fts_ids, {"id_zzz": 1, "id_aaa": 1}, k=60)
+    assert result_reversed == ["id_zzz", "id_aaa"]
+
+
 # ---------------------------------------------------------------------------
 # Tests: true semantic retrieval — vector-only matches are surfaced, but
 # never leak non-visible datasets (visibility-aware RRF union)

--- a/backend/tests/test_hybrid_search.py
+++ b/backend/tests/test_hybrid_search.py
@@ -490,35 +490,6 @@ def test_compute_rrf_scores_basic():
     assert result[3] == "d", f"Expected 'd' last, got {result}"
 
 
-def test_compute_rrf_scores_equal_score_deterministic_tiebreak():
-    """OGC-7/TQ-1: equal RRF scores get a stable, deterministic order.
-
-    Two ids with the SAME vector rank (and no FTS contribution) earn an
-    identical RRF score. Without a tiebreaker, their relative order would be
-    arbitrary (and could differ between runs / processes), which is what made
-    semantic-only matches drop or dupe across pages. The tiebreak is on the
-    record id string. Production coerces ids to str before merging, so this
-    uses str ids (not UUIDs).
-    """
-    from app.modules.catalog.search.service import _compute_rrf_scores
-
-    fts_ids: list[str] = []
-    # Identical rank => identical RRF score for both ids.
-    vector_ranks = {"id_aaa": 1, "id_zzz": 1}
-
-    result = _compute_rrf_scores(fts_ids, vector_ranks, k=60)
-
-    assert set(result) == {"id_aaa", "id_zzz"}
-    # Deterministic: sorted by (score, rid) descending, so the lexicographically
-    # larger id wins the tie. Stable across repeated calls regardless of dict
-    # insertion order.
-    assert result == ["id_zzz", "id_aaa"]
-
-    # Reversed insertion order yields the SAME deterministic result.
-    result_reversed = _compute_rrf_scores(fts_ids, {"id_zzz": 1, "id_aaa": 1}, k=60)
-    assert result_reversed == ["id_zzz", "id_aaa"]
-
-
 # ---------------------------------------------------------------------------
 # Tests: true semantic retrieval — vector-only matches are surfaced, but
 # never leak non-visible datasets (visibility-aware RRF union)
@@ -683,11 +654,6 @@ async def test_semantic_visible_match_not_crowded_out_by_nearer_private(
     dim = await _get_embedding_dim(session)
     await _set_semantic_search(session, True)
 
-    # Use a dedicated vector band (lo=110) orthogonal to every other test's
-    # records so a concurrent -n4 worker's public lo=40 embedding can't pollute
-    # this test's restricted top-k (same-band vectors are near-cosine-identical,
-    # so an unrelated public record would otherwise tie-break into the limit).
-    band_lo = 110
     public_ds = await _create_search_dataset(
         session,
         created_by=admin_id,
@@ -697,7 +663,7 @@ async def test_semantic_visible_match_not_crowded_out_by_nearer_private(
     session.add(
         RecordEmbedding(
             record_id=public_ds.record_id,
-            embedding=_make_vector_band(0.85, dim=dim, lo=band_lo),
+            embedding=_make_vector_band(0.85, dim=dim),
             model_name="text-embedding-3-small",
             content_hash="p2a_public",
         )
@@ -714,7 +680,7 @@ async def test_semantic_visible_match_not_crowded_out_by_nearer_private(
             RecordEmbedding(
                 record_id=priv.record_id,
                 embedding=_make_vector_band(
-                    base, dim=dim, lo=band_lo
+                    base, dim=dim
                 ),  # nearer than the public 0.85
                 model_name="text-embedding-3-small",
                 content_hash=f"p2a_priv_{i}",
@@ -725,7 +691,7 @@ async def test_semantic_visible_match_not_crowded_out_by_nearer_private(
     with patch(
         "app.modules.catalog.search.service_semantic.generate_embedding",
         new_callable=AsyncMock,
-        return_value=_make_vector_band(1.0, dim=dim, lo=band_lo),
+        return_value=_make_vector_band(1.0, dim=dim),
     ):
         resp = await client.get(
             "/search/datasets/",

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -790,7 +790,7 @@ def test_decomposed_service_modules_stay_within_size_budgets() -> None:
         # Phase 1191 GAP-033: +new list_relationships_with_total for the list-envelope
         # contract ({relationships,total}); list_relationships DRY'd to delegate +
         # _visible_relationships extracted (shared, fail-closed). Cap 580 -> 595 (~7 LOC headroom).
-        # Smoke-check backlog B5d: +source/target Dataset.id resolution so the
+        # Smoke-check backlog (#315): +source/target Dataset.id resolution so the
         # list response returns dereferenceable ids. Cap 595 -> 605 (~7 LOC headroom).
         "backend/app/modules/catalog/datasets/domain/service_relationships.py": 605,
         "backend/app/modules/catalog/datasets/domain/service_metadata.py": 460,
@@ -882,10 +882,10 @@ def test_router_orchestrator_modules_stay_within_loc_cap() -> None:
         # layers endpoint groups into sub-routers (per Phase 226 / Phase 238) —
         # queued. HARD ceiling — do NOT raise past 1900 without decomposing.
         "backend/app/modules/catalog/maps/router.py": 1900,
-        # Smoke-check backlog: +~10 lines for the raster coverage list metadata
-        # (B1/OGC-1), stable numberMatched + collection count (B5c), and the
-        # filter-lang 400 (B5e). Cap 1600 -> 1610 (~9 LOC headroom).
-        "backend/app/modules/catalog/search/router.py": 1610,
+        # Smoke-check backlog (#315): raster coverage list metadata (itemType +
+        # rel=tiles, omit rel=items), stable numberMatched + collection count,
+        # and the filter-lang 400. Cap 1600 -> 1625 (~5 LOC headroom).
+        "backend/app/modules/catalog/search/router.py": 1625,
         # Phase 1176 PERF-002: +~60 lines for the raster tile auth/metadata
         # TTLCache (_RasterMeta + _resolve_raster_meta), mirroring the vector
         # tile meta cache so raster tiles aren't asymmetric.

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -790,7 +790,9 @@ def test_decomposed_service_modules_stay_within_size_budgets() -> None:
         # Phase 1191 GAP-033: +new list_relationships_with_total for the list-envelope
         # contract ({relationships,total}); list_relationships DRY'd to delegate +
         # _visible_relationships extracted (shared, fail-closed). Cap 580 -> 595 (~7 LOC headroom).
-        "backend/app/modules/catalog/datasets/domain/service_relationships.py": 595,
+        # Smoke-check backlog B5d: +source/target Dataset.id resolution so the
+        # list response returns dereferenceable ids. Cap 595 -> 605 (~7 LOC headroom).
+        "backend/app/modules/catalog/datasets/domain/service_relationships.py": 605,
         "backend/app/modules/catalog/datasets/domain/service_metadata.py": 460,
         "backend/app/modules/catalog/datasets/domain/service_query.py": 390,
         # Phase 276 CODE-02: chat_*.py sub-modules are all under the 350
@@ -880,7 +882,10 @@ def test_router_orchestrator_modules_stay_within_loc_cap() -> None:
         # layers endpoint groups into sub-routers (per Phase 226 / Phase 238) —
         # queued. HARD ceiling — do NOT raise past 1900 without decomposing.
         "backend/app/modules/catalog/maps/router.py": 1900,
-        "backend/app/modules/catalog/search/router.py": 1600,
+        # Smoke-check backlog: +~10 lines for the raster coverage list metadata
+        # (B1/OGC-1), stable numberMatched + collection count (B5c), and the
+        # filter-lang 400 (B5e). Cap 1600 -> 1610 (~9 LOC headroom).
+        "backend/app/modules/catalog/search/router.py": 1610,
         # Phase 1176 PERF-002: +~60 lines for the raster tile auth/metadata
         # TTLCache (_RasterMeta + _resolve_raster_meta), mirroring the vector
         # tile meta cache so raster tiles aren't asymmetric.

--- a/backend/tests/test_middleware.py
+++ b/backend/tests/test_middleware.py
@@ -170,7 +170,7 @@ async def test_ai_endpoint_rate_limit(client: AsyncClient, admin_auth_header: di
 
 @pytest.mark.anyio
 async def test_rate_limit_429_includes_retry_after(client: AsyncClient):
-    """B5b: a 429 from the limiter carries a positive integer Retry-After header.
+    """(#315) a 429 from the limiter carries a positive integer Retry-After header.
 
     Drives POST /auth/login past its per-minute budget (5/minute by default)
     with bad credentials so slowapi fires before the handler body, then asserts

--- a/backend/tests/test_middleware.py
+++ b/backend/tests/test_middleware.py
@@ -169,6 +169,44 @@ async def test_ai_endpoint_rate_limit(client: AsyncClient, admin_auth_header: di
 
 
 @pytest.mark.anyio
+async def test_rate_limit_429_includes_retry_after(client: AsyncClient):
+    """B5b: a 429 from the limiter carries a positive integer Retry-After header.
+
+    Drives POST /auth/login past its per-minute budget (5/minute by default)
+    with bad credentials so slowapi fires before the handler body, then asserts
+    the final 429 advertises the back-off window.
+    """
+    from app.modules.auth.router import limiter
+
+    original_enabled = limiter.enabled
+    try:
+        limiter.enabled = True
+        limiter._storage.reset()
+
+        last = None
+        for _ in range(8):
+            last = await client.post(
+                "/auth/login",
+                data={"username": "nobody", "password": "wrongpassword"},
+            )
+            if last.status_code == 429:
+                break
+
+        assert last is not None and last.status_code == 429, (
+            f"Expected a 429 after exhausting login limit, got: "
+            f"{last.status_code if last is not None else None}"
+        )
+        assert "retry-after" in last.headers, (
+            f"429 response missing Retry-After header; got: {dict(last.headers)}"
+        )
+        retry_after = int(last.headers["retry-after"])
+        assert retry_after > 0, f"Retry-After must be positive, got: {retry_after}"
+    finally:
+        limiter.enabled = original_enabled
+        limiter._storage.reset()
+
+
+@pytest.mark.anyio
 async def test_global_rate_limit_configurable(client: AsyncClient):
     """Global rate limit is configurable and defaults to 60/second."""
     from app.modules.auth.router import _global_rate_limit

--- a/backend/tests/test_ogc_cql2_filtering.py
+++ b/backend/tests/test_ogc_cql2_filtering.py
@@ -265,6 +265,63 @@ async def test_cql2_unsupported_filter_lang_returns_400(client: AsyncClient):
     assert "Unsupported filter-lang" in data["detail"]
 
 
+@pytest.mark.anyio
+async def test_search_datasets_unsupported_filter_lang_returns_400(client: AsyncClient):
+    """B5e: /search/datasets/ rejects a bogus filter-lang with 400 (was silently ignored)."""
+    resp = await client.get(
+        "/search/datasets/",
+        params={"filter": "title=x", "filter-lang": "bogus"},
+    )
+    assert resp.status_code == 400
+    data = resp.json()
+    assert "Unsupported filter-lang" in data["detail"]
+
+
+# ---------------------------------------------------------------------------
+# B4: feature collections reject filter (do not silently ignore)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize(
+    "filter_value",
+    [
+        pytest.param("name='x'", id="valid-cql2-text"),
+        pytest.param("!!!INVALID!!!", id="malformed"),
+        pytest.param("", id="empty-string"),
+    ],
+)
+async def test_feature_items_rejects_filter_400(
+    client: AsyncClient, test_db_session, filter_value: str
+):
+    """B4: ANY ``filter`` param on a per-dataset FEATURE collection returns 400.
+
+    CQL2 filtering is only implemented on the datasets (records) collection. On
+    feature collections the filter was previously dropped (200); it must now be
+    explicitly rejected.
+
+    This reject is *presence-based*: the handler rejects on the mere presence of
+    a ``filter`` query param, BEFORE any parse, so the contract holds regardless
+    of whether the value is valid CQL2, malformed, or empty. The parametrize
+    cases make that explicit -- there is intentionally no parse-level validation
+    on this path (use the datasets collection for catalog-level CQL2).
+    """
+    session = test_db_session
+    admin_id = await get_user_id(session, "admin")
+    unique = uuid.uuid4().hex[:8]
+    dataset = await _create_dataset(
+        session, created_by=admin_id, name=f"b4-feature-filter-{unique}"
+    )
+
+    resp = await client.get(
+        f"/collections/{dataset.id}/items",
+        params={"filter": filter_value},
+    )
+    assert resp.status_code == 400
+    data = resp.json()
+    assert "filter is not supported" in data["detail"].lower()
+
+
 # ---------------------------------------------------------------------------
 # Default Behavior Tests
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_ogc_cql2_filtering.py
+++ b/backend/tests/test_ogc_cql2_filtering.py
@@ -267,7 +267,7 @@ async def test_cql2_unsupported_filter_lang_returns_400(client: AsyncClient):
 
 @pytest.mark.anyio
 async def test_search_datasets_unsupported_filter_lang_returns_400(client: AsyncClient):
-    """B5e: /search/datasets/ rejects a bogus filter-lang with 400 (was silently ignored)."""
+    """(#315) /search/datasets/ rejects a bogus filter-lang with 400 (was silently ignored)."""
     resp = await client.get(
         "/search/datasets/",
         params={"filter": "title=x", "filter-lang": "bogus"},
@@ -278,7 +278,7 @@ async def test_search_datasets_unsupported_filter_lang_returns_400(client: Async
 
 
 # ---------------------------------------------------------------------------
-# B4: feature collections reject filter (do not silently ignore)
+# fix(#315): feature collections reject filter (do not silently ignore)
 # ---------------------------------------------------------------------------
 
 
@@ -294,7 +294,7 @@ async def test_search_datasets_unsupported_filter_lang_returns_400(client: Async
 async def test_feature_items_rejects_filter_400(
     client: AsyncClient, test_db_session, filter_value: str
 ):
-    """B4: ANY ``filter`` param on a per-dataset FEATURE collection returns 400.
+    """(#315) ANY ``filter`` param on a per-dataset FEATURE collection returns 400.
 
     CQL2 filtering is only implemented on the datasets (records) collection. On
     feature collections the filter was previously dropped (200); it must now be

--- a/backend/tests/test_ogc_features.py
+++ b/backend/tests/test_ogc_features.py
@@ -523,6 +523,8 @@ async def test_raster_collection_metadata_has_tiles_link(
     assert tiles_link is not None, "coverage collection must expose a rel=tiles link"
     assert tiles_link["type"] == "image/png"
     assert f"/raster-tiles/{raster_dataset.id}/tiles/" in tiles_link["href"]
+    # tiles are served at the app origin, not /api (which has no such route)
+    assert "/api/raster-tiles/" not in tiles_link["href"]
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_ogc_features.py
+++ b/backend/tests/test_ogc_features.py
@@ -97,6 +97,84 @@ async def _create_test_table_and_dataset(
     return dataset
 
 
+async def _create_raster_dataset(
+    session,
+    *,
+    created_by: uuid.UUID,
+    visibility: str = "public",
+    record_type: str = "raster_dataset",
+) -> Dataset:
+    """Register a raster/VRT dataset with NO backing PostGIS feature table.
+
+    Raster records carry a table_name (NOT NULL on the model) but no data.<table>
+    is ever created — this is exactly the B1 bug-trigger condition.
+    """
+    table_name = f"test_ogc_raster_{uuid.uuid4().hex[:8]}"
+    record = Record(
+        title=f"OGC Test Raster {table_name}",
+        summary="Test raster dataset for OGC Features hardening",
+        theme_category=["test"],
+        visibility=visibility,
+        record_status="published",
+        record_type=record_type,
+        created_by=created_by,
+    )
+    session.add(record)
+    await session.flush()
+    dataset = Dataset(
+        record_id=record.id,
+        table_name=table_name,
+        srid=4326,
+        geometry_type=None,
+        feature_count=None,
+        source_format="geotiff",
+    )
+    session.add(dataset)
+    await session.commit()
+    await session.refresh(dataset)
+    return dataset
+
+
+async def _create_missing_table_vector_dataset(
+    session,
+    *,
+    created_by: uuid.UUID,
+    visibility: str = "public",
+) -> Dataset:
+    """Register a VECTOR dataset whose backing data.<table> does NOT exist.
+
+    Simulates a cold-evicted / partially-ingested vector dataset: record_type is
+    vector_dataset and geometry_type is set (so the raster/VRT 404 guard does
+    NOT fire), but no data.<table> is created — so a feature query raises
+    ProgrammingError. The OGC handler must convert that to a 503, not a 500.
+    """
+    table_name = f"test_ogc_missing_{uuid.uuid4().hex[:8]}"
+    record = Record(
+        title=f"OGC Missing-Table Vector {table_name}",
+        summary="Test vector dataset with no backing table (B1 503 backstop)",
+        theme_category=["test"],
+        visibility=visibility,
+        record_status="published",
+        record_type="vector_dataset",
+        created_by=created_by,
+    )
+    session.add(record)
+    await session.flush()
+    dataset = Dataset(
+        record_id=record.id,
+        table_name=table_name,
+        srid=4326,
+        geometry_type="POINT",
+        feature_count=None,
+        column_info=[{"name": "name", "type": "text"}],
+        source_format="geojson",
+    )
+    session.add(dataset)
+    await session.commit()
+    await session.refresh(dataset)
+    return dataset
+
+
 async def _cleanup_table(session, table_name: str) -> None:
     await session.execute(text(f"DROP TABLE IF EXISTS data.{table_name}"))
     await session.commit()
@@ -133,6 +211,32 @@ async def private_dataset(client: AsyncClient, test_db_session):
     )
     yield dataset
     await _cleanup_table(test_db_session, dataset.table_name)
+
+
+@pytest.fixture
+async def raster_dataset(client: AsyncClient, test_db_session):
+    """Create a public raster dataset with no backing feature table (B1)."""
+    admin_id = await get_user_id(test_db_session, "admin")
+    dataset = await _create_raster_dataset(
+        test_db_session,
+        created_by=admin_id,
+        visibility="public",
+    )
+    # No data.<table> exists, so nothing to drop on teardown.
+    yield dataset
+
+
+@pytest.fixture
+async def missing_table_vector_dataset(client: AsyncClient, test_db_session):
+    """Create a public VECTOR dataset whose backing table is missing (B1 503)."""
+    admin_id = await get_user_id(test_db_session, "admin")
+    dataset = await _create_missing_table_vector_dataset(
+        test_db_session,
+        created_by=admin_id,
+        visibility="public",
+    )
+    # No data.<table> exists, so nothing to drop on teardown.
+    yield dataset
 
 
 # ---------------------------------------------------------------------------
@@ -358,6 +462,99 @@ async def test_get_single_feature_not_found(
     """GET /collections/{id}/items/99999 returns 404 for non-existent feature."""
     resp = await client.get(f"/collections/{public_dataset.id}/items/99999")
     assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# B1: raster/VRT collections have no feature items (must 404, never 500)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_raster_collection_items_returns_404(
+    client: AsyncClient, raster_dataset: Dataset
+):
+    """GET /collections/{raster_id}/items returns 404 problem+json, not a 500.
+
+    Raster datasets have no backing PostGIS table; querying it would raise
+    UndefinedTableError. The guard must short-circuit to a fast 404.
+    """
+    resp = await client.get(f"/collections/{raster_dataset.id}/items")
+    assert resp.status_code == 404
+    assert "application/problem+json" in resp.headers["content-type"]
+    data = resp.json()
+    assert "raster" in data["detail"].lower()
+
+
+@pytest.mark.anyio
+async def test_raster_collection_single_item_returns_404(
+    client: AsyncClient, raster_dataset: Dataset
+):
+    """GET /collections/{raster_id}/items/1 returns 404, not a 500."""
+    resp = await client.get(f"/collections/{raster_dataset.id}/items/1")
+    assert resp.status_code == 404
+    assert "application/problem+json" in resp.headers["content-type"]
+    data = resp.json()
+    assert "raster" in data["detail"].lower()
+
+
+@pytest.mark.anyio
+async def test_raster_collection_metadata_is_coverage(
+    client: AsyncClient, raster_dataset: Dataset
+):
+    """Raster collection metadata advertises itemType=coverage and omits rel=items."""
+    resp = await client.get(f"/collections/{raster_dataset.id}")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["itemType"] == "coverage"
+    rels = {link["rel"] for link in data["links"]}
+    assert "items" not in rels
+    assert "self" in rels
+
+
+@pytest.mark.anyio
+async def test_raster_collection_metadata_has_tiles_link(
+    client: AsyncClient, raster_dataset: Dataset
+):
+    """OGC-6: a coverage collection advertises a rel=tiles link so it is not a dead-end."""
+    resp = await client.get(f"/collections/{raster_dataset.id}")
+    assert resp.status_code == 200
+    data = resp.json()
+    tiles_link = next((link for link in data["links"] if link["rel"] == "tiles"), None)
+    assert tiles_link is not None, "coverage collection must expose a rel=tiles link"
+    assert tiles_link["type"] == "image/png"
+    assert f"/raster-tiles/{raster_dataset.id}/tiles/" in tiles_link["href"]
+
+
+# ---------------------------------------------------------------------------
+# B1: a missing-table VECTOR dataset must 503, never 500
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_missing_table_vector_items_returns_503(
+    client: AsyncClient, missing_table_vector_dataset: Dataset
+):
+    """A vector dataset whose backing table is gone returns 503 on /items, not 500.
+
+    The raster/VRT 404 guard does not fire (record_type=vector_dataset,
+    geometry_type set), so the feature query hits a missing data.<table> and
+    raises ProgrammingError. The handler must convert that to a 503.
+    """
+    resp = await client.get(f"/collections/{missing_table_vector_dataset.id}/items")
+    assert resp.status_code == 503
+    data = resp.json()
+    assert "unavailable" in data["detail"].lower()
+
+
+@pytest.mark.anyio
+async def test_missing_table_vector_single_item_returns_503(
+    client: AsyncClient, missing_table_vector_dataset: Dataset
+):
+    """A vector dataset whose backing table is gone returns 503 on a single item, not 500."""
+    resp = await client.get(f"/collections/{missing_table_vector_dataset.id}/items/1")
+    assert resp.status_code == 503
+    data = resp.json()
+    assert "unavailable" in data["detail"].lower()
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_ogc_features.py
+++ b/backend/tests/test_ogc_features.py
@@ -107,7 +107,7 @@ async def _create_raster_dataset(
     """Register a raster/VRT dataset with NO backing PostGIS feature table.
 
     Raster records carry a table_name (NOT NULL on the model) but no data.<table>
-    is ever created — this is exactly the B1 bug-trigger condition.
+    is ever created — this is exactly the (#315) bug-trigger condition.
     """
     table_name = f"test_ogc_raster_{uuid.uuid4().hex[:8]}"
     record = Record(
@@ -151,7 +151,7 @@ async def _create_missing_table_vector_dataset(
     table_name = f"test_ogc_missing_{uuid.uuid4().hex[:8]}"
     record = Record(
         title=f"OGC Missing-Table Vector {table_name}",
-        summary="Test vector dataset with no backing table (B1 503 backstop)",
+        summary="Test vector dataset with no backing table (503 backstop)",
         theme_category=["test"],
         visibility=visibility,
         record_status="published",
@@ -215,7 +215,7 @@ async def private_dataset(client: AsyncClient, test_db_session):
 
 @pytest.fixture
 async def raster_dataset(client: AsyncClient, test_db_session):
-    """Create a public raster dataset with no backing feature table (B1)."""
+    """Create a public raster dataset with no backing feature table (#315)."""
     admin_id = await get_user_id(test_db_session, "admin")
     dataset = await _create_raster_dataset(
         test_db_session,
@@ -228,7 +228,7 @@ async def raster_dataset(client: AsyncClient, test_db_session):
 
 @pytest.fixture
 async def missing_table_vector_dataset(client: AsyncClient, test_db_session):
-    """Create a public VECTOR dataset whose backing table is missing (B1 503)."""
+    """Create a public VECTOR dataset whose backing table is missing (#315 503)."""
     admin_id = await get_user_id(test_db_session, "admin")
     dataset = await _create_missing_table_vector_dataset(
         test_db_session,
@@ -465,7 +465,7 @@ async def test_get_single_feature_not_found(
 
 
 # ---------------------------------------------------------------------------
-# B1: raster/VRT collections have no feature items (must 404, never 500)
+# fix(#315): raster/VRT collections have no feature items (must 404, never 500)
 # ---------------------------------------------------------------------------
 
 
@@ -515,7 +515,7 @@ async def test_raster_collection_metadata_is_coverage(
 async def test_raster_collection_metadata_has_tiles_link(
     client: AsyncClient, raster_dataset: Dataset
 ):
-    """OGC-6: a coverage collection advertises a rel=tiles link so it is not a dead-end."""
+    """(#315) a coverage collection advertises a rel=tiles link so it is not a dead-end."""
     resp = await client.get(f"/collections/{raster_dataset.id}")
     assert resp.status_code == 200
     data = resp.json()
@@ -526,7 +526,7 @@ async def test_raster_collection_metadata_has_tiles_link(
 
 
 # ---------------------------------------------------------------------------
-# B1: a missing-table VECTOR dataset must 503, never 500
+# fix(#315): a missing-table VECTOR dataset must 503, never 500
 # ---------------------------------------------------------------------------
 
 

--- a/backend/tests/test_search.py
+++ b/backend/tests/test_search.py
@@ -1144,7 +1144,7 @@ async def test_search_collections_counted_in_number_matched(
     test_db_session,
     clean_tables,
 ):
-    """B5c: appended collection features are counted in numberMatched.
+    """(#315) appended collection features are counted in numberMatched.
 
     On page 0 of a text search, matching collections (up to 5) are appended to
     ``features`` alongside the dataset results. ``numberReturned`` counts those
@@ -1201,7 +1201,7 @@ async def test_number_matched_caps_collections_at_display_limit(
     test_db_session,
     clean_tables,
 ):
-    """B5c/Codex P2: numberMatched must not exceed retrievable results.
+    """(#315) numberMatched must not exceed retrievable results.
 
     Only the first 5 matching collections are ever shown (page-0 cap) and they
     are never paginated, so numberMatched must count at most 5 of them -- counting
@@ -1241,7 +1241,7 @@ async def test_ogc_collections_list_raster_is_coverage_no_items_link(
     admin_auth_header: dict,
     test_db_session,
 ):
-    """OGC-1: GET /collections advertises raster datasets as coverages.
+    """(#315) GET /collections advertises raster datasets as coverages.
 
     A raster (or VRT) dataset has no backing feature table, so the per-dataset
     LIST endpoint must mirror the detail endpoint: itemType=="coverage" and NO
@@ -1277,6 +1277,8 @@ async def test_ogc_collections_list_raster_is_coverage_no_items_link(
     assert raster_entry["itemType"] == "coverage"
     raster_rels = {link["rel"] for link in raster_entry["links"]}
     assert "items" not in raster_rels
+    # raster coverage exposes a tiles link instead of the dead items link
+    assert "tiles" in raster_rels
 
     vector_entry = collections[str(vector.id)]
     assert vector_entry["itemType"] == "feature"
@@ -1291,7 +1293,7 @@ async def test_search_pagination_stable_number_matched_with_collection(
     test_db_session,
     clean_tables,
 ):
-    """B5c: numberMatched stable across pages; no phantom next-link.
+    """(#315) numberMatched stable across pages; no phantom next-link.
 
     Seed N datasets > limit (so dataset_total straddles the small limit
     boundary) plus a matching collection. Page through every page and assert:

--- a/backend/tests/test_search.py
+++ b/backend/tests/test_search.py
@@ -1195,6 +1195,47 @@ async def test_search_collections_counted_in_number_matched(
 
 
 @pytest.mark.anyio
+async def test_number_matched_caps_collections_at_display_limit(
+    client: AsyncClient,
+    admin_auth_header: dict,
+    test_db_session,
+    clean_tables,
+):
+    """B5c/Codex P2: numberMatched must not exceed retrievable results.
+
+    Only the first 5 matching collections are ever shown (page-0 cap) and they
+    are never paginated, so numberMatched must count at most 5 of them -- counting
+    the full match would advertise results no page can return.
+    """
+    session = test_db_session
+    admin_id = await get_user_id(session, "admin")
+    token = f"glcap{uuid.uuid4().hex[:8]}"
+
+    # Six collections match the token, zero datasets.
+    for i in range(6):
+        session.add(
+            Collection(
+                name=f"{token} Collection {i}",
+                description="matches the token",
+                created_by=admin_id,
+            )
+        )
+    await session.commit()
+
+    resp = await client.get(
+        "/search/datasets/", params={"q": token}, headers=admin_auth_header
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+
+    # 5 shown (the cap), numberMatched capped to match, invariant holds, no next.
+    assert data["numberReturned"] == 5
+    assert data["numberMatched"] == 5
+    assert data["numberReturned"] <= data["numberMatched"]
+    assert not any(link["rel"] == "next" for link in data["links"])
+
+
+@pytest.mark.anyio
 async def test_ogc_collections_list_raster_is_coverage_no_items_link(
     client: AsyncClient,
     admin_auth_header: dict,

--- a/backend/tests/test_search.py
+++ b/backend/tests/test_search.py
@@ -17,6 +17,7 @@ import pytest
 from httpx import AsyncClient
 from sqlalchemy import func, update
 
+from app.modules.catalog.collections.models import Collection
 from app.modules.catalog.datasets.domain.models import (
     Dataset,
     Record,
@@ -68,6 +69,7 @@ async def _create_search_dataset(
     theme_category: list[str] | None = None,
     lineage_summary: str | None = None,
     language: str | None = None,
+    record_type: str = "vector_dataset",
 ) -> Dataset:
     """Insert a Record + Dataset pair with optional spatial extent and keywords."""
     table_name = f"ds_{uuid.uuid4().hex[:12]}"
@@ -81,6 +83,7 @@ async def _create_search_dataset(
         "temporal_end": data_vintage_end,
         "theme_category": theme_category,
         "lineage_summary": lineage_summary,
+        "record_type": record_type,
     }
     if language is not None:
         record_kwargs["language"] = language
@@ -1132,3 +1135,204 @@ async def test_search_simple_tsvector_matches_unicode_lineage(
     assert resp.status_code == 200
     titles = [f["properties"]["title"] for f in resp.json()["features"]]
     assert title in titles
+
+
+@pytest.mark.anyio
+async def test_search_collections_counted_in_number_matched(
+    client: AsyncClient,
+    admin_auth_header: dict,
+    test_db_session,
+    clean_tables,
+):
+    """B5c: appended collection features are counted in numberMatched.
+
+    On page 0 of a text search, matching collections (up to 5) are appended to
+    ``features`` alongside the dataset results. ``numberReturned`` counts those
+    appended collections, so ``numberMatched`` must include them too -- otherwise
+    numberReturned can exceed numberMatched.
+    """
+    session = test_db_session
+    admin_id = await get_user_id(session, "admin")
+    token = f"glb5c{uuid.uuid4().hex[:8]}"
+
+    # Two datasets that match the token via title (well under the default limit).
+    for i in range(2):
+        await _create_search_dataset(
+            session,
+            created_by=admin_id,
+            name=f"{token} Dataset {i}",
+        )
+
+    # One collection that matches the token via its name.
+    collection = Collection(
+        name=f"{token} Collection",
+        description="Collection that matches the search token",
+        created_by=admin_id,
+    )
+    session.add(collection)
+    await session.commit()
+    await session.refresh(collection)
+
+    resp = await client.get(
+        "/search/datasets/",
+        params={"q": token},
+        headers=admin_auth_header,
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+
+    feature_types = [f["properties"].get("type") for f in data["features"]]
+    appended_collections = feature_types.count("collection")
+    dataset_features = len(data["features"]) - appended_collections
+
+    # The seeded collection must have been appended.
+    assert appended_collections >= 1
+    # Invariant: numberReturned never exceeds numberMatched.
+    assert data["numberReturned"] <= data["numberMatched"]
+    assert data["numberReturned"] == len(data["features"])
+    # numberMatched accounts for datasets + appended collections.
+    assert data["numberMatched"] == dataset_features + appended_collections
+
+
+@pytest.mark.anyio
+async def test_ogc_collections_list_raster_is_coverage_no_items_link(
+    client: AsyncClient,
+    admin_auth_header: dict,
+    test_db_session,
+):
+    """OGC-1: GET /collections advertises raster datasets as coverages.
+
+    A raster (or VRT) dataset has no backing feature table, so the per-dataset
+    LIST endpoint must mirror the detail endpoint: itemType=="coverage" and NO
+    rel=="items" link (which would 404 for crawlers). A vector dataset in the
+    same listing must still be itemType=="feature" with a rel=="items" link.
+    """
+    session = test_db_session
+    admin_id = await get_user_id(session, "admin")
+    token = uuid.uuid4().hex[:10]
+
+    raster = await _create_search_dataset(
+        session,
+        created_by=admin_id,
+        name=f"Raster {token}",
+        record_type="raster_dataset",
+    )
+    vector = await _create_search_dataset(
+        session,
+        created_by=admin_id,
+        name=f"Vector {token}",
+        record_type="vector_dataset",
+    )
+
+    resp = await client.get(
+        "/collections",
+        params={"limit": 200},
+        headers=admin_auth_header,
+    )
+    assert resp.status_code == 200
+    collections = {c["id"]: c for c in resp.json()["collections"]}
+
+    raster_entry = collections[str(raster.id)]
+    assert raster_entry["itemType"] == "coverage"
+    raster_rels = {link["rel"] for link in raster_entry["links"]}
+    assert "items" not in raster_rels
+
+    vector_entry = collections[str(vector.id)]
+    assert vector_entry["itemType"] == "feature"
+    vector_rels = {link["rel"] for link in vector_entry["links"]}
+    assert "items" in vector_rels
+
+
+@pytest.mark.anyio
+async def test_search_pagination_stable_number_matched_with_collection(
+    client: AsyncClient,
+    admin_auth_header: dict,
+    test_db_session,
+    clean_tables,
+):
+    """B5c: numberMatched stable across pages; no phantom next-link.
+
+    Seed N datasets > limit (so dataset_total straddles the small limit
+    boundary) plus a matching collection. Page through every page and assert:
+      - numberMatched is IDENTICAL on every page (page-independent),
+      - numberReturned <= numberMatched on every page,
+      - no page returns 0 features while it advertised a next link,
+      - the union of dataset ids across pages has no dupes/drops.
+    """
+    session = test_db_session
+    admin_id = await get_user_id(session, "admin")
+    token = f"glpage{uuid.uuid4().hex[:8]}"
+
+    n_datasets = 3
+    limit = 2  # dataset_total (3) straddles the limit (2) boundary
+    seeded_dataset_ids = set()
+    for i in range(n_datasets):
+        ds = await _create_search_dataset(
+            session,
+            created_by=admin_id,
+            name=f"{token} Dataset {i}",
+        )
+        seeded_dataset_ids.add(str(ds.id))
+
+    # A matching collection so dataset_total + collections > limit on page 0.
+    collection = Collection(
+        name=f"{token} Collection",
+        description="Collection matching the search token",
+        created_by=admin_id,
+    )
+    session.add(collection)
+    await session.commit()
+
+    seen_dataset_ids: list[str] = []
+    number_matched_values: set[int] = set()
+
+    offset = 0
+    pages = 0
+    while True:
+        pages += 1
+        assert pages < 20, "pagination did not terminate"
+        resp = await client.get(
+            "/search/datasets/",
+            params={"q": token, "limit": limit, "offset": offset},
+            headers=admin_auth_header,
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+
+        number_matched_values.add(data["numberMatched"])
+        # numberReturned never exceeds numberMatched on any page.
+        assert data["numberReturned"] <= data["numberMatched"]
+
+        page_dataset_ids = [
+            f["id"]
+            for f in data["features"]
+            if f["properties"].get("type") != "collection"
+        ]
+        seen_dataset_ids.extend(page_dataset_ids)
+
+        has_next = any(link["rel"] == "next" for link in data.get("links", []))
+        # No phantom next-link: a next link must not point at an empty page. If a
+        # next link was advertised, the FOLLOWING page must return >=1 feature.
+        if has_next:
+            next_resp = await client.get(
+                "/search/datasets/",
+                params={"q": token, "limit": limit, "offset": offset + limit},
+                headers=admin_auth_header,
+            )
+            assert next_resp.status_code == 200
+            assert next_resp.json()["numberReturned"] > 0, (
+                "next link advertised but the next page is empty (phantom next-link)"
+            )
+            offset += limit
+        else:
+            break
+
+    # numberMatched is identical on every page (page-independent).
+    assert len(number_matched_values) == 1
+    only_matched = number_matched_values.pop()
+    # Stable total = datasets (3) + the single matching collection (1).
+    assert only_matched == n_datasets + 1
+
+    # Union of dataset ids across pages: no dupes, no drops.
+    assert len(seen_dataset_ids) == len(set(seen_dataset_ids)), "duplicate dataset ids"
+    assert set(seen_dataset_ids) == seeded_dataset_ids, "dropped or extra dataset ids"

--- a/backend/tests/test_search_datetime.py
+++ b/backend/tests/test_search_datetime.py
@@ -4,6 +4,7 @@ import uuid
 from datetime import date
 
 import pytest
+from fastapi import HTTPException
 from httpx import AsyncClient
 from app.modules.catalog.datasets.domain.models import Dataset, Record, RecordKeyword
 from app.modules.catalog.search.service import parse_ogc_datetime
@@ -92,6 +93,20 @@ def test_parse_open_end():
 def test_parse_full_datetime():
     result = parse_ogc_datetime("2024-01-15T00:00:00Z")
     assert result == (date(2024, 1, 15), date(2024, 1, 15))
+
+
+def test_parse_garbage_raises_http_400():
+    """A malformed datetime raises HTTPException(400), not a generic ValueError/500."""
+    with pytest.raises(HTTPException) as exc_info:
+        parse_ogc_datetime("garbage")
+    assert exc_info.value.status_code == 400
+
+
+def test_parse_garbage_interval_raises_http_400():
+    """A malformed datetime inside an interval also raises HTTPException(400)."""
+    with pytest.raises(HTTPException) as exc_info:
+        parse_ogc_datetime("garbage/2024-12-31")
+    assert exc_info.value.status_code == 400
 
 
 # ---------------------------------------------------------------------------
@@ -215,3 +230,50 @@ async def test_datetime_no_filter_returns_all(
     assert str(datetime_datasets["ds_2020"].id) in ids
     assert str(datetime_datasets["ds_2023"].id) in ids
     assert str(datetime_datasets["ds_none"].id) in ids
+
+
+# ---------------------------------------------------------------------------
+# B5e: malformed datetime -> 400 (not 500) on every datetime chokepoint
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_collection_items_garbage_datetime_returns_400(
+    client: AsyncClient,
+    admin_auth_header: dict,
+):
+    """GET /collections/datasets/items?datetime=garbage returns 400 (was 500)."""
+    resp = await client.get(
+        "/collections/datasets/items",
+        params={"datetime": "garbage"},
+        headers=admin_auth_header,
+    )
+    assert resp.status_code == 400
+
+
+@pytest.mark.anyio
+async def test_search_datasets_garbage_datetime_returns_400(
+    client: AsyncClient,
+    admin_auth_header: dict,
+):
+    """GET /search/datasets/?datetime=garbage returns 400 (was 500)."""
+    resp = await client.get(
+        "/search/datasets/",
+        params={"datetime": "garbage"},
+        headers=admin_auth_header,
+    )
+    assert resp.status_code == 400
+
+
+@pytest.mark.anyio
+async def test_facets_garbage_datetime_returns_400(
+    client: AsyncClient,
+    admin_auth_header: dict,
+):
+    """GET /search/facets/?datetime=garbage returns 400 (was 500)."""
+    resp = await client.get(
+        "/search/facets/",
+        params={"datetime": "garbage"},
+        headers=admin_auth_header,
+    )
+    assert resp.status_code == 400

--- a/backend/tests/test_search_datetime.py
+++ b/backend/tests/test_search_datetime.py
@@ -233,7 +233,7 @@ async def test_datetime_no_filter_returns_all(
 
 
 # ---------------------------------------------------------------------------
-# B5e: malformed datetime -> 400 (not 500) on every datetime chokepoint
+# fix(#315): malformed datetime -> 400 (not 500) on every datetime chokepoint
 # ---------------------------------------------------------------------------
 
 

--- a/backend/tests/test_search_pagination.py
+++ b/backend/tests/test_search_pagination.py
@@ -1,0 +1,218 @@
+"""Pagination stability tests for /search/datasets.
+
+Regression coverage for B2: the standard (non-RRF) sort path used 6 ORDER BY
+branches, none of which had a unique tiebreaker. When many rows tie on the
+sort key (same record_status, updated_at, created_at, title) OFFSET/LIMIT
+returned a non-stable order, so paging the full result set produced duplicate
+records on some pages and dropped others.
+
+The fix appends Record.id (the UUID PK) as a deterministic final tiebreaker to
+every branch. These tests seed > limit datasets with identical sort keys, page
+the whole set at a small limit, and assert: no dupes, no drops, full coverage,
+and an identical order across two independent runs.
+"""
+
+import uuid
+from datetime import date
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import update
+
+from app.modules.catalog.datasets.domain.models import Dataset, Record
+
+from tests.factories import get_user_id
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+async def _create_tied_dataset(
+    session,
+    *,
+    created_by: uuid.UUID,
+    name: str,
+    keyword_tag: str,
+    fixed_ts,
+) -> Dataset:
+    """Insert a Record + Dataset whose sort keys are identical to its siblings.
+
+    title, record_status, created_at and updated_at are all pinned to the same
+    value so the only thing distinguishing rows is the UUID PK tiebreaker.
+    """
+    table_name = f"ds_{uuid.uuid4().hex[:12]}"
+    record = Record(
+        title=name,
+        summary=f"Description for {name}",
+        visibility="public",
+        record_status="published",
+        created_by=created_by,
+        theme_category=[keyword_tag],
+    )
+    session.add(record)
+    await session.flush()
+
+    dataset = Dataset(
+        record_id=record.id,
+        table_name=table_name,
+        srid=4326,
+        geometry_type="MultiPolygon",
+        feature_count=100,
+        source_format="geojson",
+        source_filename="test.geojson",
+    )
+    session.add(dataset)
+    await session.flush()
+
+    # Pin created_at / updated_at to identical timestamps so every row ties.
+    await session.execute(
+        update(Record)
+        .where(Record.id == record.id)
+        .values(created_at=fixed_ts, updated_at=fixed_ts)
+    )
+    await session.commit()
+    await session.refresh(dataset)
+    return dataset
+
+
+async def _page_all_ids(
+    client: AsyncClient,
+    headers: dict,
+    *,
+    sort_by: str,
+    keyword_tag: str,
+    page_size: int,
+) -> list[str]:
+    """Walk every page of a search and collect the dataset feature ids in order."""
+    all_ids: list[str] = []
+    offset = 0
+    # Use the theme_category token as q so only our seeded datasets match.
+    while True:
+        resp = await client.get(
+            "/search/datasets/",
+            params={
+                "q": keyword_tag,
+                "sort_by": sort_by,
+                "limit": page_size,
+                "offset": offset,
+            },
+            headers=headers,
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        page_ids = [
+            f["id"]
+            for f in data["features"]
+            if f["properties"].get("type") != "collection"
+        ]
+        all_ids.extend(page_ids)
+        offset += page_size
+        if offset >= data["numberMatched"]:
+            break
+        # Safety valve against an accidental infinite loop.
+        if offset > data["numberMatched"] + page_size * 5:
+            pytest.fail("pagination did not terminate")
+    return all_ids
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+async def tied_datasets(test_db_session):
+    """Seed a pool of datasets that tie on every non-id sort key."""
+    session = test_db_session
+    admin_id = await get_user_id(session, "admin")
+    keyword_tag = f"tiebreak{uuid.uuid4().hex[:8]}"
+    fixed_ts = date(2024, 3, 14)
+    datasets = []
+    # 7 rows, all identical sort keys; page at limit=2 (4 pages).
+    for _ in range(7):
+        ds = await _create_tied_dataset(
+            session,
+            created_by=admin_id,
+            name="Identical Tiebreak Dataset",
+            keyword_tag=keyword_tag,
+            fixed_ts=fixed_ts,
+        )
+        datasets.append(ds)
+    return {"datasets": datasets, "keyword_tag": keyword_tag}
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize(
+    "sort_by",
+    ["relevance", "date_added", "last_updated", "title", "name"],
+)
+async def test_pagination_no_dupes_no_drops_across_branches(
+    client: AsyncClient,
+    admin_auth_header: dict,
+    tied_datasets: dict,
+    sort_by: str,
+):
+    """Paging tied rows yields every id exactly once for every sort branch."""
+    expected = {str(ds.id) for ds in tied_datasets["datasets"]}
+    keyword_tag = tied_datasets["keyword_tag"]
+
+    paged = await _page_all_ids(
+        client,
+        admin_auth_header,
+        sort_by=sort_by,
+        keyword_tag=keyword_tag,
+        page_size=2,
+    )
+
+    seen = [pid for pid in paged if pid in expected]
+    # No duplicates across pages.
+    assert len(seen) == len(set(seen)), f"duplicate ids paging sort_by={sort_by}"
+    # Full coverage -- no dropped rows.
+    assert set(seen) == expected, f"missing/extra ids paging sort_by={sort_by}"
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize(
+    "sort_by",
+    ["relevance", "date_added", "last_updated", "title", "name"],
+)
+async def test_pagination_order_is_stable_across_runs(
+    client: AsyncClient,
+    admin_auth_header: dict,
+    tied_datasets: dict,
+    sort_by: str,
+):
+    """The full paged order is identical across two independent runs."""
+    expected = {str(ds.id) for ds in tied_datasets["datasets"]}
+    keyword_tag = tied_datasets["keyword_tag"]
+
+    run1 = [
+        pid
+        for pid in await _page_all_ids(
+            client,
+            admin_auth_header,
+            sort_by=sort_by,
+            keyword_tag=keyword_tag,
+            page_size=2,
+        )
+        if pid in expected
+    ]
+    run2 = [
+        pid
+        for pid in await _page_all_ids(
+            client,
+            admin_auth_header,
+            sort_by=sort_by,
+            keyword_tag=keyword_tag,
+            page_size=2,
+        )
+        if pid in expected
+    ]
+    assert run1 == run2, f"unstable order across runs for sort_by={sort_by}"

--- a/backend/tests/test_search_pagination.py
+++ b/backend/tests/test_search_pagination.py
@@ -1,6 +1,6 @@
 """Pagination stability tests for /search/datasets.
 
-Regression coverage for B2: the standard (non-RRF) sort path used 6 ORDER BY
+Regression coverage for (#315): the standard (non-RRF) sort path used 6 ORDER BY
 branches, none of which had a unique tiebreaker. When many rows tie on the
 sort key (same record_status, updated_at, created_at, title) OFFSET/LIMIT
 returned a non-stable order, so paging the full result set produced duplicate

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -971,6 +971,14 @@ export interface ColumnStatsResponse {
    * here so the std-dev branch is correctly enabled once the backend ships it.
    */
   stddev?: number | null;
+  /**
+   * 'categorical' when the column is non-numeric (text/varchar/etc.); null for
+   * numeric columns. Lets callers skip graduated styling on text columns
+   * instead of treating an all-null numeric response as an error.
+   */
+  data_type?: string | null;
+  /** Distinct non-null value count; populated only for categorical columns. */
+  distinct_count?: number | null;
 }
 
 // Maps

--- a/sdks/python/geolens/models/column_stats_response.py
+++ b/sdks/python/geolens/models/column_stats_response.py
@@ -19,6 +19,8 @@ class ColumnStatsResponse:
     """
     Attributes:
         count (int | Unset):  Default: 0.
+        data_type (None | str | Unset): 'categorical' for non-numeric columns; null for numeric.
+        distinct_count (int | None | Unset): Distinct non-null value count (categorical columns only).
         max_ (float | None | Unset):
         mean (float | None | Unset):
         min_ (float | None | Unset):
@@ -27,6 +29,8 @@ class ColumnStatsResponse:
     """
 
     count: int | Unset = 0
+    data_type: None | str | Unset = UNSET
+    distinct_count: int | None | Unset = UNSET
     max_: float | None | Unset = UNSET
     mean: float | None | Unset = UNSET
     min_: float | None | Unset = UNSET
@@ -36,6 +40,18 @@ class ColumnStatsResponse:
 
     def to_dict(self) -> dict[str, Any]:
         count = self.count
+
+        data_type: None | str | Unset
+        if isinstance(self.data_type, Unset):
+            data_type = UNSET
+        else:
+            data_type = self.data_type
+
+        distinct_count: int | None | Unset
+        if isinstance(self.distinct_count, Unset):
+            distinct_count = UNSET
+        else:
+            distinct_count = self.distinct_count
 
         max_: float | None | Unset
         if isinstance(self.max_, Unset):
@@ -70,6 +86,10 @@ class ColumnStatsResponse:
         field_dict.update({})
         if count is not UNSET:
             field_dict["count"] = count
+        if data_type is not UNSET:
+            field_dict["data_type"] = data_type
+        if distinct_count is not UNSET:
+            field_dict["distinct_count"] = distinct_count
         if max_ is not UNSET:
             field_dict["max"] = max_
         if mean is not UNSET:
@@ -87,6 +107,24 @@ class ColumnStatsResponse:
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         count = d.pop("count", UNSET)
+
+        def _parse_data_type(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        data_type = _parse_data_type(d.pop("data_type", UNSET))
+
+        def _parse_distinct_count(data: object) -> int | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(int | None | Unset, data)
+
+        distinct_count = _parse_distinct_count(d.pop("distinct_count", UNSET))
 
         def _parse_max_(data: object) -> float | None | Unset:
             if data is None:
@@ -128,6 +166,8 @@ class ColumnStatsResponse:
 
         column_stats_response = cls(
             count=count,
+            data_type=data_type,
+            distinct_count=distinct_count,
             max_=max_,
             mean=mean,
             min_=min_,

--- a/sdks/python/geolens/models/ogc_collection_metadata.py
+++ b/sdks/python/geolens/models/ogc_collection_metadata.py
@@ -32,8 +32,8 @@ class OGCCollectionMetadata:
         description (None | str | Unset): Collection description.
         extent (None | OGCCollectionMetadataExtentType0 | Unset): Spatial and temporal extent (OGC API Features extent
             object).
-        item_type (str | Unset): Type of items in the collection. Always 'feature' for OGC API Features. Default:
-            'feature'.
+        item_type (str | Unset): Type of items in the collection: 'feature' for vector feature collections, 'coverage'
+            for raster/VRT collections (which expose tiles instead of feature items). Default: 'feature'.
     """
 
     id: str

--- a/sdks/typescript/src/client/types.gen.ts
+++ b/sdks/typescript/src/client/types.gen.ts
@@ -1760,6 +1760,18 @@ export type ColumnStatsResponse = {
      */
     count?: number;
     /**
+     * Data Type
+     *
+     * 'categorical' for non-numeric columns; null for numeric.
+     */
+    data_type?: string | null;
+    /**
+     * Distinct Count
+     *
+     * Distinct non-null value count (categorical columns only).
+     */
+    distinct_count?: number | null;
+    /**
      * Max
      */
     max?: number | null;
@@ -5915,7 +5927,7 @@ export type OgcCollectionMetadata = {
     /**
      * Itemtype
      *
-     * Type of items in the collection. Always 'feature' for OGC API Features.
+     * Type of items in the collection: 'feature' for vector feature collections, 'coverage' for raster/VRT collections (which expose tiles instead of feature items).
      */
     itemType?: string;
     /**


### PR DESCRIPTION
## Smoke-check backlog — backend hardening

Fixes the backend defects surfaced by the post-#314 demo smoke-check. Every bug below was **reproduced live** against the local stack before fixing, and each fix ships with regression tests. Work was done in two passes: implement → adversarial multi-lens review (which caught one regression I introduced + three incomplete fixes) → round-2 fixes.

### Fixed

| # | Sev | Bug | Fix |
|---|-----|-----|-----|
| B1 | **CRITICAL** | Raster/DEM `GET /collections/{id}/items` returned **500** (`UndefinedTableError`) and held a DB connection ~20s on an unauth endpoint — a DoS-amplification vector. | `record_type` guard → fast **404** before any query, on both OGC handlers **and** the native `/datasets/{id}/features*` router (the same root cause lived on a second router). Missing-table *vector* datasets (cold-evicted/partial ingest) now return **503** instead of 500. |
| B2 | HIGH | Default search pagination **duplicated/dropped** records (unstable `ORDER BY`, no unique tiebreaker). | Append `Record.id` tiebreaker to every dataset search sort branch. |
| B3 | HIGH | `GET /datasets/{id}/columns/{col}/stats/` **500** on text columns (`::numeric` cast). | Detect column type; non-numeric columns return a categorical summary (`count` + `distinct_count` + `data_type`). New optional `ColumnStatsResponse` fields. |
| B4 | HIGH | On feature collections, CQL2 `filter=` was **silently ignored**; a malformed filter returned 200. | Reject `filter=` on feature collections with **400** (CQL2 is supported on the `datasets`/records collection, which has queryables); reserve `filter`/`filter-lang`. |
| B5b | LOW | 429 responses lacked **Retry-After**. | Emit `Retry-After` from the limiter window. |
| B5c | MED | `numberReturned > numberMatched` (appended search collections weren't counted). | `numberMatched` is now stable across pages and includes the full matching-collection count; next-link driven by the dataset total only (no phantom next-link to an empty page). |
| B5d | LOW | `/datasets/{id}/relationships/` returned `record_id`s that **404** on dereference. | Return dereferenceable `Dataset.id` values (list **and** create responses). |
| B5e | LOW | Malformed `datetime=` → **500**; `filter-lang` ignored on `/search/datasets`. | 400 on malformed datetime (records/search/facets/STAC) and on bad `filter-lang`. |

Also: collection list + detail now advertise `itemType=coverage` + a `rel=tiles` link (and omit the dead `rel=items` link) for raster/VRT, so crawlers aren't led into the B1 404.

### Not a code bug (stale demo image)

- **B5a** (duplicate security headers / missing HSTS): investigated and found **already correct** on `main` — headers are single-sourced and HSTS is TLS-gated with tests. The smoke-check saw this on the stale demo image, not current code. No change.

### Deferred (documented, low-impact / pre-existing)

- A dataset column literally named `filter` can no longer be used as a property filter on feature collections (now 400). Colliding with an OGC reserved param is non-conformant; narrow blast radius.
- Numeric values stored in a **text** column now report categorical stats (no graduated min/max). Genuine numeric columns are unaffected; GIS imports land in real numeric types.
- Semantic (RRF) result ordering on **tied cosine distances** is left to the DB's natural ordering (a pre-existing edge case). An attempt to make the vector candidate pool deterministic by `record_id` destabilized the suite's near-tied-vector test fixtures for negligible real-world benefit (real embeddings rarely tie), so it's deferred along with the pre-existing cross-page candidate-pool-growth instability. The in-scope **dataset** pagination fix (B2) is unaffected.

### Test plan

- 193 targeted + regression tests pass (OGC, search, features, column-stats, relationships, middleware, hybrid-search).
- Full backend suite green; `ruff` clean; `openapi-check` + `sdks-check` pass; frontend `tsc` + `eslint` clean.
- `openapi.json` + Python/TS SDKs regenerated for the new `ColumnStats` fields and `itemType` description.

https://claude.ai/code/session_01ATqNfJXvg3zXfktncsNUdf
