### PR TITLE
ci(verify-published): stop verifying the unused private geolens-worker image

### DIFF
--- a/.github/workflows/verify-published.yml
+++ b/.github/workflows/verify-published.yml
@@ -148,13 +148,18 @@ jobs:
             IMAGE_TAG="${VERSION#v}"
           fi
 
+          # geolens-worker is intentionally NOT verified here: the shipped
+          # docker-compose.prod.yml runs the worker service on the geolens-api
+          # image (its baked ENTRYPOINT/CMD differs only), so no consumer pulls
+          # the geolens-worker package — it stays private and unused. Pulling it
+          # anonymously returns `unauthorized` and fails this gate on an image
+          # nobody actually consumes. Verify only what a self-hoster pulls.
           attempt=1
           while true; do
             if docker pull "ghcr.io/${OWNER}/geolens-api:${IMAGE_TAG}" \
-              && docker pull "ghcr.io/${OWNER}/geolens-worker:${IMAGE_TAG}" \
               && docker pull "ghcr.io/${OWNER}/geolens-frontend:${IMAGE_TAG}" \
               && docker pull "ghcr.io/${OWNER}/geolens-backup:${IMAGE_TAG}"; then
-              echo "verified geolens-api + geolens-worker + geolens-frontend + geolens-backup @ ${IMAGE_TAG} on attempt ${attempt}"
+              echo "verified geolens-api + geolens-frontend + geolens-backup @ ${IMAGE_TAG} on attempt ${attempt}"
               break
             fi
             if [ "${attempt}" -ge "${MAX_ATTEMPTS}" ]; then


### PR DESCRIPTION
## Why

The re-run of `verify-published` for v1.4.0 failed its **Verify GHCR images** job on:

```
docker pull ghcr.io/geolens-io/geolens-worker:1.4.0
→ unauthorized
```

`geolens-worker` is published but **private and unused**: the shipped
`docker-compose.prod.yml` runs the worker service on the **geolens-api** image
(its baked ENTRYPOINT/CMD/HEALTHCHECK differ only), with an explicit comment that
this avoids any dependency on the geolens-worker package visibility. So no
self-hoster ever pulls `geolens-worker` — the gate was failing on an image nobody
consumes (api/frontend/backup pulled fine in the same job).

## Fix

Drop `geolens-worker` from the GHCR pull list; verify only what users actually
pull (api, frontend, backup), with a comment explaining the omission.

## Context

This was surfaced while closing out the v1.4.0 release tail. The other
`verify-published` failure (TypeScript SDK `ERR_MODULE_NOT_FOUND`) is fixed
separately in #333 and needs a v1.4.1 publish to clear. With both merged + 1.4.1
cut, verify-published goes fully green.