### PR TITLE
fix(ai): default LLM_MODEL to claude-sonnet-5

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -260,8 +260,8 @@ FRONTEND_PORT=8080
 # OPENAI_API_KEY=
 
 # [OPTIONAL] LLM model for Anthropic provider
-# Type: string | Default: claude-sonnet-4-20250514
-# LLM_MODEL=claude-sonnet-4-20250514
+# Type: string | Default: claude-sonnet-5
+# LLM_MODEL=claude-sonnet-5
 
 # [OPTIONAL] LLM model for OpenAI-compatible provider
 # Type: string | Default: gpt-4o

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -105,7 +105,7 @@ class Settings(BaseSettings):
     geolens_tenancy_mode: Literal["single_tenant", "multi_tenant"] = "single_tenant"
 
     anthropic_api_key: SecretStr | None = None
-    llm_model: str = "claude-sonnet-4-20250514"
+    llm_model: str = "claude-sonnet-5"
 
     openai_api_key: SecretStr | None = None
     openai_model: str = "gpt-4o"

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -75,7 +75,7 @@ x-logging-env: &logging-env
 
 x-ai-env: &ai-env
   ANTHROPIC_API_KEY: "${ANTHROPIC_API_KEY:-}"
-  LLM_MODEL: "${LLM_MODEL:-claude-sonnet-4-20250514}"
+  LLM_MODEL: "${LLM_MODEL:-claude-sonnet-5}"
   OPENAI_API_KEY: "${OPENAI_API_KEY:-}"
   OPENAI_MODEL: "${OPENAI_MODEL:-gpt-4o}"
   OPENAI_MODEL_LIGHT: "${OPENAI_MODEL_LIGHT:-}"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -61,7 +61,7 @@ x-logging-env: &logging-env
 
 x-ai-env: &ai-env
   ANTHROPIC_API_KEY: "${ANTHROPIC_API_KEY:-}"
-  LLM_MODEL: "${LLM_MODEL:-claude-sonnet-4-20250514}"
+  LLM_MODEL: "${LLM_MODEL:-claude-sonnet-5}"
   OPENAI_API_KEY: "${OPENAI_API_KEY:-}"
   OPENAI_MODEL: "${OPENAI_MODEL:-gpt-4o}"
   OPENAI_MODEL_LIGHT: "${OPENAI_MODEL_LIGHT:-}"


### PR DESCRIPTION
The default LLM snapshot `claude-sonnet-4-20250514` is **retired** — Anthropic now returns `404 not_found_error` for it. So a fresh install using the Anthropic provider with no explicit `LLM_MODEL` boots with a broken AI default (surfaced during the v1.4.6 screenshot recapture: "Something went wrong" on every AI action).

## Change
Point the effective default at `claude-sonnet-5` in the three places that actually determine it:
- `backend/app/core/config.py` — `Settings.llm_model` fallback
- `docker-compose.yml` — `${LLM_MODEL:-…}` default (dev)
- `docker-compose.prod.yml` — `${LLM_MODEL:-…}` default (self-host / demo)
- `.env.example` — documented default (doc only)

## Not included (intentional)
The retired string also appears as an **illustrative example** in `admin/schemas.py`'s field description (which propagates to `openapi.json`, the generated SDKs, and `frontend` types) and as a placeholder in `SettingsAITab.tsx`. Those are cosmetic "e.g." hints, and updating the schema description would force an OpenAPI + SDK regen. Left out to keep this a tight, regen-free fix — happy to do them separately if wanted.

## Verification
`claude-sonnet-5` verified working live (v1.4.6 stack): `POST /api/ai/chat/` → 200, AI map-edit succeeds, and it's the model behind the refreshed `ai-chat.png` in getgeolens.com PR #50.