### PR TITLE
fix(i18n): route remaining hardcoded UI strings through t() (#427)

### DIFF
--- a/frontend/src/components/admin/settings/SettingsAuthTab.tsx
+++ b/frontend/src/components/admin/settings/SettingsAuthTab.tsx
@@ -440,7 +440,7 @@ function OAuthProvidersSection({ envOnly }: { envOnly: boolean }) {
                   id="tenant-id"
                   value={form.microsoft_tenant_id}
                   onChange={(e) => handleTenantIdChange(e.target.value)}
-                  placeholder="e.g. your-tenant-id"
+                  placeholder={t('settings.oauth.tenantIdPlaceholder')}
                   disabled={envOnly}
                 />
                 <p className="text-xs text-muted-foreground">

--- a/frontend/src/components/admin/settings/SettingsNetworkTab.tsx
+++ b/frontend/src/components/admin/settings/SettingsNetworkTab.tsx
@@ -26,22 +26,24 @@ const FIELDS = [
 ] as const;
 
 function NotificationChannelBadge({ ok, label }: { ok: boolean; label: string }) {
+  const { t } = useTranslation('admin');
   return (
     <span className="inline-flex items-center gap-1">
       <span className="text-sm text-muted-foreground">{label}:</span>
-      <Badge variant={ok ? 'default' : 'secondary'}>{ok ? 'Yes' : 'No'}</Badge>
+      <Badge variant={ok ? 'default' : 'secondary'}>{ok ? t('common:yes') : t('common:no')}</Badge>
     </span>
   );
 }
 
 function ChannelResult({ result }: { result: NotificationTestChannelResult }) {
+  const { t } = useTranslation('admin');
   return (
     <div className="flex items-center gap-2 text-sm">
       <Badge variant={result.ok ? 'default' : 'destructive'}>{result.channel}</Badge>
       {result.ok ? (
-        <span className="text-muted-foreground">Delivered</span>
+        <span className="text-muted-foreground">{t('settings.notifications.delivered')}</span>
       ) : (
-        <span className="text-destructive">{result.error ?? 'Failed'}</span>
+        <span className="text-destructive">{result.error ?? t('settings.notifications.failed')}</span>
       )}
     </div>
   );
@@ -115,7 +117,7 @@ export function SettingsNetworkTab({ settings, envOnly, onSave, onReset, isSavin
         </div>
 
         {notifLoading ? (
-          <p className="text-sm text-muted-foreground">Loading...</p>
+          <p className="text-sm text-muted-foreground">{t('common:loading')}</p>
         ) : notifStatus ? (
           <div className="flex flex-wrap gap-4">
             <NotificationChannelBadge ok={notifStatus.notifications_enabled} label={t('settings.notifications.statusEnabled')} />
@@ -131,7 +133,7 @@ export function SettingsNetworkTab({ settings, envOnly, onSave, onReset, isSavin
             onClick={handleSendTest}
             disabled={testSend.isPending}
           >
-            {testSend.isPending ? 'Sending...' : t('settings.notifications.sendTest')}
+            {testSend.isPending ? t('settings.notifications.sending') : t('settings.notifications.sendTest')}
           </Button>
         </div>
 

--- a/frontend/src/components/builder/ChatPanel.tsx
+++ b/frontend/src/components/builder/ChatPanel.tsx
@@ -1103,7 +1103,7 @@ export function ChatPanel({
                                   {col}
                                 </th>
                               ))}
-                              {hasMore && <th scope="col" aria-label="more columns" className="px-2 py-1 text-xs font-medium text-muted-foreground">…</th>}
+                              {hasMore && <th scope="col" aria-label={t('common:viewer.ai.queryResult.moreColumns')} className="px-2 py-1 text-xs font-medium text-muted-foreground">…</th>}
                             </tr>
                           </thead>
                           <tbody>

--- a/frontend/src/components/builder/EmptyStackState.tsx
+++ b/frontend/src/components/builder/EmptyStackState.tsx
@@ -186,7 +186,7 @@ export function EmptyStackState({ onOpenAddData, onAddDataset }: EmptyStackState
   return (
     <div
       role="region"
-      aria-label="No layers — get started"
+      aria-label={t('unifiedStack.emptyRegionLabel', { defaultValue: 'No layers — get started' })}
       className="flex flex-col gap-4 p-4 pb-2"
     >
       {/* Prompt */}
@@ -211,7 +211,7 @@ export function EmptyStackState({ onOpenAddData, onAddDataset }: EmptyStackState
       >
         <button
           type="button"
-          aria-label="Search and open Add Data modal"
+          aria-label={t('unifiedStack.emptySearchButton', { defaultValue: 'Search and open Add Data modal' })}
           onClick={() => {
             if (inlineQuery.trim()) {
               onOpenAddData(inlineQuery.trim());
@@ -223,7 +223,7 @@ export function EmptyStackState({ onOpenAddData, onAddDataset }: EmptyStackState
         </button>
         <input
           role="searchbox"
-          aria-label="Search datasets to add"
+          aria-label={t('unifiedStack.emptySearchInput', { defaultValue: 'Search datasets to add' })}
           placeholder={t('unifiedStack.emptySearchPlaceholder', { defaultValue: 'Search datasets, URLs, or files…' })}
           value={inlineQuery}
           onChange={(e) => setInlineQuery(e.target.value)}
@@ -241,7 +241,7 @@ export function EmptyStackState({ onOpenAddData, onAddDataset }: EmptyStackState
           >
             {t('unifiedStack.suggestedLabel', { defaultValue: 'SUGGESTED' })}
           </span>
-          <ul aria-label="Suggested datasets" className="flex flex-col gap-2">
+          <ul aria-label={t('unifiedStack.suggestedListLabel', { defaultValue: 'Suggested datasets' })} className="flex flex-col gap-2">
             {SUGGESTED_DATASETS.map((suggestion) => (
               <SuggestCard
                 key={suggestion.id}
@@ -266,7 +266,7 @@ export function EmptyStackState({ onOpenAddData, onAddDataset }: EmptyStackState
       {/* Browse all */}
       <button
         type="button"
-        aria-label="Browse all datasets in the Add Data modal"
+        aria-label={t('unifiedStack.browseAllLabel', { defaultValue: 'Browse all datasets in the Add Data modal' })}
         onClick={() => onOpenAddData()}
         className="text-xs text-primary self-start hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded"
       >

--- a/frontend/src/components/builder/MapTitleBar.tsx
+++ b/frontend/src/components/builder/MapTitleBar.tsx
@@ -82,7 +82,7 @@ export function MapTitleBar({
   return (
     <div className="h-10 border-b bg-background flex items-center gap-3 px-3 shrink-0">
       {/* Breadcrumb: Maps > editable name */}
-      <nav aria-label="breadcrumb" className="flex items-center gap-1.5 min-w-0 flex-1">
+      <nav aria-label={t('common:breadcrumb.label')} className="flex items-center gap-1.5 min-w-0 flex-1">
         <Link
           to="/maps"
           className="text-sm text-muted-foreground hover:text-foreground transition-colors shrink-0"

--- a/frontend/src/components/builder/UnifiedStackPanel.tsx
+++ b/frontend/src/components/builder/UnifiedStackPanel.tsx
@@ -540,7 +540,7 @@ export const UnifiedStackPanel = memo(function UnifiedStackPanel({
             data-testid={`basemap-group-children-${basemapGroup.id}`}
             style={{ marginLeft: '28px', paddingLeft: '12px', borderLeft: '1px dashed var(--border)' }}
             role="list"
-            aria-label="Basemap sublayers"
+            aria-label={t('unifiedStack.basemapSublayers')}
           >
             {basemapGroup.sublayers.map((sub) => (
               <SublayerRow

--- a/frontend/src/components/dataset/tabs/AccessTab.tsx
+++ b/frontend/src/components/dataset/tabs/AccessTab.tsx
@@ -200,7 +200,7 @@ function ApiSnippet({
             className="px-2 py-0.5 rounded text-[11px] font-mono bg-(--code-chrome-border) text-(--code-text)/80 hover:text-(--code-text) cursor-pointer border-0"
           >
             {copied ? <Check className="inline size-3 me-1" /> : <Copy className="inline size-3 me-1" />}
-            {copied ? 'Copied' : 'Copy'}
+            {copied ? t('common:copied') : t('common:copy')}
           </button>
         </div>
         <pre className="px-5 py-4 font-mono text-[12.5px] leading-7 overflow-x-auto whitespace-pre-wrap m-0">

--- a/frontend/src/components/map/FeaturePopup.tsx
+++ b/frontend/src/components/map/FeaturePopup.tsx
@@ -352,7 +352,7 @@ function ValueDisplay({
         <span className="block">
           <iframe
             src={srcUrl}
-            title="YouTube video"
+            title={t('featurePopup.youtubeTitle')}
             sandbox="allow-scripts allow-same-origin allow-presentation"
             referrerPolicy="no-referrer-when-downgrade"
             loading="lazy"

--- a/frontend/src/components/viewer/ViewerChatPanel.tsx
+++ b/frontend/src/components/viewer/ViewerChatPanel.tsx
@@ -64,7 +64,7 @@ function QueryResultTable({ result }: { result: QueryResult }) {
                   {col}
                 </th>
               ))}
-              {hasMore && <th scope="col" aria-label="more columns" className="px-2 py-1 text-xs text-muted-foreground">…</th>}
+              {hasMore && <th scope="col" aria-label={t('viewer.ai.queryResult.moreColumns')} className="px-2 py-1 text-xs text-muted-foreground">…</th>}
             </tr>
           </thead>
           <tbody>

--- a/frontend/src/i18n/locales/de/admin.json
+++ b/frontend/src/i18n/locales/de/admin.json
@@ -610,7 +610,8 @@
       "copyCallbackUrl": "Callback-URL kopieren",
       "callbackUrlCopied": "Callback-URL in die Zwischenablage kopiert",
       "callbackUrlHint": "Registrieren Sie diese URL bei Ihrem Anbieter (Google, Microsoft oder GitHub) als autorisierte Weiterleitungs-/Callback-URL. Sie muss der konfigurierten öffentlichen API-URL der Installation entsprechen (PUBLIC_API_URL bzw. die öffentliche API-URL in den allgemeinen Einstellungen setzen), sonst schlägt die OAuth-Anmeldung mit einem Redirect-Fehler fehl.",
-      "callbackUrlCopyFailed": "Konnte nicht kopiert werden — kopieren Sie die URL manuell."
+      "callbackUrlCopyFailed": "Konnte nicht kopiert werden — kopieren Sie die URL manuell.",
+      "tenantIdPlaceholder": "z. B. ihre-mandanten-id"
     },
     "notifications": {
       "title": "Ausgehende Benachrichtigungen",
@@ -622,7 +623,10 @@
       "testSuccess": "Testbenachrichtigung gesendet",
       "testNoChannel": "Kein Kanal konfiguriert",
       "testError": "Testversand fehlgeschlagen",
-      "testFailed": "Testbenachrichtigung fehlgeschlagen"
+      "testFailed": "Testbenachrichtigung fehlgeschlagen",
+      "delivered": "Zugestellt",
+      "failed": "Fehlgeschlagen",
+      "sending": "Senden..."
     }
   },
   "infrastructure": {

--- a/frontend/src/i18n/locales/de/builder.json
+++ b/frontend/src/i18n/locales/de/builder.json
@@ -693,7 +693,8 @@
     "prev": "Vorheriges Objekt",
     "next": "Nächstes Objekt",
     "close": "Popup schließen",
-    "dialogLabel": "Objektdetails"
+    "dialogLabel": "Objektdetails",
+    "youtubeTitle": "YouTube-Video"
   },
   "descriptionPlaceholder": "Beschreibung hinzufügen...",
   "titleBar": {
@@ -1018,7 +1019,13 @@
     "emptyHelpBody": "Den Katalog durchsuchen, um Datensätze zu finden, oder die Schaltfläche \"Hochladen\" verwenden, um eigene hinzuzufügen.",
     "listboxLabel": "Karten-Layer",
     "searchPlaceholder": "Layer filtern…",
-    "searchAriaLabel": "Layer nach Name filtern"
+    "searchAriaLabel": "Layer nach Name filtern",
+    "emptyRegionLabel": "Keine Layer — loslegen",
+    "emptySearchButton": "Suchen und Dialog „Daten hinzufügen“ öffnen",
+    "emptySearchInput": "Datensätze zum Hinzufügen suchen",
+    "suggestedListLabel": "Vorgeschlagene Datensätze",
+    "browseAllLabel": "Alle Datensätze im Dialog „Daten hinzufügen“ durchsuchen",
+    "basemapSublayers": "Basiskarten-Sublayer"
   },
   "rail": {
     "aiDisabled": "KI durch Administrator deaktiviert",

--- a/frontend/src/i18n/locales/de/common.json
+++ b/frontend/src/i18n/locales/de/common.json
@@ -253,7 +253,8 @@
         "tableLabel": "Tabelle der Abfrageergebnisse",
         "rowCount_one": "{{count}} Zeile",
         "rowCount_other": "{{count}} Zeilen",
-        "truncated": "(Stichprobe wird angezeigt)"
+        "truncated": "(Stichprobe wird angezeigt)",
+        "moreColumns": "weitere Spalten"
       }
     }
   },
@@ -483,5 +484,9 @@
     "noSpatialExtent": "Keine räumliche Ausdehnung verfügbar"
   },
   "unknown": "Unbekannt",
-  "demoBanner": "Dies ist ein Demo-Konto — Ihre Daten können jederzeit gelöscht werden."
+  "demoBanner": "Dies ist ein Demo-Konto — Ihre Daten können jederzeit gelöscht werden.",
+  "yes": "Ja",
+  "no": "Nein",
+  "copy": "Kopieren",
+  "copied": "Kopiert"
 }

--- a/frontend/src/i18n/locales/en/admin.json
+++ b/frontend/src/i18n/locales/en/admin.json
@@ -540,7 +540,10 @@
       "testSuccess": "Test notification sent",
       "testNoChannel": "No channel configured",
       "testError": "Test send failed",
-      "testFailed": "Test notification failed"
+      "testFailed": "Test notification failed",
+      "delivered": "Delivered",
+      "failed": "Failed",
+      "sending": "Sending..."
     },
     "security": {
       "title": "Security",
@@ -647,7 +650,8 @@
       "copyCallbackUrl": "Copy callback URL",
       "callbackUrlCopied": "Callback URL copied to clipboard",
       "callbackUrlHint": "Register this URL with your provider (Google, Microsoft, or GitHub) as the authorized redirect / callback URL. It must match the deployment’s configured Public API URL (set PUBLIC_API_URL, or the Public API URL in General settings), or OAuth sign-in fails with a redirect mismatch.",
-      "callbackUrlCopyFailed": "Could not copy — copy the URL manually."
+      "callbackUrlCopyFailed": "Could not copy — copy the URL manually.",
+      "tenantIdPlaceholder": "e.g. your-tenant-id"
     }
   },
   "saml": {

--- a/frontend/src/i18n/locales/en/builder.json
+++ b/frontend/src/i18n/locales/en/builder.json
@@ -693,7 +693,8 @@
     "prev": "Previous feature",
     "next": "Next feature",
     "close": "Close popup",
-    "dialogLabel": "Feature details"
+    "dialogLabel": "Feature details",
+    "youtubeTitle": "YouTube video"
   },
   "descriptionPlaceholder": "Add a description...",
   "titleBar": {
@@ -1022,7 +1023,13 @@
     "emptyHelpBody": "Search the catalog to find datasets, or use the Upload button to add your own.",
     "listboxLabel": "Map layers",
     "searchPlaceholder": "Filter layers…",
-    "searchAriaLabel": "Filter layers by name"
+    "searchAriaLabel": "Filter layers by name",
+    "emptyRegionLabel": "No layers — get started",
+    "emptySearchButton": "Search and open Add Data modal",
+    "emptySearchInput": "Search datasets to add",
+    "suggestedListLabel": "Suggested datasets",
+    "browseAllLabel": "Browse all datasets in the Add Data modal",
+    "basemapSublayers": "Basemap sublayers"
   },
   "rail": {
     "aiDisabled": "AI disabled by admin",

--- a/frontend/src/i18n/locales/en/common.json
+++ b/frontend/src/i18n/locales/en/common.json
@@ -161,7 +161,8 @@
         "tableLabel": "Query result table",
         "rowCount_one": "{{count}} row",
         "rowCount_other": "{{count}} rows",
-        "truncated": "(showing a sample)"
+        "truncated": "(showing a sample)",
+        "moreColumns": "more columns"
       }
     }
   },
@@ -483,5 +484,9 @@
     "poweredBy": "Powered by GeoLens",
     "legendHeader": "Legend"
   },
-  "demoBanner": "This is a demo account — your data may be wiped at any time."
+  "demoBanner": "This is a demo account — your data may be wiped at any time.",
+  "yes": "Yes",
+  "no": "No",
+  "copy": "Copy",
+  "copied": "Copied"
 }

--- a/frontend/src/i18n/locales/es/admin.json
+++ b/frontend/src/i18n/locales/es/admin.json
@@ -610,7 +610,8 @@
       "copyCallbackUrl": "Copiar URL de devolución de llamada",
       "callbackUrlCopied": "URL de devolución de llamada copiada al portapapeles",
       "callbackUrlHint": "Registra esta URL en tu proveedor (Google, Microsoft o GitHub) como la URL de redirección / devolución autorizada. Debe coincidir con la URL pública de la API configurada en el despliegue (define PUBLIC_API_URL o la URL pública de la API en Configuración general); de lo contrario, el inicio de sesión OAuth fallará por una redirección no coincidente.",
-      "callbackUrlCopyFailed": "No se pudo copiar; copia la URL manualmente."
+      "callbackUrlCopyFailed": "No se pudo copiar; copia la URL manualmente.",
+      "tenantIdPlaceholder": "p. ej. su-id-de-inquilino"
     },
     "notifications": {
       "title": "Notificaciones salientes",
@@ -622,7 +623,10 @@
       "testSuccess": "Notificación de prueba enviada",
       "testNoChannel": "Ningún canal configurado",
       "testError": "Error al enviar la prueba",
-      "testFailed": "Notificación de prueba fallida"
+      "testFailed": "Notificación de prueba fallida",
+      "delivered": "Entregado",
+      "failed": "Fallido",
+      "sending": "Enviando..."
     }
   },
   "infrastructure": {

--- a/frontend/src/i18n/locales/es/builder.json
+++ b/frontend/src/i18n/locales/es/builder.json
@@ -693,7 +693,8 @@
     "prev": "Elemento anterior",
     "next": "Elemento siguiente",
     "close": "Cerrar popup",
-    "dialogLabel": "Detalles del elemento"
+    "dialogLabel": "Detalles del elemento",
+    "youtubeTitle": "Vídeo de YouTube"
   },
   "descriptionPlaceholder": "Agregar una descripción...",
   "titleBar": {
@@ -1018,7 +1019,13 @@
     "emptyHelpBody": "Busque en el catálogo para encontrar conjuntos de datos, o use el botón Cargar para agregar los suyos.",
     "listboxLabel": "Capas del mapa",
     "searchPlaceholder": "Filtrar capas…",
-    "searchAriaLabel": "Filtrar capas por nombre"
+    "searchAriaLabel": "Filtrar capas por nombre",
+    "emptyRegionLabel": "Sin capas — empezar",
+    "emptySearchButton": "Buscar y abrir el cuadro Agregar datos",
+    "emptySearchInput": "Buscar conjuntos de datos para agregar",
+    "suggestedListLabel": "Conjuntos de datos sugeridos",
+    "browseAllLabel": "Explorar todos los conjuntos de datos en el cuadro Agregar datos",
+    "basemapSublayers": "Subcapas del mapa base"
   },
   "rail": {
     "aiDisabled": "IA desactivada por el administrador",

--- a/frontend/src/i18n/locales/es/common.json
+++ b/frontend/src/i18n/locales/es/common.json
@@ -253,7 +253,8 @@
         "tableLabel": "Tabla de resultados de la consulta",
         "rowCount_one": "{{count}} fila",
         "rowCount_other": "{{count}} filas",
-        "truncated": "(mostrando una muestra)"
+        "truncated": "(mostrando una muestra)",
+        "moreColumns": "más columnas"
       }
     }
   },
@@ -483,5 +484,9 @@
     "noSpatialExtent": "No hay extensión espacial disponible"
   },
   "unknown": "Desconocido",
-  "demoBanner": "Esta es una cuenta de demostración — sus datos pueden eliminarse en cualquier momento."
+  "demoBanner": "Esta es una cuenta de demostración — sus datos pueden eliminarse en cualquier momento.",
+  "yes": "Sí",
+  "no": "No",
+  "copy": "Copiar",
+  "copied": "Copiado"
 }

--- a/frontend/src/i18n/locales/fr/admin.json
+++ b/frontend/src/i18n/locales/fr/admin.json
@@ -610,7 +610,8 @@
       "copyCallbackUrl": "Copier l'URL de rappel",
       "callbackUrlCopied": "URL de rappel copiée dans le presse-papiers",
       "callbackUrlHint": "Enregistrez cette URL auprès de votre fournisseur (Google, Microsoft ou GitHub) comme URL de redirection / de rappel autorisée. Elle doit correspondre à l’URL publique de l’API configurée pour le déploiement (définissez PUBLIC_API_URL ou l’URL publique de l’API dans les paramètres généraux), sinon la connexion OAuth échouera avec une redirection non concordante.",
-      "callbackUrlCopyFailed": "Impossible de copier — copiez l’URL manuellement."
+      "callbackUrlCopyFailed": "Impossible de copier — copiez l’URL manuellement.",
+      "tenantIdPlaceholder": "p. ex. votre-id-de-locataire"
     },
     "notifications": {
       "title": "Notifications sortantes",
@@ -622,7 +623,10 @@
       "testSuccess": "Notification de test envoyée",
       "testNoChannel": "Aucun canal configuré",
       "testError": "Échec de l’envoi du test",
-      "testFailed": "Échec de la notification de test"
+      "testFailed": "Échec de la notification de test",
+      "delivered": "Livré",
+      "failed": "Échoué",
+      "sending": "Envoi..."
     }
   },
   "infrastructure": {

--- a/frontend/src/i18n/locales/fr/builder.json
+++ b/frontend/src/i18n/locales/fr/builder.json
@@ -693,7 +693,8 @@
     "prev": "Entité précédente",
     "next": "Entité suivante",
     "close": "Fermer la popup",
-    "dialogLabel": "Détails de l'entité"
+    "dialogLabel": "Détails de l'entité",
+    "youtubeTitle": "Vidéo YouTube"
   },
   "descriptionPlaceholder": "Ajouter une description...",
   "titleBar": {
@@ -1018,7 +1019,13 @@
     "emptyHelpBody": "Recherchez dans le catalogue pour trouver des jeux de données, ou utilisez le bouton Importer pour ajouter les vôtres.",
     "listboxLabel": "Couches de la carte",
     "searchPlaceholder": "Filtrer les couches…",
-    "searchAriaLabel": "Filtrer les couches par nom"
+    "searchAriaLabel": "Filtrer les couches par nom",
+    "emptyRegionLabel": "Aucune couche — commencer",
+    "emptySearchButton": "Rechercher et ouvrir la fenêtre Ajouter des données",
+    "emptySearchInput": "Rechercher des jeux de données à ajouter",
+    "suggestedListLabel": "Jeux de données suggérés",
+    "browseAllLabel": "Parcourir tous les jeux de données dans la fenêtre Ajouter des données",
+    "basemapSublayers": "Sous-couches du fond de carte"
   },
   "rail": {
     "aiDisabled": "IA désactivée par l'administrateur",

--- a/frontend/src/i18n/locales/fr/common.json
+++ b/frontend/src/i18n/locales/fr/common.json
@@ -253,7 +253,8 @@
         "tableLabel": "Tableau des résultats de la requête",
         "rowCount_one": "{{count}} ligne",
         "rowCount_other": "{{count}} lignes",
-        "truncated": "(affichage d'un échantillon)"
+        "truncated": "(affichage d'un échantillon)",
+        "moreColumns": "plus de colonnes"
       }
     }
   },
@@ -483,5 +484,9 @@
     "noSpatialExtent": "Aucune étendue spatiale disponible"
   },
   "unknown": "Inconnu",
-  "demoBanner": "Ceci est un compte de démonstration — vos données peuvent être supprimées à tout moment."
+  "demoBanner": "Ceci est un compte de démonstration — vos données peuvent être supprimées à tout moment.",
+  "yes": "Oui",
+  "no": "Non",
+  "copy": "Copier",
+  "copied": "Copié"
 }


### PR DESCRIPTION
Closes #427. Follow-up to #426, which fixed the visible untranslated import-flow text; this wires the lower-visibility hardcoded strings the completeness audit found through `t()`, each with real es/fr/de translations (not copied-from-EN).

## What changed

**Screen-reader `aria-label` / iframe `title` (shipped untranslated to AT):**
- `builder/EmptyStackState.tsx` — 5 aria-labels (region, search button, search input, suggested list, browse-all)
- `builder/UnifiedStackPanel.tsx` — "Basemap sublayers"
- `viewer/ViewerChatPanel.tsx` + `builder/ChatPanel.tsx` — "more columns"
- `builder/MapTitleBar.tsx` — breadcrumb (reuses existing `common:breadcrumb.label`)
- `map/FeaturePopup.tsx` — YouTube iframe `title` (public viewer)

**Admin (visible text):**
- `admin/settings/SettingsNetworkTab.tsx` — Yes/No, Delivered, Failed, Loading, plus the adjacent hardcoded "Sending…" (one line off, folded in)
- `admin/settings/SettingsAuthTab.tsx` — `e.g. your-tenant-id` placeholder

**Dataset (visible text):**
- `dataset/tabs/AccessTab.tsx` — Copy/Copied

## Keys
16 new keys × 4 locales (en/es/fr/de). Reused strings (`yes`/`no`/`copy`/`copied`/`viewer.ai.queryResult.moreColumns`) went into the shared `common` namespace; component-specific labels into their own namespace. `Loading` and `breadcrumb.label` reuse existing `common` keys. Translations follow existing repo terminology (capas/couches/Layer, mapa base/fond de carte/Basiskarte, `p. ej.`/`p. ex.`/`z. B.`) and the German „…“ quote convention.

## Verification
- `npm run typecheck` (tsc -b) ✓
- `npm run test:i18n` (parity + source-key guard) ✓
- Full vitest suite: **3301/3301** ✓
- ESLint on all touched files ✓
- Existing tests asserting the old literals still pass (EN values preserved verbatim); e2e locators unaffected (case-insensitive/substring on preserved EN strings).

@codex please review.

https://claude.ai/code/session_01PJgR74ykezc7hmfu7xJWXL