### PR TITLE
fix(editing): editing-audit P2/P3 tail — write-path contracts, flag enforcement, draft UX

### DIFF
--- a/backend/app/modules/catalog/authorization.py
+++ b/backend/app/modules/catalog/authorization.py
@@ -170,3 +170,23 @@ async def check_dataset_write_access(
         status_code=status.HTTP_403_FORBIDDEN,
         detail="Only the dataset owner or an admin may modify this dataset.",
     )
+
+
+async def require_dataset_editing_enabled(db: AsyncSession) -> None:
+    """Enforce the `enable_dataset_editing` admin flag. Raises 403 when off.
+
+    fix(#458 E-11): the flag gated only the UI (StructureTab), so an owner/admin
+    could still edit features and run column DDL through the API with editing
+    switched off. Enforce it on those write paths server-side. Metadata edits are
+    deliberately *not* gated — the UI keeps only structure/feature editing behind
+    this toggle, and the backend mirrors that boundary.
+    """
+    # Local import mirrors the other persistent_config call sites (e.g.
+    # service_metadata's REQUIRE_METADATA_FOR_PUBLISH) and avoids any import cycle.
+    from app.core.persistent_config import ENABLE_DATASET_EDITING
+
+    if not await ENABLE_DATASET_EDITING.get(db):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Dataset editing is disabled by the administrator.",
+        )

--- a/backend/app/modules/catalog/features/router.py
+++ b/backend/app/modules/catalog/features/router.py
@@ -15,10 +15,11 @@ from fastapi import (
     status,
 )
 from fastapi.responses import JSONResponse
-from sqlalchemy.exc import OperationalError, ProgrammingError
+from sqlalchemy.exc import DBAPIError, OperationalError, ProgrammingError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.modules.audit.service import AuditEvent, audit_emit
+from app.core.db.sqlstate import is_operational
 from app.core.identity import Identity
 from app.modules.auth.dependencies import (
     get_current_active_user,
@@ -30,6 +31,7 @@ from app.modules.catalog.authorization import (
     check_dataset_access,
     check_dataset_access_or_anonymous,
     check_dataset_write_access,
+    require_dataset_editing_enabled,
 )
 from app.modules.catalog.datasets.domain.service import get_dataset
 from app.modules.embed_tokens.service import validate_embed_token_access
@@ -61,6 +63,46 @@ from app.core.public_urls import get_public_api_url
 logger = structlog.get_logger()
 
 features_router = APIRouter(prefix="/datasets", tags=["Features"])
+
+# Datasets with no PostGIS data table behind them. Any feature write 42P01s.
+_NON_FEATURE_RECORD_TYPES = ("raster_dataset", "vrt_dataset")
+
+
+def _require_feature_table(dataset) -> None:
+    """Reject feature writes to datasets that have no feature table.
+
+    fix(#458 E-08): the read handlers 404 raster/VRT datasets, but the write
+    handlers didn't — a write hit a missing `data.<table>` (42P01) and surfaced
+    as a 500. Mirror the read side. (Tabular datasets have a table but no geom
+    column; those 42703 at write time and are caught by `_feature_write_db_error`
+    below, so a generic-geometry created layer is never falsely blocked here.)
+    """
+    if dataset.record.record_type in _NON_FEATURE_RECORD_TYPES:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="This dataset has no feature table.",
+        )
+
+
+def _feature_write_db_error(exc: DBAPIError) -> HTTPException:
+    """Classify a DB error raised by a feature write.
+
+    fix(#458 E-09/E-26): feature values bind raw, so a type mismatch (22P02), a
+    NOT NULL violation (23502), or a write to a table with no such column (42703,
+    tabular datasets) used to surface as an unhandled 500. Classify by SQLSTATE:
+    a request the table cannot answer is the caller's fault (400); a database
+    outage stays a 503.
+    """
+    if is_operational(exc):
+        return HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Database temporarily unavailable.",
+        )
+    return HTTPException(
+        status_code=status.HTTP_400_BAD_REQUEST,
+        detail="Feature could not be written: a value is incompatible with a "
+        "column's type or constraints.",
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -442,6 +484,8 @@ async def create_feature(
         )
 
     await check_dataset_write_access(db, dataset, dataset_id, user)
+    await require_dataset_editing_enabled(db)
+    _require_feature_table(dataset)
 
     try:
         row = await insert_feature(
@@ -459,6 +503,9 @@ async def create_feature(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=str(e),
         )
+    except DBAPIError as exc:
+        await db.rollback()
+        raise _feature_write_db_error(exc)
 
     await refresh_dataset_metadata(db, dataset)
     dataset.record.updated_by = user.id
@@ -529,6 +576,8 @@ async def replace_single_feature(
         )
 
     await check_dataset_write_access(db, dataset, dataset_id, user)
+    await require_dataset_editing_enabled(db)
+    _require_feature_table(dataset)
 
     try:
         row = await replace_feature(
@@ -552,6 +601,9 @@ async def replace_single_feature(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=str(e),
         )
+    except DBAPIError as exc:
+        await db.rollback()
+        raise _feature_write_db_error(exc)
 
     await refresh_dataset_metadata(db, dataset)
     dataset.record.updated_by = user.id
@@ -614,6 +666,8 @@ async def patch_single_feature(
         )
 
     await check_dataset_write_access(db, dataset, dataset_id, user)
+    await require_dataset_editing_enabled(db)
+    _require_feature_table(dataset)
 
     try:
         row = await update_feature(
@@ -637,6 +691,9 @@ async def patch_single_feature(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=str(e),
         )
+    except DBAPIError as exc:
+        await db.rollback()
+        raise _feature_write_db_error(exc)
 
     # Only refresh metadata if geometry changed (extent may change)
     if body.geometry is not None:
@@ -694,6 +751,8 @@ async def delete_single_feature(
         )
 
     await check_dataset_write_access(db, dataset, dataset_id, user)
+    await require_dataset_editing_enabled(db)
+    _require_feature_table(dataset)
 
     try:
         await delete_feature(db, dataset.table_name, gid)
@@ -707,6 +766,9 @@ async def delete_single_feature(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=str(e),
         )
+    except DBAPIError as exc:
+        await db.rollback()
+        raise _feature_write_db_error(exc)
 
     await refresh_dataset_metadata(db, dataset)
     dataset.record.updated_by = user.id

--- a/backend/app/modules/catalog/features/router.py
+++ b/backend/app/modules/catalog/features/router.py
@@ -69,18 +69,31 @@ _NON_FEATURE_RECORD_TYPES = ("raster_dataset", "vrt_dataset")
 
 
 def _require_feature_table(dataset) -> None:
-    """Reject feature writes to datasets that have no feature table.
+    """Reject feature writes to datasets with no writable feature geometry.
 
     fix(#458 E-08): the read handlers 404 raster/VRT datasets, but the write
     handlers didn't — a write hit a missing `data.<table>` (42P01) and surfaced
-    as a 500. Mirror the read side. (Tabular datasets have a table but no geom
-    column; those 42703 at write time and are caught by `_feature_write_db_error`
-    below, so a generic-geometry created layer is never falsely blocked here.)
+    as a 500. Mirror the read side.
+
+    Also reject non-spatial (tabular) datasets, where `geometry_type is None`
+    (the same signal the read path uses for `has_geometry`). Their table has no
+    `geom`/`geom_4326` column, so an insert/replace 42703s, and a delete — which
+    touches no geometry — succeeds but then 500s in `refresh_dataset_metadata`'s
+    unconditional `geom_4326` read, *outside* the DBAPIError handler below
+    (PR #463 review). Created layers always carry a concrete `geometry_type`
+    (generic ones resolve via `effective_geometry_type`), so this never blocks a
+    spatial layer.
     """
     if dataset.record.record_type in _NON_FEATURE_RECORD_TYPES:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="This dataset has no feature table.",
+        )
+    if dataset.geometry_type is None:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="This dataset has no geometry column and does not support "
+            "feature editing.",
         )
 
 

--- a/backend/app/modules/catalog/features/service.py
+++ b/backend/app/modules/catalog/features/service.py
@@ -42,6 +42,26 @@ GEOJSON_TYPE_MAP: dict[str, set[str]] = {
 _MULTI_TYPES = {"MULTIPOINT", "MULTILINESTRING", "MULTIPOLYGON"}
 
 
+def _reject_unknown_properties(
+    properties: dict | None, column_info: list[dict]
+) -> None:
+    """Raise ValueError if a property key names no real attribute column.
+
+    fix(#458 E-25): writers used to silently drop unknown keys. On PUT that is a
+    footgun — a misspelled key isn't written AND the intended column is nulled
+    (replace sets every known column to `properties.get(name)`), all with a 200.
+    Rejecting unknown keys up front surfaces the typo as a 400 instead. Reserved
+    system columns (gid/geom/…) are absent from column_info, so a write attempt
+    against them is correctly reported here too.
+    """
+    if not properties:
+        return
+    allowed = {c["name"] for c in column_info}
+    unknown = sorted(k for k in properties if k not in allowed)
+    if unknown:
+        raise ValueError(f"Unknown property columns: {', '.join(unknown)}")
+
+
 def _geometry_sql(dataset_geometry_type: str) -> str:
     """Return the SQL expression for geometry insertion.
 
@@ -431,6 +451,7 @@ async def insert_feature(
     """
     _validate_geometry_type(geometry.get("type", ""), dataset_geometry_type)
     _validate_geometry_structure(geometry)
+    _reject_unknown_properties(properties, column_info)
 
     geojson_str = json.dumps(geometry)
 
@@ -478,6 +499,7 @@ async def replace_feature(
     """
     _validate_geometry_type(geometry.get("type", ""), dataset_geometry_type)
     _validate_geometry_structure(geometry)
+    _reject_unknown_properties(properties, column_info)
 
     geojson_str = json.dumps(geometry)
     geom_expr, geom_4326_expr = _geom_write_exprs(dataset_geometry_type, dataset_srid)
@@ -540,6 +562,7 @@ async def update_feature(
         params["geojson"] = geojson_str
 
     if properties is not None:
+        _reject_unknown_properties(properties, column_info)
         allowed = {c["name"] for c in column_info}
         for key, value in properties.items():
             if key in allowed and _COLUMN_NAME_RE.match(key):

--- a/backend/app/modules/catalog/layers/router.py
+++ b/backend/app/modules/catalog/layers/router.py
@@ -4,13 +4,18 @@ import uuid
 
 import structlog
 from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.exc import DBAPIError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.modules.audit.service import AuditEvent, audit_emit
+from app.core.db.sqlstate import is_operational
 from app.core.identity import Identity
 from app.modules.auth.dependencies import require_permission
 from app.core.dependencies import get_db
-from app.modules.catalog.authorization import check_dataset_write_access
+from app.modules.catalog.authorization import (
+    check_dataset_write_access,
+    require_dataset_editing_enabled,
+)
 from app.modules.catalog.datasets.domain.service import get_dataset
 from app.modules.catalog.layers.schemas import (
     AddColumnRequest,
@@ -39,6 +44,26 @@ async def _invalidate_tiles(table_name: str) -> None:
     tile_cache = get_tile_cache()
     if tile_cache is not None:
         await tile_cache.invalidate_table(table_name)
+
+
+async def _raise_ddl_db_error(db: AsyncSession, exc: DBAPIError, action: str) -> None:
+    """Roll back and map a DDL DB error to the right status. Never returns.
+
+    fix(#458 E-13): add/rename/drop caught only ValueError, so a DB-level failure
+    that isn't pre-validated — a dependent view on drop (2BP01), a lock timeout —
+    surfaced as a 500. Only `alter_column_type` mapped these. Classify by
+    SQLSTATE like the feature-write path: a bad request is a 400, an outage a 503.
+    """
+    await db.rollback()
+    if is_operational(exc):
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Database temporarily unavailable.",
+        )
+    raise HTTPException(
+        status_code=status.HTTP_400_BAD_REQUEST,
+        detail=f"{action} failed: {exc.orig or exc}",
+    )
 
 
 logger = structlog.stdlib.get_logger(__name__)
@@ -119,6 +144,7 @@ async def add_column_endpoint(
             detail="Dataset not found",
         )
     await check_dataset_write_access(db, dataset, dataset_id, user)
+    await require_dataset_editing_enabled(db)
 
     try:
         columns = await add_column(db, dataset, body.column.name, body.column.type)
@@ -127,6 +153,8 @@ async def add_column_endpoint(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=str(exc),
         )
+    except DBAPIError as exc:
+        await _raise_ddl_db_error(db, exc, "Add column")
 
     logger.info(
         "layer.add_column",
@@ -175,6 +203,7 @@ async def rename_column_endpoint(
             detail="Dataset not found",
         )
     await check_dataset_write_access(db, dataset, dataset_id, user)
+    await require_dataset_editing_enabled(db)
 
     try:
         columns = await rename_column(db, dataset, column_name, body.new_name)
@@ -183,6 +212,8 @@ async def rename_column_endpoint(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=str(exc),
         )
+    except DBAPIError as exc:
+        await _raise_ddl_db_error(db, exc, "Rename column")
 
     logger.info(
         "layer.rename_column",
@@ -231,6 +262,7 @@ async def alter_column_type_endpoint(
             detail="Dataset not found",
         )
     await check_dataset_write_access(db, dataset, dataset_id, user)
+    await require_dataset_editing_enabled(db)
 
     try:
         columns = await alter_column_type(db, dataset, column_name, body.new_type)
@@ -290,6 +322,7 @@ async def drop_column_endpoint(
             detail="Dataset not found",
         )
     await check_dataset_write_access(db, dataset, dataset_id, user)
+    await require_dataset_editing_enabled(db)
 
     try:
         columns = await drop_column(db, dataset, column_name)
@@ -298,6 +331,8 @@ async def drop_column_endpoint(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=str(exc),
         )
+    except DBAPIError as exc:
+        await _raise_ddl_db_error(db, exc, "Drop column")
 
     logger.info(
         "layer.drop_column",

--- a/backend/app/modules/catalog/records/router.py
+++ b/backend/app/modules/catalog/records/router.py
@@ -2,6 +2,7 @@
 
 import uuid
 
+import structlog
 from fastapi import APIRouter, Depends, HTTPException, Query, Response, status
 from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError
@@ -15,6 +16,8 @@ from app.modules.catalog.authorization import (
     get_user_roles,
 )
 from app.core.dependencies import get_db
+from app.platform.cache.tiles import invalidate_catalog_cache
+from app.platform.extensions import get_catalog_port
 from app.modules.catalog.datasets.domain.models import Dataset, Record
 from app.modules.catalog.records.schemas import (
     ContactCreate,
@@ -48,7 +51,32 @@ from app.modules.catalog.records.service import (
 )
 from app.standards.ogc.errors import ERROR_RESPONSES_WRITE
 
+logger = structlog.get_logger()
+
 router = APIRouter(prefix="/records", tags=["Records"], responses=ERROR_RESPONSES_WRITE)
+
+
+async def _propagate_record_write(record_id: uuid.UUID, *, reembed: bool) -> None:
+    """Keep downstream surfaces coherent after a record sub-resource write.
+
+    fix(#458 E-15): contacts/keywords/distributions feed the DCAT-US/STAC feeds
+    (so bust the catalog cache on every write), and keywords are part of the
+    search embedding text (so re-embed when keywords changed). The top-level
+    metadata PATCH already does both; these sibling writes did neither. Both
+    steps are best-effort — the write is already committed and must not fail on a
+    cache/broker hiccup.
+    """
+    try:
+        await invalidate_catalog_cache()
+    except Exception:  # broad: cache bust is non-fatal; entries expire on TTL
+        logger.warning("record.write catalog-cache invalidation failed", exc_info=True)
+    if reembed:
+        try:
+            await get_catalog_port().defer_embed_record(record_id)
+        except Exception:  # broad: embedding catches up on next edit or backfill
+            logger.warning(
+                "record.write embed defer failed for %s", record_id, exc_info=True
+            )
 
 
 async def _check_record_read_access(
@@ -118,7 +146,13 @@ async def _check_record_ownership(
     """Verify the user owns the record or is an admin. Raises 404/403.
 
     Returns the fetched Record so callers can reuse it without a second query.
+
+    fix(#458 E-14): gate on read-visibility first, so a private record the caller
+    can't even see 404s (no existence leak) instead of 403 — matching the dataset
+    PATCH IDOR contract (test_dataset_metadata_idor). A record the caller CAN see
+    but doesn't own still 403s (an honest "you can't edit this").
     """
+    await _check_record_read_access(db, record_id, user)
     record = await get_record(db, record_id)
     if record is None:
         raise HTTPException(
@@ -198,6 +232,7 @@ async def create_contact_endpoint(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="Invalid contact data (check role value against ISO CI_RoleCode codelist)",
         )
+    await _propagate_record_write(record_id, reembed=False)
     return ContactResponse.model_validate(contact)
 
 
@@ -227,6 +262,7 @@ async def update_contact_endpoint(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="Invalid contact data (check role value against ISO CI_RoleCode codelist)",
         )
+    await _propagate_record_write(record_id, reembed=False)
     return ContactResponse.model_validate(contact)
 
 
@@ -248,6 +284,7 @@ async def delete_contact_endpoint(
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND, detail="Contact not found"
         )
+    await _propagate_record_write(record_id, reembed=False)
     return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 
@@ -310,6 +347,7 @@ async def create_keyword_endpoint(
             status_code=status.HTTP_409_CONFLICT,
             detail="Duplicate keyword for this record",
         )
+    await _propagate_record_write(record_id, reembed=True)
     return KeywordResponse.model_validate(kw)
 
 
@@ -331,6 +369,7 @@ async def delete_keyword_endpoint(
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND, detail="Keyword not found"
         )
+    await _propagate_record_write(record_id, reembed=True)
     return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 
@@ -398,6 +437,7 @@ async def create_distribution_endpoint(
             status_code=status.HTTP_409_CONFLICT,
             detail="Duplicate distribution (same record, type, and format)",
         )
+    await _propagate_record_write(record_id, reembed=False)
     return DistributionResponse.model_validate(dist)
 
 
@@ -435,6 +475,7 @@ async def update_distribution_endpoint(
             status_code=status.HTTP_409_CONFLICT,
             detail="Duplicate distribution (same record, type, and format)",
         )
+    await _propagate_record_write(record_id, reembed=False)
     return DistributionResponse.model_validate(dist)
 
 
@@ -462,4 +503,5 @@ async def delete_distribution_endpoint(
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND, detail="Distribution not found"
         )
+    await _propagate_record_write(record_id, reembed=False)
     return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/backend/app/modules/catalog/records/router.py
+++ b/backend/app/modules/catalog/records/router.py
@@ -363,7 +363,7 @@ async def delete_keyword_endpoint(
     """Delete a keyword."""
     await _check_record_ownership(db, record_id, user)
     try:
-        await delete_keyword(db, keyword_id)
+        await delete_keyword(db, keyword_id, record_id)
         await db.commit()
     except ValueError:
         raise HTTPException(

--- a/backend/app/modules/catalog/records/service.py
+++ b/backend/app/modules/catalog/records/service.py
@@ -196,10 +196,22 @@ async def create_keyword(
     return kw
 
 
-async def delete_keyword(session: AsyncSession, keyword_id: uuid.UUID) -> None:
-    """Delete a keyword by ID."""
+async def delete_keyword(
+    session: AsyncSession, keyword_id: uuid.UUID, record_id: uuid.UUID
+) -> None:
+    """Delete a keyword by ID, scoped to its owning record.
+
+    fix(#463 review): scoping by ``record_id`` keeps the delete addressable only
+    through its real owner, so a keyword whose id belongs to a different record
+    404s here instead of being deleted through a mismatched path — which also
+    kept the caller's re-embed (``_propagate_record_write``) pointed at the wrong
+    record while the keyword's real owner drifted.
+    """
     result = await session.execute(
-        select(RecordKeyword).where(RecordKeyword.id == keyword_id)
+        select(RecordKeyword).where(
+            RecordKeyword.id == keyword_id,
+            RecordKeyword.record_id == record_id,
+        )
     )
     kw = result.scalar_one_or_none()
     if kw is None:

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -368,6 +368,26 @@ def _restore_process_global_config():
             os.environ.pop(_MODE_KEY, None)
 
 
+@pytest.fixture(autouse=True)
+def _enable_dataset_editing(monkeypatch):
+    """Turn on the `enable_dataset_editing` flag for the whole suite.
+
+    fix(#458 E-11): dataset editing (feature writes + column DDL) is now enforced
+    server-side and defaults OFF. The suite exercises those writes throughout, so
+    swap the persistent-config flag for an always-on stub. The guard re-imports
+    `ENABLE_DATASET_EDITING` from the module on each call, so replacing the module
+    attribute is picked up and the guard's real branch still runs. Tests that
+    assert the DISABLED path re-patch it with an always-off stub in their own body.
+    """
+    import app.core.persistent_config as pc
+
+    class _AlwaysOn:
+        async def get(self, _db):
+            return True
+
+    monkeypatch.setattr(pc, "ENABLE_DATASET_EDITING", _AlwaysOn())
+
+
 # Shared test geometries
 EMPTY_FEATURE_COLLECTION = {
     "type": "FeatureCollection",

--- a/backend/tests/test_features_crud.py
+++ b/backend/tests/test_features_crud.py
@@ -119,6 +119,44 @@ async def _create_raster_dataset(
     return dataset
 
 
+async def _create_tabular_dataset(
+    session,
+    *,
+    created_by: uuid.UUID,
+    visibility: str = "public",
+) -> Dataset:
+    """Register a non-spatial (tabular) dataset: a real data table with NO geom
+    column and geometry_type=None — the read path's has_geometry=False signal."""
+    table_name = f"test_crud_tab_{uuid.uuid4().hex[:8]}"
+    await session.execute(
+        text(
+            f"CREATE TABLE IF NOT EXISTS data.{table_name} "
+            f"(gid SERIAL PRIMARY KEY, name TEXT)"
+        )
+    )
+    await session.execute(text(f"GRANT SELECT ON data.{table_name} TO geolens_reader"))
+    record = Record(
+        title=f"Test Tabular Layer {table_name}",
+        visibility=visibility,
+        record_status="published",
+        created_by=created_by,
+    )
+    session.add(record)
+    await session.flush()
+    dataset = Dataset(
+        record_id=record.id,
+        table_name=table_name,
+        srid=4326,
+        geometry_type=None,
+        feature_count=0,
+        column_info=[{"name": "name", "type": "text"}],
+    )
+    session.add(dataset)
+    await session.commit()
+    await session.refresh(dataset)
+    return dataset
+
+
 async def _cleanup_table(session, table_name: str) -> None:
     """Drop a test data table."""
     await session.execute(text(f"DROP TABLE IF EXISTS data.{table_name}"))
@@ -180,6 +218,22 @@ async def multipolygon_layer(client: AsyncClient, test_db_session, admin_auth_he
         created_by=admin_id,
         geometry_type="MULTIPOLYGON",
     )
+    tbl = dataset.table_name
+    rec_id = dataset.record_id
+    yield dataset
+    await _cleanup_table(test_db_session, tbl)
+    await test_db_session.execute(
+        text("DELETE FROM catalog.records WHERE id = :id"),
+        {"id": rec_id},
+    )
+    await test_db_session.commit()
+
+
+@pytest.fixture
+async def tabular_layer(client: AsyncClient, test_db_session, admin_auth_header):
+    """Create a non-spatial (tabular) dataset for the geometry_type=None guard."""
+    admin_id = await get_user_id(test_db_session, "admin")
+    dataset = await _create_tabular_dataset(test_db_session, created_by=admin_id)
     tbl = dataset.table_name
     rec_id = dataset.record_id
     yield dataset
@@ -1607,6 +1661,28 @@ class TestEditingEnforcementAndContracts:
             headers=admin_auth_header,
         )
         assert resp.status_code == 404, resp.text
+
+    async def test_write_to_tabular_dataset_is_400_not_500(
+        self,
+        client: AsyncClient,
+        admin_auth_header: dict,
+        tabular_layer: Dataset,
+    ):
+        """E-08 (PR #463 review): a non-spatial dataset rejects feature writes with
+        400 — including DELETE, which touches no geometry and used to slip past to
+        refresh_dataset_metadata's geom_4326 read and 500."""
+        post = await client.post(
+            f"/datasets/{tabular_layer.id}/features/",
+            json={"geometry": POINT_GEOJSON, "properties": {}},
+            headers=admin_auth_header,
+        )
+        assert post.status_code == 400, post.text
+
+        delete = await client.delete(
+            f"/datasets/{tabular_layer.id}/features/1",
+            headers=admin_auth_header,
+        )
+        assert delete.status_code == 400, delete.text
 
     async def test_type_mismatch_is_400_not_500(
         self,

--- a/backend/tests/test_features_crud.py
+++ b/backend/tests/test_features_crud.py
@@ -1538,3 +1538,96 @@ class TestGeometryValidity:
             headers=admin_auth_header,
         )
         assert patch.status_code == 400, patch.text
+
+
+# ---------------------------------------------------------------------------
+# Editing enforcement + write-path contracts (fix #458 E-08/E-09/E-11/E-25)
+# ---------------------------------------------------------------------------
+
+
+class TestEditingEnforcementAndContracts:
+    async def test_write_blocked_when_editing_disabled(
+        self,
+        client: AsyncClient,
+        admin_auth_header: dict,
+        test_layer: Dataset,
+        monkeypatch,
+    ):
+        """E-11: with the flag off, feature writes AND column DDL 403 even for admin."""
+        import app.core.persistent_config as pc
+
+        class _AlwaysOff:
+            async def get(self, _db):
+                return False
+
+        monkeypatch.setattr(pc, "ENABLE_DATASET_EDITING", _AlwaysOff())
+
+        feature = await client.post(
+            f"/datasets/{test_layer.id}/features/",
+            json={"geometry": POINT_GEOJSON, "properties": {"name": "blocked"}},
+            headers=admin_auth_header,
+        )
+        assert feature.status_code == 403, feature.text
+
+        column = await client.post(
+            f"/layers/{test_layer.id}/columns/",
+            json={"column": {"name": "pop", "type": "integer"}},
+            headers=admin_auth_header,
+        )
+        assert column.status_code == 403, column.text
+
+    async def test_unknown_property_key_rejected(
+        self,
+        client: AsyncClient,
+        admin_auth_header: dict,
+        test_layer: Dataset,
+    ):
+        """E-25: a property key that names no column is a 400, not a silent drop."""
+        resp = await client.post(
+            f"/datasets/{test_layer.id}/features/",
+            json={
+                "geometry": POINT_GEOJSON,
+                "properties": {"name": "ok", "typoed_column": "x"},
+            },
+            headers=admin_auth_header,
+        )
+        assert resp.status_code == 400, resp.text
+        assert "typoed_column" in resp.json()["detail"]
+
+    async def test_write_to_raster_dataset_is_404_not_500(
+        self,
+        client: AsyncClient,
+        admin_auth_header: dict,
+        raster_layer: Dataset,
+    ):
+        """E-08: feature write to a dataset with no feature table 404s (was 500)."""
+        resp = await client.post(
+            f"/datasets/{raster_layer.id}/features/",
+            json={"geometry": POINT_GEOJSON, "properties": {}},
+            headers=admin_auth_header,
+        )
+        assert resp.status_code == 404, resp.text
+
+    async def test_type_mismatch_is_400_not_500(
+        self,
+        client: AsyncClient,
+        admin_auth_header: dict,
+        test_layer: Dataset,
+    ):
+        """E-09/E-26: a value incompatible with a column's type is a 400, not a 500."""
+        add = await client.post(
+            f"/layers/{test_layer.id}/columns/",
+            json={"column": {"name": "population", "type": "integer"}},
+            headers=admin_auth_header,
+        )
+        assert add.status_code == 201, add.text
+
+        resp = await client.post(
+            f"/datasets/{test_layer.id}/features/",
+            json={
+                "geometry": POINT_GEOJSON,
+                "properties": {"name": "x", "population": "not-a-number"},
+            },
+            headers=admin_auth_header,
+        )
+        assert resp.status_code == 400, resp.text

--- a/backend/tests/test_records_related.py
+++ b/backend/tests/test_records_related.py
@@ -1106,3 +1106,91 @@ class TestMigrationData:
                 assert record_id_str not in d.url, (
                     f"URL should NOT contain record_id {record_id_str}, got: {d.url}"
                 )
+
+
+# ---------------------------------------------------------------------------
+# Record-write authorization + downstream propagation (fix #458 E-14/E-15)
+# ---------------------------------------------------------------------------
+
+
+class TestRecordWriteContracts:
+    async def test_editor_private_nonowned_record_is_404_not_403(
+        self,
+        client: AsyncClient,
+        editor_auth_header: dict,
+        test_db_session: AsyncSession,
+    ):
+        """E-14: an editor who can't SEE a private, non-owned record 404s (no leak)."""
+        admin_id = await get_user_id(test_db_session, "admin")
+        ds = await create_dataset(
+            test_db_session, created_by=admin_id, visibility="private"
+        )
+        resp = await client.post(
+            f"/records/{ds.record_id}/contacts/",
+            json={"role": "author", "name": "Editor Attempt"},
+            headers=editor_auth_header,
+        )
+        assert resp.status_code == 404, resp.text
+
+    async def test_editor_public_nonowned_record_still_403(
+        self,
+        client: AsyncClient,
+        editor_auth_header: dict,
+        test_db_session: AsyncSession,
+    ):
+        """E-14: a record the editor CAN see but doesn't own is an honest 403."""
+        admin_id = await get_user_id(test_db_session, "admin")
+        ds = await create_dataset(
+            test_db_session, created_by=admin_id, visibility="public"
+        )
+        resp = await client.post(
+            f"/records/{ds.record_id}/contacts/",
+            json={"role": "author", "name": "Editor Attempt"},
+            headers=editor_auth_header,
+        )
+        assert resp.status_code == 403, resp.text
+
+    async def test_keyword_write_reembeds_contact_write_does_not(
+        self,
+        client: AsyncClient,
+        admin_auth_header: dict,
+        test_db_session: AsyncSession,
+        monkeypatch,
+    ):
+        """E-15: record sub-resource writes bust the catalog cache; keyword writes
+        (embedding text) also re-embed, contact/distribution writes do not."""
+        import app.modules.catalog.records.router as rr
+
+        cache_calls: list[int] = []
+        embed_calls: list[str] = []
+
+        async def _spy_cache():
+            cache_calls.append(1)
+
+        class _SpyPort:
+            async def defer_embed_record(self, record_id):
+                embed_calls.append(str(record_id))
+
+        monkeypatch.setattr(rr, "invalidate_catalog_cache", _spy_cache)
+        monkeypatch.setattr(rr, "get_catalog_port", lambda: _SpyPort())
+
+        admin_id = await get_user_id(test_db_session, "admin")
+        ds = await create_dataset(test_db_session, created_by=admin_id)
+
+        kw = await client.post(
+            f"/records/{ds.record_id}/keywords/",
+            json={"keyword": "hydrology"},
+            headers=admin_auth_header,
+        )
+        assert kw.status_code == 201, kw.text
+        assert len(cache_calls) == 1
+        assert embed_calls == [str(ds.record_id)]
+
+        contact = await client.post(
+            f"/records/{ds.record_id}/contacts/",
+            json={"role": "author", "name": "Jane"},
+            headers=admin_auth_header,
+        )
+        assert contact.status_code == 201, contact.text
+        assert len(cache_calls) == 2  # cache busted again
+        assert embed_calls == [str(ds.record_id)]  # NOT re-embedded

--- a/backend/tests/test_records_related.py
+++ b/backend/tests/test_records_related.py
@@ -1194,3 +1194,36 @@ class TestRecordWriteContracts:
         assert contact.status_code == 201, contact.text
         assert len(cache_calls) == 2  # cache busted again
         assert embed_calls == [str(ds.record_id)]  # NOT re-embedded
+
+    async def test_keyword_delete_is_record_scoped(
+        self,
+        client: AsyncClient,
+        admin_auth_header: dict,
+        test_db_session: AsyncSession,
+    ):
+        """PR #463 review: a keyword id addressed through a different record's
+        path 404s instead of being deleted (keeping the re-embed correct)."""
+        admin_id = await get_user_id(test_db_session, "admin")
+        ds_a = await create_dataset(test_db_session, created_by=admin_id)
+        ds_b = await create_dataset(test_db_session, created_by=admin_id)
+
+        created = await client.post(
+            f"/records/{ds_b.record_id}/keywords/",
+            json={"keyword": "geo"},
+            headers=admin_auth_header,
+        )
+        assert created.status_code == 201, created.text
+        kw_id = created.json()["id"]
+
+        # Delete B's keyword through A's path -> not found under A.
+        mismatch = await client.delete(
+            f"/records/{ds_a.record_id}/keywords/{kw_id}/",
+            headers=admin_auth_header,
+        )
+        assert mismatch.status_code == 404, mismatch.text
+
+        # The keyword still exists on B.
+        listing = await client.get(
+            f"/records/{ds_b.record_id}/keywords/", headers=admin_auth_header
+        )
+        assert any(k["id"] == kw_id for k in listing.json()["keywords"])

--- a/frontend/src/components/dataset/AttributeTable.tsx
+++ b/frontend/src/components/dataset/AttributeTable.tsx
@@ -27,6 +27,7 @@ import {
 } from '@/components/ui/dropdown-menu';
 import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip';
 import { formatNumber } from '@/lib/format';
+import { formatMutationError } from '@/lib/error-map';
 import { coerceAttributeValue } from '@/lib/attribute-values';
 import { Loader2, ArrowUpDown, Settings2, Pencil } from 'lucide-react';
 
@@ -143,16 +144,22 @@ export function AttributeTable({ datasetId, canEdit = false, compact = false }: 
       toast.error(t('attributes.editInvalidValue', { type: colType }));
       return; // keep the editor open so the value can be corrected
     }
-    setEditingCell(null);
+    // fix(#458 E-22): keep the cell in edit mode through the await so the saving
+    // spinner (InlineCellEditor isSaving) actually renders; clearing editingCell
+    // before awaiting made that branch unreachable and showed the stale value.
     try {
       await updateFeature.mutateAsync({
         datasetId,
         gid: rowGid,
         properties: { [column]: coerced.value },
       });
+      setEditingCell(null);
       toast.success(t('attributes.editSaved'));
-    } catch {
-      toast.error(t('attributes.editFailed'));
+    } catch (err) {
+      // fix(#458 E-21): surface the backend's specific reason (geometry-type
+      // mismatch, unknown column, …) instead of a generic toast, and keep the
+      // editor open so the value can be corrected rather than silently reverting.
+      toast.error(formatMutationError('dataset:attributes.editFailed', err));
     }
   }, [datasetId, updateFeature, t]);
 

--- a/frontend/src/components/dataset/PendingEditsBar.tsx
+++ b/frontend/src/components/dataset/PendingEditsBar.tsx
@@ -49,6 +49,9 @@ export function PendingEditsBar({
             variant="outline"
             size="sm"
             onClick={onCancelAll}
+            // fix(#458 E-16): don't let a Discard land mid-save — the PATCH has
+            // already committed by then, so "All changes discarded" would lie.
+            disabled={isSaving}
             data-testid="pending-edits-cancel"
           >
             {t('affordances.pending.discard')}

--- a/frontend/src/components/dataset/__tests__/PendingEditsBar.test.tsx
+++ b/frontend/src/components/dataset/__tests__/PendingEditsBar.test.tsx
@@ -51,7 +51,7 @@ describe('PendingEditsBar', () => {
     expect(onSaveAll).toHaveBeenCalledTimes(1);
   });
 
-  it('shows saving state and disables save button while submitting', () => {
+  it('shows saving state and disables both buttons while submitting', () => {
     render(
       <PendingEditsBar
         pendingCount={1}
@@ -63,6 +63,9 @@ describe('PendingEditsBar', () => {
 
     expect(screen.getByTestId('pending-edits-save')).toBeDisabled();
     expect(screen.getByTestId('pending-edits-save')).toHaveTextContent('Saving...');
+    // fix(#458 E-16): Discard must be disabled mid-save so it can't fire a
+    // misleading "discarded" toast after the PATCH has already committed.
+    expect(screen.getByTestId('pending-edits-cancel')).toBeDisabled();
   });
 });
 

--- a/frontend/src/components/dataset/hooks/__tests__/use-draft-editing.test.ts
+++ b/frontend/src/components/dataset/hooks/__tests__/use-draft-editing.test.ts
@@ -161,6 +161,57 @@ describe('useDraftEditing', () => {
     });
   });
 
+  it('savePendingDrafts includes a draft staged after the callback was captured (E-17)', async () => {
+    // fix(#458 E-17): savePendingDrafts blurs the focused input, which stages its
+    // edit mid-call. The old code read `pendingDrafts` from the callback closure
+    // and dropped that field; the ref-based read captures it. Capturing `save`
+    // BEFORE staging reproduces the stale-closure condition.
+    const { result } = renderHook(() =>
+      useDraftEditing({
+        datasetId: 'ds-1',
+        dataset: makeDataset({ summary: 'old' }),
+        isGeometryEditDirty: false,
+      }),
+    );
+
+    const save = result.current.savePendingDrafts;
+    act(() => {
+      result.current.stagePendingDraft('summary', 'late value');
+    });
+
+    await act(async () => {
+      await save();
+    });
+
+    expect(mockMutateAsync).toHaveBeenCalledWith({
+      datasetId: 'ds-1',
+      data: { summary: 'late value' },
+    });
+  });
+
+  it('save after discard sends nothing (ref is reset)', async () => {
+    const { result } = renderHook(() =>
+      useDraftEditing({
+        datasetId: 'ds-1',
+        dataset: makeDataset({ summary: 'old' }),
+        isGeometryEditDirty: false,
+      }),
+    );
+
+    act(() => {
+      result.current.stagePendingDraft('summary', 'new');
+    });
+    act(() => {
+      result.current.discardPendingDrafts();
+    });
+
+    await act(async () => {
+      await result.current.savePendingDrafts();
+    });
+
+    expect(mockMutateAsync).not.toHaveBeenCalled();
+  });
+
   it('savePendingDrafts returns true with no staged drafts', async () => {
     const { result } = renderHook(() =>
       useDraftEditing({

--- a/frontend/src/components/dataset/hooks/use-draft-editing.ts
+++ b/frontend/src/components/dataset/hooks/use-draft-editing.ts
@@ -1,4 +1,4 @@
-import { useState, useCallback, useMemo } from 'react';
+import { useState, useCallback, useMemo, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { toast } from 'sonner';
 import { useUpdateDataset } from '@/components/dataset/hooks/use-dataset';
@@ -39,6 +39,12 @@ export function useDraftEditing({ datasetId, dataset, isGeometryEditDirty }: Use
   const [pendingDrafts, setPendingDrafts] = useState<PendingDrafts>({});
   const [dirtyFields, setDirtyFields] = useState<Set<PendingDraftField>>(() => new Set());
   const [isSaving, setIsSaving] = useState(false);
+  // fix(#458 E-17): mirror pendingDrafts in a ref, updated synchronously with the
+  // state. savePendingDrafts blurs the focused input to flush its edit through
+  // stagePendingDraft — the blur event fires synchronously, so the ref carries
+  // that just-staged field, whereas the callback's pendingDrafts closure does not
+  // and used to drop it (then setPendingDrafts({}) discarded it for good).
+  const pendingDraftsRef = useRef<PendingDrafts>({});
 
   const stagePendingDraft = useCallback(
     (field: PendingDraftField, value: string) => {
@@ -51,9 +57,12 @@ export function useDraftEditing({ datasetId, dataset, isGeometryEditDirty }: Use
         const next = { ...prev };
         if (normalizedNext === currentDatasetValue) {
           delete next[field];
-          return next;
+        } else {
+          next[field] = normalizedNext;
         }
-        next[field] = normalizedNext;
+        // Keep the ref in lockstep. Idempotent in prev, so StrictMode's
+        // double-invoke of this updater lands on the same value.
+        pendingDraftsRef.current = next;
         return next;
       });
     },
@@ -101,7 +110,11 @@ export function useDraftEditing({ datasetId, dataset, isGeometryEditDirty }: Use
       await new Promise((resolve) => setTimeout(resolve, 0));
     }
 
-    const entries = Object.entries(pendingDrafts) as Array<[PendingDraftField, string | null]>;
+    // Read from the ref, not the closure — it includes the field just staged by
+    // the blur above (fix(#458 E-17)).
+    const entries = Object.entries(pendingDraftsRef.current) as Array<
+      [PendingDraftField, string | null]
+    >;
     if (entries.length === 0) {
       return true;
     }
@@ -115,6 +128,7 @@ export function useDraftEditing({ datasetId, dataset, isGeometryEditDirty }: Use
     try {
       await updateDataset.mutateAsync({ datasetId, data: payload as DatasetUpdateRequest });
       setPendingDrafts({});
+      pendingDraftsRef.current = {};
       setDirtyFields(new Set());
       toast.success(
         t('affordances.pending.saved', {
@@ -139,10 +153,13 @@ export function useDraftEditing({ datasetId, dataset, isGeometryEditDirty }: Use
     } finally {
       setIsSaving(false);
     }
-  }, [datasetId, isGeometryEditDirty, pendingDrafts, t, updateDataset]);
+    // pendingDrafts is intentionally not a dep — savePendingDrafts reads the ref,
+    // which stays current without re-creating this callback on every keystroke.
+  }, [datasetId, isGeometryEditDirty, t, updateDataset]);
 
   const discardPendingDrafts = useCallback(() => {
     setPendingDrafts({});
+    pendingDraftsRef.current = {};
     setDirtyFields(new Set());
     toast.message(
       t('affordances.pending.canceled', {


### PR DESCRIPTION
Clears the actionable P2/P3 findings from the 2026-07-11 editing audit (tracking issue #458). The P1s shipped earlier in #459/#460; this is the tail.

## Backend — write-path contracts, flag enforcement, drift (`bdb7fc5a`)
- **E-08** feature writes to raster/VRT datasets now 404 (mirror the read side) instead of 500 on a missing data table.
- **E-09 / E-26** feature-write DB errors classify by SQLSTATE (reusing `core/db/sqlstate.py`) → 400 for bad input (type mismatch 22P02, NOT NULL 23502, tabular no-column 42703), 503 for an outage. No more 500s.
- **E-11** enforce the `enable_dataset_editing` flag server-side on feature-write + column-DDL handlers (`require_dataset_editing_enabled` → 403 when off). It was UI-only; owners/admins could drive around the disabled toggle via the API.
- **E-13** add/rename/drop column now map DB errors to 400/503 like `alter_column_type` already did (dependent-object, lock timeout no longer 500).
- **E-14** record sub-resource writes gate on read-visibility first → a private, non-owned record 404s (no existence leak) instead of 403; a visible-but-non-owned record still 403s.
- **E-15** contacts/keywords/distributions writes bust the catalog cache (DCAT/STAC), and keyword writes re-embed (keywords are embedding text). Previously these siblings did neither, unlike the top-level metadata PATCH.
- **E-25** feature writers reject unknown property keys with 400 instead of silently dropping them (on PUT a typo also nulled the intended column).

## Frontend — draft + inline-edit UX (`1e84a4ad`)
- **E-16** disable Discard while a draft save is in flight (no misleading "discarded" toast after the PATCH commits).
- **E-17** `savePendingDrafts` reads pending drafts from a ref kept in lockstep with state, so the field staged by the pre-save blur is no longer dropped-then-cleared.
- **E-21** inline attribute-cell save failures surface the backend's specific reason (`formatMutationError`).
- **E-22 (partial)** keep the cell in edit mode through the save await so the saving spinner renders, and keep the editor open on failure for correction.

## Tests
- Backend: `TestEditingEnforcementAndContracts` (E-08/E-09/E-11/E-25), `TestRecordWriteContracts` (E-14/E-15), and an autouse conftest fixture that turns the editing flag on suite-wide (the guard's real branch still runs).
- Frontend: `use-draft-editing` stale-closure regression guard + discard-resets-ref guard; `PendingEditsBar` asserts Discard is disabled while saving.

## Deferred (with rationale, tracked in #458)
E-10 (gid semantics — larger design), **E-18 skip** (LWW acceptable — decided), **E-19 keep API-only** (removing drops a real capability; a UI carries unresolved lossy-cast UX — decided), E-20 (4-layer plumbing for a cosmetic diff gap), E-22 remainder (Escape/blur race — fiddly), E-23 (TerraDraw keyboard — upstream), E-24, E-27 (self-healing), E-28, E-29, E-30, E-31 (`extra="forbid"` changes the SDK contract for a robustness-only P3).

## Verification
- `uv run pytest` — features/records/layers/DDL-idor/metadata/settings suites green under the new flag fixture.
- `npm run typecheck`, `eslint`, and the touched vitest suites green.
- No OpenAPI/SDK regen: runtime status-code behavior only; response models unchanged.

https://claude.ai/code/session_01Mtp1seEXHjAu4vciRXebkd