### PR TITLE
chore(settings): storage-usage follow-ups (admin label + live usage refresh)

### DIFF
--- a/frontend/src/components/admin/UserList.tsx
+++ b/frontend/src/components/admin/UserList.tsx
@@ -185,7 +185,7 @@ export function UserList() {
                 <TableHead>{t('users.table.email')}</TableHead>
                 <TableHead>{t('users.table.roles')}</TableHead>
                 <TableHead>{t('users.table.status')}</TableHead>
-                <TableHead>Storage Used</TableHead>
+                <TableHead>{t('users.table.storage')}</TableHead>
                 <TableHead>{t('users.table.lastLogin')}</TableHead>
                 <TableHead>{t('users.table.created')}</TableHead>
                 <TableHead>{t('users.table.actions')}</TableHead>

--- a/frontend/src/hooks/use-quota.ts
+++ b/frontend/src/hooks/use-quota.ts
@@ -11,6 +11,11 @@ export function useMyUsage() {
     queryKey: queryKeys.auth.usage(user?.id),
     queryFn: getMyUsage,
     enabled: !!user,
-    staleTime: 60 * 1000, // 1 min — usage changes on upload/delete
+    // Usage changes on every upload/delete, so re-read it each time the user
+    // opens Settings rather than serving a stale used/cap figure. Mirrors the
+    // per-user remaining_dataset_quota handling in useUploadConfig
+    // (components/import/hooks/use-ingest.ts).
+    staleTime: 0,
+    refetchOnMount: 'always',
   });
 }

--- a/frontend/src/i18n/locales/de/admin.json
+++ b/frontend/src/i18n/locales/de/admin.json
@@ -48,6 +48,7 @@
       "email": "E-Mail",
       "roles": "Rollen",
       "status": "Status",
+      "storage": "Dateispeicher",
       "lastLogin": "Letzter Login",
       "created": "Erstellt",
       "actions": "Aktionen"

--- a/frontend/src/i18n/locales/en/admin.json
+++ b/frontend/src/i18n/locales/en/admin.json
@@ -48,6 +48,7 @@
       "email": "Email",
       "roles": "Roles",
       "status": "Status",
+      "storage": "File storage",
       "lastLogin": "Last Login",
       "created": "Created",
       "actions": "Actions"

--- a/frontend/src/i18n/locales/es/admin.json
+++ b/frontend/src/i18n/locales/es/admin.json
@@ -48,6 +48,7 @@
       "email": "Correo electrónico",
       "roles": "Roles",
       "status": "Estado",
+      "storage": "Almacenamiento de archivos",
       "lastLogin": "Último acceso",
       "created": "Creado",
       "actions": "Acciones"

--- a/frontend/src/i18n/locales/fr/admin.json
+++ b/frontend/src/i18n/locales/fr/admin.json
@@ -48,6 +48,7 @@
       "email": "E-mail",
       "roles": "Rôles",
       "status": "Statut",
+      "storage": "Stockage de fichiers",
       "lastLogin": "Dernière connexion",
       "created": "Création",
       "actions": "Actions"


### PR DESCRIPTION
Follow-ups from the storage-usage feature (#328), both live-verified on localhost:8080.

## 1. Admin label consistency
The admin user-list column header was a hardcoded `"Storage Used"`. Now it's an i18n'd **"File storage"** (`users.table.storage`, all 4 locales) — matching the end-user card and honest about `bytes_used` tracking raster file bytes only. (Verified: header renders "File storage".)

## 2. Live usage refresh
`useMyUsage` now uses `staleTime: 0` + `refetchOnMount: 'always'`, so opening Settings re-reads `/auth/me/usage` and reflects an upload/delete immediately instead of serving a value stale by up to the old 60s window. This mirrors the existing per-user `remaining_dataset_quota` handling in `useUploadConfig` (`use-ingest.ts`), the established pattern for this class of per-user quota data. (Verified: a usage fetch fires on each Settings mount.)

No backend/API changes. Local: typecheck + eslint + i18n parity green.

Not addressed (by design): `bytes_used` raster-only is a documented backend limitation (true cross-type total deferred to metered/cloud quota work); the dataset **count** is the accurate cross-type fence.