### PR TITLE
fix(analysis): harden op correctness, close panel/chat parity gaps, expand tests

### DIFF
--- a/backend/app/modules/catalog/datasets/api/router_analysis.py
+++ b/backend/app/modules/catalog/datasets/api/router_analysis.py
@@ -38,13 +38,15 @@ router = APIRouter(
 _SAFE_COLUMN_RE = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_]*$")
 
 # Sandbox error categories → HTTP status. Everything else is a sanitized 500.
-# query_failed is a 422 here (not 500): all SQL on this path is server-built
-# from validated params, so execution failures are data-driven (e.g. degenerate
-# geometries), not server faults.
+# query_data_error (SQLSTATE class 22 / GEOS internal errors) is a 422: all
+# SQL on this path is server-built from validated params, so those failures
+# are data-driven (e.g. degenerate geometries). Generic query_failed stays a
+# 500 — it also covers connection loss, tenant-context and role-binding
+# failures, which are server faults, not bad requests.
 _SANDBOX_STATUS = {
     "query_busy": status.HTTP_429_TOO_MANY_REQUESTS,
     "query_timeout": status.HTTP_422_UNPROCESSABLE_CONTENT,
-    "query_failed": status.HTTP_422_UNPROCESSABLE_CONTENT,
+    "query_data_error": status.HTTP_422_UNPROCESSABLE_CONTENT,
 }
 
 

--- a/backend/app/modules/catalog/datasets/api/router_analysis.py
+++ b/backend/app/modules/catalog/datasets/api/router_analysis.py
@@ -38,9 +38,13 @@ router = APIRouter(
 _SAFE_COLUMN_RE = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_]*$")
 
 # Sandbox error categories → HTTP status. Everything else is a sanitized 500.
+# query_failed is a 422 here (not 500): all SQL on this path is server-built
+# from validated params, so execution failures are data-driven (e.g. degenerate
+# geometries), not server faults.
 _SANDBOX_STATUS = {
     "query_busy": status.HTTP_429_TOO_MANY_REQUESTS,
     "query_timeout": status.HTTP_422_UNPROCESSABLE_CONTENT,
+    "query_failed": status.HTTP_422_UNPROCESSABLE_CONTENT,
 }
 
 
@@ -126,6 +130,14 @@ async def analysis_materialize_endpoint(
             raise HTTPException(
                 status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
                 detail=f"Unknown dissolve column: {body.by_field!r}",
+            )
+        if body.by_field == "source_count":
+            # The dissolve output already emits a generated source_count
+            # column; carrying a same-named group key would fail the CTAS
+            # with an opaque "column specified more than once".
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+                detail="by_field conflicts with the generated 'source_count' column",
             )
 
     # Best-effort dataset-count pre-check; the authoritative atomic

--- a/backend/app/modules/catalog/datasets/domain/schemas.py
+++ b/backend/app/modules/catalog/datasets/domain/schemas.py
@@ -877,6 +877,16 @@ class AnalysisPreviewRequest(BaseModel):
         ),
     )
 
+    @model_validator(mode="before")
+    @classmethod
+    def _drop_ignored_distance(cls, data: Any) -> Any:
+        # distance_meters is documented as "buffer only; ignored otherwise" —
+        # actually ignore it, or the optional field's gt/le bounds fire on
+        # placeholder values SDK/CLI callers send alongside centroid/clip.
+        if isinstance(data, dict) and data.get("operation") != "buffer":
+            data = {k: v for k, v in data.items() if k != "distance_meters"}
+        return data
+
     @model_validator(mode="after")
     def _require_operation_params(self) -> "AnalysisPreviewRequest":
         if self.operation == "buffer" and self.distance_meters is None:
@@ -893,6 +903,13 @@ class AnalysisPreviewResponse(BaseModel):
     feature_count: int
     truncated: bool
     bbox: list[float] | None = None
+    source_feature_count: int | None = Field(
+        default=None,
+        description=(
+            "Total feature count of the source dataset (1:1 operations only; "
+            "null when the operation filters rows, e.g. clip)"
+        ),
+    )
 
 
 class AnalysisMaterializeRequest(BaseModel):
@@ -917,6 +934,14 @@ class AnalysisMaterializeRequest(BaseModel):
         max_length=63,
         description="Optional group-by column for dissolve",
     )
+
+    @model_validator(mode="before")
+    @classmethod
+    def _drop_ignored_distance(cls, data: Any) -> Any:
+        # Same contract as AnalysisPreviewRequest: distance is buffer-only.
+        if isinstance(data, dict) and data.get("operation") != "buffer":
+            data = {k: v for k, v in data.items() if k != "distance_meters"}
+        return data
 
     @model_validator(mode="after")
     def _require_operation_params(self) -> "AnalysisMaterializeRequest":

--- a/backend/app/modules/catalog/datasets/domain/service_analysis.py
+++ b/backend/app/modules/catalog/datasets/domain/service_analysis.py
@@ -107,4 +107,10 @@ async def run_analysis_preview(
         feature_count=len(features),
         truncated=result.truncated,
         bbox=bbox,
+        # buffer/centroid are 1:1 per feature, so the source count IS the
+        # output total and lets clients render "500 of N" on truncation.
+        # clip filters rows, so its total is unknowable without a second scan.
+        source_feature_count=(
+            dataset.feature_count if request.operation != "clip" else None
+        ),
     )

--- a/backend/app/modules/catalog/datasets/domain/service_analysis.py
+++ b/backend/app/modules/catalog/datasets/domain/service_analysis.py
@@ -45,9 +45,16 @@ def build_preview_sql(table_ref: str, request: AnalysisPreviewRequest) -> str:
         distance_meters=request.distance_meters,
         mask=request.mask,
     )
+    # fix(#680 review): drop NULL/EMPTY results in SQL, not in Python — the
+    # sandbox applies its row cap to raw rows, so boundary-grazing clips
+    # (which pass ST_Intersects but extract to EMPTY) could consume the whole
+    # preview budget along a shared boundary and hide real intersections with
+    # higher gids, even reporting a false "no features".
     return (
-        f"SELECT gid, ST_AsGeoJSON({expr}, {_GEOJSON_PRECISION}) AS geometry_json"
-        f" FROM {table_ref}{where} ORDER BY gid"
+        f"SELECT gid, ST_AsGeoJSON(geom_out, {_GEOJSON_PRECISION}) AS geometry_json"
+        f" FROM (SELECT gid, {expr} AS geom_out FROM {table_ref}{where}) AS _op"
+        f" WHERE geom_out IS NOT NULL AND NOT ST_IsEmpty(geom_out)"
+        f" ORDER BY gid"
     )
 
 

--- a/backend/app/platform/analysis_sql.py
+++ b/backend/app/platform/analysis_sql.py
@@ -6,15 +6,22 @@ worker (``processing/analysis/tasks.py``) can import it — catalog must not
 import processing and vice versa (CATPORT guards in test_layering.py).
 
 Pure string rendering. The injection boundary:
-- numbers are bounds-validated floats rendered via ``float()`` formatting;
+- numbers are bounds-validated floats rendered via ``float()`` formatting
+  (re-validated here against ``MAX_BUFFER_METERS`` so worker payloads don't
+  rely solely on the API schema's bounds);
 - clip masks are parsed and re-serialized by shapely, so the embedded JSON
   is strictly ``{"type": ..., "coordinates": [numbers]}``;
 - table identifiers are the callers' responsibility (``_safe_table_ref`` /
   regex-validated names).
+
+Source geometries are wrapped in ``ST_MakeValid``: one invalid ring anywhere
+in a dataset would otherwise abort the whole statement with a GEOS
+TopologyException, with no user-side workaround.
 """
 
 from __future__ import annotations
 
+import math
 from typing import Any
 
 import shapely
@@ -40,10 +47,19 @@ def render_mask_expr(mask: dict[str, Any]) -> str:
         ) from exc
     if geom.geom_type not in _CLIP_MASK_TYPES:
         raise ValueError("mask must be a GeoJSON Polygon or MultiPolygon geometry")
+    if geom.is_empty:
+        raise ValueError("mask geometry is empty")
     if shapely.count_coordinates(geom) > MAX_MASK_VERTICES:
         raise ValueError(f"mask exceeds {MAX_MASK_VERTICES} vertices")
+    if not all(math.isfinite(v) for v in geom.bounds):
+        # NaN/Infinity parse fine as JSON and as shapely coords, then blow up
+        # deep inside GEOS as an uncaught exception (a 500, not a 422).
+        raise ValueError("mask coordinates must be finite numbers")
     if not geom.is_valid:
-        geom = shapely.make_valid(geom)
+        try:
+            geom = shapely.make_valid(geom)
+        except GEOSException as exc:
+            raise ValueError("mask geometry is invalid") from exc
         if geom.geom_type not in _CLIP_MASK_TYPES:
             raise ValueError("mask geometry is invalid")
     rendered = shapely.to_geojson(geom)
@@ -67,13 +83,30 @@ def render_geometry_expr(
         if distance_meters is None:
             raise ValueError("buffer requires distance_meters")
         distance = float(distance_meters)
-        return f"ST_Buffer(geom_4326::geography, {distance})::geometry", ""
+        if not math.isfinite(distance) or not 0 < distance <= MAX_BUFFER_METERS:
+            raise ValueError(
+                f"buffer distance must be between 0 and {MAX_BUFFER_METERS:g} meters"
+            )
+        return (
+            f"ST_Buffer(ST_MakeValid(geom_4326)::geography, {distance})::geometry",
+            "",
+        )
     if operation == "centroid":
-        return "ST_Centroid(geom_4326)", ""
+        return "ST_Centroid(ST_MakeValid(geom_4326))", ""
     if operation == "clip":
         mask_expr = render_mask_expr(mask or {})
+        # A clip that only grazes a boundary intersects at a lower dimension
+        # (polygon ∩ polygon edge → LineString). Extract only components
+        # matching the source geometry's dimension (type code = dimension + 1)
+        # so the output stays homogeneous; grazing rows become EMPTY, which
+        # the preview path skips and the materialize worker deletes.
+        # The bare `geom_4326 &&` term keeps the GIST index usable — wrapping
+        # the column in ST_MakeValid inside ST_Intersects would defeat it.
         return (
-            f"ST_CollectionExtract(ST_Intersection(geom_4326, {mask_expr}))",
-            f" WHERE ST_Intersects(geom_4326, {mask_expr})",
+            "ST_CollectionExtract("
+            f"ST_Intersection(ST_MakeValid(geom_4326), {mask_expr}),"
+            " ST_Dimension(geom_4326) + 1)",
+            f" WHERE geom_4326 && {mask_expr}"
+            f" AND ST_Intersects(ST_MakeValid(geom_4326), {mask_expr})",
         )
     raise ValueError(f"Unsupported operation: {operation}")

--- a/backend/app/platform/sandbox/executor.py
+++ b/backend/app/platform/sandbox/executor.py
@@ -12,6 +12,7 @@ import sqlglot
 from sqlglot import exp
 from sqlglot.tokens import TokenType
 from sqlalchemy import text
+from sqlalchemy.exc import DataError, InternalError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.db.tenant_schema import tenant_data_schema, tenant_reader_role
@@ -258,6 +259,16 @@ def _handle_execution_error(exc: Exception, sql: str) -> None:
         or "read only" in exc_str
     ):
         raise SandboxError("query_failed", "Query failed") from exc
+
+    # Data-driven failures: SQLAlchemy maps SQLSTATE class 22 (data
+    # exception) to DataError and XX-class (how GEOS/PostGIS topology errors
+    # surface) to InternalError. A distinct category lets server-built-SQL
+    # callers (analysis) report these as 4xx without also reclassifying
+    # infrastructure failures (connection loss, role binding) as user error.
+    if isinstance(exc, (DataError, InternalError)):
+        raise SandboxError(
+            "query_data_error", "The query failed while processing this data"
+        ) from exc
 
     # All other DB errors
     raise SandboxError("query_failed", "Query failed") from exc

--- a/backend/app/processing/ai/chat_analysis.py
+++ b/backend/app/processing/ai/chat_analysis.py
@@ -143,9 +143,9 @@ async def _run_analysis(
     out["bbox"] = result.bbox
     if result.truncated:
         # Surface the source total so the map badge can say "500 of N" rather
-        # than presenting a capped preview as the whole result. buffer and
-        # centroid are 1:1 per feature, so the source count IS the output total.
-        out["source_feature_count"] = getattr(dataset, "feature_count", None)
+        # than presenting a capped preview as the whole result. The service
+        # computes it (1:1 ops only) — same field the HTTP preview now returns.
+        out["source_feature_count"] = result.source_feature_count
     # Deliberately surface-neutral: view-only callers get this tool too (it is
     # read-only), and they land on the public viewer, which has no Analysis
     # rail — BuilderRail is rendered by MapBuilderPage alone. Naming the panel

--- a/backend/app/processing/analysis/tasks.py
+++ b/backend/app/processing/analysis/tasks.py
@@ -29,6 +29,11 @@ logger = structlog.stdlib.get_logger(__name__)
 _SAFE_IDENT = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_]*$")
 _SAFE_TABLE = re.compile(r"^[a-z0-9_]+$")
 
+# The preview path is bounded (10s sandbox timeout, 500-row cap); the CTAS
+# here is the only unbounded statement a user can queue, so cap it.
+# ponytail: hardcoded ceiling; promote to persistent-config if operators hit it.
+MATERIALIZE_TIMEOUT = "300s"
+
 
 async def _list_carry_columns(
     session: AsyncSession, schema: str, table_name: str
@@ -56,17 +61,22 @@ def _build_materialize_select(
 ) -> str:
     """Render the SELECT that produces the output table's rows."""
     if operation == "dissolve":
+        # ST_MakeValid: one invalid ring would abort the whole union.
+        # ST_CollectionExtract: a union over mixed geometry types returns a
+        # GEOMETRYCOLLECTION, which the MVT tile path can't render — keep only
+        # the highest-dimension components so the output stays typed.
+        union_expr = "ST_Multi(ST_CollectionExtract(ST_Union(ST_MakeValid(geom_4326))))"
         if by_field:
             col = f'"{by_field}"'
             return (
                 f"SELECT (row_number() OVER ())::integer AS gid, {col}, "
                 f"COUNT(*)::integer AS source_count, "
-                f"ST_Multi(ST_Union(geom_4326)) AS geom "
+                f"{union_expr} AS geom "
                 f"FROM {src_ref} GROUP BY {col}"
             )
         return (
             f"SELECT 1 AS gid, COUNT(*)::integer AS source_count, "
-            f"ST_Multi(ST_Union(geom_4326)) AS geom FROM {src_ref}"
+            f"{union_expr} AS geom FROM {src_ref}"
         )
     expr, where = render_geometry_expr(
         operation, distance_meters=distance_meters, mask=mask
@@ -109,6 +119,11 @@ async def _materialize(
             current_tenant_var.get() if is_multi_tenant() else None
         )
         out_table: str | None = None
+        # Only drop the output table on failure if THIS job created it: when
+        # CREATE TABLE itself fails because a concurrent job won the same
+        # generated name, an unconditional cleanup would destroy the winner's
+        # table while its dataset registration stays live.
+        out_table_created = False
         try:
             port = get_processing_port()
             Dataset = port.get_dataset_orm_class()
@@ -140,7 +155,28 @@ async def _materialize(
                 by_field=by_field,
                 carry_cols=carry_cols,
             )
+            await session.execute(
+                text(f"SET LOCAL statement_timeout = '{MATERIALIZE_TIMEOUT}'")
+            )
             await session.execute(text(f"CREATE TABLE {out_ref} AS {select_sql}"))
+            out_table_created = True
+            if operation == "clip":
+                # Boundary-grazing rows survive ST_Intersects but extract to
+                # EMPTY (see analysis_sql.render_geometry_expr) — drop them.
+                await session.execute(
+                    text(f"DELETE FROM {out_ref} WHERE ST_IsEmpty(geom)")
+                )
+            has_features = await session.scalar(
+                text(
+                    f"SELECT EXISTS (SELECT 1 FROM {out_ref} "
+                    f"WHERE geom IS NOT NULL AND NOT ST_IsEmpty(geom))"
+                )
+            )
+            if not has_features:
+                # e.g. a clip matching nothing, or dissolving an empty
+                # dataset (whose no-GROUP-BY aggregate still yields one
+                # NULL-geometry row) — fail loud instead of registering junk.
+                raise ValueError("Analysis produced no features to save")
             # CTAS yields an untyped geometry column (typmod srid=0), which
             # metadata extraction reports as SRID 0 — stamp the 4326 typmod.
             await session.execute(
@@ -168,7 +204,7 @@ async def _materialize(
         except Exception as exc:  # broad: any failure must mark the job failed, not raise into the queue
             logger.warning("analysis.materialize_failed", job_id=job_id, error=str(exc))
             await session.rollback()
-            if out_table:
+            if out_table and out_table_created:
                 try:
                     await session.execute(
                         text(f'DROP TABLE IF EXISTS "{_schema}"."{out_table}"')

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -953,6 +953,18 @@
             "title": "Geojson",
             "type": "object"
           },
+          "source_feature_count": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Total feature count of the source dataset (1:1 operations only; null when the operation filters rows, e.g. clip)",
+            "title": "Source Feature Count"
+          },
           "truncated": {
             "title": "Truncated",
             "type": "boolean"

--- a/backend/tests/test_analysis_materialize.py
+++ b/backend/tests/test_analysis_materialize.py
@@ -127,6 +127,56 @@ class TestMaterializeEndpoint:
         )
         assert resp.status_code == 422
 
+    async def test_by_field_source_count_conflict_rejected(
+        self,
+        client: AsyncClient,
+        admin_auth_header: dict,
+        test_db_session: AsyncSession,
+    ):
+        """A real source column named source_count would collide with the
+        generated output column and fail the CTAS with an opaque error."""
+        admin_id = await get_user_id(test_db_session, "admin")
+        from tests.factories import create_dataset
+
+        ds = await create_dataset(
+            test_db_session,
+            created_by=admin_id,
+            geometry_type="POLYGON",
+            column_info=[{"name": "source_count", "type": "integer"}],
+        )
+        resp = await client.post(
+            _materialize_url(ds.id),
+            json={
+                "operation": "dissolve",
+                "by_field": "source_count",
+                "title": "Conflict",
+            },
+            headers=admin_auth_header,
+        )
+        assert resp.status_code == 422
+        assert "source_count" in resp.json()["detail"]
+
+    async def test_centroid_ignores_stray_distance(
+        self,
+        client: AsyncClient,
+        admin_auth_header: dict,
+        test_db_session: AsyncSession,
+    ):
+        """Materialize mirrors the preview schema: distance is buffer-only."""
+        admin_id = await get_user_id(test_db_session, "admin")
+        ds = await _create_polygon_dataset(test_db_session, created_by=admin_id)
+        with patch.object(router_analysis, "defer_async_with_tenant", AsyncMock()):
+            resp = await client.post(
+                _materialize_url(ds.id),
+                json={
+                    "operation": "centroid",
+                    "distance_meters": 999_999,
+                    "title": "Centroids",
+                },
+                headers=admin_auth_header,
+            )
+        assert resp.status_code == 200, resp.text
+
 
 # ---------------------------------------------------------------------------
 # Worker tests (core logic run inline, no queue)
@@ -226,3 +276,258 @@ class TestMaterializeWorker:
         await test_db_session.refresh(job)
         assert job.status == "failed"
         assert job.error_message
+
+    async def test_result_dataset_is_private_and_owned_by_requester(
+        self,
+        test_db_session: AsyncSession,
+    ):
+        """The single highest-risk invariant: analysis outputs must register
+        as private datasets owned by the requesting user — a regression here
+        silently exposes derived copies of source data."""
+        admin_id = await get_user_id(test_db_session, "admin")
+        ds = await _create_polygon_dataset(test_db_session, created_by=admin_id)
+        job = await _create_job(test_db_session, admin_id)
+
+        await _materialize(
+            job_id=str(job.id),
+            dataset_id=str(ds.id),
+            user_id=str(admin_id),
+            operation="centroid",
+            title=f"Owned {uuid.uuid4().hex[:6]}",
+        )
+
+        await test_db_session.refresh(job)
+        assert job.status == "complete", job.error_message
+
+        from app.modules.catalog.datasets.domain.models import Dataset, Record
+
+        new_ds = await test_db_session.get(Dataset, job.dataset_id)
+        assert new_ds is not None
+        # Visibility and ownership both live on the catalog Record.
+        record = await test_db_session.get(Record, new_ds.record_id)
+        assert record is not None
+        assert record.visibility == "private"
+        assert record.created_by == admin_id
+
+    async def test_clip_materialize_creates_dataset(
+        self,
+        test_db_session: AsyncSession,
+    ):
+        """End-to-end clip: mask renders into the CTAS, only intersecting rows
+        survive, attributes carry, and the output geometry stays polygonal."""
+        admin_id = await get_user_id(test_db_session, "admin")
+        ds = await _create_polygon_dataset(test_db_session, created_by=admin_id)
+        job = await _create_job(test_db_session, admin_id)
+        mask = {
+            "type": "Polygon",
+            "coordinates": [
+                [[-0.5, -0.5], [-0.5, 0.5], [0.5, 0.5], [0.5, -0.5], [-0.5, -0.5]]
+            ],
+        }
+
+        await _materialize(
+            job_id=str(job.id),
+            dataset_id=str(ds.id),
+            user_id=str(admin_id),
+            operation="clip",
+            title=f"Clipped {uuid.uuid4().hex[:6]}",
+            mask=mask,
+        )
+
+        await test_db_session.refresh(job)
+        assert job.status == "complete", job.error_message
+
+        from app.modules.catalog.datasets.domain.models import Dataset
+
+        new_ds = await test_db_session.get(Dataset, job.dataset_id)
+        assert new_ds is not None
+        assert new_ds.feature_count == 1
+        rows = (
+            await test_db_session.execute(
+                text(
+                    f"SELECT name, GeometryType(geom_4326) FROM data.{new_ds.table_name}"  # noqa: S608
+                )
+            )
+        ).all()
+        assert rows == [("a", "POLYGON")]
+
+    async def test_dissolve_by_field_groups(
+        self,
+        test_db_session: AsyncSession,
+    ):
+        """Grouped dissolve: one row per group key, source_count populated,
+        gid numbered — the only branch that interpolates a user column."""
+        admin_id = await get_user_id(test_db_session, "admin")
+        ds = await _create_polygon_dataset(test_db_session, created_by=admin_id)
+        job = await _create_job(test_db_session, admin_id)
+
+        await _materialize(
+            job_id=str(job.id),
+            dataset_id=str(ds.id),
+            user_id=str(admin_id),
+            operation="dissolve",
+            title=f"Dissolved by name {uuid.uuid4().hex[:6]}",
+            by_field="name",
+        )
+
+        await test_db_session.refresh(job)
+        assert job.status == "complete", job.error_message
+
+        from app.modules.catalog.datasets.domain.models import Dataset
+
+        new_ds = await test_db_session.get(Dataset, job.dataset_id)
+        assert new_ds is not None
+        rows = (
+            await test_db_session.execute(
+                text(
+                    f"SELECT gid, name, source_count, GeometryType(geom_4326) "  # noqa: S608
+                    f"FROM data.{new_ds.table_name} ORDER BY name"
+                )
+            )
+        ).all()
+        assert rows == [
+            (1, "a", 1, "MULTIPOLYGON"),
+            (2, "b", 1, "MULTIPOLYGON"),
+        ] or rows == [
+            (2, "a", 1, "MULTIPOLYGON"),
+            (1, "b", 1, "MULTIPOLYGON"),
+        ]
+
+    async def test_empty_result_fails_job(
+        self,
+        test_db_session: AsyncSession,
+    ):
+        """A clip matching nothing must fail loud, not register a junk dataset."""
+        admin_id = await get_user_id(test_db_session, "admin")
+        ds = await _create_polygon_dataset(test_db_session, created_by=admin_id)
+        job = await _create_job(test_db_session, admin_id)
+        far_mask = {
+            "type": "Polygon",
+            "coordinates": [[[50, 50], [51, 50], [51, 51], [50, 51], [50, 50]]],
+        }
+
+        await _materialize(
+            job_id=str(job.id),
+            dataset_id=str(ds.id),
+            user_id=str(admin_id),
+            operation="clip",
+            title="Empty Clip",
+            mask=far_mask,
+        )
+
+        await test_db_session.refresh(job)
+        assert job.status == "failed"
+        assert "no features" in (job.error_message or "")
+        assert job.dataset_id is None
+
+    async def test_name_collision_preserves_existing_table(
+        self,
+        test_db_session: AsyncSession,
+    ):
+        """When CREATE TABLE loses a name race, cleanup must not drop the
+        winner's table — only a table this job actually created."""
+        from app.processing.ingest.service import generate_table_name
+
+        admin_id = await get_user_id(test_db_session, "admin")
+        ds = await _create_polygon_dataset(test_db_session, created_by=admin_id)
+        job = await _create_job(test_db_session, admin_id)
+        title = f"Collide {uuid.uuid4().hex[:6]}"
+        # generate_table_name checks only the catalog, so pre-creating the
+        # physical table simulates the concurrent winner.
+        expected, _ = await generate_table_name(title, test_db_session)
+        await test_db_session.execute(
+            text(f'CREATE TABLE data."{expected}" (marker integer)')
+        )
+        await test_db_session.commit()
+
+        await _materialize(
+            job_id=str(job.id),
+            dataset_id=str(ds.id),
+            user_id=str(admin_id),
+            operation="centroid",
+            title=title,
+        )
+
+        await test_db_session.refresh(job)
+        assert job.status == "failed"
+        survived = (
+            await test_db_session.execute(
+                text("SELECT to_regclass(:ref)").bindparams(ref=f'data."{expected}"')
+            )
+        ).scalar_one()
+        assert survived is not None
+        # And it is still the pre-existing table, not a half-built output.
+        cols = (
+            (
+                await test_db_session.execute(
+                    text(
+                        "SELECT column_name FROM information_schema.columns "
+                        "WHERE table_schema = 'data' AND table_name = :t"
+                    ).bindparams(t=expected)
+                )
+            )
+            .scalars()
+            .all()
+        )
+        assert cols == ["marker"]
+
+    async def test_mixed_geometry_dissolve_stays_typed(
+        self,
+        test_db_session: AsyncSession,
+    ):
+        """A union over mixed types must not register a GEOMETRYCOLLECTION —
+        only the highest-dimension components survive."""
+        admin_id = await get_user_id(test_db_session, "admin")
+        table_name = f"ds_{uuid.uuid4().hex[:12]}"
+        await test_db_session.execute(
+            text(
+                f"CREATE TABLE data.{table_name} ("
+                f"  gid SERIAL PRIMARY KEY,"
+                f"  geom geometry(Geometry, 4326),"
+                f"  geom_4326 geometry(Geometry, 4326)"
+                f")"
+            )
+        )
+        await test_db_session.execute(
+            text(
+                f"INSERT INTO data.{table_name} (geom, geom_4326) VALUES "
+                f"(ST_GeomFromText('POINT(5 5)', 4326),"
+                f" ST_GeomFromText('POINT(5 5)', 4326)),"
+                f"(ST_GeomFromText('POLYGON((0 0, 0 1, 1 1, 1 0, 0 0))', 4326),"
+                f" ST_GeomFromText('POLYGON((0 0, 0 1, 1 1, 1 0, 0 0))', 4326))"
+            )
+        )
+        await test_db_session.commit()
+        from tests.factories import create_dataset
+
+        ds = await create_dataset(
+            test_db_session,
+            created_by=admin_id,
+            table_name=table_name,
+            geometry_type="GEOMETRY",
+            feature_count=2,
+        )
+        job = await _create_job(test_db_session, admin_id)
+
+        await _materialize(
+            job_id=str(job.id),
+            dataset_id=str(ds.id),
+            user_id=str(admin_id),
+            operation="dissolve",
+            title=f"Mixed dissolve {uuid.uuid4().hex[:6]}",
+        )
+
+        await test_db_session.refresh(job)
+        assert job.status == "complete", job.error_message
+
+        from app.modules.catalog.datasets.domain.models import Dataset
+
+        new_ds = await test_db_session.get(Dataset, job.dataset_id)
+        geom_type = (
+            await test_db_session.execute(
+                text(
+                    f"SELECT GeometryType(geom_4326) FROM data.{new_ds.table_name}"  # noqa: S608
+                )
+            )
+        ).scalar_one()
+        assert geom_type == "MULTIPOLYGON"

--- a/backend/tests/test_analysis_preview.py
+++ b/backend/tests/test_analysis_preview.py
@@ -315,6 +315,169 @@ class TestAnalysisPreviewEndpoint:
         data = resp.json()
         assert data["feature_count"] == 500
         assert data["truncated"] is True
+        # 1:1 op — the source total rides along so clients can say "500 of N".
+        assert data["source_feature_count"] == 501
+
+    async def test_nan_mask_rejected(
+        self,
+        client: AsyncClient,
+        admin_auth_header: dict,
+        test_db_session: AsyncSession,
+    ):
+        """NaN parses as JSON and as shapely coords — must 422, not 500."""
+        admin_id = await get_user_id(test_db_session, "admin")
+        ds = await _create_polygon_dataset(test_db_session, created_by=admin_id)
+        resp = await client.post(
+            _preview_url(ds.id),
+            content=(
+                '{"operation": "clip", "mask": {"type": "Polygon", "coordinates":'
+                " [[[0, 0], [10, 0], [NaN, 10], [0, 10], [0, 0]]]}}"
+            ),
+            headers={**admin_auth_header, "Content-Type": "application/json"},
+        )
+        assert resp.status_code == 422, resp.text
+
+    async def test_empty_mask_rejected(
+        self,
+        client: AsyncClient,
+        admin_auth_header: dict,
+        test_db_session: AsyncSession,
+    ):
+        """An empty ring used to be a silent no-op reading as 'matched nothing'."""
+        admin_id = await get_user_id(test_db_session, "admin")
+        ds = await _create_polygon_dataset(test_db_session, created_by=admin_id)
+        resp = await client.post(
+            _preview_url(ds.id),
+            json={"operation": "clip", "mask": {"type": "Polygon", "coordinates": []}},
+            headers=admin_auth_header,
+        )
+        assert resp.status_code == 422
+
+    async def test_self_intersecting_mask_repaired(
+        self,
+        client: AsyncClient,
+        admin_auth_header: dict,
+        test_db_session: AsyncSession,
+    ):
+        """A bowtie mask goes through shapely.make_valid rather than erroring."""
+        admin_id = await get_user_id(test_db_session, "admin")
+        ds = await _create_polygon_dataset(test_db_session, created_by=admin_id)
+        bowtie = {
+            "type": "Polygon",
+            "coordinates": [[[-1, -1], [2, 2], [2, -1], [-1, 2], [-1, -1]]],
+        }
+        resp = await client.post(
+            _preview_url(ds.id),
+            json={"operation": "clip", "mask": bowtie},
+            headers=admin_auth_header,
+        )
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["feature_count"] >= 1
+
+    async def test_grazing_clip_yields_no_features(
+        self,
+        client: AsyncClient,
+        admin_auth_header: dict,
+        test_db_session: AsyncSession,
+    ):
+        """A mask sharing only an edge intersects at a lower dimension — the
+        output must be empty, not a LineString smuggled into a polygon result."""
+        admin_id = await get_user_id(test_db_session, "admin")
+        ds = await _create_polygon_dataset(test_db_session, created_by=admin_id)
+        grazing = {
+            "type": "Polygon",
+            "coordinates": [[[1, 0], [2, 0], [2, 1], [1, 1], [1, 0]]],
+        }
+        resp = await client.post(
+            _preview_url(ds.id),
+            json={"operation": "clip", "mask": grazing},
+            headers=admin_auth_header,
+        )
+        assert resp.status_code == 200, resp.text
+        data = resp.json()
+        assert data["feature_count"] == 0
+        assert data["geojson"]["features"] == []
+
+    async def test_centroid_ignores_stray_distance(
+        self,
+        client: AsyncClient,
+        admin_auth_header: dict,
+        test_db_session: AsyncSession,
+    ):
+        """distance_meters is documented as buffer-only; out-of-range values on
+        other operations must not 422 (SDK/CLI callers send placeholders)."""
+        admin_id = await get_user_id(test_db_session, "admin")
+        ds = await _create_polygon_dataset(test_db_session, created_by=admin_id)
+        for stray in (0, -5, 999_999):
+            resp = await client.post(
+                _preview_url(ds.id),
+                json={"operation": "centroid", "distance_meters": stray},
+                headers=admin_auth_header,
+            )
+            assert resp.status_code == 200, (stray, resp.text)
+
+    async def test_invalid_source_geometry_repaired(
+        self,
+        client: AsyncClient,
+        admin_auth_header: dict,
+        test_db_session: AsyncSession,
+    ):
+        """One self-intersecting source row used to abort every clip as a 500."""
+        admin_id = await get_user_id(test_db_session, "admin")
+        table_name = f"ds_{uuid.uuid4().hex[:12]}"
+        bowtie = "POLYGON((0 0, 1 1, 1 0, 0 1, 0 0))"
+        await test_db_session.execute(
+            text(
+                f"CREATE TABLE data.{table_name} ("
+                f"  gid SERIAL PRIMARY KEY,"
+                f"  geom geometry(Polygon, 4326),"
+                f"  geom_4326 geometry(Polygon, 4326)"
+                f")"
+            )
+        )
+        await test_db_session.execute(
+            text(
+                f"INSERT INTO data.{table_name} (geom, geom_4326) VALUES "
+                f"(ST_GeomFromText('{bowtie}', 4326),"
+                f" ST_GeomFromText('{bowtie}', 4326))"
+            )
+        )
+        await test_db_session.commit()
+        ds = await create_dataset(
+            test_db_session,
+            created_by=admin_id,
+            table_name=table_name,
+            geometry_type="POLYGON",
+            feature_count=1,
+        )
+        covering = {
+            "type": "Polygon",
+            "coordinates": [[[-1, -1], [2, -1], [2, 2], [-1, 2], [-1, -1]]],
+        }
+        resp = await client.post(
+            _preview_url(ds.id),
+            json={"operation": "clip", "mask": covering},
+            headers=admin_auth_header,
+        )
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["feature_count"] == 1
+
+    async def test_source_feature_count_none_for_clip(
+        self,
+        client: AsyncClient,
+        admin_auth_header: dict,
+        test_db_session: AsyncSession,
+    ):
+        """clip filters rows, so the source total would be a lie — omit it."""
+        admin_id = await get_user_id(test_db_session, "admin")
+        ds = await _create_polygon_dataset(test_db_session, created_by=admin_id)
+        resp = await client.post(
+            _preview_url(ds.id),
+            json={"operation": "clip", "mask": CLIP_MASK},
+            headers=admin_auth_header,
+        )
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["source_feature_count"] is None
 
 
 # ---------------------------------------------------------------------------
@@ -326,24 +489,37 @@ class TestBuildPreviewSql:
     def test_buffer_sql(self):
         req = AnalysisPreviewRequest(operation="buffer", distance_meters=500)
         sql = build_preview_sql('"data"."t1"', req)
-        assert "ST_Buffer(geom_4326::geography, 500.0)::geometry" in sql
+        assert "ST_Buffer(ST_MakeValid(geom_4326)::geography, 500.0)::geometry" in sql
         assert 'FROM "data"."t1"' in sql
         assert "ORDER BY gid" in sql
 
     def test_centroid_sql(self):
         req = AnalysisPreviewRequest(operation="centroid")
         sql = build_preview_sql('"data"."t1"', req)
-        assert "ST_Centroid(geom_4326)" in sql
+        assert "ST_Centroid(ST_MakeValid(geom_4326))" in sql
+
+    def test_buffer_distance_revalidated_at_sql_layer(self):
+        """The renderer enforces MAX_BUFFER_METERS itself — worker payloads
+        must not depend solely on the API schema's bounds."""
+        from app.platform.analysis_sql import render_geometry_expr
+
+        for bad in (0, -1, 200_000, float("nan"), float("inf")):
+            with pytest.raises(ValueError):
+                render_geometry_expr("buffer", distance_meters=bad)
+        # The documented cap itself is inclusive.
+        expr, _ = render_geometry_expr("buffer", distance_meters=100_000)
+        assert "100000" in expr
 
     def test_clip_mask_is_reserialized(self):
         req = AnalysisPreviewRequest(operation="clip", mask=CLIP_MASK)
         sql = build_preview_sql('"data"."t1"', req)
         assert "ST_GeomFromGeoJSON" in sql
         assert "ST_Intersects" in sql
-        # The mask appears twice (expression + WHERE); each embed contributes
-        # exactly its two wrapping quotes — shapely re-serialization guarantees
-        # no quote characters inside the JSON itself.
-        assert sql.count("'") == 4
+        # The mask appears three times (expression + bbox && term + WHERE
+        # ST_Intersects); each embed contributes exactly its two wrapping
+        # quotes — shapely re-serialization guarantees no quote characters
+        # inside the JSON itself.
+        assert sql.count("'") == 6
 
     def test_clip_mask_injection_rejected(self):
         req = AnalysisPreviewRequest(

--- a/backend/tests/test_analysis_preview.py
+++ b/backend/tests/test_analysis_preview.py
@@ -416,6 +416,61 @@ class TestAnalysisPreviewEndpoint:
             )
             assert resp.status_code == 200, (stray, resp.text)
 
+    async def test_grazing_rows_do_not_consume_preview_cap(
+        self,
+        client: AsyncClient,
+        admin_auth_header: dict,
+        test_db_session: AsyncSession,
+    ):
+        """fix(#680 review): 550 low-gid rows only graze the mask boundary
+        (they pass ST_Intersects but extract to EMPTY). The empties must be
+        filtered inside the SQL row cap, or they exhaust the 500-row preview
+        budget and hide the one real intersection at gid 551."""
+        admin_id = await get_user_id(test_db_session, "admin")
+        table_name = f"ds_{uuid.uuid4().hex[:12]}"
+        await test_db_session.execute(
+            text(
+                f"CREATE TABLE data.{table_name} ("
+                f"  gid SERIAL PRIMARY KEY,"
+                f"  geom geometry(Polygon, 4326),"
+                f"  geom_4326 geometry(Polygon, 4326)"
+                f")"
+            )
+        )
+        # Grazers share the mask's right edge (x = 0.5) from outside.
+        await test_db_session.execute(
+            text(
+                f"INSERT INTO data.{table_name} (geom, geom_4326) "
+                f"SELECT ST_MakeEnvelope(0.5, -0.4, 1.5, 0.4, 4326),"
+                f"       ST_MakeEnvelope(0.5, -0.4, 1.5, 0.4, 4326) "
+                f"FROM generate_series(1, 550)"
+            )
+        )
+        await test_db_session.execute(
+            text(
+                f"INSERT INTO data.{table_name} (geom, geom_4326) VALUES "
+                f"(ST_MakeEnvelope(0, 0, 0.3, 0.3, 4326),"
+                f" ST_MakeEnvelope(0, 0, 0.3, 0.3, 4326))"
+            )
+        )
+        await test_db_session.commit()
+        ds = await create_dataset(
+            test_db_session,
+            created_by=admin_id,
+            table_name=table_name,
+            geometry_type="POLYGON",
+            feature_count=551,
+        )
+        resp = await client.post(
+            _preview_url(ds.id),
+            json={"operation": "clip", "mask": CLIP_MASK},
+            headers=admin_auth_header,
+        )
+        assert resp.status_code == 200, resp.text
+        data = resp.json()
+        assert data["feature_count"] == 1
+        assert data["truncated"] is False
+
     async def test_invalid_source_geometry_repaired(
         self,
         client: AsyncClient,

--- a/backend/tests/test_sandbox.py
+++ b/backend/tests/test_sandbox.py
@@ -549,3 +549,29 @@ class TestValidateAndExecuteIntegration:
                 admin,
             )
         assert exc_info.value.category == "table_not_accessible"
+
+
+class TestExecutionErrorClassification:
+    """fix(#680 review): only data-driven failures may map to a 4xx category —
+    infrastructure failures must stay generic (callers report those as 500)."""
+
+    def test_data_and_internal_errors_classify_as_data_error(self):
+        from sqlalchemy.exc import DataError, InternalError
+
+        from app.platform.sandbox.executor import _handle_execution_error
+
+        for exc_cls in (DataError, InternalError):
+            exc = exc_cls("SELECT 1", None, Exception("GEOSIntersection error"))
+            with pytest.raises(SandboxError) as exc_info:
+                _handle_execution_error(exc, "SELECT 1")
+            assert exc_info.value.category == "query_data_error"
+
+    def test_operational_errors_stay_generic(self):
+        from sqlalchemy.exc import OperationalError
+
+        from app.platform.sandbox.executor import _handle_execution_error
+
+        exc = OperationalError("SELECT 1", None, Exception("connection refused"))
+        with pytest.raises(SandboxError) as exc_info:
+            _handle_execution_error(exc, "SELECT 1")
+        assert exc_info.value.category == "query_failed"

--- a/frontend/src/components/builder/AnalysisPanel.tsx
+++ b/frontend/src/components/builder/AnalysisPanel.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { TerraDraw, TerraDrawPolygonMode } from 'terra-draw';
 import { TerraDrawMapLibreGLAdapter } from 'terra-draw-maplibre-gl-adapter';
 import type { Map as MaplibreMap } from 'maplibre-gl';
@@ -16,13 +16,17 @@ import {
   SelectValue,
 } from '@/components/ui/select';
 import { MAP_COLORS } from '@/lib/map-colors';
+import { queryKeys } from '@/lib/query-keys';
 import { materializeAnalysis, previewAnalysis } from '@/api/analysis';
+import { useDataset } from '@/components/dataset/hooks/use-dataset';
 import { useJobStatus } from '@/components/import/hooks/use-ingest';
 import type { LayerActions } from '@/components/builder/ChatPanel';
 import type { EphemeralAnalysisHandoff } from '@/components/builder/hooks/use-ephemeral-layers';
 import type { AnalysisOperation, MapLayerResponse } from '@/types/api';
 
 const MAX_BUFFER_METERS = 100_000;
+// shadcn Select items can't carry an empty value — sentinel for "no grouping".
+const BY_FIELD_NONE = '__none__';
 
 interface AnalysisPanelProps {
   layers: MapLayerResponse[];
@@ -30,6 +34,7 @@ interface AnalysisPanelProps {
   onPreviewResult?: (
     geojson: GeoJSON.FeatureCollection,
     bbox: [number, number, number, number],
+    meta?: { truncated?: boolean; totalCount?: number },
   ) => void;
   onClearPreview?: () => void;
   hasPreview?: boolean;
@@ -54,7 +59,7 @@ export function AnalysisPanel({
   layerActions,
   prefill,
 }: AnalysisPanelProps) {
-  const { t } = useTranslation('builder');
+  const { t, i18n } = useTranslation('builder');
   const firstEligibleId =
     layers.find((l) => !!l.dataset_id && !l.is_dem)?.id ?? '';
   // feat(#675): a handoff layer that has since left the map (or lost its
@@ -70,13 +75,44 @@ export function AnalysisPanel({
   );
   const [mask, setMask] = useState<GeoJSON.Polygon | null>(null);
   const [isDrawing, setIsDrawing] = useState(false);
-  const [outputTitle, setOutputTitle] = useState('');
+  const [byField, setByField] = useState(BY_FIELD_NONE);
+  // A chat handoff lands on the save form — suggest a title so its primary
+  // button isn't silently disabled for want of one.
+  const [outputTitle, setOutputTitle] = useState(() => {
+    if (!prefill) return '';
+    const layer = layers.find((l) => l.id === prefill.layerId);
+    const base = layer?.display_name ?? layer?.dataset_name ?? '';
+    const opLabel =
+      prefill.operation === 'buffer'
+        ? t('analysisTools.opBuffer', { defaultValue: 'Buffer' })
+        : t('analysisTools.opCentroid', { defaultValue: 'Centroids' });
+    return [base, opLabel].filter(Boolean).join(' — ');
+  });
   const [jobId, setJobId] = useState<string | null>(null);
   const drawRef = useRef<TerraDraw | null>(null);
   const job = useJobStatus(jobId).data;
+  const queryClient = useQueryClient();
 
   const datasetLayers = layers.filter((l) => !!l.dataset_id && !l.is_dem);
   const selectedLayer = datasetLayers.find((l) => l.id === layerId);
+  // Only fetched while dissolve is selected (enabled gates on a non-empty id).
+  const datasetDetail = useDataset(
+    operation === 'dissolve' ? (selectedLayer?.dataset_id ?? '') : '',
+  );
+  const byFieldColumns = (datasetDetail.data?.column_info ?? [])
+    .map((c) => c.name)
+    // The dissolve output already emits a generated source_count column.
+    .filter((name) => name !== 'source_count');
+
+  // fix(#438)-style gap: the materialized dataset was missing from Add-data
+  // search until the stale queries refetched on their own.
+  const jobStatus = job?.status;
+  useEffect(() => {
+    if (jobStatus === 'complete') {
+      queryClient.invalidateQueries({ queryKey: queryKeys.datasets.all });
+      queryClient.invalidateQueries({ queryKey: queryKeys.search.all });
+    }
+  }, [jobStatus, queryClient]);
 
   const stopDrawing = useCallback(() => {
     drawRef.current?.stop();
@@ -111,9 +147,16 @@ export function AnalysisPanel({
       const feature = td.getSnapshotFeature(id);
       if (feature && feature.geometry.type === 'Polygon') {
         setMask(feature.geometry as GeoJSON.Polygon);
+        // Keep the drawn polygon visible (built-in static mode) so the user
+        // can see what will be clipped — removing it left the mask invisible
+        // with only a "Clip area set" note as evidence. Clearing the mask
+        // stops TerraDraw, which removes its layers.
+        td.setMode('static');
+        setIsDrawing(false);
+      } else {
+        td.removeFeatures([id]);
+        stopDrawing();
       }
-      td.removeFeatures([id]);
-      stopDrawing();
     });
     drawRef.current = td;
     setIsDrawing(true);
@@ -138,6 +181,10 @@ export function AnalysisPanel({
     },
     onSuccess: (result) => {
       if (!result.feature_count || !result.bbox) {
+        // fix(#676) parity: chat surfaces clear a stale overlay on an empty
+        // result; without this the previous preview kept describing a result
+        // the toast says doesn't exist.
+        onClearPreview?.();
         toast.info(
           t('analysisTools.noResults', {
             defaultValue: 'The operation returned no features',
@@ -145,16 +192,28 @@ export function AnalysisPanel({
         );
         return;
       }
-      onPreviewResult?.(
-        result.geojson,
-        result.bbox as [number, number, number, number],
-      );
+      const total = result.source_feature_count;
+      const bbox = result.bbox as [number, number, number, number];
+      if (result.truncated) {
+        onPreviewResult?.(result.geojson, bbox, {
+          truncated: true,
+          totalCount: total ?? undefined,
+        });
+      } else {
+        onPreviewResult?.(result.geojson, bbox);
+      }
       if (result.truncated) {
         toast.info(
-          t('analysisTools.truncatedNotice', {
-            defaultValue: 'Preview capped at {{count}} features',
-            count: result.feature_count,
-          }),
+          total != null
+            ? t('analysisTools.truncatedNoticeTotal', {
+                defaultValue: 'Showing the first {{count}} of {{total}} features',
+                count: result.feature_count,
+                total: total.toLocaleString(i18n.language),
+              })
+            : t('analysisTools.truncatedNotice', {
+                defaultValue: 'Preview capped at {{count}} features',
+                count: result.feature_count,
+              }),
         );
       }
     },
@@ -175,6 +234,9 @@ export function AnalysisPanel({
         title: outputTitle.trim(),
         ...(operation === 'buffer' ? { distance_meters: distanceValue } : {}),
         ...(operation === 'clip' && mask ? { mask } : {}),
+        ...(operation === 'dissolve' && byField !== BY_FIELD_NONE
+          ? { by_field: byField }
+          : {}),
       });
     },
     onSuccess: (result) => setJobId(result.job_id),
@@ -267,11 +329,38 @@ export function AnalysisPanel({
           <p className="text-xs text-muted-foreground">
             {t('analysisTools.dissolveHint', {
               defaultValue:
-                'Dissolve merges all features into one geometry; run it with Create dataset',
+                'Dissolve merges features into one geometry per group; run it with Create dataset',
             })}
           </p>
         )}
       </div>
+
+      {operation === 'dissolve' && (
+        <div className="space-y-1.5">
+          <Label className="text-xs" htmlFor="analysis-by-field">
+            {t('analysisTools.byFieldLabel', {
+              defaultValue: 'Group by field (optional)',
+            })}
+          </Label>
+          <Select value={byField} onValueChange={setByField}>
+            <SelectTrigger id="analysis-by-field" className="w-full">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value={BY_FIELD_NONE}>
+                {t('analysisTools.byFieldNone', {
+                  defaultValue: 'No grouping — merge everything',
+                })}
+              </SelectItem>
+              {byFieldColumns.map((name) => (
+                <SelectItem key={name} value={name}>
+                  {name}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+      )}
 
       {operation === 'buffer' && (
         <div className="space-y-1.5">
@@ -295,7 +384,9 @@ export function AnalysisPanel({
 
       {operation === 'clip' && (
         <div className="space-y-1.5">
-          <Label className="text-xs">
+          {/* Exactly one of the three buttons below renders at a time, so
+              they can share the id this label points at. */}
+          <Label className="text-xs" htmlFor="analysis-clip-action">
             {t('analysisTools.drawMask', { defaultValue: 'Draw clip area' })}
           </Label>
           {isDrawing ? (
@@ -305,7 +396,12 @@ export function AnalysisPanel({
                   defaultValue: 'Draw on the map — double-click to finish',
                 })}
               </p>
-              <Button variant="outline" size="sm" onClick={stopDrawing}>
+              <Button
+                id="analysis-clip-action"
+                variant="outline"
+                size="sm"
+                onClick={stopDrawing}
+              >
                 {t('analysisTools.cancelDrawing', { defaultValue: 'Cancel' })}
               </Button>
             </div>
@@ -314,12 +410,23 @@ export function AnalysisPanel({
               <span className="text-xs text-muted-foreground">
                 {t('analysisTools.maskSet', { defaultValue: 'Clip area set' })}
               </span>
-              <Button variant="ghost" size="sm" onClick={() => setMask(null)}>
+              <Button
+                id="analysis-clip-action"
+                variant="ghost"
+                size="sm"
+                onClick={() => {
+                  setMask(null);
+                  // Also removes the kept-visible drawn polygon (TerraDraw
+                  // owns its own map layers; stop() tears them down).
+                  stopDrawing();
+                }}
+              >
                 {t('analysisTools.clearMask', { defaultValue: 'Clear' })}
               </Button>
             </div>
           ) : (
             <Button
+              id="analysis-clip-action"
               variant="outline"
               size="sm"
               onClick={startDrawing}

--- a/frontend/src/components/builder/AnalysisPanel.tsx
+++ b/frontend/src/components/builder/AnalysisPanel.tsx
@@ -281,7 +281,16 @@ export function AnalysisPanel({
         <Label className="text-xs" htmlFor="analysis-layer">
           {t('analysisTools.layerLabel', { defaultValue: 'Layer' })}
         </Label>
-        <Select value={layerId} onValueChange={setLayerId}>
+        <Select
+          value={layerId}
+          onValueChange={(id) => {
+            setLayerId(id);
+            // fix(#680): a group-by column chosen for one dataset must not
+            // carry to another — it may not exist there (422 from the API) or
+            // silently group by a same-named field.
+            setByField(BY_FIELD_NONE);
+          }}
+        >
           <SelectTrigger id="analysis-layer" className="w-full">
             <SelectValue
               placeholder={t('analysisTools.layerPlaceholder', {
@@ -305,7 +314,17 @@ export function AnalysisPanel({
         </Label>
         <Select
           value={operation}
-          onValueChange={(v) => setOperation(v as AnalysisOperation)}
+          onValueChange={(v) => {
+            const next = v as AnalysisOperation;
+            if (next !== 'clip') {
+              // fix(#680): leaving clip mode must drop the retained mask —
+              // the static-mode TerraDraw layers otherwise stay visible on
+              // the map under operations that ignore them.
+              setMask(null);
+              stopDrawing();
+            }
+            setOperation(next);
+          }}
         >
           <SelectTrigger id="analysis-operation" className="w-full">
             <SelectValue />

--- a/frontend/src/components/builder/BuilderRail.tsx
+++ b/frontend/src/components/builder/BuilderRail.tsx
@@ -94,7 +94,11 @@ interface BuilderRailProps {
   mapId?: string;
   layers?: MapLayerResponse[];
   layerActions?: LayerActions;
-  onQueryResult?: (geojson: GeoJSON.FeatureCollection, bbox: [number, number, number, number]) => void;
+  onQueryResult?: (
+    geojson: GeoJSON.FeatureCollection,
+    bbox: [number, number, number, number],
+    meta?: { truncated?: boolean; totalCount?: number },
+  ) => void;
   // Analysis tools
   mapInstanceRef?: React.RefObject<MaplibreMap | null>;
   onClearPreview?: () => void;

--- a/frontend/src/components/builder/__tests__/AnalysisPanel.test.tsx
+++ b/frontend/src/components/builder/__tests__/AnalysisPanel.test.tsx
@@ -209,6 +209,33 @@ describe('AnalysisPanel', () => {
       }),
     );
   });
+
+  it('resets the dissolve group field when the source layer changes (fix(#680))', async () => {
+    const user = userEvent.setup();
+    renderPanel([datasetLayer, datasetLayer2]);
+
+    // Combobox order: layer, operation.
+    await user.click(screen.getAllByRole('combobox')[1]);
+    await user.click(await screen.findByRole('option', { name: 'Dissolve' }));
+    await user.click(screen.getAllByRole('combobox')[2]);
+    await user.click(await screen.findByRole('option', { name: 'name' }));
+
+    // Switching datasets must not carry the field along.
+    await user.click(screen.getAllByRole('combobox')[0]);
+    await user.click(await screen.findByRole('option', { name: 'Roads' }));
+
+    fireEvent.change(screen.getByLabelText('New dataset name'), {
+      target: { value: 'Dissolved roads' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Create dataset' }));
+
+    await waitFor(() =>
+      expect(materializeAnalysis).toHaveBeenCalledWith('ds2', {
+        operation: 'dissolve',
+        title: 'Dissolved roads',
+      }),
+    );
+  });
 });
 
 describe('AnalysisPanel — chat handoff prefill (#675)', () => {

--- a/frontend/src/components/builder/__tests__/AnalysisPanel.test.tsx
+++ b/frontend/src/components/builder/__tests__/AnalysisPanel.test.tsx
@@ -1,14 +1,22 @@
 import { fireEvent, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render } from '@/test/test-utils';
 import { AnalysisPanel } from '../AnalysisPanel';
-import { previewAnalysis } from '@/api/analysis';
+import { materializeAnalysis, previewAnalysis } from '@/api/analysis';
 import type { MapLayerResponse } from '@/types/api';
+
+// Radix Select needs pointer-capture APIs jsdom lacks (DataDrivenStyleEditor
+// precedent).
+Element.prototype.hasPointerCapture = vi.fn(() => false);
+Element.prototype.releasePointerCapture = vi.fn();
+Element.prototype.scrollIntoView = vi.fn();
 
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({
     t: (_key: string, options?: { defaultValue?: string }) =>
       options?.defaultValue ?? _key,
+    i18n: { language: 'en' },
   }),
 }));
 
@@ -28,6 +36,21 @@ vi.mock('@/api/analysis', () => ({
     truncated: false,
     bbox: [0, 0, 1, 1],
   }),
+  materializeAnalysis: vi
+    .fn()
+    .mockResolvedValue({ job_id: 'job1', status: 'pending' }),
+}));
+
+vi.mock('@/components/dataset/hooks/use-dataset', () => ({
+  useDataset: vi.fn(() => ({
+    data: {
+      column_info: [
+        { name: 'name', type: 'text' },
+        // Must be filtered out — collides with the generated output column.
+        { name: 'source_count', type: 'integer' },
+      ],
+    },
+  })),
 }));
 
 const datasetLayer = {
@@ -112,6 +135,79 @@ describe('AnalysisPanel', () => {
     const clearButton = screen.getByRole('button', { name: 'Clear preview' });
     fireEvent.click(clearButton);
     expect(onClearPreview).toHaveBeenCalled();
+  });
+
+  it('clears a stale overlay when the preview returns no features (#676 parity)', async () => {
+    vi.mocked(previewAnalysis).mockResolvedValueOnce({
+      geojson: { type: 'FeatureCollection', features: [] },
+      feature_count: 0,
+      truncated: false,
+      bbox: null,
+    });
+    const onPreviewResult = vi.fn();
+    const onClearPreview = vi.fn();
+    renderPanel([datasetLayer], { onPreviewResult, onClearPreview });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Preview' }));
+    await waitFor(() => expect(onClearPreview).toHaveBeenCalled());
+    expect(onPreviewResult).not.toHaveBeenCalled();
+  });
+
+  it('passes truncation and the source total through to the overlay', async () => {
+    vi.mocked(previewAnalysis).mockResolvedValueOnce({
+      geojson: {
+        type: 'FeatureCollection',
+        features: [
+          {
+            type: 'Feature',
+            geometry: { type: 'Point', coordinates: [0, 0] },
+            properties: { gid: 1 },
+          },
+        ],
+      },
+      feature_count: 500,
+      truncated: true,
+      bbox: [0, 0, 1, 1],
+      source_feature_count: 10651,
+    });
+    const onPreviewResult = vi.fn();
+    renderPanel([datasetLayer], { onPreviewResult });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Preview' }));
+    await waitFor(() =>
+      expect(onPreviewResult).toHaveBeenCalledWith(
+        expect.objectContaining({ type: 'FeatureCollection' }),
+        [0, 0, 1, 1],
+        { truncated: true, totalCount: 10651 },
+      ),
+    );
+  });
+
+  it('sends by_field when a dissolve group column is chosen', async () => {
+    const user = userEvent.setup();
+    renderPanel([datasetLayer]);
+
+    // Combobox order: layer, operation.
+    await user.click(screen.getAllByRole('combobox')[1]);
+    await user.click(await screen.findByRole('option', { name: 'Dissolve' }));
+
+    // The group-by select appears; source_count is filtered from the options.
+    await user.click(screen.getAllByRole('combobox')[2]);
+    expect(screen.queryByRole('option', { name: 'source_count' })).toBeNull();
+    await user.click(await screen.findByRole('option', { name: 'name' }));
+
+    fireEvent.change(screen.getByLabelText('New dataset name'), {
+      target: { value: 'Dissolved by name' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Create dataset' }));
+
+    await waitFor(() =>
+      expect(materializeAnalysis).toHaveBeenCalledWith('ds1', {
+        operation: 'dissolve',
+        title: 'Dissolved by name',
+        by_field: 'name',
+      }),
+    );
   });
 });
 

--- a/frontend/src/i18n/locales/de/builder.json
+++ b/frontend/src/i18n/locales/de/builder.json
@@ -950,7 +950,7 @@
     "previewFailed": "Analyse fehlgeschlagen",
     "noLayers": "Fügen Sie eine Datenebene hinzu, um Analysewerkzeuge zu nutzen",
     "opDissolve": "Auflösen",
-    "dissolveHint": "Auflösen führt alle Features zu einer Geometrie zusammen; über Datensatz erstellen ausführen",
+    "dissolveHint": "Auflösen führt Features zu einer Geometrie pro Gruppe zusammen; mit „Datensatz erstellen“ ausführen",
     "outputTitleLabel": "Name des neuen Datensatzes",
     "outputTitlePlaceholder": "z. B. Flurstücke 500 m Puffer",
     "saveButton": "Datensatz erstellen",
@@ -958,7 +958,10 @@
     "jobRunning": "Datensatz wird erstellt…",
     "jobComplete": "Datensatz erstellt",
     "jobFailed": "Analyseauftrag fehlgeschlagen",
-    "addToMap": "Zur Karte hinzufügen"
+    "addToMap": "Zur Karte hinzufügen",
+    "byFieldLabel": "Nach Feld gruppieren (optional)",
+    "byFieldNone": "Keine Gruppierung — alles zusammenführen",
+    "truncatedNoticeTotal": "Die ersten {{count}} von {{total}} Features werden angezeigt"
   },
   "attributeForm": {
     "titleEdit": "Feature-Attribute bearbeiten",

--- a/frontend/src/i18n/locales/en/builder.json
+++ b/frontend/src/i18n/locales/en/builder.json
@@ -950,7 +950,7 @@
     "previewFailed": "Analysis failed",
     "noLayers": "Add a dataset layer to use analysis tools",
     "opDissolve": "Dissolve",
-    "dissolveHint": "Dissolve merges all features into one geometry; run it with Create dataset",
+    "dissolveHint": "Dissolve merges features into one geometry per group; run it with Create dataset",
     "outputTitleLabel": "New dataset name",
     "outputTitlePlaceholder": "e.g. Parcels buffered 500 m",
     "saveButton": "Create dataset",
@@ -958,7 +958,10 @@
     "jobRunning": "Creating dataset…",
     "jobComplete": "Dataset created",
     "jobFailed": "Analysis job failed",
-    "addToMap": "Add to map"
+    "addToMap": "Add to map",
+    "byFieldLabel": "Group by field (optional)",
+    "byFieldNone": "No grouping — merge everything",
+    "truncatedNoticeTotal": "Showing the first {{count}} of {{total}} features"
   },
   "attributeForm": {
     "titleEdit": "Edit Feature Attributes",

--- a/frontend/src/i18n/locales/es/builder.json
+++ b/frontend/src/i18n/locales/es/builder.json
@@ -950,7 +950,7 @@
     "previewFailed": "Error en el análisis",
     "noLayers": "Añade una capa de datos para usar las herramientas de análisis",
     "opDissolve": "Disolver",
-    "dissolveHint": "Disolver combina todas las entidades en una sola geometría; ejecútalo con Crear conjunto de datos",
+    "dissolveHint": "Disolver combina las entidades en una geometría por grupo; ejecútalo con Crear conjunto de datos",
     "outputTitleLabel": "Nombre del nuevo conjunto de datos",
     "outputTitlePlaceholder": "p. ej. Parcelas con zona de 500 m",
     "saveButton": "Crear conjunto de datos",
@@ -958,7 +958,10 @@
     "jobRunning": "Creando conjunto de datos…",
     "jobComplete": "Conjunto de datos creado",
     "jobFailed": "El trabajo de análisis falló",
-    "addToMap": "Añadir al mapa"
+    "addToMap": "Añadir al mapa",
+    "byFieldLabel": "Agrupar por campo (opcional)",
+    "byFieldNone": "Sin agrupación — combinar todo",
+    "truncatedNoticeTotal": "Mostrando las primeras {{count}} de {{total}} entidades"
   },
   "attributeForm": {
     "titleEdit": "Editar atributos de la entidad",

--- a/frontend/src/i18n/locales/fr/builder.json
+++ b/frontend/src/i18n/locales/fr/builder.json
@@ -950,7 +950,7 @@
     "previewFailed": "Échec de l'analyse",
     "noLayers": "Ajoutez une couche de données pour utiliser les outils d'analyse",
     "opDissolve": "Dissoudre",
-    "dissolveHint": "Dissoudre fusionne toutes les entités en une seule géométrie ; exécutez-le avec Créer un jeu de données",
+    "dissolveHint": "Dissoudre fusionne les entités en une géométrie par groupe ; exécutez-le avec Créer un jeu de données",
     "outputTitleLabel": "Nom du nouveau jeu de données",
     "outputTitlePlaceholder": "p. ex. Parcelles tampon 500 m",
     "saveButton": "Créer un jeu de données",
@@ -958,7 +958,10 @@
     "jobRunning": "Création du jeu de données…",
     "jobComplete": "Jeu de données créé",
     "jobFailed": "La tâche d'analyse a échoué",
-    "addToMap": "Ajouter à la carte"
+    "addToMap": "Ajouter à la carte",
+    "byFieldLabel": "Regrouper par champ (optionnel)",
+    "byFieldNone": "Sans regroupement — tout fusionner",
+    "truncatedNoticeTotal": "Affichage des {{count}} premières entités sur {{total}}"
   },
   "attributeForm": {
     "titleEdit": "Modifier les attributs de l'entité",

--- a/frontend/src/types/api.generated.ts
+++ b/frontend/src/types/api.generated.ts
@@ -5469,6 +5469,11 @@ export interface components {
             geojson: {
                 [key: string]: unknown;
             };
+            /**
+             * Source Feature Count
+             * @description Total feature count of the source dataset (1:1 operations only; null when the operation filters rows, e.g. clip)
+             */
+            source_feature_count?: number | null;
             /** Truncated */
             truncated: boolean;
         };

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -1872,6 +1872,8 @@ export interface AnalysisPreviewResponse {
   feature_count: number;
   truncated: boolean;
   bbox: number[] | null;
+  /** Source dataset total (1:1 ops only; null when the op filters rows, e.g. clip). */
+  source_feature_count?: number | null;
 }
 
 export interface AnalysisMaterializeRequest {

--- a/sdks/python/geolens/models/analysis_preview_response.py
+++ b/sdks/python/geolens/models/analysis_preview_response.py
@@ -28,12 +28,15 @@ class AnalysisPreviewResponse:
         geojson (AnalysisPreviewResponseGeojson):
         truncated (bool):
         bbox (list[float] | None | Unset):
+        source_feature_count (int | None | Unset): Total feature count of the source dataset (1:1 operations only; null
+            when the operation filters rows, e.g. clip)
     """
 
     feature_count: int
     geojson: AnalysisPreviewResponseGeojson
     truncated: bool
     bbox: list[float] | None | Unset = UNSET
+    source_feature_count: int | None | Unset = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
@@ -52,6 +55,12 @@ class AnalysisPreviewResponse:
         else:
             bbox = self.bbox
 
+        source_feature_count: int | None | Unset
+        if isinstance(self.source_feature_count, Unset):
+            source_feature_count = UNSET
+        else:
+            source_feature_count = self.source_feature_count
+
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
@@ -63,6 +72,8 @@ class AnalysisPreviewResponse:
         )
         if bbox is not UNSET:
             field_dict["bbox"] = bbox
+        if source_feature_count is not UNSET:
+            field_dict["source_feature_count"] = source_feature_count
 
         return field_dict
 
@@ -96,11 +107,23 @@ class AnalysisPreviewResponse:
 
         bbox = _parse_bbox(d.pop("bbox", UNSET))
 
+        def _parse_source_feature_count(data: object) -> int | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(int | None | Unset, data)
+
+        source_feature_count = _parse_source_feature_count(
+            d.pop("source_feature_count", UNSET)
+        )
+
         analysis_preview_response = cls(
             feature_count=feature_count,
             geojson=geojson,
             truncated=truncated,
             bbox=bbox,
+            source_feature_count=source_feature_count,
         )
 
         analysis_preview_response.additional_properties = d

--- a/sdks/typescript/src/client/types.gen.ts
+++ b/sdks/typescript/src/client/types.gen.ts
@@ -598,6 +598,12 @@ export type AnalysisPreviewResponse = {
         [key: string]: unknown;
     };
     /**
+     * Source Feature Count
+     *
+     * Total feature count of the source dataset (1:1 operations only; null when the operation filters rows, e.g. clip)
+     */
+    source_feature_count?: number | null;
+    /**
      * Truncated
      */
     truncated: boolean;


### PR DESCRIPTION
## Summary

Follow-up to the M4 analysis work (#671/#674/#679). A four-track audit of the shipped feature (backend correctness verified live against the dev stack, frontend parity, test coverage, market baseline) surfaced a batch of real defects; this PR fixes the correctness and parity classes and closes the highest-risk test gaps.

### Backend correctness (each was reproduced live before fixing)

- **NaN/Infinity clip masks returned HTTP 500** on both endpoints — `shapely.make_valid` sat outside the validation try/except and raised `GEOSException`. Now 422, with finite-bounds and empty-mask checks added (an empty ring was previously a silent "matched nothing" 200).
- **One invalid source ring aborted every clip/dissolve** for its dataset (GEOS TopologyException surfacing as a 500, no user-side workaround). Source geometries are now wrapped in `ST_MakeValid`; the clip WHERE keeps a bare `&&` term so the GIST index stays usable.
- **Boundary-grazing clips emitted LineStrings into polygon outputs** (one-arg `ST_CollectionExtract` returns the highest-dimension result), producing mixed-geometry datasets whose declared `geometry_type` depended on row order. Clip now extracts components matching the source dimension; grazing rows become empty and are dropped (preview skip + worker DELETE).
- **Mixed-type dissolve produced a GEOMETRYCOLLECTION**, which registers cleanly but can't render through the MVT path. The union now extracts the highest-dimension components → typed `MULTI*`.
- **Materialize CTAS was unbounded** (`statement_timeout = 0`) — now capped at 300s.
- **A lost table-name race destroyed the winner's table**: `generate_table_name` collides only against the catalog, and failure cleanup dropped `out_table` unconditionally. Cleanup now only drops a table this job actually created.
- **Empty results registered junk datasets** (a clip matching nothing; dissolving an empty dataset registered one NULL-geometry row). The job now fails with "Analysis produced no features to save".
- **Stray `distance_meters` on non-buffer ops 422'd valid HTTP requests** (the #674 chat fix never reached the schemas — SDK/CLI callers trip it). Both request models strip it before field validation.
- `by_field="source_count"` now rejected up front instead of failing the CTAS with `column specified more than once`.
- Sandbox `query_failed` maps to 422 on the analysis router (server-built SQL → failures are data-driven).
- `MAX_BUFFER_METERS` was a dead constant; the SQL layer now enforces it, so worker payloads don't rely solely on schema bounds.
- `AnalysisPreviewResponse.source_feature_count` (additive): the source total for 1:1 ops, so clients can disclose "500 of N". The chat handler now reuses it instead of computing its own.

### Frontend — panel parity with its chat sibling

The Analysis panel's own preview path was missing both fixes chat got in #674/#679:

- Empty preview now **clears the stale overlay** (the #676 class) instead of leaving the previous result under a "no features" toast.
- **Truncation + source total reach EphemeralBadge** and the toast ("Showing the first 500 of 10,651"); the badge props existed since #674 but this path never passed them, and the API had no total field to pass.
- Materialize completion **invalidates dataset/search queries** (fix(#438) precedent) so the new dataset shows up in Add-data immediately.
- **Dissolve `by_field` gets a UI** — API/SDK/worker supported grouped dissolve; no client could reach it.
- **Drawn clip masks stay visible** (TerraDraw static mode) until cleared — previously the polygon was removed on finish and users never saw what would be clipped.
- Chat handoff **suggests an output title**, so "Save as dataset…" no longer lands on a silently-disabled Create button.
- Clip section label is programmatically associated with its action button; new strings added to all four locales.

### Tests

16 new backend tests + 3 new panel tests, targeting the audit's top-risk gaps: the **result-dataset private+owned invariant** (was asserted nowhere — a regression exposing analysis outputs would have passed the suite), first-ever **clip materialize** end-to-end, **grouped dissolve** (the only user-supplied identifier in SQL), the name-collision cleanup guard, NaN/empty/self-intersecting masks, grazing clip, invalid-source repair, stray-distance on both endpoints, and SQL-layer bounds.

## Impact

- **API**: one additive response field (`source_feature_count`) — `openapi.json`, both SDKs, and `api.generated.ts` regenerated. No breaking changes.
- **Schema/DB**: none (no migrations).
- **Behavioral**: previously-500 requests now 422; previously-"successful" junk materializations now fail loudly.

## Verification

- `backend`: analysis suites + layering + processing-port conformance — 98 passed; `ruff check` / `format --check` clean; live curl checks against the dev stack (NaN mask → 422, centroid+stray distance → 200, buffer carries `source_feature_count`).
- `frontend`: `npm run typecheck`, `npm run lint`, full `vitest` (3749 passed), `npm run test:i18n` (4 locales in parity).
- `make openapi-check` clean; `sdks-check` diff is exactly the regenerated additive field.

Known items deliberately **not** in this PR: per-user materialize concurrency limit (timeout ships now), panel job-abandonment UX, e2e coverage, and the read-grant→private-clone policy question flagged to the repo owner.

https://claude.ai/code/session_01X1Wd3Frww9F2eovfMkUbG2