### PR TITLE
fix(ai): dataset-chat smoke follow-ups — overlay idle retry, viewer result badge, e2e carryover

### DIFF
--- a/e2e/dataset-chat.spec.ts
+++ b/e2e/dataset-chat.spec.ts
@@ -63,6 +63,41 @@ const SSE_FRAMES = [
   '',
 ].join('\n');
 
+// Spatial result for the builder-carryover test (#533/#542). The bbox centers
+// at exactly (40.75, -73.95) — values chosen to round cleanly in the builder's
+// coordinate readout so the camera-fit assertion is deterministic.
+const CARRYOVER_BBOX = [-74.0, 40.7, -73.9, 40.8];
+const CARRYOVER_GEOJSON = {
+  type: 'FeatureCollection',
+  features: [
+    { type: 'Feature', geometry: { type: 'Point', coordinates: [-73.98, 40.72] }, properties: { name: 'Alpha' } },
+    { type: 'Feature', geometry: { type: 'Point', coordinates: [-73.92, 40.78] }, properties: { name: 'Beta' } },
+  ],
+};
+const CARRYOVER_SSE_FRAMES = [
+  'event: token',
+  'data: {"text": "Found 2 stations."}',
+  '',
+  'event: actions',
+  `data: ${JSON.stringify({
+    actions: [
+      {
+        type: 'show_query_result',
+        rows: [['Alpha'], ['Beta']],
+        columns: ['name'],
+        row_count: 2,
+        geojson: CARRYOVER_GEOJSON,
+        bbox: CARRYOVER_BBOX,
+      },
+    ],
+  })}`,
+  '',
+  'event: done',
+  'data: {"explanation": "Found 2 stations."}',
+  '',
+  '',
+].join('\n');
+
 test.describe('Dataset AI chat', () => {
   test.beforeAll(async () => {
     const token = getAuthToken();
@@ -153,5 +188,44 @@ test.describe('Dataset AI chat', () => {
         .filter({ hasText: datasetTitle })
         .first(),
     ).toBeVisible({ timeout: 15_000 });
+  });
+
+  test('carries a spatial result into the builder as an ephemeral overlay (#533/#542)', async ({
+    page,
+  }) => {
+    await mockAIAvailable(page, true);
+    await page.route('**/api/ai/chat/dataset/stream/', (route) =>
+      route.fulfill({
+        contentType: 'text/event-stream',
+        body: CARRYOVER_SSE_FRAMES,
+      }),
+    );
+
+    await page.goto(`/datasets/${datasetId}`);
+    await page.getByRole('button', { name: 'Ask AI' }).click();
+
+    const composer = page.getByPlaceholder('Ask about this data...');
+    await composer.fill('show me the stations');
+    await page.getByRole('button', { name: 'Send' }).click();
+    await expect(page.getByText('Found 2 stations.')).toBeVisible();
+
+    await page.getByRole('button', { name: 'Open in builder' }).click();
+    await page.waitForURL(/\/maps\/[0-9a-f-]{36}/);
+    createdMapId = page.url().match(/\/maps\/([0-9a-f-]{36})/)?.[1] ?? null;
+    expect(createdMapId).toBeTruthy();
+
+    await expect(page.locator('canvas.maplibregl-canvas')).toBeVisible({ timeout: 15_000 });
+    // Two independent assertions on purpose: the badge is React state, the
+    // camera fit is map state. The fix(#542) race kept the badge visible while
+    // the overlay and fitBounds silently never applied. The race itself is
+    // timing-dependent (it needs the style transiently unloaded at pickup, so
+    // a fast local run may not reproduce it — the deterministic regression
+    // test lives in use-ephemeral-layers.test.ts); what this spec pins down is
+    // the full stash → pickup → overlay integration, which jsdom cannot.
+    await expect(page.getByText(/Query result · 2 features/)).toBeVisible({ timeout: 15_000 });
+    await expect(page.locator('[data-coord-readout="true"]')).toContainText(
+      '40.75° N · 73.95° W',
+      { timeout: 15_000 },
+    );
   });
 });

--- a/frontend/src/components/builder/BuilderRail.tsx
+++ b/frontend/src/components/builder/BuilderRail.tsx
@@ -4,9 +4,7 @@ import { FileText, History, Sparkles, ChevronRight, Loader2, BotOff } from 'luci
 import { Link } from 'react-router';
 import { LazyLoadErrorBoundary } from '@/components/error/LazyLoadErrorBoundary';
 import { cn } from '@/lib/utils';
-import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
-import { experimentalBadgeColor } from '@/lib/status-colors';
 import type { MapLayerResponse } from '@/types/api';
 import type { LayerActions } from '@/components/builder/ChatPanel';
 import type { ViewportContext } from '@/components/builder/chat-suggestions';
@@ -213,11 +211,6 @@ export function BuilderRail({
                   ? t('dock.askAi', { defaultValue: 'Ask AI' })
                   : t('rail.aiUnavailable', { defaultValue: 'AI unavailable' }))}
               </span>
-              {activePanel === 'ai' && aiAvailable && (
-                <Badge variant="outline" className={`text-2xs px-1.5 py-0 ${experimentalBadgeColor}`}>
-                  {t('chat.experimental', { defaultValue: 'Experimental' })}
-                </Badge>
-              )}
             </div>
             <button
               onClick={() => onPanelChange(null)}

--- a/frontend/src/components/builder/EphemeralBadge.tsx
+++ b/frontend/src/components/builder/EphemeralBadge.tsx
@@ -1,5 +1,6 @@
 import { useTranslation } from 'react-i18next';
 import { X } from 'lucide-react';
+import { cn } from '@/lib/utils';
 
 interface EphemeralBadgeProps {
   featureCount: number;
@@ -8,9 +9,11 @@ interface EphemeralBadgeProps {
   truncated?: boolean;
   /** Total feature count before truncation. */
   totalCount?: number;
+  /** Position override — the viewer's bottom-left corner is occupied by its basemap toggle. */
+  className?: string;
 }
 
-export function EphemeralBadge({ featureCount, onDismiss, truncated, totalCount }: EphemeralBadgeProps) {
+export function EphemeralBadge({ featureCount, onDismiss, truncated, totalCount, className }: EphemeralBadgeProps) {
   const { t } = useTranslation('builder');
 
   const countLabel = truncated && totalCount != null
@@ -22,7 +25,7 @@ export function EphemeralBadge({ featureCount, onDismiss, truncated, totalCount 
     : t('ephemeralBadge.featureCount', { count: featureCount });
 
   return (
-    <div className="absolute bottom-8 start-4 z-[8] flex items-center gap-2 rounded-md bg-background/95 backdrop-blur-sm border shadow-sm px-3 py-1.5 text-xs">
+    <div className={cn('absolute bottom-8 start-4 z-[8] flex items-center gap-2 rounded-md bg-background/95 backdrop-blur-sm border shadow-sm px-3 py-1.5 text-xs', className)}>
       <span className="h-2 w-2 rounded-full bg-warning shrink-0" />
       <span className="text-muted-foreground">
         {t('ephemeralBadge.queryResult')} &middot; {countLabel}

--- a/frontend/src/components/builder/hooks/__tests__/use-ephemeral-layers.test.ts
+++ b/frontend/src/components/builder/hooks/__tests__/use-ephemeral-layers.test.ts
@@ -19,6 +19,8 @@ interface MockMap {
   off: (event: string, cb: () => void) => void;
   /** fix(#394) LM-02/B-028: registered style.load handlers — call to simulate a basemap/style reload. */
   styleLoadHandlers: Array<() => void>;
+  /** fix(#533 follow-up): one-shot idle handlers — call to simulate the map settling. */
+  idleHandlers: Array<() => void>;
   fitBounds: (bounds: unknown, options: unknown) => void;
 }
 
@@ -27,9 +29,11 @@ function createMockMap(): MockMap {
   const sources = new Set<string>();
   const fitBoundsCalls: MockMap['fitBoundsCalls'] = [];
   const styleLoadHandlers: Array<() => void> = [];
+  const idleHandlers: Array<() => void> = [];
 
-  return {
+  const mock: MockMap = {
     styleLoadHandlers,
+    idleHandlers,
     layers,
     sources,
     styleLoaded: true,
@@ -48,21 +52,26 @@ function createMockMap(): MockMap {
     removeSource: (id) => {
       sources.delete(id);
     },
-    isStyleLoaded: () => true,
-    once: (_event, cb) => cb(),
+    isStyleLoaded: () => mock.styleLoaded,
+    once: (event, cb) => {
+      if (event === 'idle') idleHandlers.push(cb);
+      else cb();
+    },
     on: (event, cb) => {
       if (event === 'style.load') styleLoadHandlers.push(cb);
     },
     off: (event, cb) => {
-      if (event === 'style.load') {
-        const idx = styleLoadHandlers.indexOf(cb);
-        if (idx >= 0) styleLoadHandlers.splice(idx, 1);
+      const pool = event === 'style.load' ? styleLoadHandlers : event === 'idle' ? idleHandlers : null;
+      if (pool) {
+        const idx = pool.indexOf(cb);
+        if (idx >= 0) pool.splice(idx, 1);
       }
     },
     fitBounds: (bounds, options) => {
       fitBoundsCalls.push({ bounds, options });
     },
   };
+  return mock;
 }
 
 function sampleGeoJSON(): GeoJSON.FeatureCollection {
@@ -194,6 +203,53 @@ describe('fix(#394) LM-02/B-028: overlay survives style reloads', () => {
     expect(map.layers.has('ephemeral-result-circle')).toBe(true);
     // No second auto-zoom — the viewport belongs to the user after first show.
     expect(map.fitBoundsCalls).toHaveLength(1);
+  });
+
+  it('fix(#533 follow-up): retries on idle when the style is transiently not loaded', () => {
+    const map = createMockMap();
+    // Reproduce the cold-load pickup race: style transiently reports
+    // not-loaded and the initial style.load has already fired (so the
+    // style.load subscription alone would never run).
+    map.styleLoaded = false;
+    const ref = { current: map as unknown as maplibregl.Map };
+    const { result } = renderHook(() => useEphemeralLayers(ref));
+
+    act(() => {
+      result.current.handleQueryResult(sampleGeoJSON(), [-1, -1, 1, 1]);
+    });
+
+    // Nothing applied yet — the overlay must wait for the map to settle.
+    expect(map.sources.has('ephemeral-result')).toBe(false);
+    expect(map.fitBoundsCalls).toHaveLength(0);
+    expect(map.idleHandlers).toHaveLength(1);
+
+    // Map settles.
+    map.styleLoaded = true;
+    act(() => {
+      map.idleHandlers.forEach((cb) => cb());
+    });
+
+    expect(map.sources.has('ephemeral-result')).toBe(true);
+    expect(map.layers.has('ephemeral-result-circle')).toBe(true);
+    expect(map.fitBoundsCalls).toHaveLength(1);
+    expect(map.fitBoundsCalls[0].bounds).toEqual([[-1, -1], [1, 1]]);
+  });
+
+  it('fix(#533 follow-up): unsubscribes the idle handler on dismiss', () => {
+    const map = createMockMap();
+    map.styleLoaded = false;
+    const ref = { current: map as unknown as maplibregl.Map };
+    const { result } = renderHook(() => useEphemeralLayers(ref));
+
+    act(() => {
+      result.current.handleQueryResult(sampleGeoJSON(), [0, 0, 1, 1]);
+    });
+    expect(map.idleHandlers).toHaveLength(1);
+
+    act(() => {
+      result.current.handleDismissEphemeral();
+    });
+    expect(map.idleHandlers).toHaveLength(0);
   });
 
   it('unsubscribes the style.load handler on dismiss', () => {

--- a/frontend/src/components/builder/hooks/use-ephemeral-layers.ts
+++ b/frontend/src/components/builder/hooks/use-ephemeral-layers.ts
@@ -107,6 +107,14 @@ export function useEphemeralLayers(
 
     if (map.isStyleLoaded()) {
       addLayersAndMaybeZoom();
+    } else {
+      // fix(#533 follow-up): on the ?chat_result=1 cold-load pickup the
+      // dataset-layer sync leaves the style transiently not-loaded while the
+      // initial `style.load` has ALREADY fired, so the subscription below
+      // never fires and the overlay is silently dropped (badge shows, map
+      // stays at world view). One-shot `idle` retries once the map settles —
+      // same idiom as BuilderMap's SP-03 layer-sync gate.
+      map.once('idle', addLayersAndMaybeZoom);
     }
     // fix(#394) LM-02/B-028: subscribe for the LIFETIME of the result — a
     // basemap/style reload wipes the overlay from the map while the result
@@ -115,6 +123,7 @@ export function useEphemeralLayers(
     map.on('style.load', addLayersAndMaybeZoom);
 
     return () => {
+      map.off('idle', addLayersAndMaybeZoom);
       map.off('style.load', addLayersAndMaybeZoom);
     };
   }, [ephemeralResult, mapInstanceRef]);

--- a/frontend/src/components/dataset/DatasetChatPanel.tsx
+++ b/frontend/src/components/dataset/DatasetChatPanel.tsx
@@ -194,7 +194,7 @@ export function DatasetChatPanel({ datasetId, datasetTitle, showOpenInBuilder }:
         <section
           role="dialog"
           aria-label={t('ai.chat.title')}
-          className="flex h-[min(70vh,520px)] w-[min(360px,calc(100vw-1.5rem))] flex-col overflow-hidden rounded-2xl border bg-background/98 shadow-lg backdrop-blur"
+          className="flex h-[min(70vh,520px)] w-[min(360px,calc(100vw-4.75rem))] flex-col overflow-hidden rounded-2xl border bg-background/98 shadow-lg backdrop-blur"
         >
           <div className="flex items-center justify-between border-b px-3 py-2">
             <div className="flex items-center gap-2">

--- a/frontend/src/components/maps/MapCreateDialog.tsx
+++ b/frontend/src/components/maps/MapCreateDialog.tsx
@@ -12,7 +12,6 @@ import { useAIAvailability } from '@/hooks/use-ai-availability';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Button } from '@/components/ui/button';
-import { Badge } from '@/components/ui/badge';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import {
   Dialog,
@@ -158,9 +157,6 @@ export function MapCreateDialog({ open, onOpenChange }: MapCreateDialogProps) {
               <TabsTrigger value="ai">
                 <Sparkles className="me-1 size-3.5" />
                 {t('mapCreate.tabAI')}
-                <Badge variant="outline" className="ms-1.5 border-warning/50 px-1.5 py-0 text-2xs font-medium text-warning">
-                  {t('chat.experimental')}
-                </Badge>
               </TabsTrigger>
             )}
           </TabsList>

--- a/frontend/src/components/viewer/ViewerChatPanel.tsx
+++ b/frontend/src/components/viewer/ViewerChatPanel.tsx
@@ -256,7 +256,11 @@ export function ViewerChatPanel({ mapId, layers, mapInstanceRef }: ViewerChatPan
           className="bottom-32 start-3"
         />
       )}
-    <div className="absolute bottom-8 right-3 z-10 flex flex-col items-end gap-2">
+    {/* fix(#542): end-16, not end-3 — the problem-reporter lifebuoy (fixed
+        bottom-10 right-4, size-10) appears in the bottom-right corner once
+        errors are captured and overlapped the FAB (same class of bug as the
+        dataset-page fix in #540). */}
+    <div className="absolute bottom-8 end-16 z-10 flex flex-col items-end gap-2">
       {open && (
         <section
           role="dialog"

--- a/frontend/src/components/viewer/ViewerChatPanel.tsx
+++ b/frontend/src/components/viewer/ViewerChatPanel.tsx
@@ -7,6 +7,7 @@ import { ApiError } from '@/api/client';
 import { streamChatMessage } from '@/api/maps';
 import { useAIAvailability } from '@/hooks/use-ai-availability';
 import { useEphemeralLayers } from '@/components/builder/hooks/use-ephemeral-layers';
+import { EphemeralBadge } from '@/components/builder/EphemeralBadge';
 import { cn } from '@/lib/utils';
 import type { ChatAction, ChatHistoryMessage, MapLayerResponse } from '@/types/api';
 
@@ -116,7 +117,7 @@ interface ViewerChatPanelProps {
 export function ViewerChatPanel({ mapId, layers, mapInstanceRef }: ViewerChatPanelProps) {
   const { t, i18n } = useTranslation('common');
   const { isAIAvailable } = useAIAvailability();
-  const { handleQueryResult } = useEphemeralLayers(mapInstanceRef);
+  const { ephemeralResult, handleQueryResult, handleDismissEphemeral } = useEphemeralLayers(mapInstanceRef);
 
   const [open, setOpen] = useState(false);
   const [messages, setMessages] = useState<ChatMessage[]>([]);
@@ -243,6 +244,18 @@ export function ViewerChatPanel({ mapId, layers, mapInstanceRef }: ViewerChatPan
   if (!isAIAvailable) return null;
 
   return (
+    <>
+      {/* fix(#542): the viewer applied the query overlay with no legend entry,
+          badge, or dismissal — orange highlights persisted unexplained. Reuse
+          the builder's badge; the viewer's bottom-left column is occupied by
+          BasemapToggle (bottom-8) and the Map data button (bottom-20). */}
+      {ephemeralResult && (
+        <EphemeralBadge
+          featureCount={ephemeralResult.geojson.features.length}
+          onDismiss={handleDismissEphemeral}
+          className="bottom-32 start-3"
+        />
+      )}
     <div className="absolute bottom-8 right-3 z-10 flex flex-col items-end gap-2">
       {open && (
         <section
@@ -364,5 +377,6 @@ export function ViewerChatPanel({ mapId, layers, mapInstanceRef }: ViewerChatPan
         </Button>
       )}
     </div>
+    </>
   );
 }

--- a/frontend/src/components/viewer/ViewerChatPanel.tsx
+++ b/frontend/src/components/viewer/ViewerChatPanel.tsx
@@ -265,7 +265,7 @@ export function ViewerChatPanel({ mapId, layers, mapInstanceRef }: ViewerChatPan
         <section
           role="dialog"
           aria-label={t('viewer.ai.title')}
-          className="flex h-[min(70vh,520px)] w-[min(360px,calc(100vw-1.5rem))] flex-col overflow-hidden rounded-2xl border bg-background/98 shadow-lg backdrop-blur"
+          className="flex h-[min(70vh,520px)] w-[min(360px,calc(100vw-4.75rem))] flex-col overflow-hidden rounded-2xl border bg-background/98 shadow-lg backdrop-blur"
         >
           <div className="flex items-center justify-between border-b px-3 py-2">
             <div className="flex items-center gap-2">

--- a/frontend/src/components/viewer/__tests__/ViewerChatPanel.test.tsx
+++ b/frontend/src/components/viewer/__tests__/ViewerChatPanel.test.tsx
@@ -40,6 +40,31 @@ beforeEach(() => {
 });
 
 describe('ViewerChatPanel', () => {
+  it('fix(#542): shows a dismissible query-result badge when the overlay is active', async () => {
+    setAvailable(true);
+    const handleDismissEphemeral = vi.fn();
+    mockEphemeral.mockReturnValue({
+      ephemeralResult: {
+        geojson: {
+          type: 'FeatureCollection',
+          features: [
+            { type: 'Feature', geometry: { type: 'Point', coordinates: [0, 0] }, properties: {} },
+            { type: 'Feature', geometry: { type: 'Point', coordinates: [1, 1] }, properties: {} },
+          ],
+        },
+        bbox: [0, 0, 1, 1],
+      },
+      handleQueryResult,
+      handleDismissEphemeral,
+    });
+
+    renderPanel();
+
+    expect(screen.getByText(/Query result/)).toBeInTheDocument();
+    await userEvent.click(screen.getByRole('button', { name: 'Dismiss query result' }));
+    expect(handleDismissEphemeral).toHaveBeenCalled();
+  });
+
   it('renders nothing when AI is unavailable (anon / no use_ai_chat)', () => {
     setAvailable(false);
     renderPanel();

--- a/frontend/src/i18n/locales/de/builder.json
+++ b/frontend/src/i18n/locales/de/builder.json
@@ -676,7 +676,6 @@
     "createEmbedToken": "Einbettungs-Token erstellen"
   },
   "chat": {
-    "experimental": "Experimentell",
     "emptyState": "Beschreiben Sie Änderungen an Ihrer Karte in natürlicher Sprache.",
     "placeholder": "Kartenänderung beschreiben...",
     "thinking": "Denkt nach...",

--- a/frontend/src/i18n/locales/en/builder.json
+++ b/frontend/src/i18n/locales/en/builder.json
@@ -676,7 +676,6 @@
     "createEmbedToken": "Create embed token"
   },
   "chat": {
-    "experimental": "Experimental",
     "emptyState": "Describe changes to your map using natural language.",
     "placeholder": "Describe a map change...",
     "thinking": "Thinking...",

--- a/frontend/src/i18n/locales/es/builder.json
+++ b/frontend/src/i18n/locales/es/builder.json
@@ -676,7 +676,6 @@
     "createEmbedToken": "Crear token de inserción"
   },
   "chat": {
-    "experimental": "Experimental",
     "emptyState": "Describa cambios en su mapa usando lenguaje natural.",
     "placeholder": "Describa un cambio en el mapa...",
     "thinking": "Pensando...",

--- a/frontend/src/i18n/locales/fr/builder.json
+++ b/frontend/src/i18n/locales/fr/builder.json
@@ -676,7 +676,6 @@
     "createEmbedToken": "Créer un jeton d’intégration"
   },
   "chat": {
-    "experimental": "Expérimental",
     "emptyState": "Décrivez les modifications à apporter à votre carte en langage naturel.",
     "placeholder": "Décrivez une modification de carte...",
     "thinking": "Réflexion...",

--- a/frontend/src/lib/__tests__/status-colors.test.ts
+++ b/frontend/src/lib/__tests__/status-colors.test.ts
@@ -10,7 +10,6 @@ import {
   ingestionStatusColors,
   validationLevelColors,
   healthDotColors,
-  experimentalBadgeColor,
   syntheticBadgeColor,
   vrtRasterStatusColors,
 } from '@/lib/status-colors';
@@ -153,12 +152,6 @@ describe('vrtRasterStatusColors', () => {
   });
 });
 
-describe('experimentalBadgeColor', () => {
-  it('uses the warning token', () => {
-    expect(experimentalBadgeColor).toContain('warning');
-  });
-});
-
 describe('syntheticBadgeColor', () => {
   it('uses the synthetic provenance token', () => {
     expect(syntheticBadgeColor).toContain('synthetic');
@@ -183,7 +176,6 @@ describe('token discipline (DS-01)', () => {
     ...Object.values(validationLevelColors),
     ...Object.values(healthDotColors),
     ...Object.values(vrtRasterStatusColors),
-    experimentalBadgeColor,
     syntheticBadgeColor,
     qualityScoreClasses(95),
     qualityScoreClasses(70),

--- a/frontend/src/lib/status-colors.ts
+++ b/frontend/src/lib/status-colors.ts
@@ -94,8 +94,6 @@ export const healthDotColors = {
   unknown: 'bg-muted-foreground',
 } as const;
 
-export const experimentalBadgeColor = 'border-warning/50 text-warning';
-
 /** Provenance marker, not a record type — hence its own token pair. */
 export const syntheticBadgeColor =
   'border-synthetic/30 bg-synthetic-bg text-synthetic';


### PR DESCRIPTION
## What

Post-merge browser smoke of the dataset-chat work (#532–#540) surfaced three issues on `main`; this PR closes all of them plus a UI-consistency cleanup.

### 1. Chat-result overlay lost to a style-load race (commit 1)

The `?chat_result=1` cold-load pickup shipped in #533 races the builder's dataset-layer sync. At pickup time `useEphemeralLayers` can observe `isStyleLoaded() === false` while the initial `style.load` event has already fired — so neither the immediate-add path nor the `style.load` subscription ever runs. The stash is consumed and the "Query result · N features" badge renders, but the map keeps no overlay and never fits the result bbox. Reproduced live (map probed: no `ephemeral-result` source/layers despite the badge).

**Fix:** one-shot `idle` retry when the style isn't loaded at apply time — the same idiom as BuilderMap's SP-03 layer-sync gate. The existing `zoomed` flag keeps the bbox fit single-shot; cleanup unsubscribes both listeners. Verified live after the fix (overlay + camera fit present).

### 2. Viewer overlay had no badge, legend entry, or dismissal (commit 2)

`ViewerChatPanel` shares `useEphemeralLayers` but only wired `handleQueryResult` — a viewer-role user got orange highlights with nothing naming them and no way to clear them. Reuse the builder's `EphemeralBadge` (new optional `className`; the viewer's bottom-left column is occupied by BasemapToggle at `bottom-8` and the Map data button at `bottom-20`, so the badge sits at `bottom-32` — clearance measured live, no overlap). Dismiss verified live: badge and overlay both clear.

### 3. E2E carryover coverage (commit 2)

`e2e/dataset-chat.spec.ts` gains the open-in-builder carryover flow: canned SSE with a spatial `show_query_result`, click through, then assert **both** the result badge (React state) and the camera fit via the coordinate readout (map state). Honest caveat, also noted in-spec: the race in item 1 is timing-dependent and does not reproduce in a fast local run (validated by swapping the pre-fix hook back in — the e2e still passed), so the deterministic race regression lives in the unit test; the e2e pins the stash → pickup → overlay integration that jsdom cannot.

### 4. Stale "Experimental" badge removed (commit 3)

The builder rail header and map-create AI tab still carried an Experimental badge while the two newer chat surfaces (dataset page, viewer) shipped without one. Removed for consistency, along with the now-unused `experimentalBadgeColor` token and `chat.experimental` keys in all four locales (`npm run test:i18n` green).

## Verification

- `use-ephemeral-layers` 9/9 (2 new: idle-retry race repro, idle unsubscribe on dismiss)
- `ViewerChatPanel` 6/6 (new: badge render + dismiss wiring)
- Full builder + maps suites: 87 files, 1296 tests green
- `npm run test:i18n` green after locale-key removal
- `npx playwright test e2e/dataset-chat.spec.ts` 3/3 against the live worktree stack
- eslint + `npm run typecheck` clean
- Live QA on all three chat surfaces (dataset panel, builder, viewer) with real Anthropic

https://claude.ai/code/session_01NXiEUdCwnuPRDKsbbkPWbg