### PR TITLE
fix(frontend): og:image rewrite crash-looped the unprivileged nginx image

### DIFF
--- a/frontend/docker-entrypoint.sh
+++ b/frontend/docker-entrypoint.sh
@@ -9,9 +9,14 @@ envsubst '$API_BASE_URL $TILE_BASE_URL' \
 
 # Social scrapers (LinkedIn notably) don't resolve a relative og:image URL.
 # Absolutize it when the operator set PUBLIC_APP_URL; unset leaves it relative.
+# Truncate-write via /tmp: the html dir is root-owned (only its files are
+# nginx-owned), so in-place tools like sed -i can't create their temp file there.
 if [ -n "${PUBLIC_APP_URL:-}" ]; then
-  sed -i "s|content=\"/og-image.png\"|content=\"${PUBLIC_APP_URL%/}/og-image.png\"|" \
-    /usr/share/nginx/html/index.html
+  html=/usr/share/nginx/html/index.html
+  sed "s|content=\"/og-image.png\"|content=\"${PUBLIC_APP_URL%/}/og-image.png\"|" \
+    "$html" > /tmp/index.html.new
+  cat /tmp/index.html.new > "$html"
+  rm -f /tmp/index.html.new
 fi
 
 # Replace shell with nginx (PID 1).


### PR DESCRIPTION
## What

Follow-up to #395, which crash-looped the frontend container when deployed (rolled back on the demo after ~4 min).

`sed -i` creates its temp file inside `/usr/share/nginx/html`; the COPY'd **files** are nginx-owned but the **directory** is root-owned in `nginxinc/nginx-unprivileged`, so temp-file creation got `Permission denied` and `set -e` killed PID 1 → restart loop. (Same invariant the shipped `public/env-config.js` placeholder exists for: the entrypoint may truncate existing files, never create new ones in that dir.)

Fix: stage the rewrite in `/tmp`, truncate into the existing `index.html`.

## Verification (built image, ran the container)

- `PUBLIC_APP_URL=https://demo.getgeolens.com/` → `og:image` absolute, trailing slash stripped, container healthy
- unset → relative URL unchanged, container healthy
- `docker restart` → idempotent (already-rewritten file, sed no-ops)

https://claude.ai/code/session_01ECHhAm3SfqgmjAH8EvijrB