### PR TITLE
fix(backend): address the 2026-07-09 backend audit (#435)

### DIFF
--- a/backend/alembic/env.py
+++ b/backend/alembic/env.py
@@ -222,36 +222,14 @@ def include_name(name, type_, parent_names):
     return True
 
 
-# H-21: SAML columns live in the OAuthProvider model so a single
-# ``OAuthProvider`` class serves both OSS and enterprise deployments
-# (deferred-load pattern, see ``modules/auth/oauth/models.py``). The
-# enterprise overlay's migration ``e002_add_saml_columns`` actually adds
-# the columns to the database. On OSS-only deployments these columns
-# exist in the model but not in the schema, so ``alembic check`` /
-# autogenerate always produced 4 false-positive ``add_column`` ops —
-# which made ``alembic check`` useless as a CI drift gate (real drift
-# would be lost in the noise). We skip those columns from autogenerate
-# diff when running OSS-only (no enterprise overlay discovered).
-_SAML_COLUMNS = frozenset(
-    {"idp_entity_id", "idp_sso_url", "idp_certificate", "sp_entity_id"}
-)
-_OAUTH_PROVIDERS_TABLE = "oauth_providers"
-
-
 def include_object(obj, name, type_, reflected, compare_to):
-    """Skip procrastinate-managed objects + SAML columns (when OSS-only).
+    """Skip procrastinate-managed objects and the runtime-built HNSW index.
 
     Procrastinate's tables, types, indexes, sequences, and triggers are created
     via raw SQL in ``0002_procrastinate.py`` and are not declared as SQLAlchemy
     models. Without this filter, ``alembic check`` and autogenerate diff produce
     false-positive ``remove_table`` / ``remove_index`` ops because the metadata
     lacks them.
-
-    SAML columns on ``oauth_providers`` are declared in the model union but
-    only created by ``e002_add_saml_columns`` when the enterprise overlay is
-    installed. When no overlay is present, those columns are intentional
-    schema/model drift and would be reported by ``alembic check`` on every
-    OSS deployment — see migration-audit H-21.
 
     ``ix_record_embeddings_hnsw`` is a pgvector HNSW index created and dropped
     at runtime by ``embeddings/service.py`` (``rebuild_embedding_column``) once
@@ -262,20 +240,19 @@ def include_object(obj, name, type_, reflected, compare_to):
     ``pytest -n4`` a sibling test that built it on the shared worker DB before
     ``alembic check`` ran turned this into a high-rate flake in
     ``test_alembic_check_no_drift``.
+
+    fix(#435): the four ``oauth_providers`` SAML columns used to be excluded here
+    on OSS-only deployments, because only the enterprise overlay's
+    ``e002_add_saml_columns`` created them and autogenerate reported four phantom
+    ``add_column`` ops. Core migration ``0008_oauth_saml_columns`` now creates them
+    unconditionally (``ADD COLUMN IF NOT EXISTS``), so an OSS database at head has
+    them for real. The filter had become a blind spot: dropping or retyping a
+    now-core-owned column still passed ``alembic check``. See migration-audit H-21
+    for the original rationale.
     """
     if name and name.startswith("procrastinate_"):
         return False
     if type_ == "index" and name == "ix_record_embeddings_hnsw":
-        return False
-    if (
-        type_ == "column"
-        and not _extra_paths
-        and name in _SAML_COLUMNS
-        and getattr(getattr(obj, "table", None), "name", None) == _OAUTH_PROVIDERS_TABLE
-    ):
-        # OSS-only deployment: hide the enterprise-overlay-managed SAML
-        # columns from autogenerate so 'alembic check' surfaces only real
-        # drift.
         return False
     return True
 

--- a/backend/alembic/versions/0008_oauth_saml_columns.py
+++ b/backend/alembic/versions/0008_oauth_saml_columns.py
@@ -36,9 +36,10 @@ constraint stays enterprise-only (``e002``), so community deployments still
 cannot create SAML providers (also guarded by ``is_enterprise()`` in the
 service layer). The columns simply sit ``NULL`` for OSS OAuth/OIDC providers.
 
-``env.py``'s ``include_object`` continues to exclude these four columns from
-``alembic check`` on both the model and reflected sides, so the drift gate stays
-green and unchanged.
+fix(#435): ``env.py``'s ``include_object`` no longer excludes these four columns.
+It did until this migration existed, because autogenerate saw four phantom
+``add_column`` ops on every OSS database. Now that OSS creates them for real, the
+exclusion only blinded ``alembic check`` to genuine drift on core-owned columns.
 
 Revision ID: 0008_oauth_saml_columns
 Revises:     0007_tenant_data_schemas

--- a/backend/app/api/main.py
+++ b/backend/app/api/main.py
@@ -25,7 +25,7 @@ from app.platform.cache.provider import init_tile_cache
 # settings already imported above for the tempdir override — do NOT reimport
 from app.core.db import async_session, engine
 from app.core.logging_config import setup_logging
-from app.core.runtime.staging import ensure_staging_ready
+from app.core.runtime.staging import ensure_staging_ready, sweep_orphaned_exports
 from app.platform.extensions.bootstrap import bootstrap
 from app.modules.auth.models import Role, User, UserRole
 from app.modules.auth.providers.local import hash_password
@@ -193,20 +193,13 @@ async def lifespan(app: FastAPI):
     await bootstrap(app=app)
 
     staging_root = ensure_staging_ready(settings.upload_staging_dir)
-    ensure_staging_ready(staging_root / "exports")
+    exports_dir = ensure_staging_ready(staging_root / "exports")
 
-    import shutil
-
-    exports_dir = staging_root / "exports"
-    if exports_dir.exists():
-        orphaned = list(exports_dir.iterdir())
-        if orphaned:
-            for item in orphaned:
-                if item.is_dir():
-                    shutil.rmtree(item, ignore_errors=True)
-                else:
-                    item.unlink(missing_ok=True)
-            logger.info("Cleaned orphaned export temp files", count=len(orphaned))
+    # fix(#435): this used to delete every entry unconditionally. Production runs
+    # two Uvicorn workers over one staging volume, so a restarting worker could
+    # truncate an export a surviving sibling was still writing or streaming. Share
+    # the worker's age-aware sweeper instead.
+    sweep_orphaned_exports(exports_dir)
 
     init_tile_cache()
     await init_tile_pool()
@@ -553,6 +546,9 @@ async def _rate_limit_handler(request: Request, exc: RateLimitExceeded) -> JSONR
 app.add_exception_handler(RateLimitExceeded, _rate_limit_handler)
 
 
+from sqlalchemy.exc import DBAPIError  # noqa: E402
+
+from app.core.db.sqlstate import is_operational, sqlstate  # noqa: E402
 from app.modules.quota.service import (  # noqa: E402
     DatasetQuotaExceededError,
     StorageQuotaExceededError,
@@ -592,8 +588,41 @@ async def _storage_quota_handler(
     )
 
 
+async def _database_error_handler(request: Request, exc: DBAPIError) -> JSONResponse:
+    """Map an operational database failure to a 503 (fix(#435)).
+
+    Connection loss, statement timeout, cancellation, and serialization failures used
+    to be caught per-handler and reported as domain data — a dataset with zero rows,
+    say — which hid ingest corruption and infrastructure incidents from users and from
+    health monitoring. Handlers now re-raise what they cannot legitimately answer.
+
+    Non-operational errors (integrity violations, syntax and access errors) are
+    re-raised so they keep their existing 500 path; calling a unique-constraint
+    collision "database unavailable" would just invite a retry loop.
+
+    The detail is deliberately generic: the SQLSTATE and statement go to the log.
+    """
+    if not is_operational(exc):
+        raise exc
+    logger.exception(
+        "Operational database error",
+        path=request.url.path,
+        sqlstate=sqlstate(exc),
+    )
+    return JSONResponse(
+        status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+        content=ProblemDetail(
+            title="Database unavailable",
+            status=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="The database could not serve this request. Please retry.",
+        ).model_dump(),
+        media_type="application/problem+json",
+    )
+
+
 app.add_exception_handler(DatasetQuotaExceededError, _dataset_quota_handler)
 app.add_exception_handler(StorageQuotaExceededError, _storage_quota_handler)
+app.add_exception_handler(DBAPIError, _database_error_handler)
 
 # SEC-02 / M-64 / SEC-005: gate https_only on the production indicator. Local-dev
 # and test runs use the development posture (no TLS terminator), so

--- a/backend/app/core/async_io.py
+++ b/backend/app/core/async_io.py
@@ -1,0 +1,47 @@
+"""Cancellation-safe threaded I/O (fix(#435 codex r2/r3/r4)).
+
+`asyncio.to_thread` offloads a blocking call, but cancelling the awaiting task does
+NOT stop the thread — it is already running. When that thread owns a file descriptor
+(streaming a large upload to disk, zipping an export, copying a COG into storage), an
+early return lets the caller's cleanup close or delete the file while the thread is
+still writing to it: a truncated artifact, a fd race, or a thread exception nobody
+retrieves. Worker shutdown and client disconnect both hit exactly this.
+
+`run_in_thread_draining` waits for the thread to finish before propagating the
+cancellation, and keeps waiting through repeated cancellations (a shutdown that
+cancels again while we are draining), so the thread has always released the fd by the
+time control returns to the caller.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any, Callable, TypeVar
+
+_T = TypeVar("_T")
+
+
+async def run_in_thread_draining(fn: Callable[..., _T], *args: Any) -> _T:
+    """Run ``fn(*args)`` in a worker thread; on cancellation, drain it first.
+
+    Returns the thread's result, or raises whatever the thread raised. On
+    cancellation, waits for the thread to complete (absorbing further cancels) and
+    then re-raises ``CancelledError`` — never returns while the thread is still live.
+    """
+    fut = asyncio.ensure_future(asyncio.to_thread(fn, *args))
+    # `asyncio.wait` waits on `fut` without cancelling it and without logging its
+    # exception (unlike `asyncio.shield`, which logs a cancelled shield's inner
+    # exception even after we retrieve it). The loop keeps waiting through repeated
+    # cancellations, so a running thread is never abandoned.
+    cancelled: asyncio.CancelledError | None = None
+    while not fut.done():
+        try:
+            await asyncio.wait({fut})
+        except asyncio.CancelledError as exc:
+            cancelled = cancelled or exc
+
+    if cancelled is not None:
+        if not fut.cancelled():
+            fut.exception()  # retrieve it so it is not flagged never-retrieved
+        raise cancelled
+    return fut.result()

--- a/backend/app/core/db/sqlstate.py
+++ b/backend/app/core/db/sqlstate.py
@@ -11,14 +11,18 @@ from __future__ import annotations
 
 from sqlalchemy.exc import DBAPIError
 
-# Class 42 / 3F — the relation the query names does not exist. Not always damage:
-# raster and VRT datasets carry a synthetic `table_name` with no PostGIS table.
-TABLE_ABSENT = frozenset(
-    {
-        "42P01",  # undefined_table
-        "3F000",  # invalid_schema_name
-    }
-)
+# The relation the query names does not exist. Not always damage: raster and VRT
+# datasets carry a synthetic `table_name` with no PostGIS table behind it.
+#
+# fix(#435 codex r1): `3F000` (invalid_schema_name) was in this set and is now not.
+# A `SELECT` against a missing schema reports `42P01`, so `3F000` never described the
+# benign case here; Postgres raises it from DDL paths, where it means the schema is
+# gone. Treating it as "empty dataset" would have hidden real provisioning drift.
+#
+# `42P01` alone cannot separate "raster dataset, no backing table" from "the tenant's
+# data schema was never provisioned" — both report it. Callers must probe the schema.
+# See `schema_exists()` and `get_dataset_rows()`.
+TABLE_ABSENT = frozenset({"42P01"})  # undefined_table
 
 # The caller sent something the table cannot answer — a bad filter column or an
 # unparseable literal. These are 4xx, not 5xx.

--- a/backend/app/core/db/sqlstate.py
+++ b/backend/app/core/db/sqlstate.py
@@ -1,0 +1,80 @@
+"""PostgreSQL SQLSTATE helpers for classifying database errors (fix(#435)).
+
+Handlers used to catch `Exception` (or bare `DBAPIError`) and guess. A dropped
+table, a statement timeout, and a lost connection are very different events, and
+only the first of them is a domain condition the API should paper over.
+
+SQLSTATE reference: https://www.postgresql.org/docs/current/errcodes-appendix.html
+"""
+
+from __future__ import annotations
+
+from sqlalchemy.exc import DBAPIError
+
+# Class 42 / 3F — the relation the query names does not exist. Not always damage:
+# raster and VRT datasets carry a synthetic `table_name` with no PostGIS table.
+TABLE_ABSENT = frozenset(
+    {
+        "42P01",  # undefined_table
+        "3F000",  # invalid_schema_name
+    }
+)
+
+# The caller sent something the table cannot answer — a bad filter column or an
+# unparseable literal. These are 4xx, not 5xx.
+BAD_QUERY_INPUT = frozenset(
+    {
+        "42703",  # undefined_column
+        "22P02",  # invalid_text_representation
+        "42883",  # undefined_function (e.g. no operator for the cast)
+        "42804",  # datatype_mismatch
+    }
+)
+
+
+# SQLSTATE *classes* (first two characters) that mean "the database could not serve
+# this request", as opposed to "the request was wrong". Only these become a 503.
+#
+# Selecting by class rather than by exception type matters: SQLAlchemy's asyncpg
+# dialect wraps a statement timeout (57014) as a plain `DBAPIError`, not as
+# `OperationalError`, so `except OperationalError` silently misses it.
+_OPERATIONAL_CLASSES = frozenset(
+    {
+        "08",  # connection_exception
+        "40",  # transaction_rollback — serialization_failure, deadlock_detected
+        "53",  # insufficient_resources — out of memory, too many connections
+        "57",  # operator_intervention — query_canceled, admin_shutdown
+        "58",  # system_error — I/O failure below the server
+    }
+)
+
+
+def sqlstate(exc: DBAPIError) -> str | None:
+    """Return the five-character SQLSTATE for a SQLAlchemy DBAPI error, if any.
+
+    asyncpg exposes `sqlstate`; psycopg exposes `pgcode`. Returns None when the
+    driver surfaced no code (e.g. the connection died before the server answered),
+    which callers should treat as operational.
+    """
+    orig = getattr(exc, "orig", None)
+    if orig is None:
+        return None
+    code = getattr(orig, "sqlstate", None) or getattr(orig, "pgcode", None)
+    return str(code) if code else None
+
+
+def is_operational(exc: DBAPIError) -> bool:
+    """True when *exc* means the database failed us, not that the request was bad.
+
+    A missing SQLSTATE counts as operational: the driver raised before the server
+    answered, which is a connection failure by another name.
+
+    Integrity violations (class 23), syntax and access errors (class 42), and data
+    errors (class 22) are deliberately excluded — a unique-constraint collision is a
+    bug or a conflict, and reporting it as "database unavailable" would send callers
+    into a pointless retry loop.
+    """
+    code = sqlstate(exc)
+    if code is None:
+        return True
+    return code[:2] in _OPERATIONAL_CLASSES

--- a/backend/app/core/db/tenant_schema.py
+++ b/backend/app/core/db/tenant_schema.py
@@ -266,3 +266,22 @@ def tenant_shard_id(tenant_id: str | None) -> str | None:
             exc_info=True,  # WR-01: surface stack trace so failures are diagnosable
         )
         return "shard-0"
+
+
+async def schema_exists(session, schema: str) -> bool:
+    """True when *schema* exists in the current database.
+
+    fix(#435 codex r1): Postgres answers `SELECT * FROM missing_schema.t` with
+    `42P01` (undefined_table), the same code a raster dataset's synthetic table
+    produces in a schema that does exist. Read-side callers that degrade `42P01`
+    to an empty page must probe first, or a tenant data schema that was never
+    provisioned (or was lost in a restore) is silently reported as a dataset with
+    zero rows.
+
+    Run this only on an error path: it costs a catalog lookup, and it must follow
+    a rollback because the failed statement aborted the transaction.
+    """
+    result = await session.execute(
+        text("SELECT to_regnamespace(:schema) IS NOT NULL"), {"schema": schema}
+    )
+    return bool(result.scalar_one())

--- a/backend/app/core/persistent_config.py
+++ b/backend/app/core/persistent_config.py
@@ -44,6 +44,17 @@ _CACHE_PREFIX = "config:"
 
 _registry: list[PersistentConfig] = []
 
+# Phase 279 ADMIN-03 (M-03): the single source of truth for enterprise-only Settings
+# tabs. The backend `_require_enterprise_for_key` gate, the config import/export
+# gate, and the frontend AdminSidebar (via GET /admin/settings/enterprise-tabs/) all
+# consult this set. Adding a new enterprise-only tab: edit this set.
+#
+# fix(#435): lives with the registry that defines `PersistentConfig.tab`, rather than
+# in `modules/settings/router.py` where it was a private name that `platform/config_ops`
+# reached into at import time. Edition policy now has a stable owner, and decomposing
+# the settings router can no longer break config import at runtime.
+ENTERPRISE_ONLY_TABS = frozenset({"branding", "appearance"})
+
 
 def _get_cache_safe() -> CacheProvider | None:
     """Return the cache provider or None if not yet initialized."""

--- a/backend/app/core/runtime/staging.py
+++ b/backend/app/core/runtime/staging.py
@@ -2,9 +2,95 @@
 
 from __future__ import annotations
 
+import shutil
 import tempfile
+from datetime import datetime, timezone
 from pathlib import Path
 from uuid import uuid4
+
+import structlog
+
+log = structlog.get_logger()
+
+
+# ING-04 (P2-04): exports temp-dir sweep age threshold. Only entries whose mtime
+# is older than this many seconds are deleted on startup. In-flight large exports
+# younger than 1 hour survive a rolling restart; truly orphaned crash-residue gets
+# cleaned. Matches the 1-hour window used by worker stale-job recovery
+# (`JOB_TIMEOUT_SECONDS` in jobs/router.py) so a 6-minute COG export that survives
+# a rolling restart at the job layer also keeps its on-disk staging artifact.
+EXPORTS_SWEEP_AGE_SECONDS = 3600  # 1 hour
+
+
+def sweep_orphaned_exports(
+    exports_dir: Path,
+    *,
+    age_threshold_seconds: int = EXPORTS_SWEEP_AGE_SECONDS,
+) -> tuple[int, int]:
+    """Sweep orphaned export temp entries older than ``age_threshold_seconds``.
+
+    Entries whose ``stat.st_mtime`` is within the last ``age_threshold_seconds``
+    are skipped (and logged) so an in-flight large export does not get truncated
+    by a restart. Older entries are removed (``shutil.rmtree`` for directories,
+    ``Path.unlink`` for files).
+
+    fix(#435): the API lifespan used to delete every entry unconditionally, which
+    could truncate an export owned by a *surviving* sibling Uvicorn worker sharing
+    the staging volume (`docker-compose.prod.yml` runs two). Both the API and the
+    worker now call this one age-aware sweeper.
+
+    ponytail: no cross-process advisory lock. The sweep is idempotent and tolerates
+    losing a race (``ignore_errors``/``missing_ok``/``FileNotFoundError``), and the
+    age threshold — not mutual exclusion — is what protects in-flight exports. Add a
+    lock only if a sweeper ever grows a non-idempotent step.
+
+    Args:
+        exports_dir: The ``<staging>/exports/`` directory to sweep. A missing
+            directory is treated as a no-op (no error raised).
+        age_threshold_seconds: Skip entries newer than this many seconds.
+
+    Returns:
+        ``(deleted_count, skipped_count)``.
+    """
+    if not exports_dir.exists():
+        return (0, 0)
+
+    entries = list(exports_dir.iterdir())
+    if not entries:
+        return (0, 0)
+
+    now_ts = datetime.now(timezone.utc).timestamp()
+    deleted_count = 0
+    skipped_count = 0
+    for item in entries:
+        try:
+            item_mtime = item.stat().st_mtime
+        except FileNotFoundError:
+            # Raced with another process / external cleanup — treat as already-gone.
+            continue
+        age_seconds = now_ts - item_mtime
+        if age_seconds < age_threshold_seconds:
+            log.info(
+                "sweep_skipped_recent_export",
+                path=str(item),
+                age_seconds=round(age_seconds, 1),
+                threshold_seconds=age_threshold_seconds,
+            )
+            skipped_count += 1
+            continue
+        if item.is_dir():
+            shutil.rmtree(item, ignore_errors=True)
+        else:
+            item.unlink(missing_ok=True)
+        deleted_count += 1
+
+    if deleted_count or skipped_count:
+        log.info(
+            "exports_sweep_complete",
+            deleted=deleted_count,
+            skipped=skipped_count,
+        )
+    return (deleted_count, skipped_count)
 
 
 class StagingRuntimeError(RuntimeError):

--- a/backend/app/modules/admin/router.py
+++ b/backend/app/modules/admin/router.py
@@ -35,7 +35,7 @@ from app.modules.admin.schemas import (
     UserUpdate,
 )
 from app.modules.admin.service import AdminService
-from app.modules.quota.service import get_user_quota_usage
+from app.modules.quota.service import get_user_quota_usage_bulk
 from app.modules.audit.service import AuditEvent, audit_emit
 from app.modules.auth.dependencies import require_permission
 from app.modules.auth.router import limiter  # HARDEN-01: shared rate-limiter instance
@@ -195,24 +195,23 @@ async def list_users(
     users, total = await service.list_users(
         skip=skip, limit=limit, status=status_filter, search=search
     )
-    # QUOTA-04: batch-load quota usage for each user on this page.
-    # One SQL aggregate per user (≤200/page; cheap at admin-only frequency).
-    user_responses = []
-    for u in users:
-        usage = await get_user_quota_usage(db, u.id)
-        user_responses.append(
-            UserResponse(
-                id=u.id,
-                username=u.username,
-                email=u.email,
-                is_active=u.is_active,
-                status=u.status,
-                last_login_at=u.last_login_at,
-                created_at=u.created_at,
-                roles=sorted(r.name for r in u.roles),
-                quota_usage=usage,
-            )
+    # QUOTA-04: quota usage for the page. fix(#435): genuinely batched now — this
+    # said "batch" but ran one three-table aggregate per user, 200 users per page.
+    usage_by_user = await get_user_quota_usage_bulk(db, [u.id for u in users])
+    user_responses = [
+        UserResponse(
+            id=u.id,
+            username=u.username,
+            email=u.email,
+            is_active=u.is_active,
+            status=u.status,
+            last_login_at=u.last_login_at,
+            created_at=u.created_at,
+            roles=sorted(r.name for r in u.roles),
+            quota_usage=usage_by_user[u.id],
         )
+        for u in users
+    ]
     return UserListResponse(users=user_responses, total=total)
 
 

--- a/backend/app/modules/auth/oauth/models.py
+++ b/backend/app/modules/auth/oauth/models.py
@@ -49,21 +49,19 @@ class OAuthProvider(Base):
     authorize_url: Mapped[str | None] = mapped_column(String(512), nullable=True)
     token_url: Mapped[str | None] = mapped_column(String(512), nullable=True)
     userinfo_url: Mapped[str | None] = mapped_column(String(512), nullable=True)
-    # SAML provider columns (added by enterprise migration e002_add_saml_columns).
-    # All four are nullable; only populated when provider_type='saml' and the
-    # enterprise overlay is loaded.
+    # SAML provider columns. All four are nullable; only populated when
+    # provider_type='saml' and the enterprise overlay is loaded.
     #
-    # Pitfall 11 mitigation: declared with ``deferred=True`` so they are NOT
-    # included in the default ``SELECT`` against ``oauth_providers``. Community
-    # deployments (which do NOT run e002_add_saml_columns) lack these columns
-    # entirely; without ``deferred``, every list/get of an OAuth provider would
-    # raise ``UndefinedColumnError``. With ``deferred``, the columns are only
-    # loaded when explicitly accessed (e.g. ``provider.idp_entity_id`` in the
-    # SAML router) -- which only happens when the enterprise overlay is loaded
-    # AND the row is provider_type='saml'. Grouped under ``deferred_group="saml"``
-    # so the SAML router can ``undefer_group("saml")`` to load all four in a
-    # single query when needed. Schema/service-layer validation that these are
-    # required for SAML and forbidden for OAuth lands in Plan 03.
+    # fix(#435): these are core-owned columns now. Community databases DO have them
+    # — core migration ``0008_oauth_saml_columns`` adds all four (``ADD COLUMN IF
+    # NOT EXISTS``, so the enterprise overlay's ``e002_add_saml_columns`` stays a
+    # compatible no-op). They simply sit NULL for OSS OAuth/OIDC providers, and the
+    # ``'saml'`` provider_type CHECK constraint remains enterprise-only.
+    #
+    # ``deferred=True`` is kept for the original reason it was added: the columns stay
+    # out of the default ``SELECT`` against ``oauth_providers``. Grouped under
+    # ``deferred_group="saml"`` so the SAML router can ``undefer_group("saml")`` to
+    # load all four in a single query when needed.
     idp_entity_id: Mapped[str | None] = mapped_column(
         String(512), nullable=True, deferred=True, deferred_group="saml"
     )

--- a/backend/app/modules/catalog/datasets/api/router_data.py
+++ b/backend/app/modules/catalog/datasets/api/router_data.py
@@ -12,6 +12,8 @@ from fastapi import (
 )
 from sqlalchemy import select
 from sqlalchemy.exc import DBAPIError
+
+from app.core.db.sqlstate import BAD_QUERY_INPUT, sqlstate
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import joinedload
 
@@ -126,11 +128,18 @@ async def get_dataset_rows_endpoint(
             column_info=dataset.column_info,
             filters=filters if filters else None,
         )
-    except DBAPIError:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="Invalid filter parameters",
-        )
+    except DBAPIError as exc:
+        # fix(#435): this used to swallow every DBAPIError as a 400. The service
+        # swallowed them first anyway, so the handler was unreachable for failures
+        # inside the query. Now only a caller-caused error is a 400; connection loss,
+        # statement timeout, and permission failures fall through to the central
+        # 503 handler rather than being reported as the caller's fault.
+        if sqlstate(exc) in BAD_QUERY_INPUT:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Invalid filter parameters",
+            )
+        raise
 
     return DatasetRowsResponse(
         rows=rows,

--- a/backend/app/modules/catalog/datasets/api/router_vrt.py
+++ b/backend/app/modules/catalog/datasets/api/router_vrt.py
@@ -13,6 +13,7 @@ from fastapi import (
 )
 from sqlalchemy import func, select, text
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import joinedload
 
 from app.core.identity import Identity
 from app.modules.auth.dependencies import get_current_active_user
@@ -29,6 +30,7 @@ from app.modules.catalog.datasets.domain.schemas import (
     VrtSourceListResponse,
     VrtStatusResponse,
 )
+from app.modules.catalog.datasets.domain.models import Dataset
 from app.modules.catalog.datasets.domain.service import get_dataset
 from app.core.db.tenant_session import defer_async_with_tenant
 from app.core.dependencies import get_db
@@ -45,6 +47,28 @@ VrtMutationResponse = get_catalog_port().vrt_mutation_response_model()
 def _advisory_lock_key(dataset_id: uuid.UUID) -> int:
     """Derive a PostgreSQL advisory lock key from a UUID."""
     return dataset_id.int % (2**63)
+
+
+async def _load_source_datasets(
+    db: AsyncSession, dataset_ids: list[uuid.UUID]
+) -> dict[uuid.UUID, object]:
+    """Load VRT source datasets by id in one query, records eager-loaded.
+
+    fix(#435): both VRT source endpoints called `get_dataset()` once per member row,
+    so a 200-source VRT cost 200 round trips before it could return a page. The
+    per-row `can_access_dataset()` call stays — it is the permission seam's decision
+    to make, and only `restricted` rows reach the database from there. Batching that
+    too needs a seam-level operation, because an overlay wrapping
+    `DefaultPermissionExtension` must not have its policy skipped.
+    """
+    if not dataset_ids:
+        return {}
+    result = await db.execute(
+        select(Dataset)
+        .options(joinedload(Dataset.record))
+        .where(Dataset.id.in_(dataset_ids))
+    )
+    return {dataset.id: dataset for dataset in result.scalars().unique().all()}
 
 
 @router.get("/{dataset_id}/vrt-sources/", response_model=VrtSourceListResponse)
@@ -81,9 +105,13 @@ async def list_vrt_sources(
     # title/CRS/resolution/extent never leak. Non-raising (can_access_dataset)
     # — a 404 would abort the whole listing.
     ext = get_permission_extension()
+    source_rows = rows.all()
+    datasets_by_id = await _load_source_datasets(
+        db, [row.dataset_id for row in source_rows]
+    )
     sources = []
-    for row in rows.all():
-        src_dataset = await get_dataset(db, row.dataset_id)
+    for row in source_rows:
+        src_dataset = datasets_by_id.get(row.dataset_id)
         if src_dataset is None or not await ext.can_access_dataset(
             db, src_dataset, row.dataset_id, user, user_roles=user_roles
         ):
@@ -214,8 +242,12 @@ async def get_vrt_status(
     ext = get_permission_extension()
 
     # Collect sources and their URIs for parallel checks
+    health_rows = source_rows.all()
+    datasets_by_id = await _load_source_datasets(
+        db, [row.source_dataset_id for row in health_rows if row.ds_id is not None]
+    )
     sources_to_check = []
-    for row in source_rows.all():
+    for row in health_rows:
         if row.ds_id is None:
             # Source dataset was deleted. Keep this "missing" health branch and
             # the None-guard below so can_access_dataset never deref's
@@ -228,7 +260,7 @@ async def get_vrt_status(
                 )
             )
             continue
-        src_dataset = await get_dataset(db, row.source_dataset_id)
+        src_dataset = datasets_by_id.get(row.source_dataset_id)
         if src_dataset is None or not await ext.can_access_dataset(
             db, src_dataset, row.source_dataset_id, user, user_roles=user_roles
         ):

--- a/backend/app/modules/catalog/datasets/domain/service_query.py
+++ b/backend/app/modules/catalog/datasets/domain/service_query.py
@@ -337,7 +337,7 @@ async def get_dataset_rows(
     if not SAFE_TABLE_NAME_RE.match(table_name):
         raise ValueError(f"Invalid table name: {table_name}")
 
-    from app.core.db.tenant_schema import tenant_data_schema
+    from app.core.db.tenant_schema import schema_exists, tenant_data_schema
     from app.core.db.tenant_session import current_tenant_var
     from app.modules.catalog.datasets.domain._sql_safety import _safe_table_ref
 
@@ -382,9 +382,15 @@ async def get_dataset_rows(
         # whose synthetic table_name has no PostGIS table. The rest reach the 503 path.
         if sqlstate(exc) not in TABLE_ABSENT:
             raise
-        logger.warning("Data table %s is absent", table_name, exc_info=True)
         # Postgres aborted the transaction; read-only here, so rollback is safe.
         await db.rollback()
+        # fix(#435 codex r1): a missing schema reports 42P01 too, so the code alone
+        # cannot tell a synthetic raster table from a tenant schema that was never
+        # provisioned. Only the second is drift, and it must not read as empty data.
+        if not await schema_exists(db, _schema):
+            logger.error("Data schema %s does not exist", _schema)
+            raise
+        logger.warning("Data table %s is absent", table_name, exc_info=True)
         return [], 0, column_info or [], None
 
     return rows, approx_total, column_info or [], next_cursor

--- a/backend/app/modules/catalog/datasets/domain/service_query.py
+++ b/backend/app/modules/catalog/datasets/domain/service_query.py
@@ -12,9 +12,11 @@ if TYPE_CHECKING:
     from app.modules.catalog.datasets.domain.schemas import DatasetResponse
 
 from sqlalchemy import func, select, text
+from sqlalchemy.exc import DBAPIError
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import joinedload
 
+from app.core.db.sqlstate import TABLE_ABSENT, sqlstate
 from app.core.identity import Identity
 from app.modules.catalog.authorization import apply_visibility_filter
 from app.modules.catalog.datasets.domain._sql_safety import SAFE_TABLE_NAME_RE
@@ -372,17 +374,17 @@ async def get_dataset_rows(
         rel = count_result.scalar_one_or_none()
         approx_total = max(0, rel) if rel is not None else 0
 
-        # Compute next_cursor from last row's gid (None when no more pages)
         next_cursor = rows[-1]["gid"] if rows and len(rows) == limit else None
-    except Exception:  # broad: data.* table may be missing/locked/dropped — log and degrade to empty result
-        # Table may not exist (dropped, migration issue, etc.). Log the
-        # failure so consistent errors are visible instead of silently
-        # returning empty results on every request (RES-N9).
-        logger.warning(
-            "Failed to query rows from data table %s",
-            table_name,
-            exc_info=True,
-        )
+    except DBAPIError as exc:
+        # fix(#435): was `except Exception`, so connection loss, timeouts, and
+        # permission failures all rendered as a valid dataset with zero rows. Only an
+        # absent table still degrades to an empty page — normal for raster/VRT datasets,
+        # whose synthetic table_name has no PostGIS table. The rest reach the 503 path.
+        if sqlstate(exc) not in TABLE_ABSENT:
+            raise
+        logger.warning("Data table %s is absent", table_name, exc_info=True)
+        # Postgres aborted the transaction; read-only here, so rollback is safe.
+        await db.rollback()
         return [], 0, column_info or [], None
 
     return rows, approx_total, column_info or [], next_cursor

--- a/backend/app/modules/catalog/maps/router.py
+++ b/backend/app/modules/catalog/maps/router.py
@@ -28,7 +28,6 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.modules.audit.service import AuditEvent, audit_emit
-from app.core.edition import is_enterprise
 from app.core.identity import Identity
 from app.modules.auth.dependencies import (
     get_current_active_user,
@@ -101,7 +100,6 @@ from app.modules.catalog.maps.service import (
 )
 from app.modules.catalog.maps.models import MapLayer
 from app.modules.catalog.maps.service import _validate_share_token, remove_layers_bulk
-from app.modules.embed_tokens.schemas import ADVANCED_SHARING_ERROR
 from app.modules.embed_tokens.service import (
     revoke_embed_tokens_by_map,
     revoke_embed_tokens_for_dropped_datasets,
@@ -1250,15 +1248,10 @@ async def share_map_endpoint(
             detail="Map must be public before sharing",
         )
     # builder-audit #338 P1-14: custom share expiration is an advanced-sharing control.
-    # The UI hides it in Community, but the backend accepted any expires_at — gate
-    # it here with the same error taxonomy embed tokens use so API clients cannot
-    # bypass the product gate. The basic Community share/revoke flow (no expiry)
-    # is unaffected. Enterprise accepts future expiration.
-    if body is not None and body.expires_at is not None and not is_enterprise():
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail=ADVANCED_SHARING_ERROR,
-        )
+    # fix(#435): the gate moved down to `ShareTokenRequest` (422, like every other
+    # embed/share control) and to `create_share_token` itself, so a caller that never
+    # passes through this handler cannot persist an Enterprise-only expiration. The
+    # `except ValueError` below surfaces the service-layer guard for such callers.
     try:
         token_obj = await create_share_token(
             db, map_id, user.id, expires_at=body.expires_at if body else None
@@ -1309,14 +1302,8 @@ async def update_map_share_token_endpoint(
             detail="Map not found",
         )
     await check_map_ownership(map_obj, user, db)
-    # builder-audit #338 P1-14: gate custom expiration on update too. Null clears
-    # expiration (basic Community flow, allowed); a non-null custom expiry is an
-    # advanced-sharing control reserved for Enterprise.
-    if body.expires_at is not None and not is_enterprise():
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail=ADVANCED_SHARING_ERROR,
-        )
+    # builder-audit #338 P1-14 / fix(#435): gated in `ShareTokenRequest` (422) and in
+    # `update_share_token`. Null clears expiration and stays valid in Community.
     try:
         token_obj = await update_share_token(db, map_id, body.expires_at)
     except ValueError as e:

--- a/backend/app/modules/catalog/maps/schemas.py
+++ b/backend/app/modules/catalog/maps/schemas.py
@@ -6,6 +6,7 @@ from enum import Enum
 from typing import Annotated, TypedDict
 
 from pydantic import (
+    AwareDatetime,
     BaseModel,
     ConfigDict,
     Field,
@@ -15,8 +16,10 @@ from pydantic import (
     model_validator,
 )
 
+from app.core.edition import is_enterprise
 from app.core.text import normalize_nfc as _nfc
 from app.modules.catalog.maps.filter_grammar import validate_filter
+from app.modules.embed_tokens.schemas import ADVANCED_SHARING_ERROR
 
 LEGACY_BUILDER_PAINT_KEYS = {
     "_outline-width": "outline_width",
@@ -1118,17 +1121,36 @@ class SharedMapResponse(BaseModel):
 
 
 class ShareTokenRequest(BaseModel):
-    expires_at: datetime | None = Field(
+    # fix(#435): `AwareDatetime`, not bare `datetime`. Pydantic accepts a naive ISO
+    # string for a plain `datetime`, and comparing it to `datetime.now(timezone.utc)`
+    # below raised `TypeError: can't compare offset-naive and offset-aware datetimes`
+    # — a 500 for what is a malformed payload. `AwareDatetime` rejects it with a 422.
+    expires_at: AwareDatetime | None = Field(
         default=None,
-        description="Expiration timestamp. Null creates a non-expiring share link.",
+        description=(
+            "Expiration timestamp; must carry a UTC offset. Null creates a "
+            "non-expiring share link. A custom expiration requires advanced "
+            "sharing controls."
+        ),
     )
 
     @field_validator("expires_at")
     @classmethod
-    def expires_at_must_be_future(cls, v: datetime | None) -> datetime | None:
+    def expires_at_must_be_future(cls, v: AwareDatetime | None) -> AwareDatetime | None:
         if v is not None and v < datetime.now(timezone.utc):
             raise ValueError("expires_at must be in the future")
         return v
+
+    @model_validator(mode="after")
+    def validate_enterprise_controls(self):
+        # fix(#435): the edition boundary was enforced only by the two route handlers,
+        # so any internal caller reaching the service directly could persist an
+        # Enterprise-only expiration in Community. Guard at the schema too, mirroring
+        # `EmbedTokenCreate`. `None` stays valid — Community keeps basic create/revoke
+        # and can still clear an existing expiration.
+        if self.expires_at is not None and not is_enterprise():
+            raise ValueError(ADVANCED_SHARING_ERROR)
+        return self
 
 
 class ShareTokenResponse(BaseModel):

--- a/backend/app/modules/catalog/maps/service_public.py
+++ b/backend/app/modules/catalog/maps/service_public.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING
 from sqlalchemy import func, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.core.edition import is_enterprise
 from app.core.identity import Identity
 from app.modules.auth.models import User
 from app.modules.catalog._ilike import escape_ilike
@@ -21,6 +22,7 @@ from app.modules.catalog.maps.service_shared import (
     _extract_dem_vertical_units,
 )
 from app.modules.embed_tokens.models import EmbedToken
+from app.modules.embed_tokens.schemas import ADVANCED_SHARING_ERROR
 from app.modules.embed_tokens.service import resolve_embed_scope_for_map
 from app.platform.extensions import get_catalog_port
 
@@ -85,6 +87,19 @@ async def find_public_maps_using_dataset(
     return [row[0] for row in result.all()]
 
 
+def _reject_custom_expiration_in_community(expires_at: datetime | None) -> None:
+    """Enforce the advanced-sharing edition boundary at the service entry points.
+
+    fix(#435): only the two route handlers called `is_enterprise()` before invoking
+    these services, so a bulk-import path, overlay, or test helper could persist an
+    Enterprise-only expiration on a Community deployment. `None` remains valid, which
+    keeps basic create/revoke working and lets Community clear an expiration that an
+    Enterprise license previously set.
+    """
+    if expires_at is not None and not is_enterprise():
+        raise ValueError(ADVANCED_SHARING_ERROR)
+
+
 async def create_share_token(
     session: AsyncSession,
     map_id: uuid.UUID,
@@ -92,6 +107,7 @@ async def create_share_token(
     expires_at: datetime | None = None,
 ) -> MapShareToken:
     """Create a share token for a map. Reuses existing token if one exists. Does NOT commit."""
+    _reject_custom_expiration_in_community(expires_at)
     # Check for existing token
     existing = await session.execute(
         select(MapShareToken).where(MapShareToken.map_id == map_id)
@@ -133,6 +149,7 @@ async def update_share_token(
     expires_at: datetime | None,
 ) -> MapShareToken | None:
     """Update expiration on the active share token for a map. Returns None if no active token."""
+    _reject_custom_expiration_in_community(expires_at)
     result = await session.execute(
         select(MapShareToken).where(
             MapShareToken.map_id == map_id,

--- a/backend/app/modules/quota/service.py
+++ b/backend/app/modules/quota/service.py
@@ -73,6 +73,68 @@ async def get_user_quota_usage(
     )
 
 
+async def get_user_quota_usage_bulk(
+    db: AsyncSession,
+    user_ids: list[uuid.UUID],
+) -> dict[uuid.UUID, UserQuotaUsage]:
+    """Return quota usage for many users in one aggregate plus one cap read.
+
+    fix(#435): the admin user list called `get_user_quota_usage()` once per row —
+    200 rows per page, each running its own three-table aggregate, plus two
+    persistent-config reads. That is 600 queries to render one admin page, and it
+    grows with the catalog.
+
+    Users with no records are absent from the aggregate; they get a zeroed usage
+    row so callers can index the result unconditionally.
+    """
+    storage_cap = int(await MAX_STORAGE_BYTES_PER_USER.get(db))
+    count_cap = int(await MAX_DATASETS_PER_USER.get(db))
+
+    if not user_ids:
+        return {}
+
+    sql = text(
+        """
+        SELECT
+            r.created_by                            AS user_id,
+            COALESCE(SUM(da.size_bytes), 0)::bigint AS bytes_used,
+            COUNT(DISTINCT r.id)::bigint            AS dataset_count
+        FROM   catalog.records r
+        LEFT JOIN catalog.datasets d  ON d.record_id = r.id
+        LEFT JOIN catalog.dataset_assets da
+               ON da.dataset_id = d.id AND da.key = 'data'
+        WHERE  r.created_by = ANY(CAST(:user_ids AS uuid[]))
+          AND  r.record_type IN (
+                   'vector_dataset', 'raster_dataset', 'vrt_dataset', 'table'
+               )
+        GROUP BY r.created_by
+        """
+    )
+    result = await db.execute(sql, {"user_ids": [str(uid) for uid in user_ids]})
+    by_user = {
+        row.user_id: UserQuotaUsage(
+            bytes_used=int(row.bytes_used),
+            dataset_count=int(row.dataset_count),
+            storage_cap=storage_cap,
+            count_cap=count_cap,
+        )
+        for row in result.all()
+    }
+
+    return {
+        user_id: by_user.get(
+            user_id,
+            UserQuotaUsage(
+                bytes_used=0,
+                dataset_count=0,
+                storage_cap=storage_cap,
+                count_cap=count_cap,
+            ),
+        )
+        for user_id in user_ids
+    }
+
+
 async def check_upload_quota(
     db: AsyncSession,
     user_id: uuid.UUID,

--- a/backend/app/modules/settings/router.py
+++ b/backend/app/modules/settings/router.py
@@ -25,6 +25,7 @@ from app.core.persistent_config import (
     EMBEDDING_DIMS,
     ENABLE_DATASET_EDITING,
     ENABLED_PLUGINS,
+    ENTERPRISE_ONLY_TABS,
     MAP_DEFAULTS,
     PASSWORD_LOGIN_ENABLED,
     REQUIRE_METADATA_FOR_PUBLISH,
@@ -77,19 +78,6 @@ def _basemap_proxy_rate_limit(_request: Request | None = None) -> str:
 # ---------------------------------------------------------------------------
 
 
-# Phase 279 ADMIN-03 (M-03): Single source of truth for enterprise-only Settings
-# tabs. Both the backend (_require_enterprise_for_key gate) and the frontend
-# (AdminSidebar conditional render) consult this set. The frontend reaches it
-# via GET /admin/settings/enterprise-tabs/ which returns its keys as a JSON
-# list. Adding a new enterprise-only tab: edit this set.
-#
-# Note: "appearance" was previously hardcoded as enterpriseOnly only on the
-# frontend (AdminSidebar.tsx). The backend gate did not enforce it, allowing a
-# community caller to write appearance keys silently. Adding it here closes
-# that drift before the frontend collapses to read this list.
-_ENTERPRISE_ONLY_TABS = frozenset({"branding", "appearance"})
-
-
 # Phase 279 ADMIN-09 (L-01): The PUT/RESET handlers below intentionally end with
 # `return await get_all_settings(...)` to capture side-effects from
 # rebuild_embedding_column rollback, _auto_detect_embedding_dims write, and
@@ -139,7 +127,7 @@ def _require_enterprise_for_key(key: str) -> None:
     if is_enterprise():
         return
     cfg = _get_registry_map().get(key)
-    if cfg is not None and cfg.tab in _ENTERPRISE_ONLY_TABS:
+    if cfg is not None and cfg.tab in ENTERPRISE_ONLY_TABS:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND)
 
 
@@ -198,7 +186,7 @@ async def get_all_settings(
     tabs: dict[str, list[SettingItem]] = {}
     for cfg in _registry:
         # Hide enterprise-only tabs in community edition
-        if not enterprise and cfg.tab in _ENTERPRISE_ONLY_TABS:
+        if not enterprise and cfg.tab in ENTERPRISE_ONLY_TABS:
             continue
         if cfg.key == "public_app_url":
             value = await get_public_app_url(db, request=request)
@@ -248,7 +236,7 @@ async def get_enterprise_only_tabs(
     aligned.
     """
     # Sort for stable JSON output (downstream tests rely on deterministic order)
-    return EnterpriseTabsResponse(tabs=sorted(_ENTERPRISE_ONLY_TABS))
+    return EnterpriseTabsResponse(tabs=sorted(ENTERPRISE_ONLY_TABS))
 
 
 # ROUTE-01 (Phase 1092): dual-shape decorator — see /all above. The empty

--- a/backend/app/platform/config_ops/service.py
+++ b/backend/app/platform/config_ops/service.py
@@ -291,15 +291,12 @@ async def import_config(
     Callers with access apply all keys.
     """
     from app.core.edition import is_enterprise
-    from app.core.persistent_config import _registry
+    from app.core.persistent_config import ENTERPRISE_ONLY_TABS, _registry
     from app.core.public_urls import _is_env_only
     from app.modules.audit.service import (
         AuditEvent,
         audit_emit,
     )  # LAZY — preserved per D-17
-
-    # BUG-011: mirror the same restricted tab set the settings PUT gate uses.
-    from app.modules.settings.router import _ENTERPRISE_ONLY_TABS
 
     if _is_env_only():
         raise ConfigLockedError("Configuration locked to environment variables")
@@ -343,7 +340,7 @@ async def import_config(
 
         # BUG-011: callers without access cannot write restricted keys. Skip
         # (don't apply) rather than reject the whole import.
-        if not caller_is_enterprise and cfg.tab in _ENTERPRISE_ONLY_TABS:
+        if not caller_is_enterprise and cfg.tab in ENTERPRISE_ONLY_TABS:
             settings_skipped += 1
             skipped_restricted.append(key)
             continue
@@ -385,7 +382,7 @@ async def import_config(
             # mode would still call reset() on them - reverting restricted
             # branding/appearance settings to env defaults despite reporting them
             # as skipped.
-            if not caller_is_enterprise and cfg.tab in _ENTERPRISE_ONLY_TABS:
+            if not caller_is_enterprise and cfg.tab in ENTERPRISE_ONLY_TABS:
                 continue
             # fix(#430 BA-31): defer to the single terminal commit so the whole import
             # is one transaction — a later failure (e.g. missing OAuth secret)

--- a/backend/app/platform/jobs/worker.py
+++ b/backend/app/platform/jobs/worker.py
@@ -18,7 +18,11 @@ from sqlalchemy import select, text
 
 from app.core.config import settings
 from app.core.logging_config import setup_logging
-from app.core.runtime.staging import ensure_staging_ready, redirect_tempfile_to_staging
+from app.core.runtime.staging import (
+    ensure_staging_ready,
+    redirect_tempfile_to_staging,
+    sweep_orphaned_exports,
+)
 
 # Redirect stdlib tempfile to the staging volume BEFORE any task module is
 # imported. Otherwise the COG conversion sanity check in tasks_raster
@@ -36,82 +40,6 @@ log = structlog.get_logger()
 # Stable app-unique integer used for the PostgreSQL advisory lock that
 # prevents concurrent stale-job recovery across multiple worker processes.
 RECOVERY_LOCK_KEY = 224_001
-
-
-# ING-04 (P2-04): exports temp-dir sweep age threshold. Only entries
-# whose mtime is older than this many seconds are deleted on worker
-# startup. In-flight large exports younger than 1 hour survive a
-# rolling worker restart; truly orphaned crash-residue gets cleaned.
-# Matches the 1-hour window used by the worker stale-job recovery
-# (`JOB_TIMEOUT_SECONDS` in router.py) so a 6-minute COG export that
-# survives a rolling restart at the job layer also keeps its on-disk
-# staging artifact.
-EXPORTS_SWEEP_AGE_SECONDS = 3600  # 1 hour
-
-
-def _sweep_orphaned_exports(
-    exports_dir: Path,
-    *,
-    age_threshold_seconds: int = EXPORTS_SWEEP_AGE_SECONDS,
-) -> tuple[int, int]:
-    """Sweep orphaned export temp entries older than ``age_threshold_seconds``.
-
-    ING-04 (P2-04): entries whose ``stat.st_mtime`` is within the last
-    ``age_threshold_seconds`` are skipped (and logged) so an in-flight
-    large export does not get truncated by a worker restart. Entries
-    older than the threshold are removed (``shutil.rmtree`` for
-    directories, ``Path.unlink`` for files).
-
-    Args:
-        exports_dir: The ``<staging>/exports/`` directory to sweep. A
-            missing directory is treated as a no-op (no error raised).
-        age_threshold_seconds: Skip entries newer than this many seconds.
-            Defaults to ``EXPORTS_SWEEP_AGE_SECONDS`` (1 hour).
-
-    Returns:
-        ``(deleted_count, skipped_count)``.
-    """
-    import shutil
-
-    if not exports_dir.exists():
-        return (0, 0)
-
-    entries = list(exports_dir.iterdir())
-    if not entries:
-        return (0, 0)
-
-    now_ts = datetime.now(timezone.utc).timestamp()
-    deleted_count = 0
-    skipped_count = 0
-    for item in entries:
-        try:
-            item_mtime = item.stat().st_mtime
-        except FileNotFoundError:
-            # Raced with another worker / external cleanup — treat as already-gone.
-            continue
-        age_seconds = now_ts - item_mtime
-        if age_seconds < age_threshold_seconds:
-            log.info(
-                "sweep_skipped_recent_export",
-                path=str(item),
-                age_seconds=round(age_seconds, 1),
-                threshold_seconds=age_threshold_seconds,
-            )
-            skipped_count += 1
-            continue
-        if item.is_dir():
-            shutil.rmtree(item, ignore_errors=True)
-        else:
-            item.unlink(missing_ok=True)
-        deleted_count += 1
-
-    if deleted_count or skipped_count:
-        log.info(
-            "exports_sweep_complete",
-            deleted=deleted_count,
-            skipped=skipped_count,
-        )
-    return (deleted_count, skipped_count)
 
 
 async def recover_stale_jobs() -> None:
@@ -271,7 +199,7 @@ async def main() -> None:
     # truncated mid-download because the new worker process happened to
     # boot during the export's stream phase.
     exports_dir = Path(settings.upload_staging_dir) / "exports"
-    _sweep_orphaned_exports(exports_dir)
+    sweep_orphaned_exports(exports_dir)
 
     # 3. WORK-01: shared bootstrap — load extensions (overlay), check enterprise
     # overlay requested, init edition, init storage + S3 health probe, init cache.

--- a/backend/app/platform/storage/local.py
+++ b/backend/app/platform/storage/local.py
@@ -74,16 +74,26 @@ class LocalStorageProvider:
         try:
             return await asyncio.shield(copy)
         except asyncio.CancelledError:
-            # fix(#435 codex r2): `asyncio.to_thread` cannot stop a thread that is
+            # fix(#435 codex r2/r3): `asyncio.to_thread` cannot stop a thread that is
             # already running. Once the copy reads from a caller-owned handle rather
             # than a `bytes` snapshot, returning here would let the caller leave its
             # `with open(...)` block and close `data` mid-`copyfileobj`: a truncated
             # artifact plus an exception nobody retrieves. Cancellation on an ingest
-            # task or worker shutdown hits exactly this. Wait for the thread to let
-            # go of the handle, then report the cancellation.
-            await asyncio.wait({copy})
+            # task or worker shutdown hits exactly this.
+            #
+            # The drain itself is cancellable, so a second cancel (shutdown after a
+            # timeout, say) must not abandon the thread mid-read. `copy` is never
+            # cancelled — only the shield around it is — so it always finishes; loop
+            # until it does, absorbing repeated cancellations, then report ours.
+            while not copy.done():
+                try:
+                    await asyncio.shield(copy)
+                except asyncio.CancelledError:
+                    continue
+                except Exception:
+                    break  # the copy failed; we still report the cancellation
             if not copy.cancelled():
-                copy.exception()  # retrieve it; the cancellation is what we report
+                copy.exception()  # retrieve it so it is not flagged never-retrieved
             raise
 
     async def get(self, key: str) -> bytes:

--- a/backend/app/platform/storage/local.py
+++ b/backend/app/platform/storage/local.py
@@ -50,14 +50,24 @@ class LocalStorageProvider:
         return candidate
 
     async def put(self, key: str, data: BinaryIO | bytes) -> str:
-        """Store data at key. Returns the absolute path as a string."""
+        """Store data at key. Returns the absolute path as a string.
+
+        fix(#435): a file-like `data` stays file-like. This used to call `data.read()`
+        on the event-loop thread before the handoff, materializing a whole COG, VRT,
+        or archived original as one `bytes` object — the raster/VRT/original ingest
+        paths all pass open file handles, and those artifacts can exceed the 2 GB
+        production container limit. The copy now streams in 1 MiB chunks inside the
+        worker thread, so resident memory is bounded and the loop never blocks.
+        """
         dest = self._resolve_contained(key)
-        if not isinstance(data, bytes):
-            data = data.read()  # read in async context before thread handoff
 
         def _put() -> str:
             dest.parent.mkdir(parents=True, exist_ok=True)
-            dest.write_bytes(data)
+            if isinstance(data, bytes):
+                dest.write_bytes(data)
+            else:
+                with open(dest, "wb") as out:
+                    shutil.copyfileobj(data, out, _STREAM_CHUNK_BYTES)
             return str(dest)
 
         return await asyncio.to_thread(_put)

--- a/backend/app/platform/storage/local.py
+++ b/backend/app/platform/storage/local.py
@@ -90,8 +90,8 @@ class LocalStorageProvider:
                     await asyncio.shield(copy)
                 except asyncio.CancelledError:
                     continue
-                except Exception:
-                    break  # the copy failed; we still report the cancellation
+                except Exception:  # broad: the copy thread raised (OSError, etc.); stop draining and report our cancellation
+                    break
             if not copy.cancelled():
                 copy.exception()  # retrieve it so it is not flagged never-retrieved
             raise

--- a/backend/app/platform/storage/local.py
+++ b/backend/app/platform/storage/local.py
@@ -70,7 +70,21 @@ class LocalStorageProvider:
                     shutil.copyfileobj(data, out, _STREAM_CHUNK_BYTES)
             return str(dest)
 
-        return await asyncio.to_thread(_put)
+        copy = asyncio.ensure_future(asyncio.to_thread(_put))
+        try:
+            return await asyncio.shield(copy)
+        except asyncio.CancelledError:
+            # fix(#435 codex r2): `asyncio.to_thread` cannot stop a thread that is
+            # already running. Once the copy reads from a caller-owned handle rather
+            # than a `bytes` snapshot, returning here would let the caller leave its
+            # `with open(...)` block and close `data` mid-`copyfileobj`: a truncated
+            # artifact plus an exception nobody retrieves. Cancellation on an ingest
+            # task or worker shutdown hits exactly this. Wait for the thread to let
+            # go of the handle, then report the cancellation.
+            await asyncio.wait({copy})
+            if not copy.cancelled():
+                copy.exception()  # retrieve it; the cancellation is what we report
+            raise
 
     async def get(self, key: str) -> bytes:
         """Retrieve raw bytes for a key."""

--- a/backend/app/platform/storage/local.py
+++ b/backend/app/platform/storage/local.py
@@ -6,6 +6,8 @@ import shutil
 from pathlib import Path
 from typing import AsyncIterator, BinaryIO
 
+from app.core.async_io import run_in_thread_draining
+
 
 # Chunk size for streaming reads (ING-03 / P2-03). 1 MiB is large enough to
 # amortize syscall overhead but small enough that worst-case resident memory
@@ -70,31 +72,10 @@ class LocalStorageProvider:
                     shutil.copyfileobj(data, out, _STREAM_CHUNK_BYTES)
             return str(dest)
 
-        copy = asyncio.ensure_future(asyncio.to_thread(_put))
-        try:
-            return await asyncio.shield(copy)
-        except asyncio.CancelledError:
-            # fix(#435 codex r2/r3): `asyncio.to_thread` cannot stop a thread that is
-            # already running. Once the copy reads from a caller-owned handle rather
-            # than a `bytes` snapshot, returning here would let the caller leave its
-            # `with open(...)` block and close `data` mid-`copyfileobj`: a truncated
-            # artifact plus an exception nobody retrieves. Cancellation on an ingest
-            # task or worker shutdown hits exactly this.
-            #
-            # The drain itself is cancellable, so a second cancel (shutdown after a
-            # timeout, say) must not abandon the thread mid-read. `copy` is never
-            # cancelled — only the shield around it is — so it always finishes; loop
-            # until it does, absorbing repeated cancellations, then report ours.
-            while not copy.done():
-                try:
-                    await asyncio.shield(copy)
-                except asyncio.CancelledError:
-                    continue
-                except Exception:  # broad: the copy thread raised (OSError, etc.); stop draining and report our cancellation
-                    break
-            if not copy.cancelled():
-                copy.exception()  # retrieve it so it is not flagged never-retrieved
-            raise
+        # fix(#435 codex r2/r3/r4): drain the copy thread on cancellation so the caller
+        # cannot leave its `with open(...)` block and close `data` mid-`copyfileobj`,
+        # truncating the artifact. See app/core/async_io.py.
+        return await run_in_thread_draining(_put)
 
     async def get(self, key: str) -> bytes:
         """Retrieve raw bytes for a key."""

--- a/backend/app/processing/ai/router.py
+++ b/backend/app/processing/ai/router.py
@@ -606,9 +606,13 @@ async def _authorize_metadata_dataset(
     that has a ``dataset_id``-keyed TTL cache and no ``user`` param, so a cache hit
     would bypass an in-service check). On denial ``check_dataset_access`` raises 404
     — same response as a nonexistent dataset, so this is not an existence oracle.
+
+    fix(#435): goes through ProcessingPort rather than importing catalog directly.
+    Both operations already exist on the port, so the lazy import bought nothing and
+    cost the overlay seam: an Enterprise/Cloud port could not observe this
+    authorization at all.
     """
-    from app.modules.catalog.authorization import check_dataset_access
-    from app.modules.catalog.datasets.domain.service import get_dataset
+    port = get_processing_port()
 
     try:
         dsid = uuid_mod.UUID(dataset_id)
@@ -617,12 +621,12 @@ async def _authorize_metadata_dataset(
             status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
             detail="Invalid dataset_id",
         )
-    dataset = await get_dataset(db, dsid)
+    dataset = await port.get_dataset(db, dsid)
     if dataset is None:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND, detail="Dataset not found"
         )
-    await check_dataset_access(db, dataset, dsid, user)
+    await port.check_dataset_access(db, dataset, dsid, user)
 
 
 @router.post("/metadata/summary/", response_model=SummaryDraftResponse)

--- a/backend/app/processing/export/router.py
+++ b/backend/app/processing/export/router.py
@@ -276,27 +276,34 @@ async def export_dataset_endpoint(
     # 8. Audit log. user_id may be None for anonymous exports (EXP-01).
     # The audit_logs.user_id column is nullable; AuditEvent.user_id is typed
     # uuid.UUID | None to match.
-    await audit_emit(
-        db,
-        AuditEvent(
-            user_id=user.id if user is not None else None,
-            action="dataset.export",
-            resource_type="dataset",
-            resource_id=dataset_id,
-            details={
-                "format": format,
-                "target_crs": target_crs,
-                "bbox": bbox,
-                "where": where,
-            },
-            ip_address=request.client.host if request.client else None,
-        ),
-    )
-    await db.commit()
+    #
+    # fix(#435): the export file exists from here on, but nothing owns it until the
+    # FileResponse below attaches the background cleanup. An audit or commit failure
+    # in between used to strand the directory on the staging volume.
+    temp_dir = os.path.dirname(file_path)
+    try:
+        await audit_emit(
+            db,
+            AuditEvent(
+                user_id=user.id if user is not None else None,
+                action="dataset.export",
+                resource_type="dataset",
+                resource_id=dataset_id,
+                details={
+                    "format": format,
+                    "target_crs": target_crs,
+                    "bbox": bbox,
+                    "where": where,
+                },
+                ip_address=request.client.host if request.client else None,
+            ),
+        )
+        await db.commit()
+    except BaseException:
+        _cleanup_export(temp_dir)
+        raise
 
     # 9. Return file with background cleanup
-    temp_dir = os.path.dirname(file_path)
-
     return FileResponse(
         path=file_path,
         filename=filename,

--- a/backend/app/processing/export/service.py
+++ b/backend/app/processing/export/service.py
@@ -1,7 +1,9 @@
 """Export orchestration: validate params, run ogr2ogr, package output."""
 
+import asyncio
 import os
 import re
+import shutil
 import uuid
 import zipfile
 from urllib.parse import quote
@@ -10,6 +12,17 @@ from app.core.config import settings
 from app.processing.export.ogr import FORMAT_MAP, run_ogr2ogr_export
 from app.processing.export.where_validator import validate_where_ast
 from app.core.runtime.staging import ensure_staging_ready
+
+
+def _zip_export_files(temp_dir: str, zip_path: str) -> None:
+    """DEFLATE every ``export.*`` sidecar in *temp_dir* into *zip_path*.
+
+    Blocking; call via ``asyncio.to_thread``.
+    """
+    with zipfile.ZipFile(zip_path, "w", zipfile.ZIP_DEFLATED) as zf:
+        for fname in os.listdir(temp_dir):
+            if fname.startswith("export."):
+                zf.write(os.path.join(temp_dir, fname), fname)
 
 
 def safe_content_disposition(filename: str) -> str:
@@ -155,29 +168,32 @@ async def export_dataset(
     # Sanitize dataset name for filename
     safe_name = re.sub(r"[^\w\-.]", "_", dataset_name)
 
-    if format_key == "shp":
-        # Shapefile: ogr2ogr outputs multiple files, then zip them
-        ogr_output = os.path.join(temp_dir, f"export{ext}")
-        await run_ogr2ogr_export(
-            table_name,
-            ogr_output,
-            driver,
-            target_srs=target_srs,
-            bbox=bbox,
-            where=where,
-            format_key=format_key,
-        )
+    # fix(#435): own the temp directory until we hand a path back to the caller.
+    # ogr2ogr failure, an oversized ZIP, or a cancelled request used to leave the
+    # directory behind until some later process startup swept it.
+    try:
+        if format_key == "shp":
+            # Shapefile: ogr2ogr outputs multiple files, then zip them
+            ogr_output = os.path.join(temp_dir, f"export{ext}")
+            await run_ogr2ogr_export(
+                table_name,
+                ogr_output,
+                driver,
+                target_srs=target_srs,
+                bbox=bbox,
+                where=where,
+                format_key=format_key,
+            )
 
-        # Zip all export.* files
-        zip_filename = f"{safe_name}.zip"
-        zip_path = os.path.join(temp_dir, zip_filename)
-        with zipfile.ZipFile(zip_path, "w", zipfile.ZIP_DEFLATED) as zf:
-            for fname in os.listdir(temp_dir):
-                if fname.startswith("export."):
-                    zf.write(os.path.join(temp_dir, fname), fname)
+            # Zip all export.* files. fix(#435): DEFLATE of a multi-GB shapefile
+            # is CPU-bound and ran on the event loop, stalling every other request
+            # (and job heartbeats) for the duration.
+            zip_filename = f"{safe_name}.zip"
+            zip_path = os.path.join(temp_dir, zip_filename)
+            await asyncio.to_thread(_zip_export_files, temp_dir, zip_path)
 
-        return zip_path, zip_filename, media_type
-    else:
+            return zip_path, zip_filename, media_type
+
         # Single-file formats
         filename = f"{safe_name}{ext}"
         output_path = os.path.join(temp_dir, filename)
@@ -192,3 +208,8 @@ async def export_dataset(
         )
 
         return output_path, filename, media_type
+    except BaseException:
+        # BaseException, not Exception: a client disconnect cancels this task, and
+        # asyncio.CancelledError inherits from BaseException on 3.8+.
+        shutil.rmtree(temp_dir, ignore_errors=True)
+        raise

--- a/backend/app/processing/export/service.py
+++ b/backend/app/processing/export/service.py
@@ -1,6 +1,5 @@
 """Export orchestration: validate params, run ogr2ogr, package output."""
 
-import asyncio
 import os
 import re
 import shutil
@@ -8,6 +7,7 @@ import uuid
 import zipfile
 from urllib.parse import quote
 
+from app.core.async_io import run_in_thread_draining
 from app.core.config import settings
 from app.processing.export.ogr import FORMAT_MAP, run_ogr2ogr_export
 from app.processing.export.where_validator import validate_where_ast
@@ -187,10 +187,12 @@ async def export_dataset(
 
             # Zip all export.* files. fix(#435): DEFLATE of a multi-GB shapefile
             # is CPU-bound and ran on the event loop, stalling every other request
-            # (and job heartbeats) for the duration.
+            # (and job heartbeats) for the duration. fix(#435 codex r4): drained on
+            # cancellation so the `except BaseException` rmtree below cannot delete
+            # temp_dir while the zip thread is still writing into it.
             zip_filename = f"{safe_name}.zip"
             zip_path = os.path.join(temp_dir, zip_filename)
-            await asyncio.to_thread(_zip_export_files, temp_dir, zip_path)
+            await run_in_thread_draining(_zip_export_files, temp_dir, zip_path)
 
             return zip_path, zip_filename, media_type
 

--- a/backend/app/processing/ingest/manifest_service.py
+++ b/backend/app/processing/ingest/manifest_service.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import uuid
 from pathlib import Path
 
@@ -18,6 +19,7 @@ from app.platform.jobs.defer_guard import (
     defer_with_orphan_guard,
     make_ingest_job_failed_rollback,
 )
+
 from app.platform.jobs.models import IngestJob
 from app.processing.ingest.manifest_schemas import (
     ManifestApplyEntryResult,
@@ -33,6 +35,11 @@ from app.processing.ingest.manifest_sources import (
     manifest_job_metadata,
 )
 from app.processing.ingest.service import queue_ingest_job, validate_file_extension
+
+# fix(#435): batch manifest-download writes so a 64 KiB httpx chunk does not cost
+# one `asyncio.to_thread` handoff each. 4 MiB keeps peak buffer memory small
+# while amortizing the thread hop across ~64 chunks.
+_WRITE_BUFFER_BYTES = 4 * 1024 * 1024
 
 
 async def _latest_in_flight_manifest_job(
@@ -101,14 +108,29 @@ async def _download_http_source(
         async with make_safe_client(timeout=60.0) as client:
             async with client.stream("GET", prepared.source_uri) as response:
                 response.raise_for_status()
-                with destination.open("wb") as file_obj:
+                # fix(#435): `Path.open()` + `file_obj.write()` ran synchronously
+                # inside this async loop, stalling the event loop — and therefore job
+                # heartbeats, cancellation, and unrelated requests — for the length of
+                # a multi-GB download. Writes now go to a worker thread, batched
+                # through a 4 MiB buffer so we are not paying a thread handoff per
+                # 64 KiB httpx chunk.
+                file_obj = await asyncio.to_thread(destination.open, "wb")
+                try:
+                    buffer = bytearray()
                     async for chunk in response.aiter_bytes():
                         bytes_seen += len(chunk)
                         if bytes_seen > max_size_bytes:
                             raise ManifestSourceError(
                                 "Manifest source exceeds configured upload size limit"
                             )
-                        file_obj.write(chunk)
+                        buffer.extend(chunk)
+                        if len(buffer) >= _WRITE_BUFFER_BYTES:
+                            await asyncio.to_thread(file_obj.write, bytes(buffer))
+                            buffer.clear()
+                    if buffer:
+                        await asyncio.to_thread(file_obj.write, bytes(buffer))
+                finally:
+                    await asyncio.to_thread(file_obj.close)
     except ManifestSourceError:
         destination.unlink(missing_ok=True)
         raise

--- a/backend/app/processing/ingest/manifest_service.py
+++ b/backend/app/processing/ingest/manifest_service.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import asyncio
 import uuid
 from pathlib import Path
 
@@ -10,6 +9,7 @@ from fastapi import HTTPException
 from sqlalchemy import desc, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.core.async_io import run_in_thread_draining
 from app.core.config import settings
 from app.core.db.tenant_session import defer_async_with_tenant
 from app.core.identity import Identity
@@ -114,7 +114,12 @@ async def _download_http_source(
                 # a multi-GB download. Writes now go to a worker thread, batched
                 # through a 4 MiB buffer so we are not paying a thread handoff per
                 # 64 KiB httpx chunk.
-                file_obj = await asyncio.to_thread(destination.open, "wb")
+                # fix(#435 codex r4): each threaded write/close is drained on
+                # cancellation (run_in_thread_draining), so worker shutdown or a client
+                # disconnect cannot return while a thread still owns the staged fd and
+                # race the unlink below. `bytes(buffer)` snapshots before the thread
+                # reads it, so the following `buffer.clear()` is safe.
+                file_obj = await run_in_thread_draining(destination.open, "wb")
                 try:
                     buffer = bytearray()
                     async for chunk in response.aiter_bytes():
@@ -125,18 +130,23 @@ async def _download_http_source(
                             )
                         buffer.extend(chunk)
                         if len(buffer) >= _WRITE_BUFFER_BYTES:
-                            await asyncio.to_thread(file_obj.write, bytes(buffer))
+                            await run_in_thread_draining(file_obj.write, bytes(buffer))
                             buffer.clear()
                     if buffer:
-                        await asyncio.to_thread(file_obj.write, bytes(buffer))
+                        await run_in_thread_draining(file_obj.write, bytes(buffer))
                 finally:
-                    await asyncio.to_thread(file_obj.close)
+                    await run_in_thread_draining(file_obj.close)
     except ManifestSourceError:
         destination.unlink(missing_ok=True)
         raise
     except Exception as exc:  # broad: HTTP client / I/O / decompress can throw varied types; map to ManifestSourceError
         destination.unlink(missing_ok=True)
         raise ManifestSourceError(f"Failed to download manifest source: {exc}") from exc
+    except BaseException:
+        # fix(#435 codex r4): cancellation/shutdown. The `finally` above already
+        # drained the close, so no thread owns the fd — drop the partial staged file.
+        destination.unlink(missing_ok=True)
+        raise
 
     return str(destination)
 

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -13129,7 +13129,7 @@
                 "type": "null"
               }
             ],
-            "description": "Expiration timestamp. Null creates a non-expiring share link.",
+            "description": "Expiration timestamp; must carry a UTC offset. Null creates a non-expiring share link. A custom expiration requires advanced sharing controls.",
             "title": "Expires At"
           }
         },

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -98,6 +98,50 @@ dev = [
     "pystac>=1.14",
 ]
 
+[tool.ruff.lint]
+# Ruff's defaults (E4/E7/E9/F) plus a cyclomatic-complexity gate. fix(#435): the
+# audit found 33 functions above McCabe 15 with no configured gate — a line cap on a
+# module does not stop one function accumulating branches, transaction boundaries,
+# I/O, authorization, and serialization concerns.
+select = ["E4", "E7", "E9", "F", "C901"]
+
+[tool.ruff.lint.mccabe]
+max-complexity = 15
+
+[tool.ruff.lint.per-file-ignores]
+# Burn-down baseline: every file that exceeded McCabe 15 when the gate went in.
+# New code everywhere else is gated. This list may SHRINK, never grow — a new entry
+# means a new over-complex function. Start with `raster_tile_proxy` (30),
+# `_build_dataset_context` (35), and `_stream_openai_chat` (32): they combine the
+# most failure domains. The standards serializers (dcat, dcat_us, geodcat_ap, stac,
+# ogc) are compatibility mappings — churn-only rewrites there are not worth it.
+"app/modules/auth/oauth/service.py" = ["C901"]
+"app/modules/catalog/maps/filter_grammar.py" = ["C901"]
+"app/modules/catalog/maps/service_diff.py" = ["C901"]
+"app/modules/catalog/maps/sprites.py" = ["C901"]
+"app/modules/catalog/maps/style_json.py" = ["C901"]
+"app/modules/catalog/search/router.py" = ["C901"]
+"app/modules/catalog/search/service_records.py" = ["C901"]
+"app/modules/catalog/sources/router.py" = ["C901"]
+"app/modules/embed_tokens/service.py" = ["C901"]
+"app/platform/extensions/defaults.py" = ["C901"]
+"app/processing/ai/chat_actions.py" = ["C901"]
+"app/processing/ai/metadata_service.py" = ["C901"]
+"app/processing/ai/service.py" = ["C901"]
+"app/processing/ai/streaming.py" = ["C901"]
+"app/processing/export/router.py" = ["C901"]
+"app/processing/ingest/metadata.py" = ["C901"]
+"app/processing/ingest/tasks_raster.py" = ["C901"]
+"app/processing/ingest/tasks_vector.py" = ["C901"]
+"app/processing/ingest/tasks_vrt.py" = ["C901"]
+"app/processing/raster/quicklook.py" = ["C901"]
+"app/processing/tiles/router.py" = ["C901"]
+"app/standards/dcat/service.py" = ["C901"]
+"app/standards/dcat_us/service.py" = ["C901"]
+"app/standards/geodcat_ap/service.py" = ["C901"]
+"app/standards/ogc/router.py" = ["C901"]
+"app/standards/stac/router.py" = ["C901"]
+
 [tool.pytest.ini_options]
 # Let AnyIO own the project’s coroutine tests and plain async fixtures. Keep
 # pytest-asyncio strict so it only handles the explicit asyncio-only unit-test

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1243,6 +1243,44 @@ class _RetryingAsyncEngine:
         return getattr(self._underlying, name)
 
 
+# fix(#435): fixtures whose setup needs a reachable Postgres. When the database is
+# unreachable, only tests that request one of these (directly or transitively) are
+# skipped — pure unit, schema, AST, and architecture tests still execute.
+#
+# `client` is the root of the DB fixture graph; the rest are listed because a test
+# can reach them without naming `client`, and `request.fixturenames` already carries
+# the transitive closure.
+_DB_FIXTURE_NAMES = frozenset(
+    {
+        "client",
+        "test_db_session",
+        "clean_tables",
+        "admin_auth_header",
+        "editor_auth_header",
+        "viewer_auth_header",
+    }
+)
+
+# Set by `_test_db_lifecycle` when the Postgres host cannot be reached at all.
+_db_unavailable_reason: str | None = None
+
+
+@pytest.fixture(autouse=True)
+def _skip_if_db_unavailable(request):
+    """Skip DB-backed tests — and only those — when Postgres is unreachable.
+
+    fix(#435): `_test_db_lifecycle` used to call `pytest.skip()` from session-scoped
+    autouse setup, which skipped every collected item. A targeted run of
+    `test_layering.py` then exited 0 with 48 skipped and 0 executed, so the
+    architecture gates could report green while asserting nothing.
+    """
+    if _db_unavailable_reason is None:
+        return
+    if _DB_FIXTURE_NAMES.isdisjoint(request.fixturenames):
+        return
+    pytest.skip(f"Postgres unreachable: {_db_unavailable_reason}")
+
+
 @pytest.fixture(autouse=True, scope="session")
 def _test_db_lifecycle():
     """Create, migrate, and tear down the test database once per session.
@@ -1250,10 +1288,12 @@ def _test_db_lifecycle():
     Uses sync SQLAlchemy because CREATE/DROP DATABASE require AUTOCOMMIT
     isolation which is simpler with the synchronous driver.
 
-    Gracefully skips DB setup when database host is unreachable (e.g. pure
-    unit test runs outside Docker). Tests that require DB will fail with a
-    clear connection error; DB-independent tests will run normally.
+    When the database host is unreachable (e.g. a pure unit-test run outside
+    Docker), DB setup is skipped and `_db_unavailable_reason` is recorded;
+    `_skip_if_db_unavailable` then skips the DB-backed tests individually and
+    everything else runs normally.
     """
+    global _db_unavailable_reason
     original_test_db_name = settings.postgres_db_test
     db_name = _worker_test_database_name(original_test_db_name)
     settings.postgres_db_test = db_name
@@ -1314,9 +1354,12 @@ def _test_db_lifecycle():
                 # InvalidCatalogNameError on this worker's tests.
                 raise
             # Truly unreachable host (DNS failure, refused connection, auth
-            # error, etc.) — preserve the existing skip semantics for
-            # pure unit-test runs outside Docker.
-            pytest.skip(f"Postgres unreachable: {e}")
+            # error, etc.). Record it and hand control back: the per-test
+            # `_skip_if_db_unavailable` fixture skips only the DB-backed tests,
+            # so pure unit-test runs outside Docker still execute.
+            _db_unavailable_reason = str(e)
+            yield
+            return
 
         # --- Init: extensions, schemas, roles ---
         test_engine_sync = sqlalchemy.create_engine(settings.test_database_url_sync)

--- a/backend/tests/test_1181_config_correctness.py
+++ b/backend/tests/test_1181_config_correctness.py
@@ -369,7 +369,7 @@ class TestBug011EditionGatedImport:
         allowed non-imported keys are still reset (overwrite semantics kept).
         """
         from app.core.persistent_config import _registry
-        from app.modules.settings.router import _ENTERPRISE_ONLY_TABS
+        from app.core.persistent_config import ENTERPRISE_ONLY_TABS
         from app.platform.config_ops.service import import_config
 
         mock_db = AsyncMock(spec=AsyncSession)
@@ -406,7 +406,7 @@ class TestBug011EditionGatedImport:
                     ip_address=None,
                 )
 
-        enterprise_keys = {c.key for c in _registry if c.tab in _ENTERPRISE_ONLY_TABS}
+        enterprise_keys = {c.key for c in _registry if c.tab in ENTERPRISE_ONLY_TABS}
         assert enterprise_keys, "expected the registry to define restricted keys"
         leaked = enterprise_keys & set(reset_keys)
         assert not leaked, (

--- a/backend/tests/test_advanced_sharing_schema.py
+++ b/backend/tests/test_advanced_sharing_schema.py
@@ -40,12 +40,52 @@ def test_community_rejects_embed_update_allowed_origins(community_edition):
     _assert_advanced_sharing_error(exc_info)
 
 
-def test_community_accepts_share_expiration(community_edition):
+def test_community_rejects_share_expiration(community_edition):
+    """fix(#435): a custom expiration is an Enterprise control at the schema layer too.
+
+    This test previously asserted the opposite — that Community accepts the input —
+    which pinned the gap the router alone was papering over.
+    """
+    with pytest.raises(ValidationError) as exc_info:
+        ShareTokenRequest(expires_at=_future_timestamp())
+
+    _assert_advanced_sharing_error(exc_info)
+
+
+def test_enterprise_accepts_share_expiration(enterprise_edition):
     expires_at = _future_timestamp()
 
     request = ShareTokenRequest(expires_at=expires_at)
 
     assert request.expires_at == expires_at
+
+
+@pytest.mark.parametrize(
+    "naive",
+    [
+        "2030-06-01T00:00:00",
+        datetime(2030, 6, 1, 0, 0, 0),
+    ],
+    ids=["naive-string", "naive-datetime"],
+)
+def test_share_expiration_rejects_naive_timestamp(enterprise_edition, naive):
+    """fix(#435): a naive timestamp is a 422, not a `TypeError` 500.
+
+    `expires_at: datetime` accepted naive input, then `v < datetime.now(timezone.utc)`
+    raised `TypeError: can't compare offset-naive and offset-aware datetimes`.
+    """
+    with pytest.raises(ValidationError) as exc_info:
+        ShareTokenRequest(expires_at=naive)
+
+    assert exc_info.value.errors()[0]["type"] == "timezone_aware"
+
+
+@pytest.mark.parametrize(
+    "value",
+    ["2030-06-01T00:00:00Z", "2030-06-01T00:00:00+05:30", "2030-05-31T18:30:00-05:00"],
+)
+def test_share_expiration_accepts_any_offset(enterprise_edition, value):
+    assert ShareTokenRequest(expires_at=value).expires_at.tzinfo is not None
 
 
 def test_community_accepts_basic_sharing_defaults(community_edition):
@@ -74,3 +114,49 @@ def test_share_expiration_must_be_future():
         ShareTokenRequest(expires_at=datetime.now(timezone.utc) - timedelta(seconds=1))
 
     assert "expires_at must be in the future" in str(exc_info.value)
+
+
+async def test_service_rejects_community_share_expiration(community_edition):
+    """fix(#435): the guard repeats at the service entry points.
+
+    The schema only protects HTTP callers. An internal caller — bulk import, an
+    overlay, a test helper — reaches `create_share_token` directly, and nothing
+    below the router stopped it persisting an Enterprise-only expiration.
+    """
+    import uuid
+
+    from app.modules.catalog.maps.service_public import (
+        create_share_token,
+        update_share_token,
+    )
+
+    map_id = uuid.uuid4()
+    with pytest.raises(ValueError, match=ADVANCED_SHARING_ERROR):
+        await create_share_token(None, map_id, uuid.uuid4(), _future_timestamp())
+
+    with pytest.raises(ValueError, match=ADVANCED_SHARING_ERROR):
+        await update_share_token(None, map_id, _future_timestamp())
+
+
+async def test_service_allows_clearing_expiration_in_community(
+    community_edition, monkeypatch
+):
+    """`None` must stay valid: Community keeps create/revoke and can clear an expiry."""
+    import uuid
+
+    from app.modules.catalog.maps import service_public
+
+    # Guard runs before any DB work; assert we get past it, not that we hit the DB.
+    async def _no_token(*args, **kwargs):
+        class _Empty:
+            def scalar_one_or_none(self):
+                return None
+
+        return _Empty()
+
+    class _Session:
+        execute = staticmethod(_no_token)
+
+    assert (
+        await service_public.update_share_token(_Session(), uuid.uuid4(), None) is None
+    )

--- a/backend/tests/test_async_io.py
+++ b/backend/tests/test_async_io.py
@@ -1,0 +1,86 @@
+"""fix(#435 codex r2/r3/r4): threaded I/O must finish before cancellation returns.
+
+`run_in_thread_draining` backs the local-storage copy, the manifest HTTP download, and
+the shapefile export zip. `asyncio.to_thread` cannot stop a running thread, so returning
+on cancellation while the thread still owns a file descriptor races the caller's
+close/unlink and truncates the artifact. These tests pin the drain directly, so they
+cover all three call sites.
+"""
+
+import asyncio
+import time
+
+import pytest
+
+from app.core.async_io import run_in_thread_draining
+
+
+async def test_returns_the_thread_result() -> None:
+    assert await run_in_thread_draining(lambda: 21 * 2) == 42
+
+
+async def test_propagates_the_thread_exception() -> None:
+    def _boom() -> None:
+        raise OSError("No space left on device")
+
+    with pytest.raises(OSError, match="No space left"):
+        await run_in_thread_draining(_boom)
+
+
+async def test_single_cancellation_drains_the_thread() -> None:
+    state = {"done": False}
+
+    def _slow() -> None:
+        time.sleep(0.1)
+        state["done"] = True
+
+    task = asyncio.create_task(run_in_thread_draining(_slow))
+    await asyncio.sleep(0.02)  # let the thread start
+    task.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert state["done"], "returned before the thread finished"
+
+
+async def test_repeated_cancellation_still_drains_the_thread() -> None:
+    """A second cancel (shutdown after a timeout) must not abandon the thread."""
+    state = {"done": False}
+
+    def _slow() -> None:
+        time.sleep(0.15)
+        state["done"] = True
+
+    task = asyncio.create_task(run_in_thread_draining(_slow))
+    await asyncio.sleep(0.02)
+
+    for _ in range(30):
+        task.cancel()
+        await asyncio.sleep(0.005)
+        if task.done():
+            break
+
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert state["done"], "hammered cancellation returned before the thread finished"
+
+
+async def test_cancellation_does_not_leak_the_thread_exception() -> None:
+    """If the drained thread raised, its exception is retrieved, not re-raised.
+
+    The caller asked to cancel; that is what they get. A leaked exception would show up
+    as an "exception was never retrieved" warning at GC.
+    """
+
+    def _slow_then_raise() -> None:
+        time.sleep(0.08)
+        raise OSError("write failed during shutdown")
+
+    task = asyncio.create_task(run_in_thread_draining(_slow_then_raise))
+    await asyncio.sleep(0.02)
+    task.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await task

--- a/backend/tests/test_builder_audit_p0p1_sharing.py
+++ b/backend/tests/test_builder_audit_p0p1_sharing.py
@@ -307,7 +307,9 @@ class TestP114ShareExpirationEdition:
             json={"expires_at": _future_expires_at().isoformat()},
             headers=admin_auth_header,
         )
-        assert resp.status_code == 400, resp.text
+        # fix(#435): 422, not 400 — the gate moved from the handler into
+        # ShareTokenRequest, matching the embed-token controls.
+        assert resp.status_code == 422, resp.text
         assert ADVANCED_SHARING_ERROR in resp.text
 
     async def test_community_basic_share_without_expiration_succeeds(
@@ -381,7 +383,8 @@ class TestP114ShareExpirationEdition:
             json={"expires_at": _future_expires_at().isoformat()},
             headers=admin_auth_header,
         )
-        assert resp.status_code == 400, resp.text
+        # fix(#435): schema-layer gate → 422 (see the create-path test above).
+        assert resp.status_code == 422, resp.text
         assert ADVANCED_SHARING_ERROR in resp.text
 
     async def test_community_update_null_expiration_allowed(

--- a/backend/tests/test_conftest_db_gating.py
+++ b/backend/tests/test_conftest_db_gating.py
@@ -1,0 +1,40 @@
+"""fix(#435): an unreachable Postgres must skip DB-backed tests only.
+
+`_test_db_lifecycle` used to call `pytest.skip()` from session-scoped autouse
+setup, which skipped every collected item. `pytest -q tests/test_layering.py`
+then exited 0 having executed nothing, so the architecture gates could not fail.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+import tests.conftest as conftest
+
+
+def _run_gate(fixturenames: set[str]) -> None:
+    """Invoke the body of the `_skip_if_db_unavailable` fixture directly."""
+    request = SimpleNamespace(fixturenames=fixturenames)
+    conftest._skip_if_db_unavailable.__wrapped__(request)
+
+
+def test_pure_test_runs_when_db_unavailable(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(conftest, "_db_unavailable_reason", "connection refused")
+    _run_gate({"tmp_path", "monkeypatch"})  # no pytest.Skipped raised
+
+
+def test_db_test_skips_when_db_unavailable(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(conftest, "_db_unavailable_reason", "connection refused")
+    with pytest.raises(pytest.skip.Exception, match="Postgres unreachable"):
+        _run_gate({"client", "tmp_path"})
+
+
+def test_db_test_runs_when_db_available(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(conftest, "_db_unavailable_reason", None)
+    _run_gate({"client"})
+
+
+def test_transitive_db_fixtures_are_covered() -> None:
+    """Every fixture that reaches Postgres during setup must be in the gate set."""
+    assert "client" in conftest._DB_FIXTURE_NAMES
+    assert "test_db_session" in conftest._DB_FIXTURE_NAMES

--- a/backend/tests/test_dataset_rows_db_errors.py
+++ b/backend/tests/test_dataset_rows_db_errors.py
@@ -1,0 +1,122 @@
+"""fix(#435): a database failure must not render as a valid dataset with zero rows.
+
+`get_dataset_rows()` wrapped its query in `except Exception` and returned an empty
+page for *every* failure — connection loss, statement timeout, permission failure,
+serialization error. A broken data table looked identical to an empty one, which hid
+ingest corruption and infrastructure incidents from users and from health monitoring.
+
+The one case that legitimately degrades to an empty page is an absent table: raster
+and VRT datasets carry a synthetic `table_name` with no PostGIS table behind it, and
+the rows endpoint is generic across dataset types.
+"""
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.exc import DBAPIError
+
+from app.core.db.sqlstate import BAD_QUERY_INPUT, TABLE_ABSENT, is_operational, sqlstate
+from app.modules.catalog.datasets.domain.service import get_dataset_rows
+
+
+class _FakeOrig:
+    def __init__(self, code: str | None) -> None:
+        self.sqlstate = code
+
+
+def _dbapi_error(code: str | None) -> DBAPIError:
+    return DBAPIError("SELECT 1", {}, _FakeOrig(code))
+
+
+def test_sqlstate_reads_asyncpg_code() -> None:
+    assert sqlstate(_dbapi_error("42P01")) == "42P01"
+
+
+def test_sqlstate_none_when_driver_gave_no_code() -> None:
+    assert sqlstate(_dbapi_error(None)) is None
+
+
+@pytest.mark.parametrize(
+    "code",
+    [
+        "08006",  # connection_failure
+        "08003",  # connection_does_not_exist
+        "40001",  # serialization_failure
+        "40P01",  # deadlock_detected
+        "53300",  # too_many_connections
+        "57014",  # query_canceled — statement timeout
+        "58030",  # io_error
+        None,  # driver raised before the server answered
+    ],
+)
+def test_operational_errors_are_retryable(code) -> None:
+    assert is_operational(_dbapi_error(code)) is True
+
+
+@pytest.mark.parametrize(
+    "code",
+    [
+        "23505",  # unique_violation — a conflict, not an outage
+        "42P01",  # undefined_table
+        "42703",  # undefined_column
+        "42501",  # insufficient_privilege
+        "22P02",  # invalid_text_representation
+    ],
+)
+def test_request_shaped_errors_are_not_retryable(code) -> None:
+    assert is_operational(_dbapi_error(code)) is False
+
+
+def test_sqlstate_sets_do_not_overlap() -> None:
+    assert not (TABLE_ABSENT & BAD_QUERY_INPUT)
+
+
+async def test_absent_table_still_yields_an_empty_page(test_db_session) -> None:
+    """Raster and VRT datasets have no data table; the endpoint must stay generic."""
+    rows, total, columns, cursor = await get_dataset_rows(
+        test_db_session, "raster_0123456789abcdef", column_info=[]
+    )
+
+    assert rows == []
+    assert total == 0
+    assert cursor is None
+
+
+async def test_absent_table_leaves_the_session_usable(test_db_session) -> None:
+    """Degrading to an empty page must not strand the session in a failed transaction.
+
+    Postgres aborts the transaction on `undefined_table`, so every later statement on
+    that session would raise `InFailedSqlTransaction` until someone rolled back.
+    """
+    await get_dataset_rows(test_db_session, "raster_0123456789abcdef", column_info=[])
+
+    result = await test_db_session.execute(text("SELECT 1"))
+    assert result.scalar_one() == 1
+
+
+@pytest.mark.parametrize(
+    "code",
+    ["57014", "08006", "40001"],
+    ids=["statement-timeout", "connection-failure", "serialization-failure"],
+)
+async def test_operational_failure_propagates(
+    test_db_session, monkeypatch, code
+) -> None:
+    """An operational failure reaches the caller rather than becoming `([], 0)`."""
+
+    async def _boom(*args, **kwargs):
+        raise _dbapi_error(code)
+
+    monkeypatch.setattr(test_db_session, "execute", _boom)
+
+    with pytest.raises(DBAPIError):
+        await get_dataset_rows(test_db_session, "some_table", column_info=[])
+
+
+async def test_permission_failure_propagates(test_db_session, monkeypatch) -> None:
+    async def _boom(*args, **kwargs):
+        raise _dbapi_error("42501")
+
+    monkeypatch.setattr(test_db_session, "execute", _boom)
+
+    with pytest.raises(DBAPIError):
+        await get_dataset_rows(test_db_session, "some_table", column_info=[])

--- a/backend/tests/test_dataset_rows_db_errors.py
+++ b/backend/tests/test_dataset_rows_db_errors.py
@@ -60,10 +60,21 @@ def test_operational_errors_are_retryable(code) -> None:
         "42703",  # undefined_column
         "42501",  # insufficient_privilege
         "22P02",  # invalid_text_representation
+        "3F000",  # invalid_schema_name
     ],
 )
 def test_request_shaped_errors_are_not_retryable(code) -> None:
     assert is_operational(_dbapi_error(code)) is False
+
+
+def test_invalid_schema_name_is_not_a_benign_absent_table() -> None:
+    """fix(#435 codex r1): 3F000 must never degrade to a 200 empty page.
+
+    Postgres raises it from DDL paths, where it means the schema is gone. A SELECT
+    against a missing schema reports 42P01 instead, so 3F000 never described the
+    raster/VRT case this fallback exists for.
+    """
+    assert "3F000" not in TABLE_ABSENT
 
 
 def test_sqlstate_sets_do_not_overlap() -> None:
@@ -120,3 +131,34 @@ async def test_permission_failure_propagates(test_db_session, monkeypatch) -> No
 
     with pytest.raises(DBAPIError):
         await get_dataset_rows(test_db_session, "some_table", column_info=[])
+
+
+async def test_missing_data_schema_raises_instead_of_returning_empty(
+    test_db_session,
+) -> None:
+    """fix(#435 codex r1): an unprovisioned tenant schema is drift, not empty data.
+
+    Postgres answers a SELECT against a missing schema with 42P01, the same code a
+    raster dataset's synthetic table produces inside a schema that does exist. Without
+    a schema probe, a tenant whose `data_t_*` schema was never provisioned (or was
+    lost in a restore) reads as a dataset with zero rows.
+    """
+    import app.core.db.tenant_schema as tenant_schema
+
+    # `get_dataset_rows` resolves the schema through `tenant_data_schema()`. Point it
+    # at a schema that was never provisioned; the process is single_tenant here, so
+    # setting `current_tenant_var` alone would still resolve to "data".
+    real = tenant_schema.tenant_data_schema
+    tenant_schema.tenant_data_schema = lambda _tenant: "data_t_never_provisioned"
+    try:
+        with pytest.raises(DBAPIError):
+            await get_dataset_rows(test_db_session, "some_table", column_info=[])
+    finally:
+        tenant_schema.tenant_data_schema = real
+
+
+async def test_schema_exists_probe(test_db_session) -> None:
+    from app.core.db.tenant_schema import schema_exists
+
+    assert await schema_exists(test_db_session, "catalog") is True
+    assert await schema_exists(test_db_session, "data_t_definitely_missing") is False

--- a/backend/tests/test_export_temp_cleanup.py
+++ b/backend/tests/test_export_temp_cleanup.py
@@ -1,0 +1,96 @@
+"""fix(#435): a failed export must remove its own staging temp directory.
+
+Pre-fix, `export_dataset()` created `<staging>/exports/<uuid>/` before running
+ogr2ogr and attached cleanup only to a successful `FileResponse`. Every ogr2ogr
+failure, ZIP failure, or client disconnect leaked a directory until some later
+process startup swept it.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from app.processing.export.ogr import ExportError
+
+
+@pytest.fixture
+def staging_root(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    monkeypatch.setattr(
+        "app.processing.export.service.settings.upload_staging_dir", str(tmp_path)
+    )
+    return tmp_path
+
+
+async def test_ogr_failure_removes_temp_dir(
+    staging_root: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from app.processing.export import service
+
+    async def _boom(*args, **kwargs):
+        raise ExportError("ogr2ogr exited 1")
+
+    monkeypatch.setattr(service, "run_ogr2ogr_export", _boom)
+
+    with pytest.raises(ExportError):
+        await service.export_dataset("data_table", "My Dataset", "geojson")
+
+    assert list((staging_root / "exports").iterdir()) == []
+
+
+async def test_cancellation_removes_temp_dir(
+    staging_root: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A disconnecting client cancels the task; CancelledError is not an Exception."""
+    from app.processing.export import service
+
+    async def _cancelled(*args, **kwargs):
+        raise __import__("asyncio").CancelledError()
+
+    monkeypatch.setattr(service, "run_ogr2ogr_export", _cancelled)
+
+    import asyncio
+
+    with pytest.raises(asyncio.CancelledError):
+        await service.export_dataset("data_table", "My Dataset", "gpkg")
+
+    assert list((staging_root / "exports").iterdir()) == []
+
+
+async def test_zip_failure_removes_temp_dir(
+    staging_root: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from app.processing.export import service
+
+    async def _ok(*args, **kwargs):
+        return None
+
+    def _zip_boom(temp_dir: str, zip_path: str) -> None:
+        raise OSError("No space left on device")
+
+    monkeypatch.setattr(service, "run_ogr2ogr_export", _ok)
+    monkeypatch.setattr(service, "_zip_export_files", _zip_boom)
+
+    with pytest.raises(OSError):
+        await service.export_dataset("data_table", "My Dataset", "shp")
+
+    assert list((staging_root / "exports").iterdir()) == []
+
+
+async def test_successful_export_keeps_its_file(
+    staging_root: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The success path still hands a live path to the caller (no over-eager cleanup)."""
+    from app.processing.export import service
+
+    async def _write(table, output_path, driver, **kwargs):
+        Path(output_path).write_text("{}")
+
+    monkeypatch.setattr(service, "run_ogr2ogr_export", _write)
+
+    path, filename, media_type = await service.export_dataset(
+        "data_table", "My Dataset", "geojson"
+    )
+
+    assert Path(path).exists()
+    assert filename == "My_Dataset.geojson"
+    assert media_type

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -817,7 +817,12 @@ def test_decomposed_service_modules_stay_within_size_budgets() -> None:
         # queries (raster/missing-table guard). Cap 595 -> 620 (~3 LOC headroom).
         "backend/app/modules/catalog/datasets/domain/service_relationships.py": 620,
         "backend/app/modules/catalog/datasets/domain/service_metadata.py": 460,
-        "backend/app/modules/catalog/datasets/domain/service_query.py": 390,
+        # fix(#435 codex r1): +6 LOC in get_dataset_rows to probe schema existence
+        # before degrading a 42P01 to an empty page. Postgres reports a missing
+        # tenant data schema with the same code as a raster dataset's synthetic
+        # table, so the code alone cannot tell provisioning drift from normal
+        # emptiness. Cap 390 -> 396, no headroom.
+        "backend/app/modules/catalog/datasets/domain/service_query.py": 396,
         # Phase 276 CODE-02: chat_*.py sub-modules are all under the 350
         # default (largest is chat_actions.py at ~245 LOC). No explicit
         # per-file overrides needed; default applies.

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -868,84 +868,73 @@ def test_decomposed_service_modules_stay_within_size_budgets() -> None:
         )
 
 
+# fix(#435): each cap equals the file's current LOC, so these files can only shrink.
+# Every cap here used to carry 3-7% headroom, and each time a file grew into its cap
+# the cap was raised (five documented raises for tiles/router.py alone). That is how
+# "decomposition is queued" stayed true for a year while the routers grew past 2,000
+# lines.
+#
+# To add lines to a ratcheted file: remove lines from it, or decompose it into
+# sub-routers (per Phase 226 / Phase 238) and lower its cap in the same commit.
+# Lowering a cap is always fine. Raising one needs a written carve-out here.
+#
+# History of the previous caps, kept because it records why each file is large:
+#   maps/router.py    1610 → 1700 → 1800 → 1900. Phase 1047 bulk-delete, then PR #118
+#     builder polish took it to 2107; extracting _router_helpers.py brought it back.
+#     Splitting share/media/layers into sub-routers is the remaining work.
+#   search/router.py  1515 → 1600 → 1640 → 1700. OGC record metadata (#315), then the
+#     record_type/sort_by allowlist + to_filters() chokepoint (#317 A2).
+#   tiles/router.py   1500 → 1660 → 1850 → 1920 → 2050 → 2090. Raster meta TTLCache
+#     (1176 PERF-002), SET LOCAL ROLE binding (1209-03 DP-02), cloud fairness/metering
+#     seams (1213-06), the cold-tier seam (1214-04), terrainrgb nodata (#186), and
+#     empty-tile Cache-Control (#430 V-03). NOTE: `_check_cold_rehydrate` is pinned to
+#     this module by the overlay's 1214-05 static AST proof, so the tile_seams.py split
+#     must update the overlay in lockstep.
+_ROUTER_LOC_CAPS: dict[str, int] = {
+    "backend/app/modules/catalog/maps/router.py": 1884,
+    "backend/app/modules/catalog/search/router.py": 1671,
+    "backend/app/processing/tiles/router.py": 2077,
+}
+
+
+@pytest.mark.architecture
+def test_router_loc_caps_have_no_headroom() -> None:
+    """Every ratchet must equal its file's current LOC.
+
+    A cap above the current size is permission to grow. The audit found 13, 3, and 29
+    spare lines in the three largest routers — each one the seed of the next
+    "cap raised to N, decomposition queued" comment.
+
+    Shrinking a file fails this too. Lower the cap in the same commit.
+    """
+    drift: list[str] = []
+    for rel, cap in sorted(_ROUTER_LOC_CAPS.items()):
+        actual = len(_repo_style_path(rel).read_text().splitlines())
+        if actual != cap:
+            verb = "shrank below" if actual < cap else "exceeds"
+            drift.append(f"{rel}: {actual} lines {verb} its cap of {cap}")
+
+    if drift:
+        pytest.fail(
+            "Router LOC ratchets are out of sync with the files they track. Set each "
+            "cap to the file's current line count.\n" + "\n".join(drift)
+        )
+
+
 @pytest.mark.architecture
 def test_router_orchestrator_modules_stay_within_loc_cap() -> None:
     """Phase 276 CODE-01: router and orchestrator modules stay <= 1500 LOC.
 
     Catches regrowth of large API-edge modules toward the size cliff that
     triggered the Phase 226 / Phase 238 / Phase 252 decompositions.
-    Allowlist exists for currently-over-cap modules; values are HARD CAPS
-    (current LOC + small headroom), not waivers — the test still fails if
-    an allowlisted file grows past its listed cap.
+    Allowlisted modules are ratcheted at their current size (see _ROUTER_LOC_CAPS).
 
     Scope: ``backend/app/**/router.py`` (all module + standards routers).
     Decomposed service modules (``service_*.py``) are covered separately by
     ``test_decomposed_service_modules_stay_within_size_budgets``.
     """
     DEFAULT_CAP = 1500
-    # Allowlist values track each file's current LOC + ~5-7% headroom for
-    # routine line drift (rounded up to the nearest 50). Tighten back toward
-    # DEFAULT_CAP when natural decomposition opportunities arise; do NOT
-    # raise these caps to mask regrowth without a documented carve-out.
-    allowlist: dict[str, int] = {
-        # Phase 276 CODE-01 baseline at plan time:
-        #   maps/router.py    = 1610 LOC -> cap 1700 (+5.6% headroom)
-        #   search/router.py  = 1515 LOC -> cap 1600 (+5.6% headroom)
-        # Phase 1060 CTRL-01 close-gate carve-out (v1013, 2026-05-20):
-        #   maps/router.py grew to 1761 via Phase 1047 bulk-delete endpoint
-        #   (commits 76cd7642 + 52f04462) without triggering CI on the
-        #   subsequent v1010/v1011/v1012 closes — the v1013 close gate
-        #   surfaced it. Re-baselining at 1800 with ~2% headroom; decomposition
-        #   (split into facade + sub-routers per Phase 226/238 pattern) is
-        #   queued for v1014. HARD ceiling — do NOT raise past 1800 without
-        #   decomposing.
-        # Both are top decomposition candidates for a future phase; the cap
-        # is a HARD ceiling, not a waiver — growth past it still fails CI.
-        # PR #118 (v1024->v1033 builder catch-up): maps/router.py grew to 2107
-        # via builder-polish features. Post-merge follow-up extracted the
-        # 12-helper response-builder/access-check cluster into _router_helpers.py,
-        # bringing it to 1844. Cap re-baselined to 1900 (~3% headroom). Further
-        # reduction below the 1500 default requires splitting the share/media/
-        # layers endpoint groups into sub-routers (per Phase 226 / Phase 238) —
-        # queued. HARD ceiling — do NOT raise past 1900 without decomposing.
-        "backend/app/modules/catalog/maps/router.py": 1900,
-        # Smoke-check backlog (#315): raster coverage list metadata (itemType +
-        # rel=tiles, omit rel=items), stable numberMatched + collection count,
-        # and the filter-lang 400. Smoke-residual follow-up (#315): +public_app_url
-        # fetches in 3 OGC-record handlers for the raster_tiles app-origin fix.
-        # Hygiene follow-up (#317, A2): +~25 LOC for the record_type/sort_by
-        # allowlist constants + the to_filters() validation chokepoint.
-        # Cap 1640 -> 1700 (now 1671 LOC, ~1.7% headroom).
-        "backend/app/modules/catalog/search/router.py": 1700,
-        # Phase 1176 PERF-002: +~60 lines for the raster tile auth/metadata
-        # TTLCache (_RasterMeta + _resolve_raster_meta), mirroring the vector
-        # tile meta cache so raster tiles aren't asymmetric.
-        # Phase 1209-03 DP-02: +~51 lines for per-request SET LOCAL ROLE binding,
-        # schema-qualified tile queries, and tenant-filtered resolver. Cap raised
-        # to 1660 (29 LOC headroom).
-        # Phase 1213-06 FAIR-01/METER-03: +~128 lines for _get_cloud_fairness()
-        # lazy importer, _emit_tile_usage_event() billing-import-free seam helper,
-        # per-tenant semaphore acquisition around the tile pool, and Cache-Control
-        # override for cloud CDN SLO. All cloud-conditional (has_extension gate);
-        # OSS byte-identical. Cap raised to 1850 (+62 headroom).
-        # Phase 1214-04 COLD-02/03: +~70 lines for the _check_cold_rehydrate()
-        # billing-import-free cold-tier seam (deferred geolens_cloud import behind
-        # is_multi_tenant()/has_extension('cloud') guards; never 500s a tile —
-        # T-1214-17). Cloud-conditional; OSS byte-identical. The seam helper is
-        # pinned to THIS module by the overlay's 1214-05 static AST proof
-        # (ast.AsyncFunctionDef _check_cold_rehydrate must resolve in the core
-        # router source), so it cannot be relocated without cross-repo
-        # coordination. Cap raised to 1920 (+26 headroom). HARD ceiling — the
-        # cold/fairness/metering seams must be decomposed into a tile_seams.py
-        # sub-module (updating the overlay AST proof in lockstep) before raising
-        # further.
-        # v1043 #186: terrainrgb nodata-mask handling added ~23 LOC (now 1943);
-        # cap raised to 2050 (+5.5% headroom) pending the tile_seams.py split.
-        # fix(#430 V-03): empty-tile (204) responses now carry Cache-Control via a new
-        # _empty_tile_headers helper applied at 3 sites (~21 LOC, now 2071); cap
-        # raised 2050 → 2090 (~19 headroom), still pending the tile_seams.py split.
-        "backend/app/processing/tiles/router.py": 2090,
-    }
+    allowlist = _ROUTER_LOC_CAPS
 
     violations: list[str] = []
     for path in sorted((BACKEND_ROOT / "app").rglob("router.py")):
@@ -1174,72 +1163,119 @@ def test_billing_dispatch_uses_hardcoded_timeout() -> None:
         )
 
 
+# fix(#435): burn-down list of function-local `app.modules.catalog` imports inside
+# `backend/app/processing/`. Every entry is a place where processing reaches past
+# ProcessingPort, so an Enterprise/Cloud overlay cannot observe or intercept the call.
+#
+# The list may SHRINK, never grow. Adding an entry means adding a new port bypass —
+# route the behavior through `app.core.processing_port` instead. See
+# `_authorize_metadata_dataset` in `processing/ai/router.py`, migrated to the port's
+# existing `get_dataset` / `check_dataset_access` methods.
+_PROCESSING_CATALOG_IMPORT_BURNDOWN: dict[str, set[str]] = {
+    "ai/chat_validation.py": {"app.modules.catalog.maps.filter_grammar"},
+    "ai/router.py": {
+        # Private cross-domain helpers. Needs behavior-level ProcessingPort methods
+        # (check_map_read_access, can_edit_map) before this edge can go.
+        "app.modules.catalog.maps._router_helpers",
+        "app.modules.catalog.maps.models",
+    },
+    "ai/service.py": {
+        "app.modules.catalog.datasets.domain.models",
+        "app.modules.catalog.search.service",
+    },
+    "export/router.py": {
+        "app.modules.catalog.authorization",
+        "app.modules.catalog.features.service",
+    },
+    "ingest/manifest_service.py": {
+        "app.modules.catalog.authorization",
+        # Rule 2 (AGENTS.md): SSRF redirect revalidation must use make_safe_client.
+        "app.modules.catalog.sources.security",
+    },
+    "ingest/manifest_sources.py": {"app.modules.catalog.sources"},
+    "ingest/router.py": {
+        "app.modules.catalog.authorization",
+        "app.modules.catalog.datasets.domain.service",
+        "app.modules.catalog.sources.security",
+    },
+    "ingest/service.py": {
+        "app.modules.catalog.authorization",
+        "app.modules.catalog.datasets.domain.service",
+    },
+    "ingest/tasks_reupload.py": {"app.modules.catalog.sources.security"},
+    "ingest/tasks_vector.py": {
+        "app.modules.catalog.sources.adapters.arcgis",
+        "app.modules.catalog.sources.security",
+    },
+    "tiles/router.py": {"app.modules.catalog.datasets.domain.models"},
+}
+
+_PROCESSING_DIR = REPO_ROOT / "backend" / "app" / "processing"
+
+
+def _catalog_import_edges() -> dict[str, set[str]]:
+    """Every `app.modules.catalog.*` import under processing/, at ANY scope."""
+    import ast
+
+    edges: dict[str, set[str]] = {}
+    for path in sorted(_PROCESSING_DIR.rglob("*.py")):
+        for node in ast.walk(ast.parse(path.read_text(encoding="utf-8"))):
+            if isinstance(node, ast.ImportFrom) and node.module:
+                modules = [node.module]
+            elif isinstance(node, ast.Import):
+                modules = [alias.name for alias in node.names]
+            else:
+                continue
+            for module in modules:
+                if module.startswith("app.modules.catalog"):
+                    key = str(path.relative_to(_PROCESSING_DIR))
+                    edges.setdefault(key, set()).add(module)
+    return edges
+
+
 @pytest.mark.architecture
-@pytest.mark.skipif(not _GIT_METADATA_AVAILABLE, reason=_GIT_METADATA_REASON)
-@pytest.mark.skipif(
-    not _PATHSPEC_MAGIC_AVAILABLE,
-    reason=(
-        "git < 2.13 lacks `:!` pathspec exclusion; cannot enforce "
-        "Phase 225 PROCESS-04 invariant via grep-based guard"
-    ),
-)
 def test_no_processing_imports_catalog() -> None:
-    """Phase 225 PROCESS-02/04: backend/app/processing/ must not have module-level imports from app.modules.catalog.*.
+    """Phase 225 PROCESS-02/04: processing/ reaches catalog only through ProcessingPort.
 
-    All catalog access must go through ProcessingPort (app.core.processing_port).
-    Strict zero-hit for module-level (top-level, unindented) imports — no allowlist
-    for processing/* (D-23).
-
-    Excluded paths:
-      - backend/tests/ — test fixtures construct catalog ORM objects directly,
-        structurally satisfying the Protocols (the scan target backend/app/processing/
-        is already disjoint from backend/tests/, so no explicit pathspec exclusion
-        is needed).
-
-    Scope: this guard catches module-level imports (lines starting at column 0
-    with ``from app.modules.catalog`` or ``import app.modules.catalog``).
-    Function-scope lazy imports (indented, e.g. inside async def bodies in
-    tiles/router.py, ai/service.py, ai/router.py, ai/metadata_service.py,
-    export/router.py) are a separate migration target and are out of scope for
-    this guard. The guard prevents any NEW module-level catalog import edges
-    from being introduced.
-
-    The pattern ``^(from|import) app.modules.catalog`` (literal space, no backslash-s
-    metachar) is used because git grep's POSIX ERE does not recognize backslash-s as a
-    whitespace class — the POSIX-compatible form would require ``[[:space:]]``, but
-    a literal space is equivalent for well-formatted Python import statements and
-    matches the intent of the guard.
-
-    Maps to Phase 225 ROADMAP SC#2 / SC#3. Inlines former Phase 999.11
-    (added in same phase as the inversion — guard before inversion fails CI).
+    fix(#435): this guard was a `git grep` for imports starting at column 0, so moving
+    an import inside a function body satisfied it while still bypassing the overlay
+    seam. An AST scan found 30 such function-local imports across 11 files, one
+    reaching into private router helpers and another bypassing the port for dataset
+    authorization. The guard now walks every scope, and the surviving edges are an
+    explicit burn-down list rather than an invisible exemption.
     """
-    result = subprocess.run(
-        [
-            "git",
-            "grep",
-            "-n",
-            "-E",
-            r"^(from|import) app\.modules\.catalog",
-            "--",
-            "backend/app/processing/",
-        ],
-        cwd=REPO_ROOT,
-        capture_output=True,
-        text=True,
-        check=False,
-    )
+    offenders: list[str] = []
+    for file, modules in sorted(_catalog_import_edges().items()):
+        allowed = _PROCESSING_CATALOG_IMPORT_BURNDOWN.get(file, set())
+        for module in sorted(modules - allowed):
+            offenders.append(f"  backend/app/processing/{file}: {module}")
 
-    if result.returncode == 0:
+    if offenders:
         pytest.fail(
             "Phase 225 PROCESS-02/04 invariant violated: backend/app/processing/ "
-            "contains a module-level import from app.modules.catalog.*. All catalog "
-            "access must go through ProcessingPort (app.core.processing_port). "
-            f"Offending lines:\n{result.stdout}"
+            "imports app.modules.catalog.* outside the burn-down allowlist. Route the "
+            "behavior through ProcessingPort (app.core.processing_port) instead of "
+            "adding an entry to _PROCESSING_CATALOG_IMPORT_BURNDOWN.\n"
+            + "\n".join(offenders)
         )
-    if result.returncode != 1:
+
+
+@pytest.mark.architecture
+def test_processing_catalog_import_allowlist_is_current() -> None:
+    """The burn-down list must shrink as edges are migrated — no stale entries.
+
+    A stale entry is a silent licence to reintroduce the bypass later.
+    """
+    edges = _catalog_import_edges()
+    stale: list[str] = []
+    for file, modules in sorted(_PROCESSING_CATALOG_IMPORT_BURNDOWN.items()):
+        for module in sorted(modules - edges.get(file, set())):
+            stale.append(f"  {file}: {module}")
+
+    if stale:
         pytest.fail(
-            f"git grep failed unexpectedly: rc={result.returncode}\n"
-            f"stderr: {result.stderr}"
+            "_PROCESSING_CATALOG_IMPORT_BURNDOWN lists edges that no longer exist. "
+            "Delete them — the list only shrinks.\n" + "\n".join(stale)
         )
 
 
@@ -1692,4 +1728,111 @@ def test_no_unjustified_broad_except_sites() -> None:
             "<reason>`) on the SAME line as the `except`, OR tighten the "
             "catch to a specific exception class.\n"
             "Offending lines:\n" + "\n".join(violations)
+        )
+
+
+# fix(#435): `platform/` is the shared layer beneath `modules/`, but four files import
+# upward into product domains at module scope. Each edge means a product-layer refactor
+# can break platform imports at runtime, so they are enumerated rather than tolerated
+# silently. The list may SHRINK, never grow.
+#
+# Deferred (function-local) imports are out of scope: they are the established D-17
+# discipline for breaking these cycles, and `platform/extensions/defaults.py` is built
+# on them by design.
+_PLATFORM_MODULE_IMPORT_BURNDOWN: dict[str, set[str]] = {
+    # Bootstrap adapters: FastAPI dependency callables must be imported to be used as
+    # route dependencies. Resolvable by moving these routers under modules/.
+    "config_ops/router.py": {"app.modules.auth.dependencies"},
+    "jobs/router.py": {"app.modules.auth.dependencies"},
+    # Config import/export validates product schemas. Resolvable by moving config_ops
+    # under modules/settings/, or by passing validated DTOs across a settings port.
+    "config_ops/service.py": {
+        "app.modules.auth.oauth.schemas",
+        "app.modules.auth.permissions",
+        "app.modules.settings.schemas",
+    },
+    # The SQL sandbox enforces catalog visibility. Resolvable via CatalogPort.
+    "sandbox/validator.py": {
+        "app.modules.catalog.authorization",
+        "app.modules.catalog.datasets.domain.models",
+    },
+}
+
+_PLATFORM_DIR = REPO_ROOT / "backend" / "app" / "platform"
+
+
+def _platform_module_level_edges() -> dict[str, set[str]]:
+    """Module-level (column 0) `app.modules.*` imports under platform/."""
+    import ast
+
+    edges: dict[str, set[str]] = {}
+    for path in sorted(_PLATFORM_DIR.rglob("*.py")):
+        for node in ast.walk(ast.parse(path.read_text(encoding="utf-8"))):
+            if isinstance(node, ast.ImportFrom) and node.module:
+                modules = [node.module]
+            elif isinstance(node, ast.Import):
+                modules = [alias.name for alias in node.names]
+            else:
+                continue
+            if node.col_offset != 0:
+                continue
+            for module in modules:
+                if module.startswith("app.modules"):
+                    key = str(path.relative_to(_PLATFORM_DIR))
+                    edges.setdefault(key, set()).add(module)
+    return edges
+
+
+@pytest.mark.architecture
+def test_platform_does_not_import_modules() -> None:
+    """The shared platform layer must not depend upward on product domains.
+
+    fix(#435): `platform/config_ops/service.py` reached into `modules.settings.router`
+    for the private `_ENTERPRISE_ONLY_TABS`. That constant now lives beside the
+    persistent-config registry that defines `PersistentConfig.tab`, so edition policy
+    has a stable owner and decomposing the settings router cannot break config import.
+    """
+    offenders: list[str] = []
+    for file, modules in sorted(_platform_module_level_edges().items()):
+        allowed = _PLATFORM_MODULE_IMPORT_BURNDOWN.get(file, set())
+        for module in sorted(modules - allowed):
+            offenders.append(f"  backend/app/platform/{file}: {module}")
+
+    if offenders:
+        pytest.fail(
+            "platform/ imports upward into app.modules.* at module scope. Depend on a "
+            "core port or DTO, or defer the import (D-17), rather than adding an entry "
+            "to _PLATFORM_MODULE_IMPORT_BURNDOWN.\n" + "\n".join(offenders)
+        )
+
+
+@pytest.mark.architecture
+def test_platform_does_not_import_private_module_names() -> None:
+    """No `from app.modules.… import _private` anywhere in platform/, at any scope.
+
+    A leading underscore says the name can move or vanish without notice.
+    `platform/config_ops` imported the settings router's `_ENTERPRISE_ONLY_TABS`, so any
+    refactor of that router became a runtime break here.
+    """
+    import ast
+
+    offenders: list[str] = []
+    for path in sorted(_PLATFORM_DIR.rglob("*.py")):
+        for node in ast.walk(ast.parse(path.read_text(encoding="utf-8"))):
+            if not isinstance(node, ast.ImportFrom) or not node.module:
+                continue
+            if not node.module.startswith("app.modules"):
+                continue
+            for alias in node.names:
+                if alias.name.startswith("_"):
+                    rel = path.relative_to(_PLATFORM_DIR)
+                    offenders.append(
+                        f"  backend/app/platform/{rel}: {node.module}.{alias.name}"
+                    )
+
+    if offenders:
+        pytest.fail(
+            "platform/ imports a private name from a product module. Promote it to a "
+            "public home (core registry, port, or DTO) instead.\n"
+            + "\n".join(offenders)
         )

--- a/backend/tests/test_phase_279_settings_admin.py
+++ b/backend/tests/test_phase_279_settings_admin.py
@@ -2,7 +2,7 @@
 
 ADMIN-03 (M-03): Lock the single-source-of-truth contract for enterprise-only
 Settings tab keys. Without this gate, future drift between backend
-``_ENTERPRISE_ONLY_TABS`` and frontend ``AdminSidebar`` enterpriseOnly flags
+``ENTERPRISE_ONLY_TABS`` and frontend ``AdminSidebar`` enterpriseOnly flags
 can re-emerge silently.
 
 ADMIN-04 (M-04): Lock the unified audit-export format dispatcher. Without
@@ -17,7 +17,7 @@ be unreachable (e.g. lint-only CI lanes).
 from pathlib import Path
 
 from app.modules.audit.router import FORMAT_HANDLERS
-from app.modules.settings.router import _ENTERPRISE_ONLY_TABS
+from app.core.persistent_config import ENTERPRISE_ONLY_TABS
 from app.modules.settings.schemas import EnterpriseTabsResponse
 
 
@@ -34,19 +34,19 @@ def test_enterprise_only_tabs_constant_includes_branding_and_appearance():
     settings because `_require_enterprise_for_key` only blocked branding.
     Phase 279 ADMIN-03 reconciles them and this test gates against regression.
     """
-    assert "branding" in _ENTERPRISE_ONLY_TABS
-    assert "appearance" in _ENTERPRISE_ONLY_TABS
+    assert "branding" in ENTERPRISE_ONLY_TABS
+    assert "appearance" in ENTERPRISE_ONLY_TABS
     # The set must remain exactly these two as of v13.13. Adding tabs is a
     # deliberate boundary change and should be paired with an update to this
     # assertion AND a corresponding update to the frontend FALLBACK constant
     # in AdminSidebar.tsx (server-driven hook is the canonical source, but
     # the fallback applies during boot/network failures).
-    assert _ENTERPRISE_ONLY_TABS == frozenset({"branding", "appearance"})
+    assert ENTERPRISE_ONLY_TABS == frozenset({"branding", "appearance"})
 
 
 def test_enterprise_tabs_response_schema_serializes_sorted():
     """The endpoint returns sorted(set) for stable JSON; validate the response model."""
-    resp = EnterpriseTabsResponse(tabs=sorted(_ENTERPRISE_ONLY_TABS))
+    resp = EnterpriseTabsResponse(tabs=sorted(ENTERPRISE_ONLY_TABS))
     assert resp.tabs == ["appearance", "branding"]
 
 

--- a/backend/tests/test_quota_bulk_usage.py
+++ b/backend/tests/test_quota_bulk_usage.py
@@ -1,0 +1,85 @@
+"""fix(#435): quota usage for a page of users costs one aggregate, not one per user.
+
+The admin user list labelled its loading "batch" and then called
+`get_user_quota_usage()` once per row, at up to 200 rows per page. Each call ran its
+own aggregate across records, datasets, and assets, plus two persistent-config reads.
+"""
+
+import uuid
+
+import pytest
+from sqlalchemy import event
+
+from app.modules.quota.service import get_user_quota_usage, get_user_quota_usage_bulk
+
+
+class _QueryCounter:
+    """Count SQL statements issued on a session's sync engine."""
+
+    def __init__(self) -> None:
+        self.count = 0
+
+    def __call__(self, *args, **kwargs) -> None:
+        self.count += 1
+
+
+async def _count_queries(session, coro_factory):
+    counter = _QueryCounter()
+    sync_engine = session.bind.sync_engine
+    event.listen(sync_engine, "before_cursor_execute", counter)
+    try:
+        result = await coro_factory()
+    finally:
+        event.remove(sync_engine, "before_cursor_execute", counter)
+    return result, counter.count
+
+
+async def test_bulk_usage_matches_single_user_usage(test_db_session) -> None:
+    """The batched aggregate must agree with the per-user one it replaces."""
+    from app.modules.auth.models import User
+
+    user = User(username=f"quota-{uuid.uuid4().hex[:8]}", password_hash="x")
+    test_db_session.add(user)
+    await test_db_session.flush()
+
+    single = await get_user_quota_usage(test_db_session, user.id)
+    bulk = await get_user_quota_usage_bulk(test_db_session, [user.id])
+
+    assert bulk[user.id] == single
+
+
+async def test_bulk_usage_zeroes_users_with_no_records(test_db_session) -> None:
+    """A user absent from the aggregate still gets a row, so callers can index it."""
+    missing = uuid.uuid4()
+
+    usage = await get_user_quota_usage_bulk(test_db_session, [missing])
+
+    assert usage[missing].bytes_used == 0
+    assert usage[missing].dataset_count == 0
+
+
+async def test_bulk_usage_of_empty_list_is_free(test_db_session) -> None:
+    assert await get_user_quota_usage_bulk(test_db_session, []) == {}
+
+
+@pytest.mark.parametrize("user_count", [1, 25])
+async def test_bulk_usage_query_count_is_constant(test_db_session, user_count) -> None:
+    """Query count must not grow with the page size — the whole point of the fix."""
+    from app.modules.auth.models import User
+
+    users = [
+        User(username=f"quota-{uuid.uuid4().hex[:8]}", password_hash="x")
+        for _ in range(user_count)
+    ]
+    test_db_session.add_all(users)
+    await test_db_session.flush()
+    user_ids = [u.id for u in users]
+
+    _, queries = await _count_queries(
+        test_db_session, lambda: get_user_quota_usage_bulk(test_db_session, user_ids)
+    )
+
+    # One aggregate + at most two persistent-config reads for the caps.
+    assert queries <= 3, (
+        f"{queries} queries for {user_count} users — the aggregate is running per user"
+    )

--- a/backend/tests/test_saml_column_drift_gate.py
+++ b/backend/tests/test_saml_column_drift_gate.py
@@ -1,0 +1,113 @@
+"""fix(#435): `alembic check` must see drift on the four core-owned SAML columns.
+
+`env.py`'s `include_object` hid `idp_entity_id`, `idp_sso_url`, `idp_certificate`,
+and `sp_entity_id` from autogenerate whenever no enterprise overlay was installed.
+That was right when only the overlay's `e002_add_saml_columns` created them. Core
+migration `0008_oauth_saml_columns` now creates all four on every OSS database, so
+the exclusion had turned into a blind spot: dropping one still passed the gate.
+
+The positive case (`alembic check` clean at head, columns present and included) is
+covered by `TestAlembicCheckNoDrift` in `test_email_verification_migration.py`.
+"""
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+import sqlalchemy
+from sqlalchemy import text
+
+_BACKEND_DIR = Path(__file__).resolve().parent.parent
+
+SAML_COLUMNS = ("idp_entity_id", "idp_sso_url", "idp_certificate", "sp_entity_id")
+
+
+def _enterprise_migrations_present() -> bool:
+    from alembic.config import Config
+
+    cfg = Config(str(_BACKEND_DIR / "alembic.ini"))
+    return " " in (cfg.get_main_option("version_locations") or "").strip()
+
+
+_SKIP_UNDER_OVERLAY = pytest.mark.skipif(
+    _enterprise_migrations_present(),
+    reason="OSS migration drift gate; multi-head under the enterprise overlay",
+)
+
+
+def _run_alembic(*args: str) -> subprocess.CompletedProcess:
+    from app.core.config import settings
+
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(_BACKEND_DIR)
+    env["POSTGRES_DB"] = settings.postgres_db_test
+    return subprocess.run(
+        [sys.executable, "-m", "alembic", *args],
+        cwd=_BACKEND_DIR,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _autocommit_engine():
+    from app.core.config import settings
+
+    return sqlalchemy.create_engine(
+        settings.test_database_url_sync, isolation_level="AUTOCOMMIT"
+    )
+
+
+def test_env_py_does_not_filter_saml_columns() -> None:
+    """Fast guard: no SAML column may be named in `env.py`'s object filter.
+
+    `env.py` runs migrations on import, so read its source rather than importing it.
+    """
+    source = (_BACKEND_DIR / "alembic" / "env.py").read_text()
+
+    for column in SAML_COLUMNS:
+        assert column not in source, (
+            f"{column} is named in alembic/env.py — the OSS-only SAML exclusion is "
+            "back, and the drift gate is blind to a core-owned column again"
+        )
+
+
+@_SKIP_UNDER_OVERLAY
+def test_alembic_check_fails_when_a_saml_column_is_dropped() -> None:
+    """Drop one column, prove the gate fails, then put it back.
+
+    Pre-fix this test would have passed `alembic check` with the column missing.
+    """
+    _run_alembic("upgrade", "head")
+
+    engine = _autocommit_engine()
+    try:
+        with engine.connect() as conn:
+            conn.execute(
+                text("ALTER TABLE catalog.oauth_providers DROP COLUMN idp_sso_url")
+            )
+        try:
+            result = _run_alembic("check")
+            assert result.returncode != 0, (
+                "alembic check passed with catalog.oauth_providers.idp_sso_url "
+                "dropped — the drift gate is blind to core-owned SAML columns.\n"
+                f"stdout: {result.stdout}\nstderr: {result.stderr}"
+            )
+            assert "idp_sso_url" in (result.stdout + result.stderr)
+        finally:
+            with engine.connect() as conn:
+                conn.execute(
+                    text(
+                        "ALTER TABLE catalog.oauth_providers "
+                        "ADD COLUMN IF NOT EXISTS idp_sso_url VARCHAR(512)"
+                    )
+                )
+    finally:
+        engine.dispose()
+
+    restored = _run_alembic("check")
+    assert restored.returncode == 0, (
+        f"drift gate still failing after restore:\n{restored.stdout}{restored.stderr}"
+    )

--- a/backend/tests/test_storage_put_bounded.py
+++ b/backend/tests/test_storage_put_bounded.py
@@ -178,3 +178,59 @@ async def test_cancelled_put_of_bytes_still_cancels(tmp_path: Path) -> None:
     task.cancel()
     with pytest.raises(asyncio.CancelledError):
         await task
+
+
+async def test_repeated_cancellation_still_drains_the_copy_thread(
+    tmp_path: Path,
+) -> None:
+    """fix(#435 codex r3): a second cancel during the drain must not abandon the thread.
+
+    `asyncio.wait`/`asyncio.shield` are themselves cancellable, so a shutdown or outer
+    timeout that cancels twice could return before `copyfileobj` releases the caller's
+    handle. The drain absorbs repeated cancellations until the copy actually finishes.
+    """
+    provider = LocalStorageProvider(str(tmp_path))
+
+    class _SlowReader:
+        def __init__(self) -> None:
+            self.chunks = 6
+            self.hit_eof = False
+            self.closed = False
+            self.read_after_close = False
+
+        def read(self, size: int = -1) -> bytes:
+            if self.closed:
+                self.read_after_close = True
+                raise ValueError("read of closed file")
+            if self.chunks == 0:
+                self.hit_eof = True
+                return b""
+            self.chunks -= 1
+            time.sleep(0.02)
+            return b"\x00" * 1024
+
+        def close(self) -> None:
+            self.closed = True
+
+    reader = _SlowReader()
+    task = asyncio.create_task(provider.put("hammered.bin", reader))
+    await asyncio.sleep(0.03)  # let the copy thread get going
+
+    # Hammer cancel() while the thread is still reading. A single-cancel drain would
+    # be interrupted by one of these and return before the thread finishes.
+    for _ in range(30):
+        task.cancel()
+        await asyncio.sleep(0.005)
+        if task.done():
+            break
+
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert reader.hit_eof, (
+        "put() returned mid-copy under repeated cancellation; the thread was still "
+        "reading the caller's handle"
+    )
+    reader.close()  # the caller's `with open(...)` block closes the handle next
+    await asyncio.sleep(0.05)
+    assert not reader.read_after_close

--- a/backend/tests/test_storage_put_bounded.py
+++ b/backend/tests/test_storage_put_bounded.py
@@ -119,3 +119,62 @@ async def test_put_rejects_traversal_before_touching_the_filesystem(
 
     with pytest.raises(ValueError):
         await provider.put("../escape.bin", b"x")
+
+
+async def test_cancelled_put_waits_for_the_copy_thread(tmp_path: Path) -> None:
+    """fix(#435 codex r2): cancelling a put must not leave a thread reading `data`.
+
+    `asyncio.to_thread` cannot cancel a running thread. Once `put()` reads from the
+    caller's handle instead of a `bytes` snapshot, an early return would let the
+    caller's `with open(...)` block close the file while `copyfileobj` is mid-read.
+    """
+    provider = LocalStorageProvider(str(tmp_path))
+
+    class _SlowReader:
+        def __init__(self) -> None:
+            self.chunks = 4
+            self.hit_eof = False
+            self.closed = False
+            self.read_after_close = False
+
+        def read(self, size: int = -1) -> bytes:
+            if self.closed:
+                self.read_after_close = True
+                raise ValueError("read of closed file")
+            if self.chunks == 0:
+                self.hit_eof = True
+                return b""
+            self.chunks -= 1
+            time.sleep(0.03)
+            return b"\x00" * 1024
+
+        def close(self) -> None:
+            self.closed = True
+
+    reader = _SlowReader()
+    task = asyncio.create_task(provider.put("cancelled.bin", reader))
+    await asyncio.sleep(0.04)  # let the copy thread get going
+
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    # The copy must have run to completion before `await task` returned. If it had
+    # not, the caller (below) would close the handle out from under the thread.
+    assert reader.hit_eof, (
+        "put() returned while the copy thread was still reading the caller's handle"
+    )
+
+    reader.close()  # what the caller's `with open(...)` block does next
+    await asyncio.sleep(0.1)
+    assert not reader.read_after_close
+
+
+async def test_cancelled_put_of_bytes_still_cancels(tmp_path: Path) -> None:
+    """The bytes path owns its data, so cancellation stays plain cancellation."""
+    provider = LocalStorageProvider(str(tmp_path))
+
+    task = asyncio.create_task(provider.put("b.bin", b"x" * 1024))
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task

--- a/backend/tests/test_storage_put_bounded.py
+++ b/backend/tests/test_storage_put_bounded.py
@@ -1,0 +1,121 @@
+"""fix(#435): large-file paths must stay bounded and must not block the event loop.
+
+`LocalStorageProvider.put()` called `data.read()` on the event-loop thread before its
+thread handoff, so a COG, VRT, or archived original passed as an open file handle was
+fully materialized as one `bytes` object — the raster, VRT, and original-file ingest
+paths all do exactly that, and those artifacts can exceed the 2 GB container limit.
+"""
+
+import asyncio
+import time
+from pathlib import Path
+
+import pytest
+
+from app.platform.storage.local import LocalStorageProvider
+
+
+class _RecordingReader:
+    """Minimal file-like object that records every `read(size)` it is asked for.
+
+    Deliberately not a `BufferedReader`: that would internally chunk a `read(-1)`
+    into buffer-sized `readinto` calls and hide the whole-stream slurp this test
+    exists to catch.
+    """
+
+    def __init__(self, total: int) -> None:
+        self._remaining = total
+        self.requested_sizes: list[int] = []
+
+    def read(self, size: int = -1) -> bytes:
+        self.requested_sizes.append(size)
+        if size is None or size < 0:
+            size = self._remaining
+        n = min(size, self._remaining)
+        self._remaining -= n
+        return b"\x00" * n
+
+
+async def test_put_streams_a_file_handle_in_bounded_chunks(tmp_path: Path) -> None:
+    provider = LocalStorageProvider(str(tmp_path))
+    total = 8 * 1024 * 1024  # 8 MiB
+    reader = _RecordingReader(total)
+
+    path = await provider.put("big.bin", reader)
+
+    assert Path(path).stat().st_size == total
+    assert -1 not in reader.requested_sizes, (
+        "put() called read() with no size — the whole payload was materialized as "
+        "one bytes object before the thread handoff"
+    )
+    assert max(reader.requested_sizes) <= 1024 * 1024
+    assert len(reader.requested_sizes) > 1
+
+
+async def test_put_still_accepts_raw_bytes(tmp_path: Path) -> None:
+    provider = LocalStorageProvider(str(tmp_path))
+
+    path = await provider.put("small.bin", b"hello")
+
+    assert Path(path).read_bytes() == b"hello"
+
+
+async def test_put_does_not_stall_the_event_loop(tmp_path: Path) -> None:
+    """A concurrent ticker keeps ticking while a blocking read is in flight."""
+    provider = LocalStorageProvider(str(tmp_path))
+    ticks = 0
+    stop = False
+
+    async def _ticker() -> None:
+        nonlocal ticks
+        while not stop:
+            ticks += 1
+            await asyncio.sleep(0.001)
+
+    class _SlowReader:
+        """Blocks inside read(), the way a real disk or network read would.
+
+        Both access patterns take ~100ms in total: five 20ms sized reads, or one
+        whole-stream `read(-1)`. Only the loop-thread variant starves the ticker.
+        """
+
+        def __init__(self) -> None:
+            self._chunks = 5
+
+        def read(self, size: int = -1) -> bytes:
+            if size is None or size < 0:
+                time.sleep(0.02 * self._chunks)
+                data = b"\x00" * (1024 * self._chunks)
+                self._chunks = 0
+                return data
+            if self._chunks == 0:
+                return b""
+            self._chunks -= 1
+            time.sleep(0.02)
+            return b"\x00" * 1024
+
+    task = asyncio.create_task(_ticker())
+    await asyncio.sleep(0.005)
+    ticks_before = ticks
+
+    await provider.put("slow.bin", _SlowReader())
+
+    stop = True
+    await task
+
+    # ~100ms of blocking work against a 1ms ticker. Off the loop thread this yields
+    # dozens of ticks; on it, essentially none. 10 is a wide margin against CI jitter.
+    assert ticks - ticks_before >= 10, (
+        f"the event loop ticked only {ticks - ticks_before} times during a ~100ms "
+        "blocking read — put() is still reading on the loop thread"
+    )
+
+
+async def test_put_rejects_traversal_before_touching_the_filesystem(
+    tmp_path: Path,
+) -> None:
+    """SEC-026 containment still runs before the thread handoff."""
+    provider = LocalStorageProvider(str(tmp_path))
+
+    with pytest.raises(ValueError):
+        await provider.put("../escape.bin", b"x")

--- a/backend/tests/test_vrt_catalog_175.py
+++ b/backend/tests/test_vrt_catalog_175.py
@@ -403,14 +403,29 @@ class TestVrtSourcesEndpoint:
         stub the per-member check to allow-all — otherwise can_access_dataset
         would run for real against a None user_roles and raise. The filtering
         behavior itself is covered by tests/test_vrt_source_authz_1172.py.
+
+        fix(#435): the endpoint now batch-loads member datasets in one query instead
+        of calling `get_dataset()` per row, so stub `_load_source_datasets` too. These
+        tests point a blanket `db.execute` mock at the raw-SQL result, which the
+        batch loader would otherwise read as "no member datasets exist".
         """
         ext = MagicMock()
         ext.can_access_dataset = AsyncMock(return_value=True)
+
+        async def _all_members_exist(_db, dataset_ids):
+            return {
+                ds_id: _make_mock_dataset("raster_dataset") for ds_id in dataset_ids
+            }
+
         with patch(
             "app.modules.catalog.datasets.api.router_vrt.get_permission_extension",
             return_value=ext,
         ):
-            yield
+            with patch(
+                "app.modules.catalog.datasets.api.router_vrt._load_source_datasets",
+                _all_members_exist,
+            ):
+                yield
 
     @pytest.mark.asyncio
     async def test_returns_ordered_source_list_for_vrt_dataset(self):

--- a/backend/tests/test_vrt_source_query_count.py
+++ b/backend/tests/test_vrt_source_query_count.py
@@ -1,0 +1,155 @@
+"""fix(#435): the VRT source endpoints must not issue one query per member row.
+
+`list_vrt_sources` and `get_vrt_status` used to call `get_dataset()` once per source
+link, so a 200-source VRT cost 200 round trips before it could return a page. The fix
+batches the member load into a single query (`_load_source_datasets`). This pins the
+query count so a future edit cannot silently reintroduce the N+1.
+
+The per-row `can_access_dataset()` call is intentionally NOT batched: only `restricted`
+targets reach the database from there, and a batch op on the permission seam would let
+a wrapping overlay's policy be skipped (SLOT-02). An admin caller short-circuits that
+check with no query, so the count below reflects the batched member load alone.
+"""
+
+import uuid
+
+from sqlalchemy import event, select, text
+
+from app.core.config import settings
+from app.modules.auth.models import User
+from app.modules.catalog.datasets.api.router_vrt import list_vrt_sources
+from app.modules.catalog.datasets.domain.models import Dataset, Record
+from app.processing.raster.models import RasterAsset
+
+
+async def _admin(session) -> User:
+    result = await session.execute(
+        select(User).where(User.username == settings.geolens_admin_username)
+    )
+    return result.scalar_one()
+
+
+async def _make_raster_source(session, *, created_by: uuid.UUID) -> uuid.UUID:
+    record = Record(
+        title=f"QC source {uuid.uuid4().hex[:6]}",
+        summary="raster source",
+        theme_category=["test"],
+        visibility="public",
+        record_status="published",
+        record_type="raster_dataset",
+        created_by=created_by,
+    )
+    session.add(record)
+    await session.flush()
+    dataset = Dataset(
+        record_id=record.id,
+        table_name=f"qc_src_{uuid.uuid4().hex[:8]}",
+        source_format="geotiff",
+        source_filename="s.tif",
+    )
+    session.add(dataset)
+    await session.flush()
+    session.add(
+        RasterAsset(
+            dataset_id=dataset.id,
+            asset_uri=f"rasters/{dataset.id}/s.cog.tif",
+            storage_backend="local",
+            status="ready",
+            epsg=4326,
+            band_count=1,
+            res_x=0.001,
+            res_y=0.001,
+        )
+    )
+    await session.flush()
+    return dataset.id
+
+
+async def _make_vrt_with_sources(
+    session, *, created_by: uuid.UUID, n: int
+) -> uuid.UUID:
+    record = Record(
+        title=f"QC VRT {uuid.uuid4().hex[:6]}",
+        summary="vrt",
+        theme_category=["test"],
+        visibility="public",
+        record_status="published",
+        record_type="vrt_dataset",
+        created_by=created_by,
+    )
+    session.add(record)
+    await session.flush()
+    vrt = Dataset(
+        record_id=record.id,
+        table_name=f"qc_vrt_{uuid.uuid4().hex[:8]}",
+        source_format=None,
+        source_filename=None,
+    )
+    session.add(vrt)
+    await session.flush()
+    session.add(
+        RasterAsset(
+            dataset_id=vrt.id,
+            asset_uri=f"rasters/{vrt.id}/v.vrt",
+            storage_backend="local",
+            status="ready",
+            vrt_type="mosaic",
+            resolution_strategy="finest",
+            epsg=4326,
+            band_count=1,
+        )
+    )
+    await session.flush()
+    for pos in range(n):
+        src = await _make_raster_source(session, created_by=created_by)
+        await session.execute(
+            text(
+                "INSERT INTO catalog.vrt_source_links"
+                "(vrt_dataset_id, source_dataset_id, position) "
+                "VALUES (:vrt, :src, :pos)"
+            ),
+            {"vrt": str(vrt.id), "src": str(src), "pos": pos},
+        )
+    await session.commit()
+    return vrt.id
+
+
+async def _count_list_vrt_sources_queries(
+    session, vrt_id: uuid.UUID, user
+) -> tuple[int, int]:
+    count = 0
+
+    def _tick(*args, **kwargs):
+        nonlocal count
+        count += 1
+
+    sync_engine = session.bind.sync_engine
+    event.listen(sync_engine, "before_cursor_execute", _tick)
+    try:
+        result = await list_vrt_sources(dataset_id=vrt_id, user=user, db=session)
+    finally:
+        event.remove(sync_engine, "before_cursor_execute", _tick)
+    return len(result.sources), count
+
+
+async def test_list_vrt_sources_query_count_is_flat(test_db_session) -> None:
+    """Query count must not grow with the number of VRT sources."""
+    admin = await _admin(test_db_session)
+
+    small = await _make_vrt_with_sources(test_db_session, created_by=admin.id, n=1)
+    large = await _make_vrt_with_sources(test_db_session, created_by=admin.id, n=8)
+
+    n_small, q_small = await _count_list_vrt_sources_queries(
+        test_db_session, small, admin
+    )
+    n_large, q_large = await _count_list_vrt_sources_queries(
+        test_db_session, large, admin
+    )
+
+    assert n_small == 1 and n_large == 8, "the endpoint must return every source"
+    # Pre-fix: q_large - q_small would be ~7 (one get_dataset per extra source).
+    # Batched: the delta is 0. Allow 1 for incidental variation, never O(n).
+    assert q_large - q_small <= 1, (
+        f"query count scales with source count: {q_small} for 1 source, "
+        f"{q_large} for 8 — the per-row get_dataset N+1 is back"
+    )

--- a/backend/tests/test_worker_exports_sweep.py
+++ b/backend/tests/test_worker_exports_sweep.py
@@ -1,4 +1,8 @@
-"""Regression test for ING-04 / P2-04: worker exports temp-dir sweep must skip entries younger than 1 hour."""
+"""Regression tests for the shared exports temp-dir sweep (ING-04 / P2-04, fix(#435)).
+
+The sweeper lives in ``app.core.runtime.staging`` so the API lifespan and the
+worker share one age-aware implementation; entries younger than 1 hour survive.
+"""
 
 import os
 import time
@@ -15,9 +19,9 @@ def test_sweep_deletes_only_old_entries(tmp_path: Path) -> None:
     sweep gates on `stat.st_mtime` and only deletes entries older
     than `EXPORTS_SWEEP_AGE_SECONDS = 3600`.
     """
-    from app.platform.jobs.worker import (
+    from app.core.runtime.staging import (
         EXPORTS_SWEEP_AGE_SECONDS,
-        _sweep_orphaned_exports,
+        sweep_orphaned_exports,
     )
 
     exports_dir = tmp_path / "exports"
@@ -39,7 +43,7 @@ def test_sweep_deletes_only_old_entries(tmp_path: Path) -> None:
         "rolling-deploy safety window"
     )
 
-    deleted, skipped = _sweep_orphaned_exports(exports_dir)
+    deleted, skipped = sweep_orphaned_exports(exports_dir)
 
     assert not old_file.exists(), "2-hour-old entry should have been swept"
     assert new_file.exists(), (
@@ -52,7 +56,7 @@ def test_sweep_deletes_only_old_entries(tmp_path: Path) -> None:
 
 def test_sweep_handles_subdirectories(tmp_path: Path) -> None:
     """Subdirectory entries older than threshold are removed recursively (shutil.rmtree)."""
-    from app.platform.jobs.worker import _sweep_orphaned_exports
+    from app.core.runtime.staging import sweep_orphaned_exports
 
     exports_dir = tmp_path / "exports"
     exports_dir.mkdir()
@@ -65,7 +69,7 @@ def test_sweep_handles_subdirectories(tmp_path: Path) -> None:
     # Set mtime on the directory itself
     os.utime(old_dir, (now - 2 * 3600, now - 2 * 3600))
 
-    deleted, skipped = _sweep_orphaned_exports(exports_dir)
+    deleted, skipped = sweep_orphaned_exports(exports_dir)
 
     assert not old_dir.exists(), "Old subdirectory should have been removed recursively"
     assert deleted == 1
@@ -74,7 +78,7 @@ def test_sweep_handles_subdirectories(tmp_path: Path) -> None:
 
 def test_sweep_skipped_recent_export_logs(tmp_path: Path) -> None:
     """The skip branch emits a structured `sweep_skipped_recent_export` log event."""
-    from app.platform.jobs.worker import _sweep_orphaned_exports
+    from app.core.runtime.staging import sweep_orphaned_exports
 
     exports_dir = tmp_path / "exports"
     exports_dir.mkdir()
@@ -85,7 +89,7 @@ def test_sweep_skipped_recent_export_logs(tmp_path: Path) -> None:
     os.utime(new_file, (now - 600, now - 600))  # 10 minutes old
 
     with structlog.testing.capture_logs() as captured:
-        deleted, skipped = _sweep_orphaned_exports(exports_dir)
+        deleted, skipped = sweep_orphaned_exports(exports_dir)
 
     assert deleted == 0
     assert skipped == 1
@@ -107,12 +111,12 @@ def test_sweep_skipped_recent_export_logs(tmp_path: Path) -> None:
 
 def test_sweep_empty_dir_noop(tmp_path: Path) -> None:
     """An empty exports directory yields no deletions, no skips, and no errors."""
-    from app.platform.jobs.worker import _sweep_orphaned_exports
+    from app.core.runtime.staging import sweep_orphaned_exports
 
     exports_dir = tmp_path / "exports"
     exports_dir.mkdir()
 
-    deleted, skipped = _sweep_orphaned_exports(exports_dir)
+    deleted, skipped = sweep_orphaned_exports(exports_dir)
 
     assert deleted == 0
     assert skipped == 0
@@ -120,13 +124,29 @@ def test_sweep_empty_dir_noop(tmp_path: Path) -> None:
 
 def test_sweep_missing_dir_is_noop(tmp_path: Path) -> None:
     """If the exports dir does not exist, sweep is a no-op (no FileNotFoundError)."""
-    from app.platform.jobs.worker import _sweep_orphaned_exports
+    from app.core.runtime.staging import sweep_orphaned_exports
 
     exports_dir = tmp_path / "exports"
     # Deliberately do NOT create exports_dir
     assert not exports_dir.exists()
 
-    deleted, skipped = _sweep_orphaned_exports(exports_dir)
+    deleted, skipped = sweep_orphaned_exports(exports_dir)
 
     assert deleted == 0
     assert skipped == 0
+
+
+def test_api_and_worker_share_one_sweeper() -> None:
+    """fix(#435): both startup paths bind the same age-aware sweeper.
+
+    The API lifespan used to delete every `exports/` entry unconditionally, which
+    truncated exports owned by a surviving sibling Uvicorn worker on the shared
+    staging volume. If someone reintroduces a bespoke cleanup loop, they will drop
+    this import and this test fails.
+    """
+    import app.api.main as api_main
+    import app.platform.jobs.worker as worker_main
+    from app.core.runtime import staging
+
+    assert api_main.sweep_orphaned_exports is staging.sweep_orphaned_exports
+    assert worker_main.sweep_orphaned_exports is staging.sweep_orphaned_exports

--- a/sdks/python/geolens/models/share_token_request.py
+++ b/sdks/python/geolens/models/share_token_request.py
@@ -20,7 +20,8 @@ T = TypeVar("T", bound="ShareTokenRequest")
 class ShareTokenRequest:
     """
     Attributes:
-        expires_at (datetime.datetime | None | Unset): Expiration timestamp. Null creates a non-expiring share link.
+        expires_at (datetime.datetime | None | Unset): Expiration timestamp; must carry a UTC offset. Null creates a
+            non-expiring share link. A custom expiration requires advanced sharing controls.
     """
 
     expires_at: datetime.datetime | None | Unset = UNSET

--- a/sdks/typescript/src/client/types.gen.ts
+++ b/sdks/typescript/src/client/types.gen.ts
@@ -7680,7 +7680,7 @@ export type ShareTokenRequest = {
     /**
      * Expires At
      *
-     * Expiration timestamp. Null creates a non-expiring share link.
+     * Expiration timestamp; must carry a UTC offset. Null creates a non-expiring share link. A custom expiration requires advanced sharing controls.
      */
     expires_at?: string | null;
 };


### PR DESCRIPTION
Closes #435. Addresses every finding in the 2026-07-09 backend audit: seven P1s and four P2s. Backend and generated SDKs only, no frontend files.

## P1

**Export cleanup across workers.** The API lifespan deleted every entry under `exports/` at startup. Production runs two Uvicorn workers over one staging volume, so a restarting worker could truncate an export a surviving sibling was still writing or streaming. The worker's age-aware sweeper moved to `core/runtime/staging.py` and both startup paths now call it. Separately, `export_dataset()` owns its temp directory until it hands a path back, and the route cleans up if the audit write or commit fails. `BaseException`, not `Exception`, because a client disconnect cancels the task.

**Test isolation.** `_test_db_lifecycle` called `pytest.skip()` from session-scoped autouse setup, which skipped every collected item. Running `pytest -q tests/test_layering.py tests/test_domain_enforcement.py` reported 48 skipped and 0 executed, so the architecture gates could report green while asserting nothing. An unreachable Postgres now records a reason, and a per-test fixture skips only tests that request a DB fixture. Same command today: 23 passed, 25 skipped.

**Share expiration edition gate.** `ShareTokenRequest` and both service entry points now reject a non-null `expires_at` in Community, matching `EmbedTokenCreate`. `None` stays valid, so Community keeps basic create and revoke and can still clear an expiration. The two route-handler checks are gone because they became unreachable. `test_community_accepts_share_expiration` asserted the bug, so it now asserts the fix.

**Port boundary.** The processing-to-catalog guard was a `git grep` for imports at column 0, so moving an import inside a function satisfied it while still bypassing the overlay seam. It is now an AST scan over every scope. The 30 surviving edges are an explicit burn-down list that may only shrink, and a second test fails on stale entries. `_authorize_metadata_dataset` in `processing/ai/router.py` moved onto `ProcessingPort.get_dataset` / `check_dataset_access`, which already existed, so that bypass cost the seam and bought nothing.

**Blocking and buffering.** `LocalStorageProvider.put()` called `data.read()` on the event-loop thread before its handoff, materializing a whole COG or archived original as one `bytes` object. It now streams in 1 MiB chunks inside the worker thread. Manifest downloads batch writes through a 4 MiB buffer and hand them to a thread. Shapefile export zips in a thread. Both storage regression tests fail against the old implementation, which I checked.

**Database failures.** `get_dataset_rows()` caught `Exception` and returned an empty page, so connection loss, statement timeouts, and permission failures all rendered as a valid dataset with zero rows. It now degrades only on absent-table SQLSTATEs and rolls back the aborted transaction. Everything else propagates to a new central handler that returns 503 for operational SQLSTATE classes (08, 40, 53, 57, 58) and re-raises the rest, so an `IntegrityError` keeps its existing 500 rather than claiming the database is unavailable.

Worth knowing: an absent table is not only corruption. Raster and VRT datasets carry a synthetic `table_name` with no PostGIS table behind them, and the rows endpoint is generic across dataset types. That path still returns an empty page, deliberately.

**Alembic drift gate.** `env.py` hid the four `oauth_providers` SAML columns from autogenerate on OSS. That was right when only the enterprise overlay created them. Core migration `0008` now creates them unconditionally, so the filter had become a blind spot: dropping a column still passed `alembic check`. Filter removed, ownership comments in `env.py`, `0008`, and `oauth/models.py` corrected. A new negative test drops `idp_sso_url`, proves `alembic check` fails, and restores it. `make alembic-check` is clean.

## P2

**N+1 queries.** Admin user listing ran one three-table aggregate per user at up to 200 users per page, under a comment that called it batched. `get_user_quota_usage_bulk()` does it in one grouped aggregate plus one cap read, with a query-count test at page size. Both VRT source endpoints called `get_dataset()` per member row and now batch-load in one query.

I did not batch the per-row `can_access_dataset()` call in the VRT and relationship paths. Only `restricted` rows reach the database from there, and a batch operation on the permission seam would let a wrapping overlay's policy be skipped, which is the failure mode `SLOT-02` exists to prevent. The reasoning is recorded next to the code.

**Complexity controls.** The three router caps sat 13, 3, and 29 lines above their files, which is how "decomposition is queued" stayed true through five documented cap raises. They are now ratchets pinned to current size, with a test that fails if a cap and its file disagree in either direction. To add lines to one of those files you remove lines or decompose it. Ruff also gained a McCabe 15 gate with the 26 currently-over-complexity files as an explicit baseline, so new code anywhere else is gated. The standards serializers are in the baseline on purpose, per the audit.

This is the change most likely to annoy someone. Say the word and I will put a few lines of headroom back.

**Platform layering.** `platform/config_ops/service.py` imported the private `_ENTERPRISE_ONLY_TABS` from `modules/settings/router.py` at call time. That constant now lives beside the persistent-config registry that defines `PersistentConfig.tab`, so edition policy has an owner and decomposing the settings router cannot break config import. Two new guards: platform must not import `app.modules.*` at module scope outside a 7-edge burn-down list, and must never import a private name from a product module at any scope.

**Naive timestamps.** `ShareTokenRequest(expires_at="2030-06-01T00:00:00")` raised `TypeError: can't compare offset-naive and offset-aware datetimes` and became a 500. `expires_at` is now `AwareDatetime`, so it is a 422 with `type: timezone_aware`.

## Response changes

Two error responses change shape. Neither affects a success path.

| Case | Before | After |
|---|---|---|
| Community caller sends `expires_at` to `POST`/`PATCH /maps/{id}/share/` | 400 | 422, matching the embed-token controls |
| Operational database failure on `GET /datasets/{id}/rows/` | 200 with an empty page | 503 |

`backend/openapi.json` and the generated SDKs carry one description change. The hand-maintained SDK wrappers were clobbered by the generator and have been restored.

## Verification

- `uv run pytest -n 4`: 4743 passed, 53 skipped.
- `uv run ruff check app tests` and `ruff format --check`: clean.
- `make alembic-check`: no new upgrade operations.
- `make openapi-check`, `make sdks-check`: clean after regeneration.
- Each regression test was run against the pre-fix code to confirm it fails there. Two of my first drafts passed against the old implementation and were rewritten.
- `make cli-test` fails on this branch and on a clean `main` alike. Pre-existing, untouched here.

## Not done

The 30 lazy catalog imports and the 26 over-complexity files are burn-down lists, not fixes. Adding typed ProcessingPort methods for map read access and edit checks would clear the last two edges in `processing/ai/router.py`, and that needs overlay coordination. Incremental mypy coverage on `core/*_port.py` is not in scope here.
