### PR TITLE
chore(release): bump to 1.4.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -877,7 +877,10 @@ regression-covered fixes:
 - Initial public release of the GeoLens catalog, API, map builder, CLI, SDKs,
   Docker development stack, and public documentation entrypoints.
 
-[Unreleased]: https://github.com/geolens-io/geolens/compare/v1.4.8...HEAD
+[Unreleased]: https://github.com/geolens-io/geolens/compare/v1.4.11...HEAD
+[1.4.11]: https://github.com/geolens-io/geolens/compare/v1.4.10...v1.4.11
+[1.4.10]: https://github.com/geolens-io/geolens/compare/v1.4.9...v1.4.10
+[1.4.9]: https://github.com/geolens-io/geolens/compare/v1.4.8...v1.4.9
 [1.4.8]: https://github.com/geolens-io/geolens/compare/v1.4.7...v1.4.8
 [1.4.7]: https://github.com/geolens-io/geolens/compare/v1.4.6...v1.4.7
 [1.4.6]: https://github.com/geolens-io/geolens/compare/v1.4.5...v1.4.6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ and releases use semantic versioning.
 
 ## [Unreleased]
 
+## [1.4.11] - 2026-07-19
+
+### Fixed
+
+- **Raster resolutions in geographic coordinate systems are reported honestly.**
+  Resolution is stored in the dataset's own CRS units, but the catalog and
+  search cards formatted every value as meters — so a 60-arc-second global DEM
+  advertised a "2 cm" ground sample distance. Geographic datasets now render
+  arc units alongside an approximate ground distance, e.g. `60″ (≈1.9 km)`, and
+  sub-arcsecond imagery keeps meaningful precision instead of rounding to `0″`.
+- **`geolens publish --tags` and `--collection` now apply.** Both flags were
+  accepted and silently ignored. They are applied after the dataset commits,
+  so a failure to tag or file the dataset reports which step failed and leaves
+  the uploaded dataset in place rather than aborting before its URL is printed.
+  The printed dataset URL also points at the web page instead of the JSON API.
+- **The installer no longer probes ports it will not bind.** When `DB_PORT`,
+  `API_PORT`, or `FRONTEND_PORT` was missing from `.env`, the installer
+  defaulted only its own shell variables — so it health-checked and printed
+  ports that differed from the ones Compose actually bound. The documented
+  values are now persisted to `.env`, keeping the installer, Compose, and the
+  printed URLs in agreement.
+
 ## [1.4.10] - 2026-07-19
 
 ### Added

--- a/backend/app/api/main.py
+++ b/backend/app/api/main.py
@@ -563,7 +563,7 @@ _is_production = settings.is_production
 # no metadata to read. We fall back to the current published line so import never
 # crashes. Keep this fallback in lockstep with backend/pyproject.toml — it is one
 # of the sites `make bump` rewrites.
-_FALLBACK_APP_VERSION = "1.4.10"
+_FALLBACK_APP_VERSION = "1.4.11"
 
 
 def _resolve_app_version() -> str:

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -17164,7 +17164,7 @@
     "summary": "PostGIS-native geospatial data catalog with OGC API Features and Records support",
     "termsOfService": "https://github.com/geolens-io/geolens/blob/main/LICENSE",
     "title": "GeoLens API",
-    "version": "1.4.10"
+    "version": "1.4.11"
   },
   "openapi": "3.1.0",
   "paths": {

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geolens-backend"
-version = "1.4.10"
+version = "1.4.11"
 description = "PostGIS-native GIS data catalog"
 # Docker image (Dockerfile) ships python:3.14-slim (see the Dockerfile FROM for
 # the exact patch pin) as the project's tested runtime.

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -865,7 +865,7 @@ wheels = [
 
 [[package]]
 name = "geolens-backend"
-version = "1.4.10"
+version = "1.4.11"
 source = { virtual = "." }
 dependencies = [
     { name = "alembic" },

--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "geolens-cli"
-version = "1.4.10"
+version = "1.4.11"
 description = "Apache-2.0 command-line interface for the GeoLens API. Login, scan, publish, and export STAC against any GeoLens instance."
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/docs-contract.json
+++ b/docs-contract.json
@@ -1,6 +1,6 @@
 {
   "_comment": "Canonical cross-surface facts for the GeoLens README, marketing site (getgeolens.com/src), and docs site (getgeolens.com/docs). Validated against scripts/install.sh + backend/pyproject.toml by scripts/check_docs_contract.py (geolens CI). The getgeolens.com repo vendors a copy and enforces the same `forbidden` list in its own CI. See docs-internal/DOC-CONSISTENCY-STRATEGY for the full design. Edit a fact ONCE here (and in its canonical source) — the gates make every surface follow.",
-  "version": "1.4.10",
+  "version": "1.4.11",
   "install": {
     "oneLiner": "curl -fsSL https://getgeolens.com/install.sh | sh",
     "sourceBuild": "bash scripts/install.sh",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.4.10",
+  "version": "1.4.11",
   "type": "module",
   "license": "Apache-2.0",
   "author": "Carto Concepts, LLC",

--- a/mcp/pyproject.toml
+++ b/mcp/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "geolens-mcp"
-version = "1.4.10"
+version = "1.4.11"
 description = "Apache-2.0 read-only Model Context Protocol (MCP) server for GeoLens. Lets coding agents discover datasets, inspect schemas, and ask spatial questions against any GeoLens instance."
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "geolens",
-  "version": "1.4.10",
+  "version": "1.4.11",
   "private": true,
   "license": "Apache-2.0",
   "author": "Carto Concepts, LLC",

--- a/sdks/python/.openapi-python-client.yaml
+++ b/sdks/python/.openapi-python-client.yaml
@@ -4,7 +4,7 @@ project_name_override: geolens
 package_name_override: geolens
 # Rewritten on every `make sdks` run by scripts/sync_sdk_versions.py to match
 # backend/openapi.json info.version. Do not edit by hand.
-package_version_override: 1.4.10
+package_version_override: 1.4.11
 
 # Cleaner enum output (matches our pydantic v2 backend's enum emission).
 literal_enums: true

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "geolens"
-version = "1.4.10"
+version = "1.4.11"
 description = "Auto-generated Python SDK for the GeoLens API. Typed clients with Bearer + API-key auth helpers."
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/sdks/typescript/package-lock.json
+++ b/sdks/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@geolens/sdk",
-  "version": "1.4.10",
+  "version": "1.4.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@geolens/sdk",
-      "version": "1.4.10",
+      "version": "1.4.11",
       "license": "Apache-2.0",
       "dependencies": {
         "@hey-api/client-fetch": "0.13.1"

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@geolens/sdk",
-  "version": "1.4.10",
+  "version": "1.4.11",
   "description": "Auto-generated TypeScript SDK for the GeoLens API. Typed clients with Bearer + API-key auth helpers.",
   "license": "Apache-2.0",
   "author": "Carto Concepts, LLC",


### PR DESCRIPTION
Release-prep PR for **v1.4.11**.

## Why

The v1.4.10 tag was cut at `bcb577078` (the version bump) at 15:20 EDT. #588 merged at 17:25 EDT — about two hours later — so its three fixes are on `main` but shipped in no release. This bump makes them publishable.

## Contents

Version bump across all sites (`make bump VERSION=1.4.11`) plus the CHANGELOG entry for #588, written at release time to match the #582/#586 pattern.

Shipping in 1.4.11:

- **Geographic-CRS raster resolutions** — a 60-arc-second global DEM advertised a "2 cm" ground sample distance because resolution is stored in CRS units and the UI formatted everything as meters. Now renders arc units with an approximate ground distance, e.g. `60″ (≈1.9 km)`.
- **`geolens publish --tags` / `--collection`** — both flags were accepted and silently ignored.
- **Installer port defaults** — the installer probed and printed ports that differed from the ones Compose bound when the keys were absent from `.env` (#444).

## Verification

| Gate | Result |
|---|---|
| `make version-check` | exit 0 |
| `make openapi-check` | exit 0 |
| `make sdks-check` | exit 0 (incl. TS build + 4 tests) |
| `scripts/check_docs_contract.py` | exit 0 |

Lockfile changes are version-only: `backend/uv.lock` 1 line, `sdks/typescript/package-lock.json` 2.

## Follow-on (not in this PR)

- `scripts/install.sh` changed in #588, so the public installer needs a sync after tagging — it must byte-match `releases/latest`, not `main`.
- Helm chart 0.4.0 trio wiring, targeting `appVersion: 1.4.11`.
- Demo VM redeploy. Its `docker-compose.prod.yml` is pinned at `ca70829` (v1.4.4-era) and is **125 lines behind** — it lacks the `TRUSTED_PROXY_CIDRS` and `CLIENT_MAX_BODY_SIZE` passthroughs entirely, so the demo has image parity but not compose parity. Worth folding the sync into that redeploy.