### PR TITLE
fix(sandbox): allow AND/OR in compound conditions; add spatial eval cases

### DIFF
--- a/backend/app/platform/sandbox/validator.py
+++ b/backend/app/platform/sandbox/validator.py
@@ -307,6 +307,54 @@ def _reject_recursive_cte(stmt: exp.Expression, sql: str) -> None:
         raise SandboxError("invalid_query", "Recursive queries are not allowed")
 
 
+def _check_function_allowlist(stmt: exp.Expression, sql: str) -> None:
+    """Fail-closed function check (SEC-025).
+
+    For each Func node in the AST, extract its canonical lowercase name:
+      • Anonymous nodes  → fn.name.lower()  (the raw SQL identifier)
+      • Named Func nodes → fn.sql_name().lower()  (sqlglot's canonical name,
+        which may differ from the SQL keyword — see _ALLOWED_FUNCTIONS docs)
+
+    Then apply fail-closed logic (order matters):
+      1. BLOCKED  → always reject (defense-in-depth; checked before allowlist)
+      2. "st_" name → require the prompt-derived PostGIS allowlist
+      3. Other name → require _ALLOWED_FUNCTIONS
+      4. Allowed spatial functions → reject unbounded aggregate/complexity forms
+      5. Otherwise → reject (fail-closed)
+    """
+    for func in stmt.find_all(exp.Func):
+        # fix(#538): sqlglot models AND/OR (exp.Connector) as Func subclasses,
+        # so any compound condition (WHERE x AND y, JOIN ... ON a AND b,
+        # CASE WHEN ... AND ...) was rejected as an unlisted "function".
+        # Connectors are boolean operators, not callables — and find_all walks
+        # their operands regardless, so a disallowed function inside either
+        # side of an AND/OR is still caught below.
+        if isinstance(func, exp.Connector):
+            continue
+        if isinstance(func, exp.Anonymous):
+            fn_name = func.name.lower() if hasattr(func, "name") else ""
+        else:
+            fn_name = func.sql_name().lower() if hasattr(func, "sql_name") else ""
+
+        if fn_name in _BLOCKED_FUNCTIONS:
+            logger.info("sandbox.blocked_function", sql=sql, function=fn_name)
+            raise SandboxError("invalid_query", "Query uses a disallowed function")
+
+        if fn_name.startswith("st_"):
+            if fn_name not in _ALLOWED_POSTGIS_FUNCTIONS:
+                logger.info(
+                    "sandbox.unlisted_postgis_function", sql=sql, function=fn_name
+                )
+                raise SandboxError(
+                    "invalid_query", "Query uses a disallowed spatial function"
+                )
+        elif fn_name not in _ALLOWED_FUNCTIONS:
+            logger.info("sandbox.unlisted_function", sql=sql, function=fn_name)
+            raise SandboxError("invalid_query", "Query uses a disallowed function")
+
+        _validate_function_cost(func, fn_name, sql)
+
+
 def validate_sql(sql: str) -> ValidatedQuery:
     """Parse and validate SQL. Returns validated query or raises SandboxError.
 
@@ -342,42 +390,7 @@ def validate_sql(sql: str) -> ValidatedQuery:
 
     _reject_recursive_cte(stmt, sql)
 
-    # Fail-closed function check (SEC-025).
-    #
-    # For each Func node in the AST, extract its canonical lowercase name:
-    #   • Anonymous nodes  → fn.name.lower()  (the raw SQL identifier)
-    #   • Named Func nodes → fn.sql_name().lower()  (sqlglot's canonical name,
-    #     which may differ from the SQL keyword — see _ALLOWED_FUNCTIONS docs)
-    #
-    # Then apply fail-closed logic (order matters):
-    #   1. BLOCKED  → always reject (defense-in-depth; checked before allowlist)
-    #   2. "st_" name → require the prompt-derived PostGIS allowlist
-    #   3. Other name → require _ALLOWED_FUNCTIONS
-    #   4. Allowed spatial functions → reject unbounded aggregate/complexity forms
-    #   5. Otherwise → reject (fail-closed)
-    for func in stmt.find_all(exp.Func):
-        if isinstance(func, exp.Anonymous):
-            fn_name = func.name.lower() if hasattr(func, "name") else ""
-        else:
-            fn_name = func.sql_name().lower() if hasattr(func, "sql_name") else ""
-
-        if fn_name in _BLOCKED_FUNCTIONS:
-            logger.info("sandbox.blocked_function", sql=sql, function=fn_name)
-            raise SandboxError("invalid_query", "Query uses a disallowed function")
-
-        if fn_name.startswith("st_"):
-            if fn_name not in _ALLOWED_POSTGIS_FUNCTIONS:
-                logger.info(
-                    "sandbox.unlisted_postgis_function", sql=sql, function=fn_name
-                )
-                raise SandboxError(
-                    "invalid_query", "Query uses a disallowed spatial function"
-                )
-        elif fn_name not in _ALLOWED_FUNCTIONS:
-            logger.info("sandbox.unlisted_function", sql=sql, function=fn_name)
-            raise SandboxError("invalid_query", "Query uses a disallowed function")
-
-        _validate_function_cost(func, fn_name, sql)
+    _check_function_allowlist(stmt, sql)
 
     # Extract CTE names to exclude from table validation
     cte_names: set[str] = set()

--- a/backend/tests/evals/test_sql_generation_evals.py
+++ b/backend/tests/evals/test_sql_generation_evals.py
@@ -72,6 +72,15 @@ _LARGEST = "Central Green"
 _TOP3 = ["Central Green", "North Meadow", "Sunset Park"]
 _RIVER_NAMES = {"River Bend Park", "Riverside Walk"}
 
+# Stations (points) for cross-table cases: one inside Central Green, one
+# inside Sunset Park, one inside no park at all.
+_STATIONS = [
+    ("Green Plaza Station", (-73.965, 40.780)),
+    ("Harbor Station", (-74.004, 40.651)),
+    ("Junction Station", (-73.850, 40.730)),
+]
+_STATION_IN_LARGEST = "Green Plaza Station"
+
 
 @pytest.fixture
 async def eval_dataset(test_db_session):
@@ -121,6 +130,38 @@ async def eval_dataset(test_db_session):
     )
     dataset_id, record_id = dataset.id, dataset.record_id
 
+    stations_table = f"eval_stations_{uuid.uuid4().hex[:8]}"
+    await session.execute(
+        text(
+            f"CREATE TABLE data.{stations_table} ("
+            "gid serial PRIMARY KEY, name text, geom_4326 geometry(Point, 4326))"
+        )
+    )
+    for name, (lon, lat) in _STATIONS:
+        await session.execute(
+            text(
+                f"INSERT INTO data.{stations_table} (name, geom_4326) VALUES "
+                f"(:name, ST_SetSRID(ST_MakePoint({lon}, {lat}), 4326))"
+            ),
+            {"name": name},
+        )
+    await session.commit()
+
+    stations_dataset = await create_dataset(
+        session,
+        created_by=admin.id,
+        name="Eval Stations",
+        table_name=stations_table,
+        geometry_type="Point",
+        feature_count=len(_STATIONS),
+        column_info=[
+            {"name": "gid", "type": "integer"},
+            {"name": "name", "type": "text"},
+        ],
+    )
+    stations_dataset_id = stations_dataset.id
+    stations_record_id = stations_dataset.record_id
+
     truth_acres = (
         await session.execute(
             text(
@@ -129,7 +170,17 @@ async def eval_dataset(test_db_session):
         )
     ).scalar_one()
 
-    layer = ChatMapLayer(
+    truth_miles = (
+        await session.execute(
+            text(
+                "SELECT ST_Distance(a.geom_4326::geography, b.geom_4326::geography) / 1609.344 "
+                f"FROM data.{stations_table} a, data.{stations_table} b "
+                "WHERE a.name = 'Green Plaza Station' AND b.name = 'Junction Station'"
+            )
+        )
+    ).scalar_one()
+
+    parks_layer = ChatMapLayer(
         id="eval-layer",
         name="Eval Parks",
         dataset_id=str(dataset_id),
@@ -139,21 +190,37 @@ async def eval_dataset(test_db_session):
         dataset_title="Eval Parks",
         feature_count=len(_PARKS),
     )
-    schema_context = build_sql_schema_context([layer])
+    stations_layer = ChatMapLayer(
+        id="eval-stations-layer",
+        name="Eval Stations",
+        dataset_id=str(stations_dataset_id),
+        dataset_table_name=stations_table,
+        geometry_type="Point",
+        column_info=stations_dataset.column_info,
+        dataset_title="Eval Stations",
+        feature_count=len(_STATIONS),
+    )
+    schema_context = build_sql_schema_context([parks_layer, stations_layer])
 
     yield {
         "admin": admin,
         "schema_context": schema_context,
         "truth_acres": float(truth_acres),
+        "truth_miles": float(truth_miles),
     }
 
-    await session.execute(
-        text("DELETE FROM catalog.datasets WHERE id = :id"), {"id": dataset_id}
-    )
-    await session.execute(
-        text("DELETE FROM catalog.records WHERE id = :id"), {"id": record_id}
-    )
+    for ds_id, rec_id in (
+        (dataset_id, record_id),
+        (stations_dataset_id, stations_record_id),
+    ):
+        await session.execute(
+            text("DELETE FROM catalog.datasets WHERE id = :id"), {"id": ds_id}
+        )
+        await session.execute(
+            text("DELETE FROM catalog.records WHERE id = :id"), {"id": rec_id}
+        )
     await session.execute(text(f"DROP TABLE IF EXISTS data.{table}"))
+    await session.execute(text(f"DROP TABLE IF EXISTS data.{stations_table}"))
     await session.commit()
 
 
@@ -246,3 +313,42 @@ async def test_top_n_is_limited_and_ordered(client, test_db_session, eval_datase
         for row in result.rows
     ]
     assert row_names == _TOP3, f"expected {_TOP3}, got {row_names}\nSQL: {sql}"
+
+
+async def test_distance_in_miles(client, test_db_session, eval_dataset):
+    """Cross-table distance with unit conversion: the meters/degrees trap plus
+    the meters/miles conversion, checked against geography ground truth."""
+    sql, result = await _ask(
+        test_db_session,
+        eval_dataset,
+        "How far apart are Green Plaza Station and Junction Station, in miles?",
+    )
+    assert re.search(
+        r"::\s*geography|\bcast\s*\([^)]*\bas\s+geography\s*\)", sql, re.IGNORECASE
+    ), f"no geography cast for a distance question:\n{sql}"
+    nums = _numbers(result)
+    assert nums, f"no numeric cell in result: {result}"
+    truth = eval_dataset["truth_miles"]
+    assert any(abs(n - truth) / truth < 0.10 for n in nums), (
+        f"no cell within 10% of truth {truth:.2f} miles: {nums}\nSQL: {sql}"
+    )
+
+
+async def test_spatial_containment(client, test_db_session, eval_dataset):
+    """Point-in-polygon join across the two tables resolves to exactly the
+    one station seeded inside the named park."""
+    sql, result = await _ask(
+        test_db_session,
+        eval_dataset,
+        "Which stations are inside the Central Green park?",
+    )
+    assert re.search(
+        r"\bst_(within|contains|intersects|covers|coveredby|dwithin)\s*\(",
+        sql,
+        re.IGNORECASE,
+    ), f"no spatial predicate for a containment question:\n{sql}"
+    station_names = {s[0] for s in _STATIONS}
+    found = {c for c in _cells(result) if isinstance(c, str) and c in station_names}
+    assert found == {_STATION_IN_LARGEST}, (
+        f"expected {{{_STATION_IN_LARGEST!r}}}, got {found}\nSQL: {sql}"
+    )

--- a/backend/tests/test_sec025_sandbox_allowlist.py
+++ b/backend/tests/test_sec025_sandbox_allowlist.py
@@ -403,6 +403,53 @@ class TestLegitimateQueriesAllowed:
         _assert_allows("SELECT MD5(name) FROM data.cities")
 
 
+class TestBooleanOperatorsAllowed:
+    """AND/OR are boolean operators, not callables — sqlglot models them as
+    exp.Connector (a Func subclass), so the fail-closed walk rejected every
+    compound condition as an unlisted "function" (found by the live NL→SQL
+    evals; fix skips Connector nodes, whose operands are still walked)."""
+
+    def test_allows_where_and(self):
+        _assert_allows("SELECT name FROM data.cities WHERE pop > 1 AND area < 2")
+
+    def test_allows_where_or(self):
+        _assert_allows("SELECT name FROM data.cities WHERE pop > 1 OR area < 2")
+
+    def test_allows_join_on_compound_condition(self):
+        _assert_allows(
+            "SELECT 1 FROM data.cities a JOIN data.cities b "
+            "ON a.name = 'x' AND b.name = 'y'"
+        )
+
+    def test_allows_case_when_and(self):
+        _assert_allows(
+            "SELECT CASE WHEN pop > 1 AND area < 2 THEN 'y' ELSE 'n' END "
+            "FROM data.cities"
+        )
+
+    def test_allows_having_and(self):
+        _assert_allows(
+            "SELECT name, COUNT(*) FROM data.cities "
+            "GROUP BY name HAVING COUNT(*) > 1 AND name != 'x'"
+        )
+
+    def test_rejects_blocked_function_inside_and(self):
+        """Skipping the Connector node must NOT hide functions in its operands."""
+        _assert_rejects(
+            "SELECT name FROM data.cities WHERE pg_sleep(1) IS NULL AND pop > 1"
+        )
+
+    def test_rejects_unlisted_function_inside_or(self):
+        _assert_rejects(
+            "SELECT name FROM data.cities WHERE dblink('a','b') IS NULL OR pop > 1"
+        )
+
+    def test_rejects_unlisted_spatial_function_inside_and(self):
+        _assert_rejects(
+            "SELECT name FROM data.cities WHERE ST_EvilThing(geom_4326) AND pop > 1"
+        )
+
+
 class TestResourceAmplificationRejected:
     """One-row SELECTs must not create attacker-sized intermediate values."""
 


### PR DESCRIPTION
## Summary

Extending the #537 eval harness immediately paid off: the new distance case generated a `JOIN ... ON a AND b` and exposed a **production sandbox bug** — sqlglot models `AND`/`OR` (`exp.Connector`) as `Func` subclasses, so the SEC-025 fail-closed function walk rejected **every compound condition** (`WHERE x AND y`, `JOIN ... ON ... AND ...`, `HAVING ... AND`, `CASE WHEN ... AND`) as "Query uses a disallowed function". Any AI chat question needing more than one condition failed at validation.

### Sandbox fix (`validator.py`)
- `exp.Connector` nodes are skipped in the function walk — they are boolean operators, not callables. Their operands are still visited by `find_all`, so a blocked/unlisted function inside either side of an AND/OR is still rejected (fail-closed posture unchanged; red-team cases prove it).
- The walk moved to `_check_function_allowlist()` to stay under ruff's C901 cap; logic otherwise byte-identical.

### Tests
- `test_sec025_sandbox_allowlist.py`: new `TestBooleanOperatorsAllowed` — 5 allowed operator shapes + 3 red-team rejections (`pg_sleep`/`dblink`/unlisted `ST_*` inside AND/OR operands). Pure, no LLM.
- `tests/evals/`: two new live cases — **distance-in-miles** (cross-table, geography cast + magnitude vs ground truth; the regression eval for this fix) and **spatial containment** (point-in-polygon join must resolve to exactly the one station seeded inside the park; requires an `ST_*` predicate). Fixture gains a stations point table, second catalog dataset, and full teardown.

## Verification

- `pytest tests/test_sec025_sandbox_allowlist.py tests/test_sandbox.py tests/test_ai_chat_dataset.py`: 157 passed.
- `RUN_AI_EVALS=1` live vs Anthropic: **7/7 passed** (was 6/7 — distance failed on the sandbox rejection before the fix).
- `ruff check` / `format --check`: clean.

https://claude.ai/code/session_01NXiEUdCwnuPRDKsbbkPWbg