### PR TITLE
feat(ogc): make the items page-size ceiling admin-configurable and clamp over-limit requests

### DIFF
--- a/backend/app/core/persistent_config.py
+++ b/backend/app/core/persistent_config.py
@@ -70,6 +70,11 @@ _DEFAULT_LOGIN_RATE_LIMIT = 5
 _DEFAULT_GLOBAL_RATE_LIMIT = 60
 _DEFAULT_SEMANTIC_SEARCH_RATE_LIMIT = 30
 _DEFAULT_BASEMAP_PROXY_RATE_LIMIT = 120
+# Ceiling for the OGC API Features items page size (`limit`). Conservative by
+# default (#665 review): the offset path is O(N) and the response is built fully
+# in memory on an anonymous endpoint, so a low default protects resource-limited
+# deployments while operators who need bulk export raise it from the dashboard.
+_DEFAULT_OGC_ITEMS_MAX_PAGE_SIZE = 1000
 
 
 # ---------------------------------------------------------------------------
@@ -723,6 +728,14 @@ CORS_ALLOWED_ORIGINS = PersistentConfig[str](
     env_default_factory=lambda: settings.cors_allowed_origins,
     tab="network",
     label="CORS Allowed Origins",
+)
+
+OGC_ITEMS_MAX_PAGE_SIZE = PersistentConfig[int](
+    key="ogc_items_max_page_size",
+    type_=int,
+    env_default=_DEFAULT_OGC_ITEMS_MAX_PAGE_SIZE,
+    tab="network",
+    label="OGC Features Max Page Size (items limit ceiling)",
 )
 
 # -- Storage tab --

--- a/backend/app/modules/settings/schemas.py
+++ b/backend/app/modules/settings/schemas.py
@@ -331,6 +331,15 @@ def validate_global_rate_limit(v: Any) -> int:
     return v
 
 
+def validate_ogc_items_max_page_size(v: Any) -> int:
+    # Upper bound guards against a mis-set value that would let an anonymous
+    # request build an unbounded FeatureCollection in memory (#665 review).
+    v = int(v)
+    if v < 1 or v > 100_000:
+        raise ValueError("ogc_items_max_page_size must be between 1 and 100000")
+    return v
+
+
 def validate_semantic_search_rate_limit(v: Any) -> int:
     v = int(v)
     if v < 1 or v > 1000:
@@ -549,6 +558,7 @@ SETTING_VALIDATORS: dict[str, Any] = {
     "log_level": validate_log_level,
     "login_rate_limit": validate_login_rate_limit,
     "global_rate_limit": validate_global_rate_limit,
+    "ogc_items_max_page_size": validate_ogc_items_max_page_size,
     "semantic_search_rate_limit": validate_semantic_search_rate_limit,
     "basemap_proxy_rate_limit": validate_basemap_proxy_rate_limit,
     "upload_max_size_mb": validate_upload_max_size,

--- a/backend/app/standards/ogc/router.py
+++ b/backend/app/standards/ogc/router.py
@@ -13,6 +13,7 @@ from app.core.db.tenant_session import current_tenant_var
 from app.core.dependencies import get_db
 from app.core.geo import extent_to_bbox
 from app.core.identity import Identity
+from app.core.persistent_config import OGC_ITEMS_MAX_PAGE_SIZE
 from app.core.public_urls import get_public_api_url, get_public_app_url
 from app.core.tenancy import is_multi_tenant
 from app.modules.auth.dependencies import get_optional_user_or_401
@@ -444,7 +445,19 @@ async def get_dataset_collection(
 async def get_collection_items(
     request: Request,
     dataset_id: uuid.UUID,
-    limit: int = Query(10, ge=1, le=200),
+    limit: int = Query(
+        10,
+        ge=1,
+        description=(
+            "Page size for bulk GeoJSON export. The maximum is an "
+            "admin-configurable ceiling (default 1000; Network settings tab, "
+            "`ogc_items_max_page_size`) rather than the 200 used by offset-paged "
+            "list endpoints, because this route pages via the constant-time "
+            "`after_gid` keyset cursor. Per OGC API Features Core "
+            "/req/core/fc-limit-response-1(C) a value above the ceiling is "
+            "clamped to it, not rejected."
+        ),
+    ),
     offset: int = Query(
         0,
         ge=0,
@@ -486,6 +499,16 @@ async def get_collection_items(
     """
     _validate_f_param(f)
     public_api_url = await get_public_api_url(db, request=request)
+
+    # #665 review / #666: the items page-size ceiling is an admin-configurable
+    # PersistentConfig knob (Network tab), not a static Query(le=...). Per OGC
+    # API Features Core /req/core/fc-limit-response-1(C) a limit above the
+    # maximum SHALL NOT error — clamp to the ceiling instead (mirrors the STAC
+    # side, #664). max(1, ...) guards a ceiling mis-set to 0; the clamped value
+    # flows into the feature query and the echoed self/next links.
+    max_page_size = await OGC_ITEMS_MAX_PAGE_SIZE.get(db)
+    limit = min(limit, max(1, max_page_size))
+
     dataset = await _get_visible_dataset(db, user, dataset_id)
 
     # fix(#315): raster/VRT datasets have no backing PostGIS feature table, so a feature

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -27799,12 +27799,13 @@
             }
           },
           {
+            "description": "Page size for bulk GeoJSON export. The maximum is an admin-configurable ceiling (default 1000; Network settings tab, `ogc_items_max_page_size`) rather than the 200 used by offset-paged list endpoints, because this route pages via the constant-time `after_gid` keyset cursor. Per OGC API Features Core /req/core/fc-limit-response-1(C) a value above the ceiling is clamped to it, not rejected.",
             "in": "query",
             "name": "limit",
             "required": false,
             "schema": {
               "default": 10,
-              "maximum": 200,
+              "description": "Page size for bulk GeoJSON export. The maximum is an admin-configurable ceiling (default 1000; Network settings tab, `ogc_items_max_page_size`) rather than the 200 used by offset-paged list endpoints, because this route pages via the constant-time `after_gid` keyset cursor. Per OGC API Features Core /req/core/fc-limit-response-1(C) a value above the ceiling is clamped to it, not rejected.",
               "minimum": 1,
               "title": "Limit",
               "type": "integer"

--- a/backend/tests/test_ogc_pagination.py
+++ b/backend/tests/test_ogc_pagination.py
@@ -325,3 +325,102 @@ async def test_pagination_prev_offset_does_not_go_negative(
     offset_val = int(qs["offset"][0])
     assert offset_val == 0, f"Prev offset should be 0, got {offset_val}"
     assert offset_val >= 0, "Prev offset must not be negative"
+
+
+# ---------------------------------------------------------------------------
+# Items page-size ceiling: admin-configurable, clamped not rejected (#665/#666)
+# ---------------------------------------------------------------------------
+#
+# These target the per-dataset feature route (`/collections/{id}/items`), whose
+# `limit` ceiling is the `ogc_items_max_page_size` PersistentConfig knob. Per
+# OGC API Features Core /req/core/fc-limit-response-1(C) an over-ceiling limit
+# is clamped to the maximum, never rejected. The feature-table helpers live in
+# test_ogc_features.py; reuse them rather than duplicate the PostGIS DDL.
+import app.standards.ogc.router as _ogc_router  # noqa: E402
+from app.core.persistent_config import _DEFAULT_OGC_ITEMS_MAX_PAGE_SIZE  # noqa: E402
+from tests.test_ogc_features import (  # noqa: E402
+    _cleanup_table,
+    _create_test_table_and_dataset,
+)
+
+
+def _self_limit(data: dict) -> int:
+    """Extract the echoed `limit` query param from the response's self link."""
+    self_link = _find_link(data["links"], "self")
+    assert self_link is not None, "Expected a self link"
+    return int(parse_qs(urlparse(self_link["href"]).query)["limit"][0])
+
+
+@pytest.mark.anyio
+async def test_items_limit_at_default_ceiling_accepted(
+    client: AsyncClient, test_db_session
+):
+    """A limit exactly at the default ceiling is accepted (no 4xx)."""
+    admin_id = await get_user_id(test_db_session, "admin")
+    dataset = await _create_test_table_and_dataset(
+        test_db_session, created_by=admin_id, visibility="public", with_features=3
+    )
+    try:
+        resp = await client.get(
+            f"/collections/{dataset.id}/items",
+            params={"limit": _DEFAULT_OGC_ITEMS_MAX_PAGE_SIZE},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["numberReturned"] == 3
+        assert _self_limit(data) == _DEFAULT_OGC_ITEMS_MAX_PAGE_SIZE
+    finally:
+        await _cleanup_table(test_db_session, dataset.table_name)
+
+
+@pytest.mark.anyio
+async def test_items_limit_above_ceiling_clamped_not_rejected(
+    client: AsyncClient, test_db_session
+):
+    """A limit above the ceiling is clamped to it, not rejected with 400/422."""
+    admin_id = await get_user_id(test_db_session, "admin")
+    dataset = await _create_test_table_and_dataset(
+        test_db_session, created_by=admin_id, visibility="public", with_features=5
+    )
+    try:
+        over = _DEFAULT_OGC_ITEMS_MAX_PAGE_SIZE * 5
+        resp = await client.get(
+            f"/collections/{dataset.id}/items", params={"limit": over}
+        )
+        # OGC /req/core/fc-limit-response-1(C): clamp, do not error.
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["numberReturned"] == 5
+        # The echoed self link carries the clamped ceiling, not the request value.
+        assert _self_limit(data) == _DEFAULT_OGC_ITEMS_MAX_PAGE_SIZE
+    finally:
+        await _cleanup_table(test_db_session, dataset.table_name)
+
+
+@pytest.mark.anyio
+async def test_items_limit_clamped_to_configured_ceiling(
+    client: AsyncClient, test_db_session, monkeypatch
+):
+    """A non-default configured ceiling is honored: the page is clamped to it."""
+    admin_id = await get_user_id(test_db_session, "admin")
+    dataset = await _create_test_table_and_dataset(
+        test_db_session, created_by=admin_id, visibility="public", with_features=5
+    )
+
+    async def _fake_ceiling(_db):
+        return 3
+
+    monkeypatch.setattr(_ogc_router.OGC_ITEMS_MAX_PAGE_SIZE, "get", _fake_ceiling)
+    try:
+        resp = await client.get(
+            f"/collections/{dataset.id}/items", params={"limit": 100}
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        # 5 features available, ceiling 3 -> clamped page of 3, more remain.
+        assert data["numberReturned"] == 3
+        assert data["numberMatched"] == 5
+        assert _self_limit(data) == 3
+        assert _find_link(data["links"], "next") is not None
+    finally:
+        await _cleanup_table(test_db_session, dataset.table_name)

--- a/frontend/src/components/admin/settings/SettingsNetworkTab.tsx
+++ b/frontend/src/components/admin/settings/SettingsNetworkTab.tsx
@@ -24,6 +24,7 @@ interface TabProps {
 const FIELDS = [
   { key: 'cors_allowed_origins', defaultValue: '' },
   { key: 'global_rate_limit', defaultValue: 60 },
+  { key: 'ogc_items_max_page_size', defaultValue: 1000 },
 ] as const;
 
 function NotificationChannelBadge({ ok, label }: { ok: boolean; label: string }) {
@@ -105,6 +106,24 @@ export function SettingsNetworkTab({ settings, envOnly, onSave, onReset, isSavin
           max={1000}
           value={values.global_rate_limit as number}
           onChange={(e) => setters.global_rate_limit(Number(e.target.value))}
+          disabled={envOnly}
+          className="w-32"
+        />
+      </div>
+
+      <div className="space-y-2">
+        <div className="flex items-center gap-2">
+          <Label htmlFor="ogc-items-max-page-size">{findSetting(settings, 'ogc_items_max_page_size')?.label ?? t('settings.network.ogcItemsMaxPageSize')}</Label>
+          <SettingSourceBadge source={findSetting(settings, 'ogc_items_max_page_size')?.source ?? 'default'} settingKey="ogc_items_max_page_size" onReset={onReset} />
+        </div>
+        <p className="text-sm text-muted-foreground">{t('settings.network.ogcItemsMaxPageSizeDescription')}</p>
+        <Input
+          id="ogc-items-max-page-size"
+          type="number"
+          min={1}
+          max={100000}
+          value={values.ogc_items_max_page_size as number}
+          onChange={(e) => setters.ogc_items_max_page_size(Number(e.target.value))}
           disabled={envOnly}
           className="w-32"
         />

--- a/frontend/src/i18n/locales/de/admin.json
+++ b/frontend/src/i18n/locales/de/admin.json
@@ -523,7 +523,9 @@
       "globalRateLimitDescription": "Maximale API-Anfragen pro Sekunde pro IP-Adresse. Kachelanfragen sind von diesem Limit ausgenommen.",
       "corsAllowedOrigins": "Erlaubte CORS-Ursprünge",
       "corsAllowedOriginsDescription": "Kommagetrennte Ursprünge. Verwenden Sie * für beliebige Ursprünge.",
-      "corsAllowedOriginsPlaceholder": "https://example.com, https://app.example.com"
+      "corsAllowedOriginsPlaceholder": "https://example.com, https://app.example.com",
+      "ogcItemsMaxPageSize": "OGC Features maximale Seitengröße (Items-Limit-Obergrenze)",
+      "ogcItemsMaxPageSizeDescription": "Maximale Anzahl an Features pro Seite am OGC-API-Features-Items-Endpunkt. Anfragen darüber werden begrenzt, nicht abgelehnt. Erhöhen Sie den Wert für den Massen-GeoJSON-Export; verringern Sie ihn bei speicherbeschränkten Deployments."
     },
     "security": {
       "title": "Sicherheit",

--- a/frontend/src/i18n/locales/en/admin.json
+++ b/frontend/src/i18n/locales/en/admin.json
@@ -573,7 +573,9 @@
       "globalRateLimitDescription": "Maximum API requests per second per IP address. Tile requests are excluded from this limit.",
       "corsAllowedOrigins": "CORS Allowed Origins",
       "corsAllowedOriginsDescription": "Comma-separated origins. Use * for any origin.",
-      "corsAllowedOriginsPlaceholder": "https://example.com, https://app.example.com"
+      "corsAllowedOriginsPlaceholder": "https://example.com, https://app.example.com",
+      "ogcItemsMaxPageSize": "OGC Features Max Page Size (items limit ceiling)",
+      "ogcItemsMaxPageSizeDescription": "Maximum number of features returned per page by the OGC API Features items endpoint. Requests above this are clamped, not rejected. Raise it for bulk GeoJSON export; lower it on memory-constrained deployments."
     },
     "notifications": {
       "title": "Outbound Notifications",

--- a/frontend/src/i18n/locales/es/admin.json
+++ b/frontend/src/i18n/locales/es/admin.json
@@ -523,7 +523,9 @@
       "globalRateLimitDescription": "Solicitudes API maximas por segundo por direccion IP. Las solicitudes de teselas estan excluidas de este limite.",
       "corsAllowedOrigins": "Orígenes CORS permitidos",
       "corsAllowedOriginsDescription": "Orígenes separados por comas. Use * para permitir cualquier origen.",
-      "corsAllowedOriginsPlaceholder": "https://example.com, https://app.example.com"
+      "corsAllowedOriginsPlaceholder": "https://example.com, https://app.example.com",
+      "ogcItemsMaxPageSize": "Tamaño máximo de página de OGC Features (límite de items)",
+      "ogcItemsMaxPageSizeDescription": "Número máximo de entidades devueltas por página en el endpoint de items de OGC API Features. Las solicitudes que lo superen se ajustan, no se rechazan. Auméntalo para la exportación masiva de GeoJSON; redúcelo en despliegues con memoria limitada."
     },
     "security": {
       "title": "Seguridad",

--- a/frontend/src/i18n/locales/fr/admin.json
+++ b/frontend/src/i18n/locales/fr/admin.json
@@ -523,7 +523,9 @@
       "globalRateLimitDescription": "Nombre maximal de requetes API par seconde par adresse IP. Les requetes de tuiles sont exclues de cette limite.",
       "corsAllowedOrigins": "Origines CORS autorisées",
       "corsAllowedOriginsDescription": "Origines séparées par des virgules. Utilisez * pour autoriser n'importe quelle origine.",
-      "corsAllowedOriginsPlaceholder": "https://example.com, https://app.example.com"
+      "corsAllowedOriginsPlaceholder": "https://example.com, https://app.example.com",
+      "ogcItemsMaxPageSize": "Taille de page maximale OGC Features (plafond du paramètre items)",
+      "ogcItemsMaxPageSizeDescription": "Nombre maximal d'entités renvoyées par page par le point de terminaison items d'OGC API Features. Les requêtes au-delà sont plafonnées, pas rejetées. Augmentez-le pour l'export GeoJSON en masse ; réduisez-le sur les déploiements à mémoire limitée."
     },
     "security": {
       "title": "Sécurité",

--- a/frontend/src/types/api.generated.ts
+++ b/frontend/src/types/api.generated.ts
@@ -19600,6 +19600,7 @@ export interface operations {
     get_collection_items_collections__dataset_id__items_get: {
         parameters: {
             query?: {
+                /** @description Page size for bulk GeoJSON export. The maximum is an admin-configurable ceiling (default 1000; Network settings tab, `ogc_items_max_page_size`) rather than the 200 used by offset-paged list endpoints, because this route pages via the constant-time `after_gid` keyset cursor. Per OGC API Features Core /req/core/fc-limit-response-1(C) a value above the ceiling is clamped to it, not rejected. */
                 limit?: number;
                 /** @description Legacy offset-based pagination. Prefer `after_gid` keyset cursor (via the `next` link) — offset is retained for backward compatibility but is O(N) at high values. */
                 offset?: number;

--- a/sdks/python/geolens/api/ogc_features/get_collection_items_collections_dataset_id_items_get.py
+++ b/sdks/python/geolens/api/ogc_features/get_collection_items_collections_dataset_id_items_get.py
@@ -163,7 +163,11 @@ def sync_detailed(
 
     Args:
         dataset_id (UUID):
-        limit (int | Unset):  Default: 10.
+        limit (int | Unset): Page size for bulk GeoJSON export. The maximum is an admin-
+            configurable ceiling (default 1000; Network settings tab, `ogc_items_max_page_size`)
+            rather than the 200 used by offset-paged list endpoints, because this route pages via the
+            constant-time `after_gid` keyset cursor. Per OGC API Features Core /req/core/fc-limit-
+            response-1(C) a value above the ceiling is clamped to it, not rejected. Default: 10.
         offset (int | Unset): Legacy offset-based pagination. Prefer `after_gid` keyset cursor
             (via the `next` link) — offset is retained for backward compatibility but is O(N) at high
             values. Default: 0.
@@ -230,7 +234,11 @@ def sync(
 
     Args:
         dataset_id (UUID):
-        limit (int | Unset):  Default: 10.
+        limit (int | Unset): Page size for bulk GeoJSON export. The maximum is an admin-
+            configurable ceiling (default 1000; Network settings tab, `ogc_items_max_page_size`)
+            rather than the 200 used by offset-paged list endpoints, because this route pages via the
+            constant-time `after_gid` keyset cursor. Per OGC API Features Core /req/core/fc-limit-
+            response-1(C) a value above the ceiling is clamped to it, not rejected. Default: 10.
         offset (int | Unset): Legacy offset-based pagination. Prefer `after_gid` keyset cursor
             (via the `next` link) — offset is retained for backward compatibility but is O(N) at high
             values. Default: 0.
@@ -291,7 +299,11 @@ async def asyncio_detailed(
 
     Args:
         dataset_id (UUID):
-        limit (int | Unset):  Default: 10.
+        limit (int | Unset): Page size for bulk GeoJSON export. The maximum is an admin-
+            configurable ceiling (default 1000; Network settings tab, `ogc_items_max_page_size`)
+            rather than the 200 used by offset-paged list endpoints, because this route pages via the
+            constant-time `after_gid` keyset cursor. Per OGC API Features Core /req/core/fc-limit-
+            response-1(C) a value above the ceiling is clamped to it, not rejected. Default: 10.
         offset (int | Unset): Legacy offset-based pagination. Prefer `after_gid` keyset cursor
             (via the `next` link) — offset is retained for backward compatibility but is O(N) at high
             values. Default: 0.
@@ -356,7 +368,11 @@ async def asyncio(
 
     Args:
         dataset_id (UUID):
-        limit (int | Unset):  Default: 10.
+        limit (int | Unset): Page size for bulk GeoJSON export. The maximum is an admin-
+            configurable ceiling (default 1000; Network settings tab, `ogc_items_max_page_size`)
+            rather than the 200 used by offset-paged list endpoints, because this route pages via the
+            constant-time `after_gid` keyset cursor. Per OGC API Features Core /req/core/fc-limit-
+            response-1(C) a value above the ceiling is clamped to it, not rejected. Default: 10.
         offset (int | Unset): Legacy offset-based pagination. Prefer `after_gid` keyset cursor
             (via the `next` link) — offset is retained for backward compatibility but is O(N) at high
             values. Default: 0.

--- a/sdks/typescript/src/client/types.gen.ts
+++ b/sdks/typescript/src/client/types.gen.ts
@@ -14588,6 +14588,8 @@ export type GetCollectionItemsCollectionsDatasetIdItemsGetData = {
     query?: {
         /**
          * Limit
+         *
+         * Page size for bulk GeoJSON export. The maximum is an admin-configurable ceiling (default 1000; Network settings tab, `ogc_items_max_page_size`) rather than the 200 used by offset-paged list endpoints, because this route pages via the constant-time `after_gid` keyset cursor. Per OGC API Features Core /req/core/fc-limit-response-1(C) a value above the ceiling is clamped to it, not rejected.
          */
         limit?: number;
         /**


### PR DESCRIPTION
## Summary

The OGC API Features items endpoint (`/collections/{dataset_id}/items`) capped `limit` at 200 and rejected anything above it with HTTP 400. That was sized for offset pagination; Phase 269 H-24 moved this route to the constant-time `after_gid` keyset cursor, so a large page now costs response size, not query time.

Following review, this PR does **not** hardcode a new higher constant. Instead it makes the ceiling an **admin-configurable knob** (resolving #666) and **clamps** over-ceiling requests instead of rejecting them:

- **`OGC_ITEMS_MAX_PAGE_SIZE`** — a `PersistentConfig[int]` on the Network settings tab (same mechanism as `global_rate_limit` / `upload_max_size_mb`), default **1,000**. Operators raise it for bulk GeoJSON export or lower it on memory-constrained deployments, from the dashboard, no redeploy.
- **Clamp, don't reject** — the static `Query(le=...)` bound moves into the handler (`limit = min(limit, max(1, ceiling))`), satisfying OGC API Features Core `/req/core/fc-limit-response-1(C)` ("a value above the maximum SHALL NOT error"). Mirrors the STAC side (#664). The offset-paged list endpoints keep their 200 cap.
- Conservative default addresses the memory concern (the offset path is O(N) and the response is built fully in memory on an anonymous endpoint; cf. the #643 OOM) while leaving bulk export a dashboard opt-in.

Closes #666

## Changes

- `backend/app/core/persistent_config.py` — `OGC_ITEMS_MAX_PAGE_SIZE` knob (default 1,000, `network` tab).
- `backend/app/standards/ogc/router.py` — drop `le=` from the `limit` query; clamp to the configured ceiling in the handler.
- `backend/app/modules/settings/schemas.py` — value validator (`1..100000`).
- `frontend/.../SettingsNetworkTab.tsx` + all four locale bundles — admin dashboard field.
- `backend/openapi.json`, SDKs, frontend API types — regenerated.

## Verification

- `tests/test_ogc_pagination.py`: at-ceiling accepted, above-ceiling clamped (200, not 400/422), and a non-default configured ceiling honored. Full OGC + settings backend suites pass.
- Frontend i18n locale-parity + settings-tab suites pass; `make openapi-check` and `pre-commit run --all-files` clean.