### PR TITLE
fix(frontend): parameterize nginx API upstream and resolver for non-compose deployments

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -285,6 +285,15 @@ LABEL org.opencontainers.image.licenses="Apache-2.0"
 
 USER root
 RUN apk upgrade --no-cache
+# The vhost ships as a template rendered into /tmp/geolens-nginx at startup
+# (envsubst of API_UPSTREAM/NGINX_RESOLVER — see frontend/docker-entrypoint.sh),
+# so the stock conf.d include must point at the rendered location. Remove the
+# base image's default vhost so nothing can serve if conf.d ever gets
+# re-included, and assert the include rewrite matched so a base-image layout
+# change fails this build instead of shipping an nginx with no server block.
+RUN rm -f /etc/nginx/conf.d/default.conf && \
+    sed -i 's|include /etc/nginx/conf\.d/\*\.conf;|include /tmp/geolens-nginx/*.conf;|' /etc/nginx/nginx.conf && \
+    grep -q 'include /tmp/geolens-nginx/\*\.conf;' /etc/nginx/nginx.conf
 USER nginx
 
 # Keep the built SPA immutable. The entrypoint copies it into /tmp at startup,
@@ -292,7 +301,7 @@ USER nginx
 # read-only production root filesystem without mutating image layers.
 COPY --from=frontend-build --chown=nginx:nginx /app/dist /opt/geolens/html
 COPY --from=frontend-build --chown=nginx:nginx /app/public/env-config.template.js /opt/geolens/html/env-config.template.js
-COPY frontend/nginx.conf /etc/nginx/conf.d/default.conf
+COPY frontend/nginx.conf /opt/geolens/default.conf.template
 COPY --chmod=755 frontend/docker-entrypoint.sh /docker-entrypoint.sh
 
 ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/frontend/docker-entrypoint.sh
+++ b/frontend/docker-entrypoint.sh
@@ -32,6 +32,12 @@ fi
 # which is 127.0.0.11 under Docker and the cluster DNS service on Kubernetes,
 # so the same image runs in both without configuration.
 API_UPSTREAM="${API_UPSTREAM:-http://api:8000}"
+# Codex P2 (#577): strip trailing slashes — a URI component in a variable
+# proxy_pass replaces the rewritten request URI wholesale, so a value like
+# http://api:8000/ would proxy every /api, raster, and embed request to "/".
+while [ "${API_UPSTREAM%/}" != "$API_UPSTREAM" ]; do
+  API_UPSTREAM="${API_UPSTREAM%/}"
+done
 if [ -z "${NGINX_RESOLVER:-}" ]; then
   NGINX_RESOLVER="$(awk '/^nameserver/ { print $2; exit }' /etc/resolv.conf 2>/dev/null || true)"
 fi

--- a/frontend/docker-entrypoint.sh
+++ b/frontend/docker-entrypoint.sh
@@ -27,10 +27,14 @@ fi
 # Render the nginx vhost from its template (see the TEMPLATE header in
 # frontend/nginx.conf). API_UPSTREAM points the /api, raster-tile, and embed
 # proxy blocks at the API service; NGINX_RESOLVER is the DNS server nginx uses
-# to re-resolve that hostname. Defaults preserve the Docker Compose topology:
-# the resolver falls back to the container's own /etc/resolv.conf nameserver,
-# which is 127.0.0.11 under Docker and the cluster DNS service on Kubernetes,
-# so the same image runs in both without configuration.
+# to re-resolve that hostname. The resolver default reads the container's own
+# /etc/resolv.conf nameserver (127.0.0.11 under Docker, cluster DNS on
+# Kubernetes) and needs no configuration anywhere. The upstream default
+# (http://api:8000) is compose-only: nginx's resolver does not apply
+# resolv.conf search domains, so on Kubernetes API_UPSTREAM must be set to
+# the api Service's fully qualified name
+# (e.g. http://geolens-api.<namespace>.svc.cluster.local:8000) — a short
+# service name will NXDOMAIN. The Helm chart passes exactly that.
 API_UPSTREAM="${API_UPSTREAM:-http://api:8000}"
 # Codex P2 (#577): strip trailing slashes — a URI component in a variable
 # proxy_pass replaces the rewritten request URI wholesale, so a value like

--- a/frontend/docker-entrypoint.sh
+++ b/frontend/docker-entrypoint.sh
@@ -24,5 +24,27 @@ if [ -n "${PUBLIC_APP_URL:-}" ]; then
   rm -f /tmp/index.html.new
 fi
 
+# Render the nginx vhost from its template (see the TEMPLATE header in
+# frontend/nginx.conf). API_UPSTREAM points the /api, raster-tile, and embed
+# proxy blocks at the API service; NGINX_RESOLVER is the DNS server nginx uses
+# to re-resolve that hostname. Defaults preserve the Docker Compose topology:
+# the resolver falls back to the container's own /etc/resolv.conf nameserver,
+# which is 127.0.0.11 under Docker and the cluster DNS service on Kubernetes,
+# so the same image runs in both without configuration.
+API_UPSTREAM="${API_UPSTREAM:-http://api:8000}"
+if [ -z "${NGINX_RESOLVER:-}" ]; then
+  NGINX_RESOLVER="$(awk '/^nameserver/ { print $2; exit }' /etc/resolv.conf 2>/dev/null || true)"
+fi
+NGINX_RESOLVER="${NGINX_RESOLVER:-127.0.0.11}"
+case "$NGINX_RESOLVER" in
+  \[*) ;;
+  *:*:*) NGINX_RESOLVER="[$NGINX_RESOLVER]" ;;  # bare IPv6 nameserver → nginx bracket syntax
+esac
+export API_UPSTREAM NGINX_RESOLVER
+mkdir -p /tmp/geolens-nginx
+envsubst '$API_UPSTREAM $NGINX_RESOLVER' \
+  < /opt/geolens/default.conf.template \
+  > /tmp/geolens-nginx/default.conf
+
 # Replace shell with nginx (PID 1).
 exec nginx -g 'daemon off;'

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -1,3 +1,10 @@
+# TEMPLATE: docker-entrypoint.sh renders this file with
+# `envsubst '$API_UPSTREAM $NGINX_RESOLVER'` into /tmp/geolens-nginx/default.conf
+# at container start. Exactly those two shell variables are substituted (compose
+# defaults: http://api:8000 / the container's own resolv.conf nameserver);
+# every other `$name` below is an nginx runtime variable and passes through
+# untouched. Do not add new `${...}` placeholders without extending the
+# envsubst allowlist in docker-entrypoint.sh.
 proxy_cache_path /var/cache/nginx/raster_cache levels=1:2 keys_zone=raster_cache:10m max_size=1g inactive=1h use_temp_path=off;
 
 # Bumped from 30r/m -> 600r/m: a single Mapbox/MapLibre map view loads
@@ -90,8 +97,8 @@ server {
         # the variable-interpolation pitfalls of `proxy_pass $upstream/path?query`
         # inside a regex location (nginx 1.29 silently drops the query
         # string in that case, so Titiler saw `?url=&` and 500'd).
-        resolver 127.0.0.11 valid=10s;
-        set $upstream_api http://api:8000;
+        resolver ${NGINX_RESOLVER} valid=10s;
+        set $upstream_api ${API_UPSTREAM};
         rewrite ^.*$ /tiles/raster-proxy/$dataset_id/$z/$x/$y.$fmt$is_args$args break;
         proxy_pass $upstream_api;
         proxy_set_header Host $http_host;
@@ -147,8 +154,8 @@ server {
     }
 
     location /api/ {
-        resolver 127.0.0.11 valid=10s;
-        set $upstream_api http://api:8000;
+        resolver ${NGINX_RESOLVER} valid=10s;
+        set $upstream_api ${API_UPSTREAM};
         rewrite ^/api/(.*) /$1 break;
         proxy_pass $upstream_api;
         # A3 (#315 follow-up): the FastAPI SecurityHeadersMiddleware already emits
@@ -248,8 +255,8 @@ server {
     # auth_request allows the shell to load.
     location = /_embed_frame_policy {
         internal;
-        resolver 127.0.0.11 valid=10s;
-        set $upstream_api http://api:8000;
+        resolver ${NGINX_RESOLVER} valid=10s;
+        set $upstream_api ${API_UPSTREAM};
         # Codex P1 (#338): the embed token lives in the `et` QUERY param of the
         # iframe URL (/m/<shareToken>?embed=true&et=<embedToken>), NOT the path
         # segment. Passing the path capture (the share token) made the policy


### PR DESCRIPTION
## What

The production frontend image is the app's edge nginx (it proxies `/api`, raster tiles, and the embed frame-policy subrequest), but its proxy target (`http://api:8000`) and DNS resolver (`127.0.0.11`, Docker's embedded DNS) were hardwired in `frontend/nginx.conf`. That made the image compose-only: on Kubernetes the resolver doesn't exist and the upstream name doesn't resolve, so every proxied path 502s. Found during the geolens-deployments Helm chart audit — the chart cannot route API traffic without this.

## How

The vhost now ships as a template rendered at container start:

- `docker-entrypoint.sh` envsubsts exactly `$API_UPSTREAM` and `$NGINX_RESOLVER` into `/tmp/geolens-nginx/default.conf` (allowlisted vars — all nginx runtime `$vars` pass through untouched, same mechanism as the existing `env-config.js` render).
- **Defaults preserve compose behavior byte-for-byte**: upstream `http://api:8000`; resolver falls back to the container's own `/etc/resolv.conf` nameserver, which *is* `127.0.0.11` under Docker networks and cluster DNS on Kubernetes — the resolver needs no configuration on either platform. The *upstream* default is compose-only: nginx's resolver ignores search domains, so Kubernetes deployments must set `API_UPSTREAM` to the api Service's fully qualified name (the Helm chart does). Bare IPv6 nameservers get nginx bracket syntax.
- Dockerfile points the stock `conf.d` include at the rendered location, removes the inert stock vhost, and build-time-asserts the include rewrite matched (base-image layout drift fails the build, not production).
- Rendering targets `/tmp`, so the read-only-root production filesystem posture is unchanged; no geolens-deploy compose changes needed.

## Verification

- Built the `frontend` image target and ran 15 container tests: compose-parity defaults on a user-defined network (resolver renders `127.0.0.11`, upstream `http://api:8000`, `nginx -t` passes, `GET /` 200, `env-config.js` rendered), k8s-style `API_UPSTREAM`/`NGINX_RESOLVER` overrides, restart idempotence, IPv6 resolver bracketing, no unrendered placeholders, nginx runtime vars intact. 15/15 pass.
- `pytest` source-scan suites that read `frontend/nginx.conf`/Dockerfile (`test_csp_sec020`, `test_nginx_apikey_log_scrub_sec006`, `test_phase_272_dockerfile`, `test_docker_audit_regressions`, `test_embed_frame_policy`): 38 passed.

## Consumers

The geolens-deployments chart (0.3.0, PR incoming) sets `API_UPSTREAM` to its api Service and relies on the resolv.conf resolver default.

https://claude.ai/code/session_013Q1gyuRm3QXKZL73eQ9UUV
