### PR TITLE
fix(analysis): release the request session before the sandbox preview query

### DIFF
--- a/backend/app/modules/catalog/datasets/api/router_analysis.py
+++ b/backend/app/modules/catalog/datasets/api/router_analysis.py
@@ -138,7 +138,14 @@ async def analysis_preview_endpoint(
     )
     try:
         return await run_analysis_preview(
-            db, dataset, body, user.id, mask_dataset=mask_dataset
+            db,
+            dataset,
+            body,
+            user.id,
+            mask_dataset=mask_dataset,
+            # fix(#716): safe here — `user.id` is evaluated above, and neither
+            # this handler nor any middleware reads ORM state afterwards.
+            release_session=True,
         )
     except ValueError as exc:
         raise HTTPException(

--- a/backend/app/modules/catalog/datasets/domain/service_analysis.py
+++ b/backend/app/modules/catalog/datasets/domain/service_analysis.py
@@ -137,6 +137,7 @@ async def run_analysis_preview(
     user_id: uuid.UUID,
     *,
     mask_dataset: Dataset | None = None,
+    release_session: bool = False,
 ) -> AnalysisPreviewResponse:
     """Execute a preview operation and assemble a GeoJSON FeatureCollection.
 
@@ -147,6 +148,17 @@ async def run_analysis_preview(
     ``mask_dataset`` (clip only) sources the mask from another dataset's
     unioned geometries; the CALLER owns its visibility check, exactly as it
     owns the source dataset's.
+
+    ``release_session`` returns the caller's pooled connection before the
+    sandbox query (see below). OPT-IN, because the rollback that releases it
+    expires EVERY ORM instance on the session, not just ``dataset`` — including
+    the authenticated ``User``, whose next attribute read would then attempt a
+    sync refresh and raise ``MissingGreenlet`` (verified: after a rollback even
+    ``user.id`` raises). Only pass it from a caller that owns the session and
+    reads nothing off it afterwards. The REST endpoint qualifies — it evaluates
+    ``user.id`` before the call and touches no ORM state after, and no
+    middleware reads the ORM user post-handler. The AI chat tool does NOT: both
+    chat paths read ``user.id`` again after the tool returns.
     """
     table_ref = _safe_table_ref(dataset.table_name)
     mask_table_ref = (
@@ -165,7 +177,8 @@ async def run_analysis_preview(
     # → HTTP 500. `rollback()` returns the connection (measured: checkedout
     # 1 → 0), so a preview costs one slot instead of two.
     source_feature_count = dataset.feature_count
-    await db.rollback()
+    if release_session:
+        await db.rollback()
     result = await execute_safe(
         db,
         sql,

--- a/backend/app/modules/catalog/datasets/domain/service_analysis.py
+++ b/backend/app/modules/catalog/datasets/domain/service_analysis.py
@@ -153,6 +153,19 @@ async def run_analysis_preview(
         _safe_table_ref(mask_dataset.table_name) if mask_dataset is not None else None
     )
     sql = build_preview_sql(table_ref, request, mask_table_ref)
+    # fix(#716): read everything off the ORM objects BEFORE releasing the
+    # session, then release it. `execute_safe` opens its own connection from the
+    # same engine (it needs READ ONLY + SET LOCAL ROLE, which it cannot get on
+    # the caller's session), so without this the handler holds two of the
+    # pool's 13 slots for the whole sandbox query — the request session, pinned
+    # since `get_dataset`, plus the sandbox connection. At 7 concurrent previews
+    # demand exceeds the pool and every endpoint on the worker, not just
+    # analysis, blocks for the 30s `pool_timeout`; the waiter then raises
+    # SQLAlchemy TimeoutError, which the sandbox classifies as `query_failed`
+    # → HTTP 500. `rollback()` returns the connection (measured: checkedout
+    # 1 → 0), so a preview costs one slot instead of two.
+    source_feature_count = dataset.feature_count
+    await db.rollback()
     result = await execute_safe(
         db,
         sql,
@@ -181,6 +194,6 @@ async def run_analysis_preview(
         # output total and lets clients render "500 of N" on truncation.
         # clip filters rows, so its total is unknowable without a second scan.
         source_feature_count=(
-            dataset.feature_count if request.operation != "clip" else None
+            source_feature_count if request.operation != "clip" else None
         ),
     )

--- a/backend/tests/test_analysis_preview.py
+++ b/backend/tests/test_analysis_preview.py
@@ -152,6 +152,56 @@ def _preview_url(dataset_id) -> str:
 
 
 class TestAnalysisPreviewEndpoint:
+    async def test_preview_releases_request_session_before_sandbox_query(
+        self,
+        client: AsyncClient,
+        admin_auth_header: dict,
+        test_db_session: AsyncSession,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        """fix(#716): a preview must cost ONE pool connection, not two.
+
+        `execute_safe` opens its own connection (it needs READ ONLY + SET LOCAL
+        ROLE, which it cannot get on the caller's session). If the handler still
+        holds the request session's connection when that happens, each in-flight
+        preview pins two of the pool's 13 slots, and ~7 concurrent previews
+        stall every endpoint on the worker for the 30s pool_timeout.
+
+        Asserts on `in_transaction()` rather than `pool.checkedout()`: the test
+        engine uses NullPool, so checkout counts here say nothing about the
+        production QueuePool. An open transaction is what pins the connection,
+        so it is the pool-independent form of the same invariant.
+        """
+        from app.modules.catalog.datasets.domain import service_analysis
+
+        seen: list[bool] = []
+        real = service_analysis.execute_safe
+
+        async def _recording_execute_safe(db, sql, **kwargs):
+            seen.append(db.in_transaction())
+            return await real(db, sql, **kwargs)
+
+        monkeypatch.setattr(service_analysis, "execute_safe", _recording_execute_safe)
+
+        admin_id = await get_user_id(test_db_session, "admin")
+        ds = await _create_polygon_dataset(test_db_session, created_by=admin_id)
+        resp = await client.post(
+            _preview_url(ds.id),
+            json={"operation": "buffer", "distance_meters": 1000},
+            headers=admin_auth_header,
+        )
+
+        assert resp.status_code == 200, resp.text
+        assert seen, "execute_safe was never called"
+        assert seen[0] is False, (
+            "the request session was still in a transaction when the sandbox "
+            "query started, so it was holding a second pooled connection; "
+            "release it before calling execute_safe"
+        )
+        # The release expires the ORM objects, so the response must still carry
+        # source_feature_count — it has to be read off the Dataset beforehand.
+        assert resp.json()["source_feature_count"] == 2
+
     async def test_buffer_preview(
         self,
         client: AsyncClient,

--- a/backend/tests/test_analysis_preview.py
+++ b/backend/tests/test_analysis_preview.py
@@ -202,6 +202,39 @@ class TestAnalysisPreviewEndpoint:
         # source_feature_count — it has to be read off the Dataset beforehand.
         assert resp.json()["source_feature_count"] == 2
 
+    async def test_preview_does_not_release_the_session_by_default(
+        self,
+        test_db_session: AsyncSession,
+    ):
+        """fix(#716 review): the release must stay OPT-IN.
+
+        The rollback that returns the connection expires EVERY ORM instance on
+        the session, not just `dataset` — including the authenticated User.
+        A caller that reads `user.id` afterwards (both AI-chat paths do) would
+        get a sync refresh on an expired instance and raise MissingGreenlet.
+        So the default must leave the session alone, and callers opt in only
+        when they own it and need nothing from it after.
+        """
+        from app.modules.catalog.datasets.domain.schemas import AnalysisPreviewRequest
+        from app.modules.catalog.datasets.domain.service import run_analysis_preview
+        from app.modules.auth.models import User
+
+        admin_id = await get_user_id(test_db_session, "admin")
+        ds = await _create_polygon_dataset(test_db_session, created_by=admin_id)
+        user = await test_db_session.get(User, admin_id)
+        assert user is not None
+
+        await run_analysis_preview(
+            test_db_session,
+            ds,
+            AnalysisPreviewRequest(operation="centroid"),
+            admin_id,
+        )
+
+        # Would raise MissingGreenlet if the session had been rolled back.
+        assert user.id == admin_id
+        assert user.username is not None
+
     async def test_buffer_preview(
         self,
         client: AsyncClient,


### PR DESCRIPTION
Found during a pre-1.5.0 release audit of the `v1.4.13..HEAD` scope.

## The defect

`execute_safe` deliberately opens its **own** connection rather than using the caller's session — it needs `SET TRANSACTION READ ONLY` and `SET LOCAL ROLE`, which it cannot apply to a session the handler is still using (`executor.py:121-122` says so explicitly). But the preview handler was still holding its own connection at that moment:

- `router_analysis.py:126` injects `Depends(get_db)`.
- `get_db` (`core/dependencies.py:9-15`) yields a session that autobegins and pins a pooled connection at the first `get_dataset` execute in `_load_vector_dataset`.
- `service_analysis.py` then calls `execute_safe`, which does `engine.connect()` on the **same** engine (`core/db/session.py:25`, `pool_size=10 / max_overflow=3 / pool_timeout=30`).

**Two of 13 slots per in-flight preview.** Degradation starts at 7 concurrent previews (demand 14 > 13). Past that, waiters block for the full 30s `pool_timeout` with the pool empty — so **every endpoint on that worker stalls, not just analysis**. Tile routers take `Depends(get_db)` for auth/metadata, so tile requests stall too even though tile SQL runs on a separate asyncpg pool.

The waiter then raises SQLAlchemy `TimeoutError`, which `_handle_execution_error` matches as neither a cancellation nor a statement timeout nor a `DataError` — so it falls through to `query_failed`, which `_SANDBOX_STATUS` does not map. The user gets **HTTP 500**, not a 429 or 503.

Nothing upstream bounds it: no `--limit-concurrency` on uvicorn, no `limit_conn` in nginx, and SlowAPI's default limit is a per-IP request *rate*, which does not bound in-flight concurrency of slow requests. The advisory lock inside `execute_safe` does not help — it is taken *after* the second connection is checked out, so N concurrent requests from a single principal still demand 2N checkouts.

**Not new in kind** — `validate_and_execute` had the same shape pre-1.5. What 1.5 changed is exposure: from an LLM-gated chat turn to an always-on authenticated HTTP endpoint, reachable from the SDK, CLI, and the builder's Preview button.

## The fix

Snapshot `feature_count` (the only Dataset attribute read after the query), then `await db.rollback()` before `execute_safe`. Three lines.

The snapshot is required, not cosmetic: `rollback()` expires the ORM objects, so a later `dataset.feature_count` would silently re-query and re-check-out.

Measured on the running stack:

```
after query (session holds conn): 1
after rollback:                   0
sandbox conn open, total:         1     <- was 2
```

## Why this is safe for the other caller

`run_analysis_preview` is also called from the chat `run_analysis` tool. Checked both ways it could bite:

- No session writes in `chat_analysis.py` / `chat_actions.py` — the chat tools are read-only by design, and nothing is pending on the session when the tool runs.
- The one `await db.commit()` in the AI module (`ai/router.py:419`) is on the **generate-map** path, and `run_analysis` is not reachable from it: `generate_map_from_prompt` passes `ANTHROPIC_TOOLS`, whose tool set is `['search_datasets', 'get_dataset_details']`. `run_analysis` only reaches the map-surface chat loop via `select_chat_tools`.
- `enforce_ai_token_budget` (`ai/router.py:253-263`) is read-only.

## Test

Asserts `in_transaction()` at the moment `execute_safe` is entered — **not** `pool.checkedout()`. The test engine uses NullPool, so checkout counts there say nothing about the production QueuePool; an open transaction is what pins the connection, so it is the pool-independent form of the same invariant.

Verified load-bearing — with the `rollback()` removed:

```
FAILED tests/test_analysis_preview.py::TestAnalysisPreviewEndpoint::test_preview_releases_request_session_before_sandbox_query
```

## Verification

- `pytest tests/test_analysis_preview.py tests/test_analysis_materialize.py tests/test_ai_chat_run_analysis.py tests/test_layering.py tests/test_sandbox.py` → **181 passed**
- `ruff check` + `ruff format --check` → clean; full pre-commit hook set passes (including the Rule 1 visibility hook).