### PR TITLE
fix(docker): remediate container audit findings

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -47,12 +47,6 @@ jobs:
           - image: geolens-backup
             target: backup
             description: "Automated pg_dump backup service with S3 offload"
-            # Report-only Trivy gate (exit 0): the postgres:17 base is an
-            # uncontrollable upstream fat image whose CRITICAL/HIGH CVEs we can't
-            # patch on our cadence (same policy as the postgis db image in
-            # dep-audit.yml). The scan still runs and prints findings to the log;
-            # it just doesn't block the release. Base churn is tracked separately.
-            scan_exit_code: '0'
 
     steps:
       # Fail fast (with guidance) if a real manual publish is dispatched off a
@@ -120,7 +114,7 @@ jobs:
         with:
           image-ref: ${{ matrix.image }}:scan-amd64
           format: table
-          exit-code: ${{ matrix.scan_exit_code || '1' }}
+          exit-code: '1'
           severity: CRITICAL,HIGH
           ignore-unfixed: true
 
@@ -140,7 +134,7 @@ jobs:
         with:
           image-ref: ${{ matrix.image }}:scan-arm64
           format: table
-          exit-code: ${{ matrix.scan_exit_code || '1' }}
+          exit-code: '1'
           severity: CRITICAL,HIGH
           ignore-unfixed: true
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -173,9 +173,12 @@ WORKDIR /app
 # Copy the resolved venv + code from the builder. No uv sync runs in runtime.
 COPY --from=backend-builder --chown=appuser:appgroup /app /app
 
-# Create writable directories used by the entrypoint.
-RUN mkdir -p /app/staging /home/appuser/.cache/uv && \
-    chown -R appuser:appgroup /app /app/staging /home/appuser
+# Create writable directories used by the entrypoint. The builder COPY already
+# owns /app; install only the runtime directories so this layer does not
+# recursively duplicate metadata for the full application tree.
+RUN install -d -o appuser -g appgroup \
+    /app/staging \
+    /home/appuser/.cache/uv
 
 # fix(#441): stamp the build commit for /health `build` reporting. publish.yml
 # passes it on release builds; local and dev builds leave it empty. Declared
@@ -215,9 +218,11 @@ CMD ["sh", "-c", "uv run --no-dev python -m app.worker"]
 # ==============================================================================
 # Stage: backup — pg_dump 17 + SigV4-capable S3 client; self-contained backup
 # ==============================================================================
-# Base: official postgres:17 (Debian Bookworm, multi-arch: amd64 + arm64).
+# Base: official postgres:17 (Debian Bookworm, multi-arch: amd64 + arm64),
+# pinned by digest. Dependabot tracks Docker digest updates for this file.
 # db/Dockerfile uses postgis/postgis:17-3.5 which is amd64-ONLY — this stage
-# uses the plain postgres:17 base so publish.yml can build both arches (BKP-01).
+# uses the digest-pinned postgres:17 base so publish.yml can build both arches
+# (BKP-01).
 # PostGIS is NOT needed client-side: pg_dump streams the raw catalog over the
 # wire and custom-format dumps preserve PostGIS types without PostGIS libs.
 #
@@ -226,7 +231,7 @@ CMD ["sh", "-c", "uv run --no-dev python -m app.worker"]
 # app image (frontend), never this postgres-based backup tool. Every image is
 # built with an explicit `target:` (publish.yml + docker-compose*.yml), so stage
 # order only governs that unqualified-build default — keep `backup` non-final.
-FROM postgres:17 AS backup
+FROM postgres:17@sha256:5f050f770b427fbd477edee6c3968a72e5c6be97e050a7e368b2b74a9494a285 AS backup
 
 LABEL org.opencontainers.image.title="geolens-backup"
 LABEL org.opencontainers.image.description="Automated pg_dump backup service with S3 offload"
@@ -308,14 +313,17 @@ USER root
 RUN apk upgrade --no-cache
 USER nginx
 
-COPY --from=frontend-build --chown=nginx:nginx /app/dist /usr/share/nginx/html
-COPY --from=frontend-build --chown=nginx:nginx /app/public/env-config.template.js /usr/share/nginx/html/env-config.template.js
+# Keep the built SPA immutable. The entrypoint copies it into /tmp at startup,
+# then writes the operator-specific runtime config there. This supports a
+# read-only production root filesystem without mutating image layers.
+COPY --from=frontend-build --chown=nginx:nginx /app/dist /opt/geolens/html
+COPY --from=frontend-build --chown=nginx:nginx /app/public/env-config.template.js /opt/geolens/html/env-config.template.js
 COPY frontend/nginx.conf /etc/nginx/conf.d/default.conf
 COPY --chmod=755 frontend/docker-entrypoint.sh /docker-entrypoint.sh
 
 ENTRYPOINT ["/docker-entrypoint.sh"]
 
 HEALTHCHECK --interval=10s --timeout=5s --start-period=5s --retries=3 \
-  CMD wget --no-verbose --tries=1 --spider http://localhost:8080/ || exit 1
+  CMD wget --no-verbose --tries=1 --spider http://127.0.0.1:8080/ || exit 1
 
 EXPOSE 8080

--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -2,6 +2,11 @@
 .env
 .env.*
 !.env.example
+*.pem
+*.key
+*.crt
+*.p12
+*.pfx
 .venv/
 __pycache__
 *.pyc

--- a/backend/tests/test_docker_audit_regressions.py
+++ b/backend/tests/test_docker_audit_regressions.py
@@ -1,0 +1,96 @@
+"""Regression tests for production container hardening invariants."""
+
+import re
+
+import yaml
+
+from tests.repo_paths import repo_root
+
+REPO_ROOT = repo_root(__file__)
+DOCKERFILE = REPO_ROOT / "Dockerfile"
+DEV_COMPOSE = REPO_ROOT / "docker-compose.yml"
+PROD_COMPOSE = REPO_ROOT / "docker-compose.prod.yml"
+PUBLISH_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "publish.yml"
+BACKEND_DOCKERIGNORE = REPO_ROOT / "backend" / ".dockerignore"
+FRONTEND_ENTRYPOINT = REPO_ROOT / "frontend" / "docker-entrypoint.sh"
+FRONTEND_NGINX = REPO_ROOT / "frontend" / "nginx.conf"
+
+
+def _load_compose(path):
+    with path.open() as compose_file:
+        return yaml.safe_load(compose_file)
+
+
+def test_every_publish_scan_blocks_on_vulnerabilities():
+    text = PUBLISH_WORKFLOW.read_text()
+
+    assert "scan_exit_code" not in text
+    assert text.count("exit-code: '1'") == 2
+
+
+def test_backup_base_is_digest_pinned():
+    text = DOCKERFILE.read_text()
+
+    assert re.search(
+        r"^FROM postgres:17@sha256:[0-9a-f]{64} AS backup$", text, re.MULTILINE
+    )
+
+
+def test_backend_runtime_does_not_recursively_chown_application_tree():
+    text = DOCKERFILE.read_text()
+
+    assert "chown -R appuser:appgroup /app" not in text
+    assert "install -d -o appuser -g appgroup" in text
+
+
+def test_backend_context_excludes_private_key_material():
+    patterns = set(BACKEND_DOCKERIGNORE.read_text().splitlines())
+
+    assert {"*.pem", "*.key", "*.crt", "*.p12", "*.pfx"} <= patterns
+
+
+def test_production_database_init_script_is_read_only():
+    services = _load_compose(PROD_COMPOSE)["services"]
+    init_mounts = [
+        mount for mount in services["db"]["volumes"] if "init-db.sh" in mount
+    ]
+
+    assert init_mounts == [
+        "./scripts/init-db.sh:/docker-entrypoint-initdb.d/10-init.sh:ro"
+    ]
+
+
+def test_backup_services_override_inherited_postgres_data_volume():
+    for compose_path in (DEV_COMPOSE, PROD_COMPOSE):
+        backup = _load_compose(compose_path)["services"]["backup"]
+        tmpfs_paths = [mount.split(":", 1)[0] for mount in backup["tmpfs"]]
+
+        assert "/var/lib/postgresql/data" in tmpfs_paths, compose_path.name
+
+
+def test_production_frontend_has_only_explicit_writable_mounts():
+    compose = _load_compose(PROD_COMPOSE)
+    frontend = compose["services"]["frontend"]
+
+    assert frontend["read_only"] is True
+    assert any(mount.startswith("/tmp:") for mount in frontend["tmpfs"])
+    assert frontend["volumes"] == ["frontend_cache:/var/cache/nginx"]
+    assert "frontend_cache" in compose["volumes"]
+
+
+def test_frontend_runtime_config_is_materialized_in_tmpfs():
+    dockerfile = DOCKERFILE.read_text()
+    entrypoint = FRONTEND_ENTRYPOINT.read_text()
+    nginx = FRONTEND_NGINX.read_text()
+
+    assert "/opt/geolens/html" in dockerfile
+    assert "/usr/share/nginx/html" not in dockerfile
+    assert "runtime_html=/tmp/geolens-html" in entrypoint
+    assert "root /tmp/geolens-html;" in nginx
+
+
+def test_frontend_image_healthcheck_uses_ipv4_loopback():
+    text = DOCKERFILE.read_text()
+
+    assert "--spider http://127.0.0.1:8080/" in text
+    assert "--spider http://localhost:8080/" not in text

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -160,7 +160,7 @@ services:
       - "127.0.0.1:${DB_PORT:-5432}:5432"
     volumes:
       - pgdata:/var/lib/postgresql/data
-      - ./scripts/init-db.sh:/docker-entrypoint-initdb.d/10-init.sh
+      - ./scripts/init-db.sh:/docker-entrypoint-initdb.d/10-init.sh:ro
       - ./db/postgresql.conf:/etc/postgresql/custom.conf:ro
     # GAP-001: memory limit prevents the DB from consuming all host RAM under
     # heavy query load. 2 GB covers shared_buffers (512 MB) + work_mem headroom
@@ -395,8 +395,15 @@ services:
       - no-new-privileges:true
     cap_drop:
       - ALL
+    read_only: true
+    # The entrypoint materializes the immutable SPA in /tmp; nginx keeps its
+    # bounded raster cache on a dedicated writable volume.
+    tmpfs:
+      - /tmp:size=64m,mode=1777
     ports:
       - "127.0.0.1:${FRONTEND_PORT:-8080}:8080"
+    volumes:
+      - frontend_cache:/var/cache/nginx
     environment:
       # The SPA calls relative /api (nginx proxies to api:8000), so a relative
       # base works for any host the stack is reached on. Override for a CDN.
@@ -433,6 +440,11 @@ services:
       - no-new-privileges:true
     cap_drop:
       - ALL
+    # The postgres base declares PGDATA as a VOLUME. Override it with ephemeral
+    # tmpfs because this image only runs pg_dump; otherwise Docker creates an
+    # unused anonymous volume for every backup container.
+    tmpfs:
+      - /var/lib/postgresql/data:size=1m,mode=0700
     volumes:
       # No ./scripts bind-mount in prod: the published geolens-backup image bakes
       # /scripts/backup-entrypoint.sh + restore.sh (BKP-01), so the prebuilt-prod
@@ -572,5 +584,6 @@ volumes:
   pgdata:
   upload_staging:
   backup_data:
+  frontend_cache:
   minio_data:
   valkey_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -539,6 +539,11 @@ services:
       - no-new-privileges:true
     cap_drop:
       - ALL
+    # The postgres base declares PGDATA as a VOLUME. Override it with ephemeral
+    # tmpfs because this image only runs pg_dump; otherwise Docker creates an
+    # unused anonymous volume for every backup container.
+    tmpfs:
+      - /var/lib/postgresql/data:size=1m,mode=0700
     volumes:
       - ./scripts:/scripts:ro
       - backup_data:/backups

--- a/frontend/docker-entrypoint.sh
+++ b/frontend/docker-entrypoint.sh
@@ -1,18 +1,23 @@
 #!/bin/sh
 set -e
 
-# Generate runtime config from environment variables.
-# Explicit variable list avoids clobbering nginx variables like $uri.
+# Materialize the immutable SPA in a writable tmpfs. Production mounts /tmp as
+# tmpfs while keeping the image root filesystem read-only.
+runtime_html=/tmp/geolens-html
+rm -rf "$runtime_html"
+mkdir -p "$runtime_html"
+cp -R /opt/geolens/html/. "$runtime_html/"
+
+# Generate runtime config from environment variables. The explicit variable
+# list avoids clobbering nginx variables like $uri.
 envsubst '$API_BASE_URL $TILE_BASE_URL' \
-  < /usr/share/nginx/html/env-config.template.js \
-  > /usr/share/nginx/html/env-config.js
+  < "$runtime_html/env-config.template.js" \
+  > "$runtime_html/env-config.js"
 
 # Social scrapers (LinkedIn notably) don't resolve a relative og:image URL.
 # Absolutize it when the operator set PUBLIC_APP_URL; unset leaves it relative.
-# Truncate-write via /tmp: the html dir is root-owned (only its files are
-# nginx-owned), so in-place tools like sed -i can't create their temp file there.
 if [ -n "${PUBLIC_APP_URL:-}" ]; then
-  html=/usr/share/nginx/html/index.html
+  html="$runtime_html/index.html"
   sed "s|content=\"/og-image.png\"|content=\"${PUBLIC_APP_URL%/}/og-image.png\"|" \
     "$html" > /tmp/index.html.new
   cat /tmp/index.html.new > "$html"

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -28,7 +28,9 @@ log_format geolens_safe '$remote_addr - $remote_user [$time_local] '
 
 server {
     listen 8080;
-    root /usr/share/nginx/html;
+    # The entrypoint materializes the immutable SPA and runtime env config in
+    # tmpfs so the production container can keep its root filesystem read-only.
+    root /tmp/geolens-html;
     index index.html;
 
     # Keep one capability-safe format at server scope so every location,


### PR DESCRIPTION
## What

- Make both amd64 and arm64 Trivy scans release-blocking for every published image, including backup.
- Run the production frontend with a read-only root filesystem by materializing immutable SPA assets in tmpfs and using a dedicated nginx cache volume.
- Pin the backup image's PostgreSQL base by digest and remove the redundant recursive `/app` ownership layer.
- Make the production database init-script mount read-only, suppress backup containers' inherited anonymous PGDATA volume, and exclude private-key material from the backend build context.
- Add regression tests for each hardened contract and use IPv4 loopback for the frontend image healthcheck.

## Why

The Docker audit found a release-scan exception for the backup image, a mutable production frontend root filesystem, compose drift, an unpinned backup base, an expensive redundant ownership layer, incomplete build-context exclusions, and unused anonymous volumes on backup containers. Together these weakened release gating, runtime isolation, reproducibility, and storage hygiene.

## Operational impact

- Production creates a `frontend_cache` named volume and a 64 MiB `/tmp` tmpfs for the frontend.
- Backup services mount a 1 MiB tmpfs over inherited PostgreSQL PGDATA; backup data remains on `backup_data` as before.
- Published images now fail the release job when Trivy finds a fixable HIGH or CRITICAL vulnerability.
- No API, database schema, or application behavior changes.

## Verification

- `uv run pytest tests/test_docker_audit_regressions.py tests/test_phase_272_compose.py tests/test_phase_272_dockerfile.py -q` — 69 passed
- `docker compose ... config --quiet` for development and production, including `cloud-dev`
- `docker buildx build --check .`
- Built `frontend`, `backend-base`, and `backup` targets
- Booted the frontend as nginx with `--read-only`, tmpfs, and a cache volume; healthcheck, runtime env injection, OG URL rewriting, and deep-link fallback passed
- Verified backup PGDATA is tmpfs with no anonymous volume
- Pre-commit hooks, Ruff, shell syntax, and diff checks passed
