### PR TITLE
build(sdks): pin post-hook ruff in the SDK generator env

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -143,7 +143,10 @@ sdks:
 	-cp sdks/python/geolens/__init__.py /tmp/_geolens_init.py 2>/dev/null
 	-cp sdks/typescript/src/auth.ts /tmp/_geolens_auth.ts 2>/dev/null
 	-cp sdks/typescript/src/index.ts /tmp/_geolens_index.ts 2>/dev/null
-	uvx openapi-python-client@0.28.3 generate \
+	# Post-hook ruff is pinned to the backend's version (keep in sync with
+	# backend uv.lock): left unpinned, the ruff 0.16.0 release (2026-07)
+	# rewrote generated output and broke `make sdks-check` on every PR.
+	uvx --with "ruff==0.15.21" openapi-python-client@0.28.3 generate \
 	  --path /tmp/openapi-flat.json \
 	  --output-path sdks/python/geolens \
 	  --overwrite --meta none \


### PR DESCRIPTION
## Summary

The SDKs Drift Gate started failing on every backend-touching PR today (first seen on #656, a change with zero API surface impact). Root cause: `make sdks` runs `uvx openapi-python-client@0.28.3`, whose `post_hooks` (`ruff check --fix-only` / `ruff format`) execute whatever ruff uvx resolves into the generator env. The ruff **0.16.0** release rewrote generated output (`from_dict(cls: type[T]) -> T` → `-> Self`, typing-import reordering) — 723 generated Python SDK files drift with no source change. The committed SDKs date from 2026-06-03; TypeScript output is unaffected.

Fix: pin the generator env's ruff to the backend's own version (`--with "ruff==0.15.21"`), with a Makefile comment to keep it in sync with backend `uv.lock`. Generator output now only changes when we change an input.

No schema/API/config impact; no generated files change in this PR.

## Verification

- Before: `make sdks-check` → 723 modified files under `sdks/python/`, exit 1 (reproduces the CI failure on #656)
- After: `make sdks-check` → clean, zero drift
- `uvx --from openapi-python-client@0.28.3 ruff --version` → 0.16.0 (unpinned resolve); backend `uv run ruff --version` → 0.15.21

https://claude.ai/code/session_01EJ3PZWCqfT3zCPQDCVuVUk