### PR TITLE
fix(api): neutralize leaked operation labels and compliance wording in the OpenAPI spec

### DIFF
--- a/backend/app/api/main.py
+++ b/backend/app/api/main.py
@@ -403,7 +403,7 @@ _DESCRIPTION = """\
 
 GeoLens is a self-hosted spatial data catalog that ingests vector files
 (GeoPackage, Shapefile, GeoJSON, CSV), stores them in PostGIS, and exposes
-them through a standards-compliant OGC API.
+them through OGC API endpoints.
 
 ## OGC Conformance Classes
 

--- a/backend/app/modules/audit/router.py
+++ b/backend/app/modules/audit/router.py
@@ -293,6 +293,10 @@ async def list_audit_logs(
 @router.get(
     "/audit-logs/export/{format}",
     response_class=StreamingResponse,
+    # fix(scripts/deployed_surface_gate.json#export_audit_op): neutral summary
+    # replacing the auto-derived "Export Audit Logs" banned public-copy id;
+    # operationId/path unchanged.
+    summary="Download audit records",
 )
 async def export_audit_logs(
     format: str,

--- a/backend/app/modules/settings/router.py
+++ b/backend/app/modules/settings/router.py
@@ -247,6 +247,10 @@ async def get_all_settings(
 @router.get(
     "/enterprise-tabs/",
     response_model=EnterpriseTabsResponse,
+    # fix(scripts/deployed_surface_gate.json#enterprise_tabs_op): neutral summary
+    # replacing the auto-derived "Get Enterprise Only Tabs" banned public-copy id;
+    # operationId/path unchanged.
+    summary="List restricted settings tabs",
 )
 async def get_enterprise_only_tabs(
     _user: Identity = Depends(require_settings_admin),

--- a/backend/app/modules/settings/router_public.py
+++ b/backend/app/modules/settings/router_public.py
@@ -34,7 +34,14 @@ def _basemap_proxy_rate_limit(_request: Request | None = None) -> str:
 
 
 @router.get("/edition", response_model=EditionInfoResponse, include_in_schema=False)
-@router.get("/edition/", response_model=EditionInfoResponse)
+@router.get(
+    "/edition/",
+    response_model=EditionInfoResponse,
+    # fix(scripts/deployed_surface_gate.json#edition_info_op): neutral summary — the
+    # auto-derived "Edition Info" label is a banned public-copy id; operationId/path
+    # unchanged.
+    summary="Get runtime capabilities",
+)
 async def edition_info() -> EditionInfoResponse:
     """Return runtime capability metadata. Public, no auth required."""
     from app.core.tenancy import TENANCY_MODE_SINGLE, is_multi_tenant

--- a/backend/app/standards/ogc/schemas.py
+++ b/backend/app/standards/ogc/schemas.py
@@ -69,7 +69,7 @@ class OGCCollectionMetadata(BaseModel):
 
 # Feature collection response for /collections/{id}/items
 class OGCFeatureItemsResponse(BaseModel):
-    """OGC API Features compliant feature collection response."""
+    """FeatureCollection response as defined by OGC API - Features."""
 
     type: Literal["FeatureCollection"] = Field(
         default="FeatureCollection", description="GeoJSON object type."

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -17132,7 +17132,7 @@
       "name": "GeoLens",
       "url": "https://github.com/geolens-io/geolens"
     },
-    "description": "## Overview\n\nGeoLens is a self-hosted spatial data catalog that ingests vector files\n(GeoPackage, Shapefile, GeoJSON, CSV), stores them in PostGIS, and exposes\nthem through a standards-compliant OGC API.\n\n## OGC Conformance Classes\n\n* OGC API Common 1.0 -- Core, Landing Page, JSON, OAS 3.0\n* OGC API Features Part 1 -- Core, GeoJSON, OAS 3.0\n* OGC API Features Part 3 -- Filtering (CQL2-Text, CQL2-JSON)\n\n## QGIS Quick-start\n\n1. **Layer > Add Layer > WFS / OGC API Features**\n2. URL: `{your-server}/api/`\n3. GeoLens advertises collections automatically.\n\n## GDAL / ogr2ogr Quick-start\n\n```bash\n# List collections\nogrinfo OAPIF:{your-server}/api/\n\n# Download a collection to GeoPackage\nogr2ogr -f GPKG output.gpkg OAPIF:{your-server}/api/ {collection-id}\n```\n\n## Authentication\n\nGeoLens supports three authentication methods. Public datasets are accessible\nwithout credentials; private/restricted datasets require one of:\n\n| Method | Usage |\n|--------|-------|\n| **API Key header** | `X-Api-Key: <key>` |\n| **JWT Bearer token** | `Authorization: Bearer <token>` |\n| **API Key query param** | `?api_key=<key>` |\n\nPriority: header API key > query param API key > JWT > anonymous.\n\n### GDAL / ogr2ogr with API Key\n\n```bash\n# List collections (including private ones accessible to your key)\nogrinfo \"OAPIF:{your-server}/api/?api_key=YOUR_KEY\"\n\n# Download a private collection\nogr2ogr -f GPKG out.gpkg \"OAPIF:{your-server}/api/?api_key=YOUR_KEY\" {collection-id}\n```\n\n### QGIS with API Key\n\nIn the WFS / OGC API Features connection dialog, append `?api_key=YOUR_KEY`\nto the server URL.\n",
+    "description": "## Overview\n\nGeoLens is a self-hosted spatial data catalog that ingests vector files\n(GeoPackage, Shapefile, GeoJSON, CSV), stores them in PostGIS, and exposes\nthem through OGC API endpoints.\n\n## OGC Conformance Classes\n\n* OGC API Common 1.0 -- Core, Landing Page, JSON, OAS 3.0\n* OGC API Features Part 1 -- Core, GeoJSON, OAS 3.0\n* OGC API Features Part 3 -- Filtering (CQL2-Text, CQL2-JSON)\n\n## QGIS Quick-start\n\n1. **Layer > Add Layer > WFS / OGC API Features**\n2. URL: `{your-server}/api/`\n3. GeoLens advertises collections automatically.\n\n## GDAL / ogr2ogr Quick-start\n\n```bash\n# List collections\nogrinfo OAPIF:{your-server}/api/\n\n# Download a collection to GeoPackage\nogr2ogr -f GPKG output.gpkg OAPIF:{your-server}/api/ {collection-id}\n```\n\n## Authentication\n\nGeoLens supports three authentication methods. Public datasets are accessible\nwithout credentials; private/restricted datasets require one of:\n\n| Method | Usage |\n|--------|-------|\n| **API Key header** | `X-Api-Key: <key>` |\n| **JWT Bearer token** | `Authorization: Bearer <token>` |\n| **API Key query param** | `?api_key=<key>` |\n\nPriority: header API key > query param API key > JWT > anonymous.\n\n### GDAL / ogr2ogr with API Key\n\n```bash\n# List collections (including private ones accessible to your key)\nogrinfo \"OAPIF:{your-server}/api/?api_key=YOUR_KEY\"\n\n# Download a private collection\nogr2ogr -f GPKG out.gpkg \"OAPIF:{your-server}/api/?api_key=YOUR_KEY\" {collection-id}\n```\n\n### QGIS with API Key\n\nIn the WFS / OGC API Features connection dialog, append `?api_key=YOUR_KEY`\nto the server URL.\n",
     "license": {
       "name": "Apache 2.0",
       "url": "https://www.apache.org/licenses/LICENSE-2.0"
@@ -18435,7 +18435,7 @@
             "ApiKeyQuery": []
           }
         ],
-        "summary": "Export Audit Logs",
+        "summary": "Download audit records",
         "tags": [
           "Admin"
         ]
@@ -27551,7 +27551,7 @@
             "content": {
               "application/geo+json": {
                 "schema": {
-                  "description": "OGC API Features compliant feature collection response.",
+                  "description": "FeatureCollection response as defined by OGC API - Features.",
                   "properties": {
                     "features": {
                       "description": "GeoJSON features returned by the query.",
@@ -51431,7 +51431,7 @@
             "description": "Internal server error"
           }
         },
-        "summary": "Edition Info",
+        "summary": "Get runtime capabilities",
         "tags": [
           "Admin"
         ]
@@ -51625,7 +51625,7 @@
             "ApiKeyQuery": []
           }
         ],
-        "summary": "Get Enterprise Only Tabs",
+        "summary": "List restricted settings tabs",
         "tags": [
           "Admin"
         ]

--- a/frontend/src/types/api.generated.ts
+++ b/frontend/src/types/api.generated.ts
@@ -122,7 +122,7 @@ export interface paths {
             cookie?: never;
         };
         /**
-         * Export Audit Logs
+         * Download audit records
          * @description Export up to 100,000 audit log rows as CSV or JSON.
          */
         get: operations["export_audit_logs_admin_audit_logs_export__format__get"];
@@ -4349,7 +4349,7 @@ export interface paths {
             cookie?: never;
         };
         /**
-         * Edition Info
+         * Get runtime capabilities
          * @description Return runtime capability metadata. Public, no auth required.
          */
         get: operations["edition_info_settings_edition__get"];
@@ -4389,7 +4389,7 @@ export interface paths {
             cookie?: never;
         };
         /**
-         * Get Enterprise Only Tabs
+         * List restricted settings tabs
          * @description Return the canonical list of restricted Settings tab keys.
          *
          *     The frontend AdminSidebar uses this to avoid rendering tabs that the

--- a/sdks/python/geolens/api/admin/edition_info_settings_edition_get.py
+++ b/sdks/python/geolens/api/admin/edition_info_settings_edition_get.py
@@ -60,7 +60,7 @@ def sync_detailed(
     *,
     client: AuthenticatedClient | Client,
 ) -> Response[EditionInfoResponse | ProblemDetail]:
-    """Edition Info
+    """Get runtime capabilities
 
      Return runtime capability metadata. Public, no auth required.
 
@@ -85,7 +85,7 @@ def sync(
     *,
     client: AuthenticatedClient | Client,
 ) -> EditionInfoResponse | ProblemDetail | None:
-    """Edition Info
+    """Get runtime capabilities
 
      Return runtime capability metadata. Public, no auth required.
 
@@ -106,7 +106,7 @@ async def asyncio_detailed(
     *,
     client: AuthenticatedClient | Client,
 ) -> Response[EditionInfoResponse | ProblemDetail]:
-    """Edition Info
+    """Get runtime capabilities
 
      Return runtime capability metadata. Public, no auth required.
 
@@ -129,7 +129,7 @@ async def asyncio(
     *,
     client: AuthenticatedClient | Client,
 ) -> EditionInfoResponse | ProblemDetail | None:
-    """Edition Info
+    """Get runtime capabilities
 
      Return runtime capability metadata. Public, no auth required.
 

--- a/sdks/python/geolens/api/admin/export_audit_logs_admin_audit_logs_export_format_get.py
+++ b/sdks/python/geolens/api/admin/export_audit_logs_admin_audit_logs_export_format_get.py
@@ -178,7 +178,7 @@ def sync_detailed(
     search: None | str | Unset = UNSET,
     max_rows: int | Unset = 100000,
 ) -> Response[Any | ProblemDetail]:
-    """Export Audit Logs
+    """Download audit records
 
      Export up to 100,000 audit log rows as CSV or JSON.
 
@@ -233,7 +233,7 @@ def sync(
     search: None | str | Unset = UNSET,
     max_rows: int | Unset = 100000,
 ) -> Any | ProblemDetail | None:
-    """Export Audit Logs
+    """Download audit records
 
      Export up to 100,000 audit log rows as CSV or JSON.
 
@@ -283,7 +283,7 @@ async def asyncio_detailed(
     search: None | str | Unset = UNSET,
     max_rows: int | Unset = 100000,
 ) -> Response[Any | ProblemDetail]:
-    """Export Audit Logs
+    """Download audit records
 
      Export up to 100,000 audit log rows as CSV or JSON.
 
@@ -336,7 +336,7 @@ async def asyncio(
     search: None | str | Unset = UNSET,
     max_rows: int | Unset = 100000,
 ) -> Any | ProblemDetail | None:
-    """Export Audit Logs
+    """Download audit records
 
      Export up to 100,000 audit log rows as CSV or JSON.
 

--- a/sdks/python/geolens/api/admin/get_enterprise_only_tabs_settings_enterprise_tabs_get.py
+++ b/sdks/python/geolens/api/admin/get_enterprise_only_tabs_settings_enterprise_tabs_get.py
@@ -90,7 +90,7 @@ def sync_detailed(
     *,
     client: AuthenticatedClient,
 ) -> Response[EnterpriseTabsResponse | ProblemDetail]:
-    """Get Enterprise Only Tabs
+    """List restricted settings tabs
 
      Return the canonical list of restricted Settings tab keys.
 
@@ -120,7 +120,7 @@ def sync(
     *,
     client: AuthenticatedClient,
 ) -> EnterpriseTabsResponse | ProblemDetail | None:
-    """Get Enterprise Only Tabs
+    """List restricted settings tabs
 
      Return the canonical list of restricted Settings tab keys.
 
@@ -146,7 +146,7 @@ async def asyncio_detailed(
     *,
     client: AuthenticatedClient,
 ) -> Response[EnterpriseTabsResponse | ProblemDetail]:
-    """Get Enterprise Only Tabs
+    """List restricted settings tabs
 
      Return the canonical list of restricted Settings tab keys.
 
@@ -174,7 +174,7 @@ async def asyncio(
     *,
     client: AuthenticatedClient,
 ) -> EnterpriseTabsResponse | ProblemDetail | None:
-    """Get Enterprise Only Tabs
+    """List restricted settings tabs
 
      Return the canonical list of restricted Settings tab keys.
 

--- a/sdks/python/geolens/models/get_collection_items_collections_dataset_id_items_get_ogc_feature_items_response.py
+++ b/sdks/python/geolens/models/get_collection_items_collections_dataset_id_items_get_ogc_feature_items_response.py
@@ -27,7 +27,7 @@ T = TypeVar(
 
 @_attrs_define
 class GetCollectionItemsCollectionsDatasetIdItemsGetOGCFeatureItemsResponse:
-    """OGC API Features compliant feature collection response.
+    """FeatureCollection response as defined by OGC API - Features.
 
     Attributes:
         features (list[GetCollectionItemsCollectionsDatasetIdItemsGetOGCFeatureItemsResponseFeaturesItem]): GeoJSON

--- a/sdks/typescript/src/client/sdk.gen.ts
+++ b/sdks/typescript/src/client/sdk.gen.ts
@@ -150,7 +150,7 @@ export const listAuditLogsAdminAuditLogsGet = <ThrowOnError extends boolean = fa
 });
 
 /**
- * Export Audit Logs
+ * Download audit records
  *
  * Export up to 100,000 audit log rows as CSV or JSON.
  */
@@ -4863,7 +4863,7 @@ export const detectEmbeddingDimsSettingsDetectEmbeddingDimsPost = <ThrowOnError 
 });
 
 /**
- * Edition Info
+ * Get runtime capabilities
  *
  * Return runtime capability metadata. Public, no auth required.
  */
@@ -4877,7 +4877,7 @@ export const editionInfoSettingsEditionGet = <ThrowOnError extends boolean = fal
 export const getEnabledPluginsSettingsEnabledPluginsGet = <ThrowOnError extends boolean = false>(options?: Options<GetEnabledPluginsSettingsEnabledPluginsGetData, ThrowOnError>): RequestResult<GetEnabledPluginsSettingsEnabledPluginsGetResponses, GetEnabledPluginsSettingsEnabledPluginsGetErrors, ThrowOnError> => (options?.client ?? client).get<GetEnabledPluginsSettingsEnabledPluginsGetResponses, GetEnabledPluginsSettingsEnabledPluginsGetErrors, ThrowOnError>({ url: '/settings/enabled-plugins/', ...options });
 
 /**
- * Get Enterprise Only Tabs
+ * List restricted settings tabs
  *
  * Return the canonical list of restricted Settings tab keys.
  *

--- a/sdks/typescript/src/client/types.gen.ts
+++ b/sdks/typescript/src/client/types.gen.ts
@@ -14455,7 +14455,7 @@ export type GetCollectionItemsCollectionsDatasetIdItemsGetResponses = {
     /**
      * OGCFeatureItemsResponse
      *
-     * OGC API Features compliant feature collection response.
+     * FeatureCollection response as defined by OGC API - Features.
      */
     200: {
         /**


### PR DESCRIPTION
An internal marketing-surface review found the raw OpenAPI spec still carries wording the deployed-surface gate bans from public copy — the gate scans rendered pages, never the spec itself, so these survived:

- Three auto-derived operation summaries that are banned ids in `scripts/deployed_surface_gate.json`: **"Edition Info"** (`edition_info_op`), **"Get Enterprise Only Tabs"** (`enterprise_tabs_op`), **"Export Audit Logs"** (`export_audit_op`). They render verbatim in the docs site's vendored API reference.
- Two description strings claiming a "standards-compliant" OGC API (`api/main.py` app description, `OGCFeatureItemsResponse` docstring) — the positioning rule is implements/serves framing, never compliance claims.

**Change:** explicit neutral `summary=` on the three routes ("Get runtime capabilities", "List restricted settings tabs", "Download audit records") and reworded descriptions. **operationIds, paths, schemas, and behavior are unchanged** — this is API metadata only.

**Regenerated artifacts** (all three, per the OpenAPI trilogy): `backend/openapi.json` (5 line-pairs), both SDKs (6 files, docstring-only churn, generated function names untouched), `frontend/src/types/api.generated.ts` (3 line-pairs).

**Verification:**
- `uv run ruff check` + `ruff format --check` on the five touched files — clean.
- Regenerated spec grep: all five banned strings gone.
- `sdks/typescript`: `npm run build` + `npm test` — 4/4 pass. (`make sdks-check` fails pre-commit by construction — it diffs regen output against HEAD — and will pass in CI once this lands.)
- Frontend `types:check` regen step run; only doc-comment lines changed.

The docs site's vendored spec copy picks this up at the next release sync. Companion copy fix for the docs prose (`exports.mdx` "standards-compliant" wording) is in getgeolens.com PR #60.
