### PR TITLE
fix(runbook): stop the PG 18 upgrade from overwriting real backup history

### DIFF
--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -115,7 +115,9 @@ self-hosted Docker Compose deployment).
 
 `scripts/restore.sh` is the **canonical operator-facing restore entry point**. It:
 
-1. Validates the dump with `pg_restore --list` — aborts if the file is corrupt.
+1. Validates the dump with `pg_restore -f /dev/null` — reads every data block
+   and aborts if the file is corrupt or truncated. (`--list` would only read the
+   table of contents, which a truncated archive still passes.)
 2. Creates required extensions and schemas in the database.
 3. Stops `api` and `worker` to prevent write conflicts.
 4. Runs `pg_restore --clean --if-exists --no-owner` against the bundled `db` container.
@@ -197,9 +199,12 @@ output rather than hand-editing it.
 docker run --rm -v <project>_backup_data:/backups:ro alpine \
   ls -lt /backups/daily
 
-# Validate a specific dump after copying it out of the volume (step 0 above)
+# Validate a specific dump after copying it out of the volume (step 0 above).
+# Omit the filename to read stdin — the literal `-` alias was never documented
+# for pg_restore and PG 18 rejects it with `could not open input file "-"`,
+# which reads like a corrupt backup when the dump is fine (chore(#704)).
 docker compose exec -T db \
-  pg_restore --list - < ./restore/geolens_<YYYYmmdd_HHMMSS>.dump | head -20
+  pg_restore --list < ./restore/geolens_<YYYYmmdd_HHMMSS>.dump | head -20
 ```
 
 ---
@@ -457,9 +462,14 @@ docker run --rm \
   alpine sh -c 'cp /backups/daily/geolens_<YYYYmmdd_HHMMSS>.dump /out/ && \
                 cp /backups/daily/staging-<YYYYmmdd_HHMMSS>.tar.gz /out/ 2>/dev/null; ls -lh /out'
 
-# Validate the candidate dump before restoring
+# Validate the candidate dump before restoring. Omit the filename to read
+# stdin: PG 18 rejects the literal `-` with `could not open input file "-"`,
+# which reads like a corrupt backup when the dump is fine (chore(#704)).
+# `-f /dev/null` reads every data block; `--list` alone would pass a dump
+# truncated after its table of contents.
 docker compose exec -T db \
-  pg_restore --list - < ./restore/geolens_<YYYYmmdd_HHMMSS>.dump | head -20
+  pg_restore -f /dev/null < ./restore/geolens_<YYYYmmdd_HHMMSS>.dump \
+  && echo "candidate dump reads end-to-end"
 ```
 
 If the daily dump is corrupt, fall back to a weekly backup under
@@ -533,12 +543,18 @@ set of server binaries.
 
 ```bash
 # 0. Take a fresh pre-upgrade dump WITH THE OLD STACK STILL RUNNING, then
-#    verify it exists. (The scheduled backup service works too — this just
-#    guarantees a dump from the moment of the upgrade.)
+#    verify it reads back end-to-end. (The scheduled backup service works too —
+#    this just guarantees a dump from the moment of the upgrade.)
 docker compose exec backup sh -c \
   'PGPASSWORD="$POSTGRES_PASSWORD" pg_dump -Fc -h "$POSTGRES_HOST" -U "$POSTGRES_USER" "$POSTGRES_DB" \
    > /backups/daily/pre_pg18_manual.dump'
-docker compose exec backup sh -c 'ls -l /backups/daily/pre_pg18_manual.dump'
+#    `-f /dev/null`, NOT `ls -l` and NOT `--list`: this dump is the only
+#    rollback artifact once step 2 removes the volume, and a truncated archive
+#    both looks fine to `ls` and passes `--list` (the -Fc table of contents sits
+#    at the front). Read every data block now, while the old cluster still
+#    exists to re-dump from.
+docker compose exec backup sh -c \
+  'pg_restore -f /dev/null /backups/daily/pre_pg18_manual.dump && echo "pre-upgrade dump OK"'
 
 # 1. Copy the dump out of the backup volume to the host (survives volume ops).
 #    Replace <project> with your Compose project name (see `docker volume ls`).
@@ -560,14 +576,24 @@ docker compose pull   # or: docker compose build, if you build locally.
                       # Rebuild EVERYTHING, not just db: the backup image's
                       # pg_dump major must match the new server, or every
                       # backup cycle fails with "server version mismatch".
-docker compose up -d --wait
+#    `--scale backup=0` keeps the backup service DOWN for this step. It runs an
+#    initial dump the moment it starts, so starting it here would capture the
+#    freshly migrated but still EMPTY cluster, write it to /backups/daily as the
+#    newest dump, and prune one real generation to stay inside
+#    BACKUP_RETENTION_DAILY (7). Every retry of steps 2-3 would replace another
+#    generation of real history with an empty-cluster dump — and section 5 tells
+#    an incident responder to restore the newest dump, which would then be the
+#    empty one. Nothing depends_on backup, so scaling it to 0 is safe.
+docker compose up -d --wait --scale backup=0
 
 # 4. Restore the dump (canonical entry point: validates the file, stops
 #    api/worker, restores over the freshly migrated schema via
 #    --clean --if-exists, and restarts api/worker when done).
 ./scripts/restore.sh ./restore/pre_pg18_manual.dump
 
-# 5. Verify.
+# 5. Bring the backup service up now that the cluster holds real data, and
+#    verify.
+docker compose up -d --wait
 docker compose exec db psql -U geolens -c 'select version();'
 curl -fsS http://localhost:8080/api/health
 ```

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -542,25 +542,37 @@ set of server binaries.
 ### Bundled Postgres mode (default Compose deployment)
 
 ```bash
-# 0. Take a fresh pre-upgrade dump WITH THE OLD STACK STILL RUNNING, then
-#    verify it reads back end-to-end. (The scheduled backup service works too —
-#    this just guarantees a dump from the moment of the upgrade.)
-docker compose exec backup sh -c \
-  'PGPASSWORD="$POSTGRES_PASSWORD" pg_dump -Fc -h "$POSTGRES_HOST" -U "$POSTGRES_USER" "$POSTGRES_DB" \
-   > /backups/daily/pre_pg18_manual.dump'
-#    `-f /dev/null`, NOT `ls -l` and NOT `--list`: this dump is the only
-#    rollback artifact once step 2 removes the volume, and a truncated archive
-#    both looks fine to `ls` and passes `--list` (the -Fc table of contents sits
-#    at the front). Read every data block now, while the old cluster still
-#    exists to re-dump from.
-docker compose exec backup sh -c \
-  'pg_restore -f /dev/null /backups/daily/pre_pg18_manual.dump && echo "pre-upgrade dump OK"'
+# 0. Quiesce the app's DB writers before dumping. pg_dump snapshots the moment
+#    it BEGINS and does not block writers, so a write acknowledged after it
+#    starts would be missing from the rollback dump. db stays up — the dump
+#    needs it.
+docker compose stop api worker
 
-# 1. Copy the dump out of the backup volume to the host (survives volume ops).
-#    Replace <project> with your Compose project name (see `docker volume ls`).
-mkdir -p ./restore
-docker run --rm -v <project>_backup_data:/backups -v "$PWD/restore":/out alpine \
-  cp /backups/daily/pre_pg18_manual.dump /out/
+# 1. Take the pre-upgrade dump straight to the HOST, then verify it reads back
+#    end-to-end. Streaming via `exec -T` (same technique as scripts/upgrade.sh)
+#    lands it outside the container, so there is no volume copy to make later
+#    and no <project> volume name to look up.
+#
+#    NOT into /backups/daily: that directory is under retention. An extra file
+#    there occupies a retention slot, so the next `prune_old_backups` pass —
+#    which keeps BACKUP_RETENTION_DAILY (7) `*.dump` files by mtime — deletes
+#    one more generation of real history than it otherwise would. ./backups/
+#    is gitignored and `backups/pre-upgrade/` is where scripts/upgrade.sh
+#    already puts its rollback dump.
+#
+#    `-f /dev/null` to verify, NOT `ls -l` and NOT `--list`: a truncated archive
+#    looks fine to `ls` and still passes `--list`, because the -Fc table of
+#    contents sits at the front. Read every data block now, while the old
+#    cluster is still there to re-dump from.
+#    The connection variables are read INSIDE the backup container (they are
+#    set there); `-T` is required so Docker does not allocate a TTY and corrupt
+#    the binary stream.
+mkdir -p ./backups/pre-upgrade
+docker compose exec -T backup sh -c \
+  'PGPASSWORD="$POSTGRES_PASSWORD" pg_dump -Fc -h "$POSTGRES_HOST" -U "$POSTGRES_USER" "$POSTGRES_DB"' \
+  > ./backups/pre-upgrade/pre_pg18.dump
+docker compose exec -T backup pg_restore -f /dev/null \
+  < ./backups/pre-upgrade/pre_pg18.dump && echo "pre-upgrade dump OK"
 
 # 2. Stop the stack and remove ONLY the database volume.
 docker compose down
@@ -589,7 +601,7 @@ docker compose up -d --wait --scale backup=0
 # 4. Restore the dump (canonical entry point: validates the file, stops
 #    api/worker, restores over the freshly migrated schema via
 #    --clean --if-exists, and restarts api/worker when done).
-./scripts/restore.sh ./restore/pre_pg18_manual.dump
+./scripts/restore.sh ./backups/pre-upgrade/pre_pg18.dump
 
 # 5. Bring the backup service up now that the cluster holds real data, and
 #    verify.

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -567,16 +567,33 @@ docker compose stop api worker
 #    The connection variables are read INSIDE the backup container (they are
 #    set there); `-T` is required so Docker does not allocate a TTY and corrupt
 #    the binary stream.
+#
+#    Dump to `.partial` and rename only after the read-back succeeds, so
+#    `pre_pg18.dump` exists if and only if a verified dump exists. Step 2 tests
+#    for exactly that file. The leading `rm -f` matters: an already-verified
+#    dump from an earlier attempt would otherwise green-light step 2 after a
+#    re-dump failed, and that older dump predates the step-0 quiesce.
 mkdir -p ./backups/pre-upgrade
+rm -f ./backups/pre-upgrade/pre_pg18.dump
 docker compose exec -T backup sh -c \
   'PGPASSWORD="$POSTGRES_PASSWORD" pg_dump -Fc -h "$POSTGRES_HOST" -U "$POSTGRES_USER" "$POSTGRES_DB"' \
-  > ./backups/pre-upgrade/pre_pg18.dump
-docker compose exec -T backup pg_restore -f /dev/null \
-  < ./backups/pre-upgrade/pre_pg18.dump && echo "pre-upgrade dump OK"
+  > ./backups/pre-upgrade/pre_pg18.partial \
+  && docker compose exec -T backup pg_restore -f /dev/null \
+       < ./backups/pre-upgrade/pre_pg18.partial \
+  && mv ./backups/pre-upgrade/pre_pg18.partial ./backups/pre-upgrade/pre_pg18.dump \
+  && echo "pre-upgrade dump verified"
 
 # 2. Stop the stack and remove ONLY the database volume.
-docker compose down
-docker volume rm <project>_pgdata
+#
+#    Gated on step 1's verified dump, and chained with `&&`, because this block
+#    is meant to be pasted: a failed pg_dump (disk full, version mismatch, a
+#    typo'd volume name) otherwise only suppresses step 1's echo, and the shell
+#    runs straight on into `docker volume rm`. Past that point there is no dump
+#    and no cluster. If the guard stops you here, the PG 17 volume is still
+#    intact — fix the dump and re-run step 1.
+test -f ./backups/pre-upgrade/pre_pg18.dump \
+  && docker compose down \
+  && docker volume rm <project>_pgdata
 
 # 3. Pull/build the new images and start the WHOLE stack once — a fresh PG 18
 #    cluster initializes (scripts/init-db.sh provisions extensions + base

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -568,20 +568,30 @@ docker compose stop api worker
 #    set there); `-T` is required so Docker does not allocate a TTY and corrupt
 #    the binary stream.
 #
-#    Dump to `.partial` and rename only after the read-back succeeds, so
-#    `pre_pg18.dump` exists if and only if a verified dump exists. Step 2 tests
-#    for exactly that file. The leading `rm -f` matters: an already-verified
-#    dump from an earlier attempt would otherwise green-light step 2 after a
-#    re-dump failed, and that older dump predates the step-0 quiesce.
+#    Dump to `.partial` and rename only after the read-back succeeds, so the
+#    final filename exists if and only if a verified dump exists. Step 2 gates
+#    on exactly that.
+#
+#    The name carries a timestamp and this attempt's file is remembered in
+#    $DUMP, so a retry NEVER deletes or overwrites an earlier verified dump.
+#    That matters most in the worst case: if you got past step 2 and something
+#    later failed, the PG 17 volume is already gone and that earlier dump is
+#    the only copy of your data left. A fixed filename would have it deleted
+#    at the top of the retry — and then, because the fresh PG 18 cluster is up
+#    and answering, the re-dump SUCCEEDS, verifies, and step 2 destroys the
+#    volume again. You would end up with a perfectly valid dump of an empty
+#    database and nothing else.
+#
+#    $DUMP also scopes the gate to THIS attempt, so an older verified dump
+#    cannot green-light step 2 after a re-dump fails.
 mkdir -p ./backups/pre-upgrade
-rm -f ./backups/pre-upgrade/pre_pg18.dump
+DUMP="./backups/pre-upgrade/pre_pg18_$(date +%Y%m%d_%H%M%S).dump"
 docker compose exec -T backup sh -c \
   'PGPASSWORD="$POSTGRES_PASSWORD" pg_dump -Fc -h "$POSTGRES_HOST" -U "$POSTGRES_USER" "$POSTGRES_DB"' \
-  > ./backups/pre-upgrade/pre_pg18.partial \
-  && docker compose exec -T backup pg_restore -f /dev/null \
-       < ./backups/pre-upgrade/pre_pg18.partial \
-  && mv ./backups/pre-upgrade/pre_pg18.partial ./backups/pre-upgrade/pre_pg18.dump \
-  && echo "pre-upgrade dump verified"
+  > "$DUMP.partial" \
+  && docker compose exec -T backup pg_restore -f /dev/null < "$DUMP.partial" \
+  && mv "$DUMP.partial" "$DUMP" \
+  && echo "pre-upgrade dump verified: $DUMP"
 
 # 2. Stop the stack and remove ONLY the database volume.
 #
@@ -591,7 +601,12 @@ docker compose exec -T backup sh -c \
 #    runs straight on into `docker volume rm`. Past that point there is no dump
 #    and no cluster. If the guard stops you here, the PG 17 volume is still
 #    intact — fix the dump and re-run step 1.
-test -f ./backups/pre-upgrade/pre_pg18.dump \
+#
+#    $DUMP is deliberately required, not just any file in the directory: in a
+#    NEW shell it is unset and this refuses to run. That is the safe answer —
+#    re-run step 1 so the dump you are about to bet the cluster on is one you
+#    just verified, in this session, against the cluster still standing.
+test -n "${DUMP:-}" && test -f "$DUMP" \
   && docker compose down \
   && docker volume rm <project>_pgdata
 
@@ -618,7 +633,10 @@ docker compose up -d --wait --scale backup=0
 # 4. Restore the dump (canonical entry point: validates the file, stops
 #    api/worker, restores over the freshly migrated schema via
 #    --clean --if-exists, and restarts api/worker when done).
-./scripts/restore.sh ./backups/pre-upgrade/pre_pg18.dump
+#    If the shell that ran step 1 is gone, $DUMP is unset — pick the newest
+#    verified dump explicitly:
+#      ls -t ./backups/pre-upgrade/*.dump | head -1
+./scripts/restore.sh "$DUMP"
 
 # 5. Bring the backup service up now that the cluster holds real data, and
 #    verify.
@@ -646,3 +664,8 @@ upgrade — most providers carry extensions across, but verify with
 The pre-upgrade dump restores onto a PG 17 stack the same way (step 2-5 with
 the previous image tags). A dump taken FROM PG 18 does NOT restore onto 17 —
 keep the pre-upgrade dump until you are satisfied with the upgrade.
+
+Pre-upgrade dumps are timestamped and accumulate in `./backups/pre-upgrade/`;
+nothing prunes that directory, deliberately, so a retry can never destroy the
+copy an earlier attempt verified. Delete them by hand once the upgrade has
+been accepted.

--- a/scripts/tests/test-upgrade-order.sh
+++ b/scripts/tests/test-upgrade-order.sh
@@ -68,15 +68,22 @@ if [ "$1" = "compose" ]; then
     stop)    echo "stop_app" >> "$LOG"; [ "$STOP_MODE" = "fail" ] && exit 1; exit 0 ;;
     pull)    echo "pull" >> "$LOG"; exit 0 ;;
     exec)
-      # Two distinct in-container calls share `compose exec -T db`:
-      #   psql  -> the PG-major probe (Step 2.5); answer server_version_num.
-      #   pg_dump -> the backup path; emit non-empty dump bytes to stdout.
+      # Three distinct in-container calls share `compose exec -T db`:
+      #   psql       -> the PG-major probe (Step 2.5); answer server_version_num.
+      #   pg_dump    -> the backup path; emit non-empty dump bytes to stdout.
+      #   pg_restore -> the end-to-end read-back of that dump (fix(#714)).
       for a in "$@"; do
         if [ "$a" = "psql" ]; then
           echo "probe_pg" >> "$LOG"
           # "none" models a probe that answers nothing (external/managed
           # Postgres: there is no `db` service to exec into).
           [ "${DOCKER_PG_NUM:-170005}" = "none" ] || echo "${DOCKER_PG_NUM:-170005}"
+          exit 0
+        fi
+        if [ "$a" = "pg_restore" ]; then
+          echo "verify_backup" >> "$LOG"
+          cat > /dev/null
+          [ "${DOCKER_VERIFY_MODE:-ok}" = "fail" ] && exit 1
           exit 0
         fi
       done
@@ -160,6 +167,7 @@ run_upgrade() {  # $1=migrate mode, rest=args to upgrade.sh
   ( env "PATH=$SHIM:$PATH" GEOLENS_REPO_URL="file:///fake" \
       DOCKER_LOG="$CALLLOG" DOCKER_MIGRATE_MODE="$_mode" GIT_LOG="$GITLOG" \
       DOCKER_STOP_MODE="${STOP_MODE:-ok}" \
+      DOCKER_VERIFY_MODE="${VERIFY_MODE:-ok}" \
       DOCKER_PG_NUM="${PG_NUM:-170005}" GIT_TARGET_PG="${TARGET_PG:-17}" \
       sh "$FAKE/scripts/upgrade.sh" "$@" </dev/null > "$WORK/out.txt" 2>&1 )
   echo $? > "$WORK/code.txt"
@@ -203,13 +211,25 @@ else
   bad "success path did not print rollback recipe"
 fi
 
-# Full expected order: probe_pg, stop_app, backup, pull, migrate_up, app_up.
-# The PG-major probe runs first — it must decide before anything is changed.
+# Full expected order: probe_pg, stop_app, backup, verify_backup, pull,
+# migrate_up, app_up. The PG-major probe runs first — it must decide before
+# anything is changed.
 order="$(tr '\n' ',' < "$WORK/calls.log")"
-if [ "$order" = "probe_pg,stop_app,backup,pull,migrate_up,app_up," ]; then
-  ok "full call order is probe pg major -> stop api/worker -> backup -> pull -> migrate -> app_up"
+if [ "$order" = "probe_pg,stop_app,backup,verify_backup,pull,migrate_up,app_up," ]; then
+  ok "full call order is probe pg major -> stop api/worker -> backup -> verify -> pull -> migrate -> app_up"
 else
   bad "unexpected call order: $order"
+fi
+
+# fix(#714): the rollback dump is read back end-to-end BEFORE the first
+# irreversible step. A dump truncated by a full disk is non-empty and passes
+# `--list`, so `-s` alone would let the upgrade migrate the schema behind an
+# unrestorable rollback artifact.
+v="$(pos_of verify_backup)"
+if [ -n "$v" ] && [ -n "$b" ] && [ -n "$p" ] && [ "$b" -lt "$v" ] && [ "$v" -lt "$p" ]; then
+  ok "rollback dump verified between the dump and the first irreversible step ($b < $v < $p)"
+else
+  bad "backup not verified before the pull (backup=$b verify=$v pull=$p)"
 fi
 
 # Writers quiesced BEFORE the dump (so the snapshot loses no acknowledged writes on
@@ -334,6 +354,35 @@ if [ -n "$(pos_of app_up)" ]; then
   ok "failed quiesce restarts api/worker (restart_writers ran)"
 else
   bad "failed quiesce did not restart api/worker"
+fi
+
+# ============================================================================
+# CASE 6b — fix(#714): the dump is written but reads back corrupt. Abort before
+# the first irreversible step, discard the unusable artifact, restart writers.
+# ============================================================================
+seed_prod_env
+# Clear dumps left by earlier passing cases: the filename carries a
+# whole-second timestamp, so the "was it discarded?" check below would
+# otherwise pass or fail depending on whether CASE 1 happened to land in the
+# same second as this one.
+rm -rf "$FAKE/backups/pre-upgrade"
+VERIFY_MODE=fail
+run_upgrade ok 1.2.4
+VERIFY_MODE=ok
+if [ "$(cat "$WORK/code.txt")" != "0" ] && [ -z "$(pos_of pull)" ]; then
+  ok "unreadable rollback dump aborts BEFORE the pull (nothing irreversible ran)"
+else
+  bad "corrupt dump did not abort before pull (exit=$(cat "$WORK/code.txt"), calls=$(tr '\n' ',' < "$WORK/calls.log"))"
+fi
+if [ -z "$(find "$FAKE/backups/pre-upgrade" -name '*.dump' 2>/dev/null)" ]; then
+  ok "unreadable rollback dump is discarded, not left to look like a backup"
+else
+  bad "corrupt dump was left on disk: $(find "$FAKE/backups/pre-upgrade" -name '*.dump')"
+fi
+if [ -n "$(pos_of app_up)" ]; then
+  ok "failed verification restarts api/worker (app is not left down)"
+else
+  bad "failed verification did not restart api/worker"
 fi
 
 # ============================================================================

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -215,6 +215,18 @@ if [ ! -s "$BACKUP_FILE" ]; then
   restart_writers
   fail "Pre-upgrade backup is empty. Aborting before any changes were made."
 fi
+# Read the archive back end-to-end before trusting it as the rollback artifact
+# (fix(#714), same check backup.sh got in #710). A dump truncated by a disk that
+# filled mid-write is non-empty and still passes `--list`, because the -Fc table
+# of contents sits at the front — the damage is only visible once every data
+# block is read. Do it here, while the pre-upgrade cluster is still intact and
+# a re-dump is free; the next steps migrate the schema, after which this file is
+# the only way back.
+if ! compose exec -T db pg_restore -f /dev/null < "$BACKUP_FILE" >/dev/null 2>&1; then
+  rm -f "$BACKUP_FILE"
+  restart_writers
+  fail "Pre-upgrade backup did not read back cleanly (truncated or corrupt). Aborting before any changes were made."
+fi
 say "  backup OK ($(du -h "$BACKUP_FILE" 2>/dev/null | cut -f1) ) — restore with: scripts/restore.sh \"$BACKUP_FILE\""
 say ""
 


### PR DESCRIPTION
Found during a pre-1.5.0 release audit of the `v1.4.13..HEAD` scope.

## The problem

RUNBOOK § 6 step 3 starts the whole stack, and the `backup` service runs a dump the moment it starts — `scripts/backup-entrypoint.sh:354` calls `run_backup` unconditionally on container start, with no skip-if-recent guard. At that point the new cluster is freshly migrated and **empty**.

The chain:

1. Step 3's `docker compose up -d --wait` starts `backup` (it has no `profiles:` key — "Backup runs by default", `docker-compose.yml:576`).
2. It writes a schema-only dump into `/backups/daily` as the newest file.
3. `prune_old_backups` globs `*.dump` and deletes oldest-by-mtime to stay inside `BACKUP_RETENTION_DAILY` (default 7) — so a real generation is dropped to make room.
4. `docker compose down` at step 2 carries no `-v`, so `backup_data` survives every retry and accumulates one more empty dump per pass.

The empty dumps use the same `geolens_<timestamp>.dump` naming as real ones and are the newest on disk. § 5 tells an incident responder to `ls -lt` and take the latest. That dump passes the `pg_restore -f /dev/null` gate — a schema-only archive is a perfectly valid archive, and `restore.sh` has no row-count or size sanity check — and is then applied with `--clean --if-exists`. **An incident on upgrade evening restores an empty database over production.**

`pre_pg18_manual.dump` itself is not the loss: step 1 mandates copying it to the host and step 4 restores from that copy. What is destroyed is the operator's retained backup history.

## The fix

Step 3 runs with `--scale backup=0`; step 5 brings the service up once the cluster holds real data. Nothing `depends_on` backup, so scaling it to 0 is safe.

This is an omission rather than a design choice — § 2 already treats stopping `backup` during recovery as expected practice ("Re-enable the backup service if it was stopped during recovery: `docker compose start backup`"). § 6 just never said to.

## Three further doc defects on the same paths

- **Step 0's pre-upgrade dump was verified with `ls -l`.** It is the only rollback artifact once step 2 removes the volume. A truncated archive looks fine to `ls` and also passes `--list`; corruption would not surface until `restore.sh` validates at step 4 — after the source of truth is gone. Now read back with `pg_restore -f /dev/null` while the old cluster still exists to re-dump from.
- **§ 2 and § 5 pass a literal `-` for stdin.** That alias was never documented for `pg_restore` and PG 18 rejects it. Verified against the bundled image:
  ```
  $ docker compose exec -T db pg_restore --version
  pg_restore (PostgreSQL) 18.4 (Debian 18.4-1.pgdg13+1)
  $ ... | pg_restore --list -
  pg_restore: error: could not open input file "-": No such file or directory
  ```
  That reads as "every backup is corrupt" when the dumps are fine. Omitting the filename reads stdin correctly. `chore(#704)` already fixed this in `restore.sh`; the docs lagged.
- **§ 2 described `restore.sh`'s gate as `pg_restore --list`.** It has been `-f /dev/null` since #710, and the distinction is the whole point of that change.

## Verification

- `pg_restore --list -` vs omitted-filename behavior confirmed live against the running PG 18.4 `db` container (above).
- `backup` has no dependents: confirmed via `docker compose config`.
- `run_backup` on start (`backup-entrypoint.sh:353-354`) and the `*.dump` glob in `prune_old_backups` (`:230-242`) read directly.
- Docs-only change; `pre-commit run --files RUNBOOK.md` passes.

Release impact: the PG 17 → 18 upgrade is the breaking change in 1.5.0, so this procedure is about to get its first real-world use.