### PR TITLE
test(search,pages): fix the two tracked CI flakes at their roots

### DIFF
--- a/backend/tests/test_hybrid_search.py
+++ b/backend/tests/test_hybrid_search.py
@@ -127,6 +127,32 @@ async def _get_embedding_dim(session) -> int:
 
 
 # ---------------------------------------------------------------------------
+# Cache isolation
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _fresh_has_embeddings_cache():
+    """Clear the module-global has_embeddings cache before every test.
+
+    fix(#433): the cache (TTL 30s, app/processing/embeddings/helpers.py) is
+    keyed by model name only, so a semantic search that ran against an EMPTY
+    embeddings table — e.g. test_semantic_fallback_no_embeddings, or any
+    earlier test on the same xdist worker — caches False and starves the
+    vector path of every test in the next 30 seconds even after embeddings
+    are inserted (empty_vector_ranks → FTS fallback → empty pages). This was
+    the "Pytest Parallel Isolation" flake on
+    test_semantic_vector_only_pagination: under -n 4 the poisoner and the
+    pagination test can land on the same worker seconds apart, while serial
+    runs put >30s between them.
+    """
+    from app.processing.embeddings import helpers
+
+    helpers._has_embeddings_cache.clear()
+    yield
+
+
+# ---------------------------------------------------------------------------
 # Helpers: toggle semantic search setting
 # ---------------------------------------------------------------------------
 

--- a/frontend/src/pages/__tests__/DatasetPage.edit-affordances.test.tsx
+++ b/frontend/src/pages/__tests__/DatasetPage.edit-affordances.test.tsx
@@ -265,7 +265,12 @@ describe('DatasetPage editable affordance integration', () => {
     setUser(null);
   });
 
-  it('shows sticky pending controls for staged drafts and clears after save/cancel', async () => {
+  // fix(#433): this test walks two full edit→stage→resolve cycles with
+  // per-keystroke userEvent typing through a heavy DatasetPage render; on
+  // loaded CI runners (coverage-instrumented, 2 cores) it can exceed the 5s
+  // default timeout while every step is properly awaited — slowness, not a
+  // race. Give it explicit headroom.
+  it('shows sticky pending controls for staged drafts and clears after save/cancel', { timeout: 15_000 }, async () => {
     setUser(EDITOR_USER);
     const user = userEvent.setup();
 


### PR DESCRIPTION
## What

Root-cause fixes for the two flakes that have been eating CI reruns (both are test-infrastructure issues, no production code changes):

### 1. `test_semantic_vector_only_pagination` (Pytest Parallel Isolation job)

The module-global `_has_embeddings_cache` in `app/processing/embeddings/helpers.py` (TTL 30s, keyed by model name only — deliberately, PERF-10) is poisoned `False` by any semantic-enabled search that runs against an empty embeddings table, e.g. `test_semantic_fallback_no_embeddings` in the same file. Every subsequent semantic test on the same xdist worker within 30s then short-circuits at the `has_embeddings` gate **even after inserting its own embeddings** — `empty_vector_ranks` → FTS fallback → "second page of semantic-only results must not be empty".

- Under `-n 4` the poisoner and the pagination test can land on the same worker seconds apart → flake.
- Serially, >30s of tests separate them → the TTL expires → always green. This matches the long-observed signature exactly (serial Backend Tests green, PPI red, rerun clears).
- **Reproduced deterministically**: running the two tests back-to-back in one process fails 100%; with the fix it passes.

Fix: an autouse fixture in `test_hybrid_search.py` clears the cache before each test. (The 30s staleness is fine in production — embeddings are written by a separate worker process and the cache is an accepted PERF-10 trade-off; this is purely cross-test bleed.)

### 2. `DatasetPage.edit-affordances` "sticky pending controls" (Frontend Tests job)

The test walks two full edit→stage→save/cancel cycles with per-keystroke `userEvent` typing through a heavy DatasetPage render. ~0.9s locally, but coverage-instrumented 2-core CI runners run it ~6× slower, occasionally crossing the 5s default `testTimeout`. Every step is properly awaited (`findBy*`/`waitFor`) — it's slowness, not a race — so it gets an explicit 15s per-test timeout.

It fired again today on #432 (an unrelated import-only PR), which is what pulled this fix forward.

## Verification

- `pytest tests/test_hybrid_search.py` — 11/11 pass; the deterministic poisoner+pagination pair passes with the fixture and fails without it
- `ruff check` / `ruff format --check` — clean
- `vitest run DatasetPage.edit-affordances.test.tsx` — 4/4 pass; `typecheck` + `eslint` clean

@codex review

https://claude.ai/code/session_01HSodEnENJNBi95hS2xqATn