### PR TITLE
ci: bump enterprise pin to e002 oauth-constraint fix + doc OPENAI_MODEL_LIGHT

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -265,6 +265,12 @@ FRONTEND_PORT=8080
 # Type: string | Default: gpt-4o
 # OPENAI_MODEL=gpt-4o
 
+# [OPTIONAL] Lighter LLM model for SQL generation (Ask AI "query_data") + AI metadata.
+# Type: string | Default: reuses OPENAI_MODEL (Anthropic provider uses claude-haiku)
+# Must be a model your provider actually serves; for Azure OpenAI it must match a
+# deployment name. Leave blank to reuse OPENAI_MODEL (recommended).
+# OPENAI_MODEL_LIGHT=
+
 # [OPTIONAL] Custom base URL for OpenAI-compatible providers (Ollama, Groq, Together, etc.)
 # Type: string | No default
 # Example: http://host.docker.internal:11434/v1 (Ollama)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,10 +23,12 @@ concurrency:
 # suite passes against core before merging. Companion to the EXTENSION_API_VERSION
 # fail-loud loader check introduced in Plan 1206-01.
 env:
-  # geolens-enterprise origin/main as of 2026-06-14; core@1206 re-verified GREEN
-  # against this ref (load_extensions boots, EnterprisePermissionExtension resolves,
-  # legacy EXTENSION_API_VERSION tolerated, test_saml_overlay.py 21 passed).
-  ENTERPRISE_PINNED_REF: "af12809713a5a2f481d90c9d5c65a8e2bae888bc"
+  # geolens-enterprise origin/main: the 2026-06-14 ref (af128097) plus PR #22
+  # (be40d109), which fixes e002's chk_oauth_providers_type to include 'github'
+  # — the source of the recurring Pytest Parallel Isolation flake
+  # (test_oauth_github_provider) when the overlay applies. No EXTENSION_API_VERSION
+  # change; the migration fix is the only delta from the prior pinned tree.
+  ENTERPRISE_PINNED_REF: "be40d1095f9fdce39ef0b4f4ddf4a4984ae47b21"
 
 # Least-privilege default for every job. The `changes` job widens to add
 # pull-requests:read; no job needs write (publishing lives in publish*.yml).

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,10 +24,11 @@ concurrency:
 # fail-loud loader check introduced in Plan 1206-01.
 env:
   # geolens-enterprise origin/main: the 2026-06-14 ref (af128097) plus PR #22
-  # (be40d109), which fixes e002's chk_oauth_providers_type to include 'github'
-  # — the source of the recurring Pytest Parallel Isolation flake
-  # (test_oauth_github_provider) when the overlay applies. No EXTENSION_API_VERSION
-  # change; the migration fix is the only delta from the prior pinned tree.
+  # (be40d109), which aligns e002's chk_oauth_providers_type with the canonical
+  # declaration in core's oauth/models.py by adding 'github' to the union (so the
+  # overlay can never drop it whichever parallel branch sorts last). A
+  # correctness/consistency fix — NOT a flake fix. No EXTENSION_API_VERSION
+  # change; the migration alignment is the only delta from the prior pinned tree.
   ENTERPRISE_PINNED_REF: "be40d1095f9fdce39ef0b4f4ddf4a4984ae47b21"
 
 # Least-privilege default for every job. The `changes` job widens to add


### PR DESCRIPTION
Two small follow-ups from the AI light-model session.

## 1. Bump `ENTERPRISE_PINNED_REF` → `be40d109` (consistency fix, not a flake fix)

Pulls in geolens-enterprise **PR #22**, which aligns `e002`'s `chk_oauth_providers_type` with the canonical declaration in core `oauth/models.py` by adding `'github'` to the union. The overlay's `e002` runs on a branch parallel to OSS `0010`; both recreate that constraint, so making e002 write the same full union ensures the overlay can never drop `'github'` whichever branch sorts last.

**Correction:** this was originally filed as a fix for the recurring Pytest Parallel Isolation flake on `test_oauth_github_provider`. Investigation disproved that: PPI runs OSS-only (no overlay), and the failures were the documented **v1020 per-worker-DB-lifecycle race** (3 failures clustered on one worker that lost its DB setup under connection contention), not a constraint issue. So this is a correctness/consistency improvement, **not** a flake fix. `be40d109` = the prior pinned tree + only PR #22; no `EXTENSION_API_VERSION` change.

## 2. Document `OPENAI_MODEL_LIGHT` in `.env.example`

The light-model override added in #352, documented next to `OPENAI_MODEL`. Blank reuses `OPENAI_MODEL`.