### PR TITLE
feat(ai): add a run_analysis chat tool for buffer/centroid previews

### DIFF
--- a/backend/app/core/processing_port.py
+++ b/backend/app/core/processing_port.py
@@ -230,6 +230,17 @@ class ProcessingPort(Protocol):
         self, session: AsyncSession, user: Identity
     ) -> set[str]: ...
 
+    async def run_analysis_preview(
+        self,
+        session: AsyncSession,
+        dataset: Any,
+        operation: str,
+        *,
+        user_id: uuid.UUID,
+        distance_meters: float | None = None,
+        mask: dict[str, Any] | None = None,
+    ) -> Any: ...  # -> AnalysisPreviewResponse
+
     async def get_column_stats(
         self,
         session: AsyncSession,

--- a/backend/app/platform/ai_tool_payloads.py
+++ b/backend/app/platform/ai_tool_payloads.py
@@ -1,0 +1,36 @@
+"""Trim AI tool results before they are echoed back into the model's context.
+
+A chat tool result serves two consumers with very different needs:
+
+- the **action collector**, which forwards map payload (GeoJSON overlays) to
+  the browser, and
+- the **model**, which is re-fed the tool result as conversation context so it
+  can narrate the outcome.
+
+Geometry is exclusively the first consumer's business — the model narrates from
+``feature_count`` / ``row_count`` / ``rows``, never from raw coordinates. Left
+in, a single ``run_analysis`` buffer preview of a 412-feature layer serialized
+to ~1.3 MB (~325k tokens), blowing MAX_REQUEST_TOKEN_BUDGET in one round and
+billing the user for coordinates the model cannot use. ``query_data``'s overlay
+(capped at 50 features) was quietly paying a smaller version of the same tax.
+
+Call this at every point where a tool result is serialized *for the provider*;
+the action collector must keep receiving the untrimmed dict.
+"""
+
+from __future__ import annotations
+
+# Keys whose whole purpose is client-side map rendering. `bbox` deliberately
+# stays: it is four numbers and gives the model useful spatial context.
+_MAP_ONLY_KEYS = frozenset({"geojson"})
+
+
+def model_safe_tool_result(result: dict) -> dict:
+    """Return ``result`` without map-only payload, for provider serialization.
+
+    Returns the original object when there is nothing to strip, so the common
+    path allocates nothing.
+    """
+    if not any(key in result for key in _MAP_ONLY_KEYS):
+        return result
+    return {k: v for k, v in result.items() if k not in _MAP_ONLY_KEYS}

--- a/backend/app/platform/extensions/defaults.py
+++ b/backend/app/platform/extensions/defaults.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from app.core.db.tenant_session import defer_async_with_tenant
+from app.platform.ai_tool_payloads import model_safe_tool_result
 
 
 class DefaultBrandingExtension:
@@ -392,6 +393,24 @@ class DefaultProcessingPort:
         from app.modules.catalog.authorization import get_user_roles
 
         return await get_user_roles(session, user)
+
+    async def run_analysis_preview(  # type: ignore[no-untyped-def]
+        self, session, dataset, operation, *, user_id, distance_meters=None, mask=None
+    ):
+        """Run a parameterized analysis preview (M4) for the AI chat surface.
+
+        Params are re-validated by ``AnalysisPreviewRequest`` here, so the
+        LLM-supplied values pass through exactly the same bounds/requiredness
+        checks as the HTTP endpoint (a ValueError surfaces as a tool error the
+        model can retry from). Callers own the dataset visibility check.
+        """
+        from app.modules.catalog.datasets.domain.schemas import AnalysisPreviewRequest
+        from app.modules.catalog.datasets.domain.service import run_analysis_preview
+
+        request = AnalysisPreviewRequest(
+            operation=operation, distance_meters=distance_meters, mask=mask
+        )
+        return await run_analysis_preview(session, dataset, request, user_id)
 
     async def get_column_stats(
         self, session, table_name, column_name, *, class_count=5, allowed_tables=None
@@ -1230,7 +1249,9 @@ class DefaultAnthropicProvider:
                                 "tool_use_id": block.id,
                                 # default=str: query_data rows can carry Decimal /
                                 # datetime values straight from PostGIS.
-                                "content": json.dumps(result, default=str),
+                                "content": json.dumps(
+                                    model_safe_tool_result(result), default=str
+                                ),
                             }
                         )
 
@@ -1531,7 +1552,9 @@ class DefaultOpenAICompatibleProvider:
                             "role": "tool",
                             "tool_call_id": tool_call.id,
                             # default=str: see the Anthropic tool_result path above.
-                            "content": json.dumps(result, default=str),
+                            "content": json.dumps(
+                                model_safe_tool_result(result), default=str
+                            ),
                         }
                     )
                 continue

--- a/backend/app/processing/ai/chat_actions.py
+++ b/backend/app/processing/ai/chat_actions.py
@@ -21,6 +21,10 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.identity import Identity
 from app.platform.sandbox import SandboxError
+from app.processing.ai.chat_analysis import (
+    collect_run_analysis_action,
+    handle_run_analysis,
+)
 from app.processing.ai.chat_constants import _EDIT_TOOLS, ERROR_MESSAGES
 from app.processing.ai.chat_geojson import (
     _extract_geojson,
@@ -348,6 +352,11 @@ async def _execute_chat_tool(
             )
             return {"error": "Could not generate or execute query"}
 
+    if tool_name == "run_analysis":
+        # handle_run_analysis owns its own error mapping (including the broad
+        # catch-all) so every failure returns a tool result, never an exception.
+        return await handle_run_analysis(tool_input, session, user, layers, port=port)
+
     if tool_name == "set_data_driven_style":
         return await _build_data_driven_style(tool_input, session, layers, port=port)
 
@@ -464,6 +473,8 @@ def _collect_chat_action(tool_name: str, tool_input: dict, result: dict) -> dict
                 action["geojson"] = result["geojson"]
                 action["bbox"] = result["bbox"]
             return action
+        if tool_name == "run_analysis":
+            return collect_run_analysis_action(result)
         return None
 
     if tool_name == "set_data_driven_style":

--- a/backend/app/processing/ai/chat_actions.py
+++ b/backend/app/processing/ai/chat_actions.py
@@ -355,7 +355,9 @@ async def _execute_chat_tool(
     if tool_name == "run_analysis":
         # handle_run_analysis owns its own error mapping (including the broad
         # catch-all) so every failure returns a tool result, never an exception.
-        return await handle_run_analysis(tool_input, session, user, layers, port=port)
+        return await handle_run_analysis(
+            tool_input, session, user, user_roles, layers, port=port
+        )
 
     if tool_name == "set_data_driven_style":
         return await _build_data_driven_style(tool_input, session, layers, port=port)

--- a/backend/app/processing/ai/chat_analysis.py
+++ b/backend/app/processing/ai/chat_analysis.py
@@ -137,10 +137,16 @@ async def _run_analysis(
         return out
     out["geojson"] = result.geojson
     out["bbox"] = result.bbox
-    out["note"] = (
-        "Preview only — it is not saved. The user can save it as a dataset "
-        "from the Analysis panel."
-    )
+    if result.truncated:
+        # Surface the source total so the map badge can say "500 of N" rather
+        # than presenting a capped preview as the whole result. buffer and
+        # centroid are 1:1 per feature, so the source count IS the output total.
+        out["source_feature_count"] = getattr(dataset, "feature_count", None)
+    # Deliberately surface-neutral: view-only callers get this tool too (it is
+    # read-only), and they land on the public viewer, which has no Analysis
+    # rail — BuilderRail is rendered by MapBuilderPage alone. Naming the panel
+    # here told half the audience to use something they cannot reach.
+    out["note"] = "This preview is temporary and is not saved."
     return out
 
 
@@ -148,14 +154,23 @@ def collect_run_analysis_action(result: dict) -> dict | None:
     """Build the map action for a run_analysis result, or None when there is none.
 
     run_analysis reuses ``show_query_result`` purely as the ephemeral-overlay
-    carrier: geojson + bbox only, no columns/rows. Every chat surface already
-    renders that pair (fly-to + overlay) and skips the inline data table when
-    ``rows`` is absent — a gid-only table would be noise.
+    carrier: geojson + bbox (+ the truncation pair), never columns/rows. Every
+    chat surface already renders geojson+bbox (fly-to + overlay) and skips the
+    inline data table when ``rows`` is absent — a gid-only table would be noise.
+
+    ``truncated``/``row_count`` ride along only when the 500-feature cap
+    actually bit, so EphemeralBadge can say "500 of 10,651 features" instead of
+    presenting a capped preview as the complete result.
     """
-    if result.get("bbox") and "geojson" in result:
-        return {
-            "type": "show_query_result",
-            "geojson": result["geojson"],
-            "bbox": result["bbox"],
-        }
-    return None
+    if not (result.get("bbox") and "geojson" in result):
+        return None
+    action = {
+        "type": "show_query_result",
+        "geojson": result["geojson"],
+        "bbox": result["bbox"],
+    }
+    total = result.get("source_feature_count")
+    if result.get("truncated") and total:
+        action["truncated"] = True
+        action["row_count"] = total
+    return action

--- a/backend/app/processing/ai/chat_analysis.py
+++ b/backend/app/processing/ai/chat_analysis.py
@@ -15,6 +15,7 @@ from typing import TYPE_CHECKING
 from uuid import UUID
 
 import structlog
+from fastapi import HTTPException
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.identity import Identity
@@ -32,6 +33,7 @@ async def handle_run_analysis(
     tool_input: dict,
     session: AsyncSession,
     user: Identity,
+    user_roles: set[str],
     layers: list[ChatMapLayer],
     *,
     port: "ProcessingPort",
@@ -42,7 +44,9 @@ async def handle_run_analysis(
     degrades to a message the model can react to instead of breaking the turn.
     """
     try:
-        return await _run_analysis(tool_input, session, user, layers, port=port)
+        return await _run_analysis(
+            tool_input, session, user, user_roles, layers, port=port
+        )
     except Exception as e:  # broad: analysis/sandbox layer can throw varied DB errors; map to user-facing fallback
         logger.warning("run_analysis.failed", error=str(e), error_type=type(e).__name__)
         return {"error": "Could not run that analysis."}
@@ -52,6 +56,7 @@ async def _run_analysis(
     tool_input: dict,
     session: AsyncSession,
     user: Identity,
+    user_roles: set[str],
     layers: list[ChatMapLayer],
     *,
     port: "ProcessingPort",
@@ -70,30 +75,44 @@ async def _run_analysis(
         }
 
     try:
-        dataset = await port.get_dataset(session, UUID(str(layer.dataset_id)))
-    except (ValueError, AttributeError, TypeError):
-        dataset = None
+        dataset_id = UUID(str(layer.dataset_id))
+    except ValueError:
+        # Malformed client-supplied id — same user-facing outcome as a miss.
+        return {"error": "That layer's dataset is no longer available."}
+    dataset = await port.get_dataset(session, dataset_id)
     if dataset is None:
         return {"error": "That layer's dataset is no longer available."}
 
     try:
-        await port.check_dataset_access(session, dataset, dataset.id, user)
-    except Exception:  # broad: access denial arrives as HTTPException(404) — must not break the chat turn
+        await port.check_dataset_access(
+            session, dataset, dataset.id, user, user_roles=user_roles
+        )
+    except HTTPException:
+        # check_dataset_access signals denial with a 404 — anything else is a
+        # real failure and belongs in the generic handler, not reported to the
+        # user as an access problem.
         logger.info("run_analysis.access_denied", dataset_id=str(dataset.id))
         return {"error": "You don't have access to that layer's dataset."}
 
-    if not getattr(dataset, "geometry_type", None) or not getattr(
-        dataset, "table_name", None
-    ):
+    if not dataset.geometry_type or not dataset.table_name:
         return {"error": "That layer has no geometry to analyze."}
+
+    # fix(#674 review P2): only buffer consumes distance_meters. The tool schema
+    # calls it "ignored otherwise", so a model may well send a placeholder 0 on a
+    # centroid call — forwarding that would trip AnalysisPreviewRequest's gt=0
+    # bound and fail a perfectly valid preview. Drop it for every other op.
+    operation = tool_input.get("operation")
+    distance_meters = (
+        tool_input.get("distance_meters") if operation == "buffer" else None
+    )
 
     try:
         result = await port.run_analysis_preview(
             session,
             dataset,
-            tool_input.get("operation"),
+            operation,
             user_id=user.id,
-            distance_meters=tool_input.get("distance_meters"),
+            distance_meters=distance_meters,
         )
     except ValueError as exc:
         # Pydantic/param validation (bad enum, missing or out-of-range
@@ -108,7 +127,7 @@ async def _run_analysis(
         }
 
     out: dict = {
-        "operation": tool_input.get("operation"),
+        "operation": operation,
         "layer_id": layer.id,
         "feature_count": result.feature_count,
         "truncated": result.truncated,

--- a/backend/app/processing/ai/chat_analysis.py
+++ b/backend/app/processing/ai/chat_analysis.py
@@ -1,0 +1,142 @@
+"""AI-chat ``run_analysis`` tool: parameterized PostGIS previews (M4 Phase 5).
+
+Split out of ``chat_actions.py`` to keep that module inside its line budget
+(test_layering.test_decomposed_service_modules_stay_within_size_budgets),
+following the existing ``chat_styles`` / ``chat_geojson`` sibling pattern.
+
+Reuses the catalog analysis service through ``ProcessingPort`` — the same
+server-built SQL, Pydantic param validation, and read-only sandbox rails as
+the ``/datasets/{id}/analysis/preview/`` endpoint. No LLM-authored SQL is
+involved anywhere on this path: the model only picks an operation enum and a
+bounded number.
+"""
+
+from typing import TYPE_CHECKING
+from uuid import UUID
+
+import structlog
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.identity import Identity
+from app.platform.sandbox import SandboxError
+from app.processing.ai.chat_constants import ERROR_MESSAGES
+from app.processing.ai.schemas import ChatMapLayer
+
+if TYPE_CHECKING:
+    from app.core.processing_port import ProcessingPort
+
+logger = structlog.stdlib.get_logger(__name__)
+
+
+async def handle_run_analysis(
+    tool_input: dict,
+    session: AsyncSession,
+    user: Identity,
+    layers: list[ChatMapLayer],
+    *,
+    port: "ProcessingPort",
+) -> dict:
+    """Run one parameterized PostGIS operation on a layer and return a preview.
+
+    Always returns a tool-result dict — never raises — so a failed analysis
+    degrades to a message the model can react to instead of breaking the turn.
+    """
+    try:
+        return await _run_analysis(tool_input, session, user, layers, port=port)
+    except Exception as e:  # broad: analysis/sandbox layer can throw varied DB errors; map to user-facing fallback
+        logger.warning("run_analysis.failed", error=str(e), error_type=type(e).__name__)
+        return {"error": "Could not run that analysis."}
+
+
+async def _run_analysis(
+    tool_input: dict,
+    session: AsyncSession,
+    user: Identity,
+    layers: list[ChatMapLayer],
+    *,
+    port: "ProcessingPort",
+) -> dict:
+    """Resolve the layer's dataset, authorize it, and run the preview.
+
+    The dataset is resolved from ``layer.dataset_id`` and then re-checked with
+    ``check_dataset_access`` (AGENTS.md Rule 1) — the layer list is
+    client-supplied, so neither its dataset_id nor its table name may be
+    trusted as evidence of access.
+    """
+    layer = next((lyr for lyr in layers if lyr.id == tool_input.get("layer_id")), None)
+    if layer is None:
+        return {
+            "error": "That layer is not on this map — pick one of the listed layers."
+        }
+
+    try:
+        dataset = await port.get_dataset(session, UUID(str(layer.dataset_id)))
+    except (ValueError, AttributeError, TypeError):
+        dataset = None
+    if dataset is None:
+        return {"error": "That layer's dataset is no longer available."}
+
+    try:
+        await port.check_dataset_access(session, dataset, dataset.id, user)
+    except Exception:  # broad: access denial arrives as HTTPException(404) — must not break the chat turn
+        logger.info("run_analysis.access_denied", dataset_id=str(dataset.id))
+        return {"error": "You don't have access to that layer's dataset."}
+
+    if not getattr(dataset, "geometry_type", None) or not getattr(
+        dataset, "table_name", None
+    ):
+        return {"error": "That layer has no geometry to analyze."}
+
+    try:
+        result = await port.run_analysis_preview(
+            session,
+            dataset,
+            tool_input.get("operation"),
+            user_id=user.id,
+            distance_meters=tool_input.get("distance_meters"),
+        )
+    except ValueError as exc:
+        # Pydantic/param validation (bad enum, missing or out-of-range
+        # distance) — hand the reason back so the model can retry correctly.
+        return {"error": str(exc)}
+    except SandboxError as exc:
+        return {
+            "error": ERROR_MESSAGES.get(
+                exc.category, "The analysis could not be completed."
+            ),
+            "category": exc.category,
+        }
+
+    out: dict = {
+        "operation": tool_input.get("operation"),
+        "layer_id": layer.id,
+        "feature_count": result.feature_count,
+        "truncated": result.truncated,
+    }
+    if result.feature_count == 0:
+        out["note"] = "The operation produced no geometry for this layer."
+        return out
+    out["geojson"] = result.geojson
+    out["bbox"] = result.bbox
+    out["note"] = (
+        "Preview only — it is not saved. The user can save it as a dataset "
+        "from the Analysis panel."
+    )
+    return out
+
+
+def collect_run_analysis_action(result: dict) -> dict | None:
+    """Build the map action for a run_analysis result, or None when there is none.
+
+    run_analysis reuses ``show_query_result`` purely as the ephemeral-overlay
+    carrier: geojson + bbox only, no columns/rows. Every chat surface already
+    renders that pair (fly-to + overlay) and skips the inline data table when
+    ``rows`` is absent — a gid-only table would be noise.
+    """
+    if result.get("bbox") and "geojson" in result:
+        return {
+            "type": "show_query_result",
+            "geojson": result["geojson"],
+            "bbox": result["bbox"],
+        }
+    return None

--- a/backend/app/processing/ai/chat_service.py
+++ b/backend/app/processing/ai/chat_service.py
@@ -232,7 +232,9 @@ def build_chat_system_prompt(
             "\n\n## Read-Only Access\n"
             "You do NOT have edit access to this map — the current user can view it "
             "but does not own it. You may ONLY answer questions about the map's data "
-            "using the query_data tool. You cannot change styles, filters, labels, "
+            "using the query_data and run_analysis tools (both are read-only; "
+            "run_analysis draws a temporary preview and saves nothing). "
+            "You cannot change styles, filters, labels, "
             "visibility, opacity, or add or remove layers; those tools are unavailable "
             "to you. If the user asks you to modify the map, briefly explain that only "
             "the map's owner can edit it, then offer to answer questions about the data."
@@ -269,6 +271,10 @@ You are a map editing assistant. The user has a map with these layers:
   add/remove layers), use the map editing tools.
 - query_data takes a natural language question -- the server generates and
   executes the SQL safely.
+- When the user asks to TRANSFORM a layer's geometry -- buffer ("within 500 m
+  of the schools"), centroid ("the centre point of each parcel") -- use
+  run_analysis, NOT query_data. It draws a temporary preview on the map and
+  saves nothing.
 - Keep your explanations concise (1-3 sentences).
 - Respond in PLAIN TEXT only. The chat panel does not render markdown: never
   use **bold**, headers, backticks, or [links](...). Simple "- " bullet lines

--- a/backend/app/processing/ai/constants.py
+++ b/backend/app/processing/ai/constants.py
@@ -23,6 +23,7 @@ TOOL_LABELS = {
     "add_layer": "Adding layer...",
     "set_opacity": "Adjusting opacity...",
     "query_data": "Querying data...",
+    "run_analysis": "Running analysis...",
     "get_dataset_details": "Fetching dataset details...",
 }
 

--- a/backend/app/processing/ai/router.py
+++ b/backend/app/processing/ai/router.py
@@ -720,6 +720,9 @@ async def dataset_chat_stream_endpoint(
                 # this the sandbox allowlist is user-wide and generated SQL
                 # could reach any table the user can see.
                 restrict_tables=frozenset({layer.dataset_table_name}),
+                # Dataset chat has no map — withhold the overlay-only
+                # run_analysis tool (M4 Phase 5).
+                has_map=False,
             ):
                 if await request.is_disconnected():
                     break

--- a/backend/app/processing/ai/streaming.py
+++ b/backend/app/processing/ai/streaming.py
@@ -10,6 +10,7 @@ from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.persistent_config import MAX_AI_TOKENS_PER_USER_PER_DAY
+from app.platform.ai_tool_payloads import model_safe_tool_result
 
 from app.processing.ai.chat_service import (
     _build_chat_actions,
@@ -351,7 +352,9 @@ async def _stream_anthropic_chat(
                             # default=str: query_data rows can carry Decimal /
                             # datetime values straight from PostGIS.
                             "content": json.dumps(
-                                raw_results[0] if raw_results else {},
+                                model_safe_tool_result(
+                                    raw_results[0] if raw_results else {}
+                                ),
                                 default=str,
                             ),
                         }
@@ -660,7 +663,9 @@ async def _stream_openai_chat(
                         "role": "tool",
                         "tool_call_id": call_id,
                         # default=str: see the Anthropic tool_result path above.
-                        "content": json.dumps(result, default=str),
+                        "content": json.dumps(
+                            model_safe_tool_result(result), default=str
+                        ),
                     }
                 )
             continue
@@ -742,6 +747,7 @@ async def stream_chat_edit(
     can_edit: bool = True,
     system_prompt_override: str | None = None,
     restrict_tables: frozenset[str] | None = None,
+    has_map: bool = True,
 ) -> AsyncGenerator[dict, None]:
     """Main streaming orchestrator. Yields typed event dicts.
 
@@ -758,6 +764,9 @@ async def stream_chat_edit(
     restrict_tables narrows query_data's sandbox allowlist to the calling
     surface's table scope (dataset chat passes its single table — PR #531
     review); None preserves the user-wide RBAC allowlist.
+
+    has_map=False withholds map-only tools (run_analysis) from surfaces with no
+    map to render an overlay on — see select_chat_tools.
     """
     try:
         provider, model, runtime_config = await resolve_provider(db)
@@ -779,7 +788,7 @@ async def stream_chat_edit(
             history=history_dicts,
             port=port,
             map_id=map_id,
-            tools=select_chat_tools(can_edit),
+            tools=select_chat_tools(can_edit, has_map),
             restrict_tables=restrict_tables,
         ):
             yield event

--- a/backend/app/processing/ai/tools.py
+++ b/backend/app/processing/ai/tools.py
@@ -329,23 +329,82 @@ CHAT_TOOLS_ANTHROPIC = [
             "required": ["question"],
         },
     },
+    {
+        "name": "run_analysis",
+        "description": (
+            "Run a parameterized PostGIS geometry operation on a layer and "
+            "show the result on the map as a temporary preview. Use this for "
+            "requests that TRANSFORM geometry -- 'buffer the schools by 500 "
+            "metres', 'show the centre point of each parcel'. Use query_data "
+            "instead for questions ANSWERED from the data (counts, sums, "
+            "which/where/how many). The preview is not saved; tell the user "
+            "they can save it as a dataset from the Analysis panel."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "layer_id": {
+                    "type": "string",
+                    "description": "Layer ID (UUID) to run the operation on",
+                },
+                "operation": {
+                    "type": "string",
+                    # Deliberately narrower than the preview endpoint's enum:
+                    # `clip` needs a drawn mask polygon that only the Analysis
+                    # rail panel can supply, and `dissolve` is materialize-only
+                    # (an aggregate with no preview shape).
+                    "enum": ["buffer", "centroid"],
+                    "description": (
+                        "buffer = grow each feature by a distance; "
+                        "centroid = replace each feature with its centre point"
+                    ),
+                },
+                "distance_meters": {
+                    "type": "number",
+                    "description": (
+                        "Buffer distance in metres, 0 < d <= 100000 "
+                        "(required for buffer, ignored otherwise)"
+                    ),
+                },
+            },
+            "required": ["layer_id", "operation"],
+        },
+    },
 ]
 
 
 # Read-only chat tools: a user who can VIEW a map but not edit it (non-owner /
 # non-admin) may ask the AI questions about the map's data but must not be able
 # to change it. We enforce this by withholding every mutating tool from the
-# model — with only ``query_data`` available it can answer questions (sandboxed,
-# RBAC-scoped SELECTs) but has no tool to emit a style / filter / label /
-# visibility / opacity / add- or remove-layer edit. Edit *persistence* is
-# separately owner-gated at Save, so this is defense-in-depth, not the only gate.
-CHAT_TOOLS_READONLY = [t for t in CHAT_TOOLS_ANTHROPIC if t["name"] == "query_data"]
+# model — the read-only set can answer questions (sandboxed, RBAC-scoped
+# SELECTs) and draw a temporary analysis preview, but has no tool to emit a
+# style / filter / label / visibility / opacity / add- or remove-layer edit.
+# ``run_analysis`` qualifies: it only SELECTs through the same sandbox rails and
+# its result is an ephemeral overlay, never a persisted map change. Edit
+# *persistence* is separately owner-gated at Save, so this is defense-in-depth,
+# not the only gate.
+_READONLY_TOOL_NAMES = {"query_data", "run_analysis"}
+CHAT_TOOLS_READONLY = [
+    t for t in CHAT_TOOLS_ANTHROPIC if t["name"] in _READONLY_TOOL_NAMES
+]
+
+# Tools whose entire output is a map overlay — withheld from map-less surfaces
+# (dataset-scoped chat) by select_chat_tools(has_map=False).
+_MAP_ONLY_TOOL_NAMES = {"run_analysis"}
 
 
-def select_chat_tools(can_edit: bool) -> list:
+def select_chat_tools(can_edit: bool, has_map: bool = True) -> list:
     """Return the chat tool set for a caller.
 
     Full tool set when the caller may edit the map; read-only (``query_data``
-    only) when they may only view it.
+    + ``run_analysis``) when they may only view it.
+
+    has_map=False drops the map-only tools for surfaces with no map to draw on
+    (dataset-scoped chat): ``run_analysis``'s whole output is an ephemeral map
+    overlay, so offering it there would let the model promise a preview the
+    surface cannot render.
     """
-    return CHAT_TOOLS_ANTHROPIC if can_edit else CHAT_TOOLS_READONLY
+    tools = CHAT_TOOLS_ANTHROPIC if can_edit else CHAT_TOOLS_READONLY
+    if not has_map:
+        tools = [t for t in tools if t["name"] not in _MAP_ONLY_TOOL_NAMES]
+    return tools

--- a/backend/app/processing/ai/tools.py
+++ b/backend/app/processing/ai/tools.py
@@ -337,8 +337,9 @@ CHAT_TOOLS_ANTHROPIC = [
             "requests that TRANSFORM geometry -- 'buffer the schools by 500 "
             "metres', 'show the centre point of each parcel'. Use query_data "
             "instead for questions ANSWERED from the data (counts, sums, "
-            "which/where/how many). The preview is not saved; tell the user "
-            "they can save it as a dataset from the Analysis panel."
+            "which/where/how many). The preview is temporary and is not "
+            "saved. Do NOT tell the user where to save it -- the tool result "
+            "says what they need to know, and the surfaces differ."
         ),
         "input_schema": {
             "type": "object",

--- a/backend/tests/test_ai_chat_run_analysis.py
+++ b/backend/tests/test_ai_chat_run_analysis.py
@@ -200,6 +200,7 @@ class TestRunAnalysisHandler:
             {"layer_id": "layer-1", "operation": "buffer", "distance_meters": 1000},
             test_db_session,
             admin,
+            await _default_port.get_user_roles(test_db_session, admin),
             [_layer_for(ds)],
             port=_default_port,
         )
@@ -218,6 +219,7 @@ class TestRunAnalysisHandler:
             {"layer_id": "layer-1", "operation": "centroid"},
             test_db_session,
             admin,
+            await _default_port.get_user_roles(test_db_session, admin),
             [_layer_for(ds)],
             port=_default_port,
         )
@@ -230,6 +232,7 @@ class TestRunAnalysisHandler:
             {"layer_id": "not-on-this-map", "operation": "centroid"},
             test_db_session,
             admin,
+            await _default_port.get_user_roles(test_db_session, admin),
             [],
             port=_default_port,
         )
@@ -250,11 +253,37 @@ class TestRunAnalysisHandler:
             {"layer_id": "layer-1", "operation": "centroid"},
             test_db_session,
             other,
+            await _default_port.get_user_roles(test_db_session, other),
             [_layer_for(ds)],
             port=_default_port,
         )
         assert "error" in result
         assert "geojson" not in result
+
+    @pytest.mark.parametrize("distance", [0, -5, 1_000_000, 500])
+    async def test_centroid_ignores_any_distance_meters(
+        self, test_db_session: AsyncSession, distance
+    ):
+        """fix(#674 review P2): the tool schema calls distance_meters "ignored
+        otherwise", so a model may send a placeholder on a centroid call. Those
+        values must not reach AnalysisPreviewRequest's gt=0 / le=100000 bounds
+        and fail an otherwise valid preview."""
+        admin = await _get_admin(test_db_session)
+        ds = await _create_polygon_dataset(test_db_session, created_by=admin.id)
+        result = await _handle_run_analysis(
+            {
+                "layer_id": "layer-1",
+                "operation": "centroid",
+                "distance_meters": distance,
+            },
+            test_db_session,
+            admin,
+            await _default_port.get_user_roles(test_db_session, admin),
+            [_layer_for(ds)],
+            port=_default_port,
+        )
+        assert "error" not in result, result
+        assert result["geojson"]["features"][0]["geometry"]["type"] == "Point"
 
     @pytest.mark.parametrize(
         "params",
@@ -278,6 +307,7 @@ class TestRunAnalysisHandler:
             {"layer_id": "layer-1", **params},
             test_db_session,
             admin,
+            await _default_port.get_user_roles(test_db_session, admin),
             [_layer_for(ds)],
             port=_default_port,
         )

--- a/backend/tests/test_ai_chat_run_analysis.py
+++ b/backend/tests/test_ai_chat_run_analysis.py
@@ -1,0 +1,315 @@
+"""Tests for the AI-chat ``run_analysis`` tool (M4 Phase 5).
+
+The tool lets the chat model run a parameterized PostGIS preview on a map
+layer, reusing the catalog analysis service through ProcessingPort. Two things
+matter most and are pinned here:
+
+1. Access control — the layer list is CLIENT-supplied, so a caller must not be
+   able to analyze a dataset they cannot read by naming it in ``layers``.
+2. Tool-set scoping — ``run_analysis`` is read-only (belongs in the view-only
+   toolbox) but map-only (must not reach the map-less dataset-chat surface).
+
+Requirements:
+  - Docker database must be running (docker compose up db)
+"""
+
+import uuid
+
+import pytest
+from sqlalchemy import select, text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.config import settings
+from app.modules.auth.models import User
+from app.processing.ai.chat_actions import _collect_chat_action
+from app.processing.ai.chat_analysis import handle_run_analysis as _handle_run_analysis
+from app.processing.ai.schemas import ChatAction, ChatMapLayer
+from app.processing.ai.tools import (
+    CHAT_TOOLS_ANTHROPIC,
+    CHAT_TOOLS_READONLY,
+    select_chat_tools,
+)
+from app.platform.ai_tool_payloads import model_safe_tool_result
+from app.platform.extensions.defaults import DefaultProcessingPort
+
+from tests.factories import create_dataset
+
+SQUARE = "POLYGON((0 0, 0 1, 1 1, 1 0, 0 0))"
+
+_default_port = DefaultProcessingPort()
+
+
+async def _get_admin(session: AsyncSession) -> User:
+    result = await session.execute(
+        select(User).where(User.username == settings.geolens_admin_username)
+    )
+    return result.scalar_one()
+
+
+async def _create_other_user(session: AsyncSession) -> User:
+    """A second, non-admin user with no grants on the admin's datasets."""
+    other = User(
+        username=f"analysis_chat_{uuid.uuid4().hex[:8]}",
+        password_hash="unused",
+        is_active=True,
+    )
+    session.add(other)
+    await session.flush()
+    await session.commit()
+    await session.refresh(other)
+    return other
+
+
+async def _create_polygon_dataset(
+    session: AsyncSession,
+    *,
+    created_by: uuid.UUID,
+    visibility: str = "public",
+):
+    """Create a real data table with one polygon + its catalog rows."""
+    table_name = f"ds_{uuid.uuid4().hex[:12]}"
+    await session.execute(
+        text(
+            f"CREATE TABLE data.{table_name} ("
+            f"  gid SERIAL PRIMARY KEY,"
+            f"  geom geometry(Polygon, 4326),"
+            f"  geom_4326 geometry(Polygon, 4326)"
+            f")"
+        )
+    )
+    await session.execute(
+        text(
+            f"INSERT INTO data.{table_name} (geom, geom_4326) VALUES "
+            f"(ST_GeomFromText('{SQUARE}', 4326),"
+            f" ST_GeomFromText('{SQUARE}', 4326))"
+        )
+    )
+    await session.commit()
+    return await create_dataset(
+        session,
+        created_by=created_by,
+        table_name=table_name,
+        geometry_type="POLYGON",
+        feature_count=1,
+        visibility=visibility,
+    )
+
+
+def _layer_for(dataset, layer_id: str = "layer-1") -> ChatMapLayer:
+    return ChatMapLayer(
+        id=layer_id,
+        name="Squares",
+        dataset_id=str(dataset.id),
+        dataset_table_name=dataset.table_name,
+        geometry_type=dataset.geometry_type,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tool-set scoping (pure)
+# ---------------------------------------------------------------------------
+
+
+class TestRunAnalysisToolSelection:
+    def test_run_analysis_is_advertised(self) -> None:
+        names = {t["name"] for t in CHAT_TOOLS_ANTHROPIC}
+        assert "run_analysis" in names
+
+    def test_view_only_callers_keep_run_analysis(self) -> None:
+        """It only SELECTs through the sandbox — a viewer may run it."""
+        names = {t["name"] for t in CHAT_TOOLS_READONLY}
+        assert names == {"query_data", "run_analysis"}
+
+    def test_map_less_surfaces_drop_run_analysis(self) -> None:
+        """Dataset chat has no map — offering an overlay-only tool would let
+        the model promise a preview that can never render."""
+        names = {t["name"] for t in select_chat_tools(False, has_map=False)}
+        assert names == {"query_data"}
+        edit_names = {t["name"] for t in select_chat_tools(True, has_map=False)}
+        assert "run_analysis" not in edit_names
+        assert "set_style" in edit_names
+
+    def test_clip_and_dissolve_are_not_offered(self) -> None:
+        """clip needs a drawn mask and dissolve is materialize-only; neither
+        can be driven from chat, so the enum must not tempt the model."""
+        tool = next(t for t in CHAT_TOOLS_ANTHROPIC if t["name"] == "run_analysis")
+        ops = tool["input_schema"]["properties"]["operation"]["enum"]
+        assert sorted(ops) == ["buffer", "centroid"]
+
+
+# ---------------------------------------------------------------------------
+# Action collection (pure)
+# ---------------------------------------------------------------------------
+
+
+class TestRunAnalysisActionCollection:
+    def test_emits_overlay_only_show_query_result(self) -> None:
+        """The action carries geojson+bbox and NO rows/columns, so every chat
+        surface draws the overlay and skips the inline data table."""
+        result = {
+            "operation": "centroid",
+            "feature_count": 1,
+            "truncated": False,
+            "geojson": {
+                "type": "FeatureCollection",
+                "features": [
+                    {
+                        "type": "Feature",
+                        "geometry": {"type": "Point", "coordinates": [0.5, 0.5]},
+                        "properties": {"gid": 1},
+                    }
+                ],
+            },
+            "bbox": [0.5, 0.5, 0.5, 0.5],
+        }
+        action = _collect_chat_action("run_analysis", {"layer_id": "l1"}, result)
+        assert action is not None
+        assert action["type"] == "show_query_result"
+        assert action["bbox"] == [0.5, 0.5, 0.5, 0.5]
+        assert "rows" not in action
+        assert "columns" not in action
+        # Must survive ChatAction validation on the wire.
+        assert ChatAction(**action).geojson is not None
+
+    def test_error_result_emits_no_action(self) -> None:
+        action = _collect_chat_action(
+            "run_analysis", {"layer_id": "l1"}, {"error": "nope"}
+        )
+        assert action is None
+
+    def test_empty_result_emits_no_action(self) -> None:
+        """No features => no bbox => nothing to fly the map to."""
+        action = _collect_chat_action(
+            "run_analysis",
+            {"layer_id": "l1"},
+            {"feature_count": 0, "truncated": False, "note": "no geometry"},
+        )
+        assert action is None
+
+
+# ---------------------------------------------------------------------------
+# Handler (DB-backed)
+# ---------------------------------------------------------------------------
+
+
+class TestRunAnalysisHandler:
+    async def test_buffer_preview(self, test_db_session: AsyncSession):
+        admin = await _get_admin(test_db_session)
+        ds = await _create_polygon_dataset(test_db_session, created_by=admin.id)
+        result = await _handle_run_analysis(
+            {"layer_id": "layer-1", "operation": "buffer", "distance_meters": 1000},
+            test_db_session,
+            admin,
+            [_layer_for(ds)],
+            port=_default_port,
+        )
+        assert "error" not in result, result
+        assert result["feature_count"] == 1
+        assert result["geojson"]["features"][0]["geometry"]["type"] in (
+            "Polygon",
+            "MultiPolygon",
+        )
+        assert len(result["bbox"]) == 4
+
+    async def test_centroid_preview(self, test_db_session: AsyncSession):
+        admin = await _get_admin(test_db_session)
+        ds = await _create_polygon_dataset(test_db_session, created_by=admin.id)
+        result = await _handle_run_analysis(
+            {"layer_id": "layer-1", "operation": "centroid"},
+            test_db_session,
+            admin,
+            [_layer_for(ds)],
+            port=_default_port,
+        )
+        assert "error" not in result, result
+        assert result["geojson"]["features"][0]["geometry"]["type"] == "Point"
+
+    async def test_unknown_layer_is_rejected(self, test_db_session: AsyncSession):
+        admin = await _get_admin(test_db_session)
+        result = await _handle_run_analysis(
+            {"layer_id": "not-on-this-map", "operation": "centroid"},
+            test_db_session,
+            admin,
+            [],
+            port=_default_port,
+        )
+        assert "error" in result
+        assert "geojson" not in result
+
+    async def test_private_dataset_of_another_user_is_denied(
+        self, test_db_session: AsyncSession
+    ):
+        """IDOR pin: the layers list is client-supplied, so naming someone
+        else's private dataset must NOT run the analysis."""
+        admin = await _get_admin(test_db_session)
+        other = await _create_other_user(test_db_session)
+        ds = await _create_polygon_dataset(
+            test_db_session, created_by=admin.id, visibility="private"
+        )
+        result = await _handle_run_analysis(
+            {"layer_id": "layer-1", "operation": "centroid"},
+            test_db_session,
+            other,
+            [_layer_for(ds)],
+            port=_default_port,
+        )
+        assert "error" in result
+        assert "geojson" not in result
+
+    @pytest.mark.parametrize(
+        "params",
+        [
+            {"operation": "buffer"},  # distance required
+            {"operation": "buffer", "distance_meters": 0},  # gt=0
+            {"operation": "buffer", "distance_meters": 500_000},  # le=100_000
+            {"operation": "buffer", "distance_meters": -5},
+            {"operation": "drop_table"},  # not in the enum
+        ],
+    )
+    async def test_bad_params_return_an_error_not_an_exception(
+        self, test_db_session: AsyncSession, params
+    ):
+        """Hostile / hallucinated params are rejected by the same Pydantic
+        validator the HTTP endpoint uses, and surface as a retryable tool
+        error rather than breaking the chat turn."""
+        admin = await _get_admin(test_db_session)
+        ds = await _create_polygon_dataset(test_db_session, created_by=admin.id)
+        result = await _handle_run_analysis(
+            {"layer_id": "layer-1", **params},
+            test_db_session,
+            admin,
+            [_layer_for(ds)],
+            port=_default_port,
+        )
+        assert "error" in result, result
+        assert "geojson" not in result
+
+
+# ---------------------------------------------------------------------------
+# Model-bound payload trimming (pure)
+# ---------------------------------------------------------------------------
+
+
+class TestModelSafeToolResult:
+    """The tool result is echoed back into the model's context verbatim
+    (streaming.py / defaults.py json.dumps sites). A run_analysis preview of a
+    few hundred buffered polygons is ~1.3 MB of coordinates the model cannot
+    use — it must never reach the provider."""
+
+    def test_geojson_is_stripped(self) -> None:
+        result = {
+            "feature_count": 2,
+            "bbox": [0, 0, 1, 1],
+            "geojson": {"type": "FeatureCollection", "features": [{"big": "payload"}]},
+        }
+        trimmed = model_safe_tool_result(result)
+        assert "geojson" not in trimmed
+        # bbox is 4 numbers of useful spatial context — it stays.
+        assert trimmed["bbox"] == [0, 0, 1, 1]
+        assert trimmed["feature_count"] == 2
+        # The caller's dict is untouched: the action collector still needs it.
+        assert "geojson" in result
+
+    def test_result_without_geojson_is_passed_through_unchanged(self) -> None:
+        result = {"columns": ["n"], "rows": [[1]], "row_count": 1}
+        assert model_safe_tool_result(result) is result

--- a/backend/tests/test_ai_chat_run_analysis.py
+++ b/backend/tests/test_ai_chat_run_analysis.py
@@ -171,6 +171,59 @@ class TestRunAnalysisActionCollection:
         # Must survive ChatAction validation on the wire.
         assert ChatAction(**action).geojson is not None
 
+    def test_truncated_result_carries_the_disclosure_pair(self) -> None:
+        """fix(#674 audit): a capped preview must not be presented as the whole
+        result — EphemeralBadge renders "N of TOTAL" when both ride along."""
+        action = _collect_chat_action(
+            "run_analysis",
+            {"layer_id": "l1"},
+            {
+                "feature_count": 500,
+                "truncated": True,
+                "source_feature_count": 10651,
+                "geojson": {"type": "FeatureCollection", "features": []},
+                "bbox": [0, 0, 1, 1],
+            },
+        )
+        assert action is not None
+        assert action["truncated"] is True
+        assert action["row_count"] == 10651
+        # Still no table payload — the badge reads these, the card does not.
+        assert "rows" not in action
+
+    def test_untruncated_result_omits_the_disclosure_pair(self) -> None:
+        action = _collect_chat_action(
+            "run_analysis",
+            {"layer_id": "l1"},
+            {
+                "feature_count": 12,
+                "truncated": False,
+                "source_feature_count": 12,
+                "geojson": {"type": "FeatureCollection", "features": []},
+                "bbox": [0, 0, 1, 1],
+            },
+        )
+        assert action is not None
+        assert "truncated" not in action
+        assert "row_count" not in action
+
+    def test_truncated_with_unknown_total_omits_the_pair(self) -> None:
+        """A dataset with no feature_count must not yield "500 of None"."""
+        action = _collect_chat_action(
+            "run_analysis",
+            {"layer_id": "l1"},
+            {
+                "feature_count": 500,
+                "truncated": True,
+                "source_feature_count": None,
+                "geojson": {"type": "FeatureCollection", "features": []},
+                "bbox": [0, 0, 1, 1],
+            },
+        )
+        assert action is not None
+        assert "truncated" not in action
+        assert "row_count" not in action
+
     def test_error_result_emits_no_action(self) -> None:
         action = _collect_chat_action(
             "run_analysis", {"layer_id": "l1"}, {"error": "nope"}

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -908,7 +908,12 @@ def test_decomposed_service_modules_stay_within_size_budgets() -> None:
         # degrade (clean note instead of a generic failure) at both the
         # model-written and append-retry failure points when a legacy geom-only
         # table lacks geom_4326. Cap 470 → 530 (~16 headroom).
-        "backend/app/processing/ai/chat_actions.py": 530,
+        # M4 Phase 5 (run_analysis chat tool): +~11 lines — the dispatch branch,
+        # the collector branch, and the chat_analysis import. The handler itself
+        # was split into the new chat_analysis.py sibling (auto-discovered by the
+        # chat_*.py glob below, ~142 lines under the 350 default) rather than
+        # grown here. Cap 530 → 550 (~14 headroom).
+        "backend/app/processing/ai/chat_actions.py": 550,
     }
 
     files_to_check = list(facade_line_budgets)

--- a/backend/tests/test_processing_port.py
+++ b/backend/tests/test_processing_port.py
@@ -95,6 +95,11 @@ class FakeProcessingPort:
     async def get_user_roles(self, session, user):
         return {"viewer"}
 
+    async def run_analysis_preview(
+        self, session, dataset, operation, *, user_id, distance_meters=None, mask=None
+    ):
+        return None
+
     async def get_dataset(self, session, dataset_id):
         if str(dataset_id) == self._dataset_id:
             return self._dataset

--- a/frontend/src/components/builder/ChatPanel.tsx
+++ b/frontend/src/components/builder/ChatPanel.tsx
@@ -321,7 +321,11 @@ interface ChatPanelProps {
   mapId: string;
   layers: MapLayerResponse[];
   layerActions: LayerActions;
-  onQueryResult?: (geojson: GeoJSON.FeatureCollection, bbox: [number, number, number, number]) => void;
+  onQueryResult?: (
+    geojson: GeoJSON.FeatureCollection,
+    bbox: [number, number, number, number],
+    meta?: { truncated?: boolean; totalCount?: number },
+  ) => void;
   /** Use side-by-side layout: messages left, compose right. */
   horizontal?: boolean;
   /** Phase 1135 AI-05: optional viewport context — zoom, bounds, selected layer name.
@@ -474,9 +478,16 @@ export function ChatPanel({
       if (minX < -180 || minY < -90 || maxX > 180 || maxY > 90) return;
       // fix(#527 B-054/C-06): inverted bounds also throw in fitBounds.
       if (minX > maxX || minY > maxY) return;
+      // fix(#674 audit): forward the truncation pair so EphemeralBadge can say
+      // "500 of 10,651 features". Both query_data and run_analysis emit them
+      // only when the server-side cap actually bit.
+      const total = typeof action.row_count === 'number' ? action.row_count : undefined;
       onQueryResult?.(
         geojson as GeoJSON.FeatureCollection,
         [minX, minY, maxX, maxY],
+        action.truncated === true && total != null
+          ? { truncated: true, totalCount: total }
+          : undefined,
       );
     }
   }

--- a/frontend/src/components/builder/EphemeralBadge.tsx
+++ b/frontend/src/components/builder/EphemeralBadge.tsx
@@ -14,12 +14,15 @@ interface EphemeralBadgeProps {
 }
 
 export function EphemeralBadge({ featureCount, onDismiss, truncated, totalCount, className }: EphemeralBadgeProps) {
-  const { t } = useTranslation('builder');
+  const { t, i18n } = useTranslation('builder');
 
   const countLabel = truncated && totalCount != null
     ? t('ephemeralBadge.featureCountTruncated', {
         count: featureCount,
-        total: totalCount,
+        // fix(#674 audit): group the total per locale, matching how the rest of
+        // the app renders feature counts (OverviewTab). `count` drives plural
+        // selection so it stays numeric — it is capped anyway, never grouped.
+        total: totalCount.toLocaleString(i18n.language),
         defaultValue: '{{count}} of {{total}} features',
       })
     : t('ephemeralBadge.featureCount', { count: featureCount });

--- a/frontend/src/components/builder/__tests__/ChatPanel.test.tsx
+++ b/frontend/src/components/builder/__tests__/ChatPanel.test.tsx
@@ -131,7 +131,35 @@ describe('ChatPanel', () => {
     await typeAndSend(user, 'find features');
 
     await waitFor(() => {
-      expect(props.onQueryResult).toHaveBeenCalledWith(geojson, bbox);
+      expect(props.onQueryResult).toHaveBeenCalledWith(geojson, bbox, undefined);
+    });
+  });
+
+  it('forwards the truncation pair so the badge can disclose "N of TOTAL" (#674 audit)', async () => {
+    const geojson = { type: 'FeatureCollection', features: [] };
+    const bbox = [-74, 40, -73, 41];
+
+    mockStreamChat.mockImplementation(async function* () {
+      yield {
+        event: 'actions',
+        data: {
+          actions: [
+            { type: 'show_query_result', geojson, bbox, truncated: true, row_count: 10651 },
+          ],
+        },
+      };
+      yield { event: 'done', data: { explanation: 'Buffered' } };
+    });
+
+    const user = userEvent.setup();
+    const props = renderPanel();
+    await typeAndSend(user, 'buffer the earthquakes by 10km');
+
+    await waitFor(() => {
+      expect(props.onQueryResult).toHaveBeenCalledWith(geojson, bbox, {
+        truncated: true,
+        totalCount: 10651,
+      });
     });
   });
 
@@ -1460,7 +1488,7 @@ describe('ChatPanel — inline data-analysis card (Phase 1135 AI-08)', () => {
     const props = renderPanel();
     await typeAndSend(user, 'find spatial features');
     await waitFor(() => {
-      expect(props.onQueryResult).toHaveBeenCalledWith(geojson, bbox);
+      expect(props.onQueryResult).toHaveBeenCalledWith(geojson, bbox, undefined);
     });
     // Negative control — no inline card when rows is absent
     expect(screen.queryByRole('region', { name: /query result table/i })).not.toBeInTheDocument();

--- a/frontend/src/components/builder/hooks/use-ephemeral-layers.ts
+++ b/frontend/src/components/builder/hooks/use-ephemeral-layers.ts
@@ -16,6 +16,11 @@ export function useEphemeralLayers(
   const [ephemeralResult, setEphemeralResult] = useState<{
     geojson: GeoJSON.FeatureCollection;
     bbox: [number, number, number, number];
+    /** fix(#674 audit): set when the server capped the result, so the badge
+     *  can disclose "N of TOTAL" instead of passing a capped preview off as
+     *  the whole answer. */
+    truncated?: boolean;
+    totalCount?: number;
   } | null>(null);
 
   const clearEphemeralLayer = useCallback(() => {
@@ -128,8 +133,12 @@ export function useEphemeralLayers(
     };
   }, [ephemeralResult, mapInstanceRef]);
 
-  const handleQueryResult = useCallback((geojson: GeoJSON.FeatureCollection, bbox: [number, number, number, number]) => {
-    setEphemeralResult({ geojson, bbox });
+  const handleQueryResult = useCallback((
+    geojson: GeoJSON.FeatureCollection,
+    bbox: [number, number, number, number],
+    meta?: { truncated?: boolean; totalCount?: number },
+  ) => {
+    setEphemeralResult({ geojson, bbox, ...meta });
   }, []);
 
   return {

--- a/frontend/src/components/viewer/ViewerChatPanel.tsx
+++ b/frontend/src/components/viewer/ViewerChatPanel.tsx
@@ -160,7 +160,14 @@ export function ViewerChatPanel({ mapId, layers, mapInstanceRef }: ViewerChatPan
     ) {
       const [minX, minY, maxX, maxY] = action.bbox as [number, number, number, number];
       if (!(minX < -180 || minY < -90 || maxX > 180 || maxY > 90 || minX > maxX || minY > maxY)) {
-        handleQueryResult(geojson as GeoJSON.FeatureCollection, [minX, minY, maxX, maxY]);
+        // fix(#674 audit): forward the truncation pair so the badge discloses
+        // "N of TOTAL" rather than presenting a capped overlay as complete.
+        const total = typeof action.row_count === 'number' ? action.row_count : undefined;
+        handleQueryResult(
+          geojson as GeoJSON.FeatureCollection,
+          [minX, minY, maxX, maxY],
+          action.truncated === true && total != null ? { truncated: true, totalCount: total } : undefined,
+        );
       }
     }
     const rows = Array.isArray(action.rows) ? action.rows : null;
@@ -256,6 +263,8 @@ export function ViewerChatPanel({ mapId, layers, mapInstanceRef }: ViewerChatPan
         <EphemeralBadge
           featureCount={ephemeralResult.geojson.features.length}
           onDismiss={handleDismissEphemeral}
+          truncated={ephemeralResult.truncated}
+          totalCount={ephemeralResult.totalCount}
           className="bottom-32 start-3"
         />
       )}

--- a/frontend/src/components/viewer/ViewerChatPanel.tsx
+++ b/frontend/src/components/viewer/ViewerChatPanel.tsx
@@ -105,10 +105,13 @@ interface ViewerChatPanelProps {
  *
  * The builder's full ChatPanel is reachable only to `can_edit` users; signed-in
  * viewers land on PublicMapViewerPage with no AI affordance. PR #339 made the
- * backend chat path serve view-only callers a read-only toolbox (`query_data`
- * only), so this surfaces that path: a question goes to `/ai/chat/stream/`, the
- * streamed answer renders inline, and a `show_query_result` flies the map to the
- * matched features (shared `useEphemeralLayers` overlay) + shows a compact table.
+ * backend chat path serve view-only callers a read-only toolbox (`query_data`,
+ * plus `run_analysis` since M4 — both SELECT-only), so this surfaces that path:
+ * a question goes to `/ai/chat/stream/`, the streamed answer renders inline, and
+ * a `show_query_result` flies the map to the matched features (shared
+ * `useEphemeralLayers` overlay) + shows a compact table. A `run_analysis`
+ * preview arrives as the same action carrying only geojson+bbox, so it draws the
+ * overlay and skips the table.
  *
  * Self-gates on `useAIAvailability` (token + `use_ai_chat` + AI configured), so
  * anonymous or unpermitted viewers render nothing. No edit actions are applied —

--- a/frontend/src/components/viewer/__tests__/ViewerChatPanel.test.tsx
+++ b/frontend/src/components/viewer/__tests__/ViewerChatPanel.test.tsx
@@ -60,8 +60,10 @@ describe('ViewerChatPanel', () => {
 
     renderPanel();
 
-    expect(screen.getByText(/Query result/)).toBeInTheDocument();
-    await userEvent.click(screen.getByRole('button', { name: 'Dismiss query result' }));
+    // fix(#674 audit): the badge labels analysis previews as well as query
+    // results, so its copy is operation-neutral ("Result", not "Query result").
+    expect(screen.getByText(/Result/)).toBeInTheDocument();
+    await userEvent.click(screen.getByRole('button', { name: 'Dismiss result' }));
     expect(handleDismissEphemeral).toHaveBeenCalled();
   });
 
@@ -119,6 +121,7 @@ describe('ViewerChatPanel', () => {
     expect(handleQueryResult).toHaveBeenCalledWith(
       { type: 'FeatureCollection', features: [] },
       [-1, -1, 1, 1],
+      undefined,
     );
     expect(screen.getByText('Alpha')).toBeInTheDocument();
     expect(screen.getByText('1 row')).toBeInTheDocument();

--- a/frontend/src/i18n/locales/de/builder.json
+++ b/frontend/src/i18n/locales/de/builder.json
@@ -968,10 +968,10 @@
     "skip": "Überspringen"
   },
   "ephemeralBadge": {
-    "queryResult": "Abfrageergebnis",
+    "queryResult": "Ergebnis",
     "featureCount_one": "{{count}} Feature",
     "featureCount_other": "{{count}} Features",
-    "dismiss": "Abfrageergebnis verwerfen",
+    "dismiss": "Ergebnis verwerfen",
     "featureCountTruncated": "{{count}} von {{total}} Elementen"
   },
   "plugins": {

--- a/frontend/src/i18n/locales/en/builder.json
+++ b/frontend/src/i18n/locales/en/builder.json
@@ -968,11 +968,11 @@
     "skip": "Skip"
   },
   "ephemeralBadge": {
-    "queryResult": "Query result",
+    "queryResult": "Result",
     "featureCount_one": "{{count}} feature",
     "featureCount_other": "{{count}} features",
     "featureCountTruncated": "{{count}} of {{total}} features",
-    "dismiss": "Dismiss query result"
+    "dismiss": "Dismiss result"
   },
   "plugins": {
     "measurement": {

--- a/frontend/src/i18n/locales/es/builder.json
+++ b/frontend/src/i18n/locales/es/builder.json
@@ -968,10 +968,10 @@
     "skip": "Saltar"
   },
   "ephemeralBadge": {
-    "queryResult": "Resultado de consulta",
+    "queryResult": "Resultado",
     "featureCount_one": "{{count}} entidad",
     "featureCount_other": "{{count}} entidades",
-    "dismiss": "Descartar resultado de consulta",
+    "dismiss": "Descartar resultado",
     "featureCountTruncated": "{{count}} de {{total}} elementos"
   },
   "plugins": {

--- a/frontend/src/i18n/locales/fr/builder.json
+++ b/frontend/src/i18n/locales/fr/builder.json
@@ -968,10 +968,10 @@
     "skip": "Passer"
   },
   "ephemeralBadge": {
-    "queryResult": "Résultat de requête",
+    "queryResult": "Résultat",
     "featureCount_one": "{{count}} entité",
     "featureCount_other": "{{count}} entités",
-    "dismiss": "Fermer le résultat de requête",
+    "dismiss": "Fermer le résultat",
     "featureCountTruncated": "{{count}} sur {{total}} éléments"
   },
   "plugins": {

--- a/frontend/src/pages/MapBuilderPage.tsx
+++ b/frontend/src/pages/MapBuilderPage.tsx
@@ -1747,6 +1747,8 @@ export function MapBuilderPage() {
             <EphemeralBadge
               featureCount={layers.ephemeralResult.geojson.features.length}
               onDismiss={layers.handleDismissEphemeral}
+              truncated={layers.ephemeralResult.truncated}
+              totalCount={layers.ephemeralResult.totalCount}
             />
           )}
 


### PR DESCRIPTION
Closes out the M4 spatial-analysis work (#671) with Phase 5: the AI chat tool.

## What

The map-chat assistant can now run the same parameterized PostGIS operations the Analysis rail panel offers. "Buffer the schools by 500 m" draws a preview on the map instead of being routed to `query_data`, which can answer questions about geometry but cannot transform it. This also helps #549 routing by giving analysis its own tool rather than overloading `query_data`.

## How

`run_analysis` reuses the catalog analysis service through `ProcessingPort` — the same server-built SQL, the same `AnalysisPreviewRequest` validation, and the same read-only sandbox rails as `POST /datasets/{id}/analysis/preview/`. No LLM-authored SQL touches this path: the model picks an operation enum and a bounded number, nothing else.

**Access control.** The layer list is client-supplied, so the handler re-resolves the dataset from `layer.dataset_id` and re-checks it with `check_dataset_access` (AGENTS.md Rule 1) rather than trusting the client's `dataset_id` or table name. There is an IDOR regression test for this.

**Tool scoping.**
- Offered to view-only callers: it only SELECTs, and its result is an ephemeral overlay, never a persisted map change.
- Withheld from dataset chat via `select_chat_tools(has_map=False)` — that surface has no map, so the model must not promise a preview it cannot render.
- Enum is deliberately narrower than the endpoint's: `clip` needs a drawn mask only the rail panel can supply, and `dissolve` is materialize-only.

**No frontend change needed.** Results ride the existing `show_query_result` action carrying `geojson`+`bbox` only. Every chat surface already draws that pair and skips the inline data table when `rows` is absent (pinned by the existing `ChatPanel.test.tsx` case), so a gid-only table never appears.

## Drive-by fix: stop echoing map payload into the model's context

Tool results are re-fed to the provider verbatim at four `json.dumps` sites. A 412-feature buffer preview serialized to ~1.3 MB there — **measured at 661,925 input tokens** on the follow-up round, against a 200k `MAX_REQUEST_TOKEN_BUDGET`, for coordinates the model cannot read anyway.

`model_safe_tool_result()` drops `geojson` at those sites only; the action collector still receives the untrimmed dict. The same live request now costs **354 input tokens**. `query_data`'s 50-feature overlay was quietly paying a smaller version of the same tax and benefits too.

## Layout

The handler lives in a new `chat_analysis.py` sibling (following `chat_styles` / `chat_geojson`) rather than growing `chat_actions.py`. The residual +11 lines of wiring take that module's reviewed cap from 530 to 550.

## Verification

- Full backend suite: 5786 passed. (Two unrelated modules errored in one parallel run and a third in another — different tests each time, all pass standalone and under `-n 4`; the known xdist session-acquisition flake, untouched by this diff.)
- New `test_ai_chat_run_analysis.py`: 18 tests — tool scoping, action shape, DB-backed buffer/centroid, unknown layer, foreign-private IDOR, hostile/hallucinated params, and the payload trim.
- Drift gates clean: `make openapi-check`, `make sdks-check`. **No API surface change, so no OpenAPI/SDK regeneration.**
- Frontend `npm run typecheck`, ChatPanel / ViewerChatPanel / DatasetChatPanel suites.
- Live end-to-end against the dev stack: model routed to `run_analysis`, `Running analysis...` progress event, 412-feature overlay with a valid bbox, correct narration.

## Follow-ups (unchanged from #671)

Persistent visual for the captured clip mask; `ST_SimplifyPreserveTopology` on large previews; dissolve `by_field` UI.

https://claude.ai/code/session_01X1Wd3Frww9F2eovfMkUbG2