### PR TITLE
fix(ai): degrade chat gracefully when geom_4326 column is absent (#560)

### DIFF
--- a/backend/app/processing/ai/chat_actions.py
+++ b/backend/app/processing/ai/chat_actions.py
@@ -52,6 +52,32 @@ _DEFAULT_LABEL_TEXT_COLOR = "#333333"
 _OVERLAY_ROW_BUDGET = 50
 
 
+def _geom_4326_missing_note(err: SandboxError) -> dict | None:
+    """Clean degrade note when ``err`` was caused by a missing ``geom_4326`` column.
+
+    fix(#560): the SQL prompt + schema-context always name the geometry column
+    ``geom_4326`` (sql_generator.SQL_SYSTEM_PROMPT / build_sql_schema_context),
+    so the model emits it. A table without that column — a legacy dataset
+    ingested before the geom_4326 convention (no current ingest path produces
+    one: the missing-CRS gate rejects unknown-CRS uploads and every spatial path
+    builds geom_4326) — fails with ``column "geom_4326" does not exist``.
+    ``SandboxError.category`` is the generic ``query_failed``; the Postgres text
+    lives on ``__cause__`` (executor sets it via ``raise SandboxError(...) from
+    exc``). Returns None for any other error so it propagates unmasked.
+    """
+    detail = f"{err} {err.__cause__}".lower()
+    if "geom_4326" not in detail or "does not exist" not in detail:
+        return None
+    logger.info("query_data.geom_4326_missing")
+    return {
+        "error": (
+            "This dataset's geometry can't be used in spatial queries. "
+            "I can still answer questions about its attribute columns."
+        ),
+        "category": "llm_cannot_answer",
+    }
+
+
 def _safe_label_text_color(value: object) -> str:
     # fix(#394) CH-02: hex / real CSS named color / numeric-arg functional form
     # only (see colors.py) — anything else falls back to the default so an
@@ -167,7 +193,7 @@ async def _handle_query_data(
         result = await chat_service.validate_and_execute(
             sql, session, user, **exec_kwargs
         )
-    except SandboxError:
+    except SandboxError as err:
         # fix(#556 review P2): the appended geom_4326 may not exist — a
         # SRID-less ingest keeps geometry_type but exposes only native `geom`
         # (see ensure_geom_4326_gist_index docs) — or the append otherwise
@@ -175,13 +201,29 @@ async def _handle_query_data(
         # so attribute rows still return; the overlay is simply dropped. If the
         # original also fails, its error propagates (no masking).
         if not geom_appended:
+            # fix(#560): the model wrote geom_4326 itself (append skipped), so
+            # there is no attribute-only fallback to try. If the column is
+            # simply absent (a legacy geom-only table), degrade to a clean note
+            # instead of a generic failure; any other error propagates.
+            note = _geom_4326_missing_note(err)
+            if note is not None:
+                return note
             raise
         logger.info("query_data.geometry_append_fallback")
         geom_appended = False
         sql = original_sql
-        result = await chat_service.validate_and_execute(
-            sql, session, user, restrict_tables=restrict_tables
-        )
+        try:
+            result = await chat_service.validate_and_execute(
+                sql, session, user, restrict_tables=restrict_tables
+            )
+        except SandboxError as retry_err:
+            # fix(#560): the model also referenced geom_4326 in the original
+            # query (e.g. a WHERE / ORDER BY clause), so the attribute-only
+            # retry misses it too — degrade rather than surface a generic error.
+            note = _geom_4326_missing_note(retry_err)
+            if note is not None:
+                return note
+            raise
 
     # fix(#556 review P2): the transfer cap above bounds the sandbox row_count to
     # the render budget, but show_query_result.row_count is the documented TOTAL

--- a/backend/app/processing/ai/chat_actions.py
+++ b/backend/app/processing/ai/chat_actions.py
@@ -65,8 +65,12 @@ def _geom_4326_missing_note(err: SandboxError) -> dict | None:
     lives on ``__cause__`` (executor sets it via ``raise SandboxError(...) from
     exc``). Returns None for any other error so it propagates unmasked.
     """
+    # fix(#560, PR #563 Codex P2): match the exact undefined-column phrase, not
+    # "geom_4326" and "does not exist" separately. The DB error echoes the full
+    # SQL, so a query like `SELECT bad_col, geom_4326 ...` failing on `bad_col`
+    # contains both tokens and would be mis-degraded, masking the real error.
     detail = f"{err} {err.__cause__}".lower()
-    if "geom_4326" not in detail or "does not exist" not in detail:
+    if 'column "geom_4326" does not exist' not in detail:
         return None
     logger.info("query_data.geom_4326_missing")
     return {

--- a/backend/app/processing/ai/chat_actions.py
+++ b/backend/app/processing/ai/chat_actions.py
@@ -11,6 +11,7 @@ keep working unchanged when the patch replaces the attribute on the facade.
 """
 
 import json
+import re
 from collections.abc import Callable
 from typing import TYPE_CHECKING
 from uuid import UUID
@@ -51,26 +52,36 @@ _DEFAULT_LABEL_TEXT_COLOR = "#333333"
 # discard all but these.
 _OVERLAY_ROW_BUDGET = 50
 
+# fix(#560): matches a Postgres undefined-column clause and captures the column
+# reference. Unqualified misses are quoted (`column "geom_4326" does not
+# exist`); qualified/aliased misses are not (`column a.geom_4326 does not
+# exist`) — the model's overlay/intersect queries use aliases, so both forms
+# must be recognised (PR #563 Codex P2). Anchoring on the "column ... does not
+# exist" clause (not a loose geom_4326 substring) keeps the SQL echoed into the
+# error from causing false positives when a *different* column is missing.
+_UNDEFINED_COLUMN_RE = re.compile(
+    r"column\s+([\w\".]+)\s+does not exist", re.IGNORECASE
+)
+
 
 def _geom_4326_missing_note(err: SandboxError) -> dict | None:
     """Clean degrade note when ``err`` was caused by a missing ``geom_4326`` column.
 
     fix(#560): the SQL prompt + schema-context always name the geometry column
     ``geom_4326`` (sql_generator.SQL_SYSTEM_PROMPT / build_sql_schema_context),
-    so the model emits it. A table without that column — a legacy dataset
-    ingested before the geom_4326 convention (no current ingest path produces
-    one: the missing-CRS gate rejects unknown-CRS uploads and every spatial path
-    builds geom_4326) — fails with ``column "geom_4326" does not exist``.
-    ``SandboxError.category`` is the generic ``query_failed``; the Postgres text
-    lives on ``__cause__`` (executor sets it via ``raise SandboxError(...) from
-    exc``). Returns None for any other error so it propagates unmasked.
+    so the model emits it — often qualified (``a.geom_4326``). A table without
+    that column — a legacy dataset ingested before the geom_4326 convention (no
+    current ingest path produces one: the missing-CRS gate rejects unknown-CRS
+    uploads and every spatial path builds geom_4326) — fails with ``column
+    ["<alias>".]geom_4326 does not exist``. ``SandboxError.category`` is the
+    generic ``query_failed``; the Postgres text lives on ``__cause__`` (executor
+    sets it via ``raise SandboxError(...) from exc``). Compare the missing
+    column's final segment so aliased/quoted forms match while a *different*
+    missing column (whose SQL echo merely mentions geom_4326) does not — returns
+    None for any other error so it propagates unmasked.
     """
-    # fix(#560, PR #563 Codex P2): match the exact undefined-column phrase, not
-    # "geom_4326" and "does not exist" separately. The DB error echoes the full
-    # SQL, so a query like `SELECT bad_col, geom_4326 ...` failing on `bad_col`
-    # contains both tokens and would be mis-degraded, masking the real error.
-    detail = f"{err} {err.__cause__}".lower()
-    if 'column "geom_4326" does not exist' not in detail:
+    m = _UNDEFINED_COLUMN_RE.search(f"{err} {err.__cause__}")
+    if m is None or m.group(1).replace('"', "").split(".")[-1].lower() != "geom_4326":
         return None
     logger.info("query_data.geom_4326_missing")
     return {

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -899,7 +899,11 @@ def test_decomposed_service_modules_stay_within_size_budgets() -> None:
         # fix(#556 review P2, round 7): +~15 lines — geometry-free COUNT
         # recovery so the transfer cap doesn't corrupt the documented total
         # row_count. Cap 445 → 470 (~18 headroom).
-        "backend/app/processing/ai/chat_actions.py": 470,
+        # fix(#560): +~44 lines — _geom_4326_missing_note helper + graceful
+        # degrade (clean note instead of a generic failure) at both the
+        # model-written and append-retry failure points when a legacy geom-only
+        # table lacks geom_4326. Cap 470 → 530 (~16 headroom).
+        "backend/app/processing/ai/chat_actions.py": 530,
     }
 
     files_to_check = list(facade_line_budgets)

--- a/backend/tests/test_sql_engine.py
+++ b/backend/tests/test_sql_engine.py
@@ -471,6 +471,29 @@ class TestQueryDataTool:
         "app.processing.ai.chat_service.validate_and_execute", new_callable=AsyncMock
     )
     @patch("app.processing.ai.chat_service.generate_sql", new_callable=AsyncMock)
+    async def test_qualified_geom_4326_missing_degrades(self, mock_gen, mock_exec):
+        """fix(#560, PR #563 Codex P2): overlay/intersect queries alias the
+        geometry column (`a.geom_4326`), so Postgres reports the miss WITHOUT
+        quotes and WITH the qualifier — `column a.geom_4326 does not exist`.
+        This qualified form (the primary #560 case) must still degrade cleanly,
+        not just the unqualified `column "geom_4326" does not exist`."""
+        mock_gen.return_value = "SELECT a.name, a.geom_4326 FROM data.cities AS a"
+        err = SandboxError("query_failed", "Query failed")
+        err.__cause__ = Exception("column a.geom_4326 does not exist")
+        mock_exec.side_effect = err
+        layers = [_make_layer(column_info=[{"name": "name", "type": "text"}])]
+        result = await _handle_query_data(
+            {"question": "map the cities"}, AsyncMock(), _mock_user(), layers
+        )
+        assert mock_exec.call_count == 1
+        assert result["category"] == "llm_cannot_answer"
+        assert "spatial queries" in result["error"]
+
+    @pytest.mark.asyncio
+    @patch(
+        "app.processing.ai.chat_service.validate_and_execute", new_callable=AsyncMock
+    )
+    @patch("app.processing.ai.chat_service.generate_sql", new_callable=AsyncMock)
     async def test_other_missing_column_is_not_mis_degraded(self, mock_gen, mock_exec):
         """fix(#560, PR #563 Codex P2): a DIFFERENT undefined column must surface
         the normal failure, not the geometry-degrade note — even though the DB

--- a/backend/tests/test_sql_engine.py
+++ b/backend/tests/test_sql_engine.py
@@ -414,6 +414,63 @@ class TestQueryDataTool:
         "app.processing.ai.chat_service.validate_and_execute", new_callable=AsyncMock
     )
     @patch("app.processing.ai.chat_service.generate_sql", new_callable=AsyncMock)
+    async def test_model_written_geom_4326_missing_degrades_cleanly(
+        self, mock_gen, mock_exec
+    ):
+        """fix(#560): when the model selects geom_4326 itself (so nothing is
+        appended) on a legacy geom-only table, the missing-column error degrades
+        to a clean note — there is no attribute-only fallback to retry, and the
+        user must not get a generic "something went wrong"."""
+        mock_gen.return_value = "SELECT name, geom_4326 FROM data.cities"
+        err = SandboxError("query_failed", "Query failed")
+        err.__cause__ = Exception('column "geom_4326" does not exist')
+        mock_exec.side_effect = err
+        layers = [_make_layer(column_info=[{"name": "name", "type": "text"}])]
+        result = await _handle_query_data(
+            {"question": "show me the cities"}, AsyncMock(), _mock_user(), layers
+        )
+        assert mock_exec.call_count == 1  # the model's own SQL, no retry
+        assert result["category"] == "llm_cannot_answer"
+        assert "spatial queries" in result["error"]
+        assert "geojson" not in result
+
+    @pytest.mark.asyncio
+    @patch(
+        "app.processing.ai.chat_service.validate_and_execute", new_callable=AsyncMock
+    )
+    @patch("app.processing.ai.chat_service.generate_sql", new_callable=AsyncMock)
+    async def test_geom_4326_in_order_by_missing_degrades_after_retry(
+        self, mock_gen, mock_exec
+    ):
+        """fix(#560): the model referenced geom_4326 only in ORDER BY, so the
+        append fires (nothing geometric in the SELECT) yet BOTH the appended
+        query and the attribute-only retry miss the column — degrade cleanly
+        rather than propagate a generic failure."""
+
+        def _missing():
+            e = SandboxError("query_failed", "Query failed")
+            e.__cause__ = Exception('column "geom_4326" does not exist')
+            return e
+
+        # KNN pattern: attribute-only SELECT, geom_4326 in ORDER BY → append fires.
+        mock_gen.return_value = (
+            "SELECT name FROM data.cities "
+            "ORDER BY geom_4326 <-> ST_SETSRID(ST_MAKEPOINT(0, 0), 4326) LIMIT 5"
+        )
+        mock_exec.side_effect = [_missing(), _missing()]
+        layers = [_make_layer(column_info=[{"name": "name", "type": "text"}])]
+        result = await _handle_query_data(
+            {"question": "cities nearest origin"}, AsyncMock(), _mock_user(), layers
+        )
+        assert mock_exec.call_count == 2  # appended attempt + attribute-only retry
+        assert result["category"] == "llm_cannot_answer"
+        assert "attribute columns" in result["error"]
+
+    @pytest.mark.asyncio
+    @patch(
+        "app.processing.ai.chat_service.validate_and_execute", new_callable=AsyncMock
+    )
+    @patch("app.processing.ai.chat_service.generate_sql", new_callable=AsyncMock)
     async def test_non_appended_failure_does_not_retry(self, mock_gen, mock_exec):
         """A failure on a query with no appended geometry propagates (no
         fallback double-run)."""

--- a/backend/tests/test_sql_engine.py
+++ b/backend/tests/test_sql_engine.py
@@ -471,6 +471,31 @@ class TestQueryDataTool:
         "app.processing.ai.chat_service.validate_and_execute", new_callable=AsyncMock
     )
     @patch("app.processing.ai.chat_service.generate_sql", new_callable=AsyncMock)
+    async def test_other_missing_column_is_not_mis_degraded(self, mock_gen, mock_exec):
+        """fix(#560, PR #563 Codex P2): a DIFFERENT undefined column must surface
+        the normal failure, not the geometry-degrade note — even though the DB
+        error echoes the SQL text (which contains geom_4326). Detection matches
+        the exact `column "geom_4326" does not exist` phrase, not the tokens
+        `geom_4326` and `does not exist` scattered across the message."""
+        mock_gen.return_value = "SELECT bad_col, geom_4326 FROM data.cities"
+        err = SandboxError("query_failed", "Query failed")
+        err.__cause__ = Exception(
+            'column "bad_col" does not exist\n'
+            "[SQL: SELECT bad_col, geom_4326 FROM data.cities]"
+        )
+        mock_exec.side_effect = err
+        layers = [_make_layer(column_info=[{"name": "name", "type": "text"}])]
+        with pytest.raises(SandboxError):
+            await _handle_query_data(
+                {"question": "show me the cities"}, AsyncMock(), _mock_user(), layers
+            )
+        assert mock_exec.call_count == 1  # no false retry, no degrade
+
+    @pytest.mark.asyncio
+    @patch(
+        "app.processing.ai.chat_service.validate_and_execute", new_callable=AsyncMock
+    )
+    @patch("app.processing.ai.chat_service.generate_sql", new_callable=AsyncMock)
     async def test_non_appended_failure_does_not_retry(self, mock_gen, mock_exec):
         """A failure on a query with no appended geometry propagates (no
         fallback double-run)."""


### PR DESCRIPTION
## What

AI chat geometry/overlay queries against a table that exposes only native `geom` (no reprojected `geom_4326` column) previously failed with a generic *"Something went wrong. Try rephrasing your question."* This makes `_handle_query_data` detect that specific case and return a clean, actionable note instead, so the model explains and offers attribute answers.

The SQL prompt + schema-context always name the geometry column `geom_4326`, so the model emits it. The #556 fallback only rescued *appended-geometry* attribute queries; a query where the **model itself** wrote `geom_4326` (a pure overlay/intersect question, or `geom_4326` in a `WHERE` / `ORDER BY`) hit the `raise` and surfaced the generic failure.

Detection keys on the specific Postgres error `column "geom_4326" does not exist`, which lives on `SandboxError.__cause__` (`SandboxError.category` is the generic `query_failed`). Applied at **both** failure points: the model-written path and the #556 append-retry path. Any other error still propagates unmasked.

## Why this is intentionally minimal (not a full "thread the real column name through" fix)

Research finding: **no current ingest path can produce a `geometry_type`-set-but-no-`geom_4326` dataset.** Unknown-CRS uploads are *rejected* at the missing-CRS gate (not stored geom-less), and every spatial path — ogr2ogr files, GeoParquet, WFS/ArcGIS, x/y & WKT overrides, `created`, reuploads — runs `add_4326_column`. The only real exposure is **legacy pre-convention tables** (ingested before the `geom_4326` convention existed; no backfill migration retrofits them).

Even a full fix couldn't make metric spatial math correct on such tables — the native `geom` keeps a non-4326 SRID (`::geography` distances / 4326-literal joins would still be wrong). So this ships defensive graceful-degradation and the full overlay-rendering fix stays demand-gated per the issue's own note.

For a future full fix, the clean signal is `dataset.srid IS NOT NULL` ⟺ `geom_4326` exists (`dataset.srid` = `Find_SRID(..., 'geom')`; never `0` due to `chk_datasets_srid_positive`; do **not** AND with `geometry_type`, which is `NULL` for an empty/all-NULL-geometry table that still has `geom_4326`).

## Testing

- 2 new unit tests in `tests/test_sql_engine.py::TestQueryDataTool`: model-written `geom_4326` miss → clean note, no retry; `geom_4326` in `ORDER BY` → append + retry both miss → clean note.
- Local: **324 passed** across the AI/chat/sandbox suites (`test_sql_engine`, `test_ephemeral_geojson`, `test_chat_narrative`, `test_ai_chat_dataset`, `test_sandbox`, `test_sec025_sandbox_allowlist`, `test_sandbox_tenant_schema`, `test_phase_274_caches_and_pool`); `ruff format` + `ruff check` clean; pre-commit hooks pass.

Fixes #560.
