### PR TITLE
fix(analysis): correctness & lifecycle hardening batch from the 07-25 audit

### DIFF
--- a/backend/app/modules/catalog/datasets/api/router_analysis.py
+++ b/backend/app/modules/catalog/datasets/api/router_analysis.py
@@ -10,7 +10,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.core.db.tenant_session import defer_async_with_tenant
 from app.core.dependencies import get_db
 from app.core.identity import Identity
-from app.modules.auth.dependencies import get_current_active_user
+from app.modules.auth.dependencies import get_current_active_user, require_permission
 from app.modules.catalog.authorization import check_dataset_access
 from app.modules.catalog.datasets.domain.schemas import (
     AnalysisMaterializeRequest,
@@ -130,13 +130,18 @@ async def analysis_materialize_endpoint(
     dataset_id: uuid.UUID,
     body: AnalysisMaterializeRequest,
     request: Request,
-    user: Identity = Depends(get_current_active_user),
+    # fix(#692): materialize creates a dataset, so it carries the same
+    # permission as every ingest endpoint that creates one. Preview stays on
+    # the plain active-user dependency: it is read-only, persists nothing,
+    # and the chat tool's read-only surface depends on it.
+    user: Identity = Depends(require_permission("upload")),
     db: AsyncSession = Depends(get_db),
 ) -> AnalysisMaterializeResponse:
     """Materialize an analysis result as a new private dataset (async job).
 
-    Requires read visibility on the source dataset; the new dataset is owned
-    by the caller and counted against their dataset quota (the atomic slot
+    Requires the ``upload`` permission (this endpoint creates a dataset) and
+    read visibility on the source dataset; the new dataset is owned by the
+    caller and counted against their dataset quota (the atomic slot
     reservation runs at registration inside the worker). Poll
     ``GET /jobs/{job_id}`` for progress.
     """

--- a/backend/app/modules/catalog/datasets/domain/service_analysis.py
+++ b/backend/app/modules/catalog/datasets/domain/service_analysis.py
@@ -58,17 +58,19 @@ def build_preview_sql(
     # preview budget along a shared boundary and hide real intersections with
     # higher gids, even reporting a false "no features".
     #
-    # fix(#692): fence the subquery for clip only. Three outer references to
-    # geom_out would otherwise let the planner flatten _op and evaluate
-    # ST_Intersection three times per row — and clip's WHERE means every
-    # mask-matching row is evaluated before the LIMIT can stop anything.
-    # buffer/centroid must stay flattenable: the pull-up is what lets their
-    # ORDER BY gid ride the pkey index and halt at the row cap.
-    fence = " OFFSET 0" if request.operation == "clip" else ""
+    # fix(#700 review): evaluate the geometry expression exactly once per row
+    # via a LATERAL subquery whose OFFSET 0 blocks pull-up — three outer
+    # references to geom_out would otherwise be inlined and evaluated three
+    # times per row. Unlike fencing the whole row source, the join shape
+    # keeps ORDER BY gid able to ride the pkey index, so the sandbox row cap
+    # can still stop the scan early instead of evaluating every mask match.
+    not_empty = "geom_out IS NOT NULL AND NOT ST_IsEmpty(geom_out)"
+    filters = f"{where} AND {not_empty}" if where else f" WHERE {not_empty}"
     return (
         f"{cte}SELECT gid, ST_AsGeoJSON(geom_out, {_GEOJSON_PRECISION}) AS geometry_json"
-        f" FROM (SELECT gid, {expr} AS geom_out FROM {table_ref}{where}{fence}) AS _op"
-        f" WHERE geom_out IS NOT NULL AND NOT ST_IsEmpty(geom_out)"
+        f" FROM {table_ref}"
+        f" CROSS JOIN LATERAL (SELECT {expr} AS geom_out OFFSET 0) AS _op"
+        f"{filters}"
         f" ORDER BY gid"
     )
 

--- a/backend/app/modules/catalog/datasets/domain/service_analysis.py
+++ b/backend/app/modules/catalog/datasets/domain/service_analysis.py
@@ -57,9 +57,17 @@ def build_preview_sql(
     # (which pass ST_Intersects but extract to EMPTY) could consume the whole
     # preview budget along a shared boundary and hide real intersections with
     # higher gids, even reporting a false "no features".
+    #
+    # fix(#692): fence the subquery for clip only. Three outer references to
+    # geom_out would otherwise let the planner flatten _op and evaluate
+    # ST_Intersection three times per row — and clip's WHERE means every
+    # mask-matching row is evaluated before the LIMIT can stop anything.
+    # buffer/centroid must stay flattenable: the pull-up is what lets their
+    # ORDER BY gid ride the pkey index and halt at the row cap.
+    fence = " OFFSET 0" if request.operation == "clip" else ""
     return (
         f"{cte}SELECT gid, ST_AsGeoJSON(geom_out, {_GEOJSON_PRECISION}) AS geometry_json"
-        f" FROM (SELECT gid, {expr} AS geom_out FROM {table_ref}{where}) AS _op"
+        f" FROM (SELECT gid, {expr} AS geom_out FROM {table_ref}{where}{fence}) AS _op"
         f" WHERE geom_out IS NOT NULL AND NOT ST_IsEmpty(geom_out)"
         f" ORDER BY gid"
     )

--- a/backend/app/processing/analysis/tasks.py
+++ b/backend/app/processing/analysis/tasks.py
@@ -12,20 +12,26 @@ from __future__ import annotations
 import asyncio
 import re
 import uuid
-from datetime import datetime, timezone
 from types import SimpleNamespace
 from typing import Any
 
 import structlog
 from prometheus_client import Counter
 from sqlalchemy import select, text
+from sqlalchemy.exc import DataError, InternalError, SQLAlchemyError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.db.tenant_schema import tenant_data_schema
 from app.core.db.tenant_session import current_tenant_var, tenant_task
 from app.core.tenancy import is_multi_tenant
 from app.platform.analysis_sql import render_geometry_expr, render_mask_cte
-from app.platform.jobs.heartbeat import maintain_ingest_job_heartbeat
+from app.platform.jobs.heartbeat import (
+    claim_ingest_job_attempt,
+    maintain_ingest_job_heartbeat,
+    resolve_ingest_job_attempt,
+    stop_ingest_job_heartbeat,
+    update_ingest_job_for_attempt,
+)
 from app.processing.ingest.tasks import task_app
 
 logger = structlog.stdlib.get_logger(__name__)
@@ -38,6 +44,14 @@ _SAFE_TABLE = re.compile(r"^[a-z0-9_]+$")
 # ponytail: hardcoded ceiling; promote to persistent-config if operators hit it.
 MATERIALIZE_TIMEOUT = "300s"
 
+# The mid-task commit that makes the output table durable also ends the
+# transaction carrying MATERIALIZE_TIMEOUT — registration then runs full-scan
+# metadata extraction (COUNT + ST_Extent + the sample-values CTE) in a fresh
+# transaction, which would otherwise have no statement budget at all
+# (fix(#692)). Larger than the CTAS budget: those scans are cheap relative to
+# the build, but must never be unbounded.
+REGISTRATION_TIMEOUT = "600s"
+
 # Served by the worker's :8001 /metrics endpoint (default registry).
 # ponytail: analysis-only counter; generalize to all ingest job types when
 # another type needs it.
@@ -46,6 +60,102 @@ ANALYSIS_JOBS = Counter(
     "Materialize-analysis job outcomes",
     ["operation", "status"],
 )
+
+
+def _user_error_message(exc: Exception) -> str:
+    """Map a failure onto text safe to return from ``GET /jobs/{job_id}``.
+
+    SQLAlchemy stringifies DB errors with the full statement appended
+    (``[SQL: CREATE TABLE "data"."…" AS …]``), which would hand internal
+    schema and table names to the client (fix(#692)). Mirrors the sandbox's
+    ``_handle_execution_error`` categories; raw text stays in server logs.
+    """
+    if isinstance(exc, SQLAlchemyError):
+        exc_text = str(exc).lower()
+        if "querycancelederror" in exc_text or "statement timeout" in exc_text:
+            return (
+                "The analysis exceeded its processing time limit. "
+                "Try a smaller dataset or area."
+            )
+        if isinstance(exc, (DataError, InternalError)):
+            return "The analysis failed while processing this data"
+        return "The analysis failed due to a database error"
+    return str(exc)[:2000]
+
+
+async def _fail_cancelled_job(
+    *,
+    job_id: str,
+    attempt_id: uuid.UUID,
+    schema: str,
+    out_table: str | None,
+    operation: str,
+) -> None:
+    """Bookkeeping for a materialize cancelled mid-run, on a fresh session.
+
+    Fenced on the attempt token FIRST: a successful fence proves the row was
+    still 'running', so the final registration commit (which atomically
+    persists the dataset and flips the row to 'complete') has not happened,
+    and any committed output table is an unregistered orphan — safe to drop.
+    If the fence misses, the job already reached a terminal state and the
+    table must be left alone.
+    """
+    from app.core.db import async_session
+
+    async with async_session() as session:
+        if not await update_ingest_job_for_attempt(
+            session,
+            uuid.UUID(job_id),
+            attempt_id,
+            values={
+                "status": "failed",
+                "error_message": (
+                    "The worker shut down before this analysis finished. Run it again."
+                ),
+            },
+        ):
+            await session.rollback()
+            return
+        await session.commit()
+        if out_table is not None:
+            try:
+                await session.execute(
+                    text(f'DROP TABLE IF EXISTS "{schema}"."{out_table}"')
+                )
+                await session.commit()
+            except Exception:  # broad: best-effort cleanup of the partial table
+                await session.rollback()
+    ANALYSIS_JOBS.labels(operation=operation, status="failed").inc()
+
+
+async def _mark_job_failed(
+    session: AsyncSession,
+    *,
+    job_id: str,
+    exc: Exception,
+    schema: str,
+    out_table: str | None,
+    operation: str,
+) -> None:
+    """Roll back, drop this job's own partial table, and record the failure."""
+    from app.platform.jobs.models import IngestJob
+
+    await session.rollback()
+    if out_table is not None:
+        try:
+            await session.execute(
+                text(f'DROP TABLE IF EXISTS "{schema}"."{out_table}"')
+            )
+            await session.commit()
+        except Exception:  # broad: best-effort cleanup of the partial table
+            await session.rollback()
+    failed_job = await session.get(IngestJob, uuid.UUID(job_id))
+    if failed_job is not None:
+        failed_job.status = "failed"
+        # Sanitized (fix(#692)): raw DB errors embed the generated SQL.
+        failed_job.error_message = _user_error_message(exc)
+        await session.commit()
+    ANALYSIS_JOBS.labels(operation=operation, status="failed").inc()
 
 
 async def _list_carry_columns(
@@ -131,45 +241,34 @@ async def _materialize(
         if job is None:
             logger.warning("analysis.job_not_found", job_id=job_id)
             return
-        job.status = "running"
-        # Stamp the start time. Without it this row carries NO liveness signal
-        # at all, and the platform's stale-job recovery matches on
-        # `coalesce(heartbeat_at, started_at) < cutoff` — which is NULL for
-        # such a row, so a worker that dies mid-CTAS would strand the job in
-        # 'running' forever.
-        _now = datetime.now(timezone.utc)
-        job.started_at = _now
-        # ...and renew a lease from here on, or started_at alone would condemn
-        # a job that legitimately outlives JOB_TIMEOUT_SECONDS (fix(#682
-        # review)). statement_timeout bounds each STATEMENT, not the task: the
-        # CTAS, DELETE, EXISTS probe, two ALTERs, the primary key,
-        # add_4326_column and registration each get their own budget, so a
-        # large materialize can run long. Without a lease the sweep would mark
-        # a live job failed, the watcher would report a false failure, the
-        # per-user slot would reopen for a second CTAS, and this worker would
-        # later overwrite 'failed' with 'complete'.
+        # Fenced claim (fix(#692), the ingest_file pattern): pending → running
+        # succeeds at most once per attempt token, and stamps
+        # started_at/heartbeat_at — the liveness signals the stale-job sweep
+        # and the lease below depend on (fix(#682 review): statement_timeout
+        # bounds each STATEMENT, not the task, so a large materialize can
+        # legitimately run long and only the lease keeps it out of the sweep).
+        # Without the claim this worker would act on rows some other actor
+        # already moved to a terminal state — the pending-sweeper failing a
+        # backlogged job after an hour, or the defer orphan-guard failing the
+        # row after the queue INSERT committed — and resurrect them: the
+        # per-user cap admits a second CTAS, and a dataset appears for a job
+        # the user was told failed.
         #
-        # Reuse the token the row already carries (IngestJob.attempt_id
-        # defaults to uuid4 at creation) rather than minting a fresh one —
-        # rotating it here would invalidate the token the enqueue side
-        # recorded, and this task is retry=0 so there is no second delivery to
-        # fence against. The fallback covers rows predating that default.
-        attempt_id = job.attempt_id
-        if attempt_id is None:
-            attempt_id = uuid.uuid4()
-            job.attempt_id = attempt_id
-        job.heartbeat_at = _now
+        # The row's own attempt_id is the token (column-defaulted at
+        # creation; retry=0, so there is no second delivery to fence against).
+        # Rows predating that default are adopted atomically.
+        attempt_id = job.attempt_id or await resolve_ingest_job_attempt(job.id, None)
+        if attempt_id is None or not await claim_ingest_job_attempt(
+            session, job.id, attempt_id
+        ):
+            await session.rollback()
+            logger.warning("analysis.attempt_not_claimed", job_id=job_id)
+            return
         # current_step only, no numeric progress: the operation is a single
         # CTAS, so there is no intra-statement telemetry to report and a bar
         # parked at 10% for five minutes reads as "stuck" rather than "busy".
         job.current_step = "analyzing"
         await session.commit()
-
-        # Renews on its own session, so it never contends with the work below,
-        # and returns by itself once the row leaves 'running'.
-        heartbeat = asyncio.create_task(
-            maintain_ingest_job_heartbeat(job.id, attempt_id)
-        )
 
         _schema = tenant_data_schema(
             current_tenant_var.get() if is_multi_tenant() else None
@@ -180,7 +279,17 @@ async def _materialize(
         # generated name, an unconditional cleanup would destroy the winner's
         # table while its dataset registration stays live.
         out_table_created = False
+        # Created inside the try so the finally below always reaps it: a
+        # heartbeat left running after an exception here would renew a lease
+        # for a job nobody is executing, and the sweep can never fail a row
+        # with a fresh lease (fix(#692)).
+        heartbeat: asyncio.Task[None] | None = None
         try:
+            # Renews on its own session, so it never contends with the work
+            # below, and returns by itself once the row leaves 'running'.
+            heartbeat = asyncio.create_task(
+                maintain_ingest_job_heartbeat(job.id, attempt_id)
+            )
             port = get_processing_port()
             Dataset = port.get_dataset_orm_class()
             result = await session.execute(
@@ -232,17 +341,18 @@ async def _materialize(
             )
             await session.execute(text(f"CREATE TABLE {out_ref} AS {select_sql}"))
             out_table_created = True
-            if operation == "clip":
-                # Boundary-grazing rows survive ST_Intersects but extract to
-                # EMPTY (see analysis_sql.render_geometry_expr) — drop them.
-                await session.execute(
-                    text(f"DELETE FROM {out_ref} WHERE ST_IsEmpty(geom)")
-                )
+            # Rows with nothing to show are dropped for EVERY operation, not
+            # just clip (fix(#692)): buffer/centroid map NULL source
+            # geometries to NULL, dissolve unions an all-NULL group to NULL,
+            # and boundary-grazing clips survive ST_Intersects but extract to
+            # EMPTY (see analysis_sql.render_geometry_expr). The preview
+            # filters the same rows in SQL (fix(#680 review)) — the saved
+            # dataset must agree with the preview the user approved.
+            await session.execute(
+                text(f"DELETE FROM {out_ref} WHERE geom IS NULL OR ST_IsEmpty(geom)")
+            )
             has_features = await session.scalar(
-                text(
-                    f"SELECT EXISTS (SELECT 1 FROM {out_ref} "
-                    f"WHERE geom IS NOT NULL AND NOT ST_IsEmpty(geom))"
-                )
+                text(f"SELECT EXISTS (SELECT 1 FROM {out_ref})")
             )
             if not has_features:
                 # e.g. a clip matching nothing, or dissolving an empty
@@ -259,9 +369,22 @@ async def _materialize(
             )
             await session.execute(text(f"ALTER TABLE {out_ref} ADD PRIMARY KEY (gid)"))
             await add_4326_column(session, out_table, 4326, schema=_schema)
+            # In-transaction ANALYZE (fix(#692)): the table only becomes
+            # visible to autovacuum at the commit below, and the first tile
+            # queries land before its pass — without statistics the planner
+            # has no geometry selectivity for `&&` against the fresh GIST
+            # index and can seq-scan a large output.
+            await session.execute(text(f"ANALYZE {out_ref}"))
             job.current_step = "registering"
             await session.commit()
 
+            # The commit above ended the transaction and the SET LOCAL with
+            # it — give registration its own budget (fix(#692)). Set here
+            # rather than inside register_existing_table, which is shared
+            # with the upload path.
+            await session.execute(
+                text(f"SET LOCAL statement_timeout = '{REGISTRATION_TIMEOUT}'")
+            )
             # Identity is a structural Protocol; registration only reads .id.
             requester = SimpleNamespace(id=uuid.UUID(user_id))
             dataset = await register_existing_table(
@@ -275,28 +398,52 @@ async def _materialize(
             job.status = "complete"
             await session.commit()
             ANALYSIS_JOBS.labels(operation=operation, status="complete").inc()
-        except Exception as exc:  # broad: any failure must mark the job failed, not raise into the queue
-            logger.warning("analysis.materialize_failed", job_id=job_id, error=str(exc))
-            await session.rollback()
-            if out_table and out_table_created:
-                try:
-                    await session.execute(
-                        text(f'DROP TABLE IF EXISTS "{_schema}"."{out_table}"')
+        except asyncio.CancelledError:
+            # Graceful worker shutdown cancels this task after the drain
+            # window; `except Exception` cannot catch it, and retry=0 means no
+            # redelivery — without this branch the row would strand in
+            # 'running', holding the user's one analysis slot, until the
+            # 60-minute sweep (fix(#692)). Bookkeeping runs on a fresh session
+            # (this one may be mid-statement) and is shielded so the
+            # cancellation doesn't also cancel it; then re-raise so the queue
+            # records the abort.
+            try:
+                await asyncio.shield(
+                    asyncio.wait_for(
+                        _fail_cancelled_job(
+                            job_id=job_id,
+                            attempt_id=attempt_id,
+                            schema=_schema,
+                            out_table=out_table if out_table_created else None,
+                            operation=operation,
+                        ),
+                        timeout=15,
                     )
-                    await session.commit()
-                except Exception:  # broad: best-effort cleanup of the partial table
-                    await session.rollback()
-            failed_job = await session.get(IngestJob, uuid.UUID(job_id))
-            if failed_job is not None:
-                failed_job.status = "failed"
-                failed_job.error_message = str(exc)[:2000]
-                await session.commit()
-            ANALYSIS_JOBS.labels(operation=operation, status="failed").inc()
+                )
+            except BaseException:  # broad: best-effort cleanup during shutdown; the raise below preserves the abort
+                logger.warning("analysis.cancel_cleanup_failed", job_id=job_id)
+            raise
+        except Exception as exc:  # broad: any failure must mark the job failed, not raise into the queue
+            logger.warning(
+                "analysis.materialize_failed",
+                job_id=job_id,
+                error=str(exc),
+                exc_info=True,
+            )
+            await _mark_job_failed(
+                session,
+                job_id=job_id,
+                exc=exc,
+                schema=_schema,
+                out_table=out_table if out_table_created else None,
+                operation=operation,
+            )
         finally:
             # The row has left 'running' by now, so the loop would exit on its
-            # own at the next renewal — cancel so the task does not outlive the
-            # work by up to one heartbeat interval.
-            heartbeat.cancel()
+            # own at the next renewal — stop (cancel + await, the ingest
+            # convention) so the task neither outlives the work by a heartbeat
+            # interval nor leaks a pending task through worker shutdown.
+            await stop_ingest_job_heartbeat(heartbeat)
 
 
 @task_app.task(

--- a/backend/app/processing/analysis/tasks.py
+++ b/backend/app/processing/analysis/tasks.py
@@ -84,6 +84,7 @@ def _user_error_message(exc: Exception) -> str:
 
 
 async def _fail_cancelled_job(
+    working_session: AsyncSession,
     *,
     job_id: str,
     attempt_id: uuid.UUID,
@@ -101,6 +102,17 @@ async def _fail_cancelled_job(
     table must be left alone.
     """
     from app.core.db import async_session
+
+    # fix(#700 review): the cancel can land while `working_session`'s open
+    # transaction still holds the job-row lock (any flush since its last
+    # commit, e.g. mid-commit). Release it first — time-bounded so a wedged
+    # connection can't eat the whole shield window — or the fenced update
+    # below waits on our own lock until the shield timeout and the row
+    # strands in 'running' anyway.
+    try:
+        await asyncio.wait_for(working_session.rollback(), timeout=5)
+    except Exception:  # broad: cleanup must reach the fenced update regardless
+        logger.warning("analysis.cancel_rollback_failed", job_id=job_id)
 
     async with async_session() as session:
         if not await update_ingest_job_for_attempt(
@@ -411,6 +423,7 @@ async def _materialize(
                 await asyncio.shield(
                     asyncio.wait_for(
                         _fail_cancelled_job(
+                            session,
                             job_id=job_id,
                             attempt_id=attempt_id,
                             schema=_schema,

--- a/backend/app/processing/ingest/service.py
+++ b/backend/app/processing/ingest/service.py
@@ -455,6 +455,26 @@ async def generate_table_name(
     )
     existing = {row[0] for row in result.all()}
 
+    # fix(#692): also collide against live relations. A worker killed between
+    # committing an output table and registering it leaves a physical table
+    # with no Dataset row; a catalog-only probe would hand out that name
+    # forever, failing every retry on CREATE TABLE. The retry self-heals to a
+    # _N suffix instead — deliberately NO auto-DROP of the orphan here.
+    from app.core.db.tenant_schema import tenant_data_schema
+    from app.core.db.tenant_session import current_tenant_var
+    from app.core.tenancy import is_multi_tenant
+
+    _schema = tenant_data_schema(
+        current_tenant_var.get() if is_multi_tenant() else None
+    )
+    info_result = await session.execute(
+        text(
+            "SELECT table_name FROM information_schema.tables "
+            "WHERE table_schema = :schema AND table_name LIKE :pattern"
+        ).bindparams(schema=_schema, pattern=f"{base_slug}%")
+    )
+    existing |= {row[0] for row in info_result.all()}
+
     if slug in existing:
         suffix = 2
         while f"{base_slug}_{suffix}" in existing:

--- a/backend/app/processing/ingest/service.py
+++ b/backend/app/processing/ingest/service.py
@@ -460,6 +460,12 @@ async def generate_table_name(
     # with no Dataset row; a catalog-only probe would hand out that name
     # forever, failing every retry on CREATE TABLE. The retry self-heals to a
     # _N suffix instead — deliberately NO auto-DROP of the orphan here.
+    # fix(#700 review): probe pg_catalog, not information_schema — the SQL
+    # standard filters information_schema to relations the current role has
+    # privileges on, so a role that doesn't own the orphan (it never reached
+    # grant_reader_access) can be blind to exactly the collision this probe
+    # exists to find. pg_class is visible to every role and covers all
+    # relation kinds that contend for the name.
     from app.core.db.tenant_schema import tenant_data_schema
     from app.core.db.tenant_session import current_tenant_var
     from app.core.tenancy import is_multi_tenant
@@ -469,8 +475,9 @@ async def generate_table_name(
     )
     info_result = await session.execute(
         text(
-            "SELECT table_name FROM information_schema.tables "
-            "WHERE table_schema = :schema AND table_name LIKE :pattern"
+            "SELECT c.relname FROM pg_catalog.pg_class c"
+            " JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace"
+            " WHERE n.nspname = :schema AND c.relname LIKE :pattern"
         ).bindparams(schema=_schema, pattern=f"{base_slug}%")
     )
     existing |= {row[0] for row in info_result.all()}

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -30640,7 +30640,7 @@
     },
     "/datasets/{dataset_id}/analysis/materialize/": {
       "post": {
-        "description": "Materialize an analysis result as a new private dataset (async job).\n\nRequires read visibility on the source dataset; the new dataset is owned\nby the caller and counted against their dataset quota (the atomic slot\nreservation runs at registration inside the worker). Poll\n``GET /jobs/{job_id}`` for progress.",
+        "description": "Materialize an analysis result as a new private dataset (async job).\n\nRequires the ``upload`` permission (this endpoint creates a dataset) and\nread visibility on the source dataset; the new dataset is owned by the\ncaller and counted against their dataset quota (the atomic slot\nreservation runs at registration inside the worker). Poll\n``GET /jobs/{job_id}`` for progress.",
         "operationId": "analysis_materialize_endpoint_datasets__dataset_id__analysis_materialize__post",
         "parameters": [
           {

--- a/backend/tests/test_analysis_materialize.py
+++ b/backend/tests/test_analysis_materialize.py
@@ -7,16 +7,18 @@ Requirements:
   - Docker database must be running (docker compose up db)
 """
 
+import asyncio
 import uuid
 from unittest.mock import AsyncMock, patch
 
+import pytest
 from httpx import AsyncClient
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.modules.catalog.datasets.api import router_analysis
 from app.platform.jobs.models import IngestJob
-from app.processing.analysis.tasks import _materialize
+from app.processing.analysis.tasks import _materialize, _user_error_message
 
 from tests.factories import get_user_id
 from tests.test_analysis_preview import _create_mask_dataset, _create_polygon_dataset
@@ -254,9 +256,12 @@ class TestMaterializeEndpoint:
     async def test_materialize_private_source_hidden(
         self,
         client: AsyncClient,
-        viewer_auth_header: dict,
+        editor_auth_header: dict,
         test_db_session: AsyncSession,
     ):
+        """Rule 1 on the source dataset. Editor (who HAS the upload
+        permission) so the check exercised here is visibility, not the
+        permission gate covered below."""
         admin_id = await get_user_id(test_db_session, "admin")
         ds = await _create_polygon_dataset(
             test_db_session, created_by=admin_id, visibility="private"
@@ -264,9 +269,35 @@ class TestMaterializeEndpoint:
         resp = await client.post(
             _materialize_url(ds.id),
             json={"operation": "centroid", "title": "Nope"},
-            headers=viewer_auth_header,
+            headers=editor_auth_header,
         )
         assert resp.status_code == 404
+
+    async def test_materialize_requires_upload_permission(
+        self,
+        client: AsyncClient,
+        viewer_auth_header: dict,
+        test_db_session: AsyncSession,
+    ):
+        """fix(#692): materialize creates a dataset, so it carries the same
+        `upload` permission as every ingest endpoint that creates one — a
+        viewer gets 403 even on a dataset they can read. Preview must stay
+        open to viewers: read-only, nothing persisted, and the chat tool's
+        read-only surface depends on it."""
+        admin_id = await get_user_id(test_db_session, "admin")
+        ds = await _create_polygon_dataset(test_db_session, created_by=admin_id)
+        resp = await client.post(
+            _materialize_url(ds.id),
+            json={"operation": "centroid", "title": "Not allowed"},
+            headers=viewer_auth_header,
+        )
+        assert resp.status_code == 403
+        preview = await client.post(
+            f"/datasets/{ds.id}/analysis/preview/",
+            json={"operation": "centroid"},
+            headers=viewer_auth_header,
+        )
+        assert preview.status_code == 200, preview.text
 
     async def test_dissolve_unknown_column_rejected(
         self,
@@ -421,6 +452,123 @@ class TestMaterializeWorker:
             )
         ).scalar_one()
         assert name_count == 2
+
+    async def test_null_geometry_rows_are_dropped_from_output(
+        self,
+        test_db_session: AsyncSession,
+    ):
+        """fix(#692): the preview filters NULL/EMPTY results in SQL, so the
+        saved dataset must agree — buffer of a NULL geometry is NULL and must
+        not survive into the registered output."""
+        admin_id = await get_user_id(test_db_session, "admin")
+        ds = await _create_polygon_dataset(test_db_session, created_by=admin_id)
+        await test_db_session.execute(
+            text(f"INSERT INTO data.{ds.table_name} (name) VALUES ('null-geom')")  # noqa: S608
+        )
+        await test_db_session.commit()
+        job = await _create_job(test_db_session, admin_id)
+
+        await _materialize(
+            job_id=str(job.id),
+            dataset_id=str(ds.id),
+            user_id=str(admin_id),
+            operation="buffer",
+            title=f"Buffered nulls {uuid.uuid4().hex[:6]}",
+            distance_meters=100,
+        )
+
+        await test_db_session.refresh(job)
+        assert job.status == "complete", job.error_message
+
+        from app.modules.catalog.datasets.domain.models import Dataset
+
+        new_ds = await test_db_session.get(Dataset, job.dataset_id)
+        total, nulls = (
+            await test_db_session.execute(
+                text(
+                    f"SELECT COUNT(*), COUNT(*) FILTER (WHERE geom_4326 IS NULL) "  # noqa: S608
+                    f"FROM data.{new_ds.table_name}"
+                )
+            )
+        ).one()
+        assert (total, nulls) == (2, 0)
+
+    async def test_terminal_job_is_not_resurrected(
+        self,
+        test_db_session: AsyncSession,
+    ):
+        """fix(#692): the worker claims pending→running fenced on the attempt
+        token. A job that already reached a terminal state — the pending
+        sweeper failing a backlogged job, or the defer orphan-guard failing
+        the row after the queue INSERT committed — must stay there; before
+        the claim, a late delivery would flip it back to running and later
+        'complete', defeating the per-user cap and creating a dataset for a
+        job the user was told failed."""
+        admin_id = await get_user_id(test_db_session, "admin")
+        ds = await _create_polygon_dataset(test_db_session, created_by=admin_id)
+        job = await _create_job(test_db_session, admin_id)
+        job.status = "failed"
+        job.error_message = "Stale: pending for over 1 hour (never queued)"
+        await test_db_session.commit()
+
+        await _materialize(
+            job_id=str(job.id),
+            dataset_id=str(ds.id),
+            user_id=str(admin_id),
+            operation="centroid",
+            title="Resurrected?",
+        )
+
+        await test_db_session.refresh(job)
+        assert job.status == "failed"
+        assert job.dataset_id is None
+
+    async def test_worker_cancellation_fails_job_and_reraises(
+        self,
+        test_db_session: AsyncSession,
+    ):
+        """fix(#692): graceful worker shutdown cancels the task mid-CTAS. The
+        job must fail immediately with a comprehensible message — not strand
+        in 'running' holding the slot until the 60-minute sweep — and the
+        CancelledError must propagate so the queue records the abort."""
+        admin_id = await get_user_id(test_db_session, "admin")
+        ds = await _create_polygon_dataset(test_db_session, created_by=admin_id)
+        job = await _create_job(test_db_session, admin_id)
+
+        slow_sql = (
+            "SELECT 1 AS gid, "
+            "(SELECT ST_GeomFromText('POINT(0 0)', 4326) FROM pg_sleep(30)) AS geom"
+        )
+        with patch(
+            "app.processing.analysis.tasks._build_materialize_select",
+            return_value=slow_sql,
+        ):
+            run = asyncio.create_task(
+                _materialize(
+                    job_id=str(job.id),
+                    dataset_id=str(ds.id),
+                    user_id=str(admin_id),
+                    operation="centroid",
+                    title="Cancelled",
+                )
+            )
+            # Cancel only once the worker owns the row (claim committed), so
+            # the cancellation lands inside the guarded body, then give the
+            # CTAS a beat to start.
+            for _ in range(100):
+                await asyncio.sleep(0.1)
+                await test_db_session.refresh(job)
+                if job.status == "running":
+                    break
+            assert job.status == "running"
+            await asyncio.sleep(0.3)
+            run.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await run
+
+        await test_db_session.refresh(job)
+        assert job.status == "failed"
+        assert "worker shut down" in (job.error_message or "")
 
     async def test_dissolve_materialize_single_feature(
         self,
@@ -624,28 +772,33 @@ class TestMaterializeWorker:
         test_db_session: AsyncSession,
     ):
         """When CREATE TABLE loses a name race, cleanup must not drop the
-        winner's table — only a table this job actually created."""
-        from app.processing.ingest.service import generate_table_name
+        winner's table — only a table this job actually created.
 
+        fix(#692): generate_table_name now sidesteps live relations, so the
+        lost race is simulated by pinning the generated name to the occupied
+        one — exactly what happens when two jobs draw the same name in the
+        window between generation and CREATE."""
         admin_id = await get_user_id(test_db_session, "admin")
         ds = await _create_polygon_dataset(test_db_session, created_by=admin_id)
         job = await _create_job(test_db_session, admin_id)
         title = f"Collide {uuid.uuid4().hex[:6]}"
-        # generate_table_name checks only the catalog, so pre-creating the
-        # physical table simulates the concurrent winner.
-        expected, _ = await generate_table_name(title, test_db_session)
+        expected = f"collide_{uuid.uuid4().hex[:6]}"
         await test_db_session.execute(
             text(f'CREATE TABLE data."{expected}" (marker integer)')
         )
         await test_db_session.commit()
 
-        await _materialize(
-            job_id=str(job.id),
-            dataset_id=str(ds.id),
-            user_id=str(admin_id),
-            operation="centroid",
-            title=title,
-        )
+        with patch(
+            "app.processing.ingest.service.generate_table_name",
+            AsyncMock(return_value=(expected, None)),
+        ):
+            await _materialize(
+                job_id=str(job.id),
+                dataset_id=str(ds.id),
+                user_id=str(admin_id),
+                operation="centroid",
+                title=title,
+            )
 
         await test_db_session.refresh(job)
         assert job.status == "failed"
@@ -663,6 +816,56 @@ class TestMaterializeWorker:
                         "SELECT column_name FROM information_schema.columns "
                         "WHERE table_schema = 'data' AND table_name = :t"
                     ).bindparams(t=expected)
+                )
+            )
+            .scalars()
+            .all()
+        )
+        assert cols == ["marker"]
+
+    async def test_orphan_physical_table_self_heals_to_suffix(
+        self,
+        test_db_session: AsyncSession,
+    ):
+        """fix(#692): a table committed without a catalog row (worker killed
+        during registration) used to poison its title forever — the name
+        generator collided only against the catalog, so every retry died on
+        CREATE TABLE. It now probes information_schema too: the retry lands
+        on a _2 suffix and the orphan is left untouched for an operator."""
+        from app.processing.ingest.service import generate_table_name
+
+        admin_id = await get_user_id(test_db_session, "admin")
+        ds = await _create_polygon_dataset(test_db_session, created_by=admin_id)
+        job = await _create_job(test_db_session, admin_id)
+        title = f"Orphaned {uuid.uuid4().hex[:6]}"
+        orphan, _ = await generate_table_name(title, test_db_session)
+        await test_db_session.execute(
+            text(f'CREATE TABLE data."{orphan}" (marker integer)')
+        )
+        await test_db_session.commit()
+
+        await _materialize(
+            job_id=str(job.id),
+            dataset_id=str(ds.id),
+            user_id=str(admin_id),
+            operation="centroid",
+            title=title,
+        )
+
+        await test_db_session.refresh(job)
+        assert job.status == "complete", job.error_message
+
+        from app.modules.catalog.datasets.domain.models import Dataset
+
+        new_ds = await test_db_session.get(Dataset, job.dataset_id)
+        assert new_ds.table_name == f"{orphan}_2"
+        cols = (
+            (
+                await test_db_session.execute(
+                    text(
+                        "SELECT column_name FROM information_schema.columns "
+                        "WHERE table_schema = 'data' AND table_name = :t"
+                    ).bindparams(t=orphan)
                 )
             )
             .scalars()
@@ -732,6 +935,47 @@ class TestMaterializeWorker:
         assert job.status == "failed"
         assert "Mask dataset not found" in (job.error_message or "")
 
+    async def test_analyze_and_registration_timeout_between_phases(
+        self,
+        test_db_session: AsyncSession,
+    ):
+        """fix(#692): the output table is ANALYZEd before the mid-task commit
+        (tile queries land before autovacuum's pass), and registration gets a
+        fresh statement_timeout (SET LOCAL died with that commit). Pin both
+        by inspecting the statements the worker actually ran."""
+        executed: list[str] = []
+        from sqlalchemy.ext.asyncio import AsyncSession as _AS
+
+        real_execute = _AS.execute
+
+        async def spying_execute(self, statement, *args, **kwargs):
+            executed.append(str(statement))
+            return await real_execute(self, statement, *args, **kwargs)
+
+        admin_id = await get_user_id(test_db_session, "admin")
+        ds = await _create_polygon_dataset(test_db_session, created_by=admin_id)
+        job = await _create_job(test_db_session, admin_id)
+
+        with patch.object(_AS, "execute", spying_execute):
+            await _materialize(
+                job_id=str(job.id),
+                dataset_id=str(ds.id),
+                user_id=str(admin_id),
+                operation="centroid",
+                title=f"Spied {uuid.uuid4().hex[:6]}",
+            )
+
+        await test_db_session.refresh(job)
+        assert job.status == "complete", job.error_message
+        analyzes = [s for s in executed if s.startswith("ANALYZE ")]
+        assert len(analyzes) == 1
+        timeouts = [s for s in executed if "SET LOCAL statement_timeout" in s]
+        # One budget for the build transaction, one re-armed for registration.
+        assert len(timeouts) == 2
+        # The registration budget is set after the ANALYZE (i.e. in the new
+        # transaction), not before.
+        assert executed.index(timeouts[1]) > executed.index(analyzes[0])
+
     async def test_mixed_geometry_dissolve_stays_typed(
         self,
         test_db_session: AsyncSession,
@@ -792,3 +1036,38 @@ class TestMaterializeWorker:
             )
         ).scalar_one()
         assert geom_type == "MULTIPOLYGON"
+
+
+# ---------------------------------------------------------------------------
+# Error-message sanitization (pure, no DB)
+# ---------------------------------------------------------------------------
+
+
+class TestUserErrorMessage:
+    def test_db_error_hides_generated_sql(self):
+        """fix(#692): SQLAlchemy appends `[SQL: …]` to DB errors — schema and
+        table names must never reach GET /jobs/{id}."""
+        from sqlalchemy.exc import ProgrammingError
+
+        exc = ProgrammingError(
+            'CREATE TABLE "data"."secret_output" AS SELECT 1', {}, Exception("boom")
+        )
+        msg = _user_error_message(exc)
+        assert "secret_output" not in msg
+        assert "CREATE TABLE" not in msg
+
+    def test_statement_timeout_is_actionable(self):
+        from sqlalchemy.exc import OperationalError
+
+        exc = OperationalError(
+            'CREATE TABLE "data"."big_output" AS SELECT 1',
+            {},
+            Exception("canceling statement due to statement timeout"),
+        )
+        msg = _user_error_message(exc)
+        assert "time limit" in msg
+        assert "big_output" not in msg
+
+    def test_domain_errors_pass_through(self):
+        msg = _user_error_message(ValueError("Analysis produced no features to save"))
+        assert "no features" in msg

--- a/backend/tests/test_analysis_materialize.py
+++ b/backend/tests/test_analysis_materialize.py
@@ -13,12 +13,17 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 from httpx import AsyncClient
-from sqlalchemy import text
+from sqlalchemy import text, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
+import app.core.db as core_db
 from app.modules.catalog.datasets.api import router_analysis
 from app.platform.jobs.models import IngestJob
-from app.processing.analysis.tasks import _materialize, _user_error_message
+from app.processing.analysis.tasks import (
+    _fail_cancelled_job,
+    _materialize,
+    _user_error_message,
+)
 
 from tests.factories import get_user_id
 from tests.test_analysis_preview import _create_mask_dataset, _create_polygon_dataset
@@ -565,6 +570,46 @@ class TestMaterializeWorker:
             run.cancel()
             with pytest.raises(asyncio.CancelledError):
                 await run
+
+        await test_db_session.refresh(job)
+        assert job.status == "failed"
+        assert "worker shut down" in (job.error_message or "")
+
+    async def test_cancel_cleanup_releases_working_sessions_row_lock(
+        self,
+        test_db_session: AsyncSession,
+    ):
+        """fix(#700 review): a cancel can land while the working session's
+        open transaction still holds the job-row lock (e.g. mid-commit,
+        after flush). The cleanup must roll that session back before its
+        fenced update, or it blocks on its own lock until the shield
+        timeout and the row strands in 'running' after all."""
+        admin_id = await get_user_id(test_db_session, "admin")
+        job = await _create_job(test_db_session, admin_id)
+        job.status = "running"
+        await test_db_session.commit()
+
+        # Late-bound attribute access: conftest repoints app.core.db's
+        # session maker at the per-run test DB after import time.
+        async with core_db.async_session() as working_session:
+            # Uncommitted UPDATE → this transaction holds the row lock,
+            # exactly as a cancel landing mid-commit would leave it.
+            await working_session.execute(
+                update(IngestJob)
+                .where(IngestJob.id == job.id)
+                .values(current_step="registering")
+            )
+            await asyncio.wait_for(
+                _fail_cancelled_job(
+                    working_session,
+                    job_id=str(job.id),
+                    attempt_id=job.attempt_id,
+                    schema="data",
+                    out_table=None,
+                    operation="centroid",
+                ),
+                timeout=10,
+            )
 
         await test_db_session.refresh(job)
         assert job.status == "failed"

--- a/backend/tests/test_analysis_preview.py
+++ b/backend/tests/test_analysis_preview.py
@@ -745,20 +745,23 @@ class TestBuildPreviewSql:
         # inside the JSON itself.
         assert sql.count("'") == 6
 
-    def test_clip_sql_fences_subquery_pullup(self):
-        """fix(#692): three outer references to geom_out would otherwise let
-        the planner flatten the subquery and evaluate ST_Intersection three
-        times per surviving row."""
-        req = AnalysisPreviewRequest(operation="clip", mask=CLIP_MASK)
-        assert "OFFSET 0" in build_preview_sql('"data"."t1"', req)
-
-    def test_one_to_one_ops_stay_flattenable(self):
-        """The pull-up is what lets buffer/centroid ride the pkey index and
-        halt at the row cap — they must NOT be fenced."""
-        buffer_req = AnalysisPreviewRequest(operation="buffer", distance_meters=10)
-        centroid_req = AnalysisPreviewRequest(operation="centroid")
-        assert "OFFSET 0" not in build_preview_sql('"data"."t1"', buffer_req)
-        assert "OFFSET 0" not in build_preview_sql('"data"."t1"', centroid_req)
+    def test_preview_sql_evaluates_expression_once_per_row(self):
+        """fix(#700 review): the geometry expression lives in a LATERAL
+        subquery (OFFSET 0 blocks pull-up), so the three geom_out references
+        don't triple-evaluate it — while the base table stays a plain FROM
+        item whose pkey index can satisfy ORDER BY and early-terminate at
+        the sandbox row cap."""
+        cases = {
+            "ST_Intersection": AnalysisPreviewRequest(operation="clip", mask=CLIP_MASK),
+            "ST_Buffer": AnalysisPreviewRequest(operation="buffer", distance_meters=10),
+            "ST_Centroid": AnalysisPreviewRequest(operation="centroid"),
+        }
+        for fn, req in cases.items():
+            sql = build_preview_sql('"data"."t1"', req)
+            assert "CROSS JOIN LATERAL (SELECT" in sql
+            assert "OFFSET 0" in sql
+            assert sql.count(fn) == 1
+            assert sql.endswith("ORDER BY gid")
 
     def test_clip_mask_injection_rejected(self):
         req = AnalysisPreviewRequest(

--- a/backend/tests/test_analysis_preview.py
+++ b/backend/tests/test_analysis_preview.py
@@ -745,6 +745,21 @@ class TestBuildPreviewSql:
         # inside the JSON itself.
         assert sql.count("'") == 6
 
+    def test_clip_sql_fences_subquery_pullup(self):
+        """fix(#692): three outer references to geom_out would otherwise let
+        the planner flatten the subquery and evaluate ST_Intersection three
+        times per surviving row."""
+        req = AnalysisPreviewRequest(operation="clip", mask=CLIP_MASK)
+        assert "OFFSET 0" in build_preview_sql('"data"."t1"', req)
+
+    def test_one_to_one_ops_stay_flattenable(self):
+        """The pull-up is what lets buffer/centroid ride the pkey index and
+        halt at the row cap — they must NOT be fenced."""
+        buffer_req = AnalysisPreviewRequest(operation="buffer", distance_meters=10)
+        centroid_req = AnalysisPreviewRequest(operation="centroid")
+        assert "OFFSET 0" not in build_preview_sql('"data"."t1"', buffer_req)
+        assert "OFFSET 0" not in build_preview_sql('"data"."t1"', centroid_req)
+
     def test_clip_mask_injection_rejected(self):
         req = AnalysisPreviewRequest(
             operation="clip",

--- a/frontend/src/components/builder/AnalysisPanel.tsx
+++ b/frontend/src/components/builder/AnalysisPanel.tsx
@@ -19,6 +19,7 @@ import { MAP_COLORS } from '@/lib/map-colors';
 import { materializeAnalysis, previewAnalysis } from '@/api/analysis';
 import { useDataset } from '@/components/dataset/hooks/use-dataset';
 import { useJobStatus } from '@/components/import/hooks/use-ingest';
+import { usePermissions } from '@/hooks/use-permissions';
 import { useAnalysisJobStore } from '@/stores/analysis-job-store';
 import type { LayerActions } from '@/components/builder/ChatPanel';
 import type { EphemeralAnalysisHandoff } from '@/components/builder/hooks/use-ephemeral-layers';
@@ -279,6 +280,12 @@ export function AnalysisPanel({
       );
     },
   });
+
+  // fix(#700 review): materialize requires the upload permission server-side
+  // (it creates a dataset); hide the creation half for viewer roles instead
+  // of letting them fill the form into a guaranteed 403. Preview stays.
+  const { can } = usePermissions();
+  const canCreateDataset = can('upload');
 
   const paramsValid =
     (operation !== 'buffer' || distanceValid) &&
@@ -547,64 +554,68 @@ export function AnalysisPanel({
           </Button>
         )}
 
-        <div className="space-y-1.5 border-t pt-3">
-          <Label className="text-xs" htmlFor="analysis-output-title">
-            {t('analysisTools.outputTitleLabel', {
-              defaultValue: 'New dataset name',
-            })}
-          </Label>
-          <Input
-            id="analysis-output-title"
-            value={outputTitle}
-            onChange={(e) => setOutputTitle(e.target.value)}
-            placeholder={t('analysisTools.outputTitlePlaceholder', {
-              defaultValue: 'e.g. Parcels buffered 500 m',
-            })}
-          />
-          <Button
-            variant="secondary"
-            className="w-full"
-            onClick={() => {
-              // fix(#682 review): reset only this panel's local status line.
-              // Clearing the GLOBAL tracking here would orphan a job that is
-              // still running (the server then 429s the replacement), losing
-              // the original job's completion notification for good — the
-              // mutation replaces the tracked job on success instead.
-              setJobId(null);
-              materializeMutation.mutate();
-            }}
-            disabled={!canSave}
-          >
-            {materializeMutation.isPending
-              ? t('analysisTools.saving', { defaultValue: 'Creating…' })
-              : t('analysisTools.saveButton', { defaultValue: 'Create dataset' })}
-          </Button>
-          {job && (
-            <p className="text-xs text-muted-foreground" role="status">
-              {job.status === 'failed'
-                ? `${t('analysisTools.jobFailed', { defaultValue: 'Analysis job failed' })}${job.error_message ? `: ${job.error_message}` : ''}`
-                : job.status === 'complete'
-                  ? t('analysisTools.jobComplete', { defaultValue: 'Dataset created' })
-                  : job.current_step === 'registering'
-                    ? t('analysisTools.jobSaving', {
-                        defaultValue: 'Saving the dataset…',
-                      })
-                    : t('analysisTools.jobRunning', {
-                        defaultValue: 'Creating dataset…',
-                      })}
-            </p>
-          )}
-          {job?.status === 'complete' && !!job.dataset_id && layerActions && (
+        {/* fix(#700 review): hidden without the upload permission — the
+            gating mirrors DatasetSearchPanel's import CTA. */}
+        {canCreateDataset && (
+          <div className="space-y-1.5 border-t pt-3">
+            <Label className="text-xs" htmlFor="analysis-output-title">
+              {t('analysisTools.outputTitleLabel', {
+                defaultValue: 'New dataset name',
+              })}
+            </Label>
+            <Input
+              id="analysis-output-title"
+              value={outputTitle}
+              onChange={(e) => setOutputTitle(e.target.value)}
+              placeholder={t('analysisTools.outputTitlePlaceholder', {
+                defaultValue: 'e.g. Parcels buffered 500 m',
+              })}
+            />
             <Button
-              variant="outline"
-              size="sm"
+              variant="secondary"
               className="w-full"
-              onClick={() => job.dataset_id && layerActions.onAddDataset(job.dataset_id)}
+              onClick={() => {
+                // fix(#682 review): reset only this panel's local status line.
+                // Clearing the GLOBAL tracking here would orphan a job that is
+                // still running (the server then 429s the replacement), losing
+                // the original job's completion notification for good — the
+                // mutation replaces the tracked job on success instead.
+                setJobId(null);
+                materializeMutation.mutate();
+              }}
+              disabled={!canSave}
             >
-              {t('analysisTools.addToMap', { defaultValue: 'Add to map' })}
+              {materializeMutation.isPending
+                ? t('analysisTools.saving', { defaultValue: 'Creating…' })
+                : t('analysisTools.saveButton', { defaultValue: 'Create dataset' })}
             </Button>
-          )}
-        </div>
+            {job && (
+              <p className="text-xs text-muted-foreground" role="status">
+                {job.status === 'failed'
+                  ? `${t('analysisTools.jobFailed', { defaultValue: 'Analysis job failed' })}${job.error_message ? `: ${job.error_message}` : ''}`
+                  : job.status === 'complete'
+                    ? t('analysisTools.jobComplete', { defaultValue: 'Dataset created' })
+                    : job.current_step === 'registering'
+                      ? t('analysisTools.jobSaving', {
+                          defaultValue: 'Saving the dataset…',
+                        })
+                      : t('analysisTools.jobRunning', {
+                          defaultValue: 'Creating dataset…',
+                        })}
+              </p>
+            )}
+            {job?.status === 'complete' && !!job.dataset_id && layerActions && (
+              <Button
+                variant="outline"
+                size="sm"
+                className="w-full"
+                onClick={() => job.dataset_id && layerActions.onAddDataset(job.dataset_id)}
+              >
+                {t('analysisTools.addToMap', { defaultValue: 'Add to map' })}
+              </Button>
+            )}
+          </div>
+        )}
       </div>
     </div>
   );

--- a/frontend/src/components/builder/__tests__/AnalysisPanel.test.tsx
+++ b/frontend/src/components/builder/__tests__/AnalysisPanel.test.tsx
@@ -21,6 +21,17 @@ vi.mock('react-i18next', () => ({
   }),
 }));
 
+// fix(#700 review): the save half is gated on can('upload'); default to a
+// role that has it so the existing save-path tests keep their controls.
+let mockCanUpload = true;
+vi.mock('@/hooks/use-permissions', () => ({
+  usePermissions: () => ({
+    can: () => mockCanUpload,
+    permissions: { upload: mockCanUpload },
+    isLoading: false,
+  }),
+}));
+
 vi.mock('@/api/analysis', () => ({
   previewAnalysis: vi.fn().mockResolvedValue({
     geojson: {
@@ -92,8 +103,23 @@ function renderPanel(
   );
 }
 
+beforeEach(() => {
+  mockCanUpload = true;
+});
+
 describe('AnalysisPanel', () => {
   beforeEach(() => useAnalysisJobStore.setState({ job: null }));
+
+  it('hides the dataset-creation half without the upload permission (#700)', () => {
+    mockCanUpload = false;
+    renderPanel([datasetLayer]);
+    expect(
+      screen.queryByRole('button', { name: 'Create dataset' }),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('New dataset name')).not.toBeInTheDocument();
+    // The read-only preview stays available.
+    expect(screen.getByRole('button', { name: 'Preview' })).not.toBeDisabled();
+  });
 
   it('shows a hint when no dataset layers are available', () => {
     renderPanel([groupLayer]);

--- a/frontend/src/types/api.generated.ts
+++ b/frontend/src/types/api.generated.ts
@@ -1769,8 +1769,9 @@ export interface paths {
          * Analysis Materialize Endpoint
          * @description Materialize an analysis result as a new private dataset (async job).
          *
-         *     Requires read visibility on the source dataset; the new dataset is owned
-         *     by the caller and counted against their dataset quota (the atomic slot
+         *     Requires the ``upload`` permission (this endpoint creates a dataset) and
+         *     read visibility on the source dataset; the new dataset is owned by the
+         *     caller and counted against their dataset quota (the atomic slot
          *     reservation runs at registration inside the worker). Poll
          *     ``GET /jobs/{job_id}`` for progress.
          */

--- a/sdks/python/geolens/api/datasets_analysis/analysis_materialize_endpoint_datasets_dataset_id_analysis_materialize_post.py
+++ b/sdks/python/geolens/api/datasets_analysis/analysis_materialize_endpoint_datasets_dataset_id_analysis_materialize_post.py
@@ -116,8 +116,9 @@ def sync_detailed(
 
      Materialize an analysis result as a new private dataset (async job).
 
-    Requires read visibility on the source dataset; the new dataset is owned
-    by the caller and counted against their dataset quota (the atomic slot
+    Requires the ``upload`` permission (this endpoint creates a dataset) and
+    read visibility on the source dataset; the new dataset is owned by the
+    caller and counted against their dataset quota (the atomic slot
     reservation runs at registration inside the worker). Poll
     ``GET /jobs/{job_id}`` for progress.
 
@@ -156,8 +157,9 @@ def sync(
 
      Materialize an analysis result as a new private dataset (async job).
 
-    Requires read visibility on the source dataset; the new dataset is owned
-    by the caller and counted against their dataset quota (the atomic slot
+    Requires the ``upload`` permission (this endpoint creates a dataset) and
+    read visibility on the source dataset; the new dataset is owned by the
+    caller and counted against their dataset quota (the atomic slot
     reservation runs at registration inside the worker). Poll
     ``GET /jobs/{job_id}`` for progress.
 
@@ -191,8 +193,9 @@ async def asyncio_detailed(
 
      Materialize an analysis result as a new private dataset (async job).
 
-    Requires read visibility on the source dataset; the new dataset is owned
-    by the caller and counted against their dataset quota (the atomic slot
+    Requires the ``upload`` permission (this endpoint creates a dataset) and
+    read visibility on the source dataset; the new dataset is owned by the
+    caller and counted against their dataset quota (the atomic slot
     reservation runs at registration inside the worker). Poll
     ``GET /jobs/{job_id}`` for progress.
 
@@ -229,8 +232,9 @@ async def asyncio(
 
      Materialize an analysis result as a new private dataset (async job).
 
-    Requires read visibility on the source dataset; the new dataset is owned
-    by the caller and counted against their dataset quota (the atomic slot
+    Requires the ``upload`` permission (this endpoint creates a dataset) and
+    read visibility on the source dataset; the new dataset is owned by the
+    caller and counted against their dataset quota (the atomic slot
     reservation runs at registration inside the worker). Poll
     ``GET /jobs/{job_id}`` for progress.
 

--- a/sdks/typescript/src/client/sdk.gen.ts
+++ b/sdks/typescript/src/client/sdk.gen.ts
@@ -1856,8 +1856,9 @@ export const updateDatasetMetadataDatasetsDatasetIdPatch = <ThrowOnError extends
  *
  * Materialize an analysis result as a new private dataset (async job).
  *
- * Requires read visibility on the source dataset; the new dataset is owned
- * by the caller and counted against their dataset quota (the atomic slot
+ * Requires the ``upload`` permission (this endpoint creates a dataset) and
+ * read visibility on the source dataset; the new dataset is owned by the
+ * caller and counted against their dataset quota (the atomic slot
  * reservation runs at registration inside the worker). Poll
  * ``GET /jobs/{job_id}`` for progress.
  */


### PR DESCRIPTION
Closes #692. Eight small correctness/security fixes for the analysis feature, from the 2026-07-25 scalability/tenancy/scenario audit (four independent review passes over the merged #680/#682/#690 state).

## Changes

1. **Materialize now requires the `upload` permission** (`router_analysis.py`) — it creates a dataset, so it carries the same gate as every ingest endpoint that creates one. Preview deliberately stays on the plain active-user dependency (read-only; the chat tool's read-only surface depends on it). **Behavior change:** viewer-role accounts that could previously materialize now get 403 — worth a line in the next release notes, and deployments that issued view-only accounts should pick up the next patch release.
2. **Worker claims pending→running fenced on the row's attempt token** (`processing/analysis/tasks.py`, the `ingest_file` pattern) — a job the pending-sweeper failed (worker down/backlogged >1h) or the defer orphan-guard failed can no longer resurrect to running/complete, which defeated the one-job cap and produced datasets for jobs the user was told failed. This is the fencing half of #691 and is independent of its cap-predicate change.
3. **`asyncio.CancelledError` is handled** — graceful worker shutdown (routine deploys) used to strand the row in `running`, holding the user's only analysis slot for the 60-minute sweep, since `retry=0` never redelivers. The job now fails immediately with a comprehensible message via a shielded fresh-session helper that is fenced on the attempt token *before* dropping any committed-but-unregistered output table, then the cancellation re-raises so the queue records the abort. Two siblings fixed in the same lines: the heartbeat task is now created *inside* the `try` whose cleanup reaps it (an exception in the old gap left an immortal lease the sweeper could never fail), and it is stopped with cancel+await (`stop_ingest_job_heartbeat`) like ingest.
4. **NULL/EMPTY rows are dropped from every operation's output**, not just clip — preview filters them in SQL, so the saved dataset now agrees with the preview the user approved (buffer/centroid mapped NULL source geometries to NULL rows; dissolve kept all-NULL groups).
5. **`generate_table_name` also collides against `information_schema.tables`** (`ingest/service.py`) — a table committed without a catalog row (worker killed during registration) used to poison its title forever; retries now self-heal to a `_N` suffix and the orphan is left untouched for an operator (deliberately no auto-DROP).
6. **`ANALYZE` after the build + re-armed `statement_timeout` for registration** — the mid-task commit expired the `SET LOCAL`, leaving registration's full-table scans (COUNT + ST_Extent + the 10k-row sample CTE) unbounded, and the fresh table had no planner statistics exactly when the UI navigates to its tiles. The new budget lives in the analysis task, not in the shared `register_existing_table`.
7. **Clip preview subquery is fenced with `OFFSET 0`** — three outer references to `geom_out` let the planner flatten it and evaluate `ST_Intersection` three times per surviving row. Buffer/centroid deliberately stay flattenable: the pull-up is what lets their `ORDER BY gid` ride the pkey index and halt at the row cap.
8. **Job `error_message` is sanitized** — SQLAlchemy appends `[SQL: …]` (internal schema/table names) to DB errors, which `GET /jobs/{id}` returned verbatim. Timeouts map to an actionable message, data errors to a generic one, domain messages pass through; raw text stays in server logs.

## API/schema impact

No schema or migration changes. `backend/openapi.json` and both generated SDKs regenerated for the materialize description change only. New 403 possibility on `/analysis/materialize/` for accounts without `upload`.

## Verification

- `uv run pytest tests/test_analysis_materialize.py tests/test_analysis_preview.py` — 65 passed (13 new tests: permission gate + preview parity, NULL-geometry exclusion, terminal-job fencing, mid-CTAS cancellation, orphan self-heal, ANALYZE/timeout phase ordering, error sanitization, clip fence SQL shape).
- `uv run pytest tests/test_layering.py` — 29 passed.
- `make openapi-check`, `make sdks-check` (incl. TS SDK build + tests), `ruff check` / `ruff format --check` — all green; pre-commit Rule 1/Rule 2 hooks passed.

Related follow-ups tracked separately: #693 (clip-mask scale), #694 (pre-flight gates), #695 (queue priority), #696 (governance knobs), #697 (antimeridian probe), #698 (UX), #699 (test matrix).

https://claude.ai/code/session_01X1Wd3Frww9F2eovfMkUbG2