### PR TITLE
fix(frontend): allow Cloudflare Web Analytics beacon in CSP

### DIFF
--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -210,7 +210,7 @@ server {
         #     (intentional; the trailing empty CSP directive is ignored by
         #     browsers per CSP3 and never emits frame-ancestors '*').
         # SEC-020: same script/exfil backstop as `location /`.
-        add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https:; font-src 'self' data:; connect-src 'self' https: wss:; worker-src 'self' blob:; child-src 'self' blob:; object-src 'none'; base-uri 'self'; ${embed_frame_ancestors}" always;
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'wasm-unsafe-eval' https://static.cloudflareinsights.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https:; font-src 'self' data:; connect-src 'self' https: wss:; worker-src 'self' blob:; child-src 'self' blob:; object-src 'none'; base-uri 'self'; ${embed_frame_ancestors}" always;
         try_files $uri /index.html;
     }
 
@@ -245,12 +245,14 @@ server {
         # blocks script injection; style-src 'unsafe-inline' is required by
         # React/MapLibre/Tailwind inline styles; img/connect/font/worker stay
         # permissive so map tiles, glyphs, workers and external sources still load.
+        # static.cloudflareinsights.com is the Cloudflare Web Analytics beacon,
+        # auto-injected at the edge when the site is proxied through Cloudflare.
         # Any add_header here disables inheritance, so the server-scope security
         # headers are re-declared.
         add_header X-Frame-Options "SAMEORIGIN" always;
         add_header X-Content-Type-Options "nosniff" always;
         add_header Referrer-Policy "strict-origin-when-cross-origin" always;
-        add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https:; font-src 'self' data:; connect-src 'self' https: wss:; worker-src 'self' blob:; child-src 'self' blob:; object-src 'none'; base-uri 'self'; frame-ancestors 'self'" always;
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'wasm-unsafe-eval' https://static.cloudflareinsights.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https:; font-src 'self' data:; connect-src 'self' https: wss:; worker-src 'self' blob:; child-src 'self' blob:; object-src 'none'; base-uri 'self'; frame-ancestors 'self'" always;
         try_files $uri $uri/ /index.html;
     }
 }


### PR DESCRIPTION
## What

The demo zone is proxied through Cloudflare with Web Analytics (RUM) enabled, which auto-injects `beacon.min.js` from `static.cloudflareinsights.com` into HTML responses at the edge. `script-src 'self'` blocked it, so the beacon never ran and every demo page logged a CSP violation in the console.

This allows the host in `script-src` on both CSP sites in `frontend/nginx.conf` (SPA shell and the `/m/` embed route), with a comment explaining why the host is allowed. The beacon's data POST was already permitted by `connect-src https:`.

## Impact

- No API/schema/config changes. Header-only change in the frontend nginx image.
- SEC-020 posture unchanged apart from the one Cloudflare-controlled host.

## Verification

Ran against the exact published base image:

```
docker run --rm -v $PWD/frontend/nginx.conf:/etc/nginx/conf.d/default.conf:ro nginxinc/nginx-unprivileged:1.31.1-alpine nginx -t
```

Syntax OK, and a live boot + `curl -sI` confirms the emitted header now includes `script-src 'self' 'wasm-unsafe-eval' https://static.cloudflareinsights.com`. (The `duplicate extension "wasm"` warning is pre-existing at line 43, untouched here.)

https://claude.ai/code/session_01CMhLNcUMpMUA2RX4nVUmwj