### PR TITLE
fix(viewer): flatten MultiPoint to Point so clustered map layers render

### DIFF
--- a/frontend/src/api/__tests__/geojson-z.test.ts
+++ b/frontend/src/api/__tests__/geojson-z.test.ts
@@ -92,6 +92,26 @@ describe('fetchBoundedGeoJson', () => {
     });
   });
 
+  it('flattens MultiPoint features to Point so clustering (Supercluster) renders them', () => {
+    const multiPoint = {
+      type: 'FeatureCollection' as const,
+      features: [
+        {
+          type: 'Feature' as const,
+          geometry: { type: 'MultiPoint' as const, coordinates: [[1, 2], [3, 4]] },
+          properties: { id: 7, name: 'airport' },
+        },
+      ],
+      truncated: false,
+      total_count: 1,
+    };
+
+    expect(asFeatureCollection(multiPoint).features).toEqual([
+      { type: 'Feature', geometry: { type: 'Point', coordinates: [1, 2] }, properties: { id: 7, name: 'airport' } },
+      { type: 'Feature', geometry: { type: 'Point', coordinates: [3, 4] }, properties: { id: 7, name: 'airport' } },
+    ]);
+  });
+
   it('throws for failed direct bounded GeoJSON requests', async () => {
     mockFetch.mockResolvedValueOnce(jsonResponse({ detail: 'Forbidden' }, 403));
 

--- a/frontend/src/api/geojson-z.ts
+++ b/frontend/src/api/geojson-z.ts
@@ -21,8 +21,25 @@ function directFetchPath(datasetId: string) {
 export function asFeatureCollection(response: BoundedGeoJsonResponse): GeoJSON.FeatureCollection {
   return {
     type: 'FeatureCollection',
-    features: response.features,
+    features: response.features.flatMap(flattenMultiPoint),
   };
+}
+
+/**
+ * Explode MultiPoint features into one Point feature per coordinate.
+ *
+ * The backend serves point datasets as MultiPoint (GDAL PROMOTE_TO_MULTI), but
+ * MapLibre's `cluster: true` GeoJSON sources are backed by Supercluster, which
+ * only indexes `Point` geometry and silently drops MultiPoint — leaving clustered
+ * layers blank. Flattening here fixes that for every bounded-GeoJSON consumer
+ * (viewer + builder) and is a no-op for already-Point geometry.
+ */
+function flattenMultiPoint(feature: GeoJSON.Feature): GeoJSON.Feature[] {
+  if (feature.geometry?.type !== 'MultiPoint') return [feature];
+  return feature.geometry.coordinates.map((coordinates) => ({
+    ...feature,
+    geometry: { type: 'Point', coordinates },
+  }));
 }
 
 /**


### PR DESCRIPTION
## Problem
Clustered map layers render blank — they flash for a moment, then disappear. Reproduced on the demo World Airports map (`/maps/2f5d2dd4-e44e-47b9-a456-b76282c5f4ac`).

## Root cause
The viewer/builder build a clustered GeoJSON source (`cluster: true`) for eligible point layers. Point datasets are served as **`MultiPoint`** geometry (GDAL `PROMOTE_TO_MULTI`). MapLibre's `cluster: true` sources are backed by Supercluster, which **only indexes `Point` geometry and silently drops `MultiPoint`** — so every feature vanishes and the layer renders blank. The brief "flash" is the vector-tile layer rendering before the empty clustered layer settles.

Proven with a controlled A/B on the live map (same source/layers):
- original `MultiPoint` data → `0 / 0 / 0` rendered (cluster / count / points)
- flattened to `Point` → `69 / 95 / 13` rendered

## Fix
Flatten `MultiPoint → Point` (one Point feature per coordinate, properties/id preserved) in `asFeatureCollection` (`frontend/src/api/geojson-z.ts`) — the single normalizer both `ViewerMap` and `BuilderMap` pass bounded-GeoJSON through. No-op for already-`Point` geometry.

## Tests
- New unit test: a MultiPoint feature explodes into per-coordinate Point features with properties preserved.
- `vitest` 7/7 pass · `tsc --noEmit` exit 0 · `eslint` exit 0.

## Notes
- Reaching the live demo requires a frontend rebuild + redeploy (operator step).