### PR TITLE
fix(authz): owner-or-admin consistency across dataset & collection mutations (backend + UI)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -52,19 +52,17 @@ repos:
         name: "Visibility Rule 1 — route files calling get_dataset must reference check_dataset_access or apply_visibility_filter"
         description: >
           Any route handler that fetches a Record/Dataset/Map by ID must call
-          check_dataset_access_or_anonymous (read) or check_dataset_access (write)
-          or apply_visibility_filter. See AGENTS.md Security pre-commit checklist Rule 1.
-          One file (router_reupload.py) is excluded: it has a tracked,
-          separately-managed access-control gap and stays excluded until that
-          fix ships.
+          check_dataset_access_or_anonymous (read), check_dataset_access (read),
+          check_dataset_write_access (owner-or-admin mutation), or
+          apply_visibility_filter. See AGENTS.md Security pre-commit checklist Rule 1.
         language: system
         entry: >-
           bash -c '
           for f in "$@"; do
             if grep -qE "^@(stac_|ogc_|layers_|router)\.(get|post|patch|delete|put)" "$f" \
               && grep -qE "get_dataset\(" "$f" \
-              && ! grep -qE "check_dataset_access|apply_visibility_filter" "$f"; then
-              echo "FAIL: $f has route handlers calling get_dataset without check_dataset_access or apply_visibility_filter"
+              && ! grep -qE "check_dataset_access|check_dataset_write_access|apply_visibility_filter" "$f"; then
+              echo "FAIL: $f has route handlers calling get_dataset without an access/visibility check"
               exit 1
             fi
           done

--- a/backend/app/modules/catalog/authorization.py
+++ b/backend/app/modules/catalog/authorization.py
@@ -133,3 +133,40 @@ async def check_dataset_access(
         )
 
     return user_roles
+
+
+async def check_dataset_write_access(
+    db: AsyncSession,
+    dataset: Any,
+    dataset_id: uuid.UUID,
+    user: Identity,
+    *,
+    user_roles: set[str] | None = None,
+) -> set[str]:
+    """Enforce owner-or-admin for dataset MUTATIONS. Raises 404/403.
+
+    ``check_dataset_access`` is a VISIBILITY check: it lets any authenticated
+    user through on a public+published dataset, so it must not gate writes.
+    Mutating a dataset (edit metadata, publish/unpublish, change visibility,
+    reupload, delete, attributes, relationships, VRT regenerate) requires the
+    caller to be the dataset's creator (``record.created_by``) or a global admin.
+
+    Applies the visibility check first (404, so we don't leak datasets the user
+    cannot even see), then the ownership check (403). Datasets with no recorded
+    owner (``record.created_by`` is NULL — e.g. seeded/imported data, or rows
+    whose owner was deleted) are admin-only.
+
+    Returns the resolved ``user_roles`` set so callers can reuse it downstream.
+    """
+    user_roles = await check_dataset_access(
+        db, dataset, dataset_id, user, user_roles=user_roles
+    )
+    created_by = dataset.record.created_by
+    if created_by is not None and created_by == user.id:
+        return user_roles
+    if "admin" in user_roles:
+        return user_roles
+    raise HTTPException(
+        status_code=status.HTTP_403_FORBIDDEN,
+        detail="Only the dataset owner or an admin may modify this dataset.",
+    )

--- a/backend/app/modules/catalog/collections/router.py
+++ b/backend/app/modules/catalog/collections/router.py
@@ -27,6 +27,7 @@ from app.modules.catalog.collections.service import (
     add_datasets_to_collection,
     batch_collection_dataset_counts,
     batch_collection_extents,
+    check_collection_ownership,
     create_collection,
     delete_collection,
     get_collection,
@@ -201,7 +202,14 @@ async def update_collection_endpoint(
     user: Identity = Depends(require_permission("manage_collections")),
     db: AsyncSession = Depends(get_db),
 ) -> CollectionResponse:
-    """Update a collection's name and/or description."""
+    """Update a collection's name and/or description. Owner or admin only."""
+    existing = await get_collection(db, collection_id)
+    if existing is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Collection not found",
+        )
+    await check_collection_ownership(db, existing, user)
     try:
         collection = await update_collection(
             db, collection_id, name=body.name, description=body.description
@@ -250,7 +258,14 @@ async def delete_collection_endpoint(
     user: Identity = Depends(require_permission("manage_collections")),
     db: AsyncSession = Depends(get_db),
 ) -> Response:
-    """Delete a collection. Admin only."""
+    """Delete a collection. Owner or admin only."""
+    existing = await get_collection(db, collection_id)
+    if existing is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Collection not found",
+        )
+    await check_collection_ownership(db, existing, user)
     try:
         name = await delete_collection(db, collection_id)
     except ValueError:
@@ -284,7 +299,15 @@ async def add_datasets_endpoint(
     user: Identity = Depends(require_permission("manage_collections")),
     db: AsyncSession = Depends(get_db),
 ) -> AddDatasetsResponse:
-    """Add datasets to a collection."""
+    """Add datasets to a collection. Collection owner or admin only."""
+    collection = await get_collection(db, collection_id)
+    if collection is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Collection not found",
+        )
+    await check_collection_ownership(db, collection, user)
+
     # GAP-014: authorize each dataset being LINKED at write time, mirroring the
     # FK-relationship create path (router_metadata.create_dataset_relationship)
     # and the VRT SEC-C link-time check. manage_collections gates the action but
@@ -340,7 +363,15 @@ async def remove_dataset_endpoint(
     user: Identity = Depends(require_permission("manage_collections")),
     db: AsyncSession = Depends(get_db),
 ) -> Response:
-    """Remove a dataset from a collection."""
+    """Remove a dataset from a collection. Collection owner or admin only."""
+    collection = await get_collection(db, collection_id)
+    if collection is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Collection not found",
+        )
+    await check_collection_ownership(db, collection, user)
+
     removed = await remove_dataset_from_collection(db, collection_id, dataset_id)
     if not removed:
         raise HTTPException(

--- a/backend/app/modules/catalog/collections/service.py
+++ b/backend/app/modules/catalog/collections/service.py
@@ -19,12 +19,13 @@ Handles CRUD operations for collections and collection-dataset membership.
 import json
 import uuid
 
+from fastapi import HTTPException, status
 from sqlalchemy import delete, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import joinedload
 
 from app.core.identity import Identity
-from app.modules.catalog.authorization import apply_visibility_filter
+from app.modules.catalog.authorization import apply_visibility_filter, get_user_roles
 from app.modules.catalog.collections.models import Collection, CollectionDataset
 from app.modules.catalog.datasets.domain.models import Dataset, DatasetGrant, Record
 
@@ -104,6 +105,30 @@ async def get_collection(
         select(Collection).where(Collection.id == collection_id)
     )
     return result.scalar_one_or_none()
+
+
+async def check_collection_ownership(
+    session: AsyncSession,
+    collection: Collection,
+    user: Identity,
+) -> None:
+    """Verify the user owns the collection or is admin. Raises 403 otherwise.
+
+    Mutating a collection (rename, delete, add/remove member datasets) is
+    restricted to its creator (``created_by``) or a global admin. Reading and
+    listing collections stay open (collections are organizational). Collections
+    with no recorded owner (``created_by`` is NULL — seeded data or rows whose
+    owner was deleted) are admin-only.
+    """
+    if collection.created_by is not None and collection.created_by == user.id:
+        return
+    user_roles = await get_user_roles(session, user)
+    if "admin" in user_roles:
+        return
+    raise HTTPException(
+        status_code=status.HTTP_403_FORBIDDEN,
+        detail="Only the collection owner or an admin may modify this collection.",
+    )
 
 
 async def list_collections(

--- a/backend/app/modules/catalog/datasets/api/router.py
+++ b/backend/app/modules/catalog/datasets/api/router.py
@@ -23,8 +23,8 @@ from app.modules.auth.dependencies import (
     require_permission,
 )
 from app.modules.catalog.authorization import (
-    check_dataset_access,
     check_dataset_access_or_anonymous,
+    check_dataset_write_access,
     get_user_roles,
 )
 from app.modules.catalog.datasets.domain.helpers import (
@@ -275,14 +275,16 @@ async def update_dataset_metadata(
     db: AsyncSession = Depends(get_db),
 ) -> DatasetResponse:
     """Update user-editable dataset metadata."""
-    # Phase 1061 SEC-S02: resource-level access check (role gate alone is insufficient).
+    # Owner-or-admin: editing metadata (incl. visibility/publication) is a
+    # mutation; the role gate + visibility check alone let any editor edit a
+    # peer's public dataset.
     dataset = await get_dataset(db, dataset_id)
     if dataset is None:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="Dataset not found",
         )
-    await check_dataset_access(db, dataset, dataset_id, user)
+    await check_dataset_write_access(db, dataset, dataset_id, user)
 
     try:
         dataset = await update_user_metadata(
@@ -366,9 +368,11 @@ async def bulk_delete_datasets_endpoint(
                 )
                 continue
             try:
-                await check_dataset_access(db, item_dataset, item.dataset_id, user)
+                await check_dataset_write_access(
+                    db, item_dataset, item.dataset_id, user
+                )
             except HTTPException as exc:
-                # check_dataset_access raises 404 on access denial — surface as per-item error
+                # write-access raises 404 (not visible) / 403 (not owner) — surface per-item
                 results.append(
                     BulkDeleteResultItem(
                         dataset_id=item.dataset_id,
@@ -429,25 +433,14 @@ async def delete_dataset_endpoint(
     db: AsyncSession = Depends(get_db),
 ) -> Response:
     """Delete a dataset with cascade cleanup. Owner or admin only, requires confirm_title."""
-    # Phase 1061 SEC-S02: resource-level access check.
+    # Owner-or-admin: destructive op restricted to the dataset's creator or admin.
     dataset = await get_dataset(db, dataset_id)
     if dataset is None:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="Dataset not found",
         )
-    await check_dataset_access(db, dataset, dataset_id, user)
-
-    # Phase 1061 SEC-S02: even for public datasets, only owner or admin may delete.
-    # check_dataset_access enforces ownership for private; widen to public for destructive ops.
-    user_roles = await get_user_roles(db, user)
-    is_admin = "admin" in user_roles
-    is_owner = dataset.record.created_by == user.id
-    if not (is_admin or is_owner):
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail="Only the dataset owner or an admin may delete this dataset.",
-        )
+    await check_dataset_write_access(db, dataset, dataset_id, user)
 
     try:
         table_name = await delete_dataset(db, dataset_id, body.confirm_title)

--- a/backend/app/modules/catalog/datasets/api/router_data.py
+++ b/backend/app/modules/catalog/datasets/api/router_data.py
@@ -21,8 +21,8 @@ from app.modules.auth.dependencies import (
     require_permission,
 )
 from app.modules.catalog.authorization import (
-    check_dataset_access,
     check_dataset_access_or_anonymous,
+    check_dataset_write_access,
 )
 from app.modules.catalog.datasets.domain.models import Dataset as DatasetModel
 from app.modules.catalog.datasets.domain.schemas import (
@@ -170,6 +170,18 @@ async def validate_dataset(
         )
     await check_dataset_access_or_anonymous(db, dataset, dataset_id, user)
 
+    # The explicit ?refresh=true path recomputes and PERSISTS a fresh quality
+    # score (an expensive write) — restrict it to the dataset owner or an admin.
+    # The implicit first-read populate (quality_detail is None) stays open so
+    # ordinary/anonymous readers still get a score lazily.
+    if refresh:
+        if user is None:
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="Authentication required to refresh validation.",
+            )
+        await check_dataset_write_access(db, dataset, dataset_id, user)
+
     validation = await run_validation(db, dataset.record, dataset)
 
     if refresh or dataset.quality_detail is None:
@@ -270,10 +282,10 @@ async def update_publication_status(
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND, detail="Dataset not found"
         )
-    # Phase 1061 CR-01: resource-level access check (SEC-S02 pattern).
-    # require_permission("edit_metadata") is role-level only; any editor
-    # could otherwise promote another user's private dataset to published.
-    await check_dataset_access(db, dataset, dataset_id, user)
+    # Owner-or-admin: publish/unpublish is a mutation. The role gate +
+    # visibility check let any editor change the status of a peer's public
+    # dataset (e.g. unpublish a dataset they did not publish).
+    await check_dataset_write_access(db, dataset, dataset_id, user)
 
     current = dataset.record.record_status
     target = body.status
@@ -325,11 +337,10 @@ async def set_target_status(
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND, detail="Dataset not found"
         )
-    # Phase 1061 CR-01: resource-level access check (SEC-S02 pattern).
-    # require_permission("edit_metadata") is role-level only; any editor
-    # could otherwise walk another user's private dataset through the full
-    # draft→ready→internal→published chain without ownership check.
-    await check_dataset_access(db, dataset, dataset_id, user)
+    # Owner-or-admin: walking the publication chain is a mutation. The role
+    # gate + visibility check let any editor publish/unpublish a peer's public
+    # dataset through the full draft→ready→internal→published chain.
+    await check_dataset_write_access(db, dataset, dataset_id, user)
 
     current = dataset.record.record_status
     target = body.status

--- a/backend/app/modules/catalog/datasets/api/router_metadata.py
+++ b/backend/app/modules/catalog/datasets/api/router_metadata.py
@@ -24,6 +24,7 @@ from app.modules.auth.dependencies import (
 from app.modules.catalog.authorization import (
     check_dataset_access,
     check_dataset_access_or_anonymous,
+    check_dataset_write_access,
 )
 from app.modules.catalog.datasets.domain.schemas import (
     AttributeMetadataListResponse,
@@ -155,7 +156,7 @@ async def update_attribute_endpoint(
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND, detail="Dataset not found"
         )
-    await check_dataset_access(db, dataset, dataset_id, user)
+    await check_dataset_write_access(db, dataset, dataset_id, user)
     from app.modules.catalog.datasets.domain.service import (
         get_attribute as get_attr_svc,
     )
@@ -211,7 +212,7 @@ async def reset_attribute_endpoint(
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND, detail="Dataset not found"
         )
-    await check_dataset_access(db, dataset, dataset_id, user)
+    await check_dataset_write_access(db, dataset, dataset_id, user)
     from app.modules.catalog.datasets.domain.service import (
         get_attribute as get_attr_svc,
     )
@@ -418,7 +419,9 @@ async def create_dataset_relationship(
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND, detail="Dataset not found"
         )
-    user_roles = await check_dataset_access(db, dataset, dataset_id, current_user)
+    # Owner-or-admin of the SOURCE dataset: the relationship is attached to it.
+    # The target only needs to be readable (visibility check below).
+    user_roles = await check_dataset_write_access(db, dataset, dataset_id, current_user)
 
     from app.modules.catalog.datasets.domain.models import Dataset
 
@@ -482,7 +485,9 @@ async def delete_dataset_relationship(
             status_code=status.HTTP_404_NOT_FOUND, detail="Relationship not found"
         )
     _rel, source_dataset, target_dataset = relationship
-    user_roles = await check_dataset_access(
+    # Owner-or-admin of the SOURCE dataset (the relationship belongs to it);
+    # the target only needs to remain readable.
+    user_roles = await check_dataset_write_access(
         db, source_dataset, source_dataset.id, current_user
     )
     await check_dataset_access(

--- a/backend/app/modules/catalog/datasets/api/router_reupload.py
+++ b/backend/app/modules/catalog/datasets/api/router_reupload.py
@@ -19,7 +19,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.identity import Identity
 from app.modules.auth.dependencies import require_permission
-from app.modules.catalog.authorization import check_dataset_access
+from app.modules.catalog.authorization import check_dataset_write_access
 from app.core.config import settings
 from app.core.db.tenant_session import defer_async_with_tenant
 from app.modules.catalog.datasets.domain.schemas import (
@@ -156,7 +156,7 @@ async def reupload_dataset(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="Dataset not found",
         )
-    await check_dataset_access(db, dataset, dataset_id, user)
+    await check_dataset_write_access(db, dataset, dataset_id, user)
 
     _assert_compatible_record_type(dataset, file.filename)
 
@@ -237,7 +237,7 @@ async def reupload_service_preview(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="Dataset not found",
         )
-    await check_dataset_access(db, dataset, dataset_id, user)
+    await check_dataset_write_access(db, dataset, dataset_id, user)
 
     # IA-P1-02: surface cross-record-type swaps as a useful 400 before the
     # pipeline executes (vector→raster or any→VRT explodes deep otherwise).
@@ -349,7 +349,7 @@ async def reupload_preview(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="Dataset not found",
         )
-    await check_dataset_access(db, dataset, dataset_id, user)
+    await check_dataset_write_access(db, dataset, dataset_id, user)
 
     result = await db.execute(select(IngestJob).where(IngestJob.id == job_id))
     job = result.scalar_one_or_none()
@@ -472,7 +472,7 @@ async def reupload_commit(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="Dataset not found",
         )
-    await check_dataset_access(db, dataset, dataset_id, user)
+    await check_dataset_write_access(db, dataset, dataset_id, user)
 
     result = await db.execute(select(IngestJob).where(IngestJob.id == job_id))
     job = result.scalar_one_or_none()
@@ -624,7 +624,7 @@ async def request_presigned_reupload(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="Dataset not found",
         )
-    await check_dataset_access(db, dataset, dataset_id, user)
+    await check_dataset_write_access(db, dataset, dataset_id, user)
 
     _assert_compatible_record_type(dataset, request.filename)
 
@@ -739,7 +739,7 @@ async def complete_presigned_reupload(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="Dataset not found",
         )
-    await check_dataset_access(db, dataset, dataset_id, user)
+    await check_dataset_write_access(db, dataset, dataset_id, user)
 
     job = await get_catalog_port().get_ingest_job_or_404(db, job_id, user)
     um = job.user_metadata or {}

--- a/backend/app/modules/catalog/datasets/api/router_vrt.py
+++ b/backend/app/modules/catalog/datasets/api/router_vrt.py
@@ -16,7 +16,10 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.identity import Identity
 from app.modules.auth.dependencies import get_current_active_user
-from app.modules.catalog.authorization import check_dataset_access
+from app.modules.catalog.authorization import (
+    check_dataset_access,
+    check_dataset_write_access,
+)
 from app.modules.catalog.datasets.domain.schemas import (
     VrtActiveGeneration,
     VrtGenerationItem,
@@ -328,7 +331,9 @@ async def regenerate_vrt_endpoint(
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND, detail="Dataset not found"
         )
-    await check_dataset_access(db, dataset, dataset_id, user)
+    # Owner-or-admin: regenerating the VRT mutates asset status and enqueues
+    # work; previously any authenticated user could trigger it on a peer's raster.
+    await check_dataset_write_access(db, dataset, dataset_id, user)
 
     # Load VRT RasterAsset
     asset_result = await db.execute(

--- a/backend/app/modules/catalog/features/router.py
+++ b/backend/app/modules/catalog/features/router.py
@@ -12,7 +12,10 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.modules.audit.service import AuditEvent, audit_emit
 from app.core.identity import Identity
 from app.modules.auth.dependencies import get_current_active_user, require_permission
-from app.modules.catalog.authorization import check_dataset_access
+from app.modules.catalog.authorization import (
+    check_dataset_access,
+    check_dataset_write_access,
+)
 from app.modules.catalog.datasets.domain.service import get_dataset
 from app.core.dependencies import get_db
 from app.modules.catalog.features.schemas import (
@@ -377,7 +380,7 @@ async def create_feature(
             detail="Dataset not found",
         )
 
-    await check_dataset_access(db, dataset, dataset_id, user)
+    await check_dataset_write_access(db, dataset, dataset_id, user)
 
     try:
         row = await insert_feature(
@@ -462,7 +465,7 @@ async def replace_single_feature(
             detail="Dataset not found",
         )
 
-    await check_dataset_access(db, dataset, dataset_id, user)
+    await check_dataset_write_access(db, dataset, dataset_id, user)
 
     try:
         row = await replace_feature(
@@ -545,7 +548,7 @@ async def patch_single_feature(
             detail="Dataset not found",
         )
 
-    await check_dataset_access(db, dataset, dataset_id, user)
+    await check_dataset_write_access(db, dataset, dataset_id, user)
 
     try:
         row = await update_feature(
@@ -623,7 +626,7 @@ async def delete_single_feature(
             detail="Dataset not found",
         )
 
-    await check_dataset_access(db, dataset, dataset_id, user)
+    await check_dataset_write_access(db, dataset, dataset_id, user)
 
     try:
         await delete_feature(db, dataset.table_name, gid)

--- a/backend/app/processing/ingest/router.py
+++ b/backend/app/processing/ingest/router.py
@@ -1031,17 +1031,22 @@ async def add_vrt_source(
     # duplicate-link check so a foreign source 404s rather than leaking a 409.
     from app.modules.catalog.authorization import (
         check_dataset_access,
+        check_dataset_write_access,
         get_user_roles,
     )
     from app.modules.catalog.datasets.domain.service import get_dataset
 
     user_roles = await get_user_roles(db, user)
     source_dataset = await get_dataset(db, request.source_dataset_id)
+    # The source only needs to be readable by the caller (it is being linked, not
+    # modified); the VRT itself is being mutated, so it requires owner-or-admin.
     await check_dataset_access(
         db, source_dataset, request.source_dataset_id, user, user_roles=user_roles
     )
     vrt_dataset = await get_dataset(db, dataset_id)
-    await check_dataset_access(db, vrt_dataset, dataset_id, user, user_roles=user_roles)
+    await check_dataset_write_access(
+        db, vrt_dataset, dataset_id, user, user_roles=user_roles
+    )
 
     # 4. Check for duplicate link
     dup_result = await db.execute(
@@ -1209,6 +1214,14 @@ async def remove_vrt_source(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=f"VRT dataset {dataset_id} not found",
         )
+
+    # Owner-or-admin: removing a source mutates the VRT composition. The
+    # `upload` capability alone is not ownership.
+    from app.modules.catalog.authorization import check_dataset_write_access
+    from app.modules.catalog.datasets.domain.service import get_dataset
+
+    vrt_dataset = await get_dataset(db, dataset_id)
+    await check_dataset_write_access(db, vrt_dataset, dataset_id, user)
 
     # 2. Mutation serialization guard (SRC-05)
     if vrt_asset.status == "regenerating":

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -22015,7 +22015,7 @@
     },
     "/catalog/collections/{collection_id}": {
       "delete": {
-        "description": "Delete a collection. Admin only.",
+        "description": "Delete a collection. Owner or admin only.",
         "operationId": "delete_collection_endpoint_catalog_collections__collection_id__delete",
         "parameters": [
           {
@@ -22236,7 +22236,7 @@
         ]
       },
       "patch": {
-        "description": "Update a collection's name and/or description.",
+        "description": "Update a collection's name and/or description. Owner or admin only.",
         "operationId": "update_collection_endpoint_catalog_collections__collection_id__patch",
         "parameters": [
           {
@@ -22499,7 +22499,7 @@
         ]
       },
       "post": {
-        "description": "Add datasets to a collection.",
+        "description": "Add datasets to a collection. Collection owner or admin only.",
         "operationId": "add_datasets_endpoint_catalog_collections__collection_id__datasets__post",
         "parameters": [
           {
@@ -22625,7 +22625,7 @@
     },
     "/catalog/collections/{collection_id}/datasets/{dataset_id}": {
       "delete": {
-        "description": "Remove a dataset from a collection.",
+        "description": "Remove a dataset from a collection. Collection owner or admin only.",
         "operationId": "remove_dataset_endpoint_catalog_collections__collection_id__datasets__dataset_id__delete",
         "parameters": [
           {

--- a/backend/tests/test_audit.py
+++ b/backend/tests/test_audit.py
@@ -24,18 +24,17 @@ from tests.factories import create_dataset, get_user_id
 async def test_metadata_edit_creates_audit_log(
     client: AsyncClient,
     admin_auth_header: dict,
-    editor_auth_header: dict,
     test_db_session,
 ):
     """PATCH /datasets/{id} creates a metadata.edit audit log entry."""
     admin_id = await get_user_id(test_db_session, "admin")
     ds = await create_dataset(test_db_session, created_by=admin_id)
 
-    # Editor edits the dataset metadata
+    # The owner (admin) edits the dataset metadata
     patch_resp = await client.patch(
         f"/datasets/{ds.id}",
-        json={"summary": "updated by editor"},
-        headers=editor_auth_header,
+        json={"summary": "updated by owner"},
+        headers=admin_auth_header,
     )
     assert patch_resp.status_code == 200
 

--- a/backend/tests/test_collections.py
+++ b/backend/tests/test_collections.py
@@ -199,14 +199,44 @@ class TestUpdateDeleteCollection:
         )
         assert resp.status_code == 404
 
-    async def test_delete_collection_as_editor_allowed(
+    async def test_delete_collection_as_non_owner_editor_forbidden(
         self, client: AsyncClient, admin_auth_header: dict, editor_auth_header: dict
     ):
-        """DELETE /catalog/collections/{id} as editor succeeds (manage_collections capability)."""
+        """A non-owner editor cannot delete a collection they did not create (403).
+
+        Only the collection's creator or a global admin may delete it; the
+        manage_collections capability alone is not ownership.
+        """
         resp = await client.post(
             "/catalog/collections/",
             json={"name": f"Editor Delete {uuid.uuid4().hex[:6]}"},
             headers=admin_auth_header,
+        )
+        assert resp.status_code == 201
+        coll_id = resp.json()["id"]
+
+        # Non-owner editor is forbidden.
+        resp = await client.delete(
+            f"/catalog/collections/{coll_id}",
+            headers=editor_auth_header,
+        )
+        assert resp.status_code == 403
+
+        # The admin owner can still delete it.
+        resp = await client.delete(
+            f"/catalog/collections/{coll_id}",
+            headers=admin_auth_header,
+        )
+        assert resp.status_code == 204
+
+    async def test_delete_collection_as_owner_editor_allowed(
+        self, client: AsyncClient, editor_auth_header: dict
+    ):
+        """An editor may delete a collection they created (owner)."""
+        resp = await client.post(
+            "/catalog/collections/",
+            json={"name": f"My Own {uuid.uuid4().hex[:6]}"},
+            headers=editor_auth_header,
         )
         assert resp.status_code == 201
         coll_id = resp.json()["id"]
@@ -216,6 +246,25 @@ class TestUpdateDeleteCollection:
             headers=editor_auth_header,
         )
         assert resp.status_code == 204
+
+    async def test_update_collection_as_non_owner_editor_forbidden(
+        self, client: AsyncClient, admin_auth_header: dict, editor_auth_header: dict
+    ):
+        """A non-owner editor cannot rename a collection they did not create (403)."""
+        resp = await client.post(
+            "/catalog/collections/",
+            json={"name": f"Admin Owned {uuid.uuid4().hex[:6]}"},
+            headers=admin_auth_header,
+        )
+        assert resp.status_code == 201
+        coll_id = resp.json()["id"]
+
+        resp = await client.patch(
+            f"/catalog/collections/{coll_id}",
+            json={"name": "Hijacked"},
+            headers=editor_auth_header,
+        )
+        assert resp.status_code == 403
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_dataset_metadata_idor.py
+++ b/backend/tests/test_dataset_metadata_idor.py
@@ -315,3 +315,151 @@ async def test_set_target_status_other_user_private_returns_404(
         headers=editor_b_headers,
     )
     assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Owner-or-admin: PUBLIC+PUBLISHED datasets (the reported "unpublish a dataset
+# you did not publish" bug — visibility check alone let any editor through).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_patch_dataset_other_user_public_returns_403(
+    client: AsyncClient,
+    admin_auth_header: dict,
+    test_db_session,
+):
+    """Editor B cannot edit metadata of editor A's PUBLIC dataset (owner-or-admin)."""
+    session = test_db_session
+
+    _editor_a_headers, editor_a_id_str = await _create_test_user(
+        client, admin_auth_header, "editor"
+    )
+    editor_b_headers, _ = await _create_test_user(client, admin_auth_header, "editor")
+
+    public_ds = await create_dataset(
+        session,
+        created_by=uuid.UUID(editor_a_id_str),
+        name="A public dataset metadata",
+    )
+
+    resp = await client.patch(
+        f"/datasets/{public_ds.id}",
+        json={"title": "hijacked title"},
+        headers=editor_b_headers,
+    )
+    assert resp.status_code == 403
+
+
+@pytest.mark.anyio
+async def test_patch_dataset_owner_public_returns_200(
+    client: AsyncClient,
+    admin_auth_header: dict,
+    test_db_session,
+):
+    """Owner can edit metadata of their own PUBLIC dataset (no over-restriction)."""
+    session = test_db_session
+
+    editor_a_headers, editor_a_id_str = await _create_test_user(
+        client, admin_auth_header, "editor"
+    )
+
+    public_ds = await create_dataset(
+        session,
+        created_by=uuid.UUID(editor_a_id_str),
+        name="Owner public dataset metadata",
+    )
+
+    resp = await client.patch(
+        f"/datasets/{public_ds.id}",
+        json={"title": "Updated by owner"},
+        headers=editor_a_headers,
+    )
+    assert resp.status_code == 200
+
+
+@pytest.mark.anyio
+async def test_unpublish_other_user_public_returns_403(
+    client: AsyncClient,
+    admin_auth_header: dict,
+    test_db_session,
+):
+    """THE REPORTED BUG: editor B cannot unpublish editor A's published public dataset.
+
+    create_dataset defaults to public + published; published->internal is a
+    valid transition, so before the owner-or-admin gate any editor could
+    unpublish a dataset they did not publish.
+    """
+    session = test_db_session
+
+    _editor_a_headers, editor_a_id_str = await _create_test_user(
+        client, admin_auth_header, "editor"
+    )
+    editor_b_headers, _ = await _create_test_user(client, admin_auth_header, "editor")
+
+    published = await create_dataset(
+        session,
+        created_by=uuid.UUID(editor_a_id_str),
+        name="A published public dataset",
+    )
+
+    resp = await client.patch(
+        f"/datasets/{published.id}/status/",
+        json={"status": "internal"},
+        headers=editor_b_headers,
+    )
+    assert resp.status_code == 403
+
+
+@pytest.mark.anyio
+async def test_unpublish_owner_public_returns_200(
+    client: AsyncClient,
+    admin_auth_header: dict,
+    test_db_session,
+):
+    """Owner can unpublish their own published dataset (no over-restriction)."""
+    session = test_db_session
+
+    editor_a_headers, editor_a_id_str = await _create_test_user(
+        client, admin_auth_header, "editor"
+    )
+
+    published = await create_dataset(
+        session,
+        created_by=uuid.UUID(editor_a_id_str),
+        name="Owner published dataset",
+    )
+
+    resp = await client.patch(
+        f"/datasets/{published.id}/status/",
+        json={"status": "internal"},
+        headers=editor_a_headers,
+    )
+    assert resp.status_code == 200
+
+
+@pytest.mark.anyio
+async def test_unpublish_admin_returns_200(
+    client: AsyncClient,
+    admin_auth_header: dict,
+    test_db_session,
+):
+    """Admin can unpublish any user's published dataset (admin override preserved)."""
+    session = test_db_session
+
+    _editor_a_headers, editor_a_id_str = await _create_test_user(
+        client, admin_auth_header, "editor"
+    )
+
+    published = await create_dataset(
+        session,
+        created_by=uuid.UUID(editor_a_id_str),
+        name="Admin unpublishes other dataset",
+    )
+
+    resp = await client.patch(
+        f"/datasets/{published.id}/status/",
+        json={"status": "internal"},
+        headers=admin_auth_header,
+    )
+    assert resp.status_code == 200

--- a/backend/tests/test_defer_orphan_guard.py
+++ b/backend/tests/test_defer_orphan_guard.py
@@ -215,7 +215,7 @@ class TestReuploadOrphanGuard:
                     new=AsyncMock(return_value=mock_dataset),
                 ),
                 patch(
-                    "app.modules.catalog.datasets.api.router_reupload.check_dataset_access",
+                    "app.modules.catalog.datasets.api.router_reupload.check_dataset_write_access",
                     new=AsyncMock(),
                 ),
                 patch(
@@ -272,7 +272,7 @@ class TestReuploadOrphanGuard:
                     new=AsyncMock(return_value=mock_dataset),
                 ),
                 patch(
-                    "app.modules.catalog.datasets.api.router_reupload.check_dataset_access",
+                    "app.modules.catalog.datasets.api.router_reupload.check_dataset_write_access",
                     new=AsyncMock(),
                 ),
                 patch(
@@ -323,7 +323,7 @@ class TestReuploadOrphanGuard:
                     new=AsyncMock(return_value=mock_dataset),
                 ),
                 patch(
-                    "app.modules.catalog.datasets.api.router_reupload.check_dataset_access",
+                    "app.modules.catalog.datasets.api.router_reupload.check_dataset_write_access",
                     new=AsyncMock(),
                 ),
                 patch(
@@ -664,7 +664,7 @@ class TestDatasetsVrtOrphanGuard:
                     new=AsyncMock(return_value=mock_dataset),
                 ),
                 patch(
-                    "app.modules.catalog.datasets.api.router_vrt.check_dataset_access",
+                    "app.modules.catalog.datasets.api.router_vrt.check_dataset_write_access",
                     new=AsyncMock(),
                 ),
                 patch(

--- a/backend/tests/test_defer_orphan_guard.py
+++ b/backend/tests/test_defer_orphan_guard.py
@@ -362,14 +362,13 @@ class TestVrtSourceOrphanGuard:
 
     @pytest.fixture(autouse=True)
     def _stub_vrt_source_authz(self):
-        """SEC-C (Phase 1172): add_vrt_source now authorizes the new source and
-        the parent VRT (check_dataset_access + get_user_roles + get_dataset),
-        each of which issues its own ``db.execute`` calls that would shift the
-        call-count-ordered mock ``db`` sequence in the add test. Stub them to
-        make ZERO db.execute calls (and always allow) so the sequence stays
-        valid; the authorization behavior is covered by
-        ``tests/test_vrt_source_authz_1172.py``. Harmless for the
-        remove_vrt_source test (which never invokes these helpers).
+        """SEC-C (Phase 1172): add_vrt_source authorizes the new source and the
+        parent VRT, and both add/remove_vrt_source now require owner-or-admin on
+        the VRT via ``check_dataset_write_access`` — each helper issues its own
+        ``db.execute`` calls that would shift the call-count-ordered mock ``db``
+        sequence. Stub them to make ZERO db.execute calls (and always allow) so
+        the sequence stays valid; the authorization behavior is covered by
+        ``tests/test_vrt_source_authz_1172.py``.
         """
         with (
             patch(
@@ -378,6 +377,10 @@ class TestVrtSourceOrphanGuard:
             ),
             patch(
                 "app.modules.catalog.authorization.check_dataset_access",
+                new=AsyncMock(return_value=set()),
+            ),
+            patch(
+                "app.modules.catalog.authorization.check_dataset_write_access",
                 new=AsyncMock(return_value=set()),
             ),
             patch(

--- a/backend/tests/test_features_crud.py
+++ b/backend/tests/test_features_crud.py
@@ -315,6 +315,27 @@ class TestInsertFeature:
         )
         assert resp.status_code == 403
 
+    async def test_insert_feature_non_owner_editor_forbidden(
+        self,
+        client: AsyncClient,
+        editor_auth_header: dict,
+        test_layer: Dataset,
+    ):
+        """A non-owner editor cannot insert a feature into a peer's dataset (403).
+
+        test_layer is owned by admin; editing feature rows requires owner-or-admin
+        (the edit_metadata capability alone is not ownership).
+        """
+        resp = await client.post(
+            f"/datasets/{test_layer.id}/features/",
+            json={
+                "geometry": POINT_GEOJSON,
+                "properties": {"name": "Not yours"},
+            },
+            headers=editor_auth_header,
+        )
+        assert resp.status_code == 403
+
 
 # ---------------------------------------------------------------------------
 # REPLACE (PUT) tests

--- a/backend/tests/test_vrt_source_management_174.py
+++ b/backend/tests/test_vrt_source_management_174.py
@@ -59,16 +59,14 @@ def _make_mock_source_asset(band_count: int = 1, epsg: int = 4326) -> MagicMock:
 
 @pytest.fixture(autouse=True)
 def _stub_vrt_source_authz():
-    """SEC-C (Phase 1172): ``add_vrt_source`` now authorizes the new source (and
-    the parent VRT) against the caller (check_dataset_access + get_user_roles +
-    get_dataset). Those helpers issue their own ``db.execute`` calls, which
-    would shift the call-count-ordered mock ``db`` sequences these pure unit
-    tests rely on. Stub them to make ZERO ``db.execute`` calls (and always
-    allow) so the existing sequences stay valid. The authorization behavior
-    itself is covered by the DB-backed ``tests/test_vrt_source_authz_1172.py``.
-    The stubs no-op when the function never reaches the authz block (e.g. the
-    404/409/422 guards before it) and are unused by the regenerate-task tests
-    (tasks_vrt uses only get_dataset_orm_class), so this is safe module-wide.
+    """``add_vrt_source`` authorizes the new source and the parent VRT, and both
+    add/remove_vrt_source now require owner-or-admin on the VRT via
+    ``check_dataset_write_access``. Those helpers issue their own ``db.execute``
+    calls, which would shift the call-count-ordered mock ``db`` sequences these
+    pure unit tests rely on. Stub them to make ZERO ``db.execute`` calls (and
+    always allow) so the existing sequences stay valid and the tests reach the
+    real 404/409/422 guards. The authorization behavior itself is covered by the
+    DB-backed ``tests/test_vrt_source_authz_1172.py``.
     """
     with (
         patch(
@@ -77,6 +75,10 @@ def _stub_vrt_source_authz():
         ),
         patch(
             "app.modules.catalog.authorization.check_dataset_access",
+            new=AsyncMock(return_value=set()),
+        ),
+        patch(
+            "app.modules.catalog.authorization.check_dataset_write_access",
             new=AsyncMock(return_value=set()),
         ),
         patch(

--- a/backend/tests/test_workflow_extension.py
+++ b/backend/tests/test_workflow_extension.py
@@ -28,32 +28,31 @@ def _clean_registry():
 
 
 async def _noop_check_dataset_access(db, dataset, dataset_id, user, **kwargs):
-    """No-op stub for check_dataset_access in workflow unit tests.
+    """No-op stub for the dataset write-access gate in workflow unit tests.
 
-    These tests exercise workflow extension dispatch, not RBAC.  Phase 1061
-    CR-01 added check_dataset_access to both status handlers; the _FakeDB
-    here does not wire up the role/grant queries those checks need.  Stub
-    the access gate so the workflow logic under test remains the focus.
+    These tests exercise workflow extension dispatch, not RBAC.  The status
+    handlers now gate on check_dataset_write_access (owner-or-admin); the
+    _FakeDB here does not wire up the role/grant queries that check needs.
+    Stub the gate so the workflow logic under test remains the focus.
     """
     return set()
 
 
 @pytest.fixture(autouse=True)
 def _bypass_dataset_access_check():
-    """Patch check_dataset_access to a no-op for workflow unit tests.
+    """Patch the dataset write-access gate to a no-op for workflow unit tests.
 
-    Phase 1061 CR-01 added check_dataset_access to both status handlers in
-    router_data.py, and it already existed in router.py (SEC-S02 Plan 02).
-    These tests exercise workflow extension dispatch, not RBAC, so we stub
-    the access gate in both modules.
+    Both status handlers in router_data.py and the metadata PATCH in router.py
+    gate on check_dataset_write_access (owner-or-admin). These tests exercise
+    workflow extension dispatch, not RBAC, so we stub the gate in both modules.
     """
     with (
         patch(
-            "app.modules.catalog.datasets.api.router_data.check_dataset_access",
+            "app.modules.catalog.datasets.api.router_data.check_dataset_write_access",
             side_effect=_noop_check_dataset_access,
         ),
         patch(
-            "app.modules.catalog.datasets.api.router.check_dataset_access",
+            "app.modules.catalog.datasets.api.router.check_dataset_write_access",
             side_effect=_noop_check_dataset_access,
         ),
     ):

--- a/frontend/src/components/dataset/hooks/use-dataset-edit-capabilities.ts
+++ b/frontend/src/components/dataset/hooks/use-dataset-edit-capabilities.ts
@@ -100,8 +100,15 @@ export function buildDatasetEditCapabilities({
 
 export function useDatasetEditCapabilities(
   helperOverrides?: Partial<Record<DatasetEditField, string>>,
+  /**
+   * When provided, overrides the role-only check so field editability also
+   * respects ownership (owner-or-admin). Pass `isEditor && canMutate(dataset)`.
+   * Falls back to the store's role check for callers that don't have a resource.
+   */
+  canEdit?: boolean,
 ) {
-  const isEditor = useAuthStore((state) => state.isEditor());
+  const isEditorRole = useAuthStore((state) => state.isEditor());
+  const isEditor = canEdit ?? isEditorRole;
 
   return useMemo(
     () => buildDatasetEditCapabilities({

--- a/frontend/src/hooks/use-can-mutate.ts
+++ b/frontend/src/hooks/use-can-mutate.ts
@@ -1,0 +1,14 @@
+import { useAuthStore } from '@/stores/auth-store';
+import { canMutateResource, type OwnedResource } from '@/lib/ownership';
+
+/**
+ * True if the current user may mutate the given resource — its creator, or an
+ * admin. Gate edit/delete/publish/share controls on this rather than role
+ * alone, so the UI matches the backend owner-or-admin guards. See
+ * `lib/ownership.ts`.
+ */
+export function useCanMutate(resource: OwnedResource | null | undefined): boolean {
+  const currentUserId = useAuthStore((s) => s.user?.id ?? null);
+  const isAdmin = useAuthStore((s) => s.isAdmin());
+  return canMutateResource(resource, currentUserId, isAdmin);
+}

--- a/frontend/src/lib/__tests__/ownership.test.ts
+++ b/frontend/src/lib/__tests__/ownership.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest';
+import { canMutateResource } from '@/lib/ownership';
+
+describe('canMutateResource', () => {
+  const me = 'user-1';
+  const other = 'user-2';
+
+  it('allows the owner', () => {
+    expect(canMutateResource({ created_by: me }, me, false)).toBe(true);
+  });
+
+  it('denies a non-owner non-admin', () => {
+    expect(canMutateResource({ created_by: other }, me, false)).toBe(false);
+  });
+
+  it('allows an admin regardless of owner', () => {
+    expect(canMutateResource({ created_by: other }, me, true)).toBe(true);
+  });
+
+  it('treats a null/unowned resource as admin-only', () => {
+    expect(canMutateResource({ created_by: null }, me, false)).toBe(false);
+    expect(canMutateResource({ created_by: null }, me, true)).toBe(true);
+  });
+
+  it('denies when there is no current user (anonymous), unless admin flag set', () => {
+    expect(canMutateResource({ created_by: me }, null, false)).toBe(false);
+    expect(canMutateResource(undefined, null, false)).toBe(false);
+  });
+});

--- a/frontend/src/lib/ownership.ts
+++ b/frontend/src/lib/ownership.ts
@@ -1,0 +1,30 @@
+/**
+ * Client-side owner-or-admin rule for catalog resources.
+ *
+ * Mirrors the backend guards (`check_dataset_write_access`,
+ * `check_collection_ownership`, `check_map_ownership`): only the resource's
+ * creator or a global admin may mutate it. This is a UI affordance, not a
+ * security boundary — the backend is authoritative and will 403 regardless.
+ * Keeping the front end in sync just avoids showing controls that would fail.
+ */
+
+/** A resource that records its creator's user id. */
+export interface OwnedResource {
+  created_by?: string | null;
+}
+
+/**
+ * True if the current user may mutate the resource (its creator, or an admin).
+ *
+ * Resources with no recorded owner (`created_by` null — seeded/imported data,
+ * or rows whose owner was deleted) are admin-only, matching the backend.
+ */
+export function canMutateResource(
+  resource: OwnedResource | null | undefined,
+  currentUserId: string | null | undefined,
+  isAdmin: boolean,
+): boolean {
+  if (isAdmin) return true;
+  if (!resource?.created_by || !currentUserId) return false;
+  return resource.created_by === currentUserId;
+}

--- a/frontend/src/pages/CollectionDetailPage.tsx
+++ b/frontend/src/pages/CollectionDetailPage.tsx
@@ -15,7 +15,7 @@ import { CollectionMembershipManager } from '@/components/collections/Collection
 import { CollectionEditDialog } from '@/components/collections/CollectionEditDialog';
 import { CollectionDeleteDialog } from '@/components/collections/CollectionDeleteDialog';
 import { useCollection, useRemoveDatasetFromCollection } from '@/components/collections/hooks/use-collections';
-import { useAuthStore } from '@/stores/auth-store';
+import { useCanMutate } from '@/hooks/use-can-mutate';
 import { formatDate, formatNumber } from '@/lib/format';
 import {
   DropdownMenu,
@@ -30,8 +30,9 @@ export function CollectionDetailPage() {
   const { id } = useParams<{ id: string }>();
   const { data: collection, isLoading, error } = useCollection(id ?? '');
   const removeDataset = useRemoveDatasetFromCollection();
-  const isEditor = useAuthStore((s) => s.isEditor());
-  const isAdmin = useAuthStore((s) => s.isAdmin());
+  // Owner-or-admin: only the collection's creator or an admin may mutate it
+  // (mirrors the backend check_collection_ownership).
+  const canMutate = useCanMutate(collection);
 
   const [editOpen, setEditOpen] = useState(false);
   const [deleteOpen, setDeleteOpen] = useState(false);
@@ -104,32 +105,28 @@ export function CollectionDetailPage() {
         description={collection.description ?? undefined}
         breadcrumbs={[{ label: t('detail.breadcrumb'), to: '/collections' }]}
         actions={
-          (isEditor || isAdmin) ? (
+          canMutate ? (
             <>
-              {isEditor && (
-                <Button variant="outline" size="sm" onClick={() => setEditOpen(true)}>
-                  <Pencil className="h-4 w-4 me-1" />
-                  {t('common:edit')}
-                </Button>
-              )}
-              {isAdmin && (
-                <DropdownMenu>
-                  <DropdownMenuTrigger asChild>
-                    <Button variant="outline" size="sm" aria-label={t('common:moreActions', { defaultValue: 'More actions' })}>
-                      <MoreHorizontal className="h-4 w-4" />
-                    </Button>
-                  </DropdownMenuTrigger>
-                  <DropdownMenuContent align="end">
-                    <DropdownMenuItem
-                      className="text-destructive focus:text-destructive"
-                      onSelect={() => setDeleteOpen(true)}
-                    >
-                      <Trash2 className="h-4 w-4" />
-                      {t('common:delete')}
-                    </DropdownMenuItem>
-                  </DropdownMenuContent>
-                </DropdownMenu>
-              )}
+              <Button variant="outline" size="sm" onClick={() => setEditOpen(true)}>
+                <Pencil className="h-4 w-4 me-1" />
+                {t('common:edit')}
+              </Button>
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <Button variant="outline" size="sm" aria-label={t('common:moreActions', { defaultValue: 'More actions' })}>
+                    <MoreHorizontal className="h-4 w-4" />
+                  </Button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="end">
+                  <DropdownMenuItem
+                    className="text-destructive focus:text-destructive"
+                    onSelect={() => setDeleteOpen(true)}
+                  >
+                    <Trash2 className="h-4 w-4" />
+                    {t('common:delete')}
+                  </DropdownMenuItem>
+                </DropdownMenuContent>
+              </DropdownMenu>
             </>
           ) : undefined
         }
@@ -190,12 +187,12 @@ export function CollectionDetailPage() {
         <h2 className="text-lg font-semibold">{t('detail.datasets')}</h2>
         <CollectionDatasetList
           collectionId={id!}
-          onRemove={isEditor ? handleRemoveDataset : undefined}
+          onRemove={canMutate ? handleRemoveDataset : undefined}
         />
       </div>
 
-      {/* Add datasets section (editors only) */}
-      {isEditor && (
+      {/* Add datasets section (owner or admin only) */}
+      {canMutate && (
         <CollectionMembershipManager
           collectionId={id!}
         />

--- a/frontend/src/pages/CollectionDetailPage.tsx
+++ b/frontend/src/pages/CollectionDetailPage.tsx
@@ -16,6 +16,7 @@ import { CollectionEditDialog } from '@/components/collections/CollectionEditDia
 import { CollectionDeleteDialog } from '@/components/collections/CollectionDeleteDialog';
 import { useCollection, useRemoveDatasetFromCollection } from '@/components/collections/hooks/use-collections';
 import { useCanMutate } from '@/hooks/use-can-mutate';
+import { useAuthStore } from '@/stores/auth-store';
 import { formatDate, formatNumber } from '@/lib/format';
 import {
   DropdownMenu,
@@ -30,9 +31,12 @@ export function CollectionDetailPage() {
   const { id } = useParams<{ id: string }>();
   const { data: collection, isLoading, error } = useCollection(id ?? '');
   const removeDataset = useRemoveDatasetFromCollection();
-  // Owner-or-admin: only the collection's creator or an admin may mutate it
-  // (mirrors the backend check_collection_ownership).
+  // Mutating a collection requires the manage_collections capability (proxied
+  // by the editor role) AND ownership (or admin) — mirrors the backend
+  // require_permission("manage_collections") + check_collection_ownership.
+  const isEditor = useAuthStore((s) => s.isEditor());
   const canMutate = useCanMutate(collection);
+  const canManage = isEditor && canMutate;
 
   const [editOpen, setEditOpen] = useState(false);
   const [deleteOpen, setDeleteOpen] = useState(false);
@@ -105,7 +109,7 @@ export function CollectionDetailPage() {
         description={collection.description ?? undefined}
         breadcrumbs={[{ label: t('detail.breadcrumb'), to: '/collections' }]}
         actions={
-          canMutate ? (
+          canManage ? (
             <>
               <Button variant="outline" size="sm" onClick={() => setEditOpen(true)}>
                 <Pencil className="h-4 w-4 me-1" />
@@ -187,12 +191,12 @@ export function CollectionDetailPage() {
         <h2 className="text-lg font-semibold">{t('detail.datasets')}</h2>
         <CollectionDatasetList
           collectionId={id!}
-          onRemove={canMutate ? handleRemoveDataset : undefined}
+          onRemove={canManage ? handleRemoveDataset : undefined}
         />
       </div>
 
       {/* Add datasets section (owner or admin only) */}
-      {canMutate && (
+      {canManage && (
         <CollectionMembershipManager
           collectionId={id!}
         />

--- a/frontend/src/pages/DatasetPage.tsx
+++ b/frontend/src/pages/DatasetPage.tsx
@@ -14,6 +14,7 @@ import { useDraftEditing } from '@/components/dataset/hooks/use-draft-editing';
 import { useFeatureGid } from '@/components/dataset/hooks/use-feature-gid';
 import { useHeroState } from '@/components/dataset/hooks/use-hero-state';
 import { useFeatureFlags } from '@/hooks/use-settings';
+import { useCanMutate } from '@/hooks/use-can-mutate';
 import { useAuthStore } from '@/stores/auth-store';
 import { useDrawingStore } from '@/stores/drawing-store';
 import { DatasetDeleteDialog } from '@/components/dataset/DatasetDeleteDialog';
@@ -180,9 +181,12 @@ export function DatasetPage() {
 
   const [isDataTabExpanded, setIsDataTabExpanded] = useState(false);
   const toggleDataTabExpand = useCallback(() => setIsDataTabExpanded((prev) => !prev), []);
-  const isAdmin = useAuthStore((s) => s.isAdmin());
   const isEditor = useAuthStore((s) => s.isEditor());
-  const capabilities = useDatasetEditCapabilities();
+  // Owner-or-admin: mutating this dataset requires the editor capability AND
+  // ownership (or admin), mirroring the backend check_dataset_write_access.
+  const canMutate = useCanMutate(dataset);
+  const canEdit = isEditor && canMutate;
+  const capabilities = useDatasetEditCapabilities(undefined, canEdit);
   const isDrawing = useDrawingStore((s) => s.isDrawing);
   const isGeometryEditDirty = useDrawingStore((s) => s.isEditDirty);
   useDocumentTitle(dataset?.title ?? t('common:pageTitle.dataset'));
@@ -331,7 +335,7 @@ export function DatasetPage() {
 
   // Gate geometry drawing and attribute cell editing behind the feature flag.
   // Metadata editing (overview/metadata tabs) and management actions remain ungated.
-  const canEditData = isEditor && dataEditingEnabled;
+  const canEditData = canEdit && dataEditingEnabled;
 
   const handlePublishToggle = async () => {
     if (!id) return;
@@ -384,7 +388,7 @@ export function DatasetPage() {
       icon: isPublished ? GlobeLock : Globe,
       onSelect: handlePublishToggle,
       priority: 5,
-      visible: isEditor,
+      visible: canEdit,
       disabled: setTargetStatus.isPending,
     },
     {
@@ -394,7 +398,7 @@ export function DatasetPage() {
       icon: Upload,
       onSelect: () => setActiveDialog('reupload'),
       priority: 10,
-      visible: isEditor && !isVrt,
+      visible: canEdit && !isVrt,
       variant: 'outline',
     },
     {
@@ -404,7 +408,7 @@ export function DatasetPage() {
       icon: Layers,
       onSelect: () => setActiveDialog('vrt'),
       priority: 11,
-      visible: isRaster && isEditor,
+      visible: isRaster && canEdit,
     },
     {
       id: 'delete',
@@ -413,7 +417,7 @@ export function DatasetPage() {
       icon: Trash2,
       onSelect: () => setActiveDialog('delete'),
       priority: 20,
-      visible: isAdmin,
+      visible: canMutate,
       variant: 'destructive',
     },
   ];
@@ -423,7 +427,7 @@ export function DatasetPage() {
       <DatasetDetailHeader
         title={dataset.title}
         onTitleSave={handleSaveName}
-        canEditTitle={isEditor}
+        canEditTitle={canEdit}
         breadcrumbs={[{ label: t('breadcrumbs.datasets'), to: '/' }]}
         actions={headerActions}
         statsLine={statsLine}
@@ -526,7 +530,7 @@ export function DatasetPage() {
       <Suspense fallback={<DatasetDetailSkeleton isTable={isTable} />}>
         <DetailPanel
           dataset={dataset}
-          canEdit={isEditor}
+          canEdit={canEdit}
           canEditData={canEditData}
           capabilities={capabilities}
           activeTab={activeTab}
@@ -553,7 +557,7 @@ export function DatasetPage() {
       />
 
       {/* Dialogs */}
-      {isAdmin && (
+      {canMutate && (
         <DatasetDeleteDialog
           dataset={dataset}
           open={activeDialog === 'delete'}
@@ -561,7 +565,7 @@ export function DatasetPage() {
         />
       )}
 
-      {isEditor && !isVrt && (
+      {canEdit && !isVrt && (
         <Suspense fallback={null}>
           <ReuploadDialog
             dataset={dataset}
@@ -571,7 +575,7 @@ export function DatasetPage() {
         </Suspense>
       )}
 
-      {isRaster && isEditor && (
+      {isRaster && canEdit && (
         <Suspense fallback={null}>
           <VrtCreateDialog
             open={activeDialog === 'vrt'}

--- a/frontend/src/pages/DatasetPage.tsx
+++ b/frontend/src/pages/DatasetPage.tsx
@@ -417,7 +417,7 @@ export function DatasetPage() {
       icon: Trash2,
       onSelect: () => setActiveDialog('delete'),
       priority: 20,
-      visible: canMutate,
+      visible: canEdit,
       variant: 'destructive',
     },
   ];
@@ -557,7 +557,7 @@ export function DatasetPage() {
       />
 
       {/* Dialogs */}
-      {canMutate && (
+      {canEdit && (
         <DatasetDeleteDialog
           dataset={dataset}
           open={activeDialog === 'delete'}

--- a/frontend/src/pages/DatasetPage.tsx
+++ b/frontend/src/pages/DatasetPage.tsx
@@ -408,7 +408,10 @@ export function DatasetPage() {
       icon: Layers,
       onSelect: () => setActiveDialog('vrt'),
       priority: 11,
-      visible: isRaster && canEdit,
+      // Creating a VRT makes a NEW dataset from this raster; it does not mutate
+      // the source, so it needs read + upload capability (isEditor), not source
+      // ownership. Backend /vrt/create authorizes the source via check_dataset_access.
+      visible: isRaster && isEditor,
     },
     {
       id: 'delete',
@@ -575,7 +578,7 @@ export function DatasetPage() {
         </Suspense>
       )}
 
-      {isRaster && canEdit && (
+      {isRaster && isEditor && (
         <Suspense fallback={null}>
           <VrtCreateDialog
             open={activeDialog === 'vrt'}

--- a/sdks/python/geolens/api/datasets/add_datasets_endpoint_catalog_collections_collection_id_datasets_post.py
+++ b/sdks/python/geolens/api/datasets/add_datasets_endpoint_catalog_collections_collection_id_datasets_post.py
@@ -104,7 +104,7 @@ def sync_detailed(
 ) -> Response[AddDatasetsResponse | ProblemDetail]:
     """Add Datasets Endpoint
 
-     Add datasets to a collection.
+     Add datasets to a collection. Collection owner or admin only.
 
     Args:
         collection_id (UUID):
@@ -138,7 +138,7 @@ def sync(
 ) -> AddDatasetsResponse | ProblemDetail | None:
     """Add Datasets Endpoint
 
-     Add datasets to a collection.
+     Add datasets to a collection. Collection owner or admin only.
 
     Args:
         collection_id (UUID):
@@ -167,7 +167,7 @@ async def asyncio_detailed(
 ) -> Response[AddDatasetsResponse | ProblemDetail]:
     """Add Datasets Endpoint
 
-     Add datasets to a collection.
+     Add datasets to a collection. Collection owner or admin only.
 
     Args:
         collection_id (UUID):
@@ -199,7 +199,7 @@ async def asyncio(
 ) -> AddDatasetsResponse | ProblemDetail | None:
     """Add Datasets Endpoint
 
-     Add datasets to a collection.
+     Add datasets to a collection. Collection owner or admin only.
 
     Args:
         collection_id (UUID):

--- a/sdks/python/geolens/api/datasets/delete_collection_endpoint_catalog_collections_collection_id_delete.py
+++ b/sdks/python/geolens/api/datasets/delete_collection_endpoint_catalog_collections_collection_id_delete.py
@@ -92,7 +92,7 @@ def sync_detailed(
 ) -> Response[Any | ProblemDetail]:
     """Delete Collection Endpoint
 
-     Delete a collection. Admin only.
+     Delete a collection. Owner or admin only.
 
     Args:
         collection_id (UUID):
@@ -123,7 +123,7 @@ def sync(
 ) -> Any | ProblemDetail | None:
     """Delete Collection Endpoint
 
-     Delete a collection. Admin only.
+     Delete a collection. Owner or admin only.
 
     Args:
         collection_id (UUID):
@@ -149,7 +149,7 @@ async def asyncio_detailed(
 ) -> Response[Any | ProblemDetail]:
     """Delete Collection Endpoint
 
-     Delete a collection. Admin only.
+     Delete a collection. Owner or admin only.
 
     Args:
         collection_id (UUID):
@@ -178,7 +178,7 @@ async def asyncio(
 ) -> Any | ProblemDetail | None:
     """Delete Collection Endpoint
 
-     Delete a collection. Admin only.
+     Delete a collection. Owner or admin only.
 
     Args:
         collection_id (UUID):

--- a/sdks/python/geolens/api/datasets/remove_dataset_endpoint_catalog_collections_collection_id_datasets_dataset_id_delete.py
+++ b/sdks/python/geolens/api/datasets/remove_dataset_endpoint_catalog_collections_collection_id_datasets_dataset_id_delete.py
@@ -95,7 +95,7 @@ def sync_detailed(
 ) -> Response[Any | ProblemDetail]:
     """Remove Dataset Endpoint
 
-     Remove a dataset from a collection.
+     Remove a dataset from a collection. Collection owner or admin only.
 
     Args:
         collection_id (UUID):
@@ -129,7 +129,7 @@ def sync(
 ) -> Any | ProblemDetail | None:
     """Remove Dataset Endpoint
 
-     Remove a dataset from a collection.
+     Remove a dataset from a collection. Collection owner or admin only.
 
     Args:
         collection_id (UUID):
@@ -158,7 +158,7 @@ async def asyncio_detailed(
 ) -> Response[Any | ProblemDetail]:
     """Remove Dataset Endpoint
 
-     Remove a dataset from a collection.
+     Remove a dataset from a collection. Collection owner or admin only.
 
     Args:
         collection_id (UUID):
@@ -190,7 +190,7 @@ async def asyncio(
 ) -> Any | ProblemDetail | None:
     """Remove Dataset Endpoint
 
-     Remove a dataset from a collection.
+     Remove a dataset from a collection. Collection owner or admin only.
 
     Args:
         collection_id (UUID):

--- a/sdks/python/geolens/api/datasets/update_collection_endpoint_catalog_collections_collection_id_patch.py
+++ b/sdks/python/geolens/api/datasets/update_collection_endpoint_catalog_collections_collection_id_patch.py
@@ -104,7 +104,7 @@ def sync_detailed(
 ) -> Response[CollectionResponse | ProblemDetail]:
     """Update Collection Endpoint
 
-     Update a collection's name and/or description.
+     Update a collection's name and/or description. Owner or admin only.
 
     Args:
         collection_id (UUID):
@@ -138,7 +138,7 @@ def sync(
 ) -> CollectionResponse | ProblemDetail | None:
     """Update Collection Endpoint
 
-     Update a collection's name and/or description.
+     Update a collection's name and/or description. Owner or admin only.
 
     Args:
         collection_id (UUID):
@@ -167,7 +167,7 @@ async def asyncio_detailed(
 ) -> Response[CollectionResponse | ProblemDetail]:
     """Update Collection Endpoint
 
-     Update a collection's name and/or description.
+     Update a collection's name and/or description. Owner or admin only.
 
     Args:
         collection_id (UUID):
@@ -199,7 +199,7 @@ async def asyncio(
 ) -> CollectionResponse | ProblemDetail | None:
     """Update Collection Endpoint
 
-     Update a collection's name and/or description.
+     Update a collection's name and/or description. Owner or admin only.
 
     Args:
         collection_id (UUID):

--- a/sdks/typescript/src/client/sdk.gen.ts
+++ b/sdks/typescript/src/client/sdk.gen.ts
@@ -787,7 +787,7 @@ export const createCollectionEndpointCatalogCollectionsPost = <ThrowOnError exte
 /**
  * Delete Collection Endpoint
  *
- * Delete a collection. Admin only.
+ * Delete a collection. Owner or admin only.
  */
 export const deleteCollectionEndpointCatalogCollectionsCollectionIdDelete = <ThrowOnError extends boolean = false>(options: Options<DeleteCollectionEndpointCatalogCollectionsCollectionIdDeleteData, ThrowOnError>) => (options.client ?? client).delete<DeleteCollectionEndpointCatalogCollectionsCollectionIdDeleteResponses, DeleteCollectionEndpointCatalogCollectionsCollectionIdDeleteErrors, ThrowOnError>({
     security: [{ scheme: 'bearer', type: 'http' }],
@@ -809,7 +809,7 @@ export const getCollectionEndpointCatalogCollectionsCollectionIdGet = <ThrowOnEr
 /**
  * Update Collection Endpoint
  *
- * Update a collection's name and/or description.
+ * Update a collection's name and/or description. Owner or admin only.
  */
 export const updateCollectionEndpointCatalogCollectionsCollectionIdPatch = <ThrowOnError extends boolean = false>(options: Options<UpdateCollectionEndpointCatalogCollectionsCollectionIdPatchData, ThrowOnError>) => (options.client ?? client).patch<UpdateCollectionEndpointCatalogCollectionsCollectionIdPatchResponses, UpdateCollectionEndpointCatalogCollectionsCollectionIdPatchErrors, ThrowOnError>({
     security: [{ scheme: 'bearer', type: 'http' }],
@@ -835,7 +835,7 @@ export const getCollectionDatasetsEndpointCatalogCollectionsCollectionIdDatasets
 /**
  * Add Datasets Endpoint
  *
- * Add datasets to a collection.
+ * Add datasets to a collection. Collection owner or admin only.
  */
 export const addDatasetsEndpointCatalogCollectionsCollectionIdDatasetsPost = <ThrowOnError extends boolean = false>(options: Options<AddDatasetsEndpointCatalogCollectionsCollectionIdDatasetsPostData, ThrowOnError>) => (options.client ?? client).post<AddDatasetsEndpointCatalogCollectionsCollectionIdDatasetsPostResponses, AddDatasetsEndpointCatalogCollectionsCollectionIdDatasetsPostErrors, ThrowOnError>({
     security: [{ scheme: 'bearer', type: 'http' }],
@@ -850,7 +850,7 @@ export const addDatasetsEndpointCatalogCollectionsCollectionIdDatasetsPost = <Th
 /**
  * Remove Dataset Endpoint
  *
- * Remove a dataset from a collection.
+ * Remove a dataset from a collection. Collection owner or admin only.
  */
 export const removeDatasetEndpointCatalogCollectionsCollectionIdDatasetsDatasetIdDelete = <ThrowOnError extends boolean = false>(options: Options<RemoveDatasetEndpointCatalogCollectionsCollectionIdDatasetsDatasetIdDeleteData, ThrowOnError>) => (options.client ?? client).delete<RemoveDatasetEndpointCatalogCollectionsCollectionIdDatasetsDatasetIdDeleteResponses, RemoveDatasetEndpointCatalogCollectionsCollectionIdDatasetsDatasetIdDeleteErrors, ThrowOnError>({
     security: [{ scheme: 'bearer', type: 'http' }],


### PR DESCRIPTION
## Problem

A user could unpublish (and edit, re-upload, delete, etc.) datasets they did not create. A deep authorization audit confirmed this was systemic: authz is hand-rolled per endpoint, and `check_dataset_access` — a **visibility** check that returns true for any authenticated user on a public+published dataset — was used as a **write** gate. So any `editor` could mutate other users' **public** datasets and mutate/delete **any** collection (collections had no ownership check at all). Maps were already correct via `check_map_ownership`.

The rule: **if a user created a resource, only they — or a global admin — may change it.**

## Backend (commit 1)

Shared owner-or-admin guards mirroring the map gold standard, applied to every mutating endpoint:

- **`check_dataset_write_access`** (`catalog/authorization.py`) — visibility check (404) → ownership (403). NULL `record.created_by` (seeded/import data, owner-deleted rows) is **admin-only**.
- **`check_collection_ownership`** (`catalog/collections/service.py`) — creator or admin; NULL owner admin-only.

Applied to: dataset metadata PATCH, `/status` + `/target-status` (publish/unpublish), single + bulk delete, reupload (all 6 handlers), attribute edit/reset, relationship create/delete (source-owner), VRT regenerate, `validate?refresh=true`; and collection update/delete/add/remove. Read endpoints keep `check_dataset_access`. Fixed the false "Admin only" docstring on collection delete; the `visibility-filter-coverage` pre-commit hook now recognizes the write guard.

## Frontend (commit 2)

The UI gated edit/publish/delete/membership controls on role alone, so after the backend tightened, a non-owner editor would see buttons that 403 on click. Added the canonical client helper the audit found missing — `canMutateResource` / `useCanMutate` (creator-or-admin; NULL owner admin-only) — and gated the dataset and collection mutation controls on it.

> Note: the maps list-card delete stays role-gated (cosmetic — backend already 403s; `MapSummaryResponse` carries no owner id). Tracked as a small follow-up.

## Behavior changes
- Non-owner editors can no longer mutate peers' public datasets/collections (this was the bug).
- Resources with no recorded owner are now admin-only to mutate (safe default).

## Tests
Regressions for the reported "unpublish a dataset you didn't publish" bug, plus public-dataset edit and collection delete/update — non-owner `403`, owner and admin allowed. Frontend unit test for `canMutateResource`. Updated bypass mocks in `test_workflow_extension` and `test_defer_orphan_guard` (the latter per Codex review) to patch the new write gate. Regenerated `openapi.json` + SDKs for the collection docstring changes.

https://claude.ai/code/session_01ATqNfJXvg3zXfktncsNUdf