### PR TITLE
fix(builder): keep mid-save edits dirty instead of silently discarding them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and releases use semantic versioning.
 
 ### Fixed
 
+- **Edits made while a save is in flight are no longer silently discarded.**
+  Changing a layer, name, basemap, plugin, or any other map property during
+  the save's network round-trip used to be absorbed into the saved baseline,
+  overwritten on screen by the post-save refresh, and dropped from the
+  unsaved-changes guard. The map now stays marked unsaved until those edits
+  are actually saved. (#756)
 - **The analysis completion notice no longer covers the panel's own "Add to
   map" button.** In the builder it now appears top-center, clear of the right
   rail; elsewhere it keeps the usual corner. (#725)

--- a/frontend/src/components/builder/hooks/__tests__/use-builder-save.test.ts
+++ b/frontend/src/components/builder/hooks/__tests__/use-builder-save.test.ts
@@ -482,6 +482,38 @@ describe('useBuilderSave', () => {
     expect(setHasUnsavedChanges).not.toHaveBeenCalledWith(false);
   });
 
+  it('codex(#792): keeps the dirty flag when a plugin toggles while the save is in flight', async () => {
+    let resolvePatch!: (v: unknown) => void;
+    mockPatchMapLayersMutateAsync.mockImplementationOnce(
+      () => new Promise((resolve) => { resolvePatch = resolve; }),
+    );
+    const setHasUnsavedChanges = vi.fn();
+    const state = makeSaveState({
+      localLayers: [makeLayer()],
+      hasUnsavedChanges: true,
+      setHasUnsavedChanges,
+    });
+    const { result } = renderHook(() => useBuilderSave(state));
+
+    let savePromise!: Promise<void>;
+    act(() => {
+      savePromise = result.current.handleSave();
+    });
+
+    // The plugins payload reads usePluginStore directly, not SaveState — a
+    // mid-save toggle must keep the map dirty or the toggle never persists.
+    act(() => {
+      usePluginStore.getState().toggle('legend');
+    });
+
+    await act(async () => {
+      resolvePatch({});
+      await savePromise;
+    });
+
+    expect(setHasUnsavedChanges).not.toHaveBeenCalledWith(false);
+  });
+
   it('fix(#756): still clears the dirty flag when nothing changed during the save', async () => {
     const setHasUnsavedChanges = vi.fn();
     const state = makeSaveState({

--- a/frontend/src/components/builder/hooks/__tests__/use-builder-save.test.ts
+++ b/frontend/src/components/builder/hooks/__tests__/use-builder-save.test.ts
@@ -444,6 +444,60 @@ describe('useBuilderSave', () => {
     expect(state.setHasUnsavedChanges).toHaveBeenCalledWith(false);
   });
 
+  it('fix(#756): keeps the dirty flag when an edit lands while the save is in flight', async () => {
+    // The added-layer PATCH is handleSave's first await; deferring it holds
+    // the save in flight while the test lands an edit.
+    let resolvePatch!: (v: unknown) => void;
+    mockPatchMapLayersMutateAsync.mockImplementationOnce(
+      () => new Promise((resolve) => { resolvePatch = resolve; }),
+    );
+    const setHasUnsavedChanges = vi.fn();
+    let state = makeSaveState({
+      localLayers: [makeLayer()],
+      hasUnsavedChanges: true,
+      setHasUnsavedChanges,
+    });
+    const { result, rerender } = renderHook(() => useBuilderSave(state));
+
+    let savePromise!: Promise<void>;
+    act(() => {
+      savePromise = result.current.handleSave();
+    });
+
+    // An edit lands while the network round-trip is still awaiting: the
+    // dirty flag must survive the save, or the baseline effect absorbs the
+    // edit and the query-invalidation resync overwrites it on screen.
+    state = makeSaveState({
+      localLayers: [makeLayer({ paint: { 'fill-color': '#ff0000' } })],
+      hasUnsavedChanges: true,
+      setHasUnsavedChanges,
+    });
+    rerender();
+
+    await act(async () => {
+      resolvePatch({});
+      await savePromise;
+    });
+
+    expect(setHasUnsavedChanges).not.toHaveBeenCalledWith(false);
+  });
+
+  it('fix(#756): still clears the dirty flag when nothing changed during the save', async () => {
+    const setHasUnsavedChanges = vi.fn();
+    const state = makeSaveState({
+      localLayers: [makeLayer()],
+      hasUnsavedChanges: true,
+      setHasUnsavedChanges,
+    });
+    const { result } = renderHook(() => useBuilderSave(state));
+
+    await act(async () => {
+      await result.current.handleSave();
+    });
+
+    expect(setHasUnsavedChanges).toHaveBeenCalledWith(false);
+  });
+
   it('persists terrain config in metadata saves without forcing layer replacement', async () => {
     const state = makeSaveState({
       terrainConfig: {

--- a/frontend/src/components/builder/hooks/use-builder-save.ts
+++ b/frontend/src/components/builder/hooks/use-builder-save.ts
@@ -579,10 +579,11 @@ export function useBuilderSave(state: SaveState) {
   // fix(#756): handleSave destructures `state` once at call time and then
   // awaits the network; this ref always points at the latest rendered state
   // so the post-await code can tell whether anything was edited meanwhile.
+  // codex(#792 round 2): assigned during RENDER, not in a passive effect —
+  // effects run after paint, so a mutation resolving right as an edit
+  // commits could read the stale ref and clear the dirty flag anyway.
   const latestStateRef = useRef(state);
-  useEffect(() => {
-    latestStateRef.current = state;
-  });
+  latestStateRef.current = state;
 
   function editedDuringSave(
     sent: SaveState,

--- a/frontend/src/components/builder/hooks/use-builder-save.ts
+++ b/frontend/src/components/builder/hooks/use-builder-save.ts
@@ -584,8 +584,16 @@ export function useBuilderSave(state: SaveState) {
     latestStateRef.current = state;
   });
 
-  function editedDuringSave(sent: SaveState): boolean {
+  function editedDuringSave(
+    sent: SaveState,
+    sentPluginSet: ReadonlySet<string>,
+  ): boolean {
     const latest = latestStateRef.current;
+    // codex(#792): the plugins payload reads usePluginStore directly, not
+    // SaveState, so a mid-save plugin toggle changes none of the fields
+    // below — compare the store's Set identity too (every toggle produces
+    // a new Set).
+    if (usePluginStore.getState().activePlugins !== sentPluginSet) return true;
     return SAVE_SNAPSHOT_FIELDS.some((field) => sent[field] !== latest[field]);
   }
 
@@ -620,6 +628,9 @@ export function useBuilderSave(state: SaveState) {
     } = state;
     if (!id) return;
     setLastSaveFailed(false);
+    // codex(#792): snapshot the plugin set the payload below will serialize,
+    // so the post-await comparison can tell a mid-save plugin toggle apart.
+    const sentPluginSet = usePluginStore.getState().activePlugins;
 
     // Block save if any layer's popup expression references unknown columns.
     // Server-side validation is shape-only (per CONTEXT.md / RESEARCH §4),
@@ -707,7 +718,7 @@ export function useBuilderSave(state: SaveState) {
             // fix(#756): the baseline above is the SENT snapshot; only clear
             // the dirty flag when nothing was edited during the await, so a
             // mid-save edit stays diffable and guarded.
-            if (!editedDuringSave(state)) {
+            if (!editedDuringSave(state, sentPluginSet)) {
               state.setHasUnsavedChanges(false);
             }
             if (map && id) captureThumbnail(map, id, queryClient, localLayers);
@@ -723,7 +734,7 @@ export function useBuilderSave(state: SaveState) {
       // dirty flag when nothing was edited during the network await —
       // otherwise the baseline effect would absorb the mid-save edit and the
       // query-invalidation resync would overwrite it on screen.
-      if (!editedDuringSave(state)) {
+      if (!editedDuringSave(state, sentPluginSet)) {
         state.setHasUnsavedChanges(false);
       }
 

--- a/frontend/src/components/builder/hooks/use-builder-save.ts
+++ b/frontend/src/components/builder/hooks/use-builder-save.ts
@@ -536,6 +536,24 @@ interface SaveState {
   pendingLayerAdd?: boolean;
 }
 
+/** fix(#756): the state fields handleSave snapshots into its payloads. If any
+ *  of them changes identity while the save's network round-trip is in flight,
+ *  the dirty flag must survive the save — clearing it would absorb the
+ *  mid-save edit into the baseline and let the query-invalidation resync
+ *  overwrite it on screen. */
+const SAVE_SNAPSHOT_FIELDS = [
+  'localLayers',
+  'groupMeta',
+  'localName',
+  'localDescription',
+  'legendTitle',
+  'dockNotes',
+  'localBasemap',
+  'showBasemapLabels',
+  'basemapConfig',
+  'terrainConfig',
+] as const satisfies readonly (keyof SaveState)[];
+
 export function useBuilderSave(state: SaveState) {
   const { t } = useTranslation('builder');
   const navigate = useNavigate();
@@ -557,6 +575,19 @@ export function useBuilderSave(state: SaveState) {
       baselineLayersRef.current = state.localLayers.map((layer) => ({ ...layer }));
     }
   }, [state.hasUnsavedChanges, state.localLayers]);
+
+  // fix(#756): handleSave destructures `state` once at call time and then
+  // awaits the network; this ref always points at the latest rendered state
+  // so the post-await code can tell whether anything was edited meanwhile.
+  const latestStateRef = useRef(state);
+  useEffect(() => {
+    latestStateRef.current = state;
+  });
+
+  function editedDuringSave(sent: SaveState): boolean {
+    const latest = latestStateRef.current;
+    return SAVE_SNAPSHOT_FIELDS.some((field) => sent[field] !== latest[field]);
+  }
 
   useEffect(() => {
     // fix(#392): let layer-create paths register the server-created layer into the
@@ -673,7 +704,12 @@ export function useBuilderSave(state: SaveState) {
             toast.warning(t('toasts.mapSavedFullResync', {
               defaultValue: 'Map saved, but required a full re-sync. Please double-check layer styling.',
             }));
-            state.setHasUnsavedChanges(false);
+            // fix(#756): the baseline above is the SENT snapshot; only clear
+            // the dirty flag when nothing was edited during the await, so a
+            // mid-save edit stays diffable and guarded.
+            if (!editedDuringSave(state)) {
+              state.setHasUnsavedChanges(false);
+            }
             if (map && id) captureThumbnail(map, id, queryClient, localLayers);
             return;
           }
@@ -683,7 +719,13 @@ export function useBuilderSave(state: SaveState) {
 
       baselineLayersRef.current = localLayers.map((layer) => ({ ...layer }));
       toast.success(t('toasts.mapSaved'));
-      state.setHasUnsavedChanges(false);
+      // fix(#756): the baseline above is the SENT snapshot; only clear the
+      // dirty flag when nothing was edited during the network await —
+      // otherwise the baseline effect would absorb the mid-save edit and the
+      // query-invalidation resync would overwrite it on screen.
+      if (!editedDuringSave(state)) {
+        state.setHasUnsavedChanges(false);
+      }
 
       // Capture thumbnail and upload (fire-and-forget)
       // Use `map` captured before mutate — mapInstanceRef.current may be


### PR DESCRIPTION
## What

Fixes the P1 save-path data-loss window from the 2026-07-27 builder audit: `handleSave` snapshots state at call time, awaits the network, then unconditionally cleared `hasUnsavedChanges`. Any edit made during the await was (1) absorbed into the save baseline so no future diff emitted it, (2) overwritten on screen by the `queryKeys.maps.detail` invalidation resync (gated only on `!hasUnsavedChanges`), and (3) invisible to the unsaved-navigation guard.

## How

- The save baseline is now explicitly the **sent** payload (it already was, structurally — now guaranteed against the flag).
- The dirty flag is only cleared when none of the snapshotted fields (`localLayers`, `groupMeta`, name/description/legend/notes, basemap, basemap/terrain config) changed identity during the round-trip; a `latestStateRef` tracks the last rendered state for the post-await comparison.
- Applies to both the normal save path and the #430 full-resync fallback.

If an edit did land mid-save, the map stays dirty: the mid-save edit remains diffable against the sent baseline, the resync guard keeps it on screen, and Save re-enables.

## Verification

- `npx vitest run src/components/builder/hooks/__tests__/use-builder-save.test.ts src/components/builder/hooks/__tests__/use-builder-layers-save-integration.test.ts` — 70 passed (2 new: mid-save edit keeps the flag; clean save still clears it)
- `npm run lint` + `npm run typecheck` — clean

Closes #756.