### PR TITLE
fix(frontend): restore AA contrast on footer version readout

### DIFF
--- a/frontend/src/components/layout/AppFooter.tsx
+++ b/frontend/src/components/layout/AppFooter.tsx
@@ -54,7 +54,7 @@ export function AppFooter({
         ))}
         {/* Instance version readout — self-hosters see at a glance what they run. */}
         <span aria-hidden="true">·</span>
-        <span className="readout text-muted-foreground/80">v{__APP_VERSION__}</span>
+        <span className="readout text-muted-foreground">v{__APP_VERSION__}</span>
       </nav>
     </footer>
   );


### PR DESCRIPTION
## What

The footer version badge (`AppFooter.tsx`) was set to `text-muted-foreground/80` in the #397 redesign. At `/80` opacity it composites to **4.35:1** against the footer background — under the 4.5:1 WCAG AA threshold. The axe suite (now enforced in CI, not `if:false`) fails all four public-page a11y checks on this one global element, which has left `main` red since #397.

## Fix

Drop the `/80` opacity. The full `--muted-foreground` token measures **7.13:1** against the same background.

Only this element was flagged by axe; the remaining `text-muted-foreground/80` uses on non-public-page components are left to the scheduled GLUX-012 contrast sweep.

## Verify
- Contrast computed from `--muted-foreground: oklch(0.45 0.005 250)` over the axe-measured `#fbfaf8` bg → 7.13:1.
- CI axe run is the gate; this PR turns `main` green.

https://claude.ai/code/session_01TRCpoeiQ6bpLZEHr5ZBj2T