### PR TITLE
fix(dataset): correct the visibility help text and pin the restricted rule

### DIFF
--- a/backend/tests/test_datasets.py
+++ b/backend/tests/test_datasets.py
@@ -397,6 +397,41 @@ class TestAnonymousAccess:
         resp = await client.get(f"/datasets/{ds.id}")
         assert resp.status_code == 404
 
+    async def test_logged_in_non_grantee_get_restricted_returns_404(
+        self,
+        client: AsyncClient,
+        admin_auth_header: dict,
+        viewer_auth_header: dict,
+        test_db_session,
+    ):
+        """Restricted requires a role GRANT, not merely a session.
+
+        Every other restricted-denial test signs the caller out, so nothing
+        pinned the authenticated case and the UI told users "Restricted =
+        logged-in users only" for months. The public control rules out a 404
+        from some unrelated cause: the same viewer sees a public dataset
+        built the same way.
+        """
+        admin_id = await _get_user_id(test_db_session, "admin")
+        restricted = await _create_dataset(
+            test_db_session,
+            created_by=admin_id,
+            visibility="restricted",
+            name="Non-Grantee Restricted DS",
+        )
+        public = await _create_dataset(
+            test_db_session,
+            created_by=admin_id,
+            visibility="public",
+            name="Non-Grantee Public DS",
+        )
+        control = await client.get(f"/datasets/{public.id}", headers=viewer_auth_header)
+        assert control.status_code == 200
+        resp = await client.get(
+            f"/datasets/{restricted.id}", headers=viewer_auth_header
+        )
+        assert resp.status_code == 404
+
     async def test_anon_get_attributes_public(
         self, client: AsyncClient, admin_auth_header: dict, test_db_session
     ):

--- a/backend/tests/test_datasets.py
+++ b/backend/tests/test_datasets.py
@@ -404,13 +404,15 @@ class TestAnonymousAccess:
         viewer_auth_header: dict,
         test_db_session,
     ):
-        """Restricted requires a role GRANT, not merely a session.
+        """Restricted requires a role GRANT, not merely a session — but admins bypass it.
 
         Every other restricted-denial test signs the caller out, so nothing
         pinned the authenticated case and the UI told users "Restricted =
         logged-in users only" for months. The public control rules out a 404
         from some unrelated cause: the same viewer sees a public dataset
-        built the same way.
+        built the same way. The admin leg pins the other half of the help
+        text (fix(#690) review) — `can_access_dataset` returns True on the
+        admin role before it ever looks for a grant.
         """
         admin_id = await _get_user_id(test_db_session, "admin")
         restricted = await _create_dataset(
@@ -431,6 +433,12 @@ class TestAnonymousAccess:
             f"/datasets/{restricted.id}", headers=viewer_auth_header
         )
         assert resp.status_code == 404
+
+        # ...while an admin reads the same dataset with no grant at all.
+        as_admin = await client.get(
+            f"/datasets/{restricted.id}", headers=admin_auth_header
+        )
+        assert as_admin.status_code == 200
 
     async def test_anon_get_attributes_public(
         self, client: AsyncClient, admin_auth_header: dict, test_db_session

--- a/frontend/src/i18n/locales/de/dataset.json
+++ b/frontend/src/i18n/locales/de/dataset.json
@@ -172,7 +172,7 @@
     "visibilityPublic": "Öffentlich",
     "visibilityPrivate": "Privat",
     "visibilityRestricted": "Eingeschränkt",
-    "visibilityHelp": "Öffentlich = für alle sichtbar. Eingeschränkt = nur angemeldete Benutzer. Privat = nur Bearbeiter und Administratoren.",
+    "visibilityHelp": "Öffentlich = für alle sichtbar, auch für nicht angemeldete Besucher. Eingeschränkt = nur Benutzer, deren Rolle Zugriff erhalten hat. Privat = nur der Eigentümer und Administratoren.",
     "sourceOrganization": "Quellorganisation",
     "license": "Lizenz",
     "vintageStart": "Datenstand Beginn",

--- a/frontend/src/i18n/locales/de/dataset.json
+++ b/frontend/src/i18n/locales/de/dataset.json
@@ -172,7 +172,7 @@
     "visibilityPublic": "Öffentlich",
     "visibilityPrivate": "Privat",
     "visibilityRestricted": "Eingeschränkt",
-    "visibilityHelp": "Öffentlich = für alle sichtbar, auch für nicht angemeldete Besucher. Eingeschränkt = nur Benutzer, deren Rolle Zugriff erhalten hat. Privat = nur der Eigentümer und Administratoren.",
+    "visibilityHelp": "Öffentlich = für alle sichtbar, auch für nicht angemeldete Besucher. Eingeschränkt = nur Administratoren und Benutzer, deren Rolle Zugriff erhalten hat. Privat = nur der Eigentümer und Administratoren.",
     "sourceOrganization": "Quellorganisation",
     "license": "Lizenz",
     "vintageStart": "Datenstand Beginn",

--- a/frontend/src/i18n/locales/de/import.json
+++ b/frontend/src/i18n/locales/de/import.json
@@ -209,7 +209,7 @@
     "visibilityPrivate": "Privat",
     "visibilityRestricted": "Eingeschränkt",
     "visibilityPublic": "Öffentlich",
-    "visibilityHelp": "Öffentlich = für alle sichtbar, auch für nicht angemeldete Besucher. Eingeschränkt = nur Benutzer, deren Rolle Zugriff erhalten hat. Privat = nur der Eigentümer und Administratoren.",
+    "visibilityHelp": "Öffentlich = für alle sichtbar, auch für nicht angemeldete Besucher. Eingeschränkt = nur Administratoren und Benutzer, deren Rolle Zugriff erhalten hat. Privat = nur der Eigentümer und Administratoren.",
     "registering": "Registrierung läuft...",
     "registerButton_one": "{{count}} Tabelle registrieren",
     "registerButton_other": "{{count}} Tabellen registrieren",

--- a/frontend/src/i18n/locales/de/import.json
+++ b/frontend/src/i18n/locales/de/import.json
@@ -209,7 +209,7 @@
     "visibilityPrivate": "Privat",
     "visibilityRestricted": "Eingeschränkt",
     "visibilityPublic": "Öffentlich",
-    "visibilityHelp": "Öffentlich = für alle sichtbar. Eingeschränkt = nur angemeldete Benutzer. Privat = nur Bearbeiter und Administratoren.",
+    "visibilityHelp": "Öffentlich = für alle sichtbar, auch für nicht angemeldete Besucher. Eingeschränkt = nur Benutzer, deren Rolle Zugriff erhalten hat. Privat = nur der Eigentümer und Administratoren.",
     "registering": "Registrierung läuft...",
     "registerButton_one": "{{count}} Tabelle registrieren",
     "registerButton_other": "{{count}} Tabellen registrieren",

--- a/frontend/src/i18n/locales/en/dataset.json
+++ b/frontend/src/i18n/locales/en/dataset.json
@@ -172,7 +172,7 @@
     "visibilityPublic": "Public",
     "visibilityPrivate": "Private",
     "visibilityRestricted": "Restricted",
-    "visibilityHelp": "Public = visible to everyone, including signed-out visitors. Restricted = only users whose role has been granted access. Private = only the owner and admins.",
+    "visibilityHelp": "Public = visible to everyone, including signed-out visitors. Restricted = only admins and users whose role has been granted access. Private = only the owner and admins.",
     "sourceOrganization": "Source Organization",
     "license": "License",
     "vintageStart": "Data Vintage Start",

--- a/frontend/src/i18n/locales/en/dataset.json
+++ b/frontend/src/i18n/locales/en/dataset.json
@@ -172,7 +172,7 @@
     "visibilityPublic": "Public",
     "visibilityPrivate": "Private",
     "visibilityRestricted": "Restricted",
-    "visibilityHelp": "Public = visible to all. Restricted = logged-in users only. Private = editors and admins only.",
+    "visibilityHelp": "Public = visible to everyone, including signed-out visitors. Restricted = only users whose role has been granted access. Private = only the owner and admins.",
     "sourceOrganization": "Source Organization",
     "license": "License",
     "vintageStart": "Data Vintage Start",

--- a/frontend/src/i18n/locales/en/import.json
+++ b/frontend/src/i18n/locales/en/import.json
@@ -252,7 +252,7 @@
     "visibilityPrivate": "Private",
     "visibilityRestricted": "Restricted",
     "visibilityPublic": "Public",
-    "visibilityHelp": "Public = visible to everyone, including signed-out visitors. Restricted = only users whose role has been granted access. Private = only the owner and admins.",
+    "visibilityHelp": "Public = visible to everyone, including signed-out visitors. Restricted = only admins and users whose role has been granted access. Private = only the owner and admins.",
     "registering": "Registering...",
     "registerButton_one": "Register {{count}} Table",
     "registerButton_other": "Register {{count}} Tables",

--- a/frontend/src/i18n/locales/en/import.json
+++ b/frontend/src/i18n/locales/en/import.json
@@ -252,7 +252,7 @@
     "visibilityPrivate": "Private",
     "visibilityRestricted": "Restricted",
     "visibilityPublic": "Public",
-    "visibilityHelp": "Public = visible to all. Restricted = logged-in users only. Private = editors and admins only.",
+    "visibilityHelp": "Public = visible to everyone, including signed-out visitors. Restricted = only users whose role has been granted access. Private = only the owner and admins.",
     "registering": "Registering...",
     "registerButton_one": "Register {{count}} Table",
     "registerButton_other": "Register {{count}} Tables",

--- a/frontend/src/i18n/locales/es/dataset.json
+++ b/frontend/src/i18n/locales/es/dataset.json
@@ -172,7 +172,7 @@
     "visibilityPublic": "Público",
     "visibilityPrivate": "Privado",
     "visibilityRestricted": "Restringido",
-    "visibilityHelp": "Público = visible para todos, incluidos los visitantes sin sesión iniciada. Restringido = solo usuarios cuyo rol tenga acceso concedido. Privado = solo el propietario y los administradores.",
+    "visibilityHelp": "Público = visible para todos, incluidos los visitantes sin sesión iniciada. Restringido = solo los administradores y los usuarios cuyo rol tenga acceso concedido. Privado = solo el propietario y los administradores.",
     "sourceOrganization": "Organización de origen",
     "license": "Licencia",
     "vintageStart": "Inicio de fecha de datos",

--- a/frontend/src/i18n/locales/es/dataset.json
+++ b/frontend/src/i18n/locales/es/dataset.json
@@ -172,7 +172,7 @@
     "visibilityPublic": "Público",
     "visibilityPrivate": "Privado",
     "visibilityRestricted": "Restringido",
-    "visibilityHelp": "Público = visible para todos. Restringido = solo usuarios con sesión iniciada. Privado = solo editores y administradores.",
+    "visibilityHelp": "Público = visible para todos, incluidos los visitantes sin sesión iniciada. Restringido = solo usuarios cuyo rol tenga acceso concedido. Privado = solo el propietario y los administradores.",
     "sourceOrganization": "Organización de origen",
     "license": "Licencia",
     "vintageStart": "Inicio de fecha de datos",

--- a/frontend/src/i18n/locales/es/import.json
+++ b/frontend/src/i18n/locales/es/import.json
@@ -208,7 +208,7 @@
     "visibilityLabel": "Visibilidad",
     "visibilityPrivate": "Privado",
     "visibilityRestricted": "Restringido",
-    "visibilityHelp": "Público = visible para todos, incluidos los visitantes sin sesión iniciada. Restringido = solo usuarios cuyo rol tenga acceso concedido. Privado = solo el propietario y los administradores.",
+    "visibilityHelp": "Público = visible para todos, incluidos los visitantes sin sesión iniciada. Restringido = solo los administradores y los usuarios cuyo rol tenga acceso concedido. Privado = solo el propietario y los administradores.",
     "visibilityPublic": "Público",
     "registering": "Registrando...",
     "registerButton_one": "Registrar {{count}} tabla",

--- a/frontend/src/i18n/locales/es/import.json
+++ b/frontend/src/i18n/locales/es/import.json
@@ -208,7 +208,7 @@
     "visibilityLabel": "Visibilidad",
     "visibilityPrivate": "Privado",
     "visibilityRestricted": "Restringido",
-    "visibilityHelp": "Público = visible para todos. Restringido = solo usuarios con sesión iniciada. Privado = solo editores y administradores.",
+    "visibilityHelp": "Público = visible para todos, incluidos los visitantes sin sesión iniciada. Restringido = solo usuarios cuyo rol tenga acceso concedido. Privado = solo el propietario y los administradores.",
     "visibilityPublic": "Público",
     "registering": "Registrando...",
     "registerButton_one": "Registrar {{count}} tabla",

--- a/frontend/src/i18n/locales/fr/dataset.json
+++ b/frontend/src/i18n/locales/fr/dataset.json
@@ -172,7 +172,7 @@
     "visibilityPublic": "Publique",
     "visibilityPrivate": "Privé",
     "visibilityRestricted": "Restreint",
-    "visibilityHelp": "Publique = visible par tous. Restreint = utilisateurs connectés uniquement. Privé = éditeurs et administrateurs uniquement.",
+    "visibilityHelp": "Publique = visible par tous, y compris les visiteurs non connectés. Restreint = uniquement les utilisateurs dont le rôle a reçu l'accès. Privé = uniquement le propriétaire et les administrateurs.",
     "sourceOrganization": "Organisation source",
     "license": "Licence",
     "vintageStart": "Début du millésime",

--- a/frontend/src/i18n/locales/fr/dataset.json
+++ b/frontend/src/i18n/locales/fr/dataset.json
@@ -172,7 +172,7 @@
     "visibilityPublic": "Publique",
     "visibilityPrivate": "Privé",
     "visibilityRestricted": "Restreint",
-    "visibilityHelp": "Publique = visible par tous, y compris les visiteurs non connectés. Restreint = uniquement les utilisateurs dont le rôle a reçu l'accès. Privé = uniquement le propriétaire et les administrateurs.",
+    "visibilityHelp": "Publique = visible par tous, y compris les visiteurs non connectés. Restreint = uniquement les administrateurs et les utilisateurs dont le rôle a reçu l'accès. Privé = uniquement le propriétaire et les administrateurs.",
     "sourceOrganization": "Organisation source",
     "license": "Licence",
     "vintageStart": "Début du millésime",

--- a/frontend/src/i18n/locales/fr/import.json
+++ b/frontend/src/i18n/locales/fr/import.json
@@ -209,7 +209,7 @@
     "visibilityPrivate": "Privé",
     "visibilityRestricted": "Restreint",
     "visibilityPublic": "Publique",
-    "visibilityHelp": "Publique = visible par tous, y compris les visiteurs non connectés. Restreint = uniquement les utilisateurs dont le rôle a reçu l'accès. Privé = uniquement le propriétaire et les administrateurs.",
+    "visibilityHelp": "Publique = visible par tous, y compris les visiteurs non connectés. Restreint = uniquement les administrateurs et les utilisateurs dont le rôle a reçu l'accès. Privé = uniquement le propriétaire et les administrateurs.",
     "registering": "Enregistrement...",
     "registerButton_one": "Enregistrer {{count}} table",
     "registerButton_other": "Enregistrer {{count}} tables",

--- a/frontend/src/i18n/locales/fr/import.json
+++ b/frontend/src/i18n/locales/fr/import.json
@@ -209,7 +209,7 @@
     "visibilityPrivate": "Privé",
     "visibilityRestricted": "Restreint",
     "visibilityPublic": "Publique",
-    "visibilityHelp": "Publique = visible par tous. Restreint = utilisateurs connectés uniquement. Privé = éditeurs et administrateurs uniquement.",
+    "visibilityHelp": "Publique = visible par tous, y compris les visiteurs non connectés. Restreint = uniquement les utilisateurs dont le rôle a reçu l'accès. Privé = uniquement le propriétaire et les administrateurs.",
     "registering": "Enregistrement...",
     "registerButton_one": "Enregistrer {{count}} table",
     "registerButton_other": "Enregistrer {{count}} tables",


### PR DESCRIPTION
## Summary

The dataset Access tab describes what each visibility level means, and two of its three clauses were wrong:

| Copy said | Code actually does |
|---|---|
| `Restricted` = logged-in users only | Requires a `DatasetGrant` joined through the caller's `UserRole`. A session alone grants nothing. |
| `Private` = editors and admins only | The record's **creator** plus admins. There is no editor bypass — only `"admin"` short-circuits. |

Both `can_access_dataset` and `filter_visible` (`backend/app/platform/extensions/defaults.py`) agree on this, so the detail and list paths are consistent — it was only the description that drifted.

Getting `restricted` backwards is the expensive direction: an owner reading "logged-in users only" picks Restricted expecting their signed-in team to see the dataset, when in practice **nobody** does. Grants have no UI and no API — every `DatasetGrant` reference in the backend is a read for visibility filtering, so today only hand-written SQL can create one.

## Changes

- Corrected `visibilityHelp` in the `dataset` **and** `import` namespaces across all four locales (en/es/fr/de) — the same string is duplicated in both.
- Added `test_logged_in_non_grantee_get_restricted_returns_404`.

`import.visibilityHelp` is not currently rendered — `ImportMetadataForm` shows Label + Select with no help line. Corrected anyway so the dead copy is not a trap for whoever wires it up. Wiring it in is a separate call and not done here.

## Why there was no test

The authenticated non-grantee case had **zero** coverage. Every existing restricted-denial test signs the caller out (`test_anon_get_restricted_dataset_returns_404`, `test_export_access.py`, `test_permission_overlay.py:213`), so nothing pinned the rule the copy was describing. That is how the wrong text survived. The new test includes a public control so a 404 from any unrelated cause (record status, fixture wiring) can't make it pass vacuously.

## Impact

Copy-only plus one test. No schema, API, or config change. No new i18n keys, so locale parity is unaffected.

## Verification

```
cd backend && uv run pytest tests/test_datasets.py -k restricted -v   # 2 passed
cd frontend && npm run test:i18n                                      # 4 passed
```

https://claude.ai/code/session_01X1Wd3Frww9F2eovfMkUbG2
