### PR TITLE
fix(standards): preserve 401 on stale credentials in OGC/STAC read paths

### DIFF
--- a/backend/app/modules/auth/dependencies.py
+++ b/backend/app/modules/auth/dependencies.py
@@ -202,6 +202,27 @@ def request_carries_credentials(request: Request) -> bool:
     )
 
 
+async def get_optional_user_or_401(
+    request: Request,
+    user: Annotated[Identity | None, Depends(get_optional_user)],
+) -> Identity | None:
+    """``get_optional_user``, but supplied-yet-unresolvable credentials get 401.
+
+    fix(#401): the OGC/STAC read handlers resolved a stale/revoked token to the
+    anonymous path, so a credentialed caller's private dataset 404'd instead of
+    401ing and the client's refresh-on-401 retry never fired. Use this on
+    anonymous-capable read endpoints; truly credentialless requests still
+    resolve to ``None`` and keep the public path.
+    """
+    if user is None and request_carries_credentials(request):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Not authenticated",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+    return user
+
+
 async def get_current_user(
     request: Request,
     token: Annotated[str | None, Depends(oauth2_scheme_optional)],

--- a/backend/app/standards/ogc/router.py
+++ b/backend/app/standards/ogc/router.py
@@ -15,7 +15,7 @@ from app.core.geo import extent_to_bbox
 from app.core.identity import Identity
 from app.core.public_urls import get_public_api_url, get_public_app_url
 from app.core.tenancy import is_multi_tenant
-from app.modules.auth.dependencies import get_optional_user
+from app.modules.auth.dependencies import get_optional_user_or_401
 from app.modules.catalog.authorization import apply_visibility_filter, get_user_roles
 from app.modules.catalog.datasets.domain.models import Dataset, DatasetGrant, Record
 from app.modules.catalog.features.schemas import inline_json_schema
@@ -302,7 +302,7 @@ async def get_dataset_collection(
     request: Request,
     dataset_id: uuid.UUID,
     f: str | None = Query(None),
-    user: Identity | None = Depends(get_optional_user),
+    user: Identity | None = Depends(get_optional_user_or_401),
     db: AsyncSession = Depends(get_db),
 ) -> OGCCollectionMetadata:
     """Per-dataset OGC collection metadata with extent, CRS, and items link."""
@@ -473,7 +473,7 @@ async def get_collection_items(
         True,
         description="Include geometry in response. Set to false for attribute-only queries.",
     ),
-    user: Identity | None = Depends(get_optional_user),
+    user: Identity | None = Depends(get_optional_user_or_401),
     db: AsyncSession = Depends(get_db),
 ) -> JSONResponse:
     """OGC API Features items endpoint -- returns GeoJSON FeatureCollection for a dataset.
@@ -729,7 +729,7 @@ async def get_collection_item_feature(
     dataset_id: uuid.UUID,
     feature_id: int,
     f: str | None = Query(None),
-    user: Identity | None = Depends(get_optional_user),
+    user: Identity | None = Depends(get_optional_user_or_401),
     db: AsyncSession = Depends(get_db),
 ) -> JSONResponse:
     """OGC API Features single feature endpoint -- returns a GeoJSON Feature."""

--- a/backend/app/standards/stac/router.py
+++ b/backend/app/standards/stac/router.py
@@ -29,8 +29,8 @@ from app.core.config import settings
 from app.core.identity import Identity
 import app.core.db as _db_module
 from app.modules.auth.dependencies import (
-    get_optional_user,
     get_optional_user_no_security_schema,
+    get_optional_user_or_401,
 )
 from app.modules.catalog.authorization import apply_visibility_filter, get_user_roles
 from app.modules.catalog.datasets.domain.models import (
@@ -797,7 +797,7 @@ async def get_collection_items(
     collection_id: str,
     request: Request,
     db: AsyncSession = Depends(get_db),
-    user: Identity | None = Depends(get_optional_user),
+    user: Identity | None = Depends(get_optional_user_or_401),
     bbox: str | None = Query(None, description="Bounding box: west,south,east,north"),
     datetime_param: str | None = Query(
         None, alias="datetime", description="OGC datetime interval"
@@ -1010,7 +1010,7 @@ async def get_collection_item(
     item_id: uuid.UUID,
     request: Request,
     db: AsyncSession = Depends(get_db),
-    user: Identity | None = Depends(get_optional_user),
+    user: Identity | None = Depends(get_optional_user_or_401),
 ) -> JSONResponse:
     """Get a single STAC Item within a collection."""
     stac_api_url, public_api_url = await _resolve_urls(db, request)
@@ -1055,7 +1055,7 @@ async def get_item(
     item_id: uuid.UUID,
     request: Request,
     db: AsyncSession = Depends(get_db),
-    user: Identity | None = Depends(get_optional_user),
+    user: Identity | None = Depends(get_optional_user_or_401),
 ) -> JSONResponse:
     """Get a single STAC Item by dataset ID."""
     stac_api_url, public_api_url = await _resolve_urls(db, request)
@@ -1423,7 +1423,7 @@ async def _execute_search(
 async def search_get(
     request: Request,
     db: AsyncSession = Depends(get_db),
-    user: Identity | None = Depends(get_optional_user),
+    user: Identity | None = Depends(get_optional_user_or_401),
     bbox: str | None = Query(None, description="Bounding box: west,south,east,north"),
     datetime_param: str | None = Query(
         None, alias="datetime", description="OGC datetime interval"
@@ -1536,7 +1536,7 @@ async def search_post(
     body: StacSearchBody,
     request: Request,
     db: AsyncSession = Depends(get_db),
-    user: Identity | None = Depends(get_optional_user),
+    user: Identity | None = Depends(get_optional_user_or_401),
 ) -> JSONResponse:
     """STAC Item Search (POST with JSON body)."""
     stac_api_url, public_api_url = await _resolve_urls(db, request)

--- a/backend/tests/test_ogc_public_access.py
+++ b/backend/tests/test_ogc_public_access.py
@@ -464,3 +464,39 @@ async def test_externalid_no_auth_public_returns_200(
     assert body["type"] == "FeatureCollection"
     assert body["numberMatched"] == 1
     assert [feature["id"] for feature in body["features"]] == [str(pub.id)]
+
+
+# ---------------------------------------------------------------------------
+# fix(#401): supplied-but-stale credentials must 401, not fall to anon 404
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/collections/{dataset_id}",
+        "/collections/{dataset_id}/items",
+        "/collections/{dataset_id}/items/1",
+    ],
+)
+async def test_ogc_stale_bearer_returns_401_not_404(client: AsyncClient, path: str):
+    """fix(#401): a request that supplied credentials which failed to resolve
+    (expired/revoked JWT) gets 401 — not the anonymous path's 404 — so the
+    client's refresh-on-401 retry fires instead of a private dataset
+    permanently 404ing. Fires before dataset lookup, so no fixture needed."""
+    resp = await client.get(
+        path.format(dataset_id=uuid.uuid4()),
+        headers={"Authorization": "Bearer not-a-valid-token"},
+    )
+    assert resp.status_code == 401
+
+
+@pytest.mark.anyio
+async def test_ogc_invalid_api_key_returns_401(client: AsyncClient):
+    """fix(#401): an unresolvable X-Api-Key is a supplied credential too."""
+    resp = await client.get(
+        f"/collections/{uuid.uuid4()}/items",
+        headers={"X-Api-Key": "not-a-valid-key"},
+    )
+    assert resp.status_code == 401

--- a/backend/tests/test_stac_visibility.py
+++ b/backend/tests/test_stac_visibility.py
@@ -317,3 +317,39 @@ async def test_stac_item_non_owner_cannot_read_private(
     # Non-owner (other editor) cannot read it
     resp = await client.get(f"/stac/items/{priv.id}", headers=other_headers)
     assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# fix(#401): supplied-but-stale credentials must 401, not fall to anon 404
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/stac/collections/rasters/items",
+        "/stac/items/{item_id}",
+        "/stac/search",
+    ],
+)
+async def test_stac_stale_bearer_returns_401_not_404(client: AsyncClient, path: str):
+    """fix(#401): supplied credentials that fail to resolve get 401 — not the
+    anonymous 404 — so a stale-token caller's private raster triggers the
+    client's refresh-on-401 retry instead of permanently 404ing."""
+    resp = await client.get(
+        path.format(item_id=uuid.uuid4()),
+        headers={"Authorization": "Bearer not-a-valid-token"},
+    )
+    assert resp.status_code == 401
+
+
+@pytest.mark.anyio
+async def test_stac_search_post_stale_bearer_returns_401(client: AsyncClient):
+    """fix(#401): POST /stac/search with a stale bearer 401s too."""
+    resp = await client.post(
+        "/stac/search",
+        json={"limit": 1},
+        headers={"Authorization": "Bearer not-a-valid-token"},
+    )
+    assert resp.status_code == 401


### PR DESCRIPTION
Closes the remaining half of #401. (Part 1 — the anonymous-alternative OpenAPI security modeling — already shipped in #506 via `_normalize_security_contract`; 61 ops in the committed snapshot model `security: [{}, ...]`.)

## Problem

A request that *supplied* credentials which failed to resolve (expired/revoked JWT, bad API key) fell through to the anonymous path on the OGC and STAC read handlers. A stale-token caller's private dataset then 404'd permanently — the frontend's refresh-on-401 retry never fired. `features.geojson` got this guard in #400; the OGC/STAC routers had the identical latent issue, and the demand-gate fired with the real stale-token report in #621.

## Change

- New `get_optional_user_or_401` dependency in `auth/dependencies.py`: wraps `get_optional_user`, raises 401 (`WWW-Authenticate: Bearer`) when `request_carries_credentials()` is true but resolution returned `None`. Truly credentialless requests still resolve to `None` and keep the public path.
- Swapped into the 3 OGC + 5 STAC anonymous-capable read handlers (`/collections/{id}`, `/collections/{id}/items`, `/collections/{id}/items/{fid}`; STAC collection items, item×2, search GET/POST).
- The STAC no-schema discovery trio (`get_optional_user_no_security_schema`: landing page, collections, collection) deliberately keeps the lenient public path — those are top-level discovery surfaces for STAC browsers.
- `features.geojson` keeps its inline guard: its 401 check must stay *behind* the embed-token fallback, so the shared dependency can't replace it.

## API/schema impact

None. The wrapper keeps `get_optional_user` in the dependant tree, so `_normalize_security_contract` stamps the same security contract — `make openapi-check` passes with zero snapshot diff, no SDK regen. Behavioral change only: supplied-but-invalid credentials on these 8 read ops now get 401 instead of the anonymous outcome (404 or public-subset 200), per RFC 6750.

## Verification

- `uv run pytest tests/test_ogc_public_access.py tests/test_stac_visibility.py` — 35 passed (9 new: parametrized stale-bearer 401s, invalid `X-Api-Key`, STAC search POST)
- `uv run pytest tests/test_features_geojson_z.py tests/test_layering.py tests/test_ogc_features.py tests/test_stac_api.py` — 86 passed
- `make openapi-check` — clean
- Live smoke on the dev stack (rebuilt `api` container): stale bearer → 401 on OGC items and STAC search; anonymous → 200 unchanged; valid admin token → 200.

Part of #401.

https://claude.ai/code/session_01EJ3PZWCqfT3zCPQDCVuVUk