### PR TITLE
ci(trivy): sync node scan pin to 26.5.0 and scope the node-tar CVE

### DIFF
--- a/.github/workflows/dep-audit.yml
+++ b/.github/workflows/dep-audit.yml
@@ -97,7 +97,7 @@ jobs:
         # gated (tracked via Dependabot + this report; revisit at each postgis
         # base bump).
         include:
-          - image: "node:26.3.0-alpine"
+          - image: "node:26.5.0-alpine"
             enforce: "1"
           - image: "python:3.14.6-slim"
             enforce: "1"
@@ -123,6 +123,10 @@ jobs:
           severity: "CRITICAL"
           exit-code: ${{ matrix.enforce }}
           ignore-unfixed: true
+          # Scoped, justified CVE suppressions only (see .trivyignore.yaml's
+          # `vulnerabilities:` section). Trivy <0.71 does not auto-detect the YAML
+          # ignore file, so point at it explicitly.
+          trivyignores: ".trivyignore.yaml"
 
   iac-scan:
     name: IaC config scan (Trivy)

--- a/.trivyignore.yaml
+++ b/.trivyignore.yaml
@@ -1,5 +1,16 @@
 # Trivy ignore policy (enforcing config + image scans — see .github/workflows/dep-audit.yml).
 # Scoped, justified suppressions only. Everything not listed here is still enforced.
+vulnerabilities:
+  - id: CVE-2026-59873
+    statement: >-
+      node-tar Denial of Service via a crafted gzip bomb. Fixed upstream in
+      tar 7.5.19, but no node:*-alpine image ships tar >= 7.5.19 yet (node
+      26.5.0 bundles npm's tar 7.5.16), so no tag bump can clear it. node is a
+      BUILD stage only (frontend-build in Dockerfile / frontend/Dockerfile.dev);
+      the runtime image is nginx serving static files, so the vulnerable tar
+      never reaches production, and the DoS requires feeding a crafted archive
+      to `tar` — not a surface in our controlled build. Scoped to this single
+      CVE. REMOVE once a node alpine base ships tar >= 7.5.19.
 misconfigurations:
   - id: AVD-DS-0002
     paths:


### PR DESCRIPTION
The **Docker image scan (Trivy) (node:…)** gate has been red on every PR (and on `main` re-runs). Two things were wrong; this fixes both.

## 1. Stale matrix pin
The scan matrix pinned `node:26.3.0-alpine`, but both Dockerfiles ship `node:26.5.0-alpine` (`Dockerfile:234`, `frontend/Dockerfile.dev:5`). The matrix comment already requires these pins to mirror the `FROM` tags — the pin had simply drifted. Synced to `26.5.0-alpine`.

## 2. `CVE-2026-59873` can't be cleared by a tag bump
Per the failing CI log, the image's **only** CRITICAL is `CVE-2026-59873` — node-tar DoS via a crafted gzip bomb, in `.../npm/node_modules/tar/package.json`. It's fixed upstream in `tar@7.5.19`, but **no `node:*-alpine` image ships tar ≥ 7.5.19 yet** (26.5.0 bundles npm's tar 7.5.16), so `ignore-unfixed: true` doesn't suppress it and no tag bump greens the gate.

Added a **scoped, justified** suppression in `.trivyignore.yaml` (`vulnerabilities:` section) and wired the docker-audit step to read it via `trivyignores:` (Trivy <0.71 doesn't auto-detect the YAML file — same pattern the iac-scan step already uses).

**Why this suppression is safe:**
- `node` is a **build-only stage** (`frontend-build`); the runtime image is nginx serving static files, so the vulnerable `tar` never ships to production.
- The DoS requires feeding a crafted archive to `tar` — not a surface in our controlled build.
- Scoped to this single CVE; everything else stays enforced.
- **Removal condition documented:** drop the entry once a node alpine base picks up tar ≥ 7.5.19.

## Verification
- CI log confirms `CVE-2026-59873` is the image's sole CRITICAL, so the suppression fully greens the enforcing gate.
- Node pin now matches both `FROM node:26.5.0-alpine` tags.
- `.trivyignore.yaml` + workflow YAML parse clean; pre-commit passed.
- The PR's own **Docker image scan (Trivy) (node:26.5.0-alpine)** run is the final ground-truth check.

Diff is 2 files / 16 lines.
