### PR TITLE
fix(builder): stop the style editor clobbering saved categorical symbology

### DIFF
--- a/frontend/src/components/builder/DataDrivenStyleEditor.tsx
+++ b/frontend/src/components/builder/DataDrivenStyleEditor.tsx
@@ -223,14 +223,25 @@ export function styleConfigAlreadyMatches(p: StyleGuardParams): boolean {
     // through to the paint expression's own fallback, exactly as before the
     // editor opened. A stale category value no longer present in the data still
     // fails the check, so a genuinely drifted config regenerates as before.
+    //
+    // fix(#461, codex P2): when the column has NO distinct values the effect
+    // writes `categories: []`; that empty config must count as a match or the
+    // effect re-writes every render (an empty dataset / all-null column loops).
+    // So for empty data, match iff the saved categories are also empty; for
+    // non-empty data, require a non-empty subset (empty config still regenerates
+    // to style the values).
+    const categoriesSettled =
+      values.length === 0
+        ? ec.categories?.length === 0
+        : (ec.categories?.length ?? 0) > 0 &&
+          ec.categories!.every((c) => dataValues.has(c.value));
     return Boolean(
       ec.mode === 'categorical' &&
       ec.column === p.column &&
       ec.ramp === p.ramp &&
       (ec.reversed ?? false) === p.reversed &&
       ec.categories &&
-      ec.categories.length > 0 &&
-      ec.categories.every((c) => dataValues.has(c.value)),
+      categoriesSettled,
     );
   }
 

--- a/frontend/src/components/builder/DataDrivenStyleEditor.tsx
+++ b/frontend/src/components/builder/DataDrivenStyleEditor.tsx
@@ -212,14 +212,25 @@ export function styleConfigAlreadyMatches(p: StyleGuardParams): boolean {
   // Categorical color
   if (p.mode === 'categorical') {
     const values = p.categoryValues ?? [];
+    const dataValues = new Set(values);
+    // fix(#461): clobber-on-open — skip the regenerate when
+    // every styled category still exists in the data, even if the data has
+    // ADDITIONAL distinct values the saved config never listed. Requiring exact
+    // length+order equality meant merely OPENING the style editor regenerated
+    // colors from the ramp, discarding hand-authored per-category colors/labels,
+    // for any categorical layer whose column gained a value the saved config
+    // omitted (e.g. a "TD" hurricane segment). Unlisted values keep falling
+    // through to the paint expression's own fallback, exactly as before the
+    // editor opened. A stale category value no longer present in the data still
+    // fails the check, so a genuinely drifted config regenerates as before.
     return Boolean(
       ec.mode === 'categorical' &&
       ec.column === p.column &&
       ec.ramp === p.ramp &&
       (ec.reversed ?? false) === p.reversed &&
       ec.categories &&
-      ec.categories.length === values.length &&
-      ec.categories.every((c, i) => c.value === values[i]),
+      ec.categories.length > 0 &&
+      ec.categories.every((c) => dataValues.has(c.value)),
     );
   }
 

--- a/frontend/src/components/builder/LayerEditorPanel.tsx
+++ b/frontend/src/components/builder/LayerEditorPanel.tsx
@@ -23,7 +23,7 @@ export interface LayerEditorHandlers {
   onFilterChange: (layerId: string, expression: FilterSpecification | null) => void;
   onLabelChange: (layerId: string, config: LabelConfig | null) => void;
   onPopupChange: (layerId: string, config: PopupConfig | null) => void;
-  onStyleConfigChange: (layerId: string, config: StyleConfig | null, paint: Record<string, unknown>) => void;
+  onStyleConfigChange: (layerId: string, config: StyleConfig | null, paint: Record<string, unknown>, opts?: { replace?: boolean }) => void;
   onLayoutChange: (layerId: string, layout: Record<string, unknown>) => void;
   // SF-02 (Phase 1049): widened to all RenderAsId values. use-builder-layers'
   // handleRenderModeChange now dispatches non-circle modes through

--- a/frontend/src/components/builder/LayerStyleEditor.tsx
+++ b/frontend/src/components/builder/LayerStyleEditor.tsx
@@ -37,7 +37,7 @@ interface LayerStyleEditorProps {
   onPaintChange: (layerId: string, paint: Record<string, unknown>) => void;
   /** Omit to hide the master opacity slider (e.g. when the parent owns opacity via a separate control). */
   onOpacityChange?: (layerId: string, opacity: number) => void;
-  onStyleConfigChange: (layerId: string, config: StyleConfig | null, paint: Record<string, unknown>) => void;
+  onStyleConfigChange: (layerId: string, config: StyleConfig | null, paint: Record<string, unknown>, opts?: { replace?: boolean }) => void;
   onLayoutChange: (layerId: string, layout: Record<string, unknown>) => void;
 }
 
@@ -365,7 +365,7 @@ export const LayerStyleEditor = memo(function LayerStyleEditor({
       handleResetStyle();
       return;
     }
-    onStyleConfigChange(layer.id, savedLayer.style_config ?? null, savedLayer.paint ?? {});
+    onStyleConfigChange(layer.id, savedLayer.style_config ?? null, savedLayer.paint ?? {}, { replace: true });
     onLayoutChange(layer.id, savedLayer.layout ?? {});
     onOpacityChange?.(layer.id, savedLayer.opacity ?? 1);
     // Remount DataDrivenStyleEditor so its local ramp/mode/column re-seed from the

--- a/frontend/src/components/builder/LayerStyleEditor.tsx
+++ b/frontend/src/components/builder/LayerStyleEditor.tsx
@@ -70,7 +70,7 @@ function StyleControlSection({
   );
 }
 
-function StylePreview({ layer, onReset }: { layer: MapLayerResponse; onReset: () => void }) {
+function StylePreview({ layer, onRevert }: { layer: MapLayerResponse; onRevert: () => void }) {
   const { t } = useTranslation('builder');
   const colors = getLayerColors(layer);
   const swatchColor = colors[0] ?? '#6366f1';
@@ -88,11 +88,11 @@ function StylePreview({ layer, onReset }: { layer: MapLayerResponse; onReset: ()
         variant="ghost"
         size="xs"
         className="shrink-0"
-        onClick={onReset}
-        title={t('style.resetTitle')}
+        onClick={onRevert}
+        title={t('style.preview.revertTitle')}
       >
         <RotateCcw className="h-3 w-3" />
-        {t('style.reset')}
+        {t('style.preview.revert')}
       </Button>
     </div>
   );
@@ -349,6 +349,30 @@ export const LayerStyleEditor = memo(function LayerStyleEditor({
     onOpacityChange?.(layer.id, 1);
   }, [geomType, layer.id, layoutObj, onLayoutChange, onOpacityChange, onStyleConfigChange]);
 
+  // Bumped by handleRevertToSaved to force-remount the data-driven editor.
+  const [revertNonce, setRevertNonce] = useState(0);
+
+  // fix(#461): banner Reset misbehaved — the "Pending style
+  // preview" banner promises to reflect "this layer before save", so its action
+  // must REVERT the unsaved edits to the server baseline — not apply library
+  // defaults (which silently flattened hand-authored expressions like the
+  // wind-speed line-width). The banner only renders when `savedLayer` exists
+  // (isStyleDirty is false without a baseline), but we guard and fall back to the
+  // defaults reset if it is ever missing. The section-header Reset keeps its
+  // distinct "reset appearance to defaults" behavior via handleResetStyle.
+  const handleRevertToSaved = useCallback(() => {
+    if (!savedLayer) {
+      handleResetStyle();
+      return;
+    }
+    onStyleConfigChange(layer.id, savedLayer.style_config ?? null, savedLayer.paint ?? {});
+    onLayoutChange(layer.id, savedLayer.layout ?? {});
+    onOpacityChange?.(layer.id, savedLayer.opacity ?? 1);
+    // Remount DataDrivenStyleEditor so its local ramp/mode/column re-seed from the
+    // restored config instead of re-applying the just-discarded selection.
+    setRevertNonce((n) => n + 1);
+  }, [savedLayer, layer.id, onStyleConfigChange, onLayoutChange, onOpacityChange, handleResetStyle]);
+
   const unsupportedBuilderState = hasUnsupportedBuilderState(layer, geomType);
 
   // SP-05 (Phase 1045): Gate the "Pending style preview" banner on real dirty
@@ -399,7 +423,7 @@ export const LayerStyleEditor = memo(function LayerStyleEditor({
 
   return (
     <div className="space-y-2">
-      {isStyleDirty && <StylePreview layer={layer} onReset={handleResetStyle} />}
+      {isStyleDirty && <StylePreview layer={layer} onRevert={handleRevertToSaved} />}
 
       {unsupportedBuilderState && (
         <div className="flex items-start gap-2 rounded-md border border-warning/40 bg-warning/10 p-2 text-xs text-warning-foreground">
@@ -414,6 +438,14 @@ export const LayerStyleEditor = memo(function LayerStyleEditor({
           <LazyLoadErrorBoundary>
             <Suspense fallback={null}>
               <DataDrivenStyleEditor
+                // fix(#461): DataDrivenStyleEditor seeds its
+                // ramp/mode/column into local useState on mount. A banner Revert
+                // rewrites layer.style_config externally, but that local state
+                // stays stale and its effect would immediately re-apply the
+                // discarded ramp. Bumping this key on revert remounts the editor
+                // so it re-seeds from the restored config. (Normal edits don't
+                // bump it, so typing/interaction is unaffected.)
+                key={`dds-${revertNonce}`}
                 layer={layer}
                 onStyleConfigChange={onStyleConfigChange}
               />

--- a/frontend/src/components/builder/__tests__/DataDrivenStyleEditor.guards.test.ts
+++ b/frontend/src/components/builder/__tests__/DataDrivenStyleEditor.guards.test.ts
@@ -63,6 +63,20 @@ describe('styleConfigAlreadyMatches (COMPLEXITY-01 loop guards)', () => {
       expect(styleConfigAlreadyMatches({ ...params, categoryValues: ['a', 'c'] })).toBe(false);
     });
 
+    // fix(#461): clobber-on-open — the data has an EXTRA
+    // distinct value the saved config never styled ('c'). Opening the editor
+    // must NOT regenerate (which would clobber the authored 'a'/'b' colors) —
+    // the still-present styled categories are a subset of the data values.
+    it('matches when the data has extra values not listed in the saved categories', () => {
+      expect(styleConfigAlreadyMatches({ ...params, categoryValues: ['a', 'b', 'c'] })).toBe(true);
+    });
+
+    // But a styled category that no longer exists in the data IS drift → regenerate.
+    it('does not match when a styled category is absent from the data', () => {
+      expect(styleConfigAlreadyMatches({ ...params, categoryValues: ['a', 'c'] })).toBe(false);
+      expect(styleConfigAlreadyMatches({ ...params, categoryValues: ['a'] })).toBe(false);
+    });
+
     it('treats a missing reversed field as false', () => {
       const noReversed: StyleConfig = { ...written, reversed: undefined };
       expect(styleConfigAlreadyMatches({ ...params, existing: noReversed })).toBe(true);

--- a/frontend/src/components/builder/__tests__/DataDrivenStyleEditor.guards.test.ts
+++ b/frontend/src/components/builder/__tests__/DataDrivenStyleEditor.guards.test.ts
@@ -77,6 +77,18 @@ describe('styleConfigAlreadyMatches (COMPLEXITY-01 loop guards)', () => {
       expect(styleConfigAlreadyMatches({ ...params, categoryValues: ['a'] })).toBe(false);
     });
 
+    // fix(#461, codex P2): empty column must settle. With no distinct values the
+    // effect writes categories:[]; the guard must match that empty config or it
+    // re-writes every render (loop). Empty data + non-empty saved config = drift.
+    it('matches an empty saved config when the data has no distinct values (no loop)', () => {
+      const emptyCfg: StyleConfig = { mode: 'categorical', column: 'cat', ramp: 'Set2', reversed: false, categories: [] };
+      expect(styleConfigAlreadyMatches({ ...params, existing: emptyCfg, categoryValues: [] })).toBe(true);
+    });
+
+    it('does not match when the data is empty but the saved config still has categories', () => {
+      expect(styleConfigAlreadyMatches({ ...params, categoryValues: [] })).toBe(false);
+    });
+
     it('treats a missing reversed field as false', () => {
       const noReversed: StyleConfig = { ...written, reversed: undefined };
       expect(styleConfigAlreadyMatches({ ...params, existing: noReversed })).toBe(true);

--- a/frontend/src/components/builder/__tests__/LayerStyleEditor.test.tsx
+++ b/frontend/src/components/builder/__tests__/LayerStyleEditor.test.tsx
@@ -132,8 +132,10 @@ describe('LayerStyleEditor - SP-05 pending preview banner gating', () => {
     expect(screen.getByText('Pending style preview')).toBeInTheDocument();
 
     // Restores the exact saved paint (not FILL_DEFAULTS), saved layout, saved opacity.
+    // fix(#461, codex P2): passes { replace: true } so the saved config is restored
+    // verbatim — the builder-merge must not strand a discarded builder-only edit.
     await user.click(screen.getByRole('button', { name: 'Revert' }));
-    expect(onStyleConfigChange).toHaveBeenCalledWith('layer-1', null, saved.paint);
+    expect(onStyleConfigChange).toHaveBeenCalledWith('layer-1', null, saved.paint, { replace: true });
     expect(onLayoutChange).toHaveBeenCalledWith('layer-1', saved.layout);
     expect(onOpacityChange).toHaveBeenCalledWith('layer-1', 1);
   });

--- a/frontend/src/components/builder/__tests__/LayerStyleEditor.test.tsx
+++ b/frontend/src/components/builder/__tests__/LayerStyleEditor.test.tsx
@@ -97,15 +97,21 @@ describe('LayerStyleEditor - SP-05 pending preview banner gating', () => {
     expect(screen.getByText('Reflects this layer before save')).toBeInTheDocument();
   });
 
-  it('Reset action is exposed and wired to scoped style reset when banner is visible', async () => {
+  // fix(#461): the banner action ("Revert") restores the
+  // server baseline; the section-header action ("Reset") clears to library
+  // defaults. They are now distinct handlers, so assert each separately.
+  it('banner Revert restores the saved baseline paint/layout/opacity (not defaults)', async () => {
     const onStyleConfigChange = vi.fn();
     const onOpacityChange = vi.fn();
+    const onLayoutChange = vi.fn();
     const user = userEvent.setup();
 
     const saved = makeLayer({
       dataset_geometry_type: 'Polygon',
       opacity: 1,
       paint: { 'fill-color': '#000000', 'fill-opacity': 1, '_outline-color': '#ffffff' },
+      layout: {},
+      style_config: null,
     });
     const draft = {
       ...saved,
@@ -119,17 +125,42 @@ describe('LayerStyleEditor - SP-05 pending preview banner gating', () => {
         onPaintChange={vi.fn()}
         onOpacityChange={onOpacityChange}
         onStyleConfigChange={onStyleConfigChange}
-        onLayoutChange={vi.fn()}
+        onLayoutChange={onLayoutChange}
       />,
     );
 
     expect(screen.getByText('Pending style preview')).toBeInTheDocument();
 
-    // When the dirty banner is visible there are two Reset buttons (banner + section header).
-    // Both call the same handleResetStyle handler, so clicking either one is correct.
-    const resetButtons = screen.getAllByRole('button', { name: 'Reset' });
-    expect(resetButtons.length).toBeGreaterThanOrEqual(1);
-    await user.click(resetButtons[0]);
+    // Restores the exact saved paint (not FILL_DEFAULTS), saved layout, saved opacity.
+    await user.click(screen.getByRole('button', { name: 'Revert' }));
+    expect(onStyleConfigChange).toHaveBeenCalledWith('layer-1', null, saved.paint);
+    expect(onLayoutChange).toHaveBeenCalledWith('layer-1', saved.layout);
+    expect(onOpacityChange).toHaveBeenCalledWith('layer-1', 1);
+  });
+
+  it('section-header Reset still clears to library defaults', async () => {
+    const onStyleConfigChange = vi.fn();
+    const onOpacityChange = vi.fn();
+    const user = userEvent.setup();
+
+    const saved = makeLayer({
+      dataset_geometry_type: 'Polygon',
+      opacity: 1,
+      paint: { 'fill-color': '#000000', 'fill-opacity': 1 },
+    });
+    const draft = { ...saved, opacity: 0.42, paint: { 'fill-color': '#123456', 'fill-opacity': 0.4 } };
+    render(
+      <LayerStyleEditor
+        layer={draft}
+        savedLayer={saved}
+        onPaintChange={vi.fn()}
+        onOpacityChange={onOpacityChange}
+        onStyleConfigChange={onStyleConfigChange}
+        onLayoutChange={vi.fn()}
+      />,
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Reset' }));
     expect(onStyleConfigChange).toHaveBeenCalledWith('layer-1', null, expect.objectContaining({
       'fill-color': expect.any(String),
       'fill-opacity': expect.any(Number),

--- a/frontend/src/components/builder/__tests__/builder-action-contract.test.ts
+++ b/frontend/src/components/builder/__tests__/builder-action-contract.test.ts
@@ -63,6 +63,8 @@ describe('builder action contract', () => {
           'layer-1',
           { mode: 'categorical', column: 'kind', ramp: 'Viridis', render_mode: 'heatmap' },
           { 'heatmap-opacity': 0.7 },
+          // fix(#461): the reducer forwards the optional { replace } (undefined here).
+          { replace: undefined },
         ],
       },
       {

--- a/frontend/src/components/builder/builder-action-contract.ts
+++ b/frontend/src/components/builder/builder-action-contract.ts
@@ -10,7 +10,7 @@ interface BuilderActionBase {
 export type BuilderLayerAction =
   | (BuilderActionBase & { type: 'set_filter'; layerId: string; expression: FilterSpecification | null })
   | (BuilderActionBase & { type: 'set_paint'; layerId: string; paint: Record<string, unknown> })
-  | (BuilderActionBase & { type: 'set_style_config'; layerId: string; config: StyleConfig | null; paint: Record<string, unknown> })
+  | (BuilderActionBase & { type: 'set_style_config'; layerId: string; config: StyleConfig | null; paint: Record<string, unknown>; replace?: boolean })
   | (BuilderActionBase & { type: 'set_label'; layerId: string; config: LabelConfig | null })
   | (BuilderActionBase & { type: 'set_popup'; layerId: string; config: PopupConfig | null })
   | (BuilderActionBase & { type: 'set_layout'; layerId: string; layout: Record<string, unknown> })
@@ -39,7 +39,7 @@ export type BuilderMapAction = BuilderLayerAction | BuilderBasemapAction | Build
 export interface BuilderLayerActionHandlers {
   setFilter: (layerId: string, expression: FilterSpecification | null) => void;
   setPaint: (layerId: string, paint: Record<string, unknown>) => void;
-  setStyleConfig: (layerId: string, config: StyleConfig | null, paint: Record<string, unknown>) => void;
+  setStyleConfig: (layerId: string, config: StyleConfig | null, paint: Record<string, unknown>, opts?: { replace?: boolean }) => void;
   setLabel: (layerId: string, config: LabelConfig | null) => void;
   setPopup: (layerId: string, config: PopupConfig | null) => void;
   setLayout: (layerId: string, layout: Record<string, unknown>) => void;
@@ -83,7 +83,7 @@ export function dispatchBuilderLayerAction(
       handlers.setPaint(action.layerId, action.paint);
       break;
     case 'set_style_config':
-      handlers.setStyleConfig(action.layerId, action.config, action.paint);
+      handlers.setStyleConfig(action.layerId, action.config, action.paint, { replace: action.replace });
       break;
     case 'set_label':
       handlers.setLabel(action.layerId, action.config);

--- a/frontend/src/components/builder/hooks/__tests__/use-layer-map-sync.test.ts
+++ b/frontend/src/components/builder/hooks/__tests__/use-layer-map-sync.test.ts
@@ -795,3 +795,47 @@ describe('useLayerMapSync — handleStyleConfigChange line-gradient cleanup (P1-
     expect('line-gradient' in (updated.paint ?? {})).toBe(true);
   });
 });
+
+// fix(#461, codex P2): Revert-to-saved passes { replace: true } so the saved
+// config is restored verbatim. Without it, the default builder-preserve would
+// strand a discarded builder-only edit (e.g. outline width) and keep the layer dirty.
+describe('useLayerMapSync — handleStyleConfigChange replace mode (revert)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  function runWith(opts?: { replace?: boolean }) {
+    const draftLayer = makeLayer({
+      dataset_geometry_type: 'LineString',
+      paint: { 'line-color': '#123456' },
+      // draft carries a builder-only edit the saved baseline never had
+      style_config: { builder: { outlineWidth: 4 } } as MapLayerResponse['style_config'],
+    });
+    let finalLayers: MapLayerResponse[] = [draftLayer];
+    const { result } = renderHook(() => {
+      const [layers, setLayers] = React.useState([draftLayer]);
+      finalLayers = layers;
+      return useLayerMapSync(
+        layers,
+        setLayers as React.Dispatch<React.SetStateAction<MapLayerResponse[]>>,
+        vi.fn(),
+        { current: makeMapStub() } as unknown as React.RefObject<import('maplibre-gl').Map | null>,
+      );
+    });
+    act(() => {
+      // saved baseline had no style_config → restore null
+      result.current.handleStyleConfigChange(LAYER_ID, null, { 'line-color': '#000000' }, opts);
+    });
+    return finalLayers.find((l) => l.id === LAYER_ID)!;
+  }
+
+  it('replace:true drops the draft builder (restores null verbatim)', () => {
+    expect(runWith({ replace: true }).style_config).toBeNull();
+  });
+
+  it('default (no opts) preserves the draft builder — the behavior revert must bypass', () => {
+    const updated = runWith();
+    const builder = (updated.style_config as { builder?: { outlineWidth?: number } } | null)?.builder;
+    expect(builder?.outlineWidth).toBe(4);
+  });
+});

--- a/frontend/src/components/builder/hooks/use-layer-map-sync.ts
+++ b/frontend/src/components/builder/hooks/use-layer-map-sync.ts
@@ -337,7 +337,7 @@ export function useLayerMapSync(
   );
 
   const handleStyleConfigChange = useCallback(
-    (layerId: string, config: StyleConfig | null, paint: Record<string, unknown>) => {
+    (layerId: string, config: StyleConfig | null, paint: Record<string, unknown>, opts?: { replace?: boolean }) => {
       // P1-07: a data-driven SOLID color (categorical, or graduated with the
       // color target) is incompatible with a line-gradient. Switching a line's
       // color to data-driven must drop the stale `line-gradient` paint AND the
@@ -357,16 +357,24 @@ export function useLayerMapSync(
       applyLayerUpdate(
         layerId,
         (l) => {
-          let mergedConfig: StyleConfig | null = config
-            ? {
-                ...config,
-                ...(config.builder === undefined && l.style_config?.builder
-                  ? { builder: l.style_config.builder }
-                  : {}),
-              }
-            : l.style_config?.builder
-              ? ({ builder: l.style_config.builder } as StyleConfig)
-              : null;
+          // fix(#461, codex P2): `replace` restores the config verbatim — used by
+          // Revert-to-saved, which must NOT keep the draft's style_config.builder.
+          // The default branch below deliberately preserves that builder when the
+          // incoming config omits one (so setting a data-driven color doesn't wipe
+          // your outline width), but on revert that preservation would strand a
+          // discarded builder-only edit and keep the layer dirty.
+          let mergedConfig: StyleConfig | null = opts?.replace
+            ? config
+            : config
+              ? {
+                  ...config,
+                  ...(config.builder === undefined && l.style_config?.builder
+                    ? { builder: l.style_config.builder }
+                    : {}),
+                }
+              : l.style_config?.builder
+                ? ({ builder: l.style_config.builder } as StyleConfig)
+                : null;
           if (isDataDrivenColor && mergedConfig?.builder?.lineGradient) {
             const { lineGradient: _droppedLineGradient, ...restBuilder } = mergedConfig.builder;
             mergedConfig = {

--- a/frontend/src/i18n/locales/de/builder.json
+++ b/frontend/src/i18n/locales/de/builder.json
@@ -148,7 +148,9 @@
     "radius": "Radius",
     "preview": {
       "title": "Ausstehende Stilvorschau",
-      "description": "Zeigt diesen Layer vor dem Speichern"
+      "description": "Zeigt diesen Layer vor dem Speichern",
+      "revert": "Zurücksetzen",
+      "revertTitle": "Nicht gespeicherte Stiländerungen verwerfen und den gespeicherten Stil wiederherstellen"
     },
     "reset": "Zurücksetzen",
     "resetTitle": "Stil dieses Layers zurücksetzen",

--- a/frontend/src/i18n/locales/en/builder.json
+++ b/frontend/src/i18n/locales/en/builder.json
@@ -148,7 +148,9 @@
     "radius": "Radius",
     "preview": {
       "title": "Pending style preview",
-      "description": "Reflects this layer before save"
+      "description": "Reflects this layer before save",
+      "revert": "Revert",
+      "revertTitle": "Discard unsaved style changes and restore the saved style"
     },
     "reset": "Reset",
     "resetTitle": "Reset this layer style",

--- a/frontend/src/i18n/locales/es/builder.json
+++ b/frontend/src/i18n/locales/es/builder.json
@@ -148,7 +148,9 @@
     "radius": "Radio",
     "preview": {
       "title": "Vista previa de estilo pendiente",
-      "description": "Refleja esta capa antes de guardar"
+      "description": "Refleja esta capa antes de guardar",
+      "revert": "Revertir",
+      "revertTitle": "Descartar los cambios de estilo sin guardar y restaurar el estilo guardado"
     },
     "reset": "Restablecer",
     "resetTitle": "Restablecer estilo de esta capa",

--- a/frontend/src/i18n/locales/fr/builder.json
+++ b/frontend/src/i18n/locales/fr/builder.json
@@ -148,7 +148,9 @@
     "radius": "Rayon",
     "preview": {
       "title": "Aperçu du style en attente",
-      "description": "Reflète cette couche avant l'enregistrement"
+      "description": "Reflète cette couche avant l'enregistrement",
+      "revert": "Rétablir",
+      "revertTitle": "Annuler les modifications de style non enregistrées et restaurer le style enregistré"
     },
     "reset": "Réinitialiser",
     "resetTitle": "Réinitialiser le style de cette couche",

--- a/frontend/src/pages/MapBuilderPage.tsx
+++ b/frontend/src/pages/MapBuilderPage.tsx
@@ -417,12 +417,13 @@ export function MapBuilderPage() {
       layerId,
       config,
     }),
-    onStyleConfigChange: (layerId, config, paint) => dispatchLayerAction({
+    onStyleConfigChange: (layerId, config, paint, opts) => dispatchLayerAction({
       type: 'set_style_config',
       source: 'manual',
       layerId,
       config,
       paint,
+      replace: opts?.replace,
     }),
     onLayoutChange: (layerId, layout) => dispatchLayerAction({
       type: 'set_layout',


### PR DESCRIPTION
## Summary

Two builder bugs, surfaced by the **Hurricane Alley** showcase map, that silently destroy hand-authored **categorical** symbology. The map has a categorical line layer whose saved `style_config.categories` lists fewer classes (6) than the data has distinct values (7 — the data includes a `TD` segment the config never listed).

### 1. Opening the style editor clobbered the saved symbology
Merely selecting the layer regenerated every per-category color from the ramp, dropped the category labels, and marked the map dirty — with **no user gesture**. The loop-skip guard (`styleConfigAlreadyMatches`) required the saved categories to equal the data's distinct values *exactly in count and order*, so any categorical layer with an unlisted value regenerated on mount.

**Fix:** relax the categorical guard to skip regeneration when every styled category still exists in the data (a subset), even if the data has additional values. Unlisted values keep falling through to the paint expression's own fallback, exactly as before the editor opened. A styled category that no longer exists in the data still counts as drift and regenerates.

### 2. The "Pending style preview" banner's "Reset" applied library defaults
The banner promises to reflect the layer *"before save"*, but its action flattened hand-authored expressions (e.g. the wind-speed `line-width` step expression) to defaults.

**Fix:** rename it **Revert** and restore the server baseline (paint/layout/style_config/opacity) instead. The data-driven editor is remounted on revert so its local ramp/mode/column re-seed from the restored config rather than immediately re-applying the just-discarded selection. The section-header **Reset** keeps its distinct reset-to-defaults behavior.

## Impact / scope
- Frontend-only; no schema, API, or config changes.
- Affects **every instance** — any user's hand-styled categorical map was one editor-open away from silent loss.
- New i18n keys `style.preview.revert` / `style.preview.revertTitle` added to all four locales (es/fr/de machine-authored — flagged for the batched native-speaker pass).

## Verification
- `npm run typecheck`, `npm run lint`, `npm run test:i18n` — green.
- `npx vitest run src/components/builder` — 1802 tests pass, incl. new guard subset-skip cases and split Revert/Reset tests.
- **Live** against the seeded map (standalone Vite → same DB), console watched throughout (0 errors / 0 warnings): opening the editor preserves authored colors, 0.765 opacity and the `wind_kt` width expression and stays *Saved*; a genuine ramp change still regenerates; **Revert** restores the saved style with no re-clobber and clears the banner.

## Notes
- Not included here: the Hurricane map's own seed-content polish (ramp mislabel, missing `TD` legend entry, double-dimmed opacity, arrow contrast, label density, duplicate popups) — that's demo content and will be a separate PR gated on a demo re-seed.
- After Revert the map-level "Unsaved changes" flag stays set (any layer mutation flips it); the per-layer banner correctly reads clean. Pre-existing behavior, out of scope here.

https://claude.ai/code/session_01QmxibW97dSfvC1m4S6xLXU
