### PR TITLE
fix(search): skip the embedding call for typeahead-length queries (#625)

### DIFF
--- a/backend/app/modules/catalog/search/service_semantic.py
+++ b/backend/app/modules/catalog/search/service_semantic.py
@@ -40,6 +40,13 @@ _EMBEDDING_CACHE_MAX_SIZE = 512
 # the exact vector-only match COUNT (a full cosine scan) and approximates
 # from the already-fetched top-k ranks instead.
 _EXACT_SEMANTIC_COUNT_MAX_ROWS = 5000
+
+# fix(#625): search-as-you-type sent every keystroke prefix ("u", "us", "usa")
+# through a paid provider embedding call that then virtually always missed the
+# 0.7 cosine cutoff and fell back to FTS anyway. Below this length the query is
+# treated as a typeahead prefix and skips the vector path entirely. The 300 s
+# embedding cache cannot help here — each prefix is a distinct cache key.
+_MIN_SEMANTIC_QUERY_LEN = 4
 _embedding_cache: "OrderedDict[tuple[str, str], tuple[float, list[float]]]" = (
     OrderedDict()
 )
@@ -253,8 +260,10 @@ async def _run_rrf_merge(
     that violate an active filter (e.g. a polygon under ``geometry_type=Point``),
     AND a nearer non-visible neighbour displacing a valid match out of the top-k.
 
-    Returns ``None`` when RRF doesn't apply (vector backend empty/failed).
-    Caller falls through to the standard sort path on None.
+    Returns ``None`` when RRF doesn't apply (vector backend empty/failed, or the
+    query is shorter than ``_MIN_SEMANTIC_QUERY_LEN`` = 4 characters and is
+    therefore treated as a search-as-you-type prefix). Caller falls through to
+    the standard sort path on None.
 
     Returns ``([], total)`` rather than ``None`` when the FTS-cap query
     yields zero ids -- caller returns that tuple as-is. Preserved from
@@ -264,6 +273,9 @@ async def _run_rrf_merge(
     if filters.q is None:
         raise ValueError("_run_rrf_merge requires filters.q to be non-None")
     q_stripped = filters.q.strip()
+    # fix(#625): typeahead prefixes skip the vector path (and its provider call).
+    if len(q_stripped) < _MIN_SEMANTIC_QUERY_LEN:
+        return None
     # The RRF-ordered list is sliced [skip:skip+limit], so both candidate pools must
     # reach at least skip+limit deep or a later page comes back empty.
     page_end = filters.skip + filters.limit

--- a/backend/app/modules/catalog/search/service_semantic.py
+++ b/backend/app/modules/catalog/search/service_semantic.py
@@ -41,11 +41,10 @@ _EMBEDDING_CACHE_MAX_SIZE = 512
 # from the already-fetched top-k ranks instead.
 _EXACT_SEMANTIC_COUNT_MAX_ROWS = 5000
 
-# fix(#625): search-as-you-type sent every keystroke prefix ("u", "us", "usa")
-# through a paid provider embedding call that then virtually always missed the
-# 0.7 cosine cutoff and fell back to FTS anyway. Below this length the query is
-# treated as a typeahead prefix and skips the vector path entirely. The 300 s
-# embedding cache cannot help here — each prefix is a distinct cache key.
+# fix(#625): search-as-you-type spent one paid embedding call per keystroke
+# prefix ("u", "us", "usa"), each missing the 0.7 cutoff and falling back to FTS
+# anyway; the 300s cache can't help, every prefix is a distinct key. Shorter
+# queries skip the vector path entirely.
 _MIN_SEMANTIC_QUERY_LEN = 4
 _embedding_cache: "OrderedDict[tuple[str, str], tuple[float, list[float]]]" = (
     OrderedDict()
@@ -261,8 +260,7 @@ async def _run_rrf_merge(
     AND a nearer non-visible neighbour displacing a valid match out of the top-k.
 
     Returns ``None`` when RRF doesn't apply (vector backend empty/failed, or the
-    query is shorter than ``_MIN_SEMANTIC_QUERY_LEN`` = 4 characters and is
-    therefore treated as a search-as-you-type prefix). Caller falls through to
+    query is shorter than ``_MIN_SEMANTIC_QUERY_LEN``). Caller falls through to
     the standard sort path on None.
 
     Returns ``([], total)`` rather than ``None`` when the FTS-cap query
@@ -273,7 +271,6 @@ async def _run_rrf_merge(
     if filters.q is None:
         raise ValueError("_run_rrf_merge requires filters.q to be non-None")
     q_stripped = filters.q.strip()
-    # fix(#625): typeahead prefixes skip the vector path (and its provider call).
     if len(q_stripped) < _MIN_SEMANTIC_QUERY_LEN:
         return None
     # The RRF-ordered list is sliced [skip:skip+limit], so both candidate pools must

--- a/backend/tests/test_hybrid_search.py
+++ b/backend/tests/test_hybrid_search.py
@@ -485,6 +485,55 @@ async def test_rrf_ranking_with_embeddings(
 
 
 # ---------------------------------------------------------------------------
+# Tests: typeahead prefixes skip the provider embedding call (#625)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_short_query_skips_embedding_call(
+    client: AsyncClient,
+    admin_auth_header: dict,
+    hybrid_datasets_with_embeddings: dict,
+    hybrid_vectors: dict[str, list[float]],
+):
+    """fix(#625): a query below _MIN_SEMANTIC_QUERY_LEN pays no provider call.
+
+    Search-as-you-type fired one embedding round-trip per keystroke prefix, each
+    of which then missed the cosine cutoff and fell back to FTS anyway. Short
+    queries must skip the vector path entirely and still return FTS results.
+    """
+    from app.modules.catalog.search.service_semantic import _MIN_SEMANTIC_QUERY_LEN
+
+    short_q = "map"  # matches "River Systems Map" via FTS
+    assert len(short_q) < _MIN_SEMANTIC_QUERY_LEN
+
+    with patch(
+        "app.modules.catalog.search.service_semantic.generate_embedding",
+        new_callable=AsyncMock,
+        return_value=hybrid_vectors["transport"],
+    ) as mock_embed:
+        resp = await client.get(
+            "/search/datasets/",
+            params={"q": short_q},
+            headers=admin_auth_header,
+        )
+        assert resp.status_code == 200
+        mock_embed.assert_not_called()
+        titles = [f["properties"]["title"] for f in resp.json()["features"]]
+        assert "River Systems Map" in titles
+
+        # At the threshold the vector path still runs, unchanged.
+        long_q = "r" * _MIN_SEMANTIC_QUERY_LEN
+        resp = await client.get(
+            "/search/datasets/",
+            params={"q": long_q},
+            headers=admin_auth_header,
+        )
+        assert resp.status_code == 200
+        mock_embed.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
 # Tests: unit test for _compute_rrf_scores
 # ---------------------------------------------------------------------------
 

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -849,8 +849,11 @@ def test_decomposed_service_modules_stay_within_size_budgets() -> None:
         # fix(#448): +~40 LOC — query-embedding hot-path deadline (asyncio.wait_for
         # wrapper) + the gated/approximated vector-only match COUNT in
         # _run_rrf_merge (perf audit 2026-07-10 §2d). Cap 350 → 390
-        # (~19 LOC headroom above 371).
-        "backend/app/modules/catalog/search/service_semantic.py": 390,
+        # (~19 LOC headroom above 371). That headroom is now spent (386 LOC).
+        # fix(#625): +9 LOC — the _MIN_SEMANTIC_QUERY_LEN gate that drops
+        # typeahead prefixes before they reach the provider, plus its rationale
+        # comment. Cap 390 → 395, exact: the next addition needs its own review.
+        "backend/app/modules/catalog/search/service_semantic.py": 395,
         # fix(#430 V-14): _replace_layers now reconciles layers by id (update-in-place
         # + create/delete) instead of delete-all-then-recreate, so a PUT preserves
         # layer UUIDs. +~35 LOC over the 350 default. Cap → 400 (~34 headroom).


### PR DESCRIPTION
Closes #625

## Problem

Demo API logs (48h) show the RRF semantic path firing a **paid provider embedding round-trip for every search-as-you-type prefix** — `u`, `us`, `usa`, `wa`, `tu`, `tun`, `tuni`… Each one then misses the 0.7 cosine-distance cutoff (garbage-prefix embeddings land nowhere near a real record) and falls back to FTS anyway.

The 300s embedding cache in `service_semantic.py` can't absorb this: every prefix is a distinct cache key. With search-as-you-type in the catalog UI, these prefixes are the dominant source of embedding calls in live traffic, and each adds provider latency to a response that was deterministically FTS-only.

## Fix

One `if` in `_run_rrf_merge`: return `None` when the stripped query is shorter than `_MIN_SEMANTIC_QUERY_LEN` (4). `None` is that function's existing "RRF doesn't apply → caller falls through to the standard sort path" contract, so `_get_vector_ranks` — and therefore `generate_embedding` — is never reached. No config knob.

Threshold is documented in the function docstring and on the constant.

## Verification

`backend/tests/test_hybrid_search.py::test_short_query_skips_embedding_call` asserts the provider call count directly rather than inferring it from the response:

- `q=map` (3 chars) → `mock_embed.assert_not_called()`, still returns its FTS match (`River Systems Map`)
- `q=rrrr` (at the threshold) → `mock_embed.assert_awaited_once()`, vector path unchanged

Confirmed the test has teeth: it fails with the guard stashed out, passes with it.

## Verification commands

```
cd backend && set -a && source ../.env.test && set +a && uv run pytest tests/test_hybrid_search.py -q
# 13 passed

uv run pytest tests/test_search.py tests/test_search_embedding_cache.py \
  tests/test_search_pagination.py tests/test_search_cache.py tests/test_attribute_search.py -q
# 73 passed
```

## Note on the threshold

At 4, deliberate 3-char searches (`nyc`, `dem`, `gis`) lose semantic *ranking* but still get FTS, which matches them lexically anyway — those words appear in the titles/keywords people are searching for. The prefixes this actually cuts (`u`, `wa`, `tun`) had no semantic value to lose.