### PR TITLE
fix(shell): pin the top navbar with position:fixed (#522)

### DIFF
--- a/frontend/src/components/layout/AppLayout.tsx
+++ b/frontend/src/components/layout/AppLayout.tsx
@@ -34,7 +34,17 @@ export function AppLayout() {
   const showFooterBranding = !isEnterprise || branding?.show_badge !== false;
 
   return (
-    <div className={cn('flex flex-col', isAuthenticatedMapRoute ? 'h-dvh overflow-hidden' : 'min-h-screen')}>
+    // fix(#522): the navbar is fixed (out of flow), so reserve its height
+    // (h-14 + safe-area) as top padding on the shell. Applies to both branches:
+    // min-h-screen pages get their content pushed below the navbar, and h-dvh
+    // map routes correctly lose this height to flex-1 — exactly as they did when
+    // the navbar consumed flow height. Banners render below the navbar as a result.
+    <div
+      className={cn(
+        'flex flex-col pt-[calc(3.5rem+env(safe-area-inset-top))]',
+        isAuthenticatedMapRoute ? 'h-dvh overflow-hidden' : 'min-h-screen',
+      )}
+    >
       <SkipToContent />
       {/* fix(#553): inside the flex shell so h-dvh map routes lose height to
           the banner instead of overflowing the viewport */}
@@ -49,7 +59,7 @@ export function AppLayout() {
         // hardcoded 100dvh-navbar that ignored the footer) AND lets standalone
         // pages (404) center vertically in the available viewport (#305).
         // isMapRoute retained for any map-specific tweaks.
-        // scroll-mt clears the now-sticky navbar when the skip-link scrolls
+        // scroll-mt clears the fixed navbar when the skip-link scrolls
         // #main-content into view, so the heading isn't hidden under it (#305).
         // min-h-0 on authenticated map routes fixes the flexbox min-height:auto
         // trap so the builder's editor panel scrolls internally instead of the

--- a/frontend/src/components/layout/Navbar.tsx
+++ b/frontend/src/components/layout/Navbar.tsx
@@ -388,7 +388,11 @@ export function Navbar() {
   const canAccessAdmin = can('manage_users') || can('manage_settings');
 
   return (
-    <header className="sticky top-0 z-40 border-b bg-background pt-[env(safe-area-inset-top)]">
+    // fix(#522): fixed (not sticky) so the navbar shares the viewport-fixed
+    // positioning context of the admin sidebar — otherwise macOS elastic
+    // overscroll slides the sticky navbar over the stationary fixed sidebar.
+    // AppLayout reserves this header's height (h-14 + safe-area) as top padding.
+    <header className="fixed inset-x-0 top-0 z-40 border-b bg-background pt-[env(safe-area-inset-top)]">
       {/* Full-bleed control bar — page content keeps its own max-width;
           the frame spans the viewport like the rest of the chrome. */}
       <div className="flex h-14 w-full items-center justify-between gap-4 px-4 sm:px-6">

--- a/frontend/src/components/layout/__tests__/AppLayout.test.tsx
+++ b/frontend/src/components/layout/__tests__/AppLayout.test.tsx
@@ -194,6 +194,20 @@ describe('AppLayout', () => {
     expect(screen.getByRole('main')).not.toHaveClass('min-h-0');
   });
 
+  it('pins the navbar with position:fixed and reserves its height on the shell (#522)', () => {
+    const { container } = renderAppLayout(['/']);
+    const shell = container.firstElementChild as HTMLElement;
+    // Sharing the admin sidebar's viewport-fixed context is the whole point of
+    // #522 (kills the macOS elastic-overscroll seam). A regression to `sticky`
+    // reintroduces the drift, so guard the position class directly.
+    const navbar = screen.getByRole('banner');
+    expect(navbar).toHaveClass('fixed');
+    expect(navbar).not.toHaveClass('sticky');
+    // ...and because the navbar is out of flow, the shell must reserve its
+    // height as top padding or page content hides behind it.
+    expect(shell.className).toMatch(/pt-\[/);
+  });
+
   it('renders footer links but hides Powered by GeoLens branding in enterprise mode when show_badge is false', () => {
     mockedUseEdition.mockReturnValue({
       edition: 'enterprise',


### PR DESCRIPTION
Closes #522. Follow-up to #521 (admin sidebar offset).

## Problem
The navbar was `sticky top-0` (in document flow) while the admin sidebar is `position: fixed`. Mixed positioning means macOS elastic overscroll translates the sticky navbar but not the fixed sidebar, sliding one over the other at the seam. #521 confined the artifact to a 1px seam but couldn't eliminate it.

## Fix
Make the navbar `fixed top-0 inset-x-0` so both chrome surfaces are viewport-pinned and nothing moves relative to anything during rubber-band.

The only compensation needed is reserving the navbar's height on the shell, because a `fixed` navbar leaves document flow:

- `AppLayout` shell gains `pt-[calc(3.5rem+env(safe-area-inset-top))]` (navbar `h-14` + notch inset). This applies to **both** layout branches:
  - `min-h-screen` pages → content pushed below the navbar.
  - `h-dvh overflow-hidden` map routes → `flex-1` loses exactly this height, same as when the navbar consumed flow height (so #553/#347 behavior is preserved: no page overflow, panels still scroll internally).
- The two conditional banners (`SiteBanner`, `DemoBanner`) now render below the fixed navbar — no reorder needed since the fixed navbar is out of flow.

## What did *not* need changing (already assumed a fixed-at-56px navbar)
- Admin sidebar offset `top-14 h-[calc(100svh-3.5rem)]` (#521) — now shares the navbar's fixed context.
- Skip-link target `scroll-mt-16` (64px clears the 56px navbar).
- z-order: navbar `z-40` sits above the `z-10` sidebar and all map overlays, below `z-50` modals and the `z-100` skip link.

The `overscroll-behavior-y` nice-to-have from the issue is intentionally skipped — the fixed navbar alone removes the relative motion, which is the actual artifact.

## Verification
- `npm run typecheck`, `npm run lint`, `vitest run src/components/layout` (54 tests) — all green. Added an `AppLayout.test.tsx` guard asserting the navbar is `fixed` (not `sticky`) and the shell reserves top padding, so a regression to `sticky` fails CI.
- In-browser (1440×900) computed-layout checks:
  - **Search** (`min-h-screen`): navbar `position:fixed` at y=0 (h=57, z=40); `#main-content` top = 56 (flush below, not hidden).
  - **Admin**: navbar and sidebar both `position:fixed`, seam aligned (navbar bottom 57 / sidebar top 56), sidebar header visible.
  - **Builder** (`h-dvh`): shell height 900 = viewport, main fills 844px below the navbar, map fills to the bottom edge, `document` **not** scrollable (no overflow).
