### PR TITLE
ci(release): mark semver pre-release tags as GitHub pre-releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,10 +68,24 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          # Semver pre-release tags carry a hyphenated suffix (e.g. v1.4.0-rc.1).
+          # Mark those as a GitHub pre-release so they are NEVER promoted to the
+          # "latest" pointer that the website archive link + install script follow.
+          # GA tags (vX.Y.Z, no suffix) stay full releases and become latest.
+          case "${TAG}" in
+            *-*) IS_PRERELEASE=true ;;
+            *)   IS_PRERELEASE=false ;;
+          esac
           if gh release view "${TAG}" >/dev/null 2>&1; then
             gh release edit "${TAG}" \
               --title "${TAG}" \
-              --notes-file release-notes.md
+              --notes-file release-notes.md \
+              --prerelease="${IS_PRERELEASE}"
+          elif [ "${IS_PRERELEASE}" = true ]; then
+            gh release create "${TAG}" \
+              --title "${TAG}" \
+              --notes-file release-notes.md \
+              --prerelease
           else
             gh release create "${TAG}" \
               --title "${TAG}" \


### PR DESCRIPTION
Prereq for cutting **v1.4.0-rc.1** (the soft-launch RC).

**Problem:** `release.yml` runs `gh release create "${TAG}"` with no `--prerelease`, so every tag becomes a *full* GitHub Release. The created release is "the 'latest' pointer the website archive link + GitHub's release API follow" (per the workflow's own header), so pushing `v1.4.0-rc.1` would promote the RC to **latest** — exactly what an RC must not be.

**Fix:** detect a hyphenated semver suffix (`v1.4.0-rc.1`, `-beta.2`, …) and pass `--prerelease`. GA tags (`vX.Y.Z`, no suffix) are unchanged and still become latest. Idempotent on the `gh release edit` path via `--prerelease=${IS_PRERELEASE}`.

Validated: YAML parses; logic table — `v1.4.0-rc.1→true`, `v1.4.0→false`, `v1.4.0-beta.2→true`, `v2.0.0→false`.

https://claude.ai/code/session_017QVGwV2NqDZEnh4zzA418o