### PR TITLE
feat(analysis): pre-flight size gates for dissolve, buffer, and layer masks

### DIFF
--- a/backend/app/modules/catalog/datasets/api/router_analysis.py
+++ b/backend/app/modules/catalog/datasets/api/router_analysis.py
@@ -24,7 +24,11 @@ from app.modules.catalog.datasets.domain.service import (
     run_analysis_preview,
 )
 from app.modules.quota.service import check_upload_quota
-from app.platform.analysis_sql import render_mask_expr
+from app.platform.analysis_sql import (
+    MAX_MASK_LAYER_FEATURES,
+    MAX_SOURCE_FEATURES,
+    render_mask_expr,
+)
 from app.platform.extensions import get_catalog_port
 from app.platform.jobs.defer_guard import (
     defer_with_orphan_guard,
@@ -72,24 +76,11 @@ async def _load_vector_dataset(db: AsyncSession, dataset_id: uuid.UUID, user: Id
 
 _POLYGONAL_TYPES = {"POLYGON", "MULTIPOLYGON"}
 
-# fix(#693): a layer-sourced clip mask is unioned WHOLE before any row limit
-# can bite, inside the preview's 10-second budget — a few thousand realistic
-# polygons already blow it. Counted via resolve_source_feature_count: the
+# Size-gate ceilings live in app.platform.analysis_sql (shared with the
+# worker's pre-CTAS recheck). Counted via resolve_source_feature_count: the
 # cached snapshot when present, a LIMIT-bounded live count when it is NULL
 # (fix(#701 review): NULL-as-zero would admit exactly the unknown-size
 # datasets these gates exist for).
-MAX_MASK_LAYER_FEATURES = 1_000
-
-# fix(#694): per-operation source-size ceilings, enforced at enqueue with
-# the same counting rule as the mask cap.
-# dissolve: ST_Union memory grows with input; ~1M polygons OOM-kills a 2 GB
-# db container, taking every connection with it — 250k keeps 4x headroom.
-# buffer: the only output-amplifying operation, and vector datasets carry no
-# byte quota, so bound the amplification source instead.
-_MAX_SOURCE_FEATURES = {
-    "dissolve": 250_000,
-    "buffer": 500_000,
-}
 
 
 async def _load_mask_dataset(
@@ -179,7 +170,7 @@ async def analysis_materialize_endpoint(
     """
     dataset = await _load_vector_dataset(db, dataset_id, user)
 
-    max_features = _MAX_SOURCE_FEATURES.get(body.operation)
+    max_features = MAX_SOURCE_FEATURES.get(body.operation)
     if max_features is not None:
         source_count = await resolve_source_feature_count(db, dataset, cap=max_features)
         if source_count > max_features:

--- a/backend/app/modules/catalog/datasets/api/router_analysis.py
+++ b/backend/app/modules/catalog/datasets/api/router_analysis.py
@@ -20,6 +20,7 @@ from app.modules.catalog.datasets.domain.schemas import (
 )
 from app.modules.catalog.datasets.domain.service import (
     get_dataset,
+    resolve_source_feature_count,
     run_analysis_preview,
 )
 from app.modules.quota.service import check_upload_quota
@@ -73,12 +74,14 @@ _POLYGONAL_TYPES = {"POLYGON", "MULTIPOLYGON"}
 
 # fix(#693): a layer-sourced clip mask is unioned WHOLE before any row limit
 # can bite, inside the preview's 10-second budget — a few thousand realistic
-# polygons already blow it. The cap reads the cached catalog feature_count,
-# so it is a blast-radius guard, not an exact gate.
+# polygons already blow it. Counted via resolve_source_feature_count: the
+# cached snapshot when present, a LIMIT-bounded live count when it is NULL
+# (fix(#701 review): NULL-as-zero would admit exactly the unknown-size
+# datasets these gates exist for).
 MAX_MASK_LAYER_FEATURES = 1_000
 
-# fix(#694): per-operation source-size ceilings, enforced at enqueue on the
-# cached catalog feature_count (same snapshot semantics as the mask cap).
+# fix(#694): per-operation source-size ceilings, enforced at enqueue with
+# the same counting rule as the mask cap.
 # dissolve: ST_Union memory grows with input; ~1M polygons OOM-kills a 2 GB
 # db container, taking every connection with it — 250k keeps 4x headroom.
 # buffer: the only output-amplifying operation, and vector datasets carry no
@@ -101,7 +104,10 @@ async def _load_mask_dataset(
             status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
             detail="mask_dataset_id must reference a polygon dataset",
         )
-    if (dataset.feature_count or 0) > MAX_MASK_LAYER_FEATURES:
+    mask_count = await resolve_source_feature_count(
+        db, dataset, cap=MAX_MASK_LAYER_FEATURES
+    )
+    if mask_count > MAX_MASK_LAYER_FEATURES:
         raise HTTPException(
             status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
             detail=(
@@ -174,15 +180,17 @@ async def analysis_materialize_endpoint(
     dataset = await _load_vector_dataset(db, dataset_id, user)
 
     max_features = _MAX_SOURCE_FEATURES.get(body.operation)
-    if max_features is not None and (dataset.feature_count or 0) > max_features:
-        raise HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
-            detail=(
-                f"This dataset is too large for {body.operation} "
-                f"(about {dataset.feature_count:,} features; the limit is "
-                f"{max_features:,}). Filter it to a smaller dataset first."
-            ),
-        )
+    if max_features is not None:
+        source_count = await resolve_source_feature_count(db, dataset, cap=max_features)
+        if source_count > max_features:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+                detail=(
+                    f"This dataset is too large for {body.operation} "
+                    f"(the limit is {max_features:,} features). Filter it "
+                    "to a smaller dataset first."
+                ),
+            )
 
     # Fail fast on invalid params before creating a job.
     if body.operation == "clip" and body.mask_dataset_id is not None:

--- a/backend/app/modules/catalog/datasets/api/router_analysis.py
+++ b/backend/app/modules/catalog/datasets/api/router_analysis.py
@@ -71,6 +71,23 @@ async def _load_vector_dataset(db: AsyncSession, dataset_id: uuid.UUID, user: Id
 
 _POLYGONAL_TYPES = {"POLYGON", "MULTIPOLYGON"}
 
+# fix(#693): a layer-sourced clip mask is unioned WHOLE before any row limit
+# can bite, inside the preview's 10-second budget — a few thousand realistic
+# polygons already blow it. The cap reads the cached catalog feature_count,
+# so it is a blast-radius guard, not an exact gate.
+MAX_MASK_LAYER_FEATURES = 1_000
+
+# fix(#694): per-operation source-size ceilings, enforced at enqueue on the
+# cached catalog feature_count (same snapshot semantics as the mask cap).
+# dissolve: ST_Union memory grows with input; ~1M polygons OOM-kills a 2 GB
+# db container, taking every connection with it — 250k keeps 4x headroom.
+# buffer: the only output-amplifying operation, and vector datasets carry no
+# byte quota, so bound the amplification source instead.
+_MAX_SOURCE_FEATURES = {
+    "dissolve": 250_000,
+    "buffer": 500_000,
+}
+
 
 async def _load_mask_dataset(
     db: AsyncSession, mask_dataset_id: uuid.UUID, user: Identity
@@ -83,6 +100,15 @@ async def _load_mask_dataset(
         raise HTTPException(
             status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
             detail="mask_dataset_id must reference a polygon dataset",
+        )
+    if (dataset.feature_count or 0) > MAX_MASK_LAYER_FEATURES:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail=(
+                f"The mask layer has too many features to clip with "
+                f"(limit {MAX_MASK_LAYER_FEATURES:,}). Choose a smaller mask "
+                "layer or draw the mask on the map."
+            ),
         )
     return dataset
 
@@ -146,6 +172,17 @@ async def analysis_materialize_endpoint(
     ``GET /jobs/{job_id}`` for progress.
     """
     dataset = await _load_vector_dataset(db, dataset_id, user)
+
+    max_features = _MAX_SOURCE_FEATURES.get(body.operation)
+    if max_features is not None and (dataset.feature_count or 0) > max_features:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail=(
+                f"This dataset is too large for {body.operation} "
+                f"(about {dataset.feature_count:,} features; the limit is "
+                f"{max_features:,}). Filter it to a smaller dataset first."
+            ),
+        )
 
     # Fail fast on invalid params before creating a job.
     if body.operation == "clip" and body.mask_dataset_id is not None:

--- a/backend/app/modules/catalog/datasets/domain/service.py
+++ b/backend/app/modules/catalog/datasets/domain/service.py
@@ -33,6 +33,7 @@ from app.modules.catalog.datasets.domain._sql_safety import (
 )
 from app.modules.catalog.datasets.domain.service_analysis import (
     build_preview_sql,
+    resolve_source_feature_count,
     run_analysis_preview,
 )
 from app.modules.catalog.datasets.domain.service_create import (
@@ -95,6 +96,7 @@ __all__ = [
     "list_relationships",
     "list_relationships_with_total",
     "reset_attribute",
+    "resolve_source_feature_count",
     "run_analysis_preview",
     "update_attribute",
     "update_auto_metadata",

--- a/backend/app/modules/catalog/datasets/domain/service_analysis.py
+++ b/backend/app/modules/catalog/datasets/domain/service_analysis.py
@@ -17,6 +17,8 @@ from __future__ import annotations
 
 import json
 import uuid
+
+from sqlalchemy import text
 from typing import Any
 
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -32,6 +34,33 @@ from app.platform.sandbox.executor import execute_safe
 
 PREVIEW_FEATURE_CAP = 500
 _GEOJSON_PRECISION = 6
+
+
+async def resolve_source_feature_count(
+    db: AsyncSession, dataset: Dataset, *, cap: int
+) -> int:
+    """Feature count for enqueue gating, bounded by ``cap``.
+
+    Uses the cached catalog snapshot when present. When it is NULL (legacy
+    imports, ``register_existing_table`` paths), a NULL-as-zero default
+    would admit exactly the unknown-size datasets the OOM gates exist for
+    (fix(#701 review)) — so count the physical table instead, stopping at
+    ``cap + 1`` rows so the probe itself stays bounded.
+    """
+    if dataset.feature_count is not None:
+        return dataset.feature_count
+    from app.core.db.tenant_schema import tenant_data_schema
+    from app.core.db.tenant_session import current_tenant_var
+    from app.core.tenancy import is_multi_tenant
+
+    schema = tenant_data_schema(current_tenant_var.get() if is_multi_tenant() else None)
+    ref = _safe_table_ref(dataset.table_name, schema=schema)
+    result = await db.execute(
+        text(
+            f"SELECT count(*) FROM (SELECT 1 FROM {ref} LIMIT :lim) AS _n"  # noqa: S608
+        ).bindparams(lim=cap + 1)
+    )
+    return int(result.scalar_one())
 
 
 def build_preview_sql(

--- a/backend/app/platform/analysis_sql.py
+++ b/backend/app/platform/analysis_sql.py
@@ -31,6 +31,25 @@ from shapely.geometry import shape
 MAX_BUFFER_METERS = 100_000.0
 MAX_MASK_VERTICES = 5_000
 
+# fix(#693): a layer-sourced clip mask is unioned WHOLE before any row limit
+# can bite, inside the preview's 10-second budget — a few thousand realistic
+# polygons already blow it.
+MAX_MASK_LAYER_FEATURES = 1_000
+
+# fix(#694): per-operation source-size ceilings.
+# dissolve: ST_Union memory grows with input; ~1M polygons OOM-kills a 2 GB
+# db container, taking every connection with it — 250k keeps 4x headroom.
+# buffer: the only output-amplifying operation, and vector datasets carry no
+# byte quota, so bound the amplification source instead.
+# Enforced twice with LIMIT-bounded live counts: at enqueue (router, fast
+# 422) and again in the worker right before the CTAS — the queue wait can be
+# long enough for a dataset to be re-uploaded past its cap (fix(#701
+# review)).
+MAX_SOURCE_FEATURES = {
+    "dissolve": 250_000,
+    "buffer": 500_000,
+}
+
 # CTE name for layer-sourced clip masks. The union is computed ONCE in a
 # MATERIALIZED CTE; referencing it from the expression and both WHERE terms
 # as a scalar subquery would otherwise evaluate the union three times.

--- a/backend/app/processing/analysis/tasks.py
+++ b/backend/app/processing/analysis/tasks.py
@@ -52,6 +52,12 @@ MATERIALIZE_TIMEOUT = "300s"
 # the build, but must never be unbounded.
 REGISTRATION_TIMEOUT = "600s"
 
+# fix(#694): post-CTAS backstop on the built output's on-disk size. The
+# enqueue gates read the cached feature_count snapshot, which can be stale;
+# this is the enforcement that can't be. Buffer is the motivating case: it
+# is the only amplifying operation and vector datasets carry no byte quota.
+MAX_OUTPUT_BYTES = 2 * 1024**3
+
 # Served by the worker's :8001 /metrics endpoint (default registry).
 # ponytail: analysis-only counter; generalize to all ingest job types when
 # another type needs it.
@@ -351,8 +357,29 @@ async def _materialize(
             await session.execute(
                 text(f"SET LOCAL statement_timeout = '{MATERIALIZE_TIMEOUT}'")
             )
+            if operation == "dissolve":
+                # fix(#694): hash aggregation holds every group's union state
+                # in memory at once, so a grouped dissolve over enough
+                # polygons can OOM-kill the shared db container. Sorted
+                # aggregation bounds memory to one group at a time. The
+                # enqueue-time feature cap is the first line of defense;
+                # this is the second.
+                await session.execute(text("SET LOCAL enable_hashagg = off"))
             await session.execute(text(f"CREATE TABLE {out_ref} AS {select_sql}"))
             out_table_created = True
+            size_bytes = await session.scalar(
+                text(
+                    "SELECT pg_total_relation_size(CAST(:ref AS regclass))"
+                ).bindparams(ref=out_ref)
+            )
+            if size_bytes is not None and size_bytes > MAX_OUTPUT_BYTES:
+                # Fail before spending the rewrite/index/registration phases
+                # on a table that will be rejected; the failure path drops it.
+                raise ValueError(
+                    f"The analysis output exceeded the "
+                    f"{MAX_OUTPUT_BYTES // 1024**3} GB size limit. Reduce the "
+                    "buffer distance or run it on a smaller dataset."
+                )
             # Rows with nothing to show are dropped for EVERY operation, not
             # just clip (fix(#692)): buffer/centroid map NULL source
             # geometries to NULL, dissolve unions an all-NULL group to NULL,

--- a/backend/app/processing/analysis/tasks.py
+++ b/backend/app/processing/analysis/tasks.py
@@ -146,6 +146,27 @@ async def _fail_cancelled_job(
     ANALYSIS_JOBS.labels(operation=operation, status="failed").inc()
 
 
+async def _enforce_output_size(session: AsyncSession, out_ref: str) -> None:
+    """Fail the build when the output relation is over MAX_OUTPUT_BYTES.
+
+    ``pg_total_relation_size`` counts heap, TOAST, and indexes, so the
+    post-rewrite call measures what the registered dataset will actually
+    occupy.
+    """
+    result = await session.execute(
+        text("SELECT pg_total_relation_size(CAST(:ref AS regclass))").bindparams(
+            ref=out_ref
+        )
+    )
+    size_bytes = result.scalar_one()
+    if size_bytes is not None and size_bytes > MAX_OUTPUT_BYTES:
+        raise ValueError(
+            f"The analysis output exceeded the "
+            f"{MAX_OUTPUT_BYTES // 1024**3} GB size limit. Reduce the "
+            "buffer distance or run it on a smaller dataset."
+        )
+
+
 async def _mark_job_failed(
     session: AsyncSession,
     *,
@@ -367,19 +388,10 @@ async def _materialize(
                 await session.execute(text("SET LOCAL enable_hashagg = off"))
             await session.execute(text(f"CREATE TABLE {out_ref} AS {select_sql}"))
             out_table_created = True
-            size_bytes = await session.scalar(
-                text(
-                    "SELECT pg_total_relation_size(CAST(:ref AS regclass))"
-                ).bindparams(ref=out_ref)
-            )
-            if size_bytes is not None and size_bytes > MAX_OUTPUT_BYTES:
-                # Fail before spending the rewrite/index/registration phases
-                # on a table that will be rejected; the failure path drops it.
-                raise ValueError(
-                    f"The analysis output exceeded the "
-                    f"{MAX_OUTPUT_BYTES // 1024**3} GB size limit. Reduce the "
-                    "buffer distance or run it on a smaller dataset."
-                )
+            # Early exit only — a table already over the ceiling must not
+            # hold the single worker slot through the rewrite phases. The
+            # authoritative check runs after add_4326_column below.
+            await _enforce_output_size(session, out_ref)
             # Rows with nothing to show are dropped for EVERY operation, not
             # just clip (fix(#692)): buffer/centroid map NULL source
             # geometries to NULL, dissolve unions an all-NULL group to NULL,
@@ -408,6 +420,11 @@ async def _materialize(
             )
             await session.execute(text(f"ALTER TABLE {out_ref} ADD PRIMARY KEY (gid)"))
             await add_4326_column(session, out_table, 4326, schema=_schema)
+            # fix(#701 review): the 4326 rewrite roughly doubles the geometry
+            # payload, rewrites every row, and adds the GIST index — the
+            # post-CTAS probe undercounts the final footprint by a multiple,
+            # so the ceiling is enforced here, on the finished relation.
+            await _enforce_output_size(session, out_ref)
             # In-transaction ANALYZE (fix(#692)): the table only becomes
             # visible to autovacuum at the commit below, and the first tile
             # queries land before its pass — without statistics the planner

--- a/backend/app/processing/analysis/tasks.py
+++ b/backend/app/processing/analysis/tasks.py
@@ -198,19 +198,27 @@ async def _recheck_size_caps(
         )
 
 
-async def _enforce_output_size(session: AsyncSession, out_ref: str) -> None:
+async def _enforce_output_size(
+    session: AsyncSession, schema: str, table_name: str
+) -> None:
     """Fail the build when the output relation is over MAX_OUTPUT_BYTES.
 
     ``pg_total_relation_size`` counts heap, TOAST, and indexes, so the
     post-rewrite call measures what the registered dataset will actually
-    occupy.
+    occupy. Resolved via pg_class with the ``:schema`` bind rather than a
+    ``regclass`` cast (fix(#701 review)): the tenant statement hook only
+    recognizes schema references in SQL text or schema-named binds, and it
+    masks string literals — a schema hidden inside a generic bind would
+    skip the tenant role setup and fail the lookup in multi-tenant.
     """
     result = await session.execute(
-        text("SELECT pg_total_relation_size(CAST(:ref AS regclass))").bindparams(
-            ref=out_ref
-        )
+        text(
+            "SELECT pg_total_relation_size(c.oid) FROM pg_catalog.pg_class c"
+            " JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace"
+            " WHERE n.nspname = :schema AND c.relname = :table_name"
+        ).bindparams(schema=schema, table_name=table_name)
     )
-    size_bytes = result.scalar_one()
+    size_bytes = result.scalar_one_or_none()
     if size_bytes is not None and size_bytes > MAX_OUTPUT_BYTES:
         raise ValueError(
             f"The analysis output exceeded the "
@@ -450,7 +458,7 @@ async def _materialize(
             # Early exit only — a table already over the ceiling must not
             # hold the single worker slot through the rewrite phases. The
             # authoritative check runs after add_4326_column below.
-            await _enforce_output_size(session, out_ref)
+            await _enforce_output_size(session, _schema, out_table)
             # Rows with nothing to show are dropped for EVERY operation, not
             # just clip (fix(#692)): buffer/centroid map NULL source
             # geometries to NULL, dissolve unions an all-NULL group to NULL,
@@ -483,7 +491,7 @@ async def _materialize(
             # payload, rewrites every row, and adds the GIST index — the
             # post-CTAS probe undercounts the final footprint by a multiple,
             # so the ceiling is enforced here, on the finished relation.
-            await _enforce_output_size(session, out_ref)
+            await _enforce_output_size(session, _schema, out_table)
             # In-transaction ANALYZE (fix(#692)): the table only becomes
             # visible to autovacuum at the commit below, and the first tile
             # queries land before its pass — without statistics the planner

--- a/backend/app/processing/analysis/tasks.py
+++ b/backend/app/processing/analysis/tasks.py
@@ -24,7 +24,12 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.core.db.tenant_schema import tenant_data_schema
 from app.core.db.tenant_session import current_tenant_var, tenant_task
 from app.core.tenancy import is_multi_tenant
-from app.platform.analysis_sql import render_geometry_expr, render_mask_cte
+from app.platform.analysis_sql import (
+    MAX_MASK_LAYER_FEATURES,
+    MAX_SOURCE_FEATURES,
+    render_geometry_expr,
+    render_mask_cte,
+)
 from app.platform.jobs.heartbeat import (
     claim_ingest_job_attempt,
     maintain_ingest_job_heartbeat,
@@ -144,6 +149,53 @@ async def _fail_cancelled_job(
             except Exception:  # broad: best-effort cleanup of the partial table
                 await session.rollback()
     ANALYSIS_JOBS.labels(operation=operation, status="failed").inc()
+
+
+async def _count_features_bounded(
+    session: AsyncSession, table_ref: str, cap: int
+) -> int:
+    """Live row count, stopping at ``cap + 1`` so the probe stays bounded."""
+    result = await session.execute(
+        text(
+            f"SELECT count(*) FROM (SELECT 1 FROM {table_ref} LIMIT :lim) AS _n"  # noqa: S608
+        ).bindparams(lim=cap + 1)
+    )
+    return int(result.scalar_one())
+
+
+async def _recheck_size_caps(
+    session: AsyncSession,
+    *,
+    operation: str,
+    src_ref: str,
+    mask_table_ref: str | None,
+) -> None:
+    """Re-validate the enqueue-time size gates against the live tables.
+
+    The queue wait can be long enough for a source or mask dataset to be
+    re-uploaded past its cap (fix(#701 review)), and the post-CTAS output
+    check is too late to protect the dissolve/mask union itself from OOM —
+    so the bounded counts run again here, immediately before the SQL is
+    built.
+    """
+    cap = MAX_SOURCE_FEATURES.get(operation)
+    if cap is not None and await _count_features_bounded(session, src_ref, cap) > cap:
+        raise ValueError(
+            f"This dataset is too large for {operation} (the limit is "
+            f"{cap:,} features). Filter it to a smaller dataset first."
+        )
+    if (
+        mask_table_ref is not None
+        and await _count_features_bounded(
+            session, mask_table_ref, MAX_MASK_LAYER_FEATURES
+        )
+        > MAX_MASK_LAYER_FEATURES
+    ):
+        raise ValueError(
+            "The mask layer has too many features to clip with (limit "
+            f"{MAX_MASK_LAYER_FEATURES:,}). Choose a smaller mask layer or "
+            "draw the mask on the map."
+        )
 
 
 async def _enforce_output_size(session: AsyncSession, out_ref: str) -> None:
@@ -357,6 +409,13 @@ async def _materialize(
                 if not _SAFE_TABLE.match(mask_ds.table_name):
                     raise ValueError("Invalid mask table name")
                 mask_table_ref = f'"{_schema}"."{mask_ds.table_name}"'
+
+            await _recheck_size_caps(
+                session,
+                operation=operation,
+                src_ref=src_ref,
+                mask_table_ref=mask_table_ref,
+            )
 
             out_table, _warning = await generate_table_name(title, session)
             out_ref = f'"{_schema}"."{out_table}"'

--- a/backend/tests/test_analysis_materialize.py
+++ b/backend/tests/test_analysis_materialize.py
@@ -1112,6 +1112,19 @@ class TestMaterializeWorker:
         assert executed.index(timeouts[1]) > executed.index(analyzes[0])
         # Only dissolve flips the aggregation strategy (fix(#694)).
         assert not [s for s in executed if "enable_hashagg" in s]
+        # fix(#701 review): the size ceiling is probed twice — a cheap early
+        # exit after the CTAS, and the authoritative check on the finished
+        # relation (post-4326-rewrite, so heap + TOAST + GIST all count),
+        # which must land before the ANALYZE that precedes the commit.
+        # Positions, not values: both probes stringify identically, so
+        # list.index() would find the first one twice.
+        size_pos = [i for i, s in enumerate(executed) if "pg_total_relation_size" in s]
+        assert len(size_pos) == 2
+        rewrite_pos = max(
+            i for i, s in enumerate(executed) if "geom_4326" in s and "UPDATE" in s
+        )
+        assert size_pos[1] > rewrite_pos
+        assert size_pos[1] < executed.index(analyzes[0])
 
     async def test_dissolve_ctas_disables_hashagg(
         self,

--- a/backend/tests/test_analysis_materialize.py
+++ b/backend/tests/test_analysis_materialize.py
@@ -482,6 +482,64 @@ class TestMaterializeEndpoint:
         assert resp.status_code == 422
         assert "mask layer has too many features" in resp.json()["detail"].lower()
 
+        # fix(#701 review): a NULL snapshot must not read as zero — the mask
+        # table (1 row) is counted live against the patched cap.
+        mask_ds.feature_count = None
+        await test_db_session.commit()
+        with patch.object(router_analysis, "MAX_MASK_LAYER_FEATURES", 0):
+            resp = await client.post(
+                _materialize_url(ds.id),
+                json={
+                    "operation": "clip",
+                    "mask_dataset_id": str(mask_ds.id),
+                    "title": "Unknown mask size",
+                },
+                headers=admin_auth_header,
+            )
+        assert resp.status_code == 422
+        assert "mask layer has too many features" in resp.json()["detail"].lower()
+
+    async def test_null_feature_count_probes_live_table(
+        self,
+        client: AsyncClient,
+        admin_auth_header: dict,
+        test_db_session: AsyncSession,
+    ):
+        """fix(#701 review): a NULL feature_count (legacy imports,
+        register_existing_table paths) must not read as zero — that admits
+        exactly the unknown-size datasets the OOM gate exists for. The gate
+        falls back to a LIMIT-bounded live count of the physical table."""
+        admin_id = await get_user_id(test_db_session, "admin")
+        ds = await _create_polygon_dataset(test_db_session, created_by=admin_id)
+        ds.feature_count = None
+        await test_db_session.commit()
+
+        # The fixture table holds 2 rows; a cap of 1 must reject via the
+        # live probe...
+        with patch.dict(router_analysis._MAX_SOURCE_FEATURES, {"dissolve": 1}):
+            resp = await client.post(
+                _materialize_url(ds.id),
+                json={"operation": "dissolve", "title": "Unknown size"},
+                headers=admin_auth_header,
+            )
+        assert resp.status_code == 422
+        assert "too large for dissolve" in resp.json()["detail"]
+
+        # ...and a cap above the true count enqueues.
+        with (
+            patch.dict(router_analysis._MAX_SOURCE_FEATURES, {"dissolve": 5}),
+            patch.object(router_analysis, "defer_async_with_tenant", AsyncMock()),
+        ):
+            resp = await client.post(
+                _materialize_url(ds.id),
+                json={"operation": "dissolve", "title": "Small enough"},
+                headers=admin_auth_header,
+            )
+        assert resp.status_code == 200, resp.text
+        job = await test_db_session.get(IngestJob, uuid.UUID(resp.json()["job_id"]))
+        job.status = "failed"
+        await test_db_session.commit()
+
 
 # ---------------------------------------------------------------------------
 # Worker tests (core logic run inline, no queue)

--- a/backend/tests/test_analysis_materialize.py
+++ b/backend/tests/test_analysis_materialize.py
@@ -516,7 +516,9 @@ class TestMaterializeEndpoint:
 
         # The fixture table holds 2 rows; a cap of 1 must reject via the
         # live probe...
-        with patch.dict(router_analysis._MAX_SOURCE_FEATURES, {"dissolve": 1}):
+        with patch.dict(
+            "app.platform.analysis_sql.MAX_SOURCE_FEATURES", {"dissolve": 1}
+        ):
             resp = await client.post(
                 _materialize_url(ds.id),
                 json={"operation": "dissolve", "title": "Unknown size"},
@@ -527,7 +529,9 @@ class TestMaterializeEndpoint:
 
         # ...and a cap above the true count enqueues.
         with (
-            patch.dict(router_analysis._MAX_SOURCE_FEATURES, {"dissolve": 5}),
+            patch.dict(
+                "app.platform.analysis_sql.MAX_SOURCE_FEATURES", {"dissolve": 5}
+            ),
             patch.object(router_analysis, "defer_async_with_tenant", AsyncMock()),
         ):
             resp = await client.post(
@@ -1220,6 +1224,57 @@ class TestMaterializeWorker:
         ctas = [s for s in executed if s.startswith("CREATE TABLE")]
         # Same transaction, ahead of the CTAS it protects.
         assert executed.index(hashaggs[0]) < executed.index(ctas[0])
+
+    async def test_worker_rechecks_size_caps_before_ctas(
+        self,
+        test_db_session: AsyncSession,
+    ):
+        """fix(#701 review): the enqueue gate's count can go stale while the
+        job waits in the queue (a source or mask can be re-uploaded past its
+        cap), and the post-CTAS size check is too late to protect the
+        dissolve/mask union itself from OOM — the worker re-counts the live
+        tables immediately before building the SQL."""
+        admin_id = await get_user_id(test_db_session, "admin")
+        ds = await _create_polygon_dataset(test_db_session, created_by=admin_id)
+
+        # Source recheck: the fixture table holds 2 rows; cap 1 must fail
+        # the job before any output table exists.
+        job = await _create_job(test_db_session, admin_id)
+        with patch.dict(
+            "app.platform.analysis_sql.MAX_SOURCE_FEATURES", {"dissolve": 1}
+        ):
+            await _materialize(
+                job_id=str(job.id),
+                dataset_id=str(ds.id),
+                user_id=str(admin_id),
+                operation="dissolve",
+                title="Grew past the cap",
+            )
+        await test_db_session.refresh(job)
+        assert job.status == "failed"
+        assert "too large for dissolve" in (job.error_message or "")
+        assert job.dataset_id is None
+
+        # Mask recheck: the 1-row mask table against a cap of 0.
+        mask_ds = await _create_mask_dataset(
+            test_db_session,
+            created_by=admin_id,
+            wkt="POLYGON((-0.5 -0.5, -0.5 0.5, 0.5 0.5, 0.5 -0.5, -0.5 -0.5))",
+        )
+        job2 = await _create_job(test_db_session, admin_id)
+        with patch("app.processing.analysis.tasks.MAX_MASK_LAYER_FEATURES", 0):
+            await _materialize(
+                job_id=str(job2.id),
+                dataset_id=str(ds.id),
+                user_id=str(admin_id),
+                operation="clip",
+                title="Mask grew past the cap",
+                mask_dataset_id=str(mask_ds.id),
+            )
+        await test_db_session.refresh(job2)
+        assert job2.status == "failed"
+        assert "mask layer has too many features" in (job2.error_message or "")
+        assert job2.dataset_id is None
 
     async def test_oversized_output_fails_before_registration(
         self,

--- a/backend/tests/test_analysis_materialize.py
+++ b/backend/tests/test_analysis_materialize.py
@@ -392,6 +392,96 @@ class TestMaterializeEndpoint:
         job.status = "failed"
         await test_db_session.commit()
 
+    async def test_source_size_gates_dissolve_and_buffer(
+        self,
+        client: AsyncClient,
+        admin_auth_header: dict,
+        test_db_session: AsyncSession,
+    ):
+        """fix(#694): dissolve/buffer are size-gated at enqueue on the cached
+        feature_count — dissolve's ST_Union can OOM the shared db container,
+        and buffer amplifies storage with no byte quota. Centroid is 1:1 and
+        stays ungated."""
+        admin_id = await get_user_id(test_db_session, "admin")
+        ds = await _create_polygon_dataset(test_db_session, created_by=admin_id)
+
+        ds.feature_count = 250_001
+        await test_db_session.commit()
+        resp = await client.post(
+            _materialize_url(ds.id),
+            json={"operation": "dissolve", "title": "Too big"},
+            headers=admin_auth_header,
+        )
+        assert resp.status_code == 422
+        assert "too large for dissolve" in resp.json()["detail"]
+
+        # The boundary itself is allowed.
+        ds.feature_count = 250_000
+        await test_db_session.commit()
+        with patch.object(router_analysis, "defer_async_with_tenant", AsyncMock()):
+            resp = await client.post(
+                _materialize_url(ds.id),
+                json={"operation": "dissolve", "title": "At the cap"},
+                headers=admin_auth_header,
+            )
+        assert resp.status_code == 200, resp.text
+        job = await test_db_session.get(IngestJob, uuid.UUID(resp.json()["job_id"]))
+        job.status = "failed"
+        await test_db_session.commit()
+
+        # buffer's ceiling is higher but real; centroid has none.
+        ds.feature_count = 500_001
+        await test_db_session.commit()
+        resp = await client.post(
+            _materialize_url(ds.id),
+            json={"operation": "buffer", "distance_meters": 10, "title": "Too big"},
+            headers=admin_auth_header,
+        )
+        assert resp.status_code == 422
+        assert "too large for buffer" in resp.json()["detail"]
+
+        with patch.object(router_analysis, "defer_async_with_tenant", AsyncMock()):
+            resp = await client.post(
+                _materialize_url(ds.id),
+                json={"operation": "centroid", "title": "Centroid ok"},
+                headers=admin_auth_header,
+            )
+        assert resp.status_code == 200, resp.text
+        job = await test_db_session.get(IngestJob, uuid.UUID(resp.json()["job_id"]))
+        job.status = "failed"
+        await test_db_session.commit()
+
+    async def test_oversized_mask_layer_rejected_at_enqueue(
+        self,
+        client: AsyncClient,
+        admin_auth_header: dict,
+        test_db_session: AsyncSession,
+    ):
+        """fix(#693): the shared mask loader caps the mask layer's cached
+        feature_count — the whole layer is unioned before any row limit can
+        bite — so materialize rejects it before creating a job."""
+        admin_id = await get_user_id(test_db_session, "admin")
+        ds = await _create_polygon_dataset(test_db_session, created_by=admin_id)
+        mask_ds = await _create_mask_dataset(
+            test_db_session,
+            created_by=admin_id,
+            wkt="POLYGON((-0.5 -0.5, -0.5 0.5, 0.5 0.5, 0.5 -0.5, -0.5 -0.5))",
+        )
+        mask_ds.feature_count = 1_001
+        await test_db_session.commit()
+
+        resp = await client.post(
+            _materialize_url(ds.id),
+            json={
+                "operation": "clip",
+                "mask_dataset_id": str(mask_ds.id),
+                "title": "Too many mask features",
+            },
+            headers=admin_auth_header,
+        )
+        assert resp.status_code == 422
+        assert "mask layer has too many features" in resp.json()["detail"].lower()
+
 
 # ---------------------------------------------------------------------------
 # Worker tests (core logic run inline, no queue)
@@ -1020,6 +1110,72 @@ class TestMaterializeWorker:
         # The registration budget is set after the ANALYZE (i.e. in the new
         # transaction), not before.
         assert executed.index(timeouts[1]) > executed.index(analyzes[0])
+        # Only dissolve flips the aggregation strategy (fix(#694)).
+        assert not [s for s in executed if "enable_hashagg" in s]
+
+    async def test_dissolve_ctas_disables_hashagg(
+        self,
+        test_db_session: AsyncSession,
+    ):
+        """fix(#694): hash aggregation holds every group's union state in
+        memory simultaneously; the dissolve CTAS transaction must switch to
+        sorted aggregation, which bounds memory to one group at a time."""
+        executed: list[str] = []
+        from sqlalchemy.ext.asyncio import AsyncSession as _AS
+
+        real_execute = _AS.execute
+
+        async def spying_execute(self, statement, *args, **kwargs):
+            executed.append(str(statement))
+            return await real_execute(self, statement, *args, **kwargs)
+
+        admin_id = await get_user_id(test_db_session, "admin")
+        ds = await _create_polygon_dataset(test_db_session, created_by=admin_id)
+        job = await _create_job(test_db_session, admin_id)
+
+        with patch.object(_AS, "execute", spying_execute):
+            await _materialize(
+                job_id=str(job.id),
+                dataset_id=str(ds.id),
+                user_id=str(admin_id),
+                operation="dissolve",
+                title=f"Hashagg {uuid.uuid4().hex[:6]}",
+            )
+
+        await test_db_session.refresh(job)
+        assert job.status == "complete", job.error_message
+        hashaggs = [s for s in executed if "enable_hashagg" in s]
+        assert len(hashaggs) == 1
+        ctas = [s for s in executed if s.startswith("CREATE TABLE")]
+        # Same transaction, ahead of the CTAS it protects.
+        assert executed.index(hashaggs[0]) < executed.index(ctas[0])
+
+    async def test_oversized_output_fails_before_registration(
+        self,
+        test_db_session: AsyncSession,
+    ):
+        """fix(#694): the enqueue gates read a cached feature_count snapshot;
+        the post-CTAS pg_total_relation_size backstop is the enforcement that
+        can't go stale. The job fails with an actionable message, no dataset
+        is registered, and the cleanup path drops the built table."""
+        admin_id = await get_user_id(test_db_session, "admin")
+        ds = await _create_polygon_dataset(test_db_session, created_by=admin_id)
+        job = await _create_job(test_db_session, admin_id)
+
+        with patch("app.processing.analysis.tasks.MAX_OUTPUT_BYTES", 1):
+            await _materialize(
+                job_id=str(job.id),
+                dataset_id=str(ds.id),
+                user_id=str(admin_id),
+                operation="buffer",
+                title=f"Oversized {uuid.uuid4().hex[:6]}",
+                distance_meters=10.0,
+            )
+
+        await test_db_session.refresh(job)
+        assert job.status == "failed"
+        assert "size limit" in (job.error_message or "")
+        assert job.dataset_id is None
 
     async def test_mixed_geometry_dissolve_stays_typed(
         self,

--- a/backend/tests/test_analysis_preview.py
+++ b/backend/tests/test_analysis_preview.py
@@ -619,6 +619,43 @@ class TestAnalysisPreviewEndpoint:
         assert data["feature_count"] == 1
         assert data["bbox"] == pytest.approx([0.0, 0.0, 0.5, 0.5])
 
+    async def test_oversized_mask_layer_rejected(
+        self,
+        client: AsyncClient,
+        admin_auth_header: dict,
+        test_db_session: AsyncSession,
+    ):
+        """fix(#693): the mask layer is unioned whole before any row limit
+        can bite, inside the preview's 10s budget — gate on the cached
+        feature_count when the mask dataset loads."""
+        admin_id = await get_user_id(test_db_session, "admin")
+        ds = await _create_polygon_dataset(test_db_session, created_by=admin_id)
+        mask_ds = await _create_mask_dataset(
+            test_db_session,
+            created_by=admin_id,
+            wkt="POLYGON((-0.5 -0.5, -0.5 0.5, 0.5 0.5, 0.5 -0.5, -0.5 -0.5))",
+        )
+        mask_ds.feature_count = 1_001
+        await test_db_session.commit()
+
+        resp = await client.post(
+            _preview_url(ds.id),
+            json={"operation": "clip", "mask_dataset_id": str(mask_ds.id)},
+            headers=admin_auth_header,
+        )
+        assert resp.status_code == 422
+        assert "mask layer has too many features" in resp.json()["detail"].lower()
+
+        # At the cap it still runs.
+        mask_ds.feature_count = 1_000
+        await test_db_session.commit()
+        resp = await client.post(
+            _preview_url(ds.id),
+            json={"operation": "clip", "mask_dataset_id": str(mask_ds.id)},
+            headers=admin_auth_header,
+        )
+        assert resp.status_code == 200, resp.text
+
     async def test_clip_by_layer_mask_access_checked(
         self,
         client: AsyncClient,


### PR DESCRIPTION
## What

Batch 2 (first slice) from the 2026-07-25 analysis scalability audit: the blast-radius guards that keep one analysis request from taking down shared infrastructure.

- **Dissolve OOM guard (#694).** `ST_Union` accumulates every input geometry before the cascaded union runs; around ~1M polygons it OOM-kills the 2 GB db container and the postmaster resets **every connection in the cluster**. Dissolve is now rejected at enqueue above 250k features (422 with an actionable message), and the CTAS runs with `SET LOCAL enable_hashagg = off` so grouped dissolves aggregate one group at a time instead of holding all groups' union states simultaneously.
- **Buffer output ceiling (#694).** Buffer is the only output-amplifying operation and vector datasets carry no byte quota by design. Gated at 500k features at enqueue, plus a post-CTAS `pg_total_relation_size` backstop (2 GB) that fails the job before the rewrite/index/registration phases — the enqueue gates read the cached ingest-time `feature_count` snapshot, which can be stale; the backstop can't be.
- **Layer-mask cap (#693, first half).** A layer-sourced clip mask is unioned whole before any row limit can bite, inside the preview's 10-second budget; a few thousand realistic polygons already blow it. Capped at 1,000 features in the shared `_load_mask_dataset` loader, so preview and materialize agree. The per-row semi-join redesign for preview stays open in #693.

All caps read the cached catalog `feature_count` and are documented in-code as blast-radius guards, not exact gates. No API-schema changes (no OpenAPI/SDK regen needed).

Closes #694. Part of #693.

## Verification

- `pytest tests/test_analysis_materialize.py tests/test_analysis_preview.py tests/test_layering.py` — 99 passed (6 new tests: enqueue gates incl. boundary values, per-op selectivity, mask cap on both endpoints, hashagg SET LOCAL presence for dissolve / absence otherwise, size-backstop failure path).
- `make openapi-check`, `ruff check`, `ruff format --check` — clean.

https://claude.ai/code/session_01X1Wd3Frww9F2eovfMkUbG2