### PR TITLE
build(docker): align python version references with the shipped 3.14 image

### DIFF
--- a/.github/workflows/dep-audit.yml
+++ b/.github/workflows/dep-audit.yml
@@ -87,7 +87,9 @@ jobs:
         # `enforce: "1"` fails the job on a fixable CRITICAL CVE; `enforce: "0"`
         # is report-only. The slim/alpine images we pin (node/python/nginx) are
         # controllable — a CRITICAL there is actionable (bump the tag), so they
-        # ENFORCE. postgis/postgis:17-3.5 is an uncontrollable third-party fat
+        # ENFORCE — keep these three pins matched to the Dockerfile `FROM` tags
+        # they mirror (bump together). postgis/postgis:17-3.5 is an
+        # uncontrollable third-party fat
         # Debian-11 image whose CRITICAL set is dominated by CVEs in baked-in Go
         # binaries that only the upstream maintainer can rebuild — and that set
         # shifts with every Trivy DB update. Gating on it would make CI red on
@@ -97,7 +99,7 @@ jobs:
         include:
           - image: "node:26.3.0-alpine"
             enforce: "1"
-          - image: "python:3.14.5-slim"
+          - image: "python:3.14.6-slim"
             enforce: "1"
           - image: "nginxinc/nginx-unprivileged:1.31.1-alpine"
             enforce: "1"

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 # Stage 1: backend-builder — uv sync, all build-time prep
 # ==============================================================================
 # Build-time deps (apt cache, intermediate uv-sync state) are confined to this
-# stage. The runtime layer rebuilds from a clean python:3.14.3-slim base and
+# stage. The runtime layer rebuilds from a clean python:3.14-slim base and
 # only copies the resolved /app venv from this builder.
 FROM python:3.14.6-slim AS backend-builder
 
@@ -127,10 +127,10 @@ RUN --mount=type=cache,target=/root/.cache/uv \
     done
 
 # ==============================================================================
-# Stage 2: backend-base — clean python:3.14.3-slim runtime; venv from builder
+# Stage 2: backend-base — clean python:3.14-slim runtime; venv from builder
 # ==============================================================================
 # True multi-stage split: runtime starts from a fresh
-# python:3.14.3-slim base (no apt-cache layer from builder, no intermediate
+# python:3.14-slim base (no apt-cache layer from builder, no intermediate
 # uv-sync state). Only the resolved /app/.venv + code arrive via COPY --from.
 #
 # Note: uv is kept in the runtime layer because the entrypoints and CMD use
@@ -140,8 +140,10 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 # INSTALL_ENTERPRISE_OVERLAY) to pre-bake the overlay into an enterprise image.
 # gcc/dev libs are still excluded from the runtime layer.
 #
-# Pin: python:3.14.3-slim. backend/pyproject.toml requires-python>=3.13 for
-# adopter flexibility; this image ships 3.14.3 as the project's tested runtime.
+# Pin: see the `FROM python:3.14-slim` line below (Dependabot bumps the exact
+# patch, so this prose names only the minor). backend/pyproject.toml
+# requires-python>=3.13 for adopter flexibility; this image ships the pinned
+# 3.14-slim as the project's tested runtime.
 # See backend/pyproject.toml comment at requires-python for the matching note.
 FROM python:3.14.6-slim AS backend-base
 

--- a/README.de.md
+++ b/README.de.md
@@ -10,7 +10,7 @@ Laden Sie Shapefiles, GeoTIFFs, GeoPackages oder CSVs hoch. GeoLens speichert al
 
 [![CI](https://github.com/geolens-io/geolens/actions/workflows/ci.yml/badge.svg)](https://github.com/geolens-io/geolens/actions/workflows/ci.yml)
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
-[![Python: backend 3.13 / SDK 3.10+](https://img.shields.io/badge/python-3.13_backend_%7C_3.10%2B_SDK-blue.svg)]()
+[![Python: backend 3.13+ / SDK 3.10+](https://img.shields.io/badge/python-3.13%2B_backend_%7C_3.10%2B_SDK-blue.svg)]()
 [![PostgreSQL 17 + PostGIS 3.5](https://img.shields.io/badge/PostGIS_3.5-PostgreSQL_17-336791.svg)](https://postgis.net/)
 [![OGC API](https://img.shields.io/badge/OGC_API-Features_%7C_Records-green.svg)](https://ogcapi.ogc.org/)
 

--- a/README.es.md
+++ b/README.es.md
@@ -10,7 +10,7 @@ Sube Shapefiles, GeoTIFFs, GeoPackages o CSVs. GeoLens guarda todo en PostGIS, i
 
 [![CI](https://github.com/geolens-io/geolens/actions/workflows/ci.yml/badge.svg)](https://github.com/geolens-io/geolens/actions/workflows/ci.yml)
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
-[![Python: backend 3.13 / SDK 3.10+](https://img.shields.io/badge/python-3.13_backend_%7C_3.10%2B_SDK-blue.svg)]()
+[![Python: backend 3.13+ / SDK 3.10+](https://img.shields.io/badge/python-3.13%2B_backend_%7C_3.10%2B_SDK-blue.svg)]()
 [![PostgreSQL 17 + PostGIS 3.5](https://img.shields.io/badge/PostGIS_3.5-PostgreSQL_17-336791.svg)](https://postgis.net/)
 [![OGC API](https://img.shields.io/badge/OGC_API-Features_%7C_Records-green.svg)](https://ogcapi.ogc.org/)
 

--- a/README.fr.md
+++ b/README.fr.md
@@ -10,7 +10,7 @@ Importez des Shapefiles, GeoTIFFs, GeoPackages ou CSVs. GeoLens stocke tout dans
 
 [![CI](https://github.com/geolens-io/geolens/actions/workflows/ci.yml/badge.svg)](https://github.com/geolens-io/geolens/actions/workflows/ci.yml)
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
-[![Python: backend 3.13 / SDK 3.10+](https://img.shields.io/badge/python-3.13_backend_%7C_3.10%2B_SDK-blue.svg)]()
+[![Python: backend 3.13+ / SDK 3.10+](https://img.shields.io/badge/python-3.13%2B_backend_%7C_3.10%2B_SDK-blue.svg)]()
 [![PostgreSQL 17 + PostGIS 3.5](https://img.shields.io/badge/PostGIS_3.5-PostgreSQL_17-336791.svg)](https://postgis.net/)
 [![OGC API](https://img.shields.io/badge/OGC_API-Features_%7C_Records-green.svg)](https://ogcapi.ogc.org/)
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ GeoLens is an open-source, self-hosted catalog and map builder for GIS and data 
 
 [![CI](https://github.com/geolens-io/geolens/actions/workflows/ci.yml/badge.svg)](https://github.com/geolens-io/geolens/actions/workflows/ci.yml)
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
-[![Python: backend 3.13 / SDK 3.10+](https://img.shields.io/badge/python-3.13_backend_%7C_3.10%2B_SDK-blue.svg)]()
+[![Python: backend 3.13+ / SDK 3.10+](https://img.shields.io/badge/python-3.13%2B_backend_%7C_3.10%2B_SDK-blue.svg)]()
 [![PostgreSQL 17 + PostGIS 3.5](https://img.shields.io/badge/PostGIS_3.5-PostgreSQL_17-336791.svg)](https://postgis.net/)
 [![OGC API](https://img.shields.io/badge/OGC_API-Features_%7C_Records-green.svg)](https://ogcapi.ogc.org/)
 
@@ -169,7 +169,7 @@ Each example above has a full guide in the [docs](https://docs.getgeolens.com/gu
 ships PostgreSQL 17. If you point GeoLens at an externally managed database, it
 must be **PostgreSQL 13+** (for `gen_random_uuid()`) with **pgvector 0.5+** (for
 HNSW semantic-search indexes), plus PostGIS, pg_trgm, and unaccent. The API and
-worker run in containers (Python 3.13 bundled, no host Python needed). The
+worker run in containers (Python 3.14 bundled, no host Python needed). The
 optional CLI runs on your host and requires Python 3.11+; the Python SDK and
 seed scripts require Python 3.10+.
 

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -2,8 +2,9 @@
 name = "geolens-backend"
 version = "1.4.2"
 description = "PostGIS-native GIS data catalog"
-# Docker image (Dockerfile) ships python:3.14.3-slim as the project's tested
-# runtime. requires-python>=3.13 is the backward-compat floor for adopters
+# Docker image (Dockerfile) ships python:3.14-slim (see the Dockerfile FROM for
+# the exact patch pin) as the project's tested runtime.
+# requires-python>=3.13 is the backward-compat floor for adopters
 # running their own Python (CI matrix could expand to test 3.13.x — deferred
 # to a future test-coverage milestone). Per INF-15.
 requires-python = ">=3.13"

--- a/backend/tests/test_phase_272_dockerfile.py
+++ b/backend/tests/test_phase_272_dockerfile.py
@@ -126,9 +126,23 @@ class TestInf14NginxMime:
 
 
 class TestInf15PythonPinReconciliation:
-    def test_dockerfile_pins_python_3_14_3(self):
+    def test_dockerfile_pins_python_consistently(self):
+        """INF-15: both stages pin the same concrete python:x.y.z-slim base.
+
+        Asserts the invariant (a concrete patch pin, identical across the builder
+        and runtime stages) rather than a hard-coded literal. Dependabot bumps the
+        patch; the stale `python:3.14.3-slim` literal this test used to assert is
+        exactly the drift fix(#423) removed from the Dockerfile prose.
+        """
         text = DOCKERFILE.read_text()
-        assert "python:3.14.3-slim" in text, "Dockerfile must pin python:3.14.3-slim"
+        pins = re.findall(r"^FROM\s+(python:\d+\.\d+\.\d+-slim)\b", text, re.M)
+        assert pins, (
+            "Dockerfile must pin a concrete python:x.y.z-slim base in its FROM lines"
+        )
+        assert len(set(pins)) == 1, (
+            f"backend-builder and backend-base must pin the same python base; "
+            f"got {sorted(set(pins))}"
+        )
 
     def test_pyproject_requires_python_at_least_3_13(self):
         text = PYPROJECT.read_text()
@@ -143,10 +157,10 @@ class TestInf15PythonPinReconciliation:
         lines = text.splitlines()
         for i, line in enumerate(lines):
             if "requires-python" in line and "=" in line:
-                # Look at preceding 5 lines for a comment about Dockerfile / 3.14.3 / INF-15
+                # Look at preceding 5 lines for a comment about Dockerfile / 3.14-slim / INF-15
                 preceding = "\n".join(lines[max(0, i - 5) : i])
                 assert any(
-                    kw in preceding for kw in ("3.14.3-slim", "Dockerfile", "INF-15")
+                    kw in preceding for kw in ("3.14-slim", "Dockerfile", "INF-15")
                 ), (
                     f"backend/pyproject.toml requires-python at line {i + 1} "
                     f"missing cross-comment about Docker pin (3.14.3-slim or INF-15)"

--- a/backend/tests/test_phase_272_dockerfile.py
+++ b/backend/tests/test_phase_272_dockerfile.py
@@ -127,21 +127,29 @@ class TestInf14NginxMime:
 
 class TestInf15PythonPinReconciliation:
     def test_dockerfile_pins_python_consistently(self):
-        """INF-15: both stages pin the same concrete python:x.y.z-slim base.
+        """INF-15: backend-builder and backend-base pin the same concrete
+        python:x.y.z-slim base.
 
-        Asserts the invariant (a concrete patch pin, identical across the builder
-        and runtime stages) rather than a hard-coded literal. Dependabot bumps the
+        Asserts the invariant (a concrete patch pin, identical across both named
+        backend stages) rather than a hard-coded literal. Dependabot bumps the
         patch; the stale `python:3.14.3-slim` literal this test used to assert is
         exactly the drift fix(#423) removed from the Dockerfile prose.
         """
         text = DOCKERFILE.read_text()
-        pins = re.findall(r"^FROM\s+(python:\d+\.\d+\.\d+-slim)\b", text, re.M)
-        assert pins, (
-            "Dockerfile must pin a concrete python:x.y.z-slim base in its FROM lines"
+        # Base image keyed by backend stage alias, e.g. "python:3.14.6-slim".
+        bases = dict(
+            (alias, base)
+            for base, alias in re.findall(
+                r"^FROM\s+(\S+)\s+AS\s+(backend-builder|backend-base)\s*$", text, re.M
+            )
         )
-        assert len(set(pins)) == 1, (
-            f"backend-builder and backend-base must pin the same python base; "
-            f"got {sorted(set(pins))}"
+        for alias in ("backend-builder", "backend-base"):
+            assert re.fullmatch(r"python:\d+\.\d+\.\d+-slim", bases.get(alias, "")), (
+                f"{alias} stage must pin a concrete python:x.y.z-slim base, "
+                f"got {bases.get(alias)!r}"
+            )
+        assert bases["backend-builder"] == bases["backend-base"], (
+            f"backend-builder and backend-base must pin the same python base; got {bases}"
         )
 
     def test_pyproject_requires_python_at_least_3_13(self):


### PR DESCRIPTION
## What & why

Bump #255 moved the runtime base to `python:3.14.6-slim` but left several mirrors of that version behind, so the repo advertised three different Python versions for the same image (README `3.13`, Dockerfile/pyproject comments `3.14.3`, CVE scan `3.14.5`). This is the concrete runtime/version drift flagged in a recent external audit.

Root cause: Dependabot bumps the Dockerfile `FROM` line but not the prose comments or the workflow scan tag that mirror it. This fixes the values and makes the prose drift-proof (name only the minor; point at `FROM` as the source of truth).

## Changes

- **Dockerfile / `backend/pyproject.toml`** — drop the stale `3.14.3` patch pins from comments; name only `3.14` and point at the `FROM` line as the source of truth.
- **README (en + es/fr/de)** — "Python 3.13 bundled" → `3.14` (the image ships 3.14, not 3.13); badge `backend 3.13` → `3.13+` so it reads as the `requires-python>=3.13` floor rather than a contradiction of the shipped 3.14.
- **`.github/workflows/dep-audit.yml`** — the *enforcing* Trivy scan targeted `python:3.14.5-slim`, a base we no longer ship. Bumped to `3.14.6-slim` (matches the Dockerfile) and added a note that the node/python/nginx pins must track the Dockerfile `FROM` tags. node + nginx were verified already in sync.

## Impact

- No product version change — still `1.4.2`; `make version-check` unaffected.
- Config/CI: the CVE gate now scans the base image we actually ship (small behavior fix).
- The `FROM python:3.14.6-slim` lines — the actual tested runtime — are unchanged.

## Verification

- No `3.14.3` / `3.14.5` leftovers remain in Dockerfile, `pyproject.toml`, or `dep-audit.yml`.
- All `3.14.6` references (both Dockerfile `FROM`s + the Trivy scan) now agree.
- Version surfaces still `1.4.2` across frontend/backend/cli/sdks.

https://claude.ai/code/session_01N161FvzP863aYUDGCAboBy
