### PR TITLE
ci: parallelize Backend Tests (-n4) + sysmon coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,11 @@ jobs:
               - '.dockerignore'
               - 'nginx.conf'
               - 'db/**'
+              # fix(#561): a change to this workflow can alter HOW Backend Tests
+              # runs (e.g. the -n4 parallelization / coverage core), so the suite
+              # must run on PRs that touch it — otherwise CI-config changes ship
+              # unvalidated by the very tests they configure.
+              - '.github/workflows/ci.yml'
             frontend:
               - 'frontend/**'
               - 'backend/openapi.json'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -732,6 +732,9 @@ jobs:
       GEOLENS_ADMIN_USERNAME: admin
       GEOLENS_ADMIN_PASSWORD: geolens-ci-admin-password
       PYTHONPATH: .
+      # PEP 669 sys.monitoring coverage core (Python 3.12+, coverage >= 7.4):
+      # far cheaper than the default C-trace and combines correctly under xdist.
+      COVERAGE_CORE: sysmon
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
 
@@ -841,7 +844,14 @@ jobs:
         # fail_under=60; the two are intentionally NOT yet aligned here — raising
         # the CI gate above measured coverage would RED main. Bump this to 60
         # only after a measured run confirms real coverage >= 60.
-        run: uv run pytest -v --tb=short -m 'not perf and not lifecycle' --cov=app --cov-report=term-missing --cov-report=html:htmlcov --cov-report=xml:coverage.xml --cov-fail-under=58.5
+        #
+        # -n 4 parallelizes the run (matches the Pytest Parallel Isolation job's
+        # benchmarked worker count). pytest-cov auto-combines each worker's data,
+        # so --cov-fail-under still gates on the full total. The suite is already
+        # -n4-safe (PPI runs it green), and --dist loadgroup (pyproject addopts)
+        # co-locates the global-state tenancy tests. Roughly halves this job
+        # (~1480s serial -> ~700s), the CI wall-clock's long pole.
+        run: uv run pytest -n 4 -v --tb=short -m 'not perf and not lifecycle' --cov=app --cov-report=term-missing --cov-report=html:htmlcov --cov-report=xml:coverage.xml --cov-fail-under=58.5
 
       - name: Verify SAML fixtures unchanged after pytest
         run: |


### PR DESCRIPTION
Speeds up the backend CI, which currently runs the pytest suite twice and lets the slow copy run serially.

## Evidence (recent `main` runs)
| Job | How it ran | Time |
|---|---|---|
| **Backend Tests** | serial + `--cov` | **1480s / 1425s / 1001s** |
| Pytest Parallel Isolation | `-n 4`, no coverage | 617s / 618s / 644s |

Same ~5,300 tests. The suite is DB-I/O-bound, so `-n4` overlaps DB waits (~2.4× on a 2-vCPU runner). The slow job's cost was **serialism**, not the tests — the autouse fixtures in `conftest.py` are cheap.

## Change (2 lines, `backend-test` job only)
- Add `-n 4` to the coverage run. `pytest-cov` auto-combines each worker's data, so `--cov-fail-under=58.5` still gates the full total. Verified locally that `-n4 + --cov + COVERAGE_CORE=sysmon` produces a single combined `TOTAL`. `--dist loadgroup` (already in `pyproject` addopts) co-locates the global-state tenancy tests, and PPI already proves the suite is `-n4`-safe.
- Add `COVERAGE_CORE=sysmon` — Python 3.13 + coverage 7.13 use the PEP 669 `sys.monitoring` core, far cheaper than the default C-tracer.

**Expected: ~1480s → ~700s**, which drops the CI wall-clock long pole to roughly the PPI time.

## Why PPI is kept
The natural follow-up is to delete the now-redundant Pytest Parallel Isolation job (both would be `-n4`). It's **not** done here because PPI is (a) a **required status check** in branch protection and (b) a `needs:` dependency of `e2e-test` and `accessibility`. Deleting it without first updating branch protection would permanently block merges. Since the jobs run in parallel, removing PPI saves runner-minutes but not wall-clock — so it's a separate, lower-priority change that needs a branch-protection tweak.

## Verification
- YAML parses; change scoped to the `backend-test` job (PPI's `-n4` untouched).
- The Backend Tests run on this PR is itself the test — watch that it stays green and lands near ~700s.