### PR TITLE
fix(analysis): re-add the drawn clip mask after a basemap style reload

### DIFF
--- a/frontend/src/components/builder/AnalysisPanel.tsx
+++ b/frontend/src/components/builder/AnalysisPanel.tsx
@@ -347,55 +347,91 @@ export function AnalysisPanel({
   // the panel said "Clip area set" over an empty map. Recreate the
   // kept-static overlay exactly as the finish handler leaves it. Best
   // effort: if TerraDraw rejects the feature, the mask still applies (the
-  // pre-fix behavior), just without the outline.
+  // pre-fix behavior), just without the outline. Shared by the mount
+  // restore below and the fix(#775) style.load re-add.
+  const addStaticMaskOverlay = useCallback(
+    (map: MaplibreMap, maskGeometry: GeoJSON.Polygon) => {
+      // fix(#793 review): held locally so the catch can reach a PARTIALLY
+      // started instance — drawRef is only assigned on full success, so
+      // stopping drawRef there stopped nothing while the failed instance kept
+      // its map layers and handlers attached.
+      let td: TerraDraw | null = null;
+      try {
+        td = new TerraDraw({
+          adapter: new TerraDrawMapLibreGLAdapter({ map }),
+          modes: [
+            new TerraDrawPolygonMode({
+              styles: {
+                fillColor: MAP_COLORS.default.fill,
+                fillOpacity: MAP_COLORS.default.fillOpacity,
+                outlineColor: MAP_COLORS.default.stroke,
+                outlineWidth: MAP_COLORS.default.strokeWidth,
+              },
+            }),
+          ],
+        });
+        td.start();
+        td.addFeatures([
+          {
+            id: crypto.randomUUID(),
+            type: 'Feature',
+            geometry: maskGeometry,
+            properties: { mode: 'polygon' },
+          },
+        ]);
+        td.setMode('static');
+        drawRef.current = td;
+      } catch {
+        try {
+          td?.stop();
+        } catch {
+          // stop() on a partially initialized instance may itself throw.
+        }
+        drawRef.current = null;
+      }
+    },
+    [],
+  );
   const restoredMaskDrawnRef = useRef(false);
   useEffect(() => {
     if (restoredMaskDrawnRef.current) return;
     const map = mapInstanceRef?.current;
     if (!mask || !map || drawRef.current) return;
     restoredMaskDrawnRef.current = true;
-    // fix(#793 review): held locally so the catch can reach a PARTIALLY
-    // started instance — drawRef is only assigned on full success, so
-    // stopping drawRef there stopped nothing while the failed instance kept
-    // its map layers and handlers attached.
-    let td: TerraDraw | null = null;
-    try {
-      td = new TerraDraw({
-        adapter: new TerraDrawMapLibreGLAdapter({ map }),
-        modes: [
-          new TerraDrawPolygonMode({
-            styles: {
-              fillColor: MAP_COLORS.default.fill,
-              fillOpacity: MAP_COLORS.default.fillOpacity,
-              outlineColor: MAP_COLORS.default.stroke,
-              outlineWidth: MAP_COLORS.default.strokeWidth,
-            },
-          }),
-        ],
-      });
-      td.start();
-      td.addFeatures([
-        {
-          id: crypto.randomUUID(),
-          type: 'Feature',
-          geometry: mask,
-          properties: { mode: 'polygon' },
-        },
-      ]);
-      td.setMode('static');
-      drawRef.current = td;
-    } catch {
-      try {
-        td?.stop();
-      } catch {
-        // stop() on a partially initialized instance may itself throw.
-      }
-      drawRef.current = null;
-    }
+    addStaticMaskOverlay(map, mask);
     // No dep array (fix(#793 review)): the map arrives by REF assignment —
     // no dep ever changes — but the lazy BuilderMap's load re-renders the
     // parent, so retrying every commit reaches the moment the map exists;
     // restoredMaskDrawnRef then latches this to a no-op.
+  });
+  // fix(#775): a basemap switch calls setStyle, which wipes every
+  // imperatively added source/layer — TerraDraw's static overlay included
+  // (the 1.4.x adapter has no style-reload handling) — while `mask` and
+  // drawRef survive, so the panel claimed "Clip area set" over a map with no
+  // visible mask and no re-add path. Mirror use-ephemeral-layers' fix(#394)
+  // pattern: subscribe for the lifetime of the mask and rebuild the overlay
+  // on every style.load. Stopping the orphaned instance first can throw over
+  // the already-wiped layers (the adapter's unregister removes them
+  // unguarded), hence the try/catch. No dep array for the same
+  // ref-assignment reason as above; the cleanup keeps exactly one live
+  // subscription and drops it when the mask clears or the panel unmounts.
+  useEffect(() => {
+    const map = mapInstanceRef?.current;
+    if (!mask || !map) return;
+    const readdMask = () => {
+      try {
+        drawRef.current?.stop();
+      } catch {
+        // The new style already removed the adapter's layers; stop() may
+        // throw tearing down what no longer exists.
+      }
+      drawRef.current = null;
+      addStaticMaskOverlay(map, mask);
+    };
+    map.on('style.load', readdMask);
+    return () => {
+      map.off('style.load', readdMask);
+    };
   });
   // Shares its TanStack query with the page-level tracker (same key), so
   // there is exactly one 2s poll loop however many components watch the job.

--- a/frontend/src/components/builder/__tests__/AnalysisPanel.draw-suppression.test.tsx
+++ b/frontend/src/components/builder/__tests__/AnalysisPanel.draw-suppression.test.tsx
@@ -93,8 +93,12 @@ const polygonLayer = {
 
 function renderPanel() {
   const qc = new QueryClient({ defaultOptions: { mutations: { retry: false } } });
-  // startDrawing bails without a map; the adapter is mocked, so any object does.
-  const mapInstanceRef = { current: {} as MaplibreMap };
+  // startDrawing bails without a map; the adapter is mocked. on/off: the
+  // finished polygon sets a mask, whose fix(#775) style.load subscription
+  // attaches to the map.
+  const mapInstanceRef = {
+    current: { on: vi.fn(), off: vi.fn() } as unknown as MaplibreMap,
+  };
   return render(
     <QueryClientProvider client={qc}>
       <AnalysisPanel layers={[polygonLayer]} mapInstanceRef={mapInstanceRef} />

--- a/frontend/src/components/builder/__tests__/AnalysisPanel.test.tsx
+++ b/frontend/src/components/builder/__tests__/AnalysisPanel.test.tsx
@@ -1,6 +1,7 @@
 import { act, fireEvent, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { TerraDraw } from 'terra-draw';
 import { render } from '@/test/test-utils';
 import { AnalysisPanel } from '../AnalysisPanel';
 import { ApiError } from '@/api/client';
@@ -1073,7 +1074,9 @@ describe('AnalysisPanel — chat handoff prefill (#675)', () => {
       expect(mockTerraDraw.instance.addFeatures).not.toHaveBeenCalled();
 
       // The map arrives by REF assignment; the load re-renders the parent.
-      mapRef.current = {};
+      // on/off: the fix(#775) style.load subscription attaches while a mask
+      // is set.
+      mapRef.current = { on: vi.fn(), off: vi.fn() };
       view.rerender(renderTree());
       await waitFor(() =>
         expect(mockTerraDraw.instance.addFeatures).toHaveBeenCalled(),
@@ -1094,12 +1097,75 @@ describe('AnalysisPanel — chat handoff prefill (#675)', () => {
       });
       renderPanel([datasetLayer], {
         mapId: 'm1',
-        mapInstanceRef: { current: {} as never },
+        mapInstanceRef: { current: { on: vi.fn(), off: vi.fn() } as never },
       });
       // The failed restore must stop the instance it started — the ref was
       // never assigned, so stopping via the ref would leak its map layers.
       await waitFor(() =>
         expect(mockTerraDraw.instance.stop).toHaveBeenCalled(),
+      );
+    });
+
+    it('re-adds the drawn mask overlay after a basemap style reload (#775)', async () => {
+      mockTerraDraw.instance.addFeatures.mockClear();
+      mockTerraDraw.instance.setMode.mockClear();
+      mockTerraDraw.instance.stop.mockClear();
+      const mask: GeoJSON.Polygon = {
+        type: 'Polygon',
+        coordinates: [[[0, 0], [1, 0], [1, 1], [0, 0]]],
+      };
+      useAnalysisFormStore.getState().save('m1', {
+        layerId: 'l1', operation: 'clip', distance: '500', distanceUnit: 'm',
+        mask, maskLayerId: '__none__', byField: '__none__', outputTitle: '',
+      });
+      // A map that actually tracks its style.load handlers: the fix
+      // subscribes for the lifetime of the mask, and the unsubscribe half
+      // (mask cleared → no resurrect) is only observable through a registry.
+      const styleLoadHandlers = new Set<() => void>();
+      const mockMap = {
+        on: vi.fn((event: string, fn: () => void) => {
+          if (event === 'style.load') styleLoadHandlers.add(fn);
+        }),
+        off: vi.fn((event: string, fn: () => void) => {
+          if (event === 'style.load') styleLoadHandlers.delete(fn);
+        }),
+      };
+      renderPanel([datasetLayer], {
+        mapId: 'm1',
+        mapInstanceRef: { current: mockMap as never },
+      });
+      // The #793 mount restore drew the static overlay once.
+      await waitFor(() =>
+        expect(mockTerraDraw.instance.addFeatures).toHaveBeenCalledTimes(1),
+      );
+
+      // A basemap switch: setStyle wiped TerraDraw's layers (the mask state
+      // survives), then the new style announced itself via style.load.
+      const constructionsBefore = vi.mocked(TerraDraw).mock.calls.length;
+      act(() => {
+        [...styleLoadHandlers].forEach((fn) => fn());
+      });
+      // The orphaned instance is stopped and the overlay rebuilt from mask.
+      expect(mockTerraDraw.instance.stop).toHaveBeenCalled();
+      expect(vi.mocked(TerraDraw).mock.calls.length).toBe(
+        constructionsBefore + 1,
+      );
+      expect(mockTerraDraw.instance.addFeatures).toHaveBeenCalledTimes(2);
+      expect(mockTerraDraw.instance.addFeatures).toHaveBeenLastCalledWith([
+        expect.objectContaining({ geometry: mask }),
+      ]);
+      expect(mockTerraDraw.instance.setMode).toHaveBeenLastCalledWith('static');
+
+      // Clearing the mask drops the subscription — a later style reload must
+      // not resurrect the cleared overlay.
+      fireEvent.click(screen.getByRole('button', { name: 'Clear' }));
+      await waitFor(() => expect(styleLoadHandlers.size).toBe(0));
+      const constructionsAfterClear = vi.mocked(TerraDraw).mock.calls.length;
+      act(() => {
+        [...styleLoadHandlers].forEach((fn) => fn());
+      });
+      expect(vi.mocked(TerraDraw).mock.calls.length).toBe(
+        constructionsAfterClear,
       );
     });
 


### PR DESCRIPTION
## What changed

A basemap switch calls `setStyle`, which wipes every imperatively added source/layer — including the TerraDraw static overlay that keeps the finished clip mask visible (`terra-draw-maplibre-gl-adapter` 1.4.x has no style-reload handling: its `register()` adds sources/layers once and nothing re-adds them). The `mask` state survived, so the operation still ran correctly, but the panel said "Clip area set" over a map with no visible mask and no re-add path.

Fix in `frontend/src/components/builder/AnalysisPanel.tsx`, mirroring the `use-ephemeral-layers` #394 pattern rather than inventing a new one:

- Extracted the kept-static TerraDraw overlay construction (previously inlined in the #793 mount-restore effect) into a shared `addStaticMaskOverlay` helper. The restore effect's latch/no-dep-array semantics are unchanged.
- New effect: while a drawn mask is set (and the map ref exists), subscribe to `style.load` and rebuild the overlay on every fire — stopping the orphaned instance first, guarded, since the adapter's `unregister()` removes its layers unguarded and the new style already dropped them. The cleanup drops the subscription when the mask clears or the panel unmounts, so a cleared mask cannot resurrect.
- Side benefit: a mask restored before the initial style finished loading (where the #793 latch-once creation could fail silently) now heals on the first `style.load`.

Mask state stays client-side — no `basemap_config` fields, no layer PATCH involvement, no API/schema/config impact. Not covered (pre-existing, separate surface): a basemap switch mid-draw, before the polygon is finished — the mask does not exist yet at that point.

Tests:

- New: `re-adds the drawn mask overlay after a basemap style reload (#775)` — mock map with a real `style.load` handler registry; asserts the overlay is rebuilt from `mask` (old instance stopped, new TerraDraw constructed, `setMode('static')`) and that clearing the mask unsubscribes so a later reload adds nothing. Fails against the previous `AnalysisPanel.tsx`, passes with the fix.
- Existing map fixtures in the two AnalysisPanel test files grew `on`/`off` stubs, since the panel now subscribes to the map whenever a mask is set.

## Verification

```
cd frontend && npm run lint
cd frontend && npm run typecheck
cd frontend && npx vitest run src/components/builder/__tests__/AnalysisPanel.test.tsx src/components/builder/__tests__/AnalysisPanel.draw-suppression.test.tsx
```

All clean; 70/70 tests pass. No new translation keys.

Closes #775

https://claude.ai/code/session_01TEhW22Yf94GjuKYxMhcbLt