### PR TITLE
test(ai): assertion-based NL→SQL eval harness

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,7 @@ The React/Vite frontend is in `frontend/src/`: `components/`, `pages/`, `hooks/`
 - `make dev` / `make down`: start or stop the Docker Compose development stack.
 - `make migrate`: run Alembic migrations in the API container. `make alembic-check` fails if the ORM models have drifted from the migration scripts (run it for schema-adjacent changes).
 - `make test` / `make test-cov`: run backend pytest and coverage.
+- `make ai-evals`: live-provider NL→SQL regression evals in `backend/tests/evals/` (skipped in normal test runs; costs provider tokens, needs `ANTHROPIC_API_KEY` and the dev DB).
 - `npm run e2e` or `npm run e2e:smoke`: run Playwright suites.
 - `cd frontend && npm ci && npm run dev`: install frontend dependencies and start Vite.
 - `cd frontend && npm run build && npm run lint && npm run typecheck && npm run test:coverage`: run frontend gates (`npx tsc --noEmit` is a no-op here; `npm run typecheck` is the real type gate).

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 SHELL := /bin/bash
 .SHELLFLAGS := -o pipefail -c
 
-.PHONY: dev dev-init down reset-db migrate migration alembic-check overlay-migration-check test test-sequential test-cov e2e logs logs-db logs-api status doctor preflight openapi openapi-check sdks sdks-check sdks-test manifest-contract-check publish-sdks-py publish-sdks-ts cli-build cli-test cli-check publish-cli audit-sink-discipline billing-extraction-discipline catalog-domain-discipline bump version-check public-surface-check deployed-surface-check
+.PHONY: dev dev-init down reset-db migrate migration alembic-check overlay-migration-check test test-sequential test-cov ai-evals e2e logs logs-db logs-api status doctor preflight openapi openapi-check sdks sdks-check sdks-test manifest-contract-check publish-sdks-py publish-sdks-ts cli-build cli-test cli-check publish-cli audit-sink-discipline billing-extraction-discipline catalog-domain-discipline bump version-check public-surface-check deployed-surface-check
 
 # Pre-flight: verify boot-required env vars are non-empty in .env before any
 # `docker compose` build (which takes 5-10 minutes on a cold cache only to crash
@@ -83,6 +83,12 @@ test-sequential:
 
 test-cov:
 	docker compose exec api env UV_CACHE_DIR=/app/staging/uv-cache UV_PROJECT_ENVIRONMENT=/app/staging/geolens-api-test-venv uv run pytest -o cache_dir=/app/staging/.pytest_cache -v --tb=short --cov=app --cov-report=term-missing
+
+# Live-provider AI evals (assertion-based NL->SQL regression suite). Skipped
+# in normal test runs; costs real provider tokens. Needs the dev DB up and
+# ANTHROPIC_API_KEY (or the configured provider's key) in the environment.
+ai-evals:
+	cd backend && set -a && if [ -f ../.env.test ]; then . ../.env.test; fi && set +a && RUN_AI_EVALS=1 uv run pytest tests/evals/ -v
 
 e2e:
 	npx playwright test

--- a/backend/tests/evals/test_sql_generation_evals.py
+++ b/backend/tests/evals/test_sql_generation_evals.py
@@ -32,6 +32,7 @@ ordinary test flake — investigate before rerunning.
 import os
 import re
 import uuid
+from decimal import Decimal
 
 import pytest
 from sqlalchemy import select, text
@@ -56,12 +57,15 @@ pytestmark = [
 # STRICTLY ordered under both degree-area and geography-area (no ties), so
 # the top-3 ordering is unambiguous regardless of how the model measures:
 # 0.030x0.040 > 0.030x0.020 > 0.012x0.012 > 0.010x0.010 > 0.005x0.004 > 0.002x0.002.
+# Insertion order deliberately does NOT match size order — the smallest park
+# is first and the largest mid-list, so a bare `SELECT ... LIMIT n` that
+# ignores area cannot pass the superlative or top-N evals on row order alone.
 _PARKS = [
-    ("Central Green", "regional", (-73.980, 40.760, -73.950, 40.800)),
+    ("Elm Commons", "pocket", (-73.900, 40.680, -73.898, 40.682)),
     ("River Bend Park", "community", (-73.930, 40.700, -73.920, 40.710)),
     ("Riverside Walk", "community", (-73.995, 40.740, -73.990, 40.744)),
+    ("Central Green", "regional", (-73.980, 40.760, -73.950, 40.800)),
     ("Sunset Park", "community", (-74.010, 40.645, -73.998, 40.657)),
-    ("Elm Commons", "pocket", (-73.900, 40.680, -73.898, 40.682)),
     ("North Meadow", "regional", (-73.970, 40.850, -73.940, 40.870)),
 ]
 _LARGEST = "Central Green"
@@ -166,7 +170,9 @@ def _cells(result: SandboxResult) -> list:
 
 
 def _numbers(result: SandboxResult) -> list[float]:
-    return [float(c) for c in _cells(result) if isinstance(c, (int, float))]
+    # Decimal included: ROUND(...::numeric) is legitimate SQL and arrives as
+    # Decimal from the driver, not float.
+    return [float(c) for c in _cells(result) if isinstance(c, (int, float, Decimal))]
 
 
 async def test_count_rows(client, test_db_session, eval_dataset):

--- a/backend/tests/evals/test_sql_generation_evals.py
+++ b/backend/tests/evals/test_sql_generation_evals.py
@@ -52,17 +52,20 @@ pytestmark = [
     ),
 ]
 
-# name, category, envelope (west, south, east, north) around NYC — sizes are
-# distinct enough that "largest" is unambiguous even with projection wobble.
+# name, category, envelope (west, south, east, north) around NYC. Sizes are
+# STRICTLY ordered under both degree-area and geography-area (no ties), so
+# the top-3 ordering is unambiguous regardless of how the model measures:
+# 0.030x0.040 > 0.030x0.020 > 0.012x0.012 > 0.010x0.010 > 0.005x0.004 > 0.002x0.002.
 _PARKS = [
     ("Central Green", "regional", (-73.980, 40.760, -73.950, 40.800)),
     ("River Bend Park", "community", (-73.930, 40.700, -73.920, 40.710)),
     ("Riverside Walk", "community", (-73.995, 40.740, -73.990, 40.744)),
-    ("Sunset Park", "community", (-74.010, 40.645, -74.000, 40.655)),
+    ("Sunset Park", "community", (-74.010, 40.645, -73.998, 40.657)),
     ("Elm Commons", "pocket", (-73.900, 40.680, -73.898, 40.682)),
     ("North Meadow", "regional", (-73.970, 40.850, -73.940, 40.870)),
 ]
 _LARGEST = "Central Green"
+_TOP3 = ["Central Green", "North Meadow", "Sunset Park"]
 _RIVER_NAMES = {"River Bend Park", "Riverside Walk"}
 
 
@@ -193,9 +196,14 @@ async def test_area_uses_geography_and_magnitude(client, test_db_session, eval_d
 
 
 async def test_largest_park(client, test_db_session, eval_dataset):
-    """Superlative question resolves to the geometrically largest feature."""
+    """Superlative question resolves to the geometrically largest feature,
+    ISOLATED — a query that returns every park must fail even though the
+    right answer appears somewhere in it (#537 review)."""
     sql, result = await _ask(
         test_db_session, eval_dataset, "Which park has the largest area?"
+    )
+    assert result.row_count == 1, (
+        f"expected a single-row answer, got {result.row_count} rows\nSQL: {sql}"
     )
     names = [c for c in _cells(result) if isinstance(c, str)]
     assert _LARGEST in names, f"expected {_LARGEST!r} in {names}\nSQL: {sql}"
@@ -213,15 +221,20 @@ async def test_name_filter_matches_expected_set(client, test_db_session, eval_da
 
 
 async def test_top_n_is_limited_and_ordered(client, test_db_session, eval_dataset):
-    """Top-N question returns exactly N rows with the known largest first."""
+    """Top-N question returns exactly the known top 3, in order. Requires an
+    ORDER BY — with the largest park inserted first, a bare LIMIT 3 would
+    otherwise pass on insertion order alone (#537 review)."""
     sql, result = await _ask(
         test_db_session,
         eval_dataset,
         "What are the 3 largest parks by area, largest first?",
     )
+    assert re.search(r"\border\s+by\b", sql, re.IGNORECASE), f"no ORDER BY:\n{sql}"
     assert re.search(r"\blimit\s+3\b", sql, re.IGNORECASE), f"no LIMIT 3:\n{sql}"
     assert result.row_count == 3, f"expected 3 rows, got {result.row_count}"
-    first_row_strings = [c for c in result.rows[0] if isinstance(c, str)]
-    assert _LARGEST in first_row_strings, (
-        f"largest park {_LARGEST!r} not first: {result.rows[0]}\nSQL: {sql}"
-    )
+    all_names = {p[0] for p in _PARKS}
+    row_names = [
+        next((c for c in row if isinstance(c, str) and c in all_names), None)
+        for row in result.rows
+    ]
+    assert row_names == _TOP3, f"expected {_TOP3}, got {row_names}\nSQL: {sql}"

--- a/backend/tests/evals/test_sql_generation_evals.py
+++ b/backend/tests/evals/test_sql_generation_evals.py
@@ -184,9 +184,11 @@ async def test_area_uses_geography_and_magnitude(client, test_db_session, eval_d
     sql, result = await _ask(
         test_db_session, eval_dataset, "What is the total area of all parks, in acres?"
     )
-    assert "::geography" in sql.lower(), (
-        f"no geography cast for a unit question:\n{sql}"
-    )
+    # Either cast syntax is fine — ::geography or CAST(... AS geography) —
+    # the eval cares that meters come from geography, not how it's spelled.
+    assert re.search(
+        r"::\s*geography|\bcast\s*\([^)]*\bas\s+geography\s*\)", sql, re.IGNORECASE
+    ), f"no geography cast for a unit question:\n{sql}"
     nums = _numbers(result)
     assert nums, f"no numeric cell in result: {result}"
     truth = eval_dataset["truth_acres"]

--- a/backend/tests/evals/test_sql_generation_evals.py
+++ b/backend/tests/evals/test_sql_generation_evals.py
@@ -1,0 +1,227 @@
+"""Assertion-based AI evals for NL->SQL generation (geosql follow-up, #531/#534).
+
+These call the REAL ``generate_sql()`` against the configured LLM provider and
+execute the output through the production sandbox (``validate_and_execute``),
+asserting on two layers:
+
+1. **SQL predicates** — structural requirements on the generated SQL (e.g. a
+   meters/degrees question must use ``::geography``).
+2. **Result assertions** — the executed value compared to ground truth
+   computed from the same seeded rows by direct SQL, with tolerance where the
+   model has legitimate freedom.
+
+Every case also implicitly asserts the sandbox ACCEPTS the generated SQL — a
+model drifting into disallowed constructs fails validation loudly.
+
+These are the first AI regression evals in the repo. They cost real provider
+tokens, so they are SKIPPED unless ``RUN_AI_EVALS=1``. Run them on the host
+against the dev Postgres with the provider key exported:
+
+    cd backend && set -a && source ../.env.test && set +a && \\
+        RUN_AI_EVALS=1 uv run pytest tests/evals/ -v
+
+(``ANTHROPIC_API_KEY`` / the configured provider's key must be in the
+environment; the dev stack's ``.env`` has it.)
+
+Flake policy: temperature is 0.0 in ``generate_sql`` and every assertion
+leaves the model freedom where it legitimately has it (column order, aliases,
+exact SQL shape). A failure here is a signal about prompt/model drift, not
+ordinary test flake — investigate before rerunning.
+"""
+
+import os
+import re
+import uuid
+
+import pytest
+from sqlalchemy import select, text
+
+from app.core.config import settings
+from app.modules.auth.models import User
+from app.platform.sandbox import SandboxResult, validate_and_execute
+from app.processing.ai.schemas import ChatMapLayer
+from app.processing.ai.sql_generator import build_sql_schema_context, generate_sql
+
+from tests.factories import create_dataset
+
+pytestmark = [
+    pytest.mark.anyio,
+    pytest.mark.skipif(
+        os.environ.get("RUN_AI_EVALS") != "1",
+        reason="live-provider AI evals; set RUN_AI_EVALS=1 to run",
+    ),
+]
+
+# name, category, envelope (west, south, east, north) around NYC — sizes are
+# distinct enough that "largest" is unambiguous even with projection wobble.
+_PARKS = [
+    ("Central Green", "regional", (-73.980, 40.760, -73.950, 40.800)),
+    ("River Bend Park", "community", (-73.930, 40.700, -73.920, 40.710)),
+    ("Riverside Walk", "community", (-73.995, 40.740, -73.990, 40.744)),
+    ("Sunset Park", "community", (-74.010, 40.645, -74.000, 40.655)),
+    ("Elm Commons", "pocket", (-73.900, 40.680, -73.898, 40.682)),
+    ("North Meadow", "regional", (-73.970, 40.850, -73.940, 40.870)),
+]
+_LARGEST = "Central Green"
+_RIVER_NAMES = {"River Bend Park", "Riverside Walk"}
+
+
+@pytest.fixture
+async def eval_dataset(test_db_session):
+    """Seed a real data.* table + catalog Dataset so the sandbox allowlist
+    resolves it, and precompute geography-based ground truth from the rows.
+
+    The table name is unique per test (catalog.datasets.table_name is unique)
+    and the teardown removes both the data table and the catalog rows so the
+    shared dev DB is left clean.
+    """
+    session = test_db_session
+    table = f"eval_parks_{uuid.uuid4().hex[:8]}"
+    await session.execute(
+        text(
+            f"CREATE TABLE data.{table} ("
+            "gid serial PRIMARY KEY, name text, category text, "
+            "geom_4326 geometry(Polygon, 4326))"
+        )
+    )
+    for name, category, (w, s, e, n) in _PARKS:
+        await session.execute(
+            text(
+                f"INSERT INTO data.{table} (name, category, geom_4326) VALUES "
+                f"(:name, :category, ST_MakeEnvelope({w}, {s}, {e}, {n}, 4326))"
+            ),
+            {"name": name, "category": category},
+        )
+    await session.commit()
+
+    result = await session.execute(
+        select(User).where(User.username == settings.geolens_admin_username)
+    )
+    admin = result.scalar_one()
+
+    dataset = await create_dataset(
+        session,
+        created_by=admin.id,
+        name="Eval Parks",
+        table_name=table,
+        geometry_type="Polygon",
+        feature_count=len(_PARKS),
+        column_info=[
+            {"name": "gid", "type": "integer"},
+            {"name": "name", "type": "text"},
+            {"name": "category", "type": "text"},
+        ],
+    )
+    dataset_id, record_id = dataset.id, dataset.record_id
+
+    truth_acres = (
+        await session.execute(
+            text(
+                f"SELECT SUM(ST_Area(geom_4326::geography)) / 4046.8564224 FROM data.{table}"
+            )
+        )
+    ).scalar_one()
+
+    layer = ChatMapLayer(
+        id="eval-layer",
+        name="Eval Parks",
+        dataset_id=str(dataset_id),
+        dataset_table_name=table,
+        geometry_type="Polygon",
+        column_info=dataset.column_info,
+        dataset_title="Eval Parks",
+        feature_count=len(_PARKS),
+    )
+    schema_context = build_sql_schema_context([layer])
+
+    yield {
+        "admin": admin,
+        "schema_context": schema_context,
+        "truth_acres": float(truth_acres),
+    }
+
+    await session.execute(
+        text("DELETE FROM catalog.datasets WHERE id = :id"), {"id": dataset_id}
+    )
+    await session.execute(
+        text("DELETE FROM catalog.records WHERE id = :id"), {"id": record_id}
+    )
+    await session.execute(text(f"DROP TABLE IF EXISTS data.{table}"))
+    await session.commit()
+
+
+async def _ask(session, ctx, question: str) -> tuple[str, SandboxResult]:
+    """Generate SQL for a question and execute it through the sandbox."""
+    sql = await generate_sql(session, question, ctx["schema_context"])
+    result = await validate_and_execute(sql, session, ctx["admin"])
+    return sql, result
+
+
+def _cells(result: SandboxResult) -> list:
+    """All cell values across rows, flattened (column order is model freedom)."""
+    return [cell for row in result.rows for cell in row]
+
+
+def _numbers(result: SandboxResult) -> list[float]:
+    return [float(c) for c in _cells(result) if isinstance(c, (int, float))]
+
+
+async def test_count_rows(client, test_db_session, eval_dataset):
+    """A plain count must come back exact."""
+    _sql, result = await _ask(
+        test_db_session, eval_dataset, "How many parks are in this dataset?"
+    )
+    assert _numbers(result), f"no numeric cell in result: {result}"
+    assert _numbers(result)[0] == len(_PARKS)
+
+
+async def test_area_uses_geography_and_magnitude(client, test_db_session, eval_dataset):
+    """The classic degrees/meters trap: an acres question must cast to
+    geography, and the executed total must be within 10% of ground truth."""
+    sql, result = await _ask(
+        test_db_session, eval_dataset, "What is the total area of all parks, in acres?"
+    )
+    assert "::geography" in sql.lower(), (
+        f"no geography cast for a unit question:\n{sql}"
+    )
+    nums = _numbers(result)
+    assert nums, f"no numeric cell in result: {result}"
+    truth = eval_dataset["truth_acres"]
+    assert any(abs(n - truth) / truth < 0.10 for n in nums), (
+        f"no cell within 10% of truth {truth:.0f} acres: {nums}\nSQL: {sql}"
+    )
+
+
+async def test_largest_park(client, test_db_session, eval_dataset):
+    """Superlative question resolves to the geometrically largest feature."""
+    sql, result = await _ask(
+        test_db_session, eval_dataset, "Which park has the largest area?"
+    )
+    names = [c for c in _cells(result) if isinstance(c, str)]
+    assert _LARGEST in names, f"expected {_LARGEST!r} in {names}\nSQL: {sql}"
+
+
+async def test_name_filter_matches_expected_set(client, test_db_session, eval_dataset):
+    """Substring filter finds exactly the two 'river' parks (case-insensitive)."""
+    sql, result = await _ask(
+        test_db_session, eval_dataset, "List the parks with 'river' in their name."
+    )
+    names = {
+        c for c in _cells(result) if isinstance(c, str) and c in {p[0] for p in _PARKS}
+    }
+    assert names == _RIVER_NAMES, f"expected {_RIVER_NAMES}, got {names}\nSQL: {sql}"
+
+
+async def test_top_n_is_limited_and_ordered(client, test_db_session, eval_dataset):
+    """Top-N question returns exactly N rows with the known largest first."""
+    sql, result = await _ask(
+        test_db_session,
+        eval_dataset,
+        "What are the 3 largest parks by area, largest first?",
+    )
+    assert re.search(r"\blimit\s+3\b", sql, re.IGNORECASE), f"no LIMIT 3:\n{sql}"
+    assert result.row_count == 3, f"expected 3 rows, got {result.row_count}"
+    first_row_strings = [c for c in result.rows[0] if isinstance(c, str)]
+    assert _LARGEST in first_row_strings, (
+        f"largest park {_LARGEST!r} not first: {result.rows[0]}\nSQL: {sql}"
+    )


### PR DESCRIPTION
## Summary

The remaining half of the geosql takeaway (#534 shipped the prompt half): the repo's **first AI regression evals**. `backend/tests/evals/test_sql_generation_evals.py` runs five golden questions through the REAL pipeline — `generate_sql()` against the configured LLM provider, then `validate_and_execute()` through the production sandbox — with two assertion layers per case:

1. **SQL structure** — e.g. an acres question must cast `::geography` (the degrees/meters trap), a top-N question must `LIMIT 3`.
2. **Executed results vs ground truth** — computed from the seeded rows by direct SQL (exact count, expected name sets, 10% tolerance on area magnitude, correct superlative/ordering).

Every case also implicitly asserts the sandbox accepts the generated SQL — model drift into disallowed constructs fails loudly.

## Mechanics

- **Opt-in**: skipped unless `RUN_AI_EVALS=1` (5 live light-model calls ≈ cents). Normal `pytest`/CI runs show 5 skips.
- **`make ai-evals`** target added (sources `.env.test` when present; needs the dev DB and the provider key). AGENTS.md commands list updated.
- **Fixture hygiene**: per-test unique `data.eval_parks_*` table; teardown removes the data table AND the catalog Dataset/Record rows, so the shared dev DB stays clean.
- Deterministic-leaning: `generate_sql` runs at temperature 0.0; assertions leave the model freedom where it legitimately has it (aliases, column order, SQL shape).

## Verification

- `make ai-evals` against live Anthropic: **5 passed** (twice).
- Without the flag: 5 skipped in 0.2s.
- `ruff check` / `ruff format --check`: clean.

https://claude.ai/code/session_01NXiEUdCwnuPRDKsbbkPWbg