### PR TITLE
docs+install: launch-audit polish (badge links, MCP in SECURITY scope, /api/health note, ready-banner password hint)

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -33,7 +33,7 @@ This policy covers:
 
 - The `geolens` source repository (this repo)
 - Official container images published to GHCR (`ghcr.io/geolens-io/*`)
-- Official packages published to PyPI (`geolens`, `geolens-cli`) and npm (`@geolens/sdk`)
+- Official packages published to PyPI (`geolens`, `geolens-cli`, `geolens-mcp`) and npm (`@geolens/sdk`)
 - The public demo at demo.getgeolens.com
 
 Out of scope here (report to the respective repo or contact): the marketing/docs website (getgeolens.com), and Helm/deployment packaging ([geolens-deployments](https://github.com/geolens-io/geolens-deployments)).

--- a/README.de.md
+++ b/README.de.md
@@ -14,7 +14,7 @@ GeoLens ist ein quelloffener, selbst gehosteter Katalog und Karteneditor für GI
 
 [![CI](https://github.com/geolens-io/geolens/actions/workflows/ci.yml/badge.svg)](https://github.com/geolens-io/geolens/actions/workflows/ci.yml)
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
-[![Python: backend 3.13+ / SDK 3.10+](https://img.shields.io/badge/python-3.13%2B_backend_%7C_3.10%2B_SDK-blue.svg)]()
+[![Python: backend 3.13+ / SDK 3.10+](https://img.shields.io/badge/python-3.13%2B_backend_%7C_3.10%2B_SDK-blue.svg)](https://www.python.org/)
 [![PostgreSQL 17 + PostGIS 3.5](https://img.shields.io/badge/PostGIS_3.5-PostgreSQL_17-336791.svg)](https://postgis.net/)
 [![OGC API](https://img.shields.io/badge/OGC_API-Features_%7C_Records-green.svg)](https://ogcapi.ogc.org/)
 

--- a/README.de.md
+++ b/README.de.md
@@ -183,7 +183,7 @@ bash scripts/install.sh
 
 In beiden Fällen kopiert `scripts/install.sh` `.env.example` nach `.env`, erzeugt ein JWT-Signaturgeheimnis, richtet Admin-Zugangsdaten ein und führt `docker compose up -d` aus. Der Admin-**Benutzername** ist standardmäßig `admin`; das **Passwort** wird als starker Zufallswert automatisch erzeugt (in `.env` geschrieben und nie im Terminal ausgegeben), sofern Sie keines angeben. Für unbeaufsichtigte Installationen setzen Sie vorher `GEOLENS_ADMIN_USERNAME` und `GEOLENS_ADMIN_PASSWORD`; die Abfragen entfallen. Erneutes Ausführen ist idempotent und erhält bestehende `.env`-Werte.
 
-Warten Sie etwa 60 Sekunden und öffnen Sie [http://localhost:8080](http://localhost:8080). Melden Sie sich mit dem Admin-Benutzernamen und dem erzeugten Passwort an (abrufbar mit `grep '^GEOLENS_ADMIN_PASSWORD=' .env`).
+Warten Sie etwa 60 Sekunden und öffnen Sie [http://localhost:8080](http://localhost:8080). Melden Sie sich mit dem Admin-Benutzernamen und dem erzeugten Passwort an (abrufbar mit `grep '^GEOLENS_ADMIN_PASSWORD=' geolens/.env` — der Einzeilen-Installer klont nach `geolens/` unterhalb des Verzeichnisses, aus dem Sie ihn gestartet haben; in einem Quell-Checkout einfach `.env`).
 
 Prüfen Sie den Zustand aller Dienste:
 

--- a/README.es.md
+++ b/README.es.md
@@ -183,7 +183,7 @@ bash scripts/install.sh
 
 En ambos casos, `scripts/install.sh` copia `.env.example` a `.env`, genera un secreto de firma JWT, configura las credenciales de administrador y ejecuta `docker compose up -d`. El **nombre de usuario** administrador predeterminado es `admin`; la **contraseña** se genera automáticamente como un valor aleatorio robusto (se escribe en `.env` y nunca se muestra en el terminal), salvo que proporciones la tuya. Para instalaciones desatendidas, define `GEOLENS_ADMIN_USERNAME` y `GEOLENS_ADMIN_PASSWORD` en el entorno antes de ejecutar el script y se omitirán las preguntas. Volver a ejecutarlo es idempotente: conserva los valores existentes en `.env`.
 
-Espera unos 60 segundos a que se inicien los servicios y abre [http://localhost:8080](http://localhost:8080). Inicia sesión con el usuario administrador y la contraseña generada (recupérala con `grep '^GEOLENS_ADMIN_PASSWORD=' .env`).
+Espera unos 60 segundos a que se inicien los servicios y abre [http://localhost:8080](http://localhost:8080). Inicia sesión con el usuario administrador y la contraseña generada (recupérala con `grep '^GEOLENS_ADMIN_PASSWORD=' geolens/.env` — el instalador de una línea clona en `geolens/` bajo el directorio desde el que lo ejecutaste; dentro de un checkout del código fuente es simplemente `.env`).
 
 Comprueba que todos los servicios están en buen estado:
 

--- a/README.es.md
+++ b/README.es.md
@@ -14,7 +14,7 @@ GeoLens es un catálogo y constructor de mapas de código abierto y autohospedad
 
 [![CI](https://github.com/geolens-io/geolens/actions/workflows/ci.yml/badge.svg)](https://github.com/geolens-io/geolens/actions/workflows/ci.yml)
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
-[![Python: backend 3.13+ / SDK 3.10+](https://img.shields.io/badge/python-3.13%2B_backend_%7C_3.10%2B_SDK-blue.svg)]()
+[![Python: backend 3.13+ / SDK 3.10+](https://img.shields.io/badge/python-3.13%2B_backend_%7C_3.10%2B_SDK-blue.svg)](https://www.python.org/)
 [![PostgreSQL 17 + PostGIS 3.5](https://img.shields.io/badge/PostGIS_3.5-PostgreSQL_17-336791.svg)](https://postgis.net/)
 [![OGC API](https://img.shields.io/badge/OGC_API-Features_%7C_Records-green.svg)](https://ogcapi.ogc.org/)
 

--- a/README.fr.md
+++ b/README.fr.md
@@ -183,7 +183,7 @@ bash scripts/install.sh
 
 Dans les deux cas, `scripts/install.sh` copie `.env.example` vers `.env`, génère un secret de signature JWT, configure les identifiants administrateur et exécute `docker compose up -d`. Le **nom d’utilisateur** administrateur vaut `admin` par défaut ; le **mot de passe** est automatiquement généré de façon robuste (écrit dans `.env`, jamais affiché dans le terminal), sauf si vous fournissez le vôtre. Pour une installation sans intervention, définissez `GEOLENS_ADMIN_USERNAME` et `GEOLENS_ADMIN_PASSWORD` dans l’environnement avant l’exécution afin d’ignorer les questions. Le script est idempotent : les valeurs existantes de `.env` sont conservées.
 
-Attendez environ 60 secondes, puis ouvrez [http://localhost:8080](http://localhost:8080). Connectez-vous avec votre nom administrateur et le mot de passe généré (obtenez-le avec `grep '^GEOLENS_ADMIN_PASSWORD=' .env`).
+Attendez environ 60 secondes, puis ouvrez [http://localhost:8080](http://localhost:8080). Connectez-vous avec votre nom administrateur et le mot de passe généré (obtenez-le avec `grep '^GEOLENS_ADMIN_PASSWORD=' geolens/.env` — l'installateur en une ligne clone dans `geolens/` sous le répertoire d'où vous l'avez lancé ; depuis un checkout des sources, c'est simplement `.env`).
 
 Vérifiez que tous les services sont opérationnels :
 

--- a/README.fr.md
+++ b/README.fr.md
@@ -14,7 +14,7 @@ GeoLens est un catalogue et un générateur de cartes open source et auto-héber
 
 [![CI](https://github.com/geolens-io/geolens/actions/workflows/ci.yml/badge.svg)](https://github.com/geolens-io/geolens/actions/workflows/ci.yml)
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
-[![Python: backend 3.13+ / SDK 3.10+](https://img.shields.io/badge/python-3.13%2B_backend_%7C_3.10%2B_SDK-blue.svg)]()
+[![Python: backend 3.13+ / SDK 3.10+](https://img.shields.io/badge/python-3.13%2B_backend_%7C_3.10%2B_SDK-blue.svg)](https://www.python.org/)
 [![PostgreSQL 17 + PostGIS 3.5](https://img.shields.io/badge/PostGIS_3.5-PostgreSQL_17-336791.svg)](https://postgis.net/)
 [![OGC API](https://img.shields.io/badge/OGC_API-Features_%7C_Records-green.svg)](https://ogcapi.ogc.org/)
 

--- a/README.md
+++ b/README.md
@@ -198,7 +198,9 @@ existing values in `.env` are preserved.
 
 Wait about 60 seconds for services to start, then open [http://localhost:8080](http://localhost:8080).
 Log in with your admin username and the generated password (retrieve it with
-`grep '^GEOLENS_ADMIN_PASSWORD=' .env`).
+`grep '^GEOLENS_ADMIN_PASSWORD=' geolens/.env` — the one-line installer clones
+into `geolens/` under the directory you ran it from; inside a source checkout
+it's just `.env`).
 
 Verify all services are healthy:
 

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -271,6 +271,11 @@ GeoLens exports Prometheus metrics out of the box. Reference scrape config, aler
 rules, and a Grafana dashboard ship in [`infra/monitoring/`](infra/monitoring/) —
 point your monitoring stack at them, or use them as a base for an existing one.
 
+**Uptime/liveness checks must target `/api/health`** (JSON `status`, `version`,
+`build`). Behind the bundled Nginx, a bare `/health` is not an API route — the
+frontend SPA catch-all answers it with HTML `200`, which an uptime monitor will
+happily (and wrongly) accept.
+
 ### Metrics & alerting (Prometheus / Grafana)
 
 Metrics are exposed on **two separate endpoints** — the API and the worker each

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -569,6 +569,19 @@ main() {
     say "  docker compose ps"
   fi
 
+  # fix(#572): repeat the generated-password hint in the final banner — the
+  # one-time note printed mid-install scrolls away, and a piped `curl | sh`
+  # first-timer otherwise dead-ends at the login screen.
+  if [ "${generated_admin_pw:-false}" = "true" ]; then
+    say ""
+    say "Log in as '${admin_user:-admin}' — the generated admin password is stored in .env:"
+    if [ -n "$PROJECT_HINT" ]; then
+      say "  grep '^GEOLENS_ADMIN_PASSWORD=' $PROJECT_HINT/.env"
+    else
+      say "  grep '^GEOLENS_ADMIN_PASSWORD=' .env"
+    fi
+  fi
+
   # BKP-01 (Phase 1247): backups are DEFAULT-ON. A plain `docker compose up`
   # runs the backup container (no --profile flag needed). Surface the active
   # mode: S3 offload when BACKUP_S3_ENABLED=true, otherwise local retention.


### PR DESCRIPTION
Pre-announcement polish from the 2026-07-18 launch-readiness audit (6-surface sweep ahead of the r/gis + Show HN posts). Four small fixes, no schema/API/config impact:

- **Localized READMEs (es/fr/de):** the Python badge had an empty link target (`]()`) — now links to python.org like the English README.
- **`.github/SECURITY.md`:** the supported-packages scope now includes `geolens-mcp` (first published to PyPI with v1.4.8); security researchers previously couldn't tell it was in scope.
- **`RUNBOOK.md` §4:** documents that uptime/liveness checks must target `/api/health` — a bare `/health` is answered by the frontend SPA catch-all with HTML 200, which uptime monitors happily misread as healthy (observed on the live demo).
- **`scripts/install.sh`:** the final "GeoLens is ready" banner now repeats the generated-admin-password retrieval hint (`grep '^GEOLENS_ADMIN_PASSWORD=' .env`). The existing hint prints once mid-install and scrolls away; on the piped `curl | sh` path (no TTY, password auto-generated) a first-timer otherwise dead-ends at the login screen. Guarded with `${...:-}` defaults because the configure block is skipped on idempotent re-runs, and mirrors the existing `PROJECT_HINT` cd-hint pattern.

**Verification**
- `sh -n scripts/install.sh` and `bash -n scripts/install.sh` clean.
- All four localized badge lines now byte-match the English README's target.
- Live demo probe: `GET /health` returns `text/html` (SPA shell), `GET /api/health` returns JSON with `version`/`build` — matching the new RUNBOOK note.

Note for review: the installer change intentionally does **not** echo the password itself (same posture as the mid-run hint — secret stays in `.env`).
