### PR TITLE
chore: pre-announcement cleanup — Beta classifiers + fix ingest-progress flake

### DIFF
--- a/backend/tests/test_ingest_progress.py
+++ b/backend/tests/test_ingest_progress.py
@@ -309,8 +309,16 @@ async def test_service_worker_advances_ogr2ogr_progress_while_remote_import_is_r
             await asyncio.sleep(0.01)
     finally:
         release_remote_import.set()
+        # fix(#422): join the worker directly instead of wait_for(timeout=2).
+        # Under CI load the timeout fires and cancels worker_task mid-teardown,
+        # where the product code's suppress(CancelledError) swallows the
+        # injected cancel — wait_for then sets a cancelled result on a task that
+        # completes normally, raising asyncio InvalidStateError. Releasing the
+        # blocked import makes the worker raise and finish deterministically, so
+        # a plain await never races (a genuine hang surfaces via the CI job
+        # timeout instead of a corrupted future).
         try:
-            await asyncio.wait_for(worker_task, timeout=2)
+            await worker_task
         except Exception as exc:
             worker_error = exc
 

--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -12,7 +12,7 @@ requires-python = ">=3.11"
 authors = [{ name = "Carto Concepts, LLC", email = "noreply@getgeolens.com" }]
 keywords = ["geolens", "geospatial", "cli", "stac", "openapi"]
 classifiers = [
-  "Development Status :: 5 - Production/Stable",
+  "Development Status :: 4 - Beta",
   "Environment :: Console",
   "Intended Audience :: Developers",
   "Intended Audience :: Science/Research",

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -12,7 +12,7 @@ requires-python = ">=3.10"
 authors = [{ name = "Carto Concepts, LLC", email = "noreply@getgeolens.com" }]
 keywords = ["geolens", "geospatial", "openapi", "sdk"]
 classifiers = [
-  "Development Status :: 5 - Production/Stable",
+  "Development Status :: 4 - Beta",
   "Intended Audience :: Developers",
   "License :: OSI Approved :: Apache Software License",
   "Programming Language :: Python :: 3",


### PR DESCRIPTION
Two small pre-announcement hygiene fixes. No runtime/API/schema impact.

## 1. Package classifiers → Beta
`cli/pyproject.toml` and `sdks/python/pyproject.toml` declared
`Development Status :: 5 - Production/Stable`, contradicting the repo's own
`README.md` "Early release … young … APIs may still change" copy. Downgraded
both to `4 - Beta` so PyPI metadata matches the stated maturity. Takes effect
on the next publish; no test pins the classifier.

## 2. Fix `test_service_worker_advances_ogr2ogr_progress_while_remote_import_is_running` flake
Addresses #422 (asyncio `InvalidStateError`, intermittent under CI load).

Root cause is in the test harness, not the product. The teardown used
`asyncio.wait_for(worker_task, timeout=2)`. Under CI load the timeout fires and
cancels the worker mid-teardown, where the product code's
`suppress(asyncio.CancelledError)` (`tasks_vector.py`) swallows the injected
cancel — so `wait_for` sets a cancelled result on a task that then completes
normally, raising `InvalidStateError`. Releasing the blocked import already
makes the worker raise and finish deterministically, so the timeout was pure
downside. Replaced with a plain `await worker_task`.

## Verification
- `python -m py_compile` on the test file: clean.
- Pre-commit (ruff check/format, secrets, gate hooks): pass.
- Happy path is unchanged by inspection — the flake is load-only and does not
  reproduce locally (passes 5/5). Leaving #422 open until CI confirms stability.

## Not included
- #401 (anon-read SDK auth) — deferred; needs an OpenAPI-contract + SDK
  regen/republish decision, scoped separately.