### PR TITLE
ci: run SDK gates on SDK-only changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,7 @@ jobs:
       e2e: ${{ steps.filter.outputs.e2e }}
       cli: ${{ steps.filter.outputs.cli }}
       mcp: ${{ steps.filter.outputs.mcp }}
+      sdks: ${{ steps.filter.outputs.sdks }}
       alembic: ${{ steps.filter.outputs.alembic }}
       installer: ${{ steps.filter.outputs.installer }}
       backup: ${{ steps.filter.outputs.backup }}
@@ -86,6 +87,12 @@ jobs:
             mcp:
               - 'mcp/**'
               - 'sdks/python/**'
+            # fix(#709): a PR that only touches the SDKs' own toolchain
+            # (generator, package.json, tsconfig) ran neither drift gate,
+            # so generator breakage merged green and reddened main on push.
+            sdks:
+              - 'sdks/**'
+              - 'backend/openapi.json'
             alembic:
               - 'backend/alembic/**'
               - 'backend/scripts/test_alembic_upgrade_clean_db.sh'
@@ -490,7 +497,7 @@ jobs:
   openapi-snapshot:
     name: OpenAPI Snapshot Drift
     needs: changes
-    if: needs.changes.outputs.backend == 'true' || github.event_name == 'push'
+    if: needs.changes.outputs.backend == 'true' || needs.changes.outputs.sdks == 'true' || github.event_name == 'push'
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -526,7 +533,7 @@ jobs:
   sdks-check:
     name: SDKs Drift Gate
     needs: changes
-    if: needs.changes.outputs.backend == 'true' || github.event_name == 'push'
+    if: needs.changes.outputs.backend == 'true' || needs.changes.outputs.sdks == 'true' || github.event_name == 'push'
     runs-on: ubuntu-latest
     env:
       # Match the OpenAPI snapshot job's env so dump_openapi.py runs


### PR DESCRIPTION
## What

Adds an `sdks` entry to the `changes` path-filter block (`sdks/**` + `backend/openapi.json`, per the issue's proposed fix) and ORs `needs.changes.outputs.sdks == 'true'` into the two gates that exist to catch SDK/generator breakage:

- `openapi-snapshot` (OpenAPI Snapshot Drift)
- `sdks-check` (SDKs Drift Gate)

## Why

A PR that only changes the SDKs' own toolchain (e.g. `sdks/typescript/package.json`, the `@hey-api/openapi-ts` generator, its TypeScript) matched no filter that feeds these gates, so it ran neither. The `|| github.event_name == 'push'` clause meant the failure only surfaced *after* merge — a green PR that reddens main, which is exactly how the TypeScript 7 bump in #608 got through.

## Scope notes

- Surgical: one new filter + two condition edits; no workflow restructuring.
- The issue asked to check the sibling `CLI Tests` job for the same gap: it already gates on `cli == 'true' || backend == 'true' || push`, and the `cli` filter carries `sdks/python/**` (as does `mcp`), so the Python-SDK path is covered there. The uncovered surface was `sdks/typescript/**` and the two drift gates, both fixed here.
- `backend/openapi.json` is also in the `backend` filter, so listing it under `sdks` is belt-and-braces: the sdks gate stays correct even if the backend filter list changes.

## Verification

- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"` — parses clean.
- Pre-commit `check yaml` hook passed on commit.
- Condition shape mirrors the existing multi-output condition on `cli-test`.

Closes #709

https://claude.ai/code/session_01TEhW22Yf94GjuKYxMhcbLt