### PR TITLE
fix(auth): sync rotated tokens across tabs to prevent logout-on-save

### DIFF
--- a/frontend/src/stores/__tests__/auth-store.cross-tab.test.ts
+++ b/frontend/src/stores/__tests__/auth-store.cross-tab.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it, vi, afterEach } from 'vitest';
+import { useAuthStore } from '../auth-store';
+
+// Guards the cross-tab sync listener: a `storage` event for the auth key (fired
+// by another tab rotating the single-use refresh token) must rehydrate this
+// tab's store; events for any other key must be ignored. Without this, a tab
+// holding a now-revoked refresh token 401s and logs out on the next request.
+describe('auth-store cross-tab sync', () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it('rehydrates when the geolens-auth key changes in another tab', () => {
+    const spy = vi.spyOn(useAuthStore.persist, 'rehydrate').mockResolvedValue();
+    window.dispatchEvent(new StorageEvent('storage', { key: 'geolens-auth' }));
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  it('ignores storage events for unrelated keys', () => {
+    const spy = vi.spyOn(useAuthStore.persist, 'rehydrate').mockResolvedValue();
+    window.dispatchEvent(new StorageEvent('storage', { key: 'some-other-key' }));
+    expect(spy).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/stores/auth-store.ts
+++ b/frontend/src/stores/auth-store.ts
@@ -83,3 +83,20 @@ export const useAuthStore = create<AuthState>()(
     persistConfig,
   ),
 );
+
+/**
+ * Cross-tab token sync.
+ *
+ * Refresh tokens are single-use: the backend revokes a refresh token the moment
+ * it is rotated (auth/service.py rotate_refresh_token). Without this listener,
+ * a refresh in one tab leaves every OTHER tab holding the now-revoked token in
+ * memory — the next request there 401s, its refresh 401s, and the tab logs out
+ * (e.g. "saved a map → logged out" with two tabs open). The `storage` event
+ * fires only in the tabs that did NOT make the change, so rehydrating here makes
+ * all tabs converge on the latest rotated token (and propagates logout).
+ */
+if (typeof window !== 'undefined') {
+  window.addEventListener('storage', (e) => {
+    if (e.key === persistConfig.name) void useAuthStore.persist.rehydrate();
+  });
+}


### PR DESCRIPTION
## Symptom
Saving a map logged the user out. Console showed `/api/auth/refresh/` and `/api/maps/{id}/layers` both returning `401`.

## Root cause
Not a save-side or expiry bug — saving a map touches no auth code (no `revoke` call anywhere in `backend/app/modules/maps/`). It's a **multi-tab refresh-token rotation race**:

1. Refresh tokens are **single-use**: `rotate_refresh_token` sets `stored.revoked = True` and issues a new pair (`auth/service.py:196`). Once spent, presenting it again 401s.
2. The auth store persists to `localStorage` (`geolens-auth`) but had **no cross-tab sync** — zustand `persist` writes localStorage but doesn't react to *other* tabs' writes.
3. So: Tab A refreshes → rotates `R1 → R2`, updates its store + localStorage. Tab B still holds `R1` in memory. Saving in Tab B → stale access token → `401` → `tryRefresh` presents `R1` → already revoked → `/auth/refresh/` `401` → `logout()`. The repeated 401s are the save retry plus a background query each presenting the dead `R1`.

The client retry logic is correct — given a revoked refresh token, logging out is right. The defect is that single-use rotation is hostile to multiple tabs when the tabs never converge on the rotated token.

## Fix
A `storage` event listener that rehydrates the persisted store when the `geolens-auth` key changes. The event fires only in tabs that did **not** make the change, so a tab picks up the rotated token the instant another tab writes it, and never presents the stale one. Logout also propagates across tabs (desirable). Guarded on `typeof window`, keyed on the persist name.

This shrinks the race window to near-zero but doesn't mathematically eliminate it — two tabs refreshing in the same instant could still double-spend. The fully-robust backend fix would be a refresh-token reuse grace window; deferred as YAGNI unless this proves insufficient.

## Tests
`auth-store.cross-tab.test.ts` — rehydrates on the auth key, ignores unrelated keys. Typecheck + lint clean.