### PR TITLE
chore(release): v1.4.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,20 @@ and releases use semantic versioning.
 
 ## [Unreleased]
 
+## [1.4.8] - 2026-07-18
+
 ### Added
 
+- **Ask questions about a dataset in natural language, from its page.** The
+  dataset page gains an AI chat panel that answers questions about that
+  dataset — counts, statistics, attribute filters, and spatial analysis — and
+  can hand a result straight into the map builder to visualize. It uses the
+  same read-only, sandboxed NL→SQL path as the builder assistant and is
+  scoped to the single dataset in view. Requires a configured AI provider.
+- **GeoParquet files can be uploaded and ingested.** `.parquet` joins the
+  accepted upload formats, so a GeoParquet dataset is added the same way as
+  a GeoPackage, Shapefile, or GeoJSON. (Complements GeoParquet *export*,
+  added in 1.4.6.)
 - **Coding agents can work with a GeoLens instance through a Model Context
   Protocol (MCP) server.** The new `geolens-mcp` package exposes read-only
   tools — catalog search, dataset schema inspection, feature reads, and
@@ -16,15 +28,46 @@ and releases use semantic versioning.
   can discover and read a catalog from inside a dev session. It authenticates
   with an existing API key (or runs anonymously against public data) and is
   scoped to exactly what that credential can see.
+- **Site-wide announcement banner.** Administrators can show a banner across
+  the app — enable/disable, message text, and color (info, warning, success,
+  destructive) live in Admin → General settings. Disabled by default, and
+  empty text means no banner, so existing deployments see no change.
+
+### Changed
+
+- **Accessibility and design-system pass.** A design audit closed contrast,
+  color-token, and instrument-system findings across the frontend, including
+  a dark-mode warning-text contrast fix.
 
 ### Fixed
 
+- **Tile caches roll over after content edits, not only re-uploads.** A
+  dedicated per-dataset cache-buster now advances on single-feature edits,
+  column DDL, and tile-column changes, so CDN and browser caches stop
+  serving stale tiles until max-age expiry.
+- **Map builder correctness and polish.** Three builder-audit passes closed
+  styling, filtering, viewer, and interaction findings, and adding a dataset
+  to a brand-new map no longer leaves it looking unsaved before any edit.
+- **Feature and schema editing hardening.** An editing audit tightened
+  write-path validation and edit-flag enforcement across single-feature
+  edits, column DDL, and record metadata updates.
+- **The top navbar and admin sidebar stay pinned** while content scrolls,
+  instead of scrolling away or overlapping one another.
+- **Dataset quicklook thumbnails no longer crash their consumers on a
+  cached 404 response.**
 - **The OpenAPI document no longer contains unresolvable schema references.**
   GeoJSON response schemas on the feature and collection-items endpoints
   embedded `#/$defs/...` pointers that dangled at document scope, so strict
   OpenAPI consumers (documentation generators, reference bundlers) rejected
   the whole contract. Those schemas are now fully inlined, and a contract
   test guards every `$ref` in the exported document.
+
+### Upgrade notes
+
+- **PostgreSQL `max_connections` is raised to 80** in the bundled
+  `db/postgresql.conf` to cover the API-side job-queue connector. Recreate
+  or restart the `db` container after pulling so the new value takes
+  effect.
 
 ## [1.4.7] - 2026-07-15
 
@@ -747,7 +790,8 @@ regression-covered fixes:
 - Initial public release of the GeoLens catalog, API, map builder, CLI, SDKs,
   Docker development stack, and public documentation entrypoints.
 
-[Unreleased]: https://github.com/geolens-io/geolens/compare/v1.4.7...HEAD
+[Unreleased]: https://github.com/geolens-io/geolens/compare/v1.4.8...HEAD
+[1.4.8]: https://github.com/geolens-io/geolens/compare/v1.4.7...v1.4.8
 [1.4.7]: https://github.com/geolens-io/geolens/compare/v1.4.6...v1.4.7
 [1.4.6]: https://github.com/geolens-io/geolens/compare/v1.4.5...v1.4.6
 [1.4.5]: https://github.com/geolens-io/geolens/compare/v1.4.4...v1.4.5

--- a/README.de.md
+++ b/README.de.md
@@ -46,6 +46,7 @@ GeoLens wird über die üblichen Paketregistrierungen veröffentlicht:
 ```bash
 pip install geolens          # Python SDK
 pip install geolens-cli      # CLI; installs the `geolens` command
+pip install geolens-mcp      # MCP server for coding agents (read-only)
 npm install @geolens/sdk     # TypeScript/JavaScript SDK
 ```
 
@@ -110,7 +111,7 @@ Für jedes Beispiel gibt es eine vollständige Anleitung in der [Dokumentation](
 
 ### Datenimport und -export
 
-- **Vektor:** Shapefile, GeoPackage, GeoJSON, CSV, XLSX
+- **Vektor:** Shapefile, GeoPackage, GeoJSON, GeoParquet, CSV, XLSX
 - **Raster:** GeoTIFF und Cloud-Optimized GeoTIFF (COG) mit automatischer Konvertierung
 - **Mosaike:** VRT-basierte Rastermosaike aus mehreren Quelldateien
 - **Export:** GeoJSON, Shapefile, GeoPackage, CSV, mit CRS-Reprojektion

--- a/README.es.md
+++ b/README.es.md
@@ -46,6 +46,7 @@ GeoLens se publica en los registros de paquetes estándar:
 ```bash
 pip install geolens          # Python SDK
 pip install geolens-cli      # CLI; installs the `geolens` command
+pip install geolens-mcp      # MCP server for coding agents (read-only)
 npm install @geolens/sdk     # TypeScript/JavaScript SDK
 ```
 
@@ -110,7 +111,7 @@ Cada ejemplo anterior tiene una guía completa en la [documentación](https://do
 
 ### Ingesta y exportación de datos
 
-- **Vector:** Shapefile, GeoPackage, GeoJSON, CSV, XLSX
+- **Vector:** Shapefile, GeoPackage, GeoJSON, GeoParquet, CSV, XLSX
 - **Ráster:** GeoTIFF y Cloud-Optimized GeoTIFF (COG) con conversión automática
 - **Mosaicos:** mosaicos ráster basados en VRT a partir de varios archivos fuente
 - **Exportación:** GeoJSON, Shapefile, GeoPackage y CSV, con reproyección del CRS

--- a/README.fr.md
+++ b/README.fr.md
@@ -46,6 +46,7 @@ GeoLens est publié dans les registres de paquets standard :
 ```bash
 pip install geolens          # Python SDK
 pip install geolens-cli      # CLI; installs the `geolens` command
+pip install geolens-mcp      # MCP server for coding agents (read-only)
 npm install @geolens/sdk     # TypeScript/JavaScript SDK
 ```
 
@@ -110,7 +111,7 @@ Chaque exemple ci-dessus dispose d’un guide complet dans la [documentation](ht
 
 ### Ingestion et exportation des données
 
-- **Vecteur :** Shapefile, GeoPackage, GeoJSON, CSV, XLSX
+- **Vecteur :** Shapefile, GeoPackage, GeoJSON, GeoParquet, CSV, XLSX
 - **Raster :** GeoTIFF et Cloud-Optimized GeoTIFF (COG) avec conversion automatique
 - **Mosaïques :** mosaïques raster basées sur VRT à partir de plusieurs fichiers sources
 - **Exportation :** GeoJSON, Shapefile, GeoPackage, CSV, avec reprojection du CRS

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ GeoLens is published through the standard package registries:
 ```bash
 pip install geolens          # Python SDK
 pip install geolens-cli      # CLI; installs the `geolens` command
+pip install geolens-mcp      # MCP server for coding agents (read-only)
 npm install @geolens/sdk     # TypeScript/JavaScript SDK
 ```
 
@@ -110,7 +111,7 @@ Each example above has a full guide in the [docs](https://docs.getgeolens.com/gu
 
 ### Data ingestion and export
 
-- **Vector:** Shapefile, GeoPackage, GeoJSON, CSV, XLSX
+- **Vector:** Shapefile, GeoPackage, GeoJSON, GeoParquet, CSV, XLSX
 - **Raster:** GeoTIFF and Cloud-Optimized GeoTIFF (COG) with automatic conversion
 - **Mosaics:** VRT-based raster mosaics from multiple source files
 - **Export:** GeoJSON, Shapefile, GeoPackage, CSV, with CRS reprojection

--- a/backend/app/api/main.py
+++ b/backend/app/api/main.py
@@ -559,7 +559,7 @@ _is_production = settings.is_production
 # no metadata to read. We fall back to the current published line so import never
 # crashes. Keep this fallback in lockstep with backend/pyproject.toml — it is one
 # of the sites `make bump` rewrites.
-_FALLBACK_APP_VERSION = "1.4.7"
+_FALLBACK_APP_VERSION = "1.4.8"
 
 
 def _resolve_app_version() -> str:

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -17140,7 +17140,7 @@
     "summary": "PostGIS-native geospatial data catalog with OGC API Features and Records support",
     "termsOfService": "https://github.com/geolens-io/geolens/blob/main/LICENSE",
     "title": "GeoLens API",
-    "version": "1.4.7"
+    "version": "1.4.8"
   },
   "openapi": "3.1.0",
   "paths": {

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geolens-backend"
-version = "1.4.7"
+version = "1.4.8"
 description = "PostGIS-native GIS data catalog"
 # Docker image (Dockerfile) ships python:3.14-slim (see the Dockerfile FROM for
 # the exact patch pin) as the project's tested runtime.

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -865,7 +865,7 @@ wheels = [
 
 [[package]]
 name = "geolens-backend"
-version = "1.4.7"
+version = "1.4.8"
 source = { virtual = "." }
 dependencies = [
     { name = "alembic" },

--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "geolens-cli"
-version = "1.4.7"
+version = "1.4.8"
 description = "Apache-2.0 command-line interface for the GeoLens API. Login, scan, publish, and export STAC against any GeoLens instance."
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/docs-contract.json
+++ b/docs-contract.json
@@ -1,6 +1,6 @@
 {
   "_comment": "Canonical cross-surface facts for the GeoLens README, marketing site (getgeolens.com/src), and docs site (getgeolens.com/docs). Validated against scripts/install.sh + backend/pyproject.toml by scripts/check_docs_contract.py (geolens CI). The getgeolens.com repo vendors a copy and enforces the same `forbidden` list in its own CI. See docs-internal/DOC-CONSISTENCY-STRATEGY for the full design. Edit a fact ONCE here (and in its canonical source) — the gates make every surface follow.",
-  "version": "1.4.7",
+  "version": "1.4.8",
   "install": {
     "oneLiner": "curl -fsSL https://getgeolens.com/install.sh | sh",
     "sourceBuild": "bash scripts/install.sh",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.4.7",
+  "version": "1.4.8",
   "type": "module",
   "license": "Apache-2.0",
   "author": "Carto Concepts, LLC",

--- a/mcp/pyproject.toml
+++ b/mcp/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "geolens-mcp"
-version = "1.4.7"
+version = "1.4.8"
 description = "Apache-2.0 read-only Model Context Protocol (MCP) server for GeoLens. Lets coding agents discover datasets, inspect schemas, and ask spatial questions against any GeoLens instance."
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "geolens",
-  "version": "1.4.7",
+  "version": "1.4.8",
   "private": true,
   "license": "Apache-2.0",
   "author": "Carto Concepts, LLC",

--- a/sdks/python/.openapi-python-client.yaml
+++ b/sdks/python/.openapi-python-client.yaml
@@ -4,7 +4,7 @@ project_name_override: geolens
 package_name_override: geolens
 # Rewritten on every `make sdks` run by scripts/sync_sdk_versions.py to match
 # backend/openapi.json info.version. Do not edit by hand.
-package_version_override: 1.4.7
+package_version_override: 1.4.8
 
 # Cleaner enum output (matches our pydantic v2 backend's enum emission).
 literal_enums: true

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "geolens"
-version = "1.4.7"
+version = "1.4.8"
 description = "Auto-generated Python SDK for the GeoLens API. Typed clients with Bearer + API-key auth helpers."
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/sdks/typescript/package-lock.json
+++ b/sdks/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@geolens/sdk",
-  "version": "1.4.7",
+  "version": "1.4.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@geolens/sdk",
-      "version": "1.4.7",
+      "version": "1.4.8",
       "license": "Apache-2.0",
       "dependencies": {
         "@hey-api/client-fetch": "0.13.1"

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@geolens/sdk",
-  "version": "1.4.7",
+  "version": "1.4.8",
   "description": "Auto-generated TypeScript SDK for the GeoLens API. Typed clients with Bearer + API-key auth helpers.",
   "license": "Apache-2.0",
   "author": "Carto Concepts, LLC",


### PR DESCRIPTION
## Release prep for v1.4.8

- Bump all 11 version sites to 1.4.8 (`make bump`)
- CHANGELOG: move [Unreleased] → [1.4.8] with full notes: dataset-scoped AI chat, GeoParquet ingest, read-only MCP server, announcement banner, design/builder/editing audit remediations, tile cache-buster fix, navbar/sidebar pinning, quicklook 404 fix, and a `max_connections` upgrade note
- README (all four locales): add `pip install geolens-mcp` to published artifacts; add GeoParquet to vector ingest formats
- Regenerate SDK version stamps (`make sdks`)

## Verification

Pre-release audit (2026-07-18, this branch's base = 98628eb30): 4-agent diff audit (backend/frontend/security/release-surface) — no P0-P2 code findings; host pytest 5672 passed; frontend build/lint/typecheck/coverage/i18n green; e2e:smoke 7/7; live browser smoke of chat/carry/banner/builder/viewer; CLI GeoParquet publish round-trip; `make version-check openapi-check sdks-check cli-test mcp-test alembic-check env-doc-check public-surface-check` all green; `test_phase_275_readme_accuracy` 7/7 after README edits.