### PR TITLE
fix(api): drop 'OGC API Features compliance' wording from OpenAPI summary

### DIFF
--- a/backend/app/api/main.py
+++ b/backend/app/api/main.py
@@ -435,7 +435,7 @@ def _resolve_app_version() -> str:
 app = FastAPI(
     title="GeoLens API",
     version=_resolve_app_version(),
-    summary="PostGIS-native geospatial data catalog with OGC API Features compliance",
+    summary="PostGIS-native geospatial data catalog with OGC API Features and Records support",
     description=_DESCRIPTION,
     root_path="/api",
     docs_url=None if _is_production else "/docs",

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -15816,7 +15816,7 @@
       "name": "Apache 2.0",
       "url": "https://www.apache.org/licenses/LICENSE-2.0"
     },
-    "summary": "PostGIS-native geospatial data catalog with OGC API Features compliance",
+    "summary": "PostGIS-native geospatial data catalog with OGC API Features and Records support",
     "termsOfService": "https://github.com/geolens-io/geolens/blob/main/LICENSE",
     "title": "GeoLens API",
     "version": "1.4.2"

--- a/scripts/deployed_surface_gate.json
+++ b/scripts/deployed_surface_gate.json
@@ -34,7 +34,7 @@
         },
         {
           "id": "ogc_compliant_claim",
-          "pattern": "\\bOGC[- ]API[- ](?:Compliant|compliance)\\b|\\bOGC[- ](?:Compliant|compliance)\\b",
+          "pattern": "\\bOGC[- ]API\\b[^.\\n]*?\\b(?:Compliant|compliance)\\b|\\bOGC[- ](?:Compliant|compliance)\\b",
           "flags": "i",
           "reason": "Public copy should claim OGC API support, not certification or compliance status."
         }
@@ -242,7 +242,7 @@
       "forbidden": [
         {
           "id": "ogc_compliant_claim",
-          "pattern": "\\bOGC[- ]API[- ](?:Compliant|compliance)\\b|\\bOGC[- ](?:Compliant|compliance)\\b",
+          "pattern": "\\bOGC[- ]API\\b[^.\\n]*?\\b(?:Compliant|compliance)\\b|\\bOGC[- ](?:Compliant|compliance)\\b",
           "flags": "i",
           "reason": "Public copy should claim OGC API support, not certification or compliance status."
         },
@@ -305,7 +305,7 @@
         },
         {
           "id": "ogc_compliant_claim",
-          "pattern": "\\bOGC[- ]API[- ](?:Compliant|compliance)\\b|\\bOGC[- ](?:Compliant|compliance)\\b",
+          "pattern": "\\bOGC[- ]API\\b[^.\\n]*?\\b(?:Compliant|compliance)\\b|\\bOGC[- ](?:Compliant|compliance)\\b",
           "flags": "i",
           "reason": "Public copy should claim OGC API support, not certification or compliance status."
         }
@@ -330,7 +330,7 @@
         },
         {
           "id": "ogc_compliant_claim",
-          "pattern": "\\bOGC[- ]API[- ](?:Compliant|compliance)\\b|\\bOGC[- ](?:Compliant|compliance)\\b",
+          "pattern": "\\bOGC[- ]API\\b[^.\\n]*?\\b(?:Compliant|compliance)\\b|\\bOGC[- ](?:Compliant|compliance)\\b",
           "flags": "i",
           "reason": "Public copy should claim OGC API support, not certification or compliance status."
         }
@@ -355,7 +355,7 @@
         },
         {
           "id": "ogc_compliant_claim",
-          "pattern": "\\bOGC[- ]API[- ](?:Compliant|compliance)\\b|\\bOGC[- ](?:Compliant|compliance)\\b",
+          "pattern": "\\bOGC[- ]API\\b[^.\\n]*?\\b(?:Compliant|compliance)\\b|\\bOGC[- ](?:Compliant|compliance)\\b",
           "flags": "i",
           "reason": "Public copy should claim OGC API support, not certification or compliance status."
         }

--- a/scripts/public_surface_gate.json
+++ b/scripts/public_surface_gate.json
@@ -143,7 +143,7 @@
     },
     {
       "id": "ogc_compliant_claim",
-      "pattern": "\\bOGC[- ]API[- ](?:Compliant|compliance)\\b|\\bOGC[- ](?:Compliant|compliance)\\b",
+      "pattern": "\\bOGC[- ]API\\b[^.\\n]*?\\b(?:Compliant|compliance)\\b|\\bOGC[- ](?:Compliant|compliance)\\b",
       "flags": "i",
       "reason": "GeoLens should claim OGC API support, not public certification or compliance status."
     },

--- a/tests/test_check_deployed_surface.py
+++ b/tests/test_check_deployed_surface.py
@@ -350,7 +350,7 @@ class DeployedSurfaceGateTest(unittest.TestCase):
                     ("raw_ogc_collections_url", "localhost:8001/collections", "i"),
                     (
                         "ogc_compliant_claim",
-                        "\\bOGC[- ]API[- ](?:Compliant|compliance)\\b|\\bOGC[- ](?:Compliant|compliance)\\b",
+                        "\\bOGC[- ]API\\b[^.\\n]*?\\b(?:Compliant|compliance)\\b|\\bOGC[- ](?:Compliant|compliance)\\b",
                         "i",
                     ),
                 ],
@@ -419,7 +419,7 @@ class DeployedSurfaceGateTest(unittest.TestCase):
                 "forbidden": [
                     (
                         "ogc_compliant_claim",
-                        "\\bOGC[- ]API[- ](?:Compliant|compliance)\\b|\\bOGC[- ](?:Compliant|compliance)\\b",
+                        "\\bOGC[- ]API\\b[^.\\n]*?\\b(?:Compliant|compliance)\\b|\\bOGC[- ](?:Compliant|compliance)\\b",
                         "i",
                     ),
                     ("secure_token_embed", "with\\s+a\\s+secure\\s+token", "i"),
@@ -444,7 +444,7 @@ class DeployedSurfaceGateTest(unittest.TestCase):
                     ("raw_ogc_collections_url", "localhost:8001/collections", "i"),
                     (
                         "ogc_compliant_claim",
-                        "\\bOGC[- ]API[- ](?:Compliant|compliance)\\b|\\bOGC[- ](?:Compliant|compliance)\\b",
+                        "\\bOGC[- ]API\\b[^.\\n]*?\\b(?:Compliant|compliance)\\b|\\bOGC[- ](?:Compliant|compliance)\\b",
                         "i",
                     ),
                 ],
@@ -457,7 +457,7 @@ class DeployedSurfaceGateTest(unittest.TestCase):
                     ("raw_ogc_collections_url", "localhost:8001/collections", "i"),
                     (
                         "ogc_compliant_claim",
-                        "\\bOGC[- ]API[- ](?:Compliant|compliance)\\b|\\bOGC[- ](?:Compliant|compliance)\\b",
+                        "\\bOGC[- ]API\\b[^.\\n]*?\\b(?:Compliant|compliance)\\b|\\bOGC[- ](?:Compliant|compliance)\\b",
                         "i",
                     ),
                 ],
@@ -470,7 +470,7 @@ class DeployedSurfaceGateTest(unittest.TestCase):
                     ("raw_ogc_collections_url", "localhost:8001/collections", "i"),
                     (
                         "ogc_compliant_claim",
-                        "\\bOGC[- ]API[- ](?:Compliant|compliance)\\b|\\bOGC[- ](?:Compliant|compliance)\\b",
+                        "\\bOGC[- ]API\\b[^.\\n]*?\\b(?:Compliant|compliance)\\b|\\bOGC[- ](?:Compliant|compliance)\\b",
                         "i",
                     ),
                 ],


### PR DESCRIPTION
## Context

Pre-tag audit follow-up for v1.4.2. The reviewer flagged one lingering wording issue to fix **before** the release tag: the OpenAPI `summary` still made an OGC "compliance" claim, and the surface gates didn't catch that specific variant.

## Changes

- **`backend/app/api/main.py`** — API `summary`: `PostGIS-native geospatial data catalog with OGC API Features **compliance**` → `… with OGC API Features and Records **support**`. Avoids a compliance/conformance claim the project decided not to make unless formally proven. (The top-level `description` keeps its specific OGC Conformance Classes list — that's the formal proof, not a bare claim, so it's untouched.)
- **`backend/openapi.json`** — regenerated (`make openapi`). SDKs unchanged: the summary does not propagate to generated clients (`make sdks` produced no diff).
- **`scripts/public_surface_gate.json` + `scripts/deployed_surface_gate.json`** — broadened the OGC regex from `OGC[- ]API[- ](?:Compliant|compliance)` (which missed `OGC API Features compliance`) to `OGC[- ]API\b[^.\n]*?\b(?:Compliant|compliance)`, bounded so it won't cross a sentence.
- **`tests/test_check_deployed_surface.py`** — updated the pinned expected pattern.

## Companion

`getgeolens.com` PR #39 carries the matching vendored-snapshot summary change (docs API reference).

## Verification

`make openapi-check`, `make sdks` (no diff), `check_public_surface.py`, `check_version_coherence.py`, gate self-tests (34 passed), and a regex over/under-match check all green. Ruff clean.