### PR TITLE
docs: import AGENTS.md into CLAUDE.md instead of summarizing it

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@ The React/Vite frontend is in `frontend/src/`: `components/`, `pages/`, `hooks/`
 ## Build, Test, and Development Commands
 
 - `make dev` / `make down`: start or stop the Docker Compose development stack.
-- `make migrate`: run Alembic migrations in the API container.
+- `make migrate`: run Alembic migrations in the API container. `make alembic-check` fails if the ORM models have drifted from the migration scripts (run it for schema-adjacent changes).
 - `make test` / `make test-cov`: run backend pytest and coverage.
 - `npm run e2e` or `npm run e2e:smoke`: run Playwright suites.
 - `cd frontend && npm ci && npm run dev`: install frontend dependencies and start Vite.
@@ -55,6 +55,8 @@ Avoid bare, unscoped finding ids that only resolve in a private tracker.
 Backend tests use pytest with AnyIO; files follow `test_*.py`. Coverage in `backend/pyproject.toml` has a 60% minimum (`fail_under`). For DB-backed tests, start Postgres with `docker compose up -d --wait db`; follow `.env.test.example` and `.github/workflows/ci.yml` for CI-style variables.
 
 Frontend tests use Vitest and Testing Library as `*.test.ts(x)` files or under `__tests__/`. E2E tests use Playwright and follow `*.spec.ts` in `e2e/`.
+
+New `t()` translation keys must be added to all four locales (en/es/fr/de); a `defaultValue` alone fails the `npm run test:i18n` locale-parity CI gate.
 
 ## Commit & Pull Request Guidelines
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,14 +2,6 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
-**The canonical guide is [`AGENTS.md`](AGENTS.md).** It covers project structure, build/test commands (including running a single test), architecture and service topology, coding style, testing, commit/PR conventions, and the security pre-commit rules. Read it first; everything below is a Claude-specific quick reference that points into it.
+The canonical guide is AGENTS.md, imported below so its full contents load into context automatically. Keep shared guidance in AGENTS.md, not here.
 
-## Quick reference
-
-- **Dev stack:** `make dev` (up), `make down`, `make reset-db`, `make status`. Frontend at http://localhost:8080. Backend commands run inside the `api` container.
-- **Backend tests:** `make test` (parallel), `make test-sequential`. Single test: see AGENTS.md → *Running a single test*.
-- **Frontend (from `frontend/`):** `npm run build` is the CI gate; also `npm run lint`, `npm run test`.
-- **Before pushing schema-adjacent changes, run the drift gates:** `make openapi-check`, `make sdks-check`, `make alembic-check`, `make version-check`. Lint backend with `cd backend && uv run ruff check . && uv run ruff format --check .`.
-- **Versions are single-sourced:** never edit a version string — use `make bump VERSION=X.Y.Z`.
-- **i18n parity is a CI gate:** new `t()` keys need all four locales (en/es/fr/de); `defaultValue` alone fails `npm run test:i18n`.
-- **Security guardrails** (visibility-filter coverage, SSRF redirect revalidation, no leaked credential literals) are enforced by pre-commit hooks — see AGENTS.md → *Security pre-commit checklist* before touching data access, URL fetching, or boot-time config.
+@AGENTS.md


### PR DESCRIPTION
## What

Replaces `CLAUDE.md`'s hand-written quick-reference (from #369) with a single `@AGENTS.md` import.

```markdown
The canonical guide is AGENTS.md, imported below ...

@AGENTS.md
```

## Why

Per the [Claude Code memory docs](https://code.claude.com/docs/en/memory) (updated 2026-06-30):

- Claude Code reads **only `CLAUDE.md`**, not `AGENTS.md` natively — so `CLAUDE.md` must exist as the entry point.
- An `@AGENTS.md` import **expands the full `AGENTS.md` into context at session start** — the documented single-source-of-truth pattern. The previous summary neither loaded the full guide nor stayed drift-free (it restated a few AGENTS.md facts inline).
- Portable across OSes, unlike a `CLAUDE.md → AGENTS.md` symlink, which degrades to a stub file on Windows checkouts without symlink support.

`AGENTS.md` is ~110 lines, well under the 200-line import budget. Docs-only change.

## Note

The first `@`-import in a fresh checkout can trigger a one-time approval prompt; repo-local imports are otherwise seamless.