### PR TITLE
ci: raise coverage floor to 80 (measured 85.49%)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -845,10 +845,10 @@ jobs:
             tests/test_layering.py
 
       - name: Run tests with coverage
-        # --cov-fail-under=58.5 is the CI floor. backend/pyproject.toml declares
-        # fail_under=60; the two are intentionally NOT yet aligned here — raising
-        # the CI gate above measured coverage would RED main. Bump this to 60
-        # only after a measured run confirms real coverage >= 60.
+        # --cov-fail-under=80 is the CI floor, aligned with pyproject's
+        # fail_under. The #561 -n4 run measured 85.49% actual, so 80 gates a real
+        # regression with a ~5.5 pt buffer (the old 58.5 caught nothing). Ratchet
+        # upward per the pyproject note; never lower without a CHANGELOG rationale.
         #
         # -n 4 parallelizes the run (matches the Pytest Parallel Isolation job's
         # benchmarked worker count). pytest-cov auto-combines each worker's data,
@@ -856,7 +856,7 @@ jobs:
         # -n4-safe (PPI runs it green), and --dist loadgroup (pyproject addopts)
         # co-locates the global-state tenancy tests. Roughly halves this job
         # (~1480s serial -> ~700s), the CI wall-clock's long pole.
-        run: uv run pytest -n 4 -v --tb=short -m 'not perf and not lifecycle' --cov=app --cov-report=term-missing --cov-report=html:htmlcov --cov-report=xml:coverage.xml --cov-fail-under=58.5
+        run: uv run pytest -n 4 -v --tb=short -m 'not perf and not lifecycle' --cov=app --cov-report=term-missing --cov-report=html:htmlcov --cov-report=xml:coverage.xml --cov-fail-under=80
 
       - name: Verify SAML fixtures unchanged after pytest
         run: |

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -175,11 +175,12 @@ omit = []
 [tool.coverage.report]
 show_missing = true
 # Coverage threshold ratchets upward as the suite grows (TEST-01, Phase 278).
-# Current: 60.0 (raised from 58.5 — v13.2 close baseline was 62.29% actual).
-# To ratchet further: run `make test`, take the lowest stable run's pct,
-# subtract a 1-2 pt buffer, and bump this number. Never lower it without
-# a documented rationale in CHANGELOG.
-fail_under = 60
+# Current: 80.0 (raised from 60 — the #561 -n4 run measured 85.49% actual; the
+# old 58.5/60 floors were toothless against a 25 pt regression. 80 keeps a
+# conservative ~5.5 pt buffer). To ratchet further: run `make test-cov`, take
+# the lowest stable run's pct, subtract a 1-2 pt buffer, and bump this number.
+# Never lower it without a documented rationale in CHANGELOG.
+fail_under = 80
 exclude_lines = [
     "pragma: no cover",
     "if __name__ == .__main__.:",


### PR DESCRIPTION
## Why
The `-n4` Backend Tests run in #561 measured **85.49%** actual backend coverage, but the CI floor was `--cov-fail-under=58.5` and pyproject's `fail_under=60`. The gate tolerated a ~25-point regression before failing — effectively toothless.

## Change
Raise both floors to **80** (aligned):
- `.github/workflows/ci.yml` — `--cov-fail-under=80`
- `backend/pyproject.toml` — `fail_under = 80` (used by `make test-cov`)

80 gates a real regression while leaving a conservative **~5.5-point buffer** below the measured 85.49%, so normal PR churn won't false-RED. Follows the pyproject ratchet note (raise, never lower without a CHANGELOG rationale).

## Self-validating
This PR edits `ci.yml`, which the backend paths-filter (added in #561) now includes — so **this PR's own Backend Tests job runs the full suite under the new 80 floor**. If coverage were below 80, this PR would go red. Watch that job.