### PR TITLE
[codex] humanize repository readmes

### DIFF
--- a/.github/assets/README.md
+++ b/.github/assets/README.md
@@ -1,35 +1,35 @@
 # README assets
 
 Images embedded in the top-level `README.md`. They're committed here because
-GitHub renders README images from the repository itself — **not** from an
+GitHub renders README images from the repository itself, not from an
 external URL or CDN. Keep finished images in this folder; keep the *capture
 tooling* out of this public repo (see "Where the tooling lives" below).
 
 ## Current set
 
-The README hero plus a four-beat **Find → Inspect → Build → Ask AI** story.
-Displayed at `width="900"`; sources are ~1200 px wide. Use **PNG** for UI shots
-(crisp text) and **JPG** for photographic 3D terrain (smaller).
+The README hero plus a four-step Find -> Inspect -> Build -> Ask AI story.
+Displayed at `width="900"`; sources are ~1200 px wide. Use PNG for UI shots
+(crisp text) and JPG for photographic 3D terrain (smaller).
 
 | File | Beat | Shows | How to reproduce (live seeded stack) |
 | --- | --- | --- | --- |
-| `geolens-manhattan-3d-hero.jpg` | Hero | Manhattan footprints extruded to roof height in the builder | Open the **Manhattan Skyline — Real Roof Heights** map in the builder |
+| `geolens-manhattan-3d-hero.jpg` | Hero | Manhattan footprints extruded to roof height in the builder | Open the **Manhattan Skyline - Real Roof Heights** map in the builder |
 | `geolens-search.png` | Find | Semantic search ranking hydrology datasets | Catalog at `/?q=hydrology` (dismiss the autocomplete before the shot) |
-| `geolens-dataset.png` | Inspect | Dataset map preview + typed attribute table | **Rivers Lake Centerlines (10m)** dataset → **Data** tab |
-| `geolens-matterhorn-terrain.jpg` | Build | Matterhorn 3D terrain mesh + layer stack | Open **The Matterhorn — swissALTI3D 3D Terrain** map in the builder |
-| `geolens-ai-labels.png` | Ask AI | AI adding county labels to a choropleth | **New York Income by County** map → Ask AI → "Add area labels" |
+| `geolens-dataset.png` | Inspect | Dataset map preview + typed attribute table | Rivers Lake Centerlines (10m) dataset, Data tab |
+| `geolens-matterhorn-terrain.jpg` | Build | Matterhorn 3D terrain mesh + layer stack | Open The Matterhorn - swissALTI3D 3D Terrain map in the builder |
+| `geolens-ai-labels.png` | Ask AI | AI adding county labels to a choropleth | New York Income by County map, Ask AI, "Add area labels" |
 
 ## Seeding the data
 
-`scripts/seed-showcase.py` builds the showcase maps behind the **hero**,
-**Build** (Matterhorn), and **Ask AI** (NY income) shots:
+`scripts/seed-showcase.py` builds the demo maps behind the hero,
+Build (Matterhorn), and Ask AI (NY income) shots:
 
 ```bash
 python scripts/seed-showcase.py --username admin --password admin --with-terrain
 ```
 
-The **Find** (search) and **Inspect** (dataset) shots use a Natural Earth vector
-catalog — rivers, lakes, subwatersheds. There is no bundled seeder for those;
+The Find (search) and Inspect (dataset) shots use a Natural Earth vector
+catalog: rivers, lakes, subwatersheds. There is no bundled seeder for those;
 load them into the catalog via the import flow (`geolens publish` / a manifest,
 see the main README) before capturing.
 
@@ -41,13 +41,13 @@ see the main README) before capturing.
 - The Matterhorn camera was framed via the live MapLibre map
   (`jumpTo` ≈ `{ center: [7.66, 45.97], zoom: 13.7, pitch: 60, bearing: -122 }`,
   with left padding for the layer panel). The builder caps pitch at 60°.
-- **These images are public.** Keep them free of private/draft dataset titles,
+- These images are public. Keep them free of private/draft dataset titles,
   internal hostnames, and PII.
 
 ## Where the tooling lives
 
 The reusable Playwright capture machinery and the canonical capture recipe live
-in the **private** getgeolens.com site repo (it drives that site's own
-marketing/docs screenshots). Do **not** add capture scripts to this public repo —
-capture from the live stack and copy the finished images in, the same way brand
+in the private getgeolens.com site repo (it drives that site's own
+marketing/docs screenshots). Do not add capture scripts to this public repo.
+Capture from the live stack and copy the finished images in, the same way brand
 assets are vendored (`BRANDING-VERSION`).

--- a/README.de.md
+++ b/README.de.md
@@ -4,7 +4,7 @@
 
 **Die raumbezogenen Daten Ihres Teams, an einem Ort durchsuchbar.**
 
-Laden Sie Shapefiles, GeoTIFFs, GeoPackages oder CSVs hoch. GeoLens speichert alles in PostGIS, indexiert Metadaten mit pgvector + pg_trgm für semantische und unscharfe Suche und stellt OGC APIs bereit, die QGIS, ArcGIS und MapLibre Clients direkt nutzen können. Gebaut mit FastAPI und React, bereitgestellt mit einem einzigen Befehl.
+Laden Sie Shapefiles, GeoTIFFs, GeoPackages oder CSVs hoch. GeoLens speichert alles in PostGIS, indexiert Metadaten mit pgvector + pg_trgm für semantische und unscharfe Suche und stellt OGC APIs bereit, die QGIS, ArcGIS und MapLibre Clients direkt nutzen können. Es basiert auf FastAPI und React und lässt sich mit einem einzigen Befehl bereitstellen.
 
 > Dies ist eine gekürzte Übersetzung. Das englische [README](README.md) ist die kanonische Quelle; die vollständige, stets aktuelle deutschsprachige Dokumentation finden Sie unter **[docs.getgeolens.com/de](https://docs.getgeolens.com/de)**.
 
@@ -16,13 +16,13 @@ Laden Sie Shapefiles, GeoTIFFs, GeoPackages oder CSVs hoch. GeoLens speichert al
 
 ```bash
 curl -fsSL https://getgeolens.com/install.sh | sh
-# Öffnen Sie http://localhost:8080 — Login mit den von Ihnen gewählten Anmeldedaten
+# Öffnen Sie http://localhost:8080 und melden Sie sich mit den von Ihnen gewählten Anmeldedaten an
 ```
 
 <p align="center">
   <img src=".github/assets/geolens-manhattan-3d-hero.jpg" alt="GeoLens Map Builder: Gebäudegrundrisse von Manhattan zu einer 3D-Skyline extrudiert, nach Dachhöhe eingefärbt, mit geöffnetem Layer-Stil-Editor neben der Karte" width="900" />
   <br />
-  <em>Der Map Builder — Manhattans Gebäudegrundrisse, extrudiert nach Dachhöhe und durch einen datengesteuerten Stil eingefärbt, erstellt aus offenen Daten mit <code>scripts/seed-showcase.py</code></em>
+  <em>Der Map Builder: Manhattans Gebäudegrundrisse, extrudiert nach Dachhöhe und durch einen datengesteuerten Stil eingefärbt, erstellt aus offenen Daten mit <code>scripts/seed-showcase.py</code></em>
 </p>
 
 ## Dokumentation
@@ -55,4 +55,4 @@ Dieses README ist eine Kurzfassung. Den vollständigen Funktionsüberblick, die 
 
 ## Lizenz
 
-Apache-2.0 — siehe [LICENSE](LICENSE) und [NOTICE](NOTICE).
+Apache-2.0. Siehe [LICENSE](LICENSE) und [NOTICE](NOTICE).

--- a/README.es.md
+++ b/README.es.md
@@ -16,13 +16,13 @@ Sube Shapefiles, GeoTIFFs, GeoPackages o CSVs. GeoLens guarda todo en PostGIS, i
 
 ```bash
 curl -fsSL https://getgeolens.com/install.sh | sh
-# Abre http://localhost:8080 — inicia sesión con las credenciales que elegiste
+# Abre http://localhost:8080 e inicia sesión con las credenciales que elegiste
 ```
 
 <p align="center">
   <img src=".github/assets/geolens-manhattan-3d-hero.jpg" alt="Constructor de mapas de GeoLens: huellas de edificios de Manhattan extruidas en un horizonte 3D, coloreadas según la altura del tejado, con el editor de estilo de capa abierto junto al mapa" width="900" />
   <br />
-  <em>El constructor de mapas — las huellas de edificios de Manhattan extruidas según la altura del tejado y coloreadas mediante un estilo basado en datos, creado a partir de datos abiertos con <code>scripts/seed-showcase.py</code></em>
+  <em>El constructor de mapas: las huellas de edificios de Manhattan extruidas según la altura del tejado y coloreadas mediante un estilo basado en datos, creado a partir de datos abiertos con <code>scripts/seed-showcase.py</code></em>
 </p>
 
 ## Documentación
@@ -55,4 +55,4 @@ Este README es una versión resumida. Encontrarás el resumen completo de funcio
 
 ## Licencia
 
-Apache-2.0 — consulta [LICENSE](LICENSE) y [NOTICE](NOTICE).
+Apache-2.0. Consulta [LICENSE](LICENSE) y [NOTICE](NOTICE).

--- a/README.fr.md
+++ b/README.fr.md
@@ -16,13 +16,13 @@ Importez des Shapefiles, GeoTIFFs, GeoPackages ou CSVs. GeoLens stocke tout dans
 
 ```bash
 curl -fsSL https://getgeolens.com/install.sh | sh
-# Ouvrez http://localhost:8080 — connectez-vous avec les identifiants choisis
+# Ouvrez http://localhost:8080, puis connectez-vous avec les identifiants choisis
 ```
 
 <p align="center">
   <img src=".github/assets/geolens-manhattan-3d-hero.jpg" alt="Constructeur de cartes GeoLens : empreintes des bâtiments de Manhattan extrudées en une skyline 3D, colorées selon la hauteur du toit, avec l'éditeur de style de couche ouvert à côté de la carte" width="900" />
   <br />
-  <em>Le constructeur de cartes — les empreintes des bâtiments de Manhattan extrudées selon la hauteur du toit et colorées par un style fondé sur les données, créé à partir de données ouvertes avec <code>scripts/seed-showcase.py</code></em>
+  <em>Le constructeur de cartes : les empreintes des bâtiments de Manhattan extrudées selon la hauteur du toit et colorées par un style fondé sur les données, créé à partir de données ouvertes avec <code>scripts/seed-showcase.py</code></em>
 </p>
 
 ## Documentation
@@ -55,4 +55,4 @@ Ce README est une version abrégée. Vous trouverez l'aperçu complet des foncti
 
 ## Licence
 
-Apache-2.0 — voir [LICENSE](LICENSE) et [NOTICE](NOTICE).
+Apache-2.0. Voir [LICENSE](LICENSE) et [NOTICE](NOTICE).

--- a/README.md
+++ b/README.md
@@ -2,14 +2,14 @@
 
 [English](README.md) | [Español](README.es.md) | [Français](README.fr.md) | [Deutsch](README.de.md)
 
-**Your team's spatial data — searchable, mappable, and shareable in one place.**
+**Your team's spatial data: searchable, mappable, and shareable in one place.**
 
-GeoLens is an open-source, self-hosted catalog and map builder for GIS and data teams — a single home for spatial data that you run on infrastructure you control, with no telemetry — GeoLens itself phones home to nothing. (Features you opt into can make outbound calls: AI assist to your chosen OpenAI-compatible endpoint, OAuth/OIDC sign-in, SMTP, basemap tiles, remote/S3 data sources, and off-site backups.) Upload Shapefiles, GeoTIFFs, GeoPackages, or CSVs (or register data you already have); GeoLens stores everything in PostGIS, indexes it with pgvector + pg_trgm for semantic and fuzzy search, and serves OGC/STAC APIs that QGIS, ArcGIS, and MapLibre clients connect to natively. Compose, style, and share multi-layer maps right in the browser. Built on FastAPI and React. Deployed with one command.
+GeoLens is an open-source, self-hosted catalog and map builder for GIS and data teams: a single home for spatial data that you run on infrastructure you control, with no telemetry. GeoLens itself phones home to nothing. (Features you opt into can make outbound calls: AI assist to your chosen OpenAI-compatible endpoint, OAuth/OIDC sign-in, SMTP, basemap tiles, remote/S3 data sources, and off-site backups.) Upload Shapefiles, GeoTIFFs, GeoPackages, or CSVs (or register data you already have); GeoLens stores everything in PostGIS, indexes it with pgvector + pg_trgm for semantic and fuzzy search, and serves OGC/STAC APIs that QGIS, ArcGIS, and MapLibre clients connect to natively. Compose, style, and share multi-layer maps right in the browser. Built on FastAPI and React. Deployed with one command.
 
 <p align="center">
   <a href="https://demo.getgeolens.com"><img src="https://img.shields.io/badge/%E2%96%B6%20Try%20the%20live%20demo-demo.getgeolens.com-2563eb?style=for-the-badge" alt="Try the live demo" /></a>
   <br />
-  <sub>No install required — explore the map builder with sample maps. Sign in as <code>guest</code> / <code>GeoLensDemo1!</code></sub>
+  <sub>No install required. Explore the map builder with sample maps. Sign in as <code>guest</code> / <code>GeoLensDemo1!</code></sub>
 </p>
 
 [![CI](https://github.com/geolens-io/geolens/actions/workflows/ci.yml/badge.svg)](https://github.com/geolens-io/geolens/actions/workflows/ci.yml)
@@ -20,26 +20,26 @@ GeoLens is an open-source, self-hosted catalog and map builder for GIS and data 
 
 ```bash
 curl -fsSL https://getgeolens.com/install.sh | sh
-# Open http://localhost:8080 — log in with the credentials you chose
+# Open http://localhost:8080, then log in with the credentials you chose
 ```
 
 <p align="center">
   <img src=".github/assets/geolens-manhattan-3d-hero.jpg" alt="GeoLens map builder with Manhattan building footprints extruded into a 3D skyline, color-graded by roof height, the layer style editor open beside the map" width="900" />
   <br />
-  <em>The map builder — Manhattan's building footprints extruded to roof height and color-graded by a data-driven style, built from open data with <code>scripts/seed-showcase.py</code></em>
+  <em>The map builder: Manhattan's building footprints extruded to roof height and color-graded by a data-driven style, built from open data with <code>scripts/seed-showcase.py</code></em>
 </p>
 
 > [!NOTE]
-> **Early release** — GeoLens is actively developed and maintained, and newly
+> **Early release.** GeoLens is actively developed and maintained, and newly
 > open-sourced. The core has run in production, but the self-hosted distribution is
-> young and some features and APIs may still change — please
+> young and some features and APIs may still change. Please
 > [open an issue](https://github.com/geolens-io/geolens/issues) if you hit a rough edge.
 
 ## Documentation
 
-Full user, admin, and API documentation lives at **[docs.getgeolens.com](https://docs.getgeolens.com)** — the [Reference](#reference) table below links each guide.
+Full user, admin, and API documentation lives at **[docs.getgeolens.com](https://docs.getgeolens.com)**. The [Reference](#reference) table below links each guide.
 
-## Published Artifacts
+## Published artifacts
 
 GeoLens is published through the standard package registries:
 
@@ -60,17 +60,17 @@ The `latest` tag tracks the newest published stable release.
 
 ## Why GeoLens?
 
-Spatial data ends up scattered — shapefiles on shared drives, tables in database schemas, rasters in cloud buckets, metadata in spreadsheets. Finding the right dataset means asking Slack or grepping file servers. Sharing it means exporting, emailing, and hoping the CRS matches.
+Spatial data ends up scattered: shapefiles on shared drives, tables in database schemas, rasters in cloud buckets, metadata in spreadsheets. Finding the right dataset means asking Slack or grepping file servers. Sharing it means exporting, emailing, and hoping the CRS matches.
 
 GeoLens replaces that workflow:
 
-- **One catalog** — upload Shapefiles, GeoPackages, GeoTIFFs, or CSVs and they become searchable, previewable, and exportable in minutes
-- **Works with your tools** — OGC API Features/Records, STAC API 1.0, direct tile URLs for QGIS, ArcGIS, and MapLibre
-- **Semantic + spatial search** — find datasets by meaning, not just keywords, powered by pgvector and pg_trgm full-text search
-- **Built-in map builder** — compose multi-layer maps, style them, and share via public link or embeddable iframe
-- **AI-assisted (optional)** — chat with your maps, auto-generate descriptions, search by natural language. Bring any OpenAI-compatible API key or skip it entirely
+- **One catalog:** upload Shapefiles, GeoPackages, GeoTIFFs, or CSVs and they become searchable, previewable, and exportable in minutes
+- **Works with your tools:** OGC API Features/Records, STAC API 1.0, direct tile URLs for QGIS, ArcGIS, and MapLibre
+- **Semantic and spatial search:** find datasets by meaning rather than exact keywords, powered by pgvector and pg_trgm full-text search
+- **Built-in map builder:** compose multi-layer maps, style them, and share via public link or embeddable iframe
+- **AI-assisted (optional):** chat with your maps, auto-generate descriptions, search by natural language. Bring any OpenAI-compatible API key or skip it entirely
 
-## See It in Action
+## See it in action
 
 The examples below use a JWT bearer token. Mint one against the local stack (the login endpoint accepts an OAuth2 password form, so use `-d` with form fields, not JSON). Substitute your admin username and the password from `.env` (`grep '^GEOLENS_ADMIN_PASSWORD=' .env`):
 
@@ -79,10 +79,10 @@ TOKEN=$(curl -s -X POST http://localhost:8080/api/auth/login/ \
   -d 'username=admin&password=<your-admin-password>' | jq -r '.access_token')
 ```
 
-Search datasets by meaning, not just keywords:
+Search datasets by meaning instead of exact keyword matches:
 
 ```bash
-# Semantic search ranks by meaning — "hydrology" surfaces subwatersheds, lakes,
+# Semantic search ranks by meaning: "hydrology" surfaces subwatersheds, lakes,
 # and river networks whose titles never mention the word
 curl "http://localhost:8080/api/search/datasets/?q=hydrology&limit=3" \
   -H "Authorization: Bearer $TOKEN" | jq '.features[].properties.title'
@@ -92,23 +92,23 @@ Every dataset is also a standard OGC API Features endpoint:
 
 ```bash
 # Grab a public collection id from the catalog. Search anonymously (no token) so
-# the id is one anyone can read — matching the unauthenticated items request below.
+# the id is one anyone can read, matching the unauthenticated items request below.
 CID=$(curl -s "http://localhost:8080/api/search/datasets/?q=countries&limit=1" \
   | jq -r '.features[0].id')
 
-# GeoJSON features with a bbox filter — works in QGIS, ArcGIS, any OGC client
+# GeoJSON features with a bbox filter, works in QGIS, ArcGIS, any OGC client
 curl "http://localhost:8080/api/collections/$CID/items?bbox=-10,35,30,60&limit=5"
 ```
 
-PostGIS and pgvector share one database, so you can rank datasets by meaning *inside* a spatial window in a single query — see the [search guide](https://docs.getgeolens.com/guides/user/search/) for how semantic and spatial search work together.
+PostGIS and pgvector share one database, so you can rank datasets by meaning *inside* a spatial window in a single query. See the [search guide](https://docs.getgeolens.com/guides/user/search/) for how semantic and spatial search work together.
 
 Connect directly from QGIS: **Layer > Add WFS / OGC API Features** and point at `http://localhost:8080/api/`.
 
 ## Features
 
-The highlights above each have a full guide in the [docs](https://docs.getgeolens.com/guides/). What GeoLens reads, writes, and exposes:
+Each example above has a full guide in the [docs](https://docs.getgeolens.com/guides/). What GeoLens reads, writes, and exposes:
 
-### Data Ingestion and Export
+### Data ingestion and export
 
 - **Vector:** Shapefile, GeoPackage, GeoJSON, CSV, XLSX
 - **Raster:** GeoTIFF and Cloud-Optimized GeoTIFF (COG) with automatic conversion
@@ -116,7 +116,7 @@ The highlights above each have a full guide in the [docs](https://docs.getgeolen
 - **Export:** GeoJSON, Shapefile, GeoPackage, CSV, with CRS reprojection
 - Provenance tracking and metadata editing
 
-### Standards and Interop
+### Standards and interop
 
 - OGC API - Features and OGC API - Records; STAC API 1.0 catalog endpoint
 - Direct tile URLs and per-user API keys for QGIS, ArcGIS, MapLibre, and any OGC client
@@ -137,36 +137,36 @@ The highlights above each have a full guide in the [docs](https://docs.getgeolen
 ## Screenshots
 
 <p align="center">
-  <img src=".github/assets/geolens-search.png" alt="GeoLens catalog search for 'hydrology' returning ranked hydrology datasets — subwatersheds, lakes, and river networks — with type and spatial filters" width="900" />
+  <img src=".github/assets/geolens-search.png" alt="GeoLens catalog search for 'hydrology' returning ranked hydrology datasets (subwatersheds, lakes, and river networks) with type and spatial filters" width="900" />
   <br />
-  <em><strong>Find</strong> — search by meaning: a query for "hydrology" ranks subwatersheds, lakes, and river networks, with type, spatial, and temporal filters</em>
+  <em><strong>Find:</strong> search by meaning. A query for "hydrology" ranks subwatersheds, lakes, and river networks, with type, spatial, and temporal filters</em>
 </p>
 
 <p align="center">
   <img src=".github/assets/geolens-dataset.png" alt="GeoLens dataset detail for Natural Earth river centerlines: a global map preview above a typed attribute table with per-column filters" width="900" />
   <br />
-  <em><strong>Inspect</strong> — every dataset gets a map preview, schema stats, and a typed, filterable attribute table (here: 1,473 river centerlines, 38 columns)</em>
+  <em><strong>Inspect:</strong> every dataset gets a map preview, schema stats, and a typed, filterable attribute table (here: 1,473 river centerlines, 38 columns)</em>
 </p>
 
 <p align="center">
   <img src=".github/assets/geolens-matterhorn-terrain.jpg" alt="GeoLens map builder rendering the Matterhorn as a 3D terrain mesh from swissALTI3D lidar, with labeled peaks, climbing routes, the drag-orderable layer stack, and a legend" width="900" />
   <br />
-  <em><strong>Build</strong> — compose multi-layer maps in the browser with a drag-orderable layer stack and per-layer editors (here: the Matterhorn as a 3D terrain mesh from swissALTI3D lidar)</em>
+  <em><strong>Build:</strong> compose multi-layer maps in the browser with a drag-orderable layer stack and per-layer editors (here: the Matterhorn as a 3D terrain mesh from swissALTI3D lidar)</em>
 </p>
 
 <p align="center">
   <img src=".github/assets/geolens-ai-labels.png" alt="GeoLens Ask AI panel adding county-name labels to a New York median-income choropleth from the natural-language request 'Add area labels'" width="900" />
   <br />
-  <em><strong>Ask AI</strong> — edit maps in natural language: "add area labels" puts county names on a New York income choropleth (optional — bring your own OpenAI-compatible key)</em>
+  <em><strong>Ask AI:</strong> edit maps in natural language. "Add area labels" puts county names on a New York income choropleth (optional: bring your own OpenAI-compatible key)</em>
 </p>
 
-## Quick Start
+## Quick start
 
 **Prerequisites:** Docker Engine 24+ and Docker Compose v2. The bundled stack
 ships PostgreSQL 17. If you point GeoLens at an externally managed database, it
 must be **PostgreSQL 13+** (for `gen_random_uuid()`) with **pgvector 0.5+** (for
 HNSW semantic-search indexes), plus PostGIS, pg_trgm, and unaccent. The API and
-worker run in containers (Python 3.13 bundled — no host Python needed). The
+worker run in containers (Python 3.13 bundled, no host Python needed). The
 optional CLI runs on your host and requires Python 3.11+; the Python SDK and
 seed scripts require Python 3.10+.
 
@@ -176,7 +176,7 @@ The one-line install pulls the prebuilt, version-pinned images and starts the st
 curl -fsSL https://getgeolens.com/install.sh | sh
 ```
 
-Prefer to read the script or build from source first? Clone the repo and run the same installer — it builds the images locally instead of pulling them:
+Prefer to read the script or build from source first? Clone the repo and run the same installer. It builds the images locally instead of pulling them:
 
 ```bash
 git clone https://github.com/geolens-io/geolens.git
@@ -187,9 +187,9 @@ bash scripts/install.sh
 Either way, `scripts/install.sh` copies `.env.example` to `.env`, generates a JWT signing
 secret, sets up admin credentials, and runs `docker compose up -d`. The admin **username**
 defaults to `admin`; the admin **password** is auto-generated as a strong random value
-(written to `.env`, never printed to your terminal) unless you supply your own — it is never `admin` / `admin`.
+(written to `.env`, never printed to your terminal) unless you supply your own. It is never `admin` / `admin`.
 For unattended installs, set `GEOLENS_ADMIN_USERNAME` and `GEOLENS_ADMIN_PASSWORD` in the
-environment before running and the prompts are skipped. Re-running the script is idempotent —
+environment before running and the prompts are skipped. Re-running the script is idempotent:
 existing values in `.env` are preserved.
 
 Wait about 60 seconds for services to start, then open [http://localhost:8080](http://localhost:8080).
@@ -204,7 +204,7 @@ docker compose ps
 
 First-run notes: the one-line install **pulls** prebuilt images and is up in about
 a minute (only the small PostGIS + pgvector database layer builds locally). Cloning
-and running `bash scripts/install.sh` instead **builds** every image from source —
+and running `bash scripts/install.sh` instead **builds** every image from source:
 5-10 minutes on the first run (GDAL + Postgres extensions + the frontend bundle);
 subsequent starts settle in ~60 seconds either way. If ports 5434/8001/8080 are
 already taken, change `DB_PORT`, `API_PORT`,
@@ -233,12 +233,12 @@ A passing check prints `install.sh: OK`.
 ### Upgrading
 
 To upgrade a prebuilt install, run `./scripts/upgrade.sh` from your install
-directory — it backs up the database, pulls the new images, runs migrations
+directory. It backs up the database, pulls the new images, runs migrations
 behind a health gate, and prints a rollback recipe if anything fails. See
 [`UPGRADING.md`](UPGRADING.md) for the prebuilt and source-build flows plus
 rollback, or the online [Upgrade Guide](https://docs.getgeolens.com/guides/quickstart/upgrade/).
 
-### Add Your First Dataset
+### Add your first dataset
 
 The repo ships a small `city-parks.geojson`. Upload and publish it in one command with the **GeoLens CLI**:
 
@@ -248,7 +248,7 @@ geolens login http://localhost:8080/api              # use your admin username +
 geolens publish examples/manifests/first-catalog/city-parks.geojson --name "City Parks"
 ```
 
-`geolens publish` runs the upload → preview → commit ingest flow and prints the new dataset's URL — one command takes a local file to a published, mappable dataset.
+`geolens publish` runs the upload → preview → commit ingest flow and prints the new dataset's URL. One command takes a local file to a published, mappable dataset.
 
 For repeatable, multi-dataset catalogs, describe your sources in a **manifest** (`geolens.yaml`) and apply it with `geolens apply`. Manifest sources are referenced by HTTP(S) URL, S3 URI, or a path already staged on the server; the examples in [`examples/manifests/`](examples/manifests/) are templates to adapt. Scaffold a fresh one with `geolens init` and edit it for your sources:
 
@@ -260,9 +260,9 @@ geolens apply geolens.yaml         # validates + applies via /ingest/manifest/ap
 
 See the [CLI guide](https://docs.getgeolens.com/guides/cli/) for the full manifest schema, source kinds, and CI integration patterns.
 
-### Seed Data
+### Seed data
 
-`scripts/seed-showcase.py` builds three showcase maps from public open data — a Manhattan 3D skyline (the hero above), a New York income choropleth, and an optional Matterhorn 3D-terrain hero:
+`scripts/seed-showcase.py` builds three demo maps from public open data: a Manhattan 3D skyline (the hero above), a New York income choropleth, and an optional Matterhorn 3D-terrain hero:
 
 ```bash
 pip install httpx
@@ -279,10 +279,10 @@ and Titiler serves raster tiles from object storage.
 
 ```mermaid
 flowchart TB
-    B["Browser — React + MapLibre app"]
+    B["Browser: React + MapLibre app"]
     OGC["QGIS · ArcGIS · OGC/STAC clients"]
 
-    NG["Nginx — reverse proxy<br/>serves the React build, routes /api and tiles"]
+    NG["Nginx reverse proxy<br/>serves the React build, routes /api and tiles"]
 
     subgraph Application
       API["FastAPI<br/>catalog · semantic search · OGC/STAC · vector tiles"]
@@ -323,7 +323,7 @@ flowchart TB
 
 All configuration is managed through environment variables in `.env`. See the [Configuration Reference](https://docs.getgeolens.com/guides/quickstart/configuration/) for the full list of options with defaults and descriptions.
 
-### Connection Pool Budget
+### Connection pool budget
 
 GeoLens ships tuned for a **single PostgreSQL** instance: the API, worker, and admin
 pools fit within **30 of 30 max_connections** out of the box (Postgres
@@ -334,8 +334,8 @@ for the per-process budget and how to raise the ceiling.
 
 ### Backups
 
-Automated, scheduled backups run **by default** — no `--profile backup` flag is
-required. The backup service starts alongside `api`, `worker`, and `db` on every
+Automated, scheduled backups run **by default**. You do not need a `--profile backup` flag.
+The backup service starts alongside `api`, `worker`, and `db` on every
 `docker compose up` and runs `pg_dump` on a daily/weekly schedule alongside an
 archive of the object-storage staging volume, so a restore reproduces a working
 instance (DB + uploaded files).
@@ -343,7 +343,7 @@ instance (DB + uploaded files).
 **Off-site (S3) upload** is additionally gated on `BACKUP_S3_ENABLED=true`. The
 built-in uploader signs requests with **AWS Signature V4** (awscli), compatible
 with Cloudflare R2, modern AWS S3, and MinIO. A failed upload surfaces a visible
-`ERROR` in container logs — not a swallowed warning — so silent offsite backup
+`ERROR` in container logs (not a swallowed warning), so silent offsite backup
 loss is detectable immediately.
 
 For day-2 operations, restore procedures, and incident response, see
@@ -361,24 +361,24 @@ For day-2 operations, restore procedures, and incident response, see
 | [Cloud Deployment](https://docs.getgeolens.com/guides/quickstart/cloud-deployment/) | AWS, GCP, and DigitalOcean deployment guides |
 | [CLI & Manifests](https://docs.getgeolens.com/guides/cli/) | Publish files and manage catalogs with the `geolens` CLI |
 | [API Reference](https://docs.getgeolens.com/guides/api/) | Auto-generated reference at docs.getgeolens.com; interactive Swagger UI at `/api/docs` when running |
-| [Manifest examples](examples/manifests/) | Template `geolens.yaml` manifests to adapt — public-cog (remote COG), url-source, s3-source, publication-states |
+| [Manifest examples](examples/manifests/) | Template `geolens.yaml` manifests to adapt: public-cog (remote COG), url-source, s3-source, publication-states |
 
 ## Community
 
-- [GitHub Discussions](https://github.com/geolens-io/geolens/discussions) — questions, ideas, show and tell
-- [Contributing Guide](.github/CONTRIBUTING.md) — development setup, code style, and PR guidelines
+- [GitHub Discussions](https://github.com/geolens-io/geolens/discussions): questions, ideas, show and tell
+- [Contributing Guide](.github/CONTRIBUTING.md): development setup, code style, and PR guidelines
 
-## Known Limitations
+## Known limitations
 
-- Single PostgreSQL instance — no built-in high availability or clustering.
-- Multi-tenant cloud mode is not included — GeoLens is single-organization, self-hosted.
+- Single PostgreSQL instance, with no built-in high availability or clustering.
+- Multi-tenant cloud mode is not included. GeoLens is single-organization and self-hosted.
 - Terrain rendering assumes DEM units are in meters; datasets in other vertical units may render exaggerated.
 - The self-hosted distribution is young and some features and APIs may still change (see the Early release note above).
 
 ## License
 
-GeoLens is licensed under the [Apache License 2.0](LICENSE). The GeoLens name, logo, and brand assets are not covered by this license — see [TRADEMARKS.md](TRADEMARKS.md). Third-party sample-data attribution is in [THIRD_PARTY_DATA.md](THIRD_PARTY_DATA.md).
+GeoLens is licensed under the [Apache License 2.0](LICENSE). The GeoLens name, logo, and brand assets are not covered by this license. See [TRADEMARKS.md](TRADEMARKS.md). Third-party sample-data attribution is in [THIRD_PARTY_DATA.md](THIRD_PARTY_DATA.md).
 
-GeoLens is **open core**: the full platform in this repository is Apache-2.0 and free to self-host for one organization with many users. A separately-licensed, commercial Enterprise overlay adds organization-scale identity, governance, compliance, and branding — it is never required to run GeoLens. See [EDITIONS.md](EDITIONS.md) for the exact free-vs-commercial boundary and the commitments we hold ourselves to.
+GeoLens is **open core**: the full platform in this repository is Apache-2.0 and free to self-host for one organization with many users. A separately-licensed, commercial Enterprise overlay adds organization-scale identity, governance, compliance, and branding. It is never required to run GeoLens. See [EDITIONS.md](EDITIONS.md) for the exact free-vs-commercial boundary and the commitments we hold ourselves to.
 
 Project policies: [editions](EDITIONS.md) · [governance](GOVERNANCE.md) · [maintainers](MAINTAINERS.md) · [contributing](.github/CONTRIBUTING.md) · [security](.github/SECURITY.md) · [release process](RELEASE.md) · [egress &amp; air-gap](EGRESS.md).

--- a/backend/alembic/README.md
+++ b/backend/alembic/README.md
@@ -16,7 +16,7 @@ behavior.
 `env.py` performs a `connection.rollback()` immediately after the raw `COMMIT`
 that persists its preamble DDL (schema + version table). That rollback clears
 SQLAlchemy's empty autobegun transaction so that `context.begin_transaction()`
-owns a real, committing transaction — **without it, `op.get_context().autocommit_block()`
+owns a real, committing transaction. **Without it, `op.get_context().autocommit_block()`
 raises `AssertionError`** (`context.begin_transaction()` would return a
 `nullcontext` and never set `ctx._transaction`). See finding CV-1.
 
@@ -45,7 +45,7 @@ tables a plain `CREATE INDEX` is fine.
 
 A bare `ALTER TABLE ... ADD CONSTRAINT ... CHECK (...)` takes `ACCESS EXCLUSIVE`
 and validates **every row** under that lock. On a large table, split it so the
-row-scan phase runs under the weaker `SHARE UPDATE EXCLUSIVE` lock — and run the
+row-scan phase runs under the weaker `SHARE UPDATE EXCLUSIVE` lock, and run the
 `VALIDATE` in its **own** transaction (via `autocommit_block`) so the lock is
 actually released between the two steps:
 
@@ -59,8 +59,8 @@ def upgrade() -> None:
 ```
 
 Important: inside `env.py`'s single transaction (i.e. **without** an
-`autocommit_block`), `NOT VALID` + `VALIDATE` gives **no** concurrency benefit —
-the `ACCESS EXCLUSIVE` from `ADD ... NOT VALID` is held until commit, so the
+`autocommit_block`), `NOT VALID` + `VALIDATE` gives **no** concurrency benefit.
+The `ACCESS EXCLUSIVE` from `ADD ... NOT VALID` is held until commit, so the
 split only helps when `VALIDATE` runs in a separate (autocommit) transaction.
 Migration `0018` (`chk_ingest_jobs_status`) is deliberately left as a single
 `ADD CONSTRAINT`: `ingest_jobs` is small/transient, so its full-scan validation
@@ -75,7 +75,7 @@ declared in the model's `__table_args__`. When you add an expression index in a
 migration (e.g. a trigram GIN or a functional `to_tsvector` index), **also**
 declare it on the model.
 
-The `text()` literal must byte-match the expression SQLAlchemy *reflects* — NOT
+The `text()` literal must byte-match the expression SQLAlchemy *reflects*, NOT
 the raw `pg_get_indexdef` output (they differ; e.g. the reflected form of the
 `to_tsvector` index in `Record.__table_args__` has one fewer outer paren than
 `pg_get_indexdef`). To regenerate the literal after a change: run `alembic check`

--- a/backend/app/standards/dcat/README.md
+++ b/backend/app/standards/dcat/README.md
@@ -4,10 +4,10 @@ GeoLens exposes a **W3C DCAT 3** JSON-LD serialization alongside the DCAT-US 3.0
 (`app.standards.dcat_us`) and GeoDCAT-AP 2.0.0 (`app.standards.geodcat_ap`)
 profiles. This is the baseline, vendor-neutral catalog serialization.
 
-## Version Source
+## Version source
 
 - Recommendation: <https://www.w3.org/TR/vocab-dcat-3/>
-- Pinned version: `3.0` (W3C Recommendation, 2024-08-22) — see
+- Pinned version: `3.0` (W3C Recommendation, 2024-08-22). See
   `schemas.py` (`DCAT3_SCHEMA_VERSION`, `DCAT3_SCHEMA_COMMIT`), pinned the way
   DCAT-US pins `DCAT_US_SCHEMA_VERSION` and GeoDCAT-AP pins
   `GEODCAT_AP_SCHEMA_VERSION`.
@@ -30,18 +30,18 @@ DCAT-US JSON Schema validator and the GeoDCAT-AP structural validator.
 | `GET /datasets/dcat/validation/` | Structural validation report for the visible catalog feed |
 | `GET /datasets/{dataset_id}/dcat/validation/` | Structural validation report for one accessible dataset |
 
-## Validation Behavior
+## Validation behavior
 
 Validation is a metadata-quality signal, not an authorization bypass. Catalog
 validation sees only datasets visible to the caller; per-dataset validation runs
 the same access checks as per-dataset export. Reports include `valid`,
 `error_count`, and `errors[]` with `path`, `schema_path`, `validator`, and
-`message` — identical in shape to the DCAT-US and GeoDCAT-AP validators.
+`message`, identical in shape to the DCAT-US and GeoDCAT-AP validators.
 
-## Conformance Posture: Filter the Feed
+## Conformance posture: filter the feed
 
 The DCAT 3 **catalog feed** (`GET /datasets/dcat/`) emits **only** records that
-pass DCAT 3 structural validation — records missing a mandatory property (title
+pass DCAT 3 structural validation. Records missing a mandatory property (title
 or description) are silently skipped so the feed stays conformant with zero
 onboarding friction. The **per-dataset** endpoint
 (`GET /datasets/{id}/dcat/`) is **not** filtered and always serializes the

--- a/backend/app/standards/dcat_us/README.md
+++ b/backend/app/standards/dcat_us/README.md
@@ -2,7 +2,7 @@
 
 GeoLens keeps DCAT-US Schema v3.0 support separate from the existing W3C DCAT 3 serializer.
 
-## Schema Source
+## Schema source
 
 - Repository: <https://github.com/GSA/dcat-us>
 - Vendored commit: `98408dc000f0b71131a03920e2dec6247a84abff`
@@ -11,7 +11,7 @@ GeoLens keeps DCAT-US Schema v3.0 support separate from the existing W3C DCAT 3 
 
 The schema definitions are vendored so validation is deterministic and does not depend on network access at runtime.
 
-## Mapping Contract
+## Mapping contract
 
 | DCAT-US class | GeoLens source |
 |---------------|----------------|
@@ -25,7 +25,7 @@ The schema definitions are vendored so validation is deterministic and does not 
 | Location | `Record.spatial_extent` serialized as WKT bounding polygon |
 | Concept | `Record.theme_category` and keyword values where appropriate |
 
-## Known Gaps
+## Known gaps
 
 - DatasetSeries is not first-class in the current catalog model. Use future requirement `DCAT-FU-01` before adding authoring or persistence.
 - Structured `AccessRestriction`, `UseRestriction`, and `CUIRestriction` are not first-class in the current metadata model. Current free-text access/use constraints can be surfaced, but structured authoring is future requirement `DCAT-FU-02`.
@@ -45,7 +45,7 @@ The existing W3C DCAT 3 routes remain unchanged:
 - `GET /datasets/dcat/`
 - `GET /datasets/{dataset_id}/dcat/`
 
-## Validation Behavior
+## Validation behavior
 
 Validation uses the vendored JSON Schema 2020-12 definitions with local `$ref` resolution. Reports include:
 
@@ -58,20 +58,20 @@ Validation uses the vendored JSON Schema 2020-12 definitions with local `$ref` r
 
 Validation is a metadata-quality signal, not an authorization bypass. Catalog validation sees only datasets visible to the caller, and per-dataset validation runs the same access checks as per-dataset export.
 
-## Conformance Posture: Filter the Feed
+## Conformance posture: filter the feed
 
 GeoLens keeps its catalog **feeds** conformant by **filtering**, not by blocking authoring (issue #203).
 
-- **Catalog feeds** (`GET /datasets/dcat-us/3.0/`, and the equivalent W3C DCAT 3 `/datasets/dcat/` and GeoDCAT-AP `/datasets/geodcat-ap/` feeds) emit **only** records that pass that profile's validator. A record missing a property mandatory for the profile (for DCAT-US 3.0, most commonly a usable `contactPoint`) is **silently skipped** from the feed. The feed as a whole is therefore always conformant, with **zero onboarding friction** — incomplete drafts simply do not appear until their metadata is filled in.
+- **Catalog feeds** (`GET /datasets/dcat-us/3.0/`, and the equivalent W3C DCAT 3 `/datasets/dcat/` and GeoDCAT-AP `/datasets/geodcat-ap/` feeds) emit **only** records that pass that profile's validator. A record missing a property mandatory for the profile (for DCAT-US 3.0, most commonly a usable `contactPoint`) is **silently skipped** from the feed. The feed as a whole is therefore always conformant, with **zero onboarding friction**. Incomplete drafts simply do not appear until their metadata is filled in.
 - **Per-dataset endpoints** (`GET /datasets/{id}/dcat-us/3.0/`, and the DCAT 3 / GeoDCAT-AP equivalents) are **not** filtered: they always serialize the requested record as-is so operators can inspect and fix an incomplete record. The matching `.../validation/` endpoints report exactly which mandatory properties are missing.
 
 This is implemented in the `catalog_to_*` serializers (`app.standards.dcat_us.service.catalog_to_dcat_us3`, `app.standards.dcat.service.catalog_to_dcat`, `app.standards.geodcat_ap.service.catalog_to_geodcat_ap`): each candidate record is serialized and then validated with that profile's validator, and only valid entries are included.
 
 ### Optional stricter lever: `REQUIRE_METADATA_FOR_PUBLISH`
 
-Filtering keeps the feeds clean without forcing completeness on every author. Operators who instead want to **block publish** of incomplete records (so an incomplete record can never reach a feed in the first place) can enable the optional `REQUIRE_METADATA_FOR_PUBLISH` persistent-config lever (default **False**). The two mechanisms are complementary: filtering guarantees feed conformance regardless of the lever, while the lever additionally enforces completeness at authoring time.
+Filtering keeps the feeds clean without forcing completeness on every author. Operators who instead want to **block publish** of incomplete records (so an incomplete record can never reach a feed in the first place) can enable the optional `REQUIRE_METADATA_FOR_PUBLISH` persistent-config lever (default **False**). The two mechanisms are complementary: filtering guarantees feed conformance regardless of the lever, while the lever also enforces completeness at authoring time.
 
-## Migration Notes
+## Migration notes
 
 DCAT-US v3.0 differs from DCAT-US v1.1 in areas that matter for GeoLens operators:
 

--- a/backend/app/standards/geodcat_ap/README.md
+++ b/backend/app/standards/geodcat_ap/README.md
@@ -3,13 +3,13 @@
 GeoLens exposes a **GeoDCAT-AP** serialization alongside the W3C DCAT 3
 (`app.standards.dcat`) and DCAT-US 3.0 (`app.standards.dcat_us`) profiles.
 
-GeoDCAT-AP is the geospatial profile of DCAT-AP — the European Union /
+GeoDCAT-AP is the geospatial profile of DCAT-AP, the European Union /
 INSPIRE Application Profile of DCAT. It extends DCAT with the geospatial and
 ISO 19115 / 19139 metadata that GeoLens already stores (lineage, constraints,
 responsible-party roles, maintenance frequency, reference system, spatial
 resolution, and spatial/temporal extents).
 
-## Version Source
+## Version source
 
 - Specification: <https://semiceu.github.io/GeoDCAT-AP/releases/2.0.0/>
 - Repository: <https://github.com/SEMICeu/GeoDCAT-AP>
@@ -24,7 +24,7 @@ required-field checks consistent with the mandatory-class cardinalities of the
 specification (see `validation.py`), in the same spirit and report shape as the
 DCAT-US validator.
 
-## Mapping Contract (ISO 19115 → GeoDCAT-AP)
+## Mapping contract (ISO 19115 → GeoDCAT-AP)
 
 | GeoLens / ISO source | GeoDCAT-AP term |
 |----------------------|-----------------|
@@ -80,19 +80,19 @@ organization is skipped entirely, matching the DCAT-US behavior.
 The W3C DCAT 3 (`/datasets/dcat/`) and DCAT-US 3.0 (`/datasets/dcat-us/3.0/`)
 routes are unchanged.
 
-## Validation Behavior
+## Validation behavior
 
 Validation is a metadata-quality signal, not an authorization bypass. Catalog
 validation sees only datasets visible to the caller; per-dataset validation
 runs the same access checks as per-dataset export. Reports include `valid`,
 `error_count`, and `errors[]` with `path`, `schema_path`, `validator`, and
-`message` — identical in shape to the DCAT-US validator.
+`message`, identical in shape to the DCAT-US validator.
 
-## Conformance Posture: Filter the Feed
+## Conformance posture: filter the feed
 
 Like the W3C DCAT 3 and DCAT-US 3.0 profiles, the GeoDCAT-AP **catalog feed**
 (`GET /datasets/geodcat-ap/`) emits **only** records that pass GeoDCAT-AP
-structural validation — records missing a mandatory property (title or
+structural validation. Records missing a mandatory property (title or
 description) are silently skipped so the feed stays conformant with zero
 onboarding friction. The **per-dataset** endpoint
 (`GET /datasets/{id}/geodcat-ap/`) is **not** filtered and always serializes
@@ -101,7 +101,7 @@ the requested record as-is. See
 for the full posture, including the optional stricter
 `REQUIRE_METADATA_FOR_PUBLISH` publish-time lever.
 
-## Known Gaps
+## Known gaps
 
 - Structured ISO constraint codes (`MD_RestrictionCode`, INSPIRE limitations)
   are surfaced as free-text `dcterms:RightsStatement` labels rather than

--- a/backend/scripts/README.md
+++ b/backend/scripts/README.md
@@ -9,9 +9,9 @@ meant to be run from `backend/` as the working directory.
 
 Runs `alembic upgrade head` against a freshly-initialized, throwaway
 PostGIS container. This is the semantic complement to the syntactic
-`down_revision` linkage check that v1015's close-gate ran — confirms
-the full migration chain (0001 → latest) actually applies without error
-on a clean DB, not just that the revision graph is well-formed.
+`down_revision` linkage check that v1015's close-gate ran. It confirms
+the full migration chain from 0001 to latest actually applies without error
+on a clean DB and that the revision graph is well-formed.
 
 The script builds the project's custom `./db` image (PostGIS + pgvector)
 and mounts `scripts/init-db.sh` into `/docker-entrypoint-initdb.d/` so
@@ -26,7 +26,7 @@ extensions exist and refuses to run without them).
 - `uv` installed (alembic runs through `uv run --no-dev`).
 - No other process listening on port `54399` (override with
   `ALEMBIC_TEST_DB_PORT` if the default collides). The script refuses
-  to start if the port is busy — a stale container or local postgres
+  to start if the port is busy. A stale container or local postgres
   on that port would silently mask migration failures.
 
 ### Usage
@@ -50,7 +50,7 @@ including Ctrl-C and unexpected signals (via `trap cleanup EXIT INT TERM`).
 
 - At every milestone close-gate (Phase XXXX-CLOSE) after the last
   migration lands and before the version tag is cut.
-- When adding a new migration to v1016-and-later phases — local
+- When adding a new migration to v1016-and-later phases: local
   smoke before pushing the PR.
 - Suspected migration-chain rot (e.g. an out-of-order `down_revision`
   that the linkage check missed because both sides referenced the same
@@ -61,13 +61,13 @@ including Ctrl-C and unexpected signals (via `trap cleanup EXIT INT TERM`).
 - Tests the schema-only path. Data migrations that depend on existing
   rows (rare in this repo; the convention is "expand/contract DDL with
   no row-mutation") would need a fixture step before `upgrade head`.
-- Does NOT run the application after migration — only confirms alembic
+- Does NOT run the application after migration. It only confirms alembic
   exits 0. Application boot is exercised by the existing pytest
   `test_db_session` fixture and by `docker compose up`.
 - The `POSTGIS_IMAGE_TAG` constant in the script (currently `17-3.5`)
   documents the base image the test container is layered on top of.
   The script builds the local `./db` image, so the resulting test
-  image always tracks `db/Dockerfile`'s `FROM` line — but if you bump
+  image always tracks `db/Dockerfile`'s `FROM` line, but if you bump
   `db/Dockerfile`, also bump the `POSTGIS_IMAGE_TAG` comment in the
   script to keep the documentation honest.
 - First run takes ~2-3 minutes to compile pgvector inside the image

--- a/backend/tests/fixtures/ingest/README.md
+++ b/backend/tests/fixtures/ingest/README.md
@@ -1,4 +1,4 @@
-# Ingest Test Fixtures
+# Ingest test fixtures
 
 Small, self-contained files used by `test_ingest_column_preservation.py` to
 exercise the column-preservation guarantees in the ingest pipeline.
@@ -8,8 +8,8 @@ exercise the column-preservation guarantees in the ingest pipeline.
 | File | Purpose |
 |------|---------|
 | `basic_attrs.geojson` | 3 Point features with mixed types (string, int, float, bool, date). Baseline round-trip fixture. |
-| `reserved_names.geojson` | 2 Point features with source properties named `gid`, `geom`, `geom_4326`, `fid` — exercises the reserved-name auto-rename helper. |
-| `unicode_attrs.geojson` | 2 Point features with non-ASCII property names (`Nom`, `Größe`, `Área`) — exercises SQL-quoted identifier handling in `get_sample_values`. |
+| `reserved_names.geojson` | 2 Point features with source properties named `gid`, `geom`, `geom_4326`, `fid`. Exercises the reserved-name auto-rename helper. |
+| `unicode_attrs.geojson` | 2 Point features with non-ASCII property names (`Nom`, `Größe`, `Área`). Exercises SQL-quoted identifier handling in `get_sample_values`. |
 | `mixed_types.csv` | 3 rows with bool/date/int/float columns plus `lat`/`lon` (consumed as geometry by ogr2ogr's X/Y_POSSIBLE_NAMES). |
 | `dbf_collision.zip` | Zipped shapefile whose DBF has two field names that share the same first-10-char prefix (`population_2020`, `population_2021` → both truncate to `population`). |
 

--- a/backend/tests/test_phase_275_demo_cluster.py
+++ b/backend/tests/test_phase_275_demo_cluster.py
@@ -5,8 +5,8 @@ Static regression locks in:
   project owns getgeolens.com only per memory project_domain_ownership.md).
 - README.md §'See It in Action' has the JWT-mint one-liner so a first-time
   reader can actually execute the curl examples (M-76).
-- README.md em-dash conversion landed on the six body-prose lines flagged
-  by L-16 (line 90 + the five Why GeoLens bullets at 94-98).
+- README.md keeps the six body-prose lines flagged by L-16 in the
+  humanized separator style (line 90 + the five Why GeoLens bullets at 94-98).
 
 Pure static analysis — no docker daemon, database, or HTTP fixture needed.
 """
@@ -80,23 +80,23 @@ def test_readme_has_jwt_mint_oneliner() -> None:
     )
 
 
-def test_readme_em_dash_consistency_in_six_known_lines() -> None:
-    """API-14 / L-16: the six known '--' separator lines now use '—'.
+def test_readme_humanized_separator_style_in_six_known_lines() -> None:
+    """API-14 / L-16: the six known separator lines keep the humanized style.
 
-    This test does NOT enforce em-dash everywhere — only the six lines flagged
-    in the plan are checked. CLI flags (--username, --api-key) remain hyphens.
+    This test does NOT enforce punctuation everywhere, only the six lines
+    flagged in the plan. CLI flags (--username, --api-key) remain hyphens.
     """
     body = _read("README.md")
-    expected_em_dash_signals = [
-        "Spatial data ends up scattered — ",
-        "One catalog** — ",
-        "Works with your tools** — ",
-        "Semantic + spatial search** — ",
-        "Built-in map builder** — ",
-        "AI-assisted (optional)** — ",
+    expected_humanized_signals = [
+        "Spatial data ends up scattered: ",
+        "One catalog:** ",
+        "Works with your tools:** ",
+        "Semantic and spatial search:** ",
+        "Built-in map builder:** ",
+        "AI-assisted (optional):** ",
     ]
-    for signal in expected_em_dash_signals:
-        assert signal in body, f"README.md missing em-dash conversion for: {signal}"
+    for signal in expected_humanized_signals:
+        assert signal in body, f"README.md missing humanized separator for: {signal}"
 
 
 def test_cli_flags_preserved_in_readme() -> None:

--- a/cli/README.md
+++ b/cli/README.md
@@ -2,7 +2,7 @@
 
 Apache-2.0 command-line interface for the [GeoLens](https://github.com/geolens-io/geolens) API.
 
-Login, scan local directories of spatial data, apply manifest-driven catalogs, publish vector or raster files, and export STAC metadata against any GeoLens instance — community or enterprise.
+Login, scan local directories of spatial data, apply manifest-driven catalogs, publish vector or raster files, and export STAC metadata against any GeoLens instance, community or enterprise.
 
 See [docs.getgeolens.com](https://docs.getgeolens.com/) for the full command reference.
 
@@ -22,4 +22,4 @@ geolens export stac <dataset-id> -o cities.stac.json
 
 For a one-command quickstart, run `geolens publish examples/manifests/first-catalog/city-parks.geojson` against a running stack. See the full walkthrough at [docs.getgeolens.com](https://docs.getgeolens.com/).
 
-The CLI consumes the [`geolens`](https://pypi.org/project/geolens/) Python SDK package. Manifest apply posts to the generated `POST /ingest/manifest/apply` contract through the SDK-owned client transport; there is no hand-rolled HTTP client.
+The CLI consumes the [`geolens`](https://pypi.org/project/geolens/) Python SDK package. Manifest apply posts to the generated `POST /ingest/manifest/apply` contract through the SDK-owned client transport rather than a hand-rolled HTTP client.

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -19,9 +19,9 @@ npm run e2e:smoke        # the smoke subset (core + builder + fixtures)
 
 ## Configs
 
-- `playwright.config.ts` — the default config (Chromium), used by every
+- `playwright.config.ts`: the default config (Chromium), used by every
   `e2e:smoke:*` script except builder-hardening.
-- `playwright.builder-hardening.config.ts` — a separate config that runs only
+- `playwright.builder-hardening.config.ts`: a separate config that runs only
   `builder-hardening.spec.ts` across Chromium, Firefox, and WebKit.
 
 ## Smoke groups

--- a/examples/manifests/first-catalog/README.md
+++ b/examples/manifests/first-catalog/README.md
@@ -1,4 +1,4 @@
-# First Catalog — sample data
+# First catalog: sample data
 
 Sample dataset used by the README quickstart.
 
@@ -17,8 +17,8 @@ geolens publish city-parks.geojson --name "City Parks"
 `geolens.yaml` shows the shape of a catalog manifest for use with `geolens apply`.
 
 > **Note:** `geolens apply` submits a manifest to the API but does **not** upload local
-> files — its `staging/city-parks.geojson` source resolves against the server's staging
+> files. Its `staging/city-parks.geojson` source resolves against the server's staging
 > area, so applying this manifest against a fresh stack queues an ingest job that fails
 > (nothing was staged). For local files use `geolens publish` (above). For `geolens apply`,
-> point sources at a reachable HTTP(S)/S3 URI — see the sibling [`url-source.yaml`](../url-source.yaml)
-> and [`s3-source.yaml`](../s3-source.yaml) — or pre-stage the file on the server.
+> point sources at a reachable HTTP(S)/S3 URI (see the sibling [`url-source.yaml`](../url-source.yaml)
+> and [`s3-source.yaml`](../s3-source.yaml)) or pre-stage the file on the server.

--- a/examples/manifests/public-cog/README.md
+++ b/examples/manifests/public-cog/README.md
@@ -1,4 +1,4 @@
-# Public COG Manifest Example
+# Public COG manifest example
 
 This example registers a public Sentinel-2 Cloud-Optimized GeoTIFF without requiring local sample data.
 

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -4,7 +4,7 @@ The GeoLens frontend is a React 19 + Vite + TypeScript application. It powers th
 
 For installation, environment configuration, and running the full stack with Docker Compose, see the repository root [README.md](../README.md). For contributing guidelines and development setup, see [.github/CONTRIBUTING.md](../.github/CONTRIBUTING.md).
 
-## Local Development
+## Local development
 
 Once the stack is running (`docker compose up -d` from the repo root), Vite dev mode is hot-reloaded inside the `frontend` container at http://localhost:8080. To run scripts directly on the host:
 
@@ -19,12 +19,12 @@ npm run build      # Production build (tsc -b && vite build)
 
 ## Layout
 
-- `src/components/` — feature-scoped UI components (catalog, dataset, builder, admin, shared).
-- `src/api/` — typed API client wrappers around the auto-generated `@geolens/sdk`.
-- `src/hooks/` — TanStack Query hooks and store subscriptions.
-- `src/stores/` — global Zustand stores (auth, theme, search, drawing).
-- `src/i18n/` — translation files (en/es/fr/de).
-- `src/lib/` — utilities (basemap helpers, formatting, validation).
+- `src/components/`: feature-scoped UI components (catalog, dataset, builder, admin, shared).
+- `src/api/`: typed API client wrappers around the auto-generated `@geolens/sdk`.
+- `src/hooks/`: TanStack Query hooks and store subscriptions.
+- `src/stores/`: global Zustand stores (auth, theme, search, drawing).
+- `src/i18n/`: translation files (en/es/fr/de).
+- `src/lib/`: utilities (basemap helpers, formatting, validation).
 
 ## Documentation
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -2,18 +2,17 @@
 
 Utility scripts for GeoLens administration and data seeding.
 
-## Seed Scripts
+## Seed scripts
 
 ### `seed-showcase.py`
 
-Builds three capability-showcase maps from public, openly-licensed data, end-to-end
-against a running stack:
+Builds three demo maps from public, openly licensed data against a running stack:
 
-- **Manhattan Skyline** — every Lower + Midtown building footprint extruded to its real
+- **Manhattan Skyline**: every Lower + Midtown building footprint extruded to its real
   surveyed roof height and color-graded by height (NYC Open Data).
-- **New York Income** — a data-driven quantile choropleth of median household income by
+- **New York Income**: a data-driven quantile choropleth of median household income by
   county (USDA ERS Atlas of Rural & Small-Town America).
-- **The Matterhorn** (`--with-terrain`) — a 3D terrain mesh + hillshade from a swisstopo
+- **The Matterhorn** (`--with-terrain`): a 3D terrain mesh + hillshade from a swisstopo
   swissALTI3D VRT mosaic, with OpenStreetMap climbing routes (white-cased) and named peaks
   draped on the terrain.
 
@@ -39,32 +38,32 @@ python scripts/seed-showcase.py --only income
 | `--only` | unset | Build only `manhattan`, `income`, or `matterhorn` |
 
 Requires internet access to the upstream open-data sources (NYC Open Data, USDA ERS,
-OpenStreetMap, swisstopo). The script is non-idempotent — each run POSTs new maps.
+OpenStreetMap, swisstopo). The script is non-idempotent. Each run POSTs new maps.
 
-## Shell Scripts
+## Shell scripts
 
 | Script | Purpose |
 |--------|---------|
-| `install.sh` | First-run installer — see below |
-| `preflight-env.sh` | Statically validate `.env` (JWT secret, admin creds) before boot — `make preflight` / `make dev` |
-| `check-env.sh` | Probe the running stack's env, DB connectivity, and GDAL — `make doctor` (requires the stack up) |
+| `install.sh` | First-run installer (see below) |
+| `preflight-env.sh` | Statically validate `.env` (JWT secret, admin creds) before boot via `make preflight` / `make dev` |
+| `check-env.sh` | Probe the running stack's env, DB connectivity, and GDAL via `make doctor` (requires the stack up) |
 | `init-db.sh` | Initialize the PostGIS database schema (mounted into the db container's init) |
-| `init-test-db.sh` | Initialize a host-accessible `geolens_test` database (extensions, schemas, roles) for local `psql` debugging. Not used by CI — CI and pytest each bootstrap their own test databases. |
-| `backup-entrypoint.sh` | Scheduled `pg_dump` backups with retention + optional S3 upload — the Docker Compose backup-profile service |
+| `init-test-db.sh` | Initialize a host-accessible `geolens_test` database (extensions, schemas, roles) for local `psql` debugging. Not used by CI. CI and pytest each bootstrap their own test databases. |
+| `backup-entrypoint.sh` | Scheduled `pg_dump` backups with retention + optional S3 upload (the Docker Compose backup-profile service) |
 | `restore.sh` | Restore a database backup |
 | `run-baseline.sh` | Run performance baselines |
 | `analyze-query-plans.sh` | Analyze slow query plans |
 | `cleanup-test-pollution.sql` | Remove leftover test data (manual `psql`) |
 
-## Build & Release Glue
+## Build & release glue
 
 Wired into the `Makefile` / `package.json`, not run by operators directly:
 
 | Script | Purpose |
 |--------|---------|
-| `flatten_openapi_defs.py` | Post-process `backend/openapi.json` for the SDK generators. Runs stdlib-only via `uv run --no-project` (outside the backend venv) — `make sdks` |
-| `sync_sdk_versions.py` | Sync the generated SDK package versions — `make sdks` |
-| `check-readme-locales.mjs` | Verify the README locale stubs stay in sync — `npm run check:readme-locales` |
+| `flatten_openapi_defs.py` | Post-process `backend/openapi.json` for the SDK generators. Runs stdlib-only via `uv run --no-project` outside the backend venv (`make sdks`) |
+| `sync_sdk_versions.py` | Sync the generated SDK package versions (`make sdks`) |
+| `check-readme-locales.mjs` | Verify the README locale stubs stay in sync (`npm run check:readme-locales`) |
 
 ### `install.sh`
 
@@ -81,7 +80,7 @@ bash scripts/install.sh
 # Or have the script clone for you
 GEOLENS_INSTALL_DIR=geolens bash <(curl -fsSL https://raw.githubusercontent.com/geolens-io/geolens/main/scripts/install.sh)
 
-# Non-interactive — env vars override the prompts
+# Non-interactive: env vars override the prompts
 GEOLENS_ADMIN_USERNAME=admin GEOLENS_ADMIN_PASSWORD='change-me' bash scripts/install.sh
 ```
 
@@ -89,10 +88,10 @@ GEOLENS_ADMIN_USERNAME=admin GEOLENS_ADMIN_PASSWORD='change-me' bash scripts/ins
 |----------|---------|
 | `GEOLENS_REPO_URL` | Override the clone URL (default: `https://github.com/geolens-io/geolens.git`) |
 | `GEOLENS_INSTALL_DIR` | Directory to clone into when not already in a checkout (default: `geolens`) |
-| `GEOLENS_REF` | Install a specific ref instead of the latest release tag — a tag (e.g. `v1.2.0`) or a branch (e.g. `main`). Tags are checked out by their fully-qualified `refs/tags/` ref so a same-named branch cannot shadow them. |
+| `GEOLENS_REF` | Install a specific ref instead of the latest release tag: a tag (e.g. `v1.2.0`) or a branch (e.g. `main`). Tags are checked out by their fully-qualified `refs/tags/` ref so a same-named branch cannot shadow them. |
 | `GEOLENS_ADMIN_USERNAME` | Skip the admin-username prompt with this value |
 | `GEOLENS_ADMIN_PASSWORD` | Skip the admin-password prompt with this value |
 
-Re-running the script is idempotent — existing `.env` values (including a
+Re-running the script is idempotent. Existing `.env` values (including a
 real `JWT_SECRET_KEY`) are preserved. Only missing or empty values are
 populated.

--- a/sdks/python/README.md
+++ b/sdks/python/README.md
@@ -12,6 +12,6 @@ See [docs.getgeolens.com](https://docs.getgeolens.com/) for installation, regene
 from geolens import GeolensClient
 
 client = GeolensClient(base_url="https://geolens.example.com/api", bearer_token="...")
-# The deployed API is served under /api — include that suffix in base_url.
+# The deployed API is served under /api, so include that suffix in base_url.
 # See docs.getgeolens.com for endpoint usage examples.
 ```

--- a/sdks/typescript/README.md
+++ b/sdks/typescript/README.md
@@ -12,7 +12,7 @@ See [docs.getgeolens.com](https://docs.getgeolens.com/) for installation, regene
 import { createGeolensClient } from '@geolens/sdk';
 
 const client = createGeolensClient({
-  // The deployed API is served under /api — include that suffix in baseUrl.
+  // The deployed API is served under /api, so include that suffix in baseUrl.
   baseUrl: 'https://geolens.example.com/api',
   bearerToken: '...',
 });

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,11 +1,11 @@
-# Load Tests
+# Load tests
 
-This directory holds the **Locust load-testing harness** (`load/`) — it is *not*
+This directory holds the **Locust load-testing harness** (`load/`). It is *not*
 the project's unit/integration test suite. The actual suites live elsewhere:
 
-- `backend/tests/` — backend pytest (unit + integration)
-- `frontend/src/**/__tests__/` — frontend Vitest component tests
-- `e2e/` — Playwright browser end-to-end tests
+- `backend/tests/`: backend pytest (unit + integration)
+- `frontend/src/**/__tests__/`: frontend Vitest component tests
+- `e2e/`: Playwright browser end-to-end tests
 
 ## Running the load tests
 


### PR DESCRIPTION
## Summary
- Humanize all tracked README files in geolens using the humanizer pass
- Remove AI-ish phrasing, em/en dash habits, title-case headings, and over-bolded wording while preserving technical meaning
- Keep locale README stubs aligned with the canonical README

## Validation
- npm run check:readme-locales
- git diff --check
- pre-commit hooks on commit: whitespace, EOF, merge/case conflicts, secrets; backend-specific hooks skipped because no backend files matched

## Review
@codex please review.