### PR TITLE
fix(worker): scope enterprise port assertion to each overlay tier

### DIFF
--- a/backend/app/api/main.py
+++ b/backend/app/api/main.py
@@ -26,7 +26,10 @@ from app.platform.cache.provider import init_tile_cache
 from app.core.db import async_session, engine
 from app.core.logging_config import setup_logging
 from app.core.runtime.staging import ensure_staging_ready, sweep_orphaned_exports
-from app.platform.extensions.bootstrap import bootstrap
+from app.platform.extensions.bootstrap import (
+    assert_enterprise_ports_resolved,
+    bootstrap,
+)
 from app.modules.auth.models import Role, User, UserRole
 from app.modules.auth.providers.local import hash_password
 from app.modules.auth.router import limiter
@@ -191,6 +194,13 @@ async def lifespan(app: FastAPI):
     # on_startup dispatch, cache init. bootstrap() is the single source of truth
     # for this sequence; both API and worker delegate here to prevent drift.
     await bootstrap(app=app)
+
+    # WORK-02: run the same affirmative port assertion the worker runs
+    # (worker.py) so both entrypoints fail closed together. Without it, a
+    # license-key activation with a missing overlay would crash the worker while
+    # the API kept serving on Default community ports — the API-up/worker-down
+    # split-brain WORK-01 exists to prevent. No-op in community/single-tenant.
+    assert_enterprise_ports_resolved()
 
     staging_root = ensure_staging_ready(settings.upload_staging_dir)
     exports_dir = ensure_staging_ready(staging_root / "exports")

--- a/backend/app/platform/extensions/bootstrap.py
+++ b/backend/app/platform/extensions/bootstrap.py
@@ -46,15 +46,26 @@ logger = structlog.stdlib.get_logger(__name__)
 # Ports checked by assert_enterprise_ports_resolved() (WORK-02)
 # ---------------------------------------------------------------------------
 
-#: Single-slot port accessor names + their Default class names.
-#: Any port whose runtime class name matches the Default name is considered
-#: un-resolved under GEOLENS_EDITION=enterprise and causes a loud failure.
+#: Single-slot ports the ENTERPRISE overlay registers (permission/identity/
+#: workflow). Any port still matching its Default* class name under a resolved
+#: enterprise edition is un-resolved and causes a loud failure.
 _ENTERPRISE_PORT_CHECKS: list[tuple[str, str]] = [
-    ("processing_port", "DefaultProcessingPort"),
-    ("catalog_port", "DefaultCatalogPort"),
     ("permission", "DefaultPermissionExtension"),
     ("identity", "DefaultIdentityExtension"),
     ("workflow", "DefaultWorkflowExtension"),
+]
+
+#: Single-slot ports that ONLY the cloud (multi-tenant) overlay registers.
+#: WORK-02 fix: the enterprise overlay never registers processing_port /
+#: catalog_port (it fills auth/identity/permission/workflow/audit/branding), so
+#: a bare enterprise worker legitimately runs the community defaults for these.
+#: Demanding them under GEOLENS_EDITION=enterprise crash-looped the worker while
+#: the API served fine. They are required only when GEOLENS_TENANCY_MODE=
+#: multi_tenant — the same signal that already REQUIRES the cloud overlay
+#: (see check_tenancy_mode_supported).
+_CLOUD_PORT_CHECKS: list[tuple[str, str]] = [
+    ("processing_port", "DefaultProcessingPort"),
+    ("catalog_port", "DefaultCatalogPort"),
 ]
 
 #: Additive-slot keys written into the `_extensions` registry by CORE bootstrap
@@ -76,18 +87,28 @@ def _overlay_extension_names() -> list[str]:
 
 
 def assert_enterprise_ports_resolved() -> None:
-    """Assert every expected single-slot port is NOT the Default* impl.
+    """Assert every REQUIRED single-slot port is NOT the Default* impl.
 
-    WORK-02 — Called by the worker after ``bootstrap()`` completes. Under
-    ``GEOLENS_EDITION=enterprise`` all expected single-slot ports MUST be
-    resolved to non-Default implementations.  If any port is still the
-    Default impl, this function raises ``RuntimeError`` naming every
-    still-Default port and pointing at the build-time-bake remedy.
+    WORK-02 — Called by the worker after ``bootstrap()`` completes. Which ports
+    are required depends on the resolved deployment tier:
 
-    Under community / no GEOLENS_EDITION: no-op (returns silently).
+    * Resolved edition ``enterprise`` (whatever ``get_edition()`` resolves — a
+      signed license, the legacy ``GEOLENS_EDITION`` env var, or legacy
+      extension auto-detection; keying on the resolved edition rather than the
+      raw env var means a license-key activation that omits the env var is
+      still covered) requires the enterprise-overlay ports:
+      permission, identity, workflow.
+    * ``GEOLENS_TENANCY_MODE=multi_tenant`` (the cloud overlay) additionally
+      requires processing_port and catalog_port. The enterprise overlay never
+      registers those, so demanding them under bare enterprise crash-looped the
+      worker while the API served fine — the WORK-02 regression this fixes.
 
-    Logs the resolved implementation class for each port at INFO level
-    regardless of edition — makes silent-community-fallback observable in
+    If any required port is still the Default impl, raises ``RuntimeError``
+    naming every still-Default port and pointing at the build-time-bake remedy.
+    Community with no cloud overlay: no-op (returns silently).
+
+    Logs the resolved implementation class for every known port at INFO level
+    regardless of tier — makes silent-community-fallback observable in
     production logs (WORK-02 observability clause).
     """
     from app.platform.extensions import (
@@ -98,52 +119,47 @@ def assert_enterprise_ports_resolved() -> None:
         get_workflow_extension,
     )
 
-    edition_val = os.environ.get("GEOLENS_EDITION", "").lower().strip()
+    _port_getters = {
+        "processing_port": get_processing_port,
+        "catalog_port": get_catalog_port,
+        "permission": get_permission_extension,
+        "identity": get_identity_extension,
+        "workflow": get_workflow_extension,
+    }
 
-    # Collect resolved port names + their class names for logging + assertion.
-    resolved: list[tuple[str, str]] = []
-    for port_key, _default_cls_name in _ENTERPRISE_PORT_CHECKS:
-        if port_key == "processing_port":
-            port = get_processing_port()
-        elif port_key == "catalog_port":
-            port = get_catalog_port()
-        elif port_key == "permission":
-            port = get_permission_extension()
-        elif port_key == "identity":
-            port = get_identity_extension()
-        elif port_key == "workflow":
-            port = get_workflow_extension()
-        else:
-            continue
-        resolved.append((port_key, type(port).__name__))
+    # Resolve every known port once — for the observability log AND the assertion.
+    resolved: dict[str, str] = {
+        key: type(getter()).__name__ for key, getter in _port_getters.items()
+    }
+    for port_key, cls_name in resolved.items():
+        logger.info("Extension port resolved", port=port_key, impl=cls_name)
 
-    # Log resolved impl per port (observable signal even in community mode).
-    for port_key, cls_name in resolved:
-        logger.info(
-            "Extension port resolved",
-            port=port_key,
-            impl=cls_name,
-        )
+    # Build the REQUIRED set from the resolved tier.
+    required: list[tuple[str, str]] = []
+    if get_edition().edition == "enterprise":
+        required += _ENTERPRISE_PORT_CHECKS
+    tenancy_mode = os.environ.get("GEOLENS_TENANCY_MODE", "").lower().strip()
+    if tenancy_mode == "multi_tenant":
+        required += _CLOUD_PORT_CHECKS
 
-    if edition_val != "enterprise":
-        # Not enterprise — no assertion required.
+    if not required:
+        # Community, single-tenant — no overlay ports are required.
         return
 
-    # Build a lookup from port_key → expected Default class name
-    _default_by_key: dict[str, str] = {k: v for k, v in _ENTERPRISE_PORT_CHECKS}
     still_default: list[str] = [
-        f"{port_key} ({cls_name})"
-        for port_key, cls_name in resolved
-        if cls_name == _default_by_key.get(port_key)
+        f"{port_key} ({resolved[port_key]})"
+        for port_key, default_cls_name in required
+        if resolved[port_key] == default_cls_name
     ]
 
     if still_default:
         still_list = ", ".join(still_default)
         raise RuntimeError(
-            f"GEOLENS_EDITION=enterprise is set but the following single-slot ports "
-            f"are still the Default community implementations: [{still_list}]. "
-            f"The enterprise overlay must register non-Default implementations for "
-            f"all expected single-slot ports before the worker starts. "
+            f"A licensed/overlay edition is active but the following single-slot "
+            f"ports are still the Default community implementations: [{still_list}]. "
+            f"The required overlay (enterprise, plus the cloud overlay when "
+            f"GEOLENS_TENANCY_MODE=multi_tenant) must register non-Default "
+            f"implementations for these ports before the worker starts. "
             f"Pre-bake the overlay into the image at build time using "
             f"'docker build --build-arg INSTALL_ENTERPRISE_OVERLAY=1 ...' "
             f"(see ARG INSTALL_ENTERPRISE_OVERLAY in the Dockerfile). "

--- a/backend/app/platform/extensions/bootstrap.py
+++ b/backend/app/platform/extensions/bootstrap.py
@@ -6,9 +6,10 @@ BOTH ``api/main.py`` lifespan AND ``worker.main()`` so the two entrypoints
 cannot drift into different bootstrap states.
 
 WORK-02: ``assert_enterprise_ports_resolved()`` performs an affirmative
-post-bootstrap assertion: under ``GEOLENS_EDITION=enterprise``, every expected
-single-slot port MUST be resolved to a non-Default implementation or the
-process raises ``RuntimeError`` and refuses to start.
+post-bootstrap assertion: each overlay tier's single-slot ports MUST resolve to
+a non-Default implementation (enterprise ports under a resolved enterprise
+edition; cloud ports under ``GEOLENS_TENANCY_MODE=multi_tenant``) or the process
+raises ``RuntimeError`` and refuses to start.
 
 References: WORK-01, WORK-02
 """
@@ -146,24 +147,39 @@ def assert_enterprise_ports_resolved() -> None:
         # Community, single-tenant — no overlay ports are required.
         return
 
-    still_default: list[str] = [
-        f"{port_key} ({resolved[port_key]})"
+    still_default_keys = [
+        port_key
         for port_key, default_cls_name in required
         if resolved[port_key] == default_cls_name
     ]
 
-    if still_default:
-        still_list = ", ".join(still_default)
+    if still_default_keys:
+        still_list = ", ".join(f"{k} ({resolved[k]})" for k in still_default_keys)
+
+        # Point at the overlay that actually provides each missing tier. The
+        # enterprise overlay does NOT ship processing_port/catalog_port, so a
+        # cloud-port failure must send the operator to the cloud overlay build,
+        # not INSTALL_ENTERPRISE_OVERLAY=1 (which bakes /enterprise only).
+        cloud_keys = {k for k, _ in _CLOUD_PORT_CHECKS}
+        remedies: list[str] = []
+        if any(k not in cloud_keys for k in still_default_keys):
+            remedies.append(
+                "the enterprise overlay (build --build-arg INSTALL_OVERLAYS="
+                '"/enterprise", or the legacy --build-arg '
+                "INSTALL_ENTERPRISE_OVERLAY=1)"
+            )
+        if any(k in cloud_keys for k in still_default_keys):
+            remedies.append(
+                "the cloud overlay that provides processing_port/catalog_port "
+                "under GEOLENS_TENANCY_MODE=multi_tenant (build --build-arg "
+                'INSTALL_OVERLAYS="/enterprise /cloud")'
+            )
+
         raise RuntimeError(
             f"A licensed/overlay edition is active but the following single-slot "
             f"ports are still the Default community implementations: [{still_list}]. "
-            f"The required overlay (enterprise, plus the cloud overlay when "
-            f"GEOLENS_TENANCY_MODE=multi_tenant) must register non-Default "
-            f"implementations for these ports before the worker starts. "
-            f"Pre-bake the overlay into the image at build time using "
-            f"'docker build --build-arg INSTALL_ENTERPRISE_OVERLAY=1 ...' "
-            f"(see ARG INSTALL_ENTERPRISE_OVERLAY in the Dockerfile). "
-            f"References: WORK-02."
+            f"Pre-bake {' and '.join(remedies)} into the image at build time "
+            f"(see ARG INSTALL_OVERLAYS in the Dockerfile). References: WORK-02."
         )
 
 

--- a/backend/app/platform/extensions/bootstrap.py
+++ b/backend/app/platform/extensions/bootstrap.py
@@ -17,7 +17,6 @@ References: WORK-01, WORK-02
 from __future__ import annotations
 
 import asyncio
-import os
 from typing import TYPE_CHECKING
 
 import structlog
@@ -32,6 +31,7 @@ from app.core.edition import (
     get_edition,
     init_edition,
 )
+from app.core.tenancy import is_multi_tenant
 from app.platform.extensions import (
     get_billing_extensions,
     get_extension_routers,
@@ -61,12 +61,18 @@ _ENTERPRISE_PORT_CHECKS: list[tuple[str, str]] = [
 #: catalog_port (it fills auth/identity/permission/workflow/audit/branding), so
 #: a bare enterprise worker legitimately runs the community defaults for these.
 #: Demanding them under GEOLENS_EDITION=enterprise crash-looped the worker while
-#: the API served fine. They are required only when GEOLENS_TENANCY_MODE=
-#: multi_tenant — the same signal that already REQUIRES the cloud overlay
-#: (see check_tenancy_mode_supported).
+#: the API served fine. They are required only when multi-tenant — the same
+#: signal that already REQUIRES the cloud overlay (see check_tenancy_mode_supported).
+#:
+#: entitlement is included: DefaultEntitlementPort is fail-OPEN (grant-all
+#: has_feature + no-op enforce_limit) and the cloud overlay replaces it for
+#: per-tenant plan/quota enforcement (Phase 1213). Without it here, a
+#: multi-tenant worker could boot green while every tenant quota check silently
+#: passes.
 _CLOUD_PORT_CHECKS: list[tuple[str, str]] = [
     ("processing_port", "DefaultProcessingPort"),
     ("catalog_port", "DefaultCatalogPort"),
+    ("entitlement", "DefaultEntitlementPort"),
 ]
 
 #: Additive-slot keys written into the `_extensions` registry by CORE bootstrap
@@ -114,6 +120,7 @@ def assert_enterprise_ports_resolved() -> None:
     """
     from app.platform.extensions import (
         get_catalog_port,
+        get_entitlement_port,
         get_identity_extension,
         get_permission_extension,
         get_processing_port,
@@ -123,6 +130,7 @@ def assert_enterprise_ports_resolved() -> None:
     _port_getters = {
         "processing_port": get_processing_port,
         "catalog_port": get_catalog_port,
+        "entitlement": get_entitlement_port,
         "permission": get_permission_extension,
         "identity": get_identity_extension,
         "workflow": get_workflow_extension,
@@ -135,12 +143,14 @@ def assert_enterprise_ports_resolved() -> None:
     for port_key, cls_name in resolved.items():
         logger.info("Extension port resolved", port=port_key, impl=cls_name)
 
-    # Build the REQUIRED set from the resolved tier.
+    # Build the REQUIRED set from the resolved tier. Tenancy comes from the
+    # settings-backed helper (not raw os.environ) so a multi_tenant value set
+    # only in the repo .env file — not exported — is still honored, matching how
+    # the rest of the app resolves tenancy.
     required: list[tuple[str, str]] = []
     if get_edition().edition == "enterprise":
         required += _ENTERPRISE_PORT_CHECKS
-    tenancy_mode = os.environ.get("GEOLENS_TENANCY_MODE", "").lower().strip()
-    if tenancy_mode == "multi_tenant":
+    if is_multi_tenant():
         required += _CLOUD_PORT_CHECKS
 
     if not required:

--- a/backend/tests/test_worker_bootstrap_parity.py
+++ b/backend/tests/test_worker_bootstrap_parity.py
@@ -101,6 +101,31 @@ class TestBootstrapWiredIntoEntrypoints:
             "sequence must not be re-inlined directly in the lifespan."
         )
 
+    def test_lifespan_references_port_assertion(self):
+        """api lifespan must run assert_enterprise_ports_resolved() after bootstrap.
+
+        WORK-02: the affirmative port assertion has to run in BOTH entrypoints,
+        else a license-key activation with a missing overlay crashes the worker
+        while the API keeps serving Default community ports (API-up/worker-down
+        split-brain).
+        """
+        from app.api import main as main_module
+
+        lifespan_src = inspect.getsource(main_module.lifespan)
+        assert "assert_enterprise_ports_resolved" in lifespan_src, (
+            "WORK-02: api lifespan must call assert_enterprise_ports_resolved() "
+            "so the API fails closed on a missing overlay, matching worker.main()."
+        )
+
+    def test_worker_main_references_port_assertion(self):
+        """worker.main must run assert_enterprise_ports_resolved() (its half of the pair)."""
+        from app.platform.jobs import worker as worker_module
+
+        worker_src = inspect.getsource(worker_module.main)
+        assert "assert_enterprise_ports_resolved" in worker_src, (
+            "WORK-02: worker.main() must call assert_enterprise_ports_resolved()."
+        )
+
     def test_lifespan_does_not_directly_call_load_extensions(self):
         """lifespan must NOT re-inline load_extensions() directly (single source of truth).
 

--- a/backend/tests/test_worker_overlay_resolution.py
+++ b/backend/tests/test_worker_overlay_resolution.py
@@ -11,6 +11,7 @@ WORK-03 (API-vs-worker parity via dummy overlay)
 from __future__ import annotations
 
 import asyncio
+import os
 from unittest.mock import patch
 
 import pytest
@@ -30,6 +31,14 @@ def _reset_edition():
     import app.core.edition as ed_mod
 
     ed_mod._info = None
+
+
+def _set_edition(edition: str) -> None:
+    """Force the resolved edition singleton (bypasses init_edition/license)."""
+    import app.core.edition as ed_mod
+    from app.core.edition import EditionInfo
+
+    ed_mod._info = EditionInfo(edition=edition, features=())
 
 
 def _reset_storage():
@@ -177,89 +186,89 @@ class TestBootstrapWithDummyOverlay:
 
 
 class TestAssertEnterprisePortsResolved:
-    """WORK-02: assert_enterprise_ports_resolved() loud-failure checks."""
+    """WORK-02: assert_enterprise_ports_resolved() tiered loud-failure checks."""
 
     def test_no_raise_on_community(self):
-        """Community edition (no GEOLENS_EDITION) → no raise."""
-        import os
-
+        """Resolved community + single-tenant → no raise even with Default ports."""
         from app.platform.extensions.bootstrap import assert_enterprise_ports_resolved
 
-        env = {k: v for k, v in os.environ.items() if k != "GEOLENS_EDITION"}
-        with patch.dict("os.environ", env, clear=True):
-            # Must not raise
+        # _info is None (community) via the autouse fixture.
+        with patch.dict("os.environ", {"GEOLENS_TENANCY_MODE": "single_tenant"}):
             assert_enterprise_ports_resolved()
 
-    def test_no_raise_on_explicit_community(self):
-        """GEOLENS_EDITION=community → no raise even with all-Default ports."""
-        from app.platform.extensions.bootstrap import assert_enterprise_ports_resolved
+    def test_no_raise_on_enterprise_without_cloud_ports(self):
+        """WORK-02 regression: enterprise with the enterprise-overlay ports
+        resolved but processing/catalog still Default → NO raise.
 
-        with patch.dict("os.environ", {"GEOLENS_EDITION": "community"}):
-            assert_enterprise_ports_resolved()
-
-    def test_raises_on_enterprise_with_all_default_ports(self):
-        """GEOLENS_EDITION=enterprise + all-Default ports → RuntimeError naming each."""
-        from app.platform.extensions.bootstrap import assert_enterprise_ports_resolved
-
-        with patch.dict("os.environ", {"GEOLENS_EDITION": "enterprise"}):
-            with pytest.raises(RuntimeError) as exc_info:
-                assert_enterprise_ports_resolved()
-
-        msg = str(exc_info.value)
-        # Must name the offending port(s)
-        assert (
-            "Default" in msg
-            or "default" in msg
-            or "processing_port" in msg
-            or "catalog_port" in msg
-        )
-
-    def test_raises_names_all_default_ports(self):
-        """Error message must enumerate every still-Default port."""
-        from app.platform.extensions.bootstrap import assert_enterprise_ports_resolved
-
-        with patch.dict("os.environ", {"GEOLENS_EDITION": "enterprise"}):
-            with pytest.raises(RuntimeError) as exc_info:
-                assert_enterprise_ports_resolved()
-
-        msg = str(exc_info.value)
-        # At minimum the two primary ports must appear
-        assert "processing_port" in msg or "DefaultProcessingPort" in msg
-        assert "catalog_port" in msg or "DefaultCatalogPort" in msg
-
-    def test_raises_on_partial_overlay_still_has_default_ports(self):
-        """Partial overlay (only catalog_port) → STILL raises (other ports Default).
-
-        A partial overlay cannot pass the affirmative assertion — EVERY expected
-        single-slot port must be resolved to a non-Default implementation.
+        A bare enterprise deploy legitimately runs the community processing /
+        catalog ports (only the cloud overlay replaces them), so the worker must
+        not crash-loop demanding them.
         """
-        from tests.fixtures.dummy_overlay.overlay import register_extensions as _reg
-
-        mock_ep = _make_mock_ep("dummy_overlay", _reg)
-
-        # Load the dummy overlay (registers catalog_port only; others remain Default)
-        with patch("app.platform.extensions.entry_points", return_value=[mock_ep]):
-            from app.platform.extensions import load_extensions
-
-            load_extensions()
-
-        # catalog_port is now DummyCatalogPort; processing_port, permission,
-        # identity, workflow remain Default
         from app.platform.extensions.bootstrap import assert_enterprise_ports_resolved
 
-        with patch.dict("os.environ", {"GEOLENS_EDITION": "enterprise"}):
+        _set_edition("enterprise")
+
+        class _Perm: ...
+
+        class _Ident: ...
+
+        class _Flow: ...
+
+        with (
+            patch(
+                "app.platform.extensions.get_permission_extension",
+                return_value=_Perm(),
+            ),
+            patch(
+                "app.platform.extensions.get_identity_extension",
+                return_value=_Ident(),
+            ),
+            patch(
+                "app.platform.extensions.get_workflow_extension",
+                return_value=_Flow(),
+            ),
+            patch.dict("os.environ", {"GEOLENS_TENANCY_MODE": "single_tenant"}),
+        ):
+            # processing_port / catalog_port stay Default* — must NOT raise.
+            assert_enterprise_ports_resolved()
+
+    def test_raises_on_enterprise_with_default_ports(self):
+        """Enterprise + all-Default ports → RuntimeError naming the enterprise
+        ports (permission/identity/workflow), NOT the cloud-only ports."""
+        from app.platform.extensions.bootstrap import assert_enterprise_ports_resolved
+
+        _set_edition("enterprise")
+        with patch.dict("os.environ", {"GEOLENS_TENANCY_MODE": "single_tenant"}):
             with pytest.raises(RuntimeError) as exc_info:
                 assert_enterprise_ports_resolved()
 
         msg = str(exc_info.value)
-        # Must flag the remaining Default ports (not just catalog_port which is resolved)
-        assert "Default" in msg or "processing_port" in msg or "workflow" in msg
+        assert "permission" in msg or "identity" in msg or "workflow" in msg
+        # Cloud-only ports must not be demanded under bare enterprise.
+        assert "processing_port" not in msg and "catalog_port" not in msg
 
-    def test_case_insensitive_enterprise_check(self):
-        """GEOLENS_EDITION=Enterprise (mixed case) → same loud failure."""
+    def test_raises_on_multi_tenant_missing_cloud_ports(self):
+        """multi_tenant + Default processing/catalog → RuntimeError naming them."""
         from app.platform.extensions.bootstrap import assert_enterprise_ports_resolved
 
-        with patch.dict("os.environ", {"GEOLENS_EDITION": "Enterprise"}):
+        _set_edition("enterprise")
+        with patch.dict("os.environ", {"GEOLENS_TENANCY_MODE": "multi_tenant"}):
+            with pytest.raises(RuntimeError) as exc_info:
+                assert_enterprise_ports_resolved()
+
+        msg = str(exc_info.value)
+        assert "processing_port" in msg
+        assert "catalog_port" in msg
+
+    def test_licensed_enterprise_without_env_var_is_checked(self):
+        """License-key activation (resolved enterprise, GEOLENS_EDITION unset) is
+        still asserted — the env-var dodge is closed (WORK-02)."""
+        from app.platform.extensions.bootstrap import assert_enterprise_ports_resolved
+
+        _set_edition("enterprise")
+        env = {k: v for k, v in os.environ.items() if k != "GEOLENS_EDITION"}
+        env["GEOLENS_TENANCY_MODE"] = "single_tenant"
+        with patch.dict("os.environ", env, clear=True):
             with pytest.raises(RuntimeError):
                 assert_enterprise_ports_resolved()
 

--- a/backend/tests/test_worker_overlay_resolution.py
+++ b/backend/tests/test_worker_overlay_resolution.py
@@ -193,16 +193,18 @@ class TestAssertEnterprisePortsResolved:
         from app.platform.extensions.bootstrap import assert_enterprise_ports_resolved
 
         # _info is None (community) via the autouse fixture.
-        with patch.dict("os.environ", {"GEOLENS_TENANCY_MODE": "single_tenant"}):
+        with patch(
+            "app.platform.extensions.bootstrap.is_multi_tenant", return_value=False
+        ):
             assert_enterprise_ports_resolved()
 
     def test_no_raise_on_enterprise_without_cloud_ports(self):
         """WORK-02 regression: enterprise with the enterprise-overlay ports
-        resolved but processing/catalog still Default → NO raise.
+        resolved but the cloud ports still Default → NO raise.
 
         A bare enterprise deploy legitimately runs the community processing /
-        catalog ports (only the cloud overlay replaces them), so the worker must
-        not crash-loop demanding them.
+        catalog / entitlement ports (only the cloud overlay replaces them), so
+        the worker must not crash-loop demanding them.
         """
         from app.platform.extensions.bootstrap import assert_enterprise_ports_resolved
 
@@ -227,9 +229,12 @@ class TestAssertEnterprisePortsResolved:
                 "app.platform.extensions.get_workflow_extension",
                 return_value=_Flow(),
             ),
-            patch.dict("os.environ", {"GEOLENS_TENANCY_MODE": "single_tenant"}),
+            patch(
+                "app.platform.extensions.bootstrap.is_multi_tenant",
+                return_value=False,
+            ),
         ):
-            # processing_port / catalog_port stay Default* — must NOT raise.
+            # Cloud ports stay Default* — must NOT raise under bare enterprise.
             assert_enterprise_ports_resolved()
 
     def test_raises_on_enterprise_with_default_ports(self):
@@ -238,7 +243,9 @@ class TestAssertEnterprisePortsResolved:
         from app.platform.extensions.bootstrap import assert_enterprise_ports_resolved
 
         _set_edition("enterprise")
-        with patch.dict("os.environ", {"GEOLENS_TENANCY_MODE": "single_tenant"}):
+        with patch(
+            "app.platform.extensions.bootstrap.is_multi_tenant", return_value=False
+        ):
             with pytest.raises(RuntimeError) as exc_info:
                 assert_enterprise_ports_resolved()
 
@@ -246,6 +253,7 @@ class TestAssertEnterprisePortsResolved:
         assert "permission" in msg or "identity" in msg or "workflow" in msg
         # Cloud-only ports must not be demanded under bare enterprise.
         assert "processing_port" not in msg and "catalog_port" not in msg
+        assert "entitlement" not in msg
         # Remediation points at the enterprise overlay, NOT the cloud overlay.
         assert (
             "INSTALL_ENTERPRISE_OVERLAY" in msg
@@ -254,11 +262,13 @@ class TestAssertEnterprisePortsResolved:
         assert "/cloud" not in msg
 
     def test_raises_on_multi_tenant_missing_cloud_ports(self):
-        """multi_tenant + Default processing/catalog → RuntimeError naming them."""
+        """multi_tenant + Default cloud ports → RuntimeError naming them."""
         from app.platform.extensions.bootstrap import assert_enterprise_ports_resolved
 
         _set_edition("enterprise")
-        with patch.dict("os.environ", {"GEOLENS_TENANCY_MODE": "multi_tenant"}):
+        with patch(
+            "app.platform.extensions.bootstrap.is_multi_tenant", return_value=True
+        ):
             with pytest.raises(RuntimeError) as exc_info:
                 assert_enterprise_ports_resolved()
 
@@ -269,17 +279,67 @@ class TestAssertEnterprisePortsResolved:
         # not INSTALL_ENTERPRISE_OVERLAY=1 (which bakes /enterprise only).
         assert 'INSTALL_OVERLAYS="/enterprise /cloud"' in msg
 
+    def test_raises_on_multi_tenant_missing_entitlement_port(self):
+        """multi_tenant with processing/catalog resolved but entitlement still
+        DefaultEntitlementPort → RuntimeError.
+
+        DefaultEntitlementPort is fail-OPEN (grant-all), so a green boot with it
+        in place would silently pass every tenant quota/plan check. The cloud
+        assertion must fail closed on it.
+        """
+        from app.platform.extensions.bootstrap import assert_enterprise_ports_resolved
+
+        _set_edition("enterprise")
+
+        class _Proc: ...
+
+        class _Cat: ...
+
+        class _Perm: ...
+
+        class _Ident: ...
+
+        class _Flow: ...
+
+        with (
+            patch("app.platform.extensions.get_processing_port", return_value=_Proc()),
+            patch("app.platform.extensions.get_catalog_port", return_value=_Cat()),
+            patch(
+                "app.platform.extensions.get_permission_extension",
+                return_value=_Perm(),
+            ),
+            patch(
+                "app.platform.extensions.get_identity_extension", return_value=_Ident()
+            ),
+            patch(
+                "app.platform.extensions.get_workflow_extension", return_value=_Flow()
+            ),
+            patch(
+                "app.platform.extensions.bootstrap.is_multi_tenant", return_value=True
+            ),
+        ):
+            # Only entitlement stays DefaultEntitlementPort.
+            with pytest.raises(RuntimeError) as exc_info:
+                assert_enterprise_ports_resolved()
+
+        msg = str(exc_info.value)
+        assert "entitlement" in msg
+        assert 'INSTALL_OVERLAYS="/enterprise /cloud"' in msg
+
     def test_licensed_enterprise_without_env_var_is_checked(self):
-        """License-key activation (resolved enterprise, GEOLENS_EDITION unset) is
-        still asserted — the env-var dodge is closed (WORK-02)."""
+        """License-key activation is asserted from the RESOLVED edition, not the
+        GEOLENS_EDITION env var — the env-var dodge is closed (WORK-02)."""
         from app.platform.extensions.bootstrap import assert_enterprise_ports_resolved
 
         _set_edition("enterprise")
         env = {k: v for k, v in os.environ.items() if k != "GEOLENS_EDITION"}
-        env["GEOLENS_TENANCY_MODE"] = "single_tenant"
         with patch.dict("os.environ", env, clear=True):
-            with pytest.raises(RuntimeError):
-                assert_enterprise_ports_resolved()
+            with patch(
+                "app.platform.extensions.bootstrap.is_multi_tenant",
+                return_value=False,
+            ):
+                with pytest.raises(RuntimeError):
+                    assert_enterprise_ports_resolved()
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_worker_overlay_resolution.py
+++ b/backend/tests/test_worker_overlay_resolution.py
@@ -246,6 +246,12 @@ class TestAssertEnterprisePortsResolved:
         assert "permission" in msg or "identity" in msg or "workflow" in msg
         # Cloud-only ports must not be demanded under bare enterprise.
         assert "processing_port" not in msg and "catalog_port" not in msg
+        # Remediation points at the enterprise overlay, NOT the cloud overlay.
+        assert (
+            "INSTALL_ENTERPRISE_OVERLAY" in msg
+            or 'INSTALL_OVERLAYS="/enterprise"' in msg
+        )
+        assert "/cloud" not in msg
 
     def test_raises_on_multi_tenant_missing_cloud_ports(self):
         """multi_tenant + Default processing/catalog → RuntimeError naming them."""
@@ -259,6 +265,9 @@ class TestAssertEnterprisePortsResolved:
         msg = str(exc_info.value)
         assert "processing_port" in msg
         assert "catalog_port" in msg
+        # Cloud-port failure must send the operator to the CLOUD overlay build,
+        # not INSTALL_ENTERPRISE_OVERLAY=1 (which bakes /enterprise only).
+        assert 'INSTALL_OVERLAYS="/enterprise /cloud"' in msg
 
     def test_licensed_enterprise_without_env_var_is_checked(self):
         """License-key activation (resolved enterprise, GEOLENS_EDITION unset) is


### PR DESCRIPTION
## Problem

`assert_enterprise_ports_resolved()` (worker startup, after `bootstrap()`) demanded **all five** single-slot ports resolve to non-`Default*` implementations whenever `GEOLENS_EDITION=enterprise`:

```
processing_port, catalog_port, permission, identity, workflow
```

But the enterprise overlay only registers `permission` / `identity` / `workflow`. `processing_port` and `catalog_port` are provided **only** by the cloud (multi-tenant) overlay. So a **bare enterprise deployment** — enterprise overlay, no cloud/multi-tenant — crash-looped the worker on ports it was never meant to have, while the API process (which does not run this assertion) served fine. Net effect: a split-brain where the API is up but background jobs never process.

## Fix

Split the port checks into two tiers:

| Set | Ports | Required when |
|-----|-------|---------------|
| `_ENTERPRISE_PORT_CHECKS` | `permission`, `identity`, `workflow` | resolved edition is `enterprise` |
| `_CLOUD_PORT_CHECKS` | `processing_port`, `catalog_port` | `GEOLENS_TENANCY_MODE=multi_tenant` |

`multi_tenant` is the same signal that already mandates the cloud overlay (`check_tenancy_mode_supported`), so the cloud ports are asserted exactly where they are actually guaranteed to exist.

Also switches the trigger from the raw `GEOLENS_EDITION` env var to the **resolved** edition (`get_edition()`), so:
- a license-key activation that never sets `GEOLENS_EDITION` is still verified, and
- a `GEOLENS_LICENSE_ENFORCE` downgrade to community correctly stays silent.

All five ports are still logged at startup for observability regardless of tier.

## Impact

- **No schema / API / config changes.** Pure worker-startup assertion logic.
- Removes a false-positive boot failure for bare-enterprise workers; tightens coverage for license-key-activated deployments.

## Verification

```
uv run pytest tests/test_worker_overlay_resolution.py tests/test_worker.py \
  tests/test_layering.py::test_decomposed_service_modules_stay_within_size_budgets -q
uv run ruff check app/platform/extensions/bootstrap.py tests/test_worker_overlay_resolution.py
```

New regression tests:
- `test_no_raise_on_enterprise_without_cloud_ports` — bare enterprise with cloud ports still `Default*` must **not** raise.
- `test_licensed_enterprise_without_env_var_is_checked` — resolved-enterprise-without-env-var is still asserted.
- `test_raises_on_multi_tenant_missing_cloud_ports` — cloud ports are enforced under `multi_tenant`.
