### PR TITLE
docs(changelog): announce the analysis toolkit, and gate the release header

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -583,6 +583,13 @@ jobs:
       - name: Check all version sites agree
         run: python scripts/check_version_coherence.py
 
+      # The CHANGELOG half of that gate only helps if it asks the same question
+      # release.yml asks. This asserts the two extractions agree case for case,
+      # including the empty-section and prerelease-tag paths that both fall back
+      # to a filtered git log (fix(#715)).
+      - name: Check the CHANGELOG gate tracks release.yml
+        run: python scripts/tests/test-changelog-gate.py
+
   # ---------- docs contract ----------
   # Enforce docs-contract.json: validates the contract against install.sh +
   # pyproject (so it can't drift from the binaries) and scans the READMEs for

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,9 +54,18 @@ jobs:
         run: |
           PREV="${{ steps.prev.outputs.tag }}"
 
-          # Extract section from CHANGELOG.md for this version
+          # Extract section from CHANGELOG.md for this version.
+          #
+          # fix(#715): strip any prerelease suffix first. A prerelease tag has no
+          # CHANGELOG section of its own and never will — bump_version.py's
+          # SEMVER_RE only accepts plain X.Y.Z, so `make bump` cannot create a
+          # `## [1.5.0-rc.1]` header, and check_version_coherence.py only ever
+          # validates the canonical version. Without this, every RC published the
+          # git-log fallback below, whose filter drops every docs(/chore( subject.
+          # An RC's notes are the notes for the release it is a candidate for.
           VERSION="${TAG#v}"
-          NOTES=$(awk "/^## \[${VERSION}\]/{found=1; next} /^## \[/{if(found) exit} found{print}" CHANGELOG.md)
+          CHANGELOG_VERSION="${VERSION%%-*}"
+          NOTES=$(awk "/^## \[${CHANGELOG_VERSION}\]/{found=1; next} /^## \[/{if(found) exit} found{print}" CHANGELOG.md)
 
           if [ -z "$NOTES" ]; then
             # Fallback: generate from git log

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,7 +67,12 @@ jobs:
           CHANGELOG_VERSION="${VERSION%%-*}"
           NOTES=$(awk "/^## \[${CHANGELOG_VERSION}\]/{found=1; next} /^## \[/{if(found) exit} found{print}" CHANGELOG.md)
 
-          if [ -z "$NOTES" ]; then
+          # fix(#715 review): strip whitespace before the emptiness test. `$(...)`
+          # removes trailing newlines but keeps spaces and tabs, so a section
+          # containing only whitespace made `[ -z ]` false and published
+          # effectively blank release notes — passing neither the fallback nor
+          # the version-coherence gate, which rejects exactly that input.
+          if [ -z "$(printf '%s' "$NOTES" | tr -d '[:space:]')" ]; then
             # Fallback: generate from git log
             NOTES=$(git log --format="- %s" "${PREV}..${TAG}" --no-merges | grep -v "^- docs(" | grep -v "^- chore(" | head -30)
           fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,9 +85,12 @@ and releases use semantic versioning.
   everything" — including any explicit origins listed alongside it. Saving `*`
   used to be accepted and then took the API down about 30 seconds later, once
   the middleware's cache refreshed. It now fails immediately with a 422 naming
-  the correct form. **Upgrade note:** an existing stored value of `*` keeps
-  working until the next save, but Admin → Settings → Network will refuse to
-  save the page until it is replaced with explicit origins.
+  the correct form. **Upgrade note:** if `*` is already stored, cross-origin
+  requests are *already* being denied — the new validator guards the write
+  path, not the middleware, which has always turned an allowlist containing
+  `*` into an empty set. Replace it with explicit origins to restore
+  cross-origin access; Admin → Settings → Network will refuse to save the page
+  until you do.
 - **TiTiler's glibc malloc arenas are capped.** `MALLOC_ARENA_MAX` defaults to
   `2` for the `titiler` service, which slows resident-memory growth under
   sustained tile load. Override with `TITILER_MALLOC_ARENA_MAX`. This bounds

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,32 @@ and releases use semantic versioning.
 
 ## [Unreleased]
 
+### Added
+
+- **Spatial analysis in the map builder: buffer, centroid, clip, and dissolve.**
+  A new Analysis panel runs an operation against any vector layer and draws the
+  result on the map as a preview, capped at 500 features so it stays
+  interactive. **Create dataset** re-runs the same operation over every feature
+  as a background job and registers the output as a new dataset, which then
+  behaves like any other layer — styleable, exportable, and served through the
+  OGC and STAC endpoints. Buffer distances accept metres, kilometres, feet, or
+  miles. Dissolve optionally groups by an attribute column.
+- **Clip against another layer, not just a drawn area.** `mask_dataset_id` on
+  the analysis endpoints clips a layer using the union of a polygon layer's
+  geometries. The picker offers only polygonal layers; both the source and the
+  mask dataset are access-checked independently.
+- **Ask the assistant to run an analysis.** The chat assistant gained a
+  `run_analysis` tool for buffer and centroid previews, so "buffer the fire
+  hydrants by 100 m" produces a preview on the map. The tool returns only a
+  summary to the model — counts and a bounding box, never geometry.
+- **The OGC items page-size ceiling is administrator-configurable.** Admin →
+  Settings → Network exposes **OGC Features Max Page Size**, the ceiling an
+  over-maximum `limit` is clamped to on the per-dataset items route.
+- **Analysis has blast-radius limits, and they explain themselves.** Dissolve
+  (250,000 features), buffer (500,000), and clip-against-a-layer masks (1,000)
+  are refused up front rather than accepted and left to exhaust the database.
+  The refusal names the limit so it can be filtered down to.
+
 ### Changed
 
 - **BREAKING (self-hosted): bundled database upgraded to PostgreSQL 18 +
@@ -53,6 +79,19 @@ and releases use semantic versioning.
   polygonal layers instead of letting the request fail server-side.
 - **A capped preview points at Create dataset.** The truncation notice names
   the way to run the operation over every feature.
+- **A wildcard CORS origin is now rejected at save time.** Responses carry
+  `Access-Control-Allow-Credentials: true`, so the spec forbids `*` as the
+  allow-origin value and the middleware treats a list containing `*` as "deny
+  everything" — including any explicit origins listed alongside it. Saving `*`
+  used to be accepted and then took the API down about 30 seconds later, once
+  the middleware's cache refreshed. It now fails immediately with a 422 naming
+  the correct form. **Upgrade note:** an existing stored value of `*` keeps
+  working until the next save, but Admin → Settings → Network will refuse to
+  save the page until it is replaced with explicit origins.
+- **TiTiler's glibc malloc arenas are capped.** `MALLOC_ARENA_MAX` defaults to
+  `2` for the `titiler` service, which slows resident-memory growth under
+  sustained tile load. Override with `TITILER_MALLOC_ARENA_MAX`. This bounds
+  arena-driven growth; it is not a fix for raster memory use in general.
 
 ### Fixed
 

--- a/scripts/check_version_coherence.py
+++ b/scripts/check_version_coherence.py
@@ -74,7 +74,9 @@ def _openapi_version(path: Path) -> str:
 
 
 def _main_fallback_version(path: Path) -> str:
-    m = re.search(r'^_FALLBACK_APP_VERSION = "([^"]*)"$', path.read_text(), re.MULTILINE)
+    m = re.search(
+        r'^_FALLBACK_APP_VERSION = "([^"]*)"$', path.read_text(), re.MULTILINE
+    )
     if not m:
         sys.exit(f"ERROR: no _FALLBACK_APP_VERSION line in {_rel(path)}.")
     return m.group(1)
@@ -87,17 +89,52 @@ def _yaml_override_version(path: Path) -> str:
     return m.group(1).strip()
 
 
+def _changelog_section(version: str) -> str | None:
+    """The lines under `## [version]`, or None if that header is absent.
+
+    Deliberately the same extraction .github/workflows/release.yml performs:
+
+        awk "/^## \\[${VERSION}\\]/{found=1; next} /^## \\[/{if(found) exit} found{print}"
+
+    The gate is only worth anything if it answers the question release.yml
+    actually asks, so the two must agree on where a section starts and ends.
+    """
+    out: list[str] = []
+    found = False
+    for line in CHANGELOG.read_text().splitlines():
+        if not found:
+            if re.match(rf"^## \[{re.escape(version)}\]", line):
+                found = True
+            continue
+        if line.startswith("## ["):
+            break
+        out.append(line)
+    return "\n".join(out) if found else None
+
+
 def main() -> int:
     sites: dict[str, str] = {}
-    sites[f"{_rel(BACKEND_PYPROJECT)} ([project].version)"] = _pyproject_version(BACKEND_PYPROJECT)
+    sites[f"{_rel(BACKEND_PYPROJECT)} ([project].version)"] = _pyproject_version(
+        BACKEND_PYPROJECT
+    )
     sites[f"{_rel(MAIN_PY)} (_FALLBACK_APP_VERSION)"] = _main_fallback_version(MAIN_PY)
     sites[f"{_rel(OPENAPI_PATH)} (info.version)"] = _openapi_version(OPENAPI_PATH)
-    sites[f"{_rel(FRONTEND_PACKAGE)} (.version)"] = _package_json_version(FRONTEND_PACKAGE)
+    sites[f"{_rel(FRONTEND_PACKAGE)} (.version)"] = _package_json_version(
+        FRONTEND_PACKAGE
+    )
     sites[f"{_rel(ROOT_PACKAGE)} (.version)"] = _package_json_version(ROOT_PACKAGE)
-    sites[f"{_rel(CLI_PYPROJECT)} ([project].version)"] = _pyproject_version(CLI_PYPROJECT)
-    sites[f"{_rel(MCP_PYPROJECT)} ([project].version)"] = _pyproject_version(MCP_PYPROJECT)
-    sites[f"{_rel(PY_SDK_PYPROJECT)} ([project].version)"] = _pyproject_version(PY_SDK_PYPROJECT)
-    sites[f"{_rel(PY_SDK_GEN_CONFIG)} (package_version_override)"] = _yaml_override_version(PY_SDK_GEN_CONFIG)
+    sites[f"{_rel(CLI_PYPROJECT)} ([project].version)"] = _pyproject_version(
+        CLI_PYPROJECT
+    )
+    sites[f"{_rel(MCP_PYPROJECT)} ([project].version)"] = _pyproject_version(
+        MCP_PYPROJECT
+    )
+    sites[f"{_rel(PY_SDK_PYPROJECT)} ([project].version)"] = _pyproject_version(
+        PY_SDK_PYPROJECT
+    )
+    sites[f"{_rel(PY_SDK_GEN_CONFIG)} (package_version_override)"] = (
+        _yaml_override_version(PY_SDK_GEN_CONFIG)
+    )
     sites[f"{_rel(TS_SDK_PACKAGE)} (.version)"] = _package_json_version(TS_SDK_PACKAGE)
 
     # Canonical = backend distribution version (what the app derives at runtime).
@@ -114,9 +151,12 @@ def main() -> int:
             sys.stderr.write(f"  - {site}: {v!r} != {canonical!r}\n")
         return 1
 
-    # release.yml matches this header literally to build the release body.
-    header = rf"^## \[{re.escape(canonical)}\]"
-    if not re.search(header, CHANGELOG.read_text(), re.MULTILINE):
+    # Mirror release.yml's awk: take the lines between this version's header and
+    # the next `## [` one. Matching the header alone is not enough — an empty
+    # section extracts to an empty body, and release.yml's `[ -z "$NOTES" ]`
+    # takes the same git-log fallback as a missing one.
+    body = _changelog_section(canonical)
+    if body is None:
         sys.stderr.write(
             f"FAIL: {_rel(CHANGELOG)} has no '## [{canonical}]' section.\n"
             f"release.yml extracts the release body by matching that exact header and\n"
@@ -125,11 +165,20 @@ def main() -> int:
             f"empty Unreleased above it) and add the matching link reference.\n"
         )
         return 1
+    if not body.strip():
+        sys.stderr.write(
+            f"FAIL: {_rel(CHANGELOG)}'s '## [{canonical}]' section is empty.\n"
+            f"release.yml treats an empty section exactly like a missing one and\n"
+            f"falls back to the raw git-log list. Write the release notes under that\n"
+            f"header before tagging.\n"
+        )
+        return 1
 
     print(f"OK: all {len(sites)} version sites agree on {canonical}.")
     for site, v in sites.items():
         print(f"  {site}: {v}")
-    print(f"  {_rel(CHANGELOG)}: '## [{canonical}]' section present.")
+    lines = len([ln for ln in body.strip().splitlines() if ln.strip()])
+    print(f"  {_rel(CHANGELOG)}: '## [{canonical}]' section present ({lines} lines).")
     return 0
 
 

--- a/scripts/check_version_coherence.py
+++ b/scripts/check_version_coherence.py
@@ -5,6 +5,13 @@ if any disagree, printing the offending site(s). This is the READ/verify side of
 the version contract; scripts/bump_version.py is the WRITE side — they enumerate
 the same set of sites.
 
+Also asserts CHANGELOG.md carries a `## [<version>]` section for the canonical
+version. .github/workflows/release.yml extracts the release body by matching
+that exact header and silently falls back to a raw `git log` list when it finds
+nothing — a fallback whose own filter drops every `docs(`/`chore(` subject, so a
+release whose headline change landed as `chore(db): upgrade ... PostgreSQL 18`
+would publish notes that never mention it. Nothing else in CI reads CHANGELOG.md.
+
 Sites checked:
   - backend/pyproject.toml                  [project].version (canonical)
   - backend/app/api/main.py                 _FALLBACK_APP_VERSION constant
@@ -46,6 +53,7 @@ MCP_PYPROJECT = REPO_ROOT / "mcp" / "pyproject.toml"
 PY_SDK_PYPROJECT = REPO_ROOT / "sdks" / "python" / "pyproject.toml"
 PY_SDK_GEN_CONFIG = REPO_ROOT / "sdks" / "python" / ".openapi-python-client.yaml"
 TS_SDK_PACKAGE = REPO_ROOT / "sdks" / "typescript" / "package.json"
+CHANGELOG = REPO_ROOT / "CHANGELOG.md"
 
 
 def _rel(p: Path) -> str:
@@ -106,9 +114,22 @@ def main() -> int:
             sys.stderr.write(f"  - {site}: {v!r} != {canonical!r}\n")
         return 1
 
+    # release.yml matches this header literally to build the release body.
+    header = rf"^## \[{re.escape(canonical)}\]"
+    if not re.search(header, CHANGELOG.read_text(), re.MULTILINE):
+        sys.stderr.write(
+            f"FAIL: {_rel(CHANGELOG)} has no '## [{canonical}]' section.\n"
+            f"release.yml extracts the release body by matching that exact header and\n"
+            f"silently falls back to a raw git-log list when it is missing. Rename the\n"
+            f"'## [Unreleased]' header to '## [{canonical}] - <date>' (keeping a fresh\n"
+            f"empty Unreleased above it) and add the matching link reference.\n"
+        )
+        return 1
+
     print(f"OK: all {len(sites)} version sites agree on {canonical}.")
     for site, v in sites.items():
         print(f"  {site}: {v}")
+    print(f"  {_rel(CHANGELOG)}: '## [{canonical}]' section present.")
     return 0
 
 

--- a/scripts/tests/test-changelog-gate.py
+++ b/scripts/tests/test-changelog-gate.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+"""Regression test for the CHANGELOG half of the version-coherence gate.
+
+The gate is only worth anything if it answers the question
+`.github/workflows/release.yml` actually asks. That workflow extracts the
+release body with awk:
+
+    awk "/^## \\[${V}\\]/{found=1; next} /^## \\[/{if(found) exit} found{print}"
+
+and falls back to a filtered `git log` — which drops every `docs(`/`chore(`
+subject — whenever the result is empty. So the two extractions must agree, and
+"header exists" is not the same question as "section has content".
+
+Pure stdlib, no repo state: each case builds its own CHANGELOG in a tmpdir.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import pathlib
+import re
+import subprocess
+import sys
+import tempfile
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+GATE = REPO_ROOT / "scripts" / "check_version_coherence.py"
+RELEASE_YML = REPO_ROOT / ".github" / "workflows" / "release.yml"
+
+_spec = importlib.util.spec_from_file_location("cvc", GATE)
+cvc = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(cvc)
+
+PASS = FAIL = 0
+
+
+def ok(msg: str) -> None:
+    global PASS
+    PASS += 1
+    print(f"ok {PASS + FAIL} - {msg}")
+
+
+def bad(msg: str) -> None:
+    global FAIL
+    FAIL += 1
+    print(f"not ok {PASS + FAIL} - {msg}")
+
+
+# The awk program release.yml runs, read back from the workflow so this test
+# breaks if the workflow's extraction is edited without updating the gate.
+def _release_yml_awk() -> str:
+    text = RELEASE_YML.read_text()
+    m = re.search(r'NOTES=\$\(awk "(.+?)" CHANGELOG\.md\)', text)
+    if not m:
+        sys.exit("ERROR: could not find the NOTES awk program in release.yml")
+    # Taken verbatim. Inside shell double quotes a backslash is only special
+    # before $ ` " \ or newline, so the `\[` / `\]` in the workflow reach awk
+    # unchanged as ERE-escaped brackets — unescaping them here would build a
+    # different (and invalid) program than the one that actually runs.
+    return m.group(1)
+
+
+AWK_TEMPLATE = _release_yml_awk()
+
+CASES = {
+    "normal section": "## [Unreleased]\n\n## [1.5.0] - 2026-07-26\n\n### Added\n- a thing\n\n## [1.4.13]\n- old\n",
+    "empty section": "## [Unreleased]\n\n## [1.5.0] - 2026-07-26\n\n## [1.4.13]\n- old\n",
+    "whitespace-only section": "## [1.5.0]\n   \n\t\n\n## [1.4.13]\n- old\n",
+    "missing section": "## [Unreleased]\n\n## [1.4.13]\n- old\n",
+    "last section in file": "## [Unreleased]\n\n## [1.5.0]\n- tail content\n",
+    "section followed by link refs": "## [1.5.0]\n- a\n\n[1.5.0]: https://x/compare/v1.4.13...v1.5.0\n",
+    "subsection headers inside": "## [1.5.0]\n### Added\n- a\n## [1.4.0]\n- b\n",
+}
+
+
+def awk_extract(changelog: pathlib.Path, version: str) -> str:
+    prog = AWK_TEMPLATE.replace("${CHANGELOG_VERSION}", version)
+    out = subprocess.run(
+        ["awk", prog, str(changelog)], capture_output=True, text=True, check=False
+    ).stdout
+    # release.yml captures with $(...), which strips trailing newlines.
+    return out.rstrip("\n")
+
+
+# --- 1. the gate's extraction must match release.yml's, case for case --------
+for name, text in CASES.items():
+    d = pathlib.Path(tempfile.mkdtemp())
+    f = d / "CHANGELOG.md"
+    f.write_text(text)
+    cvc.CHANGELOG = f
+
+    from_awk = awk_extract(f, "1.5.0")
+    section = cvc._changelog_section("1.5.0")
+    from_gate = "" if section is None else section.rstrip("\n")
+
+    if from_awk == from_gate:
+        ok(f"extraction matches release.yml awk: {name}")
+    else:
+        bad(f"extraction differs ({name}): awk={from_awk!r} gate={from_gate!r}")
+
+    # The gate must reject exactly the inputs that send release.yml to its
+    # git-log fallback ($NOTES empty after $(...) whitespace handling).
+    awk_falls_back = from_awk.strip() == ""
+    gate_rejects = section is None or not section.strip()
+    if awk_falls_back == gate_rejects:
+        ok(f"gate verdict tracks the release.yml fallback: {name}")
+    else:
+        bad(
+            f"verdict mismatch ({name}): release.yml falls back={awk_falls_back}, "
+            f"gate rejects={gate_rejects}"
+        )
+
+# --- 2. a prerelease tag must resolve to its GA section ----------------------
+# bump_version.py's SEMVER_RE only accepts plain X.Y.Z, so `## [1.5.0-rc.1]`
+# can never exist; release.yml has to strip the suffix or every RC publishes
+# the git-log fallback.
+if not re.search(
+    r'SEMVER_RE = re\.compile\(r"\^\\d\+\\\.\\d\+\\\.\\d\+\$"\)',
+    (REPO_ROOT / "scripts" / "bump_version.py").read_text(),
+):
+    bad("bump_version.py's SEMVER_RE changed — recheck the prerelease assumption")
+else:
+    ok("bump_version.py still refuses prerelease suffixes (no RC changelog header)")
+
+release_text = RELEASE_YML.read_text()
+if 'CHANGELOG_VERSION="${VERSION%%-*}"' in release_text:
+    ok("release.yml strips the prerelease suffix before the CHANGELOG lookup")
+else:
+    bad("release.yml no longer normalizes prerelease tags to their GA section")
+
+d = pathlib.Path(tempfile.mkdtemp())
+f = d / "CHANGELOG.md"
+f.write_text("## [Unreleased]\n\n## [1.5.0] - 2026-07-26\n\n### Added\n- a thing\n")
+for tag in ("v1.5.0", "v1.5.0-rc.1", "v1.5.0-beta.2"):
+    version = tag.lstrip("v")
+    changelog_version = version.split("-", 1)[0]  # ${VERSION%%-*}
+    if awk_extract(f, changelog_version).strip():
+        ok(f"{tag} resolves to real release notes, not the git-log fallback")
+    else:
+        bad(f"{tag} still falls back to the git log")
+
+print(f"1..{PASS + FAIL}")
+print(f"# {PASS} passed, {FAIL} failed")
+sys.exit(1 if FAIL else 0)

--- a/scripts/tests/test-changelog-gate.py
+++ b/scripts/tests/test-changelog-gate.py
@@ -99,7 +99,11 @@ for name, text in CASES.items():
         bad(f"extraction differs ({name}): awk={from_awk!r} gate={from_gate!r}")
 
     # The gate must reject exactly the inputs that send release.yml to its
-    # git-log fallback ($NOTES empty after $(...) whitespace handling).
+    # git-log fallback. fix(#715 review): `$(...)` strips trailing newlines but
+    # KEEPS spaces and tabs, so a bare `[ -z "$NOTES" ]` was false for a
+    # whitespace-only section and published blank notes — a verdict the gate
+    # did not share. release.yml now strips whitespace before the test, which
+    # is what makes .strip() the right model here rather than a convenient one.
     awk_falls_back = from_awk.strip() == ""
     gate_rejects = section is None or not section.strip()
     if awk_falls_back == gate_rejects:
@@ -123,6 +127,13 @@ else:
     ok("bump_version.py still refuses prerelease suffixes (no RC changelog header)")
 
 release_text = RELEASE_YML.read_text()
+# The emptiness test itself, not just the extraction: a plain `[ -z "$NOTES" ]`
+# disagrees with this gate on whitespace-only sections.
+if """[ -z "$(printf '%s' "$NOTES" | tr -d '[:space:]')" ]""" in release_text:
+    ok("release.yml strips whitespace before deciding the notes are empty")
+else:
+    bad("release.yml no longer whitespace-strips before its emptiness test")
+
 if 'CHANGELOG_VERSION="${VERSION%%-*}"' in release_text:
     ok("release.yml strips the prerelease suffix before the CHANGELOG lookup")
 else:


### PR DESCRIPTION
Found during a pre-1.5.0 release audit of the `v1.4.13..HEAD` scope.

## The release notes omit the release

`[Unreleased]` had `### Changed` and `### Fixed` but **no `### Added`** — so the headline feature of 1.5.0, the entire analysis toolkit, appeared nowhere in the release notes. This adds it, plus two unannounced operator-facing changes.

## The header is load-bearing and unguarded

`.github/workflows/release.yml:59` builds the release body by matching the header literally:

```
NOTES=$(awk "/^## \[${VERSION}\]/{found=1; next} /^## \[/{if(found) exit} found{print}" CHANGELOG.md)
```

If it matches nothing, lines 61-64 fall back — with no warning and exit 0 — to:

```
git log --format="- %s" "${PREV}..${TAG}" --no-merges | grep -v "^- docs(" | grep -v "^- chore(" | head -30
```

In the actual `v1.4.13..HEAD` range those two greps remove exactly two commits, and one of them is:

- `chore(db): upgrade bundled database to PostgreSQL 18 + PostGIS 3.6 (#705)` — dropped by `grep -v "^- chore("`
- `docs(runbook): §6 must rebuild the backup image too, not just db (#706)` — dropped by `grep -v "^- docs("`

So tagging `v1.5.0` with the header still reading `## [Unreleased]` would publish a release page that **never mentions the breaking PostgreSQL 17→18 upgrade or RUNBOOK § 6** — on the surface a self-hoster reads before running `docker compose pull && docker compose up -d`. The `upgrade.sh` major-boundary guard from #707 only covers the `upgrade.sh` path, not a direct compose pull.

**Nothing in CI read CHANGELOG.md.** `bump_version.py`'s site list excludes it, `check_version_coherence.py` never opened it, no pre-commit hook references it, and the three tests that do read it (`test_phase_275_changelog_routes.py`) only validate a legacy `### Added — Map Builder API surface` block. The last release got the header right purely by hand-discipline.

`make version-check` now asserts a `## [<canonical>]` section exists — green today on 1.4.13, red at bump time until the header is renamed.

## Two unannounced operator-facing changes

Both are reachable without touching a new feature:

- **CORS wildcard rejection (#689).** An operator upgrading with `cors_allowed_origins = "*"` already stored gets a 422 on the Network settings page for a value they never touched. Includes the upgrade note that an existing stored `*` keeps working until the next save.
- **TiTiler `MALLOC_ARENA_MAX=2` (#678)**, with the `TITILER_MALLOC_ARENA_MAX` override, stated as an arena-growth bound rather than a raster memory fix.

## Verification

- `uv run python scripts/check_version_coherence.py` → passes, and now reports the CHANGELOG section.
- Confirmed the gate is real: `## [1.4.13]` matches, `## [1.5.0]` does not — so it goes red at bump until the header is written.
- `pytest tests/test_phase_275_changelog_routes.py` → 3 passed (the new plain `### Added` does not collide with the legacy `### Added — Map Builder API surface` block those tests parse).
- CORS and TiTiler claims read from `backend/app/modules/settings/schemas.py:557-575` and `docker-compose.yml:496` / `.env.example:306`.

## Still to do at release time

This PR does **not** rename the header — that belongs in the `make bump VERSION=1.5.0` commit. The gate now forces it. The bump also needs the link reference:

```
[Unreleased]: https://github.com/geolens-io/geolens/compare/v1.5.0...HEAD
[1.5.0]: https://github.com/geolens-io/geolens/compare/v1.4.13...v1.5.0
```