### PR TITLE
perf(jobs): defer analysis below default priority so uploads fetch first

### DIFF
--- a/backend/app/modules/catalog/datasets/api/router_analysis.py
+++ b/backend/app/modules/catalog/datasets/api/router_analysis.py
@@ -44,6 +44,14 @@ router = APIRouter(
 
 _SAFE_COLUMN_RE = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_]*$")
 
+# fix(#695): Procrastinate ranks by per-job priority (DESC, default 0), not
+# by queue name — so a 300-second analysis CTAS enqueued first would
+# head-of-line block every upload on the shared single worker. Below-default
+# priority lets interactive ingest win the fetch whenever both are queued.
+# ponytail: a steady upload stream can starve queued analysis indefinitely —
+# acceptable for background work; a per-op budget knob is #696's scope.
+ANALYSIS_JOB_PRIORITY = -10
+
 # Sandbox error categories → HTTP status. Everything else is a sanitized 500.
 # query_data_error (SQLSTATE class 22 / GEOS internal errors) is a 422: all
 # SQL on this path is server-built from validated params, so those failures
@@ -294,7 +302,9 @@ async def analysis_materialize_endpoint(
             else {}
         )
         await defer_async_with_tenant(
-            get_catalog_port().materialize_analysis_task(),
+            get_catalog_port()
+            .materialize_analysis_task()
+            .configure(priority=ANALYSIS_JOB_PRIORITY),
             job_id=str(job.id),
             dataset_id=str(dataset.id),
             user_id=str(user.id),

--- a/backend/tests/test_analysis_materialize.py
+++ b/backend/tests/test_analysis_materialize.py
@@ -79,6 +79,13 @@ class TestMaterializeEndpoint:
         kwargs = mock_defer.await_args.kwargs
         assert kwargs["operation"] == "buffer"
         assert kwargs["dataset_id"] == str(ds.id)
+        # fix(#695): queue names don't rank in Procrastinate — the analysis
+        # defer must carry a below-default per-job priority (still on the
+        # shared "ingest" queue) so queued uploads always fetch first.
+        deferrer = mock_defer.await_args.args[0]
+        assert deferrer.job.priority == router_analysis.ANALYSIS_JOB_PRIORITY
+        assert deferrer.job.priority < 0
+        assert deferrer.job.queue == "ingest"
         job = await test_db_session.get(IngestJob, uuid.UUID(data["job_id"]))
         assert job is not None
         assert job.status == "pending"


### PR DESCRIPTION
## Summary

Addresses #695, recommendation 1 (the issue stays open for the conditional follow-ons).

`procrastinate_fetch_job_v2` orders by `jobs.priority DESC, jobs.id ASC` — queue **names** only filter, they never rank. With the default single worker (`WORKER_CONCURRENCY=1`) listening on `priority,ingest,raster`, dispatch is strictly FIFO by job id, so one queued 300-second analysis CTAS head-of-line blocked every upload, reupload, and embedding job fleet-wide. The user-visible symptom was a 2 MB GeoJSON upload pending for minutes with nothing naming analysis as the cause.

The materialize defer now rides `.configure(priority=ANALYSIS_JOB_PRIORITY)` (`-10`) on the unchanged `ingest` queue, so interactive ingest wins the fetch whenever both are queued. The supporting index (`procrastinate_jobs_priority_idx_v1`) already exists; no schema, config, or deploy-order implications — this is one argument at the defer site.

**Accepted trade-off** (called out in the issue): a steady upload stream can starve queued analysis indefinitely. Right for background work; surfacing queue wait in the UI is #698's `current_step="queued"` item, and per-op knobs are #696.

**Not done here, by design:** the dedicated `analysis` queue (only pays with a separate worker, and carries the workers-must-listen-before-API-defers deploy trap) and the per-tenant active cap — both remain tracked in #695.

## Verification

- `configure(priority=-10)` verified against installed procrastinate 3.9.0: produces a `JobDeferrer` with `job.priority == -10`, queue preserved; `defer_async_with_tenant` accepts configured tasks by documented design.
- New asserts in the happy-path defer test pin `priority == ANALYSIS_JOB_PRIORITY < 0` and `queue == "ingest"`; negative-checked (test fails with the `.configure` call removed).

```
cd backend && set -a && source ../.env.test && set +a
uv run pytest tests/test_analysis_materialize.py   # 38 passed
uv run ruff check . && uv run ruff format --check .
```

https://claude.ai/code/session_01X1Wd3Frww9F2eovfMkUbG2