### PR TITLE
fix(dataset): make AI metadata assist buttons discoverable

### DIFF
--- a/frontend/src/components/dataset/AiAssistButton.tsx
+++ b/frontend/src/components/dataset/AiAssistButton.tsx
@@ -16,11 +16,13 @@ export function AiAssistButton({ onClick, isPending, label }: AiAssistButtonProp
 
   return (
     <Button
-      variant="ghost"
+      variant="outline"
       size="xs"
       onClick={onClick}
       disabled={isPending}
-      className="text-muted-foreground hover:text-foreground"
+      // The assist buttons were muted ghost buttons users didn't notice; an
+      // outline + primary tint makes them read as a discoverable AI action.
+      className="border-primary/40 text-primary hover:bg-primary/10 hover:text-primary"
     >
       {isPending ? (
         <Loader2 className="h-3.5 w-3.5 animate-spin" />


### PR DESCRIPTION
## Problem

Users didn't notice the AI metadata assist on the dataset details page — it looked like there was no AI feature at all.

## Root cause

All four assist affordances (Generate summary, keyword AI Assist, Draft lineage, Draft quality statement) render from one shared component, `AiAssistButton`, which used the lowest-emphasis styling in the system: `ghost` variant + `size="xs"` + `text-muted-foreground` gray, parked at the right end of a section header. It read as decorative, so people's eyes slid right past it.

The feature itself works end-to-end (verified on the live demo as demoadmin: generate → accept → save persisted; all four endpoints return 200). This is purely a discoverability problem.

## Fix

One shared component → all four buttons change together: `ghost` → `outline` variant with a primary-color tint (`border-primary/40 text-primary`). Muted gray → outlined brand-blue pill, so it reads as a clickable AI action. Kept `size="xs"` so header layout is unchanged.

## Before / after

Muted gray "✨ AI Assist" (nearly invisible) → outlined brand-blue "✨ AI Assist".

## Verification

eslint clean, `tsc` clean, `DatasetPage.edit-affordances` tests 4/4 pass.