### PR TITLE
fix(backup): verify dumps end-to-end and state the recovery point objective

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,14 @@ and releases use semantic versioning.
   1.5–2.3× in like-for-like benchmarks. The backup image's `pg_dump` moves to
   18 in lockstep (a v17 `pg_dump` cannot dump a PG 18 server).
 
+- **Every backup verifies itself, and the RUNBOOK states the RPO.** Each cycle
+  now reads its dump back end-to-end and discards it if unreadable, so a
+  corrupt backup surfaces the night it happens rather than during a recovery.
+  RUNBOOK § 1 states the default recovery point objective (up to 24 hours)
+  outright instead of leaving it to be inferred from the cron schedule, and § 3
+  is explicit that point-in-time recovery is a different mechanism rather than
+  a finer setting — logical dumps cannot participate in WAL replay — including
+  the failure mode a hand-rolled `archive_command` introduces.
 - **`scripts/upgrade.sh` refuses to cross a PostgreSQL major version.** It now
   compares the running server's major against the one the target release
   bundles and stops **before** anything changes — no image pull, no version
@@ -48,6 +56,14 @@ and releases use semantic versioning.
 
 ### Fixed
 
+- **Backup integrity checks now catch a truncated dump.** Both the pre-restore
+  gate in `scripts/restore.sh` and the new per-cycle check validate the archive
+  with `pg_restore -f /dev/null` instead of `--list`. A `-Fc` archive keeps its
+  table of contents at the front, so `--list` accepts a dump truncated anywhere
+  after it — the exact shape a disk filling mid-dump produces. This mattered
+  most on restore, where the old check reported "validation passed" and then
+  ran `--clean --if-exists`, dropping the live database before failing partway
+  through repopulating it.
 - **OGC: an over-maximum `limit` is clamped on the records collection.**
   `/collections/datasets/items` returned 400 for a `limit` above the page-size
   ceiling; OGC API Features Core `/req/core/fc-limit-response-1(C)` requires

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -24,6 +24,16 @@ documentation.
 
 ## 1. Backup architecture
 
+> **Recovery point objective: up to 24 hours.** The bundled backup is a nightly
+> logical dump (`pg_dump`), so a failure restores to the last completed backup —
+> at the default 02:00 schedule, a loss at 01:59 discards a full day of uploads,
+> edits, and analysis outputs. There is no finer granularity available with this
+> tooling: logical dumps cannot participate in WAL replay, so point-in-time
+> recovery requires physical backup plus WAL archiving, which the bundled stack
+> does **not** configure (see [§ 3](#optional-point-in-time-recovery-pitr-with-wal-archiving)).
+> Shorten the exposure with a more frequent `BACKUP_SCHEDULE`, or use a managed
+> database, where the provider's native PITR applies.
+
 ### Automated backups are on by default
 
 Backup runs automatically on every `docker compose up` — no `--profile backup`
@@ -258,11 +268,34 @@ docker compose ps    # confirm api and worker are healthy
 
 ### Optional: point-in-time recovery (PITR) with WAL archiving
 
-For finer-grained recovery between backup snapshots, managed databases provide
-native PITR — enable it via the provider console (see provider links above). For
-self-hosted Docker deployments, WAL archiving requires `wal_level = replica` and
-`archive_command` in `postgresql.conf`; see the comments at the end of
-`scripts/restore.sh` for the configuration outline.
+PITR is a **different mechanism**, not a finer setting on the bundled backup.
+`pg_dump` produces a logical dump, which does not contain the information WAL
+replay needs — so no schedule change gets you recovery to an arbitrary moment.
+You either run physical backup plus continuous WAL archiving, or your recovery
+point is the last completed dump.
+
+**Managed databases (recommended):** providers offer native PITR — enable it in
+the provider console (see provider links above). Nothing changes in GeoLens.
+
+**Self-hosted Docker (advanced, unsupported):** requires `wal_level = replica`,
+`archive_mode = on`, a working `archive_command`, and a durable archive
+destination. `scripts/restore.sh` carries a configuration outline in its
+trailing comments, but this is a hand-rolled path we do not test or support.
+
+> **Understand the failure mode before enabling it.** If `archive_command`
+> starts failing — unreachable destination, full disk, bad permissions —
+> PostgreSQL retains WAL segments until `pg_wal` exhausts the filesystem, at
+> which point **the database stops accepting writes**. Continuous archiving
+> trades a bounded data-loss risk for an availability risk that needs
+> monitoring and alerting on archiver health. Do not enable it on an unattended
+> single-host deployment without that in place; a nightly dump fails far more
+> gracefully.
+
+For production WAL management, use a purpose-built tool
+([pgBackRest](https://pgbackrest.org/), [Barman](https://pgbarman.org/), or
+[WAL-G](https://github.com/wal-g/wal-g)) rather than a hand-written
+`archive_command`. See the PostgreSQL manual on
+[continuous archiving and PITR](https://www.postgresql.org/docs/18/continuous-archiving.html).
 
 ---
 

--- a/scripts/backup-entrypoint.sh
+++ b/scripts/backup-entrypoint.sh
@@ -72,6 +72,25 @@ run_backup() {
         return 1
     fi
 
+    # Verify the dump NOW, while the previous cycle's good copy is still inside
+    # retention — a corrupt dump is byte-for-byte indistinguishable from a good
+    # one until something parses it, and discovering that during a restore is
+    # too late.
+    #
+    # MUST be `-f /dev/null`, NOT `--list`. In a -Fc archive the table of
+    # contents sits at the front, so `--list` succeeds on a dump truncated
+    # anywhere after it — measured: a 60%-truncated dump passes `--list` and
+    # fails `-f /dev/null`. Truncation (disk filled mid-dump, half-written
+    # file) is precisely the corruption this is meant to catch, so the cheaper
+    # check would be theatre. `-f /dev/null` decompresses every data block and
+    # writes the SQL nowhere; it costs ~0.1s per 20 MB and touches no database.
+    if ! pg_restore -f /dev/null < "$filepath" > /dev/null 2>&1; then
+        log "ERROR: ${filename} failed verification (pg_restore could not read it) — discarding the corrupt dump"
+        rm -f "$filepath"
+        return 1
+    fi
+    log "Backup verified: ${filename} fully readable"
+
     # Weekly copy on Sundays
     if [ "$(date '+%u')" = "7" ]; then
         cp "$filepath" "${WEEKLY_DIR}/${filename}"

--- a/scripts/restore.sh
+++ b/scripts/restore.sh
@@ -31,14 +31,25 @@ fi
 # Validate backup integrity before restore
 # chore(#704): read stdin by OMITTING the filename — the literal "-" alias was
 # never documented for pg_restore and PG 18 rejects it as a filename.
+#
+# `-f /dev/null`, NOT `--list`: the -Fc table of contents sits at the front of
+# the archive, so `--list` reports a truncated dump as valid (measured: a
+# 60%-truncated dump passes `--list`). That matters more here than anywhere
+# else — the restore below runs `--clean --if-exists`, which DROPS the existing
+# objects first. Passing a short dump through this gate means dropping a live
+# database and then failing partway through repopulating it. `-f /dev/null`
+# forces every data block to be read and decompressed. It costs one extra
+# stream of the dump into the container (~0.1s per 20 MB of archive), which is
+# cheap next to what it prevents.
 echo "Validating backup integrity..."
 if ! "${COMPOSE[@]}" exec -T db \
-    pg_restore --list < "$BACKUP_FILE" > /dev/null 2>&1; then
-    echo "ERROR: Backup file is corrupt or invalid: $BACKUP_FILE" >&2
-    echo "pg_restore --list validation failed. Aborting restore." >&2
+    pg_restore -f /dev/null < "$BACKUP_FILE" > /dev/null 2>&1; then
+    echo "ERROR: Backup file is corrupt, truncated, or invalid: $BACKUP_FILE" >&2
+    echo "pg_restore could not read the archive end-to-end. Aborting restore" >&2
+    echo "BEFORE dropping anything — the existing database is untouched." >&2
     exit 1
 fi
-echo "Backup validation passed."
+echo "Backup validation passed (archive read end-to-end)."
 echo ""
 
 # Configuration with defaults
@@ -200,5 +211,10 @@ fi
 #   Plus a volume mount for /wal_archive and a separate WAL shipping process.
 #   Consider pgBackRest for production WAL management.
 #
-# See: https://www.postgresql.org/docs/17/continuous-archiving.html
+#   WARNING: a failing archive_command makes PostgreSQL retain WAL until
+#   pg_wal fills the filesystem and the database stops accepting writes.
+#   Monitor archiver health before enabling this. See RUNBOOK.md section 3.
+#
+# chore(#704): docs pinned to the bundled major — move with db/Dockerfile.
+# See: https://www.postgresql.org/docs/18/continuous-archiving.html
 # ==============================================================================

--- a/scripts/tests/test-backup-restore-roundtrip.sh
+++ b/scripts/tests/test-backup-restore-roundtrip.sh
@@ -117,8 +117,32 @@ pg_dump -h "$PGHOST" -p "$PGPORT" -U "$PGUSER" -d "$SRC_DB" \
     -Fc --no-owner --no-acl -f "$DUMP_FILE"
 [ -s "$DUMP_FILE" ] || fail "dump file is empty"
 
-# Integrity check — same as restore.sh's pre-flight.
-pg_restore --list "$DUMP_FILE" >/dev/null || fail "pg_restore --list validation failed"
+# Integrity check — same as restore.sh's and backup-entrypoint.sh's pre-flight.
+pg_restore -f /dev/null < "$DUMP_FILE" >/dev/null 2>&1 \
+    || fail "pg_restore verification of a good dump failed"
+
+# Pin WHY that check is `-f /dev/null` and not the cheaper `--list`. In a -Fc
+# archive the table of contents is at the front, so `--list` happily accepts a
+# dump truncated after it — exactly the shape a disk-full mid-dump produces.
+# Both callers depend on truncation being caught: backup-entrypoint.sh discards
+# the dump, and restore.sh aborts BEFORE its --clean --if-exists drops the live
+# database. If someone swaps these back to `--list` to save a pass, this fails.
+TRUNC_FILE="${WORKDIR}/truncated.dump"
+DUMP_BYTES="$(wc -c < "$DUMP_FILE")"
+head -c "$(( DUMP_BYTES * 60 / 100 ))" "$DUMP_FILE" > "$TRUNC_FILE"
+if pg_restore -f /dev/null < "$TRUNC_FILE" >/dev/null 2>&1; then
+    fail "a 60%-truncated dump passed verification — the integrity gate is not catching truncation"
+fi
+# Whether --list ALSO catches it depends on dump size: this fixture is small
+# enough that 60% cuts into the TOC itself, while on a realistic dump 60% lands
+# well past it and --list passes (measured on a 21 MB dump). So the assertion
+# above is deliberately only on -f /dev/null; this is reporting, not a gate.
+if pg_restore --list "$TRUNC_FILE" >/dev/null 2>&1; then
+    echo "      truncation gate OK — rejected by -f /dev/null; --list missed it (the reason for the stricter check)."
+else
+    echo "      truncation gate OK — rejected by -f /dev/null; --list also caught it (fixture too small to clear the TOC)."
+fi
+rm -f "$TRUNC_FILE"
 
 createdb -h "$PGHOST" -p "$PGPORT" -U "$PGUSER" "$DST_DB"
 # Same flags restore.sh uses. --clean --if-exists emits expected warnings on a


### PR DESCRIPTION
Prompted by a question about whether `pg_dump` is the right backup solution. Reviewing it turned up something more urgent than the tooling choice: **the integrity gate was not catching the corruption it exists for.**

## The bug

Both `scripts/restore.sh` and the round-trip test validated archives with `pg_restore --list`. In a `-Fc` archive the table of contents sits at the **front**, so `--list` only reads the TOC and succeeds on a dump truncated anywhere after it.

Measured on a 21 MB dump of the dev database:

| | `--list` | `-f /dev/null` |
|---|---|---|
| good dump | passes | passes |
| **60% truncated** | **passes** ← | rejected (`could not read from input file: end of file`) |
| empty | rejected | rejected |

A disk filling mid-dump produces exactly that shape. So the check most likely to be exercised in anger was the one it could not see.

**The dangerous side is restore, not backup.** `restore.sh` printed `Backup validation passed` and then ran `pg_restore --clean --if-exists`, which **drops existing objects before restoring**. A short dump through that gate costs you the live database and then fails partway through repopulating it — strictly worse than refusing to start.

Both callers now use `pg_restore -f /dev/null`, which decompresses every data block and writes the SQL nowhere. Cost is ~0.1s per 20 MB of archive and it touches no database.

## Also in here

- **Backups verify at write time.** Each cycle reads its own dump back and discards it on failure — while the *previous* cycle's good copy is still inside retention, which is the only window where finding out is actionable.
- **The round-trip test pins the distinction** with a deliberately truncated dump. It asserts only that `-f /dev/null` rejects it; whether `--list` also catches it depends on dump size (a small fixture truncates into its own TOC), so asserting that would be flaky. The test reports which branch it saw.
- **RUNBOOK § 1 states the RPO outright**: up to 24 hours. It was previously derivable only from the cron schedule.
- **RUNBOOK § 3 stops implying PITR is a dial.** `pg_dump` is logical and cannot participate in WAL replay, so no schedule change gets you point-in-time recovery — it is a different mechanism. The section now says that, and spells out the failure mode a hand-rolled `archive_command` introduces: WAL accumulates until `pg_wal` fills the filesystem and **the database stops accepting writes**. That is a real trap to hand an unattended single-host deployment.
- PostgreSQL doc link moves 17 → 18 to match the bundled major.

## On the original question

`pg_dump` is not the best PostgreSQL backup tool and it is not close — physical backup plus WAL archiving (pgBackRest, Barman, WAL-G) is the production answer. I would still keep it as the **default**, because the failure modes are not symmetric: a failed dump means last night's backup is missing, while a failed `archive_command` means the database stops. Trading a bounded data-loss risk for an unbounded availability one is the wrong default for self-hosters without a DBA.

The right shape is an opt-in — scoped separately, not in this PR.

## Verification

```
bash scripts/tests/test-backup-restore-roundtrip.sh    # PASS, both modes
  → truncation gate OK — rejected by -f /dev/null
bash -n on all three modified shell scripts            # clean
```

The round-trip test is path-filtered on `scripts/backup-entrypoint.sh` and `scripts/restore.sh`, so CI exercises this.

No schema, API, or config changes.

https://claude.ai/code/session_01X1Wd3Frww9F2eovfMkUbG2