### PR TITLE
fix(ci): fail the npm-audit gate closed when the scan does not run

### DIFF
--- a/scripts/js-audit-gate.mjs
+++ b/scripts/js-audit-gate.mjs
@@ -50,6 +50,22 @@ try {
 }
 const report = JSON.parse(raw);
 
+// Fail closed on anything that is not a real audit report. When the registry is
+// unreachable (outage, egress proxy, rate limit) npm still exits non-zero and
+// still writes JSON to stdout — but that JSON is `{"message": ..., "error": ...}`
+// with no `vulnerabilities` key. The scan loop below reads
+// `report.vulnerabilities ?? {}`, so it would iterate nothing, print the success
+// line, and exit 0 — reporting a clean supply chain on a scan that never ran.
+const noReport =
+  report.error || typeof report.vulnerabilities !== 'object' || report.vulnerabilities === null;
+if (noReport) {
+  console.error(
+    'npm audit did not produce a report:',
+    report.message ?? JSON.stringify(report.error ?? report).slice(0, 500),
+  );
+  process.exit(1);
+}
+
 const today = new Date().toISOString().slice(0, 10);
 const active = new Map(
   ALLOWLIST.filter((e) => e.expires >= today).map((e) => [e.id, e]),


### PR DESCRIPTION
Found during a pre-1.5.0 release audit of the `v1.4.13..HEAD` scope. `scripts/js-audit-gate.mjs` is new in this release (#672, #677), so this ships with it.

## The defect

`npm audit --json` exits non-zero for two very different reasons: vulnerabilities were found, or **the audit itself failed**. The gate correctly handles the first — it reads the report off stdout of the non-zero exit:

```js
} catch (err) {
  if (!err.stdout) throw err;
  raw = err.stdout;
}
```

But on the second, npm *also* writes JSON to stdout, and that JSON has no `vulnerabilities` key:

```json
{"message":"request to https://registry.npmjs.org/-/npm/v1/security/advisories/bulk failed, reason: getaddrinfo ENOTFOUND","error":{"code":"ENOTFOUND",...}}
```

The scan loop reads `report.vulnerabilities ?? {}`, so an error report iterates nothing, prints the success line, and exits 0.

A registry outage, a blocked egress proxy, or a rate limit turns the supply-chain gate **green** — and prints a line that tells the reviewer the opposite of what happened.

## Reproduction

With a stub `npm` on `PATH` emitting the real ENOTFOUND error shape:

```
before:  npm audit gate: no unallowlisted high/critical advisories.   exit 0
after:   npm audit did not produce a report: request to
         https://registry.npmjs.org/-/npm/v1/security/advisories/bulk
         failed, reason: getaddrinfo ENOTFOUND                        exit 1
```

## The fix

One guard after `JSON.parse`. Anything that is not a real audit report fails closed — which matches how the rest of the gate already behaves: an expired allowlist entry stops suppressing rather than lingering.

## Verification

- Real run against `frontend/`: still exits 0 and still reports both allowlisted advisories (`GHSA-mh99-v99m-4gvg`, `GHSA-qwww-vcr4-c8h2`, both expiring 2026-09-01).
- Simulated outage: exits 1 with the underlying npm message.
- Both paths re-verified after the refactor that keeps the condition inside the file's line-length convention.