### PR TITLE
fix(builder): keep groups, selection, and bulk delete consistent with the stack

### DIFF
--- a/frontend/src/components/builder/BulkActionBar.tsx
+++ b/frontend/src/components/builder/BulkActionBar.tsx
@@ -80,6 +80,16 @@ export const BulkActionBar = memo(function BulkActionBar({
     [layers, selectedIds],
   );
 
+  // fix(#771): group container rows have no backend record — handleBulkDelete
+  // filters them out of the batch — so every delete-facing count must be the
+  // DELETABLE count, not the selection size. Counting group rows promised
+  // deletions that never happened ("Delete 2 layers" on two group headers →
+  // silent no-op) and the Delete item now disables when nothing is deletable.
+  const deletableCount = useMemo(
+    () => selectedLayers.filter((l) => !isFolderGroupLayer(l)).length,
+    [selectedLayers],
+  );
+
   // Derived values for display and enable/disable logic
   const avgOpacity =
     N > 0
@@ -149,7 +159,7 @@ export const BulkActionBar = memo(function BulkActionBar({
           role="toolbar" must not carry aria-live. */}
       <span className="sr-only" aria-live="polite" aria-atomic="true">
         {isDeleting
-          ? t('bulkActions.deletingLayers', { count: N })
+          ? t('bulkActions.deletingLayers', { count: deletableCount })
           : t('bulkActions.liveAnnouncement', { count: N })}
       </span>
       {isDeleting ? (
@@ -159,7 +169,7 @@ export const BulkActionBar = memo(function BulkActionBar({
         <div className="flex items-center gap-2 w-full">
           <Loader2 className="size-4 animate-spin text-muted-foreground shrink-0" aria-hidden="true" />
           <span className="text-sm text-muted-foreground flex-1">
-            {t('bulkActions.deletingLayers', { count: N })}
+            {t('bulkActions.deletingLayers', { count: deletableCount })}
           </span>
           <Button
             type="button"
@@ -168,7 +178,7 @@ export const BulkActionBar = memo(function BulkActionBar({
             className="h-8 gap-1.5 px-2 shrink-0 text-destructive cursor-not-allowed"
             disabled={true}
             aria-busy={true}
-            aria-label={t('bulkActions.deleteAriaLabel', { count: N })}
+            aria-label={t('bulkActions.deleteAriaLabel', { count: deletableCount })}
           >
             <Loader2 className="size-4 animate-spin" aria-hidden="true" />
             {t('bulkActions.delete')}
@@ -189,7 +199,9 @@ export const BulkActionBar = memo(function BulkActionBar({
             id={confirmId}
             className="flex-1 text-sm text-destructive text-center"
           >
-            {t('bulkActions.deleteConfirmLabel', { count: N })}
+            {/* fix(#771): the confirm promises only what the handler will
+                actually delete — group rows are filtered out of the batch. */}
+            {t('bulkActions.deleteConfirmLabel', { count: deletableCount })}
           </p>
           <Button
             type="button"
@@ -217,7 +229,7 @@ export const BulkActionBar = memo(function BulkActionBar({
             }}
             onPointerDown={(e) => e.stopPropagation()}
           >
-            {t('bulkActions.deleteConfirmAction', { count: N })}
+            {t('bulkActions.deleteConfirmAction', { count: deletableCount })}
           </Button>
         </div>
       ) : (
@@ -387,16 +399,26 @@ export const BulkActionBar = memo(function BulkActionBar({
               <DropdownMenuItem
                 data-testid="bulk-action-delete"
                 className="text-destructive focus:text-destructive"
-                aria-label={t('bulkActions.deleteAriaLabel', { count: N })}
+                // fix(#771): disabled when the selection holds only group rows —
+                // the handler filters them out, so confirming would delete nothing.
+                disabled={deletableCount === 0}
+                aria-label={t('bulkActions.deleteAriaLabel', { count: deletableCount })}
                 onSelect={(e) => {
                   // Keep the row from auto-closing the menu so the inline
                   // confirmation dialog appears in the toolbar below.
                   e.preventDefault();
-                  setConfirmingDelete(true);
+                  if (deletableCount > 0) setConfirmingDelete(true);
                 }}
               >
                 <Trash2 className="h-3.5 w-3.5 me-2" aria-hidden="true" />
-                {t('bulkActions.delete')}
+                <span className="flex flex-col items-start">
+                  {t('bulkActions.delete')}
+                  {deletableCount === 0 && (
+                    <span className="text-2xs text-muted-foreground">
+                      {t('bulkActions.deleteHint', { defaultValue: 'Group rows are deleted from their row menu' })}
+                    </span>
+                  )}
+                </span>
               </DropdownMenuItem>
             </DropdownMenuContent>
           </DropdownMenu>

--- a/frontend/src/components/builder/UnifiedStackPanel.tsx
+++ b/frontend/src/components/builder/UnifiedStackPanel.tsx
@@ -1,4 +1,4 @@
-import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { memo, useEffect, useMemo, useRef, useState } from 'react';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import {
   DragOverlay,
@@ -26,6 +26,10 @@ import { BulkActionBar } from '@/components/builder/BulkActionBar';
 // builder-audit #338 STACK-01: use the single typed helper instead of a local
 // `as unknown as` re-implementation.
 import { getParentGroupId } from '@/components/builder/folder-groups';
+// fix(#771): single source of truth for which rows the stack renders — the
+// same helper MapBuilderPage uses to derive selectableRowIds, so range
+// selection can never disagree with what is on screen.
+import { computeSelectableRowIds } from '@/components/builder/selection-utils';
 import { isFolderGroupLayer } from '@/lib/layer-capabilities';
 import { cn } from '@/lib/utils';
 import type { MapLayerResponse } from '@/types/api';
@@ -122,6 +126,13 @@ interface UnifiedStackPanelProps {
   selectedIds?: Set<string>;
   isMultiSelectionActive?: boolean;
   selectableRowIds?: string[];
+  /** fix(#771): controlled layer-search query. When provided (with
+   *  onLayerSearchChange), MapBuilderPage owns the query so it can derive
+   *  selectableRowIds from the RENDERED row set via computeSelectableRowIds —
+   *  range selection must never sweep rows the search has hidden. Omit both
+   *  to keep the panel's internal search state (standalone/test usage). */
+  layerSearch?: string;
+  onLayerSearchChange?: (query: string) => void;
   onCmdClick?: (id: string) => void;
   onShiftClick?: (id: string) => void;
   onCheckboxClick?: (id: string) => void;
@@ -330,6 +341,8 @@ export const UnifiedStackPanel = memo(function UnifiedStackPanel({
   selectedIds = new Set(),
   isMultiSelectionActive = false,
   selectableRowIds = [],
+  layerSearch: layerSearchProp,
+  onLayerSearchChange,
   onCmdClick,
   onShiftClick,
   onCheckboxClick,
@@ -349,7 +362,15 @@ export const UnifiedStackPanel = memo(function UnifiedStackPanel({
   // and preserves drag/reorder. A non-empty query narrows visible rows to those
   // whose display name contains the query (case-insensitive substring) and
   // disables drag so reordering a filtered subset cannot corrupt sort_order.
-  const [layerSearch, setLayerSearch] = useState('');
+  // fix(#771): hybrid controlled — when the layerSearch prop is provided the
+  // parent owns the query (so it can derive selectableRowIds from the rendered
+  // row set); the internal state remains for standalone usage.
+  const [localLayerSearch, setLocalLayerSearch] = useState('');
+  const layerSearch = layerSearchProp ?? localLayerSearch;
+  const handleLayerSearchChange = (query: string) => {
+    setLocalLayerSearch(query);
+    onLayerSearchChange?.(query);
+  };
 
   // Phase 1040 Plan 04: read the active drag item from the lifted DndContext so the
   // DragOverlay can branch between an intra-stack StackRow ghost and a catalog drag pill.
@@ -522,16 +543,13 @@ export const UnifiedStackPanel = memo(function UnifiedStackPanel({
   // the filtered count) to avoid confusion — the filtered view is transient.
   const isSearchActive = layerSearch.trim() !== '';
 
-  // Case-insensitive substring match on display_name falling back to dataset_name.
-  // An empty (or whitespace-only) query always returns true.
-  const matchesSearch = useCallback(
-    (layer: MapLayerResponse): boolean => {
-      const q = layerSearch.trim();
-      if (q === '') return true;
-      const name = (layer.display_name ?? layer.dataset_name ?? '').toLowerCase();
-      return name.includes(q.toLowerCase());
-    },
-    [layerSearch],
+  // fix(#771): the row-skip decisions below consume the SAME helper that
+  // MapBuilderPage uses to derive selectableRowIds, so what is rendered and
+  // what is range-selectable cannot drift (search matching + group collapse
+  // + child filtering all live in computeSelectableRowIds).
+  const renderedRowIds = useMemo(
+    () => new Set(computeSelectableRowIds(visibleStackLayers, groupMeta, layerSearch)),
+    [visibleStackLayers, groupMeta, layerSearch],
   );
 
   // ---------------------------------------------------------------------------
@@ -664,7 +682,7 @@ export const UnifiedStackPanel = memo(function UnifiedStackPanel({
             aria-label={t('unifiedStack.searchAriaLabel', { defaultValue: 'Filter layers by name' })}
             placeholder={t('unifiedStack.searchPlaceholder', { defaultValue: 'Filter layers…' })}
             value={layerSearch}
-            onChange={(e) => setLayerSearch(e.target.value)}
+            onChange={(e) => handleLayerSearchChange(e.target.value)}
             className={cn(
               'w-full h-7 rounded-sm border border-[var(--border)] bg-[var(--surface-1,var(--background))]',
               'ps-7 pe-2 text-xs text-foreground placeholder:text-muted-foreground',
@@ -725,9 +743,10 @@ export const UnifiedStackPanel = memo(function UnifiedStackPanel({
                   // matches the query OR any of its children match.
                   const expanded = groupMeta[layer.id]?.expanded ?? false;
                   const children = childrenByGroup[layer.id] ?? [];
-                  const groupNameMatches = matchesSearch(layer);
-                  const anyChildMatches = children.some((c) => matchesSearch(c));
-                  if (isSearchActive && !groupNameMatches && !anyChildMatches) return null;
+                  // fix(#771): the skip decision comes from the shared
+                  // rendered-row set so selection can never target a row the
+                  // search has hidden.
+                  if (!renderedRowIds.has(layer.id)) return null;
 
                   // fix(#394) LM-04: the group eye reflects the children
                   // AGGREGATE (on while ANY child is visible) — the synthetic
@@ -765,9 +784,10 @@ export const UnifiedStackPanel = memo(function UnifiedStackPanel({
                           role="list"
                         >
                           {children.map((child) => {
-                            // Phase 1201-02: when the group itself matches, show all
-                            // its children; otherwise filter children by name.
-                            if (isSearchActive && !groupNameMatches && !matchesSearch(child)) return null;
+                            // fix(#771): child visibility under search comes
+                            // from the shared rendered-row set (a group-name
+                            // match still shows every child).
+                            if (!renderedRowIds.has(child.id)) return null;
                             return (
                               <SortableStackRow
                                 key={child.id}
@@ -812,8 +832,9 @@ export const UnifiedStackPanel = memo(function UnifiedStackPanel({
                   );
                 }
 
-                // Phase 1201-02 (ENH-07): skip loose layers that don't match the query.
-                if (isSearchActive && !matchesSearch(layer)) return null;
+                // fix(#771): loose-row visibility under search comes from the
+                // shared rendered-row set.
+                if (!renderedRowIds.has(layer.id)) return null;
 
                 // Loose layer
                 return (

--- a/frontend/src/components/builder/__tests__/BulkActionBar.test.tsx
+++ b/frontend/src/components/builder/__tests__/BulkActionBar.test.tsx
@@ -561,3 +561,64 @@ describe('BulkActionBar — isDeleting prop (PERF-03)', () => {
     expect((busyBtn as HTMLButtonElement)?.disabled).toBe(true);
   });
 });
+
+// ---------------------------------------------------------------------------
+// BulkActionBar — deletable count excludes group rows (fix #771)
+// ---------------------------------------------------------------------------
+
+describe('BulkActionBar — deletable count excludes group rows (fix #771)', () => {
+  function openOverflowMenu() {
+    fireEvent.pointerDown(screen.getByTestId('bulk-action-overflow'), { button: 0, ctrlKey: false });
+  }
+
+  it('the delete confirmation counts only deletable rows in a mixed selection', () => {
+    // 2 data layers + 1 group row selected → the handler will delete 2 rows,
+    // so the confirm must promise 2, not 3.
+    render(<BulkActionBar {...makeProps({ selectedIds: new Set(['a', 'b', 'g1']) })} />);
+
+    openOverflowMenu();
+    fireEvent.click(screen.getByTestId('bulk-action-delete'));
+
+    const confirmDialog = screen.getByRole('alertdialog');
+    // Mocked t() renders count-bearing keys as "<key> <count>".
+    expect(confirmDialog.textContent).toContain('bulkActions.deleteConfirmLabel 2');
+    expect(
+      screen.getByRole('button', { name: /bulkActions.deleteConfirmAction 2/ }),
+    ).toBeInTheDocument();
+  });
+
+  it('the Delete item is disabled with a hint when only group rows are selected', () => {
+    const g2 = makeLayer({ id: 'g2', dataset_name: 'Other Group', sort_order: 5, layer_type: 'group:folder' });
+    render(
+      <BulkActionBar
+        {...makeProps({
+          selectedIds: new Set(['g1', 'g2']),
+          layers: [...allLayers, g2],
+        })}
+      />,
+    );
+
+    openOverflowMenu();
+    const deleteItem = screen.getByTestId('bulk-action-delete');
+    expect(deleteItem).toHaveAttribute('aria-disabled', 'true');
+    // The inline hint states why (disabled menu items show no tooltip).
+    expect(deleteItem.textContent).toContain('Group rows are deleted from their row menu');
+
+    // Clicking the disabled item must NOT enter the confirmation state.
+    fireEvent.click(deleteItem);
+    expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument();
+  });
+
+  it('the deleting state announces the deletable count, not the selection size', () => {
+    // 2 data layers + 1 group row; the batch actually deleting is 2.
+    const { container } = render(
+      <BulkActionBar
+        {...makeProps({ selectedIds: new Set(['a', 'b', 'g1']) })}
+        isDeleting={true}
+      />,
+    );
+
+    const liveRegion = container.querySelector('[aria-live="polite"]');
+    expect(liveRegion?.textContent).toContain('bulkActions.deletingLayers 2');
+  });
+});

--- a/frontend/src/components/builder/__tests__/folder-groups.test.ts
+++ b/frontend/src/components/builder/__tests__/folder-groups.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import {
   hydrateFolderGroupLayers,
   prepareLayersForPersistence,
+  pruneEmptyFolderGroups,
   resolveDropGroupMembership,
   type GroupedLayer,
 } from '../folder-groups';
@@ -102,6 +103,56 @@ describe('folder group persistence helpers', () => {
       folderGroupExpanded: true,
     });
     expect(persisted[1].style_config?.builder).toEqual({ outlineWidth: 2 });
+  });
+});
+
+// fix(#767): group identity is persisted only on children, so a childless group
+// row cannot survive save+reload — it must be pruned the moment it empties.
+describe('pruneEmptyFolderGroups', () => {
+  const groupRow = (id: string, name = 'Group') =>
+    ({
+      ...makeLayer({ id, display_name: name }),
+      layer_type: 'group:folder',
+    }) as unknown as MapLayerResponse;
+  const childOf = (id: string, groupId: string) =>
+    ({ ...makeLayer({ id }), parent_group_id: groupId }) as unknown as MapLayerResponse;
+
+  it('prunes a group row with no children', () => {
+    const layers = [groupRow('group-1'), makeLayer({ id: 'loose-1' })];
+
+    const pruned = pruneEmptyFolderGroups(layers);
+
+    expect(pruned.map((l) => l.id)).toEqual(['loose-1']);
+  });
+
+  it('keeps group rows that still have children and prunes only the empty one', () => {
+    const layers = [
+      groupRow('group-1'),
+      childOf('child-1', 'group-1'),
+      groupRow('group-2'),
+      makeLayer({ id: 'loose-1' }),
+    ];
+
+    const pruned = pruneEmptyFolderGroups(layers);
+
+    expect(pruned.map((l) => l.id)).toEqual(['group-1', 'child-1', 'loose-1']);
+  });
+
+  it('returns the input array identity when there is nothing to prune', () => {
+    const layers = [groupRow('group-1'), childOf('child-1', 'group-1'), makeLayer({ id: 'loose-1' })];
+
+    expect(pruneEmptyFolderGroups(layers)).toBe(layers);
+  });
+
+  it('never touches non-folder rows even when they have no children pointing at them', () => {
+    const basemapish = {
+      ...makeLayer({ id: 'row-1' }),
+      layer_type: 'group:basemap',
+    } as unknown as MapLayerResponse;
+
+    const pruned = pruneEmptyFolderGroups([basemapish, makeLayer({ id: 'loose-1' })]);
+
+    expect(pruned.map((l) => l.id)).toEqual(['row-1', 'loose-1']);
   });
 });
 

--- a/frontend/src/components/builder/__tests__/selection-utils.test.ts
+++ b/frontend/src/components/builder/__tests__/selection-utils.test.ts
@@ -5,7 +5,8 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { computeNextSelection } from '../selection-utils';
+import { computeNextSelection, computeSelectableRowIds } from '../selection-utils';
+import type { MapLayerResponse } from '@/types/api';
 
 const ROWS = ['A', 'B', 'C', 'D', 'E'];
 
@@ -97,5 +98,70 @@ describe('computeNextSelection — shift click (range-select)', () => {
     const result = computeNextSelection(ROWS, 'C', SHIFT, new Set(['gone']), 'gone');
     expect(Array.from(result.selection)).toEqual(['C']);
     expect(result.anchor).toBe('C');
+  });
+});
+
+// fix(#771): selectableRowIds must mirror the RENDERED row set — children of
+// collapsed groups and rows hidden by the layer search are not selectable, so
+// a shift-click range can never act on rows the user cannot see.
+describe('computeSelectableRowIds', () => {
+  function makeRow(overrides: {
+    id: string;
+    display_name?: string | null;
+    dataset_name?: string;
+    layer_type?: string | null;
+    parent_group_id?: string | null;
+  }): MapLayerResponse {
+    return {
+      id: overrides.id,
+      display_name: overrides.display_name ?? null,
+      dataset_name: overrides.dataset_name ?? overrides.id,
+      layer_type: overrides.layer_type ?? 'vector_geolens',
+      parent_group_id: overrides.parent_group_id ?? null,
+    } as unknown as MapLayerResponse;
+  }
+
+  // Stack: [group G ("Roads") with children c1 ("Streets") + c2 ("Rivers"), loose L ("Parcels")]
+  const group = makeRow({ id: 'G', display_name: 'Roads', layer_type: 'group:folder' });
+  const child1 = makeRow({ id: 'c1', display_name: 'Streets', parent_group_id: 'G' });
+  const child2 = makeRow({ id: 'c2', display_name: 'Rivers', parent_group_id: 'G' });
+  const loose = makeRow({ id: 'L', display_name: 'Parcels' });
+  const stack = [group, child1, child2, loose];
+
+  it('returns render order (group, its children, loose rows) with no search and an expanded group', () => {
+    expect(computeSelectableRowIds(stack, { G: { expanded: true } }, '')).toEqual([
+      'G', 'c1', 'c2', 'L',
+    ]);
+  });
+
+  it('excludes children of a collapsed group (they are not rendered)', () => {
+    expect(computeSelectableRowIds(stack, { G: { expanded: false } }, '')).toEqual(['G', 'L']);
+    // groupMeta absence means collapsed (matches the panel's `?? false` default)
+    expect(computeSelectableRowIds(stack, {}, '')).toEqual(['G', 'L']);
+  });
+
+  it('excludes rows hidden by the layer search', () => {
+    expect(computeSelectableRowIds(stack, { G: { expanded: true } }, 'parcel')).toEqual(['L']);
+  });
+
+  it('a child match keeps the group header and only the matching children', () => {
+    expect(computeSelectableRowIds(stack, { G: { expanded: true } }, 'streets')).toEqual([
+      'G', 'c1',
+    ]);
+  });
+
+  it('a group-name match keeps every child of the expanded group', () => {
+    expect(computeSelectableRowIds(stack, { G: { expanded: true } }, 'roads')).toEqual([
+      'G', 'c1', 'c2',
+    ]);
+  });
+
+  it('a child match inside a COLLAPSED group keeps only the group header', () => {
+    expect(computeSelectableRowIds(stack, { G: { expanded: false } }, 'streets')).toEqual(['G']);
+  });
+
+  it('falls back to dataset_name when display_name is null (matches the search input behavior)', () => {
+    const unnamed = makeRow({ id: 'U', display_name: null, dataset_name: 'Unnamed dataset' });
+    expect(computeSelectableRowIds([unnamed, loose], {}, 'unnamed')).toEqual(['U']);
   });
 });

--- a/frontend/src/components/builder/folder-groups.ts
+++ b/frontend/src/components/builder/folder-groups.ts
@@ -115,6 +115,23 @@ export function getPersistedFolderGroup(layer: MapLayerResponse): PersistedFolde
   };
 }
 
+// fix(#767): group identity is persisted only on children (the builder.folderGroup*
+// markers written by prepareLayersForPersistence below), so a group row with no
+// children has no carrier and cannot survive save+reload — it kept rendering,
+// accepting drops, and dirtying the map, then silently vanished (with any rename)
+// on the next hydrate. Prune the row the moment it empties so the UI and the
+// persisted state agree. Callers renumber sort_order; returns the input array
+// unchanged (same identity) when there is nothing to prune.
+export function pruneEmptyFolderGroups(layers: MapLayerResponse[]): MapLayerResponse[] {
+  const parentIds = new Set<string>();
+  for (const layer of layers) {
+    const parentId = getParentGroupId(layer);
+    if (parentId) parentIds.add(parentId);
+  }
+  const pruned = layers.filter((layer) => !isFolderGroupLayer(layer) || parentIds.has(layer.id));
+  return pruned.length === layers.length ? layers : pruned;
+}
+
 export function hydrateFolderGroupLayers(
   layers: MapLayerResponse[],
 ): { layers: MapLayerResponse[]; groupMeta: Record<string, FolderGroupMeta> } {

--- a/frontend/src/components/builder/hooks/__tests__/use-builder-layers.bulk-ops.test.ts
+++ b/frontend/src/components/builder/hooks/__tests__/use-builder-layers.bulk-ops.test.ts
@@ -908,3 +908,99 @@ describe('useBuilderLayers — handleBulkDelete batched (PERF-03)', () => {
     expect(isDeletingDuringCall).toBe(true);
   });
 });
+
+// ---------------------------------------------------------------------------
+// handleBulkDelete — fix(#805) survivor position + fix(#767) empty-group prune
+// + fix(#771) zero-deletable feedback
+// ---------------------------------------------------------------------------
+
+describe('useBuilderLayers — handleBulkDelete survivor position and group rows', () => {
+  // fix(#805): the old partial-failure path merged the already-renumbered
+  // optimistic array with failed rows still carrying their ORIGINAL sort_order,
+  // interleaving two numbering schemes. With [a,b,c,d,e], deleting {a,b} where
+  // only 'a' succeeds used to restore 'b' AFTER c and d — and that wrong order
+  // was then saved. Survivors must keep their original relative order.
+  it('partial failure restores survivors at their original stack position (fix #805)', async () => {
+    const mockedBulkDelete = vi.mocked(bulkDeleteLayersApi);
+    mockedBulkDelete.mockResolvedValue({
+      deleted: ['a'],
+      failed: [{ id: 'b', reason: 'concurrent_edit' }],
+    });
+
+    const layers = [
+      makeMockLayer({ id: 'a', sort_order: 0 }),
+      makeMockLayer({ id: 'b', sort_order: 1 }),
+      makeMockLayer({ id: 'c', sort_order: 2 }),
+      makeMockLayer({ id: 'd', sort_order: 3 }),
+      makeMockLayer({ id: 'e', sort_order: 4 }),
+    ];
+    const { result } = renderBuilderLayers(makeMapData(layers));
+    await waitForInit();
+
+    await act(async () => {
+      await result.current.handleBulkDelete(new Set(['a', 'b']));
+    });
+
+    // Exact order matters: 'b' returns to the TOP (its original slot minus the
+    // deleted 'a'), not interleaved into the renumbered survivors.
+    expect(result.current.localLayers.map((l) => l.id)).toEqual(['b', 'c', 'd', 'e']);
+    expect(result.current.localLayers.map((l) => l.sort_order)).toEqual([0, 1, 2, 3]);
+  });
+
+  it('bulk-deleting every child of a folder group prunes the empty group row (fix #767)', async () => {
+    const mockedBulkDelete = vi.mocked(bulkDeleteLayersApi);
+    mockedBulkDelete.mockResolvedValue({ deleted: ['child-a', 'child-b'], failed: [] });
+
+    const marker = {
+      builder: { folderGroupId: 'g1', folderGroupName: 'Group 1' },
+    } as MapLayerResponse['style_config'];
+    const layers = [
+      makeMockLayer({ id: 'child-a', sort_order: 0, style_config: marker }),
+      makeMockLayer({ id: 'child-b', sort_order: 1, style_config: marker }),
+      makeMockLayer({ id: 'loose', sort_order: 2 }),
+    ];
+    const { result } = renderBuilderLayers(makeMapData(layers));
+    await waitForInit();
+
+    // Sanity: hydration materialized the group row from the child markers.
+    expect(result.current.localLayers.map((l) => l.id)).toEqual([
+      'g1', 'child-a', 'child-b', 'loose',
+    ]);
+
+    await act(async () => {
+      await result.current.handleBulkDelete(new Set(['child-a', 'child-b']));
+    });
+
+    // The emptied group row is pruned alongside its deleted children — it had
+    // no persisted carrier and would have silently vanished on reload anyway.
+    expect(result.current.localLayers.map((l) => l.id)).toEqual(['loose']);
+    // The synthetic group row was never sent to the backend.
+    expect(mockedBulkDelete).toHaveBeenCalledWith(MAP_ID, expect.not.arrayContaining(['g1']));
+  });
+
+  it('a selection of only group rows toasts instead of silently no-oping (fix #771)', async () => {
+    const mockedBulkDelete = vi.mocked(bulkDeleteLayersApi);
+    const infoSpy = vi.spyOn(toast, 'info');
+
+    const marker = {
+      builder: { folderGroupId: 'g1', folderGroupName: 'Group 1' },
+    } as MapLayerResponse['style_config'];
+    const layers = [
+      makeMockLayer({ id: 'child-a', sort_order: 0, style_config: marker }),
+      makeMockLayer({ id: 'loose', sort_order: 1 }),
+    ];
+    const { result } = renderBuilderLayers(makeMapData(layers));
+    await waitForInit();
+
+    let ok: boolean | undefined;
+    await act(async () => {
+      ok = await result.current.handleBulkDelete(new Set(['g1']));
+    });
+
+    expect(ok).toBe(false);
+    expect(infoSpy).toHaveBeenCalledOnce();
+    expect(mockedBulkDelete).not.toHaveBeenCalled();
+    // Nothing was removed locally either.
+    expect(result.current.localLayers.map((l) => l.id)).toEqual(['g1', 'child-a', 'loose']);
+  });
+});

--- a/frontend/src/components/builder/hooks/__tests__/use-builder-layers.groups.test.ts
+++ b/frontend/src/components/builder/hooks/__tests__/use-builder-layers.groups.test.ts
@@ -334,6 +334,74 @@ describe('useBuilderLayers — folder group handlers', () => {
     expect(result.current.hasUnsavedChanges).toBe(true);
   });
 
+  // fix(#767): a group whose last child leaves has no persisted carrier — it
+  // rendered, accepted drops, and dirtied the map, then silently vanished
+  // (with any rename) on save+reload. The row is pruned the moment it empties.
+  it('handleMoveLayerOutOfGroup prunes the group row when its last child moves out (fix #767)', () => {
+    const groupLayer = { ...makeMockLayer({ id: 'group-1' }), layer_type: 'group:folder' } as unknown as MapLayerResponse;
+    const childLayer = { ...makeMockLayer({ id: 'child-1' }), parent_group_id: 'group-1' } as unknown as MapLayerResponse;
+    const looseLayer = makeMockLayer({ id: 'loose-1', sort_order: 2 });
+    const { result } = renderBuilderLayers(makeMapData([groupLayer, childLayer, looseLayer]));
+
+    act(() => {
+      result.current.handleMoveLayerOutOfGroup('child-1');
+    });
+
+    // The emptied group row is gone; the moved-out child takes its position.
+    expect(result.current.localLayers.map((l) => l.id)).toEqual(['child-1', 'loose-1']);
+    expect(result.current.localLayers.map((l) => l.sort_order)).toEqual([0, 1]);
+  });
+
+  it('handleMoveLayerOutOfGroup keeps the group row while other children remain', () => {
+    const groupLayer = { ...makeMockLayer({ id: 'group-1' }), layer_type: 'group:folder' } as unknown as MapLayerResponse;
+    const childA = { ...makeMockLayer({ id: 'child-a' }), parent_group_id: 'group-1' } as unknown as MapLayerResponse;
+    const childB = { ...makeMockLayer({ id: 'child-b', sort_order: 2 }), parent_group_id: 'group-1' } as unknown as MapLayerResponse;
+    const { result } = renderBuilderLayers(makeMapData([groupLayer, childA, childB]));
+
+    act(() => {
+      result.current.handleMoveLayerOutOfGroup('child-a');
+    });
+
+    expect(result.current.localLayers.map((l) => l.id)).toContain('group-1');
+    expect(result.current.localLayers.map((l) => l.id)).toContain('child-b');
+  });
+
+  // fix(#767): the drag-out path — MapBuilderPage's handleDragEnd dispatches a
+  // reorder_layers action with the child's membership cleared; handleReorder
+  // must prune the group row the drag emptied.
+  it('handleReorder prunes a group row emptied by a drag-out (fix #767)', () => {
+    const groupLayer = { ...makeMockLayer({ id: 'group-1' }), layer_type: 'group:folder' } as unknown as MapLayerResponse;
+    const childLayer = { ...makeMockLayer({ id: 'child-1', sort_order: 1 }), parent_group_id: 'group-1' } as unknown as MapLayerResponse;
+    const looseLayer = makeMockLayer({ id: 'loose-1', sort_order: 2 });
+    const { result } = renderBuilderLayers(makeMapData([groupLayer, childLayer, looseLayer]));
+
+    // Simulate handleDragEnd's output: child dragged below the loose row and
+    // out of the group (parent_group_id cleared by resolveDropGroupMembership).
+    const [group, child, loose] = result.current.localLayers;
+    const draggedOut = { ...child, parent_group_id: null } as unknown as MapLayerResponse;
+
+    act(() => {
+      result.current.handleReorder([group, loose, draggedOut]);
+    });
+
+    expect(result.current.localLayers.map((l) => l.id)).toEqual(['loose-1', 'child-1']);
+  });
+
+  // fix(#767): the single-delete path — removing a group's only child prunes
+  // the group row in the same optimistic write.
+  it('handleRemove of the last group child prunes the group row (fix #767)', () => {
+    const groupLayer = { ...makeMockLayer({ id: 'group-1' }), layer_type: 'group:folder' } as unknown as MapLayerResponse;
+    const childLayer = { ...makeMockLayer({ id: 'child-1', sort_order: 1 }), parent_group_id: 'group-1' } as unknown as MapLayerResponse;
+    const looseLayer = makeMockLayer({ id: 'loose-1', sort_order: 2 });
+    const { result } = renderBuilderLayers(makeMapData([groupLayer, childLayer, looseLayer]));
+
+    act(() => {
+      result.current.handleRemove('child-1');
+    });
+
+    expect(result.current.localLayers.map((l) => l.id)).toEqual(['loose-1']);
+  });
+
   // fix(#392): handleMoveLayerOutOfGroup must clear the PERSISTED
   // style_config.builder.folderGroupId too — same rationale as Test 8b above. (audit CR-01)
   it('handleMoveLayerOutOfGroup clears style_config.builder.folderGroupId from the target layer (CR-01)', () => {

--- a/frontend/src/components/builder/hooks/__tests__/use-builder-save.test.ts
+++ b/frontend/src/components/builder/hooks/__tests__/use-builder-save.test.ts
@@ -296,6 +296,73 @@ describe('buildLayerDiff', () => {
     ]);
   });
 
+  // fix(#805): the baseline used to be prepared WITHOUT groupMeta, so baseline
+  // children lacked the folderGroupExpanded marker while current children
+  // carried it — every save of an unchanged grouped map emitted a spurious
+  // per-child style_config PATCH.
+  it('emits an empty diff for an unchanged grouped map (no spurious per-child style_config patch)', () => {
+    const group = {
+      ...makeLayer({ id: 'group-1', display_name: 'Field layers' }),
+      layer_type: 'group:folder',
+    } as unknown as MapLayerResponse;
+    const child = {
+      ...makeLayer({
+        id: 'layer-1',
+        sort_order: 1,
+        style_config: {
+          builder: {
+            folderGroupId: 'group-1',
+            folderGroupName: 'Field layers',
+            folderGroupExpanded: true,
+          },
+        } as MapLayerResponse['style_config'],
+      }),
+      parent_group_id: 'group-1',
+    } as MapLayerResponse;
+
+    const result = buildLayerDiff(
+      [group, child],
+      [group, child],
+      { 'group-1': { expanded: true } },
+    );
+
+    expect(result.diff).toEqual({});
+  });
+
+  // fix(#805): collapse/expand is deliberately non-dirtying (see
+  // handleToggleGroupExpand) — a collapse-state-only change between the
+  // persisted marker and the live groupMeta must not produce a patch either.
+  it('a collapse-state-only change stays out of the diff (non-dirtying by design)', () => {
+    const group = {
+      ...makeLayer({ id: 'group-1', display_name: 'Field layers' }),
+      layer_type: 'group:folder',
+    } as unknown as MapLayerResponse;
+    const child = {
+      ...makeLayer({
+        id: 'layer-1',
+        sort_order: 1,
+        style_config: {
+          builder: {
+            folderGroupId: 'group-1',
+            folderGroupName: 'Field layers',
+            folderGroupExpanded: true,
+          },
+        } as MapLayerResponse['style_config'],
+      }),
+      parent_group_id: 'group-1',
+    } as MapLayerResponse;
+
+    // The user collapsed the group after the last save: persisted marker says
+    // expanded=true, live groupMeta says false. Nothing else changed.
+    const result = buildLayerDiff(
+      [group, child],
+      [group, child],
+      { 'group-1': { expanded: false } },
+    );
+
+    expect(result.diff).toEqual({});
+  });
+
   it('returns an empty diff for no-op layers', () => {
     const baseline = makeLayer({ id: 'layer-1' });
     const current = makeLayer({ id: 'layer-1' });

--- a/frontend/src/components/builder/hooks/use-builder-layers.ts
+++ b/frontend/src/components/builder/hooks/use-builder-layers.ts
@@ -22,6 +22,7 @@ import {
 import {
   getParentGroupId,
   hydrateFolderGroupLayers,
+  pruneEmptyFolderGroups,
   type GroupedLayer,
 } from '@/components/builder/folder-groups';
 // STATE-02: cohesive handler clusters extracted into focused hooks. This hook
@@ -365,7 +366,11 @@ export function useBuilderLayers(
   const handleMoveDown = useCallback((layerId: string) => handleMove(layerId, 'down'), [handleMove]);
 
   const handleReorder = useCallback((reorderedLayers: MapLayerResponse[]) => {
-    const nextLayers = reorderedLayers.map((l, i) => ({ ...l, sort_order: i }));
+    // fix(#767): dragging the last child out of a folder group empties it —
+    // prune the childless group row so it does not linger in the UI only to
+    // vanish on save+reload (it has no persisted carrier without children).
+    const nextLayers = pruneEmptyFolderGroups(reorderedLayers)
+      .map((l, i) => ({ ...l, sort_order: i }));
     setLocalLayers(nextLayers);
 
     // Imperatively reorder MapLibre layers so the visual change is immediate
@@ -475,9 +480,11 @@ export function useBuilderLayers(
     // during the builder editing flow. The sidebar row then stays visible
     // until a full page reload.
     const previousLayers = layersRef.current;
+    // fix(#767): removing a group's last child prunes the now-empty group row
+    // in the same write; the error rollback below restores previousLayers, so
+    // a failed delete brings the group back with its child.
     setLocalLayers((prev) =>
-      prev
-        .filter((l) => l.id !== layerId)
+      pruneEmptyFolderGroups(prev.filter((l) => l.id !== layerId))
         .map((l, i) => ({ ...l, sort_order: i })),
     );
 
@@ -696,7 +703,9 @@ export function useBuilderLayers(
   // a deduped `source-data-${dataset_table_name}` in place while sibling
   // layers still reference it.
   const handleAiRemoveLayer = useCallback((layerId: string) => {
-    setLocalLayers((prev) => prev.filter((l) => l.id !== layerId));
+    // fix(#767): prune a group row emptied by this draft removal (same rule as
+    // handleRemove — an empty group cannot survive save+reload).
+    setLocalLayers((prev) => pruneEmptyFolderGroups(prev.filter((l) => l.id !== layerId)));
     // Clean up MapLibre per-layer companions imperatively. WR-01 (Phase
     // 1050-rev) factored this into removePerLayerCompanions so handleRemove
     // and handleBulkDelete now use the same helper. Sources are NOT

--- a/frontend/src/components/builder/hooks/use-builder-save.ts
+++ b/frontend/src/components/builder/hooks/use-builder-save.ts
@@ -448,7 +448,12 @@ export function buildLayerDiff(
   currentLayers: MapLayerResponse[],
   groupMeta: Record<string, FolderGroupMeta> = {},
 ): LayerDiffResult {
-  const baselinePersistedLayers = prepareLayersForPersistence(baselineLayers);
+  // fix(#805): prepare BOTH sides with the same groupMeta. The baseline used to
+  // be prepared without it, so baseline children lacked the folderGroupExpanded
+  // marker while current children carried it — every save of a grouped map then
+  // emitted a spurious per-child style_config PATCH, silently persisting
+  // collapse state that is deliberately non-dirtying (see handleToggleGroupExpand).
+  const baselinePersistedLayers = prepareLayersForPersistence(baselineLayers, groupMeta);
   const currentPersistedLayers = prepareLayersForPersistence(currentLayers, groupMeta);
   const baselineById = new Map(baselinePersistedLayers.map((layer) => [layer.id, toLayerSnapshot(layer)]));
   const currentById = new Map(currentPersistedLayers.map((layer) => [layer.id, layer]));

--- a/frontend/src/components/builder/hooks/use-bulk-layer-actions.ts
+++ b/frontend/src/components/builder/hooks/use-bulk-layer-actions.ts
@@ -13,7 +13,11 @@ import {
   removePerLayerCompanions,
   shouldClearTerrainOnDelete,
 } from '@/components/builder/hooks/builder-layer-mutations';
-import { type GroupedLayer, clearPersistedFolderGroup } from '@/components/builder/folder-groups';
+import {
+  type GroupedLayer,
+  clearPersistedFolderGroup,
+  pruneEmptyFolderGroups,
+} from '@/components/builder/folder-groups';
 import { bulkDeleteLayersApi } from '@/api/maps';
 import {
   extractCopyableStyle,
@@ -305,17 +309,24 @@ export function useBulkLayerActions({
       if ((layer as GroupedLayer).layer_type === 'group:folder') return false;
       return true;
     });
-    if (idsToDelete.length === 0) return false;
+    if (idsToDelete.length === 0) {
+      // fix(#771): a selection of only group rows used to no-op silently — the
+      // bar promised "Delete N layers", nothing happened, no toast, selection
+      // preserved. Say why nothing was deletable.
+      toast.info(t('toasts.bulkDeleteOnlyGroupRows'));
+      return false;
+    }
 
     // Clear expanded layer if it's being deleted
     setExpandedLayerId((prev) => (prev && selectedIds.has(prev) ? null : prev));
 
     // Optimistic update — remove only layers actually sent to the backend (idsToDelete),
     // not the full selectedIds which may include frontend-only group folder rows (WR-04).
+    // fix(#767): deleting every child of a folder group also prunes the now-empty
+    // group row — it has no persisted carrier and would vanish on save+reload anyway.
     const idsToDeleteSet = new Set(idsToDelete);
     setLocalLayers((prev) =>
-      prev
-        .filter((l) => !idsToDeleteSet.has(l.id))
+      pruneEmptyFolderGroups(prev.filter((l) => !idsToDeleteSet.has(l.id)))
         .map((l, i) => ({ ...l, sort_order: i })),
     );
 
@@ -353,8 +364,10 @@ export function useBulkLayerActions({
       if (result.failed.length === 0) {
         // Full success — sync baseline immediately so the subsequent invalidateQueries
         // refetch is not blocked by a stale savedLayerBaselineRef (CR-01).
-        savedLayerBaselineRef.current = savedLayerBaselineRef.current.filter(
-          (l) => !idsToDeleteSet.has(l.id),
+        // fix(#767): prune emptied group rows here too so the baseline cannot
+        // retain a group row localLayers no longer renders.
+        savedLayerBaselineRef.current = pruneEmptyFolderGroups(
+          savedLayerBaselineRef.current.filter((l) => !idsToDeleteSet.has(l.id)),
         );
         await queryClient.invalidateQueries({ queryKey: ['map', mapId] });
         toast.success(t('bulkActions.deleteSuccess', { count: idsToDelete.length }));
@@ -372,22 +385,26 @@ export function useBulkLayerActions({
         return false;
       }
 
-      // Partial failure: keep deleted layers removed, restore failed layers
-      const failedIds = new Set(result.failed.map((f) => f.id));
-      setLocalLayers((current) => {
-        // Re-insert failed layers from previousLayers at their original sort_order positions
-        const failedLayers = previousLayers.filter((l) => failedIds.has(l.id));
-        const merged = [...current, ...failedLayers];
-        // Re-sort by original sort_order so failed layers slot back in naturally
-        merged.sort((a, b) => (a.sort_order ?? 0) - (b.sort_order ?? 0));
-        return merged.map((l, i) => ({ ...l, sort_order: i }));
-      });
+      // Partial failure: keep deleted layers removed, restore failed layers.
+      // fix(#805): rebuild from previousLayers minus the actually-deleted rows.
+      // The old path merged the already-renumbered optimistic array with failed
+      // rows still carrying their ORIGINAL sort_order — interleaving two
+      // numbering schemes — so survivors slotted back at the wrong stack
+      // position, and the wrong order was then saved. previousLayers preserves
+      // the true relative order of every survivor. Empty groups are pruned like
+      // the optimistic path (#767): a group whose children all deleted
+      // successfully must not linger.
+      const deletedIds = new Set(result.deleted);
+      setLocalLayers(
+        pruneEmptyFolderGroups(
+          previousLayers.filter((l) => !deletedIds.has(l.id)),
+        ).map((l, i) => ({ ...l, sort_order: i })),
+      );
       // HI-01: the optimistic terrain clear assumed the WHOLE batch was deleted.
       // Re-evaluate against the layers that ACTUALLY remain after restoring the
       // failed ones; if terrain is still backed (its source DEM was among the
       // failures), restore terrain_config so it is not silently disabled.
       if (clearedTerrainOnBulk) {
-        const deletedIds = new Set(result.deleted);
         const remainingAfterPartial = previousLayers.filter((l) => !deletedIds.has(l.id));
         if (!shouldClearTerrainOnDelete(remainingAfterPartial, previousTerrainConfig)) {
           setLocalTerrainConfig(previousTerrainConfig);

--- a/frontend/src/components/builder/hooks/use-folder-group-layers.ts
+++ b/frontend/src/components/builder/hooks/use-folder-group-layers.ts
@@ -4,7 +4,11 @@ import type { Map as MaplibreMap } from 'maplibre-gl';
 import type { MapLayerResponse } from '@/types/api';
 import { applyLayerVisibilityToMap } from '@/components/builder/hooks/use-layer-map-sync';
 import { removePerLayerCompanions } from '@/components/builder/hooks/builder-layer-mutations';
-import { type GroupedLayer, clearPersistedFolderGroup } from '@/components/builder/folder-groups';
+import {
+  type GroupedLayer,
+  clearPersistedFolderGroup,
+  pruneEmptyFolderGroups,
+} from '@/components/builder/folder-groups';
 
 // STATE-02: folder-group handlers, relocated verbatim out of the useBuilderLayers
 // god-hook. PURE RELOCATION — handler bodies are unchanged; the shared layers
@@ -188,7 +192,9 @@ export function useFolderGroupLayers({
         : (groupIdx >= 0 ? groupIdx + 1 : without.length);
       const next = [...without];
       next.splice(insertIdx, 0, updatedLayer as MapLayerResponse);
-      return next.map((l, i) => ({ ...l, sort_order: i }));
+      // fix(#767): defensive — should the moved layer have been the last child
+      // of ANOTHER group, prune that emptied group row in the same write.
+      return pruneEmptyFolderGroups(next).map((l, i) => ({ ...l, sort_order: i }));
     });
     setGroupMeta((prev) => {
       if (prev[groupId]?.expanded) return prev;
@@ -218,7 +224,10 @@ export function useFolderGroupLayers({
       const next = prev.filter((l) => l.id !== layerId) as MapLayerResponse[];
       const insertAt = groupIdx >= 0 ? groupIdx + 1 : next.length;
       next.splice(insertAt, 0, updatedLayer as MapLayerResponse);
-      return next.map((l, i) => ({ ...l, sort_order: i }));
+      // fix(#767): moving the LAST child out empties the group — prune its row
+      // (an empty group has no persisted carrier and vanishes on save+reload).
+      // The moved-out layer then takes the pruned group's stack position.
+      return pruneEmptyFolderGroups(next).map((l, i) => ({ ...l, sort_order: i }));
     });
     setHasUnsavedChanges(true);
   }, [setLocalLayers, setHasUnsavedChanges]);

--- a/frontend/src/components/builder/selection-utils.ts
+++ b/frontend/src/components/builder/selection-utils.ts
@@ -16,10 +16,77 @@
  * blocked at the caller (boundary guard runs first).
  */
 
+import { getParentGroupId } from '@/components/builder/folder-groups';
+import { isFolderGroupLayer } from '@/lib/layer-capabilities';
+import type { MapLayerResponse } from '@/types/api';
+
 export interface ClickModifiers {
   shiftKey: boolean;
   metaKey: boolean;
   ctrlKey: boolean;
+}
+
+/** Case-insensitive substring match on display_name falling back to
+ *  dataset_name. An empty (or whitespace-only) query always matches.
+ *  Single source of truth shared by UnifiedStackPanel's row rendering and
+ *  computeSelectableRowIds below — the two must never disagree. */
+export function layerMatchesSearch(layer: MapLayerResponse, query: string): boolean {
+  const q = query.trim().toLowerCase();
+  if (q === '') return true;
+  return (layer.display_name ?? layer.dataset_name ?? '').toLowerCase().includes(q);
+}
+
+/**
+ * fix(#771): the ordered list of row ids the stack actually RENDERS — children
+ * of collapsed groups and rows hidden by the layer search are excluded. The raw
+ * flat layer array previously fed shift-click range selection directly, so a
+ * range could sweep up rows the user cannot see and bulk delete/visibility/
+ * opacity then acted on them. Mirrors UnifiedStackPanel's render plan exactly
+ * (the panel consumes this same helper for its row-skip decisions):
+ *   - group row: rendered unless a search is active and neither its name nor
+ *     any child matches;
+ *   - group children: rendered only while the group is expanded, and (under
+ *     search) only when the group name or the child itself matches;
+ *   - loose row: rendered unless a search is active and it does not match.
+ */
+export function computeSelectableRowIds(
+  layers: MapLayerResponse[],
+  groupMeta: Record<string, { expanded: boolean }>,
+  searchQuery: string,
+): string[] {
+  const isSearchActive = searchQuery.trim() !== '';
+  const childrenByGroup = new Map<string, MapLayerResponse[]>();
+  for (const layer of layers) {
+    const parentId = getParentGroupId(layer);
+    if (parentId) {
+      const siblings = childrenByGroup.get(parentId);
+      if (siblings) siblings.push(layer);
+      else childrenByGroup.set(parentId, [layer]);
+    }
+  }
+
+  const ids: string[] = [];
+  for (const layer of layers) {
+    if (getParentGroupId(layer)) continue; // children are emitted with their group
+
+    if (isFolderGroupLayer(layer)) {
+      const children = childrenByGroup.get(layer.id) ?? [];
+      const groupNameMatches = layerMatchesSearch(layer, searchQuery);
+      const anyChildMatches = children.some((child) => layerMatchesSearch(child, searchQuery));
+      if (isSearchActive && !groupNameMatches && !anyChildMatches) continue;
+      ids.push(layer.id);
+      if (!(groupMeta[layer.id]?.expanded ?? false)) continue;
+      for (const child of children) {
+        if (isSearchActive && !groupNameMatches && !layerMatchesSearch(child, searchQuery)) continue;
+        ids.push(child.id);
+      }
+      continue;
+    }
+
+    if (isSearchActive && !layerMatchesSearch(layer, searchQuery)) continue;
+    ids.push(layer.id);
+  }
+  return ids;
 }
 
 export interface NextSelection {

--- a/frontend/src/i18n/locales/de/builder.json
+++ b/frontend/src/i18n/locales/de/builder.json
@@ -886,7 +886,8 @@
     "bulkStyleSkipped": "{{count}} Ebenen übersprungen (inkompatible Geometrie)",
     "bulkGroupNeedTwo": "Wähle mindestens 2 lose Ebenen aus, um sie zu gruppieren",
     "bulkGroupSkipped": "Einige ausgewählte Ebenen sind bereits gruppiert und können nicht erneut gruppiert werden",
-    "bulkGroupSkippedGroupRow": "Gruppen können nicht gruppiert werden – entferne Gruppenzeilen aus deiner Auswahl und versuche es erneut"
+    "bulkGroupSkippedGroupRow": "Gruppen können nicht gruppiert werden – entferne Gruppenzeilen aus deiner Auswahl und versuche es erneut",
+    "bulkDeleteOnlyGroupRows": "Gruppenzeilen können nicht per Massenaktion gelöscht werden – lösche eine Gruppe über das Menü ihrer Zeile"
   },
   "builderMap": {
     "loading": "Karte wird geladen...",
@@ -1147,6 +1148,7 @@
     "ungroupHint": "Wähle zum Aufheben der Gruppierung nur Gruppenzeilen aus",
     "ungroupDisabledTooltip": "Nur Gruppen zum Aufheben der Gruppierung auswählen",
     "delete": "Löschen",
+    "deleteHint": "Gruppen werden über das Menü ihrer Zeile gelöscht",
     "deleteAriaLabel": "{{count}} ausgewählte Layer löschen",
     "deleteConfirmLabel": "{{count}} Layer löschen? Diese Aktion kann nicht rückgängig gemacht werden.",
     "deleteConfirmAction": "{{count}} Layer löschen",

--- a/frontend/src/i18n/locales/en/builder.json
+++ b/frontend/src/i18n/locales/en/builder.json
@@ -886,7 +886,8 @@
     "bulkStyleSkipped": "{{count}} layers skipped (incompatible geometry)",
     "bulkGroupNeedTwo": "Select at least 2 loose layers to group",
     "bulkGroupSkipped": "Some selected layers are already grouped and can't be grouped again",
-    "bulkGroupSkippedGroupRow": "Groups can't be grouped — remove any group rows from your selection and try again"
+    "bulkGroupSkippedGroupRow": "Groups can't be grouped — remove any group rows from your selection and try again",
+    "bulkDeleteOnlyGroupRows": "Group rows can't be bulk-deleted — use a group's row menu to delete it"
   },
   "builderMap": {
     "loading": "Loading map...",
@@ -1151,6 +1152,7 @@
     "ungroupHint": "Select only group rows to ungroup",
     "ungroupDisabledTooltip": "Select only groups to ungroup",
     "delete": "Delete",
+    "deleteHint": "Group rows are deleted from their row menu",
     "deleteAriaLabel": "Delete {{count}} selected layers",
     "deleteConfirmLabel": "Delete {{count}} layers? This cannot be undone.",
     "deleteConfirmAction": "Delete {{count}} layers",

--- a/frontend/src/i18n/locales/es/builder.json
+++ b/frontend/src/i18n/locales/es/builder.json
@@ -886,7 +886,8 @@
     "bulkStyleSkipped": "{{count}} capas omitidas (geometría incompatible)",
     "bulkGroupNeedTwo": "Selecciona al menos 2 capas sueltas para agrupar",
     "bulkGroupSkipped": "Algunas capas seleccionadas ya están agrupadas y no se pueden agrupar de nuevo",
-    "bulkGroupSkippedGroupRow": "Los grupos no se pueden agrupar; quita las filas de grupo de tu selección e inténtalo de nuevo"
+    "bulkGroupSkippedGroupRow": "Los grupos no se pueden agrupar; quita las filas de grupo de tu selección e inténtalo de nuevo",
+    "bulkDeleteOnlyGroupRows": "Las filas de grupo no se pueden eliminar en bloque; usa el menú de la fila del grupo para eliminarlo"
   },
   "builderMap": {
     "loading": "Cargando mapa...",
@@ -1147,6 +1148,7 @@
     "ungroupHint": "Selecciona solo filas de grupo para desagrupar",
     "ungroupDisabledTooltip": "Seleccione solo grupos para desagrupar",
     "delete": "Eliminar",
+    "deleteHint": "Los grupos se eliminan desde el menú de su fila",
     "deleteAriaLabel": "Eliminar {{count}} capas seleccionadas",
     "deleteConfirmLabel": "¿Eliminar {{count}} capas? Esta acción no se puede deshacer.",
     "deleteConfirmAction": "Eliminar {{count}} capas",

--- a/frontend/src/i18n/locales/fr/builder.json
+++ b/frontend/src/i18n/locales/fr/builder.json
@@ -886,7 +886,8 @@
     "bulkStyleSkipped": "{{count}} couches ignorées (géométrie incompatible)",
     "bulkGroupNeedTwo": "Sélectionnez au moins 2 couches libres pour les regrouper",
     "bulkGroupSkipped": "Certaines couches sélectionnées sont déjà groupées et ne peuvent pas être regroupées à nouveau",
-    "bulkGroupSkippedGroupRow": "Les groupes ne peuvent pas être regroupés ; retirez les lignes de groupe de votre sélection et réessayez"
+    "bulkGroupSkippedGroupRow": "Les groupes ne peuvent pas être regroupés ; retirez les lignes de groupe de votre sélection et réessayez",
+    "bulkDeleteOnlyGroupRows": "Les lignes de groupe ne peuvent pas être supprimées en masse ; utilisez le menu de la ligne du groupe pour le supprimer"
   },
   "builderMap": {
     "loading": "Chargement de la carte...",
@@ -1147,6 +1148,7 @@
     "ungroupHint": "Sélectionnez uniquement des lignes de groupe pour dégrouper",
     "ungroupDisabledTooltip": "Sélectionnez uniquement des groupes pour dégrouper",
     "delete": "Supprimer",
+    "deleteHint": "Les groupes se suppriment depuis le menu de leur ligne",
     "deleteAriaLabel": "Supprimer {{count}} couches sélectionnées",
     "deleteConfirmLabel": "Supprimer {{count}} couches ? Cette action est irréversible.",
     "deleteConfirmAction": "Supprimer {{count}} couches",

--- a/frontend/src/pages/MapBuilderPage.tsx
+++ b/frontend/src/pages/MapBuilderPage.tsx
@@ -68,7 +68,7 @@ const StyleJsonDialog = lazy(() =>
 );
 import { KeyboardShortcutsSheet } from '@/components/builder/KeyboardShortcutsSheet';
 import { ActiveFilterChips } from '@/components/builder/ActiveFilterChips';
-import { computeNextSelection } from '@/components/builder/selection-utils';
+import { computeNextSelection, computeSelectableRowIds } from '@/components/builder/selection-utils';
 import { Sheet, SheetContent, SheetHeader, SheetTitle, SheetDescription } from '@/components/ui/sheet';
 import { cn } from '@/lib/utils';
 import { MAP_COLORS } from '@/lib/map-colors';
@@ -179,6 +179,11 @@ export function MapBuilderPage() {
   // the Phase 1040 lift-DndContext architecture decision.
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
   const lastToggleAnchor = useRef<string | null>(null);
+  // fix(#771): the layer-search query is lifted here (hybrid-controlled on
+  // UnifiedStackPanel) so selectableRowIds below can be derived from the
+  // RENDERED row set — a shift-click range must never sweep rows the search
+  // has filtered out or that live inside a collapsed group.
+  const [layerSearch, setLayerSearch] = useState('');
 
   // Phase 1040 Plan 04: aria-live announcement for keyboard/mouse catalog drag (T-1040-10 / POL-05).
   // A sr-only region reads these strings to screen-reader users. We append a zero-width-space
@@ -636,14 +641,41 @@ export function MapBuilderPage() {
     return basemapGroup.sublayers.some((s) => s.id === id);
   }, [basemapGroup]);
 
-  // Phase 1041: derive selectable row ids (ordered flat list, basemap excluded)
-  // Used by handleShiftClick for range computation and by the Shift+Arrow keyboard handler
+  // Phase 1041: derive selectable row ids (ordered list, basemap excluded)
+  // Used by handleShiftClick for range computation and by the Shift+Arrow keyboard handler.
+  // fix(#771): derived from the RENDERED row set (shared helper with
+  // UnifiedStackPanel) instead of the raw flat array — the raw list let a
+  // shift-click range select children of collapsed groups and rows hidden by
+  // the layer search, so bulk delete/visibility/opacity acted on rows the
+  // user could not see.
+  // fix(HT-03): terrain-mode DEM rows render in the stack again, so they are
+  // range-selectable like any other row (the BLDR-03 skip is obsolete).
   const selectableRowIds = useMemo(
-    // fix(HT-03): terrain-mode DEM rows render in the stack again, so they are
-    // range-selectable like any other row (the BLDR-03 skip is obsolete).
-    (): string[] => layers.localLayers.map((layer) => layer.id),
-    [layers.localLayers],
+    (): string[] => computeSelectableRowIds(layers.localLayers, layers.groupMeta, layerSearch),
+    [layers.localLayers, layers.groupMeta, layerSearch],
   );
+
+  // fix(#771): selection ids can outlive their rows — handleRemove,
+  // handleDeleteGroup, handleUngroup, and the #767 empty-group prune all
+  // remove rows without touching selectedIds, so the bulk bar kept
+  // over-reporting counts it could not perform. Prune against the live layer
+  // set. Skipped while a bulk delete is in flight: its optimistic removal
+  // must not eat the preserved-on-failure selection (a full-failure rollback
+  // restores the rows in the same commit that clears isDeleting).
+  useEffect(() => {
+    if (layers.isDeleting) return;
+    setSelectedIds((prev) => {
+      if (prev.size === 0) return prev;
+      const liveIds = new Set(layers.localLayers.map((layer) => layer.id));
+      let changed = false;
+      const next = new Set<string>();
+      for (const rowId of prev) {
+        if (liveIds.has(rowId)) next.add(rowId);
+        else changed = true;
+      }
+      return changed ? next : prev;
+    });
+  }, [layers.localLayers, layers.isDeleting]);
 
   // Phase 1041 + SP-04 (Phase 1045): multi-selection handlers driven by the
   // `computeNextSelection` pure helper. Anchor lives in `lastToggleAnchor` ref
@@ -1756,6 +1788,10 @@ export function MapBuilderPage() {
               selectedIds={selectedIds}
               isMultiSelectionActive={isMultiSelectionActive}
               selectableRowIds={selectableRowIds}
+              // fix(#771): hybrid-controlled search so selectableRowIds above
+              // tracks exactly what the panel renders.
+              layerSearch={layerSearch}
+              onLayerSearchChange={setLayerSearch}
               onCmdClick={handleCmdClick}
               onShiftClick={handleShiftClick}
               onCheckboxClick={handleCheckboxClick}


### PR DESCRIPTION
Fixes three related builder stack-state drifts in one pass, since they share the same blast radius (`use-bulk-layer-actions.ts`, the selection plumbing, and the save diff).

## #767 — empty folder groups vanished on save+reload

Group identity is persisted only on children (`builder.folderGroup*` markers), so a group whose last child left had no carrier: it kept rendering, accepted drops, and marked the map dirty, then silently vanished (with any rename) on the next hydrate. The backend has no map-level `group_meta` field to persist an empty group into, so this takes the issue's other sanctioned fix: **prune the group row the moment it empties**, making the UI agree with what persistence can actually round-trip.

- New `pruneEmptyFolderGroups()` in `folder-groups.ts` (identity-stable when nothing to prune).
- Applied inside the state write at every emptying site: `handleRemove`, `handleAiRemoveLayer` (draft remove), `handleReorder` (covers the drag-out dispatch from `handleDragEnd`), `handleMoveLayerOutOfGroup`, `handleAddLayerToExistingGroup` (defensive), and `handleBulkDelete` (optimistic update, full-success baseline sync, and the partial-failure rebuild). Rollback paths restore the pre-delete snapshot, so a failed delete brings the group back with its child.

## #771 — selection could act on rows the user cannot see; group-row bulk delete was a silent no-op

1. `selectableRowIds` was the raw flat layer array, so shift-click ranges (and Shift+Arrow) swept children of collapsed groups and rows hidden by the layer search. It is now derived from the **rendered row set** via a shared `computeSelectableRowIds()` helper in `selection-utils.ts`; `UnifiedStackPanel` consumes the same helper for its row-skip decisions so the two can never drift. The panel's search query is lifted hybrid-controlled into `MapBuilderPage` (internal state remains for standalone/test usage).
2. Every delete-facing count in `BulkActionBar` (confirm label/action, deleting announcement, aria labels) now uses the **deletable count** — group rows are filtered out of the batch by the handler, so counting them promised deletions that never happened. The Delete item disables with an inline hint when nothing is deletable, and `handleBulkDelete` toasts the zero-deletable path instead of returning `false` silently.
3. A `MapBuilderPage` effect prunes `selectedIds` against the live rows, so removals outside the bulk path (`handleRemove`, `handleDeleteGroup`, `handleUngroup`, the #767 prune) no longer leave the bar over-reporting. The effect is skipped while a bulk delete is in flight so the preserved-on-failure selection survives the optimistic removal + rollback cycle.

## #805 — partial bulk-delete scrambled survivor order; grouped saves emitted a spurious per-child PATCH

1. The partial-failure path merged the already-renumbered optimistic array with failed rows still carrying their **original** `sort_order`, interleaving two numbering schemes — survivors slotted back at the wrong stack position and that order was then saved. Survivors are now rebuilt from `previousLayers` minus the actually-deleted rows.
2. `buildLayerDiff` prepared its baseline **without** `groupMeta` while the current side got it, so baseline children lacked the `folderGroupExpanded` marker and every save of a grouped map emitted a per-child `style_config` PATCH — silently persisting collapse state that is deliberately non-dirtying. Both sides now use the same `groupMeta`; collapse state still rides along only when a real change patches `style_config` or a full PUT runs.

## Config/i18n impact

Two new translation keys, literal in all four locales (en/es/fr/de): `toasts.bulkDeleteOnlyGroupRows`, `bulkActions.deleteHint`. No API, schema, or backend changes.

## Tests

New coverage, all verified to **fail against the pre-fix code** (5 targeted regression tests confirmed red with the fixes stashed) and pass with it:

- `folder-groups.test.ts`: `pruneEmptyFolderGroups` unit tests (prunes childless, keeps populated, identity-stable, ignores non-folder rows).
- `selection-utils.test.ts`: `computeSelectableRowIds` render-order/collapse/search matrix (7 cases).
- `use-builder-save.test.ts`: unchanged grouped map produces an empty diff; collapse-state-only change stays out of the diff.
- `use-builder-layers.bulk-ops.test.ts`: partial-failure survivor position is exact (`[b,c,d,e]`, not interleaved); bulk-deleting all children prunes the group row and never sends the synthetic id; group-only selection toasts instead of no-oping.
- `use-builder-layers.groups.test.ts`: move-out of the last child prunes (and keeps the group while children remain); drag-out via `handleReorder` prunes; single `handleRemove` of the last child prunes.
- `BulkActionBar.test.tsx`: mixed selection confirms the deletable count; group-only selection disables Delete with the hint; deleting state announces the deletable count.

## Verification

```
cd frontend
npm run lint
npm run typecheck
npm run test:i18n
npx vitest run src/components/builder src/pages   # 154 files, 2082 tests
```

All green on the rebased branch; the #801 layer-contiguity property test and the #794 keyboard-reorder tests are untouched and passing. No dnd-kit listener chrome was modified.

Closes #767
Closes #771
Closes #805

https://claude.ai/code/session_01TEhW22Yf94GjuKYxMhcbLt
