### PR TITLE
docs: complete the 1.4.2 changelog, condition semantic-search claims, fix SECURITY.md repo link

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -36,7 +36,7 @@ This policy covers:
 - Official packages published to PyPI (`geolens`, `geolens-cli`) and npm (`@geolens/sdk`)
 - The public demo at demo.getgeolens.com
 
-Out of scope here (report to the respective repo or contact): the marketing/docs website (getgeolens.com), and Helm/deployment packaging (geolens-deployments, geolens-helm).
+Out of scope here (report to the respective repo or contact): the marketing/docs website (getgeolens.com), and Helm/deployment packaging ([geolens-deployments](https://github.com/geolens-io/geolens-deployments)).
 
 ## Recognition
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,20 @@ and releases use semantic versioning.
   OpenAPI schema and the generated docs API reference. They still work at
   runtime for administrators; only their listing in the public schema is
   removed. The Python and TypeScript SDKs are regenerated to match.
+- **The OpenAPI description drops the compliance-status wording for the OGC
+  endpoints.** The published API summary now says the API implements the OGC
+  API building blocks; formal conformance is reported by the `/conformance`
+  endpoint itself.
+
+### Fixed
+
+- **New collections appear in the catalog immediately.** The collection
+  create endpoint now invalidates the catalog list cache like every other
+  collection mutation, so a just-created collection no longer looks like it
+  silently failed until the cache expired.
+- **The dataset page's AI metadata assist is easier to spot.** The Generate
+  summary, keyword assist, lineage, and quality-statement buttons no longer
+  use the lowest-emphasis styling that made them read as decorative.
 
 ## [1.4.1] - 2026-06-28
 

--- a/README.de.md
+++ b/README.de.md
@@ -4,7 +4,7 @@
 
 **Die raumbezogenen Daten Ihres Teams, an einem Ort durchsuchbar.**
 
-Laden Sie Shapefiles, GeoTIFFs, GeoPackages oder CSVs hoch. GeoLens speichert alles in PostGIS, indexiert Metadaten mit pgvector + pg_trgm für semantische und unscharfe Suche und stellt OGC APIs bereit, die QGIS, ArcGIS und MapLibre Clients direkt nutzen können. Es basiert auf FastAPI und React und lässt sich mit einem einzigen Befehl bereitstellen.
+Laden Sie Shapefiles, GeoTIFFs, GeoPackages oder CSVs hoch. GeoLens speichert alles in PostGIS, indexiert Metadaten mit pg_trgm für unscharfe Suche (pgvector ergänzt semantische Suche, sobald ein Embedding-Anbieter konfiguriert und die Option in den Einstellungen aktiviert ist) und stellt OGC APIs bereit, die QGIS, ArcGIS und MapLibre Clients direkt nutzen können. Es basiert auf FastAPI und React und lässt sich mit einem einzigen Befehl bereitstellen.
 
 > Dies ist eine gekürzte Übersetzung. Das englische [README](README.md) ist die kanonische Quelle; die vollständige, stets aktuelle deutschsprachige Dokumentation finden Sie unter **[docs.getgeolens.com/de](https://docs.getgeolens.com/de)**.
 

--- a/README.es.md
+++ b/README.es.md
@@ -4,7 +4,7 @@
 
 **Los datos espaciales de tu equipo, buscables en un solo lugar.**
 
-Sube Shapefiles, GeoTIFFs, GeoPackages o CSVs. GeoLens guarda todo en PostGIS, indexa los metadatos con pgvector + pg_trgm para búsqueda semántica y difusa, y sirve APIs OGC que QGIS, ArcGIS y clientes MapLibre pueden usar de forma nativa. Está construido con FastAPI y React, y se despliega con un solo comando.
+Sube Shapefiles, GeoTIFFs, GeoPackages o CSVs. GeoLens guarda todo en PostGIS, indexa los metadatos con pg_trgm para búsqueda difusa (pgvector añade búsqueda semántica al configurar un proveedor de embeddings y activar la opción en los ajustes), y sirve APIs OGC que QGIS, ArcGIS y clientes MapLibre pueden usar de forma nativa. Está construido con FastAPI y React, y se despliega con un solo comando.
 
 > Esta es una traducción resumida. El [README en inglés](README.md) es la fuente canónica; la documentación completa y actualizada en español está en **[docs.getgeolens.com/es](https://docs.getgeolens.com/es)**.
 

--- a/README.fr.md
+++ b/README.fr.md
@@ -4,7 +4,7 @@
 
 **Les données spatiales de votre équipe, consultables au même endroit.**
 
-Importez des Shapefiles, GeoTIFFs, GeoPackages ou CSVs. GeoLens stocke tout dans PostGIS, indexe les métadonnées avec pgvector + pg_trgm pour la recherche sémantique et approximative, et expose des APIs OGC utilisables directement par QGIS, ArcGIS et les clients MapLibre. L'application est construite avec FastAPI et React, et se déploie avec une seule commande.
+Importez des Shapefiles, GeoTIFFs, GeoPackages ou CSVs. GeoLens stocke tout dans PostGIS, indexe les métadonnées avec pg_trgm pour la recherche approximative (pgvector ajoute la recherche sémantique une fois un fournisseur d'embeddings configuré et l'option activée dans les réglages), et expose des APIs OGC utilisables directement par QGIS, ArcGIS et les clients MapLibre. L'application est construite avec FastAPI et React, et se déploie avec une seule commande.
 
 > Ceci est une traduction abrégée. Le [README anglais](README.md) est la source canonique ; la documentation complète et à jour en français est disponible sur **[docs.getgeolens.com/fr](https://docs.getgeolens.com/fr)**.
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 **Your team's spatial data: searchable, mappable, and shareable in one place.**
 
-GeoLens is an open-source, self-hosted catalog and map builder for GIS and data teams: a single home for spatial data that you run on infrastructure you control, with no telemetry. GeoLens itself phones home to nothing. (Features you opt into can make outbound calls: AI assist to your chosen OpenAI-compatible endpoint or Anthropic key, OAuth/OIDC sign-in, SMTP, basemap tiles, remote/S3 data sources, and off-site backups.) Upload Shapefiles, GeoTIFFs, GeoPackages, or CSVs (or register data you already have); GeoLens stores everything in PostGIS, indexes it with pgvector + pg_trgm for semantic and fuzzy search, and serves OGC/STAC APIs that QGIS, ArcGIS, and MapLibre clients connect to natively. Compose, style, and share multi-layer maps right in the browser. Built on FastAPI and React. Deployed with one command.
+GeoLens is an open-source, self-hosted catalog and map builder for GIS and data teams: a single home for spatial data that you run on infrastructure you control, with no telemetry. GeoLens itself phones home to nothing. (Features you opt into can make outbound calls: AI assist to your chosen OpenAI-compatible endpoint or Anthropic key, OAuth/OIDC sign-in, SMTP, basemap tiles, remote/S3 data sources, and off-site backups.) Upload Shapefiles, GeoTIFFs, GeoPackages, or CSVs (or register data you already have); GeoLens stores everything in PostGIS, indexes it with pg_trgm for fuzzy search out of the box (pgvector adds semantic ranking once you configure an embedding provider and enable semantic search), and serves OGC/STAC APIs that QGIS, ArcGIS, and MapLibre clients connect to natively. Compose, style, and share multi-layer maps right in the browser. Built on FastAPI and React. Deployed with one command.
 
 <p align="center">
   <a href="https://demo.getgeolens.com"><img src="https://img.shields.io/badge/%E2%96%B6%20Try%20the%20live%20demo-demo.getgeolens.com-2563eb?style=for-the-badge" alt="Try the live demo" /></a>
@@ -66,7 +66,7 @@ GeoLens replaces that workflow:
 
 - **One catalog:** upload Shapefiles, GeoPackages, GeoTIFFs, or CSVs and they become searchable, previewable, and exportable in minutes
 - **Works with your tools:** OGC API Features/Records, STAC API 1.0, direct tile URLs for QGIS, ArcGIS, and MapLibre
-- **Semantic and spatial search:** find datasets by meaning rather than exact keywords, powered by pgvector and pg_trgm full-text search
+- **Semantic and spatial search:** pg_trgm fuzzy matching out of the box; add an embedding provider and enable semantic search to rank datasets by meaning (pgvector)
 - **Built-in map builder:** compose multi-layer maps, style them, and share via public link or embeddable iframe
 - **AI-assisted (optional):** chat with your maps, auto-generate descriptions, search by natural language. Bring an OpenAI-compatible endpoint or Anthropic key, or skip it entirely
 
@@ -79,7 +79,7 @@ TOKEN=$(curl -s -X POST http://localhost:8080/api/auth/login/ \
   -d 'username=admin&password=<your-admin-password>' | jq -r '.access_token')
 ```
 
-Search datasets by meaning instead of exact keyword matches:
+Semantic search takes a one-time admin setup: an embedding provider and the AI + Semantic Search toggles in the admin AI settings, plus an embedding backfill for data ingested before setup (the [search guide](https://docs.getgeolens.com/guides/user/search/) walks through it). Once that's on, search datasets by meaning instead of exact keyword matches:
 
 ```bash
 # Semantic search ranks by meaning: "hydrology" surfaces subwatersheds, lakes,
@@ -100,7 +100,7 @@ CID=$(curl -s "http://localhost:8080/api/search/datasets/?q=countries&limit=1" \
 curl "http://localhost:8080/api/collections/$CID/items?bbox=-10,35,30,60&limit=5"
 ```
 
-PostGIS and pgvector share one database, so you can rank datasets by meaning *inside* a spatial window in a single query. See the [search guide](https://docs.getgeolens.com/guides/user/search/) for how semantic and spatial search work together.
+PostGIS and pgvector share one database, so with semantic search enabled you can rank datasets by meaning *inside* a spatial window in a single query. See the [search guide](https://docs.getgeolens.com/guides/user/search/) for how semantic and spatial search work together.
 
 Connect directly from QGIS: **Layer > Add WFS / OGC API Features** and point at `http://localhost:8080/api/`.
 


### PR DESCRIPTION
Follow-ups P2-5, P2-6, and P2-10 from the announcement-readiness audit.

## Changes

**CHANGELOG 1.4.2 completeness (P2-5).** The entry listed only the OpenAPI schema change and omitted two user-facing fixes that shipped in the release: collection creation now invalidating the catalog cache (#373) and the AI metadata assist discoverability fix (#374). Both get `### Fixed` bullets, and the OpenAPI compliance-wording change (#375) gets a `### Changed` bullet. After merge the v1.4.2 GitHub release notes should be updated to match, keeping the release body identical to the changelog section.

**Semantic-search claims conditioned (P2-6).** The README presented semantic search as working out of the box, but it needs a configured embedding provider (`embedding_base_url` defaults to none); pg_trgm fuzzy search is the out-of-the-box behavior. The intro sentence, the search example lead-in, and the pgvector paragraph now say so, in all four locale READMEs, matching the wording the marketing site and docs already use.

**SECURITY.md repo link (P2-10).** The out-of-scope note pointed packaging reports at `geolens-helm`, which is not a public repo, so the reference dead-ended for readers. It now names only the public `geolens-deployments` repo, linked.

## Verification

- `grep -c 'geolens-helm' .github/SECURITY.md` returns 0.
- Semantic phrasing now matches the marketing/docs framing (checked against `getgeolens.com` copy).
- Docs only; no code, schema, or config changes.