### PR TITLE
chore(release): prepare v1.4.3 (#441)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -159,6 +159,11 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          # fix(#441): stamp the exact commit into the image so /api/health can
+          # report it (`build` field). Only the pushed image needs it; the
+          # scan-only builds above stay cache-stable without it.
+          build-args: |
+            GEOLENS_BUILD_SHA=${{ github.sha }}
           provenance: false
           sbom: false
           cache-from: type=gha,scope=${{ matrix.image }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,11 @@ and releases use semantic versioning.
 - **Interrupted exports clean up after themselves.** A failed export removes
   its temporary directory, and the boot-time sweeper only removes export
   staging entries older than an hour instead of everything it finds.
+- **`ENVIRONMENT=production` in `.env` now reaches the containers.** Neither
+  compose file passed the variable through, so an operator who set it still
+  got the open posture: interactive docs exposed and the OAuth session cookie
+  sent without the Secure flag. Both compose files now forward it, and an
+  empty value keeps the old `LOG_JSON` fallback behavior.
 
 ## [1.4.2] - 2026-07-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,7 @@ and releases use semantic versioning.
 - **Per-user daily AI token budget.** `MAX_AI_TOKENS_PER_USER_PER_DAY` caps
   what any one user can spend on AI calls per day; 0 keeps it unlimited.
 - **Edition badge in the admin overview.** Administrators can see at a glance
-  whether a deployment runs the Community or Enterprise edition.
+  which edition a deployment runs.
 - **`/api/health` reports the running version and build.** The health payload
   carries `version` and `build` fields so operators can verify what a
   deployment runs over HTTP; release images stamp the exact build commit.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,52 @@ and releases use semantic versioning.
 
 ## [Unreleased]
 
+## [1.4.3] - 2026-07-10
+
+### Security
+
+- **Layer column changes now require write access.** The four layer-column
+  endpoints gated schema-changing operations on read visibility; they now
+  require dataset write access like every other mutation.
+- **VRT ingestion rejects remote and virtual sources.** A crafted VRT file
+  could reference URL or `/vsi`-prefixed sources and make the ingest worker
+  fetch them. Source validation now walks the full XML and rejects both.
+- **Raster preview and tile fetches no longer follow HTTP redirects.** Both
+  the GDAL source-preview path and the bundled Titiler run with
+  `GDAL_HTTP_FOLLOWLOCATION=NO`, so a redirect can no longer route an
+  already-validated fetch to an internal address.
+- **Search facets cap the geometry filter size.** The facets endpoint accepted
+  unbounded geometry input that could pin PostGIS on a single request; input
+  is now capped at 10,000 characters.
+
+### Added
+
+- **Six curated showcase maps.** The showcase seed now builds six themed maps
+  (terrain, Sentinel-2 imagery, plate tectonics, and more) on a rebuilt
+  Restless Earth dataset, replacing the older single-map demo seed.
+- **Per-user daily AI token budget.** `MAX_AI_TOKENS_PER_USER_PER_DAY` caps
+  what any one user can spend on AI calls per day; 0 keeps it unlimited.
+- **Edition badge in the admin overview.** Administrators can see at a glance
+  whether a deployment runs the Community or Enterprise edition.
+- **`/api/health` reports the running version and build.** The health payload
+  carries `version` and `build` fields so operators can verify what a
+  deployment runs over HTTP; release images stamp the exact build commit.
+
 ### Changed
 
+- **Unified interface design.** The UI moved to a single design language
+  across the catalog, builder, viewer, and admin pages, including contrast
+  fixes for accessibility.
+- **Translation completeness.** Remaining hardcoded interface strings now go
+  through the translation layer, and all four locales (en, es, fr, de) ship
+  the full key set.
+- **The installer waits longer and no longer cries wolf.** The startup health
+  wait rose from 90 to 300 seconds, and a timeout now prints "still starting"
+  guidance instead of failing the install while the stack is converging,
+  which is common on Apple Silicon where the database image runs emulated.
+  The installer also warns when Docker has less than about 8 GB of memory
+  available.
+- **Titiler updated to 2.0.5.**
 - **A custom share-link expiration is now rejected with a validation error on
   the Community edition.** Setting `expires_at` on `POST /maps/{id}/share/`
   without the advanced-sharing entitlement returns 422 instead of 400, so it
@@ -18,6 +62,34 @@ and releases use semantic versioning.
   or statement timeout) on `GET /datasets/{id}/rows/` now returns 503 rather
   than a 200 with an empty result set that looked like the dataset had no rows.
   A dataset that is genuinely empty, or has no backing table, still returns 200.
+
+### Fixed
+
+- **Saving a map right after adding a layer no longer clears that layer's
+  styling.**
+- **Mixed-geometry datasets render fully.** Layers whose table mixes geometry
+  families (points, lines, polygons) now render each family instead of
+  drawing only one.
+- **Files dropped during upload setup are no longer lost.** Dropping files
+  onto the import dialog while it was still fetching its configuration
+  silently discarded them; they now queue and validate once the
+  configuration settles.
+- **Anonymous viewers can load `features.geojson` on public datasets.**
+- **PNG map exports draw their legend swatches.**
+- **AI-assisted builder labels are readable, and active filters show a
+  summary pill.**
+- **The dataset-count quota is enforced atomically at record creation**, so
+  concurrent uploads can no longer slip past the cap.
+- **AI chat handles numeric query results reliably.** Provider calls
+  serialize decimal values safely and return plain-text output.
+- **The frontend container no longer crash-loops when `PUBLIC_APP_URL` is
+  set.** The social-preview image rewrite ran at boot in a way the
+  unprivileged nginx image could not execute.
+- **Two map-builder audit passes** fixed styling, filtering, viewer, and
+  export defects across the builder.
+- **Interrupted exports clean up after themselves.** A failed export removes
+  its temporary directory, and the boot-time sweeper only removes export
+  staging entries older than an hour instead of everything it finds.
 
 ## [1.4.2] - 2026-07-01
 
@@ -440,3 +512,13 @@ regression-covered fixes:
 
 - Initial public release of the GeoLens catalog, API, map builder, CLI, SDKs,
   Docker development stack, and public documentation entrypoints.
+
+[Unreleased]: https://github.com/geolens-io/geolens/compare/v1.4.3...HEAD
+[1.4.3]: https://github.com/geolens-io/geolens/compare/v1.4.2...v1.4.3
+[1.4.2]: https://github.com/geolens-io/geolens/compare/v1.4.1...v1.4.2
+[1.4.1]: https://github.com/geolens-io/geolens/compare/v1.4.0...v1.4.1
+[1.4.0]: https://github.com/geolens-io/geolens/compare/v1.3.0...v1.4.0
+[1.3.0]: https://github.com/geolens-io/geolens/compare/v1.2.4...v1.3.0
+[1.2.4]: https://github.com/geolens-io/geolens/compare/v1.2.3...v1.2.4
+[1.2.3]: https://github.com/geolens-io/geolens/compare/v1.2.0...v1.2.3
+[1.2.0]: https://github.com/geolens-io/geolens/releases/tag/v1.2.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -177,6 +177,13 @@ COPY --from=backend-builder --chown=appuser:appgroup /app /app
 RUN mkdir -p /app/staging /home/appuser/.cache/uv && \
     chown -R appuser:appgroup /app /app/staging /home/appuser
 
+# fix(#441): stamp the build commit for /health `build` reporting. publish.yml
+# passes it on release builds; local and dev builds leave it empty. Declared
+# last in this shared stage so a changing SHA invalidates no heavy layers, and
+# as ENV so the api and worker child stages inherit it.
+ARG GEOLENS_BUILD_SHA=
+ENV GEOLENS_BUILD_SHA=${GEOLENS_BUILD_SHA}
+
 FROM backend-base AS api
 
 LABEL org.opencontainers.image.title="geolens-api"

--- a/Makefile
+++ b/Makefile
@@ -140,7 +140,14 @@ sdks:
 	# PEP 561 marker — generator with --meta none doesn't emit it; touch so
 	# typecheckers consume the inline annotations on consumers' machines.
 	touch sdks/python/geolens/py.typed
-	cd sdks/typescript && npm install --silent && npx --yes @hey-api/openapi-ts@0.96.1 -i /tmp/openapi-flat.json
+	# fix(#441): run the generator from the LOCAL lockfile-pinned install, not a
+	# fresh `npx @hey-api/openapi-ts@…` resolve. openapi-ts declares an
+	# open-ended `typescript >=5.5.3 || >=6.0.0` peer, so a cold npx resolve
+	# pulls typescript 7 (published 2026-07-08), whose changed compiler API
+	# crashes the generator (`ts.NewLineKind` undefined) — and npm lets the peer
+	# range beat even an explicit `-p typescript@5.9.x`. package.json pins the
+	# generator + typescript exactly; package-lock.json makes it reproducible.
+	cd sdks/typescript && npm install --silent && ./node_modules/.bin/openapi-ts -i /tmp/openapi-flat.json
 	-cp /tmp/_geolens_auth.py sdks/python/geolens/auth.py 2>/dev/null
 	-cp /tmp/_geolens_init.py sdks/python/geolens/__init__.py 2>/dev/null
 	-cp /tmp/_geolens_auth.ts sdks/typescript/src/auth.ts 2>/dev/null

--- a/README.md
+++ b/README.md
@@ -374,6 +374,7 @@ For day-2 operations, restore procedures, and incident response, see
 ## Community
 
 - [GitHub Discussions](https://github.com/geolens-io/geolens/discussions): questions, ideas, show and tell
+- [Support](SUPPORT.md): where to ask for help and how problems get routed
 - [Contributing Guide](.github/CONTRIBUTING.md): development setup, code style, and PR guidelines
 
 ## Known limitations

--- a/backend/app/api/main.py
+++ b/backend/app/api/main.py
@@ -458,7 +458,7 @@ _is_production = settings.is_production
 # no metadata to read. We fall back to the current published line so import never
 # crashes. Keep this fallback in lockstep with backend/pyproject.toml — it is one
 # of the sites `make bump` rewrites.
-_FALLBACK_APP_VERSION = "1.4.2"
+_FALLBACK_APP_VERSION = "1.4.3"
 
 
 def _resolve_app_version() -> str:
@@ -802,6 +802,14 @@ async def health(request: Request):
     from fastapi.responses import JSONResponse
 
     result = await check_health()
+    # fix(#441): report the running version + build commit so a deployment can
+    # be verified over HTTP (production disables /docs, which was the only
+    # surface exposing the version). GEOLENS_BUILD_SHA is stamped into release
+    # images by publish.yml; local and source builds report null.
+    import os
+
+    result["version"] = app.version
+    result["build"] = os.environ.get("GEOLENS_BUILD_SHA") or None
     status_code = 200 if result["status"] == "healthy" else 503
 
     # Phase 1230 EVENT-04: emit a health-alert notification when the result is

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -269,6 +269,10 @@ class Settings(BaseSettings):
         "notification_webhook_url",
         # Phase 1230 EVENT-05 recipient field — blank env value normalizes to None
         "notification_admin_email",
+        # fix(#441): compose passes ENVIRONMENT through as "${ENVIRONMENT:-}",
+        # so an unset value arrives as "" — normalize to None (LOG_JSON fallback)
+        # instead of failing the Literal validation at boot.
+        "environment",
         mode="before",
     )
     @classmethod

--- a/backend/app/observability/health/schemas.py
+++ b/backend/app/observability/health/schemas.py
@@ -9,4 +9,10 @@ class ServiceHealth(BaseModel):
 
 class HealthResponse(BaseModel):
     status: str
+    # fix(#441): version + build commit make a deployment verifiable over HTTP.
+    # Production disables the interactive docs, which were the only surface
+    # that reported the running version. `build` is None outside release
+    # images (the publish workflow stamps it via GEOLENS_BUILD_SHA).
+    version: str
+    build: str | None = None
     providers: dict[str, ServiceHealth]

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -6494,6 +6494,17 @@
       },
       "HealthResponse": {
         "properties": {
+          "build": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Build"
+          },
           "providers": {
             "additionalProperties": {
               "$ref": "#/components/schemas/ServiceHealth"
@@ -6504,10 +6515,15 @@
           "status": {
             "title": "Status",
             "type": "string"
+          },
+          "version": {
+            "title": "Version",
+            "type": "string"
           }
         },
         "required": [
           "status",
+          "version",
           "providers"
         ],
         "title": "HealthResponse",
@@ -15937,7 +15953,7 @@
     "summary": "PostGIS-native geospatial data catalog with OGC API Features and Records support",
     "termsOfService": "https://github.com/geolens-io/geolens/blob/main/LICENSE",
     "title": "GeoLens API",
-    "version": "1.4.2"
+    "version": "1.4.3"
   },
   "openapi": "3.1.0",
   "paths": {

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geolens-backend"
-version = "1.4.2"
+version = "1.4.3"
 description = "PostGIS-native GIS data catalog"
 # Docker image (Dockerfile) ships python:3.14-slim (see the Dockerfile FROM for
 # the exact patch pin) as the project's tested runtime.

--- a/backend/tests/test_environment_posture_sec005.py
+++ b/backend/tests/test_environment_posture_sec005.py
@@ -58,6 +58,19 @@ def test_backward_compat_log_json_without_environment(monkeypatch):
     assert s.is_production is True
 
 
+def test_empty_environment_normalizes_to_none(monkeypatch):
+    """fix(#441): compose passes ENVIRONMENT through as "${ENVIRONMENT:-}", so
+    an operator who never set it delivers "" — that must behave exactly like
+    unset (LOG_JSON fallback), not fail the Literal validation at boot."""
+    s = _settings(monkeypatch, environment="", log_json=False)
+    assert s.environment is None
+    assert s.is_production is False
+
+    s = _settings(monkeypatch, environment="", log_json=True)
+    assert s.environment is None
+    assert s.is_production is True
+
+
 def test_default_dev_posture(monkeypatch):
     s = _settings(monkeypatch, environment=None, log_json=False)
     assert s.is_production is False

--- a/backend/tests/test_health.py
+++ b/backend/tests/test_health.py
@@ -199,6 +199,35 @@ async def test_health_endpoint_does_not_leak_provider_error(client):
     assert "error" not in payload["providers"]["storage"]
 
 
+@pytest.mark.anyio
+async def test_health_endpoint_reports_version_and_build(client, monkeypatch):
+    """fix(#441): /health carries the running version and the build commit.
+
+    Production disables /docs, so /health is the surface an operator can use
+    to verify what a deployment runs. `build` comes from the GEOLENS_BUILD_SHA
+    env stamped into release images; it is null everywhere else.
+    """
+    from app.api.main import app
+
+    async def noop():
+        pass
+
+    monkeypatch.delenv("GEOLENS_BUILD_SHA", raising=False)
+    with (
+        patch("app.observability.health.service._check_database", new=noop),
+        patch("app.observability.health.service._check_storage", new=noop),
+        patch("app.observability.health.service._check_cache", new=noop),
+    ):
+        resp = await client.get("/health")
+        payload = resp.json()
+        assert payload["version"] == app.version
+        assert payload["build"] is None
+
+        monkeypatch.setenv("GEOLENS_BUILD_SHA", "abc123def456")
+        resp = await client.get("/health")
+        assert resp.json()["build"] == "abc123def456"
+
+
 def test_health_endpoint_is_rate_limited():
     """GAP-016: /health carries an explicit rate limit and is not exempt.
 

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -865,7 +865,7 @@ wheels = [
 
 [[package]]
 name = "geolens-backend"
-version = "1.4.2"
+version = "1.4.3"
 source = { virtual = "." }
 dependencies = [
     { name = "alembic" },

--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "geolens-cli"
-version = "1.4.2"
+version = "1.4.3"
 description = "Apache-2.0 command-line interface for the GeoLens API. Login, scan, publish, and export STAC against any GeoLens instance."
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -68,6 +68,10 @@ x-storage-env: &storage-env
 x-logging-env: &logging-env
   LOG_JSON: "${LOG_JSON:-false}"
   LOG_LEVEL: "${LOG_LEVEL:-INFO}"
+  # fix(#441): the SEC-005 posture flag never reached the containers — an
+  # operator setting ENVIRONMENT=production in .env got no Secure cookie and
+  # public /docs anyway. Empty (unset) falls back to LOG_JSON in Settings.
+  ENVIRONMENT: "${ENVIRONMENT:-}"
 
 x-ai-env: &ai-env
   ANTHROPIC_API_KEY: "${ANTHROPIC_API_KEY:-}"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -55,6 +55,9 @@ x-storage-env: &storage-env
 x-logging-env: &logging-env
   LOG_JSON: "${LOG_JSON:-false}"
   LOG_LEVEL: "${LOG_LEVEL:-INFO}"
+  # fix(#441): pass the SEC-005 posture flag through (kept in sync with
+  # docker-compose.prod.yml). Empty (unset) falls back to LOG_JSON in Settings.
+  ENVIRONMENT: "${ENVIRONMENT:-}"
 
 x-ai-env: &ai-env
   ANTHROPIC_API_KEY: "${ANTHROPIC_API_KEY:-}"

--- a/docs-contract.json
+++ b/docs-contract.json
@@ -1,6 +1,6 @@
 {
   "_comment": "Canonical cross-surface facts for the GeoLens README, marketing site (getgeolens.com/src), and docs site (getgeolens.com/docs). Validated against scripts/install.sh + backend/pyproject.toml by scripts/check_docs_contract.py (geolens CI). The getgeolens.com repo vendors a copy and enforces the same `forbidden` list in its own CI. See docs-internal/DOC-CONSISTENCY-STRATEGY for the full design. Edit a fact ONCE here (and in its canonical source) — the gates make every surface follow.",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "install": {
     "oneLiner": "curl -fsSL https://getgeolens.com/install.sh | sh",
     "sourceBuild": "bash scripts/install.sh",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.4.2",
+  "version": "1.4.3",
   "type": "module",
   "license": "Apache-2.0",
   "author": "Carto Concepts, LLC",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "geolens",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "private": true,
   "license": "Apache-2.0",
   "author": "Carto Concepts, LLC",

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -162,13 +162,16 @@ prompt_value() {
   printf '%s\n' "$default"
 }
 
-# Wait up to 90s for the stack to become healthy. The migrate one-shot must
-# exit 0; every healthcheck-having service must report (healthy). If migrate
-# fails or the wait times out, surface the failing service with its log tail
-# and exit non-zero — silent "Starting..." on a dead stack is the worst kind
-# of false success signal.
+# Wait up to 300s for the stack to become healthy. The migrate one-shot must
+# exit 0; every healthcheck-having service must report (healthy). A migrate
+# failure is a real failure (return 1, with its log tail). A timeout is NOT
+# (return 2): on hosts that emulate amd64 (Apple Silicon and other ARM
+# machines) the database image runs under QEMU and first boot can outlast any
+# reasonable budget while still converging — treating that as a dead stack
+# false-alarmed real installs. fix(#441): budget raised from 90s and the
+# timeout softened to "still starting" guidance.
 wait_for_healthy() {
-  attempts=18
+  attempts=60
   sleep_s=5
   i=0
   while [ "$i" -lt "$attempts" ]; do
@@ -207,10 +210,12 @@ wait_for_healthy() {
   done
 
   printf '\n' >&2
-  warn "timed out after $((attempts * sleep_s))s waiting for services. Current status:"
+  warn "services are not all healthy yet after $((attempts * sleep_s))s. This is usually still a"
+  warn "normal startup: on Apple Silicon and other ARM hosts the database image runs emulated"
+  warn "and can take several more minutes on first boot. Current status:"
   compose ps 2>&1 | sed 's/^/  /' >&2
-  warn "Inspect with: docker compose ps  /  docker compose logs <service>"
-  return 1
+  warn "Watch progress with: docker compose ps  /  docker compose logs <service>"
+  return 2
 }
 
 # GAP-025: the entire imperative install sequence lives in main() and is
@@ -236,6 +241,21 @@ main() {
   # docker's root usage). `docker compose version` only exits 0 when the plugin is
   # actually present.
   docker compose version >/dev/null 2>&1 || fail "Docker Compose v2 is required. Install Docker Desktop or the docker compose plugin."
+
+  # fix(#441): warn when Docker has less memory than the stack's compose
+  # limits assume (worker 4g + api 2g + db 2g + titiler 1g). A low-RAM Docker
+  # Desktop otherwise OOM-kills services with no explanation. Warn-only: a
+  # light catalog can run smaller. Threshold is 7 GiB so a host that gives
+  # Docker "8 GB" minus VM overhead does not false-alarm.
+  docker_mem="$(docker info --format '{{.MemTotal}}' 2>/dev/null || printf '0')"
+  case "$docker_mem" in
+    ''|*[!0-9]*) docker_mem=0 ;;
+  esac
+  if [ "$docker_mem" -gt 0 ] && [ "$docker_mem" -lt 7516192768 ]; then
+    warn "Docker reports about $((docker_mem / 1073741824)) GB of memory. GeoLens runs best with 8 GB or more;"
+    warn "with less, services may be OOM-killed under load. On Docker Desktop, raise the limit under"
+    warn "Settings > Resources > Memory."
+  fi
 
   # If the user already cd'd into a checkout, use it. Otherwise honor INSTALL_DIR.
   PROJECT_HINT=""
@@ -505,12 +525,21 @@ main() {
   # form with "unknown flag: --detach". `compose` adds -f "$COMPOSE_FILE".
   compose up -d
 
-  if ! wait_for_healthy; then
+  # `set -eu` is active: capture the status without letting a non-zero return
+  # abort the script. 1 = migrate failed (fatal); 2 = still converging (not
+  # fatal — see wait_for_healthy).
+  health_rc=0
+  wait_for_healthy || health_rc=$?
+  if [ "$health_rc" -eq 1 ]; then
     fail "GeoLens did not come up cleanly. See the failing service output above."
   fi
 
   say ""
-  say "GeoLens is ready."
+  if [ "$health_rc" -eq 0 ]; then
+    say "GeoLens is ready."
+  else
+    say "GeoLens is still starting. Give it a few more minutes, then open the UI."
+  fi
   say "UI:  http://localhost:${fe_port}"
   say "API: http://localhost:${api_port}"
   say ""

--- a/sdks/python/.openapi-python-client.yaml
+++ b/sdks/python/.openapi-python-client.yaml
@@ -4,7 +4,7 @@ project_name_override: geolens
 package_name_override: geolens
 # Rewritten on every `make sdks` run by scripts/sync_sdk_versions.py to match
 # backend/openapi.json info.version. Do not edit by hand.
-package_version_override: 1.4.2
+package_version_override: 1.4.3
 
 # Cleaner enum output (matches our pydantic v2 backend's enum emission).
 literal_enums: true

--- a/sdks/python/geolens/models/health_response.py
+++ b/sdks/python/geolens/models/health_response.py
@@ -6,6 +6,9 @@ from typing import Any, TypeVar, TYPE_CHECKING
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
 
+from ..types import UNSET, Unset
+
+from typing import cast
 
 if TYPE_CHECKING:
     from ..models.health_response_providers import HealthResponseProviders
@@ -20,10 +23,14 @@ class HealthResponse:
     Attributes:
         providers (HealthResponseProviders):
         status (str):
+        version (str):
+        build (None | str | Unset):
     """
 
     providers: HealthResponseProviders
     status: str
+    version: str
+    build: None | str | Unset = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
@@ -31,14 +38,25 @@ class HealthResponse:
 
         status = self.status
 
+        version = self.version
+
+        build: None | str | Unset
+        if isinstance(self.build, Unset):
+            build = UNSET
+        else:
+            build = self.build
+
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
                 "providers": providers,
                 "status": status,
+                "version": version,
             }
         )
+        if build is not UNSET:
+            field_dict["build"] = build
 
         return field_dict
 
@@ -51,9 +69,22 @@ class HealthResponse:
 
         status = d.pop("status")
 
+        version = d.pop("version")
+
+        def _parse_build(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        build = _parse_build(d.pop("build", UNSET))
+
         health_response = cls(
             providers=providers,
             status=status,
+            version=version,
+            build=build,
         )
 
         health_response.additional_properties = d

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "geolens"
-version = "1.4.2"
+version = "1.4.3"
 description = "Auto-generated Python SDK for the GeoLens API. Typed clients with Bearer + API-key auth helpers."
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/sdks/typescript/package-lock.json
+++ b/sdks/typescript/package-lock.json
@@ -12,8 +12,8 @@
         "@hey-api/client-fetch": "0.13.1"
       },
       "devDependencies": {
-        "@hey-api/openapi-ts": "0.99.0",
-        "typescript": "^5.6.0"
+        "@hey-api/openapi-ts": "0.96.1",
+        "typescript": "5.9.3"
       },
       "engines": {
         "node": ">=18"
@@ -33,9 +33,9 @@
       }
     },
     "node_modules/@hey-api/codegen-core": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/@hey-api/codegen-core/-/codegen-core-0.9.1.tgz",
-      "integrity": "sha512-s97jL1dgTMuiMHv2BZ1X4Tgd99Mf9GOvGdNqNcGwIMmnR+PgYNoraj4Zvp134MKsNCap/m7k0r0vKKnl56pj4w==",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@hey-api/codegen-core/-/codegen-core-0.8.0.tgz",
+      "integrity": "sha512-OuF/jenX9wz7AWHRBfb37v+jLkrfCt0FJXQuALNH2UsW6+bdZBmoibHl0K778SiHwneotJbAaEvX2S05wEqUQw==",
       "license": "MIT",
       "dependencies": {
         "@hey-api/types": "0.1.4",
@@ -44,51 +44,50 @@
         "color-support": "1.1.3"
       },
       "engines": {
-        "node": ">=22.18.0"
+        "node": ">=22.13.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/hey-api"
       }
     },
     "node_modules/@hey-api/json-schema-ref-parser": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/@hey-api/json-schema-ref-parser/-/json-schema-ref-parser-1.4.4.tgz",
-      "integrity": "sha512-otmd+zCxbYVBIp/mlMTnGkvlNYLkVKgs3VOIq0kSnenhB1+fRwLPQIeSwyWM6E51oXhUedkYjVsVpkVexeuJOA==",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@hey-api/json-schema-ref-parser/-/json-schema-ref-parser-1.4.1.tgz",
+      "integrity": "sha512-DoPJGxVApDlktP1yYLjmOrF0YBEqb32ieCbx1S1i09n8TyCgdoh4yQaQ3kp0sMTauH+bwNKPsFh7S8qiWCoKZA==",
       "license": "MIT",
       "dependencies": {
         "@jsdevtools/ono": "7.1.3",
         "@types/json-schema": "7.0.15",
-        "js-yaml": "4.2.0"
+        "yaml": "2.8.3"
       },
       "engines": {
-        "node": ">=22.18.0"
+        "node": ">=22.13.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/hey-api"
       }
     },
     "node_modules/@hey-api/openapi-ts": {
-      "version": "0.99.0",
-      "resolved": "https://registry.npmjs.org/@hey-api/openapi-ts/-/openapi-ts-0.99.0.tgz",
-      "integrity": "sha512-SePU/5oEWWkvUBYmvzdYRctseoLuskyhs4ET0RvLIcmzc8yLQoA2R+KtBIQ8bPsoSUB0m4E5SmBnl6aGSA0szQ==",
+      "version": "0.96.1",
+      "resolved": "https://registry.npmjs.org/@hey-api/openapi-ts/-/openapi-ts-0.96.1.tgz",
+      "integrity": "sha512-EnH+6ncaVC1yNvYWcsO7MoeBSqCvYZaKvRDRqh+S7dsfb9lhe2mKUR2+7sDacGUBm7VDZZ7hg4q4egxlpZaf0g==",
       "license": "MIT",
       "dependencies": {
-        "@hey-api/codegen-core": "0.9.1",
-        "@hey-api/json-schema-ref-parser": "1.4.4",
-        "@hey-api/shared": "0.5.0",
+        "@hey-api/codegen-core": "0.8.0",
+        "@hey-api/json-schema-ref-parser": "1.4.1",
+        "@hey-api/shared": "0.4.1",
         "@hey-api/spec-types": "0.2.0",
         "@hey-api/types": "0.1.4",
-        "@lukeed/ms": "2.0.2",
         "ansi-colors": "4.1.3",
         "color-support": "1.1.3",
-        "commander": "15.0.0",
+        "commander": "14.0.3",
         "get-tsconfig": "4.14.0"
       },
       "bin": {
         "openapi-ts": "bin/run.js"
       },
       "engines": {
-        "node": ">=22.18.0"
+        "node": ">=22.13.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/hey-api"
@@ -98,22 +97,22 @@
       }
     },
     "node_modules/@hey-api/shared": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@hey-api/shared/-/shared-0.5.0.tgz",
-      "integrity": "sha512-JN/j4Ebh4cJGYIQ5cwWuqe7GeSUyQoz7oC51WqyhKOcrejK6DKZMDkshc5d1eKTRuRL+rjozuRcoUaZZn2DGPw==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@hey-api/shared/-/shared-0.4.1.tgz",
+      "integrity": "sha512-EDAjvGpEamn2fOB7W87ZStyDSv5mEpnQCciVbiZ+Ll4EfawwIjHMMtDtRQOYol0YjTkAeEm274GFPAtg3xfPGA==",
       "license": "MIT",
       "dependencies": {
-        "@hey-api/codegen-core": "0.9.1",
-        "@hey-api/json-schema-ref-parser": "1.4.4",
+        "@hey-api/codegen-core": "0.8.0",
+        "@hey-api/json-schema-ref-parser": "1.4.1",
         "@hey-api/spec-types": "0.2.0",
         "@hey-api/types": "0.1.4",
         "ansi-colors": "4.1.3",
         "cross-spawn": "7.0.6",
         "open": "11.0.0",
-        "semver": "7.8.4"
+        "semver": "7.7.4"
       },
       "engines": {
-        "node": ">=22.18.0"
+        "node": ">=22.13.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/hey-api"
@@ -143,15 +142,6 @@
       "integrity": "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg==",
       "license": "MIT"
     },
-    "node_modules/@lukeed/ms": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@lukeed/ms/-/ms-2.0.2.tgz",
-      "integrity": "sha512-9I2Zn6+NJLfaGoz9jN3lpwDgAYvfGeNYdbAIjJOqzs4Tpc+VU3Jqq4IofSUBKajiDS8k9fZIg18/z13mpk1bsA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
@@ -166,12 +156,6 @@
       "engines": {
         "node": ">=6"
       }
-    },
-    "node_modules/argparse": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "license": "Python-2.0"
     },
     "node_modules/bundle-name": {
       "version": "4.1.0",
@@ -241,12 +225,12 @@
       }
     },
     "node_modules/commander": {
-      "version": "15.0.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-15.0.0.tgz",
-      "integrity": "sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg==",
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
       "license": "MIT",
       "engines": {
-        "node": ">=22.12.0"
+        "node": ">=20"
       }
     },
     "node_modules/confbox": {
@@ -435,28 +419,6 @@
         "jiti": "lib/jiti-cli.mjs"
       }
     },
-    "node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/puzrin"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/nodeca"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^2.0.1"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
-      }
-    },
     "node_modules/ohash": {
       "version": "2.0.11",
       "resolved": "https://registry.npmjs.org/ohash/-/ohash-2.0.11.tgz",
@@ -572,9 +534,9 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.8.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
-      "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -646,6 +608,21 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/yaml": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
       }
     }
   }

--- a/sdks/typescript/package-lock.json
+++ b/sdks/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@geolens/sdk",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@geolens/sdk",
-      "version": "1.4.2",
+      "version": "1.4.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@hey-api/client-fetch": "0.13.1"

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -38,8 +38,8 @@
     "@hey-api/client-fetch": "0.13.1"
   },
   "devDependencies": {
-    "@hey-api/openapi-ts": "0.99.0",
-    "typescript": "^5.6.0"
+    "@hey-api/openapi-ts": "0.96.1",
+    "typescript": "5.9.3"
   },
   "publishConfig": {
     "access": "public"

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@geolens/sdk",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "description": "Auto-generated TypeScript SDK for the GeoLens API. Typed clients with Bearer + API-key auth helpers.",
   "license": "Apache-2.0",
   "author": "Carto Concepts, LLC",

--- a/sdks/typescript/src/client/types.gen.ts
+++ b/sdks/typescript/src/client/types.gen.ts
@@ -3788,6 +3788,10 @@ export type HttpValidationError = {
  */
 export type HealthResponse = {
     /**
+     * Build
+     */
+    build?: string | null;
+    /**
      * Providers
      */
     providers: {
@@ -3797,6 +3801,10 @@ export type HealthResponse = {
      * Status
      */
     status: string;
+    /**
+     * Version
+     */
+    version: string;
 };
 
 /**


### PR DESCRIPTION
Release preparation for v1.4.3, closing the release-blocking and release-riding items from the 2026-07-09 launch readiness audit (#441). v1.4.2 predates the five High security fixes merged on 2026-07-09, and the installer resolves the highest release tag, so cutting v1.4.3 is the launch blocker.

What rides the tag:

- Installer: the startup health wait rises from 90s to 300s, and a timeout now prints "still starting" guidance and continues instead of failing the install. On ARM hosts the amd64-only database image runs emulated and routinely outlasts 90s while converging. A migrate failure still fails the install.
- Installer: warns when Docker reports less than about 8 GB of memory, since the compose limits assume more and a low-RAM Docker Desktop otherwise OOM-kills services silently.
- /api/health now reports `version` and `build`. Production disables the interactive docs, so this is the surface an operator can use to verify what a deployment runs. publish.yml stamps the exact commit into release images via a GEOLENS_BUILD_SHA build arg; local builds report null.
- ENVIRONMENT now reaches the containers. Neither compose file passed the SEC-005 posture flag through, so an operator who set ENVIRONMENT=production in .env still got public /docs and a session cookie without Secure (the live demo VM hit exactly this). Both compose files forward it now; a blank value normalizes to None in Settings so the LOG_JSON fallback is preserved for deployments that never set it.
- The TS SDK generator is lockfile-pinned. typescript 7 (published 2026-07-08) satisfies openapi-ts's open-ended peer range and crashes it on a cold npx resolve, which is what failed the SDKs Drift Gate here; npm lets the peer range beat an explicit -p pin. The generator and typescript are now exact devDependencies in sdks/typescript and the Makefile runs the local bin.
- Curated `[1.4.3]` CHANGELOG section covering the 38 substantive commits since v1.4.2 (the release workflow's git-log fallback would include ~23 dependabot lines), plus the Keep a Changelog comparison-link footer.
- README links SUPPORT.md from the Community section.
- `make bump VERSION=1.4.3` across all version sites; openapi.json and both SDKs regenerated for the HealthResponse change.

Deliberately not included: the installer port-fallback alignment (CS-04) needs a coordinated docs-contract change, deferred on #441.

Verification: full backend suite in the release worktree (4751 passed, 59 skipped); ruff check + format; make version-check / openapi-check; the full Docs Contract trio (contract, public-surface gate, surface unittests); make sdks-check with a cold npm cache; sh -n on the installer plus stubbed tests of all three wait_for_healthy exit paths; local prod-compose boot from images built off this branch (all services healthy, migrate exit 0, /api/health reporting version 1.4.3 and the build commit through the prod proxy); Playwright audit suite through the prod proxy (21 passed); and a live before/after check that ENVIRONMENT=production flips /api/docs from 200 to 404 on the booted stack.

@codex please review.
