### PR TITLE
fix(builder): user-visible B-054 quick wins from the 2026-07-15 audit

### DIFF
--- a/backend/app/modules/catalog/maps/style_json.py
+++ b/backend/app/modules/catalog/maps/style_json.py
@@ -470,7 +470,7 @@ def _symbol_layout_from_style(
         next_layout["icon-offset"] = symbol["iconOffset"]
     if label_config and label_config.get("column"):
         next_layout.update(_label_layout(label_config))
-    # fix(#TBD B-054/LB-04): mirror the live adapter — the label overlap
+    # fix(#527 B-054/LB-04): mirror the live adapter — the label overlap
     # toggle governs the icon too, gated on an active label column.
     next_layout["icon-allow-overlap"] = not (
         label_config
@@ -974,7 +974,7 @@ def _style_layer_for_map_layer(
         )
         base["paint"] = {
             **paint,
-            # fix(#TBD B-054/S-05): the live adapter always drives icon-opacity
+            # fix(#527 B-054/S-05): the live adapter always drives icon-opacity
             # from the master opacity; export omitted it entirely.
             "icon-opacity": layer.opacity,
             **(_label_paint(label_config) if label_config else {}),

--- a/backend/app/modules/catalog/maps/style_json.py
+++ b/backend/app/modules/catalog/maps/style_json.py
@@ -470,6 +470,13 @@ def _symbol_layout_from_style(
         next_layout["icon-offset"] = symbol["iconOffset"]
     if label_config and label_config.get("column"):
         next_layout.update(_label_layout(label_config))
+    # fix(#TBD B-054/LB-04): mirror the live adapter — the label overlap
+    # toggle governs the icon too, gated on an active label column.
+    next_layout["icon-allow-overlap"] = not (
+        label_config
+        and label_config.get("column")
+        and label_config.get("allowOverlap") is False
+    )
     return next_layout
 
 
@@ -967,6 +974,9 @@ def _style_layer_for_map_layer(
         )
         base["paint"] = {
             **paint,
+            # fix(#TBD B-054/S-05): the live adapter always drives icon-opacity
+            # from the master opacity; export omitted it entirely.
+            "icon-opacity": layer.opacity,
             **(_label_paint(label_config) if label_config else {}),
         }
     elif label_config.get("column") and layer_type not in {

--- a/backend/app/processing/ai/chat_validation.py
+++ b/backend/app/processing/ai/chat_validation.py
@@ -44,11 +44,15 @@ def _build_chat_actions(raw_actions: list[dict]) -> tuple[list[ChatAction], list
 
 
 def _extract_get_refs(expr: list | None) -> set[str]:
-    """Recursively extract column names from ["get", "col"] expression nodes."""
+    """Recursively extract column names from ["get"/"has", "col"] nodes.
+
+    fix(#TBD B-054/F-04): ["has", col] refs count too — a hallucinated
+    has-column filter previously passed validation and hid every feature.
+    """
     if not isinstance(expr, list) or len(expr) == 0:
         return set()
     refs: set[str] = set()
-    if len(expr) >= 2 and expr[0] == "get" and isinstance(expr[1], str):
+    if len(expr) >= 2 and expr[0] in ("get", "has") and isinstance(expr[1], str):
         refs.add(expr[1])
     for item in expr:
         if isinstance(item, list):

--- a/backend/app/processing/ai/chat_validation.py
+++ b/backend/app/processing/ai/chat_validation.py
@@ -46,7 +46,7 @@ def _build_chat_actions(raw_actions: list[dict]) -> tuple[list[ChatAction], list
 def _extract_get_refs(expr: list | None) -> set[str]:
     """Recursively extract column names from ["get"/"has", "col"] nodes.
 
-    fix(#TBD B-054/F-04): ["has", col] refs count too — a hallucinated
+    fix(#527 B-054/F-04): ["has", col] refs count too — a hallucinated
     has-column filter previously passed validation and hid every feature.
     """
     if not isinstance(expr, list) or len(expr) == 0:

--- a/backend/tests/test_builder_audit_p1_13_ai_filter_validation.py
+++ b/backend/tests/test_builder_audit_p1_13_ai_filter_validation.py
@@ -133,3 +133,19 @@ async def test_malformed_arity_rejected():
     assert validated == []
     assert len(dropped) == 1
     assert "invalid filter expression" in dropped[0]
+
+
+# fix(#TBD B-054/F-04): ["has", col] refs are validated like ["get", col] —
+# a hallucinated has-column filter previously passed and hid every feature.
+@pytest.mark.anyio
+async def test_has_ref_against_known_column_accepted():
+    validated, dropped = await _run(_set_filter(["has", "status"]))
+    assert dropped == []
+    assert len(validated) == 1
+
+
+@pytest.mark.anyio
+async def test_has_ref_against_unknown_column_dropped():
+    validated, dropped = await _run(_set_filter(["has", "not_a_column"]))
+    assert validated == []
+    assert len(dropped) == 1

--- a/backend/tests/test_builder_audit_p1_13_ai_filter_validation.py
+++ b/backend/tests/test_builder_audit_p1_13_ai_filter_validation.py
@@ -135,7 +135,7 @@ async def test_malformed_arity_rejected():
     assert "invalid filter expression" in dropped[0]
 
 
-# fix(#TBD B-054/F-04): ["has", col] refs are validated like ["get", col] —
+# fix(#527 B-054/F-04): ["has", col] refs are validated like ["get", col] —
 # a hallucinated has-column filter previously passed and hid every feature.
 @pytest.mark.anyio
 async def test_has_ref_against_known_column_accepted():

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -1037,7 +1037,8 @@ def test_open_core_decomposition_boundaries_stay_clean() -> None:
     size_caps = {
         # fix(#526 B-044): per-layer minzoom/maxzoom in style.json export,
         # propagated to companion layers.
-        "backend/app/modules/catalog/maps/style_json.py": 1411,
+        # fix(#TBD B-054/S-05+LB-04): symbol icon-opacity + allow-overlap parity.
+        "backend/app/modules/catalog/maps/style_json.py": 1421,
         "backend/app/modules/catalog/maps/style_import.py": 450,
         "backend/app/modules/catalog/maps/style_sanitizers.py": 200,
         "backend/app/modules/catalog/maps/router_assets.py": 126,

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -1037,7 +1037,7 @@ def test_open_core_decomposition_boundaries_stay_clean() -> None:
     size_caps = {
         # fix(#526 B-044): per-layer minzoom/maxzoom in style.json export,
         # propagated to companion layers.
-        # fix(#TBD B-054/S-05+LB-04): symbol icon-opacity + allow-overlap parity.
+        # fix(#527 B-054/S-05+LB-04): symbol icon-opacity + allow-overlap parity.
         "backend/app/modules/catalog/maps/style_json.py": 1421,
         "backend/app/modules/catalog/maps/style_import.py": 450,
         "backend/app/modules/catalog/maps/style_sanitizers.py": 200,

--- a/backend/tests/test_maps_style_json.py
+++ b/backend/tests/test_maps_style_json.py
@@ -2064,3 +2064,37 @@ def test_export_omits_default_zoom_range():
     primary = next(entry for entry in exported if entry["id"].startswith("layer-"))
     assert "minzoom" not in primary
     assert "maxzoom" not in primary
+
+
+# fix(#TBD B-054/S-05 + LB-04): symbol export parity — master opacity drives
+# icon-opacity, and the label overlap toggle governs the icon.
+def test_symbol_export_emits_icon_opacity_from_master_opacity():
+    layer = _layer(
+        style_config={"render_mode": "symbol"},
+        opacity=0.4,
+        label_config=None,
+        paint={},
+    )
+    exported = style_json._style_layer_for_map_layer(layer, "src-1")
+    primary = next(e for e in exported if e["type"] == "symbol")
+    assert primary["paint"]["icon-opacity"] == 0.4
+
+
+def test_symbol_export_icon_allow_overlap_follows_label_toggle():
+    off = _layer(
+        style_config={"render_mode": "symbol"},
+        label_config={"column": "name", "allowOverlap": False},
+        paint={},
+    )
+    exported_off = style_json._style_layer_for_map_layer(off, "src-1")
+    primary_off = next(e for e in exported_off if e["type"] == "symbol")
+    assert primary_off["layout"]["icon-allow-overlap"] is False
+
+    default = _layer(
+        style_config={"render_mode": "symbol"},
+        label_config={"column": "name"},
+        paint={},
+    )
+    exported_default = style_json._style_layer_for_map_layer(default, "src-1")
+    primary_default = next(e for e in exported_default if e["type"] == "symbol")
+    assert primary_default["layout"]["icon-allow-overlap"] is True

--- a/backend/tests/test_maps_style_json.py
+++ b/backend/tests/test_maps_style_json.py
@@ -2066,7 +2066,7 @@ def test_export_omits_default_zoom_range():
     assert "maxzoom" not in primary
 
 
-# fix(#TBD B-054/S-05 + LB-04): symbol export parity — master opacity drives
+# fix(#527 B-054/S-05 + LB-04): symbol export parity — master opacity drives
 # icon-opacity, and the label overlap toggle governs the icon.
 def test_symbol_export_emits_icon_opacity_from_master_opacity():
     layer = _layer(

--- a/frontend/src/components/builder/ChatPanel.tsx
+++ b/frontend/src/components/builder/ChatPanel.tsx
@@ -465,11 +465,15 @@ export function ChatPanel({
       geojson.type === 'FeatureCollection' &&
       Array.isArray(action.bbox) &&
       action.bbox.length === 4 &&
-      action.bbox.every((n: unknown) => typeof n === 'number')
+      // fix(#TBD B-054/C-06): Number.isFinite — NaN passes typeof and every
+      // range comparison below, then throws in fitBounds.
+      action.bbox.every((n: unknown) => Number.isFinite(n))
     ) {
       const [minX, minY, maxX, maxY] = action.bbox as [number, number, number, number];
       // Phase 20260526-builder-audit #338 BLD-20260526-11: reject bbox values outside WGS84 bounds.
       if (minX < -180 || minY < -90 || maxX > 180 || maxY > 90) return;
+      // fix(#TBD B-054/C-06): inverted bounds also throw in fitBounds.
+      if (minX > maxX || minY > maxY) return;
       onQueryResult?.(
         geojson as GeoJSON.FeatureCollection,
         [minX, minY, maxX, maxY],

--- a/frontend/src/components/builder/ChatPanel.tsx
+++ b/frontend/src/components/builder/ChatPanel.tsx
@@ -465,14 +465,14 @@ export function ChatPanel({
       geojson.type === 'FeatureCollection' &&
       Array.isArray(action.bbox) &&
       action.bbox.length === 4 &&
-      // fix(#TBD B-054/C-06): Number.isFinite — NaN passes typeof and every
+      // fix(#527 B-054/C-06): Number.isFinite — NaN passes typeof and every
       // range comparison below, then throws in fitBounds.
       action.bbox.every((n: unknown) => Number.isFinite(n))
     ) {
       const [minX, minY, maxX, maxY] = action.bbox as [number, number, number, number];
       // Phase 20260526-builder-audit #338 BLD-20260526-11: reject bbox values outside WGS84 bounds.
       if (minX < -180 || minY < -90 || maxX > 180 || maxY > 90) return;
-      // fix(#TBD B-054/C-06): inverted bounds also throw in fitBounds.
+      // fix(#527 B-054/C-06): inverted bounds also throw in fitBounds.
       if (minX > maxX || minY > maxY) return;
       onQueryResult?.(
         geojson as GeoJSON.FeatureCollection,

--- a/frontend/src/components/builder/LayerFilterEditor.tsx
+++ b/frontend/src/components/builder/LayerFilterEditor.tsx
@@ -83,6 +83,7 @@ const OPERATORS_BY_TYPE: Record<ColumnType, OperatorDef[]> = {
   ],
   boolean: [
     { labelKey: 'filters.operators.equals', value: '==' },
+    { labelKey: 'filters.operators.notEquals', value: '!=' },
     { labelKey: 'filters.operators.isNull', value: 'is_null' },
     { value: 'has', labelKey: 'filters.operators.exists' },
   ],
@@ -153,6 +154,10 @@ export function buildFilterExpression(
       const coerced = values
         .map(v => coerceValue(v, pgType))
         .filter(v => !numericColumn || typeof v === 'number');
+      // fix(#TBD B-054/F-05): a list of only separators (",, ,") coerces to
+      // an empty literal — an always-false filter that silently hides every
+      // feature. Drop the condition instead.
+      if (coerced.length === 0) continue;
       const inExpr = ['in', ['get', cond.field], ['literal', coerced]];
       expressions.push(cond.operator === 'in_list' ? inExpr : ['!', inExpr]);
     } else if (cond.operator === 'contains') {
@@ -173,6 +178,7 @@ export function buildFilterExpression(
     }
   }
 
+  if (expressions.length === 0) return null;
   // Always wrap to preserve combinator intent on round-trip
   return [combinator, ...expressions] as FilterSpecification;
 }

--- a/frontend/src/components/builder/LayerFilterEditor.tsx
+++ b/frontend/src/components/builder/LayerFilterEditor.tsx
@@ -94,6 +94,11 @@ const OPERATORS_BY_TYPE: Record<ColumnType, OperatorDef[]> = {
   ],
 };
 
+// fix(#527 B-054/F-06, codex P3): boolean operators whose value renders as the
+// true/false select — a free-text input would coerce anything but "true" to
+// false and silently save e.g. `active != false`.
+const BOOLEAN_VALUE_OPERATORS = new Set(['==', '!=']);
+
 function coerceValue(value: string, pgType: string): string | number | boolean {
   const colType = classifyColumnType(pgType);
   if (colType === 'number') {
@@ -289,7 +294,7 @@ export function LayerFilterEditor({
       id: crypto.randomUUID(),
       field,
       operator,
-      value: getFieldType(field) === 'boolean' && operator === '==' ? 'true' : '',
+      value: getFieldType(field) === 'boolean' && BOOLEAN_VALUE_OPERATORS.has(operator) ? 'true' : '',
     };
     emitChange([...conditions, newCond]);
   }
@@ -308,12 +313,12 @@ export function LayerFilterEditor({
         const colType = getFieldType(patch.field);
         const ops = OPERATORS_BY_TYPE[colType];
         merged.operator = ops[0]?.value ?? '==';
-        merged.value = colType === 'boolean' && merged.operator === '==' ? 'true' : '';
+        merged.value = colType === 'boolean' && BOOLEAN_VALUE_OPERATORS.has(merged.operator) ? 'true' : '';
       }
 
       if (patch.operator && patch.operator !== c.operator) {
         const colType = getFieldType(merged.field);
-        if (colType === 'boolean' && patch.operator === '==' && !merged.value) {
+        if (colType === 'boolean' && BOOLEAN_VALUE_OPERATORS.has(patch.operator) && !merged.value) {
           merged.value = 'true';
         }
       }
@@ -566,7 +571,7 @@ export function LayerFilterEditor({
 
                   {/* Value input (hidden for is_null and has) */}
                   {cond.operator !== 'is_null' && cond.operator !== 'has' ? (
-                    getFieldType(cond.field) === 'boolean' && cond.operator === '==' ? (
+                    getFieldType(cond.field) === 'boolean' && BOOLEAN_VALUE_OPERATORS.has(cond.operator) ? (
                       <Select
                         value={cond.value || 'true'}
                         onValueChange={(val) => updateCondition(cond.id, { value: val })}

--- a/frontend/src/components/builder/LayerFilterEditor.tsx
+++ b/frontend/src/components/builder/LayerFilterEditor.tsx
@@ -154,7 +154,7 @@ export function buildFilterExpression(
       const coerced = values
         .map(v => coerceValue(v, pgType))
         .filter(v => !numericColumn || typeof v === 'number');
-      // fix(#TBD B-054/F-05): a list of only separators (",, ,") coerces to
+      // fix(#527 B-054/F-05): a list of only separators (",, ,") coerces to
       // an empty literal — an always-false filter that silently hides every
       // feature. Drop the condition instead.
       if (coerced.length === 0) continue;

--- a/frontend/src/components/builder/StyleColorPicker.tsx
+++ b/frontend/src/components/builder/StyleColorPicker.tsx
@@ -109,7 +109,9 @@ export function StyleColorPicker({ label, color, onChange }: StyleColorPickerPro
               <button
                 key={hex}
                 type="button"
-                onClick={() => onChange(hex)}
+                // fix(#TBD B-054/S-07): presets go through the same local-state
+                // path as the picker so the selected ring updates instantly.
+                onClick={() => debouncedChange(hex)}
                 className={cn(
                   'cursor-pointer w-5 h-5 rounded-sm border transition-transform hover:scale-125',
                   localColor === hex ? 'ring-2 ring-primary ring-offset-1 ring-offset-background' : 'border-border',

--- a/frontend/src/components/builder/StyleColorPicker.tsx
+++ b/frontend/src/components/builder/StyleColorPicker.tsx
@@ -109,7 +109,7 @@ export function StyleColorPicker({ label, color, onChange }: StyleColorPickerPro
               <button
                 key={hex}
                 type="button"
-                // fix(#TBD B-054/S-07): presets go through the same local-state
+                // fix(#527 B-054/S-07): presets go through the same local-state
                 // path as the picker so the selected ring updates instantly.
                 onClick={() => debouncedChange(hex)}
                 className={cn(

--- a/frontend/src/components/builder/__tests__/ChatPanel.test.tsx
+++ b/frontend/src/components/builder/__tests__/ChatPanel.test.tsx
@@ -135,7 +135,7 @@ describe('ChatPanel', () => {
     });
   });
 
-  // fix(#TBD B-054/C-06): NaN and inverted bboxes pass the range comparisons
+  // fix(#527 B-054/C-06): NaN and inverted bboxes pass the range comparisons
   // and throw in fitBounds downstream — both must be rejected.
   it.each([
     ['NaN bbox', [NaN, 40, -73, 41]],

--- a/frontend/src/components/builder/__tests__/ChatPanel.test.tsx
+++ b/frontend/src/components/builder/__tests__/ChatPanel.test.tsx
@@ -135,6 +135,34 @@ describe('ChatPanel', () => {
     });
   });
 
+  // fix(#TBD B-054/C-06): NaN and inverted bboxes pass the range comparisons
+  // and throw in fitBounds downstream — both must be rejected.
+  it.each([
+    ['NaN bbox', [NaN, 40, -73, 41]],
+    ['inverted bbox', [-73, 40, -74, 41]],
+  ])('does not call onQueryResult for a %s', async (_name, bbox) => {
+    const geojson = { type: 'FeatureCollection', features: [] };
+
+    mockStreamChat.mockImplementation(async function* () {
+      yield {
+        event: 'actions',
+        data: {
+          actions: [{ type: 'show_query_result', geojson, bbox }],
+        },
+      };
+      yield { event: 'done', data: { explanation: 'Results' } };
+    });
+
+    const user = userEvent.setup();
+    const props = renderPanel();
+    await typeAndSend(user, 'find features');
+
+    await waitFor(() => {
+      expect(screen.getByText('Results')).toBeInTheDocument();
+    });
+    expect(props.onQueryResult).not.toHaveBeenCalled();
+  });
+
   it('shows cancel button while loading and hides send button', async () => {
     let resolve!: () => void;
     const hang = new Promise<void>((r) => {

--- a/frontend/src/components/builder/__tests__/LayerFilterEditor.test.ts
+++ b/frontend/src/components/builder/__tests__/LayerFilterEditor.test.ts
@@ -668,3 +668,22 @@ describe('LayerFilterEditor - stale debounce cancellation (B-033)', () => {
     expect(lastEmitted).toEqual(['all', ['==', ['get', 'name'], 'typed']]);
   });
 });
+
+// ---------------------------------------------------------------------------
+// fix(#TBD B-054/F-05 + F-06): separators-only lists drop cleanly; boolean
+// columns support != end-to-end.
+// ---------------------------------------------------------------------------
+describe('separator-only in_list and boolean != (B-054/F-05, F-06)', () => {
+  it('drops an in_list of only separators instead of an always-false empty literal', () => {
+    const conditions = [{ id: '1', field: 'name', operator: 'in_list', value: ',, ,' }];
+    expect(buildFilterExpression(conditions, columns, 'all')).toBeNull();
+  });
+
+  it('emits != for boolean columns', () => {
+    const conditions = [{ id: '1', field: 'active', operator: '!=', value: 'true' }];
+    expect(buildFilterExpression(conditions, columns, 'all')).toEqual([
+      'all',
+      ['!=', ['get', 'active'], true],
+    ]);
+  });
+});

--- a/frontend/src/components/builder/__tests__/LayerFilterEditor.test.ts
+++ b/frontend/src/components/builder/__tests__/LayerFilterEditor.test.ts
@@ -686,4 +686,16 @@ describe('separator-only in_list and boolean != (B-054/F-05, F-06)', () => {
       ['!=', ['get', 'active'], true],
     ]);
   });
+
+  it('renders the true/false select (not a text input) for boolean != (codex P3 on #527)', () => {
+    render(createElement(LayerFilterEditor, {
+      columnInfo: [{ name: 'active', type: 'boolean' }],
+      filter: ['all', ['!=', ['get', 'active'], true]] as FilterSpecification,
+      onFilterChange: vi.fn(),
+    }));
+
+    const valueRow = screen.getByTestId('filter-value-row');
+    expect(within(valueRow).queryByRole('textbox', { name: 'Value' })).toBeNull();
+    expect(within(valueRow).getByRole('combobox', { name: 'Value' })).toBeInTheDocument();
+  });
 });

--- a/frontend/src/components/builder/__tests__/LayerFilterEditor.test.ts
+++ b/frontend/src/components/builder/__tests__/LayerFilterEditor.test.ts
@@ -670,7 +670,7 @@ describe('LayerFilterEditor - stale debounce cancellation (B-033)', () => {
 });
 
 // ---------------------------------------------------------------------------
-// fix(#TBD B-054/F-05 + F-06): separators-only lists drop cleanly; boolean
+// fix(#527 B-054/F-05 + F-06): separators-only lists drop cleanly; boolean
 // columns support != end-to-end.
 // ---------------------------------------------------------------------------
 describe('separator-only in_list and boolean != (B-054/F-05, F-06)', () => {

--- a/frontend/src/components/builder/layer-adapters/__tests__/symbol-adapter.test.ts
+++ b/frontend/src/components/builder/layer-adapters/__tests__/symbol-adapter.test.ts
@@ -103,3 +103,32 @@ describe('symbol-adapter — getLayerIds', () => {
     expect(ids).toEqual(['sym-abc']);
   });
 });
+
+describe('symbol-adapter — B-054/LB-04 icon-allow-overlap honors the label toggle', () => {
+  it('defaults to true with no label config', () => {
+    const map = createMockMap({ layerExists: false });
+    symbolAdapter.addLayers(map as unknown as import('maplibre-gl').Map, makeInput());
+    const call = map.addLayer.mock.calls[0][0] as { layout: Record<string, unknown> };
+    expect(call.layout['icon-allow-overlap']).toBe(true);
+  });
+
+  it('follows an explicit allowOverlap=false when a label column is active', () => {
+    const map = createMockMap({ layerExists: false });
+    symbolAdapter.addLayers(
+      map as unknown as import('maplibre-gl').Map,
+      makeInput({ label_config: { column: 'name', allowOverlap: false } }),
+    );
+    const call = map.addLayer.mock.calls[0][0] as { layout: Record<string, unknown> };
+    expect(call.layout['icon-allow-overlap']).toBe(false);
+  });
+
+  it('ignores a stale allowOverlap=false when the label column was cleared', () => {
+    const map = createMockMap({ layerExists: false });
+    symbolAdapter.addLayers(
+      map as unknown as import('maplibre-gl').Map,
+      makeInput({ label_config: { column: '', allowOverlap: false } }),
+    );
+    const call = map.addLayer.mock.calls[0][0] as { layout: Record<string, unknown> };
+    expect(call.layout['icon-allow-overlap']).toBe(true);
+  });
+});

--- a/frontend/src/components/builder/layer-adapters/symbol-adapter.ts
+++ b/frontend/src/components/builder/layer-adapters/symbol-adapter.ts
@@ -105,7 +105,10 @@ function symbolLayout(input: AdapterLayerInput): Record<string, unknown> {
     // fix(#527 B-054/LB-04): honor the label overlap toggle for the icon too —
     // hardcoded true meant "allow overlap: off" decluttered text only. Gated
     // on an active label column so a stale allowOverlap from a cleared label
-    // config can't hide icons with no visible control.
+    // config can't hide icons with no visible control. Deliberately EXPLICIT
+    // false only (codex P2 on #527 proposed default-off): an absent
+    // allowOverlap keeps icons overlapping so saved maps that never touched
+    // the toggle don't change rendering; text keeps its own ?? false default.
     'icon-allow-overlap': !(lc?.column && lc.allowOverlap === false),
     visibility: input.visible ? 'visible' : 'none',
   };

--- a/frontend/src/components/builder/layer-adapters/symbol-adapter.ts
+++ b/frontend/src/components/builder/layer-adapters/symbol-adapter.ts
@@ -102,7 +102,11 @@ function symbolLayout(input: AdapterLayerInput): Record<string, unknown> {
     'icon-rotate': symbol.iconRotation ?? 0,
     'icon-anchor': symbol.iconAnchor ?? 'center',
     'icon-offset': symbol.iconOffset ?? [0, 0],
-    'icon-allow-overlap': true,
+    // fix(#TBD B-054/LB-04): honor the label overlap toggle for the icon too —
+    // hardcoded true meant "allow overlap: off" decluttered text only. Gated
+    // on an active label column so a stale allowOverlap from a cleared label
+    // config can't hide icons with no visible control.
+    'icon-allow-overlap': !(lc?.column && lc.allowOverlap === false),
     visibility: input.visible ? 'visible' : 'none',
   };
 

--- a/frontend/src/components/builder/layer-adapters/symbol-adapter.ts
+++ b/frontend/src/components/builder/layer-adapters/symbol-adapter.ts
@@ -102,7 +102,7 @@ function symbolLayout(input: AdapterLayerInput): Record<string, unknown> {
     'icon-rotate': symbol.iconRotation ?? 0,
     'icon-anchor': symbol.iconAnchor ?? 'center',
     'icon-offset': symbol.iconOffset ?? [0, 0],
-    // fix(#TBD B-054/LB-04): honor the label overlap toggle for the icon too —
+    // fix(#527 B-054/LB-04): honor the label overlap toggle for the icon too —
     // hardcoded true meant "allow overlap: off" decluttered text only. Gated
     // on an active label column so a stale allowOverlap from a cleared label
     // config can't hide icons with no visible control.

--- a/frontend/src/components/viewer/ViewerChatPanel.tsx
+++ b/frontend/src/components/viewer/ViewerChatPanel.tsx
@@ -149,7 +149,7 @@ export function ViewerChatPanel({ mapId, layers, mapInstanceRef }: ViewerChatPan
       geojson.type === 'FeatureCollection' &&
       Array.isArray(action.bbox) &&
       action.bbox.length === 4 &&
-      // fix(#TBD B-054/C-06): Number.isFinite + non-inverted — NaN/inverted
+      // fix(#527 B-054/C-06): Number.isFinite + non-inverted — NaN/inverted
       // bounds pass the range comparisons and throw in fitBounds.
       action.bbox.every((n: unknown) => Number.isFinite(n))
     ) {

--- a/frontend/src/components/viewer/ViewerChatPanel.tsx
+++ b/frontend/src/components/viewer/ViewerChatPanel.tsx
@@ -149,10 +149,12 @@ export function ViewerChatPanel({ mapId, layers, mapInstanceRef }: ViewerChatPan
       geojson.type === 'FeatureCollection' &&
       Array.isArray(action.bbox) &&
       action.bbox.length === 4 &&
-      action.bbox.every((n: unknown) => typeof n === 'number')
+      // fix(#TBD B-054/C-06): Number.isFinite + non-inverted — NaN/inverted
+      // bounds pass the range comparisons and throw in fitBounds.
+      action.bbox.every((n: unknown) => Number.isFinite(n))
     ) {
       const [minX, minY, maxX, maxY] = action.bbox as [number, number, number, number];
-      if (!(minX < -180 || minY < -90 || maxX > 180 || maxY > 90)) {
+      if (!(minX < -180 || minY < -90 || maxX > 180 || maxY > 90 || minX > maxX || minY > maxY)) {
         handleQueryResult(geojson as GeoJSON.FeatureCollection, [minX, minY, maxX, maxY]);
       }
     }

--- a/frontend/src/lib/__tests__/color-ramps.test.ts
+++ b/frontend/src/lib/__tests__/color-ramps.test.ts
@@ -288,7 +288,7 @@ describe('suggestRampForMode', () => {
 });
 
 // ---------------------------------------------------------------------------
-// fix(#TBD B-054/S-03): empty categorical map emits the bare fallback, never a
+// fix(#527 B-054/S-03): empty categorical map emits the bare fallback, never a
 // zero-pair ['match'] (below spec minimum arity — addLayer throws, swallowed,
 // and the layer silently never renders).
 // ---------------------------------------------------------------------------

--- a/frontend/src/lib/__tests__/color-ramps.test.ts
+++ b/frontend/src/lib/__tests__/color-ramps.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import {
+  buildCategoricalExpression,
   buildGraduatedSizeExpression,
   getSizeProperty,
   getColorProperty,
@@ -283,5 +284,25 @@ describe('suggestRampForMode', () => {
 
   it('categorical default is nextRotatingRamp(categorical, 0)', () => {
     expect(suggestRampForMode('categorical')).toBe(nextRotatingRamp('categorical', 0));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// fix(#TBD B-054/S-03): empty categorical map emits the bare fallback, never a
+// zero-pair ['match'] (below spec minimum arity — addLayer throws, swallowed,
+// and the layer silently never renders).
+// ---------------------------------------------------------------------------
+describe('buildCategoricalExpression empty-map guard (B-054/S-03)', () => {
+  it('returns the bare fallback color when valueColorMap is empty', () => {
+    expect(buildCategoricalExpression('kind', [], '#aabbcc')).toBe('#aabbcc');
+  });
+
+  it('still emits the null-safe match expression when pairs exist', () => {
+    expect(buildCategoricalExpression('kind', [['a', '#111111']], '#aabbcc')).toEqual([
+      'case',
+      ['==', ['get', 'kind'], null],
+      '#aabbcc',
+      ['match', ['get', 'kind'], 'a', '#111111', '#aabbcc'],
+    ]);
   });
 });

--- a/frontend/src/lib/color-ramps.ts
+++ b/frontend/src/lib/color-ramps.ts
@@ -264,10 +264,17 @@ export function buildCategoricalExpression(
   column: string,
   valueColorMap: [unknown, string][],
   fallback: string,
-): unknown[] {
+): unknown[] | string {
   const pairs: unknown[] = [];
   for (const [value, color] of valueColorMap) {
     pairs.push(value, color);
+  }
+  if (pairs.length === 0) {
+    // fix(#TBD B-054/S-03): an empty/all-null column yields a zero-pair
+    // ['match', input, fallback] — below the spec's minimum arity, so
+    // addLayer throws (swallowed) and the layer silently never renders.
+    // Mirror of the symbol-adapter guard (B-024): emit the bare fallback.
+    return fallback;
   }
   const matchExpr = ['match', ['get', column], ...pairs, fallback];
   return ['case', ['==', ['get', column], null], fallback, matchExpr];

--- a/frontend/src/lib/color-ramps.ts
+++ b/frontend/src/lib/color-ramps.ts
@@ -270,7 +270,7 @@ export function buildCategoricalExpression(
     pairs.push(value, color);
   }
   if (pairs.length === 0) {
-    // fix(#TBD B-054/S-03): an empty/all-null column yields a zero-pair
+    // fix(#527 B-054/S-03): an empty/all-null column yields a zero-pair
     // ['match', input, fallback] — below the spec's minimum arity, so
     // addLayer throws (swallowed) and the layer silently never renders.
     // Mirror of the symbol-adapter guard (B-024): emit the bare fallback.

--- a/frontend/src/pages/MapBuilderPage.tsx
+++ b/frontend/src/pages/MapBuilderPage.tsx
@@ -1768,7 +1768,13 @@ export function MapBuilderPage() {
       </div>
 
       {/* Right rail + panel */}
-      {!isEditorHidden && <BuilderRail {...railProps} />}
+      {/* fix(#TBD B-054/U-08): boundary parity with the sidebar/map — a
+          HistoryPanel/Notes render error must not take down the builder. */}
+      {!isEditorHidden && (
+        <PanelErrorBoundary panelId="builder-rail">
+          <BuilderRail {...railProps} />
+        </PanelErrorBoundary>
+      )}
 
       {/* Mobile rail as Sheet overlay */}
       {isEditorHidden && railPanel && (
@@ -1789,7 +1795,9 @@ export function MapBuilderPage() {
               <SheetTitle>{railSheetTitle}</SheetTitle>
               <SheetDescription>{railSheetDescription}</SheetDescription>
             </SheetHeader>
-            <BuilderRail {...railProps} showRail={false} />
+            <PanelErrorBoundary panelId="builder-rail-sheet">
+              <BuilderRail {...railProps} showRail={false} />
+            </PanelErrorBoundary>
           </SheetContent>
         </Sheet>
       )}

--- a/frontend/src/pages/MapBuilderPage.tsx
+++ b/frontend/src/pages/MapBuilderPage.tsx
@@ -1768,7 +1768,7 @@ export function MapBuilderPage() {
       </div>
 
       {/* Right rail + panel */}
-      {/* fix(#TBD B-054/U-08): boundary parity with the sidebar/map — a
+      {/* fix(#527 B-054/U-08): boundary parity with the sidebar/map — a
           HistoryPanel/Notes render error must not take down the builder. */}
       {!isEditorHidden && (
         <PanelErrorBoundary panelId="builder-rail">


### PR DESCRIPTION
## Summary

Nine S-effort LOW findings from `docs-internal/audits/builder-audit-20260715.md` (B-054 rollup), selected for being reachable by a first-time user; pre-announcement polish.

| Finding | Fix |
|---|---|
| S-03 | Categorical color on an empty/all-null column now emits the bare fallback instead of a spec-invalid zero-pair `match` that made the layer silently never render (mirror of the B-024 symbol guard) |
| C-06 | AI-chat query-result bboxes are rejected on NaN or inverted bounds before reaching `fitBounds` (ChatPanel + ViewerChatPanel) |
| U-08 | `BuilderRail` (desktop + mobile sheet) wrapped in `PanelErrorBoundary` — a History/Notes render error no longer takes down the whole builder |
| F-04 | AI filter validation extracts `["has", col]` refs like `["get", col]` — a hallucinated has-column filter no longer passes and hides every feature |
| F-05 | An `in list` value of only separators (`",, ,"`) drops the condition instead of emitting an always-false empty-literal filter |
| F-06 | Boolean filter columns offer `!=` (existing `notEquals` label; no new i18n keys) |
| S-05 | Exported symbol layers emit `icon-opacity` from the master opacity (live/export parity) |
| S-07 | Color preset swatches route through the same debounced local-state path as the picker (selected ring updates instantly) |
| LB-04 | `icon-allow-overlap` honors the label overlap toggle (live adapter + export), gated on an active label column so a stale `allowOverlap` can't hide icons |

## Verification

- Backend: `uv run pytest tests/test_builder_audit_p1_13_ai_filter_validation.py tests/test_maps_style_json.py tests/test_layering.py` — 108 passed (4 new tests); ruff clean
- Frontend: `npm run typecheck`, `npm run lint`, full `vitest run` — 3636 passed (8 new tests)
- Live smoke (isolated Chromium against a worktree dev server): separator-only `in list` on the Manhattan stations layer leaves all stations visible (previously hid every feature); color popover path exercised; console clean

## Notes

- `test_layering` style_json cap raised 1411 → 1421 (reviewed comment inline)
- No boolean columns exist in local demo data, so F-06 is unit-verified only