### PR TITLE
fix(builder): cluster render-mode crash, broken icon swatches, missing fill color for size-graduated layers

### DIFF
--- a/frontend/src/components/builder/IconPicker.tsx
+++ b/frontend/src/components/builder/IconPicker.tsx
@@ -3,6 +3,7 @@ import { Upload } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { useMapIcons, useUploadMapIcon } from '@/hooks/use-maps';
+import { API_BASE } from '@/lib/constants';
 import { cn } from '@/lib/utils';
 
 interface IconPickerProps {
@@ -77,7 +78,14 @@ export function IconPicker({ value, onChange, label, uploadAriaLabel }: IconPick
               title={icon.name}
               aria-label={icon.name}
             >
-              <img src={icon.url} alt="" className="h-5 w-5 object-contain" />
+              {/* icon.url is the API-relative asset path (e.g. /maps/icons/...);
+                  an <img> tag bypasses apiFetch, so prefix API_BASE or it resolves
+                  against the frontend origin and 404s to the SPA shell (#350-followup). */}
+              <img
+                src={icon.url.startsWith('http') ? icon.url : `${API_BASE}${icon.url}`}
+                alt=""
+                className="h-5 w-5 object-contain"
+              />
             </button>
           ))}
         </div>

--- a/frontend/src/components/builder/LayerStyleEditor/CircleEditor.tsx
+++ b/frontend/src/components/builder/LayerStyleEditor/CircleEditor.tsx
@@ -18,18 +18,29 @@ export function CircleEditor({
   return (
     <>
       <div className="text-xs font-medium">{t('style.point')}</div>
-      {isDataDriven ? (
+      {/* Fill color is static UNLESS color is the data-driven target. When the
+          graduated/categorical target is the radius (target === 'radius'), the
+          circle-color stays a solid color the user must still be able to set —
+          so only swap the picker for the "styled by" note when color itself is
+          data-driven (target color or, per the undefined===color convention,
+          categorical). */}
+      {isDataDriven && !isRadiusDataDriven ? (
         <div className="text-xs text-muted-foreground italic">
-          {layer.style_config?.target === 'radius'
-            ? t('style.radiusByColumn', { column: layer.style_config?.column })
-            : t('style.styledBy', { column: layer.style_config?.column })}
+          {t('style.styledBy', { column: layer.style_config?.column })}
         </div>
       ) : (
-        <StyleColorPicker
-          label={t('style.color')}
-          color={getPaintValue(paint, 'circle-color', CIRCLE_DEFAULTS['circle-color'])}
-          onChange={(hex) => onPaintProp('circle-color', hex)}
-        />
+        <>
+          {isRadiusDataDriven && (
+            <div className="text-xs text-muted-foreground italic">
+              {t('style.radiusByColumn', { column: layer.style_config?.column })}
+            </div>
+          )}
+          <StyleColorPicker
+            label={t('style.color')}
+            color={getPaintValue(paint, 'circle-color', CIRCLE_DEFAULTS['circle-color'])}
+            onChange={(hex) => onPaintProp('circle-color', hex)}
+          />
+        </>
       )}
       <ZoomExpressionEditor
         label={t('style.opacity')}

--- a/frontend/src/components/builder/LayerStyleEditor/LineEditor.tsx
+++ b/frontend/src/components/builder/LayerStyleEditor/LineEditor.tsx
@@ -28,20 +28,28 @@ export function LineEditor({
   return (
     <>
       <div className="text-xs font-medium">{t('style.line')}</div>
-      {isDataDriven ? (
+      {/* Line color stays user-settable unless color is the data-driven target.
+          When width is data-driven (target === 'width') the color is still a
+          solid value, so keep the color controls visible (mirrors CircleEditor). */}
+      {isDataDriven && !isWidthDataDriven ? (
         <div className="text-xs text-muted-foreground italic">
-          {layer.style_config?.target === 'width'
-            ? t('style.widthByColumn', { column: layer.style_config?.column })
-            : t('style.styledBy', { column: layer.style_config?.column })}
+          {t('style.styledBy', { column: layer.style_config?.column })}
         </div>
       ) : (
-        <LineGradientControls
-          paint={paint}
-          styleConfig={styleConfig}
-          onPaintProp={onPaintProp}
-          onBuilderChange={onBuilderChange}
-          t={t}
-        />
+        <>
+          {isWidthDataDriven && (
+            <div className="text-xs text-muted-foreground italic">
+              {t('style.widthByColumn', { column: layer.style_config?.column })}
+            </div>
+          )}
+          <LineGradientControls
+            paint={paint}
+            styleConfig={styleConfig}
+            onPaintProp={onPaintProp}
+            onBuilderChange={onBuilderChange}
+            t={t}
+          />
+        </>
       )}
       <ZoomExpressionEditor
         label={t('style.opacity')}

--- a/frontend/src/components/builder/LayerStyleEditor/__tests__/CircleEditor.test.tsx
+++ b/frontend/src/components/builder/LayerStyleEditor/__tests__/CircleEditor.test.tsx
@@ -154,6 +154,54 @@ describe('CircleEditor', () => {
     expect(screen.getByText('Radius by: pop')).toBeInTheDocument();
   });
 
+  // Bug-bash: a graduated/categorical layer whose data-driven TARGET is the
+  // radius keeps a static fill color — the picker must stay visible (only the
+  // radius slider is replaced). Regression: the fill picker was hidden for ANY
+  // data-driven layer, leaving radius-graduated points with stroke color only.
+  it('keeps the fill color picker when target=radius (only radius is data-driven)', () => {
+    const layer = makeCircleLayer({
+      style_config: { column: 'pop', target: 'radius', mode: 'graduated', ramp: 'Blues' } as MapLayerResponse['style_config'],
+    });
+    const t = (key: string, opts?: Record<string, unknown>) => {
+      if (key === 'style.radiusByColumn') return `Radius by: ${opts?.column}`;
+      if (key === 'style.styledBy') return `Styled by: ${opts?.column}`;
+      const labels: Record<string, string> = {
+        'style.point': 'Point', 'style.color': 'Color', 'style.opacity': 'Opacity',
+        'style.radius': 'Radius', 'style.stroke': 'Stroke',
+        'style.toggleStroke': 'Toggle stroke visibility', 'style.width': 'Width',
+      };
+      return labels[key] ?? key;
+    };
+    render(<CircleEditor {...makeProps(layer, { isDataDriven: true, strokeEnabled: true, t })} />);
+
+    // Fill picker (Color) + stroke color picker (Color) = 2; the fill one was
+    // the regression — before the fix only the stroke 'Color' rendered.
+    expect(screen.getAllByText('Color')).toHaveLength(2);
+    expect(screen.getByText('Radius by: pop')).toBeInTheDocument();
+    expect(screen.queryByText(/^Styled by:/)).not.toBeInTheDocument();
+    expect(screen.queryByRole('slider', { name: 'Radius' })).not.toBeInTheDocument();
+  });
+
+  it('hides the fill color picker when color itself is the data-driven target (undefined target = color)', () => {
+    const layer = makeCircleLayer({
+      style_config: { column: 'value', mode: 'graduated', ramp: 'Blues' } as MapLayerResponse['style_config'],
+    });
+    const t = (key: string, opts?: Record<string, unknown>) => {
+      if (key === 'style.styledBy') return `Styled by: ${opts?.column}`;
+      const labels: Record<string, string> = {
+        'style.point': 'Point', 'style.color': 'Color', 'style.opacity': 'Opacity',
+        'style.radius': 'Radius', 'style.stroke': 'Stroke',
+        'style.toggleStroke': 'Toggle stroke visibility', 'style.width': 'Width',
+      };
+      return labels[key] ?? key;
+    };
+    render(<CircleEditor {...makeProps(layer, { isDataDriven: true, strokeEnabled: true, t })} />);
+
+    // Only the stroke color picker remains (1) — the data-driven fill is a note.
+    expect(screen.getAllByText('Color')).toHaveLength(1);
+    expect(screen.getByText('Styled by: value')).toBeInTheDocument();
+  });
+
   it('is a named export and a default export from CircleEditor.tsx', async () => {
     const { CircleEditor: named } = await import('../CircleEditor');
     const defaultExport = (await import('../CircleEditor')).default;

--- a/frontend/src/components/builder/LayerStyleEditor/__tests__/LineEditor.test.tsx
+++ b/frontend/src/components/builder/LayerStyleEditor/__tests__/LineEditor.test.tsx
@@ -173,6 +173,31 @@ describe('LineEditor', () => {
     expect(screen.queryByRole('group', { name: 'Width mode' })).not.toBeInTheDocument();
   });
 
+  // Bug-bash: a line whose data-driven target is the WIDTH keeps a static color,
+  // so the color controls must stay visible (mirrors CircleEditor + radius).
+  it('keeps line color controls when target=width (only width is data-driven)', () => {
+    const layer = makeLineLayer({
+      paint: { 'line-color': '#ff0000', 'line-width': ['step', ['get', 'traffic'], 1, 10, 4] },
+      style_config: { column: 'traffic', target: 'width', mode: 'graduated' } as MapLayerResponse['style_config'],
+    });
+    render(<LineEditor {...makeProps(layer, { isDataDriven: true, styleConfig: layer.style_config ?? null })} />);
+
+    // LineGradientControls (color) must still render for a width-driven line.
+    expect(screen.getByText('Solid color')).toBeInTheDocument();
+    expect(screen.getByText('Width by')).toBeInTheDocument();
+    expect(screen.queryByText('Styled by')).not.toBeInTheDocument();
+  });
+
+  it('hides line color controls when color itself is the data-driven target', () => {
+    const layer = makeLineLayer({
+      style_config: { column: 'cat', mode: 'categorical' } as MapLayerResponse['style_config'],
+    });
+    render(<LineEditor {...makeProps(layer, { isDataDriven: true, styleConfig: layer.style_config ?? null })} />);
+
+    expect(screen.getByText('Styled by')).toBeInTheDocument();
+    expect(screen.queryByText('Solid color')).not.toBeInTheDocument();
+  });
+
   it('is a named export and a default export from LineEditor.tsx', async () => {
     const { LineEditor: named } = await import('../LineEditor');
     const defaultExport = (await import('../LineEditor')).default;

--- a/frontend/src/components/builder/__tests__/IconPicker.test.tsx
+++ b/frontend/src/components/builder/__tests__/IconPicker.test.tsx
@@ -1,0 +1,37 @@
+import { render } from '@/test/test-utils';
+import { IconPicker } from '../IconPicker';
+import { API_BASE } from '@/lib/constants';
+
+// Bug-bash: the icon swatch <img> used icon.url verbatim (e.g.
+// "/maps/icons/builtin:marker/asset"). An <img> tag bypasses apiFetch, so
+// without the API_BASE prefix the request hit the frontend origin and 404'd to
+// the SPA shell (text/html) → broken image. The fix prefixes API_BASE for
+// API-relative urls while leaving absolute urls untouched.
+vi.mock('@/hooks/use-maps', () => ({
+  useMapIcons: () => ({
+    data: {
+      icons: [
+        {
+          id: 'b-marker', name: 'Marker', slug: 'marker', media_type: 'image/svg+xml',
+          url: '/maps/icons/builtin:marker/asset', sprite_id: 'marker', builtin: true,
+        },
+        {
+          id: 'cdn-1', name: 'CDN', slug: 'cdn', media_type: 'image/png',
+          url: 'https://cdn.example.com/icon.png', sprite_id: 'cdn', builtin: false,
+        },
+      ],
+    },
+  }),
+  useUploadMapIcon: () => ({ mutateAsync: vi.fn(), isPending: false }),
+}));
+
+describe('IconPicker', () => {
+  it('prefixes API_BASE on a relative icon url, leaves an absolute url untouched', () => {
+    const { container } = render(
+      <IconPicker value="marker" onChange={vi.fn()} label="Icon" uploadAriaLabel="Upload icon" />,
+    );
+    const srcs = Array.from(container.querySelectorAll('img')).map((img) => img.getAttribute('src'));
+    expect(srcs).toContain(`${API_BASE}/maps/icons/builtin:marker/asset`);
+    expect(srcs).toContain('https://cdn.example.com/icon.png');
+  });
+});

--- a/frontend/src/components/builder/hooks/__tests__/use-builder-layers.cluster-defer.test.ts
+++ b/frontend/src/components/builder/hooks/__tests__/use-builder-layers.cluster-defer.test.ts
@@ -95,8 +95,11 @@ describe('render-mode switch — cluster transitions defer to reactive sync', ()
     });
 
     // The crash was an imperative addLayer against a not-yet-created cluster
-    // source. The reactive sync owns cluster now → no imperative addLayer here.
+    // source. The reactive sync owns the ADD now → no imperative addLayer here…
     expect(mapStub.addLayer).not.toHaveBeenCalled();
+    // …but the old layer graph MUST be torn down first, or the reconciler skips
+    // re-adding the (now cluster) layer because its id still exists (Codex #351).
+    expect(mapStub.removeLayer).toHaveBeenCalledWith(`layer-${LAYER_ID}`);
   });
 
   it('leaving cluster (→ points) also defers — no imperative addLayer', () => {
@@ -114,6 +117,7 @@ describe('render-mode switch — cluster transitions defer to reactive sync', ()
     });
 
     expect(mapStub.addLayer).not.toHaveBeenCalled();
+    expect(mapStub.removeLayer).toHaveBeenCalledWith(`layer-${LAYER_ID}`);
   });
 
   it('control: a same-source swap (heatmap) STILL applies imperatively (addLayer called)', () => {

--- a/frontend/src/components/builder/hooks/__tests__/use-builder-layers.cluster-defer.test.ts
+++ b/frontend/src/components/builder/hooks/__tests__/use-builder-layers.cluster-defer.test.ts
@@ -1,0 +1,134 @@
+/**
+ * Bug-bash regression: render-mode switch to/from CLUSTER must NOT be applied
+ * imperatively via swapLayerOnMap.
+ *
+ * Cluster layers get a per-layer GeoJSON/server-tile source (`source-<id>`) that
+ * differs from the shared vector source (`source-data-<table>`) and does not
+ * exist yet when switching in. The imperative same-source swapLayerOnMap added
+ * the cluster layer to that not-yet-created source ("source ... not found") and
+ * then collided with the reactive syncMapComposition reconcile ("layer ...
+ * already exists"). The fix defers cluster transitions (entering OR leaving) to
+ * the reactive sync — so swapLayerOnMap (and thus map.addLayer) must NOT run for
+ * them, while same-source swaps (e.g. heatmap) still apply imperatively.
+ *
+ * Worker-OOM note (mirrors use-builder-layers.swap-idle-retry.test.ts): mapData
+ * MUST be created outside renderHook and passed as a stable reference.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { act } from '@testing-library/react';
+import { renderHook } from '@/test/test-utils';
+import { useBuilderLayers } from '@/components/builder/hooks/use-builder-layers';
+import {
+  makeBuilderLayer,
+  makeBuilderMap,
+} from '@/components/builder/__tests__/fixtures/map-builder-fixtures';
+import type { MapLayerResponse } from '@/types/api';
+
+type MaplibreMap = import('maplibre-gl').Map;
+
+const LAYER_ID = 'layer-cluster-defer';
+
+function makeLayer(overrides: Partial<MapLayerResponse> = {}): MapLayerResponse {
+  return makeBuilderLayer({
+    id: LAYER_ID,
+    dataset_id: 'ds-cluster',
+    dataset_geometry_type: 'Point',
+    dataset_table_name: 'cities',
+    dataset_feature_count: 1000,
+    layer_type: 'vector_geolens',
+    ...overrides,
+  });
+}
+
+function makeLoadedMapStub(existingLayerIds: string[] = []): MaplibreMap {
+  const existing = new Set(existingLayerIds);
+  return {
+    isStyleLoaded: vi.fn(() => true),
+    getLayer: vi.fn((id: string) => (existing.has(id) ? { id } : undefined)),
+    getSource: vi.fn(() => ({ tiles: ['/tiles/mock/{z}/{x}/{y}.pbf'] })),
+    addSource: vi.fn(),
+    removeSource: vi.fn(),
+    addLayer: vi.fn((spec: { id: string }) => { existing.add(spec.id); }),
+    removeLayer: vi.fn(),
+    setLayoutProperty: vi.fn(),
+    setPaintProperty: vi.fn(),
+    setFilter: vi.fn(),
+    moveLayer: vi.fn(),
+    setLayerZoomRange: vi.fn(),
+    on: vi.fn(),
+    off: vi.fn(),
+    once: vi.fn(),
+    getStyle: vi.fn(() => ({ layers: [] })),
+    fitBounds: vi.fn(),
+    setTransformRequest: vi.fn(),
+    resize: vi.fn(),
+    loaded: vi.fn(() => true),
+  } as unknown as MaplibreMap;
+}
+
+function renderBuilderLayersHook(
+  mapData: ReturnType<typeof makeBuilderMap>,
+  mapRef: React.RefObject<MaplibreMap | null>,
+) {
+  const addLayerMutation = { mutate: vi.fn() } as unknown as Parameters<typeof useBuilderLayers>[3];
+  const removeLayerMutation = { mutate: vi.fn() } as unknown as Parameters<typeof useBuilderLayers>[4];
+  return renderHook(() =>
+    useBuilderLayers(mapData, mapRef, 'map-cluster', addLayerMutation, removeLayerMutation),
+  );
+}
+
+describe('render-mode switch — cluster transitions defer to reactive sync', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('entering cluster does NOT imperatively add a layer (deferred to syncMapComposition)', () => {
+    const layer = makeLayer();
+    const mapData = makeBuilderMap([layer]);
+    const mapStub = makeLoadedMapStub([`layer-${LAYER_ID}`]);
+    const mapRef = { current: mapStub } as React.RefObject<MaplibreMap | null>;
+
+    const { result } = renderBuilderLayersHook(mapData, mapRef);
+
+    act(() => {
+      result.current.handleRenderModeChange(LAYER_ID, 'cluster');
+    });
+
+    // The crash was an imperative addLayer against a not-yet-created cluster
+    // source. The reactive sync owns cluster now → no imperative addLayer here.
+    expect(mapStub.addLayer).not.toHaveBeenCalled();
+  });
+
+  it('leaving cluster (→ points) also defers — no imperative addLayer', () => {
+    const layer = makeLayer({
+      style_config: { render_mode: 'cluster', builder: { clusterRadius: 48, clusterMaxZoom: 14 } } as MapLayerResponse['style_config'],
+    });
+    const mapData = makeBuilderMap([layer]);
+    const mapStub = makeLoadedMapStub([`layer-${LAYER_ID}`]);
+    const mapRef = { current: mapStub } as React.RefObject<MaplibreMap | null>;
+
+    const { result } = renderBuilderLayersHook(mapData, mapRef);
+
+    act(() => {
+      result.current.handleRenderModeChange(LAYER_ID, 'points');
+    });
+
+    expect(mapStub.addLayer).not.toHaveBeenCalled();
+  });
+
+  it('control: a same-source swap (heatmap) STILL applies imperatively (addLayer called)', () => {
+    const layer = makeLayer();
+    const mapData = makeBuilderMap([layer]);
+    const mapStub = makeLoadedMapStub([`layer-${LAYER_ID}`]);
+    const mapRef = { current: mapStub } as React.RefObject<MaplibreMap | null>;
+
+    const { result } = renderBuilderLayersHook(mapData, mapRef);
+
+    act(() => {
+      result.current.handleRenderModeChange(LAYER_ID, 'heatmap');
+    });
+
+    // Heatmap stays on the shared source, so the imperative swap is safe + used.
+    expect(mapStub.addLayer).toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/builder/hooks/use-render-mode-layers.ts
+++ b/frontend/src/components/builder/hooks/use-render-mode-layers.ts
@@ -179,6 +179,27 @@ export function useRenderModeLayers({
     }
   }, [mapInstanceRef, t]);
 
+  /** Cluster transitions are handed to the reactive syncMapComposition, but that
+   *  reconciler adds before it removes stale layers and SKIPS adding a layer id
+   *  that already exists (map-sync `if (!map.getLayer(id)) adapter.addLayers`).
+   *  The cluster⇄points transition reuses the layer's MapLibre ids on a DIFFERENT
+   *  source, so the old layer graph must be torn down first or the reconciler
+   *  skips the replacement and then deletes the stale layer → blank until the next
+   *  sync (Codex #351). Remove the layer + every companion id here; source
+   *  create/teardown stays with syncMapComposition's removeStaleSourcesAndLayers. */
+  const removeLayerGraphForReactiveSync = useCallback(function runRemove(layerId: string): void {
+    const map = mapInstanceRef.current;
+    if (!map) return;
+    if (!map.isStyleLoaded()) {
+      map.once('idle', () => runRemove(layerId));
+      return;
+    }
+    const ids = getCompanionLayerIds(layerId);
+    for (const id of [ids.colorRelief, ids.label, ids.arrow, ids.extrusion, ids.outline, ids.clusterCount, ids.cluster, ids.layer]) {
+      if (map.getLayer(id)) map.removeLayer(id);
+    }
+  }, [mapInstanceRef]);
+
   const handleRenderAsChange = useCallback((layerId: string, renderAs: RenderAsId) => {
     const layer = layersRef.current.find((l) => l.id === layerId);
     if (!layer) return;
@@ -208,11 +229,13 @@ export function useRenderModeLayers({
     // with the reactive reconcile ("source ... not found" / "layer ... already
     // exists"). Defer cluster transitions (entering OR leaving) to
     // syncMapComposition in BuilderMap, which rebuilds source + layers atomically.
-    if (!isClusterTransition(layer, updatedLayer)) {
+    if (isClusterTransition(layer, updatedLayer)) {
+      removeLayerGraphForReactiveSync(layerId);
+    } else {
       swapLayerOnMap(updatedLayer, mutation.adapterType, updatedLayer.paint ?? {});
     }
     setHasUnsavedChanges(true);
-  }, [layersRef, setLocalLayers, setHasUnsavedChanges, swapLayerOnMap]);
+  }, [layersRef, setLocalLayers, setHasUnsavedChanges, swapLayerOnMap, removeLayerGraphForReactiveSync]);
 
   const handleRenderModeChange = useCallback((layerId: string, mode: RenderAsId | 'points') => {
     const layer = layersRef.current.find((l) => l.id === layerId);
@@ -269,7 +292,8 @@ export function useRenderModeLayers({
         ),
       );
 
-      if (!leavingCluster) swapLayerOnMap(layer, 'heatmap', updatedPaint);
+      if (leavingCluster) removeLayerGraphForReactiveSync(layerId);
+      else swapLayerOnMap(layer, 'heatmap', updatedPaint);
     } else if (mode === 'symbol') {
       const savedCirclePaint = currentStyleConfig.savedCirclePaint ?? { ...updatedPaint };
       const nextStyleConfig = {
@@ -288,7 +312,8 @@ export function useRenderModeLayers({
         ),
       );
 
-      if (!leavingCluster) swapLayerOnMap({ ...layer, style_config: nextStyleConfig }, 'symbol', updatedPaint);
+      if (leavingCluster) removeLayerGraphForReactiveSync(layerId);
+      else swapLayerOnMap({ ...layer, style_config: nextStyleConfig }, 'symbol', updatedPaint);
     } else {
       const savedHeatmapPaint = { ...updatedPaint };
       const savedCirclePaint = currentStyleConfig.savedCirclePaint ?? {};
@@ -307,11 +332,12 @@ export function useRenderModeLayers({
         ),
       );
 
-      if (!leavingCluster) swapLayerOnMap(layer, 'circle', updatedPaint);
+      if (leavingCluster) removeLayerGraphForReactiveSync(layerId);
+      else swapLayerOnMap(layer, 'circle', updatedPaint);
     }
 
     setHasUnsavedChanges(true);
-  }, [layersRef, setLocalLayers, setHasUnsavedChanges, handleRenderAsChange, swapLayerOnMap]);
+  }, [layersRef, setLocalLayers, setHasUnsavedChanges, handleRenderAsChange, swapLayerOnMap, removeLayerGraphForReactiveSync]);
 
   return {
     swapLayerOnMap,

--- a/frontend/src/components/builder/hooks/use-render-mode-layers.ts
+++ b/frontend/src/components/builder/hooks/use-render-mode-layers.ts
@@ -27,6 +27,20 @@ const DEFAULT_SYMBOL_CONFIG: SymbolStyleConfig = {
   iconOffset: [0, 0],
 };
 
+/** A render-mode change that enters OR leaves cluster mode crosses a source
+ *  boundary — cluster layers get a per-layer GeoJSON/server-tile source while
+ *  every other render mode shares the deduped vector source. The imperative
+ *  swapLayerOnMap assumes a stable source id, so these transitions must be
+ *  handed to the reactive syncMapComposition (BuilderMap) which rebuilds the
+ *  source + layers atomically instead. */
+function isClusterTransition(
+  prev: { style_config?: StyleConfig | null },
+  next: { style_config?: StyleConfig | null },
+): boolean {
+  return prev.style_config?.render_mode === 'cluster'
+    || next.style_config?.render_mode === 'cluster';
+}
+
 // STATE-02: render-mode / layer-swap cluster, relocated verbatim out of the
 // useBuilderLayers god-hook. PURE RELOCATION — handler bodies are unchanged; the
 // shared layers state (layersRef + setters) is threaded in as params.
@@ -187,7 +201,16 @@ export function useRenderModeLayers({
     setLocalLayers((prev) =>
       prev.map((candidate) => (candidate.id === layerId ? updatedLayer : candidate)),
     );
-    swapLayerOnMap(updatedLayer, mutation.adapterType, updatedLayer.paint ?? {});
+    // Cluster uses a per-layer GeoJSON/server-tile source whose id differs from
+    // the shared vector source and may not exist yet when switching in. The
+    // imperative same-source swapLayerOnMap cannot bridge that source change — it
+    // would add the cluster layer to a not-yet-created source and then collide
+    // with the reactive reconcile ("source ... not found" / "layer ... already
+    // exists"). Defer cluster transitions (entering OR leaving) to
+    // syncMapComposition in BuilderMap, which rebuilds source + layers atomically.
+    if (!isClusterTransition(layer, updatedLayer)) {
+      swapLayerOnMap(updatedLayer, mutation.adapterType, updatedLayer.paint ?? {});
+    }
     setHasUnsavedChanges(true);
   }, [layersRef, setLocalLayers, setHasUnsavedChanges, swapLayerOnMap]);
 
@@ -218,6 +241,10 @@ export function useRenderModeLayers({
       return;
     }
 
+    // Leaving cluster crosses the per-layer→shared source boundary; defer the
+    // map mutation to the reactive syncMapComposition (see isClusterTransition).
+    const leavingCluster = layer.style_config?.render_mode === 'cluster';
+
     const currentStyleConfig: Partial<StyleConfig> = layer.style_config ?? {};
     let updatedPaint = { ...layer.paint };
 
@@ -242,7 +269,7 @@ export function useRenderModeLayers({
         ),
       );
 
-      swapLayerOnMap(layer, 'heatmap', updatedPaint);
+      if (!leavingCluster) swapLayerOnMap(layer, 'heatmap', updatedPaint);
     } else if (mode === 'symbol') {
       const savedCirclePaint = currentStyleConfig.savedCirclePaint ?? { ...updatedPaint };
       const nextStyleConfig = {
@@ -261,7 +288,7 @@ export function useRenderModeLayers({
         ),
       );
 
-      swapLayerOnMap({ ...layer, style_config: nextStyleConfig }, 'symbol', updatedPaint);
+      if (!leavingCluster) swapLayerOnMap({ ...layer, style_config: nextStyleConfig }, 'symbol', updatedPaint);
     } else {
       const savedHeatmapPaint = { ...updatedPaint };
       const savedCirclePaint = currentStyleConfig.savedCirclePaint ?? {};
@@ -280,7 +307,7 @@ export function useRenderModeLayers({
         ),
       );
 
-      swapLayerOnMap(layer, 'circle', updatedPaint);
+      if (!leavingCluster) swapLayerOnMap(layer, 'circle', updatedPaint);
     }
 
     setHasUnsavedChanges(true);


### PR DESCRIPTION
Three independent builder bugs found while bug-bashing the demo.

## 1. Cluster render-mode switch crashes (`4efa9a8b`)
Switching a layer to/from **Cluster** threw `source "source-<id>" not found`, `Source layer ... does not exist`, and `layer <id> already exists`.

Cluster layers use a **per-layer** GeoJSON/server-tile source whose id differs from the shared vector source (`source-data-<table>`) and doesn't exist yet when switching in. The imperative same-source `swapLayerOnMap` added the cluster layer to that not-yet-created source, then collided with the reactive `syncMapComposition` reconcile.

**Fix:** cluster transitions (entering OR leaving) skip the imperative swap and let `syncMapComposition` rebuild the source + layers atomically. Same-source swaps (circle/heatmap/symbol) still apply imperatively. Regression test asserts no imperative `addLayer` for cluster transitions while heatmap still applies.

## 2. Broken marker/icon swatches in the Symbol editor (`e0592188`)
`icon.url` is the API-relative asset path (`/maps/icons/builtin:<slug>/asset`). An `<img>` tag bypasses `apiFetch`, so without the `API_BASE` prefix it resolved against the frontend origin and 404'd to the SPA shell (`text/html`) → broken image. (Verified on the live demo: `…/maps/icons/builtin:marker/asset` → 200 text/html; `…/api/maps/icons/builtin:marker/asset` → 200 image/svg+xml.) On-map symbol rendering was unaffected (uses the `/api/maps/sprites/geolens` sprite).

**Fix:** prefix `API_BASE` for relative urls, leave absolute urls untouched.

## 3. No fill color for size-graduated layers (`13cb9087`)
A graduated/categorical layer whose data-driven **target is the radius** (circle) or **width** (line) keeps a static color, but the color picker was hidden for *any* data-driven layer — leaving radius-graduated points (and width-graduated lines) with stroke color only.

**Fix:** only swap the picker for the "styled by" note when **color itself** is data-driven (target `color`, or `undefined` per the `undefined === color` convention); show the picker for `radius`/`width` targets.

## Verification
- Full builder suite: **1693/1693** pass (incl. new CircleEditor, LineEditor, IconPicker, and cluster-defer regression tests)
- `npm run typecheck` clean · `eslint` clean

https://claude.ai/code/session_01RUBTQPVt96RbDf4otjq34E