### PR TITLE
fix(builder): re-arm terrain apply when a deferred idle lands mid style-transition

### DIFF
--- a/frontend/src/components/builder/BuilderMap.tsx
+++ b/frontend/src/components/builder/BuilderMap.tsx
@@ -475,9 +475,19 @@ export const BuilderMap = memo(function BuilderMap({
   const terrainStateRef = useRef({ terrainConfig, layers, tokenMap });
   terrainStateRef.current = { terrainConfig, layers, tokenMap };
 
-  const applyTerrainConfig = useCallback(() => {
+  const applyTerrainConfig = useCallback(function apply() {
     const map = mapRef.current;
-    if (!map || !map.isStyleLoaded()) return;
+    if (!map) return;
+    // fix(#454): the post-basemap-swap path re-applies terrain via a SINGLE
+    // `once('idle', applyTerrainConfig)`. When that idle lands mid
+    // style-transition, a silent return here dropped the apply for good — an
+    // enabled terrain_config rendered a flat map until an unrelated dep
+    // changed (the intermittent "Matterhorn loads without 3D" bug). Re-arm on
+    // the next idle instead of no-oping; double-applies are idempotent.
+    if (!map.isStyleLoaded()) {
+      map.once('idle', apply);
+      return;
+    }
 
     const { terrainConfig: currentTerrainConfig, layers: currentLayers, tokenMap: currentTokenMap } = terrainStateRef.current;
     if (!currentTerrainConfig?.enabled || !currentTerrainConfig.source_dataset_id) {

--- a/frontend/src/components/builder/__tests__/BuilderMap.terrain-visibility.test.tsx
+++ b/frontend/src/components/builder/__tests__/BuilderMap.terrain-visibility.test.tsx
@@ -333,4 +333,49 @@ describe('BuilderMap BLDR-02: terrain attach/detach on DEM layer visibility togg
     const lastCall = setTerrainCalls[setTerrainCalls.length - 1];
     expect(lastCall[0]).toBeNull();
   });
+
+  // fix(#454): the intermittent flat-Matterhorn-on-load bug. After a basemap
+  // style swap, terrain re-apply is deferred to ONE map.once('idle',
+  // applyTerrainConfig). When that idle fired mid style-transition
+  // (isStyleLoaded()===false), applyTerrainConfig no-oped silently and an
+  // enabled terrain_config rendered a flat map until an unrelated dep changed.
+  // It must re-arm on the next idle instead.
+  it('re-arms and applies terrain when the deferred idle lands mid style-transition (#454)', async () => {
+    const demLayer = makeDemLayer(true);
+
+    await act(async () => {
+      render(
+        <BuilderMap
+          layers={[demLayer]}
+          basemapStyle="openfreemap-positron"
+          terrainConfig={terrainConfig}
+        />,
+      );
+    });
+    mapState.fakeMap.setTerrain.mockClear();
+
+    // Basemap swap: style.load fires while the (next) transition is in flight.
+    mapState.fakeMap.isStyleLoaded.mockReturnValue(false);
+    await act(async () => {
+      mapState.fakeMap.emit('style.load');
+    });
+
+    // The deferred idle lands mid-transition — the old code dropped the apply
+    // here permanently.
+    await act(async () => {
+      mapState.fakeMap.emit('idle');
+    });
+    expect(mapState.fakeMap.setTerrain).not.toHaveBeenCalledWith(
+      expect.objectContaining({ source: TERRAIN_SOURCE_ID }),
+    );
+
+    // Style settles; the re-armed idle must now attach the mesh.
+    mapState.fakeMap.isStyleLoaded.mockReturnValue(true);
+    await act(async () => {
+      mapState.fakeMap.emit('idle');
+    });
+    const setTerrainCalls = mapState.fakeMap.setTerrain.mock.calls;
+    expect(setTerrainCalls.length).toBeGreaterThan(0);
+    expect(setTerrainCalls[setTerrainCalls.length - 1][0]).toMatchObject({ source: TERRAIN_SOURCE_ID });
+  });
 });

--- a/frontend/src/components/viewer/__tests__/use-viewer-terrain.test.ts
+++ b/frontend/src/components/viewer/__tests__/use-viewer-terrain.test.ts
@@ -40,8 +40,11 @@ function createMap() {
     }),
     emit: (event: string) => {
       for (const handler of Array.from(handlers.get(event) ?? [])) {
-        handler();
+        // Delete BEFORE invoking (maplibre removes a once-listener before it
+        // runs) so a handler that re-arms itself with the same identity — the
+        // #454 re-arm — lands in the set instead of being swallowed by dedup.
         handlers.get(event)?.delete(handler);
+        handler();
       }
     },
   };
@@ -236,6 +239,41 @@ describe('useViewerTerrain', () => {
     rerender({ liveVisible: true });
     await waitFor(() => expect(result.current.terrainReady).toBe(true));
     expect(map.setTerrain).toHaveBeenLastCalledWith({ source: 'terrain-dem', exaggeration: 1.5 });
+  });
+
+  // fix(#454): same hole as BuilderMap — a reseed idle landing mid
+  // style-transition used to no-op silently, leaving the viewer mesh flat.
+  it('re-arms when the reseed idle lands mid style-transition (#454)', async () => {
+    const map = createMap();
+    const mapRef = { current: map as unknown as MaplibreMap };
+
+    const { result } = renderHook(() => useViewerTerrain({
+      layers: [layer({})],
+      mapRef,
+      mapReady: true,
+      terrainConfig: { enabled: true, source_dataset_id: 'dem-1', exaggeration: 1 },
+    }));
+    await waitFor(() => expect(result.current.terrainReady).toBe(true));
+    map.setTerrain.mockClear();
+
+    // Style swap: reseed defers to idle; that idle lands while the next
+    // transition is still in flight.
+    map.isStyleLoaded.mockReturnValue(false);
+    act(() => {
+      result.current.reseedTerrainOnStyleLoad();
+    });
+    act(() => {
+      map.emit('idle');
+    });
+    expect(map.setTerrain).not.toHaveBeenCalled();
+
+    // Style settles — the re-armed idle must reattach the mesh.
+    map.isStyleLoaded.mockReturnValue(true);
+    act(() => {
+      map.emit('idle');
+    });
+    await waitFor(() => expect(result.current.terrainReady).toBe(true));
+    expect(map.setTerrain).toHaveBeenLastCalledWith({ source: 'terrain-dem', exaggeration: 1 });
   });
 
   it('reapplies persisted terrain after a style reload', async () => {

--- a/frontend/src/components/viewer/hooks/use-viewer-terrain.ts
+++ b/frontend/src/components/viewer/hooks/use-viewer-terrain.ts
@@ -74,10 +74,19 @@ export function useViewerTerrain({
   const terrainStateRef = useRef({ terrainConfig, terrainLayer, boundDatasetHasRows, demLayerLiveVisible });
   terrainStateRef.current = { terrainConfig, terrainLayer, boundDatasetHasRows, demLayerLiveVisible };
 
-  const applyTerrain = useCallback(() => {
+  const applyTerrain = useCallback(function apply() {
     const map = mapRef.current;
-    if (!map || !map.isStyleLoaded()) {
+    if (!map) {
       setTerrainReady(false);
+      return;
+    }
+    // fix(#454): same hole as BuilderMap.applyTerrainConfig — a one-shot idle
+    // deferral (reseedTerrainOnStyleLoad) landing mid style-transition used to
+    // no-op silently and leave the mesh flat until an unrelated dep changed.
+    // Re-arm on the next idle instead; double-applies are idempotent.
+    if (!map.isStyleLoaded()) {
+      setTerrainReady(false);
+      map.once('idle', apply);
       return;
     }
 


### PR DESCRIPTION
## What

Fixes the intermittent **flat Matterhorn on load** (terrain mesh missing despite `terrain_config.enabled`) — reported live on the demo and reproduced on both `demo-2026-07-11` and `demo-2026-07-11b`.

## Root cause

After a basemap style swap, `BuilderMap` clears terrain (`clearTerrainForStyleSwap`) and defers re-apply to a **single** `map.once('idle', applyTerrainConfig)`. `applyTerrainConfig` began with `if (!map || !map.isStyleLoaded()) return;` — so when that one idle landed while the next style transition was still in flight, the apply no-oped silently and **nothing re-armed it**. The mesh had already been applied once and cleared for the swap (network logs show the wide terrain-anchored tile frustum being fetched, then the camera dropping back), leaving an enabled terrain config rendering a flat map until an unrelated effect dep changed. Whether a load ends flat is a pure timing race between the style-JSON fetch, token arrival, and MapLibre's idle scheduling — which is why it was intermittent across builds and environments.

The viewer has the identical hole via `reseedTerrainOnStyleLoad` → `once('idle', applyTerrain)`.

## Fix

Both apply functions re-arm themselves on the next `idle` when the style isn't loaded, instead of dropping the apply. Double-applies are idempotent (`ensureRasterDemTerrainSource` + `setTerrain` with identical config).

## Tests

- `BuilderMap.terrain-visibility.test.tsx`: reproduces the exact sequence — mount-apply → `style.load` mid-transition → deferred idle lands with `isStyleLoaded()===false` → style settles → mesh must attach. Fails without the fix.
- `use-viewer-terrain.test.ts`: same sequence through `reseedTerrainOnStyleLoad`. Fails without the fix.
- Test-mock correction: the fake map's `emit` now removes a once-listener **before** invoking it (maplibre semantics), so a handler that re-arms itself with the same identity isn't swallowed by Set dedup.

Full frontend suite: 3512 passed. Typecheck + eslint clean.

## Verification plan

Deploy to the demo as `demo-2026-07-11c` and soak-test repeated builder/viewer loads of the Matterhorn map (the race hit roughly half of loads before).