### PR TITLE
fix(ci): point stac-validate at the api host port, surface login errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1590,19 +1590,31 @@ jobs:
       - name: Raise the global rate limit for the validator burst
         # stac-api-validator fires hundreds of requests back-to-back; the
         # 60 req/s default turns the tail of the run into 429 noise.
+        #
+        # The job talks to the api container's own host port (API_PORT=8001
+        # from .env.example, no /api prefix) rather than the Vite dev proxy on
+        # 8080: the maiden run failed on an opaque error through the Vite hop,
+        # and this gate validates the STAC implementation, not the dev proxy.
+        # No -f/-s silent flags — on a bad response the body must land in the
+        # job log.
         run: |
-          token=$(curl -sf -X POST http://localhost:8080/api/auth/login \
-            -H 'Content-Type: application/x-www-form-urlencoded' \
-            --data 'username=admin&password=geolens-ci-admin-password' \
-            | python3 -c 'import json,sys; print(json.load(sys.stdin)["access_token"])')
-          curl -sf -X PUT http://localhost:8080/api/settings/ \
+          for i in 1 2 3; do
+            resp=$(curl -X POST http://localhost:8001/auth/login \
+              -H 'Content-Type: application/x-www-form-urlencoded' \
+              --data 'username=admin&password=geolens-ci-admin-password') && \
+              token=$(python3 -c 'import json,sys; print(json.loads(sys.argv[1])["access_token"])' "$resp") && break
+            echo "login attempt $i failed; response was: $resp"
+            sleep 5
+          done
+          [ -n "${token:-}" ] || { echo "could not obtain an admin token"; exit 1; }
+          curl --fail-with-body -X PUT http://localhost:8001/settings/ \
             -H "Authorization: Bearer $token" -H 'Content-Type: application/json' \
             -d '{"settings":{"global_rate_limit":500}}' -o /dev/null
 
       - name: Run stac-api-validator
         run: |
           pipx run stac-api-validator==0.6.8 \
-            --root-url http://localhost:8080/api/stac/ \
+            --root-url http://localhost:8001/stac/ \
             --conformance core \
             --conformance collections \
             --conformance item-search \


### PR DESCRIPTION
The job's maiden run on main failed in the rate-limit step: the admin
login through the Vite dev proxy on 8080 returned an empty body to
curl -sf, which crashed the token parse with no diagnostic. Every
component was verifiably up (Vite ready, seed step green seconds
earlier), so whatever the proxy hop did is invisible in the logs.

Talk to the api container's own host port (API_PORT=8001, no /api
prefix) instead — the gate validates the STAC implementation, not the
dev proxy — and make the step self-diagnosing: no silent curl flags,
the response body prints on failure, login retries 3x, and the settings
PUT uses --fail-with-body. STAC links stay self-consistent on the
direct port because a fresh CI database has no configured public URL,
so get_public_api_url derives from the request host. Login and
settings PUT verified against a live stack on the direct port.

Signed-off-by: Ian Shiland <ishiland@gmail.com>
