### PR TITLE
fix(builder): remediate 2026-07-03 audit findings (B-019..B-032)

### DIFF
--- a/backend/app/modules/catalog/features/router.py
+++ b/backend/app/modules/catalog/features/router.py
@@ -4,19 +4,33 @@ import uuid
 from urllib.parse import urlencode
 
 import structlog
-from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response, status
+from fastapi import (
+    APIRouter,
+    Depends,
+    Header,
+    HTTPException,
+    Query,
+    Request,
+    Response,
+    status,
+)
 from fastapi.responses import JSONResponse
 from sqlalchemy.exc import OperationalError, ProgrammingError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.modules.audit.service import AuditEvent, audit_emit
 from app.core.identity import Identity
-from app.modules.auth.dependencies import get_current_active_user, require_permission
+from app.modules.auth.dependencies import (
+    get_current_active_user,
+    get_optional_user,
+    require_permission,
+)
 from app.modules.catalog.authorization import (
     check_dataset_access,
     check_dataset_write_access,
 )
 from app.modules.catalog.datasets.domain.service import get_dataset
+from app.modules.embed_tokens.service import validate_embed_token_access
 from app.core.dependencies import get_db
 from app.modules.catalog.features.schemas import (
     FeatureCreate,
@@ -58,10 +72,28 @@ features_router = APIRouter(prefix="/datasets", tags=["Features"])
 )
 async def get_features_geojson_z_endpoint(
     dataset_id: uuid.UUID,
-    user: Identity = Depends(get_current_active_user),
+    request: Request,
+    user: Identity | None = Depends(get_optional_user),
+    embed_token: str | None = Header(
+        default=None,
+        alias="X-Embed-Token",
+        description=(
+            "Optional embed token. Datasets in the token's scope are "
+            "authorized even without user credentials (embed viewers)."
+        ),
+    ),
     db: AsyncSession = Depends(get_db),
 ) -> JSONResponse:
-    """Return up to 5,000 features as RFC 7946 GeoJSON with Z coordinates."""
+    """Return up to 5,000 features as RFC 7946 GeoJSON with Z coordinates.
+
+    fix(#394) codex P2: the viewer's bounded-GeoJSON path (small 3D layers,
+    eligible cluster layers) already sends ``X-Embed-Token``, and the B-023
+    shared-map union now exposes embed-scoped private layers to embeds — so
+    this endpoint accepts the token as fallback authorization via the SAME
+    ``validate_embed_token_access`` capability check as tile serving.
+    Credentialed callers (JWT / API key) keep the exact prior RBAC path;
+    anonymous callers without a valid scoped token still get 401.
+    """
     dataset = await get_dataset(db, dataset_id)
     if dataset is None:
         raise HTTPException(
@@ -69,7 +101,20 @@ async def get_features_geojson_z_endpoint(
             detail="Dataset not found",
         )
 
-    await check_dataset_access(db, dataset, dataset_id, user)
+    embed_ok = bool(embed_token) and await validate_embed_token_access(
+        embed_token,  # type: ignore[arg-type]  # bool() guard above
+        dataset_id,
+        db,
+        request,
+    )
+    if not embed_ok:
+        if user is None:
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="Not authenticated",
+                headers={"WWW-Authenticate": "Bearer"},
+            )
+        await check_dataset_access(db, dataset, dataset_id, user)
 
     # fix(#315): raster/VRT datasets have no backing PostGIS feature table, so a feature
     # query would raise UndefinedTableError -> 500 (and hold a DB connection).

--- a/backend/app/modules/catalog/maps/_router_helpers.py
+++ b/backend/app/modules/catalog/maps/_router_helpers.py
@@ -74,6 +74,7 @@ def _meta_to_kwargs(meta) -> DatasetMetaKwargs:
             is_dem=None,
             dem_vertical_units=None,
             band_count=None,
+            tile_version=None,
         )
     return DatasetMetaKwargs(
         dataset_name=meta.title,
@@ -88,6 +89,7 @@ def _meta_to_kwargs(meta) -> DatasetMetaKwargs:
         is_dem=meta.is_dem,
         dem_vertical_units=meta.dem_vertical_units,
         band_count=meta.band_count,
+        tile_version=meta.tile_version,
     )
 
 
@@ -123,6 +125,7 @@ def _build_layer_response(
         is_dem=meta.get("is_dem"),
         dem_vertical_units=meta.get("dem_vertical_units"),
         band_count=meta.get("band_count"),
+        tile_version=meta.get("tile_version"),
     )
 
 
@@ -144,6 +147,7 @@ def _layers_from_tuples(layer_rows: list[LayerRow]) -> list[MapLayerResponse]:
                 is_dem=row.is_dem,
                 dem_vertical_units=row.dem_vertical_units,
                 band_count=row.band_count,
+                tile_version=row.tile_version,
             ),
         )
         for row in layer_rows

--- a/backend/app/modules/catalog/maps/router.py
+++ b/backend/app/modules/catalog/maps/router.py
@@ -343,10 +343,7 @@ async def get_shared_map_endpoint(
     embed_token: str | None = Header(
         default=None,
         alias="X-Embed-Token",
-        description=(
-            "Optional embed token. When valid for this map, layers backed by "
-            "the token's scoped (possibly non-public) datasets are included."
-        ),
+        description="Optional embed token — includes its scoped dataset layers when valid for this map.",
     ),
     db: AsyncSession = Depends(get_db),
 ) -> SharedMapResponse:
@@ -358,9 +355,8 @@ async def get_shared_map_endpoint(
     empty, defaults to ``frame-ancestors 'self'``. The SecurityHeadersMiddleware
     respects this route-level CSP and skips emitting X-Frame-Options: DENY.
 
-    fix(#394) SH-01/B-023: also accepts ``X-Embed-Token`` so embed viewers get
-    the layers the token's scope authorizes (the tile path already honored the
-    token — SEC-022 capability posture; the metadata payload now matches).
+    fix(#394) SH-01/B-023: accepts ``X-Embed-Token`` so embed viewers get the
+    layers the token's scope authorizes (SEC-022 capability posture).
     """
     user_roles: set[str] = set()
     if user is not None:

--- a/backend/app/modules/catalog/maps/router.py
+++ b/backend/app/modules/catalog/maps/router.py
@@ -15,6 +15,7 @@ from fastapi import (
     Body,
     Depends,
     File,
+    Header,
     HTTPException,
     Query,
     Request,
@@ -337,7 +338,16 @@ async def shared_map_card_endpoint(
 async def get_shared_map_endpoint(
     token: str,
     response: Response,
+    request: Request,
     user: Identity | None = Depends(get_optional_user),
+    embed_token: str | None = Header(
+        default=None,
+        alias="X-Embed-Token",
+        description=(
+            "Optional embed token. When valid for this map, layers backed by "
+            "the token's scoped (possibly non-public) datasets are included."
+        ),
+    ),
     db: AsyncSession = Depends(get_db),
 ) -> SharedMapResponse:
     """Get a shared map by token. Optionally authenticated for non-public layers.
@@ -347,11 +357,22 @@ async def get_shared_map_endpoint(
     EmbedToken for this map. When no EmbedToken exists or allowed_origins is
     empty, defaults to ``frame-ancestors 'self'``. The SecurityHeadersMiddleware
     respects this route-level CSP and skips emitting X-Frame-Options: DENY.
+
+    fix(#394) SH-01/B-023: also accepts ``X-Embed-Token`` so embed viewers get
+    the layers the token's scope authorizes (the tile path already honored the
+    token — SEC-022 capability posture; the metadata payload now matches).
     """
     user_roles: set[str] = set()
     if user is not None:
         user_roles = await get_user_roles(db, user)
-    result = await get_shared_map(db, token, user=user, user_roles=user_roles)
+    result = await get_shared_map(
+        db,
+        token,
+        user=user,
+        user_roles=user_roles,
+        embed_token=embed_token,
+        request=request,
+    )
     if result is None:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,

--- a/backend/app/modules/catalog/maps/schemas.py
+++ b/backend/app/modules/catalog/maps/schemas.py
@@ -837,6 +837,7 @@ class DatasetMetaKwargs(TypedDict, total=False):
     is_dem: bool | None
     dem_vertical_units: str | None
     band_count: int | None
+    tile_version: int | None
 
 
 class MapLayerResponse(BaseModel):
@@ -866,6 +867,10 @@ class MapLayerResponse(BaseModel):
     is_dem: bool | None = None
     dem_vertical_units: str | None = None
     band_count: int | None = None
+    # fix(#394) VT-02: dataset content version (Dataset.current_version). Feeds
+    # the client `_v=` tile-URL cache-buster (map-sync.ts) so a reupload busts
+    # browser/CDN caches; the server-side Valkey purge is B-019.
+    tile_version: int | None = None
 
     model_config = ConfigDict(from_attributes=True)
 
@@ -1063,6 +1068,9 @@ class SharedLayerResponse(BaseModel):
     dem_vertical_units: str | None = None
     is_3d: bool | None = None
     feature_count: int | None = None
+    # fix(#394) VT-02: dataset content version for the `_v=` tile cache-buster
+    # (viewer parity with MapLayerResponse.tile_version).
+    tile_version: int | None = None
 
 
 class SharedMapResponse(BaseModel):

--- a/backend/app/modules/catalog/maps/service_public.py
+++ b/backend/app/modules/catalog/maps/service_public.py
@@ -4,6 +4,7 @@ import hashlib
 import secrets
 import uuid
 from datetime import datetime, timezone
+from typing import TYPE_CHECKING
 
 from sqlalchemy import func, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -20,7 +21,11 @@ from app.modules.catalog.maps.service_shared import (
     _extract_dem_vertical_units,
 )
 from app.modules.embed_tokens.models import EmbedToken
+from app.modules.embed_tokens.service import resolve_embed_scope_for_map
 from app.platform.extensions import get_catalog_port
+
+if TYPE_CHECKING:
+    from fastapi import Request
 
 
 def _redact_terrain_config(
@@ -192,6 +197,7 @@ def _build_shared_layer_dict(
     ds_feature_count: int | None,
     ds_is_dem: bool | None,
     ds_dem_vertical_units: str | None,
+    ds_tile_version: int | None,
 ) -> tuple[dict, bool]:
     """Build a shared-layer response dict from a joined layer row.
 
@@ -236,6 +242,8 @@ def _build_shared_layer_dict(
         "dem_vertical_units": ds_dem_vertical_units,
         "is_3d": bool(ds_is_3d) if ds_is_3d else None,
         "feature_count": ds_feature_count,
+        # fix(#394) VT-02: `_v=` cache-buster input (viewer parity).
+        "tile_version": ds_tile_version,
     }, not is_public
 
 
@@ -244,6 +252,8 @@ async def get_shared_map(
     token: str,
     user: Identity | None = None,
     user_roles: set[str] | None = None,
+    embed_token: str | None = None,
+    request: "Request | None" = None,
 ) -> tuple[dict, list[dict], list[str] | None] | str | None:
     """Fetch a shared map by token.
 
@@ -260,6 +270,12 @@ async def get_shared_map(
     Applies visibility filtering based on the optional user/roles:
     - Anonymous: only public datasets
     - Authenticated: datasets visible per apply_visibility_filter()
+    - fix(#394) SH-01/B-023: a valid ``embed_token`` for this map ADDITIONALLY
+      includes layers whose dataset is in the token's scoped snapshot — embed
+      tokens are a private-dataset capability (SEC-022) and the tile path has
+      always honored them; without this the embed metadata payload dropped
+      those layers so a scoped private dataset could never render in an embed
+      despite the SharePanel promising exactly that.
     Tile URLs: vector datasets use /tiles/data.{table_name}/... — the tile
     endpoint internally distinguishes public (anonymous-allowed) vs
     private (HMAC-signature-required) at request time. Raster datasets
@@ -274,6 +290,12 @@ async def get_shared_map(
         return None
     if isinstance(token_obj, str):
         return token_obj  # "expired"
+
+    embed_scope: set[uuid.UUID] = set()
+    if embed_token:
+        embed_scope = await resolve_embed_scope_for_map(
+            session, embed_token, token_obj.map_id, request
+        )
 
     # SEC-S08 (Phase 1062-05): query the active EmbedToken for this map to
     # surface allowed_origins. The router uses this to emit a per-token
@@ -306,7 +328,7 @@ async def get_shared_map(
     RasterAsset = get_catalog_port().raster_asset_orm_class()
 
     # Single query: Map metadata + visible layers in one round trip.
-    stmt = (
+    base_stmt = (
         select(
             Map,
             MapLayer,
@@ -320,6 +342,7 @@ async def get_shared_map(
             Dataset.feature_count,
             RasterAsset.is_dem,
             RasterAsset.band_info,
+            Dataset.current_version,
         )
         .join(Map, Map.id == MapLayer.map_id)
         .join(Dataset, MapLayer.dataset_id == Dataset.id)
@@ -328,9 +351,24 @@ async def get_shared_map(
         .where(MapLayer.map_id == token_obj.map_id, Map.visibility == "public")
         .order_by(MapLayer.sort_order)
     )
-    stmt = apply_visibility_filter(stmt, user, user_roles, Record, DatasetGrant)
+    stmt = apply_visibility_filter(base_stmt, user, user_roles, Record, DatasetGrant)
     layer_result = await session.execute(stmt)
-    layer_rows = layer_result.all()
+    layer_rows = list(layer_result.all())
+
+    if embed_scope:
+        # fix(#394) SH-01/B-023: union in the embed-token-scoped layers the
+        # visibility filter excluded. The join above still requires CURRENT
+        # map membership and map publicity, so a dataset dropped from the map
+        # (or a de-published map) stays excluded even with a valid token —
+        # same fail-closed posture as the tile path's live-membership re-check.
+        seen_layer_ids = {row[1].id for row in layer_rows}
+        embed_stmt = base_stmt.where(Dataset.id.in_(embed_scope))
+        embed_rows = (await session.execute(embed_stmt)).all()
+        extra_rows = [row for row in embed_rows if row[1].id not in seen_layer_ids]
+        if extra_rows:
+            layer_rows = sorted(
+                [*layer_rows, *extra_rows], key=lambda row: row[1].sort_order
+            )
 
     if not layer_rows:
         # Map doesn't exist, is not public, or has no visible layers.
@@ -374,6 +412,7 @@ async def get_shared_map(
         ds_feature_count,
         ds_is_dem,
         ds_band_info,
+        ds_tile_version,
     ) in layer_rows:
         layer_dict, is_non_public = _build_shared_layer_dict(
             layer,
@@ -387,13 +426,16 @@ async def get_shared_map(
             ds_feature_count,
             ds_is_dem,
             _extract_dem_vertical_units(ds_band_info),
+            ds_tile_version,
         )
         if is_non_public:
             has_non_public = True
-        # SEC-024: all layer_rows passed apply_visibility_filter, so all are
-        # authorized to the caller regardless of public/non-public status.
-        # Track their dataset ids so terrain_config is only stripped when the
-        # DEM is genuinely absent from the caller's authorized layer set.
+        # SEC-024: every layer_row passed apply_visibility_filter OR the
+        # embed-token scope union (fix(#394) B-023) — both are authorization,
+        # so all rows here are authorized to the caller regardless of
+        # public/non-public status. Track their dataset ids so terrain_config
+        # is only stripped when the DEM is genuinely absent from the caller's
+        # authorized layer set.
         visible_dataset_ids.add(str(layer.dataset_id))
         layers.append(layer_dict)
 

--- a/backend/app/modules/catalog/maps/service_shared.py
+++ b/backend/app/modules/catalog/maps/service_shared.py
@@ -38,6 +38,7 @@ class DatasetMeta(NamedTuple):
     is_dem: bool | None
     dem_vertical_units: str | None
     band_count: int | None
+    tile_version: int | None
 
 
 class LayerRow(NamedTuple):
@@ -61,6 +62,7 @@ class LayerRow(NamedTuple):
     is_dem: bool | None
     dem_vertical_units: str | None
     band_count: int | None
+    tile_version: int | None
 
 
 def _extract_dem_vertical_units(band_info: object) -> str | None:
@@ -96,6 +98,7 @@ async def get_dataset_meta(
             RasterAsset.is_dem,
             RasterAsset.band_info,
             RasterAsset.band_count,
+            Dataset.current_version,
         )
         .join(Record, Dataset.record_id == Record.id)
         .outerjoin(RasterAsset, RasterAsset.dataset_id == Dataset.id)
@@ -117,6 +120,7 @@ async def get_dataset_meta(
         is_dem=bool(row[9]) if row[9] is not None else None,
         dem_vertical_units=_extract_dem_vertical_units(row[10]),
         band_count=row[11],
+        tile_version=row[12],
     )
 
 
@@ -219,6 +223,7 @@ async def _fetch_layer_rows_ordered(
             RasterAsset.is_dem,
             RasterAsset.band_info,
             RasterAsset.band_count,
+            Dataset.current_version,
         )
         .join(Dataset, MapLayer.dataset_id == Dataset.id)
         .join(Record, Dataset.record_id == Record.id)
@@ -242,6 +247,7 @@ async def _fetch_layer_rows_ordered(
             is_dem=bool(row[10]) if row[10] is not None else None,
             dem_vertical_units=_extract_dem_vertical_units(row[11]),
             band_count=row[12],
+            tile_version=row[13],
         )
         for row in result.all()
     ]

--- a/backend/app/modules/catalog/maps/style_json.py
+++ b/backend/app/modules/catalog/maps/style_json.py
@@ -441,6 +441,18 @@ def _append_cluster_source_metadata(
     cleanup confirms no consumer ever materializes, this whole block can be dropped
     to shrink the cluster path. Kept here, documented, to avoid silently changing
     the exported contract.
+
+    fix(#394) ST-06 (documented limitation, the audit's "or document" option):
+    cluster rendering does NOT round-trip through style.json export. The
+    exported layer is a plain circle layer over the vector source — no
+    ``cluster: true`` source flags and no cluster-circle/cluster-count
+    companion layers are emitted, because GeoLens clustering is server-side
+    (authenticated cluster tile URLs + per-layer radius/max-zoom the plain
+    MapLibre style format cannot express). External consumers of an exported
+    style see every point unclustered; this metadata block is the only
+    cluster trace. Full fidelity would require emitting the cluster
+    companions + a GeoJSON source per layer — revisit only if an external
+    consumer materializes.
     """
     if (layer.style_config or {}).get("render_mode") != "cluster":
         return
@@ -642,11 +654,17 @@ def _source_for_layer(layer: MapLayerResponse) -> dict[str, Any]:
             "tileSize": 256,
         }
     else:
+        # fix(#394): source maxzoom mirrors the live builder (map-sync.ts) —
+        # 14 for plain vector sources so exported styles OVERZOOM z15+ instead
+        # of hammering the backend at deep zooms, and 22 for server-cluster
+        # sources because the backend only unclusters for z > cluster_max_zoom
+        # (default 14), so cluster clients must be able to fetch z15+ tiles.
+        is_cluster = (layer.style_config or {}).get("render_mode") == "cluster"
         source = {
             "type": "vector",
             "tiles": [_tile_url_for_layer(layer)],
             "minzoom": 1,
-            "maxzoom": 22,
+            "maxzoom": 22 if is_cluster else 14,
         }
     source["metadata"] = {
         "geolens": {
@@ -709,18 +727,53 @@ def _symbol_layout_from_style(
     return next_layout
 
 
+def _symbol_match_label(value: Any) -> str:
+    """Stringify a category value the way JS ``String()`` does.
+
+    fix(#394) ST-04: match labels are compared against a
+    ``["to-string", ["get", col]]`` input (below), so every label must be a
+    string and integral floats must drop their ``.0`` (MapLibre's to-string
+    renders 4.0 as "4") to stay byte-parity with the frontend adapter.
+    """
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, float) and value.is_integer():
+        return str(int(value))
+    return str(value)
+
+
 def _symbol_icon_expression(symbol: dict[str, Any]) -> Any:
     fallback = symbol.get("iconImage") or symbol.get("icon_image") or "marker"
     category_column = symbol.get("categoryColumn") or symbol.get("category_column")
     categories = symbol.get("categories")
     if category_column and isinstance(categories, list):
-        expression: list[Any] = ["match", ["get", category_column]]
+        pairs: list[Any] = []
         for entry in categories:
-            if not isinstance(entry, dict) or entry.get("icon") is None:
+            # fix(#394) ST-04: skip null category values too — the to-string
+            # input renders null as "" so a "None"/null label could never match.
+            if (
+                not isinstance(entry, dict)
+                or entry.get("icon") is None
+                or entry.get("value") is None
+            ):
                 continue
-            expression.append(entry.get("value"))
-            expression.append(_sprite_icon_id(entry["icon"]))
-        expression.append(_sprite_icon_id(fallback))
+            pairs.append(_symbol_match_label(entry.get("value")))
+            pairs.append(_sprite_icon_id(entry["icon"]))
+        if not pairs:
+            # fix(#394) ST-01: zero surviving pairs would emit
+            # ["match", input, fallback] (length 3 < the spec minimum 5) —
+            # MapLibre addLayer throws and the symbol layer silently never
+            # renders. Mirror of the frontend symbol-adapter guard.
+            return _sprite_icon_id(fallback)
+        # fix(#394) ST-04: to-string the input so numeric MVT values match the
+        # stringified sample values the editor stores (numeric columns always
+        # fell through to the fallback icon before).
+        expression: list[Any] = [
+            "match",
+            ["to-string", ["get", category_column]],
+            *pairs,
+            _sprite_icon_id(fallback),
+        ]
         return expression
     return _sprite_icon_id(fallback)
 

--- a/backend/app/modules/embed_tokens/service.py
+++ b/backend/app/modules/embed_tokens/service.py
@@ -367,6 +367,64 @@ async def update_embed_token(
     return token
 
 
+async def resolve_embed_scope_for_map(
+    db: AsyncSession,
+    raw_token: str,
+    map_id: uuid.UUID,
+    request: Request | None = None,
+) -> set[uuid.UUID]:
+    """Resolve the dataset ids an embed token authorizes for ``map_id``.
+
+    fix(#394) SH-01/B-023: embed tokens are a private-dataset capability
+    (SEC-022 posture) — the tile path has always honored them, but the
+    shared-map metadata endpoint dropped non-visible datasets, so an embed
+    with a valid scoped token could never even construct those layers.
+    This helper lets ``get_shared_map`` widen its visibility filter to the
+    token's snapshot scope.
+
+    Fail-closed: returns an empty set (never raises) when the token is
+    unknown, inactive, expired, bound to a different map, or fails the
+    origin allowlist — the same rules as ``validate_embed_token_access``.
+    The ``map_id`` equality also pins the tenant implicitly (map ids are
+    globally unique; callers resolved ``map_id`` from their own share
+    token), so no separate tenant-equality re-check is needed here.
+    Unlike the per-tile validator there is no caching or usage tracking:
+    the metadata endpoint is low-QPS and called once per viewer load.
+    """
+    token_hash = hashlib.sha256(raw_token.encode()).hexdigest()
+    result = await db.execute(
+        select(EmbedToken).where(
+            EmbedToken.token_hash == token_hash,
+            EmbedToken.map_id == map_id,
+            EmbedToken.is_active.is_(True),
+            EmbedToken.expires_at > datetime.now(timezone.utc),
+        )
+    )
+    token = result.scalar_one_or_none()
+    if token is None:
+        return set()
+
+    # Domain-locking check — mirrors validate_embed_token_access (H-31 rules).
+    if token.allowed_origins:
+        if request is None:
+            return set()
+        origin = extract_request_origin(request)
+        if origin is None:
+            return set()
+        if _is_localhost_origin(origin) and _client_is_loopback(request):
+            pass
+        elif origin not in token.allowed_origins:
+            return set()
+
+    scoped: set[uuid.UUID] = set()
+    for raw_id in token.scoped_dataset_ids or []:
+        try:
+            scoped.add(uuid.UUID(str(raw_id)))
+        except ValueError:
+            continue
+    return scoped
+
+
 async def validate_embed_token_access(
     raw_token: str,
     dataset_id: uuid.UUID,

--- a/backend/app/platform/cache/tile_cache.py
+++ b/backend/app/platform/cache/tile_cache.py
@@ -115,18 +115,26 @@ class TileCacheProvider:
             logger.warning("tile_cache_set_failed", key=key, exc_info=True)
 
     async def invalidate_table(self, table: str) -> None:
-        """Delete all cached tiles for a table. Silent on failure."""
-        pattern = f"tile:{table}:*"
+        """Delete all cached tiles for a table. Silent on failure.
+
+        fix(#394) VT-08: in multi_tenant the tile router prefixes the cache
+        key's table segment with the tenant id (``tile:{tid}:{table}:...``,
+        DP-02 Phase 1209-CR-01), so the bare ``tile:{table}:*`` pattern missed
+        those entries. Scan both shapes; over-matching a same-named suffix
+        segment only deletes cache entries, which is harmless.
+        """
+        patterns = (f"tile:{table}:*", f"tile:*:{table}:*")
         try:
-            cursor = 0
-            while True:
-                cursor, keys = await self._client.scan(
-                    cursor=cursor, match=pattern, count=500
-                )
-                if keys:
-                    await self._client.delete(*keys)
-                if cursor == 0:
-                    break
+            for pattern in patterns:
+                cursor = 0
+                while True:
+                    cursor, keys = await self._client.scan(
+                        cursor=cursor, match=pattern, count=500
+                    )
+                    if keys:
+                        await self._client.delete(*keys)
+                    if cursor == 0:
+                        break
             logger.info("tile_cache_invalidated", table=table)
         except Exception:  # broad: redis SCAN/DELETE can throw varied pool/timeout errors; invalidation is non-fatal
             logger.warning("tile_cache_invalidate_failed", table=table, exc_info=True)
@@ -191,9 +199,14 @@ class InMemoryTileCacheProvider:
         self._cache[key] = (data, time.monotonic() + ttl)
 
     async def invalidate_table(self, table: str) -> None:
-        """Delete all cached tiles for a table."""
-        prefix = f"tile:{table}:"
-        keys = [k for k in self._cache if k.startswith(prefix)]
+        """Delete all cached tiles for a table.
+
+        fix(#394) VT-08: a single ``:{table}:`` containment check covers both
+        the single-tenant key (``tile:{table}:...`` — the ``tile:`` prefix ends
+        in a colon) and the tenant-prefixed key (``tile:{tid}:{table}:...``).
+        """
+        segment = f":{table}:"
+        keys = [k for k in self._cache if segment in k]
         for k in keys:
             self._cache.pop(k, None)
         logger.info("tile_cache_invalidated", table=table)

--- a/backend/app/processing/ai/chat_actions.py
+++ b/backend/app/processing/ai/chat_actions.py
@@ -11,7 +11,6 @@ keep working unchanged when the patch replaces the attribute on the facade.
 """
 
 import json
-import re
 from collections.abc import Callable
 from typing import TYPE_CHECKING
 from uuid import UUID
@@ -23,6 +22,7 @@ from app.core.identity import Identity
 from app.platform.sandbox import SandboxError
 from app.processing.ai.chat_constants import _EDIT_TOOLS, ERROR_MESSAGES
 from app.processing.ai.chat_geojson import _extract_geojson
+from app.processing.ai.colors import is_css_colorish
 from app.processing.ai.chat_styles import _build_data_driven_style
 from app.processing.ai.schemas import (
     ChatMapLayer,
@@ -38,19 +38,14 @@ if TYPE_CHECKING:
 logger = structlog.stdlib.get_logger(__name__)
 
 
-# fix(#394) CH-02: permissive color shape check for AI-produced label colors —
-# hex, named (`red`), or functional (`rgb(...)`/`hsla(...)`) forms MapLibre can
-# parse. Anything else (objects, numbers, expressions, junk) falls back to the
-# default so an unparseable value never reaches map.setPaintProperty.
-_CSS_COLORISH_RE = re.compile(
-    r"^(#[0-9a-fA-F]{3,8}|[a-zA-Z]{3,30}|(rgb|rgba|hsl|hsla)\([^)]{1,60}\))$"
-)
-
 _DEFAULT_LABEL_TEXT_COLOR = "#333333"
 
 
 def _safe_label_text_color(value: object) -> str:
-    if isinstance(value, str) and _CSS_COLORISH_RE.match(value.strip()):
+    # fix(#394) CH-02: hex / real CSS named color / numeric-arg functional form
+    # only (see colors.py) — anything else falls back to the default so an
+    # unparseable value never reaches map.setPaintProperty.
+    if isinstance(value, str) and is_css_colorish(value):
         return value.strip()
     return _DEFAULT_LABEL_TEXT_COLOR
 

--- a/backend/app/processing/ai/chat_actions.py
+++ b/backend/app/processing/ai/chat_actions.py
@@ -11,6 +11,7 @@ keep working unchanged when the patch replaces the attribute on the facade.
 """
 
 import json
+import re
 from collections.abc import Callable
 from typing import TYPE_CHECKING
 from uuid import UUID
@@ -37,6 +38,23 @@ if TYPE_CHECKING:
 logger = structlog.stdlib.get_logger(__name__)
 
 
+# fix(#394) CH-02: permissive color shape check for AI-produced label colors —
+# hex, named (`red`), or functional (`rgb(...)`/`hsla(...)`) forms MapLibre can
+# parse. Anything else (objects, numbers, expressions, junk) falls back to the
+# default so an unparseable value never reaches map.setPaintProperty.
+_CSS_COLORISH_RE = re.compile(
+    r"^(#[0-9a-fA-F]{3,8}|[a-zA-Z]{3,30}|(rgb|rgba|hsl|hsla)\([^)]{1,60}\))$"
+)
+
+_DEFAULT_LABEL_TEXT_COLOR = "#333333"
+
+
+def _safe_label_text_color(value: object) -> str:
+    if isinstance(value, str) and _CSS_COLORISH_RE.match(value.strip()):
+        return value.strip()
+    return _DEFAULT_LABEL_TEXT_COLOR
+
+
 def _build_label_action(tool_input: dict) -> dict:
     """Restructure set_label tool output into the ChatAction label_config shape."""
     column = tool_input.get("column")
@@ -47,7 +65,10 @@ def _build_label_action(tool_input: dict) -> dict:
             "label_config": {
                 "column": column,
                 "fontSize": tool_input.get("font_size", 12),
-                "textColor": tool_input.get("text_color", "#333333"),
+                # fix(#394) CH-02: sanitized — see _safe_label_text_color.
+                "textColor": _safe_label_text_color(
+                    tool_input.get("text_color", _DEFAULT_LABEL_TEXT_COLOR)
+                ),
                 "haloColor": "#ffffff",
                 "haloWidth": 1.5,
             },
@@ -237,6 +258,29 @@ async def _execute_chat_tool(
             if warnings:
                 return {"status": "ok", "warnings": warnings, **tool_input}
 
+    # fix(#394) CH-02: validate the set_label column against the target layer's
+    # schema before the action reaches the client — a hallucinated column
+    # previously flowed straight through to a text-field ["get", col] that
+    # renders empty labels. Returning an error lets the model retry with a real
+    # column (mirrors the set_style validation feedback pattern above).
+    if tool_name == "set_label" and tool_input.get("column"):
+        target = next(
+            (lyr for lyr in layers if lyr.id == tool_input.get("layer_id")), None
+        )
+        if target is not None and target.column_info:
+            valid_columns = {
+                col.get("name")
+                for col in target.column_info
+                if isinstance(col, dict) and col.get("name")
+            }
+            if valid_columns and tool_input["column"] not in valid_columns:
+                return {
+                    "error": (
+                        f"Column '{tool_input['column']}' does not exist on "
+                        "this layer — pick one of the layer's real columns."
+                    )
+                }
+
     # add_layer: resolve the dataset's display title server-side so the staging
     # chip can show a human name instead of the raw UUID (builder-audit #338 B-002).
     # Name resolution is best-effort — a lookup miss/error must not block the
@@ -296,6 +340,10 @@ def _collect_chat_action(tool_name: str, tool_input: dict, result: dict) -> dict
         return None
 
     if tool_name == "set_label":
+        # fix(#394) CH-02: a validation error from _execute_chat_tool (unknown
+        # column) must not still emit a label action built from the raw input.
+        if "error" in result:
+            return None
         return _build_label_action(tool_input)
 
     # fix(#392): set_style must emit the backend-validated/clamped paint computed in

--- a/backend/app/processing/ai/colors.py
+++ b/backend/app/processing/ai/colors.py
@@ -1,0 +1,56 @@
+"""CSS-color shape validation for AI-produced style values.
+
+fix(#394) CH-02 (codex round 2): the first-pass regex accepted any 3-30
+letter word ("notacolor") and any parenthesized junk ("rgb(foo)"), so
+unparseable values still reached MapLibre paint validation — exactly what
+the sanitizer exists to prevent. Named colors now validate against the real
+CSS keyword set and functional args are restricted to numeric/separator
+characters. MapLibre remains the final validator; this is the cheap junk
+gate, byte-parity with the frontend mirror in ChatPanel.tsx.
+"""
+
+import re
+
+# 3/4/6/8 hex digits only (#12345 is not a CSS color).
+_HEX_RE = re.compile(r"^#(?:[0-9a-fA-F]{3,4}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})$")
+
+# Functional args restricted to digits, separators, %, and d/e/g (hue units).
+# Letter junk like rgb(foo) fails; residual near-misses (e.g. "rgb(ded)") are
+# left to MapLibre's own validation.
+_FUNCTIONAL_RE = re.compile(r"^(?:rgb|rgba|hsl|hsla)\(\s*[0-9deg.,%\s/+-]{1,60}\s*\)$")
+
+# CSS named colors (CSS Color Level 4 keyword set) + transparent.
+CSS_NAMED_COLORS = frozenset(
+    """aliceblue antiquewhite aqua aquamarine azure beige bisque black
+    blanchedalmond blue blueviolet brown burlywood cadetblue chartreuse
+    chocolate coral cornflowerblue cornsilk crimson cyan darkblue darkcyan
+    darkgoldenrod darkgray darkgreen darkgrey darkkhaki darkmagenta
+    darkolivegreen darkorange darkorchid darkred darksalmon darkseagreen
+    darkslateblue darkslategray darkslategrey darkturquoise darkviolet
+    deeppink deepskyblue dimgray dimgrey dodgerblue firebrick floralwhite
+    forestgreen fuchsia gainsboro ghostwhite gold goldenrod gray green
+    greenyellow grey honeydew hotpink indianred indigo ivory khaki lavender
+    lavenderblush lawngreen lemonchiffon lightblue lightcoral lightcyan
+    lightgoldenrodyellow lightgray lightgreen lightgrey lightpink lightsalmon
+    lightseagreen lightskyblue lightslategray lightslategrey lightsteelblue
+    lightyellow lime limegreen linen magenta maroon mediumaquamarine
+    mediumblue mediumorchid mediumpurple mediumseagreen mediumslateblue
+    mediumspringgreen mediumturquoise mediumvioletred midnightblue mintcream
+    mistyrose moccasin navajowhite navy oldlace olive olivedrab orange
+    orangered orchid palegoldenrod palegreen paleturquoise palevioletred
+    papayawhip peachpuff peru pink plum powderblue purple rebeccapurple red
+    rosybrown royalblue saddlebrown salmon sandybrown seagreen seashell
+    sienna silver skyblue slateblue slategray slategrey snow springgreen
+    steelblue tan teal thistle tomato turquoise violet wheat white
+    whitesmoke yellow yellowgreen transparent""".split()
+)
+
+
+def is_css_colorish(value: object) -> bool:
+    """True when ``value`` is a string MapLibre can plausibly parse as a color."""
+    if not isinstance(value, str):
+        return False
+    candidate = value.strip()
+    if _HEX_RE.match(candidate) or _FUNCTIONAL_RE.match(candidate):
+        return True
+    return candidate.lower() in CSS_NAMED_COLORS

--- a/backend/app/processing/ingest/tasks_common.py
+++ b/backend/app/processing/ingest/tasks_common.py
@@ -1227,6 +1227,25 @@ async def _run_service_import_with_wfs_fallback(
             raise
 
 
+async def invalidate_tile_cache_for_table(table_name: str) -> None:
+    """Best-effort MVT tile-cache purge after a table's contents change.
+
+    fix(#394) B-019/VT-01: reupload swaps the entire table under the same
+    ``table_name`` but was the one write path that never purged the Valkey
+    tile cache — the cache key has no content-version dimension and the ETag
+    is computed over the cached bytes, so stale geometry/attributes kept
+    being 304-served for up to ``tile_cache_ttl`` after every reupload.
+    Mirrors the feature-edit path (``features/router.py``): called AFTER the
+    owning transaction commits so a concurrent tile request cannot re-cache
+    pre-swap rows, and never raises (the provider swallows backend errors).
+    """
+    from app.platform.cache.provider import get_tile_cache
+
+    tile_cache = get_tile_cache()
+    if tile_cache is not None:
+        await tile_cache.invalidate_table(table_name)
+
+
 async def _apply_reupload_swap(
     session,
     *,

--- a/backend/app/processing/ingest/tasks_reupload.py
+++ b/backend/app/processing/ingest/tasks_reupload.py
@@ -21,6 +21,7 @@ from app.processing.ingest.tasks_common import (
     _run_service_import_with_wfs_fallback,
     _run_staging_pipeline,
     _validate_upload_file_safety,
+    invalidate_tile_cache_for_table,
     resolve_service_type,
     task_app,
 )
@@ -255,6 +256,8 @@ async def reupload_file(
                 original_srid=srid,
                 file_hash=file_hash,
             )
+            # Captured pre-commit: the ORM attribute may be expired after commit.
+            live_table_name = dataset.table_name
 
             # Persist 3D fields on dataset record
             dataset.is_3d = three_d.get("is_3d")
@@ -283,6 +286,10 @@ async def reupload_file(
 
         final_status = "complete"
         await invalidate_catalog_cache()
+        # fix(#394) B-019/VT-01: the swap replaced the table's contents under the
+        # same name — purge cached MVT tiles or they 304-serve stale data for up
+        # to tile_cache_ttl. Post-commit, mirroring the feature-edit path.
+        await invalidate_tile_cache_for_table(live_table_name)
 
         # Generate embedding (non-fatal). Use a fresh session to load the
         # dataset since both phase 1 and phase 2 sessions are now closed.
@@ -549,12 +556,17 @@ async def reupload_service(
                 original_srid=metadata.get("srid"),
                 source_url=reupload_source_url,
             )
+            # Captured pre-commit: the ORM attribute may be expired after commit.
+            live_table_name = dataset.table_name
 
             job.status = "complete"
             job.completed_at = datetime.now(timezone.utc)
             await session.commit()
 
         await invalidate_catalog_cache()
+        # fix(#394) B-019/VT-01: purge cached MVT tiles after the swap (see the
+        # file-reupload path above).
+        await invalidate_tile_cache_for_table(live_table_name)
 
         # Generate embedding (non-fatal). Fresh session — both phase 1 and
         # phase 2 sessions are closed by now.

--- a/backend/app/processing/tiles/router.py
+++ b/backend/app/processing/tiles/router.py
@@ -1309,14 +1309,7 @@ async def get_tile_tokens_batch(
     body: TileTokenBatchRequest,
     request: Request,
     user: Identity | None = Depends(get_optional_user),
-    embed_token: str | None = Header(
-        default=None,
-        alias="X-Embed-Token",
-        description=(
-            "Optional embed token. Datasets in the token's scope are "
-            "authorized even without user credentials (embed viewers)."
-        ),
-    ),
+    embed_token: str | None = Header(default=None, alias="X-Embed-Token"),
     db: AsyncSession = Depends(get_db),
 ) -> TileTokenBatchResponse:
     """Batch-generate tile tokens for up to 50 datasets in one request.
@@ -1330,13 +1323,9 @@ async def get_tile_tokens_batch(
     response maps the offending dataset_id to ``{"error": "..."}``. Clients
     should check each entry for the ``error`` key.
 
-    fix(#394) SH-04: embed viewers carry no login, so this endpoint accepts
-    ``X-Embed-Token`` as a per-dataset fallback authorization — the same
-    ``validate_embed_token_access`` capability check the tile-serving path
-    uses (origin allowlist + live layer-membership + tenant equality). This
-    lets embed-mode terrain build its raster-dem source from the SAME
-    descriptor (bounds / resolution-derived maxzoom) as builder and viewer
-    instead of empty defaults.
+    fix(#394) SH-04: ``X-Embed-Token`` is accepted as per-dataset fallback
+    authorization (same capability check as tile serving), so embed terrain
+    builds its raster-dem source from the real bounds/maxzoom descriptor.
     """
     from app.modules.catalog.datasets.domain.models import Dataset as DatasetORM
 
@@ -1377,13 +1366,9 @@ async def get_tile_tokens_batch(
         try:
             await _enforce_tile_token_access(db, dataset, dataset_id, user, port)
         except HTTPException as exc:
-            # fix(#394) SH-04: fall back to embed-token capability before
-            # reporting the per-dataset error (fail-closed on any mismatch).
+            # fix(#394) SH-04: embed-token capability fallback (fail-closed).
             embed_ok = bool(embed_token) and await validate_embed_token_access(
-                embed_token,  # type: ignore[arg-type]  # bool() guard above
-                dataset_id,
-                db,
-                request,
+                embed_token, dataset_id, db, request
             )
             if not embed_ok:
                 tokens[key] = {"error": exc.detail}

--- a/backend/app/processing/tiles/router.py
+++ b/backend/app/processing/tiles/router.py
@@ -13,7 +13,16 @@ from urllib.parse import parse_qs
 import httpx
 import structlog
 from cachetools import LRUCache
-from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response, status
+from fastapi import (
+    APIRouter,
+    Depends,
+    Header,
+    HTTPException,
+    Query,
+    Request,
+    Response,
+    status,
+)
 from geoalchemy2.shape import to_shape
 from sqlalchemy import select, text
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -1298,7 +1307,16 @@ async def get_tile_token(
 @limiter.exempt
 async def get_tile_tokens_batch(
     body: TileTokenBatchRequest,
+    request: Request,
     user: Identity | None = Depends(get_optional_user),
+    embed_token: str | None = Header(
+        default=None,
+        alias="X-Embed-Token",
+        description=(
+            "Optional embed token. Datasets in the token's scope are "
+            "authorized even without user credentials (embed viewers)."
+        ),
+    ),
     db: AsyncSession = Depends(get_db),
 ) -> TileTokenBatchResponse:
     """Batch-generate tile tokens for up to 50 datasets in one request.
@@ -1311,6 +1329,14 @@ async def get_tile_tokens_batch(
     Per-dataset errors (404, 403) do not fail the batch — instead the
     response maps the offending dataset_id to ``{"error": "..."}``. Clients
     should check each entry for the ``error`` key.
+
+    fix(#394) SH-04: embed viewers carry no login, so this endpoint accepts
+    ``X-Embed-Token`` as a per-dataset fallback authorization — the same
+    ``validate_embed_token_access`` capability check the tile-serving path
+    uses (origin allowlist + live layer-membership + tenant equality). This
+    lets embed-mode terrain build its raster-dem source from the SAME
+    descriptor (bounds / resolution-derived maxzoom) as builder and viewer
+    instead of empty defaults.
     """
     from app.modules.catalog.datasets.domain.models import Dataset as DatasetORM
 
@@ -1351,8 +1377,17 @@ async def get_tile_tokens_batch(
         try:
             await _enforce_tile_token_access(db, dataset, dataset_id, user, port)
         except HTTPException as exc:
-            tokens[key] = {"error": exc.detail}
-            continue
+            # fix(#394) SH-04: fall back to embed-token capability before
+            # reporting the per-dataset error (fail-closed on any mismatch).
+            embed_ok = bool(embed_token) and await validate_embed_token_access(
+                embed_token,  # type: ignore[arg-type]  # bool() guard above
+                dataset_id,
+                db,
+                request,
+            )
+            if not embed_ok:
+                tokens[key] = {"error": exc.detail}
+                continue
 
         tokens[key] = _build_tile_token_for_dataset(
             dataset,

--- a/backend/app/processing/tiles/service.py
+++ b/backend/app/processing/tiles/service.py
@@ -209,9 +209,15 @@ mvtgeom AS (
             -- z<{_NO_SIMPLIFY_AT_OR_ABOVE_ZOOM}. tolerance = factor*360/(extent*2^z)
             -- degrees (mirrors _simplify_tolerance_degrees) so it halves smoothly
             -- each zoom instead of dropping ~360x across the old z5->z6 boundary.
+            -- fix(#394) VT-05: ST_MakeValid guards the simplify input — ingest does
+            -- not guarantee validity, and one invalid geometry raising a GEOS
+            -- TopologyException inside the simplify call 503s the whole tile.
+            -- Valid geometries pass through ST_MakeValid unchanged; the
+            -- z>={_NO_SIMPLIFY_AT_OR_ABOVE_ZOOM} branch stays untouched because
+            -- ST_AsMVTGeom's clipper tolerates invalid input.
             CASE
                 WHEN $1::integer < {_NO_SIMPLIFY_AT_OR_ABOVE_ZOOM} THEN ST_SimplifyPreserveTopology(
-                    t.geom_4326,
+                    ST_MakeValid(t.geom_4326),
                     {_SIMPLIFY_SUBPIXEL_FACTOR} * 360.0 / ({_MVT_EXTENT} * power(2, $1::integer))
                 )
                 ELSE t.geom_4326
@@ -230,7 +236,21 @@ mvtgeom AS (
 )
 SELECT ST_AsMVT(mvtgeom.*, $4::text, 4096, 'geom', 'gid')
 FROM mvtgeom
+-- fix(#394) VT-06: ST_AsMVTGeom returns NULL for features clipped away or
+-- degenerate at this zoom; without this WHERE those rows are encoded as
+-- geometry-less attribute-only MVT features (dead bytes). Matches the
+-- cluster query's existing `WHERE geom IS NOT NULL`.
+WHERE mvtgeom.geom IS NOT NULL
 """
+
+
+# fix(#394) VT-07: MVT feature id for CLUSTER features. ST_AsMVT silently drops
+# non-positive ids, so the previous `-row_number()` left clusters with no id at
+# all (breaks any future promoteId/feature-state on cluster layers). Clusters
+# share the layer with unclustered features whose ids are real `gid`s, so the
+# per-tile row number is offset by 2^40 to stay disjoint from realistic serial
+# gids while remaining exactly representable as a JS double (< 2^53).
+_CLUSTER_FEATURE_ID_OFFSET = 1 << 40
 
 
 def _build_cluster_tile_query(table_name: str, schema: str = "data") -> str:
@@ -311,7 +331,7 @@ features AS (
     SELECT
         CASE
             WHEN raw_point_count > 1 AND $1::integer <= $5::integer
-                THEN -row_number() OVER (ORDER BY bucket_x, bucket_y)::bigint
+                THEN {_CLUSTER_FEATURE_ID_OFFSET}::bigint + row_number() OVER (ORDER BY bucket_x, bucket_y)::bigint
             ELSE source_gid
         END AS gid,
         CASE

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -8501,6 +8501,17 @@
             ],
             "title": "Style Config"
           },
+          "tile_version": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Tile Version"
+          },
           "visible": {
             "title": "Visible",
             "type": "boolean"
@@ -13259,6 +13270,17 @@
           "tile_url": {
             "title": "Tile Url",
             "type": "string"
+          },
+          "tile_version": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Tile Version"
           },
           "visible": {
             "title": "Visible",
@@ -34282,7 +34304,7 @@
     },
     "/maps/shared/{token}": {
       "get": {
-        "description": "Get a shared map by token. Optionally authenticated for non-public layers.\n\nSEC-S08 (Phase 1062-05): emits ``Content-Security-Policy: frame-ancestors\n'self' [<allowed_origins>...]`` on the response, derived from the active\nEmbedToken for this map. When no EmbedToken exists or allowed_origins is\nempty, defaults to ``frame-ancestors 'self'``. The SecurityHeadersMiddleware\nrespects this route-level CSP and skips emitting X-Frame-Options: DENY.",
+        "description": "Get a shared map by token. Optionally authenticated for non-public layers.\n\nSEC-S08 (Phase 1062-05): emits ``Content-Security-Policy: frame-ancestors\n'self' [<allowed_origins>...]`` on the response, derived from the active\nEmbedToken for this map. When no EmbedToken exists or allowed_origins is\nempty, defaults to ``frame-ancestors 'self'``. The SecurityHeadersMiddleware\nrespects this route-level CSP and skips emitting X-Frame-Options: DENY.\n\nfix(#394) SH-01/B-023: also accepts ``X-Embed-Token`` so embed viewers get\nthe layers the token's scope authorizes (the tile path already honored the\ntoken \u2014 SEC-022 capability posture; the metadata payload now matches).",
         "operationId": "get_shared_map_endpoint_maps_shared__token__get",
         "parameters": [
           {
@@ -34292,6 +34314,24 @@
             "schema": {
               "title": "Token",
               "type": "string"
+            }
+          },
+          {
+            "description": "Optional embed token. When valid for this map, layers backed by the token's scoped (possibly non-public) datasets are included.",
+            "in": "header",
+            "name": "X-Embed-Token",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Optional embed token. When valid for this map, layers backed by the token's scoped (possibly non-public) datasets are included.",
+              "title": "X-Embed-Token"
             }
           }
         ],
@@ -43287,8 +43327,28 @@
     },
     "/tiles/tokens/": {
       "post": {
-        "description": "Batch-generate tile tokens for up to 50 datasets in one request.\n\nOptimization for multi-layer maps: a 20-layer builder map previously\nfired 20 parallel GET /token/{id}/ requests (20 HTTP + 20 RBAC + 20 HMAC\nsignatures). This endpoint does the same work in a single round trip\nwith one DB query for dataset metadata (PERF-N5).\n\nPer-dataset errors (404, 403) do not fail the batch \u2014 instead the\nresponse maps the offending dataset_id to ``{\"error\": \"...\"}``. Clients\nshould check each entry for the ``error`` key.",
+        "description": "Batch-generate tile tokens for up to 50 datasets in one request.\n\nOptimization for multi-layer maps: a 20-layer builder map previously\nfired 20 parallel GET /token/{id}/ requests (20 HTTP + 20 RBAC + 20 HMAC\nsignatures). This endpoint does the same work in a single round trip\nwith one DB query for dataset metadata (PERF-N5).\n\nPer-dataset errors (404, 403) do not fail the batch \u2014 instead the\nresponse maps the offending dataset_id to ``{\"error\": \"...\"}``. Clients\nshould check each entry for the ``error`` key.\n\nfix(#394) SH-04: embed viewers carry no login, so this endpoint accepts\n``X-Embed-Token`` as a per-dataset fallback authorization \u2014 the same\n``validate_embed_token_access`` capability check the tile-serving path\nuses (origin allowlist + live layer-membership + tenant equality). This\nlets embed-mode terrain build its raster-dem source from the SAME\ndescriptor (bounds / resolution-derived maxzoom) as builder and viewer\ninstead of empty defaults.",
         "operationId": "get_tile_tokens_batch_tiles_tokens__post",
+        "parameters": [
+          {
+            "description": "Optional embed token. Datasets in the token's scope are authorized even without user credentials (embed viewers).",
+            "in": "header",
+            "name": "X-Embed-Token",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Optional embed token. Datasets in the token's scope are authorized even without user credentials (embed viewers).",
+              "title": "X-Embed-Token"
+            }
+          }
+        ],
         "requestBody": {
           "content": {
             "application/json": {

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -26869,7 +26869,7 @@
     },
     "/datasets/{dataset_id}/features.geojson": {
       "get": {
-        "description": "Return up to 5,000 features as RFC 7946 GeoJSON with Z coordinates.",
+        "description": "Return up to 5,000 features as RFC 7946 GeoJSON with Z coordinates.\n\nfix(#394) codex P2: the viewer's bounded-GeoJSON path (small 3D layers,\neligible cluster layers) already sends ``X-Embed-Token``, and the B-023\nshared-map union now exposes embed-scoped private layers to embeds \u2014 so\nthis endpoint accepts the token as fallback authorization via the SAME\n``validate_embed_token_access`` capability check as tile serving.\nCredentialed callers (JWT / API key) keep the exact prior RBAC path;\nanonymous callers without a valid scoped token still get 401.",
         "operationId": "get_features_geojson_z_endpoint_datasets__dataset_id__features_geojson_get",
         "parameters": [
           {
@@ -26880,6 +26880,24 @@
               "format": "uuid",
               "title": "Dataset Id",
               "type": "string"
+            }
+          },
+          {
+            "description": "Optional embed token. Datasets in the token's scope are authorized even without user credentials (embed viewers).",
+            "in": "header",
+            "name": "X-Embed-Token",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Optional embed token. Datasets in the token's scope are authorized even without user credentials (embed viewers).",
+              "title": "X-Embed-Token"
             }
           }
         ],
@@ -34304,7 +34322,7 @@
     },
     "/maps/shared/{token}": {
       "get": {
-        "description": "Get a shared map by token. Optionally authenticated for non-public layers.\n\nSEC-S08 (Phase 1062-05): emits ``Content-Security-Policy: frame-ancestors\n'self' [<allowed_origins>...]`` on the response, derived from the active\nEmbedToken for this map. When no EmbedToken exists or allowed_origins is\nempty, defaults to ``frame-ancestors 'self'``. The SecurityHeadersMiddleware\nrespects this route-level CSP and skips emitting X-Frame-Options: DENY.\n\nfix(#394) SH-01/B-023: also accepts ``X-Embed-Token`` so embed viewers get\nthe layers the token's scope authorizes (the tile path already honored the\ntoken \u2014 SEC-022 capability posture; the metadata payload now matches).",
+        "description": "Get a shared map by token. Optionally authenticated for non-public layers.\n\nSEC-S08 (Phase 1062-05): emits ``Content-Security-Policy: frame-ancestors\n'self' [<allowed_origins>...]`` on the response, derived from the active\nEmbedToken for this map. When no EmbedToken exists or allowed_origins is\nempty, defaults to ``frame-ancestors 'self'``. The SecurityHeadersMiddleware\nrespects this route-level CSP and skips emitting X-Frame-Options: DENY.\n\nfix(#394) SH-01/B-023: accepts ``X-Embed-Token`` so embed viewers get the\nlayers the token's scope authorizes (SEC-022 capability posture).",
         "operationId": "get_shared_map_endpoint_maps_shared__token__get",
         "parameters": [
           {
@@ -34317,7 +34335,7 @@
             }
           },
           {
-            "description": "Optional embed token. When valid for this map, layers backed by the token's scoped (possibly non-public) datasets are included.",
+            "description": "Optional embed token \u2014 includes its scoped dataset layers when valid for this map.",
             "in": "header",
             "name": "X-Embed-Token",
             "required": false,
@@ -34330,7 +34348,7 @@
                   "type": "null"
                 }
               ],
-              "description": "Optional embed token. When valid for this map, layers backed by the token's scoped (possibly non-public) datasets are included.",
+              "description": "Optional embed token \u2014 includes its scoped dataset layers when valid for this map.",
               "title": "X-Embed-Token"
             }
           }
@@ -43327,11 +43345,10 @@
     },
     "/tiles/tokens/": {
       "post": {
-        "description": "Batch-generate tile tokens for up to 50 datasets in one request.\n\nOptimization for multi-layer maps: a 20-layer builder map previously\nfired 20 parallel GET /token/{id}/ requests (20 HTTP + 20 RBAC + 20 HMAC\nsignatures). This endpoint does the same work in a single round trip\nwith one DB query for dataset metadata (PERF-N5).\n\nPer-dataset errors (404, 403) do not fail the batch \u2014 instead the\nresponse maps the offending dataset_id to ``{\"error\": \"...\"}``. Clients\nshould check each entry for the ``error`` key.\n\nfix(#394) SH-04: embed viewers carry no login, so this endpoint accepts\n``X-Embed-Token`` as a per-dataset fallback authorization \u2014 the same\n``validate_embed_token_access`` capability check the tile-serving path\nuses (origin allowlist + live layer-membership + tenant equality). This\nlets embed-mode terrain build its raster-dem source from the SAME\ndescriptor (bounds / resolution-derived maxzoom) as builder and viewer\ninstead of empty defaults.",
+        "description": "Batch-generate tile tokens for up to 50 datasets in one request.\n\nOptimization for multi-layer maps: a 20-layer builder map previously\nfired 20 parallel GET /token/{id}/ requests (20 HTTP + 20 RBAC + 20 HMAC\nsignatures). This endpoint does the same work in a single round trip\nwith one DB query for dataset metadata (PERF-N5).\n\nPer-dataset errors (404, 403) do not fail the batch \u2014 instead the\nresponse maps the offending dataset_id to ``{\"error\": \"...\"}``. Clients\nshould check each entry for the ``error`` key.\n\nfix(#394) SH-04: ``X-Embed-Token`` is accepted as per-dataset fallback\nauthorization (same capability check as tile serving), so embed terrain\nbuilds its raster-dem source from the real bounds/maxzoom descriptor.",
         "operationId": "get_tile_tokens_batch_tiles_tokens__post",
         "parameters": [
           {
-            "description": "Optional embed token. Datasets in the token's scope are authorized even without user credentials (embed viewers).",
             "in": "header",
             "name": "X-Embed-Token",
             "required": false,
@@ -43344,7 +43361,6 @@
                   "type": "null"
                 }
               ],
-              "description": "Optional embed token. Datasets in the token's scope are authorized even without user credentials (embed viewers).",
               "title": "X-Embed-Token"
             }
           }

--- a/backend/tests/test_collect_chat_action.py
+++ b/backend/tests/test_collect_chat_action.py
@@ -250,3 +250,15 @@ def test_set_label_valid_text_colors_pass_through() -> None:
             {"layer_id": "l1", "column": "name", "text_color": color}
         )
         assert action["label_config"]["textColor"] == color
+
+
+def test_set_label_junk_named_and_functional_colors_fall_back() -> None:
+    """fix(#394) codex round 2: 'notacolor' / 'rgb(foo)' must not pass the
+    shape check — junk still reached MapLibre paint validation before."""
+    from app.processing.ai.chat_actions import _build_label_action
+
+    for junk in ("notacolor", "rgb(foo)", "hsl(bad, values)", "#12345"):
+        action = _build_label_action(
+            {"layer_id": "l1", "column": "name", "text_color": junk}
+        )
+        assert action["label_config"]["textColor"] == "#333333", junk

--- a/backend/tests/test_collect_chat_action.py
+++ b/backend/tests/test_collect_chat_action.py
@@ -210,3 +210,43 @@ def test_set_style_without_validation_falls_back_to_tool_input_unchanged() -> No
     assert action["layer_id"] == "layer-1"
     assert "paint" not in action
     assert "clear_paint" not in action
+
+
+# ---------------------------------------------------------------------------
+# fix(#394) CH-02: set_label validation
+# ---------------------------------------------------------------------------
+
+
+def test_set_label_error_result_emits_no_action() -> None:
+    """A column-validation error from _execute_chat_tool must not still emit
+    a label action built from the raw tool input."""
+    action = _collect_chat_action(
+        "set_label",
+        {"layer_id": "l1", "column": "nope"},
+        {"error": "Column 'nope' does not exist on this layer."},
+    )
+    assert action is None
+
+
+def test_set_label_invalid_text_color_falls_back_to_default() -> None:
+    from app.processing.ai.chat_actions import _build_label_action
+
+    action = _build_label_action(
+        {"layer_id": "l1", "column": "name", "text_color": {"r": 1}}
+    )
+    assert action["label_config"]["textColor"] == "#333333"
+
+    action = _build_label_action(
+        {"layer_id": "l1", "column": "name", "text_color": "#zzzzzz;"}
+    )
+    assert action["label_config"]["textColor"] == "#333333"
+
+
+def test_set_label_valid_text_colors_pass_through() -> None:
+    from app.processing.ai.chat_actions import _build_label_action
+
+    for color in ("#ff0000", "rebeccapurple", "rgb(1, 2, 3)", "hsla(10, 5%, 5%, 0.4)"):
+        action = _build_label_action(
+            {"layer_id": "l1", "column": "name", "text_color": color}
+        )
+        assert action["label_config"]["textColor"] == color

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -786,7 +786,11 @@ def test_decomposed_service_modules_stay_within_size_budgets() -> None:
         # on Map (visibility=public) LEFT JOINed to the latest share token per
         # map (DISTINCT ON) so every published map appears, not just shared ones.
         # Cap raised 625 → 660 (~11 LOC headroom).
-        "backend/app/modules/catalog/maps/service_public.py": 660,
+        # fix(#394) SH-01/B-023: +31 lines — get_shared_map unions embed-token
+        # scoped layers into the visibility-filtered set (SEC-022 capability
+        # parity with the tile path) + tile_version threading. Cap raised
+        # 660 → 720 (~29 LOC headroom).
+        "backend/app/modules/catalog/maps/service_public.py": 720,
         "backend/app/modules/catalog/search/service_records.py": 500,
         # Phase 269 H-05: dataset-domain modules over the 350 default at audit
         # time. Caps set ~20-30 LOC above current size to allow modest growth
@@ -809,6 +813,10 @@ def test_decomposed_service_modules_stay_within_size_budgets() -> None:
         # Phase 276 CODE-02: chat_*.py sub-modules are all under the 350
         # default (largest is chat_actions.py at ~245 LOC). No explicit
         # per-file overrides needed; default applies.
+        # fix(#394) CH-02: +~35 lines — set_label column validation against the
+        # target layer schema (error feedback to the model), the CSS-colorish
+        # sanitizer, and the collector error gate. Cap 350 → 400 (~19 headroom).
+        "backend/app/processing/ai/chat_actions.py": 400,
     }
 
     files_to_check = list(facade_line_budgets)

--- a/backend/tests/test_maps_style_json.py
+++ b/backend/tests/test_maps_style_json.py
@@ -1866,3 +1866,62 @@ def test_builder_alias_table_is_single_source_inverse_style_01():
     assert style_json._BUILDER_KEY_ALIASES is BUILDER_SNAKE_TO_CAMEL_KEYS
     # The previously-drifting folder_group_* keys are now present on export.
     assert style_json._BUILDER_KEY_ALIASES["folder_group_id"] == "folderGroupId"
+
+
+# ---------------------------------------------------------------------------
+# fix(#394) ST-01 / ST-04: symbol icon-image expression hardening
+# ---------------------------------------------------------------------------
+
+
+def test_symbol_icon_expression_zero_pairs_falls_back_flat_st01():
+    """ST-01: when every category icon is empty, emit the flat fallback id —
+    a zero-pair ["match", input, fallback] (length 3) makes addLayer throw."""
+    expr = style_json._symbol_icon_expression(
+        {
+            "iconImage": "marker",
+            "categoryColumn": "kind",
+            "categories": [
+                {"value": "a", "icon": None},
+                {"value": "b"},  # no icon key
+            ],
+        }
+    )
+    assert expr == "geolens:marker"
+
+
+def test_symbol_icon_expression_to_string_input_and_labels_st04():
+    """ST-04: match input is to-string-wrapped and labels are stringified so
+    numeric MVT values match the editor's stringified sample values."""
+    expr = style_json._symbol_icon_expression(
+        {
+            "iconImage": "marker",
+            "categoryColumn": "mag",
+            "categories": [
+                {"value": 4.0, "icon": "star"},
+                {"value": "5", "icon": "circle"},
+                {"value": None, "icon": "square"},  # null value skipped
+            ],
+        }
+    )
+    assert expr[0] == "match"
+    assert expr[1] == ["to-string", ["get", "mag"]]
+    # 4.0 stringifies like JS String(4) — no trailing ".0".
+    assert expr[2] == "4"
+    assert expr[4] == "5"
+    # The null-valued pair was skipped: match has exactly 2 pairs + fallback.
+    assert len(expr) == 7
+
+
+def test_vector_source_maxzoom_mirrors_live_builder_394():
+    """fix(#394): plain vector sources export maxzoom 14 (overzoom beyond, like
+    the live builder); server-cluster sources keep 22 so clusters can expand."""
+    plain = _layer(style_config=None)
+    source = style_json._source_for_layer(plain)
+    assert source["maxzoom"] == 14
+
+    cluster = _layer(
+        style_config={"render_mode": "cluster"},
+        dataset_feature_count=10,
+    )
+    cluster_source = style_json._source_for_layer(cluster)
+    assert cluster_source["maxzoom"] == 22

--- a/backend/tests/test_mvt_audit_fixes.py
+++ b/backend/tests/test_mvt_audit_fixes.py
@@ -154,3 +154,76 @@ def test_tile_response_returns_304_on_matching_if_none_match():
     # 304 carries no entity body, so Content-Encoding must be dropped.
     assert "content-encoding" not in resp.headers
     assert resp.body == b""
+
+
+# ---------------------------------------------------------------------------
+# fix(#394) VT-05 / VT-06 / VT-07: 2026-07-03 builder-audit query-shape fixes
+# ---------------------------------------------------------------------------
+
+
+def test_tile_query_makevalid_guards_simplify_only():
+    """VT-05: ST_MakeValid wraps the simplify input; the z>=cutoff branch is untouched."""
+    query = _build_tile_query("places", [])
+    assert "ST_MakeValid(t.geom_4326)" in query
+    # The unsimplified branch must still serve the original geometry.
+    assert "ELSE t.geom_4326" in query
+
+
+def test_tile_query_drops_null_geometry_features():
+    """VT-06: the vector query filters NULL post-clip geometries like the cluster query."""
+    query = _build_tile_query("places", [])
+    assert "WHERE mvtgeom.geom IS NOT NULL" in query
+
+
+def test_cluster_query_emits_positive_offset_gid():
+    """VT-07: cluster feature ids are positive (ST_AsMVT drops non-positive ids)
+    and offset out of the realistic serial-gid range."""
+    query = _build_cluster_tile_query("places")
+    assert "-row_number()" not in query
+    assert f"{service._CLUSTER_FEATURE_ID_OFFSET}::bigint + row_number()" in query
+    # Offset must stay exactly representable as a JS double.
+    assert service._CLUSTER_FEATURE_ID_OFFSET < 2**53
+
+
+# ---------------------------------------------------------------------------
+# fix(#394) B-019/VT-01: reupload purges the MVT tile cache post-commit
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_invalidate_tile_cache_for_table_calls_provider(monkeypatch):
+    from app.platform.cache import provider as cache_provider
+    from app.processing.ingest.tasks_common import invalidate_tile_cache_for_table
+
+    fake_cache = MagicMock()
+    fake_cache.invalidate_table = AsyncMock()
+    monkeypatch.setattr(cache_provider, "get_tile_cache", lambda: fake_cache)
+
+    await invalidate_tile_cache_for_table("reuploaded_table")
+
+    fake_cache.invalidate_table.assert_awaited_once_with("reuploaded_table")
+
+
+@pytest.mark.asyncio
+async def test_invalidate_tile_cache_for_table_noop_without_provider(monkeypatch):
+    from app.platform.cache import provider as cache_provider
+    from app.processing.ingest.tasks_common import invalidate_tile_cache_for_table
+
+    monkeypatch.setattr(cache_provider, "get_tile_cache", lambda: None)
+
+    # Must not raise — the purge is best-effort.
+    await invalidate_tile_cache_for_table("reuploaded_table")
+
+
+def test_reupload_tasks_invalidate_tile_cache_after_commit():
+    """Both reupload task bodies call the tile-cache purge after their commit.
+
+    Guards the fix(#394) B-019 call sites the way the audit found them missing:
+    the swap replaces table contents, so each task must purge post-commit.
+    """
+    import inspect
+
+    from app.processing.ingest import tasks_reupload
+
+    source = inspect.getsource(tasks_reupload)
+    assert source.count("await invalidate_tile_cache_for_table(live_table_name)") == 2

--- a/backend/tests/test_shared_map_embed_scope.py
+++ b/backend/tests/test_shared_map_embed_scope.py
@@ -1,0 +1,247 @@
+"""fix(#394) 2026-07-03 builder-audit: shared-map embed-token scope + tile_version.
+
+Covers:
+  - B-023/SH-01: GET /maps/shared/{token} honors X-Embed-Token — layers backed
+    by the token's scoped private datasets are included (the tile path always
+    honored the token; the metadata payload now matches, per the SEC-022
+    capability posture).
+  - SH-04: POST /tiles/tokens/ accepts X-Embed-Token as fallback authorization
+    so embed viewers obtain the same tile/DEM descriptors as viewers.
+  - VT-02/B-026: MapLayerResponse + SharedLayerResponse carry ``tile_version``
+    (Dataset.current_version) for the client `_v=` cache-buster.
+"""
+
+import uuid
+
+from httpx import AsyncClient
+from sqlalchemy import update
+
+from app.modules.catalog.datasets.domain.models import Dataset, Record
+from app.modules.embed_tokens.models import EmbedToken
+from app.modules.embed_tokens.service import (
+    create_embed_token,
+    resolve_embed_scope_for_map,
+)
+
+from tests.factories import create_dataset, get_user_id
+
+
+async def _downgrade_to_private(session, dataset: Dataset) -> None:
+    """Flip a dataset private AFTER map publish — the exact SH-01 scenario
+    (publishing a map with a non-public dataset is rejected up front, so the
+    gap only exists for post-publish downgrades)."""
+    await session.execute(
+        update(Record)
+        .where(Record.id == dataset.record_id)
+        .values(visibility="private")
+    )
+    await session.commit()
+
+
+async def _make_public_shared_map(
+    client: AsyncClient,
+    headers: dict,
+    dataset_ids: list[str],
+) -> tuple[str, str, list[str]]:
+    """Create a map with layers, publish it, share it. Returns (map_id, share_token, layer_ids)."""
+    create_resp = await client.post(
+        "/maps/",
+        json={"name": f"Embed Scope Map {uuid.uuid4().hex[:6]}"},
+        headers=headers,
+    )
+    assert create_resp.status_code == 201, create_resp.text
+    map_id = create_resp.json()["id"]
+
+    layer_ids = []
+    for ds_id in dataset_ids:
+        layer_resp = await client.post(
+            f"/maps/{map_id}/layers", json={"dataset_id": ds_id}, headers=headers
+        )
+        assert layer_resp.status_code == 201, layer_resp.text
+        layer_ids.append(layer_resp.json()["id"])
+
+    put_resp = await client.put(
+        f"/maps/{map_id}", json={"visibility": "public"}, headers=headers
+    )
+    assert put_resp.status_code == 200, put_resp.text
+
+    share_resp = await client.post(f"/maps/{map_id}/share/", headers=headers)
+    assert share_resp.status_code in (200, 201), share_resp.text
+    return map_id, share_resp.json()["token"], layer_ids
+
+
+class TestSharedMapEmbedScope:
+    async def test_anonymous_excludes_private_layer(
+        self, client: AsyncClient, admin_auth_header: dict, test_db_session
+    ):
+        admin_id = await get_user_id(test_db_session, "admin")
+        public_ds = await create_dataset(
+            test_db_session, created_by=admin_id, visibility="public"
+        )
+        private_ds = await create_dataset(
+            test_db_session, created_by=admin_id, visibility="public"
+        )
+        _map_id, share_token, _ = await _make_public_shared_map(
+            client, admin_auth_header, [str(public_ds.id), str(private_ds.id)]
+        )
+        await _downgrade_to_private(test_db_session, private_ds)
+
+        resp = await client.get(f"/maps/shared/{share_token}")
+        assert resp.status_code == 200
+        dataset_ids = {layer["dataset_id"] for layer in resp.json()["layers"]}
+        assert str(public_ds.id) in dataset_ids
+        assert str(private_ds.id) not in dataset_ids
+
+    async def test_valid_embed_token_includes_scoped_private_layer(
+        self, client: AsyncClient, admin_auth_header: dict, test_db_session
+    ):
+        admin_id = await get_user_id(test_db_session, "admin")
+        public_ds = await create_dataset(
+            test_db_session, created_by=admin_id, visibility="public"
+        )
+        private_ds = await create_dataset(
+            test_db_session, created_by=admin_id, visibility="public"
+        )
+        map_id, share_token, _ = await _make_public_shared_map(
+            client, admin_auth_header, [str(public_ds.id), str(private_ds.id)]
+        )
+
+        _token_obj, raw_token = await create_embed_token(
+            test_db_session, uuid.UUID(map_id), admin_id
+        )
+        await test_db_session.commit()
+        await _downgrade_to_private(test_db_session, private_ds)
+
+        resp = await client.get(
+            f"/maps/shared/{share_token}", headers={"X-Embed-Token": raw_token}
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        dataset_ids = {layer["dataset_id"] for layer in data["layers"]}
+        assert str(private_ds.id) in dataset_ids
+        assert data["has_non_public_layers"] is True
+        # Layers stay sort-ordered after the embed-scope union.
+        sort_orders = [layer["sort_order"] for layer in data["layers"]]
+        assert sort_orders == sorted(sort_orders)
+
+    async def test_revoked_embed_token_excludes_private_layer(
+        self, client: AsyncClient, admin_auth_header: dict, test_db_session
+    ):
+        admin_id = await get_user_id(test_db_session, "admin")
+        private_ds = await create_dataset(
+            test_db_session, created_by=admin_id, visibility="public"
+        )
+        map_id, share_token, _ = await _make_public_shared_map(
+            client, admin_auth_header, [str(private_ds.id)]
+        )
+        _token_obj, raw_token = await create_embed_token(
+            test_db_session, uuid.UUID(map_id), admin_id
+        )
+        await test_db_session.execute(
+            update(EmbedToken)
+            .where(EmbedToken.map_id == uuid.UUID(map_id))
+            .values(is_active=False)
+        )
+        await test_db_session.commit()
+        await _downgrade_to_private(test_db_session, private_ds)
+
+        resp = await client.get(
+            f"/maps/shared/{share_token}", headers={"X-Embed-Token": raw_token}
+        )
+        assert resp.status_code == 200
+        assert resp.json()["layers"] == []
+
+    async def test_embed_token_for_other_map_resolves_empty_scope(
+        self, client: AsyncClient, admin_auth_header: dict, test_db_session
+    ):
+        admin_id = await get_user_id(test_db_session, "admin")
+        ds_a = await create_dataset(
+            test_db_session, created_by=admin_id, visibility="public"
+        )
+        ds_b = await create_dataset(
+            test_db_session, created_by=admin_id, visibility="public"
+        )
+        map_a, _share_a, _ = await _make_public_shared_map(
+            client, admin_auth_header, [str(ds_a.id)]
+        )
+        map_b, _share_b, _ = await _make_public_shared_map(
+            client, admin_auth_header, [str(ds_b.id)]
+        )
+        _token_obj, raw_token = await create_embed_token(
+            test_db_session, uuid.UUID(map_a), admin_id
+        )
+        await test_db_session.commit()
+
+        scope = await resolve_embed_scope_for_map(
+            test_db_session, raw_token, uuid.UUID(map_b)
+        )
+        assert scope == set()
+        scope_a = await resolve_embed_scope_for_map(
+            test_db_session, raw_token, uuid.UUID(map_a)
+        )
+        assert scope_a == {ds_a.id}
+
+
+class TestBatchTokensEmbedFallback:
+    async def test_anonymous_batch_denied_without_embed_token(
+        self, client: AsyncClient, admin_auth_header: dict, test_db_session
+    ):
+        admin_id = await get_user_id(test_db_session, "admin")
+        private_ds = await create_dataset(
+            test_db_session, created_by=admin_id, visibility="public"
+        )
+        await _make_public_shared_map(client, admin_auth_header, [str(private_ds.id)])
+        await _downgrade_to_private(test_db_session, private_ds)
+
+        resp = await client.post(
+            "/tiles/tokens/", json={"dataset_ids": [str(private_ds.id)]}
+        )
+        assert resp.status_code == 200
+        assert "error" in resp.json()["tokens"][str(private_ds.id)]
+
+    async def test_anonymous_batch_authorized_with_embed_token(
+        self, client: AsyncClient, admin_auth_header: dict, test_db_session
+    ):
+        admin_id = await get_user_id(test_db_session, "admin")
+        private_ds = await create_dataset(
+            test_db_session, created_by=admin_id, visibility="public"
+        )
+        map_id, _share_token, _ = await _make_public_shared_map(
+            client, admin_auth_header, [str(private_ds.id)]
+        )
+        _token_obj, raw_token = await create_embed_token(
+            test_db_session, uuid.UUID(map_id), admin_id
+        )
+        await test_db_session.commit()
+        await _downgrade_to_private(test_db_session, private_ds)
+
+        resp = await client.post(
+            "/tiles/tokens/",
+            json={"dataset_ids": [str(private_ds.id)]},
+            headers={"X-Embed-Token": raw_token},
+        )
+        assert resp.status_code == 200
+        entry = resp.json()["tokens"][str(private_ds.id)]
+        assert entry.get("kind") == "vector", entry
+        assert entry["scope"]
+
+
+class TestTileVersionField:
+    async def test_map_layers_carry_tile_version(
+        self, client: AsyncClient, admin_auth_header: dict, test_db_session
+    ):
+        admin_id = await get_user_id(test_db_session, "admin")
+        ds = await create_dataset(
+            test_db_session, created_by=admin_id, visibility="public"
+        )
+        map_id, share_token, _ = await _make_public_shared_map(
+            client, admin_auth_header, [str(ds.id)]
+        )
+
+        builder_resp = await client.get(f"/maps/{map_id}", headers=admin_auth_header)
+        assert builder_resp.status_code == 200
+        assert builder_resp.json()["layers"][0]["tile_version"] == 1
+
+        shared_resp = await client.get(f"/maps/shared/{share_token}")
+        assert shared_resp.status_code == 200
+        assert shared_resp.json()["layers"][0]["tile_version"] == 1

--- a/backend/tests/test_shared_map_embed_scope.py
+++ b/backend/tests/test_shared_map_embed_scope.py
@@ -245,3 +245,38 @@ class TestTileVersionField:
         shared_resp = await client.get(f"/maps/shared/{share_token}")
         assert shared_resp.status_code == 200
         assert shared_resp.json()["layers"][0]["tile_version"] == 1
+
+
+class TestGeojsonZEmbedFallback:
+    async def test_geojson_z_accepts_embed_token_for_scoped_dataset(
+        self, client: AsyncClient, admin_auth_header: dict, test_db_session
+    ):
+        """fix(#394) codex P2: the viewer's bounded-GeoJSON path sends
+        X-Embed-Token, and the B-023 union exposes embed-scoped private layers
+        to embeds — the endpoint must honor the token or those layers 401.
+
+        Asserts the AUTH contract only: anonymous → 401; valid scoped token →
+        past the auth gate (200 with a backing data table, 503 without one —
+        never 401/403/404).
+        """
+        admin_id = await get_user_id(test_db_session, "admin")
+        private_ds = await create_dataset(
+            test_db_session, created_by=admin_id, visibility="public"
+        )
+        map_id, _share_token, _ = await _make_public_shared_map(
+            client, admin_auth_header, [str(private_ds.id)]
+        )
+        _token_obj, raw_token = await create_embed_token(
+            test_db_session, uuid.UUID(map_id), admin_id
+        )
+        await test_db_session.commit()
+        await _downgrade_to_private(test_db_session, private_ds)
+
+        anon = await client.get(f"/datasets/{private_ds.id}/features.geojson")
+        assert anon.status_code == 401
+
+        with_token = await client.get(
+            f"/datasets/{private_ds.id}/features.geojson",
+            headers={"X-Embed-Token": raw_token},
+        )
+        assert with_token.status_code not in (401, 403, 404), with_token.text

--- a/backend/tests/test_tile_cache.py
+++ b/backend/tests/test_tile_cache.py
@@ -312,3 +312,45 @@ async def test_init_tile_pool_passes_setup_callback(monkeypatch):
         pool_module._tile_pool = None
 
     assert captured_kwargs.get("setup") is pool_module._setup_tile_connection
+
+
+@pytest.mark.asyncio
+async def test_invalidate_table_purges_tenant_prefixed_keys(tile_cache):
+    """fix(#394) VT-08: multi_tenant keys are `tile:{tid}:{table}:...` — the
+    invalidation must purge those alongside the bare single-tenant keys."""
+    data = gzip.compress(b"tile")
+    await tile_cache.set("target", 1, 0, 0, data, ttl=60)
+    await tile_cache.set(
+        "11111111-2222-3333-4444-555555555555:target", 1, 0, 0, data, ttl=60
+    )
+    await tile_cache.set("other", 1, 0, 0, data, ttl=60)
+
+    await tile_cache.invalidate_table("target")
+
+    assert await tile_cache.get("target", 1, 0, 0) is None
+    assert (
+        await tile_cache.get("11111111-2222-3333-4444-555555555555:target", 1, 0, 0)
+        is None
+    )
+    assert await tile_cache.get("other", 1, 0, 0) == data
+
+
+@pytest.mark.asyncio
+async def test_in_memory_invalidate_table_purges_tenant_prefixed_keys():
+    """fix(#394) VT-08: same contract for the InMemory fallback provider."""
+    from app.platform.cache.tile_cache import InMemoryTileCacheProvider
+
+    cache = InMemoryTileCacheProvider(max_entries=10)
+    await cache.set("target", 1, 0, 0, b"a", ttl=60)
+    await cache.set(
+        "11111111-2222-3333-4444-555555555555:target", 1, 0, 0, b"b", ttl=60
+    )
+    await cache.set("other", 1, 0, 0, b"c", ttl=60)
+
+    await cache.invalidate_table("target")
+
+    assert await cache.get("target", 1, 0, 0) is None
+    assert (
+        await cache.get("11111111-2222-3333-4444-555555555555:target", 1, 0, 0) is None
+    )
+    assert await cache.get("other", 1, 0, 0) == b"c"

--- a/e2e/builder.spec.ts
+++ b/e2e/builder.spec.ts
@@ -427,7 +427,8 @@ test.describe.serial('Map Builder', () => {
     const presetSection = editor.locator('section').filter({ hasText: /^PRESET/i }).first();
     await expect(presetSection).toBeVisible({ timeout: 5_000 });
 
-    await presetSection.getByRole('button', { name: /OpenFreeMap Dark/i }).click();
+    // fix(#394) UX-03: preset cards are role="radio" inside a radiogroup now.
+    await presetSection.getByRole('radio', { name: /OpenFreeMap Dark/i }).click();
 
     // Phase 1035 replaced the dedicated "Basemap" section heading with a
     // basemap-group row at the top of the unified stack (id=stack-row-basemap-group);

--- a/frontend/src/api/maps.ts
+++ b/frontend/src/api/maps.ts
@@ -192,10 +192,16 @@ export async function bulkDeleteLayersApi(
  * Other error statuses (403, 410 expired, 500) still throw ApiError normally so
  * that they surface correctly (e.g. the "Link expired" view for 410).
  */
-export async function getSharedMap(token: string, apiKey?: string): Promise<SharedMapResponse | null> {
+export async function getSharedMap(token: string, apiKey?: string, embedToken?: string): Promise<SharedMapResponse | null> {
   const extraHeaders: Record<string, string> = {};
   if (apiKey) {
     extraHeaders['X-Api-Key'] = apiKey;
+  }
+  // fix(#394) SH-01/B-023: embed viewers present their embed token so the
+  // metadata payload includes the token's scoped (possibly non-public)
+  // dataset layers — the tile path already honored the same capability.
+  if (embedToken) {
+    extraHeaders['X-Embed-Token'] = embedToken;
   }
   const resp = await apiFetch<SharedMapResponse | null>(`/maps/shared/${token}`, {
     headers: extraHeaders,

--- a/frontend/src/api/tiles.ts
+++ b/frontend/src/api/tiles.ts
@@ -41,11 +41,14 @@ export type TileTokenBatchResponse = {
  * Errors for individual datasets are returned as ``{ error: string }``
  * values in the ``tokens`` map; the overall call still resolves.
  */
-export function getTileTokensBatch(datasetIds: string[], apiKey?: string): Promise<TileTokenBatchResponse> {
+// fix(#394) SH-04: embed viewers pass their X-Embed-Token so scoped datasets
+// mint the same tile/DEM descriptors an authenticated viewer would get.
+export function getTileTokensBatch(datasetIds: string[], apiKey?: string, embedToken?: string): Promise<TileTokenBatchResponse> {
+  const embedHeader: Record<string, string> = embedToken ? { 'X-Embed-Token': embedToken } : {};
   if (apiKey) {
     return fetch(`${API_BASE}/tiles/tokens/`, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json', 'X-Api-Key': apiKey },
+      headers: { 'Content-Type': 'application/json', 'X-Api-Key': apiKey, ...embedHeader },
       body: JSON.stringify({ dataset_ids: datasetIds }),
     }).then((res) => {
       if (!res.ok) throw new Error(`Batch token request failed: ${res.status}`);
@@ -54,6 +57,7 @@ export function getTileTokensBatch(datasetIds: string[], apiKey?: string): Promi
   }
   return apiFetch<TileTokenBatchResponse>('/tiles/tokens/', {
     method: 'POST',
+    headers: embedHeader,
     body: JSON.stringify({ dataset_ids: datasetIds }),
   });
 }

--- a/frontend/src/components/builder/BasemapGroupEditorScene.tsx
+++ b/frontend/src/components/builder/BasemapGroupEditorScene.tsx
@@ -84,10 +84,20 @@ export function BasemapGroupEditorScene({
           <p className="text-[10px] font-semibold uppercase tracking-[0.08em] text-muted-foreground mb-2">
             {t('basemapGroup.presetSectionLabel', { defaultValue: 'PRESET' })}
           </p>
-          <div className="grid grid-cols-2 gap-2">
+          {/* fix(#394) UX-03/B-017: expose selected-state to assistive tech —
+              radiogroup + aria-checked, same pattern as the Projection pills
+              in SettingsEditorScene. The border highlight alone was invisible
+              to screen readers. */}
+          <div
+            role="radiogroup"
+            aria-label={t('basemapGroup.presetSectionAria', { defaultValue: 'Basemap preset' })}
+            className="grid grid-cols-2 gap-2"
+          >
             {/* "No basemap" preset card — always first, before all provider presets */}
             <button
               type="button"
+              role="radio"
+              aria-checked={activePresetId === BLANK_BASEMAP_ID}
               onClick={() => onSwapBasemap(BLANK_BASEMAP_ID)}
               className={cn(
                 'flex flex-col rounded-[var(--radius-md)] border p-2 text-left transition-colors',
@@ -113,6 +123,8 @@ export function BasemapGroupEditorScene({
                 <button
                   key={preset.id}
                   type="button"
+                  role="radio"
+                  aria-checked={isActive}
                   onClick={() => onSwapBasemap(preset.id)}
                   className={cn(
                     'flex flex-col rounded-[var(--radius-md)] border p-2 text-left transition-colors',

--- a/frontend/src/components/builder/BuilderMap.tsx
+++ b/frontend/src/components/builder/BuilderMap.tsx
@@ -166,10 +166,12 @@ export function buildVectorSourceTileUrl(
     const { clusterRadius, clusterMaxZoom } = getClusterSourceOptions(
       { style_config: layer.style_config } as AdapterLayerInput,
     );
-    return buildClusterTileUrl(layer.dataset_table_name, token, tileBaseUrl, undefined, { clusterRadius, clusterMaxZoom });
+    // fix(#394) VT-02 (codex P2): keep the `_v=` cache-buster on token-refresh
+    // rebuilds — dropping it here rebuilt URLs on the pre-reupload cache key.
+    return buildClusterTileUrl(layer.dataset_table_name, token, tileBaseUrl, layer.tile_version ?? undefined, { clusterRadius, clusterMaxZoom });
   }
   const sharedSourceCols = getDataDrivenColumnsForSource(sourceId, allLayers);
-  return buildSignedTileUrl(layer.dataset_table_name, token, tileBaseUrl, undefined, sharedSourceCols);
+  return buildSignedTileUrl(layer.dataset_table_name, token, tileBaseUrl, layer.tile_version ?? undefined, sharedSourceCols);
 }
 
 export function resignVectorSourceForRetry(

--- a/frontend/src/components/builder/BuilderMap.tsx
+++ b/frontend/src/components/builder/BuilderMap.tsx
@@ -1114,7 +1114,13 @@ export const BuilderMap = memo(function BuilderMap({
   const hasSavedView = !!(initialViewState?.center_lng != null && initialViewState?.center_lat != null);
   const initialFitDoneRef = useRef(false);
   const prevLayerCountRef = useRef(layers.length);
-  const prevVisibleBoundsKeyRef = useRef(visibleLayerBoundsKey(getVisibleLayerBounds(layers)));
+  // fix(#394) PF-05: lazy-seed — a useRef initializer ARGUMENT evaluates on
+  // every render, so the full bounds walk ran per render and was discarded
+  // after mount. Seed once on first render instead.
+  const prevVisibleBoundsKeyRef = useRef<string | undefined>(undefined);
+  if (prevVisibleBoundsKeyRef.current === undefined) {
+    prevVisibleBoundsKeyRef.current = visibleLayerBoundsKey(getVisibleLayerBounds(layers));
+  }
 
   // Auto-fit to visible layers (skip on initial load if saved view exists)
   useEffect(() => {

--- a/frontend/src/components/builder/BuilderRail.tsx
+++ b/frontend/src/components/builder/BuilderRail.tsx
@@ -186,11 +186,21 @@ export function BuilderRail({
 
       {/* Expanded panel */}
       {activePanel && (
+        // eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions -- container-level Escape shortcut for keystrokes bubbling from the panel's own interactive children; the aside itself stays non-interactive
         <aside
           className={cn(
             'bg-background border-s flex h-full min-h-0 flex-col shrink-0 overflow-hidden',
             showRail ? 'w-80' : 'w-full border-s-0',
           )}
+          onKeyDown={(e) => {
+            // fix(#394) UX-07: Escape closes the expanded rail panel — parity
+            // with the editor flyout's Escape (non-modal, fires only when
+            // focus is inside the panel).
+            if (e.key === 'Escape' && !e.defaultPrevented) {
+              e.stopPropagation();
+              onPanelChange(null);
+            }
+          }}
         >
           {/* Panel header */}
           <div className="flex items-center justify-between px-3.5 py-2.5 border-b shrink-0">

--- a/frontend/src/components/builder/ChatPanel.tsx
+++ b/frontend/src/components/builder/ChatPanel.tsx
@@ -220,8 +220,29 @@ function validateChatPaint(
     for (const key of CHAT_PRESERVED_FILL_OUTLINE_KEYS) {
       if (rawPaint[key] != null) filtered[key] = rawPaint[key];
     }
+    // fix(#394) CH-01: preserve fill-extrusion-* on the fill branch — the
+    // extrusion COMPANION layer consumes them from layer.paint, and the
+    // backend keeps them for polygons (_VALID_PAINT_PROPS fill ∪
+    // fill-extrusion). Dropping them made an extrusion-only set_style a
+    // silent no-op. filterPaintForLayerType still excludes them from the
+    // actual MapLibre fill layer at apply time.
+    for (const [key, value] of Object.entries(rawPaint)) {
+      if (key.startsWith('fill-extrusion-') && value != null) {
+        filtered[key] = value;
+      }
+    }
   }
   return clampPaintBounds(filtered);
+}
+
+// fix(#394) CH-02: permissive color-shape check for AI-produced label colors —
+// hex, named (`red`), or functional (`rgb(...)`/`hsla(...)`) forms MapLibre can
+// parse. Mirrors the backend chat_actions._CSS_COLORISH_RE so both sides drop
+// the same junk.
+const CSS_COLORISH_RE = /^(#[0-9a-fA-F]{3,8}|[a-zA-Z]{3,30}|(rgb|rgba|hsl|hsla)\([^)]{1,60}\))$/;
+
+function isCssColorish(value: unknown): value is string {
+  return typeof value === 'string' && CSS_COLORISH_RE.test(value.trim());
 }
 
 // fix(#392): clamp bounds for AI-produced set_label numeric fields, matching
@@ -506,18 +527,20 @@ export function ChatPanel({
         const rawPaint = getActionPaint(action);
         if (layerId && rawPaint) {
           const layer = layersRef.current.find((candidate) => candidate.id === layerId);
+          // fix(#394) CH-03: require the target layer — when it isn't found
+          // client-side the RAW paint used to be applied unvalidated AND the
+          // turn still reported "applied". Mirrors set_style's layer gate.
+          if (!layer) return false;
           const styleConfig = isRecord(action.style_config) ? (action.style_config as StyleConfig) : null;
           // fix(#392): render-mode aware — heatmap data-driven paint keeps its heatmap-*
           // properties instead of being dropped as invalid-for-circle. Fall back to the
           // layer's own render_mode when the action omits it (style_config.render_mode is
           // optional), so a data-driven heatmap update on a heatmap layer keeps its
           // heatmap-* paint instead of validating to a no-op. (audit B-002/CH-01)
-          const effectiveRenderMode = styleConfig?.render_mode ?? layer?.style_config?.render_mode;
-          const validatedPaint = layer
-            ? validateChatPaint(rawPaint, layer, effectiveRenderMode)
-            : rawPaint;
+          const effectiveRenderMode = styleConfig?.render_mode ?? layer.style_config?.render_mode;
+          const validatedPaint = validateChatPaint(rawPaint, layer, effectiveRenderMode);
           const validatedAction: ChatAction = { ...action, paint: validatedPaint };
-          const nextPaint = buildChatActionPaint(layer?.paint, validatedAction);
+          const nextPaint = buildChatActionPaint(layer.paint, validatedAction);
           // fix(#392): carry the fallback render_mode into the persisted style_config too —
           // onStyleConfigChange REPLACES style_config, so a heatmap layer whose action
           // omitted render_mode would otherwise lose heatmap mode and (adapter resolution
@@ -525,6 +548,10 @@ export function ChatPanel({
           const nextConfig = styleConfig && effectiveRenderMode && !styleConfig.render_mode
             ? ({ ...styleConfig, render_mode: effectiveRenderMode } as StyleConfig)
             : styleConfig;
+          // fix(#394) CH-03: mutation gate (match set_style) — a paint that
+          // validated to empty with no style_config change is a no-op, not an
+          // "applied" change.
+          if (!hasPaintMutation(validatedAction) && !nextConfig) return false;
           onStyleConfigChange(layerId, nextConfig, nextPaint);
           return true;
         }
@@ -533,7 +560,28 @@ export function ChatPanel({
       case 'set_label':
         if (layerId) {
           if (isRecord(action.label_config)) {
-            onLabelChange(layerId, clampLabelConfig(action.label_config as LabelConfig));
+            const lc = action.label_config as LabelConfig;
+            // fix(#394) CH-02: validate the column against the layer schema —
+            // a hallucinated column produced a label layer whose text-field
+            // renders empty everywhere. Backend chat_actions mirrors this and
+            // feeds the model an error, so this is the client-side backstop.
+            const layer = layersRef.current.find((candidate) => candidate.id === layerId);
+            if (
+              lc.column &&
+              layer?.dataset_column_info &&
+              layer.dataset_column_info.length > 0 &&
+              !layer.dataset_column_info.some((col) => col.name === lc.column)
+            ) {
+              return false;
+            }
+            // fix(#394) CH-02: drop an unparseable textColor (objects, junk
+            // strings) instead of handing it to map.setPaintProperty — the
+            // adapter then falls back to its default label color.
+            const safeConfig = { ...lc };
+            if (safeConfig.textColor != null && !isCssColorish(safeConfig.textColor)) {
+              delete safeConfig.textColor;
+            }
+            onLabelChange(layerId, clampLabelConfig(safeConfig));
           } else {
             onLabelChange(layerId, null);
           }
@@ -633,9 +681,11 @@ export function ChatPanel({
         staging.push(action);
         // Record in pendingActions so the message's actions[] captures the intent.
         pendingActions.push(action);
-        // B-013: a destructive action is never undo-safe. Downgrade the turn's
-        // snapshot so undo stays suppressed even after the user accepts.
-        if (lastSnapshotRef.current) lastSnapshotRef.current.supportsUndo = false;
+        // fix(#394) CH-11: do NOT downgrade undo here — a merely-STAGED action
+        // hasn't touched the map, so a mixed turn's style edits stay undoable
+        // and a rejected staging leaves undo intact. The downgrade happens in
+        // handleChatAction's add_layer/remove_layer cases, which is exactly
+        // the staging-ACCEPT dispatch path.
         continue;
       }
       // fix(#392): "Applied N changes" counts effect, not intent — only record the

--- a/frontend/src/components/builder/ChatPanel.tsx
+++ b/frontend/src/components/builder/ChatPanel.tsx
@@ -235,14 +235,40 @@ function validateChatPaint(
   return clampPaintBounds(filtered);
 }
 
-// fix(#394) CH-02: permissive color-shape check for AI-produced label colors —
-// hex, named (`red`), or functional (`rgb(...)`/`hsla(...)`) forms MapLibre can
-// parse. Mirrors the backend chat_actions._CSS_COLORISH_RE so both sides drop
-// the same junk.
-const CSS_COLORISH_RE = /^(#[0-9a-fA-F]{3,8}|[a-zA-Z]{3,30}|(rgb|rgba|hsl|hsla)\([^)]{1,60}\))$/;
+// fix(#394) CH-02 (codex round 2): hex (3/4/6/8 digits), real CSS named
+// colors, or numeric-arg functional forms only — the first-pass shape regex
+// let "notacolor"/"rgb(foo)" through to MapLibre paint validation, which is
+// exactly what this sanitizer exists to prevent. Byte-parity mirror of
+// backend app/processing/ai/colors.py; MapLibre stays the final validator.
+const CSS_HEX_RE = /^#(?:[0-9a-fA-F]{3,4}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})$/;
+const CSS_FUNCTIONAL_RE = /^(?:rgb|rgba|hsl|hsla)\(\s*[0-9deg.,%\s/+-]{1,60}\s*\)$/;
+const CSS_NAMED_COLORS = new Set((
+  'aliceblue antiquewhite aqua aquamarine azure beige bisque black blanchedalmond blue '
+  + 'blueviolet brown burlywood cadetblue chartreuse chocolate coral cornflowerblue cornsilk '
+  + 'crimson cyan darkblue darkcyan darkgoldenrod darkgray darkgreen darkgrey darkkhaki '
+  + 'darkmagenta darkolivegreen darkorange darkorchid darkred darksalmon darkseagreen '
+  + 'darkslateblue darkslategray darkslategrey darkturquoise darkviolet deeppink deepskyblue '
+  + 'dimgray dimgrey dodgerblue firebrick floralwhite forestgreen fuchsia gainsboro ghostwhite '
+  + 'gold goldenrod gray green greenyellow grey honeydew hotpink indianred indigo ivory khaki '
+  + 'lavender lavenderblush lawngreen lemonchiffon lightblue lightcoral lightcyan '
+  + 'lightgoldenrodyellow lightgray lightgreen lightgrey lightpink lightsalmon lightseagreen '
+  + 'lightskyblue lightslategray lightslategrey lightsteelblue lightyellow lime limegreen linen '
+  + 'magenta maroon mediumaquamarine mediumblue mediumorchid mediumpurple mediumseagreen '
+  + 'mediumslateblue mediumspringgreen mediumturquoise mediumvioletred midnightblue mintcream '
+  + 'mistyrose moccasin navajowhite navy oldlace olive olivedrab orange orangered orchid '
+  + 'palegoldenrod palegreen paleturquoise palevioletred papayawhip peachpuff peru pink plum '
+  + 'powderblue purple rebeccapurple red rosybrown royalblue saddlebrown salmon sandybrown '
+  + 'seagreen seashell sienna silver skyblue slateblue slategray slategrey snow springgreen '
+  + 'steelblue tan teal thistle tomato turquoise violet wheat white whitesmoke yellow '
+  + 'yellowgreen transparent'
+).split(' '));
 
 function isCssColorish(value: unknown): value is string {
-  return typeof value === 'string' && CSS_COLORISH_RE.test(value.trim());
+  if (typeof value !== 'string') return false;
+  const candidate = value.trim();
+  return CSS_HEX_RE.test(candidate)
+    || CSS_FUNCTIONAL_RE.test(candidate)
+    || CSS_NAMED_COLORS.has(candidate.toLowerCase());
 }
 
 // fix(#392): clamp bounds for AI-produced set_label numeric fields, matching

--- a/frontend/src/components/builder/KeyboardShortcutsSheet.tsx
+++ b/frontend/src/components/builder/KeyboardShortcutsSheet.tsx
@@ -8,7 +8,7 @@ import {
 } from '@/components/ui/dialog';
 // builder-audit #338 STACK-07: shared platform detection + Save chord (was duplicated
 // from MapTitleBar.tsx).
-import { SAVE_SHORTCUT } from '@/lib/platform';
+import { IS_MAC, SAVE_SHORTCUT } from '@/lib/platform';
 
 interface ShortcutRowProps {
   id: string;
@@ -61,6 +61,45 @@ export function KeyboardShortcutsSheet({
       id: 'legend',
       label: t('a11y.shortcuts.legend', { defaultValue: 'Toggle legend' }),
       chord: 'L',
+    },
+    // fix(#394) UX-04/B-029: the sheet previously omitted half the real
+    // keyboard model — every row below documents a binding that already
+    // exists (MapBuilderPage '?' hotkey, StackRow reorder mode, panel
+    // Escape handlers, UnifiedStackPanel multi-select).
+    {
+      id: 'shortcuts',
+      label: t('a11y.shortcuts.showSheet', { defaultValue: 'Show this dialog' }),
+      chord: '?',
+    },
+    {
+      id: 'reorder-toggle',
+      label: t('a11y.shortcuts.reorderToggle', { defaultValue: 'Toggle reorder mode (focused layer row)' }),
+      chord: 'Enter',
+    },
+    {
+      id: 'reorder-move',
+      label: t('a11y.shortcuts.reorderMove', { defaultValue: 'Move layer up / down (reorder mode)' }),
+      chord: '↑ / ↓',
+    },
+    {
+      id: 'escape',
+      label: t('a11y.shortcuts.escape', { defaultValue: 'Close panel / clear selection / exit reorder' }),
+      chord: 'Esc',
+    },
+    {
+      id: 'multi-select',
+      label: t('a11y.shortcuts.multiSelect', { defaultValue: 'Toggle layer in selection' }),
+      chord: IS_MAC ? '⌘+Click' : 'Ctrl+Click',
+    },
+    {
+      id: 'range-select',
+      label: t('a11y.shortcuts.rangeSelect', { defaultValue: 'Select a range of layers' }),
+      chord: 'Shift+Click',
+    },
+    {
+      id: 'extend-select',
+      label: t('a11y.shortcuts.extendSelect', { defaultValue: 'Extend selection (stack focused)' }),
+      chord: 'Shift+↑ / ↓',
     },
   ];
 

--- a/frontend/src/components/builder/LayerFilterEditor.tsx
+++ b/frontend/src/components/builder/LayerFilterEditor.tsx
@@ -116,7 +116,19 @@ export function buildFilterExpression(
     if (c.value === '' || c.value === undefined || c.value === null) return false;
     // Reject non-numeric values for numeric columns
     const col = columnInfo.find((ci) => ci.name === c.field);
-    if (col && classifyColumnType(col.type) === 'number' && isNaN(Number(c.value))) return false;
+    const isNumeric = !!col && classifyColumnType(col.type) === 'number';
+    // fix(#394) FL-03: list operators validate PER ENTRY — the whole-string
+    // NaN check below would reject every numeric list ("1,2" → Number NaN);
+    // the condition stays valid while at least one entry is numeric, and the
+    // emit branch drops the non-numeric entries.
+    if (isNumeric && (c.operator === 'in_list' || c.operator === 'not_in_list')) {
+      return String(c.value)
+        .split(',')
+        .map((v) => v.trim())
+        .filter(Boolean)
+        .some((v) => !isNaN(Number(v)));
+    }
+    if (isNumeric && isNaN(Number(c.value))) return false;
     return true;
   });
   if (valid.length === 0) return null;
@@ -131,14 +143,17 @@ export function buildFilterExpression(
       expressions.push(['any', ['!', ['has', cond.field]], ['==', ['get', cond.field], null]]);
     } else if (cond.operator === 'has') {
       expressions.push(['has', cond.field]);
-    } else if (cond.operator === 'in_list') {
+    } else if (cond.operator === 'in_list' || cond.operator === 'not_in_list') {
       const values = String(cond.value).split(',').map(v => v.trim()).filter(Boolean);
-      const coerced = values.map(v => coerceValue(v, pgType));
-      expressions.push(['in', ['get', cond.field], ['literal', coerced]]);
-    } else if (cond.operator === 'not_in_list') {
-      const values = String(cond.value).split(',').map(v => v.trim()).filter(Boolean);
-      const coerced = values.map(v => coerceValue(v, pgType));
-      expressions.push(['!', ['in', ['get', cond.field], ['literal', coerced]]]);
+      // fix(#394) FL-03: per-entry NaN guard for numeric columns — coerceValue
+      // leaves non-numeric entries as strings, so "1,abc,3" silently emitted a
+      // mixed-type literal. Drop the entries that don't coerce instead.
+      const numericColumn = classifyColumnType(pgType) === 'number';
+      const coerced = values
+        .map(v => coerceValue(v, pgType))
+        .filter(v => !numericColumn || typeof v === 'number');
+      const inExpr = ['in', ['get', cond.field], ['literal', coerced]];
+      expressions.push(cond.operator === 'in_list' ? inExpr : ['!', inExpr]);
     } else if (cond.operator === 'contains') {
       expressions.push(['in', cond.value.trim(), ['get', cond.field]]);
     } else {
@@ -375,7 +390,10 @@ export function LayerFilterEditor({
 
   return (
     <div className="space-y-3 rounded-md border bg-muted/30 p-3">
-      {/* EASY-18: empty-state hint — shown when filter is active but 0 features rendered */}
+      {/* EASY-18: empty-state hint — shown when filter is active but 0 features rendered.
+          fix(#394) FL-02: the count is VIEWPORT-scoped (queryRenderedFeatures), so
+          the copy says "in view" — matches may exist off-screen and "eliminated
+          every feature" was a false alarm in that case. */}
       {showEmptyState && (
         <div
           role="status"
@@ -383,12 +401,12 @@ export function LayerFilterEditor({
           className="mb-3 rounded-md border border-destructive/30 bg-destructive/5 p-3"
         >
           <p className="text-xs font-semibold text-foreground">
-            {t('layerEditor.emptyResult.title', { defaultValue: '0 features — check your filter' })}
+            {t('layerEditor.emptyResult.title', { defaultValue: '0 features in view — check your filter' })}
           </p>
           <p className="mt-1 text-[11px] text-muted-foreground">
             {t('layerEditor.emptyResult.help', {
               defaultValue:
-                'The current filter eliminated every feature in this layer. Adjust a condition or clear the filter to see features again.',
+                'The current filter matches nothing in the visible map area. Matches may exist off-screen — pan or zoom out, adjust a condition, or clear the filter.',
             })}
           </p>
           <Button

--- a/frontend/src/components/builder/LayerStyleEditor.tsx
+++ b/frontend/src/components/builder/LayerStyleEditor.tsx
@@ -13,7 +13,7 @@ import {
   hasUnsavedStyleChanges as hasUnsavedStyleChangesImpl,
 } from './LayerStyleEditor/utils';
 import { LazyLoadErrorBoundary } from '@/components/error';
-import { getLayerType } from '@/components/builder/map-sync';
+import { getLayerType, resolveAdapterType } from '@/components/builder/map-sync';
 import { isNumericColumn } from '@/lib/column-utils';
 import { stripLegacyBuilderPaint } from '@/lib/normalize-style-config';
 import { GeometrySwatch } from '@/components/map/LegendEntries';
@@ -139,6 +139,14 @@ export const LayerStyleEditor = memo(function LayerStyleEditor({
   );
   const editorPaint = useMemo(() => stripBuilderPrivate(paint), [paint, stripBuilderPrivate]);
   const editorLayout = useMemo(() => stripBuilderPrivate(layoutObj), [layoutObj, stripBuilderPrivate]);
+  // fix(#394) ST-02/B-031: the Advanced JSON editor must validate against the
+  // RENDERED layer type, not the geometry-derived one — a heatmap-rendered
+  // point layer rejected valid heatmap-* paint and accepted dead circle-*
+  // paint. Cluster renders as circles for validation purposes.
+  const advancedJsonLayerType = useMemo(() => {
+    const resolved = resolveAdapterType(layer.dataset_geometry_type, layer.style_config, editorPaint);
+    return resolved === 'cluster' ? 'circle' : resolved;
+  }, [layer.dataset_geometry_type, layer.style_config, editorPaint]);
   const isDataDriven = !!layer.style_config?.column;
   const renderMode: 'points' | 'heatmap' | 'symbol' | 'cluster' = layer.style_config?.render_mode === 'heatmap'
     ? 'heatmap'
@@ -487,7 +495,7 @@ export const LayerStyleEditor = memo(function LayerStyleEditor({
           layout={editorLayout}
           onPaintChange={(p) => onPaintChange(layer.id, p)}
           onLayoutChange={(l) => onLayoutChange(layer.id, l)}
-          layerType={geomType}
+          layerType={advancedJsonLayerType}
         />
       </StyleControlSection>
     </div>

--- a/frontend/src/components/builder/LayerStyleEditor/AdvancedJsonEditor.tsx
+++ b/frontend/src/components/builder/LayerStyleEditor/AdvancedJsonEditor.tsx
@@ -14,7 +14,7 @@ function validatePropertyBlock(
   value: Record<string, unknown>,
   layerType: string | undefined,
   block: 'paint' | 'layout',
-): string[] {
+): string[] | null {
   if (!layerType) return [];
   // Construct a layer object with the right shape for the requested type.
   // Use a GeoJSON source stub (no source-layer needed) with lineMetrics
@@ -44,10 +44,11 @@ function validatePropertyBlock(
     // any object shape; cast to satisfy the compiler.
     errors = validateStyleMin(testStyle as unknown as Parameters<typeof validateStyleMin>[0]) ?? [];
   } catch {
-    // If the validator itself throws, fall back to no errors rather than
-    // blocking the user — better to let MapLibre runtime catch real bugs
-    // than to falsely reject a paste that the validator can't parse.
-    return [];
+    // fix(#394) ST-05: a validator crash must BLOCK the apply (null sentinel),
+    // not wave the paste through — returning [] here applied unvalidated JSON
+    // straight to MapLibre, exactly the failure class this editor exists to
+    // prevent.
+    return null;
   }
   return errors
     .map((e) => e?.message ?? '')
@@ -96,6 +97,13 @@ function JsonBlock({ label, value, onApply, layerType, block }: JsonBlockProps) 
       // names, color values, numeric bounds, expression syntax, types.
       if (layerType) {
         const validationErrors = validatePropertyBlock(parsed, layerType, block);
+        if (validationErrors === null) {
+          // fix(#394) ST-05: validator crashed — block the apply.
+          setError(t('style.validatorUnavailable', {
+            defaultValue: 'This JSON could not be validated — simplify the value and try again.',
+          }));
+          return;
+        }
         if (validationErrors.length > 0) {
           setError(validationErrors.join('; '));
           return;

--- a/frontend/src/components/builder/MapToolbar.tsx
+++ b/frontend/src/components/builder/MapToolbar.tsx
@@ -15,6 +15,13 @@ import {
 /**
  * Floating toolbar centered at the top of the map canvas.
  * Grouped into semantic sections: navigation | plugins.
+ *
+ * fix(#394) UX-08 (decision record): there is deliberately NO global terrain
+ * toggle here. Terrain is layer-owned — it activates through a DEM layer's
+ * editor scene (render mode + exaggeration live with the layer that supplies
+ * the elevation data), so a map without a DEM layer has nothing for a global
+ * toggle to enable. Revisit only alongside the global-base-DEM plan
+ * (terrain-pedestal Phase 1), which would give every map a default source.
  */
 interface MapToolbarProps {
   onStyleJsonClick?: () => void;

--- a/frontend/src/components/builder/SceneSpinnerFallback.tsx
+++ b/frontend/src/components/builder/SceneSpinnerFallback.tsx
@@ -1,17 +1,20 @@
 import { Loader2 } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
 
 /**
  * Lightweight Suspense fallback for lazy-loaded editor scenes and dialogs.
  * Used inside LayerEditorPanel flyout and BuilderDialogs — lighter than the
  * full-page LoadingState since the surrounding chrome is already visible.
  *
- * UI-SPEC PERF-05: centered Loader2 spinner, role="status", aria-label="Loading panel"
+ * UI-SPEC PERF-05: centered Loader2 spinner, role="status".
+ * fix(#394) UX-06: aria-label is localized (was hardcoded English).
  */
 export function SceneSpinnerFallback() {
+  const { t } = useTranslation('builder');
   return (
     <div
       role="status"
-      aria-label="Loading panel"
+      aria-label={t('a11y.loadingPanel', { defaultValue: 'Loading panel' })}
       className="flex items-center justify-center p-8"
     >
       <Loader2 className="size-5 animate-spin text-muted-foreground" />

--- a/frontend/src/components/builder/UnifiedStackPanel.tsx
+++ b/frontend/src/components/builder/UnifiedStackPanel.tsx
@@ -694,10 +694,18 @@ export const UnifiedStackPanel = memo(function UnifiedStackPanel({
                   const anyChildMatches = children.some((c) => matchesSearch(c));
                   if (isSearchActive && !groupNameMatches && !anyChildMatches) return null;
 
+                  // fix(#394) LM-04: the group eye reflects the children
+                  // AGGREGATE (on while ANY child is visible) — the synthetic
+                  // row's own `visible` merely mirrors whichever child was
+                  // first at hydration and goes stale on per-child toggles.
+                  const groupEyeLayer = children.length > 0
+                    ? { ...layer, visible: children.some((c) => c.visible !== false) }
+                    : layer;
+
                   return (
                     <div key={layer.id}>
                       <FolderGroupRowWrapper
-                        layer={layer}
+                        layer={groupEyeLayer}
                         selected={layer.id === selectedLayerId}
                         isExpanded={expanded}
                         onSelectGroup={onSelectLayer}

--- a/frontend/src/components/builder/__tests__/BasemapGroupEditorScene.test.tsx
+++ b/frontend/src/components/builder/__tests__/BasemapGroupEditorScene.test.tsx
@@ -92,7 +92,7 @@ describe('BasemapGroupEditorScene', () => {
 
     // The active card (Positron) should have border-primary
     // Find all preset card buttons
-    const cards = screen.getAllByRole('button').filter((b) => b.querySelector('img'));
+    const cards = screen.getAllByRole('radio');
     const positronCard = cards.find((c) => c.textContent?.includes('Positron'));
     const darkCard = cards.find((c) => c.textContent?.includes('Dark Matter'));
 
@@ -106,7 +106,7 @@ describe('BasemapGroupEditorScene', () => {
     const onSwapBasemap = vi.fn();
     render(<BasemapGroupEditorScene {...defaultSceneProps({ onSwapBasemap, activePresetId: 'openfreemap-positron' })} />);
 
-    const cards = screen.getAllByRole('button').filter((b) => b.querySelector('img'));
+    const cards = screen.getAllByRole('radio');
     const darkCard = cards.find((c) => c.textContent?.includes('Dark Matter'));
     expect(darkCard).toBeTruthy();
     fireEvent.click(darkCard!);
@@ -253,7 +253,7 @@ describe('BasemapGroupEditorScene', () => {
 
   it('Test 13: renders "No basemap" card as the FIRST entry in the preset grid', () => {
     render(<BasemapGroupEditorScene {...defaultSceneProps()} />);
-    const cards = screen.getAllByRole('button').filter((b) => b.querySelector('img'));
+    const cards = screen.getAllByRole('radio');
     // 4 existing + 1 new = 5 image-containing buttons
     expect(cards.length).toBe(5);
     expect(cards[0].textContent).toContain('No basemap');
@@ -262,27 +262,27 @@ describe('BasemapGroupEditorScene', () => {
   it('Test 14: clicking "No basemap" card dispatches onSwapBasemap("blank")', () => {
     const onSwapBasemap = vi.fn();
     render(<BasemapGroupEditorScene {...defaultSceneProps({ onSwapBasemap })} />);
-    const noBasemapCard = screen.getByRole('button', { name: /No basemap/ });
+    const noBasemapCard = screen.getByRole('radio', { name: /No basemap/ });
     fireEvent.click(noBasemapCard);
     expect(onSwapBasemap).toHaveBeenCalledWith('blank');
   });
 
   it('Test 15: "No basemap" card has active ring class when activePresetId="blank"', () => {
     render(<BasemapGroupEditorScene {...defaultSceneProps({ activePresetId: 'blank' })} />);
-    const noBasemapCard = screen.getByRole('button', { name: /No basemap/ });
+    const noBasemapCard = screen.getByRole('radio', { name: /No basemap/ });
     expect(noBasemapCard.className).toContain('border-primary');
   });
 
   it('Test 16: "No basemap" card does NOT have active class when a real preset is active', () => {
     render(<BasemapGroupEditorScene {...defaultSceneProps({ activePresetId: 'openfreemap-positron' })} />);
-    const noBasemapCard = screen.getByRole('button', { name: /No basemap/ });
+    const noBasemapCard = screen.getByRole('radio', { name: /No basemap/ });
     expect(noBasemapCard.className).toContain('border-[var(--border)]');
     expect(noBasemapCard.className).not.toContain('border-primary');
   });
 
   it('Test 17: "No basemap" card uses basemapThumbnail("blank") as the img src', () => {
     render(<BasemapGroupEditorScene {...defaultSceneProps()} />);
-    const noBasemapCard = screen.getByRole('button', { name: /No basemap/ });
+    const noBasemapCard = screen.getByRole('radio', { name: /No basemap/ });
     const img = noBasemapCard.querySelector('img');
     expect(img?.getAttribute('src')).toBe('https://thumb.test/blank.png');
   });

--- a/frontend/src/components/builder/__tests__/BuilderMap.unit.test.ts
+++ b/frontend/src/components/builder/__tests__/BuilderMap.unit.test.ts
@@ -76,10 +76,13 @@ describe('getExpressionSafeOpacity', () => {
     expect(getExpressionSafeOpacity({ 'line-opacity': 0.5 }, 'line', 0.4)).toBe(0.2);
   });
 
-  it('returns expression-valued paint opacity without multiplying it', () => {
+  it('fix(#394) ST-03: multiplies expression-valued opacity by the master slider', () => {
     const opacityExpression = ['step', ['zoom'], 0.25, 10, 0.75];
 
-    expect(getExpressionSafeOpacity({ 'circle-opacity': opacityExpression }, 'circle', 0.4)).toEqual(opacityExpression);
+    expect(getExpressionSafeOpacity({ 'circle-opacity': opacityExpression }, 'circle', 0.4))
+      .toEqual(['*', opacityExpression, 0.4]);
+    // Master at 1 keeps the expression identity (no pointless wrapper churn).
+    expect(getExpressionSafeOpacity({ 'circle-opacity': opacityExpression }, 'circle', 1)).toEqual(opacityExpression);
   });
 
   it('uses geometry defaults when paint opacity is missing', () => {

--- a/frontend/src/components/builder/__tests__/LayerFilterEditor.test.ts
+++ b/frontend/src/components/builder/__tests__/LayerFilterEditor.test.ts
@@ -455,7 +455,7 @@ describe('LayerFilterEditor - EASY-18 empty-state hint', () => {
       featureCount: 0,
     }));
 
-    expect(screen.getByText('0 features — check your filter')).toBeInTheDocument();
+    expect(screen.getByText('0 features in view — check your filter')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /clear filter/i })).toBeInTheDocument();
   });
 
@@ -468,7 +468,7 @@ describe('LayerFilterEditor - EASY-18 empty-state hint', () => {
       featureCount: 0,
     }));
 
-    expect(screen.queryByText('0 features — check your filter')).not.toBeInTheDocument();
+    expect(screen.queryByText('0 features in view — check your filter')).not.toBeInTheDocument();
   });
 
   it('EASY-18 — does NOT render hint when featureCount > 0', () => {
@@ -480,7 +480,7 @@ describe('LayerFilterEditor - EASY-18 empty-state hint', () => {
       featureCount: 5,
     }));
 
-    expect(screen.queryByText('0 features — check your filter')).not.toBeInTheDocument();
+    expect(screen.queryByText('0 features in view — check your filter')).not.toBeInTheDocument();
   });
 
   it('EASY-18 — does NOT render hint when featureCount is undefined / null', () => {
@@ -492,7 +492,7 @@ describe('LayerFilterEditor - EASY-18 empty-state hint', () => {
       // featureCount deliberately omitted
     }));
 
-    expect(screen.queryByText('0 features — check your filter')).not.toBeInTheDocument();
+    expect(screen.queryByText('0 features in view — check your filter')).not.toBeInTheDocument();
   });
 
   it('EASY-18 — Clear button invokes onFilterChange(null) (dispatcher boundary regression pin)', () => {
@@ -581,5 +581,33 @@ describe('LayerFilterEditor - B-001 / FL-01: multi-condition round-trip', () => 
     // The first condition's value must not have been reset/reminted by the
     // feed-back re-parse.
     expect((within(rows[0]).getByRole('textbox', { name: 'Value' }) as HTMLInputElement).value).toBe('100');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// fix(#394) FL-03: numeric in_list per-entry NaN guard
+// ---------------------------------------------------------------------------
+describe('numeric in_list per-entry validation (fix(#394) FL-03)', () => {
+  it('drops non-numeric entries instead of emitting a mixed-type literal', () => {
+    const conditions = [{ id: '1', field: 'population', operator: 'in_list', value: '1,abc,3' }];
+    const result = buildFilterExpression(conditions, columns, 'all');
+    expect(result).toEqual(['all', ['in', ['get', 'population'], ['literal', [1, 3]]]]);
+  });
+
+  it('keeps a fully-numeric list valid (the whole-string NaN check rejected it)', () => {
+    const conditions = [{ id: '1', field: 'population', operator: 'in_list', value: '10, 20' }];
+    const result = buildFilterExpression(conditions, columns, 'all');
+    expect(result).toEqual(['all', ['in', ['get', 'population'], ['literal', [10, 20]]]]);
+  });
+
+  it('drops the whole condition when no entry is numeric', () => {
+    const conditions = [{ id: '1', field: 'population', operator: 'in_list', value: 'abc,def' }];
+    expect(buildFilterExpression(conditions, columns, 'all')).toBeNull();
+  });
+
+  it('not_in_list applies the same per-entry guard', () => {
+    const conditions = [{ id: '1', field: 'population', operator: 'not_in_list', value: '5,junk' }];
+    const result = buildFilterExpression(conditions, columns, 'all');
+    expect(result).toEqual(['all', ['!', ['in', ['get', 'population'], ['literal', [5]]]]]);
   });
 });

--- a/frontend/src/components/builder/__tests__/layer-adapters.test.ts
+++ b/frontend/src/components/builder/__tests__/layer-adapters.test.ts
@@ -264,9 +264,11 @@ describe('symbolAdapter', () => {
     symbolAdapter.addLayers(map, input);
 
     const call = (map.addLayer as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    // fix(#394) ST-04: input is to-string-wrapped so numeric MVT values match
+    // the editor's stringified sample values.
     expect(call.layout['icon-image']).toEqual([
       'match',
-      ['get', 'kind'],
+      ['to-string', ['get', 'kind']],
       'bus',
       'geolens:bus',
       'rail',
@@ -390,7 +392,12 @@ describe('circleAdapter', () => {
     const opacityCalls = (map.setPaintProperty as ReturnType<typeof vi.fn>).mock.calls
       .filter(([, prop]) => prop === 'circle-opacity');
     expect(opacityCalls.length).toBeGreaterThan(0);
-    expect(opacityCalls.every(([, , value]) => JSON.stringify(value) === JSON.stringify(opacityExpression))).toBe(true);
+    // fix(#394) ST-03: the LAST write wins — the master slider (0.4)
+    // multiplies the expression (shape preserved, never flattened to a
+    // number). Earlier writes replay the raw expression before the compound
+    // set, same as before the fix.
+    const lastOpacityValue = opacityCalls[opacityCalls.length - 1][2];
+    expect(JSON.stringify(lastOpacityValue)).toBe(JSON.stringify(['*', opacityExpression, 0.4]));
   });
 
   it('getLayerIds returns [layerId] (single layer)', () => {
@@ -453,7 +460,12 @@ describe('circleAdapter', () => {
     const opacityCalls = (map.setPaintProperty as ReturnType<typeof vi.fn>).mock.calls
       .filter(([, prop]) => prop === 'circle-opacity');
     expect(opacityCalls.length).toBeGreaterThan(0);
-    expect(opacityCalls.every(([, , value]) => JSON.stringify(value) === JSON.stringify(opacityExpression))).toBe(true);
+    // fix(#394) ST-03: the LAST write wins — the master slider (0.4)
+    // multiplies the expression (shape preserved, never flattened to a
+    // number). Earlier writes replay the raw expression before the compound
+    // set, same as before the fix.
+    const lastOpacityValue = opacityCalls[opacityCalls.length - 1][2];
+    expect(JSON.stringify(lastOpacityValue)).toBe(JSON.stringify(['*', opacityExpression, 0.4]));
   });
 
   it('syncVisibility sets visibility layout property', () => {
@@ -501,7 +513,9 @@ describe('clusterAdapter', () => {
       id: 'layer-cluster-1-cluster',
       type: 'circle',
       source: 'source-cluster-1',
-      filter: ['all', ['has', 'point_count'], ['==', 'status', 'open']],
+      // fix(#394) FL-01: cluster layers never AND the data filter in — cluster
+      // features carry no data properties, so it hid every bubble.
+      filter: ['has', 'point_count'],
     }));
     expect(clusterCircle).not.toHaveProperty('source-layer');
     expect(clusterCircle.paint).toEqual(expect.objectContaining({
@@ -512,7 +526,7 @@ describe('clusterAdapter', () => {
       id: 'layer-cluster-1-cluster-count',
       type: 'symbol',
       source: 'source-cluster-1',
-      filter: ['all', ['has', 'point_count'], ['==', 'status', 'open']],
+      filter: ['has', 'point_count'],
     }));
     expect(clusterCount.paint).toEqual(expect.objectContaining({
       'text-color': '#111827',
@@ -583,8 +597,9 @@ describe('clusterAdapter', () => {
     expect(map.setPaintProperty).toHaveBeenCalledWith('layer-cluster-sync-cluster-count', 'text-color', '#0f172a');
     expect(map.setPaintProperty).toHaveBeenCalledWith('layer-cluster-sync-cluster-count', 'text-opacity', 0.4);
     expect(map.setPaintProperty).toHaveBeenCalledWith('layer-cluster-sync', 'circle-radius', 6);
-    expect(map.setFilter).toHaveBeenCalledWith('layer-cluster-sync-cluster', ['all', ['has', 'point_count'], ['==', 'status', 'planned']]);
-    expect(map.setFilter).toHaveBeenCalledWith('layer-cluster-sync-cluster-count', ['all', ['has', 'point_count'], ['==', 'status', 'planned']]);
+    // fix(#394) FL-01: cluster companions keep the bare point_count predicate.
+    expect(map.setFilter).toHaveBeenCalledWith('layer-cluster-sync-cluster', ['has', 'point_count']);
+    expect(map.setFilter).toHaveBeenCalledWith('layer-cluster-sync-cluster-count', ['has', 'point_count']);
     expect(map.setFilter).toHaveBeenCalledWith('layer-cluster-sync', ['all', ['!', ['has', 'point_count']], ['==', 'status', 'planned']]);
   });
 
@@ -778,7 +793,12 @@ describe('lineAdapter', () => {
     const opacityCalls = (map.setPaintProperty as ReturnType<typeof vi.fn>).mock.calls
       .filter(([, prop]) => prop === 'line-opacity');
     expect(opacityCalls.length).toBeGreaterThan(0);
-    expect(opacityCalls.every(([, , value]) => JSON.stringify(value) === JSON.stringify(opacityExpression))).toBe(true);
+    // fix(#394) ST-03: the LAST write wins — the master slider (0.4)
+    // multiplies the expression (shape preserved, never flattened to a
+    // number). Earlier writes replay the raw expression before the compound
+    // set, same as before the fix.
+    const lastOpacityValue = opacityCalls[opacityCalls.length - 1][2];
+    expect(JSON.stringify(lastOpacityValue)).toBe(JSON.stringify(['*', opacityExpression, 0.4]));
   });
 
   it('syncPaint preserves line gap, blur, offset, and line-gradient paint', () => {
@@ -863,7 +883,12 @@ describe('lineAdapter', () => {
     const opacityCalls = (map.setPaintProperty as ReturnType<typeof vi.fn>).mock.calls
       .filter(([, prop]) => prop === 'line-opacity');
     expect(opacityCalls.length).toBeGreaterThan(0);
-    expect(opacityCalls.every(([, , value]) => JSON.stringify(value) === JSON.stringify(opacityExpression))).toBe(true);
+    // fix(#394) ST-03: the LAST write wins — the master slider (0.4)
+    // multiplies the expression (shape preserved, never flattened to a
+    // number). Earlier writes replay the raw expression before the compound
+    // set, same as before the fix.
+    const lastOpacityValue = opacityCalls[opacityCalls.length - 1][2];
+    expect(JSON.stringify(lastOpacityValue)).toBe(JSON.stringify(['*', opacityExpression, 0.4]));
   });
 
   it('addLayers does not pass flattened line-gradient string to MapLibre addLayer when expressions present', () => {

--- a/frontend/src/components/builder/hooks/__tests__/use-builder-layers.add-dataset.test.ts
+++ b/frontend/src/components/builder/hooks/__tests__/use-builder-layers.add-dataset.test.ts
@@ -204,6 +204,30 @@ describe('handleAddDataset extended signature (Phase 1040 POL-03/05)', () => {
     const updated = result.current.localLayers.find((l) => l.id === 'child-layer-id');
     expect(updated).toBeDefined();
     expect((updated as { parent_group_id?: string } | undefined)?.parent_group_id).toBe('group-1');
+    // fix(#394) LM-01/B-021: assert POSITION too — the row must sit inside the
+    // group's block (immediately after the group row here), not merely carry
+    // parent_group_id from wherever it happened to be.
+    const ids = result.current.localLayers.map((l) => l.id);
+    expect(ids.indexOf('child-layer-id')).toBe(ids.indexOf('group-1') + 1);
+  });
+
+  it('Test E2: fix(#394) LM-01/B-021 — kebab Add-to-group splices into the group block and renumbers', () => {
+    // The loose row starts ABOVE the group: before the fix it kept its array
+    // position and only gained parent_group_id, so hydrateFolderGroupLayers
+    // re-anchored the whole group at the old position after save+reload.
+    const loose = makeMockLayer({ id: 'loose-1', dataset_id: 'ds-1', sort_order: 0 });
+    const group = makeMockLayer({ id: 'group-1', layer_type: 'folder_group' as MapLayerResponse['layer_type'], sort_order: 1 });
+    const below = makeMockLayer({ id: 'below-1', dataset_id: 'ds-3', sort_order: 2 });
+    const { result } = renderBuilderLayers(makeMapData([loose, group, below]));
+
+    act(() => {
+      result.current.handleAddLayerToExistingGroup('loose-1', 'group-1');
+    });
+
+    const ids = result.current.localLayers.map((l) => l.id);
+    expect(ids).toEqual(['group-1', 'loose-1', 'below-1']);
+    expect((result.current.localLayers[1] as GroupedLayer).parent_group_id).toBe('group-1');
+    expect(result.current.localLayers.map((l) => l.sort_order)).toEqual([0, 1, 2]);
   });
 
   it('Test F: parentGroupId=null does not attempt group wiring', () => {

--- a/frontend/src/components/builder/hooks/__tests__/use-ephemeral-layers.test.ts
+++ b/frontend/src/components/builder/hooks/__tests__/use-ephemeral-layers.test.ts
@@ -15,7 +15,10 @@ interface MockMap {
   removeSource: (id: string) => void;
   isStyleLoaded: () => boolean;
   once: (event: string, cb: () => void) => void;
+  on: (event: string, cb: () => void) => void;
   off: (event: string, cb: () => void) => void;
+  /** fix(#394) LM-02/B-028: registered style.load handlers — call to simulate a basemap/style reload. */
+  styleLoadHandlers: Array<() => void>;
   fitBounds: (bounds: unknown, options: unknown) => void;
 }
 
@@ -23,8 +26,10 @@ function createMockMap(): MockMap {
   const layers = new Set<string>();
   const sources = new Set<string>();
   const fitBoundsCalls: MockMap['fitBoundsCalls'] = [];
+  const styleLoadHandlers: Array<() => void> = [];
 
   return {
+    styleLoadHandlers,
     layers,
     sources,
     styleLoaded: true,
@@ -45,7 +50,15 @@ function createMockMap(): MockMap {
     },
     isStyleLoaded: () => true,
     once: (_event, cb) => cb(),
-    off: () => {},
+    on: (event, cb) => {
+      if (event === 'style.load') styleLoadHandlers.push(cb);
+    },
+    off: (event, cb) => {
+      if (event === 'style.load') {
+        const idx = styleLoadHandlers.indexOf(cb);
+        if (idx >= 0) styleLoadHandlers.splice(idx, 1);
+      }
+    },
     fitBounds: (bounds, options) => {
       fitBoundsCalls.push({ bounds, options });
     },
@@ -152,5 +165,50 @@ describe('useEphemeralLayers', () => {
     expect(map.layers.has('ephemeral-result-fill')).toBe(true);
     // Second fitBounds call
     expect(map.fitBoundsCalls.length).toBeGreaterThanOrEqual(2);
+  });
+});
+
+describe('fix(#394) LM-02/B-028: overlay survives style reloads', () => {
+  it('re-adds the overlay on style.load without re-zooming', () => {
+    const map = createMockMap();
+    const ref = { current: map as unknown as maplibregl.Map };
+    const { result } = renderHook(() => useEphemeralLayers(ref));
+
+    act(() => {
+      result.current.handleQueryResult(sampleGeoJSON(), [-1, -1, 1, 1]);
+    });
+    expect(map.layers.has('ephemeral-result-fill')).toBe(true);
+    expect(map.fitBoundsCalls).toHaveLength(1);
+    expect(map.styleLoadHandlers.length).toBeGreaterThan(0);
+
+    // Simulate a basemap switch wiping the style: MapLibre drops all layers
+    // and sources, then fires style.load.
+    map.layers.clear();
+    map.sources.clear();
+    act(() => {
+      map.styleLoadHandlers.forEach((cb) => cb());
+    });
+
+    expect(map.sources.has('ephemeral-result')).toBe(true);
+    expect(map.layers.has('ephemeral-result-fill')).toBe(true);
+    expect(map.layers.has('ephemeral-result-circle')).toBe(true);
+    // No second auto-zoom — the viewport belongs to the user after first show.
+    expect(map.fitBoundsCalls).toHaveLength(1);
+  });
+
+  it('unsubscribes the style.load handler on dismiss', () => {
+    const map = createMockMap();
+    const ref = { current: map as unknown as maplibregl.Map };
+    const { result } = renderHook(() => useEphemeralLayers(ref));
+
+    act(() => {
+      result.current.handleQueryResult(sampleGeoJSON(), [0, 0, 1, 1]);
+    });
+    expect(map.styleLoadHandlers.length).toBeGreaterThan(0);
+
+    act(() => {
+      result.current.handleDismissEphemeral();
+    });
+    expect(map.styleLoadHandlers).toHaveLength(0);
   });
 });

--- a/frontend/src/components/builder/hooks/use-builder-layers.ts
+++ b/frontend/src/components/builder/hooks/use-builder-layers.ts
@@ -276,12 +276,21 @@ export function useBuilderLayers(
 
   const handleMove = useCallback((layerId: string, direction: 'up' | 'down') => {
     const currentLayers = layersRef.current;
+    // fix(#394) LM-05: pick the neighbor from the RENDERED stack — the UI
+    // filters out terrain-suppressed DEM rows (UnifiedStackPanel
+    // visibleStackLayers), so a full-array swap could exchange with an
+    // invisible row and the arrow-move would look like a no-op.
+    const rendered = currentLayers.filter((l) => !isDemTerrainVisualSuppressed(l));
+    const renderedIdx = rendered.findIndex((l) => l.id === layerId);
+    if (direction === 'up' && renderedIdx <= 0) return;
+    if (direction === 'down' && (renderedIdx < 0 || renderedIdx >= rendered.length - 1)) return;
+    const neighborId = rendered[direction === 'up' ? renderedIdx - 1 : renderedIdx + 1].id;
+
     const idx = currentLayers.findIndex((l) => l.id === layerId);
-    if (direction === 'up' && idx <= 0) return;
-    if (direction === 'down' && (idx < 0 || idx >= currentLayers.length - 1)) return;
+    const swapIdx = currentLayers.findIndex((l) => l.id === neighborId);
+    if (idx < 0 || swapIdx < 0) return;
 
     const next = [...currentLayers];
-    const swapIdx = direction === 'up' ? idx - 1 : idx + 1;
     [next[idx], next[swapIdx]] = [next[swapIdx], next[idx]];
     const reordered = next.map((l, i) => ({ ...l, sort_order: i }));
 

--- a/frontend/src/components/builder/hooks/use-ephemeral-layers.ts
+++ b/frontend/src/components/builder/hooks/use-ephemeral-layers.ts
@@ -88,19 +88,33 @@ export function useEphemeralLayers(
         },
       });
 
-      // Auto-zoom to bounds
-      const [west, south, east, north] = ephemeralResult.bbox;
-      map.fitBounds([[west, south], [east, north]], { padding: 40, maxZoom: 18 });
+    }
+
+    // fix(#394) LM-02/B-028: zoom only on the FIRST add for this result — the
+    // persistent style.load re-adds below must not re-fit the viewport on
+    // every basemap switch.
+    let zoomed = false;
+    function addLayersAndMaybeZoom() {
+      if (!map || !ephemeralResult) return;
+      addLayers();
+      if (!zoomed) {
+        zoomed = true;
+        const [west, south, east, north] = ephemeralResult.bbox;
+        map.fitBounds([[west, south], [east, north]], { padding: 40, maxZoom: 18 });
+      }
     }
 
     if (map.isStyleLoaded()) {
-      addLayers();
-    } else {
-      map.once('style.load', addLayers);
+      addLayersAndMaybeZoom();
     }
+    // fix(#394) LM-02/B-028: subscribe for the LIFETIME of the result — a
+    // basemap/style reload wipes the overlay from the map while the result
+    // badge stays, with no re-show path. The previous `once` only covered the
+    // initial not-yet-loaded case.
+    map.on('style.load', addLayersAndMaybeZoom);
 
     return () => {
-      map.off('style.load', addLayers);
+      map.off('style.load', addLayersAndMaybeZoom);
     };
   }, [ephemeralResult, mapInstanceRef]);
 

--- a/frontend/src/components/builder/hooks/use-folder-group-layers.ts
+++ b/frontend/src/components/builder/hooks/use-folder-group-layers.ts
@@ -114,9 +114,13 @@ export function useFolderGroupLayers({
     const children = current.filter(
       (l) => (l as GroupedLayer).parent_group_id === groupId && l.id !== groupId,
     );
-    // Flip relative to the group row's current visibility so the eye affordance
-    // toggles predictably; the row + every child follow in one pass.
-    const nextVisible = !(group.visible !== false);
+    // fix(#394) LM-04: flip relative to the children AGGREGATE — the same
+    // signal the stack renders as the group eye (UnifiedStackPanel derives
+    // `children.some(visible)`), so the click always does what the eye shows.
+    // The synthetic row's own `visible` can lag per-child toggles.
+    const nextVisible = children.length > 0
+      ? !children.some((c) => c.visible !== false)
+      : !(group.visible !== false);
     const affectedIds = new Set<string>([groupId, ...children.map((c) => c.id)]);
 
     setLocalLayers((prev) =>
@@ -162,9 +166,27 @@ export function useFolderGroupLayers({
       const targetIdx = prev.findIndex((l) => l.id === layerId);
       if (targetIdx < 0) return prev;
       const updatedLayer: GroupedLayer = { ...(prev[targetIdx] as GroupedLayer), parent_group_id: groupId };
-      const next = [...prev];
-      next[targetIdx] = updatedLayer as MapLayerResponse;
-      return next;
+      // fix(#394) LM-01/B-021: splice the row adjacent to the group's block and
+      // renumber sort_order — the exact fix the drag path got in #392
+      // (handleAddDataset's group insert). Stamping parent_group_id in place
+      // left the row at its old position, so hydrateFolderGroupLayers
+      // re-anchored the whole group there after save+reload and the stack
+      // order shifted.
+      const without = prev.filter((l) => l.id !== layerId) as MapLayerResponse[];
+      const groupIdx = without.findIndex((l) => l.id === groupId);
+      let lastChildIdx = -1;
+      for (let i = without.length - 1; i >= 0; i--) {
+        if ((without[i] as GroupedLayer).parent_group_id === groupId) {
+          lastChildIdx = i;
+          break;
+        }
+      }
+      const insertIdx = lastChildIdx >= 0
+        ? lastChildIdx + 1
+        : (groupIdx >= 0 ? groupIdx + 1 : without.length);
+      const next = [...without];
+      next.splice(insertIdx, 0, updatedLayer as MapLayerResponse);
+      return next.map((l, i) => ({ ...l, sort_order: i }));
     });
     setGroupMeta((prev) => {
       if (prev[groupId]?.expanded) return prev;

--- a/frontend/src/components/builder/hooks/use-layer-map-sync.ts
+++ b/frontend/src/components/builder/hooks/use-layer-map-sync.ts
@@ -4,6 +4,8 @@ import { getLayerType, getSourceIdForLayer, resolveAdapterType, getCompoundOpaci
 import { getAdapter } from '@/components/builder/layer-adapters/registry';
 import { getBuilderStyleConfig } from '@/components/builder/layer-adapters/shared';
 import { coalesceFrame } from '@/lib/builder/raf-coalesce';
+// fix(#394) VT-03/VT-04: single source of truth for the MVT source-layer name.
+import { getMvtSourceLayerName } from '@/lib/tile-utils';
 import { effectiveDemRenderMode, normalizeDemStyleConfig } from '@/lib/dem-render-mode';
 import type { AdapterLayerInput } from '@/components/builder/layer-adapters/types';
 import { buildLabelLayerSpec, syncLabelLayer } from '@/components/builder/label-layer-utils';
@@ -88,7 +90,7 @@ export function applyLayerOpacityToMap(
       filter: layer.filter ?? null,
       sourceId: getSourceIdForLayer(layer),
       layerId: mapLayerId,
-      sourceLayer: `data.${layer.dataset_table_name}`,
+      sourceLayer: getMvtSourceLayerName(layer.dataset_table_name),
       tileUrl: '',
       style_config: layer.style_config ?? null,
       is_dem: layer.is_dem,
@@ -117,7 +119,7 @@ export function applyLayerOpacityToMap(
       // them through the cluster branch.
       sourceId: getSourceIdForLayer(layer),
       layerId: mapLayerId,
-      sourceLayer: `data.${layer.dataset_table_name}`,
+      sourceLayer: getMvtSourceLayerName(layer.dataset_table_name),
       tileUrl: '',
       style_config: layer.style_config ?? null,
       is_dem: layer.is_dem,
@@ -229,7 +231,7 @@ export function useLayerMapSync(
             // layers, per-layer for cluster/raster/hillshade.
             sourceId: getSourceIdForLayer(layer),
             layerId: mapLayerId,
-            sourceLayer: `data.${layer.dataset_table_name}`,
+            sourceLayer: getMvtSourceLayerName(layer.dataset_table_name),
             tileUrl: '',
             is_dem: layer.is_dem,
           };
@@ -285,7 +287,7 @@ export function useLayerMapSync(
         filter: layer.filter ?? null,
         sourceId,
         layerId: mapLayerId,
-        sourceLayer: `data.${layer.dataset_table_name}`,
+        sourceLayer: getMvtSourceLayerName(layer.dataset_table_name),
         tileUrl,
         is_dem: layer.is_dem,
       };
@@ -453,7 +455,11 @@ export function useLayerMapSync(
         (l) => ({ ...l, filter }),
         (map) => {
           const ids = getCompanionLayerIds(layerId);
-          const clusterFilter = filter ? ['all', ['has', 'point_count'], filter] as FilterSpecification : ['has', 'point_count'] as FilterSpecification;
+          // fix(#394) FL-01/B-020: cluster layers keep the bare point_count
+          // predicate — cluster features carry no data properties, so ANDing
+          // the data filter in hid every cluster bubble (mirrors the same fix
+          // in cluster-adapter's clusterFilter).
+          const clusterFilter = ['has', 'point_count'] as FilterSpecification;
           const unclusteredFilter = filter ? ['all', ['!', ['has', 'point_count']], filter] as FilterSpecification : ['!', ['has', 'point_count']] as FilterSpecification;
           if (map.getLayer(ids.layer)) {
             map.setFilter(ids.layer, map.getLayer(ids.cluster) ? unclusteredFilter : filter);
@@ -541,7 +547,7 @@ export function useLayerMapSync(
           const sourceId = getSourceIdForLayer(layer);
           if (!map.getSource(sourceId)) return;
 
-          const sourceLayer = `data.${layer.dataset_table_name}`;
+          const sourceLayer = getMvtSourceLayerName(layer.dataset_table_name);
           const parentVis = (map.getLayer(ids.layer)
             ? (map.getLayoutProperty(ids.layer, 'visibility') ?? 'visible')
             : 'visible') as 'visible' | 'none';

--- a/frontend/src/components/builder/hooks/use-render-mode-layers.ts
+++ b/frontend/src/components/builder/hooks/use-render-mode-layers.ts
@@ -121,7 +121,7 @@ export function useRenderModeLayers({
 
     // Get tile URL from existing source
     const source = map.getSource(sourceId) as { tiles?: string[] } | undefined;
-    const tileUrl = source?.tiles?.[0] ?? buildSignedTileUrl(layer.dataset_table_name, null, undefined);
+    const tileUrl = source?.tiles?.[0] ?? buildSignedTileUrl(layer.dataset_table_name, null, undefined, layer.tile_version ?? undefined);
     const sourceLayer = getMvtSourceLayerName(layer.dataset_table_name);
 
     const adapterInput: AdapterLayerInput & { style_config?: StyleConfig | null } = {

--- a/frontend/src/components/builder/hooks/use-render-mode-layers.ts
+++ b/frontend/src/components/builder/hooks/use-render-mode-layers.ts
@@ -6,7 +6,7 @@ import { getLayerType, getSourceIdForLayer } from '@/components/builder/map-sync
 import { getAdapter } from '@/components/builder/layer-adapters/registry';
 import type { AdapterLayerInput } from '@/components/builder/layer-adapters/types';
 import { DEFAULT_HEATMAP_PAINT } from '@/components/builder/layer-adapters/heatmap-adapter';
-import { buildSignedTileUrl } from '@/lib/tile-utils';
+import { buildSignedTileUrl, getMvtSourceLayerName } from '@/lib/tile-utils';
 import { buildLabelLayerSpec } from '@/components/builder/label-layer-utils';
 import { sanitizeNullableNumericFilter } from '@/lib/maplibre-filter-utils';
 import { normalizeDemStyleConfig } from '@/lib/dem-render-mode';
@@ -122,7 +122,7 @@ export function useRenderModeLayers({
     // Get tile URL from existing source
     const source = map.getSource(sourceId) as { tiles?: string[] } | undefined;
     const tileUrl = source?.tiles?.[0] ?? buildSignedTileUrl(layer.dataset_table_name, null, undefined);
-    const sourceLayer = `data.${layer.dataset_table_name}`;
+    const sourceLayer = getMvtSourceLayerName(layer.dataset_table_name);
 
     const adapterInput: AdapterLayerInput & { style_config?: StyleConfig | null } = {
       id: layer.id,
@@ -177,6 +177,11 @@ export function useRenderModeLayers({
         map.setFilter(labelId, sanitizeNullableNumericFilter(layer.filter));
         map.setLayoutProperty(labelId, 'visibility', vis);
       } else if (map.getLayer(labelId)) {
+        // fix(#394) LB-10: mirror the fresh-add branch's setFilter — restoring
+        // an EXISTING hidden companion label re-asserted visibility but not
+        // the filter, so filtered-out features flashed labels until the next
+        // reactive sync self-corrected.
+        map.setFilter(labelId, sanitizeNullableNumericFilter(layer.filter));
         map.setLayoutProperty(labelId, 'visibility', vis);
       }
     }

--- a/frontend/src/components/builder/layer-adapters/cluster-adapter.ts
+++ b/frontend/src/components/builder/layer-adapters/cluster-adapter.ts
@@ -55,8 +55,14 @@ function combineFilter(base: FilterSpecification, filter: FilterSpecification | 
   return hasFilter(filter) ? ['all', base, filter] as FilterSpecification : base;
 }
 
-function clusterFilter(input: AdapterLayerInput) {
-  return combineFilter(['has', 'point_count'], input.filter);
+function clusterFilter(_input: AdapterLayerInput): FilterSpecification {
+  // fix(#394) FL-01/B-020: never AND the layer's data filter into the cluster
+  // bubble/count layers — cluster features only carry point_count/cluster_id,
+  // so any feature-property predicate fails for every cluster and blanks the
+  // whole low-zoom map. Ceiling: cluster counts include filtered-out points
+  // (clusters don't re-aggregate); filtering at the source would fix that at
+  // the cost of a per-filter tile refetch.
+  return ['has', 'point_count'];
 }
 
 function unclusteredFilter(input: AdapterLayerInput) {

--- a/frontend/src/components/builder/layer-adapters/shared.ts
+++ b/frontend/src/components/builder/layer-adapters/shared.ts
@@ -143,7 +143,10 @@ export function getExpressionSafeOpacity(
   const propKey = `${geomType}-opacity`;
   const propOpacity = paint[propKey];
   if (Array.isArray(propOpacity)) {
-    return propOpacity;
+    // fix(#394) ST-03: multiply expression-valued opacity by the master
+    // slider — returning the expression untouched made the layer opacity
+    // slider a silent no-op whenever *-opacity is a zoom/data expression.
+    return masterOpacity === 1 ? propOpacity : ['*', propOpacity, masterOpacity];
   }
   if (typeof propOpacity === 'number') {
     return propOpacity * masterOpacity;

--- a/frontend/src/components/builder/layer-adapters/symbol-adapter.ts
+++ b/frontend/src/components/builder/layer-adapters/symbol-adapter.ts
@@ -73,13 +73,23 @@ function ensureGeolensSprite(map: MaplibreMap): void {
 function iconImageExpression(symbol: SymbolStyleConfig): string | unknown[] {
   const fallback = symbol.iconImage || DEFAULT_ICON;
   if (!symbol.categoryColumn || !symbol.categories?.length) return spriteIconId(fallback);
-  const expression: unknown[] = ['match', ['get', symbol.categoryColumn]];
+  const pairs: unknown[] = [];
   for (const entry of symbol.categories) {
-    if (entry.value === undefined || !entry.icon) continue;
-    expression.push(entry.value, spriteIconId(entry.icon));
+    // fix(#394) ST-04: skip null values too — the to-string input below
+    // renders null as "", so a null-valued pair could never match.
+    if (entry.value === undefined || entry.value === null || !entry.icon) continue;
+    pairs.push(String(entry.value), spriteIconId(entry.icon));
   }
-  expression.push(spriteIconId(fallback));
-  return expression;
+  if (pairs.length === 0) {
+    // fix(#394) ST-01: zero pairs would emit ['match', input, fallback]
+    // (length 3 < the spec minimum 5) — addLayer throws (swallowed) and the
+    // symbol layer silently never renders. Backend export mirrors this guard.
+    return spriteIconId(fallback);
+  }
+  // fix(#394) ST-04: to-string the input and stringify labels so numeric MVT
+  // values match the stringified sample values the editor stores (numeric
+  // category columns always fell through to the fallback icon before).
+  return ['match', ['to-string', ['get', symbol.categoryColumn]], ...pairs, spriteIconId(fallback)];
 }
 
 function symbolLayout(input: AdapterLayerInput): Record<string, unknown> {

--- a/frontend/src/components/builder/map-sync.ts
+++ b/frontend/src/components/builder/map-sync.ts
@@ -197,7 +197,7 @@ export interface SyncLayerInput {
   /** MVT-04: dataset content/version stamp threaded into the tile URL's
    *  `_v=` cache-buster so a reupload/geometry edit busts client/CDN caches.
    *  Optional — only emitted when a content version is available. */
-  tile_version?: string | null;
+  tile_version?: string | number | null;
 }
 
 /** Options that vary between Builder and Viewer contexts. */

--- a/frontend/src/components/builder/map-sync.ts
+++ b/frontend/src/components/builder/map-sync.ts
@@ -235,6 +235,9 @@ export function toSyncInput(layer: MapLayerResponse): SyncLayerInput {
     feature_count: layer.dataset_feature_count,
     layer_type: layer.layer_type,
     dataset_record_type: layer.dataset_record_type ?? null,
+    // fix(#394) VT-02 (codex P2): without this the builder's `_v=` read below
+    // always saw undefined — the cache-buster only flowed on the viewer path.
+    tile_version: layer.tile_version,
     // MVT-06: surface the dataset spatial extent so the vector source can bound
     // tile fetching to the data footprint (the raster path already passes bounds).
     bounds: layer.dataset_extent_bbox ?? null,

--- a/frontend/src/components/error/PanelErrorBoundary.tsx
+++ b/frontend/src/components/error/PanelErrorBoundary.tsx
@@ -1,0 +1,74 @@
+import { Component, type ErrorInfo, type ReactNode } from 'react';
+import { useTranslation } from 'react-i18next';
+import { AlertCircle } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { logger } from '@/lib/logger';
+import { pushReportEntry } from '@/lib/report';
+
+interface PanelErrorBoundaryState {
+  hasError: boolean;
+  resetKey: number;
+}
+
+interface PanelErrorBoundaryProps {
+  children: ReactNode;
+  /** Log prefix identifying which panel crashed (e.g. "builder-sidebar"). */
+  panelId: string;
+}
+
+function PanelErrorFallback({ onReset }: { onReset: () => void }) {
+  const { t } = useTranslation('common');
+
+  return (
+    <div className="flex h-full w-full items-center justify-center p-4">
+      <div className="text-center space-y-2 max-w-[16rem]">
+        <AlertCircle className="mx-auto size-6 text-destructive" />
+        <h3 className="text-sm font-semibold">{t('errorBoundary.panelTitle')}</h3>
+        <p className="text-xs text-muted-foreground">
+          {t('errorBoundary.panelMessage')}
+        </p>
+        <Button variant="outline" size="sm" onClick={onReset}>
+          {t('errorBoundary.lazyRetry')}
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * fix(#394) UX-01/B-027: recoverable boundary for builder side panels. A render
+ * error inside the sidebar previously crashed the whole builder page even
+ * though the map and chat were healthy. The `resetKey` remounts the children
+ * on retry, mirroring MapErrorBoundary.
+ */
+export class PanelErrorBoundary extends Component<PanelErrorBoundaryProps, PanelErrorBoundaryState> {
+  constructor(props: PanelErrorBoundaryProps) {
+    super(props);
+    this.state = { hasError: false, resetKey: 0 };
+  }
+
+  static getDerivedStateFromError(): Partial<PanelErrorBoundaryState> {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: Error, errorInfo: ErrorInfo): void {
+    logger.error(`[PanelErrorBoundary:${this.props.panelId}]`, error, errorInfo);
+    pushReportEntry({
+      severity: 'error',
+      source: 'react',
+      message: error.message || `${this.props.panelId} crash`,
+      detail: errorInfo.componentStack ?? error.stack ?? undefined,
+    });
+  }
+
+  private handleReset = () => {
+    this.setState((prev) => ({ hasError: false, resetKey: prev.resetKey + 1 }));
+  };
+
+  render() {
+    if (this.state.hasError) {
+      return <PanelErrorFallback onReset={this.handleReset} />;
+    }
+    return <div key={this.state.resetKey} className="contents">{this.props.children}</div>;
+  }
+}

--- a/frontend/src/components/error/index.ts
+++ b/frontend/src/components/error/index.ts
@@ -2,3 +2,4 @@ export { AppErrorBoundary } from './AppErrorBoundary';
 export { MapErrorBoundary } from './MapErrorBoundary';
 export { RouteErrorBoundary } from './RouteErrorBoundary';
 export { LazyLoadErrorBoundary } from './LazyLoadErrorBoundary';
+export { PanelErrorBoundary } from './PanelErrorBoundary';

--- a/frontend/src/components/maps/hooks/use-map-layers.ts
+++ b/frontend/src/components/maps/hooks/use-map-layers.ts
@@ -4,13 +4,14 @@ import { buildSignedTileUrl } from '@/lib/tile-utils';
 import { MAP_COLORS } from '@/lib/map-colors';
 import type { Map as MaplibreMap } from 'maplibre-gl';
 import maplibregl from 'maplibre-gl';
+import { getMvtSourceLayerName } from '@/lib/tile-utils';
 
 /** Empty GeoJSON FeatureCollection */
 const EMPTY_FC: GeoJSON.FeatureCollection = { type: 'FeatureCollection', features: [] };
 
-function getSourceLayerName(tableName: string): string {
-  return `data.${tableName}`;
-}
+// fix(#394) VT-04: use the shared helper — a local duplicate is exactly the
+// silent-drift class the source-layer parity test pins down.
+const getSourceLayerName = getMvtSourceLayerName;
 
 interface UseMapLayersOptions {
   tableName: string | null;

--- a/frontend/src/components/viewer/ViewerMap.tsx
+++ b/frontend/src/components/viewer/ViewerMap.tsx
@@ -758,12 +758,14 @@ export const ViewerMap = memo(function ViewerMap({
               label_config: layer.label_config ?? null,
               popup_config: layer.popup_config ?? null,
             });
+        // fix(#394) VT-02 (codex P2): keep the `_v=` cache-buster on
+        // token-refresh rebuilds (parity with the initial source build).
         const newUrl = strategy.kind === 'server-tile'
-          ? buildClusterTileUrl(layer.table_name, token, tileBaseUrl, undefined, {
+          ? buildClusterTileUrl(layer.table_name, token, tileBaseUrl, layer.tile_version ?? undefined, {
               clusterRadius: typeof builder?.clusterRadius === 'number' ? builder.clusterRadius : 48,
               clusterMaxZoom: typeof builder?.clusterMaxZoom === 'number' ? builder.clusterMaxZoom : 14,
             })
-          : buildSignedTileUrl(layer.table_name, token, tileBaseUrl, undefined, cols);
+          : buildSignedTileUrl(layer.table_name, token, tileBaseUrl, layer.tile_version ?? undefined, cols);
         (source as VectorTileSource).setTiles([newUrl]);
       }
     }

--- a/frontend/src/components/viewer/ViewerMap.tsx
+++ b/frontend/src/components/viewer/ViewerMap.tsx
@@ -11,7 +11,7 @@ import {
   resolveBasemapId,
   BLANK_BASEMAP_ID,
 } from '@/lib/basemap-utils';
-import { buildClusterTileUrl, buildSignedTileUrl, resolveTileBaseUrl } from '@/lib/tile-utils';
+import { buildClusterTileUrl, buildSignedTileUrl, getMvtSourceLayerName, resolveTileBaseUrl } from '@/lib/tile-utils';
 import { useWebGLRecovery } from '@/hooks/use-webgl-recovery';
 import { useViewerTokens } from '@/components/viewer/hooks/use-viewer-tokens';
 import { useViewerTerrain } from '@/components/viewer/hooks/use-viewer-terrain';
@@ -108,6 +108,9 @@ export function toViewerSyncInput(
     layer_type: layer.layer_type,
     dataset_record_type: layer.dataset_record_type,
     tile_url: layer.tile_url,
+    // fix(#394) VT-02: thread the dataset content version through so the
+    // viewer's tile URLs carry the same `_v=` cache-buster as the builder.
+    tile_version: layer.tile_version,
   };
 }
 
@@ -131,7 +134,10 @@ function toAdapterInput(
     is_dem: layer.is_dem,
     sourceId: prefixed('source', layerKey, VIEWER_PREFIX),
     layerId: prefixed('layer', layerKey, VIEWER_PREFIX),
-    sourceLayer: `data.${layer.table_name}`,
+    // fix(#394) VT-03: derive via the shared helper instead of a hand-rolled
+    // template — the URL path and source-layer name must come from one place
+    // or a drift is a silent empty layer (see tile-utils parity test, VT-04).
+    sourceLayer: getMvtSourceLayerName(layer.table_name),
     tileUrl: '',
   };
 }
@@ -323,11 +329,49 @@ export const ViewerMap = memo(function ViewerMap({
       const map = e.target;
       mapRef.current = map;
 
-      // Absolutify URLs and attach embed token header when present
+      // First-party vs third-party request classification. Used to gate BOTH
+      // the X-Embed-Token header (fix(#394) SH-02/B-022) and the embed-auth
+      // error toast below. First-party means: our own origin, or the
+      // configured tile CDN origin (`cdn_base_url` / `TILE_BASE_URL`,
+      // resolved via the same `resolveTileBaseUrl()` helper used to build
+      // tile URLs) — self-hosted deployments commonly serve tiles from a
+      // separate CDN origin, so same-origin alone would misclassify them.
+      // When no url is available, default to first-party to preserve prior
+      // behavior. A relative path (single leading slash) is always
+      // first-party; a protocol-relative URL (`//host/path`) is normalized
+      // with the current protocol before the origin check so it isn't
+      // misread as a relative path.
+      const isThirdPartyUrl = (url?: string): boolean => {
+        if (!url) return false;
+        if (url.startsWith('/') && !url.startsWith('//')) return false;
+        try {
+          const normalized = url.startsWith('//') ? `${window.location.protocol}${url}` : url;
+          const requestOrigin = new URL(normalized, window.location.origin).origin;
+          if (requestOrigin === window.location.origin) return false;
+          const tileBaseUrl = resolveTileBaseUrl(tileConfigRef.current);
+          if (tileBaseUrl) {
+            try {
+              if (requestOrigin === new URL(tileBaseUrl, window.location.origin).origin) return false;
+            } catch {
+              // Malformed configured tile base URL — fall through to third-party classification.
+            }
+          }
+          return true;
+        } catch {
+          return false;
+        }
+      };
+
+      // Absolutify URLs and attach embed token header when present.
+      // fix(#394) SH-02/B-022: the header is a credential — send it only to
+      // first-party origins. Attaching it to third-party basemap
+      // sprite/glyph/tile CDNs (OpenFreeMap, CartoDB, …) over-shares the
+      // token and risks CORS-preflight breakage on hosts that don't allow
+      // the custom header.
       map.setTransformRequest((url: string) => {
         const absUrl = url.startsWith('http') ? url : `${window.location.origin}${url}`;
         const headers: Record<string, string> = {};
-        if (embedToken) {
+        if (embedToken && !isThirdPartyUrl(url)) {
           headers['X-Embed-Token'] = embedToken;
         }
         return { url: absUrl, headers };
@@ -338,41 +382,8 @@ export const ViewerMap = memo(function ViewerMap({
       // has a real problem (RES-3). Previously suppressed entirely in prod.
       map.on('error', (e: { error: { message?: string; status?: number; url?: string } }) => {
         const status = e.error?.status;
-        // `transformRequest` above attaches X-Embed-Token to every request the
-        // map makes, including third-party basemap style/sprite/glyph fetches
-        // (e.g. OpenFreeMap, CartoDB). A 401/403 from one of those CDNs is not
-        // an embed-token problem, so only treat the failure as an embed-auth
-        // issue when the failing request is first-party: our own origin, or
-        // the configured tile CDN origin (`cdn_base_url` / `TILE_BASE_URL`,
-        // resolved via the same `resolveTileBaseUrl()` helper used to build
-        // tile URLs) — self-hosted deployments commonly serve tiles from a
-        // separate CDN origin, so same-origin alone would misclassify a real
-        // embed-token failure there as third-party and swallow it. When
-        // maplibre doesn't report a url, default to treating it as
-        // first-party to preserve prior behavior. A relative path (single
-        // leading slash) is always first-party; a protocol-relative URL
-        // (`//host/path`) is normalized with the current protocol before the
-        // origin check so it isn't misread as a relative path.
-        const isThirdPartyUrl = (url?: string): boolean => {
-          if (!url) return false;
-          if (url.startsWith('/') && !url.startsWith('//')) return false;
-          try {
-            const normalized = url.startsWith('//') ? `${window.location.protocol}${url}` : url;
-            const requestOrigin = new URL(normalized, window.location.origin).origin;
-            if (requestOrigin === window.location.origin) return false;
-            const tileBaseUrl = resolveTileBaseUrl(tileConfigRef.current);
-            if (tileBaseUrl) {
-              try {
-                if (requestOrigin === new URL(tileBaseUrl, window.location.origin).origin) return false;
-              } catch {
-                // Malformed configured tile base URL — fall through to third-party classification.
-              }
-            }
-            return true;
-          } catch {
-            return false;
-          }
-        };
+        // A 401/403 from a third-party CDN is not an embed-token problem —
+        // see isThirdPartyUrl above.
         // Embed-token auth failures (expired/invalid X-Embed-Token) get their own
         // deduped "access expired" toast instead of being swallowed by the generic
         // 4xx suppression below. Copy is intentionally generic — must never echo

--- a/frontend/src/components/viewer/hooks/use-viewer-tokens.ts
+++ b/frontend/src/components/viewer/hooks/use-viewer-tokens.ts
@@ -9,8 +9,9 @@ import type { SharedLayerResponse } from '@/types/api';
 async function fetchTokensWithApiKey(
   datasetIds: string[],
   apiKey: string,
+  embedToken?: string,
 ): Promise<Map<string, TileToken>> {
-  const response = await getTileTokensBatch(datasetIds, apiKey);
+  const response = await getTileTokensBatch(datasetIds, apiKey, embedToken);
   const map = new Map<string, TileToken>();
   for (const [datasetId, entry] of Object.entries(response.tokens)) {
     if ('kind' in entry) {
@@ -20,11 +21,12 @@ async function fetchTokensWithApiKey(
   return map;
 }
 
-/** Fetch tile tokens in a single batch (anonymous / JWT auth). */
+/** Fetch tile tokens in a single batch (anonymous / JWT / embed-token auth). */
 async function fetchTokensBatch(
   datasetIds: string[],
+  embedToken?: string,
 ): Promise<Map<string, TileToken>> {
-  const response = await getTileTokensBatch(datasetIds);
+  const response = await getTileTokensBatch(datasetIds, undefined, embedToken);
   const map = new Map<string, TileToken>();
   for (const [datasetId, entry] of Object.entries(response.tokens)) {
     if ('kind' in entry) {
@@ -58,7 +60,11 @@ export function useViewerTokens({
   );
 
   useEffect(() => {
-    if (embedToken || layerDatasetIds.length === 0) return;
+    // fix(#394) SH-04: embed mode no longer skips token fetching — the batch
+    // endpoint accepts X-Embed-Token, so embeds get the same raster/DEM tile
+    // descriptors (bounds, resolution-derived maxzoom) as normal viewers
+    // instead of building the terrain source from empty defaults.
+    if (layerDatasetIds.length === 0) return;
 
     let cancelled = false;
     let retryAttempt = 0;
@@ -66,8 +72,8 @@ export function useViewerTokens({
     async function fetchTokens() {
       try {
         const newMap = apiKey
-          ? await fetchTokensWithApiKey(layerDatasetIds, apiKey)
-          : await fetchTokensBatch(layerDatasetIds);
+          ? await fetchTokensWithApiKey(layerDatasetIds, apiKey, embedToken)
+          : await fetchTokensBatch(layerDatasetIds, embedToken);
 
         if (cancelled) return;
         setTokenMap(newMap);

--- a/frontend/src/hooks/use-maps.ts
+++ b/frontend/src/hooks/use-maps.ts
@@ -236,10 +236,10 @@ export function useRemoveLayer() {
   });
 }
 
-export function useSharedMap(token: string | undefined, apiKey?: string) {
+export function useSharedMap(token: string | undefined, apiKey?: string, embedToken?: string) {
   return useQuery({
-    queryKey: queryKeys.maps.sharedMap(token, apiKey),
-    queryFn: () => getSharedMap(token!, apiKey),
+    queryKey: queryKeys.maps.sharedMap(token, apiKey, embedToken),
+    queryFn: () => getSharedMap(token!, apiKey, embedToken),
     enabled: !!token,
     retry: false,
     staleTime: 30_000,

--- a/frontend/src/i18n/locales/de/builder.json
+++ b/frontend/src/i18n/locales/de/builder.json
@@ -336,7 +336,8 @@
       "cancelExpression": "Abbrechen",
       "parseError": "Ungültiges JSON",
       "structureError": "Ausdruck muss ein Array sein, das mit einem bekannten Operator beginnt"
-    }
+    },
+    "validatorUnavailable": "Dieses JSON konnte nicht validiert werden – vereinfachen Sie den Wert und versuchen Sie es erneut."
   },
   "filters": {
     "title": "Filter",
@@ -927,8 +928,16 @@
       "save": "Karte speichern",
       "pan": "Verschieben-Werkzeug",
       "measure": "Mess-Werkzeug",
-      "legend": "Legende ein-/ausblenden"
-    }
+      "legend": "Legende ein-/ausblenden",
+      "showSheet": "Diesen Dialog anzeigen",
+      "reorderToggle": "Sortiermodus umschalten (fokussierte Ebenenzeile)",
+      "reorderMove": "Ebene nach oben / unten verschieben (Sortiermodus)",
+      "escape": "Panel schließen / Auswahl aufheben / Sortiermodus beenden",
+      "multiSelect": "Ebene zur Auswahl hinzufügen/entfernen",
+      "rangeSelect": "Einen Bereich von Ebenen auswählen",
+      "extendSelect": "Auswahl erweitern (Stapel fokussiert)"
+    },
+    "loadingPanel": "Panel wird geladen"
   },
   "styleJson": {
     "title": "Stil-JSON",
@@ -1061,7 +1070,8 @@
     "swapBasemap": "Basiskarte tauschen",
     "toggleExpand": "Basiskarten-Gruppe ein-/ausklappen",
     "typeIconLabel": "Basiskarten-Gruppe",
-    "visibilityLocked": "Basiskarte ist immer sichtbar — verwenden Sie „Basiskarte entfernen“, um sie auszublenden."
+    "visibilityLocked": "Basiskarte ist immer sichtbar — verwenden Sie „Basiskarte entfernen“, um sie auszublenden.",
+    "presetSectionAria": "Basemap-Vorlage"
   },
   "basemapSublayer": {
     "breadcrumbLabel": "Zurück zur Basiskarten-Gruppe",
@@ -1159,8 +1169,8 @@
       "columns": "Spalten"
     },
     "emptyResult": {
-      "title": "0 Objekte — überprüfen Sie Ihren Filter",
-      "help": "Der aktuelle Filter hat alle Objekte in dieser Ebene ausgeschlossen. Passen Sie eine Bedingung an oder löschen Sie den Filter, um Objekte wieder anzuzeigen.",
+      "title": "0 Features im Sichtbereich – Filter prüfen",
+      "help": "Der aktuelle Filter trifft im sichtbaren Kartenbereich auf nichts zu. Treffer können außerhalb des Bildschirms liegen – verschieben oder herauszoomen, eine Bedingung anpassen oder den Filter löschen.",
       "clear": "Filter löschen"
     },
     "deleteLayer": "Ebene löschen",

--- a/frontend/src/i18n/locales/de/common.json
+++ b/frontend/src/i18n/locales/de/common.json
@@ -430,7 +430,9 @@
     "lazyTitle": "Laden fehlgeschlagen",
     "lazyMessage": "Ein Teil der Anwendung konnte nicht geladen werden. Dies ist normalerweise ein Netzwerkproblem.",
     "lazyRetry": "Erneut versuchen",
-    "lazyRetrying": "Wird erneut versucht..."
+    "lazyRetrying": "Wird erneut versucht...",
+    "panelTitle": "Panel konnte nicht geladen werden",
+    "panelMessage": "In diesem Panel ist ein Fehler aufgetreten. Der Rest des Editors ist nicht betroffen."
   },
   "export": {
     "poweredBy": "Powered by GeoLens",

--- a/frontend/src/i18n/locales/en/builder.json
+++ b/frontend/src/i18n/locales/en/builder.json
@@ -336,7 +336,8 @@
       "cancelExpression": "Cancel",
       "parseError": "Invalid JSON",
       "structureError": "Expression must be an array starting with a known operator"
-    }
+    },
+    "validatorUnavailable": "This JSON could not be validated — simplify the value and try again."
   },
   "filters": {
     "title": "Filters",
@@ -931,8 +932,16 @@
       "save": "Save map",
       "pan": "Pan tool",
       "measure": "Measure tool",
-      "legend": "Toggle legend"
-    }
+      "legend": "Toggle legend",
+      "showSheet": "Show this dialog",
+      "reorderToggle": "Toggle reorder mode (focused layer row)",
+      "reorderMove": "Move layer up / down (reorder mode)",
+      "escape": "Close panel / clear selection / exit reorder",
+      "multiSelect": "Toggle layer in selection",
+      "rangeSelect": "Select a range of layers",
+      "extendSelect": "Extend selection (stack focused)"
+    },
+    "loadingPanel": "Loading panel"
   },
   "styleJson": {
     "title": "Style JSON",
@@ -1065,7 +1074,8 @@
     "swapBasemap": "Swap basemap",
     "toggleExpand": "Toggle basemap group",
     "typeIconLabel": "Basemap group",
-    "visibilityLocked": "Basemap is always visible — use Remove basemap to hide."
+    "visibilityLocked": "Basemap is always visible — use Remove basemap to hide.",
+    "presetSectionAria": "Basemap preset"
   },
   "basemapSublayer": {
     "breadcrumbLabel": "Back to basemap group",
@@ -1167,8 +1177,8 @@
       "columns": "Columns"
     },
     "emptyResult": {
-      "title": "0 features — check your filter",
-      "help": "The current filter eliminated every feature in this layer. Adjust a condition or clear the filter to see features again.",
+      "title": "0 features in view — check your filter",
+      "help": "The current filter matches nothing in the visible map area. Matches may exist off-screen — pan or zoom out, adjust a condition, or clear the filter.",
       "clear": "Clear filter"
     }
   },

--- a/frontend/src/i18n/locales/en/common.json
+++ b/frontend/src/i18n/locales/en/common.json
@@ -453,7 +453,9 @@
     "lazyTitle": "Failed to load",
     "lazyMessage": "A part of the application failed to load. This is usually a network issue.",
     "lazyRetry": "Try again",
-    "lazyRetrying": "Retrying..."
+    "lazyRetrying": "Retrying...",
+    "panelTitle": "Panel failed to load",
+    "panelMessage": "This panel encountered an error. The rest of the builder is unaffected."
   },
   "export": {
     "poweredBy": "Powered by GeoLens",

--- a/frontend/src/i18n/locales/es/builder.json
+++ b/frontend/src/i18n/locales/es/builder.json
@@ -336,7 +336,8 @@
       "cancelExpression": "Cancelar",
       "parseError": "JSON no válido",
       "structureError": "La expresión debe ser un arreglo que comience con un operador conocido"
-    }
+    },
+    "validatorUnavailable": "No se pudo validar este JSON: simplifica el valor e inténtalo de nuevo."
   },
   "filters": {
     "title": "Filtros",
@@ -927,8 +928,16 @@
       "save": "Guardar mapa",
       "pan": "Herramienta de desplazamiento",
       "measure": "Herramienta de medición",
-      "legend": "Mostrar/ocultar leyenda"
-    }
+      "legend": "Mostrar/ocultar leyenda",
+      "showSheet": "Mostrar este diálogo",
+      "reorderToggle": "Alternar modo de reordenación (fila de capa enfocada)",
+      "reorderMove": "Mover capa arriba / abajo (modo de reordenación)",
+      "escape": "Cerrar panel / borrar selección / salir de reordenación",
+      "multiSelect": "Alternar capa en la selección",
+      "rangeSelect": "Seleccionar un rango de capas",
+      "extendSelect": "Ampliar selección (pila enfocada)"
+    },
+    "loadingPanel": "Cargando panel"
   },
   "styleJson": {
     "title": "JSON de estilo",
@@ -1061,7 +1070,8 @@
     "swapBasemap": "Cambiar mapa base",
     "toggleExpand": "Contraer/expandir grupo de mapa base",
     "typeIconLabel": "Grupo de mapa base",
-    "visibilityLocked": "El mapa base siempre está visible — use Eliminar mapa base para ocultarlo."
+    "visibilityLocked": "El mapa base siempre está visible — use Eliminar mapa base para ocultarlo.",
+    "presetSectionAria": "Mapa base predefinido"
   },
   "basemapSublayer": {
     "breadcrumbLabel": "Volver al grupo de mapa base",
@@ -1159,8 +1169,8 @@
       "columns": "Columnas"
     },
     "emptyResult": {
-      "title": "0 elementos — revisa tu filtro",
-      "help": "El filtro actual eliminó todos los elementos de esta capa. Ajusta una condición o limpia el filtro para volver a ver elementos.",
+      "title": "0 entidades a la vista: revisa tu filtro",
+      "help": "El filtro actual no coincide con nada en el área visible del mapa. Puede haber coincidencias fuera de pantalla: desplázate o aleja el zoom, ajusta una condición o borra el filtro.",
       "clear": "Limpiar filtro"
     },
     "deleteLayer": "Eliminar capa",

--- a/frontend/src/i18n/locales/es/common.json
+++ b/frontend/src/i18n/locales/es/common.json
@@ -430,7 +430,9 @@
     "lazyTitle": "Error al cargar",
     "lazyMessage": "Una parte de la aplicación no se pudo cargar. Generalmente es un problema de red.",
     "lazyRetry": "Intentar de nuevo",
-    "lazyRetrying": "Reintentando..."
+    "lazyRetrying": "Reintentando...",
+    "panelTitle": "El panel no se pudo cargar",
+    "panelMessage": "Este panel encontró un error. El resto del editor no se ve afectado."
   },
   "export": {
     "poweredBy": "Powered by GeoLens",

--- a/frontend/src/i18n/locales/fr/builder.json
+++ b/frontend/src/i18n/locales/fr/builder.json
@@ -336,7 +336,8 @@
       "cancelExpression": "Annuler",
       "parseError": "JSON invalide",
       "structureError": "L'expression doit être un tableau commençant par un opérateur connu"
-    }
+    },
+    "validatorUnavailable": "Ce JSON n'a pas pu être validé — simplifiez la valeur et réessayez."
   },
   "filters": {
     "title": "Filtres",
@@ -927,8 +928,16 @@
       "save": "Enregistrer la carte",
       "pan": "Outil panoramique",
       "measure": "Outil de mesure",
-      "legend": "Afficher/masquer la légende"
-    }
+      "legend": "Afficher/masquer la légende",
+      "showSheet": "Afficher cette boîte de dialogue",
+      "reorderToggle": "Basculer le mode de réorganisation (ligne de couche active)",
+      "reorderMove": "Déplacer la couche vers le haut / bas (mode réorganisation)",
+      "escape": "Fermer le panneau / effacer la sélection / quitter la réorganisation",
+      "multiSelect": "Basculer la couche dans la sélection",
+      "rangeSelect": "Sélectionner une plage de couches",
+      "extendSelect": "Étendre la sélection (pile active)"
+    },
+    "loadingPanel": "Chargement du panneau"
   },
   "styleJson": {
     "title": "JSON de style",
@@ -1061,7 +1070,8 @@
     "swapBasemap": "Remplacer le fond de carte",
     "toggleExpand": "Réduire/développer le groupe de fond de carte",
     "typeIconLabel": "Groupe de fond de carte",
-    "visibilityLocked": "Le fond de carte est toujours visible — utilisez « Supprimer le fond de carte » pour le masquer."
+    "visibilityLocked": "Le fond de carte est toujours visible — utilisez « Supprimer le fond de carte » pour le masquer.",
+    "presetSectionAria": "Fond de carte prédéfini"
   },
   "basemapSublayer": {
     "breadcrumbLabel": "Retour au groupe de fond de carte",
@@ -1159,8 +1169,8 @@
       "columns": "Colonnes"
     },
     "emptyResult": {
-      "title": "0 entité — vérifiez votre filtre",
-      "help": "Le filtre actuel a éliminé toutes les entités de cette couche. Ajustez une condition ou effacez le filtre pour revoir les entités.",
+      "title": "0 entités visibles — vérifiez votre filtre",
+      "help": "Le filtre actuel ne correspond à rien dans la zone visible de la carte. Des correspondances peuvent exister hors écran — déplacez la carte ou dézoomez, ajustez une condition ou effacez le filtre.",
       "clear": "Effacer le filtre"
     },
     "deleteLayer": "Supprimer le calque",

--- a/frontend/src/i18n/locales/fr/common.json
+++ b/frontend/src/i18n/locales/fr/common.json
@@ -430,7 +430,9 @@
     "lazyTitle": "Échec du chargement",
     "lazyMessage": "Une partie de l'application n'a pas pu se charger. C'est généralement un problème de réseau.",
     "lazyRetry": "Réessayer",
-    "lazyRetrying": "Nouvelle tentative..."
+    "lazyRetrying": "Nouvelle tentative...",
+    "panelTitle": "Échec du chargement du panneau",
+    "panelMessage": "Ce panneau a rencontré une erreur. Le reste de l'éditeur n'est pas affecté."
   },
   "export": {
     "poweredBy": "Powered by GeoLens",

--- a/frontend/src/lib/__tests__/query-keys.test.ts
+++ b/frontend/src/lib/__tests__/query-keys.test.ts
@@ -103,8 +103,11 @@ describe('queryKeys factory', () => {
     });
 
     it('sharedMap includes token', () => {
-      expect(queryKeys.maps.sharedMap('tok123')).toEqual(['shared-map', 'tok123', undefined]);
-      expect(queryKeys.maps.sharedMap('tok123', 'key')).toEqual(['shared-map', 'tok123', 'key']);
+      // fix(#394) B-023: the key gained an embedToken slot so embed viewers
+      // don't share cache entries with the anonymous payload.
+      expect(queryKeys.maps.sharedMap('tok123')).toEqual(['shared-map', 'tok123', undefined, undefined]);
+      expect(queryKeys.maps.sharedMap('tok123', 'key')).toEqual(['shared-map', 'tok123', 'key', undefined]);
+      expect(queryKeys.maps.sharedMap('tok123', undefined, 'et_x')).toEqual(['shared-map', 'tok123', undefined, 'et_x']);
     });
 
     it('columnValues includes datasetId and col', () => {

--- a/frontend/src/lib/__tests__/tile-utils.test.ts
+++ b/frontend/src/lib/__tests__/tile-utils.test.ts
@@ -1,4 +1,4 @@
-import { buildClusterTileUrl, buildSignedTileUrl } from '@/lib/tile-utils';
+import { buildClusterTileUrl, buildSignedTileUrl, getMvtSourceLayerName } from '@/lib/tile-utils';
 
 describe('buildSignedTileUrl', () => {
   const mockToken = { sig: 'abc123', exp: 1700000000, scope: 'ds_test' };
@@ -134,5 +134,24 @@ describe('buildClusterTileUrl', () => {
     expect(url).toBe(
       'https://tiles.example.com/tiles/clusters/data.my_table/{z}/{x}/{y}.pbf?cluster_radius=48&cluster_max_zoom=14&_v=v1',
     );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// fix(#394) VT-04: MVT source-layer ↔ tile-layer-name parity pin.
+// The SAME literal is produced by three derivation sites that must never
+// drift, or the layer silently renders empty:
+//   1. backend `app/processing/tiles/service.py` (`layer_name = f"{schema}.{table}"`,
+//      single_tenant schema == "data") — pinned by
+//      `backend/tests/test_mvt_audit_fixes.py::test_get_tile_layer_name_is_schema_qualified`;
+//   2. this helper (the ONLY frontend derivation — builder map-sync, viewer
+//      ViewerMap, and use-map-layers all import it as of fix(#394) VT-03);
+//   3. the exported style.json `_mvt_source_layer` (backend style_json.py).
+// If this assertion ever needs to change, all three sites change together.
+// ---------------------------------------------------------------------------
+
+describe('getMvtSourceLayerName (VT-04 parity pin)', () => {
+  it('produces the canonical data.{table} literal the tile server emits', () => {
+    expect(getMvtSourceLayerName('recent_earthquakes')).toBe('data.recent_earthquakes');
   });
 });

--- a/frontend/src/lib/query-keys.ts
+++ b/frontend/src/lib/query-keys.ts
@@ -66,8 +66,8 @@ export const queryKeys = {
     aiAvailability: ['ai-availability'] as const,
     shareToken: (mapId: string | undefined) => ['map-share-token', mapId] as const,
     embedTokens: (mapId: string | undefined) => ['map-embed-tokens', mapId] as const,
-    sharedMap: (token: string | undefined, apiKey?: string) =>
-      ['shared-map', token, apiKey] as const,
+    sharedMap: (token: string | undefined, apiKey?: string, embedToken?: string) =>
+      ['shared-map', token, apiKey, embedToken] as const,
     columnValues: (datasetId: string | undefined, col: string | undefined) =>
       ['column-values', datasetId, col] as const,
     columnValuesPrefix: (datasetId: string) => ['column-values', datasetId] as const,

--- a/frontend/src/lib/tile-utils.ts
+++ b/frontend/src/lib/tile-utils.ts
@@ -41,7 +41,7 @@ export function buildSignedTileUrl(
   tableName: string,
   tileToken: { sig: string; exp: number; scope: string } | null,
   tileBaseUrl?: string | null,
-  tileVersion?: string | null,
+  tileVersion?: string | number | null,
   extraCols?: string[] | null,
 ): string {
   const base = tileBaseUrl
@@ -68,7 +68,7 @@ function normalizeExtraCols(extraCols?: string[] | null): string | null {
 function appendTileParams(
   url: string,
   tileToken: { sig: string; exp: number; scope: string } | null,
-  tileVersion?: string | null,
+  tileVersion?: string | number | null,
   extraParams: Record<string, string | number | null | undefined> = {},
 ) {
   const params: string[] = [];
@@ -89,7 +89,7 @@ export function buildClusterTileUrl(
   tableName: string,
   tileToken: { sig: string; exp: number; scope: string } | null,
   tileBaseUrl?: string | null,
-  tileVersion?: string | null,
+  tileVersion?: string | number | null,
   options: { clusterRadius?: number; clusterMaxZoom?: number } = {},
 ): string {
   const base = tileBaseUrl

--- a/frontend/src/pages/MapBuilderPage.tsx
+++ b/frontend/src/pages/MapBuilderPage.tsx
@@ -66,7 +66,7 @@ import { cn } from '@/lib/utils';
 import { SceneSpinnerFallback } from '@/components/builder/SceneSpinnerFallback';
 import { LoadingState } from '@/components/layout/LoadingState';
 import { ErrorState } from '@/components/layout/ErrorState';
-import { MapErrorBoundary } from '@/components/error';
+import { MapErrorBoundary, PanelErrorBoundary } from '@/components/error';
 import { LazyLoadErrorBoundary } from '@/components/error/LazyLoadErrorBoundary';
 import { useMap, useAddLayer, useRemoveLayer } from '@/hooks/use-maps';
 import { useAIAvailability } from '@/hooks/use-ai-availability';
@@ -897,14 +897,29 @@ export function MapBuilderPage() {
       // When target is a folder group, parentGroupId is set so the new layer joins the group.
       const targetLayer = layers.localLayers.find((l) => l.id === overId);
       const parentGroupId = (targetLayer && isFolderGroupLayer(targetLayer)) ? overId : null;
-      const dropPosition = layers.localLayers.findIndex((l) => l.id === overId) + 1;
-      const safePosition = dropPosition > 0 ? dropPosition : 1;
+      // fix(#394) LM-03: announce the REAL landing position — loose catalog
+      // drops always PREPEND at top (position 1, BSR-18), and group drops land
+      // after the group's last existing child; the drop-target index the SR
+      // heard before was a lie for every drop below row 1.
+      let announcePosition = 1;
+      if (parentGroupId) {
+        const stack = layers.localLayers;
+        const groupIdx = stack.findIndex((l) => l.id === parentGroupId);
+        let lastChildIdx = -1;
+        for (let i = stack.length - 1; i >= 0; i--) {
+          if ((stack[i] as { parent_group_id?: string | null }).parent_group_id === parentGroupId) {
+            lastChildIdx = i;
+            break;
+          }
+        }
+        announcePosition = (lastChildIdx >= 0 ? lastChildIdx + 1 : groupIdx + 1) + 1;
+      }
       // Phase 20260526-builder-audit #338 BLD-20260526-11: announce fires inside onSuccessCb — only after the async mutation resolves
       // successfully. If the mutation errors, the hook fires toast.error and the announce
       // is never called, avoiding contradictory screen-reader output.
       // Modal stays open per POL-05 — onSuccessCb is not used to auto-select the layer.
       layers.handleAddDataset(datasetId, () => {
-        announce(t('a11y.dragDropped', { name: datasetName, n: safePosition }));
+        announce(t('a11y.dragDropped', { name: datasetName, n: announcePosition }));
       }, parentGroupId, datasetName);
       return;
     }
@@ -1295,6 +1310,12 @@ export function MapBuilderPage() {
   // Column 1: sidebar (340px full or 64px rail at <1100px)
   // Column 2: LayerEditorPanel flyout (380px, only when layer selected AND viewport >= 800px)
   // Column 3 (or 2 when no editor): map canvas (1fr)
+  //
+  // fix(#394) UX-05 (decision record): sidebar/editor widths are fixed and
+  // breakpoint-driven BY DESIGN — no user drag-resize, no persisted width.
+  // The three-column budget is tuned per breakpoint (340/380px columns keep
+  // the map ≥50% at 1280px) and a resizable panel would invalidate the
+  // responsive contract the e2e suite pins. Revisit only with a product ask.
   const builderBodyGridClass = cn(
     'flex-1 min-h-0 grid',
     // Base: no editor open
@@ -1371,6 +1392,9 @@ export function MapBuilderPage() {
           data-testid="builder-sidebar"
           className="border-e bg-background flex flex-col overflow-hidden"
         >
+          {/* fix(#394) UX-01/B-027: recoverable boundary — a stack-panel render
+              error must not take down the whole builder (map + chat stay up). */}
+          <PanelErrorBoundary panelId="builder-sidebar">
           {isRail ? (
             <SidebarRail
               layers={layers.localLayers}
@@ -1493,13 +1517,25 @@ export function MapBuilderPage() {
               this is inert — but it keeps the declared sidebar placement mode
               actually reachable for third-party plugins (plugin-audit finding). */}
           {!isRail && <PluginSidebar plugins={sidebarPlugins} ctx={pluginCtx} />}
+          </PanelErrorBoundary>
         </aside>
 
         {/* Column 2: LayerEditorPanel flyout (380px) — when layer selected or basemap/settings scene active; viewport >= 800px */}
         {isEditorOpen && !isEditorHidden && (
+          // eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions -- container-level Escape shortcut for keystrokes bubbling from the panel's own interactive children; the aside itself stays non-interactive
           <aside
             data-testid="builder-layer-editor"
             className="border-e bg-background flex flex-col overflow-hidden"
+            onKeyDown={(e) => {
+              // fix(#394) UX-02/B-015: Escape closes the desktop editor flyout —
+              // the <800px Sheet gets this from Radix for free. Only fires when
+              // focus is inside the flyout; nested Radix popovers/selects portal
+              // to <body>, so an open picker's Escape never reaches this aside.
+              if (e.key === 'Escape' && !e.defaultPrevented) {
+                e.stopPropagation();
+                handleCloseEditor();
+              }
+            }}
           >
             <LazyLoadErrorBoundary>
               <Suspense fallback={<SceneSpinnerFallback />}>

--- a/frontend/src/pages/PublicViewerPage.tsx
+++ b/frontend/src/pages/PublicViewerPage.tsx
@@ -56,7 +56,7 @@ export function PublicViewerPage() {
   const centerParam = searchParams.get('center');
   const legendParam = searchParams.get('legend');
 
-  const { data, isLoading, isError, error } = useSharedMap(token, apiKey);
+  const { data, isLoading, isError, error } = useSharedMap(token, apiKey, embedToken);
 
   const effectiveShowLegend = legendParam !== null ? legendParam === 'true' : !isEmbed;
 

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -1020,6 +1020,8 @@ export interface MapLayerResponse {
   is_dem?: boolean | null;
   dem_vertical_units?: string | null;
   band_count?: number | null;
+  /** fix(#394) VT-02: dataset content version — `_v=` tile-URL cache-buster. */
+  tile_version?: number | null;
 }
 
 export interface MapResponse {
@@ -1038,6 +1040,8 @@ export interface MapResponse {
   terrain_config: MapTerrainConfig | null;
   visibility: MapVisibility;
   thumbnail_url: string | null;
+  /** fix(#394) CV-01: social-card image URL — was missing from this hand-typed mirror. */
+  og_image_url?: string | null;
   created_by: string | null;
   created_by_username: string | null;
   created_at: string;
@@ -1234,6 +1238,8 @@ export interface SharedLayerResponse {
   is_3d?: boolean | null;
   tile_url: string;
   feature_count?: number | null;
+  /** fix(#394) VT-02: dataset content version — `_v=` tile-URL cache-buster. */
+  tile_version?: number | null;
 }
 
 export interface SharedMapResponse {

--- a/sdks/python/geolens/api/features/get_features_geojson_z_endpoint_datasets_dataset_id_features_geojson_get.py
+++ b/sdks/python/geolens/api/features/get_features_geojson_z_endpoint_datasets_dataset_id_features_geojson_get.py
@@ -5,16 +5,22 @@ from urllib.parse import quote
 import httpx
 
 from ...client import AuthenticatedClient, Client
-from ...types import Response
+from ...types import Response, UNSET
 from ... import errors
 
 from ...models.problem_detail import ProblemDetail
+from ...types import Unset
 from uuid import UUID
 
 
 def _get_kwargs(
     dataset_id: UUID,
+    *,
+    x_embed_token: None | str | Unset = UNSET,
 ) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+    if not isinstance(x_embed_token, Unset):
+        headers["X-Embed-Token"] = x_embed_token
 
     _kwargs: dict[str, Any] = {
         "method": "get",
@@ -23,6 +29,7 @@ def _get_kwargs(
         ),
     }
 
+    _kwargs["headers"] = headers
     return _kwargs
 
 
@@ -84,13 +91,24 @@ def sync_detailed(
     dataset_id: UUID,
     *,
     client: AuthenticatedClient,
+    x_embed_token: None | str | Unset = UNSET,
 ) -> Response[Any | ProblemDetail]:
     """Get Features Geojson Z Endpoint
 
      Return up to 5,000 features as RFC 7946 GeoJSON with Z coordinates.
 
+    fix(#394) codex P2: the viewer's bounded-GeoJSON path (small 3D layers,
+    eligible cluster layers) already sends ``X-Embed-Token``, and the B-023
+    shared-map union now exposes embed-scoped private layers to embeds — so
+    this endpoint accepts the token as fallback authorization via the SAME
+    ``validate_embed_token_access`` capability check as tile serving.
+    Credentialed callers (JWT / API key) keep the exact prior RBAC path;
+    anonymous callers without a valid scoped token still get 401.
+
     Args:
         dataset_id (UUID):
+        x_embed_token (None | str | Unset): Optional embed token. Datasets in the token's scope
+            are authorized even without user credentials (embed viewers).
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -102,6 +120,7 @@ def sync_detailed(
 
     kwargs = _get_kwargs(
         dataset_id=dataset_id,
+        x_embed_token=x_embed_token,
     )
 
     response = client.get_httpx_client().request(
@@ -115,13 +134,24 @@ def sync(
     dataset_id: UUID,
     *,
     client: AuthenticatedClient,
+    x_embed_token: None | str | Unset = UNSET,
 ) -> Any | ProblemDetail | None:
     """Get Features Geojson Z Endpoint
 
      Return up to 5,000 features as RFC 7946 GeoJSON with Z coordinates.
 
+    fix(#394) codex P2: the viewer's bounded-GeoJSON path (small 3D layers,
+    eligible cluster layers) already sends ``X-Embed-Token``, and the B-023
+    shared-map union now exposes embed-scoped private layers to embeds — so
+    this endpoint accepts the token as fallback authorization via the SAME
+    ``validate_embed_token_access`` capability check as tile serving.
+    Credentialed callers (JWT / API key) keep the exact prior RBAC path;
+    anonymous callers without a valid scoped token still get 401.
+
     Args:
         dataset_id (UUID):
+        x_embed_token (None | str | Unset): Optional embed token. Datasets in the token's scope
+            are authorized even without user credentials (embed viewers).
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -134,6 +164,7 @@ def sync(
     return sync_detailed(
         dataset_id=dataset_id,
         client=client,
+        x_embed_token=x_embed_token,
     ).parsed
 
 
@@ -141,13 +172,24 @@ async def asyncio_detailed(
     dataset_id: UUID,
     *,
     client: AuthenticatedClient,
+    x_embed_token: None | str | Unset = UNSET,
 ) -> Response[Any | ProblemDetail]:
     """Get Features Geojson Z Endpoint
 
      Return up to 5,000 features as RFC 7946 GeoJSON with Z coordinates.
 
+    fix(#394) codex P2: the viewer's bounded-GeoJSON path (small 3D layers,
+    eligible cluster layers) already sends ``X-Embed-Token``, and the B-023
+    shared-map union now exposes embed-scoped private layers to embeds — so
+    this endpoint accepts the token as fallback authorization via the SAME
+    ``validate_embed_token_access`` capability check as tile serving.
+    Credentialed callers (JWT / API key) keep the exact prior RBAC path;
+    anonymous callers without a valid scoped token still get 401.
+
     Args:
         dataset_id (UUID):
+        x_embed_token (None | str | Unset): Optional embed token. Datasets in the token's scope
+            are authorized even without user credentials (embed viewers).
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -159,6 +201,7 @@ async def asyncio_detailed(
 
     kwargs = _get_kwargs(
         dataset_id=dataset_id,
+        x_embed_token=x_embed_token,
     )
 
     response = await client.get_async_httpx_client().request(**kwargs)
@@ -170,13 +213,24 @@ async def asyncio(
     dataset_id: UUID,
     *,
     client: AuthenticatedClient,
+    x_embed_token: None | str | Unset = UNSET,
 ) -> Any | ProblemDetail | None:
     """Get Features Geojson Z Endpoint
 
      Return up to 5,000 features as RFC 7946 GeoJSON with Z coordinates.
 
+    fix(#394) codex P2: the viewer's bounded-GeoJSON path (small 3D layers,
+    eligible cluster layers) already sends ``X-Embed-Token``, and the B-023
+    shared-map union now exposes embed-scoped private layers to embeds — so
+    this endpoint accepts the token as fallback authorization via the SAME
+    ``validate_embed_token_access`` capability check as tile serving.
+    Credentialed callers (JWT / API key) keep the exact prior RBAC path;
+    anonymous callers without a valid scoped token still get 401.
+
     Args:
         dataset_id (UUID):
+        x_embed_token (None | str | Unset): Optional embed token. Datasets in the token's scope
+            are authorized even without user credentials (embed viewers).
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -190,5 +244,6 @@ async def asyncio(
         await asyncio_detailed(
             dataset_id=dataset_id,
             client=client,
+            x_embed_token=x_embed_token,
         )
     ).parsed

--- a/sdks/python/geolens/api/maps/get_shared_map_endpoint_maps_shared_token_get.py
+++ b/sdks/python/geolens/api/maps/get_shared_map_endpoint_maps_shared_token_get.py
@@ -109,14 +109,13 @@ def sync_detailed(
     empty, defaults to ``frame-ancestors 'self'``. The SecurityHeadersMiddleware
     respects this route-level CSP and skips emitting X-Frame-Options: DENY.
 
-    fix(#394) SH-01/B-023: also accepts ``X-Embed-Token`` so embed viewers get
-    the layers the token's scope authorizes (the tile path already honored the
-    token — SEC-022 capability posture; the metadata payload now matches).
+    fix(#394) SH-01/B-023: accepts ``X-Embed-Token`` so embed viewers get the
+    layers the token's scope authorizes (SEC-022 capability posture).
 
     Args:
         token (str):
-        x_embed_token (None | str | Unset): Optional embed token. When valid for this map, layers
-            backed by the token's scoped (possibly non-public) datasets are included.
+        x_embed_token (None | str | Unset): Optional embed token — includes its scoped dataset
+            layers when valid for this map.
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -154,14 +153,13 @@ def sync(
     empty, defaults to ``frame-ancestors 'self'``. The SecurityHeadersMiddleware
     respects this route-level CSP and skips emitting X-Frame-Options: DENY.
 
-    fix(#394) SH-01/B-023: also accepts ``X-Embed-Token`` so embed viewers get
-    the layers the token's scope authorizes (the tile path already honored the
-    token — SEC-022 capability posture; the metadata payload now matches).
+    fix(#394) SH-01/B-023: accepts ``X-Embed-Token`` so embed viewers get the
+    layers the token's scope authorizes (SEC-022 capability posture).
 
     Args:
         token (str):
-        x_embed_token (None | str | Unset): Optional embed token. When valid for this map, layers
-            backed by the token's scoped (possibly non-public) datasets are included.
+        x_embed_token (None | str | Unset): Optional embed token — includes its scoped dataset
+            layers when valid for this map.
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -194,14 +192,13 @@ async def asyncio_detailed(
     empty, defaults to ``frame-ancestors 'self'``. The SecurityHeadersMiddleware
     respects this route-level CSP and skips emitting X-Frame-Options: DENY.
 
-    fix(#394) SH-01/B-023: also accepts ``X-Embed-Token`` so embed viewers get
-    the layers the token's scope authorizes (the tile path already honored the
-    token — SEC-022 capability posture; the metadata payload now matches).
+    fix(#394) SH-01/B-023: accepts ``X-Embed-Token`` so embed viewers get the
+    layers the token's scope authorizes (SEC-022 capability posture).
 
     Args:
         token (str):
-        x_embed_token (None | str | Unset): Optional embed token. When valid for this map, layers
-            backed by the token's scoped (possibly non-public) datasets are included.
+        x_embed_token (None | str | Unset): Optional embed token — includes its scoped dataset
+            layers when valid for this map.
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -237,14 +234,13 @@ async def asyncio(
     empty, defaults to ``frame-ancestors 'self'``. The SecurityHeadersMiddleware
     respects this route-level CSP and skips emitting X-Frame-Options: DENY.
 
-    fix(#394) SH-01/B-023: also accepts ``X-Embed-Token`` so embed viewers get
-    the layers the token's scope authorizes (the tile path already honored the
-    token — SEC-022 capability posture; the metadata payload now matches).
+    fix(#394) SH-01/B-023: accepts ``X-Embed-Token`` so embed viewers get the
+    layers the token's scope authorizes (SEC-022 capability posture).
 
     Args:
         token (str):
-        x_embed_token (None | str | Unset): Optional embed token. When valid for this map, layers
-            backed by the token's scoped (possibly non-public) datasets are included.
+        x_embed_token (None | str | Unset): Optional embed token — includes its scoped dataset
+            layers when valid for this map.
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.

--- a/sdks/python/geolens/api/maps/get_shared_map_endpoint_maps_shared_token_get.py
+++ b/sdks/python/geolens/api/maps/get_shared_map_endpoint_maps_shared_token_get.py
@@ -5,16 +5,22 @@ from urllib.parse import quote
 import httpx
 
 from ...client import AuthenticatedClient, Client
-from ...types import Response
+from ...types import Response, UNSET
 from ... import errors
 
 from ...models.problem_detail import ProblemDetail
 from ...models.shared_map_response import SharedMapResponse
+from ...types import Unset
 
 
 def _get_kwargs(
     token: str,
+    *,
+    x_embed_token: None | str | Unset = UNSET,
 ) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+    if not isinstance(x_embed_token, Unset):
+        headers["X-Embed-Token"] = x_embed_token
 
     _kwargs: dict[str, Any] = {
         "method": "get",
@@ -23,6 +29,7 @@ def _get_kwargs(
         ),
     }
 
+    _kwargs["headers"] = headers
     return _kwargs
 
 
@@ -90,6 +97,7 @@ def sync_detailed(
     token: str,
     *,
     client: AuthenticatedClient,
+    x_embed_token: None | str | Unset = UNSET,
 ) -> Response[ProblemDetail | SharedMapResponse]:
     """Get Shared Map Endpoint
 
@@ -101,8 +109,14 @@ def sync_detailed(
     empty, defaults to ``frame-ancestors 'self'``. The SecurityHeadersMiddleware
     respects this route-level CSP and skips emitting X-Frame-Options: DENY.
 
+    fix(#394) SH-01/B-023: also accepts ``X-Embed-Token`` so embed viewers get
+    the layers the token's scope authorizes (the tile path already honored the
+    token — SEC-022 capability posture; the metadata payload now matches).
+
     Args:
         token (str):
+        x_embed_token (None | str | Unset): Optional embed token. When valid for this map, layers
+            backed by the token's scoped (possibly non-public) datasets are included.
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -114,6 +128,7 @@ def sync_detailed(
 
     kwargs = _get_kwargs(
         token=token,
+        x_embed_token=x_embed_token,
     )
 
     response = client.get_httpx_client().request(
@@ -127,6 +142,7 @@ def sync(
     token: str,
     *,
     client: AuthenticatedClient,
+    x_embed_token: None | str | Unset = UNSET,
 ) -> ProblemDetail | SharedMapResponse | None:
     """Get Shared Map Endpoint
 
@@ -138,8 +154,14 @@ def sync(
     empty, defaults to ``frame-ancestors 'self'``. The SecurityHeadersMiddleware
     respects this route-level CSP and skips emitting X-Frame-Options: DENY.
 
+    fix(#394) SH-01/B-023: also accepts ``X-Embed-Token`` so embed viewers get
+    the layers the token's scope authorizes (the tile path already honored the
+    token — SEC-022 capability posture; the metadata payload now matches).
+
     Args:
         token (str):
+        x_embed_token (None | str | Unset): Optional embed token. When valid for this map, layers
+            backed by the token's scoped (possibly non-public) datasets are included.
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -152,6 +174,7 @@ def sync(
     return sync_detailed(
         token=token,
         client=client,
+        x_embed_token=x_embed_token,
     ).parsed
 
 
@@ -159,6 +182,7 @@ async def asyncio_detailed(
     token: str,
     *,
     client: AuthenticatedClient,
+    x_embed_token: None | str | Unset = UNSET,
 ) -> Response[ProblemDetail | SharedMapResponse]:
     """Get Shared Map Endpoint
 
@@ -170,8 +194,14 @@ async def asyncio_detailed(
     empty, defaults to ``frame-ancestors 'self'``. The SecurityHeadersMiddleware
     respects this route-level CSP and skips emitting X-Frame-Options: DENY.
 
+    fix(#394) SH-01/B-023: also accepts ``X-Embed-Token`` so embed viewers get
+    the layers the token's scope authorizes (the tile path already honored the
+    token — SEC-022 capability posture; the metadata payload now matches).
+
     Args:
         token (str):
+        x_embed_token (None | str | Unset): Optional embed token. When valid for this map, layers
+            backed by the token's scoped (possibly non-public) datasets are included.
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -183,6 +213,7 @@ async def asyncio_detailed(
 
     kwargs = _get_kwargs(
         token=token,
+        x_embed_token=x_embed_token,
     )
 
     response = await client.get_async_httpx_client().request(**kwargs)
@@ -194,6 +225,7 @@ async def asyncio(
     token: str,
     *,
     client: AuthenticatedClient,
+    x_embed_token: None | str | Unset = UNSET,
 ) -> ProblemDetail | SharedMapResponse | None:
     """Get Shared Map Endpoint
 
@@ -205,8 +237,14 @@ async def asyncio(
     empty, defaults to ``frame-ancestors 'self'``. The SecurityHeadersMiddleware
     respects this route-level CSP and skips emitting X-Frame-Options: DENY.
 
+    fix(#394) SH-01/B-023: also accepts ``X-Embed-Token`` so embed viewers get
+    the layers the token's scope authorizes (the tile path already honored the
+    token — SEC-022 capability posture; the metadata payload now matches).
+
     Args:
         token (str):
+        x_embed_token (None | str | Unset): Optional embed token. When valid for this map, layers
+            backed by the token's scoped (possibly non-public) datasets are included.
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -220,5 +258,6 @@ async def asyncio(
         await asyncio_detailed(
             token=token,
             client=client,
+            x_embed_token=x_embed_token,
         )
     ).parsed

--- a/sdks/python/geolens/api/tiles/get_tile_tokens_batch_tiles_tokens_post.py
+++ b/sdks/python/geolens/api/tiles/get_tile_tokens_batch_tiles_tokens_post.py
@@ -99,17 +99,12 @@ def sync_detailed(
     response maps the offending dataset_id to ``{\"error\": \"...\"}``. Clients
     should check each entry for the ``error`` key.
 
-    fix(#394) SH-04: embed viewers carry no login, so this endpoint accepts
-    ``X-Embed-Token`` as a per-dataset fallback authorization — the same
-    ``validate_embed_token_access`` capability check the tile-serving path
-    uses (origin allowlist + live layer-membership + tenant equality). This
-    lets embed-mode terrain build its raster-dem source from the SAME
-    descriptor (bounds / resolution-derived maxzoom) as builder and viewer
-    instead of empty defaults.
+    fix(#394) SH-04: ``X-Embed-Token`` is accepted as per-dataset fallback
+    authorization (same capability check as tile serving), so embed terrain
+    builds its raster-dem source from the real bounds/maxzoom descriptor.
 
     Args:
-        x_embed_token (None | str | Unset): Optional embed token. Datasets in the token's scope
-            are authorized even without user credentials (embed viewers).
+        x_embed_token (None | str | Unset):
         body (TileTokenBatchRequest): Batch request for tile tokens — accepts up to 50 dataset
             IDs.
 
@@ -152,17 +147,12 @@ def sync(
     response maps the offending dataset_id to ``{\"error\": \"...\"}``. Clients
     should check each entry for the ``error`` key.
 
-    fix(#394) SH-04: embed viewers carry no login, so this endpoint accepts
-    ``X-Embed-Token`` as a per-dataset fallback authorization — the same
-    ``validate_embed_token_access`` capability check the tile-serving path
-    uses (origin allowlist + live layer-membership + tenant equality). This
-    lets embed-mode terrain build its raster-dem source from the SAME
-    descriptor (bounds / resolution-derived maxzoom) as builder and viewer
-    instead of empty defaults.
+    fix(#394) SH-04: ``X-Embed-Token`` is accepted as per-dataset fallback
+    authorization (same capability check as tile serving), so embed terrain
+    builds its raster-dem source from the real bounds/maxzoom descriptor.
 
     Args:
-        x_embed_token (None | str | Unset): Optional embed token. Datasets in the token's scope
-            are authorized even without user credentials (embed viewers).
+        x_embed_token (None | str | Unset):
         body (TileTokenBatchRequest): Batch request for tile tokens — accepts up to 50 dataset
             IDs.
 
@@ -200,17 +190,12 @@ async def asyncio_detailed(
     response maps the offending dataset_id to ``{\"error\": \"...\"}``. Clients
     should check each entry for the ``error`` key.
 
-    fix(#394) SH-04: embed viewers carry no login, so this endpoint accepts
-    ``X-Embed-Token`` as a per-dataset fallback authorization — the same
-    ``validate_embed_token_access`` capability check the tile-serving path
-    uses (origin allowlist + live layer-membership + tenant equality). This
-    lets embed-mode terrain build its raster-dem source from the SAME
-    descriptor (bounds / resolution-derived maxzoom) as builder and viewer
-    instead of empty defaults.
+    fix(#394) SH-04: ``X-Embed-Token`` is accepted as per-dataset fallback
+    authorization (same capability check as tile serving), so embed terrain
+    builds its raster-dem source from the real bounds/maxzoom descriptor.
 
     Args:
-        x_embed_token (None | str | Unset): Optional embed token. Datasets in the token's scope
-            are authorized even without user credentials (embed viewers).
+        x_embed_token (None | str | Unset):
         body (TileTokenBatchRequest): Batch request for tile tokens — accepts up to 50 dataset
             IDs.
 
@@ -251,17 +236,12 @@ async def asyncio(
     response maps the offending dataset_id to ``{\"error\": \"...\"}``. Clients
     should check each entry for the ``error`` key.
 
-    fix(#394) SH-04: embed viewers carry no login, so this endpoint accepts
-    ``X-Embed-Token`` as a per-dataset fallback authorization — the same
-    ``validate_embed_token_access`` capability check the tile-serving path
-    uses (origin allowlist + live layer-membership + tenant equality). This
-    lets embed-mode terrain build its raster-dem source from the SAME
-    descriptor (bounds / resolution-derived maxzoom) as builder and viewer
-    instead of empty defaults.
+    fix(#394) SH-04: ``X-Embed-Token`` is accepted as per-dataset fallback
+    authorization (same capability check as tile serving), so embed terrain
+    builds its raster-dem source from the real bounds/maxzoom descriptor.
 
     Args:
-        x_embed_token (None | str | Unset): Optional embed token. Datasets in the token's scope
-            are authorized even without user credentials (embed viewers).
+        x_embed_token (None | str | Unset):
         body (TileTokenBatchRequest): Batch request for tile tokens — accepts up to 50 dataset
             IDs.
 

--- a/sdks/python/geolens/api/tiles/get_tile_tokens_batch_tiles_tokens_post.py
+++ b/sdks/python/geolens/api/tiles/get_tile_tokens_batch_tiles_tokens_post.py
@@ -4,19 +4,23 @@ from typing import Any
 import httpx
 
 from ...client import AuthenticatedClient, Client
-from ...types import Response
+from ...types import Response, UNSET
 from ... import errors
 
 from ...models.problem_detail import ProblemDetail
 from ...models.tile_token_batch_request import TileTokenBatchRequest
 from ...models.tile_token_batch_response import TileTokenBatchResponse
+from ...types import Unset
 
 
 def _get_kwargs(
     *,
     body: TileTokenBatchRequest,
+    x_embed_token: None | str | Unset = UNSET,
 ) -> dict[str, Any]:
     headers: dict[str, Any] = {}
+    if not isinstance(x_embed_token, Unset):
+        headers["X-Embed-Token"] = x_embed_token
 
     _kwargs: dict[str, Any] = {
         "method": "post",
@@ -80,6 +84,7 @@ def sync_detailed(
     *,
     client: AuthenticatedClient,
     body: TileTokenBatchRequest,
+    x_embed_token: None | str | Unset = UNSET,
 ) -> Response[ProblemDetail | TileTokenBatchResponse]:
     r"""Get Tile Tokens Batch
 
@@ -94,7 +99,17 @@ def sync_detailed(
     response maps the offending dataset_id to ``{\"error\": \"...\"}``. Clients
     should check each entry for the ``error`` key.
 
+    fix(#394) SH-04: embed viewers carry no login, so this endpoint accepts
+    ``X-Embed-Token`` as a per-dataset fallback authorization — the same
+    ``validate_embed_token_access`` capability check the tile-serving path
+    uses (origin allowlist + live layer-membership + tenant equality). This
+    lets embed-mode terrain build its raster-dem source from the SAME
+    descriptor (bounds / resolution-derived maxzoom) as builder and viewer
+    instead of empty defaults.
+
     Args:
+        x_embed_token (None | str | Unset): Optional embed token. Datasets in the token's scope
+            are authorized even without user credentials (embed viewers).
         body (TileTokenBatchRequest): Batch request for tile tokens — accepts up to 50 dataset
             IDs.
 
@@ -108,6 +123,7 @@ def sync_detailed(
 
     kwargs = _get_kwargs(
         body=body,
+        x_embed_token=x_embed_token,
     )
 
     response = client.get_httpx_client().request(
@@ -121,6 +137,7 @@ def sync(
     *,
     client: AuthenticatedClient,
     body: TileTokenBatchRequest,
+    x_embed_token: None | str | Unset = UNSET,
 ) -> ProblemDetail | TileTokenBatchResponse | None:
     r"""Get Tile Tokens Batch
 
@@ -135,7 +152,17 @@ def sync(
     response maps the offending dataset_id to ``{\"error\": \"...\"}``. Clients
     should check each entry for the ``error`` key.
 
+    fix(#394) SH-04: embed viewers carry no login, so this endpoint accepts
+    ``X-Embed-Token`` as a per-dataset fallback authorization — the same
+    ``validate_embed_token_access`` capability check the tile-serving path
+    uses (origin allowlist + live layer-membership + tenant equality). This
+    lets embed-mode terrain build its raster-dem source from the SAME
+    descriptor (bounds / resolution-derived maxzoom) as builder and viewer
+    instead of empty defaults.
+
     Args:
+        x_embed_token (None | str | Unset): Optional embed token. Datasets in the token's scope
+            are authorized even without user credentials (embed viewers).
         body (TileTokenBatchRequest): Batch request for tile tokens — accepts up to 50 dataset
             IDs.
 
@@ -150,6 +177,7 @@ def sync(
     return sync_detailed(
         client=client,
         body=body,
+        x_embed_token=x_embed_token,
     ).parsed
 
 
@@ -157,6 +185,7 @@ async def asyncio_detailed(
     *,
     client: AuthenticatedClient,
     body: TileTokenBatchRequest,
+    x_embed_token: None | str | Unset = UNSET,
 ) -> Response[ProblemDetail | TileTokenBatchResponse]:
     r"""Get Tile Tokens Batch
 
@@ -171,7 +200,17 @@ async def asyncio_detailed(
     response maps the offending dataset_id to ``{\"error\": \"...\"}``. Clients
     should check each entry for the ``error`` key.
 
+    fix(#394) SH-04: embed viewers carry no login, so this endpoint accepts
+    ``X-Embed-Token`` as a per-dataset fallback authorization — the same
+    ``validate_embed_token_access`` capability check the tile-serving path
+    uses (origin allowlist + live layer-membership + tenant equality). This
+    lets embed-mode terrain build its raster-dem source from the SAME
+    descriptor (bounds / resolution-derived maxzoom) as builder and viewer
+    instead of empty defaults.
+
     Args:
+        x_embed_token (None | str | Unset): Optional embed token. Datasets in the token's scope
+            are authorized even without user credentials (embed viewers).
         body (TileTokenBatchRequest): Batch request for tile tokens — accepts up to 50 dataset
             IDs.
 
@@ -185,6 +224,7 @@ async def asyncio_detailed(
 
     kwargs = _get_kwargs(
         body=body,
+        x_embed_token=x_embed_token,
     )
 
     response = await client.get_async_httpx_client().request(**kwargs)
@@ -196,6 +236,7 @@ async def asyncio(
     *,
     client: AuthenticatedClient,
     body: TileTokenBatchRequest,
+    x_embed_token: None | str | Unset = UNSET,
 ) -> ProblemDetail | TileTokenBatchResponse | None:
     r"""Get Tile Tokens Batch
 
@@ -210,7 +251,17 @@ async def asyncio(
     response maps the offending dataset_id to ``{\"error\": \"...\"}``. Clients
     should check each entry for the ``error`` key.
 
+    fix(#394) SH-04: embed viewers carry no login, so this endpoint accepts
+    ``X-Embed-Token`` as a per-dataset fallback authorization — the same
+    ``validate_embed_token_access`` capability check the tile-serving path
+    uses (origin allowlist + live layer-membership + tenant equality). This
+    lets embed-mode terrain build its raster-dem source from the SAME
+    descriptor (bounds / resolution-derived maxzoom) as builder and viewer
+    instead of empty defaults.
+
     Args:
+        x_embed_token (None | str | Unset): Optional embed token. Datasets in the token's scope
+            are authorized even without user credentials (embed viewers).
         body (TileTokenBatchRequest): Batch request for tile tokens — accepts up to 50 dataset
             IDs.
 
@@ -226,5 +277,6 @@ async def asyncio(
         await asyncio_detailed(
             client=client,
             body=body,
+            x_embed_token=x_embed_token,
         )
     ).parsed

--- a/sdks/python/geolens/models/map_layer_response.py
+++ b/sdks/python/geolens/models/map_layer_response.py
@@ -62,6 +62,7 @@ class MapLayerResponse:
         popup_config (None | PopupConfig | Unset):
         show_in_legend (bool | Unset):  Default: True.
         style_config (MapLayerResponseStyleConfigType0 | None | Unset):
+        tile_version (int | None | Unset):
     """
 
     dataset_extent_bbox: list[float] | None
@@ -94,6 +95,7 @@ class MapLayerResponse:
     popup_config: None | PopupConfig | Unset = UNSET
     show_in_legend: bool | Unset = True
     style_config: MapLayerResponseStyleConfigType0 | None | Unset = UNSET
+    tile_version: int | None | Unset = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
@@ -239,6 +241,12 @@ class MapLayerResponse:
         else:
             style_config = self.style_config
 
+        tile_version: int | None | Unset
+        if isinstance(self.tile_version, Unset):
+            tile_version = UNSET
+        else:
+            tile_version = self.tile_version
+
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
@@ -286,6 +294,8 @@ class MapLayerResponse:
             field_dict["show_in_legend"] = show_in_legend
         if style_config is not UNSET:
             field_dict["style_config"] = style_config
+        if tile_version is not UNSET:
+            field_dict["tile_version"] = tile_version
 
         return field_dict
 
@@ -551,6 +561,15 @@ class MapLayerResponse:
 
         style_config = _parse_style_config(d.pop("style_config", UNSET))
 
+        def _parse_tile_version(data: object) -> int | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(int | None | Unset, data)
+
+        tile_version = _parse_tile_version(d.pop("tile_version", UNSET))
+
         map_layer_response = cls(
             dataset_extent_bbox=dataset_extent_bbox,
             dataset_geometry_type=dataset_geometry_type,
@@ -578,6 +597,7 @@ class MapLayerResponse:
             popup_config=popup_config,
             show_in_legend=show_in_legend,
             style_config=style_config,
+            tile_version=tile_version,
         )
 
         map_layer_response.additional_properties = d

--- a/sdks/python/geolens/models/shared_layer_response.py
+++ b/sdks/python/geolens/models/shared_layer_response.py
@@ -56,6 +56,7 @@ class SharedLayerResponse:
         popup_config (None | PopupConfig | Unset):
         show_in_legend (bool | Unset):  Default: True.
         style_config (None | SharedLayerResponseStyleConfigType0 | Unset):
+        tile_version (int | None | Unset):
     """
 
     dataset_id: str
@@ -82,6 +83,7 @@ class SharedLayerResponse:
     popup_config: None | PopupConfig | Unset = UNSET
     show_in_legend: bool | Unset = True
     style_config: None | SharedLayerResponseStyleConfigType0 | Unset = UNSET
+    tile_version: int | None | Unset = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
@@ -201,6 +203,12 @@ class SharedLayerResponse:
         else:
             style_config = self.style_config
 
+        tile_version: int | None | Unset
+        if isinstance(self.tile_version, Unset):
+            tile_version = UNSET
+        else:
+            tile_version = self.tile_version
+
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
@@ -244,6 +252,8 @@ class SharedLayerResponse:
             field_dict["show_in_legend"] = show_in_legend
         if style_config is not UNSET:
             field_dict["style_config"] = style_config
+        if tile_version is not UNSET:
+            field_dict["tile_version"] = tile_version
 
         return field_dict
 
@@ -458,6 +468,15 @@ class SharedLayerResponse:
 
         style_config = _parse_style_config(d.pop("style_config", UNSET))
 
+        def _parse_tile_version(data: object) -> int | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(int | None | Unset, data)
+
+        tile_version = _parse_tile_version(d.pop("tile_version", UNSET))
+
         shared_layer_response = cls(
             dataset_id=dataset_id,
             dataset_name=dataset_name,
@@ -483,6 +502,7 @@ class SharedLayerResponse:
             popup_config=popup_config,
             show_in_legend=show_in_legend,
             style_config=style_config,
+            tile_version=tile_version,
         )
 
         shared_layer_response.additional_properties = d

--- a/sdks/typescript/src/client/sdk.gen.ts
+++ b/sdks/typescript/src/client/sdk.gen.ts
@@ -2251,6 +2251,10 @@ export const importMapStyleEndpointMapsImportPost = <ThrowOnError extends boolea
  * EmbedToken for this map. When no EmbedToken exists or allowed_origins is
  * empty, defaults to ``frame-ancestors 'self'``. The SecurityHeadersMiddleware
  * respects this route-level CSP and skips emitting X-Frame-Options: DENY.
+ *
+ * fix(#394) SH-01/B-023: also accepts ``X-Embed-Token`` so embed viewers get
+ * the layers the token's scope authorizes (the tile path already honored the
+ * token — SEC-022 capability posture; the metadata payload now matches).
  */
 export const getSharedMapEndpointMapsSharedTokenGet = <ThrowOnError extends boolean = false>(options: Options<GetSharedMapEndpointMapsSharedTokenGetData, ThrowOnError>) => (options.client ?? client).get<GetSharedMapEndpointMapsSharedTokenGetResponses, GetSharedMapEndpointMapsSharedTokenGetErrors, ThrowOnError>({
     security: [{ scheme: 'bearer', type: 'http' }],
@@ -3361,6 +3365,14 @@ export const getTileTokenTilesTokenDatasetIdGet = <ThrowOnError extends boolean 
  * Per-dataset errors (404, 403) do not fail the batch — instead the
  * response maps the offending dataset_id to ``{"error": "..."}``. Clients
  * should check each entry for the ``error`` key.
+ *
+ * fix(#394) SH-04: embed viewers carry no login, so this endpoint accepts
+ * ``X-Embed-Token`` as a per-dataset fallback authorization — the same
+ * ``validate_embed_token_access`` capability check the tile-serving path
+ * uses (origin allowlist + live layer-membership + tenant equality). This
+ * lets embed-mode terrain build its raster-dem source from the SAME
+ * descriptor (bounds / resolution-derived maxzoom) as builder and viewer
+ * instead of empty defaults.
  */
 export const getTileTokensBatchTilesTokensPost = <ThrowOnError extends boolean = false>(options: Options<GetTileTokensBatchTilesTokensPostData, ThrowOnError>) => (options.client ?? client).post<GetTileTokensBatchTilesTokensPostResponses, GetTileTokensBatchTilesTokensPostErrors, ThrowOnError>({
     security: [{ scheme: 'bearer', type: 'http' }],

--- a/sdks/typescript/src/client/sdk.gen.ts
+++ b/sdks/typescript/src/client/sdk.gen.ts
@@ -1335,6 +1335,14 @@ export const exportDatasetEndpointDatasetsDatasetIdExportGet = <ThrowOnError ext
  * Get Features Geojson Z Endpoint
  *
  * Return up to 5,000 features as RFC 7946 GeoJSON with Z coordinates.
+ *
+ * fix(#394) codex P2: the viewer's bounded-GeoJSON path (small 3D layers,
+ * eligible cluster layers) already sends ``X-Embed-Token``, and the B-023
+ * shared-map union now exposes embed-scoped private layers to embeds — so
+ * this endpoint accepts the token as fallback authorization via the SAME
+ * ``validate_embed_token_access`` capability check as tile serving.
+ * Credentialed callers (JWT / API key) keep the exact prior RBAC path;
+ * anonymous callers without a valid scoped token still get 401.
  */
 export const getFeaturesGeojsonZEndpointDatasetsDatasetIdFeaturesGeojsonGet = <ThrowOnError extends boolean = false>(options: Options<GetFeaturesGeojsonZEndpointDatasetsDatasetIdFeaturesGeojsonGetData, ThrowOnError>) => (options.client ?? client).get<GetFeaturesGeojsonZEndpointDatasetsDatasetIdFeaturesGeojsonGetResponses, GetFeaturesGeojsonZEndpointDatasetsDatasetIdFeaturesGeojsonGetErrors, ThrowOnError>({
     security: [{ scheme: 'bearer', type: 'http' }],
@@ -2252,9 +2260,8 @@ export const importMapStyleEndpointMapsImportPost = <ThrowOnError extends boolea
  * empty, defaults to ``frame-ancestors 'self'``. The SecurityHeadersMiddleware
  * respects this route-level CSP and skips emitting X-Frame-Options: DENY.
  *
- * fix(#394) SH-01/B-023: also accepts ``X-Embed-Token`` so embed viewers get
- * the layers the token's scope authorizes (the tile path already honored the
- * token — SEC-022 capability posture; the metadata payload now matches).
+ * fix(#394) SH-01/B-023: accepts ``X-Embed-Token`` so embed viewers get the
+ * layers the token's scope authorizes (SEC-022 capability posture).
  */
 export const getSharedMapEndpointMapsSharedTokenGet = <ThrowOnError extends boolean = false>(options: Options<GetSharedMapEndpointMapsSharedTokenGetData, ThrowOnError>) => (options.client ?? client).get<GetSharedMapEndpointMapsSharedTokenGetResponses, GetSharedMapEndpointMapsSharedTokenGetErrors, ThrowOnError>({
     security: [{ scheme: 'bearer', type: 'http' }],
@@ -3366,13 +3373,9 @@ export const getTileTokenTilesTokenDatasetIdGet = <ThrowOnError extends boolean 
  * response maps the offending dataset_id to ``{"error": "..."}``. Clients
  * should check each entry for the ``error`` key.
  *
- * fix(#394) SH-04: embed viewers carry no login, so this endpoint accepts
- * ``X-Embed-Token`` as a per-dataset fallback authorization — the same
- * ``validate_embed_token_access`` capability check the tile-serving path
- * uses (origin allowlist + live layer-membership + tenant equality). This
- * lets embed-mode terrain build its raster-dem source from the SAME
- * descriptor (bounds / resolution-derived maxzoom) as builder and viewer
- * instead of empty defaults.
+ * fix(#394) SH-04: ``X-Embed-Token`` is accepted as per-dataset fallback
+ * authorization (same capability check as tile serving), so embed terrain
+ * builds its raster-dem source from the real bounds/maxzoom descriptor.
  */
 export const getTileTokensBatchTilesTokensPost = <ThrowOnError extends boolean = false>(options: Options<GetTileTokensBatchTilesTokensPostData, ThrowOnError>) => (options.client ?? client).post<GetTileTokensBatchTilesTokensPostResponses, GetTileTokensBatchTilesTokensPostErrors, ThrowOnError>({
     security: [{ scheme: 'bearer', type: 'http' }],

--- a/sdks/typescript/src/client/types.gen.ts
+++ b/sdks/typescript/src/client/types.gen.ts
@@ -4935,6 +4935,10 @@ export type MapLayerResponse = {
         [key: string]: unknown;
     } | null;
     /**
+     * Tile Version
+     */
+    tile_version?: number | null;
+    /**
      * Visible
      */
     visible: boolean;
@@ -7716,6 +7720,10 @@ export type SharedLayerResponse = {
      * Tile Url
      */
     tile_url: string;
+    /**
+     * Tile Version
+     */
+    tile_version?: number | null;
     /**
      * Visible
      */
@@ -17665,6 +17673,14 @@ export type ImportMapStyleEndpointMapsImportPostResponse = ImportMapStyleEndpoin
 
 export type GetSharedMapEndpointMapsSharedTokenGetData = {
     body?: never;
+    headers?: {
+        /**
+         * X-Embed-Token
+         *
+         * Optional embed token. When valid for this map, layers backed by the token's scoped (possibly non-public) datasets are included.
+         */
+        'X-Embed-Token'?: string | null;
+    };
     path: {
         /**
          * Token
@@ -21778,6 +21794,14 @@ export type GetTileTokenTilesTokenDatasetIdGetResponse = GetTileTokenTilesTokenD
 
 export type GetTileTokensBatchTilesTokensPostData = {
     body: TileTokenBatchRequest;
+    headers?: {
+        /**
+         * X-Embed-Token
+         *
+         * Optional embed token. Datasets in the token's scope are authorized even without user credentials (embed viewers).
+         */
+        'X-Embed-Token'?: string | null;
+    };
     path?: never;
     query?: never;
     url: '/tiles/tokens/';

--- a/sdks/typescript/src/client/types.gen.ts
+++ b/sdks/typescript/src/client/types.gen.ts
@@ -14377,6 +14377,14 @@ export type ExportDatasetEndpointDatasetsDatasetIdExportGetResponses = {
 
 export type GetFeaturesGeojsonZEndpointDatasetsDatasetIdFeaturesGeojsonGetData = {
     body?: never;
+    headers?: {
+        /**
+         * X-Embed-Token
+         *
+         * Optional embed token. Datasets in the token's scope are authorized even without user credentials (embed viewers).
+         */
+        'X-Embed-Token'?: string | null;
+    };
     path: {
         /**
          * Dataset Id
@@ -17677,7 +17685,7 @@ export type GetSharedMapEndpointMapsSharedTokenGetData = {
         /**
          * X-Embed-Token
          *
-         * Optional embed token. When valid for this map, layers backed by the token's scoped (possibly non-public) datasets are included.
+         * Optional embed token — includes its scoped dataset layers when valid for this map.
          */
         'X-Embed-Token'?: string | null;
     };
@@ -21797,8 +21805,6 @@ export type GetTileTokensBatchTilesTokensPostData = {
     headers?: {
         /**
          * X-Embed-Token
-         *
-         * Optional embed token. Datasets in the token's scope are authorized even without user credentials (embed viewers).
          */
         'X-Embed-Token'?: string | null;
     };


### PR DESCRIPTION
Remediates every action item from the 2026-07-03 builder deep-dive audit (the follow-up to #392's 2026-07-02 remediation): the P1 set **B-019..B-023**, the P2 set **B-024..B-031**, and the **B-032** LOW rollup. Prior deferred items B-010..B-018 remain tracked in their existing todos per the audit's own guidance, except the pieces the audit explicitly bundled here (UX-02 desktop Escape and ST-02 editor typing — closing out **B-015** — plus LM-02 from B-016 and UX-03 from B-017).

## P1

| ID | Sev | Fix |
|----|-----|-----|
| **B-019** (VT-01) | **HIGH** | Reupload (both file + service tasks) now purges the MVT tile cache **post-commit** via a shared helper — it was the one write path that never invalidated, so stale tiles kept 304-serving for up to `tile_cache_ttl` after every reupload. |
| B-020 (FL-01) | MED | Data filters are no longer ANDed into cluster/cluster-count layers (adapter + live handler) — cluster features carry only `point_count`/`cluster_id`, so any predicate blanked every bubble. Documented ceiling: cluster counts include filtered-out points. |
| B-021 (LM-01) | MED | "Add to group…" kebab splices the row after the group's last child + renumbers `sort_order` (mirror of #392's drag-path fix); Test E now asserts position and a new Test E2 covers the kebab path. |
| B-022 (SH-02) | MED | `X-Embed-Token` is only attached to first-party requests (own origin / configured tile CDN) — third-party basemap sprite/glyph/tile CDNs no longer receive the credential. |
| B-023 (SH-01) | MED | **Decision: honor the token** (not soften the copy). `GET /maps/shared/{token}` accepts `X-Embed-Token` and unions the token's scoped dataset layers into the payload — embed tokens are a private-dataset **capability** (SEC-022 posture, EMBED-02/04) that the tile path has always honored; the metadata payload now matches, so a dataset downgraded to private after publish renders in embeds exactly as the SharePanel copy promises. Fail-closed: active + map-bound + origin-checked, and the join still requires current map membership + map publicity. |

## P2

- **B-024** (ST-01, both sides): zero surviving icon pairs → flat fallback instead of a spec-invalid length-3 `match` that made `addLayer` throw (swallowed) and the symbol layer silently vanish. Plus **ST-04**: `to-string` match input + stringified labels so numeric category columns actually match (frontend adapter + `style_json.py` export, byte-parity).
- **B-025** (VT-05): `ST_MakeValid` guards the simplify input — one invalid geometry can no longer 503 a whole tile.
- **B-026** (VT-02/03/04): `tile_version` (`Dataset.current_version`) wired into `MapLayerResponse` + `SharedLayerResponse` — the builder's existing `_v=` cache-buster read finally has a producer, and the viewer threads it too. Viewer now derives its MVT source-layer via `getMvtSourceLayerName()` (every frontend hardcode of `` `data.${table}` `` converted), with a parity test pinning the contract against the server emission.
- **B-027** (UX-01): builder sidebar wrapped in a recoverable `PanelErrorBoundary` — a stack-panel render error no longer takes down the whole builder.
- **B-028** (LM-02): ephemeral query overlay re-adds itself on every `style.load` (basemap switches wiped it while the badge stayed); zooms only on first show.
- **B-029** (UX-04): shortcuts sheet documents the full existing keyboard model (`?`, reorder mode, Escape, ⌘/Ctrl+Click, Shift+Click, Shift+↑/↓).
- **B-030** (CH-01/02/03): `fill-extrusion-*` survives chat paint validation (the extrusion companion consumes it; mirrors the backend allowlist); `set_label` validates column against the layer schema + sanitizes `textColor` on **both** sides (backend feeds the model a retryable error); `set_data_driven_style` requires the target layer + a real mutation before reporting "applied".
- **B-031** (ST-02, closes half of B-015): Advanced JSON editor validates against the **rendered** adapter type (heatmap/symbol; cluster-as-circle) instead of raw geometry. Bundled per the audit: **UX-02** Escape-to-close on the desktop editor flyout (closes B-015's other half) and rail panels (UX-07).

## B-032 LOW rollup — all addressed

LM-03 (announce real drop position) · LM-04 (group eye = children aggregate, render + toggle) · LM-05 (keyboard reorder over the rendered stack) · FL-02 (empty-state copy says "in view") · FL-03 (numeric `in_list` per-entry NaN guard — the whole-string check also rejected *valid* numeric lists) · LB-10 (restore branch re-asserts label filter) · ST-03 (expression opacity × master slider) · ST-05 (validator crash blocks apply) · ST-06 (cluster export limitation documented) · SH-04 (batch token endpoint accepts `X-Embed-Token` → embed terrain gets the real DEM bounds/maxzoom descriptor instead of empty defaults) · CH-11 (staging no longer kills undo; downgrade moved to the accept path) · CV-01 (`og_image_url` added to the `MapResponse` mirror) · PF-05 (lazy-seed bounds ref) · VT-06 (NULL post-clip geometries filtered) · VT-07 (positive, offset cluster feature ids) · VT-08 (tenant-prefixed cache keys invalidated) · UX-05/UX-08 (decision records: fixed panel widths + layer-owned terrain documented as intentional) · UX-06 (spinner aria-label localized) · exported vector-source `maxzoom` aligned with the live builder (14 plain / 22 cluster, per the audit's orchestrator observation).

## API / schema impacts

- `GET /maps/shared/{token}` and `POST /tiles/tokens/` accept an optional `X-Embed-Token` header (fail-closed capability fallback; anonymous behavior unchanged without it).
- `MapLayerResponse.tile_version` + `SharedLayerResponse.tile_version` (additive, nullable).
- `backend/openapi.json` + generated SDKs regenerated accordingly. No DB migrations (reads the existing `datasets.current_version`).
- New i18n keys in all four locales (en/es/fr/de).

## Verification

- Backend: `uv run ruff check .` + `format --check` clean; targeted suites green (`test_shared_map_embed_scope.py` **new**, `test_mvt_audit_fixes.py`, `test_tile_cache.py`, `test_collect_chat_action.py`, `test_maps_style_json.py`, `test_phase_274_tile_cache.py` = 131 passed) plus regression sweep over changed areas (`test_maps.py`, `test_embed_tokens.py`, `test_vector_tile_auth.py`, `test_sec024_terrain_config_privacy.py`, `test_embed_framing_csp.py`, `test_ai_chat_actions_phase1135.py`, `test_reupload*.py` = 252 passed).
- Frontend: `npm run typecheck` (tsc -b), `npm run lint`, full `vitest` **3275/3275**, `npm run test:i18n` locale parity.
- `make openapi-check` + `make sdks-check` pass.
- E2E: `npm run e2e:smoke:builder` **26/26** against the restarted dev stack (one spec updated for the new radio-role semantics).

Audit source: `docs-internal/audits/builder-audit-20260703.md` (internal, not in repo) — finding IDs in code comments are anchored to this PR number per the inline review-comment convention.

https://claude.ai/code/session_01ECHhAm3SfqgmjAH8EvijrB