### PR TITLE
test(e2e): fix catalog keyboard smoke

### DIFF
--- a/e2e/auth.spec.ts
+++ b/e2e/auth.spec.ts
@@ -26,7 +26,7 @@ test.describe('Authentication Flow', () => {
 
     // Verify workspace loaded
     await expect(
-      page.getByRole('combobox', { name: 'Search geospatial data...' }),
+      page.getByRole('combobox', { name: 'Search the catalog...' }),
     ).toBeVisible();
 
     // Verify username displayed in navbar user menu button

--- a/e2e/keyboard-nav.spec.ts
+++ b/e2e/keyboard-nav.spec.ts
@@ -1,4 +1,12 @@
-import { test, expect } from '@playwright/test';
+import { test, expect, type Page } from '@playwright/test';
+
+const GUEST_BROWSE_KEY = 'gl-guest-browse';
+
+async function allowGuestCatalog(page: Page) {
+  await page.addInitScript((key) => {
+    window.sessionStorage.setItem(key, 'true');
+  }, GUEST_BROWSE_KEY);
+}
 
 // REL-02: lightweight keyboard-nav smoke for the public front door.
 // Scoped to /login and / only — no MapLibre/builder routes which flake headless.
@@ -41,10 +49,13 @@ test.describe('Keyboard navigation — public routes', () => {
   test('/ home: search input is keyboard-reachable and stays interactive after Enter', async ({
     page,
   }) => {
+    // Matches the LoginPage "Browse the catalog" escape path when landing_first
+    // is enabled in demo/cloud configs.
+    await allowGuestCatalog(page);
     await page.goto('/');
     await page.waitForLoadState('networkidle');
 
-    const searchInput = page.getByRole('combobox', { name: 'Search geospatial data...' });
+    const searchInput = page.getByRole('combobox', { name: 'Search the catalog...' });
     await expect(searchInput).toBeVisible();
 
     // Tab through the page until the catalog search combobox receives focus.

--- a/e2e/permissions.spec.ts
+++ b/e2e/permissions.spec.ts
@@ -1,5 +1,21 @@
 import { test, expect } from '@playwright/test';
 
+const TENANT_ADMIN_CAPABILITIES = [
+  'upload',
+  'create_layers',
+  'export',
+  'edit_metadata',
+  'manage_collections',
+  'use_ai_chat',
+  'manage_users',
+  'manage_settings',
+] as const;
+
+const ALL_CAPABILITIES = [
+  ...TENANT_ADMIN_CAPABILITIES,
+  'manage_tenants',
+] as const;
+
 test.describe('Permissions', () => {
   test('settings: permissions tab loads with matrix', async ({ page }) => {
     await page.goto('/admin/settings/permissions');
@@ -80,13 +96,15 @@ test.describe('Permissions', () => {
     expect(permResp.ok()).toBeTruthy();
     const data = await permResp.json();
 
-    // Admin should have all 8 capabilities set to true
+    // Admin should have all tenant-scoped capabilities set to true. The
+    // fleet-level manage_tenants key is present but deployment-specific.
     expect(data.permissions).toBeDefined();
     const perms = data.permissions;
-    expect(Object.keys(perms)).toHaveLength(8);
-    for (const [, val] of Object.entries(perms)) {
-      expect(val).toBe(true);
+    expect(Object.keys(perms).sort()).toEqual([...ALL_CAPABILITIES].sort());
+    for (const key of TENANT_ADMIN_CAPABILITIES) {
+      expect(perms[key]).toBe(true);
     }
+    expect(typeof perms.manage_tenants).toBe('boolean');
   });
 
   test('navbar: admin sees Maps, Admin in the user menu, and Import in the Create menu', async ({
@@ -94,7 +112,7 @@ test.describe('Permissions', () => {
   }) => {
     await page.goto('/');
     await expect(
-      page.getByRole('combobox', { name: 'Search geospatial data...' }),
+      page.getByRole('combobox', { name: 'Search the catalog...' }),
     ).toBeVisible();
 
     // Admin should see all permission-gated nav links

--- a/e2e/search.spec.ts
+++ b/e2e/search.spec.ts
@@ -11,7 +11,7 @@ test.describe('Search Flow', () => {
 
     // Search input should be present
     await expect(
-      page.getByRole('combobox', { name: 'Search geospatial data...' }),
+      page.getByRole('combobox', { name: 'Search the catalog...' }),
     ).toHaveCount(1);
 
     const filterRail = page.getByTestId('search-filter-rail');
@@ -37,7 +37,7 @@ test.describe('Search Flow', () => {
     await expect(page).toHaveURL('/?q=Zoning');
 
     // Search input should reflect the query
-    const searchInput = page.getByRole('combobox', { name: 'Search geospatial data...' });
+    const searchInput = page.getByRole('combobox', { name: 'Search the catalog...' });
     await expect(searchInput).toHaveCount(1);
     await expect(searchInput).toHaveValue('Zoning');
   });
@@ -48,13 +48,13 @@ test.describe('Search Flow', () => {
     // Verify search page loaded
     await page.goto('/');
     await expect(
-      page.getByRole('combobox', { name: 'Search geospatial data...' }),
+      page.getByRole('combobox', { name: 'Search the catalog...' }),
     ).toBeVisible();
 
     // Navigate with query param to bypass hero→sticky transition race condition.
     // This puts us directly in browse mode with a single SearchBar.
     await page.goto(`/?q=${encodeURIComponent(seed.query)}`);
-    const searchInput = page.getByRole('combobox', { name: 'Search geospatial data...' });
+    const searchInput = page.getByRole('combobox', { name: 'Search the catalog...' });
     await expect(searchInput).toHaveValue(seed.query);
 
     // Focus and re-fill to trigger typeahead (onFocus + onChange open the dropdown)


### PR DESCRIPTION
## Summary\n- seed the guest-browse session marker before the logged-out home keyboard smoke hits /\n- update E2E search combobox selectors to the current accessible name\n- align the permissions API smoke with the current manage_tenants capability key\n\n## Verification\n- npx playwright test e2e/accessibility.spec.ts e2e/keyboard-nav.spec.ts --project=chromium\n- npx playwright test e2e/auth.spec.ts e2e/search.spec.ts e2e/permissions.spec.ts --project=chromium\n- git diff --check