### PR TITLE
fix(responsive): stop mobile truncation on Fields, maps, collections, admin toolbar

### DIFF
--- a/frontend/src/components/admin/JobList.tsx
+++ b/frontend/src/components/admin/JobList.tsx
@@ -256,7 +256,10 @@ export function JobList() {
                         <TableCell>
                           {job.username ?? '-'}
                         </TableCell>
-                        <TableCell>
+                        <TableCell
+                          className="max-w-[36vw] truncate sm:max-w-none"
+                          title={job.source_filename ?? undefined}
+                        >
                           {job.source_filename ?? '-'}
                         </TableCell>
                         <TableCell>

--- a/frontend/src/components/admin/UserList.tsx
+++ b/frontend/src/components/admin/UserList.tsx
@@ -143,12 +143,12 @@ export function UserList() {
     <>
       <Card>
         <CardHeader>
-          <div className="flex items-center justify-between">
+          <div className="flex flex-wrap items-center justify-between gap-2">
             <CardTitle className="flex items-center gap-2 text-sm font-medium">
               {t('users.title')}
               {data ? <Badge variant="secondary">{data.total}</Badge> : null}
             </CardTitle>
-            <div className="flex items-center gap-3">
+            <div className="flex flex-wrap items-center gap-2">
               <DataTableSearch
                 value={searchQuery}
                 onChange={(v) => { setSearchQuery(v); setPage(0); }}

--- a/frontend/src/components/collections/CollectionDatasetList.tsx
+++ b/frontend/src/components/collections/CollectionDatasetList.tsx
@@ -76,9 +76,9 @@ export function CollectionDatasetList({ collectionId, onRemove }: CollectionData
             >
               <Link
                 to={`/datasets/${dataset.id}`}
-                className="flex items-center justify-between gap-4 min-w-0 flex-1"
+                className="flex flex-col items-start gap-1 sm:flex-row sm:items-center sm:justify-between sm:gap-4 min-w-0 flex-1"
               >
-                <span className="text-sm font-medium truncate min-w-0">
+                <span className="text-sm font-medium truncate min-w-0 max-w-full">
                   {dataset.title}
                 </span>
                 <div className="flex items-center gap-2 flex-shrink-0">

--- a/frontend/src/components/dataset/tabs/OverviewTab.tsx
+++ b/frontend/src/components/dataset/tabs/OverviewTab.tsx
@@ -382,7 +382,7 @@ export function OverviewTab({
                 </CardTitle>
               </CardHeader>
               <CardContent>
-                <div className="grid grid-cols-2 md:grid-cols-3 gap-x-6 gap-y-2 text-sm">
+                <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-x-6 gap-y-2 text-sm">
                   {dataset.column_info.slice(0, 12).map((col) => (
                     <div key={col.name} className="flex items-baseline justify-between gap-2 min-w-0">
                       <span className="font-medium truncate" title={col.name}>{col.name}</span>

--- a/frontend/src/components/maps/MapCard.tsx
+++ b/frontend/src/components/maps/MapCard.tsx
@@ -27,11 +27,11 @@ export const MapCard = memo(function MapCard({ map, onDelete }: MapCardProps) {
   const thumbnailSrc = useMapThumbnail(map.thumbnail_url, map.updated_at);
 
   return (
-    <Card className="!flex-row !gap-0 !py-0 items-stretch overflow-hidden hover:shadow-md hover:border-primary/20 hover:bg-accent/50 transition-[color,background-color,box-shadow,border-color,opacity] duration-200 ease-out">
-      {/* Thumbnail */}
+    <Card className="flex-col sm:!flex-row !gap-0 !py-0 items-stretch overflow-hidden hover:shadow-md hover:border-primary/20 hover:bg-accent/50 transition-[color,background-color,box-shadow,border-color,opacity] duration-200 ease-out">
+      {/* Thumbnail — full-width banner on mobile, fixed side thumbnail from sm up */}
       <Link
         to={`/maps/${map.id}`}
-        className="w-44 h-28 shrink-0 bg-muted flex items-center justify-center overflow-hidden"
+        className="w-full h-40 sm:w-44 sm:h-28 shrink-0 bg-muted flex items-center justify-center overflow-hidden"
         aria-label={t('maps.card.previewAlt', { name: map.name })}
         title={t('maps.card.previewAlt', { name: map.name })}
       >


### PR DESCRIPTION
The design audit's **mobile-truncation cluster** (390px). Branched off `main`; disjoint from #323. Verified with 390px screenshots.

| Finding | Sev | Fix | Verified |
|---|---|---|---|
| **Dataset Fields** card | High | Field names collapsed to **1 char** (2-col cell couldn't fit name + full type). → `grid-cols-1` on mobile, 2/3 at sm/md | ✅ full names render |
| **Maps list** card | Med | Unconditional row + fixed 176px thumb truncated every title. → `flex-col` + full-width thumbnail banner on mobile, side thumb from sm | ✅ titles readable |
| **Collection** dataset list | Med | Titles truncated to ~6 chars. → stack title above badges on mobile, inline from sm | ✅ ~30 chars |
| **Admin Users** toolbar | Med | Search/Export/Add ran off-screen. → `flex-wrap` | ✅ all visible |
| **Admin Jobs** filename | High* | Cap + truncate so it stops pushing the row | ⚠️ partial — see below |

**Honest note on Admin Jobs:** the filename cell is now width-bounded, but the dense 6-column table still exceeds 390px and scrolls horizontally — STATUS/DURATION sit past the viewport edge until you swipe. A full fix (mobile card layout or column-priority redesign) is a larger effort, **deferred**. The filename cap is a real improvement (stops a long filename pushing the table further), not a complete fix. The same dense-table pattern applies to the Users *table* (toolbar is fixed here; table scroll deferred).

## Verification
390px screenshots for all five; `typecheck` ✅ · `lint` ✅ · **3004/3004** tests ✅.

https://claude.ai/code/session_017QVGwV2NqDZEnh4zzA418o