### PR TITLE
fix(observability): zero stale job-queue gauges when a queue drains (#655)

### DIFF
--- a/backend/app/observability/metrics/jobs.py
+++ b/backend/app/observability/metrics/jobs.py
@@ -37,8 +37,15 @@ jobs_failed_total = Counter(
     ["queue"],
 )
 
-# Track previous snapshot for counter delta computation
+# Track previous snapshot for counter delta computation.
+# NOTE(#655): on the first cycle after boot this is empty, so the counters seed
+# with the full historical procrastinate_jobs row counts — raw counter values
+# include pre-boot history. increase()/rate() queries are unaffected.
 _prev_counts: dict[tuple[str, str], int] = {}
+
+# Queues whose gauge children have been set at least once — zeroed (not
+# removed) when their todo/doing rows disappear from a cycle. fix(#655)
+_known_queues: set[str] = set()
 
 
 async def _refresh_job_metrics() -> None:
@@ -60,8 +67,8 @@ async def _refresh_job_metrics() -> None:
             )
             rows = result.fetchall()
 
-        # Reset gauges to zero before setting — handles queues that disappear
-        # We track which (queue, status) combos we see this cycle
+        # Queues absent from this cycle get zeroed after the loop via
+        # _known_queues, so a drained queue reads 0 instead of its last value
         seen_todo: set[str] = set()
         seen_doing: set[str] = set()
 
@@ -88,6 +95,14 @@ async def _refresh_job_metrics() -> None:
                 if delta > 0:
                     jobs_failed_total.labels(queue=q).inc(delta)
                 _prev_counts[key] = count
+
+        # fix(#655): zero gauges for previously seen queues with no todo/doing
+        # rows this cycle — they used to freeze at their last non-zero value
+        for q in _known_queues - seen_todo:
+            jobs_queue_depth.labels(queue=q).set(0)
+        for q in _known_queues - seen_doing:
+            jobs_active.labels(queue=q).set(0)
+        _known_queues.update(seen_todo, seen_doing)
 
     except Exception:  # broad: metrics refresh is non-fatal; DB/aggregation errors should not crash background loop
         logger.warning("Failed to refresh job metrics", exc_info=True)

--- a/backend/tests/test_metrics.py
+++ b/backend/tests/test_metrics.py
@@ -70,6 +70,33 @@ async def test_refresh_job_metrics_handles_db_error():
         await _refresh_job_metrics()
 
 
+def _mock_engine_returning(rows):
+    result = MagicMock()
+    result.fetchall.return_value = rows
+    mock_conn = MagicMock()
+    mock_conn.execute = AsyncMock(return_value=result)
+    mock_conn.__aenter__ = AsyncMock(return_value=mock_conn)
+    mock_conn.__aexit__ = AsyncMock(return_value=False)
+    mock_engine = MagicMock()
+    mock_engine.connect = MagicMock(return_value=mock_conn)
+    return mock_engine
+
+
+@pytest.mark.asyncio
+async def test_refresh_job_metrics_zeroes_drained_queues():
+    """fix(#655): a queue whose todo/doing rows vanish reads 0, not its last value."""
+    rows = [("todo", "q655", 7), ("doing", "q655", 2)]
+    with patch("app.core.db.engine", _mock_engine_returning(rows)):
+        await _refresh_job_metrics()
+    assert jobs_queue_depth.labels(queue="q655")._value.get() == 7.0
+    assert jobs_active.labels(queue="q655")._value.get() == 2.0
+
+    with patch("app.core.db.engine", _mock_engine_returning([])):
+        await _refresh_job_metrics()
+    assert jobs_queue_depth.labels(queue="q655")._value.get() == 0.0
+    assert jobs_active.labels(queue="q655")._value.get() == 0.0
+
+
 @pytest.mark.asyncio
 async def test_refresh_pool_metrics_skips_non_queuepool():
     """Pool metrics collector skips when pool is not QueuePool."""


### PR DESCRIPTION
## Summary

Fixes #655. `_refresh_job_metrics` built `seen_todo`/`seen_doing` sets for a gauge reset that was never implemented — a queue whose `todo`/`doing` rows vanished between refresh cycles (bulk cancel, row deletion) froze at its last non-zero value forever, which can false-fire the `GeoLensJobQueueBacklog` reference alert and show phantom backlog on dashboards until the worker restarts.

The fix tracks queue labels ever set (`_known_queues`) and zeroes any queue absent from the current cycle's rows. Zero, not remove: the series stays exported so `or vector(0)` dashboard fallbacks and `increase()` alerts keep working.

Also adds the code comment requested in the issue's related observation: on the first post-boot cycle `_prev_counts` is empty, so the completed/failed counters seed with full historical row counts — raw values include pre-boot history; `increase()`/`rate()` are unaffected.

No schema/API/config impact.

## Verification

- `cd backend && uv run pytest tests/test_metrics.py -v` — 6 passed, including the new `test_refresh_job_metrics_zeroes_drained_queues` (populated cycle → drained cycle → gauges read 0)
- `uv run pytest tests/test_layering.py -q` — 29 passed
- `uv run ruff check . && uv run ruff format --check .` — clean

https://claude.ai/code/session_01EJ3PZWCqfT3zCPQDCVuVUk