### PR TITLE
fix(builder): clear stale chat overlays and hand analysis previews off to the Analysis panel

### DIFF
--- a/backend/app/processing/ai/chat_analysis.py
+++ b/backend/app/processing/ai/chat_analysis.py
@@ -162,8 +162,14 @@ def collect_run_analysis_action(result: dict) -> dict | None:
     actually bit, so EphemeralBadge can say "500 of 10,651 features" instead of
     presenting a capped preview as the complete result.
     """
-    if not (result.get("bbox") and "geojson" in result):
+    if "error" in result:
         return None
+    if not (result.get("bbox") and "geojson" in result):
+        # fix(#676): an empty preview still emits a geometry-less marker so the
+        # frontend clears a stale overlay from an earlier turn — with no action
+        # at all, the previous overlay (and its badge) keeps describing a
+        # result the chat text has moved past.
+        return {"type": "show_query_result", "row_count": 0}
     action = {
         "type": "show_query_result",
         "geojson": result["geojson"],

--- a/backend/app/processing/ai/chat_analysis.py
+++ b/backend/app/processing/ai/chat_analysis.py
@@ -132,6 +132,10 @@ async def _run_analysis(
         "feature_count": result.feature_count,
         "truncated": result.truncated,
     }
+    if distance_meters is not None:
+        # feat(#675): ride the sanitized buffer distance along so the action
+        # collector can hand the preview off to the Analysis panel prefilled.
+        out["distance_meters"] = distance_meters
     if result.feature_count == 0:
         out["note"] = "The operation produced no geometry for this layer."
         return out
@@ -175,6 +179,14 @@ def collect_run_analysis_action(result: dict) -> dict | None:
         "geojson": result["geojson"],
         "bbox": result["bbox"],
     }
+    # feat(#675): carry the params needed to reconstruct the request so the
+    # builder can offer a one-click "Save as dataset" handoff into the
+    # Analysis panel. The viewer surface ignores them (no Analysis rail).
+    if result.get("operation") and result.get("layer_id"):
+        action["operation"] = result["operation"]
+        action["layer_id"] = result["layer_id"]
+        if result.get("distance_meters") is not None:
+            action["distance_meters"] = result["distance_meters"]
     total = result.get("source_feature_count")
     if result.get("truncated") and total:
         action["truncated"] = True

--- a/backend/app/processing/ai/schemas.py
+++ b/backend/app/processing/ai/schemas.py
@@ -427,6 +427,10 @@ class ChatAction(BaseModel):
     columns: list[str] | None = None  # for show_query_result (inline data table)
     row_count: int | None = None  # for show_query_result (total matched rows)
     truncated: bool | None = None  # for show_query_result (rows capped for payload)
+    # feat(#675): run_analysis handoff — lets the builder prefill the Analysis
+    # panel ("Save as dataset") from a chat preview. layer_id above is reused.
+    operation: str | None = None  # for show_query_result (analysis operation)
+    distance_meters: float | None = None  # for show_query_result (buffer distance)
 
 
 class SSETokenEvent(BaseModel):

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -2357,6 +2357,17 @@
             ],
             "title": "Dataset Name"
           },
+          "distance_meters": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Distance Meters"
+          },
           "expression": {
             "anyOf": [
               {
@@ -2414,6 +2425,17 @@
               }
             ],
             "title": "Opacity"
+          },
+          "operation": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Operation"
           },
           "paint": {
             "anyOf": [

--- a/backend/tests/test_ai_chat_run_analysis.py
+++ b/backend/tests/test_ai_chat_run_analysis.py
@@ -230,6 +230,62 @@ class TestRunAnalysisActionCollection:
         )
         assert action is None
 
+    def test_action_carries_the_analysis_handoff_params(self) -> None:
+        """feat(#675): operation/layer_id/distance ride the action so the
+        builder can prefill the Analysis panel ("Save as dataset") from the
+        chat preview instead of making the user re-enter everything."""
+        action = _collect_chat_action(
+            "run_analysis",
+            {"layer_id": "l1"},
+            {
+                "operation": "buffer",
+                "layer_id": "l1",
+                "distance_meters": 500.0,
+                "feature_count": 3,
+                "truncated": False,
+                "geojson": {"type": "FeatureCollection", "features": []},
+                "bbox": [0, 0, 1, 1],
+            },
+        )
+        assert action is not None
+        assert action["operation"] == "buffer"
+        assert action["layer_id"] == "l1"
+        assert action["distance_meters"] == 500.0
+
+    def test_centroid_handoff_omits_distance(self) -> None:
+        action = _collect_chat_action(
+            "run_analysis",
+            {"layer_id": "l1"},
+            {
+                "operation": "centroid",
+                "layer_id": "l1",
+                "feature_count": 3,
+                "truncated": False,
+                "geojson": {"type": "FeatureCollection", "features": []},
+                "bbox": [0, 0, 1, 1],
+            },
+        )
+        assert action is not None
+        assert action["operation"] == "centroid"
+        assert "distance_meters" not in action
+
+    def test_chat_action_round_trip_preserves_the_handoff_params(self) -> None:
+        """Regression guard (the builder-audit #338 B-001 trap): fields the
+        collector emits but the ChatAction model lacks are silently dropped by
+        ``ChatAction(**a).model_dump(exclude_none=True)`` on the wire."""
+        action = {
+            "type": "show_query_result",
+            "operation": "buffer",
+            "layer_id": "l1",
+            "distance_meters": 500.0,
+            "geojson": {"type": "FeatureCollection", "features": []},
+            "bbox": [0, 0, 1, 1],
+        }
+        dumped = ChatAction(**action).model_dump(exclude_none=True)
+        assert dumped["operation"] == "buffer"
+        assert dumped["layer_id"] == "l1"
+        assert dumped["distance_meters"] == 500.0
+
     def test_empty_result_emits_a_geometry_less_marker(self) -> None:
         """fix(#676): no features still emits a geometry-less action — the
         frontend uses it to clear a stale overlay from an earlier turn.
@@ -269,6 +325,9 @@ class TestRunAnalysisHandler:
             "MultiPolygon",
         )
         assert len(result["bbox"]) == 4
+        # feat(#675): the sanitized buffer distance rides along for the
+        # Analysis-panel handoff.
+        assert result["distance_meters"] == 1000
 
     async def test_centroid_preview(self, test_db_session: AsyncSession):
         admin = await _get_admin(test_db_session)
@@ -283,6 +342,8 @@ class TestRunAnalysisHandler:
         )
         assert "error" not in result, result
         assert result["geojson"]["features"][0]["geometry"]["type"] == "Point"
+        # feat(#675): only buffer consumes a distance, so none rides along here.
+        assert "distance_meters" not in result
 
     async def test_unknown_layer_is_rejected(self, test_db_session: AsyncSession):
         admin = await _get_admin(test_db_session)

--- a/backend/tests/test_ai_chat_run_analysis.py
+++ b/backend/tests/test_ai_chat_run_analysis.py
@@ -230,14 +230,19 @@ class TestRunAnalysisActionCollection:
         )
         assert action is None
 
-    def test_empty_result_emits_no_action(self) -> None:
-        """No features => no bbox => nothing to fly the map to."""
+    def test_empty_result_emits_a_geometry_less_marker(self) -> None:
+        """fix(#676): no features still emits a geometry-less action — the
+        frontend uses it to clear a stale overlay from an earlier turn.
+        Previously None was returned and the previous overlay (plus its
+        feature-count badge) stayed on the map beside a "nothing found" reply."""
         action = _collect_chat_action(
             "run_analysis",
             {"layer_id": "l1"},
             {"feature_count": 0, "truncated": False, "note": "no geometry"},
         )
-        assert action is None
+        assert action == {"type": "show_query_result", "row_count": 0}
+        # Must survive ChatAction validation on the wire.
+        ChatAction(**action)
 
 
 # ---------------------------------------------------------------------------

--- a/frontend/src/components/builder/AnalysisPanel.tsx
+++ b/frontend/src/components/builder/AnalysisPanel.tsx
@@ -19,6 +19,7 @@ import { MAP_COLORS } from '@/lib/map-colors';
 import { materializeAnalysis, previewAnalysis } from '@/api/analysis';
 import { useJobStatus } from '@/components/import/hooks/use-ingest';
 import type { LayerActions } from '@/components/builder/ChatPanel';
+import type { EphemeralAnalysisHandoff } from '@/components/builder/hooks/use-ephemeral-layers';
 import type { AnalysisOperation, MapLayerResponse } from '@/types/api';
 
 const MAX_BUFFER_METERS = 100_000;
@@ -33,6 +34,10 @@ interface AnalysisPanelProps {
   onClearPreview?: () => void;
   hasPreview?: boolean;
   layerActions?: LayerActions;
+  /** feat(#675): initial form values handed off from a chat run_analysis
+   *  preview ("Save as dataset"). Applied on mount only — BuilderRail keys the
+   *  panel on the handoff so a new one remounts it. */
+  prefill?: EphemeralAnalysisHandoff;
 }
 
 /**
@@ -47,13 +52,22 @@ export function AnalysisPanel({
   onClearPreview,
   hasPreview,
   layerActions,
+  prefill,
 }: AnalysisPanelProps) {
   const { t } = useTranslation('builder');
   const firstEligibleId =
     layers.find((l) => !!l.dataset_id && !l.is_dem)?.id ?? '';
-  const [layerId, setLayerId] = useState(firstEligibleId);
-  const [operation, setOperation] = useState<AnalysisOperation>('buffer');
-  const [distance, setDistance] = useState('500');
+  // feat(#675): a handoff layer that has since left the map (or lost its
+  // dataset) falls back to the default selection instead of an empty select.
+  const prefillLayerId =
+    prefill && layers.some((l) => l.id === prefill.layerId && !!l.dataset_id && !l.is_dem)
+      ? prefill.layerId
+      : undefined;
+  const [layerId, setLayerId] = useState(prefillLayerId ?? firstEligibleId);
+  const [operation, setOperation] = useState<AnalysisOperation>(prefill?.operation ?? 'buffer');
+  const [distance, setDistance] = useState(
+    prefill?.distanceMeters != null ? String(prefill.distanceMeters) : '500',
+  );
   const [mask, setMask] = useState<GeoJSON.Polygon | null>(null);
   const [isDrawing, setIsDrawing] = useState(false);
   const [outputTitle, setOutputTitle] = useState('');

--- a/frontend/src/components/builder/BuilderRail.tsx
+++ b/frontend/src/components/builder/BuilderRail.tsx
@@ -292,6 +292,7 @@ export function BuilderRail({
                     layers={layers}
                     layerActions={layerActions}
                     onQueryResult={onQueryResult}
+                    onClearPreview={onClearPreview}
                     viewport={viewport}
                   />
                 </Suspense>

--- a/frontend/src/components/builder/BuilderRail.tsx
+++ b/frontend/src/components/builder/BuilderRail.tsx
@@ -8,6 +8,7 @@ import { Button } from '@/components/ui/button';
 import type { Map as MaplibreMap } from 'maplibre-gl';
 import type { MapLayerResponse } from '@/types/api';
 import type { LayerActions } from '@/components/builder/ChatPanel';
+import type { EphemeralAnalysisHandoff } from '@/components/builder/hooks/use-ephemeral-layers';
 import type { ViewportContext } from '@/components/builder/chat-suggestions';
 import { HistoryPanel } from '@/components/builder/HistoryPanel';
 import { useAIAvailability } from '@/hooks/use-ai-availability';
@@ -98,6 +99,9 @@ interface BuilderRailProps {
   mapInstanceRef?: React.RefObject<MaplibreMap | null>;
   onClearPreview?: () => void;
   hasPreview?: boolean;
+  /** feat(#675): chat-preview handoff — keys a remount of AnalysisPanel so the
+   *  form initializes from it. The nonce distinguishes successive handoffs. */
+  analysisPrefill?: (EphemeralAnalysisHandoff & { nonce: number }) | null;
   /** Phase 1135 AI-05: optional viewport context passed through to ChatPanel for
    *  viewport-aware suggestion chips. Purely additive — omitting this prop has no effect. */
   viewport?: ViewportContext;
@@ -118,6 +122,7 @@ export function BuilderRail({
   mapInstanceRef,
   onClearPreview,
   hasPreview,
+  analysisPrefill,
   viewport,
   onMarkDirty,
   showRail = true,
@@ -267,12 +272,14 @@ export function BuilderRail({
                   </div>
                 }>
                   <AnalysisPanel
+                    key={analysisPrefill?.nonce ?? 'analysis'}
                     layers={layers}
                     mapInstanceRef={mapInstanceRef}
                     onPreviewResult={onQueryResult}
                     onClearPreview={onClearPreview}
                     hasPreview={hasPreview}
                     layerActions={layerActions}
+                    prefill={analysisPrefill ?? undefined}
                   />
                 </Suspense>
               </LazyLoadErrorBoundary>

--- a/frontend/src/components/builder/ChatPanel.tsx
+++ b/frontend/src/components/builder/ChatPanel.tsx
@@ -326,6 +326,10 @@ interface ChatPanelProps {
     bbox: [number, number, number, number],
     meta?: { truncated?: boolean; totalCount?: number },
   ) => void;
+  /** fix(#676): clears the single-slot ephemeral overlay when a turn's winning
+   *  result carries no geometry — otherwise a stale overlay from an earlier
+   *  turn keeps describing a result the chat has moved past. */
+  onClearPreview?: () => void;
   /** Use side-by-side layout: messages left, compose right. */
   horizontal?: boolean;
   /** Phase 1135 AI-05: optional viewport context — zoom, bounds, selected layer name.
@@ -339,6 +343,7 @@ export function ChatPanel({
   layers,
   layerActions,
   onQueryResult,
+  onClearPreview,
   horizontal,
   viewport,
 }: ChatPanelProps) {
@@ -462,6 +467,13 @@ export function ChatPanel({
 
   function dispatchQueryResult(action: ChatAction) {
     const geojson = action.geojson;
+    if (!geojson) {
+      // fix(#676): the turn's winning result has no geometry (empty analysis,
+      // attribute-only query) — clear the single-slot overlay instead of
+      // leaving the previous turn's features and badge on the map.
+      onClearPreview?.();
+      return;
+    }
     if (
       geojson &&
       typeof geojson === 'object' &&

--- a/frontend/src/components/builder/ChatPanel.tsx
+++ b/frontend/src/components/builder/ChatPanel.tsx
@@ -13,6 +13,7 @@ import { getLayerType, filterPaintForLayerType, clampPaintBounds } from '@/compo
 import { useChatActionStaging, isDestructiveAction } from '@/builder/ai/chat-action-staging';
 import type { FilterSpecification } from 'maplibre-gl';
 import type { MapLayerResponse, ChatAction, ChatHistoryMessage, LabelConfig, StyleConfig } from '@/types/api';
+import type { EphemeralAnalysisHandoff } from '@/components/builder/hooks/use-ephemeral-layers';
 import { ChatInput } from './ChatInput';
 import { getSmartSuggestions, type ViewportContext } from './chat-suggestions';
 
@@ -324,7 +325,7 @@ interface ChatPanelProps {
   onQueryResult?: (
     geojson: GeoJSON.FeatureCollection,
     bbox: [number, number, number, number],
-    meta?: { truncated?: boolean; totalCount?: number },
+    meta?: { truncated?: boolean; totalCount?: number; analysis?: EphemeralAnalysisHandoff },
   ) => void;
   /** fix(#676): clears the single-slot ephemeral overlay when a turn's winning
    *  result carries no geometry — otherwise a stale overlay from an earlier
@@ -494,12 +495,25 @@ export function ChatPanel({
       // "500 of 10,651 features". Both query_data and run_analysis emit them
       // only when the server-side cap actually bit.
       const total = typeof action.row_count === 'number' ? action.row_count : undefined;
+      const truncation = action.truncated === true && total != null
+        ? { truncated: true, totalCount: total }
+        : undefined;
+      // feat(#675): a run_analysis action carries its reconstruction params so
+      // the badge can offer "Save as dataset" (prefilled Analysis panel).
+      const analysis: EphemeralAnalysisHandoff | undefined =
+        (action.operation === 'buffer' || action.operation === 'centroid') && action.layer_id
+          ? {
+              operation: action.operation,
+              layerId: action.layer_id,
+              ...(typeof action.distance_meters === 'number'
+                ? { distanceMeters: action.distance_meters }
+                : {}),
+            }
+          : undefined;
       onQueryResult?.(
         geojson as GeoJSON.FeatureCollection,
         [minX, minY, maxX, maxY],
-        action.truncated === true && total != null
-          ? { truncated: true, totalCount: total }
-          : undefined,
+        truncation || analysis ? { ...truncation, ...(analysis ? { analysis } : {}) } : undefined,
       );
     }
   }

--- a/frontend/src/components/builder/EphemeralBadge.tsx
+++ b/frontend/src/components/builder/EphemeralBadge.tsx
@@ -9,11 +9,15 @@ interface EphemeralBadgeProps {
   truncated?: boolean;
   /** Total feature count before truncation. */
   totalCount?: number;
+  /** feat(#675): opens the Analysis panel prefilled with the operation behind
+   *  this preview. Builder-only — the viewer has no Analysis rail, so it
+   *  never passes this. */
+  onSaveAsDataset?: () => void;
   /** Position override — the viewer's bottom-left corner is occupied by its basemap toggle. */
   className?: string;
 }
 
-export function EphemeralBadge({ featureCount, onDismiss, truncated, totalCount, className }: EphemeralBadgeProps) {
+export function EphemeralBadge({ featureCount, onDismiss, truncated, totalCount, onSaveAsDataset, className }: EphemeralBadgeProps) {
   const { t, i18n } = useTranslation('builder');
 
   const countLabel = truncated && totalCount != null
@@ -33,6 +37,15 @@ export function EphemeralBadge({ featureCount, onDismiss, truncated, totalCount,
       <span className="text-muted-foreground">
         {t('ephemeralBadge.queryResult')} &middot; {countLabel}
       </span>
+      {onSaveAsDataset && (
+        <button
+          type="button"
+          onClick={onSaveAsDataset}
+          className="cursor-pointer font-medium text-primary hover:underline"
+        >
+          {t('ephemeralBadge.saveAsDataset', { defaultValue: 'Save as dataset…' })}
+        </button>
+      )}
       <button
         type="button"
         onClick={onDismiss}

--- a/frontend/src/components/builder/__tests__/AnalysisPanel.test.tsx
+++ b/frontend/src/components/builder/__tests__/AnalysisPanel.test.tsx
@@ -46,6 +46,14 @@ const groupLayer = {
   is_dem: false,
 } as unknown as MapLayerResponse;
 
+const datasetLayer2 = {
+  id: 'l3',
+  dataset_id: 'ds2',
+  dataset_name: 'Roads',
+  display_name: null,
+  is_dem: false,
+} as unknown as MapLayerResponse;
+
 function renderPanel(
   layers: MapLayerResponse[],
   props: Partial<React.ComponentProps<typeof AnalysisPanel>> = {},
@@ -104,5 +112,51 @@ describe('AnalysisPanel', () => {
     const clearButton = screen.getByRole('button', { name: 'Clear preview' });
     fireEvent.click(clearButton);
     expect(onClearPreview).toHaveBeenCalled();
+  });
+});
+
+describe('AnalysisPanel — chat handoff prefill (#675)', () => {
+  it('initializes layer, operation, and distance from the prefill', async () => {
+    renderPanel([datasetLayer, datasetLayer2], {
+      prefill: { layerId: 'l3', operation: 'buffer', distanceMeters: 750 },
+    });
+    expect(screen.getByLabelText('Distance (meters)')).toHaveValue(750);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Preview' }));
+    await waitFor(() => {
+      expect(previewAnalysis).toHaveBeenCalledWith('ds2', {
+        operation: 'buffer',
+        distance_meters: 750,
+      });
+    });
+  });
+
+  it('prefills a centroid preview without a distance field', async () => {
+    renderPanel([datasetLayer], {
+      prefill: { layerId: 'l1', operation: 'centroid' },
+    });
+    expect(screen.queryByLabelText('Distance (meters)')).toBeNull();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Preview' }));
+    await waitFor(() => {
+      expect(previewAnalysis).toHaveBeenCalledWith('ds1', {
+        operation: 'centroid',
+      });
+    });
+  });
+
+  it('falls back to the first eligible layer when the prefill layer left the map', async () => {
+    renderPanel([datasetLayer], {
+      prefill: { layerId: 'gone', operation: 'buffer', distanceMeters: 250 },
+    });
+    expect(screen.getByLabelText('Distance (meters)')).toHaveValue(250);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Preview' }));
+    await waitFor(() => {
+      expect(previewAnalysis).toHaveBeenCalledWith('ds1', {
+        operation: 'buffer',
+        distance_meters: 250,
+      });
+    });
   });
 });

--- a/frontend/src/components/builder/__tests__/ChatPanel.test.tsx
+++ b/frontend/src/components/builder/__tests__/ChatPanel.test.tsx
@@ -191,6 +191,40 @@ describe('ChatPanel', () => {
     expect(props.onQueryResult).not.toHaveBeenCalled();
   });
 
+  it('threads the analysis handoff params through onQueryResult meta (#675)', async () => {
+    const geojson = { type: 'FeatureCollection', features: [] };
+    const bbox = [-74, 40, -73, 41];
+
+    mockStreamChat.mockImplementation(async function* () {
+      yield {
+        event: 'actions',
+        data: {
+          actions: [
+            {
+              type: 'show_query_result',
+              geojson,
+              bbox,
+              operation: 'buffer',
+              layer_id: 'layer-1',
+              distance_meters: 500,
+            },
+          ],
+        },
+      };
+      yield { event: 'done', data: { explanation: 'Buffered' } };
+    });
+
+    const user = userEvent.setup();
+    const props = renderPanel();
+    await typeAndSend(user, 'buffer the schools by 500m');
+
+    await waitFor(() => {
+      expect(props.onQueryResult).toHaveBeenCalledWith(geojson, bbox, {
+        analysis: { operation: 'buffer', layerId: 'layer-1', distanceMeters: 500 },
+      });
+    });
+  });
+
   it('clears the stale overlay when the winning result has no geometry (#676)', async () => {
     mockStreamChat.mockImplementation(async function* () {
       yield {

--- a/frontend/src/components/builder/__tests__/ChatPanel.test.tsx
+++ b/frontend/src/components/builder/__tests__/ChatPanel.test.tsx
@@ -69,6 +69,7 @@ function renderPanel(
     layers: [makeLayer()],
     layerActions,
     onQueryResult: vi.fn(),
+    onClearPreview: vi.fn(),
     ...rest,
   };
   render(<ChatPanel {...props} />);
@@ -188,6 +189,49 @@ describe('ChatPanel', () => {
 
     await screen.findByText('Counted on retry');
     expect(props.onQueryResult).not.toHaveBeenCalled();
+  });
+
+  it('clears the stale overlay when the winning result has no geometry (#676)', async () => {
+    mockStreamChat.mockImplementation(async function* () {
+      yield {
+        event: 'actions',
+        // The geometry-less marker an empty run_analysis / attribute-only
+        // query_data emits.
+        data: { actions: [{ type: 'show_query_result', row_count: 0 }] },
+      };
+      yield { event: 'done', data: { explanation: 'Nothing found' } };
+    });
+
+    const user = userEvent.setup();
+    const props = renderPanel();
+    await typeAndSend(user, 'buffer the empty layer');
+
+    await waitFor(() => {
+      expect(props.onClearPreview).toHaveBeenCalled();
+    });
+    expect(props.onQueryResult).not.toHaveBeenCalled();
+  });
+
+  it('does not clear the overlay when the winning result is spatial (#676)', async () => {
+    const geojson = { type: 'FeatureCollection', features: [] };
+    const bbox = [-74, 40, -73, 41];
+
+    mockStreamChat.mockImplementation(async function* () {
+      yield {
+        event: 'actions',
+        data: { actions: [{ type: 'show_query_result', geojson, bbox }] },
+      };
+      yield { event: 'done', data: { explanation: 'Results' } };
+    });
+
+    const user = userEvent.setup();
+    const props = renderPanel();
+    await typeAndSend(user, 'find features');
+
+    await waitFor(() => {
+      expect(props.onQueryResult).toHaveBeenCalled();
+    });
+    expect(props.onClearPreview).not.toHaveBeenCalled();
   });
 
   // fix(#527 B-054/C-06): NaN and inverted bboxes pass the range comparisons

--- a/frontend/src/components/builder/hooks/use-ephemeral-layers.ts
+++ b/frontend/src/components/builder/hooks/use-ephemeral-layers.ts
@@ -10,6 +10,14 @@ const EPHEMERAL_LAYERS = [
 ] as const;
 const EPHEMERAL_SOURCE = 'ephemeral-result';
 
+/** feat(#675): the params needed to reconstruct a chat run_analysis preview in
+ *  the Analysis panel, so "Save as dataset" can prefill it. */
+export interface EphemeralAnalysisHandoff {
+  operation: 'buffer' | 'centroid';
+  layerId: string;
+  distanceMeters?: number;
+}
+
 export function useEphemeralLayers(
   mapInstanceRef: React.RefObject<MaplibreMap | null>,
 ) {
@@ -21,6 +29,9 @@ export function useEphemeralLayers(
      *  the whole answer. */
     truncated?: boolean;
     totalCount?: number;
+    /** feat(#675): present when the overlay came from a chat run_analysis
+     *  preview the builder can hand off to the Analysis panel. */
+    analysis?: EphemeralAnalysisHandoff;
   } | null>(null);
 
   const clearEphemeralLayer = useCallback(() => {
@@ -136,7 +147,7 @@ export function useEphemeralLayers(
   const handleQueryResult = useCallback((
     geojson: GeoJSON.FeatureCollection,
     bbox: [number, number, number, number],
-    meta?: { truncated?: boolean; totalCount?: number },
+    meta?: { truncated?: boolean; totalCount?: number; analysis?: EphemeralAnalysisHandoff },
   ) => {
     setEphemeralResult({ geojson, bbox, ...meta });
   }, []);

--- a/frontend/src/components/viewer/ViewerChatPanel.tsx
+++ b/frontend/src/components/viewer/ViewerChatPanel.tsx
@@ -147,6 +147,12 @@ export function ViewerChatPanel({ mapId, layers, mapInstanceRef }: ViewerChatPan
   /** Flyover + highlight (WGS84-bounded bbox guard) and extract the table payload. */
   const applyQueryResult = useCallback((action: ChatAction): QueryResult | undefined => {
     const geojson = action.geojson;
+    if (!geojson) {
+      // fix(#676): the winning result has no geometry (empty analysis,
+      // attribute-only query) — clear the single-slot overlay instead of
+      // leaving the previous turn's features and badge on the map.
+      handleDismissEphemeral();
+    }
     if (
       geojson &&
       typeof geojson === 'object' &&
@@ -178,7 +184,7 @@ export function ViewerChatPanel({ mapId, layers, mapInstanceRef }: ViewerChatPan
       rowCount: typeof action.row_count === 'number' ? action.row_count : rows.length,
       truncated: action.truncated === true,
     };
-  }, [handleQueryResult]);
+  }, [handleQueryResult, handleDismissEphemeral]);
 
   const handleSend = useCallback(async () => {
     const userMsg = input.trim();

--- a/frontend/src/components/viewer/__tests__/ViewerChatPanel.test.tsx
+++ b/frontend/src/components/viewer/__tests__/ViewerChatPanel.test.tsx
@@ -160,6 +160,33 @@ describe('ViewerChatPanel', () => {
     expect(screen.getByText('496')).toBeInTheDocument();
   });
 
+  it('clears the stale overlay when the winning result has no geometry (#676)', async () => {
+    setAvailable(true);
+    const handleDismissEphemeral = vi.fn();
+    mockEphemeral.mockReturnValue({
+      ephemeralResult: null,
+      handleQueryResult,
+      handleDismissEphemeral,
+    });
+    mockStream.mockImplementation(async function* () {
+      yield {
+        event: 'actions',
+        // The geometry-less marker an empty run_analysis emits.
+        data: { actions: [{ type: 'show_query_result', row_count: 0 }] },
+      };
+      yield { event: 'done', data: { explanation: 'Nothing found.' } };
+    });
+
+    renderPanel();
+    await userEvent.click(screen.getByRole('button', { name: 'Ask AI' }));
+    await userEvent.type(screen.getByPlaceholderText('Ask about this map...'), 'buffer the empty layer');
+    await userEvent.click(screen.getByRole('button', { name: 'Send' }));
+
+    await screen.findByText('Nothing found.');
+    expect(handleDismissEphemeral).toHaveBeenCalled();
+    expect(handleQueryResult).not.toHaveBeenCalled();
+  });
+
   it('shows a retry-able error bubble when the stream fails', async () => {
     setAvailable(true);
     // eslint-disable-next-line require-yield

--- a/frontend/src/i18n/locales/de/builder.json
+++ b/frontend/src/i18n/locales/de/builder.json
@@ -972,7 +972,8 @@
     "featureCount_one": "{{count}} Feature",
     "featureCount_other": "{{count}} Features",
     "dismiss": "Ergebnis verwerfen",
-    "featureCountTruncated": "{{count}} von {{total}} Elementen"
+    "featureCountTruncated": "{{count}} von {{total}} Elementen",
+    "saveAsDataset": "Als Datensatz speichern…"
   },
   "plugins": {
     "measurement": {

--- a/frontend/src/i18n/locales/en/builder.json
+++ b/frontend/src/i18n/locales/en/builder.json
@@ -972,7 +972,8 @@
     "featureCount_one": "{{count}} feature",
     "featureCount_other": "{{count}} features",
     "featureCountTruncated": "{{count}} of {{total}} features",
-    "dismiss": "Dismiss result"
+    "dismiss": "Dismiss result",
+    "saveAsDataset": "Save as dataset…"
   },
   "plugins": {
     "measurement": {

--- a/frontend/src/i18n/locales/es/builder.json
+++ b/frontend/src/i18n/locales/es/builder.json
@@ -972,7 +972,8 @@
     "featureCount_one": "{{count}} entidad",
     "featureCount_other": "{{count}} entidades",
     "dismiss": "Descartar resultado",
-    "featureCountTruncated": "{{count}} de {{total}} elementos"
+    "featureCountTruncated": "{{count}} de {{total}} elementos",
+    "saveAsDataset": "Guardar como conjunto de datos…"
   },
   "plugins": {
     "measurement": {

--- a/frontend/src/i18n/locales/fr/builder.json
+++ b/frontend/src/i18n/locales/fr/builder.json
@@ -972,7 +972,8 @@
     "featureCount_one": "{{count}} entité",
     "featureCount_other": "{{count}} entités",
     "dismiss": "Fermer le résultat",
-    "featureCountTruncated": "{{count}} sur {{total}} éléments"
+    "featureCountTruncated": "{{count}} sur {{total}} éléments",
+    "saveAsDataset": "Enregistrer comme jeu de données…"
   },
   "plugins": {
     "measurement": {

--- a/frontend/src/pages/MapBuilderPage.tsx
+++ b/frontend/src/pages/MapBuilderPage.tsx
@@ -788,6 +788,14 @@ export function MapBuilderPage() {
     setRailPanel('analysis');
   }, [ephemeralAnalysis]);
 
+  // fix(#679 review P2): the prefill lives only for the handoff opening it
+  // triggered. Clearing it on any navigation away from the panel (rail close,
+  // panel switch, mobile sheet dismiss) keeps a later ordinary opening from
+  // remounting the form with stale handoff params.
+  useEffect(() => {
+    if (railPanel !== 'analysis' && analysisPrefill) setAnalysisPrefill(null);
+  }, [railPanel, analysisPrefill]);
+
   const railProps = useMemo(() => ({
     activePanel: railPanel,
     onPanelChange: setRailPanel,

--- a/frontend/src/pages/MapBuilderPage.tsx
+++ b/frontend/src/pages/MapBuilderPage.tsx
@@ -103,6 +103,7 @@ import {
 import { PluginHost, PluginSidebar, getDefaultPluginIds, resolveAvailablePluginIds, usePartitionedPlugins } from '@/components/map-plugins';
 import { usePluginStore } from '@/stores/map-plugin-store';
 import type { ViewportContext } from '@/components/builder/chat-suggestions';
+import type { EphemeralAnalysisHandoff } from '@/components/builder/hooks/use-ephemeral-layers';
 import { readStorage, removeStorage, storageKeys } from '@/lib/storage';
 import { takeChatResult } from '@/lib/chat-result-handoff';
 
@@ -138,6 +139,11 @@ export function MapBuilderPage() {
   // pluginCtx useMemo. The ref provides stable imperative access without re-renders.
   const [mapInstance, setMapInstance] = useState<MaplibreMap | null>(null);
   const [railPanel, setRailPanel] = useState<RailPanel>(null);
+  // feat(#675): chat run_analysis preview → Analysis panel handoff. The nonce
+  // keys a panel remount so successive handoffs re-apply the prefill.
+  const [analysisPrefill, setAnalysisPrefill] = useState<
+    (EphemeralAnalysisHandoff & { nonce: number }) | null
+  >(null);
   const [dockNotes, setDockNotes] = useState('');
   // Projection (Mercator/Globe). Persisted on basemap_config.projection; seeded from
   // the saved map on load and applied to the live map once it's ready (effects below).
@@ -773,6 +779,15 @@ export function MapBuilderPage() {
       .map((l) => ({ id: l.id, name: l.display_name ?? l.dataset_name ?? 'Group' }));
   }, [layers.localLayers]);
 
+  // feat(#675): "Save as dataset" on the ephemeral badge — open the Analysis
+  // panel prefilled with the operation behind the chat preview.
+  const ephemeralAnalysis = layers.ephemeralResult?.analysis;
+  const handleSaveAnalysisPreview = useCallback(() => {
+    if (!ephemeralAnalysis) return;
+    setAnalysisPrefill({ ...ephemeralAnalysis, nonce: Date.now() });
+    setRailPanel('analysis');
+  }, [ephemeralAnalysis]);
+
   const railProps = useMemo(() => ({
     activePanel: railPanel,
     onPanelChange: setRailPanel,
@@ -786,9 +801,10 @@ export function MapBuilderPage() {
     mapInstanceRef,
     onClearPreview: layers.handleDismissEphemeral,
     hasPreview: !!layers.ephemeralResult,
+    analysisPrefill,
     onMarkDirty: handleMarkDirty,
     viewport,
-  }), [railPanel, aiAvailable, dockNotes, id, layers.localLayers, layers.chatLayerActions, layers.handleQueryResult, layers.handleDismissEphemeral, layers.ephemeralResult, mapInstanceRef, handleMarkDirty, viewport]);
+  }), [railPanel, aiAvailable, dockNotes, id, layers.localLayers, layers.chatLayerActions, layers.handleQueryResult, layers.handleDismissEphemeral, layers.ephemeralResult, analysisPrefill, mapInstanceRef, handleMarkDirty, viewport]);
 
   const mobileRailButtons = useMemo(() => [
     {
@@ -1749,6 +1765,7 @@ export function MapBuilderPage() {
               onDismiss={layers.handleDismissEphemeral}
               truncated={layers.ephemeralResult.truncated}
               totalCount={layers.ephemeralResult.totalCount}
+              onSaveAsDataset={ephemeralAnalysis ? handleSaveAnalysisPreview : undefined}
             />
           )}
 

--- a/frontend/src/types/api.generated.ts
+++ b/frontend/src/types/api.generated.ts
@@ -6093,6 +6093,8 @@ export interface components {
             dataset_id?: string | null;
             /** Dataset Name */
             dataset_name?: string | null;
+            /** Distance Meters */
+            distance_meters?: number | null;
             /** Expression */
             expression?: unknown[] | null;
             geojson?: components["schemas"]["GeoJSONFeatureCollection"] | null;
@@ -6104,6 +6106,8 @@ export interface components {
             layer_id?: string | null;
             /** Opacity */
             opacity?: number | null;
+            /** Operation */
+            operation?: string | null;
             /** Paint */
             paint?: {
                 [key: string]: unknown;

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -1434,6 +1434,11 @@ export interface ChatAction {
   row_count?: number;
   /** True when `rows` was capped below the full `row_count`. */
   truncated?: boolean;
+  /** feat(#675): analysis operation behind a run_analysis preview, carried so
+   *  the builder can prefill the Analysis panel ("Save as dataset"). */
+  operation?: string;
+  /** feat(#675): sanitized buffer distance for the Analysis-panel handoff. */
+  distance_meters?: number;
 }
 
 export interface ChatResponse {

--- a/sdks/python/geolens/models/chat_action.py
+++ b/sdks/python/geolens/models/chat_action.py
@@ -32,11 +32,13 @@ class ChatAction:
         columns (list[str] | None | Unset):
         dataset_id (None | str | Unset):
         dataset_name (None | str | Unset):
+        distance_meters (float | None | Unset):
         expression (list[Any] | None | Unset):
         geojson (GeoJSONFeatureCollection | None | Unset):
         label_config (ChatActionLabelConfigType0 | None | Unset):
         layer_id (None | str | Unset):
         opacity (float | None | Unset):
+        operation (None | str | Unset):
         paint (ChatActionPaintType0 | None | Unset):
         replace_paint (bool | None | Unset):
         row_count (int | None | Unset):
@@ -52,11 +54,13 @@ class ChatAction:
     columns: list[str] | None | Unset = UNSET
     dataset_id: None | str | Unset = UNSET
     dataset_name: None | str | Unset = UNSET
+    distance_meters: float | None | Unset = UNSET
     expression: list[Any] | None | Unset = UNSET
     geojson: GeoJSONFeatureCollection | None | Unset = UNSET
     label_config: ChatActionLabelConfigType0 | None | Unset = UNSET
     layer_id: None | str | Unset = UNSET
     opacity: float | None | Unset = UNSET
+    operation: None | str | Unset = UNSET
     paint: ChatActionPaintType0 | None | Unset = UNSET
     replace_paint: bool | None | Unset = UNSET
     row_count: int | None | Unset = UNSET
@@ -113,6 +117,12 @@ class ChatAction:
         else:
             dataset_name = self.dataset_name
 
+        distance_meters: float | None | Unset
+        if isinstance(self.distance_meters, Unset):
+            distance_meters = UNSET
+        else:
+            distance_meters = self.distance_meters
+
         expression: list[Any] | None | Unset
         if isinstance(self.expression, Unset):
             expression = UNSET
@@ -149,6 +159,12 @@ class ChatAction:
             opacity = UNSET
         else:
             opacity = self.opacity
+
+        operation: None | str | Unset
+        if isinstance(self.operation, Unset):
+            operation = UNSET
+        else:
+            operation = self.operation
 
         paint: dict[str, Any] | None | Unset
         if isinstance(self.paint, Unset):
@@ -220,6 +236,8 @@ class ChatAction:
             field_dict["dataset_id"] = dataset_id
         if dataset_name is not UNSET:
             field_dict["dataset_name"] = dataset_name
+        if distance_meters is not UNSET:
+            field_dict["distance_meters"] = distance_meters
         if expression is not UNSET:
             field_dict["expression"] = expression
         if geojson is not UNSET:
@@ -230,6 +248,8 @@ class ChatAction:
             field_dict["layer_id"] = layer_id
         if opacity is not UNSET:
             field_dict["opacity"] = opacity
+        if operation is not UNSET:
+            field_dict["operation"] = operation
         if paint is not UNSET:
             field_dict["paint"] = paint
         if replace_paint is not UNSET:
@@ -326,6 +346,15 @@ class ChatAction:
 
         dataset_name = _parse_dataset_name(d.pop("dataset_name", UNSET))
 
+        def _parse_distance_meters(data: object) -> float | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(float | None | Unset, data)
+
+        distance_meters = _parse_distance_meters(d.pop("distance_meters", UNSET))
+
         def _parse_expression(data: object) -> list[Any] | None | Unset:
             if data is None:
                 return data
@@ -396,6 +425,15 @@ class ChatAction:
             return cast(float | None | Unset, data)
 
         opacity = _parse_opacity(d.pop("opacity", UNSET))
+
+        def _parse_operation(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        operation = _parse_operation(d.pop("operation", UNSET))
 
         def _parse_paint(data: object) -> ChatActionPaintType0 | None | Unset:
             if data is None:
@@ -498,11 +536,13 @@ class ChatAction:
             columns=columns,
             dataset_id=dataset_id,
             dataset_name=dataset_name,
+            distance_meters=distance_meters,
             expression=expression,
             geojson=geojson,
             label_config=label_config,
             layer_id=layer_id,
             opacity=opacity,
+            operation=operation,
             paint=paint,
             replace_paint=replace_paint,
             row_count=row_count,

--- a/sdks/typescript/src/client/types.gen.ts
+++ b/sdks/typescript/src/client/types.gen.ts
@@ -1460,6 +1460,10 @@ export type ChatAction = {
      */
     dataset_name?: string | null;
     /**
+     * Distance Meters
+     */
+    distance_meters?: number | null;
+    /**
      * Expression
      */
     expression?: Array<unknown> | null;
@@ -1478,6 +1482,10 @@ export type ChatAction = {
      * Opacity
      */
     opacity?: number | null;
+    /**
+     * Operation
+     */
+    operation?: string | null;
     /**
      * Paint
      */


### PR DESCRIPTION
## Summary

Two follow-ups to the M4 chat `run_analysis` tool (#674), finishing the chat-analysis slice:

**#676 — stale overlay on empty results.** The single-slot ephemeral overlay only ever *replaced*; a turn with no geometry emitted nothing, so the previous overlay and its "N features" badge stayed on the map beside a reply saying nothing was found. `collect_run_analysis_action` now emits a geometry-less marker action for the error-free empty case, and both chat surfaces treat a winning `show_query_result` without geometry as "clear the overlay" — which also fixes the pre-existing `query_data` variants of the same class (empty result, attribute-only follow-up). Error results still leave the overlay untouched.

**#675 — "Save as dataset" handoff.** A liked chat preview previously required re-selecting the layer, operation, and distance by hand in the Analysis panel. The `run_analysis` action now carries its reconstruction params (`operation`, `layer_id`, sanitized `distance_meters`), and the builder's ephemeral badge offers **Save as dataset…**, opening the Analysis rail panel prefilled (remounted via a nonce key). Nothing auto-saves; the user still names the output and hits Create dataset. The viewer surface is untouched — it never passes the affordance and has no Analysis rail. A handoff whose layer left the map falls back to the default selection.

## Schema/API impact

`ChatAction` gains optional `operation` and `distance_meters` fields (additive). `backend/openapi.json`, both SDKs, and `frontend/src/types/api.generated.ts` regenerated. New i18n key `ephemeralBadge.saveAsDataset` added to all four locales.

## Verification

- `pytest tests/test_ai_chat*.py tests/test_chat_*.py tests/test_collect_chat_action.py tests/test_layering.py` — 119 passed (incl. new pins: empty-marker action, handoff params, ChatAction round-trip)
- `vitest run src/components/builder src/components/viewer src/pages` — 2043 passed (new: clear-on-empty in both panels, meta threading, AnalysisPanel prefill × 3)
- `npm run typecheck`, `npm run lint`, `npm run test:i18n`, `make openapi-check`, ruff check/format — clean

Closes #675
Closes #676

https://claude.ai/code/session_01X1Wd3Frww9F2eovfMkUbG2