### PR TITLE
fix(a11y): builder quick wins — accessible names, live regions, translated drag announcements

### DIFF
--- a/frontend/src/components/builder/AnalysisPanel.tsx
+++ b/frontend/src/components/builder/AnalysisPanel.tsx
@@ -937,9 +937,11 @@ export function AnalysisPanel({
 
       {operation === 'clip' && maskLayer == null && (
         <div className="space-y-1.5">
-          {/* Exactly one of the three buttons below renders at a time, so
-              they can share the id this label points at. */}
-          <Label className="text-xs" htmlFor="analysis-clip-action">
+          {/* fix(#754): no htmlFor here — a <label for> pointed at a button
+              OVERRIDES the button's own text in the accessible-name
+              computation, so Cancel and Clear were both announced as "Draw
+              clip area". The buttons below are self-labeling. */}
+          <Label className="text-xs">
             {t('analysisTools.drawMask', { defaultValue: 'Draw clip area' })}
           </Label>
           {isDrawing ? (
@@ -950,7 +952,6 @@ export function AnalysisPanel({
                 })}
               </p>
               <Button
-                id="analysis-clip-action"
                 variant="outline"
                 size="sm"
                 onClick={stopDrawing}
@@ -964,7 +965,6 @@ export function AnalysisPanel({
                 {t('analysisTools.maskSet', { defaultValue: 'Clip area set' })}
               </span>
               <Button
-                id="analysis-clip-action"
                 variant="ghost"
                 size="sm"
                 onClick={() => {
@@ -981,7 +981,6 @@ export function AnalysisPanel({
           ) : (
             <div className="space-y-1.5">
               <Button
-                id="analysis-clip-action"
                 variant="outline"
                 size="sm"
                 onClick={startDrawing}
@@ -1111,46 +1110,49 @@ export function AnalysisPanel({
                 ? t('analysisTools.saving', { defaultValue: 'Creating…' })
                 : t('analysisTools.saveButton', { defaultValue: 'Create dataset' })}
             </Button>
-            {/* fix(#760): the one-job-per-user cap disables the button — say
-                so instead of leaving a disabled primary control unexplained
-                (covers a job started before a reload or from another panel). */}
-            {analysisJobRunning && !job && (
-              <p className="text-xs text-muted-foreground" role="status">
-                {t('analysisTools.anotherJobRunning', {
-                  defaultValue:
-                    'Another analysis is still running — wait for it to finish.',
-                })}
-              </p>
-            )}
-            {job && (
-              <p className="text-xs text-muted-foreground" role="status">
-                {/* ux(#698): reuse the watcher's jobFailedDetail template
-                    rather than concatenating the raw server error onto a
-                    translated prefix, which left half the sentence untranslated. */}
-                {job.status === 'failed'
-                  ? job.error_message
-                    ? t('analysisTools.jobFailedDetail', {
-                        defaultValue: 'Analysis job failed: {{message}}',
-                        message: job.error_message,
-                      })
-                    : t('analysisTools.jobFailed', {
-                        defaultValue: 'Analysis job failed',
-                      })
-                  : job.status === 'complete'
-                    ? t('analysisTools.jobComplete', { defaultValue: 'Dataset created' })
-                    : job.current_step === 'registering'
-                      ? t('analysisTools.jobSaving', {
-                          defaultValue: 'Saving the dataset…',
+            {/* fix(#784): one PERSISTENT status region, mounted empty with the
+                form — a live region that mounts already populated is not
+                announced, so the previous conditionally-rendered <p>s kept the
+                first message ("Creating dataset…") silent for AT. Every
+                message now arrives as a mutation inside an existing region.
+                fix(#760): the one-job-per-user cap disables the button — the
+                "another analysis" branch says so instead of leaving a disabled
+                primary control unexplained (covers a job started before a
+                reload or from another panel). */}
+            <p className="text-xs text-muted-foreground" role="status">
+              {analysisJobRunning && !job
+                ? t('analysisTools.anotherJobRunning', {
+                    defaultValue:
+                      'Another analysis is still running — wait for it to finish.',
+                  })
+                : job
+                  ? // ux(#698): reuse the watcher's jobFailedDetail template
+                    // rather than concatenating the raw server error onto a
+                    // translated prefix, which left half the sentence untranslated.
+                    job.status === 'failed'
+                    ? job.error_message
+                      ? t('analysisTools.jobFailedDetail', {
+                          defaultValue: 'Analysis job failed: {{message}}',
+                          message: job.error_message,
                         })
-                      : job.current_step === 'queued'
-                        ? t('analysisTools.jobQueued', {
-                            defaultValue: 'Queued — waiting for a worker…',
+                      : t('analysisTools.jobFailed', {
+                          defaultValue: 'Analysis job failed',
+                        })
+                    : job.status === 'complete'
+                      ? t('analysisTools.jobComplete', { defaultValue: 'Dataset created' })
+                      : job.current_step === 'registering'
+                        ? t('analysisTools.jobSaving', {
+                            defaultValue: 'Saving the dataset…',
                           })
-                        : t('analysisTools.jobRunning', {
-                            defaultValue: 'Creating dataset…',
-                          })}
-              </p>
-            )}
+                        : job.current_step === 'queued'
+                          ? t('analysisTools.jobQueued', {
+                              defaultValue: 'Queued — waiting for a worker…',
+                            })
+                          : t('analysisTools.jobRunning', {
+                              defaultValue: 'Creating dataset…',
+                            })
+                  : null}
+            </p>
             {job?.status === 'complete' && !!job.dataset_id && layerActions && (
               <Button
                 variant="outline"

--- a/frontend/src/components/builder/BuilderRail.tsx
+++ b/frontend/src/components/builder/BuilderRail.tsx
@@ -156,6 +156,23 @@ export function BuilderRail({
     onPanelChange(activePanel === panel ? null : panel);
   }, [activePanel, onPanelChange]);
 
+  // fix(#783): closing the panel unmounts the aside containing the focused
+  // element, dropping keyboard focus to <body>. Mirror handleCloseEditor
+  // (MapBuilderPage): return focus to the rail button that opened the panel.
+  // In sheet mode (showRail=false) the button doesn't exist and Radix's own
+  // close-time focus restoration applies instead.
+  const closePanel = useCallback(() => {
+    const panel = activePanel;
+    onPanelChange(null);
+    if (panel) {
+      requestAnimationFrame(() => {
+        document
+          .querySelector<HTMLElement>(`[data-rail-button="${panel}"]`)
+          ?.focus();
+      });
+    }
+  }, [activePanel, onPanelChange]);
+
   const railButtons = useMemo(() => [
     {
       id: 'notes' as const,
@@ -193,10 +210,16 @@ export function BuilderRail({
     <>
       {/* Icon rail */}
       {showRail && (
-        <aside className="w-11 bg-background border-s flex flex-col items-center pt-2.5 gap-1 shrink-0">
+        // fix(#788 item 5): named landmark — both builder asides announced as
+        // bare "complementary" with no way to tell rail from panel.
+        <aside
+          aria-label={t('rail.toolsLabel', { defaultValue: 'Builder tools' })}
+          className="w-11 bg-background border-s flex flex-col items-center pt-2.5 gap-1 shrink-0"
+        >
           {railButtons.map(btn => (
             <button
               key={btn.id}
+              data-rail-button={btn.id}
               onClick={btn.disabled ? undefined : () => togglePanel(btn.id)}
               disabled={btn.disabled}
               data-unavailable={btn.unavailable || undefined}
@@ -240,6 +263,9 @@ export function BuilderRail({
       {activePanel && (
         // eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions -- container-level Escape shortcut for keystrokes bubbling from the panel's own interactive children; the aside itself stays non-interactive
         <aside
+          // fix(#788 item 5): named landmark — the panel takes its accessible
+          // name from its own title, distinguishing it from the icon rail.
+          aria-labelledby="builder-rail-panel-title"
           className={cn(
             'bg-background border-s flex h-full min-h-0 flex-col shrink-0 overflow-hidden',
             showRail ? 'w-80' : 'w-full border-s-0',
@@ -250,14 +276,14 @@ export function BuilderRail({
             // focus is inside the panel).
             if (e.key === 'Escape' && !e.defaultPrevented) {
               e.stopPropagation();
-              onPanelChange(null);
+              closePanel();
             }
           }}
         >
           {/* Panel header */}
           <div className="flex items-center justify-between px-3.5 py-2.5 border-b shrink-0">
             <div className="flex items-center gap-2">
-              <span className="text-sm font-medium">
+              <span id="builder-rail-panel-title" className="text-sm font-medium">
                 {activePanel === 'notes' && t('dock.notes', { defaultValue: 'Notes' })}
                 {activePanel === 'history' && t('dock.history', { defaultValue: 'History' })}
                 {activePanel === 'analysis' && t('analysisTools.title', { defaultValue: 'Analysis' })}
@@ -267,7 +293,7 @@ export function BuilderRail({
               </span>
             </div>
             <button
-              onClick={() => onPanelChange(null)}
+              onClick={closePanel}
               title={t('rail.closePanel', { defaultValue: 'Close panel' })}
               aria-label={t('rail.closePanel', { defaultValue: 'Close panel' })}
               className="flex cursor-pointer items-center justify-center h-6 w-6 rounded-md text-muted-foreground hover:bg-accent hover:text-foreground transition-colors"

--- a/frontend/src/components/builder/EphemeralBadge.tsx
+++ b/frontend/src/components/builder/EphemeralBadge.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { X } from 'lucide-react';
 import { cn } from '@/lib/utils';
@@ -30,12 +31,27 @@ export function EphemeralBadge({ featureCount, onDismiss, truncated, totalCount,
         defaultValue: '{{count}} of {{total}} features',
       })
     : t('ephemeralBadge.featureCount', { count: featureCount });
+  const statusLabel = `${t('ephemeralBadge.queryResult')} · ${countLabel}`;
+
+  // fix(#784): live regions only announce mutations made while the region is
+  // already in the accessibility tree — this badge mounts WITH its text, so
+  // role="status" on the wrapper alone would stay silent. Mount the region
+  // empty and populate it a frame later so the preview success (and any later
+  // count change) arrives as a mutation assistive tech actually reads.
+  const [announcedLabel, setAnnouncedLabel] = useState('');
+  useEffect(() => {
+    const frame = requestAnimationFrame(() => setAnnouncedLabel(statusLabel));
+    return () => cancelAnimationFrame(frame);
+  }, [statusLabel]);
 
   return (
     <div className={cn('absolute bottom-8 start-4 z-[8] flex items-center gap-2 rounded-md bg-background/95 backdrop-blur-sm border shadow-sm px-3 py-1.5 text-xs', className)}>
       <span className="h-2 w-2 rounded-full bg-warning shrink-0" />
-      <span className="text-muted-foreground">
-        {t('ephemeralBadge.queryResult')} &middot; {countLabel}
+      <span role="status" className="sr-only">{announcedLabel}</span>
+      {/* fix(#784): aria-hidden so browse mode doesn't read the badge text
+          twice — the sr-only status region above carries the same string. */}
+      <span aria-hidden="true" className="text-muted-foreground">
+        {statusLabel}
       </span>
       {onSaveAsDataset && (
         <button

--- a/frontend/src/components/builder/HeatmapStyleControls.tsx
+++ b/frontend/src/components/builder/HeatmapStyleControls.tsx
@@ -154,11 +154,16 @@ function formatValue(value: number, format?: 'percent' | 'px' | 'zoom'): string 
 
 /** Shared slider row component used by heatmap controls and style editor. */
 export function SliderRow({ label, value, min, max, step, display, format, onChange }: SliderRowProps) {
+  const displayValue = display ?? formatValue(value, format);
   return (
     <div className="flex items-center gap-2">
       <span className="text-xs text-muted-foreground w-20">{label}</span>
       <Slider
         aria-label={label}
+        // fix(#788 item 3): announce the formatted value ("80%"), matching
+        // RasterSliderRow and the DEM/basemap scenes — without it AT read the
+        // raw number ("0.8") while the screen showed the formatted one.
+        aria-valuetext={displayValue}
         value={[value]}
         min={min}
         max={max}
@@ -167,7 +172,7 @@ export function SliderRow({ label, value, min, max, step, display, format, onCha
         className="flex-1"
       />
       <span className="text-xs text-muted-foreground w-10 text-end">
-        {display ?? formatValue(value, format)}
+        {displayValue}
       </span>
     </div>
   );

--- a/frontend/src/components/builder/LayerEditorPanel.tsx
+++ b/frontend/src/components/builder/LayerEditorPanel.tsx
@@ -322,7 +322,15 @@ export const LayerEditorPanel = memo(function LayerEditorPanel({
               onClick={onBreadcrumbClick}
               className="block text-mini leading-tight tracking-[0.04em] text-muted-foreground hover:text-foreground hover:underline"
             >
-              Basemap · {breadcrumbPresetName ?? 'Untitled'} ›
+              {/* fix(#788 item 1): translated — the visible text was a
+                  hardcoded English literal while the aria-label above is
+                  translated, so the two disagreed in non-English locales. */}
+              {t('basemapSublayer.breadcrumb', {
+                defaultValue: 'Basemap · {{name}} ›',
+                name:
+                  breadcrumbPresetName ??
+                  t('basemapSublayer.breadcrumbUntitled', { defaultValue: 'Untitled' }),
+              })}
             </button>
           </div>
         )}

--- a/frontend/src/components/builder/MapTitleBar.tsx
+++ b/frontend/src/components/builder/MapTitleBar.tsx
@@ -85,9 +85,13 @@ export function MapTitleBar({
       : saveStatus === 'saving'
         ? t('titleBar.saveStatus.saving', { defaultValue: 'Saving...' })
         : t('tooltips.allSaved', { defaultValue: 'All changes saved' });
-  const saveButtonAriaLabel = saveStatus === 'failed'
+  // fix(#782): aria-label OVERRIDES element contents in the accessible-name
+  // computation, so an sr-only status span inside the button was never
+  // conveyed. Fold the status into the label itself; the role="status" region
+  // below announces status CHANGES without the button needing focus.
+  const saveButtonAriaLabel = `${saveStatus === 'failed'
     ? t('titleBar.retrySave', { defaultValue: 'Retry save' })
-    : t('tooltips.save', { shortcut: SAVE_SHORTCUT, defaultValue: `Save (${SAVE_SHORTCUT})` });
+    : t('tooltips.save', { shortcut: SAVE_SHORTCUT, defaultValue: `Save (${SAVE_SHORTCUT})` })}, ${saveStatusLabel}`;
 
   return (
     <div className="h-10 border-b bg-background flex items-center gap-3 px-3 shrink-0">
@@ -186,15 +190,18 @@ export function MapTitleBar({
                 <span className="hidden sm:inline">
                   {isSaveRetryable ? t('titleBar.retry', { defaultValue: 'Retry' }) : saveButtonLabel}
                 </span>
-                {/* sr-only status text so AT users still hear the save state even
-                    when the visible label is hidden on narrow viewports. */}
-                <span className="sr-only">{saveStatusLabel}</span>
               </Button>
             </TooltipTrigger>
             <TooltipContent side="bottom">
               {saveTooltip}
             </TooltipContent>
           </Tooltip>
+          {/* fix(#782): persistent live region — mounts with the title bar
+              (initial "Saved" is deliberately not announced) and each status
+              change (Saving… / Saved / Save failed) is announced without
+              focus. The previous sr-only span INSIDE the button was dead: the
+              button's aria-label overrode it. */}
+          <span role="status" className="sr-only">{saveStatusLabel}</span>
 
           <DropdownMenu>
             <DropdownMenuTrigger asChild>

--- a/frontend/src/components/builder/__tests__/AnalysisPanel.test.tsx
+++ b/frontend/src/components/builder/__tests__/AnalysisPanel.test.tsx
@@ -478,6 +478,23 @@ describe('AnalysisPanel', () => {
     expect(screen.queryByRole('option', { name: 'Bus stops' })).toBeNull();
   });
 
+  it('clip action buttons keep their own accessible names (#754)', async () => {
+    // The section label used htmlFor pointed at the state-dependent action
+    // buttons, and a <label for> aimed at a button OVERRIDES the button's own
+    // text — Cancel and Clear were both announced as "Draw clip area".
+    const user = userEvent.setup();
+    renderPanel([datasetLayer, datasetLayer2]);
+
+    await user.click(screen.getAllByRole('combobox')[1]);
+    await user.click(await screen.findByRole('option', { name: 'Clip' }));
+
+    const label = screen.getByText('Draw clip area', { selector: 'label' });
+    expect(label).not.toHaveAttribute('for');
+    // The draw button is named by its own text, not by the label element.
+    const drawButton = screen.getByRole('button', { name: 'Draw clip area' });
+    expect(drawButton).not.toHaveAttribute('id');
+  });
+
   it('converts the buffer distance from the selected unit to meters (#686)', async () => {
     const user = userEvent.setup();
     renderPanel([datasetLayer]);
@@ -719,6 +736,23 @@ describe('AnalysisPanel — chat handoff prefill (#675)', () => {
       await new Promise((r) => setTimeout(r, 0));
       // The superseded response must not resurrect the run state either.
       expect(screen.queryByText('Dataset created')).not.toBeInTheDocument();
+    });
+
+    it('renders the job status in a persistent role="status" region (#784)', async () => {
+      mockJobStatus.value = { status: 'complete', dataset_id: 'out1' };
+      renderPanel([datasetLayer]);
+
+      // Mounted EMPTY with the form — a live region that mounts already
+      // populated is not announced, so the first message must arrive as a
+      // mutation inside an existing region.
+      const region = screen.getByRole('status');
+      expect(region).toBeEmptyDOMElement();
+
+      fireEvent.change(screen.getByLabelText('New dataset name'), {
+        target: { value: 'Walkshed' },
+      });
+      fireEvent.click(screen.getByRole('button', { name: 'Create dataset' }));
+      await waitFor(() => expect(region).toHaveTextContent('Dataset created'));
     });
 
     it('clears the typed name once the run completes (#793 review)', async () => {

--- a/frontend/src/components/builder/__tests__/BuilderRail.test.tsx
+++ b/frontend/src/components/builder/__tests__/BuilderRail.test.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { fireEvent, screen, within } from '@testing-library/react';
+import { fireEvent, screen, waitFor, within } from '@testing-library/react';
 import { render } from '@/test/test-utils';
 import { BuilderRail, type RailPanel } from '../BuilderRail';
 import * as availabilityModule from '@/hooks/use-ai-availability';
@@ -167,6 +167,47 @@ describe('BuilderRail', () => {
     expect(panel?.className).toContain('min-h-0');
     expect(textarea.className).toContain('flex-1');
     expect(textarea.className).toContain('min-h-[18rem]');
+  });
+});
+
+describe('fix(#783) — focus restoration on panel close', () => {
+  it('returns focus to the rail button when the close button dismisses the panel', async () => {
+    render(<RailHarness />);
+    const historyButton = screen.getByRole('button', { name: 'History' });
+    fireEvent.click(historyButton);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Close panel' }));
+
+    expect(screen.queryByTestId('history-panel')).toBeNull();
+    await waitFor(() => expect(historyButton).toHaveFocus());
+  });
+
+  it('returns focus to the rail button when Escape dismisses the panel', async () => {
+    render(<RailHarness />);
+    const notesButton = screen.getByRole('button', { name: 'Notes' });
+    fireEvent.click(notesButton);
+
+    const textarea = screen.getByRole('textbox');
+    textarea.focus();
+    fireEvent.keyDown(textarea, { key: 'Escape' });
+
+    expect(screen.queryByRole('textbox')).toBeNull();
+    await waitFor(() => expect(notesButton).toHaveFocus());
+  });
+});
+
+describe('fix(#788 item 5) — named aside landmarks', () => {
+  it('names the icon rail and the expanded panel', () => {
+    render(<RailHarness />);
+    expect(
+      screen.getByRole('complementary', { name: 'Builder tools' }),
+    ).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'History' }));
+    // The panel aside takes its accessible name from its own title.
+    expect(
+      screen.getByRole('complementary', { name: 'History' }),
+    ).toBeInTheDocument();
   });
 });
 

--- a/frontend/src/components/builder/__tests__/HeatmapStyleControls.test.tsx
+++ b/frontend/src/components/builder/__tests__/HeatmapStyleControls.test.tsx
@@ -76,4 +76,17 @@ describe('HeatmapStyleControls', () => {
 
     expect(screen.getByTestId('color-ramp-picker')).toHaveTextContent('Blues');
   });
+
+  // fix(#788 item 3): SliderRow omitted aria-valuetext, so AT read the raw
+  // number ("0.8") while the screen showed the formatted value ("80%").
+  it('exposes the formatted value to AT via aria-valuetext on each slider', () => {
+    render(<HeatmapStyleControls layer={baseLayer} onPaintChange={vi.fn()} />);
+
+    // Radius, intensity, opacity — in render order. The attribute must sit on
+    // the role="slider" element (the thumb), not a wrapper span.
+    const valuetexts = screen
+      .getAllByRole('slider')
+      .map((thumb) => thumb.getAttribute('aria-valuetext'));
+    expect(valuetexts).toEqual(['30px', '1.0', '80%']);
+  });
 });

--- a/frontend/src/components/builder/__tests__/LayerEditorPanel.test.tsx
+++ b/frontend/src/components/builder/__tests__/LayerEditorPanel.test.tsx
@@ -11,7 +11,18 @@ vi.mock('react-i18next', () => ({
       if (key === 'layerItem.filterTab') return 'Filter';
       if (key === 'layerItem.labelsTab') return 'Labels';
       if (key === 'layerItem.popupTab') return 'Popup';
-      return options?.defaultValue ?? key;
+      // fix(#788 item 1): interpolate params into defaultValue so keys like
+      // basemapSublayer.breadcrumb ("Basemap · {{name}} ›") resolve for the
+      // breadcrumb assertions.
+      let result = options?.defaultValue ?? key;
+      if (options) {
+        for (const [param, value] of Object.entries(options)) {
+          if (param !== 'defaultValue') {
+            result = result.replace(`{{${param}}}`, String(value));
+          }
+        }
+      }
+      return result;
     },
   }),
 }));

--- a/frontend/src/components/builder/__tests__/MapBuilderPage.a11y.test.tsx
+++ b/frontend/src/components/builder/__tests__/MapBuilderPage.a11y.test.tsx
@@ -278,6 +278,27 @@ describe('Phase 1044-02 — MapBuilderPage drag aria-live region (POL-23)', () =
   });
 });
 
+describe('fix(#785) — DndContext translated announcements', () => {
+  it('wires the accessibility prop (source pin)', () => {
+    // Without it, dnd-kit's DEFAULT announcements fire — hardcoded English
+    // built from the draggable id, i.e. "Picked up draggable item <uuid>…".
+    expect(mapBuilderPageSrc).toMatch(/accessibility=\{dndAccessibility\}/);
+  });
+
+  it('mounts translated screen-reader instructions for the drag handles', () => {
+    render(<MapBuilderPage />, { route: '/maps/map-test' });
+
+    // dnd-kit renders screenReaderInstructions.draggable into a hidden
+    // element portal-mounted on <body>; draggables reference it via
+    // aria-describedby.
+    const instructions = document.querySelector('[id^="DndDescribedBy"]');
+    expect(instructions).toBeInTheDocument();
+    expect(instructions?.textContent).toContain(
+      'To reorder a layer, press Enter or Space on its drag handle',
+    );
+  });
+});
+
 describe('MapBuilderPage complementary landmark names', () => {
   it('names the persistent layers sidebar', () => {
     render(<MapBuilderPage />, { route: '/maps/map-test' });

--- a/frontend/src/components/builder/__tests__/MapTitleBar.test.tsx
+++ b/frontend/src/components/builder/__tests__/MapTitleBar.test.tsx
@@ -139,9 +139,38 @@ describe('MapTitleBar', () => {
 
     // SP-06: testid now lives on the Save button itself
     const saveBtn = screen.getByTestId('builder-save-status');
-    expect(saveBtn).toHaveTextContent('Save failed');
     expect(saveBtn).toHaveAttribute('data-save-status', 'failed');
-    expect(screen.getByRole('button', { name: 'Retry save' })).toHaveTextContent('Retry');
+    // fix(#782): the status text moved OUT of the button (its aria-label
+    // overrode the old inner sr-only span) into the adjacent status region;
+    // the aria-label folds the status in ("Retry save, Save failed").
+    expect(screen.getByRole('status')).toHaveTextContent('Save failed');
+    expect(screen.getByRole('button', { name: /^Retry save/ })).toHaveTextContent('Retry');
+  });
+
+  // fix(#782): the button's aria-label used to override the sr-only status
+  // span inside it (aria-label wins over element contents in the
+  // accessible-name computation), so the save state never reached AT.
+  it('folds the save status into the Save button name and mirrors it in a role="status" region', () => {
+    const { rerender } = render(
+      <MapTitleBar {...defaultProps({ hasUnsavedChanges: true })} />,
+    );
+
+    // Accessible name carries both the action and the status.
+    expect(
+      screen.getByRole('button', { name: /^Save \(.*\), Unsaved changes$/ }),
+    ).toBeInTheDocument();
+
+    // Persistent live region announces status CHANGES without focus.
+    const region = screen.getByRole('status');
+    expect(region).toHaveTextContent('Unsaved changes');
+
+    rerender(
+      <MapTitleBar {...defaultProps({ hasUnsavedChanges: true, isSaving: true })} />,
+    );
+    expect(screen.getByRole('status')).toHaveTextContent('Saving...');
+
+    rerender(<MapTitleBar {...defaultProps({ hasUnsavedChanges: false })} />);
+    expect(screen.getByRole('status')).toHaveTextContent('Saved');
   });
 
   it('clicking the save button fires onSave', () => {

--- a/frontend/src/components/ui/slider.tsx
+++ b/frontend/src/components/ui/slider.tsx
@@ -10,6 +10,10 @@ function Slider({
   min = 0,
   max = 100,
   "aria-label": ariaLabel,
+  // fix(#788 item 3): forward aria-valuetext to the Thumb like aria-label —
+  // Radix leaves unknown props on the Root span, which has no slider role, so
+  // valuetext set by callers never reached assistive tech.
+  "aria-valuetext": ariaValueText,
   ...props
 }: React.ComponentProps<typeof SliderPrimitive.Root>) {
   const _values = React.useMemo(
@@ -51,6 +55,7 @@ function Slider({
       {Array.from({ length: _values.length }, (_, index) => (
         <SliderPrimitive.Thumb
           aria-label={ariaLabel}
+          aria-valuetext={ariaValueText}
           data-slot="slider-thumb"
           key={index}
           className="border-primary block size-4 shrink-0 rounded-full border bg-background shadow-sm transition-[color,background-color,box-shadow,border-color,opacity] duration-200 ease-out hover:ring-4 hover:ring-ring/50 outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:pointer-events-none disabled:opacity-50"

--- a/frontend/src/i18n/locales/de/builder.json
+++ b/frontend/src/i18n/locales/de/builder.json
@@ -1079,6 +1079,7 @@
     "dragPosition": "Aktuelle Position: {{n}} von {{total}}",
     "dragDropped": "Abgelegt. {{name}} an Position {{n}} hinzugefügt.",
     "dragCancelled": "Ablegen abgebrochen.",
+    "dragInstructions": "Zum Neuanordnen einer Ebene Eingabe oder Leertaste auf dem Ziehgriff drücken, die Ebene mit den Pfeiltasten verschieben und mit Eingabe, Leertaste oder Escape beenden.",
     "reorderMovedUp": "{{name}} nach oben verschoben.",
     "reorderMovedDown": "{{name}} nach unten verschoben.",
     "reorderDropped": "{{name}} abgelegt.",
@@ -1194,6 +1195,7 @@
   },
   "rail": {
     "aiDisabled": "KI durch Administrator deaktiviert",
+    "toolsLabel": "Editor-Werkzeuge",
     "aiUnavailable": "KI nicht verfügbar",
     "aiUnavailableTitle": "KI ist nicht verfügbar",
     "aiUnavailableDescription": "Ein Administrator muss einen KI-Anbieter aktivieren, bevor Frag KI in diesem Builder verwendet werden kann.",
@@ -1253,6 +1255,8 @@
   },
   "basemapSublayer": {
     "breadcrumbLabel": "Zurück zur Basiskarten-Gruppe",
+    "breadcrumb": "Basiskarte · {{name}} ›",
+    "breadcrumbUntitled": "Ohne Titel",
     "casingColor": "Umrandungsfarbe",
     "casingLabel": "UMRANDUNG",
     "casingWidth": "Breite",

--- a/frontend/src/i18n/locales/en/builder.json
+++ b/frontend/src/i18n/locales/en/builder.json
@@ -1083,6 +1083,7 @@
     "dragPosition": "Current position: {{n}} of {{total}}",
     "dragDropped": "Dropped. {{name}} added at position {{n}}.",
     "dragCancelled": "Drop cancelled.",
+    "dragInstructions": "To reorder a layer, press Enter or Space on its drag handle, use the arrow keys to move it, then press Enter, Space, or Escape to finish.",
     "reorderMovedUp": "{{name}} moved up.",
     "reorderMovedDown": "{{name}} moved down.",
     "reorderDropped": "{{name}} dropped.",
@@ -1199,6 +1200,7 @@
   "rail": {
     "aiDisabled": "AI disabled by admin",
     "closePanel": "Close panel",
+    "toolsLabel": "Builder tools",
     "aiUnavailable": "AI unavailable",
     "aiUnavailableTitle": "AI is unavailable",
     "aiUnavailableDescription": "An administrator needs to enable an AI provider before Ask AI can be used in this builder.",
@@ -1257,6 +1259,8 @@
   },
   "basemapSublayer": {
     "breadcrumbLabel": "Back to basemap group",
+    "breadcrumb": "Basemap · {{name}} ›",
+    "breadcrumbUntitled": "Untitled",
     "resetAction": "Reset to default",
     "casingColor": "Casing color",
     "casingLabel": "CASING",

--- a/frontend/src/i18n/locales/es/builder.json
+++ b/frontend/src/i18n/locales/es/builder.json
@@ -1079,6 +1079,7 @@
     "dragPosition": "Posición actual: {{n}} de {{total}}",
     "dragDropped": "Soltado. {{name}} agregado en la posición {{n}}.",
     "dragCancelled": "Soltar cancelado.",
+    "dragInstructions": "Para reordenar una capa, pulse Intro o Espacio en su asa de arrastre, use las teclas de flecha para moverla y pulse Intro, Espacio o Escape para finalizar.",
     "reorderMovedUp": "{{name}} se movió hacia arriba.",
     "reorderMovedDown": "{{name}} se movió hacia abajo.",
     "reorderDropped": "{{name}} soltado.",
@@ -1194,6 +1195,7 @@
   },
   "rail": {
     "aiDisabled": "IA desactivada por el administrador",
+    "toolsLabel": "Herramientas del editor",
     "aiUnavailable": "IA no disponible",
     "aiUnavailableTitle": "La IA no está disponible",
     "aiUnavailableDescription": "Un administrador debe habilitar un proveedor de IA antes de usar Preguntar a la IA en este builder.",
@@ -1253,6 +1255,8 @@
   },
   "basemapSublayer": {
     "breadcrumbLabel": "Volver al grupo de mapa base",
+    "breadcrumb": "Mapa base · {{name}} ›",
+    "breadcrumbUntitled": "Sin título",
     "casingColor": "Color del contorno",
     "casingLabel": "CONTORNO",
     "casingWidth": "Ancho",

--- a/frontend/src/i18n/locales/fr/builder.json
+++ b/frontend/src/i18n/locales/fr/builder.json
@@ -1079,6 +1079,7 @@
     "dragPosition": "Position actuelle : {{n}} sur {{total}}",
     "dragDropped": "Déposé. {{name}} ajouté à la position {{n}}.",
     "dragCancelled": "Dépôt annulé.",
+    "dragInstructions": "Pour réorganiser une couche, appuyez sur Entrée ou Espace sur sa poignée de déplacement, utilisez les flèches pour la déplacer, puis appuyez sur Entrée, Espace ou Échap pour terminer.",
     "reorderMovedUp": "{{name}} déplacé vers le haut.",
     "reorderMovedDown": "{{name}} déplacé vers le bas.",
     "reorderDropped": "{{name}} déposé.",
@@ -1194,6 +1195,7 @@
   },
   "rail": {
     "aiDisabled": "IA désactivée par l'administrateur",
+    "toolsLabel": "Outils de l'éditeur",
     "aiUnavailable": "IA indisponible",
     "aiUnavailableTitle": "L'IA est indisponible",
     "aiUnavailableDescription": "Un administrateur doit activer un fournisseur d'IA avant d'utiliser Demander à l'IA dans ce builder.",
@@ -1253,6 +1255,8 @@
   },
   "basemapSublayer": {
     "breadcrumbLabel": "Retour au groupe de fond de carte",
+    "breadcrumb": "Fond de carte · {{name}} ›",
+    "breadcrumbUntitled": "Sans titre",
     "casingColor": "Couleur du contour",
     "casingLabel": "CONTOUR",
     "casingWidth": "Largeur",

--- a/frontend/src/pages/MapBuilderPage.tsx
+++ b/frontend/src/pages/MapBuilderPage.tsx
@@ -13,7 +13,14 @@ import {
   useSensor,
   useSensors,
 } from '@dnd-kit/core';
-import type { DragEndEvent, DragOverEvent, DragStartEvent } from '@dnd-kit/core';
+import type {
+  Active,
+  Announcements,
+  DragEndEvent,
+  DragOverEvent,
+  DragStartEvent,
+  ScreenReaderInstructions,
+} from '@dnd-kit/core';
 import { arrayMove, sortableKeyboardCoordinates } from '@dnd-kit/sortable';
 // PERF-06 (Phase 274): lazy-load BuilderMap so map-vendor chunk loads
 // only when the builder is about to render (post-data-fetch).
@@ -1131,6 +1138,61 @@ export function MapBuilderPage() {
     announce(t('a11y.dragPosition', { n: index + 1, total: layers.localLayers.length }));
   }, [layers.localLayers, announce, t]);
 
+  // fix(#785): dnd-kit's DEFAULT announcements are hardcoded English built
+  // from the draggable id — every drag emitted "Picked up draggable item
+  // <uuid>…" into dnd-kit's own live region, in English regardless of locale,
+  // competing with the app's localized announce() region. Announce translated,
+  // human layer names instead. Catalog drags return undefined: their pickup /
+  // position / drop already flow through announce() above (the drop
+  // deliberately fires only AFTER the add-dataset mutation resolves — see
+  // handleDragEnd — which dnd-kit's synchronous onDragEnd cannot honor).
+  const dndAccessibility = useMemo(() => {
+    const isCatalogDrag = (active: Active) =>
+      (active.data.current as { source?: string } | undefined)?.source === 'catalog';
+    const itemName = (active: Active): string => {
+      const data = active.data.current as { name?: string } | undefined;
+      if (data?.name) return data.name;
+      if (basemapGroup && String(active.id) === basemapGroup.id) {
+        return basemapGroup.presetName;
+      }
+      const layer = layers.localLayers.find((l) => l.id === String(active.id));
+      return layer ? (layer.display_name ?? layer.dataset_name) : String(active.id);
+    };
+    const overPosition = (over: { id: string | number } | null): number | null => {
+      if (!over) return null;
+      const index = layers.localLayers.findIndex((l) => l.id === String(over.id));
+      return index >= 0 ? index + 1 : null;
+    };
+    const announcements: Announcements = {
+      onDragStart({ active }) {
+        if (isCatalogDrag(active)) return undefined;
+        return t('a11y.dragPickup', { name: itemName(active) });
+      },
+      onDragOver({ active, over }) {
+        if (isCatalogDrag(active)) return undefined;
+        const n = overPosition(over);
+        if (n == null) return undefined;
+        return t('a11y.dragPosition', { n, total: layers.localLayers.length });
+      },
+      onDragEnd({ active, over }) {
+        if (isCatalogDrag(active)) return undefined;
+        if (!over) return t('a11y.dragCancelled');
+        return t('a11y.dragDropped', { name: itemName(active), n: overPosition(over) ?? 1 });
+      },
+      onDragCancel({ active }) {
+        if (isCatalogDrag(active)) return undefined;
+        return t('a11y.dragCancelled');
+      },
+    };
+    const screenReaderInstructions: ScreenReaderInstructions = {
+      draggable: t('a11y.dragInstructions', {
+        defaultValue:
+          'To reorder a layer, press Enter or Space on its drag handle, use the arrow keys to move it, then press Enter, Space, or Escape to finish.',
+      }),
+    };
+    return { announcements, screenReaderInstructions };
+  }, [layers.localLayers, basemapGroup, t]);
+
   const handleCloseEditor = useCallback(() => {
     const expandedId = layers.expandedLayerId;
     layers.handleToggleExpand('');
@@ -1535,6 +1597,7 @@ export function MapBuilderPage() {
           at MapBuilderPage level so identity is stable across renders. */}
       <DndContext
         sensors={dndSensors}
+        accessibility={dndAccessibility}
         collisionDetection={(args) =>
           pointerWithin(args).length > 0 ? pointerWithin(args) : closestCenter(args)
         }


### PR DESCRIPTION
A11y quick-wins batch from the 2026-07-27 builder/analysis audit (v1.6.0 triage).

## Per issue

**#754 — clip-action label overrides button names** (`AnalysisPanel.tsx`)
Dropped the `htmlFor="analysis-clip-action"` on the section label and the shared `id` on the three state-dependent buttons. A `<label for>` aimed at a button overrides the button's own text in the accessible-name computation, so Cancel and Clear were both announced as "Draw clip area". The buttons are self-labeling; hunks kept tightly scoped away from the sibling units/precedence PR.

**#782 — Save button aria-label swallows the status** (`MapTitleBar.tsx`)
The status is folded into the button's aria-label ("Save (⌘S), Unsaved changes" / "Retry save, Save failed") and mirrored in a persistent sr-only `role="status"` region next to the button, so save completion is announced without focus. The old sr-only span inside the button was dead code — `aria-label` takes precedence over element contents.

**#783 — closing a rail panel drops focus to body** (`BuilderRail.tsx`)
Escape and the header close button now route through a `closePanel` callback that mirrors `handleCloseEditor`: focus returns to the rail button (`data-rail-button={id}`) that owns the just-closed panel, via rAF. In sheet mode (no rail) Radix's own close-time focus restoration applies.

**#784 — successful preview never announced** (`EphemeralBadge.tsx`, `AnalysisPanel.tsx`)
Live regions only announce mutations made while the region is already in the AX tree — mounting populated is silent. The badge now mounts an empty sr-only `role="status"` twin and populates it a frame later (visible text is `aria-hidden` so browse mode doesn't read it twice). The panel's two conditional job-status `<p role="status">` blocks merged into one persistently-rendered region that mounts empty, so the first message ("Creating dataset…") and each later one arrive as announced mutations.

**#785 — dnd-kit default announcements: untranslated + raw UUIDs** (`MapBuilderPage.tsx`)
`<DndContext>` now gets an `accessibility` prop: announcements built from the existing `a11y.drag*` keys using human layer names (stack rows resolve `display_name ?? dataset_name`; the basemap row resolves its preset name), plus `screenReaderInstructions` documenting the drag handle's actual keys (new `a11y.dragInstructions` key, all four locales). Catalog drags return `undefined` — their pickup/position/drop already flow through the page's own localized `announce()` region, whose drop announcement deliberately fires only after the add-dataset mutation resolves (a guarantee dnd-kit's synchronous `onDragEnd` can't honor). No drag listeners or row spread props touched.
Key-parity note: the triage said en had one more `drag` key than es/fr/de — a full key-set diff of every namespace shows all four locales identical; the extra grep hit was the English *value* "focused drag handle" inside `a11y.shortcuts.reorderToggle`, which the other locales translate. Nothing to reconcile.

**#788 item 1 — hardcoded breadcrumb literal** (`LayerEditorPanel.tsx`)
`Basemap · {name} ›` is now `t('basemapSublayer.breadcrumb')` with a translated `breadcrumbUntitled` fallback (all four locales), so visible text and the translated aria-label agree in every locale.

**#788 item 3 — vector SliderRow missing aria-valuetext** (`HeatmapStyleControls.tsx`, `components/ui/slider.tsx`)
`SliderRow` now passes `aria-valuetext` with the formatted display value, matching `RasterSliderRow` and the DEM/basemap scenes. One deliberate extra: the ui `Slider` wrapper now forwards `aria-valuetext` to the Radix `Thumb` (exactly like the existing `aria-label` forwarding) — Radix leaves unknown props on the Root span, which has no slider role, so the valuetext set by every existing call site never actually reached AT. This makes the whole convention effective (test pins the attribute on the `role="slider"` element).

**#788 item 5 — unnamed aside landmarks** (`BuilderRail.tsx`)
Icon rail: static `aria-label` (new `rail.toolsLabel` key, all four locales). Expanded panel: `aria-labelledby` pointing at its own title span.

Part of #788 (items 1, 3, 5) — items 2, 4, 6, 7 are intentionally not addressed here.

Closes #754
Closes #782
Closes #783
Closes #784
Closes #785

## i18n
New keys added literally to en/es/fr/de: `a11y.dragInstructions`, `rail.toolsLabel`, `basemapSublayer.breadcrumb`, `basemapSublayer.breadcrumbUntitled`.

## Tests
- `AnalysisPanel.test.tsx`: clip buttons keep their own accessible names; job status renders in a persistent `role="status"` region that mounts empty.
- `MapTitleBar.test.tsx`: aria-label folds the status; `role="status"` region tracks unsaved → saving → saved; failed-state assertions updated (status text moved out of the button).
- `BuilderRail.test.tsx`: focus returns to the rail button on close-button and Escape dismissal; both asides have accessible names.
- `HeatmapStyleControls.test.tsx`: all three sliders expose formatted `aria-valuetext` on the `role="slider"` element.
- `MapBuilderPage.a11y.test.tsx`: DndContext `accessibility` wiring source pin + translated drag-handle instructions mounted in the DOM.
- `LayerEditorPanel.test.tsx`: i18n mock now interpolates params so the existing breadcrumb assertions still assert the rendered strings.

## Verification
```
cd frontend && npm ci
npm run lint          # pass
npm run typecheck     # pass
npm run test:i18n     # pass (locale parity incl. the 4 new keys)
npx vitest run src/components/builder   # 129 files, 1935 tests, pass
npx vitest run src/pages/__tests__/MapBuilderPage.header-actions.test.tsx src/pages/__tests__/PublicMapViewerPage.test.tsx src/pages/__tests__/PublicViewerPage.test.tsx src/pages/__tests__/MapViewerGate.test.tsx   # pass
```

## Skipped
- Full `npm run test:coverage` suite — CI runs it.
- E2E/axe suites (stack not running here); the e2e selectors this PR could affect were checked: `Query result · N features` (Playwright ignores aria-hidden for text queries + visibility) and the `Close panel` click in `analysis.spec.ts` are unaffected.
- No screenshots: no visual changes (sr-only/ARIA-only, plus one string now translated).

https://claude.ai/code/session_01TEhW22Yf94GjuKYxMhcbLt