### PR TITLE
fix(builder): don't mark fresh maps dirty on the initial add_dataset layer add

### DIFF
--- a/frontend/src/components/builder/hooks/__tests__/use-builder-layers.add-dataset.test.ts
+++ b/frontend/src/components/builder/hooks/__tests__/use-builder-layers.add-dataset.test.ts
@@ -186,6 +186,28 @@ describe('handleAddDataset (BSR-18)', () => {
     expect(result.current.hasUnsavedChanges).toBe(false);
   });
 
+  it('fix(#554 codex P2): two adds resolving in one batch on a fresh map still mark dirty (second add renumbers the first)', () => {
+    const { result, mutate } = renderBuilderLayers(makeMapData([]));
+
+    act(() => {
+      result.current.handleAddDataset('ds-1');
+      result.current.handleAddDataset('ds-2');
+    });
+
+    const [, { onSuccess: onSuccess1 }] = mutate.mock.calls[0];
+    const [, { onSuccess: onSuccess2 }] = mutate.mock.calls[1];
+    // Both resolve inside ONE act/batch: layersRef has not committed layer-1
+    // yet when layer-2's onSuccess runs, but the renumber of layer-1 is real
+    // unpersisted local state — the map must be dirty.
+    act(() => {
+      onSuccess1({ id: 'layer-1', dataset_id: 'ds-1', sort_order: 0 });
+      onSuccess2({ id: 'layer-2', dataset_id: 'ds-2', sort_order: 0 });
+    });
+
+    expect(result.current.localLayers.map((l) => l.id)).toEqual(['layer-2', 'layer-1']);
+    expect(result.current.hasUnsavedChanges).toBe(true);
+  });
+
   it('fix(#545)/WR-02: add onto a map with existing layers STILL marks dirty (sibling renumber is unpersisted)', () => {
     const existing = makeMockLayer({ id: 'existing', sort_order: 0 });
     const { result, mutate } = renderBuilderLayers(makeMapData([existing]));

--- a/frontend/src/components/builder/hooks/__tests__/use-builder-layers.add-dataset.test.ts
+++ b/frontend/src/components/builder/hooks/__tests__/use-builder-layers.add-dataset.test.ts
@@ -171,6 +171,35 @@ describe('handleAddDataset (BSR-18)', () => {
     expect(result.current.savedLayerBaseline.some((l) => l.id === 'created-layer-id')).toBe(true);
   });
 
+  it('fix(#545): first layer on a fresh empty map does NOT mark the map dirty (no false unsaved-changes prompt)', () => {
+    const { result, mutate } = renderBuilderLayers(makeMapData([]));
+
+    act(() => {
+      result.current.handleAddDataset('ds-42');
+    });
+
+    const [, { onSuccess }] = mutate.mock.calls[0];
+    act(() => { onSuccess({ id: 'created-layer-id', dataset_id: 'ds-42', sort_order: 0 }); });
+
+    // The POST-created layer alone IS the saved state — nothing was renumbered.
+    expect(result.current.localLayers.map((l) => l.id)).toEqual(['created-layer-id']);
+    expect(result.current.hasUnsavedChanges).toBe(false);
+  });
+
+  it('fix(#545)/WR-02: add onto a map with existing layers STILL marks dirty (sibling renumber is unpersisted)', () => {
+    const existing = makeMockLayer({ id: 'existing', sort_order: 0 });
+    const { result, mutate } = renderBuilderLayers(makeMapData([existing]));
+
+    act(() => {
+      result.current.handleAddDataset('ds-42');
+    });
+
+    const [, { onSuccess }] = mutate.mock.calls[0];
+    act(() => { onSuccess({ id: 'created-layer-id', dataset_id: 'ds-42', sort_order: 0 }); });
+
+    expect(result.current.hasUnsavedChanges).toBe(true);
+  });
+
   it('Test D: backward-compat — no onSuccessCb arg does not throw', () => {
     const layer = makeMockLayer();
     const { result, mutate } = renderBuilderLayers(makeMapData([layer]));

--- a/frontend/src/components/builder/hooks/use-builder-layers.ts
+++ b/frontend/src/components/builder/hooks/use-builder-layers.ts
@@ -513,6 +513,13 @@ export function useBuilderLayers(
             // just also stamping parent_group_id so the row renders inside the
             // group immediately.
             if (createdLayer?.id) {
+              // fix(#545): the WR-02 dirty-flag below exists because prepending
+              // renumbers EXISTING siblings locally (an unpersisted diff). On a
+              // fresh map with no other layers there is nothing renumbered — the
+              // POST-created layer alone IS the saved state — so marking dirty
+              // falsely triggers the unsaved-changes prompt on every new
+              // Add-to-Map / chat-created map.
+              const hadOtherLayers = layersRef.current.some((l) => l.id !== createdLayer.id);
               const insertedLayer: GroupedLayer = parentGroupId
                 ? { ...createdLayer, parent_group_id: parentGroupId }
                 : { ...createdLayer };
@@ -568,14 +575,17 @@ export function useBuilderLayers(
               // fix(#392): also register the pure server layer into the Save-diff baseline so
               // Save doesn't treat this just-created layer as diff.added and PATCH a duplicate.
               saveBaselineSyncRef.current?.(createdLayer);
-              // fix(#392): mark dirty unconditionally, not just for the grouped
-              // branch — the non-grouped branch above renumbers every existing
-              // layer's sort_order locally, but the backend does not renumber
-              // sibling rows (maps/service_layers.py:106-120), so that renumber is
-              // an unpersisted diff the apiLayers resync effect could otherwise
+              // fix(#392): mark dirty whenever existing siblings were renumbered —
+              // the non-grouped branch above renumbers every existing layer's
+              // sort_order locally, but the backend does not renumber sibling rows
+              // (maps/service_layers.py:106-120), so that renumber is an
+              // unpersisted diff the apiLayers resync effect could otherwise
               // silently clobber before Save. Same defect class as CR-01
               // (handleDuplicateRendering). (audit WR-02)
-              setHasUnsavedChanges(true);
+              // fix(#545): skip when this is the ONLY layer (fresh map) and no
+              // group membership was stamped — local state exactly mirrors the
+              // server, so the map must stay clean.
+              if (hadOtherLayers || parentGroupId) setHasUnsavedChanges(true);
               if (parentGroupId) {
                 // Group membership is unsaved frontend state — mark dirty so the
                 // save path persists it (and the refetch sync does not wipe it),

--- a/frontend/src/components/builder/hooks/use-builder-layers.ts
+++ b/frontend/src/components/builder/hooks/use-builder-layers.ts
@@ -519,7 +519,17 @@ export function useBuilderLayers(
               // POST-created layer alone IS the saved state — so marking dirty
               // falsely triggers the unsaved-changes prompt on every new
               // Add-to-Map / chat-created map.
-              const hadOtherLayers = layersRef.current.some((l) => l.id !== createdLayer.id);
+              // fix(#554 codex P2): layersRef is committed via useLayoutEffect, so
+              // when two add mutations resolve before React commits (e.g. AI
+              // "Accept all" staging several add_layer actions) it is stale-empty
+              // for BOTH onSuccess calls, yet the second add renumbers the first.
+              // savedLayerBaselineRef is updated synchronously in this callback
+              // (below), so it sees layers from earlier same-batch adds; check
+              // both refs rather than side-effecting inside the setLocalLayers
+              // updater (which must stay pure — StrictMode double-invokes it).
+              const hadOtherLayers =
+                layersRef.current.some((l) => l.id !== createdLayer.id) ||
+                savedLayerBaselineRef.current.some((l) => l.id !== createdLayer.id);
               const insertedLayer: GroupedLayer = parentGroupId
                 ? { ...createdLayer, parent_group_id: parentGroupId }
                 : { ...createdLayer };


### PR DESCRIPTION
## Summary

Fixes #545 — freshly created maps (Add to Map → **+ New map**, or a dataset-chat "Open in builder") prompted "unsaved changes" on navigation with zero user edits.

## Root cause

Both flows navigate to the builder with `?add_dataset=<id>`, which runs `handleAddDataset`. Its `onSuccess` marked the map dirty **unconditionally** — the #392 WR-02 fix, needed because prepending renumbers existing siblings locally and the backend doesn't renumber sibling rows. On a brand-new map there are no siblings: the POST-created layer alone is exactly the saved server state, so the dirty flag was false.

## Fix

Gate the dirty flag on actually-unpersisted local state: mark dirty only when other layers existed (local renumber) or a `parentGroupId` was stamped (group membership is frontend-only until Save). The #392 duplicate-layer-on-save protection is untouched.

## Verification

- New regression tests: fresh empty map stays clean; add onto an existing stack still marks dirty (WR-02 preserved).
- `npx vitest run src/components/builder` — 127 files / 1838 tests pass (includes the #392 save-integration suite).
- `npm run lint` and `npm run typecheck` clean.

No schema/API/config impact.

https://claude.ai/code/session_01XPiD2rhh1eNmYnPRojE39j