### PR TITLE
fix(a11y): name form controls, dedupe admin <main>, restore auth page h1

### DIFF
--- a/frontend/src/components/admin/AuditLogViewer.tsx
+++ b/frontend/src/components/admin/AuditLogViewer.tsx
@@ -148,6 +148,7 @@ export function AuditLogViewer() {
             </label>
             <Input
               type="date"
+              aria-label={t('audit.filters.from')}
               value={dateFrom}
               onChange={(e) => {
                 setDateFrom(e.target.value);
@@ -162,6 +163,7 @@ export function AuditLogViewer() {
             </label>
             <Input
               type="date"
+              aria-label={t('audit.filters.to')}
               value={dateTo}
               onChange={(e) => {
                 setDateTo(e.target.value);

--- a/frontend/src/components/admin/DataTableSearch.tsx
+++ b/frontend/src/components/admin/DataTableSearch.tsx
@@ -60,6 +60,7 @@ export function DataTableSearch({ value, onChange, placeholder, debounceMs }: Da
         <button
           type="button"
           onClick={handleClear}
+          aria-label={t('clearSearch')}
           className="absolute end-2 top-1/2 -translate-y-1/2 rounded-sm p-0.5 text-muted-foreground hover:text-foreground"
         >
           <X className="h-3.5 w-3.5" />

--- a/frontend/src/components/admin/FilterSelect.tsx
+++ b/frontend/src/components/admin/FilterSelect.tsx
@@ -15,6 +15,9 @@ interface FilterSelectProps {
   onChange: (value: string) => void;
   options: readonly { value: string; label: string }[];
   className?: string;
+  /** Accessible name for the trigger when `label` is intentionally empty
+   *  (e.g. a layout that hides the visible label). Must be already localized. */
+  ariaLabel?: string;
 }
 
 /**
@@ -22,7 +25,7 @@ interface FilterSelectProps {
  * Converts empty-string values to a sentinel internally since Radix
  * Select does not support empty string values.
  */
-export function FilterSelect({ label, value, onChange, options, className }: FilterSelectProps) {
+export function FilterSelect({ label, value, onChange, options, className, ariaLabel }: FilterSelectProps) {
   const labelId = useId();
   return (
     <div className={className}>
@@ -36,12 +39,12 @@ export function FilterSelect({ label, value, onChange, options, className }: Fil
         onValueChange={(v) => onChange(v === ALL_VALUE ? '' : v)}
       >
         {/* a11y: associate the visible label with the combobox trigger so it has
-            an accessible name (WCAG 4.1.2). Falls back to aria-label if a caller
-            ever omits a visible label. */}
+            an accessible name (WCAG 4.1.2). When a caller intentionally omits the
+            visible label, fall back to the localized `ariaLabel`. */}
         <SelectTrigger
           className="h-8 w-auto min-w-[140px]"
           aria-labelledby={label ? labelId : undefined}
-          aria-label={label ? undefined : 'Filter'}
+          aria-label={label ? undefined : ariaLabel}
         >
           <SelectValue />
         </SelectTrigger>

--- a/frontend/src/components/admin/FilterSelect.tsx
+++ b/frontend/src/components/admin/FilterSelect.tsx
@@ -1,3 +1,4 @@
+import { useId } from 'react';
 import {
   Select,
   SelectContent,
@@ -22,10 +23,11 @@ interface FilterSelectProps {
  * Select does not support empty string values.
  */
 export function FilterSelect({ label, value, onChange, options, className }: FilterSelectProps) {
+  const labelId = useId();
   return (
     <div className={className}>
       {label && (
-        <label className="mb-1 block text-xs text-muted-foreground">
+        <label id={labelId} className="mb-1 block text-xs text-muted-foreground">
           {label}
         </label>
       )}
@@ -33,7 +35,14 @@ export function FilterSelect({ label, value, onChange, options, className }: Fil
         value={value || ALL_VALUE}
         onValueChange={(v) => onChange(v === ALL_VALUE ? '' : v)}
       >
-        <SelectTrigger className="h-8 w-auto min-w-[140px]">
+        {/* a11y: associate the visible label with the combobox trigger so it has
+            an accessible name (WCAG 4.1.2). Falls back to aria-label if a caller
+            ever omits a visible label. */}
+        <SelectTrigger
+          className="h-8 w-auto min-w-[140px]"
+          aria-labelledby={label ? labelId : undefined}
+          aria-label={label ? undefined : 'Filter'}
+        >
           <SelectValue />
         </SelectTrigger>
         <SelectContent>

--- a/frontend/src/components/admin/UserList.tsx
+++ b/frontend/src/components/admin/UserList.tsx
@@ -156,6 +156,7 @@ export function UserList() {
               />
               <FilterSelect
                 label=""
+                ariaLabel={t('users.table.status')}
                 value={statusFilter}
                 onChange={(v) => { setStatusFilter(v); setPage(0); }}
                 options={STATUS_OPTIONS.map((opt) => ({ value: opt.value, label: t(opt.labelKey) }))}

--- a/frontend/src/components/import/FileDropzone.tsx
+++ b/frontend/src/components/import/FileDropzone.tsx
@@ -95,7 +95,7 @@ export function FileDropzone({ onFilesAccepted, disabled, allowedExtensions, max
         disabled && 'pointer-events-none opacity-50',
       )}
     >
-      <input {...getInputProps()} />
+      <input {...getInputProps({ 'aria-label': t('dropzone.ariaLabel') })} />
 
       {/* Glyph */}
       <div className="relative mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-2xl border border-border bg-surface-0 text-primary">

--- a/frontend/src/components/ui/sidebar.tsx
+++ b/frontend/src/components/ui/sidebar.tsx
@@ -314,9 +314,14 @@ function SidebarRail({
   )
 }
 
-function SidebarInset({ className, ...props }: React.ComponentProps<"main">) {
+function SidebarInset({ className, ...props }: React.ComponentProps<"div">) {
   return (
-    <main
+    // a11y: the app shell already provides the single top-level
+    // <main id="main-content"> (AppLayout). Rendering this inset as <main> too
+    // produced two nested <main> landmarks on every /admin/* route
+    // (axe landmark-no-duplicate-main / landmark-main-is-top-level /
+    // landmark-unique). Keep it a plain <div>; data-slot still drives styling.
+    <div
       data-slot="sidebar-inset"
       className={cn(
         "bg-background relative flex w-full flex-1 flex-col",

--- a/frontend/src/i18n/locales/de/common.json
+++ b/frontend/src/i18n/locales/de/common.json
@@ -1,5 +1,6 @@
 {
   "appName": "GeoLens",
+  "clearSearch": "Suche löschen",
   "loading": "Wird geladen...",
   "error": "Fehler",
   "save": "Speichern",

--- a/frontend/src/i18n/locales/de/import.json
+++ b/frontend/src/i18n/locales/de/import.json
@@ -92,6 +92,7 @@
     }
   },
   "dropzone": {
+    "ariaLabel": "Dateien hochladen",
     "instructions": "Dateien hierher ziehen oder klicken zum Durchsuchen",
     "dropHere": "Dateien hier ablegen",
     "unsupportedType": "Dieser Dateityp wird nicht unterstützt",

--- a/frontend/src/i18n/locales/en/common.json
+++ b/frontend/src/i18n/locales/en/common.json
@@ -1,5 +1,6 @@
 {
   "appName": "GeoLens",
+  "clearSearch": "Clear search",
   "loading": "Loading...",
   "error": "Error",
   "save": "Save",

--- a/frontend/src/i18n/locales/en/import.json
+++ b/frontend/src/i18n/locales/en/import.json
@@ -103,6 +103,7 @@
     "importMore": "Import more"
   },
   "dropzone": {
+    "ariaLabel": "Upload files",
     "instructions": "Drag and drop files here, or click to browse",
     "browse": "browse",
     "toUpload": "to upload",

--- a/frontend/src/i18n/locales/es/common.json
+++ b/frontend/src/i18n/locales/es/common.json
@@ -1,5 +1,6 @@
 {
   "appName": "GeoLens",
+  "clearSearch": "Borrar búsqueda",
   "loading": "Cargando...",
   "error": "Error",
   "save": "Guardar",

--- a/frontend/src/i18n/locales/es/import.json
+++ b/frontend/src/i18n/locales/es/import.json
@@ -92,6 +92,7 @@
     }
   },
   "dropzone": {
+    "ariaLabel": "Subir archivos",
     "instructions": "Arrastre y suelte archivos aquí, o haga clic para explorar",
     "dropHere": "Suelte los archivos aquí",
     "unsupportedType": "Este tipo de archivo no es compatible",

--- a/frontend/src/i18n/locales/fr/common.json
+++ b/frontend/src/i18n/locales/fr/common.json
@@ -1,5 +1,6 @@
 {
   "appName": "GeoLens",
+  "clearSearch": "Effacer la recherche",
   "loading": "Chargement...",
   "error": "Erreur",
   "save": "Enregistrer",

--- a/frontend/src/i18n/locales/fr/import.json
+++ b/frontend/src/i18n/locales/fr/import.json
@@ -92,6 +92,7 @@
     }
   },
   "dropzone": {
+    "ariaLabel": "Téléverser des fichiers",
     "instructions": "Glissez-déposez des fichiers ici, ou cliquez pour parcourir",
     "dropHere": "Déposez les fichiers ici",
     "unsupportedType": "Ce type de fichier n'est pas pris en charge",

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -339,6 +339,10 @@ export function LoginPage() {
         </Button>
 
         <div className="w-full max-w-[360px]">
+          {/* Mobile-only level-1 heading: the desktop brand panel's <h1> is
+              display:none below 880px, so screen-reader heading nav has no h1
+              on mobile without this. Hidden on desktop to keep a single h1. */}
+          <h1 className="sr-only min-[880px]:hidden">{t('signIn')}</h1>
           {/* Form head */}
           <div className="mb-6">
             <h2 className="text-[19px] font-semibold tracking-[-0.01em] text-foreground">

--- a/frontend/src/pages/RegisterPage.tsx
+++ b/frontend/src/pages/RegisterPage.tsx
@@ -60,6 +60,9 @@ export function RegisterPage() {
     return (
       <div className="flex min-h-screen flex-col items-center justify-center gap-6 bg-background px-4">
         <div className="text-center">
+          {/* sr-only level-1 heading: screen-reader heading nav needs an <h1>
+              in every render branch, not just the form branch below. */}
+          <h1 className="sr-only">{t('createAccount')}</h1>
           <GeoLensLogo size="lg" className="justify-center" />
           <p className="text-muted-foreground mt-1 text-sm">
             {t('geospatialDataCatalog')}
@@ -89,6 +92,9 @@ export function RegisterPage() {
     return (
       <div className="flex min-h-screen flex-col items-center justify-center gap-6 bg-background px-4">
         <div className="text-center">
+          {/* sr-only level-1 heading: screen-reader heading nav needs an <h1>
+              in every render branch, not just the form branch below. */}
+          <h1 className="sr-only">{t('createAccount')}</h1>
           <GeoLensLogo size="lg" className="justify-center" />
           <p className="text-muted-foreground mt-1 text-sm">
             {t('geospatialDataCatalog')}

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -96,7 +96,7 @@ export function SettingsPage() {
                   void changeAppLanguage(lng);
                 }}
               >
-                <SelectTrigger className="w-48">
+                <SelectTrigger className="w-48" aria-label={t('settings.language.title')}>
                   <SelectValue />
                 </SelectTrigger>
                 <SelectContent>

--- a/frontend/src/pages/VerifyEmailPage.tsx
+++ b/frontend/src/pages/VerifyEmailPage.tsx
@@ -75,6 +75,9 @@ export function VerifyEmailPage() {
   return (
     <div className="flex min-h-screen flex-col items-center justify-center gap-6 bg-background px-4">
       <div className="text-center">
+        {/* sr-only level-1 heading: the state cards below use CardTitle (a plain
+            <div>), so without this the page has no heading-one for SR nav. */}
+        <h1 className="sr-only">{t('verifyEmail.title')}</h1>
         <GeoLensLogo size="lg" className="justify-center" />
         <p className="text-muted-foreground mt-1 text-sm">
           {t('geospatialDataCatalog')}

--- a/frontend/src/pages/admin/AdminConfigOpsPage.tsx
+++ b/frontend/src/pages/admin/AdminConfigOpsPage.tsx
@@ -334,7 +334,7 @@ function ImportSection() {
         <div className="space-y-2">
           <Label>{t('configOps.import.modeLabel')}</Label>
           <Select value={mode} onValueChange={(v) => setMode(v as ImportMode)}>
-            <SelectTrigger className="w-[260px]">
+            <SelectTrigger className="w-[260px]" aria-label={t('configOps.import.modeLabel')}>
               <SelectValue />
             </SelectTrigger>
             <SelectContent>


### PR DESCRIPTION
Three **systemic accessibility fixes** surfaced by the final design audit (all verified live with axe-core). Branched off `main` — independent of the open dataset-detail PR.

## 1. Unnamed form controls — WCAG 4.1.2 (`button-name` / `label`, was 6 critical)
One root cause across several controls. Each now has an accessible name:
- `FilterSelect` — associate the visible `<label>` with the combobox trigger (`useId` + `aria-labelledby`). Clears Admin Users / Jobs / Audit filters.
- Settings **language** select, Config Ops **import-mode** select — `aria-label`.
- Import **file input** (`react-dropzone`) — `aria-label` via `getInputProps`.
- Data-table search **clear (×)** button — `aria-label`.
- Audit **date-range** filters (`type="date"`) — `aria-label`.

## 2. Nested duplicate `<main>` on every `/admin/*` route
shadcn `SidebarInset` rendered a second `<main>` inside the shell's `<main id="main-content">`, tripping `landmark-no-duplicate-main` / `landmark-main-is-top-level` / `landmark-unique` on all admin pages. Render the inset as a `<div>` (style-driving `data-slot` unchanged) → one top-level main.

## 3. Missing page `<h1>` on auth pages
- **Register** (error / registration-disabled branches) and **Verify Email** rendered no `<h1>` (CardTitle is a plain `<div>`) → add `sr-only` headings.
- **Login**'s only `<h1>` lives in the desktop brand panel (`display:none` < 880px) → add a mobile-only `sr-only` h1 so screen-reader heading nav works on small screens.

Adds `common.clearSearch` + `import.dropzone.ariaLabel` across **en/de/es/fr** (locale-parity gate).

## Verification
- axe-core re-run on every affected page: targeted `button-name` / `label` / `landmark-*` / `page-has-heading-one` violations **cleared**.
- `typecheck` ✅ · `lint` ✅ · `test:i18n` parity ✅ · **3004/3004** unit tests ✅.

### Out of scope (deferred, from the audit)
Auth pages still lack a `<main>` landmark (`landmark-one-main` / `region`) — separate finding, not bundled here. Card borders, mobile truncation, map-overlay contrast, and `transition-all` hygiene are tracked in the audit report (`docs-internal/audits/design-audit-20260625.md`).

https://claude.ai/code/session_017QVGwV2NqDZEnh4zzA418o