### PR TITLE
fix(builder): remediate builder-audit 2026-07-15 P2 findings (B-041..B-050)

### DIFF
--- a/backend/app/modules/catalog/maps/router_sharing.py
+++ b/backend/app/modules/catalog/maps/router_sharing.py
@@ -78,12 +78,28 @@ async def shared_map_card_endpoint(
     metadata. This crawler-only route is excluded from OpenAPI.
     """
     token_obj = await _validate_share_token(db, token)
-    if token_obj is None or isinstance(token_obj, str):
-        raise HTTPException(status_code=404, detail="Share link not found")
-
-    map_obj = await get_map(db, token_obj.map_id)
+    map_obj = None
+    if token_obj is not None and not isinstance(token_obj, str):
+        map_obj = await get_map(db, token_obj.map_id)
     if map_obj is None or map_obj.visibility != "public":
-        raise HTTPException(status_code=404, detail="Share link not found")
+        # fix(#TBD B-048): "Copy Link" copies THIS /card URL — an expired or
+        # revoked link previously returned bare JSON 404 here, while the
+        # secondary /m/{token} route renders the friendly "link expired" view.
+        # Return 200 HTML with a meta-refresh into the SPA shell so both share
+        # affordances land on the same expired page (audit SH-01/SH-07). No
+        # map details are rendered on this path.
+        viewer_url = f"/m/{html.escape(token)}"
+        fallback_html = (
+            "<!doctype html>\n"
+            "<html><head>\n"
+            '<meta charset="UTF-8">\n'
+            f'<meta http-equiv="refresh" content="0;url={viewer_url}">\n'
+            "</head><body></body></html>"
+        )
+        return HTMLResponse(
+            content=fallback_html,
+            headers={"Cache-Control": "no-store"},
+        )
 
     image_url = await get_share_card_image_url(db, request, map_obj)
     image_url = html.escape(image_url, quote=True)

--- a/backend/app/modules/catalog/maps/router_sharing.py
+++ b/backend/app/modules/catalog/maps/router_sharing.py
@@ -82,7 +82,7 @@ async def shared_map_card_endpoint(
     if token_obj is not None and not isinstance(token_obj, str):
         map_obj = await get_map(db, token_obj.map_id)
     if map_obj is None or map_obj.visibility != "public":
-        # fix(#TBD B-048): "Copy Link" copies THIS /card URL — an expired or
+        # fix(#526 B-048): "Copy Link" copies THIS /card URL — an expired or
         # revoked link previously returned bare JSON 404 here, while the
         # secondary /m/{token} route renders the friendly "link expired" view.
         # Return 200 HTML with a meta-refresh into the SPA shell so both share

--- a/backend/app/modules/catalog/maps/style_json.py
+++ b/backend/app/modules/catalog/maps/style_json.py
@@ -922,6 +922,19 @@ def _style_layer_for_map_layer(
     if not layer.visible:
         base["layout"] = {**layout, "visibility": "none"}
 
+    # fix(#TBD B-044): the builder stores the per-layer zoom range as
+    # builder-private layout keys (`_minzoom`/`_maxzoom`, applied live via
+    # setLayerZoomRange). `_clean_layout` strips underscore keys, so exported
+    # layers previously rendered at ALL zooms. Re-emit them as the spec-level
+    # layer `minzoom`/`maxzoom` (defaults 0/22 are omitted as no-ops).
+    raw_layout = dict(layer.layout or {})
+    export_minzoom = raw_layout.get("_minzoom")
+    export_maxzoom = raw_layout.get("_maxzoom")
+    if isinstance(export_minzoom, (int, float)) and export_minzoom > 0:
+        base["minzoom"] = export_minzoom
+    if isinstance(export_maxzoom, (int, float)) and export_maxzoom < 22:
+        base["maxzoom"] = export_maxzoom
+
     # Companions emitted BELOW the primary in painter order (drawn first / underneath).
     below_companions: list[dict[str, Any]] = []
     # Companions emitted ABOVE the primary (outline/extrusion/arrow/label).

--- a/backend/app/modules/catalog/maps/style_json.py
+++ b/backend/app/modules/catalog/maps/style_json.py
@@ -930,10 +930,6 @@ def _style_layer_for_map_layer(
     raw_layout = dict(layer.layout or {})
     export_minzoom = raw_layout.get("_minzoom")
     export_maxzoom = raw_layout.get("_maxzoom")
-    if isinstance(export_minzoom, (int, float)) and export_minzoom > 0:
-        base["minzoom"] = export_minzoom
-    if isinstance(export_maxzoom, (int, float)) and export_maxzoom < 22:
-        base["maxzoom"] = export_maxzoom
 
     # Companions emitted BELOW the primary in painter order (drawn first / underneath).
     below_companions: list[dict[str, Any]] = []
@@ -998,7 +994,19 @@ def _style_layer_for_map_layer(
             label_layer["filter"] = layer.filter
         above_companions.append(label_layer)
 
-    return [*below_companions, base, *above_companions]
+    # fix(#526 codex on B-044): the zoom range applies to companions too — the
+    # live builder calls setLayerZoomRange on every companion id (outline/
+    # extrusion/arrow/label/color-relief), so export only tagging the primary
+    # left companions visible outside the range. Merge rather than clobber:
+    # the 3D extrusion companion emits its own (tighter) minzoom.
+    emitted = [*below_companions, base, *above_companions]
+    if isinstance(export_minzoom, (int, float)) and export_minzoom > 0:
+        for style_layer in emitted:
+            style_layer["minzoom"] = max(style_layer.get("minzoom", 0), export_minzoom)
+    if isinstance(export_maxzoom, (int, float)) and export_maxzoom < 22:
+        for style_layer in emitted:
+            style_layer["maxzoom"] = min(style_layer.get("maxzoom", 22), export_maxzoom)
+    return emitted
 
 
 # builder-audit #338 SPEC-01: per-layer-type MapLibre paint/layout property allow-lists.

--- a/backend/app/modules/catalog/maps/style_json.py
+++ b/backend/app/modules/catalog/maps/style_json.py
@@ -922,7 +922,7 @@ def _style_layer_for_map_layer(
     if not layer.visible:
         base["layout"] = {**layout, "visibility": "none"}
 
-    # fix(#TBD B-044): the builder stores the per-layer zoom range as
+    # fix(#526 B-044): the builder stores the per-layer zoom range as
     # builder-private layout keys (`_minzoom`/`_maxzoom`, applied live via
     # setLayerZoomRange). `_clean_layout` strips underscore keys, so exported
     # layers previously rendered at ALL zooms. Re-emit them as the spec-level

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -1035,11 +1035,13 @@ def test_open_core_decomposition_boundaries_stay_clean() -> None:
         )
 
     size_caps = {
-        "backend/app/modules/catalog/maps/style_json.py": 1390,
+        # fix(#526 B-045): +13 lines for per-layer minzoom/maxzoom in style.json export.
+        "backend/app/modules/catalog/maps/style_json.py": 1403,
         "backend/app/modules/catalog/maps/style_import.py": 450,
         "backend/app/modules/catalog/maps/style_sanitizers.py": 200,
         "backend/app/modules/catalog/maps/router_assets.py": 126,
-        "backend/app/modules/catalog/maps/router_sharing.py": 371,
+        # fix(#526 B-047): +9 lines for the card-route SPA-redirect fallback shell.
+        "backend/app/modules/catalog/maps/router_sharing.py": 380,
         "backend/app/modules/catalog/search/query_params.py": 225,
         "backend/app/modules/catalog/search/router_saved.py": 100,
         "backend/app/modules/admin/router_operations.py": 275,

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -1035,12 +1035,13 @@ def test_open_core_decomposition_boundaries_stay_clean() -> None:
         )
 
     size_caps = {
-        # fix(#526 B-045): +13 lines for per-layer minzoom/maxzoom in style.json export.
-        "backend/app/modules/catalog/maps/style_json.py": 1403,
+        # fix(#526 B-044): per-layer minzoom/maxzoom in style.json export,
+        # propagated to companion layers.
+        "backend/app/modules/catalog/maps/style_json.py": 1411,
         "backend/app/modules/catalog/maps/style_import.py": 450,
         "backend/app/modules/catalog/maps/style_sanitizers.py": 200,
         "backend/app/modules/catalog/maps/router_assets.py": 126,
-        # fix(#526 B-047): +9 lines for the card-route SPA-redirect fallback shell.
+        # fix(#526 B-048): the card-route SPA-redirect fallback shell.
         "backend/app/modules/catalog/maps/router_sharing.py": 380,
         "backend/app/modules/catalog/search/query_params.py": 225,
         "backend/app/modules/catalog/search/router_saved.py": 100,

--- a/backend/tests/test_maps_og_image.py
+++ b/backend/tests/test_maps_og_image.py
@@ -377,7 +377,7 @@ class TestCardRoute:
         )
         assert upd.status_code == 200
 
-        # fix(#TBD B-048): the card route now returns a 200 HTML shell that
+        # fix(#526 B-048): the card route now returns a 200 HTML shell that
         # meta-refreshes into /m/{token} so the SPA renders the friendly
         # expired/unavailable view (previously: bare JSON 404 on the PRIMARY
         # "Copy Link" affordance). Map details must still never leak.
@@ -390,7 +390,7 @@ class TestCardRoute:
         assert "og:title" not in resp.text
 
     async def test_card_route_404_for_invalid_token(self, client: AsyncClient) -> None:
-        """fix(#TBD B-048): bogus token returns the 200 SPA-redirect shell."""
+        """fix(#526 B-048): bogus token returns the 200 SPA-redirect shell."""
         resp = await client.get("/maps/shared/bogus-invalid-token-xyz/card")
         assert resp.status_code == 200, resp.text
         assert "0;url=/m/bogus-invalid-token-xyz" in resp.text
@@ -412,7 +412,7 @@ class TestCardRoute:
         )
         assert revoke_resp.status_code == 204, f"Revoke failed: {revoke_resp.text}"
 
-        # fix(#TBD B-048): revoked/expired links get the 200 SPA-redirect
+        # fix(#526 B-048): revoked/expired links get the 200 SPA-redirect
         # shell so the recipient lands on the friendly "link expired" view.
         resp = await client.get(f"/maps/shared/{token}/card")
         assert resp.status_code == 200, resp.text

--- a/backend/tests/test_maps_og_image.py
+++ b/backend/tests/test_maps_og_image.py
@@ -377,19 +377,24 @@ class TestCardRoute:
         )
         assert upd.status_code == 200
 
+        # fix(#TBD B-048): the card route now returns a 200 HTML shell that
+        # meta-refreshes into /m/{token} so the SPA renders the friendly
+        # expired/unavailable view (previously: bare JSON 404 on the PRIMARY
+        # "Copy Link" affordance). Map details must still never leak.
         resp = await client.get(f"/maps/shared/{token}/card")
-        assert resp.status_code == 404, (
-            f"Expected 404 for private map, got {resp.status_code}: {resp.text}"
-        )
-        # Private title must NOT appear in any error body
+        assert resp.status_code == 200, resp.text
+        assert resp.headers["cache-control"] == "no-store"
+        assert f"0;url=/m/{token}" in resp.text
+        # Private title / social-card metadata must NOT appear in the shell
         assert "Secret Private Map" not in resp.text
+        assert "og:title" not in resp.text
 
     async def test_card_route_404_for_invalid_token(self, client: AsyncClient) -> None:
-        """T-1142-02 [BLOCKING]: bogus token returns 404."""
+        """fix(#TBD B-048): bogus token returns the 200 SPA-redirect shell."""
         resp = await client.get("/maps/shared/bogus-invalid-token-xyz/card")
-        assert resp.status_code == 404, (
-            f"Expected 404 for invalid token, got {resp.status_code}"
-        )
+        assert resp.status_code == 200, resp.text
+        assert "0;url=/m/bogus-invalid-token-xyz" in resp.text
+        assert "og:title" not in resp.text
 
     async def test_card_route_404_for_expired_token(
         self, client: AsyncClient, admin_auth_header: dict, test_db_session
@@ -407,10 +412,12 @@ class TestCardRoute:
         )
         assert revoke_resp.status_code == 204, f"Revoke failed: {revoke_resp.text}"
 
+        # fix(#TBD B-048): revoked/expired links get the 200 SPA-redirect
+        # shell so the recipient lands on the friendly "link expired" view.
         resp = await client.get(f"/maps/shared/{token}/card")
-        assert resp.status_code == 404, (
-            f"Expected 404 for revoked token, got {resp.status_code}: {resp.text}"
-        )
+        assert resp.status_code == 200, resp.text
+        assert f"0;url=/m/{token}" in resp.text
+        assert "og:title" not in resp.text
 
     @pytest.mark.parametrize(
         ("api_base", "expected_prefix"),

--- a/backend/tests/test_maps_style_json.py
+++ b/backend/tests/test_maps_style_json.py
@@ -2012,3 +2012,27 @@ def test_vector_source_maxzoom_mirrors_live_builder_394():
     )
     cluster_source = style_json._source_for_layer(cluster)
     assert cluster_source["maxzoom"] == 22
+
+
+# fix(#TBD B-044): the builder stores the per-layer zoom range as
+# builder-private `_minzoom`/`_maxzoom` layout keys; export previously
+# stripped them (underscore-key cleaning) without re-emitting spec-level
+# minzoom/maxzoom, so a zoom-limited layer rendered at ALL zooms in the
+# exported style.json.
+def test_export_emits_layer_zoom_range_from_builder_layout_keys():
+    layer = _layer(layout={"_minzoom": 8, "_maxzoom": 12})
+    exported = style_json._style_layer_for_map_layer(layer, "src-1")
+    primary = next(entry for entry in exported if entry["id"].startswith("layer-"))
+    assert primary["minzoom"] == 8
+    assert primary["maxzoom"] == 12
+    # The builder-private keys themselves must not leak into the layout.
+    assert "_minzoom" not in primary["layout"]
+    assert "_maxzoom" not in primary["layout"]
+
+
+def test_export_omits_default_zoom_range():
+    layer = _layer(layout={"_minzoom": 0, "_maxzoom": 22})
+    exported = style_json._style_layer_for_map_layer(layer, "src-1")
+    primary = next(entry for entry in exported if entry["id"].startswith("layer-"))
+    assert "minzoom" not in primary
+    assert "maxzoom" not in primary

--- a/backend/tests/test_maps_style_json.py
+++ b/backend/tests/test_maps_style_json.py
@@ -2014,7 +2014,7 @@ def test_vector_source_maxzoom_mirrors_live_builder_394():
     assert cluster_source["maxzoom"] == 22
 
 
-# fix(#TBD B-044): the builder stores the per-layer zoom range as
+# fix(#526 B-044): the builder stores the per-layer zoom range as
 # builder-private `_minzoom`/`_maxzoom` layout keys; export previously
 # stripped them (underscore-key cleaning) without re-emitting spec-level
 # minzoom/maxzoom, so a zoom-limited layer rendered at ALL zooms in the

--- a/backend/tests/test_maps_style_json.py
+++ b/backend/tests/test_maps_style_json.py
@@ -2023,11 +2023,39 @@ def test_export_emits_layer_zoom_range_from_builder_layout_keys():
     layer = _layer(layout={"_minzoom": 8, "_maxzoom": 12})
     exported = style_json._style_layer_for_map_layer(layer, "src-1")
     primary = next(entry for entry in exported if entry["id"].startswith("layer-"))
-    assert primary["minzoom"] == 8
-    assert primary["maxzoom"] == 12
+    # fix(#526 codex on B-044): companions (here the -label layer) inherit the
+    # range too — the live builder zoom-ranges every companion id.
+    assert len(exported) > 1
+    for entry in exported:
+        assert entry["minzoom"] == 8
+        assert entry["maxzoom"] == 12
     # The builder-private keys themselves must not leak into the layout.
     assert "_minzoom" not in primary["layout"]
     assert "_maxzoom" not in primary["layout"]
+
+
+def test_export_zoom_range_merges_with_extrusion_companion_minzoom():
+    """The 3D extrusion companion has its own minzoom (default 14); a parent
+    _minzoom above it must win, one below it must not loosen it."""
+    layer = _layer(
+        dataset_geometry_type="POLYGON",
+        paint={"fill-color": "#2563eb", "_height_column": "height"},
+        layout={"_minzoom": 16},
+        label_config=None,
+    )
+    exported = style_json._style_layer_for_map_layer(layer, "src-1")
+    extrusion = next(e for e in exported if e["id"].endswith("-extrusion"))
+    assert extrusion["minzoom"] == 16
+
+    layer_low = _layer(
+        dataset_geometry_type="POLYGON",
+        paint={"fill-color": "#2563eb", "_height_column": "height"},
+        layout={"_minzoom": 8},
+        label_config=None,
+    )
+    exported_low = style_json._style_layer_for_map_layer(layer_low, "src-1")
+    extrusion_low = next(e for e in exported_low if e["id"].endswith("-extrusion"))
+    assert extrusion_low["minzoom"] == 14
 
 
 def test_export_omits_default_zoom_range():

--- a/frontend/src/components/builder/BuilderDialogs.tsx
+++ b/frontend/src/components/builder/BuilderDialogs.tsx
@@ -32,7 +32,7 @@ interface BuilderDialogsProps {
   onDuplicateRendering: (layerId: string) => void;
   layers: MapLayerResponse[];
   isAdding: boolean;
-  // fix(#TBD B-050): dataset id currently being added (per-row spinner).
+  // fix(#526 B-050): dataset id currently being added (per-row spinner).
   addingDatasetId?: string | null;
   addDataInitialQuery?: string;
   // Share

--- a/frontend/src/components/builder/BuilderDialogs.tsx
+++ b/frontend/src/components/builder/BuilderDialogs.tsx
@@ -32,6 +32,8 @@ interface BuilderDialogsProps {
   onDuplicateRendering: (layerId: string) => void;
   layers: MapLayerResponse[];
   isAdding: boolean;
+  // fix(#TBD B-050): dataset id currently being added (per-row spinner).
+  addingDatasetId?: string | null;
   addDataInitialQuery?: string;
   // Share
   showShare: boolean;
@@ -56,6 +58,7 @@ export function BuilderDialogs({
   onDuplicateRendering,
   layers,
   isAdding,
+  addingDatasetId,
   addDataInitialQuery,
   showShare,
   onShowShareChange,
@@ -84,6 +87,7 @@ export function BuilderDialogs({
               onDuplicateRendering={onDuplicateRendering}
               layers={layers}
               isAdding={isAdding}
+              addingDatasetId={addingDatasetId}
               initialQuery={addDataInitialQuery}
             />
           </Suspense>

--- a/frontend/src/components/builder/ChatPanel.tsx
+++ b/frontend/src/components/builder/ChatPanel.tsx
@@ -59,7 +59,10 @@ function classifyChatError(
   if (err instanceof ApiError && (err.status === 403 || err.status === 503)) {
     return { kind: 'banner', bannerKind: err.status === 403 ? 'forbidden' : 'unavailable' };
   }
-  if (err instanceof ApiError && (err.status === 401 || err.status === 500 || err.status === 502)) {
+  // fix(#TBD B-047): 429 = daily AI token budget / rate limit — retrying is a
+  // guaranteed second 429 (and previously surfaced as the generic "something
+  // went wrong" after a wasted duplicate POST). Show the real message inline.
+  if (err instanceof ApiError && (err.status === 401 || err.status === 429 || err.status === 500 || err.status === 502)) {
     return { kind: 'inline' };
   }
   // StreamModelError: model errored mid-stream — nothing to retry, show inline.
@@ -445,6 +448,9 @@ export function ChatPanel({
     if (err instanceof ApiError) {
       if (err.status === 401) return t('chat.errorSessionExpired');
       if (err.status === 403) return t('chat.errorForbidden');
+      // fix(#TBD B-047): surface the over-budget/rate-limit reason instead of
+      // the generic fallback.
+      if (err.status === 429) return t('chat.errorRateLimited');
       if (err.status === 502 || err.status === 503) return t('chat.errorAiUnavailable');
     }
     return t('chat.errorFriendly');

--- a/frontend/src/components/builder/ChatPanel.tsx
+++ b/frontend/src/components/builder/ChatPanel.tsx
@@ -59,7 +59,7 @@ function classifyChatError(
   if (err instanceof ApiError && (err.status === 403 || err.status === 503)) {
     return { kind: 'banner', bannerKind: err.status === 403 ? 'forbidden' : 'unavailable' };
   }
-  // fix(#TBD B-047): 429 = daily AI token budget / rate limit — retrying is a
+  // fix(#526 B-047): 429 = daily AI token budget / rate limit — retrying is a
   // guaranteed second 429 (and previously surfaced as the generic "something
   // went wrong" after a wasted duplicate POST). Show the real message inline.
   if (err instanceof ApiError && (err.status === 401 || err.status === 429 || err.status === 500 || err.status === 502)) {
@@ -448,7 +448,7 @@ export function ChatPanel({
     if (err instanceof ApiError) {
       if (err.status === 401) return t('chat.errorSessionExpired');
       if (err.status === 403) return t('chat.errorForbidden');
-      // fix(#TBD B-047): surface the over-budget/rate-limit reason instead of
+      // fix(#526 B-047): surface the over-budget/rate-limit reason instead of
       // the generic fallback.
       if (err.status === 429) return t('chat.errorRateLimited');
       if (err.status === 502 || err.status === 503) return t('chat.errorAiUnavailable');

--- a/frontend/src/components/builder/DatasetSearchPanel.tsx
+++ b/frontend/src/components/builder/DatasetSearchPanel.tsx
@@ -47,7 +47,7 @@ interface DatasetSearchPanelProps {
   onDuplicateRendering: (layerId: string) => void;
   layers: MapLayerResponse[];
   isAdding: boolean;
-  // fix(#TBD B-050): dataset id currently being added — drives the per-row
+  // fix(#526 B-050): dataset id currently being added — drives the per-row
   // in-flight spinner (the global isAdding flag alone gave no feedback about
   // WHICH row's click registered).
   addingDatasetId?: string | null;
@@ -382,7 +382,7 @@ export function DatasetSearchPanel({
         className={compact ? 'h-8 gap-1 px-3 text-xs' : 'h-7 w-7 shrink-0'}
         onClick={() => onAddDataset(record.id)}
         disabled={isAdding}
-        // fix(#TBD B-050): mark THIS row busy while its add is in flight
+        // fix(#526 B-050): mark THIS row busy while its add is in flight
         // (SuggestCard pattern) — all buttons stay disabled during an add, but
         // only the clicked row shows the spinner.
         aria-busy={addingDatasetId === record.id}

--- a/frontend/src/components/builder/DatasetSearchPanel.tsx
+++ b/frontend/src/components/builder/DatasetSearchPanel.tsx
@@ -9,6 +9,7 @@ import {
   GripVertical,
   Image as ImageIcon,
   Inbox,
+  Loader2,
   Plus,
   Repeat2,
   RotateCcw,
@@ -46,6 +47,10 @@ interface DatasetSearchPanelProps {
   onDuplicateRendering: (layerId: string) => void;
   layers: MapLayerResponse[];
   isAdding: boolean;
+  // fix(#TBD B-050): dataset id currently being added — drives the per-row
+  // in-flight spinner (the global isAdding flag alone gave no feedback about
+  // WHICH row's click registered).
+  addingDatasetId?: string | null;
   initialQuery?: string;
 }
 
@@ -267,6 +272,7 @@ export function DatasetSearchPanel({
   onDuplicateRendering,
   layers,
   isAdding,
+  addingDatasetId,
   initialQuery,
 }: DatasetSearchPanelProps) {
   const { t } = useTranslation('builder');
@@ -376,6 +382,10 @@ export function DatasetSearchPanel({
         className={compact ? 'h-8 gap-1 px-3 text-xs' : 'h-7 w-7 shrink-0'}
         onClick={() => onAddDataset(record.id)}
         disabled={isAdding}
+        // fix(#TBD B-050): mark THIS row busy while its add is in flight
+        // (SuggestCard pattern) — all buttons stay disabled during an add, but
+        // only the clicked row shows the spinner.
+        aria-busy={addingDatasetId === record.id}
         title={t('search.addToMap', { defaultValue: 'Add to map' })}
         // fix(#430 V-11): the row action and the expanded-details action both render
         // this button; give the details-panel instance a distinct accessible
@@ -387,7 +397,11 @@ export function DatasetSearchPanel({
             : `${t('search.addToMap', { defaultValue: 'Add to map' })} ${record.properties.title}`
         }
       >
-        <Plus className="h-3.5 w-3.5" aria-hidden="true" />
+        {addingDatasetId === record.id ? (
+          <Loader2 className="h-3.5 w-3.5 animate-spin" aria-hidden="true" />
+        ) : (
+          <Plus className="h-3.5 w-3.5" aria-hidden="true" />
+        )}
         {compact && t('search.addToMap', { defaultValue: 'Add to map' })}
       </Button>
     );

--- a/frontend/src/components/builder/KeyboardShortcutsSheet.tsx
+++ b/frontend/src/components/builder/KeyboardShortcutsSheet.tsx
@@ -73,8 +73,8 @@ export function KeyboardShortcutsSheet({
     },
     {
       id: 'reorder-toggle',
-      label: t('a11y.shortcuts.reorderToggle', { defaultValue: 'Toggle reorder mode (focused layer row)' }),
-      chord: 'Enter',
+      label: t('a11y.shortcuts.reorderToggle', { defaultValue: 'Toggle reorder mode (focused drag handle)' }),
+      chord: 'Space / Enter',
     },
     {
       id: 'reorder-move',

--- a/frontend/src/components/builder/MapToolbar.tsx
+++ b/frontend/src/components/builder/MapToolbar.tsx
@@ -77,7 +77,7 @@ export function MapToolbar({ onStyleJsonClick, onShortcutsClick }: MapToolbarPro
     return tools;
   }, [activePlugins, close, measureActive, measurementPlugin, toggle, t]);
 
-  // fix(#TBD B-041): the shortcuts sheet and these buttons' own tooltips
+  // fix(#526 B-041): the shortcuts sheet and these buttons' own tooltips
   // advertise V/M/L, but no handler was ever wired -- two surfaces
   // misinformed (audit U-02). Guarded like MapBuilderPage's '?' hotkey:
   // no-op while typing, with modifier keys held, or when a dialog is open.

--- a/frontend/src/components/builder/MapToolbar.tsx
+++ b/frontend/src/components/builder/MapToolbar.tsx
@@ -1,4 +1,4 @@
-import { useMemo, type ComponentType } from 'react';
+import { useEffect, useMemo, type ComponentType } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Hand, Ruler, Layers, FileJson, Keyboard } from 'lucide-react';
 import { cn } from '@/lib/utils';
@@ -76,6 +76,34 @@ export function MapToolbar({ onStyleJsonClick, onShortcutsClick }: MapToolbarPro
     }
     return tools;
   }, [activePlugins, close, measureActive, measurementPlugin, toggle, t]);
+
+  // fix(#TBD B-041): the shortcuts sheet and these buttons' own tooltips
+  // advertise V/M/L, but no handler was ever wired -- two surfaces
+  // misinformed (audit U-02). Guarded like MapBuilderPage's '?' hotkey:
+  // no-op while typing, with modifier keys held, or when a dialog is open.
+  useEffect(() => {
+    function handleToolHotkey(e: KeyboardEvent) {
+      if (e.metaKey || e.ctrlKey || e.altKey) return;
+      const key = e.key.toLowerCase();
+      if (key !== 'v' && key !== 'm' && key !== 'l') return;
+      const target = e.target as HTMLElement | null;
+      if (target) {
+        const tag = target.tagName;
+        if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return;
+        if (target.isContentEditable) return;
+      }
+      if (document.querySelector('[role="dialog"][data-state="open"]')) return;
+      if (key === 'v') {
+        if (activePlugins.has('measurement')) close('measurement');
+      } else if (key === 'm') {
+        if (measurementPlugin) toggle('measurement');
+      } else if (legendPlugin) {
+        toggle('legend');
+      }
+    }
+    window.addEventListener('keydown', handleToolHotkey);
+    return () => window.removeEventListener('keydown', handleToolHotkey);
+  }, [activePlugins, close, toggle, measurementPlugin, legendPlugin]);
 
   return (
     <TooltipProvider delayDuration={300}>

--- a/frontend/src/components/builder/SidebarRail.tsx
+++ b/frontend/src/components/builder/SidebarRail.tsx
@@ -115,7 +115,7 @@ export const SidebarRail = memo(function SidebarRail({
               <button
                 type="button"
                 aria-label={displayName}
-                // fix(#TBD B-049): at <1100px this rail is the ONLY layer list;
+                // fix(#526 B-049): at <1100px this rail is the ONLY layer list;
                 // selection was visual-only (data-selected). Mirror the Settings
                 // button's aria-pressed so AT users can tell which editor is open.
                 aria-pressed={isSelected}

--- a/frontend/src/components/builder/SidebarRail.tsx
+++ b/frontend/src/components/builder/SidebarRail.tsx
@@ -115,6 +115,10 @@ export const SidebarRail = memo(function SidebarRail({
               <button
                 type="button"
                 aria-label={displayName}
+                // fix(#TBD B-049): at <1100px this rail is the ONLY layer list;
+                // selection was visual-only (data-selected). Mirror the Settings
+                // button's aria-pressed so AT users can tell which editor is open.
+                aria-pressed={isSelected}
                 data-selected={isSelected ? 'true' : undefined}
                 className={cn(
                   'flex h-10 w-10 items-center justify-center rounded-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
@@ -143,6 +147,7 @@ export const SidebarRail = memo(function SidebarRail({
             <button
               type="button"
               aria-label={t('basemapGroup.railLabel', { defaultValue: 'Basemap group' })}
+              aria-pressed={basemapGroup.id === selectedLayerId}
               data-selected={basemapGroup.id === selectedLayerId ? 'true' : undefined}
               className={cn(
                 'flex h-10 w-10 items-center justify-center rounded-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',

--- a/frontend/src/components/builder/StackRow.tsx
+++ b/frontend/src/components/builder/StackRow.tsx
@@ -139,12 +139,15 @@ export const StackRow = memo(function StackRow({
     onCommit: (next) => onRename(layer.id, next),
   });
 
-  // Derived label indicator — mirrors map-sync.ts:795 gate exactly.
+  // Derived label indicator.
   // LabelConfig has no `enabled` field; `column` being set is the sole signal.
-  // Heatmap and symbol render modes suppress label rendering on the map, so we
-  // suppress the indicator too to avoid false positives.
+  // Heatmap suppresses label rendering on the map, so suppress the indicator
+  // too. Symbol mode does NOT suppress labels — it renders the text
+  // consolidated in the primary symbol layer (symbol-adapter symbolLayout),
+  // so the old renderMode !== 'symbol' clause was a false negative: a symbol
+  // point with labels showed text on the map but no badge. fix(#TBD B-042)
   const renderMode = (layer.style_config as Record<string, unknown> | null | undefined)?.render_mode as string | undefined;
-  const hasLabels = !!layer.label_config?.column && renderMode !== 'heatmap' && renderMode !== 'symbol';
+  const hasLabels = !!layer.label_config?.column && renderMode !== 'heatmap';
 
   function handleDragHandleKeyDown(e: KeyboardEvent<HTMLButtonElement>) {
     const isToggleKey = e.key === ' ' || e.key === 'Spacebar' || e.key === 'Enter';

--- a/frontend/src/components/builder/StackRow.tsx
+++ b/frontend/src/components/builder/StackRow.tsx
@@ -145,7 +145,7 @@ export const StackRow = memo(function StackRow({
   // too. Symbol mode does NOT suppress labels — it renders the text
   // consolidated in the primary symbol layer (symbol-adapter symbolLayout),
   // so the old renderMode !== 'symbol' clause was a false negative: a symbol
-  // point with labels showed text on the map but no badge. fix(#TBD B-042)
+  // point with labels showed text on the map but no badge. fix(#526 B-042)
   const renderMode = (layer.style_config as Record<string, unknown> | null | undefined)?.render_mode as string | undefined;
   const hasLabels = !!layer.label_config?.column && renderMode !== 'heatmap';
 

--- a/frontend/src/components/builder/ZoomExpressionEditor.tsx
+++ b/frontend/src/components/builder/ZoomExpressionEditor.tsx
@@ -127,7 +127,7 @@ export function ZoomExpressionEditor({
   }
 
   function updateStop(index: number, patch: Partial<{ zoom: number; value: number }>) {
-    // fix(#TBD B-043): clamp manually-typed stop values to the property's
+    // fix(#526 B-043): clamp manually-typed stop values to the property's
     // range — the <Input min/max> attributes are advisory only, and
     // validateZoomExpressionDraft checks finiteness/zoom order but never the
     // value range, so out-of-spec paint (circle-radius 0, negative
@@ -262,7 +262,7 @@ export function ZoomExpressionEditor({
                 step={step}
                 value={numericInputValue(draft.baseValue)}
                 onChange={(event) => {
-                  // fix(#TBD B-043): same manual-typing clamp as updateStop.
+                  // fix(#526 B-043): same manual-typing clamp as updateStop.
                   const raw = event.currentTarget.valueAsNumber;
                   emitDraft({
                     ...draft,

--- a/frontend/src/components/builder/ZoomExpressionEditor.tsx
+++ b/frontend/src/components/builder/ZoomExpressionEditor.tsx
@@ -127,9 +127,19 @@ export function ZoomExpressionEditor({
   }
 
   function updateStop(index: number, patch: Partial<{ zoom: number; value: number }>) {
+    // fix(#TBD B-043): clamp manually-typed stop values to the property's
+    // range — the <Input min/max> attributes are advisory only, and
+    // validateZoomExpressionDraft checks finiteness/zoom order but never the
+    // value range, so out-of-spec paint (circle-radius 0, negative
+    // line-width, opacity > 1) reached MapLibre. addStop already clamps;
+    // typing was the inconsistent path.
+    const clamped =
+      patch.value !== undefined && isFiniteNumber(patch.value)
+        ? { ...patch, value: clampValue(patch.value, min, max) }
+        : patch;
     emitDraft({
       ...draft,
-      stops: draft.stops.map((stop, stopIndex) => (stopIndex === index ? { ...stop, ...patch } : stop)),
+      stops: draft.stops.map((stop, stopIndex) => (stopIndex === index ? { ...stop, ...clamped } : stop)),
     });
   }
 
@@ -251,7 +261,14 @@ export function ZoomExpressionEditor({
                 max={max}
                 step={step}
                 value={numericInputValue(draft.baseValue)}
-                onChange={(event) => emitDraft({ ...draft, baseValue: event.currentTarget.valueAsNumber })}
+                onChange={(event) => {
+                  // fix(#TBD B-043): same manual-typing clamp as updateStop.
+                  const raw = event.currentTarget.valueAsNumber;
+                  emitDraft({
+                    ...draft,
+                    baseValue: isFiniteNumber(raw) ? clampValue(raw, min, max) : raw,
+                  });
+                }}
               />
             </div>
           )}

--- a/frontend/src/components/builder/__tests__/StackRow.test.tsx
+++ b/frontend/src/components/builder/__tests__/StackRow.test.tsx
@@ -681,7 +681,7 @@ describe('label indicator', () => {
     expect(screen.queryByTestId('label-indicator')).not.toBeInTheDocument();
   });
 
-  // fix(#TBD B-042): INVERTED — symbol mode renders label text consolidated in
+  // fix(#526 B-042): INVERTED — symbol mode renders label text consolidated in
   // the primary symbol layer, so a symbol point with label_config.column DOES
   // show text on the map and must show the badge (the old suppression was a
   // false negative built on a wrong comment).

--- a/frontend/src/components/builder/__tests__/StackRow.test.tsx
+++ b/frontend/src/components/builder/__tests__/StackRow.test.tsx
@@ -681,7 +681,11 @@ describe('label indicator', () => {
     expect(screen.queryByTestId('label-indicator')).not.toBeInTheDocument();
   });
 
-  it('symbol-suppression: shows no indicator when label_config.column is set but render_mode is symbol', () => {
+  // fix(#TBD B-042): INVERTED — symbol mode renders label text consolidated in
+  // the primary symbol layer, so a symbol point with label_config.column DOES
+  // show text on the map and must show the badge (the old suppression was a
+  // false negative built on a wrong comment).
+  it('symbol mode: shows the indicator when label_config.column is set', () => {
     const layer = makeLayer({
       id: 'symbol-layer',
       label_config: { column: 'name' },
@@ -689,6 +693,6 @@ describe('label indicator', () => {
     });
     render(<StackRow {...defaultProps({ layer })} />);
 
-    expect(screen.queryByTestId('label-indicator')).not.toBeInTheDocument();
+    expect(screen.getByTestId('label-indicator')).toBeInTheDocument();
   });
 });

--- a/frontend/src/components/builder/hooks/__tests__/use-filtered-feature-count.test.ts
+++ b/frontend/src/components/builder/hooks/__tests__/use-filtered-feature-count.test.ts
@@ -171,8 +171,13 @@ describe('useFilteredFeatureCount', () => {
       useFilteredFeatureCount(mockMap as never, layer),
     );
     expect(mockMap.getLayer).toHaveBeenCalledWith('layer-abc');
+    // fix(#TBD B-046): the count now spans the adapter's FULL sublayer set
+    // (this fill layer: primary + outline + extrusion companions; the mock
+    // getLayer reports every id present) — a mixed layer's points/lines and a
+    // cluster's bubbles render on siblings, so the primary-only count read 0
+    // while the map plainly showed features.
     expect(mockMap.queryRenderedFeatures).toHaveBeenCalledWith(undefined, {
-      layers: ['layer-abc'],
+      layers: ['layer-abc', 'layer-abc-outline', 'layer-abc-extrusion'],
     });
     expect(result.current).toBe(2);
   });

--- a/frontend/src/components/builder/hooks/__tests__/use-filtered-feature-count.test.ts
+++ b/frontend/src/components/builder/hooks/__tests__/use-filtered-feature-count.test.ts
@@ -171,7 +171,7 @@ describe('useFilteredFeatureCount', () => {
       useFilteredFeatureCount(mockMap as never, layer),
     );
     expect(mockMap.getLayer).toHaveBeenCalledWith('layer-abc');
-    // fix(#TBD B-046): the count now spans the adapter's FULL sublayer set
+    // fix(#526 B-046): the count now spans the adapter's FULL sublayer set
     // (this fill layer: primary + outline + extrusion companions; the mock
     // getLayer reports every id present) — a mixed layer's points/lines and a
     // cluster's bubbles render on siblings, so the primary-only count read 0

--- a/frontend/src/components/builder/hooks/use-filtered-feature-count.ts
+++ b/frontend/src/components/builder/hooks/use-filtered-feature-count.ts
@@ -17,6 +17,8 @@
 import { useEffect, useState } from 'react';
 import type { Map as MaplibreMap } from 'maplibre-gl';
 import type { MapLayerResponse } from '@/types/api';
+import { getAdapter } from '../layer-adapters/registry';
+import { resolveAdapterType } from '../layer-adapters/shared';
 
 export function useFilteredFeatureCount(
   map: MaplibreMap | null,
@@ -25,6 +27,13 @@ export function useFilteredFeatureCount(
   const [count, setCount] = useState<number | null>(null);
   const layerId = layer?.id ?? null;
   const layerFilter = layer?.filter ?? null;
+  // fix(#TBD B-046): resolved adapter type (a stable string) so the count can
+  // query the adapter's full sublayer-id set (mixed families, cluster bubbles).
+  const adapterType = resolveAdapterType(
+    layer?.dataset_geometry_type ?? null,
+    layer?.style_config ?? null,
+    (layer?.paint ?? undefined) as Record<string, unknown> | undefined,
+  );
 
   useEffect(() => {
     if (!map) return;
@@ -48,13 +57,18 @@ export function useFilteredFeatureCount(
       // use-layer-map-sync.ts), NOT the raw layer.id UUID. Querying the bare
       // UUID always missed, so the count was permanently null and the
       // "0 features after filter" hint (EASY-18) never fired.
-      const mapLayerId = `layer-${layerId}`;
-      const layerExistsOnMap = !!map.getLayer(mapLayerId);
-      if (!layerExistsOnMap) {
+      // fix(#TBD B-046): query the adapter's FULL layer-id set, not just the
+      // primary id — a mixed layer's points/lines render on sibling sublayers
+      // and a clustered layer's features render on the cluster bubbles, so the
+      // primary-only count read 0 while the map plainly showed features,
+      // firing the destructive "0 features in view — Clear filter" hint.
+      const candidateIds = getAdapter(adapterType).getLayerIds(`layer-${layerId}`);
+      const presentIds = candidateIds.filter((id) => !!map.getLayer(id));
+      if (presentIds.length === 0) {
         setCount(null);
         return;
       }
-      const features = map.queryRenderedFeatures(undefined, { layers: [mapLayerId] });
+      const features = map.queryRenderedFeatures(undefined, { layers: presentIds });
       setCount(features.length);
     }
 
@@ -77,7 +91,7 @@ export function useFilteredFeatureCount(
   // dispatchLayerAction on every mutation (opacity, paint, visibility), which
   // would cause queryRenderedFeatures to fire at ~60 fps during slider drags.
   // `layerId` and `layerFilter` cover all meaningful change conditions.
-  }, [map, layerId, layerFilter]);
+  }, [map, layerId, layerFilter, adapterType]);
 
   return count;
 }

--- a/frontend/src/components/builder/hooks/use-filtered-feature-count.ts
+++ b/frontend/src/components/builder/hooks/use-filtered-feature-count.ts
@@ -27,7 +27,7 @@ export function useFilteredFeatureCount(
   const [count, setCount] = useState<number | null>(null);
   const layerId = layer?.id ?? null;
   const layerFilter = layer?.filter ?? null;
-  // fix(#TBD B-046): resolved adapter type (a stable string) so the count can
+  // fix(#526 B-046): resolved adapter type (a stable string) so the count can
   // query the adapter's full sublayer-id set (mixed families, cluster bubbles).
   const adapterType = resolveAdapterType(
     layer?.dataset_geometry_type ?? null,
@@ -57,7 +57,7 @@ export function useFilteredFeatureCount(
       // use-layer-map-sync.ts), NOT the raw layer.id UUID. Querying the bare
       // UUID always missed, so the count was permanently null and the
       // "0 features after filter" hint (EASY-18) never fired.
-      // fix(#TBD B-046): query the adapter's FULL layer-id set, not just the
+      // fix(#526 B-046): query the adapter's FULL layer-id set, not just the
       // primary id — a mixed layer's points/lines render on sibling sublayers
       // and a clustered layer's features render on the cluster bubbles, so the
       // primary-only count read 0 while the map plainly showed features,

--- a/frontend/src/components/builder/layer-adapters/symbol-adapter.ts
+++ b/frontend/src/components/builder/layer-adapters/symbol-adapter.ts
@@ -110,7 +110,7 @@ function symbolLayout(input: AdapterLayerInput): Record<string, unknown> {
     layout['text-field'] = ['get', lc.column];
     layout['text-size'] = lc.fontSize ?? 12;
     layout['text-font'] = [...LABEL_FONT_STACK];
-    // fix(#TBD B-042): default anchor/offset must match the companion-label
+    // fix(#526 B-042): default anchor/offset must match the companion-label
     // path AND what LabelEditor displays (center / DEFAULT_POINT_LABEL_OFFSET).
     // The old 'top'/[0,1.2] defaults meant the editor showed Center/0/-1.5
     // while the map drew top/0/1.2, and the first Offset-X drag snapped the

--- a/frontend/src/components/builder/layer-adapters/symbol-adapter.ts
+++ b/frontend/src/components/builder/layer-adapters/symbol-adapter.ts
@@ -3,7 +3,7 @@ import type { AdapterLayerInput, LayerAdapter } from './types';
 import { syncOwnedLayoutProperties, syncOwnedPaintProperties, syncSingleLayerVisibility, syncLayerFilter } from './shared';
 import { MAP_COLORS } from '@/lib/map-colors';
 import type { SymbolStyleConfig } from '@/types/api';
-import { LABEL_FONT_STACK } from '../label-layer-utils';
+import { DEFAULT_POINT_LABEL_OFFSET, LABEL_FONT_STACK } from '../label-layer-utils';
 
 const DEFAULT_ICON = 'marker';
 const GEOLENS_SPRITE_ID = 'geolens';
@@ -110,8 +110,13 @@ function symbolLayout(input: AdapterLayerInput): Record<string, unknown> {
     layout['text-field'] = ['get', lc.column];
     layout['text-size'] = lc.fontSize ?? 12;
     layout['text-font'] = [...LABEL_FONT_STACK];
-    layout['text-anchor'] = lc.textAnchor ?? 'top';
-    layout['text-offset'] = lc.textOffset ?? [0, 1.2];
+    // fix(#TBD B-042): default anchor/offset must match the companion-label
+    // path AND what LabelEditor displays (center / DEFAULT_POINT_LABEL_OFFSET).
+    // The old 'top'/[0,1.2] defaults meant the editor showed Center/0/-1.5
+    // while the map drew top/0/1.2, and the first Offset-X drag snapped the
+    // text across the point.
+    layout['text-anchor'] = lc.textAnchor ?? 'center';
+    layout['text-offset'] = lc.textOffset ?? [...DEFAULT_POINT_LABEL_OFFSET];
     layout['text-allow-overlap'] = lc.allowOverlap ?? false;
     layout['text-max-width'] = 10;
   }

--- a/frontend/src/i18n/locales/de/builder.json
+++ b/frontend/src/i18n/locales/de/builder.json
@@ -747,7 +747,8 @@
     "bannerUnavailableTitle": "Die KI ist nicht verfügbar",
     "bannerUnavailableBody": "Der KI-Dienst ist vorübergehend nicht verfügbar. Versuchen Sie es gleich noch einmal.",
     "bannerRetry": "Erneut versuchen",
-    "bannerDismiss": "Schließen"
+    "bannerDismiss": "Schließen",
+    "errorRateLimited": "Tägliches KI-Nutzungslimit erreicht. Versuchen Sie es morgen erneut oder bitten Sie einen Admin, das Budget zu erhöhen."
   },
   "basemap": {
     "title": "Basiskarte",
@@ -1031,7 +1032,7 @@
       "measure": "Mess-Werkzeug",
       "legend": "Legende ein-/ausblenden",
       "showSheet": "Diesen Dialog anzeigen",
-      "reorderToggle": "Sortiermodus umschalten (fokussierte Ebenenzeile)",
+      "reorderToggle": "Sortiermodus umschalten (fokussierter Ziehgriff)",
       "reorderMove": "Ebene nach oben / unten verschieben (Sortiermodus)",
       "escape": "Panel schließen / Auswahl aufheben / Sortiermodus beenden",
       "multiSelect": "Ebene zur Auswahl hinzufügen/entfernen",

--- a/frontend/src/i18n/locales/en/builder.json
+++ b/frontend/src/i18n/locales/en/builder.json
@@ -747,7 +747,8 @@
     "bannerUnavailableTitle": "AI is unavailable",
     "bannerUnavailableBody": "The AI service is temporarily unavailable. Try again in a moment.",
     "bannerRetry": "Retry",
-    "bannerDismiss": "Dismiss"
+    "bannerDismiss": "Dismiss",
+    "errorRateLimited": "Daily AI usage limit reached. Try again tomorrow or ask an admin to raise the budget."
   },
   "basemap": {
     "title": "Basemap",
@@ -1035,7 +1036,7 @@
       "measure": "Measure tool",
       "legend": "Toggle legend",
       "showSheet": "Show this dialog",
-      "reorderToggle": "Toggle reorder mode (focused layer row)",
+      "reorderToggle": "Toggle reorder mode (focused drag handle)",
       "reorderMove": "Move layer up / down (reorder mode)",
       "escape": "Close panel / clear selection / exit reorder",
       "multiSelect": "Toggle layer in selection",

--- a/frontend/src/i18n/locales/es/builder.json
+++ b/frontend/src/i18n/locales/es/builder.json
@@ -747,7 +747,8 @@
     "bannerUnavailableTitle": "La IA no está disponible",
     "bannerUnavailableBody": "El servicio de IA no está disponible temporalmente. Inténtalo de nuevo en un momento.",
     "bannerRetry": "Reintentar",
-    "bannerDismiss": "Descartar"
+    "bannerDismiss": "Descartar",
+    "errorRateLimited": "Se alcanzó el límite diario de uso de IA. Inténtalo de nuevo mañana o pide a un administrador que aumente el presupuesto."
   },
   "basemap": {
     "title": "Mapa base",
@@ -1031,7 +1032,7 @@
       "measure": "Herramienta de medición",
       "legend": "Mostrar/ocultar leyenda",
       "showSheet": "Mostrar este diálogo",
-      "reorderToggle": "Alternar modo de reordenación (fila de capa enfocada)",
+      "reorderToggle": "Alternar modo de reordenación (asa de arrastre enfocada)",
       "reorderMove": "Mover capa arriba / abajo (modo de reordenación)",
       "escape": "Cerrar panel / borrar selección / salir de reordenación",
       "multiSelect": "Alternar capa en la selección",

--- a/frontend/src/i18n/locales/fr/builder.json
+++ b/frontend/src/i18n/locales/fr/builder.json
@@ -747,7 +747,8 @@
     "bannerUnavailableTitle": "L'IA est indisponible",
     "bannerUnavailableBody": "Le service d'IA est temporairement indisponible. Réessayez dans un instant.",
     "bannerRetry": "Réessayer",
-    "bannerDismiss": "Ignorer"
+    "bannerDismiss": "Ignorer",
+    "errorRateLimited": "Limite quotidienne d'utilisation de l'IA atteinte. Réessayez demain ou demandez à un administrateur d'augmenter le budget."
   },
   "basemap": {
     "title": "Fond de carte",
@@ -1031,7 +1032,7 @@
       "measure": "Outil de mesure",
       "legend": "Afficher/masquer la légende",
       "showSheet": "Afficher cette boîte de dialogue",
-      "reorderToggle": "Basculer le mode de réorganisation (ligne de couche active)",
+      "reorderToggle": "Basculer le mode de réorganisation (poignée de déplacement active)",
       "reorderMove": "Déplacer la couche vers le haut / bas (mode réorganisation)",
       "escape": "Fermer le panneau / effacer la sélection / quitter la réorganisation",
       "multiSelect": "Basculer la couche dans la sélection",

--- a/frontend/src/lib/maplibre-filter-utils.ts
+++ b/frontend/src/lib/maplibre-filter-utils.ts
@@ -327,7 +327,15 @@ function sanitizeFilterNode(node: unknown): unknown {
     ];
   }
 
-  return node.map((child, index) => index === 0 ? child : sanitizeFilterNode(child));
+  // fix(#TBD B-045): recurse only through combinator/negation wrappers. The
+  // previous fallthrough walked EVERY child, so opaque out-of-subset
+  // expressions (case/match/step/coalesce operands) had nested numeric
+  // comparisons rewritten to the nullable-safe form — breaking the verbatim
+  // round-trip contract for imported/hand-authored advanced filters.
+  if (node[0] === 'all' || node[0] === 'any' || node[0] === '!') {
+    return node.map((child, index) => (index === 0 ? child : sanitizeFilterNode(child)));
+  }
+  return node;
 }
 
 export function sanitizeNullableNumericFilter(

--- a/frontend/src/lib/maplibre-filter-utils.ts
+++ b/frontend/src/lib/maplibre-filter-utils.ts
@@ -327,7 +327,7 @@ function sanitizeFilterNode(node: unknown): unknown {
     ];
   }
 
-  // fix(#TBD B-045): recurse only through combinator/negation wrappers. The
+  // fix(#526 B-045): recurse only through combinator/negation wrappers. The
   // previous fallthrough walked EVERY child, so opaque out-of-subset
   // expressions (case/match/step/coalesce operands) had nested numeric
   // comparisons rewritten to the nullable-safe form — breaking the verbatim

--- a/frontend/src/pages/MapBuilderPage.tsx
+++ b/frontend/src/pages/MapBuilderPage.tsx
@@ -1821,6 +1821,10 @@ export function MapBuilderPage() {
         })}
         layers={layers.localLayers}
         isAdding={addLayer.isPending}
+        // fix(#TBD B-050): which dataset is in flight — the global isAdding
+        // flag disabled every Add button with no per-row feedback, so the user
+        // couldn't tell whether their click registered.
+        addingDatasetId={addLayer.isPending ? (addLayer.variables?.data?.dataset_id ?? null) : null}
         showShare={dialogs.showShare}
         onShowShareChange={dialogs.setShowShare}
         hasUnsavedChanges={layers.hasUnsavedChanges}

--- a/frontend/src/pages/MapBuilderPage.tsx
+++ b/frontend/src/pages/MapBuilderPage.tsx
@@ -1821,7 +1821,7 @@ export function MapBuilderPage() {
         })}
         layers={layers.localLayers}
         isAdding={addLayer.isPending}
-        // fix(#TBD B-050): which dataset is in flight — the global isAdding
+        // fix(#526 B-050): which dataset is in flight — the global isAdding
         // flag disabled every Add button with no per-row feedback, so the user
         // couldn't tell whether their click registered.
         addingDatasetId={addLayer.isPending ? (addLayer.variables?.data?.dataset_id ?? null) : null}


### PR DESCRIPTION
Third wave of the 2026-07-15 builder-audit remediation (P1 waves: #524, #525). All ten S-effort P2 MEDIUMs. Internal report: `docs-internal/audits/builder-audit-20260715.md`.

## Changes

- **B-041** (`MapToolbar.tsx`, `KeyboardShortcutsSheet.tsx`): the shortcuts sheet and toolbar tooltips advertised V/M/L hotkeys that were wired to nothing. The handlers now exist (guarded like the `?` hotkey: no-op while typing, with modifiers, or with a dialog open), and the sheet's reorder row is corrected to "focused drag handle — Space / Enter" (Enter on a row opens the editor).
- **B-042** (`symbol-adapter.ts`, `StackRow.tsx`): symbol-mode label text defaults now match the companion path and what LabelEditor displays (`center` / `[0,-1.5]` instead of `top` / `[0,1.2]` — the first Offset drag used to snap the text across the point). The stack "Labels on" badge no longer suppresses symbol mode, whose primary layer does render the label text (the suppression comment was factually wrong; test pin inverted).
- **B-043** (`ZoomExpressionEditor.tsx`): manually-typed stop/base values clamp to the property's min/max — `addStop` already clamped, typing bypassed it, letting circle-radius 0 / negative line-width / opacity>1 reach MapLibre.
- **B-044** (`style_json.py`): the per-layer zoom range (builder-private `_minzoom`/`_maxzoom` layout keys) is re-emitted as spec-level layer `minzoom`/`maxzoom` on export; defaults (0/22) are omitted. Two new export tests.
- **B-045** (`maplibre-filter-utils.ts`): `sanitizeFilterNode` recurses only through `all`/`any`/`!` wrappers — it previously walked every child, rewriting numeric comparisons inside opaque `case`/`match`/`step` expressions and breaking their verbatim round-trip.
- **B-046** (`use-filtered-feature-count.ts`): the "0 features in view" hint counts across the adapter's full sublayer-id set (mixed families render on `-points`/`-lines`, clustered features on the bubble layer), so it no longer shows a false destructive "Clear filter" prompt while the map plainly shows features. Existing pin updated to the new contract.
- **B-047** (`ChatPanel.tsx` + 4 locales): HTTP 429 (daily AI token budget) is classified as non-retryable and surfaces a real over-budget message (`chat.errorRateLimited`, added to en/es/fr/de) instead of a wasted duplicate POST and a generic error.
- **B-048** (`router_sharing.py`): the `/maps/shared/{token}/card` route — the URL the primary "Copy Link" affordance copies — returns a 200 SPA-redirect shell (meta-refresh to `/m/{token}`, `Cache-Control: no-store`) for invalid/expired/private links instead of bare JSON 404, so recipients land on the friendly "link expired" view. No map details are rendered on the fallback path (tests assert no title/og: metadata leak).
- **B-049** (`SidebarRail.tsx`): the collapsed rail (<1100px, the only layer list) exposes selection via `aria-pressed`, mirroring its own Settings button.
- **B-050** (`DatasetSearchPanel.tsx`, `BuilderDialogs.tsx`, `MapBuilderPage.tsx`): a per-row in-flight spinner + `aria-busy` on the clicked Add button (`addingDatasetId` threaded from the addLayer mutation's variables) — the global disabled state gave no feedback about which click registered.

## Verification

- Frontend: lint + typecheck clean; `npm run test:i18n` 4/4; builder+viewer+lib vitest **2598/2598** (updated pins: inverted symbol-badge expectation, full-sublayer count contract)
- Backend: ruff clean; maps/og-image/style-json/sharing suites green (**91 passed**) incl. two new zoom-range export tests and the card-route contract updates
- Live browser smoke: M/V/L drive the toolbar (measure toggle, pan restore, legend toggle) with the typing guard confirmed (no tool switch while editing the map name); `curl` of the card route with a bogus token returns the 200 no-store redirect shell with zero metadata

## Notes

Deferred from the audit's P2 list (tracked in the report): B-051/B-052 (M-effort refactors: sync-effect structural early-out under the SP-03 constraint; group-row discriminated union) and B-053 (ephemeral promote-to-layer — needs a product decision), plus the B-054 LOW rollup.