### PR TITLE
feat(frontend): unify the UI on the survey-instrument design language

### DIFF
--- a/backend/app/modules/catalog/search/schemas.py
+++ b/backend/app/modules/catalog/search/schemas.py
@@ -91,6 +91,14 @@ class OGCRecordProperties(BaseModel):
     )
     license: str | None = None
     source_organization: str | None = None
+    source_format: str | None = Field(
+        default=None,
+        description=(
+            "Ingest source format ('geojson', 'shapefile', 'geotiff', 'wfs', "
+            "'stac', 'created', ...). Null for datasets registered from "
+            "existing PostGIS tables and for composed VRT datasets."
+        ),
+    )
     quality_detail: dict | None = None
     quality_statement: str | None = None
     formats: list[str] | None = None

--- a/backend/app/modules/catalog/search/service_records.py
+++ b/backend/app/modules/catalog/search/service_records.py
@@ -331,6 +331,10 @@ def dataset_to_ogc_record(
             "column_count": len(dataset.column_info) if dataset.column_info else None,
             "license": record.license,
             "source_organization": record.source_organization,
+            # Dataset origin for catalog cards: file format for uploads,
+            # service/stac identifiers for remote registrations, 'created'
+            # for empty layers, null for registered PostGIS tables and VRTs.
+            "source_format": dataset.source_format,
             "quality_detail": dataset.quality_detail,
             "quality_statement": dataset.quality_statement,
             "record_status": record.record_status,

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -10743,6 +10743,18 @@
             ],
             "title": "Source Count"
           },
+          "source_format": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Ingest source format ('geojson', 'shapefile', 'geotiff', 'wfs', 'stac', 'created', ...). Null for datasets registered from existing PostGIS tables and for composed VRT datasets.",
+            "title": "Source Format"
+          },
           "source_organization": {
             "anyOf": [
               {

--- a/e2e/admin.spec.ts
+++ b/e2e/admin.spec.ts
@@ -18,10 +18,12 @@ test.describe('Admin Panel', () => {
     await expect(
       page.getByRole('heading', { name: 'Users' }),
     ).toBeVisible();
-    await expect(page.getByText('Username')).toBeVisible({ timeout: 10_000 });
-    await expect(page.getByText('Email')).toBeVisible();
-    await expect(page.getByText('Roles')).toBeVisible();
-    await expect(page.getByText('Status')).toBeVisible();
+    // Column headers asserted by role: plain getByText('Email') strict-collides
+    // with the "Export emails (CSV)" toolbar button (substring match).
+    await expect(page.getByRole('columnheader', { name: 'Username' })).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByRole('columnheader', { name: 'Email' })).toBeVisible();
+    await expect(page.getByRole('columnheader', { name: 'Roles' })).toBeVisible();
+    await expect(page.getByRole('columnheader', { name: 'Status' })).toBeVisible();
     await expect(
       page.getByRole('cell', { name: 'admin', exact: true }).first(),
     ).toBeVisible();

--- a/frontend/src/components/admin/AdminSidebar.tsx
+++ b/frontend/src/components/admin/AdminSidebar.tsx
@@ -146,7 +146,7 @@ export function AdminSidebar() {
   return (
     <Sidebar collapsible="icon" variant="sidebar" side="left">
       <SidebarHeader className="px-4 py-3 group-data-[collapsible=icon]:hidden">
-        <span className="text-sm font-semibold text-sidebar-foreground">{t('adminNav.admin')}</span>
+        <span className="eyebrow">{t('adminNav.admin')}</span>
       </SidebarHeader>
       <SidebarContent>
         {/* Overview */}
@@ -173,7 +173,7 @@ export function AdminSidebar() {
 
         {/* Operations */}
         <SidebarGroup>
-          <SidebarGroupLabel>{t('adminNav.operations')}</SidebarGroupLabel>
+          <SidebarGroupLabel className="eyebrow">{t('adminNav.operations')}</SidebarGroupLabel>
           <SidebarGroupContent>
             <SidebarMenu>
               {visibleOperationsItems.map(({ labelKey, to, icon: Icon, badgeKey }) => {
@@ -202,7 +202,7 @@ export function AdminSidebar() {
 
         {/* Settings */}
         <SidebarGroup>
-          <SidebarGroupLabel>{t('adminNav.settings')}</SidebarGroupLabel>
+          <SidebarGroupLabel className="eyebrow">{t('adminNav.settings')}</SidebarGroupLabel>
           <SidebarGroupContent>
             <SidebarMenu>
               {visibleSettingsItems.map(({ labelKey, to, icon: Icon }) => (

--- a/frontend/src/components/admin/StatsOverview.tsx
+++ b/frontend/src/components/admin/StatsOverview.tsx
@@ -202,6 +202,8 @@ function SystemHealthCard() {
   );
 }
 
+// Survey-grid stat cell — same bordered-frame pattern as DatasetStatsBar,
+// so the operator overview reads like the rest of the instrument.
 function StatCard({
   label,
   value,
@@ -210,12 +212,12 @@ function StatCard({
   value: string;
 }) {
   return (
-    <Card>
-      <CardContent>
-        <p className="text-sm text-muted-foreground">{label}</p>
-        <p className="text-3xl font-bold mt-1">{value}</p>
-      </CardContent>
-    </Card>
+    <div className="min-w-0 border-t border-l border-border bg-card px-4 py-3">
+      <p className="eyebrow mb-1">{label}</p>
+      <p className="readout text-2xl font-semibold" title={value}>
+        {value}
+      </p>
+    </div>
   );
 }
 
@@ -238,8 +240,8 @@ export function StatsOverview() {
       {/* System Health — prominent at top */}
       <SystemHealthCard />
 
-      {/* Summary Stats */}
-      <div className="grid gap-4 sm:grid-cols-3">
+      {/* Summary Stats — one bordered frame, cells complete it */}
+      <div className="grid grid-cols-1 border-r border-b border-border sm:grid-cols-3">
         <StatCard label={t('stats.totalDatasets')} value={formatNumber(data.total_datasets)} />
         <StatCard label={t('stats.recentAdditions')} value={formatNumber(data.recent_additions)} />
         <StatCard label={t('stats.storageUsed')} value={formatBytes(data.total_storage_bytes)} />

--- a/frontend/src/components/dataset/DatasetDetailHeader.tsx
+++ b/frontend/src/components/dataset/DatasetDetailHeader.tsx
@@ -116,7 +116,7 @@ export function DatasetDetailHeader({
 
       <div className="flex flex-col md:flex-row md:items-start md:justify-between gap-2 md:gap-4">
         <div className="min-w-0">
-          <h1 className="text-3xl md:text-4xl font-semibold tracking-tight break-words">
+          <h1 className="text-2xl md:text-3xl font-semibold tracking-tight break-words">
             {isTitleEditable ? (
               <InlineEdit
                 value={title}

--- a/frontend/src/components/dataset/OriginBadge.tsx
+++ b/frontend/src/components/dataset/OriginBadge.tsx
@@ -1,0 +1,74 @@
+import { Database, Globe, Satellite, SquarePen, Upload, type LucideIcon } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import { Badge } from '@/components/ui/badge';
+import { cn } from '@/lib/utils';
+
+/**
+ * Dataset origin — how the data entered the catalog. Distinct from
+ * `record_type` (what the data is): a vector dataset can be an uploaded
+ * file, a registered PostGIS table, or a mirrored remote service.
+ */
+export type DatasetOrigin = 'upload' | 'postgis' | 'service' | 'stac' | 'created';
+
+const SERVICE_FORMATS = new Set(['wfs', 'arcgis_featureserver', 'ogcapi_features']);
+
+/**
+ * Derive the origin from persisted source fields.
+ *
+ * Registration of an existing PostGIS table stores no `source_format`
+ * (see backend `register_existing_table`), so null means "referenced in
+ * place". VRTs also store null but are composed from other datasets, and
+ * collections have no dataset row — both return null so the type badge
+ * speaks for them alone.
+ */
+export function datasetOrigin(input: {
+  source_format?: string | null;
+  record_type?: string | null;
+}): DatasetOrigin | null {
+  const recordType = input.record_type ?? 'vector_dataset';
+  if (recordType === 'collection' || recordType === 'vrt_dataset') return null;
+  const format = input.source_format;
+  if (!format) return 'postgis';
+  if (format === 'created') return 'created';
+  if (format === 'stac') return 'stac';
+  if (SERVICE_FORMATS.has(format)) return 'service';
+  return 'upload';
+}
+
+const ORIGIN_ICONS: Record<DatasetOrigin, LucideIcon> = {
+  upload: Upload,
+  postgis: Database,
+  service: Globe,
+  stac: Satellite,
+  created: SquarePen,
+};
+
+interface OriginBadgeProps {
+  origin: DatasetOrigin;
+  className?: string;
+}
+
+/**
+ * Mono-caps origin chip. Icons match the Import page's mode tabs so the
+ * vocabulary stays consistent from ingest to catalog.
+ */
+export function OriginBadge({ origin, className }: OriginBadgeProps) {
+  const { t } = useTranslation();
+  const Icon = ORIGIN_ICONS[origin];
+
+  return (
+    <Badge
+      variant="outline"
+      data-testid="origin-badge"
+      data-origin={origin}
+      title={t(`origin.${origin}.title`)}
+      className={cn(
+        'gap-1 border-border/70 bg-surface-2/60 font-mono text-[10px] font-medium uppercase tracking-[0.08em] text-muted-foreground',
+        className,
+      )}
+    >
+      <Icon aria-hidden="true" />
+      {t(`origin.${origin}.label`)}
+    </Badge>
+  );
+}

--- a/frontend/src/components/import/WorkflowRail.tsx
+++ b/frontend/src/components/import/WorkflowRail.tsx
@@ -46,7 +46,7 @@ export function WorkflowRail({ mode, phase }: WorkflowRailProps) {
   return (
     <aside className="sticky top-28 flex flex-col gap-4">
       {/* Workflow steps */}
-      <div className="rounded-xl border border-border bg-card p-4">
+      <div className="rounded-lg border border-border bg-card p-4">
         <p className="mb-3 font-mono text-[10.5px] uppercase tracking-widest text-muted-foreground">
           {t('rail.workflow', { defaultValue: 'Workflow' })}
         </p>
@@ -83,7 +83,7 @@ export function WorkflowRail({ mode, phase }: WorkflowRailProps) {
       </div>
 
       {/* What gets imported */}
-      <div className="rounded-xl border border-border bg-card p-4">
+      <div className="rounded-lg border border-border bg-card p-4">
         <p className="mb-3 font-mono text-[10.5px] uppercase tracking-widest text-muted-foreground">
           {t('rail.whatImported', { defaultValue: 'What gets imported' })}
         </p>
@@ -102,7 +102,7 @@ export function WorkflowRail({ mode, phase }: WorkflowRailProps) {
       </div>
 
       {/* Tip */}
-      <div className="rounded-xl border border-border bg-surface-0 p-4">
+      <div className="rounded-lg border border-border bg-surface-0 p-4">
         <p className="mb-2 font-mono text-[10.5px] uppercase tracking-widest text-muted-foreground">
           {t('rail.tip', { defaultValue: 'Tip' })}
         </p>
@@ -123,7 +123,7 @@ function NonUploadRail({ mode }: { mode: 'register' | 'service' | 'stac' }) {
 
   return (
     <aside className="sticky top-28 flex flex-col gap-4">
-      <div className="rounded-xl border border-border bg-card p-4">
+      <div className="rounded-lg border border-border bg-card p-4">
         <p className="mb-2 font-mono text-[10.5px] uppercase tracking-widest text-muted-foreground">
           {isRegister
             ? t('rail.registerHint', { defaultValue: 'Registering existing infrastructure' })
@@ -147,7 +147,7 @@ function NonUploadRail({ mode }: { mode: 'register' | 'service' | 'stac' }) {
         </p>
       </div>
 
-      <div className="rounded-xl border border-border bg-card p-4">
+      <div className="rounded-lg border border-border bg-card p-4">
         <p className="mb-2 font-mono text-[10.5px] uppercase tracking-widest text-muted-foreground">
           {t('rail.comparedToUpload', { defaultValue: 'Compared to Upload' })}
         </p>

--- a/frontend/src/components/layout/AppFooter.tsx
+++ b/frontend/src/components/layout/AppFooter.tsx
@@ -52,6 +52,9 @@ export function AppFooter({
             </a>
           </Fragment>
         ))}
+        {/* Instance version readout — self-hosters see at a glance what they run. */}
+        <span aria-hidden="true">·</span>
+        <span className="readout text-muted-foreground/80">v{__APP_VERSION__}</span>
       </nav>
     </footer>
   );

--- a/frontend/src/components/layout/EmptyState.tsx
+++ b/frontend/src/components/layout/EmptyState.tsx
@@ -11,7 +11,7 @@ interface EmptyStateProps {
 
 export function EmptyState({ icon: Icon, title, description, action, className }: EmptyStateProps) {
   return (
-    <div className={cn('flex flex-col items-center justify-center py-16 gap-4 graticule rounded-lg', className)}>
+    <div className={cn('flex flex-col items-center justify-center py-16 gap-4 graticule rounded-lg border border-dashed border-border', className)}>
       <Icon className="size-10 text-muted-foreground/40" aria-hidden="true" />
       <div className="flex flex-col items-center gap-1 text-center">
         <p className="text-lg font-medium text-foreground">{title}</p>

--- a/frontend/src/components/layout/Navbar.tsx
+++ b/frontend/src/components/layout/Navbar.tsx
@@ -26,13 +26,17 @@ import { CollectionCreateDialog } from '@/components/collections/CollectionCreat
 import { MapCreateDialog } from '@/components/maps/MapCreateDialog';
 import { VrtCreateDialog } from '@/components/import/VrtCreateDialog';
 
+// Full-height topbar tabs with a 2px baseline marker on the active route —
+// the same underline vocabulary as the Import page's mode tabs. ring-inset
+// keeps the focus ring visible at the header's clipped top edge.
 const navLinkClass = ({ isActive }: { isActive: boolean }) =>
   cn(
-    'inline-flex items-center justify-center rounded-md px-3 py-1.5 text-sm font-medium transition-colors',
-    'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background',
+    'relative inline-flex h-14 items-center px-3 text-sm font-medium transition-colors',
+    'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset',
+    'after:pointer-events-none after:absolute after:inset-x-3 after:bottom-0 after:h-0.5 after:bg-primary after:opacity-0 after:transition-opacity',
     isActive
-      ? 'bg-accent text-accent-foreground'
-      : 'text-muted-foreground hover:bg-accent hover:text-accent-foreground',
+      ? 'text-foreground after:opacity-100'
+      : 'text-muted-foreground hover:text-foreground',
   );
 
 const mobileNavLinkClass = ({ isActive }: { isActive: boolean }) =>
@@ -285,6 +289,11 @@ function MobileNav() {
             <NavLink to="/maps" className={mobileNavLinkClass}>
               {t('nav.maps')}
             </NavLink>
+            {can('manage_users') && (
+              <NavLink to="/admin" className={mobileNavLinkClass}>
+                {t('nav.admin')}
+              </NavLink>
+            )}
             {user && (() => {
               const canCreateDataset = featureFlags?.enable_dataset_editing ?? false;
               const canImport = can('upload');
@@ -373,17 +382,20 @@ function MobileNav() {
 
 export function Navbar() {
   const { t } = useTranslation();
+  const { can } = usePermissions();
 
   return (
     <header className="sticky top-0 z-40 border-b bg-background pt-[env(safe-area-inset-top)]">
-      <div className="mx-auto flex h-14 max-w-7xl items-center justify-between px-6">
-        <div className="flex items-center gap-4">
+      {/* Full-bleed control bar — page content keeps its own max-width;
+          the frame spans the viewport like the rest of the chrome. */}
+      <div className="flex h-14 w-full items-center justify-between gap-4 px-4 sm:px-6">
+        <div className="flex min-w-0 items-center gap-4">
           <MobileNav />
           <Link to="/" aria-label={t('appName')} className="rounded-md hover:text-primary transition-colors duration-150 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background">
             <GeoLensLogo size="sm" />
           </Link>
           <Separator orientation="vertical" className="hidden md:block h-6" />
-          <nav aria-label={t('nav.mainNavigation')} className="hidden md:flex items-center gap-2">
+          <nav aria-label={t('nav.mainNavigation')} className="hidden h-14 md:flex items-center gap-1">
             <NavLink to="/" end className={navLinkClass}>
               {t('nav.search')}
             </NavLink>
@@ -393,6 +405,13 @@ export function Navbar() {
             <NavLink to="/maps" className={navLinkClass}>
               {t('nav.maps')}
             </NavLink>
+            {/* Operators get a first-class entry — previously buried in the
+                user dropdown only. */}
+            {can('manage_users') && (
+              <NavLink to="/admin" className={navLinkClass}>
+                {t('nav.admin')}
+              </NavLink>
+            )}
           </nav>
         </div>
         <div className="flex items-center gap-2">

--- a/frontend/src/components/layout/PageHeader.tsx
+++ b/frontend/src/components/layout/PageHeader.tsx
@@ -58,7 +58,7 @@ export function PageHeader({ title, description, backLink, breadcrumbs, actions,
         <div className="min-w-0">
           <h1 className="text-2xl font-semibold tracking-tight break-words">{title}</h1>
           {description && (
-            <p className="text-sm text-muted-foreground mt-1">{description}</p>
+            <p className="text-sm text-muted-foreground mt-1 max-w-2xl">{description}</p>
           )}
         </div>
         {actions && (
@@ -67,6 +67,8 @@ export function PageHeader({ title, description, backLink, breadcrumbs, actions,
           </div>
         )}
       </div>
+      {/* Neatline — the map-sheet tick rule that closes every page header. */}
+      <div className="tick-rule" aria-hidden="true" />
     </div>
   );
 }

--- a/frontend/src/components/report/ReportProblemWizard.tsx
+++ b/frontend/src/components/report/ReportProblemWizard.tsx
@@ -1,7 +1,7 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { toast } from 'sonner';
-import { AlertTriangle, ChevronDown, ShieldCheck } from 'lucide-react';
+import { AlertTriangle, ChevronDown, Copy, ShieldCheck, Trash2 } from 'lucide-react';
 import {
   Sheet,
   SheetContent,
@@ -31,6 +31,8 @@ import {
   buildClipboardReport,
   buildContext,
   buildIssueUrl,
+  buildTechnicalClipboard,
+  clearReportEntries,
   mapAreaFromPath,
 } from '@/lib/report';
 import { ReportEntryList } from './ReportEntryList';
@@ -87,10 +89,17 @@ export function ReportProblemWizard({ open, onOpenChange, entries }: ReportProbl
 
   const problemCount = useMemo(() => entries.filter((e) => e.severity !== 'info').length, [entries]);
 
-  // Start each session from a clean wizard; default the Area from the route.
+  // Tracks whether the previous session ended in a send/copy. A draft that was
+  // dismissed accidentally (Esc, outside click) survives the next open; only a
+  // completed report starts the wizard clean again.
+  const submittedRef = useRef(true);
+
   useEffect(() => {
     if (!open) return;
     setStep(1);
+    setDetailsOpen(false);
+    if (!submittedRef.current) return; // preserve the unsent draft
+    submittedRef.current = false;
     setArea(mapAreaFromPath(window.location.pathname));
     setTitle('');
     setDescription('');
@@ -100,7 +109,6 @@ export function ReportProblemWizard({ open, onOpenChange, entries }: ReportProbl
     setIncludePage(true);
     setIncludeEnv(true);
     setIncludeVersion(true);
-    setDetailsOpen(false);
   }, [open]);
 
   function assembleContext(): string {
@@ -117,6 +125,7 @@ export function ReportProblemWizard({ open, onOpenChange, entries }: ReportProbl
   }
 
   function handleOpenIssue() {
+    submittedRef.current = true;
     const context = assembleContext();
     const version = includeVersion ? APP_VERSION : '';
     const { url, truncated } = buildIssueUrl({ title, description, steps, expected, area, version, context });
@@ -135,10 +144,20 @@ export function ReportProblemWizard({ open, onOpenChange, entries }: ReportProbl
   }
 
   async function handleCopy() {
+    submittedRef.current = true;
     const context = assembleContext();
     const version = includeVersion ? APP_VERSION : '';
     await copyToClipboard(buildClipboardReport({ title, description, steps, expected, area, version, context }));
     toast.success(t('step3.copied'));
+  }
+
+  // Step-1 shortcut: grab just the environment + captured signals without
+  // filling in anything. Does not count as sending, so the draft survives.
+  async function handleCopyTechnical() {
+    const context = assembleContext();
+    const version = includeVersion ? APP_VERSION : '';
+    await copyToClipboard(buildTechnicalClipboard({ version, context }));
+    toast.success(t('technicalCopied'));
   }
 
   return (
@@ -147,7 +166,7 @@ export function ReportProblemWizard({ open, onOpenChange, entries }: ReportProbl
         <SheetHeader className="border-b">
           <SheetTitle>{t('title')}</SheetTitle>
           <SheetDescription>{t('description')}</SheetDescription>
-          <p className="text-xs font-medium text-muted-foreground">
+          <p aria-live="polite" className="text-xs font-medium text-muted-foreground">
             {t('stepIndicator', { current: step, total: TOTAL_STEPS })}
           </p>
         </SheetHeader>
@@ -229,10 +248,31 @@ export function ReportProblemWizard({ open, onOpenChange, entries }: ReportProbl
               </div>
 
               <Collapsible open={detailsOpen} onOpenChange={setDetailsOpen}>
-                <CollapsibleTrigger className="flex w-full items-center gap-1 text-xs font-medium text-muted-foreground hover:text-foreground">
-                  <ChevronDown className={cn('size-3.5 transition-transform', detailsOpen && 'rotate-180')} aria-hidden />
-                  {t('technicalDetails', { count: entries.length })}
-                </CollapsibleTrigger>
+                <div className="flex items-center justify-between gap-2">
+                  <CollapsibleTrigger className="flex min-w-0 items-center gap-1 rounded text-xs font-medium text-muted-foreground hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring">
+                    <ChevronDown className={cn('size-3.5 shrink-0 transition-transform', detailsOpen && 'rotate-180')} aria-hidden />
+                    {t('technicalDetails', { count: entries.length })}
+                  </CollapsibleTrigger>
+                  <div className="flex shrink-0 items-center gap-1">
+                    <Button type="button" variant="ghost" size="xs" onClick={handleCopyTechnical}>
+                      <Copy aria-hidden />
+                      {t('technicalCopy')}
+                    </Button>
+                    {entries.length > 0 && (
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="xs"
+                        onClick={() => clearReportEntries()}
+                        aria-label={t('technicalClearAria')}
+                        title={t('technicalClearAria')}
+                      >
+                        <Trash2 aria-hidden />
+                        {t('technicalClear')}
+                      </Button>
+                    )}
+                  </div>
+                </div>
                 <CollapsibleContent className="pt-2">
                   <ReportEntryList entries={entries} />
                 </CollapsibleContent>

--- a/frontend/src/components/report/__tests__/ReportProblemWizard.test.tsx
+++ b/frontend/src/components/report/__tests__/ReportProblemWizard.test.tsx
@@ -1,0 +1,95 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@/test/test-utils';
+import { ReportProblemWizard } from '../ReportProblemWizard';
+import { clearReportEntries, getReportEntries, pushReportEntry } from '@/lib/report';
+import type { ReportEntry } from '@/lib/report';
+
+function makeEntry(overrides: Partial<ReportEntry> = {}): ReportEntry {
+  return {
+    id: 'e1',
+    ts: Date.now(),
+    severity: 'error',
+    source: 'console',
+    message: 'TypeError: boom',
+    count: 1,
+    ...overrides,
+  };
+}
+
+let writeTextMock: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  clearReportEntries();
+  writeTextMock = vi.fn().mockResolvedValue(undefined);
+  Object.defineProperty(navigator, 'clipboard', {
+    value: { writeText: writeTextMock },
+    configurable: true,
+  });
+});
+
+describe('ReportProblemWizard', () => {
+  it('copies technical details from step 1 without requiring any typed field', async () => {
+    render(<ReportProblemWizard open onOpenChange={() => {}} entries={[makeEntry()]} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /copy technical details/i }));
+
+    await waitFor(() => expect(writeTextMock).toHaveBeenCalledOnce());
+    const [copied] = writeTextMock.mock.calls[0] as [string];
+    expect(copied).toContain('## GeoLens technical details');
+    expect(copied).toContain('TypeError: boom');
+    expect(copied).toContain('**Browser:**');
+  });
+
+  it('clears the captured buffer from the technical-details row', () => {
+    pushReportEntry({ severity: 'error', source: 'console', message: 'boom' });
+    expect(getReportEntries()).toHaveLength(1);
+
+    render(<ReportProblemWizard open onOpenChange={() => {}} entries={getReportEntries()} />);
+    fireEvent.click(screen.getByRole('button', { name: /clear captured signals/i }));
+
+    expect(getReportEntries()).toHaveLength(0);
+  });
+
+  it('hides the clear button when nothing is captured', () => {
+    render(<ReportProblemWizard open onOpenChange={() => {}} entries={[]} />);
+    expect(screen.queryByRole('button', { name: /clear captured signals/i })).toBeNull();
+    // The copy affordance stays available — env/page context is still useful.
+    expect(screen.getByRole('button', { name: /copy technical details/i })).toBeInTheDocument();
+  });
+
+  it('preserves an unsent draft across close and reopen', () => {
+    const { rerender } = render(
+      <ReportProblemWizard open onOpenChange={() => {}} entries={[]} />,
+    );
+
+    fireEvent.change(screen.getByLabelText(/what went wrong\?/i), {
+      target: { value: 'The map went blank' },
+    });
+
+    rerender(<ReportProblemWizard open={false} onOpenChange={() => {}} entries={[]} />);
+    rerender(<ReportProblemWizard open onOpenChange={() => {}} entries={[]} />);
+
+    expect(screen.getByLabelText(/what went wrong\?/i)).toHaveValue('The map went blank');
+  });
+
+  it('starts clean again after the report is sent', async () => {
+    const windowOpen = vi.spyOn(window, 'open').mockReturnValue(null);
+    const { rerender } = render(
+      <ReportProblemWizard open onOpenChange={() => {}} entries={[]} />,
+    );
+
+    fireEvent.change(screen.getByLabelText(/what went wrong\?/i), {
+      target: { value: 'The map went blank' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /next/i }));
+    fireEvent.click(screen.getByRole('button', { name: /next/i }));
+    fireEvent.click(await screen.findByRole('button', { name: /open a github issue/i }));
+    expect(windowOpen).toHaveBeenCalledOnce();
+
+    rerender(<ReportProblemWizard open={false} onOpenChange={() => {}} entries={[]} />);
+    rerender(<ReportProblemWizard open onOpenChange={() => {}} entries={[]} />);
+
+    expect(screen.getByLabelText(/what went wrong\?/i)).toHaveValue('');
+    windowOpen.mockRestore();
+  });
+});

--- a/frontend/src/components/search/FilterPanel.tsx
+++ b/frontend/src/components/search/FilterPanel.tsx
@@ -555,7 +555,7 @@ export function FilterPanel({
 
   const renderDesktopRail = () => (
     <div
-      className="space-y-4 rounded-[22px] border border-border/50 bg-background/95 p-4 shadow-sm"
+      className="space-y-4 rounded-lg border bg-card p-4 shadow-sm"
       data-testid="search-filter-rail"
     >
       <div className="flex items-start justify-between gap-3">
@@ -586,7 +586,7 @@ export function FilterPanel({
       ) : null}
 
       <div className="space-y-2">
-        <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+        <p className="eyebrow">
           {t('filters.type', { defaultValue: 'Type' })}
         </p>
         <ToggleGroup
@@ -599,31 +599,31 @@ export function FilterPanel({
         >
           <ToggleGroupItem value="all" className="h-8 justify-between px-3 text-xs">
             {t('filters.allTypes', { defaultValue: 'All' })}
-            {Object.keys(counts).length > 0 && <span className="text-muted-foreground">{allTypeCount}</span>}
+            {Object.keys(counts).length > 0 && <span className="readout text-muted-foreground">{allTypeCount}</span>}
           </ToggleGroupItem>
           <ToggleGroupItem value="vector_dataset" className="h-8 justify-between px-3 text-xs" disabled={counts.vector_dataset === 0}>
             {t('filters.vector', { defaultValue: 'Vector' })}
-            {counts.vector_dataset !== undefined && <span className="text-muted-foreground">{counts.vector_dataset}</span>}
+            {counts.vector_dataset !== undefined && <span className="readout text-muted-foreground">{counts.vector_dataset}</span>}
           </ToggleGroupItem>
           <ToggleGroupItem value="raster_dataset" className="h-8 justify-between px-3 text-xs" disabled={counts.raster_dataset === 0}>
             {t('filters.raster', { defaultValue: 'Raster' })}
-            {counts.raster_dataset !== undefined && <span className="text-muted-foreground">{counts.raster_dataset}</span>}
+            {counts.raster_dataset !== undefined && <span className="readout text-muted-foreground">{counts.raster_dataset}</span>}
           </ToggleGroupItem>
           <ToggleGroupItem value="vrt_dataset" className="h-8 justify-between px-3 text-xs" disabled={counts.vrt_dataset === 0}>
             {t('filters.vrt', { defaultValue: 'Virtual Raster' })}
-            {counts.vrt_dataset !== undefined && <span className="text-muted-foreground">{counts.vrt_dataset}</span>}
+            {counts.vrt_dataset !== undefined && <span className="readout text-muted-foreground">{counts.vrt_dataset}</span>}
           </ToggleGroupItem>
           {showsTableToggle && (
             <ToggleGroupItem value="table" className="h-8 justify-between px-3 text-xs" disabled={counts.table === 0}>
               {t('card.table', { defaultValue: 'Table' })}
-              {counts.table !== undefined && <span className="text-muted-foreground">{counts.table}</span>}
+              {counts.table !== undefined && <span className="readout text-muted-foreground">{counts.table}</span>}
             </ToggleGroupItem>
           )}
         </ToggleGroup>
       </div>
 
       <div className="space-y-2">
-        <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+        <p className="eyebrow">
           {t('filters.keywords', { defaultValue: 'Keywords' })}
         </p>
         <KeywordFacetPicker facets={facets?.keywords} isLoading={!facets} />
@@ -645,7 +645,7 @@ export function FilterPanel({
 
       {facets?.collections && facets.collections.length > 0 && (
         <div className="space-y-2">
-          <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+          <p className="eyebrow">
             {t('filters.collection', { defaultValue: 'Collection' })}
           </p>
           {renderCollectionControl()}
@@ -653,21 +653,21 @@ export function FilterPanel({
       )}
 
       <div className="space-y-2">
-        <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+        <p className="eyebrow">
           {t('filters.location')}
         </p>
         {renderDesktopLocationFilter(true)}
       </div>
 
       <div className="space-y-2">
-        <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+        <p className="eyebrow">
           {t('filters.dateRange')}
         </p>
         {renderDesktopDateFilter(true)}
       </div>
 
       <div className="space-y-2">
-        <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+        <p className="eyebrow">
           {t('filters.temporalExtent', { defaultValue: 'Temporal Extent' })}
         </p>
         {renderTemporalExtentControl(true)}
@@ -675,7 +675,7 @@ export function FilterPanel({
 
       {recordType === 'vector_dataset' && (
         <div className="space-y-2">
-          <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+          <p className="eyebrow">
             {t('filters.geometry')}
           </p>
           {renderGeometryControl()}
@@ -684,7 +684,7 @@ export function FilterPanel({
 
       {organizations.length > 0 && (
         <div className="space-y-2">
-          <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+          <p className="eyebrow">
             {t('filters.organization')}
           </p>
           {renderOrganizationControl()}
@@ -693,7 +693,7 @@ export function FilterPanel({
 
       {showSridFilter && (
         <div className="space-y-2">
-          <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+          <p className="eyebrow">
             {t('filters.crs')}
           </p>
           {renderSridControl()}
@@ -701,7 +701,7 @@ export function FilterPanel({
       )}
 
       <div className="space-y-2">
-        <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+        <p className="eyebrow">
           {t('filters.sort')}
         </p>
         {renderSortControl(true, false)}
@@ -809,7 +809,7 @@ export function FilterPanel({
               </Button>
             )}
 
-            <div className="ms-auto flex items-center gap-3 rounded-full border border-border/40 bg-muted/15 px-3 py-1 text-sm text-muted-foreground">
+            <div className="ms-auto flex items-center gap-3 rounded-md border border-border/40 bg-muted/15 px-3 py-1 text-sm text-muted-foreground">
               {totalResultsLabel && <span>{totalResultsLabel}</span>}
               {token && hasSearchState && <SaveSearchButton />}
             </div>
@@ -817,7 +817,7 @@ export function FilterPanel({
 
           {showSecondaryFilterRow && (
             <div
-              className="hidden flex-wrap items-center gap-2.5 rounded-[18px] border border-border/40 bg-muted/15 px-3 py-1.5 md:flex"
+              className="hidden flex-wrap items-center gap-2.5 rounded-md border border-border/40 bg-muted/15 px-3 py-1.5 md:flex"
               data-testid="secondary-filter-row"
             >
               <span className="text-xs font-medium text-muted-foreground whitespace-nowrap">

--- a/frontend/src/components/search/FilterSheet.tsx
+++ b/frontend/src/components/search/FilterSheet.tsx
@@ -203,7 +203,7 @@ export function FilterSheet({ totalResults }: FilterSheetProps) {
               type="button"
               variant={activeFilterCount > 0 ? 'default' : 'outline'}
               size="sm"
-              className="rounded-full border-border/60 shadow-sm"
+              className="rounded-md border-border/60 shadow-sm"
               onClick={() => {
                 syncLocalDates();
                 setMobileFiltersOpen(true);
@@ -212,7 +212,7 @@ export function FilterSheet({ totalResults }: FilterSheetProps) {
               <SlidersHorizontal className="size-4" />
               {t('filters.filtersButton', { defaultValue: 'Filters' })}
               {activeFilterCount > 0 && (
-                <span className="rounded-full bg-background/20 px-1.5 py-0 text-[11px] font-semibold">
+                <span className="rounded-sm bg-background/20 px-1.5 py-0 text-[11px] font-semibold">
                   {activeFilterCount}
                 </span>
               )}

--- a/frontend/src/components/search/KeywordFacetPicker.tsx
+++ b/frontend/src/components/search/KeywordFacetPicker.tsx
@@ -46,7 +46,7 @@ export function KeywordFacetPicker({ facets, isLoading }: KeywordFacetPickerProp
           <Tag className="me-1 size-3.5" />
           {t('filters.keywords', { defaultValue: 'Keywords' })}
           {selectedKeywords.length > 0 && (
-            <span className="ms-1 rounded-full bg-primary px-1.5 py-0 text-[11px] font-semibold text-primary-foreground">
+            <span className="ms-1 rounded-sm bg-primary px-1.5 py-0 text-[11px] font-semibold text-primary-foreground">
               {selectedKeywords.length}
             </span>
           )}

--- a/frontend/src/components/search/SavedSearches.tsx
+++ b/frontend/src/components/search/SavedSearches.tsx
@@ -50,7 +50,7 @@ export function SaveSearchButton() {
         <Button
           variant="outline"
           size="sm"
-          className="shrink-0 rounded-full border-border/50 bg-background/70 text-muted-foreground shadow-none hover:bg-accent/50 hover:text-foreground"
+          className="shrink-0 rounded-md border-border/50 bg-background/70 text-muted-foreground shadow-none hover:bg-accent/50 hover:text-foreground"
         >
           <Bookmark className="size-4" />
           <span className="hidden sm:inline">{t('savedSearches.saveButton')}</span>
@@ -137,7 +137,7 @@ export function SavedSearches({ className }: { className?: string }) {
       {searches.map((search) => (
         <div
           key={search.id}
-          className="group inline-flex min-w-0 max-w-full items-center gap-1.5 rounded-full border border-border/50 bg-background/70 py-1.5 ps-3 pe-1.5 text-xs font-medium text-muted-foreground"
+          className="group inline-flex min-w-0 max-w-full items-center gap-1.5 rounded-md border border-border/50 bg-background/70 py-1.5 ps-3 pe-1.5 text-xs font-medium text-muted-foreground"
         >
           <button
             type="button"

--- a/frontend/src/components/search/SearchBar.tsx
+++ b/frontend/src/components/search/SearchBar.tsx
@@ -86,10 +86,10 @@ export function SearchBar({ mode = 'hero', className }: SearchBarProps) {
         }}
         placeholder={t('placeholder')}
         className={cn(
-          'w-full border-border/50 bg-background/95 text-ellipsis shadow-sm placeholder:text-muted-foreground/75 focus-visible:border-primary/30 focus-visible:ring-primary/10',
+          'w-full bg-background text-ellipsis shadow-sm placeholder:text-muted-foreground/75',
           isCompact
-            ? 'h-11 rounded-[20px] ps-11 pe-11 text-base'
-            : 'h-14 rounded-[24px] ps-12 pe-12 text-base',
+            ? 'h-11 rounded-md ps-11 pe-11 text-base'
+            : 'h-14 rounded-lg ps-12 pe-12 text-base',
         )}
       />
       {value && (

--- a/frontend/src/components/search/SearchResultCard.tsx
+++ b/frontend/src/components/search/SearchResultCard.tsx
@@ -6,6 +6,7 @@ import { Combine, FolderOpen, Globe, Hash, Layers, Ruler, Shapes, Table2, type L
 import { Card } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { BBoxPreview } from '@/components/layout/BBoxPreview';
+import { OriginBadge, datasetOrigin } from '@/components/dataset/OriginBadge';
 import { RecordTypeBadge } from './RecordTypeBadge';
 import { formatProvenanceTime } from '@/lib/provenance-attribution';
 import { extractBbox, geometryIcon } from '@/lib/geo-utils';
@@ -145,6 +146,7 @@ export const SearchResultCard = memo(function SearchResultCard({ feature }: { fe
   const recordType = properties.record_type ?? 'vector_dataset';
   const isCollection = recordType === 'collection';
   const isTable = recordType === 'table';
+  const origin = datasetOrigin(properties);
   const linkPath = isCollection ? `/collections/${feature.id}` : `/datasets/${feature.id}`;
   const bbox = extractBbox(feature);
 
@@ -225,6 +227,7 @@ export const SearchResultCard = memo(function SearchResultCard({ feature }: { fe
                 <div className="min-w-0 flex flex-col gap-1.5">
                   <div className="flex flex-wrap items-center gap-2">
                     <RecordTypeBadge recordType={recordType} />
+                    {origin && <OriginBadge origin={origin} />}
                     {properties.keywords?.includes('synthetic') && (
                       <Badge variant="outline" className={`text-xs ${syntheticBadgeColor}`}>
                         {t('card.testData', { defaultValue: 'Test Data' })}
@@ -271,7 +274,7 @@ export const SearchResultCard = memo(function SearchResultCard({ feature }: { fe
                       {displayKeywords.slice(0, 3).map((tag, index) => (
                         <span
                           key={`${tag}-${index}`}
-                          className="inline-flex items-center rounded-full border border-border/30 bg-muted/15 px-2.5 py-0.5 text-[11px] text-muted-foreground"
+                          className="inline-flex items-center rounded-md border border-border/30 bg-muted/15 px-2.5 py-0.5 text-[11px] text-muted-foreground"
                         >
                           {tag}
                         </span>

--- a/frontend/src/components/search/SearchTypeahead.tsx
+++ b/frontend/src/components/search/SearchTypeahead.tsx
@@ -97,7 +97,7 @@ export function SearchTypeahead({
     <div
       id={listboxId}
       role="listbox"
-      className="absolute inset-x-0 top-full z-50 mt-2 overflow-hidden rounded-[22px] border border-border/70 bg-popover/98 text-popover-foreground shadow-xl backdrop-blur-sm"
+      className="absolute inset-x-0 top-full z-50 mt-2 overflow-hidden rounded-lg border bg-popover text-popover-foreground shadow-lg"
     >
       {isLoading && (
         <div className="flex items-center gap-2 px-4 py-3 text-sm text-muted-foreground">

--- a/frontend/src/components/ui/badge.tsx
+++ b/frontend/src/components/ui/badge.tsx
@@ -5,7 +5,10 @@ import { Slot } from "radix-ui"
 import { cn } from "@/lib/utils"
 
 const badgeVariants = cva(
-  "inline-flex items-center justify-center rounded-full border border-transparent px-2 py-0.5 text-xs font-medium w-fit whitespace-nowrap shrink-0 [&>svg]:size-3 gap-1 [&>svg]:pointer-events-none outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive transition-[color,background-color,box-shadow,border-color,opacity] duration-200 ease-out overflow-hidden",
+  // Redesign: squared chip (rounded-md, was rounded-full) — pill badges read
+  // as stock shadcn; the squared chip matches the survey-instrument language
+  // (mono type badges, bordered stat grids) used across the app.
+  "inline-flex items-center justify-center rounded-md border border-transparent px-2 py-0.5 text-xs font-medium w-fit whitespace-nowrap shrink-0 [&>svg]:size-3 gap-1 [&>svg]:pointer-events-none outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive transition-[color,background-color,box-shadow,border-color,opacity] duration-200 ease-out overflow-hidden",
   {
     variants: {
       variant: {

--- a/frontend/src/components/ui/table.tsx
+++ b/frontend/src/components/ui/table.tsx
@@ -80,8 +80,10 @@ function TableHead({ className, ...props }: React.ComponentProps<"th">) {
   return (
     <th
       data-slot="table-head"
+      // Redesign: mono-caps column headers — tables read as instrument
+      // readouts, matching the stats-grid and eyebrow label system.
       className={cn(
-        "text-muted-foreground h-10 px-4 py-3 text-start align-middle font-medium text-xs uppercase tracking-wide whitespace-nowrap [&:has([role=checkbox])]:pe-0 [&>[role=checkbox]]:translate-y-[2px]",
+        "text-muted-foreground h-10 px-4 py-3 text-start align-middle font-mono font-medium text-[11px] uppercase tracking-[0.08em] whitespace-nowrap [&:has([role=checkbox])]:pe-0 [&>[role=checkbox]]:translate-y-[2px]",
         className
       )}
       {...props}

--- a/frontend/src/i18n/locales/de/common.json
+++ b/frontend/src/i18n/locales/de/common.json
@@ -22,11 +22,11 @@
   "origin": {
     "upload": {
       "label": "Hochgeladen",
-      "title": "Hochgeladene Datei — GeoLens speichert eine eigene Kopie dieser Daten"
+      "title": "Hochgeladene Datei. GeoLens speichert eine eigene Kopie dieser Daten"
     },
     "postgis": {
       "label": "PostGIS",
-      "title": "Aus einer bestehenden PostGIS-Tabelle registriert — die Daten bleiben in Ihrer Datenbank"
+      "title": "Aus einer bestehenden PostGIS-Tabelle registriert. Die Daten bleiben in Ihrer Datenbank"
     },
     "service": {
       "label": "Dienst",

--- a/frontend/src/i18n/locales/de/common.json
+++ b/frontend/src/i18n/locales/de/common.json
@@ -19,6 +19,28 @@
   "notAvailable": "k. A.",
   "none": "Keine",
   "yesterday": "Gestern, {{time}}",
+  "origin": {
+    "upload": {
+      "label": "Hochgeladen",
+      "title": "Hochgeladene Datei — GeoLens speichert eine eigene Kopie dieser Daten"
+    },
+    "postgis": {
+      "label": "PostGIS",
+      "title": "Aus einer bestehenden PostGIS-Tabelle registriert — die Daten bleiben in Ihrer Datenbank"
+    },
+    "service": {
+      "label": "Dienst",
+      "title": "Über die URL eines entfernten Dienstes registriert"
+    },
+    "stac": {
+      "label": "STAC",
+      "title": "Aus einem STAC-Katalog importiert"
+    },
+    "created": {
+      "label": "Erstellt",
+      "title": "In GeoLens als bearbeitbare Ebene erstellt"
+    }
+  },
   "nav": {
     "search": "Suche",
     "collections": "Sammlungen",

--- a/frontend/src/i18n/locales/de/dataset.json
+++ b/frontend/src/i18n/locales/de/dataset.json
@@ -112,7 +112,8 @@
       "owner": "Eigentümer nicht verfügbar",
       "updated": "Unbekannter Aktualisierungszeitpunkt",
       "type": "Unbekannter Typ"
-    }
+    },
+    "tableReadout": "PostGIS-Tabelle"
   },
   "breadcrumbs": {
     "datasets": "Datensätze"

--- a/frontend/src/i18n/locales/de/report.json
+++ b/frontend/src/i18n/locales/de/report.json
@@ -11,6 +11,10 @@
   "noticedNone": "Es wurde nichts automatisch erkannt — Ihre Beschreibung ist am wichtigsten.",
   "technicalDetails": "Technische Details ({{count}})",
   "technicalEmpty": "Es wurde noch nichts erfasst.",
+  "technicalCopy": "Technische Details kopieren",
+  "technicalCopied": "Technische Details in die Zwischenablage kopiert",
+  "technicalClear": "Leeren",
+  "technicalClearAria": "Erfasste Signale löschen",
   "step1": {
     "heading": "Was ist passiert?",
     "areaLabel": "Wo ist das passiert?",

--- a/frontend/src/i18n/locales/en/common.json
+++ b/frontend/src/i18n/locales/en/common.json
@@ -19,6 +19,28 @@
   "notAvailable": "N/A",
   "none": "None",
   "yesterday": "Yesterday, {{time}}",
+  "origin": {
+    "upload": {
+      "label": "Uploaded",
+      "title": "Uploaded file — GeoLens stores its own copy of this data"
+    },
+    "postgis": {
+      "label": "PostGIS",
+      "title": "Registered from an existing PostGIS table — the data stays in your database"
+    },
+    "service": {
+      "label": "Service",
+      "title": "Registered from a remote service URL"
+    },
+    "stac": {
+      "label": "STAC",
+      "title": "Imported from a STAC catalog"
+    },
+    "created": {
+      "label": "Created",
+      "title": "Created in GeoLens as an editable layer"
+    }
+  },
   "nav": {
     "search": "Search",
     "collections": "Collections",

--- a/frontend/src/i18n/locales/en/common.json
+++ b/frontend/src/i18n/locales/en/common.json
@@ -22,11 +22,11 @@
   "origin": {
     "upload": {
       "label": "Uploaded",
-      "title": "Uploaded file — GeoLens stores its own copy of this data"
+      "title": "Uploaded file. GeoLens stores its own copy of this data"
     },
     "postgis": {
       "label": "PostGIS",
-      "title": "Registered from an existing PostGIS table — the data stays in your database"
+      "title": "Registered from an existing PostGIS table. The data stays in your database"
     },
     "service": {
       "label": "Service",

--- a/frontend/src/i18n/locales/en/dataset.json
+++ b/frontend/src/i18n/locales/en/dataset.json
@@ -112,7 +112,8 @@
       "owner": "Owner unavailable",
       "updated": "Unknown update time",
       "type": "Unknown type"
-    }
+    },
+    "tableReadout": "PostGIS table"
   },
   "breadcrumbs": {
     "datasets": "Datasets"

--- a/frontend/src/i18n/locales/en/report.json
+++ b/frontend/src/i18n/locales/en/report.json
@@ -11,6 +11,10 @@
   "noticedNone": "Nothing was detected automatically — your description is what matters most.",
   "technicalDetails": "Technical details ({{count}})",
   "technicalEmpty": "Nothing has been captured yet.",
+  "technicalCopy": "Copy technical details",
+  "technicalCopied": "Technical details copied to clipboard",
+  "technicalClear": "Clear",
+  "technicalClearAria": "Clear captured signals",
   "step1": {
     "heading": "What happened?",
     "areaLabel": "Where did this happen?",

--- a/frontend/src/i18n/locales/es/common.json
+++ b/frontend/src/i18n/locales/es/common.json
@@ -19,6 +19,28 @@
   "notAvailable": "N/D",
   "none": "Ninguno",
   "yesterday": "Ayer, {{time}}",
+  "origin": {
+    "upload": {
+      "label": "Subido",
+      "title": "Archivo subido — GeoLens almacena su propia copia de estos datos"
+    },
+    "postgis": {
+      "label": "PostGIS",
+      "title": "Registrado desde una tabla PostGIS existente — los datos permanecen en tu base de datos"
+    },
+    "service": {
+      "label": "Servicio",
+      "title": "Registrado desde la URL de un servicio remoto"
+    },
+    "stac": {
+      "label": "STAC",
+      "title": "Importado desde un catálogo STAC"
+    },
+    "created": {
+      "label": "Creado",
+      "title": "Creado en GeoLens como capa editable"
+    }
+  },
   "nav": {
     "search": "Buscar",
     "collections": "Colecciones",

--- a/frontend/src/i18n/locales/es/common.json
+++ b/frontend/src/i18n/locales/es/common.json
@@ -22,11 +22,11 @@
   "origin": {
     "upload": {
       "label": "Subido",
-      "title": "Archivo subido — GeoLens almacena su propia copia de estos datos"
+      "title": "Archivo subido. GeoLens almacena su propia copia de estos datos"
     },
     "postgis": {
       "label": "PostGIS",
-      "title": "Registrado desde una tabla PostGIS existente — los datos permanecen en tu base de datos"
+      "title": "Registrado desde una tabla PostGIS existente. Los datos permanecen en tu base de datos"
     },
     "service": {
       "label": "Servicio",

--- a/frontend/src/i18n/locales/es/dataset.json
+++ b/frontend/src/i18n/locales/es/dataset.json
@@ -112,7 +112,8 @@
       "owner": "Propietario no disponible",
       "updated": "Fecha de actualización desconocida",
       "type": "Tipo desconocido"
-    }
+    },
+    "tableReadout": "Tabla PostGIS"
   },
   "breadcrumbs": {
     "datasets": "Conjuntos de datos"

--- a/frontend/src/i18n/locales/es/report.json
+++ b/frontend/src/i18n/locales/es/report.json
@@ -11,6 +11,10 @@
   "noticedNone": "No se detectó nada automáticamente: lo que más importa es tu descripción.",
   "technicalDetails": "Detalles técnicos ({{count}})",
   "technicalEmpty": "Todavía no se ha capturado nada.",
+  "technicalCopy": "Copiar detalles técnicos",
+  "technicalCopied": "Detalles técnicos copiados al portapapeles",
+  "technicalClear": "Borrar",
+  "technicalClearAria": "Borrar las señales capturadas",
   "step1": {
     "heading": "¿Qué ha ocurrido?",
     "areaLabel": "¿Dónde ha ocurrido?",

--- a/frontend/src/i18n/locales/fr/common.json
+++ b/frontend/src/i18n/locales/fr/common.json
@@ -19,6 +19,28 @@
   "notAvailable": "N/D",
   "none": "Aucun",
   "yesterday": "Hier, {{time}}",
+  "origin": {
+    "upload": {
+      "label": "Téléversé",
+      "title": "Fichier téléversé — GeoLens conserve sa propre copie de ces données"
+    },
+    "postgis": {
+      "label": "PostGIS",
+      "title": "Enregistré depuis une table PostGIS existante — les données restent dans votre base"
+    },
+    "service": {
+      "label": "Service",
+      "title": "Enregistré depuis l'URL d'un service distant"
+    },
+    "stac": {
+      "label": "STAC",
+      "title": "Importé depuis un catalogue STAC"
+    },
+    "created": {
+      "label": "Créé",
+      "title": "Créé dans GeoLens comme couche modifiable"
+    }
+  },
   "nav": {
     "search": "Recherche",
     "collections": "Collections",

--- a/frontend/src/i18n/locales/fr/common.json
+++ b/frontend/src/i18n/locales/fr/common.json
@@ -22,11 +22,11 @@
   "origin": {
     "upload": {
       "label": "Téléversé",
-      "title": "Fichier téléversé — GeoLens conserve sa propre copie de ces données"
+      "title": "Fichier téléversé. GeoLens conserve sa propre copie de ces données"
     },
     "postgis": {
       "label": "PostGIS",
-      "title": "Enregistré depuis une table PostGIS existante — les données restent dans votre base"
+      "title": "Enregistré depuis une table PostGIS existante. Les données restent dans votre base"
     },
     "service": {
       "label": "Service",

--- a/frontend/src/i18n/locales/fr/dataset.json
+++ b/frontend/src/i18n/locales/fr/dataset.json
@@ -112,7 +112,8 @@
       "owner": "Propriétaire indisponible",
       "updated": "Date de mise à jour inconnue",
       "type": "Type inconnu"
-    }
+    },
+    "tableReadout": "Table PostGIS"
   },
   "breadcrumbs": {
     "datasets": "Jeux de données"

--- a/frontend/src/i18n/locales/fr/report.json
+++ b/frontend/src/i18n/locales/fr/report.json
@@ -11,6 +11,10 @@
   "noticedNone": "Rien n'a été détecté automatiquement — c'est votre description qui compte le plus.",
   "technicalDetails": "Détails techniques ({{count}})",
   "technicalEmpty": "Rien n'a encore été capturé.",
+  "technicalCopy": "Copier les détails techniques",
+  "technicalCopied": "Détails techniques copiés dans le presse-papiers",
+  "technicalClear": "Effacer",
+  "technicalClearAria": "Effacer les signaux capturés",
   "step1": {
     "heading": "Que s'est-il passé ?",
     "areaLabel": "Où cela s'est-il produit ?",

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -23,7 +23,10 @@
  */
 
 :root {
-  --radius: 0.625rem;
+  /* Redesign: 10px → 8px base radius. Cards land at 8px, buttons/inputs at
+     6px — crisper, closer to the instrument-panel look the dataset stats
+     grid established, without going full square. */
+  --radius: 0.5rem;
 
   /* ─ Primary scale (blue, hue ~250) ─ */
   --primary-50:  oklch(0.97 0.02 250);
@@ -390,6 +393,45 @@
 @keyframes shimmer {
   0% { background-position: -200% 0; }
   100% { background-position: 200% 0; }
+}
+
+/* ── Instrument Utilities ──────────────────────────────
+   The app-wide "survey instrument" label system. `.eyebrow` is the canonical
+   mono-caps section marker (same treatment as SECTION_EYEBROW on the dataset
+   page — kept in sync so the two tiers stay one system). `.readout` is for
+   measured values: counts, EPSG codes, coordinates, timestamps. */
+.eyebrow {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  line-height: 1rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: color-mix(in oklab, var(--foreground) 70%, transparent);
+}
+.readout {
+  font-family: var(--font-mono);
+  font-variant-numeric: tabular-nums;
+  letter-spacing: 0.02em;
+}
+
+/* Neatline tick rule — a map sheet's neatline: 1px baseline with survey
+   ticks rising from it every 16px. Used under page headers and panel
+   headers as the redesign's signature divider. Theme-aware via --border. */
+.tick-rule {
+  height: 5px;
+  background-image:
+    repeating-linear-gradient(
+      to right,
+      var(--border) 0,
+      var(--border) 1px,
+      transparent 1px,
+      transparent 16px
+    ),
+    linear-gradient(var(--border), var(--border));
+  background-size: 100% 5px, 100% 1px;
+  background-position: left bottom, left bottom;
+  background-repeat: no-repeat;
 }
 
 /* ── Cartographic Textures ─────────────────────────── */

--- a/frontend/src/lib/report/__tests__/build-issue.test.ts
+++ b/frontend/src/lib/report/__tests__/build-issue.test.ts
@@ -3,6 +3,7 @@ import {
   buildClipboardReport,
   buildContext,
   buildIssueUrl,
+  buildTechnicalClipboard,
   mapAreaFromPath,
   summarizeEntries,
 } from '../build-issue';
@@ -153,6 +154,20 @@ describe('summarizeEntries', () => {
     const summary = summarizeEntries([entry({ message: 'tile 404', suppressed: true, count: 3 })]);
     expect(summary).toContain('(suppressed)');
     expect(summary).toContain('×3');
+  });
+});
+
+describe('buildTechnicalClipboard', () => {
+  it('includes the heading, version, and context', () => {
+    const md = buildTechnicalClipboard({ version: '1.4.2', context: '- **Page:** /maps' });
+    expect(md).toContain('## GeoLens technical details');
+    expect(md).toContain('**GeoLens version:** 1.4.2');
+    expect(md).toContain('- **Page:** /maps');
+  });
+
+  it('omits empty version and context blocks', () => {
+    const md = buildTechnicalClipboard({ version: '', context: '' });
+    expect(md).toBe('## GeoLens technical details');
   });
 });
 

--- a/frontend/src/lib/report/build-issue.ts
+++ b/frontend/src/lib/report/build-issue.ts
@@ -179,6 +179,17 @@ export function buildIssueUrl(params: BuildIssueParams): { url: string; truncate
   return { url: base, truncated: true };
 }
 
+/**
+ * Markdown block of just the environment + captured signals, for the step-1
+ * "Copy technical details" action — usable without typing a single field.
+ */
+export function buildTechnicalClipboard(params: { version: string; context: string }): string {
+  const parts: string[] = ['## GeoLens technical details'];
+  if (params.version) parts.push(`**GeoLens version:** ${params.version}`);
+  if (params.context) parts.push(params.context);
+  return parts.join('\n\n');
+}
+
 export interface ClipboardReportParams {
   title: string;
   description: string;

--- a/frontend/src/lib/report/index.ts
+++ b/frontend/src/lib/report/index.ts
@@ -21,6 +21,7 @@ export {
   buildContext,
   buildIssueUrl,
   buildClipboardReport,
+  buildTechnicalClipboard,
 } from './build-issue';
 export type {
   IssueArea,

--- a/frontend/src/pages/DatasetPage.tsx
+++ b/frontend/src/pages/DatasetPage.tsx
@@ -52,6 +52,8 @@ const VrtCreateDialog = lazy(() =>
   import('@/components/import/VrtCreateDialog').then((m) => ({ default: m.VrtCreateDialog }))
 );
 import { RecordTypeBadge } from '@/components/search/RecordTypeBadge';
+import { OriginBadge, datasetOrigin } from '@/components/dataset/OriginBadge';
+import { CopyButton } from '@/components/ui/copy-button';
 import { DatasetStatsBar } from '@/components/dataset/DatasetStatsBar';
 import { MapErrorBoundary } from '@/components/error';
 import { getValidationNavigationAction } from '@/lib/dataset-validation-navigation';
@@ -385,10 +387,18 @@ export function DatasetPage() {
   // is the steady state and carries no information here — show a status badge
   // ONLY when it's the exception that needs action (draft). Mirrors the pattern
   // SearchResultCard already uses (showStatusBadge = record_status !== 'published').
+  const origin = datasetOrigin(dataset);
+  // Every spatial dataset lives in a PostGIS table — surfacing the table name
+  // in the header is the "works with your existing GIS tools" affordance
+  // (psql, QGIS, ogr2ogr can hit it directly). Raster/VRT data lives in
+  // object storage, not a queryable table, so those skip the readout.
+  const showTableReadout = !isRaster && !isVrt && Boolean(dataset.table_name);
+
   const statsLine = (
     <>
       <RecordTypeBadge recordType={dataset.record_type} />
       <div className="flex items-center gap-1.5">
+        {origin && <OriginBadge origin={origin} />}
         {dataset.record_status !== 'published' && (
           <Badge variant="outline" className={cn('text-xs', ingestionStatusColors[dataset.record_status] ?? '')}>
             {getRecordStatusLabel(t, dataset.record_status)}
@@ -399,6 +409,16 @@ export function DatasetPage() {
           {getVisibilityLabel(t, dataset.visibility)}
         </Badge>
       </div>
+      {showTableReadout && (
+        <span
+          className="inline-flex items-center gap-0.5 readout text-xs text-muted-foreground"
+          title={t('header.tableReadout', { defaultValue: 'PostGIS table' })}
+          data-testid="dataset-table-readout"
+        >
+          {dataset.table_name}
+          <CopyButton value={dataset.table_name} className="inline-flex size-5 items-center justify-center rounded hover:bg-muted transition-colors" />
+        </span>
+      )}
     </>
   );
 

--- a/frontend/src/pages/ImportPage.tsx
+++ b/frontend/src/pages/ImportPage.tsx
@@ -34,7 +34,7 @@ export function ImportPage() {
         <p className="mb-2.5 font-mono text-[11px] uppercase tracking-[0.12em] text-muted-foreground">
           {t('eyebrow', { defaultValue: 'Import' })}
         </p>
-        <h1 className="text-3xl font-medium tracking-tight">
+        <h1 className="text-2xl font-semibold tracking-tight">
           {t('title', { defaultValue: 'Bring data into the atlas' })}
         </h1>
         <p className="mt-2.5 max-w-2xl text-[15px] text-muted-foreground">
@@ -49,9 +49,12 @@ export function ImportPage() {
           {MODE_TABS.map(({ value, icon: Icon, labelKey }) => (
             <button
               key={value}
+              type="button"
               onClick={() => setActiveTab(value)}
+              aria-current={activeTab === value ? 'page' : undefined}
               className={cn(
                 'inline-flex items-center gap-2 border-b-2 px-4 pb-3 pt-3 text-[13.5px] font-medium transition-colors',
+                'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset',
                 activeTab === value
                   ? 'border-primary text-foreground'
                   : 'border-transparent text-muted-foreground hover:text-foreground',

--- a/frontend/src/pages/MapsPage.tsx
+++ b/frontend/src/pages/MapsPage.tsx
@@ -116,7 +116,7 @@ export function MapsPage() {
         title={t('maps.title')}
         actions={
           <div className="flex items-center gap-2">
-            {data && <Badge variant="secondary">{data.total}</Badge>}
+            {data && <Badge variant="secondary" className="readout">{data.total}</Badge>}
             {/* Hide the header create button when the empty state is showing its
                 own primary CTA (no maps, no active search/filter). */}
             {isEditor && !(data && data.total === 0 && !debouncedSearch && visibility === 'all') && (

--- a/frontend/src/pages/SearchPage.tsx
+++ b/frontend/src/pages/SearchPage.tsx
@@ -96,14 +96,14 @@ export function SearchPage() {
           </aside>
 
           <div className="min-w-0 space-y-5">
-            <section className="rounded-[22px] border border-border/50 bg-background/95 px-4 py-4 shadow-sm sm:px-5">
+            <section className="rounded-lg border bg-card px-4 py-4 shadow-sm sm:px-5">
               <SearchControls totalResults={totalMatched > 0 ? totalMatched : undefined}>
                 {token ? <SavedSearches className="justify-center md:justify-start" /> : null}
               </SearchControls>
             </section>
 
             {isFetching && data && (
-              <div role="status" aria-live="polite" className="inline-flex items-center gap-2 rounded-full border border-border/60 bg-background/85 px-3 py-1.5 text-sm text-muted-foreground shadow-sm">
+              <div role="status" aria-live="polite" className="inline-flex items-center gap-2 rounded-md border bg-card px-3 py-1.5 text-sm text-muted-foreground shadow-sm">
                 <Loader2 className="size-4 animate-spin" aria-hidden="true" />
                 {t('updating')}
               </div>

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -407,6 +407,9 @@ export interface OGCRecordProperties {
   contacts?: Array<{ name?: string; organization?: string; roles?: string[]; email?: string; phone?: string }> | null;
   license: string | null;
   source_organization: string | null;
+  /** Ingest source format ('geojson', 'wfs', 'stac', 'created', ...).
+   * Null for registered PostGIS tables and composed VRTs. */
+  source_format?: string | null;
   quality_detail?: {
     overall: number;
     metadata_completeness: number;

--- a/sdks/python/geolens/models/ogc_record_properties.py
+++ b/sdks/python/geolens/models/ogc_record_properties.py
@@ -67,6 +67,8 @@ class OGCRecordProperties:
         row_count (int | None | Unset): Row count for tabular records (alias for feature_count when
             record_type='table').
         source_count (int | None | Unset):
+        source_format (None | str | Unset): Ingest source format ('geojson', 'shapefile', 'geotiff', 'wfs', 'stac',
+            'created', ...). Null for datasets registered from existing PostGIS tables and for composed VRT datasets.
         source_organization (None | str | Unset):
         themes (list[OGCRecordPropertiesThemesType0Item] | None | Unset):
         time (None | OGCRecordPropertiesTimeType0 | Unset):
@@ -106,6 +108,7 @@ class OGCRecordProperties:
     rights: None | str | Unset = UNSET
     row_count: int | None | Unset = UNSET
     source_count: int | None | Unset = UNSET
+    source_format: None | str | Unset = UNSET
     source_organization: None | str | Unset = UNSET
     themes: list[OGCRecordPropertiesThemesType0Item] | None | Unset = UNSET
     time: None | OGCRecordPropertiesTimeType0 | Unset = UNSET
@@ -297,6 +300,12 @@ class OGCRecordProperties:
         else:
             source_count = self.source_count
 
+        source_format: None | str | Unset
+        if isinstance(self.source_format, Unset):
+            source_format = UNSET
+        else:
+            source_format = self.source_format
+
         source_organization: None | str | Unset
         if isinstance(self.source_organization, Unset):
             source_organization = UNSET
@@ -410,6 +419,8 @@ class OGCRecordProperties:
             field_dict["row_count"] = row_count
         if source_count is not UNSET:
             field_dict["source_count"] = source_count
+        if source_format is not UNSET:
+            field_dict["source_format"] = source_format
         if source_organization is not UNSET:
             field_dict["source_organization"] = source_organization
         if themes is not UNSET:
@@ -752,6 +763,15 @@ class OGCRecordProperties:
 
         source_count = _parse_source_count(d.pop("source_count", UNSET))
 
+        def _parse_source_format(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        source_format = _parse_source_format(d.pop("source_format", UNSET))
+
         def _parse_source_organization(data: object) -> None | str | Unset:
             if data is None:
                 return data
@@ -882,6 +902,7 @@ class OGCRecordProperties:
             rights=rights,
             row_count=row_count,
             source_count=source_count,
+            source_format=source_format,
             source_organization=source_organization,
             themes=themes,
             time=time,

--- a/sdks/typescript/src/client/types.gen.ts
+++ b/sdks/typescript/src/client/types.gen.ts
@@ -6190,6 +6190,12 @@ export type OgcRecordProperties = {
      */
     source_count?: number | null;
     /**
+     * Source Format
+     *
+     * Ingest source format ('geojson', 'shapefile', 'geotiff', 'wfs', 'stac', 'created', ...). Null for datasets registered from existing PostGIS tables and for composed VRT datasets.
+     */
+    source_format?: string | null;
+    /**
      * Source Organization
      */
     source_organization?: string | null;


### PR DESCRIPTION
## Summary

One-pass UI redesign that unifies the app on the "survey instrument" language the dataset page and import flow already used: mono-caps eyebrow labels, hairline survey grids, mono readouts for measured values (counts, EPSG codes, table names), squared chips, and a tick-rule "neatline" divider as the signature element. The older soft-pill generation (rounded-22px cards, translucent surfaces) and the stock-shadcn shell are gone.

This is not a reskin. The pass also surfaces dataset provenance as a first-class concept and makes the admin area read like part of the product.

## What changed

**Tokens and primitives** (`index.css`, `ui/badge`, `ui/table`)
- New `.eyebrow`, `.readout`, and `.tick-rule` utilities; base radius 10px → 8px.
- Badge goes from pill to squared chip. Table column headers go mono-caps. Both propagate app-wide, including the builder and admin, with no per-page edits.

**Shell**
- Navbar is a full-bleed control bar with baseline-marker active tabs (same underline vocabulary as the import mode tabs). Admins get a visible Admin entry in the top nav and mobile sheet instead of only the user dropdown.
- PageHeader closes with the tick-rule neatline; this lifts Collections, Maps, Settings, and all eight admin pages at once. Footer shows the instance version (`v1.4.2`) as a readout.

**Dataset origin, end to end** (the PostGIS-native ask)
- New `source_format` field on OGC search records (additive; `openapi.json` and both SDKs regenerated).
- `datasetOrigin()` derives Uploaded / PostGIS / Service / STAC / Created from persisted fields. Registered PostGIS tables store no `source_format`, VRTs are composed so they show the type badge alone.
- `OriginBadge` renders on catalog cards and the dataset header, with explanatory tooltips ("Registered from an existing PostGIS table. The data stays in your database").
- Dataset headers also show the live PostGIS table name as a copyable mono readout for vector and table datasets, so QGIS/psql/ogr2ogr users can grab it without digging.

**Catalog search**
- Filter rail and search card drop the soft-pill styling for crisp bordered cards; rail section labels use the eyebrow, facet counts are right-aligned mono readouts.

**Admin control plane**
- Overview stats become a bordered survey grid (same pattern as the dataset stats bar). Sidebar group labels use the eyebrow. Health rows keep their latency readouts and status dots.

**States and a11y**
- Empty states get a dashed frame over the existing graticule. Import mode tabs get visible focus rings and `aria-current`. All new interactive elements keep the standard `focus-visible` ring.

**i18n**
- Every new key ships in all four locales (en/es/fr/de); `npm run test:i18n` passes.

## Screenshots

| Catalog (light) | Catalog (dark) |
|---|---|
| ![catalog light](https://raw.githubusercontent.com/geolens-io/geolens/assets/ui-redesign-2026-07/search-light.png) | ![catalog dark](https://raw.githubusercontent.com/geolens-io/geolens/assets/ui-redesign-2026-07/search-dark.png) |

| Dataset detail (origin badge + table readout) | Maps (neatline) |
|---|---|
| ![dataset](https://raw.githubusercontent.com/geolens-io/geolens/assets/ui-redesign-2026-07/dataset-detail.png) | ![maps](https://raw.githubusercontent.com/geolens-io/geolens/assets/ui-redesign-2026-07/maps-light.png) |

| Admin overview (dark) | Register PostGIS tab | Mobile |
|---|---|---|
| ![admin](https://raw.githubusercontent.com/geolens-io/geolens/assets/ui-redesign-2026-07/admin-dark.png) | ![register](https://raw.githubusercontent.com/geolens-io/geolens/assets/ui-redesign-2026-07/register-dark.png) | ![mobile](https://raw.githubusercontent.com/geolens-io/geolens/assets/ui-redesign-2026-07/search-mobile.png) |

(Screenshots live on the throwaway `assets/ui-redesign-2026-07` branch; delete it after merge.)

## Schema / API / config impact

- Additive only: `OGCRecordProperties.source_format` (nullable) in the records search response and STAC items. `backend/openapi.json`, the Python SDK, and the TypeScript SDK are regenerated in this PR. No migrations, no config changes.

## Test/verification

- `cd frontend && npm run typecheck && npm run lint && npm run test:coverage` (3275 passed) and `npm run test:i18n`
- `cd frontend && npm run build`
- `make openapi-check && make sdks-check`
- Backend: `uv run ruff check` + `pytest tests/test_ogc_record_properties.py tests/test_search_facets.py` (23 passed)
- `npm run e2e:smoke` (31 passed; one pre-existing strict-mode collision in `admin.spec.ts` fixed here by asserting columnheader roles)
- Playwright MCP visual pass over catalog, dataset detail, import, register, maps, builder, collections, and admin in both themes plus 390px mobile.

## Notes for review

- The builder intentionally receives only the token-level changes (badge/radius/table); it was audited and remediated this week and its component structure is untouched.
- `datasetOrigin()` maps `source_format=null` to "PostGIS". That is exactly what `register_existing_table` persists; VRTs (also null) and collections are excluded before the null check.

https://claude.ai/code/session_01CMhLNcUMpMUA2RX4nVUmwj
