### PR TITLE
chore(community): contributor credits in release notes, issue forms, release SOP gaps

### DIFF
--- a/.github/ISSUE_TEMPLATE/docs_issue.yml
+++ b/.github/ISSUE_TEMPLATE/docs_issue.yml
@@ -1,0 +1,25 @@
+name: Documentation Issue
+description: Report incorrect, unclear, or missing documentation
+labels: ["documentation"]
+body:
+  - type: input
+    id: location
+    attributes:
+      label: Page or file
+      description: URL on docs.getgeolens.com, or a file path in this repository.
+      placeholder: e.g., https://docs.getgeolens.com/... or README.md
+    validations:
+      required: true
+  - type: textarea
+    id: problem
+    attributes:
+      label: What is wrong or missing
+    validations:
+      required: true
+  - type: textarea
+    id: suggestion
+    attributes:
+      label: Suggested fix
+      description: Optional — what the docs should say instead.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/installation_issue.yml
+++ b/.github/ISSUE_TEMPLATE/installation_issue.yml
@@ -1,0 +1,57 @@
+name: Installation / Upgrade Issue
+description: Problems installing, upgrading, or deploying GeoLens
+labels: ["installation"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for the report. Deployment problems are usually environment-specific, so the details below matter — logs especially.
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What went wrong
+      description: What you were doing (fresh install, upgrade, migration) and where it failed.
+    validations:
+      required: true
+  - type: dropdown
+    id: method
+    attributes:
+      label: Deployment method
+      options:
+        - Install script (install.sh)
+        - Docker Compose (manual)
+        - Kubernetes / Helm chart
+        - Other
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: GeoLens version
+      description: The version being installed — and the version you upgraded from, if applicable.
+      placeholder: e.g., v1.4.11 (upgrading from v1.4.9)
+    validations:
+      required: true
+  - type: input
+    id: platform
+    attributes:
+      label: Host platform
+      description: OS, architecture, and container runtime.
+      placeholder: e.g., Ubuntu 24.04, x86_64, Docker 27
+    validations:
+      required: false
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs
+      description: Output of the failing step — for boot failures, `docker compose logs api worker` (or `kubectl logs`). Redact secrets before pasting.
+      render: shell
+    validations:
+      required: true
+  - type: textarea
+    id: config
+    attributes:
+      label: Configuration changes
+      description: Anything changed from the `.env.example` / chart defaults. Never paste secrets.
+    validations:
+      required: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,10 @@ jobs:
               - 'frontend/**'
               - 'backend/openapi.json'
               - 'scripts/flatten_openapi_defs.py'
+              # fix(#636): template-parity.test.ts asserts the in-app problem
+              # reporter's prefill against this Issue Form — a template-only PR
+              # must still run the frontend tests or drift lands silently.
+              - '.github/ISSUE_TEMPLATE/bug_report.yml'
             e2e:
               - 'backend/**'
               - 'frontend/**'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,6 +49,8 @@ jobs:
 
       - name: Generate release notes
         id: notes
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           PREV="${{ steps.prev.outputs.tag }}"
 
@@ -63,6 +65,24 @@ jobs:
 
           # Write to file to preserve newlines
           echo "$NOTES" > release-notes.md
+
+          # Append contributor credits from GitHub's auto-generated notes: the
+          # "New Contributors" section (first-time contributors) and the
+          # "Full Changelog" compare link. The curated CHANGELOG section above
+          # stays the body; a failed generate-notes call must never block the
+          # release, so every step here degrades to appending nothing.
+          GEN=$(gh api "repos/${GITHUB_REPOSITORY}/releases/generate-notes" \
+            -f tag_name="${TAG}" ${PREV:+-f previous_tag_name="${PREV}"} \
+            --jq '.body' || true)
+          NEW_CONTRIBUTORS=$(printf '%s\n' "$GEN" \
+            | awk '/^## New Contributors/{f=1; print; next} /^## /||/^\*\*Full Changelog\*\*/{if(f) exit} f{print}')
+          FULL_CHANGELOG=$(printf '%s\n' "$GEN" | grep '^\*\*Full Changelog\*\*' || true)
+          if [ -n "$NEW_CONTRIBUTORS" ]; then
+            printf '\n%s\n' "$NEW_CONTRIBUTORS" >> release-notes.md
+          fi
+          if [ -n "$FULL_CHANGELOG" ]; then
+            printf '\n%s\n' "$FULL_CHANGELOG" >> release-notes.md
+          fi
 
       - name: Create release
         env:

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -41,8 +41,9 @@ welcome to return.
 ## Release authority
 
 Only maintainers cut release tags and publish official builds. The release
-process is documented internally; published images and packages always originate
-from a maintainer-cut `v*.*.*` tag, never from a contributor branch.
+process is documented in [RELEASE.md](RELEASE.md); published images and packages
+always originate from a maintainer-cut `v*.*.*` tag, never from a contributor
+branch.
 
 ## Deprecation policy
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -31,6 +31,11 @@ A release at version `X.Y.Z` is coherent when all of these agree:
    release tag and writes it to `GEOLENS_VERSION`, so a fresh install pulls the
    `X.Y.Z` images by default.
 8. **Demo build** — the public demo VM is pinned to a released image tag.
+9. **Helm chart** — the community chart in
+   [geolens-deployments](https://github.com/geolens-io/geolens-deployments)
+   defaults its `appVersion` / image tags to `X.Y.Z`. It lives in a sibling
+   repository, so it trails the tag by one manual bump PR rather than being
+   enforced by this repo's CI.
 
 ## Gates that enforce coherence
 
@@ -62,3 +67,33 @@ commit:
 
 The maintainer owns the tag cut and the publish approval. This document does not
 auto-publish or announce anything.
+
+## Release notes and credits
+
+`CHANGELOG.md` is the source of truth for release notes: the release workflow
+extracts the `## [X.Y.Z]` section verbatim as the GitHub Release body. Entries
+are written for operators — what changed and why it matters — not as a PR list.
+
+Credits:
+
+- A change contributed from outside the maintainer team is credited in its
+  CHANGELOG entry: `(thanks @user, #123)`.
+- The release workflow appends GitHub's auto-generated **New Contributors**
+  section and the **Full Changelog** compare link below the curated notes.
+- Security reporters are credited in the release notes of the fix, per the
+  [security policy](.github/SECURITY.md), unless they prefer anonymity.
+
+## Hotfixes and backports
+
+Only the latest release line is patched (see the
+[security policy](.github/SECURITY.md)), and fixes normally ship from `main` as
+the next `X.Y.(Z+1)`. There are no standing release branches. If `main` has
+moved past what should ship — unreleased breaking work on top of the current
+release — and that release needs an urgent fix:
+
+1. Cut `release/X.Y` from the existing `vX.Y.Z` tag.
+2. Cherry-pick the fix commit(s) onto it.
+3. Run the release-prep step there (version bump + CHANGELOG section) and tag
+   `vX.Y.(Z+1)` from that branch — the tag pipeline behaves identically.
+4. Delete the branch after the release. Release branches are on-demand and
+   short-lived, never maintained in parallel.

--- a/frontend/src/lib/report/__tests__/template-parity.test.ts
+++ b/frontend/src/lib/report/__tests__/template-parity.test.ts
@@ -1,0 +1,66 @@
+// Guards the coupling between the in-app "Report a problem" wizard and the
+// GitHub Issue Form it prefills. Issue Forms silently ignore query params that
+// don't exactly match a field id, and dropdowns only prefill on an exact
+// option string — so drift in bug_report.yml degrades the wizard to a
+// partially blank form with no error anywhere. This test makes that drift a
+// CI failure instead.
+
+// @types/node is already a devDependency (vite.config.ts tooling); this
+// reference admits it here so the test can read a file OUTSIDE frontend/ —
+// which vite's fs sandbox denies to ?raw imports.
+/// <reference types="node" />
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { ISSUE_AREAS } from '../build-issue';
+
+// Vitest runs with cwd = frontend/ (import.meta.url is http-scheme under
+// jsdom, so it can't anchor a relative path). An ENOENT here means the
+// template moved — also worth failing on.
+const template = readFileSync(
+  resolve(process.cwd(), '../.github/ISSUE_TEMPLATE/bug_report.yml'),
+  'utf8',
+);
+
+// ponytail: line-based extraction, not a YAML parser — no yaml dep exists in
+// package.json, and the template's shape is stable enough that a shape change
+// failing this test IS the alert we want.
+function extractFieldIds(yml: string): string[] {
+  return [...yml.matchAll(/^\s*id:\s*(\S+)\s*$/gm)].map((m) => m[1]);
+}
+
+function extractAreaOptions(yml: string): string[] {
+  const lines = yml.split('\n');
+  const options: string[] = [];
+  let inArea = false;
+  let inOptions = false;
+  for (const line of lines) {
+    if (/^\s*id:\s*area\s*$/.test(line)) inArea = true;
+    if (inArea && /^\s*options:\s*$/.test(line)) {
+      inOptions = true;
+      continue;
+    }
+    if (inOptions) {
+      const item = line.match(/^\s+-\s+(.+?)\s*$/);
+      if (!item) break; // end of the options list (validations: etc.)
+      options.push(item[1]);
+    }
+  }
+  return options;
+}
+
+describe('bug_report.yml parity with the in-app reporter', () => {
+  it('every query param the wizard prefills matches a form field id', () => {
+    const ids = extractFieldIds(template);
+    expect(ids.length).toBeGreaterThan(0);
+    // Mirrors compose() in build-issue.ts. `title` is absent by design: it is
+    // GitHub's issue-title param, not an Issue Form field.
+    for (const param of ['description', 'steps', 'expected', 'area', 'version', 'context']) {
+      expect(ids).toContain(param);
+    }
+  });
+
+  it('ISSUE_AREAS matches the area dropdown options exactly', () => {
+    expect(extractAreaOptions(template)).toEqual([...ISSUE_AREAS]);
+  });
+});


### PR DESCRIPTION
## Summary

Closes the community-process gaps from a review of the repo's release and contribution surfaces: release notes never credited contributors (though `SECURITY.md` promises credit for security reporters), the two highest-friction issue categories for a self-hosted product had no forms, and `RELEASE.md`/`GOVERNANCE.md` had drifted from practice.

## Changes

- **`release.yml`**: after extracting the curated `CHANGELOG.md` section, append GitHub's auto-generated **New Contributors** section and the **Full Changelog** compare link. A failed `generate-notes` call degrades to appending nothing — it can never block the release.
- **New issue forms**: `installation_issue.yml` (deploy method, version, host platform, logs required up front; labeled `installation` — label created on the repo) and `docs_issue.yml` (labeled `documentation`).
- **`RELEASE.md`**: adds the geolens-deployments Helm chart as release surface 9, a "Release notes and credits" section (curated CHANGELOG body, `(thanks @user, #123)` convention, security-reporter credit), and an on-demand hotfix/backport procedure (cut `release/X.Y` from the tag, cherry-pick, tag, delete — no standing branches).
- **`GOVERNANCE.md`**: release process is public in `RELEASE.md`, not "documented internally".

## Impact

No API/schema/config impact. The workflow change only affects future release bodies; the notes-extraction logic was exercised against three input shapes (with New Contributors, real v1.4.11 output without one, empty API response) — the with-contributors case caught and fixed a Full-Changelog-line duplication in the first draft.

## Verification

- `python3 -c 'yaml.safe_load(...)'` over the workflow + both issue forms
- Extraction harness run against real `generate-notes` output for v1.4.11
- `installation` label verified present on the repo