### PR TITLE
fix(ai): map viewers can use AI chat read-only; AI edits stay owner-only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ and releases use semantic versioning.
   environment variables. Off-site S3 upload remains gated on
   `BACKUP_S3_ENABLED=true` and signs with AWS Signature V4 (Cloudflare R2,
   modern AWS S3, and MinIO compatible).
+- **The map builder's AI assistant is available to anyone who can view a map.**
+  Viewers — not just the map's owner — can now ask the assistant questions about
+  a map's data (counts, statistics, spatial analysis). Using the AI to *edit* a
+  map remains limited to the owner, and AI-suggested changes still only persist
+  when the owner saves the map.
 
 ### Added
 
@@ -38,6 +43,11 @@ and releases use semantic versioning.
 
 ### Fixed
 
+- **AI assistant no longer fails with a generic error on maps you don't own.**
+  Asking the builder's AI about a map you can view but not edit previously
+  surfaced "Something went wrong. Please try again." with a retry that never
+  worked; it now answers read-only questions, and genuine permission errors
+  show a clear, non-retryable message instead of a blind retry.
 - **Map Builder correctness fixes.** Bulk visibility/opacity on a multi-layer
   selection now matches single-layer behavior (companion outlines, labels,
   hypsometric relief, and clusters included); numeric-column filters now show a

--- a/backend/app/platform/extensions/protocols.py
+++ b/backend/app/platform/extensions/protocols.py
@@ -221,6 +221,11 @@ class AIProviderExtension(Protocol):
         history: list[dict] | None = None,
         port: Any,
         map_id: str | None = None,
+        # The advertised tool set for this turn. None means the provider's
+        # default chat tools; a restricted list (e.g. read-only) must be honored.
+        # Implementations with an explicit signature must accept this kwarg —
+        # stream_chat_edit always passes it.
+        tools: list[dict] | None = None,
     ) -> AsyncIterator[dict[str, object]]: ...
 
     async def structured_complete(

--- a/backend/app/processing/ai/chat_service.py
+++ b/backend/app/processing/ai/chat_service.py
@@ -85,7 +85,7 @@ from app.processing.ai.sql_generator import (
     generate_sql,
 )  # re-exported (test patch target)
 from app.processing.ai.token_usage import record_token_usage
-from app.processing.ai.tools import CHAT_TOOLS_ANTHROPIC
+from app.processing.ai.tools import select_chat_tools
 
 if TYPE_CHECKING:
     from app.core.processing_port import ProcessingPort
@@ -175,8 +175,14 @@ def build_chat_system_prompt(
     layers: list[ChatMapLayer],
     language: str | None = None,
     basemap_style: str | None = None,
+    can_edit: bool = True,
 ) -> str:
-    """Build a system prompt that describes the user's current map state."""
+    """Build a system prompt that describes the user's current map state.
+
+    When ``can_edit`` is False the caller may view but not edit the map (the AI
+    is given read-only tools — see ``select_chat_tools``); a read-only directive
+    is injected so the model declines edit requests instead of silently failing.
+    """
     # Cap layers to prevent unbounded prompt growth
     display_layers = layers[:_MAX_SYSTEM_PROMPT_LAYERS]
     truncated_count = len(layers) - len(display_layers)
@@ -246,10 +252,24 @@ def build_chat_system_prompt(
     if truncated_count > 0:
         truncation_note = f"\n\n(... and {truncated_count} more layers not shown. If the user references a layer not listed above, tell them you cannot see that layer.)"
 
+    readonly_note = (
+        ""
+        if can_edit
+        else (
+            "\n\n## Read-Only Access\n"
+            "You do NOT have edit access to this map — the current user can view it "
+            "but does not own it. You may ONLY answer questions about the map's data "
+            "using the query_data tool. You cannot change styles, filters, labels, "
+            "visibility, opacity, or add or remove layers; those tools are unavailable "
+            "to you. If the user asks you to modify the map, briefly explain that only "
+            "the map's owner can edit it, then offer to answer questions about the data."
+        )
+    )
+
     return f"""\
 You are a map editing assistant. The user has a map with these layers:
 
-{chr(10).join(layers_desc)}{truncation_note}
+{chr(10).join(layers_desc)}{truncation_note}{readonly_note}
 
 ## Instructions
 - Modify the map based on the user's instructions using the available tools.
@@ -316,6 +336,7 @@ async def chat_edit_map(
     *,
     port: "ProcessingPort",
     map_id: str | None = None,
+    can_edit: bool = True,
 ) -> ChatResponse:
     """Main orchestrator: run LLM tool-calling loop for chat map editing.
 
@@ -324,9 +345,13 @@ async def chat_edit_map(
 
     map_id is forwarded to query_data so the schema-context cache partitions
     per-map (PERF-04 / Phase 274).
+
+    can_edit gates the tool set: an owner gets the full editing toolbox; a
+    view-only caller gets read-only tools (query_data) so the AI can answer
+    questions but cannot emit edit actions.
     """
     system_prompt = build_chat_system_prompt(
-        layers, language=language, basemap_style=basemap_style
+        layers, language=language, basemap_style=basemap_style, can_edit=can_edit
     )
     provider, model, runtime_config = await resolve_provider(session)
     provider_ext = get_ai_provider(provider)
@@ -350,7 +375,7 @@ async def chat_edit_map(
         model=model,
         system_prompt=system_prompt,
         user_message=message,
-        tools=CHAT_TOOLS_ANTHROPIC,
+        tools=select_chat_tools(can_edit),
         tool_executor=tool_executor,
         action_collector=_collect_chat_action,
         history=history_dicts,

--- a/backend/app/processing/ai/chat_service.py
+++ b/backend/app/processing/ai/chat_service.py
@@ -358,8 +358,21 @@ async def chat_edit_map(
 
     history_dicts = history_to_dicts(history)
 
-    # Build tool executor bound to this session/user/layers
+    selected_tools = select_chat_tools(can_edit)
+    allowed_tool_names = {t["name"] for t in selected_tools}
+
+    # Build tool executor bound to this session/user/layers. The non-streaming
+    # complete() loop is advertised-tool constrained and has no XML fallback, but
+    # we still reject tool names outside the selected set at execution AND
+    # collection so a view-only caller can never run or receive a mutating action
+    # (defense-in-depth, uniform with the streaming path).
     async def tool_executor(tool_name: str, tool_input: dict) -> dict:
+        if tool_name not in allowed_tool_names:
+            logger.warning(
+                "Dropped disallowed chat tool call (read-only caller)",
+                tool=tool_name,
+            )
+            return {"error": "Tool not permitted for this map."}
         return await _execute_chat_tool(
             tool_name,
             tool_input,
@@ -371,13 +384,20 @@ async def chat_edit_map(
             map_id=map_id,
         )
 
+    def collect_allowed_action(
+        tool_name: str, tool_input: dict, tool_result: dict
+    ) -> dict | None:
+        if tool_name not in allowed_tool_names:
+            return None
+        return _collect_chat_action(tool_name, tool_input, tool_result)
+
     result = await provider_ext.complete(
         model=model,
         system_prompt=system_prompt,
         user_message=message,
-        tools=select_chat_tools(can_edit),
+        tools=selected_tools,
         tool_executor=tool_executor,
-        action_collector=_collect_chat_action,
+        action_collector=collect_allowed_action,
         history=history_dicts,
         base_url=runtime_config.get("base_url"),
         temperature=0.3,

--- a/backend/app/processing/ai/router.py
+++ b/backend/app/processing/ai/router.py
@@ -145,12 +145,19 @@ async def _validate_chat_layers(
     layers: list[ChatMapLayer],
     *,
     port: "ProcessingPort",
-) -> tuple[list[ChatMapLayer], str | None]:
-    """Validate map ownership and overwrite layer metadata with authoritative DB values.
+) -> tuple[list[ChatMapLayer], str | None, bool]:
+    """Validate map view-access and overwrite layer metadata with authoritative DB values.
 
-    - Verifies the map exists and is owned by the current user.
+    - Verifies the map exists and the current user can VIEW it (404 otherwise).
     - Resolves each layer's dataset_table_name from the DB by dataset_id.
     - Rejects layers whose datasets the user cannot access.
+
+    **Access model (builder-audit follow-up):** AI chat is read-only w.r.t. map
+    state — edit actions are applied client-side and only persist at Save, which
+    is owner-gated. So chat is gated on VIEW access, not ownership: any user who
+    can view the map may ask the AI questions about it. The returned ``can_edit``
+    (owner-or-admin, matching the Save boundary) selects the AI tool set — a
+    view-only caller gets read-only tools so the model cannot emit edit actions.
 
     **Visibility decision (Pitfall #5 — v1030 Phase 1135 AI-04):** This function
     does NOT filter layers by their ``visible`` state, even if the frontend
@@ -169,8 +176,12 @@ async def _validate_chat_layers(
     Returns (validated_layers, basemap_style).
     """
     from app.modules.catalog.maps.models import Map as MapORM
+    from app.modules.catalog.maps._router_helpers import (
+        _can_edit_map,
+        _check_map_read_access,
+    )
 
-    # Verify map ownership
+    # Verify map view access
     try:
         map_uuid = uuid_mod.UUID(map_id)
     except ValueError:
@@ -184,14 +195,15 @@ async def _validate_chat_layers(
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND, detail="Map not found"
         )
-    if map_row.created_by != user.id:
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN, detail="You do not own this map"
-        )
+    # Gate on VIEW access, not ownership — a non-viewer gets 404 (no existence
+    # oracle), same as a missing map. can_edit (owner-or-admin) selects the AI
+    # tool set so a viewer can ask questions but cannot use the AI to edit.
+    await _check_map_read_access(map_row, user, db)
+    can_edit = await _can_edit_map(map_row, user, db)
     basemap_style = getattr(map_row, "basemap_style", None)
 
     if not layers:
-        return layers, basemap_style
+        return layers, basemap_style, can_edit
 
     # Build the user's allowed table set
     allowed_tables = await build_table_allowlist(db, user)
@@ -233,7 +245,7 @@ async def _validate_chat_layers(
             layer.geometry_type = ds["geometry_type"]
         validated.append(layer)
 
-    return validated, basemap_style
+    return validated, basemap_style, can_edit
 
 
 @router.post("/generate-map/", response_model=MapGenerateResponse)
@@ -338,7 +350,7 @@ async def chat_endpoint(
     """Chat-based map editing: send a message and get back edit actions."""
     await _check_ai_available(db)
 
-    validated_layers, basemap_style = await _validate_chat_layers(
+    validated_layers, basemap_style, can_edit = await _validate_chat_layers(
         db, user, body.map_id, body.layers, port=port
     )
     user_roles = await port.get_user_roles(db, user)
@@ -355,6 +367,7 @@ async def chat_endpoint(
             basemap_style=basemap_style,
             port=port,
             map_id=body.map_id,
+            can_edit=can_edit,
         ),
         error_prefix="Chat map editing",
         tool_loop_message="Request required too many steps. Try a simpler instruction.",
@@ -387,13 +400,22 @@ async def chat_stream_endpoint(
         # cannot decode.
         try:
             await _check_ai_available(db)
-            validated_layers, basemap_style = await _validate_chat_layers(
+            validated_layers, basemap_style, can_edit = await _validate_chat_layers(
                 db, user, body.map_id, body.layers, port=port
             )
             user_roles = await port.get_user_roles(db, user)
         except HTTPException as exc:
+            # Thread the HTTP status into the SSE error so the client can classify
+            # it like a normal HTTP error (403/503 → banner, etc.) instead of a
+            # generic retryable failure — the SSE body is always a 200 stream.
             yield ServerSentEvent(
-                data=json.dumps({"type": "error", "message": exc.detail}),
+                data=json.dumps(
+                    {
+                        "type": "error",
+                        "message": exc.detail,
+                        "status": exc.status_code,
+                    }
+                ),
                 event="error",
             )
             return
@@ -421,6 +443,7 @@ async def chat_stream_endpoint(
                 basemap_style=basemap_style,
                 port=port,
                 map_id=body.map_id,
+                can_edit=can_edit,
             ):
                 if await request.is_disconnected():
                     break

--- a/backend/app/processing/ai/streaming.py
+++ b/backend/app/processing/ai/streaming.py
@@ -59,6 +59,7 @@ async def _execute_and_yield_tools(
     *,
     port: "ProcessingPort",
     map_id: str | None = None,
+    allowed_tools: set[str] | None = None,
 ) -> AsyncGenerator[dict, None]:
     """Execute a list of (name, args) tool calls and yield SSE events for each.
 
@@ -67,8 +68,23 @@ async def _execute_and_yield_tools(
 
     map_id is forwarded to query_data so the schema-context cache partitions
     per-map (PERF-04 / Phase 274).
+
+    allowed_tools, when provided, restricts which tool names may run: a call
+    whose name is outside the set is dropped before execution AND collection.
+    This enforces the read-only tool set for view-only callers even when a tool
+    call arrives via the XML fallback (parse_xml_tool_calls), which bypasses the
+    advertised tool schema. Native tool calls are always advertised-constrained
+    (allowed_tools == the advertised set), so they are never dropped here and the
+    caller's results_out↔tool_calls zip stays aligned.
     """
     for fn_name, fn_args in tool_calls:
+        if allowed_tools is not None and fn_name not in allowed_tools:
+            logger.warning(
+                "Dropped disallowed chat tool call (read-only caller)",
+                tool=fn_name,
+                allowed=sorted(allowed_tools),
+            )
+            continue
         stage_events: list[dict] = []
         stage_cb = _make_stage_callback(fn_name, stage_events)
 
@@ -124,9 +140,9 @@ async def _stream_anthropic_chat(
     cached_system = [
         {"type": "text", "text": system_prompt, "cache_control": {"type": "ephemeral"}}
     ]
-    cached_tools = add_tool_cache_control(
-        CHAT_TOOLS_ANTHROPIC if tools is None else tools
-    )
+    _raw_tools = CHAT_TOOLS_ANTHROPIC if tools is None else tools
+    cached_tools = add_tool_cache_control(_raw_tools)
+    allowed_tool_names = {t["name"] for t in _raw_tools}
 
     collected_actions: list[dict] = []
     total_input = 0
@@ -228,6 +244,7 @@ async def _stream_anthropic_chat(
                         results_out=raw_results,
                         port=port,
                         map_id=map_id,
+                        allowed_tools=allowed_tool_names,
                     ):
                         yield evt
 
@@ -311,6 +328,13 @@ async def _stream_openai_chat(
     deadline = time.monotonic() + MAX_STREAMING_WALL_CLOCK_SECONDS
     total_input = 0
     total_output = 0
+    # Read-only enforcement backstop: the XML fallback (parse_xml_tool_calls)
+    # below extracts tool calls from model text, bypassing the advertised schema.
+    # Restrict execution/collection to the selected tool set so a view-only caller
+    # cannot get a mutating action even from an XML-emitting model.
+    allowed_tool_names = {
+        t["name"] for t in (CHAT_TOOLS_ANTHROPIC if tools is None else tools)
+    }
 
     for round_num in range(MAX_TOOL_ROUNDS):
         if time.monotonic() > deadline:
@@ -482,6 +506,7 @@ async def _stream_openai_chat(
                 results_out=native_results,
                 port=port,
                 map_id=map_id,
+                allowed_tools=allowed_tool_names,
             ):
                 yield evt
 
@@ -519,6 +544,7 @@ async def _stream_openai_chat(
                 collected_actions,
                 port=port,
                 map_id=map_id,
+                allowed_tools=allowed_tool_names,
             ):
                 yield evt
 

--- a/backend/app/processing/ai/streaming.py
+++ b/backend/app/processing/ai/streaming.py
@@ -70,12 +70,15 @@ async def _execute_and_yield_tools(
     per-map (PERF-04 / Phase 274).
 
     allowed_tools, when provided, restricts which tool names may run: a call
-    whose name is outside the set is dropped before execution AND collection.
-    This enforces the read-only tool set for view-only callers even when a tool
-    call arrives via the XML fallback (parse_xml_tool_calls), which bypasses the
-    advertised tool schema. Native tool calls are always advertised-constrained
-    (allowed_tools == the advertised set), so they are never dropped here and the
-    caller's results_out↔tool_calls zip stays aligned.
+    whose name is outside the set is dropped before execution AND collection,
+    enforcing the read-only tool set for view-only callers even when a call
+    arrives via the XML fallback (parse_xml_tool_calls), which bypasses the
+    advertised tool schema. A dropped call still appends a refusal entry to
+    results_out (when provided) so the caller's results_out↔tool_calls zip stays
+    aligned — the OpenAI-native path zips the original calls/ids with results_out
+    to build the next round's tool messages, so a missing entry would misalign
+    tool_call ids or emit an unmatched call. The model receives an explicit
+    "not permitted" result instead.
     """
     for fn_name, fn_args in tool_calls:
         if allowed_tools is not None and fn_name not in allowed_tools:
@@ -84,6 +87,10 @@ async def _execute_and_yield_tools(
                 tool=fn_name,
                 allowed=sorted(allowed_tools),
             )
+            if results_out is not None:
+                results_out.append({"error": "Tool not permitted for this map."})
+            # Balance the tool_start the streaming loop already emitted for this call.
+            yield {"type": "tool_result", "tool": fn_name, "success": False}
             continue
         stage_events: list[dict] = []
         stage_cb = _make_stage_callback(fn_name, stage_events)

--- a/backend/app/processing/ai/streaming.py
+++ b/backend/app/processing/ai/streaming.py
@@ -27,7 +27,7 @@ from app.processing.ai.llm_loop import (
 )
 from app.processing.ai.schemas import ChatAction, ChatHistoryMessage, history_to_dicts
 from app.processing.ai.token_usage import record_token_usage
-from app.processing.ai.tools import CHAT_TOOLS_ANTHROPIC
+from app.processing.ai.tools import CHAT_TOOLS_ANTHROPIC, select_chat_tools
 from typing import TYPE_CHECKING
 
 from app.core.identity import Identity
@@ -114,6 +114,7 @@ async def _stream_anthropic_chat(
     client,
     port: "ProcessingPort",
     map_id: str | None = None,
+    tools: list | None = None,
 ) -> AsyncGenerator[dict, None]:
     """Stream Anthropic chat with tool-calling loop."""
     messages = build_history_messages(history)
@@ -123,7 +124,9 @@ async def _stream_anthropic_chat(
     cached_system = [
         {"type": "text", "text": system_prompt, "cache_control": {"type": "ephemeral"}}
     ]
-    cached_tools = add_tool_cache_control(CHAT_TOOLS_ANTHROPIC)
+    cached_tools = add_tool_cache_control(
+        CHAT_TOOLS_ANTHROPIC if tools is None else tools
+    )
 
     collected_actions: list[dict] = []
     total_input = 0
@@ -297,6 +300,7 @@ async def _stream_openai_chat(
     client,
     port: "ProcessingPort",
     map_id: str | None = None,
+    tools: list | None = None,
 ) -> AsyncGenerator[dict, None]:
     """Stream OpenAI-compatible chat with tool-calling loop."""
     messages = [{"role": "system", "content": system_prompt}]
@@ -341,7 +345,7 @@ async def _stream_openai_chat(
                     "parameters": t["input_schema"],
                 },
             }
-            for t in CHAT_TOOLS_ANTHROPIC
+            for t in (CHAT_TOOLS_ANTHROPIC if tools is None else tools)
         ]
         response_stream = await client.chat.completions.create(
             model=model,
@@ -567,16 +571,20 @@ async def stream_chat_edit(
     *,
     port: "ProcessingPort",
     map_id: str | None = None,
+    can_edit: bool = True,
 ) -> AsyncGenerator[dict, None]:
     """Main streaming orchestrator. Yields typed event dicts.
 
     map_id is forwarded so the schema-context cache partitions per-map
     (PERF-04 / Phase 274).
+
+    can_edit gates the tool set: a view-only caller gets read-only tools so the
+    AI answers questions but cannot emit edit actions (see select_chat_tools).
     """
     try:
         provider, model, runtime_config = await resolve_provider(db)
         system_prompt = build_chat_system_prompt(
-            layers, language=language, basemap_style=basemap_style
+            layers, language=language, basemap_style=basemap_style, can_edit=can_edit
         )
 
         history_dicts = history_to_dicts(history)
@@ -593,6 +601,7 @@ async def stream_chat_edit(
             history=history_dicts,
             port=port,
             map_id=map_id,
+            tools=select_chat_tools(can_edit),
         ):
             yield event
     except Exception as e:  # broad: SSE stream generator — any unhandled SDK/runtime error must yield a graceful error event

--- a/backend/app/processing/ai/tools.py
+++ b/backend/app/processing/ai/tools.py
@@ -330,3 +330,22 @@ CHAT_TOOLS_ANTHROPIC = [
         },
     },
 ]
+
+
+# Read-only chat tools: a user who can VIEW a map but not edit it (non-owner /
+# non-admin) may ask the AI questions about the map's data but must not be able
+# to change it. We enforce this by withholding every mutating tool from the
+# model — with only ``query_data`` available it can answer questions (sandboxed,
+# RBAC-scoped SELECTs) but has no tool to emit a style / filter / label /
+# visibility / opacity / add- or remove-layer edit. Edit *persistence* is
+# separately owner-gated at Save, so this is defense-in-depth, not the only gate.
+CHAT_TOOLS_READONLY = [t for t in CHAT_TOOLS_ANTHROPIC if t["name"] == "query_data"]
+
+
+def select_chat_tools(can_edit: bool) -> list:
+    """Return the chat tool set for a caller.
+
+    Full tool set when the caller may edit the map; read-only (``query_data``
+    only) when they may only view it.
+    """
+    return CHAT_TOOLS_ANTHROPIC if can_edit else CHAT_TOOLS_READONLY

--- a/backend/tests/test_ai_chat.py
+++ b/backend/tests/test_ai_chat.py
@@ -29,9 +29,15 @@ async def _get_user(session, username: str) -> User:
     return result.scalar_one()
 
 
-async def _create_map(session, *, created_by: uuid.UUID, name: str = "Test Map") -> Map:
+async def _create_map(
+    session,
+    *,
+    created_by: uuid.UUID,
+    name: str = "Test Map",
+    visibility: str = "private",
+) -> Map:
     """Create a minimal Map."""
-    map_obj = Map(name=name, created_by=created_by)
+    map_obj = Map(name=name, created_by=created_by, visibility=visibility)
     session.add(map_obj)
     await session.flush()
     await session.commit()
@@ -68,17 +74,8 @@ async def test_validate_rejects_invalid_map_id(
     assert exc_info.value.status_code == 404
 
 
-@pytest.mark.anyio
-async def test_validate_rejects_non_owner(
-    client: AsyncClient,
-    test_db_session,
-):
-    """Returns 403 when user doesn't own the map."""
-    session = test_db_session
-    admin = await _get_user(session, settings.geolens_admin_username)
-
-    map_obj = await _create_map(session, created_by=admin.id)
-
+async def _create_other_user(session) -> User:
+    """Create a fresh non-admin user that owns nothing."""
     other_user = User(
         username=f"other_{uuid.uuid4().hex[:8]}",
         password_hash="unused",
@@ -88,13 +85,71 @@ async def test_validate_rejects_non_owner(
     await session.flush()
     await session.commit()
     await session.refresh(other_user)
+    return other_user
+
+
+@pytest.mark.anyio
+async def test_validate_rejects_non_viewer_of_private_map(
+    client: AsyncClient,
+    test_db_session,
+):
+    """Returns 404 (no existence oracle) when the user cannot view a private map.
+
+    AI chat is gated on VIEW access, not ownership: a non-owner of a *private*
+    map cannot view it, so it is indistinguishable from a missing map (404).
+    """
+    session = test_db_session
+    admin = await _get_user(session, settings.geolens_admin_username)
+    map_obj = await _create_map(session, created_by=admin.id, visibility="private")
+    other_user = await _create_other_user(session)
 
     with pytest.raises(HTTPException) as exc_info:
         await _validate_chat_layers(
             session, other_user, str(map_obj.id), [], port=_default_port
         )
 
-    assert exc_info.value.status_code == 403
+    assert exc_info.value.status_code == 404
+
+
+@pytest.mark.anyio
+async def test_validate_allows_viewer_of_public_map_read_only(
+    client: AsyncClient,
+    test_db_session,
+):
+    """A non-owner who can VIEW a public map is allowed, but read-only (can_edit=False).
+
+    This is the builder-audit follow-up: anyone who can view a map may ask the
+    AI questions about it; only the owner/admin may use the AI to edit. can_edit
+    selects the read-only vs full tool set downstream.
+    """
+    session = test_db_session
+    admin = await _get_user(session, settings.geolens_admin_username)
+    map_obj = await _create_map(session, created_by=admin.id, visibility="public")
+    other_user = await _create_other_user(session)
+
+    validated, _basemap, can_edit = await _validate_chat_layers(
+        session, other_user, str(map_obj.id), [], port=_default_port
+    )
+
+    assert validated == []
+    assert can_edit is False
+
+
+@pytest.mark.anyio
+async def test_validate_owner_can_edit(
+    client: AsyncClient,
+    test_db_session,
+):
+    """The map owner gets can_edit=True (full AI tool set)."""
+    session = test_db_session
+    admin = await _get_user(session, settings.geolens_admin_username)
+    map_obj = await _create_map(session, created_by=admin.id, visibility="private")
+
+    _validated, _basemap, can_edit = await _validate_chat_layers(
+        session, admin, str(map_obj.id), [], port=_default_port
+    )
+
+    assert can_edit is True
 
 
 @pytest.mark.anyio
@@ -115,7 +170,7 @@ async def test_validate_overwrites_client_table_name(
     )
 
     layer = _make_chat_layer(dataset, table_name_override="fake_injected_table")
-    validated, _basemap = await _validate_chat_layers(
+    validated, _basemap, _can_edit = await _validate_chat_layers(
         session, admin, str(map_obj.id), [layer], port=_default_port
     )
 
@@ -153,7 +208,7 @@ async def test_validate_filters_inaccessible_dataset(
     viewer_map = await _create_map(session, created_by=viewer.id, name="Viewer Map")
 
     layer = _make_chat_layer(private_ds)
-    validated, _basemap = await _validate_chat_layers(
+    validated, _basemap, _can_edit = await _validate_chat_layers(
         session, viewer, str(viewer_map.id), [layer], port=_default_port
     )
 

--- a/backend/tests/test_chat_streaming.py
+++ b/backend/tests/test_chat_streaming.py
@@ -367,3 +367,56 @@ async def test_stream_ai_disabled(client: AsyncClient, admin_auth_header: dict):
     assert resp.status_code == 200
     assert "event: error" in resp.text
     assert "AI features are disabled by administrator" in resp.text
+
+
+@pytest.mark.anyio
+async def test_execute_and_yield_tools_drops_disallowed_for_readonly(monkeypatch):
+    """A tool call outside allowed_tools is dropped before execution AND collection.
+
+    Covers the read-only enforcement backstop for the XML fallback path: a
+    view-only caller (allowed_tools={"query_data"}) whose model emits a mutating
+    set_style call must not have it executed or collected into a ChatAction.
+    """
+    from app.processing.ai import streaming
+
+    executed: list[str] = []
+    collected_names: list[str] = []
+
+    async def fake_exec(name, *args, **kwargs):
+        executed.append(name)
+        return {"ok": True}
+
+    def fake_collect(name, tool_input, result):
+        collected_names.append(name)
+        return {"type": name}
+
+    monkeypatch.setattr(streaming, "_execute_chat_tool", fake_exec)
+    monkeypatch.setattr(streaming, "_collect_chat_action", fake_collect)
+
+    collected_actions: list[dict] = []
+    events = [
+        evt
+        async for evt in streaming._execute_and_yield_tools(
+            [
+                ("set_style", {"layer_id": "x"}),
+                ("query_data", {"question": "how many?"}),
+            ],
+            None,  # session — unused (executor patched)
+            None,  # user
+            set(),  # user_roles
+            [],  # layers
+            collected_actions,
+            port=None,
+            map_id=None,
+            allowed_tools={"query_data"},
+        )
+    ]
+
+    # set_style was dropped; only query_data ran and was collected.
+    assert executed == ["query_data"]
+    assert collected_names == ["query_data"]
+    assert [a["type"] for a in collected_actions] == ["query_data"]
+    # Exactly one tool_result event (for query_data); none for the dropped tool.
+    assert [e for e in events if e.get("type") == "tool_result"] == [
+        {"type": "tool_result", "tool": "query_data", "success": True}
+    ]

--- a/backend/tests/test_chat_streaming.py
+++ b/backend/tests/test_chat_streaming.py
@@ -100,7 +100,7 @@ async def test_stream_returns_sse_events(client: AsyncClient, admin_auth_header:
         patch(
             "app.processing.ai.router._validate_chat_layers",
             new_callable=AsyncMock,
-            return_value=(CHAT_BODY["layers"], None),
+            return_value=(CHAT_BODY["layers"], None, True),
         ),
         patch(
             "app.processing.ai.router.stream_chat_edit", side_effect=_mock_stream_tokens
@@ -131,7 +131,7 @@ async def test_non_streaming_fallback(client: AsyncClient, admin_auth_header: di
         patch(
             "app.processing.ai.router._validate_chat_layers",
             new_callable=AsyncMock,
-            return_value=(CHAT_BODY["layers"], None),
+            return_value=(CHAT_BODY["layers"], None, True),
         ),
         patch(
             "app.processing.ai.router.chat_edit_map", new_callable=AsyncMock
@@ -152,7 +152,7 @@ async def test_tool_progress_events(client: AsyncClient, admin_auth_header: dict
         patch(
             "app.processing.ai.router._validate_chat_layers",
             new_callable=AsyncMock,
-            return_value=(CHAT_BODY["layers"], None),
+            return_value=(CHAT_BODY["layers"], None, True),
         ),
         patch(
             "app.processing.ai.router.stream_chat_edit", side_effect=_mock_stream_tools
@@ -210,7 +210,7 @@ async def test_query_data_stage_events(client: AsyncClient, admin_auth_header: d
         patch(
             "app.processing.ai.router._validate_chat_layers",
             new_callable=AsyncMock,
-            return_value=(body["layers"], None),
+            return_value=(body["layers"], None, True),
         ),
         patch(
             "app.processing.ai.router.stream_chat_edit",
@@ -313,7 +313,7 @@ async def test_show_query_result_action_in_stream(
         patch(
             "app.processing.ai.router._validate_chat_layers",
             new_callable=AsyncMock,
-            return_value=(body["layers"], None),
+            return_value=(body["layers"], None, True),
         ),
         patch(
             "app.processing.ai.router.stream_chat_edit",

--- a/backend/tests/test_chat_streaming.py
+++ b/backend/tests/test_chat_streaming.py
@@ -375,7 +375,9 @@ async def test_execute_and_yield_tools_drops_disallowed_for_readonly(monkeypatch
 
     Covers the read-only enforcement backstop for the XML fallback path: a
     view-only caller (allowed_tools={"query_data"}) whose model emits a mutating
-    set_style call must not have it executed or collected into a ChatAction.
+    set_style call must not have it executed or collected into a ChatAction. A
+    dropped call still records a refusal in results_out so the OpenAI-native
+    tool_call_id zip stays aligned.
     """
     from app.processing.ai import streaming
 
@@ -394,6 +396,7 @@ async def test_execute_and_yield_tools_drops_disallowed_for_readonly(monkeypatch
     monkeypatch.setattr(streaming, "_collect_chat_action", fake_collect)
 
     collected_actions: list[dict] = []
+    results_out: list[dict] = []
     events = [
         evt
         async for evt in streaming._execute_and_yield_tools(
@@ -406,6 +409,7 @@ async def test_execute_and_yield_tools_drops_disallowed_for_readonly(monkeypatch
             set(),  # user_roles
             [],  # layers
             collected_actions,
+            results_out=results_out,
             port=None,
             map_id=None,
             allowed_tools={"query_data"},
@@ -416,7 +420,16 @@ async def test_execute_and_yield_tools_drops_disallowed_for_readonly(monkeypatch
     assert executed == ["query_data"]
     assert collected_names == ["query_data"]
     assert [a["type"] for a in collected_actions] == ["query_data"]
-    # Exactly one tool_result event (for query_data); none for the dropped tool.
+    # results_out stays 1:1 with the two input tool calls so the OpenAI-native
+    # tool_call_id zip cannot misalign: a refusal for the dropped call, then the
+    # real result.
+    assert results_out == [
+        {"error": "Tool not permitted for this map."},
+        {"ok": True},
+    ]
+    # A tool_result event for BOTH calls: failure for the dropped one, success
+    # for query_data.
     assert [e for e in events if e.get("type") == "tool_result"] == [
-        {"type": "tool_result", "tool": "query_data", "success": True}
+        {"type": "tool_result", "tool": "set_style", "success": False},
+        {"type": "tool_result", "tool": "query_data", "success": True},
     ]

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -763,10 +763,15 @@ def test_decomposed_service_modules_stay_within_size_budgets() -> None:
         "backend/app/modules/catalog/search/service.py": 80,
         "backend/app/modules/catalog/datasets/domain/service.py": 110,
         # Phase 276 CODE-02 — chat_service.py is now a facade re-exporting
-        # from chat_*.py sub-modules. 400 is the established Phase-226 cap
+        # from chat_*.py sub-modules. 400 was the established Phase-226 cap
         # for facade modules that retain a meaty orchestrator + system-prompt
         # builder.
-        "backend/app/processing/ai/chat_service.py": 400,
+        # builder-audit follow-up (read-only AI access model): +36 LOC —
+        # build_chat_system_prompt gains a can_edit read-only directive, and
+        # chat_edit_map gains the per-turn allowed-tool guard on the tool
+        # executor + action collector (so a view-only caller cannot execute or
+        # collect a mutating tool). Cap raised 400 -> 440 (~4 LOC headroom).
+        "backend/app/processing/ai/chat_service.py": 440,
     }
     private_service_default_line_budget = 350
     private_service_line_budget_allowlist = {

--- a/frontend/src/components/builder/ChatPanel.tsx
+++ b/frontend/src/components/builder/ChatPanel.tsx
@@ -576,9 +576,17 @@ export function ChatPanel({
           break;
         }
         case 'error':
-          // Model emitted an error event mid-stream (tool-loop exhausted,
-          // deadline). Throw a typed sentinel so the catch shows an inline
-          // error instead of re-calling the LLM via the non-streaming path.
+          // A pre-flight HTTPException from the SSE endpoint carries a numeric
+          // `status` (e.g. 403 forbidden, 503 unavailable) — the SSE body is
+          // always a 200 stream, so the status would otherwise be lost. Surface
+          // it as an ApiError so the catch classifies it like the non-streaming
+          // path (banner / inline, no blind retry) rather than a generic
+          // retryable failure. A model-emitted error mid-stream (tool-loop
+          // exhausted, deadline) has no status → StreamModelError, which shows
+          // inline without re-calling the LLM via the non-streaming path.
+          if (typeof data.status === 'number') {
+            throw new ApiError(typeof data.message === 'string' ? data.message : '', data.status);
+          }
           throw new StreamModelError(typeof data.message === 'string' ? data.message : '');
       }
     }

--- a/frontend/src/components/builder/__tests__/ChatPanel.test.tsx
+++ b/frontend/src/components/builder/__tests__/ChatPanel.test.tsx
@@ -279,6 +279,25 @@ describe('ChatPanel', () => {
     expect(mockSendChat).not.toHaveBeenCalled();
   });
 
+  it('a streamed error event WITH an HTTP status classifies by status (403 → forbidden banner), not a generic retry', async () => {
+    // A pre-flight HTTPException from the SSE endpoint carries a numeric `status`
+    // (the SSE body is always a 200 stream). It must classify like the
+    // non-streaming path — 403 → sticky forbidden banner — instead of collapsing
+    // to the generic retryable "Something went wrong" inline bubble. It must also
+    // NOT fall through to the non-streaming retry (no double LLM call).
+    mockStreamChat.mockImplementation(async function* () {
+      yield { event: 'error', data: { message: 'You do not own this map', status: 403 } };
+    });
+
+    const user = userEvent.setup();
+    renderPanel();
+    await typeAndSend(user, 'edit a map I cannot edit');
+
+    const banner = await screen.findByRole('alert');
+    expect(banner).toHaveTextContent(/permission/i);
+    expect(mockSendChat).not.toHaveBeenCalled();
+  });
+
   it('ignores malformed style paint payloads instead of applying indexed string keys', async () => {
     mockStreamChat.mockImplementation(async function* () {
       yield {


### PR DESCRIPTION
## Summary

The map builder's **AI assistant now works for anyone who can view a map**, not just the owner. You can ask the assistant questions about a map's data on any map you can see; using the AI to **edit** a map stays limited to the owner, and AI-suggested changes still only persist when the owner saves.

## Root cause

AI builder chat (`/ai/chat/`, `/ai/chat/stream/`) was gated on map **ownership** — `_validate_chat_layers` raised `403 "You do not own this map"` for any map the caller didn't own. The SSE streaming path wraps every pre-flight `HTTPException` into a generic SSE `error` event (the body is always a 200 stream), so the frontend lost the status and rendered the misleading, **retryable** *"Something went wrong. Please try again."* — with a Retry button that could never succeed.

This surfaced on the demo: a `guest` (role `editor`, owns no maps) opening a showcase map in the builder and using "Ask AI" hit this every time.

## Why ownership was the wrong guard

AI chat is **read-only with respect to map state** — edit actions are applied client-side in the builder and only persist at **Save**, which is already owner-gated. And data access is independently bounded by `build_table_allowlist` (RBAC `apply_visibility_filter`), so a caller can only ever query datasets they can already see. The map-ownership check protected nothing the allowlist + Save guard didn't already cover.

## Change

- **`_validate_chat_layers`** now gates on **view access** (`_check_map_read_access` → 404 if not viewable, no existence oracle) and returns `can_edit` (`_can_edit_map`, owner-or-admin — the exact Save boundary) instead of raising a 403.
- **`can_edit` selects the AI tool set** via the new `select_chat_tools()`: owners get the full toolbox; viewers get **`query_data` only**, so the model literally cannot emit an edit action. `build_chat_system_prompt(can_edit=False)` adds a read-only directive so the assistant explains it can only answer questions on a map you don't own.
- **SSE error events now carry the HTTP `status`**, and the frontend (`ChatPanel.consumeStream`) surfaces a status-bearing pre-flight error as an `ApiError` — so a 403/503 classifies honestly (clear, non-retryable) instead of the generic retry message. Model-emitted mid-stream errors (tool-loop/deadline, no status) still map to the inline `StreamModelError` path.

## Verification

- **Live (local stack):** a non-owner editor on a public map gets a real streamed answer — *"…you're viewing it with read-only permissions… I'm happy to answer questions about the data…"* — with **`actions: []`** (no edits emitted). A non-viewer on a private map returns `{"message":"Map not found","status":404}`. Owner behavior unchanged.
- **Tests:** new cases for public read-only access, owner `can_edit`, the 404 view-access semantics, and the SSE-status → forbidden-banner mapping. `test_ai_chat.py` + `test_chat_streaming.py` (25 backend) and `ChatPanel.test.tsx` (41 frontend) green; `ruff`, `eslint`, and `tsc -b` clean.

## Notes / out of scope

- The builder still opens editable for non-owners with no guard (manual edits apply locally and Save 403s); this PR makes the **AI** path coherent (read-only) but does not add a builder-wide ownership gate — that's a separate UX decision.
