### PR TITLE
perf: close the 2026-07-10 performance-profile audit findings

### DIFF
--- a/backend/alembic/versions/0012_type_embedding_vector.py
+++ b/backend/alembic/versions/0012_type_embedding_vector.py
@@ -93,10 +93,23 @@ def upgrade() -> None:
           END IF;
 
           -- Same DDL the baseline and rebuild_embedding_column intend.
-          EXECUTE 'CREATE INDEX IF NOT EXISTS ix_record_embeddings_hnsw '
-                  'ON catalog.record_embeddings USING hnsw '
-                  '(embedding vector_cosine_ops) '
-                  'WITH (m = 16, ef_construction = 64)';
+          -- fix(#449, codex P1): pgvector rejects HNSW on vector columns over
+          -- 2000 dims (3072-dim models are legal config, cap is 4096) — skip
+          -- the index rather than fail the upgrade; semantic search falls
+          -- back to exact scans. Re-probe: the ALTER above may have typed it.
+          SELECT atttypmod INTO cur_typmod
+          FROM pg_attribute
+          WHERE attrelid = 'catalog.record_embeddings'::regclass
+            AND attname = 'embedding';
+
+          IF cur_typmod BETWEEN 1 AND 2000 THEN
+            EXECUTE 'CREATE INDEX IF NOT EXISTS ix_record_embeddings_hnsw '
+                    'ON catalog.record_embeddings USING hnsw '
+                    '(embedding vector_cosine_ops) '
+                    'WITH (m = 16, ef_construction = 64)';
+          ELSE
+            RAISE NOTICE 'Skipping ix_record_embeddings_hnsw: % dims exceeds pgvector''s 2000-dim HNSW limit; semantic search stays on exact scans.', cur_typmod;
+          END IF;
         END $$;
         """
     )

--- a/backend/alembic/versions/0012_type_embedding_vector.py
+++ b/backend/alembic/versions/0012_type_embedding_vector.py
@@ -8,17 +8,24 @@ UI, so a deployment running on defaults never gets a typed column — and an
 HNSW/ivfflat index can never be built (pgvector requires a typed column).
 Semantic search then does an O(N) x dims cosine scan per query, twice.
 
-This migration types the column in place, preferring (in order) the
-dimension of vectors already stored (only when they all agree — mixed
-dimensions mean a model switch, where the active config must win), the
-``embedding_dims`` persistent
-config override (skipped when ``ENV_ONLY_CONFIG`` is set, mirroring
-runtime resolution in persistent_config.py), and finally the configured
-``EMBEDDING_DIMS`` env value / Settings default (1536,
-text-embedding-3-small). Rows whose dimension disagrees with the chosen
-value are deleted — embeddings are a regenerable cache (content-hash
-backfill restores them). Deployments whose column is already typed (the
-settings-UI path ran) are left untouched except for ensuring the index.
+This migration types the column in place, preferring (in order):
+
+1. An explicitly configured dimension: the ``embedding_dims``
+   persistent-config override (skipped when ``ENV_ONLY_CONFIG`` is set,
+   mirroring runtime resolution in persistent_config.py), then an
+   explicitly-set ``EMBEDDING_DIMS`` env value. Explicit config beats
+   stored rows — stale cache rows from a superseded model must not pin
+   the column to the old dimension (the current model's inserts would
+   fail until a manual rebuild).
+2. The dimension of vectors already stored, when they all agree. Stored
+   rows beat only the BUILT-IN default: a local model emitting 768-dim
+   vectors with nothing configured anywhere must keep its rows.
+3. The Settings default (1536, text-embedding-3-small).
+
+Rows whose dimension disagrees with the chosen value are deleted —
+embeddings are a regenerable cache (content-hash backfill restores them).
+Deployments whose column is already typed (the settings-UI path ran) are
+left untouched except for ensuring the index.
 
 Revision ID: 0012_type_embedding_vector
 Revises: 0011_allow_generic_geometry_type
@@ -38,12 +45,19 @@ depends_on: Union[str, Sequence[str], None] = None
 
 
 def upgrade() -> None:
-    # fix(#449, codex P2): the empty-table fallback must honor the deployment's
-    # configured dimension, not a hardcoded 1536 — a fresh install running a
-    # 384/768-dim model via EMBEDDING_DIMS would otherwise get the column
-    # permanently mistyped before any data exists. Mirror runtime resolution
-    # (persistent_config.py): ENV_ONLY_CONFIG ignores DB overrides.
-    fallback_dims = settings.embedding_dims if settings.embedding_dims >= 1 else 1536
+    # fix(#449, codex P2): honor the deployment's configured dimension, not a
+    # hardcoded 1536, and let explicit config beat stale stored rows. Mirror
+    # runtime resolution (persistent_config.py): ENV_ONLY_CONFIG ignores DB
+    # overrides. "Explicit" = differs from the class default; comparing against
+    # the field default (rather than probing os.environ) also catches values
+    # set via the project-root .env file that Settings reads.
+    field_default = type(settings).model_fields["embedding_dims"].default
+    explicit = (
+        settings.embedding_dims
+        if settings.embedding_dims >= 1 and settings.embedding_dims != field_default
+        else None
+    )
+    explicit_env_dims = str(explicit) if explicit is not None else "NULL"
     consult_db = "false" if settings.env_only_config else "true"
     op.execute(
         f"""
@@ -51,7 +65,9 @@ def upgrade() -> None:
         DECLARE
           cur_typmod int;
           dims int;
+          stored_dims int;
           distinct_dims int;
+          config_dims int;
         BEGIN
           SELECT atttypmod INTO cur_typmod
           FROM pg_attribute
@@ -64,22 +80,16 @@ def upgrade() -> None:
             -- a deadlock-prone pattern if anything is reading the table.
             LOCK TABLE catalog.record_embeddings IN ACCESS EXCLUSIVE MODE;
 
-            -- Prefer the dimension of data already stored; fall back to the
-            -- embedding_dims persistent-config override (unless env-only),
-            -- then the configured EMBEDDING_DIMS / app default.
             SELECT count(DISTINCT vector_dims(embedding)),
                    max(vector_dims(embedding))
-              INTO distinct_dims, dims
+              INTO distinct_dims, stored_dims
             FROM catalog.record_embeddings;
-            IF distinct_dims > 1 THEN
-              -- fix(#449, codex P2): mixed dimensions mean a model switch
-              -- happened without a rebuild — the largest stored dim may
-              -- belong to the STALE model. Fall through to the configured
-              -- dimension instead; mismatched rows are deleted below
-              -- (embeddings are a regenerable cache).
-              dims := NULL;
-            END IF;
-            IF dims IS NULL AND {consult_db} THEN
+
+            -- fix(#449, codex P2): explicit config (app_settings override
+            -- unless env-only, then an explicitly-set EMBEDDING_DIMS) beats
+            -- stored rows — stale cache rows from a superseded model must
+            -- not pin the column to the old dimension.
+            IF {consult_db} THEN
               -- PersistentConfig wraps scalars as {{"v": <value>}} (see
               -- persistent_config.py set()); older/manual rows may hold a
               -- bare number. Handle both shapes.
@@ -88,11 +98,23 @@ def upgrade() -> None:
                        WHEN 'number' THEN (value #>> '{{}}')::int
                        ELSE NULL
                      END
-              INTO dims
+              INTO config_dims
               FROM catalog.app_settings WHERE key = 'embedding_dims';
             END IF;
-            IF dims IS NULL OR dims < 1 THEN
-              dims := {fallback_dims};
+            IF config_dims IS NULL THEN
+              config_dims := {explicit_env_dims};
+            END IF;
+
+            -- Stored rows (when they all agree) beat only the built-in
+            -- default; mixed dimensions mean a model switch, so they never
+            -- pick the dimension themselves.
+            dims := COALESCE(
+              config_dims,
+              CASE WHEN distinct_dims = 1 THEN stored_dims END,
+              1536
+            );
+            IF dims < 1 THEN
+              dims := 1536;
             END IF;
 
             DELETE FROM catalog.record_embeddings

--- a/backend/alembic/versions/0012_type_embedding_vector.py
+++ b/backend/alembic/versions/0012_type_embedding_vector.py
@@ -10,7 +10,9 @@ Semantic search then does an O(N) x dims cosine scan per query, twice.
 
 This migration types the column in place, preferring (in order) the
 dimension of vectors already stored, the ``embedding_dims`` persistent
-config override, and finally the Settings default (1536,
+config override (skipped when ``ENV_ONLY_CONFIG`` is set, mirroring
+runtime resolution in persistent_config.py), and finally the configured
+``EMBEDDING_DIMS`` env value / Settings default (1536,
 text-embedding-3-small). Rows whose dimension disagrees with the chosen
 value are deleted — embeddings are a regenerable cache (content-hash
 backfill restores them). Deployments whose column is already typed (the
@@ -25,6 +27,8 @@ from typing import Sequence, Union
 
 from alembic import op
 
+from app.core.config import settings
+
 revision: str = "0012_type_embedding_vector"
 down_revision: Union[str, None] = "0011_allow_generic_geometry_type"
 branch_labels: Union[str, Sequence[str], None] = None
@@ -32,8 +36,15 @@ depends_on: Union[str, Sequence[str], None] = None
 
 
 def upgrade() -> None:
+    # fix(#449, codex P2): the empty-table fallback must honor the deployment's
+    # configured dimension, not a hardcoded 1536 — a fresh install running a
+    # 384/768-dim model via EMBEDDING_DIMS would otherwise get the column
+    # permanently mistyped before any data exists. Mirror runtime resolution
+    # (persistent_config.py): ENV_ONLY_CONFIG ignores DB overrides.
+    fallback_dims = settings.embedding_dims if settings.embedding_dims >= 1 else 1536
+    consult_db = "false" if settings.env_only_config else "true"
     op.execute(
-        """
+        f"""
         DO $$
         DECLARE
           cur_typmod int;
@@ -51,23 +62,24 @@ def upgrade() -> None:
             LOCK TABLE catalog.record_embeddings IN ACCESS EXCLUSIVE MODE;
 
             -- Prefer the dimension of data already stored; fall back to the
-            -- embedding_dims persistent-config override, then the app default.
+            -- embedding_dims persistent-config override (unless env-only),
+            -- then the configured EMBEDDING_DIMS / app default.
             SELECT max(vector_dims(embedding)) INTO dims
             FROM catalog.record_embeddings;
-            IF dims IS NULL THEN
-              -- PersistentConfig wraps scalars as {"v": <value>} (see
+            IF dims IS NULL AND {consult_db} THEN
+              -- PersistentConfig wraps scalars as {{"v": <value>}} (see
               -- persistent_config.py set()); older/manual rows may hold a
               -- bare number. Handle both shapes.
               SELECT CASE jsonb_typeof(value)
-                       WHEN 'object' THEN (value #>> '{v}')::int
-                       WHEN 'number' THEN (value #>> '{}')::int
+                       WHEN 'object' THEN (value #>> '{{v}}')::int
+                       WHEN 'number' THEN (value #>> '{{}}')::int
                        ELSE NULL
                      END
               INTO dims
               FROM catalog.app_settings WHERE key = 'embedding_dims';
             END IF;
             IF dims IS NULL OR dims < 1 THEN
-              dims := 1536;
+              dims := {fallback_dims};
             END IF;
 
             DELETE FROM catalog.record_embeddings

--- a/backend/alembic/versions/0012_type_embedding_vector.py
+++ b/backend/alembic/versions/0012_type_embedding_vector.py
@@ -13,10 +13,12 @@ This migration types the column in place, preferring (in order):
 1. An explicitly configured dimension: the ``embedding_dims``
    persistent-config override (skipped when ``ENV_ONLY_CONFIG`` is set,
    mirroring runtime resolution in persistent_config.py), then an
-   explicitly-set ``EMBEDDING_DIMS`` env value. Explicit config beats
-   stored rows — stale cache rows from a superseded model must not pin
-   the column to the old dimension (the current model's inserts would
-   fail until a manual rebuild).
+   explicitly-set ``EMBEDDING_DIMS`` env value (detected via pydantic's
+   ``model_fields_set``, so a deliberate ``EMBEDDING_DIMS=1536`` counts
+   even though it equals the default). Explicit config beats stored
+   rows — stale cache rows from a superseded model must not pin the
+   column to the old dimension (the current model's inserts would fail
+   until a manual rebuild).
 2. The dimension of vectors already stored, when they all agree. Stored
    rows beat only the BUILT-IN default: a local model emitting 768-dim
    vectors with nothing configured anywhere must keep its rows.
@@ -48,13 +50,14 @@ def upgrade() -> None:
     # fix(#449, codex P2): honor the deployment's configured dimension, not a
     # hardcoded 1536, and let explicit config beat stale stored rows. Mirror
     # runtime resolution (persistent_config.py): ENV_ONLY_CONFIG ignores DB
-    # overrides. "Explicit" = differs from the class default; comparing against
-    # the field default (rather than probing os.environ) also catches values
-    # set via the project-root .env file that Settings reads.
-    field_default = type(settings).model_fields["embedding_dims"].default
+    # overrides. "Explicit" = the operator provided EMBEDDING_DIMS (env var or
+    # the project-root .env file Settings reads) — pydantic's model_fields_set
+    # distinguishes a deliberate EMBEDDING_DIMS=1536 from the untouched class
+    # default, which a value comparison cannot.
     explicit = (
         settings.embedding_dims
-        if settings.embedding_dims >= 1 and settings.embedding_dims != field_default
+        if "embedding_dims" in settings.model_fields_set
+        and settings.embedding_dims >= 1
         else None
     )
     explicit_env_dims = str(explicit) if explicit is not None else "NULL"

--- a/backend/alembic/versions/0012_type_embedding_vector.py
+++ b/backend/alembic/versions/0012_type_embedding_vector.py
@@ -9,7 +9,9 @@ HNSW/ivfflat index can never be built (pgvector requires a typed column).
 Semantic search then does an O(N) x dims cosine scan per query, twice.
 
 This migration types the column in place, preferring (in order) the
-dimension of vectors already stored, the ``embedding_dims`` persistent
+dimension of vectors already stored (only when they all agree — mixed
+dimensions mean a model switch, where the active config must win), the
+``embedding_dims`` persistent
 config override (skipped when ``ENV_ONLY_CONFIG`` is set, mirroring
 runtime resolution in persistent_config.py), and finally the configured
 ``EMBEDDING_DIMS`` env value / Settings default (1536,
@@ -49,6 +51,7 @@ def upgrade() -> None:
         DECLARE
           cur_typmod int;
           dims int;
+          distinct_dims int;
         BEGIN
           SELECT atttypmod INTO cur_typmod
           FROM pg_attribute
@@ -64,8 +67,18 @@ def upgrade() -> None:
             -- Prefer the dimension of data already stored; fall back to the
             -- embedding_dims persistent-config override (unless env-only),
             -- then the configured EMBEDDING_DIMS / app default.
-            SELECT max(vector_dims(embedding)) INTO dims
+            SELECT count(DISTINCT vector_dims(embedding)),
+                   max(vector_dims(embedding))
+              INTO distinct_dims, dims
             FROM catalog.record_embeddings;
+            IF distinct_dims > 1 THEN
+              -- fix(#449, codex P2): mixed dimensions mean a model switch
+              -- happened without a rebuild — the largest stored dim may
+              -- belong to the STALE model. Fall through to the configured
+              -- dimension instead; mismatched rows are deleted below
+              -- (embeddings are a regenerable cache).
+              dims := NULL;
+            END IF;
             IF dims IS NULL AND {consult_db} THEN
               -- PersistentConfig wraps scalars as {{"v": <value>}} (see
               -- persistent_config.py set()); older/manual rows may hold a

--- a/backend/alembic/versions/0012_type_embedding_vector.py
+++ b/backend/alembic/versions/0012_type_embedding_vector.py
@@ -1,0 +1,100 @@
+"""Give record_embeddings.embedding a fixed dimension so HNSW can exist.
+
+fix(#448 perf-audit): the baseline creates ``embedding`` as unbounded
+``vector`` (atttypmod=-1) and skips the HNSW index with a NOTICE, expecting
+``rebuild_embedding_column`` to type the column "on first AI-provider
+config". That hook only fires when the dimension CHANGES via the settings
+UI, so a deployment running on defaults never gets a typed column — and an
+HNSW/ivfflat index can never be built (pgvector requires a typed column).
+Semantic search then does an O(N) x dims cosine scan per query, twice.
+
+This migration types the column in place, preferring (in order) the
+dimension of vectors already stored, the ``embedding_dims`` persistent
+config override, and finally the Settings default (1536,
+text-embedding-3-small). Rows whose dimension disagrees with the chosen
+value are deleted — embeddings are a regenerable cache (content-hash
+backfill restores them). Deployments whose column is already typed (the
+settings-UI path ran) are left untouched except for ensuring the index.
+
+Revision ID: 0012_type_embedding_vector
+Revises: 0011_allow_generic_geometry_type
+Create Date: 2026-07-10
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+revision: str = "0012_type_embedding_vector"
+down_revision: Union[str, None] = "0011_allow_generic_geometry_type"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        DO $$
+        DECLARE
+          cur_typmod int;
+          dims int;
+        BEGIN
+          SELECT atttypmod INTO cur_typmod
+          FROM pg_attribute
+          WHERE attrelid = 'catalog.record_embeddings'::regclass
+            AND attname = 'embedding';
+
+          IF cur_typmod = -1 THEN
+            -- Acquire the strongest lock up front: DELETE-then-ALTER would
+            -- otherwise escalate ROW EXCLUSIVE -> ACCESS EXCLUSIVE mid-flight,
+            -- a deadlock-prone pattern if anything is reading the table.
+            LOCK TABLE catalog.record_embeddings IN ACCESS EXCLUSIVE MODE;
+
+            -- Prefer the dimension of data already stored; fall back to the
+            -- embedding_dims persistent-config override, then the app default.
+            SELECT max(vector_dims(embedding)) INTO dims
+            FROM catalog.record_embeddings;
+            IF dims IS NULL THEN
+              -- PersistentConfig wraps scalars as {"v": <value>} (see
+              -- persistent_config.py set()); older/manual rows may hold a
+              -- bare number. Handle both shapes.
+              SELECT CASE jsonb_typeof(value)
+                       WHEN 'object' THEN (value #>> '{v}')::int
+                       WHEN 'number' THEN (value #>> '{}')::int
+                       ELSE NULL
+                     END
+              INTO dims
+              FROM catalog.app_settings WHERE key = 'embedding_dims';
+            END IF;
+            IF dims IS NULL OR dims < 1 THEN
+              dims := 1536;
+            END IF;
+
+            DELETE FROM catalog.record_embeddings
+            WHERE vector_dims(embedding) <> dims;
+
+            EXECUTE format(
+              'ALTER TABLE catalog.record_embeddings '
+              'ALTER COLUMN embedding TYPE vector(%s) USING embedding::vector(%s)',
+              dims, dims
+            );
+          END IF;
+
+          -- Same DDL the baseline and rebuild_embedding_column intend.
+          EXECUTE 'CREATE INDEX IF NOT EXISTS ix_record_embeddings_hnsw '
+                  'ON catalog.record_embeddings USING hnsw '
+                  '(embedding vector_cosine_ops) '
+                  'WITH (m = 16, ef_construction = 64)';
+        END $$;
+        """
+    )
+
+
+def downgrade() -> None:
+    # Back to the baseline shape: untyped column, no ANN index. Stored
+    # vectors survive the widening cast unchanged.
+    op.execute("DROP INDEX IF EXISTS catalog.ix_record_embeddings_hnsw")
+    op.execute(
+        "ALTER TABLE catalog.record_embeddings "
+        "ALTER COLUMN embedding TYPE vector USING embedding::vector"
+    )

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -164,6 +164,15 @@ class Settings(BaseSettings):
     # CONF-03 (Phase 277 / M-38): replaces raw os.environ.get("WORKER_SHUTDOWN_TIMEOUT") in worker.py
     worker_shutdown_timeout: int = 30
 
+    # fix(#448): Procrastinate parallel job slots per worker process. The
+    # implicit default of 1 head-of-line-blocked every queued upload behind a
+    # long COG conversion. 2-3 suits multi-core hosts; keep 1 on 2-vCPU boxes.
+    worker_concurrency: int = 1
+    # fix(#448): queues this worker listens to. Lets a deployment run a second
+    # worker service dedicated to e.g. WORKER_QUEUES=raster so long raster jobs
+    # never stall vector ingests.
+    worker_queues: str = "priority,ingest,raster"
+
     # CONF-04 (Phase 277 / M-39): replaces raw os.environ.get("ENV_ONLY_CONFIG") in core/public_urls.py
     # Security-relevant: when true, the PersistentConfig DB layer is bypassed for reads
     # and writes return 403. Keep in sync with .env.example.

--- a/backend/app/modules/catalog/search/service_semantic.py
+++ b/backend/app/modules/catalog/search/service_semantic.py
@@ -315,9 +315,9 @@ async def _run_rrf_merge(
     # EVERY stored embedding — a second full O(N)·dims vector scan per search
     # that no ANN index can serve (aggregate over a distance predicate).
     # Exact and cheap at today's catalog size; past the row gate, approximate
-    # the vector-only surplus from the vetted top-k ranks already in hand —
-    # a lower bound that is ≥ page_end-deep, so pagination `next` links
-    # survive while numberMatched may under-report distant tail matches.
+    # the vector-only surplus from the vetted top-k ranks already in hand.
+    # numberMatched becomes a lower bound (may under-report distant tail
+    # matches); a full-window sentinel below keeps `next` links alive.
     emb_rows = (
         await session.execute(
             select(func.count())
@@ -339,7 +339,17 @@ async def _run_rrf_merge(
         total += (await session.execute(new_count_stmt)).scalar_one()
     else:
         fts_id_set = set(fts_ids)
-        total += sum(1 for rid in vector_ranks if rid not in fts_id_set)
+        vector_only = sum(1 for rid in vector_ranks if rid not in fts_id_set)
+        # fix(#448, codex P2): a FULL top-k window means deeper matches may
+        # exist beyond what was fetched, but reporting exactly page_end as the
+        # total makes the router's `offset + limit < total` check suppress the
+        # rel="next" link on a semantic-only page. Report one past the window
+        # so paging continues; each deeper page fetches a deeper window until
+        # a non-full window yields the exact tail. Worst case the final next
+        # link lands on one empty page — acceptable for an approximation.
+        if len(vector_ranks) >= page_end:
+            vector_only += 1
+        total += vector_only
 
     rrf_ordered = _compute_rrf_scores(fts_ids, vector_ranks)
 

--- a/backend/app/modules/catalog/search/service_semantic.py
+++ b/backend/app/modules/catalog/search/service_semantic.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import time
 import uuid as uuid_mod
 from collections import OrderedDict
@@ -32,6 +33,11 @@ EmbeddingUnavailableError = get_catalog_port().embedding_unavailable_error_class
 # 300 seconds (matches audit recommendation), max 512 entries.
 _EMBEDDING_CACHE_TTL_SECONDS = 300.0
 _EMBEDDING_CACHE_MAX_SIZE = 512
+
+# fix(#448): above this many stored embeddings, _run_rrf_merge stops running
+# the exact vector-only match COUNT (a full cosine scan) and approximates
+# from the already-fetched top-k ranks instead.
+_EXACT_SEMANTIC_COUNT_MAX_ROWS = 5000
 _embedding_cache: "OrderedDict[tuple[str, str], tuple[float, list[float]]]" = (
     OrderedDict()
 )
@@ -65,6 +71,21 @@ def _embedding_cache_clear() -> None:
     _embedding_cache.clear()
 
 
+# fix(#448): this module embeds INSIDE a search request. The provider default
+# timeout (130s) is sized for background ingest/backfill; a hung embedding
+# provider must not hold a search request when _get_vector_ranks silently
+# falls back to FTS on any error. asyncio.wait_for (rather than a port
+# signature change) keeps enterprise CatalogPort overlays source-compatible.
+_QUERY_EMBED_TIMEOUT_SECONDS = 8.0
+
+
+async def _embed_with_deadline(text: str, session: AsyncSession) -> list[float]:
+    return await asyncio.wait_for(
+        get_catalog_port().generate_embedding(text, session),
+        timeout=_QUERY_EMBED_TIMEOUT_SECONDS,
+    )
+
+
 async def generate_embedding(text: str, session: AsyncSession) -> list[float]:
     """Generate an embedding through the configured CatalogPort provider.
 
@@ -75,7 +96,7 @@ async def generate_embedding(text: str, session: AsyncSession) -> list[float]:
     normalized = text.strip().lower()
     if not normalized:
         # Don't cache empty inputs — let the provider raise its usual error.
-        return await get_catalog_port().generate_embedding(text, session)
+        return await _embed_with_deadline(text, session)
 
     model_name = await EMBEDDING_MODEL.get(session)
     cache_key = (normalized, model_name)
@@ -84,7 +105,7 @@ async def generate_embedding(text: str, session: AsyncSession) -> list[float]:
     if cached is not None:
         return cached
 
-    vector = await get_catalog_port().generate_embedding(text, session)
+    vector = await _embed_with_deadline(text, session)
     _embedding_cache_put(cache_key, vector)
     return vector
 
@@ -290,17 +311,35 @@ async def _run_rrf_merge(
     )
     model_name = await EMBEDDING_MODEL.get(session)
     RecordEmbedding = get_catalog_port().record_embedding_orm_class()
-    new_count_stmt = (
-        select(func.count())
-        .select_from(RecordEmbedding)
-        .where(
-            RecordEmbedding.model_name == model_name,
-            RecordEmbedding.embedding.cosine_distance(query_vector) <= 0.7,
-            RecordEmbedding.record_id.in_(vet_stmt),
-            RecordEmbedding.record_id.notin_(fts_match_subq),
+    # fix(#448): the exact COUNT below re-computes cosine distance against
+    # EVERY stored embedding — a second full O(N)·dims vector scan per search
+    # that no ANN index can serve (aggregate over a distance predicate).
+    # Exact and cheap at today's catalog size; past the row gate, approximate
+    # the vector-only surplus from the vetted top-k ranks already in hand —
+    # a lower bound that is ≥ page_end-deep, so pagination `next` links
+    # survive while numberMatched may under-report distant tail matches.
+    emb_rows = (
+        await session.execute(
+            select(func.count())
+            .select_from(RecordEmbedding)
+            .where(RecordEmbedding.model_name == model_name)
         )
-    )
-    total += (await session.execute(new_count_stmt)).scalar_one()
+    ).scalar_one()
+    if emb_rows <= _EXACT_SEMANTIC_COUNT_MAX_ROWS:
+        new_count_stmt = (
+            select(func.count())
+            .select_from(RecordEmbedding)
+            .where(
+                RecordEmbedding.model_name == model_name,
+                RecordEmbedding.embedding.cosine_distance(query_vector) <= 0.7,
+                RecordEmbedding.record_id.in_(vet_stmt),
+                RecordEmbedding.record_id.notin_(fts_match_subq),
+            )
+        )
+        total += (await session.execute(new_count_stmt)).scalar_one()
+    else:
+        fts_id_set = set(fts_ids)
+        total += sum(1 for rid in vector_ranks if rid not in fts_id_set)
 
     rrf_ordered = _compute_rrf_scores(fts_ids, vector_ranks)
 

--- a/backend/app/platform/extensions/defaults.py
+++ b/backend/app/platform/extensions/defaults.py
@@ -1017,12 +1017,17 @@ class DefaultAnthropicProvider:
         del temperature  # rejected by Claude 4.6+; kept in signature for callers
         # Deferred imports (Phase 214 discipline)
         import json
+        import time
 
         import structlog
         from anthropic import AsyncAnthropic
 
         from app.core.config import reveal, settings
-        from app.processing.ai.constants import MAX_TOOL_ROUNDS
+        from app.processing.ai.constants import (
+            MAX_REQUEST_TOKEN_BUDGET,
+            MAX_STREAMING_WALL_CLOCK_SECONDS,
+            MAX_TOOL_ROUNDS,
+        )
         from app.processing.ai.llm_loop import (
             ToolLoopExhaustedError,
             ToolLoopResult,
@@ -1064,8 +1069,19 @@ class DefaultAnthropicProvider:
         collected_actions: list[dict] = []
         total_input = 0
         total_output = 0
+        # fix(#448): mirror the streaming path's PERF-009 runaway guards — the
+        # blocking tool loop (map-gen and friends) previously had neither a
+        # wall-clock deadline nor a cumulative token cap, so a pathological
+        # tool loop could burn budget until max_rounds.
+        deadline = time.monotonic() + MAX_STREAMING_WALL_CLOCK_SECONDS
 
         for round_num in range(max_rounds):
+            if time.monotonic() > deadline:
+                raise ToolLoopExhaustedError("LLM tool loop exceeded wall-clock budget")
+            if total_input + total_output > MAX_REQUEST_TOKEN_BUDGET:
+                raise ToolLoopExhaustedError(
+                    "LLM tool loop exceeded request token budget"
+                )
             # Anthropic API rejects `tools=[]` with 400 BadRequestError
             # ("tools: must have at least 1 item"). Omit the kwarg entirely
             # for no-tools paths (sql_generator.generate_sql,
@@ -1262,13 +1278,18 @@ class DefaultOpenAICompatibleProvider:
     ):
         # Deferred imports (Phase 214 discipline)
         import json
+        import time
 
         import structlog
         from openai import AsyncOpenAI
 
         from app.core.ai_credentials import bind_openai_credential_base_url
         from app.core.config import reveal, settings
-        from app.processing.ai.constants import MAX_TOOL_ROUNDS
+        from app.processing.ai.constants import (
+            MAX_REQUEST_TOKEN_BUDGET,
+            MAX_STREAMING_WALL_CLOCK_SECONDS,
+            MAX_TOOL_ROUNDS,
+        )
         from app.processing.ai.llm_loop import (
             ToolLoopExhaustedError,
             ToolLoopResult,
@@ -1321,8 +1342,17 @@ class DefaultOpenAICompatibleProvider:
         collected_actions: list[dict] = []
         total_input = 0
         total_output = 0
+        # fix(#448): same PERF-009 runaway guards as the Anthropic complete()
+        # loop above — see that comment.
+        deadline = time.monotonic() + MAX_STREAMING_WALL_CLOCK_SECONDS
 
         for round_num in range(max_rounds):
+            if time.monotonic() > deadline:
+                raise ToolLoopExhaustedError("LLM tool loop exceeded wall-clock budget")
+            if total_input + total_output > MAX_REQUEST_TOKEN_BUDGET:
+                raise ToolLoopExhaustedError(
+                    "LLM tool loop exceeded request token budget"
+                )
             # OpenAI API rejects `tools=[]` similarly. Omit when empty so
             # no-tools paths (sql_generator.generate_sql, _retry_parse_map_spec)
             # work for OpenAI-compatible providers too. REVIEW.md CR-01.

--- a/backend/app/platform/jobs/worker.py
+++ b/backend/app/platform/jobs/worker.py
@@ -229,9 +229,15 @@ async def main() -> None:
     try:
         # 6. Run Procrastinate worker
         shutdown_timeout = settings.worker_shutdown_timeout
+        # fix(#448): concurrency was implicitly 1 (Procrastinate default), so a
+        # single long COG conversion head-of-line-blocked every queued upload
+        # across all three queues. Both knobs are env-configurable; a second
+        # worker service can pin WORKER_QUEUES=raster on multi-core hosts.
+        queues = [q.strip() for q in settings.worker_queues.split(",") if q.strip()]
         async with task_app.open_async():
             await task_app.run_worker_async(
-                queues=["priority", "ingest", "raster"],
+                queues=queues,
+                concurrency=settings.worker_concurrency,
                 listen_notify=not settings.db_use_external_pooler,
                 install_signal_handlers=True,
                 delete_jobs="successful",

--- a/backend/app/processing/ai/sql_generator.py
+++ b/backend/app/processing/ai/sql_generator.py
@@ -148,20 +148,18 @@ def build_sql_schema_context(
     return result
 
 
-def build_sql_generation_prompt(
+def build_sql_user_message(
     question: str, schema_context: str, layer_descriptions: str | None = None
 ) -> str:
-    """Build the complete system prompt for the SQL generation LLM call.
+    """Build the per-call (dynamic) user message for the SQL generation call.
 
-    Includes schema context, PostGIS function reference, geography cast
-    templates, example queries, and constraints.
-
-    Args:
-        question: The user's natural language question.
-        schema_context: DDL schema context from build_sql_schema_context().
-
-    Returns:
-        Complete prompt string for the SQL generation LLM.
+    fix(#448): the schema DDL and the question used to be interpolated into
+    the SYSTEM prompt together with the ~3K-token static PostGIS reference,
+    so the Anthropic cache_control breakpoint never saw a stable prefix —
+    every query_data call paid a full cache miss on the app's largest prompt,
+    and the question was billed twice (it was also sent as the user message).
+    Static reference lives in SQL_SYSTEM_PROMPT (cacheable); everything
+    per-call goes here.
     """
     layer_context = ""
     if layer_descriptions:
@@ -172,12 +170,20 @@ def build_sql_generation_prompt(
 """
 
     return f"""\
-You are a PostgreSQL/PostGIS SQL expert. Generate a single SELECT query to answer the user's question using the provided database schema.
-
 ## Available Tables
 
 {schema_context}
 {layer_context}
+## Question
+
+{question}
+
+Respond with ONLY the SQL query (or an -- ERROR comment if the query cannot be generated). No explanation, no markdown, no code fences."""
+
+
+SQL_SYSTEM_PROMPT = """\
+You are a PostgreSQL/PostGIS SQL expert. Generate a single SELECT query to answer the user's question using the database schema provided in the user message.
+
 ## PostGIS Spatial Functions
 
 ST_Intersects(geomA, geomB) -> boolean    -- True if geometries share any space
@@ -367,19 +373,14 @@ LIMIT 10;
 - For ad-hoc coordinate queries, create points with: ST_SetSRID(ST_MakePoint(longitude, latitude), 4326)::geography
 - For case-insensitive text matching, use ILIKE (e.g., WHERE name ILIKE 'california').
 - Always include LIMIT 1000 unless the query is an aggregation (GROUP BY, COUNT, SUM, etc.).
-- Use ONLY the tables and columns shown in the schema above. Do not invent names.
+- Use ONLY the tables and columns shown in the provided schema. Do not invent names.
 - Use ONLY the functions and operators listed in the PostGIS, Text Search, and Vector Similarity sections above. Do not use functions not in this reference.
 - Vector columns (type vector(N)) are queried with the <->/<=>/<#> operators, NOT with similarity() or ILIKE.
 - Queries are limited to 30 seconds. Prefer indexed operations (ST_DWithin) over unindexed scans (ST_Distance < X).
-- You may use CTEs (WITH clauses) and subqueries. All referenced tables must be from the schema above.
+- You may use CTEs (WITH clauses) and subqueries. All referenced tables must be from the provided schema.
 - If the question cannot be answered with the available schema, respond with: -- ERROR: Cannot answer this question with the available data.
 - If the question asks to modify, delete, or insert data, respond with: -- ERROR: Only SELECT queries are supported.
-
-## Question
-
-{question}
-
-Respond with ONLY the SQL query (or an -- ERROR comment if the query cannot be generated). No explanation, no markdown, no code fences."""
+"""
 
 
 async def generate_sql(
@@ -415,7 +416,10 @@ async def generate_sql(
     """
     provider = await LLM_PROVIDER.get(db)
     model = await LLM_MODEL_LIGHT.get(db)
-    prompt = build_sql_generation_prompt(
+    # fix(#448): static reference → system prompt (stable prefix, provider
+    # prompt-cacheable); schema + question → user message (sent once, not
+    # twice as before).
+    user_message = build_sql_user_message(
         question, schema_context, layer_descriptions=layer_descriptions
     )
 
@@ -439,8 +443,8 @@ async def generate_sql(
 
     result = await provider_ext.complete(
         model=model,
-        system_prompt=prompt,
-        user_message=question,
+        system_prompt=SQL_SYSTEM_PROMPT,
+        user_message=user_message,
         tools=[],
         tool_executor=_noop_executor,
         max_rounds=1,

--- a/backend/app/processing/embeddings/backfill.py
+++ b/backend/app/processing/embeddings/backfill.py
@@ -1,8 +1,10 @@
 """Backfill embeddings for records that don't have them yet.
 
-Processes all records missing a corresponding RecordEmbedding row,
-calling generate_and_store_embedding for each. Individual failures
-are logged and counted but do not halt the backfill.
+Processes all records missing a corresponding RecordEmbedding row.
+fix(#448): texts are embedded in batches of _BATCH_SIZE per provider call
+(the embeddings endpoint accepts input lists) instead of one call per
+record — a 50-200x reduction in API round trips on bulk backfills.
+Batch failures are logged and counted but do not halt the backfill.
 
 Can be run as a module: python -m app.embeddings.backfill
 """
@@ -10,11 +12,21 @@ Can be run as a module: python -m app.embeddings.backfill
 import structlog
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.core.persistent_config import AI_ENABLED, EMBEDDING_MODEL
 from app.platform.extensions import get_processing_port
 from app.processing.embeddings.models import RecordEmbedding
-from app.processing.embeddings.service import generate_and_store_embedding
+from app.processing.embeddings.service import (
+    build_content_text,
+    compute_content_hash,
+    generate_embeddings_batch,
+)
 
 logger = structlog.stdlib.get_logger(__name__)
+
+# fix(#448): texts per provider call. OpenAI accepts up to 2048 inputs per
+# request; 128 keeps request bodies modest for compatible providers (Ollama,
+# Groq, Together) while still collapsing a 10K-record backfill to ~80 calls.
+_BATCH_SIZE = 128
 
 
 async def backfill_embeddings(session: AsyncSession, *, force: bool = False) -> dict:
@@ -31,7 +43,7 @@ async def backfill_embeddings(session: AsyncSession, *, force: bool = False) -> 
     if force:
         from sqlalchemy import delete
 
-        # The HNSW index lives in Alembic migration 0001_baseline (and is recreated
+        # The HNSW index lives in Alembic migration 0012 (and is recreated
         # by service.rebuild_embedding_column on dimension change). On
         # force=True we just clear the rows; no need to drop the index.
         await session.execute(delete(RecordEmbedding))
@@ -56,54 +68,72 @@ async def backfill_embeddings(session: AsyncSession, *, force: bool = False) -> 
     ]
 
     total = len(record_data)
-    created = 0
-    errors = 0
-    skipped = 0
 
     if total == 0:
         logger.info("Backfill: no records without embeddings found")
         return {"processed": 0, "created": 0, "skipped": 0, "errors": 0}
 
-    logger.info("Backfill: starting", total_records=total)
+    # Gate once for the whole run (the per-record path checked this per call).
+    if not await AI_ENABLED.get(session):
+        logger.info("Backfill: AI disabled, skipping", total_records=total)
+        return {"processed": 0, "created": 0, "skipped": total, "errors": 0}
 
-    for i, rd in enumerate(record_data, 1):
+    model_name = await EMBEDDING_MODEL.get(session)
+
+    # Build embeddable (record_id, content_text) pairs; empty content skips.
+    skipped = 0
+    items: list[tuple[object, str]] = []
+    for rd in record_data:
+        content_text = build_content_text(
+            title=rd["title"],
+            summary=rd["summary"],
+            keywords=rd["keywords"],
+            lineage=rd["lineage"],
+        )
+        if not content_text:
+            skipped += 1
+            continue
+        items.append((rd["id"], content_text))
+
+    logger.info("Backfill: starting", total_records=total, batch_size=_BATCH_SIZE)
+
+    created = 0
+    errors = 0
+
+    for start in range(0, len(items), _BATCH_SIZE):
+        batch = items[start : start + _BATCH_SIZE]
         try:
-            stored = await generate_and_store_embedding(
-                session=session,
-                record_id=rd["id"],
-                title=rd["title"],
-                summary=rd["summary"],
-                keywords=rd["keywords"],
-                lineage=rd["lineage"],
+            vectors = await generate_embeddings_batch(
+                [content for _, content in batch], session
             )
-            if stored:
-                await session.commit()
-                created += 1
-            else:
-                await session.rollback()
-                skipped += 1
-        except Exception:  # broad: per-record backfill is isolated; embedding API/DB errors are counted not raised
+            for (record_id, content), vector in zip(batch, vectors):
+                session.add(
+                    RecordEmbedding(
+                        record_id=record_id,
+                        embedding=vector,
+                        model_name=model_name,
+                        content_hash=compute_content_hash(content),
+                    )
+                )
+            await session.commit()
+            created += len(batch)
+        except Exception:  # broad: per-batch backfill is isolated; embedding API/DB errors are counted not raised
             await session.rollback()
-            errors += 1
+            errors += len(batch)
             logger.warning(
-                "Backfill: error processing record",
-                record_id=str(rd["id"]),
+                "Backfill: error processing batch",
+                batch_start=start,
+                batch_size=len(batch),
                 exc_info=True,
             )
 
-        # Log progress every 10 records
-        if i % 10 == 0:
-            logger.info(
-                "Backfill progress",
-                processed=i,
-                total=total,
-                created=created,
-                errors=errors,
-            )
-
-    # The HNSW index is created by Alembic migration 0001_baseline (and by
-    # service.rebuild_embedding_column when the dimension is first set or
-    # changes). The backfill no longer needs to recreate it.
+        logger.info(
+            "Backfill progress",
+            processed=min(start + _BATCH_SIZE, len(items)),
+            total=len(items),
+            created=created,
+            errors=errors,
+        )
 
     processed = created + errors
     result_dict = {

--- a/backend/app/processing/embeddings/backfill.py
+++ b/backend/app/processing/embeddings/backfill.py
@@ -4,7 +4,8 @@ Processes all records missing a corresponding RecordEmbedding row.
 fix(#448): texts are embedded in batches of _BATCH_SIZE per provider call
 (the embeddings endpoint accepts input lists) instead of one call per
 record — a 50-200x reduction in API round trips on bulk backfills.
-Batch failures are logged and counted but do not halt the backfill.
+A failed batch is retried per record so a single rejected input doesn't
+sink its batchmates; only the individually-failing records count as errors.
 
 Can be run as a module: python -m app.embeddings.backfill
 """
@@ -119,13 +120,36 @@ async def backfill_embeddings(session: AsyncSession, *, force: bool = False) -> 
             created += len(batch)
         except Exception:  # broad: per-batch backfill is isolated; embedding API/DB errors are counted not raised
             await session.rollback()
-            errors += len(batch)
             logger.warning(
-                "Backfill: error processing batch",
+                "Backfill: batch failed, retrying records individually",
                 batch_start=start,
                 batch_size=len(batch),
                 exc_info=True,
             )
+            # fix(#449, codex P2): one rejected input (e.g. a record over the
+            # model's token limit) must not sink the other 127 — retry the
+            # failed batch per record so only the bad ones count as errors.
+            for record_id, content in batch:
+                try:
+                    [vector] = await generate_embeddings_batch([content], session)
+                    session.add(
+                        RecordEmbedding(
+                            record_id=record_id,
+                            embedding=vector,
+                            model_name=model_name,
+                            content_hash=compute_content_hash(content),
+                        )
+                    )
+                    await session.commit()
+                    created += 1
+                except Exception:  # broad: same isolation, per record
+                    await session.rollback()
+                    errors += 1
+                    logger.warning(
+                        "Backfill: error processing record",
+                        record_id=record_id,
+                        exc_info=True,
+                    )
 
         logger.info(
             "Backfill progress",

--- a/backend/app/processing/embeddings/service.py
+++ b/backend/app/processing/embeddings/service.py
@@ -148,7 +148,9 @@ async def rebuild_embedding_column(db: AsyncSession, new_dims: int) -> bool:
     """Resize the embedding column to new_dims if it currently differs.
 
     Deletes all existing embeddings, drops the HNSW index, alters the column
-    type, then recreates the index. Commits on success; rolls back on failure.
+    type, then recreates the index (skipped above pgvector's 2000-dim HNSW
+    limit — the column stays unindexed and searches use exact scans).
+    Commits on success; rolls back on failure.
 
     DBM-07 (Phase 271): The HNSW DDL is also issued by migration 0001_baseline for
     fresh-install / migrated-up environments. This function handles the
@@ -189,13 +191,22 @@ async def rebuild_embedding_column(db: AsyncSession, new_dims: int) -> bool:
                 f"USING embedding::vector({new_dims})"
             )
         )
-        await db.execute(
-            sa_text(
-                "CREATE INDEX ix_record_embeddings_hnsw "
-                "ON catalog.record_embeddings USING hnsw (embedding vector_cosine_ops) "
-                "WITH (m=16, ef_construction=64)"
+        if new_dims <= 2000:
+            await db.execute(
+                sa_text(
+                    "CREATE INDEX ix_record_embeddings_hnsw "
+                    "ON catalog.record_embeddings USING hnsw (embedding vector_cosine_ops) "
+                    "WITH (m=16, ef_construction=64)"
+                )
             )
-        )
+        else:
+            # fix(#449, codex P1): pgvector rejects HNSW on vector columns over
+            # 2000 dims; leave the column unindexed (exact-scan fallback)
+            # instead of failing the whole dimension change.
+            logger.warning(
+                "Skipping HNSW index: %s dims exceeds pgvector's 2000-dim limit",
+                new_dims,
+            )
         await db.commit()
     except Exception:  # broad: DDL (DROP INDEX, ALTER COLUMN) can fail for schema/lock reasons; re-raise to caller
         await db.rollback()

--- a/backend/app/processing/embeddings/service.py
+++ b/backend/app/processing/embeddings/service.py
@@ -30,12 +30,36 @@ async def generate_embedding(text: str, session: AsyncSession) -> list[float]:
     Model, dimensions, and base URL are read from PersistentConfig and the
     EmbeddingProviderExtension's resolve_runtime_config (Phase 231 D-21).
 
+    The 130s provider timeout suits background paths (ingest, backfill);
+    request-hot-path callers (semantic search) wrap this call in a short
+    ``asyncio.wait_for`` instead — see service_semantic (fix #448).
+
     Args:
         text: The text to embed.
         session: Database session for reading PersistentConfig values.
 
     Returns:
         A list of floats representing the embedding vector.
+
+    Raises:
+        EmbeddingUnavailableError: If no OpenAI-compatible API key is configured.
+    """
+    vectors = await generate_embeddings_batch([text], session)
+    return vectors[0]
+
+
+async def generate_embeddings_batch(
+    texts: list[str], session: AsyncSession
+) -> list[list[float]]:
+    """Generate embedding vectors for many texts in ONE provider call.
+
+    fix(#448): the backfill previously embedded one record per API call even
+    though the provider accepts input lists. Callers chunk to a sane batch
+    size (backfill uses 128; the OpenAI endpoint accepts up to 2048 inputs).
+    Config resolution and retry semantics are identical to the single-text
+    path — generate_embedding() delegates here with a one-element list.
+
+    Returns vectors in the same order as ``texts``.
 
     Raises:
         EmbeddingUnavailableError: If no OpenAI-compatible API key is configured.
@@ -56,28 +80,27 @@ async def generate_embedding(text: str, session: AsyncSession) -> list[float]:
     dims = await EMBEDDING_DIMS.get(session) or runtime_config.get("default_dims")
     base_url = runtime_config.get("base_url")
 
-    # Truncate very long input
-    if len(text) > _MAX_INPUT_CHARS:
-        text = text[:_MAX_INPUT_CHARS]
+    # Truncate very long inputs
+    texts = [t[:_MAX_INPUT_CHARS] if len(t) > _MAX_INPUT_CHARS else t for t in texts]
 
     logger.info(
-        "Generating embedding",
+        "Generating embeddings",
         model=model,
         dimensions=dims,
-        text_length=len(text),
+        batch_size=len(texts),
+        text_length=sum(len(t) for t in texts),
     )
 
     # Phase 231 D-22: retry/backoff lives in DefaultOpenAIEmbeddingProvider.embed().
     # The provider raises EmbeddingUnavailableError on terminal failure (no
     # service-level retry needed — single source of truth).
-    vectors = await provider_ext.embed(
-        texts=[text],
+    return await provider_ext.embed(
+        texts=texts,
         model=model,
         dimensions=dims,
         base_url=base_url,
         timeout=130.0,
     )
-    return vectors[0]
 
 
 async def probe_embedding_dimensions(session: AsyncSession) -> int:

--- a/backend/app/processing/ingest/metadata.py
+++ b/backend/app/processing/ingest/metadata.py
@@ -1141,12 +1141,7 @@ async def add_4326_column(
             text(f"UPDATE {tref} SET geom_4326 = ST_Force2D(ST_Transform(geom, 4326))")
         )
 
-    await session.execute(
-        text(
-            f"CREATE INDEX IF NOT EXISTS idx_{table_name}_geom_4326 "
-            f"ON {tref} USING GIST (geom_4326)"
-        )
-    )
+    await ensure_geom_4326_gist_index(session, table_name)
 
     # DBM-05 (Phase 271): the previously-created `idx_<table>_gid` btree
     # was redundant with the PK btree on `gid SERIAL PRIMARY KEY`. Removed
@@ -1157,6 +1152,50 @@ async def add_4326_column(
     # (_finalize_ingest at tasks_common.py:821) owns the phase-2 commit
     # boundary so a downstream failure rolls back the ALTER + UPDATE +
     # CREATE INDEX above atomically.
+
+
+async def ensure_geom_4326_gist_index(
+    session: AsyncSession, table_name: str, *, schema: str = "data"
+) -> None:
+    """Create the GIST index on geom_4326 if this table doesn't have one.
+
+    fix(#448): the previous ``CREATE INDEX IF NOT EXISTS idx_<table>_geom_4326``
+    matched by NAME schema-wide, not per-table. On a second re-ingest the
+    previous swap's index (created against ``<table>_staging`` and carried
+    along by the RENAME) still held that name, so the new staging table
+    silently got NO spatial index — and the swap then dropped the only
+    indexed copy of the data. Check ``pg_indexes`` for a gist index on THIS
+    table instead, and let PostgreSQL pick a collision-free index name.
+    Called from both add_4326_column (staging load) and _apply_reupload_swap
+    (post-swap belt-and-braces), so any re-ingest self-heals a missing index.
+
+    No-op when the table has no geom_4326 column: a dataset can carry a
+    geometry_type while only exposing the native ``geom`` column (the
+    effective_srid=None staging path skips add_4326_column).
+    """
+    has_col = await session.execute(
+        text(
+            "SELECT 1 FROM information_schema.columns "
+            "WHERE table_schema = :schema AND table_name = :tn "
+            "AND column_name = 'geom_4326'"
+        ).bindparams(schema=schema, tn=table_name)
+    )
+    if has_col.first() is None:
+        return
+
+    has_gist = await session.execute(
+        text(
+            "SELECT 1 FROM pg_indexes "
+            "WHERE schemaname = :schema AND tablename = :tn "
+            "AND indexdef LIKE '%USING gist (geom_4326)%'"
+        ).bindparams(schema=schema, tn=table_name)
+    )
+    if has_gist.first() is None:
+        await session.execute(
+            text(
+                f"CREATE INDEX ON {_qtable(table_name, schema)} USING GIST (geom_4326)"
+            )
+        )
 
 
 async def grant_reader_access(

--- a/backend/app/processing/ingest/tasks_common.py
+++ b/backend/app/processing/ingest/tasks_common.py
@@ -1378,6 +1378,15 @@ async def _apply_reupload_swap(
             retry_timeout_seconds=15,
         )
 
+    # fix(#448): belt-and-braces after the swap — the staging pipeline is
+    # responsible for the GIST index, but a re-ingest of a table that already
+    # lost its index (the IF-NOT-EXISTS name-collision regression) must
+    # self-heal here rather than serve full-scan tiles until the next audit.
+    if metadata.get("geometry_type") is not None:
+        from app.processing.ingest.metadata import ensure_geom_4326_gist_index
+
+        await ensure_geom_4326_gist_index(session, table_name, schema=_tenant_schema)
+
     # Update dataset metadata in the same transaction as swap
     dataset.srid = metadata["srid"]
     dataset.geometry_type = metadata["geometry_type"]

--- a/backend/app/processing/ingest/tasks_raster.py
+++ b/backend/app/processing/ingest/tasks_raster.py
@@ -9,6 +9,7 @@ import structlog
 from app.core.db.tenant_session import tenant_task
 from app.platform.cache.tiles import invalidate_catalog_cache
 from app.processing.raster.cog import (
+    _scratch_dir,
     check_and_prepare_cog,
     check_cog_compliance,
     extract_raster_metadata,
@@ -455,7 +456,11 @@ async def ingest_raster(job_id: str, file_path: str, user_id: str, **kwargs) -> 
             # can produce output up to ~3× source size (decompressed + tiled +
             # overviews); a stretched disk crashes here with opaque IOError and
             # may leave concurrent ingests in a half-converted state.
-            tmp_dir = tempfile.mkdtemp()
+            # fix(#448): mkdtemp() defaulted to /tmp — a 512 MB RAM-backed
+            # tmpfs in the worker container — so the disk-space check below
+            # was measuring the wrong filesystem AND a big conversion could
+            # ENOSPC or eat the memory cap. Land it on the staging volume.
+            tmp_dir = tempfile.mkdtemp(dir=_scratch_dir())
             source_bytes = os.path.getsize(file_path)
             free_bytes = shutil.disk_usage(tmp_dir).free
             min_free = source_bytes * 3

--- a/backend/app/processing/raster/cog.py
+++ b/backend/app/processing/raster/cog.py
@@ -15,6 +15,23 @@ def _is_float_dtype(dtype: str) -> bool:
     return any(f in dtype.lower() for f in _FLOAT_DTYPES)
 
 
+def _scratch_dir() -> str | None:
+    """Directory for COG temp copies (fix #448).
+
+    tempfile's default lands in /tmp — a 512 MB RAM-backed tmpfs in the
+    worker container — so a large raster both eats the memory cap and can
+    ENOSPC mid-conversion. Prefer the upload_staging volume (disk-backed,
+    shared mount). None falls back to the tempfile default for host runs
+    and tests where the staging dir doesn't exist.
+    """
+    from pathlib import Path as _Path
+
+    from app.core.config import settings
+
+    staging = settings.upload_staging_dir
+    return staging if _Path(staging).is_dir() else None
+
+
 def validate_raster_crs(file_path: str) -> None:
     """Raise ValueError if the raster file has no valid CRS."""
     import rasterio
@@ -187,7 +204,7 @@ def prepare_with_overviews(
     import shutil
 
     suffix = Path(input_path).suffix
-    tmp = tempfile.NamedTemporaryFile(suffix=suffix, delete=False)
+    tmp = tempfile.NamedTemporaryFile(suffix=suffix, delete=False, dir=_scratch_dir())
     tmp.close()
     tmp_path = tmp.name
 
@@ -273,7 +290,9 @@ def convert_to_cog(
     # If CRS assignment requested, prepend a gdalwarp step
     warp_tmp: str | None = None
     if assign_crs is not None:
-        warp_tmp_file = tempfile.NamedTemporaryFile(suffix=".tif", delete=False)
+        warp_tmp_file = tempfile.NamedTemporaryFile(
+            suffix=".tif", delete=False, dir=_scratch_dir()
+        )
         warp_tmp_file.close()
         warp_tmp = warp_tmp_file.name
         warp_cmd = [

--- a/backend/tests/test_ai_provider_extension.py
+++ b/backend/tests/test_ai_provider_extension.py
@@ -173,3 +173,46 @@ async def test_overlay_provider_is_dispatched():
         assert isinstance(
             get_ai_provider("openai_compatible"), DefaultOpenAICompatibleProvider
         )
+
+
+@pytest.mark.asyncio
+async def test_anthropic_complete_aborts_at_token_budget():
+    """fix(#448): the non-streaming tool loop must stop once cumulative
+    input+output tokens exceed MAX_REQUEST_TOKEN_BUDGET (PERF-009 parity with
+    the streaming path). A tool_use round that reports a huge usage makes the
+    next round-top guard raise instead of calling the provider again."""
+    from unittest.mock import AsyncMock
+
+    from app.core.config import settings
+    from app.platform.extensions.defaults import DefaultAnthropicProvider
+    from app.processing.ai.llm_loop import ToolLoopExhaustedError
+
+    response = MagicMock()
+    response.stop_reason = "tool_use"
+    response.usage.input_tokens = 300_000  # > MAX_REQUEST_TOKEN_BUDGET (200K)
+    response.usage.output_tokens = 0
+    response.content = []
+
+    fake_client = MagicMock()
+    fake_client.messages.create = AsyncMock(return_value=response)
+
+    provider = DefaultAnthropicProvider()
+    original_client = DefaultAnthropicProvider._client
+    DefaultAnthropicProvider._client = fake_client
+    try:
+        with patch.object(settings, "anthropic_api_key", "test-key"):
+            with pytest.raises(ToolLoopExhaustedError, match="token budget"):
+                await provider.complete(
+                    model="test-model",
+                    system_prompt="s",
+                    user_message="u",
+                    tools=[],
+                    tool_executor=AsyncMock(return_value={}),
+                    max_rounds=5,
+                    max_tokens=128,
+                )
+    finally:
+        DefaultAnthropicProvider._client = original_client
+
+    # Round 1 ran (and reported the runaway usage); round 2 was refused.
+    assert fake_client.messages.create.await_count == 1

--- a/backend/tests/test_embedding_backfill.py
+++ b/backend/tests/test_embedding_backfill.py
@@ -1,10 +1,12 @@
 """Tests for embedding backfill: backfill_embeddings processes records without
-embeddings, handles errors gracefully, and returns progress counts.
+embeddings in provider batches (fix #448), handles errors gracefully, and
+returns progress counts.
 
 Unit tests using mocks -- no running database required.
 """
 
 import uuid
+from contextlib import ExitStack
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -35,10 +37,28 @@ def _make_query_result(records):
     return result
 
 
+def _patch_backfill_gates(stack: ExitStack, *, ai_enabled=True):
+    """Patch the run-level PersistentConfig gates the backfill reads once."""
+    from app.processing.embeddings import backfill as backfill_module
+
+    stack.enter_context(
+        patch.object(
+            backfill_module.AI_ENABLED, "get", AsyncMock(return_value=ai_enabled)
+        )
+    )
+    stack.enter_context(
+        patch.object(
+            backfill_module.EMBEDDING_MODEL,
+            "get",
+            AsyncMock(return_value="test-model"),
+        )
+    )
+
+
 class TestBackfillEmbeddings:
     @pytest.mark.asyncio
-    async def test_processes_records_without_embeddings(self):
-        """Records without embeddings should be processed via generate_and_store_embedding."""
+    async def test_processes_records_in_one_batch(self):
+        """Records without embeddings are embedded in a single provider call."""
         from app.processing.embeddings.backfill import backfill_embeddings
 
         r1 = _make_record(title="Dataset A")
@@ -47,21 +67,27 @@ class TestBackfillEmbeddings:
         session = AsyncMock()
         session.execute = AsyncMock(return_value=_make_query_result([r1, r2]))
 
-        with patch(
-            "app.processing.embeddings.backfill.generate_and_store_embedding",
-            new_callable=AsyncMock,
-        ) as mock_gen:
-            mock_gen.return_value = True
+        with ExitStack() as stack:
+            _patch_backfill_gates(stack)
+            mock_batch = stack.enter_context(
+                patch(
+                    "app.processing.embeddings.backfill.generate_embeddings_batch",
+                    new_callable=AsyncMock,
+                )
+            )
+            mock_batch.return_value = [[0.1] * 3, [0.2] * 3]
             result = await backfill_embeddings(session)
 
-        assert mock_gen.call_count == 2
+        # fix(#448): both records ride ONE provider call, not one call each.
+        assert mock_batch.call_count == 1
         assert result["processed"] == 2
         assert result["created"] == 2
         assert result["errors"] == 0
+        assert session.add.call_count == 2
 
     @pytest.mark.asyncio
-    async def test_individual_errors_do_not_stop_backfill(self):
-        """If one record fails, the backfill should continue to the next."""
+    async def test_batch_errors_do_not_stop_backfill(self):
+        """If one batch fails, the backfill should continue to the next."""
         from app.processing.embeddings.backfill import backfill_embeddings
 
         r1 = _make_record(title="Fails")
@@ -70,11 +96,19 @@ class TestBackfillEmbeddings:
         session = AsyncMock()
         session.execute = AsyncMock(return_value=_make_query_result([r1, r2]))
 
-        with patch(
-            "app.processing.embeddings.backfill.generate_and_store_embedding",
-            new_callable=AsyncMock,
-        ) as mock_gen:
-            mock_gen.side_effect = [RuntimeError("API error"), True]
+        with ExitStack() as stack:
+            _patch_backfill_gates(stack)
+            # Force one record per batch so the two records land in two batches.
+            stack.enter_context(
+                patch("app.processing.embeddings.backfill._BATCH_SIZE", 1)
+            )
+            mock_batch = stack.enter_context(
+                patch(
+                    "app.processing.embeddings.backfill.generate_embeddings_batch",
+                    new_callable=AsyncMock,
+                )
+            )
+            mock_batch.side_effect = [RuntimeError("API error"), [[0.1] * 3]]
             result = await backfill_embeddings(session)
 
         assert result["processed"] == 2
@@ -89,37 +123,60 @@ class TestBackfillEmbeddings:
         session = AsyncMock()
         session.execute = AsyncMock(return_value=_make_query_result([]))
 
-        with patch(
-            "app.processing.embeddings.backfill.generate_and_store_embedding",
-            new_callable=AsyncMock,
-        ):
-            result = await backfill_embeddings(session)
+        result = await backfill_embeddings(session)
 
         assert result == {"processed": 0, "created": 0, "skipped": 0, "errors": 0}
 
     @pytest.mark.asyncio
-    async def test_skips_when_generate_returns_false(self):
-        """When generate_and_store_embedding returns False, record counts as skipped."""
+    async def test_skips_records_with_empty_content(self):
+        """Records whose metadata builds no content text count as skipped."""
         from app.processing.embeddings.backfill import backfill_embeddings
 
-        r1 = _make_record(title="Skipped")
+        r1 = _make_record(title=None)
 
         session = AsyncMock()
         session.execute = AsyncMock(return_value=_make_query_result([r1]))
 
-        with patch(
-            "app.processing.embeddings.backfill.generate_and_store_embedding",
-            new_callable=AsyncMock,
-        ) as mock_gen:
-            mock_gen.return_value = False
+        with ExitStack() as stack:
+            _patch_backfill_gates(stack)
+            mock_batch = stack.enter_context(
+                patch(
+                    "app.processing.embeddings.backfill.generate_embeddings_batch",
+                    new_callable=AsyncMock,
+                )
+            )
             result = await backfill_embeddings(session)
 
+        assert mock_batch.call_count == 0
         assert result["processed"] == 0
         assert result["skipped"] == 1
 
     @pytest.mark.asyncio
+    async def test_skips_all_when_ai_disabled(self):
+        """AI_ENABLED=false short-circuits the run with everything skipped."""
+        from app.processing.embeddings.backfill import backfill_embeddings
+
+        r1 = _make_record(title="Dataset A")
+
+        session = AsyncMock()
+        session.execute = AsyncMock(return_value=_make_query_result([r1]))
+
+        with ExitStack() as stack:
+            _patch_backfill_gates(stack, ai_enabled=False)
+            mock_batch = stack.enter_context(
+                patch(
+                    "app.processing.embeddings.backfill.generate_embeddings_batch",
+                    new_callable=AsyncMock,
+                )
+            )
+            result = await backfill_embeddings(session)
+
+        assert mock_batch.call_count == 0
+        assert result == {"processed": 0, "created": 0, "skipped": 1, "errors": 0}
+
+    @pytest.mark.asyncio
     async def test_extracts_keyword_strings(self):
-        """Keywords should be extracted as strings from RecordKeyword objects."""
+        """Keywords should be extracted as strings into the embedded content."""
         from app.processing.embeddings.backfill import backfill_embeddings
 
         r1 = _make_record(title="With Keywords", keywords=["water", "hydrology"])
@@ -127,12 +184,17 @@ class TestBackfillEmbeddings:
         session = AsyncMock()
         session.execute = AsyncMock(return_value=_make_query_result([r1]))
 
-        with patch(
-            "app.processing.embeddings.backfill.generate_and_store_embedding",
-            new_callable=AsyncMock,
-        ) as mock_gen:
-            mock_gen.return_value = True
+        with ExitStack() as stack:
+            _patch_backfill_gates(stack)
+            mock_batch = stack.enter_context(
+                patch(
+                    "app.processing.embeddings.backfill.generate_embeddings_batch",
+                    new_callable=AsyncMock,
+                )
+            )
+            mock_batch.return_value = [[0.1] * 3]
             await backfill_embeddings(session)
 
-        call_kwargs = mock_gen.call_args[1]
-        assert call_kwargs["keywords"] == ["water", "hydrology"]
+        texts = mock_batch.call_args[0][0]
+        assert len(texts) == 1
+        assert "water, hydrology" in texts[0]

--- a/backend/tests/test_embedding_backfill.py
+++ b/backend/tests/test_embedding_backfill.py
@@ -108,12 +108,52 @@ class TestBackfillEmbeddings:
                     new_callable=AsyncMock,
                 )
             )
-            mock_batch.side_effect = [RuntimeError("API error"), [[0.1] * 3]]
+            # fix(#449): a failed batch is retried per record, so the failing
+            # single-record batch consumes TWO calls (batch, then retry).
+            mock_batch.side_effect = [
+                RuntimeError("API error"),
+                RuntimeError("API error"),
+                [[0.1] * 3],
+            ]
             result = await backfill_embeddings(session)
 
         assert result["processed"] == 2
         assert result["created"] == 1
         assert result["errors"] == 1
+
+    @pytest.mark.asyncio
+    async def test_failed_batch_retries_per_record(self):
+        """fix(#449, codex P2): one rejected input must not sink its batchmates —
+        the failed batch is retried per record and only the bad one errors."""
+        from app.processing.embeddings.backfill import backfill_embeddings
+
+        r1 = _make_record(title="Good")
+        r2 = _make_record(title="Too long for the model")
+
+        session = AsyncMock()
+        session.execute = AsyncMock(return_value=_make_query_result([r1, r2]))
+
+        with ExitStack() as stack:
+            _patch_backfill_gates(stack)
+            mock_batch = stack.enter_context(
+                patch(
+                    "app.processing.embeddings.backfill.generate_embeddings_batch",
+                    new_callable=AsyncMock,
+                )
+            )
+            # Batch call rejects; per-record retry succeeds for r1, fails for r2.
+            mock_batch.side_effect = [
+                RuntimeError("one input over the token limit"),
+                [[0.1] * 3],
+                RuntimeError("input over the token limit"),
+            ]
+            result = await backfill_embeddings(session)
+
+        assert mock_batch.call_count == 3
+        assert result["processed"] == 2
+        assert result["created"] == 1
+        assert result["errors"] == 1
+        assert session.add.call_count == 1
 
     @pytest.mark.asyncio
     async def test_returns_correct_counts(self):

--- a/backend/tests/test_embedding_vector_migration.py
+++ b/backend/tests/test_embedding_vector_migration.py
@@ -1,0 +1,185 @@
+"""Round-trip tests for 0012_type_embedding_vector (#449 codex findings).
+
+Tests
+-----
+A: with an empty table and EMBEDDING_DIMS=768, the migration types the column
+   vector(768) and builds the HNSW index (codex P2: the empty-table fallback
+   must honor the configured dimension, not a hardcoded 1536).
+B: with EMBEDDING_DIMS=3072 (legal config, over pgvector's 2000-dim HNSW
+   limit), the upgrade still exits 0, types the column vector(3072), and
+   skips the index instead of failing (codex P1).
+
+Notes
+-----
+- Shells out to ``alembic`` via subprocess (the real alembic.ini / env.py
+  stack) with EMBEDDING_DIMS injected into the subprocess env; observes
+  committed DDL through AUTOCOMMIT async queries.
+- Each test truncates catalog.record_embeddings first (embeddings are a
+  regenerable cache) to force the empty-table fallback, and restores the
+  default vector(1536) + index state in a finally block.
+- Run with:
+    cd backend && set -a && source ../.env.test && set +a
+    uv run pytest tests/test_embedding_vector_migration.py -x -q
+"""
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+import sqlalchemy as sa
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_BACKEND_DIR = Path(__file__).parent.parent.resolve()
+_ALEMBIC_INI = _BACKEND_DIR / "alembic.ini"
+
+_PRE_TYPED_REVISION = "0011_allow_generic_geometry_type"
+
+
+def _run_alembic(
+    *args: str, extra_env: dict | None = None
+) -> subprocess.CompletedProcess:
+    """Run an alembic command via subprocess against the test DB.
+
+    Uses the backend .venv python so the env matches what pytest runs with.
+    PYTHONPATH is set so env.py can ``from app.core.config import settings``.
+    """
+    import os
+
+    from app.core.config import settings
+
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(_BACKEND_DIR)
+    # Target the per-worker TEST DB (isolated + conftest-migrated to head) so the
+    # destructive downgrade/upgrade roundtrips never mutate the SHARED main DB
+    # (`postgres` on CI), which would corrupt sibling workers and the drift check.
+    env["POSTGRES_DB"] = settings.postgres_db_test
+    # The dims fallback under test reads these from the subprocess env; strip
+    # any ambient values so each call sees exactly what the test injects.
+    env.pop("EMBEDDING_DIMS", None)
+    env.pop("ENV_ONLY_CONFIG", None)
+    if extra_env:
+        env.update(extra_env)
+
+    return subprocess.run(
+        [sys.executable, "-m", "alembic", "-c", str(_ALEMBIC_INI), *args],
+        capture_output=True,
+        text=True,
+        env=env,
+        cwd=str(_BACKEND_DIR),
+    )
+
+
+async def _fresh_query(query: str):
+    """Run a query on a fresh AUTOCOMMIT connection, bypassing the test
+    transaction, so DDL committed by subprocess alembic is visible."""
+    from sqlalchemy.ext.asyncio import create_async_engine
+
+    from app.core.config import settings
+
+    engine = create_async_engine(
+        settings.test_database_url,
+        isolation_level="AUTOCOMMIT",
+    )
+    try:
+        async with engine.connect() as conn:
+            result = await conn.execute(sa.text(query))
+            return result.fetchall() if result.returns_rows else None
+    finally:
+        await engine.dispose()
+
+
+async def _embedding_column_type() -> str:
+    rows = await _fresh_query(
+        "SELECT format_type(atttypid, atttypmod) FROM pg_attribute "
+        "WHERE attrelid = 'catalog.record_embeddings'::regclass "
+        "AND attname = 'embedding'"
+    )
+    return rows[0][0]
+
+
+async def _hnsw_index_exists() -> bool:
+    rows = await _fresh_query(
+        "SELECT 1 FROM pg_indexes WHERE schemaname = 'catalog' "
+        "AND indexname = 'ix_record_embeddings_hnsw'"
+    )
+    return bool(rows)
+
+
+def _enterprise_migrations_present() -> bool:
+    """Multi-head under the enterprise overlay; see
+    test_dormant_tenancy_migration_roundtrip.py for the full rationale."""
+    import pathlib
+    from importlib.metadata import entry_points
+
+    for ep in entry_points(group="geolens.migrations"):
+        try:
+            fn = ep.load()
+            if callable(fn) and any(pathlib.Path(p).is_dir() for p in fn()):
+                return True
+        except Exception:
+            pass
+    return False
+
+
+_SKIP_UNDER_OVERLAY = pytest.mark.skipif(
+    _enterprise_migrations_present(),
+    reason="OSS migration test; multi-head under enterprise overlay — "
+    "runs in the no-overlay Pytest Parallel Isolation job instead.",
+)
+
+
+async def _retype_via_migration(dims: str) -> subprocess.CompletedProcess:
+    """Downgrade below 0012, empty the table, re-upgrade with EMBEDDING_DIMS set."""
+    r = _run_alembic("downgrade", _PRE_TYPED_REVISION)
+    assert r.returncode == 0, f"downgrade failed: {r.stderr}"
+    await _fresh_query("TRUNCATE catalog.record_embeddings")
+    await _fresh_query("DELETE FROM catalog.app_settings WHERE key = 'embedding_dims'")
+    return _run_alembic("upgrade", "head", extra_env={"EMBEDDING_DIMS": dims})
+
+
+async def _restore_default_head() -> None:
+    """Back to the suite's expected state: head, vector(1536), index present."""
+    r = _run_alembic("downgrade", _PRE_TYPED_REVISION)
+    assert r.returncode == 0, f"restore downgrade failed: {r.stderr}"
+    await _fresh_query("TRUNCATE catalog.record_embeddings")
+    r = _run_alembic("upgrade", "head")
+    assert r.returncode == 0, f"restore upgrade failed: {r.stderr}"
+    assert await _embedding_column_type() == "vector(1536)"
+    assert await _hnsw_index_exists()
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@_SKIP_UNDER_OVERLAY
+class TestEmbeddingVectorMigrationDims:
+    async def test_env_dims_honored_on_empty_table(self):
+        """fix(#449, codex P2): EMBEDDING_DIMS=768 types the column vector(768)."""
+        try:
+            r = await _retype_via_migration("768")
+            assert r.returncode == 0, f"upgrade failed: {r.stderr}"
+            assert await _embedding_column_type() == "vector(768)"
+            assert await _hnsw_index_exists(), "HNSW should exist at 768 dims"
+        finally:
+            await _restore_default_head()
+
+    async def test_large_dims_skip_hnsw_instead_of_failing(self):
+        """fix(#449, codex P1): 3072 dims types the column but skips HNSW
+        (pgvector rejects HNSW over 2000 dims) instead of failing the upgrade."""
+        try:
+            r = await _retype_via_migration("3072")
+            assert r.returncode == 0, (
+                f"upgrade must succeed at 3072 dims by skipping HNSW: {r.stderr}"
+            )
+            assert await _embedding_column_type() == "vector(3072)"
+            assert not await _hnsw_index_exists(), (
+                "HNSW must be skipped above pgvector's 2000-dim limit"
+            )
+        finally:
+            await _restore_default_head()

--- a/backend/tests/test_embedding_vector_migration.py
+++ b/backend/tests/test_embedding_vector_migration.py
@@ -11,6 +11,10 @@ B: with EMBEDDING_DIMS=3072 (legal config, over pgvector's 2000-dim HNSW
 C: with mixed-dimension rows (stale 1536-dim next to current 768-dim), the
    configured dimension wins over max(stored) and only the stale row is
    deleted (codex P2 round 4).
+D: explicit config beats UNIFORM stale rows too — all-512-dim rows with
+   EMBEDDING_DIMS=768 type the column vector(768) (codex P2 round 5).
+E: uniform stored rows beat only the built-in default — all-768-dim rows
+   with nothing configured keep their dimension and their rows.
 
 Notes
 -----
@@ -249,5 +253,46 @@ class TestEmbeddingVectorMigrationDims:
             assert await _embedding_column_type() == "vector(768)"
             rows = await _fresh_query("SELECT count(*) FROM catalog.record_embeddings")
             assert rows[0][0] == 1, "only the stale 1536-dim row should be deleted"
+        finally:
+            await _restore_default_head()
+
+    async def test_explicit_config_beats_uniform_stale_rows(self):
+        """fix(#449, codex P2 round 5): rows that ALL carry a superseded
+        model's dimension must not pin the column — explicit config wins."""
+        try:
+            r = _run_alembic("downgrade", _PRE_TYPED_REVISION)
+            assert r.returncode == 0, f"downgrade failed: {r.stderr}"
+            await _fresh_query("TRUNCATE catalog.record_embeddings")
+            await _fresh_query(
+                "DELETE FROM catalog.app_settings WHERE key = 'embedding_dims'"
+            )
+            await _insert_untyped_embedding_rows([512, 512])
+
+            r = _run_alembic("upgrade", "head", extra_env={"EMBEDDING_DIMS": "768"})
+            assert r.returncode == 0, f"upgrade failed: {r.stderr}"
+            assert await _embedding_column_type() == "vector(768)"
+            rows = await _fresh_query("SELECT count(*) FROM catalog.record_embeddings")
+            assert rows[0][0] == 0, "stale rows should be deleted, not kept"
+        finally:
+            await _restore_default_head()
+
+    async def test_uniform_stored_rows_beat_builtin_default(self):
+        """Uniform stored rows with nothing configured anywhere keep their
+        dimension — a local 768-dim model on default config must not have its
+        working rows deleted in favor of the built-in 1536."""
+        try:
+            r = _run_alembic("downgrade", _PRE_TYPED_REVISION)
+            assert r.returncode == 0, f"downgrade failed: {r.stderr}"
+            await _fresh_query("TRUNCATE catalog.record_embeddings")
+            await _fresh_query(
+                "DELETE FROM catalog.app_settings WHERE key = 'embedding_dims'"
+            )
+            await _insert_untyped_embedding_rows([768, 768])
+
+            r = _run_alembic("upgrade", "head")
+            assert r.returncode == 0, f"upgrade failed: {r.stderr}"
+            assert await _embedding_column_type() == "vector(768)"
+            rows = await _fresh_query("SELECT count(*) FROM catalog.record_embeddings")
+            assert rows[0][0] == 2, "agreeing rows must survive the retype"
         finally:
             await _restore_default_head()

--- a/backend/tests/test_embedding_vector_migration.py
+++ b/backend/tests/test_embedding_vector_migration.py
@@ -15,6 +15,9 @@ D: explicit config beats UNIFORM stale rows too — all-512-dim rows with
    EMBEDDING_DIMS=768 type the column vector(768) (codex P2 round 5).
 E: uniform stored rows beat only the built-in default — all-768-dim rows
    with nothing configured keep their dimension and their rows.
+F: a deliberate EMBEDDING_DIMS=1536 (equal to the default) still counts as
+   explicit and beats uniform stale 768-dim rows (codex P2 round 7 —
+   detected via pydantic's model_fields_set, not a value comparison).
 
 Notes
 -----
@@ -294,5 +297,26 @@ class TestEmbeddingVectorMigrationDims:
             assert await _embedding_column_type() == "vector(768)"
             rows = await _fresh_query("SELECT count(*) FROM catalog.record_embeddings")
             assert rows[0][0] == 2, "agreeing rows must survive the retype"
+        finally:
+            await _restore_default_head()
+
+    async def test_explicit_default_value_still_beats_stored_rows(self):
+        """fix(#449, codex P2 round 7): EMBEDDING_DIMS=1536 set deliberately
+        equals the class default, but presence (model_fields_set) makes it
+        explicit — it must beat uniform stale 768-dim rows."""
+        try:
+            r = _run_alembic("downgrade", _PRE_TYPED_REVISION)
+            assert r.returncode == 0, f"downgrade failed: {r.stderr}"
+            await _fresh_query("TRUNCATE catalog.record_embeddings")
+            await _fresh_query(
+                "DELETE FROM catalog.app_settings WHERE key = 'embedding_dims'"
+            )
+            await _insert_untyped_embedding_rows([768, 768])
+
+            r = _run_alembic("upgrade", "head", extra_env={"EMBEDDING_DIMS": "1536"})
+            assert r.returncode == 0, f"upgrade failed: {r.stderr}"
+            assert await _embedding_column_type() == "vector(1536)"
+            rows = await _fresh_query("SELECT count(*) FROM catalog.record_embeddings")
+            assert rows[0][0] == 0, "stale 768-dim rows should be deleted"
         finally:
             await _restore_default_head()

--- a/backend/tests/test_embedding_vector_migration.py
+++ b/backend/tests/test_embedding_vector_migration.py
@@ -8,6 +8,9 @@ A: with an empty table and EMBEDDING_DIMS=768, the migration types the column
 B: with EMBEDDING_DIMS=3072 (legal config, over pgvector's 2000-dim HNSW
    limit), the upgrade still exits 0, types the column vector(3072), and
    skips the index instead of failing (codex P1).
+C: with mixed-dimension rows (stale 1536-dim next to current 768-dim), the
+   configured dimension wins over max(stored) and only the stale row is
+   deleted (codex P2 round 4).
 
 Notes
 -----
@@ -132,6 +135,46 @@ _SKIP_UNDER_OVERLAY = pytest.mark.skipif(
 )
 
 
+_TEST_RECORD_TITLE = "embedding-vector-migration-test"
+
+
+async def _insert_untyped_embedding_rows(dims_list: list[int]) -> None:
+    """Seed one embedding row per requested dimension (untyped column only).
+
+    Creates a minimal parent record per row to satisfy the records FK; the
+    rows are cleaned up by _restore_default_head's TRUNCATE + record delete.
+    """
+    from sqlalchemy.ext.asyncio import create_async_engine
+
+    from app.core.config import settings
+
+    engine = create_async_engine(
+        settings.test_database_url, isolation_level="AUTOCOMMIT"
+    )
+    try:
+        async with engine.connect() as conn:
+            for d in dims_list:
+                rid = (
+                    await conn.execute(
+                        sa.text(
+                            "INSERT INTO catalog.records (title, visibility, record_status) "
+                            "VALUES (:t, 'private', 'active') RETURNING id"
+                        ),
+                        {"t": _TEST_RECORD_TITLE},
+                    )
+                ).scalar_one()
+                await conn.execute(
+                    sa.text(
+                        "INSERT INTO catalog.record_embeddings "
+                        "(record_id, embedding, model_name, content_hash) "
+                        "VALUES (:rid, CAST(:v AS vector), 'test-model', 'x')"
+                    ),
+                    {"rid": rid, "v": "[" + ",".join(["0"] * d) + "]"},
+                )
+    finally:
+        await engine.dispose()
+
+
 async def _retype_via_migration(dims: str) -> subprocess.CompletedProcess:
     """Downgrade below 0012, empty the table, re-upgrade with EMBEDDING_DIMS set."""
     r = _run_alembic("downgrade", _PRE_TYPED_REVISION)
@@ -146,6 +189,9 @@ async def _restore_default_head() -> None:
     r = _run_alembic("downgrade", _PRE_TYPED_REVISION)
     assert r.returncode == 0, f"restore downgrade failed: {r.stderr}"
     await _fresh_query("TRUNCATE catalog.record_embeddings")
+    await _fresh_query(
+        f"DELETE FROM catalog.records WHERE title = '{_TEST_RECORD_TITLE}'"
+    )
     r = _run_alembic("upgrade", "head")
     assert r.returncode == 0, f"restore upgrade failed: {r.stderr}"
     assert await _embedding_column_type() == "vector(1536)"
@@ -181,5 +227,27 @@ class TestEmbeddingVectorMigrationDims:
             assert not await _hnsw_index_exists(), (
                 "HNSW must be skipped above pgvector's 2000-dim limit"
             )
+        finally:
+            await _restore_default_head()
+
+    async def test_mixed_dims_prefer_configured_dimension(self):
+        """fix(#449, codex P2 round 4): when stored rows disagree (stale
+        1536-dim next to current 768-dim), the configured dimension wins over
+        max(stored) — otherwise the current model's rows get deleted and its
+        future inserts fail against the stale-typed column."""
+        try:
+            r = _run_alembic("downgrade", _PRE_TYPED_REVISION)
+            assert r.returncode == 0, f"downgrade failed: {r.stderr}"
+            await _fresh_query("TRUNCATE catalog.record_embeddings")
+            await _fresh_query(
+                "DELETE FROM catalog.app_settings WHERE key = 'embedding_dims'"
+            )
+            await _insert_untyped_embedding_rows([1536, 768])
+
+            r = _run_alembic("upgrade", "head", extra_env={"EMBEDDING_DIMS": "768"})
+            assert r.returncode == 0, f"upgrade failed: {r.stderr}"
+            assert await _embedding_column_type() == "vector(768)"
+            rows = await _fresh_query("SELECT count(*) FROM catalog.record_embeddings")
+            assert rows[0][0] == 1, "only the stale 1536-dim row should be deleted"
         finally:
             await _restore_default_head()

--- a/backend/tests/test_hybrid_search.py
+++ b/backend/tests/test_hybrid_search.py
@@ -791,3 +791,70 @@ async def test_semantic_vector_only_pagination(
     assert matched >= 5, (
         f"numberMatched should count all semantic matches, got {matched}"
     )
+
+
+@pytest.mark.anyio
+async def test_semantic_approximate_count_keeps_next_link(
+    client: AsyncClient,
+    test_db_session,
+):
+    """fix(#448, codex P2): past the exact-count gate, a FULL vector window must
+    report numberMatched > offset+limit or the router suppresses the `next`
+    link on a semantic-only first page. The +1 full-window sentinel keeps
+    paging alive; a non-full (final) window reports the exact tail."""
+    session = test_db_session
+    admin_id = await get_user_id(session, "admin")
+    dim = await _get_embedding_dim(session)
+    await _set_semantic_search(session, True)
+
+    # Five public datasets in an isolated vector band (lo=90), no lexical overlap.
+    for i, base in enumerate((0.99, 0.95, 0.90, 0.85, 0.80)):
+        ds = await _create_search_dataset(
+            session,
+            created_by=admin_id,
+            name=f"Approx Band Layer {i}",
+            description="public",
+        )
+        session.add(
+            RecordEmbedding(
+                record_id=ds.record_id,
+                embedding=_make_vector_band(base, dim=dim, lo=90),
+                model_name="text-embedding-3-small",
+                content_hash=f"approx_band_{i}",
+            )
+        )
+    await session.commit()
+
+    async def _page(offset: int) -> tuple[int, int]:
+        with (
+            patch(
+                "app.modules.catalog.search.service_semantic.generate_embedding",
+                new_callable=AsyncMock,
+                return_value=_make_vector_band(1.0, dim=dim, lo=90),
+            ),
+            # Force the approximate branch (as if the catalog held >5000 embeddings).
+            patch(
+                "app.modules.catalog.search.service_semantic._EXACT_SEMANTIC_COUNT_MAX_ROWS",
+                0,
+            ),
+        ):
+            r = await client.get(
+                "/search/datasets/",
+                params={"q": "zzznolexicalapproxxyz", "limit": 2, "offset": offset},
+            )
+        assert r.status_code == 200
+        body = r.json()
+        return len(body["features"]), body.get("numberMatched", 0)
+
+    returned1, matched1 = await _page(0)
+    assert returned1 == 2
+    # Full window (2 fetched for page_end=2): the sentinel must push the total
+    # past offset+limit so rel="next" is emitted.
+    assert matched1 > 2, f"full-window total must exceed the page, got {matched1}"
+
+    # Deep page: window (page_end=6) is NOT full for 5 matches — exact tail.
+    returned3, matched3 = await _page(4)
+    assert returned3 == 1
+    assert matched3 == 5, (
+        f"non-full window should report the exact tail, got {matched3}"
+    )

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -792,6 +792,11 @@ def test_decomposed_service_modules_stay_within_size_budgets() -> None:
         # 660 → 720 (~29 LOC headroom).
         "backend/app/modules/catalog/maps/service_public.py": 720,
         "backend/app/modules/catalog/search/service_records.py": 500,
+        # fix(#448): +~40 LOC — query-embedding hot-path deadline (asyncio.wait_for
+        # wrapper) + the gated/approximated vector-only match COUNT in
+        # _run_rrf_merge (perf audit 2026-07-10 §2d). Cap 350 → 390
+        # (~19 LOC headroom above 371).
+        "backend/app/modules/catalog/search/service_semantic.py": 390,
         # fix(#430 V-14): _replace_layers now reconciles layers by id (update-in-place
         # + create/delete) instead of delete-all-then-recreate, so a PUT preserves
         # layer UUIDs. +~35 LOC over the 350 default. Cap → 400 (~34 headroom).

--- a/backend/tests/test_sql_engine.py
+++ b/backend/tests/test_sql_engine.py
@@ -12,8 +12,9 @@ from app.processing.ai.constants import tool_label
 from app.processing.ai.schemas import ChatMapLayer
 from app.processing.ai.tools import CHAT_TOOLS_ANTHROPIC
 from app.processing.ai.sql_generator import (
+    SQL_SYSTEM_PROMPT,
     build_sql_schema_context,
-    build_sql_generation_prompt,
+    build_sql_user_message,
 )
 from app.platform.extensions.defaults import DefaultProcessingPort
 from app.platform.sandbox.schemas import SandboxError, SandboxResult
@@ -122,14 +123,29 @@ class TestSchemaContext:
 
 
 class TestSqlPrompt:
-    """Tests for build_sql_generation_prompt()."""
+    """Tests for SQL_SYSTEM_PROMPT + build_sql_user_message().
+
+    fix(#448): the prompt is split — static reference in the (cacheable)
+    system prompt, schema + question in the user message. The combined text
+    keeps the pre-split assertions meaningful.
+    """
 
     def setup_method(self):
         self.schema = "CREATE TABLE data.cities (\n  name text\n);"
-        self.prompt = build_sql_generation_prompt(
+        self.user_message = build_sql_user_message(
             question="How many cities per country?",
             schema_context=self.schema,
         )
+        self.prompt = SQL_SYSTEM_PROMPT + "\n" + self.user_message
+
+    def test_system_prompt_is_static(self):
+        """The cacheable prefix must not contain per-call content."""
+        assert "How many cities per country?" not in SQL_SYSTEM_PROMPT
+        assert self.schema not in SQL_SYSTEM_PROMPT
+
+    def test_user_message_carries_schema_and_question(self):
+        assert self.schema in self.user_message
+        assert "How many cities per country?" in self.user_message
 
     def test_includes_all_8_postgis_functions(self):
         required = [

--- a/backend/tests/test_staging_pipeline.py
+++ b/backend/tests/test_staging_pipeline.py
@@ -884,3 +884,81 @@ class TestIngestVectorIntoStagingErrors:
                     user_wants_geom=True,
                     user_metadata={"x_column": "lon", "y_column": "lat"},
                 )
+
+
+# ---------------------------------------------------------------------------
+# fix(#448): ensure_geom_4326_gist_index — the staging-swap index regression
+# ---------------------------------------------------------------------------
+
+
+class TestEnsureGeom4326GistIndex:
+    """The old `CREATE INDEX IF NOT EXISTS idx_<table>_geom_4326` matched by
+    NAME schema-wide: on a second re-ingest the previous swap's index still
+    held the name, so the staging table silently got NO gist index and the
+    swap dropped the only indexed copy of the data (perf audit 2026-07-10 §4c).
+    """
+
+    @staticmethod
+    def _probe(found: bool):
+        result = MagicMock()
+        result.first.return_value = (1,) if found else None
+        return result
+
+    @pytest.mark.asyncio
+    async def test_creates_unnamed_index_when_table_has_none(self):
+        from app.processing.ingest.metadata import ensure_geom_4326_gist_index
+
+        session = AsyncMock()
+        # column exists, no gist index yet, then the CREATE INDEX itself
+        session.execute = AsyncMock(
+            side_effect=[self._probe(True), self._probe(False), MagicMock()]
+        )
+
+        await ensure_geom_4326_gist_index(session, "my_table")
+
+        assert session.execute.await_count == 3
+        create_sql = str(session.execute.await_args_list[2].args[0])
+        assert 'CREATE INDEX ON "data"."my_table" USING GIST (geom_4326)' in create_sql
+        # The index must stay UNNAMED — PostgreSQL picks a collision-free
+        # name; a fixed name is exactly what regressed.
+        assert "idx_" not in create_sql
+
+    @pytest.mark.asyncio
+    async def test_skips_when_table_already_indexed(self):
+        from app.processing.ingest.metadata import ensure_geom_4326_gist_index
+
+        session = AsyncMock()
+        session.execute = AsyncMock(side_effect=[self._probe(True), self._probe(True)])
+
+        await ensure_geom_4326_gist_index(session, "my_table")
+
+        # Column + index probes only — no DDL issued.
+        assert session.execute.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_noop_when_table_has_no_geom_4326_column(self):
+        from app.processing.ingest.metadata import ensure_geom_4326_gist_index
+
+        session = AsyncMock()
+        session.execute = AsyncMock(side_effect=[self._probe(False)])
+
+        await ensure_geom_4326_gist_index(session, "my_table")
+
+        # effective_srid=None staging path: geometry_type set, no geom_4326.
+        assert session.execute.await_count == 1
+
+    @pytest.mark.asyncio
+    async def test_existence_check_is_table_scoped(self):
+        from app.processing.ingest.metadata import ensure_geom_4326_gist_index
+
+        session = AsyncMock()
+        session.execute = AsyncMock(
+            side_effect=[self._probe(True), self._probe(False), MagicMock()]
+        )
+
+        await ensure_geom_4326_gist_index(session, "my_table", schema="data")
+
+        probe = session.execute.await_args_list[1].args[0]
+        compiled = probe.compile(compile_kwargs={"literal_binds": True})
+        assert "pg_indexes" in str(compiled)
+        assert "my_table" in str(compiled)

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -132,7 +132,10 @@ services:
     # GAP-001: memory limit prevents the DB from consuming all host RAM under
     # heavy query load. 2 GB covers shared_buffers (512 MB) + work_mem headroom
     # for concurrent queries. Raise on hosts with > 8 GB RAM.
-    mem_limit: "2g"
+    # fix(#448): env-overridable — the fixed caps summed to 9 GB, over-committing
+    # an 8 GB host (no cap sum guard exists in Docker). On 8 GB set
+    # DB_MEM_LIMIT=1.5g API_MEM_LIMIT=1g WORKER_MEM_LIMIT=2g (sum ≈ 6 GB).
+    mem_limit: "${DB_MEM_LIMIT:-2g}"
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -h 127.0.0.1 -p 5432 -U ${POSTGRES_USER} -d ${POSTGRES_DB}"]
       interval: 5s
@@ -197,7 +200,8 @@ services:
     restart: unless-stopped
     # GAP-001: 2 GB covers the Python process + Uvicorn workers + ORM caches.
     # Raise if ingesting very large files with many concurrent workers.
-    mem_limit: "2g"
+    # fix(#448): env-overridable for small hosts — see the db service note.
+    mem_limit: "${API_MEM_LIMIT:-2g}"
     <<: *hardened-base
     tmpfs:
       - /tmp:size=512m,mode=1777
@@ -259,7 +263,8 @@ services:
     restart: unless-stopped
     # GAP-001: 4 GB covers the worker process + GDAL/OGR buffers during large
     # file ingestion (GeoTIFF COG conversion can be RAM-intensive).
-    mem_limit: "4g"
+    # fix(#448): env-overridable for small hosts — see the db service note.
+    mem_limit: "${WORKER_MEM_LIMIT:-4g}"
     <<: *hardened-base
     tmpfs:
       - /tmp:size=512m,mode=1777
@@ -276,6 +281,10 @@ services:
       # operator knob in compose. See docker-compose.yml + .env.example.
       UPLOAD_STAGING_DIR: "/app/staging"
       WORKER_SHUTDOWN_TIMEOUT: "${WORKER_SHUTDOWN_TIMEOUT:-30}"
+      # fix(#448): parallel job slots (2-3 on multi-core hosts; keep 1 on
+      # 2-vCPU boxes) and queue pinning for a dedicated raster worker.
+      WORKER_CONCURRENCY: "${WORKER_CONCURRENCY:-1}"
+      WORKER_QUEUES: "${WORKER_QUEUES:-priority,ingest,raster}"
       INGEST_HTTP_TIMEOUT_SECONDS: "${INGEST_HTTP_TIMEOUT_SECONDS:-300}"
       PROCRASTINATE_SCHEMA: "${PROCRASTINATE_SCHEMA:-catalog}"
     healthcheck:
@@ -305,7 +314,8 @@ services:
       - ALL
     # GAP-001: 1 GB covers GDAL_CACHEMAX (200 MB) + Python process overhead for
     # concurrent tile rendering. Raise for very large raster catalogs.
-    mem_limit: "1g"
+    # fix(#448): env-overridable for small hosts — see the db service note.
+    mem_limit: "${TITILER_MEM_LIMIT:-1g}"
     read_only: true
     tmpfs:
       - /tmp:size=128m,mode=1777
@@ -341,6 +351,9 @@ services:
     # frontend/nginx.conf). No build, no bind-mounts, no Vite.
     image: ${REGISTRY:-ghcr.io}/${IMAGE_OWNER:-geolens-io}/geolens-frontend:${GEOLENS_VERSION:-latest}
     restart: unless-stopped
+    # fix(#448): previously uncapped — nginx idles ~25 MB, peaks ~50 MB; a cap
+    # keeps a leak from eating a small host's headroom.
+    mem_limit: "${FRONTEND_MEM_LIMIT:-128m}"
     security_opt:
       - no-new-privileges:true
     cap_drop:
@@ -372,6 +385,9 @@ services:
     image: ${REGISTRY:-ghcr.io}/${IMAGE_OWNER:-geolens-io}/geolens-backup:${GEOLENS_VERSION:-latest}
     restart: unless-stopped
     init: true
+    # fix(#448): previously uncapped — the nightly pg_dump+tar peaks ~300 MB;
+    # 512m default leaves headroom while bounding it on small hosts.
+    mem_limit: "${BACKUP_MEM_LIMIT:-512m}"
     security_opt:
       - no-new-privileges:true
     cap_drop:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -137,7 +137,9 @@ services:
     # GAP-001: memory limit prevents the DB from consuming all host RAM under
     # heavy query load. 2 GB covers shared_buffers (512 MB) + work_mem headroom
     # for concurrent queries. Raise on hosts with > 8 GB RAM.
-    mem_limit: "2g"
+    # fix(#448): env-overridable — mirrors docker-compose.prod.yml so the caps
+    # can be rebalanced on small hosts without editing the file.
+    mem_limit: "${DB_MEM_LIMIT:-2g}"
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -h 127.0.0.1 -p 5432 -U ${POSTGRES_USER} -d ${POSTGRES_DB}"]
       interval: 5s
@@ -208,7 +210,8 @@ services:
     restart: unless-stopped
     # GAP-001: 2 GB covers the Python process + Uvicorn workers + ORM caches.
     # Raise if ingesting very large files with many concurrent workers.
-    mem_limit: "2g"
+    # fix(#448): env-overridable — mirrors docker-compose.prod.yml.
+    mem_limit: "${API_MEM_LIMIT:-2g}"
     # Hardening (security_opt + cap_drop + cap_add + read_only): see
     # x-hardened-base anchor at top of file. no-new-privileges:true blocks
     # setuid escalation but NOT setpriv (which de-escalates), so the
@@ -343,7 +346,8 @@ services:
     restart: unless-stopped
     # GAP-001: 4 GB covers the worker process + GDAL/OGR buffers during large
     # file ingestion (GeoTIFF COG conversion can be RAM-intensive).
-    mem_limit: "4g"
+    # fix(#448): env-overridable — mirrors docker-compose.prod.yml.
+    mem_limit: "${WORKER_MEM_LIMIT:-4g}"
     # Hardening: see x-hardened-base anchor at top of file (same profile as api).
     <<: *hardened-base
     tmpfs:
@@ -364,6 +368,10 @@ services:
       # /app/staging mount target on every service. See .env.example.
       UPLOAD_STAGING_DIR: "/app/staging"
       WORKER_SHUTDOWN_TIMEOUT: "${WORKER_SHUTDOWN_TIMEOUT:-30}"
+      # fix(#448): parallel job slots (2-3 on multi-core hosts; keep 1 on
+      # 2-vCPU boxes) and queue pinning for a dedicated raster worker.
+      WORKER_CONCURRENCY: "${WORKER_CONCURRENCY:-1}"
+      WORKER_QUEUES: "${WORKER_QUEUES:-priority,ingest,raster}"
       # Mirror the api service: ingest tuning + procrastinate schema reach
       # the worker container so operator overrides take effect.
       INGEST_HTTP_TIMEOUT_SECONDS: "${INGEST_HTTP_TIMEOUT_SECONDS:-300}"
@@ -394,7 +402,8 @@ services:
       - ALL
     # GAP-001: 1 GB covers GDAL_CACHEMAX (200 MB) + Python process overhead for
     # concurrent tile rendering. Raise for very large raster catalogs.
-    mem_limit: "1g"
+    # fix(#448): env-overridable — mirrors docker-compose.prod.yml.
+    mem_limit: "${TITILER_MEM_LIMIT:-1g}"
     # Immutable root with /tmp tmpfs for GDAL VSI cache writes.
     read_only: true
     tmpfs:

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -14,14 +14,27 @@ const LoginPage = lazy(() => import('./pages/LoginPage').then(m => ({ default: m
 const RegisterPage = lazy(() => import('./pages/RegisterPage').then(m => ({ default: m.RegisterPage })));
 const VerifyEmailPage = lazy(() => import('./pages/VerifyEmailPage').then(m => ({ default: m.VerifyEmailPage })));
 const OAuthCallbackPage = lazy(() => import('./pages/OAuthCallbackPage').then(m => ({ default: m.OAuthCallbackPage })));
-const PublicViewerPage = lazy(() => import('./pages/PublicViewerPage').then(m => ({ default: m.PublicViewerPage })));
+// fix(#448): map routes kick off the map-vendor chunk (~306KB gz, maplibre-gl)
+// in parallel with the route chunk. Without this the vendor download
+// serializes BEHIND the page chunk — the page module only reaches its own
+// maplibre import after it has itself loaded.
+const PublicViewerPage = lazy(() =>
+  Promise.all([import('./pages/PublicViewerPage'), import('maplibre-gl')]).then(
+    ([m]) => ({ default: m.PublicViewerPage }),
+  ),
+);
 const DatasetPage = lazy(() => import('./pages/DatasetPage').then(m => ({ default: m.DatasetPage })));
 const CollectionsPage = lazy(() => import('./pages/CollectionsPage').then(m => ({ default: m.CollectionsPage })));
 const CollectionDetailPage = lazy(() => import('./pages/CollectionDetailPage').then(m => ({ default: m.CollectionDetailPage })));
 const SettingsPage = lazy(() => import('./pages/SettingsPage').then(m => ({ default: m.SettingsPage })));
 const ImportPage = lazy(() => import('./pages/ImportPage').then(m => ({ default: m.ImportPage })));
 const MapsPage = lazy(() => import('./pages/MapsPage').then(m => ({ default: m.MapsPage })));
-const MapViewerGate = lazy(() => import('./pages/MapViewerGate').then(m => ({ default: m.MapViewerGate })));
+// fix(#448): see PublicViewerPage — warm map-vendor alongside the route chunk.
+const MapViewerGate = lazy(() =>
+  Promise.all([import('./pages/MapViewerGate'), import('maplibre-gl')]).then(
+    ([m]) => ({ default: m.MapViewerGate }),
+  ),
+);
 const AdminOverviewPage = lazy(() => import('./pages/admin/AdminOverviewPage').then(m => ({ default: m.AdminOverviewPage })));
 const AdminUsersPage = lazy(() => import('./pages/admin/AdminUsersPage').then(m => ({ default: m.AdminUsersPage })));
 const AdminJobsPage = lazy(() => import('./pages/admin/AdminJobsPage').then(m => ({ default: m.AdminJobsPage })));

--- a/frontend/src/lib/__tests__/color-ramps-chroma-parity.test.ts
+++ b/frontend/src/lib/__tests__/color-ramps-chroma-parity.test.ts
@@ -38,4 +38,15 @@ describe('getRampColors ↔ chroma-js parity', () => {
     expect(getRampColors('Plasma', 5)).toEqual(chroma.scale('YlOrRd').colors(5));
     expect(getRampColors('not-a-ramp', 5)).toEqual(chroma.scale('YlOrRd').colors(5));
   });
+
+  // fix(#449, codex P2): chroma.scale() lowercases brewer names, so legacy
+  // style configs with 'viridis'/'blues' resolved correctly — the local
+  // lookup must stay case-insensitive rather than fall back to YlOrRd.
+  it.each(CHROMA_KNOWN)('%s resolves case-insensitively like chroma', (name) => {
+    const lower = name.toLowerCase();
+    expect(getRampColors(lower, 7)).toEqual(
+      chroma.scale(lower as chroma.BrewerPaletteName).colors(7),
+    );
+    expect(getRampColors(name.toUpperCase(), 7)).toEqual(getRampColors(name, 7));
+  });
 });

--- a/frontend/src/lib/__tests__/color-ramps-chroma-parity.test.ts
+++ b/frontend/src/lib/__tests__/color-ramps-chroma-parity.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+import chroma from 'chroma-js';
+import {
+  getRampColors,
+  SEQUENTIAL_RAMPS,
+  DIVERGING_RAMPS,
+  QUALITATIVE_RAMPS,
+} from '../color-ramps';
+
+// fix(#448): getRampColors no longer imports chroma-js — the static import
+// chain layer-icons/LegendEntries → color-ramps → chroma-js pulled the
+// color-vendor chunk into the ENTRY graph (the login page downloaded 19.5KB
+// gz for two decorative heatmap previews). This suite pins the local
+// reimplementation to chroma.scale(name).colors(count) BIT-FOR-BIT so
+// legend swatches keep matching the colors stored in existing saved maps
+// (which were generated with chroma in the builder). chroma-js remains a
+// builder-only dependency (color-relief-sync.ts), so importing it in tests
+// is free — tests are never bundled.
+
+const ALL_RAMPS = [...SEQUENTIAL_RAMPS, ...DIVERGING_RAMPS, ...QUALITATIVE_RAMPS].map(
+  (r) => r.name as string,
+);
+// chroma-js has no brewer entry for Inferno/Plasma — the pre-#448 try/catch
+// already served the YlOrRd fallback for them, which getRampColors preserves.
+const CHROMA_KNOWN = ALL_RAMPS.filter((n) => n !== 'Inferno' && n !== 'Plasma');
+
+describe('getRampColors ↔ chroma-js parity', () => {
+  it.each(CHROMA_KNOWN)('%s matches chroma output for counts 1..14', (name) => {
+    for (let count = 1; count <= 14; count++) {
+      expect(getRampColors(name, count)).toEqual(
+        chroma.scale(name as chroma.BrewerPaletteName).colors(count),
+      );
+    }
+  });
+
+  it('serves the YlOrRd fallback for Inferno/Plasma/unknown names (pre-#448 behavior)', () => {
+    expect(getRampColors('Inferno', 5)).toEqual(chroma.scale('YlOrRd').colors(5));
+    expect(getRampColors('Plasma', 5)).toEqual(chroma.scale('YlOrRd').colors(5));
+    expect(getRampColors('not-a-ramp', 5)).toEqual(chroma.scale('YlOrRd').colors(5));
+  });
+});

--- a/frontend/src/lib/color-ramps.ts
+++ b/frontend/src/lib/color-ramps.ts
@@ -1,4 +1,3 @@
-import chroma from 'chroma-js';
 import { classifyGeometry } from '@/components/builder/layer-adapters/shared';
 
 // --- Curated palette definitions ---
@@ -155,18 +154,98 @@ export function cvdSafeRamps<T extends { cvdSafe: boolean }>(ramps: T[] | readon
   return (ramps as T[]).filter((r) => r.cvdSafe);
 }
 
+// fix(#448): static ColorBrewer stop arrays (dumped verbatim from
+// chroma.brewer) + a local interpolator replace the chroma-js dependency in
+// this module. chroma-js (19.5KB gz, chunked as color-vendor) was leaking
+// into the ENTRY graph via layer-icons/LegendEntries → this file, making the
+// login page download it for two decorative heatmap previews. Output is
+// bit-exact with chroma.scale(name).colors(count) — including replicating
+// chroma's 1/(n-1) domain-breakpoint float arithmetic — and is pinned by a
+// parity test that compares against chroma directly
+// (__tests__/color-ramps-chroma-parity.test.ts). chroma-js remains a
+// builder-only dependency (color-relief-sync.ts).
+const BREWER_STOPS: Record<string, readonly string[]> = {
+  YlOrRd: ['#ffffcc', '#ffeda0', '#fed976', '#feb24c', '#fd8d3c', '#fc4e2a', '#e31a1c', '#bd0026', '#800026'],
+  YlGnBu: ['#ffffd9', '#edf8b1', '#c7e9b4', '#7fcdbb', '#41b6c4', '#1d91c0', '#225ea8', '#253494', '#081d58'],
+  Viridis: ['#440154', '#482777', '#3f4a8a', '#31678e', '#26838f', '#1f9d8a', '#6cce5a', '#b6de2b', '#fee825'],
+  Blues: ['#f7fbff', '#deebf7', '#c6dbef', '#9ecae1', '#6baed6', '#4292c6', '#2171b5', '#08519c', '#08306b'],
+  Greens: ['#f7fcf5', '#e5f5e0', '#c7e9c0', '#a1d99b', '#74c476', '#41ab5d', '#238b45', '#006d2c', '#00441b'],
+  Oranges: ['#fff5eb', '#fee6ce', '#fdd0a2', '#fdae6b', '#fd8d3c', '#f16913', '#d94801', '#a63603', '#7f2704'],
+  Reds: ['#fff5f0', '#fee0d2', '#fcbba1', '#fc9272', '#fb6a4a', '#ef3b2c', '#cb181d', '#a50f15', '#67000d'],
+  Purples: ['#fcfbfd', '#efedf5', '#dadaeb', '#bcbddc', '#9e9ac8', '#807dba', '#6a51a3', '#54278f', '#3f007d'],
+  BuGn: ['#f7fcfd', '#e5f5f9', '#ccece6', '#99d8c9', '#66c2a4', '#41ae76', '#238b45', '#006d2c', '#00441b'],
+  BuPu: ['#f7fcfd', '#e0ecf4', '#bfd3e6', '#9ebcda', '#8c96c6', '#8c6bb1', '#88419d', '#810f7c', '#4d004b'],
+  OrRd: ['#fff7ec', '#fee8c8', '#fdd49e', '#fdbb84', '#fc8d59', '#ef6548', '#d7301f', '#b30000', '#7f0000'],
+  YlGn: ['#ffffe5', '#f7fcb9', '#d9f0a3', '#addd8e', '#78c679', '#41ab5d', '#238443', '#006837', '#004529'],
+  RdYlBu: ['#a50026', '#d73027', '#f46d43', '#fdae61', '#fee090', '#ffffbf', '#e0f3f8', '#abd9e9', '#74add1', '#4575b4', '#313695'],
+  RdYlGn: ['#a50026', '#d73027', '#f46d43', '#fdae61', '#fee08b', '#ffffbf', '#d9ef8b', '#a6d96a', '#66bd63', '#1a9850', '#006837'],
+  RdBu: ['#67001f', '#b2182b', '#d6604d', '#f4a582', '#fddbc7', '#f7f7f7', '#d1e5f0', '#92c5de', '#4393c3', '#2166ac', '#053061'],
+  BrBG: ['#543005', '#8c510a', '#bf812d', '#dfc27d', '#f6e8c3', '#f5f5f5', '#c7eae5', '#80cdc1', '#35978f', '#01665e', '#003c30'],
+  PiYG: ['#8e0152', '#c51b7d', '#de77ae', '#f1b6da', '#fde0ef', '#f7f7f7', '#e6f5d0', '#b8e186', '#7fbc41', '#4d9221', '#276419'],
+  PRGn: ['#40004b', '#762a83', '#9970ab', '#c2a5cf', '#e7d4e8', '#f7f7f7', '#d9f0d3', '#a6dba0', '#5aae61', '#1b7837', '#00441b'],
+  Spectral: ['#9e0142', '#d53e4f', '#f46d43', '#fdae61', '#fee08b', '#ffffbf', '#e6f598', '#abdda4', '#66c2a5', '#3288bd', '#5e4fa2'],
+  Set1: ['#e41a1c', '#377eb8', '#4daf4a', '#984ea3', '#ff7f00', '#ffff33', '#a65628', '#f781bf', '#999999'],
+  Set2: ['#66c2a5', '#fc8d62', '#8da0cb', '#e78ac3', '#a6d854', '#ffd92f', '#e5c494', '#b3b3b3'],
+  Set3: ['#8dd3c7', '#ffffb3', '#bebada', '#fb8072', '#80b1d3', '#fdb462', '#b3de69', '#fccde5', '#d9d9d9', '#bc80bd', '#ccebc5', '#ffed6f'],
+  Paired: ['#a6cee3', '#1f78b4', '#b2df8a', '#33a02c', '#fb9a99', '#e31a1c', '#fdbf6f', '#ff7f00', '#cab2d6', '#6a3d9a', '#ffff99', '#b15928'],
+  Dark2: ['#1b9e77', '#d95f02', '#7570b3', '#e7298a', '#66a61e', '#e6ab02', '#a6761d', '#666666'],
+  Accent: ['#7fc97f', '#beaed4', '#fdc086', '#ffff99', '#386cb0', '#f0027f', '#bf5b17', '#666666'],
+  Pastel1: ['#fbb4ae', '#b3cde3', '#ccebc5', '#decbe4', '#fed9a6', '#ffffcc', '#e5d8bd', '#fddaec', '#f2f2f2'],
+  Pastel2: ['#b3e2cd', '#fdcdac', '#cbd5e8', '#f4cae4', '#e6f5c9', '#fff2ae', '#f1e2cc', '#cccccc'],
+};
+
+function hexToRgb(hex: string): [number, number, number] {
+  return [
+    parseInt(hex.slice(1, 3), 16),
+    parseInt(hex.slice(3, 5), 16),
+    parseInt(hex.slice(5, 7), 16),
+  ];
+}
+
+function rgbToHex(r: number, g: number, b: number): string {
+  return (
+    '#' +
+    [r, g, b].map((v) => Math.round(v).toString(16).padStart(2, '0')).join('')
+  );
+}
+
+/** Sample a stop array at t ∈ [0,1] with chroma-compatible RGB interpolation. */
+function sampleStops(stops: readonly string[], t: number): string {
+  const n = stops.length;
+  if (t <= 0) return stops[0];
+  if (t >= 1) return stops[n - 1];
+  // chroma.scale places stops at k/(n-1) breakpoints and derives the segment
+  // fraction from those (inexact) binary fractions; mirror that arithmetic
+  // so rounding matches chroma's output bit-for-bit.
+  let k = 0;
+  while (t >= (k + 1) / (n - 1)) k++;
+  if (k > n - 2) k = n - 2;
+  const f = (t - k / (n - 1)) / ((k + 1) / (n - 1) - k / (n - 1));
+  const a = hexToRgb(stops[k]);
+  const b = hexToRgb(stops[k + 1]);
+  return rgbToHex(
+    a[0] + (b[0] - a[0]) * f,
+    a[1] + (b[1] - a[1]) * f,
+    a[2] + (b[2] - a[2]) * f,
+  );
+}
+
 /**
- * Generate an array of hex color strings from a named chroma-js color scale.
+ * Generate an array of hex color strings from a named ColorBrewer color scale.
  * Pass reversed=true to get the reverse of the normal color order (e.g. dark-low vs dark-high).
+ *
+ * Unknown ramp names fall back to YlOrRd — this includes 'Inferno' and
+ * 'Plasma' from SEQUENTIAL_RAMPS, faithfully preserving the pre-#448
+ * behavior (chroma-js has no brewer entry for either, so the old
+ * try/catch already served YlOrRd for them).
  */
 export function getRampColors(rampName: string, count: number, reversed = false): string[] {
-  try {
-    const colors = chroma.scale(rampName as chroma.BrewerPaletteName).colors(count);
-    return reversed ? reverseRamp(colors) : colors;
-  } catch {
-    // Fallback for unknown ramp names
-    return chroma.scale('YlOrRd').colors(count);
-  }
+  const stops = BREWER_STOPS[rampName] ?? BREWER_STOPS.YlOrRd;
+  const colors =
+    count === 1
+      ? [sampleStops(stops, 0.5)]
+      : Array.from({ length: count }, (_, i) => sampleStops(stops, i / (count - 1)));
+  return reversed ? reverseRamp(colors) : colors;
 }
 
 /**

--- a/frontend/src/lib/color-ramps.ts
+++ b/frontend/src/lib/color-ramps.ts
@@ -230,8 +230,16 @@ function sampleStops(stops: readonly string[], t: number): string {
   );
 }
 
+// fix(#449, codex P2): chroma.scale() resolved brewer names case-insensitively
+// (chroma.brewer carries lowercase aliases), and legacy/imported style configs
+// can hold lowercase ramp names like 'viridis' — keep matching them.
+const BREWER_STOPS_BY_LOWER: Record<string, readonly string[]> = Object.fromEntries(
+  Object.entries(BREWER_STOPS).map(([name, stops]) => [name.toLowerCase(), stops]),
+);
+
 /**
- * Generate an array of hex color strings from a named ColorBrewer color scale.
+ * Generate an array of hex color strings from a named ColorBrewer color scale
+ * (case-insensitive, matching chroma.scale()'s name resolution).
  * Pass reversed=true to get the reverse of the normal color order (e.g. dark-low vs dark-high).
  *
  * Unknown ramp names fall back to YlOrRd — this includes 'Inferno' and
@@ -240,7 +248,7 @@ function sampleStops(stops: readonly string[], t: number): string {
  * try/catch already served YlOrRd for them).
  */
 export function getRampColors(rampName: string, count: number, reversed = false): string[] {
-  const stops = BREWER_STOPS[rampName] ?? BREWER_STOPS.YlOrRd;
+  const stops = BREWER_STOPS_BY_LOWER[rampName.toLowerCase()] ?? BREWER_STOPS.YlOrRd;
   const colors =
     count === 1
       ? [sampleStops(stops, 0.5)]


### PR DESCRIPTION
Closes the in-repo action items from the 2026-07-10 performance profile (internal report `perf-profile-20260710`). Tracking issue: #448.

## What changed, by audit item

| # | Item | Change |
|---|------|--------|
| 1 | Missing GIST indexes | **Applied live** (not in this diff): `CREATE INDEX CONCURRENTLY` + `ANALYZE` on dev (`meteorite_landings_meteoritical_society`, `manhattan_building_heights_3` — EXPLAIN now Index Scan, 25 buffers vs 1,136) **and demo** (`recent_earthquakes_heatmap_source`, `recent_earthquakes_m4_5_last_30_days`); both DBs re-audited clean |
| 2 | Staging-swap index regression | Root cause found: `CREATE INDEX IF NOT EXISTS idx_<staging>_geom_4326` collides **by name, schema-wide** with the previous swap's index, so the 2nd+ re-ingest silently loses the index when the old table is dropped. `add_4326_column` now does a per-table `pg_indexes` check + unnamed `CREATE INDEX`; `_apply_reupload_swap` self-heals post-swap. Regression tests added |
| 3 | D2s downsize bundle | `mem_limit`s are env-overridable in both composes (fixed caps summed 9GB > 8GB hosts); `frontend`/`backup` gain caps. Demo-side values, swap, and `UVICORN_WORKERS=1` are encoded in the private demo provisioning recipe + runbook (local `infra/`, excluded from the public repo by design) |
| 4 | Untyped embedding column blocks HNSW | Alembic `0012`: types `embedding` to `vector(N)` (N from stored data → `embedding_dims` config → default 1536) and builds `ix_record_embeddings_hnsw` (`m=16, ef_construction=64`). Applied to the dev DB: 36/36 embeddings preserved, index built. Handles the `{"v": ...}`-wrapped app_settings shape and takes the exclusive lock up front |
| 5 | 130s embed timeout in search hot path | `asyncio.wait_for(..., 8s)` around the query-embedding call (existing silent FTS fallback catches it); no port-signature change so enterprise overlays stay compatible |
| 7 | Worker concurrency = 1, unconfigurable | `WORKER_CONCURRENCY` + `WORKER_QUEUES` settings → `run_worker_async(concurrency=..., queues=...)`; a second worker service can pin `WORKER_QUEUES=raster` |
| 8 | SQL-gen prompt defeats caching | Split: static ~3K-token PostGIS reference → system prompt (stable, `cache_control`-cacheable); schema + question → user message (question no longer sent twice) |
| 9 | color-vendor leaks into entry graph | `color-ramps.ts` drops chroma-js: static brewer stops + local interpolation, **bit-exact** with `chroma.scale().colors()` (pinned by a 27-ramp × 14-count parity test so legend swatches keep matching colors stored in saved maps). `color-vendor` no longer referenced from `dist/index.html`; it loads only with builder chunks |
| 10 | Unbatched embedding backfill | `generate_embeddings_batch()` (single-text path delegates to it); backfill embeds 128 texts per provider call |
| 12 | Unbounded exact cosine COUNT in RRF | Exact count gated to ≤5,000 embeddings (cheap row-count probe); past that, approximated from the vetted top-k ranks (lower bound; pagination `next` links survive) |
| 13 | No guards on non-streaming complete() | Both provider loops get the streaming path's PERF-009 wall-clock (90s) + cumulative-token (200K) guards; unit test asserts the abort |
| 14 | COG temps on 512MB tmpfs | Temp copies (`cog.py`) **and** the conversion output dir (`tasks_raster.py` — whose disk-space check was measuring the wrong filesystem) land on the staging volume |
| 15 | map-vendor serialized behind route chunk | Map routes `Promise.all` the page chunk with `import('maplibre-gl')` so the 306KB gz vendor downloads in parallel |

## Deliberately not in this PR
- **#6 (remote Sentinel-2 COGs, 0.9–2s/tile):** content decision — localize the 9 remote assets in-region vs de-feature from hero maps; VM-size-independent. Options + steps documented in the (private) demo runbook.
- **#11 (`max_parallel_workers_per_gather=0`):** demo-DB `ALTER SYSTEM` at downsize time; in the downsize runbook.
- **#16–18 (P3: FTS OR→UNION, generated geom_4326, raster proxy ETag/cache) + single-pass `-of COG`:** the audit's own priority matrix marks these skip-for-now/deferred.

## Schema/API/config impacts
- New Alembic revision `0012_type_embedding_vector` (idempotent; skips already-typed columns; deletes only dimension-mismatched embedding rows, which are regenerable cache).
- New env knobs (all default to previous behavior): `WORKER_CONCURRENCY`, `WORKER_QUEUES`, `DB_MEM_LIMIT`, `API_MEM_LIMIT`, `WORKER_MEM_LIMIT`, `TITILER_MEM_LIMIT`, `FRONTEND_MEM_LIMIT`, `BACKUP_MEM_LIMIT`. (`.env.example` couldn't be edited in this session — follow-up if wanted.)
- No OpenAPI surface changes.

## Verification
- Backend: full suite `pytest -n 4` → 4,841 passed (1 unrelated auth flake, passes in isolation); `ruff check` + `format` clean; `make alembic-check` clean; migration round-tripped (down/up) on the test DB and applied to dev + test DBs.
- Frontend: `typecheck`, `lint`, full `test:coverage` (3,476 passed incl. new chroma-parity suite), production build — `color-vendor` absent from `dist/index.html`, map-vendor still isolated.
- Live: dev EXPLAIN flipped to Index Scan on the meteorite table; demo DB re-audit returns zero unindexed tables; https://demo.getgeolens.com returns 200.
- Compose: `docker compose config` clean for both files; pre-commit security hooks pass.

https://claude.ai/code/session_01171DzVEr4GLkrygD6fuc13