### PR TITLE
fix(migrations): harden rollback and online schema changes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -604,7 +604,7 @@ FRONTEND_PORT=8080
 # --- Managed Database ---
 # Minimum versions for an externally managed database (CV-2):
 #   - PostgreSQL >= 13   (gen_random_uuid() is used as a column default; core in PG13+)
-#   - pgvector   >= 0.5  (HNSW index for semantic search; migration 0011 fails on older)
+#   - pgvector   >= 0.5  (HNSW index for semantic search; migration 0012 fails on older)
 #   - Required extensions: postgis, pg_trgm, vector (pgvector), unaccent
 # Migration 0001 RAISEs a clear error if the server is older than PostgreSQL 13.
 #

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 SHELL := /bin/bash
 .SHELLFLAGS := -o pipefail -c
 
-.PHONY: dev dev-init down reset-db migrate migration alembic-check test test-sequential test-cov e2e logs logs-db logs-api status doctor preflight openapi openapi-check sdks sdks-check sdks-test manifest-contract-check publish-sdks-py publish-sdks-ts cli-build cli-test cli-check publish-cli audit-sink-discipline billing-extraction-discipline catalog-domain-discipline bump version-check public-surface-check deployed-surface-check
+.PHONY: dev dev-init down reset-db migrate migration alembic-check overlay-migration-check test test-sequential test-cov e2e logs logs-db logs-api status doctor preflight openapi openapi-check sdks sdks-check sdks-test manifest-contract-check publish-sdks-py publish-sdks-ts cli-build cli-test cli-check publish-cli audit-sink-discipline billing-extraction-discipline catalog-domain-discipline bump version-check public-surface-check deployed-surface-check
 
 # Pre-flight: verify boot-required env vars are non-empty in .env before any
 # `docker compose` build (which takes 5-10 minutes on a cold cache only to crash
@@ -66,6 +66,12 @@ alembic-check:
 	# missing revision — reset the dev DB or use a clean OSS DB. UV_CACHE_DIR points at a
 	# writable path because the running container's default ~/.cache/uv is read-only.
 	docker compose exec -T -e UV_CACHE_DIR=/tmp/uv-cache api uv run --no-sync alembic check
+
+# Requires a real migration overlay to already be installed in the api image.
+# The verifier fails (never skips) when the geolens.migrations entry point is
+# absent, making it suitable for an overlay-owned cross-repository release gate.
+overlay-migration-check:
+	docker compose exec -T -e UV_CACHE_DIR=/tmp/uv-cache api uv run --no-sync python scripts/verify_overlay_migrations.py
 
 # Defaults to parallel execution (the -n value was chosen from xdist benchmarking).
 # Use `make test-sequential` to opt into sequential debugging mode.

--- a/backend/alembic/README.md
+++ b/backend/alembic/README.md
@@ -80,6 +80,12 @@ Migration `0018` (`chk_ingest_jobs_status`) is deliberately left as a single
 is cheap and re-validating an already-released migration is unwarranted churn
 (finding CV-3).
 
+If existing rows need repair before validation, commit the idempotent `ADD ...
+NOT VALID` first, repair only changed rows in the restarted transaction, then
+enter a second `autocommit_block` for `VALIDATE`. Migration `0014` follows this
+pattern. The first commit makes the constraint enforce new writes before the
+repair begins; the second releases repair locks before the validation scan.
+
 ## Functional / expression indexes and `alembic check`
 
 `alembic check` must stay green (it is the drift gate). SQLAlchemy cannot

--- a/backend/alembic/README.md
+++ b/backend/alembic/README.md
@@ -106,7 +106,7 @@ and copy the expression verbatim from the diff error message, or read
 
 A fresh `alembic upgrade head` requires **PostgreSQL 13+** (`gen_random_uuid()`
 is used as a column default; migration `0001` RAISEs a clear error on older
-servers) and **pgvector 0.5+** (HNSW index in migration `0011`). Required
+servers) and **pgvector 0.5+** (HNSW index in migration `0012`). Required
 extensions (`postgis`, `pg_trgm`, `vector`, `unaccent`) are provisioned
 out-of-band by `scripts/init-db.sh`; `0001` verifies their presence and RAISEs
 if any is missing.

--- a/backend/alembic/README.md
+++ b/backend/alembic/README.md
@@ -41,6 +41,19 @@ table that may be large in production (`records`, `record_embeddings`,
 `audit_logs`, `ingest_jobs`, per-dataset `data.*` tables). For small/transient
 tables a plain `CREATE INDEX` is fine.
 
+### Embedding cache after migration 0012
+
+Migration `0012_type_embedding_vector` deliberately truncates
+`catalog.record_embeddings` before fixing the vector dimension. Embeddings are
+derived cache data, and clearing them keeps the type-change lock short even on a
+large catalog. The migration then commits that transition and builds HNSW with
+`CREATE INDEX CONCURRENTLY`; a retry repairs an invalid interrupted index.
+
+After the API starts with its embedding provider configured, an administrator
+should call `POST /admin/backfill-embeddings/` (or use the corresponding admin
+control) to restore embedding coverage. Until that backfill or later record edits
+complete, semantic search has no cached vectors for pre-existing records.
+
 ## Large-table CHECK / FK constraints (NOT VALID + VALIDATE)
 
 A bare `ALTER TABLE ... ADD CONSTRAINT ... CHECK (...)` takes `ACCESS EXCLUSIVE`

--- a/backend/alembic/README.md
+++ b/backend/alembic/README.md
@@ -48,6 +48,9 @@ Migration `0012_type_embedding_vector` deliberately truncates
 derived cache data, and clearing them keeps the type-change lock short even on a
 large catalog. The migration then commits that transition and builds HNSW with
 `CREATE INDEX CONCURRENTLY`; a retry repairs an invalid interrupted index.
+Strong-lock acquisition is capped at five seconds. If PostgreSQL reports a lock
+timeout, let the blocking transaction finish (or choose a quieter window) and
+rerun Alembic; the transition is unchanged and retry-safe.
 
 After the API starts with its embedding provider configured, an administrator
 should call `POST /admin/backfill-embeddings/` (or use the corresponding admin
@@ -85,6 +88,8 @@ NOT VALID` first, repair only changed rows in the restarted transaction, then
 enter a second `autocommit_block` for `VALIDATE`. Migration `0014` follows this
 pattern. The first commit makes the constraint enforce new writes before the
 repair begins; the second releases repair locks before the validation scan.
+Both DDL phases cap lock acquisition at five seconds and can be retried after a
+lock-timeout failure without manual schema repair.
 
 ## Functional / expression indexes and `alembic check`
 

--- a/backend/alembic/versions/0001_baseline.py
+++ b/backend/alembic/versions/0001_baseline.py
@@ -47,10 +47,10 @@ def upgrade() -> None:
     )
 
     # --- Verify required extensions (created by scripts/init-db.sh) ---
-    # NOTE: the 'vector' (pgvector) extension must be >= 0.5.0 -- migration 0011
+    # NOTE: the 'vector' (pgvector) extension must be >= 0.5.0 -- migration 0012
     # creates an HNSW index, which pgvector added in 0.5.0. Older pgvector fails
-    # at 0011 with 'access method "hnsw" does not exist'. The >= 0.5 requirement
-    # is documented (README / deployment) and enforced-by-failure at 0011.
+    # at 0012 with 'access method "hnsw" does not exist'. The >= 0.5 requirement
+    # is documented (README / deployment) and enforced-by-failure at 0012.
     for ext in ("postgis", "pg_trgm", "vector", "unaccent"):
         op.execute(
             f"DO $$ BEGIN "
@@ -1726,7 +1726,7 @@ def upgrade() -> None:
         "CREATE TRIGGER trg_records_updated_at BEFORE UPDATE ON catalog.records FOR EACH ROW EXECUTE FUNCTION catalog.set_updated_at()"
     )
 
-    # --- Conditional pgvector HNSW index (0011; skipped until the column is dimensioned) ---
+    # --- Conditional pgvector HNSW index (0012; skipped until the column is dimensioned) ---
     # Only build the HNSW index if the column has been dimensioned.
     # pgvector raises "column does not have dimensions" if typmod is -1.
     # Skipping in the virgin case is safe: rebuild_embedding_column will

--- a/backend/alembic/versions/0005_dormant_tenancy.py
+++ b/backend/alembic/versions/0005_dormant_tenancy.py
@@ -30,7 +30,12 @@ What this migration adds
    tenant_id IS NULL — breaking single_tenant global uniqueness.  The partial
    indexes are the correct solution.
 
-Downgrade reverses every operation in the exact inverse order.
+Downgrade reverses every operation in the exact inverse order only while the
+tenant substrate is empty.  Once tenant-scoped data exists, removing the
+columns and tables would silently discard ownership metadata and can make the
+restored global user constraints impossible to create.  The downgrade therefore
+locks the affected tables and fails with an operator-facing consolidation
+contract before changing the schema.
 
 Revision ID: 0005_dormant_tenancy
 Revises:     0004_add_maps_legend_title
@@ -48,19 +53,109 @@ down_revision: Union[str, None] = "0004_add_maps_legend_title"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 
+_SHARED_TABLES = (
+    "users",
+    "records",
+    "datasets",
+    "maps",
+    "collections",
+    "embed_tokens",
+)
+
+
+def _assert_downgrade_has_no_tenant_data() -> None:
+    """Refuse to erase tenant ownership or restore impossible constraints.
+
+    The lock prevents a write from racing the preflight and committing tenant
+    data before the destructive DDL acquires its stronger table locks.  It is
+    retained until Alembic's surrounding transaction commits or rolls back.
+    """
+    bind = op.get_bind()
+    bind.execute(
+        sa.text(
+            """
+            LOCK TABLE
+                catalog.users,
+                catalog.records,
+                catalog.datasets,
+                catalog.maps,
+                catalog.collections,
+                catalog.embed_tokens,
+                catalog.organizations,
+                catalog.tenants,
+                catalog.org_memberships
+            IN SHARE ROW EXCLUSIVE MODE
+            """
+        )
+    )
+    blockers = (
+        bind.execute(
+            sa.text(
+                """
+            SELECT blocker
+            FROM (
+                SELECT 'catalog.users.tenant_id' AS blocker
+                WHERE EXISTS (
+                    SELECT 1 FROM catalog.users WHERE tenant_id IS NOT NULL
+                )
+                UNION ALL
+                SELECT 'catalog.records.tenant_id'
+                WHERE EXISTS (
+                    SELECT 1 FROM catalog.records WHERE tenant_id IS NOT NULL
+                )
+                UNION ALL
+                SELECT 'catalog.datasets.tenant_id'
+                WHERE EXISTS (
+                    SELECT 1 FROM catalog.datasets WHERE tenant_id IS NOT NULL
+                )
+                UNION ALL
+                SELECT 'catalog.maps.tenant_id'
+                WHERE EXISTS (
+                    SELECT 1 FROM catalog.maps WHERE tenant_id IS NOT NULL
+                )
+                UNION ALL
+                SELECT 'catalog.collections.tenant_id'
+                WHERE EXISTS (
+                    SELECT 1 FROM catalog.collections WHERE tenant_id IS NOT NULL
+                )
+                UNION ALL
+                SELECT 'catalog.embed_tokens.tenant_id'
+                WHERE EXISTS (
+                    SELECT 1 FROM catalog.embed_tokens WHERE tenant_id IS NOT NULL
+                )
+                UNION ALL
+                SELECT 'catalog.organizations'
+                WHERE EXISTS (SELECT 1 FROM catalog.organizations)
+                UNION ALL
+                SELECT 'catalog.tenants'
+                WHERE EXISTS (SELECT 1 FROM catalog.tenants)
+                UNION ALL
+                SELECT 'catalog.org_memberships'
+                WHERE EXISTS (SELECT 1 FROM catalog.org_memberships)
+            ) AS present
+            ORDER BY blocker
+            """
+            )
+        )
+        .scalars()
+        .all()
+    )
+
+    if blockers:
+        raise RuntimeError(
+            "Cannot downgrade 0005_dormant_tenancy while tenant-scoped data "
+            f"exists in: {', '.join(blockers)}. This downgrade removes tenant "
+            "associations and tenancy tables. Back up and consolidate tenant "
+            "data, resolve global username/email collisions, clear tenant_id "
+            "values, and empty the tenancy tables before retrying."
+        )
+
 
 def upgrade() -> None:
     # ------------------------------------------------------------------
     # 1. Add nullable tenant_id to the six shared control-plane tables.
     # ------------------------------------------------------------------
-    for table in (
-        "users",
-        "records",
-        "datasets",
-        "maps",
-        "collections",
-        "embed_tokens",
-    ):
+    for table in _SHARED_TABLES:
         op.add_column(
             table,
             sa.Column(
@@ -204,6 +299,8 @@ def downgrade() -> None:
     # Reverse in exact inverse order of upgrade().
     # ------------------------------------------------------------------
 
+    _assert_downgrade_has_no_tenant_data()
+
     # 3. Restore the global unique constraints and drop the partial indexes.
     op.drop_index("uq_users_email_tenant", table_name="users", schema="catalog")
     op.drop_index("uq_users_email_global", table_name="users", schema="catalog")
@@ -222,12 +319,5 @@ def downgrade() -> None:
     op.drop_table("organizations", schema="catalog")
 
     # 1. Drop the tenant_id columns from the six shared tables.
-    for table in (
-        "embed_tokens",
-        "collections",
-        "maps",
-        "datasets",
-        "records",
-        "users",
-    ):
+    for table in reversed(_SHARED_TABLES):
         op.drop_column(table, "tenant_id", schema="catalog")

--- a/backend/alembic/versions/0006_tenant_rls.py
+++ b/backend/alembic/versions/0006_tenant_rls.py
@@ -14,7 +14,9 @@ Key design constraints
   IS NULL`` escape is intentionally absent — it would make the policy fail-open
   and is rejected by the ISO-02 decision (see 1208-CONTEXT.md).  An unset GUC
   fails closed (error or 0 rows) as required.
-- **Reversible.** ``downgrade()`` drops all 6 policies in inverse order.
+- **Safe rollback.** ``downgrade()`` unforces and disables runtime-activated RLS
+  before dropping all 6 policies in inverse order.  This prevents policy-free
+  tables from remaining in a deny-all state after rollback.
 
 The 6 tables (all in ``catalog`` schema) received a nullable ``tenant_id`` UUID
 column in ``0005_dormant_tenancy``.
@@ -63,6 +65,8 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
-    """Drop the 6 tenant isolation policies in inverse order."""
+    """Disable runtime RLS state, then drop the policies in inverse order."""
     for table in reversed(_TABLES):
+        op.execute(f"ALTER TABLE catalog.{table} NO FORCE ROW LEVEL SECURITY")
+        op.execute(f"ALTER TABLE catalog.{table} DISABLE ROW LEVEL SECURITY")
         op.execute(f"DROP POLICY IF EXISTS tenant_isolation_{table} ON catalog.{table}")

--- a/backend/alembic/versions/0010_oauth_github_provider_type.py
+++ b/backend/alembic/versions/0010_oauth_github_provider_type.py
@@ -38,13 +38,14 @@ tests (``test_tenant_rls_migration.py``, ``test_email_verification_migration.py`
 test targets this migration's parent explicitly so newer heads cannot mask the
 constraint transition.
 
-Cross-repo deferred note
-------------------------
-The enterprise overlay ``e002`` recreates ``chk_oauth_providers_type`` as part of
-its own upgrade.  If ``e002`` runs AFTER this migration (i.e. on a deployment
-that applied 0010 first) its recreation will drop ``'github'``.  The overlay team
-should add ``'github'`` to ``e002``'s constraint literal in a follow-up.  This is
-out of scope for the OSS core here — flagged for the enterprise maintainers.
+Cross-repo compatibility contract
+---------------------------------
+Any overlay migration that recreates ``chk_oauth_providers_type`` must write the
+same full provider union as this migration.  The current enterprise ``e002``
+does so, which makes the final constraint independent of which branch writes it
+last.  Overlay-owned CI can exercise the real package against this core through
+``scripts/verify_overlay_migrations.py``; public core CI does not fetch private
+overlay source.
 
 Revision ID: 0010_oauth_github_provider_type
 Revises:     0009_email_verification

--- a/backend/alembic/versions/0010_oauth_github_provider_type.py
+++ b/backend/alembic/versions/0010_oauth_github_provider_type.py
@@ -24,16 +24,19 @@ Downgrade strategy
 Recreate the constraint WITHOUT ``'github'`` but KEEP ``'saml'``:
 ``('oidc', 'google', 'microsoft', 'saml')``.  Dropping ``'saml'`` on downgrade
 would risk data loss on enterprise deployments and is explicitly forbidden by the
-0008 co-owned-constraint lesson.  Also idempotent (``DROP ... IF EXISTS``).
+0008 co-owned-constraint lesson.  Before changing the constraint, lock the table
+and refuse the downgrade while GitHub providers exist; provider credentials and
+dependent identities require an explicit operator-approved migration or removal
+plan.  The constraint replacement remains idempotent (``DROP ... IF EXISTS``).
 
 Head-coupling note
 ------------------
 Adding this migration advances the alembic head: ``0009_email_verification`` →
 ``0010_oauth_github_provider_type``.  After writing this file the head-coupled CI
 tests (``test_tenant_rls_migration.py``, ``test_email_verification_migration.py``,
-``test_ci_alembic_filter_paths.py``) must remain green.  Those tests use
-dynamic head resolution (``upgrade head`` / ``downgrade -1``) rather than
-hard-coding a revision ID, so they require no edit.
+``test_ci_alembic_filter_paths.py``) must remain green.  The focused downgrade
+test targets this migration's parent explicitly so newer heads cannot mask the
+constraint transition.
 
 Cross-repo deferred note
 ------------------------
@@ -50,12 +53,44 @@ Create Date: 2026-06-20
 
 from typing import Sequence, Union
 
+import sqlalchemy as sa
 from alembic import op
 
 revision: str = "0010_oauth_github_provider_type"
 down_revision: Union[str, None] = "0009_email_verification"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
+
+
+def _assert_no_github_providers() -> None:
+    """Block rollback rather than deleting or coercing provider credentials."""
+    bind = op.get_bind()
+    bind.execute(
+        sa.text(
+            """
+            LOCK TABLE catalog.oauth_providers
+            IN SHARE ROW EXCLUSIVE MODE
+            """
+        )
+    )
+    github_provider_count = bind.execute(
+        sa.text(
+            """
+            SELECT count(*)
+            FROM catalog.oauth_providers
+            WHERE provider_type = 'github'
+            """
+        )
+    ).scalar_one()
+
+    if github_provider_count:
+        raise RuntimeError(
+            "Cannot downgrade 0010_oauth_github_provider_type while "
+            f"{github_provider_count} GitHub OAuth provider(s) exist. Back up "
+            "and explicitly migrate or remove those providers and any dependent "
+            "identities, or cancel the downgrade. GeoLens will not delete or "
+            "coerce provider credentials automatically."
+        )
 
 
 def upgrade() -> None:
@@ -88,8 +123,12 @@ def downgrade() -> None:
     co-owned by the enterprise overlay migration e002.  Dropping it on downgrade
     would break enterprise deployments where SAML providers already exist.
 
-    Idempotent: DROP CONSTRAINT IF EXISTS before re-ADD.
+    Idempotent: DROP CONSTRAINT IF EXISTS before re-ADD.  A locked preflight
+    blocks the operation before DDL when live GitHub providers would violate the
+    restored constraint.
     """
+    _assert_no_github_providers()
+
     op.execute(
         """
         ALTER TABLE catalog.oauth_providers

--- a/backend/alembic/versions/0012_type_embedding_vector.py
+++ b/backend/alembic/versions/0012_type_embedding_vector.py
@@ -34,34 +34,63 @@ Revises: 0011_allow_generic_geometry_type
 Create Date: 2026-07-10
 """
 
+import os
 from typing import Sequence, Union
 
 from alembic import op
-
-from app.core.config import settings
 
 revision: str = "0012_type_embedding_vector"
 down_revision: Union[str, None] = "0011_allow_generic_geometry_type"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 
+_TRUE_ENV_VALUES = frozenset({"1", "true", "yes", "on"})
+_FALSE_ENV_VALUES = frozenset({"0", "false", "no", "off"})
+
+
+def _explicit_embedding_dims() -> int | None:
+    """Return an explicitly exported embedding dimension, if one exists.
+
+    Keep this parser migration-local: topology-only Alembic commands import every
+    revision module and must not need the mutable application Settings object.
+    """
+    raw = os.environ.get("EMBEDDING_DIMS")
+    if raw is None or not raw.strip():
+        return None
+    try:
+        dims = int(raw)
+    except ValueError as exc:
+        raise RuntimeError("EMBEDDING_DIMS must be an integer from 1 to 4096") from exc
+    if not 1 <= dims <= 4096:
+        raise RuntimeError("EMBEDDING_DIMS must be an integer from 1 to 4096")
+    return dims
+
+
+def _env_only_config_enabled() -> bool:
+    """Parse ENV_ONLY_CONFIG without importing application configuration."""
+    raw = os.environ.get("ENV_ONLY_CONFIG")
+    if raw is None or not raw.strip():
+        return False
+    normalized = raw.strip().lower()
+    if normalized in _TRUE_ENV_VALUES:
+        return True
+    if normalized in _FALSE_ENV_VALUES:
+        return False
+    raise RuntimeError(
+        "ENV_ONLY_CONFIG must be one of true/false, 1/0, yes/no, or on/off"
+    )
+
 
 def upgrade() -> None:
     # fix(#449, codex P2): honor the deployment's configured dimension, not a
     # hardcoded 1536, and let explicit config beat stale stored rows. Mirror
     # runtime resolution (persistent_config.py): ENV_ONLY_CONFIG ignores DB
-    # overrides. "Explicit" = the operator provided EMBEDDING_DIMS (env var or
-    # the project-root .env file Settings reads) — pydantic's model_fields_set
-    # distinguishes a deliberate EMBEDDING_DIMS=1536 from the untouched class
-    # default, which a value comparison cannot.
-    explicit = (
-        settings.embedding_dims
-        if "embedding_dims" in settings.model_fields_set
-        and settings.embedding_dims >= 1
-        else None
-    )
+    # overrides. Compose passes EMBEDDING_DIMS through only when the operator
+    # set it, so a deliberate EMBEDDING_DIMS=1536 remains distinguishable from
+    # the frozen fallback below.
+    explicit = _explicit_embedding_dims()
     explicit_env_dims = str(explicit) if explicit is not None else "NULL"
-    consult_db = "false" if settings.env_only_config else "true"
+    consult_db = "false" if _env_only_config_enabled() else "true"
     op.execute(
         f"""
         DO $$

--- a/backend/alembic/versions/0012_type_embedding_vector.py
+++ b/backend/alembic/versions/0012_type_embedding_vector.py
@@ -180,7 +180,11 @@ def upgrade() -> None:
             -- ACCESS EXCLUSIVE lock the type change needs, but makes the locked
             -- work constant-size rather than rewriting/deleting O(rows). The
             -- index is built after this transaction commits, so the lock is
-            -- released before the potentially long HNSW scan.
+            -- released before the potentially long HNSW scan. Bound lock
+            -- acquisition as well as locked work: a busy deployment fails this
+            -- transaction after five seconds instead of leaving ACCESS EXCLUSIVE
+            -- queued ahead of new readers. Alembic can be retried unchanged.
+            PERFORM set_config('lock_timeout', '5s', true);
             TRUNCATE catalog.record_embeddings;
             RAISE NOTICE 'Cleared cached record embeddings for vector(%) transition; run the embedding backfill after upgrade.', dims;
 

--- a/backend/alembic/versions/0012_type_embedding_vector.py
+++ b/backend/alembic/versions/0012_type_embedding_vector.py
@@ -13,21 +13,21 @@ This migration types the column in place, preferring (in order):
 1. An explicitly configured dimension: the ``embedding_dims``
    persistent-config override (skipped when ``ENV_ONLY_CONFIG`` is set,
    mirroring runtime resolution in persistent_config.py), then an
-   explicitly-set ``EMBEDDING_DIMS`` env value (detected via pydantic's
-   ``model_fields_set``, so a deliberate ``EMBEDDING_DIMS=1536`` counts
-   even though it equals the default). Explicit config beats stored
-   rows — stale cache rows from a superseded model must not pin the
-   column to the old dimension (the current model's inserts would fail
-   until a manual rebuild).
+   explicitly exported ``EMBEDDING_DIMS`` value. A deliberate
+   ``EMBEDDING_DIMS=1536`` counts even though it equals the fallback.
+   Explicit config beats stored rows — stale cache rows from a superseded
+   model must not pin the column to the old dimension (the current model's
+   inserts would fail until a manual rebuild).
 2. The dimension of vectors already stored, when they all agree. Stored
    rows beat only the BUILT-IN default: a local model emitting 768-dim
-   vectors with nothing configured anywhere must keep its rows.
-3. The Settings default (1536, text-embedding-3-small).
+   vectors with nothing configured anywhere still selects vector(768).
+3. The frozen migration default (1536, text-embedding-3-small).
 
-Rows whose dimension disagrees with the chosen value are deleted —
-embeddings are a regenerable cache (content-hash backfill restores them).
-Deployments whose column is already typed (the settings-UI path ran) are
-left untouched except for ensuring the index.
+When the untyped column must transition, all embedding rows are truncated before
+the type change. Embeddings are a regenerable cache (content-hash backfill restores
+them), and clearing them bounds the ACCESS EXCLUSIVE work independently of table
+size. Deployments whose column is already typed (the settings-UI path ran) are left
+untouched except for ensuring the index.
 
 Revision ID: 0012_type_embedding_vector
 Revises: 0011_allow_generic_geometry_type
@@ -37,6 +37,7 @@ Create Date: 2026-07-10
 import os
 from typing import Sequence, Union
 
+import sqlalchemy as sa
 from alembic import op
 
 revision: str = "0012_type_embedding_vector"
@@ -46,6 +47,17 @@ depends_on: Union[str, Sequence[str], None] = None
 
 _TRUE_ENV_VALUES = frozenset({"1", "true", "yes", "on"})
 _FALSE_ENV_VALUES = frozenset({"0", "false", "no", "off"})
+
+_HNSW_INDEX_VALIDITY_SQL = sa.text(
+    """
+    SELECT idx.indisvalid AND idx.indisready
+    FROM pg_index AS idx
+    JOIN pg_class AS cls ON cls.oid = idx.indexrelid
+    JOIN pg_namespace AS ns ON ns.oid = cls.relnamespace
+    WHERE ns.nspname = 'catalog'
+      AND cls.relname = 'ix_record_embeddings_hnsw'
+    """
+)
 
 
 def _explicit_embedding_dims() -> int | None:
@@ -81,6 +93,26 @@ def _env_only_config_enabled() -> bool:
     )
 
 
+def _ensure_hnsw_index_concurrently() -> None:
+    """Create the ANN index without blocking writers, recovering failed builds."""
+    index_is_valid = (
+        op.get_bind().execute(_HNSW_INDEX_VALIDITY_SQL).scalar_one_or_none()
+    )
+    if index_is_valid is False:
+        # PostgreSQL leaves an invalid same-name index after a failed concurrent
+        # build. IF NOT EXISTS would silently accept it, so remove it first.
+        op.execute(
+            "DROP INDEX CONCURRENTLY IF EXISTS catalog.ix_record_embeddings_hnsw"
+        )
+    if index_is_valid is not True:
+        op.execute(
+            "CREATE INDEX CONCURRENTLY IF NOT EXISTS ix_record_embeddings_hnsw "
+            "ON catalog.record_embeddings USING hnsw "
+            "(embedding vector_cosine_ops) "
+            "WITH (m = 16, ef_construction = 64)"
+        )
+
+
 def upgrade() -> None:
     # fix(#449, codex P2): honor the deployment's configured dimension, not a
     # hardcoded 1536, and let explicit config beat stale stored rows. Mirror
@@ -107,11 +139,6 @@ def upgrade() -> None:
             AND attname = 'embedding';
 
           IF cur_typmod = -1 THEN
-            -- Acquire the strongest lock up front: DELETE-then-ALTER would
-            -- otherwise escalate ROW EXCLUSIVE -> ACCESS EXCLUSIVE mid-flight,
-            -- a deadlock-prone pattern if anything is reading the table.
-            LOCK TABLE catalog.record_embeddings IN ACCESS EXCLUSIVE MODE;
-
             SELECT count(DISTINCT vector_dims(embedding)),
                    max(vector_dims(embedding))
               INTO distinct_dims, stored_dims
@@ -149,8 +176,13 @@ def upgrade() -> None:
               dims := 1536;
             END IF;
 
-            DELETE FROM catalog.record_embeddings
-            WHERE vector_dims(embedding) <> dims;
+            -- Embeddings are a regenerable cache. TRUNCATE acquires the same
+            -- ACCESS EXCLUSIVE lock the type change needs, but makes the locked
+            -- work constant-size rather than rewriting/deleting O(rows). The
+            -- index is built after this transaction commits, so the lock is
+            -- released before the potentially long HNSW scan.
+            TRUNCATE catalog.record_embeddings;
+            RAISE NOTICE 'Cleared cached record embeddings for vector(%) transition; run the embedding backfill after upgrade.', dims;
 
             EXECUTE format(
               'ALTER TABLE catalog.record_embeddings '
@@ -158,28 +190,37 @@ def upgrade() -> None:
               dims, dims
             );
           END IF;
-
-          -- Same DDL the baseline and rebuild_embedding_column intend.
-          -- fix(#449, codex P1): pgvector rejects HNSW on vector columns over
-          -- 2000 dims (3072-dim models are legal config, cap is 4096) — skip
-          -- the index rather than fail the upgrade; semantic search falls
-          -- back to exact scans. Re-probe: the ALTER above may have typed it.
-          SELECT atttypmod INTO cur_typmod
-          FROM pg_attribute
-          WHERE attrelid = 'catalog.record_embeddings'::regclass
-            AND attname = 'embedding';
-
-          IF cur_typmod BETWEEN 1 AND 2000 THEN
-            EXECUTE 'CREATE INDEX IF NOT EXISTS ix_record_embeddings_hnsw '
-                    'ON catalog.record_embeddings USING hnsw '
-                    '(embedding vector_cosine_ops) '
-                    'WITH (m = 16, ef_construction = 64)';
-          ELSE
-            RAISE NOTICE 'Skipping ix_record_embeddings_hnsw: % dims exceeds pgvector''s 2000-dim HNSW limit; semantic search stays on exact scans.', cur_typmod;
-          END IF;
         END $$;
         """
     )
+
+    current_dims = (
+        op.get_bind()
+        .execute(
+            sa.text(
+                "SELECT atttypmod FROM pg_attribute "
+                "WHERE attrelid = 'catalog.record_embeddings'::regclass "
+                "AND attname = 'embedding'"
+            )
+        )
+        .scalar_one()
+    )
+
+    # Entering the block commits the TRUNCATE/type transition and releases its
+    # ACCESS EXCLUSIVE lock. It also makes a partially completed migration
+    # resumable: a retry sees the typed column, then repairs/recreates the index.
+    with op.get_context().autocommit_block():
+        if 1 <= current_dims <= 2000:
+            _ensure_hnsw_index_concurrently()
+        else:
+            op.execute(
+                sa.text(
+                    "DO $$ BEGIN RAISE NOTICE "
+                    "'Skipping ix_record_embeddings_hnsw: dimensions exceed "
+                    "pgvector''s 2000-dim HNSW limit; semantic search stays on "
+                    "exact scans.'; END $$"
+                )
+            )
 
 
 def downgrade() -> None:

--- a/backend/alembic/versions/0014_record_translations.py
+++ b/backend/alembic/versions/0014_record_translations.py
@@ -17,44 +17,87 @@ depends_on: Union[str, Sequence[str], None] = None
 
 
 def upgrade() -> None:
-    op.alter_column(
-        "records",
-        "language",
-        existing_type=sa.String(length=10),
-        type_=sa.String(length=35),
-        existing_nullable=True,
-        schema="catalog",
-    )
-    # The legacy column had no format constraint. Canonicalize values that are
-    # structurally usable (EN -> en, pt_BR -> pt-BR) and use the documented
-    # English fallback for blank/free-form historical values before validating
-    # the table. This keeps upgrades safe for long-lived self-hosted catalogs.
+    # The DDL prefix commits independently so its brief ACCESS EXCLUSIVE lock is
+    # released before the data repair scans records. The conditional constraint
+    # add makes this prefix safe to retry if a later autocommit step is interrupted.
+    # NOT VALID skips the locked table scan but still constrains every new write.
+    with op.get_context().autocommit_block():
+        op.execute(
+            sa.text(
+                """
+                DO $$
+                BEGIN
+                  ALTER TABLE catalog.records
+                    ALTER COLUMN language TYPE VARCHAR(35);
+
+                  IF NOT EXISTS (
+                    SELECT 1
+                    FROM pg_constraint
+                    WHERE conrelid = 'catalog.records'::regclass
+                      AND conname = 'chk_records_language_tag'
+                  ) THEN
+                    ALTER TABLE catalog.records
+                      ADD CONSTRAINT chk_records_language_tag
+                      CHECK (
+                        language IS NULL
+                        OR language ~ '^[a-z]{2,3}(-[A-Za-z0-9]{2,8})*$'
+                      ) NOT VALID;
+                  END IF;
+                END $$;
+                """
+            )
+        )
+
+    # Canonicalize only rows whose value actually changes. The scan can run for
+    # a large catalog, but it no longer rewrites every non-NULL row or runs while
+    # the DDL lock above is held.
     op.execute(
         sa.text(
             """
-            UPDATE catalog.records
-            SET language = CASE
-                WHEN btrim(replace(language, '_', '-'))
-                     ~* '^[a-z]{2,3}(-[a-z0-9]{2,8})*$'
-                THEN lower(split_part(btrim(replace(language, '_', '-')), '-', 1))
-                     || substring(
-                         btrim(replace(language, '_', '-'))
-                         FROM length(
-                             split_part(btrim(replace(language, '_', '-')), '-', 1)
-                         ) + 1
-                     )
-                ELSE 'en'
-            END
-            WHERE language IS NOT NULL
+            WITH normalized AS (
+              SELECT id,
+                     CASE
+                       WHEN btrim(replace(language, '_', '-'))
+                            ~* '^[a-z]{2,3}(-[a-z0-9]{2,8})*$'
+                       THEN lower(
+                              split_part(
+                                btrim(replace(language, '_', '-')), '-', 1
+                              )
+                            )
+                            || substring(
+                              btrim(replace(language, '_', '-'))
+                              FROM length(
+                                split_part(
+                                  btrim(replace(language, '_', '-')), '-', 1
+                                )
+                              ) + 1
+                            )
+                       ELSE 'en'
+                     END AS normalized_language
+              FROM catalog.records
+              WHERE language IS NOT NULL
+            )
+            UPDATE catalog.records AS records
+            SET language = normalized.normalized_language
+            FROM normalized
+            WHERE records.id = normalized.id
+              AND records.language IS DISTINCT FROM normalized.normalized_language
             """
         )
     )
-    op.create_check_constraint(
-        "chk_records_language_tag",
-        "records",
-        "language IS NULL OR language ~ '^[a-z]{2,3}(-[A-Za-z0-9]{2,8})*$'",
-        schema="catalog",
-    )
+
+    # Entering this block commits the targeted repair. PostgreSQL validates the
+    # already-enforced constraint under SHARE UPDATE EXCLUSIVE, which permits
+    # ordinary reads and writes. VALIDATE is a no-op on crash/retry once valid.
+    with op.get_context().autocommit_block():
+        op.execute(
+            sa.text(
+                """
+                ALTER TABLE catalog.records
+                  VALIDATE CONSTRAINT chk_records_language_tag
+                """
+            )
+        )
     op.create_table(
         "record_translations",
         sa.Column(

--- a/backend/alembic/versions/0014_record_translations.py
+++ b/backend/alembic/versions/0014_record_translations.py
@@ -27,6 +27,9 @@ def upgrade() -> None:
                 """
                 DO $$
                 BEGIN
+                  -- Fail transactionally instead of leaving an ACCESS EXCLUSIVE
+                  -- request queued behind a long reader. The prefix is retry-safe.
+                  PERFORM set_config('lock_timeout', '5s', true);
                   ALTER TABLE catalog.records
                     ALTER COLUMN language TYPE VARCHAR(35);
 
@@ -93,8 +96,14 @@ def upgrade() -> None:
         op.execute(
             sa.text(
                 """
-                ALTER TABLE catalog.records
-                  VALIDATE CONSTRAINT chk_records_language_tag
+                DO $$
+                BEGIN
+                  -- VALIDATE takes SHARE UPDATE EXCLUSIVE. Bound acquisition so
+                  -- concurrent maintenance cannot stall the migration forever.
+                  PERFORM set_config('lock_timeout', '5s', true);
+                  ALTER TABLE catalog.records
+                    VALIDATE CONSTRAINT chk_records_language_tag;
+                END $$;
                 """
             )
         )

--- a/backend/alembic/versions/0017_add_fk_support_indexes.py
+++ b/backend/alembic/versions/0017_add_fk_support_indexes.py
@@ -1,0 +1,97 @@
+"""Add leading indexes for nullable attribution and lineage foreign keys.
+
+PostgreSQL does not create indexes on the referencing side of a foreign key.
+These columns all use ``ON DELETE SET NULL`` and are exercised by supported
+hard-delete paths for users and maps. Without a leading index, deleting a
+parent row scans the complete child table while enforcing the constraint.
+
+Every indexed column is nullable, so the indexes exclude null values. The
+tables can be large in production; concurrent, resumable DDL avoids blocking
+normal reads and writes while each index is built.
+
+Revision ID: 0017_add_fk_support_indexes
+Revises: 0016_admin_identity_hardening
+Create Date: 2026-07-14
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = "0017_add_fk_support_indexes"
+down_revision: Union[str, None] = "0016_admin_identity_hardening"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+# Fixed identifiers only; keeping the inventory in one tuple makes upgrade and
+# downgrade exact inverses and gives the focused invariant test one source of
+# truth to inspect.
+FK_SUPPORT_INDEXES: tuple[tuple[str, str, str], ...] = (
+    ("ix_collection_datasets_added_by", "collection_datasets", "added_by"),
+    ("ix_collections_created_by", "collections", "created_by"),
+    ("ix_dataset_versions_uploaded_by", "dataset_versions", "uploaded_by"),
+    ("ix_embed_tokens_created_by", "embed_tokens", "created_by"),
+    ("ix_map_share_tokens_created_by", "map_share_tokens", "created_by"),
+    ("ix_maps_forked_from", "maps", "forked_from"),
+    ("ix_records_created_by", "records", "created_by"),
+    ("ix_records_updated_by", "records", "updated_by"),
+)
+
+
+def _index_state(index_name: str) -> tuple[bool, bool] | None:
+    """Return ``(indisvalid, indisready)`` for a catalog index, if present."""
+    row = (
+        op.get_bind()
+        .execute(
+            sa.text(
+                """
+            SELECT index_row.indisvalid, index_row.indisready
+            FROM pg_catalog.pg_index AS index_row
+            JOIN pg_catalog.pg_class AS index_class
+              ON index_class.oid = index_row.indexrelid
+            JOIN pg_catalog.pg_namespace AS namespace
+              ON namespace.oid = index_class.relnamespace
+            WHERE namespace.nspname = 'catalog'
+              AND index_class.relname = :index_name
+            """
+            ),
+            {"index_name": index_name},
+        )
+        .one_or_none()
+    )
+    if row is None:
+        return None
+    return bool(row.indisvalid), bool(row.indisready)
+
+
+def upgrade() -> None:
+    """Create partial FK-support indexes without blocking table writes."""
+    # CREATE INDEX CONCURRENTLY is forbidden inside a transaction. Alembic's
+    # autocommit block commits the surrounding migration transaction, executes
+    # each statement in autocommit mode, then starts a new transaction for the
+    # version-table update. A failed concurrent build can leave an invalid,
+    # same-name index behind; IF NOT EXISTS alone would then skip it forever.
+    # Drop invalid/not-ready remnants before recreating, while preserving an
+    # already-valid index when a retry follows a later migration failure.
+    for index_name, table_name, column_name in FK_SUPPORT_INDEXES:
+        state = _index_state(index_name)
+        if state == (True, True):
+            continue
+
+        with op.get_context().autocommit_block():
+            if state is not None:
+                op.execute(f'DROP INDEX CONCURRENTLY IF EXISTS catalog."{index_name}"')
+            op.execute(
+                f'CREATE INDEX CONCURRENTLY IF NOT EXISTS "{index_name}" '
+                f'ON catalog."{table_name}" ("{column_name}") '
+                f'WHERE "{column_name}" IS NOT NULL'
+            )
+
+
+def downgrade() -> None:
+    """Drop the FK-support indexes without blocking table writes."""
+    with op.get_context().autocommit_block():
+        for index_name, _table_name, _column_name in reversed(FK_SUPPORT_INDEXES):
+            op.execute(f'DROP INDEX CONCURRENTLY IF EXISTS catalog."{index_name}"')

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -309,6 +309,17 @@ class Settings(BaseSettings):
             return None
         return v
 
+    @field_validator("embedding_dims", mode="before")
+    @classmethod
+    def empty_embedding_dims_to_default(cls, v: object) -> object:
+        # fix(#512): the one-shot migrate service deliberately preserves an
+        # unset host value as "" so migration 0012 can distinguish it from an
+        # explicitly configured 1536. Settings is imported before the revision,
+        # so normalize only the application-facing value to its existing default.
+        if isinstance(v, str) and not v.strip():
+            return 1536
+        return v
+
     @field_validator("geolens_edition", mode="before")
     @classmethod
     def normalize_geolens_edition(cls, v: str | None) -> str | None:

--- a/backend/app/modules/catalog/collections/models.py
+++ b/backend/app/modules/catalog/collections/models.py
@@ -9,6 +9,7 @@ from sqlalchemy import (
     Text,
     UniqueConstraint,
     func,
+    text,
 )
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Mapped, mapped_column
@@ -18,7 +19,14 @@ from app.core.db import Base
 
 class Collection(Base):
     __tablename__ = "collections"
-    __table_args__ = {"schema": "catalog"}
+    __table_args__ = (
+        Index(
+            "ix_collections_created_by",
+            "created_by",
+            postgresql_where=text("created_by IS NOT NULL"),
+        ),
+        {"schema": "catalog"},
+    )
 
     id: Mapped[uuid.UUID] = mapped_column(
         primary_key=True, server_default=func.gen_random_uuid()
@@ -45,6 +53,11 @@ class CollectionDataset(Base):
     __table_args__ = (
         # T-3: trailing composite-PK FK; covering index added in migration 0001_baseline.
         Index("ix_collection_datasets_dataset_id", "dataset_id"),
+        Index(
+            "ix_collection_datasets_added_by",
+            "added_by",
+            postgresql_where=text("added_by IS NOT NULL"),
+        ),
         {"schema": "catalog"},
     )
 
@@ -69,6 +82,11 @@ class DatasetVersion(Base):
         UniqueConstraint("dataset_id", "version_number", name="uq_dataset_version"),
         # DBM-10 covering index added in migration 0001_baseline.
         Index("ix_dataset_versions_dataset_id", "dataset_id"),
+        Index(
+            "ix_dataset_versions_uploaded_by",
+            "uploaded_by",
+            postgresql_where=text("uploaded_by IS NOT NULL"),
+        ),
         {"schema": "catalog"},
     )
 

--- a/backend/app/modules/catalog/datasets/domain/models.py
+++ b/backend/app/modules/catalog/datasets/domain/models.py
@@ -80,6 +80,16 @@ class Record(Base):
             "record_status",
             "created_by",
         ),
+        Index(
+            "ix_records_created_by",
+            "created_by",
+            postgresql_where=text("created_by IS NOT NULL"),
+        ),
+        Index(
+            "ix_records_updated_by",
+            "updated_by",
+            postgresql_where=text("updated_by IS NOT NULL"),
+        ),
         # Trigram GIN indexes added in migration 0010 (H-07) — declared on the
         # model so alembic check sees them; the migration is the source of truth
         # for the actual DDL (including the catalog.immutable_unaccent wrapper).

--- a/backend/app/modules/catalog/maps/models.py
+++ b/backend/app/modules/catalog/maps/models.py
@@ -44,6 +44,11 @@ class Map(Base):
             postgresql_using="gin",
             postgresql_ops={"lower(coalesce(description, ''))": "gin_trgm_ops"},
         ),
+        Index(
+            "ix_maps_forked_from",
+            "forked_from",
+            postgresql_where=text("forked_from IS NOT NULL"),
+        ),
         # DBM-06 (Phase 271): Map.visibility composite index intentionally
         # NOT created. The RBAC list-public-maps query uses
         # `WHERE visibility = 'public' AND created_by = ?` and similar combos.
@@ -220,6 +225,11 @@ class MapShareToken(Base):
     __tablename__ = "map_share_tokens"
     __table_args__ = (
         UniqueConstraint("token_hash", name="uq_map_share_tokens_token_hash"),
+        Index(
+            "ix_map_share_tokens_created_by",
+            "created_by",
+            postgresql_where=text("created_by IS NOT NULL"),
+        ),
         {"schema": "catalog"},
     )
 

--- a/backend/app/modules/embed_tokens/models.py
+++ b/backend/app/modules/embed_tokens/models.py
@@ -35,6 +35,11 @@ class EmbedToken(Base):
             "expires_at",
             postgresql_where=text("is_active = true"),
         ),
+        Index(
+            "ix_embed_tokens_created_by",
+            "created_by",
+            postgresql_where=text("created_by IS NOT NULL"),
+        ),
         {"schema": "catalog"},
     )
 

--- a/backend/scripts/README.md
+++ b/backend/scripts/README.md
@@ -3,6 +3,28 @@
 One-shot maintenance scripts for the GeoLens backend. Each script is
 meant to be run from `backend/` as the working directory.
 
+## Installed-overlay migration verification
+
+**Script:** `verify_overlay_migrations.py`
+
+Validates the current core migration chain against any real overlay already
+installed through the public `geolens.migrations` entry-point contract. It
+fails when no overlay is installed, runs `alembic upgrade heads`, proves every
+discovered core and overlay head landed, checks the co-owned OAuth/SAML schema,
+and finishes with `alembic check`.
+
+Run it from an overlay-owned CI job or a locally built image that already
+contains the overlay:
+
+```bash
+cd backend
+uv run --no-sync python scripts/verify_overlay_migrations.py
+```
+
+The verifier never imports or checks out a private package by name. Public core
+CI therefore self-tests the verifier with an in-repository fixture, while the
+private overlay's own CI supplies the real installed package and database.
+
 ## Alembic clean-DB upgrade test
 
 **Script:** `test_alembic_upgrade_clean_db.sh`

--- a/backend/scripts/verify_overlay_migrations.py
+++ b/backend/scripts/verify_overlay_migrations.py
@@ -1,0 +1,313 @@
+"""Verify an installed migration overlay against the current core chain.
+
+The verifier is deliberately overlay-agnostic: it discovers providers through
+the public ``geolens.migrations`` entry-point contract and never imports a
+private package by name. It is intended for an overlay-owned CI job (or a
+locally built enterprise image) where the real overlay is already installed.
+
+It fails rather than skips when no overlay is present, upgrades every Alembic
+head through the production environment, checks that every discovered head was
+recorded, validates the co-owned OAuth/SAML schema, and runs Alembic's drift
+check. Public core CI does not fetch private source to run this command.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+from dataclasses import dataclass
+from importlib import metadata
+import os
+from pathlib import Path
+import sys
+from typing import Iterable
+
+from alembic import command
+from alembic.config import Config
+from alembic.script import ScriptDirectory
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import create_async_engine
+from sqlalchemy.pool import NullPool
+
+
+MIGRATION_ENTRY_POINT_GROUP = "geolens.migrations"
+SAML_COLUMNS = frozenset(
+    {"idp_entity_id", "idp_sso_url", "idp_certificate", "sp_entity_id"}
+)
+SUPPORTED_PROVIDER_TYPES = frozenset({"oidc", "google", "microsoft", "saml", "github"})
+DEFAULT_BACKEND_DIR = Path(__file__).resolve().parents[1]
+
+
+class OverlayMigrationVerificationError(RuntimeError):
+    """Raised when the installed overlay fails a migration contract."""
+
+
+@dataclass(frozen=True)
+class MigrationTopology:
+    core_heads: tuple[str, ...]
+    overlay_heads: tuple[str, ...]
+
+    @property
+    def all_heads(self) -> tuple[str, ...]:
+        return tuple(sorted((*self.core_heads, *self.overlay_heads)))
+
+
+@dataclass(frozen=True)
+class DatabaseState:
+    applied_heads: tuple[str, ...]
+    saml_columns: frozenset[str]
+    provider_constraint: str | None
+
+
+def discover_overlay_migration_paths(
+    entry_points: Iterable[object] | None = None,
+) -> tuple[Path, ...]:
+    """Load and validate every installed migration path provider."""
+    providers = list(
+        entry_points
+        if entry_points is not None
+        else metadata.entry_points(group=MIGRATION_ENTRY_POINT_GROUP)
+    )
+    if not providers:
+        raise OverlayMigrationVerificationError(
+            "no geolens.migrations entry point is installed; this verifier must "
+            "run in an image or environment containing the real overlay"
+        )
+
+    paths: list[Path] = []
+    for entry_point in providers:
+        name = str(getattr(entry_point, "name", entry_point))
+        try:
+            provider = entry_point.load()
+        except Exception as exc:
+            raise OverlayMigrationVerificationError(
+                f"failed to load migration entry point {name!r}: {exc}"
+            ) from exc
+        if not callable(provider):
+            raise OverlayMigrationVerificationError(
+                f"migration entry point {name!r} did not resolve to a callable"
+            )
+
+        try:
+            provided = provider()
+        except Exception as exc:
+            raise OverlayMigrationVerificationError(
+                f"migration path provider {name!r} failed: {exc}"
+            ) from exc
+        if isinstance(provided, (str, os.PathLike)):
+            provided_values = [provided]
+        else:
+            try:
+                provided_values = list(provided)
+            except TypeError as exc:
+                raise OverlayMigrationVerificationError(
+                    f"migration path provider {name!r} did not return an iterable"
+                ) from exc
+
+        provider_paths = [Path(value).resolve() for value in provided_values]
+        if not provider_paths:
+            raise OverlayMigrationVerificationError(
+                f"migration path provider {name!r} returned no paths"
+            )
+        missing = [path for path in provider_paths if not path.is_dir()]
+        if missing:
+            raise OverlayMigrationVerificationError(
+                f"migration path provider {name!r} returned missing directories: "
+                + ", ".join(str(path) for path in missing)
+            )
+        paths.extend(provider_paths)
+
+    # Preserve provider order while removing duplicate directories.
+    return tuple(dict.fromkeys(paths))
+
+
+def resolve_migration_topology(
+    backend_dir: Path,
+    overlay_paths: Iterable[Path],
+) -> MigrationTopology:
+    """Resolve core and overlay heads without running the Alembic environment."""
+    backend_dir = backend_dir.resolve()
+    core_versions = (backend_dir / "alembic" / "versions").resolve()
+    overlay_roots = tuple(path.resolve() for path in overlay_paths)
+
+    config = _alembic_config(backend_dir)
+    config.set_main_option("path_separator", "os")
+    config.set_main_option(
+        "version_locations",
+        os.pathsep.join(str(path) for path in (core_versions, *overlay_roots)),
+    )
+    scripts = ScriptDirectory.from_config(config)
+
+    core_heads: list[str] = []
+    overlay_heads: list[str] = []
+    for head in scripts.get_heads():
+        revision = scripts.get_revision(head)
+        if revision is None or revision.path is None:
+            raise OverlayMigrationVerificationError(
+                f"could not resolve source path for Alembic head {head!r}"
+            )
+        revision_path = Path(revision.path).resolve()
+        if revision_path.is_relative_to(core_versions):
+            core_heads.append(head)
+        elif any(revision_path.is_relative_to(root) for root in overlay_roots):
+            overlay_heads.append(head)
+        else:
+            raise OverlayMigrationVerificationError(
+                f"Alembic head {head!r} came from an unexpected path: {revision_path}"
+            )
+
+    if not core_heads:
+        raise OverlayMigrationVerificationError("the core migration head is missing")
+    if not overlay_heads:
+        raise OverlayMigrationVerificationError(
+            "no overlay migration head was resolved from the installed providers"
+        )
+    return MigrationTopology(tuple(sorted(core_heads)), tuple(sorted(overlay_heads)))
+
+
+def _alembic_config(backend_dir: Path) -> Config:
+    config = Config(str(backend_dir / "alembic.ini"))
+    config.set_main_option("script_location", str(backend_dir / "alembic"))
+    return config
+
+
+def upgrade_all_heads(backend_dir: Path) -> None:
+    """Exercise the production entry-point discovery path and migrate all heads."""
+    command.upgrade(_alembic_config(backend_dir), "heads")
+
+
+def check_model_drift(backend_dir: Path) -> None:
+    command.check(_alembic_config(backend_dir))
+
+
+async def read_database_state() -> DatabaseState:
+    """Read the post-migration contract from the configured database."""
+    from app.core.config import settings
+
+    engine = create_async_engine(
+        settings.database_url,
+        connect_args=settings.database_connect_args,
+        poolclass=NullPool,
+    )
+    try:
+        async with engine.connect() as connection:
+            heads_result = await connection.execute(
+                text(
+                    "SELECT version_num FROM catalog.alembic_version "
+                    "ORDER BY version_num"
+                )
+            )
+            heads = tuple(heads_result.scalars())
+            columns_result = await connection.execute(
+                text(
+                    """
+                    SELECT column_name
+                    FROM information_schema.columns
+                    WHERE table_schema = 'catalog'
+                      AND table_name = 'oauth_providers'
+                      AND column_name = ANY(CAST(:column_names AS text[]))
+                    """
+                ),
+                {"column_names": sorted(SAML_COLUMNS)},
+            )
+            columns = frozenset(columns_result.scalars())
+            constraint = (
+                await connection.execute(
+                    text(
+                        """
+                        SELECT pg_get_constraintdef(constraint_row.oid)
+                        FROM pg_catalog.pg_constraint AS constraint_row
+                        WHERE constraint_row.conname = 'chk_oauth_providers_type'
+                          AND constraint_row.conrelid =
+                              'catalog.oauth_providers'::regclass
+                        """
+                    )
+                )
+            ).scalar_one_or_none()
+            return DatabaseState(
+                applied_heads=heads,
+                saml_columns=columns,
+                provider_constraint=constraint,
+            )
+    finally:
+        await engine.dispose()
+
+
+def validate_database_state(
+    topology: MigrationTopology,
+    state: DatabaseState,
+) -> None:
+    expected_heads = set(topology.all_heads)
+    applied_heads = set(state.applied_heads)
+    if applied_heads != expected_heads:
+        raise OverlayMigrationVerificationError(
+            "applied Alembic heads do not match discovered heads: "
+            f"expected={sorted(expected_heads)}, applied={sorted(applied_heads)}"
+        )
+
+    missing_columns = SAML_COLUMNS - state.saml_columns
+    if missing_columns:
+        raise OverlayMigrationVerificationError(
+            "oauth_providers is missing overlay-compatible SAML columns: "
+            + ", ".join(sorted(missing_columns))
+        )
+
+    if state.provider_constraint is None:
+        raise OverlayMigrationVerificationError(
+            "chk_oauth_providers_type is missing from catalog.oauth_providers"
+        )
+    missing_types = {
+        provider_type
+        for provider_type in SUPPORTED_PROVIDER_TYPES
+        if f"'{provider_type}'" not in state.provider_constraint
+    }
+    if missing_types:
+        raise OverlayMigrationVerificationError(
+            "chk_oauth_providers_type omits supported provider types: "
+            + ", ".join(sorted(missing_types))
+        )
+
+
+def verify_overlay_migrations(backend_dir: Path = DEFAULT_BACKEND_DIR) -> None:
+    """Run the complete installed-overlay migration compatibility contract."""
+    backend_dir = backend_dir.resolve()
+    overlay_paths = discover_overlay_migration_paths()
+    topology = resolve_migration_topology(backend_dir, overlay_paths)
+
+    print("Discovered overlay migration paths:")
+    for path in overlay_paths:
+        print(f"  - {path}")
+    print(f"Core heads:    {', '.join(topology.core_heads)}")
+    print(f"Overlay heads: {', '.join(topology.overlay_heads)}")
+
+    upgrade_all_heads(backend_dir)
+    state = asyncio.run(read_database_state())
+    validate_database_state(topology, state)
+    check_model_drift(backend_dir)
+
+    print(
+        "Overlay migration verification passed: all heads applied, OAuth/SAML "
+        "schema converged, and Alembic reported no model drift."
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--backend-dir",
+        type=Path,
+        default=DEFAULT_BACKEND_DIR,
+        help="GeoLens backend directory containing alembic.ini (default: inferred)",
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        verify_overlay_migrations(args.backend_dir)
+    except Exception as exc:
+        print(f"Overlay migration verification failed: {exc}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -435,6 +435,11 @@ class TestEmptyStringToNone:
         s = _make_settings(geolens_edition="")
         assert s.geolens_edition is None
 
+    @pytest.mark.parametrize("value", ["", "   "])
+    def test_empty_embedding_dims_uses_default(self, value):
+        s = _make_settings(embedding_dims=value)
+        assert s.embedding_dims == 1536
+
     def test_geolens_edition_is_normalized_case_insensitively(self):
         s = _make_settings(geolens_edition=" Enterprise ")
         assert s.geolens_edition == "enterprise"

--- a/backend/tests/test_dormant_tenancy_migration_roundtrip.py
+++ b/backend/tests/test_dormant_tenancy_migration_roundtrip.py
@@ -1,7 +1,8 @@
 """Programmatic migration round-trip + OSS drift-gate regression for Phase 1207.
 
-Verifies the 0005_dormant_tenancy migration is reversible and leaves the schema
-in the exact state the ORM expects (no alembic check drift after upgrade).
+Verifies the 0005_dormant_tenancy migration is reversible while its substrate is
+empty, refuses to discard tenant-scoped data, and leaves the schema in the exact
+state the ORM expects (no alembic check drift after upgrade).
 
 Tests
 -----
@@ -10,6 +11,8 @@ B: after downgrade, the four partial unique indexes and tenant_id columns are ab
 C: after re-upgrade, the four partial indexes and tenant_id on the six shared tables
    are all present
 D: alembic check reports no drift after upgrade (OSS drift gate)
+E: tenant-scoped users and tenancy rows block downgrade atomically with an
+   actionable error instead of failing at a later unique constraint or losing data
 
 Notes
 -----
@@ -199,6 +202,124 @@ async def _fresh_query(query: str, params: dict | None = None):
             return result.fetchall()
     finally:
         await engine.dispose()
+
+
+async def _fresh_execute(query: str, params: dict | None = None) -> None:
+    """Run committed DML on a fresh autocommit connection."""
+    from sqlalchemy.ext.asyncio import create_async_engine
+
+    from app.core.config import settings
+
+    engine = create_async_engine(
+        settings.test_database_url,
+        isolation_level="AUTOCOMMIT",
+    )
+    try:
+        async with engine.connect() as conn:
+            await conn.execute(sa.text(query), params or {})
+    finally:
+        await engine.dispose()
+
+
+# ---------------------------------------------------------------------------
+# Test E: production-shaped tenant data blocks the destructive downgrade
+# ---------------------------------------------------------------------------
+
+
+@_SKIP_UNDER_OVERLAY
+class TestTenantDataDowngradeContract:
+    """0005 fails before DDL when reverting would discard tenant ownership."""
+
+    async def test_cross_tenant_collision_and_tenancy_rows_block_atomically(self):
+        """Valid cross-tenant duplicates remain intact after a blocked downgrade."""
+        import uuid
+
+        r = _run_alembic("upgrade", "head")
+        assert r.returncode == 0, f"upgrade head failed: {r.stderr}"
+        r = _run_alembic("downgrade", "0005_dormant_tenancy")
+        assert r.returncode == 0, f"setup downgrade to 0005 failed: {r.stderr}"
+
+        suffix = uuid.uuid4().hex
+        username = f"rollback-shared-{suffix}"
+        organization_id = uuid.uuid4()
+        user_ids = (uuid.uuid4(), uuid.uuid4())
+        tenant_ids = (uuid.uuid4(), uuid.uuid4())
+
+        try:
+            await _fresh_execute(
+                """
+                INSERT INTO catalog.organizations (id, name)
+                VALUES (:organization_id, :name)
+                """,
+                {
+                    "organization_id": organization_id,
+                    "name": f"Rollback organization {suffix}",
+                },
+            )
+            await _fresh_execute(
+                """
+                INSERT INTO catalog.users (id, username, email, tenant_id)
+                VALUES
+                    (:user_a, :username, :email_a, :tenant_a),
+                    (:user_b, :username, :email_b, :tenant_b)
+                """,
+                {
+                    "user_a": user_ids[0],
+                    "user_b": user_ids[1],
+                    "username": username,
+                    "email_a": f"rollback-a-{suffix}@example.test",
+                    "email_b": f"rollback-b-{suffix}@example.test",
+                    "tenant_a": tenant_ids[0],
+                    "tenant_b": tenant_ids[1],
+                },
+            )
+
+            versions_before = await _fresh_query(
+                "SELECT version_num FROM catalog.alembic_version ORDER BY version_num"
+            )
+            assert versions_before == [("0005_dormant_tenancy",)]
+            result = _run_alembic("downgrade", "0004_add_maps_legend_title")
+            combined = result.stdout + result.stderr
+            assert result.returncode != 0, (
+                "tenant data downgrade unexpectedly succeeded"
+            )
+            assert "Cannot downgrade 0005_dormant_tenancy" in combined
+            assert "catalog.organizations" in combined
+            assert "catalog.users.tenant_id" in combined
+
+            versions_after = await _fresh_query(
+                "SELECT version_num FROM catalog.alembic_version ORDER BY version_num"
+            )
+            assert versions_after == versions_before
+
+            users = await _fresh_query(
+                """
+                SELECT tenant_id
+                FROM catalog.users
+                WHERE username = :username
+                ORDER BY tenant_id
+                """,
+                {"username": username},
+            )
+            assert {row[0] for row in users} == set(tenant_ids)
+            organizations = await _fresh_query(
+                "SELECT id FROM catalog.organizations WHERE id = :organization_id",
+                {"organization_id": organization_id},
+            )
+            assert {row[0] for row in organizations} == {organization_id}
+        finally:
+            restored = _run_alembic("upgrade", "head")
+            assert restored.returncode == 0, (
+                f"restore upgrade failed: {restored.stderr}"
+            )
+            await _fresh_execute(
+                "DELETE FROM catalog.users WHERE username = :username",
+                {"username": username},
+            )
+            await _fresh_execute(
+                "DELETE FROM catalog.organizations WHERE id = :organization_id",
+                {"organization_id": organization_id},
+            )
 
 
 @_SKIP_UNDER_OVERLAY

--- a/backend/tests/test_embedding_vector_migration.py
+++ b/backend/tests/test_embedding_vector_migration.py
@@ -9,15 +9,14 @@ B: with EMBEDDING_DIMS=3072 (legal config, over pgvector's 2000-dim HNSW
    limit), the upgrade still exits 0, types the column vector(3072), and
    skips the index instead of failing (codex P1).
 C: with mixed-dimension rows (stale 1536-dim next to current 768-dim), the
-   configured dimension wins over max(stored) and only the stale row is
-   deleted (codex P2 round 4).
+   configured dimension wins over max(stored) and the regenerable cache is
+   cleared before the bounded-lock type transition.
 D: explicit config beats UNIFORM stale rows too — all-512-dim rows with
    EMBEDDING_DIMS=768 type the column vector(768) (codex P2 round 5).
 E: uniform stored rows beat only the built-in default — all-768-dim rows
-   with nothing configured keep their dimension and their rows.
+   with nothing configured select vector(768), then the cache is cleared.
 F: a deliberate EMBEDDING_DIMS=1536 (equal to the default) still counts as
-   explicit and beats uniform stale 768-dim rows (codex P2 round 7 —
-   detected via pydantic's model_fields_set, not a value comparison).
+   explicit and beats uniform stale 768-dim rows (codex P2 round 7).
 
 Notes
 -----
@@ -117,6 +116,18 @@ async def _hnsw_index_exists() -> bool:
         "AND indexname = 'ix_record_embeddings_hnsw'"
     )
     return bool(rows)
+
+
+async def _hnsw_index_is_valid() -> bool:
+    rows = await _fresh_query(
+        "SELECT idx.indisvalid AND idx.indisready "
+        "FROM pg_index AS idx "
+        "JOIN pg_class AS cls ON cls.oid = idx.indexrelid "
+        "JOIN pg_namespace AS ns ON ns.oid = cls.relnamespace "
+        "WHERE ns.nspname = 'catalog' "
+        "AND cls.relname = 'ix_record_embeddings_hnsw'"
+    )
+    return bool(rows and rows[0][0])
 
 
 def _enterprise_migrations_present() -> bool:
@@ -219,6 +230,7 @@ class TestEmbeddingVectorMigrationDims:
             assert r.returncode == 0, f"upgrade failed: {r.stderr}"
             assert await _embedding_column_type() == "vector(768)"
             assert await _hnsw_index_exists(), "HNSW should exist at 768 dims"
+            assert await _hnsw_index_is_valid(), "HNSW must be ready and valid"
         finally:
             await _restore_default_head()
 
@@ -255,7 +267,7 @@ class TestEmbeddingVectorMigrationDims:
             assert r.returncode == 0, f"upgrade failed: {r.stderr}"
             assert await _embedding_column_type() == "vector(768)"
             rows = await _fresh_query("SELECT count(*) FROM catalog.record_embeddings")
-            assert rows[0][0] == 1, "only the stale 1536-dim row should be deleted"
+            assert rows[0][0] == 0, "the regenerable embedding cache must be cleared"
         finally:
             await _restore_default_head()
 
@@ -280,9 +292,7 @@ class TestEmbeddingVectorMigrationDims:
             await _restore_default_head()
 
     async def test_uniform_stored_rows_beat_builtin_default(self):
-        """Uniform stored rows with nothing configured anywhere keep their
-        dimension — a local 768-dim model on default config must not have its
-        working rows deleted in favor of the built-in 1536."""
+        """Uniform stored rows choose the dimension before the cache is cleared."""
         try:
             r = _run_alembic("downgrade", _PRE_TYPED_REVISION)
             assert r.returncode == 0, f"downgrade failed: {r.stderr}"
@@ -296,14 +306,14 @@ class TestEmbeddingVectorMigrationDims:
             assert r.returncode == 0, f"upgrade failed: {r.stderr}"
             assert await _embedding_column_type() == "vector(768)"
             rows = await _fresh_query("SELECT count(*) FROM catalog.record_embeddings")
-            assert rows[0][0] == 2, "agreeing rows must survive the retype"
+            assert rows[0][0] == 0, "the bounded-lock transition clears cached rows"
         finally:
             await _restore_default_head()
 
     async def test_explicit_default_value_still_beats_stored_rows(self):
         """fix(#449, codex P2 round 7): EMBEDDING_DIMS=1536 set deliberately
-        equals the class default, but presence (model_fields_set) makes it
-        explicit — it must beat uniform stale 768-dim rows."""
+        equals the frozen fallback, but the exported variable's presence makes
+        it explicit — it must beat uniform stale 768-dim rows."""
         try:
             r = _run_alembic("downgrade", _PRE_TYPED_REVISION)
             assert r.returncode == 0, f"downgrade failed: {r.stderr}"
@@ -318,5 +328,25 @@ class TestEmbeddingVectorMigrationDims:
             assert await _embedding_column_type() == "vector(1536)"
             rows = await _fresh_query("SELECT count(*) FROM catalog.record_embeddings")
             assert rows[0][0] == 0, "stale 768-dim rows should be deleted"
+        finally:
+            await _restore_default_head()
+
+    async def test_already_typed_column_resumes_at_concurrent_index_build(self):
+        """A retry after the committed type transition recreates only the index."""
+        try:
+            r = _run_alembic("downgrade", _PRE_TYPED_REVISION)
+            assert r.returncode == 0, f"downgrade failed: {r.stderr}"
+            await _fresh_query("TRUNCATE catalog.record_embeddings")
+            await _fresh_query(
+                "ALTER TABLE catalog.record_embeddings "
+                "ALTER COLUMN embedding TYPE vector(768) "
+                "USING embedding::vector(768)"
+            )
+            await _fresh_query("DROP INDEX IF EXISTS catalog.ix_record_embeddings_hnsw")
+
+            r = _run_alembic("upgrade", "head")
+            assert r.returncode == 0, f"resumed upgrade failed: {r.stderr}"
+            assert await _embedding_column_type() == "vector(768)"
+            assert await _hnsw_index_is_valid()
         finally:
             await _restore_default_head()

--- a/backend/tests/test_embedding_vector_migration_config.py
+++ b/backend/tests/test_embedding_vector_migration_config.py
@@ -115,3 +115,19 @@ def test_migrate_service_receives_embedding_config(filename: str) -> None:
     environment = body["services"]["migrate"]["environment"]
     assert environment["EMBEDDING_DIMS"] == "${EMBEDDING_DIMS-}"
     assert environment["ENV_ONLY_CONFIG"] == "${ENV_ONLY_CONFIG:-false}"
+
+
+def test_vector_transition_is_bounded_and_concurrent() -> None:
+    source = _MIGRATION_PATH.read_text(encoding="utf-8")
+    assert "TRUNCATE catalog.record_embeddings" in source
+    assert "DELETE FROM catalog.record_embeddings" not in source
+    assert "autocommit_block()" in source
+    assert "CREATE INDEX CONCURRENTLY IF NOT EXISTS" in source
+
+
+def test_concurrent_index_recovery_rejects_invalid_same_name_index() -> None:
+    source = _MIGRATION_PATH.read_text(encoding="utf-8")
+    validity_check = source.index("idx.indisvalid AND idx.indisready")
+    invalid_drop = source.index("DROP INDEX CONCURRENTLY IF EXISTS")
+    concurrent_create = source.index("CREATE INDEX CONCURRENTLY IF NOT EXISTS")
+    assert validity_check < invalid_drop < concurrent_create

--- a/backend/tests/test_embedding_vector_migration_config.py
+++ b/backend/tests/test_embedding_vector_migration_config.py
@@ -119,6 +119,9 @@ def test_migrate_service_receives_embedding_config(filename: str) -> None:
 
 def test_vector_transition_is_bounded_and_concurrent() -> None:
     source = _MIGRATION_PATH.read_text(encoding="utf-8")
+    lock_timeout = source.index("set_config('lock_timeout', '5s', true)")
+    truncate = source.index("TRUNCATE catalog.record_embeddings")
+    assert lock_timeout < truncate
     assert "TRUNCATE catalog.record_embeddings" in source
     assert "DELETE FROM catalog.record_embeddings" not in source
     assert "autocommit_block()" in source

--- a/backend/tests/test_embedding_vector_migration_config.py
+++ b/backend/tests/test_embedding_vector_migration_config.py
@@ -1,0 +1,117 @@
+"""Static/unit coverage for migration 0012 configuration resolution."""
+
+from __future__ import annotations
+
+import ast
+import importlib.util
+from types import ModuleType
+
+import pytest
+import yaml
+
+from tests.repo_paths import repo_root
+
+_REPO_ROOT = repo_root(__file__)
+_MIGRATION_PATH = _REPO_ROOT / "backend/alembic/versions/0012_type_embedding_vector.py"
+
+
+@pytest.fixture
+def migration_module() -> ModuleType:
+    spec = importlib.util.spec_from_file_location(
+        "migration_0012_config_test", _MIGRATION_PATH
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_revision_has_no_application_imports() -> None:
+    """Topology-only Alembic commands must not initialize app Settings."""
+    tree = ast.parse(_MIGRATION_PATH.read_text(encoding="utf-8"))
+    imports = {
+        alias.name
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Import)
+        for alias in node.names
+    }
+    imports.update(
+        node.module
+        for node in ast.walk(tree)
+        if isinstance(node, ast.ImportFrom) and node.module is not None
+    )
+    assert not any(name == "app" or name.startswith("app.") for name in imports)
+
+
+@pytest.mark.parametrize("value", ["768", " 1536 ", "+3072"])
+def test_explicit_embedding_dims_accepts_bounded_integers(
+    monkeypatch: pytest.MonkeyPatch,
+    migration_module: ModuleType,
+    value: str,
+) -> None:
+    monkeypatch.setenv("EMBEDDING_DIMS", value)
+    assert migration_module._explicit_embedding_dims() == int(value)
+
+
+@pytest.mark.parametrize("value", [None, "", "   "])
+def test_explicit_embedding_dims_distinguishes_unset(
+    monkeypatch: pytest.MonkeyPatch,
+    migration_module: ModuleType,
+    value: str | None,
+) -> None:
+    if value is None:
+        monkeypatch.delenv("EMBEDDING_DIMS", raising=False)
+    else:
+        monkeypatch.setenv("EMBEDDING_DIMS", value)
+    assert migration_module._explicit_embedding_dims() is None
+
+
+@pytest.mark.parametrize("value", ["zero", "0", "4097"])
+def test_explicit_embedding_dims_rejects_invalid_values(
+    monkeypatch: pytest.MonkeyPatch,
+    migration_module: ModuleType,
+    value: str,
+) -> None:
+    monkeypatch.setenv("EMBEDDING_DIMS", value)
+    with pytest.raises(RuntimeError, match="integer from 1 to 4096"):
+        migration_module._explicit_embedding_dims()
+
+
+@pytest.mark.parametrize("value", ["true", "1", "YES", "on"])
+def test_env_only_parser_accepts_true_values(
+    monkeypatch: pytest.MonkeyPatch,
+    migration_module: ModuleType,
+    value: str,
+) -> None:
+    monkeypatch.setenv("ENV_ONLY_CONFIG", value)
+    assert migration_module._env_only_config_enabled() is True
+
+
+@pytest.mark.parametrize("value", [None, "", "false", "0", "NO", "off"])
+def test_env_only_parser_accepts_false_values(
+    monkeypatch: pytest.MonkeyPatch,
+    migration_module: ModuleType,
+    value: str | None,
+) -> None:
+    if value is None:
+        monkeypatch.delenv("ENV_ONLY_CONFIG", raising=False)
+    else:
+        monkeypatch.setenv("ENV_ONLY_CONFIG", value)
+    assert migration_module._env_only_config_enabled() is False
+
+
+def test_env_only_parser_rejects_ambiguous_values(
+    monkeypatch: pytest.MonkeyPatch,
+    migration_module: ModuleType,
+) -> None:
+    monkeypatch.setenv("ENV_ONLY_CONFIG", "sometimes")
+    with pytest.raises(RuntimeError, match="must be one of"):
+        migration_module._env_only_config_enabled()
+
+
+@pytest.mark.parametrize("filename", ["docker-compose.yml", "docker-compose.prod.yml"])
+def test_migrate_service_receives_embedding_config(filename: str) -> None:
+    body = yaml.safe_load((_REPO_ROOT / filename).read_text(encoding="utf-8"))
+    environment = body["services"]["migrate"]["environment"]
+    assert environment["EMBEDDING_DIMS"] == "${EMBEDDING_DIMS-}"
+    assert environment["ENV_ONLY_CONFIG"] == "${ENV_ONLY_CONFIG:-false}"

--- a/backend/tests/test_fk_support_indexes_database.py
+++ b/backend/tests/test_fk_support_indexes_database.py
@@ -1,0 +1,88 @@
+"""Live-schema invariants for leading foreign-key indexes at Alembic head."""
+
+from __future__ import annotations
+
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+
+EXPECTED_PARTIAL_INDEXES = {
+    "ix_collection_datasets_added_by": "added_by",
+    "ix_collections_created_by": "created_by",
+    "ix_dataset_versions_uploaded_by": "uploaded_by",
+    "ix_embed_tokens_created_by": "created_by",
+    "ix_map_share_tokens_created_by": "created_by",
+    "ix_maps_forked_from": "forked_from",
+    "ix_records_created_by": "created_by",
+    "ix_records_updated_by": "updated_by",
+}
+
+
+async def test_every_catalog_fk_has_a_valid_leading_index(
+    test_db_session: AsyncSession,
+) -> None:
+    """Parent deletes must never need a full child-table FK scan."""
+    result = await test_db_session.execute(
+        text(
+            """
+            SELECT constraint_row.conname,
+                   constraint_row.conrelid::regclass::text AS table_name
+            FROM pg_catalog.pg_constraint AS constraint_row
+            JOIN pg_catalog.pg_namespace AS namespace
+              ON namespace.oid = constraint_row.connamespace
+            WHERE constraint_row.contype = 'f'
+              AND namespace.nspname = 'catalog'
+              AND NOT EXISTS (
+                  SELECT 1
+                  FROM pg_catalog.pg_index AS index_row
+                  WHERE index_row.indrelid = constraint_row.conrelid
+                    AND index_row.indisvalid
+                    AND index_row.indisready
+                    AND index_row.indnkeyatts >= cardinality(constraint_row.conkey)
+                    AND NOT EXISTS (
+                        SELECT 1
+                        FROM generate_subscripts(constraint_row.conkey, 1)
+                             AS key_position(position)
+                        WHERE constraint_row.conkey[key_position.position]
+                              <> index_row.indkey[key_position.position - 1]
+                    )
+              )
+            ORDER BY table_name, constraint_row.conname
+            """
+        )
+    )
+    uncovered = [(row.conname, row.table_name) for row in result]
+    assert uncovered == [], f"foreign keys without a valid leading index: {uncovered}"
+
+
+async def test_audit_fk_indexes_are_partial_non_null_indexes(
+    test_db_session: AsyncSession,
+) -> None:
+    result = await test_db_session.execute(
+        text(
+            """
+            SELECT index_class.relname AS index_name,
+                   pg_get_expr(index_row.indpred, index_row.indrelid) AS predicate
+            FROM pg_catalog.pg_index AS index_row
+            JOIN pg_catalog.pg_class AS index_class
+              ON index_class.oid = index_row.indexrelid
+            JOIN pg_catalog.pg_namespace AS namespace
+              ON namespace.oid = index_class.relnamespace
+            WHERE namespace.nspname = 'catalog'
+              AND index_class.relname::text =
+                  ANY(CAST(:index_names AS text[]))
+              AND index_row.indisvalid
+              AND index_row.indisready
+            ORDER BY index_class.relname
+            """
+        ),
+        {"index_names": list(EXPECTED_PARTIAL_INDEXES)},
+    )
+    predicates = {row.index_name: row.predicate for row in result}
+    assert predicates.keys() == EXPECTED_PARTIAL_INDEXES.keys()
+
+    for index_name, column_name in EXPECTED_PARTIAL_INDEXES.items():
+        predicate = predicates[index_name]
+        assert predicate is not None, f"{index_name} is not partial"
+        normalized = predicate.replace('"', "").strip().strip("()").strip()
+        assert normalized == f"{column_name} IS NOT NULL"

--- a/backend/tests/test_fk_support_indexes_migration.py
+++ b/backend/tests/test_fk_support_indexes_migration.py
@@ -1,0 +1,167 @@
+"""Static invariants for migration 0017's nullable FK-support indexes.
+
+These tests intentionally need no database. The clean-DB Alembic gate remains
+the integration proof; this suite gives fast coverage for the complete index
+inventory, concurrent/resumable DDL, and matching ORM metadata.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from contextlib import contextmanager
+from pathlib import Path
+from types import SimpleNamespace
+
+from sqlalchemy import Index
+
+import app.modules.catalog.collections.models  # noqa: F401
+import app.modules.catalog.datasets.domain.models  # noqa: F401
+import app.modules.catalog.maps.models  # noqa: F401
+import app.modules.embed_tokens.models  # noqa: F401
+from app.core.db import Base
+
+
+EXPECTED_INDEXES = (
+    ("ix_collection_datasets_added_by", "collection_datasets", "added_by"),
+    ("ix_collections_created_by", "collections", "created_by"),
+    ("ix_dataset_versions_uploaded_by", "dataset_versions", "uploaded_by"),
+    ("ix_embed_tokens_created_by", "embed_tokens", "created_by"),
+    ("ix_map_share_tokens_created_by", "map_share_tokens", "created_by"),
+    ("ix_maps_forked_from", "maps", "forked_from"),
+    ("ix_records_created_by", "records", "created_by"),
+    ("ix_records_updated_by", "records", "updated_by"),
+)
+
+
+def _load_migration():
+    path = (
+        Path(__file__).resolve().parents[1]
+        / "alembic"
+        / "versions"
+        / "0017_add_fk_support_indexes.py"
+    )
+    spec = importlib.util.spec_from_file_location("migration_0017", path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _postgresql_predicate(index: Index) -> str:
+    predicate = index.dialect_options["postgresql"]["where"]
+    assert predicate is not None
+    return str(predicate)
+
+
+def test_orm_declares_every_partial_fk_support_index() -> None:
+    for index_name, table_name, column_name in EXPECTED_INDEXES:
+        table = Base.metadata.tables[f"catalog.{table_name}"]
+        matches = [index for index in table.indexes if index.name == index_name]
+        assert len(matches) == 1, f"missing or duplicate ORM index {index_name}"
+
+        index = matches[0]
+        assert [column.name for column in index.columns] == [column_name]
+        assert _postgresql_predicate(index) == f"{column_name} IS NOT NULL"
+
+
+class _FakeResult:
+    def __init__(self, row) -> None:
+        self._row = row
+
+    def one_or_none(self):
+        return self._row
+
+
+class _FakeBind:
+    def __init__(self, states: dict[str, tuple[bool, bool] | None]) -> None:
+        self._states = states
+        self.queries: list[str] = []
+
+    def execute(self, statement, params):
+        self.queries.append(str(statement))
+        state = self._states[params["index_name"]]
+        row = (
+            None
+            if state is None
+            else SimpleNamespace(indisvalid=state[0], indisready=state[1])
+        )
+        return _FakeResult(row)
+
+
+def test_upgrade_reuses_valid_indexes_and_repairs_invalid_ones(monkeypatch) -> None:
+    migration = _load_migration()
+    executed: list[str] = []
+    autocommit_entries = 0
+    states = {name: None for name, _table, _column in EXPECTED_INDEXES}
+    states["ix_collections_created_by"] = (True, True)
+    states["ix_records_created_by"] = (False, False)
+    bind = _FakeBind(states)
+
+    class FakeContext:
+        @contextmanager
+        def autocommit_block(self):
+            nonlocal autocommit_entries
+            autocommit_entries += 1
+            yield
+
+    monkeypatch.setattr(migration.op, "get_context", lambda: FakeContext())
+    monkeypatch.setattr(migration.op, "get_bind", lambda: bind)
+    monkeypatch.setattr(migration.op, "execute", executed.append)
+
+    migration.upgrade()
+
+    assert migration.FK_SUPPORT_INDEXES == EXPECTED_INDEXES
+    assert len(bind.queries) == len(EXPECTED_INDEXES)
+    assert all("pg_catalog.pg_index" in query for query in bind.queries)
+
+    # Six absent indexes and one invalid index are built; the valid one is
+    # untouched. Repairing the invalid index emits DROP then CREATE in the same
+    # autocommit block.
+    assert autocommit_entries == len(EXPECTED_INDEXES) - 1
+    assert not any("ix_collections_created_by" in sql for sql in executed)
+    assert (
+        executed.count(
+            'DROP INDEX CONCURRENTLY IF EXISTS catalog."ix_records_created_by"'
+        )
+        == 1
+    )
+
+    create_statements = [sql for sql in executed if sql.startswith("CREATE INDEX")]
+    expected_creates = [
+        item for item in EXPECTED_INDEXES if item[0] != "ix_collections_created_by"
+    ]
+    assert len(create_statements) == len(expected_creates)
+    for sql, (index_name, table_name, column_name) in zip(
+        create_statements, expected_creates, strict=True
+    ):
+        assert sql == (
+            f'CREATE INDEX CONCURRENTLY IF NOT EXISTS "{index_name}" '
+            f'ON catalog."{table_name}" ("{column_name}") '
+            f'WHERE "{column_name}" IS NOT NULL'
+        )
+
+
+def test_downgrade_uses_concurrent_resumable_ddl(monkeypatch) -> None:
+    migration = _load_migration()
+    executed: list[str] = []
+    autocommit_entries = 0
+
+    class FakeContext:
+        @contextmanager
+        def autocommit_block(self):
+            nonlocal autocommit_entries
+            autocommit_entries += 1
+            yield
+
+    monkeypatch.setattr(migration.op, "get_context", lambda: FakeContext())
+    monkeypatch.setattr(migration.op, "execute", executed.append)
+
+    migration.downgrade()
+
+    assert autocommit_entries == 1
+    assert migration.FK_SUPPORT_INDEXES == EXPECTED_INDEXES
+    assert len(executed) == len(EXPECTED_INDEXES)
+    for sql, (index_name, _table_name, _column_name) in zip(
+        executed, reversed(EXPECTED_INDEXES), strict=True
+    ):
+        assert sql == f'DROP INDEX CONCURRENTLY IF EXISTS catalog."{index_name}"'

--- a/backend/tests/test_oauth_github_migration.py
+++ b/backend/tests/test_oauth_github_migration.py
@@ -7,12 +7,14 @@ Verifies the 0010_oauth_github_provider_type migration:
 
 Tests
 -----
-A: upgrade head → downgrade -1 → upgrade head all exit 0 (reversibility)
+A: upgrade head → downgrade explicitly below 0010 → upgrade head all exit 0
+   when no GitHub providers exist
 B: after upgrade head, a github-typed row inserts successfully into
    catalog.oauth_providers (constraint admits 'github')
 C: after upgrade head, a saml-typed row still satisfies the constraint;
-   after downgrade -1, a saml-typed row still satisfies it (saml not dropped)
+   after downgrade below 0010, a saml-typed row still satisfies it (saml not dropped)
 D: alembic heads reports a single head; alembic check reports no drift
+E: a live GitHub provider blocks downgrade atomically and remains unchanged
 
 Notes
 -----
@@ -163,9 +165,9 @@ async def _fresh_execute(query: str, params: dict | None = None) -> None:
 class TestMigrationRoundTripExitCodes:
     """0010_oauth_github_provider_type round-trips with no subprocess errors.
 
-    Downgrade recreates the constraint without 'github' (but keeps 'saml'),
-    so both downgrade and re-upgrade are real DDL operations — unlike the
-    NO-OP downgrade pattern in 0008/0009.
+    Downgrade recreates the constraint without 'github' (but keeps 'saml') when
+    the documented no-GitHub-provider precondition is satisfied, so both
+    downgrade and re-upgrade are real DDL operations.
 
     The ENTIRE round-trip (upgrade -> downgrade -> re-upgrade) runs in ONE test
     method with the re-upgrade in a finally. It MUST NOT be split into separate
@@ -190,9 +192,8 @@ class TestMigrationRoundTripExitCodes:
         )
 
         try:
-            # Delete any github-typed rows so downgrade's ADD CONSTRAINT does not
-            # fail with a CHECK violation (sibling provider-create tests use the
-            # same per-worker DB as the migration subprocess).
+            # Satisfy the migration's explicit precondition. Sibling provider-create
+            # tests use the same per-worker DB as the migration subprocess.
             async def _cleanup():
                 await _fresh_execute(
                     "DELETE FROM catalog.oauth_providers WHERE provider_type = 'github'"
@@ -200,9 +201,9 @@ class TestMigrationRoundTripExitCodes:
 
             asyncio.run(_cleanup())
 
-            r = _run_alembic("downgrade", "-1")
+            r = _run_alembic("downgrade", "0009_email_verification")
             assert r.returncode == 0, (
-                f"alembic downgrade -1 failed (rc={r.returncode}):\n"
+                f"alembic downgrade to 0009 failed (rc={r.returncode}):\n"
                 f"stdout: {r.stdout}\nstderr: {r.stderr}"
             )
         finally:
@@ -283,6 +284,86 @@ class TestGithubConstraintAfterUpgrade:
         assert "saml" in constraint_def, (
             f"'saml' missing from constraint definition after upgrade: {constraint_def}"
         )
+
+
+# ---------------------------------------------------------------------------
+# Test E: live GitHub providers block downgrade atomically
+# ---------------------------------------------------------------------------
+
+
+@_SKIP_UNDER_OVERLAY
+class TestGithubProviderDowngradeContract:
+    """A live GitHub provider is preserved by a blocked downgrade."""
+
+    async def test_live_provider_blocks_downgrade_atomically(self):
+        """Preflight fails before constraint DDL and preserves version and data."""
+        import uuid
+
+        r = _run_alembic("upgrade", "head")
+        assert r.returncode == 0, f"upgrade head failed: {r.stderr}"
+        r = _run_alembic("downgrade", "0010_oauth_github_provider_type")
+        assert r.returncode == 0, f"setup downgrade to 0010 failed: {r.stderr}"
+
+        slug = f"rollback-github-{uuid.uuid4().hex[:12]}"
+        try:
+            await _fresh_execute(
+                """
+                INSERT INTO catalog.oauth_providers
+                    (slug, display_name, provider_type, client_id,
+                     client_secret_encrypted, scopes, default_role, enabled)
+                VALUES
+                    (:slug, 'Rollback GitHub', 'github', 'rollback-client-id',
+                     'rollback-secret-encrypted', 'read:user user:email',
+                     'viewer', true)
+                """,
+                {"slug": slug},
+            )
+            versions_before = await _fresh_query(
+                "SELECT version_num FROM catalog.alembic_version ORDER BY version_num"
+            )
+            assert versions_before == [("0010_oauth_github_provider_type",)]
+
+            result = _run_alembic("downgrade", "0009_email_verification")
+            combined = result.stdout + result.stderr
+            assert result.returncode != 0, "live-provider downgrade unexpectedly passed"
+            assert "Cannot downgrade 0010_oauth_github_provider_type" in combined
+            assert "will not delete or coerce provider credentials" in combined
+
+            versions_after = await _fresh_query(
+                "SELECT version_num FROM catalog.alembic_version ORDER BY version_num"
+            )
+            assert versions_after == versions_before
+
+            providers = await _fresh_query(
+                """
+                SELECT provider_type, client_id, client_secret_encrypted
+                FROM catalog.oauth_providers
+                WHERE slug = :slug
+                """,
+                {"slug": slug},
+            )
+            assert [tuple(row) for row in providers] == [
+                ("github", "rollback-client-id", "rollback-secret-encrypted")
+            ]
+
+            rows = await _fresh_query(
+                """
+                SELECT pg_get_constraintdef(oid)
+                FROM pg_constraint
+                WHERE conname = 'chk_oauth_providers_type'
+                  AND conrelid = 'catalog.oauth_providers'::regclass
+                """
+            )
+            assert rows and "github" in rows[0][0]
+        finally:
+            restored = _run_alembic("upgrade", "head")
+            assert restored.returncode == 0, (
+                f"restore upgrade failed: {restored.stderr}"
+            )
+            await _fresh_execute(
+                "DELETE FROM catalog.oauth_providers WHERE slug = :slug",
+                {"slug": slug},
+            )
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_record_translations_migration.py
+++ b/backend/tests/test_record_translations_migration.py
@@ -94,6 +94,7 @@ def test_upgrade_uses_committed_not_valid_then_targeted_validate() -> None:
     validate = upgrade.index("VALIDATE CONSTRAINT")
 
     assert upgrade.count("autocommit_block()") == 2
+    assert upgrade.count("set_config('lock_timeout', '5s', true)") == 2
     assert not_valid < targeted_update < validate
     assert "op.create_check_constraint" not in upgrade
 

--- a/backend/tests/test_record_translations_migration.py
+++ b/backend/tests/test_record_translations_migration.py
@@ -1,0 +1,227 @@
+"""Focused regression coverage for migration 0014's online-safe prefix."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from importlib.metadata import entry_points
+from pathlib import Path
+
+import pytest
+import sqlalchemy as sa
+
+from tests.repo_paths import repo_root
+
+_REPO_ROOT = repo_root(__file__)
+_BACKEND_DIR = _REPO_ROOT / "backend"
+_ALEMBIC_INI = _BACKEND_DIR / "alembic.ini"
+_MIGRATION_PATH = _BACKEND_DIR / "alembic/versions/0014_record_translations.py"
+_PRE_TRANSLATIONS_REVISION = "0013_backfill_geoparquet_distributions"
+_TITLE_PREFIX = "migration-0014-lock-test-"
+
+
+def _enterprise_migrations_present() -> bool:
+    for entry_point in entry_points(group="geolens.migrations"):
+        try:
+            provider = entry_point.load()
+            if callable(provider) and any(Path(path).is_dir() for path in provider()):
+                return True
+        except Exception:
+            pass
+    return False
+
+
+_SKIP_UNDER_OVERLAY = pytest.mark.skipif(
+    _enterprise_migrations_present(),
+    reason="OSS migration round-trip runs in the no-overlay migration job",
+)
+
+
+def _run_alembic(*args: str) -> subprocess.CompletedProcess:
+    import os
+
+    from app.core.config import settings
+
+    environment = os.environ.copy()
+    environment["PYTHONPATH"] = str(_BACKEND_DIR)
+    environment["POSTGRES_DB"] = settings.postgres_db_test
+    return subprocess.run(
+        [sys.executable, "-m", "alembic", "-c", str(_ALEMBIC_INI), *args],
+        capture_output=True,
+        text=True,
+        env=environment,
+        cwd=str(_BACKEND_DIR),
+    )
+
+
+async def _fresh_query(query: str, params: dict | None = None):
+    from sqlalchemy.ext.asyncio import create_async_engine
+
+    from app.core.config import settings
+
+    engine = create_async_engine(
+        settings.test_database_url,
+        isolation_level="AUTOCOMMIT",
+    )
+    try:
+        async with engine.connect() as connection:
+            result = await connection.execute(sa.text(query), params or {})
+            return result.fetchall() if result.returns_rows else None
+    finally:
+        await engine.dispose()
+
+
+async def _cleanup_test_objects() -> None:
+    await _fresh_query(
+        "DROP TRIGGER IF EXISTS migration_0014_count_language_updates "
+        "ON catalog.records"
+    )
+    await _fresh_query(
+        "DROP FUNCTION IF EXISTS catalog.migration_0014_count_language_updates()"
+    )
+    await _fresh_query("DROP TABLE IF EXISTS catalog.migration_0014_update_counter")
+    await _fresh_query(
+        "DELETE FROM catalog.records WHERE title LIKE :p",
+        {"p": f"{_TITLE_PREFIX}%"},
+    )
+
+
+def test_upgrade_uses_committed_not_valid_then_targeted_validate() -> None:
+    source = _MIGRATION_PATH.read_text(encoding="utf-8")
+    upgrade = source[source.index("def upgrade()") : source.index("def downgrade()")]
+    not_valid = upgrade.index("NOT VALID")
+    targeted_update = upgrade.index("IS DISTINCT FROM")
+    validate = upgrade.index("VALIDATE CONSTRAINT")
+
+    assert upgrade.count("autocommit_block()") == 2
+    assert not_valid < targeted_update < validate
+    assert "op.create_check_constraint" not in upgrade
+
+
+@_SKIP_UNDER_OVERLAY
+async def test_upgrade_normalizes_legacy_values_and_validates_constraint() -> None:
+    try:
+        result = _run_alembic("downgrade", _PRE_TRANSLATIONS_REVISION)
+        assert result.returncode == 0, result.stderr
+        await _cleanup_test_objects()
+        await _fresh_query(
+            "CREATE TABLE catalog.migration_0014_update_counter "
+            "(updates integer NOT NULL)"
+        )
+        await _fresh_query(
+            "INSERT INTO catalog.migration_0014_update_counter VALUES (0)"
+        )
+        await _fresh_query(
+            """
+            CREATE FUNCTION catalog.migration_0014_count_language_updates()
+            RETURNS trigger
+            LANGUAGE plpgsql
+            AS $$
+            BEGIN
+              UPDATE catalog.migration_0014_update_counter
+              SET updates = updates + 1;
+              RETURN NEW;
+            END
+            $$
+            """
+        )
+        await _fresh_query(
+            """
+            CREATE TRIGGER migration_0014_count_language_updates
+            BEFORE UPDATE OF language ON catalog.records
+            FOR EACH ROW
+            WHEN (OLD.title LIKE 'migration-0014-lock-test-%')
+            EXECUTE FUNCTION catalog.migration_0014_count_language_updates()
+            """
+        )
+        # Production-shaped skew: most rows are already canonical and must not
+        # be rewritten merely because the migration scans the table.
+        await _fresh_query(
+            """
+            INSERT INTO catalog.records (title, language, visibility, record_status)
+            SELECT :p || 'bulk-' || n, 'fr-ca', 'private', 'active'
+            FROM generate_series(1, 1000) AS n
+            """,
+            {"p": _TITLE_PREFIX},
+        )
+        await _fresh_query(
+            """
+            INSERT INTO catalog.records (title, language, visibility, record_status)
+            VALUES
+              (:p || 'upper', 'EN', 'private', 'active'),
+              (:p || 'underscore', 'pt_BR', 'private', 'active'),
+              (:p || 'blank', '   ', 'private', 'active'),
+              (:p || 'freeform', 'bad value', 'private', 'active'),
+              (:p || 'canonical', 'fr-ca', 'private', 'active')
+            """,
+            {"p": _TITLE_PREFIX},
+        )
+
+        result = _run_alembic("upgrade", "heads")
+        assert result.returncode == 0, result.stderr
+        rows = await _fresh_query(
+            """
+            SELECT title, language
+            FROM catalog.records
+            WHERE title LIKE :p
+              AND title NOT LIKE :bulk
+            ORDER BY title
+            """,
+            {
+                "p": f"{_TITLE_PREFIX}%",
+                "bulk": f"{_TITLE_PREFIX}bulk-%",
+            },
+        )
+        assert dict(rows) == {
+            f"{_TITLE_PREFIX}blank": "en",
+            f"{_TITLE_PREFIX}canonical": "fr-ca",
+            f"{_TITLE_PREFIX}freeform": "en",
+            f"{_TITLE_PREFIX}underscore": "pt-BR",
+            f"{_TITLE_PREFIX}upper": "en",
+        }
+        constraint = await _fresh_query(
+            """
+            SELECT convalidated
+            FROM pg_constraint
+            WHERE conrelid = 'catalog.records'::regclass
+              AND conname = 'chk_records_language_tag'
+            """
+        )
+        assert constraint == [(True,)]
+        update_count = await _fresh_query(
+            "SELECT updates FROM catalog.migration_0014_update_counter"
+        )
+        assert update_count == [(4,)], "only four non-canonical rows should update"
+    finally:
+        _run_alembic("upgrade", "heads")
+        await _cleanup_test_objects()
+
+
+@_SKIP_UNDER_OVERLAY
+async def test_upgrade_retries_after_committed_not_valid_prefix() -> None:
+    try:
+        result = _run_alembic("downgrade", _PRE_TRANSLATIONS_REVISION)
+        assert result.returncode == 0, result.stderr
+        await _fresh_query(
+            "ALTER TABLE catalog.records ALTER COLUMN language TYPE VARCHAR(35)"
+        )
+        await _fresh_query(
+            "ALTER TABLE catalog.records "
+            "ADD CONSTRAINT chk_records_language_tag "
+            "CHECK (language IS NULL OR "
+            "language ~ '^[a-z]{2,3}(-[A-Za-z0-9]{2,8})*$') NOT VALID"
+        )
+
+        result = _run_alembic("upgrade", "heads")
+        assert result.returncode == 0, result.stderr
+        constraint = await _fresh_query(
+            """
+            SELECT convalidated
+            FROM pg_constraint
+            WHERE conrelid = 'catalog.records'::regclass
+              AND conname = 'chk_records_language_tag'
+            """
+        )
+        assert constraint == [(True,)]
+    finally:
+        _run_alembic("upgrade", "heads")

--- a/backend/tests/test_record_translations_migration.py
+++ b/backend/tests/test_record_translations_migration.py
@@ -118,8 +118,10 @@ async def test_upgrade_normalizes_legacy_values_and_validates_constraint() -> No
             LANGUAGE plpgsql
             AS $$
             BEGIN
-              UPDATE catalog.migration_0014_update_counter
-              SET updates = updates + 1;
+              IF NEW.title LIKE 'migration-0014-lock-test-%' THEN
+                UPDATE catalog.migration_0014_update_counter
+                SET updates = updates + 1;
+              END IF;
               RETURN NEW;
             END
             $$
@@ -128,9 +130,8 @@ async def test_upgrade_normalizes_legacy_values_and_validates_constraint() -> No
         await _fresh_query(
             """
             CREATE TRIGGER migration_0014_count_language_updates
-            BEFORE UPDATE OF language ON catalog.records
+            BEFORE UPDATE ON catalog.records
             FOR EACH ROW
-            WHEN (OLD.title LIKE 'migration-0014-lock-test-%')
             EXECUTE FUNCTION catalog.migration_0014_count_language_updates()
             """
         )

--- a/backend/tests/test_tenant_rls_migration.py
+++ b/backend/tests/test_tenant_rls_migration.py
@@ -7,7 +7,8 @@ B: after upgrade, all 6 policies exist in pg_policies with the correct qual +
    with_check; NEITHER contains IS NULL (no fail-open escape)
 C: after upgrade, relrowsecurity = false AND relforcerowsecurity = false on all
    6 tables (migration defines policies but does NOT enable RLS)
-D: downgrade drops all 6 policies; re-upgrade re-creates them (reversibility)
+D: downgrade disables/unforces runtime-activated RLS before dropping all 6
+   policies; re-upgrade re-creates the policies without re-enabling RLS
 E: alembic check — no drift after upgrade (policies are raw SQL, invisible to
    autogenerate, so check remains clean)
 F: apply_tenancy_rls — single_tenant: relforcerowsecurity stays false (no-op)
@@ -168,6 +169,29 @@ async def _get_rls_state() -> dict[str, dict[str, bool]]:
         row[0]: {"relrowsecurity": row[1], "relforcerowsecurity": row[2]}
         for row in rows
     }
+
+
+async def _enable_rls_on_all() -> None:
+    """Enable + force RLS on all 6 tables (runtime-state setup helper)."""
+    from sqlalchemy.ext.asyncio import create_async_engine
+
+    from app.core.config import settings
+
+    engine = create_async_engine(
+        settings.test_database_url,
+        isolation_level="AUTOCOMMIT",
+    )
+    try:
+        async with engine.connect() as conn:
+            for table in _SIX_TABLES:
+                await conn.execute(
+                    sa.text(f"ALTER TABLE catalog.{table} ENABLE ROW LEVEL SECURITY")
+                )
+                await conn.execute(
+                    sa.text(f"ALTER TABLE catalog.{table} FORCE ROW LEVEL SECURITY")
+                )
+    finally:
+        await engine.dispose()
 
 
 async def _disable_rls_on_all() -> None:
@@ -397,32 +421,46 @@ class TestPoliciesRoundTrip:
     """
 
     async def test_policies_absent_after_downgrade(self):
-        """After downgrade to 0005, all 6 policies are gone from pg_policies.
+        """Downgrade disables runtime RLS before removing all 6 policies.
 
         The policies are defined in 0006; downgrading to 0005 (explicitly, so
-        the target is head-independent) removes them.
+        the target is head-independent) removes them without leaving the tables
+        in a policy-free deny-all state.
         """
-        # Downgrade to 0005 explicitly (below the 0006 policy migration). Using an
-        # explicit target instead of relative -N steps keeps this head-robust: new
-        # head migrations (e.g. 0008_oauth_saml_columns) no longer shift the offset
-        # and silently stop above 0005, leaving the policies in place.
-        r1 = _run_alembic("downgrade", "0005_dormant_tenancy")
-        assert r1.returncode == 0, f"downgrade to 0005 failed: {r1.stderr}"
+        r0 = _run_alembic("upgrade", "head")
+        assert r0.returncode == 0, f"upgrade head failed: {r0.stderr}"
 
-        rows = await _fresh_query(
-            """
-            SELECT policyname FROM pg_policies
-            WHERE schemaname = 'catalog'
-              AND policyname = ANY(:names)
-            """,
-            {"names": _POLICY_NAMES},
-        )
-        found = {row[0] for row in rows}
-        assert not found, f"Policies still present after downgrade to 0005: {found}"
+        await _enable_rls_on_all()
+        try:
+            # Downgrade to 0005 explicitly (below the 0006 policy migration). Using
+            # an explicit target keeps this head-robust as new revisions are added.
+            r1 = _run_alembic("downgrade", "0005_dormant_tenancy")
+            assert r1.returncode == 0, f"downgrade to 0005 failed: {r1.stderr}"
 
-        # Restore head for subsequent tests.
-        r3 = _run_alembic("upgrade", "head")
-        assert r3.returncode == 0, f"re-upgrade failed: {r3.stderr}"
+            rows = await _fresh_query(
+                """
+                SELECT policyname FROM pg_policies
+                WHERE schemaname = 'catalog'
+                  AND policyname = ANY(:names)
+                """,
+                {"names": _POLICY_NAMES},
+            )
+            found = {row[0] for row in rows}
+            assert not found, f"Policies still present after downgrade to 0005: {found}"
+
+            state = await _get_rls_state()
+            assert len(state) == 6, f"Expected 6 tables, got: {list(state)}"
+            for table, flags in state.items():
+                assert flags["relrowsecurity"] is False, (
+                    f"RLS remains enabled without a policy on {table}"
+                )
+                assert flags["relforcerowsecurity"] is False, (
+                    f"RLS remains forced without a policy on {table}"
+                )
+        finally:
+            await _disable_rls_on_all()
+            restored = _run_alembic("upgrade", "head")
+            assert restored.returncode == 0, f"re-upgrade failed: {restored.stderr}"
 
     async def test_policies_present_after_reupgrade(self):
         """After re-upgrade, all 6 policies exist again."""

--- a/backend/tests/test_verify_overlay_migrations.py
+++ b/backend/tests/test_verify_overlay_migrations.py
@@ -1,0 +1,180 @@
+"""No-database self-tests for the install-agnostic overlay verifier."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+import scripts.verify_overlay_migrations as verifier_module
+from scripts.verify_overlay_migrations import (
+    DatabaseState,
+    MigrationTopology,
+    OverlayMigrationVerificationError,
+    SAML_COLUMNS,
+    discover_overlay_migration_paths,
+    read_database_state,
+    resolve_migration_topology,
+    validate_database_state,
+)
+
+
+class _FakeEntryPoint:
+    def __init__(self, name: str, provider=None, error: Exception | None = None):
+        self.name = name
+        self._provider = provider
+        self._error = error
+
+    def load(self):
+        if self._error is not None:
+            raise self._error
+        return self._provider
+
+
+def test_discovery_requires_a_real_installed_entry_point() -> None:
+    with pytest.raises(
+        OverlayMigrationVerificationError, match="no geolens.migrations"
+    ):
+        discover_overlay_migration_paths([])
+
+
+def test_discovery_validates_and_deduplicates_provider_paths(tmp_path: Path) -> None:
+    versions = tmp_path / "overlay" / "versions"
+    versions.mkdir(parents=True)
+    entry_point = _FakeEntryPoint(
+        "fixture-overlay", lambda: [str(versions), str(versions)]
+    )
+
+    assert discover_overlay_migration_paths([entry_point]) == (versions.resolve(),)
+
+
+def test_discovery_surfaces_broken_installed_overlay() -> None:
+    entry_point = _FakeEntryPoint(
+        "broken-overlay", error=ImportError("missing overlay submodule")
+    )
+    with pytest.raises(
+        OverlayMigrationVerificationError, match="broken-overlay.*missing overlay"
+    ):
+        discover_overlay_migration_paths([entry_point])
+
+
+def test_topology_resolves_core_and_fixture_overlay_heads(tmp_path: Path) -> None:
+    backend_dir = Path(__file__).resolve().parents[1]
+    versions = tmp_path / "versions"
+    versions.mkdir()
+    (versions / "fixture_overlay_head.py").write_text(
+        "\n".join(
+            (
+                'revision = "fixture_overlay_head"',
+                'down_revision = "0002_procrastinate"',
+                'branch_labels = ("fixture_overlay",)',
+                "depends_on = None",
+                "def upgrade(): pass",
+                "def downgrade(): pass",
+            )
+        )
+    )
+
+    topology = resolve_migration_topology(backend_dir, [versions])
+
+    assert len(topology.core_heads) == 1
+    assert topology.overlay_heads == ("fixture_overlay_head",)
+
+
+def _valid_state() -> tuple[MigrationTopology, DatabaseState]:
+    topology = MigrationTopology(
+        core_heads=("core_head",),
+        overlay_heads=("fixture_overlay_head",),
+    )
+    state = DatabaseState(
+        applied_heads=topology.all_heads,
+        saml_columns=SAML_COLUMNS,
+        provider_constraint=(
+            "CHECK (provider_type IN ('oidc', 'google', 'microsoft', 'saml', 'github'))"
+        ),
+    )
+    return topology, state
+
+
+def test_database_contract_accepts_converged_heads_and_provider_union() -> None:
+    topology, state = _valid_state()
+    validate_database_state(topology, state)
+
+
+def test_database_contract_rejects_a_dropped_overlay_provider_type() -> None:
+    topology, state = _valid_state()
+    broken = DatabaseState(
+        applied_heads=state.applied_heads,
+        saml_columns=state.saml_columns,
+        provider_constraint=(
+            "CHECK (provider_type IN ('oidc', 'google', 'microsoft', 'saml'))"
+        ),
+    )
+
+    with pytest.raises(OverlayMigrationVerificationError, match="github"):
+        validate_database_state(topology, broken)
+
+
+def test_database_contract_rejects_a_vacuously_missing_overlay_head() -> None:
+    topology, state = _valid_state()
+    broken = DatabaseState(
+        applied_heads=topology.core_heads,
+        saml_columns=state.saml_columns,
+        provider_constraint=state.provider_constraint,
+    )
+
+    with pytest.raises(
+        OverlayMigrationVerificationError, match="applied Alembic heads"
+    ):
+        validate_database_state(topology, broken)
+
+
+async def test_database_state_reader_is_side_effect_free(monkeypatch) -> None:
+    topology, expected = _valid_state()
+
+    class _Result:
+        def __init__(self, *, scalars=(), scalar=None):
+            self._scalars = scalars
+            self._scalar = scalar
+
+        def scalars(self):
+            return iter(self._scalars)
+
+        def scalar_one_or_none(self):
+            return self._scalar
+
+    results = iter(
+        (
+            _Result(scalars=topology.all_heads),
+            _Result(scalars=SAML_COLUMNS),
+            _Result(scalar=expected.provider_constraint),
+        )
+    )
+
+    class _Connection:
+        async def execute(self, _statement, _params=None):
+            return next(results)
+
+    class _ConnectionContext:
+        async def __aenter__(self):
+            return _Connection()
+
+        async def __aexit__(self, _exc_type, _exc, _traceback):
+            return False
+
+    class _Engine:
+        disposed = False
+
+        def connect(self):
+            return _ConnectionContext()
+
+        async def dispose(self):
+            self.disposed = True
+
+    engine = _Engine()
+    monkeypatch.setattr(
+        verifier_module, "create_async_engine", lambda *_args, **_kwargs: engine
+    )
+
+    assert await read_database_state() == expected
+    assert engine.disposed is True

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -205,6 +205,11 @@ services:
     environment:
       <<: [*db-env, *auth-env, *db-ssl-env, *edition-env]
       PYTHONPATH: /app
+      # Migration 0012 resolves the vector typmod before the API starts. Keep
+      # an unset dimension empty so stored vectors can still win over the
+      # built-in 1536 fallback; an explicitly supplied 1536 remains explicit.
+      EMBEDDING_DIMS: "${EMBEDDING_DIMS-}"
+      ENV_ONLY_CONFIG: "${ENV_ONLY_CONFIG:-false}"
     depends_on:
       db:
         condition: service_healthy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -225,6 +225,11 @@ services:
     environment:
       <<: [*db-env, *auth-env, *db-ssl-env, *edition-env]
       PYTHONPATH: /app
+      # Migration 0012 resolves the vector typmod before the API starts. Keep
+      # an unset dimension empty so stored vectors can still win over the
+      # built-in 1536 fallback; an explicitly supplied 1536 remains explicit.
+      EMBEDDING_DIMS: "${EMBEDDING_DIMS-}"
+      ENV_ONLY_CONFIG: "${ENV_ONLY_CONFIG:-false}"
     depends_on:
       db:
         condition: service_healthy


### PR DESCRIPTION
## Summary

Remediates all nine findings from the 2026-07-14 migration audit. The changes make production-shaped downgrades explicit and safe, bound strong-lock acquisition, move large-table work to retryable/concurrent paths, close foreign-key index gaps, and add a real-overlay compatibility verifier.

## Root cause

Several historical downgrades assumed empty tables or ignored runtime RLS state; two forward migrations combined large-table work with strong DDL locks; migration `0012` depended on mutable application settings; attribution foreign keys had no systematic index invariant; and core/enterprise migration compatibility had no executable contract.

## Changes

- Block destructive `0005` and `0010` downgrades before DDL when tenant-scoped or GitHub-provider data needs operator-directed consolidation.
- Disable and unforce runtime RLS before `0006` drops tenant policies.
- Make `0012` configuration migration-local, clear the regenerable embedding cache before the vector cutover, cap strong-lock acquisition at five seconds, and build/repair HNSW concurrently.
- Split `0014` into committed `NOT VALID`, targeted normalization, and bounded-lock validation phases.
- Add migration `0017` plus ORM parity for eight partial, leading-column foreign-key indexes.
- Correct stale HNSW revision references and document the embedding backfill requirement.
- Add an overlay-agnostic verifier that discovers the installed `geolens.migrations` provider, upgrades every head, validates the shared OAuth/SAML contract, and runs `alembic check`.
- Pass `EMBEDDING_DIMS` and `ENV_ONLY_CONFIG` into the migrate service in development and production Compose files.

## Impact

- **Schema:** adds eight concurrent partial indexes; no API/OpenAPI shape change.
- **Configuration:** the migrate service now receives the two existing embedding configuration variables.
- **Operations:** on databases that have not yet applied `0012`, the migration clears cached embeddings. After startup, run `POST /admin/backfill-embeddings/` to repopulate existing records. Databases already past historical revisions do not rerun them.
- **Cross-repo:** [geolens-enterprise#25](https://github.com/geolens-io/geolens-enterprise/pull/25) pins this core commit and makes the real-overlay verifier an enforced cross-repository job.

## Area

- [x] Backend (API, services, models)
- [ ] Frontend (UI, components, hooks)
- [x] Infrastructure (Docker, nginx)
- [ ] Tiles / Rendering
- [x] Auth / Permissions
- [ ] Import / Ingestion
- [ ] OGC / Standards
- [x] Docs / Config

## Testing

- [x] 93 focused migration regression tests passed.
- [x] 35 embedding/config/translation tests passed after the lock-timeout hardening.
- [x] 143 Settings and migration-config tests passed, including blank `EMBEDDING_DIMS`; `alembic heads` imports Settings successfully with the Compose-rendered empty value.
- [x] Fresh PostgreSQL 17/PostGIS/pgvector upgrade through `0017` passed; `alembic check` reported no drift.
- [x] Real `geolens-enterprise` overlay passed with core and overlay heads recorded, the complete OAuth/SAML schema, and no drift.
- [x] Contention probes for `0012` and `0014` each timed out transactionally in five seconds and succeeded unchanged on retry.
- [x] Full backend Ruff check/format, all changed-file pre-commit hooks, and development/production Compose validation passed.

## Checklist

- [x] Code follows existing project conventions
- [x] i18n: no new user-facing strings
- [x] No new lint warnings (`ruff check`)
- [x] TypeScript: no frontend changes
- [x] Migration included
- [x] No secrets or credentials in the diff
- [x] Release/docs deployed-surface check: not applicable; no marketing/docs deployment
