### PR TITLE
fix: address post-1.4.8 audit P3 batch (#569)

### DIFF
--- a/backend/app/modules/catalog/features/schemas.py
+++ b/backend/app/modules/catalog/features/schemas.py
@@ -19,22 +19,32 @@ def inline_json_schema(model: type[BaseModel]) -> dict:
     the exported OpenAPI document, where pydantic's ``#/$defs/...`` pointers
     resolve against the document root and dangle — strict consumers (docs
     generators, ref bundlers) reject the whole document. Only safe for
-    non-recursive models; the GeoJSON models here are deliberately acyclic.
+    non-recursive models; a recursive model raises instead of looping
+    (fix(#569): cycle guard so a future self-referential model fails fast
+    with a clear error at import time rather than hanging).
     """
     schema = model.model_json_schema()
     defs = schema.pop("$defs", {})
 
-    def resolve(node: Any) -> Any:
+    def resolve(node: Any, expanding: frozenset[str] = frozenset()) -> Any:
         if isinstance(node, dict):
             ref = node.get("$ref")
             if isinstance(ref, str) and ref.startswith("#/$defs/"):
-                target = resolve(defs[ref.rsplit("/", 1)[-1]])
+                name = ref.rsplit("/", 1)[-1]
+                if name in expanding:
+                    raise ValueError(
+                        f"inline_json_schema({model.__name__}): recursive "
+                        f"$ref to {name!r}; only acyclic models can be inlined"
+                    )
+                target = resolve(defs[name], expanding | {name})
                 # Keep sibling keys (description, default) over the target's.
-                extras = {k: resolve(v) for k, v in node.items() if k != "$ref"}
+                extras = {
+                    k: resolve(v, expanding) for k, v in node.items() if k != "$ref"
+                }
                 return {**target, **extras}
-            return {k: resolve(v) for k, v in node.items()}
+            return {k: resolve(v, expanding) for k, v in node.items()}
         if isinstance(node, list):
-            return [resolve(item) for item in node]
+            return [resolve(item, expanding) for item in node]
         return node
 
     return resolve(schema)

--- a/backend/app/processing/ingest/parquet.py
+++ b/backend/app/processing/ingest/parquet.py
@@ -349,13 +349,19 @@ async def load_parquet_to_postgis(
 
     read_cols = [src for src, _, _, _ in plan] + ([geom_col] if geom_col else [])
 
+    if not insert_cols:
+        # fix(#569): geometry-only file loaded as non-spatial would silently
+        # publish an empty dataset — fail with a clear message instead.
+        from app.processing.ingest.ogr import IngestionError
+
+        raise IngestionError(
+            "Parquet file contains only a geometry column; loading it "
+            "without geometry would produce an empty dataset."
+        )
+
     async with async_session() as session:
         await session.execute(text(f"DROP TABLE IF EXISTS {tref}"))
         await session.execute(text(ddl))
-        if not insert_cols:
-            # geometry-only file loaded as non-spatial: nothing to insert.
-            await session.commit()
-            return
         # Blocking parquet decode runs in a thread per batch so the worker's
         # event loop (job heartbeats) stays responsive.
         batches = pf.iter_batches(batch_size=_INSERT_BATCH_ROWS, columns=read_cols)

--- a/backend/app/processing/ingest/tasks_common.py
+++ b/backend/app/processing/ingest/tasks_common.py
@@ -64,7 +64,7 @@ async def rename_pkey_to_match_table(session: "AsyncSession", table_name: str) -
     """
     from sqlalchemy import text
 
-    from app.processing.ingest.metadata import _qtable
+    from app.processing.ingest.metadata import _qtable, _sql_quote_ident
 
     schema = _current_tenant_schema()
     desired = f"{table_name[:58]}_pkey"
@@ -85,7 +85,8 @@ async def rename_pkey_to_match_table(session: "AsyncSession", table_name: str) -
                 await session.execute(
                     text(
                         f"ALTER TABLE {_qtable(table_name, schema=schema)} "
-                        f'RENAME CONSTRAINT "{current}" TO "{desired}"'
+                        f"RENAME CONSTRAINT {_sql_quote_ident(current)} "
+                        f"TO {_sql_quote_ident(desired)}"
                     )
                 )
     except Exception:  # broad: cosmetic rename must never fail the publish

--- a/backend/tests/test_api_contract_openapi.py
+++ b/backend/tests/test_api_contract_openapi.py
@@ -399,3 +399,17 @@ def test_openapi_has_no_dangling_local_ref_pointers() -> None:
 
     walk(spec, "")
     assert dangling == []
+
+
+def test_inline_json_schema_rejects_recursive_model() -> None:
+    """fix(#569): a self-referential model must fail fast, not loop forever."""
+    import pytest
+    from pydantic import BaseModel
+
+    from app.modules.catalog.features.schemas import inline_json_schema
+
+    class Node(BaseModel):
+        children: list["Node"] = []
+
+    with pytest.raises(ValueError, match="recursive"):
+        inline_json_schema(Node)

--- a/backend/tests/test_ingest_parquet.py
+++ b/backend/tests/test_ingest_parquet.py
@@ -56,6 +56,20 @@ def _write_plain_parquet(path) -> None:
     )
 
 
+@pytest.mark.anyio
+async def test_geometry_only_without_geometry_raises(tmp_path):
+    """fix(#569): geometry-only file + include_geometry=False must fail fast
+    instead of silently publishing an empty dataset."""
+    from shapely.geometry import Point
+
+    p = tmp_path / "geomonly.parquet"
+    pq.write_table(build_geoparquet_table([Point(0, 0).wkb], {}, []), p)
+    with pytest.raises(IngestionError, match="only a geometry column"):
+        await load_parquet_to_postgis(
+            str(p), "t_geomonly", schema="data", srid=4326, include_geometry=False
+        )
+
+
 class TestParquetValidation:
     def test_valid_parquet_passes(self, tmp_path):
         p = tmp_path / "ok.parquet"

--- a/frontend/src/components/admin/AdminSidebar.tsx
+++ b/frontend/src/components/admin/AdminSidebar.tsx
@@ -160,11 +160,13 @@ export function AdminSidebar() {
     // top-14 + height calc keep the viewport-fixed sidebar below the sticky
     // h-14 navbar: without the offset the navbar buries the sidebar header and
     // slides over the sidebar during macOS elastic overscroll.
+    // fix(#569): include env(safe-area-inset-top) so the sidebar header
+    // doesn't sit under the navbar by the inset on notched devices.
     <Sidebar
       collapsible="icon"
       variant="sidebar"
       side="left"
-      className="top-14 h-[calc(100svh-3.5rem)]"
+      className="top-[calc(3.5rem+env(safe-area-inset-top))] h-[calc(100svh-3.5rem-env(safe-area-inset-top))]"
     >
       <SidebarHeader className="px-4 py-3 group-data-[collapsible=icon]:hidden">
         <span className="eyebrow">{t('adminNav.admin')}</span>

--- a/frontend/src/components/dataset/DatasetChatPanel.tsx
+++ b/frontend/src/components/dataset/DatasetChatPanel.tsx
@@ -187,9 +187,12 @@ export function DatasetChatPanel({ datasetId, datasetTitle, showOpenInBuilder }:
   // bottom-10/end-16 (not bottom-6/end-6) clears the global ReportProblemHost
   // lifebuoy (fixed bottom-10 right-4 z-40, size-10 + count badge): same
   // baseline, 8px gap to its left, so neither the FAB nor the open dialog
-  // ever sits under the higher-z reporter.
+  // ever sits under the reporter (no spatial overlap, so the z-tie is moot).
+  // fix(#569): z-40 (was z-30) so the sticky z-40 PendingEditsBar can't cover
+  // the FAB when pending edits and AI chat coexist; this panel renders later
+  // in the DOM, so it wins the tie.
   return (
-    <div className="fixed bottom-10 end-16 z-30 flex flex-col items-end gap-2">
+    <div className="fixed bottom-10 end-16 z-40 flex flex-col items-end gap-2">
       {open && (
         <section
           role="dialog"

--- a/frontend/src/i18n/locales/es/dataset.json
+++ b/frontend/src/i18n/locales/es/dataset.json
@@ -753,8 +753,8 @@
     "draftLineage": "Redactar linaje",
     "draftQualityStatement": "Redactar declaración de calidad",
     "chat": {
-      "title": "Pregunta a la IA sobre este dataset",
-      "emptyHint": "Haz una pregunta sobre los datos de este dataset.",
+      "title": "Pregunta a la IA sobre este conjunto de datos",
+      "emptyHint": "Haz una pregunta sobre los datos de este conjunto de datos.",
       "readOnlyNote": "Las respuestas son de solo lectura; los datos nunca se modifican.",
       "placeholder": "Pregunta sobre estos datos...",
       "openInBuilder": "Abrir en el editor"

--- a/frontend/src/pages/PublicViewerPage.tsx
+++ b/frontend/src/pages/PublicViewerPage.tsx
@@ -83,10 +83,14 @@ export function PublicViewerPage() {
   if (isError || !data) {
     const isExpired = error instanceof ApiError && error.status === 410;
     return (
-      <>
+      // fix(#569): h-dvh column like the loading/main branches — SiteBanner +
+      // min-h-screen overflowed the viewport by the banner's height.
+      <div className="flex h-dvh flex-col">
       {!isEmbed && <SiteBanner />}
-      <div className="app-surface-gradient flex min-h-screen items-center justify-center px-6">
-        <div className="flex w-full max-w-xl flex-col items-center rounded-2xl border bg-background/95 p-8 text-center shadow-lg backdrop-blur">
+      <div className="app-surface-gradient flex min-h-0 flex-1 overflow-y-auto px-6">
+        {/* m-auto (not items-center on the parent) so a card taller than a
+            short viewport scrolls instead of clipping its top */}
+        <div className="m-auto flex w-full max-w-xl flex-col items-center rounded-2xl border bg-background/95 p-8 text-center shadow-lg backdrop-blur">
           {isExpired ? (
             <>
               <Clock className="size-10 text-muted-foreground" />
@@ -132,7 +136,7 @@ export function PublicViewerPage() {
           </div>
         </div>
       </div>
-      </>
+      </div>
     );
   }
 


### PR DESCRIPTION
Addresses the tractable items from #569 (post-1.4.8 audit P3 batch). Does not fully close the issue — see "Not addressed" below.

## Backend
- **`tasks_common.py` / `rename_pkey_to_match_table`**: constraint identifiers now quoted via the existing `_sql_quote_ident` helper instead of bare f-string quotes (hygiene; inputs are server-derived).
- **`features/schemas.py` / `inline_json_schema`**: cycle guard — a future self-referential model now raises `ValueError` with the model and `$def` name instead of looping forever at import time. Test added.
- **`ingest/parquet.py`**: a geometry-only parquet loaded with `include_geometry=False` now raises `IngestionError` (before touching the DB) instead of silently publishing an empty dataset. Test added.

## Frontend
- **`AdminSidebar.tsx`**: top offset and height calc now include `env(safe-area-inset-top)`, matching the `AppLayout` shell formula, so the sidebar header clears the navbar on notched devices. Desktop unchanged (inset resolves to 0; live-verified).
- **Dataset Ask-AI FAB** (`DatasetChatPanel.tsx`): `z-30` → `z-40` so the sticky `z-40` `PendingEditsBar` can no longer cover it; the panel renders later in the DOM so it wins the tie, and it still has no spatial overlap with the z-40 reporter lifebuoy.
- **`PublicViewerPage.tsx`** error/expired branch: now an `h-dvh` flex column like the loading/main branches, so `SiteBanner` no longer pushes the page past the viewport; the card uses `m-auto` inside an `overflow-y-auto` region so short viewports scroll instead of clipping the card top.
- **es locale**: `ai.chat` title/emptyHint now say "conjunto de datos" like the rest of the namespace.

## Ops
- **`infra/demo/cloud-init.yaml`**: stale `GEOLENS_VERSION demo-2026-06-24e` pin bumped to `v1.4.8` (the "bump to GA tag once cut" TODO in the old comment; the live demo redeploys via a separate path).

## Verified, no change needed
- **EDITIONS.md Enterprise claims** — all four ship: identity-provider role mapping (`group_role_mapping` gated as paid in core `auth/oauth/service.py`), ABAC (enterprise v0.3.1 `permission/policy.py` + `predicates.py`), publication approval workflows (enterprise v0.3.1 `workflow/policy.py` + `notify.py`), custom embed-token lifetimes (core `embed_tokens/service.py` locks Community to the 30-day default).

## Not addressed (stay open on #569)
- Parquet ingest total-row/cell-size cap — the issue itself defers this to a future ingest-budget pass.
- `test_search_tool_omits_samples_when_disabled` `-n4` flake — needs a PPI-class investigation, not a batch fix.
- docs-site connection-pool page sync — lives in the docs repo.

## Verification
- `cd backend && uv run ruff check . && uv run ruff format --check .` on touched files — clean.
- `uv run pytest tests/test_ingest_parquet.py tests/test_api_contract_openapi.py` — 36 passed (includes 2 new tests).
- `cd frontend && npm run lint && npm run typecheck` — clean; targeted vitest (26 files / 109 tests) and `npm run test:i18n` — pass.
- Browser smoke (dev stack, frontend restarted first): invalid share link renders the not-found card with zero viewport overflow (`scrollHeight === innerHeight`); admin sidebar sits flush below the navbar; dataset-page Ask-AI FAB renders at computed `z-index: 40`.

https://claude.ai/code/session_013Q1gyuRm3QXKZL73eQ9UUV