### PR TITLE
chore(deps): resolve high-severity npm audit advisories (brace-expansion, js-yaml)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "1.4.6",
+  "version": "1.4.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "1.4.6",
+      "version": "1.4.11",
       "license": "Apache-2.0",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
@@ -4386,9 +4386,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6492,9 +6492,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "dev": true,
       "funding": [
         {

--- a/sdks/typescript/package-lock.json
+++ b/sdks/typescript/package-lock.json
@@ -436,9 +436,9 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "funding": [
         {
           "type": "github",

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -41,6 +41,9 @@
     "@hey-api/openapi-ts": "0.99.0",
     "typescript": "5.9.3"
   },
+  "overrides": {
+    "js-yaml": "^4.3.0"
+  },
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
The `JS audit (frontend)` and `JS audit (sdks/typescript)` CI gates (`npm audit --audit-level=high`) fail repo-wide — on every PR and on `main` if re-run — on two newly-disclosed transitive **dev-dependency** advisories:

- **brace-expansion `<1.1.16`** — ReDoS ([GHSA-3jxr-9vmj-r5cp](https://github.com/advisories/GHSA-3jxr-9vmj-r5cp))
- **js-yaml `4.0.0–4.2.0`** — quadratic CPU on merge-key chains ([GHSA-52cp-r559-cp3m](https://github.com/advisories/GHSA-52cp-r559-cp3m))

Both reach the tree only through eslint / openapi-ts tooling — neither is a shipped runtime dependency.

## Fix

**frontend** — plain `npm audit fix` (lockfile only, `package.json` untouched): both resolve cleanly to `brace-expansion@1.1.16` and `js-yaml@4.3.0`. → 0 vulnerabilities.

**sdks/typescript** — `npm audit fix --force` here would **downgrade** `@hey-api/openapi-ts` `0.99.0 → 0.97.0`, a breaking change to the SDK generator. Instead, pin js-yaml with an `overrides` to `^4.3.0` — a safe minor bump that the transitive `@hey-api/json-schema-ref-parser` accepts. js-yaml is generator-time tooling only (the SDK's sole runtime dep is `@hey-api/client-fetch`), and `overrides` never propagates to published-package consumers. → 0 vulnerabilities.

## Verification

- `npm audit --audit-level=high` → **0 high** in both `frontend` and `sdks/typescript`.
- frontend `eslint .` → clean.
- SDK `tsc` build + `node --test` → **4 pass / 0 fail**.
- Diff is 3 files (two `package-lock.json` + one `package.json`); no generated `src/` drift.
