### PR TITLE
feat(frontend): allow tunnelled hosts on the Vite dev server via FRONTEND_ALLOWED_HOSTS

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -576,6 +576,16 @@ FRONTEND_PORT=8080
 # Type: string | Default: http://localhost:8000 (host-side) / http://api:8000 (compose)
 # API_PROXY_TARGET=
 
+# [OPTIONAL] Comma-separated Host header values the Vite dev server accepts, in
+# addition to localhost/LAN. Needed when serving the dev app behind a tunnel or
+# reverse proxy that presents a public hostname (e.g. a Cloudflare tunnel) — Vite
+# blocks unknown Host headers as DNS-rebinding protection. Consumed only by
+# frontend/vite.config.ts (Node side); NOT exposed to the browser bundle. Empty →
+# Vite's default localhost/LAN allowlist. (For a public-internet deployment,
+# prefer the production nginx build over the dev server.)
+# Type: string (comma-separated) | Default: (empty)
+# FRONTEND_ALLOWED_HOSTS=app.example.com,datasets.example.com
+
 # --- Tooling / Load Tests ---
 # [OPTIONAL] Base URL consumed by load-test scripts (tests/load/common.py,
 # tests/load/locustfile.py) and the seed script (scripts/seed-showcase.py).

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -542,6 +542,10 @@ services:
       # API_PROXY_TARGET is consumed only by vite.config.ts (Node side); nothing
       # in the browser bundle reads it.
       API_PROXY_TARGET: http://api:8000
+      # FRONTEND_ALLOWED_HOSTS: comma-separated Host values the Vite dev server
+      # accepts, for serving the dev app behind a tunnel/reverse proxy (e.g. a
+      # Cloudflare tunnel). Empty by default → Vite's localhost/LAN allowlist.
+      FRONTEND_ALLOWED_HOSTS: ${FRONTEND_ALLOWED_HOSTS:-}
     healthcheck:
       # Vite dev server inside the container; HTTP GET / returns 200 once ready.
       # Cold start can take 10-15s while Vite resolves the import graph.

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -13,6 +13,17 @@ const apiProxyTarget =
   process.env.API_PROXY_TARGET ||
   'http://localhost:8000'
 
+// FRONTEND_ALLOWED_HOSTS: comma-separated Host header values the dev server
+// accepts in addition to localhost/LAN, for serving the dev app behind a tunnel
+// or reverse proxy that presents a public hostname (e.g. a Cloudflare tunnel).
+// Vite blocks unknown Host headers as DNS-rebinding protection, so a tunnelled
+// host must be listed here. Consumed Node-side only (no VITE_ prefix — this is
+// dev-server config, not a browser var). Unset → Vite's default allowlist.
+const allowedHosts = (process.env.FRONTEND_ALLOWED_HOSTS ?? '')
+  .split(',')
+  .map((h) => h.trim())
+  .filter(Boolean)
+
 // Stamp the frontend package version into the bundle at build time so the
 // in-app "Report a problem" flow can auto-fill the GitHub issue version field
 // without a runtime fetch. Exposed as the `__APP_VERSION__` global (see
@@ -88,6 +99,9 @@ export default defineConfig({
   server: {
     port: 5173,
     host: true,
+    // Only narrow the host allowlist when values are provided (tunnel/proxy
+    // deployments); otherwise leave Vite's default behavior intact.
+    ...(allowedHosts.length > 0 ? { allowedHosts } : {}),
     fs: {
       allow: fsAllow,
     },


### PR DESCRIPTION
## Problem

Serving the dev app behind a tunnel or reverse proxy that presents a public hostname (e.g. a Cloudflare tunnel) fails at the Vite dev server:

> Blocked request. This host ("datasets.example.app") is not allowed.
> To allow this host, add "datasets.example.app" to `server.allowedHosts` in vite.config.js.

Vite blocks unknown `Host` headers as DNS-rebinding protection, and the config had no `allowedHosts` entry, so there was no supported way to permit a tunnelled hostname short of hand-editing `vite.config.ts`.

## Change

Add an optional, comma-separated `FRONTEND_ALLOWED_HOSTS` knob that feeds `server.allowedHosts`:

- **`frontend/vite.config.ts`** — parses `FRONTEND_ALLOWED_HOSTS` (comma-separated, trimmed) into `server.allowedHosts`. Consumed Node-side only (no `VITE_` prefix — this is dev-server config, not a browser var), matching the existing `API_PROXY_TARGET` pattern.
- **`docker-compose.yml`** — passes `FRONTEND_ALLOWED_HOSTS` through to the frontend service.
- **`.env.example`** — documents the new optional knob.

When unset, Vite's default localhost/LAN allowlist is left intact, so this is a **no-op for existing installs**.

## Notes

- The `.env.example` entry keeps the env-doc drift gate aligned (`make env-doc-check` / `python scripts/check_env_doc_drift.py` passes).
- For a public-internet deployment the production nginx build remains the recommended path; this only makes the dev server usable behind a tunnel for demos/previews.

## Verification

- `pre-commit run --all-files` — all hooks pass, no files modified.
- `python scripts/check_env_doc_drift.py` — aligned.
- Manual, against a running dev stack:
  - `curl -H "Host: datasets.example.app" http://127.0.0.1:8080/` → **200** (serves the app) with the host listed in `FRONTEND_ALLOWED_HOSTS`.
  - `curl -H "Host: evil.example.com" http://127.0.0.1:8080/` → **403** (allowlist still protective).