### PR TITLE
fix(auth): make seed_initial_admin concurrency-safe (+ CI :latest gate)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -81,7 +81,11 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
-            type=raw,value=latest,enable=${{ github.event_name == 'push' && github.ref_type == 'tag' }}
+            # `latest` only on a real GA tag — exclude prereleases (a `-rc`/`-beta`
+            # suffix). Otherwise a `v1.4.0-rc.1` push clobbers `:latest` with an
+            # unreleased candidate (same spirit as #325 gating release.yml's
+            # isPrerelease). Fresh `:latest` pulls must track the last GA.
+            type=raw,value=latest,enable=${{ github.event_name == 'push' && github.ref_type == 'tag' && !contains(github.ref_name, '-') }}
           labels: |
             org.opencontainers.image.description=${{ matrix.description }}
             org.opencontainers.image.licenses=Apache-2.0

--- a/backend/app/api/main.py
+++ b/backend/app/api/main.py
@@ -47,9 +47,11 @@ structlog.contextvars.bind_contextvars(service="api")
 
 logger = structlog.stdlib.get_logger(__name__)
 
-# Arbitrary stable key for the admin-seed advisory lock (pg_advisory_xact_lock).
-# Any constant works; it only needs to be unique among advisory locks we take.
-_ADMIN_SEED_LOCK_KEY = 0x6C656E73  # "lens"
+# Arbitrary stable key for the boot-time seed advisory lock (pg_advisory_xact_lock).
+# Serializes seed_roles + seed_initial_admin so concurrent uvicorn workers don't
+# race the SELECT-then-INSERT on a fresh DB. Any constant works; it only needs to
+# be unique among advisory locks we take (conftest uses a different key).
+_SEED_LOCK_KEY = 0x6C656E73  # "lens"
 
 # Default roles to seed if they don't exist
 DEFAULT_ROLES = [
@@ -60,8 +62,18 @@ DEFAULT_ROLES = [
 
 
 async def seed_roles() -> None:
-    """Ensure default roles exist in the database (defensive safety net)."""
+    """Ensure default roles exist in the database (defensive safety net).
+
+    Concurrency-safe (see _SEED_LOCK_KEY): runs in the lifespan before
+    seed_initial_admin, so under `uvicorn --workers N` two workers on a fresh DB
+    would otherwise both SELECT-miss and both INSERT, colliding on the roles.name
+    unique constraint and crashing the loser's startup *before* the admin-seed
+    lock is ever reached.
+    """
     async with async_session() as session:
+        await session.execute(
+            text("SELECT pg_advisory_xact_lock(:k)"), {"k": _SEED_LOCK_KEY}
+        )
         for role_data in DEFAULT_ROLES:
             result = await session.execute(
                 select(Role).where(Role.name == role_data["name"])
@@ -109,7 +121,7 @@ async def seed_initial_admin() -> None:
     """
     async with async_session() as session:
         await session.execute(
-            text("SELECT pg_advisory_xact_lock(:k)"), {"k": _ADMIN_SEED_LOCK_KEY}
+            text("SELECT pg_advisory_xact_lock(:k)"), {"k": _SEED_LOCK_KEY}
         )
         result = await session.execute(select(func.count()).select_from(User))
         user_count = result.scalar() or 0

--- a/backend/app/api/main.py
+++ b/backend/app/api/main.py
@@ -47,6 +47,10 @@ structlog.contextvars.bind_contextvars(service="api")
 
 logger = structlog.stdlib.get_logger(__name__)
 
+# Arbitrary stable key for the admin-seed advisory lock (pg_advisory_xact_lock).
+# Any constant works; it only needs to be unique among advisory locks we take.
+_ADMIN_SEED_LOCK_KEY = 0x6C656E73  # "lens"
+
 # Default roles to seed if they don't exist
 DEFAULT_ROLES = [
     {"name": "admin", "description": "Full system access"},
@@ -94,8 +98,19 @@ async def seed_initial_admin() -> None:
 
     Uses GEOLENS_ADMIN_USERNAME and GEOLENS_ADMIN_PASSWORD from settings
     (configurable via environment variables).
+
+    Concurrency-safe: prod runs `uvicorn --workers N`, so every worker runs the
+    lifespan and races the count-check + INSERT on a fresh DB. Without
+    serialization two workers both see count==0 and both INSERT → one hits
+    `UniqueViolationError` on uq_users_username_global → the admin row never
+    commits → admin login 401 on every fresh self-hosted install. An
+    xact-scoped advisory lock makes exactly one worker seed; the rest see
+    count>0 and no-op. The lock releases when the session's transaction ends.
     """
     async with async_session() as session:
+        await session.execute(
+            text("SELECT pg_advisory_xact_lock(:k)"), {"k": _ADMIN_SEED_LOCK_KEY}
+        )
         result = await session.execute(select(func.count()).select_from(User))
         user_count = result.scalar() or 0
 

--- a/backend/tests/test_seed_admin_concurrency.py
+++ b/backend/tests/test_seed_admin_concurrency.py
@@ -1,18 +1,20 @@
-"""Regression: seed_initial_admin must be concurrency-safe.
+"""Regression: the boot-time seeders must be concurrency-safe.
 
 Prod runs `uvicorn --workers N`; on a fresh DB every worker runs the lifespan
-and races the count-check + INSERT in seed_initial_admin(). Before the
-advisory-lock fix two workers both saw count==0 and both INSERTed → one hit
-`UniqueViolationError` on uq_users_username_global → the admin row never
-committed → admin/admin login returned 401 on every fresh self-hosted install
-(caught by the v1.4.0-rc.1 prod-smoke gate).
+and races the SELECT-then-INSERT in seed_roles() and seed_initial_admin().
+Before the advisory-lock fix two workers both saw a row missing and both
+INSERTed → one hit `UniqueViolationError` (roles.name or uq_users_username_global)
+→ that worker's startup crashed / the admin row never committed → admin/admin
+login returned 401 on every fresh self-hosted install (caught by the
+v1.4.0-rc.1 prod-smoke gate). seed_roles runs *first*, so it must be guarded
+too — otherwise a colliding worker dies there before reaching the admin seed.
 
-The fix serializes seeders on a Postgres xact-scoped advisory lock. This test
-proves the lock is actually taken: it holds that same advisory key on a separate
-connection and asserts seed_initial_admin() *blocks* until the key is released,
-then completes and creates exactly one admin. Deterministic — it forces the
-contention rather than racing asyncio's scheduler (a plain gather() of seeds
-serializes by luck and would pass even without the lock).
+The fix serializes both seeders on one Postgres xact-scoped advisory key. These
+tests prove the lock is actually taken: they hold that key on a separate
+connection and assert each seeder *blocks* until the key is released, then
+completes correctly. Deterministic — they force the contention rather than
+racing asyncio's scheduler (a plain gather() of seeds serializes by luck and
+would pass even without the lock).
 """
 
 import asyncio
@@ -22,43 +24,54 @@ from sqlalchemy import func, select, text
 
 import app.api.main as main_module
 import app.core.db as db_module
-from app.api.main import _ADMIN_SEED_LOCK_KEY, seed_initial_admin
+from app.api.main import (
+    DEFAULT_ROLES,
+    _SEED_LOCK_KEY,
+    seed_initial_admin,
+    seed_roles,
+)
 from app.core.config import settings
-from app.modules.auth.models import User
+from app.modules.auth.models import Role, User
 
 pytestmark = pytest.mark.anyio
 
 
-async def test_seed_blocks_on_advisory_lock(test_db_session, monkeypatch):
-    # seed_initial_admin() resolves `async_session` from app.api.main's
-    # namespace; the client fixture only patches app.core.db.async_session, so
-    # repoint the seed at the same test engine.
+async def _assert_blocks_until_lock_released(seed_coro_factory):
+    """Hold the seed advisory key on an independent connection (mimicking
+    "another worker is mid-seed"), then assert the seeder blocks until released.
+
+    Returns once the seeder has run to completion against the released lock.
+    """
+    holder = await db_module.engine.connect()
+    await holder.execute(
+        text("SELECT pg_advisory_xact_lock(:k)"), {"k": _SEED_LOCK_KEY}
+    )
+    try:
+        task = asyncio.ensure_future(seed_coro_factory())
+        # With the lock held, the seeder must block on its own lock acquisition.
+        # Give it room; if the code skipped the lock it would finish here.
+        await asyncio.sleep(0.5)
+        assert not task.done(), "seeder did not block on the advisory lock"
+    finally:
+        await holder.rollback()  # release the xact-scoped lock
+        await holder.close()
+    await asyncio.wait_for(task, timeout=10)
+
+
+async def test_seed_initial_admin_blocks_on_advisory_lock(test_db_session, monkeypatch):
+    # seed_initial_admin() resolves `async_session` from app.api.main's namespace;
+    # the client fixture only patches app.core.db.async_session, so repoint the
+    # seed at the same test engine — otherwise it writes to the default DB.
     monkeypatch.setattr(main_module, "async_session", db_module.async_session)
 
-    # Fresh-DB state (count==0) — the only state the prod guard seeds in.
+    # Fresh-DB state (count==0) — the only state the prod guard seeds in. CASCADE
+    # clears user_roles; the roles table survives (the client fixture seeded the
+    # "admin" role seed_initial_admin requires). Self-healing: the seed recreates
+    # the admin + its role link below.
     await test_db_session.execute(text("TRUNCATE TABLE catalog.users CASCADE"))
     await test_db_session.commit()
 
-    # Hold the seed's advisory key on an independent connection, mimicking
-    # "worker A is mid-seed". The lock is xact-scoped, so it's held until we
-    # roll back this transaction.
-    holder = await db_module.engine.connect()
-    await holder.execute(
-        text("SELECT pg_advisory_xact_lock(:k)"), {"k": _ADMIN_SEED_LOCK_KEY}
-    )
-
-    try:
-        seed = asyncio.ensure_future(seed_initial_admin())
-        # With the lock taken, the seed must block here. Give it room to run;
-        # if the code skipped the lock it would finish and seed within this window.
-        await asyncio.sleep(0.5)
-        assert not seed.done(), "seed_initial_admin did not block on the advisory lock"
-    finally:
-        await holder.rollback()  # release the lock
-        await holder.close()
-
-    # Now the seed can proceed.
-    await asyncio.wait_for(seed, timeout=10)
+    await _assert_blocks_until_lock_released(seed_initial_admin)
 
     count = (
         await test_db_session.execute(
@@ -68,3 +81,28 @@ async def test_seed_blocks_on_advisory_lock(test_db_session, monkeypatch):
         )
     ).scalar()
     assert count == 1
+
+
+async def test_seed_roles_blocks_on_advisory_lock(test_db_session, monkeypatch):
+    # seed_roles runs in the lifespan BEFORE seed_initial_admin and has the same
+    # SELECT-then-INSERT race on the unique roles.name. It must take the lock too.
+    # No TRUNCATE: the seeder acquires the lock before its SELECT loop, so it
+    # blocks regardless of whether rows already exist — and truncating
+    # catalog.roles CASCADE would strip the admin's role link without the fixture
+    # re-linking it, poisoning the shared per-worker DB for later tests.
+    monkeypatch.setattr(main_module, "async_session", db_module.async_session)
+
+    await _assert_blocks_until_lock_released(seed_roles)
+
+    present = (
+        (
+            await test_db_session.execute(
+                select(Role.name).where(
+                    Role.name.in_([r["name"] for r in DEFAULT_ROLES])
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert set(present) == {r["name"] for r in DEFAULT_ROLES}

--- a/backend/tests/test_seed_admin_concurrency.py
+++ b/backend/tests/test_seed_admin_concurrency.py
@@ -1,0 +1,70 @@
+"""Regression: seed_initial_admin must be concurrency-safe.
+
+Prod runs `uvicorn --workers N`; on a fresh DB every worker runs the lifespan
+and races the count-check + INSERT in seed_initial_admin(). Before the
+advisory-lock fix two workers both saw count==0 and both INSERTed → one hit
+`UniqueViolationError` on uq_users_username_global → the admin row never
+committed → admin/admin login returned 401 on every fresh self-hosted install
+(caught by the v1.4.0-rc.1 prod-smoke gate).
+
+The fix serializes seeders on a Postgres xact-scoped advisory lock. This test
+proves the lock is actually taken: it holds that same advisory key on a separate
+connection and asserts seed_initial_admin() *blocks* until the key is released,
+then completes and creates exactly one admin. Deterministic — it forces the
+contention rather than racing asyncio's scheduler (a plain gather() of seeds
+serializes by luck and would pass even without the lock).
+"""
+
+import asyncio
+
+import pytest
+from sqlalchemy import func, select, text
+
+import app.api.main as main_module
+import app.core.db as db_module
+from app.api.main import _ADMIN_SEED_LOCK_KEY, seed_initial_admin
+from app.core.config import settings
+from app.modules.auth.models import User
+
+pytestmark = pytest.mark.anyio
+
+
+async def test_seed_blocks_on_advisory_lock(test_db_session, monkeypatch):
+    # seed_initial_admin() resolves `async_session` from app.api.main's
+    # namespace; the client fixture only patches app.core.db.async_session, so
+    # repoint the seed at the same test engine.
+    monkeypatch.setattr(main_module, "async_session", db_module.async_session)
+
+    # Fresh-DB state (count==0) — the only state the prod guard seeds in.
+    await test_db_session.execute(text("TRUNCATE TABLE catalog.users CASCADE"))
+    await test_db_session.commit()
+
+    # Hold the seed's advisory key on an independent connection, mimicking
+    # "worker A is mid-seed". The lock is xact-scoped, so it's held until we
+    # roll back this transaction.
+    holder = await db_module.engine.connect()
+    await holder.execute(
+        text("SELECT pg_advisory_xact_lock(:k)"), {"k": _ADMIN_SEED_LOCK_KEY}
+    )
+
+    try:
+        seed = asyncio.ensure_future(seed_initial_admin())
+        # With the lock taken, the seed must block here. Give it room to run;
+        # if the code skipped the lock it would finish and seed within this window.
+        await asyncio.sleep(0.5)
+        assert not seed.done(), "seed_initial_admin did not block on the advisory lock"
+    finally:
+        await holder.rollback()  # release the lock
+        await holder.close()
+
+    # Now the seed can proceed.
+    await asyncio.wait_for(seed, timeout=10)
+
+    count = (
+        await test_db_session.execute(
+            select(func.count())
+            .select_from(User)
+            .where(User.username == settings.geolens_admin_username)
+        )
+    ).scalar()
+    assert count == 1

--- a/frontend/src/components/auth/LoginForm.tsx
+++ b/frontend/src/components/auth/LoginForm.tsx
@@ -48,7 +48,7 @@ export function LoginForm() {
   }
 
   return (
-    <form onSubmit={handleSubmit} className="flex w-full flex-col gap-4">
+    <form onSubmit={handleSubmit} className="flex w-full flex-col gap-3.5">
       <div className="flex flex-col gap-1.5">
         <Label htmlFor="username" className="text-[12.5px]">
           {t('username')}

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -344,7 +344,7 @@ export function LoginPage() {
               on mobile without this. Hidden on desktop to keep a single h1. */}
           <h1 className="sr-only min-[880px]:hidden">{t('signIn')}</h1>
           {/* Form head */}
-          <div className="mb-6">
+          <div className="mb-5">
             <h2 className="text-[19px] font-semibold tracking-[-0.01em] text-foreground">
               {t('signIn')}
             </h2>
@@ -390,12 +390,12 @@ export function LoginPage() {
           {/* Adaptive OAuth: 0 → renders nothing; 1 → labeled; 2-3 → icon row.
               The divider only belongs above the buttons when a password form
               sits above it. */}
-          <div className="mt-6">
+          <div className="mt-5">
             <OAuthButtons showDivider={showPasswordForm} />
           </div>
 
           {/* Legal */}
-          <p className="mt-6 text-center text-[11.5px] leading-relaxed text-muted-foreground">
+          <p className="mt-5 text-center text-[11.5px] leading-relaxed text-muted-foreground">
             {t('consentNote')}{' '}
             <a
               href={GEOLENS_PRIVACY_URL}


### PR DESCRIPTION
## Why

The `v1.4.0-rc.1` prod-smoke gate correctly withheld the GitHub Release — it caught a **real backend bug**: `seed_initial_admin` is not concurrency-safe. Prod runs `uvicorn --workers N`, so on a **fresh DB** every worker runs the lifespan and races the count-check + INSERT. Two workers both see `count==0` and both INSERT → one hits `UniqueViolationError` on `uq_users_username_global` → the admin row never commits → `admin/admin` login returns 401. This breaks **every fresh self-hosted prod install**. (Existing installs are unaffected — the admin was seeded once, long ago.)

## What

**`fix(auth)` — `backend/app/api/main.py`**
- Take a `pg_advisory_xact_lock` before the count-check + INSERT in `seed_initial_admin`, so exactly one worker seeds and the rest see `count>0` and no-op. The lock is xact-scoped (released on commit/rollback).

**CI — `.github/workflows/publish.yml`**
- Gate the GHCR `:latest` tag on a **GA (non-prerelease)** tag (`!contains(ref_name, '-')`). An `-rc`/`-beta` push no longer clobbers `:latest` with an unreleased candidate (same spirit as #325 gating `release.yml`'s `isPrerelease`).

**Test — `backend/tests/test_seed_admin_concurrency.py`**
- Deterministic regression test: holds the advisory key on a separate connection and asserts `seed_initial_admin` **blocks** until released, then completes with exactly one admin. Verified it fails without the lock and passes with it.

## Verification
- New test passes; confirmed it fails when the lock is removed (has teeth). `ruff` clean; pre-commit hooks pass.
- End-to-end proof is the re-cut **`v1.4.0-rc.2`** pipeline going green (the prod-smoke gate that caught this).

## Notes / not in this PR
- **Smoke-after-publish ordering**: already handled — `prod-smoke.yml` has a 40×30s pull-retry loop whose comment documents choosing that over a `workflow_run` dependency. No change.
- **GHCR `:latest` is currently broken** (points at rc.1) — restoring `:latest`→`1.3.0` is a registry op, done separately from this merge.

Also folds in a small **login spacing** tweak (`style(login)`) — tightens the sign-in panel's vertical rhythm (right panel only; brand panel untouched).