### PR TITLE
chore(release): v1.4.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,70 @@ and releases use semantic versioning.
 
 ## [Unreleased]
 
+## [1.4.7] - 2026-07-15
+
+This release hardens the platform after a full portfolio audit — access
+control, the open-core boundary, containers, migrations, and the admin
+control plane — and completes the internationalization pass across all four
+locales.
+
+### Added
+
+- **Community administrators can download up to 100,000 audit events as CSV
+  or JSON.** Share links can expire after 1, 7, 30, or 90 days, and
+  non-expiring links remain available.
+
+### Changed
+
+- **Optional distributions now connect to GeoLens through typed extension
+  interfaces.** Community images contain only the Apache-2.0 application, and
+  the default single-tenant configuration does not load an extension.
+- **An installed version covered by a valid commercial license keeps working
+  after its maintenance date.** The date controls access to updates and
+  support; it does not shut down the installation.
+- **The AI assistant defaults to Anthropic's Claude Sonnet 5 model.**
+  Deployments that set `LLM_MODEL` explicitly keep their configured model.
+- **Updated dependencies across the backend and frontend**, including
+  security releases of Pillow (12.3.0) and click (8.4.2).
+
+### Fixed
+
+- **Role-based grants on restricted records now take effect.** The visibility
+  filter compared record identifiers against dataset identifiers, so a role
+  grant could never surface a restricted record. The gap failed closed
+  (nothing was over-exposed); granted users simply did not see the records
+  they were entitled to.
+- **Restored OGC API Features/Records, STAC, and DCAT conformance.**
+  Conformance regressions found by the standards audit are fixed, and the
+  suites gate CI again.
+- **The published OpenAPI document matches runtime behavior again**, so
+  generated SDKs and API clients reflect the deployed contract.
+- **Accessibility and design-system fixes across the frontend**, from the
+  frontend audit: keyboard navigation, contrast, and component-consistency
+  issues.
+- **Spanish, French, and German localizations are complete.** The
+  internationalization audit closed the remaining untranslated and
+  inconsistent strings in all four locales.
+- **Enterprise-edition workers no longer refuse to boot.** The worker's
+  startup assertion demanded cloud-only extensions under a single-tenant
+  enterprise deployment; each overlay tier is now checked only for the
+  extensions it actually provides.
+- **Ingestion lifecycle hardening.** Stalled ingests are reaped reliably and
+  ingest work is isolated per tenant context.
+
+### Security
+
+- **Admin control-plane governance and lifecycle hardened** following the
+  admin audit, including tighter authorization on administrative operations.
+- **Container images remediated against a Docker audit**, reducing the
+  runtime attack surface of the published images.
+- **Environment contracts aligned and validated**, so misconfigured
+  deployments fail loudly at boot instead of running with silently ignored
+  settings.
+- **Migration rollback and online schema changes hardened**, with
+  lock-sensitive steps bounded so they cannot stall a busy production
+  database indefinitely.
+
 ### Upgrade notes
 
 - **Database SSL modes now fail closed.** Undocumented `allow` and `verify-ca`
@@ -22,21 +86,6 @@ and releases use semantic versioning.
   On a busy database, lock-sensitive steps stop after five seconds instead of
   waiting behind application traffic. Retry the migration during a quieter
   window if that happens.
-
-### Added
-
-- Community administrators can download up to 100,000 audit events as CSV or
-  JSON. Share links can expire after 1, 7, 30, or 90 days, and non-expiring
-  links remain available.
-
-### Changed
-
-- Optional distributions now connect to GeoLens through typed extension
-  interfaces. Community images contain only the Apache-2.0 application, and
-  the default single-tenant configuration does not load an extension.
-- An installed version covered by a valid commercial license keeps working
-  after its maintenance date. The date controls access to updates and support;
-  it does not shut down the installation.
 
 ## [1.4.6] - 2026-07-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and releases use semantic versioning.
 ## [1.4.7] - 2026-07-15
 
 This release hardens the platform after a full portfolio audit — access
-control, the open-core boundary, containers, migrations, and the admin
+control, the extension boundary, containers, migrations, and the admin
 control plane — and completes the internationalization pass across all four
 locales.
 
@@ -51,10 +51,10 @@ locales.
 - **Spanish, French, and German localizations are complete.** The
   internationalization audit closed the remaining untranslated and
   inconsistent strings in all four locales.
-- **Enterprise-edition workers no longer refuse to boot.** The worker's
-  startup assertion demanded cloud-only extensions under a single-tenant
-  enterprise deployment; each overlay tier is now checked only for the
-  extensions it actually provides.
+- **Workers with a commercial extension installed no longer refuse to
+  boot.** The worker's startup assertion demanded extensions from a different
+  distribution tier; each tier is now checked only for the extensions it
+  actually provides.
 - **Ingestion lifecycle hardening.** Stalled ingests are reaped reliably and
   ingest work is isolated per tenant context.
 

--- a/backend/app/api/main.py
+++ b/backend/app/api/main.py
@@ -559,7 +559,7 @@ _is_production = settings.is_production
 # no metadata to read. We fall back to the current published line so import never
 # crashes. Keep this fallback in lockstep with backend/pyproject.toml — it is one
 # of the sites `make bump` rewrites.
-_FALLBACK_APP_VERSION = "1.4.6"
+_FALLBACK_APP_VERSION = "1.4.7"
 
 
 def _resolve_app_version() -> str:

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -17082,7 +17082,7 @@
     "summary": "PostGIS-native geospatial data catalog with OGC API Features and Records support",
     "termsOfService": "https://github.com/geolens-io/geolens/blob/main/LICENSE",
     "title": "GeoLens API",
-    "version": "1.4.6"
+    "version": "1.4.7"
   },
   "openapi": "3.1.0",
   "paths": {

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geolens-backend"
-version = "1.4.6"
+version = "1.4.7"
 description = "PostGIS-native GIS data catalog"
 # Docker image (Dockerfile) ships python:3.14-slim (see the Dockerfile FROM for
 # the exact patch pin) as the project's tested runtime.

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -865,7 +865,7 @@ wheels = [
 
 [[package]]
 name = "geolens-backend"
-version = "1.4.6"
+version = "1.4.7"
 source = { virtual = "." }
 dependencies = [
     { name = "alembic" },

--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "geolens-cli"
-version = "1.4.6"
+version = "1.4.7"
 description = "Apache-2.0 command-line interface for the GeoLens API. Login, scan, publish, and export STAC against any GeoLens instance."
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/docs-contract.json
+++ b/docs-contract.json
@@ -1,6 +1,6 @@
 {
   "_comment": "Canonical cross-surface facts for the GeoLens README, marketing site (getgeolens.com/src), and docs site (getgeolens.com/docs). Validated against scripts/install.sh + backend/pyproject.toml by scripts/check_docs_contract.py (geolens CI). The getgeolens.com repo vendors a copy and enforces the same `forbidden` list in its own CI. See docs-internal/DOC-CONSISTENCY-STRATEGY for the full design. Edit a fact ONCE here (and in its canonical source) — the gates make every surface follow.",
-  "version": "1.4.6",
+  "version": "1.4.7",
   "install": {
     "oneLiner": "curl -fsSL https://getgeolens.com/install.sh | sh",
     "sourceBuild": "bash scripts/install.sh",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.4.6",
+  "version": "1.4.7",
   "type": "module",
   "license": "Apache-2.0",
   "author": "Carto Concepts, LLC",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "geolens",
-  "version": "1.4.6",
+  "version": "1.4.7",
   "private": true,
   "license": "Apache-2.0",
   "author": "Carto Concepts, LLC",

--- a/sdks/python/.openapi-python-client.yaml
+++ b/sdks/python/.openapi-python-client.yaml
@@ -4,7 +4,7 @@ project_name_override: geolens
 package_name_override: geolens
 # Rewritten on every `make sdks` run by scripts/sync_sdk_versions.py to match
 # backend/openapi.json info.version. Do not edit by hand.
-package_version_override: 1.4.6
+package_version_override: 1.4.7
 
 # Cleaner enum output (matches our pydantic v2 backend's enum emission).
 literal_enums: true

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "geolens"
-version = "1.4.6"
+version = "1.4.7"
 description = "Auto-generated Python SDK for the GeoLens API. Typed clients with Bearer + API-key auth helpers."
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/sdks/typescript/package-lock.json
+++ b/sdks/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@geolens/sdk",
-  "version": "1.4.6",
+  "version": "1.4.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@geolens/sdk",
-      "version": "1.4.6",
+      "version": "1.4.7",
       "license": "Apache-2.0",
       "dependencies": {
         "@hey-api/client-fetch": "0.13.1"

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@geolens/sdk",
-  "version": "1.4.6",
+  "version": "1.4.7",
   "description": "Auto-generated TypeScript SDK for the GeoLens API. Typed clients with Bearer + API-key auth helpers.",
   "license": "Apache-2.0",
   "author": "Carto Concepts, LLC",


### PR DESCRIPTION
## What

Release prep for **v1.4.7**: `make bump VERSION=1.4.7` (all version sites, including the TS SDK lockfile), OpenAPI/SDK regen (version stamps only), and the `[1.4.7]` CHANGELOG entry promoting the curated Unreleased section plus notes for the 39 commits since v1.4.6 (portfolio-audit hardening wave: open-core boundary, access control, containers, migrations, admin control plane, i18n completion, restricted-grant visibility fix).

## Verification

- `make version-check` — green (all sites at 1.4.7).
- `backend/openapi.json` and SDK diffs are version-line-only.
- CHANGELOG header follows the exact `## [1.4.7] - 2026-07-15` shape release.yml extracts.

After merge: tag `v1.4.7` at the merge SHA via the GitHub API per the release runbook (smoke-gated release, approval-gated publishes).
