### PR TITLE
feat(admin): "Test Connection" button on the AI settings tab (#635 follow-up)

### DIFF
--- a/frontend/src/api/admin.ts
+++ b/frontend/src/api/admin.ts
@@ -176,8 +176,11 @@ export async function getAIStatus(): Promise<AIStatusResponse> {
 
 // feat(#635): live provider probe — spends real provider tokens, so only
 // invoked from an explicit admin action, never on page load.
+// fix(#652): chat + embeddings probe sequentially at up to 15s each, so the
+// backend's sanitized timeout rows can arrive after the default 30s client
+// deadline — outlive the backend worst case instead of toasting a generic error.
 export async function probeAIStatus(): Promise<AIStatusResponse> {
-  return apiFetch<AIStatusResponse>('/admin/ai-status/?probe=true');
+  return apiFetch<AIStatusResponse>('/admin/ai-status/?probe=true', { timeoutMs: 45_000 });
 }
 
 // Infrastructure

--- a/frontend/src/api/admin.ts
+++ b/frontend/src/api/admin.ts
@@ -174,6 +174,12 @@ export async function getAIStatus(): Promise<AIStatusResponse> {
   return apiFetch<AIStatusResponse>('/admin/ai-status/');
 }
 
+// feat(#635): live provider probe — spends real provider tokens, so only
+// invoked from an explicit admin action, never on page load.
+export async function probeAIStatus(): Promise<AIStatusResponse> {
+  return apiFetch<AIStatusResponse>('/admin/ai-status/?probe=true');
+}
+
 // Infrastructure
 export async function getInfrastructure(): Promise<InfrastructureResponse> {
   return apiFetch<InfrastructureResponse>('/admin/infrastructure/');

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -212,13 +212,15 @@ async function authenticatedFetch(
  */
 export async function apiFetch<T>(
   path: string,
-  options: RequestInit & { expected404?: boolean } = {},
+  options: RequestInit & { expected404?: boolean; timeoutMs?: number } = {},
 ): Promise<T> {
-  const { expected404, ...fetchOptions } = options;
+  const { expected404, timeoutMs, ...fetchOptions } = options;
 
   // fix(#438): DATA-04 — bound the request. Compose with any caller signal so
-  // an explicit cancel still works; whichever fires first wins.
-  const timeoutSignal = AbortSignal.timeout(REQUEST_TIMEOUT_MS);
+  // an explicit cancel still works; whichever fires first wins. `timeoutMs`
+  // raises the deadline for endpoints whose legitimate worst case exceeds the
+  // default (a caller signal alone can only shorten it, never extend it).
+  const timeoutSignal = AbortSignal.timeout(timeoutMs ?? REQUEST_TIMEOUT_MS);
   fetchOptions.signal = fetchOptions.signal
     ? AbortSignal.any([fetchOptions.signal, timeoutSignal])
     : timeoutSignal;

--- a/frontend/src/components/admin/settings/SettingsAITab.tsx
+++ b/frontend/src/components/admin/settings/SettingsAITab.tsx
@@ -18,6 +18,8 @@ import { useEmbeddingStats, useBackfillEmbeddings, useUpdateSemanticSearch } fro
 import { usePermissions } from '@/hooks/use-permissions';
 import { detectEmbeddingDims } from '@/api/settings';
 import type { SettingItem } from '@/api/settings';
+import { probeAIStatus } from '@/api/admin';
+import type { AIProbeCheck, AIProbeReport } from '@/types/api';
 
 interface TabProps {
   settings: SettingItem[];
@@ -54,6 +56,8 @@ export function SettingsAITab({ settings, envOnly, onSave, onReset, isSaving, on
 
   const { values, setters, dirty, hasDirty, discard } = useSettingsForm(settings, AI_FIELDS);
   const [isDetecting, setIsDetecting] = useState(false);
+  const [isProbing, setIsProbing] = useState(false);
+  const [probe, setProbe] = useState<AIProbeReport | null>(null);
 
   // Alias for readability in JSX
   const aiEnabled = values.ai_enabled as boolean;
@@ -102,6 +106,38 @@ export function SettingsAITab({ settings, envOnly, onSave, onReset, isSaving, on
       setIsDetecting(false);
     }
   };
+
+  const handleTestConnection = async () => {
+    setIsProbing(true);
+    try {
+      const result = await probeAIStatus();
+      setProbe(result.probe ?? null);
+    } catch {
+      toast.error(t('ai.testConnectionFailed'));
+    } finally {
+      setIsProbing(false);
+    }
+  };
+
+  const probeRow = (label: string, check: AIProbeCheck) => (
+    <div className="flex items-center gap-2 text-sm">
+      {!check.configured ? (
+        <XCircle className="h-4 w-4 text-muted-foreground" />
+      ) : check.ok ? (
+        <CheckCircle2 className="h-4 w-4 text-success" />
+      ) : (
+        <XCircle className="h-4 w-4 text-destructive" />
+      )}
+      <span>{label}</span>
+      <span className="text-muted-foreground">
+        {!check.configured
+          ? t('ai.keyNotSet')
+          : check.ok
+            ? t('ai.probeOk')
+            : (check.error ?? t('ai.probeFailed'))}
+      </span>
+    </div>
+  );
 
   const openaiKeyMissing = keyStatus && !keyStatus.openai_configured;
 
@@ -449,6 +485,35 @@ export function SettingsAITab({ settings, envOnly, onSave, onReset, isSaving, on
                 <Badge variant="secondary" className="text-xs">{openaiUsages.join(' + ')}</Badge>
               )}
             </div>
+          </div>
+        )}
+
+        {/* feat(#635): live probe — reader permission is manage_users, so a
+            settings-only operator would 403; hide rather than dangle a dead button. */}
+        {canManageUsers && (
+          <div className="mt-4 space-y-2">
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={handleTestConnection}
+              disabled={isProbing}
+            >
+              {isProbing ? (
+                <Loader2 className="me-1.5 h-3 w-3 animate-spin" />
+              ) : (
+                <Zap className="me-1.5 h-3 w-3" />
+              )}
+              {isProbing ? t('ai.testing') : t('ai.testConnection')}
+            </Button>
+            <p className="text-sm text-muted-foreground max-w-md">
+              {t('ai.testConnectionDescription')}
+            </p>
+            {probe && (
+              <div className="space-y-1.5 pt-1">
+                {probeRow(t('ai.inference'), probe.chat)}
+                {probeRow(t('ai.embeddings'), probe.embeddings)}
+              </div>
+            )}
           </div>
         )}
       </div>

--- a/frontend/src/components/admin/settings/SettingsAITab.tsx
+++ b/frontend/src/components/admin/settings/SettingsAITab.tsx
@@ -16,6 +16,7 @@ import { useSettingsForm } from './useSettingsForm';
 import { useApiKeyStatus } from '@/hooks/use-settings';
 import { useEmbeddingStats, useBackfillEmbeddings, useUpdateSemanticSearch } from '@/hooks/use-admin';
 import { usePermissions } from '@/hooks/use-permissions';
+import { useEdition } from '@/hooks/use-edition';
 import { detectEmbeddingDims } from '@/api/settings';
 import type { SettingItem } from '@/api/settings';
 import { probeAIStatus } from '@/api/admin';
@@ -46,6 +47,10 @@ export function SettingsAITab({ settings, envOnly, onSave, onReset, isSaving, on
   const { t } = useTranslation('admin');
   const { can } = usePermissions();
   const canManageUsers = can('manage_users');
+  const { isMultiTenant } = useEdition();
+  // fix(#652): mirror the backend's require_ai_status_reader, which switches
+  // from manage_users to manage_tenants in multi-tenant deployments.
+  const canProbe = isMultiTenant ? can('manage_tenants') : canManageUsers;
   const { data: keyStatus } = useApiKeyStatus();
   // Coverage/backfill are manage_users operations. A settings-only operator
   // can configure embeddings without issuing forbidden operational probes.
@@ -497,9 +502,9 @@ export function SettingsAITab({ settings, envOnly, onSave, onReset, isSaving, on
           </div>
         )}
 
-        {/* feat(#635): live probe — reader permission is manage_users, so a
-            settings-only operator would 403; hide rather than dangle a dead button. */}
-        {canManageUsers && (
+        {/* feat(#635): live probe — a settings-only operator would 403 on the
+            probe endpoint; hide rather than dangle a dead button. */}
+        {canProbe && (
           <div className="mt-4 space-y-2">
             {/* fix(#652): the probe resolves PERSISTED settings — block it while
                 the form is dirty so green results can't vouch for unsaved edits. */}

--- a/frontend/src/components/admin/settings/SettingsAITab.tsx
+++ b/frontend/src/components/admin/settings/SettingsAITab.tsx
@@ -109,6 +109,9 @@ export function SettingsAITab({ settings, envOnly, onSave, onReset, isSaving, on
 
   const handleTestConnection = async () => {
     setIsProbing(true);
+    // fix(#652): drop previous rows first so a failed retry can't keep
+    // showing stale green results next to only a toast.
+    setProbe(null);
     try {
       const result = await probeAIStatus();
       setProbe(result.probe ?? null);

--- a/frontend/src/components/admin/settings/SettingsAITab.tsx
+++ b/frontend/src/components/admin/settings/SettingsAITab.tsx
@@ -495,11 +495,13 @@ export function SettingsAITab({ settings, envOnly, onSave, onReset, isSaving, on
             settings-only operator would 403; hide rather than dangle a dead button. */}
         {canManageUsers && (
           <div className="mt-4 space-y-2">
+            {/* fix(#652): the probe resolves PERSISTED settings — block it while
+                the form is dirty so green results can't vouch for unsaved edits. */}
             <Button
               variant="outline"
               size="sm"
               onClick={handleTestConnection}
-              disabled={isProbing}
+              disabled={isProbing || hasDirty}
             >
               {isProbing ? (
                 <Loader2 className="me-1.5 h-3 w-3 animate-spin" />
@@ -509,7 +511,7 @@ export function SettingsAITab({ settings, envOnly, onSave, onReset, isSaving, on
               {isProbing ? t('ai.testing') : t('ai.testConnection')}
             </Button>
             <p className="text-sm text-muted-foreground max-w-md">
-              {t('ai.testConnectionDescription')}
+              {hasDirty ? t('ai.testConnectionDirty') : t('ai.testConnectionDescription')}
             </p>
             {probe && (
               <div className="space-y-1.5 pt-1">

--- a/frontend/src/components/admin/settings/SettingsAITab.tsx
+++ b/frontend/src/components/admin/settings/SettingsAITab.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { CheckCircle2, Info, Loader2, XCircle, AlertTriangle, Zap } from 'lucide-react';
 import { SettingsFormActions } from './SettingsFormActions';
@@ -58,6 +58,12 @@ export function SettingsAITab({ settings, envOnly, onSave, onReset, isSaving, on
   const [isDetecting, setIsDetecting] = useState(false);
   const [isProbing, setIsProbing] = useState(false);
   const [probe, setProbe] = useState<AIProbeReport | null>(null);
+
+  // fix(#652): probe results describe the PERSISTED config — drop them when
+  // the saved settings change underneath us (e.g. after a Save reload).
+  useEffect(() => {
+    setProbe(null);
+  }, [settings]);
 
   // Alias for readability in JSX
   const aiEnabled = values.ai_enabled as boolean;
@@ -513,7 +519,9 @@ export function SettingsAITab({ settings, envOnly, onSave, onReset, isSaving, on
             <p className="text-sm text-muted-foreground max-w-md">
               {hasDirty ? t('ai.testConnectionDirty') : t('ai.testConnectionDescription')}
             </p>
-            {probe && (
+            {/* fix(#652): hide (not clear) while dirty — a Discard restores
+                exactly the config these rows were probed against. */}
+            {probe && !hasDirty && (
               <div className="space-y-1.5 pt-1">
                 {probeRow(t('ai.inference'), probe.chat)}
                 {probeRow(t('ai.embeddings'), probe.embeddings)}

--- a/frontend/src/components/admin/settings/__tests__/SettingsAITab.test.tsx
+++ b/frontend/src/components/admin/settings/__tests__/SettingsAITab.test.tsx
@@ -1,6 +1,8 @@
-import { render, screen } from '@/test/test-utils';
+import { render, screen, waitFor } from '@/test/test-utils';
+import userEvent from '@testing-library/user-event';
 import { SettingsAITab } from '../SettingsAITab';
 import type { SettingItem } from '@/api/settings';
+import { probeAIStatus } from '@/api/admin';
 
 // #347 (ADM-05) regression: the Embedding Coverage box has two buttons ("Generate
 // Missing" + "Regenerate All") backed by one backfill mutation. Each spinner
@@ -38,6 +40,11 @@ vi.mock('@/hooks/use-settings', async (importOriginal) => {
     ...actual,
     useApiKeyStatus: () => ({ data: { configured: true } }),
   };
+});
+
+vi.mock('@/api/admin', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/api/admin')>();
+  return { ...actual, probeAIStatus: vi.fn() };
 });
 
 function renderTab(settings: SettingItem[] = []) {
@@ -91,5 +98,66 @@ describe('SettingsAITab — embedding coverage single spinner (#347 (ADM-05))', 
     expect(screen.getByRole('switch', { name: 'Semantic Search' })).toBeChecked();
     expect(screen.queryByText('Embedding Coverage')).not.toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'Generate Missing' })).not.toBeInTheDocument();
+  });
+});
+
+// feat(#635): Test Connection button drives the live ?probe=true endpoint.
+describe('SettingsAITab — Test Connection probe (#635)', () => {
+  const mockProbe = vi.mocked(probeAIStatus);
+
+  beforeEach(() => {
+    hoisted.canManageUsers = true;
+    hoisted.backfill = { mutate: vi.fn(), isPending: false, variables: undefined };
+    mockProbe.mockReset();
+  });
+
+  it('renders per-purpose results after a probe: chat ok, embeddings failed', async () => {
+    const user = userEvent.setup();
+    mockProbe.mockResolvedValue({
+      provider: 'anthropic',
+      model: 'claude',
+      enabled: true,
+      configured: true,
+      semantic_search_enabled: false,
+      has_embeddings: false,
+      probe: {
+        chat: { configured: true, ok: true },
+        embeddings: { configured: true, ok: false, status: 401, error: 'authentication failed' },
+      },
+    });
+    renderTab();
+
+    await user.click(screen.getByRole('button', { name: /Test Connection/ }));
+
+    await waitFor(() => expect(screen.getByText('OK')).toBeInTheDocument());
+    expect(screen.getByText('authentication failed')).toBeInTheDocument();
+    expect(mockProbe).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows "not set" for an unconfigured purpose (no live call was made)', async () => {
+    const user = userEvent.setup();
+    mockProbe.mockResolvedValue({
+      provider: 'anthropic',
+      model: 'claude',
+      enabled: true,
+      configured: true,
+      semantic_search_enabled: false,
+      has_embeddings: false,
+      probe: {
+        chat: { configured: true, ok: true },
+        embeddings: { configured: false, ok: null },
+      },
+    });
+    renderTab();
+
+    await user.click(screen.getByRole('button', { name: /Test Connection/ }));
+
+    await waitFor(() => expect(screen.getByText('not set')).toBeInTheDocument());
+  });
+
+  it('hides the button for a settings-only operator (probe needs manage_users)', () => {
+    hoisted.canManageUsers = false;
+    renderTab();
+    expect(screen.queryByRole('button', { name: /Test Connection/ })).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/components/admin/settings/__tests__/SettingsAITab.test.tsx
+++ b/frontend/src/components/admin/settings/__tests__/SettingsAITab.test.tsx
@@ -177,6 +177,32 @@ describe('SettingsAITab — Test Connection probe (#635)', () => {
     expect(mockProbe).not.toHaveBeenCalled();
   });
 
+  // fix(#652): prior results describe the persisted config — they must not
+  // stay visible next to unsaved edits they never probed.
+  it('hides prior results while the form is dirty', async () => {
+    const user = userEvent.setup();
+    mockProbe.mockResolvedValueOnce({
+      provider: 'anthropic',
+      model: 'claude',
+      enabled: true,
+      configured: true,
+      semantic_search_enabled: false,
+      has_embeddings: false,
+      probe: {
+        chat: { configured: true, ok: true },
+        embeddings: { configured: true, ok: true },
+      },
+    });
+    renderTab([{ key: 'llm_model', value: 'claude-3', source: 'default', label: 'Model' }]);
+
+    await user.click(screen.getByRole('button', { name: /Test Connection/ }));
+    await waitFor(() => expect(screen.getAllByText('OK')).toHaveLength(2));
+
+    await user.type(screen.getByRole('textbox', { name: 'Model' }), '-edited');
+
+    expect(screen.queryByText('OK')).not.toBeInTheDocument();
+  });
+
   // fix(#652): a failed retry must not keep showing the previous green rows.
   it('clears prior results when a retry fails before returning a probe body', async () => {
     const user = userEvent.setup();

--- a/frontend/src/components/admin/settings/__tests__/SettingsAITab.test.tsx
+++ b/frontend/src/components/admin/settings/__tests__/SettingsAITab.test.tsx
@@ -161,6 +161,22 @@ describe('SettingsAITab — Test Connection probe (#635)', () => {
     expect(screen.queryByRole('button', { name: /Test Connection/ })).not.toBeInTheDocument();
   });
 
+  // fix(#652): the probe tests PERSISTED settings — a dirty form must not
+  // let green results vouch for unsaved edits.
+  it('disables the button and explains while the form has unsaved changes', async () => {
+    const user = userEvent.setup();
+    // dirty-tracking only covers fields present in the server settings list
+    renderTab([{ key: 'llm_model', value: 'claude-3', source: 'default', label: 'Model' }]);
+
+    await user.type(screen.getByRole('textbox', { name: 'Model' }), 'claude-x');
+
+    expect(screen.getByRole('button', { name: /Test Connection/ })).toBeDisabled();
+    expect(
+      screen.getByText('Save your changes first — the test runs against the saved configuration.'),
+    ).toBeInTheDocument();
+    expect(mockProbe).not.toHaveBeenCalled();
+  });
+
   // fix(#652): a failed retry must not keep showing the previous green rows.
   it('clears prior results when a retry fails before returning a probe body', async () => {
     const user = userEvent.setup();

--- a/frontend/src/components/admin/settings/__tests__/SettingsAITab.test.tsx
+++ b/frontend/src/components/admin/settings/__tests__/SettingsAITab.test.tsx
@@ -160,4 +160,30 @@ describe('SettingsAITab — Test Connection probe (#635)', () => {
     renderTab();
     expect(screen.queryByRole('button', { name: /Test Connection/ })).not.toBeInTheDocument();
   });
+
+  // fix(#652): a failed retry must not keep showing the previous green rows.
+  it('clears prior results when a retry fails before returning a probe body', async () => {
+    const user = userEvent.setup();
+    mockProbe.mockResolvedValueOnce({
+      provider: 'anthropic',
+      model: 'claude',
+      enabled: true,
+      configured: true,
+      semantic_search_enabled: false,
+      has_embeddings: false,
+      probe: {
+        chat: { configured: true, ok: true },
+        embeddings: { configured: true, ok: true },
+      },
+    });
+    renderTab();
+
+    await user.click(screen.getByRole('button', { name: /Test Connection/ }));
+    await waitFor(() => expect(screen.getAllByText('OK')).toHaveLength(2));
+
+    mockProbe.mockRejectedValueOnce(new Error('429'));
+    await user.click(screen.getByRole('button', { name: /Test Connection/ }));
+
+    await waitFor(() => expect(screen.queryByText('OK')).not.toBeInTheDocument());
+  });
 });

--- a/frontend/src/components/admin/settings/__tests__/SettingsAITab.test.tsx
+++ b/frontend/src/components/admin/settings/__tests__/SettingsAITab.test.tsx
@@ -13,6 +13,8 @@ import { probeAIStatus } from '@/api/admin';
 const hoisted = vi.hoisted(() => ({
   backfill: { mutate: vi.fn(), isPending: false, variables: undefined as unknown },
   canManageUsers: true,
+  canManageTenants: false,
+  isMultiTenant: false,
   useEmbeddingStats: vi.fn((_options?: { enabled?: boolean }) => ({
     data: { total_records: 100, embedded_records: 50, missing_records: 50, coverage_percent: 50 },
   })),
@@ -20,7 +22,19 @@ const hoisted = vi.hoisted(() => ({
 
 vi.mock('@/hooks/use-permissions', () => ({
   usePermissions: () => ({
-    can: (capability: string) => capability === 'manage_users' && hoisted.canManageUsers,
+    can: (capability: string) =>
+      (capability === 'manage_users' && hoisted.canManageUsers) ||
+      (capability === 'manage_tenants' && hoisted.canManageTenants),
+  }),
+}));
+
+vi.mock('@/hooks/use-edition', () => ({
+  useEdition: () => ({
+    edition: 'community',
+    features: [],
+    isEnterprise: false,
+    isMultiTenant: hoisted.isMultiTenant,
+    isLoading: false,
   }),
 }));
 
@@ -107,6 +121,8 @@ describe('SettingsAITab — Test Connection probe (#635)', () => {
 
   beforeEach(() => {
     hoisted.canManageUsers = true;
+    hoisted.canManageTenants = false;
+    hoisted.isMultiTenant = false;
     hoisted.backfill = { mutate: vi.fn(), isPending: false, variables: undefined };
     mockProbe.mockReset();
   });
@@ -159,6 +175,24 @@ describe('SettingsAITab — Test Connection probe (#635)', () => {
     hoisted.canManageUsers = false;
     renderTab();
     expect(screen.queryByRole('button', { name: /Test Connection/ })).not.toBeInTheDocument();
+  });
+
+  // fix(#652): require_ai_status_reader switches to manage_tenants in
+  // multi-tenant mode — the button gate must switch with it.
+  it('multi-tenant: manage_users alone does NOT show the button', () => {
+    hoisted.isMultiTenant = true;
+    hoisted.canManageUsers = true;
+    hoisted.canManageTenants = false;
+    renderTab();
+    expect(screen.queryByRole('button', { name: /Test Connection/ })).not.toBeInTheDocument();
+  });
+
+  it('multi-tenant: manage_tenants without manage_users DOES show the button', () => {
+    hoisted.isMultiTenant = true;
+    hoisted.canManageUsers = false;
+    hoisted.canManageTenants = true;
+    renderTab();
+    expect(screen.getByRole('button', { name: /Test Connection/ })).toBeInTheDocument();
   });
 
   // fix(#652): the probe tests PERSISTED settings — a dirty form must not

--- a/frontend/src/i18n/locales/de/admin.json
+++ b/frontend/src/i18n/locales/de/admin.json
@@ -282,6 +282,7 @@
     "testConnection": "Verbindung testen",
     "testing": "Wird getestet…",
     "testConnectionDescription": "Führt einen Live-Aufruf an jeden konfigurierten Anbieter aus, um Schlüssel und Konnektivität zu prüfen. Verbraucht eine kleine Menge Anbieter-Tokens.",
+    "testConnectionDirty": "Speichern Sie zuerst Ihre Änderungen — der Test wird mit der gespeicherten Konfiguration ausgeführt.",
     "testConnectionFailed": "Verbindungstest fehlgeschlagen",
     "probeOk": "OK",
     "probeFailed": "fehlgeschlagen",

--- a/frontend/src/i18n/locales/de/admin.json
+++ b/frontend/src/i18n/locales/de/admin.json
@@ -279,6 +279,12 @@
     "openaiKeyRequired": "OPENAI_API_KEY ist nicht gesetzt. Die Embedding-Generierung erfordert einen OpenAI-kompatiblen API-Schlüssel.",
     "keyConfigured": "konfiguriert",
     "keyNotSet": "nicht konfiguriert",
+    "testConnection": "Verbindung testen",
+    "testing": "Wird getestet…",
+    "testConnectionDescription": "Führt einen Live-Aufruf an jeden konfigurierten Anbieter aus, um Schlüssel und Konnektivität zu prüfen. Verbraucht eine kleine Menge Anbieter-Tokens.",
+    "testConnectionFailed": "Verbindungstest fehlgeschlagen",
+    "probeOk": "OK",
+    "probeFailed": "fehlgeschlagen",
     "regenerateAll": "Alle neu generieren",
     "labels": {
       "aiEnabled": "KI-Chat aktiviert",

--- a/frontend/src/i18n/locales/en/admin.json
+++ b/frontend/src/i18n/locales/en/admin.json
@@ -312,6 +312,7 @@
     "testConnection": "Test Connection",
     "testing": "Testing…",
     "testConnectionDescription": "Runs a live call against each configured provider to verify keys and connectivity. Uses a small number of provider tokens.",
+    "testConnectionDirty": "Save your changes first — the test runs against the saved configuration.",
     "testConnectionFailed": "Connection test failed",
     "probeOk": "OK",
     "probeFailed": "failed",

--- a/frontend/src/i18n/locales/en/admin.json
+++ b/frontend/src/i18n/locales/en/admin.json
@@ -309,6 +309,12 @@
     "openaiKeyRequired": "OPENAI_API_KEY is not set. Embedding generation requires an OpenAI-compatible API key, even when using Anthropic for inference.",
     "keyConfigured": "configured",
     "keyNotSet": "not set",
+    "testConnection": "Test Connection",
+    "testing": "Testing…",
+    "testConnectionDescription": "Runs a live call against each configured provider to verify keys and connectivity. Uses a small number of provider tokens.",
+    "testConnectionFailed": "Connection test failed",
+    "probeOk": "OK",
+    "probeFailed": "failed",
     "regenerateAll": "Regenerate All",
     "labels": {
       "aiEnabled": "AI Chat Enabled",

--- a/frontend/src/i18n/locales/es/admin.json
+++ b/frontend/src/i18n/locales/es/admin.json
@@ -279,6 +279,12 @@
     "openaiKeyRequired": "OPENAI_API_KEY no está configurado. La generación de embeddings requiere una clave API compatible con OpenAI, incluso cuando se usa Anthropic para inferencia.",
     "keyConfigured": "configurada",
     "keyNotSet": "no configurada",
+    "testConnection": "Probar conexión",
+    "testing": "Probando…",
+    "testConnectionDescription": "Realiza una llamada real a cada proveedor configurado para verificar las claves y la conectividad. Consume una pequeña cantidad de tokens del proveedor.",
+    "testConnectionFailed": "La prueba de conexión falló",
+    "probeOk": "OK",
+    "probeFailed": "falló",
     "regenerateAll": "Regenerar todo",
     "labels": {
       "aiEnabled": "Chat IA habilitado",

--- a/frontend/src/i18n/locales/es/admin.json
+++ b/frontend/src/i18n/locales/es/admin.json
@@ -282,6 +282,7 @@
     "testConnection": "Probar conexión",
     "testing": "Probando…",
     "testConnectionDescription": "Realiza una llamada real a cada proveedor configurado para verificar las claves y la conectividad. Consume una pequeña cantidad de tokens del proveedor.",
+    "testConnectionDirty": "Guarda tus cambios primero — la prueba se ejecuta con la configuración guardada.",
     "testConnectionFailed": "La prueba de conexión falló",
     "probeOk": "OK",
     "probeFailed": "falló",

--- a/frontend/src/i18n/locales/fr/admin.json
+++ b/frontend/src/i18n/locales/fr/admin.json
@@ -282,6 +282,7 @@
     "testConnection": "Tester la connexion",
     "testing": "Test en cours…",
     "testConnectionDescription": "Effectue un appel réel vers chaque fournisseur configuré pour vérifier les clés et la connectivité. Consomme une petite quantité de jetons du fournisseur.",
+    "testConnectionDirty": "Enregistrez d'abord vos modifications — le test s'exécute avec la configuration enregistrée.",
     "testConnectionFailed": "Échec du test de connexion",
     "probeOk": "OK",
     "probeFailed": "échec",

--- a/frontend/src/i18n/locales/fr/admin.json
+++ b/frontend/src/i18n/locales/fr/admin.json
@@ -279,6 +279,12 @@
     "openaiKeyRequired": "OPENAI_API_KEY n'est pas défini. La génération d'embeddings nécessite une clé API compatible OpenAI.",
     "keyConfigured": "configurée",
     "keyNotSet": "non configurée",
+    "testConnection": "Tester la connexion",
+    "testing": "Test en cours…",
+    "testConnectionDescription": "Effectue un appel réel vers chaque fournisseur configuré pour vérifier les clés et la connectivité. Consomme une petite quantité de jetons du fournisseur.",
+    "testConnectionFailed": "Échec du test de connexion",
+    "probeOk": "OK",
+    "probeFailed": "échec",
     "regenerateAll": "Tout régénérer",
     "labels": {
       "aiEnabled": "Chat IA activé",

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -1313,6 +1313,18 @@ export interface MapAccessResponse {
 }
 
 // AI Status
+export interface AIProbeCheck {
+  configured: boolean;
+  ok: boolean | null;
+  status?: number | null;
+  error?: string | null;
+}
+
+export interface AIProbeReport {
+  chat: AIProbeCheck;
+  embeddings: AIProbeCheck;
+}
+
 export interface AIStatusResponse {
   provider: string | null;
   model: string | null;
@@ -1320,6 +1332,8 @@ export interface AIStatusResponse {
   configured: boolean;
   semantic_search_enabled: boolean;
   has_embeddings: boolean;
+  // Present only when the request opted in via ?probe=true (#635).
+  probe?: AIProbeReport;
 }
 
 export interface EmbeddingStatsResponse {


### PR DESCRIPTION
## What

Adds the frontend follow-up to the #635 probe endpoint: a **Test Connection** button in Admin → Settings → AI (API Key Status section) that calls `GET /api/admin/ai-status/?probe=true` and renders per-purpose results:

- **Inference** / **Embeddings** rows, each showing ✓ OK, ✗ with the sanitized failure reason from the backend, or "not set" when that purpose has no key configured (no live call made).
- Probe fires **only on explicit click** — it spends real provider tokens and is rate-limited server-side (30/min).
- Button is gated on `manage_users` (the probe reader permission), so a settings-only operator sees no dead button that would 403.

## Changes

- `types/api.ts`: hand-typed mirror gains `AIProbeCheck`/`AIProbeReport` and the optional `probe` field on `AIStatusResponse` (present only with `?probe=true`, matching the backend's `exclude_unset` shape).
- `api/admin.ts`: `probeAIStatus()` wrapper.
- `SettingsAITab.tsx`: button + result rows, mirroring the existing `handleDetectDims` local-state pattern.
- i18n: 6 new keys in all four locales (en/es/fr/de).

No API/schema/config impact.

## Verification

- `npx vitest run SettingsAITab.test.tsx` — 7 passed (3 new: ok+failed rows, unconfigured purpose, hidden without manage_users).
- `npm run typecheck`, `npx eslint` on changed files, `npm run test:i18n` — all clean.
- **Live against the local stack**: clicked the button as admin — real probe round-trip (200, `chat.ok=true`, `embeddings.ok=true`) with both rows rendered green.

https://claude.ai/code/session_01EJ3PZWCqfT3zCPQDCVuVUk