### PR TITLE
fix(frontend): close the #441 follow-ups and prepare v1.4.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,9 @@ and releases use semantic versioning.
 - **Accessibility improvements across the interface.** Upload and export
   progress indicators announce themselves to screen readers, sortable table
   headers report their sort state, form-input borders meet the 3:1 contrast
-  minimum, and animations respect the reduced-motion preference.
+  minimum, the destructive red is darkened in light mode so error badges and
+  text meet the 4.5:1 minimum on tinted surfaces, and animations respect the
+  reduced-motion preference.
 - **Deleting a user now asks the administrator to type the username to
   confirm.**
 - **Locale completeness checks now compare translated values and variables**,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,36 @@ and releases use semantic versioning.
 
 ## [Unreleased]
 
+## [1.4.4] - 2026-07-10
+
+### Changed
+
+- **The "Powered by GeoLens" footer badge now links to getgeolens.com.**
+- **Accessibility improvements across the interface.** Upload and export
+  progress indicators announce themselves to screen readers, sortable table
+  headers report their sort state, form-input borders meet the 3:1 contrast
+  minimum, and animations respect the reduced-motion preference.
+- **Deleting a user now asks the administrator to type the username to
+  confirm.**
+- **Locale completeness checks now compare translated values and variables**,
+  not just key presence, across all four languages.
+
+### Fixed
+
+- **Admin "Export emails (CSV)" downloads again.** The export opened a
+  browser tab without credentials and showed an authentication error instead
+  of the file; it now downloads through the authenticated path like the
+  audit-log export.
+- **Failed requests are easier to recover from.** Error panels gained a retry
+  action, API requests time out instead of hanging indefinitely, and an
+  in-flight upload can be aborted and retried.
+- **Builder polish from the frontend audit.** Map label offsets apply
+  correctly, raster styling inputs clamp when leaving the field instead of
+  while typing, and a missing tile token surfaces as an error instead of
+  rendering an empty layer.
+- **A frontend audit pass closed 85 findings in total** across design-system
+  consistency, interface resilience, and code health.
+
 ## [1.4.3] - 2026-07-10
 
 ### Security
@@ -518,7 +548,8 @@ regression-covered fixes:
 - Initial public release of the GeoLens catalog, API, map builder, CLI, SDKs,
   Docker development stack, and public documentation entrypoints.
 
-[Unreleased]: https://github.com/geolens-io/geolens/compare/v1.4.3...HEAD
+[Unreleased]: https://github.com/geolens-io/geolens/compare/v1.4.4...HEAD
+[1.4.4]: https://github.com/geolens-io/geolens/compare/v1.4.3...v1.4.4
 [1.4.3]: https://github.com/geolens-io/geolens/compare/v1.4.2...v1.4.3
 [1.4.2]: https://github.com/geolens-io/geolens/compare/v1.4.1...v1.4.2
 [1.4.1]: https://github.com/geolens-io/geolens/compare/v1.4.0...v1.4.1

--- a/backend/app/api/main.py
+++ b/backend/app/api/main.py
@@ -458,7 +458,7 @@ _is_production = settings.is_production
 # no metadata to read. We fall back to the current published line so import never
 # crashes. Keep this fallback in lockstep with backend/pyproject.toml — it is one
 # of the sites `make bump` rewrites.
-_FALLBACK_APP_VERSION = "1.4.3"
+_FALLBACK_APP_VERSION = "1.4.4"
 
 
 def _resolve_app_version() -> str:

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -15953,7 +15953,7 @@
     "summary": "PostGIS-native geospatial data catalog with OGC API Features and Records support",
     "termsOfService": "https://github.com/geolens-io/geolens/blob/main/LICENSE",
     "title": "GeoLens API",
-    "version": "1.4.3"
+    "version": "1.4.4"
   },
   "openapi": "3.1.0",
   "paths": {

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geolens-backend"
-version = "1.4.3"
+version = "1.4.4"
 description = "PostGIS-native GIS data catalog"
 # Docker image (Dockerfile) ships python:3.14-slim (see the Dockerfile FROM for
 # the exact patch pin) as the project's tested runtime.

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -865,7 +865,7 @@ wheels = [
 
 [[package]]
 name = "geolens-backend"
-version = "1.4.3"
+version = "1.4.4"
 source = { virtual = "." }
 dependencies = [
     { name = "alembic" },

--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "geolens-cli"
-version = "1.4.3"
+version = "1.4.4"
 description = "Apache-2.0 command-line interface for the GeoLens API. Login, scan, publish, and export STAC against any GeoLens instance."
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/docs-contract.json
+++ b/docs-contract.json
@@ -1,6 +1,6 @@
 {
   "_comment": "Canonical cross-surface facts for the GeoLens README, marketing site (getgeolens.com/src), and docs site (getgeolens.com/docs). Validated against scripts/install.sh + backend/pyproject.toml by scripts/check_docs_contract.py (geolens CI). The getgeolens.com repo vendors a copy and enforces the same `forbidden` list in its own CI. See docs-internal/DOC-CONSISTENCY-STRATEGY for the full design. Edit a fact ONCE here (and in its canonical source) — the gates make every surface follow.",
-  "version": "1.4.3",
+  "version": "1.4.4",
   "install": {
     "oneLiner": "curl -fsSL https://getgeolens.com/install.sh | sh",
     "sourceBuild": "bash scripts/install.sh",

--- a/e2e/non-spatial.spec.ts
+++ b/e2e/non-spatial.spec.ts
@@ -141,9 +141,14 @@ test.describe.serial('Non-spatial CSV', () => {
     await expect(codeBlock).toContainText(`/api/collections/${datasetId}/items?limit=10`);
     await expect(codeBlock).not.toContainText('/api/v1/collections/');
 
-    const options = page.locator('select option');
+    // fix(#438): DS-08 replaced the native <select> with ui/select (Radix)
+    const formatTrigger = page.getByRole('combobox', { name: 'Export format' });
+    await expect(formatTrigger).toContainText('CSV');
+    await formatTrigger.click();
+    const options = page.getByRole('option');
     await expect(options).toHaveCount(1);
     await expect(options.first()).toHaveText('CSV');
+    await page.keyboard.press('Escape');
     await expect(page.getByRole('button', { name: 'Export' })).toBeVisible();
   });
 

--- a/e2e/post-impl-validation.spec.ts
+++ b/e2e/post-impl-validation.spec.ts
@@ -4,7 +4,8 @@
  */
 import { test, expect } from '@playwright/test';
 
-const BASE = process.env.BASE_URL ?? 'http://localhost:8080';
+// fix(#441): read the same env var as playwright.config.ts so absolute URLs track baseURL
+const BASE = process.env.E2E_BASE_URL ?? 'http://localhost:8080';
 const ADMIN_USER = process.env.GEOLENS_ADMIN_USERNAME ?? 'admin';
 const ADMIN_PASS = process.env.GEOLENS_ADMIN_PASSWORD ?? 'admin';
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.4.3",
+  "version": "1.4.4",
   "type": "module",
   "license": "Apache-2.0",
   "author": "Carto Concepts, LLC",

--- a/frontend/src/components/layout/AppFooter.tsx
+++ b/frontend/src/components/layout/AppFooter.tsx
@@ -2,6 +2,7 @@ import { Fragment } from 'react';
 import { useTranslation } from 'react-i18next';
 import { cn } from '@/lib/utils';
 import {
+  GEOLENS_SITE_URL,
   GEOLENS_GITHUB_URL,
   GEOLENS_DISCUSSIONS_URL,
   GEOLENS_LICENSE_URL,
@@ -38,7 +39,17 @@ export function AppFooter({
         aria-label={showBranding ? t('footer.poweredBy') : t('appName')}
         className={cn('flex items-center justify-center flex-wrap gap-x-1.5', navClassName)}
       >
-        {showBranding && <span>{t('footer.poweredBy')}</span>}
+        {/* fix(#441): badge click-through — top-of-funnel link was a dead <span> */}
+        {showBranding && (
+          <a
+            href={GEOLENS_SITE_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+            className={cn('hover:text-foreground transition-colors', linkClassName)}
+          >
+            {t('footer.poweredBy')}
+          </a>
+        )}
         {footerLinks.map((link, index) => (
           <Fragment key={link.label}>
             {(showBranding || index > 0) && <span aria-hidden="true">·</span>}

--- a/frontend/src/components/layout/__tests__/AppLayout.test.tsx
+++ b/frontend/src/components/layout/__tests__/AppLayout.test.tsx
@@ -58,6 +58,14 @@ describe('AppLayout', () => {
     expect(footer).toHaveTextContent('GitHub');
   });
 
+  it('Powered by GeoLens badge links to getgeolens.com', () => {
+    renderAppLayout();
+    const badge = screen.getByRole('link', { name: /powered by geolens/i });
+    expect(badge).toHaveAttribute('href', 'https://getgeolens.com');
+    expect(badge).toHaveAttribute('target', '_blank');
+    expect(badge).toHaveAttribute('rel', 'noopener noreferrer');
+  });
+
   it('footer links to GitHub repository with correct attributes', () => {
     renderAppLayout();
     const link = screen.getByRole('link', { name: /^github$/i });

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -55,7 +55,11 @@
   --muted-foreground: oklch(0.45 0.005 250);
   --accent: oklch(0.97 0.003 85);
   --accent-foreground: oklch(0.205 0.005 250);
-  --destructive: oklch(0.577 0.245 27.325);
+  /* fix(#441): darkened from 0.577 like the semantic status colors below —
+   * DS-01's soft badge recipe puts text-destructive on a bg-destructive/10
+   * tint, which measured 3.89:1 at the stock value. Now 4.95:1 on the /10
+   * tint and 5.96:1 for white-on-solid (buttons). */
+  --destructive: oklch(0.50 0.245 27.325);
   --destructive-foreground: oklch(0.985 0 0);
   /* fix(#438): A11Y-02 — measured contrast (OKLCH→sRGB→WCAG):
      --border 0.88 sits at ~1.4:1 against card/background. Decorative dividers

--- a/frontend/src/lib/external-links.ts
+++ b/frontend/src/lib/external-links.ts
@@ -1,3 +1,4 @@
+export const GEOLENS_SITE_URL = 'https://getgeolens.com';
 export const GEOLENS_GITHUB_URL = 'https://github.com/geolens-io/geolens';
 export const GEOLENS_BUG_REPORT_URL = `${GEOLENS_GITHUB_URL}/issues/new?template=bug_report.yml`;
 export const GEOLENS_DISCUSSIONS_URL = 'https://github.com/geolens-io/geolens/discussions';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "geolens",
-  "version": "1.4.3",
+  "version": "1.4.4",
   "private": true,
   "license": "Apache-2.0",
   "author": "Carto Concepts, LLC",

--- a/sdks/python/.openapi-python-client.yaml
+++ b/sdks/python/.openapi-python-client.yaml
@@ -4,7 +4,7 @@ project_name_override: geolens
 package_name_override: geolens
 # Rewritten on every `make sdks` run by scripts/sync_sdk_versions.py to match
 # backend/openapi.json info.version. Do not edit by hand.
-package_version_override: 1.4.3
+package_version_override: 1.4.4
 
 # Cleaner enum output (matches our pydantic v2 backend's enum emission).
 literal_enums: true

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "geolens"
-version = "1.4.3"
+version = "1.4.4"
 description = "Auto-generated Python SDK for the GeoLens API. Typed clients with Bearer + API-key auth helpers."
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/sdks/typescript/package-lock.json
+++ b/sdks/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@geolens/sdk",
-  "version": "1.4.3",
+  "version": "1.4.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@geolens/sdk",
-      "version": "1.4.3",
+      "version": "1.4.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@hey-api/client-fetch": "0.13.1"

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@geolens/sdk",
-  "version": "1.4.3",
+  "version": "1.4.4",
   "description": "Auto-generated TypeScript SDK for the GeoLens API. Typed clients with Bearer + API-key auth helpers.",
   "license": "Apache-2.0",
   "author": "Carto Concepts, LLC",


### PR DESCRIPTION
Closes the two remaining in-repo items from the 2026-07-09 launch-readiness audit (#441) and prepares v1.4.4, which releases the frontend-audit remediation (#438) currently sitting unreleased on main.

## Audit follow-ups (#441)

- **Footer badge click-through.** The "Powered by GeoLens" badge was a plain `<span>`; it now links to getgeolens.com with the same attributes as the other footer links, behind the same `showBranding` gate. The badge-gate suite grows a test pinning the href (14 tests total).
- **e2e base-URL unification.** `post-impl-validation.spec.ts` built absolute URLs from `BASE_URL` while `playwright.config.ts` reads `E2E_BASE_URL`; both now read `E2E_BASE_URL`.

Still deferred on #441 (unchanged): CS-04 installer port fallbacks (needs the coordinated docs-contract change) and the `/privacy` 404 (marketing site).

## Found by the pre-tag smoke run

- **Light-mode `--destructive` darkened to `oklch(0.50 0.245 27.325)`.** DS-01 (#438) put `text-destructive` on `bg-destructive/10` tints; at the stock lightness that measures 3.89:1, which fails axe on the dataset-detail, maps-listing, and admin-overview pages. This is why the push(main) **Accessibility job is currently red on main** — and the same spec runs inside `e2e:smoke:audit`, so the prod-smoke gate would have failed the v1.4.4 tag. Now 4.95:1 on the /10 tint and 5.96:1 white-on-solid; dark mode untouched.
- **`non-spatial.spec.ts` updated for the ui/select migration.** DS-08 (#438) replaced ExportButton's native `<select>`; the spec still located native `select option` and found none. It now asserts through the Radix combobox/option roles.

## Release prep

- Curated `[1.4.4]` CHANGELOG section (frontend-audit remediation highlights + the badge link + the contrast fix), comparison-link footer updated.
- `make bump VERSION=1.4.4` across all nine version sites, plus the TS SDK lockfile sync the bump misses.

## Verification

- Frontend: typecheck, lint, build, full vitest suite with coverage, `npm run types:check`.
- Gates: `make version-check` (9/9 at 1.4.4), `make openapi-check`, `make sdks-check`, `make public-surface-check`.
- e2e against a freshly rebuilt local stack: `e2e:smoke` core + builder + fixtures green; `e2e:smoke:audit` green including accessibility 13/13 (red on main today) and keyboard-nav 3/3.

@codex please review.
