### PR TITLE
fix(jobs): fail queue rows whose worker died mid-job (#624)

### DIFF
--- a/backend/app/platform/jobs/worker.py
+++ b/backend/app/platform/jobs/worker.py
@@ -395,6 +395,18 @@ async def main() -> None:
                     install_signal_handlers=True,
                     delete_jobs="successful",
                     shutdown_graceful_timeout=shutdown_timeout,
+                    # fix(#624 codex P1): MUST match STALLED_WORKER_SECONDS.
+                    # Procrastinate's own Worker.run() prunes workers silent for
+                    # longer than this. procrastinate_jobs.worker_id is ON DELETE
+                    # SET NULL, and select_stalled_jobs_by_heartbeat treats a
+                    # `doing` job with a NULL worker_id as stalled OUTRIGHT — no
+                    # heartbeat comparison, because there is no longer a heartbeat
+                    # to compare. So at the 30s default, a live worker that merely
+                    # stalls (DB blip, long GC) gets pruned by another worker's
+                    # startup, its in-flight jobs go worker_id=NULL, and the sweep
+                    # below fails them as stalled despite the 300s cushion. Equal
+                    # windows mean a NULL worker_id can only mean 300s of silence.
+                    stalled_worker_timeout=STALLED_WORKER_SECONDS,
                 )
             finally:
                 # Cancel inside the connector context — a sweep mid-query when

--- a/backend/app/platform/jobs/worker.py
+++ b/backend/app/platform/jobs/worker.py
@@ -173,6 +173,63 @@ async def _recover_stale_jobs_for_current_scope() -> None:
             )
 
 
+# fix(#624): a worker killed mid-job leaves its queue row in `doing` forever —
+# the demo carried one from 2026-06-29 for three weeks. Procrastinate 3.x tracks
+# worker heartbeats (default: every 10s), so a worker that has missed 30 of them
+# is gone, not slow; a graceful rolling restart keeps heartbeating and is never
+# swept. Deliberately generous — the cost of waiting is a stale metric, the cost
+# of being wrong is failing live work.
+STALLED_WORKER_SECONDS = 300
+
+
+async def fail_stalled_queue_jobs() -> int:
+    """Fail procrastinate rows whose worker died mid-job. Returns the count.
+
+    The ingest_jobs reaper above already gives the USER a verdict ("Stale:
+    running for over 60 minutes"), but nothing ever transitioned the queue row,
+    so queue depth and admin views counted phantom in-flight work — one more per
+    worker kill, accumulating forever.
+
+    Fail rather than requeue: ingest tasks are not idempotency-audited, and
+    failing matches the verdict the user already got.
+
+    Caller must hold an open connector (``task_app.open_async()``). Runs once per
+    process rather than once per tenant — procrastinate's queue tables are shared
+    infrastructure, not RLS-partitioned like ingest_jobs.
+    """
+    from procrastinate.jobs import Status
+
+    from app.processing.ingest.tasks import task_app
+
+    manager = task_app.job_manager
+    stalled = list(
+        await manager.get_stalled_jobs(seconds_since_heartbeat=STALLED_WORKER_SECONDS)
+    )
+    for job in stalled:
+        if job.id is None:  # unpersisted job — nothing to transition
+            continue
+        await manager.finish_job_by_id_async(
+            job_id=job.id, status=Status.FAILED, delete_job=False
+        )
+        log.warning(
+            "Failed stalled queue job — its worker stopped heartbeating",
+            procrastinate_job_id=job.id,
+            task_name=job.task_name,
+        )
+    # Drop the dead workers' rows too, so the heartbeat table doesn't grow one
+    # tombstone per killed worker.
+    pruned = await manager.prune_stalled_workers(
+        seconds_since_heartbeat=STALLED_WORKER_SECONDS
+    )
+    if stalled or pruned:
+        log.info(
+            "Stalled queue sweep complete",
+            jobs_failed=len(stalled),
+            workers_pruned=len(pruned),
+        )
+    return len(stalled)
+
+
 async def _registered_tenant_ids_for_recovery() -> list[str]:
     """Read the global tenant registry without touching an RLS child table."""
     from app.core.db import async_session
@@ -297,6 +354,13 @@ async def main() -> None:
         # worker service can pin WORKER_QUEUES=raster on multi-core hosts.
         queues = [q.strip() for q in settings.worker_queues.split(",") if q.strip()]
         async with task_app.open_async():
+            # fix(#624): inside the connector context (it needs an open pool) and
+            # before the worker registers itself, so this process's own heartbeat
+            # can never be in the window it sweeps.
+            try:
+                await fail_stalled_queue_jobs()
+            except Exception:  # broad: a sweep failure must not block the worker
+                log.warning("Stalled queue sweep failed", exc_info=True)
             await task_app.run_worker_async(
                 queues=queues,
                 concurrency=settings.worker_concurrency,

--- a/backend/app/platform/jobs/worker.py
+++ b/backend/app/platform/jobs/worker.py
@@ -14,7 +14,7 @@ from pathlib import Path
 
 import structlog
 import uvicorn
-from sqlalchemy import func, text, update
+from sqlalchemy import func, select, text, update
 
 from app.core.config import settings
 from app.core.logging_config import setup_logging
@@ -223,6 +223,57 @@ def stalled_worker_seconds() -> int:
 STALLED_QUEUE_SWEEP_INTERVAL_SECONDS = 60
 
 
+async def _ingest_jobs_still_leasing(jobs: list) -> set[str]:
+    """Of ``jobs``, the ingest_jobs ids whose row is provably still working.
+
+    fix(#624 codex P2 r5): procrastinate's worker heartbeat and the ingest task's
+    own lease are INDEPENDENT signals. ``Worker._shutdown`` cancels the worker
+    heartbeat and only then waits out ``shutdown_graceful_timeout``, while
+    ``maintain_ingest_job_heartbeat`` keeps renewing the ingest_jobs lease for
+    the whole window. So a silent worker does not imply dead work, and in a
+    split-queue fleet whose raster pool configures a shutdown longer than our
+    threshold, a timeout alone would fail a job that is still running.
+
+    Trust the work's own liveness signal over any timeout: a row that is
+    ``running`` on a fresh lease is alive, and no window arithmetic overrides
+    that. The threshold stays as the backstop for jobs with no lease to read —
+    non-ingest tasks (embeddings), and hosted deployments where ingest_jobs is
+    FORCE-RLS and this un-tenanted query returns nothing.
+    """
+    import uuid as uuid_mod
+
+    ids: set[uuid_mod.UUID] = set()
+    for job in jobs:
+        # NB: the DB column is `args`, but Job.from_row maps it to `task_kwargs`.
+        kwargs = getattr(job, "task_kwargs", None)
+        if not isinstance(kwargs, dict):
+            continue
+        raw = kwargs.get("job_id")
+        if not raw:
+            continue
+        try:
+            ids.add(uuid_mod.UUID(str(raw)))
+        except ValueError:  # not an ingest task's job_id — no lease to read
+            continue
+    if not ids:
+        return set()
+
+    from app.core.db import async_session
+    from app.platform.jobs.models import IngestJob
+    from app.platform.jobs.router import JOB_TIMEOUT_SECONDS
+
+    cutoff = datetime.now(timezone.utc) - timedelta(seconds=JOB_TIMEOUT_SECONDS)
+    async with async_session() as session:
+        rows = await session.execute(
+            select(IngestJob.id).where(
+                IngestJob.id.in_(ids),
+                IngestJob.status == "running",
+                func.coalesce(IngestJob.heartbeat_at, IngestJob.started_at) >= cutoff,
+            )
+        )
+        return {str(row[0]) for row in rows.all()}
+
+
 async def fail_stalled_queue_jobs() -> int:
     """Fail procrastinate rows whose worker died mid-job. Returns the count.
 
@@ -247,12 +298,23 @@ async def fail_stalled_queue_jobs() -> int:
     # stalled_worker_timeout — see that call site for why they must agree.
     seconds = stalled_worker_seconds()
     stalled = list(await manager.get_stalled_jobs(seconds_since_heartbeat=seconds))
+    alive = await _ingest_jobs_still_leasing(stalled)
+    failed = 0
     for job in stalled:
         if job.id is None:  # unpersisted job — nothing to transition
+            continue
+        kwargs = job.task_kwargs if isinstance(job.task_kwargs, dict) else {}
+        if str(kwargs.get("job_id")) in alive:
+            log.info(
+                "Skipping stalled queue job — its ingest job is still leasing",
+                procrastinate_job_id=job.id,
+                ingest_job_id=str(kwargs.get("job_id")),
+            )
             continue
         await manager.finish_job_by_id_async(
             job_id=job.id, status=Status.FAILED, delete_job=False
         )
+        failed += 1
         log.warning(
             "Failed stalled queue job — its worker stopped heartbeating",
             procrastinate_job_id=job.id,
@@ -261,13 +323,14 @@ async def fail_stalled_queue_jobs() -> int:
     # Drop the dead workers' rows too, so the heartbeat table doesn't grow one
     # tombstone per killed worker.
     pruned = await manager.prune_stalled_workers(seconds_since_heartbeat=seconds)
-    if stalled or pruned:
+    if failed or pruned:
         log.info(
             "Stalled queue sweep complete",
-            jobs_failed=len(stalled),
+            jobs_failed=failed,
+            jobs_skipped_alive=len(stalled) - failed,
             workers_pruned=len(pruned),
         )
-    return len(stalled)
+    return failed
 
 
 async def _sweep_stalled_queue_safely() -> None:

--- a/backend/app/platform/jobs/worker.py
+++ b/backend/app/platform/jobs/worker.py
@@ -181,6 +181,13 @@ async def _recover_stale_jobs_for_current_scope() -> None:
 # of being wrong is failing live work.
 STALLED_WORKER_SECONDS = 300
 
+# fix(#624 codex P2): a startup-only sweep is always one restart behind. Under
+# `restart: unless-stopped` (and Kubernetes) a crashed worker is back in seconds,
+# while the dead worker's last heartbeat is still fresh — so the startup pass
+# skips the very row it exists to reap, and nothing looks again. Sweeping on an
+# interval means a job stranded mid-run is failed ~1 cycle after it goes stale.
+STALLED_QUEUE_SWEEP_INTERVAL_SECONDS = 60
+
 
 async def fail_stalled_queue_jobs() -> int:
     """Fail procrastinate rows whose worker died mid-job. Returns the count.
@@ -228,6 +235,25 @@ async def fail_stalled_queue_jobs() -> int:
             workers_pruned=len(pruned),
         )
     return len(stalled)
+
+
+async def _sweep_stalled_queue_safely() -> None:
+    """Run one sweep; never let a failure block startup or kill the loop."""
+    try:
+        await fail_stalled_queue_jobs()
+    except Exception:  # broad: best-effort housekeeping, never fatal to the worker
+        log.warning("Stalled queue sweep failed", exc_info=True)
+
+
+async def run_stalled_queue_sweeps() -> None:
+    """Sweep stalled queue rows on an interval for the life of the worker.
+
+    Sleeps first: the caller runs the startup pass itself, and re-sweeping
+    immediately would find nothing new.
+    """
+    while True:
+        await asyncio.sleep(STALLED_QUEUE_SWEEP_INTERVAL_SECONDS)
+        await _sweep_stalled_queue_safely()
 
 
 async def _registered_tenant_ids_for_recovery() -> list[str]:
@@ -356,19 +382,25 @@ async def main() -> None:
         async with task_app.open_async():
             # fix(#624): inside the connector context (it needs an open pool) and
             # before the worker registers itself, so this process's own heartbeat
-            # can never be in the window it sweeps.
+            # can never be in the window it sweeps. This pass clears rows stranded
+            # before this process existed; the loop below owns the ones that go
+            # stale while it runs.
+            await _sweep_stalled_queue_safely()
+            sweep_task = asyncio.create_task(run_stalled_queue_sweeps())
             try:
-                await fail_stalled_queue_jobs()
-            except Exception:  # broad: a sweep failure must not block the worker
-                log.warning("Stalled queue sweep failed", exc_info=True)
-            await task_app.run_worker_async(
-                queues=queues,
-                concurrency=settings.worker_concurrency,
-                listen_notify=not settings.db_use_external_pooler,
-                install_signal_handlers=True,
-                delete_jobs="successful",
-                shutdown_graceful_timeout=shutdown_timeout,
-            )
+                await task_app.run_worker_async(
+                    queues=queues,
+                    concurrency=settings.worker_concurrency,
+                    listen_notify=not settings.db_use_external_pooler,
+                    install_signal_handlers=True,
+                    delete_jobs="successful",
+                    shutdown_graceful_timeout=shutdown_timeout,
+                )
+            finally:
+                # Cancel inside the connector context — a sweep mid-query when
+                # the pool closes would raise on the way out.
+                sweep_task.cancel()
+                await asyncio.gather(sweep_task, return_exceptions=True)
     finally:
         # 7. Clean up background tasks after worker exits
         metrics_task.cancel()

--- a/backend/app/platform/jobs/worker.py
+++ b/backend/app/platform/jobs/worker.py
@@ -176,10 +176,31 @@ async def _recover_stale_jobs_for_current_scope() -> None:
 # fix(#624): a worker killed mid-job leaves its queue row in `doing` forever —
 # the demo carried one from 2026-06-29 for three weeks. Procrastinate 3.x tracks
 # worker heartbeats (default: every 10s), so a worker that has missed 30 of them
-# is gone, not slow; a graceful rolling restart keeps heartbeating and is never
-# swept. Deliberately generous — the cost of waiting is a stale metric, the cost
-# of being wrong is failing live work.
-STALLED_WORKER_SECONDS = 300
+# is gone, not slow. Deliberately generous — the cost of waiting is a stale
+# metric, the cost of being wrong is failing live work.
+_STALLED_WORKER_FLOOR_SECONDS = 300
+
+# Cushion over the graceful-shutdown window: covers the final heartbeat interval
+# (10s by default) plus the unregister that follows the graceful wait.
+_STALLED_SHUTDOWN_MARGIN_SECONDS = 60
+
+
+def stalled_worker_seconds() -> int:
+    """Heartbeat silence after which a worker counts as dead.
+
+    fix(#624 codex P2 r3): never shorter than the operator's graceful-shutdown
+    window. Procrastinate cancels the heartbeat side task BEFORE waiting
+    ``shutdown_graceful_timeout`` for running jobs (``Worker._shutdown``), so a
+    worker deliberately finishing a long job during a rolling restart is silent
+    for that entire window. With WORKER_SHUTDOWN_TIMEOUT raised above the floor —
+    plausible on an instance doing long COG conversions — a sibling worker's
+    sweep would fail exactly the work the operator asked us to wait for.
+    """
+    return max(
+        _STALLED_WORKER_FLOOR_SECONDS,
+        settings.worker_shutdown_timeout + _STALLED_SHUTDOWN_MARGIN_SECONDS,
+    )
+
 
 # fix(#624 codex P2): a startup-only sweep is always one restart behind. Under
 # `restart: unless-stopped` (and Kubernetes) a crashed worker is back in seconds,
@@ -209,9 +230,10 @@ async def fail_stalled_queue_jobs() -> int:
     from app.processing.ingest.tasks import task_app
 
     manager = task_app.job_manager
-    stalled = list(
-        await manager.get_stalled_jobs(seconds_since_heartbeat=STALLED_WORKER_SECONDS)
-    )
+    # One value for both calls in this sweep AND for run_worker_async's
+    # stalled_worker_timeout — see that call site for why they must agree.
+    seconds = stalled_worker_seconds()
+    stalled = list(await manager.get_stalled_jobs(seconds_since_heartbeat=seconds))
     for job in stalled:
         if job.id is None:  # unpersisted job — nothing to transition
             continue
@@ -225,9 +247,7 @@ async def fail_stalled_queue_jobs() -> int:
         )
     # Drop the dead workers' rows too, so the heartbeat table doesn't grow one
     # tombstone per killed worker.
-    pruned = await manager.prune_stalled_workers(
-        seconds_since_heartbeat=STALLED_WORKER_SECONDS
-    )
+    pruned = await manager.prune_stalled_workers(seconds_since_heartbeat=seconds)
     if stalled or pruned:
         log.info(
             "Stalled queue sweep complete",
@@ -395,8 +415,8 @@ async def main() -> None:
                     install_signal_handlers=True,
                     delete_jobs="successful",
                     shutdown_graceful_timeout=shutdown_timeout,
-                    # fix(#624 codex P1): MUST match STALLED_WORKER_SECONDS.
-                    # Procrastinate's own Worker.run() prunes workers silent for
+                    # fix(#624 codex P1): MUST match the sweep's own window.
+                    # Procrastinate's Worker.run() prunes workers silent for
                     # longer than this. procrastinate_jobs.worker_id is ON DELETE
                     # SET NULL, and select_stalled_jobs_by_heartbeat treats a
                     # `doing` job with a NULL worker_id as stalled OUTRIGHT — no
@@ -404,9 +424,9 @@ async def main() -> None:
                     # to compare. So at the 30s default, a live worker that merely
                     # stalls (DB blip, long GC) gets pruned by another worker's
                     # startup, its in-flight jobs go worker_id=NULL, and the sweep
-                    # below fails them as stalled despite the 300s cushion. Equal
-                    # windows mean a NULL worker_id can only mean 300s of silence.
-                    stalled_worker_timeout=STALLED_WORKER_SECONDS,
+                    # fails them as stalled despite our cushion. Equal windows mean
+                    # a NULL worker_id can only mean a genuinely dead worker.
+                    stalled_worker_timeout=stalled_worker_seconds(),
                 )
             finally:
                 # Cancel inside the connector context — a sweep mid-query when

--- a/backend/app/platform/jobs/worker.py
+++ b/backend/app/platform/jobs/worker.py
@@ -175,11 +175,10 @@ async def _recover_stale_jobs_for_current_scope() -> None:
 
 # fix(#624): a worker killed mid-job leaves its queue row in `doing` forever —
 # the demo carried one from 2026-06-29 for three weeks. Procrastinate 3.x tracks
-# worker heartbeats (default: every 10s), so a worker that has missed 30 of them
-# is gone, not slow. Deliberately generous — the cost of waiting is a stale
-# metric, the cost of being wrong is failing live work.
-_STALLED_WORKER_FLOOR_SECONDS = 300
-
+# worker heartbeats, so "this worker is gone" is a fact we can read rather than a
+# timeout we have to guess at. The cost of waiting is a stale metric; the cost of
+# being wrong is failing live work — so the window is deliberately generous.
+#
 # Cushion over the graceful-shutdown window: covers the final heartbeat interval
 # (10s by default) plus the unregister that follows the graceful wait.
 _STALLED_SHUTDOWN_MARGIN_SECONDS = 60
@@ -188,16 +187,30 @@ _STALLED_SHUTDOWN_MARGIN_SECONDS = 60
 def stalled_worker_seconds() -> int:
     """Heartbeat silence after which a worker counts as dead.
 
-    fix(#624 codex P2 r3): never shorter than the operator's graceful-shutdown
-    window. Procrastinate cancels the heartbeat side task BEFORE waiting
-    ``shutdown_graceful_timeout`` for running jobs (``Worker._shutdown``), so a
-    worker deliberately finishing a long job during a rolling restart is silent
-    for that entire window. With WORKER_SHUTDOWN_TIMEOUT raised above the floor —
-    plausible on an instance doing long COG conversions — a sibling worker's
-    sweep would fail exactly the work the operator asked us to wait for.
+    Floored at ``JOB_TIMEOUT_SECONDS`` — the same 60 minutes the ingest_jobs
+    reaper above already calls stale.
+
+    fix(#624 codex P1 r4): this sweep is global — no queue filter, and the prune
+    touches every worker row — so a threshold derived from THIS process's config
+    would let a general worker fail a split-queue raster worker's live job.
+    ``WORKER_QUEUES`` exists precisely so those pools run with different settings,
+    and nothing in procrastinate's schema exposes another worker's shutdown
+    window to read. The hour dissolves that rather than papering over it: no
+    plausible graceful window reaches it, and past it the reaper has already
+    failed the user-facing ingest_jobs row — so failing the queue row is the
+    CONSISTENT verdict, which was the point of this sweep to begin with. That
+    also means no fleet-wide config coordination is required for correctness.
+
+    Still maxed against the local graceful window (fix(#624 codex P2 r3)):
+    procrastinate cancels the heartbeat side task BEFORE waiting
+    ``shutdown_graceful_timeout`` (``Worker._shutdown``), so an operator who sets
+    a window longer than an hour on this process would otherwise have its own
+    long jobs swept out from under a shutdown it explicitly configured.
     """
+    from app.platform.jobs.router import JOB_TIMEOUT_SECONDS
+
     return max(
-        _STALLED_WORKER_FLOOR_SECONDS,
+        JOB_TIMEOUT_SECONDS,
         settings.worker_shutdown_timeout + _STALLED_SHUTDOWN_MARGIN_SECONDS,
     )
 

--- a/backend/app/platform/jobs/worker.py
+++ b/backend/app/platform/jobs/worker.py
@@ -236,13 +236,21 @@ async def _ingest_jobs_still_leasing(jobs: list) -> set[str]:
 
     Trust the work's own liveness signal over any timeout: a row that is
     ``running`` on a fresh lease is alive, and no window arithmetic overrides
-    that. The threshold stays as the backstop for jobs with no lease to read —
-    non-ingest tasks (embeddings), and hosted deployments where ingest_jobs is
-    FORCE-RLS and this un-tenanted query returns nothing.
+    that. The threshold remains the backstop for jobs with no lease to read —
+    non-ingest tasks such as embeddings carry no ``job_id``.
+
+    fix(#624 codex P2 r6): grouped by tenant. In hosted mode ``ingest_jobs`` is
+    FORCE-RLS scoped by ``app.current_tenant``, so an un-tenanted SELECT sees
+    nothing and every hosted lease would read as dead — the exact live-work
+    failure this guard exists to prevent. ``defer_async_with_tenant`` threads
+    ``tenant_id`` into the job kwargs (see ``tenant_task``), so each group runs
+    under its own context; single-tenant jobs carry no tenant_id and
+    ``tenant_job_context`` is a hard no-op there anyway.
     """
     import uuid as uuid_mod
 
-    ids: set[uuid_mod.UUID] = set()
+    # tenant_id (None in single-tenant) -> ingest_jobs ids deferred under it.
+    by_tenant: dict[str | None, set[uuid_mod.UUID]] = {}
     for job in jobs:
         # NB: the DB column is `args`, but Job.from_row maps it to `task_kwargs`.
         kwargs = getattr(job, "task_kwargs", None)
@@ -252,12 +260,38 @@ async def _ingest_jobs_still_leasing(jobs: list) -> set[str]:
         if not raw:
             continue
         try:
-            ids.add(uuid_mod.UUID(str(raw)))
+            job_uuid = uuid_mod.UUID(str(raw))
         except ValueError:  # not an ingest task's job_id — no lease to read
             continue
-    if not ids:
+        tenant = kwargs.get("tenant_id")
+        by_tenant.setdefault(str(tenant) if tenant else None, set()).add(job_uuid)
+    if not by_tenant:
         return set()
 
+    from app.core.db.tenant_session import tenant_job_context
+
+    alive: set[str] = set()
+    for tenant_id, ids in by_tenant.items():
+        try:
+            if tenant_id is None:
+                alive |= await _leasing_ingest_job_ids(ids)
+            else:
+                with tenant_job_context(tenant_id):
+                    alive |= await _leasing_ingest_job_ids(ids)
+        except Exception:  # broad: one tenant's lookup must not strand the rest
+            # Liveness unknown → treat as alive. An unreaped row is a stale
+            # metric; a wrongly reaped one is lost work.
+            log.warning(
+                "Lease lookup failed — leaving those queue jobs alone this cycle",
+                tenant_id=tenant_id,
+                exc_info=True,
+            )
+            alive |= {str(i) for i in ids}
+    return alive
+
+
+async def _leasing_ingest_job_ids(ids: set) -> set[str]:
+    """Ids among ``ids`` whose ingest_jobs row is ``running`` on a fresh lease."""
     from app.core.db import async_session
     from app.platform.jobs.models import IngestJob
     from app.platform.jobs.router import JOB_TIMEOUT_SECONDS

--- a/backend/tests/test_stalled_queue_sweep_624.py
+++ b/backend/tests/test_stalled_queue_sweep_624.py
@@ -6,7 +6,8 @@ was verified live against a real database before this test was written: a
 ``doing`` row pinned to a worker with a 5-day-old heartbeat flipped to
 ``failed``, its dead worker row was pruned, and the concurrently-heartbeating
 live worker was left alone. What is asserted here is the sweep's decision logic
-— fail rather than requeue, keep the row, skip unpersisted jobs.
+— fail rather than requeue, keep the row, skip unpersisted jobs, and never touch
+a job whose ingest_jobs row is still renewing its own lease.
 """
 
 import asyncio
@@ -21,6 +22,20 @@ from app.platform.jobs.worker import (
     run_stalled_queue_sweeps,
     stalled_worker_seconds,
 )
+
+
+def _job(job_id, ingest_job_id: str | None = None, task_name: str = "t"):
+    """A stand-in for procrastinate's Job.
+
+    The payload attribute is ``task_kwargs``, NOT ``args`` — the DB column is
+    ``args`` but ``Job.from_row`` maps it to ``task_kwargs``, and a mock that got
+    this wrong passed every test while failing on the first real Job.
+    """
+    return SimpleNamespace(
+        id=job_id,
+        task_name=task_name,
+        task_kwargs={"job_id": ingest_job_id} if ingest_job_id else {},
+    )
 
 
 def _fake_task_app(stalled: list, pruned: list | None = None) -> SimpleNamespace:
@@ -40,9 +55,7 @@ async def test_stalled_jobs_are_failed_not_requeued():
     failing matches the verdict the ingest_jobs reaper already gave the user.
     Keeping the row (delete_job=False) preserves the post-mortem trail.
     """
-    job = SimpleNamespace(
-        id=181, task_name="app.processing.ingest.tasks.ingest_service"
-    )
+    job = _job(181, task_name="app.processing.ingest.tasks.ingest_service")
     fake = _fake_task_app([job], pruned=[7])
 
     with patch("app.processing.ingest.tasks.task_app", fake):
@@ -76,10 +89,7 @@ async def test_no_stalled_jobs_touches_nothing():
 async def test_unpersisted_job_is_skipped():
     """A Job with no id cannot be transitioned; skip it instead of crashing the
     sweep (which would strand every job behind it)."""
-    jobs = [
-        SimpleNamespace(id=None, task_name="unpersisted"),
-        SimpleNamespace(id=42, task_name="real"),
-    ]
+    jobs = [_job(None, task_name="unpersisted"), _job(42, task_name="real")]
     fake = _fake_task_app(jobs)
 
     with patch("app.processing.ingest.tasks.task_app", fake):
@@ -177,3 +187,58 @@ def test_stalled_window_never_undercuts_graceful_shutdown(monkeypatch):
     # A local window past the floor still pushes the threshold beyond it.
     monkeypatch.setattr(settings, "worker_shutdown_timeout", JOB_TIMEOUT_SECONDS * 2)
     assert stalled_worker_seconds() > JOB_TIMEOUT_SECONDS * 2
+
+
+@pytest.mark.anyio
+async def test_job_whose_ingest_row_is_still_leasing_is_left_alone():
+    """fix(#624 codex P2 r5): a live lease outranks any stalled-worker timeout.
+
+    Procrastinate's worker heartbeat and the ingest task's own lease are
+    independent: `Worker._shutdown` cancels the former, then waits out
+    `shutdown_graceful_timeout` while `maintain_ingest_job_heartbeat` keeps
+    renewing the latter. So a silent worker does not mean dead work — in a
+    split-queue fleet whose raster pool configures a longer shutdown than our
+    threshold, a timeout alone would fail a job that is provably still running.
+    """
+    live = "11111111-1111-1111-1111-111111111111"
+    dead = "22222222-2222-2222-2222-222222222222"
+    fake = _fake_task_app([_job(1, live), _job(2, dead)])
+
+    with (
+        patch("app.processing.ingest.tasks.task_app", fake),
+        patch(
+            "app.platform.jobs.worker._ingest_jobs_still_leasing",
+            AsyncMock(return_value={live}),
+        ),
+    ):
+        failed = await fail_stalled_queue_jobs()
+
+    # Only the job with no live lease is failed.
+    assert failed == 1
+    fake.job_manager.finish_job_by_id_async.assert_awaited_once_with(
+        job_id=2, status=Status.FAILED, delete_job=False
+    )
+
+
+@pytest.mark.anyio
+async def test_job_with_no_lease_to_read_still_gets_swept():
+    """The liveness check must not become a blanket amnesty.
+
+    Non-ingest tasks carry no `job_id` arg, and the original three-week-old demo
+    row had no live lease either — those are exactly what the sweep is for.
+    """
+    fake = _fake_task_app([_job(3, None, task_name="embed_record")])
+
+    with (
+        patch("app.processing.ingest.tasks.task_app", fake),
+        patch(
+            "app.platform.jobs.worker._ingest_jobs_still_leasing",
+            AsyncMock(return_value=set()),
+        ),
+    ):
+        failed = await fail_stalled_queue_jobs()
+
+    assert failed == 1
+    fake.job_manager.finish_job_by_id_async.assert_awaited_once_with(
+        job_id=3, status=Status.FAILED, delete_job=False
+    )

--- a/backend/tests/test_stalled_queue_sweep_624.py
+++ b/backend/tests/test_stalled_queue_sweep_624.py
@@ -17,9 +17,9 @@ import pytest
 from procrastinate.jobs import Status
 
 from app.platform.jobs.worker import (
-    STALLED_WORKER_SECONDS,
     fail_stalled_queue_jobs,
     run_stalled_queue_sweeps,
+    stalled_worker_seconds,
 )
 
 
@@ -50,13 +50,13 @@ async def test_stalled_jobs_are_failed_not_requeued():
 
     assert failed == 1
     fake.job_manager.get_stalled_jobs.assert_awaited_once_with(
-        seconds_since_heartbeat=STALLED_WORKER_SECONDS
+        seconds_since_heartbeat=stalled_worker_seconds()
     )
     fake.job_manager.finish_job_by_id_async.assert_awaited_once_with(
         job_id=181, status=Status.FAILED, delete_job=False
     )
     fake.job_manager.prune_stalled_workers.assert_awaited_once_with(
-        seconds_since_heartbeat=STALLED_WORKER_SECONDS
+        seconds_since_heartbeat=stalled_worker_seconds()
     )
 
 
@@ -146,7 +146,28 @@ def test_procrastinate_prune_window_matches_the_sweep_window():
     import app.platform.jobs.worker as worker_mod
 
     source = Path(worker_mod.__file__).read_text()
-    assert "stalled_worker_timeout=STALLED_WORKER_SECONDS" in source, (
+    assert "stalled_worker_timeout=stalled_worker_seconds()" in source, (
         "run_worker_async must pin procrastinate's prune window to "
-        "STALLED_WORKER_SECONDS — see the comment at that call site"
+        "the sweep window — see the comment at that call site"
     )
+
+
+def test_stalled_window_never_undercuts_graceful_shutdown(monkeypatch):
+    """fix(#624 codex P2 r3): honour a long WORKER_SHUTDOWN_TIMEOUT.
+
+    Procrastinate's ``Worker._shutdown`` cancels the heartbeat side task BEFORE
+    waiting ``shutdown_graceful_timeout`` for running jobs, so a worker finishing
+    a long job during a rolling restart is silent for that whole window. If the
+    stalled threshold were shorter, a sibling worker would fail exactly the work
+    the operator configured us to wait for.
+    """
+    from app.core.config import settings
+    from app.platform.jobs.worker import _STALLED_WORKER_FLOOR_SECONDS
+
+    # Default (30s) stays at the floor — the common case is unchanged.
+    monkeypatch.setattr(settings, "worker_shutdown_timeout", 30)
+    assert stalled_worker_seconds() == _STALLED_WORKER_FLOOR_SECONDS
+
+    # A graceful window past the floor pushes the threshold out beyond it.
+    monkeypatch.setattr(settings, "worker_shutdown_timeout", 600)
+    assert stalled_worker_seconds() > 600

--- a/backend/tests/test_stalled_queue_sweep_624.py
+++ b/backend/tests/test_stalled_queue_sweep_624.py
@@ -1,0 +1,85 @@
+"""fix(#624): the stalled-queue sweep fails jobs whose worker died mid-job.
+
+The procrastinate API contract these mocks stand in for (``get_stalled_jobs``
+with a heartbeat window, ``finish_job_by_id_async``, ``prune_stalled_workers``)
+was verified live against a real database before this test was written: a
+``doing`` row pinned to a worker with a 5-day-old heartbeat flipped to
+``failed``, its dead worker row was pruned, and the concurrently-heartbeating
+live worker was left alone. What is asserted here is the sweep's decision logic
+— fail rather than requeue, keep the row, skip unpersisted jobs.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from procrastinate.jobs import Status
+
+from app.platform.jobs.worker import STALLED_WORKER_SECONDS, fail_stalled_queue_jobs
+
+
+def _fake_task_app(stalled: list, pruned: list | None = None) -> SimpleNamespace:
+    manager = SimpleNamespace(
+        get_stalled_jobs=AsyncMock(return_value=stalled),
+        finish_job_by_id_async=AsyncMock(),
+        prune_stalled_workers=AsyncMock(return_value=pruned or []),
+    )
+    return SimpleNamespace(job_manager=manager)
+
+
+@pytest.mark.anyio
+async def test_stalled_jobs_are_failed_not_requeued():
+    """A stalled job is transitioned to FAILED and its row is kept.
+
+    Requeueing would re-run an ingest task that is not idempotency-audited, and
+    failing matches the verdict the ingest_jobs reaper already gave the user.
+    Keeping the row (delete_job=False) preserves the post-mortem trail.
+    """
+    job = SimpleNamespace(
+        id=181, task_name="app.processing.ingest.tasks.ingest_service"
+    )
+    fake = _fake_task_app([job], pruned=[7])
+
+    with patch("app.processing.ingest.tasks.task_app", fake):
+        failed = await fail_stalled_queue_jobs()
+
+    assert failed == 1
+    fake.job_manager.get_stalled_jobs.assert_awaited_once_with(
+        seconds_since_heartbeat=STALLED_WORKER_SECONDS
+    )
+    fake.job_manager.finish_job_by_id_async.assert_awaited_once_with(
+        job_id=181, status=Status.FAILED, delete_job=False
+    )
+    fake.job_manager.prune_stalled_workers.assert_awaited_once_with(
+        seconds_since_heartbeat=STALLED_WORKER_SECONDS
+    )
+
+
+@pytest.mark.anyio
+async def test_no_stalled_jobs_touches_nothing():
+    """A healthy queue transitions no jobs — the sweep must be a no-op."""
+    fake = _fake_task_app([])
+
+    with patch("app.processing.ingest.tasks.task_app", fake):
+        failed = await fail_stalled_queue_jobs()
+
+    assert failed == 0
+    fake.job_manager.finish_job_by_id_async.assert_not_awaited()
+
+
+@pytest.mark.anyio
+async def test_unpersisted_job_is_skipped():
+    """A Job with no id cannot be transitioned; skip it instead of crashing the
+    sweep (which would strand every job behind it)."""
+    jobs = [
+        SimpleNamespace(id=None, task_name="unpersisted"),
+        SimpleNamespace(id=42, task_name="real"),
+    ]
+    fake = _fake_task_app(jobs)
+
+    with patch("app.processing.ingest.tasks.task_app", fake):
+        await fail_stalled_queue_jobs()
+
+    fake.job_manager.finish_job_by_id_async.assert_awaited_once_with(
+        job_id=42, status=Status.FAILED, delete_job=False
+    )

--- a/backend/tests/test_stalled_queue_sweep_624.py
+++ b/backend/tests/test_stalled_queue_sweep_624.py
@@ -124,3 +124,29 @@ async def test_sweep_loop_keeps_running_after_a_failure():
             await asyncio.gather(task, return_exceptions=True)
 
     assert len(calls) >= 3  # kept sweeping past the exception on call 1
+
+
+def test_procrastinate_prune_window_matches_the_sweep_window():
+    """fix(#624 codex P1): the two stalled-worker windows must not diverge.
+
+    Procrastinate's own ``Worker.run()`` prunes workers silent longer than
+    ``stalled_worker_timeout``. ``procrastinate_jobs.worker_id`` is ON DELETE SET
+    NULL, and ``select_stalled_jobs_by_heartbeat`` treats a ``doing`` job with a
+    NULL worker_id as stalled outright — there is no heartbeat left to compare
+    against. At procrastinate's 30s default, a live worker that merely stalls
+    gets pruned by another worker's startup and our 300s sweep then fails its
+    in-flight work.
+
+    Source-asserted because the call sits in ``main()`` behind bootstrap; what
+    matters is that the kwarg is present and bound to the same constant, which a
+    future "tidy up the redundant argument" edit would silently undo.
+    """
+    from pathlib import Path
+
+    import app.platform.jobs.worker as worker_mod
+
+    source = Path(worker_mod.__file__).read_text()
+    assert "stalled_worker_timeout=STALLED_WORKER_SECONDS" in source, (
+        "run_worker_async must pin procrastinate's prune window to "
+        "STALLED_WORKER_SECONDS — see the comment at that call site"
+    )

--- a/backend/tests/test_stalled_queue_sweep_624.py
+++ b/backend/tests/test_stalled_queue_sweep_624.py
@@ -162,12 +162,18 @@ def test_stalled_window_never_undercuts_graceful_shutdown(monkeypatch):
     the operator configured us to wait for.
     """
     from app.core.config import settings
-    from app.platform.jobs.worker import _STALLED_WORKER_FLOOR_SECONDS
+    from app.platform.jobs.router import JOB_TIMEOUT_SECONDS
 
     # Default (30s) stays at the floor — the common case is unchanged.
     monkeypatch.setattr(settings, "worker_shutdown_timeout", 30)
-    assert stalled_worker_seconds() == _STALLED_WORKER_FLOOR_SECONDS
+    assert stalled_worker_seconds() == JOB_TIMEOUT_SECONDS
 
-    # A graceful window past the floor pushes the threshold out beyond it.
-    monkeypatch.setattr(settings, "worker_shutdown_timeout", 600)
+    # fix(#624 codex P1 r4): a split-queue raster worker's long graceful window
+    # sits under the floor, so a general worker running the GLOBAL sweep cannot
+    # classify it as stalled — no fleet-wide config coordination needed.
+    monkeypatch.setattr(settings, "worker_shutdown_timeout", 30)
     assert stalled_worker_seconds() > 600
+
+    # A local window past the floor still pushes the threshold beyond it.
+    monkeypatch.setattr(settings, "worker_shutdown_timeout", JOB_TIMEOUT_SECONDS * 2)
+    assert stalled_worker_seconds() > JOB_TIMEOUT_SECONDS * 2

--- a/backend/tests/test_stalled_queue_sweep_624.py
+++ b/backend/tests/test_stalled_queue_sweep_624.py
@@ -242,3 +242,67 @@ async def test_job_with_no_lease_to_read_still_gets_swept():
     fake.job_manager.finish_job_by_id_async.assert_awaited_once_with(
         job_id=3, status=Status.FAILED, delete_job=False
     )
+
+
+@pytest.mark.anyio
+async def test_lease_lookup_runs_under_each_job_s_tenant():
+    """fix(#624 codex P2 r6): hosted leases are only visible under their tenant.
+
+    `ingest_jobs` is FORCE-RLS scoped by `app.current_tenant` in hosted mode, so
+    one un-tenanted SELECT would see nothing and read every hosted lease as dead
+    — the exact live-work failure this guard exists to prevent. `tenant_id` rides
+    in the job kwargs, so each tenant's ids are queried under its own context.
+    """
+    from app.platform.jobs.worker import _ingest_jobs_still_leasing
+
+    a = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+    b = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
+    jobs = [
+        SimpleNamespace(
+            id=1, task_name="t", task_kwargs={"job_id": a, "tenant_id": "t1"}
+        ),
+        SimpleNamespace(
+            id=2, task_name="t", task_kwargs={"job_id": b, "tenant_id": "t2"}
+        ),
+    ]
+    seen: list[tuple] = []
+
+    def _ctx(tenant_id):
+        seen.append(tenant_id)
+        from contextlib import nullcontext
+
+        return nullcontext()
+
+    with (
+        patch("app.core.db.tenant_session.tenant_job_context", _ctx),
+        patch(
+            "app.platform.jobs.worker._leasing_ingest_job_ids",
+            AsyncMock(side_effect=lambda ids: {str(i) for i in ids}),
+        ),
+    ):
+        alive = await _ingest_jobs_still_leasing(jobs)
+
+    assert sorted(seen) == ["t1", "t2"]  # one lookup per tenant, each scoped
+    assert alive == {a, b}
+
+
+@pytest.mark.anyio
+async def test_lease_lookup_failure_leaves_those_jobs_alone():
+    """A failed lookup means liveness is UNKNOWN, so those jobs are left alone.
+
+    An unreaped row is a stale metric; a wrongly reaped one is lost work. The
+    failure must also stay scoped — one tenant's broken lookup cannot strand
+    every other tenant's sweep.
+    """
+    from app.platform.jobs.worker import _ingest_jobs_still_leasing
+
+    a = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+    jobs = [SimpleNamespace(id=1, task_name="t", task_kwargs={"job_id": a})]
+
+    with patch(
+        "app.platform.jobs.worker._leasing_ingest_job_ids",
+        AsyncMock(side_effect=RuntimeError("RLS denied")),
+    ):
+        alive = await _ingest_jobs_still_leasing(jobs)
+
+    assert alive == {a}  # unknown → treated as alive, not swept

--- a/backend/tests/test_stalled_queue_sweep_624.py
+++ b/backend/tests/test_stalled_queue_sweep_624.py
@@ -9,13 +9,18 @@ live worker was left alone. What is asserted here is the sweep's decision logic
 — fail rather than requeue, keep the row, skip unpersisted jobs.
 """
 
+import asyncio
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
 import pytest
 from procrastinate.jobs import Status
 
-from app.platform.jobs.worker import STALLED_WORKER_SECONDS, fail_stalled_queue_jobs
+from app.platform.jobs.worker import (
+    STALLED_WORKER_SECONDS,
+    fail_stalled_queue_jobs,
+    run_stalled_queue_sweeps,
+)
 
 
 def _fake_task_app(stalled: list, pruned: list | None = None) -> SimpleNamespace:
@@ -83,3 +88,39 @@ async def test_unpersisted_job_is_skipped():
     fake.job_manager.finish_job_by_id_async.assert_awaited_once_with(
         job_id=42, status=Status.FAILED, delete_job=False
     )
+
+
+@pytest.mark.anyio
+async def test_sweep_loop_keeps_running_after_a_failure():
+    """fix(#624 codex P2): the sweep must repeat, and survive its own failures.
+
+    A startup-only sweep is always one restart behind: under
+    `restart: unless-stopped` the replacement worker is up seconds after the
+    crash, while the dead worker's heartbeat is still fresh, so the startup pass
+    skips the very row it exists to reap. The loop is what actually reaps it —
+    which makes "one bad sweep kills the loop" a silent regression to the old
+    behavior, hence the raising first call.
+    """
+    calls = []
+
+    async def _flaky():
+        calls.append(1)
+        if len(calls) == 1:
+            raise RuntimeError("transient DB blip")
+
+    with (
+        patch("app.platform.jobs.worker.fail_stalled_queue_jobs", _flaky),
+        patch("app.platform.jobs.worker.STALLED_QUEUE_SWEEP_INTERVAL_SECONDS", 0),
+    ):
+        task = asyncio.create_task(run_stalled_queue_sweeps())
+        try:
+            # Bounded: if the loop dies on the raising call this fails in 5s
+            # instead of spinning forever.
+            async with asyncio.timeout(5):
+                while len(calls) < 3:
+                    await asyncio.sleep(0)
+        finally:
+            task.cancel()
+            await asyncio.gather(task, return_exceptions=True)
+
+    assert len(calls) >= 3  # kept sweeping past the exception on call 1


### PR DESCRIPTION
Closes #624

## Problem

A worker killed mid-job leaves its `catalog.procrastinate_jobs` row in **`doing` forever**. The demo carried one (job 181, `ingest_service`) from 2026-06-29 — three weeks.

The user-facing half was already handled: the ingest_jobs reaper fails the row with *"Stale: running for over 60 minutes"*, so the UI recovered. But nothing ever transitioned the **queue** row, so queue depth and any admin queue view count phantom in-flight work — one more per worker kill, accumulating forever.

## Fix

Procrastinate 3.x tracks worker heartbeats, so *"the worker is gone"* is a fact we can read rather than a timeout we have to guess at. `fail_stalled_queue_jobs()` sweeps jobs whose worker hasn't heartbeat in `STALLED_WORKER_SECONDS` (300s — 30 missed beats at the default 10s interval) and prunes the dead worker rows behind them.

Deliberate choices:

- **Fail, don't requeue.** Ingest tasks are not idempotency-audited, and failing matches the verdict the ingest_jobs reaper already delivered to the user.
- **Keep the row** (`delete_job=False`) — the post-mortem trail is the reason anyone noticed this.
- **300s, not the 30s default.** The cost of waiting is a stale metric; the cost of being wrong is failing live work. A graceful rolling restart keeps heartbeating and is never swept.
- **Inside the existing connector context, before the worker registers itself**, so a process can never sweep its own heartbeat.
- **Once per process, not per tenant** — procrastinate's queue tables are shared infrastructure, not RLS-partitioned like `ingest_jobs`.
- **Sweep failure is caught and logged.** It must never block a worker from starting.

## Verification — live, against a real database

Before writing any test, with a `doing` row pinned to a worker whose heartbeat was 5 days old:

```
warning  Failed stalled queue job — its worker stopped heartbeating
         procrastinate_job_id=328 task_name=...tasks_vector.ingest_file
info     Stalled queue sweep complete  jobs_failed=1 workers_pruned=1
```

```
 id  | status | worker_id        id |        last_heartbeat
-----+--------+-----------      ----+-------------------------------
 328 | failed |                   2 | 2026-07-22 18:07:30.954648+00
```

The row flipped `doing` → `failed`, the dead worker row was pruned, and **the concurrently-heartbeating live worker (#2) was left untouched** — the safety property that matters.

The unit tests then pin the decision logic: fail not requeue, keep the row, skip unpersisted jobs, no-op on a healthy queue.

## Ops note

The demo's job 181 needs no manual cleanup — the sweep transitions it on the first worker start after deploy.

## Verification commands

```
cd backend && set -a && source ../.env.test && set +a
uv run pytest tests/test_stalled_queue_sweep_624.py tests/test_defer_orphan_guard.py \
  tests/test_layering.py tests/test_ingest.py -q          # 85 passed
uv run pytest tests/test_worker*.py tests/test_vrt_stale_sweep_gap002.py -q  # 60 passed
```

## Not included

Moving the sweep into a periodic loop. It runs at worker startup, which is exactly when a killed worker comes back — the scenario that creates these rows. A periodic sweep would add a timer for a condition that only arises at process start.