### PR TITLE
fix(api): bounded uvicorn worker recycling via UVICORN_MAX_REQUESTS (#643)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -248,6 +248,12 @@ GEOLENS_ADMIN_PASSWORD=
 # Type: integer | Default: 30
 # UVICORN_TIMEOUT_GRACEFUL_SHUTDOWN=30
 
+# fix(#643): recycle each API worker after this many requests — a graceful exit +
+# supervisor respawn, so slow memory growth can't ride a worker into the container
+# memory cap. Leave empty to disable; must be a positive integer (0 is invalid).
+# Type: integer (minimum 1) or empty | Default: 10000 (prod compose)
+# UVICORN_MAX_REQUESTS=10000
+
 # --- Configuration Lockdown ---
 # [OPTIONAL] When true, all admin-overridable settings are locked to their
 # environment values. The PersistentConfig DB layer is bypassed for reads and

--- a/Dockerfile
+++ b/Dockerfile
@@ -170,7 +170,7 @@ HEALTHCHECK --interval=10s --timeout=5s --start-period=20s --retries=3 \
 USER appuser
 
 ENTRYPOINT ["/app/scripts/api-entrypoint.sh"]
-CMD ["sh", "-c", "uv run --no-dev uvicorn app.api.main:app --host 0.0.0.0 --port 8000 --workers ${UVICORN_WORKERS:-1} --timeout-keep-alive ${UVICORN_TIMEOUT_KEEP_ALIVE:-5} --timeout-graceful-shutdown ${UVICORN_TIMEOUT_GRACEFUL_SHUTDOWN:-30}"]
+CMD ["sh", "-c", "uv run --no-dev uvicorn app.api.main:app --host 0.0.0.0 --port 8000 --workers ${UVICORN_WORKERS:-1} --timeout-keep-alive ${UVICORN_TIMEOUT_KEEP_ALIVE:-5} --timeout-graceful-shutdown ${UVICORN_TIMEOUT_GRACEFUL_SHUTDOWN:-30} ${UVICORN_MAX_REQUESTS:+--limit-max-requests ${UVICORN_MAX_REQUESTS}}"]
 
 FROM backend-base AS worker
 

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -230,12 +230,17 @@ services:
     # X-Forwarded-For with $remote_addr at the internet-facing edge (see
     # frontend/nginx.conf). The header is injected at that public edge, so a
     # client could otherwise forge the leftmost value uvicorn trusts.
+    # fix(#643): bounded worker recycling — a worker gracefully exits after
+    # UVICORN_MAX_REQUESTS requests and the uvicorn supervisor respawns it, so
+    # slow memory growth can't ride one worker into the cgroup OOM killer.
+    # Unset/empty disables; the value must be a positive integer.
     command: >
       sh -c "uv run --no-dev uvicorn app.api.main:app
       --host 0.0.0.0 --port 8000
       --workers $${UVICORN_WORKERS:-2}
       --timeout-keep-alive $${UVICORN_TIMEOUT_KEEP_ALIVE:-5}
       --timeout-graceful-shutdown $${UVICORN_TIMEOUT_GRACEFUL_SHUTDOWN:-30}
+      $${UVICORN_MAX_REQUESTS:+--limit-max-requests $${UVICORN_MAX_REQUESTS}}
       --proxy-headers --forwarded-allow-ips='*'"
     user: "0:0"
     init: true
@@ -262,6 +267,8 @@ services:
       UVICORN_WORKERS: "${UVICORN_WORKERS:-2}"
       UVICORN_TIMEOUT_KEEP_ALIVE: "${UVICORN_TIMEOUT_KEEP_ALIVE:-5}"
       UVICORN_TIMEOUT_GRACEFUL_SHUTDOWN: "${UVICORN_TIMEOUT_GRACEFUL_SHUTDOWN:-30}"
+      # fix(#643): recycle each worker after this many requests (empty disables).
+      UVICORN_MAX_REQUESTS: "${UVICORN_MAX_REQUESTS:-10000}"
       PUBLIC_APP_URL: ${PUBLIC_APP_URL:-http://localhost:8080}
       PUBLIC_API_URL: ${PUBLIC_API_URL:-http://localhost:8080/api}
       PUBLIC_BASE_URL: ${PUBLIC_BASE_URL:-}


### PR DESCRIPTION
## What

Adds the recycling backstop from #643: each API uvicorn worker now gracefully exits after `UVICORN_MAX_REQUESTS` requests and is respawned by uvicorn's multiprocess supervisor (verified respawn-on-clean-exit in the pinned uvicorn 0.42.0), so slow memory growth can no longer ride a single worker into the 2 GiB cgroup OOM killer.

- **Dockerfile CMD**: appends `${UVICORN_MAX_REQUESTS:+--limit-max-requests …}` — unset/empty means disabled, so a bare image run is byte-for-byte unchanged behavior.
- **docker-compose.prod.yml**: same conditional in the api command override, plus env passthrough defaulting to **10000** (≈ daily recycle per worker at current demo traffic; much sooner during heavy tile sessions, which is when #643 struck).
- Dev compose untouched (`--reload`, single worker).

Root cause of #643 stays open — this is the backstop recommended there (item 3), complementing the #650 RSS watermark observability.

## Config impact

New operator knob `UVICORN_MAX_REQUESTS` (prod compose default 10000; empty disables; must be a positive integer — 0 is not a valid disable value).

## Verification

- Live smoke on uvicorn 0.42.0: `--workers 2 --limit-max-requests 5`, 24 sequential requests → **24/24 HTTP 200** across two full recycle cycles; log shows graceful `Maximum request limit of 5 exceeded → Shutting down → Child process died → Started server process` for both workers with zero dropped requests.
- `sh` expansion check: unset → no flag; empty → no flag; `10000` → `--limit-max-requests 10000`.
- `docker compose -f docker-compose.prod.yml config` renders the folded command as a single line with the conditional intact.

Closes nothing — #643 remains open for root cause; recycling decision item can be checked off.