### PR TITLE
fix(builder): restore keyboard reorder on stack rows and gate the job poll on auth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and releases use semantic versioning.
   destroyed the keyboard drag activator on all rows — folder groups and the
   basemap group, which have no fallback, were pointer-only. The handlers are
   now composed, the row-level reorder mode exposes its armed state via
-  `aria-pressed`, and arming, each move, dropping, and cancelling are
+  `aria-pressed`, and arming, each successful move, and finishing are
   announced to screen readers like the pointer drag path already was. (#759)
 - **A stale tracked analysis job no longer logs anonymous visitors out.** The
   job-status poll is now gated on having an auth token, so a persisted job id

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and releases use semantic versioning.
 
 ### Fixed
 
+- **Keyboard reorder works again on every stack row.** The shared drag grip
+  set a key handler after spreading the dnd-kit listeners, which silently
+  destroyed the keyboard drag activator on all rows — folder groups and the
+  basemap group, which have no fallback, were pointer-only. The handlers are
+  now composed, the row-level reorder mode exposes its armed state via
+  `aria-pressed`, and arming, each move, dropping, and cancelling are
+  announced to screen readers like the pointer drag path already was. (#759)
+- **A stale tracked analysis job no longer logs anonymous visitors out.** The
+  job-status poll is now gated on having an auth token, so a persisted job id
+  can't make a public page fire an authenticated request whose 401 ended the
+  session. (#762)
 - **Edits made while a save is in flight are no longer silently discarded.**
   Changing a layer, name, basemap, plugin, or any other map property during
   the save's network round-trip used to be absorbed into the saved baseline,

--- a/frontend/src/components/builder/SortableStackRow.tsx
+++ b/frontend/src/components/builder/SortableStackRow.tsx
@@ -19,7 +19,7 @@ interface SortableStackRowProps {
   onCopyStyle?: (id: string) => void;
   onPasteStyle?: (id: string) => void;
   canPasteStyle?: boolean;
-  onKeyboardReorder?: (layerId: string, direction: 'up' | 'down') => void;
+  onKeyboardReorder?: (layerId: string, direction: 'up' | 'down') => boolean | void;
   /** fix(#759): shared aria-live announcer for the keyboard reorder mode. */
   onAnnounce?: (text: string) => void;
   existingFolderGroups?: Array<{ id: string; name: string }>;

--- a/frontend/src/components/builder/SortableStackRow.tsx
+++ b/frontend/src/components/builder/SortableStackRow.tsx
@@ -20,6 +20,8 @@ interface SortableStackRowProps {
   onPasteStyle?: (id: string) => void;
   canPasteStyle?: boolean;
   onKeyboardReorder?: (layerId: string, direction: 'up' | 'down') => void;
+  /** fix(#759): shared aria-live announcer for the keyboard reorder mode. */
+  onAnnounce?: (text: string) => void;
   existingFolderGroups?: Array<{ id: string; name: string }>;
   parentGroupId?: string | null;
   onAddToGroup?: (layerId: string, groupId: string) => void;
@@ -58,6 +60,7 @@ export const SortableStackRow = memo(function SortableStackRow({
   onPasteStyle,
   canPasteStyle,
   onKeyboardReorder,
+  onAnnounce,
   existingFolderGroups,
   parentGroupId,
   onAddToGroup,
@@ -112,6 +115,7 @@ export const SortableStackRow = memo(function SortableStackRow({
         onPasteStyle={onPasteStyle}
         canPasteStyle={canPasteStyle}
         onKeyboardReorder={onKeyboardReorder}
+        onAnnounce={onAnnounce}
         existingFolderGroups={existingFolderGroups}
         parentGroupId={parentGroupId}
         onAddToGroup={onAddToGroup}

--- a/frontend/src/components/builder/StackRow.tsx
+++ b/frontend/src/components/builder/StackRow.tsx
@@ -184,15 +184,18 @@ export const StackRow = memo(function StackRow({
       e.stopPropagation();
       // fix(#759): mirror the pointer path's pickup/drop announcements — this
       // mode was completely silent while the shortcuts sheet advertised it.
+      // codex(#794 round 2): NOT the shared dragPickup string — its "Escape
+      // to cancel" describes the real drag path, where Escape reverts. Here
+      // every arrow applies immediately and Escape only exits the mode.
       onAnnounce?.(
         keyboardReorderActive
           ? t('a11y.reorderDropped', {
               defaultValue: '{{name}} dropped.',
               name: displayName,
             })
-          : t('a11y.dragPickup', {
+          : t('a11y.reorderArmed', {
               defaultValue:
-                'Picked up {{name}}. Use arrow keys to choose a position, Enter to drop, Escape to cancel.',
+                'Reorder mode on for {{name}}. Arrow keys move the layer; Enter, Space, or Escape finishes.',
               name: displayName,
             }),
       );
@@ -203,7 +206,15 @@ export const StackRow = memo(function StackRow({
     if (e.key === 'Escape' && keyboardReorderActive) {
       e.preventDefault();
       e.stopPropagation();
-      onAnnounce?.(t('a11y.dragCancelled', { defaultValue: 'Drop cancelled.' }));
+      // codex(#794 round 2): arrows have already applied their moves, so
+      // "Drop cancelled" would falsely promise a revert — Escape only exits
+      // the mode, exactly like Enter/Space.
+      onAnnounce?.(
+        t('a11y.reorderDropped', {
+          defaultValue: '{{name}} dropped.',
+          name: displayName,
+        }),
+      );
       setKeyboardReorderActive(false);
       return;
     }

--- a/frontend/src/components/builder/StackRow.tsx
+++ b/frontend/src/components/builder/StackRow.tsx
@@ -73,7 +73,9 @@ interface StackRowProps {
   onCreateGroupWithLayer?: (layerId: string) => void;
   /** Called when user selects "Move out of group" (layer is already in a group) */
   onMoveLayerOutOfGroup?: (layerId: string) => void;
-  onKeyboardReorder?: (layerId: string, direction: 'up' | 'down') => void;
+  /** Returns whether the move happened, so boundary no-ops stay silent
+   *  (codex(#794)); void is treated as moved for older callers. */
+  onKeyboardReorder?: (layerId: string, direction: 'up' | 'down') => boolean | void;
   /** fix(#759): routes reorder-mode announcements into the builder's shared
    *  aria-live region — the pointer drag path announces pickup/position/drop
    *  while this mode used to be completely silent. */
@@ -210,14 +212,18 @@ export const StackRow = memo(function StackRow({
     e.preventDefault();
     e.stopPropagation();
     const direction = e.key === 'ArrowUp' ? 'up' : 'down';
-    onKeyboardReorder?.(layer.id, direction);
-    onAnnounce?.(
-      t(direction === 'up' ? 'a11y.reorderMovedUp' : 'a11y.reorderMovedDown', {
-        defaultValue:
-          direction === 'up' ? '{{name}} moved up.' : '{{name}} moved down.',
-        name: displayName,
-      }),
-    );
+    const moved = onKeyboardReorder?.(layer.id, direction);
+    // codex(#794): a boundary ArrowUp/Down is a no-op — announcing a move
+    // there gives screen-reader users false confirmation.
+    if (moved !== false) {
+      onAnnounce?.(
+        t(direction === 'up' ? 'a11y.reorderMovedUp' : 'a11y.reorderMovedDown', {
+          defaultValue:
+            direction === 'up' ? '{{name}} moved up.' : '{{name}} moved down.',
+          name: displayName,
+        }),
+      );
+    }
   }
 
   // Phase 1041: modifier-aware click handler (POL-06)
@@ -298,7 +304,10 @@ export const StackRow = memo(function StackRow({
           name: displayName,
         })}
         touchReveal
-        ariaPressed={keyboardReorderActive}
+        // codex(#794): dnd-kit drives aria-pressed=true through `attributes`
+        // while its sortable is active; the explicit prop must not report
+        // unpressed during a real pointer drag.
+        ariaPressed={keyboardReorderActive || isDragging}
         onKeyDown={handleDragHandleKeyDown}
         onBlur={() => setKeyboardReorderActive(false)}
       />

--- a/frontend/src/components/builder/StackRow.tsx
+++ b/frontend/src/components/builder/StackRow.tsx
@@ -74,6 +74,10 @@ interface StackRowProps {
   /** Called when user selects "Move out of group" (layer is already in a group) */
   onMoveLayerOutOfGroup?: (layerId: string) => void;
   onKeyboardReorder?: (layerId: string, direction: 'up' | 'down') => void;
+  /** fix(#759): routes reorder-mode announcements into the builder's shared
+   *  aria-live region — the pointer drag path announces pickup/position/drop
+   *  while this mode used to be completely silent. */
+  onAnnounce?: (text: string) => void;
   /** When non-null, the layer is inside a group — "Move out of group" replaces the sub-flow */
   parentGroupId?: string | null;
   // Phase 1041: multi-selection props (POL-06, POL-07)
@@ -127,6 +131,7 @@ export const StackRow = memo(function StackRow({
   onCreateGroupWithLayer,
   onMoveLayerOutOfGroup,
   onKeyboardReorder,
+  onAnnounce,
   parentGroupId = null,
   isMultiSelected = false,
   isMultiSelectionActive = false,
@@ -175,13 +180,28 @@ export const StackRow = memo(function StackRow({
     if (isToggleKey) {
       e.preventDefault();
       e.stopPropagation();
-      setKeyboardReorderActive((active) => !active);
+      // fix(#759): mirror the pointer path's pickup/drop announcements — this
+      // mode was completely silent while the shortcuts sheet advertised it.
+      onAnnounce?.(
+        keyboardReorderActive
+          ? t('a11y.reorderDropped', {
+              defaultValue: '{{name}} dropped.',
+              name: displayName,
+            })
+          : t('a11y.dragPickup', {
+              defaultValue:
+                'Picked up {{name}}. Use arrow keys to choose a position, Enter to drop, Escape to cancel.',
+              name: displayName,
+            }),
+      );
+      setKeyboardReorderActive(!keyboardReorderActive);
       return;
     }
 
     if (e.key === 'Escape' && keyboardReorderActive) {
       e.preventDefault();
       e.stopPropagation();
+      onAnnounce?.(t('a11y.dragCancelled', { defaultValue: 'Drop cancelled.' }));
       setKeyboardReorderActive(false);
       return;
     }
@@ -189,7 +209,15 @@ export const StackRow = memo(function StackRow({
     if (!keyboardReorderActive || (e.key !== 'ArrowUp' && e.key !== 'ArrowDown')) return;
     e.preventDefault();
     e.stopPropagation();
-    onKeyboardReorder?.(layer.id, e.key === 'ArrowUp' ? 'up' : 'down');
+    const direction = e.key === 'ArrowUp' ? 'up' : 'down';
+    onKeyboardReorder?.(layer.id, direction);
+    onAnnounce?.(
+      t(direction === 'up' ? 'a11y.reorderMovedUp' : 'a11y.reorderMovedDown', {
+        defaultValue:
+          direction === 'up' ? '{{name}} moved up.' : '{{name}} moved down.',
+        name: displayName,
+      }),
+    );
   }
 
   // Phase 1041: modifier-aware click handler (POL-06)
@@ -270,6 +298,7 @@ export const StackRow = memo(function StackRow({
           name: displayName,
         })}
         touchReveal
+        ariaPressed={keyboardReorderActive}
         onKeyDown={handleDragHandleKeyDown}
         onBlur={() => setKeyboardReorderActive(false)}
       />

--- a/frontend/src/components/builder/UnifiedStackPanel.tsx
+++ b/frontend/src/components/builder/UnifiedStackPanel.tsx
@@ -87,6 +87,8 @@ interface UnifiedStackPanelProps {
    *  to enable "Paste style" only on geometry-compatible rows. */
   copiedStyleGeometryClass?: GeometryStyleClass | null;
   onKeyboardReorder?: (layerId: string, direction: 'up' | 'down') => void;
+  /** fix(#759): shared aria-live announcer for the keyboard reorder mode. */
+  onAnnounce?: (text: string) => void;
   onAddDataClick: (initialQuery?: string) => void;
   onAddDataset?: (datasetId: string) => void;
   onSettingsClick: () => void;
@@ -300,6 +302,7 @@ export const UnifiedStackPanel = memo(function UnifiedStackPanel({
   onBulkApplyStyle,
   copiedStyleGeometryClass = null,
   onKeyboardReorder,
+  onAnnounce,
   onAddDataClick,
   onAddDataset,
   onSettingsClick,
@@ -780,6 +783,7 @@ export const UnifiedStackPanel = memo(function UnifiedStackPanel({
                                   copiedStyleGeometryClass === geometryClassOf(child.dataset_geometry_type)
                                 }
                                 onKeyboardReorder={onKeyboardReorder}
+                                onAnnounce={onAnnounce}
                                 existingFolderGroups={existingFolderGroups}
                                 parentGroupId={layer.id}
                                 onAddToGroup={safeAddLayerToExistingGroup}
@@ -826,6 +830,7 @@ export const UnifiedStackPanel = memo(function UnifiedStackPanel({
                       copiedStyleGeometryClass === geometryClassOf(layer.dataset_geometry_type)
                     }
                     onKeyboardReorder={onKeyboardReorder}
+                    onAnnounce={onAnnounce}
                     existingFolderGroups={existingFolderGroups}
                     parentGroupId={getParentGroupId(layer)}
                     onAddToGroup={safeAddLayerToExistingGroup}

--- a/frontend/src/components/builder/UnifiedStackPanel.tsx
+++ b/frontend/src/components/builder/UnifiedStackPanel.tsx
@@ -86,7 +86,7 @@ interface UnifiedStackPanelProps {
   /** Geometry class of the currently-copied style (null = nothing copied). Used
    *  to enable "Paste style" only on geometry-compatible rows. */
   copiedStyleGeometryClass?: GeometryStyleClass | null;
-  onKeyboardReorder?: (layerId: string, direction: 'up' | 'down') => void;
+  onKeyboardReorder?: (layerId: string, direction: 'up' | 'down') => boolean | void;
   /** fix(#759): shared aria-live announcer for the keyboard reorder mode. */
   onAnnounce?: (text: string) => void;
   onAddDataClick: (initialQuery?: string) => void;

--- a/frontend/src/components/builder/__tests__/FolderGroupRow.test.tsx
+++ b/frontend/src/components/builder/__tests__/FolderGroupRow.test.tsx
@@ -90,6 +90,25 @@ describe('FolderGroupRow', () => {
     expect(dndKeyDown).toHaveBeenCalledTimes(1);
   });
 
+  it('a key claimed by the keyboard activator does not also trigger the row (codex #794)', () => {
+    const props = defaultProps({ onCmdClick: vi.fn() });
+    props.dragHandleProps.listeners = {
+      // The real KeyboardSensor activator preventDefaults the start key.
+      onKeyDown: vi.fn((e: React.KeyboardEvent) => e.preventDefault()),
+    } as unknown as DraggableSyntheticListeners;
+    render(<FolderGroupRow {...props} />);
+
+    fireEvent.keyDown(
+      screen.getByRole('button', { name: 'Drag to reorder My Group' }),
+      { key: ' ' },
+    );
+    // Starting a keyboard drag must not simultaneously toggle the row's
+    // multi-selection (Space) or selection (Enter) — the row handlers don't
+    // check defaultPrevented, so the grip stops the claimed key's bubble.
+    expect(props.onCmdClick).not.toHaveBeenCalled();
+    expect(props.onSelectGroup).not.toHaveBeenCalled();
+  });
+
   it('Test 1: Renders the ▸ glyph in the type-icon cell using the folder-group token', () => {
     render(<FolderGroupRow {...defaultProps()} />);
 

--- a/frontend/src/components/builder/__tests__/FolderGroupRow.test.tsx
+++ b/frontend/src/components/builder/__tests__/FolderGroupRow.test.tsx
@@ -74,6 +74,22 @@ function defaultProps(overrides: Partial<React.ComponentProps<typeof FolderGroup
 }
 
 describe('FolderGroupRow', () => {
+  it('forwards grip keys to the dnd-kit keyboard activator (fix #759)', () => {
+    // The grip used to set onKeyDown={undefined} AFTER spreading listeners,
+    // which destroyed the KeyboardSensor activator — group rows have no
+    // fallback reorder mode, so they were pointer-only (WCAG 2.1.1).
+    const props = defaultProps();
+    const dndKeyDown = vi.fn();
+    props.dragHandleProps.listeners = {
+      onKeyDown: dndKeyDown,
+    } as DraggableSyntheticListeners;
+    render(<FolderGroupRow {...props} />);
+
+    const grip = screen.getByRole('button', { name: 'Drag to reorder My Group' });
+    fireEvent.keyDown(grip, { key: ' ' });
+    expect(dndKeyDown).toHaveBeenCalledTimes(1);
+  });
+
   it('Test 1: Renders the ▸ glyph in the type-icon cell using the folder-group token', () => {
     render(<FolderGroupRow {...defaultProps()} />);
 

--- a/frontend/src/components/builder/__tests__/StackRow.test.tsx
+++ b/frontend/src/components/builder/__tests__/StackRow.test.tsx
@@ -121,6 +121,24 @@ describe('StackRow', () => {
       expect(onAnnounce).toHaveBeenCalledWith('Population dropped.');
     });
 
+    it('stays silent when a boundary move does not happen (codex #794)', () => {
+      const onAnnounce = vi.fn();
+      const onKeyboardReorder = vi.fn(() => false);
+      render(<StackRow {...defaultProps({ onAnnounce, onKeyboardReorder })} />);
+      const handle = screen.getByRole('button', { name: gripName });
+      fireEvent.keyDown(handle, { key: ' ' });
+      fireEvent.keyDown(handle, { key: 'ArrowUp' });
+      expect(onKeyboardReorder).toHaveBeenCalledWith('layer-1', 'up');
+      expect(onAnnounce).not.toHaveBeenCalledWith('Population moved up.');
+    });
+
+    it('reports pressed during a pointer drag (codex #794)', () => {
+      render(<StackRow {...defaultProps({ isDragging: true })} />);
+      expect(
+        screen.getByRole('button', { name: gripName }),
+      ).toHaveAttribute('aria-pressed', 'true');
+    });
+
     it('announces a cancel on Escape', () => {
       const onAnnounce = vi.fn();
       render(<StackRow {...defaultProps({ onAnnounce })} />);

--- a/frontend/src/components/builder/__tests__/StackRow.test.tsx
+++ b/frontend/src/components/builder/__tests__/StackRow.test.tsx
@@ -96,6 +96,62 @@ function defaultProps(overrides: Partial<React.ComponentProps<typeof StackRow>> 
 }
 
 describe('StackRow', () => {
+  describe('keyboard reorder mode (fix #759)', () => {
+    const gripName = 'Drag to reorder Population';
+
+    it('announces arm, moves, and drop, and reflects the mode in aria-pressed', () => {
+      const onAnnounce = vi.fn();
+      const onKeyboardReorder = vi.fn();
+      render(<StackRow {...defaultProps({ onAnnounce, onKeyboardReorder })} />);
+      const handle = screen.getByRole('button', { name: gripName });
+      expect(handle).toHaveAttribute('aria-pressed', 'false');
+
+      fireEvent.keyDown(handle, { key: ' ' });
+      expect(handle).toHaveAttribute('aria-pressed', 'true');
+      expect(onAnnounce).toHaveBeenCalledWith(
+        expect.stringContaining('Picked up Population'),
+      );
+
+      fireEvent.keyDown(handle, { key: 'ArrowUp' });
+      expect(onKeyboardReorder).toHaveBeenCalledWith('layer-1', 'up');
+      expect(onAnnounce).toHaveBeenCalledWith('Population moved up.');
+
+      fireEvent.keyDown(handle, { key: ' ' });
+      expect(handle).toHaveAttribute('aria-pressed', 'false');
+      expect(onAnnounce).toHaveBeenCalledWith('Population dropped.');
+    });
+
+    it('announces a cancel on Escape', () => {
+      const onAnnounce = vi.fn();
+      render(<StackRow {...defaultProps({ onAnnounce })} />);
+      const handle = screen.getByRole('button', { name: gripName });
+      fireEvent.keyDown(handle, { key: ' ' });
+      fireEvent.keyDown(handle, { key: 'Escape' });
+      expect(onAnnounce).toHaveBeenCalledWith('Drop cancelled.');
+      expect(handle).toHaveAttribute('aria-pressed', 'false');
+    });
+
+    it('keeps claimed keys from the dnd-kit activator but forwards the rest', () => {
+      const dndKeyDown = vi.fn();
+      const props = defaultProps();
+      props.dragHandleProps.listeners = {
+        onKeyDown: dndKeyDown,
+      } as DraggableSyntheticListeners;
+      render(<StackRow {...props} />);
+      const handle = screen.getByRole('button', { name: gripName });
+
+      // Space is claimed by the fallback reorder mode (preventDefault), so
+      // the sensor must NOT also start a keyboard drag.
+      fireEvent.keyDown(handle, { key: ' ' });
+      expect(dndKeyDown).not.toHaveBeenCalled();
+      fireEvent.keyDown(handle, { key: 'Escape' });
+
+      // A key the row does not claim still reaches the sensor.
+      fireEvent.keyDown(handle, { key: 'a' });
+      expect(dndKeyDown).toHaveBeenCalledTimes(1);
+    });
+  });
+
   it('renders the five interactive cells in DOM order: grip → eye → name → kebab (caret hidden)', () => {
     const props = defaultProps();
     render(<StackRow {...props} />);

--- a/frontend/src/components/builder/__tests__/StackRow.test.tsx
+++ b/frontend/src/components/builder/__tests__/StackRow.test.tsx
@@ -109,7 +109,7 @@ describe('StackRow', () => {
       fireEvent.keyDown(handle, { key: ' ' });
       expect(handle).toHaveAttribute('aria-pressed', 'true');
       expect(onAnnounce).toHaveBeenCalledWith(
-        expect.stringContaining('Picked up Population'),
+        expect.stringContaining('Reorder mode on for Population'),
       );
 
       fireEvent.keyDown(handle, { key: 'ArrowUp' });
@@ -139,13 +139,16 @@ describe('StackRow', () => {
       ).toHaveAttribute('aria-pressed', 'true');
     });
 
-    it('announces a cancel on Escape', () => {
+    it('announces the exit on Escape without promising a revert (codex #794)', () => {
       const onAnnounce = vi.fn();
       render(<StackRow {...defaultProps({ onAnnounce })} />);
       const handle = screen.getByRole('button', { name: gripName });
       fireEvent.keyDown(handle, { key: ' ' });
       fireEvent.keyDown(handle, { key: 'Escape' });
-      expect(onAnnounce).toHaveBeenCalledWith('Drop cancelled.');
+      // Moves apply immediately in this mode, so Escape must not announce
+      // "Drop cancelled" — nothing is reverted.
+      expect(onAnnounce).toHaveBeenCalledWith('Population dropped.');
+      expect(onAnnounce).not.toHaveBeenCalledWith('Drop cancelled.');
       expect(handle).toHaveAttribute('aria-pressed', 'false');
     });
 

--- a/frontend/src/components/builder/hooks/__tests__/use-builder-layers.test.ts
+++ b/frontend/src/components/builder/hooks/__tests__/use-builder-layers.test.ts
@@ -148,6 +148,58 @@ describe('useBuilderLayers', () => {
     expect(result.current.hasUnsavedChanges).toBe(true);
   });
 
+  it('handleMove stops a grouped child at its folder edge (codex #794)', () => {
+    const groupLayer = {
+      ...makeMockLayer({ id: 'group-1', sort_order: 0 }),
+      layer_type: 'group:folder',
+    } as unknown as MapLayerResponse;
+    const child = {
+      ...makeMockLayer({ id: 'child-1', sort_order: 1 }),
+      parent_group_id: 'group-1',
+    } as unknown as MapLayerResponse;
+    const loose = makeMockLayer({ id: 'loose-1', sort_order: 2 });
+    const { result } = renderBuilderLayers(makeMapData([groupLayer, child, loose]));
+
+    let moved = true;
+    act(() => {
+      moved = result.current.handleMoveDown('child-1');
+    });
+
+    // The folder box lists only its own children — 'loose-1' is not a visible
+    // sibling, and swapping with it would move nothing the user can see.
+    expect(moved).toBe(false);
+    expect(result.current.localLayers.map((l) => l.id)).toEqual([
+      'group-1',
+      'child-1',
+      'loose-1',
+    ]);
+    expect(result.current.hasUnsavedChanges).toBe(false);
+  });
+
+  it('handleMove swaps same-container siblings across an interleaved child (codex #794)', () => {
+    const looseA = makeMockLayer({ id: 'loose-a', sort_order: 0 });
+    const child = {
+      ...makeMockLayer({ id: 'child-1', sort_order: 1 }),
+      parent_group_id: 'group-1',
+    } as unknown as MapLayerResponse;
+    const looseB = makeMockLayer({ id: 'loose-b', sort_order: 2 });
+    const { result } = renderBuilderLayers(makeMapData([looseA, child, looseB]));
+
+    let moved = false;
+    act(() => {
+      moved = result.current.handleMoveDown('loose-a');
+    });
+
+    // Top level renders [loose-a, loose-b]; the move swaps exactly those two
+    // and leaves the grouped child's own container order untouched.
+    expect(moved).toBe(true);
+    expect(result.current.localLayers.map((l) => l.id)).toEqual([
+      'loose-b',
+      'child-1',
+      'loose-a',
+    ]);
+  });
+
   it('handleFilterChange updates filter in local state and marks dirty', () => {
     const layer = makeMockLayer();
     const mapData = makeMapData([layer]);

--- a/frontend/src/components/builder/hooks/use-builder-layers.ts
+++ b/frontend/src/components/builder/hooks/use-builder-layers.ts
@@ -285,20 +285,23 @@ export function useBuilderLayers(
   // `layersRef.current` instead of `localLayers` to keep their dep lists
   // stable (KISS-2 / PERF-N2).
 
-  const handleMove = useCallback((layerId: string, direction: 'up' | 'down') => {
+  // codex(#794): reports whether a move actually happened, so the keyboard
+  // reorder announcement can stay silent at the stack boundaries instead of
+  // confirming a move that did not occur.
+  const handleMove = useCallback((layerId: string, direction: 'up' | 'down'): boolean => {
     const currentLayers = layersRef.current;
     // fix(HT-03): the stack no longer suppresses terrain-mode DEM rows, so the
     // rendered order IS the full layer order again (the #394 LM-05 filter is
     // obsolete — an arrow-move can never swap with an invisible row).
     const rendered = currentLayers;
     const renderedIdx = rendered.findIndex((l) => l.id === layerId);
-    if (direction === 'up' && renderedIdx <= 0) return;
-    if (direction === 'down' && (renderedIdx < 0 || renderedIdx >= rendered.length - 1)) return;
+    if (direction === 'up' && renderedIdx <= 0) return false;
+    if (direction === 'down' && (renderedIdx < 0 || renderedIdx >= rendered.length - 1)) return false;
     const neighborId = rendered[direction === 'up' ? renderedIdx - 1 : renderedIdx + 1].id;
 
     const idx = currentLayers.findIndex((l) => l.id === layerId);
     const swapIdx = currentLayers.findIndex((l) => l.id === neighborId);
-    if (idx < 0 || swapIdx < 0) return;
+    if (idx < 0 || swapIdx < 0) return false;
 
     const next = [...currentLayers];
     [next[idx], next[swapIdx]] = [next[swapIdx], next[idx]];
@@ -312,6 +315,7 @@ export function useBuilderLayers(
     }
 
     setHasUnsavedChanges(true);
+    return true;
   }, [mapInstanceRef]);
 
   const handleMoveUp = useCallback((layerId: string) => handleMove(layerId, 'up'), [handleMove]);

--- a/frontend/src/components/builder/hooks/use-builder-layers.ts
+++ b/frontend/src/components/builder/hooks/use-builder-layers.ts
@@ -20,6 +20,7 @@ import {
   shouldClearTerrainOnDelete,
 } from '@/components/builder/hooks/builder-layer-mutations';
 import {
+  getParentGroupId,
   hydrateFolderGroupLayers,
   type GroupedLayer,
 } from '@/components/builder/folder-groups';
@@ -293,15 +294,26 @@ export function useBuilderLayers(
     // fix(HT-03): the stack no longer suppresses terrain-mode DEM rows, so the
     // rendered order IS the full layer order again (the #394 LM-05 filter is
     // obsolete — an arrow-move can never swap with an invisible row).
-    const rendered = currentLayers;
-    const renderedIdx = rendered.findIndex((l) => l.id === layerId);
-    if (direction === 'up' && renderedIdx <= 0) return false;
-    if (direction === 'down' && (renderedIdx < 0 || renderedIdx >= rendered.length - 1)) return false;
-    const neighborId = rendered[direction === 'up' ? renderedIdx - 1 : renderedIdx + 1].id;
-
     const idx = currentLayers.findIndex((l) => l.id === layerId);
-    const swapIdx = currentLayers.findIndex((l) => l.id === neighborId);
-    if (idx < 0 || swapIdx < 0) return false;
+    if (idx < 0) return false;
+    // codex(#794 round 3): the row's visible neighbor is its adjacent sibling
+    // in the SAME container — the top level skips grouped children, and a
+    // folder box lists only its own children — so the raw flat-array neighbor
+    // can belong to another container. Swapping with that entry moves nothing
+    // the user can see (while still dirtying the saved order) yet would be
+    // announced as a move. Skip to the nearest same-container sibling; at the
+    // container edge there is none, and that is a boundary, not a move.
+    const container = getParentGroupId(currentLayers[idx]);
+    const step = direction === 'up' ? -1 : 1;
+    let swapIdx = idx + step;
+    while (
+      swapIdx >= 0 &&
+      swapIdx < currentLayers.length &&
+      getParentGroupId(currentLayers[swapIdx]) !== container
+    ) {
+      swapIdx += step;
+    }
+    if (swapIdx < 0 || swapIdx >= currentLayers.length) return false;
 
     const next = [...currentLayers];
     [next[idx], next[swapIdx]] = [next[swapIdx], next[idx]];

--- a/frontend/src/components/builder/row-chrome.tsx
+++ b/frontend/src/components/builder/row-chrome.tsx
@@ -124,10 +124,17 @@ export function DragGripButton({
       // custom handler, were left pointer-only. Compose instead: the row's
       // handler runs first, and the sensor only sees keys the row didn't
       // claim (StackRow's fallback mode preventDefaults the keys it owns).
+      // codex(#794 round 3): a CLAIMED key must also stop bubbling — both the
+      // sensor's activator and the custom handlers preventDefault when they
+      // take a key, and the enclosing rows (folder multi-select, basemap
+      // select) handle the same Space/Enter without checking defaultPrevented,
+      // so a keyboard drag would simultaneously fire a conflicting row action.
       onKeyDown={(e) => {
         onKeyDown?.(e);
-        if (e.defaultPrevented || listenersSuppressed) return;
-        dragHandleProps.listeners?.onKeyDown?.(e);
+        if (!e.defaultPrevented && !listenersSuppressed) {
+          dragHandleProps.listeners?.onKeyDown?.(e);
+        }
+        if (e.defaultPrevented) e.stopPropagation();
       }}
       onBlur={onBlur}
     >

--- a/frontend/src/components/builder/row-chrome.tsx
+++ b/frontend/src/components/builder/row-chrome.tsx
@@ -70,6 +70,9 @@ interface DragGripButtonProps {
   touchReveal?: boolean;
   testId?: string;
   className?: string;
+  /** fix(#759): reflects a row-level keyboard-reorder mode on the grip, so
+   *  screen readers hear the armed/disarmed state of the toggle. */
+  ariaPressed?: boolean;
   onClick?: (e: MouseEvent<HTMLButtonElement>) => void;
   onKeyDown?: (e: KeyboardEvent<HTMLButtonElement>) => void;
   onBlur?: (e: FocusEvent<HTMLButtonElement>) => void;
@@ -85,6 +88,7 @@ export function DragGripButton({
   touchReveal = false,
   testId,
   className,
+  ariaPressed,
   onClick,
   onKeyDown,
   onBlur,
@@ -96,6 +100,10 @@ export function DragGripButton({
       {...dragHandleProps.attributes}
       {...(listenersSuppressed ? {} : dragHandleProps.listeners)}
       aria-label={ariaLabel}
+      // Only override when the row drives a reorder mode — an unconditional
+      // undefined would erase the aria-pressed dnd-kit manages in
+      // `attributes` (the same later-prop-wins trap this file just fixed).
+      {...(ariaPressed !== undefined ? { 'aria-pressed': ariaPressed } : {})}
       data-testid={testId}
       {...(touchReveal ? { 'data-touch-reveal': '' } : {})}
       className={cn(
@@ -109,7 +117,18 @@ export function DragGripButton({
       // pointer drag entirely. onClick stopPropagation alone suppresses row selection on
       // grip click; pointer events do not trigger onClick handlers.
       onClick={onClick ?? ((e) => e.stopPropagation())}
-      onKeyDown={onKeyDown}
+      // fix(#759): second occurrence of the props-after-listeners-spread trap
+      // (first: #525). A later JSX prop wins even when undefined, so an
+      // unconditional onKeyDown here destroyed the dnd-kit KeyboardSensor
+      // activator on EVERY row — folder and basemap groups, which pass no
+      // custom handler, were left pointer-only. Compose instead: the row's
+      // handler runs first, and the sensor only sees keys the row didn't
+      // claim (StackRow's fallback mode preventDefaults the keys it owns).
+      onKeyDown={(e) => {
+        onKeyDown?.(e);
+        if (e.defaultPrevented || listenersSuppressed) return;
+        dragHandleProps.listeners?.onKeyDown?.(e);
+      }}
       onBlur={onBlur}
     >
       <GripVertical className="h-3.5 w-3.5" aria-hidden="true" />

--- a/frontend/src/components/import/hooks/__tests__/use-ingest.test.ts
+++ b/frontend/src/components/import/hooks/__tests__/use-ingest.test.ts
@@ -79,7 +79,23 @@ describe('useUploadFile', () => {
 });
 
 describe('useJobStatus', () => {
-  beforeEach(() => vi.clearAllMocks());
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // fix(#762): the hook now gates on an auth token; these tests run as an
+    // authenticated user unless they say otherwise.
+    useAuthStore.setState({ token: 'jwt-token', refreshToken: null, expiresAt: null, user: null });
+  });
+
+  it('does not poll a persisted analysis job for anonymous visitors (fix #762)', () => {
+    // AnalysisJobWatcher mounts in RootLayout with a persist-backed job id; a
+    // stale one used to make an anonymous session fire an authenticated-only
+    // poll whose 401 logged the visitor out of public pages.
+    useAuthStore.setState({ token: null, refreshToken: null, expiresAt: null, user: null });
+    const { result } = renderHook(() => useJobStatus('j-stale'));
+
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(mockGetJobStatus).not.toHaveBeenCalled();
+  });
 
   it('fetches job status when jobId is provided', async () => {
     const status = { job_id: 'j-1', status: 'complete', filename: 'test.geojson' };

--- a/frontend/src/components/import/hooks/use-ingest.ts
+++ b/frontend/src/components/import/hooks/use-ingest.ts
@@ -13,10 +13,16 @@ export function useUploadFile() {
 }
 
 export function useJobStatus(jobId: string | null) {
+  // fix(#762): AnalysisJobWatcher mounts in RootLayout with a persist-backed
+  // job id, so without this gate a stale tracked job made an anonymous
+  // visitor on a public page fire an authenticated-only poll — whose 401
+  // logged them out. Sibling useDatasetJobStatus gates identically; once a
+  // token appears the poll resumes and the watcher resolves the stale job.
+  const hasToken = useAuthStore((s) => !!s.token);
   return useQuery({
     queryKey: queryKeys.ingest.jobStatus(jobId),
     queryFn: () => getJobStatus(jobId!),
-    enabled: !!jobId,
+    enabled: !!jobId && hasToken,
     staleTime: 2000,
     refetchInterval: (query) => {
       const status = query.state.data?.status;

--- a/frontend/src/i18n/locales/de/builder.json
+++ b/frontend/src/i18n/locales/de/builder.json
@@ -1077,6 +1077,9 @@
     "dragPosition": "Aktuelle Position: {{n}} von {{total}}",
     "dragDropped": "Abgelegt. {{name}} an Position {{n}} hinzugefügt.",
     "dragCancelled": "Ablegen abgebrochen.",
+    "reorderMovedUp": "{{name}} nach oben verschoben.",
+    "reorderMovedDown": "{{name}} nach unten verschoben.",
+    "reorderDropped": "{{name}} abgelegt.",
     "basemapPositionChanged": "Basiskarte nach {{position}} verschoben",
     "shortcuts": {
       "title": "Tastaturkürzel",

--- a/frontend/src/i18n/locales/de/builder.json
+++ b/frontend/src/i18n/locales/de/builder.json
@@ -1080,6 +1080,7 @@
     "reorderMovedUp": "{{name}} nach oben verschoben.",
     "reorderMovedDown": "{{name}} nach unten verschoben.",
     "reorderDropped": "{{name}} abgelegt.",
+    "reorderArmed": "Sortiermodus für {{name}} aktiviert. Pfeiltasten verschieben die Ebene; Eingabe, Leertaste oder Escape beendet.",
     "basemapPositionChanged": "Basiskarte nach {{position}} verschoben",
     "shortcuts": {
       "title": "Tastaturkürzel",

--- a/frontend/src/i18n/locales/en/builder.json
+++ b/frontend/src/i18n/locales/en/builder.json
@@ -1081,6 +1081,9 @@
     "dragPosition": "Current position: {{n}} of {{total}}",
     "dragDropped": "Dropped. {{name}} added at position {{n}}.",
     "dragCancelled": "Drop cancelled.",
+    "reorderMovedUp": "{{name}} moved up.",
+    "reorderMovedDown": "{{name}} moved down.",
+    "reorderDropped": "{{name}} dropped.",
     "basemapPositionChanged": "Basemap moved to {{position}}",
     "shortcuts": {
       "title": "Keyboard shortcuts",

--- a/frontend/src/i18n/locales/en/builder.json
+++ b/frontend/src/i18n/locales/en/builder.json
@@ -1084,6 +1084,7 @@
     "reorderMovedUp": "{{name}} moved up.",
     "reorderMovedDown": "{{name}} moved down.",
     "reorderDropped": "{{name}} dropped.",
+    "reorderArmed": "Reorder mode on for {{name}}. Arrow keys move the layer; Enter, Space, or Escape finishes.",
     "basemapPositionChanged": "Basemap moved to {{position}}",
     "shortcuts": {
       "title": "Keyboard shortcuts",

--- a/frontend/src/i18n/locales/es/builder.json
+++ b/frontend/src/i18n/locales/es/builder.json
@@ -1077,6 +1077,9 @@
     "dragPosition": "Posición actual: {{n}} de {{total}}",
     "dragDropped": "Soltado. {{name}} agregado en la posición {{n}}.",
     "dragCancelled": "Soltar cancelado.",
+    "reorderMovedUp": "{{name}} se movió hacia arriba.",
+    "reorderMovedDown": "{{name}} se movió hacia abajo.",
+    "reorderDropped": "{{name}} soltado.",
     "basemapPositionChanged": "Mapa base movido a {{position}}",
     "shortcuts": {
       "title": "Atajos de teclado",

--- a/frontend/src/i18n/locales/es/builder.json
+++ b/frontend/src/i18n/locales/es/builder.json
@@ -1080,6 +1080,7 @@
     "reorderMovedUp": "{{name}} se movió hacia arriba.",
     "reorderMovedDown": "{{name}} se movió hacia abajo.",
     "reorderDropped": "{{name}} soltado.",
+    "reorderArmed": "Modo de reordenación activado para {{name}}. Las flechas mueven la capa; Intro, Espacio o Escape finaliza.",
     "basemapPositionChanged": "Mapa base movido a {{position}}",
     "shortcuts": {
       "title": "Atajos de teclado",

--- a/frontend/src/i18n/locales/fr/builder.json
+++ b/frontend/src/i18n/locales/fr/builder.json
@@ -1080,6 +1080,7 @@
     "reorderMovedUp": "{{name}} déplacé vers le haut.",
     "reorderMovedDown": "{{name}} déplacé vers le bas.",
     "reorderDropped": "{{name}} déposé.",
+    "reorderArmed": "Mode de réorganisation activé pour {{name}}. Les flèches déplacent la couche ; Entrée, Espace ou Échap termine.",
     "basemapPositionChanged": "Fond de carte déplacé vers {{position}}",
     "shortcuts": {
       "title": "Raccourcis clavier",

--- a/frontend/src/i18n/locales/fr/builder.json
+++ b/frontend/src/i18n/locales/fr/builder.json
@@ -1077,6 +1077,9 @@
     "dragPosition": "Position actuelle : {{n}} sur {{total}}",
     "dragDropped": "Déposé. {{name}} ajouté à la position {{n}}.",
     "dragCancelled": "Dépôt annulé.",
+    "reorderMovedUp": "{{name}} déplacé vers le haut.",
+    "reorderMovedDown": "{{name}} déplacé vers le bas.",
+    "reorderDropped": "{{name}} déposé.",
     "basemapPositionChanged": "Fond de carte déplacé vers {{position}}",
     "shortcuts": {
       "title": "Raccourcis clavier",

--- a/frontend/src/pages/MapBuilderPage.tsx
+++ b/frontend/src/pages/MapBuilderPage.tsx
@@ -1625,10 +1625,11 @@ export function MapBuilderPage() {
               onPasteStyle={layers.handlePasteStyle}
               onBulkApplyStyle={handleBulkApplyStyle}
               copiedStyleGeometryClass={layers.copiedStyleGeometryClass}
-              onKeyboardReorder={(layerId, direction) => {
-                if (direction === 'up') layers.handleMoveUp(layerId);
-                else layers.handleMoveDown(layerId);
-              }}
+              onKeyboardReorder={(layerId, direction) =>
+                direction === 'up'
+                  ? layers.handleMoveUp(layerId)
+                  : layers.handleMoveDown(layerId)
+              }
               // fix(#759): the keyboard reorder mode shares the pointer
               // path's aria-live region instead of staying silent.
               onAnnounce={announce}

--- a/frontend/src/pages/MapBuilderPage.tsx
+++ b/frontend/src/pages/MapBuilderPage.tsx
@@ -1629,6 +1629,9 @@ export function MapBuilderPage() {
                 if (direction === 'up') layers.handleMoveUp(layerId);
                 else layers.handleMoveDown(layerId);
               }}
+              // fix(#759): the keyboard reorder mode shares the pointer
+              // path's aria-live region instead of staying silent.
+              onAnnounce={announce}
               onAddDataClick={handleAddDataClick}
               onAddDataset={(datasetId: string) => {
                 layers.handleAddDataset(datasetId, (newLayerId) => {


### PR DESCRIPTION
## What

Two audit fixes on independent surfaces:

- **#759 — keyboard reorder was dead on every stack row (WCAG 2.1.1).** `DragGripButton` spread the dnd-kit `listeners` and then set `onKeyDown={onKeyDown}` unconditionally after the spread — a later JSX prop wins even when `undefined`, so the KeyboardSensor activator was destroyed for every caller (verified in the audit by render probe: 0 invocations). This is the second occurrence of the props-after-listeners-spread trap (first: #525).
  - The grip now **composes**: the row's own handler runs first, and the dnd-kit activator only sees keys the row didn't claim. Folder groups and the basemap group (which pass no custom handler) get native dnd-kit keyboard drag back; StackRow's fallback reorder mode keeps claiming Space/arrows/Escape, so there is no double handling.
  - The fallback mode now drives `aria-pressed` on the grip and announces arm / each move / drop / cancel through the builder's shared live region (three new `a11y.reorder*` keys in all four locales; pickup and cancel reuse the existing drag keys). `aria-pressed` is only overridden when a row actually drives the mode, so dnd-kit's own managed value is preserved on group rows.
  - The fix lives in the one shared grip component, which is also where both occurrences of the trap lived — there is no remaining listeners-spread call site to hook a grep on.
- **#762 — a stale persisted analysis job logged anonymous visitors out.** `AnalysisJobWatcher` mounts in RootLayout over a persist-backed job id; `useJobStatus` had no token gate, so an anonymous session on a public page fired an authenticated-only poll whose 401 ended the session. The hook now gates on `hasToken` exactly like its sibling `useDatasetJobStatus`; the watcher already clears the tracked job on 401/403/404 once a real response arrives.

## Verification

- `npx vitest run src/components/builder/__tests__/ src/components/import/hooks/__tests__/use-ingest.test.ts` — 1348 passed (new: FolderGroupRow activator regression test, 3 StackRow reorder-mode tests, anonymous-poll gate test)
- `npm run lint`, `npm run typecheck`, `npm run test:i18n` — clean

Closes #759. Closes #762.