### PR TITLE
fix(analysis): fence terminal writes, surface renames, size-check real output

### DIFF
--- a/backend/app/processing/analysis/tasks.py
+++ b/backend/app/processing/analysis/tasks.py
@@ -248,19 +248,83 @@ async def _enforce_output_size(
         )
 
 
+async def _complete_job_for_attempt(
+    session: AsyncSession,
+    *,
+    job_id: str,
+    attempt_id: uuid.UUID,
+    dataset_id: uuid.UUID,
+    schema: str,
+    out_table: str,
+    operation: str,
+) -> None:
+    """Commit registration together with the fenced terminal 'complete' write.
+
+    fix(#786): the terminal write is fenced on the attempt token, like the
+    claim and ``_fail_cancelled_job`` — a plain ``job.status = "complete"``
+    would overwrite a row the stale-job sweep already failed (a stalled
+    heartbeat expires the lease), resurrecting failed → complete and handing
+    the user a dataset for a job they were told failed. The fence shares the
+    registration transaction, so a miss rolls the Dataset row back with it.
+    """
+    if await update_ingest_job_for_attempt(
+        session,
+        uuid.UUID(job_id),
+        attempt_id,
+        values={"status": "complete", "dataset_id": dataset_id},
+    ):
+        await session.commit()
+        ANALYSIS_JOBS.labels(operation=operation, status="complete").inc()
+        return
+    await session.rollback()
+    logger.warning("analysis.complete_write_superseded", job_id=job_id)
+    # The build commit made the output table durable, and the rollback above
+    # discarded its only registration. Only this worker registers or
+    # completes the job (retry=0), so the table is a provable orphan — drop
+    # it instead of leaking it.
+    try:
+        await session.execute(text(f'DROP TABLE IF EXISTS "{schema}"."{out_table}"'))
+        await session.commit()
+    except Exception:  # broad: best-effort cleanup of the orphaned output
+        await session.rollback()
+
+
 async def _mark_job_failed(
     session: AsyncSession,
     *,
     job_id: str,
+    attempt_id: uuid.UUID,
     exc: Exception,
     schema: str,
     out_table: str | None,
     operation: str,
 ) -> None:
-    """Roll back, drop this job's own partial table, and record the failure."""
-    from app.platform.jobs.models import IngestJob
+    """Roll back, record the failure, and drop this job's own partial table.
 
+    fix(#786): fenced on the attempt token FIRST, mirroring
+    ``_fail_cancelled_job`` — the previous plain ORM write could overwrite a
+    terminal state some other actor already set (the stale-job sweep failing
+    the row after a stalled lease, or a final commit that reached the server
+    before the connection dropped, leaving the row 'complete'). A successful
+    fence proves the row was still 'running', so the registration commit has
+    not happened and any committed output table is an unregistered orphan —
+    safe to drop. If the fence misses, the row AND the table are left alone.
+    """
     await session.rollback()
+    if not await update_ingest_job_for_attempt(
+        session,
+        uuid.UUID(job_id),
+        attempt_id,
+        values={
+            "status": "failed",
+            # Sanitized (fix(#692)): raw DB errors embed the generated SQL.
+            "error_message": _user_error_message(exc),
+        },
+    ):
+        await session.rollback()
+        logger.warning("analysis.failed_write_superseded", job_id=job_id)
+        return
+    await session.commit()
     if out_table is not None:
         try:
             await session.execute(
@@ -269,12 +333,6 @@ async def _mark_job_failed(
             await session.commit()
         except Exception:  # broad: best-effort cleanup of the partial table
             await session.rollback()
-    failed_job = await session.get(IngestJob, uuid.UUID(job_id))
-    if failed_job is not None:
-        failed_job.status = "failed"
-        # Sanitized (fix(#692)): raw DB errors embed the generated SQL.
-        failed_job.error_message = _user_error_message(exc)
-        await session.commit()
     ANALYSIS_JOBS.labels(operation=operation, status="failed").inc()
 
 
@@ -301,6 +359,26 @@ async def _list_carry_columns(
     return [row[0] for row in rows]
 
 
+def _wrap_not_empty(select_sql: str) -> str:
+    """Exclude NULL/EMPTY-geometry rows inside the CTAS itself.
+
+    fix(#786): ``_enforce_output_size`` probes ``pg_total_relation_size``
+    right after the CTAS, and the post-CTAS DELETE cannot shrink what it
+    measures — dead tuples keep their pages until a rewrite. Rows the
+    cleanup removes therefore counted toward the output ceiling for
+    buffer/centroid/dissolve and the drawn-mask clip, failing analyses
+    whose real output is small. The clip-by-layer branch has filtered
+    in-CTAS since fix(#719 review); this extends the same rule to the
+    other shapes. ``OFFSET 0`` fences subquery pull-up so the geometry
+    expression (``ST_Buffer`` at worst) is evaluated once per row rather
+    than re-evaluated inside the outer WHERE.
+    """
+    return (
+        f"SELECT * FROM ({select_sql} OFFSET 0) AS _rows"
+        f" WHERE geom IS NOT NULL AND NOT ST_IsEmpty(geom)"
+    )
+
+
 def _build_materialize_select(
     src_ref: str,
     operation: str,
@@ -320,13 +398,13 @@ def _build_materialize_select(
         union_expr = "ST_Multi(ST_CollectionExtract(ST_Union(ST_MakeValid(geom_4326))))"
         if by_field:
             col = f'"{by_field}"'
-            return (
+            return _wrap_not_empty(
                 f"SELECT (row_number() OVER ())::integer AS gid, {col}, "
                 f"COUNT(*)::integer AS source_count, "
                 f"{union_expr} AS geom "
                 f"FROM {src_ref} GROUP BY {col}"
             )
-        return (
+        return _wrap_not_empty(
             f"SELECT 1 AS gid, COUNT(*)::integer AS source_count, "
             f"{union_expr} AS geom FROM {src_ref}"
         )
@@ -359,7 +437,7 @@ def _build_materialize_select(
         mask=mask,
     )
     cols = "".join(f"{_sql_quote_ident(c)}, " for c in carry_cols)
-    return f"SELECT gid, {cols}{expr} AS geom FROM {src_ref}{where}"
+    return _wrap_not_empty(f"SELECT gid, {cols}{expr} AS geom FROM {src_ref}{where}")
 
 
 async def _materialize(
@@ -475,7 +553,17 @@ async def _materialize(
                 mask_table_ref=mask_table_ref,
             )
 
-            out_table, _warning = await generate_table_name(title, session)
+            out_table, collision_warning = await generate_table_name(title, session)
+            if collision_warning:
+                # fix(#786): persisted like the upload path (tasks_vector) —
+                # the job-status endpoint surfaces
+                # user_metadata['collision_warning'] as warning_message, so
+                # discarding it here silently landed an analysis output in
+                # e.g. parcels_buffered_3 with no indication to the user.
+                job.user_metadata = {
+                    **(job.user_metadata or {}),
+                    "collision_warning": collision_warning,
+                }
             out_ref = f'"{_schema}"."{out_table}"'
 
             carry_cols = (
@@ -509,13 +597,16 @@ async def _materialize(
             # hold the single worker slot through the rewrite phases. The
             # authoritative check runs after add_4326_column below.
             await _enforce_output_size(session, _schema, out_table)
-            # Rows with nothing to show are dropped for EVERY operation, not
-            # just clip (fix(#692)): buffer/centroid map NULL source
+            # Rows with nothing to show are excluded inside the CTAS for
+            # EVERY shape (fix(#786), extending fix(#719 review)'s clip
+            # rule via _wrap_not_empty): buffer/centroid map NULL source
             # geometries to NULL, dissolve unions an all-NULL group to NULL,
             # and boundary-grazing clips survive ST_Intersects but extract to
             # EMPTY (see analysis_sql.render_geometry_expr). The preview
             # filters the same rows in SQL (fix(#680 review)) — the saved
-            # dataset must agree with the preview the user approved.
+            # dataset must agree with the preview the user approved. This
+            # DELETE stays as the backstop enforcing that invariant should a
+            # future query shape miss the in-CTAS filter.
             await session.execute(
                 text(f"DELETE FROM {out_ref} WHERE geom IS NULL OR ST_IsEmpty(geom)")
             )
@@ -567,10 +658,15 @@ async def _materialize(
                 ),
                 requester,
             )
-            job.dataset_id = dataset.id
-            job.status = "complete"
-            await session.commit()
-            ANALYSIS_JOBS.labels(operation=operation, status="complete").inc()
+            await _complete_job_for_attempt(
+                session,
+                job_id=job_id,
+                attempt_id=attempt_id,
+                dataset_id=dataset.id,
+                schema=_schema,
+                out_table=out_table,
+                operation=operation,
+            )
         except asyncio.CancelledError:
             # Graceful worker shutdown cancels this task after the drain
             # window; `except Exception` cannot catch it, and retry=0 means no
@@ -607,6 +703,7 @@ async def _materialize(
             await _mark_job_failed(
                 session,
                 job_id=job_id,
+                attempt_id=attempt_id,
                 exc=exc,
                 schema=_schema,
                 out_table=out_table if out_table_created else None,

--- a/backend/tests/test_analysis_materialize.py
+++ b/backend/tests/test_analysis_materialize.py
@@ -13,7 +13,7 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 from httpx import AsyncClient
-from sqlalchemy import text, update
+from sqlalchemy import select, text, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 import app.core.db as core_db
@@ -835,6 +835,212 @@ class TestMaterializeWorker:
         await test_db_session.refresh(job)
         assert job.status == "failed"
         assert job.dataset_id is None
+
+    async def test_sweeper_failed_job_is_not_resurrected_at_completion(
+        self,
+        test_db_session: AsyncSession,
+    ):
+        """fix(#786): the terminal 'complete' write is fenced on the attempt
+        token like the claim — if a stalled heartbeat lets the lease expire
+        and the stale-job sweep fails the row mid-run, the worker must not
+        overwrite failed → complete and hand the user a dataset for a job
+        they were told failed. The fence shares the registration
+        transaction, so the Dataset row rolls back with the miss, and the
+        already-committed output table is dropped as a provable orphan."""
+        import app.processing.ingest.service as ingest_service
+
+        admin_id = await get_user_id(test_db_session, "admin")
+        ds = await _create_polygon_dataset(test_db_session, created_by=admin_id)
+        job = await _create_job(test_db_session, admin_id)
+
+        real_register = ingest_service.register_existing_table
+        out_tables: list[str] = []
+
+        async def sweeping_register(session, request, user):
+            # The sweep lands between the build commit and the terminal
+            # write: fail the row out from under the worker on its own
+            # session, exactly as the platform's stale-job sweep does.
+            out_tables.append(request.table_name)
+            async with core_db.async_session() as sweeper:
+                await sweeper.execute(
+                    update(IngestJob)
+                    .where(IngestJob.id == job.id)
+                    .values(
+                        status="failed",
+                        error_message="Stale: heartbeat lease expired",
+                    )
+                )
+                await sweeper.commit()
+            return await real_register(session, request, user)
+
+        with patch.object(ingest_service, "register_existing_table", sweeping_register):
+            await _materialize(
+                job_id=str(job.id),
+                dataset_id=str(ds.id),
+                user_id=str(admin_id),
+                operation="centroid",
+                title=f"Superseded {uuid.uuid4().hex[:6]}",
+            )
+
+        await test_db_session.refresh(job)
+        assert job.status == "failed"
+        assert job.error_message == "Stale: heartbeat lease expired"
+        assert job.dataset_id is None
+        assert out_tables, "materialize never reached registration"
+
+        from app.modules.catalog.datasets.domain.models import Dataset
+
+        registered = (
+            await test_db_session.execute(
+                select(Dataset).where(Dataset.table_name == out_tables[0])
+            )
+        ).scalar_one_or_none()
+        assert registered is None
+        # ...and the committed output table was dropped, not leaked.
+        leaked = (
+            await test_db_session.execute(
+                text("SELECT to_regclass(:ref)").bindparams(
+                    ref=f'data."{out_tables[0]}"'
+                )
+            )
+        ).scalar_one()
+        assert leaked is None
+
+    async def test_sweeper_failed_job_error_is_not_overwritten(
+        self,
+        test_db_session: AsyncSession,
+    ):
+        """fix(#786): _mark_job_failed is fenced like _fail_cancelled_job —
+        when another actor already moved the row to a terminal state, this
+        worker's later failure must not clobber the message the user saw.
+        And since the failure path cannot tell a swept row from a completed
+        one, it must leave the output table alone (the name generator
+        self-heals around the orphan, fix(#692))."""
+        import app.processing.ingest.service as ingest_service
+
+        admin_id = await get_user_id(test_db_session, "admin")
+        ds = await _create_polygon_dataset(test_db_session, created_by=admin_id)
+        job = await _create_job(test_db_session, admin_id)
+
+        out_tables: list[str] = []
+
+        async def sweeping_register(session, request, user):
+            out_tables.append(request.table_name)
+            async with core_db.async_session() as sweeper:
+                await sweeper.execute(
+                    update(IngestJob)
+                    .where(IngestJob.id == job.id)
+                    .values(
+                        status="failed",
+                        error_message="Stale: heartbeat lease expired",
+                    )
+                )
+                await sweeper.commit()
+            raise RuntimeError("boom after supersession")
+
+        with patch.object(ingest_service, "register_existing_table", sweeping_register):
+            await _materialize(
+                job_id=str(job.id),
+                dataset_id=str(ds.id),
+                user_id=str(admin_id),
+                operation="centroid",
+                title=f"Superseded fail {uuid.uuid4().hex[:6]}",
+            )
+
+        await test_db_session.refresh(job)
+        assert job.status == "failed"
+        assert job.error_message == "Stale: heartbeat lease expired"
+        assert job.dataset_id is None
+        assert out_tables, "materialize never reached registration"
+        left = (
+            await test_db_session.execute(
+                text("SELECT to_regclass(:ref)").bindparams(
+                    ref=f'data."{out_tables[0]}"'
+                )
+            )
+        ).scalar_one()
+        assert left is not None
+
+    async def test_name_collision_warning_is_surfaced(
+        self,
+        test_db_session: AsyncSession,
+    ):
+        """fix(#786): the rename generate_table_name reports on a collision
+        was discarded — the upload path persists it to
+        user_metadata['collision_warning'], which the job-status endpoint
+        surfaces as warning_message, so an analysis output landing in e.g.
+        parcels_buffered_3 said nothing to the user."""
+        from app.processing.ingest.service import generate_table_name
+
+        admin_id = await get_user_id(test_db_session, "admin")
+        ds = await _create_polygon_dataset(test_db_session, created_by=admin_id)
+        job = await _create_job(test_db_session, admin_id)
+        title = f"Warned {uuid.uuid4().hex[:6]}"
+        taken, _ = await generate_table_name(title, test_db_session)
+        await test_db_session.execute(
+            text(f'CREATE TABLE data."{taken}" (marker integer)')
+        )
+        await test_db_session.commit()
+
+        await _materialize(
+            job_id=str(job.id),
+            dataset_id=str(ds.id),
+            user_id=str(admin_id),
+            operation="centroid",
+            title=title,
+        )
+
+        await test_db_session.refresh(job)
+        assert job.status == "complete", job.error_message
+        warning = (job.user_metadata or {}).get("collision_warning")
+        assert warning is not None
+        assert f"{taken}_2" in warning
+
+    async def test_cleanup_rows_do_not_count_toward_size_cap(
+        self,
+        test_db_session: AsyncSession,
+    ):
+        """fix(#786): NULL/EMPTY-geometry rows are excluded in the CTAS
+        itself — a DELETE cannot shrink pg_total_relation_size (dead tuples
+        keep their pages until a rewrite), so the early ceiling probe used
+        to measure rows the cleanup removes and could fail a small analysis
+        as oversized. Same shape as the clip-by-layer case from the #719
+        review, extended to the render_geometry_expr operations."""
+        admin_id = await get_user_id(test_db_session, "admin")
+        ds = await _create_polygon_dataset(test_db_session, created_by=admin_id)
+        # 2,025 NULL-geometry decoys: centroid maps them to NULL and the
+        # cleanup removes them, but before the in-CTAS filter they inflated
+        # the measured relation well past the 64 KB ceiling below, while
+        # the 2 real centroids fit comfortably.
+        await test_db_session.execute(
+            text(
+                f"INSERT INTO data.{ds.table_name} (name) "  # noqa: S608
+                f"SELECT 'decoy' FROM generate_series(1, 2025)"
+            )
+        )
+        await test_db_session.commit()
+        job = await _create_job(test_db_session, admin_id)
+
+        with patch("app.processing.analysis.tasks.MAX_OUTPUT_BYTES", 65536):
+            await _materialize(
+                job_id=str(job.id),
+                dataset_id=str(ds.id),
+                user_id=str(admin_id),
+                operation="centroid",
+                title=f"Centroids {uuid.uuid4().hex[:6]}",
+            )
+
+        await test_db_session.refresh(job)
+        assert job.status == "complete", job.error_message
+
+        from app.modules.catalog.datasets.domain.models import Dataset
+
+        new_ds = await test_db_session.get(Dataset, job.dataset_id)
+        assert new_ds is not None
+        kept = await test_db_session.scalar(
+            text(f"SELECT COUNT(*) FROM data.{new_ds.table_name}")  # noqa: S608
+        )
+        assert kept == 2
 
     async def test_worker_cancellation_fails_job_and_reraises(
         self,


### PR DESCRIPTION
Three P3s from the 2026-07-27 builder/analysis audit, all in `backend/app/processing/analysis/tasks.py`.

## 1. Terminal job-state writes are now attempt-fenced

The success write (`job.status = "complete"`) and `_mark_job_failed`'s failure write were plain ORM overwrites, unlike `_fail_cancelled_job`, which routes through `update_ingest_job_for_attempt`. If the heartbeat stalled a full lease and the stale-job sweep failed the row, the worker later resurrected `failed` → `complete` — the exact clobber the claim-fence comment guards against, reintroduced at the back of the task.

- The success write moves into `_complete_job_for_attempt`: the fence shares the registration transaction, so a miss rolls the `Dataset` row back with it, and the already-committed output table (provably an unregistered orphan at that point — only this worker registers or completes, `retry=0`) is dropped instead of leaked.
- `_mark_job_failed` now fences FIRST, mirroring `_fail_cancelled_job`: a successful fence proves the row was still `running`, making the partial table safe to drop; on a miss both the row and the table are left alone (the failure path cannot distinguish a swept row from a `complete` row whose final commit reached the server just before the connection dropped).
- Scope: minimal fencing only, per the issue — the #691 heartbeat-lease design is untouched.

## 2. Table-name collision warning surfaced

`out_table, _warning = await generate_table_name(...)` threw the rename away, so an analysis output could silently land in `parcels_buffered_3`. It now persists to `user_metadata['collision_warning']` — the same key the upload path (`tasks_vector.py`) writes and `_job_to_status_response` already surfaces as `JobStatusResponse.warning_message`, so the existing job-status surface picks it up with no schema change.

## 3. Output-size check measures real output

The early `_enforce_output_size` probe runs on the CTAS before the NULL/EMPTY cleanup DELETE — and a DELETE cannot shrink `pg_total_relation_size` (dead tuples keep their pages until a rewrite), so "move the check after the DELETE" would have been a no-op. Fixed via the issue's other option: NULL/EMPTY-geometry rows are excluded **inside the CTAS** (`_wrap_not_empty`, with an `OFFSET 0` fence so the geometry expression isn't re-evaluated in the outer WHERE), extending the fix(#719 review) clip-by-layer rule to buffer/centroid/dissolve and the drawn-mask clip. The DELETE stays as the backstop that keeps the saved dataset agreeing with the preview.

## Tests

Four new regression tests in `backend/tests/test_analysis_materialize.py`, each verified to fail against the pre-fix code and pass with it:

- `test_sweeper_failed_job_is_not_resurrected_at_completion` (item 1, success path — no resurrection, registration rolled back, orphan table dropped)
- `test_sweeper_failed_job_error_is_not_overwritten` (item 1, failure path — sweeper's message preserved, table left alone)
- `test_name_collision_warning_is_surfaced` (item 2)
- `test_cleanup_rows_do_not_count_toward_size_cap` (item 3 — 2,025 NULL-geometry decoys under a 64 KB cap, same shape as the #719 clip test)

## Verification

- `cd backend && uv run ruff check . && uv run ruff format --check .` — clean.
- Against local Postgres (localhost:5434): `tests/test_analysis_materialize.py` + `test_analysis_preview.py` + `test_jobs_retry_analysis_copy.py` + `test_ai_chat_run_analysis.py` — **122 passed**; `test_ingest_job_attempt_fencing.py` + `test_stalled_queue_sweep_624.py` + `test_layering.py` — **45 passed**.

No API/schema/config impact.

Closes #786

https://claude.ai/code/session_01TEhW22Yf94GjuKYxMhcbLt