### PR TITLE
docs(changelog): record the 422/503 response-shape changes from the backend audit (#435)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and releases use semantic versioning.
 
 ## [Unreleased]
 
+### Changed
+
+- **A custom share-link expiration is now rejected with a validation error on
+  the Community edition.** Setting `expires_at` on `POST /maps/{id}/share/`
+  without the advanced-sharing entitlement returns 422 instead of 400, so it
+  matches how embed tokens already report the same restriction.
+- **The dataset rows endpoint returns 503 when the database is unavailable
+  instead of an empty page.** An operational database failure (connection loss
+  or statement timeout) on `GET /datasets/{id}/rows/` now returns 503 rather
+  than a 200 with an empty result set that looked like the dataset had no rows.
+  A dataset that is genuinely empty, or has no backing table, still returns 200.
+
 ## [1.4.2] - 2026-07-01
 
 ### Changed


### PR DESCRIPTION
Follow-up to #437. That PR changed two response shapes that API consumers can observe, but the `[Unreleased]` CHANGELOG section was empty, so the changes would not have surfaced in the next release notes. This adds them.

Both entries describe behavior already merged in #437:

- Community `expires_at` on `POST /maps/{id}/share/` now returns 422 (was 400), matching how embed tokens report the same restriction.
- An operational database failure on `GET /datasets/{id}/rows/` now returns 503 instead of a 200 empty page. A genuinely empty or table-less dataset still returns 200.

Docs-only. No code or schema change.

@codex please review.
