### PR TITLE
fix(admin): keep the fixed admin sidebar below the sticky navbar

### DIFF
--- a/frontend/src/components/admin/AdminSidebar.tsx
+++ b/frontend/src/components/admin/AdminSidebar.tsx
@@ -157,7 +157,15 @@ export function AdminSidebar() {
   const capBadge = (n: number) => (n > 999 ? '999+' : String(n));
 
   return (
-    <Sidebar collapsible="icon" variant="sidebar" side="left">
+    // top-14 + height calc keep the viewport-fixed sidebar below the sticky
+    // h-14 navbar: without the offset the navbar buries the sidebar header and
+    // slides over the sidebar during macOS elastic overscroll.
+    <Sidebar
+      collapsible="icon"
+      variant="sidebar"
+      side="left"
+      className="top-14 h-[calc(100svh-3.5rem)]"
+    >
       <SidebarHeader className="px-4 py-3 group-data-[collapsible=icon]:hidden">
         <span className="eyebrow">{t('adminNav.admin')}</span>
       </SidebarHeader>


### PR DESCRIPTION
## Summary

Follow-up to the design-audit remediation (#520), from a user-reported observation: at the top of an admin page, scrolling up makes the header visibly nudge downward over the sidebar.

Root cause (measured live): the navbar is `sticky top-0` (in document flow) while the shadcn sidebar container is `fixed inset-y-0 h-svh` (viewport-pinned at y=0, behind the navbar). Two consequences:
- the sidebar's own "Admin" header was permanently buried under the navbar (~57px of the sidebar was unreachable), and
- during macOS elastic overscroll the document (navbar included) translates while the fixed sidebar stays put — the navbar slides down over the sidebar.

Fix: one line on `AdminSidebar` — `className="top-14 h-[calc(100svh-3.5rem)]"` on the `<Sidebar>` (the primitive forwards it to the fixed container; tailwind-merge swaps out `h-svh`). Verified live: sidebar spans y=56→viewport bottom, the "Admin" eyebrow header is visible, "Back to App" sits at the true bottom, icon-collapse unaffected.

Scope note: this fixes the buried header and confines the overscroll artifact to the 1px seam; *fully* eliminating relative motion during rubber-band requires making the navbar `fixed` app-wide (spacer, DemoBanner ordering, builder viewport math) — filed separately.

## Verification
- `npx eslint src/components/admin/AdminSidebar.tsx` ✅ `npm run typecheck` ✅
- `npx vitest run src/components/admin` — 56 passed ✅
- Live geometry check via Playwright (navbar bottom 57 / sidebar top 56 / eyebrow visible at y=68) ✅

https://claude.ai/code/session_01Xd64KjyK8rmgEfvWemkP5w