### PR TITLE
fix(builder): stop a clip-drawing vertex click from opening a feature popup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -126,6 +126,12 @@ and releases use semantic versioning.
 - **Drawing a clip area names its keyboard alternative.** The draw tool is
   pointer-only; the panel now points to clip-by-layer instead of leaving that
   to be discovered.
+- **Drawing a clip area no longer opens a popup at every vertex.** Each click
+  placed its vertex and then fell through to the map's own click handler, so
+  drawing a mask over a layer with popups enabled left one popup behind per
+  corner, the last of them sitting on top of the result. A draw mode now owns
+  the pointer for as long as it runs, and any popup already open is dismissed
+  when drawing starts.
 
 ## [1.4.13] - 2026-07-24
 

--- a/frontend/src/components/builder/AnalysisPanel.tsx
+++ b/frontend/src/components/builder/AnalysisPanel.tsx
@@ -21,6 +21,7 @@ import { useDataset } from '@/components/dataset/hooks/use-dataset';
 import { useJobStatus } from '@/components/import/hooks/use-ingest';
 import { usePermissions } from '@/hooks/use-permissions';
 import { useAnalysisJobStore } from '@/stores/analysis-job-store';
+import { useMapDrawStore } from '@/stores/map-draw-store';
 import type { LayerActions } from '@/components/builder/ChatPanel';
 import type { EphemeralAnalysisHandoff } from '@/components/builder/hooks/use-ephemeral-layers';
 import type { AnalysisOperation, MapLayerResponse } from '@/types/api';
@@ -182,6 +183,17 @@ export function AnalysisPanel({
 
   // Stop any active draw when the panel unmounts.
   useEffect(() => stopDrawing, [stopDrawing]);
+
+  // fix(#726): tell BuilderMap a draw mode owns the pointer, so a vertex click
+  // stops falling through and opening the clicked feature's popup. Mirrored
+  // from isDrawing in one place rather than set alongside each transition —
+  // the 'finish' handler drops to static mode without going through
+  // stopDrawing, so per-call-site updates would drift.
+  useEffect(() => {
+    const { setDrawActive } = useMapDrawStore.getState();
+    setDrawActive(isDrawing);
+    return () => setDrawActive(false);
+  }, [isDrawing]);
 
   const startDrawing = useCallback(() => {
     const map = mapInstanceRef?.current;

--- a/frontend/src/components/builder/BuilderMap.tsx
+++ b/frontend/src/components/builder/BuilderMap.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useCallback, useState, useMemo, memo } from 'react';
 import { usePluginStore } from '@/stores/map-plugin-store';
+import { useMapDrawStore } from '@/stores/map-draw-store';
 import { isPluginIdAvailable } from '@/components/map-plugins';
 import { toast } from 'sonner';
 import { Map as MapGL, NavigationControl, ScaleControl } from '@vis.gl/react-maplibre';
@@ -577,6 +578,22 @@ export const BuilderMap = memo(function BuilderMap({
     });
   }, [enabledPluginIds]);
 
+  // fix(#726): a draw mode (the analysis clip mask) owns the pointer while it
+  // runs, so feature clicks must not resolve underneath it. Same ref-and-
+  // subscribe shape as measurement above: the handlers below read a ref rather
+  // than a hook value so toggling does not re-register them on the map.
+  const drawActiveRef = useRef(false);
+
+  useEffect(() => {
+    drawActiveRef.current = useMapDrawStore.getState().drawActive;
+    return useMapDrawStore.subscribe((state) => {
+      drawActiveRef.current = state.drawActive;
+      // Drop a popup that is already open when drawing starts, or it stays
+      // parked over the area being drawn for the rest of the session.
+      if (state.drawActive) setPopupInfo(null);
+    });
+  }, []);
+
   const invalidateTileTokens = useInvalidateTileTokens();
   // fix(#621): shared tile-auth recovery — a vector tile 401/403 that the
   // cached-token re-sign can't cure kicks one throttled token re-mint; the
@@ -921,7 +938,7 @@ export const BuilderMap = memo(function BuilderMap({
 
     const handleClick = (e: MapMouseEvent) => {
       if (!map.isStyleLoaded()) return;
-      if (measureActiveRef.current) return;
+      if (measureActiveRef.current || drawActiveRef.current) return;
       const queryLayers = queryLayerIdsRef.current;
 
       if (queryLayers.length === 0) {
@@ -971,7 +988,7 @@ export const BuilderMap = memo(function BuilderMap({
       cancelAnimationFrame(rafId);
       rafId = requestAnimationFrame(() => {
         if (!map.isStyleLoaded()) return;
-        if (measureActiveRef.current) return;
+        if (measureActiveRef.current || drawActiveRef.current) return;
         const queryLayers = queryLayerIdsRef.current;
 
         let canvas;
@@ -1001,7 +1018,7 @@ export const BuilderMap = memo(function BuilderMap({
 
     const handleKeyDown = (event: KeyboardEvent) => {
       if (event.key !== 'Enter' && event.key !== ' ') return;
-      if (measureActiveRef.current) return;
+      if (measureActiveRef.current || drawActiveRef.current) return;
       const queryLayers = queryLayerIdsRef.current;
       if (queryLayers.length === 0) return;
       let canvas: HTMLCanvasElement | null = null;

--- a/frontend/src/components/builder/__tests__/AnalysisPanel.draw-suppression.test.tsx
+++ b/frontend/src/components/builder/__tests__/AnalysisPanel.draw-suppression.test.tsx
@@ -1,0 +1,167 @@
+import { act, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render } from '@/test/test-utils';
+import { AnalysisPanel } from '../AnalysisPanel';
+import { useMapDrawStore } from '@/stores/map-draw-store';
+import type { Map as MaplibreMap } from 'maplibre-gl';
+import type { MapLayerResponse } from '@/types/api';
+
+/**
+ * fix(#726): a clip-drawing vertex click also opened the clicked feature's
+ * popup, so a five-point mask left five popups behind and the last one covered
+ * the result.
+ *
+ * BuilderMap's click handler bails on `useMapDrawStore`'s `drawActive`, so what
+ * has to hold is that AnalysisPanel raises that flag for exactly as long as a
+ * draw mode is running. The lifecycle is the fragile part: `finish` drops
+ * TerraDraw to static mode WITHOUT going through `stopDrawing`, which is why
+ * the flag mirrors `isDrawing` from one effect rather than being set at each
+ * call site.
+ */
+
+Element.prototype.hasPointerCapture = vi.fn(() => false);
+Element.prototype.releasePointerCapture = vi.fn();
+Element.prototype.scrollIntoView = vi.fn();
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (_key: string, options?: { defaultValue?: string }) =>
+      options?.defaultValue ?? _key,
+    i18n: { language: 'en' },
+  }),
+}));
+
+vi.mock('@/hooks/use-permissions', () => ({
+  usePermissions: () => ({
+    can: () => true,
+    permissions: { upload: true },
+    isLoading: false,
+  }),
+}));
+
+vi.mock('@/api/analysis', () => ({
+  previewAnalysis: vi.fn(),
+  materializeAnalysis: vi.fn(),
+}));
+
+vi.mock('@/components/dataset/hooks/use-dataset', () => ({
+  useDataset: vi.fn(() => ({ data: { column_info: [] } })),
+}));
+
+// Captures the 'finish' handler so a completed polygon can be replayed without
+// a real map. TerraDrawMapLibreGLAdapter needs a live GL context otherwise.
+// vi.hoisted: the mock factories run at import time, before this file's own
+// module-level bindings would be initialized.
+const { finishRef, stopSpy, setModeSpy } = vi.hoisted(() => ({
+  finishRef: { current: null as ((id: string | number) => void) | null },
+  stopSpy: vi.fn(),
+  setModeSpy: vi.fn(),
+}));
+
+vi.mock('terra-draw', () => ({
+  TerraDraw: class {
+    start = vi.fn();
+    setMode = setModeSpy;
+    stop = stopSpy;
+    removeFeatures = vi.fn();
+    getSnapshotFeature = () => ({
+      geometry: {
+        type: 'Polygon',
+        coordinates: [[[0, 0], [1, 0], [1, 1], [0, 1], [0, 0]]],
+      },
+    });
+    on = (event: string, cb: (id: string | number) => void) => {
+      if (event === 'finish') finishRef.current = cb;
+    };
+  },
+  TerraDrawPolygonMode: class {},
+}));
+
+vi.mock('terra-draw-maplibre-gl-adapter', () => ({
+  TerraDrawMapLibreGLAdapter: class {},
+}));
+
+const polygonLayer = {
+  id: 'l1',
+  dataset_id: 'ds1',
+  dataset_name: 'Parcels',
+  display_name: null,
+  is_dem: false,
+  dataset_geometry_type: 'MultiPolygon',
+} as unknown as MapLayerResponse;
+
+function renderPanel() {
+  const qc = new QueryClient({ defaultOptions: { mutations: { retry: false } } });
+  // startDrawing bails without a map; the adapter is mocked, so any object does.
+  const mapInstanceRef = { current: {} as MaplibreMap };
+  return render(
+    <QueryClientProvider client={qc}>
+      <AnalysisPanel layers={[polygonLayer]} mapInstanceRef={mapInstanceRef} />
+    </QueryClientProvider>,
+  );
+}
+
+/** Get to Clip and start the draw mode. */
+async function startDrawing(user: ReturnType<typeof userEvent.setup>) {
+  // Combobox order: layer, operation.
+  await user.click(screen.getAllByRole('combobox')[1]);
+  await user.click(await screen.findByRole('option', { name: 'Clip' }));
+  await user.click(screen.getByRole('button', { name: 'Draw clip area' }));
+}
+
+beforeEach(() => {
+  finishRef.current = null;
+  stopSpy.mockClear();
+  setModeSpy.mockClear();
+  useMapDrawStore.setState({ drawActive: false });
+});
+
+describe('AnalysisPanel draw-mode pointer ownership (#726)', () => {
+  it('is inactive before any drawing starts', () => {
+    renderPanel();
+    expect(useMapDrawStore.getState().drawActive).toBe(false);
+  });
+
+  it('claims the pointer while the clip mask is being drawn', async () => {
+    const user = userEvent.setup();
+    renderPanel();
+    await startDrawing(user);
+    expect(useMapDrawStore.getState().drawActive).toBe(true);
+  });
+
+  it('releases the pointer when the polygon is finished', async () => {
+    const user = userEvent.setup();
+    renderPanel();
+    await startDrawing(user);
+    expect(useMapDrawStore.getState().drawActive).toBe(true);
+
+    // The regression that per-call-site updates would miss: finish keeps the
+    // TerraDraw instance alive in static mode instead of calling stopDrawing,
+    // so clicks must start resolving features again without a stop().
+    act(() => finishRef.current?.('feature-1'));
+    expect(setModeSpy).toHaveBeenCalledWith('static');
+    expect(stopSpy).not.toHaveBeenCalled();
+    expect(useMapDrawStore.getState().drawActive).toBe(false);
+  });
+
+  it('releases the pointer when drawing is cancelled', async () => {
+    const user = userEvent.setup();
+    renderPanel();
+    await startDrawing(user);
+    // By text, not role+name: the panel's <label for="analysis-clip-action">
+    // gives every variant of that button the accessible name "Draw clip area".
+    await user.click(screen.getByText('Cancel'));
+    expect(useMapDrawStore.getState().drawActive).toBe(false);
+  });
+
+  it('releases the pointer when the panel unmounts mid-draw', async () => {
+    const user = userEvent.setup();
+    const { unmount } = renderPanel();
+    await startDrawing(user);
+    expect(useMapDrawStore.getState().drawActive).toBe(true);
+
+    unmount();
+    expect(useMapDrawStore.getState().drawActive).toBe(false);
+  });
+});

--- a/frontend/src/stores/map-draw-store.ts
+++ b/frontend/src/stores/map-draw-store.ts
@@ -1,0 +1,24 @@
+import { create } from 'zustand';
+
+/**
+ * fix(#726): whether a builder draw mode currently owns the map pointer.
+ *
+ * The analysis clip mask runs its own TerraDraw instance over the live map
+ * (AnalysisPanel). A vertex click places its vertex and then falls through to
+ * BuilderMap's click handler, which resolves the feature under the cursor and
+ * opens its popup — so drawing a five-point mask left five popups behind, the
+ * last one sitting on top of the result.
+ *
+ * Deliberately separate from `drawing-store`, which is dataset-edit-specific:
+ * its `setDrawing` requires a target dataset, table, and geometry type that an
+ * analysis mask has none of.
+ */
+interface MapDrawState {
+  drawActive: boolean;
+  setDrawActive: (active: boolean) => void;
+}
+
+export const useMapDrawStore = create<MapDrawState>()((set) => ({
+  drawActive: false,
+  setDrawActive: (drawActive) => set({ drawActive }),
+}));


### PR DESCRIPTION
Closes #726.

## The bug

Drawing a clip mask over a dense layer left a trail of popups behind it, and the last one sat on top of the clip result for the rest of the session. Found while filming the 1.5 analysis demo, which had to work around it by disabling popups on the source layer.

A vertex click did double duty: TerraDraw placed the vertex, and the same click then fell through to `BuilderMap`'s handler, which resolved the feature under the cursor and opened its popup. `BuilderMap` had no awareness of an active draw mode, because `AnalysisPanel` owns its TerraDraw instance directly.

## The fix

A one-flag `map-draw-store` for "a draw mode owns the pointer". `AnalysisPanel` raises it; `BuilderMap`'s click, mousemove, and keydown handlers bail on it exactly as they already do for the measurement plugin (`measureActiveRef`, same ref-and-subscribe shape so toggling does not re-register map handlers). A popup already open is dismissed when drawing starts, since it would otherwise stay parked over the area being drawn.

Two decisions worth flagging:

**The flag mirrors `isDrawing` from a single effect** rather than being set at each transition. The `finish` handler drops TerraDraw to static mode *without* going through `stopDrawing`, so per-call-site updates would have left the flag stuck on after a completed polygon and silently killed feature clicks. There is a test for that specific path.

**Kept separate from the existing `drawing-store`,** which is dataset-edit-specific: its `setDrawing` requires a target dataset, table, and geometry type that an analysis mask has none of. That is also why `AnalysisPanel` did not reuse it originally.

## Verification

Five tests in `AnalysisPanel.draw-suppression.test.tsx` covering the full lifecycle: inactive at rest, active while drawing, released on finish (without a `stop()`), released on cancel, released on unmount mid-draw.

Confirmed the tests fail against the unfixed code: sabotaging the effect to always write `false` fails 3 of the 5.

Local gates: `npm run lint`, `npm run typecheck`, and the builder plus store suites (94 files, 1386 tests) all pass.

## Note, not fixed here

While testing I found the panel's `<label for="analysis-clip-action">` gives every variant of that button the accessible name "Draw clip area", so the Cancel and Clear buttons both announce as "Draw clip area". Pre-existing and out of scope for this fix; happy to file it separately.