### PR TITLE
fix: dataset-page tab occlusion by the AI chat panel + reliable builder popup custom fields

### DIFF
--- a/frontend/src/components/builder/BuilderMap.tsx
+++ b/frontend/src/components/builder/BuilderMap.tsx
@@ -928,6 +928,7 @@ export const BuilderMap = memo(function BuilderMap({
           columnInfo: layer.dataset_column_info ?? null,
           title: cfg?.expression ? substitutePopupTemplate(cfg.expression, props) : null,
           visibleFields: cfg?.visible_fields ?? null,
+          zoomAtClick: map.getZoom(),
         });
       }
 

--- a/frontend/src/components/builder/__tests__/map-sync.tile-refresh.test.ts
+++ b/frontend/src/components/builder/__tests__/map-sync.tile-refresh.test.ts
@@ -30,8 +30,19 @@ function createMockMap() {
     getSource: vi.fn((id: string) => sources.get(id) ?? null),
     addSource: vi.fn((id: string, spec: { type: string; tiles?: string[] }) => {
       // Vector sources expose setTiles in MapLibre — mirror that so the refresh
-      // path under test can be exercised and counted.
-      sources.set(id, spec.type === 'vector' ? { ...spec, setTiles: vi.fn() } : { ...spec });
+      // path under test can be exercised and counted. Real setTiles adopts the
+      // new URL asynchronously (load() copies _options.tiles → source.tiles);
+      // the mock adopts on the NEXT 50ms timer tick so the fix(#584)
+      // adoption-gated refresh has something realistic to wait for.
+      if (spec.type === 'vector') {
+        const src: { type: string; tiles?: string[]; setTiles?: ReturnType<typeof vi.fn> } = { ...spec };
+        src.setTiles = vi.fn((tiles: string[]) => {
+          setTimeout(() => { src.tiles = tiles; }, 50);
+        });
+        sources.set(id, src);
+      } else {
+        sources.set(id, { ...spec });
+      }
     }),
     removeSource: vi.fn((id: string) => { sources.delete(id); }),
     addLayer: vi.fn((layer: { id: string }) => { layerIds.add(layer.id); }),
@@ -145,13 +156,20 @@ describe('syncLayersToMap non-cluster vector tile refresh guard', () => {
       expect(setTiles).toHaveBeenCalledTimes(1);
       expect(setTiles).toHaveBeenCalledWith([expect.stringContaining('cols=borough')]);
 
-      // ...and the reload backstop is deferred to a macrotask (after the
-      // source's async load() adopts the new URL), because maplibre 5.x drops
-      // setTiles' own reload when the TileManager is paused.
+      // ...and the reload backstop waits for the source to ADOPT the new URL
+      // (maplibre's async load() copies it into source.tiles) before calling
+      // refreshTiles — refreshing earlier would reload the OLD url while the
+      // signature store has already advanced (codex #586 P2), re-stranding
+      // the tiles. The mock adopts at +50ms.
       const refreshTiles = (map as unknown as { refreshTiles: ReturnType<typeof vi.fn> }).refreshTiles;
       expect(refreshTiles).not.toHaveBeenCalled();
-      vi.runAllTimers();
+      vi.advanceTimersByTime(1); // the t=0 probe runs pre-adoption → must NOT refresh yet
+      expect(refreshTiles).not.toHaveBeenCalled();
+      vi.advanceTimersByTime(200); // adoption at +50, retry probe at +101 → refresh
+      expect(refreshTiles).toHaveBeenCalledTimes(1);
       expect(refreshTiles).toHaveBeenCalledWith(sourceId);
+      vi.runAllTimers(); // no further probes fire after success
+      expect(refreshTiles).toHaveBeenCalledTimes(1);
     } finally {
       vi.useRealTimers();
     }

--- a/frontend/src/components/builder/__tests__/map-sync.tile-refresh.test.ts
+++ b/frontend/src/components/builder/__tests__/map-sync.tile-refresh.test.ts
@@ -159,7 +159,7 @@ describe('syncLayersToMap non-cluster vector tile refresh guard', () => {
       // ...and the reload backstop waits for the source to ADOPT the new URL
       // (maplibre's async load() copies it into source.tiles) before calling
       // refreshTiles — refreshing earlier would reload the OLD url while the
-      // signature store has already advanced (codex #586 P2), re-stranding
+      // signature store has already advanced (fix(#586)), re-stranding
       // the tiles. The mock adopts at +50ms.
       const refreshTiles = (map as unknown as { refreshTiles: ReturnType<typeof vi.fn> }).refreshTiles;
       expect(refreshTiles).not.toHaveBeenCalled();

--- a/frontend/src/components/builder/__tests__/map-sync.tile-refresh.test.ts
+++ b/frontend/src/components/builder/__tests__/map-sync.tile-refresh.test.ts
@@ -44,6 +44,7 @@ function createMockMap() {
     setFilter: vi.fn(),
     getFilter: vi.fn().mockReturnValue(null),
     isStyleLoaded: vi.fn(() => true),
+    refreshTiles: vi.fn(),
     getStyle: vi.fn(() => ({ layers: Array.from(layerIds).map((id) => ({ id })) })),
     moveLayer: vi.fn(),
     setLayerZoomRange: vi.fn(),
@@ -121,5 +122,38 @@ describe('syncLayersToMap non-cluster vector tile refresh guard', () => {
     // Re-syncing the labeled layer with no further change must not refetch again.
     syncLayersToMap(map, [labeled], tokens, undefined, managed, order);
     expect(setTiles).toHaveBeenCalledTimes(1);
+  });
+
+  it('fix(#584): popup visible_fields ride cols= and the reload is re-issued via refreshTiles on a macrotask', () => {
+    vi.useFakeTimers();
+    try {
+      const map = createMockMap();
+      const managed = { current: new Set<string>() };
+      const order = { current: '' };
+      const layer = makeLayer();
+      const tokens = new Map<string, TileToken>([[layer.dataset_id, makeVectorToken()]]);
+      const sourceId = getSourceIdForLayer(layer);
+
+      syncLayersToMap(map, [layer], tokens, undefined, managed, order); // create
+      const setTiles = getSetTiles(map, sourceId)!;
+
+      // Selecting a popup field changes the cols= set → setTiles fires...
+      const withPopup = makeLayer({
+        popup_config: { enabled: true, expression: null, visible_fields: ['borough'] },
+      });
+      syncLayersToMap(map, [withPopup], tokens, undefined, managed, order);
+      expect(setTiles).toHaveBeenCalledTimes(1);
+      expect(setTiles).toHaveBeenCalledWith([expect.stringContaining('cols=borough')]);
+
+      // ...and the reload backstop is deferred to a macrotask (after the
+      // source's async load() adopts the new URL), because maplibre 5.x drops
+      // setTiles' own reload when the TileManager is paused.
+      const refreshTiles = (map as unknown as { refreshTiles: ReturnType<typeof vi.fn> }).refreshTiles;
+      expect(refreshTiles).not.toHaveBeenCalled();
+      vi.runAllTimers();
+      expect(refreshTiles).toHaveBeenCalledWith(sourceId);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/frontend/src/components/builder/map-sync.ts
+++ b/frontend/src/components/builder/map-sync.ts
@@ -494,6 +494,21 @@ export function refreshVectorSourceTiles(map: MaplibreMap, sourceId: string, til
   if (store.get(sourceId) === tileUrl) return false;
   source.setTiles([tileUrl]);
   store.set(sourceId, tileUrl);
+  // fix(#584): maplibre 5.x silently drops setTiles' tile reload when the
+  // source's TileManager is paused (any same-pass layer update pauses it):
+  // the 'content' data event returns early without setting the
+  // reload-on-resume flag, so loaded tiles keep serving the pre-edit cols=
+  // payload until an unrelated re-tile. Re-issue the reload through the
+  // public refreshTiles API on a macrotask (after the source's async load()
+  // has adopted the new URL) — that path DOES set the resume flag, so the
+  // refetch can no longer be lost.
+  setTimeout(() => {
+    try {
+      (map as MaplibreMap & { refreshTiles?: (id: string) => void }).refreshTiles?.(sourceId);
+    } catch {
+      /* source or style torn down before the timer fired */
+    }
+  }, 0);
   return true;
 }
 

--- a/frontend/src/components/builder/map-sync.ts
+++ b/frontend/src/components/builder/map-sync.ts
@@ -501,7 +501,7 @@ export function refreshVectorSourceTiles(map: MaplibreMap, sourceId: string, til
   // payload until an unrelated re-tile. Re-issue the reload through the
   // public refreshTiles API — that path DOES set the resume flag, so the
   // refetch can no longer be lost. The refresh must wait until the source's
-  // async load() has copied the new URL into `source.tiles` (codex #586 P2:
+  // async load() has copied the new URL into `source.tiles` (fix(#586):
   // refreshing before adoption reloads the OLD url while the signature store
   // has already advanced, re-stranding the tiles), so poll for adoption with
   // a bounded retry that bails when the url is superseded by a newer edit or

--- a/frontend/src/components/builder/map-sync.ts
+++ b/frontend/src/components/builder/map-sync.ts
@@ -499,16 +499,28 @@ export function refreshVectorSourceTiles(map: MaplibreMap, sourceId: string, til
   // the 'content' data event returns early without setting the
   // reload-on-resume flag, so loaded tiles keep serving the pre-edit cols=
   // payload until an unrelated re-tile. Re-issue the reload through the
-  // public refreshTiles API on a macrotask (after the source's async load()
-  // has adopted the new URL) — that path DOES set the resume flag, so the
-  // refetch can no longer be lost.
-  setTimeout(() => {
-    try {
-      (map as MaplibreMap & { refreshTiles?: (id: string) => void }).refreshTiles?.(sourceId);
-    } catch {
-      /* source or style torn down before the timer fired */
+  // public refreshTiles API — that path DOES set the resume flag, so the
+  // refetch can no longer be lost. The refresh must wait until the source's
+  // async load() has copied the new URL into `source.tiles` (codex #586 P2:
+  // refreshing before adoption reloads the OLD url while the signature store
+  // has already advanced, re-stranding the tiles), so poll for adoption with
+  // a bounded retry that bails when the url is superseded by a newer edit or
+  // the source is torn down.
+  const awaitAdoptionThenRefresh = (attempt: number) => {
+    if (store.get(sourceId) !== tileUrl) return; // superseded by a newer edit
+    const src = map.getSource(sourceId) as { tiles?: string[] } | undefined;
+    if (!src) return; // source removed
+    if (src.tiles?.[0] === tileUrl) {
+      try {
+        (map as MaplibreMap & { refreshTiles?: (id: string) => void }).refreshTiles?.(sourceId);
+      } catch {
+        /* style torn down between the check and the refresh */
+      }
+      return;
     }
-  }, 0);
+    if (attempt < 40) setTimeout(() => awaitAdoptionThenRefresh(attempt + 1), 100);
+  };
+  setTimeout(() => awaitAdoptionThenRefresh(0), 0);
   return true;
 }
 

--- a/frontend/src/components/dataset/DatasetChatPanel.tsx
+++ b/frontend/src/components/dataset/DatasetChatPanel.tsx
@@ -102,11 +102,13 @@ export function DatasetChatPanel({ datasetId, datasetTitle, showOpenInBuilder, o
 
   // fix(#583): keep the page informed so it can reflow content clear of the
   // fixed panel. Effect (not inline in the setOpen calls) so unmount while
-  // open also reports closed.
+  // open also reports closed. ANDed with availability — if AI availability
+  // flips off while open, the render below bails to null but the component
+  // stays mounted, and the page must not keep padding for an invisible panel.
   useEffect(() => {
-    onOpenChange?.(open);
+    onOpenChange?.(open && isAIAvailable);
     return () => onOpenChange?.(false);
-  }, [open, onOpenChange]);
+  }, [open, isAIAvailable, onOpenChange]);
 
   const handleSend = useCallback(async () => {
     const userMsg = input.trim();

--- a/frontend/src/components/dataset/DatasetChatPanel.tsx
+++ b/frontend/src/components/dataset/DatasetChatPanel.tsx
@@ -52,6 +52,10 @@ interface DatasetChatPanelProps {
   /** fix(#531): non-spatial tables can chat but have no map-layer flow —
    * the rest of the UI (AddToMapButton) hides builder handoffs for them. */
   showOpenInBuilder: boolean;
+  /** fix(#583): notifies the page when the panel opens/closes so it can pad
+   * its content clear of the fixed panel (which otherwise covers the sticky
+   * detail tabs and other controls). */
+  onOpenChange?: (open: boolean) => void;
 }
 
 /**
@@ -68,7 +72,7 @@ interface DatasetChatPanelProps {
  * Self-gates on `useAIAvailability` (token + `use_ai_chat` + AI configured),
  * so anonymous or unpermitted visitors render nothing.
  */
-export function DatasetChatPanel({ datasetId, datasetTitle, showOpenInBuilder }: DatasetChatPanelProps) {
+export function DatasetChatPanel({ datasetId, datasetTitle, showOpenInBuilder, onOpenChange }: DatasetChatPanelProps) {
   const { t, i18n } = useTranslation('dataset');
   const navigate = useNavigate();
   const { isAIAvailable } = useAIAvailability();
@@ -95,6 +99,14 @@ export function DatasetChatPanel({ datasetId, datasetTitle, showOpenInBuilder }:
   useEffect(() => {
     if (open) requestAnimationFrame(() => inputRef.current?.focus());
   }, [open]);
+
+  // fix(#583): keep the page informed so it can reflow content clear of the
+  // fixed panel. Effect (not inline in the setOpen calls) so unmount while
+  // open also reports closed.
+  useEffect(() => {
+    onOpenChange?.(open);
+    return () => onOpenChange?.(false);
+  }, [open, onOpenChange]);
 
   const handleSend = useCallback(async () => {
     const userMsg = input.trim();

--- a/frontend/src/components/map/FeaturePopup.tsx
+++ b/frontend/src/components/map/FeaturePopup.tsx
@@ -134,9 +134,11 @@ export function FeaturePopup({
   const visibleEntries = useMemo<[string, unknown][]>(() => {
     if (visibleFields !== undefined && visibleFields !== null) {
       const propMap = new Map(baseEntries);
-      return visibleFields
-        .filter((k) => propMap.has(k))
-        .map((k) => [k, propMap.get(k)] as [string, unknown]);
+      // fix(#584): render EVERY configured field. ST_AsMVT omits null-valued
+      // properties from the tile, so intersecting with the present keys
+      // silently hid configured fields that are null on the clicked feature —
+      // formatValue's '--' placeholder was unreachable.
+      return visibleFields.map((k) => [k, propMap.get(k)] as [string, unknown]);
     }
     if (columnInfo) {
       const columnNames = new Set(columnInfo.map((c) => c.name));
@@ -246,7 +248,15 @@ export function FeaturePopup({
         {/* Properties */}
         <div className="max-h-48 overflow-y-auto">
           {visibleEntries.length === 0 ? (
-            <p className="text-xs text-muted-foreground py-1">{t('featurePopup.noAttributes')}</p>
+            <p className="text-xs text-muted-foreground py-1">
+              {/* fix(#584): at z<10 the tile server strips attribute columns
+                  unless opted in via cols=; in all-fields mode nothing is
+                  opted in, so a dataset WITH columns arriving property-less
+                  means "zoom in", not "no attributes". */}
+              {(columnInfo?.length ?? 0) > 0
+                ? t('featurePopup.zoomForAttributes')
+                : t('featurePopup.noAttributes')}
+            </p>
           ) : (
             <table className="w-full">
               <tbody>

--- a/frontend/src/components/map/FeaturePopup.tsx
+++ b/frontend/src/components/map/FeaturePopup.tsx
@@ -18,7 +18,15 @@ export interface FeatureInfo {
   /** Ordered allowlist of property keys to display; null/undefined → fall
    *  back to columnInfo legacy default; [] → render zero rows. */
   visibleFields?: string[] | null;
+  /** Map zoom when the feature was clicked — distinguishes low-zoom
+   *  attribute stripping ("zoom in" hint) from a feature whose values are
+   *  genuinely all null ("no attributes"). */
+  zoomAtClick?: number;
 }
+
+/** MVT attribute budget (backend Phase 269 H-23): below this zoom the tile
+ *  server strips attribute columns unless opted in via `cols=`. */
+const ATTRIBUTE_BUDGET_MINZOOM = 10;
 
 export interface FeaturePopupProps {
   longitude: number;
@@ -258,10 +266,15 @@ export function FeaturePopup({
               {/* fix(#584): at z<10 the tile server strips attribute columns
                   unless opted in via cols=; in all-fields mode nothing is
                   opted in, so a dataset WITH columns arriving property-less
-                  means "zoom in", not "no attributes". Gated to the
-                  all-fields case (visibleFields == null) — an explicit [] is
-                  the intentional title-only mode and must stay as-is. */}
-              {visibleFields == null && (columnInfo?.length ?? 0) > 0
+                  at low zoom means "zoom in", not "no attributes". Gated to
+                  the all-fields case (visibleFields == null — an explicit []
+                  is the intentional title-only mode) AND to a click below
+                  the attribute budget — at higher zooms an empty property
+                  set means the values really are all null (fix(#586)). */}
+              {visibleFields == null
+                && (columnInfo?.length ?? 0) > 0
+                && feature.zoomAtClick !== undefined
+                && feature.zoomAtClick < ATTRIBUTE_BUDGET_MINZOOM
                 ? t('featurePopup.zoomForAttributes')
                 : t('featurePopup.noAttributes')}
             </p>

--- a/frontend/src/components/map/FeaturePopup.tsx
+++ b/frontend/src/components/map/FeaturePopup.tsx
@@ -134,11 +134,17 @@ export function FeaturePopup({
   const visibleEntries = useMemo<[string, unknown][]>(() => {
     if (visibleFields !== undefined && visibleFields !== null) {
       const propMap = new Map(baseEntries);
-      // fix(#584): render EVERY configured field. ST_AsMVT omits null-valued
-      // properties from the tile, so intersecting with the present keys
-      // silently hid configured fields that are null on the clicked feature —
-      // formatValue's '--' placeholder was unreachable.
-      return visibleFields.map((k) => [k, propMap.get(k)] as [string, unknown]);
+      // fix(#584): render configured fields even when absent from the tile
+      // properties — ST_AsMVT omits null-valued properties, so intersecting
+      // with the present keys silently hid configured fields that are null on
+      // the clicked feature (formatValue's '--' placeholder was unreachable).
+      // A name absent from BOTH the tile and the known schema is a stale
+      // config leftover (e.g. reupload/rename) and stays hidden; with no
+      // schema to consult, favor showing.
+      const known = columnInfo ? new Set(columnInfo.map((c) => c.name)) : null;
+      return visibleFields
+        .filter((k) => propMap.has(k) || known === null || known.has(k))
+        .map((k) => [k, propMap.get(k)] as [string, unknown]);
     }
     if (columnInfo) {
       const columnNames = new Set(columnInfo.map((c) => c.name));

--- a/frontend/src/components/map/FeaturePopup.tsx
+++ b/frontend/src/components/map/FeaturePopup.tsx
@@ -252,8 +252,10 @@ export function FeaturePopup({
               {/* fix(#584): at z<10 the tile server strips attribute columns
                   unless opted in via cols=; in all-fields mode nothing is
                   opted in, so a dataset WITH columns arriving property-less
-                  means "zoom in", not "no attributes". */}
-              {(columnInfo?.length ?? 0) > 0
+                  means "zoom in", not "no attributes". Gated to the
+                  all-fields case (visibleFields == null) — an explicit [] is
+                  the intentional title-only mode and must stay as-is. */}
+              {visibleFields == null && (columnInfo?.length ?? 0) > 0
                 ? t('featurePopup.zoomForAttributes')
                 : t('featurePopup.noAttributes')}
             </p>

--- a/frontend/src/components/map/__tests__/FeaturePopup.test.tsx
+++ b/frontend/src/components/map/__tests__/FeaturePopup.test.tsx
@@ -154,6 +154,28 @@ describe('FeaturePopup', () => {
     expect(cells[3]).toHaveTextContent('--');
   });
 
+  it('fix(#584): hides configured fields absent from BOTH tile properties and the schema (stale config)', () => {
+    // codex #586 P3: a reupload/rename can strand old names in visible_fields;
+    // those stay hidden, while schema-present-but-null fields render '--'.
+    const features: FeatureInfo[] = [
+      makeFeature({
+        properties: { present: 'value' },
+        columnInfo: [
+          { name: 'present', type: 'text' },
+          { name: 'null_but_in_schema', type: 'text' },
+        ],
+        visibleFields: ['present', 'null_but_in_schema', 'stale_removed_column'],
+      }),
+    ];
+    render(<FeaturePopup longitude={0} latitude={0} features={features} onClose={vi.fn()} />);
+    const cells = screen.getAllByRole('cell');
+    expect(cells).toHaveLength(4); // two rows only — stale field hidden
+    expect(cells[0]).toHaveTextContent('Present');
+    expect(cells[2]).toHaveTextContent('Null But In Schema');
+    expect(cells[3]).toHaveTextContent('--');
+    expect(screen.queryByText('Stale Removed Column')).not.toBeInTheDocument();
+  });
+
   it('fix(#584): empty properties on a dataset WITH columns show the zoom hint, not "No attributes"', () => {
     // z<10 tiles strip attribute columns unless opted in via cols= — the
     // all-fields default opts nothing in, so properties arrive empty.

--- a/frontend/src/components/map/__tests__/FeaturePopup.test.tsx
+++ b/frontend/src/components/map/__tests__/FeaturePopup.test.tsx
@@ -176,6 +176,22 @@ describe('FeaturePopup', () => {
     expect(screen.getByText('No attributes')).toBeInTheDocument();
   });
 
+  it('title-only mode (visibleFields []) never shows the zoom hint, even with columnInfo present', () => {
+    // codex #586 P2: [] is the intentional "title only" contract — the zoom
+    // hint is for the all-fields (null) case only.
+    const features: FeatureInfo[] = [
+      makeFeature({
+        title: 'Just a title',
+        properties: {},
+        columnInfo: [{ name: 'borough', type: 'text' }],
+        visibleFields: [],
+      }),
+    ];
+    render(<FeaturePopup longitude={0} latitude={0} features={features} onClose={vi.fn()} />);
+    expect(screen.getByText('Just a title')).toBeInTheDocument();
+    expect(screen.queryByText('Zoom in to view attributes')).not.toBeInTheDocument();
+  });
+
   it('honors visible_fields ordering', () => {
     const features: FeatureInfo[] = [
       makeFeature({

--- a/frontend/src/components/map/__tests__/FeaturePopup.test.tsx
+++ b/frontend/src/components/map/__tests__/FeaturePopup.test.tsx
@@ -188,7 +188,7 @@ describe('FeaturePopup', () => {
       }),
     ];
     render(<FeaturePopup longitude={0} latitude={0} features={features} onClose={vi.fn()} />);
-    expect(screen.getByText('Zoom in to view attributes')).toBeInTheDocument();
+    expect(screen.getByText('No attributes at this zoom')).toBeInTheDocument();
   });
 
   it('fix(#586): all-null feature clicked ABOVE the attribute budget shows "No attributes", not the zoom hint', () => {
@@ -204,7 +204,7 @@ describe('FeaturePopup', () => {
     ];
     render(<FeaturePopup longitude={0} latitude={0} features={features} onClose={vi.fn()} />);
     expect(screen.getByText('No attributes')).toBeInTheDocument();
-    expect(screen.queryByText('Zoom in to view attributes')).not.toBeInTheDocument();
+    expect(screen.queryByText('No attributes at this zoom')).not.toBeInTheDocument();
   });
 
   it('empty properties on a column-less dataset still show "No attributes"', () => {
@@ -228,7 +228,7 @@ describe('FeaturePopup', () => {
     ];
     render(<FeaturePopup longitude={0} latitude={0} features={features} onClose={vi.fn()} />);
     expect(screen.getByText('Just a title')).toBeInTheDocument();
-    expect(screen.queryByText('Zoom in to view attributes')).not.toBeInTheDocument();
+    expect(screen.queryByText('No attributes at this zoom')).not.toBeInTheDocument();
   });
 
   it('honors visible_fields ordering', () => {

--- a/frontend/src/components/map/__tests__/FeaturePopup.test.tsx
+++ b/frontend/src/components/map/__tests__/FeaturePopup.test.tsx
@@ -155,7 +155,7 @@ describe('FeaturePopup', () => {
   });
 
   it('fix(#584): hides configured fields absent from BOTH tile properties and the schema (stale config)', () => {
-    // codex #586 P3: a reupload/rename can strand old names in visible_fields;
+    // fix(#586): a reupload/rename can strand old names in visible_fields;
     // those stay hidden, while schema-present-but-null fields render '--'.
     const features: FeatureInfo[] = [
       makeFeature({
@@ -184,10 +184,27 @@ describe('FeaturePopup', () => {
         properties: {},
         columnInfo: [{ name: 'borough', type: 'text' }],
         visibleFields: null,
+        zoomAtClick: 8,
       }),
     ];
     render(<FeaturePopup longitude={0} latitude={0} features={features} onClose={vi.fn()} />);
     expect(screen.getByText('Zoom in to view attributes')).toBeInTheDocument();
+  });
+
+  it('fix(#586): all-null feature clicked ABOVE the attribute budget shows "No attributes", not the zoom hint', () => {
+    // At z>=10 tiles carry every column; an empty property set means the
+    // values genuinely are all null — zooming cannot reveal anything.
+    const features: FeatureInfo[] = [
+      makeFeature({
+        properties: {},
+        columnInfo: [{ name: 'borough', type: 'text' }],
+        visibleFields: null,
+        zoomAtClick: 12,
+      }),
+    ];
+    render(<FeaturePopup longitude={0} latitude={0} features={features} onClose={vi.fn()} />);
+    expect(screen.getByText('No attributes')).toBeInTheDocument();
+    expect(screen.queryByText('Zoom in to view attributes')).not.toBeInTheDocument();
   });
 
   it('empty properties on a column-less dataset still show "No attributes"', () => {
@@ -199,7 +216,7 @@ describe('FeaturePopup', () => {
   });
 
   it('title-only mode (visibleFields []) never shows the zoom hint, even with columnInfo present', () => {
-    // codex #586 P2: [] is the intentional "title only" contract — the zoom
+    // fix(#586): [] is the intentional "title only" contract — the zoom
     // hint is for the all-fields (null) case only.
     const features: FeatureInfo[] = [
       makeFeature({

--- a/frontend/src/components/map/__tests__/FeaturePopup.test.tsx
+++ b/frontend/src/components/map/__tests__/FeaturePopup.test.tsx
@@ -137,6 +137,45 @@ describe('FeaturePopup', () => {
     expect(screen.queryByText('NYC')).not.toBeInTheDocument();
   });
 
+  it('fix(#584): renders configured fields absent from tile properties as "--" instead of dropping them', () => {
+    // ST_AsMVT omits null-valued properties from the tile, so a configured
+    // field can be missing from `properties` on the clicked feature.
+    const features: FeatureInfo[] = [
+      makeFeature({
+        properties: { present: 'value' },
+        visibleFields: ['present', 'missing_null_field'],
+      }),
+    ];
+    render(<FeaturePopup longitude={0} latitude={0} features={features} onClose={vi.fn()} />);
+    const cells = screen.getAllByRole('cell');
+    expect(cells[0]).toHaveTextContent('Present');
+    expect(cells[1]).toHaveTextContent('value');
+    expect(cells[2]).toHaveTextContent('Missing Null Field');
+    expect(cells[3]).toHaveTextContent('--');
+  });
+
+  it('fix(#584): empty properties on a dataset WITH columns show the zoom hint, not "No attributes"', () => {
+    // z<10 tiles strip attribute columns unless opted in via cols= — the
+    // all-fields default opts nothing in, so properties arrive empty.
+    const features: FeatureInfo[] = [
+      makeFeature({
+        properties: {},
+        columnInfo: [{ name: 'borough', type: 'text' }],
+        visibleFields: null,
+      }),
+    ];
+    render(<FeaturePopup longitude={0} latitude={0} features={features} onClose={vi.fn()} />);
+    expect(screen.getByText('Zoom in to view attributes')).toBeInTheDocument();
+  });
+
+  it('empty properties on a column-less dataset still show "No attributes"', () => {
+    const features: FeatureInfo[] = [
+      makeFeature({ properties: {}, columnInfo: null, visibleFields: null }),
+    ];
+    render(<FeaturePopup longitude={0} latitude={0} features={features} onClose={vi.fn()} />);
+    expect(screen.getByText('No attributes')).toBeInTheDocument();
+  });
+
   it('honors visible_fields ordering', () => {
     const features: FeatureInfo[] = [
       makeFeature({

--- a/frontend/src/components/map/__tests__/cluster-interactions.test.ts
+++ b/frontend/src/components/map/__tests__/cluster-interactions.test.ts
@@ -45,6 +45,18 @@ describe('cluster interactions', () => {
     });
   });
 
+  it('fix(#584): omits absent optional keys from visibleFields so the popup never renders them as "--"', () => {
+    const feature = {
+      properties: { point_count: 42 },
+      geometry: { type: 'Point', coordinates: [0, 0] },
+    };
+    expect(clusterAggregateFeatureInfo(feature, {
+      layerName: 'Stops',
+      sourceKind: 'server-tile',
+      locale: 'en-US',
+    }).visibleFields).toEqual(['feature_count', 'source']);
+  });
+
   it('zooms to server-provided expansion zoom for MVT clusters', async () => {
     const map = {
       getSource: vi.fn(),

--- a/frontend/src/components/map/cluster-interactions.ts
+++ b/frontend/src/components/map/cluster-interactions.ts
@@ -89,7 +89,11 @@ export function clusterAggregateFeatureInfo(
     // fix(#438): I18N-02 — was `Cluster: N feature(s)` with manual English
     // pluralization; now an i18next plural key.
     title: i18n.t('builder:cluster.popupTitle', { count, countLabel }),
-    visibleFields: ['feature_count', 'source', 'expansion_zoom', 'cluster_id'],
+    // fix(#584, codex #586 r4): only list keys actually present — the popup's
+    // no-schema fallback renders configured-but-absent fields as '--', which
+    // would surface a meaningless "Expansion Zoom: --" on clusters without one.
+    visibleFields: ['feature_count', 'source', 'expansion_zoom', 'cluster_id']
+      .filter((k) => k in aggregateProperties),
   };
 }
 

--- a/frontend/src/components/map/cluster-interactions.ts
+++ b/frontend/src/components/map/cluster-interactions.ts
@@ -89,7 +89,7 @@ export function clusterAggregateFeatureInfo(
     // fix(#438): I18N-02 — was `Cluster: N feature(s)` with manual English
     // pluralization; now an i18next plural key.
     title: i18n.t('builder:cluster.popupTitle', { count, countLabel }),
-    // fix(#584, codex #586 r4): only list keys actually present — the popup's
+    // fix(#586): only list keys actually present — the popup's
     // no-schema fallback renders configured-but-absent fields as '--', which
     // would surface a meaningless "Expansion Zoom: --" on clusters without one.
     visibleFields: ['feature_count', 'source', 'expansion_zoom', 'cluster_id']

--- a/frontend/src/components/viewer/ViewerMap.tsx
+++ b/frontend/src/components/viewer/ViewerMap.tsx
@@ -656,6 +656,7 @@ export const ViewerMap = memo(function ViewerMap({
           columnInfo: layer.column_info ?? null,
           title: cfg?.expression ? substitutePopupTemplate(cfg.expression, props) : null,
           visibleFields: cfg?.visible_fields ?? null,
+          zoomAtClick: map.getZoom(),
         });
       }
 

--- a/frontend/src/i18n/locales/de/builder.json
+++ b/frontend/src/i18n/locales/de/builder.json
@@ -782,6 +782,7 @@
   },
   "featurePopup": {
     "noAttributes": "Keine Attribute",
+    "zoomForAttributes": "Zum Anzeigen der Attribute hineinzoomen",
     "booleanTrue": "Ja",
     "booleanFalse": "Nein",
     "clickToCopy": "Klicken zum Kopieren",

--- a/frontend/src/i18n/locales/de/builder.json
+++ b/frontend/src/i18n/locales/de/builder.json
@@ -782,7 +782,7 @@
   },
   "featurePopup": {
     "noAttributes": "Keine Attribute",
-    "zoomForAttributes": "Zum Anzeigen der Attribute hineinzoomen",
+    "zoomForAttributes": "Keine Attribute auf dieser Zoomstufe",
     "booleanTrue": "Ja",
     "booleanFalse": "Nein",
     "clickToCopy": "Klicken zum Kopieren",

--- a/frontend/src/i18n/locales/en/builder.json
+++ b/frontend/src/i18n/locales/en/builder.json
@@ -782,7 +782,7 @@
   },
   "featurePopup": {
     "noAttributes": "No attributes",
-    "zoomForAttributes": "Zoom in to view attributes",
+    "zoomForAttributes": "No attributes at this zoom",
     "booleanTrue": "Yes",
     "booleanFalse": "No",
     "clickToCopy": "Click to copy",

--- a/frontend/src/i18n/locales/en/builder.json
+++ b/frontend/src/i18n/locales/en/builder.json
@@ -782,6 +782,7 @@
   },
   "featurePopup": {
     "noAttributes": "No attributes",
+    "zoomForAttributes": "Zoom in to view attributes",
     "booleanTrue": "Yes",
     "booleanFalse": "No",
     "clickToCopy": "Click to copy",

--- a/frontend/src/i18n/locales/es/builder.json
+++ b/frontend/src/i18n/locales/es/builder.json
@@ -782,7 +782,7 @@
   },
   "featurePopup": {
     "noAttributes": "Sin atributos",
-    "zoomForAttributes": "Acércate para ver los atributos",
+    "zoomForAttributes": "Sin atributos en este nivel de zoom",
     "booleanTrue": "Sí",
     "booleanFalse": "No",
     "clickToCopy": "Haz clic para copiar",

--- a/frontend/src/i18n/locales/es/builder.json
+++ b/frontend/src/i18n/locales/es/builder.json
@@ -782,6 +782,7 @@
   },
   "featurePopup": {
     "noAttributes": "Sin atributos",
+    "zoomForAttributes": "Acércate para ver los atributos",
     "booleanTrue": "Sí",
     "booleanFalse": "No",
     "clickToCopy": "Haz clic para copiar",

--- a/frontend/src/i18n/locales/fr/builder.json
+++ b/frontend/src/i18n/locales/fr/builder.json
@@ -782,7 +782,7 @@
   },
   "featurePopup": {
     "noAttributes": "Aucun attribut",
-    "zoomForAttributes": "Zoomez pour afficher les attributs",
+    "zoomForAttributes": "Aucun attribut à ce niveau de zoom",
     "booleanTrue": "Oui",
     "booleanFalse": "Non",
     "clickToCopy": "Cliquer pour copier",

--- a/frontend/src/i18n/locales/fr/builder.json
+++ b/frontend/src/i18n/locales/fr/builder.json
@@ -782,6 +782,7 @@
   },
   "featurePopup": {
     "noAttributes": "Aucun attribut",
+    "zoomForAttributes": "Zoomez pour afficher les attributs",
     "booleanTrue": "Oui",
     "booleanFalse": "Non",
     "clickToCopy": "Cliquer pour copier",

--- a/frontend/src/pages/DatasetPage.tsx
+++ b/frontend/src/pages/DatasetPage.tsx
@@ -184,6 +184,9 @@ export function DatasetPage() {
 
   const [isDataTabExpanded, setIsDataTabExpanded] = useState(false);
   const toggleDataTabExpand = useCallback(() => setIsDataTabExpanded((prev) => !prev), []);
+  // fix(#583): pad the page clear of the open AI chat panel — the fixed panel
+  // otherwise floats over the sticky detail tabs and header stat cells.
+  const [isChatOpen, setIsChatOpen] = useState(false);
   const isEditor = useAuthStore((s) => s.isEditor());
   // Owner-or-admin: mutating this dataset requires the editor capability AND
   // ownership (or admin), mirroring the backend check_dataset_write_access.
@@ -475,7 +478,7 @@ export function DatasetPage() {
   ];
 
   return (
-    <PageShell>
+    <PageShell className={cn('transition-[padding] duration-200', isChatOpen && 'lg:pe-[26.5rem]')}>
       <DatasetDetailHeader
         title={dataset.title}
         onTitleSave={handleSaveName}
@@ -629,6 +632,7 @@ export function DatasetPage() {
           datasetId={dataset.id}
           datasetTitle={dataset.title}
           showOpenInBuilder={!isTable}
+          onOpenChange={setIsChatOpen}
         />
       )}
 


### PR DESCRIPTION
Closes #583, closes #584.

## What

**#583 — "cannot click on tabs in dataset details page."** The fixed Ask AI panel floated over the sticky detail tabs (Access at 1440px; Structure+Access at ≤1280px) and header stat cells. `DatasetChatPanel` now reports open/close via `onOpenChange`, and `DatasetPage` pads its content inline-end (`lg:pe-[26.5rem]`) while the chat is open, so everything reflows beside the panel.

**#584 — "popup not showing custom fields."** Three verified defects:
1. **Dropped tile reload (root cause).** Editing popup `visible_fields` correctly rebuilt the tile URL with the new `cols=` and called `setTiles()` — but maplibre-gl 5.x silently drops that reload when the source's TileManager is paused, which the same sync pass guarantees via its layer updates (`tile_manager.ts` `_dataHandler` early-returns on `content` while `_paused` without setting `_shouldReloadOnResume`). Tiles kept the pre-edit column set until a full page reload. `refreshVectorSourceTiles` now re-issues the reload via the public `map.refreshTiles()` on a macrotask; that path *does* set the resume flag. (Upstream maplibre bug — workaround is app-side and idempotent.)
2. **Null-valued fields vanished.** `FeaturePopup` intersected the configured allowlist with keys present in tile properties; ST_AsMVT omits null-valued properties, so a configured field null on the clicked feature rendered no row. Configured fields now always render, `--` when absent.
3. **Low-zoom "No attributes."** At z<10 tiles strip attribute columns unless opted in via `cols=`; the all-fields default opts nothing in. The empty state now says "Zoom in to view attributes" when the dataset has columns (new key in all four locales).

## Verification

- Live before/after on the dev stack (Playwright): tab hit-testing with chat open at 1280/1440 — all 5 tabs uncovered and clickable; builder live-edit at z10 — adding `structure` to the popup selection surfaces "Structure: Embankment" on the next click with no reload (previously never appeared); staged layer at z2 — popup shows the zoom hint instead of a bare "No attributes".
- The maplibre root cause was pinned by instrumenting `VectorTileSource.setTiles` (called exactly once per edit with the correct URL, no network refetch followed) and confirming `map.refreshTiles(sourceId)` flushes the stale tiles immediately.
- `npm run build` / `lint` / `typecheck` / `test:coverage` / `test:i18n` all green; new regression tests: `map-sync.tile-refresh.test.ts` (cols= ride-along + deferred refreshTiles), `FeaturePopup.test.tsx` (null-field `--` rows, zoom hint vs no-attributes).

Related: #585 tracks the builder contextual-menu review findings (separate, not in this PR).

https://claude.ai/code/session_013Q1gyuRm3QXKZL73eQ9UUV