### PR TITLE
test(a11y): seed a dataset for the dataset-detail accessibility check

### DIFF
--- a/e2e/accessibility.spec.ts
+++ b/e2e/accessibility.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect } from '@playwright/test';
 import AxeBuilder from '@axe-core/playwright';
-import { getAuthToken, getSearchSeed } from './helpers/catalog';
+import { getAuthToken, seedDataset, deleteDataset } from './helpers/catalog';
 
 const wcagTags = ['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa'];
 const BASE_URL = process.env.E2E_BASE_URL ?? 'http://localhost:8080';
@@ -20,8 +20,17 @@ test.describe('Accessibility - WCAG 2AA', () => {
   let builderMapId: string;
   let builderMapName: string;
   let shareToken: string;
+  let datasetId: string;
+  let datasetTitle: string;
 
   test.beforeAll(async () => {
+    // Seed a real dataset so the dataset-detail test has something to render.
+    // This spec runs standalone in the Accessibility CI job (empty stack), so
+    // nothing else creates catalog data.
+    const seeded = await seedDataset();
+    datasetId = seeded.id;
+    datasetTitle = seeded.title;
+
     builderMapName = `A11y Builder Test ${Date.now()}`;
     const response = await fetch(`${BASE_URL}/api/maps/`, {
       method: 'POST',
@@ -64,6 +73,7 @@ test.describe('Accessibility - WCAG 2AA', () => {
   });
 
   test.afterAll(async () => {
+    if (datasetId) await deleteDataset(datasetId, datasetTitle);
     if (!builderMapId) return;
     await fetch(`${BASE_URL}/api/maps/${builderMapId}`, {
       method: 'DELETE',
@@ -117,14 +127,12 @@ test.describe('Accessibility - WCAG 2AA', () => {
   });
 
   test('dataset detail page has no accessibility violations', async ({ page }) => {
-    const seed = await getSearchSeed();
-
-    await page.goto(`/datasets/${seed.id}`);
+    await page.goto(`/datasets/${datasetId}`);
     await page.waitForLoadState('networkidle');
 
     // Wait for dataset detail to load
     await expect(
-      page.getByRole('heading', { name: seed.title, exact: true }),
+      page.getByRole('heading', { name: datasetTitle, exact: true }),
     ).toBeVisible();
     await page.waitForLoadState('networkidle');
 

--- a/e2e/helpers/catalog.ts
+++ b/e2e/helpers/catalog.ts
@@ -153,3 +153,68 @@ export async function getSearchSeed(): Promise<SearchSeed> {
 
   return searchSeedPromise;
 }
+
+export interface SeededDataset {
+  id: string;
+  title: string;
+}
+
+/**
+ * Ingest the sample fixture as a real dataset and return its id + title.
+ *
+ * Specs that need a dataset to exist but don't run alongside the upload flow
+ * (e.g. the accessibility job, which runs only the a11y specs against a fresh,
+ * empty stack) must seed their own — otherwise `getSearchSeed()` / a
+ * dataset-detail visit has nothing to find. Drives the same upload → commit →
+ * poll sequence the import UI uses. Pair every call with `deleteDataset()` in
+ * `afterAll`.
+ */
+export async function seedDataset(): Promise<SeededDataset> {
+  const title = `A11y Seed Dataset ${Date.now()}`;
+  const fixture = path.join(__dirname, '../fixtures/sample.geojson');
+  const bytes = fs.readFileSync(fixture);
+
+  const form = new FormData();
+  form.append('file', new Blob([bytes], { type: 'application/geo+json' }), 'sample.geojson');
+  const upload = await fetch(`${BASE_URL}/api/ingest/upload`, {
+    method: 'POST',
+    headers: authHeaders(),
+    body: form,
+  });
+  if (!upload.ok) throw new Error(`ingest upload failed: ${upload.status}`);
+  const { job_id: jobId } = (await upload.json()) as { job_id: string };
+
+  const commit = await fetch(`${BASE_URL}/api/ingest/commit/${jobId}`, {
+    method: 'POST',
+    headers: { ...authHeaders(), 'Content-Type': 'application/json' },
+    body: JSON.stringify({ title }),
+  });
+  if (!commit.ok) throw new Error(`ingest commit failed: ${commit.status}`);
+
+  // Commit returns 202 and queues an async ingest task; poll until the dataset row exists.
+  for (let attempt = 0; attempt < 60; attempt += 1) {
+    const res = await fetch(`${BASE_URL}/api/jobs/${jobId}`, { headers: authHeaders() });
+    if (res.ok) {
+      const job = (await res.json()) as { status?: string; dataset_id?: string | null };
+      if (job.dataset_id && ['complete', 'completed', 'succeeded'].includes(job.status ?? '')) {
+        return { id: job.dataset_id, title };
+      }
+      if (['failed', 'error'].includes(job.status ?? '')) {
+        throw new Error(`ingest job ${jobId} failed: ${JSON.stringify(job)}`);
+      }
+    }
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+  }
+  throw new Error(`ingest job ${jobId} did not produce a dataset in time`);
+}
+
+/** Best-effort teardown for a `seedDataset()` result (DELETE requires confirm_title). */
+export async function deleteDataset(id: string, title: string): Promise<void> {
+  await fetch(`${BASE_URL}/api/datasets/${id}`, {
+    method: 'DELETE',
+    headers: { ...authHeaders(), 'Content-Type': 'application/json' },
+    body: JSON.stringify({ confirm_title: title }),
+  }).catch(() => {
+    /* teardown is best-effort; the CI stack is torn down anyway */
+  });
+}


### PR DESCRIPTION
## Problem

The push-only **Accessibility (axe + keyboard-nav)** CI job has **never passed** on `main` (failed on every run since it was added in v1048). The failure is a **test-fixture gap, not an axe violation**:

```
Error: Could not find a stable searchable dataset fixture   (e2e/helpers/catalog.ts:148)
  at e2e/accessibility.spec.ts:120  ("dataset detail page has no accessibility violations")
```

The job boots a fresh, **empty** stack and runs *only* `accessibility.spec.ts` + `keyboard-nav.spec.ts`. The dataset-detail test called `getSearchSeed()`, which searches the catalog for a pre-existing dataset — but nothing seeds one. (In the full E2E suite, `upload.spec.ts` creates data first; this job doesn't run it.) So `getSearchSeed` threw every time.

## Fix

- Add `seedDataset()` / `deleteDataset()` to `e2e/helpers/catalog.ts` — drives the same **upload → commit → poll** ingest sequence the import UI uses, returning `{id, title}`.
- `accessibility.spec.ts` `beforeAll` now seeds a real dataset; the dataset-detail test visits it **by id directly** (dropping the flaky search-heuristic dependency); `afterAll` deletes it (DELETE requires `confirm_title`).
- `getSearchSeed` is untouched — still used by `search.spec.ts` (which runs in the full suite where data exists).

## Verification (local, live stack)

- Full `accessibility.spec.ts` → **9/9 passed** (31.2s).
- `seedDataset` ingest completes in ~2s; the seeded title returns exactly one search result; `afterAll` leaves **0 orphan datasets**.

## Note

This job is **push-only** (gated off PRs for cost), so it does **not** run on this PR — it validates on merge to `main`. `keyboard-nav.spec.ts` has no catalog-data dependency and was unaffected.
