### PR TITLE
fix(editing): first tranche of editing-audit P1 fixes (E-01, E-03, E-05, E-12)

### DIFF
--- a/backend/app/modules/catalog/features/router.py
+++ b/backend/app/modules/catalog/features/router.py
@@ -452,6 +452,7 @@ async def create_feature(
             dataset.column_info or [],
             # fix(#430 codex r7): generic for created datasets — see effective_geometry_type
             await effective_geometry_type(db, dataset),
+            dataset_srid=dataset.srid,
         )
     except ValueError as e:
         raise HTTPException(
@@ -539,6 +540,7 @@ async def replace_single_feature(
             dataset.column_info or [],
             # fix(#430 codex r7): generic for created datasets — see effective_geometry_type
             await effective_geometry_type(db, dataset),
+            dataset_srid=dataset.srid,
         )
     except ValueError as e:
         if "not found" in str(e).lower():
@@ -623,6 +625,7 @@ async def patch_single_feature(
             dataset.column_info or [],
             # fix(#430 codex r7): generic for created datasets — see effective_geometry_type
             await effective_geometry_type(db, dataset),
+            dataset_srid=dataset.srid,
         )
     except ValueError as e:
         if "not found" in str(e).lower():

--- a/backend/app/modules/catalog/features/service.py
+++ b/backend/app/modules/catalog/features/service.py
@@ -51,6 +51,24 @@ def _geometry_sql(dataset_geometry_type: str) -> str:
     return base
 
 
+def _geom_write_exprs(
+    dataset_geometry_type: str, dataset_srid: int | None
+) -> tuple[str, str]:
+    """SQL expressions for the (geom, geom_4326) write pair.
+
+    GeoJSON is WGS84 by spec, so ST_GeomFromGeoJSON yields SRID 4326 — correct
+    for geom_4326, but file-ingested layers keep their source CRS in `geom`
+    (the file path runs ogr2ogr without -t_srs), so writing 4326 into a
+    projected-SRID column violates the typmod and 500s. Transform when the
+    dataset SRID differs; dataset.srid mirrors Find_SRID on the live column
+    (refresh_dataset_metadata), so it is the column's actual SRID.
+    """
+    base = _geometry_sql(dataset_geometry_type)
+    if dataset_srid and dataset_srid != 4326:
+        return f"ST_Transform({base}, {int(dataset_srid)})", base
+    return base, base
+
+
 def parse_bbox(bbox_str: str) -> list[float]:
     """Parse a comma-separated bbox string into a 4- or 6-element list.
 
@@ -380,6 +398,7 @@ async def insert_feature(
     properties: dict | None,
     column_info: list[dict],
     dataset_geometry_type: str,
+    dataset_srid: int | None = None,
 ) -> dict:
     """Insert a GeoJSON feature into a PostGIS data table.
 
@@ -391,9 +410,9 @@ async def insert_feature(
 
     geojson_str = json.dumps(geometry)
 
-    geom_expr = _geometry_sql(dataset_geometry_type)
+    geom_expr, geom_4326_expr = _geom_write_exprs(dataset_geometry_type, dataset_srid)
     cols = ["geom", "geom_4326"]
-    vals = [geom_expr, geom_expr]
+    vals = [geom_expr, geom_4326_expr]
     params: dict = {"geojson": geojson_str}
 
     if properties:
@@ -426,6 +445,7 @@ async def replace_feature(
     properties: dict,
     column_info: list[dict],
     dataset_geometry_type: str,
+    dataset_srid: int | None = None,
 ) -> dict:
     """Full replacement of a feature (PUT semantics).
 
@@ -435,11 +455,11 @@ async def replace_feature(
     _validate_geometry_type(geometry.get("type", ""), dataset_geometry_type)
 
     geojson_str = json.dumps(geometry)
-    geom_expr = _geometry_sql(dataset_geometry_type)
+    geom_expr, geom_4326_expr = _geom_write_exprs(dataset_geometry_type, dataset_srid)
 
     sets = [
         f"geom = {geom_expr}",
-        f"geom_4326 = {geom_expr}",
+        f"geom_4326 = {geom_4326_expr}",
     ]
     params: dict = {"geojson": geojson_str, "gid": gid}
 
@@ -472,6 +492,7 @@ async def update_feature(
     properties: dict | None,
     column_info: list[dict],
     dataset_geometry_type: str,
+    dataset_srid: int | None = None,
 ) -> dict:
     """Partial update of a feature (PATCH semantics).
 
@@ -485,9 +506,11 @@ async def update_feature(
     if geometry is not None:
         _validate_geometry_type(geometry.get("type", ""), dataset_geometry_type)
         geojson_str = json.dumps(geometry)
-        geom_expr = _geometry_sql(dataset_geometry_type)
+        geom_expr, geom_4326_expr = _geom_write_exprs(
+            dataset_geometry_type, dataset_srid
+        )
         sets.append(f"geom = {geom_expr}")
-        sets.append(f"geom_4326 = {geom_expr}")
+        sets.append(f"geom_4326 = {geom_4326_expr}")
         params["geojson"] = geojson_str
 
     if properties is not None:

--- a/backend/app/modules/catalog/layers/router.py
+++ b/backend/app/modules/catalog/layers/router.py
@@ -27,6 +27,17 @@ from app.modules.catalog.layers.service import (
     drop_column,
     rename_column,
 )
+from app.platform.cache.provider import get_tile_cache
+
+
+async def _invalidate_tiles(table_name: str) -> None:
+    """fix(#458 E-05): column DDL changes the attribute set embedded in vector
+    tiles, so purge cached tiles post-commit — same treatment as the
+    feature-edit path (features/router.py) and the reupload swap."""
+    tile_cache = get_tile_cache()
+    if tile_cache is not None:
+        await tile_cache.invalidate_table(table_name)
+
 
 logger = structlog.stdlib.get_logger(__name__)
 
@@ -138,6 +149,7 @@ async def add_column_endpoint(
         ),
     )
     await db.commit()
+    await _invalidate_tiles(dataset.table_name)
 
     return ColumnListResponse(columns=columns)
 
@@ -190,6 +202,7 @@ async def rename_column_endpoint(
         ),
     )
     await db.commit()
+    await _invalidate_tiles(dataset.table_name)
     return ColumnListResponse(columns=columns)
 
 
@@ -253,6 +266,7 @@ async def alter_column_type_endpoint(
         ),
     )
     await db.commit()
+    await _invalidate_tiles(dataset.table_name)
     return ColumnListResponse(columns=columns)
 
 
@@ -302,5 +316,6 @@ async def drop_column_endpoint(
         ),
     )
     await db.commit()
+    await _invalidate_tiles(dataset.table_name)
 
     return ColumnListResponse(columns=columns)

--- a/backend/app/modules/catalog/layers/service.py
+++ b/backend/app/modules/catalog/layers/service.py
@@ -149,25 +149,36 @@ async def add_column(
     column_info = await get_catalog_port().get_column_info(session, dataset.table_name)
     dataset.column_info = column_info
 
-    # Create AttributeMetadata row for the new column
+    # Create (or revive) the AttributeMetadata row for the new column.
+    # fix(#458 E-12): (dataset_id, field_name) is unique, so re-adding a name
+    # dropped earlier must revive the historical is_current=False row instead
+    # of inserting a duplicate (which raised UniqueViolation -> 500).
     new_col = next((c for c in column_info if c["name"] == column_name), None)
     if new_col:
         data_type = new_col.get("type", "")
-        am = AttributeMetadata(
-            dataset_id=dataset.id,
-            field_name=column_name,
-            title=get_catalog_port().humanize_column_name(column_name),
-            data_type=data_type,
-            units=get_catalog_port().infer_units(column_name),
-            semantic_role=get_catalog_port().infer_semantic_role(
-                column_name, data_type
-            ),
-            domain_type=get_catalog_port().infer_domain_type(data_type),
-            ordinal_position=new_col.get("ordinal_position"),
-            is_nullable=new_col.get("is_nullable"),
-            is_current=True,
+        result = await session.execute(
+            select(AttributeMetadata).where(
+                AttributeMetadata.dataset_id == dataset.id,
+                AttributeMetadata.field_name == column_name,
+            )
         )
-        session.add(am)
+        am = result.scalar_one_or_none()
+        if am is None:
+            am = AttributeMetadata(
+                dataset_id=dataset.id,
+                field_name=column_name,
+                title=get_catalog_port().humanize_column_name(column_name),
+            )
+            session.add(am)
+        am.data_type = data_type
+        am.units = get_catalog_port().infer_units(column_name)
+        am.semantic_role = get_catalog_port().infer_semantic_role(
+            column_name, data_type
+        )
+        am.domain_type = get_catalog_port().infer_domain_type(data_type)
+        am.ordinal_position = new_col.get("ordinal_position")
+        am.is_nullable = new_col.get("is_nullable")
+        am.is_current = True
 
     await session.flush()
 
@@ -325,11 +336,15 @@ async def drop_column(
     column_info = await get_catalog_port().get_column_info(session, dataset.table_name)
     dataset.column_info = column_info
 
-    # Mark AttributeMetadata row as removed
+    # Mark AttributeMetadata row as removed. fix(#458 E-12): filter on
+    # is_current like rename/alter do — drop→re-add→drop of the same name
+    # leaves historical rows for the field, and an unfiltered
+    # scalar_one_or_none() raised MultipleResultsFound (500).
     result = await session.execute(
         select(AttributeMetadata).where(
             AttributeMetadata.dataset_id == dataset.id,
             AttributeMetadata.field_name == column_name,
+            AttributeMetadata.is_current.is_(True),
         )
     )
     am = result.scalar_one_or_none()

--- a/backend/tests/test_features_crud.py
+++ b/backend/tests/test_features_crud.py
@@ -27,6 +27,7 @@ async def _create_test_table_and_dataset(
     table_name: str | None = None,
     geometry_type: str = "POINT",
     visibility: str = "public",
+    srid: int = 4326,
 ) -> Dataset:
     """Create a PostGIS data table and register it as a dataset.
 
@@ -42,7 +43,7 @@ async def _create_test_table_and_dataset(
         text(
             f"CREATE TABLE IF NOT EXISTS data.{table_name} ("
             f"gid SERIAL PRIMARY KEY, "
-            f"geom geometry({pg_geom_type}, 4326), "
+            f"geom geometry({pg_geom_type}, {srid}), "
             f"geom_4326 geometry(Geometry, 4326), "
             f"name TEXT, "
             f"status TEXT)"
@@ -61,7 +62,7 @@ async def _create_test_table_and_dataset(
     dataset = Dataset(
         record_id=record.id,
         table_name=table_name,
-        srid=4326,
+        srid=srid,
         geometry_type=geometry_type,
         feature_count=0,
         column_info=[
@@ -1314,6 +1315,131 @@ class TestCreateEmptyDatasetGenericGeometry:
             )
             assert point_resp.status_code == 400
             assert "mismatch" in point_resp.json()["detail"].lower()
+        finally:
+            tbl = dataset.table_name
+            rec_id = dataset.record_id
+            await _cleanup_table(test_db_session, tbl)
+            await test_db_session.execute(
+                text("DELETE FROM catalog.records WHERE id = :id"),
+                {"id": rec_id},
+            )
+            await test_db_session.commit()
+
+
+# ---------------------------------------------------------------------------
+# Native-SRID write tests
+# ---------------------------------------------------------------------------
+
+
+class TestNativeSridWrites:
+    """fix(#458 E-01): geometry writes must land in the geom column's native SRID.
+
+    File-ingested layers keep their source CRS in ``geom`` (the file path runs
+    ogr2ogr without -t_srs); ``ST_GeomFromGeoJSON`` emits SRID 4326, so before
+    the ST_Transform fix every geometry write on a projected-SRID dataset
+    violated the column typmod and returned 500.
+    """
+
+    # Empire State Building, WGS84. EPSG:2263 = NY State Plane Long Island (ft).
+    NYC_POINT = {"type": "Point", "coordinates": [-73.9857, 40.7484]}
+
+    async def _make_stateplane_layer(self, test_db_session):
+        admin_id = await get_user_id(test_db_session, "admin")
+        return await _create_test_table_and_dataset(
+            test_db_session,
+            created_by=admin_id,
+            geometry_type="POINT",
+            srid=2263,
+        )
+
+    async def _geom_srids(self, session, table_name: str, gid: int):
+        row = (
+            await session.execute(
+                text(
+                    f"SELECT ST_SRID(geom), ST_SRID(geom_4326), "
+                    f"ST_X(geom), ST_Y(geom) "
+                    f"FROM data.{table_name} WHERE gid = :gid"
+                ),
+                {"gid": gid},
+            )
+        ).one()
+        return row
+
+    async def test_insert_transforms_geom_to_native_srid(
+        self,
+        client: AsyncClient,
+        admin_auth_header: dict,
+        test_db_session,
+    ):
+        dataset = await self._make_stateplane_layer(test_db_session)
+        try:
+            resp = await client.post(
+                f"/datasets/{dataset.id}/features/",
+                json={"geometry": self.NYC_POINT, "properties": {"name": "esb"}},
+                headers=admin_auth_header,
+            )
+            assert resp.status_code == 201, resp.text
+            data = resp.json()
+            gid = data["id"]
+            # API response reads geom_4326 -> WGS84 round-trip.
+            lon, lat = data["geometry"]["coordinates"]
+            assert abs(lon - self.NYC_POINT["coordinates"][0]) < 1e-4
+            assert abs(lat - self.NYC_POINT["coordinates"][1]) < 1e-4
+
+            srid, srid4326, x, y = await self._geom_srids(
+                test_db_session, dataset.table_name, gid
+            )
+            assert srid == 2263
+            assert srid4326 == 4326
+            # Manhattan in NY-LI State Plane feet: ~987k east, ~211k north.
+            assert 900_000 < x < 1_100_000
+            assert 150_000 < y < 300_000
+        finally:
+            tbl = dataset.table_name
+            rec_id = dataset.record_id
+            await _cleanup_table(test_db_session, tbl)
+            await test_db_session.execute(
+                text("DELETE FROM catalog.records WHERE id = :id"),
+                {"id": rec_id},
+            )
+            await test_db_session.commit()
+
+    async def test_put_and_patch_geometry_on_native_srid_layer(
+        self,
+        client: AsyncClient,
+        admin_auth_header: dict,
+        test_db_session,
+    ):
+        dataset = await self._make_stateplane_layer(test_db_session)
+        try:
+            resp = await client.post(
+                f"/datasets/{dataset.id}/features/",
+                json={"geometry": self.NYC_POINT, "properties": {"name": "esb"}},
+                headers=admin_auth_header,
+            )
+            assert resp.status_code == 201, resp.text
+            gid = resp.json()["id"]
+
+            moved = {"type": "Point", "coordinates": [-73.9772, 40.7527]}
+            put_resp = await client.put(
+                f"/datasets/{dataset.id}/features/{gid}",
+                json={"geometry": moved, "properties": {"name": "grand central"}},
+                headers=admin_auth_header,
+            )
+            assert put_resp.status_code == 200, put_resp.text
+
+            patch_resp = await client.patch(
+                f"/datasets/{dataset.id}/features/{gid}",
+                json={"geometry": self.NYC_POINT},
+                headers=admin_auth_header,
+            )
+            assert patch_resp.status_code == 200, patch_resp.text
+
+            srid, srid4326, _x, _y = await self._geom_srids(
+                test_db_session, dataset.table_name, gid
+            )
+            assert srid == 2263
+            assert srid4326 == 4326
         finally:
             tbl = dataset.table_name
             rec_id = dataset.record_id

--- a/backend/tests/test_layer_column_ops.py
+++ b/backend/tests/test_layer_column_ops.py
@@ -157,3 +157,25 @@ async def test_column_ddl_invalidates_tile_cache(
         assert resp.status_code in (200, 201, 204), resp.text
 
     assert mock_cache.invalidate_table.await_count == 4
+
+
+@pytest.mark.anyio
+async def test_drop_readd_drop_same_column(
+    client: AsyncClient, admin_auth_header: dict
+):
+    """fix(#458 E-12): dropping a re-added column must not 500 on the
+    historical AttributeMetadata row left by the first drop."""
+    dataset_id = await _create_layer(client, admin_auth_header, title="Drop Readd Test")
+
+    for step in range(2):
+        resp = await client.post(
+            f"/layers/{dataset_id}/columns/",
+            json={"column": {"name": "flaky", "type": "text"}},
+            headers=admin_auth_header,
+        )
+        assert resp.status_code == 201, f"add #{step}: {resp.text}"
+        resp = await client.delete(
+            f"/layers/{dataset_id}/columns/flaky",
+            headers=admin_auth_header,
+        )
+        assert resp.status_code == 200, f"drop #{step}: {resp.text}"

--- a/backend/tests/test_layer_column_ops.py
+++ b/backend/tests/test_layer_column_ops.py
@@ -114,3 +114,46 @@ async def test_rename_column_viewer_forbidden(
         headers=viewer_auth_header,
     )
     assert resp.status_code == 403
+
+
+@pytest.mark.anyio
+async def test_column_ddl_invalidates_tile_cache(
+    client: AsyncClient, admin_auth_header: dict, monkeypatch
+):
+    """fix(#458 E-05): every column DDL op purges the layer's cached tiles."""
+    from unittest.mock import AsyncMock, MagicMock
+
+    import app.modules.catalog.layers.router as layers_router
+
+    mock_cache = MagicMock()
+    mock_cache.invalidate_table = AsyncMock()
+    monkeypatch.setattr(layers_router, "get_tile_cache", lambda: mock_cache)
+
+    dataset_id = await _create_layer(client, admin_auth_header, title="Tile Purge Test")
+
+    ops = [
+        client.post(
+            f"/layers/{dataset_id}/columns/",
+            json={"column": {"name": "extra", "type": "text"}},
+            headers=admin_auth_header,
+        ),
+        client.patch(
+            f"/layers/{dataset_id}/columns/extra/name",
+            json={"new_name": "extra2"},
+            headers=admin_auth_header,
+        ),
+        client.patch(
+            f"/layers/{dataset_id}/columns/value/type",
+            json={"new_type": "integer"},
+            headers=admin_auth_header,
+        ),
+        client.delete(
+            f"/layers/{dataset_id}/columns/extra2",
+            headers=admin_auth_header,
+        ),
+    ]
+    for op in ops:
+        resp = await op
+        assert resp.status_code in (200, 201, 204), resp.text
+
+    assert mock_cache.invalidate_table.await_count == 4

--- a/frontend/src/components/dataset/AttributeTable.tsx
+++ b/frontend/src/components/dataset/AttributeTable.tsx
@@ -27,6 +27,7 @@ import {
 } from '@/components/ui/dropdown-menu';
 import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip';
 import { formatNumber } from '@/lib/format';
+import { coerceAttributeValue } from '@/lib/attribute-values';
 import { Loader2, ArrowUpDown, Settings2, Pencil } from 'lucide-react';
 
 /** Columns that are not user-editable */
@@ -134,13 +135,20 @@ export function AttributeTable({ datasetId, canEdit = false, compact = false }: 
     setColumnFilters((prev) => ({ ...prev, [colName]: value }));
   }, []);
 
-  const handleCellSave = useCallback(async (rowGid: number, column: string, newValue: string) => {
+  const handleCellSave = useCallback(async (rowGid: number, column: string, colType: string, newValue: string) => {
+    // fix(#458 E-03): the inline editor is a plain text input; coerce to the
+    // column's wire type instead of sending a string into a typed column.
+    const coerced = coerceAttributeValue(newValue, colType);
+    if (!coerced.ok) {
+      toast.error(t('attributes.editInvalidValue', { type: colType }));
+      return; // keep the editor open so the value can be corrected
+    }
     setEditingCell(null);
     try {
       await updateFeature.mutateAsync({
         datasetId,
         gid: rowGid,
-        properties: { [column]: newValue || null },
+        properties: { [column]: coerced.value },
       });
       toast.success(t('attributes.editSaved'));
     } catch {
@@ -181,7 +189,7 @@ export function AttributeTable({ datasetId, canEdit = false, compact = false }: 
           return (
             <InlineCellEditor
               initialValue={String(info.getValue() ?? '')}
-              onSave={(val) => handleCellSave(gid, col.name, val)}
+              onSave={(val) => handleCellSave(gid, col.name, col.type, val)}
               onCancel={() => setEditingCell(null)}
               isSaving={updateFeature.isPending}
             />

--- a/frontend/src/components/drawing/AttributeForm.tsx
+++ b/frontend/src/components/drawing/AttributeForm.tsx
@@ -12,6 +12,7 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Checkbox } from '@/components/ui/checkbox';
+import { getAttributeInputType as getInputType } from '@/lib/attribute-values';
 
 /** System columns that should never appear in the attribute form */
 const SYSTEM_COLUMNS = new Set(['gid', 'geom', 'geom_4326']);
@@ -28,16 +29,6 @@ interface AttributeFormProps {
   onSubmit: (properties: Record<string, unknown>) => void;
   onCancel: () => void;
   initialValues?: Record<string, unknown>;
-}
-
-function getInputType(colType: string): string {
-  const t = colType.toLowerCase();
-  if (t === 'integer' || t === 'bigint') return 'number-int';
-  if (['double precision', 'real', 'numeric'].includes(t)) return 'number-float';
-  if (t === 'boolean') return 'checkbox';
-  if (t === 'date') return 'date';
-  if (t === 'timestamp' || t === 'timestamptz' || t.startsWith('timestamp')) return 'datetime-local';
-  return 'text';
 }
 
 function buildFormValues(

--- a/frontend/src/i18n/locales/de/dataset.json
+++ b/frontend/src/i18n/locales/de/dataset.json
@@ -197,6 +197,7 @@
     "previous": "Zurück",
     "editSaved": "Zelle aktualisiert",
     "editFailed": "Zelle konnte nicht aktualisiert werden",
+    "editInvalidValue": "Kein gültiger {{type}}-Wert",
     "filter": "Filtern...",
     "noResults": "Keine passenden Zeilen gefunden.",
     "showingExact": "{{start}}-{{end}} von {{total}} Zeilen",

--- a/frontend/src/i18n/locales/en/dataset.json
+++ b/frontend/src/i18n/locales/en/dataset.json
@@ -198,6 +198,7 @@
     "filter": "Filter...",
     "editSaved": "Cell updated",
     "editFailed": "Failed to update cell",
+    "editInvalidValue": "Not a valid {{type}} value",
     "noResults": "No matching rows found.",
     "showingExact": "Showing {{start}}-{{end}} of {{total}} rows",
     "rowsPerPage": "Rows per page",

--- a/frontend/src/i18n/locales/es/dataset.json
+++ b/frontend/src/i18n/locales/es/dataset.json
@@ -197,6 +197,7 @@
     "previous": "Anterior",
     "editSaved": "Celda actualizada",
     "editFailed": "Error al actualizar celda",
+    "editInvalidValue": "No es un valor {{type}} válido",
     "filter": "Filtrar...",
     "noResults": "No se encontraron filas coincidentes.",
     "showingExact": "Mostrando {{start}}-{{end}} de {{total}} filas",

--- a/frontend/src/i18n/locales/fr/dataset.json
+++ b/frontend/src/i18n/locales/fr/dataset.json
@@ -197,6 +197,7 @@
     "previous": "Précédent",
     "editSaved": "Cellule mise à jour",
     "editFailed": "Échec de la mise à jour de la cellule",
+    "editInvalidValue": "Valeur {{type}} non valide",
     "filter": "Filtrer...",
     "noResults": "Aucune ligne correspondante trouvée.",
     "showingExact": "Affichage {{start}}-{{end}} sur {{total}} lignes",

--- a/frontend/src/lib/__tests__/attribute-values.test.ts
+++ b/frontend/src/lib/__tests__/attribute-values.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest';
+import { coerceAttributeValue, getAttributeInputType } from '../attribute-values';
+
+describe('getAttributeInputType', () => {
+  it('maps postgres types to input kinds', () => {
+    expect(getAttributeInputType('integer')).toBe('number-int');
+    expect(getAttributeInputType('bigint')).toBe('number-int');
+    expect(getAttributeInputType('double precision')).toBe('number-float');
+    expect(getAttributeInputType('numeric')).toBe('number-float');
+    expect(getAttributeInputType('boolean')).toBe('checkbox');
+    expect(getAttributeInputType('date')).toBe('date');
+    expect(getAttributeInputType('timestamp with time zone')).toBe('datetime-local');
+    expect(getAttributeInputType('text')).toBe('text');
+    expect(getAttributeInputType('character varying')).toBe('text');
+  });
+});
+
+describe('coerceAttributeValue', () => {
+  it('empty input means NULL for every type', () => {
+    for (const type of ['integer', 'double precision', 'boolean', 'date', 'text']) {
+      expect(coerceAttributeValue('', type)).toEqual({ ok: true, value: null });
+      expect(coerceAttributeValue('   ', type)).toEqual({ ok: true, value: null });
+    }
+  });
+
+  it('coerces integers and rejects non-integers', () => {
+    expect(coerceAttributeValue('42', 'integer')).toEqual({ ok: true, value: 42 });
+    expect(coerceAttributeValue(' -7 ', 'bigint')).toEqual({ ok: true, value: -7 });
+    expect(coerceAttributeValue('1.5', 'integer')).toEqual({ ok: false });
+    expect(coerceAttributeValue('abc', 'integer')).toEqual({ ok: false });
+  });
+
+  it('coerces floats and rejects garbage', () => {
+    expect(coerceAttributeValue('3.14', 'double precision')).toEqual({ ok: true, value: 3.14 });
+    expect(coerceAttributeValue('1e3', 'numeric')).toEqual({ ok: true, value: 1000 });
+    expect(coerceAttributeValue('12abc', 'real')).toEqual({ ok: false });
+  });
+
+  it('coerces boolean words and rejects others', () => {
+    expect(coerceAttributeValue('true', 'boolean')).toEqual({ ok: true, value: true });
+    expect(coerceAttributeValue('Yes', 'boolean')).toEqual({ ok: true, value: true });
+    expect(coerceAttributeValue('0', 'boolean')).toEqual({ ok: true, value: false });
+    expect(coerceAttributeValue('nope', 'boolean')).toEqual({ ok: false });
+  });
+
+  it('trims date strings but keeps text verbatim', () => {
+    expect(coerceAttributeValue(' 2026-07-11 ', 'date')).toEqual({ ok: true, value: '2026-07-11' });
+    expect(coerceAttributeValue(' padded ', 'text')).toEqual({ ok: true, value: ' padded ' });
+  });
+});

--- a/frontend/src/lib/__tests__/attribute-values.test.ts
+++ b/frontend/src/lib/__tests__/attribute-values.test.ts
@@ -30,6 +30,15 @@ describe('coerceAttributeValue', () => {
     expect(coerceAttributeValue('abc', 'integer')).toEqual({ ok: false });
   });
 
+  it('rejects integers beyond Number precision instead of rounding them', () => {
+    expect(coerceAttributeValue('9007199254740991', 'bigint')).toEqual({
+      ok: true,
+      value: 9007199254740991,
+    });
+    expect(coerceAttributeValue('9007199254740993', 'bigint')).toEqual({ ok: false });
+    expect(coerceAttributeValue('-9007199254740993', 'bigint')).toEqual({ ok: false });
+  });
+
   it('coerces floats and rejects garbage', () => {
     expect(coerceAttributeValue('3.14', 'double precision')).toEqual({ ok: true, value: 3.14 });
     expect(coerceAttributeValue('1e3', 'numeric')).toEqual({ ok: true, value: 1000 });

--- a/frontend/src/lib/attribute-values.ts
+++ b/frontend/src/lib/attribute-values.ts
@@ -1,0 +1,65 @@
+/** Shared column-type → editor-input mapping and free-text coercion for
+ * feature attribute editors (drawing AttributeForm + dataset AttributeTable).
+ */
+
+export type AttributeInputType =
+  | 'number-int'
+  | 'number-float'
+  | 'checkbox'
+  | 'date'
+  | 'datetime-local'
+  | 'text';
+
+export function getAttributeInputType(colType: string): AttributeInputType {
+  const t = colType.toLowerCase();
+  if (t === 'integer' || t === 'bigint') return 'number-int';
+  if (['double precision', 'real', 'numeric'].includes(t)) return 'number-float';
+  if (t === 'boolean') return 'checkbox';
+  if (t === 'date') return 'date';
+  if (t === 'timestamp' || t === 'timestamptz' || t.startsWith('timestamp')) return 'datetime-local';
+  return 'text';
+}
+
+const TRUE_WORDS = new Set(['true', 't', '1', 'yes', 'y']);
+const FALSE_WORDS = new Set(['false', 'f', '0', 'no', 'n']);
+
+/**
+ * Coerce a free-text cell value to the column's wire type.
+ *
+ * fix(#458 E-03): the attribute table's inline editor is a plain text input;
+ * sending its raw string into a typed Postgres column made every non-text
+ * cell edit fail. Empty input means NULL (matches the pre-fix `value || null`
+ * contract). `ok: false` means the text is not representable in the column
+ * type and must not be sent.
+ */
+export function coerceAttributeValue(
+  raw: string,
+  colType: string,
+): { ok: true; value: unknown } | { ok: false } {
+  const trimmed = raw.trim();
+  if (trimmed === '') return { ok: true, value: null };
+
+  switch (getAttributeInputType(colType)) {
+    case 'number-int': {
+      const n = Number(trimmed);
+      return Number.isInteger(n) ? { ok: true, value: n } : { ok: false };
+    }
+    case 'number-float': {
+      const n = Number(trimmed);
+      return Number.isNaN(n) ? { ok: false } : { ok: true, value: n };
+    }
+    case 'checkbox': {
+      const w = trimmed.toLowerCase();
+      if (TRUE_WORDS.has(w)) return { ok: true, value: true };
+      if (FALSE_WORDS.has(w)) return { ok: true, value: false };
+      return { ok: false };
+    }
+    case 'date':
+    case 'datetime-local':
+      // ISO strings, same wire shape AttributeForm sends.
+      return { ok: true, value: trimmed };
+    default:
+      // text keeps the raw, untrimmed value.
+      return { ok: true, value: raw };
+  }
+}

--- a/frontend/src/lib/attribute-values.ts
+++ b/frontend/src/lib/attribute-values.ts
@@ -42,7 +42,10 @@ export function coerceAttributeValue(
   switch (getAttributeInputType(colType)) {
     case 'number-int': {
       const n = Number(trimmed);
-      return Number.isInteger(n) ? { ok: true, value: n } : { ok: false };
+      // isSafeInteger, not isInteger: beyond 2^53 Number silently rounds
+      // (9007199254740993 -> ...992), which would corrupt identifier-like
+      // bigint values on save instead of rejecting them.
+      return Number.isSafeInteger(n) ? { ok: true, value: n } : { ok: false };
     }
     case 'number-float': {
       const n = Number(trimmed);


### PR DESCRIPTION
First tranche of fixes for the 2026-07-11 editing audit (#458).

## Changes

- **E-01 — geometry writes on projected-SRID datasets** (`features/service.py`): `ST_GeomFromGeoJSON` emits SRID 4326, but file-ingested layers keep their source CRS in `geom` (file-path ogr2ogr runs without `-t_srs`), so every geometry POST/PUT/PATCH on a non-WGS84 upload violated the column typmod and 500'd. The `geom` write is now wrapped in `ST_Transform(..., dataset.srid)`; `geom_4326` keeps the raw 4326 expression. `dataset.srid` mirrors `Find_SRID` on the live column via `refresh_dataset_metadata`, so it is the column's actual SRID.
- **E-03 — attribute-table inline edits** (`AttributeTable.tsx`, new `lib/attribute-values.ts`): the inline cell editor sent every value as a string, so edits to integer/numeric/boolean/date columns always failed with a generic toast. The drawing `AttributeForm`'s type mapping is extracted into a shared lib; cell values are coerced to the column's wire type, unrepresentable input is rejected with a type-specific message (new `editInvalidValue` key, all four locales), and the editor stays open on rejection.
- **E-05 — column DDL tile purge** (`layers/router.py`): add/rename/type-change/drop now call `tile_cache.invalidate_table` post-commit, mirroring the feature-edit path and the reupload swap. Previously stale MVT tiles served the old column set until TTL.
- **E-12 — column drop→re-add 500** (`layers/service.py`): `attribute_metadata` is unique on `(dataset_id, field_name)`, so re-adding a previously dropped column name hit `UniqueViolation` when `add_column` inserted a fresh row alongside the `is_current=False` history row. The historical row is now revived and refreshed (the audit had predicted a `MultipleResultsFound` at drop time; the regression test surfaced the actual failure at re-add).

## Impact

No schema, API-contract, or config changes. `openapi.json` unaffected (internal signatures only). One new i18n key in all four locales.

## Verification

```
cd backend && set -a && source ../.env.test && set +a && \
  uv run pytest tests/test_features_crud.py tests/test_features_geojson_z.py \
    tests/test_feature_geometry_limits.py tests/test_layer_column_ops.py \
    tests/test_attribute_metadata.py -q        # 96 passed
cd frontend && npm run typecheck && npm run lint && npm run test:i18n && \
  npx vitest run src/components/drawing src/components/dataset src/lib   # 212 passed
```

New regression coverage: EPSG:2263 POST/PUT/PATCH round-trips asserting `ST_SRID(geom)=2263` + `geom_4326=4326`; coercion unit tests; DDL tile-purge assertion across all four ops; drop→re-add→drop.

Remaining P1s (E-02 geometry validity, E-04 clear-to-null, E-06 saved-map dependency warning, E-07 e2e round-trips) tracked in #458.

https://claude.ai/code/session_01Mtp1seEXHjAu4vciRXebkd