### PR TITLE
chore(release): prep v1.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and releases use semantic versioning.
 
 ## [Unreleased]
 
+## [1.4.1] - 2026-06-28
+
 ### Changed
 
 - **Automated database backups now run by default.** The `backup` service
@@ -21,9 +23,22 @@ and releases use semantic versioning.
   a map's data (counts, statistics, spatial analysis). Using the AI to *edit* a
   map remains limited to the owner, and AI-suggested changes still only persist
   when the owner saves the map.
+- **Custom share-link expiration is an advanced (Enterprise) sharing control.**
+  The backend now enforces the same edition gate the UI already applied; basic
+  Community share/revoke is unchanged.
+- **Vector tiles send an ETag.** Re-uploaded datasets now refresh in the map
+  without waiting for the cache TTL to expire.
+- **Editors with AI-chat permission can use builder chat.** Non-admin users
+  granted `use_ai_chat` can now open the Map Builder AI assistant when AI is
+  configured.
 
 ### Added
 
+- **Color map clusters by size.** Clustered point layers in the Map Builder can
+  now be colored by cluster size (point count) via a configurable step ramp —
+  toggle "Color by cluster size" in the cluster style controls and tune the
+  per-tier breakpoints. Default breakpoints are tuned to be visible on typical
+  datasets.
 - **Standalone `geolens-backup` image.** A multi-arch (amd64 + arm64)
   `geolens-backup` image is now published to GHCR alongside the api, worker, and
   frontend images, so prebuilt installs run backups without a local build.
@@ -64,17 +79,13 @@ and releases use semantic versioning.
 - **AI chat undo no longer reverts an unrelated edit.** Clicking Undo on a chat
   query answer can no longer roll back an earlier style change from a previous
   turn.
-
-### Changed
-
-- **Custom share-link expiration is an advanced (Enterprise) sharing control.**
-  The backend now enforces the same edition gate the UI already applied; basic
-  Community share/revoke is unchanged.
-- **Vector tiles send an ETag.** Re-uploaded datasets now refresh in the map
-  without waiting for the cache TTL to expire.
-- **Editors with AI-chat permission can use builder chat.** Non-admin users
-  granted `use_ai_chat` can now open the Map Builder AI assistant when AI is
-  configured.
+- **Map builder, admin console, and search polish.** The builder's layer editor
+  panel no longer scrolls the whole page; the admin "Published Maps" page now
+  lists published maps (it previously always read as empty) and the admin sidebar
+  shows live counts; per-user storage usage is reported honestly against the
+  configured quota; deactivating a user now surfaces the specific server message;
+  the catalog search box reads "Search the catalog"; and the light/dark theme
+  toggle now lives only in the top-bar menu.
 
 ## [1.4.0] - 2026-06-20
 

--- a/backend/app/api/main.py
+++ b/backend/app/api/main.py
@@ -420,7 +420,7 @@ _is_production = settings.is_production
 # no metadata to read. We fall back to the current published line so import never
 # crashes. Keep this fallback in lockstep with backend/pyproject.toml — it is one
 # of the sites `make bump` rewrites.
-_FALLBACK_APP_VERSION = "1.4.0"
+_FALLBACK_APP_VERSION = "1.4.1"
 
 
 def _resolve_app_version() -> str:

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -15884,7 +15884,7 @@
     "summary": "PostGIS-native geospatial data catalog with OGC API Features compliance",
     "termsOfService": "https://github.com/geolens-io/geolens/blob/main/LICENSE",
     "title": "GeoLens API",
-    "version": "1.4.0"
+    "version": "1.4.1"
   },
   "openapi": "3.1.0",
   "paths": {

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geolens-backend"
-version = "1.4.0"
+version = "1.4.1"
 description = "PostGIS-native GIS data catalog"
 # Docker image (Dockerfile) ships python:3.14.3-slim as the project's tested
 # runtime. requires-python>=3.13 is the backward-compat floor for adopters

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -865,7 +865,7 @@ wheels = [
 
 [[package]]
 name = "geolens-backend"
-version = "1.4.0"
+version = "1.4.1"
 source = { virtual = "." }
 dependencies = [
     { name = "alembic" },

--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "geolens-cli"
-version = "1.4.0"
+version = "1.4.1"
 description = "Apache-2.0 command-line interface for the GeoLens API. Login, scan, publish, and export STAC against any GeoLens instance."
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/docs-contract.json
+++ b/docs-contract.json
@@ -1,6 +1,6 @@
 {
   "_comment": "Canonical cross-surface facts for the GeoLens README, marketing site (getgeolens.com/src), and docs site (getgeolens.com/docs). Validated against scripts/install.sh + backend/pyproject.toml by scripts/check_docs_contract.py (geolens CI). The getgeolens.com repo vendors a copy and enforces the same `forbidden` list in its own CI. See docs-internal/DOC-CONSISTENCY-STRATEGY for the full design. Edit a fact ONCE here (and in its canonical source) — the gates make every surface follow.",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "install": {
     "oneLiner": "curl -fsSL https://getgeolens.com/install.sh | sh",
     "sourceBuild": "bash scripts/install.sh",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.4.0",
+  "version": "1.4.1",
   "type": "module",
   "license": "Apache-2.0",
   "author": "Carto Concepts, LLC",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "geolens",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "private": true,
   "license": "Apache-2.0",
   "author": "Carto Concepts, LLC",

--- a/scripts/bump_version.py
+++ b/scripts/bump_version.py
@@ -16,6 +16,9 @@
   - sdks/python/pyproject.toml             ([project] version)
   - sdks/python/.openapi-python-client.yaml (package_version_override)
   - sdks/typescript/package.json           (.version)
+  - docs-contract.json                     (.version — the cross-surface doc
+                                           contract; check_docs_contract.py
+                                           asserts it equals backend/pyproject)
 
 The version MUST be a plain X.Y.Z semver (no suffixes) — the drift gate
 (`make version-check`) is a static equality check, and the SDK sync script
@@ -48,6 +51,7 @@ CLI_PYPROJECT = REPO_ROOT / "cli" / "pyproject.toml"
 PY_SDK_PYPROJECT = REPO_ROOT / "sdks" / "python" / "pyproject.toml"
 PY_SDK_GEN_CONFIG = REPO_ROOT / "sdks" / "python" / ".openapi-python-client.yaml"
 TS_SDK_PACKAGE = REPO_ROOT / "sdks" / "typescript" / "package.json"
+DOCS_CONTRACT = REPO_ROOT / "docs-contract.json"
 
 
 def _rel(p: Path) -> str:
@@ -112,6 +116,19 @@ def _bump_yaml_override(path: Path, version: str) -> None:
     print(f"  {_rel(path)} (package_version_override) -> {version}")
 
 
+def _bump_top_level_json_version(path: Path, version: str) -> None:
+    # Targeted regex on the top-level `"version": "..."` line (first occurrence)
+    # so the hand-maintained file keeps its exact formatting — a full json
+    # round-trip would reflow the long _comment and nested structures.
+    text = path.read_text()
+    pattern = re.compile(r'^(\s*)"version": "[^"]*"', re.MULTILINE)
+    new_text, count = pattern.subn(rf'\g<1>"version": "{version}"', text, count=1)
+    if count != 1:
+        sys.exit(f"ERROR: expected a top-level '\"version\": \"...\"' line in {_rel(path)}, found {count}.")
+    path.write_text(new_text)
+    print(f"  {_rel(path)} (.version) -> {version}")
+
+
 def main(argv: list[str]) -> int:
     if len(argv) != 1:
         sys.exit("Usage: bump_version.py X.Y.Z")
@@ -129,6 +146,7 @@ def main(argv: list[str]) -> int:
     _bump_project_version(PY_SDK_PYPROJECT, version)
     _bump_yaml_override(PY_SDK_GEN_CONFIG, version)
     _bump_package_json(TS_SDK_PACKAGE, version)
+    _bump_top_level_json_version(DOCS_CONTRACT, version)
     print(f"Done. Run `make version-check` to confirm coherence.")
     return 0
 

--- a/sdks/python/.openapi-python-client.yaml
+++ b/sdks/python/.openapi-python-client.yaml
@@ -4,7 +4,7 @@ project_name_override: geolens
 package_name_override: geolens
 # Rewritten on every `make sdks` run by scripts/sync_sdk_versions.py to match
 # backend/openapi.json info.version. Do not edit by hand.
-package_version_override: 1.4.0
+package_version_override: 1.4.1
 
 # Cleaner enum output (matches our pydantic v2 backend's enum emission).
 literal_enums: true

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "geolens"
-version = "1.4.0"
+version = "1.4.1"
 description = "Auto-generated Python SDK for the GeoLens API. Typed clients with Bearer + API-key auth helpers."
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/sdks/typescript/package-lock.json
+++ b/sdks/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@geolens/sdk",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@geolens/sdk",
-      "version": "1.4.0",
+      "version": "1.4.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@hey-api/client-fetch": "0.13.1"

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@geolens/sdk",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Auto-generated TypeScript SDK for the GeoLens API. Typed clients with Bearer + API-key auth helpers.",
   "license": "Apache-2.0",
   "author": "Carto Concepts, LLC",


### PR DESCRIPTION
## Release prep: v1.4.1

Patch release rolling up everything merged to `main` since **1.4.0**.

### What's in it
- Bumps all 9 version sites `1.4.0 → 1.4.1` (`make bump`; `make version-check` green).
- Regenerates the TypeScript SDK lockfile (`make sdks`; `sdks-check` / `openapi-check` green).
- Rolls `CHANGELOG.md` `[Unreleased]` → `## [1.4.1] - 2026-06-28` and merges the duplicate `Changed` blocks; adds the v1049 **"Color map clusters by size"** feature (Added) and a **builder/admin/search polish** entry (Fixed) covering #347/#348.

### Changelog scope (since 1.4.0)
v1048 data-safety / backup-by-default; AI-chat view-access + read-only tool-gating (#339/#340); embed-token revocation + per-token CSP; the #338 builder correctness pass + style-export fixes; the v1049 builder/admin/UX bug-bash (#347); cluster color-ramp default fix (#348).

### Release steps after merge (per `docs-internal/runbooks/release-runbook.md`)
Cut tag `v1.4.1` at the merge SHA via the GitHub API (NOT `git push --tags`) → approve the two `publish` gates → `verify-published.yml` auto-runs.
