### PR TITLE
fix(builder): legend raster icon, copy-badge noise, demo-banner scroll

### DIFF
--- a/frontend/src/components/builder/__tests__/map-stack.test.ts
+++ b/frontend/src/components/builder/__tests__/map-stack.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import {
   MAP_STACK_GROUP_ORDER,
   buildMapStack,
+  computeDisambiguationLabels,
   flattenMapStack,
   type MapStackGroup,
   type MapStackMapInput,
@@ -416,5 +417,25 @@ describe('buildMapStack', () => {
         },
       },
     });
+  });
+});
+
+describe('computeDisambiguationLabels', () => {
+  it('badges duplicates that share a display name', () => {
+    const labels = computeDisambiguationLabels([
+      makeLayer({ id: 'a', display_name: 'Counties' }),
+      makeLayer({ id: 'b', display_name: 'Counties' }),
+    ]);
+    expect(labels.get('a')).toBe('Copy 1 of 2');
+    expect(labels.get('b')).toBe('Copy 2 of 2');
+  });
+
+  it('does not badge differently-named layers off the same dataset (line + casing)', () => {
+    const labels = computeDisambiguationLabels([
+      makeLayer({ id: 'route', dataset_id: 'routes', display_name: 'Climbing routes' }),
+      makeLayer({ id: 'casing', dataset_id: 'routes', display_name: 'Route casing' }),
+    ]);
+    expect(labels.get('route')).toBeNull();
+    expect(labels.get('casing')).toBeNull();
   });
 });

--- a/frontend/src/components/builder/map-stack.ts
+++ b/frontend/src/components/builder/map-stack.ts
@@ -339,16 +339,19 @@ export function computeDisambiguationMetadata(
 
     const datasetCount = datasetCounts.get(datasetKey) ?? 1;
     const nameCount = nameCounts.get(name) ?? 1;
-    const duplicateCount = Math.max(datasetCount, nameCount);
-    const copyOccurrence = datasetCount > 1 ? datasetOccurrence : nameOccurrence;
-    const copyCount = datasetCount > 1 ? datasetCount : nameCount;
+    // Disambiguate on NAME collisions only. The badge answers "which of these
+    // identical-looking rows is which?" — only ambiguous when the names match.
+    // Two differently-named layers off one dataset (e.g. a line + its casing)
+    // are an intentional cartographic pair, not a duplicate; badging them on
+    // shared dataset_id was pure noise. datasetCount/-Occurrence remain in the
+    // metadata for informational consumers.
     byLayerId.set(layer.id, {
       datasetKey,
       datasetOccurrence,
       datasetCount,
       nameOccurrence,
       nameCount,
-      disambiguationLabel: duplicateCount > 1 ? `Copy ${copyOccurrence} of ${copyCount}` : null,
+      disambiguationLabel: nameCount > 1 ? `Copy ${nameOccurrence} of ${nameCount}` : null,
     });
   }
 

--- a/frontend/src/components/map-plugins/builtin/LegendPlugin.tsx
+++ b/frontend/src/components/map-plugins/builtin/LegendPlugin.tsx
@@ -13,6 +13,7 @@ import type { MapLayerResponse, StyleConfig } from '@/types/api';
 import { MAP_COLORS } from '@/lib/map-colors';
 import { parseStepOrInterpolate } from '@/lib/normalize-style-config';
 import { inferGeometryType } from '@/lib/geo-utils';
+import { getLayerCapabilities } from '@/lib/layer-capabilities';
 import { Mountain, Pencil, Check } from 'lucide-react';
 import {
   deriveTerrainLegendEntry,
@@ -285,7 +286,11 @@ const LegendLayerEntry = memo(function LegendLayerEntry({
                   style_config: layer.style_config,
                 })}
                 layerId={`legend-plugin-${idx}`}
-                layerType={layer.layer_type ?? undefined}
+                // Pass the capability kind ('raster'/'vrt'/'vector'), not the raw
+                // layer_type ('raster_geolens') — ColorizedGeometryIcon keys its
+                // raster/vrt icons off kind, same contract StackRow uses. Raw
+                // layer_type fell through to a polygon swatch for raster layers.
+                layerType={getLayerCapabilities(layer).kind}
                 styleHints={extractStyleHints(
                   layer.paint ?? {},
                   layer.layout ?? {},

--- a/frontend/src/components/map/__tests__/layer-icons.test.tsx
+++ b/frontend/src/components/map/__tests__/layer-icons.test.tsx
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+import { render } from '@testing-library/react';
+import { ColorizedGeometryIcon } from '../layer-icons';
+
+// Guards the contract LegendPlugin + StackRow both depend on: callers pass the
+// capability KIND ('raster'/'vrt'), not the raw layer_type ('raster_geolens').
+// Passing the wrong value fell through to a polygon swatch — the "purple
+// polygon for raster layers in the legend" bug.
+describe('ColorizedGeometryIcon raster/vrt contract', () => {
+  it('renders the grid (raster) icon for kind "raster", not a polygon', () => {
+    const { container } = render(
+      <ColorizedGeometryIcon geometryType={null} colors={[]} layerId="x" layerType="raster" />,
+    );
+    expect(container.querySelector('.lucide-grid-3x3')).not.toBeNull();
+  });
+
+  it('renders the layers (vrt) icon for kind "vrt"', () => {
+    const { container } = render(
+      <ColorizedGeometryIcon geometryType={null} colors={[]} layerId="x" layerType="vrt" />,
+    );
+    expect(container.querySelector('.lucide-layers')).not.toBeNull();
+  });
+});

--- a/frontend/src/pages/MapBuilderPage.tsx
+++ b/frontend/src/pages/MapBuilderPage.tsx
@@ -1241,7 +1241,7 @@ export function MapBuilderPage() {
 
   if (isLoading) {
     return (
-      <div className="flex items-center justify-center h-[calc(100vh-3.5rem-env(safe-area-inset-top))]">
+      <div className="flex flex-1 min-h-0 items-center justify-center">
         <LoadingState message={t('loadingMap')} />
       </div>
     );
@@ -1256,7 +1256,7 @@ export function MapBuilderPage() {
           ? t('common:errors.loadFailed', { defaultValue: 'Failed to load map' })
           : t('common:errors.mapNotFound');
     return (
-      <div className="flex items-center justify-center h-[calc(100vh-3.5rem-env(safe-area-inset-top))]">
+      <div className="flex flex-1 min-h-0 items-center justify-center">
         <div className="text-center space-y-4">
           <ErrorState message={msg} />
           <Link to="/maps" className="text-sm text-primary hover:underline">
@@ -1282,7 +1282,10 @@ export function MapBuilderPage() {
   );
 
   return (
-    <div className="flex flex-col h-[calc(100vh-3.5rem-env(safe-area-inset-top))]">
+    // Fill the flex space <main> leaves (navbar + demo banner + footer), rather
+    // than a hardcoded 100vh-navbar calc that ignored the demo banner and made
+    // the whole page scroll. Matches PublicMapViewerPage's flex-1/min-h-0 layout.
+    <div className="flex flex-col flex-1 min-h-0">
       {/* Phase 1040 Plan 04: sr-only aria-live region for keyboard/mouse catalog drag announcements.
           Renders at root of the builder so screen readers in any panel can read it.
           Zero-width-space + timestamp suffix in dragAnnouncement forces aria-live re-fire on


### PR DESCRIPTION
Three small, independent Map Builder fixes.

## 1. "Copy N of M" badge noise
The duplicate-disambiguation badge fired on shared `dataset_id` **or** display name. Two differently-named layers off one dataset (a line + its casing, a halo, any multi-style-of-one-source pattern) got tagged `Copy 1 of 2` / `Copy 2 of 2` even though their names already distinguish them — and they aren't duplicates.

Now badges only on genuine **name collisions** (the only case where rows are actually indistinguishable). `dataset_*` fields stay in the metadata, unused, for informational consumers. Live stack badge and legend badge share the same function, so they can't drift.

## 2. Raster legend "purple polygon"
On-map legend (`LegendPlugin`) rendered raster/VRT layers as a polygon swatch in the default color. Root cause: it passed the raw `layer.layer_type` (`'raster_geolens'`) to `ColorizedGeometryIcon`, whose raster/vrt branch keys off the capability **kind** (`'raster'`/`'vrt'`), so the check never matched and it fell through to `ShapeIcon`. `StackRow` was immune because it passes `caps.kind`.

Fix: pass `getLayerCapabilities(layer).kind`, aligning the call site with the layer list. Raster → grid icon, VRT → layers icon.

## 3. Map page scrolls under the demo banner
`MapBuilderPage` sized itself `h-[calc(100vh - 3.5rem)]`, subtracting only the navbar — not the demo banner that sits between the navbar and `<main>`. Result: the page was `banner-height` too tall and scrolled.

Fix: `flex-1 min-h-0` so the map fills exactly what `<main>` leaves after navbar + banner + footer. Banner- and footer-agnostic, no magic numbers. Matches `PublicMapViewerPage`, which was already immune.

## Tests
- `map-stack.test.ts` — guards name-only badging (badges same-name duplicates, does **not** badge differently-named layers off one dataset)
- `layer-icons.test.tsx` — guards the `ColorizedGeometryIcon` raster/vrt contract
- Existing builder/page suites green; typecheck + lint clean.