### PR TITLE
build(deps): bump github/codeql-action to 3.37.0 (init/autobuild/analyze)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -34,14 +34,14 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@dd903d2e4f5405488e5ef1422510ee31c8b32357  # v3
+        uses: github/codeql-action/init@02c5e83432fe5497fd85b873b6c9f16a8578e1d9  # v3
         with:
           languages: ${{ matrix.language }}
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@dd903d2e4f5405488e5ef1422510ee31c8b32357  # v3
+        uses: github/codeql-action/autobuild@02c5e83432fe5497fd85b873b6c9f16a8578e1d9  # v3
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@dd903d2e4f5405488e5ef1422510ee31c8b32357  # v3
+        uses: github/codeql-action/analyze@02c5e83432fe5497fd85b873b6c9f16a8578e1d9  # v3
         with:
           category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
Dependabot split the codeql-action `3.36.2 → 3.37.0` bump into per-sub-action PRs — #411 (analyze) and #408 (autobuild) — each of which **fails the CodeQL analysis jobs** because `init` stays at 3.36.2 and all codeql-action steps must run the same version.

This bumps all three (`init`/`autobuild`/`analyze`) together so they stay in lockstep. Once merged, Dependabot auto-closes #411 and #408 (dependency already at target).

Supersedes #411, #408.