### PR TITLE
fix(a11y): wrap auth pages in <main>; border settings/config-ops cards

### DIFF
--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -273,7 +273,7 @@ export function LoginPage() {
   ];
 
   return (
-    <div className="grid min-h-screen grid-cols-1 min-[880px]:grid-cols-[1.05fr_0.95fr]">
+    <main className="grid min-h-screen grid-cols-1 min-[880px]:grid-cols-[1.05fr_0.95fr]">
       {/* ───────── LEFT — brand / map panel (hidden ≤880px) ───────── */}
       <section className="relative hidden overflow-hidden border-r border-border bg-map-paper px-14 py-12 min-[880px]:flex min-[880px]:flex-col min-[880px]:justify-between">
         <BrandMapBackdrop />
@@ -437,6 +437,6 @@ export function LoginPage() {
           </div>
         </div>
       </section>
-    </div>
+    </main>
   );
 }

--- a/frontend/src/pages/RegisterPage.tsx
+++ b/frontend/src/pages/RegisterPage.tsx
@@ -50,15 +50,15 @@ export function RegisterPage() {
 
   if (isLoading) {
     return (
-      <div className="flex min-h-screen items-center justify-center">
+      <main className="flex min-h-screen items-center justify-center">
         <Loader2 className="size-6 animate-spin text-muted-foreground" />
-      </div>
+      </main>
     );
   }
 
   if (configError) {
     return (
-      <div className="flex min-h-screen flex-col items-center justify-center gap-6 bg-background px-4">
+      <main className="flex min-h-screen flex-col items-center justify-center gap-6 bg-background px-4">
         <div className="text-center">
           {/* sr-only level-1 heading: screen-reader heading nav needs an <h1>
               in every render branch, not just the form branch below. */}
@@ -84,13 +84,13 @@ export function RegisterPage() {
             </Link>
           </CardContent>
         </Card>
-      </div>
+      </main>
     );
   }
 
   if (!config || config.registration_enabled === false) {
     return (
-      <div className="flex min-h-screen flex-col items-center justify-center gap-6 bg-background px-4">
+      <main className="flex min-h-screen flex-col items-center justify-center gap-6 bg-background px-4">
         <div className="text-center">
           {/* sr-only level-1 heading: screen-reader heading nav needs an <h1>
               in every render branch, not just the form branch below. */}
@@ -116,12 +116,12 @@ export function RegisterPage() {
             </Link>
           </CardContent>
         </Card>
-      </div>
+      </main>
     );
   }
 
   return (
-    <div className="flex min-h-screen flex-col items-center justify-center gap-6 bg-background px-4">
+    <main className="flex min-h-screen flex-col items-center justify-center gap-6 bg-background px-4">
       <div className="text-center">
         {/* sr-only level-1 heading: the visual brand mark is the GeoLensLogo, but
             screen-reader heading navigation still needs an <h1> on the page. */}
@@ -149,6 +149,6 @@ export function RegisterPage() {
           }}
         />
       )}
-    </div>
+    </main>
   );
 }

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -34,7 +34,7 @@ export function SettingsPage() {
 
         <TabsContent value="preferences" className="space-y-4">
           {/* Profile */}
-          <Card>
+          <Card className="border border-border">
             <CardHeader>
               <CardTitle>{t('settings.profile.title')}</CardTitle>
             </CardHeader>
@@ -55,7 +55,7 @@ export function SettingsPage() {
           </Card>
 
           {/* Appearance */}
-          <Card>
+          <Card className="border border-border">
             <CardHeader>
               <CardTitle>{t('settings.appearance.title')}</CardTitle>
               <CardDescription>{t('settings.appearance.description')}</CardDescription>
@@ -85,7 +85,7 @@ export function SettingsPage() {
           </Card>
 
           {/* Language */}
-          <Card>
+          <Card className="border border-border">
             <CardHeader>
               <CardTitle>{t('settings.language.title')}</CardTitle>
             </CardHeader>
@@ -112,7 +112,7 @@ export function SettingsPage() {
         </TabsContent>
 
         <TabsContent value="apiKeys">
-          <Card>
+          <Card className="border border-border">
             <CardHeader>
               <CardTitle>{t('settings.tabs.apiKeys')}</CardTitle>
             </CardHeader>

--- a/frontend/src/pages/VerifyEmailPage.tsx
+++ b/frontend/src/pages/VerifyEmailPage.tsx
@@ -73,7 +73,7 @@ export function VerifyEmailPage() {
   }
 
   return (
-    <div className="flex min-h-screen flex-col items-center justify-center gap-6 bg-background px-4">
+    <main className="flex min-h-screen flex-col items-center justify-center gap-6 bg-background px-4">
       <div className="text-center">
         {/* sr-only level-1 heading: the state cards below use CardTitle (a plain
             <div>), so without this the page has no heading-one for SR nav. */}
@@ -161,6 +161,6 @@ export function VerifyEmailPage() {
           </CardContent>
         </Card>
       )}
-    </div>
+    </main>
   );
 }

--- a/frontend/src/pages/admin/AdminConfigOpsPage.tsx
+++ b/frontend/src/pages/admin/AdminConfigOpsPage.tsx
@@ -76,7 +76,7 @@ function ExportSection() {
   const exportMutation = useExportConfig();
 
   return (
-    <Card>
+    <Card className="border border-border">
       <CardHeader>
         <CardTitle className="flex items-center gap-2">
           <Download className="h-4 w-4" />
@@ -141,7 +141,7 @@ function ValidateSection() {
   const oidcEntries = result ? Object.entries(result.oidc_providers) : [];
 
   return (
-    <Card>
+    <Card className="border border-border">
       <CardHeader>
         <CardTitle className="flex items-center gap-2">
           <ShieldCheck className="h-4 w-4" />
@@ -284,7 +284,7 @@ function ImportSection() {
       dryRunResult.oauth_providers.changes.some((c) => c.action !== 'no_change'));
 
   return (
-    <Card>
+    <Card className="border border-border">
       <CardHeader>
         <CardTitle className="flex items-center gap-2">
           <Upload className="h-4 w-4" />


### PR DESCRIPTION
Two **systemic follow-ups** from the final design audit, deferred from #322. Branched off `main` (includes #321 + #322). Both axe-verified live.

## 1. Auth-page `<main>` landmark
**Login**, **Register** (all four render branches: loading / config-error / registration-disabled / form), and **Verify Email** rendered their content in a bare `<div>` — axe flagged `landmark-one-main` and orphaned every section/card as a `region` (**16 nodes on Login** alone). Wrap each root in `<main>`.

Verified post-change: exactly **one `<main>` per page**, `landmark-one-main` + `region` **cleared** at both desktop (1440) and mobile (390).

## 2. Settings / Config Ops card borders
DESIGN-GUIDE §6 (line 411): *"Admin tables/settings cards → `border border-border`."* **Settings** (4 cards) and **Admin Config Ops** (3) used bare shadow-only `<Card>`, reading edgeless in light mode and dark-on-dark in dark mode. Added the mandated border.

Overview/marketing cards intentionally **stay shadow-only** (guide line 408) — not touched.

## Verification
- axe-core re-run on auth pages: `landmark-one-main` / `region` cleared (desktop + mobile).
- `typecheck` ✅ · `lint` ✅ · `test:i18n` ✅ · **3004/3004** tests ✅.

### Remaining audit backlog (not in this PR)
Mobile truncation (Dataset Fields → 1 char, Maps/Collection/Jobs), map-overlay contrast, and `transition-all` ×4 hygiene — tracked in `docs-internal/audits/design-audit-20260625.md`.

https://claude.ai/code/session_017QVGwV2NqDZEnh4zzA418o