### PR TITLE
feat(ai): carry the dataset-chat query result into the builder

### DIFF
--- a/frontend/src/components/dataset/DatasetChatPanel.tsx
+++ b/frontend/src/components/dataset/DatasetChatPanel.tsx
@@ -9,6 +9,7 @@ import { streamDatasetChatMessage } from '@/api/maps';
 import { useCreateMap } from '@/hooks/use-maps';
 import { useAIAvailability } from '@/hooks/use-ai-availability';
 import { QueryResultTable, type QueryResult } from '@/components/viewer/ViewerChatPanel';
+import { stashChatResult, toChatResultHandoff, type ChatResultHandoff } from '@/lib/chat-result-handoff';
 import { cn } from '@/lib/utils';
 import type { ChatAction, ChatHistoryMessage } from '@/types/api';
 
@@ -19,6 +20,8 @@ interface ChatMessage {
   role: 'user' | 'assistant' | 'error';
   content: string;
   queryResult?: QueryResult;
+  /** Spatial payload of the query result, carried into the builder on open. */
+  spatialResult?: ChatResultHandoff;
   retryMessage?: string;
 }
 
@@ -108,6 +111,7 @@ export function DatasetChatPanel({ datasetId, datasetTitle, showOpenInBuilder }:
     abortRef.current = controller;
     let streamed = '';
     let queryResult: QueryResult | undefined;
+    let spatialResult: ChatResultHandoff | undefined;
     try {
       for await (const { event, data } of streamDatasetChatMessage(datasetId, userMsg, i18n.language, history, controller.signal)) {
         if (event === 'token') {
@@ -119,11 +123,12 @@ export function DatasetChatPanel({ datasetId, datasetTitle, showOpenInBuilder }:
             if (action.type === 'show_query_result') {
               const qr = toQueryResult(action);
               if (qr) queryResult = qr;
+              spatialResult = toChatResultHandoff(action.geojson, action.bbox) ?? spatialResult;
             }
           }
         } else if (event === 'done') {
           const finalText = (typeof data.explanation === 'string' ? data.explanation : '') || streamed;
-          setMessages((prev) => [...prev, { id: crypto.randomUUID(), role: 'assistant', content: finalText, queryResult }]);
+          setMessages((prev) => [...prev, { id: crypto.randomUUID(), role: 'assistant', content: finalText, queryResult, spatialResult }]);
         } else if (event === 'error') {
           // A pre-flight HTTP status (403/503) rides the SSE error event; surface it
           // as ApiError so it classifies honestly rather than as a generic failure.
@@ -158,12 +163,15 @@ export function DatasetChatPanel({ datasetId, datasetTitle, showOpenInBuilder }:
     setMessages((prev) => prev.filter((m) => m.id !== msg.id));
   }, []);
 
-  /** "Open in builder": new map + navigate with this dataset staged (AddToMapButton flow). */
-  const handleOpenInBuilder = useCallback(async () => {
+  /** "Open in builder": new map + navigate with this dataset staged (AddToMapButton flow).
+   * A spatial query result rides sessionStorage into the builder's ephemeral-layer
+   * path; a stash failure (quota/private mode) degrades to opening without it. */
+  const handleOpenInBuilder = useCallback(async (spatial?: ChatResultHandoff) => {
     try {
       const name = t('addToMap.newMapName', { title: datasetTitle });
       const newMap = await createMap.mutateAsync({ name });
-      navigate(`/maps/${newMap.id}?add_dataset=${datasetId}`);
+      const carried = spatial ? stashChatResult(spatial) : false;
+      navigate(`/maps/${newMap.id}?add_dataset=${datasetId}${carried ? '&chat_result=1' : ''}`);
     } catch {
       toast.error(t('addToMap.createFailed'));
     }
@@ -230,7 +238,7 @@ export function DatasetChatPanel({ datasetId, datasetTitle, showOpenInBuilder }:
                               variant="outline"
                               size="sm"
                               className="h-7 gap-1 text-xs"
-                              onClick={() => void handleOpenInBuilder()}
+                              onClick={() => void handleOpenInBuilder(msg.spatialResult)}
                               disabled={createMap.isPending}
                             >
                               {createMap.isPending ? (

--- a/frontend/src/components/dataset/DatasetChatPanel.tsx
+++ b/frontend/src/components/dataset/DatasetChatPanel.tsx
@@ -122,8 +122,13 @@ export function DatasetChatPanel({ datasetId, datasetTitle, showOpenInBuilder }:
           for (const action of getChatActions(data.actions)) {
             if (action.type === 'show_query_result') {
               const qr = toQueryResult(action);
-              if (qr) queryResult = qr;
-              spatialResult = toChatResultHandoff(action.geojson, action.bbox) ?? spatialResult;
+              if (qr) {
+                // Keep table and spatial payload PAIRED: both come from the
+                // same accepted action, so "Open in builder" never carries
+                // geometry from an earlier result than the table shown (#533).
+                queryResult = qr;
+                spatialResult = toChatResultHandoff(action.geojson, action.bbox) ?? undefined;
+              }
             }
           }
         } else if (event === 'done') {

--- a/frontend/src/components/dataset/__tests__/DatasetChatPanel.test.tsx
+++ b/frontend/src/components/dataset/__tests__/DatasetChatPanel.test.tsx
@@ -136,6 +136,51 @@ describe('DatasetChatPanel', () => {
     expect(JSON.parse(sessionStorage.getItem('geolens-chat-result')!)).toEqual({ geojson, bbox });
   });
 
+  it('does not carry a stale spatial payload when a later table result has none (#533)', async () => {
+    setAvailable(true);
+    const geojson = { type: 'FeatureCollection', features: [] };
+    const bbox = [-74.5, 40.4, -73.4, 41.1];
+    mockStream.mockImplementation(async function* () {
+      yield {
+        event: 'actions',
+        data: {
+          actions: [
+            // Spatial result first...
+            {
+              type: 'show_query_result',
+              rows: [['Central Park', 843]],
+              columns: ['name', 'acres'],
+              row_count: 1,
+              geojson,
+              bbox,
+            },
+            // ...then a non-spatial table (e.g. an aggregate) wins the panel.
+            {
+              type: 'show_query_result',
+              rows: [[496]],
+              columns: ['count'],
+              row_count: 1,
+            },
+          ],
+        },
+      };
+      yield { event: 'done', data: { explanation: 'Counted.' } };
+    });
+    mockMutateAsync.mockResolvedValue({ id: 'map-9' });
+
+    renderPanel();
+    await userEvent.click(screen.getByRole('button', { name: 'Ask AI' }));
+    await userEvent.type(screen.getByPlaceholderText('Ask about this data...'), 'count parks');
+    await userEvent.click(screen.getByRole('button', { name: 'Send' }));
+
+    await screen.findByText('Counted.');
+    await userEvent.click(screen.getByRole('button', { name: /Open in builder/i }));
+
+    // The shown table is the count — the earlier geometry must not ride along.
+    expect(mockNavigate).toHaveBeenCalledWith('/maps/map-9?add_dataset=ds-1');
+    expect(sessionStorage.getItem('geolens-chat-result')).toBeNull();
+  });
+
   it('hides the open-in-builder action for non-spatial tables (fix #531)', async () => {
     setAvailable(true);
     mockStream.mockImplementation(async function* () {

--- a/frontend/src/components/dataset/__tests__/DatasetChatPanel.test.tsx
+++ b/frontend/src/components/dataset/__tests__/DatasetChatPanel.test.tsx
@@ -37,6 +37,7 @@ function renderPanel(showOpenInBuilder = true) {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  sessionStorage.clear();
 });
 
 describe('DatasetChatPanel', () => {
@@ -94,7 +95,45 @@ describe('DatasetChatPanel', () => {
 
     await userEvent.click(screen.getByRole('button', { name: /Open in builder/i }));
     expect(mockMutateAsync).toHaveBeenCalledWith({ name: 'NY Parks Map' });
+    // No spatial payload in the result — plain add_dataset URL, nothing stashed.
     expect(mockNavigate).toHaveBeenCalledWith('/maps/map-9?add_dataset=ds-1');
+    expect(sessionStorage.getItem('geolens-chat-result')).toBeNull();
+  });
+
+  it('carries a spatial query result into the builder via sessionStorage', async () => {
+    setAvailable(true);
+    const geojson = { type: 'FeatureCollection', features: [] };
+    const bbox = [-74.5, 40.4, -73.4, 41.1];
+    mockStream.mockImplementation(async function* () {
+      yield {
+        event: 'actions',
+        data: {
+          actions: [
+            {
+              type: 'show_query_result',
+              rows: [['Central Park', 843]],
+              columns: ['name', 'acres'],
+              row_count: 1,
+              geojson,
+              bbox,
+            },
+          ],
+        },
+      };
+      yield { event: 'done', data: { explanation: 'Found 1 result.' } };
+    });
+    mockMutateAsync.mockResolvedValue({ id: 'map-9' });
+
+    renderPanel();
+    await userEvent.click(screen.getByRole('button', { name: 'Ask AI' }));
+    await userEvent.type(screen.getByPlaceholderText('Ask about this data...'), 'largest park');
+    await userEvent.click(screen.getByRole('button', { name: 'Send' }));
+
+    await screen.findByText('Found 1 result.');
+    await userEvent.click(screen.getByRole('button', { name: /Open in builder/i }));
+
+    expect(mockNavigate).toHaveBeenCalledWith('/maps/map-9?add_dataset=ds-1&chat_result=1');
+    expect(JSON.parse(sessionStorage.getItem('geolens-chat-result')!)).toEqual({ geojson, bbox });
   });
 
   it('hides the open-in-builder action for non-spatial tables (fix #531)', async () => {

--- a/frontend/src/lib/__tests__/chat-result-handoff.test.ts
+++ b/frontend/src/lib/__tests__/chat-result-handoff.test.ts
@@ -1,0 +1,64 @@
+import { stashChatResult, takeChatResult, toChatResultHandoff } from '@/lib/chat-result-handoff';
+
+const fc: GeoJSON.FeatureCollection = { type: 'FeatureCollection', features: [] };
+const bbox: [number, number, number, number] = [-74.5, 40.4, -73.4, 41.1];
+
+beforeEach(() => {
+  sessionStorage.clear();
+});
+
+describe('toChatResultHandoff', () => {
+  it('accepts a valid FeatureCollection + bbox', () => {
+    expect(toChatResultHandoff(fc, bbox)).toEqual({ geojson: fc, bbox });
+  });
+
+  it.each([
+    ['non-object geojson', 'nope', bbox],
+    ['non-FeatureCollection geojson', { type: 'Feature' }, bbox],
+    ['missing bbox', fc, undefined],
+    ['short bbox', fc, [-74, 40, -73]],
+    ['NaN in bbox', fc, [-74, NaN, -73, 41]],
+    ['out-of-range bbox', fc, [-181, 40, -73, 41]],
+    ['inverted bbox', fc, [-73, 40, -74, 41]],
+  ])('rejects %s', (_label, geojson, badBbox) => {
+    expect(toChatResultHandoff(geojson, badBbox)).toBeNull();
+  });
+});
+
+describe('stashChatResult / takeChatResult', () => {
+  it('round-trips a result and clears it on take', () => {
+    expect(stashChatResult({ geojson: fc, bbox })).toBe(true);
+    expect(takeChatResult()).toEqual({ geojson: fc, bbox });
+    // One-shot: second take finds nothing.
+    expect(takeChatResult()).toBeNull();
+  });
+
+  it('returns null when nothing is stashed', () => {
+    expect(takeChatResult()).toBeNull();
+  });
+
+  it('returns null (and clears) on a malformed payload', () => {
+    sessionStorage.setItem('geolens-chat-result', 'not json');
+    expect(takeChatResult()).toBeNull();
+    sessionStorage.setItem('geolens-chat-result', JSON.stringify({ geojson: fc, bbox: [1, 2] }));
+    expect(takeChatResult()).toBeNull();
+    expect(sessionStorage.getItem('geolens-chat-result')).toBeNull();
+  });
+
+  it('returns false when storage write throws (quota/private mode)', () => {
+    // jsdom's Storage proxy turns method assignment into a stored item, so
+    // spyOn can't replace setItem — stub the whole global instead.
+    vi.stubGlobal('sessionStorage', {
+      setItem: () => {
+        throw new DOMException('quota', 'QuotaExceededError');
+      },
+      getItem: () => null,
+      removeItem: () => {},
+    });
+    try {
+      expect(stashChatResult({ geojson: fc, bbox })).toBe(false);
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+});

--- a/frontend/src/lib/chat-result-handoff.ts
+++ b/frontend/src/lib/chat-result-handoff.ts
@@ -1,0 +1,71 @@
+/**
+ * feat(#531 follow-up): session-scoped handoff of a chat query result into
+ * the map builder.
+ *
+ * DatasetChatPanel has no map, so "Open in builder" creates a map and
+ * navigates with `?add_dataset=<id>&chat_result=1`. The spatial result
+ * payload (too large for a URL) rides sessionStorage under a single key;
+ * MapBuilderPage takes it exactly once after the map instance exists and
+ * renders it through the existing ephemeral-layer mechanism
+ * (use-ephemeral-layers.ts).
+ *
+ * Exception-safe: private-mode Safari / disabled storage / quota overflow on
+ * a large FeatureCollection must degrade to "open without the result", never
+ * block the navigation.
+ */
+
+export interface ChatResultHandoff {
+  geojson: GeoJSON.FeatureCollection;
+  bbox: [number, number, number, number];
+}
+
+const KEY = 'geolens-chat-result';
+
+/**
+ * Validate a show_query_result-style geojson/bbox pair. Mirrors
+ * ViewerChatPanel's flyover guard: finite, WGS84-bounded, non-inverted bbox
+ * (fix(#527 B-054/C-06) — NaN/inverted bounds throw in fitBounds).
+ */
+export function toChatResultHandoff(geojson: unknown, bbox: unknown): ChatResultHandoff | null {
+  if (
+    !geojson ||
+    typeof geojson !== 'object' ||
+    !('type' in geojson) ||
+    geojson.type !== 'FeatureCollection' ||
+    !Array.isArray(bbox) ||
+    bbox.length !== 4 ||
+    !bbox.every((n: unknown) => Number.isFinite(n))
+  ) {
+    return null;
+  }
+  const [minX, minY, maxX, maxY] = bbox as [number, number, number, number];
+  if (minX < -180 || minY < -90 || maxX > 180 || maxY > 90 || minX > maxX || minY > maxY) {
+    return null;
+  }
+  return { geojson: geojson as GeoJSON.FeatureCollection, bbox: [minX, minY, maxX, maxY] };
+}
+
+/** Stash a result for the builder to pick up. False = storage unavailable/full. */
+export function stashChatResult(result: ChatResultHandoff): boolean {
+  try {
+    sessionStorage.setItem(KEY, JSON.stringify(result));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** Take (read + clear) the stashed result. Null on absence or malformed payload. */
+export function takeChatResult(): ChatResultHandoff | null {
+  try {
+    const raw = sessionStorage.getItem(KEY);
+    sessionStorage.removeItem(KEY);
+    if (!raw) return null;
+    const parsed: unknown = JSON.parse(raw);
+    if (!parsed || typeof parsed !== 'object') return null;
+    const { geojson, bbox } = parsed as { geojson?: unknown; bbox?: unknown };
+    return toChatResultHandoff(geojson, bbox);
+  } catch {
+    return null;
+  }
+}

--- a/frontend/src/pages/MapBuilderPage.tsx
+++ b/frontend/src/pages/MapBuilderPage.tsx
@@ -103,6 +103,7 @@ import { PluginHost, PluginSidebar, getDefaultPluginIds, resolveAvailablePluginI
 import { usePluginStore } from '@/stores/map-plugin-store';
 import type { ViewportContext } from '@/components/builder/chat-suggestions';
 import { readStorage, removeStorage, storageKeys } from '@/lib/storage';
+import { takeChatResult } from '@/lib/chat-result-handoff';
 
 export function MapBuilderPage() {
   const { id } = useParams<{ id: string }>();
@@ -112,7 +113,7 @@ export function MapBuilderPage() {
   // reactively can flip to false before the capture path runs (WR-01). Freeze
   // the mount-time value in a ref so the deferred path is honored regardless of
   // whether the API or the canvas init wins the race.
-  const [searchParams] = useSearchParams();
+  const [searchParams, setSearchParams] = useSearchParams();
   const pendingLayerAddRef = useRef(searchParams.has('add_dataset'));
   const pendingLayerAdd = pendingLayerAddRef.current;
   const { t } = useTranslation('builder');
@@ -315,6 +316,21 @@ export function MapBuilderPage() {
     if (map) save.maybeAutoCaptureThumbnail(map);
     // eslint-disable-next-line react-hooks/exhaustive-deps -- only the method reference matters, not the whole `save` object
   }, [save.maybeAutoCaptureThumbnail]);
+
+  // feat(#531 follow-up): ?chat_result=1 — DatasetChatPanel stashed its last
+  // spatial query result in sessionStorage before navigating here; render it
+  // through the ephemeral-layer path. Gated on mapInstance (not mapData) so
+  // the ephemeral effect never fires against a null map ref.
+  const handleChatQueryResult = layers.handleQueryResult;
+  useEffect(() => {
+    if (!mapInstance || !searchParams.has('chat_result')) return;
+    setSearchParams((prev) => {
+      prev.delete('chat_result');
+      return prev;
+    }, { replace: true });
+    const result = takeChatResult();
+    if (result) handleChatQueryResult(result.geojson, result.bbox);
+  }, [mapInstance, searchParams, setSearchParams, handleChatQueryResult]);
 
   const pluginCtx = useMemo(
     () => ({


### PR DESCRIPTION
## Summary

Dataset-chat v1 (#531) deferred one piece of the chosen results UX: "Open in builder" created a map and staged the dataset, but dropped the query result the user was looking at. This completes it.

- **`frontend/src/lib/chat-result-handoff.ts`** (new): one-shot sessionStorage handoff (`geolens-chat-result`). `toChatResultHandoff()` validates the `show_query_result` spatial payload with the same guard as the viewer flyover (finite, WGS84-bounded, non-inverted bbox — the #527 B-054/C-06 rule); `stashChatResult`/`takeChatResult` are exception-safe, so quota overflow on a large FeatureCollection or private-mode storage degrades to opening the builder without the result.
- **`DatasetChatPanel`**: keeps the spatial payload per assistant message; "Open in builder" stashes it and appends `&chat_result=1` only when the stash succeeded.
- **`MapBuilderPage`**: a pickup effect gated on the `mapInstance` state (not `mapData`, so it never races map creation) takes the stash once, deletes the URL param, and renders through the existing `use-ephemeral-layers` path — same dashed-outline overlay + fitBounds the viewer chat uses, including its style.load re-add behavior.

No backend, i18n, or API-contract changes.

## Verification

- `npx vitest run` — handoff lib (12 tests incl. bbox rejection matrix, one-shot take, quota fallback), DatasetChatPanel (7 tests incl. carried vs non-spatial navigation), full `src/components/builder` suite (1832), MapBuilderPage header-actions (5): all green.
- `npx eslint` on changed files, `npm run typecheck`: clean.

https://claude.ai/code/session_01NXiEUdCwnuPRDKsbbkPWbg