### PR TITLE
fix(builder): popup config not honoring selected fields (request popup cols in tiles)

### DIFF
--- a/frontend/src/components/builder/__tests__/map-sync.data-driven-cols.test.ts
+++ b/frontend/src/components/builder/__tests__/map-sync.data-driven-cols.test.ts
@@ -152,6 +152,54 @@ describe('getDataDrivenColumnsForLayer', () => {
     });
     expect(cols.sort()).toEqual(['pop_est', 'region']);
   });
+
+  // 260628-jjg: popup custom visible_fields + title-template placeholders must be
+  // requested via cols= or they get stripped at z<10 and the popup shows
+  // "No attributes" despite being configured.
+  it('extracts popup_config.visible_fields (custom selection)', () => {
+    const cols = getDataDrivenColumnsForLayer({
+      style_config: null,
+      paint: {},
+      popup_config: { enabled: true, expression: null, visible_fields: ['pop2025', 'label'] },
+    });
+    expect(cols.sort()).toEqual(['label', 'pop2025']);
+  });
+
+  it('extracts {placeholder} columns from popup_config.expression', () => {
+    const cols = getDataDrivenColumnsForLayer({
+      style_config: null,
+      paint: {},
+      popup_config: { enabled: true, expression: '{city}, {state}', visible_fields: null },
+    });
+    expect(cols.sort()).toEqual(['city', 'state']);
+  });
+
+  it('unions popup columns with paint columns and dedupes', () => {
+    const cols = getDataDrivenColumnsForLayer({
+      style_config: { mode: 'graduated', column: 'pop2025', ramp: 'YlOrRd', breaks: [] },
+      paint: {},
+      popup_config: { enabled: true, expression: '{name}', visible_fields: ['pop2025'] },
+    });
+    expect(cols.sort()).toEqual(['name', 'pop2025']);
+  });
+
+  it('ignores popup columns when the popup is disabled', () => {
+    const cols = getDataDrivenColumnsForLayer({
+      style_config: null,
+      paint: {},
+      popup_config: { enabled: false, expression: '{city}', visible_fields: ['pop2025'] },
+    });
+    expect(cols).toEqual([]);
+  });
+
+  it('contributes nothing when visible_fields is null (show-all mode) and no expression', () => {
+    const cols = getDataDrivenColumnsForLayer({
+      style_config: null,
+      paint: {},
+      popup_config: { enabled: true, expression: null, visible_fields: null },
+    });
+    expect(cols).toEqual([]);
+  });
 });
 
 describe('getDataDrivenColumnsForSource', () => {

--- a/frontend/src/components/builder/__tests__/map-sync.data-driven-cols.test.ts
+++ b/frontend/src/components/builder/__tests__/map-sync.data-driven-cols.test.ts
@@ -2,8 +2,10 @@ import { describe, it, expect } from 'vitest';
 import {
   getDataDrivenColumnsForLayer,
   getDataDrivenColumnsForSource,
+  toSyncInput,
   type SyncLayerInput,
 } from '@/components/builder/map-sync';
+import type { MapLayerResponse } from '@/types/api';
 
 describe('getDataDrivenColumnsForLayer', () => {
   it('extracts the categorical / graduated column from style_config', () => {
@@ -209,6 +211,7 @@ describe('getDataDrivenColumnsForSource', () => {
     style_config: SyncLayerInput['style_config'] = null,
     paint: SyncLayerInput['paint'] = {},
     label_config: SyncLayerInput['label_config'] = null,
+    popup_config: SyncLayerInput['popup_config'] = null,
   ): SyncLayerInput {
     return {
       id,
@@ -222,6 +225,7 @@ describe('getDataDrivenColumnsForSource', () => {
       filter: null,
       style_config,
       label_config,
+      popup_config,
     };
   }
 
@@ -258,6 +262,37 @@ describe('getDataDrivenColumnsForSource', () => {
     expect(cols).toEqual([]);
   });
 
+  // 260628-jjg: popup columns must flow through the source-union path too — this
+  // is the BuilderMap path that produces the cols= set for the shared MVT source.
+  it('unions popup_config columns from layers sharing a deduped source', () => {
+    const layers: SyncLayerInput[] = [
+      makeLayer(
+        'l1',
+        'cities',
+        null,
+        {},
+        null,
+        { enabled: true, expression: '{city}, {state}', visible_fields: ['pop2025', 'label'] },
+      ),
+      makeLayer('l2', 'cities', null, {}, null, null),
+    ];
+    const cols = getDataDrivenColumnsForSource('source-data-cities', layers);
+    expect(cols.sort()).toEqual(['city', 'label', 'pop2025', 'state']);
+  });
+
+  it('dedupes a popup field that also drives styling on a sibling layer', () => {
+    const layers: SyncLayerInput[] = [
+      makeLayer('l1', 'cities', { mode: 'graduated', column: 'pop2025', ramp: 'YlOrRd', breaks: [] }),
+      makeLayer('l2', 'cities', null, {}, null, {
+        enabled: true,
+        expression: null,
+        visible_fields: ['pop2025', 'label'],
+      }),
+    ];
+    const cols = getDataDrivenColumnsForSource('source-data-cities', layers);
+    expect(cols.sort()).toEqual(['label', 'pop2025']);
+  });
+
   it('ignores layers using a different source even on the same table (cluster)', () => {
     // A cluster layer takes a per-layer source-id; even at the same table_name,
     // it does NOT share `source-data-{table}` with non-cluster layers.
@@ -271,5 +306,42 @@ describe('getDataDrivenColumnsForSource', () => {
     ];
     const cols = getDataDrivenColumnsForSource('source-data-countries', layers);
     expect(cols).toEqual(['economy']);
+  });
+});
+
+// 260628-jjg: the builder→cols path relies on popup_config surviving the
+// MapLayerResponse → SyncLayerInput conversion. A silent drop here would
+// resurrect the "No attributes" bug, so pin the copy with a test.
+describe('toSyncInput popup_config preservation', () => {
+  it('carries popup_config through the conversion', () => {
+    const popup = { enabled: true, expression: '{city}', visible_fields: ['pop2025'] };
+    const layer = {
+      id: 'l1',
+      dataset_id: 'ds-1',
+      dataset_table_name: 'cities',
+      dataset_geometry_type: 'MultiPoint',
+      opacity: 1,
+      visible: true,
+      paint: {},
+      layout: {},
+      filter: null,
+      popup_config: popup,
+    } as unknown as MapLayerResponse;
+    expect(toSyncInput(layer).popup_config).toEqual(popup);
+  });
+
+  it('defaults popup_config to null when absent', () => {
+    const layer = {
+      id: 'l1',
+      dataset_id: 'ds-1',
+      dataset_table_name: 'cities',
+      dataset_geometry_type: 'MultiPoint',
+      opacity: 1,
+      visible: true,
+      paint: {},
+      layout: {},
+      filter: null,
+    } as unknown as MapLayerResponse;
+    expect(toSyncInput(layer).popup_config).toBeNull();
   });
 });

--- a/frontend/src/components/builder/__tests__/map-sync.data-driven-cols.test.ts
+++ b/frontend/src/components/builder/__tests__/map-sync.data-driven-cols.test.ts
@@ -155,7 +155,7 @@ describe('getDataDrivenColumnsForLayer', () => {
     expect(cols.sort()).toEqual(['pop_est', 'region']);
   });
 
-  // 260628-jjg: popup custom visible_fields + title-template placeholders must be
+  // #350: popup custom visible_fields + title-template placeholders must be
   // requested via cols= or they get stripped at z<10 and the popup shows
   // "No attributes" despite being configured.
   it('extracts popup_config.visible_fields (custom selection)', () => {
@@ -262,7 +262,7 @@ describe('getDataDrivenColumnsForSource', () => {
     expect(cols).toEqual([]);
   });
 
-  // 260628-jjg: popup columns must flow through the source-union path too — this
+  // #350: popup columns must flow through the source-union path too — this
   // is the BuilderMap path that produces the cols= set for the shared MVT source.
   it('unions popup_config columns from layers sharing a deduped source', () => {
     const layers: SyncLayerInput[] = [
@@ -309,7 +309,7 @@ describe('getDataDrivenColumnsForSource', () => {
   });
 });
 
-// 260628-jjg: the builder→cols path relies on popup_config surviving the
+// #350: the builder→cols path relies on popup_config surviving the
 // MapLayerResponse → SyncLayerInput conversion. A silent drop here would
 // resurrect the "No attributes" bug, so pin the copy with a test.
 describe('toSyncInput popup_config preservation', () => {

--- a/frontend/src/components/builder/map-sync.ts
+++ b/frontend/src/components/builder/map-sync.ts
@@ -174,6 +174,9 @@ export interface SyncLayerInput {
   filter: FilterSpecification | null;
   label_config?: LabelConfig | null;
   style_config?: StyleConfig | null;
+  /** Popup config — its visible_fields / title-template columns must be opted
+   *  into the tile `cols=` set or they get stripped at z<10 (260628-jjg). */
+  popup_config?: PopupConfig | null;
   is_dem?: boolean | null;
   is_3d?: boolean | null;
   feature_count?: number | null;
@@ -226,6 +229,7 @@ export function toSyncInput(layer: MapLayerResponse): SyncLayerInput {
     filter: layer.filter,
     label_config: layer.label_config ?? null,
     style_config: layer.style_config ?? null,
+    popup_config: layer.popup_config ?? null,
     is_dem: layer.is_dem,
     is_3d: layer.is_3d,
     feature_count: layer.dataset_feature_count,

--- a/frontend/src/components/builder/map-sync.ts
+++ b/frontend/src/components/builder/map-sync.ts
@@ -175,7 +175,7 @@ export interface SyncLayerInput {
   label_config?: LabelConfig | null;
   style_config?: StyleConfig | null;
   /** Popup config — its visible_fields / title-template columns must be opted
-   *  into the tile `cols=` set or they get stripped at z<10 (260628-jjg). */
+   *  into the tile `cols=` set or they get stripped at z<10 (#350). */
   popup_config?: PopupConfig | null;
   is_dem?: boolean | null;
   is_3d?: boolean | null;
@@ -552,7 +552,7 @@ export interface SourceIdLayer {
  *  - `filter` expressions (builder-audit #338 P1-03) — a filter that references a
  *    column NOT also used by paint/label would otherwise evaluate against
  *    missing properties at z<10, producing empty/inconsistent rendering.
- *  - `popup_config` (260628-jjg) — custom `visible_fields` and `{placeholder}`
+ *  - `popup_config` (#350) — custom `visible_fields` and `{placeholder}`
  *    title-template columns. Without these the popup filters to selected fields
  *    that were stripped from the tile at z<10 and renders "No attributes".
  */

--- a/frontend/src/components/builder/map-sync.ts
+++ b/frontend/src/components/builder/map-sync.ts
@@ -1,7 +1,8 @@
 import type { Map as MaplibreMap, GeoJSONSource, StyleSpecification, VectorSourceSpecification } from 'maplibre-gl';
 import type { FilterSpecification } from 'maplibre-gl';
 import { toast } from 'sonner';
-import type { MapBasemapConfig, MapLayerResponse, LabelConfig, StyleConfig, MapTerrainConfig } from '@/types/api';
+import type { MapBasemapConfig, MapLayerResponse, LabelConfig, StyleConfig, MapTerrainConfig, PopupConfig } from '@/types/api';
+import { extractPlaceholders } from '@/lib/popup-template';
 import type { RasterTileToken, TileToken, VectorTileToken } from '@/api/tiles';
 import i18n from '@/i18n/i18n';
 import { buildClusterTileUrl, buildSignedTileUrl, getMvtSourceLayerName } from '@/lib/tile-utils';
@@ -547,6 +548,9 @@ export interface SourceIdLayer {
  *  - `filter` expressions (builder-audit #338 P1-03) — a filter that references a
  *    column NOT also used by paint/label would otherwise evaluate against
  *    missing properties at z<10, producing empty/inconsistent rendering.
+ *  - `popup_config` (260628-jjg) — custom `visible_fields` and `{placeholder}`
+ *    title-template columns. Without these the popup filters to selected fields
+ *    that were stripped from the tile at z<10 and renders "No attributes".
  */
 export function getDataDrivenColumnsForLayer(
   layer: {
@@ -554,6 +558,7 @@ export function getDataDrivenColumnsForLayer(
     paint?: Record<string, unknown>;
     label_config?: LabelConfig | null;
     filter?: FilterSpecification | unknown[] | null;
+    popup_config?: PopupConfig | null;
   },
 ): string[] {
   const cols = new Set<string>();
@@ -582,6 +587,19 @@ export function getDataDrivenColumnsForLayer(
   }
   for (const val of Object.values(paint)) walk(val);
   if (layer.filter) walk(layer.filter);
+  // Popup columns: the title template's {placeholder} columns and the
+  // custom visible_fields list. Skipped when the popup is explicitly disabled.
+  const popup = layer.popup_config;
+  if (popup && popup.enabled !== false) {
+    if (popup.expression) {
+      for (const c of extractPlaceholders(popup.expression)) cols.add(c);
+    }
+    if (popup.visible_fields) {
+      for (const c of popup.visible_fields) {
+        if (typeof c === 'string' && c) cols.add(c);
+      }
+    }
+  }
   return Array.from(cols);
 }
 
@@ -599,6 +617,7 @@ export function getDataDrivenColumnsForSource(
       paint?: Record<string, unknown>;
       label_config?: LabelConfig | null;
       filter?: FilterSpecification | unknown[] | null;
+      popup_config?: PopupConfig | null;
     };
     for (const c of getDataDrivenColumnsForLayer(layerWithStyle)) cols.add(c);
   }

--- a/frontend/src/components/viewer/ViewerMap.tsx
+++ b/frontend/src/components/viewer/ViewerMap.tsx
@@ -690,6 +690,7 @@ export const ViewerMap = memo(function ViewerMap({
               style_config: layer.style_config ?? null,
               paint: (layer.paint as Record<string, unknown> | undefined) ?? {},
               label_config: layer.label_config ?? null,
+              popup_config: layer.popup_config ?? null,
             });
         const newUrl = strategy.kind === 'server-tile'
           ? buildClusterTileUrl(layer.table_name, token, tileBaseUrl, undefined, {

--- a/frontend/src/components/viewer/ViewerMap.tsx
+++ b/frontend/src/components/viewer/ViewerMap.tsx
@@ -79,8 +79,9 @@ interface ViewerMapProps {
 /** ID prefix used for viewer map layers — keeps IDs distinct from builder. */
 const VIEWER_PREFIX = 'viewer-';
 
-/** Convert a SharedLayerResponse to the normalized SyncLayerInput. */
-function toViewerSyncInput(
+/** Convert a SharedLayerResponse to the normalized SyncLayerInput.
+ *  Exported for unit testing (popup_config preservation, #350). */
+export function toViewerSyncInput(
   layer: SharedLayerResponse,
   layerKey: string,
   visibleLayers: Set<string>,
@@ -96,6 +97,10 @@ function toViewerSyncInput(
     filter: layer.filter ?? null,
     label_config: layer.label_config,
     style_config: layer.style_config,
+    // Carry popup_config so the INITIAL source build (syncMapComposition) requests
+    // popup visible_fields / title-template cols=. Without this a viewer opened at
+    // z<10 strips those fields until a later token-refresh rebuilds the URL (#350).
+    popup_config: layer.popup_config,
     is_dem: layer.is_dem,
     dataset_id: layer.dataset_id,
     is_3d: layer.is_3d,

--- a/frontend/src/components/viewer/__tests__/ViewerMap.popup-cols.test.ts
+++ b/frontend/src/components/viewer/__tests__/ViewerMap.popup-cols.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest';
+import { toViewerSyncInput } from '@/components/viewer/ViewerMap';
+import { getDataDrivenColumnsForLayer } from '@/components/builder/map-sync';
+import type { SharedLayerResponse } from '@/types/api';
+
+// #350 (Codex P2): the INITIAL viewer render builds its source via
+// toViewerSyncInput() -> syncMapComposition before any token-refresh path runs.
+// If popup_config is dropped in that conversion, a viewer opened at z<10 strips
+// the popup's selected fields and shows "No attributes". Pin the copy so the
+// initial source build requests the popup cols= just like the refresh path.
+describe('toViewerSyncInput popup_config preservation (#350)', () => {
+  function makeShared(popup_config: SharedLayerResponse['popup_config']): SharedLayerResponse {
+    return {
+      table_name: 'cities',
+      geometry_type: 'MultiPoint',
+      opacity: 1,
+      paint: {},
+      layout: {},
+      filter: null,
+      label_config: null,
+      style_config: null,
+      dataset_id: 'ds-1',
+      popup_config,
+    } as unknown as SharedLayerResponse;
+  }
+
+  it('carries popup_config into the normalized viewer input', () => {
+    const popup = { enabled: true, expression: '{city}, {state}', visible_fields: ['pop2025', 'label'] };
+    const input = toViewerSyncInput(makeShared(popup), 'l1', new Set(['l1']));
+    expect(input.popup_config).toEqual(popup);
+  });
+
+  it('the initial source build requests popup cols via the carried config', () => {
+    const input = toViewerSyncInput(
+      makeShared({ enabled: true, expression: '{city}', visible_fields: ['pop2025', 'label'] }),
+      'l1',
+      new Set(['l1']),
+    );
+    // This is what syncMapComposition feeds to buildSignedTileUrl for the source.
+    expect(getDataDrivenColumnsForLayer(input).sort()).toEqual(['city', 'label', 'pop2025']);
+  });
+
+  it('passes through a null popup_config without inventing cols', () => {
+    const input = toViewerSyncInput(makeShared(null), 'l1', new Set(['l1']));
+    expect(input.popup_config).toBeNull();
+    expect(getDataDrivenColumnsForLayer(input)).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Problem

Configuring a layer popup with **Custom selection** visible fields (e.g. `pop2025`, `label`) or a title template (`{city}, {state}`) showed **"No attributes"** when clicking a feature at a zoomed-out view — both in the Map Builder and the published viewer.

## Root cause

The popup config *was* honored — the data was never in the tile. The vector tile server projects **no attribute columns at z<10** by default (`map-sync.ts:534`). `getDataDrivenColumnsForLayer` opts a layer's needed columns into the MVT via the `cols=` param so styling / labels / filters survive that stripping — but it never collected **popup** columns:

- `popup_config.visible_fields` (custom-selected fields)
- `popup_config.expression` placeholders (title template)

So at low zoom the clicked feature carried none of the configured columns; the popup correctly filtered to the selected fields, found nothing, and rendered "No attributes" (`FeaturePopup.tsx:248`).

`ViewerMap.tsx:689` additionally passed a **narrowed** object to the shared collector that dropped `popup_config`, so the published viewer needed the call site patched too.

## Fix

- `map-sync.ts` — `getDataDrivenColumnsForLayer` now collects, when the popup is enabled, each `visible_fields` entry plus `extractPlaceholders(expression)`. Threaded `popup_config` through the `getDataDrivenColumnsForSource` cast (BuilderMap passes full layers).
- `ViewerMap.tsx` — narrowed call now includes `popup_config`, so the published viewer requests the same columns.

## Regression hardening

The runtime fix relied on `popup_config` being readable via a cast on a type (`SyncLayerInput`) that didn't declare it — a silent-drop trap. Closed it:

- Added `popup_config` to `SyncLayerInput` + copied it in `toSyncInput` so the `MapLayerResponse → SyncLayerInput` conversion is type-checked end-to-end.
- Expanded `map-sync.data-driven-cols.test.ts` to **28 tests** (10 popup-specific): layer-level collection (visible_fields, expression placeholders, dedupe-with-style, disabled popup → no cols, show-all mode → no cols), source-union/BuilderMap path (2), and `toSyncInput` preservation (2).

## Verification

- `vitest run map-sync.data-driven-cols.test.ts` — 28/28 pass
- `vitest run map-sync` (7 files) — 104/104 pass
- `npm run typecheck` — clean
- `eslint` on touched files — clean

## Scope notes

- "Show all fields" mode (`visible_fields: null`) can't be enumerated into a finite `cols=` budget — out of scope; the reported bug was custom selection.
- Not live-smoked on the demo VM (code + unit verified only).

https://claude.ai/code/session_01RUBTQPVt96RbDf4otjq34E