### PR TITLE
v1049 Polish & Trust Pass: builder, admin & UX bug-bash

### DIFF
--- a/backend/app/modules/catalog/maps/schemas.py
+++ b/backend/app/modules/catalog/maps/schemas.py
@@ -88,6 +88,7 @@ _BUILDER_CAMEL_TO_SNAKE_KEYS = {
     "clusterColor": "cluster_color",
     "clusterTextColor": "cluster_text_color",
     "clusterTextSize": "cluster_text_size",
+    "clusterColorRamp": "cluster_color_ramp",
     "folderGroupId": "folder_group_id",
     "folderGroupName": "folder_group_name",
     "folderGroupExpanded": "folder_group_expanded",

--- a/backend/app/modules/catalog/maps/schemas.py
+++ b/backend/app/modules/catalog/maps/schemas.py
@@ -1154,12 +1154,15 @@ class OgImageUploadRequest(BaseModel):
 
 
 class AdminShareTokenResponse(BaseModel):
-    id: uuid.UUID
+    # ADM-01: the admin "Published Maps" listing includes public maps that have
+    # no share link, so the token-specific fields are nullable. `created_at` is
+    # the map's creation time (always present).
+    id: uuid.UUID | None = None
     map_id: uuid.UUID
     map_name: str
-    token: str
-    is_active: bool
-    expires_at: datetime | None
+    token: str | None = None
+    is_active: bool | None = None
+    expires_at: datetime | None = None
     created_at: datetime
     created_by: str | None
     embed_token_count: int = 0

--- a/backend/app/modules/catalog/maps/schemas.py
+++ b/backend/app/modules/catalog/maps/schemas.py
@@ -1154,7 +1154,7 @@ class OgImageUploadRequest(BaseModel):
 
 
 class AdminShareTokenResponse(BaseModel):
-    # ADM-01: the admin "Published Maps" listing includes public maps that have
+    # #347 (ADM-01): the admin "Published Maps" listing includes public maps that have
     # no share link, so the token-specific fields are nullable. `created_at` is
     # the map's creation time (always present).
     id: uuid.UUID | None = None

--- a/backend/app/modules/catalog/maps/service_public.py
+++ b/backend/app/modules/catalog/maps/service_public.py
@@ -426,43 +426,35 @@ async def list_share_tokens(
     search: str | None = None,
     status_filter: str | None = None,
 ) -> tuple[list[dict], int]:
-    """List all share tokens with map names and embed token counts for admin view."""
-    from app.modules.embed_tokens.models import EmbedToken
+    """List published (``visibility='public'``) maps with their latest share-link
+    status and active embed-token count for the admin "Published Maps" view.
 
-    # Build base filter conditions.
-    # Typed as the SQLAlchemy `ColumnElement[bool]` supertype so both
-    # BinaryExpression (`col == val`) and combined OR expressions fit
-    # without per-append type ignores.
+    ADM-01: every public map appears whether or not it has a share link — the
+    listing is keyed on ``Map`` (not ``MapShareToken``), LEFT JOINed to the most
+    recent share token per map (preferring an active one). Maps without a link
+    carry null ``id``/``token``/``is_active``. ``created_at``/``created_by`` are
+    the map's, so the column is meaningful for unshared maps too. The optional
+    status filter narrows to maps whose latest link is active/expired/revoked.
+    """
+    from sqlalchemy.orm import aliased
     from sqlalchemy.sql import ColumnElement
 
-    conditions: list[ColumnElement[bool]] = []
-    if search:
-        # T-2: lower() column + pattern to hit ix_maps_name_trgm (on lower(name)).
-        conditions.append(
-            func.lower(Map.name).like(f"%{escape_ilike(search)}%".lower(), escape="\\")
-        )
-    if status_filter == "active":
-        conditions.append(MapShareToken.is_active.is_(True))
-        conditions.append(
-            or_(
-                MapShareToken.expires_at.is_(None),
-                MapShareToken.expires_at > func.now(),
-            )
-        )
-    elif status_filter == "expired":
-        conditions.append(MapShareToken.is_active.is_(True))
-        conditions.append(MapShareToken.expires_at <= func.now())
-    elif status_filter == "revoked":
-        conditions.append(MapShareToken.is_active.is_(False))
+    from app.modules.embed_tokens.models import EmbedToken
 
-    count_stmt = (
-        select(func.count())
-        .select_from(MapShareToken)
-        .join(Map, MapShareToken.map_id == Map.id)
+    # Most-recent share token per map (DISTINCT ON map_id, preferring an active
+    # token, then newest). map_id has no unique constraint, so a map may have
+    # several historical tokens — collapse to one row per map.
+    latest_token_sub = (
+        select(MapShareToken)
+        .order_by(
+            MapShareToken.map_id,
+            MapShareToken.is_active.desc(),
+            MapShareToken.created_at.desc(),
+        )
+        .distinct(MapShareToken.map_id)
+        .subquery()
     )
-    for cond in conditions:
-        count_stmt = count_stmt.where(cond)
-    total = (await session.execute(count_stmt)).scalar_one()
+    share = aliased(MapShareToken, latest_token_sub)
 
     embed_count_sub = (
         select(
@@ -474,17 +466,52 @@ async def list_share_tokens(
         .subquery()
     )
 
+    # Base conditions scope to published maps; the status filter (when given)
+    # narrows on the joined share-link state.
+    conditions: list[ColumnElement[bool]] = [Map.visibility == "public"]
+    if search:
+        # T-2: lower() column + pattern to hit ix_maps_name_trgm (on lower(name)).
+        conditions.append(
+            func.lower(Map.name).like(f"%{escape_ilike(search)}%".lower(), escape="\\")
+        )
+    if status_filter == "active":
+        conditions.append(share.is_active.is_(True))
+        conditions.append(
+            or_(
+                share.expires_at.is_(None),
+                share.expires_at > func.now(),
+            )
+        )
+    elif status_filter == "expired":
+        conditions.append(share.is_active.is_(True))
+        conditions.append(share.expires_at <= func.now())
+    elif status_filter == "revoked":
+        conditions.append(share.is_active.is_(False))
+
+    count_stmt = (
+        select(func.count()).select_from(Map).outerjoin(share, share.map_id == Map.id)
+    )
+    for cond in conditions:
+        count_stmt = count_stmt.where(cond)
+    total = (await session.execute(count_stmt)).scalar_one()
+
     stmt = (
         select(
-            MapShareToken,
+            share.id.label("token_id"),
+            share.token_hint.label("token_hint"),
+            share.is_active.label("is_active"),
+            share.expires_at.label("expires_at"),
+            Map.id.label("map_id"),
             Map.name.label("map_name"),
+            Map.created_at.label("map_created_at"),
             func.coalesce(embed_count_sub.c.embed_count, 0).label("embed_token_count"),
             User.username.label("creator_username"),
         )
-        .join(Map, MapShareToken.map_id == Map.id)
-        .outerjoin(User, MapShareToken.created_by == User.id)
-        .outerjoin(embed_count_sub, MapShareToken.map_id == embed_count_sub.c.map_id)
-        .order_by(MapShareToken.created_at.desc())
+        .select_from(Map)
+        .outerjoin(share, share.map_id == Map.id)
+        .outerjoin(User, Map.created_by == User.id)
+        .outerjoin(embed_count_sub, embed_count_sub.c.map_id == Map.id)
+        .order_by(Map.created_at.desc())
         .offset(skip)
         .limit(limit)
     )
@@ -494,18 +521,18 @@ async def list_share_tokens(
     rows = result.all()
 
     tokens = []
-    for token_obj, map_name, embed_token_count, creator_username in rows:
+    for row in rows:
         tokens.append(
             {
-                "id": token_obj.id,
-                "map_id": token_obj.map_id,
-                "map_name": map_name,
-                "token": token_obj.token_hint,
-                "is_active": token_obj.is_active,
-                "expires_at": token_obj.expires_at,
-                "created_at": token_obj.created_at,
-                "created_by": creator_username,
-                "embed_token_count": embed_token_count,
+                "id": row.token_id,
+                "map_id": row.map_id,
+                "map_name": row.map_name,
+                "token": row.token_hint,
+                "is_active": row.is_active,
+                "expires_at": row.expires_at,
+                "created_at": row.map_created_at,
+                "created_by": row.creator_username,
+                "embed_token_count": row.embed_token_count,
             }
         )
     return tokens, total

--- a/backend/app/modules/catalog/maps/service_public.py
+++ b/backend/app/modules/catalog/maps/service_public.py
@@ -429,7 +429,7 @@ async def list_share_tokens(
     """List published (``visibility='public'``) maps with their latest share-link
     status and active embed-token count for the admin "Published Maps" view.
 
-    ADM-01: every public map appears whether or not it has a share link — the
+    #347 (ADM-01): every public map appears whether or not it has a share link — the
     listing is keyed on ``Map`` (not ``MapShareToken``), LEFT JOINed to the most
     recent share token per map (preferring an active one). Maps without a link
     carry null ``id``/``token``/``is_active``. ``created_at``/``created_by`` are

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -573,13 +573,27 @@
             "title": "Expires At"
           },
           "id": {
-            "format": "uuid",
-            "title": "Id",
-            "type": "string"
+            "anyOf": [
+              {
+                "format": "uuid",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Id"
           },
           "is_active": {
-            "title": "Is Active",
-            "type": "boolean"
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Is Active"
           },
           "map_id": {
             "format": "uuid",
@@ -591,17 +605,20 @@
             "type": "string"
           },
           "token": {
-            "title": "Token",
-            "type": "string"
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Token"
           }
         },
         "required": [
-          "id",
           "map_id",
           "map_name",
-          "token",
-          "is_active",
-          "expires_at",
           "created_at",
           "created_by"
         ],

--- a/backend/tests/test_admin_invariants_regression.py
+++ b/backend/tests/test_admin_invariants_regression.py
@@ -150,6 +150,48 @@ async def test_last_admin_demote_is_rejected(client, test_db_session):
 
 
 # ---------------------------------------------------------------------------
+# ADM-04: deactivate guards return a SPECIFIC reason (surfaced in the admin
+# toast). Locks the exact detail strings so the frontend keeps a meaningful
+# message instead of a generic "Failed to deactivate user".
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_last_admin_deactivate_is_rejected(client, test_db_session):
+    """Deactivating the sole admin raises the specific last-admin guard string."""
+    from app.modules.auth.models import Role
+
+    result = await test_db_session.execute(
+        select(User)
+        .join(UserRole, User.id == UserRole.user_id)
+        .join(Role, UserRole.role_id == Role.id)
+        .where(Role.name == "admin")
+    )
+    admin_users = result.scalars().all()
+    assert admin_users, "No admin user in test DB"
+
+    if len(admin_users) == 1:
+        service = AdminService(test_db_session)
+        await test_db_session.refresh(admin_users[0], attribute_names=["roles"])
+        with pytest.raises(ValueError, match="Cannot deactivate the last admin user"):
+            await service.deactivate_user(admin_users[0].id)
+    else:
+        pytest.skip("Multiple admins in test DB — sole-admin guard not exercisable")
+
+
+@pytest.mark.anyio
+async def test_deactivate_self_is_rejected(client, test_db_session):
+    """Deactivating your own account raises the specific self-guard string."""
+    result = await test_db_session.execute(select(User).limit(1))
+    user = result.scalar_one_or_none()
+    assert user is not None, "No user in test DB"
+
+    service = AdminService(test_db_session)
+    with pytest.raises(ValueError, match="Cannot deactivate your own account"):
+        await service.deactivate_user(user.id, current_user_id=user.id)
+
+
+# ---------------------------------------------------------------------------
 # Invariant 3: OAuth client_secret redaction in audit details
 # ---------------------------------------------------------------------------
 

--- a/backend/tests/test_admin_invariants_regression.py
+++ b/backend/tests/test_admin_invariants_regression.py
@@ -150,7 +150,7 @@ async def test_last_admin_demote_is_rejected(client, test_db_session):
 
 
 # ---------------------------------------------------------------------------
-# ADM-04: deactivate guards return a SPECIFIC reason (surfaced in the admin
+# #347 (ADM-04): deactivate guards return a SPECIFIC reason (surfaced in the admin
 # toast). Locks the exact detail strings so the frontend keeps a meaningful
 # message instead of a generic "Failed to deactivate user".
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -782,7 +782,11 @@ def test_decomposed_service_modules_stay_within_size_budgets() -> None:
         # Phase 1176 SEC-024: +20 lines for _redact_terrain_config (strip the
         # private DEM source_dataset_id from shared/public map responses when the
         # DEM is not a visible layer). Cap raised 600 → 625 (~5 LOC headroom).
-        "backend/app/modules/catalog/maps/service_public.py": 625,
+        # #347 (ADM-01): +24 lines — the admin "Published Maps" listing re-keys
+        # on Map (visibility=public) LEFT JOINed to the latest share token per
+        # map (DISTINCT ON) so every published map appears, not just shared ones.
+        # Cap raised 625 → 660 (~11 LOC headroom).
+        "backend/app/modules/catalog/maps/service_public.py": 660,
         "backend/app/modules/catalog/search/service_records.py": 500,
         # Phase 269 H-05: dataset-domain modules over the 350 default at audit
         # time. Caps set ~20-30 LOC above current size to allow modest growth

--- a/backend/tests/test_maps.py
+++ b/backend/tests/test_maps.py
@@ -3407,7 +3407,7 @@ class TestAdminShareTokenListing:
     async def test_admin_published_map_without_share_token_appears(
         self, client: AsyncClient, admin_auth_header: dict
     ):
-        """ADM-01: a public map with no share link still appears in the admin
+        """#347 (ADM-01): a public map with no share link still appears in the admin
         Published Maps listing, with null token fields."""
         unique_name = f"NoLinkPublished_{uuid.uuid4().hex[:6]}"
         created = await _create_map(client, admin_auth_header, name=unique_name)

--- a/backend/tests/test_maps.py
+++ b/backend/tests/test_maps.py
@@ -3404,6 +3404,35 @@ class TestAdminShareTokenListing:
         assert "total" in data
         assert data["total"] >= 1
 
+    async def test_admin_published_map_without_share_token_appears(
+        self, client: AsyncClient, admin_auth_header: dict
+    ):
+        """ADM-01: a public map with no share link still appears in the admin
+        Published Maps listing, with null token fields."""
+        unique_name = f"NoLinkPublished_{uuid.uuid4().hex[:6]}"
+        created = await _create_map(client, admin_auth_header, name=unique_name)
+        map_id = created["id"]
+        await client.put(
+            f"/maps/{map_id}",
+            json={"visibility": "public"},
+            headers=admin_auth_header,
+        )
+        # Deliberately do NOT create a share token.
+
+        resp = await client.get(
+            f"/admin/share-tokens/?search={unique_name}",
+            headers=admin_auth_header,
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        rows = [t for t in data["tokens"] if t["map_id"] == map_id]
+        assert len(rows) == 1, "published map without a share link should appear once"
+        row = rows[0]
+        assert row["id"] is None
+        assert row["token"] is None
+        assert row["is_active"] is None
+        assert row["embed_token_count"] == 0
+
     async def test_admin_search_share_tokens(
         self,
         client: AsyncClient,

--- a/backend/tests/test_sso_login_mode.py
+++ b/backend/tests/test_sso_login_mode.py
@@ -128,7 +128,7 @@ class TestPasswordLoginEnabledGate:
                 f"Expected 403 for non-admin with password_login_enabled=false, "
                 f"got {resp.status_code}: {resp.text}"
             )
-            # SEC-01: pin the EXACT gate message. The reported "bypass" (clicking
+            # #347 (SEC-01): pin the EXACT gate message. The reported "bypass" (clicking
             # the login-page break-glass link) only reveals the form — the server
             # still rejects a non-admin password login here. Asserting the exact
             # 403 detail locks the gate so it cannot silently weaken to a vague

--- a/backend/tests/test_sso_login_mode.py
+++ b/backend/tests/test_sso_login_mode.py
@@ -128,9 +128,14 @@ class TestPasswordLoginEnabledGate:
                 f"Expected 403 for non-admin with password_login_enabled=false, "
                 f"got {resp.status_code}: {resp.text}"
             )
+            # SEC-01: pin the EXACT gate message. The reported "bypass" (clicking
+            # the login-page break-glass link) only reveals the form — the server
+            # still rejects a non-admin password login here. Asserting the exact
+            # 403 detail locks the gate so it cannot silently weaken to a vague
+            # message or a 200.
             assert (
-                "SSO provider" in resp.json()["detail"]
-                or "disabled" in resp.json()["detail"]
+                resp.json()["detail"]
+                == "Password login is disabled; sign in with your SSO provider"
             )
         finally:
             await _reset_password_login_enabled(client, admin_auth_header)

--- a/frontend/src/components/admin/AdminSidebar.tsx
+++ b/frontend/src/components/admin/AdminSidebar.tsx
@@ -32,7 +32,12 @@ import {
   ArrowLeft,
 } from 'lucide-react';
 import type { LucideIcon } from 'lucide-react';
-import { usePendingCount, useFailedJobCount } from '@/hooks/use-admin';
+import {
+  useFailedJobCount,
+  useUserCount,
+  usePublishedMapCount,
+  useAuditLogCount,
+} from '@/hooks/use-admin';
 import { useEdition } from '@/hooks/use-edition';
 import { useEnterpriseOnlyTabs } from '@/hooks/use-settings';
 
@@ -44,15 +49,15 @@ type OperationItem = {
   labelKey: string;
   to: string;
   icon: LucideIcon;
-  badgeKey?: 'pending' | 'failed';
+  badgeKey?: 'users' | 'failed' | 'audit' | 'sharedMaps';
   enterpriseOnly?: boolean;
 };
 
 const operationsItems: readonly OperationItem[] = [
-  { labelKey: 'adminNav.users', to: '/admin/users', icon: Users, badgeKey: 'pending' },
+  { labelKey: 'adminNav.users', to: '/admin/users', icon: Users, badgeKey: 'users' },
   { labelKey: 'adminNav.jobs', to: '/admin/jobs', icon: Briefcase, badgeKey: 'failed' },
-  { labelKey: 'adminNav.auditLog', to: '/admin/audit', icon: ScrollText },
-  { labelKey: 'adminNav.sharedMaps', to: '/admin/shared-maps', icon: Link2 },
+  { labelKey: 'adminNav.auditLog', to: '/admin/audit', icon: ScrollText, badgeKey: 'audit' },
+  { labelKey: 'adminNav.sharedMaps', to: '/admin/shared-maps', icon: Link2, badgeKey: 'sharedMaps' },
   { labelKey: 'adminNav.saml', to: '/admin/saml', icon: Lock, enterpriseOnly: true },
 ];
 
@@ -97,16 +102,18 @@ const settingsItemsBase: readonly SettingsNavBaseItem[] = [
  * Admin section navigation sidebar.
  *
  * Renders the admin navigation tree (Overview, Users, Jobs, Audit, Shared Maps,
- * Settings sub-tabs, Config Ops) with active-route highlighting, badge counts
- * for pending users and failed jobs (live via `usePendingCount` /
- * `useFailedJobCount`), and visibility filtering for `enterpriseOnly` items
+ * Settings sub-tabs, Config Ops) with active-route highlighting, total count
+ * badges for Users / Published Maps / Audit Log plus a failed-jobs badge
+ * (each capped at 999+), and visibility filtering for `enterpriseOnly` items
  * via the `useEdition` hook.
  */
 export function AdminSidebar() {
   const { pathname } = useLocation();
   const { t } = useTranslation();
-  const { data: pendingCount } = usePendingCount();
+  const { data: userCount } = useUserCount();
   const { data: failedJobCount } = useFailedJobCount();
+  const { data: auditLogCount } = useAuditLogCount();
+  const { data: publishedMapCount } = usePublishedMapCount();
   const { isEnterprise } = useEdition();
   const { data: enterpriseTabsData } = useEnterpriseOnlyTabs();
 
@@ -127,9 +134,14 @@ export function AdminSidebar() {
   const visibleOperationsItems = operationsItems.filter(item => !item.enterpriseOnly || isEnterprise);
 
   const badgeCounts: Record<string, number | undefined> = {
-    pending: pendingCount,
+    users: userCount,
     failed: failedJobCount,
+    audit: auditLogCount,
+    sharedMaps: publishedMapCount,
   };
+
+  // ADM-02: cap large counts at 999+ in the small sidebar badge.
+  const capBadge = (n: number) => (n > 999 ? '999+' : String(n));
 
   return (
     <Sidebar collapsible="icon" variant="sidebar" side="left">
@@ -179,7 +191,7 @@ export function AdminSidebar() {
                       </NavLink>
                     </SidebarMenuButton>
                     {count !== undefined && count > 0 && (
-                      <SidebarMenuBadge>{count}</SidebarMenuBadge>
+                      <SidebarMenuBadge>{capBadge(count)}</SidebarMenuBadge>
                     )}
                   </SidebarMenuItem>
                 );

--- a/frontend/src/components/admin/AdminSidebar.tsx
+++ b/frontend/src/components/admin/AdminSidebar.tsx
@@ -140,7 +140,7 @@ export function AdminSidebar() {
     sharedMaps: publishedMapCount,
   };
 
-  // ADM-02: cap large counts at 999+ in the small sidebar badge.
+  // #347 (ADM-02): cap large counts at 999+ in the small sidebar badge.
   const capBadge = (n: number) => (n > 999 ? '999+' : String(n));
 
   return (

--- a/frontend/src/components/admin/StatsOverview.tsx
+++ b/frontend/src/components/admin/StatsOverview.tsx
@@ -8,7 +8,6 @@ import {
   XCircle,
   RefreshCw,
   Shield,
-  Users,
 } from 'lucide-react';
 import { useCatalogStats, useInfrastructure } from '@/hooks/use-admin';
 import { AIStatusCard } from '@/components/admin/AIStatusCard';
@@ -247,7 +246,7 @@ export function StatsOverview() {
       </div>
 
       {/* Breakdown Cards */}
-      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
         <Card>
           <CardHeader>
             <CardTitle className="text-sm font-medium">{t('stats.byGeometryType')}</CardTitle>
@@ -307,45 +306,6 @@ export function StatsOverview() {
                         variant="secondary"
                       >
                         {getVisibilityLabel(t, visibility)}
-                      </Badge>
-                      <span className="font-medium">{count}</span>
-                    </li>
-                  ))}
-              </ul>
-            )}
-          </CardContent>
-        </Card>
-
-        <Card>
-          <CardHeader>
-            <CardTitle className="text-sm font-medium flex items-center gap-2">
-              <Users className="h-4 w-4" />
-              {t('stats.usersByStatus')}
-            </CardTitle>
-          </CardHeader>
-          <CardContent>
-            {Object.keys(data.users_by_status).length === 0 ? (
-              <p className="text-sm text-muted-foreground">{t('stats.noUsers')}</p>
-            ) : (
-              <ul className="space-y-2">
-                {Object.entries(data.users_by_status)
-                  .sort(([, a], [, b]) => b - a)
-                  .map(([userStatus, count]) => (
-                    <li
-                      key={userStatus}
-                      className="flex items-center justify-between text-sm"
-                    >
-                      <Badge
-                        variant="secondary"
-                        className={
-                          userStatus === 'active'
-                            ? semanticBadgeColors.success
-                            : userStatus === 'pending'
-                              ? semanticBadgeColors.warning
-                              : ''
-                        }
-                      >
-                        {userStatus}
                       </Badge>
                       <span className="font-medium">{count}</span>
                     </li>

--- a/frontend/src/components/admin/__tests__/AdminSidebar.test.tsx
+++ b/frontend/src/components/admin/__tests__/AdminSidebar.test.tsx
@@ -160,7 +160,7 @@ describe('AdminSidebar', () => {
     expect(link).toHaveAttribute('href', '/');
   });
 
-  it('shows total count badges and caps large counts at 999+ (ADM-02)', () => {
+  it('shows total count badges and caps large counts at 999+ (#347 (ADM-02))', () => {
     counts.users = 62;
     counts.audit = 1500;
     counts.published = 10;

--- a/frontend/src/components/admin/__tests__/AdminSidebar.test.tsx
+++ b/frontend/src/components/admin/__tests__/AdminSidebar.test.tsx
@@ -4,9 +4,13 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { SidebarProvider } from '@/components/ui/sidebar';
 import { AdminSidebar } from '../AdminSidebar';
 
+const counts = vi.hoisted(() => ({ users: 0, failed: 0, audit: 0, published: 0 }));
+
 vi.mock('@/hooks/use-admin', () => ({
-  usePendingCount: () => ({ data: 0 }),
-  useFailedJobCount: () => ({ data: 0 }),
+  useUserCount: () => ({ data: counts.users }),
+  useFailedJobCount: () => ({ data: counts.failed }),
+  useAuditLogCount: () => ({ data: counts.audit }),
+  usePublishedMapCount: () => ({ data: counts.published }),
 }));
 
 // Default: community edition. Individual tests can override per-call via
@@ -64,6 +68,13 @@ vi.mock('react-i18next', () => ({
     },
   }),
 }));
+
+beforeEach(() => {
+  counts.users = 0;
+  counts.failed = 0;
+  counts.audit = 0;
+  counts.published = 0;
+});
 
 // SidebarProvider uses useIsMobile which calls window.matchMedia
 beforeAll(() => {
@@ -147,6 +158,17 @@ describe('AdminSidebar', () => {
     renderSidebar();
     const link = screen.getByText('Back to App').closest('a');
     expect(link).toHaveAttribute('href', '/');
+  });
+
+  it('shows total count badges and caps large counts at 999+ (ADM-02)', () => {
+    counts.users = 62;
+    counts.audit = 1500;
+    counts.published = 10;
+    counts.failed = 0; // hidden when 0
+    renderSidebar();
+    expect(screen.getByText('62')).toBeInTheDocument();
+    expect(screen.getByText('999+')).toBeInTheDocument();
+    expect(screen.getByText('10')).toBeInTheDocument();
   });
 });
 

--- a/frontend/src/components/admin/settings/SettingsAITab.tsx
+++ b/frontend/src/components/admin/settings/SettingsAITab.tsx
@@ -347,7 +347,7 @@ export function SettingsAITab({ settings, envOnly, onSave, onReset, isSaving, on
                     onClick={() => handleBackfill(false)}
                     disabled={backfill.isPending}
                   >
-                    {backfill.isPending ? (
+                    {backfill.isPending && backfill.variables === false ? (
                       <>
                         <Loader2 className="me-2 h-3 w-3 animate-spin" />
                         {t('ai.generating')}
@@ -365,7 +365,7 @@ export function SettingsAITab({ settings, envOnly, onSave, onReset, isSaving, on
                     onClick={() => handleBackfill(true)}
                     disabled={backfill.isPending}
                   >
-                    {backfill.isPending ? (
+                    {backfill.isPending && backfill.variables === true ? (
                       <>
                         <Loader2 className="me-2 h-3 w-3 animate-spin" />
                         {t('ai.generating')}

--- a/frontend/src/components/admin/settings/__tests__/SettingsAITab.test.tsx
+++ b/frontend/src/components/admin/settings/__tests__/SettingsAITab.test.tsx
@@ -1,7 +1,7 @@
 import { render } from '@/test/test-utils';
 import { SettingsAITab } from '../SettingsAITab';
 
-// ADM-05 regression: the Embedding Coverage box has two buttons ("Generate
+// #347 (ADM-05) regression: the Embedding Coverage box has two buttons ("Generate
 // Missing" + "Regenerate All") backed by one backfill mutation. Each spinner
 // must key off backfill.variables (false = missing, true = regenerate) so only
 // the clicked button spins — previously both keyed off backfill.isPending and
@@ -44,7 +44,7 @@ function renderTab() {
   );
 }
 
-describe('SettingsAITab — embedding coverage single spinner (ADM-05)', () => {
+describe('SettingsAITab — embedding coverage single spinner (#347 (ADM-05))', () => {
   it('shows exactly one spinner — only Regenerate All — while regenerating', () => {
     hoisted.backfill = { mutate: vi.fn(), isPending: true, variables: true };
     const { container } = renderTab();

--- a/frontend/src/components/admin/settings/__tests__/SettingsAITab.test.tsx
+++ b/frontend/src/components/admin/settings/__tests__/SettingsAITab.test.tsx
@@ -1,0 +1,65 @@
+import { render } from '@/test/test-utils';
+import { SettingsAITab } from '../SettingsAITab';
+
+// ADM-05 regression: the Embedding Coverage box has two buttons ("Generate
+// Missing" + "Regenerate All") backed by one backfill mutation. Each spinner
+// must key off backfill.variables (false = missing, true = regenerate) so only
+// the clicked button spins — previously both keyed off backfill.isPending and
+// both spun at once.
+
+const hoisted = vi.hoisted(() => ({
+  backfill: { mutate: vi.fn(), isPending: false, variables: undefined as unknown },
+}));
+
+vi.mock('@/hooks/use-admin', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/hooks/use-admin')>();
+  return {
+    ...actual,
+    useAIStatus: () => ({ data: { available: true } }),
+    useEmbeddingStats: () => ({
+      data: { total_records: 100, embedded_records: 50, missing_records: 50, coverage_percent: 50 },
+    }),
+    useBackfillEmbeddings: () => hoisted.backfill,
+    useUpdateSemanticSearch: () => ({ mutate: vi.fn(), isPending: false }),
+  };
+});
+
+vi.mock('@/hooks/use-settings', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/hooks/use-settings')>();
+  return {
+    ...actual,
+    useApiKeyStatus: () => ({ data: { configured: true } }),
+  };
+});
+
+function renderTab() {
+  return render(
+    <SettingsAITab
+      settings={[]}
+      envOnly={false}
+      onSave={vi.fn()}
+      onReset={vi.fn()}
+      isSaving={false}
+    />,
+  );
+}
+
+describe('SettingsAITab — embedding coverage single spinner (ADM-05)', () => {
+  it('shows exactly one spinner — only Regenerate All — while regenerating', () => {
+    hoisted.backfill = { mutate: vi.fn(), isPending: true, variables: true };
+    const { container } = renderTab();
+    expect(container.querySelectorAll('.animate-spin')).toHaveLength(1);
+  });
+
+  it('shows exactly one spinner — only Generate Missing — while generating missing', () => {
+    hoisted.backfill = { mutate: vi.fn(), isPending: true, variables: false };
+    const { container } = renderTab();
+    expect(container.querySelectorAll('.animate-spin')).toHaveLength(1);
+  });
+
+  it('shows no spinner when idle', () => {
+    hoisted.backfill = { mutate: vi.fn(), isPending: false, variables: undefined };
+    const { container } = renderTab();
+    expect(container.querySelectorAll('.animate-spin')).toHaveLength(0);
+  });
+});

--- a/frontend/src/components/builder/LayerStyleEditor/ClusterEditor.tsx
+++ b/frontend/src/components/builder/LayerStyleEditor/ClusterEditor.tsx
@@ -1,7 +1,21 @@
-import { StyleColorPicker } from '../StyleColorPicker';
+import { Plus, Trash2 } from 'lucide-react';
+import { StyleColorPicker, SwatchColorPopover } from '../StyleColorPicker';
 import { SliderRow } from '../HeatmapStyleControls';
 import { CIRCLE_DEFAULTS } from './utils';
+import { Switch } from '@/components/ui/switch';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
 import type { BaseStyleEditorProps } from './types';
+
+type ClusterColorStop = { count: number; color: string };
+
+// Default tiers seeded when "color by cluster size" is enabled — mirrors the
+// MapLibre "create and style clusters" example thresholds (100 / 750).
+const DEFAULT_RAMP_TIERS: ClusterColorStop[] = [
+  { count: 100, color: '#f1f075' },
+  { count: 750, color: '#f28cb1' },
+];
 
 export function ClusterEditor({
   paint,
@@ -12,6 +26,35 @@ export function ClusterEditor({
   const clusterColor = builderConfig.clusterColor
     ?? (typeof paint['circle-color'] === 'string' ? paint['circle-color'] as string : CIRCLE_DEFAULTS['circle-color']);
   const clusterTextColor = builderConfig.clusterTextColor ?? '#ffffff';
+
+  const ramp: ClusterColorStop[] = Array.isArray(builderConfig.clusterColorRamp)
+    ? builderConfig.clusterColorRamp
+    : [];
+  // A ramp needs a base + at least one threshold (2+ stops) to color by count;
+  // anything less falls back to the flat clusterColor.
+  const rampActive = ramp.length >= 2;
+
+  // Empty array (not undefined) disables the ramp without relying on builder
+  // field-deletion semantics — the adapter reads length < 2 as "flat color".
+  const setRamp = (next: ClusterColorStop[]) => onBuilderChange({ clusterColorRamp: next });
+
+  const toggleRamp = (on: boolean) => {
+    setRamp(on ? [{ count: 0, color: clusterColor }, ...DEFAULT_RAMP_TIERS] : []);
+  };
+
+  const updateStop = (index: number, patch: Partial<ClusterColorStop>) =>
+    setRamp(ramp.map((stop, i) => (i === index ? { ...stop, ...patch } : stop)));
+
+  const addStop = () => {
+    const last = ramp[ramp.length - 1];
+    setRamp([...ramp, { count: (last?.count ?? 0) + 250, color: clusterColor }]);
+  };
+
+  const removeStop = (index: number) => {
+    const next = ramp.filter((_, i) => i !== index);
+    // Drop below 2 stops → revert to flat color.
+    setRamp(next.length >= 2 ? next : []);
+  };
 
   return (
     <div className="space-y-3">
@@ -33,11 +76,75 @@ export function ClusterEditor({
         format="zoom"
         onChange={(val) => onBuilderChange({ clusterMaxZoom: val })}
       />
-      <StyleColorPicker
-        label={t('style.cluster.color')}
-        color={clusterColor}
-        onChange={(hex) => onBuilderChange({ clusterColor: hex })}
-      />
+
+      <div className="flex items-center justify-between">
+        <Label htmlFor="cluster-color-by-count" className="text-sm font-normal">
+          {t('style.cluster.colorByCount')}
+        </Label>
+        <Switch
+          id="cluster-color-by-count"
+          checked={rampActive}
+          onCheckedChange={toggleRamp}
+        />
+      </div>
+
+      {rampActive ? (
+        <div className="space-y-2">
+          <StyleColorPicker
+            label={t('style.cluster.baseColor')}
+            color={ramp[0].color}
+            onChange={(hex) => updateStop(0, { color: hex })}
+          />
+          {ramp.slice(1).map((stop, i) => {
+            const index = i + 1;
+            return (
+              <div key={index} className="flex items-center gap-2">
+                <span className="text-xs text-muted-foreground w-20">{t('style.cluster.atCount')}</span>
+                <Input
+                  type="number"
+                  min={1}
+                  value={stop.count}
+                  onChange={(e) => updateStop(index, { count: Number(e.target.value) })}
+                  className="h-7 w-20"
+                  aria-label={`${t('style.cluster.atCount')} ${index}`}
+                />
+                <SwatchColorPopover
+                  color={stop.color}
+                  onChange={(hex) => updateStop(index, { color: hex })}
+                  label={`${t('style.cluster.colorByCount')} ${index}`}
+                />
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon"
+                  className="h-7 w-7 ml-auto"
+                  onClick={() => removeStop(index)}
+                  aria-label={t('style.cluster.removeStop')}
+                >
+                  <Trash2 className="h-4 w-4" />
+                </Button>
+              </div>
+            );
+          })}
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            className="w-full"
+            onClick={addStop}
+          >
+            <Plus className="mr-1 h-4 w-4" />
+            {t('style.cluster.addStop')}
+          </Button>
+        </div>
+      ) : (
+        <StyleColorPicker
+          label={t('style.cluster.color')}
+          color={clusterColor}
+          onChange={(hex) => onBuilderChange({ clusterColor: hex })}
+        />
+      )}
+
       <StyleColorPicker
         label={t('style.cluster.countColor')}
         color={clusterTextColor}

--- a/frontend/src/components/builder/layer-adapters/__tests__/cluster-adapter.test.ts
+++ b/frontend/src/components/builder/layer-adapters/__tests__/cluster-adapter.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import { clusterAdapter, clusterCircleLayerId, clusterCountLayerId } from '../cluster-adapter';
+import { clusterAdapter, clusterCircleLayerId, clusterCountLayerId, clusterColorValue } from '../cluster-adapter';
 import type { AdapterLayerInput } from '../types';
 
 /**
@@ -125,5 +125,68 @@ describe('cluster adapter — getLayerIds returns [clusterCircle, clusterCount, 
       clusterCountLayerId('cluster-abc'),
       'cluster-abc',
     ]);
+  });
+});
+
+describe('cluster adapter — BLDR-02 cluster color ramp (point_count step)', () => {
+  it('clusterColorValue returns a flat color when ramp has fewer than 2 stops', () => {
+    expect(clusterColorValue(undefined, '#abcdef')).toBe('#abcdef');
+    expect(clusterColorValue([], '#abcdef')).toBe('#abcdef');
+    expect(clusterColorValue([{ count: 0, color: '#111111' }], '#abcdef')).toBe('#abcdef');
+  });
+
+  it('clusterColorValue builds a strictly-ascending step expression on point_count', () => {
+    const expr = clusterColorValue(
+      [
+        { count: 750, color: '#333333' },
+        { count: 0, color: '#111111' },
+        { count: 100, color: '#222222' },
+      ],
+      '#abcdef',
+    );
+    // base color first, then strictly-ascending (threshold, color) pairs
+    expect(expr).toEqual(['step', ['get', 'point_count'], '#111111', 100, '#222222', 750, '#333333']);
+  });
+
+  it('clusterColorValue drops non-ascending/non-positive thresholds and falls back to flat if no valid step remains', () => {
+    // base + a single threshold of 0 (dropped, must be > 0) → no valid step → flat
+    expect(clusterColorValue([{ count: 0, color: '#111111' }, { count: 0, color: '#222222' }], '#abcdef')).toBe('#abcdef');
+  });
+
+  it('addLayers paints the cluster circle with the step expression when a ramp is configured', () => {
+    const map = createMockMap({ layerExists: false });
+    clusterAdapter.addLayers(
+      map as unknown as import('maplibre-gl').Map,
+      makeInput({
+        style_config: {
+          render_mode: 'cluster',
+          builder: {
+            clusterColorRamp: [
+              { count: 0, color: '#111111' },
+              { count: 100, color: '#222222' },
+              { count: 750, color: '#333333' },
+            ],
+          },
+        },
+      }),
+    );
+    const calls = map.addLayer.mock.calls as Array<[{ id: string; paint?: Record<string, unknown> }]>;
+    const circleCall = calls.find(([c]) => c.id === clusterCircleLayerId('layer-cluster-1'));
+    expect(circleCall![0].paint?.['circle-color']).toEqual([
+      'step', ['get', 'point_count'], '#111111', 100, '#222222', 750, '#333333',
+    ]);
+  });
+
+  it('addLayers keeps a flat cluster circle color when no ramp is configured', () => {
+    const map = createMockMap({ layerExists: false });
+    clusterAdapter.addLayers(
+      map as unknown as import('maplibre-gl').Map,
+      makeInput({
+        style_config: { render_mode: 'cluster', builder: { clusterColor: '#0a0a0a' } },
+      }),
+    );
+    const calls = map.addLayer.mock.calls as Array<[{ id: string; paint?: Record<string, unknown> }]>;
+    const circleCall = calls.find(([c]) => c.id === clusterCircleLayerId('layer-cluster-1'));
+    expect(circleCall![0].paint?.['circle-color']).toBe('#0a0a0a');
   });
 });

--- a/frontend/src/components/builder/layer-adapters/__tests__/cluster-adapter.test.ts
+++ b/frontend/src/components/builder/layer-adapters/__tests__/cluster-adapter.test.ts
@@ -128,7 +128,7 @@ describe('cluster adapter — getLayerIds returns [clusterCircle, clusterCount, 
   });
 });
 
-describe('cluster adapter — BLDR-02 cluster color ramp (point_count step)', () => {
+describe('cluster adapter — #347 (BLDR-02) cluster color ramp (point_count step)', () => {
   it('clusterColorValue returns a flat color when ramp has fewer than 2 stops', () => {
     expect(clusterColorValue(undefined, '#abcdef')).toBe('#abcdef');
     expect(clusterColorValue([], '#abcdef')).toBe('#abcdef');

--- a/frontend/src/components/builder/layer-adapters/cluster-adapter.ts
+++ b/frontend/src/components/builder/layer-adapters/cluster-adapter.ts
@@ -69,6 +69,35 @@ function numericBuilderValue(value: unknown, fallback: number, min: number, max:
     : fallback;
 }
 
+// BLDR-02: build the cluster circle-color value. With a 2+ stop ramp (sorted
+// ascending by point_count) emit a MapLibre `step` expression — parity with the
+// MapLibre "create and style clusters" example. Otherwise fall back to the flat
+// color so existing single-color clusters are unchanged. Step inputs must be
+// strictly ascending and > 0, so duplicate/out-of-order thresholds are dropped.
+export function clusterColorValue(ramp: unknown, flatColor: string): unknown {
+  if (!Array.isArray(ramp)) return flatColor;
+  const stops = ramp
+    .filter(
+      (s): s is { count: number; color: string } =>
+        !!s &&
+        typeof s.count === 'number' &&
+        Number.isFinite(s.count) &&
+        typeof s.color === 'string',
+    )
+    .sort((a, b) => a.count - b.count);
+  if (stops.length < 2) return flatColor;
+  const expr: unknown[] = ['step', ['get', 'point_count'], stops[0].color];
+  let lastCount = 0;
+  for (let i = 1; i < stops.length; i++) {
+    const count = stops[i].count;
+    if (count <= lastCount) continue; // step inputs must be strictly ascending & > 0
+    expr.push(count, stops[i].color);
+    lastCount = count;
+  }
+  // need a base plus at least one threshold (length > 3) to be a valid ramp
+  return expr.length > 3 ? expr : flatColor;
+}
+
 function sourceLayerSpec(input: AdapterLayerInput) {
   return input.sourceType === 'geojson' ? {} : { 'source-layer': input.sourceLayer };
 }
@@ -89,11 +118,12 @@ function clusterStyle(input: AdapterLayerInput) {
   const clusterColor = typeof builder.clusterColor === 'string'
     ? builder.clusterColor
     : pointColor;
+  const circleColor = clusterColorValue(builder.clusterColorRamp, clusterColor);
   const textColor = typeof builder.clusterTextColor === 'string'
     ? builder.clusterTextColor
     : '#ffffff';
   const textSize = numericBuilderValue(builder.clusterTextSize, 12, 8, 24);
-  return { clusterColor, textColor, textSize };
+  return { clusterColor, circleColor, textColor, textSize };
 }
 
 function unclusteredPointPaint(input: AdapterLayerInput) {
@@ -108,10 +138,10 @@ function unclusteredPointPaint(input: AdapterLayerInput) {
 // sync-time paths, so the step bucket thresholds (100/750) and stroke/text styling
 // can no longer drift between first render and a subsequent sync.
 function clusterCirclePaint(input: AdapterLayerInput): Record<string, unknown> {
-  const { clusterColor } = clusterStyle(input);
+  const { circleColor } = clusterStyle(input);
   const opacity = input.opacity ?? 1;
   return {
-    'circle-color': clusterColor,
+    'circle-color': circleColor,
     'circle-radius': ['step', ['get', 'point_count'], 16, 100, 21, 750, 27],
     'circle-opacity': opacity,
     'circle-stroke-color': '#ffffff',

--- a/frontend/src/components/builder/layer-adapters/cluster-adapter.ts
+++ b/frontend/src/components/builder/layer-adapters/cluster-adapter.ts
@@ -69,7 +69,7 @@ function numericBuilderValue(value: unknown, fallback: number, min: number, max:
     : fallback;
 }
 
-// BLDR-02: build the cluster circle-color value. With a 2+ stop ramp (sorted
+// #347 (BLDR-02): build the cluster circle-color value. With a 2+ stop ramp (sorted
 // ascending by point_count) emit a MapLibre `step` expression — parity with the
 // MapLibre "create and style clusters" example. Otherwise fall back to the flat
 // color so existing single-color clusters are unchanged. Step inputs must be

--- a/frontend/src/components/builder/layer-adapters/shared.ts
+++ b/frontend/src/components/builder/layer-adapters/shared.ts
@@ -480,6 +480,7 @@ export const BUILDER_STYLE_KEY_ALIASES: Record<string, string> = {
   cluster_color: 'clusterColor',
   cluster_text_color: 'clusterTextColor',
   cluster_text_size: 'clusterTextSize',
+  cluster_color_ramp: 'clusterColorRamp',
   folder_group_id: 'folderGroupId',
   folder_group_name: 'folderGroupName',
   folder_group_expanded: 'folderGroupExpanded',

--- a/frontend/src/components/layout/AppLayout.tsx
+++ b/frontend/src/components/layout/AppLayout.tsx
@@ -49,7 +49,7 @@ export function AppLayout() {
         // #main-content into view, so the heading isn't hidden under it (#305).
         // min-h-0 on authenticated map routes fixes the flexbox min-height:auto
         // trap so the builder's editor panel scrolls internally instead of the
-        // whole builder page scrolling when an editor bar expands (BLDR-01).
+        // whole builder page scrolling when an editor bar expands (#347 (BLDR-01)).
         className={cn(
           'flex flex-1 flex-col scroll-mt-16 animate-fade-in focus:outline-none',
           isMapRoute && 'flex-col',

--- a/frontend/src/components/layout/AppLayout.tsx
+++ b/frontend/src/components/layout/AppLayout.tsx
@@ -33,7 +33,7 @@ export function AppLayout() {
   const showFooterBranding = !isEnterprise || branding?.show_badge !== false;
 
   return (
-    <div className="flex min-h-screen flex-col">
+    <div className={cn('flex flex-col', isAuthenticatedMapRoute ? 'h-dvh overflow-hidden' : 'min-h-screen')}>
       <SkipToContent />
       <Navbar />
       <DemoBanner />
@@ -47,7 +47,14 @@ export function AppLayout() {
         // isMapRoute retained for any map-specific tweaks.
         // scroll-mt clears the now-sticky navbar when the skip-link scrolls
         // #main-content into view, so the heading isn't hidden under it (#305).
-        className={cn('flex flex-1 flex-col scroll-mt-16 animate-fade-in focus:outline-none', isMapRoute && 'flex-col')}
+        // min-h-0 on authenticated map routes fixes the flexbox min-height:auto
+        // trap so the builder's editor panel scrolls internally instead of the
+        // whole builder page scrolling when an editor bar expands (BLDR-01).
+        className={cn(
+          'flex flex-1 flex-col scroll-mt-16 animate-fade-in focus:outline-none',
+          isMapRoute && 'flex-col',
+          isAuthenticatedMapRoute && 'min-h-0',
+        )}
       >
         <Outlet />
       </main>

--- a/frontend/src/components/layout/__tests__/AppLayout.test.tsx
+++ b/frontend/src/components/layout/__tests__/AppLayout.test.tsx
@@ -109,6 +109,42 @@ describe('AppLayout', () => {
     expect(screen.getByRole('contentinfo')).toBeInTheDocument();
   });
 
+  it('clips the shell to the viewport and gives main min-h-0 on authenticated map routes (BLDR-01)', () => {
+    useAuthStore.setState({
+      token: 'token',
+      refreshToken: null,
+      expiresAt: null,
+      user: {
+        id: 'user-1',
+        username: 'editor',
+        email: 'editor@example.com',
+        is_active: true,
+        status: 'active',
+        last_login_at: null,
+        created_at: '2026-01-01T00:00:00Z',
+        roles: ['editor'],
+      },
+    });
+
+    const { container } = renderAppLayout(['/maps/map-1']);
+    const shell = container.firstElementChild as HTMLElement;
+    expect(shell).toHaveClass('h-dvh');
+    expect(shell).toHaveClass('overflow-hidden');
+    expect(shell).not.toHaveClass('min-h-screen');
+    // min-h-0 breaks the flexbox min-height:auto trap so the editor panel
+    // scrolls internally instead of the whole builder page.
+    expect(screen.getByRole('main')).toHaveClass('min-h-0');
+  });
+
+  it('lets non-map pages grow with min-h-screen (no viewport clip)', () => {
+    const { container } = renderAppLayout(['/']);
+    const shell = container.firstElementChild as HTMLElement;
+    expect(shell).toHaveClass('min-h-screen');
+    expect(shell).not.toHaveClass('h-dvh');
+    expect(shell).not.toHaveClass('overflow-hidden');
+    expect(screen.getByRole('main')).not.toHaveClass('min-h-0');
+  });
+
   it('renders footer links but hides Powered by GeoLens branding in enterprise mode when show_badge is false', () => {
     mockedUseEdition.mockReturnValue({
       edition: 'enterprise',

--- a/frontend/src/components/layout/__tests__/AppLayout.test.tsx
+++ b/frontend/src/components/layout/__tests__/AppLayout.test.tsx
@@ -109,7 +109,7 @@ describe('AppLayout', () => {
     expect(screen.getByRole('contentinfo')).toBeInTheDocument();
   });
 
-  it('clips the shell to the viewport and gives main min-h-0 on authenticated map routes (BLDR-01)', () => {
+  it('clips the shell to the viewport and gives main min-h-0 on authenticated map routes (#347 (BLDR-01))', () => {
     useAuthStore.setState({
       token: 'token',
       refreshToken: null,

--- a/frontend/src/components/search/__tests__/SearchBar.test.tsx
+++ b/frontend/src/components/search/__tests__/SearchBar.test.tsx
@@ -22,14 +22,14 @@ describe('SearchBar', () => {
   it('renders input with placeholder', () => {
     render(<SearchBar />);
 
-    expect(screen.getByPlaceholderText(/search geospatial/i)).toBeInTheDocument();
+    expect(screen.getByPlaceholderText(/search the catalog/i)).toBeInTheDocument();
   });
 
   it('accepts typed input', async () => {
     const user = userEvent.setup();
     render(<SearchBar />);
 
-    const input = screen.getByPlaceholderText(/search geospatial/i);
+    const input = screen.getByPlaceholderText(/search the catalog/i);
     await user.type(input, 'parks');
 
     expect(input).toHaveValue('parks');
@@ -39,7 +39,7 @@ describe('SearchBar', () => {
     const user = userEvent.setup();
     render(<SearchBar />);
 
-    const input = screen.getByPlaceholderText(/search geospatial/i);
+    const input = screen.getByPlaceholderText(/search the catalog/i);
     await user.type(input, 'test');
 
     expect(screen.getByRole('button', { name: /clear search/i })).toBeInTheDocument();
@@ -49,7 +49,7 @@ describe('SearchBar', () => {
     const user = userEvent.setup();
     render(<SearchBar />);
 
-    const input = screen.getByPlaceholderText(/search geospatial/i);
+    const input = screen.getByPlaceholderText(/search the catalog/i);
     await user.type(input, 'test');
 
     const clearButton = screen.getByRole('button', { name: /clear search/i });

--- a/frontend/src/hooks/use-admin.ts
+++ b/frontend/src/hooks/use-admin.ts
@@ -28,6 +28,7 @@ import {
 import { toast } from 'sonner';
 import i18n from '@/i18n/i18n';
 import { retryJob } from '@/api/ingest';
+import { ApiError } from '@/api/client';
 import { logger } from '@/lib/logger';
 
 export function useCatalogStats() {
@@ -173,7 +174,12 @@ export function useDeactivateUser() {
   return useMutation({
     mutationFn: (userId: string) => deactivateUser(userId),
     onSuccess: () => { qc.invalidateQueries({ queryKey: queryKeys.admin.allUsers }); },
-    onError: () => { toast.error(i18n.t('admin:users.deactivateDialog.error')); },
+    // ADM-04: surface the backend reason (e.g. "Cannot deactivate the last
+    // admin user" / "Cannot deactivate your own account") instead of a generic
+    // "Failed to deactivate user". ApiError.message is the translated detail.
+    onError: (err) => {
+      toast.error(err instanceof ApiError ? err.message : i18n.t('admin:users.deactivateDialog.error'));
+    },
   });
 }
 

--- a/frontend/src/hooks/use-admin.ts
+++ b/frontend/src/hooks/use-admin.ts
@@ -108,7 +108,7 @@ export function useFailedJobCount() {
   });
 }
 
-// ADM-02: total counts for the Operations sidebar badges (Users, Published
+// #347 (ADM-02): total counts for the Operations sidebar badges (Users, Published
 // Maps, Audit Log). Each reads `.total` off a 1-row list query.
 export function useUserCount() {
   return useQuery({
@@ -174,7 +174,7 @@ export function useDeactivateUser() {
   return useMutation({
     mutationFn: (userId: string) => deactivateUser(userId),
     onSuccess: () => { qc.invalidateQueries({ queryKey: queryKeys.admin.allUsers }); },
-    // ADM-04: surface the backend reason (e.g. "Cannot deactivate the last
+    // #347 (ADM-04): surface the backend reason (e.g. "Cannot deactivate the last
     // admin user" / "Cannot deactivate your own account") instead of a generic
     // "Failed to deactivate user". ApiError.message is the translated detail.
     onError: (err) => {

--- a/frontend/src/hooks/use-admin.ts
+++ b/frontend/src/hooks/use-admin.ts
@@ -107,6 +107,32 @@ export function useFailedJobCount() {
   });
 }
 
+// ADM-02: total counts for the Operations sidebar badges (Users, Published
+// Maps, Audit Log). Each reads `.total` off a 1-row list query.
+export function useUserCount() {
+  return useQuery({
+    queryKey: queryKeys.admin.userCount,
+    queryFn: async () => (await listUsers({ skip: 0, limit: 1 })).total,
+    staleTime: 60_000,
+  });
+}
+
+export function usePublishedMapCount() {
+  return useQuery({
+    queryKey: queryKeys.admin.publishedMapCount,
+    queryFn: async () => (await listShareTokens({ skip: 0, limit: 1 })).total,
+    staleTime: 60_000,
+  });
+}
+
+export function useAuditLogCount() {
+  return useQuery({
+    queryKey: queryKeys.admin.auditLogCount,
+    queryFn: async () => (await listAuditLogs({ skip: 0, limit: 1 })).total,
+    staleTime: 60_000,
+  });
+}
+
 export function useRetryAdminJob() {
   const qc = useQueryClient();
   return useMutation({

--- a/frontend/src/i18n/locales/de/admin.json
+++ b/frontend/src/i18n/locales/de/admin.json
@@ -333,6 +333,7 @@
     "active": "Aktiv",
     "expired": "Abgelaufen",
     "revoked": "Widerrufen",
+    "noLink": "Kein Link",
     "never": "Nie",
     "revoke": "Widerrufen",
     "revokeSuccess": "Freigabe-Token widerrufen",

--- a/frontend/src/i18n/locales/de/builder.json
+++ b/frontend/src/i18n/locales/de/builder.json
@@ -261,7 +261,12 @@
       "maxZoom": "Max. Cluster-Zoom",
       "color": "Cluster-Farbe",
       "countColor": "Zählerfarbe",
-      "countSize": "Zählergröße"
+      "countSize": "Zählergröße",
+      "colorByCount": "Nach Clustergröße einfärben",
+      "baseColor": "Grundfarbe",
+      "atCount": "Ab Anzahl",
+      "addStop": "Farbstufe hinzufügen",
+      "removeStop": "Farbstufe entfernen"
     },
     "raster": {
       "title": "Raster",

--- a/frontend/src/i18n/locales/de/common.json
+++ b/frontend/src/i18n/locales/de/common.json
@@ -164,7 +164,9 @@
       "description": "Ihre Dateispeicher- und Datensatznutzung",
       "storageUsed": "Dateispeicher",
       "datasetsUsed": "Datensätze",
-      "unlimited": "Unbegrenzt"
+      "unlimited": "Unbegrenzt",
+      "overLimit": "Über dem Limit",
+      "fileStorageNote": "Zählt nur die Größe hochgeladener Dateien"
     }
   },
   "footer": {

--- a/frontend/src/i18n/locales/de/search.json
+++ b/frontend/src/i18n/locales/de/search.json
@@ -1,7 +1,7 @@
 {
   "title": "Geodaten finden",
   "subtitle": "Geodaten aus dem Katalog suchen, ansehen und exportieren",
-  "placeholder": "Datensätze nach Name, Beschreibung, Tags suchen...",
+  "placeholder": "Katalog durchsuchen...",
   "updating": "Ergebnisse werden aktualisiert...",
   "loadingDatasets": "Datensätze werden geladen...",
   "resultCount_one": "{{count}} Ergebnis",

--- a/frontend/src/i18n/locales/en/admin.json
+++ b/frontend/src/i18n/locales/en/admin.json
@@ -358,6 +358,7 @@
     "active": "Active",
     "expired": "Expired",
     "revoked": "Revoked",
+    "noLink": "No link",
     "never": "Never",
     "revoke": "Revoke",
     "revokeSuccess": "Share token revoked",

--- a/frontend/src/i18n/locales/en/builder.json
+++ b/frontend/src/i18n/locales/en/builder.json
@@ -261,7 +261,12 @@
       "maxZoom": "Max cluster zoom",
       "color": "Cluster color",
       "countColor": "Count color",
-      "countSize": "Count size"
+      "countSize": "Count size",
+      "colorByCount": "Color by cluster size",
+      "baseColor": "Base color",
+      "atCount": "From count",
+      "addStop": "Add color stop",
+      "removeStop": "Remove color stop"
     },
     "raster": {
       "title": "Raster",

--- a/frontend/src/i18n/locales/en/common.json
+++ b/frontend/src/i18n/locales/en/common.json
@@ -244,7 +244,9 @@
       "description": "Your file storage and dataset usage",
       "storageUsed": "File storage",
       "datasetsUsed": "Datasets",
-      "unlimited": "Unlimited"
+      "unlimited": "Unlimited",
+      "overLimit": "Over limit",
+      "fileStorageNote": "Counts uploaded file size only"
     }
   },
   "maps": {

--- a/frontend/src/i18n/locales/en/search.json
+++ b/frontend/src/i18n/locales/en/search.json
@@ -1,7 +1,7 @@
 {
   "title": "Find Geospatial Data",
   "subtitle": "Search, preview, and export geospatial data from the catalog",
-  "placeholder": "Search geospatial data...",
+  "placeholder": "Search the catalog...",
   "updating": "Updating results...",
   "loadingDatasets": "Loading datasets...",
   "resultCount_one": "{{count}} result",

--- a/frontend/src/i18n/locales/es/admin.json
+++ b/frontend/src/i18n/locales/es/admin.json
@@ -333,6 +333,7 @@
     "active": "Activo",
     "expired": "Caducado",
     "revoked": "Revocado",
+    "noLink": "Sin enlace",
     "never": "Nunca",
     "revoke": "Revocar",
     "revokeSuccess": "Token de compartir revocado",

--- a/frontend/src/i18n/locales/es/builder.json
+++ b/frontend/src/i18n/locales/es/builder.json
@@ -261,7 +261,12 @@
       "maxZoom": "Zoom máximo de agrupación",
       "color": "Color de agrupación",
       "countColor": "Color del conteo",
-      "countSize": "Tamaño del conteo"
+      "countSize": "Tamaño del conteo",
+      "colorByCount": "Colorear por tamaño de clúster",
+      "baseColor": "Color base",
+      "atCount": "Desde recuento",
+      "addStop": "Añadir parada de color",
+      "removeStop": "Quitar parada de color"
     },
     "raster": {
       "title": "Ráster",

--- a/frontend/src/i18n/locales/es/common.json
+++ b/frontend/src/i18n/locales/es/common.json
@@ -164,7 +164,9 @@
       "description": "Su uso de almacenamiento de archivos y conjuntos de datos",
       "storageUsed": "Almacenamiento de archivos",
       "datasetsUsed": "Conjuntos de datos",
-      "unlimited": "Ilimitado"
+      "unlimited": "Ilimitado",
+      "overLimit": "Por encima del límite",
+      "fileStorageNote": "Solo cuenta el tamaño de los archivos subidos"
     }
   },
   "footer": {

--- a/frontend/src/i18n/locales/es/search.json
+++ b/frontend/src/i18n/locales/es/search.json
@@ -1,7 +1,7 @@
 {
   "title": "Buscar datos geoespaciales",
   "subtitle": "Busque, previsualice y exporte datos geoespaciales del catálogo",
-  "placeholder": "Buscar conjuntos de datos por nombre, descripción, etiquetas...",
+  "placeholder": "Buscar en el catálogo...",
   "updating": "Actualizando resultados...",
   "loadingDatasets": "Cargando conjuntos de datos...",
   "resultCount_one": "{{count}} resultado",

--- a/frontend/src/i18n/locales/fr/admin.json
+++ b/frontend/src/i18n/locales/fr/admin.json
@@ -333,6 +333,7 @@
     "active": "Actif",
     "expired": "Expire",
     "revoked": "Revoque",
+    "noLink": "Aucun lien",
     "never": "Jamais",
     "revoke": "Revoquer",
     "revokeSuccess": "Jeton de partage revoque",

--- a/frontend/src/i18n/locales/fr/builder.json
+++ b/frontend/src/i18n/locales/fr/builder.json
@@ -261,7 +261,12 @@
       "maxZoom": "Zoom max d'agrégat",
       "color": "Couleur d'agrégat",
       "countColor": "Couleur du nombre",
-      "countSize": "Taille du nombre"
+      "countSize": "Taille du nombre",
+      "colorByCount": "Colorer par taille de cluster",
+      "baseColor": "Couleur de base",
+      "atCount": "À partir du nombre",
+      "addStop": "Ajouter un palier de couleur",
+      "removeStop": "Supprimer le palier de couleur"
     },
     "raster": {
       "title": "Raster",

--- a/frontend/src/i18n/locales/fr/common.json
+++ b/frontend/src/i18n/locales/fr/common.json
@@ -164,7 +164,9 @@
       "description": "Votre utilisation du stockage de fichiers et des jeux de données",
       "storageUsed": "Stockage de fichiers",
       "datasetsUsed": "Jeux de données",
-      "unlimited": "Illimité"
+      "unlimited": "Illimité",
+      "overLimit": "Au-dessus de la limite",
+      "fileStorageNote": "Compte uniquement la taille des fichiers téléversés"
     }
   },
   "footer": {

--- a/frontend/src/i18n/locales/fr/search.json
+++ b/frontend/src/i18n/locales/fr/search.json
@@ -1,7 +1,7 @@
 {
   "title": "Trouver des données géospatiales",
   "subtitle": "Recherchez, prévisualisez et exportez des données géospatiales du catalogue",
-  "placeholder": "Rechercher des jeux de données par nom, description, tags...",
+  "placeholder": "Rechercher dans le catalogue...",
   "updating": "Mise à jour des résultats...",
   "loadingDatasets": "Chargement des jeux de données...",
   "resultCount_one": "{{count}} résultat",

--- a/frontend/src/lib/query-keys.ts
+++ b/frontend/src/lib/query-keys.ts
@@ -123,6 +123,9 @@ export const queryKeys = {
     jobs: (params: Record<string, unknown>) => ['admin', 'jobs', params] as const,
     allJobs: ['admin', 'jobs'] as const,
     failedJobCount: ['admin', 'jobs', 'failed-count'] as const,
+    userCount: ['admin', 'users', 'count'] as const,
+    publishedMapCount: ['admin', 'share-tokens', 'count'] as const,
+    auditLogCount: ['admin', 'audit-logs', 'count'] as const,
     aiStatus: ['admin', 'ai-status'] as const,
     shareTokens: (skip: number, limit: number, search?: string, status?: string) =>
       ['admin', 'share-tokens', skip, limit, search, status] as const,

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -79,7 +79,7 @@ export function SettingsPage() {
                 ) : usage ? (
                   <p className="text-xs text-muted-foreground">{t('settings.storage.unlimited')}</p>
                 ) : null}
-                {/* ADM-06: file storage only meters uploaded file bytes, so a
+                {/* #347 (ADM-06): file storage only meters uploaded file bytes, so a
                     vector-only account reads 0 B despite having datasets. */}
                 {usage && usage.bytes_used === 0 && usage.dataset_count > 0 && (
                   <p className="text-xs text-muted-foreground">{t('settings.storage.fileStorageNote')}</p>
@@ -106,7 +106,7 @@ export function SettingsPage() {
                 ) : usage ? (
                   <p className="text-xs text-muted-foreground">{t('settings.storage.unlimited')}</p>
                 ) : null}
-                {/* ADM-06: the dataset cap is enforced at upload only, so an
+                {/* #347 (ADM-06): the dataset cap is enforced at upload only, so an
                     account can sit above a later-lowered cap (e.g. 18 / 10).
                     Label it instead of letting it read as a broken counter. */}
                 {usage && usage.count_cap > 0 && usage.dataset_count > usage.count_cap && (

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -1,5 +1,4 @@
 import { useTranslation } from 'react-i18next';
-import { Sun, Moon, Monitor } from 'lucide-react';
 import { PageShell } from '@/components/layout/PageShell';
 import { PageHeader } from '@/components/layout/PageHeader';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
@@ -9,21 +8,15 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@
 import { FieldLabel } from '@/components/ui/field-label';
 import { MyApiKeySection } from '@/components/settings/MyApiKeySection';
 import { useAuth } from '@/hooks/use-auth';
-import { useTheme } from '@/components/theme-provider';
 import { changeAppLanguage } from '@/i18n';
 import { fallbackLng, languageOptions } from '@/i18n/config';
-import { cn } from '@/lib/utils';
 import { useDocumentTitle } from '@/hooks/use-document-title';
 import { useMyUsage } from '@/hooks/use-quota';
 import { formatBytes, formatNumber } from '@/lib/format';
 
-const themes = ['light', 'dark', 'system'] as const;
-const themeIcons = { light: Sun, dark: Moon, system: Monitor } as const;
-
 export function SettingsPage() {
   const { t, i18n } = useTranslation();
   const { user } = useAuth();
-  const { theme, setTheme } = useTheme();
   const { data: usage } = useMyUsage();
   useDocumentTitle(t('common:pageTitle.settings'));
 
@@ -123,36 +116,6 @@ export function SettingsPage() {
             </CardContent>
           </Card>
 
-          {/* Appearance */}
-          <Card className="border border-border">
-            <CardHeader>
-              <CardTitle>{t('settings.appearance.title')}</CardTitle>
-              <CardDescription>{t('settings.appearance.description')}</CardDescription>
-            </CardHeader>
-            <CardContent>
-              <div className="flex gap-2">
-                {themes.map((themeOption) => {
-                  const Icon = themeIcons[themeOption];
-                  return (
-                    <button
-                      key={themeOption}
-                      onClick={() => setTheme(themeOption)}
-                      aria-pressed={theme === themeOption}
-                      className={cn(
-                        'flex items-center gap-2 rounded-md border px-4 py-2 text-sm font-medium transition-colors',
-                        theme === themeOption
-                          ? 'border-primary bg-primary/10 text-foreground'
-                          : 'border-border text-muted-foreground hover:bg-accent hover:text-accent-foreground',
-                      )}
-                    >
-                      <Icon className="h-4 w-4" />
-                      {t(`theme.${themeOption}`)}
-                    </button>
-                  );
-                })}
-              </div>
-            </CardContent>
-          </Card>
 
           {/* Language */}
           <Card className="border border-border">

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -86,6 +86,11 @@ export function SettingsPage() {
                 ) : usage ? (
                   <p className="text-xs text-muted-foreground">{t('settings.storage.unlimited')}</p>
                 ) : null}
+                {/* ADM-06: file storage only meters uploaded file bytes, so a
+                    vector-only account reads 0 B despite having datasets. */}
+                {usage && usage.bytes_used === 0 && usage.dataset_count > 0 && (
+                  <p className="text-xs text-muted-foreground">{t('settings.storage.fileStorageNote')}</p>
+                )}
               </div>
               <div className="space-y-1.5">
                 <div className="flex items-center justify-between text-sm">
@@ -108,6 +113,12 @@ export function SettingsPage() {
                 ) : usage ? (
                   <p className="text-xs text-muted-foreground">{t('settings.storage.unlimited')}</p>
                 ) : null}
+                {/* ADM-06: the dataset cap is enforced at upload only, so an
+                    account can sit above a later-lowered cap (e.g. 18 / 10).
+                    Label it instead of letting it read as a broken counter. */}
+                {usage && usage.count_cap > 0 && usage.dataset_count > usage.count_cap && (
+                  <p className="text-xs text-destructive">{t('settings.storage.overLimit')}</p>
+                )}
               </div>
             </CardContent>
           </Card>

--- a/frontend/src/pages/__tests__/SettingsPage.a11y.test.tsx
+++ b/frontend/src/pages/__tests__/SettingsPage.a11y.test.tsx
@@ -5,7 +5,7 @@
  * - The language select is queryable by its accessible name via the shared
  *   FieldLabel primitive. Removing the FieldLabel + id binding fails this test.
  *
- * UX-01 (v1049): the theme toggle was removed from Settings (it now lives only
+ * #347 (UX-01) (v1049): the theme toggle was removed from Settings (it now lives only
  * in the navbar user dropdown), so the former aria-pressed assertion is gone.
  */
 import { render, screen } from '@/test/test-utils';

--- a/frontend/src/pages/__tests__/SettingsPage.a11y.test.tsx
+++ b/frontend/src/pages/__tests__/SettingsPage.a11y.test.tsx
@@ -1,12 +1,12 @@
 /**
- * GLUX-014 / GLUX-002 (Phase 1248): regression gate for the SettingsPage
- * control semantics.
+ * GLUX-002 (Phase 1248): regression gate for the SettingsPage control semantics.
  *
  * Asserts:
- * - The selected theme toggle button conveys state via aria-pressed, not color
- *   alone. Reverting the aria-pressed attribute fails this test.
  * - The language select is queryable by its accessible name via the shared
  *   FieldLabel primitive. Removing the FieldLabel + id binding fails this test.
+ *
+ * UX-01 (v1049): the theme toggle was removed from Settings (it now lives only
+ * in the navbar user dropdown), so the former aria-pressed assertion is gone.
  */
 import { render, screen } from '@/test/test-utils';
 import { vi } from 'vitest';
@@ -25,12 +25,6 @@ vi.mock('@/i18n', () => ({ changeAppLanguage: vi.fn() }));
 vi.mock('@/i18n/config', () => ({
   fallbackLng: 'en',
   languageOptions: [{ value: 'en', label: 'English' }],
-}));
-
-// ── mock useTheme — theme set to 'dark' for assertions ───────────────────────
-const mockSetTheme = vi.fn();
-vi.mock('@/components/theme-provider', () => ({
-  useTheme: () => ({ theme: 'dark', setTheme: mockSetTheme, resolvedTheme: 'dark' }),
 }));
 
 // ── mock auth ────────────────────────────────────────────────────────────────
@@ -57,21 +51,7 @@ vi.mock('@/components/settings/MyApiKeySection', () => ({
   MyApiKeySection: () => null,
 }));
 
-describe('GLUX-014 / GLUX-002: SettingsPage control semantics', () => {
-  it('selected theme button has aria-pressed=true; unselected buttons have aria-pressed=false', () => {
-    render(<SettingsPage />);
-
-    // useTheme is mocked to return theme='dark'; the dark button is selected
-    const darkButton = screen.getByRole('button', { name: 'theme.dark' });
-    expect(darkButton).toHaveAttribute('aria-pressed', 'true');
-
-    const lightButton = screen.getByRole('button', { name: 'theme.light' });
-    expect(lightButton).toHaveAttribute('aria-pressed', 'false');
-
-    const systemButton = screen.getByRole('button', { name: 'theme.system' });
-    expect(systemButton).toHaveAttribute('aria-pressed', 'false');
-  });
-
+describe('GLUX-002: SettingsPage control semantics', () => {
   it('language select is queryable by its accessible name via FieldLabel (GLUX-002)', () => {
     render(<SettingsPage />);
 

--- a/frontend/src/pages/admin/AdminSharedMapsPage.tsx
+++ b/frontend/src/pages/admin/AdminSharedMapsPage.tsx
@@ -46,7 +46,9 @@ const PAGE_SIZE = 50;
 
 type EmbedTokenStatus = 'active' | 'expiring_soon' | 'expired' | 'revoked';
 
-function getShareStatus(token: AdminShareTokenResponse): 'active' | 'revoked' | 'expired' {
+function getShareStatus(token: AdminShareTokenResponse): 'active' | 'revoked' | 'expired' | 'none' {
+  // ADM-01: a published map may have no share link at all.
+  if (!token.id) return 'none';
   if (!token.is_active) return 'revoked';
   if (token.expires_at && new Date(token.expires_at) < new Date()) return 'expired';
   return 'active';
@@ -234,9 +236,10 @@ export function AdminSharedMapsPage() {
   const tokens = data?.tokens ?? [];
   const { totalPages, rangeStart, rangeEnd } = paginationRange(total, page, PAGE_SIZE);
 
-  function shareStatusBadge(s: 'active' | 'revoked' | 'expired') {
+  function shareStatusBadge(s: 'active' | 'revoked' | 'expired' | 'none') {
     if (s === 'active') return <Badge variant="outline" className={semanticBadgeColors.success}>{t('shareTokens.active')}</Badge>;
     if (s === 'expired') return <Badge variant="secondary">{t('shareTokens.expired')}</Badge>;
+    if (s === 'none') return <Badge variant="outline" className="text-muted-foreground">{t('shareTokens.noLink')}</Badge>;
     return <Badge variant="secondary">{t('shareTokens.revoked')}</Badge>;
   }
 
@@ -319,9 +322,11 @@ export function AdminSharedMapsPage() {
               ) : (
                 tokens.map((token) => {
                   const s = getShareStatus(token);
-                  const isExpanded = expandedId === token.id;
+                  // ADM-01: expansion is keyed on map_id (always present, one
+                  // row per map) — token.id is now nullable for unshared maps.
+                  const isExpanded = expandedId === token.map_id;
                   return (
-                    <Fragment key={token.id}>
+                    <Fragment key={token.map_id}>
                       <TableRow>
                         <TableCell className="w-10">
                           {token.embed_token_count > 0 ? (
@@ -330,11 +335,11 @@ export function AdminSharedMapsPage() {
                               className="text-muted-foreground hover:text-foreground"
                               tabIndex={0}
                               aria-expanded={isExpanded}
-                              onClick={() => setExpandedId(isExpanded ? null : token.id)}
+                              onClick={() => setExpandedId(isExpanded ? null : token.map_id)}
                               onKeyDown={(e) => {
                                 if (e.key === 'Enter' || e.key === ' ') {
                                   e.preventDefault();
-                                  setExpandedId(isExpanded ? null : token.id);
+                                  setExpandedId(isExpanded ? null : token.map_id);
                                 }
                               }}
                               aria-label={t('sharedMaps.embedTokensFor', { map: token.map_name })}
@@ -397,7 +402,7 @@ export function AdminSharedMapsPage() {
                                 </AlertDialogHeader>
                                 <AlertDialogFooter>
                                   <AlertDialogCancel>{t('shareTokens.revokeDialogCancel')}</AlertDialogCancel>
-                                  <AlertDialogAction onClick={() => handleRevoke(token.id)}>
+                                  <AlertDialogAction onClick={() => token.id && handleRevoke(token.id)}>
                                     {t('shareTokens.revokeDialogConfirm')}
                                   </AlertDialogAction>
                                 </AlertDialogFooter>

--- a/frontend/src/pages/admin/AdminSharedMapsPage.tsx
+++ b/frontend/src/pages/admin/AdminSharedMapsPage.tsx
@@ -47,7 +47,7 @@ const PAGE_SIZE = 50;
 type EmbedTokenStatus = 'active' | 'expiring_soon' | 'expired' | 'revoked';
 
 function getShareStatus(token: AdminShareTokenResponse): 'active' | 'revoked' | 'expired' | 'none' {
-  // ADM-01: a published map may have no share link at all.
+  // #347 (ADM-01): a published map may have no share link at all.
   if (!token.id) return 'none';
   if (!token.is_active) return 'revoked';
   if (token.expires_at && new Date(token.expires_at) < new Date()) return 'expired';
@@ -322,7 +322,7 @@ export function AdminSharedMapsPage() {
               ) : (
                 tokens.map((token) => {
                   const s = getShareStatus(token);
-                  // ADM-01: expansion is keyed on map_id (always present, one
+                  // #347 (ADM-01): expansion is keyed on map_id (always present, one
                   // row per map) — token.id is now nullable for unshared maps.
                   const isExpanded = expandedId === token.map_id;
                   return (

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -870,6 +870,15 @@ export interface BuilderStyleConfig {
   clusterTextColor?: string;
   /** Cluster count label text size for point cluster render mode. */
   clusterTextSize?: number;
+  /**
+   * Optional cluster color ramp keyed on point_count (cluster render mode).
+   * With 2+ stops the cluster circle is colored by a MapLibre `step` expression
+   * on point_count (parity with the MapLibre "create and style clusters"
+   * example); an empty/absent ramp falls back to the flat clusterColor. Stops
+   * are sorted ascending by count — the lowest is the base color, subsequent
+   * counts are the step thresholds.
+   */
+  clusterColorRamp?: Array<{ count: number; color: string }>;
   symbol?: SymbolStyleConfig;
   /** Phase 256 — line-gradient builder intent. Stops authored in the UI; serialized
    *  to a canonical interpolate-linear-line-progress expression for paint['line-gradient'].

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -1490,7 +1490,7 @@ export interface BulkRegisterResponse {
 
 // Admin share tokens
 export interface AdminShareTokenResponse {
-  // ADM-01: the admin "Published Maps" listing includes public maps with no
+  // #347 (ADM-01): the admin "Published Maps" listing includes public maps with no
   // share link, so the token-specific fields are nullable.
   id: string | null;
   map_id: string;

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -1490,11 +1490,13 @@ export interface BulkRegisterResponse {
 
 // Admin share tokens
 export interface AdminShareTokenResponse {
-  id: string;
+  // ADM-01: the admin "Published Maps" listing includes public maps with no
+  // share link, so the token-specific fields are nullable.
+  id: string | null;
   map_id: string;
   map_name: string;
-  token: string;
-  is_active: boolean;
+  token: string | null;
+  is_active: boolean | null;
   expires_at: string | null;
   created_at: string;
   created_by: string | null;

--- a/sdks/python/geolens/models/admin_share_token_response.py
+++ b/sdks/python/geolens/models/admin_share_token_response.py
@@ -23,24 +23,24 @@ class AdminShareTokenResponse:
     Attributes:
         created_at (datetime.datetime):
         created_by (None | str):
-        expires_at (datetime.datetime | None):
-        id (UUID):
-        is_active (bool):
         map_id (UUID):
         map_name (str):
-        token (str):
         embed_token_count (int | Unset):  Default: 0.
+        expires_at (datetime.datetime | None | Unset):
+        id (None | Unset | UUID):
+        is_active (bool | None | Unset):
+        token (None | str | Unset):
     """
 
     created_at: datetime.datetime
     created_by: None | str
-    expires_at: datetime.datetime | None
-    id: UUID
-    is_active: bool
     map_id: UUID
     map_name: str
-    token: str
     embed_token_count: int | Unset = 0
+    expires_at: datetime.datetime | None | Unset = UNSET
+    id: None | Unset | UUID = UNSET
+    is_active: bool | None | Unset = UNSET
+    token: None | str | Unset = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
@@ -49,23 +49,39 @@ class AdminShareTokenResponse:
         created_by: None | str
         created_by = self.created_by
 
-        expires_at: None | str
-        if isinstance(self.expires_at, datetime.datetime):
-            expires_at = self.expires_at.isoformat()
-        else:
-            expires_at = self.expires_at
-
-        id = str(self.id)
-
-        is_active = self.is_active
-
         map_id = str(self.map_id)
 
         map_name = self.map_name
 
-        token = self.token
-
         embed_token_count = self.embed_token_count
+
+        expires_at: None | str | Unset
+        if isinstance(self.expires_at, Unset):
+            expires_at = UNSET
+        elif isinstance(self.expires_at, datetime.datetime):
+            expires_at = self.expires_at.isoformat()
+        else:
+            expires_at = self.expires_at
+
+        id: None | str | Unset
+        if isinstance(self.id, Unset):
+            id = UNSET
+        elif isinstance(self.id, UUID):
+            id = str(self.id)
+        else:
+            id = self.id
+
+        is_active: bool | None | Unset
+        if isinstance(self.is_active, Unset):
+            is_active = UNSET
+        else:
+            is_active = self.is_active
+
+        token: None | str | Unset
+        if isinstance(self.token, Unset):
+            token = UNSET
+        else:
+            token = self.token
 
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
@@ -73,16 +89,20 @@ class AdminShareTokenResponse:
             {
                 "created_at": created_at,
                 "created_by": created_by,
-                "expires_at": expires_at,
-                "id": id,
-                "is_active": is_active,
                 "map_id": map_id,
                 "map_name": map_name,
-                "token": token,
             }
         )
         if embed_token_count is not UNSET:
             field_dict["embed_token_count"] = embed_token_count
+        if expires_at is not UNSET:
+            field_dict["expires_at"] = expires_at
+        if id is not UNSET:
+            field_dict["id"] = id
+        if is_active is not UNSET:
+            field_dict["is_active"] = is_active
+        if token is not UNSET:
+            field_dict["token"] = token
 
         return field_dict
 
@@ -98,8 +118,16 @@ class AdminShareTokenResponse:
 
         created_by = _parse_created_by(d.pop("created_by"))
 
-        def _parse_expires_at(data: object) -> datetime.datetime | None:
+        map_id = UUID(d.pop("map_id"))
+
+        map_name = d.pop("map_name")
+
+        embed_token_count = d.pop("embed_token_count", UNSET)
+
+        def _parse_expires_at(data: object) -> datetime.datetime | None | Unset:
             if data is None:
+                return data
+            if isinstance(data, Unset):
                 return data
             try:
                 if not isinstance(data, str):
@@ -109,32 +137,55 @@ class AdminShareTokenResponse:
                 return expires_at_type_0
             except (TypeError, ValueError, AttributeError, KeyError):
                 pass
-            return cast(datetime.datetime | None, data)
+            return cast(datetime.datetime | None | Unset, data)
 
-        expires_at = _parse_expires_at(d.pop("expires_at"))
+        expires_at = _parse_expires_at(d.pop("expires_at", UNSET))
 
-        id = UUID(d.pop("id"))
+        def _parse_id(data: object) -> None | Unset | UUID:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, str):
+                    raise TypeError()
+                id_type_0 = UUID(data)
 
-        is_active = d.pop("is_active")
+                return id_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(None | Unset | UUID, data)
 
-        map_id = UUID(d.pop("map_id"))
+        id = _parse_id(d.pop("id", UNSET))
 
-        map_name = d.pop("map_name")
+        def _parse_is_active(data: object) -> bool | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(bool | None | Unset, data)
 
-        token = d.pop("token")
+        is_active = _parse_is_active(d.pop("is_active", UNSET))
 
-        embed_token_count = d.pop("embed_token_count", UNSET)
+        def _parse_token(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        token = _parse_token(d.pop("token", UNSET))
 
         admin_share_token_response = cls(
             created_at=created_at,
             created_by=created_by,
+            map_id=map_id,
+            map_name=map_name,
+            embed_token_count=embed_token_count,
             expires_at=expires_at,
             id=id,
             is_active=is_active,
-            map_id=map_id,
-            map_name=map_name,
             token=token,
-            embed_token_count=embed_token_count,
         )
 
         admin_share_token_response.additional_properties = d

--- a/sdks/typescript/src/client/types.gen.ts
+++ b/sdks/typescript/src/client/types.gen.ts
@@ -367,15 +367,15 @@ export type AdminShareTokenResponse = {
     /**
      * Expires At
      */
-    expires_at: string | null;
+    expires_at?: string | null;
     /**
      * Id
      */
-    id: string;
+    id?: string | null;
     /**
      * Is Active
      */
-    is_active: boolean;
+    is_active?: boolean | null;
     /**
      * Map Id
      */
@@ -387,7 +387,7 @@ export type AdminShareTokenResponse = {
     /**
      * Token
      */
-    token: string;
+    token?: string | null;
 };
 
 /**


### PR DESCRIPTION
## v1049 Polish & Trust Pass — Builder, Admin & UX bug-bash

A post-GA **fix-and-harden** pass (no new product surface) filing down the rough edges a first-time evaluator hits on the live demo, plus one security-correctness verification and a regression-coverage pass. Sourced from a founder bug list; each fix carries a regression guard.

### Map Builder
- **BLDR-01** — Expanding a layer-editor panel no longer scrolls the *entire* builder. The app shell used `min-h-screen` and `<main>` hit the flexbox `min-height:auto` trap; scoped a definite viewport height (`h-dvh`/`overflow-hidden`) + `min-h-0` to authenticated map routes so the editor panel scrolls internally. Public map routes keep their footer + document scroll.
- **BLDR-02** — The cluster editor can now color clusters **by `point_count`** with a MapLibre `step` ramp (parity with the "create and style clusters" example). A "Color by cluster size" switch seeds the example tiers (base / 100 / 750) with add/remove/threshold edits; toggling off reverts to the existing flat color (no change for existing maps). New `clusterColorRamp` builder key with camel↔snake parity on both sides (covered by the existing alias-drift guard).

### Admin Console
- **ADM-01** — "Published Maps" was wired to `map_share_tokens`, so it only showed maps with a share link (its own empty-state said "No maps have been published yet"). Re-keyed the listing on `Map` filtered to `visibility=public`, LEFT JOINing the latest share token per map (`DISTINCT ON`, preferring active). Every published map now appears; token fields are nullable; the UI shows a "No link" status for unshared maps. OpenAPI regenerated.
- **ADM-02** — Count badges for **Users / Published Maps / Audit Log** in the Operations sidebar, capped at **999+**. (The Users badge now shows total users; the pending-approval workflow remains on the Users page.)
- **ADM-03** — Removed the "Users by Status" card from the Overview.
- **ADM-04** — User-deactivation failures now surface the real reason (e.g. "Cannot deactivate the last admin user") instead of a generic toast. Backend already returned the specific 400; the frontend was discarding it.
- **ADM-05** — Embedding-Coverage "Regenerate All" showed two spinners (both buttons keyed off one `isPending`). Each spinner now keys off the in-flight mutation variable.
- **ADM-06** — Honest storage display: a "Counts uploaded file size only" note when file storage is 0 B with vector datasets, and an "Over limit" label when the dataset count sits above a later-lowered cap (e.g. 18 / 10). Display-only; cross-type byte accounting stays a deferred backend item.

### Login-mode security
- **SEC-01** — Investigated the report that disabling "Allow Password Login" is bypassable via a login-page link. **It is not**: the link only reveals the form (the intentional, clearly-labeled "Admin? Sign in with a password" break-glass), and the server returns **403** for a non-admin password login even with a correct password. Tightened the existing regression test to pin the exact 403 detail. No server/UI change — the gate is correct by design.

### Search & theme
- **SRCH-01** — Catalog search placeholder → "Search the catalog" (all 4 locales).
- **UX-01** — Theme toggle consolidated to the navbar user dropdown; removed the duplicate Settings "Appearance" card.

### Testing
- Frontend: full vitest green (3191), typecheck, eslint, i18n parity. New/updated regression tests for BLDR-01, BLDR-02, ADM-04, ADM-05, ADM-02, ADM-01, SRCH-01, UX-01.
- Backend: touched suites green `-n 4` (maps, admin invariants, SSO login-mode, builder alias drift); ruff clean; OpenAPI no-drift.

### Out of scope / deferred
- Moving the basemap selector into Map Settings (decided to keep it as a layer-stack row).
- Cross-type (vector/PostGIS) storage-byte accounting (real backend fix; deferred).
- Seeding more demo collections (a demo-content/ops task, not code).
