### PR TITLE
fix(builder,viewer): render mixed-family GEOMETRY layers with per-family sublayers

### DIFF
--- a/frontend/src/components/builder/BuilderMap.tsx
+++ b/frontend/src/components/builder/BuilderMap.tsx
@@ -46,6 +46,8 @@ import {
 } from './map-sync';
 import { resolveTerrainSourceLayer } from './map-stack';
 import { getClusterSourceOptions } from './layer-adapters/cluster-adapter';
+import { isGenericGeometryType } from './layer-adapters/shared';
+import { mixedInteractiveLayerIds } from './layer-adapters/mixed-adapter';
 import type { AdapterLayerInput } from './layer-adapters/types';
 import { maybeWarnSmallDemCoverage, resetSmallDemWarning } from './terrain-coverage';
 import { applyMapBasemapAppearance, syncMapComposition } from './map-composition-sync';
@@ -708,7 +710,12 @@ export const BuilderMap = memo(function BuilderMap({
       .filter((l) => l.visible && l.layer_type !== 'raster_geolens')
       .flatMap((l) => {
         const layerId = getLayerId(l.id);
-        return isClusterRenderMode(l) ? clusterInteractiveLayerIds(layerId) : [layerId];
+        // fix(#430 codex r23): mixed-geometry layers spread hits across
+        // per-family sublayers — include them so point/line features stay
+        // clickable (the getLayer filter below drops any that don't exist).
+        if (isClusterRenderMode(l)) return clusterInteractiveLayerIds(layerId);
+        if (isGenericGeometryType(l.dataset_geometry_type)) return mixedInteractiveLayerIds(layerId);
+        return [layerId];
       })
       .filter((id) => map.getLayer(id));
   }, []);
@@ -796,7 +803,11 @@ export const BuilderMap = memo(function BuilderMap({
       // `activateClusterFeature(map, feature, hit.sourceId)` (line 544)
       // continues to receive the cluster's per-layer source id.
       const sourceId = getSourceIdForLayer(l);
-      const ids = isClusterRenderMode(l) ? clusterInteractiveLayerIds(layerId) : [layerId];
+      const ids = isClusterRenderMode(l)
+        ? clusterInteractiveLayerIds(layerId)
+        : isGenericGeometryType(l.dataset_geometry_type)
+          ? mixedInteractiveLayerIds(layerId)
+          : [layerId];
       for (const id of ids) byMapId.set(id, { layer: l, sourceId });
     }
     layerByMapIdRef.current = byMapId;

--- a/frontend/src/components/builder/LayerStyleEditor.tsx
+++ b/frontend/src/components/builder/LayerStyleEditor.tsx
@@ -145,11 +145,10 @@ export const LayerStyleEditor = memo(function LayerStyleEditor({
   // paint. Cluster renders as circles for validation purposes.
   const advancedJsonLayerType = useMemo(() => {
     const resolved = resolveAdapterType(layer.dataset_geometry_type, layer.style_config, editorPaint);
-    if (resolved === 'cluster') return 'circle';
-    // Mixed-geometry layers have no single MapLibre type; validate against the
-    // fill primary (the editor's controls are polygon-centric for these too).
-    if (resolved === 'mixed') return 'fill';
-    return resolved;
+    // 'mixed' passes through — AdvancedJsonEditor validates each family's keys
+    // against its own sublayer type (fix #431 codex r2), so line-*/circle-*
+    // keys stay authorable for the line/point sublayers.
+    return resolved === 'cluster' ? 'circle' : resolved;
   }, [layer.dataset_geometry_type, layer.style_config, editorPaint]);
   const isDataDriven = !!layer.style_config?.column;
   const renderMode: 'points' | 'heatmap' | 'symbol' | 'cluster' = layer.style_config?.render_mode === 'heatmap'

--- a/frontend/src/components/builder/LayerStyleEditor.tsx
+++ b/frontend/src/components/builder/LayerStyleEditor.tsx
@@ -145,7 +145,11 @@ export const LayerStyleEditor = memo(function LayerStyleEditor({
   // paint. Cluster renders as circles for validation purposes.
   const advancedJsonLayerType = useMemo(() => {
     const resolved = resolveAdapterType(layer.dataset_geometry_type, layer.style_config, editorPaint);
-    return resolved === 'cluster' ? 'circle' : resolved;
+    if (resolved === 'cluster') return 'circle';
+    // Mixed-geometry layers have no single MapLibre type; validate against the
+    // fill primary (the editor's controls are polygon-centric for these too).
+    if (resolved === 'mixed') return 'fill';
+    return resolved;
   }, [layer.dataset_geometry_type, layer.style_config, editorPaint]);
   const isDataDriven = !!layer.style_config?.column;
   const renderMode: 'points' | 'heatmap' | 'symbol' | 'cluster' = layer.style_config?.render_mode === 'heatmap'

--- a/frontend/src/components/builder/LayerStyleEditor/AdvancedJsonEditor.tsx
+++ b/frontend/src/components/builder/LayerStyleEditor/AdvancedJsonEditor.tsx
@@ -4,18 +4,51 @@ import { ChevronDown, ChevronRight, Code } from 'lucide-react';
 import { validateStyleMin } from '@maplibre/maplibre-gl-style-spec';
 import { Button } from '@/components/ui/button';
 
+// fix(#431 codex r2): a mixed-geometry (GEOMETRY sentinel) layer's paint and
+// layout span three MapLibre layer types — the adapter fans the same dict out
+// to fill/line/circle sublayers via filterPaintForLayerType. Split the block
+// by family prefix so each subset validates against its own layer type;
+// un-prefixed keys (e.g. layout `visibility`) validate under the fill primary.
+// fill-extrusion-* lands in the fill bucket and is rejected there — correct,
+// since the mixed adapter deliberately has no extrusion sublayer.
+function splitMixedBlock(value: Record<string, unknown>) {
+  const buckets: Record<'fill' | 'line' | 'circle', Record<string, unknown>> = {
+    fill: {},
+    line: {},
+    circle: {},
+  };
+  for (const [key, entry] of Object.entries(value)) {
+    if (key.startsWith('line-')) buckets.line[key] = entry;
+    else if (key.startsWith('circle-')) buckets.circle[key] = entry;
+    else buckets.fill[key] = entry;
+  }
+  return buckets;
+}
+
 // Use the real MapLibre style-spec validator to catch property names,
 // color values, numeric bounds, expression syntax, and type mismatches —
 // not just property names. Wrap the user's paint/layout in a minimal
 // single-layer style of the correct layer type and filter errors that
 // aren't about paint/layout (we synthesize the source, so source errors
 // would always fire here and are irrelevant to what the user is editing).
-function validatePropertyBlock(
+// Exported for tests.
+export function validatePropertyBlock(
   value: Record<string, unknown>,
   layerType: string | undefined,
   block: 'paint' | 'layout',
 ): string[] | null {
   if (!layerType) return [];
+  if (layerType === 'mixed') {
+    const buckets = splitMixedBlock(value);
+    const allErrors: string[] = [];
+    for (const family of ['fill', 'line', 'circle'] as const) {
+      if (Object.keys(buckets[family]).length === 0) continue;
+      const familyErrors = validatePropertyBlock(buckets[family], family, block);
+      if (familyErrors === null) return null;
+      allErrors.push(...familyErrors);
+    }
+    return allErrors;
+  }
   // Construct a layer object with the right shape for the requested type.
   // Use a GeoJSON source stub (no source-layer needed) with lineMetrics
   // enabled so line-gradient expressions using ["line-progress"] validate

--- a/frontend/src/components/builder/LayerStyleEditor/__tests__/AdvancedJsonEditor.validate.test.ts
+++ b/frontend/src/components/builder/LayerStyleEditor/__tests__/AdvancedJsonEditor.validate.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest';
+import { validatePropertyBlock } from '../AdvancedJsonEditor';
+
+/**
+ * fix(#431 codex r2): mixed-geometry layers carry fill-*, line-*, and circle-*
+ * keys in ONE paint dict (the adapter fans them out to family sublayers).
+ * Validating the whole dict as a single fill layer rejected the line/circle
+ * keys — the exact keys this editor is the styling path for. The 'mixed'
+ * layerType now validates each family's subset against its own layer type.
+ */
+describe('validatePropertyBlock — mixed-geometry layers', () => {
+  it('accepts paint mixing fill-*, line-*, and circle-* keys', () => {
+    const errors = validatePropertyBlock(
+      {
+        'fill-color': '#ff0000',
+        'fill-opacity': 0.5,
+        'line-color': '#00ff00',
+        'line-width': 3,
+        'circle-color': '#0000ff',
+        'circle-radius': 6,
+      },
+      'mixed',
+      'paint',
+    );
+    expect(errors).toEqual([]);
+  });
+
+  it('still rejects invalid values within each family', () => {
+    const errors = validatePropertyBlock(
+      { 'line-width': 'not-a-number', 'circle-radius': 6 },
+      'mixed',
+      'paint',
+    );
+    expect(errors).not.toBeNull();
+    expect(errors!.length).toBeGreaterThan(0);
+    expect(errors!.join(' ')).toContain('line-width');
+  });
+
+  it('rejects fill-extrusion-* keys (the mixed adapter has no extrusion sublayer)', () => {
+    const errors = validatePropertyBlock(
+      { 'fill-extrusion-height': 10 },
+      'mixed',
+      'paint',
+    );
+    expect(errors).not.toBeNull();
+    expect(errors!.length).toBeGreaterThan(0);
+  });
+
+  it('validates un-prefixed layout keys (visibility) under the fill primary', () => {
+    expect(validatePropertyBlock({ visibility: 'none' }, 'mixed', 'layout')).toEqual([]);
+    expect(
+      validatePropertyBlock({ 'line-cap': 'round', visibility: 'visible' }, 'mixed', 'layout'),
+    ).toEqual([]);
+  });
+
+  it('single-type validation is unchanged for concrete layers', () => {
+    expect(validatePropertyBlock({ 'fill-color': '#123456' }, 'fill', 'paint')).toEqual([]);
+    const errors = validatePropertyBlock({ 'line-color': '#123456' }, 'fill', 'paint');
+    expect(errors).not.toBeNull();
+    expect(errors!.length).toBeGreaterThan(0);
+  });
+});

--- a/frontend/src/components/builder/__tests__/layer-adapters.test.ts
+++ b/frontend/src/components/builder/__tests__/layer-adapters.test.ts
@@ -178,6 +178,25 @@ describe('resolveAdapterType', () => {
   it('geometry type takes priority over paint inference', () => {
     expect(resolveAdapterType('MULTIPOLYGON', null, { 'circle-color': '#f00' })).toBe('fill');
   });
+
+  // fix(#430 codex r23): generic sentinels route to the mixed adapter so
+  // point/line features of a mixed-family sketch are no longer dropped on maps.
+  it('returns mixed for the GEOMETRY sentinel', () => {
+    expect(resolveAdapterType('GEOMETRY', null)).toBe('mixed');
+    expect(resolveAdapterType('geometry', null)).toBe('mixed');
+  });
+
+  it('returns mixed for GEOMETRYCOLLECTION', () => {
+    expect(resolveAdapterType('GEOMETRYCOLLECTION', null)).toBe('mixed');
+  });
+
+  it('render_mode still overrides the generic sentinel', () => {
+    expect(resolveAdapterType('GEOMETRY', { render_mode: 'heatmap' })).toBe('heatmap');
+  });
+
+  it('unknown exotic geometry types keep the historic fill fallback', () => {
+    expect(resolveAdapterType('CURVE', null)).toBe('fill');
+  });
 });
 
 // ──────────────────────────────────────────────────────────────────────────────

--- a/frontend/src/components/builder/__tests__/reorder-data-layers.test.ts
+++ b/frontend/src/components/builder/__tests__/reorder-data-layers.test.ts
@@ -86,6 +86,26 @@ describe('reorderDataLayers', () => {
     ]);
   });
 
+  it('moves mixed-geometry family sublayers with their parent (fix #431 codex r1)', () => {
+    const map = createMockMap([
+      'layer-a', 'layer-a-outline', 'layer-a-lines', 'layer-a-points',
+      'layer-b',
+    ]);
+    const layers = [{ id: 'a' }, { id: 'b' }];
+
+    reorderDataLayers(map, layers);
+
+    const calls = (map.moveLayer as ReturnType<typeof vi.fn>).mock.calls.map(
+      (c: string[]) => c[0],
+    );
+    // The mixed sublayers travel with layer a and preserve the adapter's add
+    // order (fill < outline < lines < points; last moved ends topmost).
+    expect(calls).toEqual([
+      'layer-b',
+      'layer-a', 'layer-a-outline', 'layer-a-lines', 'layer-a-points',
+    ]);
+  });
+
   it('does nothing for empty layers array', () => {
     const map = createMockMap([]);
 

--- a/frontend/src/components/builder/companion-ids.ts
+++ b/frontend/src/components/builder/companion-ids.ts
@@ -9,6 +9,7 @@
 // next) derives companion ids through `getCompanionLayerIds` so the convention
 // lives in exactly one place.
 import { clusterCircleLayerId, clusterCountLayerId } from './layer-adapters/cluster-adapter';
+import { mixedLinesLayerId, mixedPointsLayerId } from './layer-adapters/mixed-adapter';
 
 /**
  * Suffix for the DEM hypsometric color-relief companion layer. Unlike the other
@@ -37,6 +38,10 @@ export interface CompanionLayerIds {
   cluster: string;
   /** Cluster count label companion (`layer-${id}-cluster-count`). */
   clusterCount: string;
+  /** Mixed-geometry line-family companion (`layer-${id}-lines`, fix #430 codex r23). */
+  mixedLines: string;
+  /** Mixed-geometry point-family companion (`layer-${id}-points`, fix #430 codex r23). */
+  mixedPoints: string;
 }
 
 /**
@@ -61,5 +66,7 @@ export function getCompanionLayerIds(rawLayerId: string, prefix?: string): Compa
     colorRelief: `${layer}${COLOR_RELIEF_SUFFIX}`,
     cluster: clusterCircleLayerId(layer),
     clusterCount: clusterCountLayerId(layer),
+    mixedLines: mixedLinesLayerId(layer),
+    mixedPoints: mixedPointsLayerId(layer),
   };
 }

--- a/frontend/src/components/builder/hooks/__tests__/builder-layer-mutations.test.ts
+++ b/frontend/src/components/builder/hooks/__tests__/builder-layer-mutations.test.ts
@@ -99,8 +99,9 @@ describe('removePerLayerCompanions — per-render-mode regression (MAP-17)', () 
 
     // 'arrow' is not a registry key → getAdapter('arrow') returns circleAdapter fallback
     // whose type === 'circle', not 'arrow', so the type guard fails and the code falls
-    // through to the FALLBACK_SUFFIXES sweep (8 calls including optional companions).
-    expect(removeLayer).toHaveBeenCalledTimes(8);
+    // through to the FALLBACK_SUFFIXES sweep (10 calls including optional companions;
+    // fix #430 codex r23 added the mixed-geometry -lines/-points companions).
+    expect(removeLayer).toHaveBeenCalledTimes(10);
     expect(removeLayer).toHaveBeenCalledWith('layer-l1');
     expect(removeLayer).toHaveBeenCalledWith('layer-l1-arrow');
     expect(removeLayer).toHaveBeenCalledWith('layer-l1-colorrelief');
@@ -109,6 +110,8 @@ describe('removePerLayerCompanions — per-render-mode regression (MAP-17)', () 
     expect(removeLayer).toHaveBeenCalledWith('layer-l1-extrusion');
     expect(removeLayer).toHaveBeenCalledWith('layer-l1-cluster');
     expect(removeLayer).toHaveBeenCalledWith('layer-l1-cluster-count');
+    expect(removeLayer).toHaveBeenCalledWith('layer-l1-lines');
+    expect(removeLayer).toHaveBeenCalledWith('layer-l1-points');
   });
 
   it('Test 4: legacy / no renderMode falls back to 7-suffix sweep', () => {
@@ -119,8 +122,9 @@ describe('removePerLayerCompanions — per-render-mode regression (MAP-17)', () 
     // Called WITHOUT renderModeByLayerId — falls back to suffix list
     removePerLayerCompanions(map as never, ['l1']);
 
-    // Fallback suffixes: base + optional companions.
-    expect(removeLayer).toHaveBeenCalledTimes(8);
+    // Fallback suffixes: base + optional companions (incl. the mixed-geometry
+    // -lines/-points pair, fix #430 codex r23).
+    expect(removeLayer).toHaveBeenCalledTimes(10);
     expect(removeLayer).toHaveBeenCalledWith('layer-l1');
     expect(removeLayer).toHaveBeenCalledWith('layer-l1-outline');
     expect(removeLayer).toHaveBeenCalledWith('layer-l1-label');
@@ -129,6 +133,8 @@ describe('removePerLayerCompanions — per-render-mode regression (MAP-17)', () 
     expect(removeLayer).toHaveBeenCalledWith('layer-l1-colorrelief');
     expect(removeLayer).toHaveBeenCalledWith('layer-l1-cluster');
     expect(removeLayer).toHaveBeenCalledWith('layer-l1-cluster-count');
+    expect(removeLayer).toHaveBeenCalledWith('layer-l1-lines');
+    expect(removeLayer).toHaveBeenCalledWith('layer-l1-points');
   });
 
   it('Test 4b: hillshade render mode removes optional color-relief companion', () => {

--- a/frontend/src/components/builder/hooks/builder-layer-mutations.ts
+++ b/frontend/src/components/builder/hooks/builder-layer-mutations.ts
@@ -78,7 +78,7 @@ function deriveCompanionIds(rawLayerId: string, renderMode: string | null | unde
   // adapters. Color-relief is included because DEM hillshade layers can create
   // it as a conditional companion on the same raster-dem source.
   const c = getCompanionLayerIds(rawLayerId);
-  return [c.layer, c.outline, c.label, c.extrusion, c.arrow, c.colorRelief, c.cluster, c.clusterCount];
+  return [c.layer, c.outline, c.label, c.extrusion, c.arrow, c.colorRelief, c.cluster, c.clusterCount, c.mixedLines, c.mixedPoints];
 }
 
 /**

--- a/frontend/src/components/builder/hooks/use-layer-map-sync.ts
+++ b/frontend/src/components/builder/hooks/use-layer-map-sync.ts
@@ -3,6 +3,7 @@ import type { Map as MaplibreMap, FilterSpecification } from 'maplibre-gl';
 import { getLayerType, getSourceIdForLayer, resolveAdapterType, getCompoundOpacity, isDemTerrainVisualSuppressed } from '@/components/builder/map-sync';
 import { getAdapter } from '@/components/builder/layer-adapters/registry';
 import { getBuilderStyleConfig } from '@/components/builder/layer-adapters/shared';
+import { mixedFamilyFilter } from '@/components/builder/layer-adapters/mixed-adapter';
 import { coalesceFrame } from '@/lib/builder/raf-coalesce';
 // fix(#394) VT-03/VT-04: single source of truth for the MVT source-layer name.
 import { getMvtSourceLayerName } from '@/lib/tile-utils';
@@ -60,6 +61,8 @@ export function applyLayerVisibilityToMap(
   if (map.getLayer(ids.colorRelief)) map.setLayoutProperty(ids.colorRelief, 'visibility', newVis);
   if (map.getLayer(ids.cluster)) map.setLayoutProperty(ids.cluster, 'visibility', newVis);
   if (map.getLayer(ids.clusterCount)) map.setLayoutProperty(ids.clusterCount, 'visibility', newVis);
+  if (map.getLayer(ids.mixedLines)) map.setLayoutProperty(ids.mixedLines, 'visibility', newVis);
+  if (map.getLayer(ids.mixedPoints)) map.setLayoutProperty(ids.mixedPoints, 'visibility', newVis);
 }
 
 // STATE-03 / SYNC-04: the canonical per-layer opacity map side-effect. The
@@ -125,6 +128,27 @@ export function applyLayerOpacityToMap(
       is_dem: layer.is_dem,
     };
     getAdapter('cluster').syncPaint(map, input);
+  } else if (adapterType === 'mixed') {
+    // fix(#430 codex r23): mixed-geometry layers spread opacity across four
+    // family sublayers — route through the adapter like the cluster branch so
+    // the slider affects points/lines too, not just the fill primary.
+    const input: AdapterLayerInput & { style_config?: StyleConfig | null } = {
+      id: layer.id,
+      dataset_table_name: layer.dataset_table_name,
+      dataset_geometry_type: layer.dataset_geometry_type,
+      opacity,
+      visible: layer.visible,
+      paint,
+      layout: layer.layout ?? {},
+      filter: layer.filter ?? null,
+      sourceId: getSourceIdForLayer(layer),
+      layerId: mapLayerId,
+      sourceLayer: getMvtSourceLayerName(layer.dataset_table_name),
+      tileUrl: '',
+      style_config: layer.style_config ?? null,
+      is_dem: layer.is_dem,
+    };
+    getAdapter('mixed').syncPaint(map, input);
   } else if (adapterType === 'fill' || adapterType === 'line' || adapterType === 'circle') {
     if (map.getLayer(mapLayerId)) {
       map.setPaintProperty(
@@ -455,6 +479,20 @@ export function useLayerMapSync(
         (l) => ({ ...l, filter }),
         (map) => {
           const ids = getCompanionLayerIds(layerId);
+          // fix(#430 codex r23): mixed-geometry sublayers carry per-family
+          // geometry-type filters as part of their identity — COMPOSE the data
+          // filter with them (never replace), mirroring the dataset-page fix
+          // for the same clobber class (codex r22).
+          if (map.getLayer(ids.mixedPoints)) {
+            map.setFilter(ids.layer, mixedFamilyFilter('polygon', filter));
+            map.setFilter(ids.outline, mixedFamilyFilter('polygon', filter));
+            map.setFilter(ids.mixedLines, mixedFamilyFilter('line', filter));
+            map.setFilter(ids.mixedPoints, mixedFamilyFilter('point', filter));
+            if (map.getLayer(ids.label)) {
+              map.setFilter(ids.label, filter);
+            }
+            return;
+          }
           // fix(#394) FL-01/B-020: cluster layers keep the bare point_count
           // predicate — cluster features carry no data properties, so ANDing
           // the data filter in hid every cluster bubble (mirrors the same fix

--- a/frontend/src/components/builder/hooks/use-render-mode-layers.ts
+++ b/frontend/src/components/builder/hooks/use-render-mode-layers.ts
@@ -112,6 +112,12 @@ export function useRenderModeLayers({
     if (map.getLayer(ids.arrow)) {
       map.removeLayer(ids.arrow);
     }
+    if (map.getLayer(ids.mixedLines)) {
+      map.removeLayer(ids.mixedLines);
+    }
+    if (map.getLayer(ids.mixedPoints)) {
+      map.removeLayer(ids.mixedPoints);
+    }
     // Per-layer raster/hillshade source removal — these layer types keep
     // their per-layer source id via `getSourceIdForLayer`'s raster branch,
     // so this is still safe (no sibling layer shares it).
@@ -203,7 +209,7 @@ export function useRenderModeLayers({
       return;
     }
     const ids = getCompanionLayerIds(layerId);
-    for (const id of [ids.colorRelief, ids.label, ids.arrow, ids.extrusion, ids.outline, ids.clusterCount, ids.cluster, ids.layer]) {
+    for (const id of [ids.colorRelief, ids.label, ids.arrow, ids.extrusion, ids.outline, ids.clusterCount, ids.cluster, ids.mixedLines, ids.mixedPoints, ids.layer]) {
       if (map.getLayer(id)) map.removeLayer(id);
     }
   }, [mapInstanceRef]);

--- a/frontend/src/components/builder/layer-adapters/__tests__/mixed-adapter.test.ts
+++ b/frontend/src/components/builder/layer-adapters/__tests__/mixed-adapter.test.ts
@@ -101,6 +101,20 @@ describe('mixed adapter — data filters COMPOSE with family filters (never repl
     }
   });
 
+  it('normalizes legacy-syntax data filters before composing (fix #431 codex r3)', () => {
+    // A legacy child would make MapLibre classify the whole ['all', ...] as a
+    // legacy filter and reject the expression-syntax family predicate.
+    const composed = mixedFamilyFilter('point', ['==', 'status', 'open']) as unknown[];
+    expect(composed[0]).toBe('all');
+    expect(composed[2]).toEqual(['==', ['get', 'status'], 'open']);
+  });
+
+  it('passes expression-syntax data filters through unchanged', () => {
+    const expr = ['==', ['get', 'pop'], 5] as unknown as import('maplibre-gl').FilterSpecification;
+    const composed = mixedFamilyFilter('line', expr) as unknown[];
+    expect(composed[2]).toEqual(['==', ['get', 'pop'], 5]);
+  });
+
   it('syncPaint re-asserts a composed filter on every sublayer', () => {
     const map = createMockMap({ layerExists: true });
     mixedAdapter.syncPaint(map as unknown as import('maplibre-gl').Map, makeInput({ filter: dataFilter }));
@@ -111,6 +125,31 @@ describe('mixed adapter — data filters COMPOSE with family filters (never repl
       expect(call).toBeDefined();
       expect(call![1][0]).toBe('all');
     }
+  });
+});
+
+describe('mixed adapter — line-family sublayer honors line layout (fix #431 codex r3)', () => {
+  it('applies stored line-cap/line-join at add time (with round defaults)', () => {
+    const map = createMockMap();
+    mixedAdapter.addLayers(
+      map as unknown as import('maplibre-gl').Map,
+      makeInput({ layout: { 'line-cap': 'square', visibility: 'visible' } }),
+    );
+    const linesCall = (map.addLayer.mock.calls as Array<[{ id: string; layout?: Record<string, unknown> }]>)
+      .find(([c]) => c.id === mixedLinesLayerId('layer-mixed-1'));
+    expect(linesCall![0].layout?.['line-cap']).toBe('square');
+    expect(linesCall![0].layout?.['line-join']).toBe('round');
+  });
+
+  it('syncPaint reconciles owned line layout on the lines sublayer', () => {
+    const map = createMockMap({ layerExists: true });
+    mixedAdapter.syncPaint(
+      map as unknown as import('maplibre-gl').Map,
+      makeInput({ layout: { 'line-join': 'bevel' } }),
+    );
+    const layoutCalls = (map.setLayoutProperty.mock.calls as Array<[string, string, unknown]>)
+      .filter(([id, prop]) => id === mixedLinesLayerId('layer-mixed-1') && prop === 'line-join');
+    expect(layoutCalls).toEqual([[mixedLinesLayerId('layer-mixed-1'), 'line-join', 'bevel']]);
   });
 });
 

--- a/frontend/src/components/builder/layer-adapters/__tests__/mixed-adapter.test.ts
+++ b/frontend/src/components/builder/layer-adapters/__tests__/mixed-adapter.test.ts
@@ -1,0 +1,154 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  mixedAdapter,
+  mixedFamilyFilter,
+  mixedInteractiveLayerIds,
+  mixedLinesLayerId,
+  mixedPointsLayerId,
+} from '../mixed-adapter';
+import type { AdapterLayerInput } from '../types';
+
+/**
+ * Mixed-geometry adapter pins (fix #430 codex r23).
+ *
+ * A GEOMETRY-sentinel (mixed-family sketch) layer must install one sublayer per
+ * geometry family, each hard-filtered on ['geometry-type'], so no family is
+ * silently dropped on maps. Like the cluster adapter, filters use raw
+ * map.setFilter with the family predicate composed unconditionally — a data
+ * filter must never REPLACE the family filter.
+ */
+
+function createMockMap(opts: { layerExists?: boolean } = {}) {
+  const { layerExists = false } = opts;
+  return {
+    addLayer: vi.fn(),
+    getLayer: vi.fn().mockReturnValue(layerExists ? { id: 'mock-layer' } : undefined),
+    setFilter: vi.fn(),
+    setLayoutProperty: vi.fn(),
+    setPaintProperty: vi.fn(),
+    getLayoutProperty: vi.fn().mockReturnValue(undefined),
+    getPaintProperty: vi.fn().mockReturnValue(undefined),
+  };
+}
+
+function makeInput(overrides: Partial<AdapterLayerInput> = {}): AdapterLayerInput {
+  return {
+    id: 'layer-mixed-1',
+    dataset_table_name: 'ds_sketch',
+    dataset_geometry_type: 'GEOMETRY',
+    opacity: 1,
+    visible: true,
+    paint: {},
+    layout: {},
+    filter: null,
+    label_config: null,
+    style_config: null,
+    sourceId: 'source-mixed-1',
+    layerId: 'layer-mixed-1',
+    sourceLayer: 'ds_sketch',
+    tileUrl: '/tiles/{z}/{x}/{y}',
+    ...overrides,
+  };
+}
+
+const ALL_IDS = [
+  'layer-mixed-1',
+  'layer-mixed-1-outline',
+  mixedLinesLayerId('layer-mixed-1'),
+  mixedPointsLayerId('layer-mixed-1'),
+];
+
+describe('mixed adapter — addLayers installs one filtered sublayer per family', () => {
+  it('adds fill + outline + lines + points, each with a geometry-type filter', () => {
+    const map = createMockMap();
+    mixedAdapter.addLayers(map as unknown as import('maplibre-gl').Map, makeInput());
+
+    expect(map.addLayer).toHaveBeenCalledTimes(4);
+    const calls = map.addLayer.mock.calls as Array<[{ id: string; type: string; filter?: unknown }]>;
+    expect(calls.map(([c]) => c.id)).toEqual(ALL_IDS);
+    expect(calls.map(([c]) => c.type)).toEqual(['fill', 'line', 'line', 'circle']);
+    for (const [call] of calls) {
+      expect(JSON.stringify(call.filter)).toContain('geometry-type');
+    }
+  });
+
+  it('honors visible=false at add-time on every sublayer (BUG-01 pin)', () => {
+    const map = createMockMap();
+    mixedAdapter.addLayers(map as unknown as import('maplibre-gl').Map, makeInput({ visible: false }));
+
+    const calls = map.addLayer.mock.calls as Array<[{ id: string; layout?: { visibility?: string } }]>;
+    for (const [call] of calls) {
+      expect(call.layout?.visibility).toBe('none');
+    }
+  });
+});
+
+describe('mixed adapter — data filters COMPOSE with family filters (never replace)', () => {
+  const dataFilter = ['==', ['get', 'category'], 'A'] as unknown as import('maplibre-gl').FilterSpecification;
+
+  it('mixedFamilyFilter wraps the data filter in ["all", family, data]', () => {
+    const composed = mixedFamilyFilter('point', dataFilter) as unknown[];
+    expect(composed[0]).toBe('all');
+    expect(JSON.stringify(composed[1])).toContain('geometry-type');
+    expect(composed[2]).toEqual(dataFilter);
+  });
+
+  it('mixedFamilyFilter returns the bare family filter when the data filter is empty', () => {
+    for (const empty of [null, undefined, [] as unknown[]]) {
+      const bare = mixedFamilyFilter('line', empty) as unknown[];
+      expect(bare[0]).toBe('in');
+      expect(JSON.stringify(bare)).toContain('LineString');
+    }
+  });
+
+  it('syncPaint re-asserts a composed filter on every sublayer', () => {
+    const map = createMockMap({ layerExists: true });
+    mixedAdapter.syncPaint(map as unknown as import('maplibre-gl').Map, makeInput({ filter: dataFilter }));
+
+    const filterCalls = map.setFilter.mock.calls as Array<[string, unknown[]]>;
+    for (const id of ALL_IDS) {
+      const call = filterCalls.find(([layerId]) => layerId === id);
+      expect(call).toBeDefined();
+      expect(call![1][0]).toBe('all');
+    }
+  });
+});
+
+describe('mixed adapter — syncPaint self-heals missing sublayers', () => {
+  it('re-adds the graph when sublayers are missing (cluster-adapter pattern)', () => {
+    const map = createMockMap({ layerExists: false });
+    mixedAdapter.syncPaint(map as unknown as import('maplibre-gl').Map, makeInput());
+    expect(map.addLayer).toHaveBeenCalledTimes(4);
+  });
+});
+
+describe('mixed adapter — syncVisibility covers all sublayers', () => {
+  it('setLayoutProperty visibility=none for all four ids', () => {
+    const map = createMockMap({ layerExists: true });
+    mixedAdapter.syncVisibility(map as unknown as import('maplibre-gl').Map, makeInput({ visible: false }));
+
+    const ids = (map.setLayoutProperty.mock.calls as Array<[string, string, string]>)
+      .filter(([, prop, val]) => prop === 'visibility' && val === 'none')
+      .map(([id]) => id);
+    expect(ids).toEqual(ALL_IDS);
+  });
+});
+
+describe('mixed adapter — id contracts', () => {
+  it('getLayerIds returns fill, outline, lines, points', () => {
+    expect(mixedAdapter.getLayerIds('layer-abc')).toEqual([
+      'layer-abc',
+      'layer-abc-outline',
+      'layer-abc-lines',
+      'layer-abc-points',
+    ]);
+  });
+
+  it('mixedInteractiveLayerIds excludes the outline (fill already covers polygon hits)', () => {
+    expect(mixedInteractiveLayerIds('layer-abc')).toEqual([
+      'layer-abc',
+      'layer-abc-lines',
+      'layer-abc-points',
+    ]);
+  });
+});

--- a/frontend/src/components/builder/layer-adapters/fill-adapter.ts
+++ b/frontend/src/components/builder/layer-adapters/fill-adapter.ts
@@ -16,7 +16,8 @@ import { ensureFillPatternImages } from './fill-pattern-images';
 // single builder-defaults source of truth (shared with renderAs + backend mirror).
 import { DEFAULT_EXTRUSION_MIN_ZOOM, DEFAULT_EXTRUSION_OPACITY_CAP } from './builder-defaults';
 
-const FILL_OWNED_PAINT_PROPERTIES = [
+// Exported for the mixed adapter's fill/outline sublayers (ADAPT-03 reuse).
+export const FILL_OWNED_PAINT_PROPERTIES = [
   'fill-color',
   'fill-opacity',
   'fill-outline-color',
@@ -25,7 +26,7 @@ const FILL_OWNED_PAINT_PROPERTIES = [
   'fill-translate',
   'fill-translate-anchor',
 ] as const;
-const OUTLINE_OWNED_PAINT_PROPERTIES = ['line-color', 'line-width', 'line-opacity'] as const;
+export const OUTLINE_OWNED_PAINT_PROPERTIES = ['line-color', 'line-width', 'line-opacity'] as const;
 // builder-audit #338 SPEC-11: 3D extrusion authoring is a DELIBERATE single-purpose subset
 // (column height only). fill-extrusion-base is intentionally fixed to 0 and
 // fill-extrusion-pattern / -translate / -translate-anchor are intentionally NOT authored;

--- a/frontend/src/components/builder/layer-adapters/line-adapter.ts
+++ b/frontend/src/components/builder/layer-adapters/line-adapter.ts
@@ -25,7 +25,8 @@ export const LINE_OWNED_LAYOUT_PROPERTIES = [
   'line-join',
 ] as const;
 
-const LINE_OWNED_PAINT_PROPERTIES = [
+// Exported for the mixed adapter's line-family sublayer (ADAPT-03 reuse).
+export const LINE_OWNED_PAINT_PROPERTIES = [
   'line-color',
   'line-width',
   'line-gap-width',

--- a/frontend/src/components/builder/layer-adapters/mixed-adapter.ts
+++ b/frontend/src/components/builder/layer-adapters/mixed-adapter.ts
@@ -1,0 +1,258 @@
+import type { FilterSpecification, Map as MaplibreMap } from 'maplibre-gl';
+import { MAP_COLORS } from '@/lib/map-colors';
+import type { AdapterLayerInput, LayerAdapter } from './types';
+import {
+  filterPaintForLayerType,
+  finalizeLayer,
+  getExpressionSafeOpacity,
+  syncOwnedPaintProperties,
+  syncSingleLayerVisibility,
+} from './shared';
+// builder-audit #338 ADAPT-03 precedent (cluster-adapter): sibling sublayers reuse
+// the standalone adapters' owned-property sets and defaults instead of duplicating them.
+import { CIRCLE_OWNED_PAINT_PROPERTIES } from './circle-adapter';
+import { FILL_OWNED_PAINT_PROPERTIES, OUTLINE_OWNED_PAINT_PROPERTIES } from './fill-adapter';
+import { LINE_OWNED_PAINT_PROPERTIES } from './line-adapter';
+import { DEFAULT_CIRCLE_PAINT, DEFAULT_FILL_PAINT } from './builder-defaults';
+
+/**
+ * fix(#430 codex r23): renderer for the generic GEOMETRY sentinel.
+ *
+ * A created (sketch) dataset that mixes geometry families keeps
+ * `geometry_type='GEOMETRY'` (see backend `_derive_created_geometry_type`).
+ * The classifier used to route that sentinel to the fill adapter, so point and
+ * line features added to a map silently disappeared. This adapter installs one
+ * sublayer per family, each hard-filtered on `['geometry-type']` — mirroring
+ * the dataset-detail map's generic branch (use-map-layers.ts) and the
+ * cluster adapter's filtered-sublayer pattern.
+ *
+ * The family filter is part of each sublayer's identity: it must ALWAYS be
+ * composed with (never replaced by) the user's data filter, so filter syncing
+ * here uses raw `map.setFilter` with the composed filter — the same deliberate
+ * exception to `syncLayerFilter` the cluster adapter makes.
+ */
+
+export function mixedLinesLayerId(layerId: string) {
+  return `${layerId}-lines`;
+}
+
+export function mixedPointsLayerId(layerId: string) {
+  return `${layerId}-points`;
+}
+
+/** Sublayer ids that carry feature hits for popups/hover (the polygon outline
+ *  is excluded — the fill primary already covers polygon hits). */
+export function mixedInteractiveLayerIds(primaryLayerId: string) {
+  return [primaryLayerId, mixedLinesLayerId(primaryLayerId), mixedPointsLayerId(primaryLayerId)];
+}
+
+type MixedFamily = 'polygon' | 'line' | 'point';
+
+// Expression-syntax geometry-type filters, matching the merged generic-dataset
+// branch in use-map-layers.ts. `['geometry-type']` may return Multi* variants
+// for MVT features, so both singular and Multi forms are listed.
+const MIXED_FAMILY_FILTERS: Record<MixedFamily, FilterSpecification> = {
+  polygon: ['in', ['geometry-type'], ['literal', ['Polygon', 'MultiPolygon']]] as unknown as FilterSpecification,
+  line: ['in', ['geometry-type'], ['literal', ['LineString', 'MultiLineString']]] as unknown as FilterSpecification,
+  point: ['in', ['geometry-type'], ['literal', ['Point', 'MultiPoint']]] as unknown as FilterSpecification,
+};
+
+/** Compose the family filter with the user's data filter (never replace it). */
+export function mixedFamilyFilter(
+  family: MixedFamily,
+  filter: FilterSpecification | unknown[] | null | undefined,
+): FilterSpecification {
+  const base = MIXED_FAMILY_FILTERS[family];
+  return Array.isArray(filter) && filter.length > 0
+    ? (['all', base, filter] as FilterSpecification)
+    : base;
+}
+
+const DEFAULT_MIXED_LINE_PAINT = {
+  'line-color': MAP_COLORS.default.fill,
+  'line-width': 2,
+} as const;
+
+// ADAPT-04 pattern: each family's effective paint is built ONCE and consumed by
+// both the add-time and sync-time paths. The layer's stored paint typically only
+// carries fill-* keys (GEOMETRY seeds as the polygon family), so the line/point
+// sublayers fall back to defaults until family-specific keys are authored.
+function mixedFillPaint(input: AdapterLayerInput): Record<string, unknown> {
+  const paint = filterPaintForLayerType(input.paint, 'fill');
+  return Object.keys(paint).length > 0 ? paint : { ...DEFAULT_FILL_PAINT };
+}
+
+function mixedLinePaint(input: AdapterLayerInput): Record<string, unknown> {
+  const paint = filterPaintForLayerType(input.paint, 'line');
+  return Object.keys(paint).length > 0 ? paint : { ...DEFAULT_MIXED_LINE_PAINT };
+}
+
+function mixedPointPaint(input: AdapterLayerInput): Record<string, unknown> {
+  const paint = filterPaintForLayerType(input.paint, 'circle');
+  return Object.keys(paint).length > 0 ? paint : { ...DEFAULT_CIRCLE_PAINT };
+}
+
+// The polygon outline is deliberately minimal (token stroke, 1px, master
+// opacity). Render-As polygon options (stroke toggles, outline overrides) are
+// not offered for mixed layers, so none of that builder state is read here.
+function mixedOutlinePaint(input: AdapterLayerInput): Record<string, unknown> {
+  return {
+    'line-color': MAP_COLORS.default.stroke,
+    'line-width': 1,
+    'line-opacity': input.opacity ?? 1,
+  };
+}
+
+function sourceLayerSpec(input: AdapterLayerInput) {
+  return input.sourceType === 'geojson' ? {} : { 'source-layer': input.sourceLayer };
+}
+
+function initialLayout(input: AdapterLayerInput): Record<string, unknown> {
+  return { visibility: input.visible === false ? 'none' : 'visible' };
+}
+
+function addFillLayer(map: MaplibreMap, input: AdapterLayerInput) {
+  if (map.getLayer(input.layerId)) return;
+  const hasExpressions = Object.values(input.paint).some(Array.isArray);
+  const filter = mixedFamilyFilter('polygon', input.filter);
+  map.addLayer({
+    id: input.layerId,
+    type: 'fill',
+    source: input.sourceId,
+    ...sourceLayerSpec(input),
+    filter,
+    paint: mixedFillPaint(input),
+    layout: initialLayout(input),
+  });
+  finalizeLayer(map, input.layerId, input.paint, 'fill', input.opacity ?? 1, filter, hasExpressions);
+}
+
+function addOutlineLayer(map: MaplibreMap, input: AdapterLayerInput) {
+  const id = `${input.layerId}-outline`;
+  if (map.getLayer(id)) return;
+  map.addLayer({
+    id,
+    type: 'line',
+    source: input.sourceId,
+    ...sourceLayerSpec(input),
+    filter: mixedFamilyFilter('polygon', input.filter),
+    paint: mixedOutlinePaint(input),
+    layout: initialLayout(input),
+  });
+}
+
+function addLinesLayer(map: MaplibreMap, input: AdapterLayerInput) {
+  const id = mixedLinesLayerId(input.layerId);
+  if (map.getLayer(id)) return;
+  const hasExpressions = Object.values(input.paint).some(Array.isArray);
+  const filter = mixedFamilyFilter('line', input.filter);
+  map.addLayer({
+    id,
+    type: 'line',
+    source: input.sourceId,
+    ...sourceLayerSpec(input),
+    filter,
+    paint: mixedLinePaint(input),
+    layout: initialLayout(input),
+  });
+  finalizeLayer(map, id, input.paint, 'line', input.opacity ?? 1, filter, hasExpressions);
+}
+
+function addPointsLayer(map: MaplibreMap, input: AdapterLayerInput) {
+  const id = mixedPointsLayerId(input.layerId);
+  if (map.getLayer(id)) return;
+  const hasExpressions = Object.values(input.paint).some(Array.isArray);
+  const filter = mixedFamilyFilter('point', input.filter);
+  map.addLayer({
+    id,
+    type: 'circle',
+    source: input.sourceId,
+    ...sourceLayerSpec(input),
+    filter,
+    paint: mixedPointPaint(input),
+    layout: initialLayout(input),
+  });
+  finalizeLayer(map, id, input.paint, 'circle', input.opacity ?? 1, filter, hasExpressions);
+}
+
+function syncFillLayer(map: MaplibreMap, input: AdapterLayerInput) {
+  if (!map.getLayer(input.layerId)) return;
+  syncOwnedPaintProperties(map, input.layerId, mixedFillPaint(input), {
+    geomType: 'fill',
+    ownedProperties: FILL_OWNED_PAINT_PROPERTIES,
+  });
+  map.setPaintProperty(input.layerId, 'fill-opacity', getExpressionSafeOpacity(input.paint, 'fill', input.opacity ?? 1));
+  map.setFilter(input.layerId, mixedFamilyFilter('polygon', input.filter));
+}
+
+function syncOutlineLayer(map: MaplibreMap, input: AdapterLayerInput) {
+  const id = `${input.layerId}-outline`;
+  if (!map.getLayer(id)) return;
+  syncOwnedPaintProperties(map, id, mixedOutlinePaint(input), {
+    geomType: 'line',
+    ownedProperties: OUTLINE_OWNED_PAINT_PROPERTIES,
+  });
+  map.setFilter(id, mixedFamilyFilter('polygon', input.filter));
+}
+
+function syncLinesLayer(map: MaplibreMap, input: AdapterLayerInput) {
+  const id = mixedLinesLayerId(input.layerId);
+  if (!map.getLayer(id)) return;
+  syncOwnedPaintProperties(map, id, mixedLinePaint(input), {
+    geomType: 'line',
+    ownedProperties: LINE_OWNED_PAINT_PROPERTIES,
+  });
+  map.setPaintProperty(id, 'line-opacity', getExpressionSafeOpacity(input.paint, 'line', input.opacity ?? 1));
+  map.setFilter(id, mixedFamilyFilter('line', input.filter));
+}
+
+function syncPointsLayer(map: MaplibreMap, input: AdapterLayerInput) {
+  const id = mixedPointsLayerId(input.layerId);
+  if (!map.getLayer(id)) return;
+  syncOwnedPaintProperties(map, id, mixedPointPaint(input), {
+    geomType: 'circle',
+    ownedProperties: CIRCLE_OWNED_PAINT_PROPERTIES,
+  });
+  map.setPaintProperty(id, 'circle-opacity', getExpressionSafeOpacity(input.paint, 'circle', input.opacity ?? 1));
+  map.setFilter(id, mixedFamilyFilter('point', input.filter));
+}
+
+export const mixedAdapter: LayerAdapter = {
+  type: 'mixed',
+
+  addLayers(map: MaplibreMap, input: AdapterLayerInput): void {
+    try {
+      addFillLayer(map, input);
+      addOutlineLayer(map, input);
+      addLinesLayer(map, input);
+      addPointsLayer(map, input);
+    } catch (e) {
+      if (import.meta.env.DEV) console.warn(`[map-sync] addLayer (mixed) failed for ${input.layerId}:`, e);
+    }
+  },
+
+  syncPaint(map: MaplibreMap, input: AdapterLayerInput): void {
+    // Self-heal missing sublayers (cluster-adapter pattern) so a partial
+    // teardown never leaves a family invisible until remount.
+    this.addLayers(map, input);
+    syncFillLayer(map, input);
+    syncOutlineLayer(map, input);
+    syncLinesLayer(map, input);
+    syncPointsLayer(map, input);
+  },
+
+  syncVisibility(map: MaplibreMap, input: AdapterLayerInput): void {
+    for (const id of this.getLayerIds(input.layerId)) {
+      syncSingleLayerVisibility(map, id, input.visible);
+    }
+  },
+
+  getLayerIds(layerId: string): string[] {
+    return [
+      layerId,
+      `${layerId}-outline`,
+      mixedLinesLayerId(layerId),
+      mixedPointsLayerId(layerId),
+    ];
+  },
+};

--- a/frontend/src/components/builder/layer-adapters/mixed-adapter.ts
+++ b/frontend/src/components/builder/layer-adapters/mixed-adapter.ts
@@ -1,10 +1,12 @@
 import type { FilterSpecification, Map as MaplibreMap } from 'maplibre-gl';
+import { convertFilter } from '@maplibre/maplibre-gl-style-spec';
 import { MAP_COLORS } from '@/lib/map-colors';
 import type { AdapterLayerInput, LayerAdapter } from './types';
 import {
   filterPaintForLayerType,
   finalizeLayer,
   getExpressionSafeOpacity,
+  syncOwnedLayoutProperties,
   syncOwnedPaintProperties,
   syncSingleLayerVisibility,
 } from './shared';
@@ -12,7 +14,7 @@ import {
 // the standalone adapters' owned-property sets and defaults instead of duplicating them.
 import { CIRCLE_OWNED_PAINT_PROPERTIES } from './circle-adapter';
 import { FILL_OWNED_PAINT_PROPERTIES, OUTLINE_OWNED_PAINT_PROPERTIES } from './fill-adapter';
-import { LINE_OWNED_PAINT_PROPERTIES } from './line-adapter';
+import { LINE_OWNED_LAYOUT_PROPERTIES, LINE_OWNED_PAINT_PROPERTIES } from './line-adapter';
 import { DEFAULT_CIRCLE_PAINT, DEFAULT_FILL_PAINT } from './builder-defaults';
 
 /**
@@ -63,9 +65,21 @@ export function mixedFamilyFilter(
   filter: FilterSpecification | unknown[] | null | undefined,
 ): FilterSpecification {
   const base = MIXED_FAMILY_FILTERS[family];
-  return Array.isArray(filter) && filter.length > 0
-    ? (['all', base, filter] as FilterSpecification)
-    : base;
+  if (!Array.isArray(filter) || filter.length === 0) return base;
+  // fix(#431 codex r3): normalize legacy-syntax data filters (e.g.
+  // ['==', 'status', 'open'] from older saved maps) to expression syntax
+  // before composing. A single legacy child makes MapLibre classify the whole
+  // ['all', ...] as a LEGACY filter, which then rejects the expression-syntax
+  // ['geometry-type'] family predicate and fails addLayer/setFilter.
+  // convertFilter passes expression-syntax filters through unchanged.
+  let expressionFilter: unknown = filter;
+  try {
+    expressionFilter = convertFilter(filter as Parameters<typeof convertFilter>[0]);
+  } catch (e) {
+    if (import.meta.env.DEV) console.warn('[map-sync] mixed filter conversion failed, dropping data filter:', e);
+    return base;
+  }
+  return ['all', base, expressionFilter] as FilterSpecification;
 }
 
 const DEFAULT_MIXED_LINE_PAINT = {
@@ -100,6 +114,25 @@ function mixedOutlinePaint(input: AdapterLayerInput): Record<string, unknown> {
     'line-color': MAP_COLORS.default.stroke,
     'line-width': 1,
     'line-opacity': input.opacity ?? 1,
+  };
+}
+
+// fix(#431 codex r3): the line-family sublayer honors authored line layout
+// (line-cap/line-join via Advanced JSON), mirroring the standalone line
+// adapter's defaults + owned-layout handling. Other layout keys are excluded —
+// a circle-*/fill-* layout key on a line layer would abort addLayer entirely.
+function mixedLineLayout(input: AdapterLayerInput): Record<string, unknown> {
+  const stored = (input.layout ?? {}) as Record<string, unknown>;
+  const owned = Object.fromEntries(
+    LINE_OWNED_LAYOUT_PROPERTIES
+      .filter((key) => stored[key] != null)
+      .map((key) => [key, stored[key]]),
+  );
+  return {
+    'line-cap': 'round',
+    'line-join': 'round',
+    ...owned,
+    visibility: input.visible === false ? 'none' : 'visible',
   };
 }
 
@@ -153,7 +186,7 @@ function addLinesLayer(map: MaplibreMap, input: AdapterLayerInput) {
     ...sourceLayerSpec(input),
     filter,
     paint: mixedLinePaint(input),
-    layout: initialLayout(input),
+    layout: mixedLineLayout(input),
   });
   finalizeLayer(map, id, input.paint, 'line', input.opacity ?? 1, filter, hasExpressions);
 }
@@ -201,6 +234,13 @@ function syncLinesLayer(map: MaplibreMap, input: AdapterLayerInput) {
   syncOwnedPaintProperties(map, id, mixedLinePaint(input), {
     geomType: 'line',
     ownedProperties: LINE_OWNED_PAINT_PROPERTIES,
+  });
+  // clearMissing: false — mirrors the standalone line adapter (CR-01): addLayers
+  // hardcodes 'round'/'round'; a stored layout without cap/join must not reset
+  // the live value to MapLibre's spec defaults ('butt'/'miter').
+  syncOwnedLayoutProperties(map, id, (input.layout ?? {}) as Record<string, unknown>, {
+    ownedProperties: LINE_OWNED_LAYOUT_PROPERTIES,
+    clearMissing: false,
   });
   map.setPaintProperty(id, 'line-opacity', getExpressionSafeOpacity(input.paint, 'line', input.opacity ?? 1));
   map.setFilter(id, mixedFamilyFilter('line', input.filter));

--- a/frontend/src/components/builder/layer-adapters/registry.ts
+++ b/frontend/src/components/builder/layer-adapters/registry.ts
@@ -6,6 +6,7 @@ import { hillshadeAdapter } from './hillshade-adapter';
 import { heatmapAdapter } from './heatmap-adapter';
 import { symbolAdapter } from './symbol-adapter';
 import { clusterAdapter } from './cluster-adapter';
+import { mixedAdapter } from './mixed-adapter';
 import type { LayerAdapter } from './types';
 
 const adapters: Record<string, LayerAdapter> = {
@@ -17,6 +18,7 @@ const adapters: Record<string, LayerAdapter> = {
   hillshade: hillshadeAdapter,
   heatmap: heatmapAdapter,
   cluster: clusterAdapter,
+  mixed: mixedAdapter,
 };
 
 export function getAdapter(type: string): LayerAdapter {

--- a/frontend/src/components/builder/layer-adapters/shared.ts
+++ b/frontend/src/components/builder/layer-adapters/shared.ts
@@ -31,6 +31,15 @@ export function classifyGeometry(geometryType: string | null): GeometryFamily {
   return 'other';
 }
 
+/** fix(#430 codex r23): the generic sentinels a created/mixed dataset carries when
+ *  its geometry column holds (or may hold) multiple families. These route to the
+ *  mixed adapter so every family renders; unknown exotic types keep the historic
+ *  fill fallback. Mirrors the backend `_derive_created_geometry_type` contract. */
+export function isGenericGeometryType(geometryType: string | null): boolean {
+  const gt = (geometryType ?? '').toUpperCase();
+  return gt === 'GEOMETRY' || gt === 'GEOMETRYCOLLECTION';
+}
+
 /** MapLibre vector layer type for a geometry. polygon/other both render as fill. */
 export function getLayerType(geometryType: string | null): 'circle' | 'line' | 'fill' {
   switch (classifyGeometry(geometryType)) {
@@ -337,6 +346,12 @@ export function resolveAdapterType(
   }
   if (styleConfig?.render_mode === 'cluster') {
     return 'cluster';
+  }
+  // fix(#430 codex r23): generic sentinel datasets mix families — route to the
+  // mixed adapter (per-family filtered sublayers) instead of the fill fallback
+  // that silently dropped point/line features.
+  if (isGenericGeometryType(geometryType)) {
+    return 'mixed';
   }
   // Use geometry type when available
   if (geometryType) {

--- a/frontend/src/components/builder/layer-adapters/types.ts
+++ b/frontend/src/components/builder/layer-adapters/types.ts
@@ -42,7 +42,7 @@ export interface AdapterLayerInput {
 }
 
 export interface LayerAdapter {
-  type: 'fill' | 'line' | 'circle' | 'symbol' | 'raster' | 'heatmap' | 'hillshade' | 'cluster';
+  type: 'fill' | 'line' | 'circle' | 'symbol' | 'raster' | 'heatmap' | 'hillshade' | 'cluster' | 'mixed';
   addLayers(map: MaplibreMap, input: AdapterLayerInput): void;
   syncPaint(map: MaplibreMap, input: AdapterLayerInput): void;
   syncVisibility(map: MaplibreMap, input: AdapterLayerInput): void;

--- a/frontend/src/components/builder/map-sync.ts
+++ b/frontend/src/components/builder/map-sync.ts
@@ -410,7 +410,7 @@ export function prefixed(kind: 'source' | 'layer' | 'outline' | 'extrusion' | 'a
 function removeKnownVectorLayers(map: MaplibreMap, layerId: string, id: string, prefix: string | undefined) {
   // builder-audit #338 SYNC-04: every companion id derived from one helper.
   const ids = getCompanionLayerIds(id, prefix);
-  for (const candidate of [ids.label, ids.arrow, ids.extrusion, ids.outline, ids.clusterCount, ids.cluster, layerId]) {
+  for (const candidate of [ids.label, ids.arrow, ids.extrusion, ids.outline, ids.clusterCount, ids.cluster, ids.mixedLines, ids.mixedPoints, layerId]) {
     if (map.getLayer(candidate)) map.removeLayer(candidate);
   }
 }
@@ -1115,7 +1115,14 @@ function syncVectorLayer(
   const outlineLayerId = prefixed('outline', layer.id, prefix);
   const extrusionLayerId = prefixed('extrusion', layer.id, prefix);
   const arrowLayerId = prefixed('arrow', layer.id, prefix);
-  syncLayerZoomRange(map, [layerId, outlineLayerId, extrusionLayerId, arrowLayerId], layerMinzoom, layerMaxzoom);
+  // fix(#430 codex r23): union with the adapter's own ids so mixed-geometry
+  // sublayers (-lines/-points) honor the custom zoom range too.
+  syncLayerZoomRange(
+    map,
+    [...new Set([...mode.adapter.getLayerIds(layerId), outlineLayerId, extrusionLayerId, arrowLayerId])],
+    layerMinzoom,
+    layerMaxzoom,
+  );
 
   syncLabelCompanion(map, layer, adapterInput, mode, prefix);
 
@@ -1157,7 +1164,7 @@ function removeStaleSourcesAndLayers(
     // raster-dem source), so it is not found by the source-keyed loop and must
     // be removed explicitly here.
     removeColorReliefCompanionLayer(map, ids.layer);
-    for (const candidate of [ids.label, ids.arrow, ids.extrusion, ids.outline, ids.clusterCount, ids.cluster, ids.layer]) {
+    for (const candidate of [ids.label, ids.arrow, ids.extrusion, ids.outline, ids.clusterCount, ids.cluster, ids.mixedLines, ids.mixedPoints, ids.layer]) {
       if (map.getLayer(candidate)) map.removeLayer(candidate);
     }
     // builder-audit #338 SYNC-06: enumerate any remaining layers still referencing

--- a/frontend/src/components/builder/map-sync.ts
+++ b/frontend/src/components/builder/map-sync.ts
@@ -19,6 +19,7 @@ import { getAdapter } from './layer-adapters/registry';
 import type { AdapterLayerInput, LayerAdapter } from './layer-adapters/types';
 import { buildLabelLayerSpec, syncLabelLayer } from './label-layer-utils';
 import { clusterCircleLayerId, clusterCountLayerId, getClusterSourceOptions } from './layer-adapters/cluster-adapter';
+import { mixedLinesLayerId, mixedPointsLayerId } from './layer-adapters/mixed-adapter';
 import { getClusterSourceStrategy } from './cluster-source';
 import { syncColorReliefLayer } from './color-relief-sync';
 import { buildColormapTileUrl } from './layer-adapters/raster-adapter';
@@ -1320,6 +1321,10 @@ function reorderDataGeometry(
     const colorReliefId = `${lid}${COLOR_RELIEF_SUFFIX}`;
     const cid = clusterCircleLayerId(lid);
     const ccid = clusterCountLayerId(lid);
+    // fix(#431 codex r1): mixed-geometry family sublayers move with their parent,
+    // preserving the adapter's add order (fill < outline < lines < points).
+    const mlid = mixedLinesLayerId(lid);
+    const mpid = mixedPointsLayerId(lid);
     if (map.getLayer(cid)) map.moveLayer(cid);
     if (map.getLayer(ccid)) map.moveLayer(ccid);
     if (map.getLayer(colorReliefId)) map.moveLayer(colorReliefId);
@@ -1327,6 +1332,8 @@ function reorderDataGeometry(
     if (map.getLayer(aid)) map.moveLayer(aid);
     if (map.getLayer(eid)) map.moveLayer(eid);
     if (map.getLayer(oid)) map.moveLayer(oid);
+    if (map.getLayer(mlid)) map.moveLayer(mlid);
+    if (map.getLayer(mpid)) map.moveLayer(mpid);
   }
 }
 

--- a/frontend/src/components/viewer/ViewerMap.tsx
+++ b/frontend/src/components/viewer/ViewerMap.tsx
@@ -30,6 +30,8 @@ import type { MapLibreEvent, MapMouseEvent, StyleSpecification, VectorTileSource
 import type { Map as MaplibreMap } from 'maplibre-gl';
 import type { MapBasemapConfig, MapTerrainConfig, SharedLayerResponse } from '@/types/api';
 import { getAdapter } from '@/components/builder/layer-adapters/registry';
+import { isGenericGeometryType } from '@/components/builder/layer-adapters/shared';
+import { mixedInteractiveLayerIds } from '@/components/builder/layer-adapters/mixed-adapter';
 import type { AdapterLayerInput } from '@/components/builder/layer-adapters/types';
 import { clearTerrainForStyleSwap, resolveAdapterType, prefixed, getDataDrivenColumnsForLayer } from '@/components/builder/map-sync';
 import { applyMapBasemapAppearance, syncMapComposition } from '@/components/builder/map-composition-sync';
@@ -463,7 +465,12 @@ export const ViewerMap = memo(function ViewerMap({
         .filter(({ layer }) => layer.style_config?.render_mode !== 'heatmap')
         .flatMap(({ layer, key }) => {
           const layerId = prefixed('layer', key, VIEWER_PREFIX);
-          return isClusterRenderMode(layer) ? clusterInteractiveLayerIds(layerId) : [layerId];
+          // fix(#430 codex r23): mixed-geometry layers spread hits across
+          // per-family sublayers — include them so point/line features stay
+          // clickable (queryInteractiveFeatures filters to attached layers).
+          if (isClusterRenderMode(layer)) return clusterInteractiveLayerIds(layerId);
+          if (isGenericGeometryType(layer.geometry_type)) return mixedInteractiveLayerIds(layerId);
+          return [layerId];
         }),
     [layerEntries, visibleLayers],
   );
@@ -493,7 +500,11 @@ export const ViewerMap = memo(function ViewerMap({
     for (const { layer, key } of layerEntries) {
       const layerId = prefixed('layer', key, VIEWER_PREFIX);
       const sourceId = prefixed('source', key, VIEWER_PREFIX);
-      const ids = isClusterRenderMode(layer) ? clusterInteractiveLayerIds(layerId) : [layerId];
+      const ids = isClusterRenderMode(layer)
+        ? clusterInteractiveLayerIds(layerId)
+        : isGenericGeometryType(layer.geometry_type)
+          ? mixedInteractiveLayerIds(layerId)
+          : [layerId];
       for (const id of ids) m.set(id, { layer, sourceId });
     }
     layerByMapIdRef.current = m;


### PR DESCRIPTION
## Summary

Follow-up to #430, closing the one finding deferred there (codex r23, P1): a created (sketch) dataset that mixes geometry families carries the `geometry_type='GEOMETRY'` sentinel, and the map **builder/viewer** adapter path classified that sentinel as `fill` — so point and line features of a mixed sketch added to a map rendered as an invisible fill layer and were silently dropped. (The dataset-detail page was already fixed in #430 r21/r22; this PR brings the builder/viewer to parity.)

## What changed

- **New `mixed` layer adapter** (`layer-adapters/mixed-adapter.ts`): installs `fill` + `-outline` + `-lines` + `-points` sublayers on one vector source, each hard-filtered on `['geometry-type']` — the cluster adapter's filtered-sublayer pattern, with filter expressions identical to the dataset-detail generic branch merged in #430 (r21). Family filters are part of each sublayer's identity and are always **composed** with the user's data filter (`['all', family, data]`), never replaced.
- **Classification** (`shared.ts`): `resolveAdapterType` routes the `GEOMETRY`/`GEOMETRYCOLLECTION` sentinels (new `isGenericGeometryType`) to `mixed`. `classifyGeometry`/`getLayerType` are untouched; unknown exotic types keep the historic fill fallback. `render_mode` overrides still win.
- **Companion-id scheme** (`companion-ids.ts`): `-lines`/`-points` join the canonical set, so every teardown path (map-sync stale sweep, `removeKnownVectorLayers`, render-mode swap, `removePerLayerCompanions` fallback) removes them.
- **Edit-path integration** (`use-layer-map-sync.ts`): visibility toggles cover the new sublayers; the opacity slider routes mixed layers through the adapter (like the cluster branch); `handleFilterChange` composes data filters with family filters instead of clobbering them — the same clobber class codex r22 flagged on the dataset page.
- **Interactivity** (`BuilderMap.tsx`, `ViewerMap.tsx`): popup/hover hit-testing includes the family sublayers, so point/line features of a mixed layer are clickable in both surfaces.
- **Advanced JSON editor** (`LayerStyleEditor.tsx`): validates mixed layers against the fill primary.
- Zoom-range sync unions the adapter's own layer ids so `_minzoom`/`_maxzoom` apply to the new sublayers.

## Deliberate scope

- **Render-As stays hidden for mixed layers** (`getRenderAsSource` → `unsupported` → no options): no alternative renderer applies to a multi-family layer.
- The style editor's controls remain polygon-centric for mixed layers (fill-* keys flow to the fill sublayer; line/point sublayers use token defaults until family keys are authored via Advanced JSON). Full per-family styling UI would be a feature, not this fix.
- Viewer legend swatch for mixed layers unchanged.

## Verification

- `cd frontend && npm run typecheck && npm run lint && npm run build` — clean.
- `npm run test:coverage` — 306 files / 3345 tests green (new `mixed-adapter.test.ts` with 9 pins: per-family filters, visible=false at add, filter composition, self-heal, visibility, id contracts; `resolveAdapterType` sentinel cases; companion-sweep count pins updated 8→10).
- **Live smoke** (local stack, real browser): created an empty sketch dataset (API confirms `geometry_type=GEOMETRY`, `has_generic_geometry=true`), added point+line+polygon features, added it to a map.
  - Builder: all three families render; layer graph verified via `map.getStyle()` (fill/outline/lines/points with correct geometry-type filters); real-mouse-click popups confirmed on the **point** ("pt"), **line** ("ln"), and **polygon** ("pg") features.
  - Shared viewer (`/m/<token>`): all three families render. (Shared-viewer popups didn't fire for any family incl. polygon — pre-existing behavior of that surface, unrelated to this change.)

No backend, schema, API, or i18n changes.

https://claude.ai/code/session_01HSodEnENJNBi95hS2xqATn