### PR TITLE
fix(quicklook): call hooks unconditionally so a cached 404 can't crash consumers

### DIFF
--- a/frontend/src/components/maps/hooks/__tests__/use-quicklook.test.ts
+++ b/frontend/src/components/maps/hooks/__tests__/use-quicklook.test.ts
@@ -113,6 +113,26 @@ describe('useQuicklook', () => {
     expect(mockApiFetchBlob).toHaveBeenCalledTimes(1);
   });
 
+  // Test 4b: regression — after a 404 populates the negative cache, the SAME
+  // component instance must survive a re-render. The old implementation
+  // early-returned before its hooks once isQuicklookKnownMissing flipped true,
+  // throwing "Rendered fewer hooks than expected".
+  it('survives a re-render of the same instance after a 404 (rules-of-hooks regression)', async () => {
+    const id = 'dataset-404-rerender';
+    mockApiFetchBlob.mockRejectedValueOnce(new ApiError('Not Found', 404));
+
+    const { result, rerender } = renderHook(() => useQuicklook(id), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.status).toBe('missing'));
+
+    rerender();
+
+    expect(result.current).toEqual({ url: null, status: 'missing' });
+    expect(mockApiFetchBlob).toHaveBeenCalledTimes(1);
+  });
+
   // Test 5: non-404 error -> status error, markQuicklookMissing NOT called
   it('returns error status for non-404 errors without calling markQuicklookMissing', async () => {
     const id = 'dataset-500';

--- a/frontend/src/components/maps/hooks/use-quicklook.ts
+++ b/frontend/src/components/maps/hooks/use-quicklook.ts
@@ -24,6 +24,11 @@ export interface UseQuicklookResult {
  * valid JWT. Those are cached in quicklook-cache.ts for the session so we
  * don't re-fetch them on re-render.
  *
+ * Hooks are called unconditionally and the fetch is gated with `enabled` —
+ * an early return for null/known-missing ids would change the hook count on
+ * the render AFTER a 404 populates the negative cache ("Rendered fewer hooks
+ * than expected", crashing the consumer to its error boundary).
+ *
  * Blob URL lifecycle: the blob URL is cached in React Query under the
  * quicklook key and shared across consumers. Revocation is tied to the QUERY
  * CACHE (eviction / refetch-replacement) via registerBlobUrlRevocation, NOT to
@@ -34,25 +39,10 @@ export function useQuicklook(
   datasetId: string | null,
   size: number = 256,
 ): UseQuicklookResult {
-  // Short-circuit: no dataset — idle
-  if (datasetId == null) {
-    return { url: null, status: 'idle' };
-  }
-
-  // Short-circuit: already known missing for this session — don't fetch
-  if (isQuicklookKnownMissing(datasetId)) {
-    return { url: null, status: 'missing' };
-  }
-
-  // eslint-disable-next-line react-hooks/rules-of-hooks -- early return only happens when hooks aren't needed (datasetId is null or missing)
-  return useQuicklookQuery(datasetId, size);
-}
-
-// Separated inner hook so the early-return pattern above doesn't violate React
-// hooks exhaustive-deps lint; all conditional logic happens before any hook calls.
-function useQuicklookQuery(datasetId: string, size: number): UseQuicklookResult {
   const queryClient = useQueryClient();
   useEffect(() => { registerBlobUrlRevocation(queryClient); }, [queryClient]);
+
+  const knownMissing = datasetId != null && isQuicklookKnownMissing(datasetId);
 
   const {
     data,
@@ -64,13 +54,20 @@ function useQuicklookQuery(datasetId: string, size: number): UseQuicklookResult 
       const blob = await apiFetchBlob(`/datasets/${datasetId}/quicklook?size=${size}`);
       return URL.createObjectURL(blob);
     },
-    enabled: true,
+    enabled: datasetId != null && !knownMissing,
     staleTime: 5 * 60_000,
     gcTime: 10 * 60_000,
     retry: false,
   });
 
-  // Handle 404 negative-caching — must happen after hooks, but before return
+  if (datasetId == null) {
+    return { url: null, status: 'idle' };
+  }
+  if (knownMissing) {
+    return { url: null, status: 'missing' };
+  }
+
+  // Handle 404 negative-caching — idempotent, so safe to call during render
   if (error instanceof ApiError && error.status === 404) {
     markQuicklookMissing(datasetId);
     return { url: null, status: 'missing' };


### PR DESCRIPTION
## Summary

`useQuicklook` violated the Rules of Hooks: once a quicklook 404 populated the SP-07 session negative-cache, the next re-render of the **same** component instance early-returned before any hooks ran, throwing `Rendered fewer hooks than expected` and crashing `SearchResultCard` (search page) / `DatasetSearchPanel` (builder) to the page error boundary. Reachable in production whenever a quicklook file is missing from storage — exactly the scenario the negative-cache exists for.

## Fix

- Hooks (`useQueryClient`, `useEffect`, `useQuery`) now run on every render; the fetch is gated with the query's `enabled` flag (`datasetId != null && !knownMissing`) instead of early returns.
- Removes the `eslint-disable react-hooks/rules-of-hooks` suppression that documented the misconception.
- No behavior change otherwise: same statuses, same negative-caching, same blob-URL lifecycle.

## Verification

- New regression test re-renders the same hook instance after a 404 — it reproduces the exact crash against the old implementation and passes with the fix.
- `npx vitest run` on use-quicklook, SearchResultCard, and quicklook-cache suites: 52 passed.
- `npx eslint` on changed files and `npm run typecheck`: clean.

https://claude.ai/code/session_01NXiEUdCwnuPRDKsbbkPWbg