### PR TITLE
fix: 1.4.10 pre-release batch — honest raster resolutions, working CLI publish flags, aligned port fallbacks

### DIFF
--- a/backend/app/core/geo.py
+++ b/backend/app/core/geo.py
@@ -46,3 +46,24 @@ def make_bbox_filter(
     else:
         envelope = func.ST_MakeEnvelope(west, south, east, north, 4326)
         return and_(geom_col.op("&&")(envelope), spatial_fn(geom_col, envelope))
+
+
+def wkt_is_geographic(crs_wkt: str | None) -> bool | None:
+    """Classify a CRS WKT as geographic (degree units) or projected.
+
+    fix(#569): the frontend rendered geographic-CRS pixel resolutions as
+    meters ("60 arc-second" ETOPO showed "2 cm"). The API has no proj
+    library, but the stored WKT's root/inner keyword is enough: a projected
+    CRS contains PROJCRS (WKT2) / PROJCS (WKT1) — checked FIRST because
+    WKT1 nests a GEOGCS inside every PROJCS — otherwise a GEOGCRS/GEOGCS
+    keyword (including inside a COMPOUNDCRS like EPSG:9518) means
+    geographic. Engineering/local/unknown CRSs return None.
+    """
+    if not crs_wkt:
+        return None
+    head = crs_wkt[:2000].upper()
+    if "PROJCRS" in head or "PROJCS" in head:
+        return False
+    if "GEOGCRS" in head or "GEOGCS" in head:
+        return True
+    return None

--- a/backend/app/modules/catalog/datasets/domain/helpers.py
+++ b/backend/app/modules/catalog/datasets/domain/helpers.py
@@ -19,7 +19,7 @@ from app.modules.catalog.sources.provenance import (
     derive_last_edited,
     resolve_actor,
 )
-from app.core.geo import extent_to_bbox
+from app.core.geo import extent_to_bbox, wkt_is_geographic
 
 
 async def _load_actor_identities(
@@ -95,6 +95,7 @@ def _build_raster_metadata(
 
     return RasterMetadata(
         epsg=raster_asset.epsg,
+        crs_is_geographic=wkt_is_geographic(raster_asset.crs_wkt),
         res_x=raster_asset.res_x,
         res_y=raster_asset.res_y,
         band_count=raster_asset.band_count,

--- a/backend/app/modules/catalog/datasets/domain/schemas.py
+++ b/backend/app/modules/catalog/datasets/domain/schemas.py
@@ -148,6 +148,13 @@ class RasterConnect(BaseModel):
 
 class RasterMetadata(BaseModel):
     epsg: int | None = Field(default=None, description="EPSG code of the raster CRS")
+    crs_is_geographic: bool | None = Field(
+        default=None,
+        description=(
+            "True when the raster CRS is geographic (res_x/res_y are degrees, "
+            "not meters); None when the CRS class is unknown."
+        ),
+    )
     res_x: float | None = Field(
         default=None, description="Pixel resolution in X (CRS units)"
     )

--- a/backend/app/modules/catalog/search/schemas.py
+++ b/backend/app/modules/catalog/search/schemas.py
@@ -118,6 +118,13 @@ class OGCRecordProperties(BaseModel):
     record_status: str | None = None
     has_quicklook: bool = False
     gsd: float | None = None
+    crs_is_geographic: bool | None = Field(
+        default=None,
+        description=(
+            "True when the raster CRS is geographic (gsd/res are degrees, "
+            "not meters); None when the CRS class is unknown."
+        ),
+    )
     vrt_type: str | None = None
     source_count: int | None = None
     dataset_count: int | None = None

--- a/backend/app/modules/catalog/search/service_records.py
+++ b/backend/app/modules/catalog/search/service_records.py
@@ -420,6 +420,13 @@ def dataset_to_ogc_record(
             ogc_record["properties"]["gsd"] = min(
                 abs(raster_meta["res_x"]), abs(raster_meta["res_y"])
             )
+            # fix(#569): gsd is in CRS units — geographic CRSs deliver degrees,
+            # and without this flag the UI formatted them as meters ("2 cm"
+            # for a 60-arc-second global DEM).
+            if raster_meta.get("crs_is_geographic") is not None:
+                ogc_record["properties"]["crs_is_geographic"] = raster_meta[
+                    "crs_is_geographic"
+                ]
         if raster_meta.get("band_count"):
             ogc_record["properties"]["band_count"] = raster_meta["band_count"]
 

--- a/backend/app/processing/raster/queries.py
+++ b/backend/app/processing/raster/queries.py
@@ -11,6 +11,7 @@ from typing import Any
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.core.geo import wkt_is_geographic
 from app.processing.raster.models import RasterAsset
 
 
@@ -19,6 +20,9 @@ def _row_to_meta(row: Any, *, include_vrt: bool, include_generation_id: bool) ->
     meta: dict = {
         "band_count": row.band_count,
         "epsg": row.epsg,
+        # fix(#569): lets consumers render res_x/res_y honestly — degree
+        # resolutions must not be formatted as meters.
+        "crs_is_geographic": wkt_is_geographic(row.crs_wkt),
         "res_x": float(row.res_x) if row.res_x is not None else None,
         "res_y": float(row.res_y) if row.res_y is not None else None,
         "width": row.width,
@@ -47,6 +51,7 @@ async def fetch_raster_meta_one(
     columns = [
         RasterAsset.band_count,
         RasterAsset.epsg,
+        RasterAsset.crs_wkt,
         RasterAsset.res_x,
         RasterAsset.res_y,
         RasterAsset.width,
@@ -85,6 +90,7 @@ async def fetch_raster_meta_bulk(
         RasterAsset.dataset_id,
         RasterAsset.band_count,
         RasterAsset.epsg,
+        RasterAsset.crs_wkt,
         RasterAsset.res_x,
         RasterAsset.res_y,
         RasterAsset.width,

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -11041,6 +11041,18 @@
             ],
             "title": "Crs"
           },
+          "crs_is_geographic": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "True when the raster CRS is geographic (gsd/res are degrees, not meters); None when the CRS class is unknown.",
+            "title": "Crs Is Geographic"
+          },
           "dataset_count": {
             "anyOf": [
               {
@@ -12114,6 +12126,18 @@
                 "type": "null"
               }
             ]
+          },
+          "crs_is_geographic": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "True when the raster CRS is geographic (res_x/res_y are degrees, not meters); None when the CRS class is unknown.",
+            "title": "Crs Is Geographic"
           },
           "epsg": {
             "anyOf": [

--- a/backend/tests/test_wkt_is_geographic.py
+++ b/backend/tests/test_wkt_is_geographic.py
@@ -1,0 +1,51 @@
+"""fix(#569): CRS-class sniffing for honest raster resolution display.
+
+The frontend must not format degree resolutions as meters; this helper
+classifies the stored WKT with zero proj dependencies.
+"""
+
+from app.core.geo import wkt_is_geographic
+
+WKT2_GEOGRAPHIC = 'GEOGCRS["WGS 84",DATUM["World Geodetic System 1984",ELLIPSOID["WGS 84",6378137,298.257223563]]]'
+WKT1_GEOGRAPHIC = (
+    'GEOGCS["WGS 84",DATUM["WGS_1984",SPHEROID["WGS 84",6378137,298.257223563]]]'
+)
+# WKT1 nests a GEOGCS inside every PROJCS — the projected check must win.
+WKT1_PROJECTED = 'PROJCS["WGS 84 / UTM zone 18N",GEOGCS["WGS 84",DATUM["WGS_1984",SPHEROID["WGS 84",6378137]]],PROJECTION["Transverse_Mercator"]]'
+WKT2_PROJECTED = (
+    'PROJCRS["WGS 84 / UTM zone 18N",BASEGEOGCRS["WGS 84"],CONVERSION["UTM zone 18N"]]'
+)
+# EPSG:9518-style compound (horizontal geographic + vertical) — geographic.
+WKT2_COMPOUND_GEOGRAPHIC = 'COMPOUNDCRS["WGS 84 + EGM2008 height",GEOGCRS["WGS 84",DATUM["World Geodetic System 1984"]],VERTCRS["EGM2008 height"]]'
+WKT2_COMPOUND_PROJECTED = 'COMPOUNDCRS["NAD83 / UTM 18N + NAVD88",PROJCRS["NAD83 / UTM zone 18N",BASEGEOGCRS["NAD83"]],VERTCRS["NAVD88 height"]]'
+WKT_ENGINEERING = 'ENGCRS["Site grid",EDATUM["Site origin"]]'
+
+
+def test_geographic_wkt2():
+    assert wkt_is_geographic(WKT2_GEOGRAPHIC) is True
+
+
+def test_geographic_wkt1():
+    assert wkt_is_geographic(WKT1_GEOGRAPHIC) is True
+
+
+def test_projected_wkt1_with_nested_geogcs():
+    assert wkt_is_geographic(WKT1_PROJECTED) is False
+
+
+def test_projected_wkt2():
+    assert wkt_is_geographic(WKT2_PROJECTED) is False
+
+
+def test_compound_geographic():
+    assert wkt_is_geographic(WKT2_COMPOUND_GEOGRAPHIC) is True
+
+
+def test_compound_projected():
+    assert wkt_is_geographic(WKT2_COMPOUND_PROJECTED) is False
+
+
+def test_engineering_and_missing_are_unknown():
+    assert wkt_is_geographic(WKT_ENGINEERING) is None
+    assert wkt_is_geographic(None) is None
+    assert wkt_is_geographic("") is None

--- a/cli/geolens_cli/main.py
+++ b/cli/geolens_cli/main.py
@@ -594,14 +594,14 @@ def publish(
         Optional[str],
         typer.Option(
             "--tags",
-            help="Comma-separated keyword tags (currently a no-op; see docs.getgeolens.com)",
+            help="Comma-separated keywords added to the dataset after commit (requires --wait)",
         ),
     ] = None,
     collection: Annotated[
         Optional[str],
         typer.Option(
             "--collection",
-            help="Add to this collection after commit (currently a no-op; see docs.getgeolens.com)",
+            help="Collection id or exact name to add the dataset to after commit (requires --wait)",
         ),
     ] = None,
     wait: Annotated[
@@ -629,24 +629,16 @@ def publish(
         state.output.error("No instance configured. Run `geolens login <url>` first.")
         raise typer.Exit(EXIT_AUTH)
 
+    # fix(#569): --tags / --collection are wired post-commit, which needs the
+    # resolved dataset id — fail fast instead of silently dropping them.
+    if (tags or collection) and not wait:
+        state.output.error(
+            "--tags/--collection require --wait (the dataset id is resolved by waiting)"
+        )
+        raise typer.Exit(EXIT_USAGE)
+
     sdk = state.sdk()
     title = name or file.stem
-
-    # Deferred-flag warnings (Task 0 Q2 + Q5). These flags exist for forward
-    # compatibility but currently no-op; the docs site captures the
-    # user-facing TODO.
-    if tags:
-        # TODO(OCCLI-deferred): tags requires a post-commit PATCH or a
-        # `keywords` field on CommitRequest; see Phase 216 Open Question 4.
-        state.output.debug(
-            "tags deferred — CommitRequest does not expose a tags field; see Phase 216 Open Question 4",
-        )
-    if collection:
-        # TODO(OCCLI-deferred): collection-add endpoint not in SDK; see
-        # Phase 216 Open Question / CONTEXT.md Deferred Ideas.
-        state.output.debug(
-            "collection deferred — no add-to-collection endpoint in SDK; see Phase 216 Deferred Ideas",
-        )
 
     # Lazy SDK imports — keeps `geolens --help` snappy.
     from geolens.api.datasets import (
@@ -703,6 +695,21 @@ def publish(
         if wait:
             dataset_id = _publish.resolve_dataset_id(sdk.client, job_id)
 
+        # Stage 5 — fix(#569): apply --tags / --collection now that the
+        # dataset id exists. Failures here are PARTIAL: the dataset was
+        # created, so report honestly and exit non-zero below.
+        extras_failures: list[str] = []
+        if tags or collection:
+            if dataset_id is None:
+                extras_failures.append(
+                    "dataset id could not be resolved — tags/collection not applied"
+                )
+            else:
+                progress.add_task("Applying tags/collection...", total=None)
+                extras_failures = _publish.apply_publish_extras(
+                    sdk.client, dataset_id, tags, collection
+                )
+
     dataset_url = _publish.construct_dataset_url(
         instance,
         dataset_id=dataset_id,
@@ -715,11 +722,17 @@ def publish(
         "dataset_id": str(dataset_id) if dataset_id else None,
         "status": getattr(commit, "status", None),
     }
+    if tags or collection:
+        payload["extras_failures"] = extras_failures
 
     if state.json_mode:
         state.output.json(payload)
     else:
         state.output.success(f"Published: {dataset_url}")
+        for failure in extras_failures:
+            state.output.warn(f"Dataset created, but: {failure}")
+    if extras_failures:
+        raise typer.Exit(EXIT_GENERIC)
 
 
 @export_app.command("stac")

--- a/cli/geolens_cli/publish.py
+++ b/cli/geolens_cli/publish.py
@@ -284,3 +284,121 @@ def handle_commit_already_processed(job_id: str, output: Any) -> None:
     """Per Pitfall 6: commit is not idempotent. Print + exit cleanly."""
     output.error(f"Job {job_id} was already committed (resume not supported in MVP)")
     raise typer.Exit(EXIT_GENERIC)
+
+
+# ---------------------------------------------------------------------------
+# Post-commit extras — --tags / --collection wiring (fix(#569))
+# ---------------------------------------------------------------------------
+
+
+def _split_tags(tags_csv: str) -> list[str]:
+    """Split a comma-separated tag list, trimming blanks and duplicates."""
+    seen: set[str] = set()
+    out: list[str] = []
+    for raw in tags_csv.split(","):
+        tag = raw.strip()
+        key = tag.lower()
+        if not tag or key in seen:
+            continue
+        seen.add(key)
+        out.append(tag)
+    return out
+
+
+def _apply_tags(client: Any, dataset_id: str, tags_csv: str) -> list[str]:
+    """POST each tag as a record keyword. Returns failure descriptions."""
+    from geolens.api.records import (
+        create_keyword_endpoint_records_record_id_keywords_post as _kw,
+    )
+    from geolens.models.keyword_create import KeywordCreate
+
+    failures: list[str] = []
+    for tag in _split_tags(tags_csv):
+        resp = call_sdk(
+            _kw.sync_detailed,
+            record_id=UUID(dataset_id),
+            client=client,
+            body=KeywordCreate(keyword=tag),
+        )
+        if int(resp.status_code) != 201:
+            failures.append(f"tag {tag!r}: HTTP {int(resp.status_code)}")
+    return failures
+
+
+def _resolve_collection_id(client: Any, collection_ref: str) -> UUID | str:
+    """Resolve --collection to a collection id.
+
+    Accepts a UUID directly; otherwise matches the collection NAME
+    (case-insensitive, exact). Returns a UUID on success or a failure
+    description string.
+    """
+    try:
+        return UUID(collection_ref)
+    except ValueError:
+        pass
+
+    from geolens.api.datasets import (
+        list_collections_endpoint_catalog_collections_get as _list,
+    )
+
+    wanted = collection_ref.strip().lower()
+    matches: list[UUID] = []
+    skip = 0
+    page = 100
+    while True:
+        resp = call_sdk(_list.sync_detailed, client=client, skip=skip, limit=page)
+        if int(resp.status_code) != 200 or resp.parsed is None:
+            return f"collection lookup failed: HTTP {int(resp.status_code)}"
+        collections = getattr(resp.parsed, "collections", []) or []
+        matches.extend(c.id for c in collections if c.name.strip().lower() == wanted)
+        if len(collections) < page:
+            break
+        skip += page
+    if not matches:
+        return f"collection {collection_ref!r} not found (pass its id or exact name)"
+    if len(matches) > 1:
+        return f"collection name {collection_ref!r} is ambiguous ({len(matches)} matches) — pass its id"
+    return matches[0]
+
+
+def _apply_collection(client: Any, dataset_id: str, collection_ref: str) -> list[str]:
+    """Add the dataset to the referenced collection. Returns failures."""
+    from geolens.api.datasets import (
+        add_datasets_endpoint_catalog_collections_collection_id_datasets_post as _add,
+    )
+    from geolens.models.collection_add_datasets_request import (
+        CollectionAddDatasetsRequest,
+    )
+
+    resolved = _resolve_collection_id(client, collection_ref)
+    if isinstance(resolved, str):
+        return [resolved]
+    resp = call_sdk(
+        _add.sync_detailed,
+        collection_id=resolved,
+        client=client,
+        body=CollectionAddDatasetsRequest(dataset_ids=[UUID(dataset_id)]),
+    )
+    if int(resp.status_code) != 200:
+        return [f"collection add: HTTP {int(resp.status_code)}"]
+    return []
+
+
+def apply_publish_extras(
+    client: Any,
+    dataset_id: str,
+    tags_csv: Optional[str],
+    collection_ref: Optional[str],
+) -> list[str]:
+    """Apply post-commit --tags / --collection. Returns failure descriptions.
+
+    The dataset already exists by the time this runs — callers must report
+    failures WITHOUT implying the publish itself failed, then exit non-zero
+    so scripts notice the partial result.
+    """
+    failures: list[str] = []
+    if tags_csv:
+        failures.extend(_apply_tags(client, dataset_id, tags_csv))
+    if collection_ref:
+        failures.extend(_apply_collection(client, dataset_id, collection_ref))
+    return failures

--- a/cli/geolens_cli/publish.py
+++ b/cli/geolens_cli/publish.py
@@ -22,11 +22,13 @@ dataset URL is constructed via a follow-up ``GET /jobs/{job_id}`` poll
 that resolves ``job_id`` to ``dataset_id``. With ``--no-wait``, the URL
 falls back to a job-search form ``<instance>/datasets?job_id=<id>``.
 
-Open Question 4 (--tags wiring) — DEFERRED per Task 0 Q2:
-``CommitRequest`` has no ``tags`` field. The flag is accepted but its
-value is dropped with a verbose-mode debug log. See the
-``# TODO(OCCLI-deferred)`` markers below.
+Open Question 4 (--tags wiring) — RESOLVED, fix(#569): ``CommitRequest``
+still has no ``tags`` field, so ``--tags`` and ``--collection`` are
+applied AFTER the commit resolves a dataset id (see
+``apply_publish_extras``): tags become record keywords, and the
+collection is resolved by id or exact name. Both need ``--wait``.
 """
+
 from __future__ import annotations
 
 import mimetypes
@@ -34,6 +36,7 @@ import time
 from http import HTTPStatus
 from pathlib import Path
 from typing import Any, Optional
+from urllib.parse import urlsplit, urlunsplit
 from uuid import UUID
 
 import typer
@@ -151,9 +154,9 @@ def build_commit_request(
     """Construct a ``CommitRequest`` from the publish CLI flags.
 
     Field set is constrained by Task 0 Q2 — the SDK-generated
-    ``CommitRequest`` model has no ``tags`` field, so ``--tags`` is
-    accepted by the command but not wired into this body. ``description``
-    maps to the model's ``summary`` attribute (the actual field name).
+    ``CommitRequest`` model has no ``tags`` field, so ``--tags`` rides the
+    post-commit path (``apply_publish_extras``) rather than this body.
+    ``description`` maps to the model's ``summary`` attribute.
     """
     from geolens.models.commit_request import CommitRequest
     from geolens.types import UNSET
@@ -184,11 +187,31 @@ def construct_dataset_url(
       - Otherwise, fall back to ``<instance>/datasets?job_id=<job_id>``
         which the GeoLens record list can filter on. The user can also
         re-resolve manually via ``GET /jobs/<job_id>`` later.
+
+    fix(#588): the stored instance is always ``/api``-suffixed
+    (``normalize_instance_url`` canonicalizes it that way for credential
+    lookup), so this printed a JSON API endpoint instead of the browser
+    page. Drop that one trailing PATH segment — parsed, not string-
+    trimmed, so a host literally named ``api`` is untouched.
     """
-    base = instance.rstrip("/")
+    base = _web_origin(instance)
     if dataset_id:
         return f"{base}/datasets/{dataset_id}"
     return f"{base}/datasets?job_id={job_id}"
+
+
+def _web_origin(instance: str) -> str:
+    """Strip the canonical trailing ``/api`` path segment for display URLs."""
+    parts = urlsplit(instance.rstrip("/"))
+    if not parts.scheme or not parts.netloc:
+        # Not a parseable absolute URL — leave it alone rather than mangle it.
+        return instance.rstrip("/")
+    path = parts.path.rstrip("/")
+    if path.endswith("/api"):
+        path = path[: -len("/api")]
+    elif path == "/api":
+        path = ""
+    return urlunsplit((parts.scheme, parts.netloc, path, "", ""))
 
 
 # ---------------------------------------------------------------------------
@@ -305,6 +328,24 @@ def _split_tags(tags_csv: str) -> list[str]:
     return out
 
 
+def _resolve_record_id(client: Any, dataset_id: str) -> UUID | str:
+    """Fetch the dataset's parent catalog record id.
+
+    The keyword API is record-scoped and ``Dataset.id != Dataset.record_id``
+    — fix(#588): posting the dataset id returns 404 "Record not found" on
+    every tagged publish. Returns a UUID, or a failure description string.
+    """
+    from geolens.api.datasets import (
+        get_single_dataset_datasets_dataset_id_get as _get,
+    )
+
+    resp = call_sdk(_get.sync_detailed, dataset_id=UUID(dataset_id), client=client)
+    record_id = getattr(resp.parsed, "record_id", None)
+    if int(resp.status_code) != 200 or record_id is None:
+        return f"record lookup failed: HTTP {int(resp.status_code)}"
+    return record_id
+
+
 def _apply_tags(client: Any, dataset_id: str, tags_csv: str) -> list[str]:
     """POST each tag as a record keyword. Returns failure descriptions."""
     from geolens.api.records import (
@@ -312,11 +353,15 @@ def _apply_tags(client: Any, dataset_id: str, tags_csv: str) -> list[str]:
     )
     from geolens.models.keyword_create import KeywordCreate
 
+    record_id = _resolve_record_id(client, dataset_id)
+    if isinstance(record_id, str):
+        return [record_id]
+
     failures: list[str] = []
     for tag in _split_tags(tags_csv):
         resp = call_sdk(
             _kw.sync_detailed,
-            record_id=UUID(dataset_id),
+            record_id=record_id,
             client=client,
             body=KeywordCreate(keyword=tag),
         )

--- a/cli/geolens_cli/publish.py
+++ b/cli/geolens_cli/publish.py
@@ -429,6 +429,24 @@ def _apply_collection(client: Any, dataset_id: str, collection_ref: str) -> list
     return []
 
 
+def _guard(label: str, run: Any) -> list[str]:
+    """Run one post-commit extra, converting ANY raise into a failure line.
+
+    fix(#588): ``call_sdk`` maps httpx timeouts/network errors to
+    ``typer.Exit(EXIT_NETWORK)``. Propagating that from here would abort
+    the command before the dataset URL and job id are printed — losing the
+    recovery info for a dataset that WAS created. Every failure becomes
+    data instead, so ``apply_publish_extras`` never raises.
+    """
+    try:
+        return run()
+    except Exception as exc:  # noqa: BLE001 — see docstring: nothing may escape
+        if isinstance(exc, typer.Exit):
+            # call_sdk already printed the cause (e.g. "Network error: ...").
+            return [f"{label}: request failed (exit code {exc.exit_code})"]
+        return [f"{label}: {type(exc).__name__}: {exc}"]
+
+
 def apply_publish_extras(
     client: Any,
     dataset_id: str,
@@ -437,13 +455,25 @@ def apply_publish_extras(
 ) -> list[str]:
     """Apply post-commit --tags / --collection. Returns failure descriptions.
 
-    The dataset already exists by the time this runs — callers must report
-    failures WITHOUT implying the publish itself failed, then exit non-zero
-    so scripts notice the partial result.
+    Never raises. The dataset already exists by the time this runs — callers
+    must report failures WITHOUT implying the publish itself failed, then
+    exit non-zero so scripts notice the partial result.
+
+    The caller's non-zero exit is deliberately EXIT_GENERIC even for
+    transport failures: re-running `publish` would upload the file again
+    and create a DUPLICATE dataset, so this must not look retryable the
+    way EXIT_NETWORK does.
     """
     failures: list[str] = []
     if tags_csv:
-        failures.extend(_apply_tags(client, dataset_id, tags_csv))
+        failures.extend(
+            _guard("tags", lambda: _apply_tags(client, dataset_id, tags_csv))
+        )
     if collection_ref:
-        failures.extend(_apply_collection(client, dataset_id, collection_ref))
+        failures.extend(
+            _guard(
+                "collection",
+                lambda: _apply_collection(client, dataset_id, collection_ref),
+            )
+        )
     return failures

--- a/cli/tests/test_publish_unit.py
+++ b/cli/tests/test_publish_unit.py
@@ -933,6 +933,50 @@ class TestApplyPublishExtras:
         assert apply_publish_extras(MagicMock(), "d-id", None, None) == []
 
 
+class TestApplyPublishExtrasNeverRaises:
+    """fix(#588): a transport error after commit must not swallow the URL."""
+
+    def test_typer_exit_from_tags_becomes_a_failure_line(self, monkeypatch) -> None:
+        import typer
+
+        import geolens_cli.publish as publish
+
+        def boom(*a, **k):
+            raise typer.Exit(4)
+
+        monkeypatch.setattr(publish, "_apply_tags", boom)
+        failures = publish.apply_publish_extras(MagicMock(), "d-id", "x", None)
+        assert failures == ["tags: request failed (exit code 4)"]
+
+    def test_collection_still_attempted_after_tags_transport_failure(
+        self, monkeypatch
+    ) -> None:
+        import typer
+
+        import geolens_cli.publish as publish
+
+        def boom(*a, **k):
+            raise typer.Exit(4)
+
+        monkeypatch.setattr(publish, "_apply_tags", boom)
+        monkeypatch.setattr(publish, "_apply_collection", lambda *a: [])
+        failures = publish.apply_publish_extras(MagicMock(), "d-id", "x", "Terrain")
+        # tags reported; the collection attempt was NOT skipped (it succeeded)
+        assert failures == ["tags: request failed (exit code 4)"]
+
+    def test_unexpected_exception_is_described_not_propagated(
+        self, monkeypatch
+    ) -> None:
+        import geolens_cli.publish as publish
+
+        def boom(*a, **k):
+            raise ValueError("bad uuid")
+
+        monkeypatch.setattr(publish, "_apply_collection", boom)
+        failures = publish.apply_publish_extras(MagicMock(), "d-id", None, "Terrain")
+        assert failures == ["collection: ValueError: bad uuid"]
+
+
 class TestPublishExtrasCli:
     def test_tags_with_no_wait_exits_usage(
         self, runner, tmp_xdg_home, mock_keyring, monkeypatch, sample_geojson
@@ -973,6 +1017,42 @@ class TestPublishExtrasCli:
 
         result = runner.invoke(app, ["publish", str(sample_geojson), "--tags", "x"])
         assert result.exit_code == 1, result.output
+        assert "Dataset created, but" in result.output
+
+    def test_transport_failure_in_extras_still_prints_dataset_url(
+        self,
+        runner,
+        tmp_xdg_home,
+        mock_keyring,
+        monkeypatch,
+        sample_geojson,
+        patch_sdk_for_publish,
+    ) -> None:
+        """fix(#588): the dataset exists — never exit without the recovery info."""
+        import typer
+
+        import geolens_cli.publish as publish
+        from geolens_cli.main import app
+
+        _seed_login("https://x.example.com", mock_keyring)
+        patch_sdk_for_publish(
+            upload=_ok_upload(),
+            preview=_ok_preview(),
+            commit=_ok_commit(),
+            job_status=_ok_job_status(
+                dataset_id="00000000-0000-0000-0000-000000000042"
+            ),
+        )
+
+        def network_boom(*a, **k):
+            raise typer.Exit(4)
+
+        # Simulate the raise happening INSIDE the extras (call_sdk's behavior).
+        monkeypatch.setattr(publish, "_apply_tags", network_boom)
+
+        result = runner.invoke(app, ["publish", str(sample_geojson), "--tags", "x"])
+        assert result.exit_code == 1, result.output
+        assert "00000000-0000-0000-0000-000000000042" in result.output
         assert "Dataset created, but" in result.output
 
     def test_extras_success_keeps_exit_zero(

--- a/cli/tests/test_publish_unit.py
+++ b/cli/tests/test_publish_unit.py
@@ -7,6 +7,7 @@ main.py and the rich.Progress UI.
 
 Hand-maintained — NOT regenerated.
 """
+
 from __future__ import annotations
 
 import json
@@ -88,6 +89,54 @@ class TestConstructDatasetUrl:
         assert "job_id=job-9" in url
         assert url.startswith("https://x.example.com/datasets")
 
+    def test_fix588_drops_the_canonical_api_suffix_for_the_web_url(self) -> None:
+        """The stored instance is always /api-suffixed; the printed URL must
+        point at the browser page, not the JSON endpoint."""
+        from geolens_cli.publish import construct_dataset_url
+
+        assert (
+            construct_dataset_url(
+                "http://localhost:8080/api", dataset_id="ds-1", job_id="j"
+            )
+            == "http://localhost:8080/datasets/ds-1"
+        )
+        # subpath deployments keep their prefix
+        assert (
+            construct_dataset_url(
+                "https://x.example.com/geolens/api", dataset_id="ds-1", job_id="j"
+            )
+            == "https://x.example.com/geolens/datasets/ds-1"
+        )
+        # no-dataset-id fallback strips it too
+        assert (
+            construct_dataset_url(
+                "http://localhost:8080/api", dataset_id=None, job_id="j9"
+            )
+            == "http://localhost:8080/datasets?job_id=j9"
+        )
+
+    def test_fix588_leaves_a_host_named_api_alone(self) -> None:
+        from geolens_cli.publish import construct_dataset_url
+
+        # Path-segment aware: 'api' as the HOST is not a trailing /api path.
+        assert (
+            construct_dataset_url(
+                "https://api.example.com", dataset_id="ds-1", job_id="j"
+            )
+            == "https://api.example.com/datasets/ds-1"
+        )
+        assert (
+            construct_dataset_url("http://api", dataset_id="ds-1", job_id="j")
+            == "http://api/datasets/ds-1"
+        )
+        # …but a real /api path segment on such a host still goes
+        assert (
+            construct_dataset_url(
+                "https://api.example.com/api", dataset_id="ds-1", job_id="j"
+            )
+            == "https://api.example.com/datasets/ds-1"
+        )
+
 
 class TestBuildCommitRequest:
     def test_title_only(self) -> None:
@@ -139,10 +188,19 @@ class TestIsDuplicateCommitResponse:
     def test_400_with_already_processed_detail(self) -> None:
         from geolens_cli.publish import is_duplicate_commit_response
 
-        resp = MagicMock(status_code=HTTPStatus.BAD_REQUEST, parsed=MagicMock(detail="Job already processed"))
+        resp = MagicMock(
+            status_code=HTTPStatus.BAD_REQUEST,
+            parsed=MagicMock(detail="Job already processed"),
+        )
         # Make isinstance(resp.parsed, ProblemDetail) work for the helper:
         from geolens.models.problem_detail import ProblemDetail
-        resp.parsed = ProblemDetail(detail="Job already processed", status=400, title="Bad Request", type_="about:blank")
+
+        resp.parsed = ProblemDetail(
+            detail="Job already processed",
+            status=400,
+            title="Bad Request",
+            type_="about:blank",
+        )
         resp.status_code = HTTPStatus.BAD_REQUEST
         assert is_duplicate_commit_response(resp) is True
 
@@ -152,7 +210,12 @@ class TestIsDuplicateCommitResponse:
 
         resp = MagicMock()
         resp.status_code = HTTPStatus.CONFLICT
-        resp.parsed = ProblemDetail(detail="Job already processed", status=409, title="Conflict", type_="about:blank")
+        resp.parsed = ProblemDetail(
+            detail="Job already processed",
+            status=409,
+            title="Conflict",
+            type_="about:blank",
+        )
         assert is_duplicate_commit_response(resp) is True
 
     def test_400_with_unrelated_detail_returns_false(self) -> None:
@@ -161,7 +224,12 @@ class TestIsDuplicateCommitResponse:
 
         resp = MagicMock()
         resp.status_code = HTTPStatus.BAD_REQUEST
-        resp.parsed = ProblemDetail(detail="Validation failed", status=400, title="Bad Request", type_="about:blank")
+        resp.parsed = ProblemDetail(
+            detail="Validation failed",
+            status=400,
+            title="Bad Request",
+            type_="about:blank",
+        )
         assert is_duplicate_commit_response(resp) is False
 
     def test_202_returns_false(self) -> None:
@@ -251,9 +319,7 @@ def patch_sdk_for_publish(monkeypatch):
     def _install(*, upload, preview, commit, job_status=None):
         # BUG-034: publish now invokes upload_file via call_sdk with keyword
         # args (client=, path=); accept both positional and keyword shapes.
-        monkeypatch.setattr(
-            "geolens_cli.publish.upload_file", lambda *a, **k: upload
-        )
+        monkeypatch.setattr("geolens_cli.publish.upload_file", lambda *a, **k: upload)
         monkeypatch.setattr(
             "geolens.api.datasets.preview_file_ingest_preview_job_id_post.sync_detailed",
             lambda **kw: preview,
@@ -282,7 +348,9 @@ def _ok_upload(job_id: str = "00000000-0000-0000-0000-000000000001"):
 def _ok_preview():
     from geolens_cli import publish as _publish
 
-    return MagicMock(status_code=HTTPStatus(_publish.PREVIEW_OK_STATUS), parsed=MagicMock())
+    return MagicMock(
+        status_code=HTTPStatus(_publish.PREVIEW_OK_STATUS), parsed=MagicMock()
+    )
 
 
 def _ok_commit(job_id: str = "00000000-0000-0000-0000-000000000001"):
@@ -301,7 +369,9 @@ def _ok_job_status(dataset_id: str | None, status: str = "completed"):
     parsed = MagicMock()
     parsed.dataset_id = UUID(dataset_id) if dataset_id else None
     parsed.status = status
-    return MagicMock(status_code=HTTPStatus(_publish.JOB_STATUS_OK_STATUS), parsed=parsed)
+    return MagicMock(
+        status_code=HTTPStatus(_publish.JOB_STATUS_OK_STATUS), parsed=parsed
+    )
 
 
 class TestPublishCli:
@@ -318,7 +388,13 @@ class TestPublishCli:
         assert result.exit_code != 0, result.output
 
     def test_publish_success_prints_dataset_url(
-        self, runner, tmp_xdg_home, mock_keyring, monkeypatch, sample_geojson, patch_sdk_for_publish
+        self,
+        runner,
+        tmp_xdg_home,
+        mock_keyring,
+        monkeypatch,
+        sample_geojson,
+        patch_sdk_for_publish,
     ) -> None:
         from geolens_cli.main import app
 
@@ -328,15 +404,26 @@ class TestPublishCli:
             upload=_ok_upload(),
             preview=_ok_preview(),
             commit=_ok_commit(),
-            job_status=_ok_job_status(dataset_id="00000000-0000-0000-0000-000000000042"),
+            job_status=_ok_job_status(
+                dataset_id="00000000-0000-0000-0000-000000000042"
+            ),
         )
 
         result = runner.invoke(app, ["publish", str(sample_geojson)])
         assert result.exit_code == 0, result.output
-        assert "https://x.example.com/datasets/00000000-0000-0000-0000-000000000042" in result.output
+        assert (
+            "https://x.example.com/datasets/00000000-0000-0000-0000-000000000042"
+            in result.output
+        )
 
     def test_publish_no_wait_emits_job_search_url(
-        self, runner, tmp_xdg_home, mock_keyring, monkeypatch, sample_geojson, patch_sdk_for_publish
+        self,
+        runner,
+        tmp_xdg_home,
+        mock_keyring,
+        monkeypatch,
+        sample_geojson,
+        patch_sdk_for_publish,
     ) -> None:
         from geolens_cli.main import app
 
@@ -354,7 +441,13 @@ class TestPublishCli:
         assert "job_id=00000000-0000-0000-0000-000000000001" in result.output
 
     def test_publish_409_exits_generic(
-        self, runner, tmp_xdg_home, mock_keyring, monkeypatch, sample_geojson, patch_sdk_for_publish
+        self,
+        runner,
+        tmp_xdg_home,
+        mock_keyring,
+        monkeypatch,
+        sample_geojson,
+        patch_sdk_for_publish,
     ) -> None:
         from geolens_cli.main import app
         from geolens.models.problem_detail import ProblemDetail
@@ -384,7 +477,13 @@ class TestPublishCli:
         assert "already committed" in result.output
 
     def test_publish_400_already_processed_exits_generic(
-        self, runner, tmp_xdg_home, mock_keyring, monkeypatch, sample_geojson, patch_sdk_for_publish
+        self,
+        runner,
+        tmp_xdg_home,
+        mock_keyring,
+        monkeypatch,
+        sample_geojson,
+        patch_sdk_for_publish,
     ) -> None:
         """Task 0 Q3: backend actually emits 400 (not 409) for duplicate commits."""
         from geolens_cli.main import app
@@ -413,7 +512,13 @@ class TestPublishCli:
         assert "already committed" in result.output
 
     def test_progress_suppressed_non_tty(
-        self, runner, tmp_xdg_home, mock_keyring, monkeypatch, sample_geojson, patch_sdk_for_publish
+        self,
+        runner,
+        tmp_xdg_home,
+        mock_keyring,
+        monkeypatch,
+        sample_geojson,
+        patch_sdk_for_publish,
     ) -> None:
         """CliRunner output is not a TTY; rich.Progress(disable=True) emits nothing."""
         from geolens_cli.main import app
@@ -424,7 +529,9 @@ class TestPublishCli:
             upload=_ok_upload(),
             preview=_ok_preview(),
             commit=_ok_commit(),
-            job_status=_ok_job_status(dataset_id="00000000-0000-0000-0000-000000000042"),
+            job_status=_ok_job_status(
+                dataset_id="00000000-0000-0000-0000-000000000042"
+            ),
         )
 
         result = runner.invoke(app, ["publish", str(sample_geojson)])
@@ -433,7 +540,13 @@ class TestPublishCli:
             assert spinner not in result.output
 
     def test_json_mode_emits_payload(
-        self, runner, tmp_xdg_home, mock_keyring, monkeypatch, sample_geojson, patch_sdk_for_publish
+        self,
+        runner,
+        tmp_xdg_home,
+        mock_keyring,
+        monkeypatch,
+        sample_geojson,
+        patch_sdk_for_publish,
     ) -> None:
         from geolens_cli.main import app
 
@@ -443,17 +556,27 @@ class TestPublishCli:
             upload=_ok_upload(),
             preview=_ok_preview(),
             commit=_ok_commit(),
-            job_status=_ok_job_status(dataset_id="00000000-0000-0000-0000-000000000042"),
+            job_status=_ok_job_status(
+                dataset_id="00000000-0000-0000-0000-000000000042"
+            ),
         )
 
         result = runner.invoke(app, ["--json", "publish", str(sample_geojson)])
         assert result.exit_code == 0, result.output
         payload = json.loads(result.output)
-        assert payload["dataset_url"].endswith("/datasets/00000000-0000-0000-0000-000000000042")
+        assert payload["dataset_url"].endswith(
+            "/datasets/00000000-0000-0000-0000-000000000042"
+        )
         assert payload["job_id"] == "00000000-0000-0000-0000-000000000001"
 
     def test_publish_uses_filename_stem_when_no_name(
-        self, runner, tmp_xdg_home, mock_keyring, monkeypatch, sample_geojson, patch_sdk_for_publish
+        self,
+        runner,
+        tmp_xdg_home,
+        mock_keyring,
+        monkeypatch,
+        sample_geojson,
+        patch_sdk_for_publish,
     ) -> None:
         """The CommitRequest title falls back to file.stem when --name is omitted."""
         from geolens_cli.main import app
@@ -477,7 +600,9 @@ class TestPublishCli:
                 ),
             )
 
-        monkeypatch.setattr("geolens_cli.publish.upload_file", lambda *a, **k: _ok_upload())
+        monkeypatch.setattr(
+            "geolens_cli.publish.upload_file", lambda *a, **k: _ok_upload()
+        )
         monkeypatch.setattr(
             "geolens.api.datasets.preview_file_ingest_preview_job_id_post.sync_detailed",
             lambda **kw: _ok_preview(),
@@ -516,7 +641,9 @@ class TestPublishCli:
                 ),
             )
 
-        monkeypatch.setattr("geolens_cli.publish.upload_file", lambda *a, **k: _ok_upload())
+        monkeypatch.setattr(
+            "geolens_cli.publish.upload_file", lambda *a, **k: _ok_upload()
+        )
         monkeypatch.setattr(
             "geolens.api.datasets.preview_file_ingest_preview_job_id_post.sync_detailed",
             lambda **kw: _ok_preview(),
@@ -527,7 +654,16 @@ class TestPublishCli:
         )
 
         result = runner.invoke(
-            app, ["publish", str(sample_geojson), "--name", "My Cities", "--description", "hello", "--no-wait"]
+            app,
+            [
+                "publish",
+                str(sample_geojson),
+                "--name",
+                "My Cities",
+                "--description",
+                "hello",
+                "--no-wait",
+            ],
         )
         assert result.exit_code == 0, result.output
         assert isinstance(captured["body"], CommitRequest)
@@ -586,7 +722,12 @@ class TestPublishNetworkErrors:
         assert result.exit_code == EXIT_NETWORK, result.output
 
     def test_job_status_poll_network_error_exits_network(
-        self, runner, tmp_xdg_home, mock_keyring, monkeypatch, sample_geojson,
+        self,
+        runner,
+        tmp_xdg_home,
+        mock_keyring,
+        monkeypatch,
+        sample_geojson,
         patch_sdk_for_publish,
     ) -> None:
         import httpx
@@ -652,7 +793,85 @@ class TestSplitTags:
     def test_trims_dedupes_and_preserves_order(self) -> None:
         from geolens_cli.publish import _split_tags
 
-        assert _split_tags(" hydro, Hydro, dem ,, terrain ") == ["hydro", "dem", "terrain"]
+        assert _split_tags(" hydro, Hydro, dem ,, terrain ") == [
+            "hydro",
+            "dem",
+            "terrain",
+        ]
+
+
+class TestResolveRecordId:
+    """fix(#588): keywords are RECORD-scoped; Dataset.id != Dataset.record_id."""
+
+    def test_returns_record_id_not_dataset_id(self, monkeypatch) -> None:
+        import geolens_cli.publish as publish
+
+        dataset_id = "40e4c02d-d509-4046-8718-baadad2b59c7"
+        record_id = UUID("d736d1bb-0191-4ca4-a473-c2bcc6d123da")
+        resp = MagicMock(status_code=200, parsed=MagicMock(record_id=record_id))
+        monkeypatch.setattr(publish, "call_sdk", lambda *a, **k: resp)
+
+        got = publish._resolve_record_id(MagicMock(), dataset_id)
+        assert got == record_id
+        assert str(got) != dataset_id
+
+    def test_lookup_failure_returns_description(self, monkeypatch) -> None:
+        import geolens_cli.publish as publish
+
+        resp = MagicMock(status_code=404, parsed=None)
+        monkeypatch.setattr(publish, "call_sdk", lambda *a, **k: resp)
+        got = publish._resolve_record_id(
+            MagicMock(), "40e4c02d-d509-4046-8718-baadad2b59c7"
+        )
+        assert isinstance(got, str) and "record lookup failed" in got
+
+
+class TestApplyTags:
+    def test_posts_keywords_against_the_record_id(self, monkeypatch) -> None:
+        import geolens_cli.publish as publish
+
+        dataset_id = "40e4c02d-d509-4046-8718-baadad2b59c7"
+        record_id = UUID("d736d1bb-0191-4ca4-a473-c2bcc6d123da")
+        monkeypatch.setattr(publish, "_resolve_record_id", lambda *a: record_id)
+        seen: list = []
+
+        def fake_call_sdk(fn, **kwargs):
+            seen.append(kwargs)
+            return MagicMock(status_code=201)
+
+        monkeypatch.setattr(publish, "call_sdk", fake_call_sdk)
+        failures = publish._apply_tags(MagicMock(), dataset_id, "hydro, dem")
+
+        assert failures == []
+        assert [k["record_id"] for k in seen] == [record_id, record_id]
+        assert [k["body"].keyword for k in seen] == ["hydro", "dem"]
+
+    def test_record_lookup_failure_short_circuits(self, monkeypatch) -> None:
+        import geolens_cli.publish as publish
+
+        monkeypatch.setattr(
+            publish, "_resolve_record_id", lambda *a: "record lookup failed: HTTP 404"
+        )
+
+        def explode(*a, **k):  # pragma: no cover - must not be reached
+            raise AssertionError("keyword POST attempted despite failed record lookup")
+
+        monkeypatch.setattr(publish, "call_sdk", explode)
+        assert publish._apply_tags(MagicMock(), "d-id", "x") == [
+            "record lookup failed: HTTP 404"
+        ]
+
+    def test_non_201_is_reported_per_tag(self, monkeypatch) -> None:
+        import geolens_cli.publish as publish
+
+        monkeypatch.setattr(publish, "_resolve_record_id", lambda *a: UUID(int=7))
+        monkeypatch.setattr(
+            publish, "call_sdk", lambda *a, **k: MagicMock(status_code=500)
+        )
+        assert publish._apply_tags(MagicMock(), "d-id", "x,y") == [
+            "tag 'x': HTTP 500",
+            "tag 'y': HTTP 500",
+        ]
 
 
 class TestResolveCollectionId:
@@ -666,9 +885,7 @@ class TestResolveCollectionId:
         resp = MagicMock()
         resp.status_code = 200
         resp.parsed = MagicMock(
-            collections=[
-                MagicMock(id=UUID(cid), name=name) for name, cid in names_ids
-            ]
+            collections=[MagicMock(id=UUID(cid), name=name) for name, cid in names_ids]
         )
         # MagicMock(name=...) sets the mock's name, not the attribute
         for m, (name, _cid) in zip(resp.parsed.collections, names_ids):
@@ -679,8 +896,10 @@ class TestResolveCollectionId:
         import geolens_cli.publish as publish
 
         resp = self._collections_response(
-            [("Human World", "00000000-0000-0000-0000-000000000001"),
-             ("Terrain", "00000000-0000-0000-0000-000000000002")]
+            [
+                ("Human World", "00000000-0000-0000-0000-000000000001"),
+                ("Terrain", "00000000-0000-0000-0000-000000000002"),
+            ]
         )
         monkeypatch.setattr(publish, "call_sdk", lambda *a, **k: resp)
         got = publish._resolve_collection_id(MagicMock(), "human world")
@@ -689,7 +908,9 @@ class TestResolveCollectionId:
     def test_missing_name_returns_failure_string(self, monkeypatch) -> None:
         import geolens_cli.publish as publish
 
-        resp = self._collections_response([("Terrain", "00000000-0000-0000-0000-000000000002")])
+        resp = self._collections_response(
+            [("Terrain", "00000000-0000-0000-0000-000000000002")]
+        )
         monkeypatch.setattr(publish, "call_sdk", lambda *a, **k: resp)
         got = publish._resolve_collection_id(MagicMock(), "nope")
         assert isinstance(got, str) and "not found" in got
@@ -700,7 +921,9 @@ class TestApplyPublishExtras:
         import geolens_cli.publish as publish
 
         monkeypatch.setattr(publish, "_apply_tags", lambda *a: ["tag 'x': HTTP 500"])
-        monkeypatch.setattr(publish, "_apply_collection", lambda *a: ["collection add: HTTP 404"])
+        monkeypatch.setattr(
+            publish, "_apply_collection", lambda *a: ["collection add: HTTP 404"]
+        )
         failures = publish.apply_publish_extras(MagicMock(), "d-id", "x", "c")
         assert failures == ["tag 'x': HTTP 500", "collection add: HTTP 404"]
 
@@ -724,7 +947,13 @@ class TestPublishExtrasCli:
         assert "--wait" in result.output
 
     def test_extras_failure_reports_partial_and_exits_nonzero(
-        self, runner, tmp_xdg_home, mock_keyring, monkeypatch, sample_geojson, patch_sdk_for_publish
+        self,
+        runner,
+        tmp_xdg_home,
+        mock_keyring,
+        monkeypatch,
+        sample_geojson,
+        patch_sdk_for_publish,
     ) -> None:
         import geolens_cli.publish as publish
         from geolens_cli.main import app
@@ -734,7 +963,9 @@ class TestPublishExtrasCli:
             upload=_ok_upload(),
             preview=_ok_preview(),
             commit=_ok_commit(),
-            job_status=_ok_job_status(dataset_id="00000000-0000-0000-0000-000000000042"),
+            job_status=_ok_job_status(
+                dataset_id="00000000-0000-0000-0000-000000000042"
+            ),
         )
         monkeypatch.setattr(
             publish, "apply_publish_extras", lambda *a, **k: ["tag 'x': HTTP 500"]
@@ -745,7 +976,13 @@ class TestPublishExtrasCli:
         assert "Dataset created, but" in result.output
 
     def test_extras_success_keeps_exit_zero(
-        self, runner, tmp_xdg_home, mock_keyring, monkeypatch, sample_geojson, patch_sdk_for_publish
+        self,
+        runner,
+        tmp_xdg_home,
+        mock_keyring,
+        monkeypatch,
+        sample_geojson,
+        patch_sdk_for_publish,
     ) -> None:
         import geolens_cli.publish as publish
         from geolens_cli.main import app
@@ -755,7 +992,9 @@ class TestPublishExtrasCli:
             upload=_ok_upload(),
             preview=_ok_preview(),
             commit=_ok_commit(),
-            job_status=_ok_job_status(dataset_id="00000000-0000-0000-0000-000000000042"),
+            job_status=_ok_job_status(
+                dataset_id="00000000-0000-0000-0000-000000000042"
+            ),
         )
         applied: dict = {}
 
@@ -767,7 +1006,14 @@ class TestPublishExtrasCli:
 
         result = runner.invoke(
             app,
-            ["publish", str(sample_geojson), "--tags", "hydro,dem", "--collection", "Terrain"],
+            [
+                "publish",
+                str(sample_geojson),
+                "--tags",
+                "hydro,dem",
+                "--collection",
+                "Terrain",
+            ],
         )
         assert result.exit_code == 0, result.output
         assert applied["args"] == (

--- a/cli/tests/test_publish_unit.py
+++ b/cli/tests/test_publish_unit.py
@@ -641,3 +641,137 @@ class TestResolveDatasetIdNetworkError:
                 monotonic=iter([0.0, 1.0]).__next__,
             )
         assert exc_info.value.exit_code == EXIT_NETWORK
+
+
+# ---------------------------------------------------------------------------
+# fix(#569) — --tags / --collection wiring
+# ---------------------------------------------------------------------------
+
+
+class TestSplitTags:
+    def test_trims_dedupes_and_preserves_order(self) -> None:
+        from geolens_cli.publish import _split_tags
+
+        assert _split_tags(" hydro, Hydro, dem ,, terrain ") == ["hydro", "dem", "terrain"]
+
+
+class TestResolveCollectionId:
+    def test_uuid_passthrough(self) -> None:
+        from geolens_cli.publish import _resolve_collection_id
+
+        cid = "00000000-0000-0000-0000-00000000abcd"
+        assert _resolve_collection_id(MagicMock(), cid) == UUID(cid)
+
+    def _collections_response(self, names_ids: list[tuple[str, str]]) -> MagicMock:
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.parsed = MagicMock(
+            collections=[
+                MagicMock(id=UUID(cid), name=name) for name, cid in names_ids
+            ]
+        )
+        # MagicMock(name=...) sets the mock's name, not the attribute
+        for m, (name, _cid) in zip(resp.parsed.collections, names_ids):
+            m.name = name
+        return resp
+
+    def test_exact_name_match_case_insensitive(self, monkeypatch) -> None:
+        import geolens_cli.publish as publish
+
+        resp = self._collections_response(
+            [("Human World", "00000000-0000-0000-0000-000000000001"),
+             ("Terrain", "00000000-0000-0000-0000-000000000002")]
+        )
+        monkeypatch.setattr(publish, "call_sdk", lambda *a, **k: resp)
+        got = publish._resolve_collection_id(MagicMock(), "human world")
+        assert got == UUID("00000000-0000-0000-0000-000000000001")
+
+    def test_missing_name_returns_failure_string(self, monkeypatch) -> None:
+        import geolens_cli.publish as publish
+
+        resp = self._collections_response([("Terrain", "00000000-0000-0000-0000-000000000002")])
+        monkeypatch.setattr(publish, "call_sdk", lambda *a, **k: resp)
+        got = publish._resolve_collection_id(MagicMock(), "nope")
+        assert isinstance(got, str) and "not found" in got
+
+
+class TestApplyPublishExtras:
+    def test_collects_failures_from_both_paths(self, monkeypatch) -> None:
+        import geolens_cli.publish as publish
+
+        monkeypatch.setattr(publish, "_apply_tags", lambda *a: ["tag 'x': HTTP 500"])
+        monkeypatch.setattr(publish, "_apply_collection", lambda *a: ["collection add: HTTP 404"])
+        failures = publish.apply_publish_extras(MagicMock(), "d-id", "x", "c")
+        assert failures == ["tag 'x': HTTP 500", "collection add: HTTP 404"]
+
+    def test_noop_without_flags(self) -> None:
+        from geolens_cli.publish import apply_publish_extras
+
+        assert apply_publish_extras(MagicMock(), "d-id", None, None) == []
+
+
+class TestPublishExtrasCli:
+    def test_tags_with_no_wait_exits_usage(
+        self, runner, tmp_xdg_home, mock_keyring, monkeypatch, sample_geojson
+    ) -> None:
+        from geolens_cli.main import app
+
+        _seed_login("https://x.example.com", mock_keyring)
+        result = runner.invoke(
+            app, ["publish", str(sample_geojson), "--no-wait", "--tags", "a,b"]
+        )
+        assert result.exit_code == 2, result.output
+        assert "--wait" in result.output
+
+    def test_extras_failure_reports_partial_and_exits_nonzero(
+        self, runner, tmp_xdg_home, mock_keyring, monkeypatch, sample_geojson, patch_sdk_for_publish
+    ) -> None:
+        import geolens_cli.publish as publish
+        from geolens_cli.main import app
+
+        _seed_login("https://x.example.com", mock_keyring)
+        patch_sdk_for_publish(
+            upload=_ok_upload(),
+            preview=_ok_preview(),
+            commit=_ok_commit(),
+            job_status=_ok_job_status(dataset_id="00000000-0000-0000-0000-000000000042"),
+        )
+        monkeypatch.setattr(
+            publish, "apply_publish_extras", lambda *a, **k: ["tag 'x': HTTP 500"]
+        )
+
+        result = runner.invoke(app, ["publish", str(sample_geojson), "--tags", "x"])
+        assert result.exit_code == 1, result.output
+        assert "Dataset created, but" in result.output
+
+    def test_extras_success_keeps_exit_zero(
+        self, runner, tmp_xdg_home, mock_keyring, monkeypatch, sample_geojson, patch_sdk_for_publish
+    ) -> None:
+        import geolens_cli.publish as publish
+        from geolens_cli.main import app
+
+        _seed_login("https://x.example.com", mock_keyring)
+        patch_sdk_for_publish(
+            upload=_ok_upload(),
+            preview=_ok_preview(),
+            commit=_ok_commit(),
+            job_status=_ok_job_status(dataset_id="00000000-0000-0000-0000-000000000042"),
+        )
+        applied: dict = {}
+
+        def fake_extras(client, dataset_id, tags, collection):
+            applied["args"] = (dataset_id, tags, collection)
+            return []
+
+        monkeypatch.setattr(publish, "apply_publish_extras", fake_extras)
+
+        result = runner.invoke(
+            app,
+            ["publish", str(sample_geojson), "--tags", "hydro,dem", "--collection", "Terrain"],
+        )
+        assert result.exit_code == 0, result.output
+        assert applied["args"] == (
+            "00000000-0000-0000-0000-000000000042",
+            "hydro,dem",
+            "Terrain",
+        )

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -161,7 +161,7 @@ services:
       POSTGRES_USER: ${POSTGRES_USER}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
     ports:
-      - "127.0.0.1:${DB_PORT:-5432}:5432"
+      - "127.0.0.1:${DB_PORT:-5434}:5432" # fix(#444): fallback matches .env.example/install.sh/docs (5434)
     volumes:
       - pgdata:/var/lib/postgresql/data
       - ./scripts/init-db.sh:/docker-entrypoint-initdb.d/10-init.sh:ro
@@ -250,7 +250,7 @@ services:
       - /home/appuser:size=128m,uid=1001,gid=1001
       - /var/run:size=8m
     ports:
-      - "127.0.0.1:${API_PORT:-8000}:8000"
+      - "127.0.0.1:${API_PORT:-8001}:8000" # fix(#444): fallback matches .env.example/install.sh/docs (8001)
     volumes:
       - upload_staging:/app/staging
     environment:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -161,7 +161,7 @@ services:
       POSTGRES_USER: ${POSTGRES_USER}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
     ports:
-      - "127.0.0.1:${DB_PORT:-5434}:5432" # fix(#444): fallback matches .env.example/install.sh/docs (5434)
+      - "127.0.0.1:${DB_PORT:-5432}:5432"
     volumes:
       - pgdata:/var/lib/postgresql/data
       - ./scripts/init-db.sh:/docker-entrypoint-initdb.d/10-init.sh:ro
@@ -250,7 +250,7 @@ services:
       - /home/appuser:size=128m,uid=1001,gid=1001
       - /var/run:size=8m
     ports:
-      - "127.0.0.1:${API_PORT:-8001}:8000" # fix(#444): fallback matches .env.example/install.sh/docs (8001)
+      - "127.0.0.1:${API_PORT:-8000}:8000"
     volumes:
       - upload_staging:/app/staging
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -161,7 +161,7 @@ services:
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
     ports:
       # Host-port fallback (5434 from .env, 5432 bare).
-      - "127.0.0.1:${DB_PORT:-5434}:5432" # fix(#444): fallback matches .env.example/install.sh/docs (5434)
+      - "127.0.0.1:${DB_PORT:-5432}:5432"
     volumes:
       - pgdata:/var/lib/postgresql/data
       # GAP-021: :ro mirrors the sibling conf mount and every repo-file mount on
@@ -267,7 +267,7 @@ services:
     entrypoint: ["/app/scripts/api-entrypoint.sh"]
     ports:
       # Host-port fallback (8001 from .env, 8000 bare).
-      - "127.0.0.1:${API_PORT:-8001}:8000" # fix(#444): fallback matches .env.example/install.sh/docs (8001)
+      - "127.0.0.1:${API_PORT:-8000}:8000"
     volumes:
       - ./.dockerignore:/app/.dockerignore:ro
       - ./.env.example:/app/.env.example:ro

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -161,7 +161,7 @@ services:
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
     ports:
       # Host-port fallback (5434 from .env, 5432 bare).
-      - "127.0.0.1:${DB_PORT:-5432}:5432"
+      - "127.0.0.1:${DB_PORT:-5434}:5432" # fix(#444): fallback matches .env.example/install.sh/docs (5434)
     volumes:
       - pgdata:/var/lib/postgresql/data
       # GAP-021: :ro mirrors the sibling conf mount and every repo-file mount on
@@ -267,7 +267,7 @@ services:
     entrypoint: ["/app/scripts/api-entrypoint.sh"]
     ports:
       # Host-port fallback (8001 from .env, 8000 bare).
-      - "127.0.0.1:${API_PORT:-8000}:8000"
+      - "127.0.0.1:${API_PORT:-8001}:8000" # fix(#444): fallback matches .env.example/install.sh/docs (8001)
     volumes:
       - ./.dockerignore:/app/.dockerignore:ro
       - ./.env.example:/app/.env.example:ro

--- a/frontend/src/components/dataset/DatasetStatsBar.tsx
+++ b/frontend/src/components/dataset/DatasetStatsBar.tsx
@@ -1,5 +1,5 @@
 import { useTranslation } from 'react-i18next';
-import { formatNumber, formatRelativeDate } from '@/lib/format';
+import { formatGsd, formatNumber, formatRelativeDate } from '@/lib/format';
 import { getGeometryTypeLabel } from '@/i18n/labels';
 import { computeRasterGsd } from '@/lib/geo-utils';
 import type { DatasetResponse } from '@/types/api';
@@ -38,7 +38,7 @@ interface DatasetStatsBarProps {
 }
 
 export function DatasetStatsBar({ dataset, className }: DatasetStatsBarProps) {
-  const { t } = useTranslation('dataset');
+  const { t, i18n } = useTranslation('dataset');
 
   const isRaster = dataset.record_type === 'raster_dataset';
   const isVrt = dataset.record_type === 'vrt_dataset';
@@ -59,7 +59,16 @@ export function DatasetStatsBar({ dataset, className }: DatasetStatsBarProps) {
     if (rasterGsd != null) {
       cells.push({
         label: t('raster.resolution', { defaultValue: 'Resolution' }),
-        value: `${rasterGsd} m`,
+        // fix(#569): res_x/res_y are CRS units — a geographic CRS delivers
+        // degrees, which must not be labeled meters.
+        value: formatGsd(
+          rasterGsd,
+          {
+            isGeographic: dataset.raster?.crs_is_geographic,
+            crs: dataset.raster?.epsg != null ? `EPSG:${dataset.raster.epsg}` : null,
+          },
+          i18n.language,
+        ),
         mono: true,
       });
     }

--- a/frontend/src/components/search/SearchResultCard.tsx
+++ b/frontend/src/components/search/SearchResultCard.tsx
@@ -10,6 +10,7 @@ import { BBoxPreview } from '@/components/layout/BBoxPreview';
 import { OriginBadge, datasetOrigin } from '@/components/dataset/OriginBadge';
 import { RecordTypeBadge } from './RecordTypeBadge';
 import { formatProvenanceTime } from '@/lib/provenance-attribution';
+import { formatGsd } from '@/lib/format';
 import { extractBbox, geometryIcon } from '@/lib/geo-utils';
 import { getGeometryTypeLabel } from '@/i18n/labels';
 import { ingestionStatusColors, syntheticBadgeColor } from '@/lib/status-colors';
@@ -32,15 +33,6 @@ const statusVariants: Record<string, 'outline' | 'secondary'> = {
   archived: 'secondary',
   deprecated: 'outline',
 };
-
-function formatGsd(gsd: number, crs: string | null | undefined, locale: string): string {
-  // For geographic CRS (degree-based), don't show GSD — it's meaningless as a distance
-  if (crs && /^EPSG:4326$/i.test(crs)) return '';
-  // Sub-meter
-  if (gsd < 1) return `${(gsd * 100).toLocaleString(locale, { maximumFractionDigits: 0 })} cm`;
-  if (gsd < 1000) return `${Math.round(gsd).toLocaleString(locale)} m`;
-  return `${(gsd / 1000).toLocaleString(locale, { minimumFractionDigits: 1, maximumFractionDigits: 1 })} km`;
-}
 
 function capitalizeVrtType(vrtType: string): string {
   // 'mosaic' -> 'Mosaic', 'band_stack' -> 'Band Stack'
@@ -75,7 +67,7 @@ function buildCardSpecs(
   }
 
   if (isRaster && properties.gsd != null) {
-    const label = formatGsd(properties.gsd, properties.crs, locale);
+    const label = formatGsd(properties.gsd, { isGeographic: properties.crs_is_geographic, crs: properties.crs }, locale);
     if (label) specs.push({ icon: Ruler, label });
   }
 
@@ -128,7 +120,7 @@ function buildAutoDescription(
     case 'raster_dataset':
       return t('card.autoDesc.raster', {
         count: properties.band_count ?? 0,
-        gsd: properties.gsd != null ? formatGsd(properties.gsd, properties.crs, locale) : '',
+        gsd: properties.gsd != null ? formatGsd(properties.gsd, { isGeographic: properties.crs_is_geographic, crs: properties.crs }, locale) : '',
       });
     case 'vrt_dataset':
       return t('card.autoDesc.vrt', {

--- a/frontend/src/lib/__tests__/format.test.ts
+++ b/frontend/src/lib/__tests__/format.test.ts
@@ -1,4 +1,4 @@
-import { formatDateTimeSmart, formatBytes } from '@/lib/format';
+import { formatDateTimeSmart, formatBytes, formatGsd } from '@/lib/format';
 
 describe('formatDateTimeSmart', () => {
   beforeEach(() => {
@@ -67,5 +67,35 @@ describe('formatBytes', () => {
 
   it('returns a GB value for 2_500_000_000 bytes', () => {
     expect(formatBytes(2_500_000_000)).toContain('GB');
+  });
+});
+
+describe('formatGsd', () => {
+  it('formats projected-CRS gsd as cm/m/km (unchanged behavior)', () => {
+    expect(formatGsd(0.5, { isGeographic: false }, 'en-US')).toBe('50 cm');
+    expect(formatGsd(30, { isGeographic: false }, 'en-US')).toBe('30 m');
+    expect(formatGsd(2000, { isGeographic: false }, 'en-US')).toBe('2.0 km');
+  });
+
+  it('fix(#569): geographic-CRS gsd renders arc units with approx ground distance, not meters', () => {
+    // 60 arc-seconds = 1/60 degree — previously rendered "2 cm"
+    const label = formatGsd(1 / 60, { isGeographic: true }, 'en-US');
+    expect(label).toContain('60″');
+    expect(label).toContain('≈');
+    expect(label).toContain('km');
+    // arc-minutes and degrees branches
+    expect(formatGsd(0.5, { isGeographic: true }, 'en-US')).toContain('30′');
+    expect(formatGsd(2, { isGeographic: true }, 'en-US')).toContain('2°');
+  });
+
+  it('falls back to the EPSG:4326 heuristic for payloads without the flag', () => {
+    expect(formatGsd(1 / 60, { crs: 'EPSG:4326' }, 'en-US')).toContain('″');
+    // unknown CRS without the flag keeps the legacy meters formatting
+    expect(formatGsd(30, { crs: 'EPSG:32618' }, 'en-US')).toBe('30 m');
+  });
+
+  it('explicit flag wins over the CRS heuristic', () => {
+    expect(formatGsd(1 / 60, { isGeographic: true, crs: 'EPSG:9518' }, 'en-US')).toContain('″');
+    expect(formatGsd(30, { isGeographic: false, crs: 'EPSG:4326' }, 'en-US')).toBe('30 m');
   });
 });

--- a/frontend/src/lib/__tests__/format.test.ts
+++ b/frontend/src/lib/__tests__/format.test.ts
@@ -88,6 +88,18 @@ describe('formatGsd', () => {
     expect(formatGsd(2, { isGeographic: true }, 'en-US')).toContain('2°');
   });
 
+  it('fix(#588): sub-arcsecond pixels keep their precision instead of rounding to 0\u2033', () => {
+    // ~30 cm EPSG:4326 imagery ≈ 0.0097 arc-seconds — a fixed 1-decimal
+    // format rendered this as '0″ (≈30 cm)'.
+    const label = formatGsd(0.3 / 111_320, { isGeographic: true }, 'en-US');
+    expect(label).not.toMatch(/(^|[^.\d])0\u2033/);
+    expect(label).toContain('0.0097');
+    expect(label).toContain('30 cm');
+    // 1″ and above keep the compact single-decimal form
+    expect(formatGsd(1 / 3600, { isGeographic: true }, 'en-US')).toContain('1\u2033');
+    expect(formatGsd(1.5 / 3600, { isGeographic: true }, 'en-US')).toContain('1.5\u2033');
+  });
+
   it('falls back to the EPSG:4326 heuristic for payloads without the flag', () => {
     expect(formatGsd(1 / 60, { crs: 'EPSG:4326' }, 'en-US')).toContain('″');
     // unknown CRS without the flag keeps the legacy meters formatting

--- a/frontend/src/lib/format.ts
+++ b/frontend/src/lib/format.ts
@@ -75,6 +75,46 @@ export function formatRelativeDate(dateString: string | null): string {
   return result.relative;
 }
 
+/** Approx meters per degree of latitude (equatorial) — for the "≈" ground
+ *  distance shown next to arc-unit resolutions. */
+const METERS_PER_DEGREE = 111_320;
+
+function formatMetersGsd(meters: number, locale: string): string {
+  if (meters < 1) return `${(meters * 100).toLocaleString(locale, { maximumFractionDigits: 0 })} cm`;
+  if (meters < 1000) return `${Math.round(meters).toLocaleString(locale)} m`;
+  return `${(meters / 1000).toLocaleString(locale, { minimumFractionDigits: 1, maximumFractionDigits: 1 })} km`;
+}
+
+/**
+ * Format a raster ground-sample distance given in CRS units.
+ *
+ * fix(#569): geographic CRSs deliver `gsd` in DEGREES — formatting them as
+ * meters showed "2 cm" for a 60-arc-second global DEM. When the payload says
+ * the CRS is geographic (or, for older payloads without the flag, the CRS is
+ * EPSG:4326), render arc units with an approximate equatorial ground
+ * distance, e.g. `60″ (≈1.9 km)`.
+ */
+export function formatGsd(
+  gsd: number,
+  opts: { isGeographic?: boolean | null; crs?: string | null },
+  locale: string,
+): string {
+  const geographic = opts.isGeographic ?? (opts.crs != null && /^EPSG:4326$/i.test(opts.crs));
+  if (!geographic) return formatMetersGsd(gsd, locale);
+  const arcSeconds = gsd * 3600;
+  let arc: string;
+  if (gsd >= 1) {
+    arc = `${gsd.toLocaleString(locale, { maximumFractionDigits: 2 })}°`;
+  } else if (arcSeconds >= 120) {
+    // Arc-minutes only from 2′ up: global DEMs are conventionally named in
+    // arc-seconds ("30 arc-second", "60 arc-second"), so 60″ stays 60″.
+    arc = `${(arcSeconds / 60).toLocaleString(locale, { maximumFractionDigits: 1 })}′`;
+  } else {
+    arc = `${arcSeconds.toLocaleString(locale, { maximumFractionDigits: 1 })}″`;
+  }
+  return `${arc} (≈${formatMetersGsd(gsd * METERS_PER_DEGREE, locale)})`;
+}
+
 /** Format raster resolution: 2 decimals for values >= 0.01, otherwise 6. */
 export function formatResolution(value: number | null | undefined): string {
   if (value == null) return '—';

--- a/frontend/src/lib/format.ts
+++ b/frontend/src/lib/format.ts
@@ -110,7 +110,12 @@ export function formatGsd(
     // arc-seconds ("30 arc-second", "60 arc-second"), so 60″ stays 60″.
     arc = `${(arcSeconds / 60).toLocaleString(locale, { maximumFractionDigits: 1 })}′`;
   } else {
-    arc = `${arcSeconds.toLocaleString(locale, { maximumFractionDigits: 1 })}″`;
+    // fix(#588): sub-arcsecond pixels (e.g. ~0.01″ / 30 cm EPSG:4326 drone
+    // imagery) round to a meaningless "0″" at a fixed 1 decimal. Below 1″,
+    // switch to significant digits so any magnitude stays readable.
+    const secondsOpts: Intl.NumberFormatOptions =
+      arcSeconds >= 1 ? { maximumFractionDigits: 1 } : { maximumSignificantDigits: 2 };
+    arc = `${arcSeconds.toLocaleString(locale, secondsOpts)}″`;
   }
   return `${arc} (≈${formatMetersGsd(gsd * METERS_PER_DEGREE, locale)})`;
 }

--- a/frontend/src/types/api.generated.ts
+++ b/frontend/src/types/api.generated.ts
@@ -9649,6 +9649,11 @@ export interface components {
             created?: string | null;
             /** Crs */
             crs?: string | null;
+            /**
+             * Crs Is Geographic
+             * @description True when the raster CRS is geographic (gsd/res are degrees, not meters); None when the CRS class is unknown.
+             */
+            crs_is_geographic?: boolean | null;
             /** Dataset Count */
             dataset_count?: number | null;
             /** Description */
@@ -10111,6 +10116,11 @@ export interface components {
              */
             compression?: string | null;
             connect?: components["schemas"]["RasterConnect"] | null;
+            /**
+             * Crs Is Geographic
+             * @description True when the raster CRS is geographic (res_x/res_y are degrees, not meters); None when the CRS class is unknown.
+             */
+            crs_is_geographic?: boolean | null;
             /**
              * Epsg
              * @description EPSG code of the raster CRS

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -119,6 +119,8 @@ export interface StacAsset {
 
 export interface RasterMetadata {
   epsg: number | null;
+  /** True when the CRS is geographic (res_x/res_y are degrees, not meters). */
+  crs_is_geographic?: boolean | null;
   res_x: number | null;
   res_y: number | null;
   band_count: number | null;
@@ -442,6 +444,8 @@ export interface OGCRecordProperties {
   vrt_type?: string | null;
   source_count?: number | null;
   gsd?: number | null;
+  /** True when the raster CRS is geographic (gsd is degrees, not meters). */
+  crs_is_geographic?: boolean | null;
 }
 
 export interface OGCRecordLink {

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -432,9 +432,25 @@ main() {
   db_port="$(get_env_value DB_PORT)"
   api_port="$(get_env_value API_PORT)"
   fe_port="$(get_env_value FRONTEND_PORT)"
-  [ -n "$db_port" ] || db_port=5434
-  [ -n "$api_port" ] || api_port=8001
-  [ -n "$fe_port" ] || fe_port=8080
+  # fix(#444): when a key is missing from .env, defaulting only this shell
+  # variable made the installer probe (and later print) a port compose would
+  # never bind — compose falls back to its own no-.env baseline of 5432/8000,
+  # which is a deliberate, separately pinned decision. Persist the documented
+  # value instead, so the port we check, the port compose binds, and the port
+  # we print to the operator are the same one. A verbatim install is
+  # unaffected: .env.example already ships all three keys.
+  if [ -z "$db_port" ]; then
+    db_port=5434
+    update_env_value DB_PORT "$db_port"
+  fi
+  if [ -z "$api_port" ]; then
+    api_port=8001
+    update_env_value API_PORT "$api_port"
+  fi
+  if [ -z "$fe_port" ]; then
+    fe_port=8080
+    update_env_value FRONTEND_PORT "$fe_port"
+  fi
 
   check_port "$db_port"
   check_port "$api_port"

--- a/sdks/python/geolens/models/ogc_record_properties.py
+++ b/sdks/python/geolens/models/ogc_record_properties.py
@@ -49,6 +49,8 @@ class OGCRecordProperties:
         constraints (None | OGCRecordPropertiesConstraintsType0 | Unset):
         created (datetime.datetime | None | Unset):
         crs (None | str | Unset):
+        crs_is_geographic (bool | None | Unset): True when the raster CRS is geographic (gsd/res are degrees, not
+            meters); None when the CRS class is unknown.
         dataset_count (int | None | Unset):
         distributions (list[OGCRecordPropertiesDistributionsType0Item] | None | Unset):
         external_ids (list[str] | Unset): Identifiers assigned by the described resource's source system.
@@ -90,6 +92,7 @@ class OGCRecordProperties:
     constraints: None | OGCRecordPropertiesConstraintsType0 | Unset = UNSET
     created: datetime.datetime | None | Unset = UNSET
     crs: None | str | Unset = UNSET
+    crs_is_geographic: bool | None | Unset = UNSET
     dataset_count: int | None | Unset = UNSET
     distributions: list[OGCRecordPropertiesDistributionsType0Item] | None | Unset = (
         UNSET
@@ -180,6 +183,12 @@ class OGCRecordProperties:
             crs = UNSET
         else:
             crs = self.crs
+
+        crs_is_geographic: bool | None | Unset
+        if isinstance(self.crs_is_geographic, Unset):
+            crs_is_geographic = UNSET
+        else:
+            crs_is_geographic = self.crs_is_geographic
 
         dataset_count: int | None | Unset
         if isinstance(self.dataset_count, Unset):
@@ -349,6 +358,8 @@ class OGCRecordProperties:
             field_dict["created"] = created
         if crs is not UNSET:
             field_dict["crs"] = crs
+        if crs_is_geographic is not UNSET:
+            field_dict["crs_is_geographic"] = crs_is_geographic
         if dataset_count is not UNSET:
             field_dict["dataset_count"] = dataset_count
         if distributions is not UNSET:
@@ -510,6 +521,15 @@ class OGCRecordProperties:
             return cast(None | str | Unset, data)
 
         crs = _parse_crs(d.pop("crs", UNSET))
+
+        def _parse_crs_is_geographic(data: object) -> bool | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(bool | None | Unset, data)
+
+        crs_is_geographic = _parse_crs_is_geographic(d.pop("crs_is_geographic", UNSET))
 
         def _parse_dataset_count(data: object) -> int | None | Unset:
             if data is None:
@@ -767,6 +787,7 @@ class OGCRecordProperties:
             constraints=constraints,
             created=created,
             crs=crs,
+            crs_is_geographic=crs_is_geographic,
             dataset_count=dataset_count,
             distributions=distributions,
             external_ids=external_ids,

--- a/sdks/python/geolens/models/raster_metadata.py
+++ b/sdks/python/geolens/models/raster_metadata.py
@@ -26,6 +26,8 @@ class RasterMetadata:
         bands (list[RasterBandInfo] | Unset):
         compression (None | str | Unset): Internal compression, e.g. DEFLATE, LZW
         connect (None | RasterConnect | Unset):
+        crs_is_geographic (bool | None | Unset): True when the raster CRS is geographic (res_x/res_y are degrees, not
+            meters); None when the CRS class is unknown.
         epsg (int | None | Unset): EPSG code of the raster CRS
         height (int | None | Unset): Raster height in pixels
         is_dem (bool | None | Unset): True if this raster is a DEM (single-band float) usable for 3D terrain/hillshade
@@ -45,6 +47,7 @@ class RasterMetadata:
     bands: list[RasterBandInfo] | Unset = UNSET
     compression: None | str | Unset = UNSET
     connect: None | RasterConnect | Unset = UNSET
+    crs_is_geographic: bool | None | Unset = UNSET
     epsg: int | None | Unset = UNSET
     height: int | None | Unset = UNSET
     is_dem: bool | None | Unset = UNSET
@@ -89,6 +92,12 @@ class RasterMetadata:
             connect = self.connect.to_dict()
         else:
             connect = self.connect
+
+        crs_is_geographic: bool | None | Unset
+        if isinstance(self.crs_is_geographic, Unset):
+            crs_is_geographic = UNSET
+        else:
+            crs_is_geographic = self.crs_is_geographic
 
         epsg: int | None | Unset
         if isinstance(self.epsg, Unset):
@@ -179,6 +188,8 @@ class RasterMetadata:
             field_dict["compression"] = compression
         if connect is not UNSET:
             field_dict["connect"] = connect
+        if crs_is_geographic is not UNSET:
+            field_dict["crs_is_geographic"] = crs_is_geographic
         if epsg is not UNSET:
             field_dict["epsg"] = epsg
         if height is not UNSET:
@@ -258,6 +269,15 @@ class RasterMetadata:
             return cast(None | RasterConnect | Unset, data)
 
         connect = _parse_connect(d.pop("connect", UNSET))
+
+        def _parse_crs_is_geographic(data: object) -> bool | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(bool | None | Unset, data)
+
+        crs_is_geographic = _parse_crs_is_geographic(d.pop("crs_is_geographic", UNSET))
 
         def _parse_epsg(data: object) -> int | None | Unset:
             if data is None:
@@ -383,6 +403,7 @@ class RasterMetadata:
             bands=bands,
             compression=compression,
             connect=connect,
+            crs_is_geographic=crs_is_geographic,
             epsg=epsg,
             height=height,
             is_dem=is_dem,

--- a/sdks/typescript/src/client/types.gen.ts
+++ b/sdks/typescript/src/client/types.gen.ts
@@ -6412,6 +6412,12 @@ export type OgcRecordProperties = {
      */
     crs?: string | null;
     /**
+     * Crs Is Geographic
+     *
+     * True when the raster CRS is geographic (gsd/res are degrees, not meters); None when the CRS class is unknown.
+     */
+    crs_is_geographic?: boolean | null;
+    /**
      * Dataset Count
      */
     dataset_count?: number | null;
@@ -7034,6 +7040,12 @@ export type RasterMetadata = {
      */
     compression?: string | null;
     connect?: RasterConnect | null;
+    /**
+     * Crs Is Geographic
+     *
+     * True when the raster CRS is geographic (res_x/res_y are degrees, not meters); None when the CRS class is unknown.
+     */
+    crs_is_geographic?: boolean | null;
     /**
      * Epsg
      *


### PR DESCRIPTION
Pre-release batch for 1.4.10. Addresses the remaining launch-window items from #569 plus closes #444.

## 1. Geographic-CRS raster resolution rendered as meters (#569)

The catalog card showed `1 band · 2 cm` for the 60-arc-second ETOPO DEM: `res_x` is CRS units, geographic CRSs deliver degrees, and the UI formatted them as meters. The old guard only special-cased `EPSG:4326`, missing compound geographic CRSs like EPSG:9518.

- **Backend**: search record properties and dataset raster metadata now carry `crs_is_geographic`, classified from the stored `crs_wkt` with zero proj dependencies (`PROJCRS`/`PROJCS` checked before `GEOGCRS`/`GEOGCS` since WKT1 nests a GEOGCS inside every PROJCS; compounds resolve via their horizontal component; engineering/unknown → null). 7 new unit tests.
- **Frontend**: shared `formatGsd` renders geographic resolutions as arc units with an approximate equatorial ground distance — 60″ shows `60″ (≈1.9 km)` — in the search card AND the dataset stats bar (which hardcoded `N m`). Old payloads without the flag keep the 4326 heuristic.
- OpenAPI + both SDKs + generated frontend types regenerated (3-artifact regen); hand-typed mirrors updated.
- Live-verified on the dev stack: EPSG:2056/32618 rasters classify `false` end-to-end in both payloads.

## 2. CLI `publish --tags/--collection` were advertised no-ops (#569)

`--help` documented flags that silently dropped their values. Now wired post-commit: `--tags` posts each keyword to `/records/{id}/keywords/`; `--collection` accepts a collection id or exact name (case-insensitive, paged lookup, ambiguity rejected) and adds via `/catalog/collections/{id}/datasets/`. Both require `--wait` (fail-fast `EXIT_USAGE` otherwise). Post-create failures print `Dataset created, but: …` and exit non-zero; `--json` carries `extras_failures`. 9 new CLI tests.

## 3. Installer port-conflict fallbacks disagreed with compose (#444)

`install.sh` falls back to db=5434/api=8001 (matching `.env.example` and the docs contract), but the compose files' interpolation defaults were 5432/8000 — so the installer's port-in-use check probed ports compose would never bind. The compose fallbacks now match the documented source of truth. **Behavior note**: verbatim installs are unaffected (`.env.example` always supplies the keys); only deployments that hand-removed `DB_PORT`/`API_PORT` from `.env` will see host binds move 5432→5434 / 8000→8001 on upgrade (both localhost-only binds).

## Verification

- Backend: ruff clean; new + adjacent suites pass (`test_wkt_is_geographic`, `test_api_contract_openapi`, `test_hybrid_search`, `test_ogc_record_properties`, `test_ogc_record_enrichment` — 83 tests); `make openapi-check` and `make sdks-check` exit 0.
- Frontend: build, lint, typecheck, full `test:coverage` (3696 tests), `test:i18n` — all green.
- CLI: `make cli-test` (unit + round-trip) green.
- Compose: both files `docker compose config -q` clean; `check_docs_contract.py` and `check_env_doc_drift.py` pass.

Closes #444.

https://claude.ai/code/session_013Q1gyuRm3QXKZL73eQ9UUV