### PR TITLE
fix(map): stop double-logging tile-auth 403s the recovery path already handles

### DIFF
--- a/frontend/src/components/builder/BuilderMap.tsx
+++ b/frontend/src/components/builder/BuilderMap.tsx
@@ -13,6 +13,7 @@ import {
   BLANK_BASEMAP_ID,
 } from '@/lib/basemap-utils';
 import { buildClusterTileUrl, buildSignedTileUrl, isMvtSourceLayerConfigReady } from '@/lib/tile-utils';
+import { logUnhandledMapError } from '@/lib/map-error-log';
 import { MAP_COLORS } from '@/lib/map-colors';
 import { useTileTokens, useInvalidateTileTokens } from '@/hooks/use-tile-token';
 import { useTileAuthRecovery } from '@/hooks/use-tile-auth-recovery';
@@ -1347,6 +1348,10 @@ export const BuilderMap = memo(function BuilderMap({
         style={{ width: '100%', height: '100%' }}
         minZoom={1}
         onLoad={handleLoad}
+        // fix(#755): claim the wrapper's `error` fallback so a handled
+        // tile-auth 401/403 (GUARD-03 re-sign / #621 re-mint in handleLoad's
+        // error handler) stops double-logging a red AJAXError console row.
+        onError={logUnhandledMapError}
         aria-label={t('map.ariaLabel', { defaultValue: 'Map builder' })}
       >
         {/* RESP-01 (Phase 1051): NavigationControl anchored top-left so it does not

--- a/frontend/src/components/dataset/DatasetMap.tsx
+++ b/frontend/src/components/dataset/DatasetMap.tsx
@@ -38,6 +38,7 @@ import type { Feature, Geometry, GeoJsonProperties } from 'geojson';
 import 'maplibre-gl/dist/maplibre-gl.css';
 import { motionDuration } from '@/lib/reduced-motion';
 import { isMvtSourceLayerConfigReady } from '@/lib/tile-utils';
+import { logUnhandledMapError } from '@/lib/map-error-log';
 
 /** System columns excluded from the attribute form */
 const SYSTEM_COLUMNS = new Set(['gid', 'geom', 'geom_4326']);
@@ -813,6 +814,10 @@ export const DatasetMap = memo(function DatasetMap({
         interactive
         scrollZoom={isFullscreen}
         onLoad={handleLoad}
+        // fix(#755): claim the wrapper's `error` fallback so a handled
+        // tile-auth 401/403 (#621 re-mint in handleLoad's error handler)
+        // stops double-logging a red AJAXError console row.
+        onError={logUnhandledMapError}
       >
         <NavigationControl position="top-right" />
 

--- a/frontend/src/components/viewer/ViewerMap.tsx
+++ b/frontend/src/components/viewer/ViewerMap.tsx
@@ -13,6 +13,7 @@ import {
   BLANK_BASEMAP_ID,
 } from '@/lib/basemap-utils';
 import { buildClusterTileUrl, buildSignedTileUrl, getMvtSourceLayerName, isMvtSourceLayerConfigReady, resolveTileBaseUrl } from '@/lib/tile-utils';
+import { logUnhandledMapError } from '@/lib/map-error-log';
 import { useWebGLRecovery } from '@/hooks/use-webgl-recovery';
 import { useInvalidateTileTokens } from '@/hooks/use-tile-token';
 import { useTileAuthRecovery } from '@/hooks/use-tile-auth-recovery';
@@ -1047,6 +1048,11 @@ export const ViewerMap = memo(function ViewerMap({
         attributionControl={false}
         minZoom={1}
         onLoad={handleLoad}
+        // fix(#755): claim the wrapper's `error` fallback so a handled
+        // tile-auth 401/403 (#621 re-mint / embed-expired toast in
+        // handleLoad's error handler) stops double-logging a red AJAXError
+        // console row.
+        onError={logUnhandledMapError}
         aria-label={t('viewer.map.ariaLabel', { defaultValue: 'Map viewer' })}
       >
         <NavigationControl position="top-right" />

--- a/frontend/src/lib/__tests__/map-error-log.test.ts
+++ b/frontend/src/lib/__tests__/map-error-log.test.ts
@@ -1,0 +1,97 @@
+// fix(#755): `logUnhandledMapError` is the <Map> `onError` prop for every
+// surface with its own tile-auth recovery (builder, viewer, dataset preview).
+// It must drop the console log ONLY for the handled first-party 401/403
+// vector-tile case — the recovery path owns those — and replicate the
+// react-maplibre wrapper's default `console.error(e.error)` for everything
+// else, so real failures stay visible in devtools and the problem report.
+
+import { isHandledTileAuthError, logUnhandledMapError } from '@/lib/map-error-log';
+
+function ajaxError(status: number, url: string) {
+  return { error: { message: `AJAXError: (${status}): ${url}`, status, url } };
+}
+
+describe('logUnhandledMapError (fix #755)', () => {
+  let errorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    errorSpy.mockRestore();
+  });
+
+  it('logs nothing for a handled 403 on a same-origin signed vector tile (tab-return burst)', () => {
+    const e = ajaxError(
+      403,
+      `${window.location.origin}/api/tiles/data.prueba/4/8/5.pbf?sig=abc&exp=1785148200&scope=prueba&cols=id&_v=1`,
+    );
+    logUnhandledMapError(e);
+    expect(errorSpy).not.toHaveBeenCalled();
+  });
+
+  it('logs nothing for a handled 401 on a relative tile URL without a sig (attach race)', () => {
+    logUnhandledMapError(ajaxError(401, '/api/tiles/data.parcels/12/1205/1539.pbf'));
+    expect(errorSpy).not.toHaveBeenCalled();
+  });
+
+  it('logs nothing for a handled 403 on a CDN-fronted signed tile URL', () => {
+    logUnhandledMapError(
+      ajaxError(403, 'https://cdn.example.com/tiles/clusters/data.points/3/4/2.pbf?sig=abc&exp=1&scope=points'),
+    );
+    expect(errorSpy).not.toHaveBeenCalled();
+  });
+
+  it('keeps the default single log for a third-party 403 without a GeoLens signature', () => {
+    const e = ajaxError(403, 'https://demotiles.maplibre.org/tiles/3/4/2.pbf');
+    logUnhandledMapError(e);
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+    expect(errorSpy).toHaveBeenCalledWith(e.error);
+  });
+
+  it('keeps the default single log for a raster-tiles 403 (outside the vector-tile scope)', () => {
+    const e = ajaxError(403, `${window.location.origin}/raster-tiles/cog/9/151/191.png`);
+    logUnhandledMapError(e);
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+    expect(errorSpy).toHaveBeenCalledWith(e.error);
+  });
+
+  it('keeps the default single log for a 404 no-data tile', () => {
+    const e = ajaxError(404, `${window.location.origin}/api/tiles/data.prueba/4/8/5.pbf?sig=abc`);
+    logUnhandledMapError(e);
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+    expect(errorSpy).toHaveBeenCalledWith(e.error);
+  });
+
+  it('keeps the default single log for a tile 500', () => {
+    const e = ajaxError(500, `${window.location.origin}/api/tiles/data.prueba/4/8/5.pbf?sig=abc`);
+    logUnhandledMapError(e);
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+    expect(errorSpy).toHaveBeenCalledWith(e.error);
+  });
+
+  it('keeps the default single log for a status-less runtime/style error', () => {
+    const e = { error: { message: 'Unimplemented type: 4' } };
+    logUnhandledMapError(e);
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+    expect(errorSpy).toHaveBeenCalledWith(e.error);
+  });
+});
+
+describe('isHandledTileAuthError (fix #755)', () => {
+  it('matches only first-party tile-auth statuses', () => {
+    const url = `${window.location.origin}/api/tiles/data.t/1/2/3.pbf?sig=a`;
+    expect(isHandledTileAuthError(ajaxError(401, url))).toBe(true);
+    expect(isHandledTileAuthError(ajaxError(403, url))).toBe(true);
+    expect(isHandledTileAuthError(ajaxError(404, url))).toBe(false);
+    expect(isHandledTileAuthError(ajaxError(500, url))).toBe(false);
+    expect(isHandledTileAuthError({ error: { message: 'no status' } })).toBe(false);
+    expect(isHandledTileAuthError({})).toBe(false);
+  });
+
+  it('requires a tile URL — a 403 without one stays loggable', () => {
+    expect(isHandledTileAuthError({ error: { status: 403 } })).toBe(false);
+    expect(isHandledTileAuthError(ajaxError(403, `${window.location.origin}/api/datasets/`))).toBe(false);
+  });
+});

--- a/frontend/src/lib/map-error-log.ts
+++ b/frontend/src/lib/map-error-log.ts
@@ -1,0 +1,49 @@
+// fix(#755): the @vis.gl/react-maplibre wrapper subscribes the map `error`
+// event unconditionally and, when the <Map> component has no `onError` prop,
+// falls back to `console.error(e.error)` for every event — in parallel with
+// each surface's own `map.on('error')` handler. For the 401/403 vector-tile
+// case that handler already recovers (GUARD-03 cached-token re-sign and/or
+// the #621 throttled token re-mint), the raw AJAXError therefore still hits
+// the console and lands as an unsuppressed red row in the problem-report
+// buffer next to the suppressed recovery warnings, making a recovered
+// situation read as a breakage.
+//
+// Passing `logUnhandledMapError` as the <Map> `onError` prop keeps the
+// wrapper's default log for everything else and drops ONLY that handled case.
+
+/** Structural subset of MapLibre's ErrorEvent that this module inspects.
+ * MapLibre attaches `status`/`url` to AJAXError instances raised by tile
+ * fetches; plain style/runtime errors carry neither. */
+export interface MapLibreErrorLike {
+  error?: { message?: string; status?: number; url?: string };
+}
+
+/** True when `url` targets a first-party GeoLens tile endpoint: a relative or
+ * same-origin `/tiles/` path (`/api/tiles/…`, including `/tiles/clusters/…`),
+ * or a CDN-fronted tile URL still carrying our signed-tile `sig=` param.
+ * Third-party basemap tile URLs (different origin, no GeoLens signature) and
+ * raster `/raster-tiles/` paths do not match. */
+function isFirstPartyTileUrl(url: string | undefined): boolean {
+  if (!url || !url.includes('/tiles/')) return false;
+  if (!/^https?:\/\//i.test(url)) return true;
+  if (url.startsWith(`${window.location.origin}/`)) return true;
+  return /[?&]sig=/.test(url);
+}
+
+/** True for a 401/403 on a first-party vector-tile request — the case every
+ * map surface's own `error` handler owns end to end (re-sign, re-mint, or the
+ * session-expired / embed-expired UX). */
+export function isHandledTileAuthError(e: MapLibreErrorLike): boolean {
+  const status = e.error?.status;
+  if (status !== 401 && status !== 403) return false;
+  return isFirstPartyTileUrl(e.error?.url);
+}
+
+/** `onError` prop for @vis.gl/react-maplibre's <Map>: replicate the wrapper's
+ * default `console.error` fallback, except for handled first-party tile-auth
+ * 401/403s, which log nothing — the surface's `map.on('error')` handler
+ * recovers those and reports them (suppressed) where applicable. */
+export function logUnhandledMapError(e: MapLibreErrorLike): void {
+  if (isHandledTileAuthError(e)) return;
+  console.error(e.error);
+}


### PR DESCRIPTION
## What

Fix 2 of #755, per the v1.6.0 scoping comment (fix 2 only; the proactive `visibilitychange` re-mint stays on the issue).

Returning to a backgrounded map tab past the tile-signature boundary 403s every visible vector tile. The GUARD-03 re-sign / #621 throttled re-mint path recovers the map, but each 403 still landed as an **unsuppressed red `AJAXError` console row** in the problem report next to the suppressed recovery warnings — making a recovered situation read as a breakage.

Root cause of the duplicate: `@vis.gl/react-maplibre` subscribes the map `error` event unconditionally and falls back to `console.error(e.error)` whenever the `<Map>` component has no `onError` prop — in parallel with each surface's own `map.on('error')` recovery handler (`maplibre.ts` `_onEvent`).

- New `frontend/src/lib/map-error-log.ts`: `logUnhandledMapError` drops the log for exactly the handled first-party 401/403 vector-tile case (relative/same-origin `/tiles/` URL, or a CDN tile URL carrying our `sig=` param) and replicates the wrapper's default `console.error` for everything else.
- Wired as the `onError` prop on the three surfaces that own tile-auth recovery: `BuilderMap`, `ViewerMap`, `DatasetMap`.

A handled 403 now logs **not at all** through the wrapper path; the recovery path's suppressed `BLDR-TILE-RACE` report entries are unchanged. Third-party basemap 401/403s, raster-tile errors, 404 no-data tiles, 5xx, and status-less style errors keep the exact default single log. No API/schema/config impact; no new translation keys; `error-map.ts` untouched.

## Verification

```
cd frontend
npm run lint
npm run typecheck
npx vitest run src/lib/__tests__/map-error-log.test.ts   # 10 passed
npx vitest run src/components/builder/__tests__/BuilderMap.*.test.* \
  src/components/viewer/__tests__/ViewerMap.*.test.* \
  src/components/dataset/__tests__/DatasetMap.*.test.*    # 14 files, 106 passed
```

Part of #755 — the remainder (fix 1, proactive re-mint on `visibilitychange`) stays tracked on the issue per the scoping comment.

https://claude.ai/code/session_01TEhW22Yf94GjuKYxMhcbLt