### PR TITLE
feat(catalog): advertise GeoParquet in DCAT distributions + backfill existing datasets

### DIFF
--- a/backend/alembic/versions/0013_backfill_geoparquet_distributions.py
+++ b/backend/alembic/versions/0013_backfill_geoparquet_distributions.py
@@ -1,0 +1,61 @@
+"""Backfill GeoParquet download distributions for existing spatial datasets.
+
+fix(#462 follow-up): _DISTRIBUTION_TEMPLATES now generates a GeoParquet download
+distribution at dataset creation (records/service.py), but those rows are
+materialized — existing spatial datasets created before this deploy would never
+advertise the parquet download in DCAT feeds. This backfills one row per spatial
+dataset that lacks it, so DCAT distributions match what a fresh ingest produces.
+
+Idempotent: the NOT EXISTS guard (plus the uq_record_distribution unique
+constraint on record_id/distribution_type/format/url) makes re-running a no-op.
+Downgrade removes only the auto-generated parquet download rows.
+
+Non-spatial datasets are excluded (geometry_type IS NULL) — GeoParquet requires
+geometry, matching generate_distributions' spatial-only filter.
+
+Revision ID: 0013_backfill_geoparquet_distributions
+Revises: 0012_type_embedding_vector
+Create Date: 2026-07-12
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+revision: str = "0013_backfill_geoparquet_distributions"
+down_revision: Union[str, None] = "0012_type_embedding_vector"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        INSERT INTO catalog.record_distributions
+            (record_id, distribution_type, format, url, title, protocol,
+             media_type, is_primary, auto_generated)
+        SELECT d.record_id, 'download', 'parquet',
+               '/datasets/' || d.id::text || '/export?format=parquet',
+               'GeoParquet Download', 'HTTP',
+               'application/vnd.apache.parquet', false, true
+        FROM catalog.datasets d
+        WHERE d.geometry_type IS NOT NULL
+          AND NOT EXISTS (
+              SELECT 1 FROM catalog.record_distributions rd
+              WHERE rd.record_id = d.record_id
+                AND rd.distribution_type = 'download'
+                AND rd.format = 'parquet'
+          )
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        """
+        DELETE FROM catalog.record_distributions
+        WHERE distribution_type = 'download'
+          AND format = 'parquet'
+          AND auto_generated = true
+        """
+    )

--- a/backend/app/modules/catalog/records/service.py
+++ b/backend/app/modules/catalog/records/service.py
@@ -372,12 +372,15 @@ _DISTRIBUTION_TEMPLATES = [
         "application/zip",
         False,
     ),
-    # GeoParquet is intentionally NOT a materialized DCAT distribution here:
-    # these rows are generated per-dataset at creation, so adding a format would
-    # advertise it only for new datasets and needs a data-migration backfill for
-    # existing ones (deferred to a follow-up). GeoParquet is already advertised
-    # live for all datasets via OGC API Records / STAC (_FORMAT_MEDIA in
-    # search/service_records.py), so discovery is covered without the backfill.
+    (
+        "download",
+        "parquet",
+        "/datasets/{dataset_id}/export?format=parquet",
+        "GeoParquet Download",
+        "HTTP",
+        "application/vnd.apache.parquet",
+        False,
+    ),
     (
         "download",
         "csv",
@@ -408,8 +411,8 @@ async def generate_distributions(
 ) -> list[RecordDistribution]:
     """Generate standard distribution records for a dataset.
 
-    For spatial datasets (geometry_type is not None): creates 6 distribution rows
-    (4 download formats + OGC features + vector tiles).
+    For spatial datasets (geometry_type is not None): creates 7 distribution rows
+    (5 download formats incl. GeoParquet + OGC features + vector tiles).
     For non-spatial datasets (geometry_type is None): creates only csv download
     + OGC features (2 rows).
 

--- a/backend/tests/test_records_related.py
+++ b/backend/tests/test_records_related.py
@@ -603,7 +603,7 @@ class TestDistributions:
         )
         assert resp.status_code == 200
         data = resp.json()
-        assert data["total"] == 6
+        assert data["total"] == 7
 
         # All auto_generated
         for d in data["distributions"]:
@@ -821,7 +821,7 @@ class TestDistributions:
             geometry_type="MultiPolygon",
         )
         await test_db_session.commit()
-        assert len(created1) == 6
+        assert len(created1) == 7
 
         # Second generation (idempotent)
         created2 = await generate_distributions(
@@ -834,11 +834,11 @@ class TestDistributions:
         await test_db_session.commit()
         assert len(created2) == 0  # No new rows
 
-        # Still only 6 total
+        # Still only 7 total
         resp = await client.get(
             f"/records/{ds.record_id}/distributions/", headers=admin_auth_header
         )
-        assert resp.json()["total"] == 6
+        assert resp.json()["total"] == 7
 
     async def test_distribution_lifecycle_modes(
         self,
@@ -866,11 +866,11 @@ class TestDistributions:
         assert manual_resp.status_code == 201
         manual_id = manual_resp.json()["id"]
 
-        # Total: 6 system + 1 manual = 7
+        # Total: 7 system + 1 manual = 8
         list_resp = await client.get(
             f"/records/{ds.record_id}/distributions/", headers=admin_auth_header
         )
-        assert list_resp.json()["total"] == 7
+        assert list_resp.json()["total"] == 8
 
         # System distributions are immutable
         auto_dist = next(
@@ -996,7 +996,7 @@ class TestCascadeDelete:
         pre_result = await test_db_session.execute(
             select(RecordDistribution).where(RecordDistribution.record_id == record_id)
         )
-        assert len(pre_result.all()) == 6
+        assert len(pre_result.all()) == 7
 
         await client.request(
             "DELETE",
@@ -1095,7 +1095,7 @@ class TestMigrationData:
             )
         )
         download_dists = result.scalars().all()
-        assert len(download_dists) == 4
+        assert len(download_dists) == 5
 
         for d in download_dists:
             assert dataset_id_str in d.url, (


### PR DESCRIPTION
**Stacked on #462** (`feat/catalog-easy-wins`) — completes the one item deliberately deferred there. Retarget this PR to `main` once #462 merges.

In #462, GeoParquet is advertised **live** for all datasets via OGC API Records + STAC (`_FORMAT_MEDIA`), but the **materialized DCAT distribution rows** were left alone because extending them cleanly needs a backfill for existing datasets. This PR does that.

## Changes
- **`_DISTRIBUTION_TEMPLATES`** (`records/service.py`): re-add the GeoParquet download so a fresh spatial ingest materializes a parquet distribution. Spatial-only — non-spatial datasets still get just csv + ogc_features.
- **Alembic `0013`** (data migration): backfill the parquet distribution for existing spatial datasets. Idempotent (`NOT EXISTS` + the `uq_record_distribution` constraint), reversible (downgrade deletes the auto-generated parquet rows), **no schema change** (so `alembic-check` drift is unaffected).
- **Count tests**: spatial download `4→5`, system total `6→7` (and the "6 system + 1 manual" case `7→8`); `generate_distributions` docstring `6→7`. Non-spatial (`2`) and the OGC `formats` list are unchanged.

## Verification
Ruff clean; migration revision chain verified (`0013 → 0012`, single head); full sweep confirms no other spatial distribution-count assertion. **No local test DB**, so the migration + updated counts are validated by CI's **Alembic Clean-DB Upgrade** + **Backend Tests** gates.

## Note for review
The migration writes to `catalog.record_distributions` for every spatial dataset without a parquet row — bounded, idempotent, and reversible, but it's a data migration, so worth a look at the SQL and the downgrade.

https://claude.ai/code/session_015cpiMW7X8MNmG4nN4dfzqB