### PR TITLE
fix(ci): seed prod-smoke admin username so the release E2E can log in

### DIFF
--- a/.github/workflows/prod-smoke.yml
+++ b/.github/workflows/prod-smoke.yml
@@ -77,6 +77,12 @@ jobs:
           # to satisfy the Settings validator (backend/app/config.py).
           sed -i -E 's|^POSTGRES_PASSWORD=.*|POSTGRES_PASSWORD=geolens_smoke_pw|' .env
           sed -i -E 's|^JWT_SECRET_KEY=.*|JWT_SECRET_KEY=prod-smoke-secret-key-padding-32chars-min|' .env
+          # .env.example ships GEOLENS_ADMIN_USERNAME= empty, so the seeded admin
+          # username is "" unless set here. The E2E auth.setup logs in as `admin`
+          # (see the GEOLENS_ADMIN_USERNAME below + the E2E step env), so without
+          # this the login deterministically 401s ("Incorrect username or
+          # password") and waitForURL('/') times out — set BOTH creds, like ci.yml.
+          sed -i -E 's|^GEOLENS_ADMIN_USERNAME=.*|GEOLENS_ADMIN_USERNAME=admin|' .env
           sed -i -E 's|^GEOLENS_ADMIN_PASSWORD=.*|GEOLENS_ADMIN_PASSWORD=admin|' .env
           # The prebuilt-image path: pin the version + select the prod compose so a
           # bare `docker compose` resolves to the published images.

--- a/e2e/auth.setup.ts
+++ b/e2e/auth.setup.ts
@@ -19,8 +19,24 @@ setup('authenticate as admin', async ({ page }) => {
   // Submit the form
   await page.getByRole('button', { name: 'Sign In' }).click();
 
-  // Wait for redirect to the search workspace (index route)
-  await page.waitForURL('/');
+  // Wait for redirect to the search workspace (index route). On a credential
+  // rejection the SPA stays on /login and renders a role="alert" instead of
+  // navigating; surface that message immediately rather than letting waitForURL
+  // run out the full test timeout — an auth failure otherwise masquerades as a
+  // slow-redirect flake (e.g. the seeded admin not matching the test creds).
+  try {
+    await page.waitForURL('/', { timeout: 30_000 });
+  } catch (err) {
+    const alert = page.getByRole('alert');
+    if (await alert.isVisible().catch(() => false)) {
+      const message = (await alert.textContent())?.trim();
+      throw new Error(
+        `Login failed — credentials rejected ("${message}"). ` +
+          'Confirm GEOLENS_ADMIN_USERNAME/PASSWORD match the seeded admin.',
+      );
+    }
+    throw err;
+  }
 
   // Verify workspace loaded
   await expect(page.locator('[data-testid="search-page"], input[type="search"], [role="search"]').first()).toBeVisible({ timeout: 10000 }).catch(() => {


### PR DESCRIPTION
## Problem

`Prod Compose Smoke` failed its `auth.setup` E2E on every recent run (it gates
the GitHub Release via `release.yml`'s `workflow_run` dependency). It was assumed
to be a fresh-stack "slow redirect" flake. It was not — it was deterministic:

- `.env.example` ships `GEOLENS_ADMIN_USERNAME=` **empty**.
- The "Write .env" step in `prod-smoke.yml` sed'd only the admin **password**
  (`=admin`), leaving the username empty.
- `seed_initial_admin()` therefore seeds the admin with an **empty** username
  (compose substitutes `${GEOLENS_ADMIN_USERNAME}` from `.env`).
- The Playwright `auth.setup` logs in as `admin/admin` → no such user → **401
  "Incorrect username or password"** → the SPA never navigates → `waitForURL('/')`
  runs out the 60s test timeout. It could never pass.

The failure screenshot (run 28257970809) shows the login form with the red
"Incorrect username or password" alert — not a half-loaded workspace.

The e2e jobs in `ci.yml` already set **both** creds; `prod-smoke.yml` was the
lone gap.

## Fix

- **`.github/workflows/prod-smoke.yml`** — set `GEOLENS_ADMIN_USERNAME=admin`
  alongside the existing password sed, mirroring `ci.yml`. This is the fix.
- **`e2e/auth.setup.ts`** — on no-redirect, surface the login `role="alert"`
  text and throw a descriptive error instead of a 60s opaque `waitForURL`
  timeout, so a credential mismatch can't masquerade as a slow-redirect flake
  again.

## Verification

Run against the live local prod stack (`localhost:8080`, `admin/admin`):

- Happy path: `npx playwright test --project=setup` → **1 passed (12.1s)**.
- Failure path (bad password): now throws
  `Login failed — credentials rejected ("Incorrect username or password"). Confirm GEOLENS_ADMIN_USERNAME/PASSWORD match the seeded admin.`

## Scope note

This does not affect the already-published v1.4.0 GitHub Release (created
manually while this gate was broken). It unblocks the **automatic** release-gate
path for the next tag.
