### PR TITLE
docs: fix changelog compare links, README badge target, EDITIONS cloud wording

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -737,7 +737,10 @@ regression-covered fixes:
 - Initial public release of the GeoLens catalog, API, map builder, CLI, SDKs,
   Docker development stack, and public documentation entrypoints.
 
-[Unreleased]: https://github.com/geolens-io/geolens/compare/v1.4.4...HEAD
+[Unreleased]: https://github.com/geolens-io/geolens/compare/v1.4.7...HEAD
+[1.4.7]: https://github.com/geolens-io/geolens/compare/v1.4.6...v1.4.7
+[1.4.6]: https://github.com/geolens-io/geolens/compare/v1.4.5...v1.4.6
+[1.4.5]: https://github.com/geolens-io/geolens/compare/v1.4.4...v1.4.5
 [1.4.4]: https://github.com/geolens-io/geolens/compare/v1.4.3...v1.4.4
 [1.4.3]: https://github.com/geolens-io/geolens/compare/v1.4.2...v1.4.3
 [1.4.2]: https://github.com/geolens-io/geolens/compare/v1.4.1...v1.4.2

--- a/EDITIONS.md
+++ b/EDITIONS.md
@@ -18,7 +18,7 @@ Carto Concepts, LLC offers optional paid support and add-ons. Enterprise include
 
 A valid commercial license grants perpetual use of the installed version. The maintenance term controls access to updates and support. When maintenance ends, the installed version keeps working, data and backups remain accessible, and local administrators keep their login path.
 
-GeoLens core also contains dormant, generic multi-tenant infrastructure: nullable tenant columns, mode-gated RLS and tenant schemas, request and worker context, and typed extension ports. This code is Apache-2.0 and remains inactive in the default single-tenant mode. The vendor-hosted Cloud product, tenant provisioning, billing, and private provider implementations are separate commercial work. GeoLens refuses to start in multi-tenant mode without an isolation overlay.
+GeoLens core also contains dormant, generic multi-tenant infrastructure: nullable tenant columns, mode-gated RLS and tenant schemas, request and worker context, and typed extension ports. This code is Apache-2.0 and remains inactive in the default single-tenant mode. Any future vendor-hosted Cloud offering, along with tenant provisioning, billing, and private provider implementations, is separate commercial work. GeoLens refuses to start in multi-tenant mode without an isolation overlay.
 
 CI prevents public application code from importing private paid or Cloud packages. Optional behavior uses typed extension protocols, and the Community defaults preserve the free product.
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ GeoLens is an open-source, self-hosted catalog and map builder for GIS and data 
 
 [![CI](https://github.com/geolens-io/geolens/actions/workflows/ci.yml/badge.svg)](https://github.com/geolens-io/geolens/actions/workflows/ci.yml)
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
-[![Python: backend 3.13+ / SDK 3.10+](https://img.shields.io/badge/python-3.13%2B_backend_%7C_3.10%2B_SDK-blue.svg)]()
+[![Python: backend 3.13+ / SDK 3.10+](https://img.shields.io/badge/python-3.13%2B_backend_%7C_3.10%2B_SDK-blue.svg)](https://www.python.org/)
 [![PostgreSQL 17 + PostGIS 3.5](https://img.shields.io/badge/PostGIS_3.5-PostgreSQL_17-336791.svg)](https://postgis.net/)
 [![OGC API](https://img.shields.io/badge/OGC_API-Features_%7C_Records-green.svg)](https://ogcapi.ogc.org/)
 


### PR DESCRIPTION
Three announcement-readiness polish items from today's docs/marketing audit (docs-internal/audits/docs-site-audit-20260715.md):

- **CHANGELOG.md** — add `[1.4.5]`–`[1.4.7]` compare-link definitions and bump `[Unreleased]` to `v1.4.7...HEAD`. The three newest release headings currently render as literal bracket text on GitHub, and the Unreleased diff wrongly spans 1.4.5–1.4.7.
- **README.md** — the Python badge was wrapped in an empty anchor `]()`; link it to python.org like the sibling badges.
- **EDITIONS.md** — "The vendor-hosted Cloud product … separate commercial work" implied an existing Cloud SaaS; there is no Cloud release pipeline. Rephrased as future/separate commercial work (matches the docs-site roadmap disclaimer).

No code, schema, API, or config impact. Verification: rendered locally; link targets resolve; compare URLs follow the existing footer pattern against real tags v1.4.5–v1.4.7.