### PR TITLE
feat(analysis): clip to another layer via mask_dataset_id

### DIFF
--- a/backend/app/modules/catalog/datasets/api/router_analysis.py
+++ b/backend/app/modules/catalog/datasets/api/router_analysis.py
@@ -67,6 +67,24 @@ async def _load_vector_dataset(db: AsyncSession, dataset_id: uuid.UUID, user: Id
     return dataset
 
 
+_POLYGONAL_TYPES = {"POLYGON", "MULTIPOLYGON"}
+
+
+async def _load_mask_dataset(
+    db: AsyncSession, mask_dataset_id: uuid.UUID, user: Identity
+):
+    """Fetch + visibility-check a clip-mask dataset (Rule 1 applies to BOTH
+    datasets of a two-layer operation) and require it to be polygonal —
+    unioning points/lines produces a mask that clips nothing meaningful."""
+    dataset = await _load_vector_dataset(db, mask_dataset_id, user)
+    if (dataset.geometry_type or "").upper() not in _POLYGONAL_TYPES:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail="mask_dataset_id must reference a polygon dataset",
+        )
+    return dataset
+
+
 @router.post("/{dataset_id}/analysis/preview/", response_model=AnalysisPreviewResponse)
 async def analysis_preview_endpoint(
     dataset_id: uuid.UUID,
@@ -80,8 +98,15 @@ async def analysis_preview_endpoint(
     persistence — use the materialize endpoint to save output as a dataset.
     """
     dataset = await _load_vector_dataset(db, dataset_id, user)
+    mask_dataset = (
+        await _load_mask_dataset(db, body.mask_dataset_id, user)
+        if body.mask_dataset_id is not None
+        else None
+    )
     try:
-        return await run_analysis_preview(db, dataset, body, user.id)
+        return await run_analysis_preview(
+            db, dataset, body, user.id, mask_dataset=mask_dataset
+        )
     except ValueError as exc:
         raise HTTPException(
             status_code=status.HTTP_422_UNPROCESSABLE_CONTENT, detail=str(exc)
@@ -116,7 +141,11 @@ async def analysis_materialize_endpoint(
     dataset = await _load_vector_dataset(db, dataset_id, user)
 
     # Fail fast on invalid params before creating a job.
-    if body.operation == "clip":
+    if body.operation == "clip" and body.mask_dataset_id is not None:
+        # Access + polygon checks happen here at enqueue time; the worker
+        # re-resolves the table name and re-validates it against _SAFE_TABLE.
+        await _load_mask_dataset(db, body.mask_dataset_id, user)
+    elif body.operation == "clip":
         try:
             render_mask_expr(body.mask or {})
         except ValueError as exc:
@@ -149,6 +178,23 @@ async def analysis_materialize_endpoint(
     job = await get_catalog_port().create_ingest_job(
         db, f"analysis-{body.operation}", "", user.id
     )
+    # Record the request params so Admin → Jobs can diagnose a failed run
+    # ("analysis-buffer failed" alone says nothing). The drawn mask geometry
+    # is deliberately NOT stored — it can be kilobytes; a marker suffices.
+    analysis_meta = {
+        "operation": body.operation,
+        "source_dataset_id": str(dataset.id),
+        "title": body.title,
+    }
+    if body.distance_meters is not None:
+        analysis_meta["distance_meters"] = body.distance_meters
+    if body.by_field is not None:
+        analysis_meta["by_field"] = body.by_field
+    if body.operation == "clip":
+        analysis_meta["mask_source"] = "layer" if body.mask_dataset_id else "drawn"
+        if body.mask_dataset_id is not None:
+            analysis_meta["mask_dataset_id"] = str(body.mask_dataset_id)
+    job.user_metadata = {"analysis": analysis_meta}
     await db.commit()
 
     rollback = make_ingest_job_failed_rollback(
@@ -156,6 +202,15 @@ async def analysis_materialize_endpoint(
     )
 
     async def _defer() -> None:
+        # mask_dataset_id rides along only when set: a worker still running
+        # the pre-clip-by-layer code rejects unknown kwargs, and an
+        # unconditional None would break EVERY materialize during a rolling
+        # deploy instead of only the new feature.
+        extra_kwargs = (
+            {"mask_dataset_id": str(body.mask_dataset_id)}
+            if body.mask_dataset_id is not None
+            else {}
+        )
         await defer_async_with_tenant(
             get_catalog_port().materialize_analysis_task(),
             job_id=str(job.id),
@@ -166,6 +221,7 @@ async def analysis_materialize_endpoint(
             distance_meters=body.distance_meters,
             mask=body.mask,
             by_field=body.by_field,
+            **extra_kwargs,
         )
 
     await defer_with_orphan_guard(_defer, rollback=rollback, db=db)

--- a/backend/app/modules/catalog/datasets/api/router_analysis.py
+++ b/backend/app/modules/catalog/datasets/api/router_analysis.py
@@ -4,6 +4,7 @@ import re
 import uuid
 
 from fastapi import APIRouter, Depends, HTTPException, Request, status
+from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.db.tenant_session import defer_async_with_tenant
@@ -28,6 +29,7 @@ from app.platform.jobs.defer_guard import (
     defer_with_orphan_guard,
     make_ingest_job_failed_rollback,
 )
+from app.platform.jobs.models import IngestJob
 from app.platform.sandbox.schemas import SandboxError
 from app.standards.ogc.errors import ERROR_RESPONSES_WRITE
 
@@ -174,6 +176,26 @@ async def analysis_materialize_endpoint(
     # Best-effort dataset-count pre-check; the authoritative atomic
     # reservation happens at registration time in the worker.
     await check_upload_quota(db, user.id, 0, request)
+
+    # One materialize at a time per user: each queued job is an unbounded-ish
+    # CTAS (bounded only by the 300s statement timeout), so without a cap one
+    # user can stack N of them. ponytail: soft cap — a TOCTOU race can briefly
+    # admit two; add a DB-side partial unique index if operators need a hard
+    # guarantee.
+    active = await db.scalar(
+        select(func.count())
+        .select_from(IngestJob)
+        .where(
+            IngestJob.created_by == user.id,
+            IngestJob.source_filename.like("analysis-%"),
+            IngestJob.status.in_(("pending", "running")),
+        )
+    )
+    if active:
+        raise HTTPException(
+            status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+            detail="An analysis job is already running; wait for it to finish",
+        )
 
     job = await get_catalog_port().create_ingest_job(
         db, f"analysis-{body.operation}", "", user.id

--- a/backend/app/modules/catalog/datasets/api/router_analysis.py
+++ b/backend/app/modules/catalog/datasets/api/router_analysis.py
@@ -72,14 +72,15 @@ async def _load_vector_dataset(db: AsyncSession, dataset_id: uuid.UUID, user: Id
 
 _POLYGONAL_TYPES = {"POLYGON", "MULTIPOLYGON"}
 
-# Staleness bound for a *running* analysis job. Materialize tasks do not renew
-# a heartbeat lease (that is opt-in per task — see maintain_ingest_job_heartbeat,
-# which only the ingest tasks use), so there is no liveness signal to read here.
-# Age is a sound proxy in this one case because the work is self-limiting: the
-# CTAS carries a 300s statement timeout, so a live job physically cannot still
-# be working past this window — anything older is a worker that died mid-job.
-# Without the bound, such a zombie would hold the user's slot until the
-# platform reaper sweeps it an HOUR later.
+# Staleness bound for a *running* analysis job, measured from when it actually
+# STARTED (fix(#682 review)): a job can sit queued arbitrarily long behind a
+# backlog, so enqueue time would exclude a CTAS the moment it finally began.
+# Materialize tasks do not renew a heartbeat lease (that is opt-in per task —
+# see maintain_ingest_job_heartbeat, which only the ingest tasks use), so
+# elapsed run time is the liveness signal available here. It is a sound one
+# because the work is self-limiting: the CTAS carries a 300s statement timeout,
+# so a live job cannot still be working past this window — anything older is a
+# worker that died mid-job, holding the user's slot.
 #
 # Deliberately NOT applied to pending jobs: those are queued work that will
 # still run, and a backlogged queue must not be able to let a second CTAS
@@ -215,7 +216,9 @@ async def analysis_materialize_endpoint(
                 IngestJob.status == "pending",
                 and_(
                     IngestJob.status == "running",
-                    IngestJob.created_at
+                    # created_at is the fallback for rows written before the
+                    # worker started stamping started_at.
+                    func.coalesce(IngestJob.started_at, IngestJob.created_at)
                     >= datetime.now(timezone.utc) - _RUNNING_JOB_WINDOW,
                 ),
             ),

--- a/backend/app/modules/catalog/datasets/api/router_analysis.py
+++ b/backend/app/modules/catalog/datasets/api/router_analysis.py
@@ -2,6 +2,7 @@
 
 import re
 import uuid
+from datetime import datetime, timedelta, timezone
 
 from fastapi import APIRouter, Depends, HTTPException, Request, status
 from sqlalchemy import func, select
@@ -70,6 +71,14 @@ async def _load_vector_dataset(db: AsyncSession, dataset_id: uuid.UUID, user: Id
 
 
 _POLYGONAL_TYPES = {"POLYGON", "MULTIPOLYGON"}
+
+# How far back the per-user active-job check looks. The materialize CTAS is
+# capped by its own 300s statement timeout, so anything older than this is a
+# zombie (worker died mid-job, or the job was never picked up) — and the
+# platform-wide stale-job reaper only sweeps those after an hour. Without this
+# window a single crashed worker would lock a user out of analysis for that
+# whole hour.
+_ACTIVE_JOB_WINDOW = timedelta(minutes=10)
 
 
 async def _load_mask_dataset(
@@ -189,6 +198,7 @@ async def analysis_materialize_endpoint(
             IngestJob.created_by == user.id,
             IngestJob.source_filename.like("analysis-%"),
             IngestJob.status.in_(("pending", "running")),
+            IngestJob.created_at >= datetime.now(timezone.utc) - _ACTIVE_JOB_WINDOW,
         )
     )
     if active:

--- a/backend/app/modules/catalog/datasets/api/router_analysis.py
+++ b/backend/app/modules/catalog/datasets/api/router_analysis.py
@@ -5,7 +5,7 @@ import uuid
 from datetime import datetime, timedelta, timezone
 
 from fastapi import APIRouter, Depends, HTTPException, Request, status
-from sqlalchemy import func, select
+from sqlalchemy import and_, func, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.db.tenant_session import defer_async_with_tenant
@@ -72,13 +72,22 @@ async def _load_vector_dataset(db: AsyncSession, dataset_id: uuid.UUID, user: Id
 
 _POLYGONAL_TYPES = {"POLYGON", "MULTIPOLYGON"}
 
-# How far back the per-user active-job check looks. The materialize CTAS is
-# capped by its own 300s statement timeout, so anything older than this is a
-# zombie (worker died mid-job, or the job was never picked up) — and the
-# platform-wide stale-job reaper only sweeps those after an hour. Without this
-# window a single crashed worker would lock a user out of analysis for that
-# whole hour.
-_ACTIVE_JOB_WINDOW = timedelta(minutes=10)
+# Staleness bound for a *running* analysis job. Materialize tasks do not renew
+# a heartbeat lease (that is opt-in per task — see maintain_ingest_job_heartbeat,
+# which only the ingest tasks use), so there is no liveness signal to read here.
+# Age is a sound proxy in this one case because the work is self-limiting: the
+# CTAS carries a 300s statement timeout, so a live job physically cannot still
+# be working past this window — anything older is a worker that died mid-job.
+# Without the bound, such a zombie would hold the user's slot until the
+# platform reaper sweeps it an HOUR later.
+#
+# Deliberately NOT applied to pending jobs: those are queued work that will
+# still run, and a backlogged queue must not be able to let a second CTAS
+# through (fix(#682 review)). Orphaned pending jobs are already handled —
+# defer_with_orphan_guard fails them when the enqueue itself fails, and the
+# platform sweeps the rest. Upgrade path: call maintain_ingest_job_heartbeat
+# from the materialize task and switch this to a real liveness check.
+_RUNNING_JOB_WINDOW = timedelta(minutes=10)
 
 
 async def _load_mask_dataset(
@@ -202,8 +211,14 @@ async def analysis_materialize_endpoint(
             # uploader out of analysis. The metadata below is written in the
             # same transaction as the job row, so this never misses one.
             IngestJob.user_metadata.has_key("analysis"),
-            IngestJob.status.in_(("pending", "running")),
-            IngestJob.created_at >= datetime.now(timezone.utc) - _ACTIVE_JOB_WINDOW,
+            or_(
+                IngestJob.status == "pending",
+                and_(
+                    IngestJob.status == "running",
+                    IngestJob.created_at
+                    >= datetime.now(timezone.utc) - _RUNNING_JOB_WINDOW,
+                ),
+            ),
         )
     )
     if active:

--- a/backend/app/modules/catalog/datasets/api/router_analysis.py
+++ b/backend/app/modules/catalog/datasets/api/router_analysis.py
@@ -2,10 +2,9 @@
 
 import re
 import uuid
-from datetime import datetime, timedelta, timezone
 
 from fastapi import APIRouter, Depends, HTTPException, Request, status
-from sqlalchemy import and_, func, or_, select
+from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.db.tenant_session import defer_async_with_tenant
@@ -71,24 +70,6 @@ async def _load_vector_dataset(db: AsyncSession, dataset_id: uuid.UUID, user: Id
 
 
 _POLYGONAL_TYPES = {"POLYGON", "MULTIPOLYGON"}
-
-# Staleness bound for a *running* analysis job, measured from when it actually
-# STARTED (fix(#682 review)): a job can sit queued arbitrarily long behind a
-# backlog, so enqueue time would exclude a CTAS the moment it finally began.
-# Materialize tasks do not renew a heartbeat lease (that is opt-in per task —
-# see maintain_ingest_job_heartbeat, which only the ingest tasks use), so
-# elapsed run time is the liveness signal available here. It is a sound one
-# because the work is self-limiting: the CTAS carries a 300s statement timeout,
-# so a live job cannot still be working past this window — anything older is a
-# worker that died mid-job, holding the user's slot.
-#
-# Deliberately NOT applied to pending jobs: those are queued work that will
-# still run, and a backlogged queue must not be able to let a second CTAS
-# through (fix(#682 review)). Orphaned pending jobs are already handled —
-# defer_with_orphan_guard fails them when the enqueue itself fails, and the
-# platform sweeps the rest. Upgrade path: call maintain_ingest_job_heartbeat
-# from the materialize task and switch this to a real liveness check.
-_RUNNING_JOB_WINDOW = timedelta(minutes=10)
 
 
 async def _load_mask_dataset(
@@ -197,10 +178,24 @@ async def analysis_materialize_endpoint(
     await check_upload_quota(db, user.id, 0, request)
 
     # One materialize at a time per user: each queued job is an unbounded-ish
-    # CTAS (bounded only by the 300s statement timeout), so without a cap one
-    # user can stack N of them. ponytail: soft cap — a TOCTOU race can briefly
-    # admit two; add a DB-side partial unique index if operators need a hard
-    # guarantee.
+    # CTAS, so without a cap one user can stack N of them. ponytail: soft cap —
+    # a TOCTOU race can briefly admit two; add a DB-side partial unique index if
+    # operators need a hard guarantee.
+    #
+    # Any pending-or-running job blocks, with NO staleness window (fix(#682
+    # review)). A window looks appealing — it would stop a worker that died
+    # mid-job from holding the slot — but there is no liveness signal here to
+    # base one on, and elapsed time is not a substitute: the 300s
+    # statement_timeout bounds each STATEMENT, while the task runs a CTAS, a
+    # DELETE, an EXISTS probe, two ALTERs, a primary key, add_4326_column and
+    # registration in sequence. A legitimate materialize over a large dataset
+    # can outlive any window short enough to be useful, and releasing the slot
+    # then lets a second expensive CTAS through — defeating the cap outright.
+    # The cost of not having one is bounded and visible: a dead worker holds
+    # the slot until the platform's job timeout fails the row (started_at is
+    # stamped, so that path works), and the client applies this same rule, so
+    # the UI never disagrees with the API about whether a job is active.
+    # Proper fix is a heartbeat lease (issue #691), as the ingest tasks use.
     active = await db.scalar(
         select(func.count())
         .select_from(IngestJob)
@@ -212,16 +207,7 @@ async def analysis_materialize_endpoint(
             # uploader out of analysis. The metadata below is written in the
             # same transaction as the job row, so this never misses one.
             IngestJob.user_metadata.has_key("analysis"),
-            or_(
-                IngestJob.status == "pending",
-                and_(
-                    IngestJob.status == "running",
-                    # created_at is the fallback for rows written before the
-                    # worker started stamping started_at.
-                    func.coalesce(IngestJob.started_at, IngestJob.created_at)
-                    >= datetime.now(timezone.utc) - _RUNNING_JOB_WINDOW,
-                ),
-            ),
+            IngestJob.status.in_(("pending", "running")),
         )
     )
     if active:

--- a/backend/app/modules/catalog/datasets/api/router_analysis.py
+++ b/backend/app/modules/catalog/datasets/api/router_analysis.py
@@ -196,7 +196,12 @@ async def analysis_materialize_endpoint(
         .select_from(IngestJob)
         .where(
             IngestJob.created_by == user.id,
-            IngestJob.source_filename.like("analysis-%"),
+            # fix(#682 review): the analysis marker in user_metadata, NOT
+            # source_filename — uploads copy the user's own filename into that
+            # column, so an upload named "analysis-data.geojson" would lock the
+            # uploader out of analysis. The metadata below is written in the
+            # same transaction as the job row, so this never misses one.
+            IngestJob.user_metadata.has_key("analysis"),
             IngestJob.status.in_(("pending", "running")),
             IngestJob.created_at >= datetime.now(timezone.utc) - _ACTIVE_JOB_WINDOW,
         )

--- a/backend/app/modules/catalog/datasets/domain/schemas.py
+++ b/backend/app/modules/catalog/datasets/domain/schemas.py
@@ -855,6 +855,27 @@ class IngestionResult(BaseModel):
 # Analysis (M4) — parameterized PostGIS operations
 # ---------------------------------------------------------------------------
 
+# Operation-scoped request fields → the only operation that reads them.
+# Documented as "<op> only; ignored otherwise", and actually dropped by the
+# request validators (fix(#682): a stray mask_dataset_id sent alongside
+# buffer/centroid would otherwise be loaded — and could 404/422 the request
+# or fail the job — and distance's gt/le bounds fire on placeholder values).
+_ANALYSIS_PARAM_OWNERS = {
+    "distance_meters": "buffer",
+    "mask": "clip",
+    "mask_dataset_id": "clip",
+    "by_field": "dissolve",
+}
+
+
+def _drop_params_for_other_operations(data: Any) -> Any:
+    if isinstance(data, dict):
+        op = data.get("operation")
+        data = {
+            k: v for k, v in data.items() if _ANALYSIS_PARAM_OWNERS.get(k, op) == op
+        }
+    return data
+
 
 class AnalysisPreviewRequest(BaseModel):
     """Parameters for a synchronous analysis preview.
@@ -876,23 +897,27 @@ class AnalysisPreviewRequest(BaseModel):
             "GeoJSON Polygon or MultiPolygon geometry in EPSG:4326 (clip only)"
         ),
     )
+    mask_dataset_id: uuid.UUID | None = Field(
+        default=None,
+        description=(
+            "Polygon dataset whose unioned features form the clip mask "
+            "(clip only; alternative to mask)"
+        ),
+    )
 
     @model_validator(mode="before")
     @classmethod
-    def _drop_ignored_distance(cls, data: Any) -> Any:
-        # distance_meters is documented as "buffer only; ignored otherwise" —
-        # actually ignore it, or the optional field's gt/le bounds fire on
-        # placeholder values SDK/CLI callers send alongside centroid/clip.
-        if isinstance(data, dict) and data.get("operation") != "buffer":
-            data = {k: v for k, v in data.items() if k != "distance_meters"}
-        return data
+    def _drop_ignored_params(cls, data: Any) -> Any:
+        return _drop_params_for_other_operations(data)
 
     @model_validator(mode="after")
     def _require_operation_params(self) -> "AnalysisPreviewRequest":
         if self.operation == "buffer" and self.distance_meters is None:
             raise ValueError("buffer requires distance_meters")
-        if self.operation == "clip" and self.mask is None:
-            raise ValueError("clip requires mask")
+        if self.operation == "clip" and (self.mask is None) == (
+            self.mask_dataset_id is None
+        ):
+            raise ValueError("clip requires exactly one of mask or mask_dataset_id")
         return self
 
 
@@ -929,6 +954,13 @@ class AnalysisMaterializeRequest(BaseModel):
             "GeoJSON Polygon or MultiPolygon geometry in EPSG:4326 (clip only)"
         ),
     )
+    mask_dataset_id: uuid.UUID | None = Field(
+        default=None,
+        description=(
+            "Polygon dataset whose unioned features form the clip mask "
+            "(clip only; alternative to mask)"
+        ),
+    )
     by_field: str | None = Field(
         default=None,
         max_length=63,
@@ -937,18 +969,17 @@ class AnalysisMaterializeRequest(BaseModel):
 
     @model_validator(mode="before")
     @classmethod
-    def _drop_ignored_distance(cls, data: Any) -> Any:
-        # Same contract as AnalysisPreviewRequest: distance is buffer-only.
-        if isinstance(data, dict) and data.get("operation") != "buffer":
-            data = {k: v for k, v in data.items() if k != "distance_meters"}
-        return data
+    def _drop_ignored_params(cls, data: Any) -> Any:
+        return _drop_params_for_other_operations(data)
 
     @model_validator(mode="after")
     def _require_operation_params(self) -> "AnalysisMaterializeRequest":
         if self.operation == "buffer" and self.distance_meters is None:
             raise ValueError("buffer requires distance_meters")
-        if self.operation == "clip" and self.mask is None:
-            raise ValueError("clip requires mask")
+        if self.operation == "clip" and (self.mask is None) == (
+            self.mask_dataset_id is None
+        ):
+            raise ValueError("clip requires exactly one of mask or mask_dataset_id")
         return self
 
 

--- a/backend/app/modules/catalog/datasets/domain/service_analysis.py
+++ b/backend/app/modules/catalog/datasets/domain/service_analysis.py
@@ -27,31 +27,38 @@ from app.modules.catalog.datasets.domain.schemas import (
     AnalysisPreviewRequest,
     AnalysisPreviewResponse,
 )
-from app.platform.analysis_sql import render_geometry_expr
+from app.platform.analysis_sql import render_geometry_expr, render_mask_cte
 from app.platform.sandbox.executor import execute_safe
 
 PREVIEW_FEATURE_CAP = 500
 _GEOJSON_PRECISION = 6
 
 
-def build_preview_sql(table_ref: str, request: AnalysisPreviewRequest) -> str:
+def build_preview_sql(
+    table_ref: str,
+    request: AnalysisPreviewRequest,
+    mask_table_ref: str | None = None,
+) -> str:
     """Render the preview SELECT for one operation. Pure; unit-testable.
 
-    ``table_ref`` must come from ``_safe_table_ref`` (logical ``data`` schema;
-    the sandbox executor rewrites it to the tenant schema in multi-tenant).
+    ``table_ref`` (and ``mask_table_ref`` for layer-sourced clip masks) must
+    come from ``_safe_table_ref`` (logical ``data`` schema; the sandbox
+    executor rewrites it to the tenant schema in multi-tenant).
     """
     expr, where = render_geometry_expr(
         request.operation,
         distance_meters=request.distance_meters,
         mask=request.mask,
+        layer_mask=mask_table_ref is not None,
     )
+    cte = f"{render_mask_cte(mask_table_ref)} " if mask_table_ref else ""
     # fix(#680 review): drop NULL/EMPTY results in SQL, not in Python — the
     # sandbox applies its row cap to raw rows, so boundary-grazing clips
     # (which pass ST_Intersects but extract to EMPTY) could consume the whole
     # preview budget along a shared boundary and hide real intersections with
     # higher gids, even reporting a false "no features".
     return (
-        f"SELECT gid, ST_AsGeoJSON(geom_out, {_GEOJSON_PRECISION}) AS geometry_json"
+        f"{cte}SELECT gid, ST_AsGeoJSON(geom_out, {_GEOJSON_PRECISION}) AS geometry_json"
         f" FROM (SELECT gid, {expr} AS geom_out FROM {table_ref}{where}) AS _op"
         f" WHERE geom_out IS NOT NULL AND NOT ST_IsEmpty(geom_out)"
         f" ORDER BY gid"
@@ -81,15 +88,24 @@ async def run_analysis_preview(
     dataset: Dataset,
     request: AnalysisPreviewRequest,
     user_id: uuid.UUID,
+    *,
+    mask_dataset: Dataset | None = None,
 ) -> AnalysisPreviewResponse:
     """Execute a preview operation and assemble a GeoJSON FeatureCollection.
 
     Results are capped at ``PREVIEW_FEATURE_CAP`` features (``truncated`` set
     when the cap was hit). Shares the sandbox's per-user advisory lock
     namespace with AI data queries: one expensive read per user at a time.
+
+    ``mask_dataset`` (clip only) sources the mask from another dataset's
+    unioned geometries; the CALLER owns its visibility check, exactly as it
+    owns the source dataset's.
     """
     table_ref = _safe_table_ref(dataset.table_name)
-    sql = build_preview_sql(table_ref, request)
+    mask_table_ref = (
+        _safe_table_ref(mask_dataset.table_name) if mask_dataset is not None else None
+    )
+    sql = build_preview_sql(table_ref, request, mask_table_ref)
     result = await execute_safe(
         db,
         sql,

--- a/backend/app/platform/analysis_sql.py
+++ b/backend/app/platform/analysis_sql.py
@@ -31,7 +31,33 @@ from shapely.geometry import shape
 MAX_BUFFER_METERS = 100_000.0
 MAX_MASK_VERTICES = 5_000
 
+# CTE name for layer-sourced clip masks. The union is computed ONCE in a
+# MATERIALIZED CTE; referencing it from the expression and both WHERE terms
+# as a scalar subquery would otherwise evaluate the union three times.
+MASK_CTE_NAME = "_mask"
+
 _CLIP_MASK_TYPES = ("Polygon", "MultiPolygon")
+
+
+def render_mask_cte(mask_table_ref: str) -> str:
+    """Render the CTE that unions a mask layer's geometries into one mask.
+
+    ``mask_table_ref`` must come from ``_safe_table_ref`` / regex-validated
+    names, same contract as the source table. NULL geometries are excluded;
+    a mask layer with no usable geometry unions to NULL, which intersects
+    nothing — callers surface that as an empty result.
+
+    Only polygonal components enter the union (fix(#682): the catalog's
+    geometry_type is classified from the first feature, so a "POLYGON" mask
+    layer can still hold point/line rows, and ST_MakeValid can shed line
+    remnants from degenerate polygons — either would let point/line source
+    features outside every polygon survive the clip).
+    """
+    return (
+        f"WITH {MASK_CTE_NAME} AS MATERIALIZED ("
+        f"SELECT ST_Union(ST_CollectionExtract(ST_MakeValid(geom_4326), 3)) AS geom "
+        f"FROM {mask_table_ref} WHERE geom_4326 IS NOT NULL)"
+    )
 
 
 def render_mask_expr(mask: dict[str, Any]) -> str:
@@ -72,12 +98,17 @@ def render_geometry_expr(
     *,
     distance_meters: float | None = None,
     mask: dict[str, Any] | None = None,
+    layer_mask: bool = False,
 ) -> tuple[str, str]:
     """Return ``(geometry expression, WHERE clause)`` for a per-row operation.
 
     Operates on the conventional ``geom_4326`` column. The aggregate
     ``dissolve`` operation has a different query shape and is rendered by the
     materialize worker, not here.
+
+    ``layer_mask=True`` renders clip against the ``MASK_CTE_NAME`` CTE (see
+    ``render_mask_cte``, which the caller must prepend) instead of an inline
+    GeoJSON mask.
     """
     if operation == "buffer":
         if distance_meters is None:
@@ -94,7 +125,10 @@ def render_geometry_expr(
     if operation == "centroid":
         return "ST_Centroid(ST_MakeValid(geom_4326))", ""
     if operation == "clip":
-        mask_expr = render_mask_expr(mask or {})
+        if layer_mask:
+            mask_expr = f"(SELECT geom FROM {MASK_CTE_NAME})"
+        else:
+            mask_expr = render_mask_expr(mask or {})
         # A clip that only grazes a boundary intersects at a lower dimension
         # (polygon ∩ polygon edge → LineString). Extract only components
         # matching the source geometry's dimension (type code = dimension + 1)

--- a/backend/app/platform/jobs/schemas.py
+++ b/backend/app/platform/jobs/schemas.py
@@ -94,6 +94,10 @@ class JobStatusResponse(BaseModel):
             "complete",
             "cog_convert",
             "quicklook",
+            # Analysis materialize (no numeric progress — the operation is a
+            # single CTAS, so there is nothing to report between these two).
+            "analyzing",
+            "registering",
         ]
         | None
     ) = None

--- a/backend/app/processing/analysis/tasks.py
+++ b/backend/app/processing/analysis/tasks.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import re
 import uuid
+from datetime import datetime, timezone
 from types import SimpleNamespace
 from typing import Any
 
@@ -129,6 +130,14 @@ async def _materialize(
             logger.warning("analysis.job_not_found", job_id=job_id)
             return
         job.status = "running"
+        # Stamp the start time. Without it this row carries NO liveness signal
+        # at all (materialize does not renew a heartbeat lease), and the
+        # platform's stale-job recovery matches on
+        # `coalesce(heartbeat_at, started_at) < cutoff` — which is NULL for
+        # such a row, so a worker that dies mid-CTAS would strand the job in
+        # 'running' forever. It also lets the per-user job cap measure from
+        # actual start rather than enqueue time (fix(#682 review)).
+        job.started_at = datetime.now(timezone.utc)
         # current_step only, no numeric progress: the operation is a single
         # CTAS, so there is no intra-statement telemetry to report and a bar
         # parked at 10% for five minutes reads as "stuck" rather than "busy".

--- a/backend/app/processing/analysis/tasks.py
+++ b/backend/app/processing/analysis/tasks.py
@@ -129,6 +129,10 @@ async def _materialize(
             logger.warning("analysis.job_not_found", job_id=job_id)
             return
         job.status = "running"
+        # current_step only, no numeric progress: the operation is a single
+        # CTAS, so there is no intra-statement telemetry to report and a bar
+        # parked at 10% for five minutes reads as "stuck" rather than "busy".
+        job.current_step = "analyzing"
         await session.commit()
 
         _schema = tenant_data_schema(
@@ -219,6 +223,7 @@ async def _materialize(
             )
             await session.execute(text(f"ALTER TABLE {out_ref} ADD PRIMARY KEY (gid)"))
             await add_4326_column(session, out_table, 4326, schema=_schema)
+            job.current_step = "registering"
             await session.commit()
 
             # Identity is a structural Protocol; registration only reads .id.

--- a/backend/app/processing/analysis/tasks.py
+++ b/backend/app/processing/analysis/tasks.py
@@ -15,6 +15,7 @@ from types import SimpleNamespace
 from typing import Any
 
 import structlog
+from prometheus_client import Counter
 from sqlalchemy import select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -33,6 +34,15 @@ _SAFE_TABLE = re.compile(r"^[a-z0-9_]+$")
 # here is the only unbounded statement a user can queue, so cap it.
 # ponytail: hardcoded ceiling; promote to persistent-config if operators hit it.
 MATERIALIZE_TIMEOUT = "300s"
+
+# Served by the worker's :8001 /metrics endpoint (default registry).
+# ponytail: analysis-only counter; generalize to all ingest job types when
+# another type needs it.
+ANALYSIS_JOBS = Counter(
+    "geolens_analysis_jobs_total",
+    "Materialize-analysis job outcomes",
+    ["operation", "status"],
+)
 
 
 async def _list_carry_columns(
@@ -223,6 +233,7 @@ async def _materialize(
             job.dataset_id = dataset.id
             job.status = "complete"
             await session.commit()
+            ANALYSIS_JOBS.labels(operation=operation, status="complete").inc()
         except Exception as exc:  # broad: any failure must mark the job failed, not raise into the queue
             logger.warning("analysis.materialize_failed", job_id=job_id, error=str(exc))
             await session.rollback()
@@ -239,6 +250,7 @@ async def _materialize(
                 failed_job.status = "failed"
                 failed_job.error_message = str(exc)[:2000]
                 await session.commit()
+            ANALYSIS_JOBS.labels(operation=operation, status="failed").inc()
 
 
 @task_app.task(

--- a/backend/app/processing/analysis/tasks.py
+++ b/backend/app/processing/analysis/tasks.py
@@ -9,6 +9,7 @@ reader grants, and the atomic dataset-slot quota all apply.
 
 from __future__ import annotations
 
+import asyncio
 import re
 import uuid
 from datetime import datetime, timezone
@@ -24,6 +25,7 @@ from app.core.db.tenant_schema import tenant_data_schema
 from app.core.db.tenant_session import current_tenant_var, tenant_task
 from app.core.tenancy import is_multi_tenant
 from app.platform.analysis_sql import render_geometry_expr, render_mask_cte
+from app.platform.jobs.heartbeat import maintain_ingest_job_heartbeat
 from app.processing.ingest.tasks import task_app
 
 logger = structlog.stdlib.get_logger(__name__)
@@ -131,18 +133,43 @@ async def _materialize(
             return
         job.status = "running"
         # Stamp the start time. Without it this row carries NO liveness signal
-        # at all (materialize does not renew a heartbeat lease), and the
-        # platform's stale-job recovery matches on
+        # at all, and the platform's stale-job recovery matches on
         # `coalesce(heartbeat_at, started_at) < cutoff` — which is NULL for
         # such a row, so a worker that dies mid-CTAS would strand the job in
-        # 'running' forever. It also lets the per-user job cap measure from
-        # actual start rather than enqueue time (fix(#682 review)).
-        job.started_at = datetime.now(timezone.utc)
+        # 'running' forever.
+        _now = datetime.now(timezone.utc)
+        job.started_at = _now
+        # ...and renew a lease from here on, or started_at alone would condemn
+        # a job that legitimately outlives JOB_TIMEOUT_SECONDS (fix(#682
+        # review)). statement_timeout bounds each STATEMENT, not the task: the
+        # CTAS, DELETE, EXISTS probe, two ALTERs, the primary key,
+        # add_4326_column and registration each get their own budget, so a
+        # large materialize can run long. Without a lease the sweep would mark
+        # a live job failed, the watcher would report a false failure, the
+        # per-user slot would reopen for a second CTAS, and this worker would
+        # later overwrite 'failed' with 'complete'.
+        #
+        # Reuse the token the row already carries (IngestJob.attempt_id
+        # defaults to uuid4 at creation) rather than minting a fresh one —
+        # rotating it here would invalidate the token the enqueue side
+        # recorded, and this task is retry=0 so there is no second delivery to
+        # fence against. The fallback covers rows predating that default.
+        attempt_id = job.attempt_id
+        if attempt_id is None:
+            attempt_id = uuid.uuid4()
+            job.attempt_id = attempt_id
+        job.heartbeat_at = _now
         # current_step only, no numeric progress: the operation is a single
         # CTAS, so there is no intra-statement telemetry to report and a bar
         # parked at 10% for five minutes reads as "stuck" rather than "busy".
         job.current_step = "analyzing"
         await session.commit()
+
+        # Renews on its own session, so it never contends with the work below,
+        # and returns by itself once the row leaves 'running'.
+        heartbeat = asyncio.create_task(
+            maintain_ingest_job_heartbeat(job.id, attempt_id)
+        )
 
         _schema = tenant_data_schema(
             current_tenant_var.get() if is_multi_tenant() else None
@@ -265,6 +292,11 @@ async def _materialize(
                 failed_job.error_message = str(exc)[:2000]
                 await session.commit()
             ANALYSIS_JOBS.labels(operation=operation, status="failed").inc()
+        finally:
+            # The row has left 'running' by now, so the loop would exit on its
+            # own at the next renewal — cancel so the task does not outlive the
+            # work by up to one heartbeat interval.
+            heartbeat.cancel()
 
 
 @task_app.task(

--- a/backend/app/processing/analysis/tasks.py
+++ b/backend/app/processing/analysis/tasks.py
@@ -21,7 +21,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.core.db.tenant_schema import tenant_data_schema
 from app.core.db.tenant_session import current_tenant_var, tenant_task
 from app.core.tenancy import is_multi_tenant
-from app.platform.analysis_sql import render_geometry_expr
+from app.platform.analysis_sql import render_geometry_expr, render_mask_cte
 from app.processing.ingest.tasks import task_app
 
 logger = structlog.stdlib.get_logger(__name__)
@@ -58,6 +58,7 @@ def _build_materialize_select(
     mask: dict[str, Any] | None,
     by_field: str | None,
     carry_cols: list[str],
+    mask_table_ref: str | None = None,
 ) -> str:
     """Render the SELECT that produces the output table's rows."""
     if operation == "dissolve":
@@ -79,10 +80,14 @@ def _build_materialize_select(
             f"{union_expr} AS geom FROM {src_ref}"
         )
     expr, where = render_geometry_expr(
-        operation, distance_meters=distance_meters, mask=mask
+        operation,
+        distance_meters=distance_meters,
+        mask=mask,
+        layer_mask=mask_table_ref is not None,
     )
+    cte = f"{render_mask_cte(mask_table_ref)} " if mask_table_ref else ""
     cols = "".join(f'"{c}", ' for c in carry_cols)
-    return f"SELECT gid, {cols}{expr} AS geom FROM {src_ref}{where}"
+    return f"{cte}SELECT gid, {cols}{expr} AS geom FROM {src_ref}{where}"
 
 
 async def _materialize(
@@ -94,6 +99,7 @@ async def _materialize(
     title: str,
     distance_meters: float | None = None,
     mask: dict[str, Any] | None = None,
+    mask_dataset_id: str | None = None,
     by_field: str | None = None,
 ) -> None:
     """Core materialize logic; separated from the task wrapper for tests."""
@@ -139,6 +145,21 @@ async def _materialize(
                 raise ValueError("Invalid dissolve column name")
             src_ref = f'"{_schema}"."{src.table_name}"'
 
+            # Layer-sourced clip mask: re-resolve the table name at run time
+            # (access was checked at enqueue by the router, same trust model
+            # as the source dataset).
+            mask_table_ref: str | None = None
+            if mask_dataset_id is not None:
+                mask_result = await session.execute(
+                    select(Dataset).where(Dataset.id == uuid.UUID(mask_dataset_id))
+                )
+                mask_ds = mask_result.scalar_one_or_none()
+                if mask_ds is None or not mask_ds.table_name:
+                    raise ValueError("Mask dataset not found")
+                if not _SAFE_TABLE.match(mask_ds.table_name):
+                    raise ValueError("Invalid mask table name")
+                mask_table_ref = f'"{_schema}"."{mask_ds.table_name}"'
+
             out_table, _warning = await generate_table_name(title, session)
             out_ref = f'"{_schema}"."{out_table}"'
 
@@ -154,6 +175,7 @@ async def _materialize(
                 mask=mask,
                 by_field=by_field,
                 carry_cols=carry_cols,
+                mask_table_ref=mask_table_ref,
             )
             await session.execute(
                 text(f"SET LOCAL statement_timeout = '{MATERIALIZE_TIMEOUT}'")
@@ -231,6 +253,7 @@ async def materialize_analysis(
     title: str,
     distance_meters: float | None = None,
     mask: dict[str, Any] | None = None,
+    mask_dataset_id: str | None = None,
     by_field: str | None = None,
 ) -> None:
     """Procrastinate entry point for async analysis materialization."""
@@ -242,5 +265,6 @@ async def materialize_analysis(
         title=title,
         distance_meters=distance_meters,
         mask=mask,
+        mask_dataset_id=mask_dataset_id,
         by_field=by_field,
     )

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -837,6 +837,19 @@
             "description": "GeoJSON Polygon or MultiPolygon geometry in EPSG:4326 (clip only)",
             "title": "Mask"
           },
+          "mask_dataset_id": {
+            "anyOf": [
+              {
+                "format": "uuid",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Polygon dataset whose unioned features form the clip mask (clip only; alternative to mask)",
+            "title": "Mask Dataset Id"
+          },
           "operation": {
             "enum": [
               "buffer",
@@ -910,6 +923,19 @@
             ],
             "description": "GeoJSON Polygon or MultiPolygon geometry in EPSG:4326 (clip only)",
             "title": "Mask"
+          },
+          "mask_dataset_id": {
+            "anyOf": [
+              {
+                "format": "uuid",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Polygon dataset whose unioned features form the clip mask (clip only; alternative to mask)",
+            "title": "Mask Dataset Id"
           },
           "operation": {
             "enum": [

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -7410,7 +7410,9 @@
                   "finalize",
                   "complete",
                   "cog_convert",
-                  "quicklook"
+                  "quicklook",
+                  "analyzing",
+                  "registering"
                 ],
                 "type": "string"
               },

--- a/backend/tests/test_analysis_materialize.py
+++ b/backend/tests/test_analysis_materialize.py
@@ -387,8 +387,14 @@ class TestMaterializeWorker:
         # fix(#682 review): without started_at the row carries no liveness
         # signal, so the platform's stale-job sweep (which matches on
         # coalesce(heartbeat_at, started_at)) could never recover a crashed
-        # analysis job, and the per-user cap could not time from actual start.
+        # analysis job.
         assert job.started_at is not None
+        # ...and started_at ALONE would condemn a job that legitimately outlives
+        # JOB_TIMEOUT_SECONDS, since the same coalesce would then read as stale
+        # while the work is still running. The lease the worker takes is what
+        # keeps a live job out of the sweep, so pin that it exists.
+        assert job.attempt_id is not None
+        assert job.heartbeat_at is not None
 
         from app.modules.catalog.datasets.domain.models import Dataset
 

--- a/backend/tests/test_analysis_materialize.py
+++ b/backend/tests/test_analysis_materialize.py
@@ -127,6 +127,36 @@ class TestMaterializeEndpoint:
             third_job.status = "failed"
             await test_db_session.commit()
 
+    async def test_upload_named_like_an_analysis_job_does_not_block(
+        self,
+        client: AsyncClient,
+        admin_auth_header: dict,
+        test_db_session: AsyncSession,
+    ):
+        """fix(#682 review): the active-job check keys on the analysis marker
+        in user_metadata, not source_filename — that column holds the user's
+        own upload filename, so uploading "analysis-data.geojson" must not
+        lock them out of analysis."""
+        admin_id = await get_user_id(test_db_session, "admin")
+        ds = await _create_polygon_dataset(test_db_session, created_by=admin_id)
+        upload = await _create_job(test_db_session, admin_id)
+        upload.source_filename = "analysis-data.geojson"
+        upload.status = "running"
+        upload.user_metadata = None
+        await test_db_session.commit()
+
+        with patch.object(router_analysis, "defer_async_with_tenant", AsyncMock()):
+            resp = await client.post(
+                _materialize_url(ds.id),
+                json={"operation": "centroid", "title": "Not blocked"},
+                headers=admin_auth_header,
+            )
+        assert resp.status_code == 200, resp.text
+        job = await test_db_session.get(IngestJob, uuid.UUID(resp.json()["job_id"]))
+        job.status = "failed"
+        upload.status = "failed"
+        await test_db_session.commit()
+
     async def test_zombie_job_stops_blocking_after_the_window(
         self,
         client: AsyncClient,
@@ -143,6 +173,7 @@ class TestMaterializeEndpoint:
         zombie = await _create_job(test_db_session, admin_id)
         zombie.status = "running"
         zombie.source_filename = "analysis-buffer"
+        zombie.user_metadata = {"analysis": {"operation": "buffer"}}
         zombie.created_at = (
             datetime.now(timezone.utc)
             - router_analysis._ACTIVE_JOB_WINDOW

--- a/backend/tests/test_analysis_materialize.py
+++ b/backend/tests/test_analysis_materialize.py
@@ -127,6 +127,41 @@ class TestMaterializeEndpoint:
             third_job.status = "failed"
             await test_db_session.commit()
 
+    async def test_zombie_job_stops_blocking_after_the_window(
+        self,
+        client: AsyncClient,
+        admin_auth_header: dict,
+        test_db_session: AsyncSession,
+    ):
+        """A job stuck 'running' (worker died mid-CTAS) must not hold the
+        per-user slot until the hour-long platform reaper sweeps it — the
+        active-job check only looks back _ACTIVE_JOB_WINDOW."""
+        from datetime import datetime, timedelta, timezone
+
+        admin_id = await get_user_id(test_db_session, "admin")
+        ds = await _create_polygon_dataset(test_db_session, created_by=admin_id)
+        zombie = await _create_job(test_db_session, admin_id)
+        zombie.status = "running"
+        zombie.source_filename = "analysis-buffer"
+        zombie.created_at = (
+            datetime.now(timezone.utc)
+            - router_analysis._ACTIVE_JOB_WINDOW
+            - timedelta(minutes=1)
+        )
+        await test_db_session.commit()
+
+        with patch.object(router_analysis, "defer_async_with_tenant", AsyncMock()):
+            resp = await client.post(
+                _materialize_url(ds.id),
+                json={"operation": "centroid", "title": "After zombie"},
+                headers=admin_auth_header,
+            )
+        assert resp.status_code == 200, resp.text
+        job = await test_db_session.get(IngestJob, uuid.UUID(resp.json()["job_id"]))
+        job.status = "failed"
+        zombie.status = "failed"
+        await test_db_session.commit()
+
     async def test_materialize_private_source_hidden(
         self,
         client: AsyncClient,

--- a/backend/tests/test_analysis_materialize.py
+++ b/backend/tests/test_analysis_materialize.py
@@ -157,6 +157,34 @@ class TestMaterializeEndpoint:
         upload.status = "failed"
         await test_db_session.commit()
 
+    async def test_old_pending_job_still_blocks(
+        self,
+        client: AsyncClient,
+        admin_auth_header: dict,
+        test_db_session: AsyncSession,
+    ):
+        """fix(#682 review): the staleness window applies to RUNNING jobs only.
+        A pending job is queued work that will still run, so a backlogged
+        ingest queue must not let a second CTAS through however old it is."""
+        from datetime import datetime, timedelta, timezone
+
+        admin_id = await get_user_id(test_db_session, "admin")
+        ds = await _create_polygon_dataset(test_db_session, created_by=admin_id)
+        backlogged = await _create_job(test_db_session, admin_id)
+        backlogged.user_metadata = {"analysis": {"operation": "buffer"}}
+        backlogged.created_at = datetime.now(timezone.utc) - timedelta(hours=2)
+        await test_db_session.commit()
+
+        with patch.object(router_analysis, "defer_async_with_tenant", AsyncMock()):
+            resp = await client.post(
+                _materialize_url(ds.id),
+                json={"operation": "centroid", "title": "Should be blocked"},
+                headers=admin_auth_header,
+            )
+        assert resp.status_code == 429, resp.text
+        backlogged.status = "failed"
+        await test_db_session.commit()
+
     async def test_zombie_job_stops_blocking_after_the_window(
         self,
         client: AsyncClient,
@@ -176,7 +204,7 @@ class TestMaterializeEndpoint:
         zombie.user_metadata = {"analysis": {"operation": "buffer"}}
         zombie.created_at = (
             datetime.now(timezone.utc)
-            - router_analysis._ACTIVE_JOB_WINDOW
+            - router_analysis._RUNNING_JOB_WINDOW
             - timedelta(minutes=1)
         )
         await test_db_session.commit()

--- a/backend/tests/test_analysis_materialize.py
+++ b/backend/tests/test_analysis_materialize.py
@@ -19,7 +19,7 @@ from app.platform.jobs.models import IngestJob
 from app.processing.analysis.tasks import _materialize
 
 from tests.factories import get_user_id
-from tests.test_analysis_preview import _create_polygon_dataset
+from tests.test_analysis_preview import _create_mask_dataset, _create_polygon_dataset
 
 
 def _materialize_url(dataset_id) -> str:
@@ -75,6 +75,12 @@ class TestMaterializeEndpoint:
         job = await test_db_session.get(IngestJob, uuid.UUID(data["job_id"]))
         assert job is not None
         assert job.status == "pending"
+        # Request params ride the job row so Admin → Jobs can diagnose runs.
+        meta = (job.user_metadata or {}).get("analysis", {})
+        assert meta["operation"] == "buffer"
+        assert meta["distance_meters"] == 100
+        assert meta["source_dataset_id"] == str(ds.id)
+        assert "mask" not in meta
 
     async def test_materialize_private_source_hidden(
         self,
@@ -470,6 +476,68 @@ class TestMaterializeWorker:
             .all()
         )
         assert cols == ["marker"]
+
+    async def test_clip_by_layer_materialize(
+        self,
+        test_db_session: AsyncSession,
+    ):
+        """Worker resolves the mask dataset's table and clips against its
+        unioned geometries — same output as an equivalent drawn mask."""
+        admin_id = await get_user_id(test_db_session, "admin")
+        ds = await _create_polygon_dataset(test_db_session, created_by=admin_id)
+        mask_ds = await _create_mask_dataset(
+            test_db_session,
+            created_by=admin_id,
+            wkt="POLYGON((-0.5 -0.5, -0.5 0.5, 0.5 0.5, 0.5 -0.5, -0.5 -0.5))",
+        )
+        job = await _create_job(test_db_session, admin_id)
+
+        await _materialize(
+            job_id=str(job.id),
+            dataset_id=str(ds.id),
+            user_id=str(admin_id),
+            operation="clip",
+            title=f"Layer clipped {uuid.uuid4().hex[:6]}",
+            mask_dataset_id=str(mask_ds.id),
+        )
+
+        await test_db_session.refresh(job)
+        assert job.status == "complete", job.error_message
+
+        from app.modules.catalog.datasets.domain.models import Dataset
+
+        new_ds = await test_db_session.get(Dataset, job.dataset_id)
+        assert new_ds is not None
+        rows = (
+            await test_db_session.execute(
+                text(
+                    f"SELECT name, GeometryType(geom_4326) FROM data.{new_ds.table_name}"  # noqa: S608
+                )
+            )
+        ).all()
+        assert rows == [("a", "POLYGON")]
+
+    async def test_clip_by_layer_missing_mask_fails_job(
+        self,
+        test_db_session: AsyncSession,
+    ):
+        """A mask dataset deleted between enqueue and run fails cleanly."""
+        admin_id = await get_user_id(test_db_session, "admin")
+        ds = await _create_polygon_dataset(test_db_session, created_by=admin_id)
+        job = await _create_job(test_db_session, admin_id)
+
+        await _materialize(
+            job_id=str(job.id),
+            dataset_id=str(ds.id),
+            user_id=str(admin_id),
+            operation="clip",
+            title="Ghost mask",
+            mask_dataset_id=str(uuid.uuid4()),
+        )
+
+        await test_db_session.refresh(job)
+        assert job.status == "failed"
+        assert "Mask dataset not found" in (job.error_message or "")
 
     async def test_mixed_geometry_dissolve_stays_typed(
         self,

--- a/backend/tests/test_analysis_materialize.py
+++ b/backend/tests/test_analysis_materialize.py
@@ -185,6 +185,36 @@ class TestMaterializeEndpoint:
         backlogged.status = "failed"
         await test_db_session.commit()
 
+    async def test_backlogged_job_that_just_started_still_blocks(
+        self,
+        client: AsyncClient,
+        admin_auth_header: dict,
+        test_db_session: AsyncSession,
+    ):
+        """fix(#682 review): the window measures from actual START. A job that
+        waited out a queue backlog and only just began is fully active, so
+        enqueue age must not exclude it from the cap."""
+        from datetime import datetime, timedelta, timezone
+
+        admin_id = await get_user_id(test_db_session, "admin")
+        ds = await _create_polygon_dataset(test_db_session, created_by=admin_id)
+        backlogged = await _create_job(test_db_session, admin_id)
+        backlogged.user_metadata = {"analysis": {"operation": "buffer"}}
+        backlogged.status = "running"
+        backlogged.created_at = datetime.now(timezone.utc) - timedelta(hours=2)
+        backlogged.started_at = datetime.now(timezone.utc) - timedelta(minutes=1)
+        await test_db_session.commit()
+
+        with patch.object(router_analysis, "defer_async_with_tenant", AsyncMock()):
+            resp = await client.post(
+                _materialize_url(ds.id),
+                json={"operation": "centroid", "title": "Should be blocked"},
+                headers=admin_auth_header,
+            )
+        assert resp.status_code == 429, resp.text
+        backlogged.status = "failed"
+        await test_db_session.commit()
+
     async def test_zombie_job_stops_blocking_after_the_window(
         self,
         client: AsyncClient,
@@ -202,6 +232,11 @@ class TestMaterializeEndpoint:
         zombie.status = "running"
         zombie.source_filename = "analysis-buffer"
         zombie.user_metadata = {"analysis": {"operation": "buffer"}}
+        zombie.started_at = (
+            datetime.now(timezone.utc)
+            - router_analysis._RUNNING_JOB_WINDOW
+            - timedelta(minutes=1)
+        )
         zombie.created_at = (
             datetime.now(timezone.utc)
             - router_analysis._RUNNING_JOB_WINDOW
@@ -354,6 +389,11 @@ class TestMaterializeWorker:
         await test_db_session.refresh(job)
         assert job.status == "complete", job.error_message
         assert job.dataset_id is not None
+        # fix(#682 review): without started_at the row carries no liveness
+        # signal, so the platform's stale-job sweep (which matches on
+        # coalesce(heartbeat_at, started_at)) could never recover a crashed
+        # analysis job, and the per-user cap could not time from actual start.
+        assert job.started_at is not None
 
         from app.modules.catalog.datasets.domain.models import Dataset
 

--- a/backend/tests/test_analysis_materialize.py
+++ b/backend/tests/test_analysis_materialize.py
@@ -81,6 +81,51 @@ class TestMaterializeEndpoint:
         assert meta["distance_meters"] == 100
         assert meta["source_dataset_id"] == str(ds.id)
         assert "mask" not in meta
+        # Release the per-user active-job slot for later tests (shared DB).
+        job.status = "failed"
+        await test_db_session.commit()
+
+    async def test_second_materialize_while_active_is_rejected(
+        self,
+        client: AsyncClient,
+        admin_auth_header: dict,
+        test_db_session: AsyncSession,
+    ):
+        """One materialize per user at a time: a second request while a job is
+        still pending/running 429s instead of stacking CTAS work; a finished
+        job releases the slot."""
+        admin_id = await get_user_id(test_db_session, "admin")
+        ds = await _create_polygon_dataset(test_db_session, created_by=admin_id)
+        with patch.object(router_analysis, "defer_async_with_tenant", AsyncMock()):
+            first = await client.post(
+                _materialize_url(ds.id),
+                json={"operation": "centroid", "title": "First"},
+                headers=admin_auth_header,
+            )
+            assert first.status_code == 200, first.text
+            second = await client.post(
+                _materialize_url(ds.id),
+                json={"operation": "centroid", "title": "Second"},
+                headers=admin_auth_header,
+            )
+            assert second.status_code == 429
+            job = await test_db_session.get(
+                IngestJob, uuid.UUID(first.json()["job_id"])
+            )
+            job.status = "failed"
+            await test_db_session.commit()
+            third = await client.post(
+                _materialize_url(ds.id),
+                json={"operation": "centroid", "title": "Third"},
+                headers=admin_auth_header,
+            )
+            assert third.status_code == 200, third.text
+            # Release the slot for later tests (shared DB).
+            third_job = await test_db_session.get(
+                IngestJob, uuid.UUID(third.json()["job_id"])
+            )
+            third_job.status = "failed"
+            await test_db_session.commit()
 
     async def test_materialize_private_source_hidden(
         self,
@@ -182,6 +227,10 @@ class TestMaterializeEndpoint:
                 headers=admin_auth_header,
             )
         assert resp.status_code == 200, resp.text
+        # Release the per-user active-job slot for later tests (shared DB).
+        job = await test_db_session.get(IngestJob, uuid.UUID(resp.json()["job_id"]))
+        job.status = "failed"
+        await test_db_session.commit()
 
 
 # ---------------------------------------------------------------------------
@@ -404,6 +453,8 @@ class TestMaterializeWorker:
         test_db_session: AsyncSession,
     ):
         """A clip matching nothing must fail loud, not register a junk dataset."""
+        from app.processing.analysis.tasks import ANALYSIS_JOBS
+
         admin_id = await get_user_id(test_db_session, "admin")
         ds = await _create_polygon_dataset(test_db_session, created_by=admin_id)
         job = await _create_job(test_db_session, admin_id)
@@ -411,6 +462,9 @@ class TestMaterializeWorker:
             "type": "Polygon",
             "coordinates": [[[50, 50], [51, 50], [51, 51], [50, 51], [50, 50]]],
         }
+        failed_before = ANALYSIS_JOBS.labels(
+            operation="clip", status="failed"
+        )._value.get()
 
         await _materialize(
             job_id=str(job.id),
@@ -425,6 +479,10 @@ class TestMaterializeWorker:
         assert job.status == "failed"
         assert "no features" in (job.error_message or "")
         assert job.dataset_id is None
+        assert (
+            ANALYSIS_JOBS.labels(operation="clip", status="failed")._value.get()
+            == failed_before + 1
+        )
 
     async def test_name_collision_preserves_existing_table(
         self,

--- a/backend/tests/test_analysis_materialize.py
+++ b/backend/tests/test_analysis_materialize.py
@@ -163,8 +163,7 @@ class TestMaterializeEndpoint:
         admin_auth_header: dict,
         test_db_session: AsyncSession,
     ):
-        """fix(#682 review): the staleness window applies to RUNNING jobs only.
-        A pending job is queued work that will still run, so a backlogged
+        """A pending job is queued work that will still run, so a backlogged
         ingest queue must not let a second CTAS through however old it is."""
         from datetime import datetime, timedelta, timezone
 
@@ -191,9 +190,8 @@ class TestMaterializeEndpoint:
         admin_auth_header: dict,
         test_db_session: AsyncSession,
     ):
-        """fix(#682 review): the window measures from actual START. A job that
-        waited out a queue backlog and only just began is fully active, so
-        enqueue age must not exclude it from the cap."""
+        """A job that waited out a queue backlog and only just began is fully
+        active, so enqueue age must not exclude it from the cap."""
         from datetime import datetime, timedelta, timezone
 
         admin_id = await get_user_id(test_db_session, "admin")
@@ -215,45 +213,42 @@ class TestMaterializeEndpoint:
         backlogged.status = "failed"
         await test_db_session.commit()
 
-    async def test_zombie_job_stops_blocking_after_the_window(
+    async def test_long_running_job_still_blocks(
         self,
         client: AsyncClient,
         admin_auth_header: dict,
         test_db_session: AsyncSession,
     ):
-        """A job stuck 'running' (worker died mid-CTAS) must not hold the
-        per-user slot until the hour-long platform reaper sweeps it — the
-        active-job check only looks back _ACTIVE_JOB_WINDOW."""
+        """fix(#682 review): elapsed time is NOT a liveness signal, so an old
+        'running' job keeps the slot.
+
+        The 300s statement_timeout bounds each statement, not the job — a
+        materialize runs a CTAS, a DELETE, an EXISTS probe, two ALTERs, a
+        primary key, add_4326_column and registration in sequence, so a
+        legitimate run over a large dataset can outlive any window short
+        enough to be useful. Releasing the slot on age would let a second
+        expensive CTAS through and defeat the cap. A worker that truly died
+        is resolved by the platform job timeout instead (see #691).
+        """
         from datetime import datetime, timedelta, timezone
 
         admin_id = await get_user_id(test_db_session, "admin")
         ds = await _create_polygon_dataset(test_db_session, created_by=admin_id)
-        zombie = await _create_job(test_db_session, admin_id)
-        zombie.status = "running"
-        zombie.source_filename = "analysis-buffer"
-        zombie.user_metadata = {"analysis": {"operation": "buffer"}}
-        zombie.started_at = (
-            datetime.now(timezone.utc)
-            - router_analysis._RUNNING_JOB_WINDOW
-            - timedelta(minutes=1)
-        )
-        zombie.created_at = (
-            datetime.now(timezone.utc)
-            - router_analysis._RUNNING_JOB_WINDOW
-            - timedelta(minutes=1)
-        )
+        long_running = await _create_job(test_db_session, admin_id)
+        long_running.status = "running"
+        long_running.user_metadata = {"analysis": {"operation": "buffer"}}
+        long_running.started_at = datetime.now(timezone.utc) - timedelta(minutes=45)
+        long_running.created_at = datetime.now(timezone.utc) - timedelta(minutes=45)
         await test_db_session.commit()
 
         with patch.object(router_analysis, "defer_async_with_tenant", AsyncMock()):
             resp = await client.post(
                 _materialize_url(ds.id),
-                json={"operation": "centroid", "title": "After zombie"},
+                json={"operation": "centroid", "title": "Should be blocked"},
                 headers=admin_auth_header,
             )
-        assert resp.status_code == 200, resp.text
-        job = await test_db_session.get(IngestJob, uuid.UUID(resp.json()["job_id"]))
-        job.status = "failed"
-        zombie.status = "failed"
+        assert resp.status_code == 429, resp.text
+        long_running.status = "failed"
         await test_db_session.commit()
 
     async def test_materialize_private_source_hidden(

--- a/backend/tests/test_analysis_preview.py
+++ b/backend/tests/test_analysis_preview.py
@@ -104,6 +104,41 @@ async def _create_point_dataset(
     )
 
 
+async def _create_mask_dataset(
+    session: AsyncSession,
+    *,
+    created_by: uuid.UUID,
+    wkt: str,
+    visibility: str = "public",
+):
+    """Create a one-polygon dataset usable as a clip-by-layer mask."""
+    table_name = f"ds_{uuid.uuid4().hex[:12]}"
+    await session.execute(
+        text(
+            f"CREATE TABLE data.{table_name} ("
+            f"  gid SERIAL PRIMARY KEY,"
+            f"  geom geometry(Polygon, 4326),"
+            f"  geom_4326 geometry(Polygon, 4326)"
+            f")"
+        )
+    )
+    await session.execute(
+        text(
+            f"INSERT INTO data.{table_name} (geom, geom_4326) VALUES "
+            f"(ST_GeomFromText('{wkt}', 4326), ST_GeomFromText('{wkt}', 4326))"
+        )
+    )
+    await session.commit()
+    return await create_dataset(
+        session,
+        created_by=created_by,
+        table_name=table_name,
+        geometry_type="POLYGON",
+        feature_count=1,
+        visibility=visibility,
+    )
+
+
 def _preview_url(dataset_id) -> str:
     return f"/datasets/{dataset_id}/analysis/preview/"
 
@@ -416,6 +451,30 @@ class TestAnalysisPreviewEndpoint:
             )
             assert resp.status_code == 200, (stray, resp.text)
 
+    async def test_buffer_ignores_stray_mask_sources(
+        self,
+        client: AsyncClient,
+        admin_auth_header: dict,
+        test_db_session: AsyncSession,
+    ):
+        """fix(#682): mask/mask_dataset_id are clip-only; a stray (even
+        nonexistent) mask dataset riding along on a buffer request must not
+        be loaded, let alone 404 the whole call."""
+        admin_id = await get_user_id(test_db_session, "admin")
+        ds = await _create_polygon_dataset(test_db_session, created_by=admin_id)
+        resp = await client.post(
+            _preview_url(ds.id),
+            json={
+                "operation": "buffer",
+                "distance_meters": 100,
+                "mask": CLIP_MASK,
+                "mask_dataset_id": str(uuid.uuid4()),
+            },
+            headers=admin_auth_header,
+        )
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["feature_count"] == 2
+
     async def test_grazing_rows_do_not_consume_preview_cap(
         self,
         client: AsyncClient,
@@ -534,6 +593,116 @@ class TestAnalysisPreviewEndpoint:
         assert resp.status_code == 200, resp.text
         assert resp.json()["source_feature_count"] is None
 
+    async def test_clip_by_layer_preview(
+        self,
+        client: AsyncClient,
+        admin_auth_header: dict,
+        test_db_session: AsyncSession,
+    ):
+        """Clip against another dataset's unioned geometries via mask_dataset_id."""
+        admin_id = await get_user_id(test_db_session, "admin")
+        ds = await _create_polygon_dataset(test_db_session, created_by=admin_id)
+        # Mask layer overlapping only SQUARE's lower-left quarter (same
+        # geometry as CLIP_MASK, but sourced from a table).
+        mask_ds = await _create_mask_dataset(
+            test_db_session,
+            created_by=admin_id,
+            wkt="POLYGON((-0.5 -0.5, -0.5 0.5, 0.5 0.5, 0.5 -0.5, -0.5 -0.5))",
+        )
+        resp = await client.post(
+            _preview_url(ds.id),
+            json={"operation": "clip", "mask_dataset_id": str(mask_ds.id)},
+            headers=admin_auth_header,
+        )
+        assert resp.status_code == 200, resp.text
+        data = resp.json()
+        assert data["feature_count"] == 1
+        assert data["bbox"] == pytest.approx([0.0, 0.0, 0.5, 0.5])
+
+    async def test_clip_by_layer_mask_access_checked(
+        self,
+        client: AsyncClient,
+        viewer_auth_header: dict,
+        test_db_session: AsyncSession,
+    ):
+        """Rule 1 applies to the MASK dataset too: a private mask layer of
+        another user 404s even when the source dataset is readable."""
+        admin_id = await get_user_id(test_db_session, "admin")
+        ds = await _create_polygon_dataset(test_db_session, created_by=admin_id)
+        private_mask = await _create_mask_dataset(
+            test_db_session,
+            created_by=admin_id,
+            wkt="POLYGON((-1 -1, -1 1, 1 1, 1 -1, -1 -1))",
+            visibility="private",
+        )
+        resp = await client.post(
+            _preview_url(ds.id),
+            json={"operation": "clip", "mask_dataset_id": str(private_mask.id)},
+            headers=viewer_auth_header,
+        )
+        assert resp.status_code == 404
+
+    async def test_clip_by_layer_requires_polygonal_mask(
+        self,
+        client: AsyncClient,
+        admin_auth_header: dict,
+        test_db_session: AsyncSession,
+    ):
+        admin_id = await get_user_id(test_db_session, "admin")
+        ds = await _create_polygon_dataset(test_db_session, created_by=admin_id)
+        points = await _create_point_dataset(test_db_session, created_by=admin_id, n=3)
+        resp = await client.post(
+            _preview_url(ds.id),
+            json={"operation": "clip", "mask_dataset_id": str(points.id)},
+            headers=admin_auth_header,
+        )
+        assert resp.status_code == 422
+        assert "polygon dataset" in resp.json()["detail"]
+
+    async def test_degenerate_mask_row_stays_polygonal(
+        self,
+        client: AsyncClient,
+        admin_auth_header: dict,
+        test_db_session: AsyncSession,
+    ):
+        """fix(#682): ST_MakeValid collapses a zero-area mask polygon to
+        LINESTRING(0 0, 0.002 0); without polygon extraction in the mask
+        union, the point source at (0.001, 0) sits on that line and would
+        survive the clip despite being outside every real polygon."""
+        admin_id = await get_user_id(test_db_session, "admin")
+        points = await _create_point_dataset(test_db_session, created_by=admin_id, n=1)
+        degenerate = await _create_mask_dataset(
+            test_db_session,
+            created_by=admin_id,
+            wkt="POLYGON((0 0, 0.002 0, 0.002 0, 0 0))",
+        )
+        resp = await client.post(
+            _preview_url(points.id),
+            json={"operation": "clip", "mask_dataset_id": str(degenerate.id)},
+            headers=admin_auth_header,
+        )
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["feature_count"] == 0
+
+    async def test_clip_rejects_both_mask_sources(
+        self,
+        client: AsyncClient,
+        admin_auth_header: dict,
+        test_db_session: AsyncSession,
+    ):
+        admin_id = await get_user_id(test_db_session, "admin")
+        ds = await _create_polygon_dataset(test_db_session, created_by=admin_id)
+        resp = await client.post(
+            _preview_url(ds.id),
+            json={
+                "operation": "clip",
+                "mask": CLIP_MASK,
+                "mask_dataset_id": str(uuid.uuid4()),
+            },
+            headers=admin_auth_header,
+        )
+        assert resp.status_code == 422
+
 
 # ---------------------------------------------------------------------------
 # Pure SQL-builder tests (no DB)
@@ -598,3 +767,26 @@ class TestBuildPreviewSql:
         )
         with pytest.raises(ValueError, match="vertices"):
             build_preview_sql('"data"."t1"', req)
+
+    def test_materialize_request_drops_other_operations_params(self):
+        """fix(#682): the defer builds worker kwargs from the parsed model, so
+        stray clip/dissolve params on a buffer request must parse to None or
+        the worker would resolve a mask dataset the operation never uses."""
+        from app.modules.catalog.datasets.domain.schemas import (
+            AnalysisMaterializeRequest,
+        )
+
+        req = AnalysisMaterializeRequest.model_validate(
+            {
+                "operation": "buffer",
+                "title": "t",
+                "distance_meters": 100,
+                "mask": CLIP_MASK,
+                "mask_dataset_id": str(uuid.uuid4()),
+                "by_field": "name",
+            }
+        )
+        assert req.mask is None
+        assert req.mask_dataset_id is None
+        assert req.by_field is None
+        assert req.distance_meters == 100

--- a/e2e/analysis.spec.ts
+++ b/e2e/analysis.spec.ts
@@ -1,0 +1,101 @@
+import { test, expect } from '@playwright/test';
+import { getAuthToken, seedDataset, deleteDataset, type SeededDataset } from './helpers/catalog';
+
+const BASE_URL = process.env.E2E_BASE_URL ?? 'http://localhost:8080';
+const OUTPUT_TITLE = `E2E Analysis Buffer ${Date.now()}`;
+
+/**
+ * Builder analysis tools (M4): buffer preview + materialize to a new dataset.
+ * The completion toast is page-owned, so it must appear even after the
+ * Analysis panel is closed mid-job (fix #682).
+ */
+test.describe('builder analysis tools', () => {
+  let seed: SeededDataset;
+  let mapId: string;
+  let headers: Record<string, string>;
+  let createdDatasetId: string | null = null;
+
+  test.beforeAll(async () => {
+    headers = {
+      Authorization: `Bearer ${getAuthToken()}`,
+      'Content-Type': 'application/json',
+    };
+    // Title must not contain "Analysis" — layer-row button labels embed the
+    // dataset title and would collide with the rail button's accessible name.
+    seed = await seedDataset('E2E Buffer Source');
+
+    const mapRes = await fetch(`${BASE_URL}/api/maps/`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({
+        name: 'E2E Analysis Map',
+        description: 'Auto-created for analysis e2e',
+      }),
+    });
+    expect(mapRes.ok).toBe(true);
+    mapId = (await mapRes.json()).id;
+
+    const layerRes = await fetch(`${BASE_URL}/api/maps/${mapId}/layers/`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({ dataset_id: seed.id }),
+    });
+    expect(layerRes.ok).toBe(true);
+  });
+
+  test.afterAll(async () => {
+    if (mapId) {
+      await fetch(`${BASE_URL}/api/maps/${mapId}`, { method: 'DELETE', headers });
+    }
+    if (createdDatasetId) {
+      await deleteDataset(createdDatasetId, OUTPUT_TITLE);
+    }
+    if (seed) {
+      await deleteDataset(seed.id, seed.title);
+    }
+  });
+
+  test('buffer preview, materialize, and page-level completion toast', async ({ page }) => {
+    await page.goto(`/maps/${mapId}`);
+    await expect(page.locator('canvas.maplibregl-canvas')).toBeVisible({ timeout: 15_000 });
+
+    await page.getByRole('button', { name: 'Analysis', exact: true }).click();
+    await expect(page.getByTestId('analysis-panel')).toBeVisible();
+
+    // Default operation is buffer @ 500 m; the only dataset layer auto-selects.
+    await page.getByRole('button', { name: 'Preview', exact: true }).click();
+    await expect(page.getByRole('button', { name: 'Clear preview' })).toBeVisible({
+      timeout: 15_000,
+    });
+
+    await page.getByLabel('New dataset name').fill(OUTPUT_TITLE);
+    const materializeResponse = page.waitForResponse(
+      (r) => r.url().includes('/analysis/materialize/') && r.request().method() === 'POST',
+    );
+    await page.getByRole('button', { name: 'Create dataset' }).click();
+    const { job_id: jobId } = (await (await materializeResponse).json()) as {
+      job_id: string;
+    };
+    expect(jobId).toBeTruthy();
+
+    // Close the panel mid-job: completion must still surface (page-level toast).
+    await page.getByRole('button', { name: 'Close panel' }).click();
+    await expect(page.getByText('Dataset created')).toBeVisible({ timeout: 60_000 });
+    await expect(page.getByRole('button', { name: 'Add to map' })).toBeVisible();
+
+    // Resolve the created dataset id for cleanup.
+    for (let attempt = 0; attempt < 30; attempt++) {
+      const res = await fetch(`${BASE_URL}/api/jobs/${jobId}`, { headers });
+      if (res.ok) {
+        const body = (await res.json()) as { status: string; dataset_id: string | null };
+        if (body.status === 'complete' && body.dataset_id) {
+          createdDatasetId = body.dataset_id;
+          break;
+        }
+        if (body.status === 'failed') throw new Error('analysis job failed');
+      }
+      await new Promise((resolve) => setTimeout(resolve, 1000));
+    }
+    expect(createdDatasetId).toBeTruthy();
+  });
+});

--- a/e2e/analysis.spec.ts
+++ b/e2e/analysis.spec.ts
@@ -78,10 +78,20 @@ test.describe('builder analysis tools', () => {
     };
     expect(jobId).toBeTruthy();
 
-    // Close the panel mid-job: completion must still surface (page-level toast).
+    // Abandon the builder mid-job: tracking is global (AnalysisJobWatcher in
+    // RootLayout), so completion must still surface on a different page — with
+    // "View dataset" rather than "Add to map", since no builder is mounted.
     await page.getByRole('button', { name: 'Close panel' }).click();
-    await expect(page.getByText('Dataset created')).toBeVisible({ timeout: 60_000 });
-    await expect(page.getByRole('button', { name: 'Add to map' })).toBeVisible();
+    await page.goto('/');
+    // Scope to the toast: the finished dataset also lands in the catalog list
+    // behind it (which is the query invalidation doing its job).
+    const completionToast = page
+      .locator('[data-sonner-toast]')
+      .filter({ hasText: OUTPUT_TITLE });
+    await expect(completionToast).toBeVisible({ timeout: 60_000 });
+    await expect(
+      completionToast.getByRole('button', { name: 'View dataset' }),
+    ).toBeVisible();
 
     // Resolve the created dataset id for cleanup.
     for (let attempt = 0; attempt < 30; attempt++) {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -10,6 +10,7 @@ import { AdminLayout } from '@/components/admin/AdminLayout';
 import { LoadingState } from '@/components/layout/LoadingState';
 import { LazyLoadErrorBoundary, RouteErrorBoundary } from '@/components/error';
 import { SessionExpiredDialog } from '@/components/auth/SessionExpiredDialog';
+import { AnalysisJobWatcher } from '@/components/analysis/AnalysisJobWatcher';
 
 // Lazy page imports — each produces a separate Vite chunk
 const LoginPage = lazy(() => import('./pages/LoginPage').then(m => ({ default: m.LoginPage })));
@@ -55,6 +56,11 @@ function RootLayout() {
       {/* fix(#628): global session-expiry host — needs router context for the
           sign-in-returns-to-route action, so it lives here rather than main.tsx. */}
       <SessionExpiredDialog />
+      {/* feat(#682): analysis-job notifier — global so a materialize job that
+          outlives the builder (panel closed, navigated away, tab reloaded)
+          still reports when it lands. Needs router context for its
+          "View dataset" action, so it lives here rather than main.tsx. */}
+      <AnalysisJobWatcher />
       <Suspense fallback={<LoadingState />}>
         <Outlet />
       </Suspense>

--- a/frontend/src/components/analysis/AnalysisJobWatcher.tsx
+++ b/frontend/src/components/analysis/AnalysisJobWatcher.tsx
@@ -89,8 +89,16 @@ export function AnalysisJobWatcher() {
       );
     } else {
       const message = data?.error_message;
+      // Interpolate the detail through i18n rather than concatenating onto
+      // t(): check:i18n:toast-strings flags any toast call whose first
+      // argument opens with a quote or backtick, template literals included.
       toast.error(
-        `${t('analysisTools.jobFailed', { defaultValue: 'Analysis job failed' })}${message ? `: ${message}` : ''}`,
+        message
+          ? t('analysisTools.jobFailedDetail', {
+              message,
+              defaultValue: 'Analysis job failed: {{message}}',
+            })
+          : t('analysisTools.jobFailed', { defaultValue: 'Analysis job failed' }),
         { id: toastId, duration: Infinity },
       );
     }

--- a/frontend/src/components/analysis/AnalysisJobWatcher.tsx
+++ b/frontend/src/components/analysis/AnalysisJobWatcher.tsx
@@ -8,9 +8,6 @@ import { ApiError } from '@/api/client';
 import { useJobStatus } from '@/components/import/hooks/use-ingest';
 import { analysisAddToMap, useAnalysisJobStore } from '@/stores/analysis-job-store';
 
-/** Mirrors _RUNNING_JOB_WINDOW in backend/.../api/router_analysis.py. */
-const STALE_RUNNING_JOB_MS = 10 * 60 * 1000;
-
 /**
  * Global notifier for a materialize-analysis job (renders nothing).
  *
@@ -44,27 +41,13 @@ export function AnalysisJobWatcher() {
       setJob(null);
       return;
     }
-    // fix(#682 review): stop tracking a job stuck in 'running' past the window
-    // the API uses for its per-user cap. Without this the save guard outlives
-    // the server's own: the materialize endpoint stops counting a job this old
-    // (_RUNNING_JOB_WINDOW in router_analysis.py), but GET /jobs/{id} keeps
-    // reporting 'running' until the hour-long platform reaper fails it, so the
-    // Create button stayed disabled for ~50 minutes after the API would have
-    // accepted a replacement. The CTAS carries a 300s statement timeout, so a
-    // job still 'running' here is a dead worker, not slow work.
-    //
-    // Deliberately not applied to 'pending': queued work will still run, and
-    // the endpoint counts pending jobs without a time bound for that reason.
-    // This measures from enqueue while the server measures from actual start,
-    // so a job that sat in a backlog can clear here while the endpoint still
-    // counts it — that path just earns an explicit 429 instead of a dead button.
-    if (
-      status === 'running' &&
-      Date.now() - job.enqueuedAt > STALE_RUNNING_JOB_MS
-    ) {
-      setJob(null);
-      return;
-    }
+    // Only a terminal status stops tracking — deliberately no client-side
+    // staleness rule (fix(#682 review)). An elapsed-time guess is wrong in both
+    // directions: too short and a legitimately long job loses its completion
+    // notification entirely, too long and the save guard outlives the API's own
+    // cap. The endpoint applies the same rule (pending or running blocks), so
+    // the two never disagree. A dead worker is resolved by the platform's job
+    // timeout rather than guessed at here.
     if (status !== 'complete' && status !== 'failed') return;
 
     // Stable id so a re-run (StrictMode's double invoke) replaces the toast

--- a/frontend/src/components/analysis/AnalysisJobWatcher.tsx
+++ b/frontend/src/components/analysis/AnalysisJobWatcher.tsx
@@ -1,0 +1,93 @@
+import { useEffect } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useNavigate } from 'react-router';
+import { useQueryClient } from '@tanstack/react-query';
+import { toast } from 'sonner';
+import { queryKeys } from '@/lib/query-keys';
+import { useJobStatus } from '@/components/import/hooks/use-ingest';
+import { analysisAddToMap, useAnalysisJobStore } from '@/stores/analysis-job-store';
+
+/**
+ * Global notifier for a materialize-analysis job (renders nothing).
+ *
+ * Mounted in RootLayout so tracking outlives the things a long job outlives:
+ * the Analysis panel closing, navigation off the builder, and a page reload
+ * (the job id is persisted). It owns the completion notification and the
+ * catalog cache invalidation so there is exactly one of each per job.
+ */
+export function AnalysisJobWatcher() {
+  const { t } = useTranslation('builder');
+  const job = useAnalysisJobStore((s) => s.job);
+  const setJob = useAnalysisJobStore((s) => s.setJob);
+  const queryClient = useQueryClient();
+  const navigate = useNavigate();
+  // Shares its query key with the Analysis panel, so both watching costs one poll.
+  const { data, isError } = useJobStatus(job?.jobId ?? null);
+  const status = data?.status;
+
+  useEffect(() => {
+    if (!job) return;
+    if (isError) {
+      // Unreadable job (pruned by the retention sweep, or signed out) —
+      // nothing to report, and keeping it would poll forever.
+      setJob(null);
+      return;
+    }
+    if (status !== 'complete' && status !== 'failed') return;
+
+    // Stable id so a re-run (StrictMode's double invoke) replaces the toast
+    // instead of stacking a second one.
+    const toastId = `analysis-job-${job.jobId}`;
+    if (status === 'complete') {
+      queryClient.invalidateQueries({ queryKey: queryKeys.datasets.all });
+      queryClient.invalidateQueries({ queryKey: queryKeys.search.all });
+      const datasetId = data?.dataset_id;
+      const canAddToMap =
+        !!analysisAddToMap.current && analysisAddToMap.mapId === job.mapId;
+      toast.success(
+        job.title
+          ? t('analysisTools.jobCompleteNamed', {
+              defaultValue: '“{{title}}” is ready',
+              title: job.title,
+            })
+          : t('analysisTools.jobComplete', { defaultValue: 'Dataset created' }),
+        {
+          id: toastId,
+          // A long job lands when attention has moved on, so the default 4s
+          // notification is one the user is likely to miss entirely. The
+          // Toaster is configured with closeButton, so this stays until
+          // acknowledged.
+          duration: Infinity,
+          action: datasetId
+            ? {
+                label: canAddToMap
+                  ? t('analysisTools.addToMap', { defaultValue: 'Add to map' })
+                  : t('analysisTools.viewDataset', { defaultValue: 'View dataset' }),
+                onClick: () => {
+                  // Re-check: the builder may have unmounted since this toast
+                  // was raised.
+                  if (
+                    analysisAddToMap.current &&
+                    analysisAddToMap.mapId === job.mapId
+                  ) {
+                    analysisAddToMap.current(datasetId);
+                  } else {
+                    navigate(`/datasets/${datasetId}`);
+                  }
+                },
+              }
+            : undefined,
+        },
+      );
+    } else {
+      const message = data?.error_message;
+      toast.error(
+        `${t('analysisTools.jobFailed', { defaultValue: 'Analysis job failed' })}${message ? `: ${message}` : ''}`,
+        { id: toastId, duration: Infinity },
+      );
+    }
+    setJob(null);
+  }, [job, status, isError, data, queryClient, navigate, setJob, t]);
+
+  return null;
+}

--- a/frontend/src/components/analysis/AnalysisJobWatcher.tsx
+++ b/frontend/src/components/analysis/AnalysisJobWatcher.tsx
@@ -8,6 +8,9 @@ import { ApiError } from '@/api/client';
 import { useJobStatus } from '@/components/import/hooks/use-ingest';
 import { analysisAddToMap, useAnalysisJobStore } from '@/stores/analysis-job-store';
 
+/** Mirrors _RUNNING_JOB_WINDOW in backend/.../api/router_analysis.py. */
+const STALE_RUNNING_JOB_MS = 10 * 60 * 1000;
+
 /**
  * Global notifier for a materialize-analysis job (renders nothing).
  *
@@ -38,6 +41,27 @@ export function AnalysisJobWatcher() {
     if (gone) {
       // Pruned by the retention sweep, or no longer ours to read — nothing to
       // report, and keeping it would poll forever.
+      setJob(null);
+      return;
+    }
+    // fix(#682 review): stop tracking a job stuck in 'running' past the window
+    // the API uses for its per-user cap. Without this the save guard outlives
+    // the server's own: the materialize endpoint stops counting a job this old
+    // (_RUNNING_JOB_WINDOW in router_analysis.py), but GET /jobs/{id} keeps
+    // reporting 'running' until the hour-long platform reaper fails it, so the
+    // Create button stayed disabled for ~50 minutes after the API would have
+    // accepted a replacement. The CTAS carries a 300s statement timeout, so a
+    // job still 'running' here is a dead worker, not slow work.
+    //
+    // Deliberately not applied to 'pending': queued work will still run, and
+    // the endpoint counts pending jobs without a time bound for that reason.
+    // This measures from enqueue while the server measures from actual start,
+    // so a job that sat in a backlog can clear here while the endpoint still
+    // counts it — that path just earns an explicit 429 instead of a dead button.
+    if (
+      status === 'running' &&
+      Date.now() - job.enqueuedAt > STALE_RUNNING_JOB_MS
+    ) {
       setJob(null);
       return;
     }

--- a/frontend/src/components/analysis/AnalysisJobWatcher.tsx
+++ b/frontend/src/components/analysis/AnalysisJobWatcher.tsx
@@ -4,6 +4,7 @@ import { useNavigate } from 'react-router';
 import { useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
 import { queryKeys } from '@/lib/query-keys';
+import { ApiError } from '@/api/client';
 import { useJobStatus } from '@/components/import/hooks/use-ingest';
 import { analysisAddToMap, useAnalysisJobStore } from '@/stores/analysis-job-store';
 
@@ -22,14 +23,21 @@ export function AnalysisJobWatcher() {
   const queryClient = useQueryClient();
   const navigate = useNavigate();
   // Shares its query key with the Analysis panel, so both watching costs one poll.
-  const { data, isError } = useJobStatus(job?.jobId ?? null);
+  const { data, error } = useJobStatus(job?.jobId ?? null);
   const status = data?.status;
+  // fix(#682 review): only a definitive answer stops tracking. A transient 5xx
+  // or dropped connection must NOT discard the job — refetchInterval keeps
+  // polling through errors, so tracking recovers on the next good response,
+  // and the reload/navigation cases this exists for are exactly when a blip is
+  // most likely.
+  const gone =
+    error instanceof ApiError && [401, 403, 404].includes(error.status);
 
   useEffect(() => {
     if (!job) return;
-    if (isError) {
-      // Unreadable job (pruned by the retention sweep, or signed out) —
-      // nothing to report, and keeping it would poll forever.
+    if (gone) {
+      // Pruned by the retention sweep, or no longer ours to read — nothing to
+      // report, and keeping it would poll forever.
       setJob(null);
       return;
     }
@@ -87,7 +95,7 @@ export function AnalysisJobWatcher() {
       );
     }
     setJob(null);
-  }, [job, status, isError, data, queryClient, navigate, setJob, t]);
+  }, [job, status, gone, data, queryClient, navigate, setJob, t]);
 
   return null;
 }

--- a/frontend/src/components/analysis/__tests__/AnalysisJobWatcher.test.tsx
+++ b/frontend/src/components/analysis/__tests__/AnalysisJobWatcher.test.tsx
@@ -12,8 +12,14 @@ vi.mock('sonner', () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
 vi.mock('@/components/import/hooks/use-ingest', () => ({ useJobStatus: vi.fn() }));
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({
-    t: (key: string, options?: { defaultValue?: string; title?: string }) =>
-      (options?.defaultValue ?? key).replace('{{title}}', options?.title ?? ''),
+    // Interpolates every {{placeholder}} from options, not just one: the
+    // assertions below check that real values (a dataset title, a job error)
+    // reach the user, which a mock returning the raw template would fake.
+    t: (key: string, options?: Record<string, unknown>) =>
+      String(options?.defaultValue ?? key).replace(
+        /\{\{(\w+)\}\}/g,
+        (_match, name: string) => String(options?.[name] ?? ''),
+      ),
   }),
 }));
 

--- a/frontend/src/components/analysis/__tests__/AnalysisJobWatcher.test.tsx
+++ b/frontend/src/components/analysis/__tests__/AnalysisJobWatcher.test.tsx
@@ -1,0 +1,119 @@
+import { render, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { toast } from 'sonner';
+import { AnalysisJobWatcher } from '../AnalysisJobWatcher';
+import { analysisAddToMap, useAnalysisJobStore } from '@/stores/analysis-job-store';
+import { useJobStatus } from '@/components/import/hooks/use-ingest';
+
+const navigate = vi.fn();
+vi.mock('react-router', () => ({ useNavigate: () => navigate }));
+vi.mock('sonner', () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
+vi.mock('@/components/import/hooks/use-ingest', () => ({ useJobStatus: vi.fn() }));
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, options?: { defaultValue?: string; title?: string }) =>
+      (options?.defaultValue ?? key).replace('{{title}}', options?.title ?? ''),
+  }),
+}));
+
+function renderWatcher() {
+  const qc = new QueryClient();
+  return render(
+    <QueryClientProvider client={qc}>
+      <AnalysisJobWatcher />
+    </QueryClientProvider>,
+  );
+}
+
+function mockJob(data: unknown, isError = false) {
+  vi.mocked(useJobStatus).mockReturnValue({
+    data,
+    isError,
+  } as unknown as ReturnType<typeof useJobStatus>);
+}
+
+describe('AnalysisJobWatcher', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useAnalysisJobStore.setState({ job: null });
+    analysisAddToMap.current = null;
+    analysisAddToMap.mapId = null;
+  });
+
+  it('does nothing while the job is still running', () => {
+    useAnalysisJobStore.setState({ job: { jobId: 'j1', title: 'Buffered', mapId: 'm1' } });
+    mockJob({ status: 'running', dataset_id: null });
+    renderWatcher();
+    expect(toast.success).not.toHaveBeenCalled();
+    expect(useAnalysisJobStore.getState().job).not.toBeNull();
+  });
+
+  it('raises a non-expiring named toast on completion and stops tracking', async () => {
+    useAnalysisJobStore.setState({ job: { jobId: 'j1', title: 'Buffered', mapId: 'm1' } });
+    mockJob({ status: 'complete', dataset_id: 'ds9' });
+    renderWatcher();
+
+    await waitFor(() => expect(toast.success).toHaveBeenCalled());
+    const [message, options] = vi.mocked(toast.success).mock.calls[0];
+    expect(message).toBe('“Buffered” is ready');
+    // A long job lands after attention has moved on — the notification has to wait.
+    expect(options?.duration).toBe(Infinity);
+    expect(useAnalysisJobStore.getState().job).toBeNull();
+  });
+
+  it('offers Add to map only when a builder for that map is mounted', async () => {
+    const onAdd = vi.fn();
+    analysisAddToMap.current = onAdd;
+    analysisAddToMap.mapId = 'm1';
+    useAnalysisJobStore.setState({ job: { jobId: 'j1', title: 'Buffered', mapId: 'm1' } });
+    mockJob({ status: 'complete', dataset_id: 'ds9' });
+    renderWatcher();
+
+    await waitFor(() => expect(toast.success).toHaveBeenCalled());
+    const action = vi.mocked(toast.success).mock.calls[0][1]?.action as {
+      label: string;
+      onClick: () => void;
+    };
+    expect(action.label).toBe('Add to map');
+    action.onClick();
+    expect(onAdd).toHaveBeenCalledWith('ds9');
+    expect(navigate).not.toHaveBeenCalled();
+  });
+
+  it('falls back to viewing the dataset when the builder is gone', async () => {
+    analysisAddToMap.mapId = 'a-different-map';
+    useAnalysisJobStore.setState({ job: { jobId: 'j1', title: '', mapId: 'm1' } });
+    mockJob({ status: 'complete', dataset_id: 'ds9' });
+    renderWatcher();
+
+    await waitFor(() => expect(toast.success).toHaveBeenCalled());
+    expect(vi.mocked(toast.success).mock.calls[0][0]).toBe('Dataset created');
+    const action = vi.mocked(toast.success).mock.calls[0][1]?.action as {
+      label: string;
+      onClick: () => void;
+    };
+    expect(action.label).toBe('View dataset');
+    action.onClick();
+    expect(navigate).toHaveBeenCalledWith('/datasets/ds9');
+  });
+
+  it('reports failures with the job error message', async () => {
+    useAnalysisJobStore.setState({ job: { jobId: 'j1', title: 'Buffered', mapId: 'm1' } });
+    mockJob({ status: 'failed', dataset_id: null, error_message: 'no features' });
+    renderWatcher();
+
+    await waitFor(() => expect(toast.error).toHaveBeenCalled());
+    expect(vi.mocked(toast.error).mock.calls[0][0]).toContain('no features');
+    expect(useAnalysisJobStore.getState().job).toBeNull();
+  });
+
+  it('stops tracking an unreadable job instead of polling forever', async () => {
+    useAnalysisJobStore.setState({ job: { jobId: 'gone', title: 'x', mapId: null } });
+    mockJob(undefined, true);
+    renderWatcher();
+
+    await waitFor(() => expect(useAnalysisJobStore.getState().job).toBeNull());
+    expect(toast.success).not.toHaveBeenCalled();
+    expect(toast.error).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/analysis/__tests__/AnalysisJobWatcher.test.tsx
+++ b/frontend/src/components/analysis/__tests__/AnalysisJobWatcher.test.tsx
@@ -48,7 +48,7 @@ describe('AnalysisJobWatcher', () => {
   });
 
   it('does nothing while the job is still running', () => {
-    useAnalysisJobStore.setState({ job: { jobId: 'j1', title: 'Buffered', mapId: 'm1', enqueuedAt: Date.now() } });
+    useAnalysisJobStore.setState({ job: { jobId: 'j1', title: 'Buffered', mapId: 'm1' } });
     mockJob({ status: 'running', dataset_id: null });
     renderWatcher();
     expect(toast.success).not.toHaveBeenCalled();
@@ -56,7 +56,7 @@ describe('AnalysisJobWatcher', () => {
   });
 
   it('raises a non-expiring named toast on completion and stops tracking', async () => {
-    useAnalysisJobStore.setState({ job: { jobId: 'j1', title: 'Buffered', mapId: 'm1', enqueuedAt: Date.now() } });
+    useAnalysisJobStore.setState({ job: { jobId: 'j1', title: 'Buffered', mapId: 'm1' } });
     mockJob({ status: 'complete', dataset_id: 'ds9' });
     renderWatcher();
 
@@ -72,7 +72,7 @@ describe('AnalysisJobWatcher', () => {
     const onAdd = vi.fn();
     analysisAddToMap.current = onAdd;
     analysisAddToMap.mapId = 'm1';
-    useAnalysisJobStore.setState({ job: { jobId: 'j1', title: 'Buffered', mapId: 'm1', enqueuedAt: Date.now() } });
+    useAnalysisJobStore.setState({ job: { jobId: 'j1', title: 'Buffered', mapId: 'm1' } });
     mockJob({ status: 'complete', dataset_id: 'ds9' });
     renderWatcher();
 
@@ -89,7 +89,7 @@ describe('AnalysisJobWatcher', () => {
 
   it('falls back to viewing the dataset when the builder is gone', async () => {
     analysisAddToMap.mapId = 'a-different-map';
-    useAnalysisJobStore.setState({ job: { jobId: 'j1', title: '', mapId: 'm1', enqueuedAt: Date.now() } });
+    useAnalysisJobStore.setState({ job: { jobId: 'j1', title: '', mapId: 'm1' } });
     mockJob({ status: 'complete', dataset_id: 'ds9' });
     renderWatcher();
 
@@ -105,7 +105,7 @@ describe('AnalysisJobWatcher', () => {
   });
 
   it('reports failures with the job error message', async () => {
-    useAnalysisJobStore.setState({ job: { jobId: 'j1', title: 'Buffered', mapId: 'm1', enqueuedAt: Date.now() } });
+    useAnalysisJobStore.setState({ job: { jobId: 'j1', title: 'Buffered', mapId: 'm1' } });
     mockJob({ status: 'failed', dataset_id: null, error_message: 'no features' });
     renderWatcher();
 
@@ -115,7 +115,7 @@ describe('AnalysisJobWatcher', () => {
   });
 
   it('stops tracking a job that is gone instead of polling forever', async () => {
-    useAnalysisJobStore.setState({ job: { jobId: 'gone', title: 'x', mapId: null, enqueuedAt: Date.now() } });
+    useAnalysisJobStore.setState({ job: { jobId: 'gone', title: 'x', mapId: null } });
     mockJob(undefined, new ApiError('Not Found', 404));
     renderWatcher();
 
@@ -127,7 +127,7 @@ describe('AnalysisJobWatcher', () => {
   it('keeps tracking through a transient failure (fix(#682) review)', () => {
     // A 5xx or dropped connection after a reload must not discard the job:
     // polling continues, so tracking recovers on the next good response.
-    useAnalysisJobStore.setState({ job: { jobId: 'j1', title: 'x', mapId: null, enqueuedAt: Date.now() } });
+    useAnalysisJobStore.setState({ job: { jobId: 'j1', title: 'x', mapId: null } });
     mockJob(undefined, new ApiError('Service Unavailable', 503));
     renderWatcher();
 
@@ -135,39 +135,16 @@ describe('AnalysisJobWatcher', () => {
     expect(toast.error).not.toHaveBeenCalled();
   });
 
-  it('stops tracking a job stuck running past the cap window (fix(#682) review)', async () => {
-    // The API stops counting a 'running' job this old, but GET /jobs/{id}
-    // reports 'running' until the hour-long reaper — so without this the save
-    // guard outlives the server's own cap by ~50 minutes.
-    useAnalysisJobStore.setState({
-      job: {
-        jobId: 'zombie',
-        title: 'x',
-        mapId: null,
-        enqueuedAt: Date.now() - 11 * 60 * 1000,
-      },
-    });
-    mockJob({ status: 'running' });
-    renderWatcher();
-
-    await waitFor(() => expect(useAnalysisJobStore.getState().job).toBeNull());
-    // Silent: nothing completed and nothing is known to have failed.
-    expect(toast.success).not.toHaveBeenCalled();
-    expect(toast.error).not.toHaveBeenCalled();
-  });
-
-  it('keeps tracking a running job inside the window', () => {
-    useAnalysisJobStore.setState({
-      job: {
-        jobId: 'j1',
-        title: 'x',
-        mapId: null,
-        enqueuedAt: Date.now() - 60 * 1000,
-      },
-    });
+  it('keeps tracking a long-running job — no client staleness rule (fix(#682) review)', () => {
+    // Deliberately mirrors the API's cap, which also has no staleness window.
+    // Dropping a job on elapsed time loses its completion notification for
+    // good, and the endpoint would still refuse a replacement anyway.
+    useAnalysisJobStore.setState({ job: { jobId: 'slow', title: 'x', mapId: null } });
     mockJob({ status: 'running' });
     renderWatcher();
 
     expect(useAnalysisJobStore.getState().job).not.toBeNull();
+    expect(toast.success).not.toHaveBeenCalled();
+    expect(toast.error).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/components/analysis/__tests__/AnalysisJobWatcher.test.tsx
+++ b/frontend/src/components/analysis/__tests__/AnalysisJobWatcher.test.tsx
@@ -48,7 +48,7 @@ describe('AnalysisJobWatcher', () => {
   });
 
   it('does nothing while the job is still running', () => {
-    useAnalysisJobStore.setState({ job: { jobId: 'j1', title: 'Buffered', mapId: 'm1' } });
+    useAnalysisJobStore.setState({ job: { jobId: 'j1', title: 'Buffered', mapId: 'm1', enqueuedAt: Date.now() } });
     mockJob({ status: 'running', dataset_id: null });
     renderWatcher();
     expect(toast.success).not.toHaveBeenCalled();
@@ -56,7 +56,7 @@ describe('AnalysisJobWatcher', () => {
   });
 
   it('raises a non-expiring named toast on completion and stops tracking', async () => {
-    useAnalysisJobStore.setState({ job: { jobId: 'j1', title: 'Buffered', mapId: 'm1' } });
+    useAnalysisJobStore.setState({ job: { jobId: 'j1', title: 'Buffered', mapId: 'm1', enqueuedAt: Date.now() } });
     mockJob({ status: 'complete', dataset_id: 'ds9' });
     renderWatcher();
 
@@ -72,7 +72,7 @@ describe('AnalysisJobWatcher', () => {
     const onAdd = vi.fn();
     analysisAddToMap.current = onAdd;
     analysisAddToMap.mapId = 'm1';
-    useAnalysisJobStore.setState({ job: { jobId: 'j1', title: 'Buffered', mapId: 'm1' } });
+    useAnalysisJobStore.setState({ job: { jobId: 'j1', title: 'Buffered', mapId: 'm1', enqueuedAt: Date.now() } });
     mockJob({ status: 'complete', dataset_id: 'ds9' });
     renderWatcher();
 
@@ -89,7 +89,7 @@ describe('AnalysisJobWatcher', () => {
 
   it('falls back to viewing the dataset when the builder is gone', async () => {
     analysisAddToMap.mapId = 'a-different-map';
-    useAnalysisJobStore.setState({ job: { jobId: 'j1', title: '', mapId: 'm1' } });
+    useAnalysisJobStore.setState({ job: { jobId: 'j1', title: '', mapId: 'm1', enqueuedAt: Date.now() } });
     mockJob({ status: 'complete', dataset_id: 'ds9' });
     renderWatcher();
 
@@ -105,7 +105,7 @@ describe('AnalysisJobWatcher', () => {
   });
 
   it('reports failures with the job error message', async () => {
-    useAnalysisJobStore.setState({ job: { jobId: 'j1', title: 'Buffered', mapId: 'm1' } });
+    useAnalysisJobStore.setState({ job: { jobId: 'j1', title: 'Buffered', mapId: 'm1', enqueuedAt: Date.now() } });
     mockJob({ status: 'failed', dataset_id: null, error_message: 'no features' });
     renderWatcher();
 
@@ -115,7 +115,7 @@ describe('AnalysisJobWatcher', () => {
   });
 
   it('stops tracking a job that is gone instead of polling forever', async () => {
-    useAnalysisJobStore.setState({ job: { jobId: 'gone', title: 'x', mapId: null } });
+    useAnalysisJobStore.setState({ job: { jobId: 'gone', title: 'x', mapId: null, enqueuedAt: Date.now() } });
     mockJob(undefined, new ApiError('Not Found', 404));
     renderWatcher();
 
@@ -127,11 +127,47 @@ describe('AnalysisJobWatcher', () => {
   it('keeps tracking through a transient failure (fix(#682) review)', () => {
     // A 5xx or dropped connection after a reload must not discard the job:
     // polling continues, so tracking recovers on the next good response.
-    useAnalysisJobStore.setState({ job: { jobId: 'j1', title: 'x', mapId: null } });
+    useAnalysisJobStore.setState({ job: { jobId: 'j1', title: 'x', mapId: null, enqueuedAt: Date.now() } });
     mockJob(undefined, new ApiError('Service Unavailable', 503));
     renderWatcher();
 
     expect(useAnalysisJobStore.getState().job).not.toBeNull();
     expect(toast.error).not.toHaveBeenCalled();
+  });
+
+  it('stops tracking a job stuck running past the cap window (fix(#682) review)', async () => {
+    // The API stops counting a 'running' job this old, but GET /jobs/{id}
+    // reports 'running' until the hour-long reaper — so without this the save
+    // guard outlives the server's own cap by ~50 minutes.
+    useAnalysisJobStore.setState({
+      job: {
+        jobId: 'zombie',
+        title: 'x',
+        mapId: null,
+        enqueuedAt: Date.now() - 11 * 60 * 1000,
+      },
+    });
+    mockJob({ status: 'running' });
+    renderWatcher();
+
+    await waitFor(() => expect(useAnalysisJobStore.getState().job).toBeNull());
+    // Silent: nothing completed and nothing is known to have failed.
+    expect(toast.success).not.toHaveBeenCalled();
+    expect(toast.error).not.toHaveBeenCalled();
+  });
+
+  it('keeps tracking a running job inside the window', () => {
+    useAnalysisJobStore.setState({
+      job: {
+        jobId: 'j1',
+        title: 'x',
+        mapId: null,
+        enqueuedAt: Date.now() - 60 * 1000,
+      },
+    });
+    mockJob({ status: 'running' });
+    renderWatcher();
+
+    expect(useAnalysisJobStore.getState().job).not.toBeNull();
   });
 });

--- a/frontend/src/components/analysis/__tests__/AnalysisJobWatcher.test.tsx
+++ b/frontend/src/components/analysis/__tests__/AnalysisJobWatcher.test.tsx
@@ -4,6 +4,7 @@ import { toast } from 'sonner';
 import { AnalysisJobWatcher } from '../AnalysisJobWatcher';
 import { analysisAddToMap, useAnalysisJobStore } from '@/stores/analysis-job-store';
 import { useJobStatus } from '@/components/import/hooks/use-ingest';
+import { ApiError } from '@/api/client';
 
 const navigate = vi.fn();
 vi.mock('react-router', () => ({ useNavigate: () => navigate }));
@@ -25,10 +26,10 @@ function renderWatcher() {
   );
 }
 
-function mockJob(data: unknown, isError = false) {
+function mockJob(data: unknown, error: unknown = null) {
   vi.mocked(useJobStatus).mockReturnValue({
     data,
-    isError,
+    error,
   } as unknown as ReturnType<typeof useJobStatus>);
 }
 
@@ -107,13 +108,24 @@ describe('AnalysisJobWatcher', () => {
     expect(useAnalysisJobStore.getState().job).toBeNull();
   });
 
-  it('stops tracking an unreadable job instead of polling forever', async () => {
+  it('stops tracking a job that is gone instead of polling forever', async () => {
     useAnalysisJobStore.setState({ job: { jobId: 'gone', title: 'x', mapId: null } });
-    mockJob(undefined, true);
+    mockJob(undefined, new ApiError('Not Found', 404));
     renderWatcher();
 
     await waitFor(() => expect(useAnalysisJobStore.getState().job).toBeNull());
     expect(toast.success).not.toHaveBeenCalled();
+    expect(toast.error).not.toHaveBeenCalled();
+  });
+
+  it('keeps tracking through a transient failure (fix(#682) review)', () => {
+    // A 5xx or dropped connection after a reload must not discard the job:
+    // polling continues, so tracking recovers on the next good response.
+    useAnalysisJobStore.setState({ job: { jobId: 'j1', title: 'x', mapId: null } });
+    mockJob(undefined, new ApiError('Service Unavailable', 503));
+    renderWatcher();
+
+    expect(useAnalysisJobStore.getState().job).not.toBeNull();
     expect(toast.error).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/components/builder/AnalysisPanel.tsx
+++ b/frontend/src/components/builder/AnalysisPanel.tsx
@@ -43,9 +43,10 @@ interface AnalysisPanelProps {
    *  preview ("Save as dataset"). Applied on mount only — BuilderRail keys the
    *  panel on the handoff so a new one remounts it. */
   prefill?: EphemeralAnalysisHandoff;
-  /** Notifies the page of materialize-job changes so completion/failure can
-   *  toast (and invalidate queries) even after this panel unmounts. */
-  onAnalysisJobChange?: (jobId: string | null) => void;
+  /** Notifies the app-level watcher of materialize-job changes so
+   *  completion/failure still reports after this panel unmounts. The title
+   *  rides along so a notification arriving minutes later has context. */
+  onAnalysisJobChange?: (jobId: string | null, title?: string) => void;
 }
 
 /**
@@ -246,9 +247,10 @@ export function AnalysisPanel({
     mutationFn: async () => {
       const datasetId = selectedLayer?.dataset_id;
       if (!datasetId) throw new Error('No layer selected');
+      const title = outputTitle.trim();
       const result = await materializeAnalysis(datasetId, {
         operation,
-        title: outputTitle.trim(),
+        title,
         ...(operation === 'buffer' ? { distance_meters: distanceValue } : {}),
         ...(operation === 'clip' && mask ? { mask } : {}),
         ...(operation === 'clip' && !mask && maskLayer?.dataset_id
@@ -262,7 +264,7 @@ export function AnalysisPanel({
       // suppresses observer callbacks once the component unmounts, and the
       // whole point of page-level tracking is surviving an unmount while the
       // request is in flight.
-      onAnalysisJobChange?.(result.job_id);
+      onAnalysisJobChange?.(result.job_id, title);
       return result;
     },
     onSuccess: (result) => setJobId(result.job_id),
@@ -572,7 +574,13 @@ export function AnalysisPanel({
                 ? `${t('analysisTools.jobFailed', { defaultValue: 'Analysis job failed' })}${job.error_message ? `: ${job.error_message}` : ''}`
                 : job.status === 'complete'
                   ? t('analysisTools.jobComplete', { defaultValue: 'Dataset created' })
-                  : t('analysisTools.jobRunning', { defaultValue: 'Creating dataset…' })}
+                  : job.current_step === 'registering'
+                    ? t('analysisTools.jobSaving', {
+                        defaultValue: 'Saving the dataset…',
+                      })
+                    : t('analysisTools.jobRunning', {
+                        defaultValue: 'Creating dataset…',
+                      })}
             </p>
           )}
           {job?.status === 'complete' && !!job.dataset_id && layerActions && (

--- a/frontend/src/components/builder/AnalysisPanel.tsx
+++ b/frontend/src/components/builder/AnalysisPanel.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useMutation } from '@tanstack/react-query';
 import { TerraDraw, TerraDrawPolygonMode } from 'terra-draw';
 import { TerraDrawMapLibreGLAdapter } from 'terra-draw-maplibre-gl-adapter';
 import type { Map as MaplibreMap } from 'maplibre-gl';
@@ -16,7 +16,6 @@ import {
   SelectValue,
 } from '@/components/ui/select';
 import { MAP_COLORS } from '@/lib/map-colors';
-import { queryKeys } from '@/lib/query-keys';
 import { materializeAnalysis, previewAnalysis } from '@/api/analysis';
 import { useDataset } from '@/components/dataset/hooks/use-dataset';
 import { useJobStatus } from '@/components/import/hooks/use-ingest';
@@ -25,8 +24,9 @@ import type { EphemeralAnalysisHandoff } from '@/components/builder/hooks/use-ep
 import type { AnalysisOperation, MapLayerResponse } from '@/types/api';
 
 const MAX_BUFFER_METERS = 100_000;
-// shadcn Select items can't carry an empty value — sentinel for "no grouping".
+// shadcn Select items can't carry an empty value — sentinels for "none".
 const BY_FIELD_NONE = '__none__';
+const MASK_LAYER_NONE = '__none__';
 
 interface AnalysisPanelProps {
   layers: MapLayerResponse[];
@@ -43,6 +43,9 @@ interface AnalysisPanelProps {
    *  preview ("Save as dataset"). Applied on mount only — BuilderRail keys the
    *  panel on the handoff so a new one remounts it. */
   prefill?: EphemeralAnalysisHandoff;
+  /** Notifies the page of materialize-job changes so completion/failure can
+   *  toast (and invalidate queries) even after this panel unmounts. */
+  onAnalysisJobChange?: (jobId: string | null) => void;
 }
 
 /**
@@ -58,6 +61,7 @@ export function AnalysisPanel({
   hasPreview,
   layerActions,
   prefill,
+  onAnalysisJobChange,
 }: AnalysisPanelProps) {
   const { t, i18n } = useTranslation('builder');
   const firstEligibleId =
@@ -75,6 +79,8 @@ export function AnalysisPanel({
   );
   const [mask, setMask] = useState<GeoJSON.Polygon | null>(null);
   const [isDrawing, setIsDrawing] = useState(false);
+  // Layer-sourced clip mask; mutually exclusive with a drawn mask.
+  const [maskLayerId, setMaskLayerId] = useState(MASK_LAYER_NONE);
   const [byField, setByField] = useState(BY_FIELD_NONE);
   // A chat handoff lands on the save form — suggest a title so its primary
   // button isn't silently disabled for want of one.
@@ -90,11 +96,19 @@ export function AnalysisPanel({
   });
   const [jobId, setJobId] = useState<string | null>(null);
   const drawRef = useRef<TerraDraw | null>(null);
+  // Shares its TanStack query with the page-level tracker (same key), so
+  // there is exactly one 2s poll loop however many components watch the job.
   const job = useJobStatus(jobId).data;
-  const queryClient = useQueryClient();
 
   const datasetLayers = layers.filter((l) => !!l.dataset_id && !l.is_dem);
   const selectedLayer = datasetLayers.find((l) => l.id === layerId);
+  // Candidate clip-mask layers: any other dataset layer (the server rejects
+  // non-polygon mask datasets with a clear 422).
+  const maskLayerOptions = datasetLayers.filter((l) => l.id !== layerId);
+  const maskLayer =
+    maskLayerId !== MASK_LAYER_NONE
+      ? maskLayerOptions.find((l) => l.id === maskLayerId)
+      : undefined;
   // Only fetched while dissolve is selected (enabled gates on a non-empty id).
   const datasetDetail = useDataset(
     operation === 'dissolve' ? (selectedLayer?.dataset_id ?? '') : '',
@@ -103,16 +117,6 @@ export function AnalysisPanel({
     .map((c) => c.name)
     // The dissolve output already emits a generated source_count column.
     .filter((name) => name !== 'source_count');
-
-  // fix(#438)-style gap: the materialized dataset was missing from Add-data
-  // search until the stale queries refetched on their own.
-  const jobStatus = job?.status;
-  useEffect(() => {
-    if (jobStatus === 'complete') {
-      queryClient.invalidateQueries({ queryKey: queryKeys.datasets.all });
-      queryClient.invalidateQueries({ queryKey: queryKeys.search.all });
-    }
-  }, [jobStatus, queryClient]);
 
   const stopDrawing = useCallback(() => {
     drawRef.current?.stop();
@@ -126,6 +130,8 @@ export function AnalysisPanel({
   const startDrawing = useCallback(() => {
     const map = mapInstanceRef?.current;
     if (!map || drawRef.current) return;
+    // Drawing replaces a layer-sourced mask.
+    setMaskLayerId(MASK_LAYER_NONE);
     // Direct TerraDraw instantiation (BboxMapPicker precedent) — the feature
     // editing drawing-store is dataset-edit-specific and not reused here.
     const td = new TerraDraw({
@@ -177,6 +183,9 @@ export function AnalysisPanel({
         operation: operation as Exclude<AnalysisOperation, 'dissolve'>,
         ...(operation === 'buffer' ? { distance_meters: distanceValue } : {}),
         ...(operation === 'clip' && mask ? { mask } : {}),
+        ...(operation === 'clip' && !mask && maskLayer?.dataset_id
+          ? { mask_dataset_id: maskLayer.dataset_id }
+          : {}),
       });
     },
     onSuccess: (result) => {
@@ -229,15 +238,24 @@ export function AnalysisPanel({
     mutationFn: async () => {
       const datasetId = selectedLayer?.dataset_id;
       if (!datasetId) throw new Error('No layer selected');
-      return materializeAnalysis(datasetId, {
+      const result = await materializeAnalysis(datasetId, {
         operation,
         title: outputTitle.trim(),
         ...(operation === 'buffer' ? { distance_meters: distanceValue } : {}),
         ...(operation === 'clip' && mask ? { mask } : {}),
+        ...(operation === 'clip' && !mask && maskLayer?.dataset_id
+          ? { mask_dataset_id: maskLayer.dataset_id }
+          : {}),
         ...(operation === 'dissolve' && byField !== BY_FIELD_NONE
           ? { by_field: byField }
           : {}),
       });
+      // Notify the page from inside the mutationFn, NOT onSuccess: TanStack
+      // suppresses observer callbacks once the component unmounts, and the
+      // whole point of page-level tracking is surviving an unmount while the
+      // request is in flight.
+      onAnalysisJobChange?.(result.job_id);
+      return result;
     },
     onSuccess: (result) => setJobId(result.job_id),
     onError: (error: Error) => {
@@ -250,7 +268,7 @@ export function AnalysisPanel({
 
   const paramsValid =
     (operation !== 'buffer' || distanceValid) &&
-    (operation !== 'clip' || !!mask);
+    (operation !== 'clip' || !!mask || !!maskLayer);
   const canRun =
     !!selectedLayer?.dataset_id &&
     !previewMutation.isPending &&
@@ -283,8 +301,10 @@ export function AnalysisPanel({
         </Label>
         <Select
           value={layerId}
-          onValueChange={(id) => {
-            setLayerId(id);
+          onValueChange={(v) => {
+            setLayerId(v);
+            // A mask layer can't clip itself.
+            if (v === maskLayerId) setMaskLayerId(MASK_LAYER_NONE);
             // fix(#680): a group-by column chosen for one dataset must not
             // carry to another — it may not exist there (422 from the API) or
             // silently group by a same-named field.
@@ -401,7 +421,7 @@ export function AnalysisPanel({
         </div>
       )}
 
-      {operation === 'clip' && (
+      {operation === 'clip' && maskLayer == null && (
         <div className="space-y-1.5">
           {/* Exactly one of the three buttons below renders at a time, so
               they can share the id this label points at. */}
@@ -457,6 +477,43 @@ export function AnalysisPanel({
         </div>
       )}
 
+      {operation === 'clip' && (
+        <div className="space-y-1.5">
+          <Label className="text-xs" htmlFor="analysis-mask-layer">
+            {t('analysisTools.clipLayerLabel', {
+              defaultValue: 'Or clip to a layer',
+            })}
+          </Label>
+          <Select
+            value={maskLayerId}
+            onValueChange={(v) => {
+              setMaskLayerId(v);
+              if (v !== MASK_LAYER_NONE) {
+                // A layer mask replaces a drawn one.
+                setMask(null);
+                stopDrawing();
+              }
+            }}
+          >
+            <SelectTrigger id="analysis-mask-layer" className="w-full">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value={MASK_LAYER_NONE}>
+                {t('analysisTools.clipLayerNone', {
+                  defaultValue: 'None — draw on the map',
+                })}
+              </SelectItem>
+              {maskLayerOptions.map((l) => (
+                <SelectItem key={l.id} value={l.id}>
+                  {l.display_name ?? l.dataset_name ?? l.id}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+      )}
+
       <div className="mt-auto flex flex-col gap-2 pt-1">
         {operation !== 'dissolve' && (
           <Button onClick={() => previewMutation.mutate()} disabled={!canRun}>
@@ -490,6 +547,7 @@ export function AnalysisPanel({
             className="w-full"
             onClick={() => {
               setJobId(null);
+              onAnalysisJobChange?.(null);
               materializeMutation.mutate();
             }}
             disabled={!canSave}

--- a/frontend/src/components/builder/AnalysisPanel.tsx
+++ b/frontend/src/components/builder/AnalysisPanel.tsx
@@ -19,6 +19,7 @@ import { MAP_COLORS } from '@/lib/map-colors';
 import { materializeAnalysis, previewAnalysis } from '@/api/analysis';
 import { useDataset } from '@/components/dataset/hooks/use-dataset';
 import { useJobStatus } from '@/components/import/hooks/use-ingest';
+import { useAnalysisJobStore } from '@/stores/analysis-job-store';
 import type { LayerActions } from '@/components/builder/ChatPanel';
 import type { EphemeralAnalysisHandoff } from '@/components/builder/hooks/use-ephemeral-layers';
 import type { AnalysisOperation, MapLayerResponse } from '@/types/api';
@@ -104,6 +105,9 @@ export function AnalysisPanel({
   // Shares its TanStack query with the page-level tracker (same key), so
   // there is exactly one 2s poll loop however many components watch the job.
   const job = useJobStatus(jobId).data;
+  // AnalysisJobWatcher clears this on any terminal status, so a tracked job
+  // is by definition still in flight.
+  const analysisJobRunning = useAnalysisJobStore((s) => !!s.job);
 
   const datasetLayers = layers.filter((l) => !!l.dataset_id && !l.is_dem);
   const selectedLayer = datasetLayers.find((l) => l.id === layerId);
@@ -287,6 +291,9 @@ export function AnalysisPanel({
   const canSave =
     !!selectedLayer?.dataset_id &&
     !materializeMutation.isPending &&
+    // The API allows one active analysis job per user; reflect that instead of
+    // letting the click earn a 429.
+    !analysisJobRunning &&
     paramsValid &&
     outputTitle.trim().length > 0;
 
@@ -558,8 +565,12 @@ export function AnalysisPanel({
             variant="secondary"
             className="w-full"
             onClick={() => {
+              // fix(#682 review): reset only this panel's local status line.
+              // Clearing the GLOBAL tracking here would orphan a job that is
+              // still running (the server then 429s the replacement), losing
+              // the original job's completion notification for good — the
+              // mutation replaces the tracked job on success instead.
               setJobId(null);
-              onAnalysisJobChange?.(null);
               materializeMutation.mutate();
             }}
             disabled={!canSave}

--- a/frontend/src/components/builder/AnalysisPanel.tsx
+++ b/frontend/src/components/builder/AnalysisPanel.tsx
@@ -91,7 +91,11 @@ export function AnalysisPanel({
     const opLabel =
       prefill.operation === 'buffer'
         ? t('analysisTools.opBuffer', { defaultValue: 'Buffer' })
-        : t('analysisTools.opCentroid', { defaultValue: 'Centroids' });
+        : prefill.operation === 'centroid'
+          ? t('analysisTools.opCentroid', { defaultValue: 'Centroids' })
+          : prefill.operation === 'clip'
+            ? t('analysisTools.opClip', { defaultValue: 'Clip' })
+            : t('analysisTools.opDissolve', { defaultValue: 'Dissolve' });
     return [base, opLabel].filter(Boolean).join(' — ');
   });
   const [jobId, setJobId] = useState<string | null>(null);
@@ -215,7 +219,11 @@ export function AnalysisPanel({
         toast.info(
           total != null
             ? t('analysisTools.truncatedNoticeTotal', {
-                defaultValue: 'Showing the first {{count}} of {{total}} features',
+                // fix(#680 review): "source features" — the total is the
+                // source dataset's COUNT(*), which can exceed the number of
+                // rows that produce output (NULL/EMPTY geometries).
+                defaultValue:
+                  'Showing the first {{count}} of {{total}} source features',
                 count: result.feature_count,
                 total: total.toLocaleString(i18n.language),
               })
@@ -247,7 +255,7 @@ export function AnalysisPanel({
           ? { mask_dataset_id: maskLayer.dataset_id }
           : {}),
         ...(operation === 'dissolve' && byField !== BY_FIELD_NONE
-          ? { by_field: byField }
+          ? { by_field: byField.replace(/^col:/, '') }
           : {}),
       });
       // Notify the page from inside the mutationFn, NOT onSuccess: TanStack
@@ -368,7 +376,7 @@ export function AnalysisPanel({
           <p className="text-xs text-muted-foreground">
             {t('analysisTools.dissolveHint', {
               defaultValue:
-                'Dissolve merges features into one geometry per group; run it with Create dataset',
+                'Dissolve merges features into one geometry per group; only the group field is carried over. Run it with Create dataset',
             })}
           </p>
         )}
@@ -392,7 +400,9 @@ export function AnalysisPanel({
                 })}
               </SelectItem>
               {byFieldColumns.map((name) => (
-                <SelectItem key={name} value={name}>
+                // fix(#680 review): 'col:' prefix keeps a real column named
+                // '__none__' from colliding with the no-grouping sentinel.
+                <SelectItem key={name} value={`col:${name}`}>
                   {name}
                 </SelectItem>
               ))}

--- a/frontend/src/components/builder/BuilderRail.tsx
+++ b/frontend/src/components/builder/BuilderRail.tsx
@@ -106,6 +106,8 @@ interface BuilderRailProps {
   /** feat(#675): chat-preview handoff — keys a remount of AnalysisPanel so the
    *  form initializes from it. The nonce distinguishes successive handoffs. */
   analysisPrefill?: (EphemeralAnalysisHandoff & { nonce: number }) | null;
+  /** Page-level materialize-job tracking (toast survives panel close). */
+  onAnalysisJobChange?: (jobId: string | null) => void;
   /** Phase 1135 AI-05: optional viewport context passed through to ChatPanel for
    *  viewport-aware suggestion chips. Purely additive — omitting this prop has no effect. */
   viewport?: ViewportContext;
@@ -127,6 +129,7 @@ export function BuilderRail({
   onClearPreview,
   hasPreview,
   analysisPrefill,
+  onAnalysisJobChange,
   viewport,
   onMarkDirty,
   showRail = true,
@@ -284,6 +287,7 @@ export function BuilderRail({
                     hasPreview={hasPreview}
                     layerActions={layerActions}
                     prefill={analysisPrefill ?? undefined}
+                    onAnalysisJobChange={onAnalysisJobChange}
                   />
                 </Suspense>
               </LazyLoadErrorBoundary>

--- a/frontend/src/components/builder/BuilderRail.tsx
+++ b/frontend/src/components/builder/BuilderRail.tsx
@@ -4,6 +4,7 @@ import { FileText, History, Sparkles, ChevronRight, Loader2, BotOff, FlaskConica
 import { Link } from 'react-router';
 import { LazyLoadErrorBoundary } from '@/components/error/LazyLoadErrorBoundary';
 import { cn } from '@/lib/utils';
+import { useAnalysisJobStore } from '@/stores/analysis-job-store';
 import { Button } from '@/components/ui/button';
 import type { Map as MaplibreMap } from 'maplibre-gl';
 import type { MapLayerResponse } from '@/types/api';
@@ -135,6 +136,9 @@ export function BuilderRail({
   showRail = true,
 }: BuilderRailProps) {
   const { t } = useTranslation('builder');
+  // AnalysisJobWatcher clears the tracked job on any terminal status, so a
+  // tracked job is by definition still in flight.
+  const analysisJobRunning = useAnalysisJobStore((s) => !!s.job);
 
   const togglePanel = useCallback((panel: RailPanel) => {
     onPanelChange(activePanel === panel ? null : panel);
@@ -187,6 +191,11 @@ export function BuilderRail({
               title={btn.label}
               aria-label={btn.label}
               aria-pressed={activePanel === btn.id}
+              // feat(#682): the only ambient signal that a materialize job is
+              // still running once the panel is closed — the completion toast
+              // fires at the END, so without this the rail says nothing for up
+              // to five minutes.
+              aria-busy={btn.id === 'analysis' && analysisJobRunning}
               className={cn(
                 'relative flex items-center justify-center h-8 w-8 rounded-md transition-colors',
                 btn.disabled
@@ -196,7 +205,11 @@ export function BuilderRail({
                     : 'cursor-pointer text-muted-foreground hover:bg-accent hover:text-foreground',
               )}
             >
-              <btn.icon className="h-4 w-4" />
+              {btn.id === 'analysis' && analysisJobRunning ? (
+                <Loader2 className="h-4 w-4 animate-spin" />
+              ) : (
+                <btn.icon className="h-4 w-4" />
+              )}
               {/* MAP-22: presence dot — non-whitespace notes render a 6px primary-color dot
                   at the button's top-right corner. aria-label keeps the dot accessible.
                   No animation (static state indicator per UI-SPEC). */}

--- a/frontend/src/components/builder/__tests__/AnalysisPanel.test.tsx
+++ b/frontend/src/components/builder/__tests__/AnalysisPanel.test.tsx
@@ -4,6 +4,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render } from '@/test/test-utils';
 import { AnalysisPanel } from '../AnalysisPanel';
 import { materializeAnalysis, previewAnalysis } from '@/api/analysis';
+import { useAnalysisJobStore } from '@/stores/analysis-job-store';
 import type { MapLayerResponse } from '@/types/api';
 
 // Radix Select needs pointer-capture APIs jsdom lacks (DataDrivenStyleEditor
@@ -92,6 +93,8 @@ function renderPanel(
 }
 
 describe('AnalysisPanel', () => {
+  beforeEach(() => useAnalysisJobStore.setState({ job: null }));
+
   it('shows a hint when no dataset layers are available', () => {
     renderPanel([groupLayer]);
     expect(
@@ -195,6 +198,20 @@ describe('AnalysisPanel', () => {
     await waitFor(() =>
       expect(onAnalysisJobChange).toHaveBeenCalledWith('job1', 'Buffered parcels'),
     );
+  });
+
+  it('blocks a second Create while an earlier job is still running', () => {
+    // fix(#682 review): the API allows one active analysis job per user.
+    // Clicking through would 429 AND orphan the running job's notification.
+    useAnalysisJobStore.setState({
+      job: { jobId: 'j-earlier', title: 'Earlier', mapId: 'm1' },
+    });
+    renderPanel([datasetLayer]);
+
+    fireEvent.change(screen.getByLabelText('New dataset name'), {
+      target: { value: 'Second run' },
+    });
+    expect(screen.getByRole('button', { name: 'Create dataset' })).toBeDisabled();
   });
 
   it('sends mask_dataset_id when clipping to a layer', async () => {

--- a/frontend/src/components/builder/__tests__/AnalysisPanel.test.tsx
+++ b/frontend/src/components/builder/__tests__/AnalysisPanel.test.tsx
@@ -204,12 +204,7 @@ describe('AnalysisPanel', () => {
     // fix(#682 review): the API allows one active analysis job per user.
     // Clicking through would 429 AND orphan the running job's notification.
     useAnalysisJobStore.setState({
-      job: {
-        jobId: 'j-earlier',
-        title: 'Earlier',
-        mapId: 'm1',
-        enqueuedAt: Date.now(),
-      },
+      job: { jobId: 'j-earlier', title: 'Earlier', mapId: 'm1' },
     });
     renderPanel([datasetLayer]);
 

--- a/frontend/src/components/builder/__tests__/AnalysisPanel.test.tsx
+++ b/frontend/src/components/builder/__tests__/AnalysisPanel.test.tsx
@@ -183,7 +183,7 @@ describe('AnalysisPanel', () => {
     );
   });
 
-  it('notifies the page of the materialize job id', async () => {
+  it('notifies the watcher of the materialize job id and title', async () => {
     const onAnalysisJobChange = vi.fn();
     renderPanel([datasetLayer], { onAnalysisJobChange });
 
@@ -193,7 +193,7 @@ describe('AnalysisPanel', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Create dataset' }));
 
     await waitFor(() =>
-      expect(onAnalysisJobChange).toHaveBeenCalledWith('job1'),
+      expect(onAnalysisJobChange).toHaveBeenCalledWith('job1', 'Buffered parcels'),
     );
   });
 

--- a/frontend/src/components/builder/__tests__/AnalysisPanel.test.tsx
+++ b/frontend/src/components/builder/__tests__/AnalysisPanel.test.tsx
@@ -204,7 +204,12 @@ describe('AnalysisPanel', () => {
     // fix(#682 review): the API allows one active analysis job per user.
     // Clicking through would 429 AND orphan the running job's notification.
     useAnalysisJobStore.setState({
-      job: { jobId: 'j-earlier', title: 'Earlier', mapId: 'm1' },
+      job: {
+        jobId: 'j-earlier',
+        title: 'Earlier',
+        mapId: 'm1',
+        enqueuedAt: Date.now(),
+      },
     });
     renderPanel([datasetLayer]);
 

--- a/frontend/src/components/builder/__tests__/AnalysisPanel.test.tsx
+++ b/frontend/src/components/builder/__tests__/AnalysisPanel.test.tsx
@@ -183,6 +183,42 @@ describe('AnalysisPanel', () => {
     );
   });
 
+  it('notifies the page of the materialize job id', async () => {
+    const onAnalysisJobChange = vi.fn();
+    renderPanel([datasetLayer], { onAnalysisJobChange });
+
+    fireEvent.change(screen.getByLabelText('New dataset name'), {
+      target: { value: 'Buffered parcels' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Create dataset' }));
+
+    await waitFor(() =>
+      expect(onAnalysisJobChange).toHaveBeenCalledWith('job1'),
+    );
+  });
+
+  it('sends mask_dataset_id when clipping to a layer', async () => {
+    const user = userEvent.setup();
+    renderPanel([datasetLayer, datasetLayer2]);
+
+    // Combobox order: layer, operation.
+    await user.click(screen.getAllByRole('combobox')[1]);
+    await user.click(await screen.findByRole('option', { name: 'Clip' }));
+
+    // Mask-layer select excludes the source layer itself.
+    await user.click(screen.getAllByRole('combobox')[2]);
+    expect(screen.queryByRole('option', { name: 'Parcels' })).toBeNull();
+    await user.click(await screen.findByRole('option', { name: 'Roads' }));
+
+    fireEvent.click(screen.getByRole('button', { name: 'Preview' }));
+    await waitFor(() =>
+      expect(previewAnalysis).toHaveBeenCalledWith('ds1', {
+        operation: 'clip',
+        mask_dataset_id: 'ds2',
+      }),
+    );
+  });
+
   it('sends by_field when a dissolve group column is chosen', async () => {
     const user = userEvent.setup();
     renderPanel([datasetLayer]);

--- a/frontend/src/i18n/locales/de/builder.json
+++ b/frontend/src/i18n/locales/de/builder.json
@@ -961,7 +961,9 @@
     "addToMap": "Zur Karte hinzufügen",
     "byFieldLabel": "Nach Feld gruppieren (optional)",
     "byFieldNone": "Keine Gruppierung — alles zusammenführen",
-    "truncatedNoticeTotal": "Die ersten {{count}} von {{total}} Features werden angezeigt"
+    "truncatedNoticeTotal": "Die ersten {{count}} von {{total}} Features werden angezeigt",
+    "clipLayerLabel": "Oder an einer Ebene zuschneiden",
+    "clipLayerNone": "Keine — auf der Karte zeichnen"
   },
   "attributeForm": {
     "titleEdit": "Feature-Attribute bearbeiten",

--- a/frontend/src/i18n/locales/de/builder.json
+++ b/frontend/src/i18n/locales/de/builder.json
@@ -963,7 +963,10 @@
     "byFieldNone": "Keine Gruppierung — alles zusammenführen",
     "truncatedNoticeTotal": "Die ersten {{count}} von {{total}} Quell-Features werden angezeigt",
     "clipLayerLabel": "Oder an einer Ebene zuschneiden",
-    "clipLayerNone": "Keine — auf der Karte zeichnen"
+    "clipLayerNone": "Keine — auf der Karte zeichnen",
+    "jobCompleteNamed": "„{{title}}“ ist fertig",
+    "viewDataset": "Datensatz anzeigen",
+    "jobSaving": "Datensatz wird gespeichert…"
   },
   "attributeForm": {
     "titleEdit": "Feature-Attribute bearbeiten",

--- a/frontend/src/i18n/locales/de/builder.json
+++ b/frontend/src/i18n/locales/de/builder.json
@@ -958,6 +958,7 @@
     "jobRunning": "Datensatz wird erstellt…",
     "jobComplete": "Datensatz erstellt",
     "jobFailed": "Analyseauftrag fehlgeschlagen",
+    "jobFailedDetail": "Analyseauftrag fehlgeschlagen: {{message}}",
     "addToMap": "Zur Karte hinzufügen",
     "byFieldLabel": "Nach Feld gruppieren (optional)",
     "byFieldNone": "Keine Gruppierung — alles zusammenführen",

--- a/frontend/src/i18n/locales/de/builder.json
+++ b/frontend/src/i18n/locales/de/builder.json
@@ -950,7 +950,7 @@
     "previewFailed": "Analyse fehlgeschlagen",
     "noLayers": "Fügen Sie eine Datenebene hinzu, um Analysewerkzeuge zu nutzen",
     "opDissolve": "Auflösen",
-    "dissolveHint": "Auflösen führt Features zu einer Geometrie pro Gruppe zusammen; mit „Datensatz erstellen“ ausführen",
+    "dissolveHint": "Auflösen führt Features zu einer Geometrie pro Gruppe zusammen; nur das Gruppierungsfeld bleibt erhalten. Mit „Datensatz erstellen“ ausführen",
     "outputTitleLabel": "Name des neuen Datensatzes",
     "outputTitlePlaceholder": "z. B. Flurstücke 500 m Puffer",
     "saveButton": "Datensatz erstellen",
@@ -961,7 +961,7 @@
     "addToMap": "Zur Karte hinzufügen",
     "byFieldLabel": "Nach Feld gruppieren (optional)",
     "byFieldNone": "Keine Gruppierung — alles zusammenführen",
-    "truncatedNoticeTotal": "Die ersten {{count}} von {{total}} Features werden angezeigt",
+    "truncatedNoticeTotal": "Die ersten {{count}} von {{total}} Quell-Features werden angezeigt",
     "clipLayerLabel": "Oder an einer Ebene zuschneiden",
     "clipLayerNone": "Keine — auf der Karte zeichnen"
   },

--- a/frontend/src/i18n/locales/en/builder.json
+++ b/frontend/src/i18n/locales/en/builder.json
@@ -961,7 +961,9 @@
     "addToMap": "Add to map",
     "byFieldLabel": "Group by field (optional)",
     "byFieldNone": "No grouping — merge everything",
-    "truncatedNoticeTotal": "Showing the first {{count}} of {{total}} features"
+    "truncatedNoticeTotal": "Showing the first {{count}} of {{total}} features",
+    "clipLayerLabel": "Or clip to a layer",
+    "clipLayerNone": "None — draw on the map"
   },
   "attributeForm": {
     "titleEdit": "Edit Feature Attributes",

--- a/frontend/src/i18n/locales/en/builder.json
+++ b/frontend/src/i18n/locales/en/builder.json
@@ -963,7 +963,10 @@
     "byFieldNone": "No grouping — merge everything",
     "truncatedNoticeTotal": "Showing the first {{count}} of {{total}} source features",
     "clipLayerLabel": "Or clip to a layer",
-    "clipLayerNone": "None — draw on the map"
+    "clipLayerNone": "None — draw on the map",
+    "jobCompleteNamed": "“{{title}}” is ready",
+    "viewDataset": "View dataset",
+    "jobSaving": "Saving the dataset…"
   },
   "attributeForm": {
     "titleEdit": "Edit Feature Attributes",

--- a/frontend/src/i18n/locales/en/builder.json
+++ b/frontend/src/i18n/locales/en/builder.json
@@ -950,7 +950,7 @@
     "previewFailed": "Analysis failed",
     "noLayers": "Add a dataset layer to use analysis tools",
     "opDissolve": "Dissolve",
-    "dissolveHint": "Dissolve merges features into one geometry per group; run it with Create dataset",
+    "dissolveHint": "Dissolve merges features into one geometry per group; only the group field is carried over. Run it with Create dataset",
     "outputTitleLabel": "New dataset name",
     "outputTitlePlaceholder": "e.g. Parcels buffered 500 m",
     "saveButton": "Create dataset",
@@ -961,7 +961,7 @@
     "addToMap": "Add to map",
     "byFieldLabel": "Group by field (optional)",
     "byFieldNone": "No grouping — merge everything",
-    "truncatedNoticeTotal": "Showing the first {{count}} of {{total}} features",
+    "truncatedNoticeTotal": "Showing the first {{count}} of {{total}} source features",
     "clipLayerLabel": "Or clip to a layer",
     "clipLayerNone": "None — draw on the map"
   },

--- a/frontend/src/i18n/locales/en/builder.json
+++ b/frontend/src/i18n/locales/en/builder.json
@@ -958,6 +958,7 @@
     "jobRunning": "Creating dataset…",
     "jobComplete": "Dataset created",
     "jobFailed": "Analysis job failed",
+    "jobFailedDetail": "Analysis job failed: {{message}}",
     "addToMap": "Add to map",
     "byFieldLabel": "Group by field (optional)",
     "byFieldNone": "No grouping — merge everything",

--- a/frontend/src/i18n/locales/es/builder.json
+++ b/frontend/src/i18n/locales/es/builder.json
@@ -963,7 +963,10 @@
     "byFieldNone": "Sin agrupación — combinar todo",
     "truncatedNoticeTotal": "Mostrando las primeras {{count}} de {{total}} entidades de origen",
     "clipLayerLabel": "O recortar con una capa",
-    "clipLayerNone": "Ninguna — dibujar en el mapa"
+    "clipLayerNone": "Ninguna — dibujar en el mapa",
+    "jobCompleteNamed": "«{{title}}» está listo",
+    "viewDataset": "Ver conjunto de datos",
+    "jobSaving": "Guardando el conjunto de datos…"
   },
   "attributeForm": {
     "titleEdit": "Editar atributos de la entidad",

--- a/frontend/src/i18n/locales/es/builder.json
+++ b/frontend/src/i18n/locales/es/builder.json
@@ -958,6 +958,7 @@
     "jobRunning": "Creando conjunto de datos…",
     "jobComplete": "Conjunto de datos creado",
     "jobFailed": "El trabajo de análisis falló",
+    "jobFailedDetail": "El trabajo de análisis falló: {{message}}",
     "addToMap": "Añadir al mapa",
     "byFieldLabel": "Agrupar por campo (opcional)",
     "byFieldNone": "Sin agrupación — combinar todo",

--- a/frontend/src/i18n/locales/es/builder.json
+++ b/frontend/src/i18n/locales/es/builder.json
@@ -950,7 +950,7 @@
     "previewFailed": "Error en el análisis",
     "noLayers": "Añade una capa de datos para usar las herramientas de análisis",
     "opDissolve": "Disolver",
-    "dissolveHint": "Disolver combina las entidades en una geometría por grupo; ejecútalo con Crear conjunto de datos",
+    "dissolveHint": "Disolver combina las entidades en una geometría por grupo; solo se conserva el campo de agrupación. Ejecútalo con Crear conjunto de datos",
     "outputTitleLabel": "Nombre del nuevo conjunto de datos",
     "outputTitlePlaceholder": "p. ej. Parcelas con zona de 500 m",
     "saveButton": "Crear conjunto de datos",
@@ -961,7 +961,7 @@
     "addToMap": "Añadir al mapa",
     "byFieldLabel": "Agrupar por campo (opcional)",
     "byFieldNone": "Sin agrupación — combinar todo",
-    "truncatedNoticeTotal": "Mostrando las primeras {{count}} de {{total}} entidades",
+    "truncatedNoticeTotal": "Mostrando las primeras {{count}} de {{total}} entidades de origen",
     "clipLayerLabel": "O recortar con una capa",
     "clipLayerNone": "Ninguna — dibujar en el mapa"
   },

--- a/frontend/src/i18n/locales/es/builder.json
+++ b/frontend/src/i18n/locales/es/builder.json
@@ -961,7 +961,9 @@
     "addToMap": "Añadir al mapa",
     "byFieldLabel": "Agrupar por campo (opcional)",
     "byFieldNone": "Sin agrupación — combinar todo",
-    "truncatedNoticeTotal": "Mostrando las primeras {{count}} de {{total}} entidades"
+    "truncatedNoticeTotal": "Mostrando las primeras {{count}} de {{total}} entidades",
+    "clipLayerLabel": "O recortar con una capa",
+    "clipLayerNone": "Ninguna — dibujar en el mapa"
   },
   "attributeForm": {
     "titleEdit": "Editar atributos de la entidad",

--- a/frontend/src/i18n/locales/fr/builder.json
+++ b/frontend/src/i18n/locales/fr/builder.json
@@ -963,7 +963,10 @@
     "byFieldNone": "Sans regroupement — tout fusionner",
     "truncatedNoticeTotal": "Affichage des {{count}} premières entités sur {{total}} entités sources",
     "clipLayerLabel": "Ou découper selon une couche",
-    "clipLayerNone": "Aucune — dessiner sur la carte"
+    "clipLayerNone": "Aucune — dessiner sur la carte",
+    "jobCompleteNamed": "« {{title}} » est prêt",
+    "viewDataset": "Voir le jeu de données",
+    "jobSaving": "Enregistrement du jeu de données…"
   },
   "attributeForm": {
     "titleEdit": "Modifier les attributs de l'entité",

--- a/frontend/src/i18n/locales/fr/builder.json
+++ b/frontend/src/i18n/locales/fr/builder.json
@@ -961,7 +961,9 @@
     "addToMap": "Ajouter à la carte",
     "byFieldLabel": "Regrouper par champ (optionnel)",
     "byFieldNone": "Sans regroupement — tout fusionner",
-    "truncatedNoticeTotal": "Affichage des {{count}} premières entités sur {{total}}"
+    "truncatedNoticeTotal": "Affichage des {{count}} premières entités sur {{total}}",
+    "clipLayerLabel": "Ou découper selon une couche",
+    "clipLayerNone": "Aucune — dessiner sur la carte"
   },
   "attributeForm": {
     "titleEdit": "Modifier les attributs de l'entité",

--- a/frontend/src/i18n/locales/fr/builder.json
+++ b/frontend/src/i18n/locales/fr/builder.json
@@ -950,7 +950,7 @@
     "previewFailed": "Échec de l'analyse",
     "noLayers": "Ajoutez une couche de données pour utiliser les outils d'analyse",
     "opDissolve": "Dissoudre",
-    "dissolveHint": "Dissoudre fusionne les entités en une géométrie par groupe ; exécutez-le avec Créer un jeu de données",
+    "dissolveHint": "Dissoudre fusionne les entités en une géométrie par groupe ; seul le champ de regroupement est conservé. Exécutez-le avec Créer un jeu de données",
     "outputTitleLabel": "Nom du nouveau jeu de données",
     "outputTitlePlaceholder": "p. ex. Parcelles tampon 500 m",
     "saveButton": "Créer un jeu de données",
@@ -961,7 +961,7 @@
     "addToMap": "Ajouter à la carte",
     "byFieldLabel": "Regrouper par champ (optionnel)",
     "byFieldNone": "Sans regroupement — tout fusionner",
-    "truncatedNoticeTotal": "Affichage des {{count}} premières entités sur {{total}}",
+    "truncatedNoticeTotal": "Affichage des {{count}} premières entités sur {{total}} entités sources",
     "clipLayerLabel": "Ou découper selon une couche",
     "clipLayerNone": "Aucune — dessiner sur la carte"
   },

--- a/frontend/src/i18n/locales/fr/builder.json
+++ b/frontend/src/i18n/locales/fr/builder.json
@@ -958,6 +958,7 @@
     "jobRunning": "Création du jeu de données…",
     "jobComplete": "Jeu de données créé",
     "jobFailed": "La tâche d'analyse a échoué",
+    "jobFailedDetail": "La tâche d'analyse a échoué : {{message}}",
     "addToMap": "Ajouter à la carte",
     "byFieldLabel": "Regrouper par champ (optionnel)",
     "byFieldNone": "Sans regroupement — tout fusionner",

--- a/frontend/src/pages/MapBuilderPage.tsx
+++ b/frontend/src/pages/MapBuilderPage.tsx
@@ -816,11 +816,16 @@ export function MapBuilderPage() {
             }
           : undefined,
       );
+      // fix(#682 review P3): stop tracking a handled job — `t` is a dep, so a
+      // language switch would otherwise rerun this effect and replay the
+      // toast + invalidation for a job that already finished.
+      setAnalysisJobId(null);
     } else if (analysisJobStatus === 'failed') {
       const message = analysisJobRef.current?.error_message;
       toast.error(
         `${t('analysisTools.jobFailed', { defaultValue: 'Analysis job failed' })}${message ? `: ${message}` : ''}`,
       );
+      setAnalysisJobId(null);
     }
   }, [analysisJobId, analysisJobStatus, queryClient, t]);
 

--- a/frontend/src/pages/MapBuilderPage.tsx
+++ b/frontend/src/pages/MapBuilderPage.tsx
@@ -1,8 +1,6 @@
 import { lazy, Suspense, useState, useEffect, useRef, useCallback, useMemo, type ReactNode } from 'react';
 import { useParams, Link, useSearchParams } from 'react-router';
 import { useTranslation } from 'react-i18next';
-import { toast } from 'sonner';
-import { useQueryClient } from '@tanstack/react-query';
 import { FileText, History, Sparkles, Info, FlaskConical } from 'lucide-react';
 import type { Map as MaplibreMap } from 'maplibre-gl';
 import { ApiError } from '@/api/client';
@@ -54,8 +52,6 @@ import { clearPersistedFolderGroup, getParentGroupId, resolveDropGroupMembership
 import { SidebarRail } from '@/components/builder/SidebarRail';
 import { LayerEditorPanel, type LayerEditorHandlers } from '@/components/builder/LayerEditorPanel';
 import { EphemeralBadge } from '@/components/builder/EphemeralBadge';
-import { useJobStatus } from '@/components/import/hooks/use-ingest';
-import { queryKeys } from '@/lib/query-keys';
 import { MapToolbar } from '@/components/builder/MapToolbar';
 import { MapTitleBar } from '@/components/builder/MapTitleBar';
 import { BuilderRail, type RailPanel } from '@/components/builder/BuilderRail';
@@ -109,6 +105,7 @@ import { usePluginStore } from '@/stores/map-plugin-store';
 import type { ViewportContext } from '@/components/builder/chat-suggestions';
 import type { EphemeralAnalysisHandoff } from '@/components/builder/hooks/use-ephemeral-layers';
 import { readStorage, removeStorage, storageKeys } from '@/lib/storage';
+import { analysisAddToMap, useAnalysisJobStore } from '@/stores/analysis-job-store';
 import { takeChatResult } from '@/lib/chat-result-handoff';
 
 export function MapBuilderPage() {
@@ -148,11 +145,6 @@ export function MapBuilderPage() {
   const [analysisPrefill, setAnalysisPrefill] = useState<
     (EphemeralAnalysisHandoff & { nonce: number }) | null
   >(null);
-  // Page-level analysis-job tracking: the AnalysisPanel unmounts on rail
-  // switch/sheet close, which used to silently abandon a running materialize.
-  // TanStack dedupes this against the panel's own useJobStatus (same key),
-  // so there is still exactly one 2s poll loop.
-  const [analysisJobId, setAnalysisJobId] = useState<string | null>(null);
   const [dockNotes, setDockNotes] = useState('');
   // Projection (Mercator/Globe). Persisted on basemap_config.projection; seeded from
   // the saved map on load and applied to the live map once it's ready (effects below).
@@ -788,46 +780,28 @@ export function MapBuilderPage() {
       .map((l) => ({ id: l.id, name: l.display_name ?? l.dataset_name ?? 'Group' }));
   }, [layers.localLayers]);
 
-  // Completion/failure signal for analysis materialize jobs that outlives the
-  // AnalysisPanel: toast with an "Add to map" action, and invalidate the
-  // dataset/search queries exactly once per job (the panel used to own the
-  // invalidation, but it unmounts).
-  const queryClient = useQueryClient();
-  const analysisJob = useJobStatus(analysisJobId).data;
-  const analysisJobStatus = analysisJob?.status;
-  const analysisJobRef = useRef(analysisJob);
-  analysisJobRef.current = analysisJob;
-  const addDatasetRef = useRef(layers.chatLayerActions?.onAddDataset);
-  addDatasetRef.current = layers.chatLayerActions?.onAddDataset;
+  // Analysis materialize jobs are tracked globally (AnalysisJobWatcher in
+  // RootLayout owns polling, the completion toast, and cache invalidation) so
+  // the signal survives this page unmounting. This page contributes only the
+  // "Add to map" capability, which needs its layer actions.
+  const setAnalysisJob = useAnalysisJobStore((s) => s.setJob);
+  const handleAnalysisJobChange = useCallback(
+    (jobId: string | null, title?: string) => {
+      setAnalysisJob(jobId ? { jobId, title: title ?? '', mapId: id ?? null } : null);
+    },
+    [setAnalysisJob, id],
+  );
+  // No dep array: keeps the registered callback fresh on every render; the
+  // cleanup is what matters, so the watcher falls back to "View dataset" once
+  // this builder is gone.
   useEffect(() => {
-    if (!analysisJobId) return;
-    if (analysisJobStatus === 'complete') {
-      queryClient.invalidateQueries({ queryKey: queryKeys.datasets.all });
-      queryClient.invalidateQueries({ queryKey: queryKeys.search.all });
-      const datasetId = analysisJobRef.current?.dataset_id;
-      toast.success(
-        t('analysisTools.jobComplete', { defaultValue: 'Dataset created' }),
-        datasetId
-          ? {
-              action: {
-                label: t('analysisTools.addToMap', { defaultValue: 'Add to map' }),
-                onClick: () => addDatasetRef.current?.(datasetId),
-              },
-            }
-          : undefined,
-      );
-      // fix(#682 review P3): stop tracking a handled job — `t` is a dep, so a
-      // language switch would otherwise rerun this effect and replay the
-      // toast + invalidation for a job that already finished.
-      setAnalysisJobId(null);
-    } else if (analysisJobStatus === 'failed') {
-      const message = analysisJobRef.current?.error_message;
-      toast.error(
-        `${t('analysisTools.jobFailed', { defaultValue: 'Analysis job failed' })}${message ? `: ${message}` : ''}`,
-      );
-      setAnalysisJobId(null);
-    }
-  }, [analysisJobId, analysisJobStatus, queryClient, t]);
+    analysisAddToMap.current = layers.chatLayerActions?.onAddDataset ?? null;
+    analysisAddToMap.mapId = id ?? null;
+    return () => {
+      analysisAddToMap.current = null;
+      analysisAddToMap.mapId = null;
+    };
+  });
 
   // feat(#675): "Save as dataset" on the ephemeral badge — open the Analysis
   // panel prefilled with the operation behind the chat preview.
@@ -861,10 +835,10 @@ export function MapBuilderPage() {
     hasPreview: !!layers.ephemeralResult,
     analysisPrefill,
     // setState identity is stable — safe to pass without a memo dep.
-    onAnalysisJobChange: setAnalysisJobId,
+    onAnalysisJobChange: handleAnalysisJobChange,
     onMarkDirty: handleMarkDirty,
     viewport,
-  }), [railPanel, aiAvailable, dockNotes, id, layers.localLayers, layers.chatLayerActions, layers.handleQueryResult, layers.handleDismissEphemeral, layers.ephemeralResult, analysisPrefill, mapInstanceRef, handleMarkDirty, viewport]);
+  }), [railPanel, aiAvailable, dockNotes, id, layers.localLayers, layers.chatLayerActions, layers.handleQueryResult, layers.handleDismissEphemeral, layers.ephemeralResult, analysisPrefill, mapInstanceRef, handleMarkDirty, viewport, handleAnalysisJobChange]);
 
   const mobileRailButtons = useMemo(() => [
     {

--- a/frontend/src/pages/MapBuilderPage.tsx
+++ b/frontend/src/pages/MapBuilderPage.tsx
@@ -787,11 +787,7 @@ export function MapBuilderPage() {
   const setAnalysisJob = useAnalysisJobStore((s) => s.setJob);
   const handleAnalysisJobChange = useCallback(
     (jobId: string | null, title?: string) => {
-      setAnalysisJob(
-        jobId
-          ? { jobId, title: title ?? '', mapId: id ?? null, enqueuedAt: Date.now() }
-          : null,
-      );
+      setAnalysisJob(jobId ? { jobId, title: title ?? '', mapId: id ?? null } : null);
     },
     [setAnalysisJob, id],
   );

--- a/frontend/src/pages/MapBuilderPage.tsx
+++ b/frontend/src/pages/MapBuilderPage.tsx
@@ -787,7 +787,11 @@ export function MapBuilderPage() {
   const setAnalysisJob = useAnalysisJobStore((s) => s.setJob);
   const handleAnalysisJobChange = useCallback(
     (jobId: string | null, title?: string) => {
-      setAnalysisJob(jobId ? { jobId, title: title ?? '', mapId: id ?? null } : null);
+      setAnalysisJob(
+        jobId
+          ? { jobId, title: title ?? '', mapId: id ?? null, enqueuedAt: Date.now() }
+          : null,
+      );
     },
     [setAnalysisJob, id],
   );

--- a/frontend/src/pages/MapBuilderPage.tsx
+++ b/frontend/src/pages/MapBuilderPage.tsx
@@ -1,6 +1,8 @@
 import { lazy, Suspense, useState, useEffect, useRef, useCallback, useMemo, type ReactNode } from 'react';
 import { useParams, Link, useSearchParams } from 'react-router';
 import { useTranslation } from 'react-i18next';
+import { toast } from 'sonner';
+import { useQueryClient } from '@tanstack/react-query';
 import { FileText, History, Sparkles, Info, FlaskConical } from 'lucide-react';
 import type { Map as MaplibreMap } from 'maplibre-gl';
 import { ApiError } from '@/api/client';
@@ -52,6 +54,8 @@ import { clearPersistedFolderGroup, getParentGroupId, resolveDropGroupMembership
 import { SidebarRail } from '@/components/builder/SidebarRail';
 import { LayerEditorPanel, type LayerEditorHandlers } from '@/components/builder/LayerEditorPanel';
 import { EphemeralBadge } from '@/components/builder/EphemeralBadge';
+import { useJobStatus } from '@/components/import/hooks/use-ingest';
+import { queryKeys } from '@/lib/query-keys';
 import { MapToolbar } from '@/components/builder/MapToolbar';
 import { MapTitleBar } from '@/components/builder/MapTitleBar';
 import { BuilderRail, type RailPanel } from '@/components/builder/BuilderRail';
@@ -144,6 +148,11 @@ export function MapBuilderPage() {
   const [analysisPrefill, setAnalysisPrefill] = useState<
     (EphemeralAnalysisHandoff & { nonce: number }) | null
   >(null);
+  // Page-level analysis-job tracking: the AnalysisPanel unmounts on rail
+  // switch/sheet close, which used to silently abandon a running materialize.
+  // TanStack dedupes this against the panel's own useJobStatus (same key),
+  // so there is still exactly one 2s poll loop.
+  const [analysisJobId, setAnalysisJobId] = useState<string | null>(null);
   const [dockNotes, setDockNotes] = useState('');
   // Projection (Mercator/Globe). Persisted on basemap_config.projection; seeded from
   // the saved map on load and applied to the live map once it's ready (effects below).
@@ -779,6 +788,42 @@ export function MapBuilderPage() {
       .map((l) => ({ id: l.id, name: l.display_name ?? l.dataset_name ?? 'Group' }));
   }, [layers.localLayers]);
 
+  // Completion/failure signal for analysis materialize jobs that outlives the
+  // AnalysisPanel: toast with an "Add to map" action, and invalidate the
+  // dataset/search queries exactly once per job (the panel used to own the
+  // invalidation, but it unmounts).
+  const queryClient = useQueryClient();
+  const analysisJob = useJobStatus(analysisJobId).data;
+  const analysisJobStatus = analysisJob?.status;
+  const analysisJobRef = useRef(analysisJob);
+  analysisJobRef.current = analysisJob;
+  const addDatasetRef = useRef(layers.chatLayerActions?.onAddDataset);
+  addDatasetRef.current = layers.chatLayerActions?.onAddDataset;
+  useEffect(() => {
+    if (!analysisJobId) return;
+    if (analysisJobStatus === 'complete') {
+      queryClient.invalidateQueries({ queryKey: queryKeys.datasets.all });
+      queryClient.invalidateQueries({ queryKey: queryKeys.search.all });
+      const datasetId = analysisJobRef.current?.dataset_id;
+      toast.success(
+        t('analysisTools.jobComplete', { defaultValue: 'Dataset created' }),
+        datasetId
+          ? {
+              action: {
+                label: t('analysisTools.addToMap', { defaultValue: 'Add to map' }),
+                onClick: () => addDatasetRef.current?.(datasetId),
+              },
+            }
+          : undefined,
+      );
+    } else if (analysisJobStatus === 'failed') {
+      const message = analysisJobRef.current?.error_message;
+      toast.error(
+        `${t('analysisTools.jobFailed', { defaultValue: 'Analysis job failed' })}${message ? `: ${message}` : ''}`,
+      );
+    }
+  }, [analysisJobId, analysisJobStatus, queryClient, t]);
+
   // feat(#675): "Save as dataset" on the ephemeral badge — open the Analysis
   // panel prefilled with the operation behind the chat preview.
   const ephemeralAnalysis = layers.ephemeralResult?.analysis;
@@ -810,6 +855,8 @@ export function MapBuilderPage() {
     onClearPreview: layers.handleDismissEphemeral,
     hasPreview: !!layers.ephemeralResult,
     analysisPrefill,
+    // setState identity is stable — safe to pass without a memo dep.
+    onAnalysisJobChange: setAnalysisJobId,
     onMarkDirty: handleMarkDirty,
     viewport,
   }), [railPanel, aiAvailable, dockNotes, id, layers.localLayers, layers.chatLayerActions, layers.handleQueryResult, layers.handleDismissEphemeral, layers.ephemeralResult, analysisPrefill, mapInstanceRef, handleMarkDirty, viewport]);

--- a/frontend/src/stores/analysis-job-store.ts
+++ b/frontend/src/stores/analysis-job-store.ts
@@ -1,0 +1,46 @@
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+
+export interface TrackedAnalysisJob {
+  jobId: string;
+  /** Output dataset name, so a notification arriving minutes later has context. */
+  title: string;
+  /** Map the job was started from; enables the "Add to map" action. */
+  mapId: string | null;
+}
+
+interface AnalysisJobState {
+  job: TrackedAnalysisJob | null;
+  setJob: (job: TrackedAnalysisJob | null) => void;
+}
+
+/**
+ * The one in-flight materialize job being tracked for notification.
+ *
+ * Persisted because the whole point is surviving what a long job outlives:
+ * closing the Analysis panel, navigating off the builder, or reloading the
+ * tab. The job itself always completes server-side — this only carries the
+ * id needed to tell the user about it. AnalysisJobWatcher (mounted in
+ * RootLayout) owns polling and clears this on any terminal status.
+ *
+ * Singular by design: the API allows one active analysis job per user.
+ */
+export const useAnalysisJobStore = create<AnalysisJobState>()(
+  persist((set) => ({ job: null, setJob: (job) => set({ job }) }), {
+    name: 'geolens-analysis-job',
+    version: 1,
+  }),
+);
+
+/**
+ * Add-to-map handler registered by MapBuilderPage while it is mounted.
+ *
+ * A module ref rather than store state: it is a live callback (not
+ * serializable, and re-rendering the watcher when it changes is pointless).
+ * The watcher offers "Add to map" only when a builder for the job's own map
+ * is mounted, and falls back to navigating to the dataset otherwise.
+ */
+export const analysisAddToMap: {
+  current: ((datasetId: string) => void) | null;
+  mapId: string | null;
+} = { current: null, mapId: null };

--- a/frontend/src/stores/analysis-job-store.ts
+++ b/frontend/src/stores/analysis-job-store.ts
@@ -7,6 +7,8 @@ export interface TrackedAnalysisJob {
   title: string;
   /** Map the job was started from; enables the "Add to map" action. */
   mapId: string | null;
+  /** Enqueue time (ms epoch), used to stop tracking a job whose worker died. */
+  enqueuedAt: number;
 }
 
 interface AnalysisJobState {
@@ -28,7 +30,10 @@ interface AnalysisJobState {
 export const useAnalysisJobStore = create<AnalysisJobState>()(
   persist((set) => ({ job: null, setJob: (job) => set({ job }) }), {
     name: 'geolens-analysis-job',
-    version: 1,
+    // v2 added enqueuedAt. A v1 entry has no timestamp, so it could never age
+    // out of the save guard — drop it rather than invent a start time.
+    version: 2,
+    migrate: () => ({ job: null }),
   }),
 );
 

--- a/frontend/src/stores/analysis-job-store.ts
+++ b/frontend/src/stores/analysis-job-store.ts
@@ -7,8 +7,6 @@ export interface TrackedAnalysisJob {
   title: string;
   /** Map the job was started from; enables the "Add to map" action. */
   mapId: string | null;
-  /** Enqueue time (ms epoch), used to stop tracking a job whose worker died. */
-  enqueuedAt: number;
 }
 
 interface AnalysisJobState {
@@ -30,10 +28,7 @@ interface AnalysisJobState {
 export const useAnalysisJobStore = create<AnalysisJobState>()(
   persist((set) => ({ job: null, setJob: (job) => set({ job }) }), {
     name: 'geolens-analysis-job',
-    // v2 added enqueuedAt. A v1 entry has no timestamp, so it could never age
-    // out of the save guard — drop it rather than invent a start time.
-    version: 2,
-    migrate: () => ({ job: null }),
+    version: 1,
   }),
 );
 

--- a/frontend/src/types/api.generated.ts
+++ b/frontend/src/types/api.generated.ts
@@ -5410,6 +5410,11 @@ export interface components {
                 [key: string]: unknown;
             } | null;
             /**
+             * Mask Dataset Id
+             * @description Polygon dataset whose unioned features form the clip mask (clip only; alternative to mask)
+             */
+            mask_dataset_id?: string | null;
+            /**
              * Operation
              * @enum {string}
              */
@@ -5450,6 +5455,11 @@ export interface components {
             mask?: {
                 [key: string]: unknown;
             } | null;
+            /**
+             * Mask Dataset Id
+             * @description Polygon dataset whose unioned features form the clip mask (clip only; alternative to mask)
+             */
+            mask_dataset_id?: string | null;
             /**
              * Operation
              * @enum {string}

--- a/frontend/src/types/api.generated.ts
+++ b/frontend/src/types/api.generated.ts
@@ -8242,7 +8242,7 @@ export interface components {
              */
             created_at: string;
             /** Current Step */
-            current_step?: ("validating" | "ogr2ogr" | "finalize" | "complete" | "cog_convert" | "quicklook") | null;
+            current_step?: ("validating" | "ogr2ogr" | "finalize" | "complete" | "cog_convert" | "quicklook" | "analyzing" | "registering") | null;
             /** Dataset Id */
             dataset_id: string | null;
             /** Error Message */

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -609,6 +609,8 @@ export interface JobStatusResponse {
     | 'complete'
     | 'cog_convert'
     | 'quicklook'
+    | 'analyzing'
+    | 'registering'
     | null;
   rows_processed?: number | null;
   archive_failed: boolean;

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -1865,6 +1865,8 @@ export interface AnalysisPreviewRequest {
   distance_meters?: number;
   /** GeoJSON Polygon/MultiPolygon mask in EPSG:4326 (clip only). */
   mask?: GeoJSON.Polygon | GeoJSON.MultiPolygon;
+  /** Polygon dataset whose unioned features form the clip mask (clip only; alternative to mask). */
+  mask_dataset_id?: string;
 }
 
 export interface AnalysisPreviewResponse {
@@ -1881,6 +1883,8 @@ export interface AnalysisMaterializeRequest {
   title: string;
   distance_meters?: number;
   mask?: GeoJSON.Polygon | GeoJSON.MultiPolygon;
+  /** Polygon dataset whose unioned features form the clip mask (clip only; alternative to mask). */
+  mask_dataset_id?: string;
   by_field?: string;
 }
 

--- a/sdks/python/geolens/models/analysis_materialize_request.py
+++ b/sdks/python/geolens/models/analysis_materialize_request.py
@@ -15,6 +15,7 @@ from ..models.analysis_materialize_request_operation import (
     check_analysis_materialize_request_operation,
 )
 from typing import cast
+from uuid import UUID
 
 if TYPE_CHECKING:
     from ..models.analysis_materialize_request_mask_type_0 import (
@@ -36,6 +37,8 @@ class AnalysisMaterializeRequest:
         distance_meters (float | None | Unset): Buffer distance in meters (buffer only)
         mask (AnalysisMaterializeRequestMaskType0 | None | Unset): GeoJSON Polygon or MultiPolygon geometry in EPSG:4326
             (clip only)
+        mask_dataset_id (None | Unset | UUID): Polygon dataset whose unioned features form the clip mask (clip only;
+            alternative to mask)
     """
 
     operation: AnalysisMaterializeRequestOperation
@@ -43,6 +46,7 @@ class AnalysisMaterializeRequest:
     by_field: None | str | Unset = UNSET
     distance_meters: float | None | Unset = UNSET
     mask: AnalysisMaterializeRequestMaskType0 | None | Unset = UNSET
+    mask_dataset_id: None | Unset | UUID = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
@@ -74,6 +78,14 @@ class AnalysisMaterializeRequest:
         else:
             mask = self.mask
 
+        mask_dataset_id: None | str | Unset
+        if isinstance(self.mask_dataset_id, Unset):
+            mask_dataset_id = UNSET
+        elif isinstance(self.mask_dataset_id, UUID):
+            mask_dataset_id = str(self.mask_dataset_id)
+        else:
+            mask_dataset_id = self.mask_dataset_id
+
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
@@ -88,6 +100,8 @@ class AnalysisMaterializeRequest:
             field_dict["distance_meters"] = distance_meters
         if mask is not UNSET:
             field_dict["mask"] = mask
+        if mask_dataset_id is not UNSET:
+            field_dict["mask_dataset_id"] = mask_dataset_id
 
         return field_dict
 
@@ -139,12 +153,30 @@ class AnalysisMaterializeRequest:
 
         mask = _parse_mask(d.pop("mask", UNSET))
 
+        def _parse_mask_dataset_id(data: object) -> None | Unset | UUID:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, str):
+                    raise TypeError()
+                mask_dataset_id_type_0 = UUID(data)
+
+                return mask_dataset_id_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(None | Unset | UUID, data)
+
+        mask_dataset_id = _parse_mask_dataset_id(d.pop("mask_dataset_id", UNSET))
+
         analysis_materialize_request = cls(
             operation=operation,
             title=title,
             by_field=by_field,
             distance_meters=distance_meters,
             mask=mask,
+            mask_dataset_id=mask_dataset_id,
         )
 
         analysis_materialize_request.additional_properties = d

--- a/sdks/python/geolens/models/analysis_preview_request.py
+++ b/sdks/python/geolens/models/analysis_preview_request.py
@@ -13,6 +13,7 @@ from ..models.analysis_preview_request_operation import (
     check_analysis_preview_request_operation,
 )
 from typing import cast
+from uuid import UUID
 
 if TYPE_CHECKING:
     from ..models.analysis_preview_request_mask_type_0 import (
@@ -35,11 +36,14 @@ class AnalysisPreviewRequest:
             distance_meters (float | None | Unset): Buffer distance in meters (buffer only)
             mask (AnalysisPreviewRequestMaskType0 | None | Unset): GeoJSON Polygon or MultiPolygon geometry in EPSG:4326
                 (clip only)
+            mask_dataset_id (None | Unset | UUID): Polygon dataset whose unioned features form the clip mask (clip only;
+                alternative to mask)
     """
 
     operation: AnalysisPreviewRequestOperation
     distance_meters: float | None | Unset = UNSET
     mask: AnalysisPreviewRequestMaskType0 | None | Unset = UNSET
+    mask_dataset_id: None | Unset | UUID = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
@@ -63,6 +67,14 @@ class AnalysisPreviewRequest:
         else:
             mask = self.mask
 
+        mask_dataset_id: None | str | Unset
+        if isinstance(self.mask_dataset_id, Unset):
+            mask_dataset_id = UNSET
+        elif isinstance(self.mask_dataset_id, UUID):
+            mask_dataset_id = str(self.mask_dataset_id)
+        else:
+            mask_dataset_id = self.mask_dataset_id
+
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
@@ -74,6 +86,8 @@ class AnalysisPreviewRequest:
             field_dict["distance_meters"] = distance_meters
         if mask is not UNSET:
             field_dict["mask"] = mask
+        if mask_dataset_id is not UNSET:
+            field_dict["mask_dataset_id"] = mask_dataset_id
 
         return field_dict
 
@@ -112,10 +126,28 @@ class AnalysisPreviewRequest:
 
         mask = _parse_mask(d.pop("mask", UNSET))
 
+        def _parse_mask_dataset_id(data: object) -> None | Unset | UUID:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, str):
+                    raise TypeError()
+                mask_dataset_id_type_0 = UUID(data)
+
+                return mask_dataset_id_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(None | Unset | UUID, data)
+
+        mask_dataset_id = _parse_mask_dataset_id(d.pop("mask_dataset_id", UNSET))
+
         analysis_preview_request = cls(
             operation=operation,
             distance_meters=distance_meters,
             mask=mask,
+            mask_dataset_id=mask_dataset_id,
         )
 
         analysis_preview_request.additional_properties = d

--- a/sdks/python/geolens/models/job_status_response_current_step_type_0.py
+++ b/sdks/python/geolens/models/job_status_response_current_step_type_0.py
@@ -1,17 +1,26 @@
 from typing import Literal, cast
 
 JobStatusResponseCurrentStepType0 = Literal[
-    "cog_convert", "complete", "finalize", "ogr2ogr", "quicklook", "validating"
-]
-
-JOB_STATUS_RESPONSE_CURRENT_STEP_TYPE_0_VALUES: set[
-    JobStatusResponseCurrentStepType0
-] = {
+    "analyzing",
     "cog_convert",
     "complete",
     "finalize",
     "ogr2ogr",
     "quicklook",
+    "registering",
+    "validating",
+]
+
+JOB_STATUS_RESPONSE_CURRENT_STEP_TYPE_0_VALUES: set[
+    JobStatusResponseCurrentStepType0
+] = {
+    "analyzing",
+    "cog_convert",
+    "complete",
+    "finalize",
+    "ogr2ogr",
+    "quicklook",
+    "registering",
     "validating",
 }
 

--- a/sdks/typescript/src/client/types.gen.ts
+++ b/sdks/typescript/src/client/types.gen.ts
@@ -523,6 +523,12 @@ export type AnalysisMaterializeRequest = {
         [key: string]: unknown;
     } | null;
     /**
+     * Mask Dataset Id
+     *
+     * Polygon dataset whose unioned features form the clip mask (clip only; alternative to mask)
+     */
+    mask_dataset_id?: string | null;
+    /**
      * Operation
      */
     operation: 'buffer' | 'centroid' | 'clip' | 'dissolve';
@@ -571,6 +577,12 @@ export type AnalysisPreviewRequest = {
     mask?: {
         [key: string]: unknown;
     } | null;
+    /**
+     * Mask Dataset Id
+     *
+     * Polygon dataset whose unioned features form the clip mask (clip only; alternative to mask)
+     */
+    mask_dataset_id?: string | null;
     /**
      * Operation
      */

--- a/sdks/typescript/src/client/types.gen.ts
+++ b/sdks/typescript/src/client/types.gen.ts
@@ -4407,7 +4407,7 @@ export type JobStatusResponse = {
     /**
      * Current Step
      */
-    current_step?: 'validating' | 'ogr2ogr' | 'finalize' | 'complete' | 'cog_convert' | 'quicklook' | null;
+    current_step?: 'validating' | 'ogr2ogr' | 'finalize' | 'complete' | 'cog_convert' | 'quicklook' | 'analyzing' | 'registering' | null;
     /**
      * Dataset Id
      */


### PR DESCRIPTION
## Summary

**#680 is merged; this now targets `main` directly.** The branch was rebuilt onto the post-merge `main` rather than rebased (its first commits predate two base commits that #680's squash folded into `main`); the rebuilt head is byte-identical to the reviewed head `87d4166`, verified with an empty `git diff`. Two of #680's review findings — the `__none__` group-by collision and the inflated truncation copy — were fixed here rather than on #680 because the panel had diverged, so they land with this PR.

Clip masks no longer have to be hand-drawn: both analysis endpoints accept `mask_dataset_id` as an alternative to the inline GeoJSON `mask`, clipping against the referenced polygon dataset's unioned geometries — "clip lakes to Brazil" instead of tracing Brazil by hand. This also removes the pointer-only-drawing accessibility dead end for clip and lays the first brick of the two-layer operations planned in #681 (a second dataset reference with its own access check is exactly what spatial join / select-by-location will reuse).

## How

- **API**: `mask_dataset_id: UUID` on `AnalysisPreviewRequest` and `AnalysisMaterializeRequest`; clip requires exactly one of `mask` / `mask_dataset_id` (422 otherwise). Additive — openapi + both SDKs + `api.generated.ts` regenerated.
- **SQL**: the mask layer unions **once** in a `MATERIALIZED` CTE (`render_mask_cte`, with `ST_MakeValid` inside the union); the clip expression and both WHERE terms reference it as a scalar subquery, so the union isn't evaluated three times. The dimension-preserving extract and `&&` index term from #680 apply unchanged. No vertex cap needed — nothing is inlined into SQL text; the 10s sandbox timeout bounds preview cost, the 300s statement timeout bounds materialize.
- **Authorization (Rule 1 on BOTH datasets)**: the mask dataset gets its own `check_dataset_access` on the preview path and the materialize fail-fast; the worker re-resolves the mask table at run time and re-validates it against `_SAFE_TABLE`. A private mask layer 404s for a non-grantee even when the source dataset is readable — pinned by an IDOR test.
- **Constraints**: mask datasets must be `POLYGON`/`MULTIPOLYGON` (unioning points/lines clips nothing meaningful) — 422 with a clear message.
- **Panel**: the clip section gains an "Or clip to a layer" select listing the map's other dataset layers (source layer excluded — a layer can't clip itself). Drawn and layer masks are mutually exclusive; picking one clears the other. Strings added to all four locales.

## Verification

- Backend: 45 analysis tests + layering + port-conformance + chat suites green (new: clip-by-layer preview, mask IDOR, non-polygon mask, both-sources 422, worker end-to-end, deleted-mask job failure).
- Frontend: 11 panel tests, `typecheck`, `lint`, `test:i18n` green.
- Live against the dev stack: lakes clipped by the 29-polygon QA layer → 200 with 29 features; `mask`+`mask_dataset_id` together → 422; MultiPoint dataset as mask → 422 "must reference a polygon dataset".

Chat's `run_analysis` deliberately stays buffer/centroid-only.

https://claude.ai/code/session_01X1Wd3Frww9F2eovfMkUbG2
