### PR TITLE
docs: add CLAUDE.md pointer, expand and correct AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,24 @@ The React/Vite frontend is in `frontend/src/`: `components/`, `pages/`, `hooks/`
 - `cd frontend && npm ci && npm run dev`: install frontend dependencies and start Vite.
 - `cd frontend && npm run build && npm run lint && npm run test:coverage`: run frontend gates.
 - `make openapi-check`, `make sdks-check`, `make cli-test`: validate API snapshots and SDK/CLI drift.
+- `make bump VERSION=X.Y.Z`: rewrite every version site atomically. Never edit a version string by hand; `make version-check` is the CI gate.
+
+### Running a single test
+
+- Backend, in-container: mirror `make test`'s env (the container's default uv cache is read-only), e.g. `docker compose exec api env UV_CACHE_DIR=/app/staging/uv-cache UV_PROJECT_ENVIRONMENT=/app/staging/geolens-api-test-venv uv run pytest -o cache_dir=/app/staging/.pytest_cache tests/test_foo.py::test_bar -v`.
+- Backend, on the host (needs Postgres at localhost:5434): `cd backend && set -a && source ../.env.test && set +a && uv run pytest tests/test_foo.py -v`.
+- Frontend: `cd frontend && npx vitest run src/path/foo.test.ts`.
+- E2E: `npx playwright test e2e/foo.spec.ts --project=chromium` (stack must be running).
+
+## Architecture
+
+Services (`docker-compose.yml`): Nginx (prod proxy; Vite proxy in dev) fronts the FastAPI `api` (catalog, search, OGC/STAC, vector tiles) and Titiler (COG raster tiles). A `worker` runs GDAL/ogr2ogr ingestion, dispatched via the Procrastinate job queue that lives *inside* PostgreSQL (no separate broker). PostgreSQL 17 (PostGIS + pgvector + pg_trgm) is the single source of truth; object storage is MinIO/S3; Valkey is the tile/query cache.
+
+Backend `backend/app/`: `modules/` (domain areas — `catalog` is the core, with `datasets`/`collections`/`records`/`features`/`maps`/`layers`/`search`/`sources`), `platform/` (shared services), `processing/` (ingest/export/raster/tiles/embeddings/ai), `standards/` (OGC/STAC/DCAT), `core/` (config, DB, permissions, edition). Access control is in `catalog/authorization.py`. The `datasets` domain is split into `service_X` sub-modules behind a re-export façade in `service.py` — import via the façade, never the sub-modules (architecture-guard test enforces this).
+
+Frontend `frontend/src/` (React 19, `@vis.gl/react-maplibre` v8 / maplibre-gl v5, TanStack Query, zustand, Tailwind): the map builder is `builder/`; all API calls go through `apiFetch()` in `api/client.ts`; the auth token lives in `useAuthStore` (persisted `geolens-auth`, read outside React via `useAuthStore.getState().token`); reuse UI primitives from `components/ui/`.
+
+CLI (`cli/geolens_cli/`) and SDKs (`sdks/`) wrap the API. SDKs are generated from `backend/openapi.json` — regenerate with `make sdks`, never hand-edit generated files (only `auth.*`/`__init__`/`index` wrappers are hand-maintained).
 
 ## Coding Style & Naming Conventions
 
@@ -34,7 +52,7 @@ Avoid bare, unscoped finding ids that only resolve in a private tracker.
 
 ## Testing Guidelines
 
-Backend tests use pytest with AnyIO; files follow `test_*.py`. Coverage in `backend/pyproject.toml` has a 58.5% minimum. For DB-backed tests, start Postgres with `docker compose up -d --wait db`; follow `.env.test.example` and `.github/workflows/ci.yml` for CI-style variables.
+Backend tests use pytest with AnyIO; files follow `test_*.py`. Coverage in `backend/pyproject.toml` has a 60% minimum (`fail_under`). For DB-backed tests, start Postgres with `docker compose up -d --wait db`; follow `.env.test.example` and `.github/workflows/ci.yml` for CI-style variables.
 
 Frontend tests use Vitest and Testing Library as `*.test.ts(x)` files or under `__tests__/`. E2E tests use Playwright and follow `*.spec.ts` in `e2e/`.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,15 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+**The canonical guide is [`AGENTS.md`](AGENTS.md).** It covers project structure, build/test commands (including running a single test), architecture and service topology, coding style, testing, commit/PR conventions, and the security pre-commit rules. Read it first; everything below is a Claude-specific quick reference that points into it.
+
+## Quick reference
+
+- **Dev stack:** `make dev` (up), `make down`, `make reset-db`, `make status`. Frontend at http://localhost:8080. Backend commands run inside the `api` container.
+- **Backend tests:** `make test` (parallel), `make test-sequential`. Single test: see AGENTS.md → *Running a single test*.
+- **Frontend (from `frontend/`):** `npm run build` is the CI gate; also `npm run lint`, `npm run test`.
+- **Before pushing schema-adjacent changes, run the drift gates:** `make openapi-check`, `make sdks-check`, `make alembic-check`, `make version-check`. Lint backend with `cd backend && uv run ruff check . && uv run ruff format --check .`.
+- **Versions are single-sourced:** never edit a version string — use `make bump VERSION=X.Y.Z`.
+- **i18n parity is a CI gate:** new `t()` keys need all four locales (en/es/fr/de); `defaultValue` alone fails `npm run test:i18n`.
+- **Security guardrails** (visibility-filter coverage, SSRF redirect revalidation, no leaked credential literals) are enforced by pre-commit hooks — see AGENTS.md → *Security pre-commit checklist* before touching data access, URL fetching, or boot-time config.


### PR DESCRIPTION
## What

- **`CLAUDE.md`** is now a thin pointer to `AGENTS.md` (single source of truth), matching the repo convention of one canonical agent guide instead of two files that drift.
- **`AGENTS.md`** gains an Architecture section (service topology, backend module map, frontend patterns, SDK generation), single-test recipes, and the `make bump` version note.

## Corrections

Two stale/incorrect facts were fixed while verifying the guide against the code:

- Coverage floor is **60%** (`fail_under` in `backend/pyproject.toml`), not 58.5%.
- The in-container single-test recipe now carries `make test`'s env vars (`UV_CACHE_DIR` / `UV_PROJECT_ENVIRONMENT` / `-o cache_dir`). A bare `docker compose exec api uv run pytest` fails because the container's default `~/.cache/uv` is read-only.

## Verification

All claims were checked against ground truth: `docker-compose.yml`, catalog sub-modules and the `service_X` façade guard, `apiFetch`/`useAuthStore`, `make sdks` generation, the security-checklist file paths, and the host single-test recipe (`POSTGRES_HOST=localhost`, `:5434`). Docs-only change — no code paths touched.