### PR TITLE
fix(ci): allowlist the brace-expansion DoS advisory with an expiry

### DIFF
--- a/scripts/js-audit-gate.mjs
+++ b/scripts/js-audit-gate.mjs
@@ -17,6 +17,23 @@ const ALLOWLIST = [
       '7.x backport ships or the router is upgraded to >=8.3.0.',
     expires: '2026-09-01',
   },
+  {
+    id: 'GHSA-mh99-v99m-4gvg', // brace-expansion DoS via unbounded expansion (high)
+    reason:
+      'Reached only through the eslint toolchain — eslint / ' +
+      '@typescript-eslint/typescript-estree, and eslint-plugin-jsx-a11y via ' +
+      'minimatch@3. It is a devDependency in every path, so the vulnerable ' +
+      'code is never in the shipped bundle; exploiting it needs an ' +
+      'attacker-controlled glob handed to eslint, and our globs come from ' +
+      'repo-authored config. No in-range fix exists: 1.1.16 is the last of the ' +
+      '1.x line (unpatched), and overriding to the patched 5.0.8 breaks ' +
+      'linting outright — minimatch@3 throws in `new Minimatch` against the ' +
+      '5.x API (verified locally). npm’s only suggested fix is the eslint 10 ' +
+      'major. Drop this entry when eslint 10 lands (Dependabot #595) or a ' +
+      'patched 1.x ships. Shares the react-router expiry so both allowlist ' +
+      'entries get one review date.',
+    expires: '2026-09-01',
+  },
 ];
 
 let raw;


### PR DESCRIPTION
## Why

`GHSA-mh99-v99m-4gvg` (brace-expansion, **high** — DoS via unbounded expansion causing an OOM crash) was published today and turns `JS audit (frontend)` red on **every open PR**. `dep-audit.yml` runs on `pull_request` plus a weekly cron, so main stays green while nothing can merge.

Same shape as the react-router incident that produced #672.

## Why an allowlist rather than a fix

The advisory is **devDependency-only**. `brace-expansion` reaches the tree solely through the eslint toolchain:

- `eslint` / `@typescript-eslint/typescript-estree` → `brace-expansion@5.0.7`
- `eslint-plugin-jsx-a11y` → `minimatch@3.1.5` → `brace-expansion@1.1.16`

It is never in the shipped bundle, and exploiting it requires an attacker-controlled glob handed to eslint — ours come from repo-authored config.

There is **no in-range fix**:

- `1.1.16` is the last of the 1.x line and is unpatched.
- The patched `5.0.8` exists, but forcing it through npm `overrides` **breaks linting outright** — `minimatch@3` throws in `new Minimatch` against the 5.x API. I tried this first and backed it out:
  ```
  at new Minimatch (node_modules/minimatch/minimatch.js:156:8)
  at doMatch (node_modules/@eslint/config-array/dist/cjs/index.cjs:422:13)
  ```
- npm's only suggested fix is the **eslint 10 major**, already open as Dependabot #595. That's a toolchain bump deserving its own validation pass, not something to smuggle in as an unblock.

## The entry

Shares the react-router entry's `2026-09-01` expiry so both allowlist entries get a single review date.

Verified both directions locally:

```
# with the entry
allowlisted high: brace-expansion — ... (GHSA-mh99-v99m-4gvg, expires 2026-09-01)
npm audit gate: no unallowlisted high/critical advisories.   exit 0

# entry back-dated to 2020-01-01 — suppression genuinely lapses
allowlist entry GHSA-mh99-v99m-4gvg expired 2020-01-01 — no longer suppressed
BLOCKING high: brace-expansion — ...                        exit 1
```

Drop the entry when eslint 10 lands or a patched 1.x ships.

https://claude.ai/code/session_01X1Wd3Frww9F2eovfMkUbG2