### PR TITLE
fix(terrain): consistent terrain status across legend + settings

### DIFF
--- a/frontend/src/components/builder/BuilderMap.tsx
+++ b/frontend/src/components/builder/BuilderMap.tsx
@@ -40,11 +40,11 @@ import {
   getLayerId,
   ensureRasterDemTerrainSource,
   clearTerrainForStyleSwap,
-  isTerrainCapableDemLayer,
   normalizeTerrainExaggeration,
   refreshVectorSourceTiles,
   TERRAIN_SOURCE_ID,
 } from './map-sync';
+import { resolveTerrainSourceLayer } from './map-stack';
 import { getClusterSourceOptions } from './layer-adapters/cluster-adapter';
 import type { AdapterLayerInput } from './layer-adapters/types';
 import { maybeWarnSmallDemCoverage, resetSmallDemWarning } from './terrain-coverage';
@@ -483,10 +483,9 @@ export const BuilderMap = memo(function BuilderMap({
     // This aligns the builder with the proven viewer resolver
     // (viewer/hooks/use-viewer-terrain.ts) so a DEM layer in hillshade mode can
     // still drive the 3D mesh, enabling mesh + visible hillshade on one DEM.
-    const demLayer = currentLayers.find(
-      (layer) => layer.dataset_id === currentTerrainConfig.source_dataset_id
-        && isTerrainCapableDemLayer(layer),
-    );
+    // Shared with MapBuilderPage's isTerrainActive so the rendered state and the
+    // settings status can't drift.
+    const demLayer = resolveTerrainSourceLayer(currentLayers, currentTerrainConfig);
     const token = demLayer ? currentTokenMap.get(demLayer.dataset_id) : null;
     // Honor the layer's visibility eye: treat undefined visible as visible (default-visible semantics).
     const demLayerVisible = demLayer?.visible !== false;

--- a/frontend/src/components/builder/BuilderMap.tsx
+++ b/frontend/src/components/builder/BuilderMap.tsx
@@ -478,13 +478,11 @@ export const BuilderMap = memo(function BuilderMap({
       return;
     }
 
-    // FIX-3-RESOLVER (D-06): resolve the terrain DEM by source_dataset_id +
-    // isTerrainCapableDemLayer ONLY — do NOT require render_mode === 'terrain'.
-    // This aligns the builder with the proven viewer resolver
-    // (viewer/hooks/use-viewer-terrain.ts) so a DEM layer in hillshade mode can
-    // still drive the 3D mesh, enabling mesh + visible hillshade on one DEM.
-    // Shared with MapBuilderPage's isTerrainActive so the rendered state and the
-    // settings status can't drift.
+    // Resolve the terrain DEM by source_dataset_id + isTerrainCapableDemLayer
+    // ONLY — do NOT require render_mode === 'terrain'. This matches the viewer
+    // resolver (viewer/hooks/use-viewer-terrain.ts) so a DEM in hillshade mode can
+    // drive the 3D mesh AND paint its 2D relief on one dataset. Shared with
+    // MapBuilderPage's isTerrainActive so render state and settings status can't drift.
     const demLayer = resolveTerrainSourceLayer(currentLayers, currentTerrainConfig);
     const token = demLayer ? currentTokenMap.get(demLayer.dataset_id) : null;
     // Honor the layer's visibility eye: treat undefined visible as visible (default-visible semantics).

--- a/frontend/src/components/builder/SettingsEditorScene.tsx
+++ b/frontend/src/components/builder/SettingsEditorScene.tsx
@@ -13,7 +13,9 @@ import type { MapTerrainConfig } from '@/types/api';
 export interface SettingsEditorSceneProps {
   // Terrain
   terrainConfig: MapTerrainConfig | null;
-  /** True when at least one DEM layer has render_mode === 'terrain' */
+  /** True when terrain_config is enabled and bound to a visible terrain-capable
+   *  DEM (any render_mode — hillshade DEMs drive the mesh too), matching what the
+   *  map actually renders. */
   isTerrainActive: boolean;
   /** Name of the bound DEM layer (for the "Bound to:" hint) */
   boundLayerName?: string;

--- a/frontend/src/components/builder/__tests__/map-stack.test.ts
+++ b/frontend/src/components/builder/__tests__/map-stack.test.ts
@@ -4,6 +4,7 @@ import {
   buildMapStack,
   computeDisambiguationLabels,
   flattenMapStack,
+  resolveTerrainSourceLayer,
   type MapStackGroup,
   type MapStackMapInput,
 } from '../map-stack';
@@ -437,5 +438,27 @@ describe('computeDisambiguationLabels', () => {
     ]);
     expect(labels.get('route')).toBeNull();
     expect(labels.get('casing')).toBeNull();
+  });
+});
+
+describe('resolveTerrainSourceLayer', () => {
+  const dem = (overrides = {}) =>
+    makeLayer({ id: 'dem', dataset_id: 'dem-1', is_dem: true, dataset_record_type: 'raster_dataset', ...overrides });
+
+  it('resolves a hillshade-mode DEM as the terrain source (render_mode-agnostic)', () => {
+    const layer = dem({ style_config: { render_mode: 'hillshade' } as unknown as StyleConfig });
+    expect(resolveTerrainSourceLayer([layer], { source_dataset_id: 'dem-1' })?.id).toBe('dem');
+  });
+
+  it('resolves a terrain-mode DEM source too', () => {
+    const layer = dem({ style_config: { render_mode: 'terrain' } as unknown as StyleConfig });
+    expect(resolveTerrainSourceLayer([layer], { source_dataset_id: 'dem-1' })?.id).toBe('dem');
+  });
+
+  it('returns undefined when no terrain-capable DEM matches the source dataset', () => {
+    const vector = makeLayer({ id: 'roads', dataset_id: 'dem-1', is_dem: false });
+    expect(resolveTerrainSourceLayer([vector], { source_dataset_id: 'dem-1' })).toBeUndefined();
+    expect(resolveTerrainSourceLayer([dem()], { source_dataset_id: 'other' })).toBeUndefined();
+    expect(resolveTerrainSourceLayer([dem()], null)).toBeUndefined();
   });
 });

--- a/frontend/src/components/builder/__tests__/terrain-legend.test.ts
+++ b/frontend/src/components/builder/__tests__/terrain-legend.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'vitest';
 import type { MapTerrainConfig } from '@/types/api';
-import { deriveTerrainLegendEntry, isDemTerrainVisualSuppressed } from '../terrain-legend';
+import {
+  deriveTerrainLegendEntry,
+  isDemTerrainVisualSuppressed,
+  terrainSourceIsShownAsLayer,
+} from '../terrain-legend';
 
 describe('terrain-legend helper', () => {
   describe('isDemTerrainVisualSuppressed (re-exported single source of truth)', () => {
@@ -119,6 +123,23 @@ describe('terrain-legend helper', () => {
           { labelKey },
         ),
       ).toBeNull();
+    });
+  });
+
+  describe('terrainSourceIsShownAsLayer (dedup guard)', () => {
+    const active: MapTerrainConfig = { enabled: true, source_dataset_id: 'dem-1', exaggeration: 1 };
+
+    it('is true when the terrain source dataset has a shown per-layer entry', () => {
+      expect(terrainSourceIsShownAsLayer(active, [{ dataset_id: 'dem-1' }, { dataset_id: 'roads' }])).toBe(true);
+    });
+
+    it('is false when the source dataset is not among the shown entries (suppressed/hidden)', () => {
+      expect(terrainSourceIsShownAsLayer(active, [{ dataset_id: 'roads' }])).toBe(false);
+    });
+
+    it('is false when terrain is disabled or has no source', () => {
+      expect(terrainSourceIsShownAsLayer({ enabled: false, source_dataset_id: 'dem-1', exaggeration: 1 }, [{ dataset_id: 'dem-1' }])).toBe(false);
+      expect(terrainSourceIsShownAsLayer(null, [{ dataset_id: 'dem-1' }])).toBe(false);
     });
   });
 });

--- a/frontend/src/components/builder/map-stack.ts
+++ b/frontend/src/components/builder/map-stack.ts
@@ -225,6 +225,26 @@ export function isTerrainCapableDemLayer(layer: {
   return layer.is_dem === true && DEM_RECORD_TYPES.has(String(layer.dataset_record_type ?? ''));
 }
 
+/**
+ * Resolve the DEM layer that backs `terrain_config`, the SINGLE way both the map
+ * renderer (BuilderMap, FIX-3-RESOLVER D-06) and the settings status
+ * (MapBuilderPage `isTerrainActive`) must agree on: match the source dataset and
+ * be terrain-capable, regardless of render_mode (a hillshade-mode DEM drives the
+ * 3D mesh too). Sharing this prevents the two from drifting — which is exactly
+ * what made the settings report "No terrain layer is active" while the map was
+ * rendering terrain from a hillshade DEM.
+ */
+export function resolveTerrainSourceLayer<
+  T extends { dataset_id?: string | null; is_dem?: boolean | null; dataset_record_type?: string | null },
+>(
+  layers: readonly T[],
+  terrainConfig: { source_dataset_id?: string | null } | null | undefined,
+): T | undefined {
+  const src = terrainConfig?.source_dataset_id;
+  if (!src) return undefined;
+  return layers.find((l) => l.dataset_id === src && isTerrainCapableDemLayer(l));
+}
+
 function isTerrainRenderLayer(layer: MapLayerResponse) {
   return isTerrainCapableDemLayer(layer) && renderMode(layer.style_config) === 'terrain';
 }

--- a/frontend/src/components/builder/map-stack.ts
+++ b/frontend/src/components/builder/map-stack.ts
@@ -227,7 +227,7 @@ export function isTerrainCapableDemLayer(layer: {
 
 /**
  * Resolve the DEM layer that backs `terrain_config`, the SINGLE way both the map
- * renderer (BuilderMap, FIX-3-RESOLVER D-06) and the settings status
+ * renderer (BuilderMap) and the settings status
  * (MapBuilderPage `isTerrainActive`) must agree on: match the source dataset and
  * be terrain-capable, regardless of render_mode (a hillshade-mode DEM drives the
  * 3D mesh too). Sharing this prevents the two from drifting — which is exactly

--- a/frontend/src/components/builder/terrain-legend.ts
+++ b/frontend/src/components/builder/terrain-legend.ts
@@ -68,3 +68,20 @@ export function deriveTerrainLegendEntry(
     labelKey: opts.labelKey,
   };
 }
+
+/**
+ * True when the terrain source dataset is already represented by one of the
+ * surface's per-layer legend entries — so the synthetic "3D terrain" entry would
+ * duplicate it. Callers pass THEIR OWN shown-entry list (each surface filters
+ * differently: LegendPlugin drops hidden layers, LayerLegend keeps them as
+ * toggles), so the dedup is correct per surface. When the source DEM has no
+ * shown entry (pure terrain render_mode → suppressed, or hidden), this returns
+ * false and the synthetic entry remains the only terrain indicator.
+ */
+export function terrainSourceIsShownAsLayer(
+  terrainConfig: MapTerrainConfig | null | undefined,
+  shownLayers: readonly { dataset_id?: string | null }[],
+): boolean {
+  const src = terrainConfig?.enabled === true ? terrainConfig.source_dataset_id : null;
+  return !!src && shownLayers.some((l) => l.dataset_id === src);
+}

--- a/frontend/src/components/map-plugins/builtin/LegendPlugin.tsx
+++ b/frontend/src/components/map-plugins/builtin/LegendPlugin.tsx
@@ -20,6 +20,7 @@ import {
   isDemTerrainVisualSuppressed,
   terrainSourceIsShownAsLayer,
 } from '@/components/builder/terrain-legend';
+import { resolveTerrainSourceLayer } from '@/components/builder/map-stack';
 import type { PluginContext } from '../types';
 
 /** Extract swatch style properties from layer paint based on geometry type. */
@@ -118,11 +119,23 @@ export function LegendPlugin({ ctx }: { ctx: PluginContext }) {
     () => deriveTerrainLegendEntry(ctx.terrainConfig, ctx.layers, { labelKey: 'plugins.legend.terrain3d' }),
     [ctx.terrainConfig, ctx.layers],
   );
-  // Dedup: drop the synthetic entry when the terrain source DEM is ALSO shown as
-  // a per-layer entry (e.g. a visible hillshade of the same dataset), so the
-  // legend doesn't list one DEM twice. Keeps it for the pure-terrain / hidden
-  // case where the synthetic is the only terrain indicator.
-  const terrainEntry = terrainEntryRaw && !terrainSourceIsShownAsLayer(ctx.terrainConfig, legendLayers)
+  // The synthetic entry must track what the map ACTUALLY renders. In the builder,
+  // BuilderMap clears terrain when the bound DEM is hidden (effectiveTerrainEnabled
+  // = enabled && demLayerVisible), so a hidden source = no mesh = no synthetic row.
+  // Resolve the bound DEM with the SAME shared resolver BuilderMap uses so the two
+  // can't drift. (The viewer differs — useViewerTerrain ignores the toggle — which
+  // is why LayerLegend gates on its own visible set, not this.)
+  const boundTerrainDem = useMemo(
+    () => resolveTerrainSourceLayer(ctx.layers, ctx.terrainConfig),
+    [ctx.layers, ctx.terrainConfig],
+  );
+  // Show the synthetic entry only when terrain is effectively rendering (bound DEM
+  // visible) AND the source DEM isn't ALSO shown as a per-layer entry (e.g. a
+  // visible hillshade of the same dataset would list one DEM twice). Kept for the
+  // pure-terrain case where the suppressed DEM has no per-layer row.
+  const terrainEntry = terrainEntryRaw
+    && boundTerrainDem?.visible !== false
+    && !terrainSourceIsShownAsLayer(ctx.terrainConfig, legendLayers)
     ? terrainEntryRaw
     : null;
 

--- a/frontend/src/components/map-plugins/builtin/LegendPlugin.tsx
+++ b/frontend/src/components/map-plugins/builtin/LegendPlugin.tsx
@@ -18,6 +18,7 @@ import { Mountain, Pencil, Check } from 'lucide-react';
 import {
   deriveTerrainLegendEntry,
   isDemTerrainVisualSuppressed,
+  terrainSourceIsShownAsLayer,
 } from '@/components/builder/terrain-legend';
 import type { PluginContext } from '../types';
 
@@ -113,10 +114,17 @@ export function LegendPlugin({ ctx }: { ctx: PluginContext }) {
   // D-01: single synthetic "3D terrain" entry driven by terrain_config — only
   // when a backing terrain-capable DEM layer for the source dataset is present
   // (999.17 MD-01: no phantom entry for a dangling terrain_config).
-  const terrainEntry = useMemo(
+  const terrainEntryRaw = useMemo(
     () => deriveTerrainLegendEntry(ctx.terrainConfig, ctx.layers, { labelKey: 'plugins.legend.terrain3d' }),
     [ctx.terrainConfig, ctx.layers],
   );
+  // Dedup: drop the synthetic entry when the terrain source DEM is ALSO shown as
+  // a per-layer entry (e.g. a visible hillshade of the same dataset), so the
+  // legend doesn't list one DEM twice. Keeps it for the pure-terrain / hidden
+  // case where the synthetic is the only terrain indicator.
+  const terrainEntry = terrainEntryRaw && !terrainSourceIsShownAsLayer(ctx.terrainConfig, legendLayers)
+    ? terrainEntryRaw
+    : null;
 
   if (legendLayers.length === 0 && !terrainEntry) {
     return (

--- a/frontend/src/components/map-plugins/builtin/__tests__/LegendPlugin.terrain.test.tsx
+++ b/frontend/src/components/map-plugins/builtin/__tests__/LegendPlugin.terrain.test.tsx
@@ -176,6 +176,20 @@ describe('LegendPlugin terrain consistency (Fix 1)', () => {
     expect(screen.queryByText('3D terrain')).not.toBeInTheDocument();
   });
 
+  // In the builder, BuilderMap clears terrain when the bound DEM is HIDDEN
+  // (effectiveTerrainEnabled = enabled && demLayerVisible). The synthetic entry
+  // must track that — no mesh rendered, no "3D terrain" row.
+  it('drops the synthetic entry when the bound terrain DEM is hidden (no mesh rendered)', () => {
+    const ctx = createCtx({
+      layers: [backingDemLayer({ visible: false })],
+      terrainConfig: activeTerrain,
+    });
+    render(<LegendPlugin ctx={ctx} />);
+
+    expect(screen.queryByTestId('legend-terrain-synthetic')).not.toBeInTheDocument();
+    expect(screen.queryByText('3D terrain')).not.toBeInTheDocument();
+  });
+
   it('leaves non-DEM layers unaffected when terrain is inactive (regression)', () => {
     const ctx = createCtx({
       layers: [

--- a/frontend/src/components/map-plugins/builtin/__tests__/LegendPlugin.terrain.test.tsx
+++ b/frontend/src/components/map-plugins/builtin/__tests__/LegendPlugin.terrain.test.tsx
@@ -151,6 +151,31 @@ describe('LegendPlugin terrain consistency (Fix 1)', () => {
     expect(screen.getByText('Hillshade relief')).toBeInTheDocument();
   });
 
+  // Dedup: when the terrain SOURCE dataset is itself shown as a visible hillshade
+  // entry (same dataset_id as terrain_config.source_dataset_id, e.g. the
+  // Matterhorn swissALTI3D map), the synthetic "3D terrain" entry would list one
+  // DEM twice. Suppress it; the hillshade entry stands in.
+  it('drops the synthetic entry when the source DEM is shown as a visible hillshade layer', () => {
+    const ctx = createCtx({
+      layers: [
+        layer({
+          id: 'dem-hillshade',
+          display_name: 'swissALTI3D relief',
+          dataset_id: 'dem-1', // SAME dataset as activeTerrain.source_dataset_id
+          dataset_record_type: 'raster_dataset',
+          is_dem: true,
+          style_config: demHillshadeStyle,
+        }),
+      ],
+      terrainConfig: activeTerrain,
+    });
+    render(<LegendPlugin ctx={ctx} />);
+
+    expect(screen.getByText('swissALTI3D relief')).toBeInTheDocument();
+    expect(screen.queryByTestId('legend-terrain-synthetic')).not.toBeInTheDocument();
+    expect(screen.queryByText('3D terrain')).not.toBeInTheDocument();
+  });
+
   it('leaves non-DEM layers unaffected when terrain is inactive (regression)', () => {
     const ctx = createCtx({
       layers: [

--- a/frontend/src/components/viewer/LayerLegend.tsx
+++ b/frontend/src/components/viewer/LayerLegend.tsx
@@ -214,13 +214,19 @@ export function LayerLegend({
   // (999.17 MD-01: no phantom entry for a dangling terrain_config).
   const terrainEntry = useMemo(() => {
     const entry = deriveTerrainLegendEntry(terrainConfig, layers, { labelKey: 'viewer.legend.terrain3d' });
-    // Dedup: drop the synthetic entry when the terrain source DEM is also shown
-    // as a per-layer entry (e.g. a visible hillshade of the same dataset), so
-    // the legend doesn't list one DEM twice. Kept for the pure-terrain case.
-    return entry && !terrainSourceIsShownAsLayer(terrainConfig, sorted.map((s) => s.layer))
+    // Dedup: drop the synthetic entry when the terrain source DEM is shown as a
+    // VISIBLE per-layer entry (e.g. a visible hillshade of the same dataset), so
+    // the legend doesn't list one DEM twice. The viewer keeps toggled-off layers
+    // in `sorted` (visibility lives in `visibleLayers`, not the list), but 3D
+    // terrain stays active from terrain_config regardless of that toggle — so we
+    // must dedup against currently-visible entries only, else toggling the
+    // hillshade off would hide BOTH it and the synthetic row, leaving active 3D
+    // terrain unrepresented. Kept for the pure-terrain / hidden-source case.
+    const visibleSourceLayers = sorted.filter((s) => visibleLayers.has(s.key)).map((s) => s.layer);
+    return entry && !terrainSourceIsShownAsLayer(terrainConfig, visibleSourceLayers)
       ? entry
       : null;
-  }, [terrainConfig, layers, sorted]);
+  }, [terrainConfig, layers, sorted, visibleLayers]);
 
   // Dismiss on Escape
   useEffect(() => {

--- a/frontend/src/components/viewer/LayerLegend.tsx
+++ b/frontend/src/components/viewer/LayerLegend.tsx
@@ -19,6 +19,7 @@ import { createViewerLayerEntries } from '@/components/viewer/layer-identity';
 import {
   deriveTerrainLegendEntry,
   isDemTerrainVisualSuppressed,
+  terrainSourceIsShownAsLayer,
 } from '@/components/builder/terrain-legend';
 import { getClusterSourceStrategy, isClusterRenderMode } from '@/components/builder/cluster-source';
 
@@ -211,10 +212,15 @@ export function LayerLegend({
   // D-01: single synthetic "3D terrain" entry driven by terrain_config — only
   // when a backing terrain-capable DEM layer for the source dataset is present
   // (999.17 MD-01: no phantom entry for a dangling terrain_config).
-  const terrainEntry = useMemo(
-    () => deriveTerrainLegendEntry(terrainConfig, layers, { labelKey: 'viewer.legend.terrain3d' }),
-    [terrainConfig, layers],
-  );
+  const terrainEntry = useMemo(() => {
+    const entry = deriveTerrainLegendEntry(terrainConfig, layers, { labelKey: 'viewer.legend.terrain3d' });
+    // Dedup: drop the synthetic entry when the terrain source DEM is also shown
+    // as a per-layer entry (e.g. a visible hillshade of the same dataset), so
+    // the legend doesn't list one DEM twice. Kept for the pure-terrain case.
+    return entry && !terrainSourceIsShownAsLayer(terrainConfig, sorted.map((s) => s.layer))
+      ? entry
+      : null;
+  }, [terrainConfig, layers, sorted]);
 
   // Dismiss on Escape
   useEffect(() => {

--- a/frontend/src/components/viewer/__tests__/LayerLegend.test.tsx
+++ b/frontend/src/components/viewer/__tests__/LayerLegend.test.tsx
@@ -370,4 +370,31 @@ describe('LayerLegend terrain consistency (Fix 1)', () => {
     expect(screen.queryByTestId('legend-terrain-synthetic')).not.toBeInTheDocument();
     expect(screen.queryByText('3D terrain')).not.toBeInTheDocument();
   });
+
+  // Codex P2: the viewer keeps toggled-off layers in the list (visibility lives
+  // in visibleLayers, not the list), but 3D terrain stays active from
+  // terrain_config regardless. If the source hillshade is toggled OFF, the
+  // synthetic entry must STILL show — otherwise active 3D terrain has no legend
+  // representation. So dedup against visible entries only.
+  it('keeps the synthetic entry when the source DEM is toggled off but terrain is active', () => {
+    render(
+      <LayerLegend
+        layers={[
+          demLayer({
+            id: 'dem-hillshade',
+            display_name: 'swissALTI3D relief',
+            style_config: { render_mode: 'hillshade' } as SharedLayerResponse['style_config'],
+          }),
+        ]}
+        visibleLayers={new Set()} /* source layer toggled OFF */
+        terrainConfig={activeTerrain}
+        onToggleVisibility={vi.fn()}
+        isOpen
+        onToggle={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByTestId('legend-terrain-synthetic')).toBeInTheDocument();
+    expect(screen.getByText('3D terrain')).toBeInTheDocument();
+  });
 });

--- a/frontend/src/components/viewer/__tests__/LayerLegend.test.tsx
+++ b/frontend/src/components/viewer/__tests__/LayerLegend.test.tsx
@@ -344,4 +344,30 @@ describe('LayerLegend terrain consistency (Fix 1)', () => {
 
     expect(screen.getByText('Hillshade relief')).toBeInTheDocument();
   });
+
+  // Dedup: when the terrain SOURCE DEM is shown as a visible hillshade entry of
+  // the same dataset (the Matterhorn swissALTI3D case), suppress the synthetic
+  // "3D terrain" entry so the legend doesn't list one DEM twice.
+  it('drops the synthetic entry when the source DEM is shown as a visible hillshade layer', () => {
+    render(
+      <LayerLegend
+        layers={[
+          demLayer({
+            id: 'dem-hillshade',
+            display_name: 'swissALTI3D relief',
+            style_config: { render_mode: 'hillshade' } as SharedLayerResponse['style_config'],
+          }),
+        ]}
+        visibleLayers={new Set(['dem-hillshade'])}
+        terrainConfig={activeTerrain}
+        onToggleVisibility={vi.fn()}
+        isOpen
+        onToggle={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText('swissALTI3D relief')).toBeInTheDocument();
+    expect(screen.queryByTestId('legend-terrain-synthetic')).not.toBeInTheDocument();
+    expect(screen.queryByText('3D terrain')).not.toBeInTheDocument();
+  });
 });

--- a/frontend/src/components/viewer/__tests__/LayerLegend.test.tsx
+++ b/frontend/src/components/viewer/__tests__/LayerLegend.test.tsx
@@ -371,8 +371,8 @@ describe('LayerLegend terrain consistency (Fix 1)', () => {
     expect(screen.queryByText('3D terrain')).not.toBeInTheDocument();
   });
 
-  // Codex P2: the viewer keeps toggled-off layers in the list (visibility lives
-  // in visibleLayers, not the list), but 3D terrain stays active from
+  // Regression: the viewer keeps toggled-off layers in the list (visibility
+  // lives in visibleLayers, not the list), but 3D terrain stays active from
   // terrain_config regardless. If the source hillshade is toggled OFF, the
   // synthetic entry must STILL show — otherwise active 3D terrain has no legend
   // representation. So dedup against visible entries only.

--- a/frontend/src/pages/MapBuilderPage.tsx
+++ b/frontend/src/pages/MapBuilderPage.tsx
@@ -79,6 +79,7 @@ import { useFilteredFeatureCount } from '@/components/builder/hooks/use-filtered
 import { useBuilderLayers } from '@/components/builder/hooks/use-builder-layers';
 import { useBuilderSave } from '@/components/builder/hooks/use-builder-save';
 import { TERRAIN_SOURCE_ID, normalizeTerrainExaggeration, isHillshadeTerrainBound, isDemTerrainVisualSuppressed } from '@/components/builder/map-sync';
+import { resolveTerrainSourceLayer } from '@/components/builder/map-stack';
 import {
   createBuilderBasemapState,
   removeBasemap as removeBasemapFromState,
@@ -1016,14 +1017,20 @@ export function MapBuilderPage() {
 
   // Terrain is layer-owned: the map-level terrain source is active only while
   // the bound DEM layer is in Terrain render mode.
-  const boundTerrainLayer = useMemo(() => {
-    if (!layers.localTerrainConfig?.source_dataset_id) return undefined;
-    return layers.localLayers.find(
-      (l) => l.dataset_id === layers.localTerrainConfig?.source_dataset_id
-        && (l.style_config as { render_mode?: unknown } | null | undefined)?.render_mode === 'terrain',
-    );
-  }, [layers.localLayers, layers.localTerrainConfig]);
-  const isTerrainActive = Boolean(layers.localTerrainConfig?.enabled && boundTerrainLayer);
+  // Resolve the bound terrain DEM the SAME way the map renderer does
+  // (BuilderMap FIX-3-RESOLVER D-06): by source_dataset_id + isTerrainCapableDemLayer,
+  // NOT by render_mode === 'terrain'. A hillshade-mode DEM drives the 3D mesh
+  // too, so requiring terrain mode here made the settings report "No terrain
+  // layer is active" while the map was actively rendering terrain from it.
+  const boundTerrainLayer = useMemo(
+    () => resolveTerrainSourceLayer(layers.localLayers, layers.localTerrainConfig),
+    [layers.localLayers, layers.localTerrainConfig],
+  );
+  // Match the map's effectiveTerrainEnabled: terrain only renders when the bound
+  // DEM is also visible (BuilderMap sets terrain to null for a hidden DEM).
+  const isTerrainActive = Boolean(
+    layers.localTerrainConfig?.enabled && boundTerrainLayer && boundTerrainLayer.visible !== false,
+  );
   const boundLayerName = boundTerrainLayer
     ? (boundTerrainLayer.display_name ?? boundTerrainLayer.dataset_name ?? undefined)
     : undefined;

--- a/frontend/src/pages/MapBuilderPage.tsx
+++ b/frontend/src/pages/MapBuilderPage.tsx
@@ -1015,13 +1015,11 @@ export function MapBuilderPage() {
     handleSelectLayer('basemap-group');
   }, [handleSelectLayer]);
 
-  // Terrain is layer-owned: the map-level terrain source is active only while
-  // the bound DEM layer is in Terrain render mode.
-  // Resolve the bound terrain DEM the SAME way the map renderer does
-  // (BuilderMap FIX-3-RESOLVER D-06): by source_dataset_id + isTerrainCapableDemLayer,
-  // NOT by render_mode === 'terrain'. A hillshade-mode DEM drives the 3D mesh
-  // too, so requiring terrain mode here made the settings report "No terrain
-  // layer is active" while the map was actively rendering terrain from it.
+  // Resolve the bound terrain DEM the SAME way the map renderer (BuilderMap)
+  // does: by source_dataset_id + isTerrainCapableDemLayer, NOT by
+  // render_mode === 'terrain'. A hillshade-mode DEM drives the 3D mesh too, so
+  // requiring terrain mode here made the settings report "No terrain layer is
+  // active" while the map was actively rendering terrain from it.
   const boundTerrainLayer = useMemo(
     () => resolveTerrainSourceLayer(layers.localLayers, layers.localTerrainConfig),
     [layers.localLayers, layers.localTerrainConfig],


### PR DESCRIPTION
Two related fixes making the terrain truth consistent across the map, the legend, and the settings panel. Both stem from the renderer resolving terrain **mode-agnostically** (a hillshade-mode DEM drives the 3D mesh and paints its 2D relief) while other surfaces hadn't caught up.

## 1. Legend: dedup the synthetic "3D terrain" entry
On the swissALTI3D Matterhorn map the on-map legend showed a "3D terrain" row with no counterpart in the layer list that **duplicated** the visible "swissALTI3D relief" hillshade — same dataset (`terrain_config.source_dataset_id` == the visible DEM's `dataset_id`). `deriveTerrainLegendEntry` fires render-mode-agnostically, so when the source DEM also paints a visible hillshade the dataset appears twice.

Fix: suppress the synthetic entry when the terrain source dataset is already a **visible** per-layer entry, via a shared `terrainSourceIsShownAsLayer` gated in both consumers (builder `LegendPlugin` against `legendLayers`, viewer `LayerLegend` against currently-visible `sorted` entries — the viewer keeps toggled-off rows, so it must dedup against visible ones only, else toggling the hillshade off would hide both it and the synthetic row while terrain is still active). Kept for the pure-terrain / hidden-source case where the synthetic row is the only indicator.

## 2. Settings: "No terrain layer is active" shown while terrain renders
The map renderer (`BuilderMap` FIX-3-RESOLVER D-06) resolves the terrain DEM by `source_dataset_id` + `isTerrainCapableDemLayer`, **not** `render_mode === 'terrain'`. But `MapBuilderPage.isTerrainActive` (via `boundTerrainLayer`) still required terrain mode — so the Matterhorn map (terrain enabled, DEM in hillshade mode) reported **"No terrain layer is active"** while the 3D mesh was rendering from that DEM.

Fix: extract one shared `resolveTerrainSourceLayer` (map-stack) and consume it in **both** the renderer and the status computation so they can't drift again (the drift is what caused this bug). `isTerrainActive` now also honors the DEM's visibility, matching the renderer's `effectiveTerrainEnabled` (terrain clears when the bound DEM is hidden). Stale `SettingsEditorScene` JSDoc updated.

## Tests
- `terrain-legend.test.ts` — `terrainSourceIsShownAsLayer` unit tests
- `LegendPlugin.terrain.test.tsx` + `LayerLegend.test.tsx` — dedup guards incl. the toggled-off-source case (Codex P2 regression)
- `map-stack.test.ts` — `resolveTerrainSourceLayer` unit tests (hillshade + terrain modes resolve; non-DEM / wrong dataset / no source → undefined)
- Existing D-01/D-02/D-03, position, dangling, and BuilderMap terrain-visibility cases unchanged. Typecheck + lint clean.

## Out of scope (noted)
The builder *layer list* (`UnifiedStackPanel`) renders raw layers and has no terrain row — after fix 1 the legend matches it. The stack's `makeTerrainReliefEntry` still computes terrain "active" by terrain-mode only, but that row isn't rendered anywhere user-facing.