### PR TITLE
docs(readme): make no-lock-in an explicit position and drop the production claim

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -66,7 +66,7 @@ GeoLens ersetzt diesen Ablauf:
 
 - **Ein Katalog:** Laden Sie Shapefiles, GeoPackages, GeoTIFFs, CSVs oder XLSX hoch; innerhalb weniger Minuten sind sie durchsuchbar, als Vorschau verfügbar und exportierbar
 - **Funktioniert mit Ihren Werkzeugen:** OGC API Features/Records, STAC API 1.0, DCAT-3-/DCAT-US-/GeoDCAT-AP-Kataloge und direkte Kachel-URLs für QGIS, ArcGIS und MapLibre
-- **Kein Lock-in:** Ihre Daten bleiben in Ihrem eigenen PostGIS und verlassen es über offene Standards. Exportieren Sie nach GeoPackage, GeoJSON, Shapefile, CSV oder GeoParquet, oder richten Sie einen beliebigen OGC-API-Client direkt darauf
+- **Kein Lock-in:** Ihre Daten bleiben auf der Infrastruktur, die Sie kontrollieren, und verlassen sie über offene Formate. Vektordatensätze werden als GeoPackage, GeoJSON, Shapefile, CSV oder GeoParquet exportiert; Raster werden als Cloud-optimiertes GeoTIFF (COG) heruntergeladen; und jeder OGC-API-Client liest den Katalog direkt
 - **Semantische und räumliche Suche:** sofort einsatzbereiter unscharfer Abgleich mit pg_trgm; mit Embedding-Anbieter und aktivierter semantischer Suche werden Datensätze nach Bedeutung geordnet (pgvector)
 - **Integrierter Karteneditor:** mehrschichtige Karten zusammenstellen, gestalten und über öffentlichen Link oder einbettbares iframe teilen
 - **KI-Unterstützung (optional):** mit Karten chatten, Beschreibungen automatisch erzeugen und in natürlicher Sprache suchen. Verwenden Sie einen OpenAI-kompatiblen Endpunkt oder Anthropic-Schlüssel – oder verzichten Sie vollständig darauf

--- a/README.de.md
+++ b/README.de.md
@@ -31,9 +31,8 @@ curl -fsSL https://getgeolens.com/install.sh | sh
 
 > [!NOTE]
 > **Frühe Version.** GeoLens wird aktiv entwickelt und gepflegt und wurde erst
-> kürzlich als Open Source veröffentlicht. Der Kern lief bereits produktiv, doch
-> die selbst gehostete Distribution ist jung und manche Funktionen und APIs können
-> sich noch ändern. [Erstellen Sie ein Issue](https://github.com/geolens-io/geolens/issues), wenn Probleme auftreten.
+> kürzlich als Open Source veröffentlicht. Die selbst gehostete Distribution ist
+> jung und manche Funktionen und APIs können sich noch ändern. [Erstellen Sie ein Issue](https://github.com/geolens-io/geolens/issues), wenn Probleme auftreten.
 
 ## Dokumentation
 
@@ -67,6 +66,7 @@ GeoLens ersetzt diesen Ablauf:
 
 - **Ein Katalog:** Laden Sie Shapefiles, GeoPackages, GeoTIFFs, CSVs oder XLSX hoch; innerhalb weniger Minuten sind sie durchsuchbar, als Vorschau verfügbar und exportierbar
 - **Funktioniert mit Ihren Werkzeugen:** OGC API Features/Records, STAC API 1.0, DCAT-3-/DCAT-US-/GeoDCAT-AP-Kataloge und direkte Kachel-URLs für QGIS, ArcGIS und MapLibre
+- **Kein Lock-in:** Ihre Daten bleiben in Ihrem eigenen PostGIS und verlassen es über offene Standards. Exportieren Sie nach GeoPackage, GeoJSON, Shapefile, CSV oder GeoParquet, oder richten Sie einen beliebigen OGC-API-Client direkt darauf
 - **Semantische und räumliche Suche:** sofort einsatzbereiter unscharfer Abgleich mit pg_trgm; mit Embedding-Anbieter und aktivierter semantischer Suche werden Datensätze nach Bedeutung geordnet (pgvector)
 - **Integrierter Karteneditor:** mehrschichtige Karten zusammenstellen, gestalten und über öffentlichen Link oder einbettbares iframe teilen
 - **KI-Unterstützung (optional):** mit Karten chatten, Beschreibungen automatisch erzeugen und in natürlicher Sprache suchen. Verwenden Sie einen OpenAI-kompatiblen Endpunkt oder Anthropic-Schlüssel – oder verzichten Sie vollständig darauf

--- a/README.es.md
+++ b/README.es.md
@@ -67,7 +67,7 @@ GeoLens sustituye ese flujo de trabajo:
 
 - **Un solo catálogo:** sube Shapefiles, GeoPackages, GeoTIFFs, CSVs o XLSX y en minutos serán consultables, previsualizables y exportables
 - **Funciona con tus herramientas:** OGC API Features/Records, STAC API 1.0, catálogos DCAT 3/DCAT-US/GeoDCAT-AP y URLs directas de teselas para QGIS, ArcGIS y MapLibre
-- **Sin dependencia de proveedor:** tus datos permanecen en tu propio PostGIS y salen mediante estándares abiertos. Exporta a GeoPackage, GeoJSON, Shapefile, CSV o GeoParquet, o apunta cualquier cliente OGC API directamente a ellos
+- **Sin dependencia de proveedor:** tus datos permanecen en la infraestructura que controlas y salen mediante formatos abiertos. Los datasets vectoriales se exportan a GeoPackage, GeoJSON, Shapefile, CSV o GeoParquet; los ráster se descargan como GeoTIFF optimizado para la nube (COG); y cualquier cliente OGC API lee el catálogo directamente
 - **Búsqueda semántica y espacial:** coincidencia difusa con pg_trgm desde el primer momento; añade un proveedor de embeddings y activa la búsqueda semántica para clasificar conjuntos de datos por significado (pgvector)
 - **Constructor de mapas integrado:** compón mapas multicapa, aplica estilos y compártelos mediante un enlace público o un iframe incrustable
 - **Asistencia de IA (opcional):** conversa con tus mapas, genera descripciones automáticamente y busca con lenguaje natural. Aporta un endpoint compatible con OpenAI o una clave de Anthropic, o prescinde por completo de esta función

--- a/README.es.md
+++ b/README.es.md
@@ -31,8 +31,8 @@ curl -fsSL https://getgeolens.com/install.sh | sh
 
 > [!NOTE]
 > **Versión inicial.** GeoLens se desarrolla y mantiene activamente y se ha publicado
-> recientemente como código abierto. El núcleo se ha ejecutado en producción, pero la
-> distribución autohospedada es joven y algunas funciones y APIs aún pueden cambiar.
+> recientemente como código abierto. La distribución autohospedada es joven y
+> algunas funciones y APIs aún pueden cambiar.
 > [Abre una incidencia](https://github.com/geolens-io/geolens/issues) si encuentras algún problema.
 
 ## Documentación
@@ -67,6 +67,7 @@ GeoLens sustituye ese flujo de trabajo:
 
 - **Un solo catálogo:** sube Shapefiles, GeoPackages, GeoTIFFs, CSVs o XLSX y en minutos serán consultables, previsualizables y exportables
 - **Funciona con tus herramientas:** OGC API Features/Records, STAC API 1.0, catálogos DCAT 3/DCAT-US/GeoDCAT-AP y URLs directas de teselas para QGIS, ArcGIS y MapLibre
+- **Sin dependencia de proveedor:** tus datos permanecen en tu propio PostGIS y salen mediante estándares abiertos. Exporta a GeoPackage, GeoJSON, Shapefile, CSV o GeoParquet, o apunta cualquier cliente OGC API directamente a ellos
 - **Búsqueda semántica y espacial:** coincidencia difusa con pg_trgm desde el primer momento; añade un proveedor de embeddings y activa la búsqueda semántica para clasificar conjuntos de datos por significado (pgvector)
 - **Constructor de mapas integrado:** compón mapas multicapa, aplica estilos y compártelos mediante un enlace público o un iframe incrustable
 - **Asistencia de IA (opcional):** conversa con tus mapas, genera descripciones automáticamente y busca con lenguaje natural. Aporta un endpoint compatible con OpenAI o una clave de Anthropic, o prescinde por completo de esta función

--- a/README.fr.md
+++ b/README.fr.md
@@ -66,7 +66,7 @@ GeoLens remplace ce processus :
 
 - **Un catalogue unique :** chargez des Shapefiles, GeoPackages, GeoTIFFs, CSVs ou XLSX ; ils deviennent consultables, prévisualisables et exportables en quelques minutes
 - **Compatible avec vos outils :** OGC API Features/Records, STAC API 1.0, catalogues DCAT 3/DCAT-US/GeoDCAT-AP et URLs directes de tuiles pour QGIS, ArcGIS et MapLibre
-- **Sans verrouillage :** vos données restent dans votre propre PostGIS et en sortent via des standards ouverts. Exportez en GeoPackage, GeoJSON, Shapefile, CSV ou GeoParquet, ou pointez n’importe quel client OGC API directement dessus
+- **Sans verrouillage :** vos données restent sur l’infrastructure que vous contrôlez et en sortent via des formats ouverts. Les jeux de données vectoriels s’exportent en GeoPackage, GeoJSON, Shapefile, CSV ou GeoParquet ; les rasters se téléchargent en GeoTIFF optimisé pour le cloud (COG) ; et n’importe quel client OGC API lit le catalogue directement
 - **Recherche sémantique et spatiale :** correspondance approximative pg_trgm prête à l’emploi ; ajoutez un fournisseur d’embeddings et activez la recherche sémantique pour classer les jeux de données par sens (pgvector)
 - **Générateur de cartes intégré :** composez des cartes multicouches, stylisez-les et partagez-les par lien public ou iframe intégrable
 - **Assistance IA (facultative) :** dialogue avec les cartes, génération automatique de descriptions et recherche en langage naturel. Utilisez un point de terminaison compatible OpenAI ou une clé Anthropic, ou ignorez entièrement cette fonction

--- a/README.fr.md
+++ b/README.fr.md
@@ -31,9 +31,8 @@ curl -fsSL https://getgeolens.com/install.sh | sh
 
 > [!NOTE]
 > **Version initiale.** GeoLens est activement développé et maintenu, et vient
-> d’être publié en open source. Le cœur a été utilisé en production, mais la
-> distribution auto-hébergée est jeune et certaines fonctions et APIs peuvent
-> encore évoluer. [Ouvrez un ticket](https://github.com/geolens-io/geolens/issues) en cas de difficulté.
+> d’être publié en open source. La distribution auto-hébergée est jeune et
+> certaines fonctions et APIs peuvent encore évoluer. [Ouvrez un ticket](https://github.com/geolens-io/geolens/issues) en cas de difficulté.
 
 ## Documentation
 
@@ -67,6 +66,7 @@ GeoLens remplace ce processus :
 
 - **Un catalogue unique :** chargez des Shapefiles, GeoPackages, GeoTIFFs, CSVs ou XLSX ; ils deviennent consultables, prévisualisables et exportables en quelques minutes
 - **Compatible avec vos outils :** OGC API Features/Records, STAC API 1.0, catalogues DCAT 3/DCAT-US/GeoDCAT-AP et URLs directes de tuiles pour QGIS, ArcGIS et MapLibre
+- **Sans verrouillage :** vos données restent dans votre propre PostGIS et en sortent via des standards ouverts. Exportez en GeoPackage, GeoJSON, Shapefile, CSV ou GeoParquet, ou pointez n’importe quel client OGC API directement dessus
 - **Recherche sémantique et spatiale :** correspondance approximative pg_trgm prête à l’emploi ; ajoutez un fournisseur d’embeddings et activez la recherche sémantique pour classer les jeux de données par sens (pgvector)
 - **Générateur de cartes intégré :** composez des cartes multicouches, stylisez-les et partagez-les par lien public ou iframe intégrable
 - **Assistance IA (facultative) :** dialogue avec les cartes, génération automatique de descriptions et recherche en langage naturel. Utilisez un point de terminaison compatible OpenAI ou une clé Anthropic, ou ignorez entièrement cette fonction

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ GeoLens replaces that workflow:
 
 - **One catalog:** upload Shapefiles, GeoPackages, GeoTIFFs, or CSVs and they become searchable, previewable, and exportable in minutes
 - **Works with your tools:** OGC API Features/Records, STAC API 1.0, direct tile URLs for QGIS, ArcGIS, and MapLibre
-- **No lock-in:** your data stays in your own PostGIS and leaves through open standards. Export to GeoPackage, GeoJSON, Shapefile, CSV, or GeoParquet, or point any OGC API client straight at it
+- **No lock-in:** your data stays on infrastructure you control and leaves through open formats. Vector datasets export to GeoPackage, GeoJSON, Shapefile, CSV, or GeoParquet; rasters download as Cloud-Optimized GeoTIFF; and any OGC API client reads the catalog directly
 - **Semantic and spatial search:** pg_trgm fuzzy matching out of the box; add an embedding provider and enable semantic search to rank datasets by meaning (pgvector)
 - **Built-in map builder:** compose multi-layer maps, style them, and share via public link or embeddable iframe
 - **AI-assisted (optional):** chat with your maps, auto-generate descriptions, search by natural language. Bring an OpenAI-compatible endpoint or Anthropic key, or skip it entirely

--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ curl -fsSL https://getgeolens.com/install.sh | sh
 
 > [!NOTE]
 > **Early release.** GeoLens is actively developed and maintained, and newly
-> open-sourced. The core has run in production, but the self-hosted distribution is
-> young and some features and APIs may still change. Please
+> open-sourced. The self-hosted distribution is young and some features and APIs
+> may still change. Please
 > [open an issue](https://github.com/geolens-io/geolens/issues) if you hit a rough edge.
 
 ## Documentation
@@ -67,6 +67,7 @@ GeoLens replaces that workflow:
 
 - **One catalog:** upload Shapefiles, GeoPackages, GeoTIFFs, or CSVs and they become searchable, previewable, and exportable in minutes
 - **Works with your tools:** OGC API Features/Records, STAC API 1.0, direct tile URLs for QGIS, ArcGIS, and MapLibre
+- **No lock-in:** your data stays in your own PostGIS and leaves through open standards. Export to GeoPackage, GeoJSON, Shapefile, CSV, or GeoParquet, or point any OGC API client straight at it
 - **Semantic and spatial search:** pg_trgm fuzzy matching out of the box; add an embedding provider and enable semantic search to rank datasets by meaning (pgvector)
 - **Built-in map builder:** compose multi-layer maps, style them, and share via public link or embeddable iframe
 - **AI-assisted (optional):** chat with your maps, auto-generate descriptions, search by natural language. Bring an OpenAI-compatible endpoint or Anthropic key, or skip it entirely


### PR DESCRIPTION
## What

Two changes to all four README locales.

**1. Removes an inaccurate claim.** The Early release note said *"The core has run in production"*. It is not accurate, and it had shipped translated into `es`, `fr`, and `de`. Removed from all four.

**2. Makes no-lock-in an explicit position.** The README already contained every portability fact (export formats, OGC/STAC endpoints, PostGIS storage, no telemetry) but scattered across sections and always phrased as a capability, never as a promise. Adds one bullet to the `Why GeoLens?` list stating it directly.

Localized to each locale's established term rather than transliterating the English:

| Locale | Term |
|---|---|
| en | No lock-in |
| es | Sin dependencia de proveedor |
| fr | Sans verrouillage |
| de | Kein Lock-in |

## Why now

Part of making data portability a consistent position across every GeoLens surface. The companion change to the marketing site and docs is geolens-io/getgeolens.com#68.

## Scope note

No new claims. Everything the new bullet asserts is already documented behavior and already stated elsewhere in the same README.

Deliberately **not** touching `frontend/src/i18n/**`: `common.json` already ships *"The data stays in your database"* in all four locales, so the in-app surface is already on-message, and adding keys there would risk the parity gate for no positional gain.

## Verification

```
python3 scripts/check_public_surface.py    # passed, 68 tracked files scanned
python3 scripts/check_docs_contract.py     # passed, no forbidden drift
```

## Drift spotted, not fixed here

The English README is **behind** its translations in two places. `es`/`fr`/`de` list `XLSX` as an upload format and `DCAT 3/DCAT-US/GeoDCAT-AP` catalogs in the "works with your tools" bullet; English lists neither. Out of scope for a copy-position change, worth a follow-up.

https://claude.ai/code/session_01GkA7MLHfoRxF9RU7Srs5rk