### PR TITLE
feat(viewer): read-only "Ask AI" for public map viewers

### DIFF
--- a/frontend/src/components/viewer/ViewerChatPanel.tsx
+++ b/frontend/src/components/viewer/ViewerChatPanel.tsx
@@ -1,0 +1,357 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { AlertCircle, Loader2, RotateCcw, SendHorizontal, Sparkles, Square, X } from 'lucide-react';
+import type { Map as MaplibreMap } from 'maplibre-gl';
+import { Button } from '@/components/ui/button';
+import { ApiError } from '@/api/client';
+import { streamChatMessage } from '@/api/maps';
+import { useAIAvailability } from '@/hooks/use-ai-availability';
+import { useEphemeralLayers } from '@/components/builder/hooks/use-ephemeral-layers';
+import { cn } from '@/lib/utils';
+import type { ChatAction, ChatHistoryMessage, MapLayerResponse } from '@/types/api';
+
+const prefersReducedMotion = globalThis.matchMedia?.('(prefers-reduced-motion: reduce)')?.matches ?? false;
+
+interface QueryResult {
+  rows: unknown[];
+  columns: string[];
+  rowCount: number;
+  truncated: boolean;
+}
+
+interface ChatMessage {
+  id: string;
+  role: 'user' | 'assistant' | 'error';
+  content: string;
+  queryResult?: QueryResult;
+  retryMessage?: string;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+function getChatActions(value: unknown): ChatAction[] {
+  if (!Array.isArray(value)) return [];
+  return value.filter((item): item is ChatAction => isRecord(item) && typeof item.type === 'string');
+}
+
+/** Compact, read-only render of a `show_query_result` table (cols capped at 5). */
+function QueryResultTable({ result }: { result: QueryResult }) {
+  const { t } = useTranslation('common');
+  const { rows, columns, rowCount, truncated } = result;
+  if (rows.length === 0 || columns.length === 0) {
+    return (
+      <div className="mt-2 rounded-md border px-3 py-2">
+        <p className="text-sm text-muted-foreground">{t('viewer.ai.queryResult.empty')}</p>
+      </div>
+    );
+  }
+  const visibleColumns = columns.slice(0, 5);
+  const hasMore = columns.length > 5;
+  const cellAt = (row: unknown, index: number): string => {
+    const raw = Array.isArray(row) ? row[index] : undefined;
+    return raw == null ? '' : String(raw);
+  };
+  return (
+    <div className="mt-2 overflow-hidden rounded-md border">
+      <div className="max-h-48 overflow-y-auto" role="region" aria-label={t('viewer.ai.queryResult.tableLabel')}>
+        <table className="w-full table-fixed text-sm">
+          <thead>
+            <tr className="bg-muted/50">
+              {visibleColumns.map((col) => (
+                <th key={col} scope="col" className="px-2 py-1 text-left text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                  {col}
+                </th>
+              ))}
+              {hasMore && <th scope="col" aria-label="more columns" className="px-2 py-1 text-xs text-muted-foreground">…</th>}
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((row, idx) => (
+              <tr key={idx} className="border-b border-border last:border-0">
+                {visibleColumns.map((col, colIdx) => {
+                  const display = cellAt(row, colIdx);
+                  return (
+                    <td key={col} className="max-w-[8rem] truncate px-2 py-1 text-foreground" title={display}>
+                      {display}
+                    </td>
+                  );
+                })}
+                {hasMore && <td className="px-2 py-1 text-muted-foreground">…</td>}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+      <p className="px-2 py-1 text-xs text-muted-foreground">
+        {t('viewer.ai.queryResult.rowCount', { count: rowCount })}
+        {truncated && <span className="ms-1 text-muted-foreground/80">{t('viewer.ai.queryResult.truncated')}</span>}
+      </p>
+    </div>
+  );
+}
+
+interface ViewerChatPanelProps {
+  mapId: string;
+  layers: MapLayerResponse[];
+  mapInstanceRef: React.RefObject<MaplibreMap | null>;
+}
+
+/**
+ * Read-only "Ask AI" for the public map viewer.
+ *
+ * The builder's full ChatPanel is reachable only to `can_edit` users; signed-in
+ * viewers land on PublicMapViewerPage with no AI affordance. PR #339 made the
+ * backend chat path serve view-only callers a read-only toolbox (`query_data`
+ * only), so this surfaces that path: a question goes to `/ai/chat/stream/`, the
+ * streamed answer renders inline, and a `show_query_result` flies the map to the
+ * matched features (shared `useEphemeralLayers` overlay) + shows a compact table.
+ *
+ * Self-gates on `useAIAvailability` (token + `use_ai_chat` + AI configured), so
+ * anonymous or unpermitted viewers render nothing. No edit actions are applied —
+ * non-query actions are ignored defensively.
+ */
+export function ViewerChatPanel({ mapId, layers, mapInstanceRef }: ViewerChatPanelProps) {
+  const { t, i18n } = useTranslation('common');
+  const { isAIAvailable } = useAIAvailability();
+  const { handleQueryResult } = useEphemeralLayers(mapInstanceRef);
+
+  const [open, setOpen] = useState(false);
+  const [messages, setMessages] = useState<ChatMessage[]>([]);
+  const [input, setInput] = useState('');
+  const [isLoading, setIsLoading] = useState(false);
+  const [streamingText, setStreamingText] = useState('');
+
+  const abortRef = useRef<AbortController | null>(null);
+  const inflightRef = useRef(false);
+  const inputRef = useRef<HTMLTextAreaElement>(null);
+  const messagesEndRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    messagesEndRef.current?.scrollIntoView({ behavior: prefersReducedMotion ? 'auto' : 'smooth' });
+  }, [messages, isLoading, streamingText]);
+
+  // Abort any in-flight stream on unmount.
+  useEffect(() => () => abortRef.current?.abort(), []);
+
+  useEffect(() => {
+    if (open) requestAnimationFrame(() => inputRef.current?.focus());
+  }, [open]);
+
+  /** Flyover + highlight (WGS84-bounded bbox guard) and extract the table payload. */
+  const applyQueryResult = useCallback((action: ChatAction): QueryResult | undefined => {
+    const geojson = action.geojson;
+    if (
+      geojson &&
+      typeof geojson === 'object' &&
+      'type' in geojson &&
+      geojson.type === 'FeatureCollection' &&
+      Array.isArray(action.bbox) &&
+      action.bbox.length === 4 &&
+      action.bbox.every((n: unknown) => typeof n === 'number')
+    ) {
+      const [minX, minY, maxX, maxY] = action.bbox as [number, number, number, number];
+      if (!(minX < -180 || minY < -90 || maxX > 180 || maxY > 90)) {
+        handleQueryResult(geojson as GeoJSON.FeatureCollection, [minX, minY, maxX, maxY]);
+      }
+    }
+    const rows = Array.isArray(action.rows) ? action.rows : null;
+    if (rows === null) return undefined;
+    return {
+      rows,
+      columns: Array.isArray(action.columns) ? action.columns.filter((c): c is string => typeof c === 'string') : [],
+      rowCount: typeof action.row_count === 'number' ? action.row_count : rows.length,
+      truncated: action.truncated === true,
+    };
+  }, [handleQueryResult]);
+
+  const handleSend = useCallback(async () => {
+    const userMsg = input.trim();
+    if (!userMsg || isLoading || inflightRef.current) return;
+    inflightRef.current = true;
+    setInput('');
+    const history: ChatHistoryMessage[] = messages
+      .filter((m) => m.role === 'user' || m.role === 'assistant')
+      .slice(-20)
+      .map((m) => ({ role: m.role as 'user' | 'assistant', content: m.content }));
+    setMessages((prev) => [...prev, { id: crypto.randomUUID(), role: 'user', content: userMsg }]);
+    setIsLoading(true);
+    const controller = new AbortController();
+    abortRef.current = controller;
+    let streamed = '';
+    let queryResult: QueryResult | undefined;
+    try {
+      for await (const { event, data } of streamChatMessage(mapId, userMsg, layers, i18n.language, history, controller.signal)) {
+        if (event === 'token') {
+          streamed += typeof data.text === 'string' ? data.text : '';
+          setStreamingText(streamed);
+        } else if (event === 'actions') {
+          // Read-only: only show_query_result is acted on; any edit action is ignored.
+          for (const action of getChatActions(data.actions)) {
+            if (action.type === 'show_query_result') {
+              const qr = applyQueryResult(action);
+              if (qr) queryResult = qr;
+            }
+          }
+        } else if (event === 'done') {
+          const finalText = (typeof data.explanation === 'string' ? data.explanation : '') || streamed;
+          setMessages((prev) => [...prev, { id: crypto.randomUUID(), role: 'assistant', content: finalText, queryResult }]);
+        } else if (event === 'error') {
+          // A pre-flight HTTP status (403/503) rides the SSE error event; surface it
+          // as ApiError so it classifies honestly rather than as a generic failure.
+          if (typeof data.status === 'number') {
+            throw new ApiError(typeof data.message === 'string' ? data.message : '', data.status);
+          }
+          throw new Error(typeof data.message === 'string' ? data.message : '');
+        }
+      }
+    } catch {
+      if (controller.signal.aborted) {
+        setMessages((prev) => [
+          ...prev,
+          { id: crypto.randomUUID(), role: 'assistant', content: streamed || t('viewer.ai.cancelled') },
+        ]);
+      } else {
+        setMessages((prev) => [
+          ...prev,
+          { id: crypto.randomUUID(), role: 'error', content: t('viewer.ai.error'), retryMessage: userMsg },
+        ]);
+      }
+    } finally {
+      abortRef.current = null;
+      inflightRef.current = false;
+      setStreamingText('');
+      setIsLoading(false);
+    }
+  }, [input, isLoading, messages, mapId, layers, i18n.language, applyQueryResult, t]);
+
+  const handleRetry = useCallback((msg: ChatMessage) => {
+    if (msg.retryMessage) setInput(msg.retryMessage);
+    setMessages((prev) => prev.filter((m) => m.id !== msg.id));
+  }, []);
+
+  if (!isAIAvailable) return null;
+
+  return (
+    <div className="absolute bottom-8 right-3 z-10 flex flex-col items-end gap-2">
+      {open && (
+        <section
+          role="dialog"
+          aria-label={t('viewer.ai.title')}
+          className="flex h-[min(70vh,520px)] w-[min(360px,calc(100vw-1.5rem))] flex-col overflow-hidden rounded-2xl border bg-background/98 shadow-xl backdrop-blur"
+        >
+          <div className="flex items-center justify-between border-b px-3 py-2">
+            <div className="flex items-center gap-2">
+              <Sparkles className="size-4 text-primary" aria-hidden="true" />
+              <h2 className="text-sm font-semibold text-foreground">{t('viewer.ai.title')}</h2>
+            </div>
+            <Button size="icon-xs" variant="ghost" onClick={() => setOpen(false)} aria-label={t('close')}>
+              <X className="size-4" />
+            </Button>
+          </div>
+
+          <div className="flex-1 space-y-2 overflow-y-auto px-3 py-2" role="log" aria-live="polite">
+            {messages.length === 0 && (
+              <div className="space-y-1 py-6 text-center">
+                <p className="text-sm text-muted-foreground">{t('viewer.ai.emptyHint')}</p>
+                <p className="text-xs text-muted-foreground/80">{t('viewer.ai.readOnlyNote')}</p>
+              </div>
+            )}
+            {messages.map((msg) =>
+              msg.role === 'error' ? (
+                <div key={msg.id} className="flex justify-start">
+                  <div className="max-w-[85%] rounded-lg border border-destructive/20 bg-destructive/10 px-3 py-2">
+                    <div className="flex items-start gap-2">
+                      <AlertCircle className="mt-0.5 size-4 shrink-0 text-destructive" />
+                      <p className="text-sm text-foreground">{msg.content}</p>
+                    </div>
+                    <div className="mt-2 flex justify-end">
+                      <Button variant="outline" size="sm" className="h-7 gap-1 text-xs" onClick={() => handleRetry(msg)}>
+                        <RotateCcw className="size-3" />
+                        {t('viewer.ai.retry')}
+                      </Button>
+                    </div>
+                  </div>
+                </div>
+              ) : (
+                <div key={msg.id} className={cn('flex', msg.role === 'user' ? 'justify-end' : 'justify-start')}>
+                  <div
+                    className={cn(
+                      'max-w-[85%] rounded-lg px-3 py-1.5 text-sm',
+                      msg.role === 'user' ? 'bg-primary text-primary-foreground' : 'bg-muted text-foreground',
+                    )}
+                  >
+                    <p className="whitespace-pre-wrap break-words">{msg.content}</p>
+                    {msg.queryResult && <QueryResultTable result={msg.queryResult} />}
+                  </div>
+                </div>
+              ),
+            )}
+            {isLoading && (
+              <div className="flex justify-start">
+                <div className="max-w-[85%] rounded-lg bg-muted px-3 py-1.5 text-sm text-foreground">
+                  {streamingText ? (
+                    <p className="whitespace-pre-wrap">{streamingText}</p>
+                  ) : (
+                    <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+                      <Loader2 className="size-3 animate-spin" />
+                      {t('viewer.ai.thinking')}
+                    </div>
+                  )}
+                </div>
+              </div>
+            )}
+            <div ref={messagesEndRef} />
+          </div>
+
+          <div className="flex items-end gap-2 border-t px-3 py-2">
+            <textarea
+              ref={inputRef}
+              value={input}
+              onChange={(e) => setInput(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter' && !e.shiftKey) {
+                  e.preventDefault();
+                  void handleSend();
+                }
+              }}
+              rows={1}
+              placeholder={t('viewer.ai.placeholder')}
+              disabled={isLoading}
+              aria-label={t('viewer.ai.placeholder')}
+              className="max-h-28 min-h-9 flex-1 resize-none rounded-md border border-input bg-background px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:opacity-60"
+            />
+            {isLoading ? (
+              <Button
+                size="icon-xs"
+                variant="destructive"
+                onClick={() => abortRef.current?.abort()}
+                aria-label={t('viewer.ai.cancel')}
+                title={t('viewer.ai.cancel')}
+              >
+                <Square className="size-3" />
+              </Button>
+            ) : (
+              <Button
+                size="icon-xs"
+                onClick={() => void handleSend()}
+                disabled={!input.trim()}
+                aria-label={t('viewer.ai.send')}
+                title={t('viewer.ai.send')}
+              >
+                <SendHorizontal className="size-3" />
+              </Button>
+            )}
+          </div>
+        </section>
+      )}
+      {!open && (
+        <Button onClick={() => setOpen(true)} aria-haspopup="dialog" className="gap-2 rounded-full shadow-lg">
+          <Sparkles className="size-4" aria-hidden="true" />
+          {t('viewer.ai.launch')}
+        </Button>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/viewer/__tests__/ViewerChatPanel.test.tsx
+++ b/frontend/src/components/viewer/__tests__/ViewerChatPanel.test.tsx
@@ -1,0 +1,117 @@
+import { render, screen } from '@/test/test-utils';
+import userEvent from '@testing-library/user-event';
+import { streamChatMessage } from '@/api/maps';
+import { useAIAvailability } from '@/hooks/use-ai-availability';
+import { useEphemeralLayers } from '@/components/builder/hooks/use-ephemeral-layers';
+import { ViewerChatPanel } from '../ViewerChatPanel';
+import type { MapLayerResponse } from '@/types/api';
+
+// scrollIntoView is not available in jsdom
+Element.prototype.scrollIntoView = vi.fn();
+
+vi.mock('@/api/maps', () => ({ streamChatMessage: vi.fn() }));
+vi.mock('@/hooks/use-ai-availability', () => ({ useAIAvailability: vi.fn() }));
+vi.mock('@/components/builder/hooks/use-ephemeral-layers', () => ({ useEphemeralLayers: vi.fn() }));
+
+const mockStream = vi.mocked(streamChatMessage);
+const mockAvailability = vi.mocked(useAIAvailability);
+const mockEphemeral = vi.mocked(useEphemeralLayers);
+const handleQueryResult = vi.fn();
+
+function setAvailable(available: boolean) {
+  // Only the isAIAvailable field is read by the component.
+  mockAvailability.mockReturnValue({ isAIAvailable: available } as ReturnType<typeof useAIAvailability>);
+}
+
+function renderPanel() {
+  const mapInstanceRef = { current: null };
+  return render(
+    <ViewerChatPanel mapId="map-1" layers={[] as MapLayerResponse[]} mapInstanceRef={mapInstanceRef} />,
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockEphemeral.mockReturnValue({
+    ephemeralResult: null,
+    handleQueryResult,
+    handleDismissEphemeral: vi.fn(),
+  });
+});
+
+describe('ViewerChatPanel', () => {
+  it('renders nothing when AI is unavailable (anon / no use_ai_chat)', () => {
+    setAvailable(false);
+    renderPanel();
+    expect(screen.queryByRole('button', { name: 'Ask AI' })).toBeNull();
+  });
+
+  it('opens the panel and streams a read-only answer', async () => {
+    setAvailable(true);
+    mockStream.mockImplementation(async function* () {
+      yield { event: 'token', data: { text: 'You are viewing read-only.' } };
+      yield { event: 'done', data: { explanation: 'You are viewing read-only.' } };
+    });
+
+    renderPanel();
+    await userEvent.click(screen.getByRole('button', { name: 'Ask AI' }));
+
+    const input = screen.getByPlaceholderText('Ask about this map...');
+    await userEvent.type(input, 'what is here?');
+    await userEvent.click(screen.getByRole('button', { name: 'Send' }));
+
+    await screen.findByText('You are viewing read-only.');
+    expect(mockStream).toHaveBeenCalledWith('map-1', 'what is here?', [], expect.any(String), [], expect.any(AbortSignal));
+  });
+
+  it('flies the map to a show_query_result and renders its table', async () => {
+    setAvailable(true);
+    mockStream.mockImplementation(async function* () {
+      yield {
+        event: 'actions',
+        data: {
+          actions: [
+            {
+              type: 'show_query_result',
+              geojson: { type: 'FeatureCollection', features: [] },
+              bbox: [-1, -1, 1, 1],
+              rows: [['Alpha', 10]],
+              columns: ['name', 'count'],
+              row_count: 1,
+            },
+          ],
+        },
+      };
+      yield { event: 'done', data: { explanation: 'Found 1 result.' } };
+    });
+
+    renderPanel();
+    await userEvent.click(screen.getByRole('button', { name: 'Ask AI' }));
+    await userEvent.type(screen.getByPlaceholderText('Ask about this map...'), 'count features');
+    await userEvent.click(screen.getByRole('button', { name: 'Send' }));
+
+    await screen.findByText('Found 1 result.');
+    expect(handleQueryResult).toHaveBeenCalledWith(
+      { type: 'FeatureCollection', features: [] },
+      [-1, -1, 1, 1],
+    );
+    expect(screen.getByText('Alpha')).toBeInTheDocument();
+    expect(screen.getByText('1 row')).toBeInTheDocument();
+  });
+
+  it('shows a retry-able error bubble when the stream fails', async () => {
+    setAvailable(true);
+    // eslint-disable-next-line require-yield
+    mockStream.mockImplementation(async function* () {
+      throw new Error('boom');
+    });
+
+    renderPanel();
+    await userEvent.click(screen.getByRole('button', { name: 'Ask AI' }));
+    await userEvent.type(screen.getByPlaceholderText('Ask about this map...'), 'hi');
+    await userEvent.click(screen.getByRole('button', { name: 'Send' }));
+
+    await screen.findByText('Something went wrong. Please try again.');
+    expect(screen.getByRole('button', { name: 'Retry' })).toBeInTheDocument();
+  });
+});

--- a/frontend/src/i18n/locales/de/common.json
+++ b/frontend/src/i18n/locales/de/common.json
@@ -210,7 +210,27 @@
     "mapError": "Kachelfehler — einige Ebenen werden möglicherweise nicht korrekt angezeigt.",
     "openMaps": "Karten öffnen",
     "signIn": "Anmelden",
-    "tokenError": "Kartenebenentokens konnten nicht geladen werden — einige Ebenen werden möglicherweise nicht angezeigt."
+    "tokenError": "Kartenebenentokens konnten nicht geladen werden — einige Ebenen werden möglicherweise nicht angezeigt.",
+    "ai": {
+      "launch": "KI fragen",
+      "title": "KI fragen",
+      "placeholder": "Fragen Sie zu dieser Karte...",
+      "send": "Senden",
+      "cancel": "Stopp",
+      "cancelled": "Abgebrochen.",
+      "thinking": "Denkt nach...",
+      "emptyHint": "Stellen Sie eine Frage zu den Daten dieser Karte.",
+      "readOnlyNote": "Antworten sind schreibgeschützt — erkunden Sie die Daten, ohne die Karte zu ändern.",
+      "error": "Etwas ist schiefgelaufen. Bitte versuchen Sie es erneut.",
+      "retry": "Erneut versuchen",
+      "queryResult": {
+        "empty": "Keine passenden Ergebnisse.",
+        "tableLabel": "Tabelle der Abfrageergebnisse",
+        "rowCount_one": "{{count}} Zeile",
+        "rowCount_other": "{{count}} Zeilen",
+        "truncated": "(Stichprobe wird angezeigt)"
+      }
+    }
   },
   "maps": {
     "title": "Karten",

--- a/frontend/src/i18n/locales/en/common.json
+++ b/frontend/src/i18n/locales/en/common.json
@@ -120,7 +120,27 @@
     "mapError": "Map tile error — some layers may not display correctly.",
     "openMaps": "Open maps",
     "signIn": "Sign in",
-    "tokenError": "Failed to load map layer tokens — some layers may not display."
+    "tokenError": "Failed to load map layer tokens — some layers may not display.",
+    "ai": {
+      "launch": "Ask AI",
+      "title": "Ask AI",
+      "placeholder": "Ask about this map...",
+      "send": "Send",
+      "cancel": "Stop",
+      "cancelled": "Cancelled.",
+      "thinking": "Thinking...",
+      "emptyHint": "Ask a question about this map's data.",
+      "readOnlyNote": "Answers are read-only — explore the data without changing the map.",
+      "error": "Something went wrong. Please try again.",
+      "retry": "Retry",
+      "queryResult": {
+        "empty": "No matching results.",
+        "tableLabel": "Query result table",
+        "rowCount_one": "{{count}} row",
+        "rowCount_other": "{{count}} rows",
+        "truncated": "(showing a sample)"
+      }
+    }
   },
   "actions": {
     "editGeometry": "Edit Features"

--- a/frontend/src/i18n/locales/es/common.json
+++ b/frontend/src/i18n/locales/es/common.json
@@ -210,7 +210,27 @@
     "mapError": "Error de tile — algunas capas podrían no mostrarse correctamente.",
     "openMaps": "Abrir mapas",
     "signIn": "Iniciar sesión",
-    "tokenError": "No se pudieron cargar los tokens de capa — algunas capas podrían no mostrarse."
+    "tokenError": "No se pudieron cargar los tokens de capa — algunas capas podrían no mostrarse.",
+    "ai": {
+      "launch": "Preguntar a la IA",
+      "title": "Preguntar a la IA",
+      "placeholder": "Pregunta sobre este mapa...",
+      "send": "Enviar",
+      "cancel": "Detener",
+      "cancelled": "Cancelado.",
+      "thinking": "Pensando...",
+      "emptyHint": "Haz una pregunta sobre los datos de este mapa.",
+      "readOnlyNote": "Las respuestas son de solo lectura: explora los datos sin modificar el mapa.",
+      "error": "Algo salió mal. Inténtalo de nuevo.",
+      "retry": "Reintentar",
+      "queryResult": {
+        "empty": "No hay resultados coincidentes.",
+        "tableLabel": "Tabla de resultados de la consulta",
+        "rowCount_one": "{{count}} fila",
+        "rowCount_other": "{{count}} filas",
+        "truncated": "(mostrando una muestra)"
+      }
+    }
   },
   "maps": {
     "title": "Mapas",

--- a/frontend/src/i18n/locales/fr/common.json
+++ b/frontend/src/i18n/locales/fr/common.json
@@ -210,7 +210,27 @@
     "mapError": "Erreur de tuile — certains calques pourraient ne pas s'afficher correctement.",
     "openMaps": "Ouvrir les cartes",
     "signIn": "Se connecter",
-    "tokenError": "Impossible de charger les jetons de calque — certains calques pourraient ne pas s'afficher."
+    "tokenError": "Impossible de charger les jetons de calque — certains calques pourraient ne pas s'afficher.",
+    "ai": {
+      "launch": "Demander à l'IA",
+      "title": "Demander à l'IA",
+      "placeholder": "Posez une question sur cette carte...",
+      "send": "Envoyer",
+      "cancel": "Arrêter",
+      "cancelled": "Annulé.",
+      "thinking": "Réflexion...",
+      "emptyHint": "Posez une question sur les données de cette carte.",
+      "readOnlyNote": "Les réponses sont en lecture seule — explorez les données sans modifier la carte.",
+      "error": "Une erreur s'est produite. Veuillez réessayer.",
+      "retry": "Réessayer",
+      "queryResult": {
+        "empty": "Aucun résultat correspondant.",
+        "tableLabel": "Tableau des résultats de la requête",
+        "rowCount_one": "{{count}} ligne",
+        "rowCount_other": "{{count}} lignes",
+        "truncated": "(affichage d'un échantillon)"
+      }
+    }
   },
   "maps": {
     "title": "Cartes",

--- a/frontend/src/pages/PublicMapViewerPage.tsx
+++ b/frontend/src/pages/PublicMapViewerPage.tsx
@@ -1,5 +1,6 @@
-import { lazy, Suspense, useCallback, useMemo, useState } from 'react';
+import { lazy, Suspense, useCallback, useMemo, useRef, useState } from 'react';
 import { Link, useParams } from 'react-router';
+import type { Map as MaplibreMap } from 'maplibre-gl';
 import { useMap } from '@/hooks/use-maps';
 import { useViewerLayers } from '@/components/viewer/hooks/use-viewer-layers';
 // PERF-06 (Phase 274): lazy-load ViewerMap so map-vendor chunk fetch
@@ -7,6 +8,7 @@ import { useViewerLayers } from '@/components/viewer/hooks/use-viewer-layers';
 const ViewerMap = lazy(() =>
   import('@/components/viewer/ViewerMap').then((m) => ({ default: m.ViewerMap }))
 );
+import { ViewerChatPanel } from '@/components/viewer/ViewerChatPanel';
 import { LayerLegend } from '@/components/viewer/LayerLegend';
 import { MapTitlePill } from '@/components/map/MapTitlePill';
 import { BasemapToggle } from '@/components/map/BasemapToggle';
@@ -68,6 +70,7 @@ export function PublicMapViewerPage() {
     useViewerLayers(layers);
 
   const [basemapId, setBasemapId] = useState<string | null>(null);
+  const mapInstanceRef = useRef<MaplibreMap | null>(null);
   const handleLegendToggle = useCallback(() => setIsLegendOpen((prev) => !prev), [setIsLegendOpen]);
 
   if (isLoading) {
@@ -139,6 +142,9 @@ export function PublicMapViewerPage() {
             terrainConfig={data.terrain_config ?? null}
             initialViewState={viewState}
             visibleLayers={visibleLayers}
+            onMapReady={(map) => {
+              mapInstanceRef.current = map;
+            }}
           />
         </Suspense>
       </MapErrorBoundary>
@@ -161,6 +167,12 @@ export function PublicMapViewerPage() {
         title={t('viewer.changeBasemap')}
         className="absolute bottom-8 left-3 z-10"
       />
+
+      {/* Read-only "Ask AI" — self-gates on AI availability + use_ai_chat, so anonymous
+          and unpermitted viewers render nothing (PR #339 follow-up). */}
+      {id && (
+        <ViewerChatPanel mapId={id} layers={data.layers} mapInstanceRef={mapInstanceRef} />
+      )}
     </main>
   );
 }


### PR DESCRIPTION
## What

Follow-up to #339. That PR let the chat backend serve view-only callers a read-only toolbox (`query_data` only), but the path was **UI-unreachable**: the builder `ChatPanel` only mounts for `can_edit` users, while signed-in viewers land on `PublicMapViewerPage` with no AI affordance (the demo guest audience).

This adds a lightweight **`ViewerChatPanel`** that surfaces the read-only path.

## How

- **Self-gating** on `useAIAvailability` (token + `use_ai_chat` + AI configured) — anonymous and unpermitted viewers render nothing, no console noise.
- **Read-only by construction:** streams from `/ai/chat/stream/`; a `show_query_result` flies the map to the matched features via the shared `useEphemeralLayers` overlay and renders a compact result table. Non-query (edit) actions are ignored defensively (the backend already withholds edit tools from viewers).
- **Bundle-clean:** dedicated viewer component with a plain textarea (no builder mention/slash machinery); the builder `ChatPanel` is untouched and never pulled into the viewer chunk.
- Map instance captured via `ViewerMap`'s existing `onMapReady` to drive flyover.
- i18n keys added under `viewer.ai` across all four locales (parity gate green).

## Scope note

Read-only chat is reachable only to **signed-in viewers with `use_ai_chat`** — `/ai/chat` requires that capability. Anonymous share-link viewers see no panel.

## Tests

- New `ViewerChatPanel.test.tsx`: gating (renders nothing when unavailable), streamed answer, `show_query_result` → flyover + table, retry-able error.
- Full frontend gate green locally: `tsc -b` (0), `eslint .` (0), `vitest run` (3162 passed), i18n source-key + parity gates pass.
- No backend changes — the read-only chat path shipped in #339.

> Not live-verified end-to-end: the local dev stack's `LLM_MODEL` 404s the local key (pre-existing, unrelated), so the LLM round-trip can't run locally. Gating/streaming/flyover/error are covered by unit tests against mocked streams.