### PR TITLE
fix(oauth): persist the IdP's email_verified assertion on JIT provisioning (#623)

### DIFF
--- a/backend/alembic/versions/0028_oauth_email_verified_backfill.py
+++ b/backend/alembic/versions/0028_oauth_email_verified_backfill.py
@@ -1,0 +1,54 @@
+"""Backfill email_verified for GitHub-provisioned OAuth users.
+
+fix(#623): the JIT provisioning path built ``User(...)`` without
+``email_verified``, so every OAuth-provisioned account persisted the model
+default (false) even though the claim guaranteed verification — 27 of 27 SSO
+users on the public demo.
+
+Backfill is deliberately narrow. Only GitHub-linked accounts are provably
+verified: ``_fetch_github_claims`` raises unless the account has a
+primary+verified email, so a GitHub-linked row with an email cannot have been
+created from an unverified address. OIDC/Google/Microsoft rows are left alone —
+their ``email_verified`` claim is per-provider and older rows predate the H-30
+gate, so asserting verification for them would be a guess. Those converge on
+next login instead (the returning-user refresh added alongside this migration).
+
+Revision ID: 0028_oauth_email_verified_backfill
+Revises: 0027_source_format_parquet
+Create Date: 2026-07-22
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+revision: str = "0028_oauth_email_verified_backfill"
+down_revision: Union[str, None] = "0027_source_format_parquet"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        UPDATE catalog.users u
+        SET email_verified = true
+        WHERE u.auth_provider = 'oauth'
+          AND u.email IS NOT NULL
+          AND u.email_verified = false
+          AND EXISTS (
+              SELECT 1
+              FROM catalog.oauth_accounts a
+              JOIN catalog.oauth_providers p ON p.id = a.provider_id
+              WHERE a.user_id = u.id
+                AND p.provider_type = 'github'
+          )
+        """
+    )
+
+
+def downgrade() -> None:
+    # Not reversible: the pre-migration false was indistinguishable from a
+    # genuinely-unverified row, so there is nothing to restore it to. Leaving the
+    # backfilled value is the honest no-op — it is what the provider asserted.
+    pass

--- a/backend/app/modules/auth/oauth/service.py
+++ b/backend/app/modules/auth/oauth/service.py
@@ -833,6 +833,22 @@ async def find_or_create_oauth_user(
                     user_id=str(returning_user.id),
                 )
 
+        # fix(#623): converge accounts provisioned before the JIT path persisted
+        # email_verified. Only when the IdP asserts verification for the SAME
+        # address we store — a verified claim for a different email says nothing
+        # about this account's address — and only for OAuth-provisioned users, so
+        # a local account's own verification state is never flipped by a link.
+        if (
+            claim_trusted
+            and not returning_user.email_verified
+            and returning_user.auth_provider == "oauth"
+            and returning_user.email is not None
+            and email is not None
+            and returning_user.email.lower() == email.lower()
+        ):
+            returning_user.email_verified = True
+            await db.flush()
+
         logger.info(
             "OAuth login: existing link found",
             provider=provider.slug,
@@ -975,6 +991,12 @@ async def find_or_create_oauth_user(
         auth_provider="oauth",
         status="active",
         is_active=True,
+        # fix(#623): persist the IdP's assertion instead of falling to the model
+        # default (false), which left every SSO user unverified. Reaching here
+        # with a non-None email means the IdP verified it (the H-30 branch above
+        # nulls an unverified one), and an account with no email has nothing
+        # verified — so both halves of the AND are load-bearing.
+        email_verified=email is not None and email_verified,
     )
     db.add(new_user)
     await db.flush()

--- a/backend/tests/test_oauth.py
+++ b/backend/tests/test_oauth.py
@@ -731,6 +731,141 @@ class TestFindOrCreateOAuthUser:
         role_names = {r.name for r in user.roles}
         assert "viewer" in role_names
 
+    async def test_jit_persists_email_verified_claim(self, client, test_db_session):
+        """fix(#623): JIT provisioning persists the IdP's email_verified claim.
+
+        The User(...) construction omitted the field, so every SSO account
+        persisted the model default (false) — 27 of 27 on the public demo. Both
+        halves of the persisted expression are covered: a verified claim stores
+        True, and an unverified one leaves False (its email is dropped by H-30,
+        so there is nothing verified to record).
+        """
+        from app.modules.auth.oauth.service import find_or_create_oauth_user
+
+        provider = await self._create_test_provider(test_db_session)
+        await test_db_session.commit()
+
+        verified = await find_or_create_oauth_user(
+            test_db_session,
+            provider,
+            {
+                "sub": f"verified-{uuid.uuid4().hex[:6]}",
+                "email": f"verified-{uuid.uuid4().hex[:6]}@example.com",
+                "email_verified": True,
+                "name": "Verified User",
+            },
+            {},
+        )
+        await test_db_session.commit()
+        assert verified.email is not None
+        assert verified.email_verified is True
+
+        # No email_verified claim: H-30 drops the email, so nothing is verified.
+        unverified = await find_or_create_oauth_user(
+            test_db_session,
+            provider,
+            {
+                "sub": f"unverified-{uuid.uuid4().hex[:6]}",
+                "email": f"unverified-{uuid.uuid4().hex[:6]}@example.com",
+                "name": "Unverified User",
+            },
+            {},
+        )
+        await test_db_session.commit()
+        assert unverified.email is None
+        assert unverified.email_verified is False
+
+    async def test_returning_user_email_verified_refreshes(
+        self, client, test_db_session
+    ):
+        """fix(#623): a returning OAuth user converges to the IdP's assertion.
+
+        Accounts provisioned before the JIT fix stay false forever otherwise;
+        the migration only backfills provably-verified GitHub rows, so this is
+        how OIDC populations catch up.
+        """
+        from app.modules.auth.models import User
+        from app.modules.auth.oauth.models import OAuthAccount
+        from app.modules.auth.oauth.service import find_or_create_oauth_user
+
+        provider = await self._create_test_provider(test_db_session)
+        email = f"returning-{uuid.uuid4().hex[:6]}@example.com"
+        subject = f"returning-sub-{uuid.uuid4().hex[:6]}"
+        legacy_user = User(
+            username=f"returning-{uuid.uuid4().hex[:6]}",
+            email=email,
+            auth_provider="oauth",
+            status="active",
+            is_active=True,
+            email_verified=False,
+        )
+        test_db_session.add(legacy_user)
+        await test_db_session.flush()
+        test_db_session.add(
+            OAuthAccount(
+                provider_id=provider.id, user_id=legacy_user.id, subject=subject
+            )
+        )
+        await test_db_session.commit()
+
+        returned = await find_or_create_oauth_user(
+            test_db_session,
+            provider,
+            {"sub": subject, "email": email, "email_verified": True, "name": "R"},
+            {},
+        )
+        await test_db_session.commit()
+
+        assert returned.id == legacy_user.id
+        assert returned.email_verified is True
+
+    async def test_returning_user_email_verified_not_flipped_for_other_email(
+        self, client, test_db_session
+    ):
+        """fix(#623): a verified claim for a DIFFERENT address verifies nothing.
+
+        The IdP asserting it verified some other mailbox says nothing about the
+        address this account actually stores.
+        """
+        from app.modules.auth.models import User
+        from app.modules.auth.oauth.models import OAuthAccount
+        from app.modules.auth.oauth.service import find_or_create_oauth_user
+
+        provider = await self._create_test_provider(test_db_session)
+        subject = f"mismatch-sub-{uuid.uuid4().hex[:6]}"
+        legacy_user = User(
+            username=f"mismatch-{uuid.uuid4().hex[:6]}",
+            email=f"stored-{uuid.uuid4().hex[:6]}@example.com",
+            auth_provider="oauth",
+            status="active",
+            is_active=True,
+            email_verified=False,
+        )
+        test_db_session.add(legacy_user)
+        await test_db_session.flush()
+        test_db_session.add(
+            OAuthAccount(
+                provider_id=provider.id, user_id=legacy_user.id, subject=subject
+            )
+        )
+        await test_db_session.commit()
+
+        returned = await find_or_create_oauth_user(
+            test_db_session,
+            provider,
+            {
+                "sub": subject,
+                "email": f"different-{uuid.uuid4().hex[:6]}@example.com",
+                "email_verified": True,
+                "name": "M",
+            },
+            {},
+        )
+        await test_db_session.commit()
+
+        assert returned.id == legacy_user.id
+        assert returned.email_verified is False
+
     async def test_microsoft_multitenant_no_cross_tenant_bare_sub_match(
         self, client, test_db_session
     ):


### PR DESCRIPTION
Closes #623

## Problem

**27 of 27 OAuth-provisioned users on the public demo have `email_verified = false`**, though every OAuth path guarantees a verified email before provisioning. The JIT `User(...)` construction simply never set the field, so the model default persisted.

## Fix

```python
email_verified=email is not None and email_verified,
```

Both halves are load-bearing: reaching provisioning with a non-`None` email means the IdP verified it (the H-30 branch nulls an unverified one), and an account with no email has nothing verified to record. Deliberately **not** hardcoded `True` — the OIDC path can provision from a claim that is absent or false; only the *linking* path requires it true.

## Existing rows — two complementary paths

**Migration `0028` backfills only GitHub-linked accounts.** That's the one provider whose assertion is unconditional: `_fetch_github_claims` raises unless the account has a primary+verified email, so a GitHub-linked row with an email cannot have come from an unverified address. OIDC/Google/Microsoft rows are left alone — their claim is per-provider and older rows predate the H-30 gate, so flipping them would be a guess on a security-adjacent flag.

**Those converge on next login instead.** A returning user whose IdP asserts verification for the *same* address we store gets the flag set. Guards: a verified claim for a *different* address changes nothing, and only `auth_provider='oauth'` accounts are touched, so a local account's own verification state is never flipped by an OAuth link.

Between them, the demo's 27 (all GitHub) fix on deploy, and any OIDC population catches up without a bulk assertion nobody can justify.

## Tests

| test | covers |
|---|---|
| `test_jit_persists_email_verified_claim` | both halves — verified claim → `True`; absent claim → email dropped, `False` |
| `test_returning_user_email_verified_refreshes` | legacy row converges on next login |
| `test_returning_user_email_verified_not_flipped_for_other_email` | verified claim for a different address verifies nothing |

The first two fail with the fix stashed out; the third is a guard test (asserts absence of change) and passes either way by design.

## Verification commands

```
cd backend && set -a && source ../.env.test && set +a
uv run pytest tests/test_oauth.py tests/test_oauth_github_provider.py \
  tests/test_oauth_github_migration.py tests/test_oauth_account_tenant_isolation.py \
  tests/test_oauth_audit_correlation.py tests/test_oauth_destination_security.py \
  tests/test_oauth_microsoft_iss.py tests/test_layering.py -q
# 143 passed

docker compose exec api ... alembic upgrade heads   # applied clean on the dev stack
make alembic-check                                   # No new upgrade operations detected
```

## Not included

A login-time refresh for **local** accounts linking an OAuth identity — `email_verified` there belongs to the SIGNUP-03 verification flow, and an OAuth link shouldn't satisfy it. Say the word if that's wanted; it's a different question from this one.