### PR TITLE
docs(changelog): correct two overstated analysis claims before the 1.5.0 cut

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,13 +10,14 @@ and releases use semantic versioning.
 ### Added
 
 - **Spatial analysis in the map builder: buffer, centroid, clip, and dissolve.**
-  A new Analysis panel runs an operation against any vector layer and draws the
-  result on the map as a preview, capped at 500 features so it stays
-  interactive. **Create dataset** re-runs the same operation over every feature
-  as a background job and registers the output as a new dataset, which then
-  behaves like any other layer — styleable, exportable, and served through the
-  OGC and STAC endpoints. Buffer distances accept metres, kilometres, feet, or
-  miles. Dissolve optionally groups by an attribute column.
+  A new Analysis panel runs an operation against any vector layer. Buffer,
+  centroid, and clip draw the result on the map as a preview, capped at 500
+  features so it stays interactive; dissolve is materialize-only. **Create
+  dataset** re-runs the same operation over every feature as a background job
+  and registers the output as a new dataset, which then behaves like any other
+  layer — styleable, exportable, and served through the OGC API endpoints.
+  Buffer distances accept metres, kilometres, feet, or miles. Dissolve
+  optionally groups by an attribute column.
 - **Clip against another layer, not just a drawn area.** `mask_dataset_id` on
   the analysis endpoints clips a layer using the union of a polygon layer's
   geometries. The picker offers only polygonal layers; both the source and the


### PR DESCRIPTION
## What

The `## [Unreleased]` analysis bullet still carried the two claims that #721 corrected in the four READMEs. The CHANGELOG never got the same pass.

This matters more than a docs typo: `.github/workflows/release.yml` feeds this section straight into the GitHub release body, so both claims would have shipped as the public 1.5.0 release notes.

## The two claims

**STAC exposure.** Analysis outputs register as vector datasets, and the STAC router serves only `_STAC_RECORD_TYPES = ("raster_dataset", "vrt_dataset")` (`backend/app/standards/stac/router.py:81`). No analysis output can appear through a STAC endpoint. Now reads "served through the OGC API endpoints", which is accurate.

**Dissolve preview.** The bullet named all four operations and then said the panel "draws the result on the map as a preview". `AnalysisPanel` excludes dissolve from both `canRun` (`AnalysisPanel.tsx:366`) and the Preview button itself (line 675). Dissolve is materialize-only.

Wording mirrors the corrected README so the two stay in sync.

## Verification

- OGC claim, live against the walkshed dataset the demo video produced: `/api/collections/{id}/items` returns 200 with 496 features and their source attributes intact.
- STAC claim: `/api/stac/collections/{id}` returns 404; the dataset is absent from the STAC collections listing. Confirmed structurally at `router.py:81`.
- `make version-check` passes, still 1.4.13 across all ten sites. No version site touched.

## Scope

CHANGELOG prose only. Lands before the 1.5.0 bump so the bump PR is purely mechanical.