### PR TITLE
fix(builder): remediate builder-audit 2026-07-15 P1 findings (B-037..B-040)

### DIFF
--- a/backend/alembic/versions/0025_dataset_tile_cache_version.py
+++ b/backend/alembic/versions/0025_dataset_tile_cache_version.py
@@ -1,0 +1,44 @@
+"""Add datasets.tile_cache_version — URL-keyed tile cache-buster.
+
+`Dataset.current_version` is coupled to DatasetVersion history rows and is
+bumped on reupload only, yet it fed `MapLayerResponse.tile_version` (the
+frontend's `_v=` tile-URL parameter). Content mutations that don't create a
+version — single-feature edits, column DDL, tile_columns changes — purged the
+Valkey tile cache but left the tile URL unchanged, so CDN/browser/nginx caches
+kept serving stale tiles until max-age expiry (builder-audit 2026-07-15 T-01).
+
+This dedicated counter is bumped by every tile-content mutation (including
+reupload) and now feeds tile_version, leaving current_version's version-history
+semantics untouched.
+
+Revision ID: 0025_dataset_tile_cache_version
+Revises: 0024_tenant_provisioning_reentry
+Create Date: 2026-07-15
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0025_dataset_tile_cache_version"
+down_revision: Union[str, None] = "0024_tenant_provisioning_reentry"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "datasets",
+        sa.Column(
+            "tile_cache_version",
+            sa.Integer(),
+            server_default="1",
+            nullable=False,
+        ),
+        schema="catalog",
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("datasets", "tile_cache_version", schema="catalog")

--- a/backend/app/core/processing_port.py
+++ b/backend/app/core/processing_port.py
@@ -99,6 +99,7 @@ class DatasetProtocol(Protocol):
     quality_detail: dict | None
     quality_statement: str | None
     current_version: int
+    tile_cache_version: int
     is_3d: bool | None
     record: RecordProtocol
     attributes: Sequence[AttributeProtocol]

--- a/backend/app/modules/catalog/datasets/api/router.py
+++ b/backend/app/modules/catalog/datasets/api/router.py
@@ -327,7 +327,7 @@ async def update_dataset_metadata(
             ip_address=request.client.host if request.client else None,
         ),
     )
-    # fix(#TBD B-038): a tile_columns change alters the attribute set embedded
+    # fix(#525 B-038): a tile_columns change alters the attribute set embedded
     # in vector tiles — roll the _v= URL cache-buster in the same transaction
     # (the post-commit Valkey purge cannot reach CDN/browser caches).
     if "tile_columns" in meta.model_fields_set:

--- a/backend/app/modules/catalog/datasets/api/router.py
+++ b/backend/app/modules/catalog/datasets/api/router.py
@@ -327,6 +327,11 @@ async def update_dataset_metadata(
             ip_address=request.client.host if request.client else None,
         ),
     )
+    # fix(#TBD B-038): a tile_columns change alters the attribute set embedded
+    # in vector tiles — roll the _v= URL cache-buster in the same transaction
+    # (the post-commit Valkey purge cannot reach CDN/browser caches).
+    if "tile_columns" in meta.model_fields_set:
+        dataset.bump_tile_cache_version()
     await db.commit()
     await db.refresh(dataset)
     await db.refresh(dataset.record)

--- a/backend/app/modules/catalog/datasets/domain/models.py
+++ b/backend/app/modules/catalog/datasets/domain/models.py
@@ -423,7 +423,7 @@ class Dataset(Base):
     # Version tracking
     current_version: Mapped[int] = mapped_column(Integer, server_default="1", default=1)
 
-    # fix(#TBD B-038): URL-keyed tile cache-buster. current_version is coupled
+    # fix(#525 B-038): URL-keyed tile cache-buster. current_version is coupled
     # to DatasetVersion history rows (bumped on reupload only), so content
     # mutations that don't create a version — single-feature edits, column DDL,
     # tile_columns changes — bump this counter instead. It feeds
@@ -465,7 +465,7 @@ class Dataset(Base):
         Call in the same transaction as any change to the dataset's tile
         content (feature edits, column DDL, tile_columns, reupload) — the
         post-commit Valkey purge cannot reach CDN/browser caches keyed on the
-        tile URL. fix(#TBD B-038)
+        tile URL. fix(#525 B-038)
         """
         self.tile_cache_version = (self.tile_cache_version or 1) + 1
 

--- a/backend/app/modules/catalog/datasets/domain/models.py
+++ b/backend/app/modules/catalog/datasets/domain/models.py
@@ -423,6 +423,17 @@ class Dataset(Base):
     # Version tracking
     current_version: Mapped[int] = mapped_column(Integer, server_default="1", default=1)
 
+    # fix(#TBD B-038): URL-keyed tile cache-buster. current_version is coupled
+    # to DatasetVersion history rows (bumped on reupload only), so content
+    # mutations that don't create a version — single-feature edits, column DDL,
+    # tile_columns changes — bump this counter instead. It feeds
+    # MapLayerResponse.tile_version and the frontend's `_v=` tile-URL param, so
+    # CDN/browser/nginx caches keyed on the URL roll over immediately (the
+    # Valkey purge alone cannot reach them).
+    tile_cache_version: Mapped[int] = mapped_column(
+        Integer, server_default="1", default=1
+    )
+
     # Per-dataset tile cache TTL override (null = use global settings.tile_cache_ttl)
     tile_cache_ttl: Mapped[int | None] = mapped_column(Integer, nullable=True)
 
@@ -447,6 +458,16 @@ class Dataset(Base):
         passive_deletes=True,
         lazy="select",
     )
+
+    def bump_tile_cache_version(self) -> None:
+        """Roll the `_v=` tile-URL cache-buster after a tile-content mutation.
+
+        Call in the same transaction as any change to the dataset's tile
+        content (feature edits, column DDL, tile_columns, reupload) — the
+        post-commit Valkey purge cannot reach CDN/browser caches keyed on the
+        tile URL. fix(#TBD B-038)
+        """
+        self.tile_cache_version = (self.tile_cache_version or 1) + 1
 
 
 class RecordContact(Base):

--- a/backend/app/modules/catalog/features/router.py
+++ b/backend/app/modules/catalog/features/router.py
@@ -536,6 +536,9 @@ async def create_feature(
             },
         ),
     )
+    # fix(#TBD B-038): roll the _v= URL cache-buster in the same transaction —
+    # the post-commit Valkey purge cannot reach CDN/browser caches keyed on the URL.
+    dataset.bump_tile_cache_version()
     await db.commit()
 
     # Invalidate cached tiles so the new feature appears immediately
@@ -634,6 +637,8 @@ async def replace_single_feature(
             },
         ),
     )
+    # fix(#TBD B-038): roll the _v= URL cache-buster (see feature.insert above).
+    dataset.bump_tile_cache_version()
     await db.commit()
 
     # Invalidate cached tiles so the replaced feature renders correctly
@@ -727,6 +732,8 @@ async def patch_single_feature(
             },
         ),
     )
+    # fix(#TBD B-038): roll the _v= URL cache-buster (see feature.insert above).
+    dataset.bump_tile_cache_version()
     await db.commit()
 
     # Invalidate cached tiles so the updated feature renders correctly
@@ -796,6 +803,8 @@ async def delete_single_feature(
             details={"gid": gid},
         ),
     )
+    # fix(#TBD B-038): roll the _v= URL cache-buster (see feature.insert above).
+    dataset.bump_tile_cache_version()
     await db.commit()
 
     # Invalidate cached tiles so the deleted feature disappears immediately

--- a/backend/app/modules/catalog/features/router.py
+++ b/backend/app/modules/catalog/features/router.py
@@ -536,7 +536,7 @@ async def create_feature(
             },
         ),
     )
-    # fix(#TBD B-038): roll the _v= URL cache-buster in the same transaction —
+    # fix(#525 B-038): roll the _v= URL cache-buster in the same transaction —
     # the post-commit Valkey purge cannot reach CDN/browser caches keyed on the URL.
     dataset.bump_tile_cache_version()
     await db.commit()
@@ -637,7 +637,7 @@ async def replace_single_feature(
             },
         ),
     )
-    # fix(#TBD B-038): roll the _v= URL cache-buster (see feature.insert above).
+    # fix(#525 B-038): roll the _v= URL cache-buster (see feature.insert above).
     dataset.bump_tile_cache_version()
     await db.commit()
 
@@ -732,7 +732,7 @@ async def patch_single_feature(
             },
         ),
     )
-    # fix(#TBD B-038): roll the _v= URL cache-buster (see feature.insert above).
+    # fix(#525 B-038): roll the _v= URL cache-buster (see feature.insert above).
     dataset.bump_tile_cache_version()
     await db.commit()
 
@@ -803,7 +803,7 @@ async def delete_single_feature(
             details={"gid": gid},
         ),
     )
-    # fix(#TBD B-038): roll the _v= URL cache-buster (see feature.insert above).
+    # fix(#525 B-038): roll the _v= URL cache-buster (see feature.insert above).
     dataset.bump_tile_cache_version()
     await db.commit()
 

--- a/backend/app/modules/catalog/layers/router.py
+++ b/backend/app/modules/catalog/layers/router.py
@@ -181,7 +181,7 @@ async def add_column_endpoint(
             },
         ),
     )
-    # fix(#TBD B-038): roll the _v= URL cache-buster in the same transaction —
+    # fix(#525 B-038): roll the _v= URL cache-buster in the same transaction —
     # the post-commit Valkey purge cannot reach CDN/browser caches keyed on the URL.
     dataset.bump_tile_cache_version()
     await db.commit()
@@ -240,7 +240,7 @@ async def rename_column_endpoint(
             details={"old_name": column_name, "new_name": body.new_name},
         ),
     )
-    # fix(#TBD B-038): roll the _v= URL cache-buster in the same transaction —
+    # fix(#525 B-038): roll the _v= URL cache-buster in the same transaction —
     # the post-commit Valkey purge cannot reach CDN/browser caches keyed on the URL.
     dataset.bump_tile_cache_version()
     await db.commit()
@@ -308,7 +308,7 @@ async def alter_column_type_endpoint(
             details={"column_name": column_name, "new_type": body.new_type},
         ),
     )
-    # fix(#TBD B-038): roll the _v= URL cache-buster in the same transaction —
+    # fix(#525 B-038): roll the _v= URL cache-buster in the same transaction —
     # the post-commit Valkey purge cannot reach CDN/browser caches keyed on the URL.
     dataset.bump_tile_cache_version()
     await db.commit()
@@ -364,7 +364,7 @@ async def drop_column_endpoint(
             details={"column_name": column_name},
         ),
     )
-    # fix(#TBD B-038): roll the _v= URL cache-buster in the same transaction —
+    # fix(#525 B-038): roll the _v= URL cache-buster in the same transaction —
     # the post-commit Valkey purge cannot reach CDN/browser caches keyed on the URL.
     dataset.bump_tile_cache_version()
     await db.commit()

--- a/backend/app/modules/catalog/layers/router.py
+++ b/backend/app/modules/catalog/layers/router.py
@@ -181,6 +181,9 @@ async def add_column_endpoint(
             },
         ),
     )
+    # fix(#TBD B-038): roll the _v= URL cache-buster in the same transaction —
+    # the post-commit Valkey purge cannot reach CDN/browser caches keyed on the URL.
+    dataset.bump_tile_cache_version()
     await db.commit()
     await _invalidate_tiles(dataset.table_name)
 
@@ -237,6 +240,9 @@ async def rename_column_endpoint(
             details={"old_name": column_name, "new_name": body.new_name},
         ),
     )
+    # fix(#TBD B-038): roll the _v= URL cache-buster in the same transaction —
+    # the post-commit Valkey purge cannot reach CDN/browser caches keyed on the URL.
+    dataset.bump_tile_cache_version()
     await db.commit()
     await _invalidate_tiles(dataset.table_name)
     return ColumnListResponse(columns=columns)
@@ -302,6 +308,9 @@ async def alter_column_type_endpoint(
             details={"column_name": column_name, "new_type": body.new_type},
         ),
     )
+    # fix(#TBD B-038): roll the _v= URL cache-buster in the same transaction —
+    # the post-commit Valkey purge cannot reach CDN/browser caches keyed on the URL.
+    dataset.bump_tile_cache_version()
     await db.commit()
     await _invalidate_tiles(dataset.table_name)
     return ColumnListResponse(columns=columns)
@@ -355,6 +364,9 @@ async def drop_column_endpoint(
             details={"column_name": column_name},
         ),
     )
+    # fix(#TBD B-038): roll the _v= URL cache-buster in the same transaction —
+    # the post-commit Valkey purge cannot reach CDN/browser caches keyed on the URL.
+    dataset.bump_tile_cache_version()
     await db.commit()
     await _invalidate_tiles(dataset.table_name)
 

--- a/backend/app/modules/catalog/maps/schemas.py
+++ b/backend/app/modules/catalog/maps/schemas.py
@@ -932,7 +932,7 @@ class MapLayerResponse(BaseModel):
     band_count: int | None = None
     # fix(#394) VT-02: dataset content version. Feeds the client `_v=` tile-URL
     # cache-buster (map-sync.ts); the server-side Valkey purge is B-019.
-    # fix(#TBD B-038): now reads Dataset.tile_cache_version (bumped by feature
+    # fix(#525 B-038): now reads Dataset.tile_cache_version (bumped by feature
     # edits, column DDL, tile_columns changes, AND reupload) instead of
     # current_version (reupload-only), so every content mutation rolls the URL.
     tile_version: int | None = None

--- a/backend/app/modules/catalog/maps/schemas.py
+++ b/backend/app/modules/catalog/maps/schemas.py
@@ -930,9 +930,11 @@ class MapLayerResponse(BaseModel):
     is_dem: bool | None = None
     dem_vertical_units: str | None = None
     band_count: int | None = None
-    # fix(#394) VT-02: dataset content version (Dataset.current_version). Feeds
-    # the client `_v=` tile-URL cache-buster (map-sync.ts) so a reupload busts
-    # browser/CDN caches; the server-side Valkey purge is B-019.
+    # fix(#394) VT-02: dataset content version. Feeds the client `_v=` tile-URL
+    # cache-buster (map-sync.ts); the server-side Valkey purge is B-019.
+    # fix(#TBD B-038): now reads Dataset.tile_cache_version (bumped by feature
+    # edits, column DDL, tile_columns changes, AND reupload) instead of
+    # current_version (reupload-only), so every content mutation rolls the URL.
     tile_version: int | None = None
     # fix(#430 V-17): dataset visibility/status so the builder can badge a layer whose
     # dataset is hidden from a public/shared map's anonymous audience.

--- a/backend/app/modules/catalog/maps/service_public.py
+++ b/backend/app/modules/catalog/maps/service_public.py
@@ -365,7 +365,7 @@ async def get_shared_map(
             Dataset.feature_count,
             RasterAsset.is_dem,
             RasterAsset.band_info,
-            # fix(#TBD B-038): tile_version reads the dedicated URL cache-buster —
+            # fix(#525 B-038): tile_version reads the dedicated URL cache-buster —
             # current_version only changes on reupload, so feature edits and
             # column DDL never rolled the _v= param (stale CDN/browser tiles).
             Dataset.tile_cache_version,

--- a/backend/app/modules/catalog/maps/service_public.py
+++ b/backend/app/modules/catalog/maps/service_public.py
@@ -365,7 +365,10 @@ async def get_shared_map(
             Dataset.feature_count,
             RasterAsset.is_dem,
             RasterAsset.band_info,
-            Dataset.current_version,
+            # fix(#TBD B-038): tile_version reads the dedicated URL cache-buster —
+            # current_version only changes on reupload, so feature edits and
+            # column DDL never rolled the _v= param (stale CDN/browser tiles).
+            Dataset.tile_cache_version,
         )
         .join(Map, Map.id == MapLayer.map_id)
         .join(Dataset, MapLayer.dataset_id == Dataset.id)

--- a/backend/app/modules/catalog/maps/service_shared.py
+++ b/backend/app/modules/catalog/maps/service_shared.py
@@ -106,7 +106,7 @@ async def get_dataset_meta(
             RasterAsset.is_dem,
             RasterAsset.band_info,
             RasterAsset.band_count,
-            # fix(#TBD B-038): tile_version reads the dedicated URL cache-buster —
+            # fix(#525 B-038): tile_version reads the dedicated URL cache-buster —
             # current_version only changes on reupload, so feature edits and
             # column DDL never rolled the _v= param (stale CDN/browser tiles).
             Dataset.tile_cache_version,
@@ -238,7 +238,7 @@ async def _fetch_layer_rows_ordered(
             RasterAsset.is_dem,
             RasterAsset.band_info,
             RasterAsset.band_count,
-            # fix(#TBD B-038): tile_version reads the dedicated URL cache-buster —
+            # fix(#525 B-038): tile_version reads the dedicated URL cache-buster —
             # current_version only changes on reupload, so feature edits and
             # column DDL never rolled the _v= param (stale CDN/browser tiles).
             Dataset.tile_cache_version,

--- a/backend/app/modules/catalog/maps/service_shared.py
+++ b/backend/app/modules/catalog/maps/service_shared.py
@@ -106,7 +106,10 @@ async def get_dataset_meta(
             RasterAsset.is_dem,
             RasterAsset.band_info,
             RasterAsset.band_count,
-            Dataset.current_version,
+            # fix(#TBD B-038): tile_version reads the dedicated URL cache-buster —
+            # current_version only changes on reupload, so feature edits and
+            # column DDL never rolled the _v= param (stale CDN/browser tiles).
+            Dataset.tile_cache_version,
             Record.visibility,
             Record.record_status,
         )
@@ -235,7 +238,10 @@ async def _fetch_layer_rows_ordered(
             RasterAsset.is_dem,
             RasterAsset.band_info,
             RasterAsset.band_count,
-            Dataset.current_version,
+            # fix(#TBD B-038): tile_version reads the dedicated URL cache-buster —
+            # current_version only changes on reupload, so feature edits and
+            # column DDL never rolled the _v= param (stale CDN/browser tiles).
+            Dataset.tile_cache_version,
             Record.visibility,
             Record.record_status,
         )

--- a/backend/app/processing/ai/chat_actions.py
+++ b/backend/app/processing/ai/chat_actions.py
@@ -375,7 +375,7 @@ def _collect_chat_action(tool_name: str, tool_input: dict, result: dict) -> dict
         except (json.JSONDecodeError, ValueError):
             pass
 
-    # fix(#TBD B-037): clamp opacity server-side, matching the paint-clamping
+    # fix(#525 B-037): clamp opacity server-side, matching the paint-clamping
     # precedent (_PAINT_BOUNDS in set_style). Models emit percent values
     # (opacity: 50), which previously failed ChatAction's ge=0/le=1 validation
     # downstream instead of applying at all.

--- a/backend/app/processing/ai/chat_actions.py
+++ b/backend/app/processing/ai/chat_actions.py
@@ -375,4 +375,16 @@ def _collect_chat_action(tool_name: str, tool_input: dict, result: dict) -> dict
         except (json.JSONDecodeError, ValueError):
             pass
 
+    # fix(#TBD B-037): clamp opacity server-side, matching the paint-clamping
+    # precedent (_PAINT_BOUNDS in set_style). Models emit percent values
+    # (opacity: 50), which previously failed ChatAction's ge=0/le=1 validation
+    # downstream instead of applying at all.
+    if tool_name == "set_opacity":
+        raw_opacity = tool_input.get("opacity")
+        if isinstance(raw_opacity, (int, float)) and not isinstance(raw_opacity, bool):
+            tool_input = {
+                **tool_input,
+                "opacity": min(1.0, max(0.0, float(raw_opacity))),
+            }
+
     return {"type": tool_name, **tool_input}

--- a/backend/app/processing/ai/chat_service.py
+++ b/backend/app/processing/ai/chat_service.py
@@ -423,7 +423,7 @@ async def chat_edit_map(
     )
 
     # Parse actions into ChatAction models (per-item; invalid ones drop with a
-    # note instead of failing the whole turn — fix(#TBD B-037))
+    # note instead of failing the whole turn — fix(#525 B-037))
     actions, invalid = _build_chat_actions(result.actions)
 
     # Validate layer_id references + add_layer dataset RBAC

--- a/backend/app/processing/ai/chat_service.py
+++ b/backend/app/processing/ai/chat_service.py
@@ -69,13 +69,13 @@ from app.processing.ai.chat_styles import (
     _get_color_property,
 )
 from app.processing.ai.chat_validation import (
+    _build_chat_actions,
     _extract_get_refs,
     _validate_actions,
     _validate_filter_columns,
 )
 from app.processing.ai.llm_loop import resolve_provider
 from app.processing.ai.schemas import (
-    ChatAction,
     ChatHistoryMessage,
     ChatMapLayer,
     ChatResponse,
@@ -105,6 +105,7 @@ __all__ = [
     "_handle_query_data",
     "_collect_chat_action",
     # Validation (used by streaming.py)
+    "_build_chat_actions",
     "_validate_actions",
     "_validate_filter_columns",
     "_extract_get_refs",
@@ -421,13 +422,15 @@ async def chat_edit_map(
         output_tokens=result.output_tokens,
     )
 
-    # Parse actions into ChatAction models
-    actions = [ChatAction(**a) for a in result.actions]
+    # Parse actions into ChatAction models (per-item; invalid ones drop with a
+    # note instead of failing the whole turn — fix(#TBD B-037))
+    actions, invalid = _build_chat_actions(result.actions)
 
     # Validate layer_id references + add_layer dataset RBAC
     actions, dropped = await _validate_actions(
         actions, layers, session=session, user=user, port=port
     )
+    dropped = invalid + dropped
 
     explanation = result.text
     if dropped:

--- a/backend/app/processing/ai/chat_validation.py
+++ b/backend/app/processing/ai/chat_validation.py
@@ -22,7 +22,7 @@ logger = structlog.stdlib.get_logger(__name__)
 def _build_chat_actions(raw_actions: list[dict]) -> tuple[list[ChatAction], list[str]]:
     """Build ChatAction models per-item, dropping invalid ones with a note.
 
-    fix(#TBD B-037): the previous ``[ChatAction(**a) for a in raw_actions]``
+    fix(#525 B-037): the previous ``[ChatAction(**a) for a in raw_actions]``
     list comprehension let ONE Pydantic-invalid action (e.g. ``opacity: 50``)
     raise through the caller's broad except — a single generic error event and
     every valid action in the turn discarded. Malformed LLM output must degrade

--- a/backend/app/processing/ai/chat_validation.py
+++ b/backend/app/processing/ai/chat_validation.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING
 from uuid import UUID
 
 import structlog
+from pydantic import ValidationError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.identity import Identity
@@ -16,6 +17,30 @@ if TYPE_CHECKING:
     from app.core.processing_port import ProcessingPort
 
 logger = structlog.stdlib.get_logger(__name__)
+
+
+def _build_chat_actions(raw_actions: list[dict]) -> tuple[list[ChatAction], list[str]]:
+    """Build ChatAction models per-item, dropping invalid ones with a note.
+
+    fix(#TBD B-037): the previous ``[ChatAction(**a) for a in raw_actions]``
+    list comprehension let ONE Pydantic-invalid action (e.g. ``opacity: 50``)
+    raise through the caller's broad except — a single generic error event and
+    every valid action in the turn discarded. Malformed LLM output must degrade
+    per-action, mirroring _validate_actions' dropped[] pattern.
+    """
+    actions: list[ChatAction] = []
+    dropped: list[str] = []
+    for raw in raw_actions:
+        try:
+            actions.append(ChatAction(**raw))
+        except (ValidationError, TypeError):
+            action_type = raw.get("type") if isinstance(raw, dict) else None
+            logger.warning(
+                "Invalid chat action payload, skipping",
+                action_type=action_type,
+            )
+            dropped.append(f"{action_type or 'unknown'} (invalid action payload)")
+    return actions, dropped
 
 
 def _extract_get_refs(expr: list | None) -> set[str]:

--- a/backend/app/processing/ai/streaming.py
+++ b/backend/app/processing/ai/streaming.py
@@ -379,7 +379,7 @@ async def _stream_anthropic_chat(
 
     # Validate actions before yielding (mirrors non-streaming path).
     # Per-item build: one invalid action drops with a note instead of raising
-    # through the broad except and discarding the whole turn (fix(#TBD B-037)).
+    # through the broad except and discarding the whole turn (fix(#525 B-037)).
     actions, invalid = _build_chat_actions(collected_actions)
     actions, dropped = await _validate_actions(
         actions, layers, session=session, user=user, port=port
@@ -703,7 +703,7 @@ async def _stream_openai_chat(
 
     # Validate actions before yielding (mirrors non-streaming path).
     # Per-item build: one invalid action drops with a note instead of raising
-    # through the broad except and discarding the whole turn (fix(#TBD B-037)).
+    # through the broad except and discarding the whole turn (fix(#525 B-037)).
     actions, invalid = _build_chat_actions(collected_actions)
     actions, dropped = await _validate_actions(
         actions, layers, session=session, user=user, port=port

--- a/backend/app/processing/ai/streaming.py
+++ b/backend/app/processing/ai/streaming.py
@@ -12,6 +12,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.core.persistent_config import MAX_AI_TOKENS_PER_USER_PER_DAY
 
 from app.processing.ai.chat_service import (
+    _build_chat_actions,
     _collect_chat_action,
     _execute_chat_tool,
     _validate_actions,
@@ -29,7 +30,7 @@ from app.processing.ai.llm_loop import (
     build_history_messages,
     resolve_provider,
 )
-from app.processing.ai.schemas import ChatAction, ChatHistoryMessage, history_to_dicts
+from app.processing.ai.schemas import ChatHistoryMessage, history_to_dicts
 from app.processing.ai.token_usage import AITokenUsage, record_token_usage
 from app.processing.ai.tools import CHAT_TOOLS_ANTHROPIC, select_chat_tools
 from typing import TYPE_CHECKING
@@ -376,11 +377,14 @@ async def _stream_anthropic_chat(
         block.text for block in final_message.content if block.type == "text"
     )
 
-    # Validate actions before yielding (mirrors non-streaming path)
-    actions = [ChatAction(**a) for a in collected_actions]
+    # Validate actions before yielding (mirrors non-streaming path).
+    # Per-item build: one invalid action drops with a note instead of raising
+    # through the broad except and discarding the whole turn (fix(#TBD B-037)).
+    actions, invalid = _build_chat_actions(collected_actions)
     actions, dropped = await _validate_actions(
         actions, layers, session=session, user=user, port=port
     )
+    dropped = invalid + dropped
     if dropped:
         explanation += "\n\nNote: some actions were skipped: " + "; ".join(dropped)
 
@@ -697,11 +701,14 @@ async def _stream_openai_chat(
     # end-of-stream record here — that would double-count and be skipped on
     # disconnect.
 
-    # Validate actions before yielding (mirrors non-streaming path)
-    actions = [ChatAction(**a) for a in collected_actions]
+    # Validate actions before yielding (mirrors non-streaming path).
+    # Per-item build: one invalid action drops with a note instead of raising
+    # through the broad except and discarding the whole turn (fix(#TBD B-037)).
+    actions, invalid = _build_chat_actions(collected_actions)
     actions, dropped = await _validate_actions(
         actions, layers, session=session, user=user, port=port
     )
+    dropped = invalid + dropped
     explanation_text = "".join(content_parts)
     if dropped:
         explanation_text += "\n\nNote: some actions were skipped: " + "; ".join(dropped)

--- a/backend/app/processing/ingest/tasks_common.py
+++ b/backend/app/processing/ingest/tasks_common.py
@@ -1480,7 +1480,7 @@ async def _apply_reupload_swap(
     dataset.source_filename = source_filename
     dataset.original_srid = original_srid
     dataset.current_version = new_version
-    # fix(#TBD B-038): tile_version now reads tile_cache_version (not
+    # fix(#525 B-038): tile_version now reads tile_cache_version (not
     # current_version), so reupload must roll it too or the _v= tile-URL
     # cache-buster stops changing on the largest content mutation of all.
     dataset.bump_tile_cache_version()

--- a/backend/app/processing/ingest/tasks_common.py
+++ b/backend/app/processing/ingest/tasks_common.py
@@ -1480,6 +1480,10 @@ async def _apply_reupload_swap(
     dataset.source_filename = source_filename
     dataset.original_srid = original_srid
     dataset.current_version = new_version
+    # fix(#TBD B-038): tile_version now reads tile_cache_version (not
+    # current_version), so reupload must roll it too or the _v= tile-URL
+    # cache-buster stops changing on the largest content mutation of all.
+    dataset.bump_tile_cache_version()
     dataset.record.updated_by = actor_id
     if source_url is not None:
         dataset.source_url = source_url

--- a/backend/tests/test_collect_chat_action.py
+++ b/backend/tests/test_collect_chat_action.py
@@ -282,3 +282,59 @@ def test_set_label_halo_contrasts_text_color() -> None:
     # Dark text (incl. the #333333 default) -> light halo, preserving prior contrast.
     for dark in (None, "#333333", "#000000", "#102040", "navy"):
         assert halo(dark) == "#ffffff", dark
+
+
+# ---------------------------------------------------------------------------
+# fix(#TBD B-037): set_opacity server-side clamp + per-item action building
+# ---------------------------------------------------------------------------
+
+
+def test_set_opacity_clamps_out_of_range_values() -> None:
+    """Models emit percent opacity (e.g. 50); the collector must clamp into
+    [0,1] (matching the set_style paint-clamping precedent) instead of letting
+    ChatAction's ge/le validation reject the action downstream."""
+    over = _collect_chat_action(
+        "set_opacity", {"layer_id": "l1", "opacity": 50}, {"status": "ok"}
+    )
+    assert over == {"type": "set_opacity", "layer_id": "l1", "opacity": 1.0}
+
+    under = _collect_chat_action(
+        "set_opacity", {"layer_id": "l1", "opacity": -0.5}, {"status": "ok"}
+    )
+    assert under is not None and under["opacity"] == 0.0
+
+    in_range = _collect_chat_action(
+        "set_opacity", {"layer_id": "l1", "opacity": 0.5}, {"status": "ok"}
+    )
+    assert in_range is not None and in_range["opacity"] == 0.5
+
+    # Non-numeric junk passes through untouched — _build_chat_actions drops it
+    # per-item rather than the whole turn failing.
+    junk = _collect_chat_action(
+        "set_opacity", {"layer_id": "l1", "opacity": "half"}, {"status": "ok"}
+    )
+    assert junk is not None and junk["opacity"] == "half"
+
+
+def test_build_chat_actions_drops_invalid_items_per_action() -> None:
+    """fix(#TBD B-037): one Pydantic-invalid action must drop with a note —
+    the previous ``[ChatAction(**a) for a in actions]`` raised through the
+    caller's broad except, discarding every valid action in the turn."""
+    from app.processing.ai.chat_validation import _build_chat_actions
+
+    raw = [
+        {"type": "set_opacity", "layer_id": "l1", "opacity": 0.5},
+        {"type": "set_opacity", "layer_id": "l2", "opacity": "not-a-number"},
+        {"type": "toggle_visibility", "layer_id": "l3", "visible": True},
+    ]
+    actions, dropped = _build_chat_actions(raw)
+    assert [(a.type, a.layer_id) for a in actions] == [
+        ("set_opacity", "l1"),
+        ("toggle_visibility", "l3"),
+    ]
+    assert dropped == ["set_opacity (invalid action payload)"]
+
+    # Every item invalid -> empty actions, all noted, no exception.
+    actions, dropped = _build_chat_actions([{"type": "no-such-type"}])
+    assert actions == []
+    assert dropped == ["no-such-type (invalid action payload)"]

--- a/backend/tests/test_collect_chat_action.py
+++ b/backend/tests/test_collect_chat_action.py
@@ -285,7 +285,7 @@ def test_set_label_halo_contrasts_text_color() -> None:
 
 
 # ---------------------------------------------------------------------------
-# fix(#TBD B-037): set_opacity server-side clamp + per-item action building
+# fix(#525 B-037): set_opacity server-side clamp + per-item action building
 # ---------------------------------------------------------------------------
 
 
@@ -317,7 +317,7 @@ def test_set_opacity_clamps_out_of_range_values() -> None:
 
 
 def test_build_chat_actions_drops_invalid_items_per_action() -> None:
-    """fix(#TBD B-037): one Pydantic-invalid action must drop with a note —
+    """fix(#525 B-037): one Pydantic-invalid action must drop with a note —
     the previous ``[ChatAction(**a) for a in actions]`` raised through the
     caller's broad except, discarding every valid action in the turn."""
     from app.processing.ai.chat_validation import _build_chat_actions

--- a/backend/tests/test_email_verification_migration.py
+++ b/backend/tests/test_email_verification_migration.py
@@ -136,11 +136,16 @@ async def _fresh_query(query: str, params: dict | None = None):
 
 @_SKIP_UNDER_OVERLAY
 class TestMigrationRoundTripExitCodes:
-    """0009_email_verification round-trips with no subprocess errors.
+    """The migration chain round-trips with no subprocess errors.
 
-    Downgrade is a NO-OP (passes immediately) per the 0008_oauth_saml_columns
-    precedent — so downgrade exit 0 + re-upgrade exit 0 are both guaranteed once
-    upgrade head succeeds.
+    NOTE: ``downgrade -1`` reverts the CURRENT head, not 0009 — the original
+    "downgrade is a NO-OP" premise went stale as new heads landed. The
+    downgrade test therefore restores head in a ``finally``: under xdist the
+    reupgrade test can be scheduled onto a DIFFERENT worker (own database), so
+    without the in-test restore this worker's DB stays one revision behind for
+    every later test — with a destructive head downgrade (e.g. 0025 drops
+    datasets.tile_cache_version) that poisons unrelated tests with
+    UndefinedColumnError. fix(#525 B-038)
     """
 
     def test_upgrade_head_exits_zero(self):
@@ -152,12 +157,19 @@ class TestMigrationRoundTripExitCodes:
         )
 
     def test_downgrade_minus_one_exits_zero(self):
-        """alembic downgrade -1 exits 0 (downgrade is a NO-OP per 0009 docstring)."""
-        r = _run_alembic("downgrade", "-1")
-        assert r.returncode == 0, (
-            f"alembic downgrade -1 failed (rc={r.returncode}):\n"
-            f"stdout: {r.stdout}\nstderr: {r.stderr}"
-        )
+        """alembic downgrade -1 exits 0, then head is restored in-test."""
+        try:
+            r = _run_alembic("downgrade", "-1")
+            assert r.returncode == 0, (
+                f"alembic downgrade -1 failed (rc={r.returncode}):\n"
+                f"stdout: {r.stdout}\nstderr: {r.stderr}"
+            )
+        finally:
+            restore = _run_alembic("upgrade", "head")
+            assert restore.returncode == 0, (
+                f"alembic upgrade head (restore) failed (rc={restore.returncode}):\n"
+                f"stdout: {restore.stdout}\nstderr: {restore.stderr}"
+            )
 
     def test_reupgrade_head_exits_zero(self):
         """alembic upgrade head (re-apply) exits 0 after NO-OP downgrade."""

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -814,7 +814,11 @@ def test_decomposed_service_modules_stay_within_size_budgets() -> None:
         # chat_edit_map gains the per-turn allowed-tool guard on the tool
         # executor + action collector (so a view-only caller cannot execute or
         # collect a mutating tool). Cap raised 400 -> 440 (~4 LOC headroom).
-        "backend/app/processing/ai/chat_service.py": 440,
+        # fix(#TBD B-037): +2 LOC — chat_edit_map builds ChatActions per-item
+        # via _build_chat_actions (re-exported here for streaming.py) so one
+        # invalid action drops with a note instead of failing the whole turn.
+        # Cap raised 440 -> 446 (~4 LOC headroom).
+        "backend/app/processing/ai/chat_service.py": 446,
     }
     private_service_default_line_budget = 350
     private_service_line_budget_allowlist = {

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -814,7 +814,7 @@ def test_decomposed_service_modules_stay_within_size_budgets() -> None:
         # chat_edit_map gains the per-turn allowed-tool guard on the tool
         # executor + action collector (so a view-only caller cannot execute or
         # collect a mutating tool). Cap raised 400 -> 440 (~4 LOC headroom).
-        # fix(#TBD B-037): +2 LOC — chat_edit_map builds ChatActions per-item
+        # fix(#525 B-037): +2 LOC — chat_edit_map builds ChatActions per-item
         # via _build_chat_actions (re-exported here for streaming.py) so one
         # invalid action drops with a note instead of failing the whole turn.
         # Cap raised 440 -> 446 (~4 LOC headroom).

--- a/backend/tests/test_reupload_swap_lock_retry.py
+++ b/backend/tests/test_reupload_swap_lock_retry.py
@@ -67,12 +67,13 @@ def _make_dataset_stub(table_name: str):
         spatial_extent=None,
         updated_by=None,
     )
-    return types.SimpleNamespace(
+    dataset = types.SimpleNamespace(
         id=uuid.uuid4(),
         record=record,
         record_id=uuid.uuid4(),
         table_name=table_name,
         current_version=1,
+        tile_cache_version=1,
         srid=4326,
         geometry_type="Point",
         feature_count=1,
@@ -84,6 +85,12 @@ def _make_dataset_stub(table_name: str):
         source_url=None,
         quality_detail=None,
     )
+    # fix(#525 B-038): _apply_reupload_swap now rolls the `_v=` tile
+    # cache-buster alongside current_version.
+    dataset.bump_tile_cache_version = lambda: setattr(
+        dataset, "tile_cache_version", dataset.tile_cache_version + 1
+    )
+    return dataset
 
 
 def _minimal_metadata():

--- a/backend/tests/test_shared_map_embed_scope.py
+++ b/backend/tests/test_shared_map_embed_scope.py
@@ -246,6 +246,43 @@ class TestTileVersionField:
         assert shared_resp.status_code == 200
         assert shared_resp.json()["layers"][0]["tile_version"] == 1
 
+    async def test_tile_version_bumps_on_content_mutation(
+        self, client: AsyncClient, admin_auth_header: dict, test_db_session
+    ):
+        """fix(#TBD B-038): tile_version must roll on content mutations that
+        don't create a DatasetVersion row. It previously read current_version
+        (bumped on reupload only), so feature edits / column DDL / tile_columns
+        changes purged Valkey but left the ``_v=`` tile URL unchanged — CDN and
+        browser caches kept serving stale tiles until max-age expiry (T-01).
+        """
+        admin_id = await get_user_id(test_db_session, "admin")
+        ds = await create_dataset(
+            test_db_session,
+            created_by=admin_id,
+            visibility="public",
+            column_info=[{"name": "name", "type": "text"}],
+        )
+        map_id, share_token, _ = await _make_public_shared_map(
+            client, admin_auth_header, [str(ds.id)]
+        )
+
+        # A tile_columns change alters the attribute set embedded in vector
+        # tiles — the PATCH handler must bump the dedicated cache-buster.
+        resp = await client.patch(
+            f"/datasets/{ds.id}",
+            json={"tile_columns": ["name"]},
+            headers=admin_auth_header,
+        )
+        assert resp.status_code == 200, resp.text
+
+        builder_resp = await client.get(f"/maps/{map_id}", headers=admin_auth_header)
+        assert builder_resp.status_code == 200
+        assert builder_resp.json()["layers"][0]["tile_version"] == 2
+
+        shared_resp = await client.get(f"/maps/shared/{share_token}")
+        assert shared_resp.status_code == 200
+        assert shared_resp.json()["layers"][0]["tile_version"] == 2
+
 
 class TestGeojsonZEmbedFallback:
     async def test_geojson_z_accepts_embed_token_for_scoped_dataset(

--- a/backend/tests/test_shared_map_embed_scope.py
+++ b/backend/tests/test_shared_map_embed_scope.py
@@ -249,7 +249,7 @@ class TestTileVersionField:
     async def test_tile_version_bumps_on_content_mutation(
         self, client: AsyncClient, admin_auth_header: dict, test_db_session
     ):
-        """fix(#TBD B-038): tile_version must roll on content mutations that
+        """fix(#525 B-038): tile_version must roll on content mutations that
         don't create a DatasetVersion row. It previously read current_version
         (bumped on reupload only), so feature edits / column DDL / tile_columns
         changes purged Valkey but left the ``_v=`` tile URL unchanged — CDN and

--- a/frontend/src/components/builder/__tests__/folder-groups.test.ts
+++ b/frontend/src/components/builder/__tests__/folder-groups.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import {
   hydrateFolderGroupLayers,
   prepareLayersForPersistence,
+  resolveDropGroupMembership,
   type GroupedLayer,
 } from '../folder-groups';
 import type { MapLayerResponse, StyleConfig } from '@/types/api';
@@ -101,5 +102,45 @@ describe('folder group persistence helpers', () => {
       folderGroupExpanded: true,
     });
     expect(persisted[1].style_config?.builder).toEqual({ outlineWidth: 2 });
+  });
+});
+
+// fix(#TBD B-040): membership rule for intra-stack drag drops — childrenByGroup
+// renders by parent_group_id, not array position, so handleDragEnd must derive
+// the target membership from the drop target instead of doing a bare arrayMove.
+describe('resolveDropGroupMembership', () => {
+  const groupRow = {
+    ...makeLayer({ id: 'group-1', display_name: 'Group' }),
+    layer_type: 'group:folder',
+  } as unknown as MapLayerResponse;
+  const childOfGroup = {
+    ...makeLayer({ id: 'child-1' }),
+    parent_group_id: 'group-1',
+  } as unknown as MapLayerResponse;
+  const childOfOther = {
+    ...makeLayer({ id: 'child-2' }),
+    parent_group_id: 'group-2',
+  } as unknown as MapLayerResponse;
+  const loose = makeLayer({ id: 'loose-1' });
+
+  it('a grouped child dropped onto a loose row leaves its group', () => {
+    expect(resolveDropGroupMembership(childOfGroup, loose)).toBeNull();
+  });
+
+  it('a loose layer dropped onto a group child adopts that group', () => {
+    expect(resolveDropGroupMembership(loose, childOfGroup)).toBe('group-1');
+  });
+
+  it('a grouped child dropped onto another group\'s child adopts the new group', () => {
+    expect(resolveDropGroupMembership(childOfGroup, childOfOther)).toBe('group-2');
+  });
+
+  it('dropping onto a group header row keeps the dragged row\'s membership', () => {
+    expect(resolveDropGroupMembership(childOfGroup, groupRow)).toBe('group-1');
+    expect(resolveDropGroupMembership(loose, groupRow)).toBeNull();
+  });
+
+  it('a loose layer dropped onto another loose row stays loose', () => {
+    expect(resolveDropGroupMembership(loose, makeLayer({ id: 'loose-2' }))).toBeNull();
   });
 });

--- a/frontend/src/components/builder/__tests__/folder-groups.test.ts
+++ b/frontend/src/components/builder/__tests__/folder-groups.test.ts
@@ -105,7 +105,7 @@ describe('folder group persistence helpers', () => {
   });
 });
 
-// fix(#TBD B-040): membership rule for intra-stack drag drops — childrenByGroup
+// fix(#525 B-040): membership rule for intra-stack drag drops — childrenByGroup
 // renders by parent_group_id, not array position, so handleDragEnd must derive
 // the target membership from the drop target instead of doing a bare arrayMove.
 describe('resolveDropGroupMembership', () => {

--- a/frontend/src/components/builder/folder-groups.ts
+++ b/frontend/src/components/builder/folder-groups.ts
@@ -66,7 +66,7 @@ export function getParentGroupId(layer: MapLayerResponse): string | null {
   return (layer as GroupedLayer).parent_group_id ?? null;
 }
 
-// fix(#TBD B-040): membership rule for intra-stack drops. childrenByGroup
+// fix(#525 B-040): membership rule for intra-stack drops. childrenByGroup
 // renders by parent_group_id, not array position, so a drag that changes
 // position without updating membership silently snaps back on render.
 // A drop onto a group child adopts that child's group; onto a loose data row

--- a/frontend/src/components/builder/folder-groups.ts
+++ b/frontend/src/components/builder/folder-groups.ts
@@ -66,6 +66,20 @@ export function getParentGroupId(layer: MapLayerResponse): string | null {
   return (layer as GroupedLayer).parent_group_id ?? null;
 }
 
+// fix(#TBD B-040): membership rule for intra-stack drops. childrenByGroup
+// renders by parent_group_id, not array position, so a drag that changes
+// position without updating membership silently snaps back on render.
+// A drop onto a group child adopts that child's group; onto a loose data row
+// leaves any group; onto a group header row keeps the dragged row's current
+// membership (header drops are ambiguous — treat as position-only).
+export function resolveDropGroupMembership(
+  activeLayer: MapLayerResponse,
+  overLayer: MapLayerResponse,
+): string | null {
+  if (isFolderGroupLayer(overLayer)) return getParentGroupId(activeLayer);
+  return getParentGroupId(overLayer);
+}
+
 // fix(#392): handleUngroup / handleMoveLayerOutOfGroup previously only
 // cleared the frontend-only `parent_group_id` field, leaving any PERSISTED
 // `style_config.builder.folderGroupId` on the underlying layer object intact.

--- a/frontend/src/components/builder/hooks/__tests__/use-builder-layers.bulk-ops.test.ts
+++ b/frontend/src/components/builder/hooks/__tests__/use-builder-layers.bulk-ops.test.ts
@@ -461,6 +461,34 @@ describe('useBuilderLayers — handleBulkGroup (POL-09)', () => {
     expect(updatedC?.parent_group_id).toBe(groupId);
   });
 
+  // fix(#TBD B-040): a non-contiguous selection must compact the grouped block
+  // adjacent to the group row. Stamping parent_group_id in place stranded any
+  // non-selected layer between selected ones below the group — stack order and
+  // map draw order diverged for it, and it persisted through save/reload.
+  it('non-contiguous selection compacts the grouped block and moves unselected layers below it', async () => {
+    const layerA = makeMockLayer({ id: 'a', sort_order: 0, dataset_record_type: 'vector_dataset' });
+    const layerB = makeMockLayer({ id: 'b', sort_order: 1, dataset_record_type: 'vector_dataset' });
+    const layerC = makeMockLayer({ id: 'c', sort_order: 2, dataset_record_type: 'vector_dataset' });
+    const { result } = renderBuilderLayers(makeMapData([layerA, layerB, layerC]));
+    await waitForInit();
+
+    act(() => {
+      result.current.handleBulkGroup(new Set(['a', 'c']));
+    });
+
+    const updated = result.current.localLayers as GroupedLayer[];
+    const shape = updated.map((l) => (l.layer_type === 'group:folder' ? 'G' : l.id));
+    // Group row at the first selected position, children compacted directly
+    // after it, the unselected middle layer pushed below the block.
+    expect(shape).toEqual(['G', 'a', 'c', 'b']);
+    expect(updated.map((l) => l.sort_order)).toEqual([0, 1, 2, 3]);
+
+    const groupId = updated.find((l) => l.layer_type === 'group:folder')!.id;
+    expect(updated.find((l) => l.id === 'a')?.parent_group_id).toBe(groupId);
+    expect(updated.find((l) => l.id === 'c')?.parent_group_id).toBe(groupId);
+    expect(updated.find((l) => l.id === 'b')?.parent_group_id ?? null).toBeNull();
+  });
+
   // fix(#392): a single loose layer selection
   // returns false, toasts the "need two" reason, and does not mutate localLayers. (audit B-004d/LM-04)
   it('Test A: single loose layer returns false, toasts bulkGroupNeedTwo, and does not mutate localLayers', async () => {

--- a/frontend/src/components/builder/hooks/__tests__/use-builder-layers.bulk-ops.test.ts
+++ b/frontend/src/components/builder/hooks/__tests__/use-builder-layers.bulk-ops.test.ts
@@ -461,7 +461,7 @@ describe('useBuilderLayers — handleBulkGroup (POL-09)', () => {
     expect(updatedC?.parent_group_id).toBe(groupId);
   });
 
-  // fix(#TBD B-040): a non-contiguous selection must compact the grouped block
+  // fix(#525 B-040): a non-contiguous selection must compact the grouped block
   // adjacent to the group row. Stamping parent_group_id in place stranded any
   // non-selected layer between selected ones below the group — stack order and
   // map draw order diverged for it, and it persisted through save/reload.

--- a/frontend/src/components/builder/hooks/use-bulk-layer-actions.ts
+++ b/frontend/src/components/builder/hooks/use-bulk-layer-actions.ts
@@ -247,18 +247,20 @@ export function useBulkLayerActions({
     };
 
     setLocalLayers((prev) => {
-      const next = prev.map((l) =>
-        selectedIds.has(l.id)
-          ? ({ ...l, parent_group_id: groupId } as unknown as MapLayerResponse)
-          : l,
-      );
-      // Insert group row at position of first selected layer (smallest sort_order)
-      const insertIdx = next.findIndex((l) => selectedIds.has(l.id));
-      if (insertIdx >= 0) {
-        next.splice(insertIdx, 0, groupRow as unknown as MapLayerResponse);
-      } else {
-        next.push(groupRow as unknown as MapLayerResponse);
-      }
+      // fix(#TBD B-040): compact the selected block adjacent to the group row.
+      // Stamping parent_group_id in place stranded any non-selected layer that
+      // sat between selected ones below the group — stack order and map draw
+      // order diverged for it, persistently (not self-healed by save+reload).
+      const insertIdx = prev.findIndex((l) => selectedIds.has(l.id));
+      const grouped = prev
+        .filter((l) => selectedIds.has(l.id))
+        .map((l) => ({ ...l, parent_group_id: groupId } as unknown as MapLayerResponse));
+      const rest = prev.filter((l) => !selectedIds.has(l.id));
+      const next = [...rest];
+      // Every row before the first selected one is unselected, so the prev
+      // index of the first selected row is also its insertion index in `rest`.
+      const at = insertIdx >= 0 ? Math.min(insertIdx, rest.length) : rest.length;
+      next.splice(at, 0, groupRow as unknown as MapLayerResponse, ...grouped);
       return next.map((l, i) => ({ ...l, sort_order: i }));
     });
     setGroupMeta((prev) => ({ ...prev, [groupId]: { expanded: true } }));

--- a/frontend/src/components/builder/hooks/use-bulk-layer-actions.ts
+++ b/frontend/src/components/builder/hooks/use-bulk-layer-actions.ts
@@ -247,7 +247,7 @@ export function useBulkLayerActions({
     };
 
     setLocalLayers((prev) => {
-      // fix(#TBD B-040): compact the selected block adjacent to the group row.
+      // fix(#525 B-040): compact the selected block adjacent to the group row.
       // Stamping parent_group_id in place stranded any non-selected layer that
       // sat between selected ones below the group — stack order and map draw
       // order diverged for it, persistently (not self-healed by save+reload).

--- a/frontend/src/lib/__tests__/basemap-utils.test.ts
+++ b/frontend/src/lib/__tests__/basemap-utils.test.ts
@@ -271,7 +271,7 @@ describe('BLANK_BASEMAP_ID', () => {
       type: 'background',
       paint: { 'background-color': 'rgba(0,0,0,0)' },
     });
-    // fix(#TBD B-039): the blank basemap MUST carry a glyphs URL — user data
+    // fix(#525 B-039): the blank basemap MUST carry a glyphs URL — user data
     // label layers (companion `*-label`, symbol-mode text) are added to this
     // style, and MapLibre cannot render any text-field without one. Glyphs are
     // fetched lazily, so a label-free blank map still makes no font requests.

--- a/frontend/src/lib/__tests__/basemap-utils.test.ts
+++ b/frontend/src/lib/__tests__/basemap-utils.test.ts
@@ -271,8 +271,11 @@ describe('BLANK_BASEMAP_ID', () => {
       type: 'background',
       paint: { 'background-color': 'rgba(0,0,0,0)' },
     });
-    // Blank basemap intentionally omits glyphs — no text layers, avoids CORS errors
-    expect(result.glyphs).toBeUndefined();
+    // fix(#TBD B-039): the blank basemap MUST carry a glyphs URL — user data
+    // label layers (companion `*-label`, symbol-mode text) are added to this
+    // style, and MapLibre cannot render any text-field without one. Glyphs are
+    // fetched lazily, so a label-free blank map still makes no font requests.
+    expect(result.glyphs).toBe('https://tiles.openfreemap.org/fonts/{fontstack}/{range}.pbf');
   });
 
   it('toMaplibreStyle blank ignores attribution param', () => {

--- a/frontend/src/lib/basemap-utils.ts
+++ b/frontend/src/lib/basemap-utils.ts
@@ -161,10 +161,14 @@ const LEGACY_KEY_MAP: Record<string, string> = {
  */
 export function toMaplibreStyle(url: string, attribution?: string): string | StyleSpecification {
   if (url === BLANK_BASEMAP_ID) {
-    // No glyphs property — blank basemap has zero symbol/text layers so no
-    // glyph fetch is needed. Omitting prevents any glyph request attempts.
+    // fix(#TBD B-039): the blank basemap itself has zero symbol layers, but
+    // user data layers (companion `*-label` layers, symbol-mode text) are
+    // added to THIS style — without a glyphs URL MapLibre cannot render any
+    // text-field, so feature labels silently failed in no-basemap mode.
+    // Glyphs are fetched lazily; with no text layers nothing is requested.
     return {
       version: 8 as const,
+      glyphs: FALLBACK_GLYPHS,
       sources: {},
       layers: [
         {

--- a/frontend/src/lib/basemap-utils.ts
+++ b/frontend/src/lib/basemap-utils.ts
@@ -161,7 +161,7 @@ const LEGACY_KEY_MAP: Record<string, string> = {
  */
 export function toMaplibreStyle(url: string, attribution?: string): string | StyleSpecification {
   if (url === BLANK_BASEMAP_ID) {
-    // fix(#TBD B-039): the blank basemap itself has zero symbol layers, but
+    // fix(#525 B-039): the blank basemap itself has zero symbol layers, but
     // user data layers (companion `*-label` layers, symbol-mode text) are
     // added to THIS style — without a glyphs URL MapLibre cannot render any
     // text-field, so feature labels silently failed in no-basemap mode.

--- a/frontend/src/pages/MapBuilderPage.tsx
+++ b/frontend/src/pages/MapBuilderPage.tsx
@@ -48,6 +48,7 @@ import {
 } from '@/lib/basemap-utils';
 import type { MapLayerResponse, MapSublayerOverride } from '@/types/api';
 import { isFolderGroupLayer } from '@/lib/layer-capabilities';
+import { clearPersistedFolderGroup, getParentGroupId, resolveDropGroupMembership } from '@/components/builder/folder-groups';
 import { SidebarRail } from '@/components/builder/SidebarRail';
 import { LayerEditorPanel, type LayerEditorHandlers } from '@/components/builder/LayerEditorPanel';
 import { EphemeralBadge } from '@/components/builder/EphemeralBadge';
@@ -985,10 +986,33 @@ export function MapBuilderPage() {
       return;
     }
 
+    // fix(#TBD B-040): derive group membership from the drop target — the
+    // bare arrayMove never touched parent_group_id, so dragging a child out
+    // of its group was a silent no-op (childrenByGroup renders by membership,
+    // not array position, so the row snapped back) and a loose layer dropped
+    // between group children never joined the group.
+    const overLayer = currentLayers[newIndex];
+    const currentGroupId = getParentGroupId(activeLayer);
+    const targetGroupId = resolveDropGroupMembership(activeLayer, overLayer);
+    let moved = arrayMove(currentLayers, oldIndex, newIndex);
+    if (targetGroupId !== currentGroupId) {
+      moved = moved.map((l) => {
+        if (l.id !== activeLayer.id) return l;
+        return {
+          ...l,
+          parent_group_id: targetGroupId,
+          // Leaving a group also clears the persisted folderGroupId — mirrors
+          // handleMoveLayerOutOfGroup (fix(#392) CR-01).
+          ...(targetGroupId === null
+            ? { style_config: clearPersistedFolderGroup(l.style_config) }
+            : {}),
+        } as MapLayerResponse;
+      });
+    }
     dispatchLayerAction({
       type: 'reorder_layers',
       source: 'manual',
-      layers: arrayMove(currentLayers, oldIndex, newIndex),
+      layers: moved,
     });
   // eslint-disable-next-line react-hooks/exhaustive-deps -- layers.localLayers + dispatchLayerAction + handleAddDataset captured; basemapGroup is stable derived value; announce is stable
   }, [layers.localLayers, dispatchLayerAction, layers.handleAddDataset, layers.markDirty, basemapGroup, t, announce, applyBasemapPatch, basemapState]);

--- a/frontend/src/pages/MapBuilderPage.tsx
+++ b/frontend/src/pages/MapBuilderPage.tsx
@@ -986,7 +986,7 @@ export function MapBuilderPage() {
       return;
     }
 
-    // fix(#TBD B-040): derive group membership from the drop target — the
+    // fix(#525 B-040): derive group membership from the drop target — the
     // bare arrayMove never touched parent_group_id, so dragging a child out
     // of its group was a silent no-op (childrenByGroup renders by membership,
     // not array position, so the row snapped back) and a loose layer dropped


### PR DESCRIPTION
Second wave of the 2026-07-15 builder-audit P1 remediation (first wave: #524). Internal report: `docs-internal/audits/builder-audit-20260715.md`.

## Changes

**B-037 — one invalid AI action killed the whole chat turn (`chat_validation.py`, `streaming.py`, `chat_service.py`, `chat_actions.py`)**
All three action-collection sites built ChatActions with an unguarded list comprehension, so a single Pydantic-invalid action (e.g. `opacity: 50`) raised through the broad except — one generic error event, every valid action in the turn discarded. Actions are now built per-item via `_build_chat_actions` and invalid ones drop with a user-visible note (mirroring `_validate_actions`' pattern). `set_opacity` is additionally clamped server-side into [0,1] (models emit percent values), matching the set_style paint-clamping precedent.

**B-038 — CDN/browser tile staleness after content edits (migration `0025`, `datasets/domain/models.py`, feature/DDL/metadata routers, `tasks_common.py`, maps services)**
`tile_version` (the frontend's `_v=` tile-URL cache-buster) read `Dataset.current_version`, which is coupled to DatasetVersion history rows and bumps on reupload only. Feature edits, column DDL, and `tile_columns` changes purged Valkey but left the URL unchanged — behind an edge cache (e.g. the demo's Cloudflare tile Cache Rule) stale tiles persisted until max-age expiry. A dedicated `Dataset.tile_cache_version` counter is now bumped in-transaction by every tile-content mutation (including reupload) and feeds `tile_version`. `current_version`'s version-history semantics are untouched; no API schema change (openapi.json unchanged).

**B-039 — feature labels never rendered on the blank basemap (`basemap-utils.ts`)**
The "No basemap" style omitted the `glyphs` URL on the reasoning that the basemap has no text layers — but user data label layers are added to that same style, and MapLibre cannot render any `text-field` without one. The blank style now carries the fallback glyphs URL (fetched lazily, so a label-free blank map still makes no font requests).

**B-040 — group membership defects (`MapBuilderPage.tsx`, `folder-groups.ts`, `use-bulk-layer-actions.ts`)**
Intra-stack drags did a bare `arrayMove` with no `parent_group_id` mutation — dragging a child out of its group silently snapped back (rendering is membership-driven, not position-driven) and a loose layer dropped between group children never joined. Drops now derive membership from the drop target (`resolveDropGroupMembership`: child → adopt its group, loose row → leave any group, group header → position-only), clearing the persisted folderGroupId on leave per the fix(#392) CR-01 pattern. Bulk-group also compacts the selected block adjacent to the group row, so a non-contiguous selection no longer strands unselected layers inside the group block (stack/draw-order divergence that persisted through save/reload).

## Schema/API impact

- New Alembic migration `0025_dataset_tile_cache_version` (single INTEGER column, server_default 1). `make alembic-check` green.
- No OpenAPI change (`tile_version` field already existed; only its derivation changed).

## Verification

- Backend: `uv run ruff check/format` clean; 235-test sweep over touched areas (ai chat, streaming, features CRUD, tile_columns metadata, maps) + layering suite green; new regression tests for the per-item action build, the opacity clamp, and the tile_version bump (asserted through the real PATCH route on both builder and shared responses)
- Frontend: lint + typecheck clean; 2597 vitest incl. new tests for `resolveDropGroupMembership` (5 cases), non-contiguous bulk-group compaction, and the blank-basemap glyphs assertion (inverted from the old pin)
- E2E: `e2e:smoke:builder` 27/27; hardening chromium 7/8 on this branch where the single red is the known B-036 console-gate noise — re-run with #524's gate fix applied locally: **8/8** (no functional regression from the drag changes)
- Live browser smoke (Restless Earth, all draft-only, discarded via the unsaved-changes guard): non-contiguous bulk group produced the compacted `[Group → a, c]` shape with the unselected layer below the block; real pointer drags moved a child out of its group (no snap-back) and adopted a loose layer into it; blank basemap rendered visible city label text ("Tokyo", "Nagoya") with glyph requests on the wire — impossible before the fix; zero console errors in-session

## Notes

- Dev environments must run `make migrate` after pulling — the API's MIG-02 schema-skew guard refuses to boot on a DB behind 0025.
- Remaining audit items are P2s (B-041..B-054), tracked in the report.