### PR TITLE
fix(import): queue drops staged during the upload-config fetch instead of swallowing them

### DIFF
--- a/frontend/src/components/import/FileDropzone.tsx
+++ b/frontend/src/components/import/FileDropzone.tsx
@@ -11,9 +11,21 @@ import type { DataKind } from '@/types/api';
 /** Client-side batch guard. Real caps (per-file size, dataset quota) are server-enforced. */
 const MAX_BATCH_FILES = 25;
 
+/**
+ * Batch cap = the smaller of the UX limit and remaining quota. Floor at 1
+ * (not 0 — react-dropzone treats maxFiles:0 as unlimited) so an at-cap user
+ * can still drop one file and get the explicit server quota error + banner.
+ * Shared with UploadForm's queued-drop flush (PR #274 follow-up) so both
+ * enforce the same limit.
+ */
+export function effectiveBatchLimit(remainingQuota: number | null | undefined): number {
+  return remainingQuota != null
+    ? Math.min(MAX_BATCH_FILES, Math.max(1, remainingQuota))
+    : MAX_BATCH_FILES;
+}
+
 interface FileDropzoneProps {
   onFilesAccepted: (files: File[]) => void;
-  disabled?: boolean;
   allowedExtensions?: string[];
   maxSizeMb?: number;
   /** Remaining per-user dataset quota; null = unlimited. Caps the batch so the
@@ -42,16 +54,12 @@ function groupByKind(extensions: string[]): { kind: DataKind; ext: string }[] {
   return result;
 }
 
-export function FileDropzone({ onFilesAccepted, disabled, allowedExtensions, maxSizeMb, remainingQuota }: FileDropzoneProps) {
+export function FileDropzone({ onFilesAccepted, allowedExtensions, maxSizeMb, remainingQuota }: FileDropzoneProps) {
   const { t } = useTranslation('import');
 
-  // Cap the batch at the smaller of the UX limit and remaining quota. Floor at
-  // 1 (not 0 — react-dropzone treats maxFiles:0 as unlimited) so an at-cap user
-  // can still drop one file and get the explicit server quota error + banner.
   // ponytail: client-side UX guard only; the cap is enforced server-side at
   // upload. Atomic batch enforcement is a deferred worker-side concern.
-  const effectiveMaxFiles =
-    remainingQuota != null ? Math.min(MAX_BATCH_FILES, Math.max(1, remainingQuota)) : MAX_BATCH_FILES;
+  const effectiveMaxFiles = effectiveBatchLimit(remainingQuota);
 
   const accept = useMemo(() => {
     if (!allowedExtensions || allowedExtensions.length === 0) return undefined;
@@ -76,7 +84,6 @@ export function FileDropzone({ onFilesAccepted, disabled, allowedExtensions, max
       maxFiles: effectiveMaxFiles,
       maxSize: maxSizeMb ? maxSizeMb * 1024 * 1024 : undefined,
       multiple: true,
-      disabled,
       onDrop: (accepted) => {
         if (accepted.length > 0) onFilesAccepted(accepted);
       },
@@ -92,7 +99,6 @@ export function FileDropzone({ onFilesAccepted, disabled, allowedExtensions, max
         isDragReject && 'border-destructive bg-destructive/10 scale-[1.005]',
         isDragActive && !isDragReject && 'border-primary bg-primary/5 scale-[1.005]',
         !isDragActive && !isDragReject && 'border-muted-foreground/30 hover:border-muted-foreground/50',
-        disabled && 'pointer-events-none opacity-50',
       )}
     >
       <input {...getInputProps({ 'aria-label': t('dropzone.ariaLabel') })} />

--- a/frontend/src/components/import/UploadForm.tsx
+++ b/frontend/src/components/import/UploadForm.tsx
@@ -525,15 +525,16 @@ export function UploadForm({ onPhaseChange }: UploadFormProps) {
   // still never *act* on an unresolved/stale quota (Codex P2 on PR #274). Once
   // a fetch settles, success carries the live remaining quota; an error
   // degrades to permissive — consistent with allowedExtensions/maxSizeMb.
-  // While fetching, the quota cap is also permissive (null): react-dropzone
-  // enforces maxFiles at drop time, so a cached stale-LOW quota would reject a
-  // multi-file drop before it could queue for fresh validation (Codex P2 on
-  // PR #432).
+  // While fetching, every config-derived gate is permissive (quota null,
+  // extensions/size undefined): react-dropzone enforces accept/maxSize/maxFiles
+  // at drop time, so cached stale values would reject files the fresh config
+  // allows before they could queue — the flush validates all three against the
+  // settled config instead (Codex P2 rounds 1-3 on PR #432).
   return (
     <FileDropzone
       onFilesAccepted={handleFilesAccepted}
-      allowedExtensions={allowedExtensions}
-      maxSizeMb={maxSizeMb}
+      allowedExtensions={configFetching ? undefined : allowedExtensions}
+      maxSizeMb={configFetching ? undefined : maxSizeMb}
       remainingQuota={configFetching ? null : (uploadConfig?.remaining_dataset_quota ?? null)}
     />
   );

--- a/frontend/src/components/import/UploadForm.tsx
+++ b/frontend/src/components/import/UploadForm.tsx
@@ -16,7 +16,7 @@ import {
   DialogFooter,
 } from '@/components/ui/dialog';
 import { CheckCircle2, AlertCircle } from 'lucide-react';
-import { FileDropzone } from './FileDropzone';
+import { FileDropzone, effectiveBatchLimit } from './FileDropzone';
 import { BulkUploadProgress } from './BulkUploadProgress';
 import { inferImportedKind, isFilePreview, stripExtension } from './utils';
 import { BulkReviewList } from './BulkReviewList';
@@ -86,9 +86,16 @@ export function UploadForm({ onPhaseChange }: UploadFormProps) {
     entryId: string;
     results: FanOutResult[];
   } | null>(null);
-  // isFetching (not just isPending) so the dropzone is also disabled during the
-  // refetchOnMount background refresh — otherwise the cached-but-stale quota is
-  // briefly usable on remount before the live GET lands (Codex P2 on PR #274).
+  // Files dropped while the quota query is still fetching (initial load OR the
+  // refetch-on-mount refresh) are held here and processed once it settles.
+  // Disabling the dropzone during that window (the previous design) made
+  // react-dropzone silently swallow drops with no feedback and no same-page
+  // recovery (PR #274 follow-up).
+  const [pendingFiles, setPendingFiles] = useState<File[] | null>(null);
+  // isFetching (not just isPending) so drops during the refetchOnMount
+  // background refresh are also deferred — otherwise the cached-but-stale
+  // quota would briefly apply on remount before the live GET lands (Codex P2
+  // on PR #274).
   const { data: uploadConfig, isFetching: configFetching } = useUploadConfig();
 
   const allowedExtensions = useMemo(
@@ -108,6 +115,7 @@ export function UploadForm({ onPhaseChange }: UploadFormProps) {
     setEntries([]);
     setAutoOpenVrt(false);
     setQuotaNotice(null);
+    setPendingFiles(null);
     // Refresh remaining_dataset_quota so "Upload More" after an import reflects
     // the new dataset count instead of the cached pre-import value (Codex P2 on
     // PR #274). invalidate matches the user-scoped key by prefix.
@@ -138,7 +146,7 @@ export function UploadForm({ onPhaseChange }: UploadFormProps) {
     }
   }, [entries, phase, setPhase]);
 
-  const handleFilesAccepted = async (files: File[]) => {
+  const processFiles = useCallback(async (files: File[]) => {
     if (phase !== 'idle') return;
     setQuotaNotice(null);
 
@@ -204,7 +212,36 @@ export function UploadForm({ onPhaseChange }: UploadFormProps) {
     );
 
     setPhase('reviewing');
+  }, [phase, entries, t, uploadConfig?.presigned_uploads, updateEntry, setPhase]);
+
+  // Queue drops that land mid-fetch instead of processing them against an
+  // unresolved/stale quota; merge (not replace) so a second drop in the same
+  // window can't swallow the first (PR #274 follow-up).
+  const handleFilesAccepted = (files: File[]) => {
+    if (phase !== 'idle') return;
+    if (configFetching) {
+      setPendingFiles((prev) => (prev ? [...prev, ...files] : files));
+      return;
+    }
+    void processFiles(files);
   };
+
+  // Flush queued drops once the quota query settles, re-applying the batch cap
+  // with the fresh quota (the dropzone's own maxFiles guard ran against the
+  // pre-fetch value). Over-cap batches are rejected whole, matching
+  // react-dropzone's maxFiles behavior.
+  useEffect(() => {
+    if (configFetching || !pendingFiles || phase !== 'idle') return;
+    setPendingFiles(null);
+    const limit = effectiveBatchLimit(uploadConfig?.remaining_dataset_quota ?? null);
+    if (pendingFiles.length > limit) {
+      toast.error(t('dropzone.batchLimit', { max: limit }));
+      return;
+    }
+    void processFiles(pendingFiles);
+    // processFiles is recreated per render; the pendingFiles/configFetching
+    // guards make re-runs no-ops, so listing it is safe.
+  }, [configFetching, pendingFiles, phase, uploadConfig?.remaining_dataset_quota, processFiles, t]);
 
   const handleCommitSingle = async (
     entryId: string,
@@ -465,19 +502,18 @@ export function UploadForm({ onPhaseChange }: UploadFormProps) {
     return <BulkTrackingList entries={entries} onReset={reset} autoOpenVrt={autoOpenVrt} />;
   }
 
-  // idle. Disable while the quota query is fetching (initial load OR the
-  // refetch-on-mount refresh) so we never act on an unresolved/stale quota:
-  // treating undefined→null as "unlimited" would offer the full 25-file batch
-  // on a capped deployment (Codex P2 on PR #274). Once a fetch settles, success
-  // carries the live remaining quota; an error degrades to permissive —
-  // consistent with allowedExtensions/maxSizeMb.
+  // idle. The dropzone stays enabled while the quota query fetches — disabling
+  // it made react-dropzone silently swallow drops (PR #274 follow-up). Drops in
+  // that window queue in pendingFiles and flush with the fresh quota, so we
+  // still never *act* on an unresolved/stale quota (Codex P2 on PR #274). Once
+  // a fetch settles, success carries the live remaining quota; an error
+  // degrades to permissive — consistent with allowedExtensions/maxSizeMb.
   return (
     <FileDropzone
       onFilesAccepted={handleFilesAccepted}
       allowedExtensions={allowedExtensions}
       maxSizeMb={maxSizeMb}
       remainingQuota={uploadConfig?.remaining_dataset_quota ?? null}
-      disabled={configFetching}
     />
   );
 }

--- a/frontend/src/components/import/UploadForm.tsx
+++ b/frontend/src/components/import/UploadForm.tsx
@@ -508,12 +508,16 @@ export function UploadForm({ onPhaseChange }: UploadFormProps) {
   // still never *act* on an unresolved/stale quota (Codex P2 on PR #274). Once
   // a fetch settles, success carries the live remaining quota; an error
   // degrades to permissive — consistent with allowedExtensions/maxSizeMb.
+  // While fetching, the quota cap is also permissive (null): react-dropzone
+  // enforces maxFiles at drop time, so a cached stale-LOW quota would reject a
+  // multi-file drop before it could queue for fresh validation (Codex P2 on
+  // PR #432).
   return (
     <FileDropzone
       onFilesAccepted={handleFilesAccepted}
       allowedExtensions={allowedExtensions}
       maxSizeMb={maxSizeMb}
-      remainingQuota={uploadConfig?.remaining_dataset_quota ?? null}
+      remainingQuota={configFetching ? null : (uploadConfig?.remaining_dataset_quota ?? null)}
     />
   );
 }

--- a/frontend/src/components/import/UploadForm.tsx
+++ b/frontend/src/components/import/UploadForm.tsx
@@ -226,22 +226,39 @@ export function UploadForm({ onPhaseChange }: UploadFormProps) {
     void processFiles(files);
   };
 
-  // Flush queued drops once the quota query settles, re-applying the batch cap
-  // with the fresh quota (the dropzone's own maxFiles guard ran against the
-  // pre-fetch value). Over-cap batches are rejected whole, matching
-  // react-dropzone's maxFiles behavior.
+  // Flush queued drops once the quota query settles, re-applying every gate
+  // the dropzone validated against nothing (or stale values) during the fetch
+  // window: extension and per-file size are re-checked per file with the same
+  // rejection toast react-dropzone shows (Codex P2 round 2 on PR #432), then
+  // the batch cap with the fresh quota. Over-cap batches are rejected whole,
+  // matching react-dropzone's maxFiles behavior.
   useEffect(() => {
     if (configFetching || !pendingFiles || phase !== 'idle') return;
     setPendingFiles(null);
+    const files = pendingFiles.filter((f) => {
+      if (
+        allowedExtensions?.length &&
+        !allowedExtensions.some((ext) => f.name.toLowerCase().endsWith(ext.toLowerCase()))
+      ) {
+        toast.error(t('dropzone.fileRejected', { filename: f.name, reason: t('dropzone.unsupportedType') }));
+        return false;
+      }
+      if (maxSizeMb != null && f.size > maxSizeMb * 1024 * 1024) {
+        toast.error(t('dropzone.fileRejected', { filename: f.name, reason: t('dropzone.sizeLimitDynamic', { size: maxSizeMb }) }));
+        return false;
+      }
+      return true;
+    });
+    if (files.length === 0) return;
     const limit = effectiveBatchLimit(uploadConfig?.remaining_dataset_quota ?? null);
-    if (pendingFiles.length > limit) {
+    if (files.length > limit) {
       toast.error(t('dropzone.batchLimit', { max: limit }));
       return;
     }
-    void processFiles(pendingFiles);
+    void processFiles(files);
     // processFiles is recreated per render; the pendingFiles/configFetching
     // guards make re-runs no-ops, so listing it is safe.
-  }, [configFetching, pendingFiles, phase, uploadConfig?.remaining_dataset_quota, processFiles, t]);
+  }, [configFetching, pendingFiles, phase, uploadConfig?.remaining_dataset_quota, allowedExtensions, maxSizeMb, processFiles, t]);
 
   const handleCommitSingle = async (
     entryId: string,

--- a/frontend/src/components/import/__tests__/UploadForm.pendingConfigQueue.test.tsx
+++ b/frontend/src/components/import/__tests__/UploadForm.pendingConfigQueue.test.tsx
@@ -1,0 +1,175 @@
+/**
+ * PR #274 follow-up regression test — drops during the upload-config fetch
+ *
+ * The dropzone used to be disabled while useUploadConfig was fetching, which
+ * made react-dropzone silently swallow files staged in that window (no toast,
+ * no request, no same-page recovery). UploadForm now queues those drops and
+ * flushes them once the query settles, re-applying the batch cap with the
+ * fresh quota.
+ */
+import { render, screen, act, waitFor } from '@/test/test-utils';
+import { UploadForm } from '../UploadForm';
+
+// ---------------------------------------------------------------------------
+// Module mocks
+// ---------------------------------------------------------------------------
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, opts?: Record<string, unknown>) => {
+      if (typeof opts?.defaultValue === 'string') return opts.defaultValue;
+      return key;
+    },
+  }),
+}));
+
+vi.mock('@/api/ingest', () => ({
+  uploadFile: vi.fn(),
+  uploadPresigned: vi.fn(),
+  previewFile: vi.fn(),
+  commitImport: vi.fn(),
+}));
+
+// Controllable useUploadConfig state — tests mutate this then rerender.
+let mockConfig: { data: unknown; isFetching: boolean } = { data: null, isFetching: false };
+vi.mock('@/components/import/hooks/use-ingest', () => ({
+  useUploadConfig: () => mockConfig,
+}));
+
+// Stub the dropzone: expose onFilesAccepted via buttons so tests can stage
+// drops without real DOM file inputs.
+vi.mock('../FileDropzone', async (importOriginal) => {
+  const original = await importOriginal<typeof import('../FileDropzone')>();
+  return {
+    effectiveBatchLimit: original.effectiveBatchLimit,
+    FileDropzone: ({ onFilesAccepted }: { onFilesAccepted: (files: File[]) => void }) => (
+      <div data-testid="file-dropzone">
+        <button
+          data-testid="drop-one"
+          onClick={() => onFilesAccepted([new File(['{}'], 'a.geojson')])}
+        >
+          Drop one
+        </button>
+        <button
+          data-testid="drop-two"
+          onClick={() =>
+            onFilesAccepted([new File(['{}'], 'b.geojson'), new File(['{}'], 'c.geojson')])
+          }
+        >
+          Drop two
+        </button>
+      </div>
+    ),
+  };
+});
+
+vi.mock('../BulkUploadProgress', () => ({
+  BulkUploadProgress: () => <div data-testid="bulk-upload-progress" />,
+}));
+vi.mock('../BulkReviewList', () => ({
+  BulkReviewList: () => <div data-testid="bulk-review-list" />,
+}));
+vi.mock('../BulkTrackingList', () => ({
+  BulkTrackingList: () => <div data-testid="bulk-tracking-list" />,
+}));
+
+vi.mock('sonner', () => ({
+  toast: { success: vi.fn(), warning: vi.fn(), error: vi.fn() },
+}));
+
+// ---------------------------------------------------------------------------
+
+import { uploadFile, previewFile } from '@/api/ingest';
+import { toast } from 'sonner';
+
+const mockUploadFile = vi.mocked(uploadFile);
+const mockPreviewFile = vi.mocked(previewFile);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockConfig = { data: null, isFetching: false };
+  mockUploadFile.mockResolvedValue({ job_id: 'job-1' } as never);
+  mockPreviewFile.mockResolvedValue({
+    source_filename: 'a.geojson',
+    columns: [],
+    row_count: 1,
+    geometry_type: 'Point',
+    crs: null,
+    latlon_candidates: null,
+  } as never);
+});
+
+describe('UploadForm — queued drops during config fetch', () => {
+  it('queues a drop while fetching and processes it once the config settles', async () => {
+    mockConfig = { data: null, isFetching: true };
+    const { rerender } = render(<UploadForm />);
+
+    await act(async () => {
+      screen.getByTestId('drop-one').click();
+    });
+
+    // Still fetching: nothing processed, nothing swallowed silently.
+    expect(mockUploadFile).not.toHaveBeenCalled();
+    expect(screen.getByTestId('file-dropzone')).toBeInTheDocument();
+
+    mockConfig = { data: { remaining_dataset_quota: null }, isFetching: false };
+    await act(async () => {
+      rerender(<UploadForm />);
+    });
+
+    await waitFor(() => expect(mockUploadFile).toHaveBeenCalledTimes(1));
+  });
+
+  it('merges multiple drops staged in the same fetch window', async () => {
+    mockConfig = { data: null, isFetching: true };
+    const { rerender } = render(<UploadForm />);
+
+    await act(async () => {
+      screen.getByTestId('drop-one').click();
+    });
+    await act(async () => {
+      screen.getByTestId('drop-two').click();
+    });
+
+    mockConfig = { data: { remaining_dataset_quota: null }, isFetching: false };
+    await act(async () => {
+      rerender(<UploadForm />);
+    });
+
+    // All three files from both drops upload — the second drop didn't
+    // overwrite the first.
+    await waitFor(() => expect(mockUploadFile).toHaveBeenCalledTimes(3));
+  });
+
+  it('rejects a queued batch that exceeds the fresh quota, whole, with a toast', async () => {
+    mockConfig = { data: null, isFetching: true };
+    const { rerender } = render(<UploadForm />);
+
+    await act(async () => {
+      screen.getByTestId('drop-two').click();
+    });
+
+    // Fresh quota allows only 1 dataset — the 2-file batch is over the cap.
+    mockConfig = { data: { remaining_dataset_quota: 1 }, isFetching: false };
+    await act(async () => {
+      rerender(<UploadForm />);
+    });
+
+    expect(mockUploadFile).not.toHaveBeenCalled();
+    expect(vi.mocked(toast.error)).toHaveBeenCalledTimes(1);
+    // Form stays idle so the user can retry immediately.
+    expect(screen.getByTestId('file-dropzone')).toBeInTheDocument();
+  });
+
+  it('processes immediately when the config is already settled', async () => {
+    mockConfig = { data: { remaining_dataset_quota: null }, isFetching: false };
+    render(<UploadForm />);
+
+    await act(async () => {
+      screen.getByTestId('drop-one').click();
+    });
+
+    await waitFor(() => expect(mockUploadFile).toHaveBeenCalledTimes(1));
+    expect(vi.mocked(toast.error)).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/import/__tests__/UploadForm.pendingConfigQueue.test.tsx
+++ b/frontend/src/components/import/__tests__/UploadForm.pendingConfigQueue.test.tsx
@@ -64,6 +64,16 @@ vi.mock('../FileDropzone', async (importOriginal) => {
         >
           Drop two
         </button>
+        <button
+          data-testid="drop-mixed"
+          onClick={() => {
+            const oversized = new File(['{}'], 'huge.geojson');
+            Object.defineProperty(oversized, 'size', { value: 50 * 1024 * 1024 });
+            onFilesAccepted([new File(['{}'], 'good.geojson'), new File(['x'], 'evil.exe'), oversized]);
+          }}
+        >
+          Drop mixed
+        </button>
       </div>
     ),
   };
@@ -165,6 +175,34 @@ describe('UploadForm — queued drops during config fetch', () => {
     expect(vi.mocked(toast.error)).toHaveBeenCalledTimes(1);
     // Form stays idle so the user can retry immediately.
     expect(screen.getByTestId('file-dropzone')).toBeInTheDocument();
+  });
+
+  it('re-applies extension and size gates from the settled config to queued drops', async () => {
+    // During the fetch window the dropzone validated against nothing — the
+    // flush must reject what the settled config rejects (Codex P2 r2 on #432).
+    mockConfig = { data: null, isFetching: true };
+    const { rerender } = render(<UploadForm />);
+
+    await act(async () => {
+      screen.getByTestId('drop-mixed').click();
+    });
+
+    mockConfig = {
+      data: {
+        remaining_dataset_quota: null,
+        allowed_extensions: '.geojson,.zip',
+        max_file_size_bytes: 10 * 1024 * 1024,
+      },
+      isFetching: false,
+    };
+    await act(async () => {
+      rerender(<UploadForm />);
+    });
+
+    // Only good.geojson survives: evil.exe (extension) and huge.geojson (50MB
+    // vs 10MB cap) are rejected with the dropzone's own toast.
+    await waitFor(() => expect(mockUploadFile).toHaveBeenCalledTimes(1));
+    expect(vi.mocked(toast.error)).toHaveBeenCalledTimes(2);
   });
 
   it('passes a permissive quota to the dropzone while fetching, the live one after', async () => {

--- a/frontend/src/components/import/__tests__/UploadForm.pendingConfigQueue.test.tsx
+++ b/frontend/src/components/import/__tests__/UploadForm.pendingConfigQueue.test.tsx
@@ -42,8 +42,14 @@ vi.mock('../FileDropzone', async (importOriginal) => {
   const original = await importOriginal<typeof import('../FileDropzone')>();
   return {
     effectiveBatchLimit: original.effectiveBatchLimit,
-    FileDropzone: ({ onFilesAccepted }: { onFilesAccepted: (files: File[]) => void }) => (
-      <div data-testid="file-dropzone">
+    FileDropzone: ({
+      onFilesAccepted,
+      remainingQuota,
+    }: {
+      onFilesAccepted: (files: File[]) => void;
+      remainingQuota?: number | null;
+    }) => (
+      <div data-testid="file-dropzone" data-remaining-quota={String(remainingQuota)}>
         <button
           data-testid="drop-one"
           onClick={() => onFilesAccepted([new File(['{}'], 'a.geojson')])}
@@ -159,6 +165,21 @@ describe('UploadForm — queued drops during config fetch', () => {
     expect(vi.mocked(toast.error)).toHaveBeenCalledTimes(1);
     // Form stays idle so the user can retry immediately.
     expect(screen.getByTestId('file-dropzone')).toBeInTheDocument();
+  });
+
+  it('passes a permissive quota to the dropzone while fetching, the live one after', async () => {
+    // Cached stale-LOW quota during the refetch window must not reach
+    // react-dropzone's maxFiles — it would reject a multi-file drop before the
+    // queue could re-validate it against the fresh value (Codex P2 on #432).
+    mockConfig = { data: { remaining_dataset_quota: 1 }, isFetching: true };
+    const { rerender } = render(<UploadForm />);
+    expect(screen.getByTestId('file-dropzone')).toHaveAttribute('data-remaining-quota', 'null');
+
+    mockConfig = { data: { remaining_dataset_quota: 7 }, isFetching: false };
+    await act(async () => {
+      rerender(<UploadForm />);
+    });
+    expect(screen.getByTestId('file-dropzone')).toHaveAttribute('data-remaining-quota', '7');
   });
 
   it('processes immediately when the config is already settled', async () => {

--- a/frontend/src/components/import/__tests__/UploadForm.pendingConfigQueue.test.tsx
+++ b/frontend/src/components/import/__tests__/UploadForm.pendingConfigQueue.test.tsx
@@ -45,11 +45,20 @@ vi.mock('../FileDropzone', async (importOriginal) => {
     FileDropzone: ({
       onFilesAccepted,
       remainingQuota,
+      allowedExtensions,
+      maxSizeMb,
     }: {
       onFilesAccepted: (files: File[]) => void;
       remainingQuota?: number | null;
+      allowedExtensions?: string[];
+      maxSizeMb?: number;
     }) => (
-      <div data-testid="file-dropzone" data-remaining-quota={String(remainingQuota)}>
+      <div
+        data-testid="file-dropzone"
+        data-remaining-quota={String(remainingQuota)}
+        data-allowed-extensions={String(allowedExtensions)}
+        data-max-size-mb={String(maxSizeMb)}
+      >
         <button
           data-testid="drop-one"
           onClick={() => onFilesAccepted([new File(['{}'], 'a.geojson')])}
@@ -205,19 +214,40 @@ describe('UploadForm — queued drops during config fetch', () => {
     expect(vi.mocked(toast.error)).toHaveBeenCalledTimes(2);
   });
 
-  it('passes a permissive quota to the dropzone while fetching, the live one after', async () => {
-    // Cached stale-LOW quota during the refetch window must not reach
-    // react-dropzone's maxFiles — it would reject a multi-file drop before the
-    // queue could re-validate it against the fresh value (Codex P2 on #432).
-    mockConfig = { data: { remaining_dataset_quota: 1 }, isFetching: true };
+  it('passes permissive gates to the dropzone while fetching, the live ones after', async () => {
+    // Cached stale values during the refetch window must not reach
+    // react-dropzone's maxFiles/accept/maxSize — they would reject drops the
+    // fresh config allows before the queue could re-validate them (Codex P2
+    // rounds 1-3 on #432).
+    mockConfig = {
+      data: {
+        remaining_dataset_quota: 1,
+        allowed_extensions: '.zip',
+        max_file_size_bytes: 1024 * 1024,
+      },
+      isFetching: true,
+    };
     const { rerender } = render(<UploadForm />);
-    expect(screen.getByTestId('file-dropzone')).toHaveAttribute('data-remaining-quota', 'null');
+    const dz = screen.getByTestId('file-dropzone');
+    expect(dz).toHaveAttribute('data-remaining-quota', 'null');
+    expect(dz).toHaveAttribute('data-allowed-extensions', 'undefined');
+    expect(dz).toHaveAttribute('data-max-size-mb', 'undefined');
 
-    mockConfig = { data: { remaining_dataset_quota: 7 }, isFetching: false };
+    mockConfig = {
+      data: {
+        remaining_dataset_quota: 7,
+        allowed_extensions: '.zip,.geojson',
+        max_file_size_bytes: 10 * 1024 * 1024,
+      },
+      isFetching: false,
+    };
     await act(async () => {
       rerender(<UploadForm />);
     });
-    expect(screen.getByTestId('file-dropzone')).toHaveAttribute('data-remaining-quota', '7');
+    const settled = screen.getByTestId('file-dropzone');
+    expect(settled).toHaveAttribute('data-remaining-quota', '7');
+    expect(settled).toHaveAttribute('data-allowed-extensions', '.zip,.geojson');
+    expect(settled).toHaveAttribute('data-max-size-mb', '10');
   });
 
   it('processes immediately when the config is already settled', async () => {


### PR DESCRIPTION
## What

The /import dropzone could **silently swallow files** (no toast, no request, no recovery without a page reload): `useUploadConfig` runs with `staleTime: 0` + `refetchOnMount: 'always'` (quota freshness, PR #274), and the dropzone was `disabled` during that fetch — react-dropzone ignores drops while disabled. Any file staged in the boot-time refetch window was dropped on the floor. This is the product fix for the race the PR #430 e2e suite had to work around with reload-retry.

## How

- `FileDropzone` is no longer disabled during the config fetch (the `disabled` prop is deleted — this was its only user).
- `UploadForm` queues files accepted while `isFetching` and flushes them once the query settles; multiple drops in the window **merge** rather than overwrite.
- The flush re-applies the batch cap against the **fresh** quota via a shared `effectiveBatchLimit` helper; over-cap batches are rejected whole with a toast, matching react-dropzone's own `maxFiles` semantics. So the original Codex P2 guarantee on #274 — never act on an unresolved/stale quota — still holds; the difference is queued-then-validated instead of silently discarded.

No schema/API/i18n impact (the toast reuses the existing `dropzone.batchLimit` key).

## Verification

- `npm run typecheck` / `npm run lint` / `npm run build` — clean
- `npm run test:coverage` — full suite passes
- New regression suite `UploadForm.pendingConfigQueue.test.tsx` (4 tests): queue-then-process, merge of same-window drops, whole-batch rejection when the fresh quota is exceeded, immediate processing when already settled

@codex review

https://claude.ai/code/session_01HSodEnENJNBi95hS2xqATn