### PR TITLE
fix(observability): split the p95 latency alert into interactive vs tile rules

### DIFF
--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -312,7 +312,8 @@ targets just need network reach to `api:8000` and `worker:8001`.
 |---|---|---|
 | `GeoLensTargetDown` | API or worker unscrapeable for >2m | critical |
 | `GeoLensApiHigh5xxRate` | 5xx share of requests >5% over 5m | critical |
-| `GeoLensApiHighLatencyP95` | p95 request latency >1s, sustained 10m | warning |
+| `GeoLensApiInteractiveLatencyP95` | non-tile p95 at the 1s histogram ceiling for 10m | warning |
+| `GeoLensApiTileLatencyMean` | mean `/tiles/*` latency >2s for 10m | warning |
 | `GeoLensJobQueueBacklog` | any queue >100 jobs for 15m | warning |
 | `GeoLensJobFailures` | >5 job failures in 15m | warning |
 | `GeoLensDbPoolSaturated` | connection-pool overflow in use for >10m | warning |

--- a/infra/monitoring/alerts.yml
+++ b/infra/monitoring/alerts.yml
@@ -40,22 +40,45 @@ groups:
             {{ $value | humanizePercentage }} of API requests returned 5xx over
             the last 5 minutes.
 
-      - alert: GeoLensApiHighLatencyP95
-        # fix(#466): use the HIGH-resolution histogram. The default
-        # http_request_duration_seconds tops out at le=1.0 (then +Inf), so
-        # histogram_quantile caps at 1.0 and `> 1` could never fire; the highr
-        # histogram has buckets out to 60s. No status label on either → group by le.
+      - alert: GeoLensApiInteractiveLatencyP95
+        # fix(#658): replaces the all-handler p95 alert (#466), which fired
+        # during plain map browsing — tile requests are the legitimate slow
+        # tail, so they get their own rule below. Excluding a handler forces
+        # the handler-labeled histogram, whose buckets top out at le=1.0, so
+        # histogram_quantile clips at 1.0 and `>= 1` is the only expressible
+        # "worse than 1s" predicate (`> 1` could never fire).
         expr: |
           histogram_quantile(0.95,
-            sum by (le) (rate(http_request_duration_highr_seconds_bucket[5m]))) > 1
+            sum by (le) (rate(http_request_duration_seconds_bucket{handler!~"/tiles/.*"}[5m]))) >= 1
         for: 10m
         labels:
           severity: warning
         annotations:
-          summary: "API p95 latency above 1s"
+          summary: "API p95 latency (non-tile) at or above 1s"
           description: >-
-            95th-percentile request latency is {{ $value | humanizeDuration }}
-            (sustained over 10 minutes).
+            95th-percentile latency of non-tile API requests has been at the
+            1s histogram ceiling for 10 minutes. Tile endpoints are excluded;
+            see GeoLensApiTileLatencyMean.
+
+      - alert: GeoLensApiTileLatencyMean
+        # fix(#658): tile p95 is unreadable from the handler-labeled histogram
+        # (clips at 1s), so alert on the exact mean from _sum/_count instead.
+        # Active map browsing keeps the mean well under 1s even while p95 sits
+        # at the ceiling; a sustained mean above 2s means tiles are genuinely
+        # grinding (raster-proxy incidents run 2.2-2.6s/tile, cf. #643).
+        # With no tile traffic the ratio is 0/0 = NaN, which never compares true.
+        expr: |
+          sum(rate(http_request_duration_seconds_sum{handler=~"/tiles/.*"}[10m]))
+            / sum(rate(http_request_duration_seconds_count{handler=~"/tiles/.*"}[10m])) > 2
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Mean tile latency above 2s"
+          description: >-
+            Requests under /tiles/ have averaged {{ $value | humanizeDuration }}
+            over the last 10 minutes — vector-tile queries or the raster proxy
+            are grinding.
 
   - name: geolens-jobs
     rules:


### PR DESCRIPTION
## Summary

Dogfooding the reference monitoring config on the demo VM: within 35 minutes of wiring alert delivery, `GeoLensApiHighLatencyP95` fired during plain map browsing. A visitor panning the NYC showcase map at ~2.2 tile-req/s pushed **global** p95 to 1.4s while non-tile p95 sat at 0.35s and host load at 0.13 — the alert paged on the product working as intended, because the label-less `highr` histogram can't exclude the legitimately slow tile tail.

Replaced with two rules in `infra/monitoring/alerts.yml`:

- **`GeoLensApiInteractiveLatencyP95`** — p95 of non-`/tiles/` handlers `>= 1` for 10m. Excluding a handler forces the handler-labeled histogram, whose buckets top out at `le=1.0`, so `histogram_quantile` clips at 1.0 and `>= 1` is the only expressible "worse than 1s" predicate (same bucket-ceiling reasoning as the #466 fix this replaces).
- **`GeoLensApiTileLatencyMean`** — exact mean from `_sum`/`_count` over `/tiles/*` `> 2s` for 10m. Means don't clip, active browsing keeps the mean well under 1s, and 2s+ sustained is genuine grinding (#643's raster-proxy incident ran 2.2–2.6s/tile). No traffic → 0/0 = NaN → never fires.

All tile serving (vector `.pbf` + raster proxy) lives under the single `/tiles` router prefix, so one regex covers it. RUNBOOK §4 alert table updated.

No schema/API impact; config + docs only.

## Verification

- `promtool check rules` — 7 rules OK
- Deployed live to the demo VM (which dogfoods this file verbatim): all 12 rules `health=ok`, the old alert cleared, neither new rule fires under the active tile-browsing session that false-fired the old one
- prom-guard healthchecks integration recovers on the next clean 15-min cycle

https://claude.ai/code/session_01EJ3PZWCqfT3zCPQDCVuVUk