### PR TITLE
fix(ai): drop temperature on Anthropic path, Decimal-safe serialization, plain-text chat output

### DIFF
--- a/backend/app/platform/extensions/defaults.py
+++ b/backend/app/platform/extensions/defaults.py
@@ -1004,6 +1004,7 @@ class DefaultAnthropicProvider:
         base_url=None,
         temperature=0.5,
     ):
+        del temperature  # rejected by Claude 4.6+; kept in signature for callers
         # Deferred imports (Phase 214 discipline)
         import json
 
@@ -1059,10 +1060,11 @@ class DefaultAnthropicProvider:
             # ("tools: must have at least 1 item"). Omit the kwarg entirely
             # for no-tools paths (sql_generator.generate_sql,
             # _retry_parse_map_spec). REVIEW.md CR-01.
+            # Claude 4.6+ models reject a non-default `temperature` with a
+            # 400; omit it on the Anthropic path (steering is prompt-based).
             create_kwargs: dict[str, object] = {
                 "model": model,
                 "max_tokens": max_tokens,
-                "temperature": temperature,
                 "system": cached_system,
                 "messages": messages,
             }
@@ -1183,10 +1185,12 @@ class DefaultAnthropicProvider:
             response_model=response_model.__name__,
         )
 
+        # Claude 4.6+ models reject a non-default `temperature` with a 400;
+        # omit it on the Anthropic path (steering is prompt-based).
+        del temperature
         response = await client.messages.create(
             model=model,
             max_tokens=max_tokens,
-            temperature=temperature,
             system=system_prompt,
             messages=[{"role": "user", "content": user_message}],
             tools=[tool],

--- a/backend/app/processing/ai/chat_service.py
+++ b/backend/app/processing/ai/chat_service.py
@@ -297,6 +297,9 @@ You are a map editing assistant. The user has a map with these layers:
 - query_data takes a natural language question -- the server generates and
   executes the SQL safely.
 - Keep your explanations concise (1-3 sentences).
+- Respond in PLAIN TEXT only. The chat panel does not render markdown: never
+  use **bold**, headers, backticks, or [links](...). Simple "- " bullet lines
+  are fine.
 - For raster layers (marked "[raster layer]"), only use set_opacity (with layer_id and opacity 0.0-1.0) or toggle_visibility. Do not use set_style, set_filter, set_label, or set_data_driven_style on raster layers.
 - To add a raster dataset as a layer, use search_datasets then add_layer — same as vector.
 - The current basemap is: {basemap_style or "unknown"}.{" This is a dark basemap — use light colors for labels (#e5e7eb) and outlines (#d1d5db)." if basemap_style and "dark" in basemap_style.lower() else " Use dark colors for labels (#333333) and outlines (#374151)."}

--- a/backend/app/processing/ai/router.py
+++ b/backend/app/processing/ai/router.py
@@ -325,7 +325,10 @@ async def generate_map_stream_endpoint(
             ):
                 if await request.is_disconnected():
                     break
-                yield ServerSentEvent(data=json.dumps(event), event=event["type"])
+                # default=str: events can carry Decimal/datetime from query_data rows
+                yield ServerSentEvent(
+                    data=json.dumps(event, default=str), event=event["type"]
+                )
         except Exception:  # broad: SSE stream generator — any unhandled error must yield a graceful error event
             logger.exception("Map generation stream error")
             yield ServerSentEvent(
@@ -447,7 +450,10 @@ async def chat_stream_endpoint(
             ):
                 if await request.is_disconnected():
                     break
-                yield ServerSentEvent(data=json.dumps(event), event=event["type"])
+                # default=str: events can carry Decimal/datetime from query_data rows
+                yield ServerSentEvent(
+                    data=json.dumps(event, default=str), event=event["type"]
+                )
         except Exception:  # broad: SSE stream generator — any unhandled error must yield a graceful error event
             logger.exception("Chat stream error")
             yield ServerSentEvent(

--- a/backend/app/processing/ai/streaming.py
+++ b/backend/app/processing/ai/streaming.py
@@ -183,10 +183,11 @@ async def _stream_anthropic_chat(
         buffered_tokens: list[str] = []
         has_tool_use = False
 
+        # Claude 4.6+ models reject a non-default `temperature` with a 400;
+        # omit it on the Anthropic path (steering is prompt-based there).
         async with client.messages.stream(
             model=model,
             max_tokens=4096,
-            temperature=0.3,
             system=cached_system,
             tools=cached_tools,
             messages=messages,
@@ -259,8 +260,11 @@ async def _stream_anthropic_chat(
                         {
                             "type": "tool_result",
                             "tool_use_id": block.id,
+                            # default=str: query_data rows can carry Decimal /
+                            # datetime values straight from PostGIS.
                             "content": json.dumps(
-                                raw_results[0] if raw_results else {}
+                                raw_results[0] if raw_results else {},
+                                default=str,
                             ),
                         }
                     )
@@ -524,7 +528,8 @@ async def _stream_openai_chat(
                     {
                         "role": "tool",
                         "tool_call_id": call_id,
-                        "content": json.dumps(result),
+                        # default=str: see the Anthropic tool_result path above.
+                        "content": json.dumps(result, default=str),
                     }
                 )
             continue


### PR DESCRIPTION
## What

Three small, self-contained fixes to the AI chat stack, all verified live against the local dev stack (end-to-end Ask AI spatial query returning Decimal-carrying SQL results):

1. **Drop `temperature` at the three Anthropic call sites** (`DefaultAnthropicProvider.complete`, its structured-output method, and `_stream_anthropic_chat`). Claude 4.6+ models reject a non-default `temperature` with a 400. The provider-agnostic `complete()`/`structured_complete()` signatures are unchanged — the Anthropic provider now discards the kwarg, while the OpenAI-compatible path (`DefaultOpenAICompatibleProvider`, `_stream_openai_chat`) still sends it, which gpt-4.1-mini accepts.
2. **`json.dumps(..., default=str)` at tool-result and SSE sites** (both stream emitters in `processing/ai/router.py`, the Anthropic `tool_result` content and OpenAI `tool` message content in `streaming.py`). `query_data` rows can carry Postgres `numeric` (Decimal) and `datetime` values straight from PostGIS, which crashed serialization on every provider path.
3. **Plain-text rule in the chat system prompt** (`build_chat_system_prompt`). ChatPanel renders message content raw, so markdown arrived as literal `**bold**`/backticks on every provider.

## Impact

- No schema, API-contract, or config changes. No OpenAPI/SDK regeneration needed.
- Fixes two bugs that are currently live on the demo's Azure OpenAI path (Decimal crash, markdown artifacts) — should be deployed to the demo VM after merge.

## Verification

- `cd backend && uv run ruff check .` and `uv run ruff format --check .` — green
- Pre-commit hooks (SSRF rule, secrets, ruff) — green
- Live: restarted `api` on the dev stack; AI chat answers in plain text and a spatial `query_data` question returning Decimal columns streams a results table without error; Anthropic provider (`claude-sonnet-5`) no longer 400s