### PR TITLE
docs(github): prune shipped items from the starter-issues backlog

### DIFF
--- a/.github/GOOD_FIRST_ISSUES.md
+++ b/.github/GOOD_FIRST_ISSUES.md
@@ -14,16 +14,7 @@ discuss the approach first.
 
 ## Good first issues
 
-### 1. Document the migrate-container exit in the quickstart
-- **Area:** docs
-- **Files likely involved:** `.github/CONTRIBUTING.md`
-- **Acceptance criteria:** A short troubleshooting subsection explains that the
-  `migrate` service is expected to exit after it finishes (it is not a crash),
-  and how to read its logs with `docker compose logs migrate`.
-- **Test command:** n/a (docs) — proofread rendered Markdown.
-- **Design settled:** yes
-
-### 2. Add a README package-smoke snippet
+### 1. Add a README package-smoke snippet
 - **Area:** docs
 - **Files likely involved:** `README.md`, `.github/CONTRIBUTING.md`
 - **Acceptance criteria:** The docs show a short clean-environment smoke for
@@ -31,7 +22,7 @@ discuss the approach first.
 - **Test command:** n/a (docs).
 - **Design settled:** yes
 
-### 3. Add an SDK example for listing datasets
+### 2. Add an SDK example for listing datasets
 - **Area:** SDK
 - **Files likely involved:** `sdks/python/README.md`,
   `sdks/typescript/README.md`
@@ -40,16 +31,7 @@ discuss the approach first.
 - **Test command:** n/a (docs).
 - **Design settled:** yes
 
-### 4. Document the `&cols=` opt-in for low-zoom vector tiles
-- **Area:** spatial-interop
-- **Files likely involved:** `README.md` (or a docs pointer)
-- **Acceptance criteria:** A short note explains that attribute columns are
-  stripped below zoom 10 and that callers can append `&cols=<col>` to request
-  specific columns at low zoom.
-- **Test command:** n/a (docs).
-- **Design settled:** yes
-
-### 5. Add an `.env.example` comment for generated admin credentials
+### 3. Add an `.env.example` comment for generated admin credentials
 - **Area:** docs
 - **Files likely involved:** `.env.example`
 - **Acceptance criteria:** The generated admin password behavior is documented
@@ -57,27 +39,11 @@ discuss the approach first.
 - **Test command:** n/a (docs).
 - **Design settled:** yes
 
-### 6. Add a single-test-file example to the test docs
-- **Area:** docs
-- **Files likely involved:** `.github/CONTRIBUTING.md`
-- **Acceptance criteria:** The "Running tests" section shows how to run one
-  backend test file, e.g. `docker compose exec api pytest backend/tests/test_auth.py`.
-- **Test command:** n/a (docs) — verify the command runs.
-- **Design settled:** yes
-
-### 7. Show a friendlier empty state on the admin shared-maps page
-- **Area:** frontend
-- **Files likely involved:** `frontend/src/pages/admin/AdminSharedMapsPage.tsx`
-- **Acceptance criteria:** When there are no shared maps, the page renders a
-  clear empty-state message instead of a blank table.
-- **Test command:** `docker compose exec frontend npm test`
-- **Design settled:** yes
-
 ## Help wanted
 
 These are larger or less settled. Please discuss the approach before starting.
 
-### 8. Improve error messages for unsupported upload formats
+### 4. Improve error messages for unsupported upload formats
 - **Area:** backend
 - **Files likely involved:** `backend/app/` ingestion handlers, `backend/tests/`
 - **Acceptance criteria:** Uploading an unsupported file format returns a clear,
@@ -85,7 +51,7 @@ These are larger or less settled. Please discuss the approach before starting.
 - **Test command:** `docker compose exec api pytest -k ingest`
 - **Design settled:** no — agree the exact message and accepted-format list first.
 
-### 9. Add keyboard navigation to the layer stack
+### 5. Add keyboard navigation to the layer stack
 - **Area:** frontend
 - **Files likely involved:** Map Builder layer-stack components under
   `frontend/src/`
@@ -94,7 +60,7 @@ These are larger or less settled. Please discuss the approach before starting.
 - **Test command:** `docker compose exec frontend npm test`
 - **Design settled:** no — discuss the interaction model first.
 
-### 10. Document additional vector format support paths
+### 6. Document additional vector format support paths
 - **Area:** spatial-interop
 - **Files likely involved:** docs / README, `backend/app/` format adapters
 - **Acceptance criteria:** A doc captures which vector formats are supported and


### PR DESCRIPTION
Four of the seven "good first issues" in .github/GOOD_FIRST_ISSUES.md have already shipped, so a launch-week contributor picking one up would duplicate merged work. This prunes the shipped items and renumbers.

Removed, with where each shipped:

- **Document the migrate-container exit** — shipped in `.github/CONTRIBUTING.md:45` ("The migrate container exits -- that's expected", including the `docker compose logs migrate` guidance).
- **Document the `&cols=` opt-in for low-zoom vector tiles** — shipped in `README.md` (cols= note present).
- **Add a single-test-file example to the test docs** — shipped in `.github/CONTRIBUTING.md` (single-test-file command example present).
- **Friendlier empty state on admin shared-maps page** — shipped (`sharedMaps.empty` i18n key and empty-state render exist in `frontend/src`).

Kept as-is: the README package-smoke snippet and SDK listing examples (verified still absent), the `.env.example` generated-credentials comment (not re-verified this pass; remove in a follow-up if it shipped too), and the three help-wanted items.

Docs-only change; no code paths touched.

Verification: grepped each acceptance criterion against the current tree (citations above).