### PR TITLE
test(e2e): make clean-stack gate deterministic

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1242,7 +1242,9 @@ jobs:
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     needs: [backend-lint, backend-test, pytest-parallel-isolation, frontend-lint, frontend-test, security-scan]
-    timeout-minutes: 15
+    # A clean run includes fixture ingestion, 150+ checks, retries, and cleanup.
+    # Keep enough headroom for the whole suite to finish on a shared runner.
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1239,7 +1239,13 @@ jobs:
   # CI signal.
   e2e-test:
     name: E2E Tests
-    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    # Path-filtered prerequisites may be skipped on a test-only branch. Evaluate
+    # this job anyway for scheduled and manual runs, but preserve their failures.
+    if: >-
+      always()
+      && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')
+      && !contains(needs.*.result, 'failure')
+      && !contains(needs.*.result, 'cancelled')
     runs-on: ubuntu-latest
     needs: [backend-lint, backend-test, pytest-parallel-isolation, frontend-lint, frontend-test, security-scan]
     # A clean run includes fixture ingestion, 150+ checks, retries, and cleanup.

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -24,6 +24,11 @@ npm run e2e:smoke        # the smoke subset (core + builder + fixtures)
 - `playwright.builder-hardening.config.ts`: a separate config that runs only
   `builder-hardening.spec.ts` across Chromium, Firefox, and WebKit.
 
+The browser projects in both configs create one temporary vector dataset for
+catalog-dependent flows. The cleanup project removes it after the browser tests
+finish, including failed runs. The API-only export suite manages its own fixture
+and does not require a browser install.
+
 ## Smoke groups
 
 The `e2e:smoke:*` scripts in the root `package.json` group specs by area

--- a/e2e/accessibility.spec.ts
+++ b/e2e/accessibility.spec.ts
@@ -26,10 +26,9 @@ test.describe('Accessibility - WCAG 2AA', () => {
   let collectionName: string;
 
   test.beforeAll(async () => {
-    // Seed a real dataset so the dataset-detail test has something to render.
-    // This spec runs standalone in the Accessibility CI job (empty stack), so
-    // nothing else creates catalog data.
-    const seeded = await seedDataset();
+    // Use a separate dataset because this suite publishes it for anonymous
+    // checks and must not change the shared catalog fixture.
+    const seeded = await seedDataset('A11y Seed Dataset');
     datasetId = seeded.id;
     datasetTitle = seeded.title;
 

--- a/e2e/admin.spec.ts
+++ b/e2e/admin.spec.ts
@@ -77,9 +77,21 @@ test.describe('Admin Panel', () => {
     await expect(page.locator('label').filter({ hasText: 'To' })).toBeVisible();
     await expect(page.getByRole('button', { name: 'Clear' })).toBeVisible();
 
-    // A clean installation may not have an audit row yet. Exporting the empty
-    // result records its own audit.export event and gives the table a stable row.
-    if (await page.getByText('No audit logs found').isVisible()) {
+    const emptyState = page.getByText('No audit logs found');
+    const detailsToggles = page.getByTestId('audit-details-toggle');
+    const firstToggle = detailsToggles.first();
+
+    // Wait for loading to finish before deciding whether the clean installation
+    // needs a seed row. Exporting an empty result records its own audit.export event.
+    await expect
+      .poll(
+        async () =>
+          (await emptyState.isVisible()) || (await firstToggle.isVisible()),
+        { message: 'audit table did not reach an empty or populated state' },
+      )
+      .toBe(true);
+
+    if (await emptyState.isVisible()) {
       const downloadPromise = page.waitForEvent('download');
       await page.getByRole('button', { name: 'Export CSV' }).click();
       const download = await downloadPromise;
@@ -89,8 +101,6 @@ test.describe('Admin Panel', () => {
 
     await expect(page.getByRole('columnheader', { name: 'Timestamp' })).toBeVisible();
     await expect(page.getByRole('columnheader', { name: 'IP Address' })).toBeVisible();
-    const detailsToggles = page.getByTestId('audit-details-toggle');
-    const firstToggle = detailsToggles.first();
     await expect(firstToggle).toBeVisible();
 
     await page.getByRole('button', { name: 'Clear' }).focus();

--- a/e2e/admin.spec.ts
+++ b/e2e/admin.spec.ts
@@ -5,7 +5,7 @@ test.describe('Admin Panel', () => {
     await page.goto('/admin/overview');
 
     await expect(
-      page.getByRole('heading', { name: 'Overview' }),
+      page.getByRole('heading', { level: 1, name: 'Overview' }),
     ).toBeVisible();
     await expect(page.getByText('Total Datasets')).toBeVisible({
       timeout: 10_000,
@@ -16,7 +16,7 @@ test.describe('Admin Panel', () => {
     await page.goto('/admin/users');
 
     await expect(
-      page.getByRole('heading', { name: 'Users' }),
+      page.getByRole('heading', { level: 1, name: 'Users' }),
     ).toBeVisible();
     // Column headers asserted by role: plain getByText('Email') strict-collides
     // with the "Export emails (CSV)" toolbar button (substring match).
@@ -36,7 +36,7 @@ test.describe('Admin Panel', () => {
     await page.goto('/admin/jobs');
 
     await expect(
-      page.getByRole('heading', { name: 'Jobs' }),
+      page.getByRole('heading', { level: 1, name: 'Jobs' }),
     ).toBeVisible();
     await expect(page.locator('label').filter({ hasText: 'Status' })).toBeVisible();
     await expect(page.locator('label').filter({ hasText: 'User' })).toBeVisible();
@@ -70,12 +70,23 @@ test.describe('Admin Panel', () => {
     await page.goto('/admin/audit');
 
     await expect(
-      page.getByRole('heading', { name: 'Audit Logs' }),
+      page.getByRole('heading', { level: 1, name: 'Audit Logs' }),
     ).toBeVisible();
     await expect(page.locator('label').filter({ hasText: 'Action' })).toBeVisible();
     await expect(page.locator('label').filter({ hasText: 'From' })).toBeVisible();
     await expect(page.locator('label').filter({ hasText: 'To' })).toBeVisible();
     await expect(page.getByRole('button', { name: 'Clear' })).toBeVisible();
+
+    // A clean installation may not have an audit row yet. Exporting the empty
+    // result records its own audit.export event and gives the table a stable row.
+    if (await page.getByText('No audit logs found').isVisible()) {
+      const downloadPromise = page.waitForEvent('download');
+      await page.getByRole('button', { name: 'Export CSV' }).click();
+      const download = await downloadPromise;
+      await download.path();
+      await page.reload();
+    }
+
     await expect(page.getByRole('columnheader', { name: 'Timestamp' })).toBeVisible();
     await expect(page.getByRole('columnheader', { name: 'IP Address' })).toBeVisible();
     const detailsToggles = page.getByTestId('audit-details-toggle');
@@ -106,7 +117,7 @@ test.describe('Admin Panel', () => {
     await page.goto('/admin/settings/general');
 
     await expect(
-      page.getByRole('heading', { name: 'General' }),
+      page.getByRole('heading', { level: 1, name: 'General' }),
     ).toBeVisible();
     await expect(page.getByText('Require Metadata for Publishing')).toBeVisible({
       timeout: 10_000,
@@ -120,7 +131,7 @@ test.describe('Admin Panel', () => {
     await page.goto('/admin/settings/auth');
 
     await expect(
-      page.getByRole('heading', { name: 'Auth', exact: true }),
+      page.getByRole('heading', { level: 1, name: 'Auth', exact: true }),
     ).toBeVisible();
     await expect(page.getByRole('heading', { name: 'OAuth Providers' })).toBeVisible({
       timeout: 10_000,
@@ -133,7 +144,7 @@ test.describe('Admin Panel', () => {
     await page.goto('/admin/settings/network');
 
     await expect(
-      page.getByRole('heading', { name: 'Network' }),
+      page.getByRole('heading', { level: 1, name: 'Network' }),
     ).toBeVisible();
     await expect(page.getByText('CORS Allowed Origins')).toBeVisible({
       timeout: 10_000,
@@ -145,7 +156,7 @@ test.describe('Admin Panel', () => {
     await page.goto('/admin/settings/storage');
 
     await expect(
-      page.getByRole('heading', { name: 'Storage' }),
+      page.getByRole('heading', { level: 1, name: 'Storage' }),
     ).toBeVisible();
     await expect(page.getByText('Maximum file size (MB)')).toBeVisible({
       timeout: 10_000,
@@ -158,7 +169,7 @@ test.describe('Admin Panel', () => {
     await page.goto('/admin/settings/map');
 
     await expect(
-      page.getByRole('heading', { name: 'Map', exact: true }),
+      page.getByRole('heading', { level: 1, name: 'Map', exact: true }),
     ).toBeVisible();
     await expect(page.getByText('Basemap Presets')).toBeVisible({
       timeout: 10_000,
@@ -171,7 +182,7 @@ test.describe('Admin Panel', () => {
     await page.goto('/admin/shared-maps');
 
     await expect(
-      page.getByRole('heading', { name: 'Published Maps' }),
+      page.getByRole('heading', { level: 1, name: 'Published Maps' }),
     ).toBeVisible();
     await expect(page.getByPlaceholder('Search by map name...')).toBeVisible({
       timeout: 10_000,
@@ -184,37 +195,37 @@ test.describe('Admin Panel', () => {
     await page.goto('/admin/overview');
 
     await expect(
-      page.getByRole('heading', { name: 'Overview' }),
+      page.getByRole('heading', { level: 1, name: 'Overview' }),
     ).toBeVisible();
 
     await page.getByRole('link', { name: 'Users' }).click();
     await page.waitForURL('/admin/users');
     await expect(
-      page.getByRole('heading', { name: 'Users' }),
+      page.getByRole('heading', { level: 1, name: 'Users' }),
     ).toBeVisible();
 
     await page.getByRole('link', { name: 'Jobs' }).click();
     await page.waitForURL('/admin/jobs');
     await expect(
-      page.getByRole('heading', { name: 'Jobs' }),
+      page.getByRole('heading', { level: 1, name: 'Jobs' }),
     ).toBeVisible();
 
     await page.getByRole('link', { name: 'Audit Log' }).click();
     await page.waitForURL('/admin/audit');
     await expect(
-      page.getByRole('heading', { name: 'Audit Logs' }),
+      page.getByRole('heading', { level: 1, name: 'Audit Logs' }),
     ).toBeVisible();
 
     await page.getByRole('link', { name: 'Published Maps' }).click();
     await page.waitForURL('/admin/shared-maps');
     await expect(
-      page.getByRole('heading', { name: 'Published Maps' }),
+      page.getByRole('heading', { level: 1, name: 'Published Maps' }),
     ).toBeVisible();
 
     await page.locator('a[href="/admin/settings/map"]').click();
     await page.waitForURL('/admin/settings/map');
     await expect(
-      page.getByRole('heading', { name: 'Map', exact: true }),
+      page.getByRole('heading', { level: 1, name: 'Map', exact: true }),
     ).toBeVisible();
   });
 });

--- a/e2e/auth.setup.ts
+++ b/e2e/auth.setup.ts
@@ -1,9 +1,17 @@
 import { test as setup, expect } from '@playwright/test';
+import fs from 'fs';
 import path from 'path';
+import {
+  deleteDataset,
+  seedDataset,
+  type SeededDataset,
+} from './helpers/catalog';
 
 const authFile = path.join(__dirname, '../playwright/.auth/user.json');
+const catalogFixtureFile = path.join(__dirname, '../playwright/.auth/catalog-fixture.json');
 
 setup('authenticate as admin', async ({ page }) => {
+  setup.slow();
   const adminUser = process.env.GEOLENS_ADMIN_USERNAME ?? 'admin';
   const adminPass = process.env.GEOLENS_ADMIN_PASSWORD ?? 'admin';
 
@@ -46,4 +54,22 @@ setup('authenticate as admin', async ({ page }) => {
 
   // Save storage state (includes localStorage with auth token)
   await page.context().storageState({ path: authFile });
+
+  // An interrupted local run may leave its manifest behind. Remove that
+  // fixture before recording a replacement so repeated runs cannot orphan it.
+  if (fs.existsSync(catalogFixtureFile)) {
+    const staleFixture = JSON.parse(
+      fs.readFileSync(catalogFixtureFile, 'utf-8'),
+    ) as SeededDataset;
+    expect(
+      await deleteDataset(staleFixture.id, staleFixture.title),
+      'stale shared catalog fixture should be removable',
+    ).toBe(true);
+    fs.rmSync(catalogFixtureFile);
+  }
+
+  // Several browser flows need a real vector dataset. Seed one here so a
+  // clean CI database exercises those flows without depending on demo data.
+  const catalogFixture = await seedDataset('Shared E2E Catalog Fixture');
+  fs.writeFileSync(catalogFixtureFile, JSON.stringify(catalogFixture));
 });

--- a/e2e/builder-hardening.spec.ts
+++ b/e2e/builder-hardening.spec.ts
@@ -275,9 +275,21 @@ test.describe('Builder residual-risk hardening', () => {
       const dragHandle = page
         .locator(`#stack-row-${looseB.id}`)
         .getByRole('button', { name: /drag to reorder/i });
+      const rowIdsBeforeReorder = await stackRows.evaluateAll((elements) =>
+        elements.map((element) => element.id),
+      );
+      const looseAIndex = rowIdsBeforeReorder.indexOf(`stack-row-${looseA.id}`);
+      const looseBIndex = rowIdsBeforeReorder.indexOf(`stack-row-${looseB.id}`);
+      expect(looseAIndex).toBeGreaterThanOrEqual(0);
+      expect(looseBIndex).toBeGreaterThan(looseAIndex);
+
+      // Duplicating looseA inserts a row between these layers. Move looseB far
+      // enough to cross both the duplicate and looseA, whatever their distance.
       await dragHandle.focus();
       await page.keyboard.press('Space');
-      await page.keyboard.press('ArrowUp');
+      for (let step = looseAIndex; step < looseBIndex; step += 1) {
+        await page.keyboard.press('ArrowUp');
+      }
       await page.keyboard.press('Space');
 
       await expect.poll(async () => {

--- a/e2e/builder-hardening.spec.ts
+++ b/e2e/builder-hardening.spec.ts
@@ -1,9 +1,22 @@
-import { expect, test, type APIRequestContext, type Page } from '@playwright/test';
+import {
+  expect,
+  test,
+  type APIRequestContext,
+  type Page,
+  type Response,
+} from '@playwright/test';
 import fs from 'fs';
 import path from 'path';
 
 const AUTH_FILE = path.join(__dirname, '../playwright/.auth/user.json');
 const BASE_URL = process.env.E2E_BASE_URL ?? 'http://localhost:8080';
+
+function isMapUpdateResponse(response: Response, mapId: string): boolean {
+  return (
+    response.request().method() === 'PUT' &&
+    new URL(response.url()).pathname === `/api/maps/${mapId}`
+  );
+}
 
 interface DatasetListItem {
   id: string;
@@ -301,7 +314,7 @@ test.describe('Builder residual-risk hardening', () => {
         (response) => response.url().includes(`/api/maps/${mapId}/layers`) && response.request().method() === 'PATCH',
       );
       const metadataResponse = page.waitForResponse(
-        (response) => response.url().includes(`/api/maps/${mapId}`) && response.request().method() === 'PUT',
+        (response) => isMapUpdateResponse(response, mapId),
       );
       await page.getByRole('button', { name: /save/i }).first().click();
       expect((await patchResponse).status()).toBe(200);
@@ -358,7 +371,8 @@ test.describe('Builder residual-risk hardening', () => {
       await expect(page.getByTestId('builder-save-status')).toHaveAttribute('data-save-status', 'failed');
 
       const retryResponse = page.waitForResponse(
-        (response) => response.url().includes(`/api/maps/${mapId}`) && response.request().method() === 'PUT' && response.status() === 200,
+        (response) =>
+          isMapUpdateResponse(response, mapId) && response.status() === 200,
       );
       await page.getByTestId('builder-save-status').click();
       await retryResponse;

--- a/e2e/builder-unified-stack.spec.ts
+++ b/e2e/builder-unified-stack.spec.ts
@@ -451,10 +451,10 @@ test.describe.serial('Builder Unified Stack UAT (Phase 1038, BSR-25 + BSR-27)', 
   });
 
   // =========================================================================
-  // Test 6: Empty-state entry shows search input + suggestions
+  // Test 6: Empty-state entry shows search and browse controls
   // =========================================================================
 
-  test('6. empty-state entry shows search input + suggestions', async ({ page }) => {
+  test('6. empty-state entry shows search input and browse control', async ({ page }) => {
     const gate = attachConsoleGate(page);
 
     await page.setViewportSize({ width: 1280, height: 900 });
@@ -473,18 +473,13 @@ test.describe.serial('Builder Unified Stack UAT (Phase 1038, BSR-25 + BSR-27)', 
     const searchInput = emptyRegion.getByRole('searchbox');
     await expect(searchInput, 'Inline search input should be present in empty state').toBeVisible();
 
-    // EmptyStackState branches: when SUGGESTED_DATASETS is populated it renders
-    // a <ul aria-label="Suggested datasets"> scaffold; when empty (the default
-    // for operator-curated deployments), it renders an empty-help fallback
-    // with a "Browse catalog" CTA. Either branch is valid empty-state UX.
-    const suggestedList = emptyRegion.getByRole('list', { name: /suggested datasets/i });
-    const browseFallback = emptyRegion.getByRole('button', { name: /^browse catalog$/i });
-    const listCount = await suggestedList.count();
-    const fallbackCount = await browseFallback.count();
-    expect(
-      listCount + fallbackCount,
-      'Empty state must render either the suggested-datasets list or the browse-catalog fallback',
-    ).toBeGreaterThanOrEqual(1);
+    // Suggestions are optional. The browse control is always available and is
+    // the fallback when no operator-curated suggestions are configured.
+    await expect(
+      emptyRegion.getByRole('button', {
+        name: 'Browse all datasets in the Add Data modal',
+      }),
+    ).toBeVisible();
 
     assertConsoleClean(gate);
   });

--- a/e2e/builder-unified-stack.spec.ts
+++ b/e2e/builder-unified-stack.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect, type Page } from '@playwright/test';
+import { test, expect, type Page, type Response } from '@playwright/test';
 import fs from 'fs';
 import path from 'path';
 
@@ -8,6 +8,13 @@ import path from 'path';
 
 const AUTH_FILE = path.join(__dirname, '../playwright/.auth/user.json');
 const BASE_URL = process.env.E2E_BASE_URL ?? 'http://localhost:8080';
+
+function isMapUpdateResponse(response: Response, mapId: string): boolean {
+  return (
+    response.request().method() === 'PUT' &&
+    new URL(response.url()).pathname === `/api/maps/${mapId}`
+  );
+}
 
 /** Extract JWT token from the Playwright storage state file. */
 function getAuthToken(): string {
@@ -565,7 +572,7 @@ test.describe.serial('Builder Unified Stack UAT (Phase 1038, BSR-25 + BSR-27)', 
     if (initialCount < 2) {
       // Cannot test reorder with fewer than 2 rows — just verify save works
       const saveResponsePromise = page.waitForResponse(
-        (resp) => resp.url().includes(`/api/maps/${mapId}`) && resp.request().method() === 'PUT',
+        (response) => isMapUpdateResponse(response, mapId),
       );
       await page.getByRole('button', { name: /save/i }).first().click();
       expect((await saveResponsePromise).status()).toBe(200);
@@ -579,7 +586,7 @@ test.describe.serial('Builder Unified Stack UAT (Phase 1038, BSR-25 + BSR-27)', 
 
     // Save the map
     const saveResponsePromise = page.waitForResponse(
-      (resp) => resp.url().includes(`/api/maps/${mapId}`) && resp.request().method() === 'PUT',
+      (response) => isMapUpdateResponse(response, mapId),
     );
     await page.getByRole('button', { name: /save/i }).first().click();
     const saveResponse = await saveResponsePromise;
@@ -666,7 +673,7 @@ test.describe.serial('Builder Unified Stack UAT (Phase 1038, BSR-25 + BSR-27)', 
         (resp) => resp.url().includes(`/api/maps/${groupMapId}/layers`) && resp.request().method() === 'PATCH',
       );
       const metadataResponsePromise = page.waitForResponse(
-        (resp) => resp.url().includes(`/api/maps/${groupMapId}`) && resp.request().method() === 'PUT',
+        (response) => isMapUpdateResponse(response, groupMapId),
       );
       await page.getByRole('button', { name: /save/i }).first().click();
       expect((await patchResponsePromise).status()).toBe(200);

--- a/e2e/builder.spec.ts
+++ b/e2e/builder.spec.ts
@@ -169,7 +169,9 @@ test.describe.serial('Map Builder', () => {
       (ds) => ds.record_type === 'vector_dataset' && hasTextColumn(ds.column_info ?? null),
     );
     let datasetId = suitable?.id ?? datasets[0]?.id;
-    if (!datasetId) {
+    // Keep one dataset out of the map so the Add Dataset tests always have a
+    // catalog row to inspect on a clean installation.
+    if (datasets.length < 2) {
       const fallback = await createFallbackVectorDataset(authHeaders);
       datasetId = fallback.datasetId;
       fallbackDatasetId = fallback.datasetId;
@@ -259,7 +261,9 @@ test.describe.serial('Map Builder', () => {
       } else {
         await expect(sidebar.getByRole('button', { name: /add data/i }).first()).toBeVisible();
       }
-      await expect(page.getByRole('button', { name: 'Share' })).toBeVisible();
+      await expect(
+        page.getByRole('button', { name: 'Share', exact: true }),
+      ).toBeVisible();
       await expect(page.getByRole('button', { name: /save/i })).toBeVisible();
       await expect(page.locator('[inert]')).toHaveCount(0);
 
@@ -557,7 +561,7 @@ test.describe.serial('Map Builder', () => {
     await page.goto(`/maps/${mapId}`);
     await waitForBuilder(page);
 
-    const shareButton = page.getByRole('button', { name: 'Share' });
+    const shareButton = page.getByRole('button', { name: 'Share', exact: true });
     await expect(shareButton).toBeVisible();
     await shareButton.click();
     await expect(page.getByRole('heading', { name: 'Share' })).toBeVisible();

--- a/e2e/builder.spec.ts
+++ b/e2e/builder.spec.ts
@@ -1,10 +1,17 @@
-import { test, expect, type Page } from '@playwright/test';
+import { test, expect, type Page, type Response } from '@playwright/test';
 import fs from 'fs';
 import path from 'path';
 
 const AUTH_FILE = path.join(__dirname, '../playwright/.auth/user.json');
 const BASE_URL = process.env.E2E_BASE_URL ?? 'http://localhost:8080';
 const TEXT_TYPES = ['character', 'text', 'varchar', 'char'];
+
+function isMapUpdateResponse(response: Response, mapId: string): boolean {
+  return (
+    response.request().method() === 'PUT' &&
+    new URL(response.url()).pathname === `/api/maps/${mapId}`
+  );
+}
 
 interface DatasetListItem {
   id?: string;
@@ -444,7 +451,7 @@ test.describe.serial('Map Builder', () => {
       .toHaveCount(beforeLayerIdentity.length);
 
     const saveResponsePromise = page.waitForResponse(
-      (resp) => resp.url().includes(`/api/maps/${mapId}`) && resp.request().method() === 'PUT',
+      (response) => isMapUpdateResponse(response, mapId),
     );
     await page.getByRole('button', { name: /save/i }).first().click();
     expect((await saveResponsePromise).status()).toBe(200);
@@ -506,7 +513,7 @@ test.describe.serial('Map Builder', () => {
       (resp) => resp.url().includes(`/api/maps/${mapId}/layers`) && resp.request().method() === 'PATCH',
     );
     const mapSavePromise = page.waitForResponse(
-      (resp) => resp.url().includes(`/api/maps/${mapId}`) && resp.request().method() === 'PUT',
+      (response) => isMapUpdateResponse(response, mapId),
     );
     await page.getByRole('button', { name: /save/i }).first().click();
     expect((await layerPatchPromise).status()).toBe(200);
@@ -583,7 +590,7 @@ test.describe.serial('Map Builder', () => {
 
     // Set up response listener before clicking
     const saveResponsePromise = page.waitForResponse(
-      (resp) => resp.url().includes('/api/maps/') && resp.request().method() === 'PUT',
+      (response) => isMapUpdateResponse(response, mapId),
     );
     await saveBtn.click();
 
@@ -860,8 +867,7 @@ test.describe.serial('Map Builder', () => {
 
     // Save — no popup-config-invalid toast, success toast appears (FOLLOWUP-01 round-trip)
     const saveResponsePromise = page.waitForResponse(
-      (resp) =>
-        resp.url().includes(`/api/maps/${mapId}`) && resp.request().method() === 'PUT',
+      (response) => isMapUpdateResponse(response, mapId),
     );
     await page.getByRole('button', { name: /save/i }).first().click();
     const saveResp = await saveResponsePromise;

--- a/e2e/catalog.teardown.ts
+++ b/e2e/catalog.teardown.ts
@@ -1,0 +1,17 @@
+import { test as teardown, expect } from '@playwright/test';
+import fs from 'fs';
+import path from 'path';
+import { deleteDataset, type SeededDataset } from './helpers/catalog';
+
+const catalogFixtureFile = path.join(__dirname, '../playwright/.auth/catalog-fixture.json');
+
+teardown('remove shared catalog fixture', async () => {
+  if (!fs.existsSync(catalogFixtureFile)) return;
+
+  const fixture = JSON.parse(
+    fs.readFileSync(catalogFixtureFile, 'utf-8'),
+  ) as SeededDataset;
+  const deleted = await deleteDataset(fixture.id, fixture.title);
+  expect(deleted).toBe(true);
+  fs.rmSync(catalogFixtureFile);
+});

--- a/e2e/collections.spec.ts
+++ b/e2e/collections.spec.ts
@@ -112,14 +112,16 @@ test.describe.serial('Collections', () => {
       page.getByRole('heading', { name: 'Collections' }),
     ).toBeVisible();
     await expect(
-      page.getByRole('button', { name: 'New Collection' }),
+      page.getByRole('button', {
+        name: /^(New Collection|Create your first collection)$/,
+      }),
     ).toBeVisible();
   });
 
   test('create a new collection from the global create menu', async ({ page }) => {
     await page.goto('/collections');
 
-    await page.getByRole('button', { name: 'Create' }).click();
+    await page.getByRole('button', { name: 'Create', exact: true }).click();
     await page.getByRole('menuitem', { name: 'Collection' }).click();
 
     await expect(
@@ -134,7 +136,7 @@ test.describe.serial('Collections', () => {
         response.request().method() === 'POST' &&
         response.url().includes('/api/catalog/collections/'),
     );
-    await page.getByRole('button', { name: 'Create' }).click();
+    await page.getByRole('button', { name: 'Create', exact: true }).click();
 
     const createResponse = await createResponsePromise;
     const createdCollection = await createResponse.json();

--- a/e2e/export-runtime.spec.ts
+++ b/e2e/export-runtime.spec.ts
@@ -7,10 +7,6 @@ import {
 
 type BBox = [number, number, number, number];
 
-type SearchFeatureCollection = {
-  features?: Array<{ id?: string }>;
-};
-
 type DatasetDetail = {
   id: string;
   title: string;
@@ -59,6 +55,11 @@ type AuditLogEntry = {
 type AuditLogListResponse = {
   logs?: AuditLogEntry[];
   total?: number;
+};
+
+type OwnedDataset = {
+  id: string;
+  title: string;
 };
 
 const adminUser = process.env.GEOLENS_ADMIN_USERNAME ?? 'admin';
@@ -353,6 +354,101 @@ async function loginAsAdmin(request: APIRequestContext): Promise<string> {
   return payload.access_token as string;
 }
 
+async function seedRuntimeDataset(
+  request: APIRequestContext,
+  authHeader: Record<string, string>,
+): Promise<OwnedDataset> {
+  const title = `E2E Runtime Export ${Date.now()}`;
+  const fixture = {
+    type: 'FeatureCollection',
+    features: [
+      {
+        type: 'Feature',
+        geometry: { type: 'Point', coordinates: [-100, 30] },
+        properties: { name: 'west', value: 10 },
+      },
+      {
+        type: 'Feature',
+        geometry: { type: 'Point', coordinates: [-95, 35] },
+        properties: { name: 'center', value: 20 },
+      },
+      {
+        type: 'Feature',
+        geometry: { type: 'Point', coordinates: [-90, 40] },
+        properties: { name: 'east', value: 30 },
+      },
+    ],
+  };
+
+  const uploadResponse = await request.post('/api/ingest/upload', {
+    headers: authHeader,
+    multipart: {
+      file: {
+        name: 'runtime-export.geojson',
+        mimeType: 'application/geo+json',
+        buffer: Buffer.from(JSON.stringify(fixture)),
+      },
+    },
+  });
+  if (!uploadResponse.ok()) {
+    throw new Error(`Runtime export fixture upload failed (${uploadResponse.status()})`);
+  }
+
+  const uploadPayload = (await uploadResponse.json()) as { job_id?: string };
+  if (!uploadPayload.job_id) {
+    throw new Error('Runtime export fixture upload did not return a job id');
+  }
+
+  const commitResponse = await request.post(
+    `/api/ingest/commit/${uploadPayload.job_id}`,
+    {
+      headers: authHeader,
+      data: { title },
+    },
+  );
+  if (!commitResponse.ok()) {
+    throw new Error(`Runtime export fixture commit failed (${commitResponse.status()})`);
+  }
+
+  for (let attempt = 0; attempt < 60; attempt += 1) {
+    const jobResponse = await request.get(`/api/jobs/${uploadPayload.job_id}`, {
+      headers: authHeader,
+    });
+    if (jobResponse.ok()) {
+      const job = (await jobResponse.json()) as {
+        status?: string;
+        dataset_id?: string | null;
+      };
+      if (
+        job.dataset_id &&
+        ['complete', 'completed', 'succeeded'].includes(job.status ?? '')
+      ) {
+        return { id: job.dataset_id, title };
+      }
+      if (['failed', 'error'].includes(job.status ?? '')) {
+        throw new Error(`Runtime export fixture ingest failed with status ${job.status}`);
+      }
+    }
+    await new Promise((resolve) => setTimeout(resolve, 1_000));
+  }
+
+  throw new Error('Runtime export fixture ingest did not complete in time');
+}
+
+async function deleteRuntimeDataset(
+  request: APIRequestContext,
+  authHeader: Record<string, string>,
+  dataset: OwnedDataset,
+): Promise<void> {
+  const response = await request.delete(`/api/datasets/${dataset.id}`, {
+    headers: authHeader,
+    data: { confirm_title: dataset.title },
+  });
+  if (!response.ok() && response.status() !== 404) {
+    throw new Error(`Runtime export fixture cleanup failed (${response.status()})`);
+  }
+}
+
 async function exportDataset(
   request: APIRequestContext,
   authHeader: Record<string, string>,
@@ -391,6 +487,7 @@ async function exportGeoJson(
 async function resolveRuntimeDataset(
   request: APIRequestContext,
   authHeader: Record<string, string>,
+  datasetId: string,
 ): Promise<{ dataset: DatasetDetail; baseline: GeoJsonFeatureCollection }> {
   async function resolveCandidate(
     datasetId: string,
@@ -476,39 +573,13 @@ async function resolveRuntimeDataset(
     return { dataset: detail, baseline };
   }
 
-  const preferredDatasetId = process.env.E2E_EXPORT_DATASET_ID?.trim();
-  if (preferredDatasetId) {
-    const preferred = await resolveCandidate(preferredDatasetId);
-    if (preferred) {
-      return preferred;
-    }
-    throw new Error(
-      `E2E_EXPORT_DATASET_ID=${preferredDatasetId} did not satisfy runtime semantic preconditions`,
-    );
-  }
-
-  // Trailing slash required — see loginAsAdmin() above for the rationale.
-  const searchResponse = await request.get('/api/search/datasets/?limit=10', {
-    headers: authHeader,
-  });
-  expect(searchResponse.ok()).toBeTruthy();
-
-  const searchPayload = (await searchResponse.json()) as SearchFeatureCollection;
-  const candidates = searchPayload.features ?? [];
-  expect(candidates.length).toBeGreaterThan(0);
-
-  for (const feature of candidates) {
-    if (!feature.id) {
-      continue;
-    }
-    const resolved = await resolveCandidate(feature.id);
-    if (resolved) {
-      return resolved;
-    }
+  const resolved = await resolveCandidate(datasetId);
+  if (resolved) {
+    return resolved;
   }
 
   throw new Error(
-    'No runtime dataset satisfied format + target_crs semantic preconditions; set E2E_EXPORT_DATASET_ID to a known-good dataset id to skip discovery',
+    `Runtime export dataset ${datasetId} did not satisfy format and target_crs semantic preconditions`,
   );
 }
 
@@ -522,13 +593,27 @@ test.describe('Runtime export integrity', () => {
   let auditDateFrom: string;
   let lastBboxFilter: string | null = null;
   let lastWhereFilter: string | null = null;
+  let ownedDataset: OwnedDataset | null = null;
 
   test.beforeAll(async ({ request }) => {
     const token = await loginAsAdmin(request);
     authHeader = { Authorization: `Bearer ${token}` };
     auditDateFrom = new Date(Date.now() - 5_000).toISOString();
 
-    const runtimeContext = await resolveRuntimeDataset(request, authHeader);
+    const preferredDatasetId = process.env.E2E_EXPORT_DATASET_ID?.trim();
+    if (!preferredDatasetId) {
+      ownedDataset = await seedRuntimeDataset(request, authHeader);
+    }
+    const runtimeDatasetId = preferredDatasetId ?? ownedDataset?.id;
+    if (!runtimeDatasetId) {
+      throw new Error('Runtime export fixture setup did not produce a dataset id');
+    }
+
+    const runtimeContext = await resolveRuntimeDataset(
+      request,
+      authHeader,
+      runtimeDatasetId,
+    );
     dataset = runtimeContext.dataset;
     baseline = runtimeContext.baseline;
 
@@ -539,6 +624,12 @@ test.describe('Runtime export integrity', () => {
 
     expect(extentFromDataset ?? extentFromFeatures).toBeTruthy();
     baselineExtent = (extentFromDataset ?? extentFromFeatures) as BBox;
+  });
+
+  test.afterAll(async ({ request }) => {
+    if (ownedDataset) {
+      await deleteRuntimeDataset(request, authHeader, ownedDataset);
+    }
   });
 
   test('exports gpkg with SQLite payload header', async ({ request }) => {

--- a/e2e/feature-editing.spec.ts
+++ b/e2e/feature-editing.spec.ts
@@ -30,61 +30,101 @@ function getAuthToken(): string {
 
 let datasetId: string;
 let datasetTitle: string;
-let editingWasEnabled: boolean;
+let editingWasEnabled: boolean | undefined;
 let headers: Record<string, string>;
 
-test.describe('Feature editing round-trips', () => {
-  test.beforeAll(async () => {
-    const token = getAuthToken();
-    headers = {
-      Authorization: `Bearer ${token}`,
-      'Content-Type': 'application/json',
-    };
-
-    // Editing is deployment-gated (enable_dataset_editing, default off).
-    const flags = await fetch(`${BASE_URL}/api/settings/feature-flags/`, { headers });
-    expect(flags.ok).toBe(true);
-    editingWasEnabled = (await flags.json()).enable_dataset_editing === true;
-    if (!editingWasEnabled) {
-      const res = await fetch(`${BASE_URL}/api/settings/`, {
-        method: 'PUT',
-        headers,
-        body: JSON.stringify({ settings: { enable_dataset_editing: true } }),
-      });
-      expect(res.ok).toBe(true);
-    }
-
-    // Throwaway layer with a text and an integer column + one feature.
-    datasetTitle = `E2E Feature Editing ${Date.now()}`;
-    const layer = await fetch(`${BASE_URL}/api/layers/`, {
-      method: 'POST',
-      headers,
-      body: JSON.stringify({
-        title: datasetTitle,
-        geometry_type: 'Point',
-        columns: [
-          { name: 'name', type: 'text' },
-          { name: 'population', type: 'integer' },
-        ],
-      }),
-    });
-    expect(layer.ok).toBe(true);
-    datasetId = (await layer.json()).id;
-
-    const feature = await fetch(`${BASE_URL}/api/datasets/${datasetId}/features/`, {
-      method: 'POST',
-      headers,
-      body: JSON.stringify({
-        geometry: { type: 'Point', coordinates: [-73.9857, 40.7484] },
-        properties: { name: 'alpha', population: 100 },
-      }),
-    });
-    expect(feature.ok).toBe(true);
+async function createEditingDataset() {
+  datasetTitle = `E2E Feature Editing ${Date.now()}`;
+  const layer = await fetch(`${BASE_URL}/api/layers/`, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify({
+      title: datasetTitle,
+      geometry_type: 'Point',
+      columns: [
+        { name: 'name', type: 'text' },
+        { name: 'population', type: 'integer' },
+      ],
+    }),
   });
+  expect(layer.ok).toBe(true);
+  datasetId = (await layer.json()).id;
+
+  const feature = await fetch(`${BASE_URL}/api/datasets/${datasetId}/features/`, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify({
+      geometry: { type: 'Point', coordinates: [-73.9857, 40.7484] },
+      properties: { name: 'alpha', population: 100 },
+    }),
+  });
+  expect(feature.ok).toBe(true);
+}
+
+async function waitForPersistedValue(column: string, expectedValue: string | number) {
+  await expect.poll(async () => {
+    const response = await fetch(`${BASE_URL}/api/datasets/${datasetId}/rows/?limit=1`, {
+      headers,
+    });
+    if (!response.ok) return undefined;
+    const body = await response.json() as { rows?: Array<Record<string, unknown>> };
+    return body.rows?.[0]?.[column];
+  }, {
+    message: `wait for ${column} edit to persist before reloading`,
+    timeout: 15_000,
+  }).toBe(expectedValue);
+}
+
+test.beforeAll(async () => {
+  const token = getAuthToken();
+  headers = {
+    Authorization: `Bearer ${token}`,
+    'Content-Type': 'application/json',
+  };
+
+  const flags = await fetch(`${BASE_URL}/api/settings/feature-flags/`, { headers });
+  expect(flags.ok).toBe(true);
+  editingWasEnabled = (await flags.json()).enable_dataset_editing === true;
+  if (!editingWasEnabled) {
+    const response = await fetch(`${BASE_URL}/api/settings/`, {
+      method: 'PUT',
+      headers,
+      body: JSON.stringify({ settings: { enable_dataset_editing: true } }),
+    });
+    expect(response.ok).toBe(true);
+  }
+});
+
+test.beforeEach(async () => {
+  await createEditingDataset();
+});
+
+test.afterEach(async () => {
+  if (!datasetId) return;
+  const response = await fetch(`${BASE_URL}/api/datasets/${datasetId}`, {
+    method: 'DELETE',
+    headers,
+    body: JSON.stringify({ confirm_title: datasetTitle }),
+  });
+  expect(response.ok).toBe(true);
+  datasetId = '';
+});
+
+test.afterAll(async () => {
+  if (editingWasEnabled === false) {
+    const response = await fetch(`${BASE_URL}/api/settings/`, {
+      method: 'PUT',
+      headers,
+      body: JSON.stringify({ settings: { enable_dataset_editing: false } }),
+    });
+    expect(response.ok).toBe(true);
+  }
+});
+
+test.describe('Feature editing round-trips', () => {
 
   async function openDataTab(page: import('@playwright/test').Page) {
-    await page.goto(`/datasets/${datasetId}`);
-    await page.getByRole('tab', { name: 'Data', exact: true }).click();
+    await page.goto(`/datasets/${datasetId}#data`);
   }
 
   async function editCell(
@@ -107,9 +147,9 @@ test.describe('Feature editing round-trips', () => {
   test('text cell edit persists across reload', async ({ page }) => {
     await openDataTab(page);
     await editCell(page, 'alpha', 'bravo');
+    await waitForPersistedValue('name', 'bravo');
 
     await page.reload();
-    await page.getByRole('tab', { name: 'Data', exact: true }).click();
     await expect(
       page.getByRole('button', { name: 'bravo', exact: true }),
     ).toBeVisible({ timeout: 15_000 });
@@ -118,9 +158,9 @@ test.describe('Feature editing round-trips', () => {
   test('integer cell edit persists across reload (E-03 live)', async ({ page }) => {
     await openDataTab(page);
     await editCell(page, '100', '250');
+    await waitForPersistedValue('population', 250);
 
     await page.reload();
-    await page.getByRole('tab', { name: 'Data', exact: true }).click();
     await expect(
       page.getByRole('button', { name: '250', exact: true }),
     ).toBeVisible({ timeout: 15_000 });
@@ -130,7 +170,7 @@ test.describe('Feature editing round-trips', () => {
     page,
   }) => {
     await openDataTab(page);
-    const cell = page.getByRole('button', { name: '250', exact: true });
+    const cell = page.getByRole('button', { name: '100', exact: true });
     await expect(cell).toBeVisible({ timeout: 15_000 });
     await cell.click();
     const input = page.locator('tbody input');
@@ -141,37 +181,14 @@ test.describe('Feature editing round-trips', () => {
     });
     // Value unchanged after reload.
     await page.reload();
-    await page.getByRole('tab', { name: 'Data', exact: true }).click();
     await expect(
-      page.getByRole('button', { name: '250', exact: true }),
+      page.getByRole('button', { name: '100', exact: true }),
     ).toBeVisible({ timeout: 15_000 });
   });
 });
 
 test.describe('Feature editing affordances (anonymous)', () => {
   test.use({ storageState: { cookies: [], origins: [] } });
-
-  // Cleanup for the whole file lives here: workers=1 runs describes in file
-  // order, so this afterAll is the last hook to fire.
-  test.afterAll(async () => {
-    if (datasetId) {
-      // The delete API demands title confirmation; assert cleanup worked so
-      // repeated runs can't silently accrete published throwaway datasets.
-      const res = await fetch(`${BASE_URL}/api/datasets/${datasetId}`, {
-        method: 'DELETE',
-        headers,
-        body: JSON.stringify({ confirm_title: datasetTitle }),
-      });
-      expect(res.ok).toBe(true);
-    }
-    if (!editingWasEnabled) {
-      await fetch(`${BASE_URL}/api/settings/`, {
-        method: 'PUT',
-        headers,
-        body: JSON.stringify({ settings: { enable_dataset_editing: false } }),
-      });
-    }
-  });
 
   test('anonymous viewer of a public dataset sees no editable cells', async ({
     page,
@@ -184,14 +201,13 @@ test.describe('Feature editing affordances (anonymous)', () => {
     });
     expect(res.ok).toBe(true);
 
-    await page.goto(`/datasets/${datasetId}`);
-    await page.getByRole('tab', { name: 'Data', exact: true }).click();
+    await page.goto(`/datasets/${datasetId}#data`);
     // Value renders as plain text, not as an edit button.
-    await expect(page.getByText('bravo', { exact: true })).toBeVisible({
+    await expect(page.getByText('alpha', { exact: true })).toBeVisible({
       timeout: 15_000,
     });
     await expect(
-      page.getByRole('button', { name: 'bravo', exact: true }),
+      page.getByRole('button', { name: 'alpha', exact: true }),
     ).toHaveCount(0);
   });
 });

--- a/e2e/helpers/catalog.ts
+++ b/e2e/helpers/catalog.ts
@@ -162,15 +162,13 @@ export interface SeededDataset {
 /**
  * Ingest the sample fixture as a real dataset and return its id + title.
  *
- * Specs that need a dataset to exist but don't run alongside the upload flow
- * (e.g. the accessibility job, which runs only the a11y specs against a fresh,
- * empty stack) must seed their own — otherwise `getSearchSeed()` / a
- * dataset-detail visit has nothing to find. Drives the same upload → commit →
- * poll sequence the import UI uses. Pair every call with `deleteDataset()` in
- * `afterAll`.
+ * The default Playwright setup uses this helper to give every project one
+ * catalog fixture. Specs may also create an isolated fixture when they need to
+ * publish or mutate it. The helper follows the same upload, commit, and poll
+ * sequence as the import UI. Pair each call with `deleteDataset()`.
  */
-export async function seedDataset(): Promise<SeededDataset> {
-  return seedFixtureDataset('sample.geojson', 'application/geo+json', `A11y Seed Dataset ${Date.now()}`);
+export async function seedDataset(titlePrefix = 'E2E Seed Dataset'): Promise<SeededDataset> {
+  return seedFixtureDataset('sample.geojson', 'application/geo+json', `${titlePrefix} ${Date.now()}`);
 }
 
 /**
@@ -225,13 +223,23 @@ async function seedFixtureDataset(
   throw new Error(`ingest job ${jobId} did not produce a dataset in time`);
 }
 
-/** Best-effort teardown for a `seedDataset()` result (DELETE requires confirm_title). */
-export async function deleteDataset(id: string, title: string): Promise<void> {
-  await fetch(`${BASE_URL}/api/datasets/${id}`, {
-    method: 'DELETE',
-    headers: { ...authHeaders(), 'Content-Type': 'application/json' },
-    body: JSON.stringify({ confirm_title: title }),
-  }).catch(() => {
-    /* teardown is best-effort; the CI stack is torn down anyway */
-  });
+/** Delete a seeded dataset. Returns false when best-effort cleanup fails. */
+export async function deleteDataset(id: string, title: string): Promise<boolean> {
+  for (let attempt = 0; attempt < 3; attempt += 1) {
+    try {
+      const response = await fetch(`${BASE_URL}/api/datasets/${id}`, {
+        method: 'DELETE',
+        headers: { ...authHeaders(), 'Content-Type': 'application/json' },
+        body: JSON.stringify({ confirm_title: title }),
+      });
+      if (response.ok || response.status === 404) return true;
+      if (response.status < 500 && response.status !== 429) return false;
+    } catch {
+      // Retry transient network failures before reporting cleanup failure.
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 250 * (attempt + 1)));
+  }
+
+  return false;
 }

--- a/e2e/permissions.spec.ts
+++ b/e2e/permissions.spec.ts
@@ -22,7 +22,7 @@ test.describe('Permissions', () => {
 
     // Verify permissions page heading
     await expect(
-      page.getByRole('heading', { name: 'Permissions' }),
+      page.getByRole('heading', { level: 1, name: 'Permissions' }),
     ).toBeVisible();
 
     // Verify matrix card
@@ -80,7 +80,7 @@ test.describe('Permissions', () => {
     request,
   }) => {
     // Login to get token
-    const loginResp = await request.post('http://localhost:8080/api/auth/login', {
+    const loginResp = await request.post('/api/auth/login', {
       form: {
         username: process.env.GEOLENS_ADMIN_USERNAME ?? 'admin',
         password: process.env.GEOLENS_ADMIN_PASSWORD ?? 'admin',
@@ -90,7 +90,7 @@ test.describe('Permissions', () => {
     const { access_token } = await loginResp.json();
 
     // Fetch permissions
-    const permResp = await request.get('http://localhost:8080/api/auth/me/permissions/', {
+    const permResp = await request.get('/api/auth/me/permissions/', {
       headers: { Authorization: `Bearer ${access_token}` },
     });
     expect(permResp.ok()).toBeTruthy();

--- a/e2e/sec-audit.spec.ts
+++ b/e2e/sec-audit.spec.ts
@@ -285,15 +285,23 @@ test('hygiene — malformed bbox is rejected', async ({ request }) => {
   expect([400, 422, 429]).toContain(res.status()); // 429: safe rate-limit rejection (S11 burst bleed)
 });
 
-test('hygiene — CORS allow_origins=* is never reflected', async ({ request }) => {
-  // No Origin header → no CORS headers
-  const res = await request.get(`${API}/`, {
+test('hygiene — CORS does not grant credentials to an untrusted origin', async ({ request }) => {
+  const origin = 'http://attacker.example';
+  const appResponse = await request.get(`${API}/auth/me/`, {
+    headers: { Origin: origin },
+  });
+  expect(appResponse.headers()['access-control-allow-origin']).toBeUndefined();
+  expect(appResponse.headers()['access-control-allow-credentials']).toBeUndefined();
+
+  // Anonymous standards routes may use a wildcard, but never with credentials.
+  const standardsResponse = await request.get(`${API}/`, {
     headers: { Origin: 'http://attacker.example' },
   });
-  const acao = res.headers()['access-control-allow-origin'];
-  // Should NOT echo a non-allowlisted origin and never be `*` with credentials
-  if (acao) {
-    expect(acao).not.toBe('*');
-    expect(acao).not.toBe('http://attacker.example');
+  const standardsOrigin = standardsResponse.headers()['access-control-allow-origin'];
+  expect(standardsOrigin).not.toBe(origin);
+  if (standardsOrigin === '*') {
+    expect(
+      standardsResponse.headers()['access-control-allow-credentials'],
+    ).toBeUndefined();
   }
 });

--- a/playwright.builder-hardening.config.ts
+++ b/playwright.builder-hardening.config.ts
@@ -20,6 +20,11 @@ export default defineConfig({
     {
       name: 'setup',
       testMatch: /.*\.setup\.ts/,
+      teardown: 'cleanup',
+    },
+    {
+      name: 'cleanup',
+      testMatch: /.*\.teardown\.ts/,
     },
     {
       name: 'chromium-hardening',

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -18,7 +18,15 @@ export default defineConfig({
     video: 'on-first-retry',
   },
   projects: [
-    { name: 'setup', testMatch: /.*\.setup\.ts/ },
+    {
+      name: 'setup',
+      testMatch: /.*\.setup\.ts/,
+      teardown: 'cleanup',
+    },
+    {
+      name: 'cleanup',
+      testMatch: /.*\.teardown\.ts/,
+    },
     {
       name: 'chromium',
       testIgnore: /export-runtime\.spec\.ts/,


### PR DESCRIPTION
## Summary

- Seed and remove a temporary vector dataset for browser tests that need catalog data.
- Give the API-only export suite its own deterministic fixture so it stays browser-independent.
- Remove hidden test ordering, stale selectors, fixed-port calls, and assumptions about preloaded data.
- Let scheduled and manual E2E runs proceed when path-filtered prerequisites are skipped, while preserving failed and cancelled prerequisites.
- Give the scheduled and manual full E2E job enough time to finish ingestion, retries, and cleanup.
- Match map metadata saves by exact route so thumbnail and Open Graph uploads cannot satisfy the wrong test wait.
- Wait for the audit table to finish loading before deciding whether an empty installation needs a seed event.

## Why

The clean-stack validation after #507 exposed test assumptions that were hidden by populated development databases. A manual run also showed that an E2E-only branch could skip the browser job when path-filtered prerequisites were skipped. This follow-up keeps product behavior unchanged and makes the release gate reproducible from an empty database.

## Scope

This changes Playwright tests, test configuration, E2E documentation, and scheduled/manual E2E workflow control. It does not change backend, frontend, database, Docker, edition, or extension behavior.

## Validation

- Fresh isolated database and volumes: 130 runnable tests passed, 27 environment-gated tests skipped as designed, zero failures, retries disabled.
- Chromium, Firefox, and WebKit hardening config: 12 runnable tests passed, 8 browser-specific tests skipped as designed, zero failures, retries disabled.
- API-only export suite: 8 of 8 passed without a browser installation and left no fixture records.
- Affected builder suites: 34 tests passed, 1 browser-gated test skipped as designed, zero failures, retries disabled.
- Empty audit-table path: 1 of 1 passed after clearing the isolated test table, retries disabled.
- Complete admin spec: 13 of 13 passed, retries disabled.
- Pre-commit hooks, secret detection, YAML validation, diff checks, and the public-surface wording gate passed.
- Core main CI for b7a5ca921180f212081bc070944432a6638eea16 passed before this test-only follow-up.