### PR TITLE
fix(dataset): lead header with visibility, badge status only when draft

### DIFF
--- a/frontend/src/pages/DatasetPage.tsx
+++ b/frontend/src/pages/DatasetPage.tsx
@@ -72,7 +72,7 @@ import { useUnsavedGuard } from '@/hooks/use-unsaved-guard';
 import { Badge } from '@/components/ui/badge';
 import { Skeleton } from '@/components/ui/skeleton';
 import { cn } from '@/lib/utils';
-import { visibilityColors } from '@/lib/status-colors';
+import { ingestionStatusColors, visibilityColors } from '@/lib/status-colors';
 import type { DatasetResponse } from '@/types/api';
 import { downloadCog } from '@/api/datasets';
 
@@ -381,12 +381,19 @@ export function DatasetPage() {
     }
   };
 
+  // Lead with visibility (the access question users actually have). "Published"
+  // is the steady state and carries no information here — show a status badge
+  // ONLY when it's the exception that needs action (draft). Mirrors the pattern
+  // SearchResultCard already uses (showStatusBadge = record_status !== 'published').
   const statsLine = (
     <>
       <RecordTypeBadge recordType={dataset.record_type} />
-      <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
-        <span>{getRecordStatusLabel(t, dataset.record_status)}</span>
-        <span className="text-muted-foreground/50">·</span>
+      <div className="flex items-center gap-1.5">
+        {dataset.record_status !== 'published' && (
+          <Badge variant="outline" className={cn('text-xs', ingestionStatusColors[dataset.record_status] ?? '')}>
+            {getRecordStatusLabel(t, dataset.record_status)}
+          </Badge>
+        )}
         <Badge variant="outline" className={cn('text-xs', visibilityColors[dataset.visibility] ?? '')}>
           {dataset.visibility === 'public' ? <Eye className="me-1 h-3 w-3" /> : dataset.visibility === 'restricted' ? <ShieldAlert className="me-1 h-3 w-3" /> : <EyeOff className="me-1 h-3 w-3" />}
           {getVisibilityLabel(t, dataset.visibility)}

--- a/frontend/src/pages/__tests__/DatasetPage.hero.test.tsx
+++ b/frontend/src/pages/__tests__/DatasetPage.hero.test.tsx
@@ -399,3 +399,34 @@ describe('DatasetPage no-tile badge', () => {
     expect(screen.queryByText('No raster tiles available')).not.toBeInTheDocument();
   });
 });
+
+describe('DatasetPage header status badge', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    drawingStoreState.isDrawing = false;
+    drawingStoreState.isEditDirty = false;
+    mockMapConfig.autoFireMapReady = false;
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    setUser(null);
+  });
+
+  // "Published · Private" read as a contradiction; "Published" is the steady
+  // state and carries no info. Show the status badge only for the exceptional
+  // draft state; published records lead with visibility alone.
+  it('hides the status badge for a published dataset', () => {
+    setup({ record_status: 'published', visibility: 'private' });
+    render(<DatasetPage />, { route: '/datasets/dataset-1' });
+
+    expect(screen.queryByText('Published')).not.toBeInTheDocument();
+  });
+
+  it('shows a Draft badge for a draft dataset', () => {
+    setup({ record_status: 'draft', visibility: 'private' });
+    render(<DatasetPage />, { route: '/datasets/dataset-1' });
+
+    expect(screen.getByText('Draft')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Problem
The dataset header showed `Published · Private`, which reads as a contradiction. They're **two orthogonal fields** — `record_status` (lifecycle: `draft` → `published`) and `visibility` (`public`/`restricted`/`private`) — but "Published" colloquially implies "public," so the pair looks self-contradictory. The data is correct; the labeling isn't legible.

Compounding it: "Published" is the steady state and carries no information once a record is live — *of course* it's published, you're looking at it. The status badge only earns its place when the state is the **exception that needs action** (`draft`).

## Fix
- Lead with the **visibility** badge (the access question users actually have).
- Show the record-status badge **only** when `record_status !== 'published'` (i.e. draft).

A published+private dataset now reads simply **Private**; a draft shows a **Draft** badge. This mirrors the pattern `SearchResultCard` already uses (`showStatusBadge = record_status !== 'published'`), so the detail header and search cards are now consistent.

No backend, API, or i18n change — purely how the existing fields are displayed.

## Tests
`DatasetPage.hero.test.tsx` — published hides the status badge; draft shows "Draft". Existing suites green; typecheck + lint clean.