### PR TITLE
fix(installer): fail on terminal service states instead of soft-passing as 'still starting'

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -210,6 +210,25 @@ wait_for_healthy() {
   done
 
   printf '\n' >&2
+
+  # fix(#446): distinguish genuinely-still-starting from stuck. A service that is
+  # crash-looping (Restarting) or sitting in a non-zero Exited state after the full
+  # timeout is not converging (bad image, OOM-kill, broken config) — fail with its
+  # logs like the migrate path, instead of the exit-0 "still starting" guidance
+  # below. `Exited (0)` and `starting`/`health: starting` are excluded, so the
+  # ARM/QEMU first-boot case (#441) stays non-fatal (return 2).
+  stuck=$(compose ps --format '{{.Service}}|{{.Status}}' 2>/dev/null \
+    | grep -E '\|(Restarting|Exited \([1-9])' || true)
+  if [ -n "$stuck" ]; then
+    warn "services failed to start after $((attempts * sleep_s))s (crash-looping or exited non-zero):"
+    printf '%s\n' "$stuck" | sed 's/^/  /' >&2
+    for svc in $(printf '%s\n' "$stuck" | cut -d'|' -f1); do
+      warn "last 30 log lines for $svc:"
+      compose logs --tail 30 "$svc" 2>&1 | sed 's/^/  /' >&2
+    done
+    return 1
+  fi
+
   warn "services are not all healthy yet after $((attempts * sleep_s))s. This is usually still a"
   warn "normal startup: on Apple Silicon and other ARM hosts the database image runs emulated"
   warn "and can take several more minutes on first boot. Current status:"
@@ -526,8 +545,8 @@ main() {
   compose up -d
 
   # `set -eu` is active: capture the status without letting a non-zero return
-  # abort the script. 1 = migrate failed (fatal); 2 = still converging (not
-  # fatal — see wait_for_healthy).
+  # abort the script. 1 = migrate failed or a service is stuck in a terminal
+  # failed state (fatal); 2 = still converging (not fatal — see wait_for_healthy).
   health_rc=0
   wait_for_healthy || health_rc=$?
   if [ "$health_rc" -eq 1 ]; then


### PR DESCRIPTION
## Problem
Since #441 softened the health timeout (`return 2` = non-fatal *"still starting"*), `wait_for_healthy` returned 2 for **any** non-healthy end state. A service that is crash-looping (`Restarting (1)`) or sitting in a terminal `Exited (N≠0)` for the full 300s — bad image, OOM-kill, broken config — fell through to `return 2`, so the installer printed *"still starting. Give it a few more minutes"* and **exited 0**, masking the failure.

## Fix
At timeout, classify the unhealthy set: `Restarting` or `Exited (non-zero)` is terminal → **fail (`return 1`)** with the service's log tail, like the existing `migrate` one-shot path. `Exited (0)` and services still in `starting`/`health: starting` stay non-fatal (`return 2`), so the ARM/QEMU first-boot case from #441 is unchanged.

Verified the grep classification against sample Compose status strings (Restarting + Exited(137) flag; Exited(0), health:starting, Created, healthy pass through).

## Follow-up
Per the issue: `getgeolens.com/public/install.sh` is a byte-copy gated by `check-install-sync` — after this lands in a release the web repo needs `npm run sync-install`.

Closes #446