### PR TITLE
docs(readme-assets): refresh capture recipe for showcase v2 + automation

### DIFF
--- a/.github/assets/README.md
+++ b/.github/assets/README.md
@@ -8,22 +8,23 @@ tooling* out of this public repo (see "Where the tooling lives" below).
 ## Current set
 
 The README hero plus a four-step Find -> Inspect -> Build -> Ask AI story.
-Displayed at `width="900"`; sources are ~1200 px wide. Use PNG for UI shots
+Displayed at `width="900"`; sources are ~1200–1600 px wide. Use PNG for UI shots
 (crisp text) and JPG for photographic 3D terrain (smaller).
 
-| File | Beat | Shows | How to reproduce (live seeded stack) |
+| File | Beat | Shows | Subject (live seeded stack) |
 | --- | --- | --- | --- |
-| `geolens-manhattan-3d-hero.jpg` | Hero | Manhattan footprints extruded to roof height in the builder | Open the **Manhattan - A Century of Skyline** map in the builder |
-| `geolens-search.png` | Find | Semantic search ranking hydrology datasets | Catalog at `/?q=hydrology` (dismiss the autocomplete before the shot) |
-| `geolens-dataset.png` | Inspect | Dataset map preview + typed attribute table | Rivers Lake Centerlines (10m) dataset, Data tab |
-| `geolens-matterhorn-terrain.jpg` | Build | Matterhorn 3D terrain mesh + layer stack | Open the **The Matterhorn in 3D** map in the builder |
-| `geolens-ai-labels.png` | Ask AI | AI mapping + labeling a choropleth | New York Income dataset (catalog), Ask AI: "Map this as a choropleth and label each county" |
+| `geolens-manhattan-3d-hero.jpg` | Hero | Manhattan footprints extruded to roof height, colored by era, with the layer editor open | **Manhattan - A Century of Skyline** map, Buildings (3D) layer selected |
+| `geolens-search.png` | Find | Semantic search: "natural disasters" ranks earthquakes + volcanic eruptions with no keyword match | Catalog, search `natural disasters` (2 results) |
+| `geolens-dataset.png` | Inspect | Dataset map preview + typed metadata over a dense point cloud | **Meteorite Landings** dataset detail (32,186 points) |
+| `geolens-matterhorn-terrain.jpg` | Build | Matterhorn 3D terrain mesh + layer stack + legend | **The Matterhorn in 3D** map |
+| `geolens-ai-labels.png` | Ask AI | AI editing a map in natural language | **Restless Earth** map, Ask AI: "Label the volcanoes with their names" |
 
 ## Seeding the data
 
-`scripts/seed-showcase.py` builds the demo maps behind the hero
-(Manhattan), Build (Matterhorn), and the New York Income catalog dataset
-behind the Ask AI shot (terrain is built by default now):
+`scripts/seed-showcase.py` builds the showcase maps behind the Hero (Manhattan),
+Build (Matterhorn), and Ask AI (Restless Earth) shots, plus the catalog datasets
+the Find and Inspect shots use (the earthquake / volcanic-eruption datasets and
+Meteorite Landings). Terrain is built by default.
 
 ```bash
 python scripts/seed-showcase.py \
@@ -31,20 +32,37 @@ python scripts/seed-showcase.py \
   --password "$GEOLENS_ADMIN_PASSWORD"
 ```
 
-The Find (search) and Inspect (dataset) shots use a Natural Earth vector
-catalog: rivers, lakes, subwatersheds. There is no bundled seeder for those;
-load them into the catalog via the import flow (`geolens publish` / a manifest,
-see the main README) before capturing.
+## Reproducing the shots
+
+The canonical recipe is now automated. From a checkout of the private
+getgeolens.com site repo, sitting next to this one, against a live seeded stack:
+
+```bash
+cd ../getgeolens.com
+GEOLENS_ADMIN_PASSWORD="$GEOLENS_ADMIN_PASSWORD" npm run capture:readme
+# writes the 5 images straight into this folder (GEOLENS_REPO_DIR, default ../geolens)
+```
+
+Then review the `git diff` here before committing — these images are public.
+
+Two shots need a human eye after every run:
+
+- **Ask AI** performs a real, non-deterministic AI edit that *mutates* the
+  Restless Earth map. Re-seed to reset it; a second run against an
+  already-labeled map is expected to fall back to the plain map.
+- **Matterhorn** framing rides that map's saved camera (`jumpTo` ≈
+  `{ center: [7.66, 45.97], zoom: 13.7, pitch: 60, bearing: -122 }`; the builder
+  caps pitch at 60°). Adjust the saved map, not the script, to reframe.
+
+The three content shots (Find / Inspect / Ask AI panel) are deterministic — they
+are the ones that drift with catalog data, which is exactly what the automated
+recipe keeps in parity with the marketing site.
 
 ## Capture notes
 
-- Capture from a live stack at `http://localhost:8080` (username `admin` and
-  the generated password from `.env`),
-  viewport ~1280×800 / 1600×900, then crop/scale to ~1200 px wide and optimize
-  (e.g. `magick in.png -strip out.png`; JPG at quality ~88 for terrain).
-- The Matterhorn camera was framed via the live MapLibre map
-  (`jumpTo` ≈ `{ center: [7.66, 45.97], zoom: 13.7, pitch: 60, bearing: -122 }`,
-  with left padding for the layer panel). The builder caps pitch at 60°.
+- Sources are captured at 1600×900; the README renders them at `width="900"`.
+  Optionally strip/optimize before committing (e.g. `magick in.png -strip out.png`;
+  JPG at quality ~88 for terrain).
 - These images are public. Keep them free of private/draft dataset titles,
   internal hostnames, and PII.
 
@@ -52,6 +70,7 @@ see the main README) before capturing.
 
 The reusable Playwright capture machinery and the canonical capture recipe live
 in the private getgeolens.com site repo (it drives that site's own
-marketing/docs screenshots). Do not add capture scripts to this public repo.
-Capture from the live stack and copy the finished images in, the same way brand
-assets are vendored (`BRANDING-VERSION`).
+marketing/docs screenshots, and `capture:readme` is a third target list sharing
+the same core). Do not add capture scripts to this public repo. The recipe writes
+finished images in from the live stack, the same way brand assets are vendored
+(`BRANDING-VERSION`) — the copy is automated, the tooling stays out.


### PR DESCRIPTION
Refreshes `.github/assets/README.md`, the capture recipe for the README screenshots.

The per-shot table still described the retired first-generation subjects — hydrology search, Rivers Lake Centerlines, a New York income choropleth — none of which the README shows anymore (the images were updated in #407). This updates the recipe to the current showcase-v2 subjects and points the reproduce steps at the now-automated `npm run capture:readme` (getgeolens.com#43).

## Changes

- Per-shot table → current subjects: `natural disasters` search (2 results), Meteorite Landings (32k points), Restless Earth volcano labels, Manhattan Buildings-3D hero, Matterhorn terrain.
- "Reproducing the shots" now points at the automated `npm run capture:readme` in the getgeolens.com repo (writes straight into this folder via `GEOLENS_REPO_DIR`), with the review-the-diff-before-commit gate for these public images.
- Keeps the standing decision intact: capture tooling stays out of this public repo; only finished images are vendored in — the copy is just automated now.
- Flags the two shots that need a human eye (the non-deterministic Ask AI write; the Matterhorn saved-camera framing).

Docs-only. Pairs with getgeolens.com#43 (the capture surface).
