### PR TITLE
fix(api): raster tile fmt sanitize (stretch/colormap 422) + search param validation + facet/header/login hygiene

### DIFF
--- a/backend/app/modules/catalog/search/router.py
+++ b/backend/app/modules/catalog/search/router.py
@@ -212,6 +212,21 @@ async def _build_raster_assets(
 # ---------------------------------------------------------------------------
 
 
+# Allowed values for record_type / sort_by query params (A2 validation). Kept in
+# sync with the Record.record_type CHECK constraint (models.py) and the sort
+# branches in service_datasets._resolve_sort_order.
+_ALLOWED_RECORD_TYPES = {
+    "vector_dataset",
+    "raster_dataset",
+    "vrt_dataset",
+    "map",
+    "service",
+    "collection",
+    "table",
+}
+_ALLOWED_SORT_BY = {"relevance", "date_added", "name", "title", "last_updated"}
+
+
 class SearchQueryParams(_BaseModel):
     """Query parameters for the search endpoints, injectable via FastAPI Depends().
 
@@ -276,6 +291,25 @@ class SearchQueryParams(_BaseModel):
 
     def to_filters(self) -> SearchFilters:
         """Convert raw query params into a service-layer SearchFilters."""
+        # fix(#315 follow-up, A2): reject unknown record_type / sort_by with a 400
+        # instead of silently returning a 200 (bogus record_type -> empty result;
+        # bogus sort_by -> silent created_at fallback). Validated here (the single
+        # conversion chokepoint for both the native and OGC search endpoints)
+        # rather than via a Pydantic field_validator, which FastAPI surfaces as an
+        # unhandled error instead of a clean 4xx on Depends() query-param models.
+        if (
+            self.record_type is not None
+            and self.record_type not in _ALLOWED_RECORD_TYPES
+        ):
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"record_type must be one of: {sorted(_ALLOWED_RECORD_TYPES)}",
+            )
+        if self.sort_by not in _ALLOWED_SORT_BY:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"sort_by must be one of: {sorted(_ALLOWED_SORT_BY)}",
+            )
         geometry_geojson, bbox_parsed = _parse_spatial_params(self.geometry, self.bbox)
         return SearchFilters(
             q=self.q,

--- a/backend/app/modules/catalog/search/service_facets.py
+++ b/backend/app/modules/catalog/search/service_facets.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from sqlalchemy import String as SAString, func, or_, select
+from sqlalchemy import String as SAString, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.identity import Identity
@@ -57,19 +57,11 @@ async def get_facet_counts(
     result = await session.execute(type_stmt)
     counts = {row.record_type: row.count for row in result.all()}
 
-    # Separately count collections from the collections table
-    coll_stmt = select(func.count()).select_from(Collection)
-    if filters.q and filters.q.strip():
-        q_like = f"%{filters.q.strip().lower()}%"
-        coll_stmt = coll_stmt.where(
-            or_(
-                func.lower(Collection.name).like(q_like),
-                func.lower(func.coalesce(Collection.description, "")).like(q_like),
-            )
-        )
-    coll_count = (await session.execute(coll_stmt)).scalar_one()
-    if coll_count > 0:
-        counts["collection"] = coll_count
+    # fix(#315 follow-up, A4): do NOT inject a "collection" record_type facet.
+    # Collections live in the separate Collection table, not as Record rows with
+    # record_type='collection', so ?record_type=collection filters Record.record_type
+    # and always returns 0 -- a dead facet value (advertises N, filter yields 0).
+    # Collections are surfaced via the dedicated "collections" facet below instead.
 
     # Facet queries are intentionally sequential -- SQLAlchemy AsyncSession
     # is not safe for concurrent execute() on a shared connection.

--- a/backend/app/processing/tiles/router.py
+++ b/backend/app/processing/tiles/router.py
@@ -8,6 +8,7 @@ import threading
 import time
 import uuid
 from typing import Any, Literal, NamedTuple
+from urllib.parse import parse_qs
 
 import httpx
 import structlog
@@ -920,10 +921,38 @@ async def raster_tile_proxy(
     # nginx `rewrite ... $is_args$args` + a variable `proxy_pass`) URL-encode the
     # request's query string into the PATH, so {fmt} can arrive as "png?stretch=..."
     # -> the built Titiler URL becomes ".../771.png?stretch=...?url=..." (double "?")
-    # which Titiler rejects with 422. The real render params still arrive as proper
-    # query params (parsed above), so stripping the pollution lets the tile render
-    # correctly. Also a hardening win: {fmt} feeds an upstream URL and must be an
-    # allowlisted extension.
+    # which Titiler rejects with 422. Strip the pollution so the Titiler URL is
+    # well-formed; also a hardening win since {fmt} feeds an upstream URL.
+    if "?" in fmt:
+        # The render params may have ONLY arrived buried in the path (a proxy that
+        # path-encodes the query without also forwarding it as a real query string).
+        # Recover them into the typed params they were parsed-as-None for, so styling
+        # is preserved rather than silently rendering the default tile (Codex P2).
+        _buried = parse_qs(fmt.split("?", 1)[1])
+        if stretch is None and _buried.get("stretch"):
+            _s = _buried["stretch"][0]
+            if _s in ("minmax", "percentile", "stddev"):
+                stretch = _s  # type: ignore[assignment]
+        if colormap_name is None and _buried.get("colormap_name"):
+            # Validated by the _ALLOWED_COLORMAPS allowlist below.
+            colormap_name = _buried["colormap_name"][0]  # type: ignore[assignment]
+
+        def _buried_float(key: str) -> float | None:
+            # pmin/pmax/sigma are validated by the 0<=pmin<pmax<=100 / sigma>0
+            # checks below, so an out-of-range recovered value still 422s cleanly.
+            if _buried.get(key):
+                try:
+                    return float(_buried[key][0])
+                except ValueError:
+                    return None
+            return None
+
+        if pmin is None:
+            pmin = _buried_float("pmin")
+        if pmax is None:
+            pmax = _buried_float("pmax")
+        if sigma is None:
+            sigma = _buried_float("sigma")
     fmt = fmt.split("?", 1)[0].lower()
     if fmt not in ("png", "webp", "jpg", "jpeg", "tif", "tiff"):
         raise HTTPException(

--- a/backend/app/processing/tiles/router.py
+++ b/backend/app/processing/tiles/router.py
@@ -915,6 +915,22 @@ async def raster_tile_proxy(
     sigma: Standard-deviation multiplier for stretch=stddev (default 2.0).
     Must be > 0.
     """
+    # A-fix(#315 follow-up): defensively sanitize the {fmt} path param before it is
+    # interpolated into the Titiler endpoint URL. Some reverse-proxy rewrites (e.g.
+    # nginx `rewrite ... $is_args$args` + a variable `proxy_pass`) URL-encode the
+    # request's query string into the PATH, so {fmt} can arrive as "png?stretch=..."
+    # -> the built Titiler URL becomes ".../771.png?stretch=...?url=..." (double "?")
+    # which Titiler rejects with 422. The real render params still arrive as proper
+    # query params (parsed above), so stripping the pollution lets the tile render
+    # correctly. Also a hardening win: {fmt} feeds an upstream URL and must be an
+    # allowlisted extension.
+    fmt = fmt.split("?", 1)[0].lower()
+    if fmt not in ("png", "webp", "jpg", "jpeg", "tif", "tiff"):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Unsupported tile format: {fmt!r}",
+        )
+
     # Resolve effective bounds (apply defaults so callers downstream always receive
     # concrete values, not None).
     eff_pmin: float = pmin if pmin is not None else 2.0

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -888,8 +888,10 @@ def test_router_orchestrator_modules_stay_within_loc_cap() -> None:
         # rel=tiles, omit rel=items), stable numberMatched + collection count,
         # and the filter-lang 400. Smoke-residual follow-up (#315): +public_app_url
         # fetches in 3 OGC-record handlers for the raster_tiles app-origin fix.
-        # Cap 1600 -> 1640 (~6 LOC headroom).
-        "backend/app/modules/catalog/search/router.py": 1640,
+        # Hygiene follow-up (#317, A2): +~25 LOC for the record_type/sort_by
+        # allowlist constants + the to_filters() validation chokepoint.
+        # Cap 1640 -> 1700 (now 1671 LOC, ~1.7% headroom).
+        "backend/app/modules/catalog/search/router.py": 1700,
         # Phase 1176 PERF-002: +~60 lines for the raster tile auth/metadata
         # TTLCache (_RasterMeta + _resolve_raster_meta), mirroring the vector
         # tile meta cache so raster tiles aren't asymmetric.

--- a/backend/tests/test_raster_colormap_proxy.py
+++ b/backend/tests/test_raster_colormap_proxy.py
@@ -660,9 +660,11 @@ class TestRasterColormapProxy:
     # ------------------------------------------------------------------
 
     async def test_proxy_polluted_fmt_query_in_path_is_sanitized(self, client):
-        """fmt='png?stretch=...' (query encoded into the path) renders a tile with
-        a well-formed single-'?' Titiler URL, not a 422 from a double-'?'."""
-        # '?' percent-encoded into the fmt path segment (what a misbehaving proxy sends)
+        """fmt='png?stretch=...' (query encoded ONLY into the path) renders a tile
+        with a well-formed single-'?' Titiler URL, AND the buried stretch is
+        recovered + applied (not silently dropped to the default tile — Codex P2)."""
+        # '?' + '&' percent-encoded into the fmt path segment (a path-encoding proxy
+        # that did NOT also forward the query as a real ?query string).
         resp = await client.get(
             f"/tiles/raster-proxy/{_DATASET_ID}/0/0/0.png%3Fstretch=percentile"
         )
@@ -674,6 +676,24 @@ class TestRasterColormapProxy:
         assert "/0/0/0.png?url=" in url, f"Polluted fmt leaked into endpoint: {url}"
         assert "stretch=" not in url.split("?", 1)[0], (
             f"Pollution before the query separator: {url}"
+        )
+        # The recovered stretch=percentile must be APPLIED: a /cog/statistics lookup
+        # ran and the tile rescale is the percentile (512.66,1304.31), not default.
+        assert self._stats_titiler_calls, "buried stretch was dropped (no stats fetch)"
+        assert "rescale=512.66,1304.31" in url, (
+            f"recovered stretch=percentile not applied to tile URL: {url}"
+        )
+
+    async def test_proxy_recovers_buried_pmin_pmax_from_fmt(self, client):
+        """Buried pmin/pmax in the path are recovered and forwarded to /cog/statistics."""
+        resp = await client.get(
+            f"/tiles/raster-proxy/{_DATASET_ID}/0/0/0.png%3Fstretch=percentile%26pmin=5%26pmax=95"
+        )
+        assert resp.status_code in (200, 204)
+        assert self._stats_titiler_calls, "no stats fetch for recovered percentile"
+        stats_url = self._stats_titiler_calls[0]
+        assert "p=5" in stats_url and "p=95" in stats_url, (
+            f"recovered pmin/pmax not forwarded to statistics URL: {stats_url}"
         )
 
     async def test_proxy_rejects_unsupported_fmt(self, client):

--- a/backend/tests/test_raster_colormap_proxy.py
+++ b/backend/tests/test_raster_colormap_proxy.py
@@ -651,3 +651,33 @@ class TestRasterColormapProxy:
         assert "rescale=512.66,1304.31" not in tile_url, (
             f"SPIKE-01: tile URL must NOT use hardcoded percentile_2/percentile_98 values: {tile_url}"
         )
+
+    # ------------------------------------------------------------------
+    # A-fix (#315 follow-up): proxy-polluted {fmt} must be sanitized so the
+    # Titiler URL is never malformed with a double "?". Some reverse-proxy
+    # rewrites URL-encode the request query into the PATH, delivering
+    # fmt="png?stretch=...".
+    # ------------------------------------------------------------------
+
+    async def test_proxy_polluted_fmt_query_in_path_is_sanitized(self, client):
+        """fmt='png?stretch=...' (query encoded into the path) renders a tile with
+        a well-formed single-'?' Titiler URL, not a 422 from a double-'?'."""
+        # '?' percent-encoded into the fmt path segment (what a misbehaving proxy sends)
+        resp = await client.get(
+            f"/tiles/raster-proxy/{_DATASET_ID}/0/0/0.png%3Fstretch=percentile"
+        )
+        assert resp.status_code in (200, 204)
+        assert len(self._tile_titiler_calls) == 1
+        url = self._tile_titiler_calls[0]
+        assert url.count("?") == 1, f"Titiler URL must have exactly one '?': {url}"
+        # endpoint must be the clean ".png" with the query starting at url=
+        assert "/0/0/0.png?url=" in url, f"Polluted fmt leaked into endpoint: {url}"
+        assert "stretch=" not in url.split("?", 1)[0], (
+            f"Pollution before the query separator: {url}"
+        )
+
+    async def test_proxy_rejects_unsupported_fmt(self, client):
+        """A non-image fmt is rejected with 400 (hardening: {fmt} feeds an upstream URL)."""
+        resp = await client.get(f"/tiles/raster-proxy/{_DATASET_ID}/0/0/0.exe")
+        assert resp.status_code == 400
+        assert not self._tile_titiler_calls, "Titiler must not be called for a bad fmt"

--- a/backend/tests/test_search.py
+++ b/backend/tests/test_search.py
@@ -253,6 +253,40 @@ async def test_search_text_match(
 
 
 @pytest.mark.anyio
+@pytest.mark.parametrize("param", ["record_type", "sort_by"])
+async def test_search_rejects_bogus_enum_params(
+    client: AsyncClient,
+    admin_auth_header: dict,
+    param: str,
+):
+    """A2 (#315 follow-up): a bogus record_type / sort_by is rejected (400) instead
+    of silently returning 200 (empty result / silent created_at fallback)."""
+    resp = await client.get(
+        "/search/datasets/",
+        params={param: "banana"},
+        headers=admin_auth_header,
+    )
+    assert resp.status_code == 400, (
+        f"bogus {param}=banana should 400, got {resp.status_code}"
+    )
+
+
+@pytest.mark.anyio
+async def test_search_accepts_valid_enum_params(
+    client: AsyncClient,
+    admin_auth_header: dict,
+    search_datasets: dict,
+):
+    """A2: valid record_type / sort_by values still pass."""
+    resp = await client.get(
+        "/search/datasets/",
+        params={"record_type": "vector_dataset", "sort_by": "date_added"},
+        headers=admin_auth_header,
+    )
+    assert resp.status_code == 200
+
+
+@pytest.mark.anyio
 async def test_search_text_empty_returns_all(
     client: AsyncClient,
     admin_auth_header: dict,

--- a/backend/tests/test_search_facets.py
+++ b/backend/tests/test_search_facets.py
@@ -197,12 +197,16 @@ async def test_facets_with_srid_filter(
 
 
 @pytest.mark.anyio
-async def test_facets_includes_collection_count(
+async def test_facets_excludes_dead_collection_record_type(
     client: AsyncClient,
     admin_auth_header: dict,
     test_db_session,
 ):
-    """GET /search/facets returns a 'collection' count when collections exist."""
+    """A4 (#315 follow-up): the record_type facet must NOT advertise a 'collection'
+    value. Collections live in the separate Collection table, not as Record rows
+    with record_type='collection', so ?record_type=collection always returns 0 --
+    a dead facet value. Collections are surfaced via the 'collections' facet instead.
+    """
     session = test_db_session
     admin_id = await get_user_id(session, "admin")
 
@@ -222,7 +226,11 @@ async def test_facets_includes_collection_count(
     assert resp.status_code == 200
     data = resp.json()
     counts = data["record_type"]
-    assert counts.get("collection", 0) >= 1
+    assert "collection" not in counts, (
+        "record_type facet must not advertise the unfilterable 'collection' value"
+    )
+    # Collections are exposed via the dedicated 'collections' facet group.
+    assert "collections" in data
 
 
 @pytest.mark.anyio

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -125,6 +125,14 @@ server {
         set $upstream_api http://api:8000;
         rewrite ^/api/(.*) /$1 break;
         proxy_pass $upstream_api;
+        # A3 (#315 follow-up): the FastAPI SecurityHeadersMiddleware already emits
+        # X-Frame-Options: DENY. This block has no add_header, so it inherits the
+        # server-scope `add_header X-Frame-Options SAMEORIGIN`, which nginx APPENDS
+        # to the proxied DENY -> two conflicting X-Frame-Options on every /api
+        # response. Strip the upstream header so exactly one (the inherited
+        # SAMEORIGIN) survives. The backend still emits DENY for direct,
+        # non-proxied access (defense-in-depth when nginx isn't in front).
+        proxy_hide_header X-Frame-Options;
         proxy_set_header Host $http_host;
         proxy_set_header X-Forwarded-Host $http_host;
         proxy_set_header X-Real-IP $remote_addr;

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -106,7 +106,10 @@ server {
         # public datasets. Private datasets get distinct cache keys via the
         # api setting Cache-Control on its response (`no-store` for private).
         proxy_cache raster_cache;
-        proxy_cache_key "$dataset_id/$z/$x/$y.$fmt/$arg_colormap_name/$arg_stretch";
+        # Cache key must vary by EVERY render param the api forwards to Titiler,
+        # else tiles with different bounds collide (#317 Codex P2): include
+        # pmin/pmax/sigma alongside colormap_name/stretch.
+        proxy_cache_key "$dataset_id/$z/$x/$y.$fmt/$arg_colormap_name/$arg_stretch/$arg_pmin/$arg_pmax/$arg_sigma";
         proxy_cache_valid 200 1h;
         proxy_cache_use_stale error timeout updating;
         # Honor the api's Cache-Control: nginx skips caching when the api

--- a/frontend/src/components/auth/OAuthButtons.tsx
+++ b/frontend/src/components/auth/OAuthButtons.tsx
@@ -152,9 +152,6 @@ export function OAuthButtons({ showDivider = true }: { showDivider?: boolean } =
           );
         })}
       </div>
-      <p className="text-center text-[11.5px] leading-snug text-muted-foreground">
-        {t('oauth.helper')}
-      </p>
     </div>
   );
 }

--- a/frontend/src/i18n/locales/de/auth.json
+++ b/frontend/src/i18n/locales/de/auth.json
@@ -71,8 +71,7 @@
       "google": "Google",
       "microsoft": "Microsoft",
       "github": "GitHub"
-    },
-    "helper": "Single Sign-On ist verfügbar, wenn Ihre Organisation es konfiguriert hat."
+    }
   },
   "oauthCallback": {
     "completingSignIn": "Anmeldung wird abgeschlossen..."

--- a/frontend/src/i18n/locales/en/auth.json
+++ b/frontend/src/i18n/locales/en/auth.json
@@ -67,7 +67,6 @@
     "divider": "or continue with",
     "unavailable": "SSO options unavailable",
     "signInWith": "Sign in with {{provider}}",
-    "helper": "Single sign-on is available when your organization has configured it.",
     "providers": {
       "google": "Google",
       "microsoft": "Microsoft",

--- a/frontend/src/i18n/locales/es/auth.json
+++ b/frontend/src/i18n/locales/es/auth.json
@@ -71,8 +71,7 @@
       "google": "Google",
       "microsoft": "Microsoft",
       "github": "GitHub"
-    },
-    "helper": "El inicio de sesión único está disponible cuando tu organización lo ha configurado."
+    }
   },
   "oauthCallback": {
     "completingSignIn": "Completando inicio de sesión..."

--- a/frontend/src/i18n/locales/fr/auth.json
+++ b/frontend/src/i18n/locales/fr/auth.json
@@ -71,8 +71,7 @@
       "google": "Google",
       "microsoft": "Microsoft",
       "github": "GitHub"
-    },
-    "helper": "L'authentification unique est disponible lorsque votre organisation l'a configurée."
+    }
   },
   "oauthCallback": {
     "completingSignIn": "Connexion en cours..."


### PR DESCRIPTION
Follow-up to #315/#316 — closes the residual smoke-check hygiene items plus a real, live-reproduced raster rendering bug.

## Raster stretch/colormap 422 (the big one)
On the live demo, `?stretch=minmax|percentile|stddev` and `?colormap_name=` on raster tiles returned **422** (base tiles were fine). Root-caused by isolating the layers: hitting the api **directly** → 200, but through the proxy chain → 422. A reverse-proxy rewrite (frontend nginx `/raster-tiles`: `rewrite ... $is_args$args` + a *variable* `proxy_pass`) URL-encodes the request query into the **path**, so the `{fmt}` path param arrives as `png?stretch=...` and the built Titiler URL becomes `.../771.png?stretch=...?url=...` (double `?`) → Titiler 422.

**Fix:** sanitize + allowlist `{fmt}` at the top of `raster_tile_proxy`. The real render params still arrive as proper query params, so stripping the path pollution lets the tile render **with** the stretch applied. Also a hardening win — `{fmt}` feeds an upstream URL. (Left the nginx rewrite alone: it works for base tiles and variable-`proxy_pass` query handling is fragile to change blind; the backend sanitize covers all deployments.)

## Hygiene (post-#315 assessment residuals)
- **A2** — `record_type` / `sort_by` were free-form: a bogus value silently returned 200 (empty result / silent `created_at` fallback). Now `400` via `SearchQueryParams.to_filters()` (the single chokepoint for both native + OGC search).
- **A4** — the `record_type` facet advertised a `collection` count, but `?record_type=collection` filters `Record.record_type` (no such rows) and always returned 0 — a dead facet value. Dropped it; collections are surfaced via the dedicated `collections` facet.
- **A3** — `/api` responses carried **two** conflicting `X-Frame-Options` (backend `DENY` + nginx-inherited `SAMEORIGIN`). nginx `proxy_hide_header X-Frame-Options` in the `/api/` block → exactly one survives. Backend still emits `DENY` for direct (non-proxied) access.
- **Login** — removed the redundant "Single sign-on is available when your organization has configured it" caption that only ever rendered *beneath already-configured SSO buttons* (the component returns null with zero providers, so it never showed in the no-provider case it described). Dropped the unused i18n key (en/de/fr/es).

## Tests
- `test_proxy_polluted_fmt_query_in_path_is_sanitized`, `test_proxy_rejects_unsupported_fmt`
- `test_search_rejects_bogus_enum_params[record_type|sort_by]`, `test_search_accepts_valid_enum_params`
- `test_facets_excludes_dead_collection_record_type`
- 84 backend (touched files) + 31 frontend auth tests green; frontend typecheck clean.

## Live-verified on the demo (`demo-2026-06-24d`)
- stretch minmax/percentile/stddev + custom pmin/pmax → **200** (differing PNG sizes confirm stretch is applied)
- bogus `record_type`/`sort_by` → **400**; facet no longer lists `collection`
- `/api` → single `X-Frame-Options: SAMEORIGIN`; login caption gone from the served bundle

https://claude.ai/code/session_01ATqNfJXvg3zXfktncsNUdf