### PR TITLE
fix(docker): drop unused gosu from the backup image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -217,7 +217,11 @@ RUN apt-get update && apt-get upgrade -y --no-install-recommends && \
     apt-get install -y --no-install-recommends \
     awscli \
     procps \
-    && rm -rf /var/lib/apt/lists/*
+    && rm -rf /var/lib/apt/lists/* \
+    # fix(#517): drop the base image's gosu — the backup entrypoint never
+    # invokes it, and its Go-built binary trips Trivy's CRITICAL/HIGH gate
+    # (Go stdlib CVEs) independently of our own code.
+    && rm -f /usr/local/bin/gosu
 
 # Bake the backup and restore scripts so the image is self-contained and
 # runnable without a host bind-mount. The compose bind-mount


### PR DESCRIPTION
The v1.4.7 tag publish failed at the geolens-backup Trivy gate: the digest-pinned postgres:17 base bundles `gosu`, whose Go-built binary now carries 1 CRITICAL + 14 HIGH Go-stdlib findings (Trivy DB moved since v1.4.6). Neither `backup-entrypoint.sh` nor `restore.sh` invokes gosu, so remove it in the backup stage — clears all findings and stays fixed regardless of upstream's rebuild cadence.

Verified locally: `docker build --target backup` succeeds; gosu absent; awscli + entrypoint intact.

After merge: re-cut the v1.4.7 tag at the new SHA (the current tag was never released — publish gates unapproved, no Release object; GHCR images are reversible per the runbook).