### PR TITLE
fix: address video-reshoot findings (R-01, R-02) + loose ends 3/7/8/9

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -183,6 +183,13 @@ class Settings(BaseSettings):
     # Set INGEST_HTTP_TIMEOUT_SECONDS in the api service env to override.
     ingest_http_timeout_seconds: int = 300
 
+    # fix(R-02, video-reshoot 2026-07-09): finished ingest_jobs rows previously
+    # lived forever, so the admin Jobs page accumulated stale test junk with no
+    # cleanup affordance. Terminal jobs (complete/failed/cancelled/fanned_out)
+    # older than this many days are purged by the 5-minute lifespan sweeper.
+    # 0 disables the purge (keep history forever).
+    ingest_jobs_retention_days: int = 30
+
     # ---------------------------------------------------------------------------
     # Outbound Notification channels (Phase 1229 NOTIF-02 / NOTIF-03 / NOTIF-05)
     # ---------------------------------------------------------------------------

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -183,10 +183,11 @@ class Settings(BaseSettings):
     # Set INGEST_HTTP_TIMEOUT_SECONDS in the api service env to override.
     ingest_http_timeout_seconds: int = 300
 
-    # fix(R-02, video-reshoot 2026-07-09): finished ingest_jobs rows previously
-    # lived forever, so the admin Jobs page accumulated stale test junk with no
-    # cleanup affordance. Terminal jobs (complete/failed/cancelled/fanned_out)
-    # older than this many days are purged by the 5-minute lifespan sweeper.
+    # fix(#434): finished ingest_jobs rows previously lived forever, so the
+    # admin Jobs page accumulated stale test junk with no cleanup affordance.
+    # Terminal jobs (complete/failed/cancelled/fanned_out) older than this many
+    # days are purged by the 5-minute lifespan sweeper, except each dataset's
+    # most recent complete job (it backs /jobs/by-dataset warning metadata).
     # 0 disables the purge (keep history forever).
     ingest_jobs_retention_days: int = 30
 

--- a/backend/app/platform/jobs/router.py
+++ b/backend/app/platform/jobs/router.py
@@ -193,11 +193,30 @@ async def fail_stale_jobs(db: AsyncSession) -> tuple[int, int]:
             .distinct(IngestJob.dataset_id)
             .order_by(IngestJob.dataset_id, IngestJob.created_at.desc())
         )
+        # codex P2 (r7) on #434: manifest apply classifies skip/update-vs-create
+        # via _latest_completed_manifest_job (manifest_service.py), which looks
+        # up the newest complete job per user_metadata->>'manifest_key'. A
+        # manual reupload makes the manual job the per-dataset exemption, so
+        # without this second exemption the manifest-keyed row would age out
+        # and the next apply would duplicate the dataset. Mirrors the lookup's
+        # ordering (completed_at desc, created_at desc).
+        manifest_key = IngestJob.user_metadata["manifest_key"].astext
+        latest_manifest_ids = (
+            select(IngestJob.id)
+            .where(IngestJob.status == "complete", manifest_key.is_not(None))
+            .distinct(manifest_key)
+            .order_by(
+                manifest_key,
+                IngestJob.completed_at.desc(),
+                IngestJob.created_at.desc(),
+            )
+        )
         candidates = await db.execute(
             select(IngestJob.id, IngestJob.file_path).where(
                 IngestJob.status.not_in(("pending", "running")),
                 IngestJob.created_at < retention_cutoff,
                 IngestJob.id.not_in(latest_complete_ids),
+                IngestJob.id.not_in(latest_manifest_ids),
             )
         )
         purge_rows = candidates.all()

--- a/backend/app/platform/jobs/router.py
+++ b/backend/app/platform/jobs/router.py
@@ -7,9 +7,10 @@ from typing import Literal, cast
 
 import structlog
 from fastapi import APIRouter, Depends, HTTPException, status
-from sqlalchemy import select
+from sqlalchemy import delete, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.core.config import settings
 from app.core.identity import Identity
 from app.modules.auth.dependencies import get_current_active_user, require_permission
 from app.core.dependencies import get_db
@@ -172,6 +173,25 @@ async def fail_stale_jobs(db: AsyncSession) -> tuple[int, int]:
 
     # GAP-002: sweep stale VRT regenerating assets using the same cutoff.
     await sweep_stale_vrt_assets(db, running_cutoff)
+
+    # fix(R-02, video-reshoot 2026-07-09): purge terminal jobs past retention so
+    # the admin Jobs page doesn't accumulate history forever. Cutoff is on
+    # created_at (always set; jobs cap at 1h, so it is equivalent to finished-at
+    # for retention purposes and needs no NULL handling). 0 = keep forever.
+    if settings.ingest_jobs_retention_days > 0:
+        retention_cutoff = now - timedelta(days=settings.ingest_jobs_retention_days)
+        purge_result = await db.execute(
+            delete(IngestJob).where(
+                IngestJob.status.not_in(("pending", "running")),
+                IngestJob.created_at < retention_cutoff,
+            )
+        )
+        if purge_result.rowcount:
+            log.info(
+                "Purged ingest jobs past retention",
+                purged=purge_result.rowcount,
+                retention_days=settings.ingest_jobs_retention_days,
+            )
 
     await db.commit()
     return len(pending_jobs), len(running_jobs)

--- a/backend/app/platform/jobs/router.py
+++ b/backend/app/platform/jobs/router.py
@@ -193,13 +193,43 @@ async def fail_stale_jobs(db: AsyncSession) -> tuple[int, int]:
             .distinct(IngestJob.dataset_id)
             .order_by(IngestJob.dataset_id, IngestJob.created_at.desc())
         )
-        purge_result = await db.execute(
-            delete(IngestJob).where(
-                IngestJob.status.not_in(("pending", "running")),
-                IngestJob.created_at < retention_cutoff,
-                IngestJob.id.not_in(latest_complete_ids),
+        purge_filter = (
+            IngestJob.status.not_in(("pending", "running")),
+            IngestJob.created_at < retention_cutoff,
+            IngestJob.id.not_in(latest_complete_ids),
+        )
+
+        # codex P2 (r3) on #434: failed local uploads keep their staged file
+        # for retry (_should_unlink_staging), and fan-out children's shared S3
+        # original is explicitly deferred to "a retention policy" (#430 BA-09)
+        # — this purge is that policy. Reap the staged object before deleting
+        # its last pointer. Local paths are absolute and only ever unlinked
+        # inside the staging dir; S3 staging keys are relative. Best-effort:
+        # a failed reap never blocks the sweep.
+        staged = await db.execute(
+            select(IngestJob.id, IngestJob.file_path).where(
+                *purge_filter, IngestJob.file_path.is_not(None)
             )
         )
+        staging_root = Path(settings.upload_staging_dir).resolve()
+        for purge_job_id, file_path in staged.all():
+            try:
+                local = Path(file_path).resolve()
+                if local.exists():
+                    if local.is_relative_to(staging_root):
+                        local.unlink(missing_ok=True)
+                elif not Path(file_path).is_absolute():
+                    from app.platform.storage import get_storage
+
+                    await get_storage().delete(file_path)
+            except Exception:  # broad: best-effort staging cleanup
+                log.warning(
+                    "Failed to reap staged file for purged job",
+                    job_id=str(purge_job_id),
+                    file_path=file_path,
+                )
+
+        purge_result = await db.execute(delete(IngestJob).where(*purge_filter))
         if purge_result.rowcount:
             log.info(
                 "Purged ingest jobs past retention",

--- a/backend/app/platform/jobs/router.py
+++ b/backend/app/platform/jobs/router.py
@@ -205,7 +205,14 @@ async def fail_stale_jobs(db: AsyncSession) -> tuple[int, int]:
         manifest_key = IngestJob.user_metadata["manifest_key"].astext
         latest_manifest_ids = (
             select(IngestJob.id)
-            .where(IngestJob.status == "complete", manifest_key.is_not(None))
+            .where(
+                IngestJob.status == "complete",
+                manifest_key.is_not(None),
+                # codex P2 (r9): the mirrored lookup joins Dataset, so a job
+                # whose dataset was deleted (dataset_id nulled by the FK) can't
+                # influence reapply — exempting it would only defeat cleanup.
+                IngestJob.dataset_id.is_not(None),
+            )
             .distinct(manifest_key)
             .order_by(
                 manifest_key,
@@ -259,7 +266,12 @@ async def fail_stale_jobs(db: AsyncSession) -> tuple[int, int]:
                 if local.exists():
                     if local.is_relative_to(staging_root):
                         local.unlink(missing_ok=True)
-                elif not Path(file_path).is_absolute():
+                elif file_path.startswith("staging/"):
+                    # codex P1 (r9): only presigned-upload staging keys
+                    # ("staging/{job_id}/…", see ingest service/router) may be
+                    # deleted from object storage — manifest sources store
+                    # arbitrary same-bucket keys (user-managed objects) as
+                    # relative file_path values too.
                     from app.platform.storage import get_storage
 
                     await get_storage().delete(file_path)

--- a/backend/app/platform/jobs/router.py
+++ b/backend/app/platform/jobs/router.py
@@ -220,47 +220,52 @@ async def fail_stale_jobs(db: AsyncSession) -> tuple[int, int]:
                 IngestJob.created_at.desc(),
             )
         )
-        candidates = await db.execute(
-            select(IngestJob.id, IngestJob.file_path).where(
+        # Single DELETE .. RETURNING re-applies every predicate atomically at
+        # delete time — a SELECT-then-DELETE-by-id pair let /jobs/{id}/retry
+        # flip a candidate back to pending between the two statements and
+        # still lose the row (codex P2 r10 on #434).
+        deleted = await db.execute(
+            delete(IngestJob)
+            .where(
                 IngestJob.status.not_in(("pending", "running")),
                 func.coalesce(IngestJob.completed_at, IngestJob.created_at)
                 < retention_cutoff,
                 IngestJob.id.not_in(latest_complete_ids),
                 IngestJob.id.not_in(latest_manifest_ids),
             )
+            .returning(IngestJob.file_path)
         )
-        purge_rows = candidates.all()
-        purge_ids = [row_id for row_id, _ in purge_rows]
+        deleted_rows = deleted.all()
+        deleted_paths = {fp for (fp,) in deleted_rows if fp}
+        if deleted_rows:
+            log.info(
+                "Purged ingest jobs past retention",
+                purged=len(deleted_rows),
+                retention_days=settings.ingest_jobs_retention_days,
+            )
 
         # codex P2 (r3) on #434: failed local uploads keep their staged file
         # for retry (_should_unlink_staging), and fan-out children's shared S3
         # original is explicitly deferred to "a retention policy" (#430 BA-09)
-        # — this purge is that policy. Reap the staged object before deleting
-        # its last pointer, but (codex P2 r4) only when no surviving row still
-        # references the same path — fan-out siblings share one staging object
-        # and a younger row must stay retryable. Local paths are absolute and
-        # only ever unlinked inside the staging dir; S3 staging keys are
-        # relative. Best-effort: a failed reap never blocks the sweep.
-        staged_paths = {fp for _, fp in purge_rows if fp}
-        if staged_paths:
-            # Only surviving rows that still NEED the file block the reap:
-            # pending/running read it now; failed keeps it for /jobs/{id}/retry
-            # (a failed-only endpoint). Surviving complete rows (e.g. the
-            # latest-complete exemption above) keep their metadata row but not
-            # the staged file — otherwise a successful fan-out's shared
-            # original, referenced forever by children that are each a
-            # dataset's latest complete job, would never be reaped
-            # (codex P2 r5 on #434).
+        # — this purge is that policy. Reap staged objects whose last pointer
+        # was just deleted, but (codex P2 r4) only when no surviving row that
+        # still NEEDS the file references the same path: pending/running read
+        # it now; failed keeps it for /jobs/{id}/retry (a failed-only
+        # endpoint). Surviving complete rows (e.g. the exemptions above) keep
+        # their metadata row but not the staged file — otherwise a successful
+        # fan-out's shared original, referenced forever by children that are
+        # each a dataset's latest complete job, would never be reaped
+        # (codex P2 r5). Running after the DELETE, any remaining row counts.
+        if deleted_paths:
             survivors = await db.execute(
                 select(IngestJob.file_path).where(
-                    IngestJob.file_path.in_(staged_paths),
-                    IngestJob.id.not_in(purge_ids),
+                    IngestJob.file_path.in_(deleted_paths),
                     IngestJob.status.in_(("pending", "running", "failed")),
                 )
             )
-            staged_paths -= set(survivors.scalars())
+            deleted_paths -= set(survivors.scalars())
         staging_root = Path(settings.upload_staging_dir).resolve()
-        for file_path in staged_paths:
+        for file_path in deleted_paths:
             try:
                 local = Path(file_path).resolve()
                 if local.exists():
@@ -280,14 +285,6 @@ async def fail_stale_jobs(db: AsyncSession) -> tuple[int, int]:
                     "Failed to reap staged file for purged jobs",
                     file_path=file_path,
                 )
-
-        if purge_ids:
-            await db.execute(delete(IngestJob).where(IngestJob.id.in_(purge_ids)))
-            log.info(
-                "Purged ingest jobs past retention",
-                purged=len(purge_ids),
-                retention_days=settings.ingest_jobs_retention_days,
-            )
 
     await db.commit()
     return len(pending_jobs), len(running_jobs)

--- a/backend/app/platform/jobs/router.py
+++ b/backend/app/platform/jobs/router.py
@@ -174,16 +174,30 @@ async def fail_stale_jobs(db: AsyncSession) -> tuple[int, int]:
     # GAP-002: sweep stale VRT regenerating assets using the same cutoff.
     await sweep_stale_vrt_assets(db, running_cutoff)
 
-    # fix(R-02, video-reshoot 2026-07-09): purge terminal jobs past retention so
-    # the admin Jobs page doesn't accumulate history forever. Cutoff is on
-    # created_at (always set; jobs cap at 1h, so it is equivalent to finished-at
-    # for retention purposes and needs no NULL handling). 0 = keep forever.
+    # fix(#434): purge terminal jobs past retention so the admin Jobs page
+    # doesn't accumulate history forever. Cutoff is on created_at (always set;
+    # jobs cap at 1h, so it is equivalent to finished-at for retention purposes
+    # and needs no NULL handling). 0 = keep forever. Each dataset's most recent
+    # complete job is exempt regardless of age: /jobs/by-dataset/{id} serves the
+    # dataset page's persistent ingest warnings and the reupload source_layer
+    # hint from it (codex P2 on #434). Jobs whose dataset was deleted have
+    # dataset_id nulled (FK ondelete=SET NULL) and stay purgeable.
     if settings.ingest_jobs_retention_days > 0:
         retention_cutoff = now - timedelta(days=settings.ingest_jobs_retention_days)
+        latest_complete_ids = (
+            select(IngestJob.id)
+            .where(
+                IngestJob.status == "complete",
+                IngestJob.dataset_id.is_not(None),
+            )
+            .distinct(IngestJob.dataset_id)
+            .order_by(IngestJob.dataset_id, IngestJob.created_at.desc())
+        )
         purge_result = await db.execute(
             delete(IngestJob).where(
                 IngestJob.status.not_in(("pending", "running")),
                 IngestJob.created_at < retention_cutoff,
+                IngestJob.id.not_in(latest_complete_ids),
             )
         )
         if purge_result.rowcount:

--- a/backend/app/platform/jobs/router.py
+++ b/backend/app/platform/jobs/router.py
@@ -193,26 +193,36 @@ async def fail_stale_jobs(db: AsyncSession) -> tuple[int, int]:
             .distinct(IngestJob.dataset_id)
             .order_by(IngestJob.dataset_id, IngestJob.created_at.desc())
         )
-        purge_filter = (
-            IngestJob.status.not_in(("pending", "running")),
-            IngestJob.created_at < retention_cutoff,
-            IngestJob.id.not_in(latest_complete_ids),
+        candidates = await db.execute(
+            select(IngestJob.id, IngestJob.file_path).where(
+                IngestJob.status.not_in(("pending", "running")),
+                IngestJob.created_at < retention_cutoff,
+                IngestJob.id.not_in(latest_complete_ids),
+            )
         )
+        purge_rows = candidates.all()
+        purge_ids = [row_id for row_id, _ in purge_rows]
 
         # codex P2 (r3) on #434: failed local uploads keep their staged file
         # for retry (_should_unlink_staging), and fan-out children's shared S3
         # original is explicitly deferred to "a retention policy" (#430 BA-09)
         # — this purge is that policy. Reap the staged object before deleting
-        # its last pointer. Local paths are absolute and only ever unlinked
-        # inside the staging dir; S3 staging keys are relative. Best-effort:
-        # a failed reap never blocks the sweep.
-        staged = await db.execute(
-            select(IngestJob.id, IngestJob.file_path).where(
-                *purge_filter, IngestJob.file_path.is_not(None)
+        # its last pointer, but (codex P2 r4) only when no surviving row still
+        # references the same path — fan-out siblings share one staging object
+        # and a younger row must stay retryable. Local paths are absolute and
+        # only ever unlinked inside the staging dir; S3 staging keys are
+        # relative. Best-effort: a failed reap never blocks the sweep.
+        staged_paths = {fp for _, fp in purge_rows if fp}
+        if staged_paths:
+            survivors = await db.execute(
+                select(IngestJob.file_path).where(
+                    IngestJob.file_path.in_(staged_paths),
+                    IngestJob.id.not_in(purge_ids),
+                )
             )
-        )
+            staged_paths -= set(survivors.scalars())
         staging_root = Path(settings.upload_staging_dir).resolve()
-        for purge_job_id, file_path in staged.all():
+        for file_path in staged_paths:
             try:
                 local = Path(file_path).resolve()
                 if local.exists():
@@ -224,16 +234,15 @@ async def fail_stale_jobs(db: AsyncSession) -> tuple[int, int]:
                     await get_storage().delete(file_path)
             except Exception:  # broad: best-effort staging cleanup
                 log.warning(
-                    "Failed to reap staged file for purged job",
-                    job_id=str(purge_job_id),
+                    "Failed to reap staged file for purged jobs",
                     file_path=file_path,
                 )
 
-        purge_result = await db.execute(delete(IngestJob).where(*purge_filter))
-        if purge_result.rowcount:
+        if purge_ids:
+            await db.execute(delete(IngestJob).where(IngestJob.id.in_(purge_ids)))
             log.info(
                 "Purged ingest jobs past retention",
-                purged=purge_result.rowcount,
+                purged=len(purge_ids),
                 retention_days=settings.ingest_jobs_retention_days,
             )
 

--- a/backend/app/platform/jobs/router.py
+++ b/backend/app/platform/jobs/router.py
@@ -7,7 +7,7 @@ from typing import Literal, cast
 
 import structlog
 from fastapi import APIRouter, Depends, HTTPException, status
-from sqlalchemy import delete, select
+from sqlalchemy import delete, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.config import settings
@@ -175,9 +175,11 @@ async def fail_stale_jobs(db: AsyncSession) -> tuple[int, int]:
     await sweep_stale_vrt_assets(db, running_cutoff)
 
     # fix(#434): purge terminal jobs past retention so the admin Jobs page
-    # doesn't accumulate history forever. Cutoff is on created_at (always set;
-    # jobs cap at 1h, so it is equivalent to finished-at for retention purposes
-    # and needs no NULL handling). 0 = keep forever. Each dataset's most recent
+    # doesn't accumulate history forever. Cutoff is on finished-at
+    # (coalesce(completed_at, created_at)) rather than created_at — the stale
+    # sweep above fails ancient pending/running rows with completed_at=now, and
+    # a created_at cutoff would delete that fresh failure evidence in the same
+    # transaction (codex P2 r8). 0 = keep forever. Each dataset's most recent
     # complete job is exempt regardless of age: /jobs/by-dataset/{id} serves the
     # dataset page's persistent ingest warnings and the reupload source_layer
     # hint from it (codex P2 on #434). Jobs whose dataset was deleted have
@@ -214,7 +216,8 @@ async def fail_stale_jobs(db: AsyncSession) -> tuple[int, int]:
         candidates = await db.execute(
             select(IngestJob.id, IngestJob.file_path).where(
                 IngestJob.status.not_in(("pending", "running")),
-                IngestJob.created_at < retention_cutoff,
+                func.coalesce(IngestJob.completed_at, IngestJob.created_at)
+                < retention_cutoff,
                 IngestJob.id.not_in(latest_complete_ids),
                 IngestJob.id.not_in(latest_manifest_ids),
             )

--- a/backend/app/platform/jobs/router.py
+++ b/backend/app/platform/jobs/router.py
@@ -214,10 +214,19 @@ async def fail_stale_jobs(db: AsyncSession) -> tuple[int, int]:
         # relative. Best-effort: a failed reap never blocks the sweep.
         staged_paths = {fp for _, fp in purge_rows if fp}
         if staged_paths:
+            # Only surviving rows that still NEED the file block the reap:
+            # pending/running read it now; failed keeps it for /jobs/{id}/retry
+            # (a failed-only endpoint). Surviving complete rows (e.g. the
+            # latest-complete exemption above) keep their metadata row but not
+            # the staged file — otherwise a successful fan-out's shared
+            # original, referenced forever by children that are each a
+            # dataset's latest complete job, would never be reaped
+            # (codex P2 r5 on #434).
             survivors = await db.execute(
                 select(IngestJob.file_path).where(
                     IngestJob.file_path.in_(staged_paths),
                     IngestJob.id.not_in(purge_ids),
+                    IngestJob.status.in_(("pending", "running", "failed")),
                 )
             )
             staged_paths -= set(survivors.scalars())

--- a/backend/tests/test_related_datasets.py
+++ b/backend/tests/test_related_datasets.py
@@ -6,11 +6,27 @@ datasets ranked by embedding cosine similarity.
 
 import uuid
 
+import pytest
 from httpx import AsyncClient
 
 from app.processing.embeddings.models import RecordEmbedding
 
 from tests.factories import create_dataset, get_user_id
+
+
+@pytest.fixture(autouse=True)
+def _fresh_has_embeddings_cache():
+    """Clear the module-global has_embeddings cache before every test.
+
+    fix(#433 follow-up): same hazard class as test_hybrid_search.py — this file
+    inserts RecordEmbedding rows, so under xdist a stale cached False (poisoned
+    by an earlier empty-table test on the same worker, TTL 30s) would starve
+    the vector path, and our own inserts can poison True for later tests.
+    """
+    from app.processing.embeddings import helpers
+
+    helpers._has_embeddings_cache.clear()
+    yield
 
 
 def _make_embedding(base: list[float], dim: int = 1536) -> list[float]:

--- a/backend/tests/test_vrt_stale_sweep_gap002.py
+++ b/backend/tests/test_vrt_stale_sweep_gap002.py
@@ -315,9 +315,14 @@ async def test_retention_purge_keeps_latest_complete_job_per_dataset(
     staged_file = tmp_path / "failed-upload.geojson"
     staged_file.write_text("{}")
     # codex P2 (r4): fan-out siblings share one staging object — a path also
-    # referenced by a row OUTSIDE the purge set must NOT be reaped.
+    # referenced by a retryable row OUTSIDE the purge set must NOT be reaped.
     shared_file = tmp_path / "shared-fanout.gpkg"
     shared_file.write_text("{}")
+    # codex P2 (r5): a SUCCESSFUL fan-out's shared original is referenced
+    # forever by exempt latest-complete children — a surviving complete row
+    # must NOT block the reap (only pending/running/failed need the file).
+    fanout_file = tmp_path / "successful-fanout.gpkg"
+    fanout_file.write_text("{}")
 
     now = datetime.now(timezone.utc)
     ancient = now - timedelta(days=120)
@@ -327,7 +332,16 @@ async def test_retention_purge_keeps_latest_complete_job_per_dataset(
             dataset_id=ds.id, status="complete", created_at=ancient
         ),
         "latest_complete": IngestJob(
-            dataset_id=ds.id, status="complete", created_at=old
+            dataset_id=ds.id,
+            status="complete",
+            created_at=old,
+            file_path=str(fanout_file),
+        ),
+        "old_fanned_out_parent": IngestJob(
+            dataset_id=None,
+            status="fanned_out",
+            created_at=old,
+            file_path=str(fanout_file),
         ),
         "old_failed": IngestJob(
             dataset_id=ds.id,
@@ -369,13 +383,18 @@ async def test_retention_purge_keeps_latest_complete_job_per_dataset(
         "old_failed",
         "orphan_complete",
         "old_failed_shared",
+        "old_fanned_out_parent",
     ):
         assert ids[name] not in remaining, f"{name} should have been purged"
     assert not staged_file.exists(), (
         "the purged failed job's staged file must be reaped with the row"
     )
     assert shared_file.exists(), (
-        "a staging file still referenced by a surviving job must NOT be reaped"
+        "a staging file still referenced by a surviving RETRYABLE job must NOT be reaped"
+    )
+    assert not fanout_file.exists(), (
+        "a successful fan-out's shared original must be reaped even though the "
+        "exempt latest-complete child still references it"
     )
 
 

--- a/backend/tests/test_vrt_stale_sweep_gap002.py
+++ b/backend/tests/test_vrt_stale_sweep_gap002.py
@@ -376,6 +376,16 @@ async def test_retention_purge_keeps_latest_complete_job_per_dataset(
             created_at=now - timedelta(days=1),
             file_path=str(shared_file),
         ),
+        # codex P2 (r8): an ancient still-running row gets stale-failed by THIS
+        # same fail_stale_jobs call (completed_at=now) — the purge cutoff is on
+        # finished-at, so the fresh failure evidence must survive a full
+        # retention window instead of being deleted in the same transaction.
+        "ancient_stale_running": IngestJob(
+            dataset_id=ds.id,
+            status="running",
+            created_at=ancient,
+            started_at=ancient,
+        ),
     }
     test_db_session.add_all(rows.values())
     await test_db_session.commit()
@@ -393,6 +403,12 @@ async def test_retention_purge_keeps_latest_complete_job_per_dataset(
     assert ids["manifest_complete"] in remaining, (
         "the newest complete job per manifest_key must survive retention"
     )
+    assert ids["ancient_stale_running"] in remaining, (
+        "a row stale-failed by this same sweep must keep its fresh failure "
+        "evidence for a full retention window"
+    )
+    stale_failed = await test_db_session.get(IngestJob, ids["ancient_stale_running"])
+    assert stale_failed.status == "failed"
     for name in (
         "older_complete",
         "old_failed",

--- a/backend/tests/test_vrt_stale_sweep_gap002.py
+++ b/backend/tests/test_vrt_stale_sweep_gap002.py
@@ -110,7 +110,7 @@ def _make_mock_db_for_fail_stale(
       2. stale running IngestJobs → scalars() returns list
       3. stale regenerating RasterAssets → scalars() returns list
       4. stale VrtGeneration rows → scalars() returns list
-      5. retention purge DELETE (fix R-02) → rowcount
+      5. retention purge DELETE (fix #434) → rowcount
     """
     results = []
     for lst in [
@@ -251,7 +251,7 @@ async def test_fail_stale_jobs_returns_vrt_asset_count():
 
 
 # ---------------------------------------------------------------------------
-# fix(R-02, video-reshoot 2026-07-09): retention purge of terminal jobs
+# fix(#434): retention purge of terminal jobs
 # ---------------------------------------------------------------------------
 
 
@@ -272,6 +272,54 @@ async def test_fail_stale_jobs_purges_terminal_jobs_past_retention():
     assert "'pending'" in where_sql and "'running'" in where_sql, (
         "purge must exclude active statuses, got: " + where_sql
     )
+
+
+# NOTE: no @pytest.mark.asyncio here — test_db_session is an AnyIO fixture and
+# the pytest-asyncio marker would run the test body on a different event loop
+# than the fixture's asyncpg connection ("attached to a different loop").
+async def test_retention_purge_keeps_latest_complete_job_per_dataset(test_db_session):
+    """codex P2 on #434: /jobs/by-dataset serves persistent ingest warnings and
+    the reupload source_layer hint from a dataset's most recent complete job —
+    that row must survive the purge no matter how old it is. Older completes
+    and failed rows past retention are still deleted."""
+    from sqlalchemy import select as sa_select
+
+    from app.platform.jobs.models import IngestJob
+    from app.platform.jobs.router import fail_stale_jobs
+    from tests.factories import create_dataset, get_user_id
+
+    user_id = await get_user_id(test_db_session, "admin")
+    ds = await create_dataset(
+        test_db_session, created_by=user_id, name="Retention Exemption DS"
+    )
+
+    now = datetime.now(timezone.utc)
+    ancient = now - timedelta(days=120)
+    old = now - timedelta(days=90)
+    rows = {
+        "older_complete": IngestJob(
+            dataset_id=ds.id, status="complete", created_at=ancient
+        ),
+        "latest_complete": IngestJob(
+            dataset_id=ds.id, status="complete", created_at=old
+        ),
+        "old_failed": IngestJob(dataset_id=ds.id, status="failed", created_at=old),
+        "orphan_complete": IngestJob(
+            dataset_id=None, status="complete", created_at=old
+        ),
+    }
+    test_db_session.add_all(rows.values())
+    await test_db_session.commit()
+    ids = {k: v.id for k, v in rows.items()}
+
+    await fail_stale_jobs(test_db_session)
+
+    remaining = set((await test_db_session.execute(sa_select(IngestJob.id))).scalars())
+    assert ids["latest_complete"] in remaining, (
+        "the dataset's most recent complete job must survive retention"
+    )
+    for name in ("older_complete", "old_failed", "orphan_complete"):
+        assert ids[name] not in remaining, f"{name} should have been purged"
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_vrt_stale_sweep_gap002.py
+++ b/backend/tests/test_vrt_stale_sweep_gap002.py
@@ -110,7 +110,8 @@ def _make_mock_db_for_fail_stale(
       2. stale running IngestJobs → scalars() returns list
       3. stale regenerating RasterAssets → scalars() returns list
       4. stale VrtGeneration rows → scalars() returns list
-      5. retention purge DELETE (fix #434) → rowcount
+      5. staged-file SELECT for the retention purge (fix #434) → .all() rows
+      6. retention purge DELETE (fix #434) → rowcount
     """
     results = []
     for lst in [
@@ -122,6 +123,10 @@ def _make_mock_db_for_fail_stale(
         mock_result = MagicMock()
         mock_result.scalars.return_value = lst
         results.append(mock_result)
+
+    staged_result = MagicMock()
+    staged_result.all.return_value = []
+    results.append(staged_result)
 
     purge_result = MagicMock()
     purge_result.rowcount = 0
@@ -257,7 +262,7 @@ async def test_fail_stale_jobs_returns_vrt_asset_count():
 
 @pytest.mark.asyncio
 async def test_fail_stale_jobs_purges_terminal_jobs_past_retention():
-    """The 5th execute() is a DELETE on ingest_jobs scoped to terminal statuses."""
+    """The final execute() is a DELETE on ingest_jobs scoped to terminal statuses."""
     from sqlalchemy.sql.dml import Delete
 
     from app.platform.jobs.router import fail_stale_jobs
@@ -265,8 +270,8 @@ async def test_fail_stale_jobs_purges_terminal_jobs_past_retention():
     mock_db = _make_mock_db_for_fail_stale()
     await fail_stale_jobs(mock_db)
 
-    assert mock_db.execute.await_count == 5
-    purge_stmt = mock_db.execute.await_args_list[4].args[0]
+    assert mock_db.execute.await_count == 6
+    purge_stmt = mock_db.execute.await_args_list[5].args[0]
     assert isinstance(purge_stmt, Delete)
     where_sql = str(purge_stmt.compile(compile_kwargs={"literal_binds": True}))
     assert "'pending'" in where_sql and "'running'" in where_sql, (
@@ -277,13 +282,17 @@ async def test_fail_stale_jobs_purges_terminal_jobs_past_retention():
 # NOTE: no @pytest.mark.asyncio here — test_db_session is an AnyIO fixture and
 # the pytest-asyncio marker would run the test body on a different event loop
 # than the fixture's asyncpg connection ("attached to a different loop").
-async def test_retention_purge_keeps_latest_complete_job_per_dataset(test_db_session):
+async def test_retention_purge_keeps_latest_complete_job_per_dataset(
+    test_db_session, tmp_path, monkeypatch
+):
     """codex P2 on #434: /jobs/by-dataset serves persistent ingest warnings and
     the reupload source_layer hint from a dataset's most recent complete job —
     that row must survive the purge no matter how old it is. Older completes
-    and failed rows past retention are still deleted."""
+    and failed rows past retention are still deleted, and (codex P2 r3) a
+    purged failed job's staged local file is reaped along with the row."""
     from sqlalchemy import select as sa_select
 
+    from app.core.config import settings
     from app.platform.jobs.models import IngestJob
     from app.platform.jobs.router import fail_stale_jobs
     from tests.factories import create_dataset, get_user_id
@@ -292,6 +301,12 @@ async def test_retention_purge_keeps_latest_complete_job_per_dataset(test_db_ses
     ds = await create_dataset(
         test_db_session, created_by=user_id, name="Retention Exemption DS"
     )
+
+    # Staged local upload kept for retry by a failed job (see
+    # _should_unlink_staging) — must be unlinked when its row is purged.
+    monkeypatch.setattr(settings, "upload_staging_dir", str(tmp_path))
+    staged_file = tmp_path / "failed-upload.geojson"
+    staged_file.write_text("{}")
 
     now = datetime.now(timezone.utc)
     ancient = now - timedelta(days=120)
@@ -303,7 +318,12 @@ async def test_retention_purge_keeps_latest_complete_job_per_dataset(test_db_ses
         "latest_complete": IngestJob(
             dataset_id=ds.id, status="complete", created_at=old
         ),
-        "old_failed": IngestJob(dataset_id=ds.id, status="failed", created_at=old),
+        "old_failed": IngestJob(
+            dataset_id=ds.id,
+            status="failed",
+            created_at=old,
+            file_path=str(staged_file),
+        ),
         "orphan_complete": IngestJob(
             dataset_id=None, status="complete", created_at=old
         ),
@@ -320,6 +340,9 @@ async def test_retention_purge_keeps_latest_complete_job_per_dataset(test_db_ses
     )
     for name in ("older_complete", "old_failed", "orphan_complete"):
         assert ids[name] not in remaining, f"{name} should have been purged"
+    assert not staged_file.exists(), (
+        "the purged failed job's staged file must be reaped with the row"
+    )
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_vrt_stale_sweep_gap002.py
+++ b/backend/tests/test_vrt_stale_sweep_gap002.py
@@ -102,6 +102,7 @@ def _make_mock_db_for_fail_stale(
     stale_jobs_running: list | None = None,
     stale_vrt_assets: list | None = None,
     stale_vrt_generations: list | None = None,
+    purge_candidates: list | None = None,
 ) -> AsyncMock:
     """Build a mock AsyncSession for fail_stale_jobs.
 
@@ -110,8 +111,10 @@ def _make_mock_db_for_fail_stale(
       2. stale running IngestJobs → scalars() returns list
       3. stale regenerating RasterAssets → scalars() returns list
       4. stale VrtGeneration rows → scalars() returns list
-      5. staged-file SELECT for the retention purge (fix #434) → .all() rows
-      6. retention purge DELETE (fix #434) → rowcount
+      5. purge-candidate SELECT (fix #434) → .all() returns (id, file_path) rows
+      6. purge DELETE by id (fix #434) — only issued when candidates exist
+    (a survivors SELECT fires between 5 and 6 only when a candidate has a
+    non-null file_path — keep mock candidates' file_path None)
     """
     results = []
     for lst in [
@@ -124,13 +127,14 @@ def _make_mock_db_for_fail_stale(
         mock_result.scalars.return_value = lst
         results.append(mock_result)
 
-    staged_result = MagicMock()
-    staged_result.all.return_value = []
-    results.append(staged_result)
+    candidates_result = MagicMock()
+    candidates_result.all.return_value = purge_candidates or []
+    results.append(candidates_result)
 
-    purge_result = MagicMock()
-    purge_result.rowcount = 0
-    results.append(purge_result)
+    if purge_candidates:
+        delete_result = MagicMock()
+        delete_result.rowcount = len(purge_candidates)
+        results.append(delete_result)
 
     mock_db = AsyncMock()
     mock_db.execute = AsyncMock(side_effect=results)
@@ -262,21 +266,24 @@ async def test_fail_stale_jobs_returns_vrt_asset_count():
 
 @pytest.mark.asyncio
 async def test_fail_stale_jobs_purges_terminal_jobs_past_retention():
-    """The final execute() is a DELETE on ingest_jobs scoped to terminal statuses."""
+    """Candidates are selected with terminal-status scoping, then deleted by id."""
     from sqlalchemy.sql.dml import Delete
+    from sqlalchemy.sql.selectable import Select
 
     from app.platform.jobs.router import fail_stale_jobs
 
-    mock_db = _make_mock_db_for_fail_stale()
+    mock_db = _make_mock_db_for_fail_stale(purge_candidates=[(uuid4(), None)])
     await fail_stale_jobs(mock_db)
 
     assert mock_db.execute.await_count == 6
+    candidates_stmt = mock_db.execute.await_args_list[4].args[0]
+    assert isinstance(candidates_stmt, Select)
+    where_sql = str(candidates_stmt.compile(compile_kwargs={"literal_binds": True}))
+    assert "'pending'" in where_sql and "'running'" in where_sql, (
+        "purge candidates must exclude active statuses, got: " + where_sql
+    )
     purge_stmt = mock_db.execute.await_args_list[5].args[0]
     assert isinstance(purge_stmt, Delete)
-    where_sql = str(purge_stmt.compile(compile_kwargs={"literal_binds": True}))
-    assert "'pending'" in where_sql and "'running'" in where_sql, (
-        "purge must exclude active statuses, got: " + where_sql
-    )
 
 
 # NOTE: no @pytest.mark.asyncio here — test_db_session is an AnyIO fixture and
@@ -307,6 +314,10 @@ async def test_retention_purge_keeps_latest_complete_job_per_dataset(
     monkeypatch.setattr(settings, "upload_staging_dir", str(tmp_path))
     staged_file = tmp_path / "failed-upload.geojson"
     staged_file.write_text("{}")
+    # codex P2 (r4): fan-out siblings share one staging object — a path also
+    # referenced by a row OUTSIDE the purge set must NOT be reaped.
+    shared_file = tmp_path / "shared-fanout.gpkg"
+    shared_file.write_text("{}")
 
     now = datetime.now(timezone.utc)
     ancient = now - timedelta(days=120)
@@ -327,6 +338,18 @@ async def test_retention_purge_keeps_latest_complete_job_per_dataset(
         "orphan_complete": IngestJob(
             dataset_id=None, status="complete", created_at=old
         ),
+        "old_failed_shared": IngestJob(
+            dataset_id=ds.id,
+            status="failed",
+            created_at=old,
+            file_path=str(shared_file),
+        ),
+        "recent_failed_shared": IngestJob(
+            dataset_id=ds.id,
+            status="failed",
+            created_at=now - timedelta(days=1),
+            file_path=str(shared_file),
+        ),
     }
     test_db_session.add_all(rows.values())
     await test_db_session.commit()
@@ -338,10 +361,21 @@ async def test_retention_purge_keeps_latest_complete_job_per_dataset(
     assert ids["latest_complete"] in remaining, (
         "the dataset's most recent complete job must survive retention"
     )
-    for name in ("older_complete", "old_failed", "orphan_complete"):
+    assert ids["recent_failed_shared"] in remaining, (
+        "a failed job within retention must survive"
+    )
+    for name in (
+        "older_complete",
+        "old_failed",
+        "orphan_complete",
+        "old_failed_shared",
+    ):
         assert ids[name] not in remaining, f"{name} should have been purged"
     assert not staged_file.exists(), (
         "the purged failed job's staged file must be reaped with the row"
+    )
+    assert shared_file.exists(), (
+        "a staging file still referenced by a surviving job must NOT be reaped"
     )
 
 

--- a/backend/tests/test_vrt_stale_sweep_gap002.py
+++ b/backend/tests/test_vrt_stale_sweep_gap002.py
@@ -111,10 +111,10 @@ def _make_mock_db_for_fail_stale(
       2. stale running IngestJobs → scalars() returns list
       3. stale regenerating RasterAssets → scalars() returns list
       4. stale VrtGeneration rows → scalars() returns list
-      5. purge-candidate SELECT (fix #434) → .all() returns (id, file_path) rows
-      6. purge DELETE by id (fix #434) — only issued when candidates exist
-    (a survivors SELECT fires between 5 and 6 only when a candidate has a
-    non-null file_path — keep mock candidates' file_path None)
+      5. purge DELETE .. RETURNING file_path (fix #434) → .all() returns
+         (file_path,) one-tuples
+    (a survivors SELECT fires after 5 only when a deleted row had a non-null
+    file_path — keep mock candidates' file_path None)
     """
     results = []
     for lst in [
@@ -127,14 +127,9 @@ def _make_mock_db_for_fail_stale(
         mock_result.scalars.return_value = lst
         results.append(mock_result)
 
-    candidates_result = MagicMock()
-    candidates_result.all.return_value = purge_candidates or []
-    results.append(candidates_result)
-
-    if purge_candidates:
-        delete_result = MagicMock()
-        delete_result.rowcount = len(purge_candidates)
-        results.append(delete_result)
+    delete_result = MagicMock()
+    delete_result.all.return_value = purge_candidates or []
+    results.append(delete_result)
 
     mock_db = AsyncMock()
     mock_db.execute = AsyncMock(side_effect=results)
@@ -266,24 +261,23 @@ async def test_fail_stale_jobs_returns_vrt_asset_count():
 
 @pytest.mark.asyncio
 async def test_fail_stale_jobs_purges_terminal_jobs_past_retention():
-    """Candidates are selected with terminal-status scoping, then deleted by id."""
+    """The purge is one DELETE that carries the terminal-status predicates
+    itself (codex P2 r10: a SELECT-then-DELETE-by-id pair raced with
+    /jobs/{id}/retry)."""
     from sqlalchemy.sql.dml import Delete
-    from sqlalchemy.sql.selectable import Select
 
     from app.platform.jobs.router import fail_stale_jobs
 
-    mock_db = _make_mock_db_for_fail_stale(purge_candidates=[(uuid4(), None)])
+    mock_db = _make_mock_db_for_fail_stale(purge_candidates=[(None,)])
     await fail_stale_jobs(mock_db)
 
-    assert mock_db.execute.await_count == 6
-    candidates_stmt = mock_db.execute.await_args_list[4].args[0]
-    assert isinstance(candidates_stmt, Select)
-    where_sql = str(candidates_stmt.compile(compile_kwargs={"literal_binds": True}))
-    assert "'pending'" in where_sql and "'running'" in where_sql, (
-        "purge candidates must exclude active statuses, got: " + where_sql
-    )
-    purge_stmt = mock_db.execute.await_args_list[5].args[0]
+    assert mock_db.execute.await_count == 5
+    purge_stmt = mock_db.execute.await_args_list[4].args[0]
     assert isinstance(purge_stmt, Delete)
+    where_sql = str(purge_stmt.compile(compile_kwargs={"literal_binds": True}))
+    assert "'pending'" in where_sql and "'running'" in where_sql, (
+        "purge must exclude active statuses at delete time, got: " + where_sql
+    )
 
 
 # NOTE: no @pytest.mark.asyncio here — test_db_session is an AnyIO fixture and

--- a/backend/tests/test_vrt_stale_sweep_gap002.py
+++ b/backend/tests/test_vrt_stale_sweep_gap002.py
@@ -110,6 +110,7 @@ def _make_mock_db_for_fail_stale(
       2. stale running IngestJobs → scalars() returns list
       3. stale regenerating RasterAssets → scalars() returns list
       4. stale VrtGeneration rows → scalars() returns list
+      5. retention purge DELETE (fix R-02) → rowcount
     """
     results = []
     for lst in [
@@ -121,6 +122,10 @@ def _make_mock_db_for_fail_stale(
         mock_result = MagicMock()
         mock_result.scalars.return_value = lst
         results.append(mock_result)
+
+    purge_result = MagicMock()
+    purge_result.rowcount = 0
+    results.append(purge_result)
 
     mock_db = AsyncMock()
     mock_db.execute = AsyncMock(side_effect=results)
@@ -243,6 +248,43 @@ async def test_fail_stale_jobs_returns_vrt_asset_count():
 
     # Result must be a tuple (the IngestJob counts are the base contract).
     assert isinstance(result, tuple)
+
+
+# ---------------------------------------------------------------------------
+# fix(R-02, video-reshoot 2026-07-09): retention purge of terminal jobs
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_fail_stale_jobs_purges_terminal_jobs_past_retention():
+    """The 5th execute() is a DELETE on ingest_jobs scoped to terminal statuses."""
+    from sqlalchemy.sql.dml import Delete
+
+    from app.platform.jobs.router import fail_stale_jobs
+
+    mock_db = _make_mock_db_for_fail_stale()
+    await fail_stale_jobs(mock_db)
+
+    assert mock_db.execute.await_count == 5
+    purge_stmt = mock_db.execute.await_args_list[4].args[0]
+    assert isinstance(purge_stmt, Delete)
+    where_sql = str(purge_stmt.compile(compile_kwargs={"literal_binds": True}))
+    assert "'pending'" in where_sql and "'running'" in where_sql, (
+        "purge must exclude active statuses, got: " + where_sql
+    )
+
+
+@pytest.mark.asyncio
+async def test_fail_stale_jobs_retention_zero_disables_purge(monkeypatch):
+    """ingest_jobs_retention_days=0 keeps history forever (no DELETE issued)."""
+    from app.core.config import settings
+    from app.platform.jobs.router import fail_stale_jobs
+
+    monkeypatch.setattr(settings, "ingest_jobs_retention_days", 0)
+    mock_db = _make_mock_db_for_fail_stale()
+    await fail_stale_jobs(mock_db)
+
+    assert mock_db.execute.await_count == 4
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_vrt_stale_sweep_gap002.py
+++ b/backend/tests/test_vrt_stale_sweep_gap002.py
@@ -343,6 +343,18 @@ async def test_retention_purge_keeps_latest_complete_job_per_dataset(
             created_at=old,
             file_path=str(fanout_file),
         ),
+        # codex P2 (r7): manifest apply resolves datasets via the newest
+        # complete job per manifest_key — this row is OLDER than the dataset's
+        # latest complete job (so the per-dataset exemption skips it) but must
+        # survive via the manifest-key exemption or re-applying the manifest
+        # would duplicate the dataset.
+        "manifest_complete": IngestJob(
+            dataset_id=ds.id,
+            status="complete",
+            created_at=ancient,
+            completed_at=ancient,
+            user_metadata={"manifest_key": "showcase/retention-ds"},
+        ),
         "old_failed": IngestJob(
             dataset_id=ds.id,
             status="failed",
@@ -377,6 +389,9 @@ async def test_retention_purge_keeps_latest_complete_job_per_dataset(
     )
     assert ids["recent_failed_shared"] in remaining, (
         "a failed job within retention must survive"
+    )
+    assert ids["manifest_complete"] in remaining, (
+        "the newest complete job per manifest_key must survive retention"
     )
     for name in (
         "older_complete",

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -291,7 +291,7 @@ services:
 
   titiler:
     # Third-party image — identical to docker-compose.yml.
-    image: ghcr.io/developmentseed/titiler:2.0.2
+    image: ghcr.io/developmentseed/titiler:2.0.5
     init: true
     restart: unless-stopped
     stop_grace_period: 15s

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -230,6 +230,9 @@ services:
       ENV_ONLY_CONFIG: "${ENV_ONLY_CONFIG:-false}"
       CORS_ALLOWED_ORIGINS: "${CORS_ALLOWED_ORIGINS:-}"
       INGEST_HTTP_TIMEOUT_SECONDS: "${INGEST_HTTP_TIMEOUT_SECONDS:-300}"
+      # fix(#434): retention for terminal ingest_jobs rows, purged by the API
+      # lifespan sweeper (0 = keep history forever).
+      INGEST_JOBS_RETENTION_DAYS: "${INGEST_JOBS_RETENTION_DAYS:-30}"
       PROCRASTINATE_SCHEMA: "${PROCRASTINATE_SCHEMA:-catalog}"
     depends_on:
       db:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -376,7 +376,8 @@ services:
 
   titiler:
     # Pinned to 2.x stable (held back from 3.x without contract testing).
-    image: ghcr.io/developmentseed/titiler:2.0.2
+    # 2.0.5 bump per the 2026-07 TiTiler assessment (patch-level, same contract).
+    image: ghcr.io/developmentseed/titiler:2.0.5
     init: true
     restart: unless-stopped
     stop_grace_period: 15s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -310,6 +310,9 @@ services:
       # Ingest tuning: GDAL_HTTP_TIMEOUT passed to ogr2ogr (SEED-02, raised
       # from the 120s hardcoded default that timed out 50% of AGO layers).
       INGEST_HTTP_TIMEOUT_SECONDS: "${INGEST_HTTP_TIMEOUT_SECONDS:-300}"
+      # fix(#434): retention for terminal ingest_jobs rows, purged by the API
+      # lifespan sweeper (0 = keep history forever).
+      INGEST_JOBS_RETENTION_DAYS: "${INGEST_JOBS_RETENTION_DAYS:-30}"
       # Job-queue schema: PROCRASTINATE_SCHEMA selects which Postgres schema
       # holds the procrastinate_jobs tables; default matches the bundled migration.
       PROCRASTINATE_SCHEMA: "${PROCRASTINATE_SCHEMA:-catalog}"

--- a/e2e/non-spatial.spec.ts
+++ b/e2e/non-spatial.spec.ts
@@ -72,21 +72,12 @@ test.describe.serial('Non-spatial CSV', () => {
       page.getByRole('heading', { name: 'Import Data' }),
     ).toBeVisible();
 
-    // Retry staging until the row renders: the upload-config query runs with
-    // staleTime 0, and a file set while its boot-time refetch is settling can
-    // be silently swallowed (#274 dropzone-disable design; pre-existing race,
-    // surfaced by dev-server timing). A swallowed drop does not recover on the
-    // same page, so each retry reloads for a fresh boot.
+    // fix(#432): files staged during the upload-config boot fetch are queued
+    // and flushed once the config settles, so a single set must stage the row
+    // — no reload-retry. This test failing here means the queue regressed.
     const fileInput = page.locator('input[type="file"]');
-    await expect(async () => {
-      await fileInput.setInputFiles(tempCsvPath);
-      try {
-        await expect(page.getByText(datasetSlug)).toBeVisible({ timeout: 3_000 });
-      } catch (err) {
-        await page.reload();
-        throw err;
-      }
-    }).toPass({ timeout: 45_000 });
+    await fileInput.setInputFiles(tempCsvPath);
+    await expect(page.getByText(datasetSlug)).toBeVisible({ timeout: 15_000 });
 
     // Commit the import
     await page

--- a/e2e/upload.spec.ts
+++ b/e2e/upload.spec.ts
@@ -17,23 +17,14 @@ test.describe('Upload Flow', () => {
     await expect(uploadTab).toBeVisible();
 
     // Upload via hidden file input (react-dropzone renders a hidden input).
-    // Retry staging until the row renders: the upload-config query runs with
-    // staleTime 0, and a file set while its boot-time refetch is settling can
-    // be silently swallowed (#274 dropzone-disable design; pre-existing race,
-    // surfaced by dev-server timing). A swallowed drop does not recover on the
-    // same page, so each retry reloads for a fresh boot.
+    // fix(#432): files staged during the upload-config boot fetch are queued
+    // and flushed once the config settles, so a single set must stage the row
+    // — no reload-retry. This test failing here means the queue regressed.
     const fileInput = page.locator('input[type="file"]');
-    await expect(async () => {
-      await fileInput.setInputFiles(
-        path.join(__dirname, 'fixtures/sample.geojson'),
-      );
-      try {
-        await expect(page.getByText('sample')).toBeVisible({ timeout: 3_000 });
-      } catch (err) {
-        await page.reload();
-        throw err;
-      }
-    }).toPass({ timeout: 45_000 });
+    await fileInput.setInputFiles(
+      path.join(__dirname, 'fixtures/sample.geojson'),
+    );
+    await expect(page.getByText('sample')).toBeVisible({ timeout: 15_000 });
     await expect(page.getByText('Using embedded geometry')).toBeVisible({ timeout: 30_000 });
     await expect(page.getByText('Import as non-spatial')).toHaveCount(0);
 

--- a/frontend/src/components/builder/StackRow.tsx
+++ b/frontend/src/components/builder/StackRow.tsx
@@ -349,10 +349,10 @@ export const StackRow = memo(function StackRow({
                 hover/sr-only text is wrapped in t() for parity hygiene. Mirrors
                 the warning-tone badge visual language used in the derived stack
                 (map-stack.ts layerBadges → tone 'warning'). */}
-            {/* fix(R-01, video-reshoot 2026-07-09): badges were shrink-0 and starved
-                the truncating title span to ~2 chars at sidebar width. Cap each
-                badge at 45% of the row and truncate inside; the title=/tooltip
-                keeps the full text discoverable. */}
+            {/* fix(#434): badges were shrink-0 and starved the truncating title
+                span to ~2 chars at sidebar width. Cap each badge at 45% of the
+                row and truncate inside; the title=/tooltip keeps the full text
+                discoverable. */}
             {disambiguationLabel && (
               <span
                 title={t('stackRow.disambiguation', { label: disambiguationLabel, defaultValue: '{{label}}' })}

--- a/frontend/src/components/builder/StackRow.tsx
+++ b/frontend/src/components/builder/StackRow.tsx
@@ -349,13 +349,17 @@ export const StackRow = memo(function StackRow({
                 hover/sr-only text is wrapped in t() for parity hygiene. Mirrors
                 the warning-tone badge visual language used in the derived stack
                 (map-stack.ts layerBadges → tone 'warning'). */}
+            {/* fix(R-01, video-reshoot 2026-07-09): badges were shrink-0 and starved
+                the truncating title span to ~2 chars at sidebar width. Cap each
+                badge at 45% of the row and truncate inside; the title=/tooltip
+                keeps the full text discoverable. */}
             {disambiguationLabel && (
               <span
                 title={t('stackRow.disambiguation', { label: disambiguationLabel, defaultValue: '{{label}}' })}
                 data-testid="stack-row-disambiguation"
-                className="shrink-0 inline-flex items-center rounded-sm px-1 text-[10px] font-medium leading-tight bg-[var(--warning-50,oklch(0.97_0.04_85))] text-[var(--warning-700,oklch(0.45_0.12_85))]"
+                className="min-w-0 max-w-[45%] inline-flex items-center rounded-sm px-1 text-[10px] font-medium leading-tight bg-[var(--warning-50,oklch(0.97_0.04_85))] text-[var(--warning-700,oklch(0.45_0.12_85))]"
               >
-                {disambiguationLabel}
+                <span className="truncate">{disambiguationLabel}</span>
                 <span className="sr-only">{t('stackRow.disambiguation', { label: disambiguationLabel, defaultValue: '{{label}}' })}</span>
               </span>
             )}
@@ -366,9 +370,11 @@ export const StackRow = memo(function StackRow({
               <span
                 title={t('stackRow.audienceHidden', { defaultValue: "Hidden from this map's viewers" })}
                 data-testid="stack-row-audience-hidden"
-                className="shrink-0 inline-flex items-center rounded-sm px-1 text-[10px] font-medium leading-tight bg-[var(--warning-50,oklch(0.97_0.04_85))] text-[var(--warning-700,oklch(0.45_0.12_85))]"
+                className="min-w-0 max-w-[45%] inline-flex items-center rounded-sm px-1 text-[10px] font-medium leading-tight bg-[var(--warning-50,oklch(0.97_0.04_85))] text-[var(--warning-700,oklch(0.45_0.12_85))]"
               >
-                {t('stackRow.audienceHidden', { defaultValue: "Hidden from this map's viewers" })}
+                <span className="truncate">
+                  {t('stackRow.audienceHidden', { defaultValue: "Hidden from this map's viewers" })}
+                </span>
               </span>
             )}
           </div>

--- a/frontend/src/components/viewer/ViewerMap.tsx
+++ b/frontend/src/components/viewer/ViewerMap.tsx
@@ -522,7 +522,7 @@ export const ViewerMap = memo(function ViewerMap({
   // Click handler: show popup with feature attributes
   useEffect(() => {
     const map = mapRef.current;
-    if (!map || !map.isStyleLoaded()) return;
+    if (!map) return;
 
     const fallbackName = t('viewer.featureFallback');
     const buildClusterPopup = (feature: Parameters<typeof isClusterFeature>[0], hit: { layer: SharedLayerResponse; sourceId: string }) => (
@@ -622,15 +622,28 @@ export const ViewerMap = memo(function ViewerMap({
       handleClusterHit(clusterHit.feature, clusterHit.hit, null);
     };
 
-    map.on('click', handleClick);
     let canvasForKeyboard: HTMLCanvasElement | null = null;
-    try {
-      canvasForKeyboard = map.getCanvas();
-      canvasForKeyboard?.addEventListener?.('keydown', handleKeyDown);
-    } catch {
-      canvasForKeyboard = null;
+    const attach = () => {
+      map.on('click', handleClick);
+      try {
+        canvasForKeyboard = map.getCanvas();
+        canvasForKeyboard?.addEventListener?.('keydown', handleKeyDown);
+      } catch {
+        canvasForKeyboard = null;
+      }
+    };
+    // BUG-037-style idle retry (mirrors the layer-sync/visibility effects):
+    // on a cold hard load — exactly how a share link opens — the style is
+    // still transitioning when this effect runs, and a plain early-return
+    // never re-attached the click listener, leaving popups inert for every
+    // geometry family on the shared-viewer surface (#431 QA finding).
+    if (!map.isStyleLoaded()) {
+      map.once('idle', attach);
+    } else {
+      attach();
     }
     return () => {
+      map.off('idle', attach);
       map.off('click', handleClick);
       canvasForKeyboard?.removeEventListener?.('keydown', handleKeyDown);
     };
@@ -639,7 +652,7 @@ export const ViewerMap = memo(function ViewerMap({
   // Mousemove: pointer cursor on interactive features
   useEffect(() => {
     const map = mapRef.current;
-    if (!map || !map.isStyleLoaded()) return;
+    if (!map) return;
 
     let rafId = 0;
     const handleMouseMove = (e: MapMouseEvent) => {
@@ -668,8 +681,15 @@ export const ViewerMap = memo(function ViewerMap({
       });
     };
 
-    map.on('mousemove', handleMouseMove);
+    // Same cold-load idle retry as the click effect above.
+    const attach = () => map.on('mousemove', handleMouseMove);
+    if (!map.isStyleLoaded()) {
+      map.once('idle', attach);
+    } else {
+      attach();
+    }
     return () => {
+      map.off('idle', attach);
       cancelAnimationFrame(rafId);
       map.off('mousemove', handleMouseMove);
       try {

--- a/frontend/src/components/viewer/__tests__/ViewerMap.popup-idle-retry.test.tsx
+++ b/frontend/src/components/viewer/__tests__/ViewerMap.popup-idle-retry.test.tsx
@@ -1,0 +1,187 @@
+// Shared-viewer popup inertness (#431 QA finding): the click and mousemove
+// effects early-returned on !isStyleLoaded() with no idle retry, so on a cold
+// hard load — exactly how a share link opens — map.on('click') was never
+// attached and popups were inert for every geometry family. The fix mirrors
+// the BUG-037 idle-retry used by the layer-sync/visibility effects.
+import type { ReactNode } from 'react';
+import { render, waitFor } from '@/test/test-utils';
+import { ViewerMap } from '../ViewerMap';
+import type { SharedLayerResponse } from '@/types/api';
+
+type FakeMap = {
+  isStyleLoaded: ReturnType<typeof vi.fn>;
+  on: ReturnType<typeof vi.fn>;
+  off: ReturnType<typeof vi.fn>;
+  once: ReturnType<typeof vi.fn>;
+  setTransformRequest: ReturnType<typeof vi.fn>;
+  getLayer: ReturnType<typeof vi.fn>;
+  getSource: ReturnType<typeof vi.fn>;
+  getStyle: ReturnType<typeof vi.fn>;
+  queryRenderedFeatures: ReturnType<typeof vi.fn>;
+  getCanvas: ReturnType<typeof vi.fn>;
+  getZoom: ReturnType<typeof vi.fn>;
+  easeTo: ReturnType<typeof vi.fn>;
+  moveLayer: ReturnType<typeof vi.fn>;
+  removeSource: ReturnType<typeof vi.fn>;
+  setTerrain: ReturnType<typeof vi.fn>;
+  setLayoutProperty: ReturnType<typeof vi.fn>;
+  setPaintProperty: ReturnType<typeof vi.fn>;
+  setFilter: ReturnType<typeof vi.fn>;
+  addLayer: ReturnType<typeof vi.fn>;
+  addSource: ReturnType<typeof vi.fn>;
+  removeLayer: ReturnType<typeof vi.fn>;
+  triggerRepaint: ReturnType<typeof vi.fn>;
+  setLayerZoomRange: ReturnType<typeof vi.fn>;
+  emit: (event: string, payload?: unknown) => void;
+};
+
+const mapState = vi.hoisted(() => {
+  const handlers = new Map<string, Set<(payload?: unknown) => void>>();
+  const canvas = {
+    width: 800, height: 600, clientWidth: 800, clientHeight: 600,
+    style: { cursor: '' },
+    addEventListener: vi.fn(), removeEventListener: vi.fn(),
+  };
+  const fakeMap: FakeMap = {
+    // Default: style NOT loaded — the cold share-link load.
+    isStyleLoaded: vi.fn(() => false),
+    on: vi.fn((event: string, handler: (payload?: unknown) => void) => {
+      const existing = handlers.get(event) ?? new Set();
+      existing.add(handler);
+      handlers.set(event, existing);
+    }),
+    off: vi.fn((event: string, handler: (payload?: unknown) => void) => {
+      handlers.get(event)?.delete(handler);
+    }),
+    once: vi.fn((event: string, handler: (payload?: unknown) => void) => {
+      const existing = handlers.get(event) ?? new Set();
+      existing.add(handler);
+      handlers.set(event, existing);
+    }),
+    setTransformRequest: vi.fn(),
+    getLayer: vi.fn(() => ({ id: 'x' })),
+    getSource: vi.fn(() => null),
+    getStyle: vi.fn(() => ({ version: 8, sources: {}, layers: [] })),
+    queryRenderedFeatures: vi.fn(() => []),
+    getCanvas: vi.fn(() => canvas),
+    getZoom: vi.fn(() => 5),
+    easeTo: vi.fn(),
+    moveLayer: vi.fn(),
+    removeSource: vi.fn(),
+    setTerrain: vi.fn(),
+    setLayoutProperty: vi.fn(),
+    setPaintProperty: vi.fn(),
+    setFilter: vi.fn(),
+    addLayer: vi.fn(),
+    addSource: vi.fn(),
+    removeLayer: vi.fn(),
+    triggerRepaint: vi.fn(),
+    setLayerZoomRange: vi.fn(),
+    emit: (event: string, payload?: unknown) => {
+      for (const handler of Array.from(handlers.get(event) ?? [])) handler(payload);
+    },
+  };
+  return {
+    fakeMap,
+    handlers,
+    reset: () => {
+      handlers.clear();
+      Object.values(fakeMap).forEach((v) => {
+        if (typeof v === 'function' && 'mockClear' in v) (v as ReturnType<typeof vi.fn>).mockClear();
+      });
+      fakeMap.isStyleLoaded.mockReturnValue(false);
+      fakeMap.getLayer.mockReturnValue({ id: 'x' });
+    },
+  };
+});
+
+vi.mock('@vis.gl/react-maplibre', async () => {
+  const React = await import('react');
+  return {
+    Map: ({ children, onLoad }: { children?: ReactNode; onLoad?: (e: { target: FakeMap }) => void }) => {
+      React.useEffect(() => { onLoad?.({ target: mapState.fakeMap }); }, [onLoad]);
+      return <div data-testid="mapgl">{children}</div>;
+    },
+    NavigationControl: () => null,
+    ScaleControl: () => null,
+    FullscreenControl: () => null,
+    AttributionControl: () => null,
+    TerrainControl: () => null,
+    Popup: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+  };
+});
+
+vi.mock('@/hooks/use-settings', () => ({
+  useBasemaps: () => ({ data: [] }),
+  useTileConfig: () => ({ data: { cdn_base_url: null } }),
+  useBranding: () => ({ data: undefined }),
+}));
+vi.mock('@/hooks/use-webgl-recovery', () => ({
+  useWebGLRecovery: () => ({ contextLost: false, reload: vi.fn() }),
+}));
+vi.mock('@/components/viewer/hooks/use-viewer-tokens', () => ({
+  useViewerTokens: () => ({ tokenMap: new Map([['dataset-pt', { kind: 'vector', token: 't' }]]) }),
+}));
+vi.mock('@/components/viewer/hooks/use-viewer-terrain', () => ({
+  useViewerTerrain: () => ({ terrainReady: false, reseedTerrainOnStyleLoad: vi.fn() }),
+}));
+vi.mock('@/components/map/MapCoordReadout', () => ({ MapCoordReadout: () => null }));
+vi.mock('@/components/builder/map-sync', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/components/builder/map-sync')>();
+  return { ...actual, applyBasemapConfigToMap: vi.fn(), syncLayersToMap: vi.fn() };
+});
+vi.mock('@/lib/builder/basemap-style-mutation', () => ({ applySublayerOverrides: vi.fn() }));
+
+const LAYER: SharedLayerResponse = {
+  id: 'pt-layer',
+  dataset_id: 'dataset-pt',
+  dataset_name: 'Points',
+  display_name: 'Points',
+  table_name: 'points',
+  geometry_type: 'POINT',
+  column_info: null,
+  sort_order: 0,
+  visible: true,
+  opacity: 1,
+  paint: { 'circle-color': '#2255aa', 'circle-radius': 6 },
+  layout: {},
+  filter: null,
+  label_config: null,
+  popup_config: null,
+  style_config: null,
+  tile_url: '',
+};
+
+describe('ViewerMap popup listeners idle-retry (shared-viewer cold load)', () => {
+  beforeEach(() => { mapState.reset(); });
+
+  it('attaches click and mousemove handlers via idle retry when the style is still transitioning', async () => {
+    // Cold load: isStyleLoaded() is false from the very first effect run.
+    render(
+      <ViewerMap
+        layers={[LAYER]}
+        basemapStyle="openfreemap-positron"
+        basemapConfig={null}
+        showBasemapLabels={true}
+        terrainConfig={null}
+        initialViewState={{ center_lng: 0, center_lat: 0, zoom: 2, bearing: 0, pitch: 0 }}
+        visibleLayers={new Set(['pt-layer'])}
+      />,
+    );
+
+    // The effects must schedule idle retries instead of bailing forever.
+    await waitFor(() => {
+      expect(mapState.fakeMap.once).toHaveBeenCalledWith('idle', expect.any(Function));
+    });
+    // Pre-fix behavior: neither listener was ever attached on a cold load.
+    expect(mapState.fakeMap.on).not.toHaveBeenCalledWith('click', expect.any(Function));
+    expect(mapState.fakeMap.on).not.toHaveBeenCalledWith('mousemove', expect.any(Function));
+
+    // Style settles → the retries attach the interaction listeners.
+    mapState.fakeMap.isStyleLoaded.mockReturnValue(true);
+    mapState.fakeMap.emit('idle');
+
+    expect(mapState.fakeMap.on).toHaveBeenCalledWith('click', expect.any(Function));
+    expect(mapState.fakeMap.on).toHaveBeenCalledWith('mousemove', expect.any(Function));
+  });
+});


### PR DESCRIPTION
Closes out the actionable findings from the 2026-07-09 video-reshoot handoff (`docs-internal/handoff-video-reshoot-findings-20260709.md`) plus the in-repo loose ends. Validated end-to-end by reshooting the announcement video (v4) on this branch.

## Findings fixed

- **R-01 (builder UI):** the audience-hidden and disambiguation badges in `StackRow` were `shrink-0` and starved the truncating layer title down to ~2 characters at default sidebar width. Badges now cap at 45% of the row and truncate internally; the `title=` tooltip keeps the full text. Verified on film — a 24-char layer title keeps a readable prefix with the badge present.
- **R-02 (jobs retention):** finished `ingest_jobs` rows lived forever, so the admin Jobs page accumulated stale test junk with no cleanup affordance. The 5-minute lifespan sweeper (and the ops cleanup endpoint, via the shared `fail_stale_jobs`) now purges terminal jobs (`complete`/`failed`/`cancelled`/`fanned_out`) older than `INGEST_JOBS_RETENTION_DAYS` (default 30; `0` keeps history forever). No schema or API-surface change.

## Loose ends closed

- **Shared-viewer popups inert (loose end 7):** root-caused to a cold-load timing bug, not product behavior — the `ViewerMap` click/mousemove effects early-returned on `!isStyleLoaded()` with no retry, and a share link always opens on a cold load. Fixed with the same BUG-037 idle-retry pattern the layer-sync/visibility effects in the file already use. Verified live: cold anonymous `/m/:token` load, feature click opens the popup.
- **e2e reload-retry removal (loose end 3):** `upload.spec.ts` / `non-spatial.spec.ts` no longer wrap `setInputFiles` in reload-retry, so e2e validates the #432 staged-drop queue directly. Both specs pass against the live stack (6/6).
- **`test_related_datasets.py` cache hazard (loose end 9):** copied the #433 autouse `_has_embeddings_cache`-clearing fixture before it flakes under xdist.
- **TiTiler 2.0.2 → 2.0.5 (loose end 8, bump half):** patch-level, per the 2026-07 assessment. Exercised live by the Matterhorn terrain capture on this branch. Scoped S3 credentials remain a separate ops task.

Also noted while closing the list: loose end 6 (worker-side atomic dataset quota, #274) turned out to be **already implemented** — `reserve_dataset_slot` (advisory lock + recount, `modules/quota/service.py`) runs in the same transaction as every worker-side Record insert, with green regression tests (`test_302_quota_reservation.py`). No change needed; #274 can be closed as a duplicate of #302.

## Impacts

- New setting: `INGEST_JOBS_RETENTION_DAYS` (backend env, default 30, `0` disables). Not part of the OpenAPI surface.
- `docker-compose.yml`: titiler image tag only.
- No migrations, no i18n keys, no SDK/OpenAPI changes.

## Verification

- `cd frontend && npm run lint && npm run typecheck && npx vitest run` — 3362 tests pass.
- `cd backend && uv run ruff check . && pytest tests/test_vrt_stale_sweep_gap002.py tests/test_related_datasets.py tests/test_302_quota_reservation.py` — 20 tests pass (includes 2 new retention-purge tests + 1 new popup idle-retry test on the frontend side).
- `npx playwright test e2e/upload.spec.ts e2e/non-spatial.spec.ts --project=chromium` — 6/6.
- Announcement video reshot on this branch (72.5s v4): R-01 fix, #432 staged-drop behavior, titiler 2.0.5 terrain, and a clean admin Jobs page are all on film.