### PR TITLE
chore(trust): release-polish batch — STAC hardening + stac-api-validator gate, GHCR image.source

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1475,6 +1475,7 @@ jobs:
   #                                                  workflow_run on "Prod Compose Smoke"
   # pull_request                                  → NO browser jobs; per-PR Actions budget = 0
   # push(main) + nightly + dispatch               → accessibility (axe + keyboard-nav, below)
+  # push(main) + nightly + dispatch               → stac-validate (stac-api-validator, below)
   accessibility:
     name: Accessibility (axe + keyboard-nav)
     # always() so this still evaluates when the needed jobs are SKIPPED on
@@ -1539,6 +1540,74 @@ jobs:
           name: accessibility-playwright-report
           path: playwright-report/
           retention-days: 14
+
+      - name: Docker Compose logs
+        if: failure()
+        run: docker compose logs --tail=200
+
+      - name: Stop services
+        if: always()
+        run: docker compose down
+
+  stac-validate:
+    name: STAC API conformance (stac-api-validator)
+    # Same trigger/guard shape as the accessibility job above: force-run on
+    # push(main), evaluate on schedule/dispatch despite skipped needs, and stay
+    # off PRs (per-PR Actions budget = 0).
+    if: >-
+      always()
+      && (github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')
+      && !contains(needs.*.result, 'failure')
+      && !contains(needs.*.result, 'cancelled')
+    runs-on: ubuntu-latest
+    needs: [backend-lint, backend-test, pytest-parallel-isolation, frontend-lint, frontend-test, security-scan]
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+
+      - name: Create .env file
+        run: |
+          cp .env.example .env
+          sed -i -E 's|^POSTGRES_PASSWORD=.*|POSTGRES_PASSWORD=geolens_dev|' .env
+          sed -i -E 's|^JWT_SECRET_KEY=.*|JWT_SECRET_KEY=e2e-test-secret-key-padding-32chars-min|' .env
+          sed -i -E 's|^GEOLENS_ADMIN_PASSWORD=.*|GEOLENS_ADMIN_PASSWORD=geolens-ci-admin-password|' .env
+          echo "DATABASE_SSL_MODE=disable" >> .env
+
+      - name: Start services
+        run: docker compose up -d --wait --wait-timeout 120
+
+      - name: Seed STAC fixture
+        id: seed
+        # -u 1001 + a tmpfs uv cache: the hardened api container is read-only
+        # and `docker compose exec` defaults to root, whose cache dir is not
+        # writable.
+        run: |
+          out=$(docker compose exec -T -u 1001:1001 -e UV_CACHE_DIR=/tmp/uv-cache api \
+            uv run --no-dev python /app/backend/scripts/seed_stac_ci.py)
+          echo "$out"
+          echo "collection_id=$(echo "$out" | sed -n 's/^collection_id=//p')" >> "$GITHUB_OUTPUT"
+
+      - name: Raise the global rate limit for the validator burst
+        # stac-api-validator fires hundreds of requests back-to-back; the
+        # 60 req/s default turns the tail of the run into 429 noise.
+        run: |
+          token=$(curl -sf -X POST http://localhost:8080/api/auth/login \
+            -H 'Content-Type: application/x-www-form-urlencoded' \
+            --data 'username=admin&password=geolens-ci-admin-password' \
+            | python3 -c 'import json,sys; print(json.load(sys.stdin)["access_token"])')
+          curl -sf -X PUT http://localhost:8080/api/settings/ \
+            -H "Authorization: Bearer $token" -H 'Content-Type: application/json' \
+            -d '{"settings":{"global_rate_limit":500}}' -o /dev/null
+
+      - name: Run stac-api-validator
+        run: |
+          pipx run stac-api-validator==0.6.8 \
+            --root-url http://localhost:8080/api/stac/ \
+            --conformance core \
+            --conformance collections \
+            --conformance item-search \
+            --collection "${{ steps.seed.outputs.collection_id }}" \
+            --geometry '{"type": "Polygon", "coordinates": [[[-105, 39], [-104, 39], [-104, 40], [-105, 40], [-105, 39]]]}'
 
       - name: Docker Compose logs
         if: failure()

--- a/Dockerfile
+++ b/Dockerfile
@@ -163,6 +163,7 @@ FROM backend-base AS api
 LABEL org.opencontainers.image.title="geolens-api"
 LABEL org.opencontainers.image.description="PostGIS-native GIS data catalog API"
 LABEL org.opencontainers.image.licenses="Apache-2.0"
+LABEL org.opencontainers.image.source="https://github.com/geolens-io/geolens"
 
 HEALTHCHECK --interval=10s --timeout=5s --start-period=20s --retries=3 \
   CMD python -c "import urllib.request; urllib.request.urlopen('http://localhost:8000/health')"
@@ -177,6 +178,7 @@ FROM backend-base AS worker
 LABEL org.opencontainers.image.title="geolens-worker"
 LABEL org.opencontainers.image.description="PostGIS-native GIS data catalog worker"
 LABEL org.opencontainers.image.licenses="Apache-2.0"
+LABEL org.opencontainers.image.source="https://github.com/geolens-io/geolens"
 
 HEALTHCHECK --interval=10s --timeout=5s --start-period=10s --retries=3 \
   CMD python -c "import urllib.request; urllib.request.urlopen('http://localhost:8001/health/live')"
@@ -207,6 +209,7 @@ FROM postgres:17@sha256:a426e44bac0b759c95894d68e1a0ac03ecc20b619f498a91aae373bf
 LABEL org.opencontainers.image.title="geolens-backup"
 LABEL org.opencontainers.image.description="Automated pg_dump backup service with S3 offload"
 LABEL org.opencontainers.image.licenses="Apache-2.0"
+LABEL org.opencontainers.image.source="https://github.com/geolens-io/geolens"
 
 # awscli (SigV4-capable S3 client) for the BKP-02 S3 upload path; procps for the
 # compose healthcheck (`pgrep -f backup-entrypoint || pgrep -f sleep`) — pgrep is
@@ -282,6 +285,7 @@ FROM nginxinc/nginx-unprivileged:1.31.3-alpine AS frontend
 LABEL org.opencontainers.image.title="geolens-frontend"
 LABEL org.opencontainers.image.description="PostGIS-native GIS data catalog frontend"
 LABEL org.opencontainers.image.licenses="Apache-2.0"
+LABEL org.opencontainers.image.source="https://github.com/geolens-io/geolens"
 
 USER root
 RUN apk upgrade --no-cache

--- a/backend/app/standards/stac/router.py
+++ b/backend/app/standards/stac/router.py
@@ -10,9 +10,10 @@ from __future__ import annotations
 import asyncio
 import json
 import math
+import re
 import uuid
 from collections.abc import Sequence
-from datetime import timedelta
+from datetime import datetime, timedelta
 
 from urllib.parse import urlencode
 
@@ -144,7 +145,9 @@ def _item_collection_response(result: StacItemCollection) -> Response:
     headers = _stac_content_language_headers(result.features)
     if link_value := link_header_value(result.links):
         headers["Link"] = link_value
-    payload = result.model_dump(mode="json")
+    # exclude_none: optional StacLink fields (method, title) must be omitted,
+    # not null — the STAC link schema requires `method` to match ^[A-Z]+$.
+    payload = result.model_dump(mode="json", exclude_none=True)
     # Validation must not add optional fields that the item serializer omitted.
     payload["features"] = [
         feature.model_dump(mode="json", exclude_unset=True)
@@ -169,8 +172,8 @@ def _stac_page_url(
 
 def _parse_extent_row(
     ext_row: tuple | None,
-) -> tuple[list[float] | None, list[str | None] | None]:
-    """Parse a spatial/temporal extent DB row into STAC-ready values."""
+) -> tuple[list[float] | None, list[str | None] | None, str | None]:
+    """Parse a spatial/temporal extent + license DB row into STAC-ready values."""
     spatial_extent = None
     temporal_extent = None
     if ext_row and ext_row[0] is not None:
@@ -184,7 +187,16 @@ def _parse_extent_row(
         t_start = ext_row[4].isoformat() + "T00:00:00Z" if ext_row[4] else None
         t_end = ext_row[5].isoformat() + "T00:00:00Z" if ext_row[5] else None
         temporal_extent = [t_start, t_end]
-    return spatial_extent, temporal_extent
+    license = _collapse_licenses(ext_row[6]) if ext_row else None
+    return spatial_extent, temporal_extent, license
+
+
+def _collapse_licenses(values: list[str | None] | None) -> str | None:
+    """Collapse member-record licenses into one STAC Collection license."""
+    licenses = {v for v in (values or []) if v}
+    if not licenses:
+        return None
+    return licenses.pop() if len(licenses) == 1 else "various"
 
 
 async def _fetch_dataset_asset_rows(
@@ -313,6 +325,71 @@ def _require_finite_bbox(values: list[float]) -> None:
     for i, v in enumerate(values):
         if not math.isfinite(v):
             raise ValueError(f"bbox coordinate at index {i} is non-finite ({v!r})")
+    # South > north is always invalid; longitude order is NOT checked because
+    # west > east legitimately means an antimeridian-crossing box.
+    south, north = (
+        (values[1], values[3]) if len(values) == 4 else (values[1], values[4])
+    )
+    if south > north:
+        raise ValueError("bbox south latitude is greater than north latitude")
+
+
+# RFC 3339 date-time as required by the STAC API spec: full date + time with a
+# Z or numeric UTC offset. The shared parse_ogc_datetime is deliberately more
+# lenient (day-granular, bare dates), so STAC validates syntax first.
+_RFC3339_DATETIME_RE = re.compile(
+    r"^\d{4}-\d{2}-\d{2}[Tt]\d{2}:\d{2}:\d{2}(\.\d+)?([Zz]|[+-]\d{2}:\d{2})$"
+)
+
+
+def _validate_stac_datetime(datetime_str: str) -> str:
+    """Enforce STAC's strict RFC 3339 datetime syntax, returning a normalized
+    value (empty open-interval ends become ``..``) for the shared parser."""
+
+    def _parse_side(part: str) -> datetime | None:
+        if part in ("", ".."):
+            return None
+        if not _RFC3339_DATETIME_RE.match(part):
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"Invalid RFC 3339 datetime: {part!r}",
+            )
+        try:
+            # RFC 3339 allows lowercase t/z; fromisoformat does not.
+            return datetime.fromisoformat(part.upper())
+        except ValueError as e:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"Invalid RFC 3339 datetime: {e}",
+            )
+
+    if "/" in datetime_str:
+        parts = datetime_str.split("/")
+        if len(parts) != 2:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Invalid datetime interval: expected exactly one '/'",
+            )
+        start, end = (_parse_side(p) for p in parts)
+        if start is None and end is None:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Invalid datetime interval: both ends are open",
+            )
+        if start is not None and end is not None and start > end:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Invalid datetime interval: start is after end",
+            )
+        return f"{parts[0] or '..'}/{parts[1] or '..'}"
+
+    _parse_side(datetime_str)
+    if datetime_str == "..":
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Invalid datetime: '..' is only valid inside an interval",
+        )
+    return datetime_str
 
 
 def _base_published_raster_query(
@@ -349,19 +426,38 @@ async def _resolve_roles(db: AsyncSession, user: Identity | None) -> set[str]:
     return await get_user_roles(db, user)
 
 
+async def _has_visible_items(
+    db: AsyncSession,
+    user: Identity | None,
+    user_roles: set[str],
+    scope_filter,
+) -> bool:
+    """Return whether the caller can see at least one STAC Item in scope."""
+    stmt = (
+        _base_published_raster_query(user, user_roles)
+        .where(scope_filter)
+        .with_only_columns(Dataset.id)
+        .limit(1)
+    )
+    return (await db.execute(stmt)).scalar_one_or_none() is not None
+
+
 async def _has_unassigned_items(
     db: AsyncSession,
     user: Identity | None,
     user_roles: set[str],
 ) -> bool:
     """Return whether the caller can see at least one unassigned STAC Item."""
-    stmt = (
-        _base_published_raster_query(user, user_roles)
-        .where(_unassigned_dataset_filter())
-        .with_only_columns(Dataset.id)
-        .limit(1)
+    return await _has_visible_items(db, user, user_roles, _unassigned_dataset_filter())
+
+
+def _collection_membership_filter(collection_uuid: uuid.UUID):
+    """Match datasets belonging to a stored Collection."""
+    return Dataset.id.in_(
+        select(CollectionDataset.dataset_id).where(
+            CollectionDataset.collection_id == collection_uuid
+        )
     )
-    return (await db.execute(stmt)).scalar_one_or_none() is not None
 
 
 async def _collection_scope_filter(
@@ -393,11 +489,16 @@ async def _collection_scope_filter(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="Collection not found",
         )
-    return Dataset.id.in_(
-        select(CollectionDataset.dataset_id).where(
-            CollectionDataset.collection_id == collection_uuid
+    membership = _collection_membership_filter(collection_uuid)
+    # Collections with no visible STAC Items are hidden from the STAC surface
+    # (they would otherwise advertise a fabricated global extent), matching the
+    # gating the virtual unassigned collection already gets above.
+    if not await _has_visible_items(db, user, user_roles, membership):
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Collection not found",
         )
-    )
+    return membership
 
 
 # ---------------------------------------------------------------------------
@@ -405,7 +506,10 @@ async def _collection_scope_filter(
 # ---------------------------------------------------------------------------
 
 
-@stac_router.get("/", response_model=StacCatalog)
+# response_model_exclude_none (here and on the collection routes): optional
+# StacLink fields must be omitted rather than serialized as null — the STAC
+# link schema types `method` as a ^[A-Z]+$ string.
+@stac_router.get("/", response_model=StacCatalog, response_model_exclude_none=True)
 async def landing_page(
     request: Request,
     db: AsyncSession = Depends(get_db),
@@ -433,22 +537,35 @@ async def landing_page(
         ),
         StacLink(
             rel="service-desc",
-            href=f"{stac_api_url.rsplit('/stac', 1)[0]}/openapi.json",
+            href=f"{stac_api_url}/api",
             type="application/vnd.oai.openapi+json;version=3.1",
         ),
     ]
 
-    # Add rel=child for each collection
-    coll_result = await db.execute(select(Collection))
-    for coll in coll_result.scalars().all():
+    # Add rel=child for each collection with at least one visible STAC Item —
+    # empty collections are hidden from the STAC surface (see
+    # _collection_scope_filter).
+    user_roles = await _resolve_roles(db, user)
+    child_stmt = (
+        select(CollectionDataset.collection_id)
+        .distinct()
+        .select_from(Record)
+        .join(Dataset, Dataset.record_id == Record.id)
+        .join(CollectionDataset, CollectionDataset.dataset_id == Dataset.id)
+        .where(*_published_raster_filters())
+        .order_by(CollectionDataset.collection_id)
+    )
+    child_stmt = apply_visibility_filter(
+        child_stmt, user, user_roles, Record, DatasetGrant
+    )
+    for coll_id in (await db.execute(child_stmt)).scalars().all():
         links.append(
             StacLink(
                 rel="child",
-                href=f"{stac_api_url}/collections/{coll.id}",
+                href=f"{stac_api_url}/collections/{coll_id}",
                 type="application/json",
             )
         )
-    user_roles = await _resolve_roles(db, user)
     if await _has_unassigned_items(db, user, user_roles):
         links.append(
             StacLink(
@@ -467,13 +584,28 @@ async def landing_page(
     )
 
 
+@stac_router.get("/api", include_in_schema=False)
+async def service_desc(request: Request) -> Response:
+    """The OpenAPI document, served with the media type the landing page's
+    service-desc link advertises (the shared /openapi.json route always
+    answers ``application/json``, which fails the STAC round-trip check)."""
+    return JSONResponse(
+        request.app.openapi(),
+        media_type="application/vnd.oai.openapi+json;version=3.1",
+    )
+
+
 @stac_router.get("/conformance", response_model=StacConformance)
 async def conformance() -> StacConformance:
     """STAC API conformance classes."""
     return StacConformance(conformsTo=STAC_CONFORMANCE)
 
 
-@stac_router.get("/collections", response_model=StacCollectionListResponse)
+@stac_router.get(
+    "/collections",
+    response_model=StacCollectionListResponse,
+    response_model_exclude_none=True,
+)
 async def get_collections(
     request: Request,
     db: AsyncSession = Depends(get_db),
@@ -505,6 +637,7 @@ async def get_collections(
                 func.ST_YMax(func.ST_Extent(Record.spatial_extent)),
                 func.min(Record.temporal_start),
                 func.max(Record.temporal_end),
+                func.array_agg(func.distinct(Record.license)),
             )
             .select_from(Record)
             .join(Dataset, Dataset.record_id == Record.id)
@@ -600,8 +733,13 @@ async def get_collections(
     stac_collections = []
     for coll in collections:
         coll_key = str(coll.id)
-        ext_row = extent_map.get(coll_key)
-        spatial_extent, temporal_extent = _parse_extent_row(ext_row)
+        if coll_key not in extent_map:
+            # No visible STAC Items — hidden from the STAC surface rather than
+            # advertised with a fabricated global extent.
+            continue
+        spatial_extent, temporal_extent, license = _parse_extent_row(
+            extent_map[coll_key]
+        )
 
         summaries = {}
         if coll_key in projection_map:
@@ -616,12 +754,13 @@ async def get_collections(
             stac_api_url=stac_api_url,
             keywords=keywords_map.get(coll_key),
             summaries=summaries or None,
+            license=license,
         )
         stac_collections.append(stac_coll)
 
     if has_unassigned:
         fallback_key = STAC_UNASSIGNED_COLLECTION_ID
-        spatial_extent, temporal_extent = _parse_extent_row(
+        spatial_extent, temporal_extent, license = _parse_extent_row(
             extent_map.get(fallback_key)
         )
         fallback_summaries = None
@@ -637,6 +776,7 @@ async def get_collections(
                 stac_api_url=stac_api_url,
                 keywords=keywords_map.get(fallback_key),
                 summaries=fallback_summaries,
+                license=license,
             )
         )
 
@@ -654,6 +794,7 @@ async def get_collections(
 @stac_router.get(
     "/collections/{collection_id}",
     response_model=StacCollection,
+    response_model_exclude_none=True,
     responses={404: NOT_FOUND_RESPONSE},
 )
 async def get_collection(
@@ -695,6 +836,15 @@ async def get_collection(
             )
         collection_name = coll.name
         collection_description = coll.description
+        # Hidden from the STAC surface when it has no visible Items — see
+        # _collection_scope_filter.
+        if not await _has_visible_items(
+            db, user, user_roles, _collection_membership_filter(collection_uuid)
+        ):
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="Collection not found",
+            )
 
     # Three independent metadata queries -- run concurrently with separate sessions.
 
@@ -707,6 +857,7 @@ async def get_collection(
                 func.ST_YMax(func.ST_Extent(Record.spatial_extent)),
                 func.min(Record.temporal_start),
                 func.max(Record.temporal_end),
+                func.array_agg(func.distinct(Record.license)),
             )
             .select_from(Record)
             .join(Dataset, Dataset.record_id == Record.id)
@@ -773,7 +924,7 @@ async def get_collection(
     ext_row, coll_keywords, summaries = await asyncio.gather(
         _fetch_extent(), _fetch_kw(), _fetch_projection()
     )
-    spatial_extent, temporal_extent = _parse_extent_row(ext_row)
+    spatial_extent, temporal_extent, license = _parse_extent_row(ext_row)
 
     return ogc_collection_to_stac_collection(
         collection_id,
@@ -784,6 +935,7 @@ async def get_collection(
         stac_api_url=stac_api_url,
         keywords=coll_keywords,
         summaries=summaries,
+        license=license,
     )
 
 
@@ -1146,6 +1298,13 @@ def _build_search_filters(
             # broaden a scoped search to the entire catalog.
             filters.append(Dataset.id.in_([]))
 
+    # bbox and intersects are mutually exclusive per the STAC Item Search spec.
+    if intersects and bbox:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Only one of bbox and intersects may be specified",
+        )
+
     # Filter by intersects (GeoJSON geometry) — accept string or dict
     if intersects:
         if isinstance(intersects, dict):
@@ -1439,7 +1598,15 @@ async def search_get(
             "polygons at 2-decimal-place lat/lon coordinates."
         ),
     ),
-    limit: int = Query(10, ge=1, le=200),
+    limit: int = Query(
+        10,
+        ge=1,
+        description=(
+            "Maximum number of items returned. Values above 200 are clamped "
+            "to 200, per the STAC Item Search spec's clamp-don't-reject "
+            "recommendation."
+        ),
+    ),
     offset: int = Query(
         0,
         ge=0,
@@ -1465,7 +1632,9 @@ async def search_get(
         collections=collections,
         ids=ids,
         intersects=intersects,
-        limit=limit,
+        # STAC Item Search: limits above the server maximum are clamped, not
+        # rejected (stac-api-validator enforces this).
+        limit=min(limit, 200),
         offset=offset,
         public_app_url=public_app_url,
         preferred_languages=parse_accept_languages(request),
@@ -1495,13 +1664,13 @@ class StacSearchBody(BaseModel):
     limit: int = Field(
         default=10,
         ge=1,
-        le=200,
-        # WR-01 (Phase 1071 review): le=200 matches the GET /stac/search handler
-        # ceiling (router.py:544). The previous le=1000 created a schema
-        # asymmetry where POST appeared to accept up to 1000 items while the
-        # effective ceiling was 200. Conservative: align schemas so the public
-        # API contract is honest.
-        description="Maximum number of items returned (1-200).",
+        # WR-01 (Phase 1071 review) aligned GET/POST ceilings at le=200; the
+        # STAC hardening pass replaces the hard bound with clamping on both
+        # handlers — the Item Search spec (and stac-api-validator) requires
+        # over-limit values to be clamped to the server maximum, not rejected.
+        description=(
+            "Maximum number of items returned. Values above 200 are clamped to 200."
+        ),
     )
     offset: int = Field(
         default=0,
@@ -1555,9 +1724,8 @@ async def search_post(
         collections=body.collections,
         ids=body.ids,
         intersects=body.intersects,
-        # H-24: clamp body limit to 200 (was 1000) for parity with GET search.
-        # KNOWN-12 (Phase 1071): StacSearchBody.limit now carries ge=1, le=1000;
-        # the min(body.limit, 200) keeps the operational 200-item ceiling.
+        # Over-limit values clamp to the 200-item operational ceiling (H-24),
+        # required by the Item Search spec instead of a le=200 rejection.
         limit=max(1, min(body.limit, 200)),
         offset=max(0, body.offset),
         public_app_url=public_app_url,
@@ -1580,7 +1748,8 @@ def _apply_datetime_filter(stmt, datetime_str: str):
     """
     from app.modules.catalog.search.service import parse_ogc_datetime
 
-    start, end = parse_ogc_datetime(datetime_str.strip())
+    datetime_str = _validate_stac_datetime(datetime_str.strip())
+    start, end = parse_ogc_datetime(datetime_str)
 
     # fix(#430 BA-13): admit null-temporal records — dataset_to_ogc_record advertises
     # datetime=created_at for them, so filter them by that SAME fallback instant.

--- a/backend/app/standards/stac/serializer.py
+++ b/backend/app/standards/stac/serializer.py
@@ -232,6 +232,7 @@ def ogc_collection_to_stac_collection(
     stac_api_url: str,
     keywords: list[str] | None = None,
     summaries: dict | None = None,
+    license: str | None = None,
 ) -> dict:
     """Build a STAC Collection dict from GeoLens collection metadata.
 
@@ -244,11 +245,17 @@ def ogc_collection_to_stac_collection(
     description:
         Collection description (falls back to empty string).
     spatial_extent:
-        ``[west, south, east, north]`` bounding box. Defaults to global.
+        ``[west, south, east, north]`` bounding box. Defaults to global —
+        a schema-validity backstop only (STAC requires a bbox); the router
+        hides collections with no visible items, so in practice this is
+        reached only when every member record has a NULL spatial extent.
     temporal_extent:
         ``[start, end]`` ISO-8601 strings (either can be ``None``).
     stac_api_url:
         Base URL for the STAC API.
+    license:
+        SPDX identifier, ``"various"``, or ``None`` (emitted as STAC 1.0's
+        ``"proprietary"`` placeholder — record licenses are unknown).
     """
     result: dict = {
         "type": "Collection",
@@ -256,7 +263,7 @@ def ogc_collection_to_stac_collection(
         "id": collection_id,
         "title": name,
         "description": description or "",
-        "license": "proprietary",
+        "license": license or "proprietary",
         "extent": {
             "spatial": {
                 "bbox": [spatial_extent or [-180, -90, 180, 90]],

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -15572,8 +15572,7 @@
           },
           "limit": {
             "default": 10,
-            "description": "Maximum number of items returned (1-200).",
-            "maximum": 200.0,
+            "description": "Maximum number of items returned. Values above 200 are clamped to 200.",
             "minimum": 1.0,
             "title": "Limit",
             "type": "integer"
@@ -53619,12 +53618,13 @@
             }
           },
           {
+            "description": "Maximum number of items returned. Values above 200 are clamped to 200, per the STAC Item Search spec's clamp-don't-reject recommendation.",
             "in": "query",
             "name": "limit",
             "required": false,
             "schema": {
               "default": 10,
-              "maximum": 200,
+              "description": "Maximum number of items returned. Values above 200 are clamped to 200, per the STAC Item Search spec's clamp-don't-reject recommendation.",
               "minimum": 1,
               "title": "Limit",
               "type": "integer"

--- a/backend/scripts/seed_stac_ci.py
+++ b/backend/scripts/seed_stac_ci.py
@@ -1,0 +1,66 @@
+"""Seed one published public raster dataset in a collection for CI STAC validation.
+
+Run inside the api container (the CI stac-validate job does this):
+
+    docker compose exec -T api uv run --no-dev python /app/backend/scripts/seed_stac_ci.py
+
+Prints ``collection_id=<uuid>`` on success; the CI job feeds it to
+stac-api-validator's ``--collection`` flag. Mirrors the ORM factory pattern in
+backend/tests/test_stac_visibility.py — no real COG is ingested because the
+validator exercises the metadata surface only.
+"""
+
+import asyncio
+import uuid
+from datetime import date
+
+
+async def main() -> None:
+    from sqlalchemy import select
+
+    from app.core.db import async_session
+    from app.modules.auth.models import User
+    from app.modules.catalog.collections.models import Collection, CollectionDataset
+    from app.modules.catalog.datasets.domain.models import Dataset, Record
+
+    async with async_session() as session:
+        admin_id = (
+            await session.execute(select(User.id).order_by(User.created_at).limit(1))
+        ).scalar_one()
+        record = Record(
+            title="STAC CI raster",
+            summary="Fixture record for the stac-api-validator CI gate.",
+            visibility="public",
+            record_status="published",
+            record_type="raster_dataset",
+            license="CC-BY-4.0",
+            created_by=admin_id,
+            spatial_extent=(
+                "SRID=4326;POLYGON((-105 39,-104 39,-104 40,-105 40,-105 39))"
+            ),
+            temporal_start=date(2024, 1, 1),
+            temporal_end=date(2024, 12, 31),
+        )
+        session.add(record)
+        await session.flush()
+        dataset = Dataset(
+            record_id=record.id,
+            table_name=f"ds_{uuid.uuid4().hex[:12]}",
+            srid=4326,
+            source_format="geotiff",
+            source_filename="stac-ci.tif",
+        )
+        session.add(dataset)
+        coll = Collection(
+            name="STAC CI Collection",
+            description="Fixture collection for the stac-api-validator CI gate.",
+        )
+        session.add(coll)
+        await session.flush()
+        session.add(CollectionDataset(collection_id=coll.id, dataset_id=dataset.id))
+        await session.commit()
+        print(f"collection_id={coll.id}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/backend/scripts/seed_stac_ci.py
+++ b/backend/scripts/seed_stac_ci.py
@@ -16,17 +16,15 @@ from datetime import date
 
 
 async def main() -> None:
-    from sqlalchemy import select
-
+    import app.modules.auth.models  # noqa: F401 -- register catalog.users so the records FK resolves (same pattern as alembic/env.py); the User symbol itself stays unimported per the IDENT-02 layering guard
     from app.core.db import async_session
-    from app.modules.auth.models import User
     from app.modules.catalog.collections.models import Collection, CollectionDataset
     from app.modules.catalog.datasets.domain.models import Dataset, Record
 
     async with async_session() as session:
-        admin_id = (
-            await session.execute(select(User.id).order_by(User.created_at).limit(1))
-        ).scalar_one()
+        # created_by stays NULL: the record is public+published, so the
+        # anonymous visibility filter never consults ownership, and importing
+        # the concrete User ORM here would violate the IDENT-02 layering guard.
         record = Record(
             title="STAC CI raster",
             summary="Fixture record for the stac-api-validator CI gate.",
@@ -34,7 +32,6 @@ async def main() -> None:
             record_status="published",
             record_type="raster_dataset",
             license="CC-BY-4.0",
-            created_by=admin_id,
             spatial_extent=(
                 "SRID=4326;POLYGON((-105 39,-104 39,-104 40,-105 40,-105 39))"
             ),

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -991,7 +991,12 @@ _ROUTER_LOC_CAPS: dict[str, int] = {
     # fix(#474): negotiate localized STAC record text; fix(#475) adds the
     # unassigned Collection and matching HTTP Link navigation. fix(#506): keep
     # validated STAC item responses wire-compatible with serializer output.
-    "backend/app/standards/stac/router.py": 1626,
+    # STAC hardening (roadmap trust batch): collection license aggregated from
+    # member records, item-less collections hidden from the STAC surface
+    # instead of advertising a fabricated global extent, and stac-api-validator
+    # conformance (strict RFC 3339 datetime gate, bbox/intersects exclusivity,
+    # south<=north bbox check, limit clamping). Ratchet stays exact.
+    "backend/app/standards/stac/router.py": 1795,
     # Central tenant-bound scope resolution replaced duplicated inline logic.
     "backend/app/processing/tiles/router.py": 2043,
 }

--- a/backend/tests/test_stac_api.py
+++ b/backend/tests/test_stac_api.py
@@ -187,7 +187,9 @@ class TestStacItemCollection:
         assert response.media_type == "application/geo+json"
         assert parsed.features[0].id == "item-1"
         assert payload["type"] == "FeatureCollection"
-        assert payload["links"][0]["method"] is None
+        # Optional link fields serialize as omitted, not null — the STAC link
+        # schema types `method` as a ^[A-Z]+$ string.
+        assert "method" not in payload["links"][0]
         assert payload["features"][0] == item
 
     def test_item_bbox_requires_exactly_four_or_six_coordinates(self):
@@ -242,19 +244,67 @@ async def test_get_item_not_found(client: AsyncClient):
     assert "not found" in resp.json()["detail"].lower()
 
 
+def test_collapse_licenses():
+    """Member licenses collapse: none → None, one → itself, mixed → various."""
+    from app.standards.stac.router import _collapse_licenses
+
+    assert _collapse_licenses(None) is None
+    assert _collapse_licenses([None]) is None
+    assert _collapse_licenses(["CC-BY-4.0", None]) == "CC-BY-4.0"
+    assert _collapse_licenses(["CC-BY-4.0", "ODbL-1.0"]) == "various"
+
+
+async def _create_collection_with_item(
+    session, name: str, description: str, *, license: str | None = None
+):
+    """Create a Collection holding one public published raster dataset.
+
+    Collections with no visible STAC Items are hidden from the STAC surface,
+    so router tests must seed at least one item.
+    """
+    from app.modules.catalog.collections.models import Collection, CollectionDataset
+    from app.modules.catalog.datasets.domain.models import Dataset, Record
+    from tests.factories import get_user_id
+
+    coll = Collection(name=name, description=description)
+    session.add(coll)
+    record = Record(
+        title=f"{name} item",
+        summary=f"Raster item for {name}",
+        visibility="public",
+        record_status="published",
+        record_type="raster_dataset",
+        license=license,
+        created_by=await get_user_id(session, "admin"),
+    )
+    session.add(record)
+    await session.flush()
+    dataset = Dataset(
+        record_id=record.id,
+        table_name=f"ds_{uuid.uuid4().hex[:12]}",
+        srid=4326,
+        source_format="geotiff",
+        source_filename="test.tif",
+    )
+    session.add(dataset)
+    await session.flush()
+    session.add(CollectionDataset(collection_id=coll.id, dataset_id=dataset.id))
+    await session.commit()
+    await session.refresh(coll)
+    return coll
+
+
 @pytest.mark.anyio
 async def test_get_collection_valid(
     client: AsyncClient, admin_auth_header: dict, test_db_session
 ):
-    """GET /stac/collections/{id} returns collection data when it exists."""
-    from app.modules.catalog.collections.models import Collection
-
-    coll = Collection(
-        name="STAC Test Collection", description="Test collection for STAC"
+    """GET /stac/collections/{id} returns collection data when it has items."""
+    coll = await _create_collection_with_item(
+        test_db_session,
+        "STAC Test Collection",
+        "Test collection for STAC",
+        license="CC-BY-4.0",
     )
-    test_db_session.add(coll)
-    await test_db_session.commit()
-    await test_db_session.refresh(coll)
 
     resp = await client.get(f"/stac/collections/{coll.id}")
     assert resp.status_code == 200
@@ -263,11 +313,16 @@ async def test_get_collection_valid(
     assert data["type"] == "Collection"
     assert data["title"] == "STAC Test Collection"
     assert data["description"] == "Test collection for STAC"
+    # License aggregates from member records instead of hardcoding proprietary.
+    assert data["license"] == "CC-BY-4.0"
 
 
 @pytest.mark.anyio
-async def test_get_collection_items_empty(client: AsyncClient, test_db_session):
-    """GET /stac/collections/{id}/items returns empty feature collection."""
+async def test_get_collection_without_items_hidden(
+    client: AsyncClient, test_db_session
+):
+    """A collection with no visible STAC Items is hidden (404), not served
+    with a fabricated global extent."""
     from app.modules.catalog.collections.models import Collection
 
     coll = Collection(name="Empty STAC Collection", description="No items")
@@ -275,13 +330,13 @@ async def test_get_collection_items_empty(client: AsyncClient, test_db_session):
     await test_db_session.commit()
     await test_db_session.refresh(coll)
 
+    resp = await client.get(f"/stac/collections/{coll.id}")
+    assert resp.status_code == 404
     resp = await client.get(f"/stac/collections/{coll.id}/items")
-    assert resp.status_code == 200
-    data = resp.json()
-    assert data["type"] == "FeatureCollection"
-    assert data["numberMatched"] == 0
-    assert data["numberReturned"] == 0
-    assert data["features"] == []
+    assert resp.status_code == 404
+
+    listing = await client.get("/stac/collections")
+    assert str(coll.id) not in [c["id"] for c in listing.json()["collections"]]
 
 
 @pytest.mark.anyio
@@ -289,18 +344,15 @@ async def test_collection_items_self_link_preserves_active_params(
     client: AsyncClient, test_db_session
 ):
     """STAC collection items self link preserves active filter params."""
-    from app.modules.catalog.collections.models import Collection
-
-    coll = Collection(name="Filtered STAC Collection", description="No items")
-    test_db_session.add(coll)
-    await test_db_session.commit()
-    await test_db_session.refresh(coll)
+    coll = await _create_collection_with_item(
+        test_db_session, "Filtered STAC Collection", "One item"
+    )
 
     resp = await client.get(
         f"/stac/collections/{coll.id}/items",
         params={
             "bbox": "-180,-90,180,90",
-            "datetime": "2024-01-01/2024-12-31",
+            "datetime": "2024-01-01T00:00:00Z/2024-12-31T00:00:00Z",
             "limit": 1,
             "offset": 2,
         },
@@ -312,7 +364,7 @@ async def test_collection_items_self_link_preserves_active_params(
     assert self_link is not None
     qs = parse_qs(urlparse(self_link["href"]).query)
     assert qs["bbox"] == ["-180,-90,180,90"]
-    assert qs["datetime"] == ["2024-01-01/2024-12-31"]
+    assert qs["datetime"] == ["2024-01-01T00:00:00Z/2024-12-31T00:00:00Z"]
     assert qs["limit"] == ["1"]
     assert qs["offset"] == ["2"]
     assert 'rel="self"' in resp.headers["link"]

--- a/backend/tests/test_stac_search_validation.py
+++ b/backend/tests/test_stac_search_validation.py
@@ -144,22 +144,15 @@ class TestSecFu05StacIntersectsMaxLength:
 class TestStacSearchBodyBounds:
     """KNOWN-12: POST /stac/search body.limit/offset carry Pydantic ge/le."""
 
-    async def test_post_search_limit_above_le_rejected(self, client: AsyncClient):
-        """limit=201 returns an OGC 400 Problem Detail (le=200).
+    async def test_post_search_limit_above_max_clamped(self, client: AsyncClient):
+        """limit above the 200 ceiling is clamped, not rejected.
 
-        WR-01: POST /stac/search schema now matches GET ceiling (le=200).
+        The STAC Item Search spec (enforced by stac-api-validator) requires
+        over-limit values to fall back to the server maximum.
         """
-        resp = await client.post("/stac/search", json={"limit": 201})
-        assert resp.status_code == 400, resp.text
-        assert resp.headers["content-type"].startswith("application/problem+json")
-        body = resp.json()
-        # GeoLens uses RFC 7807 problem-details shape — `detail` is a string
-        # (e.g. "body.limit: Input should be less than or equal to 200"),
-        # not FastAPI's default list-of-errors structure.
-        detail = str(body.get("detail", "")).lower()
-        assert "limit" in detail and (
-            "less than or equal" in detail or "le " in detail or "<=" in detail
-        ), f"400 detail did not name limit/le bound: {body}"
+        resp = await client.post("/stac/search", json={"limit": 100000})
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["context"]["limit"] == 200
 
     async def test_post_search_negative_offset_rejected(self, client: AsyncClient):
         """offset=-1 must be rejected with 400 (not silently clamped)."""

--- a/frontend/src/types/api.generated.ts
+++ b/frontend/src/types/api.generated.ts
@@ -11710,7 +11710,7 @@ export interface components {
             } | null;
             /**
              * Limit
-             * @description Maximum number of items returned (1-200).
+             * @description Maximum number of items returned. Values above 200 are clamped to 200.
              * @default 10
              */
             limit: number;
@@ -37135,6 +37135,7 @@ export interface operations {
                 ids?: string | null;
                 /** @description GeoJSON geometry for spatial intersection. SEC-FU-05 (sec-audit-20260519.md): max_length=10000 caps a multi-megabyte GeoJSON DoS-amplifier — fits ~150-vertex polygons at 2-decimal-place lat/lon coordinates. */
                 intersects?: string | null;
+                /** @description Maximum number of items returned. Values above 200 are clamped to 200, per the STAC Item Search spec's clamp-don't-reject recommendation. */
                 limit?: number;
                 /** @description Legacy offset-based pagination. Phase 269 H-24 lowered the max limit to 200 from 1000 to bound deep-paging cost. */
                 offset?: number;

--- a/sdks/python/geolens/api/stac/search_get_stac_search_get.py
+++ b/sdks/python/geolens/api/stac/search_get_stac_search_get.py
@@ -148,7 +148,8 @@ def sync_detailed(
         intersects (None | str | Unset): GeoJSON geometry for spatial intersection. SEC-FU-05
             (sec-audit-20260519.md): max_length=10000 caps a multi-megabyte GeoJSON DoS-amplifier —
             fits ~150-vertex polygons at 2-decimal-place lat/lon coordinates.
-        limit (int | Unset):  Default: 10.
+        limit (int | Unset): Maximum number of items returned. Values above 200 are clamped to
+            200, per the STAC Item Search spec's clamp-don't-reject recommendation. Default: 10.
         offset (int | Unset): Legacy offset-based pagination. Phase 269 H-24 lowered the max limit
             to 200 from 1000 to bound deep-paging cost. Default: 0.
 
@@ -200,7 +201,8 @@ def sync(
         intersects (None | str | Unset): GeoJSON geometry for spatial intersection. SEC-FU-05
             (sec-audit-20260519.md): max_length=10000 caps a multi-megabyte GeoJSON DoS-amplifier —
             fits ~150-vertex polygons at 2-decimal-place lat/lon coordinates.
-        limit (int | Unset):  Default: 10.
+        limit (int | Unset): Maximum number of items returned. Values above 200 are clamped to
+            200, per the STAC Item Search spec's clamp-don't-reject recommendation. Default: 10.
         offset (int | Unset): Legacy offset-based pagination. Phase 269 H-24 lowered the max limit
             to 200 from 1000 to bound deep-paging cost. Default: 0.
 
@@ -247,7 +249,8 @@ async def asyncio_detailed(
         intersects (None | str | Unset): GeoJSON geometry for spatial intersection. SEC-FU-05
             (sec-audit-20260519.md): max_length=10000 caps a multi-megabyte GeoJSON DoS-amplifier —
             fits ~150-vertex polygons at 2-decimal-place lat/lon coordinates.
-        limit (int | Unset):  Default: 10.
+        limit (int | Unset): Maximum number of items returned. Values above 200 are clamped to
+            200, per the STAC Item Search spec's clamp-don't-reject recommendation. Default: 10.
         offset (int | Unset): Legacy offset-based pagination. Phase 269 H-24 lowered the max limit
             to 200 from 1000 to bound deep-paging cost. Default: 0.
 
@@ -297,7 +300,8 @@ async def asyncio(
         intersects (None | str | Unset): GeoJSON geometry for spatial intersection. SEC-FU-05
             (sec-audit-20260519.md): max_length=10000 caps a multi-megabyte GeoJSON DoS-amplifier —
             fits ~150-vertex polygons at 2-decimal-place lat/lon coordinates.
-        limit (int | Unset):  Default: 10.
+        limit (int | Unset): Maximum number of items returned. Values above 200 are clamped to
+            200, per the STAC Item Search spec's clamp-don't-reject recommendation. Default: 10.
         offset (int | Unset): Legacy offset-based pagination. Phase 269 H-24 lowered the max limit
             to 200 from 1000 to bound deep-paging cost. Default: 0.
 

--- a/sdks/python/geolens/models/stac_search_body.py
+++ b/sdks/python/geolens/models/stac_search_body.py
@@ -29,7 +29,7 @@ class StacSearchBody:
         datetime_ (None | str | Unset):
         ids (list[str] | None | Unset):
         intersects (None | StacSearchBodyIntersectsType0 | Unset):
-        limit (int | Unset): Maximum number of items returned (1-200). Default: 10.
+        limit (int | Unset): Maximum number of items returned. Values above 200 are clamped to 200. Default: 10.
         offset (int | Unset): Number of items to skip for pagination. Default: 0.
     """
 

--- a/sdks/typescript/src/client/types.gen.ts
+++ b/sdks/typescript/src/client/types.gen.ts
@@ -9119,7 +9119,7 @@ export type StacSearchBody = {
     /**
      * Limit
      *
-     * Maximum number of items returned (1-200).
+     * Maximum number of items returned. Values above 200 are clamped to 200.
      */
     limit?: number;
     /**
@@ -25493,6 +25493,8 @@ export type SearchGetStacSearchGetData = {
         intersects?: string | null;
         /**
          * Limit
+         *
+         * Maximum number of items returned. Values above 200 are clamped to 200, per the STAC Item Search spec's clamp-don't-reject recommendation.
          */
         limit?: number;
         /**


### PR DESCRIPTION
Two items from the release-trust roadmap batch (the other two — a11y CI and security CI — turned out to be already done).

## GHCR branding
All four published stages (api/worker/backup/frontend) now carry `org.opencontainers.image.source`, repo-linking the GHCR packages (and pulling the org avatar).

## STAC hardening
`stac-api-validator` 0.6.8 now runs **green (zero errors)** for core + collections + item-search against a live stack, and a new `stac-validate` CI job (push(main)/nightly/dispatch, same trigger shape as the accessibility job) keeps it that way.

**Collection metadata honesty**
- `license` aggregates from member `Record.license` — one distinct value passes through, mixed → `various`, none → STAC 1.0's `proprietary` placeholder (previously always hardcoded `proprietary`).
- Collections with no visible STAC items are hidden from the STAC surface (landing children, `/collections`, 404 on direct access) instead of advertising a fabricated global extent — the same gating the virtual `geolens-unassigned` collection already had.

**Item Search conformance fixes**
- Strict RFC 3339 datetime gate on `/search` + `/items` (malformed values 400; open-ended intervals now work; lowercase `t`/`z` accepted). The shared day-granular `parse_ogc_datetime` is unchanged for OGC Records.
- `bbox`+`intersects` together → 400; `bbox` south > north → 400 (antimeridian longitude order still allowed).
- `limit` above 200 clamps instead of rejecting (GET + POST; `le=200` removed from both schemas).
- Optional `StacLink` fields serialize as omitted, not `null` (STAC link schema types `method` as `^[A-Z]+$`).
- New `/stac/api` service-desc endpoint serves the OpenAPI doc with the advertised `application/vnd.oai.openapi+json` media type.

The roadmap's "reconcile the 1.1 claim" sub-item was stale — only an internal ADR ever said 1.1; the API consistently claims and emits 1.0.0.

## Schema/API/config impacts
- `backend/openapi.json`, generated SDKs, and `frontend/src/types/api.generated.ts` regenerated (limit `le` removal + description changes only).
- `stac/router.py` LOC ratchet 1626 → 1795 with a carve-out comment in `test_layering.py`.
- New `backend/scripts/seed_stac_ci.py` (CI fixture seed, ORM-based, no real COG needed for the metadata surface).

## Verification
- `stac-api-validator --root-url http://localhost:8080/api/stac/ --conformance core --conformance collections --conformance item-search --collection <seeded> --geometry <fixture bbox>` → exit 0, `Errors: none` (run twice: against showcase data and against the CI seed path, executed in-container exactly as the CI job does).
- Full backend suite: 5739 passed (one unrelated `-n 4` flake in `test_ai_metadata` passes in isolation).
- `make openapi-check`, `make sdks` + drift diff, `cd frontend && npm run typecheck` — clean.