### PR TITLE
fix(api): close raster DoS-class + STAC tile-URL residuals (follow-up to #315)

### DIFF
--- a/backend/app/modules/catalog/datasets/api/router_metadata.py
+++ b/backend/app/modules/catalog/datasets/api/router_metadata.py
@@ -11,6 +11,7 @@ from fastapi import (
     status,
 )
 from sqlalchemy import select
+from sqlalchemy.exc import OperationalError, ProgrammingError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.modules.audit.service import AuditEvent, audit_emit
@@ -283,12 +284,33 @@ async def get_column_values(
     # Visibility check
     await check_dataset_access(db, dataset, dataset_id, user)
 
+    # fix(#315): raster/VRT datasets have a synthetic table_name (raster_<hex>)
+    # with NO backing data.<table>, so get_distinct_values would run SELECT ...
+    # FROM a missing table -> UndefinedTableError -> 500 (holding a DB
+    # connection). Return a fast 404 before any column query is attempted.
+    if dataset.record.record_type in ("raster_dataset", "vrt_dataset"):
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=(
+                f"Dataset '{dataset_id}' is a raster dataset and has no tabular "
+                "columns; use the tile/coverage endpoints."
+            ),
+        )
+
     try:
         values = await get_distinct_values(db, dataset.table_name, column_name, limit)
     except ValueError as exc:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=str(exc),
+        )
+    except (ProgrammingError, OperationalError):
+        # A non-raster dataset whose backing data.<table> is missing
+        # (cold-evicted / partial ingest) raises here. Convert to a 503
+        # rather than letting it surface as an unhandled 500.
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Dataset table is temporarily unavailable",
         )
 
     return ColumnValuesResponse(values=values, count=len(values))

--- a/backend/app/modules/catalog/datasets/domain/service_relationships.py
+++ b/backend/app/modules/catalog/datasets/domain/service_relationships.py
@@ -13,7 +13,9 @@ if TYPE_CHECKING:
         DatasetRelationshipCreate,
     )
 
+from fastapi import HTTPException, status
 from sqlalchemy import select, text
+from sqlalchemy.exc import OperationalError, ProgrammingError
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import joinedload
 
@@ -568,23 +570,41 @@ async def get_related_records(
     ) or not SAFE_COLUMN_NAME_RE.match(rel.target_column):
         raise ValueError("Invalid column name in relationship")
 
-    # 4. Get FK value from source table
-    fk_value = await _fetch_fk_value(
-        session, source_ds.table_name, rel.source_column, feature_gid
-    )
-    if fk_value is None:
-        return {"rows": [], "approximate_total": 0, "next_cursor": None, "columns": []}
+    # 4-5. Touch the source/target tables. fix(#315 sibling): a raster/VRT
+    # endpoint dataset (or a cold-evicted/partial vector table) resolves to a
+    # missing data.<table>, so these queries raise UndefinedTableError. Map that
+    # to 503 instead of an uncaught 500 that holds the DB connection (mirrors the
+    # features-router ProgrammingError->503 guard from PR #315).
+    try:
+        # 4. Get FK value from source table
+        fk_value = await _fetch_fk_value(
+            session, source_ds.table_name, rel.source_column, feature_gid
+        )
+        if fk_value is None:
+            return {
+                "rows": [],
+                "approximate_total": 0,
+                "next_cursor": None,
+                "columns": [],
+            }
 
-    # 5. Query target table for matching rows
-    total = await _count_target_rows(
-        session, target_ds.table_name, rel.target_column, fk_value
-    )
-    rows = await _fetch_target_rows(
-        session, target_ds.table_name, rel.target_column, fk_value, limit, after
-    )
+        # 5. Query target table for matching rows
+        total = await _count_target_rows(
+            session, target_ds.table_name, rel.target_column, fk_value
+        )
+        rows = await _fetch_target_rows(
+            session, target_ds.table_name, rel.target_column, fk_value, limit, after
+        )
 
-    # Get column info for target table
-    columns = await get_catalog_port().get_column_info(session, target_ds.table_name)
+        # Get column info for target table
+        columns = await get_catalog_port().get_column_info(
+            session, target_ds.table_name
+        )
+    except (ProgrammingError, OperationalError):
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="A related dataset table is temporarily unavailable",
+        )
     col_list = [{"name": c["name"], "type": c["type"]} for c in columns]
 
     next_cursor = after + limit if after + limit < total else None

--- a/backend/app/modules/catalog/search/cache.py
+++ b/backend/app/modules/catalog/search/cache.py
@@ -35,6 +35,7 @@ def build_cache_key(
     filters: SearchFilters,
     user_roles: set[str],
     public_api_url: str | None = None,
+    public_app_url: str | None = None,
     semantic_enabled: bool | None = None,
 ) -> str:
     """Build a deterministic cache key for the given request shape.
@@ -44,9 +45,13 @@ def build_cache_key(
     handles ``date``/``UUID`` fields on the dataclass; ``sort_keys=True`` makes
     the digest stable across Python versions.
 
-    ``public_api_url`` and ``semantic_enabled`` are included only for the
-    "search" endpoint — facets responses carry no URLs and do not run semantic
-    ranking, so passing ``None`` keeps facet keys stable.
+    ``public_api_url``, ``public_app_url`` and ``semantic_enabled`` are included
+    only for the "search" endpoint — facets responses carry no URLs and do not
+    run semantic ranking, so passing ``None`` keeps facet keys stable.
+    ``public_app_url`` is in the key because raster_tiles asset hrefs are built
+    against the app origin (fix(#315)); a multi-origin deployment with a fixed
+    PUBLIC_API_URL but request-derived PUBLIC_APP_URL would otherwise serve a
+    cached response with another origin's tile host.
 
     Maintenance contract:
     - Every ``SearchFilters`` field must be JSON-native or have a deterministic
@@ -62,6 +67,7 @@ def build_cache_key(
         "endpoint": endpoint,
         "roles": sorted(user_roles),
         "public_api_url": public_api_url or "",
+        "public_app_url": public_app_url or "",
     }
     if semantic_enabled is not None:
         payload["semantic_enabled"] = bool(semantic_enabled)

--- a/backend/app/modules/catalog/search/router.py
+++ b/backend/app/modules/catalog/search/router.py
@@ -357,6 +357,9 @@ async def _handle_search(
 ) -> OGCFeatureCollectionResponse:
     """Parse parameters, run search, and return OGC FeatureCollection."""
     public_api_url = await get_public_api_url(db, request=request)
+    # fix(#315 follow-up): raster/VRT raster_tiles assets are served at the
+    # public APP origin (/raster-tiles/...), not the /api origin.
+    public_app_url = await get_public_app_url(db, request=request)
 
     filters = params.to_filters()
 
@@ -406,6 +409,7 @@ async def _handle_search(
             stac_asset_rows=stac_assets_by_dataset.get(str(d.id)),
             raster_meta=raster_meta.get(str(d.id)),
             spatial_extent_geojson=extent_geojson_map.get(str(d.id)),
+            public_app_url=public_app_url,
         )
         for d in datasets
     ]
@@ -1264,7 +1268,11 @@ async def _lookup_by_external_id(
     # dataset's full OGC metadata by UUID via ?externalId=.
     await check_dataset_access_or_anonymous(db, dataset, record_uuid, user)
     public_api_url = await get_public_api_url(db, request=request)
-    content = dataset_to_ogc_record(dataset, public_api_url)
+    # fix(#315 follow-up): raster_tiles asset href uses the public APP origin.
+    public_app_url = await get_public_app_url(db, request=request)
+    content = dataset_to_ogc_record(
+        dataset, public_api_url, public_app_url=public_app_url
+    )
     return JSONResponse(
         content=content,
         media_type="application/geo+json",
@@ -1434,11 +1442,14 @@ async def get_collection_item(
             item_raster_meta = None
 
     public_api_url = await get_public_api_url(db, request=request)
+    # fix(#315 follow-up): raster_tiles asset href uses the public APP origin.
+    public_app_url = await get_public_app_url(db, request=request)
     content = dataset_to_ogc_record(
         dataset,
         public_api_url,
         stac_asset_rows=stac_asset_rows or None,
         raster_meta=item_raster_meta,
+        public_app_url=public_app_url,
     )
     return JSONResponse(
         content=content,

--- a/backend/app/modules/catalog/search/router.py
+++ b/backend/app/modules/catalog/search/router.py
@@ -377,6 +377,9 @@ async def _handle_search(
             filters=filters,
             user_roles=user_roles,
             public_api_url=public_api_url,
+            # fix(#315): raster_tiles asset hrefs depend on the app origin, so it
+            # must be in the key (multi-origin deploys sharing one API host).
+            public_app_url=public_app_url,
             semantic_enabled=semantic_enabled_for_key,
         )
         cached = await search_cache.get_cached(cache_key)

--- a/backend/app/modules/catalog/search/service_records.py
+++ b/backend/app/modules/catalog/search/service_records.py
@@ -47,8 +47,18 @@ def build_assets(
     record_status: str = "draft",
     storage_backend: str = "local",
     storage_provider: "StorageProvider | None" = None,
+    public_app_url: str | None = None,
 ) -> dict:
-    """Build a modality-aware unified assets dict for a dataset."""
+    """Build a modality-aware unified assets dict for a dataset.
+
+    fix(#315 follow-up): the raster/VRT ``raster_tiles`` asset is served at the
+    public APP origin (``/raster-tiles/...``, nginx-rewritten to the tile proxy),
+    NOT the ``/api`` origin (which has no such route). Callers thread
+    ``public_app_url`` so that one href uses the app origin; every other
+    asset/link (vector_tiles at ``/tiles/...``, downloads, ogc_features) stays on
+    ``public_api_url``. The ``or public_api_url`` fallback preserves prior
+    behavior when a caller omits it.
+    """
     record_type = (
         getattr(dataset.record, "record_type", "vector_dataset") or "vector_dataset"
     )
@@ -92,11 +102,11 @@ def build_assets(
             }
 
     elif record_type in ("raster_dataset", "vrt_dataset"):
-        # Raster tile endpoint
+        # Raster tile endpoint -- served at the public APP origin, not /api.
         assets["raster_tiles"] = {
             "href": build_url(
                 f"/raster-tiles/{dataset.id}/tiles/{{z}}/{{x}}/{{y}}.png",
-                base_url=public_api_url,
+                base_url=(public_app_url or public_api_url),
             ),
             "type": "image/png",
             "title": "Raster tiles",
@@ -205,8 +215,14 @@ def dataset_to_ogc_record(
     stac_asset_rows: list[dict] | None = None,
     raster_meta: dict | None = None,
     spatial_extent_geojson: str | None = None,
+    public_app_url: str | None = None,
 ) -> dict:
-    """Convert a Dataset ORM object to an OGC Record GeoJSON Feature dict."""
+    """Convert a Dataset ORM object to an OGC Record GeoJSON Feature dict.
+
+    ``public_app_url`` is threaded to :func:`build_assets` so the raster/VRT
+    ``raster_tiles`` asset href uses the app origin (see that function's
+    docstring); all other assets/links remain on ``public_api_url``.
+    """
     record = dataset.record
     updated_user = getattr(record, "_provenance_updated_user", None)
     last_edited = derive_last_edited(
@@ -421,6 +437,7 @@ def dataset_to_ogc_record(
             stac_asset_rows=stac_asset_rows,
             record_status=record.record_status or "draft",
             storage_backend=settings.storage_provider,
+            public_app_url=public_app_url,
         ),
     }
 

--- a/backend/app/processing/export/router.py
+++ b/backend/app/processing/export/router.py
@@ -128,14 +128,30 @@ async def export_dataset_endpoint(
                 detail="Invalid target_crs: must match EPSG:<code> (e.g. EPSG:3857)",
             )
 
-    # 5. Check geometry compatibility
+    # 5. Reject raster/VRT datasets: they have no tabular feature table.
+    # Key on record_type (loaded via joinedload(Dataset.record) in
+    # get_dataset), NOT geometry_type — a legitimate non-spatial TABLE
+    # dataset (record_type="table") also has geometry_type=None but IS a
+    # real CSV-exportable table and must NOT be blocked. A raster/VRT
+    # dataset has a synthetic table_name with no backing table, so letting
+    # csv proceed would hit ogr2ogr on a nonexistent table -> raw 500.
+    if dataset.record.record_type in ("raster_dataset", "vrt_dataset"):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=(
+                "Raster datasets have no tabular feature data to export; "
+                "use the raster tile/COG endpoints."
+            ),
+        )
+
+    # 6. Check geometry compatibility
     if dataset.geometry_type is None and format in ("gpkg", "geojson", "shp"):
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=f"Cannot export non-spatial dataset as {format}. Use csv format.",
         )
 
-    # 6. Run export
+    # 7. Run export
     try:
         file_path, filename, media_type = await export_dataset(
             dataset.table_name,
@@ -162,7 +178,7 @@ async def export_dataset_endpoint(
             detail="Export temporarily unavailable",
         )
 
-    # 7. Audit log. user_id may be None for anonymous exports (EXP-01).
+    # 8. Audit log. user_id may be None for anonymous exports (EXP-01).
     # The audit_logs.user_id column is nullable; AuditEvent.user_id is typed
     # uuid.UUID | None to match.
     await audit_emit(
@@ -183,7 +199,7 @@ async def export_dataset_endpoint(
     )
     await db.commit()
 
-    # 8. Return file with background cleanup
+    # 9. Return file with background cleanup
     temp_dir = os.path.dirname(file_path)
 
     return FileResponse(

--- a/backend/app/standards/stac/router.py
+++ b/backend/app/standards/stac/router.py
@@ -34,7 +34,7 @@ from app.modules.catalog.datasets.domain.models import (
     RecordKeyword,
 )
 from app.core.dependencies import get_db
-from app.core.public_urls import get_public_api_url
+from app.core.public_urls import get_public_api_url, get_public_app_url
 from app.processing.raster.models import DatasetAsset, RasterAsset
 from app.standards.ogc.errors import ERROR_RESPONSES_PUBLIC
 from app.core.geo import make_bbox_filter
@@ -160,12 +160,18 @@ async def _dataset_to_stac_item(
     raster_meta: dict | None = None,
     collection_id: str | None = None,
     spatial_extent_geojson: str | None = None,
+    public_app_url: str | None = None,
 ) -> dict:
     """Convert a Dataset ORM object to a STAC Item dict with presigned URLs.
 
     ``spatial_extent_geojson`` (PERF-5) lets bulk callers (e.g. STAC items
     page) skip per-dataset Python-side WKB deserialization in
     ``dataset_to_ogc_record`` by precomputing ST_AsGeoJSON in one query.
+
+    ``public_app_url`` (fix(#315) follow-up): the raster/VRT ``raster_tiles``
+    asset is served at the public APP origin (/raster-tiles/...), not the /api
+    origin, so it is threaded to both ``dataset_to_ogc_record`` and the
+    presigned-URL ``build_assets`` re-build below.
     """
     record = dataset.record
 
@@ -176,6 +182,7 @@ async def _dataset_to_stac_item(
         stac_asset_rows=stac_asset_rows,
         raster_meta=raster_meta,
         spatial_extent_geojson=spatial_extent_geojson,
+        public_app_url=public_app_url,
     )
 
     # Re-build assets with storage_provider for presigned URLs
@@ -191,6 +198,7 @@ async def _dataset_to_stac_item(
         record_status=record.record_status or "draft",
         storage_backend=settings.storage_provider,
         storage_provider=storage,
+        public_app_url=public_app_url,
     )
 
     # Declare projection STAC extension for raster/VRT items that emit proj:* properties.
@@ -559,6 +567,8 @@ async def get_collection_items(
 ) -> JSONResponse:
     """List STAC Items within a collection."""
     stac_api_url, public_api_url = await _resolve_urls(db, request)
+    # fix(#315 follow-up): raster_tiles assets are served at the public APP origin.
+    public_app_url = await get_public_app_url(db, request=request)
     user_roles = await _resolve_roles(db, user)
 
     # Verify collection exists
@@ -653,6 +663,7 @@ async def get_collection_items(
             raster_meta=raster_meta_map.get(str(dataset.id)),
             collection_id=coll_id_str,
             spatial_extent_geojson=extent_geojson_map.get(str(dataset.id)),
+            public_app_url=public_app_url,
         )
         features.append(item)
 
@@ -712,6 +723,7 @@ async def _build_item_response(
     stac_api_url: str,
     *,
     collection_id: str | None = None,
+    public_app_url: str | None = None,
 ) -> JSONResponse:
     """Fetch assets/raster metadata, convert to STAC Item, return as geo+json."""
 
@@ -733,6 +745,7 @@ async def _build_item_response(
         stac_asset_rows=asset_rows.get(str(dataset.id)),
         raster_meta=raster_meta.get(str(dataset.id)),
         collection_id=collection_id,
+        public_app_url=public_app_url,
     )
     return JSONResponse(content=item, media_type="application/geo+json")
 
@@ -747,6 +760,8 @@ async def get_collection_item(
 ) -> JSONResponse:
     """Get a single STAC Item within a collection."""
     stac_api_url, public_api_url = await _resolve_urls(db, request)
+    # fix(#315 follow-up): raster_tiles assets are served at the public APP origin.
+    public_app_url = await get_public_app_url(db, request=request)
     user_roles = await _resolve_roles(db, user)
 
     # Verify collection exists
@@ -775,7 +790,12 @@ async def get_collection_item(
         )
 
     return await _build_item_response(
-        db, dataset, public_api_url, stac_api_url, collection_id=str(collection_id)
+        db,
+        dataset,
+        public_api_url,
+        stac_api_url,
+        collection_id=str(collection_id),
+        public_app_url=public_app_url,
     )
 
 
@@ -788,6 +808,8 @@ async def get_item(
 ) -> JSONResponse:
     """Get a single STAC Item by dataset ID."""
     stac_api_url, public_api_url = await _resolve_urls(db, request)
+    # fix(#315 follow-up): raster_tiles assets are served at the public APP origin.
+    public_app_url = await get_public_app_url(db, request=request)
     user_roles = await _resolve_roles(db, user)
 
     stmt = _base_published_raster_query(user, user_roles).where(Dataset.id == item_id)
@@ -798,7 +820,9 @@ async def get_item(
             status_code=status.HTTP_404_NOT_FOUND, detail="Item not found"
         )
 
-    return await _build_item_response(db, dataset, public_api_url, stac_api_url)
+    return await _build_item_response(
+        db, dataset, public_api_url, stac_api_url, public_app_url=public_app_url
+    )
 
 
 def _build_search_filters(
@@ -969,6 +993,7 @@ async def _execute_search(
     intersects: str | dict | None = None,
     limit: int = 10,
     offset: int = 0,
+    public_app_url: str | None = None,
 ) -> JSONResponse:
     """Shared STAC Item Search logic for GET and POST endpoints.
 
@@ -1058,6 +1083,7 @@ async def _execute_search(
             stac_asset_rows=asset_rows_map.get(str(dataset.id)),
             raster_meta=raster_meta_map.get(str(dataset.id)),
             collection_id=collection_id_map.get(str(dataset.id)),
+            public_app_url=public_app_url,
         )
         features.append(item)
 
@@ -1124,6 +1150,8 @@ async def search_get(
 ) -> JSONResponse:
     """STAC Item Search (GET)."""
     stac_api_url, public_api_url = await _resolve_urls(db, request)
+    # fix(#315 follow-up): raster_tiles assets are served at the public APP origin.
+    public_app_url = await get_public_app_url(db, request=request)
     user_roles = await _resolve_roles(db, user)
     return await _execute_search(
         db,
@@ -1138,6 +1166,7 @@ async def search_get(
         intersects=intersects,
         limit=limit,
         offset=offset,
+        public_app_url=public_app_url,
     )
 
 
@@ -1199,6 +1228,8 @@ async def search_post(
 ) -> JSONResponse:
     """STAC Item Search (POST with JSON body)."""
     stac_api_url, public_api_url = await _resolve_urls(db, request)
+    # fix(#315 follow-up): raster_tiles assets are served at the public APP origin.
+    public_app_url = await get_public_app_url(db, request=request)
     user_roles = await _resolve_roles(db, user)
 
     return await _execute_search(
@@ -1217,6 +1248,7 @@ async def search_post(
         # the min(body.limit, 200) keeps the operational 200-item ceiling.
         limit=max(1, min(body.limit, 200)),
         offset=max(0, body.offset),
+        public_app_url=public_app_url,
     )
 
 

--- a/backend/tests/test_column_stats_stddev.py
+++ b/backend/tests/test_column_stats_stddev.py
@@ -15,6 +15,7 @@ from httpx import AsyncClient
 from sqlalchemy import text
 
 from app.modules.catalog.datasets.domain.column_stats import get_column_stats
+from app.modules.catalog.datasets.domain.models import Dataset, Record
 from tests.factories import create_dataset, get_user_id
 
 TEST_TABLE_NAME = f"test_stddev_{uuid.uuid4().hex[:8]}"
@@ -205,3 +206,101 @@ async def test_column_stats_endpoint_nonexistent_column_returns_400(
         headers=admin_auth_header,
     )
     assert resp.status_code == 400, resp.text
+
+
+# ---------------------------------------------------------------------------
+# G2/E1: HTTP-layer coverage for /datasets/{id}/columns/{col}/values/
+# A raster_dataset/vrt_dataset has a synthetic table_name with NO backing
+# data.<table>; the distinct-values query would hit an UndefinedTableError ->
+# unhandled 500 (holding a DB connection). The guard must return 404 instead.
+# ---------------------------------------------------------------------------
+
+
+async def _create_raster_dataset(
+    session,
+    *,
+    created_by: uuid.UUID,
+    record_type: str = "raster_dataset",
+) -> Dataset:
+    """Register a raster/VRT dataset with NO backing PostGIS table.
+
+    The record carries a table_name (NOT NULL on the model) but no data.<table>
+    is ever created -- exactly the G2/E1 bug-trigger condition.
+    """
+    table_name = f"raster_{uuid.uuid4().hex}"
+    record = Record(
+        title=f"Column Values Raster {table_name}",
+        summary="Test raster dataset for column-values hardening",
+        theme_category=["test"],
+        visibility="public",
+        record_status="published",
+        record_type=record_type,
+        created_by=created_by,
+    )
+    session.add(record)
+    await session.flush()
+    dataset = Dataset(
+        record_id=record.id,
+        table_name=table_name,
+        srid=4326,
+        geometry_type=None,
+        feature_count=None,
+        source_format="geotiff",
+    )
+    session.add(dataset)
+    await session.commit()
+    await session.refresh(dataset)
+    return dataset
+
+
+@pytest.fixture
+async def raster_values_dataset(test_db_session):
+    """A raster dataset with no backing data.<table> (no cleanup needed)."""
+    admin_id = await get_user_id(test_db_session, "admin")
+    return await _create_raster_dataset(test_db_session, created_by=admin_id)
+
+
+@pytest.fixture
+async def vrt_values_dataset(test_db_session):
+    """A VRT dataset with no backing data.<table>."""
+    admin_id = await get_user_id(test_db_session, "admin")
+    return await _create_raster_dataset(
+        test_db_session, created_by=admin_id, record_type="vrt_dataset"
+    )
+
+
+async def test_column_values_endpoint_raster_returns_404_not_500(
+    client: AsyncClient, admin_auth_header: dict, raster_values_dataset
+):
+    """(G2/E1) GET values on a raster dataset returns 404, never a 500."""
+    resp = await client.get(
+        f"/datasets/{raster_values_dataset.id}/columns/anycol/values/",
+        headers=admin_auth_header,
+    )
+    assert resp.status_code == 404, resp.text
+    assert "raster" in resp.json()["detail"].lower()
+
+
+async def test_column_values_endpoint_vrt_returns_404_not_500(
+    client: AsyncClient, admin_auth_header: dict, vrt_values_dataset
+):
+    """(G2/E1) GET values on a VRT dataset returns 404, never a 500."""
+    resp = await client.get(
+        f"/datasets/{vrt_values_dataset.id}/columns/anycol/values/",
+        headers=admin_auth_header,
+    )
+    assert resp.status_code == 404, resp.text
+
+
+async def test_column_values_endpoint_vector_returns_distinct_values(
+    client: AsyncClient, admin_auth_header: dict, stats_dataset
+):
+    """Regression: a real vector dataset still returns its distinct values."""
+    resp = await client.get(
+        f"/datasets/{stats_dataset.id}/columns/label/values/",
+        headers=admin_auth_header,
+    )
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    assert data["count"] == 5
+    assert sorted(data["values"]) == ["a", "b", "c", "d", "e"]

--- a/backend/tests/test_export.py
+++ b/backend/tests/test_export.py
@@ -39,6 +39,7 @@ async def _create_dataset(
     feature_count: int = 42,
     description: str | None = "A test dataset",
     column_info: list[dict] | None = None,
+    record_type: str = "vector_dataset",
 ) -> Dataset:
     """Insert a Record + Dataset pair directly into the DB."""
     if table_name is None:
@@ -54,6 +55,7 @@ async def _create_dataset(
         summary=description,
         visibility=visibility,
         record_status="published",
+        record_type=record_type,
         created_by=created_by,
     )
     session.add(record)
@@ -362,6 +364,98 @@ class TestExportValidation:
             headers=admin_auth_header,
         )
         assert resp.status_code == 200
+
+    @pytest.mark.anyio
+    async def test_export_table_dataset_csv_allowed(
+        self, client: AsyncClient, admin_auth_header: dict, test_db_session
+    ):
+        """A legitimate non-spatial TABLE dataset (record_type='table',
+        geometry_type=None) is a real CSV-exportable table and must NOT be
+        blocked by the raster/VRT record_type guard. Regression for the guard
+        keying on record_type (not geometry_type)."""
+        admin_id = await get_user_id(test_db_session, "admin")
+        ds = await _create_dataset(
+            test_db_session,
+            created_by=admin_id,
+            name="TableCsvDS",
+            geometry_type=None,
+            record_type="table",
+        )
+        resp = await client.get(
+            f"/datasets/{ds.id}/export",
+            params={"format": "csv"},
+            headers=admin_auth_header,
+        )
+        assert resp.status_code == 200
+
+    @pytest.mark.anyio
+    async def test_export_raster_dataset_csv_returns_400_not_500(
+        self, client: AsyncClient, admin_auth_header: dict, test_db_session
+    ):
+        """E2: a raster dataset (record_type='raster_dataset', geometry_type
+        None, synthetic table_name with no backing table) requesting format=csv
+        must return a clean 400 — NOT a raw 500 from ogr2ogr hitting a
+        nonexistent table."""
+        admin_id = await get_user_id(test_db_session, "admin")
+        ds = await _create_dataset(
+            test_db_session,
+            created_by=admin_id,
+            name="RasterCsvDS",
+            geometry_type=None,
+            record_type="raster_dataset",
+        )
+        resp = await client.get(
+            f"/datasets/{ds.id}/export",
+            params={"format": "csv"},
+            headers=admin_auth_header,
+        )
+        assert resp.status_code == 400
+        assert "raster" in resp.json()["detail"].lower()
+
+    @pytest.mark.anyio
+    async def test_export_vrt_dataset_csv_returns_400(
+        self, client: AsyncClient, admin_auth_header: dict, test_db_session
+    ):
+        """E2: a VRT dataset (record_type='vrt_dataset') is likewise blocked
+        from tabular export with a 400."""
+        admin_id = await get_user_id(test_db_session, "admin")
+        ds = await _create_dataset(
+            test_db_session,
+            created_by=admin_id,
+            name="VrtCsvDS",
+            geometry_type=None,
+            record_type="vrt_dataset",
+        )
+        resp = await client.get(
+            f"/datasets/{ds.id}/export",
+            params={"format": "csv"},
+            headers=admin_auth_header,
+        )
+        assert resp.status_code == 400
+        assert "raster" in resp.json()["detail"].lower()
+
+    @pytest.mark.anyio
+    async def test_export_raster_dataset_gpkg_returns_400(
+        self, client: AsyncClient, admin_auth_header: dict, test_db_session
+    ):
+        """E2: the raster guard fires before the geometry/format gate, so a
+        spatial format (gpkg) on a raster dataset also returns the raster 400
+        (not the generic non-spatial 400)."""
+        admin_id = await get_user_id(test_db_session, "admin")
+        ds = await _create_dataset(
+            test_db_session,
+            created_by=admin_id,
+            name="RasterGpkgDS",
+            geometry_type=None,
+            record_type="raster_dataset",
+        )
+        resp = await client.get(
+            f"/datasets/{ds.id}/export",
+            params={"format": "gpkg"},
+            headers=admin_auth_header,
+        )
+        assert resp.status_code == 400
+        assert "raster" in resp.json()["detail"].lower()
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_fk_relationships.py
+++ b/backend/tests/test_fk_relationships.py
@@ -310,6 +310,62 @@ class TestFKRelationships:
 
         assert resp.status_code == 404, resp.text
 
+    async def test_related_records_missing_target_table_returns_503(
+        self,
+        client: AsyncClient,
+        admin_auth_header: dict,
+        test_db_session,
+    ):
+        """A relationship whose target has no backing table returns 503, not 500.
+
+        fix(#315 sibling, G4/E3): the related-records traversal queries
+        data.<target_table> directly. If the target dataset is a raster/VRT (no
+        feature table) or its table was cold-evicted, that query raises
+        UndefinedTableError. The service must map ProgrammingError ->
+        HTTPException(503) so the connection is released cleanly instead of
+        bubbling an uncaught 500.
+        """
+        admin_id = await get_user_id(test_db_session, "admin")
+        source = await create_dataset(
+            test_db_session, created_by=admin_id, name="Missing-Tbl Source"
+        )
+        target = await create_dataset(
+            test_db_session, created_by=admin_id, name="Missing-Tbl Target"
+        )
+        # Create ONLY the source table + a row with a resolvable FK value. The
+        # target table is intentionally NOT created, so the target-side query
+        # hits data.<missing> -> UndefinedTableError.
+        await test_db_session.execute(
+            text(
+                f"CREATE TABLE data.{source.table_name} "
+                "(gid integer PRIMARY KEY, target_id integer)"
+            )
+        )
+        await test_db_session.execute(
+            text(
+                f"INSERT INTO data.{source.table_name} (gid, target_id) VALUES (1, 42)"
+            )
+        )
+        await test_db_session.commit()
+
+        create_resp = await client.post(
+            f"/datasets/{source.id}/relationships/",
+            json={
+                "target_dataset_id": str(target.record_id),
+                "source_column": "target_id",
+                "target_column": "target_id",
+            },
+            headers=admin_auth_header,
+        )
+        assert create_resp.status_code == 201, create_resp.text
+        rel_id = create_resp.json()["id"]
+
+        resp = await client.get(
+            f"/datasets/{source.id}/features/1/related/{rel_id}/",
+            headers=admin_auth_header,
+        )
+        assert resp.status_code == 503, resp.text
+
     async def test_related_records_rejects_relationship_for_different_source(
         self,
         client: AsyncClient,

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -791,8 +791,10 @@ def test_decomposed_service_modules_stay_within_size_budgets() -> None:
         # contract ({relationships,total}); list_relationships DRY'd to delegate +
         # _visible_relationships extracted (shared, fail-closed). Cap 580 -> 595 (~7 LOC headroom).
         # Smoke-check backlog (#315): +source/target Dataset.id resolution so the
-        # list response returns dereferenceable ids. Cap 595 -> 605 (~7 LOC headroom).
-        "backend/app/modules/catalog/datasets/domain/service_relationships.py": 605,
+        # list response returns dereferenceable ids. Smoke-residual follow-up (#315):
+        # +try/except (ProgrammingError->503) around get_related_records table
+        # queries (raster/missing-table guard). Cap 595 -> 620 (~3 LOC headroom).
+        "backend/app/modules/catalog/datasets/domain/service_relationships.py": 620,
         "backend/app/modules/catalog/datasets/domain/service_metadata.py": 460,
         "backend/app/modules/catalog/datasets/domain/service_query.py": 390,
         # Phase 276 CODE-02: chat_*.py sub-modules are all under the 350
@@ -884,8 +886,10 @@ def test_router_orchestrator_modules_stay_within_loc_cap() -> None:
         "backend/app/modules/catalog/maps/router.py": 1900,
         # Smoke-check backlog (#315): raster coverage list metadata (itemType +
         # rel=tiles, omit rel=items), stable numberMatched + collection count,
-        # and the filter-lang 400. Cap 1600 -> 1625 (~5 LOC headroom).
-        "backend/app/modules/catalog/search/router.py": 1625,
+        # and the filter-lang 400. Smoke-residual follow-up (#315): +public_app_url
+        # fetches in 3 OGC-record handlers for the raster_tiles app-origin fix.
+        # Cap 1600 -> 1640 (~6 LOC headroom).
+        "backend/app/modules/catalog/search/router.py": 1640,
         # Phase 1176 PERF-002: +~60 lines for the raster tile auth/metadata
         # TTLCache (_RasterMeta + _resolve_raster_meta), mirroring the vector
         # tile meta cache so raster tiles aren't asymmetric.

--- a/backend/tests/test_modality_assets.py
+++ b/backend/tests/test_modality_assets.py
@@ -143,3 +143,53 @@ class TestModalityAssets:
 
         assert "download_geojson" in assets
         assert "raster_tiles" not in assets
+
+
+# Public APP origin (no /api suffix) vs the public API origin.
+APP_URL = "http://localhost:8080"
+
+
+class TestRasterTilesAssetOrigin:
+    """fix(#315 follow-up): the raster_tiles asset must use the APP origin
+    (/raster-tiles/...), never the /api origin which has no such route.
+    Sibling endpoints (STAC items, OGC records, search) thread public_app_url
+    into build_assets just like PR #315 did for the OGC rel=tiles links.
+    """
+
+    def test_raster_tiles_uses_app_origin_when_provided(self):
+        """raster_tiles href uses public_app_url; NOT /api/raster-tiles."""
+        ds = _make_dataset(record_type="raster_dataset")
+        assets = build_assets(ds, API_URL, public_app_url=APP_URL)
+
+        href = assets["raster_tiles"]["href"]
+        assert "/raster-tiles/" in href
+        # The /api origin has no /raster-tiles route -> must not appear.
+        assert "/api/raster-tiles" not in href
+        assert href.startswith(APP_URL + "/raster-tiles/")
+
+    def test_vrt_raster_tiles_uses_app_origin(self):
+        """VRT datasets get the same app-origin raster_tiles href."""
+        ds = _make_dataset(record_type="vrt_dataset")
+        assets = build_assets(ds, API_URL, public_app_url=APP_URL)
+
+        href = assets["raster_tiles"]["href"]
+        assert "/raster-tiles/" in href
+        assert "/api/raster-tiles" not in href
+
+    def test_raster_tiles_falls_back_to_api_url_when_app_url_omitted(self):
+        """No public_app_url -> falls back to public_api_url (old behavior)."""
+        ds = _make_dataset(record_type="raster_dataset")
+        assets = build_assets(ds, API_URL)
+
+        # Fallback preserves the pre-fix href on the api origin.
+        assert assets["raster_tiles"]["href"].startswith(API_URL + "/raster-tiles/")
+
+    def test_app_url_does_not_affect_vector_assets(self):
+        """public_app_url only steers raster_tiles; vector assets stay on /api."""
+        ds = _make_dataset(record_type="vector_dataset", table_name="parcels")
+        assets = build_assets(ds, API_URL, public_app_url=APP_URL)
+
+        # Vector tiles are correctly served under /api -> keep the api origin.
+        assert assets["vector_tiles"]["href"].startswith(API_URL + "/tiles/")
+        assert assets["ogc_features"]["href"].startswith(API_URL + "/collections/")
+        assert assets["download_geojson"]["href"].startswith(API_URL + "/datasets/")

--- a/backend/tests/test_search_cache.py
+++ b/backend/tests/test_search_cache.py
@@ -374,3 +374,34 @@ async def test_authed_facets_bypasses_cache(
     assert second_total == first_total + 1, (
         "authed second request should reflect DB mutation (cache bypass)"
     )
+
+
+@pytest.mark.anyio
+async def test_build_cache_key_includes_public_app_url():
+    """fix(#315): public_app_url is in the search cache key.
+
+    raster_tiles asset hrefs are built against the app origin, so two requests
+    that differ only in public_app_url (e.g. a multi-origin deploy with a fixed
+    PUBLIC_API_URL) must NOT collide on one cache entry.
+    """
+    from app.modules.catalog.search.service import SearchFilters
+
+    filters = SearchFilters()
+    base = dict(
+        endpoint="search",
+        filters=filters,
+        user_roles=set(),
+        public_api_url="https://api.example.com",
+    )
+    key_app_a = search_cache.build_cache_key(
+        **base, public_app_url="https://a.example.com"
+    )
+    key_app_b = search_cache.build_cache_key(
+        **base, public_app_url="https://b.example.com"
+    )
+    key_app_a2 = search_cache.build_cache_key(
+        **base, public_app_url="https://a.example.com"
+    )
+
+    assert key_app_a != key_app_b  # different app origin -> different key
+    assert key_app_a == key_app_a2  # deterministic for the same inputs

--- a/backend/tests/test_stac_record_output.py
+++ b/backend/tests/test_stac_record_output.py
@@ -358,3 +358,49 @@ class TestStacExtensionsRemoved:
 
         assert "stac_extensions" not in result
         assert "bands" not in result["properties"]
+
+
+# ---------------------------------------------------------------------------
+# raster_tiles asset origin (fix(#315) follow-up)
+# ---------------------------------------------------------------------------
+
+
+class TestRasterTilesAssetOrigin:
+    """The raster/VRT ``raster_tiles`` asset is served at the public APP origin
+    (/raster-tiles/...), not the /api origin which has no such route. The OGC
+    record builder threads ``public_app_url`` to that one asset; all other
+    assets stay on ``public_api_url``.
+    """
+
+    async def test_raster_tiles_asset_uses_app_origin(self, client, test_db_session):
+        """raster_tiles asset href contains /raster-tiles/ and NOT /api/raster-tiles."""
+        admin_id = await _get_admin_id(test_db_session)
+        dataset = await _create_record_and_dataset(test_db_session, admin_id=admin_id)
+        dataset.record.record_type = "raster_dataset"
+        await test_db_session.flush()
+        await _prepare_for_sync(test_db_session, dataset)
+
+        result = dataset_to_ogc_record(
+            dataset,
+            "http://localhost:8080/api",
+            public_app_url="http://localhost:8080",
+        )
+
+        href = result["assets"]["raster_tiles"]["href"]
+        assert "/raster-tiles/" in href
+        # The /api origin has no /raster-tiles route -> must not appear.
+        assert "/api/raster-tiles" not in href
+        assert href.startswith("http://localhost:8080/raster-tiles/")
+
+    async def test_raster_tiles_falls_back_to_api_url(self, client, test_db_session):
+        """Without public_app_url the href falls back to the api origin (old behavior)."""
+        admin_id = await _get_admin_id(test_db_session)
+        dataset = await _create_record_and_dataset(test_db_session, admin_id=admin_id)
+        dataset.record.record_type = "raster_dataset"
+        await test_db_session.flush()
+        await _prepare_for_sync(test_db_session, dataset)
+
+        result = dataset_to_ogc_record(dataset, "http://localhost:8080/api")
+
+        href = result["assets"]["raster_tiles"]["href"]
+        assert href.startswith("http://localhost:8080/api/raster-tiles/")


### PR DESCRIPTION
## Smoke-check residual fixes (follow-up to #315)

The post-merge assessment of #315 found sibling endpoints sharing the raster-hardening / tile-URL class the #315 fix didn't cover. All live-reproduced; each ships with raster-fixture regression tests.

| # | Sev | Fix |
|---|-----|-----|
| **E1** | **HIGH (DoS)** | `GET /datasets/{id}/columns/{col}/values/` on a raster 500'd (UndefinedTableError on the synthetic raster table, holding a DB connection, reachable by any authenticated user incl. the demo `guest=editor`). Added the raster/VRT fast-**404** guard + `ProgrammingError`/`OperationalError`→**503** backstop for missing-table vector datasets. (Sibling `/stats/` was already safe.) |
| **E2** | MED | `GET /datasets/{id}/export?format=csv` on a raster 500'd via ogr2ogr on a nonexistent table. Early `record_type` guard → **400**. Keyed on `record_type`, **not** `geometry_type`, so a legitimate non-spatial **table** dataset still CSV-exports (pinned by a test). |
| **E3** | LOW | `get_related_records` ran source/target table queries unguarded → 500 on a raster/missing-table endpoint. Wrapped in `ProgrammingError`/`OperationalError`→**503**. |
| **STAC tiles** | HIGH | The `raster_tiles` STAC/OGC-record asset href was built with the `/api` origin → **404** (no `/raster-tiles` route there). Threaded `public_app_url` through `build_assets` → `dataset_to_ogc_record` → the STAC item builders, so the href uses the public **app** origin — mirroring the #315 OGC `rel=tiles` fix. All other assets stay on `/api`. |

### Notes
- **No schema changes** (no OpenAPI/SDK regen).
- The `record_type` raster signal is read from the already-eager-loaded `dataset.record`.
- Known unrelated `-n4` flake: `test_semantic_vector_only_pagination` (pre-existing near-tied-vector candidate-pool non-determinism; the proper fix is the deferred OGC-7 vector tiebreaker). Not touched here — this branch changes no semantic code. Passes 5/5 isolated; re-run the job if it flakes.

### Test plan
- 117 targeted + regression tests pass (column-stats/values, export, relationships, STAC, OGC features).
- Full backend suite green except the pre-existing semantic `-n4` flake above; ruff clean; layering caps updated with justification.

https://claude.ai/code/session_01ATqNfJXvg3zXfktncsNUdf
