### PR TITLE
chore(release): prepare v1.4.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,10 @@ and releases use semantic versioning.
   viewer.
 - **Maps with an inconsistent saved terrain configuration open normally**
   (terrain simply stays off) instead of failing to load.
+- **The hypsometric elevation tint no longer paints areas outside the DEM's
+  coverage.** Pixels beyond the data footprint used to render as a solid
+  ramp-low band with a hard edge along the coverage boundary; they are now
+  transparent.
 - **Performance-profile follow-ups from the 2026-07-10 audit** landed:
   faster catalog search paging and reduced tile-request overhead on
   layer-heavy maps.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,60 @@ and releases use semantic versioning.
 
 ## [Unreleased]
 
+## [1.4.5] - 2026-07-11
+
+### Security
+
+- **AI-generated SQL runs under a stricter sandbox.** An explicit
+  PostGIS/function allow-policy, rejection of recursive CTEs (at any nesting
+  depth), set-generating and collection-amplifying functions, anchoring to
+  data tables, a 10-second statement timeout, and a per-user execution lock.
+- **Environment AI credentials and OAuth secrets bind to their configured
+  destinations.** Operator-supplied keys can no longer be redirected to
+  attacker-chosen endpoints via settings or config import; changing a
+  provider origin or mode requires rotating the secret atomically, and
+  provider fetches use SSRF-safe IP-pinned transports.
+- **Feature writes and archive ingestion validate before parsing.** GeoJSON
+  writes get a 1 MiB pre-parse cap plus depth/cardinality/coordinate
+  validation, and ZIP/XLSX containers are preflighted before extraction.
+
+### Changed
+
+- **Hillshade shading and 3D terrain are now independent controls on a DEM
+  layer.** The old either/or "render as" choice is gone: a DEM can paint
+  hillshade (with an optional hypsometric elevation tint) and drive the 3D
+  terrain mesh at the same time, from one layer. Terrain binds at the map
+  level, so duplicating a DEM rendering can no longer accumulate extra
+  terrain. Every DEM rendering is reachable in the layer stack, and a DEM
+  that draws nothing says so with a "Not shown" badge.
+- **Layer icons match everywhere.** The layer stack, the builder legend, and
+  the shared-map legend now render the same type icon for every layer,
+  including the DEM glyphs (hillshade, terrain, image).
+
+### Fixed
+
+- **Saving an unrelated layer change no longer erases DEM styling.** A
+  partial layer update (for example toggling visibility) used to clear the
+  layer's saved style metadata — hypsometric tint settings and render mode
+  could vanish on the next save. Partial updates now leave untouched fields
+  alone.
+- **Hiding a DEM layer in the shared-map viewer hides all of it.** The
+  legend's eye toggle used to leave the elevation tint painting, the 3D
+  terrain mesh extruded, and a phantom legend entry behind; all three now
+  follow the toggle, and re-showing the layer restores them.
+- **3D terrain no longer intermittently fails to appear on load.** A terrain
+  re-apply scheduled around a basemap style change could land mid-transition
+  and be dropped silently, leaving a terrain-enabled map flat until an
+  unrelated change; the re-apply now retries until the style settles.
+- **Terrain status, legend entries, and the 3D mesh stay in lockstep** when
+  the bound DEM layer is hidden, on both the builder and the shared-map
+  viewer.
+- **Maps with an inconsistent saved terrain configuration open normally**
+  (terrain simply stays off) instead of failing to load.
+- **Performance-profile follow-ups from the 2026-07-10 audit** landed:
+  faster catalog search paging and reduced tile-request overhead on
+  layer-heavy maps.
+
 ## [1.4.4] - 2026-07-10
 
 ### Changed

--- a/backend/app/api/main.py
+++ b/backend/app/api/main.py
@@ -458,7 +458,7 @@ _is_production = settings.is_production
 # no metadata to read. We fall back to the current published line so import never
 # crashes. Keep this fallback in lockstep with backend/pyproject.toml — it is one
 # of the sites `make bump` rewrites.
-_FALLBACK_APP_VERSION = "1.4.4"
+_FALLBACK_APP_VERSION = "1.4.5"
 
 
 def _resolve_app_version() -> str:

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -15961,7 +15961,7 @@
     "summary": "PostGIS-native geospatial data catalog with OGC API Features and Records support",
     "termsOfService": "https://github.com/geolens-io/geolens/blob/main/LICENSE",
     "title": "GeoLens API",
-    "version": "1.4.4"
+    "version": "1.4.5"
   },
   "openapi": "3.1.0",
   "paths": {

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geolens-backend"
-version = "1.4.4"
+version = "1.4.5"
 description = "PostGIS-native GIS data catalog"
 # Docker image (Dockerfile) ships python:3.14-slim (see the Dockerfile FROM for
 # the exact patch pin) as the project's tested runtime.

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -865,7 +865,7 @@ wheels = [
 
 [[package]]
 name = "geolens-backend"
-version = "1.4.4"
+version = "1.4.5"
 source = { virtual = "." }
 dependencies = [
     { name = "alembic" },

--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "geolens-cli"
-version = "1.4.4"
+version = "1.4.5"
 description = "Apache-2.0 command-line interface for the GeoLens API. Login, scan, publish, and export STAC against any GeoLens instance."
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/docs-contract.json
+++ b/docs-contract.json
@@ -1,6 +1,6 @@
 {
   "_comment": "Canonical cross-surface facts for the GeoLens README, marketing site (getgeolens.com/src), and docs site (getgeolens.com/docs). Validated against scripts/install.sh + backend/pyproject.toml by scripts/check_docs_contract.py (geolens CI). The getgeolens.com repo vendors a copy and enforces the same `forbidden` list in its own CI. See docs-internal/DOC-CONSISTENCY-STRATEGY for the full design. Edit a fact ONCE here (and in its canonical source) — the gates make every surface follow.",
-  "version": "1.4.4",
+  "version": "1.4.5",
   "install": {
     "oneLiner": "curl -fsSL https://getgeolens.com/install.sh | sh",
     "sourceBuild": "bash scripts/install.sh",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.4.4",
+  "version": "1.4.5",
   "type": "module",
   "license": "Apache-2.0",
   "author": "Carto Concepts, LLC",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "geolens",
-  "version": "1.4.4",
+  "version": "1.4.5",
   "private": true,
   "license": "Apache-2.0",
   "author": "Carto Concepts, LLC",

--- a/sdks/python/.openapi-python-client.yaml
+++ b/sdks/python/.openapi-python-client.yaml
@@ -4,7 +4,7 @@ project_name_override: geolens
 package_name_override: geolens
 # Rewritten on every `make sdks` run by scripts/sync_sdk_versions.py to match
 # backend/openapi.json info.version. Do not edit by hand.
-package_version_override: 1.4.4
+package_version_override: 1.4.5
 
 # Cleaner enum output (matches our pydantic v2 backend's enum emission).
 literal_enums: true

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "geolens"
-version = "1.4.4"
+version = "1.4.5"
 description = "Auto-generated Python SDK for the GeoLens API. Typed clients with Bearer + API-key auth helpers."
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/sdks/typescript/package-lock.json
+++ b/sdks/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@geolens/sdk",
-  "version": "1.4.4",
+  "version": "1.4.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@geolens/sdk",
-      "version": "1.4.4",
+      "version": "1.4.5",
       "license": "Apache-2.0",
       "dependencies": {
         "@hey-api/client-fetch": "0.13.1"

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@geolens/sdk",
-  "version": "1.4.4",
+  "version": "1.4.5",
   "description": "Auto-generated TypeScript SDK for the GeoLens API. Typed clients with Bearer + API-key auth helpers.",
   "license": "Apache-2.0",
   "author": "Carto Concepts, LLC",


### PR DESCRIPTION
Release prep for **v1.4.5**: version bump across all 9 gated sites (plus the TS SDK package-lock that `make bump` misses), OpenAPI snapshot + SDK regeneration, and the changelog section.

Ships everything merged since the v1.4.4 tag:
- #451 — composable hillshade + terrain; partial layer patches no longer erase style metadata (HT-14)
- #453 — viewer DEM live eye-toggle parity + shared layer icons
- #454 — terrain apply re-arms when a deferred idle lands mid style-transition (intermittent flat-terrain-on-load)
- #449 — 2026-07-10 performance-profile audit follow-ups
- #445 / #447 — security hardening (AI SQL sandbox incl. recursive-CTE rejection, credential/secret destination binding, pre-parse ingestion validation)

Gates: `make version-check`, `make openapi-check`, `make sdks-check` all green locally. Post-merge: cut the `v1.4.5` tag per the release runbook (GitHub API at the merge SHA), approve the two publish gates, bump the geolens-deployments chart, and move the demo to the release tag.