### PR TITLE
ux(builder): make every destructive confirm safe-left, destructive-right

### DIFF
--- a/frontend/src/components/builder/BasemapSublayerEditorScene.tsx
+++ b/frontend/src/components/builder/BasemapSublayerEditorScene.tsx
@@ -13,6 +13,7 @@ import { Input } from '@/components/ui/input';
 import { cn } from '@/lib/utils';
 import { MAP_COLORS } from '@/lib/map-colors';
 import { StyleColorPicker } from '@/components/builder/StyleColorPicker';
+import { InlineDeleteConfirm } from '@/components/builder/row-chrome';
 import { formatNumber } from '@/lib/format';
 
 // Phase 1051 Plan 11 (INV-01): DETAIL LEVEL pill strip REMAINS REMOVED.
@@ -303,38 +304,23 @@ export function BasemapSublayerEditorScene({
                 {t('basemapSublayer.resetAction', { defaultValue: 'Reset to default' })}
               </Button>
             ) : (
-              <div role="alertdialog" aria-labelledby="confirm-reset-title" className="space-y-2">
-                <p id="confirm-reset-title" className="text-sm text-destructive text-center">
-                  {t('basemapSublayer.resetConfirmMessage', {
-                    sublayer: sublayerName,
-                    defaultValue: 'This will remove all custom appearance for {{sublayer}}.',
-                  })}
-                </p>
-                <div className="flex gap-2">
-                  <Button
-                    type="button"
-                    variant="destructive"
-                    className="flex-1"
-                    onClick={() => {
-                      onResetSublayer();
-                      setConfirmingReset(false);
-                    }}
-                  >
-                    {t('basemapSublayer.resetConfirmAction', { defaultValue: 'Reset' })}
-                  </Button>
-                  {/* autoFocus on the safe choice — "Keep customization" */}
-                  <Button
-                    type="button"
-                    variant="secondary"
-                    className="flex-1"
-                    // eslint-disable-next-line jsx-a11y/no-autofocus
-                    autoFocus
-                    onClick={() => setConfirmingReset(false)}
-                  >
-                    {t('basemapSublayer.resetConfirmCancel', { defaultValue: 'Keep customization' })}
-                  </Button>
-                </div>
-              </div>
+              // ux(#777): shared builder-wide inline confirm — safe action left,
+              // destructive right, cancel autofocused.
+              <InlineDeleteConfirm
+                confirmId="confirm-reset-title"
+                message={t('basemapSublayer.resetConfirmMessage', {
+                  sublayer: sublayerName,
+                  defaultValue: 'This will remove all custom appearance for {{sublayer}}.',
+                })}
+                confirmLabel={t('basemapSublayer.resetConfirmAction', { defaultValue: 'Reset' })}
+                cancelLabel={t('basemapSublayer.resetConfirmCancel', { defaultValue: 'Keep customization' })}
+                onConfirm={() => {
+                  onResetSublayer();
+                  setConfirmingReset(false);
+                }}
+                onCancel={() => setConfirmingReset(false)}
+                className="mx-0 mb-0"
+              />
             )}
           </div>
         </CollapsibleContent>

--- a/frontend/src/components/builder/BuilderDialogs.tsx
+++ b/frontend/src/components/builder/BuilderDialogs.tsx
@@ -1,8 +1,17 @@
 import { lazy, Suspense } from 'react';
 import { Link } from 'react-router';
 import { useTranslation } from 'react-i18next';
-import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
 import {
   Dialog,
   DialogContent,
@@ -160,23 +169,26 @@ export function BuilderDialogs({
         </DialogContent>
       </Dialog>
 
-      {/* Unsaved changes leave warning */}
-      <Dialog open={blockerState === 'blocked'} onOpenChange={() => onBlockerReset?.()}>
-        <DialogContent className="sm:max-w-sm">
-          <DialogHeader>
-            <DialogTitle>{t('leaveWarning.title')}</DialogTitle>
-            <DialogDescription>{t('leaveWarning.description')}</DialogDescription>
-          </DialogHeader>
-          <div className="flex justify-end gap-2">
-            <Button variant="outline" onClick={() => onBlockerReset?.()}>
+      {/* Unsaved changes leave warning.
+          ux(#777): a modal AlertDialog with the canonical Cancel-then-Action
+          footer, matching the DatasetPage / AdminSettingsPage navigation guards
+          — was a dismissible Dialog with a hand-rolled footer. */}
+      <AlertDialog open={blockerState === 'blocked'} onOpenChange={() => onBlockerReset?.()}>
+        <AlertDialogContent size="sm">
+          <AlertDialogHeader>
+            <AlertDialogTitle>{t('leaveWarning.title')}</AlertDialogTitle>
+            <AlertDialogDescription>{t('leaveWarning.description')}</AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel onClick={() => onBlockerReset?.()}>
               {t('leaveWarning.stay')}
-            </Button>
-            <Button variant="destructive" onClick={() => onBlockerProceed?.()}>
+            </AlertDialogCancel>
+            <AlertDialogAction variant="destructive" onClick={() => onBlockerProceed?.()}>
               {t('leaveWarning.leave')}
-            </Button>
-          </div>
-        </DialogContent>
-      </Dialog>
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </>
   );
 }

--- a/frontend/src/components/builder/BulkActionBar.tsx
+++ b/frontend/src/components/builder/BulkActionBar.tsx
@@ -161,11 +161,13 @@ export const BulkActionBar = memo(function BulkActionBar({
           <span className="text-sm text-muted-foreground flex-1">
             {t('bulkActions.deletingLayers', { count: N })}
           </span>
+          {/* ux(#777): variant="destructive" (not ghost+text-destructive) so the
+              in-flight button matches the confirm button the user just pressed. */}
           <Button
             type="button"
-            variant="ghost"
+            variant="destructive"
             size="sm"
-            className="h-8 gap-1.5 px-2 shrink-0 text-destructive cursor-not-allowed"
+            className="h-8 gap-1.5 px-2 shrink-0 cursor-not-allowed"
             disabled={true}
             aria-busy={true}
             aria-label={t('bulkActions.deleteAriaLabel', { count: N })}
@@ -205,11 +207,13 @@ export const BulkActionBar = memo(function BulkActionBar({
           >
             {t('bulkActions.deleteConfirmCancel')}
           </Button>
+          {/* ux(#777): destructive action styled variant="destructive" and placed
+              last (right), matching InlineDeleteConfirm and every ui/alert-dialog
+              footer — deleting one layer and deleting five are the same gesture. */}
           <Button
             type="button"
-            variant="ghost"
+            variant="destructive"
             size="sm"
-            className="text-destructive"
             onClick={(e) => {
               e.stopPropagation();
               onBulkDelete(selectedIds);

--- a/frontend/src/components/builder/DEMEditorScene.tsx
+++ b/frontend/src/components/builder/DEMEditorScene.tsx
@@ -9,6 +9,7 @@ import { StyleColorPicker } from './StyleColorPicker';
 import { ColorRampPicker } from './ColorRampPicker';
 import { SunCompass } from './SunCompass';
 import { getNumberPaint, getStringPaint } from './paint-accessors';
+import { InlineDeleteConfirm } from './row-chrome';
 import {
   HILLSHADE_EXAGGERATION_MAX,
   HILLSHADE_EXAGGERATION_MIN,
@@ -514,35 +515,20 @@ export const DEMEditorScene = memo(function DEMEditorScene({
             {t('layerEditor.deleteLayer', { defaultValue: 'Delete layer' })}
           </Button>
         ) : (
-          <div role="alertdialog" aria-labelledby="dem-delete-confirm-title" className="space-y-2">
-            <p id="dem-delete-confirm-title" className="text-sm text-destructive text-center">
-              {t('layerEditor.deleteLayerConfirmMessage', { defaultValue: 'Delete this layer? This cannot be undone.' })}
-            </p>
-            <div className="flex gap-2">
-              <Button
-                type="button"
-                variant="destructive"
-                className="flex-1"
-                onClick={() => {
-                  onRemove(layer.id);
-                  setConfirmDelete(false);
-                }}
-              >
-                {t('layerEditor.deleteLayerConfirmAction', { defaultValue: 'Delete' })}
-              </Button>
-              {/* autoFocus on the safe choice */}
-              <Button
-                type="button"
-                variant="secondary"
-                className="flex-1"
-                // eslint-disable-next-line jsx-a11y/no-autofocus
-                autoFocus
-                onClick={() => setConfirmDelete(false)}
-              >
-                {t('layerEditor.deleteLayerConfirmCancel', { defaultValue: 'Keep layer' })}
-              </Button>
-            </div>
-          </div>
+          // ux(#777): shared builder-wide inline confirm — safe action left,
+          // destructive right, cancel autofocused.
+          <InlineDeleteConfirm
+            confirmId="dem-delete-confirm-title"
+            message={t('layerEditor.deleteLayerConfirmMessage', { defaultValue: 'Delete this layer? This cannot be undone.' })}
+            confirmLabel={t('layerEditor.deleteLayerConfirmAction', { defaultValue: 'Delete' })}
+            cancelLabel={t('layerEditor.deleteLayerConfirmCancel', { defaultValue: 'Keep layer' })}
+            onConfirm={() => {
+              onRemove(layer.id);
+              setConfirmDelete(false);
+            }}
+            onCancel={() => setConfirmDelete(false)}
+            className="mx-0 mb-0"
+          />
         )}
       </footer>
     </div>

--- a/frontend/src/components/builder/LayerEditorPanel.tsx
+++ b/frontend/src/components/builder/LayerEditorPanel.tsx
@@ -6,7 +6,7 @@ import { LayerFilterEditor } from './LayerFilterEditor';
 import { LabelEditor } from './LabelEditor';
 import { PopupConfigEditor } from './PopupConfigEditor';
 import { RasterLayerControls } from './RasterLayerControls';
-import { Button } from '@/components/ui/button';
+import { InlineDeleteConfirm } from './row-chrome';
 import { cn } from '@/lib/utils';
 import { getLayerCapabilities } from '@/lib/layer-capabilities';
 import { getRenderAsOptions, getCurrentRenderAs, hasCustomizedRenderAsStyle, type RenderAsId } from './renderAs';
@@ -483,42 +483,19 @@ export const LayerEditorPanel = memo(function LayerEditorPanel({
                         })}
                       </div>
                       {pendingRenderAs && (
-                        <div
-                          role="alertdialog"
-                          aria-labelledby={`confirm-render-as-${layer.id}`}
-                          className="mt-3 space-y-2 rounded-md border border-destructive/30 bg-destructive/5 p-2"
-                        >
-                          <p
-                            id={`confirm-render-as-${layer.id}`}
-                            className="text-xs text-foreground"
-                          >
-                            {t('layerEditor.confirmRenderAs.message', {
-                              defaultValue: 'Compatible style is carried over; only mode-specific settings will reset. Continue?',
-                            })}
-                          </p>
-                          <div className="flex gap-2">
-                            <Button
-                              type="button"
-                              variant="destructive"
-                              size="sm"
-                              className="flex-1"
-                              onClick={confirmRenderAsSwitch}
-                            >
-                              {t('layerEditor.confirmRenderAs.confirm', { defaultValue: 'Switch mode' })}
-                            </Button>
-                            <Button
-                              type="button"
-                              variant="ghost"
-                              size="sm"
-                              className="flex-1"
-                              onClick={cancelRenderAsSwitch}
-                              // eslint-disable-next-line jsx-a11y/no-autofocus -- safe action so Enter dismisses, not destroys
-                              autoFocus
-                            >
-                              {t('layerEditor.confirmRenderAs.cancel', { defaultValue: 'Keep style' })}
-                            </Button>
-                          </div>
-                        </div>
+                        // ux(#777): shared builder-wide inline confirm — safe
+                        // action left, destructive right, cancel autofocused.
+                        <InlineDeleteConfirm
+                          confirmId={`confirm-render-as-${layer.id}`}
+                          message={t('layerEditor.confirmRenderAs.message', {
+                            defaultValue: 'Compatible style is carried over; only mode-specific settings will reset. Continue?',
+                          })}
+                          confirmLabel={t('layerEditor.confirmRenderAs.confirm', { defaultValue: 'Switch mode' })}
+                          cancelLabel={t('layerEditor.confirmRenderAs.cancel', { defaultValue: 'Keep style' })}
+                          onConfirm={confirmRenderAsSwitch}
+                          onCancel={cancelRenderAsSwitch}
+                          className="mx-0 mt-3 mb-0"
+                        />
                       )}
                     </section>
                   )}

--- a/frontend/src/components/builder/__tests__/FolderGroupRow.test.tsx
+++ b/frontend/src/components/builder/__tests__/FolderGroupRow.test.tsx
@@ -349,12 +349,12 @@ describe('FolderGroupRow', () => {
     expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument();
   });
 
-  it('Test 17: When confirmingDelete=true, "Keep group" button is the secondary safe-choice action (autoFocus declared)', () => {
-    // This test verifies the safe-choice UI contract: "Keep group" is secondary (not destructive),
-    // and appears last in the confirm — meaning it gets autoFocus by the component.
+  it('Test 17: When confirmingDelete=true, "Keep group" button is the leading safe-choice action (autoFocus declared)', () => {
+    // fix(#777): the safe-choice UI contract is the app's canonical AlertDialog order —
+    // safe choice first ("Keep group", secondary variant, autoFocus), destructive last ("Delete all").
     // In practice, jsdom + Radix focus management makes document.activeElement unreliable here.
     // We verify: (a) the alertdialog appears, (b) Keep group button exists and is secondary variant,
-    // (c) Delete all is the first button (destructive), Keep group is second.
+    // (c) Keep group is the first button (safe), Delete all is last (destructive).
     const { container } = render(<FolderGroupRow {...defaultProps()} />);
 
     const kebabTrigger = screen.getByRole('button', { name: /Group options/i });
@@ -366,11 +366,10 @@ describe('FolderGroupRow', () => {
 
     const buttons = alertdialog?.querySelectorAll('button');
     expect(buttons?.length).toBe(2);
-    // First button is destructive ("Delete all"), second is secondary safe choice ("Keep group")
-    expect(buttons?.[0].textContent).toContain('Delete all');
-    expect(buttons?.[1].textContent).toContain('Keep group');
+    // First button is the secondary safe choice ("Keep group"), last is destructive ("Delete all")
+    expect(buttons?.[0].textContent).toContain('Keep group');
+    expect(buttons?.[1].textContent).toContain('Delete all');
     // The safe choice button has autoFocus as a React prop (renders as autofocus attribute in HTML)
-    // verifying it's the LAST button (autoFocus on secondary safe choice = accessibility contract)
     expect(screen.getByRole('button', { name: /Keep group/i })).toBeInTheDocument();
   });
 

--- a/frontend/src/components/builder/hooks/use-builder-save.ts
+++ b/frontend/src/components/builder/hooks/use-builder-save.ts
@@ -1009,10 +1009,17 @@ export function useBuilderSave(state: SaveState) {
         // EASY-02 (Phase 1138-01): no-op when any Radix dialog/sheet is open so
         // typing Cmd+S inside the Share dialog or Add Dataset modal does not race
         // a layer mutation against open-modal context. Radix sets
-        // data-state="open" on its content element; we check both the role-dialog
-        // selector (covers Dialog, AlertDialog) and the Sheet-specific data-slot
-        // selector (covers Sheet, which uses role="dialog" but also data-slot="sheet-content").
-        const dialogOpen = document.querySelector('[role="dialog"][data-state="open"]');
+        // data-state="open" on its content element; we check the role-dialog
+        // selector (covers Dialog and, via role="dialog", Sheet — which also
+        // carries data-slot="sheet-content").
+        // ux(#777): Radix AlertDialog content renders role="alertdialog", NOT
+        // role="dialog" — matched explicitly so the unsaved-changes leave
+        // dialog (now an AlertDialog) still suppresses Cmd+S. The builder's
+        // inline row confirms also use role="alertdialog" but have no
+        // data-state attribute, so they intentionally do not match.
+        const dialogOpen = document.querySelector(
+          '[role="dialog"][data-state="open"], [role="alertdialog"][data-state="open"]',
+        );
         if (dialogOpen) return;
         if (updateMap.isPending || patchMapLayers.isPending) return;
         handleSaveRef.current();

--- a/frontend/src/components/builder/row-chrome.tsx
+++ b/frontend/src/components/builder/row-chrome.tsx
@@ -149,6 +149,11 @@ export function DragGripButton({
 // box, small buttons, cancel autofocused per AUD-09 so Enter dismisses rather
 // than destroys). BulkActionBar keeps its horizontal single-line variant — its
 // confirm lives INSIDE the fixed-height toolbar, not below a row.
+// ux(#777): the builder-wide destructive-confirm order is safe action first
+// (left), destructive action last (right) — the same Cancel-then-Action order
+// every ui/alert-dialog footer in the app renders. The DEM editor footer,
+// basemap-sublayer reset, and render-as confirms mount this component (with a
+// container-specific className) instead of hand-rolling their own.
 interface InlineDeleteConfirmProps {
   /** ids the aria-labelledby / message paragraph; must be unique per row. */
   confirmId: string;
@@ -157,6 +162,8 @@ interface InlineDeleteConfirmProps {
   cancelLabel: string;
   onConfirm: () => void;
   onCancel: () => void;
+  /** Container-specific spacing overrides (tailwind-merged onto the defaults). */
+  className?: string;
 }
 
 export function InlineDeleteConfirm({
@@ -166,22 +173,20 @@ export function InlineDeleteConfirm({
   cancelLabel,
   onConfirm,
   onCancel,
+  className,
 }: InlineDeleteConfirmProps) {
   return (
     // eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-noninteractive-element-interactions
     <div
       role="alertdialog"
       aria-labelledby={confirmId}
-      className="mx-2 mb-2 flex flex-col gap-2 p-3 bg-destructive/10 rounded-md"
+      className={cn('mx-2 mb-2 flex flex-col gap-2 p-3 bg-destructive/10 rounded-md', className)}
       onClick={(e) => e.stopPropagation()}
     >
       <p id={confirmId} className="text-sm text-destructive">
         {message}
       </p>
       <div className="flex gap-2">
-        <Button size="sm" variant="destructive" onClick={onConfirm}>
-          {confirmLabel}
-        </Button>
         <Button
           size="sm"
           variant="ghost"
@@ -190,6 +195,9 @@ export function InlineDeleteConfirm({
           autoFocus
         >
           {cancelLabel}
+        </Button>
+        <Button size="sm" variant="destructive" onClick={onConfirm}>
+          {confirmLabel}
         </Button>
       </div>
     </div>


### PR DESCRIPTION
Fixes the inverted destructive-confirm button order flagged by the 2026-07-27 builder/analysis audit. Every `ui/alert-dialog` footer in the app renders Cancel then Action — safe left, destructive right — but four builder inline confirms put the destructive action first, while the bulk bar and the leave dialog put it last. Deleting one layer and deleting five were the same gesture with the buttons swapped.

## What changed

One canonical order everywhere — safe action left (autofocused, per AUD-09 so Enter dismisses), destructive action right with `variant="destructive"`:

- **`row-chrome.tsx` — `InlineDeleteConfirm`**: flipped to Cancel-then-Action; gains an optional `className` (tailwind-merged) so other builder containers can mount it. StackRow and FolderGroupRow pick the fix up for free.
- **`DEMEditorScene.tsx`** (footer delete), **`BasemapSublayerEditorScene.tsx`** (reset-to-default), **`LayerEditorPanel.tsx`** (render-as switch): hand-rolled destructive-first confirm markup replaced by `InlineDeleteConfirm`, making it the single builder-wide inline confirm the issue asked for. Same translation keys, same `confirmId`s, same callbacks.
- **`BulkActionBar.tsx`**: order was already canonical; the delete confirm (and its disabled in-flight twin) now use `variant="destructive"` instead of `ghost` + `text-destructive`.
- **`BuilderDialogs.tsx`**: the unsaved-changes leave dialog is now a modal `AlertDialog` with the canonical `AlertDialogCancel` / `AlertDialogAction variant="destructive"` footer, matching the DatasetPage and AdminSettingsPage navigation guards, instead of a dismissible `Dialog` with a hand-rolled footer.
- **`hooks/use-builder-save.ts`**: the Cmd+S guard selector claimed to cover AlertDialog but only matched `role="dialog"`; it now also matches `role="alertdialog"` so the converted leave dialog still suppresses the save shortcut. The inline confirms carry no `data-state` attribute and intentionally stay unmatched.

Swept the rest of `components/builder/` for the class: ChatPanel's stop button and LayerFilterEditor's clear-filter button are single-action destructive buttons, not confirms — left alone.

No new translation keys; all labels reuse existing ones. No API/schema/config impact.

## Verification

```
cd frontend
npm run lint        # clean
npm run typecheck   # clean
npx vitest run src/components/builder/__tests__/BulkActionBar.test.tsx \
  src/components/builder/__tests__/DEMEditorScene.test.tsx \
  src/components/builder/__tests__/BasemapSublayerEditorScene.test.tsx \
  src/components/builder/__tests__/LayerEditorPanel.test.tsx \
  src/components/builder/__tests__/UnifiedStackPanel.test.tsx \
  src/components/builder/hooks/__tests__/use-builder-save.test.ts \
  src/components/builder/hooks/__tests__/use-builder-layers-save-integration.test.ts \
  src/components/builder/__tests__/MapBuilderPage.a11y.test.tsx \
  src/components/builder/__tests__/MapBuilderPage.notes-ai-rail.test.tsx \
  src/components/builder/__tests__/MapBuilderPage.settings-wiring.test.tsx \
  src/components/builder/__tests__/MapBuilderPage.sheet-close-button.test.tsx \
  src/pages/__tests__/MapBuilderPage.header-actions.test.tsx
                    # 12 files, 250 tests passed
npm run test:i18n   # locale parity green
```

Closes #777

https://claude.ai/code/session_01TEhW22Yf94GjuKYxMhcbLt
