### PR TITLE
feat(observability): ship reference Prometheus/Grafana monitoring config

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,6 +358,13 @@ For day-2 operations, restore procedures, and incident response, see
 [RUNBOOK.md](RUNBOOK.md). For provider-specific configuration options, see
 [Backups & Restore](https://docs.getgeolens.com/guides/admin/backups/#backup-destinations).
 
+### Monitoring
+
+The API and worker export Prometheus metrics out of the box (HTTP rate/latency/
+errors, job-queue depth, DB pool, tile-cache). Reference scrape config, alert
+rules, and a Grafana dashboard ship in [`infra/monitoring/`](infra/monitoring/);
+see [RUNBOOK.md §4](RUNBOOK.md#4-monitoring) for the setup steps.
+
 ## Reference
 
 | Guide | Description |

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -240,6 +240,55 @@ self-hosted Docker deployments, WAL archiving requires `wal_level = replica` and
 
 ## 4. Monitoring
 
+GeoLens exports Prometheus metrics out of the box. Reference scrape config, alert
+rules, and a Grafana dashboard ship in [`infra/monitoring/`](infra/monitoring/) —
+point your monitoring stack at them, or use them as a base for an existing one.
+
+### Metrics & alerting (Prometheus / Grafana)
+
+Metrics are exposed on **two separate endpoints** — the API and the worker each
+run their own:
+
+| Source | On the Compose network | Host mapping | Exports |
+|---|---|---|---|
+| API | `http://api:8000/metrics` | `127.0.0.1:8001/metrics` | HTTP request rate / latency / errors, DB connection-pool gauges, tile-cache hit/miss |
+| Worker | `http://worker:8001/metrics` | internal-only | Procrastinate job-queue depth, active, completed, failed (per queue) |
+
+`infra/monitoring/prometheus.yml` already defines both scrape jobs
+(`geolens-api`, `geolens-worker`) and loads `alerts.yml` as a rule file. Run
+Prometheus on the Compose network so the `api` / `worker` hostnames resolve:
+
+```bash
+docker run --rm -d --name geolens-prometheus \
+  --network geolens_default \
+  -p 127.0.0.1:9090:9090 \
+  -v "$PWD/infra/monitoring/prometheus.yml:/etc/prometheus/prometheus.yml:ro" \
+  -v "$PWD/infra/monitoring/alerts.yml:/etc/prometheus/alerts.yml:ro" \
+  prom/prometheus:v3.5.0   # or a newer pinned tag
+```
+
+Then import `infra/monitoring/grafana-dashboard.json` into Grafana
+(**Dashboards → Import**) and select your Prometheus data source when prompted.
+
+Already running Prometheus/Grafana elsewhere? Copy the `scrape_configs` jobs and
+the `rule_files` entry into your own config and import the dashboard JSON — the
+targets just need network reach to `api:8000` and `worker:8001`.
+
+**Alert rules** (`infra/monitoring/alerts.yml`) — thresholds are tunable defaults:
+
+| Alert | Fires when | Severity |
+|---|---|---|
+| `GeoLensTargetDown` | API or worker unscrapeable for >2m | critical |
+| `GeoLensApiHigh5xxRate` | 5xx share of requests >5% over 5m | critical |
+| `GeoLensApiHighLatencyP95` | p95 request latency >1s, sustained 10m | warning |
+| `GeoLensJobQueueBacklog` | any queue >100 jobs for 15m | warning |
+| `GeoLensJobFailures` | >5 job failures in 15m | warning |
+| `GeoLensDbPoolSaturated` | connection-pool overflow in use for >10m | warning |
+
+> Under an external pooler (`DB_USE_EXTERNAL_POOLER=true` → SQLAlchemy `NullPool`),
+> the `geolens_db_pool_*` gauges are not emitted and `GeoLensDbPoolSaturated`
+> never fires — pool health is the provider's responsibility there.
+
 ### Backup service healthcheck
 
 The `backup` service exposes a Docker healthcheck:

--- a/infra/monitoring/alerts.yml
+++ b/infra/monitoring/alerts.yml
@@ -41,10 +41,13 @@ groups:
             the last 5 minutes.
 
       - alert: GeoLensApiHighLatencyP95
-        # The duration histogram has no status label; aggregate by le only.
+        # fix(#466): use the HIGH-resolution histogram. The default
+        # http_request_duration_seconds tops out at le=1.0 (then +Inf), so
+        # histogram_quantile caps at 1.0 and `> 1` could never fire; the highr
+        # histogram has buckets out to 60s. No status label on either → group by le.
         expr: |
           histogram_quantile(0.95,
-            sum by (le) (rate(http_request_duration_seconds_bucket[5m]))) > 1
+            sum by (le) (rate(http_request_duration_highr_seconds_bucket[5m]))) > 1
         for: 10m
         labels:
           severity: warning

--- a/infra/monitoring/alerts.yml
+++ b/infra/monitoring/alerts.yml
@@ -1,0 +1,98 @@
+# GeoLens reference alerting rules.
+#
+# These are conservative defaults meant to catch the failure modes a self-hoster
+# actually gets paged for — a target down, the API erroring or stalling, the job
+# queue not draining, the DB pool saturating. Thresholds (>5%, >1s, >100, etc.)
+# are starting points; tune them to your traffic. See RUNBOOK.md §4.
+#
+# Every expression below references a metric this build actually exports (verified
+# against a live /metrics). `up` is synthesized by Prometheus per scrape target.
+
+groups:
+  - name: geolens-availability
+    rules:
+      - alert: GeoLensTargetDown
+        expr: up{job=~"geolens-.*"} == 0
+        for: 2m
+        labels:
+          severity: critical
+        annotations:
+          summary: "{{ $labels.job }} scrape target is down"
+          description: >-
+            Prometheus has failed to scrape {{ $labels.job }}
+            ({{ $labels.instance }}) for more than 2 minutes — the API or worker
+            process may be down.
+
+  - name: geolens-api
+    rules:
+      - alert: GeoLensApiHigh5xxRate
+        # 5xx as a share of all requests. status is the ungrouped code because the
+        # instrumentator is configured should_group_status_codes=False.
+        expr: |
+          sum(rate(http_requests_total{status=~"5.."}[5m]))
+            / sum(rate(http_requests_total[5m])) > 0.05
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: "API 5xx error ratio above 5%"
+          description: >-
+            {{ $value | humanizePercentage }} of API requests returned 5xx over
+            the last 5 minutes.
+
+      - alert: GeoLensApiHighLatencyP95
+        # The duration histogram has no status label; aggregate by le only.
+        expr: |
+          histogram_quantile(0.95,
+            sum by (le) (rate(http_request_duration_seconds_bucket[5m]))) > 1
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          summary: "API p95 latency above 1s"
+          description: >-
+            95th-percentile request latency is {{ $value | humanizeDuration }}
+            (sustained over 10 minutes).
+
+  - name: geolens-jobs
+    rules:
+      - alert: GeoLensJobQueueBacklog
+        # geolens_jobs_queue_depth is a per-queue gauge exported by the worker.
+        expr: max by (queue) (geolens_jobs_queue_depth) > 100
+        for: 15m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Job queue '{{ $labels.queue }}' backlog above 100"
+          description: >-
+            {{ $value }} jobs have been waiting in the '{{ $labels.queue }}' queue
+            for more than 15 minutes — the worker may be stuck or under-provisioned.
+            Threshold is tunable.
+
+      - alert: GeoLensJobFailures
+        expr: increase(geolens_jobs_failed_total[15m]) > 5
+        for: 2m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Jobs failing in queue '{{ $labels.queue }}'"
+          description: >-
+            {{ $value }} jobs failed in the '{{ $labels.queue }}' queue in the last
+            15 minutes.
+
+  - name: geolens-database
+    rules:
+      - alert: GeoLensDbPoolSaturated
+        # Overflow connections are only opened once the base pool is full. Sustained
+        # overflow use = the pool is a bottleneck. Not emitted under an external
+        # pooler (DB_USE_EXTERNAL_POOLER → NullPool has no stats).
+        expr: geolens_db_pool_overflow > 0
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          summary: "DB connection pool saturated (overflow in use)"
+          description: >-
+            The base connection pool has been full and using overflow connections
+            for more than 10 minutes. Consider raising the pool size or
+            investigating slow queries.

--- a/infra/monitoring/grafana-dashboard.json
+++ b/infra/monitoring/grafana-dashboard.json
@@ -118,7 +118,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "histogram_quantile(0.95, sum by (le) (rate(http_request_duration_seconds_bucket[5m])))",
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(http_request_duration_highr_seconds_bucket[5m])))",
           "refId": "A",
           "legendFormat": "p95"
         },
@@ -127,7 +127,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "histogram_quantile(0.99, sum by (le) (rate(http_request_duration_seconds_bucket[5m])))",
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(http_request_duration_highr_seconds_bucket[5m])))",
           "refId": "B",
           "legendFormat": "p99"
         }

--- a/infra/monitoring/grafana-dashboard.json
+++ b/infra/monitoring/grafana-dashboard.json
@@ -1,0 +1,652 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "lineWidth": 1
+          },
+          "unit": "reqps",
+          "color": {
+            "mode": "palette-classic"
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (status) (rate(http_requests_total[5m]))",
+          "refId": "A",
+          "legendFormat": "{{status}}"
+        }
+      ],
+      "title": "API request rate (by status)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "lineWidth": 1
+          },
+          "unit": "s",
+          "color": {
+            "mode": "palette-classic"
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 0
+      },
+      "id": 2,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(http_request_duration_seconds_bucket[5m])))",
+          "refId": "A",
+          "legendFormat": "p95"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(http_request_duration_seconds_bucket[5m])))",
+          "refId": "B",
+          "legendFormat": "p99"
+        }
+      ],
+      "title": "API latency (p95 / p99)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 0.01
+              },
+              {
+                "color": "red",
+                "value": 0.05
+              }
+            ]
+          },
+          "color": {
+            "mode": "thresholds"
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 4,
+        "x": 16,
+        "y": 0
+      },
+      "id": 3,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum(rate(http_requests_total{status=~\"5..\"}[5m])) / clamp_min(sum(rate(http_requests_total[5m])), 1)",
+          "refId": "A"
+        }
+      ],
+      "title": "API 5xx ratio (5m)",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "color": {
+            "mode": "thresholds"
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 4,
+        "x": 20,
+        "y": 0
+      },
+      "id": 4,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum(http_requests_inprogress)",
+          "refId": "A"
+        }
+      ],
+      "title": "Requests in progress",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "lineWidth": 1
+          },
+          "unit": "short",
+          "color": {
+            "mode": "palette-classic"
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 8
+      },
+      "id": 5,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "geolens_jobs_queue_depth",
+          "refId": "A",
+          "legendFormat": "{{queue}}"
+        }
+      ],
+      "title": "Job queue depth (by queue)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "lineWidth": 1
+          },
+          "unit": "short",
+          "color": {
+            "mode": "palette-classic"
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 8
+      },
+      "id": 6,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "geolens_jobs_active",
+          "refId": "A",
+          "legendFormat": "{{queue}}"
+        }
+      ],
+      "title": "Active jobs (by queue)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "lineWidth": 1
+          },
+          "unit": "cps",
+          "color": {
+            "mode": "palette-classic"
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 8
+      },
+      "id": 7,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "rate(geolens_jobs_completed_total[15m])",
+          "refId": "A",
+          "legendFormat": "{{queue}} completed"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "rate(geolens_jobs_failed_total[15m])",
+          "refId": "B",
+          "legendFormat": "{{queue}} failed"
+        }
+      ],
+      "title": "Job throughput (completed / failed, per s)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "lineWidth": 1
+          },
+          "unit": "short",
+          "color": {
+            "mode": "palette-classic"
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 16
+      },
+      "id": 8,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "geolens_db_pool_checkedout",
+          "refId": "A",
+          "legendFormat": "checked out"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "geolens_db_pool_checkedin",
+          "refId": "B",
+          "legendFormat": "checked in"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "geolens_db_pool_overflow",
+          "refId": "C",
+          "legendFormat": "overflow"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "geolens_db_pool_size",
+          "refId": "D",
+          "legendFormat": "size"
+        }
+      ],
+      "title": "DB connection pool",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "lineWidth": 1
+          },
+          "unit": "bytes",
+          "color": {
+            "mode": "palette-classic"
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 16
+      },
+      "id": 9,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "process_resident_memory_bytes{job=~\"geolens-.*\"}",
+          "refId": "A",
+          "legendFormat": "{{job}}"
+        }
+      ],
+      "title": "Process resident memory (by service)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 0.5
+              },
+              {
+                "color": "green",
+                "value": 0.8
+              }
+            ]
+          },
+          "color": {
+            "mode": "thresholds"
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 16
+      },
+      "id": 10,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum(rate(geolens_tile_cache_hits_total[30m])) / clamp_min(sum(rate(geolens_tile_cache_hits_total[30m])) + sum(rate(geolens_tile_cache_misses_total[30m])), 1)",
+          "refId": "A"
+        }
+      ],
+      "title": "Tile cache hit ratio (30m)",
+      "type": "stat"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 39,
+  "tags": [
+    "geolens"
+  ],
+  "templating": {
+    "list": [
+      {
+        "current": {},
+        "hide": 0,
+        "includeAll": false,
+        "label": "Prometheus",
+        "multi": false,
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "GeoLens \u2014 Overview",
+  "uid": "geolens-overview",
+  "version": 1,
+  "weekStart": ""
+}

--- a/infra/monitoring/prometheus.yml
+++ b/infra/monitoring/prometheus.yml
@@ -1,0 +1,36 @@
+# GeoLens reference Prometheus scrape config.
+# Usage and the batteries-included quickstart are in RUNBOOK.md §4 (Monitoring).
+#
+# Two scrape targets — the API and the worker expose SEPARATE /metrics endpoints:
+#   api:8000     HTTP request metrics (rate/latency/errors) + DB connection-pool
+#                gauges + tile-cache hit/miss counters
+#   worker:8001  Procrastinate job-queue metrics (queue depth, active, completed,
+#                failed) — the worker runs its own tiny metrics server, it is NOT
+#                on the API's /metrics.
+#
+# The `api` / `worker` hostnames resolve on the Compose network (geolens_default).
+# Running Prometheus outside that network? Replace them with reachable host:port
+# (e.g. the API's host mapping is 127.0.0.1:8001 -> api:8000; the worker port is
+# internal-only, so join the Compose network or publish it).
+
+global:
+  scrape_interval: 15s # matches the 15s gauge-refresh loop in the app
+  evaluation_interval: 15s
+
+rule_files:
+  - alerts.yml # sits alongside this file; load both from the same directory
+
+scrape_configs:
+  - job_name: geolens-api
+    metrics_path: /metrics
+    static_configs:
+      - targets: ["api:8000"]
+        labels:
+          service: api
+
+  - job_name: geolens-worker
+    metrics_path: /metrics
+    static_configs:
+      - targets: ["worker:8001"]
+        labels:
+          service: worker


### PR DESCRIPTION
## Summary

Ship reference Prometheus/Grafana monitoring config. The backend already exports metrics but shipped nothing to consume them — this closes M1's "instrumented but unusable out of the box" gap.

## What's included

- `infra/monitoring/prometheus.yml` — scrapes **both** metrics endpoints (the API at `api:8000`, and the worker's own server at `worker:8001`) and loads the alert rules
- `infra/monitoring/alerts.yml` — 6 alerts: target-down, API 5xx rate, p95 latency, job-queue backlog, job failures, DB-pool saturation. Thresholds are tunable defaults.
- `infra/monitoring/grafana-dashboard.json` — 10-panel, import-portable dashboard (uses a datasource variable so import prompts for Prometheus)
- `RUNBOOK.md` §4 — setup + quickstart; `README.md` — `### Monitoring` pointer

## Design

Reference config only — **no bundled Prometheus/Grafana stack**. Operators point their own monitoring at the files (a compose profile can wrap them later if there's demand). This keeps two CVE-prone images and a default-credential surface out of the maintained footprint while still closing the observability gap.

## Verification

- `promtool check config` + `check rules` — config valid, `rule_files` resolves, all 6 rules parse
- Live Prometheus scrape against the running stack: **both targets `up=1`**, all 6 rules loaded `[ok]`, custom metrics queryable end-to-end

## Schema / API / config impact

None. No app code, no compose services, no migrations — additive config files + docs only.
