### PR TITLE
docs(changelog): move the 1.5.1 export-capability fix under Security with its advisory link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ and releases use semantic versioning.
 
 ## [1.5.1] - 2026-07-27
 
+### Security
+
+- **Creating a dataset from an analysis now requires the `export`
+  capability in addition to `upload`** — advisory `GHSA-8gvc-94m7-m462`
+  (moderate): analysis materialize bypassed the export capability, enabling
+  durable dataset copies that survive grant revocation. The download
+  endpoints already enforced `export`; a materialized result is a
+  caller-owned copy of the source's attributes, so the two paths now agree.
+  Installations on the default role matrix are unaffected (editor and admin
+  hold both capabilities); deployments that withhold `export` from a role
+  should upgrade. Details:
+  <https://github.com/geolens-io/geolens/security/advisories/GHSA-8gvc-94m7-m462>
+
 ### Fixed
 
 - **Keyboard reorder works again on every stack row.** The shared drag grip
@@ -58,11 +71,6 @@ and releases use semantic versioning.
 
 ### Changed
 
-- **Creating a dataset from an analysis now requires the `export`
-  capability in addition to `upload`,** matching the download endpoints —
-  the result is a caller-owned copy of the source's attributes, so the two
-  paths now agree under a customized role matrix. Installations using the
-  default role matrix are unaffected (editor and admin hold both).
 - **The Analysis panel no longer loses its form to a panel switch.** Clicking
   Notes, History, or Ask AI (or crossing the mobile breakpoint) used to
   silently discard every field — including a hand-drawn clip mask and a typed


### PR DESCRIPTION
GHSA-8gvc-94m7-m462 is published, so the changelog entry for the 1.5.1 fix can now say what it was: the materialize path bypassed the `export` capability. This moves the bullet from **Changed** to a new **Security** section at the top of the 1.5.1 entry and links the advisory (inline URL, so the awk-extracted release body renders it).

The v1.5.1 GitHub Release body has been re-extracted from this version of the entry and already updated to match.

No code changes. Verification: `awk '/^## \[1.5.1\]/{f=1;next} /^## \[/{if(f)exit} f{print}' CHANGELOG.md` renders the Security section first (83 lines).