### PR TITLE
fix(config): refuse boot when admin credentials are empty

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -527,6 +527,26 @@ class Settings(BaseSettings):
         return self
 
     @model_validator(mode="after")
+    def validate_admin_credentials_nonempty(self) -> "Settings":
+        # fix(#668): .env.example ships these keys empty and compose passes
+        # "" straight through, so without this guard a verbatim-template
+        # install silently seeds the initial admin with an empty username
+        # and empty password. .env.example documents that empty values
+        # refuse to boot; enforce that here.
+        if not self.geolens_admin_username.strip():
+            raise ValueError(
+                "GEOLENS_ADMIN_USERNAME must not be empty. The initial "
+                "admin user is seeded from it on first startup; set a "
+                "username (e.g. admin) in your .env."
+            )
+        if not self.geolens_admin_password.get_secret_value().strip():
+            raise ValueError(
+                "GEOLENS_ADMIN_PASSWORD must not be empty. Generate one "
+                "with `openssl rand -base64 16` and set it in your .env."
+            )
+        return self
+
+    @model_validator(mode="after")
     def validate_known_bad_credentials(self) -> "Settings":
         jwt_value = self.jwt_secret_key.get_secret_value()
         admin_value = self.geolens_admin_password.get_secret_value()

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -580,6 +580,22 @@ class TestKnownBadCredentialsGuard:
         assert "POSTGRES_PASSWORD" in str(exc_info.value)
 
 
+class TestEmptyAdminCredentialsGuard:
+    """Refuse to boot with empty admin credentials (verbatim .env.example)."""
+
+    @pytest.mark.parametrize("username", ["", "   "])
+    def test_empty_admin_username_rejected(self, username):
+        with pytest.raises(Exception) as exc_info:
+            _make_settings(geolens_admin_username=username)
+        assert "GEOLENS_ADMIN_USERNAME" in str(exc_info.value)
+
+    @pytest.mark.parametrize("password", ["", "   "])
+    def test_empty_admin_password_rejected(self, password):
+        with pytest.raises(Exception) as exc_info:
+            _make_settings(geolens_admin_password=password)
+        assert "GEOLENS_ADMIN_PASSWORD" in str(exc_info.value)
+
+
 class TestLogLevelValidator:
     """LOG_LEVEL must be a valid stdlib logging level."""
 


### PR DESCRIPTION
## What

Adds a `Settings` model validator that refuses to boot when `GEOLENS_ADMIN_USERNAME` or `GEOLENS_ADMIN_PASSWORD` is empty or whitespace, with an actionable error message. Plus parametrized tests in `tests/test_config.py`.

## Why

`.env.example` ships both keys empty and `docker-compose.yml` passes them through verbatim (`${GEOLENS_ADMIN_USERNAME}`, no fallback), so a verbatim-template install silently seeded the initial admin with an empty username and an empty-string password. This was the root cause of the stac-validate maiden-run failures (fixed on the CI side in #668); the product-side gap remained.

Both `.env.example` and the Helm chart already claim this behavior exists ("empty values fail boot", "The backend REQUIRES these at boot") — this PR makes that true, following the existing `JWT_SECRET_KEY` guard pattern.

## Impact

- No schema/API changes. No behavior change for any deployment that sets the values, which every supported path already requires: compose (`.env`), Helm (`required` in secret.yaml), cloud-init (generated), CI (exported to `GITHUB_ENV`).
- A previously-broken install (empty admin creds, unusable admin account) now fails fast at boot with a clear message instead.

## Verification

```
cd backend && uv run pytest tests/test_config.py -q   # 126 passed
uv run ruff check . && uv run ruff format --check .
```