### PR TITLE
feat(observability): per-worker RSS gauge + log watermark (#643)

### DIFF
--- a/backend/app/api/main.py
+++ b/backend/app/api/main.py
@@ -314,9 +314,13 @@ async def lifespan(app: FastAPI):
     await init_tile_pool()
     await task_app.open_async()
 
+    from app.observability.metrics.memory import update_memory_metrics
     from app.observability.metrics.pool import update_pool_metrics
 
     pool_metrics_task = asyncio.create_task(update_pool_metrics())
+    # fix(#643): per-worker RSS gauge + log watermark so an OOM-bound worker
+    # is visible in normal logs before the kernel kills it.
+    memory_metrics_task = asyncio.create_task(update_memory_metrics())
 
     async def _stale_jobs_sweeper() -> None:
         """Periodically fail jobs whose worker crashed mid-run.
@@ -394,6 +398,7 @@ async def lifespan(app: FastAPI):
     yield
 
     pool_metrics_task.cancel()
+    memory_metrics_task.cancel()
     stale_jobs_task.cancel()
     rate_limit_warmer_task.cancel()
     await task_app.close_async()

--- a/backend/app/observability/metrics/memory.py
+++ b/backend/app/observability/metrics/memory.py
@@ -1,0 +1,121 @@
+"""Per-worker RSS memory metrics for Prometheus + log watermarks.
+
+fix(#643): an api uvicorn worker was OOM-killed at the container cgroup cap
+(~1.9 GB RSS) with nothing in the normal logs — the event was only visible
+in the VM's dmesg. Expose each worker's RSS as a gauge and, because many
+deployments never scrape /metrics, WARN in the structured logs whenever a
+worker crosses the memory watermark, so runaway growth is diagnosable from
+`docker logs` alone.
+
+Reads /proc directly (Linux containers; no psutil dependency). On platforms
+without /proc (macOS dev) the loop idles silently.
+"""
+
+import asyncio
+import os
+import time
+
+import structlog
+from prometheus_client import Gauge
+
+logger = structlog.stdlib.get_logger(__name__)
+
+worker_rss_bytes = Gauge(
+    "geolens_worker_rss_bytes",
+    "Resident set size of this API worker process",
+)
+
+_INTERVAL_SECONDS = 60
+# WARN when a single worker exceeds this share of the container memory limit
+# (two workers share one cgroup, so one worker at 60% starves its sibling).
+_WARN_FRACTION_OF_LIMIT = 0.6
+# Fallback watermark when no cgroup limit is readable (bytes).
+_WARN_DEFAULT_BYTES = 1200 * 1024 * 1024
+# Re-warn at most every 5 minutes while above the watermark.
+_WARN_REPEAT_SECONDS = 300
+
+
+def read_rss_bytes() -> int | None:
+    """Current process RSS from /proc/self/status, or None off-Linux."""
+    try:
+        with open("/proc/self/status") as f:
+            for line in f:
+                if line.startswith("VmRSS:"):
+                    return int(line.split()[1]) * 1024
+    except OSError:
+        return None
+    return None
+
+
+def read_cgroup_limit_bytes() -> int | None:
+    """Container memory limit (cgroup v2 then v1), or None if unlimited."""
+    for path in (
+        "/sys/fs/cgroup/memory.max",
+        "/sys/fs/cgroup/memory/memory.limit_in_bytes",
+    ):
+        try:
+            with open(path) as f:
+                raw = f.read().strip()
+        except OSError:
+            continue
+        if raw == "max" or not raw.isdigit():
+            return None
+        limit = int(raw)
+        # cgroup v1 reports a huge sentinel when unlimited.
+        return limit if limit < 1 << 60 else None
+    return None
+
+
+class MemoryWatch:
+    """One sampling pass + watermark state, separated from the loop for tests."""
+
+    def __init__(self) -> None:
+        self._warn_bytes: int | None = None
+        # -inf so the very first over-watermark sample always warns.
+        self._last_warned_at: float = float("-inf")
+        self._samples = 0
+
+    def _watermark(self) -> int:
+        if self._warn_bytes is None:
+            limit = read_cgroup_limit_bytes()
+            self._warn_bytes = (
+                int(limit * _WARN_FRACTION_OF_LIMIT) if limit else _WARN_DEFAULT_BYTES
+            )
+        return self._warn_bytes
+
+    def sample(self, now: float | None = None) -> int | None:
+        rss = read_rss_bytes()
+        if rss is None:
+            return None
+        worker_rss_bytes.set(rss)
+        self._samples += 1
+        watermark = self._watermark()
+        now = time.monotonic() if now is None else now
+        fields = {"pid": os.getpid(), "rss_mb": rss // (1024 * 1024)}
+        if rss >= watermark and now - self._last_warned_at >= _WARN_REPEAT_SECONDS:
+            self._last_warned_at = now
+            logger.warning(
+                "API worker memory above watermark",
+                watermark_mb=watermark // (1024 * 1024),
+                **fields,
+            )
+        elif self._samples == 1 or self._samples % 60 == 0:
+            # Hourly heartbeat (plus a startup baseline) so a growth curve
+            # exists in plain logs even when /metrics is never scraped.
+            logger.info("API worker memory", **fields)
+        else:
+            logger.debug("API worker memory", **fields)
+        return rss
+
+
+async def update_memory_metrics() -> None:
+    """Background loop that samples worker RSS every 60 seconds."""
+    watch = MemoryWatch()
+    while True:
+        try:
+            watch.sample()
+        except (
+            Exception
+        ):  # broad: metrics sampling is non-fatal; must not crash the loop
+            logger.warning("Failed to sample worker memory", exc_info=True)
+        await asyncio.sleep(_INTERVAL_SECONDS)

--- a/backend/app/observability/metrics/memory.py
+++ b/backend/app/observability/metrics/memory.py
@@ -9,6 +9,15 @@ worker crosses the memory watermark, so runaway growth is diagnosable from
 
 Reads /proc directly (Linux containers; no psutil dependency). On platforms
 without /proc (macOS dev) the loop idles silently.
+
+Multi-worker caveat (codex P2 on #650): each uvicorn worker owns its own
+prometheus_client registry and /metrics is served by whichever worker takes
+the scrape, so one scrape sees one worker — a repo-wide property of the
+metrics stack (pool/jobs/HTTP metrics behave the same; multiprocess mode is
+tracked separately, see #651). The gauge is labeled by pid so successive
+scrapes accumulate as distinct per-worker series in the TSDB instead of
+silently flip-flopping one series; the structured-log heartbeat/watermark
+remains the authoritative per-worker signal.
 """
 
 import asyncio
@@ -22,7 +31,8 @@ logger = structlog.stdlib.get_logger(__name__)
 
 worker_rss_bytes = Gauge(
     "geolens_worker_rss_bytes",
-    "Resident set size of this API worker process",
+    "Resident set size of an API worker process",
+    ["pid"],
 )
 
 _INTERVAL_SECONDS = 60
@@ -87,7 +97,7 @@ class MemoryWatch:
         rss = read_rss_bytes()
         if rss is None:
             return None
-        worker_rss_bytes.set(rss)
+        worker_rss_bytes.labels(pid=str(os.getpid())).set(rss)
         self._samples += 1
         watermark = self._watermark()
         now = time.monotonic() if now is None else now

--- a/backend/tests/test_memory_metrics.py
+++ b/backend/tests/test_memory_metrics.py
@@ -1,0 +1,53 @@
+"""fix(#643): worker RSS sampling — gauge, watermark warning, rate limiting."""
+
+import pytest
+
+from app.observability.metrics import memory as mem
+
+
+@pytest.fixture
+def fixed_env(monkeypatch):
+    """Pin RSS and cgroup limit so sampling is deterministic."""
+    state = {"rss": 700 * 1024 * 1024, "limit": 2 * 1024 * 1024 * 1024}
+    monkeypatch.setattr(mem, "read_rss_bytes", lambda: state["rss"])
+    monkeypatch.setattr(mem, "read_cgroup_limit_bytes", lambda: state["limit"])
+    return state
+
+
+def test_sample_sets_gauge(fixed_env):
+    watch = mem.MemoryWatch()
+    assert watch.sample(now=0.0) == fixed_env["rss"]
+    assert mem.worker_rss_bytes._value.get() == fixed_env["rss"]
+
+
+def test_watermark_is_fraction_of_cgroup_limit(fixed_env):
+    watch = mem.MemoryWatch()
+    watch.sample(now=0.0)
+    # 60% of the 2 GiB limit
+    assert watch._warn_bytes == int(fixed_env["limit"] * 0.6)
+
+
+def test_watermark_falls_back_without_limit(fixed_env, monkeypatch):
+    monkeypatch.setattr(mem, "read_cgroup_limit_bytes", lambda: None)
+    watch = mem.MemoryWatch()
+    watch.sample(now=0.0)
+    assert watch._warn_bytes == mem._WARN_DEFAULT_BYTES
+
+
+def test_warning_fires_above_watermark_and_rate_limits(fixed_env, monkeypatch):
+    warnings: list[dict] = []
+    monkeypatch.setattr(mem.logger, "warning", lambda msg, **kw: warnings.append(kw))
+    watch = mem.MemoryWatch()
+    fixed_env["rss"] = int(fixed_env["limit"] * 0.7)  # above the 60% mark
+
+    watch.sample(now=0.0)
+    watch.sample(now=10.0)  # within repeat window: suppressed
+    watch.sample(now=mem._WARN_REPEAT_SECONDS + 1.0)  # window elapsed: re-warns
+
+    assert len(warnings) == 2
+    assert warnings[0]["rss_mb"] == fixed_env["rss"] // (1024 * 1024)
+
+
+def test_sample_noop_without_proc(monkeypatch):
+    monkeypatch.setattr(mem, "read_rss_bytes", lambda: None)
+    assert mem.MemoryWatch().sample(now=0.0) is None

--- a/backend/tests/test_memory_metrics.py
+++ b/backend/tests/test_memory_metrics.py
@@ -14,10 +14,13 @@ def fixed_env(monkeypatch):
     return state
 
 
-def test_sample_sets_gauge(fixed_env):
+def test_sample_sets_gauge_labeled_by_pid(fixed_env):
+    import os
+
     watch = mem.MemoryWatch()
     assert watch.sample(now=0.0) == fixed_env["rss"]
-    assert mem.worker_rss_bytes._value.get() == fixed_env["rss"]
+    child = mem.worker_rss_bytes.labels(pid=str(os.getpid()))
+    assert child._value.get() == fixed_env["rss"]
 
 
 def test_watermark_is_fraction_of_cgroup_limit(fixed_env):


### PR DESCRIPTION
Part of #643 (does not close it — root cause still open; findings posted on the issue).

## What
Each api worker now samples its own RSS from `/proc/self/status` every 60s:
- **Prometheus gauge** `geolens_worker_rss_bytes` (mirrors the existing `pool.py` background-task pattern; task started/cancelled in the lifespan).
- **Hourly INFO heartbeat + startup baseline** in structured logs, so a growth curve exists in `docker logs` even when `/metrics` is never scraped — the demo OOM was invisible outside dmesg.
- **Rate-limited WARNING** (≤1 per 5 min) when a worker crosses **60% of the container cgroup limit** (v2 `memory.max`, v1 fallback; 1200 MB default when unlimited) — with two workers per cgroup, one worker at 60% is already starving its sibling.

No new dependencies; quietly no-ops on platforms without `/proc` (macOS dev).

## Verification
- `pytest tests/test_memory_metrics.py` — 5 passed (gauge set, watermark derivation from cgroup limit, no-limit fallback, warn + rate-limit + re-warn after window, no-/proc no-op). The rate-limit test caught a real bug (initial `_last_warned_at=0.0` suppressed the first warning near clock zero — now `-inf`).
- `tests/test_layering.py` — 29 passed; ruff clean.
- **Live in the real api container**: startup baseline `API worker memory ... rss_mb=257` logged per worker, and `/metrics` serves `geolens_worker_rss_bytes 2.6968064e+08` matching the log.

https://claude.ai/code/session_01EJ3PZWCqfT3zCPQDCVuVUk