### PR TITLE
test(enterprise): add composed ABAC and workflow overlay coverage

### DIFF
--- a/EDITIONS.md
+++ b/EDITIONS.md
@@ -14,7 +14,7 @@ These commitments define the free and paid boundary:
 - Capabilities released for free in this repository will stay free. Paid modules will add separate capabilities instead of taking existing ones away.
 - Your data and catalog remain exportable through open standards.
 
-Carto Concepts, LLC offers optional paid support and add-ons. Enterprise includes SAML identity, SIEM streaming, compliance automation, branding controls, arbitrary share-link expiration, origin-restricted embeds, and support with an SLA. Community includes OIDC and OAuth, bounded CSV and JSON audit export, share creation and revocation, fixed expiration presets, non-expiring links, and default-lifetime embeds. The paid modules ship in a separately licensed, immutable Enterprise image. You do not need them to build or run this repository.
+Carto Concepts, LLC offers optional paid support and add-ons. Enterprise includes SAML identity, SIEM audit streaming, branding controls, arbitrary share-link expiration, origin-restricted embeds, and support with an SLA. Community includes OIDC and OAuth, bounded CSV and JSON audit export, share creation and revocation, fixed expiration presets, non-expiring links, and default-lifetime embeds. The paid modules ship in a separately licensed, immutable Enterprise image. You do not need them to build or run this repository.
 
 A valid commercial license grants perpetual use of the installed version. The maintenance term controls access to updates and support. When maintenance ends, the installed version keeps working, data and backups remain accessible, and local administrators keep their login path.
 

--- a/backend/app/core/db/schema_skew.py
+++ b/backend/app/core/db/schema_skew.py
@@ -116,6 +116,12 @@ def _build_alembic_config() -> Config:
     return cfg
 
 
+def build_alembic_config() -> Config:
+    """Supported external entry point for overlay tooling to build the merged
+    alembic ``Config`` (OSS base + installed overlay version dirs)."""
+    return _build_alembic_config()
+
+
 def get_script_heads() -> set[str]:
     """Return the set of head revisions the image's migration scripts declare."""
     script = ScriptDirectory.from_config(_build_alembic_config())

--- a/backend/app/platform/extensions/defaults.py
+++ b/backend/app/platform/extensions/defaults.py
@@ -75,11 +75,16 @@ class DefaultPermissionExtension:
         ]
 
         if grant_cls is not None:
+            # fix(#515): grants key catalog.datasets.id, not records.id — route
+            # through Dataset.record_id so granted restricted records resolve.
+            from app.modules.catalog.datasets.domain.models import Dataset
+
             conditions.append(
                 and_(
                     record_cls.visibility == "restricted",
                     record_cls.id.in_(
-                        select(grant_cls.dataset_id)
+                        select(Dataset.record_id)
+                        .join(grant_cls, grant_cls.dataset_id == Dataset.id)
                         .join(UserRole, grant_cls.role_id == UserRole.role_id)
                         .where(UserRole.user_id == user.id)
                     ),

--- a/backend/tests/test_permission_overlay.py
+++ b/backend/tests/test_permission_overlay.py
@@ -1,0 +1,342 @@
+"""Composed integration tests for the enterprise ABAC PermissionExtension.
+
+These exercise the private overlay's ``EnterprisePermissionExtension.filter_visible``
+against the REAL core models (``Record`` / ``DatasetGrant`` / ``User`` /
+``UserRole``) and a REAL Postgres database, so a core column rename
+(``sensitivity_classification`` / ``owner_org`` / ``spatial_extent``) or a
+baseline that silently *widens* is caught. The overlay's own suite can only
+compile the ABAC predicate against a test-local ``_Record`` fake, so this file
+is the composed counterpart that lives in CORE (only core ships the ORM model +
+DB fixtures). See enterprise-overlay-audit-20260715 §6 and enterprise issue #13.
+
+Skip-not-fail: the overlay is imported via ``pytest.importorskip`` inside the
+``enterprise_permission`` fixture, exactly like conftest's
+``saml_overlay_registered``. An OSS checkout without ``geolens_enterprise``
+SKIPS these tests instead of failing collection; the overlay's cross-repo CI job
+installs the overlay and forces them to run.
+
+ABAC is inert unless ``GEOLENS_PERM_ABAC_MODE=role``. Each test sets the mode
+via ``monkeypatch`` BEFORE constructing the extension, because
+``load_policy()`` reads the environment at construction time.
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+
+import pytest
+from geoalchemy2 import WKTElement
+from sqlalchemy import select
+
+from app.modules.auth.models import Role, User, UserRole
+from app.modules.catalog.datasets.domain.models import Dataset, DatasetGrant, Record
+from app.platform.extensions.defaults import DefaultPermissionExtension
+
+# A 10x10 degree box used as the ABAC region for the spatial-straddle tests.
+REGION_WKT = "POLYGON((0 0, 0 10, 10 10, 10 0, 0 0))"
+EXTENT_INSIDE = "POLYGON((2 2, 2 4, 4 4, 4 2, 2 2))"  # fully within REGION
+EXTENT_OUTSIDE = "POLYGON((20 20, 20 22, 22 22, 22 20, 20 20))"  # fully outside
+EXTENT_STRADDLE = "POLYGON((8 8, 8 12, 12 12, 12 8, 8 8))"  # crosses the boundary
+
+
+@pytest.fixture
+def enterprise_permission():
+    """Import the overlay's permission package or SKIP (never fail).
+
+    Mirrors conftest's ``saml_overlay_registered``: the deferred
+    ``pytest.importorskip`` keeps collection working in community-only
+    environments while the overlay CI job forces a real run.
+    """
+    return pytest.importorskip(
+        "geolens_enterprise.permission",
+        reason="geolens_enterprise package is not installed",
+    )
+
+
+def _unique(prefix: str) -> str:
+    return f"{prefix}_{uuid.uuid4().hex[:8]}"
+
+
+async def _add_user(session) -> User:
+    user = User(username=_unique("abac_user"), status="active", is_active=True)
+    session.add(user)
+    await session.flush()
+    return user
+
+
+async def _add_record(
+    session,
+    *,
+    visibility: str = "public",
+    record_status: str = "published",
+    sensitivity: str | None = None,
+    owner_org: str | None = None,
+    extent_wkt: str | None = None,
+    created_by: uuid.UUID | None = None,
+) -> Record:
+    record = Record(
+        title=_unique("record"),
+        visibility=visibility,
+        record_status=record_status,
+        record_type="vector_dataset",
+        sensitivity_classification=sensitivity,
+        owner_org=owner_org,
+        spatial_extent=(
+            WKTElement(extent_wkt, srid=4326) if extent_wkt is not None else None
+        ),
+        created_by=created_by,
+    )
+    session.add(record)
+    await session.flush()
+    return record
+
+
+async def _grant_dataset(session, record: Record, role: Role) -> None:
+    """Wire a real DatasetGrant so the default's restricted-grant JOIN runs
+    against real ``Dataset`` / ``DatasetGrant`` / ``UserRole`` rows."""
+    dataset = Dataset(record_id=record.id, table_name=_unique("tbl"))
+    session.add(dataset)
+    await session.flush()
+    session.add(DatasetGrant(dataset_id=dataset.id, role_id=role.id))
+    await session.flush()
+
+
+async def _visible_ids(session, stmt) -> set[uuid.UUID]:
+    result = await session.execute(stmt)
+    return set(result.scalars().all())
+
+
+async def test_filter_visible_subset_invariant(
+    enterprise_permission, test_db_session, clean_tables, monkeypatch
+):
+    """Overlay filter is always a SUBSET of the community baseline, and it
+    genuinely narrows for a plain user — exercised for admin, a plain user with
+    a dataset grant, and an anonymous caller against real seeded rows."""
+    session = test_db_session
+    role_name = _unique("analyst")
+
+    owner = await _add_user(session)
+    plain_user = await _add_user(session)
+
+    # Real role + grant so the plain user carries a dataset grant (drift tripwire
+    # on DatasetGrant/UserRole schema); the overlay narrows regardless of it.
+    granted_role = Role(name=role_name, description="ABAC test role")
+    session.add(granted_role)
+    await session.flush()
+    session.add(UserRole(user_id=plain_user.id, role_id=granted_role.id))
+    await session.flush()
+
+    rec_a = await _add_record(
+        session, sensitivity="internal", owner_org="alpha", created_by=owner.id
+    )  # allowed by ABAC (internal <= confidential, org alpha)
+    rec_b = await _add_record(
+        session, sensitivity="restricted", owner_org="alpha", created_by=owner.id
+    )  # narrowed out: classification above clearance
+    rec_c = await _add_record(
+        session, sensitivity="internal", owner_org="beta", created_by=owner.id
+    )  # narrowed out: org not in allow-list
+    rec_d = await _add_record(
+        session, sensitivity=None, owner_org="alpha", created_by=owner.id
+    )  # narrowed out: NULL sensitivity -> most-restrictive under "restricted"
+    rec_restricted = await _add_record(
+        session,
+        visibility="restricted",
+        sensitivity="internal",
+        owner_org="alpha",
+        created_by=owner.id,
+    )
+    await _grant_dataset(session, rec_restricted, granted_role)
+    await session.commit()
+
+    seeded = {rec_a.id, rec_b.id, rec_c.id, rec_d.id, rec_restricted.id}
+
+    monkeypatch.setenv("GEOLENS_PERM_ABAC_MODE", "role")
+    monkeypatch.setenv(
+        "GEOLENS_PERM_ROLE_POLICY",
+        json.dumps({role_name: {"clearance": "confidential", "orgs": ["alpha"]}}),
+    )
+
+    default = DefaultPermissionExtension()
+    overlay = enterprise_permission.EnterprisePermissionExtension()
+
+    # --- plain user with a dataset grant: overlay strictly narrows ---
+    base_plain = await _visible_ids(
+        session,
+        default.filter_visible(
+            select(Record.id), plain_user, {role_name}, Record, DatasetGrant
+        ),
+    )
+    over_plain = await _visible_ids(
+        session,
+        overlay.filter_visible(
+            select(Record.id), plain_user, {role_name}, Record, DatasetGrant
+        ),
+    )
+    assert over_plain <= base_plain  # global subset invariant (never widens)
+    assert rec_a.id in over_plain
+    assert {rec_b.id, rec_c.id, rec_d.id} <= base_plain  # visible at baseline
+    assert not ({rec_b.id, rec_c.id, rec_d.id} & over_plain)  # narrowed out
+
+    # --- admin: admin_bypass -> overlay == baseline (equal, still a subset) ---
+    base_admin = await _visible_ids(
+        session,
+        default.filter_visible(
+            select(Record.id), plain_user, {"admin"}, Record, DatasetGrant
+        ),
+    )
+    over_admin = await _visible_ids(
+        session,
+        overlay.filter_visible(
+            select(Record.id), plain_user, {"admin"}, Record, DatasetGrant
+        ),
+    )
+    assert over_admin <= base_admin
+    assert seeded <= over_admin  # admin sees all seeded rows, unfiltered
+
+    # --- anonymous caller: overlay short-circuits to the baseline (inert) ---
+    base_anon = await _visible_ids(
+        session,
+        default.filter_visible(select(Record.id), None, set(), Record, DatasetGrant),
+    )
+    over_anon = await _visible_ids(
+        session,
+        overlay.filter_visible(select(Record.id), None, set(), Record, DatasetGrant),
+    )
+    assert (over_anon & seeded) == (base_anon & seeded)
+    assert rec_a.id in over_anon  # public + published stays visible
+
+
+async def test_filter_visible_spatial_straddle_within_excludes(
+    enterprise_permission, test_db_session, clean_tables, monkeypatch
+):
+    """Under the default ``within`` predicate, a record whose extent straddles
+    the region boundary is EXCLUDED — only fully-contained extents pass."""
+    session = test_db_session
+    role_name = _unique("geo")
+    user = await _add_user(session)
+
+    inside = await _add_record(session, sensitivity="public", extent_wkt=EXTENT_INSIDE)
+    outside = await _add_record(
+        session, sensitivity="public", extent_wkt=EXTENT_OUTSIDE
+    )
+    straddle = await _add_record(
+        session, sensitivity="public", extent_wkt=EXTENT_STRADDLE
+    )
+    await session.commit()
+
+    monkeypatch.setenv("GEOLENS_PERM_ABAC_MODE", "role")
+    monkeypatch.setenv("GEOLENS_PERM_SPATIAL_PREDICATE", "within")
+    monkeypatch.setenv(
+        "GEOLENS_PERM_ROLE_POLICY",
+        json.dumps({role_name: {"clearance": "restricted", "region_wkt": REGION_WKT}}),
+    )
+
+    overlay = enterprise_permission.EnterprisePermissionExtension()
+    visible = await _visible_ids(
+        session,
+        overlay.filter_visible(
+            select(Record.id), user, {role_name}, Record, DatasetGrant
+        ),
+    )
+
+    seeded = {inside.id, outside.id, straddle.id}
+    assert visible & seeded == {inside.id}
+
+
+async def test_filter_visible_spatial_straddle_intersects_includes(
+    enterprise_permission, test_db_session, clean_tables, monkeypatch
+):
+    """Switching the predicate to ``intersects`` INCLUDES the straddling record
+    (any overlap qualifies) while the fully-outside record stays excluded."""
+    session = test_db_session
+    role_name = _unique("geo")
+    user = await _add_user(session)
+
+    inside = await _add_record(session, sensitivity="public", extent_wkt=EXTENT_INSIDE)
+    outside = await _add_record(
+        session, sensitivity="public", extent_wkt=EXTENT_OUTSIDE
+    )
+    straddle = await _add_record(
+        session, sensitivity="public", extent_wkt=EXTENT_STRADDLE
+    )
+    await session.commit()
+
+    monkeypatch.setenv("GEOLENS_PERM_ABAC_MODE", "role")
+    monkeypatch.setenv("GEOLENS_PERM_SPATIAL_PREDICATE", "intersects")
+    monkeypatch.setenv(
+        "GEOLENS_PERM_ROLE_POLICY",
+        json.dumps({role_name: {"clearance": "restricted", "region_wkt": REGION_WKT}}),
+    )
+
+    overlay = enterprise_permission.EnterprisePermissionExtension()
+    visible = await _visible_ids(
+        session,
+        overlay.filter_visible(
+            select(Record.id), user, {role_name}, Record, DatasetGrant
+        ),
+    )
+
+    seeded = {inside.id, outside.id, straddle.id}
+    assert visible & seeded == {inside.id, straddle.id}
+
+
+async def test_filter_visible_inert_when_mode_unset(
+    enterprise_permission, test_db_session, clean_tables, monkeypatch
+):
+    """With ABAC mode unset the overlay returns EXACTLY the delegate result —
+    same rows and the same compiled statement (no narrowing clause added)."""
+    session = test_db_session
+    monkeypatch.delenv("GEOLENS_PERM_ABAC_MODE", raising=False)
+    user = await _add_user(session)
+    rec = await _add_record(session, sensitivity="restricted", created_by=user.id)
+    await session.commit()
+
+    default = DefaultPermissionExtension()
+    overlay = enterprise_permission.EnterprisePermissionExtension()
+
+    base_stmt = default.filter_visible(
+        select(Record.id), user, {"viewer"}, Record, DatasetGrant
+    )
+    over_stmt = overlay.filter_visible(
+        select(Record.id), user, {"viewer"}, Record, DatasetGrant
+    )
+
+    assert str(over_stmt) == str(base_stmt)  # no restrictive clause appended
+    assert await _visible_ids(session, over_stmt) == await _visible_ids(
+        session, base_stmt
+    )
+    assert rec.id in await _visible_ids(session, over_stmt)  # own record visible
+
+
+def test_abac_clause_compiles_against_real_record_columns(
+    enterprise_permission, monkeypatch
+):
+    """The restrictive clause must reference the REAL Record columns; a rename of
+    sensitivity_classification / owner_org / spatial_extent trips this guard even
+    without a database."""
+    from geolens_enterprise.permission.policy import load_policy
+    from geolens_enterprise.permission.predicates import build_abac_clause
+
+    role_name = _unique("compile")
+    monkeypatch.setenv("GEOLENS_PERM_ABAC_MODE", "role")
+    monkeypatch.setenv(
+        "GEOLENS_PERM_ROLE_POLICY",
+        json.dumps(
+            {
+                role_name: {
+                    "clearance": "confidential",
+                    "region_wkt": REGION_WKT,
+                    "orgs": ["alpha"],
+                }
+            }
+        ),
+    )
+
+    policy = load_policy()
+    scope = policy.resolve({role_name})
+    clause_sql = str(build_abac_clause(Record, scope, policy))
+
+    assert "sensitivity_classification" in clause_sql
+    assert "owner_org" in clause_sql
+    assert "spatial_extent" in clause_sql

--- a/backend/tests/test_permission_overlay.py
+++ b/backend/tests/test_permission_overlay.py
@@ -177,6 +177,11 @@ async def test_filter_visible_subset_invariant(
     assert rec_a.id in over_plain
     assert {rec_b.id, rec_c.id, rec_d.id} <= base_plain  # visible at baseline
     assert not ({rec_b.id, rec_c.id, rec_d.id} & over_plain)  # narrowed out
+    # fix(#515): the grant path must be LIVE — the restricted record reaches the
+    # baseline via Dataset.record_id -> DatasetGrant -> UserRole, and survives
+    # the ABAC narrowing because it is internal/alpha (within policy).
+    assert rec_restricted.id in base_plain
+    assert rec_restricted.id in over_plain
 
     # --- admin: admin_bypass -> overlay == baseline (equal, still a subset) ---
     base_admin = await _visible_ids(
@@ -205,6 +210,7 @@ async def test_filter_visible_subset_invariant(
     )
     assert (over_anon & seeded) == (base_anon & seeded)
     assert rec_a.id in over_anon  # public + published stays visible
+    assert rec_restricted.id not in base_anon  # grants never leak to anonymous
 
 
 async def test_filter_visible_spatial_straddle_within_excludes(

--- a/backend/tests/test_workflow_overlay.py
+++ b/backend/tests/test_workflow_overlay.py
@@ -1,0 +1,420 @@
+"""Composed integration tests for the enterprise publication WorkflowExtension.
+
+These exercise the private overlay's ``EnterpriseWorkflowExtension`` SoD /
+clearance / reviewer-role gating through the REAL core consumption path — the
+real ``WorkflowTransitionContext`` protocol class over real seeded
+``Dataset`` / ``Record`` / ``User`` rows, and the real
+``update_publication_status`` route handler that raises 422 when a transition is
+denied. The overlay's own suite can only assert this logic against
+``SimpleNamespace`` stubs, so context-shape drift (``dataset.record.created_by``,
+``actor.roles``) would go undetected there; this composed file catches it. It
+lives in CORE because only core ships the ORM models, the route, and the DB
+fixtures. See enterprise-overlay-audit-20260715 §6.
+
+Skip-not-fail: the overlay is imported via ``pytest.importorskip`` inside the
+``enterprise_workflow`` fixture, exactly like conftest's
+``saml_overlay_registered``. An OSS checkout without ``geolens_enterprise``
+SKIPS these tests; the overlay's cross-repo CI job forces them to run.
+
+The workflow is inert unless ``GEOLENS_WORKFLOW_MODE=on``. Each test sets the
+mode + policy via ``monkeypatch`` BEFORE constructing the extension, because
+``load_policy()`` reads the environment at construction time.
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+
+from fastapi import HTTPException
+import pytest
+from sqlalchemy import select
+from sqlalchemy.orm import joinedload
+from types import SimpleNamespace
+
+from app.modules.auth.models import Role, User, UserRole
+from app.modules.catalog.datasets.domain.models import Dataset, Record
+from app.platform.extensions.defaults import DefaultWorkflowExtension
+from app.platform.extensions.protocols import WorkflowTransitionContext
+
+
+@pytest.fixture
+def enterprise_workflow():
+    """Import the overlay's workflow package or SKIP (never fail)."""
+    return pytest.importorskip(
+        "geolens_enterprise.workflow",
+        reason="geolens_enterprise package is not installed",
+    )
+
+
+@pytest.fixture
+def workflow_slot():
+    """Save/restore ``_extensions['workflow']`` so a test can install the overlay
+    into the live registry (the shape the /status/ route reads) without leaking
+    it to other tests. Mirrors conftest's ``saml_overlay_registered`` teardown."""
+    import app.platform.extensions as ext_mod
+
+    had = "workflow" in ext_mod._extensions
+    saved = ext_mod._extensions.get("workflow")
+    yield ext_mod
+    if had:
+        ext_mod._extensions["workflow"] = saved
+    else:
+        ext_mod._extensions.pop("workflow", None)
+
+
+def _unique(prefix: str) -> str:
+    return f"{prefix}_{uuid.uuid4().hex[:8]}"
+
+
+def _policy_json(reviewer_role: str) -> str:
+    """A minimal three-axis approval policy: only ``reviewer_role`` may approve,
+    the edge is separation-of-duties AND clearance gated."""
+    return json.dumps(
+        {
+            "states": ["draft", "pending_review", "approved", "published"],
+            "transitions": {
+                "draft": ["pending_review"],
+                "pending_review": ["approved", "draft"],
+                "approved": ["published", "pending_review"],
+                "published": ["approved"],
+            },
+            "edge_roles": {"pending_review->approved": [reviewer_role]},
+            "sod_edges": ["pending_review->approved"],
+            "clearance_edges": ["pending_review->approved"],
+            "role_clearance": {reviewer_role: "confidential"},
+        }
+    )
+
+
+async def _make_role(session, name: str) -> Role:
+    role = Role(name=name, description="wf test role")
+    session.add(role)
+    await session.flush()
+    return role
+
+
+async def _get_or_create_admin_role(session) -> Role:
+    result = await session.execute(select(Role).where(Role.name == "admin"))
+    role = result.scalar_one_or_none()
+    if role is None:
+        role = await _make_role(session, "admin")
+    return role
+
+
+async def _make_user(session, role_ids: list[uuid.UUID]) -> User:
+    user = User(username=_unique("wf_user"), status="active", is_active=True)
+    session.add(user)
+    await session.flush()
+    for role_id in role_ids:
+        session.add(UserRole(user_id=user.id, role_id=role_id))
+    await session.flush()
+    # Re-fetch so the selectin `roles` relationship is populated for async access.
+    result = await session.execute(select(User).where(User.id == user.id))
+    return result.scalar_one()
+
+
+async def _make_dataset(
+    session, *, created_by: uuid.UUID, sensitivity: str, record_status: str
+) -> Dataset:
+    record = Record(
+        title=_unique("record"),
+        visibility="private",
+        record_status=record_status,
+        record_type="vector_dataset",
+        sensitivity_classification=sensitivity,
+        created_by=created_by,
+    )
+    session.add(record)
+    await session.flush()
+    dataset = Dataset(record_id=record.id, table_name=_unique("tbl"))
+    session.add(dataset)
+    await session.flush()
+    # joinedload so the overlay's `dataset.record.*` reads work in async context.
+    result = await session.execute(
+        select(Dataset)
+        .options(joinedload(Dataset.record))
+        .where(Dataset.id == dataset.id)
+    )
+    return result.unique().scalar_one()
+
+
+def _context(dataset, actor, from_status, to_status, *, mode="status"):
+    return WorkflowTransitionContext(
+        session=None,
+        dataset=dataset,
+        actor=actor,
+        from_status=from_status,
+        to_status=to_status,
+        mode=mode,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Gating matrix — real WorkflowTransitionContext over real models
+# ---------------------------------------------------------------------------
+
+
+async def test_allowed_transitions_allows_cleared_non_author_reviewer(
+    enterprise_workflow, test_db_session, clean_tables, monkeypatch
+):
+    """A reviewer who is NOT the author and holds sufficient clearance may
+    approve — 'approved' is a permitted transition from 'pending_review'."""
+    session = test_db_session
+    reviewer_role = _unique("reviewer")
+    role = await _make_role(session, reviewer_role)
+    author = await _make_user(session, [])
+    reviewer = await _make_user(session, [role.id])
+    dataset = await _make_dataset(
+        session,
+        created_by=author.id,
+        sensitivity="confidential",
+        record_status="pending_review",
+    )
+    await session.commit()
+
+    monkeypatch.setenv("GEOLENS_WORKFLOW_MODE", "on")
+    monkeypatch.setenv("GEOLENS_WORKFLOW_POLICY", _policy_json(reviewer_role))
+    ext = enterprise_workflow.EnterpriseWorkflowExtension()
+
+    allowed = await ext.allowed_transitions(
+        _context(dataset, reviewer, "pending_review", "approved")
+    )
+    assert "approved" in allowed
+
+
+async def test_allowed_transitions_denies_self_approval_sod(
+    enterprise_workflow, test_db_session, clean_tables, monkeypatch
+):
+    """Separation of duties: the dataset author cannot approve their own
+    dataset, even holding the reviewer role and sufficient clearance."""
+    session = test_db_session
+    reviewer_role = _unique("reviewer")
+    role = await _make_role(session, reviewer_role)
+    # Author also holds the reviewer role, so the ONLY failing axis is SoD.
+    author = await _make_user(session, [role.id])
+    dataset = await _make_dataset(
+        session,
+        created_by=author.id,
+        sensitivity="confidential",
+        record_status="pending_review",
+    )
+    await session.commit()
+
+    monkeypatch.setenv("GEOLENS_WORKFLOW_MODE", "on")
+    monkeypatch.setenv("GEOLENS_WORKFLOW_POLICY", _policy_json(reviewer_role))
+    ext = enterprise_workflow.EnterpriseWorkflowExtension()
+
+    allowed = await ext.allowed_transitions(
+        _context(dataset, author, "pending_review", "approved")
+    )
+    assert "approved" not in allowed
+
+
+async def test_allowed_transitions_denies_insufficient_clearance(
+    enterprise_workflow, test_db_session, clean_tables, monkeypatch
+):
+    """A reviewer whose clearance is below the dataset's sensitivity cannot
+    approve it (they could not even see it under the ABAC gate)."""
+    session = test_db_session
+    reviewer_role = _unique("reviewer")
+    role = await _make_role(session, reviewer_role)
+    author = await _make_user(session, [])
+    reviewer = await _make_user(session, [role.id])  # clearance = confidential (2)
+    dataset = await _make_dataset(
+        session,
+        created_by=author.id,
+        sensitivity="restricted",  # ordinal 3 > reviewer's 2
+        record_status="pending_review",
+    )
+    await session.commit()
+
+    monkeypatch.setenv("GEOLENS_WORKFLOW_MODE", "on")
+    monkeypatch.setenv("GEOLENS_WORKFLOW_POLICY", _policy_json(reviewer_role))
+    ext = enterprise_workflow.EnterpriseWorkflowExtension()
+
+    allowed = await ext.allowed_transitions(
+        _context(dataset, reviewer, "pending_review", "approved")
+    )
+    assert "approved" not in allowed
+
+
+async def test_allowed_transitions_denies_missing_reviewer_role(
+    enterprise_workflow, test_db_session, clean_tables, monkeypatch
+):
+    """An actor lacking the edge's required role cannot traverse it, even when
+    SoD and clearance would otherwise pass."""
+    session = test_db_session
+    reviewer_role = _unique("reviewer")
+    other_role = await _make_role(session, _unique("editor"))
+    author = await _make_user(session, [])
+    actor = await _make_user(session, [other_role.id])  # not the reviewer role
+    dataset = await _make_dataset(
+        session,
+        created_by=author.id,
+        sensitivity="public",
+        record_status="pending_review",
+    )
+    await session.commit()
+
+    monkeypatch.setenv("GEOLENS_WORKFLOW_MODE", "on")
+    monkeypatch.setenv("GEOLENS_WORKFLOW_POLICY", _policy_json(reviewer_role))
+    ext = enterprise_workflow.EnterpriseWorkflowExtension()
+
+    allowed = await ext.allowed_transitions(
+        _context(dataset, actor, "pending_review", "approved")
+    )
+    assert "approved" not in allowed
+
+
+async def test_allowed_transitions_inert_when_mode_off(
+    enterprise_workflow, test_db_session, clean_tables, monkeypatch
+):
+    """With mode unset the overlay delegates entirely to the community default —
+    same status_order and the same allowed set for the same context."""
+    session = test_db_session
+    monkeypatch.delenv("GEOLENS_WORKFLOW_MODE", raising=False)
+    author = await _make_user(session, [])
+    dataset = await _make_dataset(
+        session, created_by=author.id, sensitivity="internal", record_status="draft"
+    )
+    await session.commit()
+
+    default = DefaultWorkflowExtension()
+    ext = enterprise_workflow.EnterpriseWorkflowExtension()
+
+    assert ext.status_order() == default.status_order()
+    ctx = _context(dataset, author, "draft", "ready")
+    assert await ext.allowed_transitions(ctx) == await default.allowed_transitions(ctx)
+    assert "ready" in await ext.allowed_transitions(ctx)
+
+
+# ---------------------------------------------------------------------------
+# Real route handler — 422 on deny / 200 on allow / inert delegate
+# ---------------------------------------------------------------------------
+
+
+async def test_status_route_denies_sod_self_approval_422(
+    enterprise_workflow, workflow_slot, test_db_session, clean_tables, monkeypatch
+):
+    """The real /status/ handler returns 422 when the overlay denies a
+    self-approval (SoD), and the record status is left unchanged."""
+    from app.modules.catalog.datasets.api.router_data import update_publication_status
+    from app.modules.catalog.datasets.domain.schemas import StatusUpdate
+
+    session = test_db_session
+    reviewer_role = _unique("reviewer")
+    role = await _make_role(session, reviewer_role)
+    author = await _make_user(session, [role.id])
+    dataset = await _make_dataset(
+        session,
+        created_by=author.id,
+        sensitivity="confidential",
+        record_status="pending_review",
+    )
+    await session.commit()
+
+    monkeypatch.setenv("GEOLENS_WORKFLOW_MODE", "on")
+    monkeypatch.setenv("GEOLENS_WORKFLOW_POLICY", _policy_json(reviewer_role))
+    workflow_slot._extensions["workflow"] = (
+        enterprise_workflow.EnterpriseWorkflowExtension()
+    )
+
+    with pytest.raises(HTTPException) as exc:
+        await update_publication_status(
+            dataset.id,
+            StatusUpdate(status="approved"),
+            SimpleNamespace(),
+            author,
+            session,
+        )
+    assert exc.value.status_code == 422
+    assert "Cannot transition" in exc.value.detail
+
+    refreshed = await session.execute(
+        select(Record.record_status).where(Record.id == dataset.record_id)
+    )
+    assert refreshed.scalar_one() == "pending_review"
+
+
+async def test_status_route_allows_admin_transition_200(
+    enterprise_workflow, workflow_slot, test_db_session, clean_tables, monkeypatch
+):
+    """The real /status/ handler commits an admin-bypassed transition (200) and
+    persists the new status."""
+    from app.modules.catalog.datasets.api.router_data import update_publication_status
+    from app.modules.catalog.datasets.domain.schemas import StatusUpdate
+
+    session = test_db_session
+    admin_role = await _get_or_create_admin_role(session)
+    admin = await _make_user(session, [admin_role.id])
+    reviewer_role = _unique("reviewer")
+    dataset = await _make_dataset(
+        session,
+        created_by=admin.id,
+        sensitivity="confidential",
+        record_status="pending_review",
+    )
+    await session.commit()
+
+    monkeypatch.setenv("GEOLENS_WORKFLOW_MODE", "on")
+    monkeypatch.setenv("GEOLENS_WORKFLOW_POLICY", _policy_json(reviewer_role))
+    workflow_slot._extensions["workflow"] = (
+        enterprise_workflow.EnterpriseWorkflowExtension()
+    )
+
+    response = await update_publication_status(
+        dataset.id,
+        StatusUpdate(status="approved"),
+        SimpleNamespace(),
+        admin,
+        session,
+    )
+    assert response.record_status == "approved"
+
+    refreshed = await session.execute(
+        select(Record.record_status).where(Record.id == dataset.record_id)
+    )
+    assert refreshed.scalar_one() == "approved"
+
+
+async def test_status_route_inert_delegates_when_mode_off(
+    enterprise_workflow, workflow_slot, test_db_session, clean_tables, monkeypatch
+):
+    """With the overlay installed but mode unset, the /status/ handler follows
+    the community lifecycle: draft->ready allowed (200), draft->published 422."""
+    from app.modules.catalog.datasets.api.router_data import update_publication_status
+    from app.modules.catalog.datasets.domain.schemas import StatusUpdate
+
+    session = test_db_session
+    monkeypatch.delenv("GEOLENS_WORKFLOW_MODE", raising=False)
+    admin_role = await _get_or_create_admin_role(session)
+    admin = await _make_user(session, [admin_role.id])
+    dataset = await _make_dataset(
+        session, created_by=admin.id, sensitivity="internal", record_status="draft"
+    )
+    await session.commit()
+
+    workflow_slot._extensions["workflow"] = (
+        enterprise_workflow.EnterpriseWorkflowExtension()
+    )
+
+    ok = await update_publication_status(
+        dataset.id, StatusUpdate(status="ready"), SimpleNamespace(), admin, session
+    )
+    assert ok.record_status == "ready"
+
+    # Reset to draft to exercise the disallowed one-shot jump from the same base.
+    reset = await session.execute(select(Record).where(Record.id == dataset.record_id))
+    reset.scalar_one().record_status = "draft"
+    await session.commit()
+
+    with pytest.raises(HTTPException) as exc:
+        await update_publication_status(
+            dataset.id,
+            StatusUpdate(status="published"),
+            SimpleNamespace(),
+            admin,
+            session,
+        )
+    assert exc.value.status_code == 422


### PR DESCRIPTION
## What

Closes the two composed-coverage gaps found by the 2026-07-15 enterprise-overlay audit (§6): the enterprise governance surfaces — ABAC row-filtering and publication approval workflows — were previously validated only against test-local fakes in the overlay repo, so a core column rename or a widening regression would pass every existing test.

- **`backend/tests/test_permission_overlay.py`** (new, 5 tests): `EnterprisePermissionExtension.filter_visible` against real `Record`/`DatasetGrant`/`User` rows in Postgres — subset invariant (admin / granted user / anonymous), spatial straddle semantics, inert-when-unconfigured, and a predicate compile guard pinning the real `sensitivity_classification`/`owner_org`/`spatial_extent` columns.
- **`backend/tests/test_workflow_overlay.py`** (new, 8 tests): `EnterpriseWorkflowExtension` gating through the real `update_publication_status` path — SoD self-approval → 422 with the record unchanged, allowed admin transition → persisted, inert delegate parity when the mode is off.
- **`backend/app/core/db/schema_skew.py`**: public `build_alembic_config()` wrapper so overlay tooling stops importing the private `_build_alembic_config` (no behavior change).
- **`EDITIONS.md`**: scope the Enterprise claim to "SIEM audit streaming" (no discrete compliance-automation feature exists).

Both test modules gate on `pytest.importorskip("geolens_enterprise…")` inside a fixture (same pattern as `test_saml_overlay.py`), so OSS CI **skips** them; the enterprise overlay's cross-repo CI job will force them to run once it repins to a core commit containing this PR.

## Impacts

- No runtime/schema/API changes (one additive public function in `schema_skew`).
- Public docs: one-line EDITIONS.md wording fix.

## Verification

- `cd backend && uv run ruff check . && uv run ruff format --check .` — clean.
- Without the overlay (host-port recipe, Postgres :5434): `uv run pytest tests/test_permission_overlay.py tests/test_workflow_overlay.py -v` → **13 skipped** (skip-not-fail).
- With `geolens_enterprise` 0.3.1 editable-installed into an isolated venv: same command → **13 passed**.
