### PR TITLE
chore(release): bump to 1.4.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,36 @@ and releases use semantic versioning.
 
 ## [Unreleased]
 
+## [1.4.9] - 2026-07-18
+
+### Changed
+
+- **The frontend image can now front the API outside Docker Compose.** Its
+  bundled nginx renders its proxy configuration at container start, taking
+  the API upstream (`API_UPSTREAM`) and DNS resolver (`NGINX_RESOLVER`) from
+  the environment instead of hardwiring Docker-only values. Compose
+  deployments are unchanged (the defaults are identical); Kubernetes
+  deployments set `API_UPSTREAM` to the api Service's fully qualified name —
+  which the community Helm chart
+  ([geolens-deployments](https://github.com/geolens-io/geolens-deployments)
+  0.3.x) now does. Trailing slashes on `API_UPSTREAM` are stripped, and bare
+  IPv6 resolvers are bracketed.
+- The install script's ready banner now points at where the admin password
+  was configured, and README/SECURITY polish landed alongside it (badge
+  links, MCP server in the security-policy scope, an `/api/health` note).
+
+### Fixed
+
+- The public OpenAPI document no longer carries internal operation labels or
+  compliance-implying wording.
+- Post-1.4.8 audit follow-ups: geometry-only GeoParquet uploads fail with a
+  clear ingestion error instead of publishing an empty dataset; primary-key
+  rename migrations quote constraint identifiers; the admin sidebar clears
+  the navbar on notched devices; the dataset Ask-AI button is no longer
+  covered by the pending-edits bar; the public viewer's error page no longer
+  overflows when the site banner is shown; Spanish AI-chat wording is
+  consistent with the rest of the locale.
+
 ## [1.4.8] - 2026-07-18
 
 ### Added

--- a/backend/app/api/main.py
+++ b/backend/app/api/main.py
@@ -559,7 +559,7 @@ _is_production = settings.is_production
 # no metadata to read. We fall back to the current published line so import never
 # crashes. Keep this fallback in lockstep with backend/pyproject.toml — it is one
 # of the sites `make bump` rewrites.
-_FALLBACK_APP_VERSION = "1.4.8"
+_FALLBACK_APP_VERSION = "1.4.9"
 
 
 def _resolve_app_version() -> str:

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -17140,7 +17140,7 @@
     "summary": "PostGIS-native geospatial data catalog with OGC API Features and Records support",
     "termsOfService": "https://github.com/geolens-io/geolens/blob/main/LICENSE",
     "title": "GeoLens API",
-    "version": "1.4.8"
+    "version": "1.4.9"
   },
   "openapi": "3.1.0",
   "paths": {

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geolens-backend"
-version = "1.4.8"
+version = "1.4.9"
 description = "PostGIS-native GIS data catalog"
 # Docker image (Dockerfile) ships python:3.14-slim (see the Dockerfile FROM for
 # the exact patch pin) as the project's tested runtime.

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -865,7 +865,7 @@ wheels = [
 
 [[package]]
 name = "geolens-backend"
-version = "1.4.8"
+version = "1.4.9"
 source = { virtual = "." }
 dependencies = [
     { name = "alembic" },

--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "geolens-cli"
-version = "1.4.8"
+version = "1.4.9"
 description = "Apache-2.0 command-line interface for the GeoLens API. Login, scan, publish, and export STAC against any GeoLens instance."
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/docs-contract.json
+++ b/docs-contract.json
@@ -1,6 +1,6 @@
 {
   "_comment": "Canonical cross-surface facts for the GeoLens README, marketing site (getgeolens.com/src), and docs site (getgeolens.com/docs). Validated against scripts/install.sh + backend/pyproject.toml by scripts/check_docs_contract.py (geolens CI). The getgeolens.com repo vendors a copy and enforces the same `forbidden` list in its own CI. See docs-internal/DOC-CONSISTENCY-STRATEGY for the full design. Edit a fact ONCE here (and in its canonical source) — the gates make every surface follow.",
-  "version": "1.4.8",
+  "version": "1.4.9",
   "install": {
     "oneLiner": "curl -fsSL https://getgeolens.com/install.sh | sh",
     "sourceBuild": "bash scripts/install.sh",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.4.8",
+  "version": "1.4.9",
   "type": "module",
   "license": "Apache-2.0",
   "author": "Carto Concepts, LLC",

--- a/mcp/pyproject.toml
+++ b/mcp/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "geolens-mcp"
-version = "1.4.8"
+version = "1.4.9"
 description = "Apache-2.0 read-only Model Context Protocol (MCP) server for GeoLens. Lets coding agents discover datasets, inspect schemas, and ask spatial questions against any GeoLens instance."
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "geolens",
-  "version": "1.4.8",
+  "version": "1.4.9",
   "private": true,
   "license": "Apache-2.0",
   "author": "Carto Concepts, LLC",

--- a/sdks/python/.openapi-python-client.yaml
+++ b/sdks/python/.openapi-python-client.yaml
@@ -4,7 +4,7 @@ project_name_override: geolens
 package_name_override: geolens
 # Rewritten on every `make sdks` run by scripts/sync_sdk_versions.py to match
 # backend/openapi.json info.version. Do not edit by hand.
-package_version_override: 1.4.8
+package_version_override: 1.4.9
 
 # Cleaner enum output (matches our pydantic v2 backend's enum emission).
 literal_enums: true

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "geolens"
-version = "1.4.8"
+version = "1.4.9"
 description = "Auto-generated Python SDK for the GeoLens API. Typed clients with Bearer + API-key auth helpers."
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/sdks/typescript/package-lock.json
+++ b/sdks/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@geolens/sdk",
-  "version": "1.4.8",
+  "version": "1.4.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@geolens/sdk",
-      "version": "1.4.8",
+      "version": "1.4.9",
       "license": "Apache-2.0",
       "dependencies": {
         "@hey-api/client-fetch": "0.13.1"

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@geolens/sdk",
-  "version": "1.4.8",
+  "version": "1.4.9",
   "description": "Auto-generated TypeScript SDK for the GeoLens API. Typed clients with Bearer + API-key auth helpers.",
   "license": "Apache-2.0",
   "author": "Carto Concepts, LLC",


### PR DESCRIPTION
Release prep for **v1.4.9** (patch).

Version sites via `make bump VERSION=1.4.9`, CHANGELOG `## [1.4.9]` entry, OpenAPI snapshot + SDK regen. Local gates green: `make version-check`, `make openapi-check`, `make sdks-check`.

Notable content since v1.4.8: parameterized frontend nginx upstream/resolver for non-compose deployments (#577 — unblocks the Helm chart, geolens-deployments#1), OpenAPI label/wording neutralization (#573), post-1.4.8 audit P3 batch (#575), installer ready-banner hint (#572).

After merge: tag `v1.4.9` at the merge SHA per the release runbook (API-cut tag → three gated publishes → smoke-gated Release), then chart 0.3.1, installer + docs-site sync, demo redeploy.

https://claude.ai/code/session_013Q1gyuRm3QXKZL73eQ9UUV