### PR TITLE
perf(analysis): per-row subdivided mask joins for clip previews

### DIFF
--- a/backend/app/modules/catalog/datasets/domain/service_analysis.py
+++ b/backend/app/modules/catalog/datasets/domain/service_analysis.py
@@ -29,7 +29,7 @@ from app.modules.catalog.datasets.domain.schemas import (
     AnalysisPreviewRequest,
     AnalysisPreviewResponse,
 )
-from app.platform.analysis_sql import render_geometry_expr, render_mask_cte
+from app.platform.analysis_sql import render_clip_layer_preview, render_geometry_expr
 from app.platform.sandbox.executor import execute_safe
 
 PREVIEW_FEATURE_CAP = 500
@@ -74,13 +74,21 @@ def build_preview_sql(
     come from ``_safe_table_ref`` (logical ``data`` schema; the sandbox
     executor rewrites it to the tenant schema in multi-tenant).
     """
-    expr, where = render_geometry_expr(
-        request.operation,
-        distance_meters=request.distance_meters,
-        mask=request.mask,
-        layer_mask=mask_table_ref is not None,
-    )
-    cte = f"{render_mask_cte(mask_table_ref)} " if mask_table_ref else ""
+    if mask_table_ref is not None:
+        # fix(#693): layer-sourced clip previews subdivide the mask once and
+        # join it per row instead of unioning the whole layer per request;
+        # the union CTE remains the materialize shape (see
+        # render_clip_layer_preview for the measured rationale).
+        cte, lateral, where = render_clip_layer_preview(mask_table_ref, src="_src")
+        cte = f"{cte} "
+    else:
+        cte = ""
+        expr, where = render_geometry_expr(
+            request.operation,
+            distance_meters=request.distance_meters,
+            mask=request.mask,
+        )
+        lateral = f"(SELECT {expr} AS geom_out OFFSET 0)"
     # fix(#680 review): drop NULL/EMPTY results in SQL, not in Python — the
     # sandbox applies its row cap to raw rows, so boundary-grazing clips
     # (which pass ST_Intersects but extract to EMPTY) could consume the whole
@@ -97,8 +105,8 @@ def build_preview_sql(
     filters = f"{where} AND {not_empty}" if where else f" WHERE {not_empty}"
     return (
         f"{cte}SELECT gid, ST_AsGeoJSON(geom_out, {_GEOJSON_PRECISION}) AS geometry_json"
-        f" FROM {table_ref}"
-        f" CROSS JOIN LATERAL (SELECT {expr} AS geom_out OFFSET 0) AS _op"
+        f" FROM {table_ref} AS _src"
+        f" CROSS JOIN LATERAL {lateral} AS _op"
         f"{filters}"
         f" ORDER BY gid"
     )

--- a/backend/app/platform/analysis_sql.py
+++ b/backend/app/platform/analysis_sql.py
@@ -31,9 +31,9 @@ from shapely.geometry import shape
 MAX_BUFFER_METERS = 100_000.0
 MAX_MASK_VERTICES = 5_000
 
-# fix(#693): a layer-sourced clip mask is unioned WHOLE before any row limit
-# can bite, inside the preview's 10-second budget — a few thousand realistic
-# polygons already blow it.
+# fix(#693): the materialize path unions the mask layer WHOLE, and the
+# preview pays a per-request subdivide pass over every mask row — both scale
+# with the layer, and neither is bounded by any row limit.
 MAX_MASK_LAYER_FEATURES = 1_000
 
 # fix(#694): per-operation source-size ceilings.
@@ -77,6 +77,66 @@ def render_mask_cte(mask_table_ref: str) -> str:
         f"SELECT ST_Union(ST_CollectionExtract(ST_MakeValid(geom_4326), 3)) AS geom "
         f"FROM {mask_table_ref} WHERE geom_4326 IS NOT NULL)"
     )
+
+
+# Vertex ceiling per mask piece in the preview shape below. 256 is the
+# PostGIS-documented sweet spot where per-piece index rebuild overhead and
+# per-pair intersection cost balance.
+MASK_SUBDIVIDE_MAX_VERTICES = 256
+
+
+def render_clip_layer_preview(mask_table_ref: str, *, src: str) -> tuple[str, str, str]:
+    """Clip against a mask LAYER — the PREVIEW shape (fix(#693)).
+
+    Returns ``(cte, lateral_subquery, where_clause)`` for a source table
+    aliased ``src``. The materialize worker keeps ``render_mask_cte``'s
+    single whole-layer union: right for a batch job, where one union
+    amortizes over every row — but a preview pays it per click inside a
+    10-second sandbox budget, and per-row ST_Intersection against one giant
+    union geometry is what made realistic mask layers time out (measured,
+    first 500 rows of a 100k-row source: 1,000 x 257-vertex mask >120s;
+    single 100k-vertex mask 87.9s).
+
+    Three cooperating parts (each choice benchmarked on those same masks):
+
+    - ``_mask_pieces`` subdivides the mask's polygonal parts into bounded
+      chunks ONCE per statement (MATERIALIZED), so per-row intersection cost
+      scales with the local overlap instead of the whole mask — the single
+      100k-vertex mask drops 87.9s -> 0.36s. Intersection distributes over
+      union, so unioning the per-piece intersections equals clipping against
+      the unioned mask.
+    - The lateral aggregates those piece intersections per source row: one
+      output row per gid however many mask rows touch it, evaluated once per
+      row (aggregate subqueries cannot be pulled up, so the fix(#700)
+      property needs no OFFSET 0 fence here; the inner OFFSET 0 only pins
+      the extract/makevalid pass to once per mask row).
+    - The EXISTS row filter probes the RAW mask table, not the CTE: it stays
+      index-drivable with real join statistics in either direction (the
+      union CTE reached the outer query as an InitPlan Param, blinding the
+      selectivity estimator; filtering on the un-indexed piece CTE instead
+      costs a linear piece scan per source row — 2.4s vs 0.25s when the mask
+      sits at the high end of the gid order).
+    """
+    cte = (
+        f"WITH _mask_pieces AS MATERIALIZED ("
+        f"SELECT ST_Subdivide(geom, {MASK_SUBDIVIDE_MAX_VERTICES}) AS geom"
+        f" FROM (SELECT ST_CollectionExtract(ST_MakeValid(geom_4326), 3) AS geom"
+        f" FROM {mask_table_ref} WHERE geom_4326 IS NOT NULL OFFSET 0) AS _p"
+        f" WHERE NOT ST_IsEmpty(geom))"
+    )
+    lateral = (
+        f"(SELECT ST_Union(ST_CollectionExtract("
+        f"ST_Intersection(ST_MakeValid({src}.geom_4326), _m.geom),"
+        f" ST_Dimension({src}.geom_4326) + 1)) AS geom_out"
+        f" FROM _mask_pieces AS _m"
+        f" WHERE _m.geom && {src}.geom_4326"
+        f" AND ST_Intersects(_m.geom, ST_MakeValid({src}.geom_4326)))"
+    )
+    where = (
+        f" WHERE EXISTS (SELECT 1 FROM {mask_table_ref}"
+        f" WHERE geom_4326 && {src}.geom_4326)"
+    )
+    return cte, lateral, where
 
 
 def render_mask_expr(mask: dict[str, Any]) -> str:
@@ -127,7 +187,8 @@ def render_geometry_expr(
 
     ``layer_mask=True`` renders clip against the ``MASK_CTE_NAME`` CTE (see
     ``render_mask_cte``, which the caller must prepend) instead of an inline
-    GeoJSON mask.
+    GeoJSON mask — the materialize shape; previews use
+    ``render_clip_layer_preview``.
     """
     if operation == "buffer":
         if distance_meters is None:

--- a/backend/tests/test_analysis_preview.py
+++ b/backend/tests/test_analysis_preview.py
@@ -110,8 +110,9 @@ async def _create_mask_dataset(
     created_by: uuid.UUID,
     wkt: str,
     visibility: str = "public",
+    extra_wkts: tuple[str, ...] = (),
 ):
-    """Create a one-polygon dataset usable as a clip-by-layer mask."""
+    """Create a small polygon dataset usable as a clip-by-layer mask."""
     table_name = f"ds_{uuid.uuid4().hex[:12]}"
     await session.execute(
         text(
@@ -122,19 +123,21 @@ async def _create_mask_dataset(
             f")"
         )
     )
-    await session.execute(
-        text(
-            f"INSERT INTO data.{table_name} (geom, geom_4326) VALUES "
-            f"(ST_GeomFromText('{wkt}', 4326), ST_GeomFromText('{wkt}', 4326))"
+    for row_wkt in (wkt, *extra_wkts):
+        await session.execute(
+            text(
+                f"INSERT INTO data.{table_name} (geom, geom_4326) VALUES "
+                f"(ST_GeomFromText('{row_wkt}', 4326),"
+                f" ST_GeomFromText('{row_wkt}', 4326))"
+            )
         )
-    )
     await session.commit()
     return await create_dataset(
         session,
         created_by=created_by,
         table_name=table_name,
         geometry_type="POLYGON",
-        feature_count=1,
+        feature_count=1 + len(extra_wkts),
         visibility=visibility,
     )
 
@@ -619,15 +622,49 @@ class TestAnalysisPreviewEndpoint:
         assert data["feature_count"] == 1
         assert data["bbox"] == pytest.approx([0.0, 0.0, 0.5, 0.5])
 
+    async def test_clip_by_layer_overlapping_mask_rows(
+        self,
+        client: AsyncClient,
+        admin_auth_header: dict,
+        test_db_session: AsyncSession,
+    ):
+        """fix(#693): the preview semi-joins the mask per row instead of
+        unioning the layer per request; two OVERLAPPING mask rows must still
+        yield one merged feature per source row (intersection distributes
+        over union), not duplicates or double-counted slivers."""
+        admin_id = await get_user_id(test_db_session, "admin")
+        ds = await _create_polygon_dataset(test_db_session, created_by=admin_id)
+        # Together the two rows cover SQUARE's lower-left quarter, same as
+        # CLIP_MASK — but split into overlapping halves (both cover
+        # x in [0.1, 0.25]).
+        mask_ds = await _create_mask_dataset(
+            test_db_session,
+            created_by=admin_id,
+            wkt="POLYGON((-0.5 -0.5, -0.5 0.5, 0.25 0.5, 0.25 -0.5, -0.5 -0.5))",
+            extra_wkts=("POLYGON((0.1 -0.5, 0.1 0.5, 0.5 0.5, 0.5 -0.5, 0.1 -0.5))",),
+        )
+        resp = await client.post(
+            _preview_url(ds.id),
+            json={"operation": "clip", "mask_dataset_id": str(mask_ds.id)},
+            headers=admin_auth_header,
+        )
+        assert resp.status_code == 200, resp.text
+        data = resp.json()
+        assert data["feature_count"] == 1
+        assert data["bbox"] == pytest.approx([0.0, 0.0, 0.5, 0.5])
+        # The overlapping pieces union into one clean polygon.
+        geometry = data["geojson"]["features"][0]["geometry"]
+        assert geometry["type"] == "Polygon"
+
     async def test_oversized_mask_layer_rejected(
         self,
         client: AsyncClient,
         admin_auth_header: dict,
         test_db_session: AsyncSession,
     ):
-        """fix(#693): the mask layer is unioned whole before any row limit
-        can bite, inside the preview's 10s budget — gate on the cached
-        feature_count when the mask dataset loads."""
+        """fix(#693): the materialize path unions the mask layer whole and
+        the preview subdivides every mask row per request — gate on the
+        cached feature_count when the mask dataset loads."""
         admin_id = await get_user_id(test_db_session, "admin")
         ds = await _create_polygon_dataset(test_db_session, created_by=admin_id)
         mask_ds = await _create_mask_dataset(
@@ -799,6 +836,29 @@ class TestBuildPreviewSql:
             assert "OFFSET 0" in sql
             assert sql.count(fn) == 1
             assert sql.endswith("ORDER BY gid")
+
+    def test_clip_by_layer_sql_subdivides_instead_of_unioning(self):
+        """fix(#693): a layer-sourced clip preview must not union the whole
+        mask layer per request — that shape made realistic masks time out
+        inside the 10s sandbox budget. The preview subdivides the mask into
+        bounded pieces once per statement, joins the pieces per source row,
+        and row-filters via an EXISTS probe of the raw (GIST-indexed) mask
+        table; the whole-layer union remains materialize-only."""
+        req = AnalysisPreviewRequest(operation="clip", mask_dataset_id=uuid.uuid4())
+        sql = build_preview_sql('"data"."t1"', req, '"data"."m1"')
+        assert "ST_Subdivide" in sql
+        assert "AS MATERIALIZED" in sql
+        # The layer union shape must be gone...
+        assert "ST_Union(ST_CollectionExtract(ST_MakeValid" not in sql
+        # ...replaced by one per-row aggregate over the intersected pieces:
+        # one output row per gid however many mask rows intersect it.
+        assert sql.count("ST_Union") == 1
+        assert sql.count("ST_Intersection") == 1
+        # Mask table referenced twice: the pieces CTE and the EXISTS probe.
+        assert sql.count('"data"."m1"') == 2
+        assert "EXISTS" in sql
+        assert "CROSS JOIN LATERAL" in sql
+        assert sql.endswith("ORDER BY gid")
 
     def test_clip_mask_injection_rejected(self):
         req = AnalysisPreviewRequest(


### PR DESCRIPTION
## Summary

Closes #693 (step 2; the step-1 mask-size guard shipped in #701).

Clip-by-layer **previews** re-unioned the entire mask layer on every request (`render_mask_cte`) and then ran `ST_Intersection` against that single giant geometry per candidate row — all inside the 10s sandbox budget. Realistic masks made the preview time out, independent of source-dataset size.

The preview now uses a three-part shape rendered by the new `render_clip_layer_preview` in `app/platform/analysis_sql.py` (placed there so #681's spatial-join work can share it):

- a `_mask_pieces` MATERIALIZED CTE: the mask's polygonal parts, `ST_Subdivide`d into ≤256-vertex chunks once per statement;
- a per-row LATERAL aggregate that unions the intersections of only the pieces whose boxes touch the row (intersection distributes over union, so the result equals clipping against the unioned mask — one output row per gid however many mask rows overlap it);
- an EXISTS row filter probing the **raw** mask table, keeping the filter index-drivable with real join statistics in either direction (the old CTE reached the outer query as an InitPlan Param, which blinds the selectivity estimator).

**The materialize path is untouched** — the whole-layer union CTE is right for a batch job, where one union amortizes over every row.

## Benchmarks (100k-row source, first 500 preview rows, dev DB)

| mask layer | old (union CTE) | raw semi-join | subdivided CTE only | **shipped hybrid** |
|---|---|---|---|---|
| 1,000 × 257-vertex polygons | **>120s (timeout)** | 0.35s | 0.90s | **0.55s** |
| 3 small polygons | 0.03s | 0.05s | 0.06s | **0.05s** |
| single 100k-vertex polygon | 88s | 125s | 2.0s | **0.36s** |
| 100 polygons at the high-gid end | (≥ dense) | 0.23s | 2.4s | **0.25s** |

The two intermediate shapes each fail a realistic scenario, which is why the hybrid ships: pieces bound the per-pair intersection cost; the raw-table EXISTS keeps the row filter off the un-indexed CTE.

## Correctness

Old vs new result sets compared row-by-row (gid sets + `ST_Equals`/Hausdorff ≤1e-5 on geometries) on four mask layers — scattered dense, sparse, single-huge (182 rows straddling subdivision seams), and a degenerate layer with a LINESTRING row and a NULL-geometry row: identical everywhere. New live test covers overlapping mask rows (one merged feature per gid, no duplicate rows or slivers); new unit test pins the SQL shape.

## Verification

```
cd backend && set -a && source ../.env.test && set +a
uv run pytest tests/test_analysis_preview.py tests/test_analysis_materialize.py tests/test_layering.py
uv run ruff check . && uv run ruff format --check .
```

No API, schema, or config changes.

https://claude.ai/code/session_01X1Wd3Frww9F2eovfMkUbG2