### PR TITLE
fix(docker): bump the uv installer pin to 0.11.32 to clear GHSA-4w2j-m93h-cj5j

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ FROM python:3.14.6-slim AS backend-builder
 
 # uv is build-time + runtime: see runtime-stage comment below for runtime rationale.
 # Aligned uv installer pin across builder + runtime stages.
-COPY --from=ghcr.io/astral-sh/uv:0.11.11 /uv /uvx /bin/
+COPY --from=ghcr.io/astral-sh/uv:0.11.32 /uv /uvx /bin/
 
 WORKDIR /app
 
@@ -120,7 +120,7 @@ FROM python:3.14.6-slim AS backend-base
 
 # uv kept for `uv run --no-dev` launch pattern (entrypoints + CMD).
 # Aligned uv installer pin across builder + runtime stages.
-COPY --from=ghcr.io/astral-sh/uv:0.11.11 /uv /uvx /bin/
+COPY --from=ghcr.io/astral-sh/uv:0.11.32 /uv /uvx /bin/
 
 # Runtime apt deps — clean install on a fresh layer (no apt cache from builder).
 RUN apt-get update && apt-get upgrade -y --no-install-recommends && \


### PR DESCRIPTION
## Why

The v1.5.0 tag's Publish Images run failed on the Trivy image-scan gate for `geolens-api` and `geolens-worker`: the `uv`/`uvx` binaries baked into the image statically link **quinn-proto 0.11.14**, flagged HIGH by **GHSA-4w2j-m93h-cj5j** (remote memory exhaustion via unbounded out-of-order QUIC stream reassembly; published 2026-07-24 — after the current `0.11.11` pin). Prod Compose Smoke failed downstream (nothing to pull) and the Release run correctly skipped, so no GitHub Release was created.

## What

Bump the aligned uv pin `0.11.11` → `0.11.32` in both stages of the root `Dockerfile`. uv `0.11.31`+ links the patched **quinn-proto 0.11.15** (verified in upstream `Cargo.lock` for 0.11.31 and 0.11.32); the GHCR tag exists and the frontend/backup targets are unaffected. A real fix, so no `.trivyignore.yaml` entry is needed.

## After merge

The `v1.5.0` tag will be moved to include this commit and re-pushed to re-run the publish → smoke → release chain. Safe because the failed attempt created no GitHub Release and the re-run overwrites the two image tags (frontend/backup) the failed attempt had already pushed.