### PR TITLE
fix(editing): remediate editing-audit 2026-07-16 findings (E-32..E-51)

### DIFF
--- a/backend/app/core/processing_port.py
+++ b/backend/app/core/processing_port.py
@@ -216,6 +216,16 @@ class ProcessingPort(Protocol):
         user_roles: set[str] | None = None,
     ) -> set[str]: ...
 
+    async def check_dataset_write_access(
+        self,
+        session: AsyncSession,
+        dataset: Any,
+        dataset_id: uuid.UUID,
+        user: Identity,
+        *,
+        user_roles: set[str] | None = None,
+    ) -> set[str]: ...
+
     async def get_user_roles(
         self, session: AsyncSession, user: Identity
     ) -> set[str]: ...

--- a/backend/app/modules/audit/router.py
+++ b/backend/app/modules/audit/router.py
@@ -413,10 +413,13 @@ async def get_column_ddl_feed(
     to dataset owners so they can detect editor-initiated schema changes.
 
     Access control (AGENTS.md Pre-Commit Checklist Rule 1):
-    - Owner + granted roles: 200 with their own dataset's DDL history
-    - Non-owner editor (no grant): 404 (check_dataset_access raises 404 for
-      private datasets)
+    - Owner: 200 with their own dataset's DDL history
     - Admin: 200 (admin access is always allowed)
+    - Anyone else — including authenticated readers of a PUBLIC dataset: 404
+      via check_dataset_write_access. fix(#458 E-37): the feed previously used
+      check_dataset_access (read visibility), which let any logged-in user
+      enumerate editor usernames/user_ids on public datasets, contradicting
+      this owner-facing contract.
     - Anonymous: 401 (get_current_active_user dependency)
 
     The dataset 404-before-auth-query ordering ensures non-existent datasets
@@ -433,10 +436,9 @@ async def get_column_ddl_feed(
             status_code=status.HTTP_404_NOT_FOUND, detail="Dataset not found"
         )
 
-    # Step 2: enforce visibility / ownership gate
-    # check_dataset_access raises HTTPException(404) for non-owners of private datasets,
-    # consistent with the column-DDL write endpoints from Phase 1061 Plan 02.
-    await port.check_dataset_access(db, dataset, dataset_id, user)
+    # Step 2: enforce ownership gate (owner-or-admin, 404 on denial), matching
+    # the column-DDL write endpoints this feed reports on (fix(#458 E-37)).
+    await port.check_dataset_write_access(db, dataset, dataset_id, user)
 
     # Step 3: fetch DDL history. Preserve the old offset parameter while new
     # clients converge on the repository-wide skip/limit convention.

--- a/backend/app/modules/catalog/datasets/api/router.py
+++ b/backend/app/modules/catalog/datasets/api/router.py
@@ -293,6 +293,10 @@ async def update_dataset_metadata(
         )
     await check_dataset_write_access(db, dataset, dataset_id, user)
 
+    # fix(#458 E-48): capture the pre-update value so a PATCH that echoes the
+    # same tile_columns doesn't roll the tile version / purge the tile cache.
+    tile_columns_before = list(dataset.tile_columns or [])
+
     try:
         dataset = await update_user_metadata(
             db,
@@ -330,13 +334,19 @@ async def update_dataset_metadata(
     # fix(#525 B-038): a tile_columns change alters the attribute set embedded
     # in vector tiles — roll the _v= URL cache-buster in the same transaction
     # (the post-commit Valkey purge cannot reach CDN/browser caches).
-    if "tile_columns" in meta.model_fields_set:
+    # fix(#458 E-48): only when the value actually changed — a no-op echo used
+    # to purge every cached tile for the table.
+    tile_columns_changed = (
+        "tile_columns" in meta.model_fields_set
+        and list(dataset.tile_columns or []) != tile_columns_before
+    )
+    if tile_columns_changed:
         dataset.bump_tile_cache_version()
     await db.commit()
     await db.refresh(dataset)
     await db.refresh(dataset.record)
     await invalidate_catalog_cache()
-    if "tile_columns" in meta.model_fields_set:
+    if tile_columns_changed:
         tile_cache = get_tile_cache()
         if tile_cache is not None:
             await tile_cache.invalidate_table(dataset.table_name)

--- a/backend/app/modules/catalog/datasets/api/router.py
+++ b/backend/app/modules/catalog/datasets/api/router.py
@@ -295,7 +295,12 @@ async def update_dataset_metadata(
 
     # fix(#458 E-48): capture the pre-update value so a PATCH that echoes the
     # same tile_columns doesn't roll the tile version / purge the tile cache.
-    tile_columns_before = list(dataset.tile_columns or [])
+    # None and [] are captured distinctly (fix(#528) codex r1): None means
+    # per-zoom defaults while [] means "never project attributes"
+    # (_select_tile_columns), so a None↔[] flip IS a tile-content change.
+    tile_columns_before = (
+        list(dataset.tile_columns) if dataset.tile_columns is not None else None
+    )
 
     try:
         dataset = await update_user_metadata(
@@ -338,7 +343,7 @@ async def update_dataset_metadata(
     # to purge every cached tile for the table.
     tile_columns_changed = (
         "tile_columns" in meta.model_fields_set
-        and list(dataset.tile_columns or []) != tile_columns_before
+        and dataset.tile_columns != tile_columns_before
     )
     if tile_columns_changed:
         dataset.bump_tile_cache_version()

--- a/backend/app/modules/catalog/datasets/domain/column_stats.py
+++ b/backend/app/modules/catalog/datasets/domain/column_stats.py
@@ -73,11 +73,15 @@ async def get_distinct_values(
         raise PermissionError(f"Access denied to table: {table_name!r}")
 
     table_ref = _qtable(table_name)
+    # fix(#458 E-33): quote the (already regex-validated) identifier so
+    # reserved-word column names (desc, order, user) don't 500 the query;
+    # get_column_stats/get_column_null_cardinality below already quote.
+    col_q = _sql_quote_ident(column_name)
 
     sql = text(
-        f"SELECT DISTINCT {column_name} AS val "
+        f"SELECT DISTINCT {col_q} AS val "
         f"FROM {table_ref} "
-        f"WHERE {column_name} IS NOT NULL "
+        f"WHERE {col_q} IS NOT NULL "
         f"ORDER BY val LIMIT :limit"
     ).bindparams(limit=limit)
 

--- a/backend/app/modules/catalog/features/router.py
+++ b/backend/app/modules/catalog/features/router.py
@@ -19,7 +19,7 @@ from sqlalchemy.exc import DBAPIError, OperationalError, ProgrammingError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.modules.audit.service import AuditEvent, audit_emit
-from app.core.db.sqlstate import is_operational
+from app.core.db.sqlstate import BAD_QUERY_INPUT, TABLE_ABSENT, is_operational, sqlstate
 from app.core.identity import Identity
 from app.modules.auth.dependencies import (
     get_current_active_user,
@@ -106,16 +106,33 @@ def _feature_write_db_error(exc: DBAPIError) -> HTTPException:
     tabular datasets) used to surface as an unhandled 500. Classify by SQLSTATE:
     a request the table cannot answer is the caller's fault (400); a database
     outage stays a 503.
+
+    fix(#458 E-41): don't collapse every non-operational state to 400 — a
+    missing backing table (42P01, schema-provisioning drift) is a 503 like the
+    read path reports it, and an unrecognized state (our own bad SQL, 42601) is
+    an honest 500, not the caller's fault.
     """
     if is_operational(exc):
         return HTTPException(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
             detail="Database temporarily unavailable.",
         )
+    state = sqlstate(exc)
+    if state in TABLE_ABSENT:
+        return HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Dataset table is temporarily unavailable.",
+        )
+    if state in BAD_QUERY_INPUT or (state or "")[:2] in ("22", "23"):
+        return HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Feature could not be written: a value is incompatible with a "
+            "column's type or constraints.",
+        )
+    logger.error("feature.write unexpected DB error", sqlstate=state, exc_info=exc)
     return HTTPException(
-        status_code=status.HTTP_400_BAD_REQUEST,
-        detail="Feature could not be written: a value is incompatible with a "
-        "column's type or constraints.",
+        status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+        detail="Feature write failed unexpectedly.",
     )
 
 
@@ -265,7 +282,14 @@ async def list_features(
     user: Identity = Depends(get_current_active_user),
     db: AsyncSession = Depends(get_db),
 ) -> JSONResponse:
-    """Get paginated GeoJSON features for a dataset."""
+    """Get paginated GeoJSON features for a dataset.
+
+    Pagination is OFFSET-based (fix(#458 E-40), documented limitation): rows can
+    skip or duplicate across pages under concurrent writes, though feature ids
+    stay stable (ORDER BY gid, the primary key). Clients that need stable
+    cursoring should use the OGC API Features endpoint, which supports keyset
+    pagination via ``after_gid``.
+    """
     # Fetch dataset
     dataset = await get_dataset(db, dataset_id)
     if dataset is None:

--- a/backend/app/modules/catalog/layers/router.py
+++ b/backend/app/modules/catalog/layers/router.py
@@ -280,14 +280,11 @@ async def alter_column_type_endpoint(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=str(exc),
         )
-    except Exception as exc:  # broad: PostgreSQL ALTER COLUMN cast can throw varied DataError types; map all to 400 with rollback
-        # Cast failures (e.g. "abc" → integer) surface as Postgres DataError;
-        # turn them into 400s instead of 500s so the UI can render the message.
-        await db.rollback()
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail=f"Type change failed: {exc}",
-        )
+    except DBAPIError as exc:
+        # fix(#458 E-42): route through the shared classifier like add/rename/
+        # drop, so a lock timeout or connection failure during ALTER TYPE is a
+        # 503, while cast failures ("abc" → integer) stay 400 with the message.
+        await _raise_ddl_db_error(db, exc, "Type change")
 
     logger.info(
         "layer.alter_column_type",

--- a/backend/app/modules/catalog/layers/service.py
+++ b/backend/app/modules/catalog/layers/service.py
@@ -24,6 +24,37 @@ from app.platform.extensions import get_catalog_port
 logger = structlog.stdlib.get_logger(__name__)
 
 
+def _qcol(name: str) -> str:
+    """Return a double-quoted column identifier for DDL interpolation.
+
+    fix(#458 E-33): column names were interpolated bare, so a name that is a
+    SQL reserved word (``desc``, ``order``, ``user`` — routine ogr2ogr output
+    from DBF fields) passed COLUMN_NAME_RE but broke every DDL statement with
+    a syntax error, leaving the column permanently un-editable. Names are
+    regex-validated before reaching here, so quoting is belt-and-braces, not
+    an injection guard.
+    """
+    return '"' + name.replace('"', '""') + '"'
+
+
+async def _refresh_quality_detail(
+    session: AsyncSession, dataset: Dataset, column_info: list[dict]
+) -> None:
+    """Recompute the stored quality score after a schema change.
+
+    fix(#458 E-34): reupload recomputes quality_detail but column DDL did not,
+    so attribute_completeness drifted (an all-null added column, or a dropped
+    fully-populated one, changed the real score while the displayed one stayed
+    stale until the next reupload).
+    """
+    dataset.quality_detail = await get_catalog_port().compute_quality_score(
+        session,
+        dataset.table_name,
+        column_info,
+        dataset,
+    )
+
+
 async def create_layer(
     session: AsyncSession,
     name: str,
@@ -68,7 +99,7 @@ async def create_layer(
             if not COLUMN_NAME_RE.match(col.name):
                 raise ValueError(f"Invalid column name: {col.name!r}")
             pg_type = ALLOWED_COLUMN_TYPES[col.type]
-            col_defs += f", {col.name} {pg_type}"
+            col_defs += f", {_qcol(col.name)} {pg_type}"
 
     ddl = f"CREATE TABLE {table_ref} ({col_defs})"
     await session.execute(text(ddl))
@@ -192,12 +223,13 @@ async def add_column(
 
     # Execute DDL
     table_ref = get_catalog_port().quote_table(dataset.table_name)
-    ddl = f"ALTER TABLE {table_ref} ADD COLUMN {column_name} {pg_type}"
+    ddl = f"ALTER TABLE {table_ref} ADD COLUMN {_qcol(column_name)} {pg_type}"
     await session.execute(text(ddl))
 
     # Refresh column_info
     column_info = await get_catalog_port().get_column_info(session, dataset.table_name)
     dataset.column_info = column_info
+    await _refresh_quality_detail(session, dataset, column_info)
 
     # Create (or revive) the AttributeMetadata row for the new column.
     # fix(#458 E-12): (dataset_id, field_name) is unique, so re-adding a name
@@ -221,11 +253,18 @@ async def add_column(
             )
             session.add(am)
         am.data_type = data_type
-        am.units = get_catalog_port().infer_units(column_name)
-        am.semantic_role = get_catalog_port().infer_semantic_role(
-            column_name, data_type
-        )
-        am.domain_type = get_catalog_port().infer_domain_type(data_type)
+        # fix(#458 E-44): the revive path (drop → re-add the same name) used to
+        # overwrite user-customized inferred fields with fresh inference while
+        # user_modified_fields still claimed the customization. Honor it.
+        user_modified = set(am.user_modified_fields or [])
+        if "units" not in user_modified:
+            am.units = get_catalog_port().infer_units(column_name)
+        if "semantic_role" not in user_modified:
+            am.semantic_role = get_catalog_port().infer_semantic_role(
+                column_name, data_type
+            )
+        if "domain_type" not in user_modified:
+            am.domain_type = get_catalog_port().infer_domain_type(data_type)
         am.ordinal_position = new_col.get("ordinal_position")
         am.is_nullable = new_col.get("is_nullable")
         am.is_current = True
@@ -267,11 +306,19 @@ async def rename_column(
         raise ValueError(f"Column {new_name!r} already exists on this layer.")
 
     table_ref = get_catalog_port().quote_table(dataset.table_name)
-    ddl = f"ALTER TABLE {table_ref} RENAME COLUMN {column_name} TO {new_name}"
+    ddl = f"ALTER TABLE {table_ref} RENAME COLUMN {_qcol(column_name)} TO {_qcol(new_name)}"
     await session.execute(text(ddl))
 
     column_info = await get_catalog_port().get_column_info(session, dataset.table_name)
     dataset.column_info = column_info
+
+    # fix(#458 E-43): keep the cached sample-values snapshot keyed by the new
+    # name; the builder reads this dict and an old-name entry looks like an
+    # empty column after a rename.
+    if dataset.sample_values and column_name in dataset.sample_values:
+        samples = dict(dataset.sample_values)
+        samples[new_name] = samples.pop(column_name)
+        dataset.sample_values = samples
 
     # Migrate the AttributeMetadata row in place so attribute history follows
     # the rename instead of being orphaned.
@@ -323,13 +370,14 @@ async def alter_column_type(
     pg_type = ALLOWED_COLUMN_TYPES[new_type]
     table_ref = get_catalog_port().quote_table(dataset.table_name)
     ddl = (
-        f"ALTER TABLE {table_ref} ALTER COLUMN {column_name} TYPE {pg_type} "
-        f"USING {column_name}::{pg_type}"
+        f"ALTER TABLE {table_ref} ALTER COLUMN {_qcol(column_name)} TYPE {pg_type} "
+        f"USING {_qcol(column_name)}::{pg_type}"
     )
     await session.execute(text(ddl))
 
     column_info = await get_catalog_port().get_column_info(session, dataset.table_name)
     dataset.column_info = column_info
+    await _refresh_quality_detail(session, dataset, column_info)
 
     # Refresh AttributeMetadata.data_type so quality metrics + UI labels match.
     result = await session.execute(
@@ -378,12 +426,19 @@ async def drop_column(
 
     # Execute DDL
     table_ref = get_catalog_port().quote_table(dataset.table_name)
-    ddl = f"ALTER TABLE {table_ref} DROP COLUMN {column_name}"
+    ddl = f"ALTER TABLE {table_ref} DROP COLUMN {_qcol(column_name)}"
     await session.execute(text(ddl))
 
     # Refresh column_info
     column_info = await get_catalog_port().get_column_info(session, dataset.table_name)
     dataset.column_info = column_info
+    await _refresh_quality_detail(session, dataset, column_info)
+
+    # fix(#458 E-43): drop the removed column's cached sample values too.
+    if dataset.sample_values and column_name in dataset.sample_values:
+        samples = dict(dataset.sample_values)
+        samples.pop(column_name)
+        dataset.sample_values = samples
 
     # Mark AttributeMetadata row as removed. fix(#458 E-12): filter on
     # is_current like rename/alter do — drop→re-add→drop of the same name

--- a/backend/app/modules/catalog/records/router.py
+++ b/backend/app/modules/catalog/records/router.py
@@ -10,6 +10,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import joinedload
 
 from app.core.identity import Identity
+from app.modules.audit.service import AuditEvent, audit_emit
 from app.modules.auth.dependencies import get_optional_user, require_permission
 from app.modules.catalog.authorization import (
     check_dataset_access_or_anonymous,
@@ -72,7 +73,14 @@ _LANGUAGE_PATH = Path(
 )
 
 
-async def _propagate_record_write(record_id: uuid.UUID, *, reembed: bool) -> None:
+async def _propagate_record_write(
+    record_id: uuid.UUID,
+    *,
+    reembed: bool,
+    db: AsyncSession | None = None,
+    user: Identity | None = None,
+    details: dict | None = None,
+) -> None:
     """Keep downstream surfaces coherent after a record sub-resource write.
 
     fix(#458 E-15): contacts/keywords/distributions feed the DCAT-US/STAC feeds
@@ -81,6 +89,12 @@ async def _propagate_record_write(record_id: uuid.UUID, *, reembed: bool) -> Non
     metadata PATCH already does both; these sibling writes did neither. Both
     steps are best-effort — the write is already committed and must not fail on a
     cache/broker hiccup.
+
+    fix(#458 E-47): when db/user/details are passed, also emit a metadata.edit
+    audit event against the backing dataset, so contact/keyword/distribution/
+    translation changes appear in GET /datasets/{id}/history like top-level
+    metadata PATCHes do. Best-effort and post-commit for the same reason as the
+    cache bust; records without a backing dataset (mid-ingest orphans) skip it.
     """
     try:
         await invalidate_catalog_cache()
@@ -92,6 +106,29 @@ async def _propagate_record_write(record_id: uuid.UUID, *, reembed: bool) -> Non
         except Exception:  # broad: embedding catches up on next edit or backfill
             logger.warning(
                 "record.write embed defer failed for %s", record_id, exc_info=True
+            )
+    if db is not None and user is not None and details is not None:
+        try:
+            dataset_id = (
+                await db.execute(
+                    select(Dataset.id).where(Dataset.record_id == record_id)
+                )
+            ).scalar_one_or_none()
+            if dataset_id is not None:
+                await audit_emit(
+                    db,
+                    AuditEvent(
+                        user_id=user.id,
+                        action="metadata.edit",
+                        resource_type="dataset",
+                        resource_id=dataset_id,
+                        details=details,
+                    ),
+                )
+                await db.commit()
+        except Exception:  # broad: audit is best-effort here; the write is committed
+            logger.warning(
+                "record.write audit emit failed for %s", record_id, exc_info=True
             )
 
 
@@ -237,7 +274,17 @@ async def upsert_translation_endpoint(
     record.updated_by = user.id
     await db.commit()
     await db.refresh(translation)
-    await _propagate_record_write(record_id, reembed=True)
+    await _propagate_record_write(
+        record_id,
+        reembed=True,
+        db=db,
+        user=user,
+        details={
+            "resource": "translation",
+            "op": "upsert",
+            "language": normalized_language,
+        },
+    )
     return TranslationResponse.model_validate(translation)
 
 
@@ -263,7 +310,17 @@ async def delete_translation_endpoint(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="Record translation not found",
         )
-    await _propagate_record_write(record_id, reembed=True)
+    await _propagate_record_write(
+        record_id,
+        reembed=True,
+        db=db,
+        user=user,
+        details={
+            "resource": "translation",
+            "op": "delete",
+            "language": normalize_language_tag(language),
+        },
+    )
     return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 
@@ -330,7 +387,13 @@ async def create_contact_endpoint(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="Invalid contact data (check role value against ISO CI_RoleCode codelist)",
         )
-    await _propagate_record_write(record_id, reembed=False)
+    await _propagate_record_write(
+        record_id,
+        reembed=False,
+        db=db,
+        user=user,
+        details={"resource": "contact", "op": "create", "role": body.role},
+    )
     return ContactResponse.model_validate(contact)
 
 
@@ -345,8 +408,11 @@ async def update_contact_endpoint(
     """Update a contact."""
     await _check_record_ownership(db, record_id, user)
     try:
+        # fix(#458 E-46): exclude_unset, not exclude_none — an explicitly-set
+        # null clears the field (dataset E-04 contract); the schema already
+        # 422s nulls on non-clearable fields.
         contact = await update_contact(
-            db, contact_id, record_id, **body.model_dump(exclude_none=True)
+            db, contact_id, record_id, **body.model_dump(exclude_unset=True)
         )
         await db.commit()
         await db.refresh(contact)
@@ -360,7 +426,17 @@ async def update_contact_endpoint(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="Invalid contact data (check role value against ISO CI_RoleCode codelist)",
         )
-    await _propagate_record_write(record_id, reembed=False)
+    await _propagate_record_write(
+        record_id,
+        reembed=False,
+        db=db,
+        user=user,
+        details={
+            "resource": "contact",
+            "op": "update",
+            "fields": sorted(body.model_fields_set),
+        },
+    )
     return ContactResponse.model_validate(contact)
 
 
@@ -382,7 +458,17 @@ async def delete_contact_endpoint(
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND, detail="Contact not found"
         )
-    await _propagate_record_write(record_id, reembed=False)
+    await _propagate_record_write(
+        record_id,
+        reembed=False,
+        db=db,
+        user=user,
+        details={
+            "resource": "contact",
+            "op": "delete",
+            "contact_id": str(contact_id),
+        },
+    )
     return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 
@@ -445,7 +531,13 @@ async def create_keyword_endpoint(
             status_code=status.HTTP_409_CONFLICT,
             detail="Duplicate keyword for this record",
         )
-    await _propagate_record_write(record_id, reembed=True)
+    await _propagate_record_write(
+        record_id,
+        reembed=True,
+        db=db,
+        user=user,
+        details={"resource": "keyword", "op": "create", "keyword": body.keyword},
+    )
     return KeywordResponse.model_validate(kw)
 
 
@@ -467,7 +559,17 @@ async def delete_keyword_endpoint(
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND, detail="Keyword not found"
         )
-    await _propagate_record_write(record_id, reembed=True)
+    await _propagate_record_write(
+        record_id,
+        reembed=True,
+        db=db,
+        user=user,
+        details={
+            "resource": "keyword",
+            "op": "delete",
+            "keyword_id": str(keyword_id),
+        },
+    )
     return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 
@@ -535,7 +637,17 @@ async def create_distribution_endpoint(
             status_code=status.HTTP_409_CONFLICT,
             detail="Duplicate distribution (same record, type, and format)",
         )
-    await _propagate_record_write(record_id, reembed=False)
+    await _propagate_record_write(
+        record_id,
+        reembed=False,
+        db=db,
+        user=user,
+        details={
+            "resource": "distribution",
+            "op": "create",
+            "distribution_type": body.distribution_type,
+        },
+    )
     return DistributionResponse.model_validate(dist)
 
 
@@ -553,8 +665,9 @@ async def update_distribution_endpoint(
     """Update a distribution (manual only; auto-generated distributions are immutable)."""
     await _check_record_ownership(db, record_id, user)
     try:
+        # fix(#458 E-46): exclude_unset, not exclude_none — see update_contact.
         dist = await update_distribution(
-            db, distribution_id, record_id, **body.model_dump(exclude_none=True)
+            db, distribution_id, record_id, **body.model_dump(exclude_unset=True)
         )
         await db.commit()
         await db.refresh(dist)
@@ -573,7 +686,17 @@ async def update_distribution_endpoint(
             status_code=status.HTTP_409_CONFLICT,
             detail="Duplicate distribution (same record, type, and format)",
         )
-    await _propagate_record_write(record_id, reembed=False)
+    await _propagate_record_write(
+        record_id,
+        reembed=False,
+        db=db,
+        user=user,
+        details={
+            "resource": "distribution",
+            "op": "update",
+            "fields": sorted(body.model_fields_set),
+        },
+    )
     return DistributionResponse.model_validate(dist)
 
 
@@ -601,5 +724,15 @@ async def delete_distribution_endpoint(
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND, detail="Distribution not found"
         )
-    await _propagate_record_write(record_id, reembed=False)
+    await _propagate_record_write(
+        record_id,
+        reembed=False,
+        db=db,
+        user=user,
+        details={
+            "resource": "distribution",
+            "op": "delete",
+            "distribution_id": str(distribution_id),
+        },
+    )
     return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/backend/app/modules/catalog/records/schemas.py
+++ b/backend/app/modules/catalog/records/schemas.py
@@ -4,7 +4,15 @@ import re
 import uuid
 from typing import Any
 
-from pydantic import BaseModel, ConfigDict, EmailStr, Field, HttpUrl, field_validator
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    EmailStr,
+    Field,
+    HttpUrl,
+    field_validator,
+    model_validator,
+)
 
 from app.core.text import normalize_nfc as _nfc
 
@@ -96,6 +104,16 @@ class ContactUpdate(BaseModel):
     @classmethod
     def normalize_nfc(cls, v: str | None) -> str | None:
         return _nfc(v)
+
+    @model_validator(mode="after")
+    def _reject_null_required(self) -> "ContactUpdate":
+        # fix(#458 E-46): PATCH follows the dataset E-04 contract — an
+        # explicitly-set null clears the field. `role` is NOT NULL in the
+        # model, so an explicit null there is a 422, not a silent drop.
+        for field in ("role", "sort_order"):
+            if field in self.model_fields_set and getattr(self, field) is None:
+                raise ValueError(f"{field} cannot be cleared to null")
+        return self
 
 
 class ContactResponse(BaseModel):
@@ -204,10 +222,29 @@ class DistributionUpdate(BaseModel):
     media_type: str | None = Field(default=None, max_length=100)
     is_primary: bool | None = None
 
+    @field_validator("url")
+    @classmethod
+    def _validate_url(cls, v: str | None) -> str | None:
+        # fix(#458 E-45): the update path skipped the HTTP(S) validation the
+        # create path enforces, letting javascript:/file:// strings re-enter
+        # the DCAT/STAC feeds as accessURL/downloadURL.
+        if v is not None:
+            HttpUrl(v)
+        return v
+
     @field_validator("title", "description", mode="before")
     @classmethod
     def normalize_nfc(cls, v: str | None) -> str | None:
         return _nfc(v)
+
+    @model_validator(mode="after")
+    def _reject_null_required(self) -> "DistributionUpdate":
+        # fix(#458 E-46): explicit null clears optional fields (E-04 contract);
+        # the NOT NULL trio must 422 instead of silently dropping the null.
+        for field in ("distribution_type", "format", "url", "is_primary"):
+            if field in self.model_fields_set and getattr(self, field) is None:
+                raise ValueError(f"{field} cannot be cleared to null")
+        return self
 
 
 class DistributionResponse(BaseModel):

--- a/backend/app/modules/catalog/records/service.py
+++ b/backend/app/modules/catalog/records/service.py
@@ -184,9 +184,10 @@ async def update_contact(
     if contact is None:
         raise ValueError(f"Contact {contact_id} not found")
 
+    # fix(#458 E-46): kwargs carry only explicitly-set fields (exclude_unset
+    # at the router), so apply nulls too — that's how a field is cleared.
     for key, value in kwargs.items():
-        if value is not None:
-            setattr(contact, key, value)
+        setattr(contact, key, value)
 
     await session.flush()
     return contact
@@ -379,7 +380,7 @@ async def update_distribution(
     record_id: uuid.UUID,
     **kwargs,
 ) -> RecordDistribution:
-    """Update a distribution. Only non-None fields are updated.
+    """Update a distribution. Explicitly-set fields are applied, nulls included.
 
     Auto-generated distributions cannot be updated (raises ValueError).
     """
@@ -396,9 +397,9 @@ async def update_distribution(
     if dist.auto_generated:
         raise ValueError("Cannot update auto-generated distributions")
 
+    # fix(#458 E-46): apply explicitly-set nulls too — see update_contact.
     for key, value in kwargs.items():
-        if value is not None:
-            setattr(dist, key, value)
+        setattr(dist, key, value)
 
     await session.flush()
     return dist

--- a/backend/app/platform/extensions/defaults.py
+++ b/backend/app/platform/extensions/defaults.py
@@ -379,6 +379,15 @@ class DefaultProcessingPort:
             session, dataset, dataset_id, user, user_roles=user_roles
         )
 
+    async def check_dataset_write_access(
+        self, session, dataset, dataset_id, user, *, user_roles=None
+    ):  # type: ignore[no-untyped-def]
+        from app.modules.catalog.authorization import check_dataset_write_access
+
+        return await check_dataset_write_access(
+            session, dataset, dataset_id, user, user_roles=user_roles
+        )
+
     async def get_user_roles(self, session, user):  # type: ignore[no-untyped-def]
         from app.modules.catalog.authorization import get_user_roles
 

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -22417,7 +22417,7 @@
     },
     "/audit/datasets/{dataset_id}/column-ddl": {
       "get": {
-        "description": "Return the column-DDL audit history for a dataset.\n\nSEC-FU-08: Surfaces the column-DDL events written by SEC-S03 (Phase 1061)\nto dataset owners so they can detect editor-initiated schema changes.\n\nAccess control (AGENTS.md Pre-Commit Checklist Rule 1):\n- Owner + granted roles: 200 with their own dataset's DDL history\n- Non-owner editor (no grant): 404 (check_dataset_access raises 404 for\n  private datasets)\n- Admin: 200 (admin access is always allowed)\n- Anonymous: 401 (get_current_active_user dependency)\n\nThe dataset 404-before-auth-query ordering ensures non-existent datasets\nreturn 404 without leaking audit log details.",
+        "description": "Return the column-DDL audit history for a dataset.\n\nSEC-FU-08: Surfaces the column-DDL events written by SEC-S03 (Phase 1061)\nto dataset owners so they can detect editor-initiated schema changes.\n\nAccess control (AGENTS.md Pre-Commit Checklist Rule 1):\n- Owner: 200 with their own dataset's DDL history\n- Admin: 200 (admin access is always allowed)\n- Anyone else \u2014 including authenticated readers of a PUBLIC dataset: 404\n  via check_dataset_write_access. fix(#458 E-37): the feed previously used\n  check_dataset_access (read visibility), which let any logged-in user\n  enumerate editor usernames/user_ids on public datasets, contradicting\n  this owner-facing contract.\n- Anonymous: 401 (get_current_active_user dependency)\n\nThe dataset 404-before-auth-query ordering ensures non-existent datasets\nreturn 404 without leaking audit log details.",
         "operationId": "get_column_ddl_feed_audit_datasets__dataset_id__column_ddl_get",
         "parameters": [
           {
@@ -31883,7 +31883,7 @@
     },
     "/datasets/{dataset_id}/features/": {
       "get": {
-        "description": "Get paginated GeoJSON features for a dataset.",
+        "description": "Get paginated GeoJSON features for a dataset.\n\nPagination is OFFSET-based (fix(#458 E-40), documented limitation): rows can\nskip or duplicate across pages under concurrent writes, though feature ids\nstay stable (ORDER BY gid, the primary key). Clients that need stable\ncursoring should use the OGC API Features endpoint, which supports keyset\npagination via ``after_gid``.",
         "operationId": "list_features_datasets__dataset_id__features__get",
         "parameters": [
           {

--- a/backend/tests/test_audit_column_ddl_feed.py
+++ b/backend/tests/test_audit_column_ddl_feed.py
@@ -434,3 +434,46 @@ async def test_column_ddl_feed_pagination(
     ids_p1 = {item["action"] + str(item["created_at"]) for item in body_p1["items"]}
     ids_p2 = {item["action"] + str(item["created_at"]) for item in body_p2["items"]}
     assert not ids_p1.intersection(ids_p2), "Pagination pages must not overlap"
+
+
+@pytest.mark.anyio
+async def test_column_ddl_feed_non_owner_public_dataset_denied(
+    client: AsyncClient,
+    admin_auth_header: dict,
+    test_db_session: AsyncSession,
+):
+    """fix(#458 E-37): the feed is owner-facing — a PUBLIC dataset must not let
+    arbitrary authenticated users enumerate editor usernames/user_ids. The old
+    check_dataset_access (read visibility) allowed exactly that."""
+    owner_headers, owner_id_str = await _create_test_user(
+        client, admin_auth_header, "editor"
+    )
+    owner_id = uuid.UUID(owner_id_str)
+    dataset_id = await _create_dataset_direct(
+        test_db_session,
+        created_by=owner_id,
+        name="DDL Feed Test Public Non-Owner",
+        visibility="public",
+    )
+    await _seed_ddl_event(
+        test_db_session, dataset_id=dataset_id, action="layer.add_column"
+    )
+
+    other_headers, _ = await _create_test_user(client, admin_auth_header, "editor")
+
+    resp = await client.get(
+        f"/api/audit/datasets/{dataset_id}/column-ddl",
+        headers=other_headers,
+    )
+    assert resp.status_code in (403, 404), (
+        f"Expected denial on public dataset for non-owner, got {resp.status_code}: {resp.text}"
+    )
+    assert "layer.add_column" not in resp.text
+
+    # The owner still sees it.
+    resp = await client.get(
+        f"/api/audit/datasets/{dataset_id}/column-ddl",
+        headers=owner_headers,
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["total"] >= 1

--- a/backend/tests/test_dataset_tile_columns_metadata.py
+++ b/backend/tests/test_dataset_tile_columns_metadata.py
@@ -66,3 +66,15 @@ async def test_tile_columns_noop_patch_does_not_bump_tile_version(
     assert resp.status_code == 200, resp.text
     await test_db_session.refresh(ds)
     assert ds.tile_cache_version > version_after_change
+    version_after_clear = ds.tile_cache_version
+
+    # fix(#528) codex r1: None (per-zoom defaults) and [] (never project
+    # attributes) render DIFFERENT tiles, so a None→[] flip must bump too.
+    resp = await client.patch(
+        f"/datasets/{ds.id}",
+        json={"tile_columns": []},
+        headers=admin_auth_header,
+    )
+    assert resp.status_code == 200, resp.text
+    await test_db_session.refresh(ds)
+    assert ds.tile_cache_version > version_after_clear

--- a/backend/tests/test_dataset_tile_columns_metadata.py
+++ b/backend/tests/test_dataset_tile_columns_metadata.py
@@ -20,3 +20,49 @@ def test_dataset_meta_rejects_duplicate_tile_columns() -> None:
 def test_dataset_meta_rejects_invalid_tile_column_names() -> None:
     with pytest.raises(ValidationError, match="Invalid tile column names"):
         DatasetMeta(tile_columns=["mag", "drop table"])
+
+
+@pytest.mark.anyio
+async def test_tile_columns_noop_patch_does_not_bump_tile_version(
+    client, admin_auth_header, test_db_session
+):
+    """fix(#458 E-48): a PATCH echoing the current tile_columns must not roll
+    the _v= tile version (which forces every client to refetch all tiles)."""
+    import uuid as _uuid
+
+    from tests.factories import create_dataset, get_user_id
+
+    admin_id = await get_user_id(test_db_session, "admin")
+    ds = await create_dataset(
+        test_db_session,
+        created_by=admin_id,
+        name=f"TileCols NoOp {_uuid.uuid4().hex[:6]}",
+        column_info=[{"name": "name", "type": "text"}],
+    )
+
+    resp = await client.patch(
+        f"/datasets/{ds.id}",
+        json={"tile_columns": ["name"]},
+        headers=admin_auth_header,
+    )
+    assert resp.status_code == 200, resp.text
+    await test_db_session.refresh(ds)
+    version_after_change = ds.tile_cache_version
+
+    resp = await client.patch(
+        f"/datasets/{ds.id}",
+        json={"tile_columns": ["name"]},
+        headers=admin_auth_header,
+    )
+    assert resp.status_code == 200, resp.text
+    await test_db_session.refresh(ds)
+    assert ds.tile_cache_version == version_after_change
+
+    resp = await client.patch(
+        f"/datasets/{ds.id}",
+        json={"tile_columns": None},
+        headers=admin_auth_header,
+    )
+    assert resp.status_code == 200, resp.text
+    await test_db_session.refresh(ds)
+    assert ds.tile_cache_version > version_after_change

--- a/backend/tests/test_layer_column_ops.py
+++ b/backend/tests/test_layer_column_ops.py
@@ -227,3 +227,76 @@ async def test_column_references_counts_saved_maps(
     )
     assert unreferenced.status_code == 200
     assert unreferenced.json()["map_count"] == 0
+
+
+@pytest.mark.anyio
+async def test_reserved_word_column_full_ddl_lifecycle(
+    client: AsyncClient, admin_auth_header: dict
+):
+    """fix(#458 E-33): SQL reserved words as column names (desc, order — routine
+    ogr2ogr output from DBF fields) must survive every DDL op and the
+    distinct-values probe; unquoted interpolation used to raise syntax errors."""
+    dataset_id = await _create_layer(
+        client, admin_auth_header, title="Reserved Word DDL"
+    )
+
+    resp = await client.post(
+        f"/layers/{dataset_id}/columns/",
+        json={"column": {"name": "desc", "type": "text"}},
+        headers=admin_auth_header,
+    )
+    assert resp.status_code == 201, resp.text
+    assert "desc" in {c["name"] for c in resp.json()["columns"]}
+
+    resp = await client.get(
+        f"/datasets/{dataset_id}/columns/desc/values/",
+        headers=admin_auth_header,
+    )
+    assert resp.status_code == 200, resp.text
+
+    resp = await client.patch(
+        f"/layers/{dataset_id}/columns/desc/type",
+        json={"new_type": "integer"},
+        headers=admin_auth_header,
+    )
+    assert resp.status_code == 200, resp.text
+
+    resp = await client.patch(
+        f"/layers/{dataset_id}/columns/desc/name",
+        json={"new_name": "order"},
+        headers=admin_auth_header,
+    )
+    assert resp.status_code == 200, resp.text
+    assert "order" in {c["name"] for c in resp.json()["columns"]}
+
+    resp = await client.delete(
+        f"/layers/{dataset_id}/columns/order",
+        headers=admin_auth_header,
+    )
+    assert resp.status_code == 200, resp.text
+    assert "order" not in {c["name"] for c in resp.json()["columns"]}
+
+
+@pytest.mark.anyio
+async def test_column_ddl_recomputes_quality_detail(
+    client: AsyncClient, admin_auth_header: dict
+):
+    """fix(#458 E-34): column DDL recomputes the stored quality score like
+    reupload does; it used to stay stale until the next reupload."""
+    dataset_id = await _create_layer(client, admin_auth_header, title="Quality Refresh")
+
+    before = await client.get(f"/datasets/{dataset_id}", headers=admin_auth_header)
+    assert before.status_code == 200
+    computed_before = before.json()["quality_detail"]["computed_at"]
+
+    resp = await client.post(
+        f"/layers/{dataset_id}/columns/",
+        json={"column": {"name": "extra", "type": "text"}},
+        headers=admin_auth_header,
+    )
+    assert resp.status_code == 201, resp.text
+
+    after = await client.get(f"/datasets/{dataset_id}", headers=admin_auth_header)
+    assert after.status_code == 200
+    computed_after = after.json()["quality_detail"]["computed_at"]
+    assert computed_after > computed_before

--- a/backend/tests/test_processing_port.py
+++ b/backend/tests/test_processing_port.py
@@ -87,6 +87,11 @@ class FakeProcessingPort:
     ):
         return user_roles or set()
 
+    async def check_dataset_write_access(
+        self, session, dataset, dataset_id, user, *, user_roles=None
+    ):
+        return user_roles or set()
+
     async def get_user_roles(self, session, user):
         return {"viewer"}
 

--- a/backend/tests/test_record_subresource_edits.py
+++ b/backend/tests/test_record_subresource_edits.py
@@ -1,0 +1,179 @@
+"""Record sub-resource edit contracts (fix(#458 E-45/E-46/E-47)).
+
+Covers the update-path gaps the 2026-07-16 editing audit found:
+- E-45: DistributionUpdate.url gets the same HTTP(S) validation as create.
+- E-46: PATCH clears optional fields with an explicit null (dataset E-04
+  contract); non-nullable fields 422 instead of silently dropping the null.
+- E-47: sub-resource writes emit metadata.edit audit events into the backing
+  dataset's history.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from httpx import AsyncClient
+
+from tests.factories import create_dataset, get_user_id
+
+
+async def _dataset_and_record(test_db_session, admin_id: uuid.UUID):
+    ds = await create_dataset(
+        test_db_session,
+        created_by=admin_id,
+        name=f"Subresource Edits {uuid.uuid4().hex[:6]}",
+    )
+    return ds.id, ds.record_id
+
+
+async def _create_contact(client: AsyncClient, record_id, headers) -> str:
+    resp = await client.post(
+        f"/records/{record_id}/contacts/",
+        json={
+            "role": "pointOfContact",
+            "name": "Jane Doe",
+            "email": "jane@example.com",
+            "organization": "Example Org",
+        },
+        headers=headers,
+    )
+    assert resp.status_code in (200, 201), resp.text
+    return resp.json()["id"]
+
+
+async def _create_distribution(client: AsyncClient, record_id, headers) -> str:
+    resp = await client.post(
+        f"/records/{record_id}/distributions/",
+        json={
+            "distribution_type": "download",
+            "format": "GeoJSON",
+            "url": "https://example.com/data.geojson",
+            "title": "Download",
+        },
+        headers=headers,
+    )
+    assert resp.status_code in (200, 201), resp.text
+    return resp.json()["id"]
+
+
+@pytest.mark.anyio
+async def test_distribution_update_rejects_non_http_url(
+    client: AsyncClient, admin_auth_header: dict, test_db_session
+):
+    """fix(#458 E-45): the update path validates URLs like the create path."""
+    admin_id = await get_user_id(test_db_session, "admin")
+    _, record_id = await _dataset_and_record(test_db_session, admin_id)
+    dist_id = await _create_distribution(client, record_id, admin_auth_header)
+
+    resp = await client.patch(
+        f"/records/{record_id}/distributions/{dist_id}/",
+        json={"url": "javascript:alert(1)"},
+        headers=admin_auth_header,
+    )
+    assert resp.status_code == 422, resp.text
+
+    resp = await client.patch(
+        f"/records/{record_id}/distributions/{dist_id}/",
+        json={"url": "https://example.com/updated.geojson"},
+        headers=admin_auth_header,
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["url"] == "https://example.com/updated.geojson"
+
+
+@pytest.mark.anyio
+async def test_contact_patch_clears_optional_field_with_null(
+    client: AsyncClient, admin_auth_header: dict, test_db_session
+):
+    """fix(#458 E-46): an explicit null clears optional fields; it used to be
+    silently dropped by double exclude_none."""
+    admin_id = await get_user_id(test_db_session, "admin")
+    _, record_id = await _dataset_and_record(test_db_session, admin_id)
+    contact_id = await _create_contact(client, record_id, admin_auth_header)
+
+    resp = await client.patch(
+        f"/records/{record_id}/contacts/{contact_id}/",
+        json={"email": None},
+        headers=admin_auth_header,
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["email"] is None
+
+    # Omitted fields stay untouched.
+    assert resp.json()["organization"] == "Example Org"
+
+
+@pytest.mark.anyio
+async def test_contact_patch_null_role_is_422(
+    client: AsyncClient, admin_auth_header: dict, test_db_session
+):
+    """fix(#458 E-46): role is NOT NULL — explicit null is a 422, not a drop."""
+    admin_id = await get_user_id(test_db_session, "admin")
+    _, record_id = await _dataset_and_record(test_db_session, admin_id)
+    contact_id = await _create_contact(client, record_id, admin_auth_header)
+
+    resp = await client.patch(
+        f"/records/{record_id}/contacts/{contact_id}/",
+        json={"role": None},
+        headers=admin_auth_header,
+    )
+    assert resp.status_code == 422, resp.text
+
+
+@pytest.mark.anyio
+async def test_distribution_patch_null_url_is_422(
+    client: AsyncClient, admin_auth_header: dict, test_db_session
+):
+    """fix(#458 E-46): the NOT NULL trio (type/format/url) rejects explicit null."""
+    admin_id = await get_user_id(test_db_session, "admin")
+    _, record_id = await _dataset_and_record(test_db_session, admin_id)
+    dist_id = await _create_distribution(client, record_id, admin_auth_header)
+
+    resp = await client.patch(
+        f"/records/{record_id}/distributions/{dist_id}/",
+        json={"url": None},
+        headers=admin_auth_header,
+    )
+    assert resp.status_code == 422, resp.text
+
+    # Optional field still clearable.
+    resp = await client.patch(
+        f"/records/{record_id}/distributions/{dist_id}/",
+        json={"title": None},
+        headers=admin_auth_header,
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["title"] is None
+
+
+@pytest.mark.anyio
+async def test_subresource_write_appears_in_dataset_history(
+    client: AsyncClient, admin_auth_header: dict, test_db_session
+):
+    """fix(#458 E-47): sub-resource writes emit metadata.edit audit events into
+    the backing dataset's history like top-level metadata PATCHes do."""
+    admin_id = await get_user_id(test_db_session, "admin")
+    dataset_id, record_id = await _dataset_and_record(test_db_session, admin_id)
+
+    resp = await client.post(
+        f"/records/{record_id}/keywords/",
+        json={"keyword": "audit-trail", "keyword_type": "theme"},
+        headers=admin_auth_header,
+    )
+    assert resp.status_code in (200, 201), resp.text
+
+    resp = await client.get(
+        f"/datasets/{dataset_id}/history",
+        headers=admin_auth_header,
+    )
+    assert resp.status_code == 200, resp.text
+    keyword_events = [
+        log
+        for log in resp.json()["logs"]
+        if log["action"] == "metadata.edit"
+        and (log.get("details") or {}).get("resource") == "keyword"
+    ]
+    assert keyword_events, resp.json()["logs"]
+    assert keyword_events[0]["details"]["op"] == "create"
+    assert keyword_events[0]["details"]["keyword"] == "audit-trail"

--- a/backend/tests/test_workflow_extension.py
+++ b/backend/tests/test_workflow_extension.py
@@ -75,6 +75,9 @@ def _context(from_status: str, to_status: str, *, mode: str = "status"):
 def _dataset(record_status: str):
     return SimpleNamespace(
         id=uuid.uuid4(),
+        # fix(#458 E-48): the PATCH handler snapshots tile_columns pre-update
+        # to detect no-op echoes, so the fake needs the attribute.
+        tile_columns=None,
         record=SimpleNamespace(record_status=record_status),
     )
 

--- a/frontend/src/components/dataset/AttributeTable.tsx
+++ b/frontend/src/components/dataset/AttributeTable.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, useRef, useEffect, useCallback } from 'react';
+import { useState, useMemo, useRef, useEffect, useCallback, useId } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
   useReactTable,
@@ -47,29 +47,50 @@ interface AttributeTableProps {
   compact?: boolean;
 }
 
+/** Postgres numeric types get a decimal input mode on touch keyboards. */
+const NUMERIC_COL_TYPES = /^(smallint|integer|bigint|numeric|decimal|real|double precision)/;
+
 function InlineCellEditor({
   initialValue,
+  label,
+  colType,
+  error,
   onSave,
   onCancel,
   isSaving,
 }: {
   initialValue: string;
+  label: string;
+  colType: string;
+  error?: string | null;
   onSave: (value: string) => void;
   onCancel: () => void;
   isSaving: boolean;
 }) {
   const inputRef = useRef<HTMLInputElement>(null);
   const [value, setValue] = useState(initialValue);
+  const errorId = useId();
 
   useEffect(() => {
     inputRef.current?.focus();
     inputRef.current?.select();
   }, []);
 
+  // fix(#458 E-35): an unchanged value is a cancel, not a save — blur used to
+  // commit a no-op PATCH that bumped updated_at, rolled the tile version, and
+  // wrote an attribute.edit audit event for a non-change.
+  const commit = () => {
+    if (value === initialValue) {
+      onCancel();
+      return;
+    }
+    onSave(value);
+  };
+
   const handleKeyDown = (e: React.KeyboardEvent) => {
     if (e.key === 'Enter') {
       e.preventDefault();
-      onSave(value);
+      commit();
     } else if (e.key === 'Escape') {
       e.preventDefault();
       onCancel();
@@ -81,14 +102,27 @@ function InlineCellEditor({
   }
 
   return (
-    <Input
-      ref={inputRef}
-      value={value}
-      onChange={(e) => setValue(e.target.value)}
-      onBlur={() => onSave(value)}
-      onKeyDown={handleKeyDown}
-      className="h-7 text-xs px-1"
-    />
+    <>
+      <Input
+        ref={inputRef}
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+        onBlur={commit}
+        onKeyDown={handleKeyDown}
+        className="h-7 text-xs px-1"
+        // fix(#458 E-39): name the editor (column + row) and tie the rejection
+        // reason to the field so it isn't just a transient toast for SR users.
+        aria-label={label}
+        aria-invalid={error ? true : undefined}
+        aria-describedby={error ? errorId : undefined}
+        inputMode={NUMERIC_COL_TYPES.test(colType) ? 'decimal' : undefined}
+      />
+      {error ? (
+        <span id={errorId} className="sr-only" role="alert">
+          {error}
+        </span>
+      ) : null}
+    </>
   );
 }
 
@@ -97,6 +131,7 @@ export function AttributeTable({ datasetId, canEdit = false, compact = false }: 
   const [cursor, setCursor] = useState(0);
   const [cursorHistory, setCursorHistory] = useState<number[]>([0]);
   const [editingCell, setEditingCell] = useState<EditingCell | null>(null);
+  const [editError, setEditError] = useState<string | null>(null);
   const editingCellRef = useRef<EditingCell | null>(null);
   editingCellRef.current = editingCell;
   // Scroll container ref used by the row virtualizer (PERF-07).
@@ -125,6 +160,14 @@ export function AttributeTable({ datasetId, canEdit = false, compact = false }: 
     setCursorHistory([0]);
   }, [debouncedFilters]);
 
+  // fix(#458 E-51): an open cell editor survives a page/filter/page-size
+  // change; if the edited row leaves the result set the in-progress edit
+  // silently vanishes. Close it (and clear any error) when the row set moves.
+  useEffect(() => {
+    setEditingCell(null);
+    setEditError(null);
+  }, [cursor, activeFilters, pageSize]);
+
   const { data, isLoading, isFetching, isError } = useDatasetRows(
     datasetId,
     pageSize,
@@ -141,9 +184,14 @@ export function AttributeTable({ datasetId, canEdit = false, compact = false }: 
     // column's wire type instead of sending a string into a typed column.
     const coerced = coerceAttributeValue(newValue, colType);
     if (!coerced.ok) {
-      toast.error(t('attributes.editInvalidValue', { type: colType }));
+      const msg = t('attributes.editInvalidValue', { type: colType });
+      // fix(#458 E-39): mirror the toast into field-associated state so the
+      // open editor carries aria-invalid/aria-describedby.
+      setEditError(msg);
+      toast.error(msg);
       return; // keep the editor open so the value can be corrected
     }
+    setEditError(null);
     // fix(#458 E-22): keep the cell in edit mode through the await so the saving
     // spinner (InlineCellEditor isSaving) actually renders; clearing editingCell
     // before awaiting made that branch unreachable and showed the stale value.
@@ -196,8 +244,18 @@ export function AttributeTable({ datasetId, canEdit = false, compact = false }: 
           return (
             <InlineCellEditor
               initialValue={String(info.getValue() ?? '')}
+              label={t('attributes.cellEditorLabel', {
+                column: col.name,
+                gid,
+                defaultValue: 'Edit {{column}} for feature {{gid}}',
+              })}
+              colType={col.type}
+              error={editError}
               onSave={(val) => handleCellSave(gid, col.name, col.type, val)}
-              onCancel={() => setEditingCell(null)}
+              onCancel={() => {
+                setEditError(null);
+                setEditingCell(null);
+              }}
               isSaving={updateFeature.isPending}
             />
           );
@@ -234,7 +292,7 @@ export function AttributeTable({ datasetId, canEdit = false, compact = false }: 
         return cellValue;
       },
     }));
-  }, [data?.columns, canEdit, handleCellSave, updateFeature.isPending]);
+  }, [data?.columns, canEdit, handleCellSave, updateFeature.isPending, editError, t]);
 
   // eslint-disable-next-line react-hooks/incompatible-library -- TanStack Table returns imperative helpers; this component keeps table state local.
   const table = useReactTable({

--- a/frontend/src/components/dataset/InlineEdit.tsx
+++ b/frontend/src/components/dataset/InlineEdit.tsx
@@ -36,6 +36,7 @@ export function InlineEdit({
   const [editing, setEditing] = useState(initialEditing);
   const [draft, setDraft] = useState(value);
   const inputRef = useRef<HTMLInputElement | HTMLTextAreaElement>(null);
+  const multilineContainerRef = useRef<HTMLDivElement>(null);
   const isDirtyRef = useRef(false);
 
   const emitDirtyChange = useCallback(
@@ -158,12 +159,21 @@ export function InlineEdit({
 
     if (multiline) {
       return (
-        <div>
+        <div ref={multilineContainerRef}>
           <textarea
             ref={inputRef as React.RefObject<HTMLTextAreaElement>}
             value={draft}
             onChange={(e) => handleDraftChange(e.target.value)}
-            onBlur={cancel}
+            // fix(#528 review): don't cancel when focus moves to the editor's
+            // own Save/Cancel buttons — Tab from the textarea used to fire
+            // blur→cancel and unmount the buttons before a keyboard user
+            // could reach them (mousedown-preventDefault only covers pointers).
+            onBlur={(e) => {
+              if (multilineContainerRef.current?.contains(e.relatedTarget as Node)) {
+                return;
+              }
+              cancel();
+            }}
             onKeyDown={handleKeyDown}
             // fix(#438): DS-03 — deliberately shares inputClasses with its
             // sibling <input> so the inline editor looks identical in both modes;

--- a/frontend/src/components/dataset/InlineEdit.tsx
+++ b/frontend/src/components/dataset/InlineEdit.tsx
@@ -1,6 +1,7 @@
 import { useState, useRef, useEffect, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { toast } from 'sonner';
+import { Button } from '@/components/ui/button';
 import { cn } from '@/lib/utils';
 
 interface InlineEditProps {
@@ -122,11 +123,20 @@ export function InlineEdit({
     [cancel, save, multiline],
   );
 
+  // fix(#458 E-32): clear the dirty flag on true unmount ONLY. Depending on
+  // [emitDirtyChange] re-ran this cleanup whenever the onDirtyChange prop
+  // identity changed — which the dirty change itself triggers when the parent
+  // passes an inline arrow — instantly self-reverting the flag, so the
+  // pending-edits bar never appeared for an in-progress multiline edit.
+  const emitDirtyChangeRef = useRef(emitDirtyChange);
+  useEffect(() => {
+    emitDirtyChangeRef.current = emitDirtyChange;
+  });
   useEffect(
     () => () => {
-      emitDirtyChange(false);
+      emitDirtyChangeRef.current(false);
     },
-    [emitDirtyChange],
+    [],
   );
 
   // Not editable -- render plain text
@@ -148,19 +158,44 @@ export function InlineEdit({
 
     if (multiline) {
       return (
-        <textarea
-          ref={inputRef as React.RefObject<HTMLTextAreaElement>}
-          value={draft}
-          onChange={(e) => handleDraftChange(e.target.value)}
-          onBlur={cancel}
-          onKeyDown={handleKeyDown}
-          // fix(#438): DS-03 — deliberately shares inputClasses with its
-          // sibling <input> so the inline editor looks identical in both modes;
-          // that's why it doesn't use the ui/textarea primitive.
-          className={cn(inputClasses, 'resize-none min-h-[3rem]')}
-          rows={3}
-          title={t('common:inlineEdit.hint', { defaultValue: 'Ctrl+Enter to save, Escape to cancel' })}
-        />
+        <div>
+          <textarea
+            ref={inputRef as React.RefObject<HTMLTextAreaElement>}
+            value={draft}
+            onChange={(e) => handleDraftChange(e.target.value)}
+            onBlur={cancel}
+            onKeyDown={handleKeyDown}
+            // fix(#438): DS-03 — deliberately shares inputClasses with its
+            // sibling <input> so the inline editor looks identical in both modes;
+            // that's why it doesn't use the ui/textarea primitive.
+            className={cn(inputClasses, 'resize-none min-h-[3rem]')}
+            rows={3}
+            title={t('common:inlineEdit.hint', { defaultValue: 'Ctrl+Enter to save, Escape to cancel' })}
+          />
+          {/* fix(#458 E-32): Ctrl+Enter was the ONLY save path, hinted solely
+              by a hover tooltip — click-away cancels, so edits were silently
+              lost. Visible buttons; mousedown is prevented so the textarea's
+              blur→cancel doesn't fire before the click lands. */}
+          <div className="mt-1 flex items-center gap-2">
+            <Button
+              type="button"
+              size="sm"
+              onMouseDown={(e) => e.preventDefault()}
+              onClick={() => void save()}
+            >
+              {t('common:save')}
+            </Button>
+            <Button
+              type="button"
+              size="sm"
+              variant="outline"
+              onMouseDown={(e) => e.preventDefault()}
+              onClick={cancel}
+            >
+              {t('common:cancel')}
+            </Button>
+          </div>
+        </div>
       );
     }
 

--- a/frontend/src/components/dataset/SchemaEditor.tsx
+++ b/frontend/src/components/dataset/SchemaEditor.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useId, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { toast } from 'sonner';
 import { Trash2, Plus } from 'lucide-react';
@@ -56,6 +56,8 @@ export function SchemaEditor({ datasetId, columns, open, onOpenChange }: SchemaE
   const [newType, setNewType] = useState<string>('text');
   const [nameError, setNameError] = useState<string | null>(null);
   const [confirmDelete, setConfirmDelete] = useState<string | null>(null);
+  const nameInputId = useId();
+  const nameErrorId = useId();
 
   const addColumnMutation = useAddColumn();
   const dropColumnMutation = useDropColumn();
@@ -193,7 +195,10 @@ export function SchemaEditor({ datasetId, columns, open, onOpenChange }: SchemaE
               </AlertDialogCancel>
               <AlertDialogAction
                 variant="destructive"
-                disabled={dropColumnMutation.isPending}
+                // fix(#458 E-50): also wait for the map-references query — a
+                // fast confirm could drop the column before the "used by N
+                // maps" warning (E-06) had a chance to render.
+                disabled={dropColumnMutation.isPending || columnReferences.isLoading}
                 onClick={() => {
                   if (confirmDelete) handleDropColumn(confirmDelete);
                 }}
@@ -206,10 +211,15 @@ export function SchemaEditor({ datasetId, columns, open, onOpenChange }: SchemaE
 
         {/* Add column form */}
         <div className="border-t pt-4 space-y-3">
-          <Label className="text-sm font-medium">{t('schema.addColumn')}</Label>
+          {/* fix(#458 E-49): a placeholder is not an accessible name — tie the
+              section label to the name input. */}
+          <Label htmlFor={nameInputId} className="text-sm font-medium">
+            {t('schema.addColumn')}
+          </Label>
           <div className="flex items-start gap-2">
             <div className="flex-1 space-y-2">
               <Input
+                id={nameInputId}
                 placeholder={t('schema.columnNamePlaceholder')}
                 value={newName}
                 onChange={(e) => {
@@ -220,13 +230,19 @@ export function SchemaEditor({ datasetId, columns, open, onOpenChange }: SchemaE
                   if (e.key === 'Enter') handleAddColumn();
                 }}
                 className="font-mono text-xs h-9"
+                // fix(#458 E-38): announce the validation failure and associate
+                // it with the field instead of a visually-adjacent <p> only.
+                aria-invalid={nameError ? true : undefined}
+                aria-describedby={nameError ? nameErrorId : undefined}
               />
               {nameError && (
-                <p className="text-xs text-destructive">{nameError}</p>
+                <p id={nameErrorId} role="alert" className="text-xs text-destructive">
+                  {nameError}
+                </p>
               )}
             </div>
             <Select value={newType} onValueChange={setNewType}>
-              <SelectTrigger className="w-[130px]">
+              <SelectTrigger className="w-[130px]" aria-label={t('schema.columnType')}>
                 <SelectValue />
               </SelectTrigger>
               <SelectContent>

--- a/frontend/src/components/dataset/__tests__/AttributeTable.test.tsx
+++ b/frontend/src/components/dataset/__tests__/AttributeTable.test.tsx
@@ -101,3 +101,34 @@ describe('PERF-07: AttributeTable virtualization wiring', () => {
     expect(attributeTableSrc).toMatch(/columnVisibility/);
   });
 });
+
+// ── fix(#458 E-35/E-39/E-51) source contracts ────────────────────────────────
+// The body rows are virtualized, and jsdom computes no layout, so the cell
+// editor can't be rendered here (same constraint as PERF-07 above). Lock the
+// contracts against the source instead; the live flow is covered by
+// e2e/feature-editing.spec.ts.
+describe('AttributeTable editing contracts (E-35/E-39/E-51)', () => {
+  it('E-35: an unchanged cell value commits as a cancel, not a PATCH', () => {
+    // commit() guards on value === initialValue and routes to onCancel —
+    // removing the guard reintroduces no-op writes (tile purge + audit noise).
+    expect(attributeTableSrc).toMatch(
+      /if \(value === initialValue\) \{\s*onCancel\(\);\s*return;\s*\}/,
+    );
+    // blur goes through commit, never straight to onSave
+    expect(attributeTableSrc).toContain('onBlur={commit}');
+    expect(attributeTableSrc).not.toContain('onBlur={() => onSave(value)}');
+  });
+
+  it('E-39: the cell editor is named and carries invalid-state wiring', () => {
+    expect(attributeTableSrc).toContain('aria-label={label}');
+    expect(attributeTableSrc).toContain('aria-invalid={error ? true : undefined}');
+    expect(attributeTableSrc).toContain('aria-describedby={error ? errorId : undefined}');
+    expect(attributeTableSrc).toContain("t('attributes.cellEditorLabel'");
+  });
+
+  it('E-51: an open cell edit closes when the row set changes', () => {
+    expect(attributeTableSrc).toMatch(
+      /setEditingCell\(null\);\s*setEditError\(null\);\s*\}, \[cursor, activeFilters, pageSize\]\)/,
+    );
+  });
+});

--- a/frontend/src/components/dataset/__tests__/InlineEdit.test.tsx
+++ b/frontend/src/components/dataset/__tests__/InlineEdit.test.tsx
@@ -247,3 +247,49 @@ describe('InlineEdit multiline (E-32)', () => {
     expect(container.querySelector('textarea')).toBeNull();
   });
 });
+
+/**
+ * fix(#528 review): Tab from the textarea to the editor's own Save/Cancel
+ * buttons must not blur-cancel — keyboard users need to reach the buttons.
+ */
+describe('InlineEdit multiline keyboard reachability (#528 review)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('keeps the editor open when focus moves to its own Save button, and Save commits', async () => {
+    const onSave = vi.fn().mockResolvedValue(undefined);
+    const { container, getByText } = render(
+      <InlineEdit value="original" onSave={onSave} canEdit multiline />,
+    );
+    fireEvent.click(container.querySelector('[role="button"]') as HTMLElement);
+
+    const textarea = container.querySelector('textarea') as HTMLTextAreaElement;
+    fireEvent.change(textarea, { target: { value: 'edited value' } });
+
+    const saveBtn = getByText('common:save');
+    // Simulate Tab: blur with focus landing on the editor's own button.
+    fireEvent.blur(textarea, { relatedTarget: saveBtn });
+    expect(container.querySelector('textarea')).not.toBeNull();
+
+    fireEvent.click(saveBtn);
+    await waitFor(() => {
+      expect(onSave).toHaveBeenCalledWith('edited value');
+    });
+  });
+
+  it('still cancels when focus leaves the editor entirely', () => {
+    const onSave = vi.fn();
+    const { container } = render(
+      <InlineEdit value="original" onSave={onSave} canEdit multiline />,
+    );
+    fireEvent.click(container.querySelector('[role="button"]') as HTMLElement);
+
+    const textarea = container.querySelector('textarea') as HTMLTextAreaElement;
+    fireEvent.change(textarea, { target: { value: 'edited value' } });
+    fireEvent.blur(textarea, { relatedTarget: document.body });
+
+    expect(container.querySelector('textarea')).toBeNull();
+    expect(onSave).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/dataset/__tests__/InlineEdit.test.tsx
+++ b/frontend/src/components/dataset/__tests__/InlineEdit.test.tsx
@@ -154,3 +154,96 @@ describe('InlineEdit allowClear (#458 E-04)', () => {
     expect(onSave).not.toHaveBeenCalled();
   });
 });
+
+/**
+ * fix(#458 E-32): multiline drafts had no working save affordance —
+ * (1) the unmount cleanup re-ran whenever the parent passed a new inline-arrow
+ *     onDirtyChange, instantly self-reverting the dirty flag (so the
+ *     pending-edits bar never appeared), and
+ * (2) Ctrl+Enter was the only save path; blur cancelled. Visible Save/Cancel
+ *     buttons now commit without being defeated by the textarea blur.
+ */
+describe('InlineEdit multiline (E-32)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  function renderMultiline(onDirtyChange: (d: boolean) => void, onSave = vi.fn()) {
+    const view = render(
+      <InlineEdit
+        value="original"
+        onSave={onSave}
+        canEdit
+        multiline
+        onDirtyChange={onDirtyChange}
+      />,
+    );
+    const displayEl = view.container.querySelector('[role="button"]') as HTMLElement;
+    fireEvent.click(displayEl);
+    return view;
+  }
+
+  it('keeps the dirty flag when the parent re-renders with a new onDirtyChange identity', () => {
+    const dirtyCalls: boolean[] = [];
+    const { container, rerender } = renderMultiline((d) => dirtyCalls.push(d));
+
+    const textarea = container.querySelector('textarea') as HTMLTextAreaElement;
+    fireEvent.change(textarea, { target: { value: 'edited value' } });
+    expect(dirtyCalls).toEqual([true]);
+
+    // Parent re-render with a NEW inline arrow — exactly what DetailPanel/
+    // SourceQualityTab do. The old [emitDirtyChange]-dep cleanup fired
+    // onDirtyChange(false) here, self-reverting the flag.
+    rerender(
+      <InlineEdit
+        value="original"
+        onSave={vi.fn()}
+        canEdit
+        multiline
+        onDirtyChange={(d) => dirtyCalls.push(d)}
+      />,
+    );
+    expect(dirtyCalls).toEqual([true]);
+  });
+
+  it('clears the dirty flag on true unmount', () => {
+    const dirtyCalls: boolean[] = [];
+    const { container, unmount } = renderMultiline((d) => dirtyCalls.push(d));
+    const textarea = container.querySelector('textarea') as HTMLTextAreaElement;
+    fireEvent.change(textarea, { target: { value: 'edited value' } });
+    unmount();
+    expect(dirtyCalls).toEqual([true, false]);
+  });
+
+  it('saves via the visible Save button despite the textarea blur-cancel', async () => {
+    const onSave = vi.fn().mockResolvedValue(undefined);
+    const { container, getByText } = renderMultiline(vi.fn(), onSave);
+
+    const textarea = container.querySelector('textarea') as HTMLTextAreaElement;
+    fireEvent.change(textarea, { target: { value: 'edited value' } });
+
+    const saveBtn = getByText('common:save');
+    // mousedown is prevented so blur→cancel can't fire first; click commits.
+    fireEvent.mouseDown(saveBtn);
+    fireEvent.click(saveBtn);
+
+    await waitFor(() => {
+      expect(onSave).toHaveBeenCalledWith('edited value');
+    });
+  });
+
+  it('cancels via the visible Cancel button without saving', () => {
+    const onSave = vi.fn();
+    const { container, getByText } = renderMultiline(vi.fn(), onSave);
+
+    const textarea = container.querySelector('textarea') as HTMLTextAreaElement;
+    fireEvent.change(textarea, { target: { value: 'edited value' } });
+
+    const cancelBtn = getByText('common:cancel');
+    fireEvent.mouseDown(cancelBtn);
+    fireEvent.click(cancelBtn);
+
+    expect(onSave).not.toHaveBeenCalled();
+    expect(container.querySelector('textarea')).toBeNull();
+  });
+});

--- a/frontend/src/components/dataset/__tests__/SchemaEditor.test.tsx
+++ b/frontend/src/components/dataset/__tests__/SchemaEditor.test.tsx
@@ -1,0 +1,117 @@
+/**
+ * fix(#458 E-38/E-49/E-50): SchemaEditor accessibility + destructive-confirm
+ * guards. First direct suite for this component (StructureTab.test mocks it
+ * away), covering:
+ * - E-38: name-validation errors are announced (role="alert") and associated
+ *   with the input (aria-invalid/aria-describedby).
+ * - E-49: the name input and type select carry accessible names.
+ * - E-50: the drop-column Confirm stays disabled until the map-references
+ *   query resolves, so a fast confirm can't outrun the E-06 warning.
+ */
+import { render, screen, fireEvent } from '@testing-library/react';
+import { vi } from 'vitest';
+import { SchemaEditor } from '@/components/dataset/SchemaEditor';
+import { useAddColumn, useColumnReferences, useDropColumn } from '@/hooks/use-features';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, opts?: { defaultValue?: string }) => opts?.defaultValue ?? key,
+  }),
+}));
+
+vi.mock('sonner', () => ({
+  toast: { error: vi.fn(), success: vi.fn() },
+}));
+
+vi.mock('@/hooks/use-features', () => ({
+  useAddColumn: vi.fn(),
+  useDropColumn: vi.fn(),
+  useColumnReferences: vi.fn(),
+}));
+
+const COLUMNS = [
+  { name: 'name', type: 'character varying' },
+  { name: 'value', type: 'integer' },
+];
+
+function renderEditor() {
+  return render(
+    <SchemaEditor
+      datasetId="test-ds"
+      columns={COLUMNS}
+      open
+      onOpenChange={vi.fn()}
+    />,
+  );
+}
+
+describe('SchemaEditor (E-38/E-49/E-50)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(useAddColumn).mockReturnValue({
+      mutate: vi.fn(),
+      isPending: false,
+    } as unknown as ReturnType<typeof useAddColumn>);
+    vi.mocked(useDropColumn).mockReturnValue({
+      mutate: vi.fn(),
+      isPending: false,
+    } as unknown as ReturnType<typeof useDropColumn>);
+    vi.mocked(useColumnReferences).mockReturnValue({
+      data: { map_count: 0 },
+      isLoading: false,
+    } as unknown as ReturnType<typeof useColumnReferences>);
+  });
+
+  it('E-49: name input and type select carry accessible names', () => {
+    renderEditor();
+    expect(
+      screen.getByRole('textbox', { name: 'schema.addColumn' }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('combobox', { name: 'schema.columnType' }),
+    ).toBeInTheDocument();
+  });
+
+  it('E-38: a reserved name announces an associated validation error', () => {
+    renderEditor();
+    const input = screen.getByRole('textbox', { name: 'schema.addColumn' });
+    fireEvent.change(input, { target: { value: 'gid' } });
+    fireEvent.click(screen.getByRole('button', { name: /schema\.add$/ }));
+
+    const alert = screen.getByRole('alert');
+    expect(alert).toHaveTextContent('schema.validation.reserved');
+    expect(input).toHaveAttribute('aria-invalid', 'true');
+    expect(input.getAttribute('aria-describedby')).toBe(alert.id);
+    // ...and typing clears it
+    fireEvent.change(input, { target: { value: 'gid2' } });
+    expect(screen.queryByRole('alert')).toBeNull();
+    expect(input).not.toHaveAttribute('aria-invalid');
+  });
+
+  it('E-50: drop confirm is disabled while the map-references query loads', () => {
+    vi.mocked(useColumnReferences).mockReturnValue({
+      data: undefined,
+      isLoading: true,
+    } as unknown as ReturnType<typeof useColumnReferences>);
+    renderEditor();
+
+    fireEvent.click(screen.getAllByTitle('schema.removeColumn')[0]);
+    expect(
+      screen.getByRole('button', { name: 'common:confirm' }),
+    ).toBeDisabled();
+  });
+
+  it('E-50: drop confirm enables once references resolve, showing the E-06 warning', () => {
+    vi.mocked(useColumnReferences).mockReturnValue({
+      data: { map_count: 2 },
+      isLoading: false,
+    } as unknown as ReturnType<typeof useColumnReferences>);
+    renderEditor();
+
+    fireEvent.click(screen.getAllByTitle('schema.removeColumn')[0]);
+    expect(
+      screen.getByRole('button', { name: 'common:confirm' }),
+    ).toBeEnabled();
+    expect(screen.getByText('schema.usedByMaps')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/dataset/hooks/use-feature-editing.ts
+++ b/frontend/src/components/dataset/hooks/use-feature-editing.ts
@@ -12,6 +12,7 @@ import { useCreateFeature, useUpdateFeature, useDeleteFeature } from '@/hooks/us
 import { getFeature } from '@/api/features';
 import { getModeName, extractSingleGeometry, isMultiPartGeometry } from '@/components/drawing/hooks/use-terra-draw';
 import { buildSignedTileUrl } from '@/lib/tile-utils';
+import { formatMutationError } from '@/lib/error-map';
 import { getEnvConfig } from '@/lib/env';
 import type { Map as MaplibreMap } from 'maplibre-gl';
 import type { Feature, Geometry } from 'geojson';
@@ -175,8 +176,10 @@ export function useFeatureEditing({
             clearTimer: () => clearTimeout(fallbackTimer),
           };
         }
-      } catch {
-        toast.error(t('map.featureSaveFailed'));
+      } catch (err) {
+        // fix(#458 E-36): surface the backend's reason (invalid geometry,
+        // type mismatch) like the table path does, not a bare "failed".
+        toast.error(formatMutationError('dataset:map.featureSaveFailed', err));
         overlayFeaturesRef.current = overlayFeaturesRef.current.filter((f) => f !== overlayFeature);
         if (map) {
           const src = map.getSource('drawn-overlay') as maplibregl.GeoJSONSource | undefined;
@@ -220,8 +223,9 @@ export function useFeatureEditing({
       const map = mapRef.current;
       if (map) showAllFeaturesInTiles(map);
       clearSelectedFeature();
-    } catch {
-      toast.error(t('map.featureUpdateFailed'));
+    } catch (err) {
+      // fix(#458 E-36): keep the backend detail.
+      toast.error(formatMutationError('dataset:map.featureUpdateFailed', err));
     }
   }, [datasetId, tableName, mapRef, getSnapshotFeature, updateFeatureMutation, removeFeatures, clearSelectedFeature, reloadTiles, t]);
 
@@ -238,8 +242,9 @@ export function useFeatureEditing({
       const map = mapRef.current;
       if (map) showAllFeaturesInTiles(map);
       clearSelectedFeature();
-    } catch {
-      toast.error(t('map.featureDeleteFailed'));
+    } catch (err) {
+      // fix(#458 E-36): keep the backend detail.
+      toast.error(formatMutationError('dataset:map.featureDeleteFailed', err));
     }
   }, [datasetId, tableName, mapRef, deleteFeatureMutation, removeFeatures, clearSelectedFeature, reloadTiles, t]);
 
@@ -258,8 +263,9 @@ export function useFeatureEditing({
         // Cache-bust the vector tiles so the edited attributes render. Geometry
         // is unchanged, so the selection is intentionally kept.
         reloadTiles();
-      } catch {
-        toast.error(t('map.attributesUpdateFailed'));
+      } catch (err) {
+        // fix(#458 E-36): keep the backend detail.
+        toast.error(formatMutationError('dataset:map.attributesUpdateFailed', err));
       }
     },
     [datasetId, updateFeatureMutation, setSelectedFeature, reloadTiles, t],

--- a/frontend/src/i18n/locales/de/dataset.json
+++ b/frontend/src/i18n/locales/de/dataset.json
@@ -206,7 +206,8 @@
     "rowsPerPage": "Zeilen pro Seite",
     "columns": "Spalten",
     "loadFailed": "Daten konnten nicht geladen werden. Bitte erneut versuchen.",
-    "tableLabel": "Feature-Attribute"
+    "tableLabel": "Feature-Attribute",
+    "cellEditorLabel": "{{column}} für Feature {{gid}} bearbeiten"
   },
   "changeHistory": {
     "title": "Änderungsverlauf ({{count}})",

--- a/frontend/src/i18n/locales/en/dataset.json
+++ b/frontend/src/i18n/locales/en/dataset.json
@@ -206,7 +206,8 @@
     "rowsPerPage": "Rows per page",
     "columns": "Columns",
     "loadFailed": "Failed to load data. Please try again.",
-    "tableLabel": "Feature attributes"
+    "tableLabel": "Feature attributes",
+    "cellEditorLabel": "Edit {{column}} for feature {{gid}}"
   },
   "changeHistory": {
     "title": "Change History ({{count}})",

--- a/frontend/src/i18n/locales/es/dataset.json
+++ b/frontend/src/i18n/locales/es/dataset.json
@@ -206,7 +206,8 @@
     "rowsPerPage": "Filas por página",
     "columns": "Columnas",
     "loadFailed": "No se pudieron cargar los datos. Inténtalo de nuevo.",
-    "tableLabel": "Atributos de entidades"
+    "tableLabel": "Atributos de entidades",
+    "cellEditorLabel": "Editar {{column}} del elemento {{gid}}"
   },
   "changeHistory": {
     "title": "Historial de cambios ({{count}})",

--- a/frontend/src/i18n/locales/fr/dataset.json
+++ b/frontend/src/i18n/locales/fr/dataset.json
@@ -206,7 +206,8 @@
     "rowsPerPage": "Lignes par page",
     "columns": "Colonnes",
     "loadFailed": "Impossible de charger les données. Veuillez réessayer.",
-    "tableLabel": "Attributs des entités"
+    "tableLabel": "Attributs des entités",
+    "cellEditorLabel": "Modifier {{column}} pour l’entité {{gid}}"
   },
   "changeHistory": {
     "title": "Historique des modifications ({{count}})",

--- a/frontend/src/types/api.generated.ts
+++ b/frontend/src/types/api.generated.ts
@@ -679,10 +679,13 @@ export interface paths {
          *     to dataset owners so they can detect editor-initiated schema changes.
          *
          *     Access control (AGENTS.md Pre-Commit Checklist Rule 1):
-         *     - Owner + granted roles: 200 with their own dataset's DDL history
-         *     - Non-owner editor (no grant): 404 (check_dataset_access raises 404 for
-         *       private datasets)
+         *     - Owner: 200 with their own dataset's DDL history
          *     - Admin: 200 (admin access is always allowed)
+         *     - Anyone else — including authenticated readers of a PUBLIC dataset: 404
+         *       via check_dataset_write_access. fix(#458 E-37): the feed previously used
+         *       check_dataset_access (read visibility), which let any logged-in user
+         *       enumerate editor usernames/user_ids on public datasets, contradicting
+         *       this owner-facing contract.
          *     - Anonymous: 401 (get_current_active_user dependency)
          *
          *     The dataset 404-before-auth-query ordering ensures non-existent datasets
@@ -2013,6 +2016,12 @@ export interface paths {
         /**
          * List Features
          * @description Get paginated GeoJSON features for a dataset.
+         *
+         *     Pagination is OFFSET-based (fix(#458 E-40), documented limitation): rows can
+         *     skip or duplicate across pages under concurrent writes, though feature ids
+         *     stay stable (ORDER BY gid, the primary key). Clients that need stable
+         *     cursoring should use the OGC API Features endpoint, which supports keyset
+         *     pagination via ``after_gid``.
          */
         get: operations["list_features_datasets__dataset_id__features__get"];
         put?: never;

--- a/sdks/python/geolens/api/audit/get_column_ddl_feed_audit_datasets_dataset_id_column_ddl_get.py
+++ b/sdks/python/geolens/api/audit/get_column_ddl_feed_audit_datasets_dataset_id_column_ddl_get.py
@@ -129,10 +129,13 @@ def sync_detailed(
     to dataset owners so they can detect editor-initiated schema changes.
 
     Access control (AGENTS.md Pre-Commit Checklist Rule 1):
-    - Owner + granted roles: 200 with their own dataset's DDL history
-    - Non-owner editor (no grant): 404 (check_dataset_access raises 404 for
-      private datasets)
+    - Owner: 200 with their own dataset's DDL history
     - Admin: 200 (admin access is always allowed)
+    - Anyone else — including authenticated readers of a PUBLIC dataset: 404
+      via check_dataset_write_access. fix(#458 E-37): the feed previously used
+      check_dataset_access (read visibility), which let any logged-in user
+      enumerate editor usernames/user_ids on public datasets, contradicting
+      this owner-facing contract.
     - Anonymous: 401 (get_current_active_user dependency)
 
     The dataset 404-before-auth-query ordering ensures non-existent datasets
@@ -182,10 +185,13 @@ def sync(
     to dataset owners so they can detect editor-initiated schema changes.
 
     Access control (AGENTS.md Pre-Commit Checklist Rule 1):
-    - Owner + granted roles: 200 with their own dataset's DDL history
-    - Non-owner editor (no grant): 404 (check_dataset_access raises 404 for
-      private datasets)
+    - Owner: 200 with their own dataset's DDL history
     - Admin: 200 (admin access is always allowed)
+    - Anyone else — including authenticated readers of a PUBLIC dataset: 404
+      via check_dataset_write_access. fix(#458 E-37): the feed previously used
+      check_dataset_access (read visibility), which let any logged-in user
+      enumerate editor usernames/user_ids on public datasets, contradicting
+      this owner-facing contract.
     - Anonymous: 401 (get_current_active_user dependency)
 
     The dataset 404-before-auth-query ordering ensures non-existent datasets
@@ -230,10 +236,13 @@ async def asyncio_detailed(
     to dataset owners so they can detect editor-initiated schema changes.
 
     Access control (AGENTS.md Pre-Commit Checklist Rule 1):
-    - Owner + granted roles: 200 with their own dataset's DDL history
-    - Non-owner editor (no grant): 404 (check_dataset_access raises 404 for
-      private datasets)
+    - Owner: 200 with their own dataset's DDL history
     - Admin: 200 (admin access is always allowed)
+    - Anyone else — including authenticated readers of a PUBLIC dataset: 404
+      via check_dataset_write_access. fix(#458 E-37): the feed previously used
+      check_dataset_access (read visibility), which let any logged-in user
+      enumerate editor usernames/user_ids on public datasets, contradicting
+      this owner-facing contract.
     - Anonymous: 401 (get_current_active_user dependency)
 
     The dataset 404-before-auth-query ordering ensures non-existent datasets
@@ -281,10 +290,13 @@ async def asyncio(
     to dataset owners so they can detect editor-initiated schema changes.
 
     Access control (AGENTS.md Pre-Commit Checklist Rule 1):
-    - Owner + granted roles: 200 with their own dataset's DDL history
-    - Non-owner editor (no grant): 404 (check_dataset_access raises 404 for
-      private datasets)
+    - Owner: 200 with their own dataset's DDL history
     - Admin: 200 (admin access is always allowed)
+    - Anyone else — including authenticated readers of a PUBLIC dataset: 404
+      via check_dataset_write_access. fix(#458 E-37): the feed previously used
+      check_dataset_access (read visibility), which let any logged-in user
+      enumerate editor usernames/user_ids on public datasets, contradicting
+      this owner-facing contract.
     - Anonymous: 401 (get_current_active_user dependency)
 
     The dataset 404-before-auth-query ordering ensures non-existent datasets

--- a/sdks/python/geolens/api/features/list_features_datasets_dataset_id_features_get.py
+++ b/sdks/python/geolens/api/features/list_features_datasets_dataset_id_features_get.py
@@ -143,6 +143,12 @@ def sync_detailed(
 
      Get paginated GeoJSON features for a dataset.
 
+    Pagination is OFFSET-based (fix(#458 E-40), documented limitation): rows can
+    skip or duplicate across pages under concurrent writes, though feature ids
+    stay stable (ORDER BY gid, the primary key). Clients that need stable
+    cursoring should use the OGC API Features endpoint, which supports keyset
+    pagination via ``after_gid``.
+
     Args:
         dataset_id (UUID):
         limit (int | Unset):  Default: 10.
@@ -191,6 +197,12 @@ def sync(
 
      Get paginated GeoJSON features for a dataset.
 
+    Pagination is OFFSET-based (fix(#458 E-40), documented limitation): rows can
+    skip or duplicate across pages under concurrent writes, though feature ids
+    stay stable (ORDER BY gid, the primary key). Clients that need stable
+    cursoring should use the OGC API Features endpoint, which supports keyset
+    pagination via ``after_gid``.
+
     Args:
         dataset_id (UUID):
         limit (int | Unset):  Default: 10.
@@ -231,6 +243,12 @@ async def asyncio_detailed(
     """List Features
 
      Get paginated GeoJSON features for a dataset.
+
+    Pagination is OFFSET-based (fix(#458 E-40), documented limitation): rows can
+    skip or duplicate across pages under concurrent writes, though feature ids
+    stay stable (ORDER BY gid, the primary key). Clients that need stable
+    cursoring should use the OGC API Features endpoint, which supports keyset
+    pagination via ``after_gid``.
 
     Args:
         dataset_id (UUID):
@@ -277,6 +295,12 @@ async def asyncio(
     """List Features
 
      Get paginated GeoJSON features for a dataset.
+
+    Pagination is OFFSET-based (fix(#458 E-40), documented limitation): rows can
+    skip or duplicate across pages under concurrent writes, though feature ids
+    stay stable (ORDER BY gid, the primary key). Clients that need stable
+    cursoring should use the OGC API Features endpoint, which supports keyset
+    pagination via ``after_gid``.
 
     Args:
         dataset_id (UUID):

--- a/sdks/typescript/src/client/sdk.gen.ts
+++ b/sdks/typescript/src/client/sdk.gen.ts
@@ -775,10 +775,13 @@ export const generateMetadataSummaryAiMetadataSummaryPost = <ThrowOnError extend
  * to dataset owners so they can detect editor-initiated schema changes.
  *
  * Access control (AGENTS.md Pre-Commit Checklist Rule 1):
- * - Owner + granted roles: 200 with their own dataset's DDL history
- * - Non-owner editor (no grant): 404 (check_dataset_access raises 404 for
- * private datasets)
+ * - Owner: 200 with their own dataset's DDL history
  * - Admin: 200 (admin access is always allowed)
+ * - Anyone else — including authenticated readers of a PUBLIC dataset: 404
+ * via check_dataset_write_access. fix(#458 E-37): the feed previously used
+ * check_dataset_access (read visibility), which let any logged-in user
+ * enumerate editor usernames/user_ids on public datasets, contradicting
+ * this owner-facing contract.
  * - Anonymous: 401 (get_current_active_user dependency)
  *
  * The dataset 404-before-auth-query ordering ensures non-existent datasets
@@ -2106,6 +2109,12 @@ export const getFeaturesGeojsonZEndpointDatasetsDatasetIdFeaturesGeojsonGet = <T
  * List Features
  *
  * Get paginated GeoJSON features for a dataset.
+ *
+ * Pagination is OFFSET-based (fix(#458 E-40), documented limitation): rows can
+ * skip or duplicate across pages under concurrent writes, though feature ids
+ * stay stable (ORDER BY gid, the primary key). Clients that need stable
+ * cursoring should use the OGC API Features endpoint, which supports keyset
+ * pagination via ``after_gid``.
  */
 export const listFeaturesDatasetsDatasetIdFeaturesGet = <ThrowOnError extends boolean = false>(options: Options<ListFeaturesDatasetsDatasetIdFeaturesGetData, ThrowOnError>): RequestResult<ListFeaturesDatasetsDatasetIdFeaturesGetResponses, ListFeaturesDatasetsDatasetIdFeaturesGetErrors, ThrowOnError> => (options.client ?? client).get<ListFeaturesDatasetsDatasetIdFeaturesGetResponses, ListFeaturesDatasetsDatasetIdFeaturesGetErrors, ThrowOnError>({
     security: [


### PR DESCRIPTION
Remediates all 20 findings from the 2026-07-16 editing audit (`docs-internal/audits/editing-audit-20260716.md`). Prior-audit remediations (E-01..E-31, #458) were regression-checked intact; this PR covers the new tail.

## P1
- **E-32** — multiline metadata drafts were effectively unsaveable: `InlineEdit`'s unmount cleanup re-ran on every parent re-render (inline-arrow `onDirtyChange` props), instantly self-reverting the dirty flag, so the pending-edits bar never appeared; multiline blur cancelled, and Ctrl+Enter (hover-tooltip-only) was the sole save path. Fixed with a ref-based unmount-only cleanup + visible Save/Cancel buttons (mousedown-prevented so blur can't cancel first). Live-verified pre-fix in the audit.

## P2
- **E-33** — column identifiers now quoted in all layer DDL + `get_distinct_values`; reserved-word columns (`desc`, `order` — routine ogr2ogr output) no longer break every schema op.
- **E-34** — `quality_detail` recomputed after column DDL (parity with reupload).
- **E-35** — unchanged cell values commit as cancel; blur no longer fires no-op PATCHes that bumped `updated_at`, rolled the tile `_v=`, purged Valkey, and wrote `attribute.edit` audit events for non-changes (observed live).
- **E-36** — map-path feature-edit errors surface backend detail via `formatMutationError` (E-21 parity).
- **E-37** — column-DDL audit feed gates on `check_dataset_write_access`; any authenticated user could previously enumerate editor usernames/user_ids on public datasets. (New `check_dataset_write_access` on ProcessingPort; enterprise overlay doesn't override this port.)
- **E-38/E-39** — validation errors announced + field-associated (`aria-invalid`/`aria-describedby`/`role="alert"`); the inline cell editor has an accessible name and numeric `inputMode`.

## P3
E-40 (offset-pagination documented), E-41/E-42 (SQLSTATE-granular error mapping: `42P01`→503, unknown→500), E-43 (`sample_values` reconciled on rename/drop), E-44 (`user_modified_fields` honored on column revive), E-45 (`DistributionUpdate.url` HTTP(S)-validated), E-46 (explicit-null clears on contact/distribution PATCH; non-nullable fields 422), E-47 (record sub-resource writes emit `metadata.edit` into dataset history), E-48 (no-op `tile_columns` PATCH no longer purges tiles), E-49/E-50/E-51 (SchemaEditor labels, drop-confirm waits for the map-references warning, open cell editor closes when the row set changes).

## API/schema impact
- `backend/openapi.json` + SDKs regenerated (two endpoint description updates only; no shape changes).
- Behavior changes: column-DDL audit feed now 404s non-owners on public datasets (E-37); contact/distribution PATCH treats explicit null as clear and 422s nulls on required fields (E-46); distribution PATCH validates URLs (E-45).

## Tests
- Backend: reserved-word DDL lifecycle, quality-recompute, public-dataset audit-feed denial, URL validation, clear-to-null + 422 contracts, history audit events, no-op tile_columns guard — all passing (`test_layer_column_ops`, `test_audit_column_ddl_feed`, `test_record_subresource_edits` (new), `test_dataset_tile_columns_metadata`), plus adjacent suites (`test_features_crud`, `test_dataset_metadata_idor`, `test_metadata_roundtrip`, `test_layering`, `test_records_authz_sec001`) — 110 passed.
- Frontend: E-32 dirty-persistence + Save/Cancel button suite (`InlineEdit.test.tsx`), E-35/39/51 contracts (`AttributeTable.test.tsx`), new `SchemaEditor.test.tsx` (first direct coverage of the destructive-DDL surface). 204 tests across the dataset surface passing; `npm run typecheck`, eslint, and `test:i18n` green (one new key, `attributes.cellEditorLabel`, added to all four locales).

## Verification
- `make openapi-check` green; `make sdks` regenerated (sdks-check drift was the uncommitted doc updates).
- Browser smoke check of E-32/E-35/E-38/E-39/E-50 against the live dev stack to follow on this PR.

https://claude.ai/code/session_01Xd64KjyK8rmgEfvWemkP5w