### PR TITLE
ci(frontend): make TypeScript check a real gate (tsc -b, not no-op)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1027,7 +1027,10 @@ jobs:
         run: npm run lint
 
       - name: TypeScript check
-        run: npx tsc --noEmit
+        # `npx tsc --noEmit` is a no-op here: the solution-style root tsconfig has an
+        # empty `files`/`include`, so it compiles nothing and always exits 0. The real
+        # type gate is `tsc -b --noEmit`, which walks the project references.
+        run: npm run typecheck
 
   frontend-test:
     name: Frontend Tests


### PR DESCRIPTION
## Problem
The `Frontend Lint & Typecheck` job ran `npx tsc --noEmit` (ci.yml:1030). Against the solution-style root `tsconfig` that has an empty program, this compiles nothing and **always exits 0** — so frontend type regressions could land on `main` unchecked. This mirrors the well-known repo gotcha that the real type gate is `npm run typecheck` (`tsc -b --noEmit`), which walks the project references.

## Fix
Switch the step to `npm run typecheck` and add a comment explaining why the old form was inert.

## Verification
`npm run typecheck` passes clean on current `main` (exit 0, no errors), so this change surfaces **no** pre-existing errors — it just prevents future ones from slipping through.

https://claude.ai/code/session_01PDW786uH6nfZBzvWTMK2sd