### PR TITLE
fix(embed): serve the /m/ shell in place so per-token frame-ancestors survives

### DIFF
--- a/backend/tests/test_embed_frame_policy.py
+++ b/backend/tests/test_embed_frame_policy.py
@@ -250,3 +250,27 @@ def test_nginx_spa_route_keeps_sameorigin():
     assert "frame-ancestors 'self'" in conf, (
         "P0-02: the SPA catch-all CSP must keep frame-ancestors 'self'."
     )
+
+
+def test_nginx_m_route_serves_in_place_not_try_files():
+    """The /m/ block must serve the SPA shell in place via `rewrite ... break`,
+    NOT via `try_files $uri /index.html`. try_files internal-redirects to
+    /index.html which re-enters `location /`, and nginx then emits location /'s
+    add_header set — discarding this block's per-token frame-ancestors CSP and
+    re-adding X-Frame-Options: SAMEORIGIN, which blocks every cross-origin embed.
+    Regression guard for the 2026-07-21 fix (verified on the demo's live nginx)."""
+    conf = _nginx_conf_text()
+    start = conf.index("location ~ ^/m/ {")
+    block = conf[start : conf.index("\n    }", start)]
+    # Strip comment lines — the fix's own comment names `try_files` when
+    # explaining the bug, so only inspect actual directives.
+    directives = "\n".join(
+        ln for ln in block.splitlines() if not ln.strip().startswith("#")
+    )
+    assert "rewrite ^ /index.html break;" in directives, (
+        "the /m/ block must serve the SPA shell in place via `rewrite ... break`."
+    )
+    assert "try_files" not in directives, (
+        "the /m/ block must NOT use try_files — its internal redirect to "
+        "/index.html re-enters `location /` and discards the per-token embed headers."
+    )

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -262,7 +262,17 @@ server {
         #     browsers per CSP3 and never emits frame-ancestors '*').
         # SEC-020: same script/exfil backstop as `location /`.
         add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'wasm-unsafe-eval' https://static.cloudflareinsights.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https:; font-src 'self' data:; connect-src 'self' https: wss:; worker-src 'self' blob:; child-src 'self' blob:; object-src 'none'; base-uri 'self'; ${embed_frame_ancestors}" always;
-        try_files $uri /index.html;
+        # Serve the SPA shell in place — do NOT use `try_files $uri /index.html`.
+        # That fallback internal-redirects to /index.html, which re-enters
+        # `location /`; nginx then emits the FINAL location's add_header set,
+        # silently DISCARDING this block's per-token frame-ancestors CSP and
+        # re-adding `X-Frame-Options: SAMEORIGIN` — which blocks every
+        # cross-origin embed (=404 does not help; found-file try_files still
+        # re-matches. Verified against the demo's live nginx 2026-07-21).
+        # `rewrite ^ ... break` rewrites the URI in place and STOPS location
+        # re-matching, so this block's headers are the ones served. /m/* is never
+        # a real static file, so the old `$uri` existence check was a no-op.
+        rewrite ^ /index.html break;
     }
 
     # builder-audit P0-02: internal subrequest target for the /m/ framing policy.


### PR DESCRIPTION
Cross-origin **map embedding is broken on every production deployment** (found on the demo). The `/m/<token>` embed shell returns `X-Frame-Options: SAMEORIGIN` + a static `frame-ancestors 'self'` instead of the per-token policy, so any external site that iframes a share link gets a blocked frame.

## Root cause (not a stale demo — a real nginx bug)
The `location ~ ^/m/` block is entered correctly (its `auth_request` to `/embed/frame-policy` fires and returns 200), but it ends in:

```nginx
try_files $uri /index.html;
```

`/m/<token>` isn't a file, so nginx **internal-redirects to `/index.html`, which re-enters `location /`**. nginx then applies the *final* location's `add_header` set — silently discarding the `/m/` block's per-token `frame-ancestors` CSP and re-adding `X-Frame-Options: SAMEORIGIN`. The API's per-token clickjacking policy is computed but never reaches the browser.

`try_files … =404` does **not** help — a found-file `try_files` still re-matches `location /`.

## Fix
```nginx
rewrite ^ /index.html break;
```
The `break` flag rewrites the URI **in place** and stops location re-matching, so the `/m/` block's own headers are the ones served. `/m/*` is never a real static file, so the old `$uri` existence check was a no-op.

## Verified end-to-end on the demo's live nginx (2026-07-21)
Curled nginx-direct (bypassing Caddy/CF, whose config has zero header rules) **and** through the public edge:
- `/m/<token>?embed=true&et=xyz` → **no `X-Frame-Options`**; CSP ends `frame-ancestors 'none'` (fail-closed for the invalid token). Domain-locked tokens get `frame-ancestors 'self' <origins>`.
- `/catalog` (and all normal SPA routes) → **still** `X-Frame-Options: SAMEORIGIN`, CSP `frame-ancestors 'self'` — unchanged.
- `/m/<token>` still serves the SPA (200 `text/html`).

The demo is already running this fix (applied to its live config); this PR makes it durable for every deployment.

## Tests
- Adds `test_nginx_m_route_serves_in_place_not_try_files` (regression guard: the `/m/` block must use `rewrite … break`, never `try_files`).
- Existing `test_embed_frame_policy.py` invariants (auth_request wiring, `${embed_frame_ancestors}` interpolation, location-/ SAMEORIGIN) all still pass — **8/8**.
