### PR TITLE
fix(ci): give the npm audit gate a scoped, expiring allowlist

### DIFF
--- a/.github/workflows/dep-audit.yml
+++ b/.github/workflows/dep-audit.yml
@@ -66,9 +66,12 @@ jobs:
       - name: Install
         working-directory: ${{ matrix.directory }}
         run: npm ci
-      - name: npm audit (block high+)
+      # Gate script instead of bare `npm audit --audit-level=high`: npm audit
+      # has no ignore mechanism, and the script carries the scoped, justified,
+      # expiring allowlist (same posture as .trivyignore.yaml).
+      - name: npm audit (block high+, scoped allowlist)
         working-directory: ${{ matrix.directory }}
-        run: npm audit --audit-level=high
+        run: node "$GITHUB_WORKSPACE/scripts/js-audit-gate.mjs"
       - name: License report (advisory — tune allowlist before enforcing)
         working-directory: ${{ matrix.directory }}
         continue-on-error: true

--- a/scripts/js-audit-gate.mjs
+++ b/scripts/js-audit-gate.mjs
@@ -1,0 +1,67 @@
+#!/usr/bin/env node
+// npm-audit gate with a scoped allowlist — the JS twin of .trivyignore.yaml
+// (npm audit has no native ignore mechanism). Runs `npm audit --json` in the
+// current working directory and fails on any high/critical advisory that is
+// not explicitly allowlisted below. Every entry needs a reason and an expiry;
+// an expired entry stops suppressing, forcing a revisit.
+import { execFileSync } from 'node:child_process';
+
+const ALLOWLIST = [
+  {
+    id: 'GHSA-qwww-vcr4-c8h2', // react-router RSC-mode CSRF (high)
+    reason:
+      'Vulnerable code is react-router’s RSC server runtime; the frontend is a ' +
+      'Vite SPA using library-mode <BrowserRouter> (frontend/src/main.tsx) — no ' +
+      'RSC entry point exists, so the vulnerable code never executes. No patched ' +
+      '7.x exists yet (the only fix is the 8.3.0 major). Drop this entry when a ' +
+      '7.x backport ships or the router is upgraded to >=8.3.0.',
+    expires: '2026-09-01',
+  },
+];
+
+let raw;
+try {
+  raw = execFileSync('npm', ['audit', '--json'], {
+    encoding: 'utf8',
+    maxBuffer: 64 * 1024 * 1024,
+  });
+} catch (err) {
+  // npm audit exits non-zero when any vulnerability exists; the JSON report is
+  // still on stdout. Anything without stdout is a real npm failure.
+  if (!err.stdout) throw err;
+  raw = err.stdout;
+}
+const report = JSON.parse(raw);
+
+const today = new Date().toISOString().slice(0, 10);
+const active = new Map(
+  ALLOWLIST.filter((e) => e.expires >= today).map((e) => [e.id, e]),
+);
+for (const e of ALLOWLIST.filter((e) => e.expires < today)) {
+  console.error(`allowlist entry ${e.id} expired ${e.expires} — no longer suppressed`);
+}
+
+// Advisories live in `via` objects on the directly-vulnerable package; string
+// entries are transitive references rooted at one of those objects, so
+// checking the objects alone covers the whole tree.
+const failing = new Map();
+for (const vuln of Object.values(report.vulnerabilities ?? {})) {
+  for (const via of vuln.via ?? []) {
+    if (typeof via !== 'object') continue;
+    if (via.severity !== 'high' && via.severity !== 'critical') continue;
+    const id = (via.url ?? '').split('/').pop() ?? '';
+    if (active.has(id)) {
+      console.log(`allowlisted ${via.severity}: ${via.name} — ${via.title} (${id}, expires ${active.get(id).expires})`);
+    } else {
+      failing.set(id || `${via.name}: ${via.title}`, via);
+    }
+  }
+}
+
+if (failing.size > 0) {
+  for (const [id, via] of failing) {
+    console.error(`BLOCKING ${via.severity}: ${via.name} — ${via.title} (${id})`);
+  }
+  process.exit(1);
+}
+console.log('npm audit gate: no unallowlisted high/critical advisories.');


### PR DESCRIPTION
## Summary

GHSA-qwww-vcr4-c8h2 (react-router 7.12.0–8.2.0, high: CSRF in **RSC mode**) published this week and now fails the `JS audit (frontend)` job on every frontend-touching PR (first tripped on #671). Main itself goes red on Monday's scheduled run.

The advisory doesn't apply here: the frontend is a Vite SPA using library-mode `<BrowserRouter>` (`frontend/src/main.tsx`) — react-router's RSC server runtime never executes. There is no patched 7.x; the only npm-suggested fix is the 8.3.0 **major**, which is not something to take mid-launch-window for unreachable code.

## Change

`npm audit` has no native ignore mechanism, so the bare `npm audit --audit-level=high` step becomes `node scripts/js-audit-gate.mjs` — a ~70-line gate that runs `npm audit --json` and fails on any high/critical advisory **not** in its inline allowlist. Same posture as the existing `.trivyignore.yaml`: every entry carries a written justification and an **expiry date** (this one: 2026-09-01) after which it stops suppressing and the gate goes red again, forcing a revisit. Drop the entry when a 7.x backport ships or the router moves to ≥8.3.0.

## Verification

Ran the gate in all three matrix directories locally:
- `.` and `sdks/typescript`: pass, no advisories.
- `frontend`: prints the allowlisted advisory, passes.
- Failure path: with the entry's expiry set in the past, the gate prints `BLOCKING high: react-router …` and exits 1.

No schema/API/config impacts; CI-only.