### PR TITLE
fix(ai): carry geometry into chat query results deterministically

### DIFF
--- a/backend/app/processing/ai/chat_actions.py
+++ b/backend/app/processing/ai/chat_actions.py
@@ -44,6 +44,13 @@ logger = structlog.stdlib.get_logger(__name__)
 
 _DEFAULT_LABEL_TEXT_COLOR = "#333333"
 
+# Overlay/table render budget: only this many rows reach the chat result table
+# and the ephemeral map overlay. fix(#556 review P2): when we append geom_4326
+# to an otherwise attribute-only query, cap the fetch to this budget so a
+# large polygon/line layer doesn't transfer up to 1000 full geometries just to
+# discard all but these.
+_OVERLAY_ROW_BUDGET = 50
+
 
 def _safe_label_text_color(value: object) -> str:
     # fix(#394) CH-02: hex / real CSS named color / numeric-arg functional form
@@ -139,17 +146,27 @@ async def _handle_query_data(
 
     # fix(#544): geometry must reach _extract_geojson regardless of which
     # columns the model chose, or every map surface silently loses its overlay.
-    sql = ensure_geometry_selected(sql, layers)
+    sql_with_geom = ensure_geometry_selected(sql, layers)
+    geom_appended = sql_with_geom != sql
+    sql = sql_with_geom
 
     if stage_callback:
         stage_callback("Running query...")
 
-    result = await chat_service.validate_and_execute(
-        sql, session, user, restrict_tables=restrict_tables
-    )
+    # fix(#556 review P2): when we appended geometry, cap the fetch to the
+    # overlay render budget. Only _OVERLAY_ROW_BUDGET rows reach the table and
+    # overlay anyway, so fetching (and holding) up to 1000 full geometries for
+    # a large polygon/line layer is a transfer/memory regression. row_count
+    # then reflects the rendered budget with the truncated flag signalling more
+    # rows exist. Queries where the model selected geometry itself keep the
+    # default limit (pre-existing behavior, out of this rewrite's scope).
+    exec_kwargs: dict = {"restrict_tables": restrict_tables}
+    if geom_appended:
+        exec_kwargs["row_limit"] = _OVERLAY_ROW_BUDGET
+    result = await chat_service.validate_and_execute(sql, session, user, **exec_kwargs)
 
     # Extract GeoJSON for ephemeral result layers
-    columns, rows = result.columns, result.rows[:50]
+    columns, rows = result.columns, result.rows[:_OVERLAY_ROW_BUDGET]
     geojson_result = _extract_geojson(columns, rows)
     if geojson_result is not None:
         # fix(#544): geometry now travels via geojson only — raw WKB in the

--- a/backend/app/processing/ai/chat_actions.py
+++ b/backend/app/processing/ai/chat_actions.py
@@ -21,7 +21,11 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.core.identity import Identity
 from app.platform.sandbox import SandboxError
 from app.processing.ai.chat_constants import _EDIT_TOOLS, ERROR_MESSAGES
-from app.processing.ai.chat_geojson import _extract_geojson
+from app.processing.ai.chat_geojson import (
+    _extract_geojson,
+    ensure_geometry_selected,
+    strip_geometry_columns,
+)
 from app.processing.ai.colors import is_css_colorish, label_halo_color
 from app.processing.ai.chat_styles import _build_data_driven_style
 from app.processing.ai.schemas import (
@@ -133,17 +137,31 @@ async def _handle_query_data(
         error_msg = sql.strip().removeprefix("-- ERROR:").strip()
         return {"error": error_msg, "category": "llm_cannot_answer"}
 
+    # fix(#544): geometry must reach _extract_geojson regardless of which
+    # columns the model chose, or every map surface silently loses its overlay.
+    sql = ensure_geometry_selected(sql, layers)
+
     if stage_callback:
         stage_callback("Running query...")
 
     result = await chat_service.validate_and_execute(
         sql, session, user, restrict_tables=restrict_tables
     )
+
+    # Extract GeoJSON for ephemeral result layers
+    columns, rows = result.columns, result.rows[:50]
+    geojson_result = _extract_geojson(columns, rows)
+    if geojson_result is not None:
+        # fix(#544): geometry now travels via geojson only — raw WKB in the
+        # tabular payload is token noise for the model and renders as hex in
+        # the chat result tables.
+        columns, rows = strip_geometry_columns(columns, rows)
+
     # Limit rows in tool result for token economy
     # Note: raw SQL intentionally excluded to prevent info disclosure via LLM leakage
     out: dict = {
-        "columns": result.columns,
-        "rows": result.rows[:50],
+        "columns": columns,
+        "rows": rows,
         "row_count": result.row_count,
         "truncated": result.truncated,
     }
@@ -151,9 +169,6 @@ async def _handle_query_data(
         out["note"] = (
             "No matching results found. The user may want to try different criteria."
         )
-
-    # Extract GeoJSON for ephemeral result layers
-    geojson_result = _extract_geojson(result.columns, result.rows[:50])
     if geojson_result is not None:
         out["geojson"] = geojson_result[0]
         out["bbox"] = geojson_result[1]

--- a/backend/app/processing/ai/chat_actions.py
+++ b/backend/app/processing/ai/chat_actions.py
@@ -165,6 +165,25 @@ async def _handle_query_data(
         exec_kwargs["row_limit"] = _OVERLAY_ROW_BUDGET
     result = await chat_service.validate_and_execute(sql, session, user, **exec_kwargs)
 
+    # fix(#556 review P2): the transfer cap above bounds the sandbox row_count to
+    # the render budget, but show_query_result.row_count is the documented TOTAL
+    # matched rows (the model narrates it, the UI displays it). When the cap
+    # actually truncated the result, recover the true total with a geometry-free
+    # COUNT wrapping the same validated SQL (still bounded by the query's own
+    # LIMIT). Best-effort — a failure keeps the capped count rather than erroring.
+    if geom_appended and result.truncated:
+        try:
+            count_res = await chat_service.validate_and_execute(
+                f"SELECT COUNT(*) AS n FROM ({sql}) AS _geolens_total",
+                session,
+                user,
+                row_limit=1,
+                restrict_tables=restrict_tables,
+            )
+            result = result.model_copy(update={"row_count": int(count_res.rows[0][0])})
+        except Exception:  # broad: count recovery is best-effort, never fail the query
+            logger.warning("query_data.total_count_recovery_failed")
+
     # Extract GeoJSON for ephemeral result layers
     columns, rows = result.columns, result.rows[:_OVERLAY_ROW_BUDGET]
     geojson_result = _extract_geojson(columns, rows)

--- a/backend/app/processing/ai/chat_actions.py
+++ b/backend/app/processing/ai/chat_actions.py
@@ -146,9 +146,9 @@ async def _handle_query_data(
 
     # fix(#544): geometry must reach _extract_geojson regardless of which
     # columns the model chose, or every map surface silently loses its overlay.
-    sql_with_geom = ensure_geometry_selected(sql, layers)
-    geom_appended = sql_with_geom != sql
-    sql = sql_with_geom
+    original_sql = sql
+    sql = ensure_geometry_selected(original_sql, layers)
+    geom_appended = sql != original_sql
 
     if stage_callback:
         stage_callback("Running query...")
@@ -163,7 +163,25 @@ async def _handle_query_data(
     exec_kwargs: dict = {"restrict_tables": restrict_tables}
     if geom_appended:
         exec_kwargs["row_limit"] = _OVERLAY_ROW_BUDGET
-    result = await chat_service.validate_and_execute(sql, session, user, **exec_kwargs)
+    try:
+        result = await chat_service.validate_and_execute(
+            sql, session, user, **exec_kwargs
+        )
+    except SandboxError:
+        # fix(#556 review P2): the appended geom_4326 may not exist — a
+        # SRID-less ingest keeps geometry_type but exposes only native `geom`
+        # (see ensure_geom_4326_gist_index docs) — or the append otherwise
+        # broke a query the model wrote validly. Fall back to the original SQL
+        # so attribute rows still return; the overlay is simply dropped. If the
+        # original also fails, its error propagates (no masking).
+        if not geom_appended:
+            raise
+        logger.info("query_data.geometry_append_fallback")
+        geom_appended = False
+        sql = original_sql
+        result = await chat_service.validate_and_execute(
+            sql, session, user, restrict_tables=restrict_tables
+        )
 
     # fix(#556 review P2): the transfer cap above bounds the sandbox row_count to
     # the render budget, but show_query_result.row_count is the documented TOTAL

--- a/backend/app/processing/ai/chat_geojson.py
+++ b/backend/app/processing/ai/chat_geojson.py
@@ -45,23 +45,22 @@ def _func_name(fn: exp.Func) -> str:
 
 
 def _selects_geometry(item: exp.Expression) -> bool:
-    """True when a select item already yields a geometry-valued column."""
+    """True when a select item already yields a geometry-valued column.
+
+    Structural, never name-based (#556 review P2): a scalar aliased to a
+    geometry-looking name — ``md5(name) AS geometry``, ``ST_X(geom_4326) AS
+    st_x`` — must NOT count as selected geometry. If it did, the append is
+    skipped and the strict value parser then finds no geometry to overlay,
+    reintroducing the missing-map regression. Only the underlying expression
+    (an aliased ``geom_4326``, or a geometry-returning function) decides;
+    Cast/Paren wrappers are unwrapped first (``ST_Buffer(...)::geometry AS
+    buffer`` genuinely is geometry and correctly suppresses the append).
+    """
     if isinstance(item, exp.Alias):
-        name = item.alias.lower()
-        if name in _GEOM_NAMES or name.startswith("st_"):
-            return True
-        # fix(#556 review P2): an aliased geometry expression — geom_4326 AS
-        # location, ST_Buffer(...)::geometry AS buffer — yields geometry the
-        # value-based detection in _detect_geom_column will find; appending
-        # the source geom_4326 would overlay the wrong shapes.
         inner = item.this
         while isinstance(inner, (exp.Cast, exp.Paren)):
             inner = inner.this
-        if isinstance(inner, exp.Column):
-            return inner.name.lower() in _GEOM_NAMES
-        if isinstance(inner, exp.Func):
-            return _func_name(inner) in _GEOM_RETURNING_FUNCS
-        return False
+        item = inner
     if isinstance(item, exp.Column):
         return item.name.lower() in _GEOM_NAMES
     if isinstance(item, exp.Func):

--- a/backend/app/processing/ai/chat_geojson.py
+++ b/backend/app/processing/ai/chat_geojson.py
@@ -10,10 +10,114 @@ from decimal import Decimal
 from uuid import UUID
 
 import shapely
+import sqlglot
 from shapely.geometry import shape as shapely_shape
+from sqlglot import exp
 
 _GEOM_NAMES = {"geom_4326", "geom", "geometry", "the_geom", "wkb_geometry"}
 _HEX_RE = re.compile(r"^[0-9a-fA-F]{10,}$")
+
+# Anonymous-func aggregates the isinstance(exp.AggFunc) check misses (sqlglot
+# parses them as exp.Anonymous — see the sandbox validator's allowlist notes).
+# Appending a bare column beside one of these without GROUP BY would make the
+# query invalid, so their presence disables the geometry append.
+_ANON_AGG_NAMES = {"every", "mode", "percentile_cont", "percentile_disc"}
+
+# Unaliased calls to these produce an st_*-named output column that
+# _detect_geom_column already recognizes as geometry — no append needed.
+_GEOM_RETURNING_FUNCS = {
+    "st_asgeojson",
+    "st_buffer",
+    "st_centroid",
+    "st_collect",
+    "st_makepoint",
+    "st_point",
+    "st_setsrid",
+    "st_transform",
+    "st_union",
+}
+
+
+def _selects_geometry(item: exp.Expression) -> bool:
+    """True when a select item already yields a geometry-detectable column."""
+    if isinstance(item, exp.Alias):
+        name = item.alias.lower()
+        return name in _GEOM_NAMES or name.startswith("st_")
+    if isinstance(item, exp.Column):
+        return item.name.lower() in _GEOM_NAMES
+    if isinstance(item, exp.Func):
+        return item.name.lower() in _GEOM_RETURNING_FUNCS
+    return False
+
+
+def ensure_geometry_selected(sql: str, layers) -> str:
+    """fix(#544): deterministically append geom_4326 to row-level selects.
+
+    The SQL model is free to answer a location-shaped question with attribute
+    columns only, which silently drops the map overlay on every chat surface.
+    Rather than a model-dependent prompt rule, rewrite the generated SQL: when
+    it is a plain single-table SELECT from a layer that has geometry and no
+    geometry column in the select list, append the table's geom_4326.
+
+    Conservative by design — any shape where the appended column could change
+    results or break the query (aggregates, GROUP BY, DISTINCT, joins, CTEs,
+    set operations, SELECT *) is returned unchanged.
+    """
+    geom_tables = {layer.dataset_table_name for layer in layers if layer.geometry_type}
+    if not geom_tables:
+        return sql
+    try:
+        stmt = sqlglot.parse_one(sql, dialect="postgres")
+    except Exception:  # broad: unparseable SQL is the sandbox validator's job
+        return sql
+    if not isinstance(stmt, exp.Select):
+        return sql
+    if (
+        stmt.args.get("group")
+        or stmt.args.get("distinct")
+        or stmt.find(exp.With)  # any CTE, top-level or nested — stay out
+        or stmt.args.get("joins")
+    ):
+        return sql
+    # sqlglot renamed the arg key "from" -> "from_" across versions
+    from_clause = stmt.args.get("from") or stmt.args.get("from_")
+    if from_clause is None:
+        return sql
+    table = from_clause.this
+    if (
+        not isinstance(table, exp.Table)
+        or table.db != "data"
+        or table.name not in geom_tables
+    ):
+        return sql
+    for item in stmt.expressions:
+        if item.find(exp.Star):
+            return sql  # SELECT * already includes the geometry column
+        for fn in item.find_all(exp.Func):
+            if isinstance(fn, exp.AggFunc) or fn.name.lower() in _ANON_AGG_NAMES:
+                return sql
+        if _selects_geometry(item):
+            return sql
+    stmt.select(f"{table.alias_or_name}.geom_4326", copy=False)
+    return stmt.sql(dialect="postgres")
+
+
+def strip_geometry_columns(
+    columns: list[str], rows: list[list]
+) -> tuple[list[str], list[list]]:
+    """Drop the geometry column from tabular chat output (fix #544).
+
+    Raw WKB hex is noise in a result table; geometry travels via the geojson
+    payload instead. No-op when no geometry column is detected.
+    """
+    geom_idx = _detect_geom_column(columns, rows[0]) if rows else None
+    if geom_idx is None:
+        return columns, rows
+    kept = [i for i in range(len(columns)) if i != geom_idx]
+    return (
+        [columns[i] for i in kept],
+        [[row[i] if i < len(row) else None for i in kept] for row in rows],
+    )
 
 
 def _is_geom_value(val: object) -> bool:

--- a/backend/app/processing/ai/chat_geojson.py
+++ b/backend/app/processing/ai/chat_geojson.py
@@ -151,7 +151,18 @@ def ensure_geometry_selected(sql: str, layers) -> str:
     ref_ident = alias_node.this if alias_node is not None else table.this
     geom_col = exp.Column(this=exp.to_identifier("geom_4326"), table=ref_ident.copy())
     stmt.select(geom_col, copy=False)
-    return stmt.sql(dialect="postgres")
+    rendered = stmt.sql(dialect="postgres")
+    # fix(#556 review P2): sqlglot's postgres dialect does not faithfully
+    # round-trip every pgvector/PostGIS distance operator — `<=>` (cosine) is
+    # re-serialized as IS NOT DISTINCT FROM, silently turning nearest-neighbor
+    # ranking into boolean equality. Re-rendering only happens on the append
+    # path, so if it dropped any distance operator the original had, sacrifice
+    # the overlay and return the untouched SQL. (`<#>` already fails parse_one
+    # above and never reaches here.)
+    for op in ("<=>", "<->", "<#>"):
+        if sql.count(op) > rendered.count(op):
+            return sql
+    return rendered
 
 
 _GEOJSON_TYPES = {

--- a/backend/app/processing/ai/chat_geojson.py
+++ b/backend/app/processing/ai/chat_geojson.py
@@ -38,15 +38,34 @@ _GEOM_RETURNING_FUNCS = {
 }
 
 
+def _func_name(fn: exp.Func) -> str:
+    if isinstance(fn, exp.Anonymous):
+        return fn.name.lower()
+    return fn.sql_name().lower() if hasattr(fn, "sql_name") else ""
+
+
 def _selects_geometry(item: exp.Expression) -> bool:
-    """True when a select item already yields a geometry-detectable column."""
+    """True when a select item already yields a geometry-valued column."""
     if isinstance(item, exp.Alias):
         name = item.alias.lower()
-        return name in _GEOM_NAMES or name.startswith("st_")
+        if name in _GEOM_NAMES or name.startswith("st_"):
+            return True
+        # fix(#556 review P2): an aliased geometry expression — geom_4326 AS
+        # location, ST_Buffer(...)::geometry AS buffer — yields geometry the
+        # value-based detection in _detect_geom_column will find; appending
+        # the source geom_4326 would overlay the wrong shapes.
+        inner = item.this
+        while isinstance(inner, exp.Cast):
+            inner = inner.this
+        if isinstance(inner, exp.Column):
+            return inner.name.lower() in _GEOM_NAMES
+        if isinstance(inner, exp.Func):
+            return _func_name(inner) in _GEOM_RETURNING_FUNCS
+        return False
     if isinstance(item, exp.Column):
         return item.name.lower() in _GEOM_NAMES
     if isinstance(item, exp.Func):
-        return item.name.lower() in _GEOM_RETURNING_FUNCS
+        return _func_name(item) in _GEOM_RETURNING_FUNCS
     return False
 
 
@@ -132,23 +151,32 @@ def _is_geometry_cell(val: object) -> bool:
     return False
 
 
+def _first_non_null(rows: list[list], i: int) -> object:
+    """First non-null value in column i (fix #556 review P2: probing only
+    rows[0] made a NULL leading geometry break detection and stripping)."""
+    for row in rows:
+        val = row[i] if i < len(row) else None
+        if val is not None:
+            return val
+    return None
+
+
 def strip_geometry_columns(
     columns: list[str], rows: list[list]
 ) -> tuple[list[str], list[list]]:
     """Drop geometry-valued columns from tabular chat output (fix #544).
 
     Raw WKB hex / GeoJSON strings are noise in a result table; geometry
-    travels via the geojson payload instead. Value-based (first row), not
-    name-based: the model may alias geometry to anything (live smoke found
+    travels via the geojson payload instead. Value-based, not name-based:
+    the model may alias geometry to anything (live smoke found
     ``ST_AsGeoJSON(geom_4326) AS location`` surviving a name-only strip).
     """
     if not rows:
         return columns, rows
-    first = rows[0]
     kept = [
         i
         for i in range(len(columns))
-        if not _is_geometry_cell(first[i] if i < len(first) else None)
+        if not _is_geometry_cell(_first_non_null(rows, i))
     ]
     if len(kept) == len(columns):
         return columns, rows
@@ -171,13 +199,22 @@ def _is_geom_value(val: object) -> bool:
     return False
 
 
-def _detect_geom_column(columns: list[str], first_row: list) -> int | None:
-    """Find the index of a geometry column by name + value check."""
+def _detect_geom_column(columns: list[str], rows: list[list]) -> int | None:
+    """Find the index of a geometry column.
+
+    Geometry-named columns are preferred; otherwise fall back to any column
+    whose value looks like geometry (fix #556 review P2: aliased computed
+    geometry such as ``ST_Buffer(...) AS buffer``). Values are probed at the
+    first non-null row, not row 0, so a NULL leading geometry still detects.
+    """
     for i, col in enumerate(columns):
         name = col.lower()
         if name in _GEOM_NAMES or name.startswith("st_"):
-            if i < len(first_row) and _is_geom_value(first_row[i]):
+            if _is_geom_value(_first_non_null(rows, i)):
                 return i
+    for i in range(len(columns)):
+        if _is_geometry_cell(_first_non_null(rows, i)):
+            return i
     return None
 
 
@@ -197,7 +234,7 @@ def _extract_geojson(
     if not rows:
         return None
 
-    geom_idx = _detect_geom_column(columns, rows[0])
+    geom_idx = _detect_geom_column(columns, rows)
     if geom_idx is None:
         return None
 

--- a/backend/app/processing/ai/chat_geojson.py
+++ b/backend/app/processing/ai/chat_geojson.py
@@ -132,13 +132,15 @@ _GEOJSON_TYPES = {
 }
 
 
-def _is_geometry_cell(val: object) -> bool:
-    """Strict value-based geometry check for detection fallback + stripping.
+def _is_geom_value(val: object) -> bool:
+    """Strict, parse-verified geometry check.
 
-    Unlike the name-gated _is_geom_value, candidates here must actually
-    parse: a hex-like attribute (md5(name) AS id) must not shadow the real
-    geometry column, and a jsonb attribute that merely contains a "type"
-    key must not be misclassified (#556 review P2s).
+    A candidate must actually parse — a hex-like attribute (``md5(name)``)
+    or a jsonb attribute that merely contains a ``"type"`` key is NOT a
+    geometry, and must not shadow the real geometry column (#556 review).
+    Used for both name-preferred detection and value-based stripping, so a
+    geometry-*named* column holding a non-WKB hash falls through to the
+    real column instead of being accepted and failing extraction later.
     """
     if not isinstance(val, str):
         return False
@@ -180,9 +182,7 @@ def strip_geometry_columns(
     if not rows:
         return columns, rows
     kept = [
-        i
-        for i in range(len(columns))
-        if not _is_geometry_cell(_first_non_null(rows, i))
+        i for i in range(len(columns)) if not _is_geom_value(_first_non_null(rows, i))
     ]
     if len(kept) == len(columns):
         return columns, rows
@@ -192,26 +192,15 @@ def strip_geometry_columns(
     )
 
 
-def _is_geom_value(val: object) -> bool:
-    """Check if a value looks like WKB hex or ST_AsGeoJSON output."""
-    if not isinstance(val, str):
-        return False
-    # WKB hex: long even-length hex string
-    if len(val) >= 10 and len(val) % 2 == 0 and _HEX_RE.match(val):
-        return True
-    # ST_AsGeoJSON: JSON string containing geometry type
-    if val.startswith("{") and '"type"' in val:
-        return True
-    return False
-
-
 def _detect_geom_column(columns: list[str], rows: list[list]) -> int | None:
     """Find the index of a geometry column.
 
-    Geometry-named columns are preferred; otherwise fall back to any column
-    whose value looks like geometry (fix #556 review P2: aliased computed
-    geometry such as ``ST_Buffer(...) AS buffer``). Values are probed at the
-    first non-null row, not row 0, so a NULL leading geometry still detects.
+    A geometry-*named* column that actually parses is preferred; otherwise
+    fall back to any column whose value parses as geometry (fix #556 review:
+    aliased computed geometry such as ``ST_Buffer(...) AS buffer``). Both
+    phases use the strict, parse-verified _is_geom_value so a geometry-named
+    hash column cannot shadow the real geometry, and values are probed at the
+    first non-null row (not row 0) so a NULL leading geometry still detects.
     """
     for i, col in enumerate(columns):
         name = col.lower()
@@ -219,7 +208,7 @@ def _detect_geom_column(columns: list[str], rows: list[list]) -> int | None:
             if _is_geom_value(_first_non_null(rows, i)):
                 return i
     for i in range(len(columns)):
-        if _is_geometry_cell(_first_non_null(rows, i)):
+        if _is_geom_value(_first_non_null(rows, i)):
             return i
     return None
 

--- a/backend/app/processing/ai/chat_geojson.py
+++ b/backend/app/processing/ai/chat_geojson.py
@@ -118,7 +118,14 @@ def ensure_geometry_selected(sql: str, layers) -> str:
                 return sql
         if _selects_geometry(item):
             return sql
-    stmt.select(f"{table.alias_or_name}.geom_4326", copy=False)
+    # fix(#556 review P2): build the qualifier from the alias/table AST
+    # identifier (not an f-string) so a quoted alias survives — FROM ... AS "P"
+    # must append "P".geom_4326 (unquoted P folds to lowercase and fails), and
+    # an alias with spaces must not raise a ParseError inside stmt.select().
+    alias_node = table.args.get("alias")
+    ref_ident = alias_node.this if alias_node is not None else table.this
+    geom_col = exp.Column(this=exp.to_identifier("geom_4326"), table=ref_ident.copy())
+    stmt.select(geom_col, copy=False)
     return stmt.sql(dialect="postgres")
 
 

--- a/backend/app/processing/ai/chat_geojson.py
+++ b/backend/app/processing/ai/chat_geojson.py
@@ -17,10 +17,11 @@ from sqlglot import exp
 _GEOM_NAMES = {"geom_4326", "geom", "geometry", "the_geom", "wkb_geometry"}
 _HEX_RE = re.compile(r"^[0-9a-fA-F]{10,}$")
 
-# Anonymous-func aggregates the isinstance(exp.AggFunc) check misses (sqlglot
-# parses them as exp.Anonymous — see the sandbox validator's allowlist notes).
-# Appending a bare column beside one of these without GROUP BY would make the
-# query invalid, so their presence disables the geometry append.
+# Aggregate names checked ONLY on exp.Anonymous nodes (see the guard in
+# ensure_geometry_selected). In current sqlglot only EVERY parses as Anonymous;
+# MODE/PERCENTILE_CONT/PERCENTILE_DISC are exp.AggFunc subclasses already caught
+# by isinstance. The others are retained as a version-drift guard — harmless
+# because the Anonymous gate keeps them from matching a same-named column.
 _ANON_AGG_NAMES = {"every", "mode", "percentile_cont", "percentile_disc"}
 
 # Unaliased calls to these produce an st_*-named output column that
@@ -120,11 +121,19 @@ def ensure_geometry_selected(sql: str, layers) -> str:
         ):
             return sql
         for fn in item.find_all(exp.Func):
-            is_agg = isinstance(fn, exp.AggFunc) or fn.name.lower() in _ANON_AGG_NAMES
-            # fix(#556 review P2): a WINDOWED aggregate — COUNT(*) OVER (),
-            # RANK() OVER (ORDER BY ...) — is row-level (one row per input row,
-            # no GROUP BY), so appending geom_4326 is safe. Only a true,
-            # non-windowed aggregate collapses cardinality and must block it.
+            # fix(#556 review P2): only consult _ANON_AGG_NAMES for exp.Anonymous
+            # nodes. On a named Func, fn.name is arg-derived, not the function
+            # name — CAST(mode AS TEXT) reports name="mode", which would falsely
+            # trip the guard and drop the overlay for any row-level query that
+            # casts a column named mode/every/percentile_*. (Mirrors the
+            # sandbox validator's Anonymous-vs-named name resolution.)
+            is_agg = isinstance(fn, exp.AggFunc) or (
+                isinstance(fn, exp.Anonymous) and fn.name.lower() in _ANON_AGG_NAMES
+            )
+            # A WINDOWED aggregate — COUNT(*) OVER (), RANK() OVER (ORDER BY ...)
+            # — is row-level (one row per input row, no GROUP BY), so appending
+            # geom_4326 is safe. Only a true, non-windowed aggregate collapses
+            # cardinality and must block it.
             if is_agg and fn.find_ancestor(exp.Window) is None:
                 return sql
         if _selects_geometry(item):

--- a/backend/app/processing/ai/chat_geojson.py
+++ b/backend/app/processing/ai/chat_geojson.py
@@ -55,7 +55,7 @@ def _selects_geometry(item: exp.Expression) -> bool:
         # value-based detection in _detect_geom_column will find; appending
         # the source geom_4326 would overlay the wrong shapes.
         inner = item.this
-        while isinstance(inner, exp.Cast):
+        while isinstance(inner, (exp.Cast, exp.Paren)):
             inner = inner.this
         if isinstance(inner, exp.Column):
             return inner.name.lower() in _GEOM_NAMES
@@ -133,20 +133,26 @@ _GEOJSON_TYPES = {
 
 
 def _is_geometry_cell(val: object) -> bool:
-    """Value-based geometry check for column stripping.
+    """Strict value-based geometry check for detection fallback + stripping.
 
-    Like _is_geom_value but the JSON branch requires an actual GeoJSON
-    geometry type, so a jsonb attribute column that merely contains a
-    "type" key is not misclassified.
+    Unlike the name-gated _is_geom_value, candidates here must actually
+    parse: a hex-like attribute (md5(name) AS id) must not shadow the real
+    geometry column, and a jsonb attribute that merely contains a "type"
+    key must not be misclassified (#556 review P2s).
     """
     if not isinstance(val, str):
         return False
-    if len(val) >= 10 and len(val) % 2 == 0 and _HEX_RE.match(val):
-        return True
     if val.startswith("{"):
         try:
-            return json.loads(val).get("type") in _GEOJSON_TYPES
-        except Exception:  # broad: not JSON — then not a geometry cell
+            obj = json.loads(val)
+            return obj.get("type") in _GEOJSON_TYPES and shapely_shape(obj) is not None
+        except Exception:  # broad: not parseable GeoJSON — not a geometry cell
+            return False
+    if len(val) >= 10 and len(val) % 2 == 0 and _HEX_RE.match(val):
+        try:
+            shapely.from_wkb(bytes.fromhex(val))
+            return True
+        except Exception:  # broad: hex but not WKB (e.g. a hash column)
             return False
     return False
 

--- a/backend/app/processing/ai/chat_geojson.py
+++ b/backend/app/processing/ai/chat_geojson.py
@@ -111,10 +111,21 @@ def ensure_geometry_selected(sql: str, layers) -> str:
     ):
         return sql
     for item in stmt.expressions:
-        if item.find(exp.Star):
-            return sql  # SELECT * already includes the geometry column
+        # A bare * or table.* already includes the geometry column. fix(#556
+        # review P2): match only a genuine all-columns star, NOT a functional
+        # star like COUNT(*) — item.find(exp.Star) caught the latter and
+        # suppressed the append for windowed COUNT(*) OVER () queries.
+        if isinstance(item, exp.Star) or (
+            isinstance(item, exp.Column) and isinstance(item.this, exp.Star)
+        ):
+            return sql
         for fn in item.find_all(exp.Func):
-            if isinstance(fn, exp.AggFunc) or fn.name.lower() in _ANON_AGG_NAMES:
+            is_agg = isinstance(fn, exp.AggFunc) or fn.name.lower() in _ANON_AGG_NAMES
+            # fix(#556 review P2): a WINDOWED aggregate — COUNT(*) OVER (),
+            # RANK() OVER (ORDER BY ...) — is row-level (one row per input row,
+            # no GROUP BY), so appending geom_4326 is safe. Only a true,
+            # non-windowed aggregate collapses cardinality and must block it.
+            if is_agg and fn.find_ancestor(exp.Window) is None:
                 return sql
         if _selects_geometry(item):
             return sql

--- a/backend/app/processing/ai/chat_geojson.py
+++ b/backend/app/processing/ai/chat_geojson.py
@@ -102,18 +102,56 @@ def ensure_geometry_selected(sql: str, layers) -> str:
     return stmt.sql(dialect="postgres")
 
 
+_GEOJSON_TYPES = {
+    "Point",
+    "MultiPoint",
+    "LineString",
+    "MultiLineString",
+    "Polygon",
+    "MultiPolygon",
+    "GeometryCollection",
+}
+
+
+def _is_geometry_cell(val: object) -> bool:
+    """Value-based geometry check for column stripping.
+
+    Like _is_geom_value but the JSON branch requires an actual GeoJSON
+    geometry type, so a jsonb attribute column that merely contains a
+    "type" key is not misclassified.
+    """
+    if not isinstance(val, str):
+        return False
+    if len(val) >= 10 and len(val) % 2 == 0 and _HEX_RE.match(val):
+        return True
+    if val.startswith("{"):
+        try:
+            return json.loads(val).get("type") in _GEOJSON_TYPES
+        except Exception:  # broad: not JSON — then not a geometry cell
+            return False
+    return False
+
+
 def strip_geometry_columns(
     columns: list[str], rows: list[list]
 ) -> tuple[list[str], list[list]]:
-    """Drop the geometry column from tabular chat output (fix #544).
+    """Drop geometry-valued columns from tabular chat output (fix #544).
 
-    Raw WKB hex is noise in a result table; geometry travels via the geojson
-    payload instead. No-op when no geometry column is detected.
+    Raw WKB hex / GeoJSON strings are noise in a result table; geometry
+    travels via the geojson payload instead. Value-based (first row), not
+    name-based: the model may alias geometry to anything (live smoke found
+    ``ST_AsGeoJSON(geom_4326) AS location`` surviving a name-only strip).
     """
-    geom_idx = _detect_geom_column(columns, rows[0]) if rows else None
-    if geom_idx is None:
+    if not rows:
         return columns, rows
-    kept = [i for i in range(len(columns)) if i != geom_idx]
+    first = rows[0]
+    kept = [
+        i
+        for i in range(len(columns))
+        if not _is_geometry_cell(first[i] if i < len(first) else None)
+    ]
+    if len(kept) == len(columns):
+        return columns, rows
     return (
         [columns[i] for i in kept],
         [[row[i] if i < len(row) else None for i in kept] for row in rows],

--- a/backend/app/processing/ai/chat_geojson.py
+++ b/backend/app/processing/ai/chat_geojson.py
@@ -52,15 +52,17 @@ def _selects_geometry(item: exp.Expression) -> bool:
     st_x`` — must NOT count as selected geometry. If it did, the append is
     skipped and the strict value parser then finds no geometry to overlay,
     reintroducing the missing-map regression. Only the underlying expression
-    (an aliased ``geom_4326``, or a geometry-returning function) decides;
-    Cast/Paren wrappers are unwrapped first (``ST_Buffer(...)::geometry AS
-    buffer`` genuinely is geometry and correctly suppresses the append).
+    (a ``geom_4326`` column, or a geometry-returning function) decides.
+
+    Alias and Cast/Paren wrappers are unwrapped first, and — #556 review —
+    the unwrap runs for the UNALIASED case too, so a bare
+    ``ST_Buffer(...)::geometry`` (no ``AS``) correctly suppresses the append
+    instead of getting a redundant second geometry column bolted on.
     """
     if isinstance(item, exp.Alias):
-        inner = item.this
-        while isinstance(inner, (exp.Cast, exp.Paren)):
-            inner = inner.this
-        item = inner
+        item = item.this
+    while isinstance(item, (exp.Cast, exp.Paren)):
+        item = item.this
     if isinstance(item, exp.Column):
         return item.name.lower() in _GEOM_NAMES
     if isinstance(item, exp.Func):

--- a/backend/app/processing/ai/chat_geojson.py
+++ b/backend/app/processing/ai/chat_geojson.py
@@ -98,6 +98,11 @@ def ensure_geometry_selected(sql: str, layers) -> str:
         or stmt.args.get("distinct")
         or stmt.find(exp.With)  # any CTE, top-level or nested — stay out
         or stmt.args.get("joins")
+        # fix(#556 review P2): HAVING without GROUP BY is still an aggregate
+        # (implicit single group), and its COUNT(*) lives outside the SELECT
+        # list where the per-item aggregate check can't see it. args.get scopes
+        # to THIS query, so a subquery's HAVING doesn't suppress the append.
+        or stmt.args.get("having")
     ):
         return sql
     # sqlglot renamed the arg key "from" -> "from_" across versions

--- a/backend/app/processing/ai/chat_service.py
+++ b/backend/app/processing/ai/chat_service.py
@@ -68,6 +68,8 @@ from app.processing.ai.chat_geojson import (
     _extract_geojson,
     _is_geom_value,
     _safe_value,
+    ensure_geometry_selected,
+    strip_geometry_columns,
 )
 from app.processing.ai.chat_styles import (
     _build_categorical_style,
@@ -122,6 +124,8 @@ __all__ = [
     "_detect_geom_column",
     "_safe_value",
     "_extract_geojson",
+    "ensure_geometry_selected",
+    "strip_geometry_columns",
     # Test patch targets (kept module-level so unittest.mock.patch resolves
     # ``app.processing.ai.chat_service.{generate_sql,validate_and_execute}``)
     "generate_sql",

--- a/backend/tests/evals/test_sql_generation_evals.py
+++ b/backend/tests/evals/test_sql_generation_evals.py
@@ -205,6 +205,7 @@ async def eval_dataset(test_db_session):
     yield {
         "admin": admin,
         "schema_context": schema_context,
+        "layers": [parks_layer, stations_layer],
         "truth_acres": float(truth_acres),
         "truth_miles": float(truth_miles),
     }
@@ -352,3 +353,33 @@ async def test_spatial_containment(client, test_db_session, eval_dataset):
     assert found == {_STATION_IN_LARGEST}, (
         f"expected {{{_STATION_IN_LARGEST!r}}}, got {found}\nSQL: {sql}"
     )
+
+
+async def test_locations_reach_geojson_deterministically(
+    client, test_db_session, eval_dataset
+):
+    """fix(#544): a 'names and locations' question must produce mappable
+    geometry after the deterministic geometry-append pass, no matter which
+    columns the model chose (attribute-only selects previously dropped the
+    map overlay on every chat surface)."""
+    from app.processing.ai.chat_geojson import (
+        _extract_geojson,
+        ensure_geometry_selected,
+    )
+
+    sql = await generate_sql(
+        test_db_session,
+        "List the name and location of every station.",
+        eval_dataset["schema_context"],
+    )
+    sql = ensure_geometry_selected(sql, eval_dataset["layers"])
+    result = await validate_and_execute(sql, test_db_session, eval_dataset["admin"])
+    geo = _extract_geojson(result.columns, result.rows[:50])
+    assert geo is not None, (
+        f"no extractable geometry in result columns {result.columns}\nSQL: {sql}"
+    )
+    fc, bbox = geo
+    assert len(fc["features"]) == len(_STATIONS), (
+        f"expected {len(_STATIONS)} features, got {len(fc['features'])}\nSQL: {sql}"
+    )
+    assert len(bbox) == 4

--- a/backend/tests/test_ephemeral_geojson.py
+++ b/backend/tests/test_ephemeral_geojson.py
@@ -266,6 +266,22 @@ class TestEnsureGeometrySelected:
         )
         assert "p.geom_4326" in sql
 
+    def test_preserves_quoted_uppercase_alias(self):
+        # fix(#556 review P2): a quoted alias must survive the append — unquoted
+        # "P" folds to lowercase p in Postgres and fails at execution.
+        sql = ensure_geometry_selected(
+            'SELECT "P".name FROM data.parks AS "P"', [_layer()]
+        )
+        assert '"P".geom_4326' in sql
+
+    def test_preserves_alias_with_spaces(self):
+        # fix(#556 review P2): a spaced alias must not raise a ParseError inside
+        # stmt.select() (the old f-string path did).
+        sql = ensure_geometry_selected(
+            'SELECT t.name FROM data.parks AS "my tbl"', [_layer()]
+        )
+        assert '"my tbl".geom_4326' in sql
+
     def test_skips_when_geometry_already_selected(self):
         sql = "SELECT name, geom_4326 FROM data.parks"
         assert ensure_geometry_selected(sql, [_layer()]) == sql

--- a/backend/tests/test_ephemeral_geojson.py
+++ b/backend/tests/test_ephemeral_geojson.py
@@ -290,6 +290,30 @@ class TestEnsureGeometrySelected:
         sql = "SELECT name, ST_ASGEOJSON(geom_4326) FROM data.parks"
         assert ensure_geometry_selected(sql, [_layer()]) == sql
 
+    def test_preserves_pgvector_cosine_operator(self):
+        # fix(#556 review P2): sqlglot rewrites `<=>` (cosine) to
+        # IS NOT DISTINCT FROM on re-render — appending must not corrupt a
+        # nearest-neighbor query. The append is skipped, original preserved.
+        sql = (
+            "SELECT name, embedding <=> '[1,2,3]'::vector AS dist "
+            "FROM data.parks ORDER BY dist LIMIT 10"
+        )
+        result = ensure_geometry_selected(sql, [_layer()])
+        assert result == sql
+        assert "<=>" in result
+        assert "IS NOT DISTINCT FROM" not in result.upper()
+
+    def test_appends_for_l2_knn_operator(self):
+        # `<->` round-trips faithfully, so a spatial-KNN query still gains its
+        # overlay (geom_4326 appended) while the operator is preserved.
+        sql = (
+            "SELECT name FROM data.parks "
+            "ORDER BY geom_4326 <-> ST_SETSRID(ST_MAKEPOINT(0, 0), 4326) LIMIT 5"
+        )
+        result = ensure_geometry_selected(sql, [_layer()])
+        assert "parks.geom_4326" in result
+        assert "<->" in result
+
     def test_appends_when_st_x_only(self):
         # ST_X yields a float, not a detectable geometry — still append.
         sql = ensure_geometry_selected(

--- a/backend/tests/test_ephemeral_geojson.py
+++ b/backend/tests/test_ephemeral_geojson.py
@@ -284,6 +284,25 @@ class TestEnsureGeometrySelected:
         assert sql.count("geom_4326") == 3
         assert "parks.geom_4326" in sql
 
+    def test_appends_when_scalar_aliased_to_geometry_name(self):
+        # fix(#556 review P2): md5(name) AS geometry is a scalar aliased to a
+        # geometry-looking name — the append must still fire (the alias name
+        # alone must not count as selected geometry).
+        sql = ensure_geometry_selected(
+            "SELECT md5(name) AS geometry FROM data.parks", [_layer()]
+        )
+        assert "parks.geom_4326" in sql
+
+    def test_appends_when_st_x_aliased_to_st_name(self):
+        # fix(#556 review P2): ST_X(...) AS st_x — scalar under an st_-prefixed
+        # alias; append must fire.
+        sql = ensure_geometry_selected(
+            "SELECT name, ST_X(geom_4326) AS st_x FROM data.parks", [_layer()]
+        )
+        assert "parks.geom_4326" in sql
+        # the scalar st_x is untouched; only the source geom_4326 is added
+        assert sql.count("geom_4326") == 2
+
     def test_skips_select_star(self):
         sql = "SELECT * FROM data.parks"
         assert ensure_geometry_selected(sql, [_layer()]) == sql

--- a/backend/tests/test_ephemeral_geojson.py
+++ b/backend/tests/test_ephemeral_geojson.py
@@ -366,6 +366,22 @@ class TestEnsureGeometrySelected:
         )
         assert ensure_geometry_selected(sql, [_layer()]) == sql
 
+    def test_skips_unaliased_cast_wrapped_geometry(self):
+        # fix(#556 review P2): an UNALIASED cast-wrapped geometry expression
+        # already selects geometry — the append must be suppressed even though
+        # there's no AS clause. Previously the Cast/Paren unwrap only ran
+        # inside exp.Alias, so geom_4326 got appended beside the buffer.
+        sql = "SELECT ST_BUFFER(geom_4326::geography, 1000)::geometry FROM data.parks"
+        assert ensure_geometry_selected(sql, [_layer()]) == sql
+
+    def test_skips_unaliased_parenthesized_cast_geometry(self):
+        sql = "SELECT (ST_BUFFER(geom_4326::geography, 1000)::geometry) FROM data.parks"
+        assert ensure_geometry_selected(sql, [_layer()]) == sql
+
+    def test_skips_unaliased_cast_of_geom_column(self):
+        sql = "SELECT geom_4326::geometry FROM data.parks"
+        assert ensure_geometry_selected(sql, [_layer()]) == sql
+
     def test_skips_parenthesized_aliased_geometry(self):
         # fix(#556 review P2): sqlglot wraps a parenthesized alias body in
         # exp.Paren — unwrap it too, or the source geometry gets appended

--- a/backend/tests/test_ephemeral_geojson.py
+++ b/backend/tests/test_ephemeral_geojson.py
@@ -370,6 +370,23 @@ class TestEnsureGeometrySelected:
         sql = "SELECT DISTINCT category FROM data.parks"
         assert ensure_geometry_selected(sql, [_layer()]) == sql
 
+    def test_skips_having_without_group_by(self):
+        # fix(#556 review P2): HAVING without GROUP BY is an aggregate query
+        # (implicit single group) — appending geom_4326 makes Postgres reject
+        # the non-grouped column. The COUNT lives outside the SELECT list.
+        sql = "SELECT 1 FROM data.parks HAVING COUNT(*) > 0"
+        assert ensure_geometry_selected(sql, [_layer()]) == sql
+
+    def test_appends_despite_subquery_having(self):
+        # A HAVING inside a subquery does not make the outer query an aggregate;
+        # the append must still fire on the row-level outer SELECT.
+        sql = ensure_geometry_selected(
+            "SELECT name FROM data.parks WHERE category IN "
+            "(SELECT category FROM data.parks GROUP BY category HAVING COUNT(*) > 1)",
+            [_layer()],
+        )
+        assert "parks.geom_4326" in sql
+
     def test_skips_joins(self):
         sql = (
             "SELECT p.name FROM data.parks AS p"

--- a/backend/tests/test_ephemeral_geojson.py
+++ b/backend/tests/test_ephemeral_geojson.py
@@ -319,3 +319,22 @@ class TestStripGeometryColumns:
         )
         assert cols == ["name", "pop"]
         assert rows == [["A", None]]
+
+    def test_strips_aliased_geojson_string_column(self):
+        # Live smoke (#544): the model emitted ST_AsGeoJSON(geom_4326) AS
+        # location — a name-based strip missed it and raw GeoJSON strings
+        # rendered in the table. Value-based strip drops both geometry cols.
+        cols, rows = strip_geometry_columns(
+            ["stop_name", "location", "geom_4326"],
+            [["Jay St", POINT_GEOJSON_STR, POINT_WKB_HEX]],
+        )
+        assert cols == ["stop_name"]
+        assert rows == [["Jay St"]]
+
+    def test_json_attribute_with_type_key_kept(self):
+        meta = json.dumps({"type": "station", "zone": 2})
+        cols, rows = strip_geometry_columns(
+            ["name", "meta", "geom_4326"], [["A", meta, POINT_WKB_HEX]]
+        )
+        assert cols == ["name", "meta"]
+        assert rows == [["A", meta]]

--- a/backend/tests/test_ephemeral_geojson.py
+++ b/backend/tests/test_ephemeral_geojson.py
@@ -3,6 +3,7 @@
 import json
 from datetime import datetime, date
 from decimal import Decimal
+from types import SimpleNamespace
 from uuid import UUID
 
 import shapely
@@ -14,6 +15,8 @@ from app.processing.ai.chat_service import (
     _detect_geom_column,
     _safe_value,
     _extract_geojson,
+    ensure_geometry_selected,
+    strip_geometry_columns,
 )
 
 
@@ -194,3 +197,125 @@ class TestExtractGeojson:
         cols = ["id", "geom"]
         rows = []
         assert _extract_geojson(cols, rows) is None
+
+
+# ---------------------------------------------------------------------------
+# fix(#544): deterministic geometry append + WKB stripping
+# ---------------------------------------------------------------------------
+
+
+def _layer(table="parks", geometry_type="Polygon"):
+    return SimpleNamespace(dataset_table_name=table, geometry_type=geometry_type)
+
+
+class TestEnsureGeometrySelected:
+    def test_appends_geometry_to_plain_select(self):
+        sql = ensure_geometry_selected("SELECT name FROM data.parks", [_layer()])
+        assert sql == "SELECT name, parks.geom_4326 FROM data.parks"
+
+    def test_uses_table_alias(self):
+        sql = ensure_geometry_selected(
+            "SELECT p.name FROM data.parks AS p WHERE p.name ILIKE '%river%'",
+            [_layer()],
+        )
+        assert "p.geom_4326" in sql
+
+    def test_skips_when_geometry_already_selected(self):
+        sql = "SELECT name, geom_4326 FROM data.parks"
+        assert ensure_geometry_selected(sql, [_layer()]) == sql
+
+    def test_skips_unaliased_st_asgeojson(self):
+        sql = "SELECT name, ST_ASGEOJSON(geom_4326) FROM data.parks"
+        assert ensure_geometry_selected(sql, [_layer()]) == sql
+
+    def test_appends_when_st_x_only(self):
+        # ST_X yields a float, not a detectable geometry — still append.
+        sql = ensure_geometry_selected(
+            "SELECT name, ST_X(geom_4326) AS longitude, ST_Y(geom_4326) AS latitude"
+            " FROM data.parks",
+            [_layer()],
+        )
+        assert sql.count("geom_4326") == 3
+        assert "parks.geom_4326" in sql
+
+    def test_skips_select_star(self):
+        sql = "SELECT * FROM data.parks"
+        assert ensure_geometry_selected(sql, [_layer()]) == sql
+
+    def test_skips_aggregates(self):
+        sql = "SELECT COUNT(*) FROM data.parks"
+        assert ensure_geometry_selected(sql, [_layer()]) == sql
+
+    def test_skips_anonymous_aggregate(self):
+        sql = "SELECT EVERY(name IS NOT NULL) FROM data.parks"
+        assert ensure_geometry_selected(sql, [_layer()]) == sql
+
+    def test_skips_group_by(self):
+        sql = "SELECT category, COUNT(*) AS n FROM data.parks GROUP BY category"
+        assert ensure_geometry_selected(sql, [_layer()]) == sql
+
+    def test_skips_distinct(self):
+        sql = "SELECT DISTINCT category FROM data.parks"
+        assert ensure_geometry_selected(sql, [_layer()]) == sql
+
+    def test_skips_joins(self):
+        sql = (
+            "SELECT p.name FROM data.parks AS p"
+            " JOIN data.cities AS c ON ST_INTERSECTS(p.geom_4326, c.geom_4326)"
+        )
+        assert ensure_geometry_selected(sql, [_layer(), _layer(table="cities")]) == sql
+
+    def test_skips_cte(self):
+        sql = "WITH big AS (SELECT name FROM data.parks) SELECT name FROM big"
+        assert ensure_geometry_selected(sql, [_layer()]) == sql
+
+    def test_skips_union(self):
+        sql = "SELECT name FROM data.parks UNION SELECT name FROM data.cities"
+        assert ensure_geometry_selected(sql, [_layer(), _layer(table="cities")]) == sql
+
+    def test_skips_non_geometry_layer(self):
+        sql = "SELECT name FROM data.attendance"
+        layers = [_layer(table="attendance", geometry_type=None)]
+        assert ensure_geometry_selected(sql, layers) == sql
+
+    def test_skips_table_not_in_layers(self):
+        sql = "SELECT name FROM data.other_table"
+        assert ensure_geometry_selected(sql, [_layer()]) == sql
+
+    def test_unparseable_sql_unchanged(self):
+        sql = "SELECT FROM WHERE ((("
+        assert ensure_geometry_selected(sql, [_layer()]) == sql
+
+    def test_row_level_spatial_expr_still_appends(self):
+        # ST_Distance is row-level (not an aggregate) — append proceeds.
+        sql = ensure_geometry_selected(
+            "SELECT name, ST_DISTANCE(geom_4326, geom_4326) AS d FROM data.parks",
+            [_layer()],
+        )
+        assert "parks.geom_4326" in sql
+
+
+class TestStripGeometryColumns:
+    def test_strips_wkb_column(self):
+        cols, rows = strip_geometry_columns(
+            ["name", "geom_4326"], [["A", POINT_WKB_HEX], ["B", POINT2_WKB_HEX]]
+        )
+        assert cols == ["name"]
+        assert rows == [["A"], ["B"]]
+
+    def test_no_geom_column_unchanged(self):
+        cols, rows = strip_geometry_columns(["name", "pop"], [["A", 1]])
+        assert cols == ["name", "pop"]
+        assert rows == [["A", 1]]
+
+    def test_empty_rows_unchanged(self):
+        cols, rows = strip_geometry_columns(["name", "geom_4326"], [])
+        assert cols == ["name", "geom_4326"]
+        assert rows == []
+
+    def test_short_row_padded_with_none(self):
+        cols, rows = strip_geometry_columns(
+            ["geom_4326", "name", "pop"], [[POINT_WKB_HEX, "A"]]
+        )
+        assert cols == ["name", "pop"]
+        assert rows == [["A", None]]

--- a/backend/tests/test_ephemeral_geojson.py
+++ b/backend/tests/test_ephemeral_geojson.py
@@ -57,34 +57,53 @@ class TestDetectGeomColumn:
     def test_geom_column_by_name(self):
         cols = ["id", "name", "geom_4326"]
         row = [1, "test", POINT_WKB_HEX]
-        assert _detect_geom_column(cols, row) == 2
+        assert _detect_geom_column(cols, [row]) == 2
 
     def test_geometry_column_name(self):
         cols = ["id", "geometry"]
         row = [1, POINT_WKB_HEX]
-        assert _detect_geom_column(cols, row) == 1
+        assert _detect_geom_column(cols, [row]) == 1
 
     def test_the_geom_column_name(self):
         cols = ["the_geom", "name"]
         row = [POINT_WKB_HEX, "test"]
-        assert _detect_geom_column(cols, row) == 0
+        assert _detect_geom_column(cols, [row]) == 0
 
     def test_st_prefix_column(self):
         cols = ["id", "st_asgeojson"]
         row = [1, POINT_GEOJSON_STR]
-        assert _detect_geom_column(cols, row) == 1
+        assert _detect_geom_column(cols, [row]) == 1
 
     def test_no_geom_column(self):
         cols = ["id", "name", "population"]
         row = [1, "test", 1000]
-        assert _detect_geom_column(cols, row) is None
+        assert _detect_geom_column(cols, [row]) is None
 
     def test_geom_name_but_null_value(self):
         """Column name matches but value is null -- still detected (None values are skipped later)."""
         cols = ["id", "geom"]
         row = [1, None]
         # With null value, _is_geom_value returns False, so no detection
-        assert _detect_geom_column(cols, row) is None
+        assert _detect_geom_column(cols, [row]) is None
+
+    def test_null_leading_row_probes_later_rows(self):
+        # fix(#556 review P2): a NULL geometry in row 0 must not break
+        # detection when later rows are mappable.
+        cols = ["id", "geom_4326"]
+        rows = [[1, None], [2, POINT_WKB_HEX]]
+        assert _detect_geom_column(cols, rows) == 1
+
+    def test_value_fallback_detects_aliased_geometry(self):
+        # fix(#556 review P2): aliased computed geometry (ST_Buffer(...) AS
+        # buffer) has no geometry-ish name — detect it by value.
+        cols = ["name", "buffer"]
+        rows = [["A", POINT_WKB_HEX]]
+        assert _detect_geom_column(cols, rows) == 1
+
+    def test_value_fallback_ignores_non_geometry_json(self):
+        cols = ["name", "meta"]
+        rows = [["A", json.dumps({"type": "station", "zone": 2})]]
+        assert _detect_geom_column(cols, rows) is None
 
 
 class TestSafeValue:
@@ -198,6 +217,25 @@ class TestExtractGeojson:
         rows = []
         assert _extract_geojson(cols, rows) is None
 
+    def test_null_leading_geometry_still_extracts(self):
+        # fix(#556 review P2): first row NULL, later rows mappable.
+        cols = ["id", "geom_4326"]
+        rows = [[1, None], [2, POINT_WKB_HEX]]
+        result = _extract_geojson(cols, rows)
+        assert result is not None
+        fc, _ = result
+        assert len(fc["features"]) == 1
+
+    def test_aliased_computed_geometry_extracts(self):
+        # fix(#556 review P2): ST_Buffer(...) AS buffer — the overlay must
+        # come from the computed geometry, found by value.
+        cols = ["name", "buffer"]
+        rows = [["A", POINT_WKB_HEX]]
+        result = _extract_geojson(cols, rows)
+        assert result is not None
+        fc, _ = result
+        assert fc["features"][0]["properties"] == {"name": "A"}
+
 
 # ---------------------------------------------------------------------------
 # fix(#544): deterministic geometry append + WKB stripping
@@ -286,6 +324,21 @@ class TestEnsureGeometrySelected:
         sql = "SELECT FROM WHERE ((("
         assert ensure_geometry_selected(sql, [_layer()]) == sql
 
+    def test_skips_aliased_geometry_column(self):
+        # fix(#556 review P2): geom_4326 AS location already yields geometry
+        # (found by value) — appending the source column would duplicate it.
+        sql = "SELECT name, geom_4326 AS location FROM data.parks"
+        assert ensure_geometry_selected(sql, [_layer()]) == sql
+
+    def test_skips_aliased_computed_geometry(self):
+        # fix(#556 review P2): the overlay must show the buffers, not the
+        # source geometry — don't append geom_4326 beside them.
+        sql = (
+            "SELECT name, ST_BUFFER(geom_4326::geography, 1000)::geometry"
+            " AS buffer FROM data.parks"
+        )
+        assert ensure_geometry_selected(sql, [_layer()]) == sql
+
     def test_row_level_spatial_expr_still_appends(self):
         # ST_Distance is row-level (not an aggregate) — append proceeds.
         sql = ensure_geometry_selected(
@@ -338,3 +391,12 @@ class TestStripGeometryColumns:
         )
         assert cols == ["name", "meta"]
         assert rows == [["A", meta]]
+
+    def test_null_leading_geometry_still_stripped(self):
+        # fix(#556 review P2): NULL geometry in row 0 must not leak later
+        # rows' WKB into the table.
+        cols, rows = strip_geometry_columns(
+            ["name", "geom_4326"], [["A", None], ["B", POINT_WKB_HEX]]
+        )
+        assert cols == ["name"]
+        assert rows == [["A"], ["B"]]

--- a/backend/tests/test_ephemeral_geojson.py
+++ b/backend/tests/test_ephemeral_geojson.py
@@ -105,6 +105,14 @@ class TestDetectGeomColumn:
         rows = [["A", json.dumps({"type": "station", "zone": 2})]]
         assert _detect_geom_column(cols, rows) is None
 
+    def test_value_fallback_skips_hex_hash_column(self):
+        # fix(#556 review P2): md5(name) AS id is a long even-length hex
+        # string but not WKB — it must not shadow the real geometry column.
+        md5_hex = "9e107d9d372bb6826bd81d3542a419d6"
+        cols = ["id", "buffer"]
+        rows = [[md5_hex, POINT_WKB_HEX]]
+        assert _detect_geom_column(cols, rows) == 1
+
 
 class TestSafeValue:
     def test_str_passthrough(self):
@@ -339,6 +347,16 @@ class TestEnsureGeometrySelected:
         )
         assert ensure_geometry_selected(sql, [_layer()]) == sql
 
+    def test_skips_parenthesized_aliased_geometry(self):
+        # fix(#556 review P2): sqlglot wraps a parenthesized alias body in
+        # exp.Paren — unwrap it too, or the source geometry gets appended
+        # and the overlay shows the wrong shapes.
+        sql = (
+            "SELECT name, (ST_BUFFER(geom_4326::geography, 1000)::geometry)"
+            " AS buffer FROM data.parks"
+        )
+        assert ensure_geometry_selected(sql, [_layer()]) == sql
+
     def test_row_level_spatial_expr_still_appends(self):
         # ST_Distance is row-level (not an aggregate) — append proceeds.
         sql = ensure_geometry_selected(
@@ -400,3 +418,13 @@ class TestStripGeometryColumns:
         )
         assert cols == ["name"]
         assert rows == [["A"], ["B"]]
+
+    def test_hex_hash_column_kept(self):
+        # fix(#556 review P2): hex-like attributes (md5 hashes) are not
+        # geometry and must stay in the table.
+        md5_hex = "9e107d9d372bb6826bd81d3542a419d6"
+        cols, rows = strip_geometry_columns(
+            ["id", "geom_4326"], [[md5_hex, POINT_WKB_HEX]]
+        )
+        assert cols == ["id"]
+        assert rows == [[md5_hex]]

--- a/backend/tests/test_ephemeral_geojson.py
+++ b/backend/tests/test_ephemeral_geojson.py
@@ -331,6 +331,21 @@ class TestEnsureGeometrySelected:
         sql = "SELECT EVERY(name IS NOT NULL) FROM data.parks"
         assert ensure_geometry_selected(sql, [_layer()]) == sql
 
+    def test_appends_for_window_count(self):
+        # fix(#556 review P2): COUNT(*) OVER () is a row-level window function
+        # (no cardinality collapse, no GROUP BY) — the append must still fire.
+        sql = ensure_geometry_selected(
+            "SELECT name, COUNT(*) OVER () AS total FROM data.parks", [_layer()]
+        )
+        assert "parks.geom_4326" in sql
+
+    def test_appends_for_window_rank(self):
+        sql = ensure_geometry_selected(
+            "SELECT name, RANK() OVER (ORDER BY name DESC) AS r FROM data.parks",
+            [_layer()],
+        )
+        assert "parks.geom_4326" in sql
+
     def test_skips_group_by(self):
         sql = "SELECT category, COUNT(*) AS n FROM data.parks GROUP BY category"
         assert ensure_geometry_selected(sql, [_layer()]) == sql

--- a/backend/tests/test_ephemeral_geojson.py
+++ b/backend/tests/test_ephemeral_geojson.py
@@ -331,6 +331,22 @@ class TestEnsureGeometrySelected:
         sql = "SELECT EVERY(name IS NOT NULL) FROM data.parks"
         assert ensure_geometry_selected(sql, [_layer()]) == sql
 
+    def test_skips_ordered_set_aggregate(self):
+        # MODE()/PERCENTILE_* parse as exp.AggFunc subclasses — still blocked
+        # (they collapse to one row), independent of the _ANON_AGG_NAMES gate.
+        sql = "SELECT MODE() WITHIN GROUP (ORDER BY category) FROM data.parks"
+        assert ensure_geometry_selected(sql, [_layer()]) == sql
+
+    def test_appends_when_casting_column_named_like_aggregate(self):
+        # fix(#556 review P2): CAST(mode AS TEXT) is exp.Cast with name="mode";
+        # the _ANON_AGG_NAMES check must not fire on named funcs, or a row-level
+        # query casting a column named `mode` loses its overlay.
+        sql = ensure_geometry_selected(
+            "SELECT name, CAST(mode AS TEXT) AS mode_text FROM data.parks",
+            [_layer()],
+        )
+        assert "parks.geom_4326" in sql
+
     def test_appends_for_window_count(self):
         # fix(#556 review P2): COUNT(*) OVER () is a row-level window function
         # (no cardinality collapse, no GROUP BY) — the append must still fire.

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -890,7 +890,10 @@ def test_decomposed_service_modules_stay_within_size_budgets() -> None:
         # fix(#394) CH-02: +~35 lines — set_label column validation against the
         # target layer schema (error feedback to the model), the CSS-colorish
         # sanitizer, and the collector error gate. Cap 350 → 400 (~19 headroom).
-        "backend/app/processing/ai/chat_actions.py": 400,
+        # fix(#544): +~14 lines — deterministic geom_4326 append before
+        # execution and WKB-column strip after geojson extraction in
+        # _handle_query_data. Cap 400 → 425 (~11 headroom).
+        "backend/app/processing/ai/chat_actions.py": 425,
     }
 
     files_to_check = list(facade_line_budgets)

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -893,7 +893,10 @@ def test_decomposed_service_modules_stay_within_size_budgets() -> None:
         # fix(#544): +~14 lines — deterministic geom_4326 append before
         # execution and WKB-column strip after geojson extraction in
         # _handle_query_data. Cap 400 → 425 (~11 headroom).
-        "backend/app/processing/ai/chat_actions.py": 425,
+        # fix(#556 review P2): +~8 lines — overlay-row-budget fetch cap when
+        # geometry is appended (constant + conditional row_limit). Cap
+        # 425 → 445 (~12 headroom).
+        "backend/app/processing/ai/chat_actions.py": 445,
     }
 
     files_to_check = list(facade_line_budgets)

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -896,7 +896,10 @@ def test_decomposed_service_modules_stay_within_size_budgets() -> None:
         # fix(#556 review P2): +~8 lines — overlay-row-budget fetch cap when
         # geometry is appended (constant + conditional row_limit). Cap
         # 425 → 445 (~12 headroom).
-        "backend/app/processing/ai/chat_actions.py": 445,
+        # fix(#556 review P2, round 7): +~15 lines — geometry-free COUNT
+        # recovery so the transfer cap doesn't corrupt the documented total
+        # row_count. Cap 445 → 470 (~18 headroom).
+        "backend/app/processing/ai/chat_actions.py": 470,
     }
 
     files_to_check = list(facade_line_budgets)

--- a/backend/tests/test_sql_engine.py
+++ b/backend/tests/test_sql_engine.py
@@ -231,6 +231,39 @@ class TestQueryDataTool:
         "app.processing.ai.chat_service.validate_and_execute", new_callable=AsyncMock
     )
     @patch("app.processing.ai.chat_service.generate_sql", new_callable=AsyncMock)
+    async def test_geometry_appended_and_stripped_from_table(self, mock_gen, mock_exec):
+        """fix(#544): geom_4326 is appended to the executed SQL when the model
+        omits it, and the raw WKB column is stripped from the tabular payload
+        once the geojson is extracted."""
+        import shapely
+
+        wkb = shapely.to_wkb(shapely.Point(1, 2), hex=True)
+        mock_gen.return_value = "SELECT name FROM data.cities"
+        mock_exec.return_value = SandboxResult(
+            rows=[["Springfield", wkb]],
+            columns=["name", "geom_4326"],
+            row_count=1,
+            truncated=False,
+        )
+        layers = [_make_layer(column_info=[{"name": "name", "type": "text"}])]
+        result = await _handle_query_data(
+            {"question": "List the names and locations of cities"},
+            AsyncMock(),
+            _mock_user(),
+            layers,
+        )
+        executed_sql = mock_exec.call_args.args[0]
+        assert "geom_4326" in executed_sql
+        assert result["geojson"]["features"][0]["geometry"]["type"] == "Point"
+        assert result["bbox"] == [1.0, 2.0, 1.0, 2.0]
+        assert result["columns"] == ["name"]
+        assert result["rows"] == [["Springfield"]]
+
+    @pytest.mark.asyncio
+    @patch(
+        "app.processing.ai.chat_service.validate_and_execute", new_callable=AsyncMock
+    )
+    @patch("app.processing.ai.chat_service.generate_sql", new_callable=AsyncMock)
     async def test_rows_truncated_to_50(self, mock_gen, mock_exec):
         mock_gen.return_value = "SELECT * FROM data.cities"
         mock_exec.return_value = SandboxResult(

--- a/backend/tests/test_sql_engine.py
+++ b/backend/tests/test_sql_engine.py
@@ -254,10 +254,42 @@ class TestQueryDataTool:
         )
         executed_sql = mock_exec.call_args.args[0]
         assert "geom_4326" in executed_sql
+        # fix(#556 review P2): appended-geometry queries cap the fetch to the
+        # overlay render budget so full geometries for discarded rows are not
+        # transferred.
+        assert mock_exec.call_args.kwargs.get("row_limit") == 50
         assert result["geojson"]["features"][0]["geometry"]["type"] == "Point"
         assert result["bbox"] == [1.0, 2.0, 1.0, 2.0]
         assert result["columns"] == ["name"]
         assert result["rows"] == [["Springfield"]]
+
+    @pytest.mark.asyncio
+    @patch(
+        "app.processing.ai.chat_service.validate_and_execute", new_callable=AsyncMock
+    )
+    @patch("app.processing.ai.chat_service.generate_sql", new_callable=AsyncMock)
+    async def test_no_row_limit_cap_when_geometry_not_appended(
+        self, mock_gen, mock_exec
+    ):
+        """fix(#556 review P2): the fetch cap is scoped to the append. A query
+        the model wrote with its own geometry (or SELECT *) keeps the default
+        row limit, preserving the accurate row_count."""
+        import shapely
+
+        wkb = shapely.to_wkb(shapely.Point(1, 2), hex=True)
+        mock_gen.return_value = "SELECT * FROM data.cities"
+        mock_exec.return_value = SandboxResult(
+            rows=[["Springfield", wkb]],
+            columns=["name", "geom_4326"],
+            row_count=1,
+            truncated=False,
+        )
+        layers = [_make_layer(column_info=[{"name": "name", "type": "text"}])]
+        await _handle_query_data(
+            {"question": "everything"}, AsyncMock(), _mock_user(), layers
+        )
+        # SELECT * already carries geometry — nothing appended, no cap passed.
+        assert mock_exec.call_args.kwargs.get("row_limit") is None
 
     @pytest.mark.asyncio
     @patch(

--- a/backend/tests/test_sql_engine.py
+++ b/backend/tests/test_sql_engine.py
@@ -296,6 +296,72 @@ class TestQueryDataTool:
         "app.processing.ai.chat_service.validate_and_execute", new_callable=AsyncMock
     )
     @patch("app.processing.ai.chat_service.generate_sql", new_callable=AsyncMock)
+    async def test_truncated_appended_query_recovers_true_row_count(
+        self, mock_gen, mock_exec
+    ):
+        """fix(#556 review P2): when the geometry-transfer cap truncates the
+        result, row_count is recovered from a geometry-free COUNT so the model
+        and UI see the true total, not the render budget."""
+        import shapely
+
+        wkb = shapely.to_wkb(shapely.Point(1, 2), hex=True)
+        mock_gen.return_value = "SELECT name FROM data.cities"
+        capped = SandboxResult(
+            rows=[["City %d" % i, wkb] for i in range(50)],
+            columns=["name", "geom_4326"],
+            row_count=50,
+            truncated=True,
+        )
+        count = SandboxResult(rows=[[496]], columns=["n"], row_count=1, truncated=False)
+        mock_exec.side_effect = [capped, count]
+        layers = [_make_layer(column_info=[{"name": "name", "type": "text"}])]
+        result = await _handle_query_data(
+            {"question": "list every city with its location"},
+            AsyncMock(),
+            _mock_user(),
+            layers,
+        )
+        # Two calls: the capped fetch, then the COUNT recovery.
+        assert mock_exec.call_count == 2
+        count_sql = mock_exec.call_args_list[1].args[0]
+        assert count_sql.lower().startswith("select count(*)")
+        assert mock_exec.call_args_list[1].kwargs.get("row_limit") == 1
+        # The documented total is the true count, not the 50-row render budget.
+        assert result["row_count"] == 496
+        assert result["truncated"] is True
+
+    @pytest.mark.asyncio
+    @patch(
+        "app.processing.ai.chat_service.validate_and_execute", new_callable=AsyncMock
+    )
+    @patch("app.processing.ai.chat_service.generate_sql", new_callable=AsyncMock)
+    async def test_untruncated_appended_query_skips_count_recovery(
+        self, mock_gen, mock_exec
+    ):
+        """The COUNT recovery only fires when the cap actually truncated —
+        a small appended-geometry result issues a single query."""
+        import shapely
+
+        wkb = shapely.to_wkb(shapely.Point(1, 2), hex=True)
+        mock_gen.return_value = "SELECT name FROM data.cities"
+        mock_exec.return_value = SandboxResult(
+            rows=[["Springfield", wkb]],
+            columns=["name", "geom_4326"],
+            row_count=1,
+            truncated=False,
+        )
+        layers = [_make_layer(column_info=[{"name": "name", "type": "text"}])]
+        result = await _handle_query_data(
+            {"question": "cities"}, AsyncMock(), _mock_user(), layers
+        )
+        assert mock_exec.call_count == 1
+        assert result["row_count"] == 1
+
+    @pytest.mark.asyncio
+    @patch(
+        "app.processing.ai.chat_service.validate_and_execute", new_callable=AsyncMock
+    )
+    @patch("app.processing.ai.chat_service.generate_sql", new_callable=AsyncMock)
     async def test_rows_truncated_to_50(self, mock_gen, mock_exec):
         mock_gen.return_value = "SELECT * FROM data.cities"
         mock_exec.return_value = SandboxResult(

--- a/backend/tests/test_sql_engine.py
+++ b/backend/tests/test_sql_engine.py
@@ -362,6 +362,61 @@ class TestQueryDataTool:
         "app.processing.ai.chat_service.validate_and_execute", new_callable=AsyncMock
     )
     @patch("app.processing.ai.chat_service.generate_sql", new_callable=AsyncMock)
+    async def test_geometry_append_falls_back_when_column_absent(
+        self, mock_gen, mock_exec
+    ):
+        """fix(#556 review P2): a geom-only dataset (geometry_type but no
+        geom_4326) makes the appended query fail; fall back to the model's
+        original SQL so attribute rows still return (overlay dropped)."""
+        mock_gen.return_value = "SELECT name FROM data.cities"
+        original_ok = SandboxResult(
+            rows=[["Springfield"]], columns=["name"], row_count=1, truncated=False
+        )
+        # First call (appended geom_4326) raises undefined-column; second
+        # call (original SQL) succeeds.
+        mock_exec.side_effect = [SandboxError("query_failed", "boom"), original_ok]
+        layers = [_make_layer(column_info=[{"name": "name", "type": "text"}])]
+        result = await _handle_query_data(
+            {"question": "list cities"}, AsyncMock(), _mock_user(), layers
+        )
+        assert mock_exec.call_count == 2
+        # The fallback ran the ORIGINAL (un-appended) SQL, no row_limit cap.
+        fallback_sql = mock_exec.call_args_list[1].args[0]
+        assert "geom_4326" not in fallback_sql
+        assert mock_exec.call_args_list[1].kwargs.get("row_limit") is None
+        assert result["columns"] == ["name"]
+        assert result["rows"] == [["Springfield"]]
+        assert "geojson" not in result  # overlay dropped, query still succeeded
+
+    @pytest.mark.asyncio
+    @patch(
+        "app.processing.ai.chat_service.validate_and_execute", new_callable=AsyncMock
+    )
+    @patch("app.processing.ai.chat_service.generate_sql", new_callable=AsyncMock)
+    async def test_non_appended_failure_does_not_retry(self, mock_gen, mock_exec):
+        """A failure on a query with no appended geometry propagates (no
+        fallback double-run)."""
+        mock_gen.return_value = "SELECT * FROM data.cities"  # star → no append
+        mock_exec.side_effect = SandboxError("query_timeout", "slow")
+        layers = [_make_layer(column_info=[{"name": "name", "type": "text"}])]
+        result = await _execute_chat_tool(
+            "query_data",
+            {"question": "everything"},
+            AsyncMock(),
+            _mock_user(),
+            set(),
+            layers,
+            port=_default_port,
+        )
+        # SandboxError caught by _execute_chat_tool → friendly message, one call.
+        assert mock_exec.call_count == 1
+        assert result["category"] == "query_timeout"
+
+    @pytest.mark.asyncio
+    @patch(
+        "app.processing.ai.chat_service.validate_and_execute", new_callable=AsyncMock
+    )
+    @patch("app.processing.ai.chat_service.generate_sql", new_callable=AsyncMock)
     async def test_rows_truncated_to_50(self, mock_gen, mock_exec):
         mock_gen.return_value = "SELECT * FROM data.cities"
         mock_exec.return_value = SandboxResult(


### PR DESCRIPTION
Fixes #544.

## Problem

Two symptoms, one root (found in the post-merge browser smoke of the dataset-chat work):

1. **Spatial questions often produced no map overlay.** The SQL model could answer "list the names and locations of X" with attribute columns only (e.g. `longitude`/`latitude`), so `_extract_geojson` found nothing, `show_query_result` carried no geojson, and every geometry-dependent surface silently degraded (builder/viewer highlight overlay, dataset-panel "Open in builder" result-layer carryover).
2. **When geometry WAS selected, raw WKB hex rendered** in the chat result tables on all three surfaces.

## Approach (server-side, deterministic — no prompt rule)

- **`ensure_geometry_selected()`** (`chat_geojson.py`): a sqlglot pass over the generated SQL that appends the layer's `geom_4326` when the query is a plain single-table row-level SELECT from a geometry layer. Conservative by design — aggregates (incl. anonymous ones like `EVERY`), `GROUP BY`, `DISTINCT`, joins, CTEs, set operations, `SELECT *`, and already-selected geometry all leave the SQL unchanged. Runs before sandbox validation, so the appended column goes through the normal validate/execute path.
- **`strip_geometry_columns()`**: once the geojson payload is extracted, the geometry column is dropped from the tabular tool result. WKB never reaches the result tables (all three chat surfaces get this for free — no frontend change needed) and stops wasting model-context tokens.
- **Eval**: new live NL→SQL eval case pins the "list the name and location of every station" shape end-to-end through `generate_sql` → append pass → sandbox → `_extract_geojson` (verified locally against the real provider: passed).

## Notes

- `chat_actions.py` line-cap 400 → 425 in `test_layering.py` (reviewed bump, +14 lines of logic in `_handle_query_data`).
- No OpenAPI/SDK impact — `show_query_result` action shape is unchanged.
- Skipped the issue's optional system-prompt rule: the server-side rewrite covers the single-table case deterministically; joins/aggregates keep today's behavior.

## Verification

- `uv run pytest tests/test_ephemeral_geojson.py tests/test_sql_engine.py tests/test_layering.py` — 120 passed (18 new unit tests + 1 mocked integration test).
- `RUN_AI_EVALS=1 uv run pytest tests/evals/...::test_locations_reach_geojson_deterministically` — passed against the live provider.
- `ruff check` / `ruff format --check` clean; pre-commit hooks passed.

https://claude.ai/code/session_01XPiD2rhh1eNmYnPRojE39j