### PR TITLE
test(e2e): add E2E_SKIP_SEED opt-out for host-backend stacks

### DIFF
--- a/e2e/README.md
+++ b/e2e/README.md
@@ -29,6 +29,14 @@ catalog-dependent flows. The cleanup project removes it after the browser tests
 finish, including failed runs. The API-only export suite manages its own fixture
 and does not require a browser install.
 
+Against a host-run backend (uvicorn on the host + docker Postgres), the seeding
+ingest cannot work — set `E2E_SKIP_SEED=1` to make setup authenticate and save
+storage state without creating the shared fixture:
+
+```bash
+E2E_SKIP_SEED=1 E2E_BASE_URL=http://localhost:5173 npx playwright test e2e/foo.spec.ts --project=chromium
+```
+
 ## Smoke groups
 
 The `e2e:smoke:*` scripts in the root `package.json` group specs by area

--- a/e2e/auth.setup.ts
+++ b/e2e/auth.setup.ts
@@ -55,6 +55,12 @@ setup('authenticate as admin', async ({ page }) => {
   // Save storage state (includes localStorage with auth token)
   await page.context().storageState({ path: authFile });
 
+  // fix(#547): host-backend stacks (uvicorn on the host + docker Postgres)
+  // cannot run the real ingest that seedDataset needs, so E2E_SKIP_SEED=1
+  // stops here — auth state is saved, no shared fixture is created, and
+  // catalog.teardown already no-ops when the manifest is absent.
+  if (process.env.E2E_SKIP_SEED === '1') return;
+
   // An interrupted local run may leave its manifest behind. Remove that
   // fixture before recording a replacement so repeated runs cannot orphan it.
   if (fs.existsSync(catalogFixtureFile)) {


### PR DESCRIPTION
Closes #547.

## What

`E2E_SKIP_SEED=1` makes `e2e/auth.setup.ts` authenticate and save storage state, then return before the shared catalog fixture is seeded. Documented in `e2e/README.md`.

## Why

Against a host-run backend (uvicorn on the host + docker Postgres — the standard worktree QA rig), the seeding ingest cannot work: the local storage adapter rejects the absolute staging path, so setup fails **after** `storageState` is written and every run needs the two-step `--no-deps` workaround (#547).

## Impact

- CI behavior unchanged (flag unset → identical code path).
- `catalog.teardown.ts` already no-ops when the manifest is absent, so cleanup is unaffected.
- No API/schema/config impact.

## Verification

- `E2E_SKIP_SEED=1 npx playwright test --project=setup` → 2 passed; `user.json` written, no `catalog-fixture.json` created, teardown no-oped.
- `npx playwright test --project=setup` (flag unset) → 2 passed; fixture seeded and removed by teardown as before.

https://claude.ai/code/session_013Q1gyuRm3QXKZL73eQ9UUV