### PR TITLE
fix: revalidate the SPA shell (#622) + seed water/hydrology showcase data (#626)

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,8 +84,8 @@ TOKEN=$(curl -s -X POST http://localhost:8080/api/auth/login/ \
 Semantic search takes a one-time admin setup: an embedding provider and the AI + Semantic Search toggles in the admin AI settings, plus an embedding backfill for data ingested before setup (the [search guide](https://docs.getgeolens.com/guides/user/search/) walks through it). Once that's on, search datasets by meaning instead of exact keyword matches:
 
 ```bash
-# Semantic search ranks by meaning: "hydrology" surfaces subwatersheds, lakes,
-# and river networks whose titles never mention the word
+# Semantic search ranks by meaning: "hydrology" surfaces the lake and river
+# network datasets whose titles never mention the word
 curl "http://localhost:8080/api/search/datasets/?q=hydrology&limit=3" \
   -H "Authorization: Bearer $TOKEN" | jq '.features[].properties.title'
 ```

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -272,6 +272,8 @@ server {
         # `rewrite ^ ... break` rewrites the URI in place and STOPS location
         # re-matching, so this block's headers are the ones served. /m/* is never
         # a real static file, so the old `$uri` existence check was a no-op.
+        # fix(#622): same shell-revalidation rule as `location /` below.
+        add_header Cache-Control "no-cache" always;
         rewrite ^ /index.html break;
     }
 
@@ -318,6 +320,14 @@ server {
         add_header X-Content-Type-Options "nosniff" always;
         add_header Referrer-Policy "strict-origin-when-cross-origin" always;
         add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'wasm-unsafe-eval' https://static.cloudflareinsights.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https:; font-src 'self' data:; connect-src 'self' https: wss:; worker-src 'self' blob:; child-src 'self' blob:; object-src 'none'; base-uri 'self'; frame-ancestors 'self'" always;
+        # fix(#622): the SPA shell carried NO Cache-Control, so browsers cached it
+        # heuristically and, after a redeploy, asked for hashed /assets/* that the
+        # new image no longer contains (real 404s from 3 visitors on launch day).
+        # `no-cache` = revalidate every time, but ETag/304 still applies, so the
+        # cost is one conditional GET. Everything else served from here is
+        # unhashed too (favicon, og images), so it wants the same rule.
+        # /assets/* keeps `public, immutable` from its own location above.
+        add_header Cache-Control "no-cache" always;
         try_files $uri $uri/ /index.html;
     }
 }

--- a/scripts/seed-showcase.py
+++ b/scripts/seed-showcase.py
@@ -169,6 +169,8 @@ NE_BASE = (
 NE_COUNTRIES = NE_BASE + "ne_50m_admin_0_countries.geojson"
 NE_PLACES = NE_BASE + "ne_50m_populated_places.geojson"
 NE_ADMIN1 = NE_BASE + "ne_50m_admin_1_states_provinces.geojson"
+NE_RIVERS = NE_BASE + "ne_50m_rivers_lake_centerlines.geojson"
+NE_LAKES = NE_BASE + "ne_50m_lakes.geojson"
 # PB2002 plate-boundary steps (Peter Bird 2003, via Hugo Ahlenius/Nordpil; the
 # *steps* file - not boundaries - carries per-segment STEPCLASS + velocity).
 PB2002_STEPS = (
@@ -1054,6 +1056,7 @@ def build_catalog(api: Api, force: bool = False) -> str:
       build the choropleth live instead of shipping a static one.
     * Admin-1 states/provinces committed SUMMARY-LESS: raw material for the
       AI metadata-generation demo.
+    * Rivers + lakes: the water/hydrology searches every GIS user types first.
     """
     print("\n[catalog] AI-demo + search-breadth datasets (no maps)")
     by_title = api.datasets_by_title()
@@ -1094,6 +1097,31 @@ def build_catalog(api: Api, force: bool = False) -> str:
         lambda: fetch(USDA_INCOME),
         "Median household income (2017-21 ACS) for all 62 NY counties. "
         "Source: USDA ERS Atlas of Rural & Small-Town America.",
+        force=force,
+    )
+    # fix(#626): water/hydrology terms (water, water bodies, rivers, lakes,
+    # hydrology) were the top zero-result organic searches on the public demo,
+    # and the README's own `q=hydrology` curl returned nothing - the showcase
+    # had no aquatic data at all. Both files are ~800 KB and public domain.
+    _get_or_ingest(
+        api,
+        by_title,
+        "World Rivers & Lake Centerlines (Natural Earth 1:50m)",
+        "world_rivers.geojson",
+        lambda: fetch(NE_RIVERS),
+        "Major rivers and lake centerlines worldwide - the global surface "
+        "hydrology network, named and scale-ranked. Source: Natural Earth "
+        "1:50m (public domain).",
+        force=force,
+    )
+    _get_or_ingest(
+        api,
+        by_title,
+        "World Lakes & Reservoirs (Natural Earth 1:50m)",
+        "world_lakes.geojson",
+        lambda: fetch(NE_LAKES),
+        "Lakes and reservoirs worldwide - named inland water bodies with "
+        "scale rank. Source: Natural Earth 1:50m (public domain).",
         force=force,
     )
     if force or "World States & Provinces (Natural Earth 1:50m)" not in by_title:
@@ -2991,6 +3019,14 @@ SHOWCASE_METADATA: dict[str, dict] = {
     "World Countries (Natural Earth 1:50m)": {
         "license": "Natural Earth (public domain)",
         "keywords": ["countries", "boundaries", "admin-0", "natural earth"],
+    },
+    "World Rivers & Lake Centerlines (Natural Earth 1:50m)": {
+        "license": "Natural Earth (public domain)",
+        "keywords": ["rivers", "hydrology", "water", "water bodies", "natural earth"],
+    },
+    "World Lakes & Reservoirs (Natural Earth 1:50m)": {
+        "license": "Natural Earth (public domain)",
+        "keywords": ["lakes", "hydrology", "water", "water bodies", "reservoirs"],
     },
     "World Major Cities (500k+)": {
         "license": "Natural Earth (public domain)",


### PR DESCRIPTION
Two small demo-visible fixes that share one redeploy/re-seed ops step.

Closes #622
Closes #626

## #622 — SPA shell served with no Cache-Control

`frontend/nginx.conf` set cache headers for `/env-config.js` and `/assets/` only. `index.html` went out with **no** `Cache-Control`, so browsers cached it heuristically and, after a redeploy, asked for hashed `/assets/*` that the new image no longer contains — 3 real visitors hit 404s on the root stylesheet on launch day (`LazyLoadErrorBoundary` only covers lazy JS chunks).

Fix: `add_header Cache-Control "no-cache"` on both locations that serve the shell — the SPA fallback (`location /`) and the `/m/` embed shell. `no-cache` revalidates but keeps ETag/304, so the cost is one conditional GET on a tiny document. `location /` also serves the other unhashed root files (favicon, og-image), which want the same rule.

**Verified** against the built `frontend` image running on the compose network:

| request | result |
|---|---|
| `/` | `Cache-Control: no-cache` |
| `/maps/anything` (deep SPA route) | `Cache-Control: no-cache` |
| `/m/<token>?embed=true` | `Cache-Control: no-cache` |
| `/assets/index-*.css` | `Expires: +1y`, `Cache-Control: public, immutable` (unchanged) |
| `/m/x?embed=true&et=bogus` | CSP still ends `frame-ancestors 'none'` — #618 fail-closed intact |

## #626 — no data for the most common organic searches

Demo visitors searched `water`, `water bodies`, `rivers`, `lakes`, `hydrology` → zero results for all five. Not a search bug (semantic was verified healthy by direct vector probe the same day): the catalog simply had nothing aquatic, so every water query landed past the 0.7 relevance cutoff. The README's own `q=hydrology` curl returned empty on every seeded install.

Fix: seed Natural Earth 1:50m **rivers + lake centerlines** and **1:50m lakes** in `build_catalog` (public domain, ~800 KB each, same pinned `v5.1.2` tag as the other NE sources), with summaries and keywords covering the terms people actually type. Also trims one fictional dataset (`subwatersheds`) out of the README's semantic-search example comment.

- Embeddings need no extra seeder step: ingest defers one, and the keyword/license pass re-defers on change.
- Titles deliberately differ from the retired first-generation ones in `RETIRED_DATASETS` (`… (Natural Earth 10m)`, `World Lakes (Natural Earth 1:50m)`), so `--prune` does not delete what this seeds.

**Verified** on the dev stack — anonymous, checking result sets rather than status codes:

```
water          2 ['World Lakes & Reservoirs …', 'World Rivers & Lake Centerlines …']
water bodies   2 [same]
rivers         2 [same]
lakes          2 [same]
hydrology      2 [same]
countries      4 (unchanged)
```

## Ops follow-up (after merge + release)

1. Redeploy the demo so nginx picks up the shell header (prune first, per the redeploy procedure).
2. Re-run the seeder on the demo: `python3 scripts/seed-showcase.py --only catalog` — it reuses everything existing and only ingests the two new datasets.
3. Spot-check `https://demo.getgeolens.com/api/search/datasets/?q=hydrology`.

## Note for reviewers

On a **fresh** seed the license/keyword enrichment pass can skip the just-ingested datasets: the admin dataset list is Valkey-cached for 60s and the worker's `invalidate_catalog_cache()` only reaches the API process when a shared Valkey is running. A second `--only catalog` run fills them in. That is pre-existing (#614's pass has the same exposure) and does not affect this PR's acceptance criteria — `hydrology`/`water bodies` are in the summaries, not only the keywords — so it is left alone here rather than widened into a backend change.

## Verification commands

- `docker build --target frontend -t geolens-frontend-test .` then run with `API_UPSTREAM=http://api:8000` on the compose network + `curl -sI`
- `python3 scripts/seed-showcase.py --only catalog`
- `curl -sG "http://localhost:8080/api/search/datasets/" --data-urlencode "q=hydrology"`