### PR TITLE
chore(release): bump every version site to 1.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and releases use semantic versioning.
 
 ## [Unreleased]
 
+## [1.5.0] - 2026-07-26
+
 ### Added
 
 - **Spatial analysis in the map builder: buffer, centroid, clip, and dissolve.**
@@ -1141,7 +1143,8 @@ regression-covered fixes:
 - Initial public release of the GeoLens catalog, API, map builder, CLI, SDKs,
   Docker development stack, and public documentation entrypoints.
 
-[Unreleased]: https://github.com/geolens-io/geolens/compare/v1.4.13...HEAD
+[Unreleased]: https://github.com/geolens-io/geolens/compare/v1.5.0...HEAD
+[1.5.0]: https://github.com/geolens-io/geolens/compare/v1.4.13...v1.5.0
 [1.4.13]: https://github.com/geolens-io/geolens/compare/v1.4.12...v1.4.13
 [1.4.12]: https://github.com/geolens-io/geolens/compare/v1.4.11...v1.4.12
 [1.4.11]: https://github.com/geolens-io/geolens/compare/v1.4.10...v1.4.11

--- a/backend/app/api/main.py
+++ b/backend/app/api/main.py
@@ -568,7 +568,7 @@ _is_production = settings.is_production
 # no metadata to read. We fall back to the current published line so import never
 # crashes. Keep this fallback in lockstep with backend/pyproject.toml — it is one
 # of the sites `make bump` rewrites.
-_FALLBACK_APP_VERSION = "1.4.13"
+_FALLBACK_APP_VERSION = "1.5.0"
 
 
 def _resolve_app_version() -> str:

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -17488,7 +17488,7 @@
     "summary": "PostGIS-native geospatial data catalog with OGC API Features and Records support",
     "termsOfService": "https://github.com/geolens-io/geolens/blob/main/LICENSE",
     "title": "GeoLens API",
-    "version": "1.4.13"
+    "version": "1.5.0"
   },
   "openapi": "3.1.0",
   "paths": {

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geolens-backend"
-version = "1.4.13"
+version = "1.5.0"
 description = "PostGIS-native GIS data catalog"
 # Docker image (Dockerfile) ships python:3.14-slim (see the Dockerfile FROM for
 # the exact patch pin) as the project's tested runtime.

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -865,7 +865,7 @@ wheels = [
 
 [[package]]
 name = "geolens-backend"
-version = "1.4.13"
+version = "1.5.0"
 source = { virtual = "." }
 dependencies = [
     { name = "alembic" },

--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "geolens-cli"
-version = "1.4.13"
+version = "1.5.0"
 description = "Apache-2.0 command-line interface for the GeoLens API. Login, scan, publish, and export STAC against any GeoLens instance."
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/docs-contract.json
+++ b/docs-contract.json
@@ -1,6 +1,6 @@
 {
   "_comment": "Canonical cross-surface facts for the GeoLens README, marketing site (getgeolens.com/src), and docs site (getgeolens.com/docs). Validated against scripts/install.sh + backend/pyproject.toml by scripts/check_docs_contract.py (geolens CI). The getgeolens.com repo vendors a copy and enforces the same `forbidden` list in its own CI. See docs-internal/DOC-CONSISTENCY-STRATEGY for the full design. Edit a fact ONCE here (and in its canonical source) — the gates make every surface follow.",
-  "version": "1.4.13",
+  "version": "1.5.0",
   "install": {
     "oneLiner": "curl -fsSL https://getgeolens.com/install.sh | sh",
     "sourceBuild": "bash scripts/install.sh",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.4.13",
+  "version": "1.5.0",
   "type": "module",
   "license": "Apache-2.0",
   "author": "Carto Concepts, LLC",

--- a/mcp/pyproject.toml
+++ b/mcp/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "geolens-mcp"
-version = "1.4.13"
+version = "1.5.0"
 description = "Apache-2.0 read-only Model Context Protocol (MCP) server for GeoLens. Lets coding agents discover datasets, inspect schemas, and ask spatial questions against any GeoLens instance."
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "geolens",
-  "version": "1.4.13",
+  "version": "1.5.0",
   "private": true,
   "license": "Apache-2.0",
   "author": "Carto Concepts, LLC",

--- a/sdks/python/.openapi-python-client.yaml
+++ b/sdks/python/.openapi-python-client.yaml
@@ -4,7 +4,7 @@ project_name_override: geolens
 package_name_override: geolens
 # Rewritten on every `make sdks` run by scripts/sync_sdk_versions.py to match
 # backend/openapi.json info.version. Do not edit by hand.
-package_version_override: 1.4.13
+package_version_override: 1.5.0
 
 # Cleaner enum output (matches our pydantic v2 backend's enum emission).
 literal_enums: true

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "geolens"
-version = "1.4.13"
+version = "1.5.0"
 description = "Auto-generated Python SDK for the GeoLens API. Typed clients with Bearer + API-key auth helpers."
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/sdks/typescript/package-lock.json
+++ b/sdks/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@geolens/sdk",
-  "version": "1.4.13",
+  "version": "1.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@geolens/sdk",
-      "version": "1.4.13",
+      "version": "1.5.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@hey-api/client-fetch": "0.13.1"

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@geolens/sdk",
-  "version": "1.4.13",
+  "version": "1.5.0",
   "description": "Auto-generated TypeScript SDK for the GeoLens API. Typed clients with Bearer + API-key auth helpers.",
   "license": "Apache-2.0",
   "author": "Carto Concepts, LLC",


### PR DESCRIPTION
**Draft on purpose.** It must not merge ahead of #729, and nothing here should be tagged yet.

## What

`make bump VERSION=1.5.0` across all 10 coherence-gated sites plus `docs-contract.json`, and closes the CHANGELOG's `## [Unreleased]` section as `## [1.5.0] - 2026-07-26`.

No source changes. Version strings and the CHANGELOG header only.

## The header is load-bearing

`release.yml:68` extracts the release notes with `awk "/^## \[${VERSION}\]/..."` and **silently falls back to git log** if it matches nothing. That fallback is worse than raw commit subjects: its own `grep -v "^- chore("` would delete the PostgreSQL 18 entry, publishing a database major upgrade with no release note at all.

Simulated the extraction against this CHANGELOG:

```
extracted lines: 120        (starts at ### Added, stops at the 1.4.13 boundary)
BREAKING (self-hosted):  1  (PG18 entry present)
```

Link refs repointed: `[Unreleased]` now spans `v1.5.0...HEAD`, and `[1.5.0]` compares `v1.4.13...v1.5.0`.

## Verification

- `make version-check`: all 10 sites agree on 1.5.0, `## [1.5.0]` section present (112 lines).
- `make openapi-check`: clean.
- `make sdks-check`: clean against the committed state, SDK tests 4/4. Regeneration produced version strings and nothing else, so there is **no API surface drift** in this release's generated clients.

## Blocked on

- **#729** (the #726 draw-popup fix) should merge first. It edits the CHANGELOG's `### Fixed` list, and its entry belongs inside this `## [1.5.0]` section. This branch needs a rebase after that lands.

## Not in scope

No tag. Tagging is a separate, deliberate step and the owner's call.

After the tag, two follow-ups: the demo VM is still on 1.4.13 and should be redeployed before the docs site and the analysis video go public, and `docs/src/content/openapi/geolens.json` in getgeolens.com needs syncing to 1.5.0 (it is pinned at 1.4.13, which predates the analysis endpoints).