### PR TITLE
feat(catalog): launch-window catalog easy wins — GeoParquet, DCAT paging, ingest AI metadata, llms.txt

### DIFF
--- a/backend/app/modules/catalog/datasets/api/router_export.py
+++ b/backend/app/modules/catalog/datasets/api/router_export.py
@@ -8,6 +8,7 @@ from fastapi import (
     APIRouter,
     Depends,
     HTTPException,
+    Query,
     Request,
     Response,
     status,
@@ -72,21 +73,32 @@ def _dcat_relationship_options():
 
 
 # fix(#430 BA-28): these anonymous feeds materialize every visible dataset (+ keywords/
-# contacts/distributions) into one in-memory JSON-LD doc with no pagination or
-# cache — a cheap repeatable memory/CPU amplifier on a large catalog. Bound the
-# row count (OGC/STAC cap at ≤200) and log when the bound truncates the feed.
+# contacts/distributions) into one in-memory JSON-LD doc with no cache — a cheap
+# repeatable memory/CPU amplifier on a large catalog. A single page is bounded at
+# _DCAT_FEED_MAX_DATASETS; the catalog #catalog-enhancement fix adds limit/offset
+# so a large-catalog operator (e.g. a federal data.json harvester) can crawl the
+# whole feed instead of silently losing everything past the first 10k.
+#
+# ponytail: offset paging keeps the memory guard while unblocking >10k catalogs;
+# a spec-correct single-document streaming data.json is the real fix if a
+# harvester that can't page ever needs >10k in one request.
 _DCAT_FEED_MAX_DATASETS = 10_000
 
 
 async def _get_visible_dcat_datasets(
-    db: AsyncSession, user: Identity | None
+    db: AsyncSession,
+    user: Identity | None,
+    *,
+    limit: int = _DCAT_FEED_MAX_DATASETS,
+    offset: int = 0,
 ) -> list[DatasetModel]:
     stmt = (
         select(DatasetModel)
         .join(Record, DatasetModel.record_id == Record.id)
         .options(_dcat_relationship_options())
         .order_by(Record.created_at.desc(), Record.id.desc())
-        .limit(_DCAT_FEED_MAX_DATASETS)
+        .offset(offset)
+        .limit(limit)
     )
 
     if user is not None:
@@ -98,13 +110,26 @@ async def _get_visible_dcat_datasets(
 
     result = await db.execute(stmt)
     datasets = list(result.unique().scalars().all())
-    if len(datasets) >= _DCAT_FEED_MAX_DATASETS:
+    if len(datasets) >= limit:
         logger.warning(
             "dcat_feed_truncated",
-            limit=_DCAT_FEED_MAX_DATASETS,
+            limit=limit,
+            offset=offset,
             authenticated=user is not None,
         )
     return datasets
+
+
+# Shared query params for the paginated catalog feed handlers.
+_FEED_LIMIT_Q = Query(
+    _DCAT_FEED_MAX_DATASETS,
+    ge=1,
+    le=_DCAT_FEED_MAX_DATASETS,
+    description="Max datasets in this page (default = max).",
+)
+_FEED_OFFSET_Q = Query(
+    0, ge=0, description="Datasets to skip — page a catalog larger than one page."
+)
 
 
 async def _get_dcat_dataset_for_export(
@@ -138,9 +163,11 @@ async def get_dcat_catalog(
     request: Request,
     user: Identity | None = Depends(get_optional_user),
     db: AsyncSession = Depends(get_db),
+    limit: int = _FEED_LIMIT_Q,
+    offset: int = _FEED_OFFSET_Q,
 ) -> JSONResponse:
     """DCAT 3 JSON-LD catalog feed. Respects dataset visibility."""
-    datasets = await _get_visible_dcat_datasets(db, user)
+    datasets = await _get_visible_dcat_datasets(db, user, limit=limit, offset=offset)
 
     base_url = await get_public_api_url(db)
     catalog = catalog_to_dcat(datasets, base_url)
@@ -181,9 +208,11 @@ async def get_dcat_us3_catalog(
     request: Request,
     user: Identity | None = Depends(get_optional_user),
     db: AsyncSession = Depends(get_db),
+    limit: int = _FEED_LIMIT_Q,
+    offset: int = _FEED_OFFSET_Q,
 ) -> JSONResponse:
     """DCAT-US Schema v3.0 catalog feed. Respects dataset visibility."""
-    datasets = await _get_visible_dcat_datasets(db, user)
+    datasets = await _get_visible_dcat_datasets(db, user, limit=limit, offset=offset)
 
     base_url = await get_public_api_url(db)
     catalog = catalog_to_dcat_us3(datasets, base_url)
@@ -224,9 +253,11 @@ async def get_geodcat_ap_catalog(
     request: Request,
     user: Identity | None = Depends(get_optional_user),
     db: AsyncSession = Depends(get_db),
+    limit: int = _FEED_LIMIT_Q,
+    offset: int = _FEED_OFFSET_Q,
 ) -> JSONResponse:
     """GeoDCAT-AP 2.0.0 catalog feed. Respects dataset visibility."""
-    datasets = await _get_visible_dcat_datasets(db, user)
+    datasets = await _get_visible_dcat_datasets(db, user, limit=limit, offset=offset)
 
     base_url = await get_public_api_url(db)
     catalog = catalog_to_geodcat_ap(datasets, base_url)

--- a/backend/app/modules/catalog/records/service.py
+++ b/backend/app/modules/catalog/records/service.py
@@ -360,15 +360,12 @@ _DISTRIBUTION_TEMPLATES = [
         "application/zip",
         False,
     ),
-    (
-        "download",
-        "parquet",
-        "/datasets/{dataset_id}/export?format=parquet",
-        "GeoParquet Download",
-        "HTTP",
-        "application/vnd.apache.parquet",
-        False,
-    ),
+    # GeoParquet is intentionally NOT a materialized DCAT distribution here:
+    # these rows are generated per-dataset at creation, so adding a format would
+    # advertise it only for new datasets and needs a data-migration backfill for
+    # existing ones (deferred to a follow-up). GeoParquet is already advertised
+    # live for all datasets via OGC API Records / STAC (_FORMAT_MEDIA in
+    # search/service_records.py), so discovery is covered without the backfill.
     (
         "download",
         "csv",

--- a/backend/app/modules/catalog/records/service.py
+++ b/backend/app/modules/catalog/records/service.py
@@ -362,6 +362,15 @@ _DISTRIBUTION_TEMPLATES = [
     ),
     (
         "download",
+        "parquet",
+        "/datasets/{dataset_id}/export?format=parquet",
+        "GeoParquet Download",
+        "HTTP",
+        "application/vnd.apache.parquet",
+        False,
+    ),
+    (
+        "download",
         "csv",
         "/datasets/{dataset_id}/export?format=csv",
         "CSV Download",

--- a/backend/app/modules/catalog/search/service_records.py
+++ b/backend/app/modules/catalog/search/service_records.py
@@ -24,6 +24,7 @@ _FORMAT_MEDIA = {
     "geojson": "application/geo+json",
     "shp": "application/x-shapefile",
     "csv": "text/csv",
+    "parquet": "application/vnd.apache.parquet",
 }
 
 _RASTER_FORMAT_MEDIA = {

--- a/backend/app/processing/export/parquet.py
+++ b/backend/app/processing/export/parquet.py
@@ -27,7 +27,7 @@ from app.core.config import settings
 from app.core.runtime.staging import ensure_staging_ready
 from app.processing.export.service import validate_where_clause
 from app.processing.export.where_validator import canonical_where
-from app.processing.ingest.metadata import _qtable
+from app.processing.ingest.metadata import _qtable, get_column_info
 
 PARQUET_MEDIA_TYPE = "application/vnd.apache.parquet"
 
@@ -153,7 +153,11 @@ async def export_parquet(
     else:
         safe_where = None
 
-    attr_names = _attr_names(column_info)
+    # Introspect the live table for attribute columns rather than trusting the
+    # (nullable) dataset.column_info — otherwise a dataset with missing metadata
+    # would silently export geometry-only. Names come from information_schema, so
+    # they are real identifiers safe to quote.
+    attr_names = _attr_names(await get_column_info(db, table_name))
 
     # No blanket geom_4326 IS NOT NULL: a full export must keep rows with null
     # geometry (they export with a null geometry cell, like the feature read path
@@ -190,23 +194,29 @@ async def export_parquet(
         clauses.append(f"({escaped_where})")
     where_sql = " AND ".join(clauses) if clauses else "TRUE"
 
+    # Select the attribute columns directly (not via to_jsonb) so the async
+    # driver returns native Python values — dates, timestamps, UUIDs, numerics —
+    # and Arrow infers real column types instead of everything-as-string. Geometry
+    # is selected last and read positionally, so a user column that happens to
+    # share the WKB alias can't shadow it. Idents are information_schema names,
+    # double-quoted (embedded quotes doubled) defensively.
+    select_parts = ['"' + n.replace('"', '""') + '"' for n in attr_names]
+    select_parts.append("ST_AsBinary(geom_4326)")
     sql = (
-        "SELECT ST_AsBinary(geom_4326) AS wkb_geom, "
-        "to_jsonb(t.*) - 'gid' - 'geom' - 'geom_4326' AS props_json "
+        f"SELECT {', '.join(select_parts)} "
         f"FROM {_qtable(table_name)} t WHERE {where_sql}"
     )
 
     geom: list[bytes | None] = []
     cols: dict[str, list] = {name: [] for name in attr_names}
+    geom_idx = len(attr_names)
 
     result = await db.stream(text(sql).bindparams(**params))
     async for row in result:
-        m = row._mapping
-        wkb = m["wkb_geom"]
+        for i, name in enumerate(attr_names):
+            cols[name].append(row[i])
+        wkb = row[geom_idx]
         geom.append(bytes(wkb) if wkb is not None else None)
-        props = m["props_json"] or {}
-        for name in attr_names:
-            cols[name].append(props.get(name))
 
     exports_root = ensure_staging_ready(
         os.path.join(settings.upload_staging_dir, "exports")

--- a/backend/app/processing/export/parquet.py
+++ b/backend/app/processing/export/parquet.py
@@ -113,7 +113,11 @@ async def export_parquet(
 
     attr_names = _attr_names(column_info)
 
-    clauses: list[str] = ["geom_4326 IS NOT NULL"]
+    # No blanket geom_4326 IS NOT NULL: a full export must keep rows with null
+    # geometry (they export with a null geometry cell, like the feature read path
+    # and the other export formats). A bbox filter still drops them naturally —
+    # a null geometry neither && nor ST_Intersects an envelope.
+    clauses: list[str] = []
     params: dict = {}
     if bbox is not None:
         # Mirror the features query bbox semantics (features/service.py): an
@@ -136,7 +140,7 @@ async def export_parquet(
         params.update(minx=bbox[0], miny=bbox[1], maxx=bbox[2], maxy=bbox[3])
     if safe_where is not None:
         clauses.append(f"({safe_where})")
-    where_sql = " AND ".join(clauses)
+    where_sql = " AND ".join(clauses) if clauses else "TRUE"
 
     sql = (
         "SELECT ST_AsBinary(geom_4326) AS wkb_geom, "

--- a/backend/app/processing/export/parquet.py
+++ b/backend/app/processing/export/parquet.py
@@ -181,7 +181,13 @@ async def export_parquet(
             )
         params.update(minx=bbox[0], miny=bbox[1], maxx=bbox[2], maxy=bbox[3])
     if safe_where is not None:
-        clauses.append(f"({safe_where})")
+        # SQLAlchemy text() reads ":name" as a bind parameter; a colon inside a
+        # string literal in the validated where clause (e.g. name = 'A:B' or an
+        # ISO timestamp) would otherwise misparse as an unbound param and fail.
+        # Escape colons to text()'s literal-colon form (\:). The bbox clause's
+        # real :minx/:miny binds are added separately and stay unescaped.
+        escaped_where = safe_where.replace(":", "\\:")
+        clauses.append(f"({escaped_where})")
     where_sql = " AND ".join(clauses) if clauses else "TRUE"
 
     sql = (

--- a/backend/app/processing/export/parquet.py
+++ b/backend/app/processing/export/parquet.py
@@ -30,25 +30,36 @@ from app.processing.ingest.metadata import _qtable
 
 PARQUET_MEDIA_TYPE = "application/vnd.apache.parquet"
 
-# GeoParquet 1.1 file-level metadata. crs omitted => defaults to OGC:CRS84,
-# which is exactly how PostGIS stores geom_4326 (x=lon, y=lat).
-_GEO_METADATA = {
-    "version": "1.1.0",
-    "primary_column": "geometry",
-    "columns": {
-        "geometry": {
-            "encoding": "WKB",
-            # Empty list = "geometry types not advertised" per the spec; avoids a
-            # second pass to collect distinct types.
-            "geometry_types": [],
-        }
-    },
-}
+
+def _geo_metadata(primary_column: str) -> dict:
+    """GeoParquet 1.1 file-level metadata for a given geometry column name.
+
+    crs omitted => defaults to OGC:CRS84, which is exactly how PostGIS stores
+    geom_4326 (x=lon, y=lat).
+    """
+    return {
+        "version": "1.1.0",
+        "primary_column": primary_column,
+        "columns": {
+            primary_column: {
+                "encoding": "WKB",
+                # Empty list = "geometry types not advertised" per the spec;
+                # avoids a second pass to collect distinct types.
+                "geometry_types": [],
+            }
+        },
+    }
 
 
 def _attr_names(column_info: list[dict] | None) -> list[str]:
-    """Attribute column names in declared order, minus internal geometry cols."""
-    skip = {"gid", "geom", "geom_4326", "geometry"}
+    """Attribute column names in declared order, minus internal geometry cols.
+
+    Only the true internal columns (gid + the two geometry columns) are dropped;
+    a user attribute literally named ``geometry`` is a real column and is kept
+    (the WKB output column is renamed to avoid the collision — see
+    build_geoparquet_table).
+    """
+    skip = {"gid", "geom", "geom_4326"}
     return [
         c["name"]
         for c in (column_info or [])
@@ -56,15 +67,30 @@ def _attr_names(column_info: list[dict] | None) -> list[str]:
     ]
 
 
+def _geometry_column_name(attr_names: list[str]) -> str:
+    """Pick the WKB output column name, avoiding a collision with a user column
+    that is itself named ``geometry`` (e.g. a CSV/WKT import's original column)."""
+    if "geometry" not in attr_names:
+        return "geometry"
+    candidate = "geom_wkb"
+    i = 1
+    while candidate in attr_names:
+        candidate = f"geom_wkb_{i}"
+        i += 1
+    return candidate
+
+
 def build_geoparquet_table(
     geom: list[bytes | None],
     cols: dict[str, list],
     attr_names: list[str],
+    geom_col: str = "geometry",
 ) -> "pa.Table":
     """Build a GeoParquet-annotated Arrow table from columnar Python values.
 
-    The geometry column holds WKB bytes; ``geo`` file metadata is attached so
-    DuckDB/GeoPandas/QGIS recognize the file. pyarrow infers each attribute
+    The WKB geometry lives in ``geom_col`` (renamed off "geometry" only when a
+    user attribute already claims that name); ``geo`` file metadata is attached
+    so DuckDB/GeoPandas/QGIS recognize the file. pyarrow infers each attribute
     column's type; a column it can't unify (rare, mixed JSON) falls back to
     string so the export still succeeds. Pure/DB-free so it is unit-testable.
     """
@@ -77,11 +103,11 @@ def build_geoparquet_table(
                 [None if v is None else str(v) for v in cols[name]],
                 type=pa.string(),
             )
-    arrays["geometry"] = pa.array(geom, type=pa.binary())
+    arrays[geom_col] = pa.array(geom, type=pa.binary())
 
     table = pa.table(arrays)
     return table.replace_schema_metadata(
-        {b"geo": json.dumps(_GEO_METADATA).encode("utf-8")}
+        {b"geo": json.dumps(_geo_metadata(geom_col)).encode("utf-8")}
     )
 
 
@@ -160,7 +186,9 @@ async def export_parquet(
         for name in attr_names:
             cols[name].append(props.get(name))
 
-    table = build_geoparquet_table(geom, cols, attr_names)
+    table = build_geoparquet_table(
+        geom, cols, attr_names, _geometry_column_name(attr_names)
+    )
 
     exports_root = ensure_staging_ready(
         os.path.join(settings.upload_staging_dir, "exports")

--- a/backend/app/processing/export/parquet.py
+++ b/backend/app/processing/export/parquet.py
@@ -1,0 +1,159 @@
+"""GeoParquet export writer (pyarrow).
+
+The Debian GDAL build ships without the Arrow/Parquet driver, so ogr2ogr
+(export/ogr.py) cannot emit Parquet. This module writes a spec-valid
+GeoParquet 1.1 file directly from PostGIS via pyarrow instead — the geometry
+column is WKB-encoded and the file carries the ``geo`` metadata key that
+DuckDB, GeoPandas, and QGIS read.
+
+CRS: output is always EPSG:4326 (lon/lat), i.e. GeoParquet's default OGC:CRS84.
+The router rejects a non-4326 ``target_crs`` for parquet, so no reprojection or
+embedded PROJJSON is needed here.
+"""
+
+import json
+import os
+import re
+import shutil
+import uuid
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.config import settings
+from app.core.runtime.staging import ensure_staging_ready
+from app.processing.export.service import validate_where_clause
+from app.processing.export.where_validator import canonical_where
+from app.processing.ingest.metadata import _qtable
+
+PARQUET_MEDIA_TYPE = "application/vnd.apache.parquet"
+
+# GeoParquet 1.1 file-level metadata. crs omitted => defaults to OGC:CRS84,
+# which is exactly how PostGIS stores geom_4326 (x=lon, y=lat).
+_GEO_METADATA = {
+    "version": "1.1.0",
+    "primary_column": "geometry",
+    "columns": {
+        "geometry": {
+            "encoding": "WKB",
+            # Empty list = "geometry types not advertised" per the spec; avoids a
+            # second pass to collect distinct types.
+            "geometry_types": [],
+        }
+    },
+}
+
+
+def _attr_names(column_info: list[dict] | None) -> list[str]:
+    """Attribute column names in declared order, minus internal geometry cols."""
+    skip = {"gid", "geom", "geom_4326", "geometry"}
+    return [
+        c["name"]
+        for c in (column_info or [])
+        if c.get("name") and c["name"] not in skip
+    ]
+
+
+def build_geoparquet_table(
+    geom: list[bytes | None],
+    cols: dict[str, list],
+    attr_names: list[str],
+) -> "pa.Table":
+    """Build a GeoParquet-annotated Arrow table from columnar Python values.
+
+    The geometry column holds WKB bytes; ``geo`` file metadata is attached so
+    DuckDB/GeoPandas/QGIS recognize the file. pyarrow infers each attribute
+    column's type; a column it can't unify (rare, mixed JSON) falls back to
+    string so the export still succeeds. Pure/DB-free so it is unit-testable.
+    """
+    arrays: dict[str, "pa.Array"] = {}
+    for name in attr_names:
+        try:
+            arrays[name] = pa.array(cols[name])
+        except (pa.ArrowInvalid, pa.ArrowTypeError):
+            arrays[name] = pa.array(
+                [None if v is None else str(v) for v in cols[name]],
+                type=pa.string(),
+            )
+    arrays["geometry"] = pa.array(geom, type=pa.binary())
+
+    table = pa.table(arrays)
+    return table.replace_schema_metadata(
+        {b"geo": json.dumps(_GEO_METADATA).encode("utf-8")}
+    )
+
+
+async def export_parquet(
+    db: AsyncSession,
+    table_name: str,
+    dataset_name: str,
+    *,
+    bbox: list[float] | None = None,
+    where: str | None = None,
+    column_info: list[dict] | None = None,
+) -> tuple[str, str, str]:
+    """Export a PostGIS feature table to a GeoParquet file.
+
+    Returns (file_path, download_filename, media_type). The caller owns the
+    returned file's parent directory (FileResponse background cleanup).
+
+    ponytail: builds the whole selection in memory before writing one Parquet
+    file. The export is already capped at 5M features upstream; switch to a
+    fixed-schema batched ParquetWriter if large-catalog exports OOM.
+    """
+    if where is not None:
+        # Same trust boundary as the ogr2ogr -where path: AST allowlist + column
+        # check, then interpolate the canonical re-render, never the raw bytes.
+        validate_where_clause(where, column_info)
+        safe_where = canonical_where(where)
+    else:
+        safe_where = None
+
+    attr_names = _attr_names(column_info)
+
+    clauses: list[str] = ["geom_4326 IS NOT NULL"]
+    params: dict = {}
+    if bbox is not None and bbox[0] <= bbox[2]:
+        clauses.append("geom_4326 && ST_MakeEnvelope(:minx, :miny, :maxx, :maxy, 4326)")
+        params.update(minx=bbox[0], miny=bbox[1], maxx=bbox[2], maxy=bbox[3])
+    if safe_where is not None:
+        clauses.append(f"({safe_where})")
+    where_sql = " AND ".join(clauses)
+
+    sql = (
+        "SELECT ST_AsBinary(geom_4326) AS wkb_geom, "
+        "to_jsonb(t.*) - 'gid' - 'geom' - 'geom_4326' AS props_json "
+        f"FROM {_qtable(table_name)} t WHERE {where_sql}"
+    )
+
+    geom: list[bytes | None] = []
+    cols: dict[str, list] = {name: [] for name in attr_names}
+
+    result = await db.stream(text(sql).bindparams(**params))
+    async for row in result:
+        m = row._mapping
+        wkb = m["wkb_geom"]
+        geom.append(bytes(wkb) if wkb is not None else None)
+        props = m["props_json"] or {}
+        for name in attr_names:
+            cols[name].append(props.get(name))
+
+    table = build_geoparquet_table(geom, cols, attr_names)
+
+    exports_root = ensure_staging_ready(
+        os.path.join(settings.upload_staging_dir, "exports")
+    )
+    temp_dir = str(exports_root / uuid.uuid4().hex)
+    os.mkdir(temp_dir)
+    safe_name = re.sub(r"[^\w\-.]", "_", dataset_name)
+    filename = f"{safe_name}.parquet"
+    output_path = os.path.join(temp_dir, filename)
+    try:
+        pq.write_table(table, output_path)
+    except BaseException:
+        shutil.rmtree(temp_dir, ignore_errors=True)
+        raise
+
+    return output_path, filename, PARQUET_MEDIA_TYPE

--- a/backend/app/processing/export/parquet.py
+++ b/backend/app/processing/export/parquet.py
@@ -22,6 +22,7 @@ import pyarrow.parquet as pq
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.core.async_io import run_in_thread_draining
 from app.core.config import settings
 from app.core.runtime.staging import ensure_staging_ready
 from app.processing.export.service import validate_where_clause
@@ -111,6 +112,21 @@ def build_geoparquet_table(
     )
 
 
+def _write_geoparquet(
+    geom: list[bytes | None],
+    cols: dict[str, list],
+    attr_names: list[str],
+    geom_col: str,
+    output_path: str,
+) -> None:
+    """Build the Arrow table and write the Parquet file (both CPU-bound).
+
+    Blocking; call via run_in_thread_draining so it doesn't stall the event loop.
+    """
+    table = build_geoparquet_table(geom, cols, attr_names, geom_col)
+    pq.write_table(table, output_path)
+
+
 async def export_parquet(
     db: AsyncSession,
     table_name: str,
@@ -186,10 +202,6 @@ async def export_parquet(
         for name in attr_names:
             cols[name].append(props.get(name))
 
-    table = build_geoparquet_table(
-        geom, cols, attr_names, _geometry_column_name(attr_names)
-    )
-
     exports_root = ensure_staging_ready(
         os.path.join(settings.upload_staging_dir, "exports")
     )
@@ -198,8 +210,15 @@ async def export_parquet(
     safe_name = re.sub(r"[^\w\-.]", "_", dataset_name)
     filename = f"{safe_name}.parquet"
     output_path = os.path.join(temp_dir, filename)
+    geom_col = _geometry_column_name(attr_names)
     try:
-        pq.write_table(table, output_path)
+        # Arrow encoding + write are CPU-bound and can block the event loop for
+        # a multi-GB export; run them in a thread (mirrors the shapefile zip path
+        # in export/service.py), drained so a client disconnect can't rmtree
+        # temp_dir mid-write.
+        await run_in_thread_draining(
+            _write_geoparquet, geom, cols, attr_names, geom_col, output_path
+        )
     except BaseException:
         shutil.rmtree(temp_dir, ignore_errors=True)
         raise

--- a/backend/app/processing/export/parquet.py
+++ b/backend/app/processing/export/parquet.py
@@ -115,8 +115,24 @@ async def export_parquet(
 
     clauses: list[str] = ["geom_4326 IS NOT NULL"]
     params: dict = {}
-    if bbox is not None and bbox[0] <= bbox[2]:
-        clauses.append("geom_4326 && ST_MakeEnvelope(:minx, :miny, :maxx, :maxy, 4326)")
+    if bbox is not None:
+        # Mirror the features query bbox semantics (features/service.py): an
+        # envelope && prefilter for the index PLUS an exact ST_Intersects, and
+        # the antimeridian split when minx > maxx (parse_bbox allows it). Using
+        # only && would silently drop antimeridian boxes and return an
+        # envelope-overlap superset instead of the rows actually in the bbox.
+        if bbox[0] > bbox[2]:
+            clauses.append(
+                "((geom_4326 && ST_MakeEnvelope(:minx, :miny, 180, :maxy, 4326)"
+                " AND ST_Intersects(geom_4326, ST_MakeEnvelope(:minx, :miny, 180, :maxy, 4326)))"
+                " OR (geom_4326 && ST_MakeEnvelope(-180, :miny, :maxx, :maxy, 4326)"
+                " AND ST_Intersects(geom_4326, ST_MakeEnvelope(-180, :miny, :maxx, :maxy, 4326))))"
+            )
+        else:
+            clauses.append(
+                "geom_4326 && ST_MakeEnvelope(:minx, :miny, :maxx, :maxy, 4326)"
+                " AND ST_Intersects(geom_4326, ST_MakeEnvelope(:minx, :miny, :maxx, :maxy, 4326))"
+            )
         params.update(minx=bbox[0], miny=bbox[1], maxx=bbox[2], maxy=bbox[3])
     if safe_where is not None:
         clauses.append(f"({safe_where})")

--- a/backend/app/processing/export/parquet.py
+++ b/backend/app/processing/export/parquet.py
@@ -31,6 +31,15 @@ from app.processing.ingest.metadata import _qtable, get_column_info
 
 PARQUET_MEDIA_TYPE = "application/vnd.apache.parquet"
 
+# Mirror router._MAX_EXPORT_FEATURES. The router skips its cap when a dataset's
+# feature_count is NULL (legacy/registered rows); the parquet path builds the
+# selection in memory, so it enforces its own bounded-count cap regardless.
+_MAX_EXPORT_FEATURES = 5_000_000
+
+
+class ExportTooLargeError(Exception):
+    """Raised when a parquet export's selection exceeds _MAX_EXPORT_FEATURES."""
+
 
 def _geo_metadata(primary_column: str) -> dict:
     """GeoParquet 1.1 file-level metadata for a given geometry column name.
@@ -134,7 +143,6 @@ async def export_parquet(
     *,
     bbox: list[float] | None = None,
     where: str | None = None,
-    column_info: list[dict] | None = None,
 ) -> tuple[str, str, str]:
     """Export a PostGIS feature table to a GeoParquet file.
 
@@ -142,22 +150,24 @@ async def export_parquet(
     returned file's parent directory (FileResponse background cleanup).
 
     ponytail: builds the whole selection in memory before writing one Parquet
-    file. The export is already capped at 5M features upstream; switch to a
-    fixed-schema batched ParquetWriter if large-catalog exports OOM.
+    file. Bounded by _MAX_EXPORT_FEATURES below; switch to a fixed-schema batched
+    ParquetWriter if that ceiling ever needs raising.
     """
+    # Introspect the live table once and use it for BOTH column selection and
+    # filter validation — dataset.column_info is nullable, and trusting it would
+    # (a) silently export geometry-only and (b) reject a valid filter on a
+    # metadata-less dataset even though the columns are right here.
+    live_columns = await get_column_info(db, table_name)
+    attr_names = _attr_names(live_columns)
+
     if where is not None:
         # Same trust boundary as the ogr2ogr -where path: AST allowlist + column
-        # check, then interpolate the canonical re-render, never the raw bytes.
-        validate_where_clause(where, column_info)
+        # check (against the live columns), then interpolate the canonical
+        # re-render, never the raw bytes.
+        validate_where_clause(where, live_columns)
         safe_where = canonical_where(where)
     else:
         safe_where = None
-
-    # Introspect the live table for attribute columns rather than trusting the
-    # (nullable) dataset.column_info — otherwise a dataset with missing metadata
-    # would silently export geometry-only. Names come from information_schema, so
-    # they are real identifiers safe to quote.
-    attr_names = _attr_names(await get_column_info(db, table_name))
 
     # No blanket geom_4326 IS NOT NULL: a full export must keep rows with null
     # geometry (they export with a null geometry cell, like the feature read path
@@ -193,6 +203,25 @@ async def export_parquet(
         escaped_where = safe_where.replace(":", "\\:")
         clauses.append(f"({escaped_where})")
     where_sql = " AND ".join(clauses) if clauses else "TRUE"
+
+    # Bound the in-memory build. The router caps by feature_count, but that guard
+    # is skipped when feature_count is NULL, so count the actual selection here
+    # (LIMIT stops the scan at cap+1) before streaming millions of rows into
+    # Python lists and OOMing the worker.
+    count_sql = (
+        f"SELECT COUNT(*) FROM (SELECT 1 FROM {_qtable(table_name)} t "
+        f"WHERE {where_sql} LIMIT :__cap) sub"
+    )
+    count = (
+        await db.execute(
+            text(count_sql).bindparams(**params, __cap=_MAX_EXPORT_FEATURES + 1)
+        )
+    ).scalar_one()
+    if count > _MAX_EXPORT_FEATURES:
+        raise ExportTooLargeError(
+            f"Export selects more than {_MAX_EXPORT_FEATURES} features; narrow it "
+            "with a bbox or attribute filter."
+        )
 
     # Select the attribute columns directly (not via to_jsonb) so the async
     # driver returns native Python values — dates, timestamps, UUIDs, numerics —

--- a/backend/app/processing/export/router.py
+++ b/backend/app/processing/export/router.py
@@ -264,16 +264,26 @@ async def export_dataset_endpoint(
     # build has no Arrow driver); all other formats use the ogr2ogr path.
     try:
         if format == ExportFormat.parquet:
-            from app.processing.export.parquet import export_parquet
-
-            file_path, filename, media_type = await export_parquet(
-                db,
-                dataset.table_name,
-                dataset.record.title,
-                bbox=bbox_parsed,
-                where=where,
-                column_info=dataset.column_info,
+            from app.processing.export.parquet import (
+                ExportTooLargeError,
+                export_parquet,
             )
+
+            try:
+                file_path, filename, media_type = await export_parquet(
+                    db,
+                    dataset.table_name,
+                    dataset.record.title,
+                    bbox=bbox_parsed,
+                    where=where,
+                )
+            except ExportTooLargeError as e:
+                # In-memory parquet build exceeded the cap (covers datasets with a
+                # NULL feature_count that skipped the guard above).
+                raise HTTPException(
+                    status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+                    detail=str(e),
+                )
         else:
             file_path, filename, media_type = await export_dataset(
                 dataset.table_name,

--- a/backend/app/processing/export/router.py
+++ b/backend/app/processing/export/router.py
@@ -113,8 +113,9 @@ async def export_dataset_endpoint(
 ) -> FileResponse:
     """Export a dataset as a downloadable file.
 
-    Supports GeoPackage, GeoJSON, Shapefile (zipped), and CSV formats.
-    Optional CRS reprojection, spatial filtering, and attribute filtering.
+    Supports GeoPackage, GeoJSON, Shapefile (zipped), CSV, and GeoParquet
+    formats. Optional CRS reprojection, spatial filtering, and attribute
+    filtering. GeoParquet is always emitted in EPSG:4326 (OGC:CRS84).
     """
     port = get_processing_port()
     # 1. Fetch dataset
@@ -188,6 +189,14 @@ async def export_dataset_endpoint(
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail="Invalid target_crs: must match EPSG:<code> (e.g. EPSG:3857)",
             )
+        # GeoParquet is written directly via pyarrow in EPSG:4326 (OGC:CRS84);
+        # reprojection/PROJJSON isn't implemented on that path, so reject a
+        # conflicting target rather than silently emitting 4326.
+        if format == ExportFormat.parquet and target_crs.upper() != "EPSG:4326":
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="GeoParquet export is emitted in EPSG:4326; omit target_crs.",
+            )
 
     # 5. Reject raster/VRT datasets: they have no tabular feature table.
     # Key on record_type (loaded via joinedload(Dataset.record) in
@@ -206,7 +215,12 @@ async def export_dataset_endpoint(
         )
 
     # 6. Check geometry compatibility
-    if dataset.geometry_type is None and format in ("gpkg", "geojson", "shp"):
+    if dataset.geometry_type is None and format in (
+        "gpkg",
+        "geojson",
+        "shp",
+        "parquet",
+    ):
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=f"Cannot export non-spatial dataset as {format}. Use csv format.",
@@ -246,17 +260,30 @@ async def export_dataset_endpoint(
                 ),
             )
 
-    # 7. Run export
+    # 7. Run export. GeoParquet goes through the pyarrow writer (the Debian GDAL
+    # build has no Arrow driver); all other formats use the ogr2ogr path.
     try:
-        file_path, filename, media_type = await export_dataset(
-            dataset.table_name,
-            dataset.record.title,
-            format,
-            target_srs=target_crs,
-            bbox=bbox_parsed,
-            where=where,
-            column_info=dataset.column_info,
-        )
+        if format == ExportFormat.parquet:
+            from app.processing.export.parquet import export_parquet
+
+            file_path, filename, media_type = await export_parquet(
+                db,
+                dataset.table_name,
+                dataset.record.title,
+                bbox=bbox_parsed,
+                where=where,
+                column_info=dataset.column_info,
+            )
+        else:
+            file_path, filename, media_type = await export_dataset(
+                dataset.table_name,
+                dataset.record.title,
+                format,
+                target_srs=target_crs,
+                bbox=bbox_parsed,
+                where=where,
+                column_info=dataset.column_info,
+            )
     except ValueError as e:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,

--- a/backend/app/processing/export/router.py
+++ b/backend/app/processing/export/router.py
@@ -229,8 +229,15 @@ async def export_dataset_endpoint(
     # 6b. fix(#430 BA-08): bound full-table exports. Codex r8: for oversized
     # datasets a filter only passes if it actually narrows the selection under
     # the cap (bounded filtered COUNT), closing the where=1=1 bypass.
+    #
+    # Parquet is exempt here: export_parquet() runs its own bounded-count cap
+    # against the LIVE-introspected columns. Running this guard for parquet too
+    # would validate the filter against the nullable dataset.column_info and
+    # wrongly reject a valid filter on a metadata-less oversized dataset before
+    # the parquet path's introspection can run (Codex r10).
     if (
-        dataset.feature_count is not None
+        format != ExportFormat.parquet
+        and dataset.feature_count is not None
         and dataset.feature_count > _MAX_EXPORT_FEATURES
     ):
         if bbox_parsed is None and where is None:

--- a/backend/app/processing/export/schemas.py
+++ b/backend/app/processing/export/schemas.py
@@ -8,3 +8,4 @@ class ExportFormat(StrEnum):
     geojson = "geojson"
     shp = "shp"
     csv = "csv"
+    parquet = "parquet"

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -6067,7 +6067,8 @@
           "gpkg",
           "geojson",
           "shp",
-          "csv"
+          "csv",
+          "parquet"
         ],
         "title": "ExportFormat",
         "type": "string"
@@ -24853,6 +24854,35 @@
       "get": {
         "description": "DCAT-US Schema v3.0 catalog feed. Respects dataset visibility.",
         "operationId": "get_dcat_us3_catalog_datasets_dcat_us_3_0__get",
+        "parameters": [
+          {
+            "description": "Max datasets in this page (default = max).",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 10000,
+              "description": "Max datasets in this page (default = max).",
+              "maximum": 10000,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Datasets to skip \u2014 page a catalog larger than one page.",
+            "in": "query",
+            "name": "offset",
+            "required": false,
+            "schema": {
+              "default": 0,
+              "description": "Datasets to skip \u2014 page a catalog larger than one page.",
+              "minimum": 0,
+              "title": "Offset",
+              "type": "integer"
+            }
+          }
+        ],
         "responses": {
           "200": {
             "content": {
@@ -24991,6 +25021,35 @@
       "get": {
         "description": "DCAT 3 JSON-LD catalog feed. Respects dataset visibility.",
         "operationId": "get_dcat_catalog_datasets_dcat__get",
+        "parameters": [
+          {
+            "description": "Max datasets in this page (default = max).",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 10000,
+              "description": "Max datasets in this page (default = max).",
+              "maximum": 10000,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Datasets to skip \u2014 page a catalog larger than one page.",
+            "in": "query",
+            "name": "offset",
+            "required": false,
+            "schema": {
+              "default": 0,
+              "description": "Datasets to skip \u2014 page a catalog larger than one page.",
+              "minimum": 0,
+              "title": "Offset",
+              "type": "integer"
+            }
+          }
+        ],
         "responses": {
           "200": {
             "content": {
@@ -25129,6 +25188,35 @@
       "get": {
         "description": "GeoDCAT-AP 2.0.0 catalog feed. Respects dataset visibility.",
         "operationId": "get_geodcat_ap_catalog_datasets_geodcat_ap__get",
+        "parameters": [
+          {
+            "description": "Max datasets in this page (default = max).",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 10000,
+              "description": "Max datasets in this page (default = max).",
+              "maximum": 10000,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Datasets to skip \u2014 page a catalog larger than one page.",
+            "in": "query",
+            "name": "offset",
+            "required": false,
+            "schema": {
+              "default": 0,
+              "description": "Datasets to skip \u2014 page a catalog larger than one page.",
+              "minimum": 0,
+              "title": "Offset",
+              "type": "integer"
+            }
+          }
+        ],
         "responses": {
           "200": {
             "content": {
@@ -26905,7 +26993,7 @@
     },
     "/datasets/{dataset_id}/export": {
       "get": {
-        "description": "Export a dataset as a downloadable file.\n\nSupports GeoPackage, GeoJSON, Shapefile (zipped), and CSV formats.\nOptional CRS reprojection, spatial filtering, and attribute filtering.",
+        "description": "Export a dataset as a downloadable file.\n\nSupports GeoPackage, GeoJSON, Shapefile (zipped), CSV, and GeoParquet\nformats. Optional CRS reprojection, spatial filtering, and attribute\nfiltering. GeoParquet is always emitted in EPSG:4326 (OGC:CRS84).",
         "operationId": "export_dataset_endpoint_datasets__dataset_id__export_get",
         "parameters": [
           {

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -77,6 +77,9 @@ dependencies = [
     # prometheus-fastapi-instrumentator>=8.0.0 above; FastAPI (>=0.46.0) and
     # sse-starlette (>=0.49.1) already permit starlette 1.x.
     "starlette>=1.2.1",
+    # GeoParquet export writer (processing/export/parquet.py). The Debian GDAL
+    # build has no Arrow/Parquet driver, so exports are written via pyarrow.
+    "pyarrow>=18.0.0",
 ]
 
 [project.urls]

--- a/backend/tests/test_export_parquet.py
+++ b/backend/tests/test_export_parquet.py
@@ -226,6 +226,63 @@ class TestGeoParquetExport:
             await test_db_session.commit()
 
     @pytest.mark.anyio
+    async def test_export_parquet_introspects_columns_and_preserves_types(
+        self, client: AsyncClient, admin_auth_header: dict, test_db_session
+    ):
+        """Even with column_info absent, attributes are exported (live
+        introspection, not the nullable metadata), and typed columns keep native
+        Arrow types instead of JSON strings."""
+        import datetime
+
+        import pyarrow as pa
+
+        table_name = f"exp_pqtype_{uuid.uuid4().hex[:12]}"
+        await test_db_session.execute(
+            text(
+                f"CREATE TABLE data.{table_name} "
+                "(gid serial PRIMARY KEY, pop integer, evt date, "
+                "geom geometry(Point, 4326), geom_4326 geometry(Point, 4326))"
+            )
+        )
+        await test_db_session.execute(
+            text(
+                f"INSERT INTO data.{table_name} (pop, evt, geom, geom_4326) VALUES "
+                "(7, '2020-01-15', ST_SetSRID(ST_MakePoint(0, 0), 4326), "
+                " ST_SetSRID(ST_MakePoint(0, 0), 4326))"
+            )
+        )
+        await test_db_session.commit()
+        admin_id = await get_user_id(test_db_session, "admin")
+        ds = await _create_dataset(
+            test_db_session,
+            created_by=admin_id,
+            name="TypedParquetDS",
+            table_name=table_name,
+            geometry_type="Point",
+            feature_count=1,
+            column_info=[],  # absent/empty metadata — export must still introspect
+        )
+        try:
+            resp = await client.get(
+                f"/datasets/{ds.id}/export",
+                params={"format": "parquet"},
+                headers=admin_auth_header,
+            )
+            assert resp.status_code == 200
+            table = _read_parquet(resp.content)
+            # Attributes present despite empty column_info.
+            assert {"pop", "evt"} <= set(table.column_names)
+            # Date column kept a native date type (not a JSON/text string).
+            assert pa.types.is_date(table.schema.field("evt").type)
+            assert table.column("evt").to_pylist()[0] == datetime.date(2020, 1, 15)
+            assert table.column("pop").to_pylist()[0] == 7
+        finally:
+            await test_db_session.execute(
+                text(f"DROP TABLE IF EXISTS data.{table_name}")
+            )
+            await test_db_session.commit()
+
+    @pytest.mark.anyio
     async def test_export_parquet_non_spatial_400(
         self, client: AsyncClient, admin_auth_header: dict, test_db_session
     ):

--- a/backend/tests/test_export_parquet.py
+++ b/backend/tests/test_export_parquet.py
@@ -1,0 +1,163 @@
+"""End-to-end tests for the GeoParquet export path.
+
+Unlike test_export.py (which mocks the ogr2ogr service), the parquet path is
+written directly via pyarrow and must run against a real data table. These
+tests create a 3-row point table, export it, and read the bytes back with
+pyarrow to assert the GeoParquet `geo` metadata and geometry decoding.
+
+Requires the Docker database (docker compose up db) with migrations applied.
+"""
+
+import json
+import uuid
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import text
+
+from tests.factories import get_user_id
+from tests.test_export import _create_dataset
+
+
+@pytest.fixture
+async def parquet_dataset(test_db_session):
+    """Real 3-row point table + Dataset row for GeoParquet export."""
+    table_name = f"exp_pq_{uuid.uuid4().hex[:12]}"
+    await test_db_session.execute(
+        text(
+            f"CREATE TABLE data.{table_name} "
+            "(gid serial PRIMARY KEY, pop integer, name text, "
+            "geom geometry(Point, 4326), geom_4326 geometry(Point, 4326))"
+        )
+    )
+    await test_db_session.execute(
+        text(
+            f"INSERT INTO data.{table_name} (pop, name, geom, geom_4326) VALUES "
+            "(10, 'a', ST_SetSRID(ST_MakePoint(0, 0), 4326), "
+            " ST_SetSRID(ST_MakePoint(0, 0), 4326)), "
+            "(20, 'b', ST_SetSRID(ST_MakePoint(1, 1), 4326), "
+            " ST_SetSRID(ST_MakePoint(1, 1), 4326)), "
+            "(30, 'c', ST_SetSRID(ST_MakePoint(2, 2), 4326), "
+            " ST_SetSRID(ST_MakePoint(2, 2), 4326))"
+        )
+    )
+    await test_db_session.commit()
+
+    admin_id = await get_user_id(test_db_session, "admin")
+    ds = await _create_dataset(
+        test_db_session,
+        created_by=admin_id,
+        name="ParquetExportDS",
+        table_name=table_name,
+        geometry_type="Point",
+        feature_count=3,
+        column_info=[
+            {"name": "gid", "type": "integer"},
+            {"name": "pop", "type": "integer"},
+            {"name": "name", "type": "text"},
+        ],
+    )
+    yield ds
+    await test_db_session.execute(text(f"DROP TABLE IF EXISTS data.{table_name}"))
+    await test_db_session.commit()
+
+
+def _read_parquet(content: bytes):
+    return pq.read_table(pa.BufferReader(content))
+
+
+class TestGeoParquetExport:
+    @pytest.mark.anyio
+    async def test_export_parquet_valid_geoparquet(
+        self, client: AsyncClient, admin_auth_header: dict, parquet_dataset
+    ):
+        """format=parquet returns a valid GeoParquet: geo metadata + all rows."""
+        resp = await client.get(
+            f"/datasets/{parquet_dataset.id}/export",
+            params={"format": "parquet"},
+            headers=admin_auth_header,
+        )
+        assert resp.status_code == 200
+        assert "parquet" in resp.headers["content-type"]
+
+        table = _read_parquet(resp.content)
+        assert table.num_rows == 3
+        assert "geometry" in table.column_names
+        assert {"pop", "name"} <= set(table.column_names)
+
+        # GeoParquet file-level `geo` metadata is present and well-formed.
+        meta = table.schema.metadata
+        assert meta is not None and b"geo" in meta
+        geo = json.loads(meta[b"geo"])
+        assert geo["version"] == "1.1.0"
+        assert geo["primary_column"] == "geometry"
+        assert geo["columns"]["geometry"]["encoding"] == "WKB"
+
+        # Geometry column decodes as valid WKB.
+        from shapely import wkb as shapely_wkb
+
+        geoms = table.column("geometry").to_pylist()
+        assert len(geoms) == 3
+        pt = shapely_wkb.loads(geoms[0])
+        assert pt.geom_type == "Point"
+
+    @pytest.mark.anyio
+    async def test_export_parquet_where_filter(
+        self, client: AsyncClient, admin_auth_header: dict, parquet_dataset
+    ):
+        """A where clause narrows the exported rows."""
+        resp = await client.get(
+            f"/datasets/{parquet_dataset.id}/export",
+            params={"format": "parquet", "where": "pop > 25"},
+            headers=admin_auth_header,
+        )
+        assert resp.status_code == 200
+        table = _read_parquet(resp.content)
+        assert table.num_rows == 1
+
+    @pytest.mark.anyio
+    async def test_export_parquet_rejects_non_4326_crs(
+        self, client: AsyncClient, admin_auth_header: dict, parquet_dataset
+    ):
+        """A non-4326 target_crs is rejected (parquet is CRS84-only)."""
+        resp = await client.get(
+            f"/datasets/{parquet_dataset.id}/export",
+            params={"format": "parquet", "target_crs": "EPSG:3857"},
+            headers=admin_auth_header,
+        )
+        assert resp.status_code == 400
+        assert "4326" in resp.json()["detail"]
+
+    @pytest.mark.anyio
+    async def test_export_parquet_allows_4326_crs(
+        self, client: AsyncClient, admin_auth_header: dict, parquet_dataset
+    ):
+        """target_crs=EPSG:4326 is the identity case and is allowed."""
+        resp = await client.get(
+            f"/datasets/{parquet_dataset.id}/export",
+            params={"format": "parquet", "target_crs": "EPSG:4326"},
+            headers=admin_auth_header,
+        )
+        assert resp.status_code == 200
+
+    @pytest.mark.anyio
+    async def test_export_parquet_non_spatial_400(
+        self, client: AsyncClient, admin_auth_header: dict, test_db_session
+    ):
+        """A non-spatial dataset cannot be exported as parquet."""
+        admin_id = await get_user_id(test_db_session, "admin")
+        ds = await _create_dataset(
+            test_db_session,
+            created_by=admin_id,
+            name="NonSpatialParquetDS",
+            geometry_type=None,
+        )
+        resp = await client.get(
+            f"/datasets/{ds.id}/export",
+            params={"format": "parquet"},
+            headers=admin_auth_header,
+        )
+        assert resp.status_code == 400
+        assert "non-spatial" in resp.json()["detail"].lower()

--- a/backend/tests/test_export_parquet.py
+++ b/backend/tests/test_export_parquet.py
@@ -331,6 +331,56 @@ class TestGeoParquetExport:
             await test_db_session.commit()
 
     @pytest.mark.anyio
+    async def test_export_parquet_oversized_metadata_less_is_filterable(
+        self, client: AsyncClient, admin_auth_header: dict, test_db_session
+    ):
+        """An oversized (feature_count > cap) parquet dataset with empty
+        column_info stays filterable: the router's cap guard is skipped for
+        parquet, and export_parquet validates the filter against live columns
+        (Codex r10 regression)."""
+        table_name = f"exp_pqov_{uuid.uuid4().hex[:12]}"
+        await test_db_session.execute(
+            text(
+                f"CREATE TABLE data.{table_name} (gid serial PRIMARY KEY, "
+                "pop integer, geom geometry(Point, 4326), "
+                "geom_4326 geometry(Point, 4326))"
+            )
+        )
+        await test_db_session.execute(
+            text(
+                f"INSERT INTO data.{table_name} (pop, geom, geom_4326) VALUES "
+                "(10, ST_SetSRID(ST_MakePoint(0, 0), 4326), "
+                " ST_SetSRID(ST_MakePoint(0, 0), 4326)), "
+                "(30, ST_SetSRID(ST_MakePoint(1, 1), 4326), "
+                " ST_SetSRID(ST_MakePoint(1, 1), 4326))"
+            )
+        )
+        await test_db_session.commit()
+        admin_id = await get_user_id(test_db_session, "admin")
+        ds = await _create_dataset(
+            test_db_session,
+            created_by=admin_id,
+            name="OversizedNoMetaDS",
+            table_name=table_name,
+            geometry_type="Point",
+            feature_count=5_000_001,  # trips the router cap path
+            column_info=[],  # ...which must NOT reject the filter for parquet
+        )
+        try:
+            resp = await client.get(
+                f"/datasets/{ds.id}/export",
+                params={"format": "parquet", "where": "pop > 20"},
+                headers=admin_auth_header,
+            )
+            assert resp.status_code == 200
+            assert _read_parquet(resp.content).num_rows == 1
+        finally:
+            await test_db_session.execute(
+                text(f"DROP TABLE IF EXISTS data.{table_name}")
+            )
+            await test_db_session.commit()
+
+    @pytest.mark.anyio
     async def test_export_parquet_bounded_row_cap(
         self, client: AsyncClient, admin_auth_header: dict, parquet_dataset, monkeypatch
     ):

--- a/backend/tests/test_export_parquet.py
+++ b/backend/tests/test_export_parquet.py
@@ -132,6 +132,23 @@ class TestGeoParquetExport:
         assert _read_parquet(resp.content).num_rows == 1
 
     @pytest.mark.anyio
+    async def test_export_parquet_where_colon_literal(
+        self, client: AsyncClient, admin_auth_header: dict, parquet_dataset
+    ):
+        """A colon inside a where string literal must not be misparsed as a
+        SQLAlchemy bind param. The literal ' :name' has a colon after a
+        non-word char (space), which text() would otherwise read as an unbound
+        ':name' param; 'name' also keeps the identifier validator happy."""
+        resp = await client.get(
+            f"/datasets/{parquet_dataset.id}/export",
+            params={"format": "parquet", "where": "name = ' :name'"},
+            headers=admin_auth_header,
+        )
+        assert resp.status_code == 200
+        # No row equals ' :name'; the point is that it executes rather than 500s.
+        assert _read_parquet(resp.content).num_rows == 0
+
+    @pytest.mark.anyio
     async def test_export_parquet_rejects_non_4326_crs(
         self, client: AsyncClient, admin_auth_header: dict, parquet_dataset
     ):

--- a/backend/tests/test_export_parquet.py
+++ b/backend/tests/test_export_parquet.py
@@ -157,6 +157,58 @@ class TestGeoParquetExport:
         assert resp.status_code == 200
 
     @pytest.mark.anyio
+    async def test_export_parquet_keeps_null_geometry_rows(
+        self, client: AsyncClient, admin_auth_header: dict, test_db_session
+    ):
+        """A full export keeps rows whose geom_4326 is NULL (exported with a null
+        geometry cell), matching the other formats and the feature read path."""
+        table_name = f"exp_pqnull_{uuid.uuid4().hex[:12]}"
+        await test_db_session.execute(
+            text(
+                f"CREATE TABLE data.{table_name} "
+                "(gid serial PRIMARY KEY, pop integer, "
+                "geom geometry(Point, 4326), geom_4326 geometry(Point, 4326))"
+            )
+        )
+        await test_db_session.execute(
+            text(
+                f"INSERT INTO data.{table_name} (pop, geom, geom_4326) VALUES "
+                "(1, ST_SetSRID(ST_MakePoint(0, 0), 4326), "
+                " ST_SetSRID(ST_MakePoint(0, 0), 4326)), "
+                "(2, NULL, NULL)"
+            )
+        )
+        await test_db_session.commit()
+        admin_id = await get_user_id(test_db_session, "admin")
+        ds = await _create_dataset(
+            test_db_session,
+            created_by=admin_id,
+            name="NullGeomParquetDS",
+            table_name=table_name,
+            geometry_type="Point",
+            feature_count=2,
+            column_info=[
+                {"name": "gid", "type": "integer"},
+                {"name": "pop", "type": "integer"},
+            ],
+        )
+        try:
+            resp = await client.get(
+                f"/datasets/{ds.id}/export",
+                params={"format": "parquet"},
+                headers=admin_auth_header,
+            )
+            assert resp.status_code == 200
+            table = _read_parquet(resp.content)
+            assert table.num_rows == 2
+            assert None in table.column("geometry").to_pylist()
+        finally:
+            await test_db_session.execute(
+                text(f"DROP TABLE IF EXISTS data.{table_name}")
+            )
+            await test_db_session.commit()
+
+    @pytest.mark.anyio
     async def test_export_parquet_non_spatial_400(
         self, client: AsyncClient, admin_auth_header: dict, test_db_session
     ):

--- a/backend/tests/test_export_parquet.py
+++ b/backend/tests/test_export_parquet.py
@@ -283,6 +283,70 @@ class TestGeoParquetExport:
             await test_db_session.commit()
 
     @pytest.mark.anyio
+    async def test_export_parquet_filter_without_column_info(
+        self, client: AsyncClient, admin_auth_header: dict, test_db_session
+    ):
+        """A where filter works on a dataset with empty column_info — validated
+        against live-introspected columns, not the absent stored metadata."""
+        table_name = f"exp_pqf_{uuid.uuid4().hex[:12]}"
+        await test_db_session.execute(
+            text(
+                f"CREATE TABLE data.{table_name} (gid serial PRIMARY KEY, "
+                "pop integer, geom geometry(Point, 4326), "
+                "geom_4326 geometry(Point, 4326))"
+            )
+        )
+        await test_db_session.execute(
+            text(
+                f"INSERT INTO data.{table_name} (pop, geom, geom_4326) VALUES "
+                "(10, ST_SetSRID(ST_MakePoint(0, 0), 4326), "
+                " ST_SetSRID(ST_MakePoint(0, 0), 4326)), "
+                "(30, ST_SetSRID(ST_MakePoint(1, 1), 4326), "
+                " ST_SetSRID(ST_MakePoint(1, 1), 4326))"
+            )
+        )
+        await test_db_session.commit()
+        admin_id = await get_user_id(test_db_session, "admin")
+        ds = await _create_dataset(
+            test_db_session,
+            created_by=admin_id,
+            name="NoMetaFilterDS",
+            table_name=table_name,
+            geometry_type="Point",
+            feature_count=2,
+            column_info=[],  # absent metadata — filter must validate on live cols
+        )
+        try:
+            resp = await client.get(
+                f"/datasets/{ds.id}/export",
+                params={"format": "parquet", "where": "pop > 20"},
+                headers=admin_auth_header,
+            )
+            assert resp.status_code == 200
+            assert _read_parquet(resp.content).num_rows == 1
+        finally:
+            await test_db_session.execute(
+                text(f"DROP TABLE IF EXISTS data.{table_name}")
+            )
+            await test_db_session.commit()
+
+    @pytest.mark.anyio
+    async def test_export_parquet_bounded_row_cap(
+        self, client: AsyncClient, admin_auth_header: dict, parquet_dataset, monkeypatch
+    ):
+        """The parquet path enforces its own in-memory cap (independent of the
+        router's feature_count guard) — lower it to 1 against a 3-row table."""
+        from app.processing.export import parquet as parquet_mod
+
+        monkeypatch.setattr(parquet_mod, "_MAX_EXPORT_FEATURES", 1)
+        resp = await client.get(
+            f"/datasets/{parquet_dataset.id}/export",
+            params={"format": "parquet"},
+            headers=admin_auth_header,
+        )
+        assert resp.status_code == 413
+
+    @pytest.mark.anyio
     async def test_export_parquet_non_spatial_400(
         self, client: AsyncClient, admin_auth_header: dict, test_db_session
     ):

--- a/backend/tests/test_export_parquet.py
+++ b/backend/tests/test_export_parquet.py
@@ -118,6 +118,20 @@ class TestGeoParquetExport:
         assert table.num_rows == 1
 
     @pytest.mark.anyio
+    async def test_export_parquet_bbox_exact_intersection(
+        self, client: AsyncClient, admin_auth_header: dict, parquet_dataset
+    ):
+        """A bbox selects only features that actually intersect it (points at
+        (0,0),(1,1),(2,2); bbox around (1,1) returns exactly one)."""
+        resp = await client.get(
+            f"/datasets/{parquet_dataset.id}/export",
+            params={"format": "parquet", "bbox": "0.5,0.5,1.5,1.5"},
+            headers=admin_auth_header,
+        )
+        assert resp.status_code == 200
+        assert _read_parquet(resp.content).num_rows == 1
+
+    @pytest.mark.anyio
     async def test_export_parquet_rejects_non_4326_crs(
         self, client: AsyncClient, admin_auth_header: dict, parquet_dataset
     ):

--- a/backend/tests/test_export_parquet_writer.py
+++ b/backend/tests/test_export_parquet_writer.py
@@ -1,0 +1,67 @@
+"""DB-free unit tests for the GeoParquet writer core.
+
+These exercise build_geoparquet_table() directly (no Postgres, no HTTP), so the
+risky bits — geo metadata, WKB round-trip, mixed-type fallback — are verified
+without infrastructure. The DB-backed endpoint path is covered by
+test_export_parquet.py.
+"""
+
+import io
+import json
+
+import pyarrow.parquet as pq
+from shapely import wkb as shapely_wkb
+from shapely.geometry import Point
+
+from app.processing.export.parquet import _attr_names, build_geoparquet_table
+
+
+def _roundtrip(table):
+    buf = io.BytesIO()
+    pq.write_table(table, buf)
+    buf.seek(0)
+    return pq.read_table(buf)
+
+
+def test_attr_names_strips_internal_geometry_columns():
+    column_info = [
+        {"name": "gid", "type": "integer"},
+        {"name": "geom", "type": "geometry"},
+        {"name": "geom_4326", "type": "geometry"},
+        {"name": "pop", "type": "integer"},
+        {"name": "name", "type": "text"},
+    ]
+    assert _attr_names(column_info) == ["pop", "name"]
+
+
+def test_build_table_has_geoparquet_metadata_and_decodes():
+    geom = [Point(0, 0).wkb, Point(1, 1).wkb]
+    cols = {"pop": [10, 20], "name": ["a", "b"]}
+    table = _roundtrip(build_geoparquet_table(geom, cols, ["pop", "name"]))
+
+    assert table.num_rows == 2
+    assert table.column_names == ["pop", "name", "geometry"]
+
+    geo = json.loads(table.schema.metadata[b"geo"])
+    assert geo["version"] == "1.1.0"
+    assert geo["primary_column"] == "geometry"
+    assert geo["columns"]["geometry"]["encoding"] == "WKB"
+
+    pt = shapely_wkb.loads(table.column("geometry").to_pylist()[0])
+    assert (pt.x, pt.y) == (0.0, 0.0)
+
+
+def test_build_table_null_geometry_allowed():
+    table = _roundtrip(build_geoparquet_table([None], {"pop": [1]}, ["pop"]))
+    assert table.column("geometry").to_pylist() == [None]
+
+
+def test_build_table_mixed_type_column_falls_back_to_string():
+    # A column pyarrow cannot unify (int + dict) must not crash the export; it
+    # degrades to string so the file still writes.
+    geom = [Point(0, 0).wkb, Point(1, 1).wkb]
+    cols = {"weird": [1, {"nested": True}]}
+    table = _roundtrip(build_geoparquet_table(geom, cols, ["weird"]))
+    vals = table.column("weird").to_pylist()
+    assert vals[0] == "1"
+    assert "nested" in vals[1]

--- a/backend/tests/test_export_parquet_writer.py
+++ b/backend/tests/test_export_parquet_writer.py
@@ -13,7 +13,11 @@ import pyarrow.parquet as pq
 from shapely import wkb as shapely_wkb
 from shapely.geometry import Point
 
-from app.processing.export.parquet import _attr_names, build_geoparquet_table
+from app.processing.export.parquet import (
+    _attr_names,
+    _geometry_column_name,
+    build_geoparquet_table,
+)
 
 
 def _roundtrip(table):
@@ -32,6 +36,34 @@ def test_attr_names_strips_internal_geometry_columns():
         {"name": "name", "type": "text"},
     ]
     assert _attr_names(column_info) == ["pop", "name"]
+
+
+def test_attr_names_keeps_user_geometry_column():
+    # A user attribute literally named "geometry" (e.g. a WKT import's original
+    # column) must NOT be dropped as if it were internal.
+    column_info = [
+        {"name": "gid", "type": "integer"},
+        {"name": "geom_4326", "type": "geometry"},
+        {"name": "geometry", "type": "text"},
+        {"name": "pop", "type": "integer"},
+    ]
+    assert _attr_names(column_info) == ["geometry", "pop"]
+
+
+def test_user_geometry_column_preserved_without_collision():
+    # WKB output column is renamed off "geometry"; the user's "geometry" values
+    # survive, and geo metadata points primary_column at the renamed column.
+    geom = [Point(0, 0).wkb, Point(1, 1).wkb]
+    cols = {"geometry": ["POINT(0 0)", "POINT(1 1)"], "pop": [1, 2]}
+    attr_names = ["geometry", "pop"]
+    geom_col = _geometry_column_name(attr_names)
+    assert geom_col == "geom_wkb"
+
+    table = _roundtrip(build_geoparquet_table(geom, cols, attr_names, geom_col))
+    assert table.column("geometry").to_pylist() == ["POINT(0 0)", "POINT(1 1)"]
+    geo = json.loads(table.schema.metadata[b"geo"])
+    assert geo["primary_column"] == "geom_wkb"
+    assert shapely_wkb.loads(table.column("geom_wkb").to_pylist()[0]).x == 0.0
 
 
 def test_build_table_has_geoparquet_metadata_and_decodes():

--- a/backend/tests/test_ogc_record_properties.py
+++ b/backend/tests/test_ogc_record_properties.py
@@ -99,11 +99,12 @@ async def test_record_has_formats_list(client: AsyncClient, test_db_session):
     assert "formats" in props
     formats = props["formats"]
     assert isinstance(formats, list)
-    assert len(formats) == 4
+    assert len(formats) == 5
     assert "application/geopackage+sqlite3" in formats
     assert "application/geo+json" in formats
     assert "application/x-shapefile" in formats
     assert "text/csv" in formats
+    assert "application/vnd.apache.parquet" in formats
 
 
 # ---------------------------------------------------------------------------
@@ -496,7 +497,7 @@ async def test_vector_record_formats_includes_shapefile(
     props = resp.json()["properties"]
     formats = props["formats"]
     assert "application/x-shapefile" in formats
-    assert len(formats) == 4
+    assert len(formats) == 5
 
 
 @pytest.mark.anyio

--- a/backend/tests/test_records_related.py
+++ b/backend/tests/test_records_related.py
@@ -1095,7 +1095,7 @@ class TestMigrationData:
             )
         )
         download_dists = result.scalars().all()
-        assert len(download_dists) == 4
+        assert len(download_dists) == 5
 
         for d in download_dists:
             assert dataset_id_str in d.url, (

--- a/backend/tests/test_records_related.py
+++ b/backend/tests/test_records_related.py
@@ -1095,7 +1095,7 @@ class TestMigrationData:
             )
         )
         download_dists = result.scalars().all()
-        assert len(download_dists) == 5
+        assert len(download_dists) == 4
 
         for d in download_dists:
             assert dataset_id_str in d.url, (

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -893,6 +893,7 @@ dependencies = [
     { name = "psycopg" },
     { name = "puremagic" },
     { name = "pwdlib", extra = ["bcrypt"] },
+    { name = "pyarrow" },
     { name = "pydantic", extra = ["email"] },
     { name = "pydantic-settings" },
     { name = "pygeofilter", extra = ["backend-sqlalchemy"] },
@@ -952,6 +953,7 @@ requires-dist = [
     { name = "psycopg", specifier = ">=3.3.4" },
     { name = "puremagic", specifier = ">=2.2.0" },
     { name = "pwdlib", extras = ["bcrypt"], specifier = ">=0.3.0" },
+    { name = "pyarrow", specifier = ">=18.0.0" },
     { name = "pydantic", extras = ["email"], specifier = ">=2.13.4" },
     { name = "pydantic-settings", specifier = ">=2.14.2" },
     { name = "pygeofilter", extras = ["backend-sqlalchemy"], specifier = ">=0.4.0" },
@@ -1766,6 +1768,35 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/73/21/d250cfca8ff30c2e5a7447bc13861541126ce9bd4426cd5d0c9f08b5547d/py_serializable-2.1.0.tar.gz", hash = "sha256:9d5db56154a867a9b897c0163b33a793c804c80cee984116d02d49e4578fc103", size = 52368, upload-time = "2025-07-21T09:56:48.07Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9b/bf/7595e817906a29453ba4d99394e781b6fabe55d21f3c15d240f85dd06bb1/py_serializable-2.1.0-py3-none-any.whl", hash = "sha256:b56d5d686b5a03ba4f4db5e769dc32336e142fc3bd4d68a8c25579ebb0a67304", size = 23045, upload-time = "2025-07-21T09:56:46.848Z" },
+]
+
+[[package]]
+name = "pyarrow"
+version = "25.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/27/f3/95428098d1fa7d04432fb750eed06b41304c2f6a5d3319985e64db2d9d41/pyarrow-25.0.0.tar.gz", hash = "sha256:d2d697008b5ec06d75952ef260c2e9a8a0f6ccfce24266c04c9c8ade927cb3b4", size = 1199181, upload-time = "2026-07-10T08:29:50.116Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6c/c8/098ce17d778fd9d29e40bb8c5f19a40cc90c3f0b46c9057b0d7993f42f54/pyarrow-25.0.0-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:8831a3ba52fa7cdb78d368d968b1dcd06171e6dff5461e16d90de91d371e47bc", size = 35844549, upload-time = "2026-07-10T08:27:37.956Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/66/24c28877219abf6263d909b1592c97ff82c59f13a59acbed11fc87c0654f/pyarrow-25.0.0-cp313-cp313-macosx_12_0_x86_64.whl", hash = "sha256:5f4bacb60f91dd2fca6c52f1b9a0012cd090e0294f1f781dc1881a247a352f8e", size = 37610397, upload-time = "2026-07-10T08:27:43.803Z" },
+    { url = "https://files.pythonhosted.org/packages/53/55/6d1d5f5aff317ec5de9421594679ed51ed828fe7e2ce209327f819d801e4/pyarrow-25.0.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:59516c822d5fd8e544aaa0dfe72f36fed5d4c24ea8390aab1bcd31d7e959c6be", size = 46841701, upload-time = "2026-07-10T08:27:49.741Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/5d/f790fb6965ab54c9da0dda7856abc75fd0d7648d865f8d603c111d203a64/pyarrow-25.0.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:6f9dbd83e91c239a1f5ee7ce13f108b5f6c0efbe40a4375260d8f08b43ad05e9", size = 50090118, upload-time = "2026-07-10T08:27:56.051Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/8c/faf025357ebf31bc96777f234277aa31e2aeca6dd4ecaa391f29085473c2/pyarrow-25.0.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:18dcc8cc50b5e72eae6fcbfc6c8776c21a007176b27a3cdec5c2f5bcf126708d", size = 49945559, upload-time = "2026-07-10T08:28:01.927Z" },
+    { url = "https://files.pythonhosted.org/packages/07/a1/bd051871708ea99a5e0fc711926c26c6f2c6d0130c7aaac8093e34998af6/pyarrow-25.0.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:4ec1895a87aa834c3b99b7a1e758747eb8bb57f922b32c0e0fa04afb8d6998b1", size = 53114238, upload-time = "2026-07-10T08:28:08.594Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/31/737f0c3cffcd6af647849477d1dd68045deac2e3963c3f9f211bedc48540/pyarrow-25.0.0-cp313-cp313-win_amd64.whl", hash = "sha256:77c8d1ae46a44b4006e8db1cc977bbcc6ce4873c92f74137d68e45503b97fb18", size = 27861162, upload-time = "2026-07-10T08:28:12.975Z" },
+    { url = "https://files.pythonhosted.org/packages/55/c7/581ccbcdb3d897eb2893328d68db3d52eca373bf2a7e964d0a6276b8e85b/pyarrow-25.0.0-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:72132b9a8a0a1840197794d4dea26080069b6b0981c116bc078762dc9691b21b", size = 35878945, upload-time = "2026-07-10T08:28:18.222Z" },
+    { url = "https://files.pythonhosted.org/packages/64/d1/ccb01db7329ea0411ef4fbd9b62a04d3268b36777d4e758d5e39b91ddeab/pyarrow-25.0.0-cp314-cp314-macosx_12_0_x86_64.whl", hash = "sha256:e009ef945e498dca2f050ea10d2e9764cb44017254826fc4574fdb8d2530173b", size = 37630854, upload-time = "2026-07-10T08:28:23.452Z" },
+    { url = "https://files.pythonhosted.org/packages/af/9f/2d81ba89d1e4198d0cb25fe7529de936830fdaec0db926bb52a1ef7080d4/pyarrow-25.0.0-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:f57a39dbcb416345401c2e77a4373669b45fd111a1768e6cf267a7a0607ff0ec", size = 46905617, upload-time = "2026-07-10T08:28:29.376Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/29/0ed312ec800fb536f93783215126cee4b8977dcfeccba6f0f44df0cc87d7/pyarrow-25.0.0-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:447df764beb07c544f0178a5f6b70ef44b9ecf382b3cdfad4c2d7867353c3887", size = 50119765, upload-time = "2026-07-10T08:28:35.826Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/88/cab5063ba0c4d46a9f6b4b7eb1c9029dc0302d65cd5ab3510c949a386568/pyarrow-25.0.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:ac5dfeee59f9ceb4d45ba76e83b026c38c24334135bb329d8274baa49cec3c62", size = 50027563, upload-time = "2026-07-10T08:28:43.848Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/fb/4d24f1b7fe2e042dc4ef315ef75e4e702d8e46fe10c37e63caff00502b03/pyarrow-25.0.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:f0f100dacf2c0f400601664a79d1a907ced4740514bb2b00917341038e2ce76f", size = 53162437, upload-time = "2026-07-10T08:28:52.819Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/65/da20806de93ca6ee91e72cb6a9b08b3ac890b46efc8d94a7326c651c4c81/pyarrow-25.0.0-cp314-cp314-win_amd64.whl", hash = "sha256:2e093efbecb5317372f819228fa4b4e6157eee48d3f0a7b0303705ebf81a7104", size = 28613262, upload-time = "2026-07-10T08:29:47.544Z" },
+    { url = "https://files.pythonhosted.org/packages/86/9f/c632afb1d3ef4a7814cee236718235f3a47eac46e97eb87df40f550b6b48/pyarrow-25.0.0-cp314-cp314t-macosx_12_0_arm64.whl", hash = "sha256:26be35b80780d2d21f4bae3d568b1666337c3a89722cc1794c956a77017cb24e", size = 36120702, upload-time = "2026-07-10T08:28:59.577Z" },
+    { url = "https://files.pythonhosted.org/packages/36/0a/093d53a0e72ad06e45d6443e00651bbc2d21af4211295086cbf4d873d3b9/pyarrow-25.0.0-cp314-cp314t-macosx_12_0_x86_64.whl", hash = "sha256:6f4812bfbf11ca7d8faf59eb8fff8bf4dd25ce3a38b62baa010cc17a0926d1b2", size = 37750674, upload-time = "2026-07-10T08:29:06.916Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/18/b37fc31a69cff4bdfb8842683def5612f551b93fff6f44375e4a4a6a5535/pyarrow-25.0.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:b8af8ceedf0c9c160fd2b63440f2d205b9404db85866c1217bfea601de7cfb50", size = 46912304, upload-time = "2026-07-10T08:29:14.656Z" },
+    { url = "https://files.pythonhosted.org/packages/32/35/5cae19ba72493e5598022468b56f6a5571f399f485bf412f157356476caa/pyarrow-25.0.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:c70a5fd9a82bd1a702fd482bdc62d38dcb672fb2b449b1d7c0d7d1f4be7b7bfe", size = 50073652, upload-time = "2026-07-10T08:29:22.467Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/a5/ddd508424bdfd5e6945765e9e2ffc687e2f6115972badc8ecf423076c407/pyarrow-25.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:0490a7f8b38ffe11cc26526b50c65d111cb54ddac3717cec781806793f1244dc", size = 50058654, upload-time = "2026-07-10T08:29:29.689Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/a4/324d0db203ff5eebe8694ec2d6ec5a23f9aaa5d02e5b8c692914c518c33c/pyarrow-25.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:e83916bbcf380866b4e14255850b33323ff678dc9758411d0409cdd2523880b0", size = 53140153, upload-time = "2026-07-10T08:29:36.041Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/8d/d236e9c82fe315f9128885c8be3ec719f41965a1eb6b6f4b42470904cd41/pyarrow-25.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:13240f0d3dc5932ccd0bfa90cd76d835680b9d94a7661c635df4b703d40ce849", size = 28743657, upload-time = "2026-07-10T08:29:42.742Z" },
 ]
 
 [[package]]

--- a/frontend/public/llms.txt
+++ b/frontend/public/llms.txt
@@ -1,0 +1,29 @@
+# GeoLens
+
+> GeoLens is a PostGIS-native geospatial data catalog. It exposes its holdings
+> through open standards (OGC API, STAC, DCAT) and a JSON search API, so agents
+> can discover datasets, read metadata, and query features directly. The links
+> below are live discovery endpoints on this instance — follow them to enumerate
+> the actual collections; they reflect only datasets the caller is allowed to see.
+
+## API
+
+- [OpenAPI schema](/api/openapi.json): Full machine-readable API description.
+- [API docs](/api/docs): Interactive OpenAPI documentation (non-production instances).
+- [Dataset search](/api/search/datasets/): Keyword, spatial (bbox/GeoJSON), and CQL2 search over the catalog. Returns dataset metadata as JSON.
+- [Search facets](/api/search/facets/): Aggregated facet counts (record type, keywords, organization, SRID, collections).
+
+## Standards
+
+- [OGC API landing](/api/): OGC API — Common/Features/Records landing page and conformance.
+- [OGC API collections](/api/collections): Each dataset as an OGC API collection; the `datasets` collection is the Records catalog (CQL2 + sorting).
+- [STAC catalog](/api/stac): SpatioTemporal Asset Catalog root, collections, and `/search`.
+- [DCAT-US 3.0 feed](/api/datasets/dcat-us/3.0): Federal `data.json`-style catalog feed (supports `?limit=&offset=` paging).
+- [DCAT 3 feed](/api/datasets/dcat/): W3C DCAT 3 JSON-LD catalog feed.
+- [GeoDCAT-AP feed](/api/datasets/geodcat-ap/): GeoDCAT-AP 2.0.0 JSON-LD catalog feed.
+
+## Data access
+
+- Per-dataset metadata: `/api/datasets/{id}` — full record, schema, extent, and distributions.
+- Features: `/api/collections/{id}/items` — GeoJSON features (OGC API — Features).
+- Export: `/api/datasets/{id}/export?format=parquet` — GeoParquet (also gpkg, geojson, shp, csv); query the result with DuckDB.

--- a/frontend/public/llms.txt
+++ b/frontend/public/llms.txt
@@ -17,7 +17,7 @@
 
 - [OGC API landing](/api/): OGC API — Common/Features/Records landing page and conformance.
 - [OGC API collections](/api/collections): Each dataset as an OGC API collection; the `datasets` collection is the Records catalog (CQL2 + sorting).
-- [STAC catalog](/api/stac): SpatioTemporal Asset Catalog root, collections, and `/search`.
+- [STAC catalog](/api/stac/): SpatioTemporal Asset Catalog root, collections, and `/search`.
 - [DCAT-US 3.0 feed](/api/datasets/dcat-us/3.0): Federal `data.json`-style catalog feed (supports `?limit=&offset=` paging).
 - [DCAT 3 feed](/api/datasets/dcat/): W3C DCAT 3 JSON-LD catalog feed.
 - [GeoDCAT-AP feed](/api/datasets/geodcat-ap/): GeoDCAT-AP 2.0.0 JSON-LD catalog feed.

--- a/frontend/src/components/dataset/ExportButton.tsx
+++ b/frontend/src/components/dataset/ExportButton.tsx
@@ -9,6 +9,7 @@ import {
   SelectValue,
 } from '@/components/ui/select';
 import { downloadExport } from '@/api/datasets';
+import { CopyButton } from '@/components/ui/copy-button';
 import { Download, Loader2 } from 'lucide-react';
 import type { RecordType } from '@/types/api';
 
@@ -23,6 +24,7 @@ const EXPORT_FORMATS = [
   { value: 'geojson', labelKey: 'export.geojson', ext: 'geojson' },
   { value: 'shp', labelKey: 'export.shp', ext: 'zip' },
   { value: 'csv', labelKey: 'export.csv', ext: 'csv' },
+  { value: 'parquet', labelKey: 'export.parquet', ext: 'parquet' },
 ] as const;
 
 const CSV_ONLY = EXPORT_FORMATS.filter((f) => f.value === 'csv');
@@ -37,6 +39,11 @@ export function ExportButton({ datasetId, datasetName, recordType }: ExportButto
 
   // Derive effective format — if current selection isn't in the available list, reset
   const effectiveFormat = formats.some((f) => f.value === format) ? format : formats[0]?.value ?? 'gpkg';
+
+  // GeoParquet is a lakehouse-native format — show a copy-paste DuckDB snippet
+  // so the download becomes queryable, not just archived. Points at the local
+  // file (works for any dataset, no auth caveats).
+  const duckdbSnippet = `INSTALL spatial; LOAD spatial;\nSELECT * FROM '${datasetName}.parquet' LIMIT 10;`;
 
   const handleExport = async () => {
     setLoading(true);
@@ -82,6 +89,19 @@ export function ExportButton({ datasetId, datasetName, recordType }: ExportButto
           {t('export.button')}
         </Button>
       </div>
+      {effectiveFormat === 'parquet' && (
+        <div className="rounded-md border bg-muted/30 p-2.5">
+          <div className="mb-1.5 flex items-center justify-between">
+            <span className="font-mono text-2xs uppercase tracking-wide text-muted-foreground">
+              {t('export.duckdbHint', { defaultValue: 'Query with DuckDB' })}
+            </span>
+            <CopyButton value={duckdbSnippet} />
+          </div>
+          <pre className="overflow-x-auto text-2xs leading-5 text-foreground/90">
+            <code>{duckdbSnippet}</code>
+          </pre>
+        </div>
+      )}
       {error && <p className="text-sm text-destructive">{error}</p>}
     </div>
   );

--- a/frontend/src/components/dataset/ExportButton.tsx
+++ b/frontend/src/components/dataset/ExportButton.tsx
@@ -42,8 +42,11 @@ export function ExportButton({ datasetId, datasetName, recordType }: ExportButto
 
   // GeoParquet is a lakehouse-native format — show a copy-paste DuckDB snippet
   // so the download becomes queryable, not just archived. Points at the local
-  // file (works for any dataset, no auth caveats).
-  const duckdbSnippet = `INSTALL spatial; LOAD spatial;\nSELECT * FROM '${datasetName}.parquet' LIMIT 10;`;
+  // file (works for any dataset, no auth caveats). Single quotes in the title
+  // (e.g. "Bob's Roads") are doubled so the DuckDB string literal stays valid —
+  // and this matches the downloaded filename (anchor.download uses datasetName).
+  const duckdbFile = `${datasetName.replace(/'/g, "''")}.parquet`;
+  const duckdbSnippet = `INSTALL spatial; LOAD spatial;\nSELECT * FROM '${duckdbFile}' LIMIT 10;`;
 
   const handleExport = async () => {
     setLoading(true);

--- a/frontend/src/components/dataset/ExportButton.tsx
+++ b/frontend/src/components/dataset/ExportButton.tsx
@@ -42,10 +42,11 @@ export function ExportButton({ datasetId, datasetName, recordType }: ExportButto
 
   // GeoParquet is a lakehouse-native format — show a copy-paste DuckDB snippet
   // so the download becomes queryable, not just archived. Points at the local
-  // file (works for any dataset, no auth caveats). Single quotes in the title
-  // (e.g. "Bob's Roads") are doubled so the DuckDB string literal stays valid —
-  // and this matches the downloaded filename (anchor.download uses datasetName).
-  const duckdbFile = `${datasetName.replace(/'/g, "''")}.parquet`;
+  // file (works for any dataset, no auth caveats). Match the browser-saved
+  // filename so the snippet actually resolves: browsers replace path separators
+  // (/ \) in anchor.download, so mirror that here, then double single quotes so
+  // a title like "Bob's Roads" stays a valid DuckDB string literal.
+  const duckdbFile = `${datasetName.replace(/[/\\]/g, '_').replace(/'/g, "''")}.parquet`;
   const duckdbSnippet = `INSTALL spatial; LOAD spatial;\nSELECT * FROM '${duckdbFile}' LIMIT 10;`;
 
   const handleExport = async () => {

--- a/frontend/src/components/dataset/__tests__/ExportButton.test.tsx
+++ b/frontend/src/components/dataset/__tests__/ExportButton.test.tsx
@@ -17,17 +17,28 @@ beforeAll(() => {
 });
 
 describe('ExportButton', () => {
-  it('renders all 4 format options by default', async () => {
+  it('renders all 5 format options by default', async () => {
     const user = userEvent.setup();
     render(<ExportButton datasetId="ds-1" datasetName="test" />);
 
     await user.click(screen.getByRole('combobox'));
     const options = await screen.findAllByRole('option');
-    expect(options).toHaveLength(4);
+    expect(options).toHaveLength(5);
     const labels = options.map((o) => o.textContent);
     expect(labels).toEqual(
-      expect.arrayContaining(['GeoPackage', 'GeoJSON', 'Shapefile', 'CSV']),
+      expect.arrayContaining(['GeoPackage', 'GeoJSON', 'Shapefile', 'CSV', 'GeoParquet']),
     );
+  });
+
+  it('shows a DuckDB snippet when GeoParquet is selected', async () => {
+    const user = userEvent.setup();
+    render(<ExportButton datasetId="ds-1" datasetName="rivers" />);
+
+    await user.click(screen.getByRole('combobox'));
+    await user.click(await screen.findByRole('option', { name: 'GeoParquet' }));
+
+    expect(screen.getByText(/LOAD spatial/)).toBeInTheDocument();
+    expect(screen.getByText(/rivers\.parquet/)).toBeInTheDocument();
   });
 
   it('limits table datasets to CSV export', async () => {

--- a/frontend/src/components/dataset/__tests__/ExportButton.test.tsx
+++ b/frontend/src/components/dataset/__tests__/ExportButton.test.tsx
@@ -41,15 +41,16 @@ describe('ExportButton', () => {
     expect(screen.getByText(/rivers\.parquet/)).toBeInTheDocument();
   });
 
-  it('escapes single quotes in the DuckDB snippet filename', async () => {
+  it('sanitizes quotes and path separators in the DuckDB snippet filename', async () => {
     const user = userEvent.setup();
-    render(<ExportButton datasetId="ds-1" datasetName="Bob's Roads" />);
+    render(<ExportButton datasetId="ds-1" datasetName="Bob's Roads/2026" />);
 
     await user.click(screen.getByRole('combobox'));
     await user.click(await screen.findByRole('option', { name: 'GeoParquet' }));
 
-    // Single quote doubled -> valid DuckDB string literal.
-    expect(screen.getByText(/Bob''s Roads\.parquet/)).toBeInTheDocument();
+    // Path separator -> _, single quote doubled -> valid DuckDB string literal
+    // that matches the browser-saved filename.
+    expect(screen.getByText(/Bob''s Roads_2026\.parquet/)).toBeInTheDocument();
   });
 
   it('limits table datasets to CSV export', async () => {

--- a/frontend/src/components/dataset/__tests__/ExportButton.test.tsx
+++ b/frontend/src/components/dataset/__tests__/ExportButton.test.tsx
@@ -41,6 +41,17 @@ describe('ExportButton', () => {
     expect(screen.getByText(/rivers\.parquet/)).toBeInTheDocument();
   });
 
+  it('escapes single quotes in the DuckDB snippet filename', async () => {
+    const user = userEvent.setup();
+    render(<ExportButton datasetId="ds-1" datasetName="Bob's Roads" />);
+
+    await user.click(screen.getByRole('combobox'));
+    await user.click(await screen.findByRole('option', { name: 'GeoParquet' }));
+
+    // Single quote doubled -> valid DuckDB string literal.
+    expect(screen.getByText(/Bob''s Roads\.parquet/)).toBeInTheDocument();
+  });
+
   it('limits table datasets to CSV export', async () => {
     const user = userEvent.setup();
     render(<ExportButton datasetId="ds-1" datasetName="test" recordType="table" />);

--- a/frontend/src/components/import/BulkTrackingList.tsx
+++ b/frontend/src/components/import/BulkTrackingList.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect, useRef, useMemo } from 'react';
 import { Link } from 'react-router';
 import { useTranslation } from 'react-i18next';
 import { useQueries } from '@tanstack/react-query';
-import { ArrowRight, CheckCircle2, Layers } from 'lucide-react';
+import { ArrowRight, CheckCircle2, Layers, Sparkles } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
@@ -11,6 +11,7 @@ import { VrtCreateDialog } from './VrtCreateDialog';
 import { TypeTag } from './TypeTag';
 import { StatusPill } from './StatusPill';
 import { getJobStatus } from '@/api/ingest';
+import { useAIAvailability } from '@/hooks/use-ai-availability';
 import { queryKeys } from '@/lib/query-keys';
 import { getVisibilityLabel } from '@/i18n/labels';
 import type { FileEntry } from '@/types/api';
@@ -27,6 +28,9 @@ export function BulkTrackingList({ entries, onReset, autoOpenVrt = false }: Bulk
   const { t } = useTranslation('import');
   const [vrtDialogOpen, setVrtDialogOpen] = useState(false);
   const autoOpenedRef = useRef(false);
+  // Surface the (existing) AI metadata drafter at the ingest exit — the moment a
+  // dataset lands is when its metadata is emptiest. Only when AI is available.
+  const { isAIAvailable } = useAIAvailability();
 
   const trackable = entries.filter(
     (e) =>
@@ -174,6 +178,19 @@ export function BulkTrackingList({ entries, onReset, autoOpenVrt = false }: Bulk
                 <Link to={`/datasets/${completedEntries[0].datasetId}`}>
                   {t('bulk.openDataset', { defaultValue: 'Open dataset' })}
                   <ArrowRight className="ms-1 size-3 rtl-mirror" />
+                </Link>
+              </Button>
+            )}
+            {completedEntries.length === 1 && completedEntries[0] && isAIAvailable && (
+              <Button
+                asChild
+                variant="outline"
+                size="sm"
+                className="border-primary/40 text-primary hover:bg-primary/10 hover:text-primary"
+              >
+                <Link to={`/datasets/${completedEntries[0].datasetId}`}>
+                  <Sparkles className="me-1 size-3" />
+                  {t('complete.aiMetadata', { defaultValue: 'Add AI metadata' })}
                 </Link>
               </Button>
             )}

--- a/frontend/src/components/import/__tests__/BulkTrackingList.test.tsx
+++ b/frontend/src/components/import/__tests__/BulkTrackingList.test.tsx
@@ -30,6 +30,13 @@ vi.mock('../VrtCreateDialog', () => ({
   VrtCreateDialog: () => null,
 }));
 
+// AI availability is toggled per test via aiState; the ingest AI-metadata CTA
+// only renders when AI is available (and a single dataset completed).
+const { aiState } = vi.hoisted(() => ({ aiState: { value: false } }));
+vi.mock('@/hooks/use-ai-availability', () => ({
+  useAIAvailability: () => ({ isAIAvailable: aiState.value }),
+}));
+
 const mockUseQueries = vi.mocked(useQueries);
 
 function makeEntry(overrides: Partial<FileEntry> = {}): FileEntry {
@@ -51,6 +58,7 @@ function makeEntry(overrides: Partial<FileEntry> = {}): FileEntry {
 describe('BulkTrackingList', () => {
   beforeEach(() => {
     mockUseQueries.mockReset();
+    aiState.value = false;
   });
 
   it('surfaces completed datasets in the summary while keeping only active jobs in the main list', () => {
@@ -92,5 +100,30 @@ describe('BulkTrackingList', () => {
     expect(screen.getByRole('link', { name: 'Open dataset' })).toHaveAttribute('href', '/datasets/dataset-1');
     expect(screen.queryByTestId('job-progress-job-1')).not.toBeInTheDocument();
     expect(screen.getByTestId('job-progress-job-2')).toBeInTheDocument();
+  });
+
+  it('offers the AI-metadata CTA on a single completed dataset when AI is available', () => {
+    aiState.value = true;
+    mockUseQueries.mockReturnValueOnce([
+      { data: { status: 'complete', dataset_id: 'dataset-9', source_filename: 'sample.geojson' } },
+    ] as never);
+
+    render(<BulkTrackingList entries={[makeEntry()]} onReset={vi.fn()} />);
+
+    expect(screen.getByRole('link', { name: /Add AI metadata/ })).toHaveAttribute(
+      'href',
+      '/datasets/dataset-9',
+    );
+  });
+
+  it('hides the AI-metadata CTA when AI is unavailable', () => {
+    aiState.value = false;
+    mockUseQueries.mockReturnValueOnce([
+      { data: { status: 'complete', dataset_id: 'dataset-9', source_filename: 'sample.geojson' } },
+    ] as never);
+
+    render(<BulkTrackingList entries={[makeEntry()]} onReset={vi.fn()} />);
+
+    expect(screen.queryByRole('link', { name: /Add AI metadata/ })).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/i18n/locales/de/dataset.json
+++ b/frontend/src/i18n/locales/de/dataset.json
@@ -187,6 +187,8 @@
     "geojson": "GeoJSON",
     "shp": "Shapefile",
     "csv": "CSV",
+    "parquet": "GeoParquet",
+    "duckdbHint": "Mit DuckDB abfragen",
     "button": "Exportieren",
     "failed": "Export fehlgeschlagen",
     "formatLabel": "Exportformat"

--- a/frontend/src/i18n/locales/de/import.json
+++ b/frontend/src/i18n/locales/de/import.json
@@ -434,7 +434,8 @@
     "statTabular": "Tabellarisch",
     "next": "Weiter:",
     "viewCatalog": "Im Katalog anzeigen",
-    "importMore": "Mehr importieren"
+    "importMore": "Mehr importieren",
+    "aiMetadata": "KI-Metadaten hinzufügen"
   },
   "rail": {
     "stageTitle": "Dateien bereitstellen",

--- a/frontend/src/i18n/locales/en/dataset.json
+++ b/frontend/src/i18n/locales/en/dataset.json
@@ -187,6 +187,8 @@
     "geojson": "GeoJSON",
     "shp": "Shapefile",
     "csv": "CSV",
+    "parquet": "GeoParquet",
+    "duckdbHint": "Query with DuckDB",
     "button": "Export",
     "failed": "Export failed",
     "formatLabel": "Export format"

--- a/frontend/src/i18n/locales/en/import.json
+++ b/frontend/src/i18n/locales/en/import.json
@@ -100,7 +100,8 @@
     "statTabular": "Tabular",
     "next": "Next:",
     "viewCatalog": "View in Catalog",
-    "importMore": "Import more"
+    "importMore": "Import more",
+    "aiMetadata": "Add AI metadata"
   },
   "dropzone": {
     "ariaLabel": "Upload files",

--- a/frontend/src/i18n/locales/es/dataset.json
+++ b/frontend/src/i18n/locales/es/dataset.json
@@ -187,6 +187,8 @@
     "geojson": "GeoJSON",
     "shp": "Shapefile",
     "csv": "CSV",
+    "parquet": "GeoParquet",
+    "duckdbHint": "Consultar con DuckDB",
     "button": "Exportar",
     "failed": "Exportación fallida",
     "formatLabel": "Formato de exportación"

--- a/frontend/src/i18n/locales/es/import.json
+++ b/frontend/src/i18n/locales/es/import.json
@@ -434,7 +434,8 @@
     "statTabular": "Tabular",
     "next": "Siguiente:",
     "viewCatalog": "Ver en el catálogo",
-    "importMore": "Importar más"
+    "importMore": "Importar más",
+    "aiMetadata": "Añadir metadatos con IA"
   },
   "rail": {
     "stageTitle": "Preparar archivos",

--- a/frontend/src/i18n/locales/fr/dataset.json
+++ b/frontend/src/i18n/locales/fr/dataset.json
@@ -187,6 +187,8 @@
     "geojson": "GeoJSON",
     "shp": "Shapefile",
     "csv": "CSV",
+    "parquet": "GeoParquet",
+    "duckdbHint": "Interroger avec DuckDB",
     "button": "Exporter",
     "failed": "Échec de l'exportation",
     "formatLabel": "Format d'exportation"

--- a/frontend/src/i18n/locales/fr/import.json
+++ b/frontend/src/i18n/locales/fr/import.json
@@ -434,7 +434,8 @@
     "statTabular": "Tabulaire",
     "next": "Suivant :",
     "viewCatalog": "Voir dans le catalogue",
-    "importMore": "Importer davantage"
+    "importMore": "Importer davantage",
+    "aiMetadata": "Ajouter des métadonnées IA"
   },
   "rail": {
     "stageTitle": "Préparer les fichiers",

--- a/frontend/src/types/api.generated.ts
+++ b/frontend/src/types/api.generated.ts
@@ -1927,8 +1927,9 @@ export interface paths {
          * Export Dataset Endpoint
          * @description Export a dataset as a downloadable file.
          *
-         *     Supports GeoPackage, GeoJSON, Shapefile (zipped), and CSV formats.
-         *     Optional CRS reprojection, spatial filtering, and attribute filtering.
+         *     Supports GeoPackage, GeoJSON, Shapefile (zipped), CSV, and GeoParquet
+         *     formats. Optional CRS reprojection, spatial filtering, and attribute
+         *     filtering. GeoParquet is always emitted in EPSG:4326 (OGC:CRS84).
          */
         get: operations["export_dataset_endpoint_datasets__dataset_id__export_get"];
         put?: never;
@@ -3063,6 +3064,30 @@ export interface paths {
          * @description Rename a column on an existing layer.
          */
         patch: operations["rename_column_endpoint_layers__dataset_id__columns__column_name__name_patch"];
+        trace?: never;
+    };
+    "/layers/{dataset_id}/columns/{column_name}/references": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Column References Endpoint
+         * @description Count saved maps whose layer config references a column.
+         *
+         *     fix(#458 E-06): surfaced in the schema editor before a rename/drop so the
+         *     editor knows how many saved maps depend on the column. Count only — map
+         *     titles may belong to other users and are not exposed here.
+         */
+        get: operations["column_references_endpoint_layers__dataset_id__columns__column_name__references_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
         trace?: never;
     };
     "/layers/{dataset_id}/columns/{column_name}/type": {
@@ -5975,6 +6000,17 @@ export interface components {
             /** Type */
             type: string;
         };
+        /**
+         * ColumnReferencesResponse
+         * @description How many saved maps reference a column in their layer config.
+         */
+        ColumnReferencesResponse: {
+            /**
+             * Map Count
+             * @description Distinct saved maps whose styles/filters/labels/popups reference this column
+             */
+            map_count: number;
+        };
         /** ColumnStatsResponse */
         ColumnStatsResponse: {
             /**
@@ -7217,7 +7253,7 @@ export interface components {
          * ExportFormat
          * @enum {string}
          */
-        ExportFormat: "gpkg" | "geojson" | "shp" | "csv";
+        ExportFormat: "gpkg" | "geojson" | "shp" | "csv" | "parquet";
         /**
          * FacetCountResponse
          * @description Multi-group facet counts for the search sidebar.
@@ -7442,8 +7478,11 @@ export interface components {
         GeoJSONGeometry: {
             /** Coordinates */
             coordinates: unknown[];
-            /** Type */
-            type: string;
+            /**
+             * Type
+             * @enum {string}
+             */
+            type: "Point" | "MultiPoint" | "LineString" | "MultiLineString" | "Polygon" | "MultiPolygon";
         };
         /**
          * GeoJSONGeometryCollection
@@ -17991,7 +18030,12 @@ export interface operations {
     };
     get_dcat_us3_catalog_datasets_dcat_us_3_0__get: {
         parameters: {
-            query?: never;
+            query?: {
+                /** @description Max datasets in this page (default = max). */
+                limit?: number;
+                /** @description Datasets to skip — page a catalog larger than one page. */
+                offset?: number;
+            };
             header?: never;
             path?: never;
             cookie?: never;
@@ -18111,7 +18155,12 @@ export interface operations {
     };
     get_dcat_catalog_datasets_dcat__get: {
         parameters: {
-            query?: never;
+            query?: {
+                /** @description Max datasets in this page (default = max). */
+                limit?: number;
+                /** @description Datasets to skip — page a catalog larger than one page. */
+                offset?: number;
+            };
             header?: never;
             path?: never;
             cookie?: never;
@@ -18231,7 +18280,12 @@ export interface operations {
     };
     get_geodcat_ap_catalog_datasets_geodcat_ap__get: {
         parameters: {
-            query?: never;
+            query?: {
+                /** @description Max datasets in this page (default = max). */
+                limit?: number;
+                /** @description Datasets to skip — page a catalog larger than one page. */
+                offset?: number;
+            };
             header?: never;
             path?: never;
             cookie?: never;
@@ -24356,6 +24410,38 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["ColumnListResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    column_references_endpoint_layers__dataset_id__columns__column_name__references_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                dataset_id: string;
+                column_name: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ColumnReferencesResponse"];
                 };
             };
             /** @description Validation Error */

--- a/sdks/python/geolens/api/datasets/export_dataset_endpoint_datasets_dataset_id_export_get.py
+++ b/sdks/python/geolens/api/datasets/export_dataset_endpoint_datasets_dataset_id_export_get.py
@@ -107,8 +107,9 @@ def sync_detailed(
 
      Export a dataset as a downloadable file.
 
-    Supports GeoPackage, GeoJSON, Shapefile (zipped), and CSV formats.
-    Optional CRS reprojection, spatial filtering, and attribute filtering.
+    Supports GeoPackage, GeoJSON, Shapefile (zipped), CSV, and GeoParquet
+    formats. Optional CRS reprojection, spatial filtering, and attribute
+    filtering. GeoParquet is always emitted in EPSG:4326 (OGC:CRS84).
 
     Args:
         dataset_id (UUID):
@@ -153,8 +154,9 @@ def sync(
 
      Export a dataset as a downloadable file.
 
-    Supports GeoPackage, GeoJSON, Shapefile (zipped), and CSV formats.
-    Optional CRS reprojection, spatial filtering, and attribute filtering.
+    Supports GeoPackage, GeoJSON, Shapefile (zipped), CSV, and GeoParquet
+    formats. Optional CRS reprojection, spatial filtering, and attribute
+    filtering. GeoParquet is always emitted in EPSG:4326 (OGC:CRS84).
 
     Args:
         dataset_id (UUID):
@@ -194,8 +196,9 @@ async def asyncio_detailed(
 
      Export a dataset as a downloadable file.
 
-    Supports GeoPackage, GeoJSON, Shapefile (zipped), and CSV formats.
-    Optional CRS reprojection, spatial filtering, and attribute filtering.
+    Supports GeoPackage, GeoJSON, Shapefile (zipped), CSV, and GeoParquet
+    formats. Optional CRS reprojection, spatial filtering, and attribute
+    filtering. GeoParquet is always emitted in EPSG:4326 (OGC:CRS84).
 
     Args:
         dataset_id (UUID):
@@ -238,8 +241,9 @@ async def asyncio(
 
      Export a dataset as a downloadable file.
 
-    Supports GeoPackage, GeoJSON, Shapefile (zipped), and CSV formats.
-    Optional CRS reprojection, spatial filtering, and attribute filtering.
+    Supports GeoPackage, GeoJSON, Shapefile (zipped), CSV, and GeoParquet
+    formats. Optional CRS reprojection, spatial filtering, and attribute
+    filtering. GeoParquet is always emitted in EPSG:4326 (OGC:CRS84).
 
     Args:
         dataset_id (UUID):

--- a/sdks/python/geolens/api/datasets_export/get_dcat_catalog_datasets_dcat_get.py
+++ b/sdks/python/geolens/api/datasets_export/get_dcat_catalog_datasets_dcat_get.py
@@ -4,17 +4,31 @@ from typing import Any
 import httpx
 
 from ...client import AuthenticatedClient, Client
-from ...types import Response
+from ...types import Response, UNSET
 from ... import errors
 
 from ...models.problem_detail import ProblemDetail
+from ...types import Unset
 
 
-def _get_kwargs() -> dict[str, Any]:
+def _get_kwargs(
+    *,
+    limit: int | Unset = 10000,
+    offset: int | Unset = 0,
+) -> dict[str, Any]:
+
+    params: dict[str, Any] = {}
+
+    params["limit"] = limit
+
+    params["offset"] = offset
+
+    params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
 
     _kwargs: dict[str, Any] = {
         "method": "get",
         "url": "/datasets/dcat/",
+        "params": params,
     }
 
     return _kwargs
@@ -67,10 +81,16 @@ def _build_response(
 def sync_detailed(
     *,
     client: AuthenticatedClient,
+    limit: int | Unset = 10000,
+    offset: int | Unset = 0,
 ) -> Response[Any | ProblemDetail]:
     """Get Dcat Catalog
 
      DCAT 3 JSON-LD catalog feed. Respects dataset visibility.
+
+    Args:
+        limit (int | Unset): Max datasets in this page (default = max). Default: 10000.
+        offset (int | Unset): Datasets to skip — page a catalog larger than one page. Default: 0.
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -80,7 +100,10 @@ def sync_detailed(
         Response[Any | ProblemDetail]
     """
 
-    kwargs = _get_kwargs()
+    kwargs = _get_kwargs(
+        limit=limit,
+        offset=offset,
+    )
 
     response = client.get_httpx_client().request(
         **kwargs,
@@ -92,10 +115,16 @@ def sync_detailed(
 def sync(
     *,
     client: AuthenticatedClient,
+    limit: int | Unset = 10000,
+    offset: int | Unset = 0,
 ) -> Any | ProblemDetail | None:
     """Get Dcat Catalog
 
      DCAT 3 JSON-LD catalog feed. Respects dataset visibility.
+
+    Args:
+        limit (int | Unset): Max datasets in this page (default = max). Default: 10000.
+        offset (int | Unset): Datasets to skip — page a catalog larger than one page. Default: 0.
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -107,16 +136,24 @@ def sync(
 
     return sync_detailed(
         client=client,
+        limit=limit,
+        offset=offset,
     ).parsed
 
 
 async def asyncio_detailed(
     *,
     client: AuthenticatedClient,
+    limit: int | Unset = 10000,
+    offset: int | Unset = 0,
 ) -> Response[Any | ProblemDetail]:
     """Get Dcat Catalog
 
      DCAT 3 JSON-LD catalog feed. Respects dataset visibility.
+
+    Args:
+        limit (int | Unset): Max datasets in this page (default = max). Default: 10000.
+        offset (int | Unset): Datasets to skip — page a catalog larger than one page. Default: 0.
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -126,7 +163,10 @@ async def asyncio_detailed(
         Response[Any | ProblemDetail]
     """
 
-    kwargs = _get_kwargs()
+    kwargs = _get_kwargs(
+        limit=limit,
+        offset=offset,
+    )
 
     response = await client.get_async_httpx_client().request(**kwargs)
 
@@ -136,10 +176,16 @@ async def asyncio_detailed(
 async def asyncio(
     *,
     client: AuthenticatedClient,
+    limit: int | Unset = 10000,
+    offset: int | Unset = 0,
 ) -> Any | ProblemDetail | None:
     """Get Dcat Catalog
 
      DCAT 3 JSON-LD catalog feed. Respects dataset visibility.
+
+    Args:
+        limit (int | Unset): Max datasets in this page (default = max). Default: 10000.
+        offset (int | Unset): Datasets to skip — page a catalog larger than one page. Default: 0.
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -152,5 +198,7 @@ async def asyncio(
     return (
         await asyncio_detailed(
             client=client,
+            limit=limit,
+            offset=offset,
         )
     ).parsed

--- a/sdks/python/geolens/api/datasets_export/get_dcat_us3_catalog_datasets_dcat_us_3_0_get.py
+++ b/sdks/python/geolens/api/datasets_export/get_dcat_us3_catalog_datasets_dcat_us_3_0_get.py
@@ -4,17 +4,31 @@ from typing import Any
 import httpx
 
 from ...client import AuthenticatedClient, Client
-from ...types import Response
+from ...types import Response, UNSET
 from ... import errors
 
 from ...models.problem_detail import ProblemDetail
+from ...types import Unset
 
 
-def _get_kwargs() -> dict[str, Any]:
+def _get_kwargs(
+    *,
+    limit: int | Unset = 10000,
+    offset: int | Unset = 0,
+) -> dict[str, Any]:
+
+    params: dict[str, Any] = {}
+
+    params["limit"] = limit
+
+    params["offset"] = offset
+
+    params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
 
     _kwargs: dict[str, Any] = {
         "method": "get",
         "url": "/datasets/dcat-us/3.0/",
+        "params": params,
     }
 
     return _kwargs
@@ -67,10 +81,16 @@ def _build_response(
 def sync_detailed(
     *,
     client: AuthenticatedClient,
+    limit: int | Unset = 10000,
+    offset: int | Unset = 0,
 ) -> Response[Any | ProblemDetail]:
     """Get Dcat Us3 Catalog
 
      DCAT-US Schema v3.0 catalog feed. Respects dataset visibility.
+
+    Args:
+        limit (int | Unset): Max datasets in this page (default = max). Default: 10000.
+        offset (int | Unset): Datasets to skip — page a catalog larger than one page. Default: 0.
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -80,7 +100,10 @@ def sync_detailed(
         Response[Any | ProblemDetail]
     """
 
-    kwargs = _get_kwargs()
+    kwargs = _get_kwargs(
+        limit=limit,
+        offset=offset,
+    )
 
     response = client.get_httpx_client().request(
         **kwargs,
@@ -92,10 +115,16 @@ def sync_detailed(
 def sync(
     *,
     client: AuthenticatedClient,
+    limit: int | Unset = 10000,
+    offset: int | Unset = 0,
 ) -> Any | ProblemDetail | None:
     """Get Dcat Us3 Catalog
 
      DCAT-US Schema v3.0 catalog feed. Respects dataset visibility.
+
+    Args:
+        limit (int | Unset): Max datasets in this page (default = max). Default: 10000.
+        offset (int | Unset): Datasets to skip — page a catalog larger than one page. Default: 0.
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -107,16 +136,24 @@ def sync(
 
     return sync_detailed(
         client=client,
+        limit=limit,
+        offset=offset,
     ).parsed
 
 
 async def asyncio_detailed(
     *,
     client: AuthenticatedClient,
+    limit: int | Unset = 10000,
+    offset: int | Unset = 0,
 ) -> Response[Any | ProblemDetail]:
     """Get Dcat Us3 Catalog
 
      DCAT-US Schema v3.0 catalog feed. Respects dataset visibility.
+
+    Args:
+        limit (int | Unset): Max datasets in this page (default = max). Default: 10000.
+        offset (int | Unset): Datasets to skip — page a catalog larger than one page. Default: 0.
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -126,7 +163,10 @@ async def asyncio_detailed(
         Response[Any | ProblemDetail]
     """
 
-    kwargs = _get_kwargs()
+    kwargs = _get_kwargs(
+        limit=limit,
+        offset=offset,
+    )
 
     response = await client.get_async_httpx_client().request(**kwargs)
 
@@ -136,10 +176,16 @@ async def asyncio_detailed(
 async def asyncio(
     *,
     client: AuthenticatedClient,
+    limit: int | Unset = 10000,
+    offset: int | Unset = 0,
 ) -> Any | ProblemDetail | None:
     """Get Dcat Us3 Catalog
 
      DCAT-US Schema v3.0 catalog feed. Respects dataset visibility.
+
+    Args:
+        limit (int | Unset): Max datasets in this page (default = max). Default: 10000.
+        offset (int | Unset): Datasets to skip — page a catalog larger than one page. Default: 0.
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -152,5 +198,7 @@ async def asyncio(
     return (
         await asyncio_detailed(
             client=client,
+            limit=limit,
+            offset=offset,
         )
     ).parsed

--- a/sdks/python/geolens/api/datasets_export/get_geodcat_ap_catalog_datasets_geodcat_ap_get.py
+++ b/sdks/python/geolens/api/datasets_export/get_geodcat_ap_catalog_datasets_geodcat_ap_get.py
@@ -4,17 +4,31 @@ from typing import Any
 import httpx
 
 from ...client import AuthenticatedClient, Client
-from ...types import Response
+from ...types import Response, UNSET
 from ... import errors
 
 from ...models.problem_detail import ProblemDetail
+from ...types import Unset
 
 
-def _get_kwargs() -> dict[str, Any]:
+def _get_kwargs(
+    *,
+    limit: int | Unset = 10000,
+    offset: int | Unset = 0,
+) -> dict[str, Any]:
+
+    params: dict[str, Any] = {}
+
+    params["limit"] = limit
+
+    params["offset"] = offset
+
+    params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
 
     _kwargs: dict[str, Any] = {
         "method": "get",
         "url": "/datasets/geodcat-ap/",
+        "params": params,
     }
 
     return _kwargs
@@ -67,10 +81,16 @@ def _build_response(
 def sync_detailed(
     *,
     client: AuthenticatedClient,
+    limit: int | Unset = 10000,
+    offset: int | Unset = 0,
 ) -> Response[Any | ProblemDetail]:
     """Get Geodcat Ap Catalog
 
      GeoDCAT-AP 2.0.0 catalog feed. Respects dataset visibility.
+
+    Args:
+        limit (int | Unset): Max datasets in this page (default = max). Default: 10000.
+        offset (int | Unset): Datasets to skip — page a catalog larger than one page. Default: 0.
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -80,7 +100,10 @@ def sync_detailed(
         Response[Any | ProblemDetail]
     """
 
-    kwargs = _get_kwargs()
+    kwargs = _get_kwargs(
+        limit=limit,
+        offset=offset,
+    )
 
     response = client.get_httpx_client().request(
         **kwargs,
@@ -92,10 +115,16 @@ def sync_detailed(
 def sync(
     *,
     client: AuthenticatedClient,
+    limit: int | Unset = 10000,
+    offset: int | Unset = 0,
 ) -> Any | ProblemDetail | None:
     """Get Geodcat Ap Catalog
 
      GeoDCAT-AP 2.0.0 catalog feed. Respects dataset visibility.
+
+    Args:
+        limit (int | Unset): Max datasets in this page (default = max). Default: 10000.
+        offset (int | Unset): Datasets to skip — page a catalog larger than one page. Default: 0.
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -107,16 +136,24 @@ def sync(
 
     return sync_detailed(
         client=client,
+        limit=limit,
+        offset=offset,
     ).parsed
 
 
 async def asyncio_detailed(
     *,
     client: AuthenticatedClient,
+    limit: int | Unset = 10000,
+    offset: int | Unset = 0,
 ) -> Response[Any | ProblemDetail]:
     """Get Geodcat Ap Catalog
 
      GeoDCAT-AP 2.0.0 catalog feed. Respects dataset visibility.
+
+    Args:
+        limit (int | Unset): Max datasets in this page (default = max). Default: 10000.
+        offset (int | Unset): Datasets to skip — page a catalog larger than one page. Default: 0.
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -126,7 +163,10 @@ async def asyncio_detailed(
         Response[Any | ProblemDetail]
     """
 
-    kwargs = _get_kwargs()
+    kwargs = _get_kwargs(
+        limit=limit,
+        offset=offset,
+    )
 
     response = await client.get_async_httpx_client().request(**kwargs)
 
@@ -136,10 +176,16 @@ async def asyncio_detailed(
 async def asyncio(
     *,
     client: AuthenticatedClient,
+    limit: int | Unset = 10000,
+    offset: int | Unset = 0,
 ) -> Any | ProblemDetail | None:
     """Get Geodcat Ap Catalog
 
      GeoDCAT-AP 2.0.0 catalog feed. Respects dataset visibility.
+
+    Args:
+        limit (int | Unset): Max datasets in this page (default = max). Default: 10000.
+        offset (int | Unset): Datasets to skip — page a catalog larger than one page. Default: 0.
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -152,5 +198,7 @@ async def asyncio(
     return (
         await asyncio_detailed(
             client=client,
+            limit=limit,
+            offset=offset,
         )
     ).parsed

--- a/sdks/python/geolens/models/export_format.py
+++ b/sdks/python/geolens/models/export_format.py
@@ -1,11 +1,12 @@
 from typing import Literal, cast
 
-ExportFormat = Literal["csv", "geojson", "gpkg", "shp"]
+ExportFormat = Literal["csv", "geojson", "gpkg", "parquet", "shp"]
 
 EXPORT_FORMAT_VALUES: set[ExportFormat] = {
     "csv",
     "geojson",
     "gpkg",
+    "parquet",
     "shp",
 }
 

--- a/sdks/typescript/src/client/sdk.gen.ts
+++ b/sdks/typescript/src/client/sdk.gen.ts
@@ -1322,8 +1322,9 @@ export const downloadCogDatasetsDatasetIdDownloadCogGet = <ThrowOnError extends 
  *
  * Export a dataset as a downloadable file.
  *
- * Supports GeoPackage, GeoJSON, Shapefile (zipped), and CSV formats.
- * Optional CRS reprojection, spatial filtering, and attribute filtering.
+ * Supports GeoPackage, GeoJSON, Shapefile (zipped), CSV, and GeoParquet
+ * formats. Optional CRS reprojection, spatial filtering, and attribute
+ * filtering. GeoParquet is always emitted in EPSG:4326 (OGC:CRS84).
  */
 export const exportDatasetEndpointDatasetsDatasetIdExportGet = <ThrowOnError extends boolean = false>(options: Options<ExportDatasetEndpointDatasetsDatasetIdExportGetData, ThrowOnError>): RequestResult<ExportDatasetEndpointDatasetsDatasetIdExportGetResponses, ExportDatasetEndpointDatasetsDatasetIdExportGetErrors, ThrowOnError> => (options.client ?? client).get<ExportDatasetEndpointDatasetsDatasetIdExportGetResponses, ExportDatasetEndpointDatasetsDatasetIdExportGetErrors, ThrowOnError>({
     security: [{ scheme: 'bearer', type: 'http' }],

--- a/sdks/typescript/src/client/types.gen.ts
+++ b/sdks/typescript/src/client/types.gen.ts
@@ -3478,7 +3478,7 @@ export type EmbeddingStatsResponse = {
 /**
  * ExportFormat
  */
-export type ExportFormat = 'gpkg' | 'geojson' | 'shp' | 'csv';
+export type ExportFormat = 'gpkg' | 'geojson' | 'shp' | 'csv' | 'parquet';
 
 /**
  * FacetCountResponse
@@ -13459,7 +13459,20 @@ export type CreateEmptyDatasetEndpointDatasetsCreatePostResponse = CreateEmptyDa
 export type GetDcatUs3CatalogDatasetsDcatUs30GetData = {
     body?: never;
     path?: never;
-    query?: never;
+    query?: {
+        /**
+         * Limit
+         *
+         * Max datasets in this page (default = max).
+         */
+        limit?: number;
+        /**
+         * Offset
+         *
+         * Datasets to skip — page a catalog larger than one page.
+         */
+        offset?: number;
+    };
     url: '/datasets/dcat-us/3.0/';
 };
 
@@ -13529,7 +13542,20 @@ export type ValidateDcatUs3CatalogDatasetsDcatUs30ValidationGetResponses = {
 export type GetDcatCatalogDatasetsDcatGetData = {
     body?: never;
     path?: never;
-    query?: never;
+    query?: {
+        /**
+         * Limit
+         *
+         * Max datasets in this page (default = max).
+         */
+        limit?: number;
+        /**
+         * Offset
+         *
+         * Datasets to skip — page a catalog larger than one page.
+         */
+        offset?: number;
+    };
     url: '/datasets/dcat/';
 };
 
@@ -13599,7 +13625,20 @@ export type ValidateDcat3CatalogDatasetsDcatValidationGetResponses = {
 export type GetGeodcatApCatalogDatasetsGeodcatApGetData = {
     body?: never;
     path?: never;
-    query?: never;
+    query?: {
+        /**
+         * Limit
+         *
+         * Max datasets in this page (default = max).
+         */
+        limit?: number;
+        /**
+         * Offset
+         *
+         * Datasets to skip — page a catalog larger than one page.
+         */
+        offset?: number;
+    };
     url: '/datasets/geodcat-ap/';
 };
 


### PR DESCRIPTION
Four small, high-leverage wins from the 2026-07-11 catalog-enhancement research (`docs-internal/GTM/catalog-enhancement-research-2026-07-11/`), scoped to ship before the outreach wave without opening any long-lived project. Each is deliberately small; the compounding-but-heavy Tier-1 items (scheduled harvesting, white-label portal, subscriptions) are intentionally **not** here.

## What's in

**1. GeoParquet export** — the marquee differentiator ("your catalog is directly queryable").
- The Debian GDAL build ships **no Arrow/Parquet driver** (verified: `gdal-plugins` doesn't include it at any version), so ogr2ogr can't emit Parquet. New `processing/export/parquet.py` writes a spec-valid **GeoParquet 1.1** file directly via `pyarrow` — WKB geometry + `geo` file metadata, **EPSG:4326 / OGC:CRS84**.
- Wired into `GET /datasets/{id}/export?format=parquet`; rejects a non-4326 `target_crs` (no reprojection on that path). Non-spatial datasets are blocked like the other spatial formats.
- Dataset UI adds the **GeoParquet** format plus a copy-paste **DuckDB snippet** so the download is queryable, not just archived.
- New dependency: `pyarrow` (pure wheel, ~40 MB; no system libs, no base-image change). Chosen over swapping to `ghcr.io/osgeo/gdal` (large blast radius) — see PR discussion.

**2. DCAT feed paging** — `dcat`, `dcat-us/3.0`, `geodcat-ap` catalog feeds gain `limit`/`offset` so a catalog larger than 10k datasets (e.g. a federal `data.json` harvester) can crawl the whole feed instead of silently truncating. Defaults preserve the current single-document behavior and the BA-28 memory guard.

**3. Ingest AI metadata** — the bulk-import completion card now surfaces the **existing** AI metadata drafter (gated on `useAIAvailability`) the moment a dataset lands. Placement, not new capability.

**4. `/llms.txt`** — static file pointing agents at this instance's live discovery, search, and OGC/STAC/DCAT endpoints.

## API / schema impact
- New export format enum value `parquet`; new `limit`/`offset` query params on three DCAT feeds.
- Regenerated `backend/openapi.json` + Python/TS SDKs (drift-gate clean; diff is limited to these additions).

## Verification
- **GeoParquet writer** (DB-free unit test + a manual round-trip): `geo` metadata, WKB decode, null-geometry, and mixed-type→string fallback all pass.
- Added `test_export_parquet.py` (DB-backed endpoint test) for CI.
- Frontend: `typecheck`, `lint`, `test:i18n` (all four locales), and the ExportButton/BulkTrackingList component tests all green.
- Backend `ruff check` + `format` clean; pre-commit hooks (SSRF/visibility/secrets) passed.

## Notes for review
- GeoParquet is written in EPSG:4326 only (CRS84) — the lakehouse/DuckDB convention; a projected `target_crs` is rejected rather than silently ignored.
- The parquet writer builds the selection in memory before writing (bounded by the existing 5M-feature export cap); marked with a `ponytail:` upgrade path to a batched `ParquetWriter` if large-catalog exports OOM.

https://claude.ai/code/session_015cpiMW7X8MNmG4nN4dfzqB