### PR TITLE
docs(contributing): match the real good-first-issue label name

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -239,7 +239,7 @@ direct imports of split internals from outside the domain.
 
 ## First Contribution
 
-New to the project? Look for issues labeled **good-first-issue** in the [issue tracker](https://github.com/geolens-io/geolens/issues). These are scoped, well-described tasks suitable for getting familiar with the codebase.
+New to the project? Look for issues labeled [**good first issue**](https://github.com/geolens-io/geolens/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) in the issue tracker. These are scoped, well-described tasks suitable for getting familiar with the codebase.
 
 If you're unsure where to start, open an issue describing what you'd like to work on and we'll point you in the right direction.
 


### PR DESCRIPTION
One-line follow-up from the announcement-readiness audit (P2-1).

CONTRIBUTING told newcomers to search for a hyphenated `good-first-issue` label, but the repo's label is the spaced `good first issue`, so the documented search returned an empty list. The text now links the label query directly. Three starter issues (#378, #379, #380) are filed under the label, so the on-ramp is no longer empty.