### PR TITLE
fix(builder): render visible PNG-export legend swatches

### DIFF
--- a/frontend/src/components/builder/hooks/__tests__/use-builder-save.test.ts
+++ b/frontend/src/components/builder/hooks/__tests__/use-builder-save.test.ts
@@ -1712,6 +1712,9 @@ describe('SHARE-09 export PNG composition', () => {
   let fillTextSpy: ReturnType<typeof vi.fn>;
   let fillRectSpy: ReturnType<typeof vi.fn>;
   let strokeStyleAtStroke: string[];
+  let createGradientSpy: ReturnType<typeof vi.fn>;
+  let addColorStopSpy: ReturnType<typeof vi.fn>;
+  let toBlobSpy: ReturnType<typeof vi.fn>;
   let createElementSpy: ReturnType<typeof vi.spyOn>;
 
   beforeEach(() => {
@@ -1722,6 +1725,12 @@ describe('SHARE-09 export PNG composition', () => {
     fillTextSpy = vi.fn();
     fillRectSpy = vi.fn();
     strokeStyleAtStroke = [];
+    // Mimic the browser: CanvasGradient.addColorStop throws on an unparseable color.
+    addColorStopSpy = vi.fn((_offset: number, color: unknown) => {
+      if (typeof color !== 'string' || color === '') throw new SyntaxError('unparseable color');
+    });
+    createGradientSpy = vi.fn(() => ({ addColorStop: addColorStopSpy }));
+    toBlobSpy = vi.fn((cb: (b: Blob | null) => void) => cb(new Blob(['png'], { type: 'image/png' })));
 
     const ctx2d = {
       fillStyle: '' as string | CanvasGradient,
@@ -1733,7 +1742,7 @@ describe('SHARE-09 export PNG composition', () => {
       fillRect: fillRectSpy,
       // Record the border color used for each swatch (stroke-color border).
       strokeRect: vi.fn(() => { strokeStyleAtStroke.push(ctx2d.strokeStyle); }),
-      createLinearGradient: vi.fn(() => ({ addColorStop: vi.fn() })),
+      createLinearGradient: createGradientSpy,
       drawImage: vi.fn(),
       measureText: vi.fn(() => ({ width: 120 })),
     };
@@ -1742,7 +1751,7 @@ describe('SHARE-09 export PNG composition', () => {
       width: 800,
       height: 600,
       getContext: vi.fn(() => ctx2d),
-      toBlob: vi.fn((cb: (b: Blob | null) => void) => cb(new Blob(['png'], { type: 'image/png' }))),
+      toBlob: toBlobSpy,
     };
 
     const origCreateElement = document.createElement.bind(document);
@@ -1874,6 +1883,64 @@ describe('SHARE-09 export PNG composition', () => {
 
     expect(strokeStyleAtStroke).not.toContain('#ea580c');
     expect(strokeStyleAtStroke).toContain('rgba(0,0,0,0.35)');
+  });
+
+  it('draws a gradient swatch for a multi-stop ramp layer', () => {
+    const mockMap = makeExportMap();
+    // Empty paint + style_config.colors makes getLayerColors return the ramp array.
+    const graduated = makeLayer({
+      id: 'layer-graduated',
+      display_name: 'Graduated',
+      paint: {},
+      style_config: { colors: ['#111111', '#999999'] } as MapLayerResponse['style_config'],
+      visible: true,
+      show_in_legend: true,
+    });
+    const state = makeSaveState({
+      localName: '',
+      localDescription: '',
+      localLayers: [graduated],
+      mapInstanceRef: { current: mockMap } as unknown as SaveState['mapInstanceRef'],
+    });
+    const { result } = renderHook(() => useBuilderSave(state));
+
+    act(() => { result.current.handleExportPNG(); });
+    act(() => { fireRenderCallback(mockMap); });
+
+    expect(createGradientSpy).toHaveBeenCalled();
+    const stops = addColorStopSpy.mock.calls.map((c: unknown[]) => c[1]);
+    expect(stops).toEqual(['#111111', '#999999']);
+  });
+
+  it('an unparseable ramp color falls back to solid instead of aborting the export', () => {
+    const mockMap = makeExportMap();
+    // The empty-string second stop makes the mocked addColorStop throw (as the browser
+    // would). The export must still complete rather than failing entirely.
+    const badRamp = makeLayer({
+      id: 'layer-bad-ramp',
+      display_name: 'Bad ramp',
+      paint: {},
+      style_config: { colors: ['#111111', ''] } as MapLayerResponse['style_config'],
+      visible: true,
+      show_in_legend: true,
+    });
+    const state = makeSaveState({
+      localName: '',
+      localDescription: '',
+      localLayers: [badRamp],
+      mapInstanceRef: { current: mockMap } as unknown as SaveState['mapInstanceRef'],
+    });
+    const { result } = renderHook(() => useBuilderSave(state));
+
+    act(() => { result.current.handleExportPNG(); });
+    act(() => { fireRenderCallback(mockMap); });
+
+    // Gradient was attempted (and threw) ...
+    expect(createGradientSpy).toHaveBeenCalled();
+    // ... but the export ran to completion: the footer drew and the canvas serialized.
+    const texts = fillTextSpy.mock.calls.map((c: unknown[]) => String(c[0]));
+    expect(texts.some((t) => /poweredBy|Powered by GeoLens/.test(t))).toBe(true);
+    expect(toBlobSpy).toHaveBeenCalled();
   });
 
   it('renders Powered by GeoLens footer when isEnterprise is false', () => {

--- a/frontend/src/components/builder/hooks/__tests__/use-builder-save.test.ts
+++ b/frontend/src/components/builder/hooks/__tests__/use-builder-save.test.ts
@@ -1711,6 +1711,7 @@ describe('useBuilderSave', () => {
 describe('SHARE-09 export PNG composition', () => {
   let fillTextSpy: ReturnType<typeof vi.fn>;
   let fillRectSpy: ReturnType<typeof vi.fn>;
+  let strokeStyleAtStroke: string[];
   let createElementSpy: ReturnType<typeof vi.spyOn>;
 
   beforeEach(() => {
@@ -1720,16 +1721,19 @@ describe('SHARE-09 export PNG composition', () => {
 
     fillTextSpy = vi.fn();
     fillRectSpy = vi.fn();
+    strokeStyleAtStroke = [];
 
     const ctx2d = {
-      fillStyle: '',
+      fillStyle: '' as string | CanvasGradient,
       strokeStyle: '',
       font: '',
       textBaseline: '',
       lineWidth: 1,
       fillText: fillTextSpy,
       fillRect: fillRectSpy,
-      strokeRect: vi.fn(),
+      // Record the border color used for each swatch (stroke-color border).
+      strokeRect: vi.fn(() => { strokeStyleAtStroke.push(ctx2d.strokeStyle); }),
+      createLinearGradient: vi.fn(() => ({ addColorStop: vi.fn() })),
       drawImage: vi.fn(),
       measureText: vi.fn(() => ({ width: 120 })),
     };
@@ -1815,6 +1819,33 @@ describe('SHARE-09 export PNG composition', () => {
     expect(calls.some((text) => text === 'Streets')).toBe(true);
     // Color swatch fill rect for the qualifying layer
     expect(fillRectSpy).toHaveBeenCalled();
+  });
+
+  it('swatch border uses the layer stroke color for hollow-circle styles', () => {
+    const mockMap = makeExportMap();
+    // Light fill + colored stroke (hollow circle). The old export drew the near-white
+    // fill with a faint 0.15 border, so the swatch was effectively invisible.
+    const hollow = makeLayer({
+      id: 'layer-eruptions',
+      display_name: 'Eruptions',
+      dataset_geometry_type: 'MULTIPOINT',
+      paint: { 'circle-color': '#fff7ed', 'circle-stroke-color': '#ea580c' },
+      visible: true,
+      show_in_legend: true,
+    });
+    const state = makeSaveState({
+      localName: '',
+      localDescription: '',
+      localLayers: [hollow],
+      mapInstanceRef: { current: mockMap } as unknown as SaveState['mapInstanceRef'],
+    });
+    const { result } = renderHook(() => useBuilderSave(state));
+
+    act(() => { result.current.handleExportPNG(); });
+    act(() => { fireRenderCallback(mockMap); });
+
+    // The swatch border is the visible stroke color, not the transparent fallback.
+    expect(strokeStyleAtStroke).toContain('#ea580c');
   });
 
   it('renders Powered by GeoLens footer when isEnterprise is false', () => {

--- a/frontend/src/components/builder/hooks/__tests__/use-builder-save.test.ts
+++ b/frontend/src/components/builder/hooks/__tests__/use-builder-save.test.ts
@@ -1848,6 +1848,34 @@ describe('SHARE-09 export PNG composition', () => {
     expect(strokeStyleAtStroke).toContain('#ea580c');
   });
 
+  it('does not draw the stroke-color border when the stroke is disabled', () => {
+    const mockMap = makeExportMap();
+    // Stroke turned off in the builder leaves a stale circle-stroke-color in paint;
+    // the export must not reintroduce it as a border (mirrors the map, which hides it).
+    const disabled = makeLayer({
+      id: 'layer-eruptions-off',
+      display_name: 'Eruptions (no ring)',
+      dataset_geometry_type: 'MULTIPOINT',
+      paint: { 'circle-color': '#fff7ed', 'circle-stroke-color': '#ea580c', 'circle-stroke-width': 0 },
+      style_config: { builder: { strokeDisabled: true } } as MapLayerResponse['style_config'],
+      visible: true,
+      show_in_legend: true,
+    });
+    const state = makeSaveState({
+      localName: '',
+      localDescription: '',
+      localLayers: [disabled],
+      mapInstanceRef: { current: mockMap } as unknown as SaveState['mapInstanceRef'],
+    });
+    const { result } = renderHook(() => useBuilderSave(state));
+
+    act(() => { result.current.handleExportPNG(); });
+    act(() => { fireRenderCallback(mockMap); });
+
+    expect(strokeStyleAtStroke).not.toContain('#ea580c');
+    expect(strokeStyleAtStroke).toContain('rgba(0,0,0,0.35)');
+  });
+
   it('renders Powered by GeoLens footer when isEnterprise is false', () => {
     mockEdition.isEnterprise = false;
     const mockMap = makeExportMap();

--- a/frontend/src/components/builder/hooks/use-builder-save.ts
+++ b/frontend/src/components/builder/hooks/use-builder-save.ts
@@ -747,13 +747,20 @@ export function useBuilderSave(state: SaveState) {
                 layer.paint?.['circle-stroke-width'] === 0 ||
                 layer.paint?.['_outline-width'] === 0;
               const rowY = cursorY + (legendRowH - swatchSize) / 2;
+              const solidFill = colors.find((c) => !!c) || '#6366f1';
+              let filled = false;
               if (colors.length > 1) {
-                const grad = ctx.createLinearGradient(pad, 0, pad + swatchSize, 0);
-                colors.forEach((c, i) => grad.addColorStop(i / (colors.length - 1), c));
-                ctx.fillStyle = grad;
-              } else {
-                ctx.fillStyle = colors[0] || '#6366f1';
+                try {
+                  const grad = ctx.createLinearGradient(pad, 0, pad + swatchSize, 0);
+                  colors.forEach((c, i) => grad.addColorStop(i / (colors.length - 1), c));
+                  ctx.fillStyle = grad;
+                  filled = true;
+                } catch {
+                  // An unparseable ramp color makes addColorStop throw; fall back to a
+                  // solid swatch rather than aborting the whole export.
+                }
               }
+              if (!filled) ctx.fillStyle = solidFill;
               ctx.fillRect(pad, rowY, swatchSize, swatchSize);
               ctx.strokeStyle = (!strokeHidden && hints.strokeColor) || 'rgba(0,0,0,0.35)';
               ctx.lineWidth = Math.max(1, dpr);

--- a/frontend/src/components/builder/hooks/use-builder-save.ts
+++ b/frontend/src/components/builder/hooks/use-builder-save.ts
@@ -11,7 +11,7 @@ import { ApiError } from '@/api/client';
 import { useUpdateMap, useDuplicateMap, usePatchMapLayers } from '@/hooks/use-maps';
 import { useEnabledPlugins } from '@/hooks/use-settings';
 import { useEdition } from '@/hooks/use-edition';
-import { getLayerColors } from '@/components/map/layer-icons';
+import { getLayerColors, extractStyleHints } from '@/components/map/layer-icons';
 import { uploadThumbnail, uploadOgImage } from '@/api/maps';
 import { extractPlaceholders, validatePlaceholders } from '@/lib/popup-template';
 import type { MapBasemapConfig, MapLayerDiffRequest, MapLayerInput, MapLayerPatch, MapLayerResponse, MapResponse, MapTerrainConfig, MapUpdateRequest } from '@/types/api';
@@ -725,12 +725,28 @@ export function useBuilderSave(state: SaveState) {
             ctx.font = `400 ${13 * dpr}px system-ui, -apple-system, "Segoe UI", Roboto, sans-serif`;
             const swatchSize = 14 * dpr;
             for (const layer of legendLayers) {
+              // fix(#424): mirror the on-screen legend swatch — draw a gradient for
+              // multi-stop ramps (graduated/categorical/heatmap) and use the real
+              // stroke color as the border so hollow-circle styles (light fill +
+              // colored ring, e.g. #fff7ed fill / #ea580c stroke) don't export blank.
               const colors = getLayerColors(layer);
-              const colorVal = (typeof colors[0] === 'string' && colors[0]) || '#6366f1';
+              const hints = extractStyleHints(
+                layer.paint ?? {},
+                layer.layout ?? {},
+                layer.dataset_geometry_type,
+                undefined,
+                layer.style_config,
+              );
               const rowY = cursorY + (legendRowH - swatchSize) / 2;
-              ctx.fillStyle = colorVal;
+              if (colors.length > 1) {
+                const grad = ctx.createLinearGradient(pad, 0, pad + swatchSize, 0);
+                colors.forEach((c, i) => grad.addColorStop(i / (colors.length - 1), c));
+                ctx.fillStyle = grad;
+              } else {
+                ctx.fillStyle = colors[0] || '#6366f1';
+              }
               ctx.fillRect(pad, rowY, swatchSize, swatchSize);
-              ctx.strokeStyle = 'rgba(0,0,0,0.15)';
+              ctx.strokeStyle = hints.strokeColor || 'rgba(0,0,0,0.35)';
               ctx.lineWidth = Math.max(1, dpr);
               ctx.strokeRect(pad, rowY, swatchSize, swatchSize);
               ctx.fillStyle = '#0a0a0a';

--- a/frontend/src/components/builder/hooks/use-builder-save.ts
+++ b/frontend/src/components/builder/hooks/use-builder-save.ts
@@ -737,6 +737,15 @@ export function useBuilderSave(state: SaveState) {
                 undefined,
                 layer.style_config,
               );
+              // A stroke the user turned off lives in builder.strokeDisabled (which
+              // leaves a stale circle-stroke-color in paint) or a zeroed width, but
+              // extractStyleHints only honors paint['_stroke-disabled']. Resolve it the
+              // way the map adapters do so the export doesn't reintroduce a hidden ring.
+              const builder = layer.style_config?.builder;
+              const strokeHidden =
+                (builder?.strokeDisabled ?? !!layer.paint?.['_stroke-disabled']) ||
+                layer.paint?.['circle-stroke-width'] === 0 ||
+                layer.paint?.['_outline-width'] === 0;
               const rowY = cursorY + (legendRowH - swatchSize) / 2;
               if (colors.length > 1) {
                 const grad = ctx.createLinearGradient(pad, 0, pad + swatchSize, 0);
@@ -746,7 +755,7 @@ export function useBuilderSave(state: SaveState) {
                 ctx.fillStyle = colors[0] || '#6366f1';
               }
               ctx.fillRect(pad, rowY, swatchSize, swatchSize);
-              ctx.strokeStyle = hints.strokeColor || 'rgba(0,0,0,0.35)';
+              ctx.strokeStyle = (!strokeHidden && hints.strokeColor) || 'rgba(0,0,0,0.35)';
               ctx.lineWidth = Math.max(1, dpr);
               ctx.strokeRect(pad, rowY, swatchSize, swatchSize);
               ctx.fillStyle = '#0a0a0a';


### PR DESCRIPTION
## Problem

The map-builder **Download PNG** export composited a legend where every entry was a single flat square using the layer's **fill** color with a near-transparent (`rgba(0,0,0,0.15)`) border. Two failure modes:

- **Invisible swatches for hollow-circle styles.** Point layers styled as a light fill + colored stroke exported as a blank white box — the real color is the stroke. On the *Restless Earth* showcase map, "Major eruptions" (`#fff7ed` fill / `#ea580c` stroke) and "Major cities" (`#e2e8f0` fill / `#0b0f14` stroke) both rendered as blank squares.
- **Ramps collapsed to one color.** Graduated/categorical/heatmap layers showed only `getLayerColors(layer)[0]` (the first ramp stop), losing the rest of the ramp the on-screen legend shows.

## Fix

In `handleExportPNG`'s legend loop (`frontend/src/components/builder/hooks/use-builder-save.ts`):

- Use the layer's real **stroke color** (`extractStyleHints().strokeColor`) as the swatch border, with a darker neutral fallback, so hollow-circle styles are visible.
- Draw a **linear gradient** across the swatch when the layer has a multi-stop ramp, so graduated/categorical/heatmap layers read as ramps.

This reuses the same `getLayerColors` / `extractStyleHints` helpers the on-screen legend already uses, so the export tracks the live legend instead of diverging.

## Verification

- `npm run build`, `npm run typecheck`, `npm run lint` — clean.
- `use-builder-save.test.ts` — 61/61 pass, including a new pin asserting the swatch border uses the layer's stroke color for a hollow-circle style.
- Live smoke check against the running backend via local Vite dev: exported the *Restless Earth* PNG (graduated points, categorical lines, heatmap, raster). Previously-blank "Major eruptions" and "Major cities" swatches now render with orange/dark borders; graduated/categorical layers render as gradients.

## Impact

Frontend-only, scoped to the PNG export legend. No schema/API/OpenAPI/SDK/i18n changes.

https://claude.ai/code/session_01N161FvzP863aYUDGCAboBy