### PR TITLE
fix(dataset): stop the Ask AI FAB overlapping the problem-reporter badge

### DIFF
--- a/frontend/src/components/dataset/DatasetChatPanel.tsx
+++ b/frontend/src/components/dataset/DatasetChatPanel.tsx
@@ -184,8 +184,12 @@ export function DatasetChatPanel({ datasetId, datasetTitle, showOpenInBuilder }:
 
   if (!isAIAvailable) return null;
 
+  // bottom-10/end-16 (not bottom-6/end-6) clears the global ReportProblemHost
+  // lifebuoy (fixed bottom-10 right-4 z-40, size-10 + count badge): same
+  // baseline, 8px gap to its left, so neither the FAB nor the open dialog
+  // ever sits under the higher-z reporter.
   return (
-    <div className="fixed bottom-6 end-6 z-30 flex flex-col items-end gap-2">
+    <div className="fixed bottom-10 end-16 z-30 flex flex-col items-end gap-2">
       {open && (
         <section
           role="dialog"


### PR DESCRIPTION
## Summary

The dataset-chat "Ask AI" FAB (`fixed bottom-6 end-6 z-30`) collided with the global problem-reporter lifebuoy (`ReportProblemHost`: `fixed bottom-10 right-4 z-40`) whenever captured errors made the reporter appear — the higher-z badge floated over the FAB's corner (user-reported screenshot), and the open chat dialog slid under it too.

**Fix:** the FAB container moves to `bottom-10 end-16` — same baseline as the reporter, 8px gap to its left. One class change plus a comment documenting the geometry.

## Verification

- Live QA (worktree Vite + host API): triggered captured errors to summon the reporter; measured bounding boxes — FAB right edge 1136px, reporter 1144–1184px, shared bottom at 519px; open dialog vs reporter `overlap: false`. Screenshots of both states attached to the session.
- `vitest` DatasetChatPanel (7 passed), eslint, `npm run typecheck`: clean.

Note: `ViewerChatPanel` positions its FAB inside the map container (`absolute bottom-8 right-3`) and can also sit near the reporter on viewer pages — left untouched here since the geometry differs (map-relative, and the attribution bar factors in); worth a separate look if reported.

https://claude.ai/code/session_01NXiEUdCwnuPRDKsbbkPWbg