### PR TITLE
fix(collections): invalidate catalog cache on create

### DIFF
--- a/backend/app/modules/catalog/collections/router.py
+++ b/backend/app/modules/catalog/collections/router.py
@@ -104,6 +104,10 @@ async def create_collection_endpoint(
         )
         await db.commit()
         await db.refresh(collection)
+        # Without this, an admin's newly created collection stays hidden behind
+        # the 60s catalog:collections:admin cache until it expires. Matches the
+        # invalidate call in the update/delete/dataset-membership handlers.
+        await invalidate_catalog_cache()
     except IntegrityError:
         await db.rollback()
         raise HTTPException(

--- a/backend/tests/test_collections.py
+++ b/backend/tests/test_collections.py
@@ -96,6 +96,38 @@ class TestCreateCollection:
         assert data["extent_bbox"] is None
         assert "id" in data
 
+    async def test_create_collection_invalidates_admin_list_cache(
+        self, client: AsyncClient, admin_auth_header: dict
+    ):
+        """Regression: create must bust the 60s admin list cache.
+
+        The list endpoint caches admin views under
+        ``catalog:collections:admin:{skip}:{limit}``. Before the fix, create
+        (unlike update/delete) did not call invalidate_catalog_cache(), so a
+        freshly created collection stayed hidden behind the stale cache — the
+        201 + success toast were real, but it never appeared in the list.
+        """
+        # Populate the admin list cache (default skip=0, limit=50).
+        first = await client.get("/catalog/collections/", headers=admin_auth_header)
+        assert first.status_code == 200
+        assert "Cache Bust Collection" not in {
+            c["name"] for c in first.json()["collections"]
+        }
+
+        created = await client.post(
+            "/catalog/collections/",
+            json={"name": "Cache Bust Collection"},
+            headers=admin_auth_header,
+        )
+        assert created.status_code == 201
+
+        # The very next list must reflect it — proving the cache was busted.
+        second = await client.get("/catalog/collections/", headers=admin_auth_header)
+        assert second.status_code == 200
+        assert "Cache Bust Collection" in {
+            c["name"] for c in second.json()["collections"]
+        }
+
     async def test_create_collection_as_editor(
         self, client: AsyncClient, editor_auth_header: dict
     ):


### PR DESCRIPTION
## Problem

Creating a collection in the demo showed the success toast but the collection appeared to never be created.

## Root cause

The collections **list** endpoint serves admins a 60-second Valkey cache keyed `catalog:collections:admin:{skip}:{limit}`. The **create** handler was the only mutation that never called `invalidate_catalog_cache()` — `update`, `delete`, and both dataset-membership handlers already do.

So for an admin, a freshly created collection stayed hidden behind the stale cache for up to 60s: the `201` and success toast were real and the row **was** persisted, but the list kept returning the cached page without it — looking like the create silently failed. Non-admins hit no server cache, so their creates showed instantly (which is why this only reproduces on the demo's admin account).

## Fix

One line: `await invalidate_catalog_cache()` after the create commits, matching the sibling handlers.

## Test

`test_create_collection_invalidates_admin_list_cache` populates the admin list cache, creates a collection, and asserts the next list reflects it. Verified it **fails without the fix and passes with it**. Full `TestCreateCollection` suite green; ruff clean.