### PR TITLE
fix(security): close post-merge review gaps

### DIFF
--- a/backend/app/platform/config_ops/service.py
+++ b/backend/app/platform/config_ops/service.py
@@ -70,6 +70,10 @@ _PROVIDER_COMPARE_FIELDS = [
     "enabled",
 ]
 
+_OAUTH_ENDPOINT_FIELDS = frozenset(
+    {"discovery_url", "authorize_url", "token_url", "userinfo_url"}
+)
+
 
 def _diff_provider(existing_dict: dict, imported: dict) -> list[str]:
     """Return list of fields that differ between existing and imported provider."""
@@ -251,8 +255,12 @@ async def _apply_oauth_providers(
                     raise ConfigValidationError(str(exc)) from exc
                 created += 1
             else:
+                # Exported endpoint nulls explicitly clear the inactive OAuth mode.
+                # Other null values retain merge mode's "leave unchanged" semantics.
                 update_fields = {
-                    k: v for k, v in imp.items() if k != "slug" and v is not None
+                    k: v
+                    for k, v in imp.items()
+                    if k != "slug" and (v is not None or k in _OAUTH_ENDPOINT_FIELDS)
                 }
                 if update_fields:
                     try:

--- a/backend/app/platform/sandbox/validator.py
+++ b/backend/app/platform/sandbox/validator.py
@@ -300,8 +300,9 @@ def _validate_function_cost(func: exp.Func, fn_name: str, sql: str) -> None:
 
 def _reject_recursive_cte(stmt: exp.Expression, sql: str) -> None:
     """Reject recursive CTEs, which are unbounded row generators."""
-    recursive_with = stmt.find(exp.With)
-    if recursive_with is not None and recursive_with.args.get("recursive"):
+    if any(
+        with_clause.args.get("recursive") for with_clause in stmt.find_all(exp.With)
+    ):
         logger.info("sandbox.recursive_cte", sql=sql)
         raise SandboxError("invalid_query", "Recursive queries are not allowed")
 

--- a/backend/tests/test_oauth_destination_security.py
+++ b/backend/tests/test_oauth_destination_security.py
@@ -390,6 +390,107 @@ async def test_merge_import_cannot_bypass_destination_binding(
 
 
 @pytest.mark.anyio
+async def test_merge_import_applies_null_endpoint_clears(
+    test_db_session: AsyncSession,
+) -> None:
+    provider = await _make_oidc_provider(test_db_session)
+    discovery_url = "https://idp.example.com/.well-known/openid-configuration"
+
+    counts = await _apply_oauth_providers(
+        test_db_session,
+        [
+            {
+                "slug": provider.slug,
+                "display_name": None,
+                "client_secret": "replacement-secret",
+                "discovery_url": discovery_url,
+                "authorize_url": None,
+                "token_url": None,
+                "userinfo_url": None,
+            }
+        ],
+        "merge",
+    )
+
+    assert counts == (0, 1, 0)
+    assert provider.display_name == "Destination Security"
+    assert provider.discovery_url == discovery_url
+    assert provider.authorize_url is None
+    assert provider.token_url is None
+    assert provider.userinfo_url is None
+    assert decrypt_secret(provider.client_secret_encrypted) == "replacement-secret"
+
+
+@pytest.mark.anyio
+async def test_merge_import_mode_switch_requires_secret_rotation(
+    test_db_session: AsyncSession,
+) -> None:
+    provider = await _make_oidc_provider(test_db_session)
+
+    with pytest.raises(ConfigValidationError, match="client_secret"):
+        await _apply_oauth_providers(
+            test_db_session,
+            [
+                {
+                    "slug": provider.slug,
+                    "discovery_url": (
+                        "https://idp.example.com/.well-known/openid-configuration"
+                    ),
+                    "authorize_url": None,
+                    "token_url": None,
+                    "userinfo_url": None,
+                }
+            ],
+            "merge",
+        )
+
+    assert provider.discovery_url is None
+    assert provider.authorize_url == "https://idp.example.com/authorize"
+    assert provider.token_url == "https://idp.example.com/token"
+    assert provider.userinfo_url == "https://idp.example.com/userinfo"
+
+
+@pytest.mark.anyio
+async def test_merge_import_clears_discovery_for_explicit_mode(
+    test_db_session: AsyncSession,
+) -> None:
+    suffix = uuid.uuid4().hex[:8]
+    provider = await create_provider(
+        test_db_session,
+        OAuthProviderCreate(
+            slug=f"discovery-{suffix}",
+            display_name="Discovery Provider",
+            provider_type="oidc",
+            client_id=f"client-{suffix}",
+            client_secret="original-secret",
+            discovery_url="https://idp.example.com/.well-known/openid-configuration",
+        ),
+    )
+
+    counts = await _apply_oauth_providers(
+        test_db_session,
+        [
+            {
+                "slug": provider.slug,
+                "client_secret": "replacement-secret",
+                "discovery_url": None,
+                "authorize_url": "https://idp.example.com/authorize",
+                "token_url": "https://idp.example.com/token",
+                "userinfo_url": "https://idp.example.com/userinfo",
+            }
+        ],
+        "merge",
+    )
+
+    assert counts == (0, 1, 0)
+    assert provider.discovery_url is None
+    assert provider.authorize_url == "https://idp.example.com/authorize"
+    assert provider.token_url == "https://idp.example.com/token"
+    assert provider.userinfo_url == "https://idp.example.com/userinfo"
+    assert decrypt_secret(provider.client_secret_encrypted) == "replacement-secret"
+
+
+@pytest.mark.anyio
 async def test_runtime_validation_checks_all_server_endpoints(
     test_db_session: AsyncSession,
 ) -> None:

--- a/backend/tests/test_sec025_sandbox_allowlist.py
+++ b/backend/tests/test_sec025_sandbox_allowlist.py
@@ -25,7 +25,11 @@ from app.platform.sandbox.validator import validate_sql
 # ---------------------------------------------------------------------------
 
 
-def _assert_rejects(sql: str, expected_category: str = "invalid_query") -> None:
+def _assert_rejects(
+    sql: str,
+    expected_category: str = "invalid_query",
+    expected_message: str | None = None,
+) -> None:
     """Assert that validate_sql raises SandboxError for the given SQL."""
     with pytest.raises(SandboxError) as exc_info:
         validate_sql(sql)
@@ -33,6 +37,8 @@ def _assert_rejects(sql: str, expected_category: str = "invalid_query") -> None:
         f"Expected category={expected_category!r} but got "
         f"{exc_info.value.category!r} for SQL: {sql!r}"
     )
+    if expected_message is not None:
+        assert exc_info.value.user_message == expected_message
 
 
 def _assert_allows(sql: str) -> None:
@@ -444,6 +450,17 @@ class TestResourceAmplificationRejected:
             "WITH RECURSIVE bomb(n) AS ("
             "SELECT 1 UNION ALL SELECT n + 1 FROM bomb WHERE n < 1000000000"
             ") SELECT count(*) FROM bomb, data.cities"
+        )
+
+    def test_rejects_nested_recursive_cte_after_non_recursive_outer_cte(self):
+        _assert_rejects(
+            "WITH harmless AS (SELECT 1 AS marker) "
+            "SELECT count(*) FROM data.cities CROSS JOIN LATERAL ("
+            "WITH RECURSIVE bomb(n) AS ("
+            "SELECT 1 UNION ALL SELECT n + 1 FROM bomb WHERE n < 1000000000"
+            ") SELECT n FROM bomb"
+            ") AS nested",
+            expected_message="Recursive queries are not allowed",
         )
 
     @pytest.mark.parametrize(


### PR DESCRIPTION
## What

- Reject recursive CTEs anywhere in the parsed SQL tree, including nested `WITH RECURSIVE` clauses behind a harmless outer `WITH`.
- Preserve explicit `null` values for OAuth endpoint fields during merge-mode config imports so discovery and explicit endpoint modes can switch atomically.
- Add regressions for nested recursion, both OAuth mode-switch directions, required secret rotation, and unrelated-null merge semantics.

## Why

A Codex review triggered when #445 was marked ready landed after that PR had already merged and identified two actionable P2 gaps:

- [Reject every recursive CTE](https://github.com/geolens-io/geolens/pull/445#discussion_r3562510748)
- [Keep null endpoint clears in merge imports](https://github.com/geolens-io/geolens/pull/445#discussion_r3562510752)

## Impact

AI-generated SQL now fails closed on every recursive CTE node. Config imports can apply valid OAuth endpoint-mode transitions while credential destination changes still require a replacement secret.

## Root cause

The sandbox inspected only the first `exp.With` node. Merge-mode config import also treated every `None` value as “leave unchanged,” even though endpoint nulls are explicit mode-clearing values in exported configurations.

## Checks

- Confirmed both new regressions failed before the fixes and passed afterward.
- 183 sandbox/config/OAuth regression tests passed.
- 111 focused sandbox and OAuth destination tests passed.
- Ruff check and format checks passed.
- Pre-commit hooks and `git diff --check` passed.
- Independent review found no blocking issues.