### PR TITLE
docs(compose): clarify FRONTEND_TILE_BASE_URL vs CDN_BASE_URL for tile routing

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -399,8 +399,13 @@ FRONTEND_PORT=8080
 # ==============================================================================
 
 # --- CDN ---
-# [OPTIONAL] CDN origin URL for tile delivery
-# When set, the frontend requests tiles from this URL instead of the API.
+# [OPTIONAL] CDN origin URL for tile delivery.
+# NOTE: this is only a FALLBACK — the frontend's TILE_BASE_URL outranks it
+# (resolveTileBaseUrl). Because docker-compose.prod.yml defaults the frontend
+# TILE_BASE_URL to /api, setting CDN_BASE_URL alone does NOT reroute tiles; it
+# only flips the admin "Tile Cache" badge to "CDN". To actually serve tiles from
+# a separate CDN host, set FRONTEND_TILE_BASE_URL (frontend service). A CDN
+# fronting the whole domain needs neither — tiles route through the edge same-origin.
 # Type: string | No default
 # Example: https://cdn.example.com/tiles
 # CDN_BASE_URL=

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -364,6 +364,10 @@ services:
       # The SPA calls relative /api (nginx proxies to api:8000), so a relative
       # base works for any host the stack is reached on. Override for a CDN.
       API_BASE_URL: "${FRONTEND_API_BASE_URL:-/api}"
+      # FRONTEND_TILE_BASE_URL (this var) is the tile-CDN lever and OUTRANKS the
+      # backend CDN_BASE_URL setting (see resolveTileBaseUrl); CDN_BASE_URL alone
+      # only flips the admin "Tile Cache" badge. Fronting the whole domain with a
+      # CDN needs neither — tiles route through the edge same-origin; leave at /api.
       TILE_BASE_URL: "${FRONTEND_TILE_BASE_URL:-/api}"
       # Empty default on purpose: the api service's localhost fallback must not
       # leak into og:image; unset keeps the built relative URL.


### PR DESCRIPTION
One-line clarification prompted by live demo setup: the frontend `TILE_BASE_URL` (`FRONTEND_TILE_BASE_URL`) outranks the backend `CDN_BASE_URL` in `resolveTileBaseUrl`, so setting `CDN_BASE_URL` alone only flips the admin **Tile Cache** badge — it does not route tiles. The existing "Override for a CDN" comment implied otherwise.

Fronting the whole domain with a CDN (as the demo now does via Cloudflare) needs neither var — tiles route through the edge same-origin.

Doc-only; no functional change.