### PR TITLE
fix(analysis): honor the stack selection, convert buffer units, and keep Add Data open

### DIFF
--- a/frontend/src/components/builder/AnalysisPanel.tsx
+++ b/frontend/src/components/builder/AnalysisPanel.tsx
@@ -29,6 +29,7 @@ import { useAuthStore } from '@/stores/auth-store';
 import { useAnalysisJobStore } from '@/stores/analysis-job-store';
 import { useMapDrawStore } from '@/stores/map-draw-store';
 import type { LayerActions } from '@/components/builder/ChatPanel';
+import { isAnalysableLayer } from '@/components/builder/analysis-eligibility';
 import type { EphemeralAnalysisHandoff } from '@/components/builder/hooks/use-ephemeral-layers';
 import type { AnalysisOperation, MapLayerResponse } from '@/types/api';
 
@@ -40,34 +41,27 @@ const MASK_LAYER_NONE = '__none__';
 // backend/app/modules/catalog/datasets/api/router_analysis.py — the server
 // rejects any other mask dataset with a 422.
 const POLYGONAL_GEOMETRY_TYPES = new Set(['POLYGON', 'MULTIPOLYGON']);
-// ux(#720): analysis needs a VECTOR dataset. `!is_dem` alone let ordinary
-// raster layers (COG orthophotos, Sentinel scenes) through — they carry a
-// dataset_id, so the panel offered them and auto-selected the first one, and
-// every Preview 422'd.
-//
-// Keyed on dataset_record_type, NOT layer_type (fix(#720 review)). layer_type
-// selects a RENDERER and the API validates it against nothing — MapLayerInput
-// accepts any supported value and add_layer persists it, defaulting to
-// 'vector_geolens'. So a raster dataset can carry the vector default, which is
-// how getLayerCapabilities (which keys on layer_type) would misclassify it, and
-// a vector dataset overridden to the raster renderer would be hidden even
-// though the analysis endpoint accepts it. record_type is what the data IS.
-//
-// geometry_type is required on top of that: it is the precondition
-// _load_vector_dataset enforces server-side, so a vector dataset missing one
-// would 422 just the same. Testing it ALONE was the original bug — it happened
-// to work only because every raster dataset currently stores NULL there, an
-// incidental property of the ingest path rather than an invariant.
-const RASTER_RECORD_TYPES = new Set(['raster_dataset', 'vrt_dataset']);
-const isAnalysableLayer = (l: MapLayerResponse) =>
-  !!l.dataset_id &&
-  !l.is_dem &&
-  !RASTER_RECORD_TYPES.has((l.dataset_record_type ?? '').toLowerCase()) &&
-  !!l.dataset_geometry_type;
 // ux(#686): buffer distances are metres on the wire; the picker converts so a
 // user thinking in feet or miles doesn't have to.
 const BUFFER_UNIT_METERS = { m: 1, km: 1000, ft: 0.3048, mi: 1609.344 } as const;
 type BufferUnit = keyof typeof BUFFER_UNIT_METERS;
+// ux(#773): switching the unit converts the displayed number so the PHYSICAL
+// distance is preserved — "100 m" becomes "0.1 km", not a silent 1000×
+// reinterpretation. Rounded to 6 significant digits to trim float tails
+// (0.3 km → 300 m, not 300.00000000000006) while staying far finer than any
+// map-distance precision the buffer endpoint cares about.
+const convertDistanceBetweenUnits = (
+  raw: string,
+  from: BufferUnit,
+  to: BufferUnit,
+): string => {
+  if (from === to) return raw;
+  const value = Number(raw);
+  // An empty or unparseable field has no physical distance to preserve.
+  if (raw.trim() === '' || !Number.isFinite(value)) return raw;
+  const converted = (value * BUFFER_UNIT_METERS[from]) / BUFFER_UNIT_METERS[to];
+  return String(Number(converted.toPrecision(6)));
+};
 // Suffixes of the existing analysisTools.unit* keys, so the range message can
 // name the unit in the user's language without a second set of strings.
 const UNIT_KEY: Record<BufferUnit, string> = {
@@ -82,6 +76,11 @@ interface AnalysisPanelProps {
   /** fix(#757)/fix(#760): keys the remembered form and the rehydrated job to
    *  the map they belong to. */
   mapId?: string;
+  /** ux(#772): the layer currently selected in the builder's stack. When it is
+   *  analysable, the panel opens targeting it instead of whatever sorts first —
+   *  behind an explicit chat prefill, ahead of the remembered form's layer.
+   *  Read at mount only, like every other initializer here. */
+  selectedLayerId?: string | null;
   mapInstanceRef?: React.RefObject<MaplibreMap | null>;
   onPreviewResult?: (
     geojson: GeoJSON.FeatureCollection,
@@ -117,6 +116,7 @@ interface AnalysisPanelProps {
 export function AnalysisPanel({
   layers,
   mapId,
+  selectedLayerId,
   mapInstanceRef,
   onPreviewResult,
   onClearPreview,
@@ -134,6 +134,17 @@ export function AnalysisPanel({
     prefill && layers.some((l) => l.id === prefill.layerId && isAnalysableLayer(l))
       ? prefill.layerId
       : undefined;
+  // ux(#772): the stack's selected row, when it is an analysable layer —
+  // "analyze THIS layer" is the common intent behind opening the panel, so it
+  // beats the remembered form's layer and the first-eligible default. A chat
+  // prefill still wins: it names its own layer explicitly. Non-layer ids the
+  // selection slot also carries ('settings', a folder group) validate false
+  // here and change nothing.
+  const stackLayerId =
+    selectedLayerId &&
+    layers.some((l) => l.id === selectedLayerId && isAnalysableLayer(l))
+      ? selectedLayerId
+      : undefined;
   // fix(#757): the panel is conditionally mounted, so a rail switch, Escape,
   // or a breakpoint crossing destroys it — restore the remembered form for
   // this map instead of losing a drawn mask and a typed name to a stray
@@ -149,9 +160,16 @@ export function AnalysisPanel({
     );
     return sourceStillEligible ? remembered : null;
   });
-  const [layerId, setLayerId] = useState(
-    prefillLayerId ?? savedForm?.layerId ?? firstEligibleId,
-  );
+  const initialLayerId =
+    prefillLayerId ?? stackLayerId ?? savedForm?.layerId ?? firstEligibleId;
+  // ux(#772): a stack selection that DISPLACES the remembered layer makes this
+  // mount a different draft. The layer-coupled remembered fields (byField, any
+  // run the form still owned) reset exactly as if the layer select had been
+  // edited — fix(#680)/fix(#793) semantics — while the layer-agnostic ones
+  // (operation, distance, drawn mask, typed name) still restore.
+  const stackDisplacesSavedLayer =
+    stackLayerId != null && !!savedForm && savedForm.layerId !== stackLayerId;
+  const [layerId, setLayerId] = useState(initialLayerId);
   // fix(#793 review): the initializers here deliberately DROP a remembered
   // selection whose source or mask layer left the map while the panel was
   // closed — but the page-level preview overlay drawn from that selection is
@@ -166,6 +184,10 @@ export function AnalysisPanel({
       const remembered = useAnalysisFormStore.getState().forms[mapId];
       if (!remembered) return false;
       return (
+        // ux(#772): a stack selection displacing the remembered layer leaves
+        // any panel-drawn overlay depicting the displaced layer's result —
+        // stale for the same reason a vanished layer's would be.
+        stackDisplacesSavedLayer ||
         !layers.some(
           (l) => l.id === remembered.layerId && isAnalysableLayer(l),
         ) ||
@@ -190,11 +212,19 @@ export function AnalysisPanel({
   const [isDrawing, setIsDrawing] = useState(false);
   // Layer-sourced clip mask; mutually exclusive with a drawn mask.
   const [maskLayerId, setMaskLayerId] = useState(() =>
-    savedForm && layers.some((l) => l.id === savedForm.maskLayerId)
+    savedForm &&
+    // ux(#772): a mask layer can't clip itself — the stack-selected layer may
+    // BE the remembered mask layer (mirrors the layer select's own guard).
+    savedForm.maskLayerId !== initialLayerId &&
+    layers.some((l) => l.id === savedForm.maskLayerId)
       ? savedForm.maskLayerId
       : MASK_LAYER_NONE,
   );
-  const [byField, setByField] = useState(savedForm?.byField ?? BY_FIELD_NONE);
+  const [byField, setByField] = useState(
+    // ux(#772)/fix(#680) parity: a remembered group-by column belongs to the
+    // remembered layer — it must not carry to a stack-selected one.
+    savedForm && !stackDisplacesSavedLayer ? savedForm.byField : BY_FIELD_NONE,
+  );
   // A chat handoff lands on the save form — suggest a title so its primary
   // button isn't silently disabled for want of one.
   const [outputTitle, setOutputTitle] = useState(() => {
@@ -222,7 +252,9 @@ export function AnalysisPanel({
     // fix(#793 review): a restored draft that disowned the run (edited
     // mid-flight, then the panel closed) must not readopt it at mount — the
     // run stays ambient, exactly as the adoption effect below decides.
-    if (savedForm?.runDisowned) return null;
+    // ux(#772): a stack selection displacing the remembered layer disowns the
+    // run the same way — the mounted form no longer matches its parameters.
+    if (savedForm?.runDisowned || stackDisplacesSavedLayer) return null;
     const tracked = useAnalysisJobStore.getState().job;
     return tracked && tracked.mapId && tracked.mapId === mapId
       ? tracked.jobId
@@ -231,7 +263,7 @@ export function AnalysisPanel({
   // fix(#764): the completed run's title, so "Add to map" can say what it
   // adds even after the input field is cleared or edited.
   const [lastRunTitle, setLastRunTitle] = useState(() => {
-    if (prefill || savedForm?.runDisowned) return '';
+    if (prefill || savedForm?.runDisowned || stackDisplacesSavedLayer) return '';
     const tracked = useAnalysisJobStore.getState().job;
     return tracked && tracked.mapId && tracked.mapId === mapId
       ? tracked.title
@@ -255,8 +287,12 @@ export function AnalysisPanel({
   // between the edit and the POST response cannot launder the disowning.
   // A chat prefill starts disowned outright (fix(#793 review)): it is a new
   // draft, so no pre-existing run may be adopted or clear its suggested
-  // title on completion.
-  const formEditedRef = useRef(prefill ? true : (savedForm?.runDisowned ?? false));
+  // title on completion. ux(#772): so does a mount whose stack selection
+  // displaced the remembered layer — the run's blessed form is known to
+  // differ from what this mount shows.
+  const formEditedRef = useRef(
+    prefill || stackDisplacesSavedLayer ? true : (savedForm?.runDisowned ?? false),
+  );
   const trackedJob = useAnalysisJobStore((s) => s.job);
   useEffect(() => {
     if (!trackedJob || !mapId || trackedJob.mapId !== mapId) return;
@@ -883,7 +919,12 @@ export function AnalysisPanel({
               value={distanceUnit}
               onValueChange={(v) => {
                 handleInputsChanged();
-                setDistanceUnit(v as BufferUnit);
+                const next = v as BufferUnit;
+                // ux(#773): keep the physical distance, not the number —
+                // without this, "100 m" switched to miles silently meant
+                // "100 miles".
+                setDistance(convertDistanceBetweenUnits(distance, distanceUnit, next));
+                setDistanceUnit(next);
               }}
             >
               <SelectTrigger

--- a/frontend/src/components/builder/BuilderRail.tsx
+++ b/frontend/src/components/builder/BuilderRail.tsx
@@ -106,6 +106,10 @@ interface BuilderRailProps {
   ) => void;
   // Analysis tools
   mapInstanceRef?: React.RefObject<MaplibreMap | null>;
+  /** ux(#772): the layer selected in the builder's stack — the Analysis
+   *  panel prefers it (when analysable) over the remembered form's layer and
+   *  the first-eligible default. */
+  selectedLayerId?: string | null;
   onClearPreview?: () => void;
   hasPreview?: boolean;
   /** fix(#793 review): who drew the current ephemeral overlay — the
@@ -137,6 +141,7 @@ export function BuilderRail({
   layerActions,
   onQueryResult,
   mapInstanceRef,
+  selectedLayerId,
   onClearPreview,
   hasPreview,
   previewSource,
@@ -332,6 +337,7 @@ export function BuilderRail({
                     }
                     layers={layers}
                     mapId={mapId}
+                    selectedLayerId={selectedLayerId}
                     mapInstanceRef={mapInstanceRef}
                     onPreviewResult={onQueryResult}
                     onClearPreview={onClearPreview}

--- a/frontend/src/components/builder/DatasetSearchPanel.tsx
+++ b/frontend/src/components/builder/DatasetSearchPanel.tsx
@@ -569,12 +569,10 @@ export function DatasetSearchPanel({
         </div>
       )}
 
-      <div
-        className={cn(
-          'mt-3 max-h-[24rem] space-y-1 overflow-y-auto px-1',
-          isFetching && !isLoading && 'pointer-events-none opacity-50',
-        )}
-      >
+      {/* ux(#776): no pointer-events/opacity freeze during debounced
+          refetches — the pulse band above already signals them, and the
+          freeze made visible rows unclickable on every keystroke pause. */}
+      <div className="mt-3 max-h-[24rem] space-y-1 overflow-y-auto px-1">
         {results.map((record) => (
           <DraggableDatasetRow
             key={record.id}

--- a/frontend/src/components/builder/SortableStackRow.tsx
+++ b/frontend/src/components/builder/SortableStackRow.tsx
@@ -16,6 +16,8 @@ interface SortableStackRowProps {
   onDuplicate: (id: string) => void;
   // Phase 1201-01 (ENH-01/ENH-02): kebab authoring actions threaded to StackRow.
   onZoomToLayer?: (id: string) => void;
+  /** ux(#772): opens the Analysis panel prefilled with this layer. */
+  onAnalyzeLayer?: (id: string) => void;
   onCopyStyle?: (id: string) => void;
   onPasteStyle?: (id: string) => void;
   canPasteStyle?: boolean;
@@ -56,6 +58,7 @@ export const SortableStackRow = memo(function SortableStackRow({
   onRename,
   onDuplicate,
   onZoomToLayer,
+  onAnalyzeLayer,
   onCopyStyle,
   onPasteStyle,
   canPasteStyle,
@@ -111,6 +114,7 @@ export const SortableStackRow = memo(function SortableStackRow({
         onRename={onRename}
         onDuplicate={onDuplicate}
         onZoomToLayer={onZoomToLayer}
+        onAnalyzeLayer={onAnalyzeLayer}
         onCopyStyle={onCopyStyle}
         onPasteStyle={onPasteStyle}
         canPasteStyle={canPasteStyle}

--- a/frontend/src/components/builder/StackRow.tsx
+++ b/frontend/src/components/builder/StackRow.tsx
@@ -9,6 +9,7 @@ import {
   ExternalLink,
   Eye,
   EyeOff,
+  FlaskConical,
   Folder,
   FolderMinus,
   FolderPlus,
@@ -31,6 +32,7 @@ import {
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
 import { LayerTypeIcon } from '@/components/map/layer-icons';
+import { isAnalysableLayer } from '@/components/builder/analysis-eligibility';
 import { getLayerCapabilities } from '@/lib/layer-capabilities';
 import { cn } from '@/lib/utils';
 import { semanticBadgeColors } from '@/lib/status-colors';
@@ -59,6 +61,9 @@ interface StackRowProps {
   // Phase 1201-01 (ENH-01/ENH-02): kebab authoring actions.
   /** Frames the map to this layer's extent (ENH-01). */
   onZoomToLayer?: (id: string) => void;
+  /** ux(#772): opens the Analysis panel prefilled with this layer. Rendered
+   *  only for analysable (vector dataset) layers. */
+  onAnalyzeLayer?: (id: string) => void;
   /** Stashes this layer's geometry-compatible style in the session clipboard (ENH-02). */
   onCopyStyle?: (id: string) => void;
   /** Applies the clipboard style to this layer (ENH-02); disabled when !canPasteStyle. */
@@ -125,6 +130,7 @@ export const StackRow = memo(function StackRow({
   onRename,
   onDuplicate,
   onZoomToLayer,
+  onAnalyzeLayer,
   onCopyStyle,
   onPasteStyle,
   canPasteStyle = false,
@@ -580,6 +586,18 @@ export const StackRow = memo(function StackRow({
               <Crosshair className="h-3.5 w-3.5 me-2" aria-hidden="true" />
               {t('stackRow.kebabZoomToLayer', { defaultValue: 'Zoom to layer' })}
             </DropdownMenuItem>
+            {/* ux(#772): jump straight into Analysis targeting this layer.
+                Gated on the panel's own eligibility predicate so a raster or
+                DEM row doesn't offer an entry the panel would ignore. */}
+            {onAnalyzeLayer && isAnalysableLayer(layer) && (
+              <DropdownMenuItem
+                data-testid="kebab-analyze-layer"
+                onSelect={() => onAnalyzeLayer(layer.id)}
+              >
+                <FlaskConical className="h-3.5 w-3.5 me-2" aria-hidden="true" />
+                {t('stackRow.kebabAnalyzeLayer', { defaultValue: 'Analyze this layer' })}
+              </DropdownMenuItem>
+            )}
             <DropdownMenuItem
               data-testid="kebab-copy-style"
               onSelect={() => onCopyStyle?.(layer.id)}

--- a/frontend/src/components/builder/UnifiedStackPanel.tsx
+++ b/frontend/src/components/builder/UnifiedStackPanel.tsx
@@ -80,6 +80,8 @@ interface UnifiedStackPanelProps {
   // Phase 1201-01 (ENH-01/ENH-02/ENH-03): authoring actions threaded to the kebab
   // + bulk bar.
   onZoomToLayer?: (id: string) => void;
+  /** ux(#772): opens the Analysis panel prefilled with this layer. */
+  onAnalyzeLayer?: (id: string) => void;
   onCopyStyle?: (id: string) => void;
   onPasteStyle?: (id: string) => void;
   onBulkApplyStyle?: (ids: Set<string>) => void;
@@ -297,6 +299,7 @@ export const UnifiedStackPanel = memo(function UnifiedStackPanel({
   onRename,
   onDuplicate,
   onZoomToLayer,
+  onAnalyzeLayer,
   onCopyStyle,
   onPasteStyle,
   onBulkApplyStyle,
@@ -776,6 +779,7 @@ export const UnifiedStackPanel = memo(function UnifiedStackPanel({
                                 onRename={onRename}
                                 onDuplicate={onDuplicate}
                                 onZoomToLayer={onZoomToLayer}
+                                onAnalyzeLayer={onAnalyzeLayer}
                                 onCopyStyle={onCopyStyle}
                                 onPasteStyle={onPasteStyle}
                                 canPasteStyle={
@@ -823,6 +827,7 @@ export const UnifiedStackPanel = memo(function UnifiedStackPanel({
                     onRename={onRename}
                     onDuplicate={onDuplicate}
                     onZoomToLayer={onZoomToLayer}
+                    onAnalyzeLayer={onAnalyzeLayer}
                     onCopyStyle={onCopyStyle}
                     onPasteStyle={onPasteStyle}
                     canPasteStyle={

--- a/frontend/src/components/builder/__tests__/AnalysisPanel.test.tsx
+++ b/frontend/src/components/builder/__tests__/AnalysisPanel.test.tsx
@@ -482,12 +482,15 @@ describe('AnalysisPanel', () => {
     const user = userEvent.setup();
     renderPanel([datasetLayer]);
 
-    fireEvent.change(screen.getByLabelText('Distance'), {
-      target: { value: '2' },
-    });
+    // ux(#773): pick the unit FIRST — changing it now converts the number to
+    // preserve the physical distance, so typing after the switch is how a
+    // user enters "2 miles".
     // Combobox order under buffer: layer, operation, distance unit.
     await user.click(screen.getAllByRole('combobox')[2]);
     await user.click(await screen.findByRole('option', { name: 'miles' }));
+    fireEvent.change(screen.getByLabelText('Distance'), {
+      target: { value: '2' },
+    });
 
     fireEvent.click(screen.getByRole('button', { name: 'Preview' }));
     await waitFor(() =>
@@ -496,6 +499,59 @@ describe('AnalysisPanel', () => {
         distance_meters: 2 * 1609.344,
       }),
     );
+  });
+
+  it('converts the displayed number on a unit switch, preserving the distance (#773)', async () => {
+    const user = userEvent.setup();
+    renderPanel([datasetLayer]);
+
+    fireEvent.change(screen.getByLabelText('Distance'), {
+      target: { value: '100' },
+    });
+    // 100 m → km converts to 0.1 instead of silently meaning 100 km.
+    await user.click(screen.getAllByRole('combobox')[2]);
+    await user.click(await screen.findByRole('option', { name: 'kilometers' }));
+    expect(screen.getByLabelText('Distance')).toHaveValue(0.1);
+
+    // The wire value is the same physical distance as before the switch.
+    fireEvent.click(screen.getByRole('button', { name: 'Preview' }));
+    await waitFor(() =>
+      expect(previewAnalysis).toHaveBeenCalledWith('ds1', {
+        operation: 'buffer',
+        distance_meters: 100,
+      }),
+    );
+
+    // And back — a clean round trip, no drift.
+    await user.click(screen.getAllByRole('combobox')[2]);
+    await user.click(await screen.findByRole('option', { name: 'meters' }));
+    expect(screen.getByLabelText('Distance')).toHaveValue(100);
+  });
+
+  it('rounds converted distances instead of leaving float tails (#773)', async () => {
+    const user = userEvent.setup();
+    renderPanel([datasetLayer]);
+
+    fireEvent.change(screen.getByLabelText('Distance'), {
+      target: { value: '500' },
+    });
+    await user.click(screen.getAllByRole('combobox')[2]);
+    await user.click(await screen.findByRole('option', { name: 'feet' }));
+    // 500 / 0.3048 = 1640.419947506… — trimmed to 6 significant digits.
+    expect(screen.getByLabelText('Distance')).toHaveValue(1640.42);
+  });
+
+  it('leaves an empty distance field alone on a unit switch (#773)', async () => {
+    const user = userEvent.setup();
+    renderPanel([datasetLayer]);
+
+    fireEvent.change(screen.getByLabelText('Distance'), {
+      target: { value: '' },
+    });
+    await user.click(screen.getAllByRole('combobox')[2]);
+    await user.click(await screen.findByRole('option', { name: 'kilometers' }));
+    // Nothing to convert — no NaN materializes in the field.
+    expect(screen.getByLabelText('Distance')).toHaveValue(null);
   });
 
   it('sends by_field when a dissolve group column is chosen', async () => {
@@ -1151,5 +1207,161 @@ describe('AnalysisPanel — chat handoff prefill (#675)', () => {
       renderPanel([datasetLayer], { mapId: 'm2' });
       expect(screen.getByLabelText('Distance')).toHaveValue(500);
     });
+  });
+});
+
+describe('AnalysisPanel — stack-selected layer (#772)', () => {
+  beforeEach(() => {
+    mockJobStatus.value = null;
+    mockJobStatus.error = null;
+    useAnalysisFormStore.setState({ forms: {} });
+    useAnalysisJobStore.setState({ job: null });
+    useAuthStore.setState({ token: null, refreshToken: null, user: null });
+    vi.mocked(previewAnalysis).mockClear();
+    vi.mocked(materializeAnalysis).mockClear();
+  });
+
+  it('targets the stack-selected layer instead of the first eligible one', async () => {
+    renderPanel([datasetLayer, datasetLayer2], { selectedLayerId: 'l3' });
+    expect(screen.getByText('Roads')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Preview' }));
+    await waitFor(() =>
+      expect(previewAnalysis).toHaveBeenCalledWith('ds2', {
+        operation: 'buffer',
+        distance_meters: 500,
+      }),
+    );
+  });
+
+  it('ignores a selection that is not an analysable layer', () => {
+    // The selection slot also carries raster layers, folder groups, and
+    // sentinel ids like 'settings' — none of them may hijack the default.
+    renderPanel([datasetLayer, rasterLayer], { selectedLayerId: 'l5' });
+    expect(screen.getByText('Parcels')).toBeInTheDocument();
+  });
+
+  it('yields to an explicit chat prefill', async () => {
+    renderPanel([datasetLayer, datasetLayer2], {
+      selectedLayerId: 'l3',
+      prefill: { layerId: 'l1', operation: 'buffer', distanceMeters: 750 },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Preview' }));
+    await waitFor(() =>
+      expect(previewAnalysis).toHaveBeenCalledWith('ds1', {
+        operation: 'buffer',
+        distance_meters: 750,
+      }),
+    );
+  });
+
+  it("beats the remembered form's layer while the rest of the form restores", () => {
+    useAnalysisFormStore.getState().save('m1', {
+      layerId: 'l1', operation: 'buffer', distance: '750', distanceUnit: 'm',
+      mask: null, maskLayerId: '__none__', byField: '__none__',
+      outputTitle: 'Draft name',
+    });
+    renderPanel([datasetLayer, datasetLayer2], {
+      mapId: 'm1',
+      selectedLayerId: 'l3',
+    });
+    expect(screen.getByText('Roads')).toBeInTheDocument();
+    expect(screen.getByLabelText('Distance')).toHaveValue(750);
+    expect(screen.getByLabelText('New dataset name')).toHaveValue('Draft name');
+  });
+
+  it("drops the displaced layer's remembered group-by (#680 parity)", async () => {
+    useAnalysisFormStore.getState().save('m1', {
+      layerId: 'l1', operation: 'dissolve', distance: '500', distanceUnit: 'm',
+      mask: null, maskLayerId: '__none__', byField: 'col:name',
+      outputTitle: 'Dissolved',
+    });
+    renderPanel([datasetLayer, datasetLayer2], {
+      mapId: 'm1',
+      selectedLayerId: 'l3',
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Create dataset' }));
+    // No by_field: the remembered column belonged to the displaced layer.
+    await waitFor(() =>
+      expect(materializeAnalysis).toHaveBeenCalledWith('ds2', {
+        operation: 'dissolve',
+        title: 'Dissolved',
+      }),
+    );
+  });
+
+  it('clears a remembered mask layer the selection displaces into the source slot', () => {
+    useAnalysisFormStore.getState().save('m1', {
+      layerId: 'l1', operation: 'clip', distance: '500', distanceUnit: 'm',
+      mask: null, maskLayerId: 'l3', byField: '__none__', outputTitle: '',
+    });
+    renderPanel([datasetLayer, datasetLayer2], {
+      mapId: 'm1',
+      selectedLayerId: 'l3',
+    });
+    // A mask layer can't clip itself, so the clip params are incomplete again.
+    expect(screen.getAllByRole('combobox')[2]).toHaveTextContent(
+      'None — draw on the map',
+    );
+    expect(screen.getByRole('button', { name: 'Preview' })).toBeDisabled();
+  });
+
+  it('leaves a tracked run ambient when the selection displaces its form (#793 semantics)', () => {
+    mockJobStatus.value = { status: 'running', current_step: null };
+    useAnalysisFormStore.getState().save('m1', {
+      layerId: 'l1', operation: 'buffer', distance: '500', distanceUnit: 'm',
+      mask: null, maskLayerId: '__none__', byField: '__none__',
+      outputTitle: 'Run name',
+    });
+    useAnalysisJobStore.setState({
+      job: { jobId: 'job9', title: 'Run name', mapId: 'm1' },
+    });
+    renderPanel([datasetLayer, datasetLayer2], {
+      mapId: 'm1',
+      selectedLayerId: 'l3',
+    });
+    // The run's blessed form is known to differ from this mount — adopting it
+    // would surface (and later clear) state over a different draft.
+    expect(screen.queryByText('Creating dataset…')).not.toBeInTheDocument();
+    expect(
+      screen.getByText(
+        'Another analysis is still running — wait for it to finish.',
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it('still rehydrates the run when the selection matches the remembered layer', () => {
+    mockJobStatus.value = { status: 'running', current_step: null };
+    useAnalysisFormStore.getState().save('m1', {
+      layerId: 'l1', operation: 'buffer', distance: '500', distanceUnit: 'm',
+      mask: null, maskLayerId: '__none__', byField: '__none__',
+      outputTitle: 'Run name',
+    });
+    useAnalysisJobStore.setState({
+      job: { jobId: 'job9', title: 'Run name', mapId: 'm1' },
+    });
+    renderPanel([datasetLayer, datasetLayer2], {
+      mapId: 'm1',
+      selectedLayerId: 'l1',
+    });
+    expect(screen.getByText('Creating dataset…')).toBeInTheDocument();
+  });
+
+  it('clears a panel-owned overlay when the selection displaces the remembered layer', async () => {
+    const onClearPreview = vi.fn();
+    useAnalysisFormStore.getState().save('m1', {
+      layerId: 'l1', operation: 'buffer', distance: '750', distanceUnit: 'm',
+      mask: null, maskLayerId: '__none__', byField: '__none__', outputTitle: '',
+    });
+    renderPanel([datasetLayer, datasetLayer2], {
+      mapId: 'm1',
+      selectedLayerId: 'l3',
+      onClearPreview,
+      hasPreview: true,
+      previewSource: 'analysis-panel',
+    });
+    // The overlay depicts the displaced layer's preview — stale for the same
+    // reason a vanished layer's would be.
+    await waitFor(() => expect(onClearPreview).toHaveBeenCalled());
   });
 });

--- a/frontend/src/components/builder/__tests__/DatasetSearchPanel.test.tsx
+++ b/frontend/src/components/builder/__tests__/DatasetSearchPanel.test.tsx
@@ -417,7 +417,7 @@ describe('DatasetSearchPanel — Phase 1042-02 polish fixes', () => {
     expect(container.querySelector('.animate-spin')).toBeNull();
   });
 
-  it('Test 2 (AUD-13): isFetching=true && isLoading=false shows thin progress band above dimmed list', () => {
+  it('Test 2 (AUD-13/ux #776): refetch shows the thin progress band and keeps the list interactive', () => {
     useQueryOverride = {
       data: searchResponse,
       isLoading: false,
@@ -430,9 +430,10 @@ describe('DatasetSearchPanel — Phase 1042-02 polish fixes', () => {
     // Progress band — h-0.5 element with animate-pulse
     const progressBand = container.querySelector('.h-0\\.5.animate-pulse');
     expect(progressBand).not.toBeNull();
-    // The results list should be present but dimmed (pointer-events-none opacity-50)
-    const dimmedList = container.querySelector('.pointer-events-none.opacity-50');
-    expect(dimmedList).not.toBeNull();
+    // ux(#776): the stale list stays fully interactive during a debounced
+    // refetch — the band is the signal; the old pointer-events/opacity freeze
+    // made visible rows unclickable on every keystroke pause.
+    expect(container.querySelector('.pointer-events-none.opacity-50')).toBeNull();
     // No skeleton rows during refetch
     const skeletons = container.querySelectorAll('[data-slot="skeleton"]');
     expect(skeletons.length).toBe(0);

--- a/frontend/src/components/builder/__tests__/StackRow.test.tsx
+++ b/frontend/src/components/builder/__tests__/StackRow.test.tsx
@@ -372,6 +372,42 @@ describe('StackRow', () => {
     expect(link).toHaveAttribute('rel', 'noopener noreferrer');
   });
 
+  // ux(#772): kebab entry into the Analysis panel, prefilled with this layer.
+  it('kebab "Analyze this layer" calls onAnalyzeLayer for an analysable layer', () => {
+    const onAnalyzeLayer = vi.fn();
+    const layer = makeLayer({ id: 'analyzable-layer' });
+    render(<StackRow {...defaultProps({ layer, onAnalyzeLayer })} />);
+
+    fireEvent.pointerDown(screen.getByRole('button', { name: /Layer options for/i }), { button: 0, ctrlKey: false });
+    fireEvent.click(screen.getByTestId('kebab-analyze-layer'));
+
+    expect(onAnalyzeLayer).toHaveBeenCalledOnce();
+    expect(onAnalyzeLayer).toHaveBeenCalledWith('analyzable-layer');
+  });
+
+  it('hides "Analyze this layer" for a layer the panel would not offer (ux #772)', () => {
+    const layer = makeLayer({
+      id: 'raster-layer',
+      dataset_record_type: 'raster_dataset',
+      dataset_geometry_type: null,
+    });
+    render(<StackRow {...defaultProps({ layer, onAnalyzeLayer: vi.fn() })} />);
+
+    fireEvent.pointerDown(screen.getByRole('button', { name: /Layer options for/i }), { button: 0, ctrlKey: false });
+
+    // The menu is open (its siblings render) but the analysis entry is gated
+    // on the panel's own eligibility predicate.
+    expect(screen.getByTestId('kebab-zoom-to-layer')).toBeInTheDocument();
+    expect(screen.queryByTestId('kebab-analyze-layer')).toBeNull();
+  });
+
+  it('hides "Analyze this layer" when no handler is wired (ux #772)', () => {
+    render(<StackRow {...defaultProps()} />);
+    fireEvent.pointerDown(screen.getByRole('button', { name: /Layer options for/i }), { button: 0, ctrlKey: false });
+    expect(screen.getByTestId('kebab-zoom-to-layer')).toBeInTheDocument();
+    expect(screen.queryByTestId('kebab-analyze-layer')).toBeNull();
+  });
+
   it('"Add to group…" submenu exposes "New group…" when no existing groups (#585)', () => {
     const layer = makeLayer({ id: 'group-layer' });
     render(<StackRow {...defaultProps({ layer, existingFolderGroups: [] })} />);

--- a/frontend/src/components/builder/analysis-eligibility.ts
+++ b/frontend/src/components/builder/analysis-eligibility.ts
@@ -1,0 +1,30 @@
+import type { MapLayerResponse } from '@/types/api';
+
+// ux(#720): analysis needs a VECTOR dataset. `!is_dem` alone let ordinary
+// raster layers (COG orthophotos, Sentinel scenes) through — they carry a
+// dataset_id, so the panel offered them and auto-selected the first one, and
+// every Preview 422'd.
+//
+// Keyed on dataset_record_type, NOT layer_type (fix(#720 review)). layer_type
+// selects a RENDERER and the API validates it against nothing — MapLayerInput
+// accepts any supported value and add_layer persists it, defaulting to
+// 'vector_geolens'. So a raster dataset can carry the vector default, which is
+// how getLayerCapabilities (which keys on layer_type) would misclassify it, and
+// a vector dataset overridden to the raster renderer would be hidden even
+// though the analysis endpoint accepts it. record_type is what the data IS.
+//
+// geometry_type is required on top of that: it is the precondition
+// _load_vector_dataset enforces server-side, so a vector dataset missing one
+// would 422 just the same. Testing it ALONE was the original bug — it happened
+// to work only because every raster dataset currently stores NULL there, an
+// incidental property of the ingest path rather than an invariant.
+//
+// ux(#772): extracted from AnalysisPanel.tsx so the stack-row kebab can gate
+// its "Analyze this layer" entry on the same predicate without statically
+// importing the lazy-loaded panel chunk.
+const RASTER_RECORD_TYPES = new Set(['raster_dataset', 'vrt_dataset']);
+export const isAnalysableLayer = (l: MapLayerResponse) =>
+  !!l.dataset_id &&
+  !l.is_dem &&
+  !RASTER_RECORD_TYPES.has((l.dataset_record_type ?? '').toLowerCase()) &&
+  !!l.dataset_geometry_type;

--- a/frontend/src/i18n/locales/de/builder.json
+++ b/frontend/src/i18n/locales/de/builder.json
@@ -1225,6 +1225,7 @@
     "labelsIndicator": "Beschriftungen an: {{column}}",
     "kebabGroupTrigger": "Gruppenoptionen für {{name}}",
     "kebabZoomToLayer": "Auf Ebene zoomen",
+    "kebabAnalyzeLayer": "Diese Ebene analysieren",
     "kebabCopyStyle": "Stil kopieren",
     "kebabPasteStyle": "Stil einfügen",
     "kebabPasteStyleHint": "Kopiere zuerst einen Stil von einer passenden Ebene",

--- a/frontend/src/i18n/locales/en/builder.json
+++ b/frontend/src/i18n/locales/en/builder.json
@@ -1229,6 +1229,7 @@
     "kebabMoveOutOfGroup": "Move out of group",
     "labelsIndicator": "Labels on: {{column}}",
     "kebabZoomToLayer": "Zoom to layer",
+    "kebabAnalyzeLayer": "Analyze this layer",
     "kebabCopyStyle": "Copy style",
     "kebabPasteStyle": "Paste style",
     "kebabPasteStyleHint": "Copy a style from a matching layer first",

--- a/frontend/src/i18n/locales/es/builder.json
+++ b/frontend/src/i18n/locales/es/builder.json
@@ -1225,6 +1225,7 @@
     "labelsIndicator": "Etiquetas activadas: {{column}}",
     "kebabGroupTrigger": "Opciones de grupo para {{name}}",
     "kebabZoomToLayer": "Acercar a la capa",
+    "kebabAnalyzeLayer": "Analizar esta capa",
     "kebabCopyStyle": "Copiar estilo",
     "kebabPasteStyle": "Pegar estilo",
     "kebabPasteStyleHint": "Copia primero un estilo de una capa compatible",

--- a/frontend/src/i18n/locales/fr/builder.json
+++ b/frontend/src/i18n/locales/fr/builder.json
@@ -1225,6 +1225,7 @@
     "labelsIndicator": "Étiquettes activées : {{column}}",
     "kebabGroupTrigger": "Options de groupe pour {{name}}",
     "kebabZoomToLayer": "Zoomer sur la couche",
+    "kebabAnalyzeLayer": "Analyser cette couche",
     "kebabCopyStyle": "Copier le style",
     "kebabPasteStyle": "Coller le style",
     "kebabPasteStyleHint": "Copiez d'abord un style depuis une couche compatible",

--- a/frontend/src/pages/MapBuilderPage.tsx
+++ b/frontend/src/pages/MapBuilderPage.tsx
@@ -816,6 +816,14 @@ export function MapBuilderPage() {
     setRailPanel('analysis');
   }, [ephemeralAnalysis]);
 
+  // ux(#772): stack-row kebab "Analyze this layer" — the same handoff path the
+  // chat preview uses, so the panel opens (or remounts, via the prefill nonce
+  // key) targeting exactly this layer even when the row isn't selected.
+  const handleAnalyzeLayer = useCallback((layerId: string) => {
+    setAnalysisPrefill({ layerId, operation: 'buffer', nonce: Date.now() });
+    setRailPanel('analysis');
+  }, []);
+
   // fix(#679 review P2): the prefill lives only for the handoff opening it
   // triggered. Clearing it on any navigation away from the panel (rail close,
   // panel switch, mobile sheet dismiss) keeps a later ordinary opening from
@@ -833,6 +841,9 @@ export function MapBuilderPage() {
     mapId: id,
     layers: layers.localLayers,
     layersMapId: layers.layersMapId,
+    // ux(#772): the stack's selected row, so the Analysis panel can open
+    // targeting it instead of the first eligible layer.
+    selectedLayerId: layers.expandedLayerId,
     layerActions: layers.chatLayerActions,
     onQueryResult: layers.handleQueryResult,
     mapInstanceRef,
@@ -844,7 +855,7 @@ export function MapBuilderPage() {
     onAnalysisJobChange: handleAnalysisJobChange,
     onMarkDirty: handleMarkDirty,
     viewport,
-  }), [railPanel, aiAvailable, dockNotes, id, layers.localLayers, layers.layersMapId, layers.chatLayerActions, layers.handleQueryResult, layers.handleDismissEphemeral, layers.ephemeralResult, analysisPrefill, mapInstanceRef, handleMarkDirty, viewport, handleAnalysisJobChange]);
+  }), [railPanel, aiAvailable, dockNotes, id, layers.localLayers, layers.layersMapId, layers.expandedLayerId, layers.chatLayerActions, layers.handleQueryResult, layers.handleDismissEphemeral, layers.ephemeralResult, analysisPrefill, mapInstanceRef, handleMarkDirty, viewport, handleAnalysisJobChange]);
 
   const mobileRailButtons = useMemo(() => [
     {
@@ -900,9 +911,18 @@ export function MapBuilderPage() {
         })
       : t('dock.notesPlaceholder', { defaultValue: 'Add notes about this map...' });
 
+  // ux(#776): the Add Data dialog stays open for repeated adds, so the
+  // "open the editor on the new layer" step is DEFERRED — opening it per-add
+  // would stack the flyout behind the still-open dialog. The last added
+  // layer's id waits here until the dialog closes.
+  const pendingEditorLayerIdRef = useRef<string | null>(null);
+
   const handleAddDataClick = useCallback(
     (initialQuery?: string) => {
       dialogs.setAddDataInitialQuery(initialQuery ?? '');
+      // A pending id from a previous session's mid-flight add must not leak
+      // into this one's close.
+      pendingEditorLayerIdRef.current = null;
       dialogs.setShowAddData(true);
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps -- stable setters from useBuilderDialogs
@@ -1627,6 +1647,7 @@ export function MapBuilderPage() {
                 layerId,
               })}
               onZoomToLayer={layers.handleZoomToLayer}
+              onAnalyzeLayer={handleAnalyzeLayer}
               onCopyStyle={layers.handleCopyStyle}
               onPasteStyle={layers.handlePasteStyle}
               onBulkApplyStyle={handleBulkApplyStyle}
@@ -1918,14 +1939,22 @@ export function MapBuilderPage() {
           dialogs.setShowAddData(open);
           if (!open) {
             dialogs.setAddDataInitialQuery('');
+            // ux(#776): the deferred editor-open — once per dialog session,
+            // on the most recently added layer.
+            if (pendingEditorLayerIdRef.current) {
+              handleSelectLayer(pendingEditorLayerIdRef.current);
+              pendingEditorLayerIdRef.current = null;
+            }
           }
         }}
         addDataInitialQuery={dialogs.addDataInitialQuery}
         onAddDataset={(datasetId: string) => {
           layers.handleAddDataset(datasetId, (newLayerId) => {
-            dialogs.setShowAddData(false);
-            dialogs.setAddDataInitialQuery('');
-            handleSelectLayer(newLayerId);
+            // ux(#776): keep the dialog open for multi-add — the row flips to
+            // "Added ✓" and Escape/backdrop/X still close it. The editor
+            // opens on close (see onShowAddDataChange above) instead of
+            // landing behind the dialog.
+            pendingEditorLayerIdRef.current = newLayerId;
           });
         }}
         onDuplicateRendering={(layerId) => layers.dispatchLayerAction({


### PR DESCRIPTION
Three analysis-panel UX fixes from the 2026-07-27 builder/analysis audit, batched because #772 threads a new source into the same layer/form precedence chain #773's converted value has to survive.

## #773 — unit switch converts instead of reinterpreting
Switching the buffer unit now converts the displayed number so the physical distance is preserved: 100 m → **0.1 km**, not "100 km". Conversion goes through the existing `BUFFER_UNIT_METERS` table and is rounded to 6 significant digits to avoid float tails (`0.3 km → 300`, not `300.00000000000006`). An empty/unparseable field just switches the unit. The existing input-change invalidation (preview clear, seq bump) is kept — the rounded value can differ from the previewed one by a hair, and the conservative path is the existing one.

## #772 — panel targets the stack-selected layer + kebab entry
`selectedLayerId` (the builder's `layers.expandedLayerId`) is now threaded through `railProps` → `BuilderRail` → `AnalysisPanel`.

**Chosen precedence (mount-time):**
1. explicit chat prefill (`prefill.layerId`)
2. stack-selected layer, when analysable (raster/DEM/group/'settings' ids validate false and change nothing)
3. remembered form's layer (#793 store)
4. first eligible layer

Honoring the #793 store semantics: when the stack selection **displaces** the remembered layer, the mount is treated as a different draft — the layer-coupled fields reset exactly as if the layer select had been edited (group-by → none per #680, a remembered mask layer that would now mask itself → none), any tracked run stays ambient instead of being adopted (`runDisowned` path), and a panel-owned preview overlay is cleared as stale. The layer-agnostic fields (operation, distance+unit, drawn mask, typed dataset name) still restore. Selection changes while the panel is already mounted deliberately do NOT re-target it — a live override would clobber an explicit in-panel choice and wipe a just-run preview; the kebab entry below covers that intent explicitly.

Also adds an **"Analyze this layer"** entry to the stack-row kebab (next to Zoom to layer), which opens the panel via the same prefill path the chat handoff uses — so it works even when the row isn't selected, and remounts an already-open panel via the prefill nonce key. The entry is gated on the panel's own eligibility predicate, extracted to `frontend/src/components/builder/analysis-eligibility.ts` so `StackRow` doesn't statically import the lazy-loaded panel chunk. New `stackRow.kebabAnalyzeLayer` key added to all four locales (en/es/fr/de).

## #776 — Add Data dialog stays open for multi-add
The add callback no longer calls `setShowAddData(false)` — the dialog stays open so the row's "Added ✓ / another rendering" states finally do their job, matching the POL-05 drag-drop path (which already kept the modal open) and the EmptyStackState direct-add path. Escape / backdrop / the dialog's X still close it.

**Editor-behind-dialog decision:** the old callback also ran `handleSelectLayer(newLayerId)`, which would now open the layer editor *behind* the still-open dialog. Instead, the last added layer id is parked in a ref and the editor opens **when the dialog closes** — the single-add flow ends in the same place it used to (editor open on the new layer), multi-add ends on the most recently added layer, and closing without adding selects nothing. The pending id is cleared on dialog open so a mid-flight add finishing after an instant close can't leak into a later session.

Bonus from the same issue: dropped the `pointer-events-none opacity-50` freeze on the results list during debounced refetches — the pulse band already signals them, and the freeze made visible rows unclickable on every keystroke pause.

## Tests
- `AnalysisPanel.test.tsx`: 13 new tests — unit-conversion behavior (convert, round, empty-field, wire-value preservation) and the full #772 precedence matrix (stack beats first-eligible, ineligible selection ignored, prefill wins, remembered-form displacement: field restore, group-by reset, self-mask reset, run stays ambient vs. still rehydrates on match, stale overlay clear). The #686 wire-conversion test now picks the unit before typing, since switching afterwards now converts the number.
- `StackRow.test.tsx`: kebab entry fires `onAnalyzeLayer`, hidden for non-analysable layers, hidden when unwired.
- `DatasetSearchPanel.test.tsx`: Test 2 now asserts the refetch band shows with **no** interaction freeze.
- `analysis-form-store.test.ts`: unchanged (no store changes) — still passes.

## Verification
- `cd frontend && npm ci`
- `npm run lint` — clean
- `npm run typecheck` — clean
- `npm run test:i18n` — 4/4 pass (locale parity incl. the new key)
- `npx vitest run` on: AnalysisPanel (62), AnalysisPanel.draw-suppression, analysis-form-store, StackRow, DatasetSearchPanel ×2, BuilderRail, UnifiedStackPanel, MapBuilderPage.{notes-ai-rail,a11y,settings-wiring,sheet-close-button,header-actions} — 208 tests, all passing

Skipped: the full `npm run test:coverage` suite and Playwright e2e (CI runs them). Checked e2e specs for reliance on the old auto-close: none — the existing "another rendering" flow already closes via Escape.

Note for the concurrent a11y PR: AnalysisPanel hunks stay clear of the clip-action label (~:942) and the status region (~:1118).

Closes #773
Closes #772
Closes #776

https://claude.ai/code/session_01TEhW22Yf94GjuKYxMhcbLt