### PR TITLE
chore(release): v1.4.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,46 @@ and releases use semantic versioning.
 
 ## [Unreleased]
 
+## [1.4.6] - 2026-07-12
+
+### Added
+
+- **GeoParquet export.** Any spatial dataset can now be exported as GeoParquet
+  (`GET /datasets/{id}/export?format=parquet`), and every spatial dataset now
+  advertises a GeoParquet download in its DCAT distributions — including a
+  backfill so existing datasets gain the distribution automatically.
+- **AI-generated metadata on ingest.** Newly ingested datasets can have a
+  summary and metadata drafted for them automatically, giving the catalog a
+  head start on description quality.
+- **`llms.txt`.** A machine-readable `llms.txt` now describes the API surface
+  for LLM-based agents and crawlers.
+- **Reference monitoring stack.** Ships a reference Prometheus + Grafana
+  configuration so self-hosters can stand up metrics and dashboards without
+  assembling them from scratch.
+
+### Changed
+
+- **The DCAT catalog is paginated.** Large catalogs no longer serialize every
+  dataset into a single response.
+- Clarified the distinction between `FRONTEND_TILE_BASE_URL` and
+  `CDN_BASE_URL` for tile routing in the Compose documentation.
+
+### Fixed
+
+- **Feature and schema editing hardening.** A round of editing-correctness
+  fixes: stricter validation on write paths, correct enforcement of
+  per-dataset edit flags, and a clearer draft-editing experience.
+- **The style editor no longer clobbers saved categorical symbology.** Opening
+  the builder's style editor on a layer with categorical colors preserves the
+  saved per-category styling.
+- **The installer fails fast on terminal service states** instead of
+  soft-passing a crashed or exited service as "still starting."
+
+### Dependencies
+
+- Bumped procrastinate (3.9.0), the SQLAlchemy ecosystem, the TanStack Query
+  packages, pytest, `github/codeql-action`, and `docker/login-action`.
+
 ## [1.4.5] - 2026-07-11
 
 ### Security

--- a/backend/app/api/main.py
+++ b/backend/app/api/main.py
@@ -458,7 +458,7 @@ _is_production = settings.is_production
 # no metadata to read. We fall back to the current published line so import never
 # crashes. Keep this fallback in lockstep with backend/pyproject.toml — it is one
 # of the sites `make bump` rewrites.
-_FALLBACK_APP_VERSION = "1.4.5"
+_FALLBACK_APP_VERSION = "1.4.6"
 
 
 def _resolve_app_version() -> str:

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -15977,7 +15977,7 @@
     "summary": "PostGIS-native geospatial data catalog with OGC API Features and Records support",
     "termsOfService": "https://github.com/geolens-io/geolens/blob/main/LICENSE",
     "title": "GeoLens API",
-    "version": "1.4.5"
+    "version": "1.4.6"
   },
   "openapi": "3.1.0",
   "paths": {

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geolens-backend"
-version = "1.4.5"
+version = "1.4.6"
 description = "PostGIS-native GIS data catalog"
 # Docker image (Dockerfile) ships python:3.14-slim (see the Dockerfile FROM for
 # the exact patch pin) as the project's tested runtime.

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -865,7 +865,7 @@ wheels = [
 
 [[package]]
 name = "geolens-backend"
-version = "1.4.5"
+version = "1.4.6"
 source = { virtual = "." }
 dependencies = [
     { name = "alembic" },

--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "geolens-cli"
-version = "1.4.5"
+version = "1.4.6"
 description = "Apache-2.0 command-line interface for the GeoLens API. Login, scan, publish, and export STAC against any GeoLens instance."
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/docs-contract.json
+++ b/docs-contract.json
@@ -1,6 +1,6 @@
 {
   "_comment": "Canonical cross-surface facts for the GeoLens README, marketing site (getgeolens.com/src), and docs site (getgeolens.com/docs). Validated against scripts/install.sh + backend/pyproject.toml by scripts/check_docs_contract.py (geolens CI). The getgeolens.com repo vendors a copy and enforces the same `forbidden` list in its own CI. See docs-internal/DOC-CONSISTENCY-STRATEGY for the full design. Edit a fact ONCE here (and in its canonical source) — the gates make every surface follow.",
-  "version": "1.4.5",
+  "version": "1.4.6",
   "install": {
     "oneLiner": "curl -fsSL https://getgeolens.com/install.sh | sh",
     "sourceBuild": "bash scripts/install.sh",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "1.4.5",
+  "version": "1.4.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "1.4.5",
+      "version": "1.4.6",
       "license": "Apache-2.0",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.4.5",
+  "version": "1.4.6",
   "type": "module",
   "license": "Apache-2.0",
   "author": "Carto Concepts, LLC",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "geolens",
-  "version": "1.4.5",
+  "version": "1.4.6",
   "private": true,
   "license": "Apache-2.0",
   "author": "Carto Concepts, LLC",

--- a/sdks/python/.openapi-python-client.yaml
+++ b/sdks/python/.openapi-python-client.yaml
@@ -4,7 +4,7 @@ project_name_override: geolens
 package_name_override: geolens
 # Rewritten on every `make sdks` run by scripts/sync_sdk_versions.py to match
 # backend/openapi.json info.version. Do not edit by hand.
-package_version_override: 1.4.5
+package_version_override: 1.4.6
 
 # Cleaner enum output (matches our pydantic v2 backend's enum emission).
 literal_enums: true

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "geolens"
-version = "1.4.5"
+version = "1.4.6"
 description = "Auto-generated Python SDK for the GeoLens API. Typed clients with Bearer + API-key auth helpers."
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/sdks/typescript/package-lock.json
+++ b/sdks/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@geolens/sdk",
-  "version": "1.4.5",
+  "version": "1.4.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@geolens/sdk",
-      "version": "1.4.5",
+      "version": "1.4.6",
       "license": "Apache-2.0",
       "dependencies": {
         "@hey-api/client-fetch": "0.13.1"

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@geolens/sdk",
-  "version": "1.4.5",
+  "version": "1.4.6",
   "description": "Auto-generated TypeScript SDK for the GeoLens API. Typed clients with Bearer + API-key auth helpers.",
   "license": "Apache-2.0",
   "author": "Carto Concepts, LLC",


### PR DESCRIPTION
Release prep for **v1.4.6**. Cut from a clean-audit `main` (fresh container rebuild, full showcase reseed, data-backed smoke across catalog/OGC/STAC/tiles/exports/embed, zero log/console errors).

## What's in 1.4.6 (17 commits since v1.4.5)

**Added**
- GeoParquet export (`?format=parquet`) + DCAT GeoParquet distribution with backfill (#462, #465)
- AI-drafted metadata on ingest; `llms.txt` (#462)
- Reference Prometheus/Grafana monitoring config (#466)

**Changed**
- DCAT catalog pagination (#462); Compose docs clarify `FRONTEND_TILE_BASE_URL` vs `CDN_BASE_URL` (#467)

**Fixed**
- Feature/schema editing hardening (#459, #460, #463)
- Style editor no longer clobbers saved categorical symbology (#461)
- Installer fails fast on terminal service states (#469)

**Dependencies**
- procrastinate 3.9.0, SQLAlchemy ecosystem, TanStack, pytest, codeql-action, docker/login-action

## Contents of this PR
Version bump across all 9 sites (+ frontend/TS-SDK lockfiles, `docs-contract.json`, `backend/uv.lock`), regenerated OpenAPI snapshot + SDK manifests, and the curated CHANGELOG section. **No source/contract changes** — `openapi-check`, `sdks-check`, `version-check` all green locally.

## Schema/API impact
No new migration in this PR. The release includes migration `0013_backfill_geoparquet_distributions` (already merged via #465).

## Verification
`make version-check` · `make openapi-check` · `make sdks-check` (TS build + tests) all pass locally.