### PR TITLE
fix(analysis): enforce export capability on materialize and harden column handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,24 @@ and releases use semantic versioning.
   was a dead end whose hint named an invisible button. The clip mask picker
   also says "No polygon layers on this map" instead of showing a lone "None"
   entry. (#779)
+- **Analysis outputs now keep every attribute column.** Columns whose names
+  are not identifier-shaped (`Área`, `2020_pop`, `my field`) were silently
+  dropped from buffer, centroid, and clip outputs; they are now carried
+  through intact. (#763)
+- **Dissolving by a non-groupable column is refused up front.** A `json`
+  column (how nested GeoJSON attributes ingest) used to enqueue, wait out
+  the queue, and fail with a generic database error; the request is now
+  rejected immediately with the column named, and schema-shaped failures
+  that do reach the worker report "a column can't be used for this
+  operation" instead of "database error". (#766)
+
+### Changed
+
+- **Creating a dataset from an analysis now requires the `export`
+  capability in addition to `upload`,** matching the download endpoints —
+  the result is a caller-owned copy of the source's attributes, so the two
+  paths now agree under a customized role matrix. Installations using the
+  default role matrix are unaffected (editor and admin hold both).
 
 ## [1.5.0] - 2026-07-26
 

--- a/backend/app/modules/catalog/datasets/api/router_analysis.py
+++ b/backend/app/modules/catalog/datasets/api/router_analysis.py
@@ -44,6 +44,12 @@ router = APIRouter(
 
 _SAFE_COLUMN_RE = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_]*$")
 
+# fix(#766): PostgreSQL has no equality operator for these types, so a
+# dissolve GROUP BY on such a column fails the CTAS with an opaque 42883
+# after the queue wait. GDAL maps nested GeoJSON objects to `json`, so
+# real uploads hit this. Rejected at enqueue with the column named.
+_NON_GROUPABLE_TYPES = {"json", "xml"}
+
 # fix(#695): Procrastinate ranks by per-job priority (DESC, default 0), not
 # by queue name — so a 300-second analysis CTAS enqueued first would
 # head-of-line block every upload on the shared single worker. Below-default
@@ -161,6 +167,34 @@ async def analysis_preview_endpoint(
         ) from exc
 
 
+def _validate_dissolve_by_field(dataset, by_field: str) -> None:
+    """422 on an unknown, generated-name-conflicting, or non-groupable column."""
+    known_columns = {col.get("name"): col for col in (dataset.column_info or []) if col}
+    if not _SAFE_COLUMN_RE.match(by_field) or by_field not in known_columns:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail=f"Unknown dissolve column: {by_field!r}",
+        )
+    if by_field == "source_count":
+        # The dissolve output already emits a generated source_count
+        # column; carrying a same-named group key would fail the CTAS
+        # with an opaque "column specified more than once".
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail="by_field conflicts with the generated 'source_count' column",
+        )
+    by_field_type = str(known_columns[by_field].get("type") or "").lower()
+    if by_field_type in _NON_GROUPABLE_TYPES:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail=(
+                f"Column {by_field!r} has type '{by_field_type}' "
+                "and can't be used to group features. Choose a column "
+                "with comparable values."
+            ),
+        )
+
+
 @router.post(
     "/{dataset_id}/analysis/materialize/",
     response_model=AnalysisMaterializeResponse,
@@ -170,16 +204,21 @@ async def analysis_materialize_endpoint(
     body: AnalysisMaterializeRequest,
     request: Request,
     # fix(#692): materialize creates a dataset, so it carries the same
-    # permission as every ingest endpoint that creates one. Preview stays on
-    # the plain active-user dependency: it is read-only, persists nothing,
-    # and the chat tool's read-only surface depends on it.
-    user: Identity = Depends(require_permission("upload")),
+    # permission as every ingest endpoint that creates one. It also hands the
+    # caller a durable, caller-owned copy of the source attributes (a
+    # centroid materialize preserves every column), which is the outcome the
+    # download endpoints gate on `export` — so it requires that capability
+    # too, keeping the two paths consistent under a customized role matrix.
+    # Preview stays on the plain active-user dependency: it is read-only,
+    # persists nothing, and the chat tool's read-only surface depends on it.
+    user: Identity = Depends(require_permission("upload", "export")),
     db: AsyncSession = Depends(get_db),
 ) -> AnalysisMaterializeResponse:
     """Materialize an analysis result as a new private dataset (async job).
 
-    Requires the ``upload`` permission (this endpoint creates a dataset) and
-    read visibility on the source dataset; the new dataset is owned by the
+    Requires the ``upload`` and ``export`` permissions (this endpoint
+    creates a dataset that carries the source's attributes) and read
+    visibility on the source dataset; the new dataset is owned by the
     caller and counted against their dataset quota (the atomic slot
     reservation runs at registration inside the worker). Poll
     ``GET /jobs/{job_id}`` for progress.
@@ -212,23 +251,7 @@ async def analysis_materialize_endpoint(
                 status_code=status.HTTP_422_UNPROCESSABLE_CONTENT, detail=str(exc)
             ) from exc
     if body.operation == "dissolve" and body.by_field is not None:
-        known_columns = {col.get("name") for col in (dataset.column_info or []) if col}
-        if (
-            not _SAFE_COLUMN_RE.match(body.by_field)
-            or body.by_field not in known_columns
-        ):
-            raise HTTPException(
-                status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
-                detail=f"Unknown dissolve column: {body.by_field!r}",
-            )
-        if body.by_field == "source_count":
-            # The dissolve output already emits a generated source_count
-            # column; carrying a same-named group key would fail the CTAS
-            # with an opaque "column specified more than once".
-            raise HTTPException(
-                status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
-                detail="by_field conflicts with the generated 'source_count' column",
-            )
+        _validate_dissolve_by_field(dataset, body.by_field)
 
     # Best-effort dataset-count pre-check; the authoritative atomic
     # reservation happens at registration time in the worker.

--- a/backend/app/processing/analysis/tasks.py
+++ b/backend/app/processing/analysis/tasks.py
@@ -43,6 +43,7 @@ from app.platform.jobs.heartbeat import (
     stop_ingest_job_heartbeat,
     update_ingest_job_for_attempt,
 )
+from app.processing.ingest.metadata import _sql_quote_ident
 from app.processing.ingest.tasks import task_app
 
 logger = structlog.stdlib.get_logger(__name__)
@@ -96,12 +97,16 @@ def _user_error_message(exc: Exception) -> str:
             )
         if isinstance(exc, (DataError, InternalError)):
             return "The analysis failed while processing this data"
-        # fix(#766): SQLSTATE class 42 is a schema-shaped failure (e.g.
-        # 42883 "no equality operator for type json" on a dissolve GROUP
-        # BY) — the parameters, not the data, are the problem.
+        # fix(#766): only the SQLSTATEs that mean "this column/type
+        # combination can't do this operation": 42883 undefined_function
+        # (e.g. no equality operator for `json` in a dissolve GROUP BY),
+        # 42803 grouping_error, 42804 datatype_mismatch. Deliberately NOT
+        # the whole class 42 — 42501 (privilege), 42P01 (missing table),
+        # and 42601 (syntax) are server or configuration faults and must
+        # keep reporting as the generic database error.
         if isinstance(exc, ProgrammingError) and str(
             getattr(exc.orig, "sqlstate", "") or ""
-        ).startswith("42"):
+        ) in ("42883", "42803", "42804"):
             return (
                 "A column in this dataset can't be used for this "
                 "operation. Try a different column."
@@ -273,15 +278,6 @@ async def _mark_job_failed(
     ANALYSIS_JOBS.labels(operation=operation, status="failed").inc()
 
 
-def _quote_ident(name: str) -> str:
-    """Render a PostgreSQL quoted identifier.
-
-    Names come from ``information_schema``, never the request, so doubling
-    embedded double quotes is the only escaping identifiers need.
-    """
-    return '"' + name.replace('"', '""') + '"'
-
-
 async def _list_carry_columns(
     session: AsyncSession, schema: str, table_name: str
 ) -> list[str]:
@@ -290,7 +286,9 @@ async def _list_carry_columns(
     fix(#763): every name is carried — GDAL launders only case/`-`/`#`, so
     ingested tables legitimately hold columns like ``Área`` or ``2020_pop``;
     filtering to identifier-shaped names silently dropped them from every
-    analysis output. Rendering quotes via ``_quote_ident`` instead.
+    analysis output. Rendering quotes via ``_sql_quote_ident``, whose
+    colon escape also keeps Socrata-style ``:id`` columns from being parsed
+    as bind parameters by ``text()``.
     """
     rows = await session.execute(
         text(
@@ -348,7 +346,7 @@ def _build_materialize_select(
         # the dataset it would have saved is small. Clip has no source-feature
         # cap, so nothing else bounds how many of them there are.
         cte, lateral, where = render_clip_layer_join(mask_table_ref, src="_src")
-        cols = "".join(f"_src.{_quote_ident(c)}, " for c in carry_cols)
+        cols = "".join(f"_src.{_sql_quote_ident(c)}, " for c in carry_cols)
         return (
             f"{cte} SELECT _src.gid, {cols}_op.geom_out AS geom"
             f" FROM {src_ref} AS _src"
@@ -360,7 +358,7 @@ def _build_materialize_select(
         distance_meters=distance_meters,
         mask=mask,
     )
-    cols = "".join(f"{_quote_ident(c)}, " for c in carry_cols)
+    cols = "".join(f"{_sql_quote_ident(c)}, " for c in carry_cols)
     return f"SELECT gid, {cols}{expr} AS geom FROM {src_ref}{where}"
 
 

--- a/backend/app/processing/analysis/tasks.py
+++ b/backend/app/processing/analysis/tasks.py
@@ -18,7 +18,12 @@ from typing import Any
 import structlog
 from prometheus_client import Counter
 from sqlalchemy import select, text
-from sqlalchemy.exc import DataError, InternalError, SQLAlchemyError
+from sqlalchemy.exc import (
+    DataError,
+    InternalError,
+    ProgrammingError,
+    SQLAlchemyError,
+)
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.db.tenant_schema import tenant_data_schema
@@ -91,6 +96,16 @@ def _user_error_message(exc: Exception) -> str:
             )
         if isinstance(exc, (DataError, InternalError)):
             return "The analysis failed while processing this data"
+        # fix(#766): SQLSTATE class 42 is a schema-shaped failure (e.g.
+        # 42883 "no equality operator for type json" on a dissolve GROUP
+        # BY) — the parameters, not the data, are the problem.
+        if isinstance(exc, ProgrammingError) and str(
+            getattr(exc.orig, "sqlstate", "") or ""
+        ).startswith("42"):
+            return (
+                "A column in this dataset can't be used for this "
+                "operation. Try a different column."
+            )
         return "The analysis failed due to a database error"
     return str(exc)[:2000]
 
@@ -258,10 +273,25 @@ async def _mark_job_failed(
     ANALYSIS_JOBS.labels(operation=operation, status="failed").inc()
 
 
+def _quote_ident(name: str) -> str:
+    """Render a PostgreSQL quoted identifier.
+
+    Names come from ``information_schema``, never the request, so doubling
+    embedded double quotes is the only escaping identifiers need.
+    """
+    return '"' + name.replace('"', '""') + '"'
+
+
 async def _list_carry_columns(
     session: AsyncSession, schema: str, table_name: str
 ) -> list[str]:
-    """Attribute columns to carry into 1:1 op output (skip system/geom cols)."""
+    """Attribute columns to carry into 1:1 op output (skip system/geom cols).
+
+    fix(#763): every name is carried — GDAL launders only case/`-`/`#`, so
+    ingested tables legitimately hold columns like ``Área`` or ``2020_pop``;
+    filtering to identifier-shaped names silently dropped them from every
+    analysis output. Rendering quotes via ``_quote_ident`` instead.
+    """
     rows = await session.execute(
         text(
             "SELECT column_name FROM information_schema.columns "
@@ -270,7 +300,7 @@ async def _list_carry_columns(
             "ORDER BY ordinal_position"
         ).bindparams(schema=schema, table_name=table_name)
     )
-    return [row[0] for row in rows if _SAFE_IDENT.match(row[0])]
+    return [row[0] for row in rows]
 
 
 def _build_materialize_select(
@@ -318,7 +348,7 @@ def _build_materialize_select(
         # the dataset it would have saved is small. Clip has no source-feature
         # cap, so nothing else bounds how many of them there are.
         cte, lateral, where = render_clip_layer_join(mask_table_ref, src="_src")
-        cols = "".join(f'_src."{c}", ' for c in carry_cols)
+        cols = "".join(f"_src.{_quote_ident(c)}, " for c in carry_cols)
         return (
             f"{cte} SELECT _src.gid, {cols}_op.geom_out AS geom"
             f" FROM {src_ref} AS _src"
@@ -330,7 +360,7 @@ def _build_materialize_select(
         distance_meters=distance_meters,
         mask=mask,
     )
-    cols = "".join(f'"{c}", ' for c in carry_cols)
+    cols = "".join(f"{_quote_ident(c)}, " for c in carry_cols)
     return f"SELECT gid, {cols}{expr} AS geom FROM {src_ref}{where}"
 
 

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -30641,7 +30641,7 @@
     },
     "/datasets/{dataset_id}/analysis/materialize/": {
       "post": {
-        "description": "Materialize an analysis result as a new private dataset (async job).\n\nRequires the ``upload`` permission (this endpoint creates a dataset) and\nread visibility on the source dataset; the new dataset is owned by the\ncaller and counted against their dataset quota (the atomic slot\nreservation runs at registration inside the worker). Poll\n``GET /jobs/{job_id}`` for progress.",
+        "description": "Materialize an analysis result as a new private dataset (async job).\n\nRequires the ``upload`` and ``export`` permissions (this endpoint\ncreates a dataset that carries the source's attributes) and read\nvisibility on the source dataset; the new dataset is owned by the\ncaller and counted against their dataset quota (the atomic slot\nreservation runs at registration inside the worker). Poll\n``GET /jobs/{job_id}`` for progress.",
         "operationId": "analysis_materialize_endpoint_datasets__dataset_id__analysis_materialize__post",
         "parameters": [
           {

--- a/backend/tests/test_analysis_materialize.py
+++ b/backend/tests/test_analysis_materialize.py
@@ -25,8 +25,13 @@ from app.processing.analysis.tasks import (
     _user_error_message,
 )
 
-from tests.factories import get_user_id
+from tests.factories import create_dataset, get_user_id
 from tests.test_analysis_preview import _create_mask_dataset, _create_polygon_dataset
+from tests.test_export_hardening import (
+    _DEFAULT_PERMISSION_MATRIX,
+    _put_permission_matrix,
+    _reset_permission_matrix,
+)
 
 
 def _materialize_url(dataset_id) -> str:
@@ -285,6 +290,35 @@ class TestMaterializeEndpoint:
         )
         assert resp.status_code == 404
 
+    async def test_materialize_private_mask_hidden(
+        self,
+        client: AsyncClient,
+        editor_auth_header: dict,
+        test_db_session: AsyncSession,
+    ):
+        """test(#761): Rule 1 applies to the MASK dataset on the write path
+        too. The preview suite pins this; the materialize branch sits between
+        two size gates that were each rewritten twice in two weeks (#693,
+        #701) and had no test of its own."""
+        admin_id = await get_user_id(test_db_session, "admin")
+        ds = await _create_polygon_dataset(test_db_session, created_by=admin_id)
+        private_mask = await _create_mask_dataset(
+            test_db_session,
+            created_by=admin_id,
+            wkt="POLYGON((-1 -1, -1 1, 1 1, 1 -1, -1 -1))",
+            visibility="private",
+        )
+        resp = await client.post(
+            _materialize_url(ds.id),
+            json={
+                "operation": "clip",
+                "mask_dataset_id": str(private_mask.id),
+                "title": "Nope",
+            },
+            headers=editor_auth_header,
+        )
+        assert resp.status_code == 404
+
     async def test_materialize_requires_upload_permission(
         self,
         client: AsyncClient,
@@ -311,6 +345,35 @@ class TestMaterializeEndpoint:
         )
         assert preview.status_code == 200, preview.text
 
+    async def test_materialize_requires_export_permission(
+        self,
+        client: AsyncClient,
+        admin_auth_header: dict,
+        editor_auth_header: dict,
+        test_db_session: AsyncSession,
+    ):
+        """Materialize hands the caller an owned dataset carrying the
+        source's attributes — the outcome the download endpoints gate on
+        `export` — so the two paths must agree under a customized role
+        matrix: an editor whose export was revoked gets 403, not a job."""
+        admin_id = await get_user_id(test_db_session, "admin")
+        ds = await _create_polygon_dataset(test_db_session, created_by=admin_id)
+        revoked = {
+            **_DEFAULT_PERMISSION_MATRIX,
+            "editor": {**_DEFAULT_PERMISSION_MATRIX["editor"], "export": False},
+        }
+        try:
+            await _put_permission_matrix(client, admin_auth_header, revoked)
+            resp = await client.post(
+                _materialize_url(ds.id),
+                json={"operation": "centroid", "title": "Not allowed"},
+                headers=editor_auth_header,
+            )
+            assert resp.status_code == 403, resp.text
+            assert "export" in resp.json()["detail"].lower()
+        finally:
+            await _reset_permission_matrix(client, admin_auth_header)
+
     async def test_dissolve_unknown_column_rejected(
         self,
         client: AsyncClient,
@@ -329,6 +392,37 @@ class TestMaterializeEndpoint:
             headers=admin_auth_header,
         )
         assert resp.status_code == 422
+
+    async def test_dissolve_json_column_rejected_at_enqueue(
+        self,
+        client: AsyncClient,
+        admin_auth_header: dict,
+        test_db_session: AsyncSession,
+    ):
+        """fix(#766): PG has no equality operator for `json` (GDAL maps
+        nested GeoJSON objects to it), so the CTAS GROUP BY would burn the
+        queue wait and the per-user job slot on an opaque 42883. Reject at
+        enqueue, naming the column."""
+        admin_id = await get_user_id(test_db_session, "admin")
+        ds = await create_dataset(
+            test_db_session,
+            created_by=admin_id,
+            geometry_type="POLYGON",
+            feature_count=2,
+            column_info=[
+                {"name": "props", "type": "json"},
+                {"name": "name", "type": "text"},
+            ],
+        )
+        resp = await client.post(
+            _materialize_url(ds.id),
+            json={"operation": "dissolve", "by_field": "props", "title": "Grouped"},
+            headers=admin_auth_header,
+        )
+        assert resp.status_code == 422
+        detail = resp.json()["detail"]
+        assert "props" in detail
+        assert "group" in detail.lower()
 
     async def test_materialize_requires_title(
         self,
@@ -616,6 +710,57 @@ class TestMaterializeWorker:
             )
         ).scalar_one()
         assert name_count == 2
+
+    async def test_non_identifier_columns_survive_materialize(
+        self,
+        test_db_session: AsyncSession,
+    ):
+        """fix(#763): GDAL launders only case/`-`/`#`, so ingested tables
+        legitimately carry columns like `Área` or `2020_pop`; the old
+        identifier-shaped filter silently dropped them from every analysis
+        output."""
+        admin_id = await get_user_id(test_db_session, "admin")
+        ds = await _create_polygon_dataset(test_db_session, created_by=admin_id)
+        await test_db_session.execute(
+            text(
+                f"ALTER TABLE data.{ds.table_name} "
+                f'ADD COLUMN "Área" TEXT, ADD COLUMN "2020_pop" INTEGER'
+            )
+        )
+        await test_db_session.execute(
+            text(
+                f"UPDATE data.{ds.table_name} "  # noqa: S608
+                f'SET "Área" = \'norte\', "2020_pop" = 7'
+            )
+        )
+        await test_db_session.commit()
+        job = await _create_job(test_db_session, admin_id)
+
+        await _materialize(
+            job_id=str(job.id),
+            dataset_id=str(ds.id),
+            user_id=str(admin_id),
+            operation="buffer",
+            title=f"Buffered unicode {uuid.uuid4().hex[:6]}",
+            distance_meters=100,
+        )
+
+        await test_db_session.refresh(job)
+        assert job.status == "complete", job.error_message
+
+        from app.modules.catalog.datasets.domain.models import Dataset
+
+        new_ds = await test_db_session.get(Dataset, job.dataset_id)
+        rows = (
+            await test_db_session.execute(
+                text(
+                    f'SELECT "Área", "2020_pop" '  # noqa: S608
+                    f"FROM data.{new_ds.table_name}"
+                )
+            )
+        ).all()
+        assert len(rows) == 2
+        assert all(tuple(row) == ("norte", 7) for row in rows)
 
     async def test_null_geometry_rows_are_dropped_from_output(
         self,
@@ -1778,6 +1923,22 @@ class TestUserErrorMessage:
             'CREATE TABLE "data"."secret_output" AS SELECT 1', {}, Exception("boom")
         )
         msg = _user_error_message(exc)
+        assert "secret_output" not in msg
+        assert "CREATE TABLE" not in msg
+
+    def test_sqlstate_42_is_named_a_column_problem(self):
+        """fix(#766): SQLSTATE class 42 (e.g. no equality operator for
+        `json` in a dissolve GROUP BY) is a parameter problem, not a
+        generic database error — say so, without leaking the SQL."""
+        from sqlalchemy.exc import ProgrammingError
+
+        orig = Exception("could not identify an equality operator for type json")
+        orig.sqlstate = "42883"
+        exc = ProgrammingError(
+            'CREATE TABLE "data"."secret_output" AS SELECT 1', {}, orig
+        )
+        msg = _user_error_message(exc)
+        assert "column" in msg.lower()
         assert "secret_output" not in msg
         assert "CREATE TABLE" not in msg
 

--- a/backend/tests/test_analysis_materialize.py
+++ b/backend/tests/test_analysis_materialize.py
@@ -721,16 +721,20 @@ class TestMaterializeWorker:
         output."""
         admin_id = await get_user_id(test_db_session, "admin")
         ds = await _create_polygon_dataset(test_db_session, created_by=admin_id)
+        # ":id" doubles as the codex-review case: text() parses `:name` as a
+        # bind parameter even inside quoted identifiers, so an unescaped
+        # Socrata-style column would fail the whole CTAS, not just drop out.
         await test_db_session.execute(
             text(
                 f"ALTER TABLE data.{ds.table_name} "
-                f'ADD COLUMN "Área" TEXT, ADD COLUMN "2020_pop" INTEGER'
+                f'ADD COLUMN "Área" TEXT, ADD COLUMN "2020_pop" INTEGER, '
+                f'ADD COLUMN "\\:id" TEXT'
             )
         )
         await test_db_session.execute(
             text(
                 f"UPDATE data.{ds.table_name} "  # noqa: S608
-                f'SET "Área" = \'norte\', "2020_pop" = 7'
+                f'SET "Área" = \'norte\', "2020_pop" = 7, "\\:id" = \'r1\''
             )
         )
         await test_db_session.commit()
@@ -754,13 +758,13 @@ class TestMaterializeWorker:
         rows = (
             await test_db_session.execute(
                 text(
-                    f'SELECT "Área", "2020_pop" '  # noqa: S608
+                    f'SELECT "Área", "2020_pop", "\\:id" '  # noqa: S608
                     f"FROM data.{new_ds.table_name}"
                 )
             )
         ).all()
         assert len(rows) == 2
-        assert all(tuple(row) == ("norte", 7) for row in rows)
+        assert all(tuple(row) == ("norte", 7, "r1") for row in rows)
 
     async def test_null_geometry_rows_are_dropped_from_output(
         self,
@@ -1941,6 +1945,20 @@ class TestUserErrorMessage:
         assert "column" in msg.lower()
         assert "secret_output" not in msg
         assert "CREATE TABLE" not in msg
+
+    def test_other_class_42_states_stay_generic(self):
+        """codex(#791): 42501 (privilege), 42P01 (missing table) and the
+        like are server/configuration faults — mapping them onto "choose a
+        different column" would bury the actionable failure."""
+        from sqlalchemy.exc import ProgrammingError
+
+        for sqlstate in ("42501", "42P01", "42601"):
+            orig = Exception("boom")
+            orig.sqlstate = sqlstate
+            exc = ProgrammingError("CREATE TABLE x AS SELECT 1", {}, orig)
+            assert _user_error_message(exc) == (
+                "The analysis failed due to a database error"
+            ), sqlstate
 
     def test_statement_timeout_is_actionable(self):
         from sqlalchemy.exc import OperationalError

--- a/frontend/src/components/builder/AnalysisPanel.tsx
+++ b/frontend/src/components/builder/AnalysisPanel.tsx
@@ -243,8 +243,11 @@ export function AnalysisPanel({
   // (it creates a dataset); hide the creation half for viewer roles instead
   // of letting them fill the form into a guaranteed 403. Preview stays.
   // Read before the mutations so their callbacks can branch on it too.
+  // The endpoint also requires `export` (the output carries the source's
+  // attributes, matching the download endpoints), so the gate mirrors both —
+  // an upload-only role must not fill the form into a guaranteed 403.
   const { can } = usePermissions();
-  const canCreateDataset = can('upload');
+  const canCreateDataset = can('upload') && can('export');
 
   const distanceValid =
     Number.isFinite(distanceValue) &&

--- a/frontend/src/types/api.generated.ts
+++ b/frontend/src/types/api.generated.ts
@@ -1769,8 +1769,9 @@ export interface paths {
          * Analysis Materialize Endpoint
          * @description Materialize an analysis result as a new private dataset (async job).
          *
-         *     Requires the ``upload`` permission (this endpoint creates a dataset) and
-         *     read visibility on the source dataset; the new dataset is owned by the
+         *     Requires the ``upload`` and ``export`` permissions (this endpoint
+         *     creates a dataset that carries the source's attributes) and read
+         *     visibility on the source dataset; the new dataset is owned by the
          *     caller and counted against their dataset quota (the atomic slot
          *     reservation runs at registration inside the worker). Poll
          *     ``GET /jobs/{job_id}`` for progress.

--- a/sdks/python/geolens/api/datasets_analysis/analysis_materialize_endpoint_datasets_dataset_id_analysis_materialize_post.py
+++ b/sdks/python/geolens/api/datasets_analysis/analysis_materialize_endpoint_datasets_dataset_id_analysis_materialize_post.py
@@ -116,8 +116,9 @@ def sync_detailed(
 
      Materialize an analysis result as a new private dataset (async job).
 
-    Requires the ``upload`` permission (this endpoint creates a dataset) and
-    read visibility on the source dataset; the new dataset is owned by the
+    Requires the ``upload`` and ``export`` permissions (this endpoint
+    creates a dataset that carries the source's attributes) and read
+    visibility on the source dataset; the new dataset is owned by the
     caller and counted against their dataset quota (the atomic slot
     reservation runs at registration inside the worker). Poll
     ``GET /jobs/{job_id}`` for progress.
@@ -157,8 +158,9 @@ def sync(
 
      Materialize an analysis result as a new private dataset (async job).
 
-    Requires the ``upload`` permission (this endpoint creates a dataset) and
-    read visibility on the source dataset; the new dataset is owned by the
+    Requires the ``upload`` and ``export`` permissions (this endpoint
+    creates a dataset that carries the source's attributes) and read
+    visibility on the source dataset; the new dataset is owned by the
     caller and counted against their dataset quota (the atomic slot
     reservation runs at registration inside the worker). Poll
     ``GET /jobs/{job_id}`` for progress.
@@ -193,8 +195,9 @@ async def asyncio_detailed(
 
      Materialize an analysis result as a new private dataset (async job).
 
-    Requires the ``upload`` permission (this endpoint creates a dataset) and
-    read visibility on the source dataset; the new dataset is owned by the
+    Requires the ``upload`` and ``export`` permissions (this endpoint
+    creates a dataset that carries the source's attributes) and read
+    visibility on the source dataset; the new dataset is owned by the
     caller and counted against their dataset quota (the atomic slot
     reservation runs at registration inside the worker). Poll
     ``GET /jobs/{job_id}`` for progress.
@@ -232,8 +235,9 @@ async def asyncio(
 
      Materialize an analysis result as a new private dataset (async job).
 
-    Requires the ``upload`` permission (this endpoint creates a dataset) and
-    read visibility on the source dataset; the new dataset is owned by the
+    Requires the ``upload`` and ``export`` permissions (this endpoint
+    creates a dataset that carries the source's attributes) and read
+    visibility on the source dataset; the new dataset is owned by the
     caller and counted against their dataset quota (the atomic slot
     reservation runs at registration inside the worker). Poll
     ``GET /jobs/{job_id}`` for progress.

--- a/sdks/typescript/src/client/sdk.gen.ts
+++ b/sdks/typescript/src/client/sdk.gen.ts
@@ -1856,8 +1856,9 @@ export const updateDatasetMetadataDatasetsDatasetIdPatch = <ThrowOnError extends
  *
  * Materialize an analysis result as a new private dataset (async job).
  *
- * Requires the ``upload`` permission (this endpoint creates a dataset) and
- * read visibility on the source dataset; the new dataset is owned by the
+ * Requires the ``upload`` and ``export`` permissions (this endpoint
+ * creates a dataset that carries the source's attributes) and read
+ * visibility on the source dataset; the new dataset is owned by the
  * caller and counted against their dataset quota (the atomic slot
  * reservation runs at registration inside the worker). Poll
  * ``GET /jobs/{job_id}`` for progress.


### PR DESCRIPTION
## What

Backend batch for the v1.5.1 milestone (analysis materialize path):

- **Materialize now requires the `export` capability in addition to `upload`.** The output dataset is a caller-owned copy of the source's attributes — the same outcome the download endpoints gate on `export` — so the two paths now agree under a customized role matrix. Default-matrix installs are unaffected (editor/admin hold both capabilities). OpenAPI + generated SDK descriptions regenerated.
- **#763 — analysis outputs keep every attribute column.** `_list_carry_columns` filtered names against an identifier regex, silently dropping columns GDAL legitimately produces (`Área`, `2020_pop`, `my field`). Identifiers are now rendered with quote-escaping (names come from `information_schema`, never the request).
- **#766 — dissolve `by_field` is validated by type at enqueue.** PG has no equality operator for `json`/`xml`, so those columns burned the queue wait + the per-user job slot on an opaque 42883. Also classifies SQLSTATE 42xxx in `_user_error_message` as a column problem instead of a generic database error.
- **#761 — the materialize clip-mask visibility check is now pinned by a test** (private mask, non-owner caller, 404), mirroring the preview suite.

## Impact

- API: materialize 403s for roles granted `upload` but not `export` (non-default matrices only). Documented in CHANGELOG under Changed.
- No schema changes.

## Verification

- `cd backend && uv run ruff check . && uv run ruff format --check .` — clean
- Full backend suite: **5878 passed, 75 skipped** (`pytest -n 4`)
- `make openapi` + `make sdks` regenerated; snapshots committed

Closes #761. Closes #763. Closes #766.