### PR TITLE
fix(builder): remediate builder-audit 2026-07-15 P1 findings (B-033..B-036)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1287,6 +1287,15 @@ jobs:
       - name: Run E2E tests
         run: npx playwright test
 
+      # fix(#TBD B-036): the builder-hardening suite previously ran in NO CI
+      # trigger (this job runs only the default config), so a red hardening
+      # gate on main was invisible. Chromium project only — the runner installs
+      # chromium alone, and the firefox/webkit projects are a local reviewer
+      # concern. --reporter=line keeps it from clobbering the main suite's
+      # playwright-report/ artifact.
+      - name: Run builder-hardening E2E suite (chromium)
+        run: npx playwright test -c playwright.builder-hardening.config.ts --project=chromium-hardening --reporter=line
+
       - name: Upload test results
         if: ${{ !cancelled() }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
@@ -1312,7 +1321,8 @@ jobs:
         run: docker compose down
 
   # ---- E2E / A11Y trigger matrix (REL-03) ----
-  # nightly cron ("0 7 * * *") + workflow_dispatch → e2e-test (full npx playwright test)
+  # nightly cron ("0 7 * * *") + workflow_dispatch → e2e-test (full npx playwright test
+  #                                                  + builder-hardening chromium suite)
   # release tag push (v*)                         → prod-smoke.yml (e2e:smoke:audit against
   #                                                  published images), gates release.yml via
   #                                                  workflow_run on "Prod Compose Smoke"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1287,7 +1287,7 @@ jobs:
       - name: Run E2E tests
         run: npx playwright test
 
-      # fix(#TBD B-036): the builder-hardening suite previously ran in NO CI
+      # fix(#524 B-036): the builder-hardening suite previously ran in NO CI
       # trigger (this job runs only the default config), so a red hardening
       # gate on main was invisible. Chromium project only — the runner installs
       # chromium alone, and the firefox/webkit projects are a local reviewer

--- a/e2e/builder-hardening.spec.ts
+++ b/e2e/builder-hardening.spec.ts
@@ -91,7 +91,7 @@ function attachConsoleGate(page: Page): ConsoleGate {
   return { errors, warnings };
 }
 
-// fix(#TBD B-036): status-0 AJAXErrors are network-level aborts of in-flight
+// fix(#524 B-036): status-0 AJAXErrors are network-level aborts of in-flight
 // tile fetches (page reload / source teardown mid-request), not server or app
 // failures. MapLibre surfaces them as console errors during the
 // save-and-reload flows this suite drives, and BuilderMap's DEV error handler

--- a/e2e/builder-hardening.spec.ts
+++ b/e2e/builder-hardening.spec.ts
@@ -91,15 +91,25 @@ function attachConsoleGate(page: Page): ConsoleGate {
   return { errors, warnings };
 }
 
+// fix(#TBD B-036): status-0 AJAXErrors are network-level aborts of in-flight
+// tile fetches (page reload / source teardown mid-request), not server or app
+// failures. MapLibre surfaces them as console errors during the
+// save-and-reload flows this suite drives, and BuilderMap's DEV error handler
+// re-logs the same events as '[BuilderMap] Map error:' warnings. Real tile
+// failures carry an HTTP status (404/500/...) and still fail the gate.
+const BENIGN_ABORTED_FETCH = /AJAXError: Failed to fetch \(0\)/;
+
 function assertConsoleClean(gate: ConsoleGate) {
-  expect(gate.errors, `Console errors:\n${gate.errors.join('\n')}`).toHaveLength(0);
+  const errors = gate.errors.filter((error) => !BENIGN_ABORTED_FETCH.test(error));
+  expect(errors, `Console errors:\n${errors.join('\n')}`).toHaveLength(0);
   const filtered = gate.warnings.filter(
     (warning) =>
       !warning.includes('MapLibre') &&
       !warning.includes('GL Driver') &&
       !warning.includes('GPU stall') &&
       !warning.includes('Unable to load glyph range') &&
-      !warning.includes('Rendering codepoint'),
+      !warning.includes('Rendering codepoint') &&
+      !BENIGN_ABORTED_FETCH.test(warning),
   );
   expect(filtered, `Console warnings:\n${filtered.join('\n')}`).toHaveLength(0);
 }

--- a/frontend/src/components/builder/BuilderMap.tsx
+++ b/frontend/src/components/builder/BuilderMap.tsx
@@ -381,7 +381,7 @@ export const BuilderMap = memo(function BuilderMap({
   const clusterGeoJsonDataRef = useRef<Map<string, GeoJSON.FeatureCollection>>(new Map());
   const clusterFallbackNotifiedRef = useRef<Set<string>>(new Set());
   const [clusterGeoJsonVersion, setClusterGeoJsonVersion] = useState(0);
-  // fix(#TBD B-035): key the fetch effect on a structural signature, not the
+  // fix(#524 B-035): key the fetch effect on a structural signature, not the
   // layers array — paint/opacity/filter edits replace the array identity on
   // every debounce tick (~10Hz during a slider drag) and previously re-issued
   // a network GeoJSON fetch per bounded-geojson cluster layer on each tick.

--- a/frontend/src/components/builder/BuilderMap.tsx
+++ b/frontend/src/components/builder/BuilderMap.tsx
@@ -32,7 +32,7 @@ import {
 } from '@/components/map/cluster-interactions';
 import { substitutePopupTemplate } from '@/lib/popup-template';
 import { MapCoordReadout } from '@/components/map/MapCoordReadout';
-import { clusterFallbackMessage, getClusterSourceEligibility, getClusterSourceStrategy, isClusterRenderMode, shouldFetchClusterGeoJson } from './cluster-source';
+import { clusterFallbackMessage, getClusterSourceEligibility, getClusterSourceKey, getClusterSourceStrategy, isClusterRenderMode, shouldFetchClusterGeoJson } from './cluster-source';
 import type { StyleSpecification, VectorTileSource } from 'maplibre-gl';
 import {
   toSyncInput,
@@ -381,13 +381,15 @@ export const BuilderMap = memo(function BuilderMap({
   const clusterGeoJsonDataRef = useRef<Map<string, GeoJSON.FeatureCollection>>(new Map());
   const clusterFallbackNotifiedRef = useRef<Set<string>>(new Set());
   const [clusterGeoJsonVersion, setClusterGeoJsonVersion] = useState(0);
-  const clusterSourceLayers = useMemo(
-    () => layers.filter((layer) => isClusterRenderMode(layer)),
-    [layers],
-  );
+  // fix(#TBD B-035): key the fetch effect on a structural signature, not the
+  // layers array — paint/opacity/filter edits replace the array identity on
+  // every debounce tick (~10Hz during a slider drag) and previously re-issued
+  // a network GeoJSON fetch per bounded-geojson cluster layer on each tick.
+  const clusterSourceKey = useMemo(() => getClusterSourceKey(layers), [layers]);
 
   useEffect(() => {
     let cancelled = false;
+    const clusterSourceLayers = layersRef.current.filter((layer) => isClusterRenderMode(layer));
     if (clusterSourceLayers.length === 0) {
       if (clusterGeoJsonDataRef.current.size > 0) {
         clusterGeoJsonDataRef.current = new Map();
@@ -461,7 +463,9 @@ export const BuilderMap = memo(function BuilderMap({
     return () => {
       cancelled = true;
     };
-  }, [clusterSourceLayers, t]);
+    // layers is read through layersRef (always fresh post-render);
+    // clusterSourceKey covers every field that changes what gets fetched.
+  }, [clusterSourceKey, t]);
 
   // Build a lookup map from dataset_id -> TileToken, memoized by sig values
   const tokenMap = useMemo(() => {

--- a/frontend/src/components/builder/LayerEditorPanel.tsx
+++ b/frontend/src/components/builder/LayerEditorPanel.tsx
@@ -203,6 +203,28 @@ export const LayerEditorPanel = memo(function LayerEditorPanel({
     return 'style';
   }, [activeTab, availableTabs]);
 
+  // fix(#TBD B-034): roving-tabindex tablists need an arrow-key handler —
+  // inactive tabs carry tabIndex=-1, so without this a keyboard-only user has
+  // no path to the Filter/Labels/Popup editors at all. Selection follows focus
+  // (WAI-ARIA automatic-activation tabs pattern).
+  const handleTablistKeyDown = (event: React.KeyboardEvent<HTMLButtonElement>) => {
+    const currentIndex = availableTabs.indexOf(resolvedActiveTab);
+    let nextTab: LayerEditorTab | undefined;
+    if (event.key === 'ArrowRight') {
+      nextTab = availableTabs[(currentIndex + 1) % availableTabs.length];
+    } else if (event.key === 'ArrowLeft') {
+      nextTab = availableTabs[(currentIndex - 1 + availableTabs.length) % availableTabs.length];
+    } else if (event.key === 'Home') {
+      nextTab = availableTabs[0];
+    } else if (event.key === 'End') {
+      nextTab = availableTabs[availableTabs.length - 1];
+    }
+    if (!nextTab) return;
+    event.preventDefault();
+    if (nextTab !== resolvedActiveTab) handlers.onTabChange(layer.id, nextTab);
+    document.getElementById(`tab-${layer.id}-${nextTab}`)?.focus();
+  };
+
   // Destructive render-as switch — when the user clicks a different render-as
   // pill, hold the intended target until they confirm. null = no pending switch.
   const [pendingRenderAs, setPendingRenderAs] = useState<RenderAsId | null>(null);
@@ -401,6 +423,7 @@ export const LayerEditorPanel = memo(function LayerEditorPanel({
                         : 'text-muted-foreground hover:text-foreground border-b-2 border-transparent',
                     )}
                     onClick={() => handlers.onTabChange(layer.id, tab)}
+                    onKeyDown={handleTablistKeyDown}
                   >
                     <span>{t(`layerItem.${tab}Tab`)}</span>
                     {pip}

--- a/frontend/src/components/builder/LayerEditorPanel.tsx
+++ b/frontend/src/components/builder/LayerEditorPanel.tsx
@@ -203,7 +203,7 @@ export const LayerEditorPanel = memo(function LayerEditorPanel({
     return 'style';
   }, [activeTab, availableTabs]);
 
-  // fix(#TBD B-034): roving-tabindex tablists need an arrow-key handler —
+  // fix(#524 B-034): roving-tabindex tablists need an arrow-key handler —
   // inactive tabs carry tabIndex=-1, so without this a keyboard-only user has
   // no path to the Filter/Labels/Popup editors at all. Selection follows focus
   // (WAI-ARIA automatic-activation tabs pattern).

--- a/frontend/src/components/builder/LayerFilterEditor.tsx
+++ b/frontend/src/components/builder/LayerFilterEditor.tsx
@@ -247,7 +247,7 @@ export function LayerFilterEditor({
   }, []);
 
   function emitChange(updated: FilterCondition[], combo: 'all' | 'any' = combinator) {
-    // fix(#TBD B-033): cancel any pending debounced value emit — a stale 200ms
+    // fix(#524 B-033): cancel any pending debounced value emit — a stale 200ms
     // timer firing after this immediate emit would rebuild the filter from
     // captured (pre-change) conditions/combinator, silently overwrite the newer
     // filter, and set lastEmittedFilterRef to the stale value so the prop-sync
@@ -323,7 +323,7 @@ export function LayerFilterEditor({
 
   function handleCombinatorChange(value: string) {
     const combo = value as 'all' | 'any';
-    // fix(#TBD B-033): same stale-timer cancellation as emitChange — an All↔Any
+    // fix(#524 B-033): same stale-timer cancellation as emitChange — an All↔Any
     // toggle within the debounce window must not be clobbered by the pending
     // value emit (which captured the previous combinator).
     if (debounceTimerRef.current) {

--- a/frontend/src/components/builder/LayerFilterEditor.tsx
+++ b/frontend/src/components/builder/LayerFilterEditor.tsx
@@ -247,6 +247,15 @@ export function LayerFilterEditor({
   }, []);
 
   function emitChange(updated: FilterCondition[], combo: 'all' | 'any' = combinator) {
+    // fix(#TBD B-033): cancel any pending debounced value emit — a stale 200ms
+    // timer firing after this immediate emit would rebuild the filter from
+    // captured (pre-change) conditions/combinator, silently overwrite the newer
+    // filter, and set lastEmittedFilterRef to the stale value so the prop-sync
+    // effect never corrects the UI. The wrong filter then persists on Save.
+    if (debounceTimerRef.current) {
+      clearTimeout(debounceTimerRef.current);
+      debounceTimerRef.current = null;
+    }
     setConditions(updated);
     const newFilter = buildFilterExpression(updated, columnInfo, combo);
     lastEmittedFilterRef.current = newFilter;
@@ -314,6 +323,13 @@ export function LayerFilterEditor({
 
   function handleCombinatorChange(value: string) {
     const combo = value as 'all' | 'any';
+    // fix(#TBD B-033): same stale-timer cancellation as emitChange — an All↔Any
+    // toggle within the debounce window must not be clobbered by the pending
+    // value emit (which captured the previous combinator).
+    if (debounceTimerRef.current) {
+      clearTimeout(debounceTimerRef.current);
+      debounceTimerRef.current = null;
+    }
     setCombinator(combo);
     const newFilter = buildFilterExpression(conditions, columnInfo, combo);
     lastEmittedFilterRef.current = newFilter;

--- a/frontend/src/components/builder/__tests__/LayerEditorPanel.test.tsx
+++ b/frontend/src/components/builder/__tests__/LayerEditorPanel.test.tsx
@@ -726,7 +726,7 @@ describe('LayerEditorPanel', () => {
     });
   });
 
-  // fix(#TBD B-034): the tab strip uses a roving tabindex (inactive tabs are
+  // fix(#524 B-034): the tab strip uses a roving tabindex (inactive tabs are
   // tabIndex=-1), so without arrow-key handling a keyboard-only user has NO
   // path to the Filter/Labels/Popup editors.
   describe('tablist keyboard navigation (B-034)', () => {

--- a/frontend/src/components/builder/__tests__/LayerEditorPanel.test.tsx
+++ b/frontend/src/components/builder/__tests__/LayerEditorPanel.test.tsx
@@ -725,4 +725,57 @@ describe('LayerEditorPanel', () => {
       expect(handlers.onFilterChange).toHaveBeenCalledWith('layer-99', null);
     });
   });
+
+  // fix(#TBD B-034): the tab strip uses a roving tabindex (inactive tabs are
+  // tabIndex=-1), so without arrow-key handling a keyboard-only user has NO
+  // path to the Filter/Labels/Popup editors.
+  describe('tablist keyboard navigation (B-034)', () => {
+    it('ArrowRight selects and focuses the next tab', () => {
+      const onTabChange = vi.fn();
+      const layer = makeLayer();
+      render(
+        <LayerEditorPanel
+          layer={layer}
+          onClose={vi.fn()}
+          handlers={makeHandlers({ onTabChange })}
+          activeTab={null}
+        />
+      );
+      fireEvent.keyDown(screen.getByRole('tab', { name: 'Style' }), { key: 'ArrowRight' });
+      expect(onTabChange).toHaveBeenCalledWith(layer.id, 'filter');
+      expect(document.activeElement).toBe(
+        screen.getByRole('tab', { name: 'Filter' }),
+      );
+    });
+
+    it('ArrowLeft wraps from the first tab to the last', () => {
+      const onTabChange = vi.fn();
+      const layer = makeLayer();
+      render(
+        <LayerEditorPanel
+          layer={layer}
+          onClose={vi.fn()}
+          handlers={makeHandlers({ onTabChange })}
+          activeTab={null}
+        />
+      );
+      fireEvent.keyDown(screen.getByRole('tab', { name: 'Style' }), { key: 'ArrowLeft' });
+      expect(onTabChange).toHaveBeenCalledWith(layer.id, 'popup');
+    });
+
+    it('End jumps to the last tab', () => {
+      const onTabChange = vi.fn();
+      const layer = makeLayer();
+      render(
+        <LayerEditorPanel
+          layer={layer}
+          onClose={vi.fn()}
+          handlers={makeHandlers({ onTabChange })}
+          activeTab={null}
+        />
+      );
+      fireEvent.keyDown(screen.getByRole('tab', { name: 'Style' }), { key: 'End' });
+      expect(onTabChange).toHaveBeenCalledWith(layer.id, 'popup');
+    });
+  });
 });

--- a/frontend/src/components/builder/__tests__/LayerFilterEditor.test.ts
+++ b/frontend/src/components/builder/__tests__/LayerFilterEditor.test.ts
@@ -613,7 +613,7 @@ describe('numeric in_list per-entry validation (fix(#394) FL-03)', () => {
 });
 
 // ---------------------------------------------------------------------------
-// fix(#TBD B-033): a pending debounced value emit must be cancelled by any
+// fix(#524 B-033): a pending debounced value emit must be cancelled by any
 // immediate emit — otherwise the stale 200ms timer re-emits the pre-change
 // filter, overwrites the newer one, and (because lastEmittedFilterRef is set
 // to the stale value) the prop-sync effect never corrects the UI, so the

--- a/frontend/src/components/builder/__tests__/LayerFilterEditor.test.ts
+++ b/frontend/src/components/builder/__tests__/LayerFilterEditor.test.ts
@@ -611,3 +611,60 @@ describe('numeric in_list per-entry validation (fix(#394) FL-03)', () => {
     expect(result).toEqual(['all', ['!', ['in', ['get', 'population'], ['literal', [5]]]]]);
   });
 });
+
+// ---------------------------------------------------------------------------
+// fix(#TBD B-033): a pending debounced value emit must be cancelled by any
+// immediate emit — otherwise the stale 200ms timer re-emits the pre-change
+// filter, overwrites the newer one, and (because lastEmittedFilterRef is set
+// to the stale value) the prop-sync effect never corrects the UI, so the
+// wrong filter persists on Save.
+// ---------------------------------------------------------------------------
+describe('LayerFilterEditor - stale debounce cancellation (B-033)', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('removing a condition inside the debounce window is not clobbered by the pending value emit', () => {
+    const onFilterChange = vi.fn();
+    const existingFilter: FilterSpecification = [
+      'all',
+      ['==', ['get', 'name'], 'foo'],
+      ['==', ['get', 'name'], 'bar'],
+    ] as FilterSpecification;
+
+    render(createElement(LayerFilterEditor, {
+      columnInfo: columns,
+      filter: existingFilter,
+      onFilterChange,
+    }));
+
+    // Type into the FIRST condition's value input — arms the 200ms timer with
+    // a snapshot that still contains BOTH conditions. (fireEvent.change drives
+    // the controlled input through React onChange; a raw 'input' event does
+    // not update React state, which would leave the timer unarmed and the
+    // race unexercised.)
+    const valueInputs = screen.getAllByRole('textbox', { name: 'Value' });
+    act(() => {
+      fireEvent.change(valueInputs[0], { target: { value: 'typed' } });
+    });
+
+    // Remove the SECOND condition before the timer fires (immediate emit).
+    const removeButtons = screen.getAllByRole('button', { name: 'Remove condition' });
+    act(() => {
+      fireEvent.click(removeButtons[1]);
+    });
+
+    // Let any stale timer fire. Before the fix, it re-emitted the 2-condition
+    // snapshot, resurrecting the deleted condition as the LAST emitted filter.
+    act(() => {
+      vi.advanceTimersByTime(250);
+    });
+
+    const lastEmitted = onFilterChange.mock.calls.at(-1)?.[0] as unknown[];
+    expect(lastEmitted).toEqual(['all', ['==', ['get', 'name'], 'typed']]);
+  });
+});

--- a/frontend/src/components/builder/__tests__/cluster-source.test.ts
+++ b/frontend/src/components/builder/__tests__/cluster-source.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { getClusterSourceStrategy, shouldFetchClusterGeoJson, shouldUseServerClusterTiles } from '../cluster-source';
+import { getClusterSourceKey, getClusterSourceStrategy, shouldFetchClusterGeoJson, shouldUseServerClusterTiles } from '../cluster-source';
 
 const baseLayer = {
   dataset_geometry_type: 'POINT',
@@ -39,5 +39,31 @@ describe('cluster source strategy', () => {
       kind: 'fallback',
       status: 'not-point',
     });
+  });
+});
+
+// fix(#TBD B-035): the cluster fetch effect keys on this signature so that
+// paint/opacity/filter edits (new layers-array identity, same cluster set)
+// never re-trigger network GeoJSON fetches.
+describe('getClusterSourceKey', () => {
+  const clusterLayer = { ...baseLayer, id: 'l1', dataset_id: 'ds1', dataset_feature_count: 250 };
+
+  it('returns an empty key when no layer is in cluster render mode', () => {
+    const heatmap = { ...clusterLayer, style_config: { render_mode: 'heatmap' as const } };
+    expect(getClusterSourceKey([heatmap])).toBe('');
+  });
+
+  it('is stable across array/object identity changes that leave cluster inputs unchanged', () => {
+    const first = getClusterSourceKey([{ ...clusterLayer }]);
+    const second = getClusterSourceKey([{ ...clusterLayer }]);
+    expect(first).toBe(second);
+    expect(first).toContain('l1|ds1|bounded-geojson');
+  });
+
+  it('changes when membership, dataset, or resolved strategy change', () => {
+    const base = getClusterSourceKey([clusterLayer]);
+    expect(getClusterSourceKey([{ ...clusterLayer, dataset_id: 'ds2' }])).not.toBe(base);
+    expect(getClusterSourceKey([{ ...clusterLayer, dataset_feature_count: 50_000 }])).not.toBe(base);
+    expect(getClusterSourceKey([clusterLayer, { ...clusterLayer, id: 'l2' }])).not.toBe(base);
   });
 });

--- a/frontend/src/components/builder/__tests__/cluster-source.test.ts
+++ b/frontend/src/components/builder/__tests__/cluster-source.test.ts
@@ -42,7 +42,7 @@ describe('cluster source strategy', () => {
   });
 });
 
-// fix(#TBD B-035): the cluster fetch effect keys on this signature so that
+// fix(#524 B-035): the cluster fetch effect keys on this signature so that
 // paint/opacity/filter edits (new layers-array identity, same cluster set)
 // never re-trigger network GeoJSON fetches.
 describe('getClusterSourceKey', () => {

--- a/frontend/src/components/builder/cluster-source.ts
+++ b/frontend/src/components/builder/cluster-source.ts
@@ -120,6 +120,21 @@ export function shouldFetchClusterGeoJson(layer: ClusterSourceLayer) {
   return getClusterSourceStrategy(layer).kind === 'bounded-geojson';
 }
 
+// fix(#TBD B-035): structural identity key for the cluster-source fetch effect.
+// Folds in only the fields that change WHICH GeoJSON gets fetched (cluster
+// membership, dataset, resolved strategy). Paint/opacity/filter edits replace
+// the layers array identity on every tick; keying the fetch effect on this
+// string instead of the array keeps those edits from re-issuing network
+// fetches for bounded-geojson cluster layers.
+export function getClusterSourceKey(
+  layers: Array<ClusterSourceLayer & { id?: string; dataset_id?: string | null }>,
+): string {
+  return layers
+    .filter((layer) => isClusterRenderMode(layer))
+    .map((layer) => `${layer.id ?? ''}|${layer.dataset_id ?? ''}|${getClusterSourceStrategy(layer).kind}`)
+    .join(',');
+}
+
 export function clusterFallbackMessage(status: ClusterSourceStatus) {
   switch (status) {
     case 'missing-count':

--- a/frontend/src/components/builder/cluster-source.ts
+++ b/frontend/src/components/builder/cluster-source.ts
@@ -120,7 +120,7 @@ export function shouldFetchClusterGeoJson(layer: ClusterSourceLayer) {
   return getClusterSourceStrategy(layer).kind === 'bounded-geojson';
 }
 
-// fix(#TBD B-035): structural identity key for the cluster-source fetch effect.
+// fix(#524 B-035): structural identity key for the cluster-source fetch effect.
 // Folds in only the fields that change WHICH GeoJSON gets fetched (cluster
 // membership, dataset, resolved strategy). Paint/opacity/filter edits replace
 // the layers array identity on every tick; keying the fetch effect on this


### PR DESCRIPTION
Remediates the four HIGH findings from the 2026-07-15 builder audit (internal report: `docs-internal/audits/builder-audit-20260715.md`).

## Changes

**B-033 — filter debounce race (`LayerFilterEditor.tsx`)**
A pending 200 ms debounced value emit was never cancelled by immediate emits. Toggling All/Any or removing a condition within the window let the stale timer re-emit the pre-change filter, overwrite the newer one, and set `lastEmittedFilterRef` to the stale value so the prop-sync effect never corrected the UI — the wrong filter then persisted on Save. Both immediate-emit paths now clear the timer first.

**B-034 — layer-editor tabs were mouse-only (`LayerEditorPanel.tsx`)**
The tab strip is a roving-tabindex tablist (inactive tabs `tabIndex=-1`) with no arrow-key handler, so keyboard-only users had no path to the Filter/Labels/Popup editors. Added ArrowLeft/ArrowRight (wrapping) + Home/End roving navigation per the WAI-ARIA tabs pattern; selection follows focus.

**B-035 — cluster GeoJSON refetch storm (`BuilderMap.tsx`, `cluster-source.ts`)**
The cluster-source fetch effect was keyed on the `layers` array, whose identity changes on every paint/opacity/filter edit tick (~10 Hz during a slider drag), re-issuing a network GeoJSON fetch per bounded-geojson cluster layer on each tick. The effect is now keyed on a structural signature (`getClusterSourceKey`: membership | dataset | resolved strategy) and reads layers through the existing ref.

**B-036 — builder-hardening gate red on main and invisible (`e2e/builder-hardening.spec.ts`, `ci.yml`)**
The large-stack save-and-reload test failed deterministically on status-0 `AJAXError: Failed to fetch (0)` console noise — network-level aborts of in-flight raster tile fetches during reload/teardown, surfaced once by MapLibre as errors and once by BuilderMap's DEV handler as warnings. Both gate halves now allowlist exactly that signature (real tile failures carry an HTTP status and still fail). The chromium hardening suite is also wired into the nightly e2e CI job — it previously ran in **no** CI trigger, so the red gate was undetectable.

## Verification

- `cd frontend && npx vitest run src/components/builder src/components/viewer` — **1892/1892** (7 new regression tests; the B-033 test was verified to fail with the fix reverted)
- `npm run lint` / `npm run typecheck` — clean
- `npx playwright test -c playwright.builder-hardening.config.ts --project=chromium-hardening` — **8/8** (was 7/8 red on main)
- `npm run e2e:smoke:builder` — **27/27**
- Live browser smoke (Restless Earth, discarded via the unsaved-changes guard): arrow/Home/End tab navigation works with focus following; typed `mag >= 6` then immediately toggled All→Any — emitted filter is `["any", [">=", ...], 6]` with the typed value intact; cluster mode switch issued exactly **one** `features.geojson` fetch and 9 subsequent opacity/radius edit ticks issued **zero** additional fetches; cluster bubbles render; zero console errors/warnings.

## Impact

Frontend-only plus one e2e gate and one CI job addition. No schema, API, or config changes. Remaining audit P1s (B-037..B-040) will follow separately.