### PR TITLE
fix(builder): render DEM no-data as transparent in the hypsometric tint

### DIFF
--- a/frontend/src/components/builder/__tests__/color-relief-sync.test.ts
+++ b/frontend/src/components/builder/__tests__/color-relief-sync.test.ts
@@ -55,6 +55,11 @@ function makeInput(
 // buildElevationExpression
 // ---------------------------------------------------------------------------
 describe('buildElevationExpression', () => {
+  // fix(#455): 3 header tokens + 3 no-data guard pairs + 7 ramp pairs.
+  const HEADER = 3;
+  const GUARD_PAIRS = 3;
+  const RAMP_START = HEADER + GUARD_PAIRS * 2;
+
   it('returns an interpolate expression starting with the correct tokens', () => {
     const expr = buildElevationExpression('Viridis');
     expect(expr[0]).toBe('interpolate');
@@ -62,15 +67,26 @@ describe('buildElevationExpression', () => {
     expect(expr[2]).toEqual(['elevation']);
   });
 
-  it('produces 7 color stops (14 value/color pairs after the 3 header tokens)', () => {
+  it('produces the guard + 7 color stops (23 tokens total)', () => {
     const expr = buildElevationExpression('Viridis');
-    // Total length = 3 (header) + 7 * 2 (stop pairs) = 17
-    expect(expr.length).toBe(17);
+    expect(expr.length).toBe(HEADER + (GUARD_PAIRS + 7) * 2);
   });
 
-  it('first elevation stop is at elevMin (default 0)', () => {
+  // fix(#455): no-data pixels read as the -10000 m encoding floor and used to
+  // clamp to the first ramp color, painting a solid fringe beyond the DEM
+  // footprint. The ramp must hold fully transparent through the guard band.
+  it('holds transparent from the encoding floor to below the lowest land', () => {
     const expr = buildElevationExpression('Viridis');
-    expect(expr[3]).toBe(0);
+    expect(expr.slice(HEADER, RAMP_START)).toEqual([
+      -10000, 'rgba(0,0,0,0)',
+      -500, 'rgba(0,0,0,0)',
+      -499, expr[RAMP_START + 1],
+    ]);
+  });
+
+  it('first ramp stop is at elevMin (default 0)', () => {
+    const expr = buildElevationExpression('Viridis');
+    expect(expr[RAMP_START]).toBe(0);
   });
 
   it('last elevation stop is at elevMax (default 4000)', () => {
@@ -78,23 +94,22 @@ describe('buildElevationExpression', () => {
     expect(expr[expr.length - 2]).toBe(4000);
   });
 
-  it('elevation stops are evenly spaced across 0–4000 m', () => {
+  it('elevation stops are evenly spaced across 0-4000 m', () => {
     const expr = buildElevationExpression('Viridis');
     const stops: number[] = [];
-    for (let i = 3; i < expr.length; i += 2) {
+    for (let i = RAMP_START; i < expr.length; i += 2) {
       stops.push(expr[i] as number);
     }
     expect(stops).toHaveLength(7);
-    // Step = 4000 / 6 ≈ 666.67
     const step = 4000 / 6;
     for (let i = 0; i < stops.length; i++) {
       expect(stops[i]).toBeCloseTo(i * step, 5);
     }
   });
 
-  it('color values are hex strings', () => {
+  it('ramp color values are hex strings', () => {
     const expr = buildElevationExpression('Viridis');
-    for (let i = 4; i < expr.length; i += 2) {
+    for (let i = RAMP_START + 1; i < expr.length; i += 2) {
       expect(typeof expr[i]).toBe('string');
       expect((expr[i] as string).startsWith('#')).toBe(true);
     }
@@ -102,15 +117,23 @@ describe('buildElevationExpression', () => {
 
   it('respects custom elevMin and elevMax', () => {
     const expr = buildElevationExpression('Inferno', 500, 2000);
-    expect(expr[3]).toBe(500);
+    expect(expr[RAMP_START]).toBe(500);
     expect(expr[expr.length - 2]).toBe(2000);
+  });
+
+  // fix(#455): an elevMin inside the guard band (e.g. bathymetry) must skip
+  // the guard rather than emit non-ascending interpolate stops.
+  it('skips the guard when elevMin dips into the guard band', () => {
+    const expr = buildElevationExpression('Viridis', -600, 4000);
+    expect(expr.length).toBe(HEADER + 7 * 2);
+    expect(expr[HEADER]).toBe(-600);
   });
 
   it('falls back to a valid expression for an unknown ramp name', () => {
     // getRampColors falls back to YlOrRd for unknown names (Threat T-1140-05)
     const expr = buildElevationExpression('NotARealRamp');
     expect(expr[0]).toBe('interpolate');
-    expect(expr.length).toBe(17);
+    expect(expr.length).toBe(HEADER + (GUARD_PAIRS + 7) * 2);
   });
 });
 

--- a/frontend/src/components/builder/color-relief-sync.ts
+++ b/frontend/src/components/builder/color-relief-sync.ts
@@ -43,6 +43,17 @@ const STOP_COUNT = 7;
  * ['interpolate', ['linear'], ['elevation'], elev0, '#color0', elev1, '#color1', ...]
  * ```
  */
+// fix(#455): no-data guard. Titiler masks no-data pixels with alpha=0, but the
+// color-relief shader reads decoded elevation regardless of the mask, and after
+// texture upload those pixels read as the mapbox-encoding floor (-10000 m,
+// RGB 0/0/0) — which clamped to the ramp's FIRST color and painted a solid
+// ramp-low fringe over everything beyond the DEM's data footprint. Hold the
+// ramp fully transparent from the encoding floor up to below Earth's lowest
+// land (Dead Sea shore ≈ -418 m), so real below-`elevMin` terrain keeps its
+// first-color clamp while no-data renders as nothing.
+const NODATA_ELEVATION_FLOOR = -10000;
+const LOWEST_LAND_GUARD = -500;
+
 export function buildElevationExpression(
   rampName: string,
   elevMin = DEFAULT_ELEV_MIN,
@@ -51,6 +62,14 @@ export function buildElevationExpression(
   const colors = getRampColors(rampName, STOP_COUNT);
   const step = (elevMax - elevMin) / (colors.length - 1);
   const expr: unknown[] = ['interpolate', ['linear'], ['elevation']];
+  // Guard stops only make sense below the real domain; a ramp whose elevMin
+  // dips into the guard band (unusual, e.g. bathymetry) skips them rather than
+  // emit non-ascending stops.
+  if (elevMin > LOWEST_LAND_GUARD + 1) {
+    expr.push(NODATA_ELEVATION_FLOOR, 'rgba(0,0,0,0)');
+    expr.push(LOWEST_LAND_GUARD, 'rgba(0,0,0,0)');
+    expr.push(LOWEST_LAND_GUARD + 1, colors[0]);
+  }
   colors.forEach((color, i) => {
     expr.push(elevMin + i * step, color);
   });


### PR DESCRIPTION
Closes #455.

## Root cause (empirically verified)

Decoded a partial edge tile from the local Matterhorn VRT: titiler correctly masks no-data with **alpha=0**, but the RGB under the mask is fill garbage, and MapLibre's `color-relief` shader reads decoded elevation regardless of the mask. After texture upload the masked pixels read as the mapbox-encoding floor (**-10000 m**), clamping to the ramp's FIRST color — a solid viridis-purple fringe over everything beyond the DEM footprint, with a hard edge along the coverage boundary.

## Fix

`buildElevationExpression` prepends transparent guard stops: fully transparent from -10000 m up to **-500 m** (below the Dead Sea shore at ≈-418 m, so real below-`elevMin` land keeps its existing first-color clamp), with a 1 m transition into the first ramp color. When a caller's `elevMin` dips into the guard band (e.g. future bathymetry ranges) the guard is skipped — interpolate stops must ascend.

## Verification

- Local Matterhorn builder at z12 (where the fringe/pedestal wall painted solid purple on both old and new code): the no-data band now renders as plain hillshade gray; the in-footprint tint is unchanged. Zero console errors.
- Unit tests pin the guard band, the skip case, and the (shifted) ramp shape; full frontend suite 3514 green.

The mesh-side pedestal wall itself (terrain dropping to zero at the footprint edge) is the separate, already-tracked partial-DEM pedestal follow-up — this PR only stops the tint from painting no-data.