### PR TITLE
feat(builder): contextual-menu polish — findings 4-8 (#585 slice 2)

### DIFF
--- a/frontend/src/components/builder/BasemapGroupRow.tsx
+++ b/frontend/src/components/builder/BasemapGroupRow.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable jsx-a11y/no-static-element-interactions, jsx-a11y/no-noninteractive-tabindex -- Phase 1111 LINT-01: stack rows are composite focus targets with nested controls, so role="button"/listbox roles are intentionally avoided. */
 import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
-import { ChevronRight, Eye, EyeOff, MoreVertical } from 'lucide-react';
+import { ChevronRight, Eye, EyeOff, MoreVertical, Repeat, RotateCcw } from 'lucide-react';
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -31,6 +31,10 @@ interface BasemapGroupRowProps {
   onToggleVisibility: (id: string) => void;
   onSwapBasemap: () => void;
   onResetAppearance: () => void;
+  /** fix(#585): true when basemap_config holds appearance customizations —
+   *  false disables "Reset appearance" (nothing to reset). Defaults to true so
+   *  an unwired call site never blocks the action. */
+  hasCustomAppearance?: boolean;
   // Phase 1041: boundary signal — shows cursor-not-allowed when multi-selection is active (POL-11)
   isMultiSelectionActive?: boolean;
 }
@@ -49,6 +53,7 @@ export const BasemapGroupRow = memo(function BasemapGroupRow({
   onToggleVisibility,
   onSwapBasemap,
   onResetAppearance,
+  hasCustomAppearance = true,
   isMultiSelectionActive = false,
 }: BasemapGroupRowProps) {
   const { t } = useTranslation('builder');
@@ -216,12 +221,30 @@ export const BasemapGroupRow = memo(function BasemapGroupRow({
               <MoreVertical className="h-3.5 w-3.5" aria-hidden="true" />
             </button>
           </DropdownMenuTrigger>
-          <DropdownMenuContent align="end" className="w-40">
+          <DropdownMenuContent align="end" className="w-52">
+            {/* fix(#585): kebab items carry icons, matching StackRow. */}
             <DropdownMenuItem onSelect={() => onSwapBasemap()}>
+              <Repeat className="h-3.5 w-3.5 me-2" aria-hidden="true" />
               {t('basemapGroup.swapBasemap', { defaultValue: 'Swap basemap' })}
             </DropdownMenuItem>
-            <DropdownMenuItem onSelect={() => onResetAppearance()}>
-              {t('basemapGroup.resetAppearance', { defaultValue: 'Reset appearance' })}
+            {/* fix(#585): disabled when there is nothing to reset; the reason
+                is inline muted text (tooltips don't fire on disabled items). */}
+            <DropdownMenuItem
+              data-testid="basemap-reset-appearance"
+              disabled={!hasCustomAppearance}
+              onSelect={() => {
+                if (hasCustomAppearance) onResetAppearance();
+              }}
+            >
+              <RotateCcw className="h-3.5 w-3.5 me-2" aria-hidden="true" />
+              <span className="flex flex-col items-start">
+                {t('basemapGroup.resetAppearance', { defaultValue: 'Reset appearance' })}
+                {!hasCustomAppearance && (
+                  <span className="text-2xs text-muted-foreground">
+                    {t('basemapGroup.resetAppearanceHint', { defaultValue: 'Appearance is already at defaults' })}
+                  </span>
+                )}
+              </span>
             </DropdownMenuItem>
           </DropdownMenuContent>
         </DropdownMenu>

--- a/frontend/src/components/builder/BasemapGroupRowWrapper.tsx
+++ b/frontend/src/components/builder/BasemapGroupRowWrapper.tsx
@@ -112,6 +112,7 @@ export const BasemapGroupRowWrapper = memo(function BasemapGroupRowWrapper({
         onToggleVisibility={onToggleVisibility}
         onSwapBasemap={onSwapBasemap}
         onResetAppearance={onResetAppearance}
+        hasCustomAppearance={group.hasCustomAppearance}
         isMultiSelectionActive={isMultiSelectionActive}
       />
     </div>

--- a/frontend/src/components/builder/FolderGroupRow.tsx
+++ b/frontend/src/components/builder/FolderGroupRow.tsx
@@ -1,9 +1,8 @@
 /* eslint-disable jsx-a11y/no-static-element-interactions, jsx-a11y/no-noninteractive-tabindex -- Phase 1111 LINT-01: stack rows are composite focus targets with nested controls, so role="button"/listbox roles are intentionally avoided. */
 import { memo, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { ChevronRight, Eye, EyeOff, MoreVertical } from 'lucide-react';
+import { ChevronRight, Eye, EyeOff, FolderMinus, MoreVertical, Pencil, Plus, Trash2 } from 'lucide-react';
 import { Checkbox } from '@/components/ui/checkbox';
-import { Button } from '@/components/ui/button';
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -14,6 +13,7 @@ import {
 import { cn } from '@/lib/utils';
 import {
   DragGripButton,
+  InlineDeleteConfirm,
   STACK_ROW_GRID,
   rowStateClasses,
   useKebabContextMenu,
@@ -283,19 +283,24 @@ export const FolderGroupRow = memo(function FolderGroupRow({
                   startRename();
                 }}
               >
+                {/* fix(#585): kebab items carry icons, matching StackRow. */}
+                <Pencil className="h-3.5 w-3.5 me-2" aria-hidden="true" />
                 {t('stackRow.kebabRenameGroup', { defaultValue: 'Rename group' })}
               </DropdownMenuItem>
               <DropdownMenuItem onSelect={() => onAddLayer(groupId)}>
+                <Plus className="h-3.5 w-3.5 me-2" aria-hidden="true" />
                 {t('stackRow.kebabAddLayer', { defaultValue: 'Add layer' })}
               </DropdownMenuItem>
               <DropdownMenuSeparator />
               <DropdownMenuItem onSelect={() => onUngroup(groupId)}>
+                <FolderMinus className="h-3.5 w-3.5 me-2" aria-hidden="true" />
                 {t('stackRow.kebabUngroup', { defaultValue: 'Ungroup' })}
               </DropdownMenuItem>
               <DropdownMenuItem
                 className="text-destructive focus:text-destructive"
                 onSelect={() => setConfirmingDelete(true)}
               >
+                <Trash2 className="h-3.5 w-3.5 me-2" aria-hidden="true" />
                 {t('stackRow.kebabDeleteGroup', { defaultValue: 'Delete group' })}
               </DropdownMenuItem>
             </DropdownMenuContent>
@@ -303,42 +308,19 @@ export const FolderGroupRow = memo(function FolderGroupRow({
         </div>
       </div>
 
-      {/* Inline alertdialog for delete confirmation — sibling of grid row, NOT inside DropdownMenuContent */}
+      {/* fix(#585): shared inline confirm — sibling of grid row, NOT inside DropdownMenuContent */}
       {confirmingDelete && (
-        // eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-noninteractive-element-interactions
-        <div
-          role="alertdialog"
-          aria-labelledby={`confirm-delete-${groupId}`}
-          className="mx-2 mb-2 p-3 rounded-md border bg-popover space-y-2"
-          onClick={(e) => e.stopPropagation()}
-        >
-          <p id={`confirm-delete-${groupId}`} className="text-sm text-destructive text-center">
-            {t('folderGroup.deleteConfirmMessage', { defaultValue: 'Delete this group and all its layers?' })}
-          </p>
-          <div className="flex gap-2">
-            <Button
-              type="button"
-              variant="destructive"
-              className="flex-1"
-              onClick={() => {
-                onDeleteGroup(groupId);
-                setConfirmingDelete(false);
-              }}
-            >
-              {t('folderGroup.deleteConfirmAction', { defaultValue: 'Delete all' })}
-            </Button>
-            <Button
-              type="button"
-              variant="ghost"
-              className="flex-1"
-              onClick={() => setConfirmingDelete(false)}
-              // eslint-disable-next-line jsx-a11y/no-autofocus -- focus on safe choice per UI-SPEC accessibility
-              autoFocus
-            >
-              {t('folderGroup.deleteConfirmCancel', { defaultValue: 'Keep group' })}
-            </Button>
-          </div>
-        </div>
+        <InlineDeleteConfirm
+          confirmId={`confirm-delete-${groupId}`}
+          message={t('folderGroup.deleteConfirmMessage', { defaultValue: 'Delete this group and all its layers?' })}
+          confirmLabel={t('folderGroup.deleteConfirmAction', { defaultValue: 'Delete all' })}
+          cancelLabel={t('folderGroup.deleteConfirmCancel', { defaultValue: 'Keep group' })}
+          onConfirm={() => {
+            onDeleteGroup(groupId);
+            setConfirmingDelete(false);
+          }}
+          onCancel={() => setConfirmingDelete(false)}
+        />
       )}
     </div>
   );

--- a/frontend/src/components/builder/MapTitleBar.tsx
+++ b/frontend/src/components/builder/MapTitleBar.tsx
@@ -216,9 +216,18 @@ export function MapTitleBar({
                 <Info className="h-3.5 w-3.5 me-2" />
                 {t('tooltips.mapInfo', { defaultValue: 'Map info' })}
               </DropdownMenuItem>
+              {/* fix(#585): in-flight feedback — spinner + "Duplicating…" while
+                  the fork mutation is pending (was disabled-only, invisible
+                  until the settle toast). */}
               <DropdownMenuItem onClick={overflow.onFork} disabled={overflow.isForkPending}>
-                <Copy className="h-3.5 w-3.5 me-2" />
-                {t('tooltips.duplicateMap', { defaultValue: 'Duplicate map' })}
+                {overflow.isForkPending ? (
+                  <Loader2 className="h-3.5 w-3.5 me-2 animate-spin" />
+                ) : (
+                  <Copy className="h-3.5 w-3.5 me-2" />
+                )}
+                {overflow.isForkPending
+                  ? t('tooltips.duplicatingMap', { defaultValue: 'Duplicating…' })
+                  : t('tooltips.duplicateMap', { defaultValue: 'Duplicate map' })}
               </DropdownMenuItem>
               {overflow.onViewAsViewer && (
                 <DropdownMenuItem onClick={overflow.onViewAsViewer}>

--- a/frontend/src/components/builder/StackRow.tsx
+++ b/frontend/src/components/builder/StackRow.tsx
@@ -6,6 +6,7 @@ import {
   Copy,
   CopyPlus,
   Crosshair,
+  ExternalLink,
   Eye,
   EyeOff,
   Folder,
@@ -475,6 +476,27 @@ export const StackRow = memo(function StackRow({
                 </>
               );
             })()}
+            {/* fix(#585): navigable follow-up to the Source block — the builder
+                previously had NO path to the dataset page (notably: the
+                audienceHidden badge warns about dataset visibility, which is
+                fixed THERE). New tab on purpose: in-place navigation would trip
+                the unsaved-changes guard, matching the "View as viewer"
+                precedent. A real <a> so middle-click/cmd-click work. */}
+            {layer.dataset_id && (
+              <>
+                <DropdownMenuItem asChild data-testid="kebab-view-dataset">
+                  <a
+                    href={`/datasets/${layer.dataset_id}`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    <ExternalLink className="h-3.5 w-3.5 me-2" aria-hidden="true" />
+                    {t('layerItem.openDataset', { defaultValue: 'Open dataset detail' })}
+                  </a>
+                </DropdownMenuItem>
+                <DropdownMenuSeparator />
+              </>
+            )}
             <DropdownMenuItem
               onSelect={() => {
                 // Let the menu close; the hook's rAF focus + select runs once

--- a/frontend/src/components/builder/StackRow.tsx
+++ b/frontend/src/components/builder/StackRow.tsx
@@ -1,8 +1,22 @@
 /* eslint-disable jsx-a11y/no-static-element-interactions, jsx-a11y/no-noninteractive-tabindex -- Phase 1111 LINT-01: stack rows are composite focus targets with nested controls, so role="button"/listbox roles are intentionally avoided. */
 import { memo, useState, type KeyboardEvent } from 'react';
 import { useTranslation } from 'react-i18next';
-import { ClipboardPaste, Copy, Crosshair, Eye, EyeOff, MoreVertical, Type } from 'lucide-react';
-import { Button } from '@/components/ui/button';
+import {
+  ClipboardPaste,
+  Copy,
+  CopyPlus,
+  Crosshair,
+  Eye,
+  EyeOff,
+  Folder,
+  FolderMinus,
+  FolderPlus,
+  MoreVertical,
+  Pencil,
+  Plus,
+  Trash2,
+  Type,
+} from 'lucide-react';
 import { Checkbox } from '@/components/ui/checkbox';
 import {
   DropdownMenu,
@@ -10,6 +24,9 @@ import {
   DropdownMenuItem,
   DropdownMenuLabel,
   DropdownMenuSeparator,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
 import { LayerTypeIcon } from '@/components/map/layer-icons';
@@ -18,6 +35,7 @@ import { cn } from '@/lib/utils';
 import { semanticBadgeColors } from '@/lib/status-colors';
 import {
   DragGripButton,
+  InlineDeleteConfirm,
   STACK_ROW_GRID,
   rowStateClasses,
   useKebabContextMenu,
@@ -466,6 +484,10 @@ export const StackRow = memo(function StackRow({
                 startRename();
               }}
             >
+              {/* fix(#585): every kebab item carries an icon — Zoom/Copy/Paste
+                  had them while Rename/Duplicate/Delete and the group flow
+                  didn't, which read as ragged. */}
+              <Pencil className="h-3.5 w-3.5 me-2" aria-hidden="true" />
               {t('stackRow.kebabRenameLayer', { defaultValue: 'Rename layer' })}
             </DropdownMenuItem>
             <DropdownMenuItem
@@ -473,6 +495,7 @@ export const StackRow = memo(function StackRow({
                 onDuplicate(layer.id);
               }}
             >
+              <CopyPlus className="h-3.5 w-3.5 me-2" aria-hidden="true" />
               {t('stackRow.kebabDuplicate', { defaultValue: 'Duplicate' })}
             </DropdownMenuItem>
             {/* Phase 1201-01 ENH-01/ENH-02: zoom-to-extent + copy/paste style.
@@ -519,74 +542,64 @@ export const StackRow = memo(function StackRow({
                 setConfirmingDelete(true);
               }}
             >
+              <Trash2 className="h-3.5 w-3.5 me-2" aria-hidden="true" />
               {t('stackRow.kebabDeleteLayer', { defaultValue: 'Delete layer' })}
             </DropdownMenuItem>
             <DropdownMenuSeparator />
             {parentGroupId ? (
               // Layer is already inside a group: show "Move out of group"
               <DropdownMenuItem onSelect={() => onMoveLayerOutOfGroup?.(layer.id)}>
+                <FolderMinus className="h-3.5 w-3.5 me-2" aria-hidden="true" />
                 {t('stackRow.kebabMoveOutOfGroup', { defaultValue: 'Move out of group' })}
               </DropdownMenuItem>
             ) : (
-              <>
-                <DropdownMenuLabel className="text-xs font-normal text-muted-foreground px-2 py-1">
+              // fix(#585): submenu instead of a flat inline list — the group
+              // list grows unbounded with many groups and previously pushed
+              // Delete off-screen.
+              <DropdownMenuSub>
+                <DropdownMenuSubTrigger data-testid="kebab-add-to-group">
+                  <FolderPlus className="h-3.5 w-3.5 me-2" aria-hidden="true" />
                   {t('stackRow.kebabAddToGroup', { defaultValue: 'Add to group…' })}
-                </DropdownMenuLabel>
-                {(existingFolderGroups).map((g) => (
+                </DropdownMenuSubTrigger>
+                <DropdownMenuSubContent>
+                  {(existingFolderGroups).map((g) => (
+                    <DropdownMenuItem
+                      key={g.id}
+                      onSelect={() => onAddToGroup?.(layer.id, g.id)}
+                    >
+                      <Folder className="h-3.5 w-3.5 me-2" aria-hidden="true" />
+                      {g.name}
+                    </DropdownMenuItem>
+                  ))}
+                  {existingFolderGroups.length > 0 && <DropdownMenuSeparator />}
                   <DropdownMenuItem
-                    key={g.id}
-                    onSelect={() => onAddToGroup?.(layer.id, g.id)}
+                    className="text-primary"
+                    onSelect={() => onCreateGroupWithLayer?.(layer.id)}
                   >
-                    ▸ {g.name}
+                    <Plus className="h-3.5 w-3.5 me-2" aria-hidden="true" />
+                    {t('folderGroup.newGroupItem', { defaultValue: 'New group…' })}
                   </DropdownMenuItem>
-                ))}
-                <DropdownMenuItem
-                  className="text-primary"
-                  onSelect={() => onCreateGroupWithLayer?.(layer.id)}
-                >
-                  {t('folderGroup.newGroupItem', { defaultValue: '＋ New group…' })}
-                </DropdownMenuItem>
-              </>
+                </DropdownMenuSubContent>
+              </DropdownMenuSub>
             )}
           </DropdownMenuContent>
         </DropdownMenu>
       </div>
     </div>
 
-    {/* Inline alertdialog confirm — appears below the row when kebab Delete is clicked */}
+    {/* fix(#585): shared inline confirm — appears below the row when kebab Delete is clicked */}
     {confirmingDelete && (
-      // eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-noninteractive-element-interactions
-      <div
-        role="alertdialog"
-        aria-label={t('layerEditor.confirmDelete.message', { defaultValue: 'Are you sure? This cannot be undone.' })}
-        className="mx-2 mb-2 flex flex-col gap-2 p-3 bg-destructive/10 rounded-md"
-        onClick={(e) => e.stopPropagation()}
-      >
-        <p className="text-sm text-destructive">
-          {t('layerEditor.confirmDelete.message', { defaultValue: 'Are you sure? This cannot be undone.' })}
-        </p>
-        <div className="flex gap-2">
-          <Button
-            size="sm"
-            variant="destructive"
-            onClick={() => {
-              onRemove(layer.id);
-              setConfirmingDelete(false);
-            }}
-          >
-            {t('layerEditor.confirmDelete.delete', { defaultValue: 'Delete' })}
-          </Button>
-          <Button
-            size="sm"
-            variant="ghost"
-            onClick={() => setConfirmingDelete(false)}
-            // eslint-disable-next-line jsx-a11y/no-autofocus -- moves focus to safe action so Enter dismisses, not destroys (AUD-09)
-            autoFocus
-          >
-            {t('layerEditor.confirmDelete.keep', { defaultValue: 'Keep layer' })}
-          </Button>
-        </div>
-      </div>
+      <InlineDeleteConfirm
+        confirmId={`confirm-delete-${layer.id}`}
+        message={t('layerEditor.confirmDelete.message', { defaultValue: 'Are you sure? This cannot be undone.' })}
+        confirmLabel={t('layerEditor.confirmDelete.delete', { defaultValue: 'Delete' })}
+        cancelLabel={t('layerEditor.confirmDelete.keep', { defaultValue: 'Keep layer' })}
+        onConfirm={() => {
+          onRemove(layer.id);
+          setConfirmingDelete(false);
+        }}
+        onCancel={() => setConfirmingDelete(false)}
+      />
     )}
     </>
   );

--- a/frontend/src/components/builder/__tests__/BasemapGroupRow.test.tsx
+++ b/frontend/src/components/builder/__tests__/BasemapGroupRow.test.tsx
@@ -193,6 +193,23 @@ describe('BasemapGroupRow', () => {
     expect(onResetAppearance).toHaveBeenCalledOnce();
   });
 
+  // fix(#585): "Reset appearance" disables (with an inline reason) when the
+  // basemap has no appearance customizations to reset.
+  it('Test 7b: "Reset appearance" is disabled with a reason when hasCustomAppearance=false', () => {
+    const onResetAppearance = vi.fn();
+    render(
+      <BasemapGroupRow {...defaultProps({ onResetAppearance, hasCustomAppearance: false })} />,
+    );
+
+    fireEvent.pointerDown(screen.getByRole('button', { name: /options/i }), { button: 0, ctrlKey: false });
+    const resetItem = screen.getByTestId('basemap-reset-appearance');
+    expect(resetItem).toHaveAttribute('data-disabled');
+    expect(screen.getByText('Appearance is already at defaults')).toBeInTheDocument();
+
+    fireEvent.click(resetItem);
+    expect(onResetAppearance).not.toHaveBeenCalled();
+  });
+
   it('Test 8: row name renders "Basemap · {presetName}" with provider label at muted weight', () => {
     render(<BasemapGroupRow {...defaultProps({ presetName: 'Positron', providerLabel: 'OpenFreeMap' })} />);
 

--- a/frontend/src/components/builder/__tests__/MapTitleBar.test.tsx
+++ b/frontend/src/components/builder/__tests__/MapTitleBar.test.tsx
@@ -192,7 +192,10 @@ describe('MapTitleBar', () => {
 
     const downloadItem = await screen.findByRole('menuitem', { name: /Download PNG/i });
     const infoItem = screen.getByRole('menuitem', { name: /Map info/i });
-    const forkItem = screen.getByRole('menuitem', { name: /Duplicate map/i });
+    // fix(#585): while the fork is pending the item shows in-flight feedback —
+    // "Duplicating…" + spinner — instead of the idle "Duplicate map" label.
+    const forkItem = screen.getByRole('menuitem', { name: /Duplicating/i });
+    expect(forkItem.querySelector('.animate-spin')).not.toBeNull();
 
     expect(downloadItem).toBeInTheDocument();
     expect(infoItem).toBeInTheDocument();

--- a/frontend/src/components/builder/__tests__/StackRow.test.tsx
+++ b/frontend/src/components/builder/__tests__/StackRow.test.tsx
@@ -218,8 +218,8 @@ describe('StackRow', () => {
     expect(menuTexts).toContain('Rename layer');
     expect(menuTexts).toContain('Duplicate');
     expect(menuTexts).toContain('Delete layer');
-    // "＋ New group…" always appears (no existing groups in this test)
-    expect(menuTexts).toContain('＋ New group…');
+    // fix(#585): the group flow lives behind an "Add to group…" submenu trigger
+    expect(screen.getByTestId('kebab-add-to-group')).toBeInTheDocument();
 
     // Verify core order
     const renameIdx = menuTexts.indexOf('Rename layer');
@@ -281,15 +281,15 @@ describe('StackRow', () => {
     expect(onDuplicate).toHaveBeenCalledWith('dup-layer');
   });
 
-  it('"Add to group…" label and "＋ New group…" item appear when no existing groups', () => {
+  it('"Add to group…" submenu exposes "New group…" when no existing groups (#585)', () => {
     const layer = makeLayer({ id: 'group-layer' });
     render(<StackRow {...defaultProps({ layer, existingFolderGroups: [] })} />);
 
     fireEvent.pointerDown(screen.getByRole('button', { name: /Layer options for/i }), { button: 0, ctrlKey: false });
 
-    // The label "Add to group…" appears (DropdownMenuLabel)
-    expect(screen.getByText('Add to group…')).toBeInTheDocument();
-    // "＋ New group…" item appears as the only group option
+    // fix(#585): "Add to group…" is a submenu trigger; its content mounts on open
+    const subTrigger = screen.getByTestId('kebab-add-to-group');
+    fireEvent.click(subTrigger);
     expect(screen.getByRole('menuitem', { name: /New group/i })).toBeInTheDocument();
   });
 
@@ -492,8 +492,8 @@ describe('Add to group sub-flow', () => {
     };
   }
 
-  // Test 1: empty existing groups shows only "＋ New group…"
-  it('Test 1: shows only "＋ New group…" when existingFolderGroups is empty and parentGroupId is null', () => {
+  // Test 1: empty existing groups shows only "New group…"
+  it('Test 1: shows only "New group…" when existingFolderGroups is empty and parentGroupId is null', () => {
     const layer = makeLayer({ id: 'test-layer' });
     render(
       <StackRow
@@ -506,13 +506,13 @@ describe('Add to group sub-flow', () => {
 
     fireEvent.pointerDown(screen.getByRole('button', { name: /Layer options for/i }), { button: 0, ctrlKey: false });
 
-    // Label visible
-    expect(screen.getByText('Add to group…')).toBeInTheDocument();
-    // Only "＋ New group…" — no other group items
+    // fix(#585): open the "Add to group…" submenu first
+    fireEvent.click(screen.getByTestId('kebab-add-to-group'));
+    // Only "New group…" — no other group items
     const menuItems = screen.getAllByRole('menuitem').filter((i) => i.textContent?.includes('New group'));
     expect(menuItems).toHaveLength(1);
     // No group names present
-    expect(screen.queryByText('▸ Hydrology')).not.toBeInTheDocument();
+    expect(screen.queryByText('Hydrology')).not.toBeInTheDocument();
   });
 
   // Test 2: existing groups appear in sub-list
@@ -532,10 +532,12 @@ describe('Add to group sub-flow', () => {
 
     fireEvent.pointerDown(screen.getByRole('button', { name: /Layer options for/i }), { button: 0, ctrlKey: false });
 
+    // fix(#585): open the "Add to group…" submenu first
+    fireEvent.click(screen.getByTestId('kebab-add-to-group'));
     // Both groups appear
-    expect(screen.getByText('▸ Hydrology')).toBeInTheDocument();
-    expect(screen.getByText('▸ Transit')).toBeInTheDocument();
-    // "＋ New group…" also appears
+    expect(screen.getByText('Hydrology')).toBeInTheDocument();
+    expect(screen.getByText('Transit')).toBeInTheDocument();
+    // "New group…" also appears
     expect(screen.getByRole('menuitem', { name: /New group/i })).toBeInTheDocument();
   });
 
@@ -553,14 +555,16 @@ describe('Add to group sub-flow', () => {
     );
 
     fireEvent.pointerDown(screen.getByRole('button', { name: /Layer options for/i }), { button: 0, ctrlKey: false });
-    fireEvent.click(screen.getByText('▸ Hydrology'));
+    // fix(#585): open the "Add to group…" submenu first
+    fireEvent.click(screen.getByTestId('kebab-add-to-group'));
+    fireEvent.click(screen.getByText('Hydrology'));
 
     expect(onAddToGroup).toHaveBeenCalledOnce();
     expect(onAddToGroup).toHaveBeenCalledWith('test-layer', 'g1');
   });
 
-  // Test 4: clicking "＋ New group…" calls onCreateGroupWithLayer
-  it('Test 4: clicking "＋ New group…" calls onCreateGroupWithLayer(layerId)', () => {
+  // Test 4: clicking "New group…" calls onCreateGroupWithLayer
+  it('Test 4: clicking "New group…" calls onCreateGroupWithLayer(layerId)', () => {
     const layer = makeLayer({ id: 'new-group-layer' });
     const onCreateGroupWithLayer = vi.fn();
     render(
@@ -573,6 +577,8 @@ describe('Add to group sub-flow', () => {
     );
 
     fireEvent.pointerDown(screen.getByRole('button', { name: /Layer options for/i }), { button: 0, ctrlKey: false });
+    // fix(#585): open the "Add to group…" submenu first
+    fireEvent.click(screen.getByTestId('kebab-add-to-group'));
     fireEvent.click(screen.getByRole('menuitem', { name: /New group/i }));
 
     expect(onCreateGroupWithLayer).toHaveBeenCalledOnce();

--- a/frontend/src/components/builder/__tests__/StackRow.test.tsx
+++ b/frontend/src/components/builder/__tests__/StackRow.test.tsx
@@ -281,6 +281,20 @@ describe('StackRow', () => {
     expect(onDuplicate).toHaveBeenCalledWith('dup-layer');
   });
 
+  // fix(#585): the kebab links to the dataset detail page — new tab so the
+  // unsaved-changes guard never fires mid-edit.
+  it('kebab "Open dataset detail" is a new-tab link to /datasets/{dataset_id}', () => {
+    const layer = makeLayer({ id: 'link-layer', dataset_id: 'ds-42' });
+    render(<StackRow {...defaultProps({ layer })} />);
+
+    fireEvent.pointerDown(screen.getByRole('button', { name: /Layer options for/i }), { button: 0, ctrlKey: false });
+
+    const link = screen.getByTestId('kebab-view-dataset');
+    expect(link).toHaveAttribute('href', '/datasets/ds-42');
+    expect(link).toHaveAttribute('target', '_blank');
+    expect(link).toHaveAttribute('rel', 'noopener noreferrer');
+  });
+
   it('"Add to group…" submenu exposes "New group…" when no existing groups (#585)', () => {
     const layer = makeLayer({ id: 'group-layer' });
     render(<StackRow {...defaultProps({ layer, existingFolderGroups: [] })} />);

--- a/frontend/src/components/builder/__tests__/basemap-state-controller.test.ts
+++ b/frontend/src/components/builder/__tests__/basemap-state-controller.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import type { MapBasemapConfig, MapTerrainConfig } from '@/types/api';
 import {
   createBuilderBasemapState,
+  hasCustomBasemapAppearance,
   removeBasemap,
   resetBasemapAppearance,
   resetBasemapSublayer,
@@ -185,5 +186,53 @@ describe('basemap-state-controller', () => {
       source_dataset_id: null,
       exaggeration: 0,
     });
+  });
+});
+
+// fix(#585): "Reset appearance" enable signal — semantic comparison against
+// the default appearance, not a null check (stored configs are often
+// materialized all-defaults objects).
+describe('hasCustomBasemapAppearance', () => {
+  it('null / undefined config is NOT custom', () => {
+    expect(hasCustomBasemapAppearance(null, true)).toBe(false);
+    expect(hasCustomBasemapAppearance(undefined, true)).toBe(false);
+  });
+
+  it('a materialized all-defaults config is NOT custom', () => {
+    const stored = {
+      label_mode: 'full',
+      road_visibility: 'full',
+      boundary_visibility: 'full',
+      building_visibility: true,
+      land_water_tone: 'default',
+      relief_contrast: null,
+      opacity: 1,
+      background_color: null,
+      sublayer_overrides: null,
+      // The wire sends explicit nulls for these even though the TS type only
+      // allows undefined — keep them to exercise the real API shape.
+      basemap_position: null,
+      projection: null,
+    } as unknown as MapBasemapConfig;
+    expect(hasCustomBasemapAppearance(stored, true)).toBe(false);
+  });
+
+  it('a changed visibility field IS custom', () => {
+    expect(
+      hasCustomBasemapAppearance({ road_visibility: 'hidden' } as MapBasemapConfig, true),
+    ).toBe(true);
+  });
+
+  it('a non-default projection IS custom (reset would drop it)', () => {
+    expect(
+      hasCustomBasemapAppearance({ projection: 'globe' } as MapBasemapConfig, true),
+    ).toBe(true);
+  });
+
+  it('labels-hidden maps compare against the labels-hidden default (not custom)', () => {
+    expect(hasCustomBasemapAppearance(null, false)).toBe(false);
+    expect(
+      hasCustomBasemapAppearance({ label_mode: 'hidden' } as MapBasemapConfig, false),
+    ).toBe(false);
   });
 });

--- a/frontend/src/components/builder/__tests__/basemap-state-controller.test.ts
+++ b/frontend/src/components/builder/__tests__/basemap-state-controller.test.ts
@@ -229,6 +229,23 @@ describe('hasCustomBasemapAppearance', () => {
     ).toBe(true);
   });
 
+  // codex P2 on #654: explicit default-valued optional metadata is clean —
+  // dragging the basemap back to bottom writes basemap_position: 'bottom'.
+  it('explicit default position/projection values are NOT custom', () => {
+    expect(
+      hasCustomBasemapAppearance(
+        { basemap_position: 'bottom', projection: 'mercator' } as MapBasemapConfig,
+        true,
+      ),
+    ).toBe(false);
+  });
+
+  it('a non-default basemap position IS custom', () => {
+    expect(
+      hasCustomBasemapAppearance({ basemap_position: 'top' } as MapBasemapConfig, true),
+    ).toBe(true);
+  });
+
   it('labels-hidden maps compare against the labels-hidden default (not custom)', () => {
     expect(hasCustomBasemapAppearance(null, false)).toBe(false);
     expect(

--- a/frontend/src/components/builder/__tests__/basemap-state-controller.test.ts
+++ b/frontend/src/components/builder/__tests__/basemap-state-controller.test.ts
@@ -165,8 +165,10 @@ describe('basemap-state-controller', () => {
     });
   });
 
-  it('resets appearance by clearing local config so state re-normalizes to defaults', () => {
-    expect(resetBasemapAppearance()).toEqual({ basemapConfig: null });
+  it('resets appearance by clearing local config and restoring label visibility', () => {
+    // fix(#654, codex round 2): labels persist outside basemap_config, so the
+    // reset patch must set showBasemapLabels too or hidden labels survive it.
+    expect(resetBasemapAppearance()).toEqual({ basemapConfig: null, showBasemapLabels: true });
   });
 
   it('clamps terrain exaggeration for existing and new terrain configs', () => {
@@ -246,10 +248,12 @@ describe('hasCustomBasemapAppearance', () => {
     ).toBe(true);
   });
 
-  it('labels-hidden maps compare against the labels-hidden default (not custom)', () => {
-    expect(hasCustomBasemapAppearance(null, false)).toBe(false);
+  // fix(#654, codex round 2): reset restores label visibility, so hidden
+  // labels ARE a resettable customization — the baseline is labels-on.
+  it('hidden labels ARE custom (reset restores them)', () => {
+    expect(hasCustomBasemapAppearance(null, false)).toBe(true);
     expect(
       hasCustomBasemapAppearance({ label_mode: 'hidden' } as MapBasemapConfig, false),
-    ).toBe(false);
+    ).toBe(true);
   });
 });

--- a/frontend/src/components/builder/basemap-state-controller.ts
+++ b/frontend/src/components/builder/basemap-state-controller.ts
@@ -322,6 +322,28 @@ export function resetBasemapAppearance(): BuilderBasemapPatch {
   return { basemapConfig: null };
 }
 
+// fix(#585): true when resetting appearance (basemap_config → null) would
+// actually change the normalized config — the "Reset appearance" enable
+// signal. Stored configs are often materialized all-defaults objects, so a
+// non-null check alone reads every map as customized. Null-valued keys are
+// stripped before comparing because the normalizer includes optional keys
+// (e.g. sublayer_overrides: null) only when present on the input, and null
+// means "default" for every appearance field.
+// ponytail: an empty-but-present sublayer_overrides ({}) still reads as
+// custom — fails safe (Reset stays enabled), refine if it ever matters.
+export function hasCustomBasemapAppearance(
+  basemapConfig: MapBasemapConfig | null | undefined,
+  showBasemapLabels: boolean | null | undefined,
+): boolean {
+  const labels = showBasemapLabels ?? true;
+  const canonical = (config: MapBasemapConfig) =>
+    JSON.stringify(
+      Object.fromEntries(Object.entries(config).filter(([, v]) => v != null)),
+    );
+  return canonical(normalizedConfig(basemapConfig, labels))
+    !== canonical(normalizedConfig(null, labels));
+}
+
 export function setTerrainExaggeration(
   terrainConfig: MapTerrainConfig | null | undefined,
   value: number,

--- a/frontend/src/components/builder/basemap-state-controller.ts
+++ b/frontend/src/components/builder/basemap-state-controller.ts
@@ -336,9 +336,21 @@ export function hasCustomBasemapAppearance(
   showBasemapLabels: boolean | null | undefined,
 ): boolean {
   const labels = showBasemapLabels ?? true;
+  // codex P2 on #654: explicit default-valued optional metadata must read as
+  // clean too — dragging the basemap back to bottom writes basemap_position:
+  // 'bottom', and 'mercator' is the projection default; the null baseline
+  // omits both keys, so keeping them would flag an all-defaults map as custom.
+  const OPTIONAL_DEFAULTS: Record<string, unknown> = {
+    basemap_position: 'bottom',
+    projection: 'mercator',
+  };
   const canonical = (config: MapBasemapConfig) =>
     JSON.stringify(
-      Object.fromEntries(Object.entries(config).filter(([, v]) => v != null)),
+      Object.fromEntries(
+        Object.entries(config).filter(
+          ([k, v]) => v != null && OPTIONAL_DEFAULTS[k] !== v,
+        ),
+      ),
     );
   return canonical(normalizedConfig(basemapConfig, labels))
     !== canonical(normalizedConfig(null, labels));

--- a/frontend/src/components/builder/basemap-state-controller.ts
+++ b/frontend/src/components/builder/basemap-state-controller.ts
@@ -319,7 +319,12 @@ export function resetBasemapSublayer(
 }
 
 export function resetBasemapAppearance(): BuilderBasemapPatch {
-  return { basemapConfig: null };
+  // fix(#654, codex round 2): also restore label visibility. Labels are the
+  // one sublayer whose visibility persists outside basemap_config
+  // (showBasemapLabels), so clearing the config alone reset roads/buildings/
+  // boundaries but left labels hidden — inconsistent with the sibling eye
+  // toggles and with resetBasemapSublayer('basemap:labels').
+  return { basemapConfig: null, showBasemapLabels: true };
 }
 
 // fix(#585): true when resetting appearance (basemap_config → null) would
@@ -352,8 +357,12 @@ export function hasCustomBasemapAppearance(
         ),
       ),
     );
+  // fix(#654, codex round 2): the baseline is the TRUE default (labels on),
+  // not the current labels flag — reset restores label visibility, so a
+  // labels-only-hidden map must read as custom or Reset disables itself on
+  // exactly the state it exists to undo.
   return canonical(normalizedConfig(basemapConfig, labels))
-    !== canonical(normalizedConfig(null, labels));
+    !== canonical(normalizedConfig(null, true));
 }
 
 export function setTerrainExaggeration(

--- a/frontend/src/components/builder/row-chrome.tsx
+++ b/frontend/src/components/builder/row-chrome.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import type { FocusEvent, KeyboardEvent, MouseEvent } from 'react';
 import { GripVertical } from 'lucide-react';
 import type { DraggableAttributes, DraggableSyntheticListeners } from '@dnd-kit/core';
+import { Button } from '@/components/ui/button';
 import { cn } from '@/lib/utils';
 
 // builder-audit #338 STACK-04: shared 6-cell grid template for every stack row
@@ -113,5 +114,58 @@ export function DragGripButton({
     >
       <GripVertical className="h-3.5 w-3.5" aria-hidden="true" />
     </button>
+  );
+}
+
+// fix(#585): ONE inline delete-confirmation pattern for stack rows. StackRow
+// and FolderGroupRow previously rendered two visually different confirm boxes
+// for the same interaction; this is the single shared shape (destructive-tint
+// box, small buttons, cancel autofocused per AUD-09 so Enter dismisses rather
+// than destroys). BulkActionBar keeps its horizontal single-line variant — its
+// confirm lives INSIDE the fixed-height toolbar, not below a row.
+interface InlineDeleteConfirmProps {
+  /** ids the aria-labelledby / message paragraph; must be unique per row. */
+  confirmId: string;
+  message: string;
+  confirmLabel: string;
+  cancelLabel: string;
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+export function InlineDeleteConfirm({
+  confirmId,
+  message,
+  confirmLabel,
+  cancelLabel,
+  onConfirm,
+  onCancel,
+}: InlineDeleteConfirmProps) {
+  return (
+    // eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-noninteractive-element-interactions
+    <div
+      role="alertdialog"
+      aria-labelledby={confirmId}
+      className="mx-2 mb-2 flex flex-col gap-2 p-3 bg-destructive/10 rounded-md"
+      onClick={(e) => e.stopPropagation()}
+    >
+      <p id={confirmId} className="text-sm text-destructive">
+        {message}
+      </p>
+      <div className="flex gap-2">
+        <Button size="sm" variant="destructive" onClick={onConfirm}>
+          {confirmLabel}
+        </Button>
+        <Button
+          size="sm"
+          variant="ghost"
+          onClick={onCancel}
+          // eslint-disable-next-line jsx-a11y/no-autofocus -- focus on the safe action so Enter dismisses, not destroys (AUD-09)
+          autoFocus
+        >
+          {cancelLabel}
+        </Button>
+      </div>
+    </div>
   );
 }

--- a/frontend/src/components/builder/stack-types.ts
+++ b/frontend/src/components/builder/stack-types.ts
@@ -17,4 +17,6 @@ export interface BasemapGroupInfo {
   visible: boolean;
   opacity: number;
   sublayers: BasemapSublayerInfo[];
+  /** fix(#585): raw basemap_config is non-null → "Reset appearance" has work to do. */
+  hasCustomAppearance?: boolean;
 }

--- a/frontend/src/components/ui/dropdown-menu.tsx
+++ b/frontend/src/components/ui/dropdown-menu.tsx
@@ -233,7 +233,10 @@ function DropdownMenuSubContent({
     <DropdownMenuPrimitive.SubContent
       data-slot="dropdown-menu-sub-content"
       className={cn(
-        "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-hidden rounded-md border p-1 shadow-lg",
+        // fix(#585, codex P2): bound + scroll like DropdownMenuContent above —
+        // an unbounded submenu (e.g. many folder groups) grew past the viewport
+        // and made its lower items unreachable.
+        "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 max-h-(--radix-dropdown-menu-content-available-height) min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border p-1 shadow-lg",
         className
       )}
       {...props}

--- a/frontend/src/i18n/locales/de/builder.json
+++ b/frontend/src/i18n/locales/de/builder.json
@@ -832,6 +832,7 @@
     "mapInfo": "Karteninfo",
     "downloadPng": "PNG herunterladen",
     "duplicateMap": "Karte duplizieren",
+    "duplicatingMap": "Wird dupliziert…",
     "viewAsViewer": "Als Betrachter anzeigen",
     "save": "Speichern ({{shortcut}})",
     "collapseSidebar": "Seitenleiste einklappen",
@@ -1180,6 +1181,7 @@
     "railLabel": "Basiskarten-Gruppe",
     "removeBasemap": "Basiskarte entfernen",
     "resetAppearance": "Darstellung zurücksetzen",
+    "resetAppearanceHint": "Das Erscheinungsbild entspricht bereits den Standardwerten",
     "rowName": "Basiskarte · {{name}}",
     "sublayersSectionHint": "Auf einen Sublayer in der Seitenleiste klicken, um ihn einzeln zu gestalten.",
     "sublayersSectionLabel": "SUBLAYER",
@@ -1236,7 +1238,7 @@
     "deleteConfirmMessage": "Diese Gruppe und alle ihre Layer löschen?",
     "deleteConfirmAction": "Alle löschen",
     "deleteConfirmCancel": "Gruppe behalten",
-    "newGroupItem": "＋ Neue Gruppe…",
+    "newGroupItem": "Neue Gruppe…",
     "toggleExpand": "Ordnergruppe umschalten"
   },
   "layerEditor": {

--- a/frontend/src/i18n/locales/en/builder.json
+++ b/frontend/src/i18n/locales/en/builder.json
@@ -832,6 +832,7 @@
     "mapInfo": "Map info",
     "downloadPng": "Download PNG",
     "duplicateMap": "Duplicate map",
+    "duplicatingMap": "Duplicating…",
     "viewAsViewer": "View as viewer",
     "save": "Save ({{shortcut}})",
     "collapseSidebar": "Collapse sidebar",
@@ -1184,6 +1185,7 @@
     "railLabel": "Basemap group",
     "removeBasemap": "Remove basemap",
     "resetAppearance": "Reset appearance",
+    "resetAppearanceHint": "Appearance is already at defaults",
     "rowName": "Basemap · {{name}}",
     "sublayersSectionHint": "Click any sublayer in the sidebar to style it individually.",
     "sublayersSectionLabel": "SUBLAYERS",
@@ -1241,7 +1243,7 @@
     "deleteConfirmMessage": "Delete this group and all its layers?",
     "deleteConfirmAction": "Delete all",
     "deleteConfirmCancel": "Keep group",
-    "newGroupItem": "＋ New group…"
+    "newGroupItem": "New group…"
   },
   "layerEditor": {
     "close": "Close layer editor",

--- a/frontend/src/i18n/locales/es/builder.json
+++ b/frontend/src/i18n/locales/es/builder.json
@@ -832,6 +832,7 @@
     "mapInfo": "Info del mapa",
     "downloadPng": "Descargar PNG",
     "duplicateMap": "Duplicar mapa",
+    "duplicatingMap": "Duplicando…",
     "viewAsViewer": "Ver como visitante",
     "save": "Guardar ({{shortcut}})",
     "collapseSidebar": "Contraer barra lateral",
@@ -1180,6 +1181,7 @@
     "railLabel": "Grupo de mapa base",
     "removeBasemap": "Eliminar mapa base",
     "resetAppearance": "Restablecer apariencia",
+    "resetAppearanceHint": "La apariencia ya tiene los valores predeterminados",
     "rowName": "Mapa base · {{name}}",
     "sublayersSectionHint": "Haga clic en cualquier subcapa de la barra lateral para darle estilo individualmente.",
     "sublayersSectionLabel": "SUBCAPAS",
@@ -1236,7 +1238,7 @@
     "deleteConfirmMessage": "¿Eliminar este grupo y todas sus capas?",
     "deleteConfirmAction": "Eliminar todo",
     "deleteConfirmCancel": "Conservar grupo",
-    "newGroupItem": "＋ Nuevo grupo…",
+    "newGroupItem": "Nuevo grupo…",
     "toggleExpand": "Alternar grupo de carpetas"
   },
   "layerEditor": {

--- a/frontend/src/i18n/locales/fr/builder.json
+++ b/frontend/src/i18n/locales/fr/builder.json
@@ -832,6 +832,7 @@
     "mapInfo": "Info carte",
     "downloadPng": "Télécharger PNG",
     "duplicateMap": "Dupliquer la carte",
+    "duplicatingMap": "Duplication…",
     "viewAsViewer": "Afficher en tant que visiteur",
     "save": "Enregistrer ({{shortcut}})",
     "collapseSidebar": "Réduire le panneau latéral",
@@ -1180,6 +1181,7 @@
     "railLabel": "Groupe de fond de carte",
     "removeBasemap": "Supprimer le fond de carte",
     "resetAppearance": "Réinitialiser l'apparence",
+    "resetAppearanceHint": "L'apparence est déjà aux valeurs par défaut",
     "rowName": "Fond de carte · {{name}}",
     "sublayersSectionHint": "Cliquez sur une sous-couche dans la barre latérale pour la styliser individuellement.",
     "sublayersSectionLabel": "SOUS-COUCHES",
@@ -1236,7 +1238,7 @@
     "deleteConfirmMessage": "Supprimer ce groupe et toutes ses couches ?",
     "deleteConfirmAction": "Tout supprimer",
     "deleteConfirmCancel": "Conserver le groupe",
-    "newGroupItem": "＋ Nouveau groupe…",
+    "newGroupItem": "Nouveau groupe…",
     "toggleExpand": "Basculer le groupe de dossiers"
   },
   "layerEditor": {

--- a/frontend/src/pages/MapBuilderPage.tsx
+++ b/frontend/src/pages/MapBuilderPage.tsx
@@ -85,6 +85,7 @@ import { resolveTerrainSourceLayer } from '@/components/builder/map-stack';
 import { effectiveDemRenderMode } from '@/lib/dem-render-mode';
 import {
   createBuilderBasemapState,
+  hasCustomBasemapAppearance,
   removeBasemap as removeBasemapFromState,
   resetBasemapAppearance,
   resetBasemapSublayer,
@@ -560,6 +561,10 @@ export function MapBuilderPage() {
         visible: basemapVisible,
         opacity: basemapState.config.opacity ?? 1,
         sublayers: [],
+        // fix(#585): semantic comparison against the default appearance — the
+        // stored config is often a materialized all-defaults object, so a
+        // non-null check would read every map as customized.
+        hasCustomAppearance: hasCustomBasemapAppearance(layers.basemapConfig, layers.showBasemapLabels),
       };
     }
     // Derive preset name from the basemap id (label portion after last dash, capitalized)
@@ -577,8 +582,10 @@ export function MapBuilderPage() {
       visible: basemapVisible,
       opacity: basemapState.config.opacity ?? 1,
       sublayers: basemapState.sublayers,
+      // fix(#585): see the no-basemap branch above.
+      hasCustomAppearance: hasCustomBasemapAppearance(layers.basemapConfig, layers.showBasemapLabels),
     };
-  }, [basemapState, basemapVisible, t]);
+  }, [basemapState, basemapVisible, layers.basemapConfig, layers.showBasemapLabels, t]);
 
   const isBasemapExpanded = layers.groupMeta?.['basemap-group']?.expanded ?? false;
 


### PR DESCRIPTION
## What

Second and final slice of the #585 builder contextual-menu audit (slice 1 = #639). Covers findings 4–8:

- **(4) Consistent icons** in every row kebab: StackRow (Rename/Duplicate/Delete + group flow), FolderGroupRow (all four items), BasemapGroupRow (Swap/Reset). The hardcoded `▸`/`＋` glyphs are gone (the `＋` was baked into the `folderGroup.newGroupItem` translation — value updated in all four locales).
- **(5) "Add to group…" is a `DropdownMenuSub`** instead of a flat inline list that grew unbounded with many groups and pushed Delete off-screen. Groups get a Folder icon, "New group…" a Plus.
- **(6) "Reset appearance" dirty-gate**: disabled with an inline reason ("Appearance is already at defaults") when resetting would change nothing. The signal is a **semantic comparison against the default appearance** (`hasCustomBasemapAppearance` in basemap-state-controller) — stored configs are often materialized all-defaults objects, so the obvious `basemap_config != null` check reads every map as customized (found live: every seeded map had a non-null all-defaults config).
- **(7) One inline delete-confirm pattern**: shared `InlineDeleteConfirm` in row-chrome replaces the two divergent boxes in StackRow (destructive-tint) and FolderGroupRow (popover-bordered, full-width buttons). Per-caller labels stay ("Delete/Keep layer" vs "Delete all/Keep group"). BulkActionBar keeps its horizontal variant — its confirm lives inside the fixed-height toolbar, not below a row.
- **(8) Duplicate-map in-flight feedback**: the overflow item shows a spinner + "Duplicating…" while the fork mutation is pending (was disabled-only with no visible signal until the settle toast).

Closes #585.

## i18n

New keys `basemapGroup.resetAppearanceHint`, `tooltips.duplicatingMap`; value change for `folderGroup.newGroupItem` — all four locales (en/es/fr/de), parity gate green.

## Verification

- `npx vitest run src/components/builder src/pages` — 1,370 + 75 tests pass (new: submenu flow ×5 reworked, reset-gate disabled state, fork-pending label+spinner, `hasCustomBasemapAppearance` ×5).
- `npm run typecheck`, `npm run test:i18n`, eslint on all changed files — clean.
- **Live in the local builder** (Restless Earth + Earthquakes maps): every kebab item renders an icon; "Add to group…" opens a real submenu; Reset appearance is disabled+hinted on an all-defaults map and enables after hiding a basemap sublayer; the delete confirm shows the unified destructive-tint box and Keep dismisses without deleting.

https://claude.ai/code/session_01EJ3PZWCqfT3zCPQDCVuVUk