### PR TITLE
chore(release): bump to 1.4.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,47 @@ and releases use semantic versioning.
 
 ## [Unreleased]
 
+## [1.4.13] - 2026-07-24
+
+STAC conformance hardening: the STAC API now passes stac-api-validator for
+the core, collections, and item-search conformance classes, and a CI gate
+keeps it that way. Fresh installs with incomplete configuration now fail
+loudly at boot instead of seeding a broken admin account.
+
+### Added
+
+- **STAC API conformance is verified in CI.** Every merge to main and a
+  nightly run boot the full stack, seed a fixture catalog, and run
+  stac-api-validator (v1.0.0 core, collections, and item-search classes)
+  against it, so STAC regressions are caught before they ship.
+- **Published images link back to the repository.** All published Docker
+  images now carry the `org.opencontainers.image.source` label, so GHCR
+  package pages link to the GeoLens repository.
+
+### Changed
+
+- **STAC collection licenses reflect their members.** A collection's
+  `license` field aggregates from its member records (`various` when they
+  mix) instead of hardcoding `proprietary`.
+- **Empty STAC collections are hidden.** Collections with no visible STAC
+  items no longer appear in the catalog with a fabricated global extent;
+  they are omitted from listings and return 404 until they gain an item
+  the requester can see.
+
+### Fixed
+
+- **STAC item-search conformance.** A `limit` above the maximum now clamps
+  to 200 instead of returning an error; `bbox` and `intersects` together
+  are rejected; inverted bounding boxes are rejected; open-ended datetime
+  intervals and lowercase RFC 3339 forms are accepted while malformed
+  datetimes are rejected; optional link fields are omitted instead of
+  serialized as `null`; and the service description is served with its
+  OpenAPI media type.
+- **Empty admin credentials fail at boot.** The API refuses to start when
+  `GEOLENS_ADMIN_USERNAME` or `GEOLENS_ADMIN_PASSWORD` is empty, instead of
+  silently seeding an unusable admin account on a verbatim-template
+  install. The error says exactly which variable to set.
+
 ## [1.4.12] - 2026-07-23
 
 Launch-week hardening: cross-origin map embedding works again on every
@@ -974,7 +1015,9 @@ regression-covered fixes:
 - Initial public release of the GeoLens catalog, API, map builder, CLI, SDKs,
   Docker development stack, and public documentation entrypoints.
 
-[Unreleased]: https://github.com/geolens-io/geolens/compare/v1.4.11...HEAD
+[Unreleased]: https://github.com/geolens-io/geolens/compare/v1.4.13...HEAD
+[1.4.13]: https://github.com/geolens-io/geolens/compare/v1.4.12...v1.4.13
+[1.4.12]: https://github.com/geolens-io/geolens/compare/v1.4.11...v1.4.12
 [1.4.11]: https://github.com/geolens-io/geolens/compare/v1.4.10...v1.4.11
 [1.4.10]: https://github.com/geolens-io/geolens/compare/v1.4.9...v1.4.10
 [1.4.9]: https://github.com/geolens-io/geolens/compare/v1.4.8...v1.4.9

--- a/backend/app/api/main.py
+++ b/backend/app/api/main.py
@@ -568,7 +568,7 @@ _is_production = settings.is_production
 # no metadata to read. We fall back to the current published line so import never
 # crashes. Keep this fallback in lockstep with backend/pyproject.toml — it is one
 # of the sites `make bump` rewrites.
-_FALLBACK_APP_VERSION = "1.4.12"
+_FALLBACK_APP_VERSION = "1.4.13"
 
 
 def _resolve_app_version() -> str:

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -17253,7 +17253,7 @@
     "summary": "PostGIS-native geospatial data catalog with OGC API Features and Records support",
     "termsOfService": "https://github.com/geolens-io/geolens/blob/main/LICENSE",
     "title": "GeoLens API",
-    "version": "1.4.12"
+    "version": "1.4.13"
   },
   "openapi": "3.1.0",
   "paths": {

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geolens-backend"
-version = "1.4.12"
+version = "1.4.13"
 description = "PostGIS-native GIS data catalog"
 # Docker image (Dockerfile) ships python:3.14-slim (see the Dockerfile FROM for
 # the exact patch pin) as the project's tested runtime.

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -865,7 +865,7 @@ wheels = [
 
 [[package]]
 name = "geolens-backend"
-version = "1.4.12"
+version = "1.4.13"
 source = { virtual = "." }
 dependencies = [
     { name = "alembic" },

--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "geolens-cli"
-version = "1.4.12"
+version = "1.4.13"
 description = "Apache-2.0 command-line interface for the GeoLens API. Login, scan, publish, and export STAC against any GeoLens instance."
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/docs-contract.json
+++ b/docs-contract.json
@@ -1,6 +1,6 @@
 {
   "_comment": "Canonical cross-surface facts for the GeoLens README, marketing site (getgeolens.com/src), and docs site (getgeolens.com/docs). Validated against scripts/install.sh + backend/pyproject.toml by scripts/check_docs_contract.py (geolens CI). The getgeolens.com repo vendors a copy and enforces the same `forbidden` list in its own CI. See docs-internal/DOC-CONSISTENCY-STRATEGY for the full design. Edit a fact ONCE here (and in its canonical source) — the gates make every surface follow.",
-  "version": "1.4.12",
+  "version": "1.4.13",
   "install": {
     "oneLiner": "curl -fsSL https://getgeolens.com/install.sh | sh",
     "sourceBuild": "bash scripts/install.sh",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.4.12",
+  "version": "1.4.13",
   "type": "module",
   "license": "Apache-2.0",
   "author": "Carto Concepts, LLC",

--- a/mcp/pyproject.toml
+++ b/mcp/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "geolens-mcp"
-version = "1.4.12"
+version = "1.4.13"
 description = "Apache-2.0 read-only Model Context Protocol (MCP) server for GeoLens. Lets coding agents discover datasets, inspect schemas, and ask spatial questions against any GeoLens instance."
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "geolens",
-  "version": "1.4.12",
+  "version": "1.4.13",
   "private": true,
   "license": "Apache-2.0",
   "author": "Carto Concepts, LLC",

--- a/sdks/python/.openapi-python-client.yaml
+++ b/sdks/python/.openapi-python-client.yaml
@@ -4,7 +4,7 @@ project_name_override: geolens
 package_name_override: geolens
 # Rewritten on every `make sdks` run by scripts/sync_sdk_versions.py to match
 # backend/openapi.json info.version. Do not edit by hand.
-package_version_override: 1.4.12
+package_version_override: 1.4.13
 
 # Cleaner enum output (matches our pydantic v2 backend's enum emission).
 literal_enums: true

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "geolens"
-version = "1.4.12"
+version = "1.4.13"
 description = "Auto-generated Python SDK for the GeoLens API. Typed clients with Bearer + API-key auth helpers."
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/sdks/typescript/package-lock.json
+++ b/sdks/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@geolens/sdk",
-  "version": "1.4.12",
+  "version": "1.4.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@geolens/sdk",
-      "version": "1.4.12",
+      "version": "1.4.13",
       "license": "Apache-2.0",
       "dependencies": {
         "@hey-api/client-fetch": "0.13.1"

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@geolens/sdk",
-  "version": "1.4.12",
+  "version": "1.4.13",
   "description": "Auto-generated TypeScript SDK for the GeoLens API. Typed clients with Bearer + API-key auth helpers.",
   "license": "Apache-2.0",
   "author": "Carto Concepts, LLC",


### PR DESCRIPTION
Release 1.4.13 — STAC conformance hardening.

Bumps every version site via `make bump VERSION=1.4.13` plus the TypeScript SDK lockfile stamp and `backend/uv.lock`, and adds the 1.4.13 changelog entry (also repairs the stale `[Unreleased]` compare link and the missing `[1.4.12]` link definition).

Ships since v1.4.12:
- #664 — STAC hardening (license aggregation, empty collections hidden, item-search conformance fixes) + stac-validate CI gate + GHCR `image.source` labels
- #669 — refuse boot on empty admin credentials
- #667/#668 — stac-validate CI plumbing
- Dependabot minors (actions, frontend)

No schema or API-shape changes beyond the version stamps.

Verification: `make version-check` passes; `stac-validate` green on main (run 30098991387).