### PR TITLE
fix(gates): check PyPI description via JSON API, not the HTML project page

### DIFF
--- a/scripts/check_deployed_surface.py
+++ b/scripts/check_deployed_surface.py
@@ -16,7 +16,7 @@ import sys
 from dataclasses import dataclass
 from html.parser import HTMLParser
 from pathlib import Path
-from typing import Callable, Sequence
+from typing import Callable, Iterator, Sequence
 from urllib.parse import urljoin, urlparse
 from urllib.error import HTTPError, URLError
 from urllib.request import HTTPRedirectHandler, Request, build_opener
@@ -275,6 +275,37 @@ def load_config(path: Path = DEFAULT_CONFIG) -> GateConfig:
     return GateConfig(timeout_seconds=timeout_seconds, max_bytes=max_bytes, pages=pages)
 
 
+def _iter_json_strings(value: object) -> "Iterator[str]":
+    if isinstance(value, str):
+        yield value
+    elif isinstance(value, dict):
+        for item in value.values():
+            yield from _iter_json_strings(item)
+    elif isinstance(value, list):
+        for item in value:
+            yield from _iter_json_strings(item)
+
+
+def decode_scannable_text(data: bytes, content_type: str) -> str:
+    """Decode a fetched response body to scannable text.
+
+    For JSON responses (e.g. the PyPI ``/pypi/<name>/json`` endpoint) the raw
+    bytes leave JSON escapes (``\\n``, ``\\uXXXX``) intact, so a forbidden
+    phrase wrapped across an escape (``community\\nor enterprise``) would evade
+    the assertions. Parse the JSON and join its decoded string values so escapes
+    are resolved before scanning. Falls back to the raw decoded text on any
+    parse failure or non-JSON content type.
+    """
+    text = data.decode("utf-8", errors="replace")
+    if "json" in content_type.lower():
+        try:
+            parsed = json.loads(text)
+        except ValueError:
+            return text
+        return "\n".join(_iter_json_strings(parsed))
+    return text
+
+
 def fetch_url(url: str, timeout_seconds: float, max_bytes: int) -> PageFetch:
     validate_deployed_url("configured page", url)
     request = Request(url, headers={"User-Agent": USER_AGENT})
@@ -283,6 +314,7 @@ def fetch_url(url: str, timeout_seconds: float, max_bytes: int) -> PageFetch:
         with opener.open(request, timeout=timeout_seconds) as response:
             data = response.read(max_bytes + 1)
             final_url = response.geturl()
+            content_type = response.headers.get_content_type()
             validate_deployed_url("final response", final_url)
     except HTTPError as exc:
         raise OSError(f"{url} returned HTTP {exc.code}") from exc
@@ -291,7 +323,7 @@ def fetch_url(url: str, timeout_seconds: float, max_bytes: int) -> PageFetch:
 
     if len(data) > max_bytes:
         raise OSError(f"{url} response exceeded max_bytes={max_bytes}")
-    return PageFetch(url=final_url, text=data.decode("utf-8", errors="replace"))
+    return PageFetch(url=final_url, text=decode_scannable_text(data, content_type))
 
 
 def normalize_text(text: str) -> str:

--- a/scripts/deployed_surface_gate.json
+++ b/scripts/deployed_surface_gate.json
@@ -407,27 +407,27 @@
     },
     {
       "id": "pypi_geolens_cli",
-      "url": "https://pypi.org/project/geolens-cli/",
+      "url": "https://pypi.org/pypi/geolens-cli/json",
       "required": [],
       "forbidden": [
         {
           "id": "community_or_enterprise",
           "pattern": "community\\s+or\\s+enterprise",
           "flags": "i",
-          "reason": "The published geolens-cli long description must not carry the stale 'community or enterprise' wording."
+          "reason": "The published geolens-cli long description (latest release, via the PyPI JSON API) must not carry the stale 'community or enterprise' wording. The /project/ HTML page serves a minimal bot response without the description, so the JSON endpoint is the reliable source."
         }
       ]
     },
     {
       "id": "pypi_geolens",
-      "url": "https://pypi.org/project/geolens/",
+      "url": "https://pypi.org/pypi/geolens/json",
       "required": [],
       "forbidden": [
         {
           "id": "community_or_enterprise",
           "pattern": "community\\s+or\\s+enterprise",
           "flags": "i",
-          "reason": "The published geolens long description must not carry the stale 'community or enterprise' wording."
+          "reason": "The published geolens long description (latest release, via the PyPI JSON API) must not carry the stale 'community or enterprise' wording."
         }
       ]
     }

--- a/tests/test_check_deployed_surface.py
+++ b/tests/test_check_deployed_surface.py
@@ -317,6 +317,23 @@ class DeployedSurfaceGateTest(unittest.TestCase):
                 )
             )
 
+    def test_json_response_is_decoded_before_scanning(self) -> None:
+        # PyPI /pypi/<name>/json returns the long description as a JSON string.
+        # A forbidden phrase wrapped across a newline arrives JSON-escaped as
+        # literal \n; decoding must resolve it so the assertion still matches.
+        raw = json.dumps({"info": {"description": "any GeoLens instance community\nor enterprise."}})
+        decoded = self.scanner.decode_scannable_text(raw.encode("utf-8"), "application/json")
+        self.assertIn("community\nor enterprise", decoded)
+        self.assertNotIn("\\n", decoded)
+        normalized = self.scanner.normalize_text(decoded)
+        self.assertRegex(normalized, r"community\s+or\s+enterprise")
+
+    def test_non_json_response_is_passed_through_unchanged(self) -> None:
+        html = b"<main>community or enterprise</main>"
+        self.assertEqual(html.decode(), self.scanner.decode_scannable_text(html, "text/html"))
+        # Malformed JSON falls back to the raw decoded text rather than raising.
+        self.assertEqual("{bad", self.scanner.decode_scannable_text(b"{bad", "application/json"))
+
     def test_default_config_covers_marketing_and_docs_requirements(self) -> None:
         config = self.scanner.load_config(CONFIG)
         pages = {page.id: page for page in config.pages}

--- a/tests/test_check_deployed_surface.py
+++ b/tests/test_check_deployed_surface.py
@@ -472,14 +472,14 @@ class DeployedSurfaceGateTest(unittest.TestCase):
                 ],
             },
             "pypi_geolens_cli": {
-                "url": "https://pypi.org/project/geolens-cli/",
+                "url": "https://pypi.org/pypi/geolens-cli/json",
                 "required": [],
                 "forbidden": [
                     ("community_or_enterprise", "community\\s+or\\s+enterprise", "i"),
                 ],
             },
             "pypi_geolens": {
-                "url": "https://pypi.org/project/geolens/",
+                "url": "https://pypi.org/pypi/geolens/json",
                 "required": [],
                 "forbidden": [
                     ("community_or_enterprise", "community\\s+or\\s+enterprise", "i"),


### PR DESCRIPTION
## Summary

Follow-up to #371. The `pypi_geolens_cli` / `pypi_geolens` deployed-surface checks were vacuously passing, which is a false-confidence gap in the launch gate.

## The bug

The two PyPI checks pointed at the `/project/<name>/` HTML pages. `pypi.org` serves a ~3KB minimal response to non-browser fetches (the checker's `urllib` UA), so the long description is absent from the fetched HTML and the `community or enterprise` forbidden pattern never matched — the gate passed even though the live `geolens-cli` 1.4.1 description still contains "community or enterprise".

## The fix

Point both checks at the PyPI JSON API (`/pypi/<name>/json`), whose `info.description` carries the full rendered long description and is served in full to programmatic clients (host stays `pypi.org`, already allowlisted).

## Verification

- `python3 -m unittest tests.test_check_public_surface tests.test_check_deployed_surface` — 32 OK
- Live gate now correctly **FAILS** on the stale `geolens-cli` 1.4.1 description (`community or enterprise` matched via JSON) and **passes** on `geolens`. It clears once `1.4.2` publishes a clean description from `cli/README.md`.

This makes GATE-04 actually detect the PyPI blocker instead of silently passing.
