### PR TITLE
fix(ai): Decimal-safe tool results in provider complete() tool loops

### DIFF
--- a/backend/app/platform/extensions/defaults.py
+++ b/backend/app/platform/extensions/defaults.py
@@ -1114,7 +1114,9 @@ class DefaultAnthropicProvider:
                             {
                                 "type": "tool_result",
                                 "tool_use_id": block.id,
-                                "content": json.dumps(result),
+                                # default=str: query_data rows can carry Decimal /
+                                # datetime values straight from PostGIS.
+                                "content": json.dumps(result, default=str),
                             }
                         )
 
@@ -1394,7 +1396,8 @@ class DefaultOpenAICompatibleProvider:
                         {
                             "role": "tool",
                             "tool_call_id": tool_call.id,
-                            "content": json.dumps(result),
+                            # default=str: see the Anthropic tool_result path above.
+                            "content": json.dumps(result, default=str),
                         }
                     )
                 continue


### PR DESCRIPTION
## What

Follow-up to #387. That PR added `default=str` at the streaming tool-result sites but missed the two `json.dumps(result)` calls inside the provider `complete()` tool loops in `backend/app/platform/extensions/defaults.py` (Anthropic `tool_result` content and OpenAI-compatible `tool` message content). Those loops serve the **non-streaming** `POST /ai/chat/` endpoint (used by `frontend/src/api/maps.ts` and both SDKs), so a `query_data` result carrying Postgres `numeric` (Decimal) values still crashed with a 500.

## How it was found

Live smoke on the demo after deploying #387: an income-average question against the NY Income map returned `TypeError: Object of type Decimal is not JSON serializable` — the SQL executed fine and computed the answer; serialization into the tool loop crashed. Also swept every remaining `json.dumps` in the AI paths: the rest are static error events or request-supplied JSON (no DB rows), so these two sites complete the fix.

## Verification

- `cd backend && uv run ruff check` / `ruff format --check` — green
- Post-merge: redeploy demo and re-run the same non-streaming chat smoke (expect 200 with the computed average)