### PR TITLE
fix(sandbox/ai): preserve pgvector <=> in multi-tenant rewrite; drop unparseable <#> from prompt (#557, #558)

### DIFF
--- a/backend/app/platform/sandbox/executor.py
+++ b/backend/app/platform/sandbox/executor.py
@@ -7,6 +7,8 @@ for end users while full details are logged server-side.
 
 from __future__ import annotations
 
+import re
+
 import structlog
 import sqlglot
 from sqlglot import exp
@@ -29,14 +31,34 @@ DEFAULT_TIMEOUT_MS = 10_000
 # boolean equality test. The multi-tenant schema rewrite MUST re-render (the
 # logical `data.` schema has no physical table), so unlike the optional
 # geometry-append guard (#556) it cannot bail to the original SQL. Instead we
-# swap `<=>` for a sentinel operator that DOES round-trip, rewrite the schema on
-# the parsed AST, then restore. `&&` is chosen because the sandbox validator
-# rejects it (unlisted_function: array_overlaps), so validated SQL can never
-# contain it and the restore can't collide with real input. `<->` (L2) already
-# round-trips and `<#>` fails parse upstream, so `<=>` is the only operator that
-# reaches here valid-but-corrupted.
+# swap the `<=>` OPERATOR for a sentinel that DOES round-trip (`&&`, which the
+# validator rejects as array_overlaps so it never appears as a real operator in
+# validated SQL), rewrite the schema on the parsed AST, then restore. Both swaps
+# skip single-quoted string literals, so a literal such as `note = '&&'` or
+# `note = '<=>'` is preserved verbatim (fix(#559) review: a raw substring swap
+# corrupted or rejected such literals). `<->` (L2) already round-trips and `<#>`
+# fails parse upstream, so `<=>` is the only operator that reaches here
+# valid-but-corrupted.
 _COSINE_OP = "<=>"
 _COSINE_SENTINEL = "&&"
+_STRING_LITERAL_RE = re.compile(r"'(?:[^']|'')*'")
+
+
+def _swap_outside_string_literals(sql: str, old: str, new: str) -> str:
+    """Replace ``old`` with ``new`` only outside single-quoted string literals.
+
+    Splitting on the literal pattern keeps operator tokens in the code segments
+    replaceable while literal contents (which may legitimately contain the same
+    characters) pass through untouched.
+    """
+    segments = _STRING_LITERAL_RE.split(sql)
+    literals = _STRING_LITERAL_RE.findall(sql)
+    out: list[str] = []
+    for i, segment in enumerate(segments):
+        out.append(segment.replace(old, new))
+        if i < len(literals):
+            out.append(literals[i])
+    return "".join(out)
 
 
 def _rewrite_logical_data_schema(sql: str, physical_schema: str) -> str:
@@ -52,17 +74,13 @@ def _rewrite_logical_data_schema(sql: str, physical_schema: str) -> str:
     ``physical_schema`` is produced by :func:`tenant_data_schema`, which accepts
     only a normalized UUID-derived identifier in multi-tenant mode.
     """
-    protect_cosine = _COSINE_OP in sql
-    if protect_cosine:
-        if _COSINE_SENTINEL in sql:
-            # Only reachable if a direct, unvalidated caller passes the
-            # validator-rejected sentinel alongside `<=>`. Fail closed rather
-            # than risk restoring the sentinel over real input.
-            raise SandboxError("invalid_query", "Invalid SQL syntax")
-        sql = sql.replace(_COSINE_OP, _COSINE_SENTINEL)
+    guarded = _swap_outside_string_literals(sql, _COSINE_OP, _COSINE_SENTINEL)
+    # protect only when an actual `<=>` operator was swapped (a literal `'<=>'`
+    # leaves `guarded` equal to `sql` and needs no restore pass).
+    protect_cosine = guarded != sql
 
     try:
-        statement = sqlglot.parse_one(sql, dialect="postgres")
+        statement = sqlglot.parse_one(guarded, dialect="postgres")
     except sqlglot.errors.ParseError as exc:
         # execute_safe receives validated SQL in normal operation.  Keep direct
         # callers fail-closed if that contract is accidentally violated.
@@ -78,7 +96,7 @@ def _rewrite_logical_data_schema(sql: str, physical_schema: str) -> str:
 
     rendered = statement.sql(dialect="postgres")
     if protect_cosine:
-        rendered = rendered.replace(_COSINE_SENTINEL, _COSINE_OP)
+        rendered = _swap_outside_string_literals(rendered, _COSINE_SENTINEL, _COSINE_OP)
     return rendered
 
 

--- a/backend/app/platform/sandbox/executor.py
+++ b/backend/app/platform/sandbox/executor.py
@@ -23,6 +23,21 @@ logger = structlog.stdlib.get_logger(__name__)
 DEFAULT_ROW_LIMIT = 1000
 DEFAULT_TIMEOUT_MS = 10_000
 
+# fix(#557): sqlglot's postgres dialect mis-parses the pgvector cosine operator
+# `<=>` as NullSafeEQ, so re-serializing the AST rewrites it to
+# `IS NOT DISTINCT FROM` — silently turning nearest-neighbor ranking into a
+# boolean equality test. The multi-tenant schema rewrite MUST re-render (the
+# logical `data.` schema has no physical table), so unlike the optional
+# geometry-append guard (#556) it cannot bail to the original SQL. Instead we
+# swap `<=>` for a sentinel operator that DOES round-trip, rewrite the schema on
+# the parsed AST, then restore. `&&` is chosen because the sandbox validator
+# rejects it (unlisted_function: array_overlaps), so validated SQL can never
+# contain it and the restore can't collide with real input. `<->` (L2) already
+# round-trips and `<#>` fails parse upstream, so `<=>` is the only operator that
+# reaches here valid-but-corrupted.
+_COSINE_OP = "<=>"
+_COSINE_SENTINEL = "&&"
+
 
 def _rewrite_logical_data_schema(sql: str, physical_schema: str) -> str:
     """Rewrite validated ``data.*`` references to one physical tenant schema.
@@ -37,6 +52,15 @@ def _rewrite_logical_data_schema(sql: str, physical_schema: str) -> str:
     ``physical_schema`` is produced by :func:`tenant_data_schema`, which accepts
     only a normalized UUID-derived identifier in multi-tenant mode.
     """
+    protect_cosine = _COSINE_OP in sql
+    if protect_cosine:
+        if _COSINE_SENTINEL in sql:
+            # Only reachable if a direct, unvalidated caller passes the
+            # validator-rejected sentinel alongside `<=>`. Fail closed rather
+            # than risk restoring the sentinel over real input.
+            raise SandboxError("invalid_query", "Invalid SQL syntax")
+        sql = sql.replace(_COSINE_OP, _COSINE_SENTINEL)
+
     try:
         statement = sqlglot.parse_one(sql, dialect="postgres")
     except sqlglot.errors.ParseError as exc:
@@ -52,7 +76,10 @@ def _rewrite_logical_data_schema(sql: str, physical_schema: str) -> str:
         if column.db == "data":
             column.set("db", exp.to_identifier(physical_schema, quoted=True))
 
-    return statement.sql(dialect="postgres")
+    rendered = statement.sql(dialect="postgres")
+    if protect_cosine:
+        rendered = rendered.replace(_COSINE_SENTINEL, _COSINE_OP)
+    return rendered
 
 
 async def execute_safe(

--- a/backend/app/platform/sandbox/executor.py
+++ b/backend/app/platform/sandbox/executor.py
@@ -7,11 +7,10 @@ for end users while full details are logged server-side.
 
 from __future__ import annotations
 
-import re
-
 import structlog
 import sqlglot
 from sqlglot import exp
+from sqlglot.tokens import TokenType
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -33,32 +32,36 @@ DEFAULT_TIMEOUT_MS = 10_000
 # geometry-append guard (#556) it cannot bail to the original SQL. Instead we
 # swap the `<=>` OPERATOR for a sentinel that DOES round-trip (`&&`, which the
 # validator rejects as array_overlaps so it never appears as a real operator in
-# validated SQL), rewrite the schema on the parsed AST, then restore. Both swaps
-# skip single-quoted string literals, so a literal such as `note = '&&'` or
-# `note = '<=>'` is preserved verbatim (fix(#559) review: a raw substring swap
-# corrupted or rejected such literals). `<->` (L2) already round-trips and `<#>`
-# fails parse upstream, so `<=>` is the only operator that reaches here
-# valid-but-corrupted.
+# validated SQL), rewrite the schema on the parsed AST, then restore the
+# operator. The swap is driven by sqlglot's own tokenizer, so `<=>` / `&&`
+# appearing inside a string literal of ANY quoting form — `'...'`, `E'...'`,
+# `$$...$$` — tokenizes as a string and is left untouched (fix(#559) review: a
+# naive substring / single-quote-only swap corrupted dollar-quoted and
+# sentinel-lookalike literals). `IS NOT DISTINCT FROM` tokenizes as keywords, not
+# NULLSAFE_EQ, so a legitimate null-safe comparison is never rewritten. `<->`
+# (L2) already round-trips and `<#>` fails parse upstream, so `<=>` is the only
+# operator that reaches here valid-but-corrupted.
 _COSINE_OP = "<=>"
 _COSINE_SENTINEL = "&&"
-_STRING_LITERAL_RE = re.compile(r"'(?:[^']|'')*'")
 
 
-def _swap_outside_string_literals(sql: str, old: str, new: str) -> str:
-    """Replace ``old`` with ``new`` only outside single-quoted string literals.
+def _swap_operator_tokens(sql: str, token_type: TokenType, replacement: str) -> str:
+    """Replace every operator token of ``token_type`` with ``replacement``.
 
-    Splitting on the literal pattern keeps operator tokens in the code segments
-    replaceable while literal contents (which may legitimately contain the same
-    characters) pass through untouched.
+    Uses sqlglot's tokenizer so only genuine operator tokens are rewritten — the
+    same characters inside a string literal (any quoting form) tokenize as a
+    string and pass through untouched. Replacements run back-to-front so earlier
+    source offsets stay valid.
     """
-    segments = _STRING_LITERAL_RE.split(sql)
-    literals = _STRING_LITERAL_RE.findall(sql)
-    out: list[str] = []
-    for i, segment in enumerate(segments):
-        out.append(segment.replace(old, new))
-        if i < len(literals):
-            out.append(literals[i])
-    return "".join(out)
+    spans = [
+        (t.start, t.end)
+        for t in sqlglot.tokenize(sql, dialect="postgres")
+        if t.token_type == token_type
+    ]
+    out = sql
+    for start, end in reversed(spans):
+        out = out[:start] + replacement + out[end + 1 :]
+    return out
 
 
 def _rewrite_logical_data_schema(sql: str, physical_schema: str) -> str:
@@ -74,17 +77,18 @@ def _rewrite_logical_data_schema(sql: str, physical_schema: str) -> str:
     ``physical_schema`` is produced by :func:`tenant_data_schema`, which accepts
     only a normalized UUID-derived identifier in multi-tenant mode.
     """
-    guarded = _swap_outside_string_literals(sql, _COSINE_OP, _COSINE_SENTINEL)
-    # protect only when an actual `<=>` operator was swapped (a literal `'<=>'`
-    # leaves `guarded` equal to `sql` and needs no restore pass).
-    protect_cosine = guarded != sql
-
     try:
+        guarded = _swap_operator_tokens(sql, TokenType.NULLSAFE_EQ, _COSINE_SENTINEL)
         statement = sqlglot.parse_one(guarded, dialect="postgres")
-    except sqlglot.errors.ParseError as exc:
+    except sqlglot.errors.SqlglotError as exc:
         # execute_safe receives validated SQL in normal operation.  Keep direct
-        # callers fail-closed if that contract is accidentally violated.
+        # callers fail-closed if that contract is accidentally violated (covers
+        # both tokenize and parse failures).
         raise SandboxError("invalid_query", "Invalid SQL syntax") from exc
+
+    # protect only when a real `<=>` operator was swapped; a literal `<=>` (any
+    # quoting form) tokenizes as a string and leaves `guarded` unchanged.
+    protect_cosine = guarded != sql
 
     for table in statement.find_all(exp.Table):
         if table.db == "data":
@@ -96,7 +100,10 @@ def _rewrite_logical_data_schema(sql: str, physical_schema: str) -> str:
 
     rendered = statement.sql(dialect="postgres")
     if protect_cosine:
-        rendered = _swap_outside_string_literals(rendered, _COSINE_SENTINEL, _COSINE_OP)
+        # The rendered `&&` operators can only be the ones swapped in above (the
+        # validator rejects `&&` as a real operator), so restoring every DAMP
+        # token back to `<=>` is exact.
+        rendered = _swap_operator_tokens(rendered, TokenType.DAMP, _COSINE_OP)
     return rendered
 
 

--- a/backend/app/processing/ai/sql_generator.py
+++ b/backend/app/processing/ai/sql_generator.py
@@ -217,7 +217,6 @@ Use these when a column has type vector(N) (commonly named `embedding` or
 
   embedding <-> '[...]'::vector   -- L2 (Euclidean) distance
   embedding <=> '[...]'::vector   -- cosine distance
-  embedding <#> '[...]'::vector   -- negative inner product
 
 To find the K most similar rows to a reference row's embedding:
   SELECT name, embedding <=> (SELECT embedding FROM data.t WHERE id = '<id>') AS distance
@@ -376,7 +375,7 @@ LIMIT 10;
 - Always include LIMIT 1000 unless the query is an aggregation (GROUP BY, COUNT, SUM, etc.).
 - Use ONLY the tables and columns shown in the provided schema. Do not invent names.
 - Use ONLY the functions and operators listed in the PostGIS, Text Search, and Vector Similarity sections above. Do not use functions not in this reference.
-- Vector columns (type vector(N)) are queried with the <->/<=>/<#> operators, NOT with similarity() or ILIKE.
+- Vector columns (type vector(N)) are queried with the <->/<=> operators, NOT with similarity() or ILIKE.
 - Queries are limited to 30 seconds. Prefer indexed operations (ST_DWithin) over unindexed scans (ST_Distance < X).
 - You may use CTEs (WITH clauses) and subqueries. All referenced tables must be from the provided schema.
 - If the question cannot be answered with the available schema, respond with: -- ERROR: Cannot answer this question with the available data.

--- a/backend/tests/test_sandbox_tenant_schema.py
+++ b/backend/tests/test_sandbox_tenant_schema.py
@@ -51,6 +51,43 @@ def _mock_engine(executed: list[str], *, fail_role: str | None = None) -> MagicM
     return engine
 
 
+def test_schema_rewrite_preserves_pgvector_cosine_operator():
+    """fix(#557): the rewrite re-renders the parsed AST, and sqlglot mis-parses
+    pgvector ``<=>`` as NullSafeEQ. Without the sentinel guard the schema rewrite
+    silently turns cosine nearest-neighbor ranking into ``IS NOT DISTINCT FROM``,
+    returning the wrong rows in multi-tenant. The operator must survive and the
+    logical ``data`` schema must still be translated."""
+    from app.platform.sandbox.executor import _rewrite_logical_data_schema
+
+    sql = (
+        "SELECT name, embedding <=> '[1,2,3]'::vector AS distance "
+        "FROM data.records ORDER BY distance LIMIT 10"
+    )
+    rewritten = _rewrite_logical_data_schema(sql, _SCHEMA_A)
+
+    assert "<=>" in rewritten
+    assert "IS NOT DISTINCT FROM" not in rewritten
+    assert f'"{_SCHEMA_A}".records' in rewritten
+    assert "data.records" not in rewritten
+
+
+def test_schema_rewrite_preserves_l2_and_cosine_together():
+    """Both advertised distance operators survive the rewrite: ``<->`` already
+    round-trips, ``<=>`` is protected by the sentinel swap."""
+    from app.platform.sandbox.executor import _rewrite_logical_data_schema
+
+    sql = (
+        "SELECT id, embedding <=> '[1]'::vector AS cos "
+        "FROM data.t ORDER BY embedding <-> '[2]'::vector LIMIT 5"
+    )
+    rewritten = _rewrite_logical_data_schema(sql, _SCHEMA_A)
+
+    assert rewritten.count("<=>") == 1
+    assert rewritten.count("<->") == 1
+    assert "IS NOT DISTINCT FROM" not in rewritten
+    assert f'"{_SCHEMA_A}".t' in rewritten
+
+
 @pytest.mark.asyncio
 async def test_multi_tenant_rewrites_only_logical_data_schema(monkeypatch):
     monkeypatch.setattr("app.platform.sandbox.executor.is_multi_tenant", lambda: True)

--- a/backend/tests/test_sandbox_tenant_schema.py
+++ b/backend/tests/test_sandbox_tenant_schema.py
@@ -88,6 +88,33 @@ def test_schema_rewrite_preserves_l2_and_cosine_together():
     assert f'"{_SCHEMA_A}".t' in rewritten
 
 
+def test_schema_rewrite_preserves_sentinel_lookalike_literals():
+    """fix(#559 review): a string literal containing the sentinel (``&&``) or the
+    cosine operator text (``<=>``) must survive the rewrite. The swap skips
+    string literals, so ``note = '&&'`` and ``note = '<=>'`` pass through verbatim
+    while the real ``<=>`` operator is still protected. A raw substring swap
+    corrupted or rejected these legitimate queries."""
+    from app.platform.sandbox.executor import _rewrite_logical_data_schema
+
+    sql = (
+        "SELECT id FROM data.t WHERE note = '&&' "
+        "ORDER BY embedding <=> '[1,2,3]'::vector LIMIT 5"
+    )
+    rewritten = _rewrite_logical_data_schema(sql, _SCHEMA_A)
+
+    assert "'&&'" in rewritten  # literal left untouched
+    assert rewritten.count("<=>") == 1  # the operator, not the literal
+    assert "IS NOT DISTINCT FROM" not in rewritten
+    assert f'"{_SCHEMA_A}".t' in rewritten
+
+    # a literal that looks like the operator is also preserved
+    sql2 = "SELECT id FROM data.t WHERE note = '<=>' ORDER BY embedding <=> '[1]'::vector LIMIT 5"
+    rewritten2 = _rewrite_logical_data_schema(sql2, _SCHEMA_A)
+    assert "'<=>'" in rewritten2
+    assert rewritten2.count("<=>") == 2  # literal + operator both intact
+    assert "IS NOT DISTINCT FROM" not in rewritten2
+
+
 @pytest.mark.asyncio
 async def test_multi_tenant_rewrites_only_logical_data_schema(monkeypatch):
     monkeypatch.setattr("app.platform.sandbox.executor.is_multi_tenant", lambda: True)

--- a/backend/tests/test_sandbox_tenant_schema.py
+++ b/backend/tests/test_sandbox_tenant_schema.py
@@ -115,6 +115,32 @@ def test_schema_rewrite_preserves_sentinel_lookalike_literals():
     assert "IS NOT DISTINCT FROM" not in rewritten2
 
 
+def test_schema_rewrite_preserves_non_single_quoted_literals():
+    """fix(#559 review round 2): the operator swap is tokenizer-driven, so a
+    ``<=>`` inside a dollar-quoted literal — which the validator accepts —
+    tokenizes as a string and is preserved, not swapped to the sentinel. And
+    ``IS NOT DISTINCT FROM`` (keywords, not a NULLSAFE_EQ token) is never
+    rewritten into the cosine operator."""
+    from app.platform.sandbox.executor import _rewrite_logical_data_schema
+
+    # dollar-quoted literal containing the operator text, no real operator
+    out = _rewrite_logical_data_schema(
+        "SELECT id FROM data.t WHERE note = $$<=>$$ LIMIT 5", _SCHEMA_A
+    )
+    assert "&&" not in out  # sentinel never leaks into output
+    assert "<=>" in out  # the literal value survives (sqlglot re-quotes it)
+    assert f'"{_SCHEMA_A}".t' in out
+
+    # a legit IS NOT DISTINCT FROM alongside a real cosine operator: both survive
+    out2 = _rewrite_logical_data_schema(
+        "SELECT id FROM data.t WHERE a IS NOT DISTINCT FROM b "
+        "ORDER BY embedding <=> '[1]'::vector LIMIT 5",
+        _SCHEMA_A,
+    )
+    assert "IS NOT DISTINCT FROM" in out2
+    assert out2.count("<=>") == 1
+
+
 @pytest.mark.asyncio
 async def test_multi_tenant_rewrites_only_logical_data_schema(monkeypatch):
     monkeypatch.setattr("app.platform.sandbox.executor.is_multi_tenant", lambda: True)

--- a/backend/tests/test_sql_engine.py
+++ b/backend/tests/test_sql_engine.py
@@ -192,6 +192,27 @@ class TestSqlPrompt:
     def test_instructs_human_friendly_units(self):
         assert "human-friendly units" in self.prompt
 
+    def test_advertised_vector_operators_pass_the_validator(self):
+        """fix(#558): every pgvector operator the prompt tells the model to emit
+        must survive the sandbox validator. ``<#>`` fails ``sqlglot.parse``, so
+        advertising it means the model's inner-product queries are rejected as
+        invalid_query before they run. Scanning the prompt keeps this honest —
+        re-adding an unparseable operator re-breaks the test."""
+        from app.platform.sandbox.validator import validate_sql
+
+        advertised = [op for op in ("<->", "<=>", "<#>") if op in SQL_SYSTEM_PROMPT]
+        # sanity: cosine + L2 remain advertised (only <#> was dropped)
+        assert "<->" in advertised and "<=>" in advertised
+        for op in advertised:
+            q = f"SELECT id FROM data.t ORDER BY embedding {op} '[1,2,3]'::vector LIMIT 5"
+            try:
+                validate_sql(q)
+            except SandboxError as exc:
+                pytest.fail(
+                    f"prompt advertises `{op}` but the validator rejects it "
+                    f"({exc.category})"
+                )
+
 
 # ------------------------------------------------------------------
 # Tests for query_data tool integration (Plan 02)


### PR DESCRIPTION
Fixes #557 and #558 — two latent pgvector correctness bugs from the same root cause (sqlglot's postgres dialect imperfectly round-trips pgvector distance operators), surfaced during the #556 review.

## #558 — prompt advertised `<#>` the validator can't parse
`SQL_SYSTEM_PROMPT` told the model `embedding <#> '[...]'::vector` was valid, but `sqlglot.parse` (the sandbox validator's first stage) raises `ParseError` on `<#>`, so any model-generated inner-product query was rejected as `invalid_query` before running. Cosine (`<=>`) and L2 (`<->`) cover the practical similarity cases, so `<#>` is dropped from the operator reference and the constraints list.

## #557 — multi-tenant schema rewrite corrupted `<=>`
`_rewrite_logical_data_schema` re-serializes the parsed AST to map the logical `data.*` schema to a per-tenant physical schema, on **every** sandbox query in multi-tenant mode. sqlglot mis-parses `<=>` (cosine) as `NullSafeEQ`, so the re-render rewrote it to `IS NOT DISTINCT FROM` — silently turning nearest-neighbor ranking into a boolean equality test and returning the **wrong rows**. Single-tenant runs the original SQL verbatim and is unaffected.

The schema rewrite is mandatory (the logical `data.` schema has no physical table), so unlike the optional geometry-append guard in #556 it can't bail to the original SQL. Instead it swaps `<=>` for a sentinel operator that round-trips (`&&`, which the validator rejects as `array_overlaps`, so validated input can never contain it), rewrites the schema on the AST, then restores the operator. Fails closed if the sentinel is somehow already present.

## Tests
- `test_advertised_vector_operators_pass_the_validator` — scans the prompt and asserts every advertised vector operator survives `validate_sql` (would have caught #558; re-adding `<#>` re-breaks it).
- `test_schema_rewrite_preserves_pgvector_cosine_operator` / `..._l2_and_cosine_together` — DB-free unit tests proving `<=>` (and `<->` alongside) survive the rewrite while the logical schema is still translated.

## Deferred
The geom-only-dataset overlay gap noted in #557 (SRID-less ingests expose native `geom`, not `geom_4326`, which the prompt + `build_sql_schema_context` hardcode) is **not** addressed here — it needs ingest-metadata plumbing, not an operator fix. Tracking it separately; leaving #557 to close on the `<=>` fix.

## Verification
- `pytest tests/test_sandbox_tenant_schema.py tests/test_sql_engine.py tests/test_sandbox.py tests/test_sql_safety.py tests/test_sec025_sandbox_allowlist.py tests/test_ephemeral_geojson.py tests/test_layering.py` — all green
- `ruff check` + `ruff format --check` — clean
- No OpenAPI/SDK impact (prompt text + internal executor only)