### PR TITLE
fix(design): remediate 2026-07-15 design-audit findings (a11y, tokens, instrument system)

### DIFF
--- a/frontend/src/components/admin/AuditLogViewer.tsx
+++ b/frontend/src/components/admin/AuditLogViewer.tsx
@@ -333,7 +333,7 @@ export function AuditLogViewer() {
 
         {/* Loading skeleton */}
         {isLoading && !data ? (
-          <Table>
+          <Table aria-label={t('audit.title')}>
             <TableHeader>
               <TableRow>
                 <TableHead className="w-12">
@@ -372,7 +372,7 @@ export function AuditLogViewer() {
                     defaultValue: 'Tab to the details control, then use Up and Down arrows to move between rows.',
                   })}
                 </p>
-                <Table containerFocusable={false}>
+                <Table aria-label={t('audit.title')} containerFocusable={false}>
                 <TableHeader>
                   <TableRow>
                     <TableHead className="w-12">

--- a/frontend/src/components/admin/JobList.tsx
+++ b/frontend/src/components/admin/JobList.tsx
@@ -158,7 +158,7 @@ export function JobList() {
 
         {/* Job entries */}
         {isLoading && !data ? (
-          <Table>
+          <Table aria-label={t('jobs.title')}>
             <TableHeader>
               <TableRow>
                 <TableHead className="w-12">
@@ -195,7 +195,7 @@ export function JobList() {
                     defaultValue: 'Tab to the details control, then use Up and Down arrows to move between rows.',
                   })}
                 </p>
-                <Table containerFocusable={false}>
+                <Table aria-label={t('jobs.title')} containerFocusable={false}>
                 <TableHeader>
                   <TableRow>
                     <TableHead className="w-12">

--- a/frontend/src/components/admin/UserList.tsx
+++ b/frontend/src/components/admin/UserList.tsx
@@ -210,7 +210,7 @@ export function UserList() {
           </CardAction>
         </CardHeader>
         <CardContent>
-          <Table>
+          <Table aria-label={t('users.title')}>
             <TableHeader>
               <TableRow>
                 <TableHead>{t('users.table.username')}</TableHead>

--- a/frontend/src/components/admin/saml/SamlProvidersSection.tsx
+++ b/frontend/src/components/admin/saml/SamlProvidersSection.tsx
@@ -313,7 +313,7 @@ export function SamlProvidersSection() {
         ) : providers.length === 0 ? (
           <p className="text-sm text-muted-foreground italic">{t('saml.emptyState')}</p>
         ) : (
-          <Table>
+          <Table aria-label={t('saml.title')}>
             <TableHeader>
               <TableRow>
                 <TableHead>{t('saml.provider')}</TableHead>

--- a/frontend/src/components/admin/settings/SettingsAITab.tsx
+++ b/frontend/src/components/admin/settings/SettingsAITab.tsx
@@ -119,7 +119,7 @@ export function SettingsAITab({ settings, envOnly, onSave, onReset, isSaving, on
     <div className="space-y-6">
       {/* --- Inference (LLM) Configuration --- */}
       <div className="space-y-4">
-        <h3 className="text-sm font-semibold text-muted-foreground uppercase tracking-wide mb-4">
+        <h3 className="eyebrow mb-4">
           {t('ai.sectionInference')}
         </h3>
 
@@ -236,7 +236,7 @@ export function SettingsAITab({ settings, envOnly, onSave, onReset, isSaving, on
 
       {/* --- Semantic Search & Embeddings --- */}
       <div>
-        <h3 className="text-sm font-semibold text-muted-foreground uppercase tracking-wide mb-4">
+        <h3 className="eyebrow mb-4">
           {t('ai.sectionSemanticSearch')}
         </h3>
 
@@ -412,7 +412,7 @@ export function SettingsAITab({ settings, envOnly, onSave, onReset, isSaving, on
 
       {/* --- API Key Status --- */}
       <div>
-        <h3 className="text-sm font-semibold text-muted-foreground uppercase tracking-wide mb-4">
+        <h3 className="eyebrow mb-4">
           {t('ai.sectionApiKeys')}
         </h3>
         <div className="flex items-start gap-2 rounded-md border border-border bg-muted/30 p-3 max-w-md mb-4">

--- a/frontend/src/components/admin/settings/SettingsAuthTab.tsx
+++ b/frontend/src/components/admin/settings/SettingsAuthTab.tsx
@@ -347,7 +347,7 @@ function OAuthProvidersSection({ envOnly }: { envOnly: boolean }) {
             {t('settings.oauth.emptyState')}
           </p>
         ) : (
-          <Table>
+          <Table aria-label={t('settings.oauth.title')}>
             <TableHeader>
               <TableRow>
                 <TableHead>{t('settings.oauth.provider')}</TableHead>

--- a/frontend/src/components/admin/settings/SettingsPermissionsTab.tsx
+++ b/frontend/src/components/admin/settings/SettingsPermissionsTab.tsx
@@ -88,7 +88,7 @@ export function SettingsPermissionsTab({ settings, envOnly, onSave, onReset, isS
       </CardHeader>
       <CardContent>
         <div className="overflow-x-auto">
-          <Table>
+          <Table aria-label={t('settings.permissions.title')}>
             <TableHeader>
               <TableRow>
                 <TableHead>{t('settings.permissions.capabilityHeader')}</TableHead>

--- a/frontend/src/components/auth/OAuthButtons.tsx
+++ b/frontend/src/components/auth/OAuthButtons.tsx
@@ -121,7 +121,7 @@ export function OAuthButtons({ showDivider = true }: { showDivider?: boolean } =
             <span className="w-full border-t opacity-60" />
           </div>
           <div className="relative flex justify-center">
-            <span className="bg-background px-3 font-mono text-mini uppercase tracking-[0.1em] text-muted-foreground">
+            <span className="eyebrow bg-background px-3">
               {t('oauth.divider')}
             </span>
           </div>

--- a/frontend/src/components/builder/ActiveFilterChips.tsx
+++ b/frontend/src/components/builder/ActiveFilterChips.tsx
@@ -115,7 +115,7 @@ export function ActiveFilterChips({ layers, onClearFilter }: ActiveFilterChipsPr
           onClick={() => setOpen((v) => !v)}
           aria-expanded={open}
           aria-label={t('filters.toggle', { defaultValue: 'Show or hide active filters' })}
-          className="inline-flex items-center gap-1.5 rounded-full border bg-background/90 px-2.5 py-1 text-xs shadow-sm backdrop-blur-sm transition-colors hover:bg-accent"
+          className="inline-flex items-center gap-1.5 rounded-md border bg-background/90 px-2.5 py-1 text-xs shadow-sm backdrop-blur-sm transition-colors hover:bg-accent"
         >
           <Filter className="h-3.5 w-3.5 text-muted-foreground" aria-hidden="true" />
           <span className="font-medium text-foreground">
@@ -130,7 +130,7 @@ export function ActiveFilterChips({ layers, onClearFilter }: ActiveFilterChipsPr
           chips.map((chip) => (
             <span
               key={chip.layerId}
-              className="inline-flex items-center gap-1.5 rounded-full border bg-background/90 px-2.5 py-1 text-xs shadow-sm backdrop-blur-sm"
+              className="inline-flex items-center gap-1.5 rounded-md border bg-background/90 px-2.5 py-1 text-xs shadow-sm backdrop-blur-sm"
               title={`${chip.layerName}: ${chip.label}`}
             >
               <span className="font-mono text-2xs uppercase tracking-wider text-muted-foreground">
@@ -152,7 +152,7 @@ export function ActiveFilterChips({ layers, onClearFilter }: ActiveFilterChipsPr
           <button
             type="button"
             onClick={() => chips.forEach((chip) => onClearFilter(chip.layerId))}
-            className="rounded-full border bg-background/90 px-2.5 py-1 text-2xs font-medium uppercase tracking-wider text-muted-foreground shadow-sm backdrop-blur-sm transition-colors hover:text-destructive"
+            className="rounded-md border bg-background/90 px-2.5 py-1 text-2xs font-medium uppercase tracking-wider text-muted-foreground shadow-sm backdrop-blur-sm transition-colors hover:text-destructive"
           >
             {t('filters.clearAll', { defaultValue: 'Clear all' })}
           </button>

--- a/frontend/src/components/builder/BasemapGroupEditorScene.tsx
+++ b/frontend/src/components/builder/BasemapGroupEditorScene.tsx
@@ -81,7 +81,7 @@ export function BasemapGroupEditorScene({
       {/* 1. Preset section */}
       <section className="border-b">
         <div className="px-4 py-2">
-          <p className="text-2xs font-semibold uppercase tracking-[0.08em] text-muted-foreground mb-2">
+          <p className="eyebrow mb-2">
             {t('basemapGroup.presetSectionLabel', { defaultValue: 'PRESET' })}
           </p>
           {/* fix(#394) UX-03/B-017: expose selected-state to assistive tech —
@@ -168,7 +168,7 @@ export function BasemapGroupEditorScene({
       {sublayers.length > 0 && (
       <section className="border-b">
         <div className="px-4 py-2">
-          <p className="text-2xs font-semibold uppercase tracking-[0.08em] text-muted-foreground mb-2">
+          <p className="eyebrow mb-2">
             {t('basemapGroup.sublayersSectionLabel', { defaultValue: 'SUBLAYERS' })}
           </p>
           <p className="text-xs text-muted-foreground mb-2">

--- a/frontend/src/components/builder/BasemapGroupRow.tsx
+++ b/frontend/src/components/builder/BasemapGroupRow.tsx
@@ -162,8 +162,8 @@ export const BasemapGroupRow = memo(function BasemapGroupRow({
         <span
           className="flex items-center justify-center h-[22px] w-[22px] rounded-sm text-xs font-medium"
           style={{
-            backgroundColor: 'var(--primary-50, oklch(0.97 0.02 250))',
-            color: 'var(--primary-700, oklch(0.46 0.16 250))',
+            backgroundColor: 'var(--primary-50)',
+            color: 'var(--primary-700)',
           }}
           aria-hidden="true"
         >

--- a/frontend/src/components/builder/CatalogDragGhost.tsx
+++ b/frontend/src/components/builder/CatalogDragGhost.tsx
@@ -15,17 +15,17 @@ export function CatalogDragGhost({
   let swatchColor: string;
   let swatchGlyph: string;
   if (recordType === 'basemap') {
-    swatchBg = 'var(--primary-50, oklch(0.97 0.02 250))';
-    swatchColor = 'var(--primary-700, oklch(0.40 0.15 250))';
+    swatchBg = 'var(--primary-50)';
+    swatchColor = 'var(--primary-700)';
     swatchGlyph = 'B';
   } else if (recordType === 'raster_dataset' || recordType === 'vrt_dataset') {
-    swatchBg = 'var(--type-raster-bg, oklch(0.95 0.04 60))';
-    swatchColor = 'var(--type-raster, oklch(0.55 0.12 60))';
+    swatchBg = 'var(--type-raster-bg)';
+    swatchColor = 'var(--type-raster)';
     swatchGlyph = 'R';
   } else {
     // vector_dataset or unknown
-    swatchBg = 'var(--type-vector-bg, oklch(0.95 0.04 145))';
-    swatchColor = 'var(--type-vector, oklch(0.45 0.12 145))';
+    swatchBg = 'var(--type-vector-bg)';
+    swatchColor = 'var(--type-vector)';
     swatchGlyph = 'V';
   }
 

--- a/frontend/src/components/builder/ChatPanel.tsx
+++ b/frontend/src/components/builder/ChatPanel.tsx
@@ -1020,7 +1020,7 @@ export function ChatPanel({
                 <button
                   key={suggestion}
                   type="button"
-                  className="cursor-pointer text-xs px-2.5 py-1 rounded-full border border-border hover:bg-accent hover:border-primary/30 text-muted-foreground hover:text-foreground transition-colors"
+                  className="cursor-pointer text-xs px-2.5 py-1 rounded-md border border-border hover:bg-accent hover:border-primary/30 text-muted-foreground hover:text-foreground transition-colors"
                   onClick={() => {
                     setInput(suggestion);
                     requestAnimationFrame(() => {

--- a/frontend/src/components/builder/DEMEditorScene.tsx
+++ b/frontend/src/components/builder/DEMEditorScene.tsx
@@ -223,7 +223,7 @@ export const DEMEditorScene = memo(function DEMEditorScene({
         <div className="px-4 py-2">
           <p
             id={`section-appearance-dem-${layer.id}`}
-            className="text-2xs font-semibold uppercase tracking-[0.08em] text-muted-foreground mb-2"
+            className="eyebrow mb-2"
           >
             {t('demEditor.reliefShadingLabel', { defaultValue: 'RELIEF SHADING' })}
           </p>
@@ -251,7 +251,7 @@ export const DEMEditorScene = memo(function DEMEditorScene({
             <div className="space-y-4">
               {/* Sub-section: SUN POSITION */}
               <div>
-                <p className="text-2xs font-semibold uppercase tracking-[0.08em] text-muted-foreground mb-3">
+                <p className="eyebrow mb-3">
                   {t('demEditor.sunPositionLabel', { defaultValue: 'SUN POSITION' })}
                 </p>
 
@@ -291,7 +291,7 @@ export const DEMEditorScene = memo(function DEMEditorScene({
 
               {/* Sub-section: SHADING COLORS */}
               <div>
-                <p className="text-2xs font-semibold uppercase tracking-[0.08em] text-muted-foreground mb-2">
+                <p className="eyebrow mb-2">
                   {t('demEditor.shadingColorsLabel', { defaultValue: 'SHADING COLORS' })}
                 </p>
                 <div className="space-y-2">
@@ -326,7 +326,7 @@ export const DEMEditorScene = memo(function DEMEditorScene({
         <div className="px-4 py-2">
           <p
             id={`section-terrain-dem-${layer.id}`}
-            className="text-2xs font-semibold uppercase tracking-[0.08em] text-muted-foreground mb-2"
+            className="eyebrow mb-2"
           >
             {t('demEditor.terrainSectionLabel', { defaultValue: '3D TERRAIN' })}
           </p>

--- a/frontend/src/components/builder/DataDrivenStyleEditor.tsx
+++ b/frontend/src/components/builder/DataDrivenStyleEditor.tsx
@@ -839,13 +839,13 @@ export function DataDrivenStyleEditor({
       )}
 
       {selectedColumnMissing && (
-        <p className="rounded-md bg-warning/15 px-2 py-1.5 text-mini leading-snug text-warning-foreground">
+        <p className="rounded-md bg-warning/15 px-2 py-1.5 text-mini leading-snug text-warning">
           {t('dataDriven.missingColumnHelp', { column })}
         </p>
       )}
 
       {graduatedStatsUnavailable && (
-        <p className="rounded-md bg-warning/15 px-2 py-1.5 text-mini leading-snug text-warning-foreground">
+        <p className="rounded-md bg-warning/15 px-2 py-1.5 text-mini leading-snug text-warning">
           {t('dataDriven.statsUnavailableHelp')}
         </p>
       )}
@@ -1041,7 +1041,7 @@ export function DataDrivenStyleEditor({
                 {t('dataDriven.manualBreaksAddRow')}
               </Button>
               {manualBreaksInvalid && (
-                <p className="rounded-md bg-warning/15 px-2 py-1.5 text-mini leading-snug text-warning-foreground">
+                <p className="rounded-md bg-warning/15 px-2 py-1.5 text-mini leading-snug text-warning">
                   {t('dataDriven.manualBreaksInvalid')}
                 </p>
               )}
@@ -1051,7 +1051,7 @@ export function DataDrivenStyleEditor({
       )}
 
       {hasTooManyCategories && (
-        <p className="rounded-md bg-warning/15 px-2 py-1.5 text-mini leading-snug text-warning-foreground">
+        <p className="rounded-md bg-warning/15 px-2 py-1.5 text-mini leading-snug text-warning">
           {t('dataDriven.categoriesWarning', { count: valuesData.values.length })}
         </p>
       )}

--- a/frontend/src/components/builder/EmptyStackState.tsx
+++ b/frontend/src/components/builder/EmptyStackState.tsx
@@ -139,7 +139,7 @@ function SuggestCard({ suggestion, onOpenAddData, addingId, addedIds, onDirectAd
             e.stopPropagation();
             onDirectAdd(suggestion.id);
           }}
-          className="h-[22px] w-[22px] flex items-center justify-center rounded-sm text-primary hover:bg-[var(--primary-50,oklch(0.97_0.02_250))] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          className="h-[22px] w-[22px] flex items-center justify-center rounded-sm text-primary hover:bg-primary-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
         >
           {isAdding ? (
             <Loader2 className="h-3.5 w-3.5 animate-spin" aria-hidden="true" />

--- a/frontend/src/components/builder/EphemeralBadge.tsx
+++ b/frontend/src/components/builder/EphemeralBadge.tsx
@@ -22,7 +22,7 @@ export function EphemeralBadge({ featureCount, onDismiss, truncated, totalCount 
     : t('ephemeralBadge.featureCount', { count: featureCount });
 
   return (
-    <div className="absolute bottom-8 start-4 z-[8] flex items-center gap-2 rounded-full bg-background/95 backdrop-blur-sm border shadow-sm px-3 py-1.5 text-xs">
+    <div className="absolute bottom-8 start-4 z-[8] flex items-center gap-2 rounded-md bg-background/95 backdrop-blur-sm border shadow-sm px-3 py-1.5 text-xs">
       <span className="h-2 w-2 rounded-full bg-warning shrink-0" />
       <span className="text-muted-foreground">
         {t('ephemeralBadge.queryResult')} &middot; {countLabel}

--- a/frontend/src/components/builder/LayerEditorPanel.tsx
+++ b/frontend/src/components/builder/LayerEditorPanel.tsx
@@ -427,7 +427,7 @@ export const LayerEditorPanel = memo(function LayerEditorPanel({
                     >
                       <p
                         id={`section-renderas-${layer.id}`}
-                        className="text-2xs font-semibold uppercase tracking-[0.08em] text-muted-foreground mb-2"
+                        className="eyebrow mb-2"
                       >
                         {t('layerEditor.section.renderAs', { defaultValue: 'Render as' })}
                       </p>

--- a/frontend/src/components/builder/LayerEditorPanel.tsx
+++ b/frontend/src/components/builder/LayerEditorPanel.tsx
@@ -441,10 +441,10 @@ export const LayerEditorPanel = memo(function LayerEditorPanel({
                               data-active={isActive ? 'true' : 'false'}
                               onClick={() => handleRenderAsClick(option.id)}
                               className={cn(
-                                'rounded-full border border-transparent px-[10px] py-[5px] text-xs transition-colors',
+                                'rounded-md border border-transparent px-2.5 py-1 text-xs transition-colors',
                                 isActive
                                   ? 'bg-primary text-primary-foreground border-transparent'
-                                  : 'bg-[var(--surface-2,theme(colors.muted.DEFAULT))] text-foreground hover:bg-[var(--surface-3,theme(colors.muted.DEFAULT))]',
+                                  : 'bg-surface-2 text-foreground hover:bg-surface-3',
                               )}
                             >
                               {option.label}

--- a/frontend/src/components/builder/LayerEditorPanel.tsx
+++ b/frontend/src/components/builder/LayerEditorPanel.tsx
@@ -91,8 +91,8 @@ function LayerEditorTypePill({ layer }: { layer: MapLayerResponse }) {
   return (
     <span className={cn(
       'inline-flex items-center rounded-sm px-1.5 py-0.5 text-2xs font-semibold uppercase tracking-[0.08em]',
-      caps.kind === 'vector' && 'bg-[var(--type-vector-bg)] text-[var(--type-vector)]',
-      (caps.kind === 'raster' || caps.kind === 'vrt') && 'bg-[var(--type-raster-bg)] text-[var(--type-raster)]',
+      caps.kind === 'vector' && 'bg-type-vector-bg text-type-vector',
+      (caps.kind === 'raster' || caps.kind === 'vrt') && 'bg-type-raster-bg text-type-raster',
     )}>
       {label}
     </span>

--- a/frontend/src/components/builder/LayerEditorPanel.tsx
+++ b/frontend/src/components/builder/LayerEditorPanel.tsx
@@ -298,8 +298,7 @@ export const LayerEditorPanel = memo(function LayerEditorPanel({
               type="button"
               aria-label={t('basemapSublayer.breadcrumbLabel', { defaultValue: 'Back to basemap group' })}
               onClick={onBreadcrumbClick}
-              style={{ fontSize: '11px', lineHeight: 1.2, letterSpacing: '0.04em' }}
-              className="text-muted-foreground hover:text-foreground hover:underline block"
+              className="block text-mini leading-tight tracking-[0.04em] text-muted-foreground hover:text-foreground hover:underline"
             >
               Basemap · {breadcrumbPresetName ?? 'Untitled'} ›
             </button>

--- a/frontend/src/components/builder/LayerStyleEditor.tsx
+++ b/frontend/src/components/builder/LayerStyleEditor.tsx
@@ -427,7 +427,7 @@ export const LayerStyleEditor = memo(function LayerStyleEditor({
       {isStyleDirty && <StylePreview layer={layer} onRevert={handleRevertToSaved} />}
 
       {unsupportedBuilderState && (
-        <div className="flex items-start gap-2 rounded-md border border-warning/40 bg-warning/10 p-2 text-xs text-warning-foreground">
+        <div className="flex items-start gap-2 rounded-md border border-warning/40 bg-warning/10 p-2 text-xs text-warning">
           <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
           <span>{t('style.unsupportedBuilderState')}</span>
         </div>

--- a/frontend/src/components/builder/LayerStyleEditor/ClusterEditor.tsx
+++ b/frontend/src/components/builder/LayerStyleEditor/ClusterEditor.tsx
@@ -20,9 +20,10 @@ type ClusterColorStop = { count: number; color: string };
 // min zoom, dropping into the low tens by the default view).
 // Seed reachable breaks so enabling the ramp produces a visible gradient out of
 // the box; the user can raise them for denser data.
+// Ramp seeds trace to the shared categorical palette (amber -> pink).
 const DEFAULT_RAMP_TIERS: ClusterColorStop[] = [
-  { count: 10, color: '#f1f075' },
-  { count: 50, color: '#f28cb1' },
+  { count: 10, color: MAP_COLORS.categorical[6] },
+  { count: 50, color: MAP_COLORS.categorical[5] },
 ];
 
 export function ClusterEditor({

--- a/frontend/src/components/builder/LayerStyleEditor/FillEditor.tsx
+++ b/frontend/src/components/builder/LayerStyleEditor/FillEditor.tsx
@@ -127,8 +127,8 @@ export function FillEditor({
       })()}
       {isPolygon && currentHeightCol && !(layer.dataset_column_info ?? []).some((col) => col.name === currentHeightCol) && (
         <div className="flex items-start gap-2 rounded-sm bg-warning/15 p-2">
-          <AlertTriangle className="h-4 w-4 shrink-0 text-warning-foreground mt-0.5" />
-          <span className="text-xs text-warning-foreground">
+          <AlertTriangle className="h-4 w-4 shrink-0 text-warning mt-0.5" />
+          <span className="text-xs text-warning">
             {t('style.heightColumnRemoved', {
               column: currentHeightCol,
               defaultValue: 'Height column “{{column}}” was removed during re-upload. Select a new column or clear this setting.',

--- a/frontend/src/components/builder/LineGradientControls.tsx
+++ b/frontend/src/components/builder/LineGradientControls.tsx
@@ -443,7 +443,7 @@ export function LineGradientControls({ paint, styleConfig, onPaintProp, onBuilde
                   <div className="text-xs text-destructive">{t('style.lineGradient.invalidPosition')}</div>
                 )}
                 {positionValid && !monotonic && (
-                  <div className="text-xs text-warning-foreground">{t('style.lineGradient.duplicatePosition')}</div>
+                  <div className="text-xs text-warning">{t('style.lineGradient.duplicatePosition')}</div>
                 )}
               </div>
             );

--- a/frontend/src/components/builder/LineGradientControls.tsx
+++ b/frontend/src/components/builder/LineGradientControls.tsx
@@ -10,9 +10,11 @@ import { MAP_COLORS } from '@/lib/map-colors';
 import { walkExpressionPairs } from '@/lib/zoom-expressions';
 import { Textarea } from '@/components/ui/textarea';
 
+// Seed endpoints come from the shared categorical palette (blue -> pink) so
+// user-editable gradient defaults trace to MAP_COLORS, not fresh literals.
 export const DEFAULT_GRADIENT_STOPS: ReadonlyArray<{ position: number; color: string }> = [
-  { position: 0, color: '#0066cc' },
-  { position: 1, color: '#cc3300' },
+  { position: 0, color: MAP_COLORS.categorical[0] },
+  { position: 1, color: MAP_COLORS.categorical[5] },
 ];
 
 // Hydrated working-set stop type — id is REQUIRED at runtime once liveStops is

--- a/frontend/src/components/builder/RasterAppearanceSliders.tsx
+++ b/frontend/src/components/builder/RasterAppearanceSliders.tsx
@@ -128,7 +128,7 @@ export function RasterAppearanceSliders({
         />
       )}
       {hasBrightnessRangeError && (
-        <p className="rounded-md bg-warning/15 px-2 py-1.5 text-mini leading-snug text-warning-foreground">
+        <p className="rounded-md bg-warning/15 px-2 py-1.5 text-mini leading-snug text-warning">
           {t('style.raster.brightnessRangeError', { defaultValue: 'Brightness min must be less than or equal to brightness max.' })}
         </p>
       )}

--- a/frontend/src/components/builder/SettingsEditorScene.tsx
+++ b/frontend/src/components/builder/SettingsEditorScene.tsx
@@ -293,10 +293,10 @@ export const SettingsEditorScene = memo(function SettingsEditorScene({
                     role="radio"
                     aria-checked={isActive}
                     className={[
-                      'rounded-full border border-transparent px-[10px] py-[5px] text-xs transition-colors',
+                      'rounded-md border border-transparent px-2.5 py-1 text-xs transition-colors',
                       isActive
                         ? 'bg-primary text-primary-foreground border-transparent'
-                        : 'bg-[var(--surface-2,theme(colors.muted.DEFAULT))] text-foreground hover:bg-[var(--surface-3,theme(colors.muted.DEFAULT))]',
+                        : 'bg-surface-2 text-foreground hover:bg-surface-3',
                     ].join(' ')}
                     onClick={() => {
                       if (!isActive) onSetProjection(pill.id);

--- a/frontend/src/components/builder/SharePanel.tsx
+++ b/frontend/src/components/builder/SharePanel.tsx
@@ -444,7 +444,7 @@ function ShareLinkSettings({
                         <span
                           key={o}
                           role="listitem"
-                          className="inline-flex items-center gap-1 rounded-full border border-border bg-muted px-3 py-1 text-xs"
+                          className="inline-flex items-center gap-1 rounded-md border border-border bg-muted px-3 py-1 text-xs"
                         >
                           <span className="font-mono truncate max-w-[16rem]" title={o}>{o}</span>
                           <button

--- a/frontend/src/components/builder/SidebarRail.tsx
+++ b/frontend/src/components/builder/SidebarRail.tsx
@@ -70,7 +70,7 @@ export const SidebarRail = memo(function SidebarRail({
               'flex h-10 w-10 items-center justify-center rounded-md',
               'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
               isSettingsOpen
-                ? 'bg-[var(--primary-50,oklch(0.97_0.02_250))] text-primary'
+                ? 'bg-primary-50 text-primary'
                 : 'text-muted-foreground hover:bg-[var(--surface-2)] hover:text-foreground',
             )}
             onClick={onSettingsClick}
@@ -119,7 +119,7 @@ export const SidebarRail = memo(function SidebarRail({
                 className={cn(
                   'flex h-10 w-10 items-center justify-center rounded-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
                   isSelected
-                    ? 'bg-[var(--primary-50,theme(colors.accent.DEFAULT))] selection-inset'
+                    ? 'bg-primary-50 selection-inset'
                     : 'hover:bg-[var(--surface-2)]',
                 )}
                 onClick={() => onSelectLayer(layer.id)}
@@ -147,7 +147,7 @@ export const SidebarRail = memo(function SidebarRail({
               className={cn(
                 'flex h-10 w-10 items-center justify-center rounded-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
                 basemapGroup.id === selectedLayerId
-                  ? 'bg-[var(--primary-50,oklch(0.97_0.02_250))] selection-inset'
+                  ? 'bg-primary-50 selection-inset'
                   : 'hover:bg-[var(--surface-2)] text-muted-foreground hover:text-foreground',
               )}
               onClick={() => onSelectLayer(basemapGroup.id)}

--- a/frontend/src/components/builder/StackRow.tsx
+++ b/frontend/src/components/builder/StackRow.tsx
@@ -15,6 +15,7 @@ import {
 import { LayerTypeIcon } from '@/components/map/layer-icons';
 import { getLayerCapabilities } from '@/lib/layer-capabilities';
 import { cn } from '@/lib/utils';
+import { semanticBadgeColors } from '@/lib/status-colors';
 import {
   DragGripButton,
   STACK_ROW_GRID,
@@ -321,7 +322,7 @@ export const StackRow = memo(function StackRow({
               <span
                 title={t('stackRow.disambiguation', { label: disambiguationLabel, defaultValue: '{{label}}' })}
                 data-testid="stack-row-disambiguation"
-                className="min-w-0 max-w-[45%] inline-flex items-center rounded-sm border border-warning/30 px-1 text-2xs font-medium leading-tight bg-warning/10 text-warning"
+                className={cn('min-w-0 max-w-[45%] inline-flex items-center rounded-sm px-1 text-2xs font-medium leading-tight', semanticBadgeColors.warning)}
               >
                 <span className="truncate">{disambiguationLabel}</span>
                 <span className="sr-only">{t('stackRow.disambiguation', { label: disambiguationLabel, defaultValue: '{{label}}' })}</span>
@@ -334,7 +335,7 @@ export const StackRow = memo(function StackRow({
               <span
                 title={t('stackRow.audienceHidden', { defaultValue: "Hidden from this map's viewers" })}
                 data-testid="stack-row-audience-hidden"
-                className="min-w-0 max-w-[45%] inline-flex items-center rounded-sm border border-warning/30 px-1 text-2xs font-medium leading-tight bg-warning/10 text-warning"
+                className={cn('min-w-0 max-w-[45%] inline-flex items-center rounded-sm px-1 text-2xs font-medium leading-tight', semanticBadgeColors.warning)}
               >
                 <span className="truncate">
                   {t('stackRow.audienceHidden', { defaultValue: "Hidden from this map's viewers" })}
@@ -347,7 +348,7 @@ export const StackRow = memo(function StackRow({
               <span
                 title={t('stackRow.drawsNothing', { defaultValue: 'Not shown — enable Hillshade or 3D terrain' })}
                 data-testid="stack-row-draws-nothing"
-                className="min-w-0 max-w-[45%] inline-flex items-center rounded-sm border border-warning/30 px-1 text-2xs font-medium leading-tight bg-warning/10 text-warning"
+                className={cn('min-w-0 max-w-[45%] inline-flex items-center rounded-sm px-1 text-2xs font-medium leading-tight', semanticBadgeColors.warning)}
               >
                 <span className="truncate">
                   {t('stackRow.drawsNothing', { defaultValue: 'Not shown — enable Hillshade or 3D terrain' })}

--- a/frontend/src/components/builder/StyleJsonDialog.tsx
+++ b/frontend/src/components/builder/StyleJsonDialog.tsx
@@ -55,7 +55,7 @@ function ImportSummary({ summary }: { summary: MapStyleImportSummary }) {
       {summary.warnings.length > 0 && (
         <div className="space-y-1">
           {summary.warnings.map((warning, index) => (
-            <div key={`${warning.code}-${index}`} className="flex items-start gap-1.5 text-warning-foreground">
+            <div key={`${warning.code}-${index}`} className="flex items-start gap-1.5 text-warning">
               <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0" />
               <span>{warning.message}</span>
             </div>

--- a/frontend/src/components/builder/SublayerConfigIndicators.tsx
+++ b/frontend/src/components/builder/SublayerConfigIndicators.tsx
@@ -89,7 +89,7 @@ export function SublayerConfigIndicators({ layer }: Props) {
         <span
           key={id}
           title={label}
-          className="inline-flex items-center justify-center h-4 w-4 rounded-sm bg-[var(--primary-50)] text-[var(--primary-600)]"
+          className="inline-flex items-center justify-center h-4 w-4 rounded-sm bg-primary-50 text-primary-600"
         >
           <Icon className="h-3 w-3" aria-hidden="true" />
           <span className="sr-only">{label}</span>

--- a/frontend/src/components/builder/UnifiedStackPanel.tsx
+++ b/frontend/src/components/builder/UnifiedStackPanel.tsx
@@ -598,7 +598,7 @@ export const UnifiedStackPanel = memo(function UnifiedStackPanel({
             {t('unifiedStack.title', { defaultValue: 'Layers' })}
           </h2>
           {visibleStackLayers.length > 0 && (
-            <Badge variant="secondary" className="rounded-full px-2 text-xs font-semibold">
+            <Badge variant="secondary" className="px-2 text-xs font-semibold">
               {visibleStackLayers.length}
             </Badge>
           )}

--- a/frontend/src/components/builder/UnifiedStackPanel.tsx
+++ b/frontend/src/components/builder/UnifiedStackPanel.tsx
@@ -186,7 +186,7 @@ const SublayerRow = memo(function SublayerRow({
         'group/row grid grid-cols-[16px_14px_22px_22px_1fr_76px_22px] gap-2 items-center py-2 px-2 cursor-pointer select-none',
         'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset',
         !selected && 'hover:bg-[var(--surface-2,theme(colors.accent.DEFAULT))]',
-        selected && 'bg-[var(--primary-50,theme(colors.accent.DEFAULT))] selection-inset',
+        selected && 'bg-primary-50 selection-inset',
       )}
       onClick={() => onSelectLayer(sublayer.id)}
       onKeyDown={(e) => {
@@ -615,7 +615,7 @@ export const UnifiedStackPanel = memo(function UnifiedStackPanel({
                   'flex h-8 w-8 items-center justify-center rounded-sm transition-colors',
                   'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
                   isSettingsOpen
-                    ? 'bg-[var(--primary-50,oklch(0.97_0.02_250))] text-primary'
+                    ? 'bg-primary-50 text-primary'
                     : 'text-muted-foreground hover:bg-[var(--surface-2)] hover:text-foreground',
                 )}
                 onClick={onSettingsClick}

--- a/frontend/src/components/builder/ZoomExpressionEditor.tsx
+++ b/frontend/src/components/builder/ZoomExpressionEditor.tsx
@@ -161,7 +161,7 @@ export function ZoomExpressionEditor({
       <div className="space-y-1.5">
         <div className="flex items-center justify-between gap-2">
           <span className="text-xs text-muted-foreground w-20">{label}</span>
-          <p className="flex-1 text-xs text-warning-foreground bg-warning/15 rounded-sm px-2 py-1">
+          <p className="flex-1 text-xs text-warning bg-warning/15 rounded-sm px-2 py-1">
             {t('style.zoomExpression.unsupported')}
           </p>
         </div>

--- a/frontend/src/components/builder/__tests__/LineGradientControls.test.tsx
+++ b/frontend/src/components/builder/__tests__/LineGradientControls.test.tsx
@@ -108,8 +108,8 @@ describe('LineGradientControls — UI', () => {
       {
         lineGradient: {
           stops: expect.arrayContaining([
-            expect.objectContaining({ position: 0, color: '#0066cc' }),
-            expect.objectContaining({ position: 1, color: '#cc3300' }),
+            expect.objectContaining({ position: 0, color: DEFAULT_GRADIENT_STOPS[0].color }),
+            expect.objectContaining({ position: 1, color: DEFAULT_GRADIENT_STOPS[1].color }),
           ]),
         },
       },

--- a/frontend/src/components/builder/row-chrome.tsx
+++ b/frontend/src/components/builder/row-chrome.tsx
@@ -27,7 +27,7 @@ export function rowStateClasses({
 }): string {
   return cn(
     !selected && !isDragging && 'hover:bg-[var(--surface-2,theme(colors.accent.DEFAULT))]',
-    selected && 'bg-[var(--primary-50,theme(colors.accent.DEFAULT))] selection-inset',
+    selected && 'bg-primary-50 selection-inset',
     isDragging && 'opacity-40 bg-[var(--surface-2,theme(colors.accent.DEFAULT))] scale-[0.98]',
   );
 }

--- a/frontend/src/components/collections/CollectionCardSkeleton.tsx
+++ b/frontend/src/components/collections/CollectionCardSkeleton.tsx
@@ -11,8 +11,8 @@ export function CollectionCardSkeleton() {
           <Skeleton className="h-3 w-2/3" />
         </div>
         <div className="flex gap-2">
-          <Skeleton className="h-4 w-20 rounded-full" />
-          <Skeleton className="h-4 w-24 rounded-full" />
+          <Skeleton className="h-4 w-20 rounded-md" />
+          <Skeleton className="h-4 w-24 rounded-md" />
         </div>
       </div>
       <div className="sm:w-48 sm:flex-shrink-0 p-3 sm:p-4 sm:border-s border-t sm:border-t-0 border-border/50">

--- a/frontend/src/components/dataset/AttributeMetadataTable.tsx
+++ b/frontend/src/components/dataset/AttributeMetadataTable.tsx
@@ -146,7 +146,7 @@ export function AttributeMetadataTable({ datasetId, canEdit }: AttributeMetadata
 
   return (
     <div className="rounded-md border">
-      <Table>
+      <Table aria-label={t('attributeMetadata.title')}>
         <TableHeader className="sticky top-0 bg-muted/80 backdrop-blur-sm">
           <TableRow>
             <TableHead className="w-[140px]">{t('attributeMetadata.fieldName')}</TableHead>

--- a/frontend/src/components/dataset/AttributeTable.tsx
+++ b/frontend/src/components/dataset/AttributeTable.tsx
@@ -343,7 +343,7 @@ export function AttributeTable({ datasetId, canEdit = false, compact = false }: 
               : { height: `${virtualizer.getTotalSize()}px`, width: '100%' }
           }
         >
-          <Table className="w-max">
+          <Table aria-label={t('attributes.tableLabel')} className="w-max">
             <TableHeader className="sticky top-0 z-10 bg-muted/80 backdrop-blur-sm">
               {table.getHeaderGroups().map((headerGroup) => (
                 <TableRow key={headerGroup.id}>

--- a/frontend/src/components/dataset/DatasetDetailSkeleton.tsx
+++ b/frontend/src/components/dataset/DatasetDetailSkeleton.tsx
@@ -22,7 +22,7 @@ export function DatasetDetailSkeleton({ isTable }: DatasetDetailSkeletonProps = 
 
       {/* Stats line skeleton */}
       <div className="flex items-center gap-2">
-        <Skeleton className="h-5 w-16 rounded-full" />
+        <Skeleton className="h-5 w-16 rounded-md" />
         <Skeleton className="h-4 w-24" />
         <Skeleton className="h-4 w-20" />
         <Skeleton className="h-4 w-16" />
@@ -78,7 +78,7 @@ export function DatasetDetailSkeleton({ isTable }: DatasetDetailSkeletonProps = 
         <div className="rounded-lg border p-6 space-y-3">
           <div className="flex items-center justify-between">
             <Skeleton className="h-5 w-28" />
-            <Skeleton className="h-6 w-10 rounded-full" />
+            <Skeleton className="h-6 w-10 rounded-md" />
           </div>
           {Array.from({ length: 4 }).map((_, i) => (
             <div key={i} className="space-y-1">

--- a/frontend/src/components/dataset/QualityScoreCard.tsx
+++ b/frontend/src/components/dataset/QualityScoreCard.tsx
@@ -1,7 +1,7 @@
 import { useTranslation } from 'react-i18next';
 import type { DatasetResponse } from '@/types/api';
 import { Card, CardAction, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { qualityScoreClasses } from '@/lib/status-colors';
+import { qualityScoreClasses, semanticBadgeColors } from '@/lib/status-colors';
 import { Badge } from '@/components/ui/badge';
 import { deriveQualityFreshness } from '@/lib/quality-freshness';
 
@@ -26,8 +26,8 @@ function barColor(score: number): string {
 }
 
 function freshnessBadgeClass(state: 'fresh' | 'stale' | 'missing'): string {
-  if (state === 'fresh') return 'bg-success/10 text-success border-success/30';
-  if (state === 'stale') return 'bg-warning/10 text-warning border-warning/30';
+  if (state === 'fresh') return semanticBadgeColors.success;
+  if (state === 'stale') return semanticBadgeColors.warning;
   return 'bg-muted text-muted-foreground border-border';
 }
 

--- a/frontend/src/components/dataset/ReuploadDialog.tsx
+++ b/frontend/src/components/dataset/ReuploadDialog.tsx
@@ -593,7 +593,7 @@ export function ReuploadDialog({
                   {reuploadBadges.map((ext) => (
                     <span
                       key={ext}
-                      className="inline-flex items-center rounded-full bg-muted px-2 py-0.5 text-xs font-medium text-muted-foreground"
+                      className="inline-flex items-center rounded-md bg-muted px-2 py-0.5 text-xs font-medium text-muted-foreground"
                     >
                       {ext}
                     </span>

--- a/frontend/src/components/dataset/ReuploadDialog.tsx
+++ b/frontend/src/components/dataset/ReuploadDialog.tsx
@@ -684,7 +684,7 @@ export function ReuploadDialog({
               </p>
             ) : (
               <div className="max-h-64 overflow-y-auto rounded-md border">
-                <Table>
+                <Table aria-label={t('reupload.service.tableLabel', { defaultValue: 'Service layers' })}>
                   <TableHeader>
                     <TableRow>
                       <TableHead>{t('reupload.service.columns.name', { defaultValue: 'Name' })}</TableHead>
@@ -757,7 +757,7 @@ export function ReuploadDialog({
             )}
             {error && <p className="text-sm text-destructive">{error}</p>}
             <div className="max-h-64 overflow-y-auto rounded-md border">
-              <Table>
+              <Table aria-label={t('reupload.fileLayer.tableLabel', { defaultValue: 'File layers' })}>
                 <TableHeader>
                   <TableRow>
                     <TableHead>{t('reupload.service.columns.name', { defaultValue: 'Name' })}</TableHead>

--- a/frontend/src/components/dataset/SchemaEditor.tsx
+++ b/frontend/src/components/dataset/SchemaEditor.tsx
@@ -9,6 +9,16 @@ import {
   DialogTitle,
   DialogDescription,
 } from '@/components/ui/dialog';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
@@ -134,37 +144,15 @@ export function SchemaEditor({ datasetId, columns, open, onOpenChange }: SchemaE
                     <TableCell className="font-mono text-xs">{col.name}</TableCell>
                     <TableCell className="text-muted-foreground text-xs">{col.type}</TableCell>
                     <TableCell>
-                      {confirmDelete === col.name ? (
-                        <div className="flex items-center gap-1">
-                          <Button
-                            variant="destructive"
-                            size="sm"
-                            className="h-7 text-xs"
-                            onClick={() => handleDropColumn(col.name)}
-                            disabled={dropColumnMutation.isPending}
-                          >
-                            {t('common:confirm')}
-                          </Button>
-                          <Button
-                            variant="ghost"
-                            size="sm"
-                            className="h-7 text-xs"
-                            onClick={() => setConfirmDelete(null)}
-                          >
-                            {t('common:cancel')}
-                          </Button>
-                        </div>
-                      ) : (
-                        <Button
-                          variant="ghost"
-                          size="sm"
-                          className="h-7 w-7 p-0"
-                          onClick={() => setConfirmDelete(col.name)}
-                          title={t('schema.removeColumn', { name: col.name })}
-                        >
-                          <Trash2 className="h-3.5 w-3.5 text-muted-foreground" />
-                        </Button>
-                      )}
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        className="h-7 w-7 p-0"
+                        onClick={() => setConfirmDelete(col.name)}
+                        title={t('schema.removeColumn', { name: col.name })}
+                      >
+                        <Trash2 className="h-3.5 w-3.5 text-muted-foreground" />
+                      </Button>
                     </TableCell>
                   </TableRow>
                 ))}
@@ -177,18 +165,44 @@ export function SchemaEditor({ datasetId, columns, open, onOpenChange }: SchemaE
           </p>
         )}
 
-        {confirmDelete != null && (
-          <div className="space-y-1 text-xs" role="alert">
-            <p className="text-destructive">
-              {t('schema.dropWarning', { name: confirmDelete })}
-            </p>
+        {/* Dropping a column is irreversible — confirm through an AlertDialog
+            so dismissal must be explicit (DESIGN-GUIDE §6). */}
+        <AlertDialog
+          open={confirmDelete != null}
+          onOpenChange={(isOpen) => {
+            if (!isOpen) setConfirmDelete(null);
+          }}
+        >
+          <AlertDialogContent>
+            <AlertDialogHeader>
+              <AlertDialogTitle>
+                {t('schema.removeColumn', { name: confirmDelete ?? '' })}
+              </AlertDialogTitle>
+              <AlertDialogDescription>
+                {t('schema.dropWarning', { name: confirmDelete ?? '' })}
+              </AlertDialogDescription>
+            </AlertDialogHeader>
             {(columnReferences.data?.map_count ?? 0) > 0 && (
-              <p className="text-warning">
+              <p className="text-xs text-warning">
                 {t('schema.usedByMaps', { mapCount: columnReferences.data!.map_count })}
               </p>
             )}
-          </div>
-        )}
+            <AlertDialogFooter>
+              <AlertDialogCancel disabled={dropColumnMutation.isPending}>
+                {t('common:cancel')}
+              </AlertDialogCancel>
+              <AlertDialogAction
+                variant="destructive"
+                disabled={dropColumnMutation.isPending}
+                onClick={() => {
+                  if (confirmDelete) handleDropColumn(confirmDelete);
+                }}
+              >
+                {t('common:confirm')}
+              </AlertDialogAction>
+            </AlertDialogFooter>
+          </AlertDialogContent>
+        </AlertDialog>
 
         {/* Add column form */}
         <div className="border-t pt-4 space-y-3">

--- a/frontend/src/components/dataset/SchemaEditor.tsx
+++ b/frontend/src/components/dataset/SchemaEditor.tsx
@@ -120,7 +120,7 @@ export function SchemaEditor({ datasetId, columns, open, onOpenChange }: SchemaE
         {/* Existing columns */}
         {displayColumns.length > 0 ? (
           <div className="max-h-60 overflow-y-auto">
-            <Table>
+            <Table aria-label={t('schema.title')}>
               <TableHeader>
                 <TableRow>
                   <TableHead>{t('schema.columnName')}</TableHead>

--- a/frontend/src/components/dataset/tabs/OverviewTab.tsx
+++ b/frontend/src/components/dataset/tabs/OverviewTab.tsx
@@ -478,7 +478,7 @@ export function OverviewTab({
                       </Button>
                     </CollapsibleTrigger>
                     <CollapsibleContent>
-                      <Table>
+                      <Table aria-label={t('overview.bandDetails', { defaultValue: 'Band Details' })}>
                         <TableHeader>
                           <TableRow>
                             <TableHead>#</TableHead>

--- a/frontend/src/components/dataset/tabs/OverviewTab.tsx
+++ b/frontend/src/components/dataset/tabs/OverviewTab.tsx
@@ -78,7 +78,7 @@ function KeywordsSidebarCard({ recordId }: { recordId: string }) {
           {data.keywords.map((kw) => (
             <span
               key={kw.id}
-              className="inline-flex items-center gap-1 px-2 py-1 rounded-full bg-muted border text-xs font-medium text-muted-foreground"
+              className="inline-flex items-center gap-1 px-2 py-1 rounded-md bg-muted border text-xs font-medium text-muted-foreground"
             >
               <span className="text-muted-foreground/60">#</span>
               {kw.keyword}

--- a/frontend/src/components/dataset/tabs/SourcesTab.tsx
+++ b/frontend/src/components/dataset/tabs/SourcesTab.tsx
@@ -299,7 +299,7 @@ export function SourcesTab({ dataset, canEdit, datasetId }: SourcesTabProps) {
             <span>{t('vrt.sourcesLoadError', { defaultValue: 'Failed to load VRT sources.' })}</span>
           </div>
         ) : (
-          <Table>
+          <Table aria-label={t('vrt.sourcesTableLabel', { defaultValue: 'VRT sources' })}>
             <TableHeader>
               <TableRow>
                 <TableHead className="w-24">{t('vrt.sourceTableHealth', { defaultValue: 'Health' })}</TableHead>
@@ -431,7 +431,7 @@ export function SourcesTab({ dataset, canEdit, datasetId }: SourcesTabProps) {
             <h2 className="text-sm font-medium text-muted-foreground">
               {t('vrt.generationHistory', { defaultValue: 'Generation History' })}
             </h2>
-            <Table>
+            <Table aria-label={t('vrt.generationHistory', { defaultValue: 'Generation History' })}>
               <TableHeader>
                 <TableRow>
                   <TableHead className="w-24">{t('vrt.genStatus', { defaultValue: 'Status' })}</TableHead>

--- a/frontend/src/components/import/BulkReviewList.tsx
+++ b/frontend/src/components/import/BulkReviewList.tsx
@@ -46,7 +46,7 @@ function DetectionPanel({ entry }: { entry: FileEntry }) {
               <dd className="font-mono text-mini">
                 {preview.is_cog_compliant
                   ? <span className="text-success">{t('detect.validCog')}</span>
-                  : <span className="text-warning-foreground">{t('detect.willConvert')}</span>}
+                  : <span className="text-warning">{t('detect.willConvert')}</span>}
               </dd>
             </>
           ) : file ? (

--- a/frontend/src/components/import/BulkReviewList.tsx
+++ b/frontend/src/components/import/BulkReviewList.tsx
@@ -28,7 +28,7 @@ function DetectionPanel({ entry }: { entry: FileEntry }) {
     <div className="col-span-full mt-3 grid gap-5 border-t border-dashed border-border pt-4 md:grid-cols-2">
       {/* Geometry & projection */}
       <div>
-        <h5 className="mb-2 font-mono text-2xs uppercase tracking-widest text-muted-foreground">
+        <h5 className="eyebrow mb-2">
           {raster ? t('detect.rasterInfo') : t('detect.geometry')}
         </h5>
         <dl className="grid grid-cols-[92px_1fr] gap-x-3 gap-y-1 text-xs">
@@ -76,7 +76,7 @@ function DetectionPanel({ entry }: { entry: FileEntry }) {
       {/* Schema columns */}
       {file && file.columns.length > 0 && (
         <div>
-          <h5 className="mb-2 font-mono text-2xs uppercase tracking-widest text-muted-foreground">
+          <h5 className="eyebrow mb-2">
             {t('detect.schema')} · {t('detect.columnCount', { count: file.columns.length, value: formatNumber(file.columns.length) })}
           </h5>
           <div className="max-h-44 overflow-y-auto rounded-sm border border-border">
@@ -265,7 +265,7 @@ export function BulkReviewList({
       {/* File list card */}
       <div className="overflow-hidden rounded-xl border border-border bg-card">
         {/* Header */}
-        <div className="flex items-center gap-3 border-b border-border bg-surface-0 px-4 py-2.5 font-mono text-2xs uppercase tracking-widest text-muted-foreground">
+        <div className="eyebrow flex items-center gap-3 border-b border-border bg-surface-0 px-4 py-2.5">
           <span>
             {t('review.headerStatus')} · <span className="text-success">{t('review.readyCount', { count: readyCount, value: formatNumber(readyCount) })}</span>
           </span>

--- a/frontend/src/components/import/BulkReviewList.tsx
+++ b/frontend/src/components/import/BulkReviewList.tsx
@@ -317,7 +317,7 @@ export function BulkReviewList({
                       <span className="font-mono font-normal text-muted-foreground">{ext}</span>
                     </span>
                     {entry.status === 'tracking' && (
-                      <Badge variant="outline" className="bg-success/10 text-success border-success/30 text-2xs">
+                      <Badge variant="success" className="text-2xs">
                         {t('bulk.committed')}
                       </Badge>
                     )}

--- a/frontend/src/components/import/BulkTrackingList.tsx
+++ b/frontend/src/components/import/BulkTrackingList.tsx
@@ -141,7 +141,7 @@ export function BulkTrackingList({ entries, onReset, autoOpenVrt = false }: Bulk
               { label: t('complete.statTabular', { defaultValue: 'Tabular' }), value: completedEntries.filter((e) => e.kind === 'table').length },
             ].map((stat, i) => (
               <div key={i} className="px-5 py-4">
-                <dt className="mb-1.5 font-mono text-2xs uppercase tracking-widest text-muted-foreground">{stat.label}</dt>
+                <dt className="eyebrow mb-1.5">{stat.label}</dt>
                 <dd className="text-xl font-medium tracking-tight">{stat.value}</dd>
               </div>
             ))}

--- a/frontend/src/components/import/BulkUploadProgress.tsx
+++ b/frontend/src/components/import/BulkUploadProgress.tsx
@@ -15,7 +15,7 @@ export function BulkUploadProgress({ entries }: BulkUploadProgressProps) {
   return (
     <div className="overflow-hidden rounded-xl border border-border bg-card">
       {/* Header */}
-      <div className="flex items-center gap-3 border-b border-border bg-surface-0 px-4 py-2.5 font-mono text-2xs uppercase tracking-widest text-muted-foreground">
+      <div className="eyebrow flex items-center gap-3 border-b border-border bg-surface-0 px-4 py-2.5">
         <span>
           {t('bulk.uploading', { count: entries.length })}
         </span>

--- a/frontend/src/components/import/FileDropzone.tsx
+++ b/frontend/src/components/import/FileDropzone.tsx
@@ -147,7 +147,7 @@ export function FileDropzone({ onFilesAccepted, allowedExtensions, maxSizeMb, re
         </div>
       )}
 
-      <p className="font-mono text-2xs uppercase tracking-widest text-muted-foreground">
+      <p className="eyebrow">
         {maxSizeMb != null
           ? t('dropzone.sizeLimitDynamic', { size: maxSizeMb, defaultValue: `Max ${maxSizeMb} MB per file` })
           : t('dropzone.sizeLimit')}{' '}

--- a/frontend/src/components/import/ImportPreview.tsx
+++ b/frontend/src/components/import/ImportPreview.tsx
@@ -143,7 +143,7 @@ export function ImportPreview({ preview }: ImportPreviewProps) {
               )}
             </p>
             <div className="overflow-x-auto">
-              <Table>
+              <Table aria-label={t('preview.sampleData')}>
                 <TableHeader>
                   <TableRow>
                     {visibleColumns.map((col) => (

--- a/frontend/src/components/import/RegisterForm.tsx
+++ b/frontend/src/components/import/RegisterForm.tsx
@@ -191,7 +191,7 @@ export function RegisterForm() {
           </div>
         </div>
 
-        <div className="px-3.5 py-1.5 font-mono text-2xs uppercase tracking-widest text-muted-foreground flex items-center gap-1.5">
+        <div className="eyebrow px-3.5 py-1.5 flex items-center gap-1.5">
           <Database className="size-2.5" />
           {t('register.tableCount', { schema: 'public', count: filtered.length })}
         </div>
@@ -258,7 +258,7 @@ function TableDetail({
 
   return (
     <>
-      <p className="font-mono text-mini uppercase tracking-widest text-muted-foreground mb-2.5">
+      <p className="eyebrow mb-2.5">
         public / <span className="font-medium text-foreground normal-case">{table.table_name}</span>
       </p>
       <h2 className="text-xl font-medium tracking-tight mb-1.5">{table.table_name}</h2>
@@ -277,7 +277,7 @@ function TableDetail({
           { label: t('register.stats.type'), value: table.geometry_type ? t('register.stats.spatial') : t('register.stats.nonSpatial') },
         ].map((stat) => (
           <div key={stat.label} className="bg-card px-3.5 py-2.5">
-            <dt className="font-mono text-2xs uppercase tracking-widest text-muted-foreground mb-1">{stat.label}</dt>
+            <dt className="eyebrow mb-1">{stat.label}</dt>
             <dd className="text-sm font-medium tracking-tight">{stat.value}</dd>
           </div>
         ))}

--- a/frontend/src/components/import/ServiceUrlForm.tsx
+++ b/frontend/src/components/import/ServiceUrlForm.tsx
@@ -148,7 +148,7 @@ export function ServiceUrlForm() {
       <div className="space-y-5">
         {/* Probe input — detected state */}
         <div className="rounded-xl border border-border bg-card p-5">
-          <label className="mb-2.5 block font-mono text-mini uppercase tracking-widest text-muted-foreground">
+          <label className="eyebrow mb-2.5 block">
             {t('serviceUrl.detectedLabel', { defaultValue: 'Service URL — detected' })}
           </label>
           <div className="flex items-stretch overflow-hidden rounded-lg border-[1.5px] border-success bg-surface-0">
@@ -258,7 +258,7 @@ export function ServiceUrlForm() {
     <div className="rounded-xl border border-border bg-card p-5">
       <form onSubmit={handleConnect} className="space-y-5">
         <div>
-          <label className="mb-2.5 block font-mono text-mini uppercase tracking-widest text-muted-foreground">
+          <label className="eyebrow mb-2.5 block">
             {t('serviceUrl.label', { defaultValue: 'Service URL — we\'ll auto-detect the type' })}
           </label>
           <div className="flex items-stretch overflow-hidden rounded-lg border-[1.5px] border-border bg-surface-0 transition-colors focus-within:border-primary">

--- a/frontend/src/components/import/StacImportForm.tsx
+++ b/frontend/src/components/import/StacImportForm.tsx
@@ -210,13 +210,13 @@ export function StacImportForm() {
 
           <div className="grid grid-cols-2 gap-px overflow-hidden rounded-lg border border-border bg-border">
             <div className="bg-surface-0 px-4 py-3">
-              <dt className="font-mono text-2xs uppercase tracking-widest text-muted-foreground mb-1">
+              <dt className="eyebrow mb-1">
                 {t('stac.confirm.itemsLabel')}
               </dt>
               <dd className="text-lg font-medium tracking-tight">{itemsToImport.length}</dd>
             </div>
             <div className="bg-surface-0 px-4 py-3">
-              <dt className="font-mono text-2xs uppercase tracking-widest text-muted-foreground mb-1">
+              <dt className="eyebrow mb-1">
                 {t('stac.confirm.totalSizeLabel')}
               </dt>
               <dd className="text-lg font-medium tracking-tight">
@@ -343,7 +343,7 @@ export function StacImportForm() {
       <div className="space-y-5">
         {/* Connected state header */}
         <div className="rounded-xl border border-border bg-card p-5">
-          <span className="mb-2.5 block font-mono text-mini uppercase tracking-widest text-muted-foreground">
+          <span className="eyebrow mb-2.5 block">
             {t('stac.catalogConnected')}
           </span>
           <div className="flex items-stretch overflow-hidden rounded-lg border-[1.5px] border-success bg-surface-0">
@@ -554,7 +554,7 @@ export function StacImportForm() {
     <div className="rounded-xl border border-border bg-card p-5">
       <form onSubmit={handleConnect} className="space-y-5">
         <div>
-          <label className="mb-2.5 block font-mono text-mini uppercase tracking-widest text-muted-foreground">
+          <label className="eyebrow mb-2.5 block">
             {t('stac.label', { defaultValue: "STAC API URL — paste the catalog root endpoint" })}
           </label>
           <div className="flex items-stretch overflow-hidden rounded-lg border-[1.5px] border-border bg-surface-0 transition-colors focus-within:border-primary">

--- a/frontend/src/components/import/StatusPill.tsx
+++ b/frontend/src/components/import/StatusPill.tsx
@@ -1,17 +1,19 @@
 import { useTranslation } from 'react-i18next';
+import { Badge } from '@/components/ui/badge';
 import { cn } from '@/lib/utils';
+import { fileEntryStatusColors } from '@/lib/status-colors';
 import type { FileEntryStatus } from '@/types/api';
 
-const STATUS_CONFIG: Partial<Record<FileEntryStatus | 'detected', { key: string; cls: string; pulse?: boolean }>> = {
-  uploading: { key: 'status.uploading', cls: 'bg-info/15 text-info', pulse: true },
-  previewing: { key: 'status.detecting', cls: 'bg-info/15 text-info', pulse: true },
-  preview: { key: 'status.detected', cls: 'bg-success/15 text-success' },
-  committing: { key: 'status.importing', cls: 'bg-primary/12 text-primary', pulse: true },
-  tracking: { key: 'status.ready', cls: 'bg-success/18 text-success' },
-  complete: { key: 'status.ready', cls: 'bg-success/18 text-success' },
-  'upload-failed': { key: 'status.failed', cls: 'bg-destructive/15 text-destructive' },
-  'commit-failed': { key: 'status.failed', cls: 'bg-destructive/15 text-destructive' },
-  failed: { key: 'status.failed', cls: 'bg-destructive/15 text-destructive' },
+const STATUS_CONFIG: Partial<Record<FileEntryStatus | 'detected', { key: string; pulse?: boolean }>> = {
+  uploading: { key: 'status.uploading', pulse: true },
+  previewing: { key: 'status.detecting', pulse: true },
+  preview: { key: 'status.detected' },
+  committing: { key: 'status.importing', pulse: true },
+  tracking: { key: 'status.ready' },
+  complete: { key: 'status.ready' },
+  'upload-failed': { key: 'status.failed' },
+  'commit-failed': { key: 'status.failed' },
+  failed: { key: 'status.failed' },
 };
 
 interface StatusPillProps {
@@ -26,10 +28,10 @@ export function StatusPill({ status }: StatusPillProps) {
   const label = c ? (t(c.key) as string) : status;
 
   return (
-    <span
+    <Badge
       className={cn(
-        'inline-flex items-center gap-1.5 rounded-full px-2 py-0.5 font-mono text-2xs font-medium uppercase tracking-wider',
-        c?.cls ?? 'bg-muted text-muted-foreground',
+        'gap-1.5 font-mono text-2xs uppercase tracking-wider',
+        fileEntryStatusColors[status] ?? 'border-border bg-muted text-muted-foreground',
       )}
     >
       <span
@@ -39,6 +41,6 @@ export function StatusPill({ status }: StatusPillProps) {
         )}
       />
       {label}
-    </span>
+    </Badge>
   );
 }

--- a/frontend/src/components/import/TypeTag.tsx
+++ b/frontend/src/components/import/TypeTag.tsx
@@ -56,7 +56,7 @@ export function TypeTag({ kind, size = 'md', className }: TypeTagProps) {
 export function FormatPill({ kind, ext }: { kind: DataKind; ext: string }) {
   const cfg = KIND_CONFIG[kind];
   return (
-    <span className="inline-flex items-center gap-1.5 rounded-full border border-border bg-surface-0 px-2 py-0.5 font-mono text-mini text-muted-foreground">
+    <span className="inline-flex items-center gap-1.5 rounded-md border border-border bg-surface-0 px-2 py-0.5 font-mono text-mini text-muted-foreground">
       <span
         className={cn(
           'rounded-sm px-1 py-px text-2xs font-bold uppercase tracking-wider',

--- a/frontend/src/components/import/WorkflowRail.tsx
+++ b/frontend/src/components/import/WorkflowRail.tsx
@@ -47,7 +47,7 @@ export function WorkflowRail({ mode, phase }: WorkflowRailProps) {
     <aside className="sticky top-28 flex flex-col gap-4">
       {/* Workflow steps */}
       <div className="rounded-lg border border-border bg-card p-4">
-        <p className="mb-3 font-mono text-2xs uppercase tracking-widest text-muted-foreground">
+        <p className="eyebrow mb-3">
           {t('rail.workflow', { defaultValue: 'Workflow' })}
         </p>
         <div className="flex flex-col gap-3.5">
@@ -84,7 +84,7 @@ export function WorkflowRail({ mode, phase }: WorkflowRailProps) {
 
       {/* What gets imported */}
       <div className="rounded-lg border border-border bg-card p-4">
-        <p className="mb-3 font-mono text-2xs uppercase tracking-widest text-muted-foreground">
+        <p className="eyebrow mb-3">
           {t('rail.whatImported', { defaultValue: 'What gets imported' })}
         </p>
         <div className="flex flex-col gap-2 text-xs">
@@ -103,7 +103,7 @@ export function WorkflowRail({ mode, phase }: WorkflowRailProps) {
 
       {/* Tip */}
       <div className="rounded-lg border border-border bg-surface-0 p-4">
-        <p className="mb-2 font-mono text-2xs uppercase tracking-widest text-muted-foreground">
+        <p className="eyebrow mb-2">
           {t('rail.tip', { defaultValue: 'Tip' })}
         </p>
         <p className="text-xs text-muted-foreground">
@@ -124,7 +124,7 @@ function NonUploadRail({ mode }: { mode: 'register' | 'service' | 'stac' }) {
   return (
     <aside className="sticky top-28 flex flex-col gap-4">
       <div className="rounded-lg border border-border bg-card p-4">
-        <p className="mb-2 font-mono text-2xs uppercase tracking-widest text-muted-foreground">
+        <p className="eyebrow mb-2">
           {isRegister
             ? t('rail.registerHint', { defaultValue: 'Registering existing infrastructure' })
             : isStac
@@ -148,7 +148,7 @@ function NonUploadRail({ mode }: { mode: 'register' | 'service' | 'stac' }) {
       </div>
 
       <div className="rounded-lg border border-border bg-card p-4">
-        <p className="mb-2 font-mono text-2xs uppercase tracking-widest text-muted-foreground">
+        <p className="eyebrow mb-2">
           {t('rail.comparedToUpload', { defaultValue: 'Compared to Upload' })}
         </p>
         <p className="text-xs text-muted-foreground leading-relaxed">

--- a/frontend/src/components/layout/Navbar.tsx
+++ b/frontend/src/components/layout/Navbar.tsx
@@ -307,7 +307,7 @@ function MobileNav() {
               return (
                 <>
                   <Separator className="my-2" />
-                  <p className="px-3 text-xs font-medium text-muted-foreground uppercase tracking-wider mb-1">
+                  <p className="eyebrow px-3 mb-1">
                     {t('create')}
                   </p>
                   {canCreateDataset && (

--- a/frontend/src/components/maps/MapCardSkeleton.tsx
+++ b/frontend/src/components/maps/MapCardSkeleton.tsx
@@ -11,7 +11,7 @@ export function MapCardSkeleton() {
         <Skeleton className="h-5 w-2/3" />
         <Skeleton className="h-3 w-full" />
         <div className="flex gap-2">
-          <Skeleton className="h-4 w-16 rounded-full" />
+          <Skeleton className="h-4 w-16 rounded-md" />
           <Skeleton className="h-4 w-24" />
         </div>
       </div>

--- a/frontend/src/components/search/DatasetCardSkeleton.tsx
+++ b/frontend/src/components/search/DatasetCardSkeleton.tsx
@@ -11,7 +11,7 @@ export function DatasetCardSkeleton() {
             <div className="grid grid-cols-1 gap-4 md:grid-cols-[1fr_160px]">
               <div className="flex flex-col gap-2">
                 <div className="flex flex-wrap gap-2">
-                  <Skeleton className="h-6 w-16 rounded-full" />
+                  <Skeleton className="h-6 w-16 rounded-md" />
                 </div>
                 <Skeleton className="h-6 w-4/5" />
                 <Skeleton className="h-4 w-2/3" />
@@ -29,13 +29,13 @@ export function DatasetCardSkeleton() {
             </div>
             {/* Band 3 — Tags */}
             <div className="flex flex-wrap gap-1.5">
-              <Skeleton className="h-6 w-16 rounded-full" />
-              <Skeleton className="h-6 w-20 rounded-full" />
+              <Skeleton className="h-6 w-16 rounded-md" />
+              <Skeleton className="h-6 w-20 rounded-md" />
             </div>
             {/* Band 4 — Footer */}
             <div className="flex items-center justify-between">
               <Skeleton className="h-4 w-36" />
-              <Skeleton className="h-5 w-14 rounded-full" />
+              <Skeleton className="h-5 w-14 rounded-md" />
             </div>
           </div>
         </div>

--- a/frontend/src/components/search/QualityBadge.tsx
+++ b/frontend/src/components/search/QualityBadge.tsx
@@ -1,4 +1,6 @@
 import { useTranslation } from 'react-i18next';
+import { Badge } from '@/components/ui/badge';
+import { cn } from '@/lib/utils';
 import { qualityScoreClasses } from '@/lib/status-colors';
 import {
   Tooltip,
@@ -13,11 +15,9 @@ export function QualityBadge({ score }: { score: number | null | undefined }) {
   return (
     <Tooltip>
       <TooltipTrigger asChild>
-        <span
-          className={`text-xs px-2 py-0.5 border rounded-full font-medium transition-colors duration-150 cursor-help ${qualityScoreClasses(score)}`}
-        >
+        <Badge className={cn('cursor-help', qualityScoreClasses(score))}>
           {t('quality.label', { score })}
-        </span>
+        </Badge>
       </TooltipTrigger>
       <TooltipContent>
         <p className="text-xs">{t('qualityBadge.tooltip')}</p>

--- a/frontend/src/components/settings/MyApiKeySection.tsx
+++ b/frontend/src/components/settings/MyApiKeySection.tsx
@@ -5,6 +5,7 @@ import { formatDate } from '@/lib/format';
 import { activeDotColor, semanticBadgeColors } from '@/lib/status-colors';
 import { cn } from '@/lib/utils';
 import type { MyApiKeyResponse, ApiKeyCreateResponse } from '@/types/api';
+import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { FieldLabel } from '@/components/ui/field-label';
@@ -151,14 +152,14 @@ export function MyApiKeySection() {
                   />
                   {/* fix(#305): replace dot+title+sr-only with a visible status badge so state is
                       conveyed as visible text, not color alone. The dot stays as a secondary visual cue. */}
-                  <span
+                  <Badge
                     className={cn(
-                      'inline-flex items-center rounded-full border px-1.5 py-0.5 text-xs font-medium',
+                      'px-1.5',
                       key.is_active ? semanticBadgeColors.success : semanticBadgeColors.destructive,
                     )}
                   >
                     {key.is_active ? t('admin:apiKeys.active') : t('admin:apiKeys.revoked')}
-                  </span>
+                  </Badge>
                 </div>
                 <div className="text-xs text-muted-foreground">
                   {t('admin:apiKeys.created', { date: formatDate(key.created_at) })} · {t('admin:apiKeys.lastUsed')} {relativeTime(key.last_used_at, t)}

--- a/frontend/src/components/viewer/AccessibleMapDataPanel.tsx
+++ b/frontend/src/components/viewer/AccessibleMapDataPanel.tsx
@@ -186,7 +186,7 @@ export function AccessibleMapDataPanel({
                                 })
                               : t('viewer.data.geometryType', { type: feature.geometryType })}
                         </p>
-                        <h5 className="mt-3 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                        <h5 className="eyebrow mt-3">
                           {t('viewer.data.attributes')}
                         </h5>
                         {feature.properties.length === 0 ? (

--- a/frontend/src/components/viewer/ViewerMap.tsx
+++ b/frontend/src/components/viewer/ViewerMap.tsx
@@ -1033,7 +1033,7 @@ export const ViewerMap = memo(function ViewerMap({
         attributionControl={false}
         minZoom={1}
         onLoad={handleLoad}
-        aria-label={t('viewer.legend.title')}
+        aria-label={t('viewer.map.ariaLabel', { defaultValue: 'Map viewer' })}
       >
         <NavigationControl position="top-right" />
         <FullscreenControl position="top-right" />

--- a/frontend/src/i18n/locales/de/admin.json
+++ b/frontend/src/i18n/locales/de/admin.json
@@ -389,7 +389,8 @@
     "bulkRevokeConfirm": "Widerrufen",
     "bulkRevokeCancel": "Abbrechen",
     "bulkRevokeSuccess": "{{count}} Einbettungstokens widerrufen",
-    "bulkRevokeFailed": "Einbettungstokens konnten nicht widerrufen werden"
+    "bulkRevokeFailed": "Einbettungstokens konnten nicht widerrufen werden",
+    "tableLabel": "Einbettungstokens"
   },
   "settings": {
     "copySPEntityId": "SP-Entitäts-ID kopieren",

--- a/frontend/src/i18n/locales/de/common.json
+++ b/frontend/src/i18n/locales/de/common.json
@@ -328,7 +328,10 @@
         "moreColumns": "weitere Spalten"
       }
     },
-    "anonMapRecovery": "Diese Karte ist möglicherweise privat. Melden Sie sich an, um zu prüfen, ob Ihr Konto sie öffnen kann."
+    "anonMapRecovery": "Diese Karte ist möglicherweise privat. Melden Sie sich an, um zu prüfen, ob Ihr Konto sie öffnen kann.",
+    "map": {
+      "ariaLabel": "Kartenansicht"
+    }
   },
   "maps": {
     "title": "Karten",

--- a/frontend/src/i18n/locales/de/common.json
+++ b/frontend/src/i18n/locales/de/common.json
@@ -437,7 +437,8 @@
       "statusOk": "Verbunden",
       "statusError": "Fehlgeschlagen",
       "latency": "{{ms}}ms",
-      "noOidc": "Keine OIDC-Anbieter konfiguriert"
+      "noOidc": "Keine OIDC-Anbieter konfiguriert",
+      "resultsLabel": "Konnektivitätsergebnisse"
     },
     "import": {
       "title": "Konfiguration importieren",

--- a/frontend/src/i18n/locales/de/dataset.json
+++ b/frontend/src/i18n/locales/de/dataset.json
@@ -205,7 +205,8 @@
     "showingExact": "{{start}}-{{end}} von {{total}} Zeilen",
     "rowsPerPage": "Zeilen pro Seite",
     "columns": "Spalten",
-    "loadFailed": "Daten konnten nicht geladen werden. Bitte erneut versuchen."
+    "loadFailed": "Daten konnten nicht geladen werden. Bitte erneut versuchen.",
+    "tableLabel": "Feature-Attribute"
   },
   "changeHistory": {
     "title": "Änderungsverlauf ({{count}})",
@@ -275,7 +276,8 @@
     "noSources": "Keine Quellen",
     "searchError": "Datensätze konnten nicht durchsucht werden.",
     "sourcesLoadError": "VRT-Quellen konnten nicht geladen werden.",
-    "sourceTableHealth": "Gesundheit"
+    "sourceTableHealth": "Gesundheit",
+    "sourcesTableLabel": "VRT-Quellen"
   },
   "deleteDialog": {
     "title": "Datensatz löschen",
@@ -326,12 +328,14 @@
         "name": "Name",
         "geometry": "Geometrie",
         "featureCount": "Features"
-      }
+      },
+      "tableLabel": "Dienst-Layer"
     },
     "fileLayer": {
       "layerStep": "Layer auswählen",
       "missingLayerWarning": "Der ursprüngliche Layer '{{layer}}' ist in der neuen Datei nicht vorhanden. Wählen Sie einen Ersatz, um fortzufahren.",
-      "previewLayer": "Layer prüfen"
+      "previewLayer": "Layer prüfen",
+      "tableLabel": "Datei-Layer"
     },
     "dropzone": "Datei hierher ziehen oder klicken zum Durchsuchen",
     "uploadingMessage": "Datei wird hochgeladen und analysiert...",

--- a/frontend/src/i18n/locales/en/admin.json
+++ b/frontend/src/i18n/locales/en/admin.json
@@ -414,7 +414,8 @@
     "bulkRevokeConfirm": "Revoke",
     "bulkRevokeCancel": "Cancel",
     "bulkRevokeSuccess": "{{count}} embed tokens revoked",
-    "bulkRevokeFailed": "Failed to revoke embed tokens"
+    "bulkRevokeFailed": "Failed to revoke embed tokens",
+    "tableLabel": "Embed tokens"
   },
   "settings": {
     "copySPEntityId": "Copy SP Entity ID",

--- a/frontend/src/i18n/locales/en/common.json
+++ b/frontend/src/i18n/locales/en/common.json
@@ -202,7 +202,10 @@
         "moreColumns": "more columns"
       }
     },
-    "anonMapRecovery": "This map may be private. Sign in to check whether your account can open it."
+    "anonMapRecovery": "This map may be private. Sign in to check whether your account can open it.",
+    "map": {
+      "ariaLabel": "Map viewer"
+    }
   },
   "actions": {
     "editGeometry": "Edit Features",

--- a/frontend/src/i18n/locales/en/common.json
+++ b/frontend/src/i18n/locales/en/common.json
@@ -453,7 +453,8 @@
       "statusOk": "Connected",
       "statusError": "Failed",
       "latency": "{{ms}}ms",
-      "noOidc": "No OIDC providers configured"
+      "noOidc": "No OIDC providers configured",
+      "resultsLabel": "Connectivity results"
     },
     "import": {
       "title": "Import Configuration",

--- a/frontend/src/i18n/locales/en/dataset.json
+++ b/frontend/src/i18n/locales/en/dataset.json
@@ -205,7 +205,8 @@
     "showingExact": "Showing {{start}}-{{end}} of {{total}} rows",
     "rowsPerPage": "Rows per page",
     "columns": "Columns",
-    "loadFailed": "Failed to load data. Please try again."
+    "loadFailed": "Failed to load data. Please try again.",
+    "tableLabel": "Feature attributes"
   },
   "changeHistory": {
     "title": "Change History ({{count}})",
@@ -278,12 +279,14 @@
         "name": "Name",
         "geometry": "Geometry",
         "featureCount": "Features"
-      }
+      },
+      "tableLabel": "Service layers"
     },
     "fileLayer": {
       "layerStep": "Select a layer",
       "missingLayerWarning": "Original layer '{{layer}}' is not present in the new file. Pick a replacement to continue.",
-      "previewLayer": "Preview Layer"
+      "previewLayer": "Preview Layer",
+      "tableLabel": "File layers"
     },
     "dropzone": "Drag and drop a file here, or click to browse",
     "uploadingMessage": "Uploading and analyzing file...",
@@ -727,7 +730,8 @@
     "noSources": "No sources",
     "searchError": "Failed to search datasets.",
     "sourcesLoadError": "Failed to load VRT sources.",
-    "sourceTableHealth": "Health"
+    "sourceTableHealth": "Health",
+    "sourcesTableLabel": "VRT sources"
   },
   "ai": {
     "assist": "AI Assist",

--- a/frontend/src/i18n/locales/es/admin.json
+++ b/frontend/src/i18n/locales/es/admin.json
@@ -389,7 +389,8 @@
     "bulkRevokeConfirm": "Revocar",
     "bulkRevokeCancel": "Cancelar",
     "bulkRevokeSuccess": "{{count}} tokens de insercion revocados",
-    "bulkRevokeFailed": "No se pudieron revocar los tokens de insercion"
+    "bulkRevokeFailed": "No se pudieron revocar los tokens de insercion",
+    "tableLabel": "Tokens de inserción"
   },
   "settings": {
     "copySPEntityId": "Copiar ID de entidad SP",

--- a/frontend/src/i18n/locales/es/common.json
+++ b/frontend/src/i18n/locales/es/common.json
@@ -328,7 +328,10 @@
         "moreColumns": "más columnas"
       }
     },
-    "anonMapRecovery": "Puede que este mapa sea privado. Inicia sesión para comprobar si tu cuenta puede abrirlo."
+    "anonMapRecovery": "Puede que este mapa sea privado. Inicia sesión para comprobar si tu cuenta puede abrirlo.",
+    "map": {
+      "ariaLabel": "Visor del mapa"
+    }
   },
   "maps": {
     "title": "Mapas",

--- a/frontend/src/i18n/locales/es/common.json
+++ b/frontend/src/i18n/locales/es/common.json
@@ -437,7 +437,8 @@
       "statusOk": "Conectado",
       "statusError": "Fallido",
       "latency": "{{ms}}ms",
-      "noOidc": "No hay proveedores OIDC configurados"
+      "noOidc": "No hay proveedores OIDC configurados",
+      "resultsLabel": "Resultados de conectividad"
     },
     "import": {
       "title": "Importar configuración",

--- a/frontend/src/i18n/locales/es/dataset.json
+++ b/frontend/src/i18n/locales/es/dataset.json
@@ -205,7 +205,8 @@
     "showingExact": "Mostrando {{start}}-{{end}} de {{total}} filas",
     "rowsPerPage": "Filas por página",
     "columns": "Columnas",
-    "loadFailed": "No se pudieron cargar los datos. Inténtalo de nuevo."
+    "loadFailed": "No se pudieron cargar los datos. Inténtalo de nuevo.",
+    "tableLabel": "Atributos de entidades"
   },
   "changeHistory": {
     "title": "Historial de cambios ({{count}})",
@@ -275,7 +276,8 @@
     "noSources": "Sin fuentes",
     "searchError": "No se pudieron buscar conjuntos de datos.",
     "sourcesLoadError": "No se pudieron cargar las fuentes VRT.",
-    "sourceTableHealth": "Salud"
+    "sourceTableHealth": "Salud",
+    "sourcesTableLabel": "Fuentes del VRT"
   },
   "deleteDialog": {
     "title": "Eliminar conjunto de datos",
@@ -326,12 +328,14 @@
         "name": "Nombre",
         "geometry": "Geometría",
         "featureCount": "Entidades"
-      }
+      },
+      "tableLabel": "Capas del servicio"
     },
     "fileLayer": {
       "layerStep": "Seleccione una capa",
       "missingLayerWarning": "La capa original '{{layer}}' no está presente en el nuevo archivo. Seleccione un reemplazo para continuar.",
-      "previewLayer": "Vista previa de la capa"
+      "previewLayer": "Vista previa de la capa",
+      "tableLabel": "Capas del archivo"
     },
     "dropzone": "Arrastre y suelte un archivo aquí, o haga clic para explorar",
     "uploadingMessage": "Subiendo y analizando archivo...",

--- a/frontend/src/i18n/locales/fr/admin.json
+++ b/frontend/src/i18n/locales/fr/admin.json
@@ -389,7 +389,8 @@
     "bulkRevokeConfirm": "Revoquer",
     "bulkRevokeCancel": "Annuler",
     "bulkRevokeSuccess": "{{count}} jetons d'integration revoques",
-    "bulkRevokeFailed": "Echec de la revocation des jetons d'integration"
+    "bulkRevokeFailed": "Echec de la revocation des jetons d'integration",
+    "tableLabel": "Jetons d'intégration"
   },
   "settings": {
     "copySPEntityId": "Copier l'ID d'entité SP",

--- a/frontend/src/i18n/locales/fr/common.json
+++ b/frontend/src/i18n/locales/fr/common.json
@@ -328,7 +328,10 @@
         "moreColumns": "plus de colonnes"
       }
     },
-    "anonMapRecovery": "Cette carte est peut-être privée. Connectez-vous pour vérifier si votre compte peut l'ouvrir."
+    "anonMapRecovery": "Cette carte est peut-être privée. Connectez-vous pour vérifier si votre compte peut l'ouvrir.",
+    "map": {
+      "ariaLabel": "Visionneuse de carte"
+    }
   },
   "maps": {
     "title": "Cartes",

--- a/frontend/src/i18n/locales/fr/common.json
+++ b/frontend/src/i18n/locales/fr/common.json
@@ -437,7 +437,8 @@
       "statusOk": "Connecté",
       "statusError": "Échoué",
       "latency": "{{ms}}ms",
-      "noOidc": "Aucun fournisseur OIDC configuré"
+      "noOidc": "Aucun fournisseur OIDC configuré",
+      "resultsLabel": "Résultats de connectivité"
     },
     "import": {
       "title": "Importer la configuration",

--- a/frontend/src/i18n/locales/fr/dataset.json
+++ b/frontend/src/i18n/locales/fr/dataset.json
@@ -205,7 +205,8 @@
     "showingExact": "Affichage {{start}}-{{end}} sur {{total}} lignes",
     "rowsPerPage": "Lignes par page",
     "columns": "Colonnes",
-    "loadFailed": "Impossible de charger les données. Veuillez réessayer."
+    "loadFailed": "Impossible de charger les données. Veuillez réessayer.",
+    "tableLabel": "Attributs des entités"
   },
   "changeHistory": {
     "title": "Historique des modifications ({{count}})",
@@ -275,7 +276,8 @@
     "noSources": "Aucune source",
     "searchError": "Impossible de rechercher des jeux de données.",
     "sourcesLoadError": "Impossible de charger les sources VRT.",
-    "sourceTableHealth": "Santé"
+    "sourceTableHealth": "Santé",
+    "sourcesTableLabel": "Sources du VRT"
   },
   "deleteDialog": {
     "title": "Supprimer le jeu de données",
@@ -326,12 +328,14 @@
         "name": "Nom",
         "geometry": "Géométrie",
         "featureCount": "Entités"
-      }
+      },
+      "tableLabel": "Couches du service"
     },
     "fileLayer": {
       "layerStep": "Sélectionnez une couche",
       "missingLayerWarning": "La couche d'origine '{{layer}}' n'est pas présente dans le nouveau fichier. Sélectionnez un remplacement pour continuer.",
-      "previewLayer": "Prévisualiser la couche"
+      "previewLayer": "Prévisualiser la couche",
+      "tableLabel": "Couches du fichier"
     },
     "dropzone": "Glissez-déposez un fichier ici, ou cliquez pour parcourir",
     "uploadingMessage": "Téléchargement et analyse du fichier...",

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -72,8 +72,9 @@
   --input: oklch(0.65 0.006 85);
   /* Focus-ring color. fix(#438): DS-10 — the standard focus treatment is
      `ring-2 ring-ring`. `ring-primary` was folded into `ring-ring` (same hue).
-     The residual `ring-1` width one-offs and unmapped shadow-xs/xl are a
-     visible-weight change left for a dedicated design pass, not swept here. */
+     The residual `ring-1` width one-offs are a visible-weight change left for
+     a dedicated design pass, not swept here. (shadow-xs has since been mapped
+     through --elevation-xs; shadow-xl remains unmapped and unused.) */
   --ring: oklch(0.55 0.18 250);
 
   /* ─ Surface hierarchy (light mode — warm) ─ */

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -103,9 +103,14 @@
    * #305: light fg darkened so text-warning/info/success clear WCAG AA
    * (>=4.5:1) on card AND soft 10-percent-tint surfaces. Measured ratios:
    * warning 6.01 and 5.05, info 5.41 and 4.54, success 5.5 and 4.64 (was
-   * 2.19, 4.07, 4.07). --warning-foreground stays DARK: it is used as text
-   * on light/soft surfaces (e.g. BulkReviewList, LayerStyleEditor), not on a
-   * solid warning fill, so a dark foreground keeps those readable. */
+   * 2.19, 4.07, 4.07).
+   * --warning-foreground is DARK in BOTH themes and is reserved for text on a
+   * solid bg-warning fill. Never use it as standalone text on card or tint
+   * surfaces — in dark mode it composites to ~1:1 (illegible); use
+   * text-warning there instead. A source-scan test
+   * (warning-foreground-usage.test.ts) enforces this. No component renders a
+   * solid warning fill today; retune the light value (~2.4:1 on solid
+   * warning) before introducing one. */
   --success: oklch(0.49 0.16 150);
   --success-foreground: oklch(0.985 0 0);
   --warning: oklch(0.50 0.13 68);
@@ -604,7 +609,9 @@
   border-bottom-color: var(--popover);
 }
 
-/* Popup close button — 32×32 visible, 44×44 touch target via padding */
+/* Popup close button — 32×32 visible (border-box, so the padding is inside
+   that box); coarse pointers get a ≥44px hit target via the pointer-coarse
+   rule further down. */
 .maplibregl-popup-close-button {
   color: var(--popover-foreground);
   font-size: 18px;
@@ -693,7 +700,8 @@ html.dragging-active {
    target. Scoped to pointer:coarse so fine-pointer desktop density is
    unchanged (mirrors the existing maplibre popup-close 44px treatment). */
 @media (pointer: coarse) {
-  .maplibregl-ctrl-group button {
+  .maplibregl-ctrl-group button,
+  .maplibregl-popup-close-button {
     min-width: 44px;
     min-height: 44px;
   }

--- a/frontend/src/lib/__tests__/warning-foreground-usage.test.ts
+++ b/frontend/src/lib/__tests__/warning-foreground-usage.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+
+/**
+ * --warning-foreground is a DARK value in BOTH themes (tuned as text over a
+ * solid bg-warning fill). Used as text on card or soft-tint surfaces it
+ * composites to ~1.05:1 in dark mode — a WCAG 1.4.3 failure. The on-tint /
+ * on-card warning text color is `text-warning`, which is tuned to clear AA
+ * on card AND /10 tints in both themes (see the #305 comment in index.css).
+ *
+ * No component currently renders a solid bg-warning fill, so there is no
+ * legitimate use of text-warning-foreground in components today. If one is
+ * introduced, pair it with a solid bg-warning AND retune the light-mode
+ * value first (it measured 2.42:1 on solid warning at time of writing).
+ */
+const sources = import.meta.glob(['/src/**/*.tsx', '/src/**/*.ts'], {
+  query: '?raw',
+  import: 'default',
+  eager: true,
+}) as Record<string, string>;
+
+describe('warning-foreground usage', () => {
+  it('is not used as a text color in components', () => {
+    const offenders = Object.entries(sources)
+      .filter(([path]) => !path.includes('__tests__') && !path.endsWith('.test.ts') && !path.endsWith('.test.tsx'))
+      .filter(([, source]) => source.includes('text-warning-foreground'))
+      .map(([path]) => path);
+
+    expect(offenders).toEqual([]);
+  });
+});

--- a/frontend/src/lib/status-colors.ts
+++ b/frontend/src/lib/status-colors.ts
@@ -100,6 +100,23 @@ export const experimentalBadgeColor = 'border-warning/50 text-warning';
 export const syntheticBadgeColor =
   'border-synthetic/30 bg-synthetic-bg text-synthetic';
 
+/**
+ * Import file-entry lifecycle (upload → detect → commit → track). The
+ * `committing` state deliberately uses the primary action color rather than a
+ * status hue — it marks "acting on your request", not a health state.
+ */
+export const fileEntryStatusColors: Record<string, string> = {
+  uploading: semanticBadgeColors.info,
+  previewing: semanticBadgeColors.info,
+  preview: semanticBadgeColors.success,
+  committing: 'border-primary/30 bg-primary/10 text-primary',
+  tracking: semanticBadgeColors.success,
+  complete: semanticBadgeColors.success,
+  'upload-failed': semanticBadgeColors.destructive,
+  'commit-failed': semanticBadgeColors.destructive,
+  failed: semanticBadgeColors.destructive,
+};
+
 export const vrtRasterStatusColors: Record<string, string> = {
   ready: 'border-success/50 text-success',
   regenerating: 'border-warning/50 text-warning',

--- a/frontend/src/pages/CollectionDetailPage.tsx
+++ b/frontend/src/pages/CollectionDetailPage.tsx
@@ -144,35 +144,35 @@ export function CollectionDetailPage() {
             className="grid grid-cols-1 gap-x-6 gap-y-4 sm:grid-cols-2"
           >
             <div className="space-y-2 sm:col-start-1 sm:row-start-1">
-              <dt className="flex items-center gap-1.5 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+              <dt className="eyebrow flex items-center gap-1.5">
                 <Database className="h-3.5 w-3.5" />
                 {t('detail.datasets')}
               </dt>
               <dd className="text-sm">{formatNumber(collection.dataset_count)}</dd>
             </div>
             <div className="space-y-2 sm:col-start-1 sm:row-start-2">
-              <dt className="flex items-center gap-1.5 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+              <dt className="eyebrow flex items-center gap-1.5">
                 <Calendar className="h-3.5 w-3.5" />
                 {t('detail.temporalRange')}
               </dt>
               <dd className="text-sm">{formatTemporal()}</dd>
             </div>
             <div className="space-y-2 sm:col-start-1 sm:row-start-3">
-              <dt className="flex items-center gap-1.5 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+              <dt className="eyebrow flex items-center gap-1.5">
                 <Calendar className="h-3.5 w-3.5" />
                 {t('detail.created')}
               </dt>
               <dd className="text-sm">{formatDate(collection.created_at)}</dd>
             </div>
             <div className="space-y-2 sm:col-start-1 sm:row-start-4">
-              <dt className="flex items-center gap-1.5 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+              <dt className="eyebrow flex items-center gap-1.5">
                 <Calendar className="h-3.5 w-3.5" />
                 {t('detail.lastUpdated')}
               </dt>
               <dd className="text-sm">{formatDate(collection.updated_at)}</dd>
             </div>
             <div className="space-y-2 sm:col-start-2 sm:row-span-4 sm:row-start-1">
-              <dt className="flex items-center gap-1.5 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+              <dt className="eyebrow flex items-center gap-1.5">
                 <MapPin className="h-3.5 w-3.5" />
                 {t('detail.spatialExtent')}
               </dt>

--- a/frontend/src/pages/DatasetPage.tsx
+++ b/frontend/src/pages/DatasetPage.tsx
@@ -567,7 +567,7 @@ export function DatasetPage() {
             </Suspense>
           </MapErrorBoundary>
           {dataset.record_type === 'raster_dataset' && !dataset.raster?.tile_url && heroState === 'loaded' && (
-            <div className="absolute bottom-2 left-2 z-10 px-2 py-1 rounded-sm bg-muted/80 text-xs text-muted-foreground">
+            <div className="absolute bottom-2 start-2 z-10 px-2 py-1 rounded-sm bg-muted/80 text-xs text-muted-foreground">
               {t('raster.noTiles')}
             </div>
           )}

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -277,7 +277,7 @@ export function LoginPage() {
   return (
     <main className="grid min-h-screen grid-cols-1 min-[880px]:grid-cols-[1.05fr_0.95fr]">
       {/* ───────── LEFT — brand / map panel (hidden ≤880px) ───────── */}
-      <section className="relative hidden overflow-hidden border-r border-border bg-map-paper px-14 py-12 min-[880px]:flex min-[880px]:flex-col min-[880px]:justify-between">
+      <section className="relative hidden overflow-hidden border-e border-border bg-map-paper px-14 py-12 min-[880px]:flex min-[880px]:flex-col min-[880px]:justify-between">
         <BrandMapBackdrop />
         {/* Paper scrim keeps the left-aligned text legible over the map. */}
         <div className="pointer-events-none absolute inset-0 bg-gradient-to-br from-map-paper/90 via-map-paper/70 to-map-paper/30" />
@@ -333,7 +333,7 @@ export function LoginPage() {
         {/* Persistent top-right browse link — the immediate escape hatch. */}
         <Button
           variant="ghost"
-          className="absolute right-[14px] top-[14px] h-auto gap-1.5 px-3 py-1.5 text-xs font-medium text-muted-foreground min-[880px]:right-[26px] min-[880px]:top-[22px]"
+          className="absolute end-[14px] top-[14px] h-auto gap-1.5 px-3 py-1.5 text-xs font-medium text-muted-foreground min-[880px]:end-[26px] min-[880px]:top-[22px]"
           onClick={handleBrowseCatalog}
         >
           {t('browseCatalogCta')}

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -291,7 +291,7 @@ export function LoginPage() {
             >
               <GeoLensLogo size="lg" />
             </Link>
-            <p className="mt-2.5 font-mono text-mini uppercase tracking-[0.08em] text-muted-foreground">
+            <p className="eyebrow mt-2.5">
               {t('geospatialDataCatalog')}
             </p>
           </div>

--- a/frontend/src/pages/PublicMapViewerPage.tsx
+++ b/frontend/src/pages/PublicMapViewerPage.tsx
@@ -185,7 +185,7 @@ export function PublicMapViewerPage() {
         value={basemapId ?? data.basemap_style}
         onChange={setBasemapId}
         title={t('viewer.changeBasemap')}
-        className="absolute bottom-8 left-3 z-10"
+        className="absolute bottom-8 start-3 z-10"
       />
 
       {/* Read-only "Ask AI" — self-gates on AI availability + use_ai_chat, so anonymous

--- a/frontend/src/pages/PublicViewerPage.tsx
+++ b/frontend/src/pages/PublicViewerPage.tsx
@@ -179,7 +179,7 @@ export function PublicViewerPage() {
           value={basemapId ?? data.basemap_style}
           onChange={setBasemapId}
           title={t('viewer.changeBasemap')}
-          className="absolute bottom-8 left-3 z-10"
+          className="absolute bottom-8 start-3 z-10"
         />
       )}
 

--- a/frontend/src/pages/VerifyEmailPage.tsx
+++ b/frontend/src/pages/VerifyEmailPage.tsx
@@ -145,7 +145,7 @@ export function VerifyEmailPage() {
                 <Button type="submit" disabled={resending}>
                   {resending ? (
                     <>
-                      <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                      <Loader2 className="me-2 h-4 w-4 animate-spin" />
                       {t('verifyEmail.resending')}
                     </>
                   ) : (

--- a/frontend/src/pages/admin/AdminConfigOpsPage.tsx
+++ b/frontend/src/pages/admin/AdminConfigOpsPage.tsx
@@ -179,7 +179,7 @@ function ValidateSection() {
 
         {result && (
           <div className="space-y-2">
-            <Table>
+            <Table aria-label={t('configOps.validate.resultsLabel', { defaultValue: 'Connectivity results' })}>
               <TableHeader>
                 <TableRow>
                   <TableHead>{t('configOps.validate.serviceHeader')}</TableHead>
@@ -475,7 +475,7 @@ function ImportSection() {
                 <h3 className="text-sm font-medium">
                   {t('configOps.import.settingsChanges')}
                 </h3>
-                <Table>
+                <Table aria-label={t('configOps.import.settingsChanges')}>
                   <TableHeader>
                     <TableRow>
                       <TableHead>{t('configOps.import.key')}</TableHead>
@@ -522,7 +522,7 @@ function ImportSection() {
                     })}
                   </p>
                 )}
-                <Table>
+                <Table aria-label={t('configOps.import.oauthChanges')}>
                   <TableHeader>
                     <TableRow>
                       <TableHead>{t('configOps.import.slug')}</TableHead>

--- a/frontend/src/pages/admin/AdminSamlPage.tsx
+++ b/frontend/src/pages/admin/AdminSamlPage.tsx
@@ -41,7 +41,7 @@ export function AdminSamlPage() {
           breadcrumbs={[{ label: t('common:adminNav.admin'), to: '/admin' }]}
         />
         <div className="rounded-xl border border-border bg-card p-6 max-w-2xl">
-          <h2 className="text-lg font-medium mb-2">{t('saml.enterpriseOnly.heading')}</h2>
+          <h2 className="text-lg font-semibold mb-2">{t('saml.enterpriseOnly.heading')}</h2>
           <p className="text-sm text-muted-foreground mb-4">
             {t('saml.enterpriseOnly.body')}
           </p>

--- a/frontend/src/pages/admin/AdminSharedMapsPage.tsx
+++ b/frontend/src/pages/admin/AdminSharedMapsPage.tsx
@@ -173,7 +173,7 @@ function EmbedTokensSubTable({ mapId }: { mapId: string }) {
         </AlertDialog>
       )}
 
-      <Table>
+      <Table aria-label={t('embedTokens.tableLabel', { defaultValue: 'Embed tokens' })}>
         <TableHeader>
           <TableRow>
             <TableHead className="w-8">
@@ -280,7 +280,7 @@ export function AdminSharedMapsPage() {
               ))}
             </div>
           </div>
-          <Table>
+          <Table aria-label={t('sharedMaps.title')}>
             <TableHeader>
               <TableRow>
                 <TableHead className="w-10" />

--- a/frontend/src/pages/admin/AdminSharedMapsPage.tsx
+++ b/frontend/src/pages/admin/AdminSharedMapsPage.tsx
@@ -179,12 +179,12 @@ function EmbedTokensSubTable({ mapId }: { mapId: string }) {
             <TableHead className="w-8">
               <Checkbox checked={allSelected} onCheckedChange={toggleSelectAll} aria-label={t('common:selectAll')} />
             </TableHead>
-            <TableHead className="text-xs">{t('embedTokens.tokenHint')}</TableHead>
-            <TableHead className="text-xs">{t('embedTokens.status')}</TableHead>
-            <TableHead className="text-xs">{t('embedTokens.useCount')}</TableHead>
-            <TableHead className="text-xs">{t('embedTokens.lastUsed')}</TableHead>
-            <TableHead className="text-xs">{t('embedTokens.expires')}</TableHead>
-            <TableHead className="text-xs">{t('embedTokens.origins')}</TableHead>
+            <TableHead>{t('embedTokens.tokenHint')}</TableHead>
+            <TableHead>{t('embedTokens.status')}</TableHead>
+            <TableHead>{t('embedTokens.useCount')}</TableHead>
+            <TableHead>{t('embedTokens.lastUsed')}</TableHead>
+            <TableHead>{t('embedTokens.expires')}</TableHead>
+            <TableHead>{t('embedTokens.origins')}</TableHead>
           </TableRow>
         </TableHeader>
         <TableBody>
@@ -415,9 +415,9 @@ export function AdminSharedMapsPage() {
                         <TableRow>
                           <TableCell colSpan={8} className="p-0">
                             <div className="border-t bg-muted/30 px-6 py-4">
-                              <h4 className="mb-2 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                              <p className="eyebrow mb-2">
                                 {t('sharedMaps.embedTokensFor', { map: token.map_name })}
-                              </h4>
+                              </p>
                               <EmbedTokensSubTable mapId={token.map_id} />
                             </div>
                           </TableCell>


### PR DESCRIPTION
## Summary

Addresses every finding from the 2026-07-15 design-system & accessibility audit (7-dimension sweep against DESIGN-GUIDE.md; grades were A/A/A-/A-/B/B-/C+ with 0 P0s). All three P1s and every P2 are fixed.

### P1 — accessibility
- **Dark-mode WCAG 1.4.3 failure**: `text-warning-foreground` is dark in *both* themes; used as text on tint/card surfaces it composited to ~1.05:1 in dark mode. Replaced with `text-warning` at all 13 sites (8 files) and added a source-scan regression test (`warning-foreground-usage.test.ts`) so it can't come back. The `index.css` token comment now documents the constraint.
- **Table region labels**: all 22 `<Table>` call sites (15 files) now pass a meaningful `aria-label` instead of the generic default — reusing existing locale keys where a section title exists; 6 new keys added to all four locales (en/es/fr/de).
- **Pill-chip drift (instrument system, anti-pattern #8)**: `StatusPill` rebuilt on `<Badge>` + a new centralized `fileEntryStatusColors` map in `status-colors.ts`; `QualityBadge` and the API-key status chip converted to `<Badge>`; `rounded-full` overrides dropped across 10 chip sites, 2 segmented toggles (also off arbitrary `px-[10px]/py-[5px]` and `var(--surface-*)` fallbacks), and 9 badge-shaped skeletons.

### P2
- **`.eyebrow` adoption**: 39 hand-rolled mono-caps/uppercase section labels across import, builder, auth, admin, and viewer now use the canonical utility.
- **Token-value fallbacks**: inline `var(--primary-50, oklch(…))` / `theme()` fallbacks in builder classes replaced with bridged utilities (`bg-primary-50`, `bg-type-*-bg`); dynamic inline styles keep bare `var()`.
- **Status-recipe centralization**: BulkReviewList uses the Badge `success` variant; QualityScoreCard and StackRow reference `semanticBadgeColors` instead of inlining the soft-tint recipe.
- **RTL**: six remaining physical direction utilities migrated to logical (`start-/end-/border-e/me-`).
- **Singles**: ViewerMap map region gets a dedicated aria-label key (was mislabeled with the legend title); AdminSharedMapsPage h1→h4 heading skip fixed (marker is now a non-heading eyebrow) and `TableHead` `text-xs` overrides dropped; AdminSamlPage heading weight; LayerEditorPanel inline `fontSize:'11px'` → `text-mini`; SchemaEditor's irreversible drop-column now confirms via `AlertDialog`; LineGradientControls/ClusterEditor seed colors derive from `MAP_COLORS.categorical` (visual change: gradient seeds are now brand blue→pink, cluster ramp amber→pink instead of MapLibre-example colors).
- **Touch target**: the MapLibre popup close button now genuinely reaches 44px on coarse pointers (the old comment claimed 44px but border-box kept it at 32px).

### Impacts
- No API/schema/config changes. Frontend-only.
- i18n: 7 new keys (6 table labels + ViewerMap label), present in all four locales — `test:i18n` parity gate green.
- Intentional visual deltas: standardized 11px eyebrow labels (were 10–14px ad-hoc), squared chips, brand-palette seed colors for new gradients/cluster ramps.
- DESIGN-GUIDE.md (internal, untracked) reconciled in the same pass: theme-init.js FOUC note, minzoom MVT-03 exception, popup touch-target wording, `--warning-foreground` semantics, `fileEntryStatusColors` export.

## Verification

- `npm run lint` ✅  `npm run typecheck` ✅
- `npx vitest run` — 331 files / 3,614 tests ✅ (one test updated: LineGradientControls default-stop assertion now references `DEFAULT_GRADIENT_STOPS`)
- `npm run test:i18n` locale parity ✅
- `npx playwright test e2e/accessibility.spec.ts e2e/keyboard-nav.spec.ts --project=chromium` — 17 passed against the live dev stack (restarted to pick up this branch) ✅

https://claude.ai/code/session_01Xd64KjyK8rmgEfvWemkP5w