### PR TITLE
fix: repair the two dead /api/docs links (footer API entry + OGC service-doc)

### DIFF
--- a/backend/app/standards/ogc/router.py
+++ b/backend/app/standards/ogc/router.py
@@ -8,6 +8,7 @@ from sqlalchemy import select
 from sqlalchemy.exc import OperationalError, ProgrammingError
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.core.config import settings
 from app.core.db.tenant_session import current_tenant_var
 from app.core.dependencies import get_db
 from app.core.geo import extent_to_bbox
@@ -207,41 +208,51 @@ async def landing_page(
     # the requested language.
     response.headers["Content-Language"] = "en"
     public_api_url = await get_public_api_url(db, request=request)
-    return LandingPage(
-        title="GeoLens",
-        description="OGC API Records catalog for geospatial datasets",
-        links=[
-            OGCLink(
-                href=build_url("/", base_url=public_api_url),
-                rel="self",
-                type="application/json",
-                title="This document",
-            ),
-            OGCLink(
-                href=build_url("/conformance", base_url=public_api_url),
-                rel="conformance",
-                type="application/json",
-                title="Conformance classes",
-            ),
-            OGCLink(
-                href=build_url("/collections", base_url=public_api_url),
-                rel="data",
-                type="application/json",
-                title="Collections",
-            ),
-            OGCLink(
-                href=build_url("/openapi.json", base_url=public_api_url),
-                rel="service-desc",
-                type="application/vnd.oai.openapi+json;version=3.1",
-                title="OpenAPI definition",
-            ),
+    links = [
+        OGCLink(
+            href=build_url("/", base_url=public_api_url),
+            rel="self",
+            type="application/json",
+            title="This document",
+        ),
+        OGCLink(
+            href=build_url("/conformance", base_url=public_api_url),
+            rel="conformance",
+            type="application/json",
+            title="Conformance classes",
+        ),
+        OGCLink(
+            href=build_url("/collections", base_url=public_api_url),
+            rel="data",
+            type="application/json",
+            title="Collections",
+        ),
+        OGCLink(
+            href=build_url("/openapi.json", base_url=public_api_url),
+            rel="service-desc",
+            type="application/vnd.oai.openapi+json;version=3.1",
+            title="OpenAPI definition",
+        ),
+    ]
+    # service-doc points at the interactive Swagger UI (/docs), which FastAPI
+    # disables in production (settings.is_production -> docs_url=None, see
+    # api/main.py). Advertising it unconditionally makes the OGC landing link a
+    # dead /docs (404) on every production instance and the demo. service-doc is
+    # optional in OGC API Common, so only emit it when /docs actually resolves.
+    # service-desc -> /openapi.json stays available in production and is kept.
+    if not settings.is_production:
+        links.append(
             OGCLink(
                 href=build_url("/docs", base_url=public_api_url),
                 rel="service-doc",
                 type="text/html",
                 title="API documentation",
-            ),
-        ],
+            )
+        )
+    return LandingPage(
+        title="GeoLens",
+        description="OGC API Records catalog for geospatial datasets",
+        links=links,
     )
 
 

--- a/backend/tests/test_ogc_discovery.py
+++ b/backend/tests/test_ogc_discovery.py
@@ -65,6 +65,20 @@ async def test_landing_page_service_doc_link(client):
     assert service_doc["type"] == "text/html"
 
 
+async def test_landing_page_omits_service_doc_in_production(client, monkeypatch):
+    """In production, FastAPI disables Swagger (/docs -> 404), so the landing page
+    must NOT advertise a dead service-doc link. service-desc (/openapi.json stays
+    served in production) must remain."""
+    from app.core.config import settings
+
+    monkeypatch.setattr(type(settings), "is_production", property(lambda self: True))
+    response = await client.get("/")
+    assert response.status_code == 200
+    rels = {link["rel"] for link in response.json()["links"]}
+    assert "service-doc" not in rels
+    assert "service-desc" in rels
+
+
 async def test_landing_page_openapi_link(client):
     """The service-desc link points to a valid OpenAPI JSON endpoint."""
     response = await client.get("/")

--- a/frontend/src/lib/external-links.ts
+++ b/frontend/src/lib/external-links.ts
@@ -7,5 +7,8 @@ export const GEOLENS_DOCS_URL = 'https://docs.getgeolens.com/';
 // Privacy policy page — the page returns 404 today; it will be added in the marketing-site phase.
 export const GEOLENS_PRIVACY_URL = 'https://getgeolens.com/privacy';
 
-// Requires the production reverse proxy to forward /api → backend (same as Vite dev proxy).
-export const GEOLENS_API_DOCS_URL = '/api/docs';
+// Footer "API" link. Points at the canonical public API guide (always 200) rather
+// than the instance's /api/docs Swagger, which 404s whenever interactive docs are
+// disabled (ENVIRONMENT=production — the recommended self-host setting), so the
+// footer link is live on every deployment including the demo.
+export const GEOLENS_API_DOCS_URL = 'https://docs.getgeolens.com/guides/api/';


### PR DESCRIPTION
Two launch-day links point at `/api/docs` (Swagger UI), which returns `404 {"detail":"Not Found"}` whenever interactive docs are disabled — i.e. **every `ENVIRONMENT=production` deployment** (the recommended self-host setting) and the **public demo**. Same root cause, two surfaces; fixed together.

## 1. Footer "API" link (user-visible) — `frontend/src/lib/external-links.ts`
The app footer renders for anonymous visitors on every non-authenticated route. Its **API** entry linked to the instance-relative `/api/docs`, so one of only five footer links — the one an API-minded evaluator is most likely to click — was dead on the demo and every production instance.

**Fix:** repoint `GEOLENS_API_DOCS_URL` at the canonical public API guide `https://docs.getgeolens.com/guides/api/` (verified `200`), matching how every other external footer link already works. The const is used only in `AppFooter.tsx`. No i18n change — `footer.api` is already `"API"` in all four locales.

## 2. OGC landing `service-doc` link (machine-visible) — `backend/app/standards/ogc/router.py`
`GET /api/` advertised `rel="service-doc" → /api/docs` **unconditionally**, so the one HTML entry point a standards client discovers by walking the landing links 404s in production. Walking the API root is exactly what a skeptical GIS professional does to check whether the OGC claims are real.

**Fix:** emit `service-doc` only when Swagger actually resolves (`not settings.is_production` — the same signal that drives `docs_url` in `api/main.py`). `service-doc` is optional in OGC API Common, so omitting it when `/docs` is off is spec-compliant. `service-desc → /openapi.json` (still served `200` in production) is unchanged.

## Verification
- `docs.getgeolens.com/guides/api/` → `200`; live demo: `/api/docs` → `404`, `/api/openapi.json` → `200` (confirms only `service-doc` needed gating).
- **Frontend:** ESLint clean, `tsc -b --noEmit` clean, 20/20 AppFooter-touching tests pass; no test hardcoded the old URL.
- **Backend:** `ruff check` + `ruff format --check` clean; `tests/test_ogc_discovery.py` 19/19 pass, including a new `test_landing_page_omits_service_doc_in_production` covering the production branch (service-doc absent, service-desc retained).
- No OpenAPI snapshot drift — the `LandingPage` response schema is unchanged (only runtime link content varies).
