### PR TITLE
ci: detect changes via git diff, not the GitHub API

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,8 +17,8 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-# Least-privilege default for every job. The `changes` job widens to add
-# pull-requests:read; no job needs write (publishing lives in publish*.yml).
+# Least-privilege default for every job; no job needs write (publishing lives
+# in publish*.yml).
 permissions:
   contents: read
 
@@ -27,9 +27,6 @@ jobs:
   changes:
     name: Detect Changes
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      pull-requests: read
     outputs:
       backend: ${{ steps.filter.outputs.backend }}
       frontend: ${{ steps.filter.outputs.frontend }}
@@ -43,6 +40,10 @@ jobs:
       - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706  # v4
         id: filter
         with:
+          # fix(#546): empty token switches paths-filter to git-diff detection
+          # (base.sha..merge-commit from the checkout), removing the GitHub API
+          # call whose transient 503s failed this required check hard.
+          token: ''
           filters: |
             backend:
               - 'backend/**'


### PR DESCRIPTION
## Change

Passes `token: ''` to `dorny/paths-filter` in the required **Detect Changes** job. With an empty token the action (verified in the pinned v4 source) detects PR changes locally via `git diff base.sha..merge-commit` from the existing checkout instead of calling the GitHub API to list changed files — the call whose transient 503s failed the check hard three times on #542 and stalled auto-merge.

Semantics are identical: on `pull_request` events the checked-out merge commit is built on `base.sha`, so the two-dot diff yields exactly the PR's changed files. Push/schedule paths were already git-based. Also drops the job's now-unneeded `pull-requests: read` permission.

## Verification

`pull_request` workflows run the PR's own ci.yml, so the Detect Changes run on this PR exercises git-mode detection directly — confirm its log shows "changes will be detected using git diff" and the filter outputs fire (this PR should trigger no backend/frontend jobs, only the always-on ones).

Closes #546

https://claude.ai/code/session_01XPiD2rhh1eNmYnPRojE39j