### PR TITLE
docs(runbook): §6 must rebuild the backup image too, not just db (#704)

### DIFF
--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -523,7 +523,10 @@ docker volume rm <project>_pgdata
 #    REQUIRED before the restore: migrations create the app roles (e.g.
 #    geolens_readonly) that the dump's GRANT statements reference — restoring
 #    onto an unmigrated cluster spews "role ... does not exist" errors.
-docker compose pull   # or: docker compose build db, if you build locally
+docker compose pull   # or: docker compose build, if you build locally.
+                      # Rebuild EVERYTHING, not just db: the backup image's
+                      # pg_dump major must match the new server, or every
+                      # backup cycle fails with "server version mismatch".
 docker compose up -d --wait
 
 # 4. Restore the dump (canonical entry point: validates the file, stops


### PR DESCRIPTION
One-line hardening of the RUNBOOK §6 migration procedure, found post-#705 on a live source-build stack: step 3's "build db" guidance leaves the previous backup image in place, and its pg_dump 17 fails against the PG 18 server ("server version mismatch") on every cycle — silently killing nightly backups. The step now says to rebuild everything and explains why. Verified: rebuilt backup image on the affected stack, initial cycle green (pg_dump 18.4, 21M dump).