### PR TITLE
fix(db): remediate db-audit 2026-07-16 findings (CONN-1, BLOAT-1/3, BKR-1..3, CFG-1/2)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -737,7 +737,7 @@ FRONTEND_PORT=8080
 
 # [OPTIONAL] Maximum overflow connections beyond DB_POOL_SIZE.
 # Default lowered from 5 to 3 to keep the worst-case budget at 70 of
-# max_connections=80 (db-audit-20260716 CONN-1 arithmetic). See
+# max_connections=80 (db-audit #529 CONN-1 arithmetic). See
 # README §"Connection Pool Budget" for the full arithmetic.
 # Type: integer (minimum -1; -1 means unlimited) | Default: 3
 # DB_MAX_OVERFLOW=3

--- a/.env.example
+++ b/.env.example
@@ -736,8 +736,8 @@ FRONTEND_PORT=8080
 # DB_POOL_SIZE=10
 
 # [OPTIONAL] Maximum overflow connections beyond DB_POOL_SIZE.
-# Default lowered from 5 to 3 to give max_connections=30 some room above the
-# worst-case 30 in-flight. See
+# Default lowered from 5 to 3 to keep the worst-case budget at 70 of
+# max_connections=80 (db-audit-20260716 CONN-1 arithmetic). See
 # README §"Connection Pool Budget" for the full arithmetic.
 # Type: integer (minimum -1; -1 means unlimited) | Default: 3
 # DB_MAX_OVERFLOW=3

--- a/README.de.md
+++ b/README.de.md
@@ -297,7 +297,7 @@ Die gesamte Konfiguration erfolgt über Umgebungsvariablen in `.env`. Die [Konfi
 
 ### Budget des Verbindungspools
 
-GeoLens ist für **eine PostgreSQL-Instanz** abgestimmt: API-, Worker- und Admin-Pools passen standardmäßig in **30 von 30 max_connections** (`max_connections` von Postgres ist 30), gesteuert durch `DB_POOL_SIZE` (`pool_size`) und `DB_MAX_OVERFLOW` (`max_overflow`, Standard 3). [Connection Pool Tuning](https://docs.getgeolens.com/guides/quickstart/configuration/#connection-pool-tuning) erklärt Prozessbudgets und höhere Grenzen.
+GeoLens ist für **eine PostgreSQL-Instanz** abgestimmt: API-, Worker- und Admin-Pools passen standardmäßig in **70 von 80 max_connections** (`max_connections` von Postgres ist 80), gesteuert durch `DB_POOL_SIZE` (`pool_size`) und `DB_MAX_OVERFLOW` (`max_overflow`, Standard 3). [Connection Pool Tuning](https://docs.getgeolens.com/guides/quickstart/configuration/#connection-pool-tuning) erklärt Prozessbudgets und höhere Grenzen.
 
 ### Sicherungen
 

--- a/README.es.md
+++ b/README.es.md
@@ -297,7 +297,7 @@ Toda la configuración se gestiona mediante variables de entorno en `.env`. Cons
 
 ### Presupuesto del pool de conexiones
 
-GeoLens viene ajustado para una **única instancia PostgreSQL**: los pools de API, worker y administración caben de serie en **30 de 30 max_connections** (`max_connections` de Postgres es 30), dimensionados por `DB_POOL_SIZE` (`pool_size`) y `DB_MAX_OVERFLOW` (`max_overflow`, predeterminado 3). Consulta [Ajuste del pool de conexiones](https://docs.getgeolens.com/guides/quickstart/configuration/#connection-pool-tuning) para ver el presupuesto por proceso y cómo elevar el límite.
+GeoLens viene ajustado para una **única instancia PostgreSQL**: los pools de API, worker y administración caben de serie en **70 de 80 max_connections** (`max_connections` de Postgres es 80), dimensionados por `DB_POOL_SIZE` (`pool_size`) y `DB_MAX_OVERFLOW` (`max_overflow`, predeterminado 3). Consulta [Ajuste del pool de conexiones](https://docs.getgeolens.com/guides/quickstart/configuration/#connection-pool-tuning) para ver el presupuesto por proceso y cómo elevar el límite.
 
 ### Copias de seguridad
 

--- a/README.fr.md
+++ b/README.fr.md
@@ -297,7 +297,7 @@ Toute la configuration est gérée par des variables d’environnement dans `.en
 
 ### Budget du pool de connexions
 
-GeoLens est réglé pour une **instance PostgreSQL unique** : les pools API, worker et administration tiennent dans **30 sur 30 max_connections** par défaut (`max_connections` de Postgres vaut 30), dimensionnés par `DB_POOL_SIZE` (`pool_size`) et `DB_MAX_OVERFLOW` (`max_overflow`, valeur par défaut 3). Consultez [Réglage du pool de connexions](https://docs.getgeolens.com/guides/quickstart/configuration/#connection-pool-tuning) pour le budget par processus et le relèvement de la limite.
+GeoLens est réglé pour une **instance PostgreSQL unique** : les pools API, worker et administration tiennent dans **70 sur 80 max_connections** par défaut (`max_connections` de Postgres vaut 80), dimensionnés par `DB_POOL_SIZE` (`pool_size`) et `DB_MAX_OVERFLOW` (`max_overflow`, valeur par défaut 3). Consultez [Réglage du pool de connexions](https://docs.getgeolens.com/guides/quickstart/configuration/#connection-pool-tuning) pour le budget par processus et le relèvement de la limite.
 
 ### Sauvegardes
 

--- a/README.md
+++ b/README.md
@@ -334,8 +334,8 @@ All configuration is managed through environment variables in `.env`. See the [C
 ### Connection pool budget
 
 GeoLens ships tuned for a **single PostgreSQL** instance: the API, worker, and admin
-pools fit within **30 of 30 max_connections** out of the box (Postgres
-`max_connections` is set to 30), sized by `DB_POOL_SIZE` (`pool_size`) and
+pools fit within **70 of 80 max_connections** out of the box (Postgres
+`max_connections` is set to 80), sized by `DB_POOL_SIZE` (`pool_size`) and
 `DB_MAX_OVERFLOW` (`max_overflow`, default 3). See
 [Connection Pool Tuning](https://docs.getgeolens.com/guides/quickstart/configuration/#connection-pool-tuning)
 for the per-process budget and how to raise the ceiling.

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -76,9 +76,11 @@ Also set `S3_SECRET_ACCESS_KEY` to your access secret. See `.env.example` for al
 available S3 options including `S3_ALLOW_HTTP`.
 
 The built-in uploader signs requests with **AWS Signature V4** (awscli), compatible
-with Cloudflare R2, modern AWS S3, and MinIO. A failed upload returns non-zero and
-is logged as `ERROR: S3 upload failed for <key>` — a failed offsite upload aborts
-the current backup cycle so the failure is immediately visible in container logs.
+with Cloudflare R2, modern AWS S3, and MinIO. A failed upload is logged as
+`ERROR: S3 upload failed for <key>` and fails the cycle (non-zero exit) **after**
+local retention pruning has run — the local dump is kept and pruned normally even
+when the offsite copy fails, so the failure is visible in container logs without
+sacrificing the local backup.
 
 ### Scope caveat
 
@@ -320,11 +322,11 @@ The `backup` service exposes a Docker healthcheck:
 
 ```bash
 docker compose ps backup    # Status column: healthy / unhealthy / starting
-docker compose inspect backup --format '{{.State.Health.Status}}'
+docker inspect --format '{{.State.Health.Status}}' $(docker compose ps -q backup)
 ```
 
 The check (`pgrep -f backup-entrypoint || pgrep -f sleep`) confirms the entrypoint
-process is running. `start_period` is 30 s; the check runs every 60 s.
+process is running. `start_period` is 30 s; the check runs every 30 s.
 
 ### Log markers
 
@@ -340,7 +342,7 @@ docker compose logs -f backup
 | `Object-storage archive complete: staging-<ts>.tar.gz (<size>)` | `upload_staging` archived alongside the dump |
 | `Backup cycle complete` | Full cycle (dump + staging + S3 if enabled) finished |
 | `ERROR: S3 upload failed for <key>` | Offsite upload failed; cycle returns non-zero |
-| `WARNING: object-storage archive failed (non-fatal)` | Staging tar failed; DB dump is still good |
+| `WARNING: object-storage archive failed — staging backup skipped` | Staging tar failed; DB dump is still good |
 | `ERROR: pg_dump failed` | DB dump failed; no artifacts written for this cycle |
 
 A healthy cycle produces at least `Backup complete` and `Backup cycle complete`.
@@ -370,6 +372,22 @@ docker compose logs backup | grep 'ERROR: S3 upload failed'
 A failed S3 upload causes the backup cycle to exit non-zero (visible as an
 `ERROR: backup S3 upload failed` log line). Investigate S3 credentials and
 endpoint reachability before the next scheduled run.
+
+### PostgreSQL server logs
+
+`docker compose logs db` shows **nothing** by design: the shipped
+`db/postgresql.conf` sets `logging_collector = on`, which routes all PostgreSQL
+output — slow-query lines (`log_min_duration_statement = 1000`), `auto_explain`
+plans, checkpoint activity — into daily-rotated files inside the pgdata volume.
+Read them with:
+
+```bash
+docker compose exec db sh -c 'ls -t /var/lib/postgresql/data/log/'
+docker compose exec db sh -c 'tail -100 "/var/lib/postgresql/data/log/$(ls -t /var/lib/postgresql/data/log/ | head -1)"'
+```
+
+An empty `docker compose logs db` does **not** mean there are no slow queries —
+always check the collector files.
 
 ---
 

--- a/backend/alembic/versions/0026_db_audit_naming_cleanup.py
+++ b/backend/alembic/versions/0026_db_audit_naming_cleanup.py
@@ -1,6 +1,6 @@
-"""db-audit-20260716 naming cleanup: duplicate slug index + staging pkey names.
+"""db-audit #529 naming cleanup: duplicate slug index + staging pkey names.
 
-Two findings from the 2026-07-16 DB audit:
+Two findings from the 2026-07-16 DB audit (PR #529):
 
 BLOAT-1 — `ix_catalog_map_icon_assets_slug` fully duplicated the backing index
 of `uq_map_icon_assets_slug` on the same column; every write maintained both.
@@ -49,10 +49,18 @@ def upgrade() -> None:
             WHERE con.contype = 'p'
               AND con.conname LIKE '%\_staging\_%' ESCAPE '\'
               AND c.relname NOT LIKE '%\_staging\_%' ESCAPE '\'
-              -- Only GeoLens-owned data schemas ('data', or 'data_t_<tenant>'
-              -- per tenant_data_schema); a co-hosted non-GeoLens schema could
+              -- Only GeoLens-owned data schemas: 'data' (single-tenant) or the
+              -- exact per-tenant schemas derived from catalog.tenants — the
+              -- same construction as tenant_data_schema() and migration 0024.
+              -- A co-hosted schema that merely starts with 'data_t_' could
               -- legitimately contain '_staging_' pkey names we must not touch.
-              AND (n.nspname = 'data' OR n.nspname LIKE 'data\_t\_%' ESCAPE '\')
+              AND (
+                n.nspname = 'data'
+                OR n.nspname IN (
+                    SELECT 'data_t_' || pg_catalog.replace(id::text, '-', '_')
+                    FROM catalog.tenants
+                )
+              )
             """
         )
     ).fetchall()

--- a/backend/alembic/versions/0026_db_audit_naming_cleanup.py
+++ b/backend/alembic/versions/0026_db_audit_naming_cleanup.py
@@ -49,7 +49,10 @@ def upgrade() -> None:
             WHERE con.contype = 'p'
               AND con.conname LIKE '%\_staging\_%' ESCAPE '\'
               AND c.relname NOT LIKE '%\_staging\_%' ESCAPE '\'
-              AND n.nspname NOT IN ('pg_catalog', 'information_schema')
+              -- Only GeoLens-owned data schemas ('data', or 'data_t_<tenant>'
+              -- per tenant_data_schema); a co-hosted non-GeoLens schema could
+              -- legitimately contain '_staging_' pkey names we must not touch.
+              AND (n.nspname = 'data' OR n.nspname LIKE 'data\_t\_%' ESCAPE '\')
             """
         )
     ).fetchall()

--- a/backend/alembic/versions/0026_db_audit_naming_cleanup.py
+++ b/backend/alembic/versions/0026_db_audit_naming_cleanup.py
@@ -1,0 +1,86 @@
+"""db-audit-20260716 naming cleanup: duplicate slug index + staging pkey names.
+
+Two findings from the 2026-07-16 DB audit:
+
+BLOAT-1 — `ix_catalog_map_icon_assets_slug` fully duplicated the backing index
+of `uq_map_icon_assets_slug` on the same column; every write maintained both.
+
+BLOAT-3 — `ALTER TABLE ... RENAME TO` at ingest publish kept each table's PK
+constraint (and backing index) named after its attempt-scoped staging table
+(`*_staging_<uuid>_pkey`). Those names are user-visible to anyone connecting
+directly with QGIS/pgAdmin/DBeaver. Ingest now renames the constraint at
+publish (`rename_pkey_to_match_table` in tasks_common.py); this migration
+fixes the tables published before that change, across all tenant schemas.
+
+Downgrade drops back to the pre-audit index but does NOT restore the staging
+pkey names — the attempt UUIDs are gone and the names are cosmetic.
+
+Revision ID: 0026_db_audit_naming_cleanup
+Revises: 0025_dataset_tile_cache_version
+Create Date: 2026-07-16
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0026_db_audit_naming_cleanup"
+down_revision: Union[str, None] = "0025_dataset_tile_cache_version"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.drop_index(
+        "ix_catalog_map_icon_assets_slug",
+        table_name="map_icon_assets",
+        schema="catalog",
+    )
+
+    conn = op.get_bind()
+    rows = conn.execute(
+        sa.text(
+            r"""
+            SELECT n.nspname, c.relname, con.conname
+            FROM pg_constraint con
+            JOIN pg_class c ON c.oid = con.conrelid
+            JOIN pg_namespace n ON n.oid = c.relnamespace
+            WHERE con.contype = 'p'
+              AND con.conname LIKE '%\_staging\_%' ESCAPE '\'
+              AND c.relname NOT LIKE '%\_staging\_%' ESCAPE '\'
+              AND n.nspname NOT IN ('pg_catalog', 'information_schema')
+            """
+        )
+    ).fetchall()
+    for schema, table, conname in rows:
+        desired = f"{table[:58]}_pkey"
+        if conname == desired:
+            continue
+        # Skip if the target index name is already taken in this schema
+        # (e.g. an orphaned *_old table) rather than fail the migration.
+        taken = conn.execute(
+            sa.text(
+                "SELECT 1 FROM pg_class c "
+                "JOIN pg_namespace n ON n.oid = c.relnamespace "
+                "WHERE n.nspname = :schema AND c.relname = :name"
+            ),
+            {"schema": schema, "name": desired},
+        ).scalar()
+        if taken:
+            continue
+        conn.execute(
+            sa.text(
+                f'ALTER TABLE "{schema}"."{table}" '
+                f'RENAME CONSTRAINT "{conname}" TO "{desired}"'
+            )
+        )
+
+
+def downgrade() -> None:
+    op.create_index(
+        "ix_catalog_map_icon_assets_slug",
+        "map_icon_assets",
+        ["slug"],
+        schema="catalog",
+    )

--- a/backend/app/modules/catalog/maps/models.py
+++ b/backend/app/modules/catalog/maps/models.py
@@ -270,7 +270,7 @@ class MapIconAsset(Base):
         primary_key=True, server_default=func.gen_random_uuid()
     )
     name: Mapped[str] = mapped_column(String(255), nullable=False)
-    # db-audit-20260716 BLOAT-1: no index=True — uq_map_icon_assets_slug's
+    # db-audit #529 BLOAT-1: no index=True — uq_map_icon_assets_slug's
     # backing index already covers slug lookups; a second btree was pure
     # write amplification.
     slug: Mapped[str] = mapped_column(String(255), nullable=False)

--- a/backend/app/modules/catalog/maps/models.py
+++ b/backend/app/modules/catalog/maps/models.py
@@ -270,7 +270,10 @@ class MapIconAsset(Base):
         primary_key=True, server_default=func.gen_random_uuid()
     )
     name: Mapped[str] = mapped_column(String(255), nullable=False)
-    slug: Mapped[str] = mapped_column(String(255), nullable=False, index=True)
+    # db-audit-20260716 BLOAT-1: no index=True — uq_map_icon_assets_slug's
+    # backing index already covers slug lookups; a second btree was pure
+    # write amplification.
+    slug: Mapped[str] = mapped_column(String(255), nullable=False)
     media_type: Mapped[str] = mapped_column(String(50), nullable=False)
     storage_key: Mapped[str] = mapped_column(Text, nullable=False)
     size_bytes: Mapped[int] = mapped_column(Integer, nullable=False)

--- a/backend/app/processing/ingest/tasks_common.py
+++ b/backend/app/processing/ingest/tasks_common.py
@@ -57,7 +57,7 @@ async def rename_pkey_to_match_table(session: "AsyncSession", table_name: str) -
     ALTER TABLE ... RENAME TO keeps the constraint (and its backing index)
     named after the attempt-scoped staging table (``*_staging_<uuid>_pkey``),
     which is what QGIS/pgAdmin/DBeaver users see on a direct connection
-    (db-audit-20260716). Call inside the publish transaction, which already
+    (db-audit #529). Call inside the publish transaction, which already
     holds the table's AccessExclusiveLock from the rename, so this cannot
     block. Failure is cosmetic and must never fail the ingest — it is
     swallowed under a SAVEPOINT and logged.

--- a/backend/app/processing/ingest/tasks_common.py
+++ b/backend/app/processing/ingest/tasks_common.py
@@ -51,6 +51,52 @@ def _current_tenant_schema() -> str:
     return tenant_data_schema(tenant_id)
 
 
+async def rename_pkey_to_match_table(session: "AsyncSession", table_name: str) -> None:
+    """Rename a just-published table's PK constraint to ``<table>_pkey``.
+
+    ALTER TABLE ... RENAME TO keeps the constraint (and its backing index)
+    named after the attempt-scoped staging table (``*_staging_<uuid>_pkey``),
+    which is what QGIS/pgAdmin/DBeaver users see on a direct connection
+    (db-audit-20260716). Call inside the publish transaction, which already
+    holds the table's AccessExclusiveLock from the rename, so this cannot
+    block. Failure is cosmetic and must never fail the ingest — it is
+    swallowed under a SAVEPOINT and logged.
+    """
+    from sqlalchemy import text
+
+    from app.processing.ingest.metadata import _qtable
+
+    schema = _current_tenant_schema()
+    desired = f"{table_name[:58]}_pkey"
+    try:
+        async with session.begin_nested():
+            result = await session.execute(
+                text(
+                    "SELECT con.conname FROM pg_constraint con "
+                    "JOIN pg_class c ON c.oid = con.conrelid "
+                    "JOIN pg_namespace n ON n.oid = c.relnamespace "
+                    "WHERE n.nspname = :schema AND c.relname = :tn "
+                    "AND con.contype = 'p'"
+                ),
+                {"schema": schema, "tn": table_name},
+            )
+            current = result.scalar()
+            if current and current != desired:
+                await session.execute(
+                    text(
+                        f"ALTER TABLE {_qtable(table_name, schema=schema)} "
+                        f'RENAME CONSTRAINT "{current}" TO "{desired}"'
+                    )
+                )
+    except Exception:  # broad: cosmetic rename must never fail the publish
+        structlog.get_logger().warning(
+            "pkey_rename_failed",
+            table_name=table_name,
+            schema=schema,
+            exc_info=True,
+        )
+
+
 def _current_tenant_role() -> str:
     """Return the reader role for the current tenant (or 'geolens_reader' in single_tenant).
 
@@ -1408,6 +1454,9 @@ async def _apply_reupload_swap(
                     f"DROP TABLE IF EXISTS {_qtable(table_name + '_old', schema=_tenant_schema)}"
                 )
             )
+        # After the _old table (and its identically-named pkey index) is gone,
+        # give the new live table's PK its final name.
+        await rename_pkey_to_match_table(session, table_name)
 
     _FIRST_TIMEOUT = "5s"
     _RETRY_TIMEOUT = "15s"

--- a/backend/app/processing/ingest/tasks_vector.py
+++ b/backend/app/processing/ingest/tasks_vector.py
@@ -33,6 +33,7 @@ from app.processing.ingest.tasks_common import (
     _resolve_effective_srid,
     _run_service_import_with_wfs_fallback,
     _validate_upload_file_safety,
+    rename_pkey_to_match_table,
     resolve_service_type,
     task_app,
 )
@@ -67,6 +68,8 @@ async def _publish_attempt_staging_table(
             f'RENAME TO "{live_table}"'
         )
     )
+    # RENAME TO keeps the staging-era pkey name; fix it while we hold the lock.
+    await rename_pkey_to_match_table(session, live_table)
 
 
 async def _drop_attempt_staging_table(staging_table: str) -> None:

--- a/backend/tests/test_phase_274_caches_and_pool.py
+++ b/backend/tests/test_phase_274_caches_and_pool.py
@@ -95,14 +95,14 @@ def test_readme_documents_perf_05_in_effect():
     )
 
 
-def test_env_example_dbm04_comment_references_30():
-    """PERF-05: .env.example DBM-04 comment block references max_connections=30."""
+def test_env_example_dbm04_comment_references_80():
+    """PERF-05 + db-audit-20260716: .env.example DBM-04 comment matches the live budget."""
     env_example = (_REPO_ROOT / ".env.example").read_text()
     assert (
-        "max_connections=30" in env_example or "max_connections = 30" in env_example
+        "max_connections=80" in env_example or "max_connections = 80" in env_example
     ), (
-        ".env.example DBM-04 comment must reference max_connections=30 "
-        "after PERF-05 lands."
+        ".env.example DBM-04 comment must reference the shipped max_connections=80 "
+        "(keep it in lockstep with db/postgresql.conf and the README envelope)."
     )
 
 

--- a/backend/tests/test_phase_274_caches_and_pool.py
+++ b/backend/tests/test_phase_274_caches_and_pool.py
@@ -34,10 +34,10 @@ def _reset_has_embeddings_cache() -> None:
 
 
 def test_postgresql_conf_max_connections_is_80():
-    """PERF-05 + v1039 PERF-003 + db-audit-20260716 CONN-1: max_connections = 80.
+    """PERF-05 + v1039 PERF-003 + db-audit #529 CONN-1: max_connections = 80.
 
     v1039 PERF-003 found the old budget (30) undercounted the asyncpg tile pool
-    + procrastinate connectors and raised it to 70. db-audit-20260716 CONN-1
+    + procrastinate connectors and raised it to 70. db-audit #529 CONN-1
     found that 70 still omitted the API-side Procrastinate connector (each
     uvicorn worker opens task_app for enqueueing, max_size=3), putting the
     worst case at 68 > 67 non-reserved slots. Raised to 80 with itemized math
@@ -56,7 +56,7 @@ def test_postgresql_conf_max_connections_is_80():
     )
     # Match `max_connections = 80` allowing trailing whitespace + inline comment.
     assert re.match(r"^max_connections\s*=\s*80(\s|$|#)", max_conn_lines[0]), (
-        f"db-audit-20260716 CONN-1: expected max_connections = 80, got: {max_conn_lines[0]}"
+        f"db-audit #529 CONN-1: expected max_connections = 80, got: {max_conn_lines[0]}"
     )
 
 
@@ -84,7 +84,7 @@ def test_readme_no_longer_says_perf_05_planned():
 def test_readme_documents_perf_05_in_effect():
     """PERF-05: README budget section matches the shipped connection envelope.
 
-    db-audit-20260716: the README claimed "30 of 30" long after the conf moved
+    db-audit #529: the README claimed "30 of 30" long after the conf moved
     to 70 — this gate now pins the README to the live 70-of-80 envelope so the
     two can't drift apart silently again.
     """
@@ -96,7 +96,7 @@ def test_readme_documents_perf_05_in_effect():
 
 
 def test_env_example_dbm04_comment_references_80():
-    """PERF-05 + db-audit-20260716: .env.example DBM-04 comment matches the live budget."""
+    """PERF-05 + db-audit #529: .env.example DBM-04 comment matches the live budget."""
     env_example = (_REPO_ROOT / ".env.example").read_text()
     assert (
         "max_connections=80" in env_example or "max_connections = 80" in env_example

--- a/backend/tests/test_phase_274_caches_and_pool.py
+++ b/backend/tests/test_phase_274_caches_and_pool.py
@@ -33,11 +33,14 @@ def _reset_has_embeddings_cache() -> None:
 # --- PERF-05: postgresql.conf max_connections --------------------------------
 
 
-def test_postgresql_conf_max_connections_is_70():
-    """PERF-05 + v1039 PERF-003: max_connections recomputed to 70.
+def test_postgresql_conf_max_connections_is_80():
+    """PERF-05 + v1039 PERF-003 + db-audit-20260716 CONN-1: max_connections = 80.
 
     v1039 PERF-003 found the old budget (30) undercounted the asyncpg tile pool
-    + procrastinate connectors (worst case ~64). Raised to 70 with itemized math
+    + procrastinate connectors and raised it to 70. db-audit-20260716 CONN-1
+    found that 70 still omitted the API-side Procrastinate connector (each
+    uvicorn worker opens task_app for enqueueing, max_size=3), putting the
+    worst case at 68 > 67 non-reserved slots. Raised to 80 with itemized math
     in db/postgresql.conf.
     """
     conf = (_REPO_ROOT / "db" / "postgresql.conf").read_text()
@@ -51,9 +54,9 @@ def test_postgresql_conf_max_connections_is_70():
     assert len(max_conn_lines) == 1, (
         f"Expected exactly one max_connections directive; found {max_conn_lines}"
     )
-    # Match `max_connections = 70` allowing trailing whitespace + inline comment.
-    assert re.match(r"^max_connections\s*=\s*70(\s|$|#)", max_conn_lines[0]), (
-        f"v1039 PERF-003: expected max_connections = 70, got: {max_conn_lines[0]}"
+    # Match `max_connections = 80` allowing trailing whitespace + inline comment.
+    assert re.match(r"^max_connections\s*=\s*80(\s|$|#)", max_conn_lines[0]), (
+        f"db-audit-20260716 CONN-1: expected max_connections = 80, got: {max_conn_lines[0]}"
     )
 
 
@@ -79,17 +82,17 @@ def test_readme_no_longer_says_perf_05_planned():
 
 
 def test_readme_documents_perf_05_in_effect():
-    """PERF-05: README budget table mentions max_connections of 30 in effect."""
+    """PERF-05: README budget section matches the shipped connection envelope.
+
+    db-audit-20260716: the README claimed "30 of 30" long after the conf moved
+    to 70 — this gate now pins the README to the live 70-of-80 envelope so the
+    two can't drift apart silently again.
+    """
     readme = (_REPO_ROOT / "README.md").read_text()
     assert "max_connections" in readme
-    # Either the new totals row "30 of 30" or the explicit 50 -> 30 sentence
-    # is enough to confirm PERF-05 is documented as live.
-    assert (
-        "30 of `30 max_connections" in readme
-        or "30 of 30 max_connections" in readme
-        or "`max_connections` 50 → 30" in readme
-        or "max_connections 50 -> 30" in readme
-    ), "README must show the PERF-05 envelope (30 of 30) or the 50->30 transition."
+    assert "70 of 80 max_connections" in readme, (
+        "README must show the shipped connection envelope (70 of 80)."
+    )
 
 
 def test_env_example_dbm04_comment_references_30():

--- a/backend/tests/test_reupload_swap_lock_retry.py
+++ b/backend/tests/test_reupload_swap_lock_retry.py
@@ -226,7 +226,7 @@ class TestApplyReuploadSwapRetry:
         ).scalar()
         assert staging_exists is False
 
-        # db-audit-20260716 BLOAT-3: the swap also renamed the staging-era PK
+        # db-audit #529 BLOAT-3: the swap also renamed the staging-era PK
         # constraint, so direct-DB clients see `<live_table>_pkey`.
         pkey = (
             await self.session.execute(
@@ -370,7 +370,7 @@ class TestApplyReuploadSwapRetry:
 
 
 class TestRenamePkeyToMatchTable:
-    """Direct coverage for ``rename_pkey_to_match_table`` (db-audit-20260716 BLOAT-3)."""
+    """Direct coverage for ``rename_pkey_to_match_table`` (db-audit #529 BLOAT-3)."""
 
     _PKEY_SQL = (
         "SELECT con.conname FROM pg_constraint con "

--- a/backend/tests/test_reupload_swap_lock_retry.py
+++ b/backend/tests/test_reupload_swap_lock_retry.py
@@ -22,6 +22,7 @@ from sqlalchemy import text
 from app.processing.ingest.tasks_common import (
     _apply_reupload_swap,
     _is_lock_timeout_error,
+    rename_pkey_to_match_table,
 )
 
 
@@ -225,6 +226,22 @@ class TestApplyReuploadSwapRetry:
         ).scalar()
         assert staging_exists is False
 
+        # db-audit-20260716 BLOAT-3: the swap also renamed the staging-era PK
+        # constraint, so direct-DB clients see `<live_table>_pkey`.
+        pkey = (
+            await self.session.execute(
+                text(
+                    "SELECT con.conname FROM pg_constraint con "
+                    "JOIN pg_class c ON c.oid = con.conrelid "
+                    "JOIN pg_namespace n ON n.oid = c.relnamespace "
+                    "WHERE n.nspname = 'data' AND c.relname = :tn "
+                    "AND con.contype = 'p'"
+                ),
+                {"tn": self.live},
+            )
+        ).scalar_one()
+        assert pkey == f"{self.live}_pkey"
+
     async def test_retry_path_logs_and_succeeds(self, monkeypatch) -> None:
         """First swap raises ``LockNotAvailableError``; retry succeeds and both logs fire."""
         dataset = _make_dataset_stub(self.live)
@@ -350,3 +367,50 @@ class TestApplyReuploadSwapRetry:
             await self.session.execute(text(f'SELECT name FROM data."{self.live}"'))
         ).scalar_one()
         assert row == "new_data"
+
+
+class TestRenamePkeyToMatchTable:
+    """Direct coverage for ``rename_pkey_to_match_table`` (db-audit-20260716 BLOAT-3)."""
+
+    _PKEY_SQL = (
+        "SELECT con.conname FROM pg_constraint con "
+        "JOIN pg_class c ON c.oid = con.conrelid "
+        "JOIN pg_namespace n ON n.oid = c.relnamespace "
+        "WHERE n.nspname = 'data' AND c.relname = :tn AND con.contype = 'p'"
+    )
+
+    async def test_renames_staging_pkey_and_is_idempotent(
+        self, test_db_session
+    ) -> None:
+        """A staging-era pkey name is renamed; a second call is a no-op."""
+        suffix = uuid.uuid4().hex[:8]
+        table = f"pkey_fix_{suffix}"
+        staging_pkey = f"{table}_staging_{suffix}_pkey"
+        await test_db_session.execute(
+            text(
+                f'CREATE TABLE data."{table}" '
+                f'(id serial CONSTRAINT "{staging_pkey}" PRIMARY KEY)'
+            )
+        )
+        try:
+            await rename_pkey_to_match_table(test_db_session, table)
+            pkey = (
+                await test_db_session.execute(text(self._PKEY_SQL), {"tn": table})
+            ).scalar_one()
+            assert pkey == f"{table}_pkey"
+
+            # Idempotent: already-correct name stays put, no error raised.
+            await rename_pkey_to_match_table(test_db_session, table)
+            pkey = (
+                await test_db_session.execute(text(self._PKEY_SQL), {"tn": table})
+            ).scalar_one()
+            assert pkey == f"{table}_pkey"
+        finally:
+            await test_db_session.execute(
+                text(f'DROP TABLE IF EXISTS data."{table}" CASCADE')
+            )
+            await test_db_session.commit()
+
+    async def test_missing_table_is_swallowed(self, test_db_session) -> None:
+        """A vanished table must not raise — the rename is cosmetic by contract."""
+        await rename_pkey_to_match_table(test_db_session, "no_such_table_anywhere_xyz")

--- a/db/postgresql.conf
+++ b/db/postgresql.conf
@@ -8,20 +8,24 @@
 # Connection
 # ---------------------------------------------------------------------------
 listen_addresses = '*'
-max_connections = 70                   # PERF-003 (Phase 1184): recomputed from actual pool configs.
+max_connections = 80                   # PERF-003, recomputed by db-audit-20260716 (CONN-1): the original
+                                       # 70 omitted the API-side Procrastinate connector — every uvicorn
+                                       # worker opens one for job ENQUEUEING (task_app.open_async() in
+                                       # api/main.py lifespan), not just the worker process.
                                        # Per-process breakdown (all limits are worst-case / max_size):
-                                       #   API process (SQLAlchemy):  pool_size=10 + max_overflow=3 = 13  [config.py:129-130, session.py:18-19]
-                                       #   API process (asyncpg tile): TILE_POOL_MAX_SIZE default = 10   [config.py:135, tiles/pool.py:89]
-                                       #   API process total per worker: 13 + 10 = 23
-                                       #   Worker (SQLAlchemy):        pool_size=10 + max_overflow=3 = 13  [config.py:129-130]
-                                       #   Worker (Procrastinate):     PsycopgConnector max_size = 3    [tasks_common.py:71-72]
-                                       #   Worker process total:        13 + 3 = 16
-                                       #   Admin headroom (psql/ops):   2
+                                       #   API process (SQLAlchemy):    pool_size=10 + max_overflow=3 = 13  [config.py db_pool_size/db_max_overflow; core/db/session.py]
+                                       #   API process (asyncpg tile):  TILE_POOL_MAX_SIZE default = 10     [config.py tile_pool_max_size; tiles/pool.py]
+                                       #   API process (Procrastinate): PsycopgConnector max_size = 3       [tasks_common.py _connector_kwargs]
+                                       #   API process total per worker: 13 + 10 + 3 = 26
+                                       #   Worker (SQLAlchemy):         pool_size=10 + max_overflow=3 = 13
+                                       #   Worker (Procrastinate):      PsycopgConnector max_size = 3
+                                       #   Worker process total:         13 + 3 = 16
+                                       #   Admin headroom (psql/ops):    2
                                        # Worst case: 2 API workers (prod default) + 1 worker + admin
-                                       #   2 × 23 + 16 + 2 = 64 → round up to 70 with 6-connection buffer.
+                                       #   2 × 26 + 16 + 2 = 70 → 80 keeps a 10-connection buffer.
                                        # Single-worker dev (UVICORN_WORKERS=1):
-                                       #   1 × 23 + 16 + 2 = 41 (well within 70).
-                                       # Raise TILE_POOL_MAX_SIZE or DB_POOL_SIZE in .env to stay under 70
+                                       #   1 × 26 + 16 + 2 = 44 (well within 80).
+                                       # Lower TILE_POOL_MAX_SIZE or DB_POOL_SIZE in .env to stay under 80
                                        # if adding more API workers. See docs.getgeolens.com/guides/quickstart/configuration/#connection-pool-tuning
 
 # ---------------------------------------------------------------------------
@@ -29,6 +33,9 @@ max_connections = 70                   # PERF-003 (Phase 1184): recomputed from 
 # ---------------------------------------------------------------------------
 # Tracks execution statistics for all SQL statements.
 # Query with: SELECT * FROM pg_stat_statements ORDER BY total_exec_time DESC;
+# Stats are CLUSTER-wide — on hosts that also run pytest databases, filter with
+#   WHERE dbid = (SELECT oid FROM pg_database WHERE datname = current_database())
+# or TRUNCATE/DROP DATABASE noise from test runs dominates the rankings.
 shared_preload_libraries = 'pg_stat_statements,auto_explain'
 pg_stat_statements.max = 5000
 pg_stat_statements.track = all
@@ -46,6 +53,13 @@ auto_explain.log_format = text
 # ---------------------------------------------------------------------------
 # Logging
 # ---------------------------------------------------------------------------
+# NOTE (db-audit-20260716): with the collector on, ALL PostgreSQL output —
+# slow-query lines, auto_explain plans, checkpoints — lands in files under
+# $PGDATA/log/ inside the pgdata volume. `docker compose logs db` shows
+# NOTHING by design. Read with:
+#   docker compose exec db sh -c 'ls -t /var/lib/postgresql/data/log/ | head'
+#   docker compose exec db sh -c 'tail -100 /var/lib/postgresql/data/log/<file>'
+# Kept on deliberately: log files survive container restarts and rotate daily.
 logging_collector = on
 log_destination = 'stderr'
 
@@ -85,6 +99,10 @@ maintenance_work_mem = 128MB
 # ---------------------------------------------------------------------------
 wal_buffers = 16MB
 min_wal_size = 100MB
+max_wal_size = 1GB                  # Explicit PG default (db-audit-20260716). Bulk GDAL/ogr2ogr
+                                    # ingests can hit checkpoint storms at 1GB — raise to 2GB on
+                                    # ingest-heavy hosts if `checkpoints are occurring too frequently`
+                                    # warnings appear in $PGDATA/log/.
 
 # ---------------------------------------------------------------------------
 # Logging (slow queries)

--- a/db/postgresql.conf
+++ b/db/postgresql.conf
@@ -8,7 +8,7 @@
 # Connection
 # ---------------------------------------------------------------------------
 listen_addresses = '*'
-max_connections = 80                   # PERF-003, recomputed by db-audit-20260716 (CONN-1): the original
+max_connections = 80                   # PERF-003, recomputed by db-audit #529 (CONN-1): the original
                                        # 70 omitted the API-side Procrastinate connector — every uvicorn
                                        # worker opens one for job ENQUEUEING (task_app.open_async() in
                                        # api/main.py lifespan), not just the worker process.
@@ -53,7 +53,7 @@ auto_explain.log_format = text
 # ---------------------------------------------------------------------------
 # Logging
 # ---------------------------------------------------------------------------
-# NOTE (db-audit-20260716): with the collector on, ALL PostgreSQL output —
+# NOTE (db-audit #529): with the collector on, ALL PostgreSQL output —
 # slow-query lines, auto_explain plans, checkpoints — lands in files under
 # $PGDATA/log/ inside the pgdata volume. `docker compose logs db` shows
 # NOTHING by design. Read with:
@@ -99,7 +99,7 @@ maintenance_work_mem = 128MB
 # ---------------------------------------------------------------------------
 wal_buffers = 16MB
 min_wal_size = 100MB
-max_wal_size = 1GB                  # Explicit PG default (db-audit-20260716). Bulk GDAL/ogr2ogr
+max_wal_size = 1GB                  # Explicit PG default (db-audit #529). Bulk GDAL/ogr2ogr
                                     # ingests can hit checkpoint storms at 1GB — raise to 2GB on
                                     # ingest-heavy hosts if `checkpoints are occurring too frequently`
                                     # warnings appear in $PGDATA/log/.


### PR DESCRIPTION
## Summary

Remediates the actionable findings from the first `/db-audit` run (2026-07-16, overall B-, 1 P1). Audit report lives in `docs-internal/audits/db-audit-20260716.md` (untracked by design).

### CONN-1 (P1) — connection budget omitted the API-side Procrastinate connector
Every uvicorn API worker opens `task_app` for job enqueueing (`api/main.py` lifespan), adding up to 3 connections per worker that the PERF-003 model in `db/postgresql.conf` never counted. Worst-case prod demand was 68 against 67 non-reserved slots — the documented 6-connection buffer was silently consumed. Fixed by bumping `max_connections` 70 → 80 and rewriting the budget comment with the corrected per-process model (plus durable file/symbol citations and the "Raise" → "Lower" wording fix).

### BLOAT-3 — staging-era PK constraint names on published tables
`ALTER TABLE … RENAME TO` keeps the constraint (and backing index) named after the attempt-scoped staging table (`*_staging_<uuid>_pkey`). All 14 ingested `data.*` tables carried these — directly visible to QGIS/pgAdmin/DBeaver users on direct connections. New `rename_pkey_to_match_table()` runs at publish in both paths (initial ingest `_publish_attempt_staging_table`, reupload `_apply_reupload_swap` — after the `_old` drop to avoid index-name collision), savepoint-guarded so a cosmetic rename can never fail an ingest. Migration `0026` fixes pre-existing tables across all tenant schemas, skipping in-flight staging tables and taken names.

### BLOAT-1 — duplicate index
`ix_catalog_map_icon_assets_slug` was fully shadowed by `uq_map_icon_assets_slug`'s backing index; dropped in migration 0026 + `index=True` removed from the model.

### BKR-1..3 — RUNBOOK drift
Dead `docker compose inspect` command replaced, log-marker string and healthcheck interval aligned with the shipped scripts, S3-failure wording corrected (cycle completes retention pruning, then exits non-zero).

### CFG-1/2 — observability & WAL
Documented that `logging_collector=on` routes ALL PG output to `$PGDATA/log/` (`docker compose logs db` is empty by design) — conf comment + new RUNBOOK §4 subsection. Made `max_wal_size` explicit with ingest-heavy guidance; added a dbid-filter tip for cluster-wide `pg_stat_statements`.

### READMEs (4 locales)
The connection-budget section claimed `max_connections=30` — stale even against the previous 70. Aligned with the shipped 80 (worst case 70).

## Impacts
- **Config**: `max_connections` 70 → 80 — applied on db container restart (conf is volume-mounted). Worst-case memory budget rises ~80 MB (8 MB work_mem × 10 conns), still ~1.8 GB vs the 2 GiB container limit.
- **Schema**: migration `0026_db_audit_naming_cleanup` — index drop + constraint renames only, no data changes. Downgrade restores the index; staging pkey names are not restorable (cosmetic, attempt UUIDs gone).
- **Docs follow-up (external)**: docs.getgeolens.com `connection-pool-tuning` page still shows the old budget — needs a sync in the docs repo.
- **Deferred (documented, not in this PR)**: CONN-2 — app role is SUPERUSER (prod-relevance, needs its own design pass); QP-01 tile-plan flip (owned by /perf-profile); per-user account export (product scoping).

## Verification
```
cd backend && uv run ruff check . && uv run ruff format --check .   # clean
# scratch DB on the test Postgres: full chain 0001→0026, then downgrade→upgrade
# with fixtures: staging-named pkey (renamed ✓), in-flight *_staging_* table (untouched ✓),
# ix_catalog_map_icon_assets_slug gone / uq index kept ✓
POSTGRES_DB=scratch PYTHONPATH=. uv run alembic upgrade head && uv run alembic check   # 'No new upgrade operations detected'
uv run pytest tests/test_layering.py tests/test_reupload_swap_lock_retry.py \
  tests/test_ingest_job_attempt_fencing.py tests/test_staging_pipeline_integration.py \
  tests/test_provenance_attribution.py tests/test_phase_273_icon_csp.py   # 54 passed
```

https://claude.ai/code/session_01NTRWzEErmEcje3KFy2GejS