### PR TITLE
docs(launch): route doc contributions publicly and retire demo guest creds

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -6,7 +6,7 @@ No CLA required -- the Apache 2.0 license covers all contributions. We do ask th
 
 ## Documentation
 
-Full user, admin, and API documentation lives at **[docs.getgeolens.com](https://docs.getgeolens.com)**. Source MDX files for the documentation site live in the [getgeolens-com repo](https://github.com/geolens-io/getgeolens.com/tree/main/docs/) under `docs/src/content/docs/guides/`. Submit product-doc fixes via PRs against that repo, not this one.
+Full user, admin, and API documentation lives at **[docs.getgeolens.com](https://docs.getgeolens.com)**. The docs site's source isn't public yet, so report doc problems as [issues in this repo](https://github.com/geolens-io/geolens/issues/new?labels=documentation) with the `documentation` label and we'll port the fixes over.
 
 Full narrative product docs live in the sibling `getgeolens.com` repo and are
 served at `docs.getgeolens.com`. Keep README images under `.github/assets/`,
@@ -263,7 +263,7 @@ For non-security bugs, feature requests, and questions, open an issue in the [Ge
 - Expected vs. actual behavior
 - Logs (`docker compose logs api worker | tail -200`)
 
-Search existing issues before opening a new one. For documentation bugs, file the issue in the [getgeolens.com repo](https://github.com/geolens-io/getgeolens.com/issues) instead.
+Search existing issues before opening a new one. For documentation bugs, open an issue here with the `documentation` label.
 
 ## Questions?
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ GeoLens is an open-source, self-hosted catalog and map builder for GIS and data 
 <p align="center">
   <a href="https://demo.getgeolens.com"><img src="https://img.shields.io/badge/%E2%96%B6%20Try%20the%20live%20demo-demo.getgeolens.com-2563eb?style=for-the-badge" alt="Try the live demo" /></a>
   <br />
-  <sub>No install required. Explore the map builder with sample maps. Sign in as <code>guest</code> / <code>GeoLensDemo1!</code></sub>
+  <sub>No install required. Browse the sample catalog and maps without an account, or sign in with Google, GitHub, or Microsoft to try the map builder. Demo data may be wiped at any time.</sub>
 </p>
 
 [![CI](https://github.com/geolens-io/geolens/actions/workflows/ci.yml/badge.svg)](https://github.com/geolens-io/geolens/actions/workflows/ci.yml)


### PR DESCRIPTION
Two P1 fixes from the 2026-07-01 announcement-readiness audit.

## Changes

**CONTRIBUTING.md: route doc contributions somewhere public.** Both doc-contribution pointers (product-doc fixes at the top, doc bugs under Reporting Issues) linked the `getgeolens.com` repo, which is not public, so outside contributors hit hard 404s. Doc issues now go to this repo's tracker via the `documentation` label, with a note that the docs-site source isn't public yet.

**README.md: remove the demo guest credentials.** The demo now offers anonymous browsing plus social sign-in (Google/GitHub/Microsoft) instead of a shared writable `guest` account. The demo blurb reflects that and keeps the data-wipe caveat.

## Impact

Docs only. No code, schema, API, or config changes. The `documentation` label already exists on this repo.

## Verification

- `grep -rn 'geolens-io/getgeolens' README*.md .github/` returns nothing, so no private-repo links remain in public docs.
- `grep -rn 'GeoLensDemo1\|guest' README*.md` returns nothing.
- pre-commit hooks (including gitleaks) pass.