### PR TITLE
fix(settings): stop advising a CORS wildcard the middleware rejects

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -319,6 +319,9 @@ FRONTEND_PORT=8080
 # Required when the frontend is served from a different domain than the API.
 # Type: string (comma-separated URLs) | Default: "" (same-origin only)
 # Example: https://app.example.com,https://other.example.com
+# List every origin in full. A wildcard "*" is NOT accepted: responses carry
+# Access-Control-Allow-Credentials, so a list containing "*" is treated as
+# deny-all and disables CORS for every origin listed alongside it.
 # CORS_ALLOWED_ORIGINS=
 
 # --- Backup Automation ---

--- a/backend/app/modules/settings/schemas.py
+++ b/backend/app/modules/settings/schemas.py
@@ -554,8 +554,30 @@ def validate_allowed_email_domains(v: Any) -> list[str]:
     return normalized
 
 
+def validate_cors_allowed_origins(v: Any) -> str:
+    """Reject a wildcard origin, which the CORS middleware cannot honour.
+
+    Responses carry `Access-Control-Allow-Credentials: true`, so the spec
+    forbids `*` as the allow-origin value. DynamicCORSMiddleware therefore
+    treats a list containing `*` as "deny everything" — including any explicit
+    origins listed alongside it. Catching it here turns a silent, 30s-delayed
+    outage (the middleware caches the empty set) into an immediate 422.
+    """
+    if not isinstance(v, str):
+        raise ValueError("cors_allowed_origins must be a string")
+    origins = [o.strip() for o in v.split(",") if o.strip()]
+    if "*" in origins:
+        raise ValueError(
+            "Wildcard '*' is not accepted because credentialed CORS requires "
+            "explicit origins. List each origin in full, e.g. "
+            "https://example.com, https://app.example.com"
+        )
+    return ", ".join(origins)
+
+
 SETTING_VALIDATORS: dict[str, Any] = {
     "log_level": validate_log_level,
+    "cors_allowed_origins": validate_cors_allowed_origins,
     "login_rate_limit": validate_login_rate_limit,
     "global_rate_limit": validate_global_rate_limit,
     "ogc_items_max_page_size": validate_ogc_items_max_page_size,

--- a/backend/tests/test_persistent_config.py
+++ b/backend/tests/test_persistent_config.py
@@ -824,15 +824,45 @@ async def test_cors_preflight_returns_200(client: AsyncClient, admin_auth_header
 
 
 @pytest.mark.anyio
-async def test_cors_wildcard_rejected_with_credentials(
+async def test_cors_wildcard_rejected_at_settings_write(
     client: AsyncClient, admin_auth_header: dict
 ):
-    """Wildcard '*' is rejected — credentials=true requires explicit origins."""
-    await client.put(
+    """A wildcard is refused on save, naming the setting, so the admin sees why.
+
+    Without this the middleware silently denies every origin (including valid
+    ones listed alongside the '*') up to _ORIGINS_CACHE_TTL later.
+    """
+    resp = await client.put(
         "/settings/",
-        json={"settings": {"cors_allowed_origins": "*"}},
+        json={
+            "settings": {
+                "cors_allowed_origins": "https://example.com, *",
+            }
+        },
         headers=admin_auth_header,
     )
+    assert resp.status_code == 422
+    assert "cors_allowed_origins" in resp.json()["detail"]
+
+
+@pytest.mark.anyio
+async def test_cors_wildcard_rejected_with_credentials(
+    client: AsyncClient, test_db_session
+):
+    """Middleware still denies a wildcard reaching it via env, not the settings API.
+
+    validate_cors_allowed_origins guards the settings write path only; the env
+    var flows straight into PersistentConfig, so this guard stays load-bearing.
+    PersistentConfig.set bypasses SETTING_VALIDATORS (those run in the settings
+    router), which is exactly the env-supplied path this covers.
+    """
+    from app.api.middleware import cors as cors_middleware
+    from app.core.persistent_config import CORS_ALLOWED_ORIGINS
+
+    await CORS_ALLOWED_ORIGINS.set(test_db_session, "*")
+    # The allowlist cache is a module global with a 30s TTL and no write-through
+    # invalidation, so a stale entry from an earlier test would mask the result.
+    cors_middleware._origins_cache = (0.0, set())
 
     resp = await client.get("/health", headers={"Origin": "http://anything.com"})
     assert resp.status_code == 200

--- a/frontend/src/i18n/locales/de/admin.json
+++ b/frontend/src/i18n/locales/de/admin.json
@@ -522,7 +522,7 @@
       "globalRateLimit": "Globale Ratenbegrenzung (pro Sekunde)",
       "globalRateLimitDescription": "Maximale API-Anfragen pro Sekunde pro IP-Adresse. Kachelanfragen sind von diesem Limit ausgenommen.",
       "corsAllowedOrigins": "Erlaubte CORS-Ursprünge",
-      "corsAllowedOriginsDescription": "Kommagetrennte Ursprünge. Verwenden Sie * für beliebige Ursprünge.",
+      "corsAllowedOriginsDescription": "Kommagetrennte Ursprünge, jeweils vollständig angegeben. Platzhalter werden nicht akzeptiert – Anfragen mit Anmeldedaten erfordern explizite Ursprünge.",
       "corsAllowedOriginsPlaceholder": "https://example.com, https://app.example.com",
       "ogcItemsMaxPageSize": "OGC Features maximale Seitengröße (Items-Limit-Obergrenze)",
       "ogcItemsMaxPageSizeDescription": "Maximale Anzahl an Features pro Seite am OGC-API-Features-Items-Endpunkt. Anfragen darüber werden begrenzt, nicht abgelehnt. Erhöhen Sie den Wert für den Massen-GeoJSON-Export; verringern Sie ihn bei speicherbeschränkten Deployments."

--- a/frontend/src/i18n/locales/en/admin.json
+++ b/frontend/src/i18n/locales/en/admin.json
@@ -572,7 +572,7 @@
       "globalRateLimit": "Global Rate Limit (per second)",
       "globalRateLimitDescription": "Maximum API requests per second per IP address. Tile requests are excluded from this limit.",
       "corsAllowedOrigins": "CORS Allowed Origins",
-      "corsAllowedOriginsDescription": "Comma-separated origins. Use * for any origin.",
+      "corsAllowedOriginsDescription": "Comma-separated origins, each listed in full. Wildcards are not accepted — credentialed requests require explicit origins.",
       "corsAllowedOriginsPlaceholder": "https://example.com, https://app.example.com",
       "ogcItemsMaxPageSize": "OGC Features Max Page Size (items limit ceiling)",
       "ogcItemsMaxPageSizeDescription": "Maximum number of features returned per page by the OGC API Features items endpoint. Requests above this are clamped, not rejected. Raise it for bulk GeoJSON export; lower it on memory-constrained deployments."

--- a/frontend/src/i18n/locales/es/admin.json
+++ b/frontend/src/i18n/locales/es/admin.json
@@ -522,7 +522,7 @@
       "globalRateLimit": "Limite de tasa global (por segundo)",
       "globalRateLimitDescription": "Solicitudes API maximas por segundo por direccion IP. Las solicitudes de teselas estan excluidas de este limite.",
       "corsAllowedOrigins": "Orígenes CORS permitidos",
-      "corsAllowedOriginsDescription": "Orígenes separados por comas. Use * para permitir cualquier origen.",
+      "corsAllowedOriginsDescription": "Orígenes separados por comas, cada uno indicado por completo. No se aceptan comodines: las solicitudes con credenciales requieren orígenes explícitos.",
       "corsAllowedOriginsPlaceholder": "https://example.com, https://app.example.com",
       "ogcItemsMaxPageSize": "Tamaño máximo de página de OGC Features (límite de items)",
       "ogcItemsMaxPageSizeDescription": "Número máximo de entidades devueltas por página en el endpoint de items de OGC API Features. Las solicitudes que lo superen se ajustan, no se rechazan. Auméntalo para la exportación masiva de GeoJSON; redúcelo en despliegues con memoria limitada."

--- a/frontend/src/i18n/locales/fr/admin.json
+++ b/frontend/src/i18n/locales/fr/admin.json
@@ -522,7 +522,7 @@
       "globalRateLimit": "Limite de debit globale (par seconde)",
       "globalRateLimitDescription": "Nombre maximal de requetes API par seconde par adresse IP. Les requetes de tuiles sont exclues de cette limite.",
       "corsAllowedOrigins": "Origines CORS autorisées",
-      "corsAllowedOriginsDescription": "Origines séparées par des virgules. Utilisez * pour autoriser n'importe quelle origine.",
+      "corsAllowedOriginsDescription": "Origines séparées par des virgules, chacune indiquée en entier. Les caractères génériques ne sont pas acceptés : les requêtes avec identifiants exigent des origines explicites.",
       "corsAllowedOriginsPlaceholder": "https://example.com, https://app.example.com",
       "ogcItemsMaxPageSize": "Taille de page maximale OGC Features (plafond du paramètre items)",
       "ogcItemsMaxPageSizeDescription": "Nombre maximal d'entités renvoyées par page par le point de terminaison items d'OGC API Features. Les requêtes au-delà sont plafonnées, pas rejetées. Augmentez-le pour l'export GeoJSON en masse ; réduisez-le sur les déploiements à mémoire limitée."


### PR DESCRIPTION
## Summary

The admin Settings > Network help text told operators "Use * for any origin" in all four locales. `DynamicCORSMiddleware` does the opposite: because responses carry `Access-Control-Allow-Credentials: true`, a list containing `*` is treated as deny-all and caches an **empty** origin set (`backend/app/api/middleware/cors.py:84-88`). Following the UI's own advice therefore disables CORS for every origin, including any valid ones listed alongside the `*`, with nothing surfaced to the admin and up to `_ORIGINS_CACHE_TTL` (30s) of delay before it even manifests.

This corrects the guidance in en/es/fr/de and rejects the wildcard at the settings write boundary, so it fails immediately as a 422 naming the setting instead of as an unexplained CORS failure in a browser console.

The middleware guard stays load-bearing and is unchanged: `CORS_ALLOWED_ORIGINS` can also arrive from the environment, which does not pass through `SETTING_VALIDATORS`. Both layers are now covered by tests.

Found while checking whether `demo.getgeolens.com` was reachable from GeoLibre's web build (it wasn't; that instance is now configured separately).

## Verification

- `tests/test_persistent_config.py -k cors`: 6 passed, including a new test for the settings-write rejection and the existing middleware guard rewritten to exercise the env path via `PersistentConfig.set` (which bypasses the validator, exactly like an env-supplied value).
- Negative check: with the validator unregistered the new test fails; restored, it passes. It is not vacuous.
- `tests/test_persistent_config.py test_settings_router.py test_settings_admin.py test_config_ops.py test_cli_round_trip.py`: 127 passed, 1 skipped. The validator normalizes whitespace, so the round-trip suites were included deliberately.
- `ruff check` / `ruff format --check` clean; `npm run test:i18n` locale parity passes; all pre-commit hooks green.

## Notes

`.env.example` was already correct and needed no change. No API or schema impact.