### PR TITLE
docs(editions): complete the paid-capabilities list

### DIFF
--- a/EDITIONS.md
+++ b/EDITIONS.md
@@ -14,7 +14,7 @@ These commitments define the free and paid boundary:
 - Capabilities released for free in this repository will stay free. Paid modules will add separate capabilities instead of taking existing ones away.
 - Your data and catalog remain exportable through open standards.
 
-Carto Concepts, LLC offers optional paid support and add-ons. Enterprise includes SAML identity, SIEM audit streaming, branding controls, arbitrary share-link expiration, origin-restricted embeds, and support with an SLA. Community includes OIDC and OAuth, bounded CSV and JSON audit export, share creation and revocation, fixed expiration presets, non-expiring links, and default-lifetime embeds. The paid modules ship in a separately licensed, immutable Enterprise image. You do not need them to build or run this repository.
+Carto Concepts, LLC offers optional paid support and add-ons. Enterprise includes SAML identity, identity-provider role mapping, attribute-based access control, publication approval workflows, SIEM audit streaming, branding controls, arbitrary share-link expiration, custom embed-token lifetimes, origin-restricted embeds, and support with an SLA. Community includes OIDC and OAuth, bounded CSV and JSON audit export, share creation and revocation, fixed expiration presets, non-expiring links, and default-lifetime embeds. The paid modules ship in a separately licensed, immutable Enterprise image. You do not need them to build or run this repository.
 
 A valid commercial license grants perpetual use of the installed version. The maintenance term controls access to updates and support. When maintenance ends, the installed version keeps working, data and backups remain accessible, and local administrators keep their login path.
 


### PR DESCRIPTION
## What

Adds the four shipped paid capabilities missing from EDITIONS.md's Enterprise sentence:

- identity-provider role mapping
- attribute-based access control
- publication approval workflows
- custom embed-token lifetimes

The Community sentence is unchanged.

## Why

EDITIONS.md is the licensing-transparency doc (REL-01). Two of the added items are gates a Community user can encounter in-product (IdP role mapping, custom embed lifetimes) — a hittable gate absent from the transparency doc reads as undisclosed gating. The other two (ABAC, approval workflows) ship in the paid overlay and were simply never listed.

## Verification

- `python3 scripts/check_public_surface.py` — passed (67 files scanned)
- No pricing added; no marketing language; doc voice unchanged