### PR TITLE
feat(edge): deployment chart-enablement trio (#579, #580, #581)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -817,3 +817,10 @@ FRONTEND_PORT=8080
 # origin only when tiles are actually routed there.
 # Type: URL path or absolute URL | Default: /api
 # FRONTEND_TILE_BASE_URL=/api
+
+# [OPTIONAL] fix(#581): comma/space-separated CIDRs of proxies TRUSTED to set
+# X-Forwarded-For/-Proto (frontend service; e.g. Cloudflare's published ranges
+# when the site is proxied through Cloudflare). Empty keeps the edge nginx's
+# anti-spoofing overwrite: the direct peer is treated as the client.
+# Type: CIDR list | Default: empty
+# TRUSTED_PROXY_CIDRS=

--- a/backend/app/api/main.py
+++ b/backend/app/api/main.py
@@ -8,9 +8,13 @@ import structlog
 # docstring. Originally added inline for gh #101 (260508-rr5), now shared with
 # the worker (which had the same /tmp tmpfs problem during COG conversion).
 from app.core.config import settings
+from app.core.runtime.gdal_env import configure_gdal_s3_env
 from app.core.runtime.staging import redirect_tempfile_to_staging
 
 redirect_tempfile_to_staging(settings.upload_staging_dir)
+# fix(#579): before any GDAL/rasterio import — /vsis3/ reads need the custom
+# S3 endpoint derived into AWS_* env, and subprocesses inherit os.environ.
+configure_gdal_s3_env(settings)
 
 from fastapi import FastAPI, Request, status
 from fastapi.responses import JSONResponse

--- a/backend/app/core/runtime/gdal_env.py
+++ b/backend/app/core/runtime/gdal_env.py
@@ -1,0 +1,74 @@
+"""Derive GDAL's AWS_* config for /vsis3/ reads from the app's S3_* settings.
+
+fix(#579): with STORAGE_PROVIDER=s3 on an S3-compatible endpoint (MinIO, R2),
+stored raster assets resolve as /vsis3/<bucket>/<key> open-paths, but nothing
+told GDAL about the custom endpoint — /vsis3/ reads targeted the default AWS
+endpoint and failed. The application-side SDK honors S3_ENDPOINT /
+S3_ADDRESSING_STYLE, so only the GDAL read path was unaware.
+
+configure_gdal_s3_env() is called once at api and worker process start, before
+any GDAL/rasterio use. It applies values with os.environ.setdefault, so
+explicit operator-provided AWS_* env always wins, and GDAL subprocesses
+(gdal_safe_env, ogr2ogr) inherit them through os.environ. It copies no secret
+that is not already in the process env: AWS_SECRET_ACCESS_KEY mirrors the
+S3_SECRET_ACCESS_KEY env var the process was booted with.
+
+The titiler container is a separate process tree and cannot be configured
+here — the compose files derive the same trio in its command wrapper, and the
+Helm chart derives it at template time.
+"""
+
+import os
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from app.core.config import Settings
+
+
+def derive_gdal_s3_env(settings: "Settings") -> dict[str, str]:
+    """Return the AWS_* variables GDAL needs to read /vsis3/ paths.
+
+    Empty when the storage provider is not s3. Endpoint-specific keys
+    (AWS_S3_ENDPOINT, AWS_HTTPS) appear only for a custom S3_ENDPOINT;
+    AWS_VIRTUAL_HOSTING=FALSE only for path-style addressing (MinIO default).
+    """
+    if settings.storage_provider != "s3":
+        return {}
+
+    derived: dict[str, str] = {}
+    if settings.s3_access_key_id:
+        derived["AWS_ACCESS_KEY_ID"] = settings.s3_access_key_id
+    if settings.s3_secret_access_key:
+        derived["AWS_SECRET_ACCESS_KEY"] = (
+            settings.s3_secret_access_key.get_secret_value()
+        )
+    if settings.s3_region:
+        derived["AWS_DEFAULT_REGION"] = settings.s3_region
+
+    endpoint = (settings.s3_endpoint or "").strip()
+    if endpoint:
+        # GDAL wants a scheme-less host[:port]; the scheme maps to AWS_HTTPS.
+        # (GDAL >= 3.5.2 would accept a full URL, but the scheme-less form
+        # works on every GDAL the images ship.)
+        scheme, sep, rest = endpoint.partition("://")
+        host = rest if sep else endpoint
+        host = host.split("/", 1)[0]
+        if host:
+            derived["AWS_S3_ENDPOINT"] = host
+            if sep and scheme == "http":
+                derived["AWS_HTTPS"] = "NO"
+
+    if settings.s3_addressing_style == "path":
+        derived["AWS_VIRTUAL_HOSTING"] = "FALSE"
+
+    return derived
+
+
+def configure_gdal_s3_env(settings: "Settings") -> None:
+    """Apply the derived GDAL S3 config to the process environment.
+
+    setdefault semantics: an operator who already exports AWS_* env (or relies
+    on ambient AWS credentials with no custom endpoint) is left untouched.
+    """
+    for key, value in derive_gdal_s3_env(settings).items():
+        os.environ.setdefault(key, value)

--- a/backend/app/core/runtime/gdal_env.py
+++ b/backend/app/core/runtime/gdal_env.py
@@ -1,8 +1,8 @@
-"""Derive GDAL's AWS_* config for /vsis3/ reads from the app's S3_* settings.
+"""Derive GDAL's AWS_* config for its S3 VSI reads from the app's S3_* settings.
 
 fix(#579): with STORAGE_PROVIDER=s3 on an S3-compatible endpoint (MinIO, R2),
-stored raster assets resolve as /vsis3/<bucket>/<key> open-paths, but nothing
-told GDAL about the custom endpoint — /vsis3/ reads targeted the default AWS
+stored raster assets resolve as GDAL S3 VSI open-paths, but nothing told GDAL
+about the custom endpoint — those reads targeted the default AWS
 endpoint and failed. The application-side SDK honors S3_ENDPOINT /
 S3_ADDRESSING_STYLE, so only the GDAL read path was unaware.
 
@@ -26,7 +26,7 @@ if TYPE_CHECKING:
 
 
 def derive_gdal_s3_env(settings: "Settings") -> dict[str, str]:
-    """Return the AWS_* variables GDAL needs to read /vsis3/ paths.
+    """Return the AWS_* variables GDAL needs for its S3 VSI reads.
 
     Empty when the storage provider is not s3. Endpoint-specific keys
     (AWS_S3_ENDPOINT, AWS_HTTPS) appear only for a custom S3_ENDPOINT;

--- a/backend/app/core/runtime/gdal_env.py
+++ b/backend/app/core/runtime/gdal_env.py
@@ -49,13 +49,16 @@ def derive_gdal_s3_env(settings: "Settings") -> dict[str, str]:
     if endpoint:
         # GDAL wants a scheme-less host[:port]; the scheme maps to AWS_HTTPS.
         # (GDAL >= 3.5.2 would accept a full URL, but the scheme-less form
-        # works on every GDAL the images ship.)
+        # works on every GDAL the images ship.) Scheme resolution mirrors
+        # S3StorageProvider: an explicit scheme wins; a scheme-less endpoint
+        # is http exactly when S3_ALLOW_HTTP is set.
         scheme, sep, rest = endpoint.partition("://")
         host = rest if sep else endpoint
         host = host.split("/", 1)[0]
         if host:
             derived["AWS_S3_ENDPOINT"] = host
-            if sep and scheme == "http":
+            uses_http = scheme == "http" if sep else settings.s3_allow_http
+            if uses_http:
                 derived["AWS_HTTPS"] = "NO"
 
     if settings.s3_addressing_style == "path":

--- a/backend/app/platform/jobs/worker.py
+++ b/backend/app/platform/jobs/worker.py
@@ -18,6 +18,7 @@ from sqlalchemy import func, text, update
 
 from app.core.config import settings
 from app.core.logging_config import setup_logging
+from app.core.runtime.gdal_env import configure_gdal_s3_env
 from app.core.runtime.staging import (
     ensure_staging_ready,
     redirect_tempfile_to_staging,
@@ -30,6 +31,10 @@ from app.core.runtime.staging import (
 # `/tmp` tmpfs and rejects rasters that would fit fine on the multi-GB
 # staging volume. Mirrors the same redirect in `app.api.main`.
 redirect_tempfile_to_staging(settings.upload_staging_dir)
+
+# fix(#579): before any GDAL/rasterio use — /vsis3/ reads need the custom
+# S3 endpoint derived into AWS_* env, and GDAL subprocesses inherit os.environ.
+configure_gdal_s3_env(settings)
 
 # Configure structured logging with service label
 setup_logging(json_logs=settings.log_json, log_level=settings.log_level)

--- a/backend/tests/test_gdal_env.py
+++ b/backend/tests/test_gdal_env.py
@@ -1,0 +1,91 @@
+"""fix(#579): GDAL /vsis3/ AWS_* derivation from the app's S3_* settings."""
+
+from types import SimpleNamespace
+
+from pydantic import SecretStr
+
+from app.core.runtime.gdal_env import configure_gdal_s3_env, derive_gdal_s3_env
+
+
+def _s3_settings(**overrides):
+    base = dict(
+        storage_provider="s3",
+        s3_endpoint=None,
+        s3_access_key_id="test-access-key",
+        s3_secret_access_key=SecretStr("test-secret-key"),
+        s3_region="us-east-1",
+        s3_addressing_style="auto",
+    )
+    base.update(overrides)
+    return SimpleNamespace(**base)
+
+
+def test_non_s3_provider_derives_nothing():
+    assert derive_gdal_s3_env(_s3_settings(storage_provider="local")) == {}
+    assert derive_gdal_s3_env(_s3_settings(storage_provider="azure")) == {}
+
+
+def test_aws_proper_gets_creds_and_region_only():
+    derived = derive_gdal_s3_env(_s3_settings())
+    assert derived == {
+        "AWS_ACCESS_KEY_ID": "test-access-key",
+        "AWS_SECRET_ACCESS_KEY": "test-secret-key",
+        "AWS_DEFAULT_REGION": "us-east-1",
+    }
+
+
+def test_minio_style_endpoint_derives_full_trio():
+    derived = derive_gdal_s3_env(
+        _s3_settings(s3_endpoint="http://minio:9000", s3_addressing_style="path")
+    )
+    assert derived["AWS_S3_ENDPOINT"] == "minio:9000"
+    assert derived["AWS_HTTPS"] == "NO"
+    assert derived["AWS_VIRTUAL_HOSTING"] == "FALSE"
+
+
+def test_https_endpoint_leaves_https_default():
+    derived = derive_gdal_s3_env(
+        _s3_settings(s3_endpoint="https://account.r2.cloudflarestorage.com")
+    )
+    assert derived["AWS_S3_ENDPOINT"] == "account.r2.cloudflarestorage.com"
+    assert "AWS_HTTPS" not in derived
+    assert "AWS_VIRTUAL_HOSTING" not in derived
+
+
+def test_endpoint_path_suffix_and_schemeless_form_reduce_to_host():
+    assert (
+        derive_gdal_s3_env(_s3_settings(s3_endpoint="http://minio:9000/"))[
+            "AWS_S3_ENDPOINT"
+        ]
+        == "minio:9000"
+    )
+    schemeless = derive_gdal_s3_env(_s3_settings(s3_endpoint="minio:9000"))
+    assert schemeless["AWS_S3_ENDPOINT"] == "minio:9000"
+    assert "AWS_HTTPS" not in schemeless
+
+
+def test_empty_region_omits_default_region():
+    assert "AWS_DEFAULT_REGION" not in derive_gdal_s3_env(_s3_settings(s3_region=""))
+
+
+def test_configure_sets_missing_and_never_clobbers(monkeypatch):
+    for key in (
+        "AWS_ACCESS_KEY_ID",
+        "AWS_SECRET_ACCESS_KEY",
+        "AWS_DEFAULT_REGION",
+        "AWS_S3_ENDPOINT",
+        "AWS_HTTPS",
+        "AWS_VIRTUAL_HOSTING",
+    ):
+        monkeypatch.delenv(key, raising=False)
+    monkeypatch.setenv("AWS_S3_ENDPOINT", "operator-override:9000")
+
+    import os
+
+    configure_gdal_s3_env(
+        _s3_settings(s3_endpoint="http://minio:9000", s3_addressing_style="path")
+    )
+    assert os.environ["AWS_S3_ENDPOINT"] == "operator-override:9000"
+    assert os.environ["AWS_ACCESS_KEY_ID"] == "test-access-key"
+    assert os.environ["AWS_HTTPS"] == "NO"
+    assert os.environ["AWS_VIRTUAL_HOSTING"] == "FALSE"

--- a/backend/tests/test_gdal_env.py
+++ b/backend/tests/test_gdal_env.py
@@ -14,6 +14,7 @@ def _s3_settings(**overrides):
         s3_access_key_id="test-access-key",
         s3_secret_access_key=SecretStr("test-secret-key"),
         s3_region="us-east-1",
+        s3_allow_http=False,
         s3_addressing_style="auto",
     )
     base.update(overrides)
@@ -62,6 +63,19 @@ def test_endpoint_path_suffix_and_schemeless_form_reduce_to_host():
     schemeless = derive_gdal_s3_env(_s3_settings(s3_endpoint="minio:9000"))
     assert schemeless["AWS_S3_ENDPOINT"] == "minio:9000"
     assert "AWS_HTTPS" not in schemeless
+
+
+def test_schemeless_endpoint_honors_allow_http():
+    # Mirrors S3StorageProvider: scheme-less + S3_ALLOW_HTTP -> http endpoint.
+    derived = derive_gdal_s3_env(
+        _s3_settings(s3_endpoint="minio:9000", s3_allow_http=True)
+    )
+    assert derived["AWS_HTTPS"] == "NO"
+    # An explicit https scheme wins over allow_http, as in the provider.
+    explicit = derive_gdal_s3_env(
+        _s3_settings(s3_endpoint="https://minio:9000", s3_allow_http=True)
+    )
+    assert "AWS_HTTPS" not in explicit
 
 
 def test_empty_region_omits_default_region():

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -363,8 +363,30 @@ services:
     read_only: true
     tmpfs:
       - /tmp:size=128m,mode=1777
-    command: uvicorn titiler.application.main:app --host 0.0.0.0 --port 8000 --workers 1
+    # fix(#579): derive GDAL's AWS_* trio from the app's S3_* settings before
+    # exec'ing uvicorn — /vsis3/ reads against a custom endpoint (MinIO, R2)
+    # otherwise target the default AWS endpoint and fail. Mirrors the wrapper
+    # in docker-compose.yml ($$ escapes compose interpolation; explicitly set
+    # AWS_* env always wins).
+    command:
+      - /bin/sh
+      - -ec
+      - |
+        if [ -z "$${AWS_S3_ENDPOINT:-}" ]; then
+          ep="$${S3_ENDPOINT:-}"
+          case "$$ep" in
+            http://*)  export AWS_HTTPS="$${AWS_HTTPS:-NO}"; ep="$${ep#http://}" ;;
+            https://*) ep="$${ep#https://}" ;;
+          esac
+          ep="$${ep%%/*}"
+          [ -n "$$ep" ] && export AWS_S3_ENDPOINT="$$ep"
+        fi
+        [ "$${S3_ADDRESSING_STYLE:-auto}" = "path" ] && export AWS_VIRTUAL_HOSTING="$${AWS_VIRTUAL_HOSTING:-FALSE}"
+        exec uvicorn titiler.application.main:app --host 0.0.0.0 --port 8000 --workers 1
     environment:
+      # fix(#579): inputs for the AWS_* derivation in the command wrapper above.
+      S3_ENDPOINT: "${S3_ENDPOINT:-}"
+      S3_ADDRESSING_STYLE: "${S3_ADDRESSING_STYLE:-auto}"
       GDAL_CACHEMAX: "200"
       GDAL_DISABLE_READDIR_ON_OPEN: "EMPTY_DIR"
       CPL_VSIL_CURL_ALLOWED_EXTENSIONS: ".tif,.tiff,.cog,.vrt"
@@ -426,6 +448,13 @@ services:
       # Empty default on purpose: the api service's localhost fallback must not
       # leak into og:image; unset keeps the built relative URL.
       PUBLIC_APP_URL: "${PUBLIC_APP_URL:-}"
+      # fix(#580): keep the edge upload cap in lockstep with the backend's
+      # UPLOAD_MAX_SIZE_MB (same host var the api service reads).
+      CLIENT_MAX_BODY_SIZE: "${UPLOAD_MAX_SIZE_MB:-500}m"
+      # fix(#581): CIDRs of proxies trusted to set X-Forwarded-For/-Proto
+      # (e.g. Cloudflare's published ranges when fronted by Cloudflare).
+      # Empty keeps the anti-spoofing overwrite unchanged.
+      TRUSTED_PROXY_CIDRS: "${TRUSTED_PROXY_CIDRS:-}"
     healthcheck:
       test: ["CMD-SHELL", "wget --quiet --tries=1 --spider http://127.0.0.1:8080/ || exit 1"]
       interval: 30s

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -374,9 +374,13 @@ services:
       - |
         if [ -z "$${AWS_S3_ENDPOINT:-}" ]; then
           ep="$${S3_ENDPOINT:-}"
+          allow_http=$$(printf '%s' "$${S3_ALLOW_HTTP:-}" | tr '[:upper:]' '[:lower:]')
           case "$$ep" in
             http://*)  export AWS_HTTPS="$${AWS_HTTPS:-NO}"; ep="$${ep#http://}" ;;
             https://*) ep="$${ep#https://}" ;;
+            # scheme-less endpoint: http exactly when S3_ALLOW_HTTP is truthy,
+            # mirroring the app SDK's S3StorageProvider scheme resolution.
+            ?*) case "$$allow_http" in true|1|yes|on) export AWS_HTTPS="$${AWS_HTTPS:-NO}" ;; esac ;;
           esac
           ep="$${ep%%/*}"
           [ -n "$$ep" ] && export AWS_S3_ENDPOINT="$$ep"
@@ -386,6 +390,7 @@ services:
     environment:
       # fix(#579): inputs for the AWS_* derivation in the command wrapper above.
       S3_ENDPOINT: "${S3_ENDPOINT:-}"
+      S3_ALLOW_HTTP: "${S3_ALLOW_HTTP:-}"
       S3_ADDRESSING_STYLE: "${S3_ADDRESSING_STYLE:-auto}"
       GDAL_CACHEMAX: "200"
       GDAL_DISABLE_READDIR_ON_OPEN: "EMPTY_DIR"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -462,9 +462,13 @@ services:
       - |
         if [ -z "$${AWS_S3_ENDPOINT:-}" ]; then
           ep="$${S3_ENDPOINT:-}"
+          allow_http=$$(printf '%s' "$${S3_ALLOW_HTTP:-}" | tr '[:upper:]' '[:lower:]')
           case "$$ep" in
             http://*)  export AWS_HTTPS="$${AWS_HTTPS:-NO}"; ep="$${ep#http://}" ;;
             https://*) ep="$${ep#https://}" ;;
+            # scheme-less endpoint: http exactly when S3_ALLOW_HTTP is truthy,
+            # mirroring the app SDK's S3StorageProvider scheme resolution.
+            ?*) case "$$allow_http" in true|1|yes|on) export AWS_HTTPS="$${AWS_HTTPS:-NO}" ;; esac ;;
           esac
           ep="$${ep%%/*}"
           [ -n "$$ep" ] && export AWS_S3_ENDPOINT="$$ep"
@@ -474,6 +478,7 @@ services:
     environment:
       # fix(#579): inputs for the AWS_* derivation in the command wrapper above.
       S3_ENDPOINT: "${S3_ENDPOINT:-}"
+      S3_ALLOW_HTTP: "${S3_ALLOW_HTTP:-}"
       S3_ADDRESSING_STYLE: "${S3_ADDRESSING_STYLE:-auto}"
       # GDAL raster I/O tuning — these control how Titiler reads COG/VRT files
       GDAL_CACHEMAX: "200"                              # GDAL block cache in MB (default 5 — raise for concurrent tile requests)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -451,8 +451,30 @@ services:
     read_only: true
     tmpfs:
       - /tmp:size=128m,mode=1777
-    command: uvicorn titiler.application.main:app --host 0.0.0.0 --port 8000 --workers 1
+    # fix(#579): derive GDAL's AWS_* trio from the app's S3_* settings before
+    # exec'ing uvicorn — /vsis3/ reads against a custom endpoint (MinIO, R2)
+    # otherwise target the default AWS endpoint and fail. Compose has no
+    # string functions, so a sh wrapper does the scheme/host split ($$ escapes
+    # compose interpolation; the vars come from this container's environment).
+    command:
+      - /bin/sh
+      - -ec
+      - |
+        if [ -z "$${AWS_S3_ENDPOINT:-}" ]; then
+          ep="$${S3_ENDPOINT:-}"
+          case "$$ep" in
+            http://*)  export AWS_HTTPS="$${AWS_HTTPS:-NO}"; ep="$${ep#http://}" ;;
+            https://*) ep="$${ep#https://}" ;;
+          esac
+          ep="$${ep%%/*}"
+          [ -n "$$ep" ] && export AWS_S3_ENDPOINT="$$ep"
+        fi
+        [ "$${S3_ADDRESSING_STYLE:-auto}" = "path" ] && export AWS_VIRTUAL_HOSTING="$${AWS_VIRTUAL_HOSTING:-FALSE}"
+        exec uvicorn titiler.application.main:app --host 0.0.0.0 --port 8000 --workers 1
     environment:
+      # fix(#579): inputs for the AWS_* derivation in the command wrapper above.
+      S3_ENDPOINT: "${S3_ENDPOINT:-}"
+      S3_ADDRESSING_STYLE: "${S3_ADDRESSING_STYLE:-auto}"
       # GDAL raster I/O tuning — these control how Titiler reads COG/VRT files
       GDAL_CACHEMAX: "200"                              # GDAL block cache in MB (default 5 — raise for concurrent tile requests)
       GDAL_DISABLE_READDIR_ON_OPEN: "EMPTY_DIR"         # Skip directory listing on S3/HTTP — avoids slow LIST calls per tile

--- a/frontend/docker-entrypoint.sh
+++ b/frontend/docker-entrypoint.sh
@@ -50,9 +50,57 @@ case "$NGINX_RESOLVER" in
   \[*) ;;
   *:*:*) NGINX_RESOLVER="[$NGINX_RESOLVER]" ;;  # bare IPv6 nameserver → nginx bracket syntax
 esac
-export API_UPSTREAM NGINX_RESOLVER
+# fix(#580): /api/ upload cap, matching the backend's UPLOAD_MAX_SIZE_MB.
+# Deployment configs map that setting here with an "m" suffix; the default
+# preserves the previously hard-coded 500m. Guarded so an invalid value fails
+# fast at boot instead of crash-looping on an nginx config error.
+CLIENT_MAX_BODY_SIZE="${CLIENT_MAX_BODY_SIZE:-500m}"
+case "$CLIENT_MAX_BODY_SIZE" in
+  *[!0-9kKmMgG]* | "" | [!0-9]*)
+    echo "ERROR: CLIENT_MAX_BODY_SIZE must be a number with an optional k/m/g suffix, got: $CLIENT_MAX_BODY_SIZE" >&2
+    exit 1
+    ;;
+esac
+
+# fix(#581): trusted-proxy trust boundary (see the matching comment in the
+# vhost template). Unset TRUSTED_PROXY_CIDRS renders an identity map that
+# keeps $geolens_fwd_proto = $scheme — the previous hard-coded behavior.
+# A comma- or space-separated CIDR list renders realip directives that
+# recover the client address from X-Forwarded-For for exactly those hops,
+# plus a geo/map pair honoring X-Forwarded-Proto only from a trusted peer.
+# Entries are pinned to IP/CIDR characters so a malformed value cannot
+# smuggle nginx directives into the rendered config.
+TRUSTED_PROXY_CONFIG='map $scheme $geolens_fwd_proto { default $scheme; }'
+if [ -n "${TRUSTED_PROXY_CIDRS:-}" ]; then
+  realip_directives=""
+  geo_entries=""
+  for cidr in $(printf '%s' "$TRUSTED_PROXY_CIDRS" | tr ',' ' '); do
+    case "$cidr" in
+      *[!0-9a-fA-F:./]*)
+        echo "ERROR: invalid entry in TRUSTED_PROXY_CIDRS: $cidr" >&2
+        exit 1
+        ;;
+    esac
+    realip_directives="${realip_directives}set_real_ip_from ${cidr};
+"
+    geo_entries="${geo_entries}    ${cidr} 1;
+"
+  done
+  TRUSTED_PROXY_CONFIG="${realip_directives}real_ip_header X-Forwarded-For;
+real_ip_recursive on;
+geo \$realip_remote_addr \$geolens_peer_trusted {
+    default 0;
+${geo_entries}}
+map \"\$geolens_peer_trusted:\$http_x_forwarded_proto\" \$geolens_fwd_proto {
+    \"1:https\" https;
+    \"1:http\" http;
+    default \$scheme;
+}"
+fi
+
+export API_UPSTREAM NGINX_RESOLVER CLIENT_MAX_BODY_SIZE TRUSTED_PROXY_CONFIG
 mkdir -p /tmp/geolens-nginx
-envsubst '$API_UPSTREAM $NGINX_RESOLVER' \
+envsubst '$API_UPSTREAM $NGINX_RESOLVER $CLIENT_MAX_BODY_SIZE $TRUSTED_PROXY_CONFIG' \
   < /opt/geolens/default.conf.template \
   > /tmp/geolens-nginx/default.conf
 

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -1,10 +1,13 @@
-# TEMPLATE: docker-entrypoint.sh renders this file with
-# `envsubst '$API_UPSTREAM $NGINX_RESOLVER'` into /tmp/geolens-nginx/default.conf
-# at container start. Exactly those two shell variables are substituted (compose
-# defaults: http://api:8000 / the container's own resolv.conf nameserver);
-# every other `$name` below is an nginx runtime variable and passes through
-# untouched. Do not add new `${...}` placeholders without extending the
-# envsubst allowlist in docker-entrypoint.sh.
+# TEMPLATE: docker-entrypoint.sh renders this file with envsubst into
+# /tmp/geolens-nginx/default.conf at container start. Exactly four shell
+# variables are substituted — API_UPSTREAM, NGINX_RESOLVER,
+# CLIENT_MAX_BODY_SIZE, TRUSTED_PROXY_CONFIG (defaults: http://api:8000 /
+# the container's own resolv.conf nameserver / 500m / a pass-through map —
+# see the entrypoint); every other `$name` below is an nginx runtime variable
+# and passes through untouched. Do not add new `${...}` placeholders without
+# extending the envsubst allowlist in docker-entrypoint.sh — and never write
+# an allowlisted name with a `$` prefix in comments: envsubst substitutes
+# inside comments too, and a multi-line value would break the rendered config.
 proxy_cache_path /var/cache/nginx/raster_cache levels=1:2 keys_zone=raster_cache:10m max_size=1g inactive=1h use_temp_path=off;
 
 # Bumped from 30r/m -> 600r/m: a single Mapbox/MapLibre map view loads
@@ -32,6 +35,17 @@ log_format geolens_safe '$remote_addr - $remote_user [$time_local] '
                         'request_id=$request_id '
                         '"$request_method $geolens_safe_log_path $server_protocol" '
                         '$status $body_bytes_sent "$http_user_agent"';
+
+# fix(#581): trusted-proxy trust boundary, rendered by the entrypoint from
+# TRUSTED_PROXY_CIDRS. Unset (the default), this is only an identity map
+# defining $geolens_fwd_proto = $scheme — byte-equivalent to the previous
+# hard-coded behavior. When CIDRs are set (Kubernetes ingress, Cloudflare),
+# it renders set_real_ip_from/real_ip_header/real_ip_recursive so
+# $remote_addr, the raster rate-limit key, and access logs recover the real
+# client address from X-Forwarded-For — honoring ONLY the listed hops, so the
+# BA-01 anti-spoofing overwrite below stays intact — plus a geo/map pair that
+# honors X-Forwarded-Proto solely when the direct peer is a trusted proxy.
+${TRUSTED_PROXY_CONFIG}
 
 server {
     listen 8080;
@@ -114,7 +128,7 @@ server {
         # real_ip_header your edge sets) to restore real client IPs; do NOT
         # revert to $proxy_add_x_forwarded_for.
         proxy_set_header X-Forwarded-For $remote_addr;
-        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Proto $geolens_fwd_proto;
 
         # Pass through auth headers so the api can apply RBAC.
         proxy_set_header Authorization $http_authorization;
@@ -174,11 +188,14 @@ server {
         # bypass + forged audit IPs). $remote_addr is the real socket peer at this
         # internet-facing edge.
         proxy_set_header X-Forwarded-For $remote_addr;
-        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Proto $geolens_fwd_proto;
         proxy_set_header X-Accel-Buffering no;
         proxy_buffering off;
         proxy_cache off;
-        client_max_body_size 500m;
+        # fix(#580): tracks the backend's UPLOAD_MAX_SIZE_MB (default 500m) —
+        # a fixed 500m rejected larger configured uploads here with 413
+        # before FastAPI ever saw them.
+        client_max_body_size ${CLIENT_MAX_BODY_SIZE};
         proxy_read_timeout 600s;
         proxy_send_timeout 600s;
         proxy_connect_timeout 30s;
@@ -273,7 +290,7 @@ server {
         # bypass + forged audit IPs). $remote_addr is the real socket peer at this
         # internet-facing edge.
         proxy_set_header X-Forwarded-For $remote_addr;
-        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Proto $geolens_fwd_proto;
     }
 
     location / {

--- a/scripts/check_env_doc_drift.py
+++ b/scripts/check_env_doc_drift.py
@@ -149,7 +149,10 @@ def compose_host_keys(compose_files: tuple[Path, ...]) -> set[str]:
             for line in path.read_text().splitlines()
             if not line.lstrip().startswith("#")
         )
-        keys.update(re.findall(r"\$\{([A-Z][A-Z0-9_]*)", text))
+        # fix(#582): (?<!\$) skips $$-escaped references — Compose passes those
+        # through as literal ${...} for in-container shells (e.g. the titiler
+        # command wrapper), so they are not host inputs.
+        keys.update(re.findall(r"(?<!\$)\$\{([A-Z][A-Z0-9_]*)", text))
     return keys
 
 


### PR DESCRIPTION
Implements the three chart-enablement issues flagged during the Helm chart 0.3.0 review (geolens-deployments#1). All three ride the #577 vhost-template machinery; defaults are byte-preserving, every knob is a plain container env var — nothing couples to compose or Kubernetes, so ECS/EC2/Cloud Run task definitions can set them like any other env.

## Fixes #579 — GDAL never saw custom S3 endpoints (MinIO/R2)

- New `app/core/runtime/gdal_env.py`: `configure_gdal_s3_env()` derives `AWS_S3_ENDPOINT` (scheme-less host[:port]), `AWS_HTTPS=NO` for http endpoints, `AWS_VIRTUAL_HOSTING=FALSE` for path-style addressing, plus `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY`/`AWS_DEFAULT_REGION` from the existing `S3_*` settings. Called at api and worker process start with `os.environ.setdefault` semantics — explicit operator `AWS_*` env (or ambient-credential setups) always wins, and GDAL subprocesses (`gdal_safe_env`, ogr2ogr) inherit through `os.environ`. No secret enters the environment that wasn't already there as `S3_SECRET_ACCESS_KEY`.
- The titiler container is a separate process tree, so the compose service derives the same trio in a `sh` command wrapper (compose has no string functions). Same operator-override-wins guards.

## Fixes #580 — `client_max_body_size` was baked at 500m

`CLIENT_MAX_BODY_SIZE` template var, default `500m` (unchanged). Deployment configs map `UPLOAD_MAX_SIZE_MB` here with an `m` suffix. Invalid values fail fast at boot with a clear error instead of crash-looping on an nginx config error.

## Fixes #581 — forwarded headers overwritten even behind trusted proxies

`TRUSTED_PROXY_CIDRS` (comma/space-separated). Unset renders an identity map — byte-equivalent to today's BA-01 overwrite. When set, the entrypoint renders `set_real_ip_from` per CIDR + `real_ip_header X-Forwarded-For` + `real_ip_recursive on`, so `$remote_addr`, the anonymous raster rate-limit key, and access logs recover the real client from XFF honoring only the listed hops, plus a `geo $realip_remote_addr`/`map` pair that honors `X-Forwarded-Proto` solely when the direct peer is a trusted proxy. Entries are charset-pinned (`0-9a-fA-F:./`) so env values cannot smuggle nginx directives into the rendered config; malformed entries abort boot.

Also hardened the template header comment: envsubst substitutes inside comments too, so allowlisted variable names must never appear with a `$` prefix in comments (a multi-line value there breaks the rendered config — caught by the container tests below).

## Verification

- 7 new unit tests for the derivation (`backend/tests/test_gdal_env.py`); ruff clean; `tests/test_layering.py` green.
- 30/30 container tests on the built frontend image: default render parity (500m, identity proto map, no realip), `CLIENT_MAX_BODY_SIZE=2g` render + `nginx -t`, invalid-value boot rejection, dual-CIDR (IPv4+IPv6) realip/geo/map render + `nginx -t`, directive-injection rejection, plus the pre-existing #577 suite (resolver/upstream/IPv6/restart).
- Functional realip check: with `TRUSTED_PROXY_CIDRS` covering the docker bridge, a request carrying `X-Forwarded-For: 203.0.113.9` logs `203.0.113.9`; headerless direct traffic still logs the socket peer.
- `docker compose config` parses; titiler wrapper renders correctly with `S3_ENDPOINT`/`S3_ADDRESSING_STYLE` set.

Consumers (next steps, separate repos): prod compose wiring in geolens-deploy; Helm chart values (`frontend.trustedProxyCidrs`, `uploadMaxSizeMb` mapping, titiler template-time derivation) once these ship in a release.

https://claude.ai/code/session_013Q1gyuRm3QXKZL73eQ9UUV