### PR TITLE
docs(api): remove 'in every edition' tier phrasing from share-expiry docs

### DIFF
--- a/backend/app/modules/catalog/maps/router_sharing.py
+++ b/backend/app/modules/catalog/maps/router_sharing.py
@@ -305,7 +305,7 @@ async def update_map_share_token_endpoint(
 ) -> ShareTokenResponse:
     """Update expiration on an existing share token. Owner or admin only.
 
-    A fixed-day preset is available in every edition. Null clears expiration.
+    A fixed-day preset is always available. Null clears expiration.
     """
     map_obj = await get_map(db, map_id)
     if map_obj is None:

--- a/backend/app/modules/catalog/maps/schemas.py
+++ b/backend/app/modules/catalog/maps/schemas.py
@@ -1175,8 +1175,7 @@ class ShareTokenRequest(BaseModel):
     expires_in_days: ShareExpirationPresetDays | None = Field(
         default=None,
         description=(
-            "Server-calculated expiration preset available in every edition. "
-            "Choose 1, 7, 30, or 90 days."
+            "Server-calculated expiration preset. Choose 1, 7, 30, or 90 days."
         ),
     )
 

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -13706,7 +13706,7 @@
                 "type": "null"
               }
             ],
-            "description": "Server-calculated expiration preset available in every edition. Choose 1, 7, 30, or 90 days.",
+            "description": "Server-calculated expiration preset. Choose 1, 7, 30, or 90 days.",
             "title": "Expires In Days"
           }
         },
@@ -44902,7 +44902,7 @@
         ]
       },
       "patch": {
-        "description": "Update expiration on an existing share token. Owner or admin only.\n\nA fixed-day preset is available in every edition. Null clears expiration.",
+        "description": "Update expiration on an existing share token. Owner or admin only.\n\nA fixed-day preset is always available. Null clears expiration.",
         "operationId": "update_map_share_token_endpoint_maps__map_id__share__patch",
         "parameters": [
           {

--- a/frontend/src/types/api.generated.ts
+++ b/frontend/src/types/api.generated.ts
@@ -3620,7 +3620,7 @@ export interface paths {
          * Update Map Share Token Endpoint
          * @description Update expiration on an existing share token. Owner or admin only.
          *
-         *     A fixed-day preset is available in every edition. Null clears expiration.
+         *     A fixed-day preset is always available. Null clears expiration.
          */
         patch: operations["update_map_share_token_endpoint_maps__map_id__share__patch"];
         trace?: never;
@@ -10797,7 +10797,7 @@ export interface components {
             expires_at?: string | null;
             /**
              * Expires In Days
-             * @description Server-calculated expiration preset available in every edition. Choose 1, 7, 30, or 90 days.
+             * @description Server-calculated expiration preset. Choose 1, 7, 30, or 90 days.
              */
             expires_in_days?: (1 | 7 | 30 | 90) | null;
         };

--- a/sdks/python/geolens/api/maps/update_map_share_token_endpoint_maps_map_id_share_patch.py
+++ b/sdks/python/geolens/api/maps/update_map_share_token_endpoint_maps_map_id_share_patch.py
@@ -116,7 +116,7 @@ def sync_detailed(
 
      Update expiration on an existing share token. Owner or admin only.
 
-    A fixed-day preset is available in every edition. Null clears expiration.
+    A fixed-day preset is always available. Null clears expiration.
 
     Args:
         map_id (UUID):
@@ -152,7 +152,7 @@ def sync(
 
      Update expiration on an existing share token. Owner or admin only.
 
-    A fixed-day preset is available in every edition. Null clears expiration.
+    A fixed-day preset is always available. Null clears expiration.
 
     Args:
         map_id (UUID):
@@ -183,7 +183,7 @@ async def asyncio_detailed(
 
      Update expiration on an existing share token. Owner or admin only.
 
-    A fixed-day preset is available in every edition. Null clears expiration.
+    A fixed-day preset is always available. Null clears expiration.
 
     Args:
         map_id (UUID):
@@ -217,7 +217,7 @@ async def asyncio(
 
      Update expiration on an existing share token. Owner or admin only.
 
-    A fixed-day preset is available in every edition. Null clears expiration.
+    A fixed-day preset is always available. Null clears expiration.
 
     Args:
         map_id (UUID):

--- a/sdks/python/geolens/models/share_token_request.py
+++ b/sdks/python/geolens/models/share_token_request.py
@@ -28,8 +28,8 @@ class ShareTokenRequest:
     Attributes:
         expires_at (datetime.datetime | None | Unset): Expiration timestamp; must carry a UTC offset. Null creates a
             non-expiring share link. A custom expiration requires advanced sharing controls.
-        expires_in_days (None | ShareTokenRequestExpiresInDaysType0 | Unset): Server-calculated expiration preset
-            available in every edition. Choose 1, 7, 30, or 90 days.
+        expires_in_days (None | ShareTokenRequestExpiresInDaysType0 | Unset): Server-calculated expiration preset.
+            Choose 1, 7, 30, or 90 days.
     """
 
     expires_at: datetime.datetime | None | Unset = UNSET

--- a/sdks/typescript/src/client/sdk.gen.ts
+++ b/sdks/typescript/src/client/sdk.gen.ts
@@ -3960,7 +3960,7 @@ export const getMapShareTokenEndpointMapsMapIdShareGet = <ThrowOnError extends b
  *
  * Update expiration on an existing share token. Owner or admin only.
  *
- * A fixed-day preset is available in every edition. Null clears expiration.
+ * A fixed-day preset is always available. Null clears expiration.
  */
 export const updateMapShareTokenEndpointMapsMapIdSharePatch = <ThrowOnError extends boolean = false>(options: Options<UpdateMapShareTokenEndpointMapsMapIdSharePatchData, ThrowOnError>): RequestResult<UpdateMapShareTokenEndpointMapsMapIdSharePatchResponses, UpdateMapShareTokenEndpointMapsMapIdSharePatchErrors, ThrowOnError> => (options.client ?? client).patch<UpdateMapShareTokenEndpointMapsMapIdSharePatchResponses, UpdateMapShareTokenEndpointMapsMapIdSharePatchErrors, ThrowOnError>({
     security: [

--- a/sdks/typescript/src/client/types.gen.ts
+++ b/sdks/typescript/src/client/types.gen.ts
@@ -8009,7 +8009,7 @@ export type ShareTokenRequest = {
     /**
      * Expires In Days
      *
-     * Server-calculated expiration preset available in every edition. Choose 1, 7, 30, or 90 days.
+     * Server-calculated expiration preset. Choose 1, 7, 30, or 90 days.
      */
     expires_in_days?: 1 | 7 | 30 | 90 | null;
 };


### PR DESCRIPTION
## Summary

The share-token expiry docstrings said the fixed-day preset is *"available in every edition"* — tier/edition phrasing on public API surfaces. These descriptions flow verbatim into `backend/openapi.json`, both generated SDKs, and the rendered API reference at docs.getgeolens.com, where the 2026-07-16 separation audit flagged them as the last remaining edition prose in the snapshot (the surfaces are de-commercialized for the beta window).

## Changes

- `catalog/maps/schemas.py` — `expires_in_days` description: "Server-calculated expiration preset. Choose 1, 7, 30, or 90 days."
- `catalog/maps/router_sharing.py` — PATCH share docstring: "A fixed-day preset is always available. Null clears expiration."
- `backend/openapi.json` + Python/TypeScript SDKs regenerated (`make openapi && make sdks`)

No behavior change — docstrings and generated artifacts only.

## Verification

- `make openapi-check` — PASS
- `make sdks-check` — PASS (regen is a fixpoint; TS build + tests green)

## Downstream

getgeolens.com's committed OpenAPI snapshot picks this up via its release-sync flow after the next release (geolens-io/getgeolens.com#55 has context).