### PR TITLE
fix(frontend): absolutize og:image at boot from PUBLIC_APP_URL

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -341,6 +341,9 @@ services:
       # base works for any host the stack is reached on. Override for a CDN.
       API_BASE_URL: "${FRONTEND_API_BASE_URL:-/api}"
       TILE_BASE_URL: "${FRONTEND_TILE_BASE_URL:-/api}"
+      # Empty default on purpose: the api service's localhost fallback must not
+      # leak into og:image; unset keeps the built relative URL.
+      PUBLIC_APP_URL: "${PUBLIC_APP_URL:-}"
     healthcheck:
       test: ["CMD-SHELL", "wget --quiet --tries=1 --spider http://127.0.0.1:8080/ || exit 1"]
       interval: 30s

--- a/frontend/docker-entrypoint.sh
+++ b/frontend/docker-entrypoint.sh
@@ -7,5 +7,12 @@ envsubst '$API_BASE_URL $TILE_BASE_URL' \
   < /usr/share/nginx/html/env-config.template.js \
   > /usr/share/nginx/html/env-config.js
 
+# Social scrapers (LinkedIn notably) don't resolve a relative og:image URL.
+# Absolutize it when the operator set PUBLIC_APP_URL; unset leaves it relative.
+if [ -n "${PUBLIC_APP_URL:-}" ]; then
+  sed -i "s|content=\"/og-image.png\"|content=\"${PUBLIC_APP_URL%/}/og-image.png\"|" \
+    /usr/share/nginx/html/index.html
+fi
+
 # Replace shell with nginx (PID 1).
 exec nginx -g 'daemon off;'


### PR DESCRIPTION
## What

Social scrapers (LinkedIn documented, others inconsistent) don't reliably resolve the **relative** `og:image` URL (`/og-image.png`) in the built `index.html`, so link previews for a deployed instance can miss the social card that shipped in #383.

- `frontend/docker-entrypoint.sh`: when `PUBLIC_APP_URL` is set, rewrite the `og:image` content to an absolute URL at container boot (same boot-time templating mechanism as `env-config.js`). Unset → no-op, built relative URL unchanged.
- `docker-compose.prod.yml`: pass `PUBLIC_APP_URL` through to the frontend service with an **empty** default — the api service's `localhost:8080` fallback must not leak into og tags.

## Why this env var

`PUBLIC_APP_URL` is already the canonical public app origin (required for OAuth `redirect_uri`, H-27), so operators set one value. Dev compose runs Vite (no nginx entrypoint) and needs no change.

## Config impact

None for existing installs: unset `PUBLIC_APP_URL` keeps today's behavior exactly. Deployments that already set it (any SSO-enabled install, incl. the demo) get absolute og:image with no further action.

## Verification

- Sed substitution self-check: trailing-slash strip + exact-match replace verified; empty/unset var no-ops.
- `docker compose -f docker-compose.prod.yml config -q` passes.
- Will verify live on the demo post-deploy: `curl -s https://demo.getgeolens.com | grep og:image` → absolute URL.

https://claude.ai/code/session_01ECHhAm3SfqgmjAH8EvijrB