### PR TITLE
chore(release): bump to 1.4.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,41 @@ and releases use semantic versioning.
 
 ## [Unreleased]
 
+## [1.4.10] - 2026-07-19
+
+### Added
+
+- **Three deployment knobs for running GeoLens outside Docker Compose.** Each
+  is a plain container environment variable with a byte-preserving default,
+  so existing Compose deployments are unchanged:
+  - GDAL now honors custom S3 endpoints. Reads against MinIO, R2, or any
+    other non-AWS S3 backend derive `AWS_S3_ENDPOINT`, `AWS_HTTPS`, and
+    `AWS_VIRTUAL_HOSTING` from the existing `S3_*` settings at api and worker
+    start, and GDAL subprocesses inherit them. Explicit operator `AWS_*`
+    environment — and ambient-credential setups — always wins.
+  - `CLIENT_MAX_BODY_SIZE` replaces the frontend image's hardwired `500m`
+    upload ceiling. Invalid values fail fast at boot with a clear error
+    instead of crash-looping on an nginx config error.
+  - `TRUSTED_PROXY_CIDRS` recovers the real client address from
+    `X-Forwarded-For` behind a trusted load balancer, restoring accurate
+    access logs and anonymous raster rate limiting. Left unset, the rendered
+    configuration is equivalent to the previous overwrite behavior. Entries
+    are charset-validated, so environment values cannot inject nginx
+    directives.
+
+### Fixed
+
+- Dataset detail tabs are clickable again while the Ask AI panel is open. The
+  fixed panel covered the Access tab at 1440px, and Structure as well at
+  narrower widths; the page now reflows beside the panel.
+- Popup custom fields appear as soon as they are configured. Editing a layer's
+  popup fields rebuilt the tile request correctly, but maplibre-gl 5.x
+  silently dropped the reload while the tile source was paused, so the map
+  kept serving the pre-edit column set until a full page reload.
+- Popup fields that are configured but null on the clicked feature render as
+  `--` instead of vanishing, and the popup's empty state now reads "Zoom in to
+  view attributes" when the dataset has columns that low zoom levels strip.
+
 ## [1.4.9] - 2026-07-18
 
 ### Changed

--- a/backend/app/api/main.py
+++ b/backend/app/api/main.py
@@ -563,7 +563,7 @@ _is_production = settings.is_production
 # no metadata to read. We fall back to the current published line so import never
 # crashes. Keep this fallback in lockstep with backend/pyproject.toml — it is one
 # of the sites `make bump` rewrites.
-_FALLBACK_APP_VERSION = "1.4.9"
+_FALLBACK_APP_VERSION = "1.4.10"
 
 
 def _resolve_app_version() -> str:

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -17140,7 +17140,7 @@
     "summary": "PostGIS-native geospatial data catalog with OGC API Features and Records support",
     "termsOfService": "https://github.com/geolens-io/geolens/blob/main/LICENSE",
     "title": "GeoLens API",
-    "version": "1.4.9"
+    "version": "1.4.10"
   },
   "openapi": "3.1.0",
   "paths": {

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geolens-backend"
-version = "1.4.9"
+version = "1.4.10"
 description = "PostGIS-native GIS data catalog"
 # Docker image (Dockerfile) ships python:3.14-slim (see the Dockerfile FROM for
 # the exact patch pin) as the project's tested runtime.

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -865,7 +865,7 @@ wheels = [
 
 [[package]]
 name = "geolens-backend"
-version = "1.4.9"
+version = "1.4.10"
 source = { virtual = "." }
 dependencies = [
     { name = "alembic" },

--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "geolens-cli"
-version = "1.4.9"
+version = "1.4.10"
 description = "Apache-2.0 command-line interface for the GeoLens API. Login, scan, publish, and export STAC against any GeoLens instance."
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/docs-contract.json
+++ b/docs-contract.json
@@ -1,6 +1,6 @@
 {
   "_comment": "Canonical cross-surface facts for the GeoLens README, marketing site (getgeolens.com/src), and docs site (getgeolens.com/docs). Validated against scripts/install.sh + backend/pyproject.toml by scripts/check_docs_contract.py (geolens CI). The getgeolens.com repo vendors a copy and enforces the same `forbidden` list in its own CI. See docs-internal/DOC-CONSISTENCY-STRATEGY for the full design. Edit a fact ONCE here (and in its canonical source) — the gates make every surface follow.",
-  "version": "1.4.9",
+  "version": "1.4.10",
   "install": {
     "oneLiner": "curl -fsSL https://getgeolens.com/install.sh | sh",
     "sourceBuild": "bash scripts/install.sh",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.4.9",
+  "version": "1.4.10",
   "type": "module",
   "license": "Apache-2.0",
   "author": "Carto Concepts, LLC",

--- a/mcp/pyproject.toml
+++ b/mcp/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "geolens-mcp"
-version = "1.4.9"
+version = "1.4.10"
 description = "Apache-2.0 read-only Model Context Protocol (MCP) server for GeoLens. Lets coding agents discover datasets, inspect schemas, and ask spatial questions against any GeoLens instance."
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "geolens",
-  "version": "1.4.9",
+  "version": "1.4.10",
   "private": true,
   "license": "Apache-2.0",
   "author": "Carto Concepts, LLC",

--- a/sdks/python/.openapi-python-client.yaml
+++ b/sdks/python/.openapi-python-client.yaml
@@ -4,7 +4,7 @@ project_name_override: geolens
 package_name_override: geolens
 # Rewritten on every `make sdks` run by scripts/sync_sdk_versions.py to match
 # backend/openapi.json info.version. Do not edit by hand.
-package_version_override: 1.4.9
+package_version_override: 1.4.10
 
 # Cleaner enum output (matches our pydantic v2 backend's enum emission).
 literal_enums: true

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "geolens"
-version = "1.4.9"
+version = "1.4.10"
 description = "Auto-generated Python SDK for the GeoLens API. Typed clients with Bearer + API-key auth helpers."
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/sdks/typescript/package-lock.json
+++ b/sdks/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@geolens/sdk",
-  "version": "1.4.9",
+  "version": "1.4.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@geolens/sdk",
-      "version": "1.4.9",
+      "version": "1.4.10",
       "license": "Apache-2.0",
       "dependencies": {
         "@hey-api/client-fetch": "0.13.1"

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@geolens/sdk",
-  "version": "1.4.9",
+  "version": "1.4.10",
   "description": "Auto-generated TypeScript SDK for the GeoLens API. Typed clients with Bearer + API-key auth helpers.",
   "license": "Apache-2.0",
   "author": "Carto Concepts, LLC",


### PR DESCRIPTION
Release prep for **v1.4.10**. No behavior change beyond the version bump — this
packages the two commits that landed on `main` after the v1.4.9 tag.

## Contents

- **#582** — deployment chart-enablement trio (#579 GDAL S3 endpoints, #580
  `CLIENT_MAX_BODY_SIZE`, #581 `TRUSTED_PROXY_CIDRS`). Unblocks the Helm chart
  0.4.0 values wiring, which was waiting on these knobs shipping in a release.
- **#586** — dataset-page tab occlusion by the AI chat panel (#583) and
  reliable builder popup custom fields (#584).

Neither PR added a CHANGELOG entry at merge time, so both are written up here.

## Changes

- All 11 version sites → 1.4.10 via `make bump` (never hand-edited).
- Regenerated `backend/openapi.json`, `sdks/python`, `sdks/typescript`, plus
  the `backend/uv.lock` / `sdks/typescript/package-lock.json` version echoes.
  The frontend `api.generated.ts` regen was a no-op diff (version does not
  appear in generated types) — run per the three-artifact rule, not skipped.
- `CHANGELOG.md` gains a curated `## [1.4.10] - 2026-07-19` section.

## Verification

Local, all green before push: `make version-check`, `make openapi-check`,
`make sdks-check` (run against a clean tree — it is git-diff-based and reports
a false failure on an uncommitted bump).

## Follow-on (post-tag, not this PR)

Helm chart bump in `geolens-deployments`, public installer release-pin sync,
and the demo VM redeploy 1.4.9 → 1.4.10.

https://claude.ai/code/session_01R7E9gqb46RXrn4EnZHZZAD
