### PR TITLE
feat(builder): right-click context menus, unified grouping predicate, disabled-item reasons (#585)

### DIFF
--- a/frontend/src/components/builder/BasemapGroupRow.tsx
+++ b/frontend/src/components/builder/BasemapGroupRow.tsx
@@ -13,6 +13,7 @@ import {
   DragGripButton,
   STACK_ROW_GRID,
   rowStateClasses,
+  useKebabContextMenu,
   type DragHandleProps,
 } from '@/components/builder/row-chrome';
 
@@ -51,6 +52,7 @@ export const BasemapGroupRow = memo(function BasemapGroupRow({
   isMultiSelectionActive = false,
 }: BasemapGroupRowProps) {
   const { t } = useTranslation('builder');
+  const kebabMenu = useKebabContextMenu();
 
   // Phase 1051 IN-01: single source for the display name string. Used by
   // aria-label (visibility toggle), aria-label (kebab trigger), and the visible
@@ -84,10 +86,17 @@ export const BasemapGroupRow = memo(function BasemapGroupRow({
         isMultiSelectionActive && 'cursor-not-allowed',
       )}
       onClick={handleRowClick}
+      onContextMenu={(e) => {
+        // Phase 1051 CR-02: the basemap row is non-interactive during
+        // multi-selection — the context menu honors the same boundary.
+        if (isMultiSelectionActive) return;
+        kebabMenu.onContextMenu(e);
+      }}
       onKeyDown={(e) => {
         // Phase 1051 CR-02: mirror handleRowClick — keyboard activation must
         // honor the multi-selection boundary, matching the visual signal.
         if (isMultiSelectionActive) return;
+        if (kebabMenu.handleContextMenuKey(e)) return;
         if (e.key === 'Enter' || e.key === ' ') {
           e.preventDefault();
           onSelectGroup(groupId);
@@ -184,7 +193,7 @@ export const BasemapGroupRow = memo(function BasemapGroupRow({
       {/* Cell 6: Kebab menu — basemap variant with only 2 items */}
       {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events */}
       <div onClick={(e) => e.stopPropagation()}>
-        <DropdownMenu>
+        <DropdownMenu open={kebabMenu.open} onOpenChange={kebabMenu.onOpenChange}>
           <DropdownMenuTrigger asChild>
             <button
               type="button"
@@ -199,6 +208,7 @@ export const BasemapGroupRow = memo(function BasemapGroupRow({
                 'flex items-center justify-center h-[22px] w-[22px] rounded-sm text-muted-foreground',
                 'opacity-0 group-hover/row:opacity-100 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
                 'hover:text-foreground hover:bg-[var(--surface-2)]',
+                'data-[state=open]:opacity-100',
                 selected && 'opacity-100',
               )}
               onClick={(e) => e.stopPropagation()}

--- a/frontend/src/components/builder/BulkActionBar.tsx
+++ b/frontend/src/components/builder/BulkActionBar.tsx
@@ -13,7 +13,7 @@ import {
 } from '@/components/ui/dropdown-menu';
 import { cn } from '@/lib/utils';
 import { isFolderGroupLayer } from '@/lib/layer-capabilities';
-import { getParentGroupId } from '@/components/builder/folder-groups';
+import { canJoinFolderGroup } from '@/components/builder/folder-groups';
 import type { MapLayerResponse } from '@/types/api';
 
 // ---------------------------------------------------------------------------
@@ -89,16 +89,12 @@ export const BulkActionBar = memo(function BulkActionBar({
   const visibleCount = selectedLayers.filter((l) => l.visible !== false).length;
   const majorityVisible = visibleCount > N / 2;
 
-  // Group enabled: ALL selected are loose vector layers (not in a group, not a group row, not raster/DEM/basemap)
+  // Group enabled: ALL selected are loose layers (not in a group, not a group
+  // row). fix(#585): the extra vector_dataset requirement disagreed with
+  // StackRow's "Add to group…" and with drag-and-drop membership, both of
+  // which accept raster/DEM rows — canJoinFolderGroup is the shared predicate.
   const canGroup = useMemo(
-    () =>
-      N > 0 &&
-      selectedLayers.every(
-        (l) =>
-          !getParentGroupId(l) &&
-          !isFolderGroupLayer(l) &&
-          l.dataset_record_type === 'vector_dataset',
-      ),
+    () => N > 0 && selectedLayers.every(canJoinFolderGroup),
     [selectedLayers, N],
   );
 
@@ -339,7 +335,16 @@ export const BulkActionBar = memo(function BulkActionBar({
                   }}
                 >
                   <Paintbrush className="h-3.5 w-3.5 me-2" aria-hidden="true" />
-                  {t('bulkActions.applyStyle')}
+                  {/* fix(#585): disabled items state their reason inline
+                      (tooltips don't fire on disabled elements). */}
+                  <span className="flex flex-col items-start">
+                    {t('bulkActions.applyStyle')}
+                    {N < 2 && (
+                      <span className="text-2xs text-muted-foreground">
+                        {t('bulkActions.applyStyleHint', { defaultValue: 'Select at least 2 layers' })}
+                      </span>
+                    )}
+                  </span>
                 </DropdownMenuItem>
               )}
               <DropdownMenuItem
@@ -351,7 +356,14 @@ export const BulkActionBar = memo(function BulkActionBar({
                 }}
               >
                 <FolderPlus className="h-3.5 w-3.5 me-2" aria-hidden="true" />
-                {t('bulkActions.group')}
+                <span className="flex flex-col items-start">
+                  {t('bulkActions.group')}
+                  {!canGroup && (
+                    <span className="text-2xs text-muted-foreground">
+                      {t('bulkActions.groupHint', { defaultValue: 'Only ungrouped layers can be grouped' })}
+                    </span>
+                  )}
+                </span>
               </DropdownMenuItem>
               <DropdownMenuItem
                 data-testid="bulk-action-ungroup"
@@ -362,7 +374,14 @@ export const BulkActionBar = memo(function BulkActionBar({
                 }}
               >
                 <FolderMinus className="h-3.5 w-3.5 me-2" aria-hidden="true" />
-                {t('bulkActions.ungroup')}
+                <span className="flex flex-col items-start">
+                  {t('bulkActions.ungroup')}
+                  {!canUngroup && (
+                    <span className="text-2xs text-muted-foreground">
+                      {t('bulkActions.ungroupHint', { defaultValue: 'Select only group rows to ungroup' })}
+                    </span>
+                  )}
+                </span>
               </DropdownMenuItem>
               <DropdownMenuSeparator />
               <DropdownMenuItem

--- a/frontend/src/components/builder/FolderGroupRow.tsx
+++ b/frontend/src/components/builder/FolderGroupRow.tsx
@@ -16,6 +16,7 @@ import {
   DragGripButton,
   STACK_ROW_GRID,
   rowStateClasses,
+  useKebabContextMenu,
   type DragHandleProps,
 } from '@/components/builder/row-chrome';
 import { useInlineRename } from '@/components/builder/useInlineRename';
@@ -66,6 +67,7 @@ export const FolderGroupRow = memo(function FolderGroupRow({
 }: FolderGroupRowProps) {
   const { t } = useTranslation('builder');
   const [confirmingDelete, setConfirmingDelete] = useState(false);
+  const kebabMenu = useKebabContextMenu();
 
   // builder-audit #338 STACK-03: shared inline-rename state machine (was duplicated
   // verbatim with StackRow, including the BUG-03 focus-race gating). Empty input
@@ -115,7 +117,9 @@ export const FolderGroupRow = memo(function FolderGroupRow({
       tabIndex={0}
       className="focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset"
       onClick={handleRowClick}
+      onContextMenu={kebabMenu.onContextMenu}
       onKeyDown={(e) => {
+        if (kebabMenu.handleContextMenuKey(e)) return;
         if (e.key === 'Enter') {
           e.preventDefault();
           onSelectGroup(groupId);
@@ -241,7 +245,7 @@ export const FolderGroupRow = memo(function FolderGroupRow({
         {/* Cell 6: Kebab menu */}
         {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events */}
         <div onClick={(e) => e.stopPropagation()}>
-          <DropdownMenu>
+          <DropdownMenu open={kebabMenu.open} onOpenChange={kebabMenu.onOpenChange}>
             <DropdownMenuTrigger asChild>
               <button
                 type="button"
@@ -256,6 +260,7 @@ export const FolderGroupRow = memo(function FolderGroupRow({
                   'flex items-center justify-center h-[22px] w-[22px] rounded-sm text-muted-foreground',
                   'opacity-0 group-hover/row:opacity-100 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
                   'hover:text-foreground hover:bg-[var(--surface-2)]',
+                  'data-[state=open]:opacity-100',
                   selected && 'opacity-100',
                 )}
                 onClick={(e) => e.stopPropagation()}

--- a/frontend/src/components/builder/StackRow.tsx
+++ b/frontend/src/components/builder/StackRow.tsx
@@ -20,6 +20,7 @@ import {
   DragGripButton,
   STACK_ROW_GRID,
   rowStateClasses,
+  useKebabContextMenu,
   type DragHandleProps,
 } from '@/components/builder/row-chrome';
 import { useInlineRename } from '@/components/builder/useInlineRename';
@@ -121,6 +122,7 @@ export const StackRow = memo(function StackRow({
   const { t } = useTranslation('builder');
   const [confirmingDelete, setConfirmingDelete] = useState(false);
   const [keyboardReorderActive, setKeyboardReorderActive] = useState(false);
+  const kebabMenu = useKebabContextMenu();
 
   const displayName = layer.display_name ?? layer.dataset_name;
 
@@ -206,7 +208,9 @@ export const StackRow = memo(function StackRow({
         isFresh && 'animate-in fade-in duration-[--motion-fast]',
       )}
       onClick={handleRowClick}
+      onContextMenu={kebabMenu.onContextMenu}
       onKeyDown={(e) => {
+        if (kebabMenu.handleContextMenuKey(e)) return;
         if (e.key === 'Enter') {
           e.preventDefault();
           onSelectLayer(layer.id);
@@ -365,7 +369,7 @@ export const StackRow = memo(function StackRow({
       {/* Cell 6: Kebab menu — stopPropagation prevents row click when opening menu */}
       {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events */}
       <div onClick={(e) => e.stopPropagation()}>
-        <DropdownMenu>
+        <DropdownMenu open={kebabMenu.open} onOpenChange={kebabMenu.onOpenChange}>
           <DropdownMenuTrigger asChild>
             <button
               type="button"
@@ -380,6 +384,7 @@ export const StackRow = memo(function StackRow({
                 'flex items-center justify-center h-[22px] w-[22px] rounded-sm text-muted-foreground',
                 'opacity-0 group-hover/row:opacity-100 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
                 'hover:text-foreground hover:bg-[var(--surface-2)]',
+                'data-[state=open]:opacity-100',
                 selected && 'opacity-100',
               )}
               onClick={(e) => e.stopPropagation()}
@@ -496,7 +501,16 @@ export const StackRow = memo(function StackRow({
               }}
             >
               <ClipboardPaste className="h-3.5 w-3.5 me-2" aria-hidden="true" />
-              {t('stackRow.kebabPasteStyle', { defaultValue: 'Paste style' })}
+              {/* fix(#585): disabled items state their reason inline (tooltips
+                  don't fire on disabled elements). */}
+              <span className="flex flex-col items-start">
+                {t('stackRow.kebabPasteStyle', { defaultValue: 'Paste style' })}
+                {!canPasteStyle && (
+                  <span className="text-2xs text-muted-foreground">
+                    {t('stackRow.kebabPasteStyleHint', { defaultValue: 'Copy a style from a matching layer first' })}
+                  </span>
+                )}
+              </span>
             </DropdownMenuItem>
             <DropdownMenuSeparator />
             <DropdownMenuItem

--- a/frontend/src/components/builder/__tests__/BulkActionBar.test.tsx
+++ b/frontend/src/components/builder/__tests__/BulkActionBar.test.tsx
@@ -196,13 +196,15 @@ describe('BulkActionBar — disable rules (POL-08)', () => {
     );
 
     // canGroup=false because layerInGroup has parent_group_id. The disabled
-    // Group menuitem renders with aria-disabled="true".
+    // Group menuitem renders with aria-disabled="true" plus an inline reason
+    // hint (fix(#585)).
     fireEvent.pointerDown(screen.getByTestId('bulk-action-overflow'), { button: 0, ctrlKey: false });
     const groupItem = screen.getByTestId('bulk-action-group');
     expect(groupItem.getAttribute('aria-disabled')).toBe('true');
+    expect(groupItem.textContent).toContain('Only ungrouped layers can be grouped');
   });
 
-  it('Test 6: Group menuitem is disabled when raster layer is in selection', () => {
+  it('Test 6: Group menuitem is enabled when a loose raster layer is in selection (fix(#585))', () => {
     render(
       <BulkActionBar
         {...makeProps({
@@ -212,10 +214,12 @@ describe('BulkActionBar — disable rules (POL-08)', () => {
       />
     );
 
-    // canGroup=false: r1 is raster_dataset
+    // fix(#585): canGroup no longer requires vector_dataset — StackRow's
+    // "Add to group…" and drag-and-drop membership both accept raster rows,
+    // so the bulk predicate matches (canJoinFolderGroup).
     fireEvent.pointerDown(screen.getByTestId('bulk-action-overflow'), { button: 0, ctrlKey: false });
     const groupItem = screen.getByTestId('bulk-action-group');
-    expect(groupItem.getAttribute('aria-disabled')).toBe('true');
+    expect(groupItem.getAttribute('aria-disabled')).toBeNull();
   });
 
   it('Test 7: Ungroup menuitem is disabled when mix of group + loose is selected', () => {

--- a/frontend/src/components/builder/__tests__/StackRow.test.tsx
+++ b/frontend/src/components/builder/__tests__/StackRow.test.tsx
@@ -229,6 +229,27 @@ describe('StackRow', () => {
     expect(dupIdx).toBeLessThan(deleteIdx);
   });
 
+  // fix(#585): right-click / Shift+F10 open the same kebab menu.
+  it('right-clicking the row opens the kebab menu without selecting the row', () => {
+    const onSelectLayer = vi.fn();
+    const layer = makeLayer({ id: 'ctx-layer' });
+    render(<StackRow {...defaultProps({ layer, onSelectLayer })} />);
+
+    fireEvent.contextMenu(document.getElementById('stack-row-ctx-layer')!);
+
+    expect(onSelectLayer).not.toHaveBeenCalled();
+    expect(screen.getByRole('menuitem', { name: /Rename layer/i })).toBeInTheDocument();
+  });
+
+  it('Shift+F10 on the row opens the kebab menu', () => {
+    const layer = makeLayer({ id: 'kbd-ctx-layer' });
+    render(<StackRow {...defaultProps({ layer })} />);
+
+    fireEvent.keyDown(document.getElementById('stack-row-kbd-ctx-layer')!, { key: 'F10', shiftKey: true });
+
+    expect(screen.getByRole('menuitem', { name: /Rename layer/i })).toBeInTheDocument();
+  });
+
   it('clicking "Delete layer" in the kebab calls onRemove(layer.id)', () => {
     const onRemove = vi.fn();
     const layer = makeLayer({ id: 'delete-layer' });

--- a/frontend/src/components/builder/folder-groups.ts
+++ b/frontend/src/components/builder/folder-groups.ts
@@ -66,6 +66,14 @@ export function getParentGroupId(layer: MapLayerResponse): string | null {
   return (layer as GroupedLayer).parent_group_id ?? null;
 }
 
+// fix(#585): the single grouping predicate. StackRow's "Add to group…" menu and
+// BulkActionBar's Group action previously disagreed (the bar also required
+// vector_dataset), but drag-and-drop membership (resolveDropGroupMembership)
+// has never checked record type — any non-group row can live in a group.
+export function canJoinFolderGroup(layer: MapLayerResponse): boolean {
+  return !isFolderGroupLayer(layer) && !getParentGroupId(layer);
+}
+
 // fix(#525 B-040): membership rule for intra-stack drops. childrenByGroup
 // renders by parent_group_id, not array position, so a drag that changes
 // position without updating membership silently snaps back on render.

--- a/frontend/src/components/builder/hooks/__tests__/use-builder-layers.bulk-ops.test.ts
+++ b/frontend/src/components/builder/hooks/__tests__/use-builder-layers.bulk-ops.test.ts
@@ -530,26 +530,26 @@ describe('useBuilderLayers — handleBulkGroup (POL-09)', () => {
     expect(result.current.localLayers.length).toBe(before);
   });
 
-  // fix(#392): mixed selection with a raster layer must toast the
-  // TYPE-specific reason, not the generic (and factually wrong, for this
-  // case) "already grouped" message. (audit WR-01)
-  it('Test 11: mixed selection including a raster layer returns false, toasts bulkGroupSkippedType, does not mutate localLayers', async () => {
-    const infoSpy = vi.spyOn(toast, 'info');
+  // fix(#585): mixed vector + raster selection groups successfully — the
+  // vector-only restriction disagreed with StackRow's "Add to group…" and
+  // drag-and-drop membership, which have always accepted raster/DEM rows.
+  it('Test 11: mixed selection including a raster layer creates a group containing both', async () => {
     const layerA = makeMockLayer({ id: 'a', sort_order: 0, dataset_record_type: 'vector_dataset' });
     const layerR = makeMockLayer({ id: 'r', sort_order: 1, dataset_record_type: 'raster_dataset', layer_type: 'raster_geolens' });
     const { result } = renderBuilderLayers(makeMapData([layerA, layerR]));
     await waitForInit();
-
-    const before = result.current.localLayers.length;
 
     let created: boolean | undefined;
     act(() => {
       created = result.current.handleBulkGroup(new Set(['a', 'r']));
     });
 
-    expect(created).toBe(false);
-    expect(infoSpy).toHaveBeenCalledWith("Non-vector layers can't be grouped — remove them from your selection and try again");
-    expect(result.current.localLayers.length).toBe(before);
+    expect(created).toBe(true);
+    const updated = result.current.localLayers as GroupedLayer[];
+    const groupRow = updated.find((l) => l.layer_type === 'group:folder');
+    expect(groupRow).toBeDefined();
+    expect(updated.find((l) => l.id === 'a')?.parent_group_id).toBe(groupRow!.id);
+    expect(updated.find((l) => l.id === 'r')?.parent_group_id).toBe(groupRow!.id);
   });
 
   // fix(#392): a group row in the selection must toast the

--- a/frontend/src/components/builder/hooks/use-bulk-layer-actions.ts
+++ b/frontend/src/components/builder/hooks/use-bulk-layer-actions.ts
@@ -191,10 +191,11 @@ export function useBulkLayerActions({
   const handleBulkGroup = useCallback((selectedIds: Set<string>): boolean => {
     const current = layersRef.current;
     const selectedLayers = current.filter((l) => selectedIds.has(l.id));
-    // Defense-in-depth: all selected must be loose vector layers (not already
-    // grouped, not group rows themselves, not raster/DEM/basemap).
+    // Defense-in-depth: all selected must be loose layers (not already
+    // grouped, not group rows themselves). fix(#585): the extra
+    // vector_dataset requirement disagreed with StackRow's "Add to group…"
+    // and drag-and-drop membership, both of which accept raster/DEM rows.
     const groupableLayers = selectedLayers.filter((l) =>
-      l.dataset_record_type === 'vector_dataset' &&
       !(l as GroupedLayer).parent_group_id &&
       (l as GroupedLayer).layer_type !== 'group:folder',
     );
@@ -202,22 +203,14 @@ export function useBulkLayerActions({
     // fix(#392): surface WHY the group action no-op'd instead
     // of returning silently while the caller clears the selection anyway. (audit B-004d/LM-04)
     if (groupableLayers.length !== selectedLayers.length) {
-      // fix(#392): the toast previously always said "already grouped,"
-      // which is wrong when the real disqualifier is a raster/DEM layer or a
-      // group row in the selection. Pick the message that matches the actual
-      // reason. Priority: a group row in the selection is the most distinct
-      // mistake, then an ineligible (non-vector) layer type, and only then
-      // fall back to the "already grouped" message. (audit WR-01)
+      // fix(#392): pick the message that matches the actual reason — a group
+      // row in the selection is the most distinct mistake, otherwise
+      // "already grouped". (audit WR-01)
       const hasGroupRow = selectedLayers.some(
         (l) => (l as GroupedLayer).layer_type === 'group:folder',
       );
-      const hasIneligibleType = selectedLayers.some(
-        (l) => l.dataset_record_type !== 'vector_dataset',
-      );
       if (hasGroupRow) {
         toast.info(t('toasts.bulkGroupSkippedGroupRow'));
-      } else if (hasIneligibleType) {
-        toast.info(t('toasts.bulkGroupSkippedType'));
       } else {
         toast.info(t('toasts.bulkGroupSkipped'));
       }

--- a/frontend/src/components/builder/row-chrome.tsx
+++ b/frontend/src/components/builder/row-chrome.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import type { FocusEvent, KeyboardEvent, MouseEvent } from 'react';
 import { GripVertical } from 'lucide-react';
 import type { DraggableAttributes, DraggableSyntheticListeners } from '@dnd-kit/core';
@@ -8,6 +9,31 @@ import { cn } from '@/lib/utils';
 // column-width change happens in a single place. SublayerRow keeps its own
 // 7-column variant (it carries an extra indicator/opacity cell).
 export const STACK_ROW_GRID = 'grid-cols-[16px_14px_22px_22px_1fr_22px]';
+
+// fix(#585): right-click (and Shift+F10 / ContextMenu key) on a stack row opens
+// its existing kebab menu, so row actions are reachable without discovering the
+// hover-revealed kebab. Shared by StackRow, FolderGroupRow, and BasemapGroupRow:
+// spread the returned `open`/`onOpenChange` onto the row's <DropdownMenu>, wire
+// `onContextMenu` on the row container, and call `handleContextMenuKey` from the
+// row's onKeyDown (returns true when it consumed the event).
+export function useKebabContextMenu() {
+  const [open, setOpen] = useState(false);
+  function onContextMenu(e: MouseEvent) {
+    e.preventDefault();
+    e.stopPropagation();
+    setOpen(true);
+  }
+  function handleContextMenuKey(e: KeyboardEvent): boolean {
+    if (e.key === 'ContextMenu' || (e.shiftKey && e.key === 'F10')) {
+      e.preventDefault();
+      e.stopPropagation();
+      setOpen(true);
+      return true;
+    }
+    return false;
+  }
+  return { open, onOpenChange: setOpen, onContextMenu, handleContextMenuKey };
+}
 
 export interface DragHandleProps {
   attributes: DraggableAttributes;

--- a/frontend/src/i18n/locales/de/builder.json
+++ b/frontend/src/i18n/locales/de/builder.json
@@ -885,7 +885,6 @@
     "bulkStyleSkipped": "{{count}} Ebenen übersprungen (inkompatible Geometrie)",
     "bulkGroupNeedTwo": "Wähle mindestens 2 lose Ebenen aus, um sie zu gruppieren",
     "bulkGroupSkipped": "Einige ausgewählte Ebenen sind bereits gruppiert und können nicht erneut gruppiert werden",
-    "bulkGroupSkippedType": "Nicht-Vektor-Ebenen können nicht gruppiert werden – entferne sie aus deiner Auswahl und versuche es erneut",
     "bulkGroupSkippedGroupRow": "Gruppen können nicht gruppiert werden – entferne Gruppenzeilen aus deiner Auswahl und versuche es erneut"
   },
   "builderMap": {
@@ -1079,9 +1078,11 @@
     "opacityAriaLabel": "Deckkraft für {{count}} ausgewählte Layer festlegen",
     "group": "Gruppieren",
     "groupAriaLabel": "{{count}} ausgewählte Layer gruppieren",
+    "groupHint": "Nur nicht gruppierte Ebenen können gruppiert werden",
     "groupDisabledTooltip": "Nur einzelne Layer zum Gruppieren auswählen",
     "ungroup": "Gruppierung aufheben",
     "ungroupAriaLabel": "Gruppierung von {{count}} ausgewählten Gruppen aufheben",
+    "ungroupHint": "Wähle zum Aufheben der Gruppierung nur Gruppenzeilen aus",
     "ungroupDisabledTooltip": "Nur Gruppen zum Aufheben der Gruppierung auswählen",
     "delete": "Löschen",
     "deleteAriaLabel": "{{count}} ausgewählte Layer löschen",
@@ -1100,7 +1101,8 @@
     "moreActions": "Weitere Aktionen",
     "moreActionsAriaLabel": "Weitere Aktionen für {{count}} ausgewählte Layer",
     "applyStyle": "Stil auf Auswahl anwenden",
-    "applyStyleAriaLabel": "Stil auf {{count}} ausgewählte Ebenen anwenden"
+    "applyStyleAriaLabel": "Stil auf {{count}} ausgewählte Ebenen anwenden",
+    "applyStyleHint": "Wähle mindestens 2 Ebenen aus"
   },
   "unifiedStack": {
     "title": "Layer",
@@ -1164,6 +1166,7 @@
     "kebabZoomToLayer": "Auf Ebene zoomen",
     "kebabCopyStyle": "Stil kopieren",
     "kebabPasteStyle": "Stil einfügen",
+    "kebabPasteStyleHint": "Kopiere zuerst einen Stil von einer passenden Ebene",
     "disambiguation": "{{label}}",
     "audienceHidden": "Für die Betrachter dieser Karte ausgeblendet",
     "drawsNothing": "Nicht sichtbar — Schummerung oder 3D-Terrain aktivieren"

--- a/frontend/src/i18n/locales/en/builder.json
+++ b/frontend/src/i18n/locales/en/builder.json
@@ -885,7 +885,6 @@
     "bulkStyleSkipped": "{{count}} layers skipped (incompatible geometry)",
     "bulkGroupNeedTwo": "Select at least 2 loose layers to group",
     "bulkGroupSkipped": "Some selected layers are already grouped and can't be grouped again",
-    "bulkGroupSkippedType": "Non-vector layers can't be grouped — remove them from your selection and try again",
     "bulkGroupSkippedGroupRow": "Groups can't be grouped — remove any group rows from your selection and try again"
   },
   "builderMap": {
@@ -1083,9 +1082,11 @@
     "opacityAriaLabel": "Set opacity for {{count}} selected layers",
     "group": "Group",
     "groupAriaLabel": "Group {{count}} selected layers",
+    "groupHint": "Only ungrouped layers can be grouped",
     "groupDisabledTooltip": "Select only loose layers to group",
     "ungroup": "Ungroup",
     "ungroupAriaLabel": "Ungroup {{count}} selected groups",
+    "ungroupHint": "Select only group rows to ungroup",
     "ungroupDisabledTooltip": "Select only groups to ungroup",
     "delete": "Delete",
     "deleteAriaLabel": "Delete {{count}} selected layers",
@@ -1104,7 +1105,8 @@
     "moreActions": "More actions",
     "moreActionsAriaLabel": "More actions for {{count}} selected layers",
     "applyStyle": "Apply style to selection",
-    "applyStyleAriaLabel": "Apply style to {{count}} selected layers"
+    "applyStyleAriaLabel": "Apply style to {{count}} selected layers",
+    "applyStyleHint": "Select at least 2 layers"
   },
   "unifiedStack": {
     "title": "Layers",
@@ -1168,6 +1170,7 @@
     "kebabZoomToLayer": "Zoom to layer",
     "kebabCopyStyle": "Copy style",
     "kebabPasteStyle": "Paste style",
+    "kebabPasteStyleHint": "Copy a style from a matching layer first",
     "disambiguation": "{{label}}",
     "audienceHidden": "Hidden from this map's viewers",
     "drawsNothing": "Not shown — enable Hillshade or 3D terrain"

--- a/frontend/src/i18n/locales/es/builder.json
+++ b/frontend/src/i18n/locales/es/builder.json
@@ -885,7 +885,6 @@
     "bulkStyleSkipped": "{{count}} capas omitidas (geometría incompatible)",
     "bulkGroupNeedTwo": "Selecciona al menos 2 capas sueltas para agrupar",
     "bulkGroupSkipped": "Algunas capas seleccionadas ya están agrupadas y no se pueden agrupar de nuevo",
-    "bulkGroupSkippedType": "Las capas no vectoriales no se pueden agrupar; quítalas de tu selección e inténtalo de nuevo",
     "bulkGroupSkippedGroupRow": "Los grupos no se pueden agrupar; quita las filas de grupo de tu selección e inténtalo de nuevo"
   },
   "builderMap": {
@@ -1079,9 +1078,11 @@
     "opacityAriaLabel": "Establecer opacidad para {{count}} capas seleccionadas",
     "group": "Agrupar",
     "groupAriaLabel": "Agrupar {{count}} capas seleccionadas",
+    "groupHint": "Solo se pueden agrupar capas sin agrupar",
     "groupDisabledTooltip": "Seleccione solo capas sueltas para agrupar",
     "ungroup": "Desagrupar",
     "ungroupAriaLabel": "Desagrupar {{count}} grupos seleccionados",
+    "ungroupHint": "Selecciona solo filas de grupo para desagrupar",
     "ungroupDisabledTooltip": "Seleccione solo grupos para desagrupar",
     "delete": "Eliminar",
     "deleteAriaLabel": "Eliminar {{count}} capas seleccionadas",
@@ -1100,7 +1101,8 @@
     "moreActions": "Más acciones",
     "moreActionsAriaLabel": "Más acciones para {{count}} capas seleccionadas",
     "applyStyle": "Aplicar estilo a la selección",
-    "applyStyleAriaLabel": "Aplicar estilo a {{count}} capas seleccionadas"
+    "applyStyleAriaLabel": "Aplicar estilo a {{count}} capas seleccionadas",
+    "applyStyleHint": "Selecciona al menos 2 capas"
   },
   "unifiedStack": {
     "title": "Capas",
@@ -1164,6 +1166,7 @@
     "kebabZoomToLayer": "Acercar a la capa",
     "kebabCopyStyle": "Copiar estilo",
     "kebabPasteStyle": "Pegar estilo",
+    "kebabPasteStyleHint": "Copia primero un estilo de una capa compatible",
     "disambiguation": "{{label}}",
     "audienceHidden": "Oculto para los visitantes de este mapa",
     "drawsNothing": "No se muestra — activa el sombreado o el terreno 3D"

--- a/frontend/src/i18n/locales/fr/builder.json
+++ b/frontend/src/i18n/locales/fr/builder.json
@@ -885,7 +885,6 @@
     "bulkStyleSkipped": "{{count}} couches ignorées (géométrie incompatible)",
     "bulkGroupNeedTwo": "Sélectionnez au moins 2 couches libres pour les regrouper",
     "bulkGroupSkipped": "Certaines couches sélectionnées sont déjà groupées et ne peuvent pas être regroupées à nouveau",
-    "bulkGroupSkippedType": "Les couches non vectorielles ne peuvent pas être regroupées ; retirez-les de votre sélection et réessayez",
     "bulkGroupSkippedGroupRow": "Les groupes ne peuvent pas être regroupés ; retirez les lignes de groupe de votre sélection et réessayez"
   },
   "builderMap": {
@@ -1079,9 +1078,11 @@
     "opacityAriaLabel": "Définir l'opacité de {{count}} couches sélectionnées",
     "group": "Grouper",
     "groupAriaLabel": "Grouper {{count}} couches sélectionnées",
+    "groupHint": "Seules les couches non groupées peuvent être groupées",
     "groupDisabledTooltip": "Sélectionnez uniquement des couches libres pour grouper",
     "ungroup": "Dégrouper",
     "ungroupAriaLabel": "Dégrouper {{count}} groupes sélectionnés",
+    "ungroupHint": "Sélectionnez uniquement des lignes de groupe pour dégrouper",
     "ungroupDisabledTooltip": "Sélectionnez uniquement des groupes pour dégrouper",
     "delete": "Supprimer",
     "deleteAriaLabel": "Supprimer {{count}} couches sélectionnées",
@@ -1100,7 +1101,8 @@
     "moreActions": "Plus d'actions",
     "moreActionsAriaLabel": "Plus d'actions pour {{count}} couches sélectionnées",
     "applyStyle": "Appliquer le style à la sélection",
-    "applyStyleAriaLabel": "Appliquer le style à {{count}} couches sélectionnées"
+    "applyStyleAriaLabel": "Appliquer le style à {{count}} couches sélectionnées",
+    "applyStyleHint": "Sélectionnez au moins 2 couches"
   },
   "unifiedStack": {
     "title": "Couches",
@@ -1164,6 +1166,7 @@
     "kebabZoomToLayer": "Zoomer sur la couche",
     "kebabCopyStyle": "Copier le style",
     "kebabPasteStyle": "Coller le style",
+    "kebabPasteStyleHint": "Copiez d'abord un style depuis une couche compatible",
     "disambiguation": "{{label}}",
     "audienceHidden": "Masqué pour les visiteurs de cette carte",
     "drawsNothing": "Non affiché — activez l'ombrage ou le terrain 3D"


### PR DESCRIPTION
First slice of #585 (findings 1–3, the issue's suggested first slice).

## What changed

**1. Right-click context menu on stack rows** (finding 1)
`useKebabContextMenu` in `row-chrome.tsx` makes each row's existing kebab `DropdownMenu` controlled: right-click, Shift+F10, or the ContextMenu key on a `StackRow`, `FolderGroupRow`, or `BasemapGroupRow` opens it. The basemap row honors the existing multi-selection boundary (Phase 1051 CR-02). The kebab trigger gains `data-[state=open]:opacity-100` so the anchor is visible while the menu is open.

**2. Unified grouping predicate** (finding 2)
`canJoinFolderGroup` in `folder-groups.ts` is now the single rule: not a group row, not already in a group. The `dataset_record_type === 'vector_dataset'` requirement existed in **two** places — `BulkActionBar.canGroup` and the defense-in-depth filter in `use-bulk-layer-actions.ts` `handleBulkGroup` (the issue only caught the first) — and disagreed with StackRow's "Add to group…" and drag-and-drop membership (`resolveDropGroupMembership`), which have always accepted raster/DEM rows with no record-type guard. The now-unreachable `toasts.bulkGroupSkippedType` key is removed from all four locales.

**3. Inline reasons on disabled menu items** (finding 3)
Bulk Group / Ungroup / Apply-style and StackRow Paste-style show a muted one-line reason under the label when disabled. Inline text instead of the issue's suggested tooltips because tooltips don't fire on disabled elements.

4 new i18n keys added to all four locales (en/es/fr/de).

## Verification

- `npx vitest run` — 339 files / 3713 tests pass (incl. new right-click + Shift+F10 StackRow tests; flipped `BulkActionBar` Test 6 and bulk-ops Test 11 from "raster blocks grouping" to "raster groups successfully")
- `npm run typecheck`, `npm run lint`, `npm run test:i18n`, `npm run build` — clean
- Live smoke on the dev stack ("Restless Earth"): right-click opens the menu on layer/group/basemap rows; disabled Paste-style and Ungroup show their reasons; bulk-grouped a vector heatmap + the ETOPO raster, saved, reloaded — the group with the raster persists (confirming the record-type restriction was the outlier, not a backend constraint); ungrouped and re-saved to restore the map.

## Not in this slice (remaining #585 findings)

Ragged kebab icons (4), `DropdownMenuSub` for the group list (5), basemap Reset-appearance dirty-check (6), unified delete-confirm pattern (7), duplicate-map spinner (8).

Closes nothing — #585 stays open for the remaining findings.

https://claude.ai/code/session_01EJ3PZWCqfT3zCPQDCVuVUk