### PR TITLE
fix(e2e): publish accessibility fixture dataset

### DIFF
--- a/e2e/accessibility.spec.ts
+++ b/e2e/accessibility.spec.ts
@@ -33,6 +33,17 @@ test.describe('Accessibility - WCAG 2AA', () => {
     datasetId = seeded.id;
     datasetTitle = seeded.title;
 
+    // Public maps may only reference public datasets; publish the fixture for anonymous viewing.
+    const publishDatasetResponse = await fetch(`${BASE_URL}/api/datasets/${datasetId}`, {
+      method: 'PATCH',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${getAuthToken()}`,
+      },
+      body: JSON.stringify({ visibility: 'public', record_status: 'published' }),
+    });
+    expect(publishDatasetResponse.ok).toBe(true);
+
     collectionName = `A11y Collection Test ${Date.now()}`;
     const collectionResponse = await fetch(`${BASE_URL}/api/catalog/collections/`, {
       method: 'POST',


### PR DESCRIPTION
## Summary

- Publish the accessibility fixture dataset before attaching it to a public map.
- Restore the axe and keyboard-navigation CI setup so the full suite can execute.

## Root cause

PR #508 added a freshly ingested dataset to the temporary accessibility map. Fresh ingests are private drafts, while the map API correctly rejects public maps containing non-public datasets. The setup therefore received HTTP 400 before axe ran, leaving 12 accessibility tests unexecuted.

The accessibility job is skipped for pull-request events and runs on pushes to `main`, schedules, and manual dispatches, so the mismatch first appeared after merge and persisted across subsequent main pushes.

## Impact

Test-only change. There are no application, schema, API, SDK, or configuration changes.

## Verification

- `CI=1 npx playwright test e2e/accessibility.spec.ts e2e/keyboard-nav.spec.ts --project=chromium` — 16 passed
- `pre-commit run --files e2e/accessibility.spec.ts`
- `git diff --check`