### PR TITLE
fix(seed): polish the Hurricane Alley showcase map

### DIFF
--- a/scripts/seed-showcase.py
+++ b/scripts/seed-showcase.py
@@ -2168,8 +2168,10 @@ def build_hurricanes(api: Api, force: bool = False) -> str:
             "style_config": {
                 "render_mode": "arrow",
                 "builder": {
-                    "arrow_color": "#701a75",
-                    "arrow_size": 12,
+                    # White arrows read clearly against the magenta Cat-5 line;
+                    # the old dark-purple (#701a75) was nearly invisible on it.
+                    "arrow_color": "#ffffff",
+                    "arrow_size": 16,
                     "arrow_spacing": 90,
                 },
             },
@@ -2187,17 +2189,10 @@ def build_hurricanes(api: Api, force: bool = False) -> str:
                 "line-opacity": 0.9,
             },
             "layout": {"line-cap": "round", "line-join": "round"},
-            "popup_config": {
-                "enabled": True,
-                "expression": "{name} ({season})",
-                "visible_fields": [
-                    "category",
-                    "wind_kt",
-                    "pressure_mb",
-                    "status",
-                    "landfall",
-                ],
-            },
+            # No popup on the highlight layer: it overlaps the storm-tracks layer
+            # on every Cat-5 segment, so enabling both made the feature popup pager
+            # show each Cat-5 leg twice. The storm-tracks layer below owns popups.
+            "popup_config": {"enabled": False},
         },
     )
     api.add_layer(
@@ -2205,13 +2200,21 @@ def build_hurricanes(api: Api, force: bool = False) -> str:
         {
             "dataset_id": tracks_ds,
             "sort_order": 1,
-            "opacity": 0.9,
+            # Single source of dimming: layer opacity 1.0 × line-opacity 0.85 keeps
+            # the intended ~0.85. The old 0.9 compounded to a washed-out 0.765.
+            "opacity": 1.0,
             "display_name": "Storm tracks (by intensity at each leg)",
             "style_config": {
                 "mode": "categorical",
                 "column": "category",
-                "ramp": "Dark2",
+                # These colors are hand-picked (Saffir-Simpson), not a named ramp;
+                # "custom" keeps the ramp picker honest instead of falsely showing
+                # Dark2 selected. TD is included so the legend matches the paint
+                # (which already colors TD via cat_colors) — degenerate/weak legs
+                # are no longer an unlabeled gray on the map.
+                "ramp": "custom",
                 "categories": [
+                    {"value": "TD", "color": "#9ca3af", "label": "Tropical depression"},
                     {"value": "TS", "color": "#60a5fa", "label": "Tropical storm"},
                     {"value": "Cat 1", "color": "#facc15", "label": "Category 1"},
                     {"value": "Cat 2", "color": "#fb923c", "label": "Category 2"},
@@ -2262,7 +2265,10 @@ def build_hurricanes(api: Api, force: bool = False) -> str:
             "label_config": {
                 "column": "name",
                 "fontSize": 11,
-                "minZoom": 4.2,
+                # Raised from 4.2: at world/basin zoom, labelling every 6-hour
+                # segment carpeted the map in repeated storm names. From ~z6 the
+                # view is regional and names read instead of collide.
+                "minZoom": 6,
                 "placement": "line-center",
                 "textColor": "#334155",
                 "haloColor": "#ffffff",


### PR DESCRIPTION
## Summary

Six symbology/config issues on the seeded **Hurricane Alley** showcase map (`scripts/seed-showcase.py`, `build_hurricanes`). Surfaced by the Hurricane Alley audit; the editor-side product bugs the same audit found shipped separately in #461. This PR is demo-content only.

| Fix | Before | After |
|---|---|---|
| Legend omitted TD | `categories` listed 6 classes; TD legs rendered as unlabeled gray | added **Tropical depression** (matches the paint, which already colored TD) |
| Ramp mislabel | `ramp: "Dark2"` but colors are hand-picked Saffir-Simpson | `ramp: "custom"` — ramp picker no longer falsely shows Dark2 selected |
| Double-dimmed | layer `0.9` × line-opacity `0.85` = washed-out **0.765** | layer `1.0` → single ~`0.85` source |
| Illegible arrows | dark purple `#701a75` on magenta `#c026d3`, size 12 | **white** `#ffffff`, size 16 — reads as direction of motion |
| Label spam | `minZoom 4.2` carpeted the basin in repeated names at world zoom | `minZoom 6` — names read regionally |
| Duplicate popups | both layers enabled popups → Cat-5 click paged the same feature twice | popup disabled on the highlight layer; storm-tracks owns popups |

## Impact / scope
- **Demo content only** — one function in the seed script; no product code, schema, or API change.
- Takes effect on the next showcase re-seed / demo redeploy (not automatic on existing instances).
- Interacts cleanly with #461: the config is now internally consistent (7 categories matching the data), so the editor guard has an exact match anyway.

## Verification
Re-seeded the map against the local stack (dataset reused, no HURDAT2 re-ingest) and confirmed both in the **stored config** and on the **rendered map**:
- Legend now shows Tropical depression (7 entries); no world-zoom label carpet.
- White Cat-5 arrows clearly visible at z6 (Katrina/Ivan/Rita/Camille).
- Clicking a Cat-5 leg now sources popups from the storm-tracks layer only (no duplicate page); adjacent legs still page as distinct real segments.
- `ramp: "custom"` and `popup_config: {enabled: false}` accepted by the API (no 422).

## Follow-up (not in this PR)
- Per-storm dissolve would thin labels further in dense basins (z6 still busy in the Gulf); the audit noted it as the deeper fix. `landfall` still shows raw `0`/`1` in popups — a frontend popup-formatting concern, not seed.

https://claude.ai/code/session_01QmxibW97dSfvC1m4S6xLXU
