### PR TITLE
fix(frontend): global signed-out surface + shared tile-auth re-mint

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -9,6 +9,7 @@ import { SiteBanner } from '@/components/layout/SiteBanner';
 import { AdminLayout } from '@/components/admin/AdminLayout';
 import { LoadingState } from '@/components/layout/LoadingState';
 import { LazyLoadErrorBoundary, RouteErrorBoundary } from '@/components/error';
+import { SessionExpiredDialog } from '@/components/auth/SessionExpiredDialog';
 
 // Lazy page imports — each produces a separate Vite chunk
 const LoginPage = lazy(() => import('./pages/LoginPage').then(m => ({ default: m.LoginPage })));
@@ -51,6 +52,9 @@ const NotFoundPage = lazy(() => import('./pages/NotFoundPage').then(m => ({ defa
 function RootLayout() {
   return (
     <LazyLoadErrorBoundary>
+      {/* fix(#628): global session-expiry host — needs router context for the
+          sign-in-returns-to-route action, so it lives here rather than main.tsx. */}
+      <SessionExpiredDialog />
       <Suspense fallback={<LoadingState />}>
         <Outlet />
       </Suspense>

--- a/frontend/src/api/__tests__/client.session-expiry.test.ts
+++ b/frontend/src/api/__tests__/client.session-expiry.test.ts
@@ -1,0 +1,131 @@
+import { apiFetch, ApiError, onSessionExpired } from '@/api/client';
+import { useAuthStore } from '@/stores/auth-store';
+import { refreshAccessToken } from '@/api/auth';
+
+// fix(#628): the fetch core must treat "401 + the follow-up refresh is also
+// dead" as a single session-death event: clear the persisted auth state and
+// invoke the registered handler exactly ONCE, no matter how many in-flight
+// requests fail together. Anonymous 401s (no session to expire) must never
+// raise the handler.
+
+vi.mock('@/api/auth', () => ({
+  refreshAccessToken: vi.fn(),
+}));
+
+const mockFetch = vi.fn();
+globalThis.fetch = mockFetch;
+
+function errorResponse(status: number): Response {
+  return {
+    ok: false,
+    status,
+    statusText: 'Unauthorized',
+    json: () => Promise.reject(new Error('not json')),
+    headers: new Headers(),
+  } as Response;
+}
+
+function jsonResponse(data: unknown, status = 200): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    statusText: 'OK',
+    json: () => Promise.resolve(data),
+    headers: new Headers(),
+  } as Response;
+}
+
+// Refresh tokens rotate, so every session's token value is unique — the
+// notification latch is keyed on it.
+let sessionCounter = 0;
+function signIn() {
+  sessionCounter += 1;
+  useAuthStore.setState({
+    token: 'stale-access-token',
+    refreshToken: `dead-refresh-token-${sessionCounter}`,
+    // Far enough out that the proactive-refresh branch does not fire.
+    expiresAt: Date.now() + 120_000,
+  });
+}
+
+describe('session-expiry notification (fix #628)', () => {
+  let handler: ReturnType<typeof vi.fn<() => void>>;
+  let unregister: () => void;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    handler = vi.fn<() => void>();
+    unregister = onSessionExpired(handler);
+  });
+
+  afterEach(() => {
+    unregister();
+    useAuthStore.setState({ token: null, refreshToken: null, expiresAt: null, user: null });
+  });
+
+  it('401 + dead refresh: clears the store and invokes the handler exactly once across N concurrent requests', async () => {
+    signIn();
+    mockFetch.mockResolvedValue(errorResponse(401));
+    vi.mocked(refreshAccessToken).mockRejectedValue(new ApiError('unauthorized', 401));
+
+    const results = await Promise.allSettled([
+      apiFetch('/a/'),
+      apiFetch('/b/'),
+      apiFetch('/c/'),
+      apiFetch('/d/'),
+      apiFetch('/e/'),
+    ]);
+
+    for (const r of results) {
+      expect(r.status).toBe('rejected');
+      expect((r as PromiseRejectedResult).reason).toBeInstanceOf(ApiError);
+      expect(((r as PromiseRejectedResult).reason as ApiError).status).toBe(401);
+    }
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(useAuthStore.getState().token).toBeNull();
+    expect(useAuthStore.getState().refreshToken).toBeNull();
+  });
+
+  it('does not invoke the handler for an anonymous 401 (no session to expire)', async () => {
+    mockFetch.mockResolvedValue(errorResponse(401));
+
+    await expect(apiFetch('/private/')).rejects.toMatchObject({ status: 401 });
+
+    expect(refreshAccessToken).not.toHaveBeenCalled();
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it('does not invoke the handler when the refresh succeeds and the retry passes', async () => {
+    signIn();
+    mockFetch
+      .mockResolvedValueOnce(errorResponse(401))
+      .mockResolvedValueOnce(jsonResponse({ ok: true }));
+    vi.mocked(refreshAccessToken).mockResolvedValue({
+      access_token: 'fresh',
+      refresh_token: 'fresh-refresh',
+      expires_in: 900,
+      token_type: 'bearer',
+    });
+
+    await expect(apiFetch('/a/')).resolves.toEqual({ ok: true });
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it('notifies once per dead session, and again for the next dead session', async () => {
+    signIn();
+    mockFetch.mockResolvedValue(errorResponse(401));
+    vi.mocked(refreshAccessToken).mockRejectedValue(new ApiError('unauthorized', 401));
+
+    await expect(apiFetch('/a/')).rejects.toMatchObject({ status: 401 });
+    expect(handler).toHaveBeenCalledTimes(1);
+
+    // Signed out now — a further 401 is anonymous and must not re-notify.
+    await expect(apiFetch('/b/')).rejects.toMatchObject({ status: 401 });
+    expect(handler).toHaveBeenCalledTimes(1);
+
+    // A fresh sign-in mints a NEW (rotated) refresh token; its death is a new event.
+    signIn();
+    await expect(apiFetch('/c/')).rejects.toMatchObject({ status: 401 });
+    expect(handler).toHaveBeenCalledTimes(2);
+  });
+});

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -28,6 +28,33 @@ export class ApiError extends Error {
 // expiration starts fresh.
 let inflightRefresh: Promise<void> | null = null;
 
+// fix(#628): once a request 401s AND the follow-up refresh cannot produce a
+// working token, the session is conclusively dead — every surface in the app
+// is about to fail the same way (silent 403 tiles, quiet query errors, generic
+// toasts). Instead of letting each surface invent its own failure UX, clear
+// the session once and notify a single app-level handler (the signed-out
+// dialog host). The latch is keyed on the dead refresh token's value: the
+// burst of concurrent in-flight failures all captured the same token, so they
+// collapse to one notification, while the next session (refresh tokens
+// rotate, so its token is always new) notifies again.
+let sessionExpiredHandler: (() => void) | null = null;
+let lastNotifiedRefreshToken: string | null = null;
+
+/** Register the app-level signed-out handler. Returns an unregister fn. */
+export function onSessionExpired(handler: () => void): () => void {
+  sessionExpiredHandler = handler;
+  return () => {
+    if (sessionExpiredHandler === handler) sessionExpiredHandler = null;
+  };
+}
+
+export function notifySessionExpired(deadRefreshToken: string): void {
+  if (deadRefreshToken === lastNotifiedRefreshToken) return;
+  lastNotifiedRefreshToken = deadRefreshToken;
+  useAuthStore.getState().logout();
+  sessionExpiredHandler?.();
+}
+
 export async function tryRefresh(): Promise<boolean> {
   const { refreshToken } = useAuthStore.getState();
   if (!refreshToken) return false;
@@ -133,6 +160,11 @@ export async function authenticatedRawFetch(
   });
 
   if (response.status === 401) {
+    // fix(#628): only a session that existed can expire. A real session always
+    // holds a refresh token; an anonymous 401 (or the transient token-only
+    // state mid-login) must not raise the signed-out prompt. Captured BEFORE
+    // tryRefresh so every concurrent failure holds the same dead token.
+    const sessionRefreshToken = useAuthStore.getState().refreshToken;
     const refreshed = await tryRefresh();
     if (refreshed) {
       const retry = await safeFetch(target, {
@@ -145,7 +177,11 @@ export async function authenticatedRawFetch(
       // a spurious logout.
       if (retry.status !== 401) return retry;
     }
-    useAuthStore.getState().logout();
+    if (sessionRefreshToken) {
+      notifySessionExpired(sessionRefreshToken);
+    } else {
+      useAuthStore.getState().logout();
+    }
     // fix(#438): UX-10 — was hardcoded English.
     throw new ApiError(i18n.t('common:errors.unauthorized'), 401);
   }

--- a/frontend/src/components/auth/SessionExpiredDialog.tsx
+++ b/frontend/src/components/auth/SessionExpiredDialog.tsx
@@ -1,7 +1,10 @@
 import { useEffect, useRef, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router';
+import { useQuery } from '@tanstack/react-query';
 import { useTranslation } from 'react-i18next';
 import { onSessionExpired } from '@/api/client';
+import { getAuthConfig } from '@/api/auth';
+import { queryKeys } from '@/lib/query-keys';
 import { Button } from '@/components/ui/button';
 import {
   Dialog,
@@ -18,8 +21,9 @@ import {
 // instead of prompting. Detail pages (/datasets/:id, /maps/:id) are excluded:
 // whether they work anonymously depends on the resource's visibility, so they
 // keep the prompt; a public resource still recovers after dismissal via the
-// same anonymous refetch.
-const ANON_EXACT = new Set(['/', '/collections', '/maps', '/login', '/register', '/verify-email']);
+// same anonymous refetch. The root route is handled separately — see the
+// landing-first check in the handler.
+const ANON_EXACT = new Set(['/collections', '/maps', '/login', '/register', '/verify-email']);
 const ANON_PREFIXES = ['/m/', '/oauth/'];
 
 function isAnonymousCapable(pathname: string): boolean {
@@ -46,23 +50,36 @@ export function SessionExpiredDialog() {
   const locationRef = useRef(location);
   locationRef.current = location;
 
+  // fix(#633 codex P2): whether "/" is anonymous-capable depends on the
+  // landing-first flag — LandingFirstGuard bounces anonymous visitors without
+  // the guest-browse marker to /login. Held in a ref because at event time
+  // the logout has already fired wireAuthCacheReset's queryClient.clear(),
+  // so the cache read would race the wipe; the ref keeps the last-known value.
+  const { data: authConfig } = useQuery({
+    queryKey: queryKeys.authConfig.config,
+    queryFn: getAuthConfig,
+    staleTime: 5 * 60 * 1000,
+  });
+  const landingFirstRef = useRef(false);
+  if (authConfig) landingFirstRef.current = authConfig.landing_first ?? false;
+
   useEffect(
     () =>
       onSessionExpired(() => {
         const { pathname, search } = locationRef.current;
-        if (isAnonymousCapable(pathname)) return;
+        if (pathname === '/') {
+          // Anonymous catalog browsing exists on "/" unless landing-first
+          // would bounce this (now signed-out) visitor to /login — there the
+          // prompt is exactly the context the teleport otherwise lacks.
+          const guestBrowse = sessionStorage.getItem('gl-guest-browse') === 'true';
+          if (!landingFirstRef.current || guestBrowse) return;
+        } else if (isAnonymousCapable(pathname)) {
+          return;
+        }
         setFrom(pathname + search);
       }),
     [],
   );
-
-  // A protected route bounces to /login on its own the moment the store is
-  // cleared (ProtectedRoute) — the prompt over the login form is noise.
-  useEffect(() => {
-    if (from && (location.pathname === '/login' || location.pathname === '/register')) {
-      setFrom(null);
-    }
-  }, [from, location.pathname]);
 
   const signIn = () => {
     if (from) sessionStorage.setItem('geolens-login-redirect', from);

--- a/frontend/src/components/auth/SessionExpiredDialog.tsx
+++ b/frontend/src/components/auth/SessionExpiredDialog.tsx
@@ -1,0 +1,89 @@
+import { useEffect, useRef, useState } from 'react';
+import { useLocation, useNavigate } from 'react-router';
+import { useTranslation } from 'react-i18next';
+import { onSessionExpired } from '@/api/client';
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+
+// fix(#628): routes whose anonymous view is a complete experience — when the
+// session dies here we downgrade silently (the auth-store logout triggers the
+// wireAuthCacheReset cache clear, so active queries refetch anonymously)
+// instead of prompting. Detail pages (/datasets/:id, /maps/:id) are excluded:
+// whether they work anonymously depends on the resource's visibility, so they
+// keep the prompt; a public resource still recovers after dismissal via the
+// same anonymous refetch.
+const ANON_EXACT = new Set(['/', '/collections', '/maps', '/login', '/register', '/verify-email']);
+const ANON_PREFIXES = ['/m/', '/oauth/'];
+
+function isAnonymousCapable(pathname: string): boolean {
+  return ANON_EXACT.has(pathname) || ANON_PREFIXES.some((p) => pathname.startsWith(p));
+}
+
+/**
+ * fix(#628): global last-resort session-expiry surface. The fetch core calls
+ * the onSessionExpired handler exactly once when a request 401s and the
+ * follow-up refresh is also dead; this host shows a single dismissable
+ * "signed out" dialog whose sign-in action returns to the current route
+ * (same `from` contract as ProtectedRoute/LoginPage, including the
+ * sessionStorage key the OAuth callback reads).
+ */
+export function SessionExpiredDialog() {
+  const { t } = useTranslation('auth');
+  const location = useLocation();
+  const navigate = useNavigate();
+  // The route to return to after sign-in; non-null means the dialog is open.
+  const [from, setFrom] = useState<string | null>(null);
+
+  // Ref, not closure: the handler is registered once and must read the route
+  // at event time, not the route captured when the effect ran.
+  const locationRef = useRef(location);
+  locationRef.current = location;
+
+  useEffect(
+    () =>
+      onSessionExpired(() => {
+        const { pathname, search } = locationRef.current;
+        if (isAnonymousCapable(pathname)) return;
+        setFrom(pathname + search);
+      }),
+    [],
+  );
+
+  // A protected route bounces to /login on its own the moment the store is
+  // cleared (ProtectedRoute) — the prompt over the login form is noise.
+  useEffect(() => {
+    if (from && (location.pathname === '/login' || location.pathname === '/register')) {
+      setFrom(null);
+    }
+  }, [from, location.pathname]);
+
+  const signIn = () => {
+    if (from) sessionStorage.setItem('geolens-login-redirect', from);
+    navigate('/login', { state: { from } });
+    setFrom(null);
+  };
+
+  return (
+    <Dialog open={from !== null} onOpenChange={(open) => !open && setFrom(null)}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>{t('sessionExpired.title')}</DialogTitle>
+          <DialogDescription>{t('sessionExpired.body')}</DialogDescription>
+        </DialogHeader>
+        <DialogFooter>
+          <Button variant="outline" onClick={() => setFrom(null)}>
+            {t('sessionExpired.dismiss')}
+          </Button>
+          <Button onClick={signIn}>{t('sessionExpired.signIn')}</Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/src/components/auth/__tests__/SessionExpiredDialog.test.tsx
+++ b/frontend/src/components/auth/__tests__/SessionExpiredDialog.test.tsx
@@ -2,28 +2,45 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter, Route, Routes, useLocation } from 'react-router';
 import { act } from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { SessionExpiredDialog } from '@/components/auth/SessionExpiredDialog';
 import { notifySessionExpired } from '@/api/client';
 import { useAuthStore } from '@/stores/auth-store';
+import { queryKeys } from '@/lib/query-keys';
+import type { AuthConfigResponse } from '@/types/api';
 
 // fix(#628): the global signed-out host — one dismissable prompt when the
 // fetch core declares the session dead, sign-in returns to the current route,
 // and anonymous-capable routes downgrade silently instead of prompting.
+
+vi.mock('@/api/auth', () => ({
+  getAuthConfig: vi.fn().mockRejectedValue(new Error('not stubbed')),
+  refreshAccessToken: vi.fn(),
+}));
 
 function LoginProbe() {
   const location = useLocation();
   return <div data-testid="login-probe">{(location.state as { from?: string } | null)?.from ?? 'no-from'}</div>;
 }
 
-function renderAt(path: string) {
+function renderAt(path: string, { landingFirst }: { landingFirst?: boolean } = {}) {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  if (landingFirst !== undefined) {
+    queryClient.setQueryData(
+      queryKeys.authConfig.config,
+      { landing_first: landingFirst } as AuthConfigResponse,
+    );
+  }
   return render(
-    <MemoryRouter initialEntries={[path]}>
-      <SessionExpiredDialog />
-      <Routes>
-        <Route path="/login" element={<LoginProbe />} />
-        <Route path="*" element={<div />} />
-      </Routes>
-    </MemoryRouter>,
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter initialEntries={[path]}>
+        <SessionExpiredDialog />
+        <Routes>
+          <Route path="/login" element={<LoginProbe />} />
+          <Route path="*" element={<div />} />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>,
   );
 }
 
@@ -73,5 +90,23 @@ describe('SessionExpiredDialog', () => {
     expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
     // The session is still cleared — queries refetch anonymously.
     expect(useAuthStore.getState().token).toBeNull();
+  });
+
+  // fix(#633 codex P2): on landing-first deployments "/" is NOT anonymous-
+  // capable — LandingFirstGuard bounces the now-signed-out visitor to /login,
+  // so the prompt must show to explain the teleport.
+  it('prompts on "/" when landing-first would bounce the anonymous visitor', () => {
+    renderAt('/', { landingFirst: true });
+    act(() => notifySessionExpired(nextDeadToken()));
+
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+  });
+
+  it('still downgrades silently on "/" under landing-first when guest browsing was chosen', () => {
+    sessionStorage.setItem('gl-guest-browse', 'true');
+    renderAt('/', { landingFirst: true });
+    act(() => notifySessionExpired(nextDeadToken()));
+
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/components/auth/__tests__/SessionExpiredDialog.test.tsx
+++ b/frontend/src/components/auth/__tests__/SessionExpiredDialog.test.tsx
@@ -1,0 +1,77 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, Route, Routes, useLocation } from 'react-router';
+import { act } from 'react';
+import { SessionExpiredDialog } from '@/components/auth/SessionExpiredDialog';
+import { notifySessionExpired } from '@/api/client';
+import { useAuthStore } from '@/stores/auth-store';
+
+// fix(#628): the global signed-out host — one dismissable prompt when the
+// fetch core declares the session dead, sign-in returns to the current route,
+// and anonymous-capable routes downgrade silently instead of prompting.
+
+function LoginProbe() {
+  const location = useLocation();
+  return <div data-testid="login-probe">{(location.state as { from?: string } | null)?.from ?? 'no-from'}</div>;
+}
+
+function renderAt(path: string) {
+  return render(
+    <MemoryRouter initialEntries={[path]}>
+      <SessionExpiredDialog />
+      <Routes>
+        <Route path="/login" element={<LoginProbe />} />
+        <Route path="*" element={<div />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+// The client module's notification latch is keyed on the dead refresh token's
+// value — give each test a unique one so notify fires.
+let deadToken = 0;
+function nextDeadToken() {
+  deadToken += 1;
+  return `dead-refresh-${deadToken}`;
+}
+
+describe('SessionExpiredDialog', () => {
+  beforeEach(() => {
+    useAuthStore.setState({ token: 't', refreshToken: 'r', expiresAt: Date.now() + 120_000 });
+    sessionStorage.clear();
+  });
+
+  it('shows a single signed-out prompt whose sign-in action returns to the current route', async () => {
+    renderAt('/datasets/abc?tab=preview');
+
+    const dead = nextDeadToken();
+    act(() => notifySessionExpired(dead));
+    // Duplicate notifications (concurrent request failures) stay latched.
+    act(() => notifySessionExpired(dead));
+
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    expect(screen.getByText("You've been signed out")).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole('button', { name: 'Sign in' }));
+    expect(screen.getByTestId('login-probe')).toHaveTextContent('/datasets/abc?tab=preview');
+    // The OAuth callback reads this key for the SSO round-trip.
+    expect(sessionStorage.getItem('geolens-login-redirect')).toBe('/datasets/abc?tab=preview');
+  });
+
+  it('is dismissable', async () => {
+    renderAt('/datasets/abc');
+    act(() => notifySessionExpired(nextDeadToken()));
+
+    await userEvent.click(screen.getByRole('button', { name: 'Dismiss' }));
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  it('downgrades silently on anonymous-capable routes instead of prompting', () => {
+    renderAt('/');
+    act(() => notifySessionExpired(nextDeadToken()));
+
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    // The session is still cleared — queries refetch anonymously.
+    expect(useAuthStore.getState().token).toBeNull();
+  });
+});

--- a/frontend/src/components/builder/BuilderMap.tsx
+++ b/frontend/src/components/builder/BuilderMap.tsx
@@ -14,6 +14,7 @@ import {
 import { buildClusterTileUrl, buildSignedTileUrl, isMvtSourceLayerConfigReady } from '@/lib/tile-utils';
 import { MAP_COLORS } from '@/lib/map-colors';
 import { useTileTokens, useInvalidateTileTokens } from '@/hooks/use-tile-token';
+import { useTileAuthRecovery } from '@/hooks/use-tile-auth-recovery';
 import { useTileTokenError } from './hooks/use-tile-token-error';
 import { getEnvConfig } from '@/lib/env';
 import { pushReportEntry } from '@/lib/report';
@@ -576,6 +577,12 @@ export const BuilderMap = memo(function BuilderMap({
     });
   }, [enabledPluginIds]);
 
+  const invalidateTileTokens = useInvalidateTileTokens();
+  // fix(#621): shared tile-auth recovery — a vector tile 401/403 that the
+  // cached-token re-sign can't cure kicks one throttled token re-mint; the
+  // token-sync effect re-signs sources when the fresh batch lands.
+  const recoverTileAuth = useTileAuthRecovery(invalidateTileTokens);
+
   const handleLoad = useCallback(
     (e: MapLibreEvent) => {
       const map = e.target;
@@ -648,20 +655,34 @@ export const BuilderMap = memo(function BuilderMap({
             const failingSourceId = e.sourceId;
             if (map && failingSourceId) {
               const { layers: l, tokenMap: tm, tileConfig: tc } = syncInputsRef.current;
-              if (resignVectorSourceForRetry(map, failingSourceId, l, tm, tc)) {
+              const resigned = resignVectorSourceForRetry(map, failingSourceId, l, tm, tc);
+              // fix(#621): the cached-token re-sign only cures the attach
+              // race — when the sig itself has expired (stranded session),
+              // it re-signs with the same stale sig forever. Also kick one
+              // throttled token re-mint; the token-sync effect re-signs with
+              // the fresh batch, and a conclusively dead session surfaces
+              // through the global signed-out handling (#628) via the mint
+              // request itself.
+              const reminted = recoverTileAuth();
+              if (resigned || reminted) {
                 pushReportEntry({
                   severity: 'warning',
                   source: 'maplibre',
-                  message: `Vector tile re-signed and retried after HTTP ${status} (BLDR-TILE-RACE)`,
+                  message: `Vector tile ${resigned ? 're-signed' : 're-mint requested'} after HTTP ${status} (BLDR-TILE-RACE)`,
                   detail: `source: ${failingSourceId}`,
                   suppressed: true,
                 });
                 return;
               }
             }
-            toast.error(t('builderMap.authError', { defaultValue: 'Session expired — reload the page to restore tile access.' }), {
-              id: 'builder-map-auth-error',
-            });
+            // fix(#628): once the session is conclusively dead the global
+            // signed-out dialog owns the UX — the stale reload-toast is
+            // noise on top of it. Keep it only while a session exists.
+            if (useAuthStore.getState().refreshToken) {
+              toast.error(t('builderMap.authError', { defaultValue: 'Session expired — reload the page to restore tile access.' }), {
+                id: 'builder-map-auth-error',
+              });
+            }
           }
           return;
         }
@@ -715,7 +736,7 @@ export const BuilderMap = memo(function BuilderMap({
 
       onMapRef?.(map);
     },
-    [onMapRef, t],
+    [onMapRef, t, recoverTileAuth],
   );
 
   // Helper: refresh the cached list of queryable layer IDs. Called after every
@@ -1257,7 +1278,6 @@ export const BuilderMap = memo(function BuilderMap({
     pitch: initialViewState?.pitch ?? 0,
   }), [initialViewState?.center_lng, initialViewState?.center_lat, initialViewState?.zoom, initialViewState?.bearing, initialViewState?.pitch, mapDefaults?.center_lng, mapDefaults?.center_lat, mapDefaults?.zoom]);
 
-    const invalidateTileTokens = useInvalidateTileTokens();
   const { contextLost, reload } = useWebGLRecovery(mapRef, mapReady, invalidateTileTokens);
 
   return (

--- a/frontend/src/components/dataset/DatasetMap.tsx
+++ b/frontend/src/components/dataset/DatasetMap.tsx
@@ -11,6 +11,7 @@ import { useFeatureEditing, showAllFeaturesInTiles } from '@/components/dataset/
 import { DrawingToolbar } from '@/components/drawing/DrawingToolbar';
 import { AttributeForm } from '@/components/drawing/AttributeForm';
 import { useTileToken, useInvalidateTileTokens } from '@/hooks/use-tile-token';
+import { useTileAuthRecovery } from '@/hooks/use-tile-auth-recovery';
 import { useMapLayers, getSourceLayerName } from '@/components/maps/hooks/use-map-layers';
 import { computeLargeExtentView, isLargeExtent } from '@/lib/map-extent';
 import { findElevationColumn } from '@/lib/geo-utils';
@@ -141,8 +142,13 @@ export const DatasetMap = memo(function DatasetMap({
   const hasBbox = bbox && bbox.length >= 4;
   const mapRef = useRef<MaplibreMap | null>(null);
   const [mapInstance, setMapInstance] = useState<MaplibreMap | null>(null);
-    const invalidateTileTokens = useInvalidateTileTokens();
+  const invalidateTileTokens = useInvalidateTileTokens();
   const { contextLost, reload } = useWebGLRecovery(mapRef, !!mapInstance, invalidateTileTokens);
+  // fix(#621): shared tile-auth recovery — a tile 401/403 kicks one throttled
+  // token re-mint; the refreshed token re-renders the declarative <Source>
+  // with a freshly signed URL.
+  const recoverTileAuth = useTileAuthRecovery(invalidateTileTokens);
+  const tileAuthErrorHandlerRef = useRef<((e: { error?: { status?: number } }) => void) | null>(null);
   // fix(#430 V-13): dataset-detail preview map had no data-tiles-loaded signal at
   // all. Mirror the re-arming ViewerMap/BuilderMap behavior: false while a
   // camera move is in flight, true once idle (no tiles loading / no
@@ -297,6 +303,10 @@ export const DatasetMap = memo(function DatasetMap({
         }
         if (tilesIdleIdleHandlerRef.current) {
           map.off('idle', tilesIdleIdleHandlerRef.current);
+        }
+        // fix(#621): detach the tile-auth recovery handler symmetrically.
+        if (tileAuthErrorHandlerRef.current) {
+          map.off('error', tileAuthErrorHandlerRef.current);
         }
       }
       rasterListenersRef.current = {};
@@ -578,6 +588,17 @@ export const DatasetMap = memo(function DatasetMap({
       map.on('movestart', tilesIdleMovestartHandlerRef.current);
       map.on('idle', tilesIdleIdleHandlerRef.current);
 
+      // fix(#621): the dataset preview previously had NO vector-tile 401/403
+      // handling — the most likely surface in the 7-hour silent-403 incident.
+      // A stale sig kicks one throttled token re-mint, and a conclusively
+      // dead session surfaces through the global signed-out handling (#628)
+      // via the mint request itself.
+      tileAuthErrorHandlerRef.current = (e: { error?: { status?: number } }) => {
+        const s = e.error?.status;
+        if (s === 401 || s === 403) recoverTileAuth();
+      };
+      map.on('error', tileAuthErrorHandlerRef.current);
+
       if (recordType === 'raster_dataset' || recordType === 'vrt_dataset') {
         // Fresh mount: detach any stale listeners and reset the fire-once guards.
         if (rasterListenersRef.current.error) {
@@ -655,7 +676,7 @@ export const DatasetMap = memo(function DatasetMap({
         onMapReady?.();
       }
     },
-    [recordType, addRasterLayers, addVectorLayers, addOverlaySource, onMapReady, onTileError],
+    [recordType, addRasterLayers, addVectorLayers, addOverlaySource, onMapReady, onTileError, recoverTileAuth],
   );
 
   const finishDrawingSession = useCallback(() => {

--- a/frontend/src/components/viewer/ViewerMap.tsx
+++ b/frontend/src/components/viewer/ViewerMap.tsx
@@ -15,6 +15,7 @@ import {
 import { buildClusterTileUrl, buildSignedTileUrl, getMvtSourceLayerName, isMvtSourceLayerConfigReady, resolveTileBaseUrl } from '@/lib/tile-utils';
 import { useWebGLRecovery } from '@/hooks/use-webgl-recovery';
 import { useInvalidateTileTokens } from '@/hooks/use-tile-token';
+import { useTileAuthRecovery } from '@/hooks/use-tile-auth-recovery';
 import { useViewerTokens } from '@/components/viewer/hooks/use-viewer-tokens';
 import { isViewerTerrainExpected, useViewerTerrain } from '@/components/viewer/hooks/use-viewer-terrain';
 import { FeaturePopup, type FeatureInfo } from '@/components/map/FeaturePopup';
@@ -180,7 +181,10 @@ export const ViewerMap = memo(function ViewerMap({
   const layerEntries = useMemo(() => createViewerLayerEntries(layers), [layers]);
 
   // Tile token management (fetch, auto-refresh, error toast)
-  const { tokenMap } = useViewerTokens({ layers, apiKey, embedToken });
+  const { tokenMap, refreshTokens } = useViewerTokens({ layers, apiKey, embedToken });
+  // fix(#621): shared tile-auth recovery — a vector tile 401/403 kicks one
+  // throttled token re-mint; the token-refresh effect below re-signs sources.
+  const recoverTileAuth = useTileAuthRecovery(refreshTokens);
 
   // fix(#452): the bound DEM's LIVE visibility (legend eye toggle). Saved
   // visibility is handled inside the hook (HT-12); this covers the client-side
@@ -454,6 +458,15 @@ export const ViewerMap = memo(function ViewerMap({
           });
           return;
         }
+        // fix(#621): a first-party tile 401/403 means the signed tile URL has
+        // gone stale (expired sig / stranded session). Kick one throttled
+        // token re-mint — the token-refresh effect re-signs the sources when
+        // it lands, and a conclusively dead session surfaces through the
+        // global signed-out handling (#628) via the mint request itself.
+        if ((status === 401 || status === 403) && !isThirdPartyUrl(e.error?.url)) {
+          recoverTileAuth();
+          return;
+        }
         // Suppress expected no-data tiles (404) and other client errors
         if (status && status >= 400 && status < 500) {
           return;
@@ -488,7 +501,7 @@ export const ViewerMap = memo(function ViewerMap({
       setMapReady(true);
       onMapReady?.(map);
     },
-    [onMapReady, embedToken, t],
+    [onMapReady, embedToken, t, recoverTileAuth],
   );
 
   // Stable list of interactive (non-heatmap, visible) layer IDs for query operations

--- a/frontend/src/components/viewer/hooks/use-viewer-tokens.ts
+++ b/frontend/src/components/viewer/hooks/use-viewer-tokens.ts
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { toast } from 'sonner';
 import { getTileTokensBatch } from '@/api/tiles';
@@ -53,6 +53,9 @@ export function useViewerTokens({
   const [tokenMap, setTokenMap] = useState<Map<string, TileToken>>(new Map());
   const [tokenError, setTokenError] = useState(false);
   const refreshTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // fix(#621): latest fetchTokens, so the on-demand refresh below always runs
+  // the current effect generation's fetcher (or nothing after unmount).
+  const fetchRef = useRef<(() => void) | null>(null);
 
   const layerDatasetIds = useMemo(
     () => [...new Set(layers.map((l) => l.dataset_id).filter(Boolean))],
@@ -109,15 +112,23 @@ export function useViewerTokens({
     }
 
     fetchTokens();
+    fetchRef.current = fetchTokens;
 
     return () => {
       cancelled = true;
+      fetchRef.current = null;
       if (refreshTimerRef.current) {
         clearTimeout(refreshTimerRef.current);
         refreshTimerRef.current = null;
       }
     };
   }, [embedToken, apiKey, layerDatasetIds]);
+
+  // fix(#621): on-demand re-mint for the tile 401/403 recovery path. Stable
+  // identity so map error handlers can depend on it without re-registering.
+  const refreshTokens = useCallback(() => {
+    fetchRef.current?.();
+  }, []);
 
   // Surface tile token fetch failures as a user-visible toast
   useEffect(() => {
@@ -128,5 +139,5 @@ export function useViewerTokens({
     }
   }, [tokenError, t]);
 
-  return { tokenMap, tokenError };
+  return { tokenMap, tokenError, refreshTokens };
 }

--- a/frontend/src/hooks/__tests__/use-tile-auth-recovery.test.ts
+++ b/frontend/src/hooks/__tests__/use-tile-auth-recovery.test.ts
@@ -1,0 +1,41 @@
+import { renderHook } from '@testing-library/react';
+import { useTileAuthRecovery } from '@/hooks/use-tile-auth-recovery';
+
+// fix(#621): one re-mint per cooldown window — MapLibre can fire dozens of
+// tile errors per pan, and hammering the mint endpoint cannot help.
+
+describe('useTileAuthRecovery', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('kicks the re-mint on the first error and reports it handled', () => {
+    const remint = vi.fn();
+    const { result } = renderHook(() => useTileAuthRecovery(remint));
+
+    expect(result.current()).toBe(true);
+    expect(remint).toHaveBeenCalledTimes(1);
+  });
+
+  it('suppresses further re-mints inside the cooldown window', () => {
+    const remint = vi.fn();
+    const { result } = renderHook(() => useTileAuthRecovery(remint));
+
+    expect(result.current()).toBe(true);
+    expect(result.current()).toBe(false);
+    expect(result.current()).toBe(false);
+    expect(remint).toHaveBeenCalledTimes(1);
+  });
+
+  it('allows another re-mint once the cooldown has elapsed', () => {
+    const remint = vi.fn();
+    const now = Date.now();
+    const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(now);
+    const { result } = renderHook(() => useTileAuthRecovery(remint));
+
+    expect(result.current()).toBe(true);
+    nowSpy.mockReturnValue(now + 31_000);
+    expect(result.current()).toBe(true);
+    expect(remint).toHaveBeenCalledTimes(2);
+  });
+});

--- a/frontend/src/hooks/use-tile-auth-recovery.ts
+++ b/frontend/src/hooks/use-tile-auth-recovery.ts
@@ -1,0 +1,33 @@
+import { useCallback, useRef } from 'react';
+
+// fix(#621): one re-mint per cooldown window bounds the retry loop — MapLibre
+// can fire dozens of tile errors per pan, and a mint that just failed will not
+// succeed milliseconds later.
+const REMINT_COOLDOWN_MS = 30_000;
+
+/**
+ * fix(#621): shared vector-tile auth recovery for every map surface (builder,
+ * viewer, dataset preview). The builder's GUARD-03 re-sign only reuses the
+ * token already in hand — when the signature itself has expired, the only fix
+ * is a re-mint. Each surface passes its own `remint` (invalidate the
+ * tile-token queries, or the viewer's imperative refetch); the fresh token
+ * then flows through that surface's existing token→setTiles plumbing.
+ *
+ * The mint request rides the shared fetch core, so a conclusively dead
+ * session (401 + refresh-401) triggers the global signed-out handling (#628)
+ * instead of a per-surface toast.
+ *
+ * Returns true when a re-mint was kicked off (recovery in progress — suppress
+ * per-surface error UI); false while in cooldown (a recent re-mint didn't
+ * cure the error — fall through to existing error UI).
+ */
+export function useTileAuthRecovery(remint: () => void) {
+  const lastAttemptRef = useRef(0);
+  return useCallback((): boolean => {
+    const now = Date.now();
+    if (now - lastAttemptRef.current < REMINT_COOLDOWN_MS) return false;
+    lastAttemptRef.current = now;
+    remint();
+    return true;
+  }, [remint]);
+}

--- a/frontend/src/i18n/locales/de/auth.json
+++ b/frontend/src/i18n/locales/de/auth.json
@@ -105,5 +105,11 @@
     "resend": "Bestätigungs-E-Mail erneut senden",
     "resending": "Wird gesendet...",
     "resendSent": "Wenn Ihre E-Mail-Adresse registriert ist und auf Bestätigung wartet, wurde ein neuer Link gesendet."
+  },
+  "sessionExpired": {
+    "title": "Sie wurden abgemeldet",
+    "body": "Ihre Sitzung ist abgelaufen. Melden Sie sich erneut an, um dort weiterzumachen, wo Sie aufgehört haben.",
+    "signIn": "Anmelden",
+    "dismiss": "Verwerfen"
   }
 }

--- a/frontend/src/i18n/locales/en/auth.json
+++ b/frontend/src/i18n/locales/en/auth.json
@@ -105,5 +105,11 @@
     "resend": "Resend verification email",
     "resending": "Sending...",
     "resendSent": "If your email address is registered and awaiting verification, a new link has been sent."
+  },
+  "sessionExpired": {
+    "title": "You've been signed out",
+    "body": "Your session has expired. Sign in again to pick up where you left off.",
+    "signIn": "Sign in",
+    "dismiss": "Dismiss"
   }
 }

--- a/frontend/src/i18n/locales/es/auth.json
+++ b/frontend/src/i18n/locales/es/auth.json
@@ -105,5 +105,11 @@
     "resend": "Reenviar correo de verificación",
     "resending": "Enviando...",
     "resendSent": "Si su dirección de correo electrónico está registrada y pendiente de verificación, se ha enviado un nuevo enlace."
+  },
+  "sessionExpired": {
+    "title": "Se ha cerrado su sesión",
+    "body": "Su sesión ha expirado. Inicie sesión de nuevo para continuar donde lo dejó.",
+    "signIn": "Iniciar sesión",
+    "dismiss": "Descartar"
   }
 }

--- a/frontend/src/i18n/locales/fr/auth.json
+++ b/frontend/src/i18n/locales/fr/auth.json
@@ -105,5 +105,11 @@
     "resend": "Renvoyer l'e-mail de vérification",
     "resending": "Envoi en cours...",
     "resendSent": "Si votre adresse e-mail est enregistrée et en attente de vérification, un nouveau lien a été envoyé."
+  },
+  "sessionExpired": {
+    "title": "Vous avez été déconnecté",
+    "body": "Votre session a expiré. Reconnectez-vous pour reprendre là où vous en étiez.",
+    "signIn": "Se connecter",
+    "dismiss": "Ignorer"
   }
 }


### PR DESCRIPTION
Closes #628; implements the shared re-sign/re-mint slice of #621.

## What

Two composed fixes from the 2026-07-21 demo incident (a stranded session silently 403'd on map tiles for ~7 hours with no recovery and no error UI):

**Shared tile-auth recovery (#621 slice).** New `useTileAuthRecovery` hook: every map surface (builder, viewer, dataset preview) reacts to a first-party vector-tile 401/403 with **one throttled tile-token re-mint** (30s cooldown). The fresh token flows through each surface's existing token→`setTiles` plumbing — builder/viewer token-refresh effects, dataset preview's declarative `<Source>`. Notes:

- The dataset preview (the incident's most likely surface) previously had **no** vector 401/403 handling at all.
- The builder keeps its GUARD-03 cached-token re-sign for the drag-attach race, but no longer dead-ends when the cached sig itself is stale.
- The viewer exposes an on-demand `refreshTokens` from `useViewerTokens` (its token loop is imperative, not TanStack).

**Global session-expiry handling (#628).** The re-mint rides the shared fetch core, which now owns the last-resort UX. In `authenticatedRawFetch`, a 401 whose follow-up refresh is also dead clears the session **once** and notifies a single app-level handler. The latch is keyed on the dead refresh token's value, so N concurrent in-flight failures collapse to one event while the next session (tokens rotate) notifies again. `SessionExpiredDialog` (mounted in the router root) shows one dismissable "You've been signed out" prompt whose sign-in action returns to the current route — same `from` contract as ProtectedRoute/LoginPage, including the sessionStorage key the OAuth callback reads. Anonymous-capable routes (catalog/search, list pages, public viewer) downgrade silently instead: the logout triggers `wireAuthCacheReset`'s cache clear, so active queries refetch anonymously.

## Acceptance criteria (#628)

- [x] Dead session → next API interaction produces exactly one signed-out prompt (latched across concurrent failures; unit-tested with N=5)
- [x] Sign-in from the prompt returns to the same route (router state + sessionStorage for the SSO round-trip)
- [x] Anonymous-capable routes fall back to anonymous data instead of prompting
- [x] Fetch-core unit test: 401 + refresh-401 → store cleared + handler invoked once across N concurrent requests

## Out of scope (stays open on #621)

- The cross-tab refresh-rotation race itself (BroadcastChannel single-flight / server-side reuse grace window)
- Hard-stopping MapLibre's TTL-cadence tile retries against a dead credential (bounded here by the re-mint cooldown, not eliminated)

## Config/API impact

None — frontend-only. New `t()` keys added to all four locales (en/es/fr/de).

## Verification

```
cd frontend && npm run lint && npm run typecheck && npx vitest run && npm run test:i18n
```

All pass locally (338 test files / 3707 tests; 12 new tests across the fetch core, the recovery hook, and the dialog host).