### PR TITLE
fix(builder): make cluster color-ramp defaults reachable

### DIFF
--- a/frontend/src/components/builder/LayerStyleEditor/ClusterEditor.tsx
+++ b/frontend/src/components/builder/LayerStyleEditor/ClusterEditor.tsx
@@ -10,11 +10,17 @@ import type { BaseStyleEditorProps } from './types';
 
 type ClusterColorStop = { count: number; color: string };
 
-// Default tiers seeded when "color by cluster size" is enabled — mirrors the
-// MapLibre "create and style clusters" example thresholds (100 / 750).
+// Default tiers seeded when "color by cluster size" is enabled. MapLibre's own
+// "create and style clusters" example uses 100/750, but those thresholds are
+// tuned to its dense earthquake dataset — for typical clustered layers the
+// rendered cluster point_count at usable zooms sits in the 1s–low-100s, so
+// 100/750 leaves every cluster in the base bucket and the toggle looks dead
+// (e.g. World Airports tops out at ~234 at min zoom, ~90 at the default view).
+// Seed reachable breaks so enabling the ramp produces a visible gradient out of
+// the box; the user can raise them for denser data.
 const DEFAULT_RAMP_TIERS: ClusterColorStop[] = [
-  { count: 100, color: '#f1f075' },
-  { count: 750, color: '#f28cb1' },
+  { count: 10, color: '#f1f075' },
+  { count: 50, color: '#f28cb1' },
 ];
 
 export function ClusterEditor({


### PR DESCRIPTION
## Problem

The Map Builder's **"Color by cluster size"** toggle (BLDR-02, shipped in v1049) produced no visible change on real data. The switch rendered and the map received a valid MapLibre `step` expression, but the seeded default thresholds were `point_count` **100 / 750** — lifted from MapLibre's earthquake-clusters example. Real cluster sizes on typical layers sit far below that, so every cluster fell in the base bucket and rendered the same color as the toggle being off.

Measured on the **World Airports** demo layer:

| Zoom | Max cluster | OLD 100/750 (base / mid / top) | NEW 10/50 (base / mid / top) |
|------|-------------|-------------------------------|------------------------------|
| 0 (min) | 234 | 60 / 9 / **0** | 20 / 26 / 23 |
| 2 (default open view) | 90 | **94 / 0 / 0** | 37 / 51 / 6 |
| 3 | 25 | 76 / 0 / 0 | 54 / 22 / 0 |

The `750` tier was unreachable at any zoom; the `100` tier only affected 9 clusters and only when fully zoomed out. At the default view: zero effect.

## Fix

Lower the seeded `DEFAULT_RAMP_TIERS` in `ClusterEditor.tsx` from `100 / 750` to `10 / 50` so enabling the ramp yields a visible gradient out of the box. Adapter logic is unchanged.

## Limitation (intentional)

Thresholds remain fixed constants, not data-driven. `point_count` is zoom-dependent and the style editor has no live-map handle, so true auto-seeding would require threading the map through `LayerStyleEditor → RenderModeSwitch → editors` for marginal gain. `10/50` works for typical datasets and degrades gracefully; users can raise the breaks for denser data via the existing stop editor.

## Verification

- Live in the running builder (HMR): toggling on now seeds `["step",["get","point_count"],"#334155",10,"#f1f075",50,"#f28cb1"]`; the map shows a 3-color gradient at the default view.
- `eslint` clean on the changed file; `cluster-adapter` unit tests 9/9 green.
