### PR TITLE
chore(db): upgrade bundled database to PostgreSQL 18 + PostGIS 3.6 (#704)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -271,7 +271,7 @@ jobs:
       S3_SECRET_ACCESS_KEY: minioadmin
     services:
       postgres:
-        image: postgis/postgis:17-3.5
+        image: postgis/postgis:18-3.6
         env:
           POSTGRES_USER: geolens
           POSTGRES_PASSWORD: geolens_test
@@ -320,10 +320,10 @@ jobs:
 
       - name: Install postgresql-client + tooling
         run: |
-          # The postgres service for this job is postgis/postgis:17-3.5 (PG17).
+          # The postgres service for this job is postgis/postgis:18-3.6 (PG18).
           # Ubuntu 24.04 (noble) ships postgresql-client 16 by default, and pg_dump
           # refuses to dump a newer server ("aborting because of server version
-          # mismatch"), so add the PGDG apt repo and install the matching v17
+          # mismatch"), so add the PGDG apt repo and install the matching v18
           # client (pg_dump/pg_restore/psql/createdb/dropdb).
           #
           # awscli is intentionally NOT installed from apt (dropped from noble).
@@ -336,7 +336,7 @@ jobs:
           echo "deb [signed-by=/usr/share/postgresql-common/pgdg/apt.postgresql.org.asc] https://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" \
             | sudo tee /etc/apt/sources.list.d/pgdg.list >/dev/null
           sudo apt-get update
-          sudo apt-get install -y --no-install-recommends postgresql-client-17 curl
+          sudo apt-get install -y --no-install-recommends postgresql-client-18 curl
 
       - name: Local round-trip (bundled + managed modes, no S3)
         env:
@@ -626,9 +626,9 @@ jobs:
         working-directory: .
         run: |
           docker build -t geolens-cli-test-db -f - . <<'DOCKERFILE'
-          FROM postgis/postgis:17-3.5
+          FROM postgis/postgis:18-3.6
           RUN apt-get update \
-              && apt-get install -y --no-install-recommends postgresql-17-pgvector \
+              && apt-get install -y --no-install-recommends postgresql-18-pgvector \
               && rm -rf /var/lib/apt/lists/*
           DOCKERFILE
           docker run -d --name cli-test-postgres \
@@ -779,9 +779,9 @@ jobs:
         working-directory: .
         run: |
           docker build -t geolens-test-db -f - . <<'DOCKERFILE'
-          FROM postgis/postgis:17-3.5
+          FROM postgis/postgis:18-3.6
           RUN apt-get update \
-              && apt-get install -y --no-install-recommends postgresql-17-pgvector \
+              && apt-get install -y --no-install-recommends postgresql-18-pgvector \
               && rm -rf /var/lib/apt/lists/*
           DOCKERFILE
           docker run -d --name test-postgres \
@@ -1314,9 +1314,9 @@ jobs:
         working-directory: .
         run: |
           docker build -t geolens-test-db -f - . <<'DOCKERFILE'
-          FROM postgis/postgis:17-3.5
+          FROM postgis/postgis:18-3.6
           RUN apt-get update \
-              && apt-get install -y --no-install-recommends postgresql-17-pgvector \
+              && apt-get install -y --no-install-recommends postgresql-18-pgvector \
               && rm -rf /var/lib/apt/lists/*
           DOCKERFILE
           docker run -d --name test-postgres \

--- a/.github/workflows/dep-audit.yml
+++ b/.github/workflows/dep-audit.yml
@@ -91,9 +91,9 @@ jobs:
         # is report-only. The slim/alpine images we pin (node/python/nginx) are
         # controllable — a CRITICAL there is actionable (bump the tag), so they
         # ENFORCE — keep these three pins matched to the Dockerfile `FROM` tags
-        # they mirror (bump together). postgis/postgis:17-3.5 is an
+        # they mirror (bump together). postgis/postgis:18-3.6 is an
         # uncontrollable third-party fat
-        # Debian-11 image whose CRITICAL set is dominated by CVEs in baked-in Go
+        # Debian-13 image whose CRITICAL set is dominated by CVEs in baked-in Go
         # binaries that only the upstream maintainer can rebuild — and that set
         # shifts with every Trivy DB update. Gating on it would make CI red on
         # upstream timing, not on our code, so it is scanned + REPORTED but not
@@ -106,7 +106,7 @@ jobs:
             enforce: "1"
           - image: "nginxinc/nginx-unprivileged:1.31.1-alpine"
             enforce: "1"
-          - image: "postgis/postgis:17-3.5"
+          - image: "postgis/postgis:18-3.6"
             enforce: "0"
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,7 +27,7 @@ The React/Vite frontend is in `frontend/src/`: `components/`, `pages/`, `hooks/`
 
 ## Architecture
 
-Services (`docker-compose.yml`): Nginx (prod proxy; Vite proxy in dev) fronts the FastAPI `api` (catalog, search, OGC/STAC, vector tiles) and Titiler (COG raster tiles). A `worker` runs GDAL/ogr2ogr ingestion, dispatched via the Procrastinate job queue that lives *inside* PostgreSQL (no separate broker). PostgreSQL 17 (PostGIS + pgvector + pg_trgm) is the single source of truth; object storage is MinIO/S3; Valkey is the tile/query cache.
+Services (`docker-compose.yml`): Nginx (prod proxy; Vite proxy in dev) fronts the FastAPI `api` (catalog, search, OGC/STAC, vector tiles) and Titiler (COG raster tiles). A `worker` runs GDAL/ogr2ogr ingestion, dispatched via the Procrastinate job queue that lives *inside* PostgreSQL (no separate broker). PostgreSQL 18 (PostGIS + pgvector + pg_trgm) is the single source of truth; object storage is MinIO/S3; Valkey is the tile/query cache.
 
 Backend `backend/app/`: `modules/` (domain areas — `catalog` is the core, with `datasets`/`collections`/`records`/`features`/`maps`/`layers`/`search`/`sources`/`validation`), `platform/` (shared services), `processing/` (ingest/export/raster/tiles/embeddings/ai), `standards/` (OGC/STAC/DCAT), `core/` (config, DB, permissions, edition). Access control is in `catalog/authorization.py`. The `datasets` domain is split into `api/` (routers) and `domain/`, where service logic lives in `service_X` sub-modules behind a re-export façade in `domain/service.py` — import via the façade, never the sub-modules (`backend/tests/test_layering.py` enforces this).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and releases use semantic versioning.
 
 ## [Unreleased]
 
+### Changed
+
+- **BREAKING (self-hosted): bundled database upgraded to PostgreSQL 18 +
+  PostGIS 3.6** (from PostgreSQL 17 + PostGIS 3.5; GEOS 3.9 → 3.13, PROJ 7.2 →
+  9.6, pgvector stays on 0.8.x). An existing PG 17 `pgdata` volume cannot be
+  opened by PG 18 — the standard `scripts/upgrade.sh` flow does **not** apply
+  to this release. Follow the dump → fresh volume → restore procedure in
+  [RUNBOOK.md § 6](RUNBOOK.md#6-major-postgresql-version-upgrade-17--18).
+  Managed/external-Postgres deployments: run your provider's PG 17 → 18
+  upgrade, then deploy as usual (minimum supported external version remains
+  PostgreSQL 13). Motivation: the upstream `postgis/postgis:17-3.5` image line
+  is frozen on Debian bullseye (LTS ends 2026-08-31) at PostgreSQL 17.5, and
+  GEOS 3.13 speeds up the analysis hot paths (dissolve/buffer/repair)
+  1.5–2.3× in like-for-like benchmarks. The backup image's `pg_dump` moves to
+  18 in lockstep (a v17 `pg_dump` cannot dump a PG 18 server).
+
 ## [1.4.13] - 2026-07-24
 
 STAC conformance hardening: the STAC API now passes stac-api-validator for

--- a/Dockerfile
+++ b/Dockerfile
@@ -189,13 +189,15 @@ ENTRYPOINT ["/app/scripts/worker-entrypoint.sh"]
 CMD ["sh", "-c", "uv run --no-dev python -m app.worker"]
 
 # ==============================================================================
-# Stage: backup — pg_dump 17 + SigV4-capable S3 client; self-contained backup
+# Stage: backup — pg_dump 18 + SigV4-capable S3 client; self-contained backup
 # ==============================================================================
-# Base: official postgres:17 (Debian Bookworm, multi-arch: amd64 + arm64),
-# pinned by digest. Dependabot tracks Docker digest updates for this file.
-# db/Dockerfile uses postgis/postgis:17-3.5 which is amd64-ONLY — this stage
-# uses the digest-pinned postgres:17 base so publish.yml can build both arches
+# Base: official postgres:18 (multi-arch: amd64 + arm64), pinned by digest.
+# Dependabot tracks Docker digest updates for this file.
+# db/Dockerfile uses postgis/postgis:18-3.6 which is amd64-ONLY — this stage
+# uses the digest-pinned postgres:18 base so publish.yml can build both arches
 # (BKP-01).
+# chore(#704): must match the db server major — pg_dump refuses to dump a
+# server NEWER than itself, so this stage bumps in lockstep with db/Dockerfile.
 # PostGIS is NOT needed client-side: pg_dump streams the raw catalog over the
 # wire and custom-format dumps preserve PostGIS types without PostGIS libs.
 #
@@ -204,7 +206,7 @@ CMD ["sh", "-c", "uv run --no-dev python -m app.worker"]
 # app image (frontend), never this postgres-based backup tool. Every image is
 # built with an explicit `target:` (publish.yml + docker-compose*.yml), so stage
 # order only governs that unqualified-build default — keep `backup` non-final.
-FROM postgres:17@sha256:a426e44bac0b759c95894d68e1a0ac03ecc20b619f498a91aae373bf06d8508d AS backup
+FROM postgres:18@sha256:3a82e1f56c8f0f5616a11103ac3d47e632c3938698946a7ad26da0df1334744a AS backup
 
 LABEL org.opencontainers.image.title="geolens-backup"
 LABEL org.opencontainers.image.description="Automated pg_dump backup service with S3 offload"
@@ -213,7 +215,7 @@ LABEL org.opencontainers.image.source="https://github.com/geolens-io/geolens"
 
 # awscli (SigV4-capable S3 client) for the BKP-02 S3 upload path; procps for the
 # compose healthcheck (`pgrep -f backup-entrypoint || pgrep -f sleep`) — pgrep is
-# present in the postgres:17 base today but is installed explicitly so the
+# present in the postgres base today but is installed explicitly so the
 # default-on healthcheck's pgrep dependency survives a base-image change.
 # Installed from Debian apt only — no pip/PyPI (T-1247-SC mitigation).
 RUN apt-get update && apt-get upgrade -y --no-install-recommends && \

--- a/README.de.md
+++ b/README.de.md
@@ -15,7 +15,7 @@ GeoLens ist ein quelloffener, selbst gehosteter Katalog und Karteneditor für GI
 [![CI](https://github.com/geolens-io/geolens/actions/workflows/ci.yml/badge.svg)](https://github.com/geolens-io/geolens/actions/workflows/ci.yml)
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![Python: backend 3.13+ / SDK 3.10+](https://img.shields.io/badge/python-3.13%2B_backend_%7C_3.10%2B_SDK-blue.svg)](https://www.python.org/)
-[![PostgreSQL 17 + PostGIS 3.5](https://img.shields.io/badge/PostGIS_3.5-PostgreSQL_17-336791.svg)](https://postgis.net/)
+[![PostgreSQL 18 + PostGIS 3.6](https://img.shields.io/badge/PostGIS_3.6-PostgreSQL_18-336791.svg)](https://postgis.net/)
 [![OGC API](https://img.shields.io/badge/OGC_API-Features_%7C_Records-green.svg)](https://ogcapi.ogc.org/)
 
 ```bash
@@ -183,7 +183,7 @@ Für jedes Beispiel gibt es eine vollständige Anleitung in der [Dokumentation](
 
 ## Schnellstart
 
-**Voraussetzungen:** Docker Engine 24+ und Docker Compose v2. Der enthaltene Stack liefert PostgreSQL 17. Für eine extern verwaltete Datenbank ist **PostgreSQL 13+** (für `gen_random_uuid()`) mit **pgvector 0.5+** (für HNSW-Indizes der semantischen Suche) sowie PostGIS, pg_trgm und unaccent erforderlich. API und Worker laufen in Containern (Python 3.14 enthalten, kein Python auf dem Host nötig). Die optionale CLI läuft auf dem Host und benötigt Python 3.11+; Python-SDK und Seed-Skripte benötigen Python 3.10+.
+**Voraussetzungen:** Docker Engine 24+ und Docker Compose v2. Der enthaltene Stack liefert PostgreSQL 18. Für eine extern verwaltete Datenbank ist **PostgreSQL 13+** (für `gen_random_uuid()`) mit **pgvector 0.5+** (für HNSW-Indizes der semantischen Suche) sowie PostGIS, pg_trgm und unaccent erforderlich. API und Worker laufen in Containern (Python 3.14 enthalten, kein Python auf dem Host nötig). Die optionale CLI läuft auf dem Host und benötigt Python 3.11+; Python-SDK und Seed-Skripte benötigen Python 3.10+.
 
 Die Einzeileninstallation lädt vorgefertigte, versionsgebundene Images und startet den Stack:
 
@@ -282,7 +282,7 @@ flowchart TB
     end
 
     subgraph store [Data and storage]
-      PG[("PostgreSQL 17<br/>PostGIS · pgvector · pg_trgm<br/>+ Procrastinate queue")]
+      PG[("PostgreSQL 18<br/>PostGIS · pgvector · pg_trgm<br/>+ Procrastinate queue")]
       OBJ[("Object storage<br/>local files or S3/MinIO")]
       CACHE[("Valkey cache")]
     end
@@ -307,7 +307,7 @@ flowchart TB
 | Rasterkacheln | Titiler (COG-Kachelserver) |
 | Objektspeicher | MinIO (S3-kompatibel, lokale Entwicklung) oder beliebiger S3-Anbieter |
 | Cache | Valkey (Kachel- und Abfragecache) |
-| Datenbank | PostgreSQL 17 + PostGIS 3.5 + pgvector + pg_trgm (Minimum: PostgreSQL 13, pgvector 0.5) |
+| Datenbank | PostgreSQL 18 + PostGIS 3.6 + pgvector + pg_trgm (Minimum: PostgreSQL 13, pgvector 0.5) |
 | Reverse Proxy | Nginx (Produktion) / Vite-Entwicklungsproxy (Entwicklung) |
 
 ## Konfiguration

--- a/README.es.md
+++ b/README.es.md
@@ -15,7 +15,7 @@ GeoLens es un catálogo y constructor de mapas de código abierto y autohospedad
 [![CI](https://github.com/geolens-io/geolens/actions/workflows/ci.yml/badge.svg)](https://github.com/geolens-io/geolens/actions/workflows/ci.yml)
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![Python: backend 3.13+ / SDK 3.10+](https://img.shields.io/badge/python-3.13%2B_backend_%7C_3.10%2B_SDK-blue.svg)](https://www.python.org/)
-[![PostgreSQL 17 + PostGIS 3.5](https://img.shields.io/badge/PostGIS_3.5-PostgreSQL_17-336791.svg)](https://postgis.net/)
+[![PostgreSQL 18 + PostGIS 3.6](https://img.shields.io/badge/PostGIS_3.6-PostgreSQL_18-336791.svg)](https://postgis.net/)
 [![OGC API](https://img.shields.io/badge/OGC_API-Features_%7C_Records-green.svg)](https://ogcapi.ogc.org/)
 
 ```bash
@@ -184,7 +184,7 @@ Cada ejemplo anterior tiene una guía completa en la [documentación](https://do
 
 ## Inicio rápido
 
-**Requisitos previos:** Docker Engine 24+ y Docker Compose v2. El entorno incluido incorpora PostgreSQL 17. Si conectas GeoLens a una base de datos administrada externamente, debe ser **PostgreSQL 13+** (para `gen_random_uuid()`) con **pgvector 0.5+** (para índices HNSW de búsqueda semántica), además de PostGIS, pg_trgm y unaccent. La API y el worker se ejecutan en contenedores (se incluye Python 3.14; no hace falta Python en el host). La CLI opcional se ejecuta en el host y requiere Python 3.11+; el SDK de Python y los scripts de datos iniciales requieren Python 3.10+.
+**Requisitos previos:** Docker Engine 24+ y Docker Compose v2. El entorno incluido incorpora PostgreSQL 18. Si conectas GeoLens a una base de datos administrada externamente, debe ser **PostgreSQL 13+** (para `gen_random_uuid()`) con **pgvector 0.5+** (para índices HNSW de búsqueda semántica), además de PostGIS, pg_trgm y unaccent. La API y el worker se ejecutan en contenedores (se incluye Python 3.14; no hace falta Python en el host). La CLI opcional se ejecuta en el host y requiere Python 3.11+; el SDK de Python y los scripts de datos iniciales requieren Python 3.10+.
 
 La instalación en una línea descarga las imágenes precompiladas y fijadas a una versión e inicia el entorno:
 
@@ -283,7 +283,7 @@ flowchart TB
     end
 
     subgraph store [Data and storage]
-      PG[("PostgreSQL 17<br/>PostGIS · pgvector · pg_trgm<br/>+ Procrastinate queue")]
+      PG[("PostgreSQL 18<br/>PostGIS · pgvector · pg_trgm<br/>+ Procrastinate queue")]
       OBJ[("Object storage<br/>local files or S3/MinIO")]
       CACHE[("Valkey cache")]
     end
@@ -308,7 +308,7 @@ flowchart TB
 | Teselas ráster | Titiler (servidor de teselas COG) |
 | Almacenamiento de objetos | MinIO (compatible con S3, desarrollo local) o cualquier proveedor S3 |
 | Caché | Valkey (caché de teselas y consultas) |
-| Base de datos | PostgreSQL 17 + PostGIS 3.5 + pgvector + pg_trgm (mínimo: PostgreSQL 13, pgvector 0.5) |
+| Base de datos | PostgreSQL 18 + PostGIS 3.6 + pgvector + pg_trgm (mínimo: PostgreSQL 13, pgvector 0.5) |
 | Proxy inverso | Nginx (producción) / proxy de desarrollo Vite (desarrollo) |
 
 ## Configuración

--- a/README.fr.md
+++ b/README.fr.md
@@ -15,7 +15,7 @@ GeoLens est un catalogue et un générateur de cartes open source et auto-héber
 [![CI](https://github.com/geolens-io/geolens/actions/workflows/ci.yml/badge.svg)](https://github.com/geolens-io/geolens/actions/workflows/ci.yml)
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![Python: backend 3.13+ / SDK 3.10+](https://img.shields.io/badge/python-3.13%2B_backend_%7C_3.10%2B_SDK-blue.svg)](https://www.python.org/)
-[![PostgreSQL 17 + PostGIS 3.5](https://img.shields.io/badge/PostGIS_3.5-PostgreSQL_17-336791.svg)](https://postgis.net/)
+[![PostgreSQL 18 + PostGIS 3.6](https://img.shields.io/badge/PostGIS_3.6-PostgreSQL_18-336791.svg)](https://postgis.net/)
 [![OGC API](https://img.shields.io/badge/OGC_API-Features_%7C_Records-green.svg)](https://ogcapi.ogc.org/)
 
 ```bash
@@ -183,7 +183,7 @@ Chaque exemple ci-dessus dispose d’un guide complet dans la [documentation](ht
 
 ## Démarrage rapide
 
-**Prérequis :** Docker Engine 24+ et Docker Compose v2. La pile incluse fournit PostgreSQL 17. Si GeoLens utilise une base gérée en externe, celle-ci doit être **PostgreSQL 13+** (pour `gen_random_uuid()`) avec **pgvector 0.5+** (pour les index HNSW de recherche sémantique), ainsi que PostGIS, pg_trgm et unaccent. L’API et le worker s’exécutent en conteneurs (Python 3.14 inclus, aucun Python hôte nécessaire). La CLI facultative s’exécute sur l’hôte et nécessite Python 3.11+ ; le SDK Python et les scripts d’initialisation nécessitent Python 3.10+.
+**Prérequis :** Docker Engine 24+ et Docker Compose v2. La pile incluse fournit PostgreSQL 18. Si GeoLens utilise une base gérée en externe, celle-ci doit être **PostgreSQL 13+** (pour `gen_random_uuid()`) avec **pgvector 0.5+** (pour les index HNSW de recherche sémantique), ainsi que PostGIS, pg_trgm et unaccent. L’API et le worker s’exécutent en conteneurs (Python 3.14 inclus, aucun Python hôte nécessaire). La CLI facultative s’exécute sur l’hôte et nécessite Python 3.11+ ; le SDK Python et les scripts d’initialisation nécessitent Python 3.10+.
 
 L’installation en une ligne télécharge les images précompilées épinglées à une version et démarre la pile :
 
@@ -282,7 +282,7 @@ flowchart TB
     end
 
     subgraph store [Data and storage]
-      PG[("PostgreSQL 17<br/>PostGIS · pgvector · pg_trgm<br/>+ Procrastinate queue")]
+      PG[("PostgreSQL 18<br/>PostGIS · pgvector · pg_trgm<br/>+ Procrastinate queue")]
       OBJ[("Object storage<br/>local files or S3/MinIO")]
       CACHE[("Valkey cache")]
     end
@@ -307,7 +307,7 @@ flowchart TB
 | Tuiles raster | Titiler (serveur de tuiles COG) |
 | Stockage objet | MinIO (compatible S3, développement local) ou tout fournisseur S3 |
 | Cache | Valkey (cache de tuiles et de requêtes) |
-| Base de données | PostgreSQL 17 + PostGIS 3.5 + pgvector + pg_trgm (minimum : PostgreSQL 13, pgvector 0.5) |
+| Base de données | PostgreSQL 18 + PostGIS 3.6 + pgvector + pg_trgm (minimum : PostgreSQL 13, pgvector 0.5) |
 | Proxy inverse | Nginx (production) / proxy de développement Vite (développement) |
 
 ## Configuration

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ GeoLens is an open-source, self-hosted catalog and map builder for GIS and data 
 [![CI](https://github.com/geolens-io/geolens/actions/workflows/ci.yml/badge.svg)](https://github.com/geolens-io/geolens/actions/workflows/ci.yml)
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![Python: backend 3.13+ / SDK 3.10+](https://img.shields.io/badge/python-3.13%2B_backend_%7C_3.10%2B_SDK-blue.svg)](https://www.python.org/)
-[![PostgreSQL 17 + PostGIS 3.5](https://img.shields.io/badge/PostGIS_3.5-PostgreSQL_17-336791.svg)](https://postgis.net/)
+[![PostgreSQL 18 + PostGIS 3.6](https://img.shields.io/badge/PostGIS_3.6-PostgreSQL_18-336791.svg)](https://postgis.net/)
 [![OGC API](https://img.shields.io/badge/OGC_API-Features_%7C_Records-green.svg)](https://ogcapi.ogc.org/)
 
 ```bash
@@ -186,7 +186,7 @@ Each example above has a full guide in the [docs](https://docs.getgeolens.com/gu
 ## Quick start
 
 **Prerequisites:** Docker Engine 24+ and Docker Compose v2. The bundled stack
-ships PostgreSQL 17. If you point GeoLens at an externally managed database, it
+ships PostgreSQL 18. If you point GeoLens at an externally managed database, it
 must be **PostgreSQL 13+** (for `gen_random_uuid()`) with **pgvector 0.5+** (for
 HNSW semantic-search indexes), plus PostGIS, pg_trgm, and unaccent. The API and
 worker run in containers (Python 3.14 bundled, no host Python needed). The
@@ -321,7 +321,7 @@ flowchart TB
     end
 
     subgraph store [Data and storage]
-      PG[("PostgreSQL 17<br/>PostGIS · pgvector · pg_trgm<br/>+ Procrastinate queue")]
+      PG[("PostgreSQL 18<br/>PostGIS · pgvector · pg_trgm<br/>+ Procrastinate queue")]
       OBJ[("Object storage<br/>local files or S3/MinIO")]
       CACHE[("Valkey cache")]
     end
@@ -346,7 +346,7 @@ flowchart TB
 | Raster Tiles | Titiler (COG tile server) |
 | Object Storage | MinIO (S3-compatible, local dev) or any S3 provider |
 | Cache | Valkey (tile and query cache) |
-| Database | PostgreSQL 17 + PostGIS 3.5 + pgvector + pg_trgm (minimum: PostgreSQL 13, pgvector 0.5) |
+| Database | PostgreSQL 18 + PostGIS 3.6 + pgvector + pg_trgm (minimum: PostgreSQL 13, pgvector 0.5) |
 | Reverse Proxy | Nginx (production) / Vite dev proxy (development) |
 
 ## Configuration

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -18,6 +18,7 @@ documentation.
 3. [Restore — managed / external Postgres mode](#3-restore--managed--external-postgres-mode)
 4. [Monitoring](#4-monitoring)
 5. [Incident response — data loss](#5-incident-response--data-loss)
+6. [Major PostgreSQL version upgrade (17 → 18)](#6-major-postgresql-version-upgrade-17--18)
 
 ---
 
@@ -479,3 +480,74 @@ stack to confirm the restore procedure from end to end before trusting the data.
   whether any `ERROR: pg_dump failed` entries appear in the logs for that period.
 - Re-enable the backup service if it was stopped during recovery:
   `docker compose start backup`.
+
+---
+
+## 6. Major PostgreSQL version upgrade (17 → 18)
+
+GeoLens moved its bundled database image from PostgreSQL 17 + PostGIS 3.5 to
+PostgreSQL 18 + PostGIS 3.6. **A PG 17 `pgdata` volume cannot be opened by a
+PG 18 server** — the `db` container will refuse to start against the old
+volume ("database files are incompatible with server"). Plan a maintenance
+window; downtime is roughly proportional to database size (dump + restore).
+
+The supported path for the bundled `db` container is **dump → fresh volume →
+restore**, using the same shipped tooling as disaster recovery (section 2).
+`pg_upgrade` is not practical here because the bundled image ships only one
+set of server binaries.
+
+### Bundled Postgres mode (default Compose deployment)
+
+```bash
+# 0. Take a fresh pre-upgrade dump WITH THE OLD STACK STILL RUNNING, then
+#    verify it exists. (The scheduled backup service works too — this just
+#    guarantees a dump from the moment of the upgrade.)
+docker compose exec backup sh -c \
+  'PGPASSWORD="$POSTGRES_PASSWORD" pg_dump -Fc -h "$POSTGRES_HOST" -U "$POSTGRES_USER" "$POSTGRES_DB" \
+   > /backups/daily/pre_pg18_manual.dump'
+docker compose exec backup sh -c 'ls -l /backups/daily/pre_pg18_manual.dump'
+
+# 1. Copy the dump out of the backup volume to the host (survives volume ops).
+#    Replace <project> with your Compose project name (see `docker volume ls`).
+mkdir -p ./restore
+docker run --rm -v <project>_backup_data:/backups -v "$PWD/restore":/out alpine \
+  cp /backups/daily/pre_pg18_manual.dump /out/
+
+# 2. Stop the stack and remove ONLY the database volume.
+docker compose down
+docker volume rm <project>_pgdata
+
+# 3. Pull/build the new images and start the db — a fresh PG 18 cluster
+#    initializes, and scripts/init-db.sh provisions extensions + roles.
+docker compose pull   # or: docker compose build db, if you build locally
+docker compose up -d --wait db
+
+# 4. Restore the dump (canonical entry point, validates before restoring).
+./scripts/restore.sh ./restore/pre_pg18_manual.dump
+
+# 5. Start the rest of the stack; migrations run via the migrate service.
+docker compose up -d
+
+# 6. Verify.
+docker compose exec db psql -U geolens -c 'select version();'
+curl -fsS http://localhost:8080/api/health
+```
+
+Multi-tenant deployments: after the fresh-cluster restore, rebuild the
+tenant data-plane roles exactly as documented in
+[section 2 → Multi-tenant role reconstruction](#multi-tenant-role-reconstruction-after-a-fresh-cluster-restore).
+
+### Managed / external Postgres mode
+
+Use your provider's managed major-version upgrade (all managed providers
+support in-place PG 17 → 18), then start the new GeoLens release and let the
+`migrate` service run as usual. GeoLens requires the `postgis`, `pg_trgm`,
+`unaccent`, and `vector` extensions to remain installed after the engine
+upgrade — most providers carry extensions across, but verify with
+`\dx` before starting the stack.
+
+### Rollback
+
+The pre-upgrade dump restores onto a PG 17 stack the same way (step 2-5 with
+the previous image tags). A dump taken FROM PG 18 does NOT restore onto 17 —
+keep the pre-upgrade dump until you are satisfied with the upgrade.

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -389,8 +389,8 @@ plans, checkpoint activity — into daily-rotated files inside the pgdata volume
 Read them with:
 
 ```bash
-docker compose exec db sh -c 'ls -t /var/lib/postgresql/data/log/'
-docker compose exec db sh -c 'tail -100 "/var/lib/postgresql/data/log/$(ls -t /var/lib/postgresql/data/log/ | head -1)"'
+docker compose exec db sh -c 'ls -t "$PGDATA/log/"'
+docker compose exec db sh -c 'tail -100 "$PGDATA/log/$(ls -t "$PGDATA/log/" | head -1)"'
 ```
 
 An empty `docker compose logs db` does **not** mean there are no slow queries —
@@ -517,18 +517,21 @@ docker run --rm -v <project>_backup_data:/backups -v "$PWD/restore":/out alpine 
 docker compose down
 docker volume rm <project>_pgdata
 
-# 3. Pull/build the new images and start the db — a fresh PG 18 cluster
-#    initializes, and scripts/init-db.sh provisions extensions + roles.
+# 3. Pull/build the new images and start the WHOLE stack once — a fresh PG 18
+#    cluster initializes (scripts/init-db.sh provisions extensions + base
+#    roles), then the migrate service applies all migrations. This step is
+#    REQUIRED before the restore: migrations create the app roles (e.g.
+#    geolens_readonly) that the dump's GRANT statements reference — restoring
+#    onto an unmigrated cluster spews "role ... does not exist" errors.
 docker compose pull   # or: docker compose build db, if you build locally
-docker compose up -d --wait db
+docker compose up -d --wait
 
-# 4. Restore the dump (canonical entry point, validates before restoring).
+# 4. Restore the dump (canonical entry point: validates the file, stops
+#    api/worker, restores over the freshly migrated schema via
+#    --clean --if-exists, and restarts api/worker when done).
 ./scripts/restore.sh ./restore/pre_pg18_manual.dump
 
-# 5. Start the rest of the stack; migrations run via the migrate service.
-docker compose up -d
-
-# 6. Verify.
+# 5. Verify.
 docker compose exec db psql -U geolens -c 'select version();'
 curl -fsS http://localhost:8080/api/health
 ```

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -536,9 +536,10 @@ docker compose exec db psql -U geolens -c 'select version();'
 curl -fsS http://localhost:8080/api/health
 ```
 
-Multi-tenant deployments: after the fresh-cluster restore, rebuild the
-tenant data-plane roles exactly as documented in
-[section 2 → Multi-tenant role reconstruction](#multi-tenant-role-reconstruction-after-a-fresh-cluster-restore).
+Deployments with tenant isolation enabled: after the fresh-cluster restore,
+rebuild the tenant data-plane roles exactly as documented in the
+role-reconstruction subsection of section 2 before starting API, worker, or
+tile traffic.
 
 ### Managed / external Postgres mode
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -10,6 +10,16 @@ fails, you re-pin the old version and restore the pre-upgrade dump.
 > **Always take a backup before upgrading.** The one-command flow does this for
 > you; the manual flows below tell you exactly when to do it.
 
+> **⚠️ Major PostgreSQL upgrades are a special case.** When a GeoLens release
+> bumps the bundled PostgreSQL **major** version (first occurrence: the release
+> that moves PostgreSQL 17 → 18 / PostGIS 3.5 → 3.6), the flows on this page do
+> **not** apply: a PG 17 `pgdata` volume cannot be opened by a PG 18 server, so
+> after the image pull the `db` container will refuse to start ("database files
+> are incompatible with server"). Follow
+> [RUNBOOK.md § 6 — Major PostgreSQL version upgrade](RUNBOOK.md#6-major-postgresql-version-upgrade-17--18)
+> instead (dump → fresh volume → restore, with rollback notes). The release
+> notes call out every release this applies to.
+
 ---
 
 ## How your install was set up

--- a/backend/tests/test_docker_audit_regressions.py
+++ b/backend/tests/test_docker_audit_regressions.py
@@ -32,7 +32,7 @@ def test_backup_base_is_digest_pinned():
     text = DOCKERFILE.read_text()
 
     assert re.search(
-        r"^FROM postgres:17@sha256:[0-9a-f]{64} AS backup$", text, re.MULTILINE
+        r"^FROM postgres:18@sha256:[0-9a-f]{64} AS backup$", text, re.MULTILINE
     )
 
 

--- a/backend/tests/test_docker_audit_regressions.py
+++ b/backend/tests/test_docker_audit_regressions.py
@@ -61,11 +61,14 @@ def test_production_database_init_script_is_read_only():
 
 
 def test_backup_services_override_inherited_postgres_data_volume():
+    # chore(#704): postgres 18+ bases declare VOLUME /var/lib/postgresql
+    # (PGDATA moved to <major>/docker inside it) — the tmpfs override must
+    # target the new path or the anonymous volume comes back.
     for compose_path in (DEV_COMPOSE, PROD_COMPOSE):
         backup = _load_compose(compose_path)["services"]["backup"]
         tmpfs_paths = [mount.split(":", 1)[0] for mount in backup["tmpfs"]]
 
-        assert "/var/lib/postgresql/data" in tmpfs_paths, compose_path.name
+        assert "/var/lib/postgresql" in tmpfs_paths, compose_path.name
 
 
 def test_production_frontend_has_only_explicit_writable_mounts():

--- a/db/Dockerfile
+++ b/db/Dockerfile
@@ -1,11 +1,17 @@
-# PostGIS 17 + pgvector, built on the OFFICIAL postgis/postgis image (the source
+# PostGIS 18 + pgvector, built on the OFFICIAL postgis/postgis image (the source
 # maintainer). pgvector is installed from its official PGDG apt package
-# (postgresql-17-pgvector), NOT compiled from source — same extension version
+# (postgresql-18-pgvector), NOT compiled from source — same extension version
 # (0.8.x), a small/fast layer, and no build toolchain left in the final image.
 #
-# The --platform=linux/amd64 pin is required: postgis/postgis:17-3.5 only
+# chore(#704): bumped from 17-3.5 (Debian bullseye, EOL 2026-08-31, frozen at
+# PG 17.5 / GEOS 3.9) to 18-3.6 (Debian trixie, GEOS 3.13 / PROJ 9.6 — measured
+# 1.5–2.3× on ST_Union/ST_Buffer/ST_MakeValid analysis paths; no 17-3.6 tag
+# exists upstream). Major-version bump: existing pgdata volumes need
+# pg_upgrade or dump/restore — see RUNBOOK.md.
+#
+# The --platform=linux/amd64 pin is required: postgis/postgis:18-3.6 only
 # publishes an amd64 manifest (no arm64 variant), so arm64 hosts run this under
-# emulation. This is unchanged from the previous source-compile Dockerfile.
+# emulation. This is unchanged from the 17-3.5 image.
 #
 # Expected build/runtime warnings (NOT bugs):
 #   - WARN: FromPlatformFlagConstDisallowed: FROM --platform flag should not use
@@ -18,11 +24,11 @@
 # scoped entry + rationale in .trivyignore.yaml). The official postgis/postgres
 # entrypoint runs as root only to initdb/chown on first boot, then drops to the
 # unprivileged `postgres` user via gosu for the server process.
-FROM --platform=linux/amd64 postgis/postgis:17-3.5
+FROM --platform=linux/amd64 postgis/postgis:18-3.6
 
 # pgvector for semantic-search embeddings, from the PGDG apt repository that the
 # official postgres/postgis base image already configures.
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-        postgresql-17-pgvector && \
+        postgresql-18-pgvector && \
     rm -rf /var/lib/apt/lists/*

--- a/db/postgresql.conf
+++ b/db/postgresql.conf
@@ -57,8 +57,8 @@ auto_explain.log_format = text
 # slow-query lines, auto_explain plans, checkpoints — lands in files under
 # $PGDATA/log/ inside the pgdata volume. `docker compose logs db` shows
 # NOTHING by design. Read with:
-#   docker compose exec db sh -c 'ls -t /var/lib/postgresql/data/log/ | head'
-#   docker compose exec db sh -c 'tail -100 /var/lib/postgresql/data/log/<file>'
+#   docker compose exec db sh -c 'ls -t "$PGDATA/log/" | head'
+#   docker compose exec db sh -c 'tail -100 "$PGDATA/log/<file>"'
 # Kept on deliberately: log files survive container restarts and rotate daily.
 logging_collector = on
 log_destination = 'stderr'

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -164,7 +164,10 @@ services:
     ports:
       - "127.0.0.1:${DB_PORT:-5432}:5432"
     volumes:
-      - pgdata:/var/lib/postgresql/data
+      # chore(#704): PG 18+ images take a single mount at /var/lib/postgresql
+      # (PGDATA lives at <major>/docker inside it); mounting the legacy
+      # /var/lib/postgresql/data path makes the 18+ entrypoint refuse to boot.
+      - pgdata:/var/lib/postgresql
       - ./scripts/init-db.sh:/docker-entrypoint-initdb.d/10-init.sh:ro
       - ./db/postgresql.conf:/etc/postgresql/custom.conf:ro
     # GAP-001: memory limit prevents the DB from consuming all host RAM under
@@ -499,7 +502,7 @@ services:
     # tmpfs because this image only runs pg_dump; otherwise Docker creates an
     # unused anonymous volume for every backup container.
     tmpfs:
-      - /var/lib/postgresql/data:size=1m,mode=0700
+      - /var/lib/postgresql:size=1m,mode=0700
     volumes:
       # No ./scripts bind-mount in prod: the published geolens-backup image bakes
       # /scripts/backup-entrypoint.sh + restore.sh (BKP-01), so the prebuilt-prod

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -164,7 +164,10 @@ services:
       # Host-port fallback (5434 from .env, 5432 bare).
       - "127.0.0.1:${DB_PORT:-5432}:5432"
     volumes:
-      - pgdata:/var/lib/postgresql/data
+      # chore(#704): PG 18+ images take a single mount at /var/lib/postgresql
+      # (PGDATA lives at <major>/docker inside it); mounting the legacy
+      # /var/lib/postgresql/data path makes the 18+ entrypoint refuse to boot.
+      - pgdata:/var/lib/postgresql
       # GAP-021: :ro mirrors the sibling conf mount and every repo-file mount on
       # the api service — the init script is read+exec inside the container, never
       # written, so a compromised db container cannot rewrite this host file (it
@@ -595,7 +598,7 @@ services:
     # tmpfs because this image only runs pg_dump; otherwise Docker creates an
     # unused anonymous volume for every backup container.
     tmpfs:
-      - /var/lib/postgresql/data:size=1m,mode=0700
+      - /var/lib/postgresql:size=1m,mode=0700
     volumes:
       - ./scripts:/scripts:ro
       - backup_data:/backups

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -133,7 +133,7 @@ x-hardened-base: &hardened-base
 # Services
 # ==============================================================================
 # Services at a glance:
-#   db        — PostgreSQL 17 + PostGIS 3.5 (catalog data, pgvector, pg_trgm)
+#   db        — PostgreSQL 18 + PostGIS 3.6 (catalog data, pgvector, pg_trgm)
 #   migrate   — one-shot alembic upgrade heads, exits when done
 #   api       — FastAPI REST + OGC API + Records (host :8001 -> container :8000)
 #   worker    — Procrastinate job queue (GDAL ingest, embeddings, exports)
@@ -581,7 +581,7 @@ services:
     restart: unless-stopped
     # D03 (docker-audit-20260604): backup-entrypoint.sh runs as root throughout
     # (pg_dump/cp/tar/awscli/sleep on files it owns under /backups; the
-    # postgres:17 base ships no cron, so it runs the built-in sleep-loop
+    # postgres:18 base ships no cron, so it runs the built-in sleep-loop
     # scheduler). It never drops privilege or chowns across uids, so it needs NO
     # added capabilities — cap_drop ALL just removes the unused kernel surface.
     # init:true reaps the sleep loop. No read_only — the entrypoint writes under
@@ -623,7 +623,7 @@ services:
       S3_ADDRESSING_STYLE: ${S3_ADDRESSING_STYLE:-auto}
     entrypoint: ["/scripts/backup-entrypoint.sh"]
     healthcheck:
-      # The entrypoint runs the built-in sleep-loop scheduler (postgres:17 has no
+      # The entrypoint runs the built-in sleep-loop scheduler (postgres:18 has no
       # cron); the probe just verifies that process is alive.
       test: ["CMD-SHELL", "pgrep -f backup-entrypoint || pgrep -f sleep || exit 1"]
       interval: 30s

--- a/scripts/restore.sh
+++ b/scripts/restore.sh
@@ -29,9 +29,11 @@ if [ ! -f "$BACKUP_FILE" ]; then
 fi
 
 # Validate backup integrity before restore
+# chore(#704): read stdin by OMITTING the filename — the literal "-" alias was
+# never documented for pg_restore and PG 18 rejects it as a filename.
 echo "Validating backup integrity..."
 if ! "${COMPOSE[@]}" exec -T db \
-    pg_restore --list - < "$BACKUP_FILE" > /dev/null 2>&1; then
+    pg_restore --list < "$BACKUP_FILE" > /dev/null 2>&1; then
     echo "ERROR: Backup file is corrupt or invalid: $BACKUP_FILE" >&2
     echo "pg_restore --list validation failed. Aborting restore." >&2
     exit 1


### PR DESCRIPTION
Closes the image-bump portion of #704.

## What

- **db image → `postgis/postgis:18-3.6`** (PG 18.4, PostGIS 3.6.4, GEOS 3.13, PROJ 9.6, Debian trixie) with pgvector via `postgresql-18-pgvector` (stays 0.8.x). The upstream `17-3.5` line is frozen on Debian bullseye (LTS ends **2026-08-31**) at PG 17.5/GEOS 3.9, and no `17-3.6` tag exists.
- **backup stage → `postgres:18` digest**, in lockstep: `pg_dump` refuses to dump a server newer than itself.
- **RUNBOOK §6**: the operator procedure for the major bump (dump → fresh volume → restore; managed-mode path; rollback notes). **UPGRADING.md** callout: the standard `scripts/upgrade.sh` flow does not apply across a PG major (the new db image refuses the old `pgdata` volume). **CHANGELOG** breaking notice under Unreleased.
- CI provisions 18-3.6 + the v18 client everywhere it provisioned 17; dep-audit Trivy matrix mirrors the new pin; version references swept in compose comments, AGENTS.md, and all four READMEs (51 replacements).
- **Two PG 18 incompatibilities found by performing the migration live** (both fixed here):
  1. postgres 18+ images moved PGDATA to `/var/lib/postgresql/<major>/docker` and refuse a volume at the legacy `/var/lib/postgresql/data` path — compose mounts (dev + prod) and the backup service's VOLUME tmpfs override moved to the single `/var/lib/postgresql` mount; log-path docs now use `$PGDATA`.
  2. `pg_restore` 18 rejects the undocumented `-` stdin alias `restore.sh` used for dump validation — now reads stdin the documented way (filename omitted).

## Why

Maintenance (frozen bullseye base, a year of missed PG minors) plus measured wins on the analysis hot paths — GEOS 3.9→3.13 in like-for-like seeded benchmarks: `ST_Union` (dissolve) **2.2–2.3×**, `ST_MakeValid` 1.7× (and the `method=structure` variant, silently ignored on GEOS 3.9, is another 3.2× on 18), `ST_Intersection` 1.6×, `ST_Buffer` 1.5×. Full numbers and methodology in #704. The #701 size gates get re-evaluated on native amd64 as follow-up.

## Schema / API / config impact

- **No schema or API change**; no OpenAPI/SDK regen needed.
- **Operator-breaking for self-hosters**: existing PG 17 `pgdata` volumes require the RUNBOOK §6 dump→restore migration. Release notes must carry the callout; the release that ships this is v1.5.0-shaped.
- `db/postgresql.conf` unchanged — all GUCs valid on PG 18 (`jit=off` retained for pgvector).
- Demo VM and Helm chart/deployments repo pick this up at release time (tracked in #704), not at merge.

## Verification

- Full backend suite against a fresh 18-3.6 container: **5,847 passed / 75 skipped**, 1 failure = an order-dependent `test_ai_metadata_authz_1173` case that passes serially (known parallel-run flake family, not PG 18). An earlier pass isolated 20 failures — 19 were probe-harness artifacts (throwaway DB had skipped `scripts/init-db.sh` + primary migrations), 1 was the digest-pin regression test updated in this PR; every one re-verified green.
- Alembic chain 0001→0028 applied cleanly on PG 18; `pg_dump` 18.4 confirmed in the rebuilt backup image.
- Local dev stack migrated 17→18 by following RUNBOOK §6 end-to-end — which is how the volume-layout and `pg_restore` stdin fixes were found; final §6 as written completed with restore exit 0 and full row parity (86 records / 86 datasets / 9 maps).
- Playwright smoke against the migrated stack: 7/7 passed (includes upload → ingest → preview).
- `uv run ruff check` / `format --check` clean on the touched test file; pre-commit hooks green on all three commits.
