### PR TITLE
[codex] Fix Service URL progress and large ArcGIS imports

### DIFF
--- a/backend/app/core/processing_port.py
+++ b/backend/app/core/processing_port.py
@@ -317,6 +317,7 @@ class ProcessingPort(Protocol):
         token: str | None = None,
         order_field: str | None = None,
         result_limit: int | None = None,
+        result_offset: int | None = None,
     ) -> tuple[str, str]: ...
 
     # -------------------------------------------------------------------------

--- a/backend/app/modules/catalog/sources/adapters/arcgis.py
+++ b/backend/app/modules/catalog/sources/adapters/arcgis.py
@@ -62,6 +62,31 @@ def _normalize_esri_geom_type(esri_type: str | None) -> str | None:
     return _ESRI_GEOM_TYPE_MAP.get(esri_type, esri_type)
 
 
+def _extract_arcgis_object_id_field(data: dict) -> str | None:
+    value = data.get("objectIdField")
+    if isinstance(value, str) and value.strip():
+        return value.strip()
+
+    fields = data.get("fields")
+    if isinstance(fields, list):
+        for field in fields:
+            if not isinstance(field, dict):
+                continue
+            if field.get("type") != "esriFieldTypeOID":
+                continue
+            name = field.get("name")
+            if isinstance(name, str) and name.strip():
+                return name.strip()
+
+    unique_id_field = data.get("uniqueIdField")
+    if isinstance(unique_id_field, dict):
+        name = unique_id_field.get("name")
+        if isinstance(name, str) and name.strip():
+            return name.strip()
+
+    return None
+
+
 def _looks_like_arcgis(url: str) -> bool:
     """Check if a URL looks like an ArcGIS service (FeatureServer or MapServer)."""
     lower = url.lower()
@@ -264,8 +289,8 @@ async def fetch_arcgis_pagination_info(
     layer_id: int | str,
     client: httpx.AsyncClient,
     token: str | None = None,
-) -> tuple[int | None, bool]:
-    """Fetch ArcGIS pagination support and the advertised maximum page size."""
+) -> tuple[int | None, bool, str | None]:
+    """Fetch ArcGIS pagination support, page size, and stable order field."""
     base = base_url.rstrip("/")
     safe_layer_id = str(layer_id).strip("/")
     params: dict[str, str] = {"f": "json"}
@@ -277,7 +302,7 @@ async def fetch_arcgis_pagination_info(
         resp.raise_for_status()
         data = resp.json()
     except (httpx.HTTPError, ValueError, TypeError):
-        return None, False
+        return None, False, None
 
     if "error" in data:
         error_info = data["error"]
@@ -285,7 +310,7 @@ async def fetch_arcgis_pagination_info(
         message = error_info.get("message", "Unknown ArcGIS error")
         if code in (498, 499):
             raise ArcGISTokenError(code, message)
-        return None, False
+        return None, False, None
 
     value = data.get("maxRecordCount")
     max_record_count = value if isinstance(value, int) and value > 0 else None
@@ -293,7 +318,7 @@ async def fetch_arcgis_pagination_info(
     supports_pagination = (
         isinstance(advanced, dict) and advanced.get("supportsPagination") is True
     )
-    return max_record_count, supports_pagination
+    return max_record_count, supports_pagination, _extract_arcgis_object_id_field(data)
 
 
 async def fetch_arcgis_layer_preview(

--- a/backend/app/modules/catalog/sources/adapters/arcgis.py
+++ b/backend/app/modules/catalog/sources/adapters/arcgis.py
@@ -259,13 +259,13 @@ async def fetch_arcgis_feature_count(
     return None
 
 
-async def fetch_arcgis_max_record_count(
+async def fetch_arcgis_pagination_info(
     base_url: str,
     layer_id: int | str,
     client: httpx.AsyncClient,
     token: str | None = None,
-) -> int | None:
-    """Fetch an ArcGIS layer's advertised maximum page size."""
+) -> tuple[int | None, bool]:
+    """Fetch ArcGIS pagination support and the advertised maximum page size."""
     base = base_url.rstrip("/")
     safe_layer_id = str(layer_id).strip("/")
     params: dict[str, str] = {"f": "json"}
@@ -277,7 +277,7 @@ async def fetch_arcgis_max_record_count(
         resp.raise_for_status()
         data = resp.json()
     except (httpx.HTTPError, ValueError, TypeError):
-        return None
+        return None, False
 
     if "error" in data:
         error_info = data["error"]
@@ -285,12 +285,15 @@ async def fetch_arcgis_max_record_count(
         message = error_info.get("message", "Unknown ArcGIS error")
         if code in (498, 499):
             raise ArcGISTokenError(code, message)
-        return None
+        return None, False
 
     value = data.get("maxRecordCount")
-    if isinstance(value, int) and value > 0:
-        return value
-    return None
+    max_record_count = value if isinstance(value, int) and value > 0 else None
+    advanced = data.get("advancedQueryCapabilities") or {}
+    supports_pagination = (
+        isinstance(advanced, dict) and advanced.get("supportsPagination") is True
+    )
+    return max_record_count, supports_pagination
 
 
 async def fetch_arcgis_layer_preview(

--- a/backend/app/modules/catalog/sources/adapters/arcgis.py
+++ b/backend/app/modules/catalog/sources/adapters/arcgis.py
@@ -225,6 +225,74 @@ async def enrich_arcgis_feature_counts(
     return list(enriched)
 
 
+async def fetch_arcgis_feature_count(
+    base_url: str,
+    layer_id: int | str,
+    client: httpx.AsyncClient,
+    token: str | None = None,
+) -> int | None:
+    """Fetch a layer feature count from ArcGIS REST query metadata."""
+    base = base_url.rstrip("/")
+    safe_layer_id = str(layer_id).strip("/")
+    params: dict[str, str] = {
+        "where": "1=1",
+        "returnCountOnly": "true",
+        "f": "json",
+    }
+    if token:
+        params["token"] = token
+
+    resp = await client.get(f"{base}/{safe_layer_id}/query", params=params)
+    resp.raise_for_status()
+    data = resp.json()
+    if "error" in data:
+        error_info = data["error"]
+        code = error_info.get("code", 0)
+        message = error_info.get("message", "Unknown ArcGIS error")
+        if code in (498, 499):
+            raise ArcGISTokenError(code, message)
+        return None
+
+    count = data.get("count")
+    if isinstance(count, int) and count >= 0:
+        return count
+    return None
+
+
+async def fetch_arcgis_max_record_count(
+    base_url: str,
+    layer_id: int | str,
+    client: httpx.AsyncClient,
+    token: str | None = None,
+) -> int | None:
+    """Fetch an ArcGIS layer's advertised maximum page size."""
+    base = base_url.rstrip("/")
+    safe_layer_id = str(layer_id).strip("/")
+    params: dict[str, str] = {"f": "json"}
+    if token:
+        params["token"] = token
+
+    try:
+        resp = await client.get(f"{base}/{safe_layer_id}", params=params)
+        resp.raise_for_status()
+        data = resp.json()
+    except (httpx.HTTPError, ValueError, TypeError):
+        return None
+
+    if "error" in data:
+        error_info = data["error"]
+        code = error_info.get("code", 0)
+        message = error_info.get("message", "Unknown ArcGIS error")
+        if code in (498, 499):
+            raise ArcGISTokenError(code, message)
+        return None
+
+    value = data.get("maxRecordCount")
+    if isinstance(value, int) and value > 0:
+        return value
+    return None
+
+
 async def fetch_arcgis_layer_preview(
     base_url: str,
     layer_id: int | str,

--- a/backend/app/modules/catalog/sources/preview.py
+++ b/backend/app/modules/catalog/sources/preview.py
@@ -31,6 +31,7 @@ def build_gdal_source(
     token: str | None = None,
     order_field: str | None = "OBJECTID",
     result_limit: int | None = None,
+    result_offset: int | None = None,
 ) -> tuple[str, str]:
     """Construct a GDAL-prefixed source string for a remote service.
 
@@ -50,6 +51,8 @@ def build_gdal_source(
             params["orderByFields"] = f"{order_field} ASC"
         if result_limit is not None:
             params["resultRecordCount"] = result_limit
+        if result_offset is not None:
+            params["resultOffset"] = result_offset
         if token:
             params["token"] = token
         query_url = f"{safe_base_url}/{safe_layer_id}/query?{urlencode(params)}"

--- a/backend/app/platform/extensions/defaults.py
+++ b/backend/app/platform/extensions/defaults.py
@@ -547,6 +547,7 @@ class DefaultProcessingPort:
         token=None,
         order_field=None,
         result_limit=None,
+        result_offset=None,
     ):  # type: ignore[no-untyped-def]
         from app.modules.catalog.sources.preview import build_gdal_source
 
@@ -558,6 +559,7 @@ class DefaultProcessingPort:
             token=token,
             order_field=order_field,
             result_limit=result_limit,
+            result_offset=result_offset,
         )
 
     # -------------------------------------------------------------------------

--- a/backend/app/processing/ingest/ogr.py
+++ b/backend/app/processing/ingest/ogr.py
@@ -600,6 +600,7 @@ async def run_ogr2ogr_service(
     timeout: float = 1800.0,
     token: str | None = None,
     is_non_spatial: bool = False,
+    append: bool = False,
 ) -> None:
     """Run ogr2ogr to load a remote service layer into PostGIS.
 
@@ -613,6 +614,8 @@ async def run_ogr2ogr_service(
         is_non_spatial: When True, omit geometry-specific flags (-nlt, -t_srs,
             GEOMETRY_NAME) to avoid dropping attribute columns for tables with
             no geometry (ArcGIS Table layers, non-spatial WFS, etc.)
+        append: When True, append to an existing target layer instead of
+            overwriting it. Used by chunked ArcGIS imports after the first page.
     """
     cmd = [
         "ogr2ogr",
@@ -620,7 +623,7 @@ async def run_ogr2ogr_service(
         "PostgreSQL",
         db_conn_str,
         gdal_source,
-        "-overwrite",
+        "-append" if append else "-overwrite",
         "-nln",
         f"data.{table_name}",
         "-lco",

--- a/backend/app/processing/ingest/tasks_vector.py
+++ b/backend/app/processing/ingest/tasks_vector.py
@@ -7,8 +7,10 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 import structlog
+from sqlalchemy import text
 
 from app.core.db.tenant_session import tenant_task
+from app.processing.ingest.metadata import _qtable
 from app.processing.ingest.tasks_common import (
     IngestContext,
     _append_job_warning,
@@ -31,6 +33,7 @@ _SERVICE_IMPORT_INITIAL_PROGRESS = 0.1
 _SERVICE_IMPORT_HEARTBEAT_INTERVAL_SECONDS = 5.0
 _SERVICE_IMPORT_HEARTBEAT_INCREMENT = 0.05
 _SERVICE_IMPORT_HEARTBEAT_MAX_PROGRESS = 0.65
+_ARCGIS_SERVICE_IMPORT_CHUNK_SIZE = 2000
 
 
 async def _heartbeat_service_import_progress(job_uuid: uuid.UUID) -> None:
@@ -67,6 +70,87 @@ async def _heartbeat_service_import_progress(job_uuid: uuid.UUID) -> None:
                 job_id=str(job_uuid),
                 exc_info=True,
             )
+
+
+async def _write_service_import_progress(
+    job_uuid: uuid.UUID, *, imported_rows: int, feature_count: int
+) -> None:
+    if feature_count <= 0:
+        return
+
+    completed_ratio = min(1.0, imported_rows / feature_count)
+    next_progress = min(
+        _SERVICE_IMPORT_HEARTBEAT_MAX_PROGRESS,
+        _SERVICE_IMPORT_INITIAL_PROGRESS
+        + (_SERVICE_IMPORT_HEARTBEAT_MAX_PROGRESS - _SERVICE_IMPORT_INITIAL_PROGRESS)
+        * completed_ratio,
+    )
+
+    async with _job_phase_session(job_uuid, phase="service_import_chunk_progress") as (
+        session,
+        job,
+    ):
+        if job is None:
+            return
+        if job.status != "running" or job.current_step != "ogr2ogr":
+            return
+        existing_progress = (
+            job.progress
+            if job.progress is not None
+            else _SERVICE_IMPORT_INITIAL_PROGRESS
+        )
+        if next_progress <= existing_progress:
+            return
+        job.progress = next_progress
+        await session.commit()
+
+
+async def _count_service_import_rows(table_name: str) -> int:
+    from app.core import db as db_module
+
+    async with db_module.async_session() as session:
+        result = await session.execute(
+            text(
+                f"SELECT COUNT(*) FROM "
+                f"{_qtable(table_name, schema=_current_tenant_schema())}"
+            )
+        )
+        return int(result.scalar_one())
+
+
+async def _fetch_arcgis_import_page_info(
+    source_url: str, layer_id: int | str | None, token: str | None
+) -> tuple[int | None, int | None]:
+    if layer_id is None:
+        return None, None
+
+    from app.modules.catalog.sources.adapters.arcgis import (
+        ArcGISTokenError,
+        fetch_arcgis_feature_count,
+        fetch_arcgis_max_record_count,
+    )
+    from app.modules.catalog.sources.security import make_safe_client
+    from app.processing.ingest.ogr import IngestionError
+
+    try:
+        async with make_safe_client(timeout=30.0) as client:
+            max_record_count = await fetch_arcgis_max_record_count(
+                source_url, layer_id, client, token=token
+            )
+            feature_count = await fetch_arcgis_feature_count(
+                source_url, layer_id, client, token=token
+            )
+            return feature_count, max_record_count
+    except ArcGISTokenError as exc:
+        raise IngestionError(str(exc)) from exc
+    except Exception as exc:  # broad: count is an optimization; import can fall back
+        structlog.get_logger().warning(
+            "arcgis_import_page_info_fetch_failed",
+            source_url=source_url,
+            layer_id=str(layer_id),
+            error=str(exc),
+        )
+        return None, None
 
 
 def _should_unlink_staging(
@@ -595,6 +679,61 @@ async def ingest_service(
 
         # WFS namespace retry via shared helper (KISS-8).
         async def _do_import(layer_name: str) -> None:
+            feature_count = None
+            page_size = _ARCGIS_SERVICE_IMPORT_CHUNK_SIZE
+            if service_type == "arcgis_featureserver":
+                feature_count, max_record_count = await _fetch_arcgis_import_page_info(
+                    source_url, layer_id, token
+                )
+                if max_record_count is not None:
+                    page_size = max(1, min(page_size, max_record_count))
+
+            if (
+                service_type == "arcgis_featureserver"
+                and feature_count is not None
+                and feature_count > page_size
+            ):
+                imported_rows = 0
+                append = False
+                for offset in range(0, feature_count, page_size):
+                    _src, _layer = port.build_gdal_source(
+                        service_type_raw,
+                        source_url,
+                        layer_name,
+                        layer_id,
+                        token=token,
+                        order_field=object_id_field,
+                        result_limit=page_size,
+                        result_offset=offset,
+                    )
+                    await run_ogr2ogr_service(
+                        _src,
+                        _layer,
+                        table_name,
+                        db_conn_str,
+                        service_type,
+                        token=token,
+                        is_non_spatial=is_non_spatial,
+                        append=append,
+                    )
+                    next_imported_rows = await _count_service_import_rows(table_name)
+                    if next_imported_rows <= imported_rows:
+                        from app.processing.ingest.ogr import IngestionError
+
+                        raise IngestionError(
+                            "ArcGIS service import made no row-count progress "
+                            f"at offset {offset}; upstream pagination may be "
+                            "unsupported or returned an empty page."
+                        )
+                    imported_rows = next_imported_rows
+                    await _write_service_import_progress(
+                        job_uuid,
+                        imported_rows=imported_rows,
+                        feature_count=feature_count,
+                    )
+                    append = True
+                return
+
             _src, _layer = port.build_gdal_source(
                 service_type_raw,
                 source_url,

--- a/backend/app/processing/ingest/tasks_vector.py
+++ b/backend/app/processing/ingest/tasks_vector.py
@@ -120,27 +120,29 @@ async def _count_service_import_rows(table_name: str) -> int:
 
 async def _fetch_arcgis_import_page_info(
     source_url: str, layer_id: int | str | None, token: str | None
-) -> tuple[int | None, int | None]:
+) -> tuple[int | None, int | None, bool]:
     if layer_id is None:
-        return None, None
+        return None, None, False
 
     from app.modules.catalog.sources.adapters.arcgis import (
         ArcGISTokenError,
         fetch_arcgis_feature_count,
-        fetch_arcgis_max_record_count,
+        fetch_arcgis_pagination_info,
     )
     from app.modules.catalog.sources.security import make_safe_client
     from app.processing.ingest.ogr import IngestionError
 
     try:
         async with make_safe_client(timeout=30.0) as client:
-            max_record_count = await fetch_arcgis_max_record_count(
+            max_record_count, supports_pagination = await fetch_arcgis_pagination_info(
                 source_url, layer_id, client, token=token
             )
+            if not supports_pagination or max_record_count is None:
+                return None, max_record_count, supports_pagination
             feature_count = await fetch_arcgis_feature_count(
                 source_url, layer_id, client, token=token
             )
-            return feature_count, max_record_count
+            return feature_count, max_record_count, supports_pagination
     except ArcGISTokenError as exc:
         raise IngestionError(str(exc)) from exc
     except Exception as exc:  # broad: count is an optimization; import can fall back
@@ -150,7 +152,7 @@ async def _fetch_arcgis_import_page_info(
             layer_id=str(layer_id),
             error=str(exc),
         )
-        return None, None
+        return None, None, False
 
 
 def _should_unlink_staging(
@@ -681,15 +683,19 @@ async def ingest_service(
         async def _do_import(layer_name: str) -> None:
             feature_count = None
             page_size = _ARCGIS_SERVICE_IMPORT_CHUNK_SIZE
+            supports_pagination = False
             if service_type == "arcgis_featureserver":
-                feature_count, max_record_count = await _fetch_arcgis_import_page_info(
-                    source_url, layer_id, token
-                )
+                (
+                    feature_count,
+                    max_record_count,
+                    supports_pagination,
+                ) = await _fetch_arcgis_import_page_info(source_url, layer_id, token)
                 if max_record_count is not None:
                     page_size = max(1, min(page_size, max_record_count))
 
             if (
                 service_type == "arcgis_featureserver"
+                and supports_pagination
                 and feature_count is not None
                 and feature_count > page_size
             ):

--- a/backend/app/processing/ingest/tasks_vector.py
+++ b/backend/app/processing/ingest/tasks_vector.py
@@ -1,6 +1,8 @@
 """Procrastinate task definitions for vector file and service ingestion."""
 
+import asyncio
 import uuid
+from contextlib import suppress
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -23,6 +25,48 @@ from app.processing.ingest.tasks_common import (
     resolve_service_type,
     task_app,
 )
+
+
+_SERVICE_IMPORT_INITIAL_PROGRESS = 0.1
+_SERVICE_IMPORT_HEARTBEAT_INTERVAL_SECONDS = 5.0
+_SERVICE_IMPORT_HEARTBEAT_INCREMENT = 0.05
+_SERVICE_IMPORT_HEARTBEAT_MAX_PROGRESS = 0.65
+
+
+async def _heartbeat_service_import_progress(job_uuid: uuid.UUID) -> None:
+    """Advance service-ingest progress while GDAL loads remote features."""
+    while True:
+        await asyncio.sleep(_SERVICE_IMPORT_HEARTBEAT_INTERVAL_SECONDS)
+        try:
+            async with _job_phase_session(
+                job_uuid, phase="service_import_heartbeat"
+            ) as (session, job):
+                if job is None:
+                    return
+                if job.status != "running" or job.current_step != "ogr2ogr":
+                    return
+
+                existing_progress = (
+                    job.progress
+                    if job.progress is not None
+                    else _SERVICE_IMPORT_INITIAL_PROGRESS
+                )
+                next_progress = min(
+                    _SERVICE_IMPORT_HEARTBEAT_MAX_PROGRESS,
+                    existing_progress + _SERVICE_IMPORT_HEARTBEAT_INCREMENT,
+                )
+                if next_progress <= existing_progress:
+                    continue
+
+                job.progress = next_progress
+                await session.commit()
+        except Exception:
+            # Heartbeat progress is best-effort and must not mask ingest work.
+            structlog.get_logger().warning(
+                "service_import_progress_heartbeat_failed",
+                job_id=str(job_uuid),
+                exc_info=True,
+            )
 
 
 def _should_unlink_staging(
@@ -546,7 +590,7 @@ async def ingest_service(
         ):
             if _progress_job is not None:
                 _progress_job.current_step = "ogr2ogr"
-                _progress_job.progress = 0.1
+                _progress_job.progress = _SERVICE_IMPORT_INITIAL_PROGRESS
                 await _progress_session.commit()
 
         # WFS namespace retry via shared helper (KISS-8).
@@ -569,9 +613,17 @@ async def ingest_service(
                 is_non_spatial=is_non_spatial,
             )
 
-        await _run_service_import_with_wfs_fallback(
-            _do_import, source_layer, token=token
+        service_progress_task = asyncio.create_task(
+            _heartbeat_service_import_progress(job_uuid)
         )
+        try:
+            await _run_service_import_with_wfs_fallback(
+                _do_import, source_layer, token=token
+            )
+        finally:
+            service_progress_task.cancel()
+            with suppress(asyncio.CancelledError):
+                await service_progress_task
 
         # ----------------------------------------------------------------- #
         # Phase 2 (short-lived session): post-ogr2ogr finalization.

--- a/backend/app/processing/ingest/tasks_vector.py
+++ b/backend/app/processing/ingest/tasks_vector.py
@@ -63,7 +63,7 @@ async def _heartbeat_service_import_progress(job_uuid: uuid.UUID) -> None:
 
                 job.progress = next_progress
                 await session.commit()
-        except Exception:
+        except Exception:  # broad: best-effort heartbeat must not fail ingest
             # Heartbeat progress is best-effort and must not mask ingest work.
             structlog.get_logger().warning(
                 "service_import_progress_heartbeat_failed",

--- a/backend/app/processing/ingest/tasks_vector.py
+++ b/backend/app/processing/ingest/tasks_vector.py
@@ -120,9 +120,9 @@ async def _count_service_import_rows(table_name: str) -> int:
 
 async def _fetch_arcgis_import_page_info(
     source_url: str, layer_id: int | str | None, token: str | None
-) -> tuple[int | None, int | None, bool]:
+) -> tuple[int | None, int | None, bool, str | None]:
     if layer_id is None:
-        return None, None, False
+        return None, None, False, None
 
     from app.modules.catalog.sources.adapters.arcgis import (
         ArcGISTokenError,
@@ -134,15 +134,23 @@ async def _fetch_arcgis_import_page_info(
 
     try:
         async with make_safe_client(timeout=30.0) as client:
-            max_record_count, supports_pagination = await fetch_arcgis_pagination_info(
+            (
+                max_record_count,
+                supports_pagination,
+                order_field,
+            ) = await fetch_arcgis_pagination_info(
                 source_url, layer_id, client, token=token
             )
-            if not supports_pagination or max_record_count is None:
-                return None, max_record_count, supports_pagination
+            if (
+                not supports_pagination
+                or max_record_count is None
+                or order_field is None
+            ):
+                return None, max_record_count, supports_pagination, order_field
             feature_count = await fetch_arcgis_feature_count(
                 source_url, layer_id, client, token=token
             )
-            return feature_count, max_record_count, supports_pagination
+            return feature_count, max_record_count, supports_pagination, order_field
     except ArcGISTokenError as exc:
         raise IngestionError(str(exc)) from exc
     except Exception as exc:  # broad: count is an optimization; import can fall back
@@ -152,7 +160,7 @@ async def _fetch_arcgis_import_page_info(
             layer_id=str(layer_id),
             error=str(exc),
         )
-        return None, None, False
+        return None, None, False, None
 
 
 def _should_unlink_staging(
@@ -684,11 +692,13 @@ async def ingest_service(
             feature_count = None
             page_size = _ARCGIS_SERVICE_IMPORT_CHUNK_SIZE
             supports_pagination = False
+            pagination_order_field = None
             if service_type == "arcgis_featureserver":
                 (
                     feature_count,
                     max_record_count,
                     supports_pagination,
+                    pagination_order_field,
                 ) = await _fetch_arcgis_import_page_info(source_url, layer_id, token)
                 if max_record_count is not None:
                     page_size = max(1, min(page_size, max_record_count))
@@ -696,6 +706,7 @@ async def ingest_service(
             if (
                 service_type == "arcgis_featureserver"
                 and supports_pagination
+                and pagination_order_field is not None
                 and feature_count is not None
                 and feature_count > page_size
             ):
@@ -708,7 +719,7 @@ async def ingest_service(
                         layer_name,
                         layer_id,
                         token=token,
-                        order_field=object_id_field,
+                        order_field=pagination_order_field,
                         result_limit=page_size,
                         result_offset=offset,
                     )

--- a/backend/tests/test_arcgis_auth.py
+++ b/backend/tests/test_arcgis_auth.py
@@ -216,7 +216,11 @@ async def test_fetch_arcgis_pagination_info_requires_explicit_support():
         }
     )
 
-    max_record_count, supports_pagination = await fetch_arcgis_pagination_info(
+    (
+        max_record_count,
+        supports_pagination,
+        object_id_field,
+    ) = await fetch_arcgis_pagination_info(
         "https://services.arcgis.com/svc/FeatureServer",
         0,
         mock_client,
@@ -224,15 +228,21 @@ async def test_fetch_arcgis_pagination_info_requires_explicit_support():
 
     assert max_record_count == 1000
     assert supports_pagination is False
+    assert object_id_field is None
 
     mock_client.get.return_value = _make_mock_response(
         {
             "maxRecordCount": 1000,
             "advancedQueryCapabilities": {"supportsPagination": True},
+            "objectIdField": "FID",
         }
     )
 
-    max_record_count, supports_pagination = await fetch_arcgis_pagination_info(
+    (
+        max_record_count,
+        supports_pagination,
+        object_id_field,
+    ) = await fetch_arcgis_pagination_info(
         "https://services.arcgis.com/svc/FeatureServer",
         0,
         mock_client,
@@ -240,3 +250,34 @@ async def test_fetch_arcgis_pagination_info_requires_explicit_support():
 
     assert max_record_count == 1000
     assert supports_pagination is True
+    assert object_id_field == "FID"
+
+
+@pytest.mark.asyncio
+async def test_fetch_arcgis_pagination_info_uses_oid_field_fallback():
+    """Layer metadata can identify the stable order field via field type."""
+    mock_client = AsyncMock(spec=httpx.AsyncClient)
+    mock_client.get.return_value = _make_mock_response(
+        {
+            "maxRecordCount": 1000,
+            "advancedQueryCapabilities": {"supportsPagination": True},
+            "fields": [
+                {"name": "NAME", "type": "esriFieldTypeString"},
+                {"name": "OBJECTID_1", "type": "esriFieldTypeOID"},
+            ],
+        }
+    )
+
+    (
+        max_record_count,
+        supports_pagination,
+        object_id_field,
+    ) = await fetch_arcgis_pagination_info(
+        "https://services.arcgis.com/svc/FeatureServer",
+        0,
+        mock_client,
+    )
+
+    assert max_record_count == 1000
+    assert supports_pagination is True
+    assert object_id_field == "OBJECTID_1"

--- a/backend/tests/test_arcgis_auth.py
+++ b/backend/tests/test_arcgis_auth.py
@@ -184,3 +184,21 @@ def test_build_gdal_source_encodes_arcgis_service_paths_with_spaces():
     assert "resultRecordCount=5" in source
     assert "token=abc+123" in source
     assert " " not in source
+
+
+def test_build_gdal_source_arcgis_result_offset():
+    """ArcGIS import chunking should encode resultOffset for paged queries."""
+    source, layer_name = build_gdal_source(
+        "ArcGIS FeatureServer",
+        "https://services.arcgis.com/svc/FeatureServer",
+        "my_layer",
+        layer_id=0,
+        order_field="FID",
+        result_limit=2000,
+        result_offset=4000,
+    )
+
+    assert layer_name == ""
+    assert "orderByFields=FID+ASC" in source
+    assert "resultRecordCount=2000" in source
+    assert "resultOffset=4000" in source

--- a/backend/tests/test_arcgis_auth.py
+++ b/backend/tests/test_arcgis_auth.py
@@ -7,6 +7,7 @@ import pytest
 
 from app.modules.catalog.sources.adapters.arcgis import (
     ArcGISTokenError,
+    fetch_arcgis_pagination_info,
     probe_arcgis_service,
 )
 from app.modules.catalog.sources.preview import build_gdal_source
@@ -202,3 +203,40 @@ def test_build_gdal_source_arcgis_result_offset():
     assert "orderByFields=FID+ASC" in source
     assert "resultRecordCount=2000" in source
     assert "resultOffset=4000" in source
+
+
+@pytest.mark.asyncio
+async def test_fetch_arcgis_pagination_info_requires_explicit_support():
+    """Chunking must require ArcGIS supportsPagination, not just maxRecordCount."""
+    mock_client = AsyncMock(spec=httpx.AsyncClient)
+    mock_client.get.return_value = _make_mock_response(
+        {
+            "maxRecordCount": 1000,
+            "advancedQueryCapabilities": {"supportsPagination": False},
+        }
+    )
+
+    max_record_count, supports_pagination = await fetch_arcgis_pagination_info(
+        "https://services.arcgis.com/svc/FeatureServer",
+        0,
+        mock_client,
+    )
+
+    assert max_record_count == 1000
+    assert supports_pagination is False
+
+    mock_client.get.return_value = _make_mock_response(
+        {
+            "maxRecordCount": 1000,
+            "advancedQueryCapabilities": {"supportsPagination": True},
+        }
+    )
+
+    max_record_count, supports_pagination = await fetch_arcgis_pagination_info(
+        "https://services.arcgis.com/svc/FeatureServer",
+        0,
+        mock_client,
+    )
+
+    assert max_record_count == 1000
+    assert supports_pagination is True

--- a/backend/tests/test_ingest_progress.py
+++ b/backend/tests/test_ingest_progress.py
@@ -20,6 +20,7 @@ Pins the contract that the polling UI depends on:
 import asyncio
 import uuid as _uuid
 from pathlib import Path
+from urllib.parse import parse_qs, urlsplit
 
 import pytest
 from sqlalchemy import select, text
@@ -317,6 +318,186 @@ async def test_service_worker_advances_ogr2ogr_progress_while_remote_import_is_r
     assert last_progress is not None
     assert last_progress > 0.1
     assert last_progress < 0.7
+
+
+@pytest.mark.anyio
+async def test_service_worker_chunks_large_arcgis_imports(test_db_session, monkeypatch):
+    """Large ArcGIS imports should dispatch bounded paged ogr2ogr calls."""
+    from app.processing.ingest import tasks_vector
+    from app.modules.catalog.sources.preview import build_gdal_source
+
+    admin_id = await _get_admin_id(test_db_session)
+    table_name = f"tbl_arcgis_chunks_{_uuid.uuid4().hex[:8]}"
+
+    job = IngestJob(
+        source_filename="Big ArcGIS Layer",
+        source_url="https://example.test/arcgis/rest/services/Big/FeatureServer",
+        source_layer="0",
+        created_by=admin_id,
+        status="pending",
+        user_metadata={
+            "title": "Big ArcGIS Layer",
+            "visibility": "private",
+            "service_type": "ArcGIS FeatureServer",
+            "layer_id": "0",
+            "geometry_type": "Point",
+            "object_id_field": "FID",
+        },
+    )
+    test_db_session.add(job)
+    await test_db_session.flush()
+    await test_db_session.commit()
+    job_id = job.id
+
+    calls: list[dict[str, object]] = []
+
+    class _FakeProcessingPort:
+        def build_gdal_source(self, *args, **kwargs):
+            return build_gdal_source(*args, **kwargs)
+
+    async def _validate_url_noop(_url: str) -> None:
+        return None
+
+    async def _fake_generate_table_name(*args, **kwargs):
+        return table_name, None
+
+    async def _fake_page_info(*args, **kwargs):
+        return 4500, 1000
+
+    async def _fake_run_ogr2ogr_service(
+        gdal_source: str,
+        layer_name: str,
+        target_table: str,
+        db_conn_str: str,
+        service_type: str,
+        *,
+        append: bool = False,
+        **kwargs,
+    ) -> None:
+        query = parse_qs(urlsplit(gdal_source.removeprefix("ESRIJSON:")).query)
+        offset = int(query.get("resultOffset", ["0"])[0])
+        limit = int(query["resultRecordCount"][0])
+        rows_to_insert = max(0, min(limit, 4500 - offset))
+        calls.append(
+            {
+                "offset": offset,
+                "limit": limit,
+                "append": append,
+                "target_table": target_table,
+                "layer_name": layer_name,
+                "service_type": service_type,
+            }
+        )
+
+        if not append:
+            await test_db_session.execute(
+                text(f'DROP TABLE IF EXISTS data."{target_table}"')
+            )
+            await test_db_session.execute(
+                text(f'CREATE TABLE data."{target_table}" (gid serial PRIMARY KEY)')
+            )
+        for _ in range(rows_to_insert):
+            await test_db_session.execute(
+                text(f'INSERT INTO data."{target_table}" DEFAULT VALUES')
+            )
+        await test_db_session.commit()
+
+    async def _fake_rename_reserved_columns(*args, **kwargs):
+        return []
+
+    async def _fake_finalize_ingest(context):
+        context.job.status = "complete"
+        context.job.current_step = "complete"
+        context.job.progress = 1.0
+        context.job.rows_processed = 4500
+        await context.session.commit()
+
+    async def _fake_emit_billing_event(*args, **kwargs):
+        return None
+
+    monkeypatch.setattr(
+        "app.modules.catalog.sources.security.validate_url_for_ssrf",
+        _validate_url_noop,
+    )
+    monkeypatch.setattr(
+        "app.platform.extensions.get_processing_port",
+        lambda: _FakeProcessingPort(),
+    )
+    monkeypatch.setattr("app.processing.ingest.ogr.build_pg_conn_str", lambda: "PG:")
+    monkeypatch.setattr(
+        "app.processing.ingest.service.generate_table_name",
+        _fake_generate_table_name,
+    )
+    monkeypatch.setattr(
+        tasks_vector,
+        "_fetch_arcgis_import_page_info",
+        _fake_page_info,
+    )
+    monkeypatch.setattr(
+        "app.processing.ingest.ogr.run_ogr2ogr_service",
+        _fake_run_ogr2ogr_service,
+    )
+    monkeypatch.setattr(
+        "app.processing.ingest.metadata.rename_reserved_columns",
+        _fake_rename_reserved_columns,
+    )
+    monkeypatch.setattr(tasks_vector, "_finalize_ingest", _fake_finalize_ingest)
+    monkeypatch.setattr(tasks_vector, "_emit_billing_event", _fake_emit_billing_event)
+
+    await tasks_vector.ingest_service.func(
+        job_id=str(job_id),
+        source_url="https://example.test/arcgis/rest/services/Big/FeatureServer",
+        source_layer="0",
+        user_id=str(admin_id),
+    )
+
+    assert calls == [
+        {
+            "offset": 0,
+            "limit": 1000,
+            "append": False,
+            "target_table": table_name,
+            "layer_name": "",
+            "service_type": "arcgis_featureserver",
+        },
+        {
+            "offset": 1000,
+            "limit": 1000,
+            "append": True,
+            "target_table": table_name,
+            "layer_name": "",
+            "service_type": "arcgis_featureserver",
+        },
+        {
+            "offset": 2000,
+            "limit": 1000,
+            "append": True,
+            "target_table": table_name,
+            "layer_name": "",
+            "service_type": "arcgis_featureserver",
+        },
+        {
+            "offset": 3000,
+            "limit": 1000,
+            "append": True,
+            "target_table": table_name,
+            "layer_name": "",
+            "service_type": "arcgis_featureserver",
+        },
+        {
+            "offset": 4000,
+            "limit": 1000,
+            "append": True,
+            "target_table": table_name,
+            "layer_name": "",
+            "service_type": "arcgis_featureserver",
+        },
+    ]
+
+    row_count = (
+        await test_db_session.execute(text(f'SELECT COUNT(*) FROM data."{table_name}"'))
+    ).scalar_one()
+    assert row_count == 4500
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_ingest_progress.py
+++ b/backend/tests/test_ingest_progress.py
@@ -17,6 +17,7 @@ Pins the contract that the polling UI depends on:
    assertion against the writes the worker code actually does.
 """
 
+import asyncio
 import uuid as _uuid
 from pathlib import Path
 
@@ -195,7 +196,131 @@ async def test_vector_worker_writes_ogr2ogr_step_before_subprocess(
 
 
 # ---------------------------------------------------------------------------
-# 3. Progress is non-decreasing across the named steps
+# 3. Service ingest advances progress while remote import is still running
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_service_worker_advances_ogr2ogr_progress_while_remote_import_is_running(
+    test_db_session, monkeypatch
+):
+    """Service URL ingest must publish progress during the remote load window."""
+    from app.core import db as db_module
+    from app.processing.ingest import tasks_vector
+    from app.processing.ingest.ogr import IngestionError
+
+    admin_id = await _get_admin_id(test_db_session)
+
+    job = IngestJob(
+        source_filename="Add_addressPoint",
+        source_url="https://example.test/arcgis/rest/services/Address/FeatureServer",
+        source_layer="0",
+        created_by=admin_id,
+        status="pending",
+        user_metadata={
+            "title": "Add_addressPoint",
+            "visibility": "private",
+            "service_type": "ArcGIS FeatureServer",
+            "layer_id": "0",
+            "geometry_type": "Point",
+        },
+    )
+    test_db_session.add(job)
+    await test_db_session.flush()
+    await test_db_session.commit()
+    job_id = job.id
+
+    remote_import_started = asyncio.Event()
+    release_remote_import = asyncio.Event()
+    worker_error: Exception | None = None
+    last_progress: float | None = None
+
+    class _FakeProcessingPort:
+        def build_gdal_source(self, *args, **kwargs):
+            return "FAKE_GDAL_SOURCE", "0"
+
+    async def _validate_url_noop(_url: str) -> None:
+        return None
+
+    async def _fallback_calls_import_once(import_fn, source_layer, **kwargs) -> None:
+        await import_fn(source_layer)
+
+    async def _blocking_run_ogr2ogr_service(*args, **kwargs) -> None:
+        remote_import_started.set()
+        await release_remote_import.wait()
+        raise IngestionError("simulated remote service import stop")
+
+    monkeypatch.setattr(
+        "app.modules.catalog.sources.security.validate_url_for_ssrf",
+        _validate_url_noop,
+    )
+    monkeypatch.setattr(
+        "app.platform.extensions.get_processing_port",
+        lambda: _FakeProcessingPort(),
+    )
+    monkeypatch.setattr("app.processing.ingest.ogr.build_pg_conn_str", lambda: "PG:")
+    monkeypatch.setattr(
+        tasks_vector,
+        "_run_service_import_with_wfs_fallback",
+        _fallback_calls_import_once,
+    )
+    monkeypatch.setattr(
+        "app.processing.ingest.ogr.run_ogr2ogr_service",
+        _blocking_run_ogr2ogr_service,
+    )
+    monkeypatch.setattr(
+        tasks_vector,
+        "_SERVICE_IMPORT_HEARTBEAT_INTERVAL_SECONDS",
+        0.01,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        tasks_vector,
+        "_SERVICE_IMPORT_HEARTBEAT_INCREMENT",
+        0.2,
+        raising=False,
+    )
+
+    worker_task = asyncio.create_task(
+        tasks_vector.ingest_service.func(
+            job_id=str(job_id),
+            source_url="https://example.test/arcgis/rest/services/Address/FeatureServer",
+            source_layer="0",
+            user_id=str(admin_id),
+        )
+    )
+
+    try:
+        await asyncio.wait_for(remote_import_started.wait(), timeout=1)
+
+        deadline = asyncio.get_running_loop().time() + 1
+        while asyncio.get_running_loop().time() < deadline:
+            async with db_module.async_session() as poll_session:
+                result = await poll_session.execute(
+                    select(IngestJob).where(IngestJob.id == job_id)
+                )
+                current_job = result.scalar_one()
+                last_progress = current_job.progress
+                if last_progress is not None and last_progress > 0.1:
+                    break
+
+            assert not worker_task.done()
+            await asyncio.sleep(0.01)
+    finally:
+        release_remote_import.set()
+        try:
+            await asyncio.wait_for(worker_task, timeout=2)
+        except Exception as exc:
+            worker_error = exc
+
+    assert isinstance(worker_error, IngestionError)
+    assert last_progress is not None
+    assert last_progress > 0.1
+    assert last_progress < 0.7
+
+
+# ---------------------------------------------------------------------------
+# 4. Progress is non-decreasing across the named steps
 # ---------------------------------------------------------------------------
 
 

--- a/backend/tests/test_ingest_progress.py
+++ b/backend/tests/test_ingest_progress.py
@@ -362,7 +362,7 @@ async def test_service_worker_chunks_large_arcgis_imports(test_db_session, monke
         return table_name, None
 
     async def _fake_page_info(*args, **kwargs):
-        return 4500, 1000
+        return 4500, 1000, True
 
     async def _fake_run_ogr2ogr_service(
         gdal_source: str,
@@ -498,6 +498,134 @@ async def test_service_worker_chunks_large_arcgis_imports(test_db_session, monke
         await test_db_session.execute(text(f'SELECT COUNT(*) FROM data."{table_name}"'))
     ).scalar_one()
     assert row_count == 4500
+
+
+@pytest.mark.anyio
+async def test_service_worker_skips_arcgis_chunking_without_pagination_support(
+    test_db_session, monkeypatch
+):
+    """ArcGIS layers without supportsPagination should use the legacy import."""
+    from app.modules.catalog.sources.preview import build_gdal_source
+    from app.processing.ingest import tasks_vector
+
+    admin_id = await _get_admin_id(test_db_session)
+    table_name = f"tbl_arcgis_single_{_uuid.uuid4().hex[:8]}"
+
+    job = IngestJob(
+        source_filename="Legacy ArcGIS Layer",
+        source_url="https://example.test/arcgis/rest/services/Legacy/FeatureServer",
+        source_layer="0",
+        created_by=admin_id,
+        status="pending",
+        user_metadata={
+            "title": "Legacy ArcGIS Layer",
+            "visibility": "private",
+            "service_type": "ArcGIS FeatureServer",
+            "layer_id": "0",
+            "geometry_type": "Point",
+            "object_id_field": "FID",
+        },
+    )
+    test_db_session.add(job)
+    await test_db_session.flush()
+    await test_db_session.commit()
+    job_id = job.id
+
+    calls: list[dict[str, object]] = []
+
+    class _FakeProcessingPort:
+        def build_gdal_source(self, *args, **kwargs):
+            return build_gdal_source(*args, **kwargs)
+
+    async def _validate_url_noop(_url: str) -> None:
+        return None
+
+    async def _fake_generate_table_name(*args, **kwargs):
+        return table_name, None
+
+    async def _fake_page_info(*args, **kwargs):
+        return None, 1000, False
+
+    async def _fake_run_ogr2ogr_service(
+        gdal_source: str,
+        layer_name: str,
+        target_table: str,
+        db_conn_str: str,
+        service_type: str,
+        *,
+        append: bool = False,
+        **kwargs,
+    ) -> None:
+        query = parse_qs(urlsplit(gdal_source.removeprefix("ESRIJSON:")).query)
+        calls.append(
+            {
+                "has_limit": "resultRecordCount" in query,
+                "has_offset": "resultOffset" in query,
+                "append": append,
+                "target_table": target_table,
+                "layer_name": layer_name,
+                "service_type": service_type,
+            }
+        )
+
+    async def _fake_rename_reserved_columns(*args, **kwargs):
+        return []
+
+    async def _fake_finalize_ingest(context):
+        context.job.status = "complete"
+        context.job.current_step = "complete"
+        context.job.progress = 1.0
+        await context.session.commit()
+
+    async def _fake_emit_billing_event(*args, **kwargs):
+        return None
+
+    monkeypatch.setattr(
+        "app.modules.catalog.sources.security.validate_url_for_ssrf",
+        _validate_url_noop,
+    )
+    monkeypatch.setattr(
+        "app.platform.extensions.get_processing_port",
+        lambda: _FakeProcessingPort(),
+    )
+    monkeypatch.setattr("app.processing.ingest.ogr.build_pg_conn_str", lambda: "PG:")
+    monkeypatch.setattr(
+        "app.processing.ingest.service.generate_table_name",
+        _fake_generate_table_name,
+    )
+    monkeypatch.setattr(
+        tasks_vector,
+        "_fetch_arcgis_import_page_info",
+        _fake_page_info,
+    )
+    monkeypatch.setattr(
+        "app.processing.ingest.ogr.run_ogr2ogr_service",
+        _fake_run_ogr2ogr_service,
+    )
+    monkeypatch.setattr(
+        "app.processing.ingest.metadata.rename_reserved_columns",
+        _fake_rename_reserved_columns,
+    )
+    monkeypatch.setattr(tasks_vector, "_finalize_ingest", _fake_finalize_ingest)
+    monkeypatch.setattr(tasks_vector, "_emit_billing_event", _fake_emit_billing_event)
+
+    await tasks_vector.ingest_service.func(
+        job_id=str(job_id),
+        source_url="https://example.test/arcgis/rest/services/Legacy/FeatureServer",
+        source_layer="0",
+        user_id=str(admin_id),
+    )
+
+    assert calls == [
+        {
+            "has_limit": False,
+            "has_offset": False,
+            "append": False,
+            "target_table": table_name,
+            "layer_name": "",
+            "service_type": "arcgis_featureserver",
+        }
+    ]
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_ingest_progress.py
+++ b/backend/tests/test_ingest_progress.py
@@ -341,7 +341,6 @@ async def test_service_worker_chunks_large_arcgis_imports(test_db_session, monke
             "service_type": "ArcGIS FeatureServer",
             "layer_id": "0",
             "geometry_type": "Point",
-            "object_id_field": "FID",
         },
     )
     test_db_session.add(job)
@@ -362,7 +361,7 @@ async def test_service_worker_chunks_large_arcgis_imports(test_db_session, monke
         return table_name, None
 
     async def _fake_page_info(*args, **kwargs):
-        return 4500, 1000, True
+        return 4500, 1000, True, "FID"
 
     async def _fake_run_ogr2ogr_service(
         gdal_source: str,
@@ -382,6 +381,7 @@ async def test_service_worker_chunks_large_arcgis_imports(test_db_session, monke
             {
                 "offset": offset,
                 "limit": limit,
+                "order_by": query.get("orderByFields", [None])[0],
                 "append": append,
                 "target_table": target_table,
                 "layer_name": layer_name,
@@ -455,6 +455,7 @@ async def test_service_worker_chunks_large_arcgis_imports(test_db_session, monke
         {
             "offset": 0,
             "limit": 1000,
+            "order_by": "FID ASC",
             "append": False,
             "target_table": table_name,
             "layer_name": "",
@@ -463,6 +464,7 @@ async def test_service_worker_chunks_large_arcgis_imports(test_db_session, monke
         {
             "offset": 1000,
             "limit": 1000,
+            "order_by": "FID ASC",
             "append": True,
             "target_table": table_name,
             "layer_name": "",
@@ -471,6 +473,7 @@ async def test_service_worker_chunks_large_arcgis_imports(test_db_session, monke
         {
             "offset": 2000,
             "limit": 1000,
+            "order_by": "FID ASC",
             "append": True,
             "target_table": table_name,
             "layer_name": "",
@@ -479,6 +482,7 @@ async def test_service_worker_chunks_large_arcgis_imports(test_db_session, monke
         {
             "offset": 3000,
             "limit": 1000,
+            "order_by": "FID ASC",
             "append": True,
             "target_table": table_name,
             "layer_name": "",
@@ -487,6 +491,7 @@ async def test_service_worker_chunks_large_arcgis_imports(test_db_session, monke
         {
             "offset": 4000,
             "limit": 1000,
+            "order_by": "FID ASC",
             "append": True,
             "target_table": table_name,
             "layer_name": "",
@@ -544,7 +549,7 @@ async def test_service_worker_skips_arcgis_chunking_without_pagination_support(
         return table_name, None
 
     async def _fake_page_info(*args, **kwargs):
-        return None, 1000, False
+        return None, 1000, False, "FID"
 
     async def _fake_run_ogr2ogr_service(
         gdal_source: str,
@@ -620,6 +625,135 @@ async def test_service_worker_skips_arcgis_chunking_without_pagination_support(
         {
             "has_limit": False,
             "has_offset": False,
+            "append": False,
+            "target_table": table_name,
+            "layer_name": "",
+            "service_type": "arcgis_featureserver",
+        }
+    ]
+
+
+@pytest.mark.anyio
+async def test_service_worker_skips_arcgis_chunking_without_order_field(
+    test_db_session, monkeypatch
+):
+    """Offset chunking requires a stable ArcGIS object-id order field."""
+    from app.modules.catalog.sources.preview import build_gdal_source
+    from app.processing.ingest import tasks_vector
+
+    admin_id = await _get_admin_id(test_db_session)
+    table_name = f"tbl_arcgis_no_oid_{_uuid.uuid4().hex[:8]}"
+
+    job = IngestJob(
+        source_filename="Unordered ArcGIS Layer",
+        source_url="https://example.test/arcgis/rest/services/Unordered/FeatureServer",
+        source_layer="0",
+        created_by=admin_id,
+        status="pending",
+        user_metadata={
+            "title": "Unordered ArcGIS Layer",
+            "visibility": "private",
+            "service_type": "ArcGIS FeatureServer",
+            "layer_id": "0",
+            "geometry_type": "Point",
+        },
+    )
+    test_db_session.add(job)
+    await test_db_session.flush()
+    await test_db_session.commit()
+    job_id = job.id
+
+    calls: list[dict[str, object]] = []
+
+    class _FakeProcessingPort:
+        def build_gdal_source(self, *args, **kwargs):
+            return build_gdal_source(*args, **kwargs)
+
+    async def _validate_url_noop(_url: str) -> None:
+        return None
+
+    async def _fake_generate_table_name(*args, **kwargs):
+        return table_name, None
+
+    async def _fake_page_info(*args, **kwargs):
+        return 4500, 1000, True, None
+
+    async def _fake_run_ogr2ogr_service(
+        gdal_source: str,
+        layer_name: str,
+        target_table: str,
+        db_conn_str: str,
+        service_type: str,
+        *,
+        append: bool = False,
+        **kwargs,
+    ) -> None:
+        query = parse_qs(urlsplit(gdal_source.removeprefix("ESRIJSON:")).query)
+        calls.append(
+            {
+                "has_limit": "resultRecordCount" in query,
+                "has_offset": "resultOffset" in query,
+                "has_order": "orderByFields" in query,
+                "append": append,
+                "target_table": target_table,
+                "layer_name": layer_name,
+                "service_type": service_type,
+            }
+        )
+
+    async def _fake_rename_reserved_columns(*args, **kwargs):
+        return []
+
+    async def _fake_finalize_ingest(context):
+        context.job.status = "complete"
+        context.job.current_step = "complete"
+        context.job.progress = 1.0
+        await context.session.commit()
+
+    async def _fake_emit_billing_event(*args, **kwargs):
+        return None
+
+    monkeypatch.setattr(
+        "app.modules.catalog.sources.security.validate_url_for_ssrf",
+        _validate_url_noop,
+    )
+    monkeypatch.setattr(
+        "app.platform.extensions.get_processing_port",
+        lambda: _FakeProcessingPort(),
+    )
+    monkeypatch.setattr("app.processing.ingest.ogr.build_pg_conn_str", lambda: "PG:")
+    monkeypatch.setattr(
+        "app.processing.ingest.service.generate_table_name",
+        _fake_generate_table_name,
+    )
+    monkeypatch.setattr(
+        tasks_vector,
+        "_fetch_arcgis_import_page_info",
+        _fake_page_info,
+    )
+    monkeypatch.setattr(
+        "app.processing.ingest.ogr.run_ogr2ogr_service",
+        _fake_run_ogr2ogr_service,
+    )
+    monkeypatch.setattr(
+        "app.processing.ingest.metadata.rename_reserved_columns",
+        _fake_rename_reserved_columns,
+    )
+    monkeypatch.setattr(tasks_vector, "_finalize_ingest", _fake_finalize_ingest)
+    monkeypatch.setattr(tasks_vector, "_emit_billing_event", _fake_emit_billing_event)
+
+    await tasks_vector.ingest_service.func(
+        job_id=str(job_id),
+        source_url="https://example.test/arcgis/rest/services/Unordered/FeatureServer",
+        source_layer="0",
+        user_id=str(admin_id),
+    )
+
+    assert calls == [
+        {
+            "has_limit": False,
+            "has_offset": False,
+            "has_order": False,
             "append": False,
             "target_table": table_name,
             "layer_name": "",


### PR DESCRIPTION
## Summary

Fixes the Service URL import path for large remote layers in two parts:

- publishes bounded progress during the long service ogr2ogr loading phase so the UI no longer appears stalled at the initial value
- chunks large ArcGIS FeatureServer and MapServer imports into paged resultOffset / resultRecordCount queries, respecting the service maxRecordCount, and appends later chunks into the same target table
- keeps WFS and OGC API Features on the existing single-GDAL import path; the progress heartbeat still applies to all service imports

## Root Cause

Service imports only wrote progress at the start of ogr2ogr and then again during finalization. Large ArcGIS layers also ran as one unbounded ESRIJSON import, so a slow upstream service could hit the 1800 second subprocess timeout.

## Validation

- POSTGRES_PORT=5434 uv run pytest tests/test_ingest_progress.py tests/test_arcgis_auth.py::test_build_gdal_source_arcgis_result_offset tests/test_ogr_subprocess_env.py tests/test_ingest_service_geometry_type.py -q
- uv run ruff check app/processing/ingest/tasks_vector.py app/processing/ingest/ogr.py app/modules/catalog/sources/preview.py app/modules/catalog/sources/adapters/arcgis.py app/platform/extensions/defaults.py app/core/processing_port.py tests/test_ingest_progress.py tests/test_arcgis_auth.py
- uv run ruff format --check app/processing/ingest/tasks_vector.py app/processing/ingest/ogr.py app/modules/catalog/sources/preview.py app/modules/catalog/sources/adapters/arcgis.py app/platform/extensions/defaults.py app/core/processing_port.py tests/test_ingest_progress.py tests/test_arcgis_auth.py

## Follow-up

OGC API Features chunking is intentionally out of scope for this PR because that needs provider-specific handling of next links or pagination rather than ArcGIS REST offsets.