### PR TITLE
fix: v1.6.0 pre-tag audit remediation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -506,8 +506,9 @@ jobs:
              GRANT USAGE ON SCHEMA data TO geolens_reader;
              GRANT SELECT ON ALL TABLES IN SCHEMA data TO geolens_reader;
              ALTER DEFAULT PRIVILEGES IN SCHEMA data GRANT SELECT ON TABLES TO geolens_reader;"
+          # tail -1: -tA still prints the SET command tag ahead of the count
           READER_CNT=$(psql -h "$PGHOST" -p "$PGPORT" -U "$PGUSER" -d "$DST" -tAc \
-            "SET ROLE geolens_reader; SELECT COUNT(*) FROM data.ci_probe;")
+            "SET ROLE geolens_reader; SELECT COUNT(*) FROM data.ci_probe;" | tail -n 1)
           [ "$READER_CNT" = "1" ] || { echo "FAIL: geolens_reader cannot select restored data.ci_probe (got '${READER_CNT}')"; exit 1; }
           echo "  geolens_reader post-restore grant verified (data.ci_probe readable)"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,8 +59,21 @@ jobs:
               - 'CHANGELOG.md'
               - '.env.example'
               - '.dockerignore'
-              - 'nginx.conf'
               - 'db/**'
+              # Frontend files that backend parity/drift tests read by literal
+              # path (fe-sdk type drift, basemap/capability/paint-key drift,
+              # nginx/CSP/Dockerfile regressions). Specific files only — NOT
+              # frontend/src/** — so ordinary frontend PRs stay backend-skipped.
+              - 'frontend/nginx.conf'
+              - 'frontend/Dockerfile'
+              - 'frontend/Dockerfile.dev'
+              - 'frontend/docker-entrypoint.sh'
+              - 'frontend/index.html'
+              - 'frontend/public/theme-init.js'
+              - 'frontend/src/types/api.ts'
+              - 'frontend/src/lib/basemap-utils.ts'
+              - 'frontend/src/lib/capabilities.ts'
+              - 'frontend/src/components/builder/layer-adapters/shared.ts'
               # fix(#561): a change to this workflow can alter HOW Backend Tests
               # runs (e.g. the -n4 parallelization / coverage core), so the suite
               # must run on PRs that touch it — otherwise CI-config changes ship
@@ -74,6 +87,10 @@ jobs:
               # reporter's prefill against this Issue Form — a template-only PR
               # must still run the frontend tests or drift lands silently.
               - '.github/ISSUE_TEMPLATE/bug_report.yml'
+              # PR #745 bumped root @playwright/test with every frontend/e2e/axe
+              # job skipping — the root manifests were in NO filter.
+              - 'package.json'
+              - 'package-lock.json'
             e2e:
               - 'backend/**'
               - 'frontend/**'
@@ -81,9 +98,15 @@ jobs:
               - 'playwright.config.ts'
               - 'playwright.builder-hardening.config.ts'
               - 'docker-compose*.yml'
+              # PR #745: the Playwright toolchain lives in the ROOT manifests.
+              - 'package.json'
+              - 'package-lock.json'
             cli:
               - 'cli/**'
               - 'sdks/python/**'
+              # test_cli_round_trip.py applies examples/manifests/first-catalog
+              # verbatim — an example-only change must still run the CLI suite.
+              - 'examples/**'
             mcp:
               - 'mcp/**'
               - 'sdks/python/**'
@@ -93,6 +116,11 @@ jobs:
             sdks:
               - 'sdks/**'
               - 'backend/openapi.json'
+              # `make sdks-check` is driven by the Makefile recipe and the
+              # flatten intermediate — a change to either alters what the drift
+              # gate regenerates, so it must run.
+              - 'Makefile'
+              - 'scripts/flatten_openapi_defs.py'
             alembic:
               - 'backend/alembic/**'
               - 'backend/scripts/test_alembic_upgrade_clean_db.sh'
@@ -115,6 +143,9 @@ jobs:
               - 'scripts/tests/test-upgrading-doc-consistency.sh'
               - 'scripts/tests/test-backup-s3-signature.sh'
               - 'scripts/check_env_doc_drift.py'
+              # check_env_doc_drift.py parses the Settings class out of this
+              # file — a new Settings field must re-run the drift gate.
+              - 'backend/app/core/config.py'
               - '.env.example'
               - 'UPGRADING.md'
               - 'docker-compose.yml'
@@ -123,9 +154,14 @@ jobs:
               - 'scripts/backup-entrypoint.sh'
               - 'scripts/restore.sh'
               - 'scripts/tests/test-backup-restore-roundtrip.sh'
+              # Both compose files carry the backup service healthcheck.
+              - 'docker-compose.yml'
               - 'docker-compose.prod.yml'
               - 'Dockerfile'
               - '.github/workflows/publish.yml'
+              # The round-trip proof itself is ~220 inline lines of THIS
+              # workflow — a ci.yml-only edit to those steps must run them.
+              - '.github/workflows/ci.yml'
 
   # ---------- backend ----------
   backend-lint:
@@ -181,7 +217,7 @@ jobs:
         with:
           python-version: "3.13"
 
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v6
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0
         with:
           node-version: 22
 
@@ -371,7 +407,17 @@ jobs:
           # provider-snapshot + object-storage recovery without requiring S3/MinIO
           # or the backup image (pure pg_dump/pg_restore + tar). CI checkout ships
           # .env.test, so env overrides are passed explicitly.
-          bash scripts/tests/test-backup-restore-roundtrip.sh
+          #
+          # The script exits 0 with a "SKIP:" line when its prerequisites are
+          # missing (it doubles as a local dev tool). This job only runs when
+          # the backup path filter matched, so a skip here means CI asserted
+          # NOTHING about the backup path — treat it as a hard failure.
+          set -o pipefail
+          bash scripts/tests/test-backup-restore-roundtrip.sh | tee /tmp/roundtrip-fast.log
+          if grep -q '^SKIP:' /tmp/roundtrip-fast.log; then
+            echo "::error::backup round-trip script skipped (prerequisites missing on the CI runner) — nothing was asserted"
+            exit 1
+          fi
 
       - name: BUNDLED MODE — boot backup image (SigV4 S3 upload via image) → download → pg_restore → row-count assert
         run: |
@@ -579,7 +625,7 @@ jobs:
         with:
           python-version: "3.13"
 
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v6
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0
         with:
           node-version: 22
           cache: npm
@@ -1028,7 +1074,7 @@ jobs:
         with:
           version: "0.10.2"
 
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v6
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0
         with:
           node-version: 22
           cache: npm
@@ -1069,7 +1115,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v6
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0
         with:
           node-version: 22
           cache: npm
@@ -1101,7 +1147,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v6
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0
         with:
           node-version: 22
           cache: npm
@@ -1168,6 +1214,45 @@ jobs:
 
       - name: Run pip-audit (dependency vulnerability scan)
         run: uv run pip-audit --strict --desc
+
+  # ---------- required-checks aggregator ----------
+  # Every job below is path-filtered (skippable via `if:`), and GitHub treats a
+  # skipped required context as PASSING — the "main red while PRs green" hole.
+  # This job always runs and inspects each needed job's actual result: failure
+  # or cancelled fails it; skipped and success pass. Branch protection should
+  # require THIS single context instead of the individual skippable jobs.
+  ci-ok:
+    name: CI OK
+    needs:
+      - backend-lint
+      - backend-test
+      - installer-test
+      - backup-roundtrip
+      - openapi-snapshot
+      - sdks-check
+      - cli-test
+      - mcp-test
+      - alembic-clean-db
+      - frontend-lint
+      - frontend-test
+      - security-scan
+    # always() alone would rubber-stamp: it only guarantees this job RUNS.
+    # The step below does the real gating on needs.*.result.
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fail if any needed job failed or was cancelled
+        env:
+          NEEDS_JSON: ${{ toJSON(needs) }}
+        run: |
+          echo "$NEEDS_JSON" | jq -r 'to_entries[] | "\(.key): \(.value.result)"'
+          BAD=$(echo "$NEEDS_JSON" | jq -r \
+            'to_entries[] | select(.value.result == "failure" or .value.result == "cancelled") | .key')
+          if [ -n "$BAD" ]; then
+            echo "::error::Required jobs failed or were cancelled: $(echo "$BAD" | tr '\n' ' ')"
+            exit 1
+          fi
+          echo "OK: no needed job failed (skipped counts as pass)"
 
   # ---------- WORK-04: runtime extension image probe matrix ----------
   # Builds BOTH the 'api' and 'worker' image targets and runs a python probe
@@ -1277,7 +1362,7 @@ jobs:
       - name: Start services
         run: docker compose up -d --wait --wait-timeout 120
 
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v6
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0
         with:
           node-version: 22
           cache: npm
@@ -1469,7 +1554,7 @@ jobs:
       - name: Start services
         run: docker compose up -d --wait --wait-timeout 120
 
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v6
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0
         with:
           node-version: 22
           cache: npm

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -385,7 +385,10 @@ jobs:
              CREATE TABLE catalog.records (id serial PRIMARY KEY, name text);
              CREATE TABLE catalog.datasets (id serial PRIMARY KEY, slug text);
              INSERT INTO catalog.records (name) SELECT 'img-r-'||g FROM generate_series(1, 113) g;
-             INSERT INTO catalog.datasets (slug) SELECT 'img-d-'||g FROM generate_series(1, 57) g;"
+             INSERT INTO catalog.datasets (slug) SELECT 'img-d-'||g FROM generate_series(1, 57) g;
+             CREATE SCHEMA IF NOT EXISTS data;
+             CREATE TABLE data.ci_probe (id int PRIMARY KEY);
+             INSERT INTO data.ci_probe VALUES (1);"
           SRC_R=$(psql -h "$PGHOST" -p "$PGPORT" -U "$PGUSER" -d "$SRC" -tAc "SELECT COUNT(*) FROM catalog.records;")
           SRC_D=$(psql -h "$PGHOST" -p "$PGPORT" -U "$PGUSER" -d "$SRC" -tAc "SELECT COUNT(*) FROM catalog.datasets;")
 
@@ -441,6 +444,27 @@ jobs:
           # Hard row-count asserts — must not be weakened with || true (T-1247-09).
           [ "$SRC_R" = "$DST_R" ] || { echo "FAIL: bundled-mode records count mismatch: $SRC_R != $DST_R"; exit 1; }
           [ "$SRC_D" = "$DST_D" ] || { echo "FAIL: bundled-mode datasets count mismatch: $SRC_D != $DST_D"; exit 1; }
+
+          # geolens_reader grant round-trip: --clean drops schema `data` with
+          # its ACLs and the dump is --no-acl, so restore.sh re-grants AFTER
+          # pg_restore. Mirror that re-grant here, then prove the reader can
+          # actually select from a restored table in schema `data`.
+          psql -h "$PGHOST" -p "$PGPORT" -U "$PGUSER" -d "$DST" -v ON_ERROR_STOP=1 -c \
+            "DO \$\$
+             BEGIN
+                 IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'geolens_reader') THEN
+                     CREATE ROLE geolens_reader NOLOGIN;
+                 END IF;
+             END
+             \$\$;
+             GRANT USAGE ON SCHEMA data TO geolens_reader;
+             GRANT SELECT ON ALL TABLES IN SCHEMA data TO geolens_reader;
+             ALTER DEFAULT PRIVILEGES IN SCHEMA data GRANT SELECT ON TABLES TO geolens_reader;"
+          READER_CNT=$(psql -h "$PGHOST" -p "$PGPORT" -U "$PGUSER" -d "$DST" -tAc \
+            "SET ROLE geolens_reader; SELECT COUNT(*) FROM data.ci_probe;")
+          [ "$READER_CNT" = "1" ] || { echo "FAIL: geolens_reader cannot select restored data.ci_probe (got '${READER_CNT}')"; exit 1; }
+          echo "  geolens_reader post-restore grant verified (data.ci_probe readable)"
+
           echo "PASS [BUNDLED MODE]: image backup→SigV4-S3→restore, records=${SRC_R} datasets=${SRC_D}"
           dropdb -h "$PGHOST" -p "$PGPORT" -U "$PGUSER" --if-exists "$SRC"
           dropdb -h "$PGHOST" -p "$PGPORT" -U "$PGUSER" --if-exists "$DST"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -415,7 +415,7 @@ jobs:
             -e S3_ENDPOINT="$S3_ENDPOINT" -e S3_BUCKET="$S3_BUCKET"
             -e S3_ACCESS_KEY_ID="$S3_ACCESS_KEY_ID"
             -e S3_SECRET_ACCESS_KEY="$S3_SECRET_ACCESS_KEY"
-            -e S3_ALLOW_HTTP=true -e S3_ADDRESSING_STYLE=path
+            -e S3_ADDRESSING_STYLE=path
             -v /tmp/ci-backups:/backups -v /tmp/ci-staging:/staging:ro
           )
           docker run "${run_args[@]}" geolens-backup:ci --run-backup

--- a/.github/workflows/dep-audit.yml
+++ b/.github/workflows/dep-audit.yml
@@ -58,7 +58,7 @@ jobs:
         directory: [".", "frontend", "sdks/typescript"]
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v6
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0
         with:
           node-version: "24" # CI tooling runner (LTS); build image is node 26
           cache: "npm"

--- a/.github/workflows/prod-smoke.yml
+++ b/.github/workflows/prod-smoke.yml
@@ -33,7 +33,10 @@ permissions:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  # Never cancel a tag smoke: release.yml fires only on this workflow's
+  # SUCCESS, and a cancelled run (which is not a failure — nothing goes red)
+  # would silently withhold the GitHub Release for the tag.
+  cancel-in-progress: false
 
 jobs:
   prod-smoke:
@@ -45,13 +48,18 @@ jobs:
 
       - name: Resolve image tag to smoke
         id: ver
+        env:
+          # Free-text dispatch input: pass via env and reference as "$VAR"
+          # (same pattern as the .env step below) — never interpolate it into
+          # the script body, where it would be evaluated as shell.
+          INPUT_VERSION: ${{ github.event.inputs.version }}
         run: |
           # On a tag push, github.ref_name is the tag (vX.Y.Z). On manual
           # dispatch, use the input (default latest).
           if [ "${{ github.event_name }}" = "push" ]; then
             VER="${{ github.ref_name }}"
           else
-            VER="${{ github.event.inputs.version }}"
+            VER="$INPUT_VERSION"
           fi
           # publish.yml tags images via `type=semver,pattern={{version}}`, which
           # STRIPS the leading `v` (a `v1.3.0` tag push publishes `geolens-api:1.3.0`).
@@ -150,7 +158,7 @@ jobs:
       # success (workflow_run), so a failing tag E2E withholds the GitHub Release
       # (the "latest" pointer the website + release API follow).
       - name: Set up Node
-        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v6
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0
         with:
           node-version: 22
           cache: npm

--- a/.github/workflows/publish-sdks.yml
+++ b/.github/workflows/publish-sdks.yml
@@ -159,16 +159,12 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v6
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0
         with:
           node-version: 22
           registry-url: 'https://registry.npmjs.org'
           cache: npm
           cache-dependency-path: sdks/typescript/package-lock.json
-
-      # OIDC Trusted Publishing requires npm >= 11.5.1; Node 22 ships an older npm.
-      - name: Upgrade npm (OIDC trusted publishing support)
-        run: npm install -g npm@latest
 
       - name: Assert tag matches package version (tag push only)
         if: ${{ github.event_name == 'push' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,6 +33,18 @@ jobs:
     env:
       TAG: ${{ github.event.workflow_run.head_branch }}
     steps:
+      # The job-level startsWith(head_branch, 'v') gate also matches ordinary
+      # branch names like `video-fix` smoked via workflow_dispatch. Only a
+      # semver-shaped tag (optional prerelease suffix) may create or update a
+      # GitHub Release — anything else reaching this job is an anomaly, so
+      # fail loudly rather than releasing from it.
+      - name: Assert semver-shaped tag
+        run: |
+          if ! printf '%s' "${TAG}" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$'; then
+            echo "::error::head_branch '${TAG}' is not a semver tag; refusing to release"
+            exit 1
+          fi
+
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           ref: ${{ github.event.workflow_run.head_sha }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,6 +59,8 @@ Frontend tests use Vitest and Testing Library as `*.test.ts(x)` files or under `
 
 New `t()` translation keys must be added to all four locales (en/es/fr/de); a `defaultValue` alone fails the `npm run test:i18n` locale-parity CI gate.
 
+Plural-suffix keys follow the same all-four-or-none rule, with two i18next facts to respect: there is no `_many`→`_other` fallback (a `_many` added to es/fr alone renders the raw key or English for exact millions), and French resolves count 0 to `_one` — so `_one` values must interpolate `{{count}}`, never hardcode "1".
+
 ## Commit & Pull Request Guidelines
 
 History follows a Conventional Commit-like pattern, for example `feat(sharing): add schema gates for advanced sharing` or `docs(readme): clarify the install steps`. Use an imperative subject and meaningful scope.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,74 @@ and releases use semantic versioning.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Upgrading no longer reports a false "Upgrade FAILED".** The new backup
+  freshness marker doesn't exist yet on a pre-upgrade install, and the
+  upgrade script's 90-second health wait counted services still inside
+  their declared start period as unhealthy — so any database that took
+  longer than that to dump printed a failure banner and a rollback recipe
+  while the stack was actually fine. Services still starting are now
+  treated as converging.
+- **A restored database keeps its read-only grants.** The single-server
+  restore script granted the reader role before `pg_restore --clean`
+  dropped and recreated the schema, silently revoking them again; tiles
+  and sandbox queries then failed with permission errors. Grants now
+  apply after the restore and are asserted before the script reports
+  success.
+- **A backup cycle whose staging archive fails is no longer reported as
+  successful**, and several backup edge cases are closed: a zero-padded
+  schedule minute never matching, a truncated dump left looking complete,
+  blank S3 credentials counting as an upload, and a retention setting of
+  0 deleting the dump it just wrote.
+- **Layer rows are fully keyboard-operable.** Visibility eyes, group
+  carets, inline delete confirms, and renames (including typing spaces
+  and committing with Enter) now work from the keyboard on every row
+  type, with focus returned where it was.
+- **Raster tile errors are no longer misclassified as handled**, and an
+  authentication failure that can't be recovered now surfaces the map's
+  error state on the dataset preview and viewer instead of failing
+  silently. Vector previews gained the same loading and error states
+  rasters already had.
+- **Bulk delete announces the real count while deleting**, its
+  confirmation prompt behaves as a proper dialog, selection no longer
+  survives on rows hidden by search or a collapsed group, and a partial
+  failure no longer discards layers added while the delete was in
+  flight.
+- **The Analysis panel keeps a drawing session intact**: Escape cancels
+  the draw instead of closing the panel, converted buffer distances can
+  no longer exceed the cap in the converted unit, Enter runs Preview,
+  and the collision warning the backend already recorded is finally
+  shown. Analysis jobs also record their completion time, so job lists
+  and retention age on the right timestamp.
+- **Switching a vector basemap to a raster one no longer stacks the old
+  basemap on top** of the new one on dataset previews.
+- **Clearing a max-zoom field no longer writes 0** (which hid the layer
+  at every zoom), the last movement of an opacity slider isn't lost when
+  the editor closes, Reset asks before destroying a configured style,
+  and the "Reverse" ramp option actually reverses DEM and heatmap ramps.
+
+### Changed
+
+- **The backup container reports unhealthy when backups stop
+  succeeding**, not just when its loop dies — operators see a red
+  container instead of discovering stale backups during a restore.
+  (#800)
+- **Destructive confirms are consistently ordered** (safe action left,
+  destructive right) across the builder, and revoking a share link asks
+  first. (#809)
+- **Builder accessibility batch**: accessible names on maps, sliders and
+  rename inputs, live regions that announce reliably, translated drag
+  announcements, and honest inline-confirm semantics. (#804, #810)
+- **Analysis correctness batch**: terminal job writes are fenced,
+  renamed outputs surface correctly, the output size check measures the
+  real output, the stack selection is honored, and a drawn clip mask
+  survives a basemap style reload. (#802, #803, #807)
+- **CI closes several audit gaps**: an aggregator check that fails when
+  a required job fails instead of skipping, path filters that actually
+  cover the files jobs read (including the root `package.json`, so a
+  Playwright bump runs the suites again), and workflow hardening.
+
 ## [1.5.1] - 2026-07-27
 
 ### Security

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -84,7 +84,10 @@ S3_REGION=us-east-1
 ```
 
 Also set `S3_SECRET_ACCESS_KEY` to your access secret. See `.env.example` for all
-available S3 options including `S3_ALLOW_HTTP`.
+available S3 options including `S3_ADDRESSING_STYLE`. The backup uploader follows
+whatever scheme `S3_ENDPOINT` carries — use an `http://` endpoint for a
+plain-HTTP MinIO (`S3_ALLOW_HTTP` only affects the app's own object-storage
+client, not the backup uploader).
 
 The built-in uploader signs requests with **AWS Signature V4** (awscli), compatible
 with Cloudflare R2, modern AWS S3, and MinIO. A failed upload is logged as

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -121,9 +121,13 @@ self-hosted Docker Compose deployment).
 2. Creates required extensions and schemas in the database.
 3. Stops `api` and `worker` to prevent write conflicts.
 4. Runs `pg_restore --clean --if-exists --no-owner` against the bundled `db` container.
-5. Restarts `api` and `worker` on exit (including on failure — via a trap).
-6. Runs a post-restore row-count check (`catalog.records`, `catalog.datasets`).
-7. Auto-detects any sibling `staging-<timestamp>.tar.gz` next to the dump and
+5. Re-applies the `geolens_reader` grants on schema `data` and asserts they took
+   (`has_schema_privilege`). `--clean` drops the schema together with its ACLs
+   and default privileges, and the dump carries no ACLs (`--no-acl`), so the
+   grants must be rebuilt after every restore.
+6. Restarts `api` and `worker` on exit (including on failure — via a trap).
+7. Runs a post-restore row-count check (`catalog.records`, `catalog.datasets`).
+8. Auto-detects any sibling `staging-<timestamp>.tar.gz` next to the dump and
    prints the exact manual object-storage extract command.
 
 **Never** use `psql < <dump>` on a custom-format (`-Fc`) dump file — it is binary,
@@ -132,7 +136,11 @@ not plain SQL, and will fail.
 ### Multi-tenant role reconstruction after a fresh-cluster restore
 
 PostgreSQL roles are cluster objects and are not included in a database-only
-`pg_dump`. A same-cluster restore normally retains them. When restoring a
+`pg_dump`. A same-cluster restore normally retains the roles themselves — but
+not the ACLs on schemas that `--clean` drops and recreates: those (including
+default privileges) die with the schema and must be re-granted after the
+restore, which is why `restore.sh` re-applies the `geolens_reader` grants as a
+post-restore step. When restoring a
 multi-tenant dump into a brand-new cluster, restore without ACL entries (the old
 tenant role names do not exist yet), then rebuild the guarded topology with the
 0019 migration before starting API, worker, or tile traffic:

--- a/backend/app/modules/catalog/maps/schemas.py
+++ b/backend/app/modules/catalog/maps/schemas.py
@@ -35,6 +35,7 @@ LEGACY_BUILDER_PAINT_KEYS = {
     "_fill-opacity-saved": "fill_opacity_saved",
     "_outline-width-saved": "outline_width_saved",
     "_heatmap-ramp": "heatmap_ramp",
+    "_heatmap-reversed": "heatmap_reversed",
     "_heatmap-weight-column": "heatmap_weight_column",
     "_height_column": "height_column",
     # Raster colormap/stretch builder-private keys (v1031/v1032/v1034). The
@@ -53,6 +54,7 @@ LEGACY_BUILDER_PAINT_KEYS = {
     # stays clean and the round-trip persists across save/reload.
     "_hypso-enabled": "hypso_enabled",
     "_hypso-ramp": "hypso_ramp",
+    "_hypso-reversed": "hypso_reversed",
 }
 _STYLE_CONFIG_BUILDER_KEY = "builder"
 
@@ -82,6 +84,7 @@ _BUILDER_CAMEL_TO_SNAKE_KEYS = {
     "outlineColor": "outline_color",
     "outlineWidth": "outline_width",
     "heatmapRamp": "heatmap_ramp",
+    "heatmapReversed": "heatmap_reversed",
     "heatmapWeightColumn": "heatmap_weight_column",
     "heightColumn": "height_column",
     "heightScale": "height_scale",

--- a/backend/app/modules/catalog/maps/style_json.py
+++ b/backend/app/modules/catalog/maps/style_json.py
@@ -805,9 +805,13 @@ _COLOR_RELIEF_RAMPS: dict[str, list[str]] = {
 }
 
 
-def _color_relief_color_expression(ramp_name: str) -> list[Any]:
+def _color_relief_color_expression(
+    ramp_name: str, reversed_: bool = False
+) -> list[Any]:
     """Build a MapLibre ``color-relief-color`` interpolate-over-elevation expression."""
     colors = _COLOR_RELIEF_RAMPS.get(ramp_name, _COLOR_RELIEF_RAMPS["YlOrRd"])
+    if reversed_:
+        colors = list(reversed(colors))
     step = (COLOR_RELIEF_ELEV_MAX - COLOR_RELIEF_ELEV_MIN) / (len(colors) - 1)
     expr: list[Any] = ["interpolate", ["linear"], ["elevation"]]
     for index, color in enumerate(colors):
@@ -816,12 +820,13 @@ def _color_relief_color_expression(ramp_name: str) -> list[Any]:
     return expr
 
 
-def _hypso_config_for_layer(layer: MapLayerResponse) -> tuple[bool, str]:
-    """Resolve (enabled, ramp_name) for a DEM layer's color-relief companion.
+def _hypso_config_for_layer(layer: MapLayerResponse) -> tuple[bool, str, bool]:
+    """Resolve (enabled, ramp_name, reversed) for a DEM layer's color-relief companion.
 
     Reads the builder-private hypsometric flags from either the builder block
-    (snake_case ``hypso_enabled``/``hypso_ramp`` after the paint->builder split,
-    or camelCase if a client sent it that way) or the raw ``_hypso-*`` paint keys.
+    (snake_case ``hypso_enabled``/``hypso_ramp``/``hypso_reversed`` after the
+    paint->builder split, or camelCase if a client sent it that way) or the raw
+    ``_hypso-*`` paint keys.
     """
     builder = _builder_style_config(layer.style_config)
     paint = layer.paint or {}
@@ -838,7 +843,12 @@ def _hypso_config_for_layer(layer: MapLayerResponse) -> tuple[bool, str]:
     )
     if not isinstance(ramp, str) or not ramp:
         ramp = COLOR_RELIEF_DEFAULT_RAMP
-    return enabled, ramp
+    reversed_ = bool(
+        builder.get("hypso_reversed")
+        or builder.get("hypsoReversed")
+        or paint.get("_hypso-reversed")
+    )
+    return enabled, ramp, reversed_
 
 
 def _color_relief_companion_layer(
@@ -853,7 +863,7 @@ def _color_relief_companion_layer(
     paint keys are already stripped from the primary paint by ``_clean_paint``; this
     reconstructs the visible tint as a spec-valid layer that re-imports cleanly.
     """
-    enabled, ramp = _hypso_config_for_layer(layer)
+    enabled, ramp, reversed_ = _hypso_config_for_layer(layer)
     if not enabled:
         return None
     return {
@@ -870,7 +880,7 @@ def _color_relief_companion_layer(
         },
         "layout": _companion_visibility(layer),
         "paint": {
-            "color-relief-color": _color_relief_color_expression(ramp),
+            "color-relief-color": _color_relief_color_expression(ramp, reversed_),
             "color-relief-opacity": COLOR_RELIEF_DEFAULT_OPACITY,
         },
     }

--- a/backend/app/processing/analysis/tasks.py
+++ b/backend/app/processing/analysis/tasks.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import asyncio
 import re
 import uuid
+from datetime import datetime, timezone
 from types import SimpleNamespace
 from typing import Any
 
@@ -91,9 +92,11 @@ def _user_error_message(exc: Exception) -> str:
     if isinstance(exc, SQLAlchemyError):
         exc_text = str(exc).lower()
         if "querycancelederror" in exc_text or "statement timeout" in exc_text:
+            # fix(v1.6.0 audit D11): name the configured limit so the user
+            # knows what budget was exceeded.
             return (
-                "The analysis exceeded its processing time limit. "
-                "Try a smaller dataset or area."
+                f"The analysis exceeded its {MATERIALIZE_TIMEOUT} processing "
+                "time limit. Try a smaller dataset or area."
             )
         if isinstance(exc, (DataError, InternalError)):
             return "The analysis failed while processing this data"
@@ -156,6 +159,10 @@ async def _fail_cancelled_job(
                 "error_message": (
                     "The worker shut down before this analysis finished. Run it again."
                 ),
+                # fix(v1.6.0 audit B12): terminal writes must stamp
+                # completed_at (the ingest tasks all do) — without it the
+                # jobs UI renders '-' and retention ages on queue time.
+                "completed_at": datetime.now(timezone.utc),
             },
         ):
             await session.rollback()
@@ -220,7 +227,7 @@ async def _recheck_size_caps(
 
 
 async def _enforce_output_size(
-    session: AsyncSession, schema: str, table_name: str
+    session: AsyncSession, schema: str, table_name: str, *, operation: str
 ) -> None:
     """Fail the build when the output relation is over MAX_OUTPUT_BYTES.
 
@@ -241,10 +248,17 @@ async def _enforce_output_size(
     )
     size_bytes = result.scalar_one_or_none()
     if size_bytes is not None and size_bytes > MAX_OUTPUT_BYTES:
+        # fix(v1.6.0 audit D11): only buffer has a distance to reduce —
+        # telling a clip/centroid/dissolve user to shrink a buffer they
+        # never set is a dead end.
+        advice = (
+            "Reduce the buffer distance or run it on a smaller dataset."
+            if operation == "buffer"
+            else "Run it on a smaller dataset or area."
+        )
         raise ValueError(
             f"The analysis output exceeded the "
-            f"{MAX_OUTPUT_BYTES // 1024**3} GB size limit. Reduce the "
-            "buffer distance or run it on a smaller dataset."
+            f"{MAX_OUTPUT_BYTES // 1024**3} GB size limit. {advice}"
         )
 
 
@@ -271,7 +285,12 @@ async def _complete_job_for_attempt(
         session,
         uuid.UUID(job_id),
         attempt_id,
-        values={"status": "complete", "dataset_id": dataset_id},
+        values={
+            "status": "complete",
+            "dataset_id": dataset_id,
+            # fix(v1.6.0 audit B12): stamp completion time like ingest does.
+            "completed_at": datetime.now(timezone.utc),
+        },
     ):
         await session.commit()
         ANALYSIS_JOBS.labels(operation=operation, status="complete").inc()
@@ -287,6 +306,31 @@ async def _complete_job_for_attempt(
         await session.commit()
     except Exception:  # broad: best-effort cleanup of the orphaned output
         await session.rollback()
+
+
+async def _output_table_adopted(session: AsyncSession, out_table: str) -> bool:
+    """Whether a dataset row has adopted ``out_table`` (fix(v1.6.0 audit B13)).
+
+    Index-backed: ``catalog.datasets`` carries two partial unique indexes on
+    ``table_name`` (global and per-tenant). Tenant-scoped in multi_tenant —
+    an unscoped probe could match another tenant's dataset of the same name
+    and skip a legitimate drop (the IN-01 pattern from the ingest discover
+    query). With no tenant context in multi_tenant, report adopted: the
+    caller then prefers leaking a table over dropping one it can't attribute.
+    """
+    tid = current_tenant_var.get() if is_multi_tenant() else None
+    if is_multi_tenant():
+        if tid is None:
+            return True
+        stmt = text(
+            "SELECT 1 FROM catalog.datasets"
+            " WHERE table_name = :out AND tenant_id = :tenant_id"
+        ).bindparams(out=out_table, tenant_id=tid)
+    else:
+        stmt = text(
+            "SELECT 1 FROM catalog.datasets WHERE table_name = :out"
+        ).bindparams(out=out_table)
+    return (await session.execute(stmt)).first() is not None
 
 
 async def _mark_job_failed(
@@ -308,7 +352,9 @@ async def _mark_job_failed(
     before the connection dropped, leaving the row 'complete'). A successful
     fence proves the row was still 'running', so the registration commit has
     not happened and any committed output table is an unregistered orphan —
-    safe to drop. If the fence misses, the row AND the table are left alone.
+    safe to drop. If the fence misses, the row is left alone; the table is
+    dropped only when the adoption probe proves no dataset registered it
+    (fix(v1.6.0 audit B13)).
     """
     await session.rollback()
     if not await update_ingest_job_for_attempt(
@@ -319,10 +365,34 @@ async def _mark_job_failed(
             "status": "failed",
             # Sanitized (fix(#692)): raw DB errors embed the generated SQL.
             "error_message": _user_error_message(exc),
+            # fix(v1.6.0 audit B12): stamp completion time like ingest does.
+            "completed_at": datetime.now(timezone.utc),
         },
     ):
         await session.rollback()
         logger.warning("analysis.failed_write_superseded", job_id=job_id)
+        # fix(v1.6.0 audit B13): a fence miss means some other actor set a
+        # terminal state, but only a completed job has adopted the table —
+        # a swept row leaves an unregistered orphan that used to leak
+        # permanently. Probe for an adopting dataset row; no row means the
+        # DROP is safe. Failure direction stays safe: if the probe itself
+        # errors, prefer leaking the table to dropping a registered
+        # dataset's storage.
+        if out_table is not None:
+            adopted = True
+            try:
+                adopted = await _output_table_adopted(session, out_table)
+            except Exception:  # broad: prefer leak over loss
+                logger.warning("analysis.adoption_probe_failed", job_id=job_id)
+                await session.rollback()
+            if not adopted:
+                try:
+                    await session.execute(
+                        text(f'DROP TABLE IF EXISTS "{schema}"."{out_table}"')
+                    )
+                    await session.commit()
+                except Exception:  # broad: best-effort cleanup of the orphan
+                    await session.rollback()
         return
     await session.commit()
     if out_table is not None:
@@ -564,6 +634,14 @@ async def _materialize(
                     **(job.user_metadata or {}),
                     "collision_warning": collision_warning,
                 }
+            # INVARIANT: from the user_metadata/current_step assignments above
+            # to the commit after ANALYZE, every statement must stay text() —
+            # SQLAlchemy autoflushes only for ORM queries, so the dirty job
+            # row is flushed (and its row lock taken) only microseconds inside
+            # that commit. A single ORM select() added in this stretch would
+            # autoflush the dirty row and hold the job-row lock across the
+            # CTAS, blocking renew_ingest_job_heartbeat (separate session,
+            # same row) for the entire build.
             out_ref = f'"{_schema}"."{out_table}"'
 
             carry_cols = (
@@ -596,7 +674,7 @@ async def _materialize(
             # Early exit only — a table already over the ceiling must not
             # hold the single worker slot through the rewrite phases. The
             # authoritative check runs after add_4326_column below.
-            await _enforce_output_size(session, _schema, out_table)
+            await _enforce_output_size(session, _schema, out_table, operation=operation)
             # Rows with nothing to show are excluded inside the CTAS for
             # EVERY shape (fix(#786), extending fix(#719 review)'s clip
             # rule via _wrap_not_empty): buffer/centroid map NULL source
@@ -632,7 +710,7 @@ async def _materialize(
             # payload, rewrites every row, and adds the GIST index — the
             # post-CTAS probe undercounts the final footprint by a multiple,
             # so the ceiling is enforced here, on the finished relation.
-            await _enforce_output_size(session, _schema, out_table)
+            await _enforce_output_size(session, _schema, out_table, operation=operation)
             # In-transaction ANALYZE (fix(#692)): the table only becomes
             # visible to autovacuum at the commit below, and the first tile
             # queries land before its pass — without statistics the planner

--- a/backend/tests/test_analysis_materialize.py
+++ b/backend/tests/test_analysis_materialize.py
@@ -20,7 +20,10 @@ import app.core.db as core_db
 from app.modules.catalog.datasets.api import router_analysis
 from app.platform.jobs.models import IngestJob
 from app.processing.analysis.tasks import (
+    MATERIALIZE_TIMEOUT,
+    _enforce_output_size,
     _fail_cancelled_job,
+    _mark_job_failed,
     _materialize,
     _user_error_message,
 )
@@ -673,6 +676,9 @@ class TestMaterializeWorker:
         await test_db_session.refresh(job)
         assert job.status == "complete", job.error_message
         assert job.dataset_id is not None
+        # fix(v1.6.0 audit B12): the terminal write must stamp completed_at —
+        # without it the jobs UI renders '-' and retention ages on queue time.
+        assert job.completed_at is not None
         # fix(#682 review): without started_at the row carries no liveness
         # signal, so the platform's stale-job sweep (which matches on
         # coalesce(heartbeat_at, started_at)) could never recover a crashed
@@ -913,9 +919,9 @@ class TestMaterializeWorker:
         """fix(#786): _mark_job_failed is fenced like _fail_cancelled_job —
         when another actor already moved the row to a terminal state, this
         worker's later failure must not clobber the message the user saw.
-        And since the failure path cannot tell a swept row from a completed
-        one, it must leave the output table alone (the name generator
-        self-heals around the orphan, fix(#692))."""
+        fix(v1.6.0 audit B13): the failure path CAN now tell a swept row
+        from a completed one — no dataset row adopted the table here, so it
+        is a provable orphan and gets dropped instead of leaking forever."""
         import app.processing.ingest.service as ingest_service
 
         admin_id = await get_user_id(test_db_session, "admin")
@@ -952,11 +958,58 @@ class TestMaterializeWorker:
         assert job.error_message == "Stale: heartbeat lease expired"
         assert job.dataset_id is None
         assert out_tables, "materialize never reached registration"
+        # fix(v1.6.0 audit B13): the sweep never registered a dataset for the
+        # table, so the fence-missed failure path drops it as an orphan.
         left = (
             await test_db_session.execute(
                 text("SELECT to_regclass(:ref)").bindparams(
                     ref=f'data."{out_tables[0]}"'
                 )
+            )
+        ).scalar_one()
+        assert left is None
+
+    async def test_fence_missed_failure_keeps_adopted_table(
+        self,
+        test_db_session: AsyncSession,
+    ):
+        """fix(v1.6.0 audit B13): the other side of the adoption probe — a
+        final commit that reached the server before the connection dropped
+        leaves the row 'complete' with a registered dataset. The late
+        _mark_job_failed fence-misses AND finds the adopting dataset row, so
+        it must leave the table (a live dataset's storage) alone."""
+        admin_id = await get_user_id(test_db_session, "admin")
+        table_name = f"ds_{uuid.uuid4().hex[:12]}"
+        await test_db_session.execute(
+            text(f"CREATE TABLE data.{table_name} (gid SERIAL PRIMARY KEY)")
+        )
+        await test_db_session.commit()
+        await create_dataset(
+            test_db_session,
+            created_by=admin_id,
+            table_name=table_name,
+        )
+        job = await _create_job(test_db_session, admin_id)
+        job.status = "complete"
+        await test_db_session.commit()
+        assert job.attempt_id is not None
+
+        async with core_db.async_session() as session:
+            await _mark_job_failed(
+                session,
+                job_id=str(job.id),
+                attempt_id=job.attempt_id,
+                exc=RuntimeError("late failure after commit"),
+                schema="data",
+                out_table=table_name,
+                operation="centroid",
+            )
+
+        await test_db_session.refresh(job)
+        assert job.status == "complete"
+        left = (
+            await test_db_session.execute(
+                text("SELECT to_regclass(:ref)").bindparams(ref=f"data.{table_name}")
             )
         ).scalar_one()
         assert left is not None
@@ -1173,6 +1226,8 @@ class TestMaterializeWorker:
         await test_db_session.refresh(job)
         assert job.status == "failed"
         assert job.error_message
+        # fix(v1.6.0 audit B12): the failure path stamps completed_at too.
+        assert job.completed_at is not None
 
     async def test_result_dataset_is_private_and_owned_by_requester(
         self,
@@ -2056,6 +2111,29 @@ class TestMaterializeWorker:
         assert "size limit" in (job.error_message or "")
         assert job.dataset_id is None
 
+    async def test_oversized_message_advice_matches_operation(
+        self,
+        test_db_session: AsyncSession,
+    ):
+        """fix(v1.6.0 audit D11): only buffer has a distance to reduce —
+        clip/centroid/dissolve users must not be told to shrink a buffer
+        they never set."""
+        admin_id = await get_user_id(test_db_session, "admin")
+        ds = await _create_polygon_dataset(test_db_session, created_by=admin_id)
+
+        with patch("app.processing.analysis.tasks.MAX_OUTPUT_BYTES", 1):
+            with pytest.raises(ValueError) as clip_exc:
+                await _enforce_output_size(
+                    test_db_session, "data", ds.table_name, operation="clip"
+                )
+            with pytest.raises(ValueError) as buffer_exc:
+                await _enforce_output_size(
+                    test_db_session, "data", ds.table_name, operation="buffer"
+                )
+        assert "buffer" not in str(clip_exc.value)
+        assert "smaller dataset" in str(clip_exc.value)
+        assert "buffer distance" in str(buffer_exc.value)
+
     async def test_mixed_geometry_dissolve_stays_typed(
         self,
         test_db_session: AsyncSession,
@@ -2176,6 +2254,8 @@ class TestUserErrorMessage:
         )
         msg = _user_error_message(exc)
         assert "time limit" in msg
+        # fix(v1.6.0 audit D11): the message names the configured limit.
+        assert MATERIALIZE_TIMEOUT in msg
         assert "big_output" not in msg
 
     def test_domain_errors_pass_through(self):

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -1066,7 +1066,9 @@ def test_open_core_decomposition_boundaries_stay_clean() -> None:
         # fix(#526 B-044): per-layer minzoom/maxzoom in style.json export,
         # propagated to companion layers.
         # fix(#527 B-054/S-05+LB-04): symbol icon-opacity + allow-overlap parity.
-        "backend/app/modules/catalog/maps/style_json.py": 1421,
+        # fix(v1.6.0 audit): hypso_reversed flows into the color-relief
+        # companion so exported ramps match the builder's Reverse toggle.
+        "backend/app/modules/catalog/maps/style_json.py": 1431,
         "backend/app/modules/catalog/maps/style_import.py": 450,
         "backend/app/modules/catalog/maps/style_sanitizers.py": 200,
         "backend/app/modules/catalog/maps/router_assets.py": 126,

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -532,7 +532,8 @@ services:
       S3_ACCESS_KEY_ID: ${S3_ACCESS_KEY_ID:-}
       S3_SECRET_ACCESS_KEY: ${S3_SECRET_ACCESS_KEY:-}
       S3_REGION: ${S3_REGION:-us-east-1}
-      S3_ALLOW_HTTP: ${S3_ALLOW_HTTP:-false}
+      # No S3_ALLOW_HTTP here: the backup uploader (awscli) follows the scheme
+      # in S3_ENDPOINT directly; that knob only configures the app's client.
       S3_ADDRESSING_STYLE: ${S3_ADDRESSING_STYLE:-auto}
     entrypoint: ["/scripts/backup-entrypoint.sh"]
     healthcheck:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -622,7 +622,8 @@ services:
       S3_ACCESS_KEY_ID: ${S3_ACCESS_KEY_ID:-}
       S3_SECRET_ACCESS_KEY: ${S3_SECRET_ACCESS_KEY:-}
       S3_REGION: ${S3_REGION:-us-east-1}
-      S3_ALLOW_HTTP: ${S3_ALLOW_HTTP:-false}
+      # No S3_ALLOW_HTTP here: the backup uploader (awscli) follows the scheme
+      # in S3_ENDPOINT directly; that knob only configures the app's client.
       S3_ADDRESSING_STYLE: ${S3_ADDRESSING_STYLE:-auto}
     entrypoint: ["/scripts/backup-entrypoint.sh"]
     healthcheck:

--- a/e2e/builder-unified-stack.spec.ts
+++ b/e2e/builder-unified-stack.spec.ts
@@ -666,6 +666,8 @@ test.describe.serial('Builder Unified Stack UAT (Phase 1038, BSR-25 + BSR-27)', 
       const targetRow = page.locator(`#stack-row-${targetLayerId}`);
       await targetRow.hover();
       await targetRow.locator('[data-kebab-trigger]').click();
+      // "New group…" lives inside the "Add to group…" submenu (Phase 1035).
+      await page.getByTestId('kebab-add-to-group').click();
       await page.getByRole('menuitem', { name: /New group/i }).click();
       await expect(page.getByText(/^Group 1$/).first()).toBeVisible();
 

--- a/frontend/src/components/analysis/AnalysisJobWatcher.tsx
+++ b/frontend/src/components/analysis/AnalysisJobWatcher.tsx
@@ -64,6 +64,12 @@ export function AnalysisJobWatcher() {
       const datasetId = data?.dataset_id;
       const canAddToMap =
         !!analysisAddToMap.current && analysisAddToMap.mapId === job.mapId;
+      // Sonner dismisses a toast when its action is clicked, but the exit
+      // animation leaves a window for a second click — and the panel's own
+      // "Add to map" button is a second affordance for the same add. Each
+      // affordance goes single-use after its click; the add itself stays
+      // repeatable elsewhere (adding a dataset twice is legitimate).
+      let addActionUsed = false;
       toast.success(
         job.title
           ? t('analysisTools.jobCompleteNamed', {
@@ -91,6 +97,8 @@ export function AnalysisJobWatcher() {
                   ? t('analysisTools.addToMap', { defaultValue: 'Add to map' })
                   : t('analysisTools.viewDataset', { defaultValue: 'View dataset' }),
                 onClick: () => {
+                  if (addActionUsed) return;
+                  addActionUsed = true;
                   // Re-check: the builder may have unmounted since this toast
                   // was raised.
                   if (
@@ -106,6 +114,17 @@ export function AnalysisJobWatcher() {
             : undefined,
         },
       );
+      // The backend persists a collision note (e.g. the output was renamed
+      // to avoid clobbering an existing dataset) in warning_message; surface
+      // it beside the success toast, mirroring the upload path's
+      // JobProgress warning. Raw message, same as JobProgress — it is
+      // operator-facing server prose with no client-side template.
+      if (data?.warning_message) {
+        toast.warning(data.warning_message, {
+          id: `${toastId}-warning`,
+          duration: Infinity,
+        });
+      }
     } else {
       const message = data?.error_message;
       // Interpolate the detail through i18n rather than concatenating onto
@@ -118,7 +137,20 @@ export function AnalysisJobWatcher() {
               defaultValue: 'Analysis job failed: {{message}}',
             })
           : t('analysisTools.jobFailed', { defaultValue: 'Analysis job failed' }),
-        { id: toastId, duration: Infinity },
+        {
+          id: toastId,
+          duration: Infinity,
+          // Mirror the success branch's recovery action: the failure toast
+          // dead-ended with no way back to the run. Opening the map lands on
+          // the Analysis panel's remembered form — the failed run's name is
+          // deliberately kept there for the retry.
+          action: job.mapId
+            ? {
+                label: t('analysisTools.openMap', { defaultValue: 'Open map' }),
+                onClick: () => navigate(`/maps/${job.mapId}`),
+              }
+            : undefined,
+        },
       );
     }
     // fix(#793 review): the remembered form title belongs to a finished run —

--- a/frontend/src/components/analysis/__tests__/AnalysisJobWatcher.test.tsx
+++ b/frontend/src/components/analysis/__tests__/AnalysisJobWatcher.test.tsx
@@ -4,12 +4,16 @@ import { toast } from 'sonner';
 import { AnalysisJobWatcher } from '../AnalysisJobWatcher';
 import { useAnalysisFormStore } from '@/stores/analysis-form-store';
 import { analysisAddToMap, useAnalysisJobStore } from '@/stores/analysis-job-store';
+import { useAuthStore } from '@/stores/auth-store';
 import { useJobStatus } from '@/components/import/hooks/use-ingest';
 import { ApiError } from '@/api/client';
+import type { UserResponse } from '@/types/api';
 
 const navigate = vi.fn();
 vi.mock('react-router', () => ({ useNavigate: () => navigate }));
-vi.mock('sonner', () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
+vi.mock('sonner', () => ({
+  toast: { success: vi.fn(), error: vi.fn(), warning: vi.fn() },
+}));
 vi.mock('@/components/import/hooks/use-ingest', () => ({ useJobStatus: vi.fn() }));
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({
@@ -189,6 +193,101 @@ describe('AnalysisJobWatcher', () => {
     await waitFor(() => expect(toast.error).toHaveBeenCalled());
     expect(vi.mocked(toast.error).mock.calls[0][0]).toContain('no features');
     expect(useAnalysisJobStore.getState().job).toBeNull();
+  });
+
+  it('the Add to map toast action adds only once', async () => {
+    // Sonner dismisses the toast on action click, but the exit animation
+    // leaves a window for a second click — the add must not repeat.
+    const onAdd = vi.fn();
+    analysisAddToMap.current = onAdd;
+    analysisAddToMap.mapId = 'm1';
+    useAnalysisJobStore.setState({ job: { jobId: 'j1', title: 'Buffered', mapId: 'm1' } });
+    mockJob({ status: 'complete', dataset_id: 'ds9' });
+    renderWatcher();
+
+    await waitFor(() => expect(toast.success).toHaveBeenCalled());
+    const action = vi.mocked(toast.success).mock.calls[0][1]?.action as {
+      label: string;
+      onClick: () => void;
+    };
+    action.onClick();
+    action.onClick();
+    expect(onAdd).toHaveBeenCalledTimes(1);
+  });
+
+  it('surfaces the persisted warning_message beside the completion toast', async () => {
+    // The backend stores a collision note (e.g. a renamed output) in
+    // warning_message; the watcher is the only completion surface once the
+    // panel is closed, so it has to say so — mirrors JobProgress's upload
+    // warning toast.
+    useAnalysisJobStore.setState({ job: { jobId: 'j1', title: 'Buffered', mapId: 'm1' } });
+    mockJob({
+      status: 'complete',
+      dataset_id: 'ds9',
+      warning_message: 'Renamed to “Buffered (2)” to avoid a collision',
+    });
+    renderWatcher();
+
+    await waitFor(() => expect(toast.warning).toHaveBeenCalled());
+    expect(vi.mocked(toast.warning).mock.calls[0][0]).toContain('Renamed');
+    // The success toast still fires alongside it.
+    expect(toast.success).toHaveBeenCalled();
+  });
+
+  it('raises no warning toast when the job completed clean', async () => {
+    useAnalysisJobStore.setState({ job: { jobId: 'j1', title: 'Buffered', mapId: 'm1' } });
+    mockJob({ status: 'complete', dataset_id: 'ds9', warning_message: null });
+    renderWatcher();
+
+    await waitFor(() => expect(toast.success).toHaveBeenCalled());
+    expect(toast.warning).not.toHaveBeenCalled();
+  });
+
+  it('offers an Open map recovery action on the failure toast', async () => {
+    // The failure toast dead-ended with no way back to the run; the success
+    // branch has an action, so the failure branch mirrors it. The remembered
+    // form keeps the failed run's name for the retry.
+    useAnalysisJobStore.setState({ job: { jobId: 'j1', title: 'Buffered', mapId: 'm1' } });
+    mockJob({ status: 'failed', dataset_id: null, error_message: 'no features' });
+    renderWatcher();
+
+    await waitFor(() => expect(toast.error).toHaveBeenCalled());
+    const options = vi.mocked(toast.error).mock.calls[0][1] as {
+      action?: { label: string; onClick: () => void };
+    };
+    expect(options.action?.label).toBe('Open map');
+    options.action?.onClick();
+    expect(navigate).toHaveBeenCalledWith('/maps/m1');
+  });
+
+  it('omits the recovery action when the failed job has no map', async () => {
+    useAnalysisJobStore.setState({ job: { jobId: 'j1', title: 'Buffered', mapId: null } });
+    mockJob({ status: 'failed', dataset_id: null, error_message: 'no features' });
+    renderWatcher();
+
+    await waitFor(() => expect(toast.error).toHaveBeenCalled());
+    const options = vi.mocked(toast.error).mock.calls[0][1] as {
+      action?: { label: string; onClick: () => void };
+    };
+    expect(options.action).toBeUndefined();
+  });
+
+  it('clears the tracked job when the signed-in user changes', () => {
+    // The store persists across reloads, so without the identity guard the
+    // next account on this browser inherits the previous user's run.
+    useAuthStore.setState({ user: { id: 'u1' } as UserResponse });
+    useAnalysisJobStore.setState({ job: { jobId: 'j1', title: 'x', mapId: null } });
+    useAuthStore.setState({ user: { id: 'u2' } as UserResponse });
+    expect(useAnalysisJobStore.getState().job).toBeNull();
+  });
+
+  it('keeps the tracked job through a token rotation for the same user', () => {
+    // Keyed on user identity, not token — refresh-token rotation must not
+    // drop a job mid-run.
+    useAuthStore.setState({ user: { id: 'u1' } as UserResponse, token: 't1' });
+    useAnalysisJobStore.setState({ job: { jobId: 'j1', title: 'x', mapId: null } });
+    useAuthStore.setState({ token: 't2' });
+    expect(useAnalysisJobStore.getState().job).not.toBeNull();
   });
 
   it('stops tracking a job that is gone instead of polling forever', async () => {

--- a/frontend/src/components/builder/AnalysisPanel.tsx
+++ b/frontend/src/components/builder/AnalysisPanel.tsx
@@ -45,6 +45,14 @@ const POLYGONAL_GEOMETRY_TYPES = new Set(['POLYGON', 'MULTIPOLYGON']);
 // user thinking in feet or miles doesn't have to.
 const BUFFER_UNIT_METERS = { m: 1, km: 1000, ft: 0.3048, mi: 1609.344 } as const;
 type BufferUnit = keyof typeof BUFFER_UNIT_METERS;
+// fix(#773 follow-up): the cap expressed in a display unit, floored to two
+// decimals so the STATED maximum is itself a legal value. Rounding to nearest
+// overstated it — 100 000 m in feet displayed as 328,083.99 ft, which
+// converts back to 100 000.0005 m, over the cap, making the panel's own
+// stated maximum unattainable. Flooring keeps it attainable in every unit
+// (100 000 m and 100 km are exact; feet and miles floor slightly short).
+const maxBufferInUnit = (unit: BufferUnit): number =>
+  Math.floor((MAX_BUFFER_METERS / BUFFER_UNIT_METERS[unit]) * 100) / 100;
 // ux(#773): switching the unit converts the displayed number so the PHYSICAL
 // distance is preserved — "100 m" becomes "0.1 km", not a silent 1000×
 // reinterpretation. Rounded to 6 significant digits to trim float tails
@@ -60,7 +68,18 @@ const convertDistanceBetweenUnits = (
   // An empty or unparseable field has no physical distance to preserve.
   if (raw.trim() === '' || !Number.isFinite(value)) return raw;
   const converted = (value * BUFFER_UNIT_METERS[from]) / BUFFER_UNIT_METERS[to];
-  return String(Number(converted.toPrecision(6)));
+  let rounded = Number(converted.toPrecision(6));
+  // fix(#773 follow-up): a legal value must stay legal across a unit switch.
+  // 100 000 m rounded to 6 digits became 328 084 ft, which the panel then
+  // flagged invalid against its own cap. Round DOWN to the cap in the target
+  // unit instead of letting the significant-digit rounding step over it.
+  if (
+    value * BUFFER_UNIT_METERS[from] <= MAX_BUFFER_METERS &&
+    rounded * BUFFER_UNIT_METERS[to] > MAX_BUFFER_METERS
+  ) {
+    rounded = maxBufferInUnit(to);
+  }
+  return String(rounded);
 };
 // Suffixes of the existing analysisTools.unit* keys, so the range message can
 // name the unit in the user's language without a second set of strings.
@@ -269,6 +288,13 @@ export function AnalysisPanel({
       ? tracked.title
       : '';
   });
+  // A completed run raises TWO "Add to map" affordances (this button and the
+  // watcher's toast action) and both added — mark this one used after its
+  // click so a second click can't add the layer twice. Keyed on the dataset
+  // id, so a NEW run's completion re-enables it. Deliberately local: adding
+  // a dataset twice via other surfaces is legitimate, so no global
+  // idempotency in onAddDataset.
+  const [addedDatasetId, setAddedDatasetId] = useState<string | null>(null);
   // fix(#793 review): a materialize can outlive the panel instance that
   // started it — closed during the POST, reopened before the response lands.
   // The mount-time initializers above see no tracked job yet, so a job that
@@ -397,8 +423,13 @@ export function AnalysisPanel({
     if (restoredMaskDrawnRef.current) return;
     const map = mapInstanceRef?.current;
     if (!mask || !map || drawRef.current) return;
-    restoredMaskDrawnRef.current = true;
     addStaticMaskOverlay(map, mask);
+    // Latch AFTER the attempt, and only on success (the overlay helper
+    // assigns drawRef when it fully starts, and resets it to null on
+    // failure) — latching before the attempt made a failed overlay
+    // permanent: the mask applied but never became visible, with no retry.
+    // Mirrors use-ephemeral-layers' retry-until-attached idiom.
+    if (drawRef.current) restoredMaskDrawnRef.current = true;
     // No dep array (fix(#793 review)): the map arrives by REF assignment —
     // no dep ever changes — but the lazy BuilderMap's load re-renders the
     // parent, so retrying every commit reaches the moment the map exists;
@@ -497,6 +528,24 @@ export function AnalysisPanel({
     drawRef.current = null;
     setIsDrawing(false);
   }, []);
+
+  // Starting a draw swaps the Draw button for Cancel, which dropped focus to
+  // <body> — keyboard users lost their place, and the Escape-cancels-draw
+  // handler below never received the keystroke. Follow the swap in both
+  // directions: onto Cancel when drawing starts, back onto Draw (or Clear,
+  // when finishing the polygon replaced Draw with the mask row) when it ends.
+  const drawButtonRef = useRef<HTMLButtonElement | null>(null);
+  const cancelDrawButtonRef = useRef<HTMLButtonElement | null>(null);
+  const clearMaskButtonRef = useRef<HTMLButtonElement | null>(null);
+  const wasDrawingRef = useRef(false);
+  useEffect(() => {
+    if (isDrawing) {
+      cancelDrawButtonRef.current?.focus();
+    } else if (wasDrawingRef.current) {
+      (drawButtonRef.current ?? clearMaskButtonRef.current)?.focus();
+    }
+    wasDrawingRef.current = isDrawing;
+  }, [isDrawing]);
 
   // fix(#758): a preview belongs to the inputs that produced it. Every input
   // change bumps the sequence (so an in-flight response knows it has been
@@ -618,7 +667,9 @@ export function AnalysisPanel({
 
   // The API takes metres; the input is whatever unit the user picked.
   const distanceValue = Number(distance) * BUFFER_UNIT_METERS[distanceUnit];
-  const distanceMaxInUnit = MAX_BUFFER_METERS / BUFFER_UNIT_METERS[distanceUnit];
+  // fix(#773 follow-up): same floor as the unit-switch clamp, so the stated
+  // maximum is attainable — see maxBufferInUnit.
+  const distanceMaxInUnit = maxBufferInUnit(distanceUnit);
   // fix(#700 review): materialize requires the upload permission server-side
   // (it creates a dataset); hide the creation half for viewer roles instead
   // of letting them fill the form into a guaranteed 403. Preview stays.
@@ -795,6 +846,15 @@ export function AnalysisPanel({
     !analysisJobRunning &&
     paramsValid &&
     outputTitle.trim().length > 0;
+  // Create dataset went disabled with no reason: the role="status" region
+  // below explains only the job case. A validation reason lives in this
+  // STATIC hint instead (pointed at via aria-describedby) — putting it in
+  // the polite live region would narrate every keystroke.
+  const saveBlockedReason = !outputTitle.trim()
+    ? ('name' as const)
+    : !paramsValid
+      ? ('params' as const)
+      : null;
 
   if (datasetLayers.length === 0) {
     return (
@@ -807,9 +867,30 @@ export function AnalysisPanel({
   }
 
   return (
-    <div
+    // A <form> so Enter in any field runs Preview — the panel had no submit
+    // path at all. Every non-submit button below carries an explicit
+    // type="button" so it doesn't trigger this instead.
+    // eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions -- container-level Escape shortcut for keystrokes bubbling from the panel's own interactive children (cancels a pending draw, BuilderRail precedent); the form itself stays non-interactive
+    <form
       className="flex h-full flex-col gap-3 overflow-y-auto p-3.5"
       data-testid="analysis-panel"
+      // The panel renders its own range message (#723); native constraint
+      // bubbles on the number input would double up with it.
+      noValidate
+      onSubmit={(e) => {
+        e.preventDefault();
+        if (canRun) previewMutation.mutate({ seq: previewSeqRef.current });
+      }}
+      onKeyDown={(e) => {
+        // Escape while a clip-mask draw is pending cancels the DRAW, not the
+        // panel: BuilderRail's container Escape handler guards on
+        // !e.defaultPrevented, so this preventDefault is what keeps the whole
+        // Analysis panel (and the in-progress mask) from being torn down.
+        if (e.key === 'Escape' && isDrawing) {
+          e.preventDefault();
+          stopDrawing();
+        }
+      }}
     >
       <div className="space-y-1.5">
         <Label className="text-xs" htmlFor="analysis-layer">
@@ -1032,6 +1113,8 @@ export function AnalysisPanel({
                 })}
               </p>
               <Button
+                ref={cancelDrawButtonRef}
+                type="button"
                 variant="outline"
                 size="sm"
                 onClick={stopDrawing}
@@ -1045,6 +1128,8 @@ export function AnalysisPanel({
                 {t('analysisTools.maskSet', { defaultValue: 'Clip area set' })}
               </span>
               <Button
+                ref={clearMaskButtonRef}
+                type="button"
                 variant="ghost"
                 size="sm"
                 onClick={() => {
@@ -1061,6 +1146,8 @@ export function AnalysisPanel({
           ) : (
             <div className="space-y-1.5">
               <Button
+                ref={drawButtonRef}
+                type="button"
                 variant="outline"
                 size="sm"
                 onClick={startDrawing}
@@ -1130,8 +1217,10 @@ export function AnalysisPanel({
 
       <div className="mt-auto flex flex-col gap-2 pt-1">
         {operation !== 'dissolve' && (
+          // The form's submit button — Enter in any field previews too.
           <Button
-            onClick={() => previewMutation.mutate({ seq: previewSeqRef.current })}
+            type="submit"
+            aria-busy={previewMutation.isPending || undefined}
             disabled={!canRun}
           >
             {previewMutation.isPending
@@ -1140,7 +1229,7 @@ export function AnalysisPanel({
           </Button>
         )}
         {hasPreview && (
-          <Button variant="outline" onClick={onClearPreview}>
+          <Button type="button" variant="outline" onClick={onClearPreview}>
             {t('analysisTools.clearPreview', { defaultValue: 'Clear preview' })}
           </Button>
         )}
@@ -1173,8 +1262,13 @@ export function AnalysisPanel({
               })}
             />
             <Button
+              type="button"
               variant="secondary"
               className="w-full"
+              aria-busy={materializeMutation.isPending || undefined}
+              // The validation hint below says WHY this is disabled; the
+              // job cases are narrated by the status region instead.
+              aria-describedby={saveBlockedReason ? 'analysis-save-hint' : undefined}
               onClick={() => {
                 // fix(#682 review): reset only this panel's local status line.
                 // Clearing the GLOBAL tracking here would orphan a job that is
@@ -1190,6 +1284,21 @@ export function AnalysisPanel({
                 ? t('analysisTools.saving', { defaultValue: 'Creating…' })
                 : t('analysisTools.saveButton', { defaultValue: 'Create dataset' })}
             </Button>
+            {/* Static hint, deliberately NOT in the role="status" region —
+                a polite live region would narrate it on every keystroke. */}
+            {saveBlockedReason && (
+              <p id="analysis-save-hint" className="text-xs text-muted-foreground">
+                {saveBlockedReason === 'name'
+                  ? t('analysisTools.saveHintNeedsName', {
+                      defaultValue:
+                        'Enter a name for the new dataset to enable Create dataset.',
+                    })
+                  : t('analysisTools.saveHintNeedsParams', {
+                      defaultValue:
+                        'Complete the operation settings above to enable Create dataset.',
+                    })}
+              </p>
+            )}
             {/* fix(#784): one PERSISTENT status region, mounted empty with the
                 form — a live region that mounts already populated is not
                 announced, so the previous conditionally-rendered <p>s kept the
@@ -1200,7 +1309,17 @@ export function AnalysisPanel({
                 primary control unexplained (covers a job started before a
                 reload or from another panel). */}
             <p className="text-xs text-muted-foreground" role="status">
-              {analysisJobRunning && !job
+              {/* "Another analysis" means a FOREIGN job only. The panel's own
+                  run passes through two tracked-but-not-yet-observed gaps —
+                  mutationFn (onAnalysisJobChange) → onSuccess (setJobId), and
+                  setJobId → the first poll response — during which the store
+                  holds OUR job while `job` is still empty; announcing then
+                  was a false warning. Guarding on isPending alone would still
+                  leave the second gap open. */}
+              {analysisJobRunning &&
+              !job &&
+              jobId == null &&
+              !materializeMutation.isPending
                 ? t('analysisTools.anotherJobRunning', {
                     defaultValue:
                       'Another analysis is still running — wait for it to finish.',
@@ -1235,24 +1354,35 @@ export function AnalysisPanel({
             </p>
             {job?.status === 'complete' && !!job.dataset_id && layerActions && (
               <Button
+                type="button"
                 variant="outline"
                 size="sm"
                 className="w-full"
-                onClick={() => job.dataset_id && layerActions.onAddDataset(job.dataset_id)}
+                // Completion raises this button AND the watcher's toast
+                // action, and both added — mark this one used after its
+                // click. See addedDatasetId.
+                disabled={addedDatasetId === job.dataset_id}
+                onClick={() => {
+                  if (!job.dataset_id) return;
+                  layerActions.onAddDataset(job.dataset_id);
+                  setAddedDatasetId(job.dataset_id);
+                }}
               >
                 {/* fix(#764): name the dataset this adds — after a rail
                     round-trip or reload the field above may no longer say. */}
-                {lastRunTitle
-                  ? t('analysisTools.addToMapNamed', {
-                      defaultValue: 'Add "{{name}}" to map',
-                      name: lastRunTitle,
-                    })
-                  : t('analysisTools.addToMap', { defaultValue: 'Add to map' })}
+                {addedDatasetId === job.dataset_id
+                  ? t('analysisTools.addedToMap', { defaultValue: 'Added to map' })
+                  : lastRunTitle
+                    ? t('analysisTools.addToMapNamed', {
+                        defaultValue: 'Add "{{name}}" to map',
+                        name: lastRunTitle,
+                      })
+                    : t('analysisTools.addToMap', { defaultValue: 'Add to map' })}
               </Button>
             )}
           </div>
         )}
       </div>
-    </div>
+    </form>
   );
 }

--- a/frontend/src/components/builder/BasemapGroupRow.tsx
+++ b/frontend/src/components/builder/BasemapGroupRow.tsx
@@ -102,6 +102,11 @@ export const BasemapGroupRow = memo(function BasemapGroupRow({
         // honor the multi-selection boundary, matching the visual signal.
         if (isMultiSelectionActive) return;
         if (kebabMenu.handleContextMenuKey(e)) return;
+        // a11y(v1.6.0 audit A7, WCAG 2.1.1): Enter on the caret or eye was
+        // dead — the container preventDefaulted descendant keys and cancelled
+        // native button activation. Only handle keys aimed at the row itself;
+        // AFTER the context-menu branch so Shift+F10 works from descendants.
+        if (e.target !== e.currentTarget) return;
         if (e.key === 'Enter' || e.key === ' ') {
           e.preventDefault();
           onSelectGroup(groupId);

--- a/frontend/src/components/builder/BasemapGroupRowWrapper.tsx
+++ b/frontend/src/components/builder/BasemapGroupRowWrapper.tsx
@@ -1,6 +1,6 @@
 // builder-audit #338 STACK-05: extracted from UnifiedStackPanel.tsx into a sibling
 // file. Sortable wrapper for the basemap group row.
-import { memo, useCallback } from 'react';
+import { memo, useCallback, useMemo } from 'react';
 import { useDndContext } from '@dnd-kit/core';
 import { useSortable } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
@@ -91,6 +91,13 @@ export const BasemapGroupRowWrapper = memo(function BasemapGroupRowWrapper({
     [onSelectGroup],
   );
 
+  // fix(v1.6.0 audit D7): a fresh object literal here re-broke the row memo on
+  // every wrapper render even when the drag state was unchanged.
+  const dragHandleProps = useMemo(
+    () => ({ attributes, listeners, setActivatorNodeRef }),
+    [attributes, listeners, setActivatorNodeRef],
+  );
+
   return (
     <div
       ref={setNodeRef}
@@ -106,7 +113,7 @@ export const BasemapGroupRowWrapper = memo(function BasemapGroupRowWrapper({
         selected={selected}
         isExpanded={isExpanded}
         isDragging={isDragging}
-        dragHandleProps={{ attributes, listeners, setActivatorNodeRef }}
+        dragHandleProps={dragHandleProps}
         onSelectGroup={handleSelectGroup}
         onToggleExpand={onToggleExpand}
         onToggleVisibility={onToggleVisibility}

--- a/frontend/src/components/builder/BasemapSublayerEditorScene.tsx
+++ b/frontend/src/components/builder/BasemapSublayerEditorScene.tsx
@@ -201,7 +201,9 @@ export function BasemapSublayerEditorScene({
                 step={0.5}
                 value={minZoom ?? 0}
                 onChange={(e) => {
-                  const v = Number(e.target.value);
+                  // Number('') === 0 is finite — clearing the field must reset
+                  // the clamp (0), not pass through as an accidental bound.
+                  const v = e.target.value === '' ? 0 : Number(e.target.value);
                   if (!Number.isFinite(v)) return;
                   onMinZoomChange?.(Math.min(24, Math.max(0, v)));
                 }}
@@ -221,7 +223,9 @@ export function BasemapSublayerEditorScene({
                 step={0.5}
                 value={maxZoom ?? 22}
                 onChange={(e) => {
-                  const v = Number(e.target.value);
+                  // Number('') === 0 is finite — clearing max-zoom used to write
+                  // 0 and hide the sublayer at every zoom. Empty resets the clamp.
+                  const v = e.target.value === '' ? 22 : Number(e.target.value);
                   if (!Number.isFinite(v)) return;
                   onMaxZoomChange?.(Math.min(24, Math.max(0, v)));
                 }}

--- a/frontend/src/components/builder/BuilderDialogs.tsx
+++ b/frontend/src/components/builder/BuilderDialogs.tsx
@@ -172,7 +172,16 @@ export function BuilderDialogs({
       {/* Unsaved changes leave warning.
           ux(#777): a modal AlertDialog with the canonical Cancel-then-Action
           footer, matching the DatasetPage / AdminSettingsPage navigation guards
-          — was a dismissible Dialog with a hand-rolled footer. */}
+          — was a dismissible Dialog with a hand-rolled footer.
+          Note on the blocker callbacks: AlertDialogAction/Cancel ALSO close
+          the dialog, so every click double-invokes — the button's own handler
+          runs, then the close fires onOpenChange, which calls reset again
+          (proceed→reset, or reset→reset). Verified benign with react-router
+          7.18.1: proceed() re-checks the blocker synchronously, so by the
+          time the trailing reset() runs the blocker is no longer 'blocked'
+          and reset() is a no-op that cannot throw. Don't "fix" the
+          double-invoke by dropping onOpenChange — Escape/overlay dismissal
+          needs it to reset the blocker. */}
       <AlertDialog open={blockerState === 'blocked'} onOpenChange={() => onBlockerReset?.()}>
         <AlertDialogContent size="sm">
           <AlertDialogHeader>

--- a/frontend/src/components/builder/BuilderMap.tsx
+++ b/frontend/src/components/builder/BuilderMap.tsx
@@ -251,6 +251,11 @@ export const BuilderMap = memo(function BuilderMap({
   const tilesIdleIdleHandlerRef = useRef<(() => void) | null>(null);
   // SF-08: latch first-load success so transient 5xx during save don't surface as outage
   const basemapLoadedAtRef = useRef<number | null>(null);
+  // audit(w3-maps): true when a 5xx/unknown tile error fired since the last
+  // 'dataloading'. Lets the idle handler clear the 'tiles' basemap notice
+  // only after a clean load cycle — the notice previously latched for the
+  // whole session because nothing ever reset it.
+  const sawTileErrorSinceLoadingRef = useRef(false);
   const lastOrderKeyRef = useRef('');
   const [mapReady, setMapReady] = useState(false);
   // Phase 1051 WR-04: state mirror of mapRef.current so MapCoordReadout consumes
@@ -625,8 +630,21 @@ export const BuilderMap = memo(function BuilderMap({
 
       // Tile loading indicator. builder-audit #338 SYNC-08: keep references so the
       // unmount cleanup can detach them symmetrically.
-      dataLoadingHandlerRef.current = () => setTilesLoading(true);
-      idleHandlerRef.current = () => setTilesLoading(false);
+      dataLoadingHandlerRef.current = () => {
+        setTilesLoading(true);
+        sawTileErrorSinceLoadingRef.current = false;
+      };
+      idleHandlerRef.current = () => {
+        setTilesLoading(false);
+        // audit(w3-maps): a load cycle finished without a hard tile error —
+        // the 'tiles' notice's condition has passed, so clear it (the 'style'
+        // notice has its own clearing path in the style-fetch effect). During
+        // an ongoing outage the errors that precede idle re-arm the flag, so
+        // the banner does not flap.
+        if (!sawTileErrorSinceLoadingRef.current) {
+          setBasemapNotice((notice) => (notice === 'tiles' ? null : notice));
+        }
+      };
       map.on('dataloading', dataLoadingHandlerRef.current);
       map.on('idle', idleHandlerRef.current);
 
@@ -719,6 +737,7 @@ export const BuilderMap = memo(function BuilderMap({
           // masking ongoing outages.
           const loadedAt = basemapLoadedAtRef.current;
           if (loadedAt !== null && Date.now() - loadedAt < 3000) return;
+          sawTileErrorSinceLoadingRef.current = true;
           setBasemapNotice('tiles');
           // Name the failing layer when the error carries a sourceId.
           // MapLibre attaches the source id to tile/source errors as they
@@ -937,6 +956,28 @@ export const BuilderMap = memo(function BuilderMap({
       return null;
     };
 
+    // Shared by mouse click and the keyboard handler below so keyboard users
+    // get the same non-cluster feature popups as mouse users.
+    const mapFeatureHits = (hits: ReturnType<MaplibreMap['queryRenderedFeatures']>): FeatureInfo[] => {
+      const mapped: FeatureInfo[] = [];
+      for (const feature of hits) {
+        const hit = lookupHitLayer(feature.layer.id);
+        if (!hit) continue;
+        const layer = hit.layer;
+        const cfg = hit.layer.popup_config;
+        const props = (feature.properties ?? {}) as Record<string, unknown>;
+        mapped.push({
+          properties: props,
+          layerName: layer.display_name || layer.dataset_name || fallbackName,
+          columnInfo: layer.dataset_column_info ?? null,
+          title: cfg?.expression ? substitutePopupTemplate(cfg.expression, props) : null,
+          visibleFields: cfg?.visible_fields ?? null,
+          zoomAtClick: map.getZoom(),
+        });
+      }
+      return mapped;
+    };
+
     const handleClick = (e: MapMouseEvent) => {
       if (!map.isStyleLoaded()) return;
       if (measureActiveRef.current || drawActiveRef.current) return;
@@ -954,22 +995,7 @@ export const BuilderMap = memo(function BuilderMap({
         return;
       }
 
-      const mapped: FeatureInfo[] = [];
-      for (const feature of hits) {
-        const hit = lookupHitLayer(feature.layer.id);
-        if (!hit) continue;
-        const layer = hit.layer;
-        const cfg = hit.layer.popup_config;
-        const props = (feature.properties ?? {}) as Record<string, unknown>;
-        mapped.push({
-          properties: props,
-          layerName: layer.display_name || layer.dataset_name || fallbackName,
-          columnInfo: layer.dataset_column_info ?? null,
-          title: cfg?.expression ? substitutePopupTemplate(cfg.expression, props) : null,
-          visibleFields: cfg?.visible_fields ?? null,
-          zoomAtClick: map.getZoom(),
-        });
-      }
+      const mapped = mapFeatureHits(hits);
 
       if (mapped.length > 0) {
         setPopupInfo({
@@ -1035,9 +1061,25 @@ export const BuilderMap = memo(function BuilderMap({
       ];
       const hits = map.queryRenderedFeatures(point, { layers: queryLayers });
       const clusterHit = findClusterHit(hits);
-      if (!clusterHit) return;
+      if (clusterHit) {
+        event.preventDefault();
+        handleClusterHit(clusterHit.feature, clusterHit.hit, null);
+        return;
+      }
+      // audit(w3-maps): the popup was mouse-only for non-cluster features —
+      // the early return above made Enter/Space a no-op unless the
+      // centre-of-canvas hit happened to be a cluster. Mirror handleClick's
+      // mapping so keyboard users can open the same feature popup.
+      const mapped = mapFeatureHits(hits);
+      if (mapped.length === 0) return;
       event.preventDefault();
-      handleClusterHit(clusterHit.feature, clusterHit.hit, null);
+      const lngLat = map.unproject(point);
+      setPopupInfo({
+        longitude: lngLat.lng,
+        latitude: lngLat.lat,
+        features: mapped,
+      });
+      onFeatureSelect?.(mapped[0]);
     };
 
     map.on('click', handleClick);

--- a/frontend/src/components/builder/BuilderMap.tsx
+++ b/frontend/src/components/builder/BuilderMap.tsx
@@ -1350,6 +1350,12 @@ export const BuilderMap = memo(function BuilderMap({
   return (
     <div
       className="relative h-full w-full"
+      // audit(w3-maps): aria-label on <MapGL> is silently dropped —
+      // @vis.gl/react-maplibre v8 forwards only id/ref/style, and MapLibre
+      // labels its canvas "Map". Label the wrapper region instead (same
+      // pattern as DatasetMap's shell).
+      role="region"
+      aria-label={t('map.ariaLabel', { defaultValue: 'Map builder' })}
       data-tiles-loaded={tilesIdle ? 'true' : 'false'}
       // RESP-02-FOLLOWUP (Phase 1051): marker consumed by the
       // `[data-builder-canvas="true"] .maplibregl-ctrl-top-left` rule in
@@ -1394,7 +1400,6 @@ export const BuilderMap = memo(function BuilderMap({
         // tile-auth 401/403 (GUARD-03 re-sign / #621 re-mint in handleLoad's
         // error handler) stops double-logging a red AJAXError console row.
         onError={logUnhandledMapError}
-        aria-label={t('map.ariaLabel', { defaultValue: 'Map builder' })}
       >
         {/* RESP-01 (Phase 1051): NavigationControl anchored top-left so it does not
             collide with the right-side BuilderRail (Notes/History/Ask AI buttons) at

--- a/frontend/src/components/builder/BuilderRail.tsx
+++ b/frontend/src/components/builder/BuilderRail.tsx
@@ -31,14 +31,11 @@ function AIDisabledState() {
   const { reason, isLoading } = useAIAvailability();
   const isAdmin = useAuthStore((s) => s.isAdmin());
 
-  // Loading or indeterminate — render spinner only
-  if (isLoading || reason === null) {
-    return (
-      <div className="flex h-full flex-col items-center justify-center p-6" role="status" aria-live="polite">
-        <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />
-      </div>
-    );
-  }
+  // fix(#788 follow-up): one persistent live region whose CONTENT toggles —
+  // the loading spinner and the disabled-state message used to be two
+  // conditionally-mounted role="status" regions, so the message often
+  // appeared pre-populated and was never announced.
+  const loading = isLoading || reason === null;
 
   const titleKey = reason === 'env_disabled' ? ('rail.aiDisabledTitle' as const)
     : reason === 'no_key' ? ('rail.aiNoKeyTitle' as const)
@@ -67,15 +64,21 @@ function AIDisabledState() {
       className="flex h-full flex-col items-center justify-center gap-3 p-6 text-sm"
       role="status"
       aria-live="polite"
-      data-ai-reason={reason}
+      data-ai-reason={loading ? undefined : reason}
     >
-      <BotOff className="h-8 w-8 text-muted-foreground" aria-hidden="true" />
-      <p className="text-sm font-medium text-foreground">{t(titleKey, { defaultValue: titleDefault })}</p>
-      <p className="text-sm text-muted-foreground text-center max-w-[18rem]">{t(bodyKey, { defaultValue: bodyDefault })}</p>
-      {showCTA && (
-        <Button variant="outline" size="sm" asChild>
-          <Link to="/admin/settings?tab=ai">{t(ctaKey!, { defaultValue: ctaDefault })}</Link>
-        </Button>
+      {loading ? (
+        <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />
+      ) : (
+        <>
+          <BotOff className="h-8 w-8 text-muted-foreground" aria-hidden="true" />
+          <p className="text-sm font-medium text-foreground">{t(titleKey, { defaultValue: titleDefault })}</p>
+          <p className="text-sm text-muted-foreground text-center max-w-[18rem]">{t(bodyKey, { defaultValue: bodyDefault })}</p>
+          {showCTA && (
+            <Button variant="outline" size="sm" asChild>
+              <Link to="/admin/settings?tab=ai">{t(ctaKey!, { defaultValue: ctaDefault })}</Link>
+            </Button>
+          )}
+        </>
       )}
     </div>
   );
@@ -158,7 +161,16 @@ export function BuilderRail({
   const analysisJobRunning = useAnalysisJobStore((s) => !!s.job);
 
   const togglePanel = useCallback((panel: RailPanel) => {
-    onPanelChange(activePanel === panel ? null : panel);
+    const next = activePanel === panel ? null : panel;
+    onPanelChange(next);
+    // Opening counterpart to closePanel's focus restore below: move keyboard
+    // focus into the freshly-mounted panel (rAF — it doesn't exist yet this
+    // tick), so rail-button activation doesn't leave focus stranded on the rail.
+    if (next) {
+      requestAnimationFrame(() => {
+        document.querySelector<HTMLElement>('[data-rail-panel]')?.focus();
+      });
+    }
   }, [activePanel, onPanelChange]);
 
   // fix(#783): closing the panel unmounts the aside containing the focused
@@ -229,7 +241,15 @@ export function BuilderRail({
               disabled={btn.disabled}
               data-unavailable={btn.unavailable || undefined}
               title={btn.label}
-              aria-label={btn.label}
+              // MAP-22 rework: the notes-presence state lives in the BUTTON's
+              // accessible name — aria-label replaces the subtree, so a label
+              // on the dot span was never exposed (and aria-label on a
+              // role-less span is invalid ARIA anyway).
+              aria-label={
+                btn.id === 'notes' && notes.trim().length > 0
+                  ? t('rail.notesButtonWithNotes', { defaultValue: 'Notes (map has notes)' })
+                  : btn.label
+              }
               aria-pressed={activePanel === btn.id}
               // feat(#682): the only ambient signal that a materialize job is
               // still running once the panel is closed — the completion toast
@@ -251,11 +271,12 @@ export function BuilderRail({
                 <btn.icon className="h-4 w-4" />
               )}
               {/* MAP-22: presence dot — non-whitespace notes render a 6px primary-color dot
-                  at the button's top-right corner. aria-label keeps the dot accessible.
+                  at the button's top-right corner. Purely decorative: the state is
+                  announced via the button's conditional aria-label above.
                   No animation (static state indicator per UI-SPEC). */}
               {btn.id === 'notes' && notes.trim().length > 0 && (
                 <span
-                  aria-label={t('rail.notesPresent', { defaultValue: 'Map has notes' })}
+                  aria-hidden="true"
                   className="absolute -top-0.5 -end-0.5 size-1.5 rounded-full bg-primary"
                 />
               )}
@@ -271,8 +292,11 @@ export function BuilderRail({
           // fix(#788 item 5): named landmark — the panel takes its accessible
           // name from its own title, distinguishing it from the icon rail.
           aria-labelledby="builder-rail-panel-title"
+          // togglePanel focuses the panel on open (see above).
+          data-rail-panel=""
+          tabIndex={-1}
           className={cn(
-            'bg-background border-s flex h-full min-h-0 flex-col shrink-0 overflow-hidden',
+            'bg-background border-s flex h-full min-h-0 flex-col shrink-0 overflow-hidden focus:outline-none',
             showRail ? 'w-80' : 'w-full border-s-0',
           )}
           onKeyDown={(e) => {

--- a/frontend/src/components/builder/BulkActionBar.tsx
+++ b/frontend/src/components/builder/BulkActionBar.tsx
@@ -1,4 +1,4 @@
-import { memo, useState, useMemo, useEffect, useId } from 'react';
+import { memo, useState, useMemo, useEffect, useId, useRef, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Eye, EyeOff, FolderPlus, FolderMinus, Loader2, Paintbrush, Trash2, MoreHorizontal } from 'lucide-react';
 import { Button } from '@/components/ui/button';
@@ -37,6 +37,12 @@ export interface BulkActionBarProps {
   /** Phase 1047-04 (PERF-03): true while bulk-delete HTTP call is in flight.
    *  Swaps Trash2 → Loader2, disables the Delete button, sets aria-busy. */
   isDeleting?: boolean;
+  /** fix(v1.6.0 audit A5): count of layers in the in-flight delete batch, captured
+   *  synchronously in the hook BEFORE the optimistic removal. The optimistic
+   *  setLocalLayers empties the selection-derived deletableCount in the same
+   *  commit that sets isDeleting, so deriving the deleting label from props
+   *  here would announce "Deleting 0 layers…". */
+  deletingCount?: number;
 }
 
 // ---------------------------------------------------------------------------
@@ -60,11 +66,48 @@ export const BulkActionBar = memo(function BulkActionBar({
   onBulkDelete,
   onBulkApplyStyle,
   isDeleting = false,
+  deletingCount,
 }: BulkActionBarProps) {
   const { t } = useTranslation('builder');
   const [confirmingDelete, setConfirmingDelete] = useState(false);
   const [mounted, setMounted] = useState(false);
   const confirmId = useId();
+  const barRef = useRef<HTMLDivElement>(null);
+  const confirmRef = useRef<HTMLDivElement>(null);
+
+  // fix(v1.6.0 audit A3): every exit path out of the inline delete-confirm must
+  // hand focus somewhere stable instead of dropping it on <body>. The
+  // pre-confirm trigger (the overflow-menu Delete item) unmounts on confirm, so
+  // restore to the first remaining enabled control in the bar, else the bar
+  // itself (tabIndex={-1} below makes it focusable as the last resort).
+  // Mirrors the row-chrome.tsx InlineDeleteConfirm cancel-path restore.
+  const restoreFocusToBar = useCallback(() => {
+    requestAnimationFrame(() => {
+      const bar = barRef.current;
+      if (!bar) return;
+      const first = bar.querySelector<HTMLElement>('button:not([disabled])');
+      (first ?? bar).focus();
+    });
+  }, []);
+
+  // fix(v1.6.0 audit A3): minimal focus trap for the aria-modal confirm — Tab
+  // and Shift+Tab cycle between Cancel and the destructive action.
+  const handleConfirmKeyDown = useCallback((e: React.KeyboardEvent<HTMLDivElement>) => {
+    if (e.key !== 'Tab') return;
+    const root = confirmRef.current;
+    if (!root) return;
+    const focusables = Array.from(root.querySelectorAll<HTMLElement>('button:not([disabled])'));
+    if (focusables.length === 0) return;
+    const first = focusables[0];
+    const last = focusables[focusables.length - 1];
+    if (e.shiftKey && document.activeElement === first) {
+      e.preventDefault();
+      last.focus();
+    } else if (!e.shiftKey && document.activeElement === last) {
+      e.preventDefault();
+      first.focus();
+    }
+  }, []);
 
   // Mount animation: initial state → rAF flip to mounted state (translate-y + opacity)
   useEffect(() => {
@@ -129,11 +172,20 @@ export const BulkActionBar = memo(function BulkActionBar({
     if (e.key === 'Escape' && confirmingDelete) {
       e.stopPropagation();
       setConfirmingDelete(false);
+      // fix(v1.6.0 audit A3): Escape closed a focus-owning confirm — restore.
+      restoreFocusToBar();
     }
   }
 
+  // fix(v1.6.0 audit A5): while a delete is in flight the optimistic removal
+  // has already emptied selectedLayers, so deletableCount is 0 — render the
+  // batch size the hook captured synchronously instead.
+  const displayDeleteCount = isDeleting ? (deletingCount ?? deletableCount) : deletableCount;
+
   return (
     <div
+      ref={barRef}
+      tabIndex={-1}
       role="toolbar"
       aria-label={t('bulkActions.toolbarLabel', { count: N })}
       // SF-01 (Phase 1049): marker for UnifiedStackPanel's outside-click guard.
@@ -156,11 +208,16 @@ export const BulkActionBar = memo(function BulkActionBar({
     >
       {/* Dedicated sr-only live region — announces selection count during normal
           state and "Deleting N layers…" when a bulk-delete is in flight.
-          role="toolbar" must not carry aria-live. */}
+          role="toolbar" must not carry aria-live.
+          fix(v1.6.0 audit): mounts EMPTY and populates on the rAF tick (the
+          `mounted` flip) — screen readers ignore content already present when
+          a live region enters the accessibility tree. */}
       <span className="sr-only" aria-live="polite" aria-atomic="true">
-        {isDeleting
-          ? t('bulkActions.deletingLayers', { count: deletableCount })
-          : t('bulkActions.liveAnnouncement', { count: N })}
+        {mounted
+          ? isDeleting
+            ? t('bulkActions.deletingLayers', { count: displayDeleteCount })
+            : t('bulkActions.liveAnnouncement', { count: N })
+          : null}
       </span>
       {isDeleting ? (
         // ------------------------------------------------------------------
@@ -169,7 +226,7 @@ export const BulkActionBar = memo(function BulkActionBar({
         <div className="flex items-center gap-2 w-full">
           <Loader2 className="size-4 animate-spin text-muted-foreground shrink-0" aria-hidden="true" />
           <span className="text-sm text-muted-foreground flex-1">
-            {t('bulkActions.deletingLayers', { count: deletableCount })}
+            {t('bulkActions.deletingLayers', { count: displayDeleteCount })}
           </span>
           {/* ux(#777): variant="destructive" (not ghost+text-destructive) so the
               in-flight button matches the confirm button the user just pressed. */}
@@ -180,7 +237,7 @@ export const BulkActionBar = memo(function BulkActionBar({
             className="h-8 gap-1.5 px-2 shrink-0 cursor-not-allowed"
             disabled={true}
             aria-busy={true}
-            aria-label={t('bulkActions.deleteAriaLabel', { count: deletableCount })}
+            aria-label={t('bulkActions.deleteAriaLabel', { count: displayDeleteCount })}
           >
             <Loader2 className="size-4 animate-spin" aria-hidden="true" />
             {t('bulkActions.delete')}
@@ -192,10 +249,16 @@ export const BulkActionBar = memo(function BulkActionBar({
         // ------------------------------------------------------------------
         // eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-noninteractive-element-interactions
         <div
+          ref={confirmRef}
           role="alertdialog"
+          // fix(v1.6.0 audit A3): the role promised modal semantics it didn't
+          // deliver — declare aria-modal and back it with the Tab-cycle trap
+          // below plus focus restoration on every exit path.
+          aria-modal="true"
           aria-labelledby={confirmId}
           className="flex items-center gap-2 w-full"
           onClick={(e) => e.stopPropagation()}
+          onKeyDown={handleConfirmKeyDown}
         >
           <p
             id={confirmId}
@@ -214,6 +277,8 @@ export const BulkActionBar = memo(function BulkActionBar({
             onClick={(e) => {
               e.stopPropagation();
               setConfirmingDelete(false);
+              // fix(v1.6.0 audit A3): the confirm owned focus — hand it back.
+              restoreFocusToBar();
             }}
             onPointerDown={(e) => e.stopPropagation()}
           >
@@ -230,6 +295,11 @@ export const BulkActionBar = memo(function BulkActionBar({
               e.stopPropagation();
               onBulkDelete(selectedIds);
               setConfirmingDelete(false);
+              // fix(v1.6.0 audit A3): confirming unmounts this button (the bar
+              // swaps to the deleting state) — restore to a stable element (the
+              // first remaining control, else the bar itself), never the dead
+              // trigger.
+              restoreFocusToBar();
             }}
             onPointerDown={(e) => e.stopPropagation()}
           >

--- a/frontend/src/components/builder/DEMEditorScene.tsx
+++ b/frontend/src/components/builder/DEMEditorScene.tsx
@@ -408,6 +408,10 @@ export const DEMEditorScene = memo(function DEMEditorScene({
                     mode="graduated"
                     rampName={getStringPaint(paint, '_hypso-ramp', 'Viridis')}
                     onChange={(name) => handlePaintValue('_hypso-ramp', name)}
+                    // Reverse checkbox was rendered inert (no props wired);
+                    // color-relief-sync consumes _hypso-reversed to flip the ramp.
+                    reversed={paint['_hypso-reversed'] === true}
+                    onReversedChange={(next) => handlePaintValue('_hypso-reversed', next)}
                   />
                   {/* builder-audit #338 MAINT-01: surface the hardcoded 0–4000 m, meters-only
                       elevation range limitation in-product (buildElevationExpression in
@@ -474,7 +478,13 @@ export const DEMEditorScene = memo(function DEMEditorScene({
                   min={0}
                   max={Math.max(0, maxZoom - 1)}
                   value={minZoom}
-                  onChange={(e) => onZoomChange(clampZoom(Number(e.target.value)), maxZoom)}
+                  // Number('') === 0 — clearing the field must reset the clamp
+                  // (min 0), not silently write a real bound; NaN is ignored.
+                  onChange={(e) => {
+                    const v = e.target.value === '' ? 0 : Number(e.target.value);
+                    if (!Number.isFinite(v)) return;
+                    onZoomChange(clampZoom(v), maxZoom);
+                  }}
                   className="h-8 text-xs"
                   aria-label={t('layerEditor.visibility.minZoom', { defaultValue: 'Minimum zoom' })}
                 />
@@ -492,7 +502,13 @@ export const DEMEditorScene = memo(function DEMEditorScene({
                   min={Math.min(22, minZoom + 1)}
                   max={22}
                   value={maxZoom}
-                  onChange={(e) => onZoomChange(minZoom, clampZoom(Number(e.target.value)))}
+                  // Number('') === 0 — clearing max-zoom used to write 0 and hide
+                  // the layer at every zoom. Empty clears the clamp (22); NaN is ignored.
+                  onChange={(e) => {
+                    const v = e.target.value === '' ? 22 : Number(e.target.value);
+                    if (!Number.isFinite(v)) return;
+                    onZoomChange(minZoom, clampZoom(v));
+                  }}
                   className="h-8 text-xs"
                   aria-label={t('layerEditor.visibility.maxZoom', { defaultValue: 'Maximum zoom' })}
                 />

--- a/frontend/src/components/builder/DataDrivenStyleEditor.tsx
+++ b/frontend/src/components/builder/DataDrivenStyleEditor.tsx
@@ -872,6 +872,7 @@ export function DataDrivenStyleEditor({
           <div className="flex items-center gap-2">
             <span className="text-xs text-muted-foreground w-20">{t('dataDriven.sizeMin')}</span>
             <Slider
+              aria-label={t('dataDriven.sizeMin')}
               value={[sizeRange[0]]}
               min={1}
               max={target === 'width' ? 20 : 30}
@@ -884,6 +885,7 @@ export function DataDrivenStyleEditor({
           <div className="flex items-center gap-2">
             <span className="text-xs text-muted-foreground w-20">{t('dataDriven.sizeMax')}</span>
             <Slider
+              aria-label={t('dataDriven.sizeMax')}
               value={[sizeRange[1]]}
               min={1}
               max={target === 'width' ? 20 : 30}
@@ -976,6 +978,7 @@ export function DataDrivenStyleEditor({
             <div className="flex items-center gap-2">
               <span className="text-xs text-muted-foreground w-20">{t('dataDriven.classes')}</span>
               <Slider
+                aria-label={t('dataDriven.classes')}
                 value={[classCount]}
                 min={3}
                 max={9}

--- a/frontend/src/components/builder/DatasetSearchPanel.tsx
+++ b/frontend/src/components/builder/DatasetSearchPanel.tsx
@@ -65,13 +65,15 @@ function isRasterRecord(recordType: RecordType | undefined) {
   return recordType === 'raster_dataset' || recordType === 'vrt_dataset';
 }
 
-function typeMeta(record: OGCRecordResponse) {
+// i18n: was hardcoded English ('Raster'/'Table'/'Vector') plus the raw
+// geometry enum (e.g. MULTIPOLYGON) — localize like the result-row badges.
+function typeMeta(record: OGCRecordResponse, t: TFunction<'builder'>) {
   const props = record.properties;
   const recordType = props.record_type ?? 'vector_dataset';
-  if (isRasterRecord(recordType)) return 'Raster';
-  if (recordType === 'table') return 'Table';
-  if (props.geometry_type) return props.geometry_type;
-  return 'Vector';
+  if (isRasterRecord(recordType)) return t('search.raster', { defaultValue: 'Raster' });
+  if (recordType === 'table') return t('search.table', { defaultValue: 'Table' });
+  if (props.geometry_type) return getGeometryTypeLabel(t, props.geometry_type);
+  return t('search.vector', { defaultValue: 'Vector' });
 }
 
 // fix(#788): "1 features" — the counts were hardcoded English with no plural
@@ -142,7 +144,7 @@ function DatasetMetadata({ record }: { record: OGCRecordResponse }) {
   const { t } = useTranslation('builder');
   const props = record.properties;
   const rows = [
-    [t('search.metadata.type', { defaultValue: 'Type' }), typeMeta(record)],
+    [t('search.metadata.type', { defaultValue: 'Type' }), typeMeta(record, t)],
     [t('search.metadata.source', { defaultValue: 'Source' }), props.source_organization],
     [t('search.metadata.count', { defaultValue: 'Count' }), featureMeta(record, t)],
     [t('search.metadata.crs', { defaultValue: 'CRS' }), props.epsg ? `EPSG:${props.epsg}` : props.crs],
@@ -527,51 +529,56 @@ export function DatasetSearchPanel({
         <div className="h-0.5 w-full bg-[var(--primary)] animate-pulse" />
       )}
 
-      {/* State A: Unfiltered empty — catalog is empty */}
-      {!isLoading && !isFetching && !isError
-        && debouncedQuery.trim().length === 0 && results.length === 0 && (
-        <div role="status" className="flex flex-col items-center gap-2 px-4 py-6">
-          <Inbox className="h-8 w-8 text-muted-foreground" aria-hidden="true" />
-          <p className="text-center text-sm font-semibold">
-            {t('search.catalogEmpty', { defaultValue: 'Your catalog is empty. Upload a dataset to get started.' })}
-          </p>
-          {/* builder-audit #338 SEARCH-01: only show the Upload CTA when the session can upload. */}
-          {canImport && (
-            <Button variant="ghost" size="sm" asChild>
-              <Link to="/import">
-                {t('search.uploadCta', { defaultValue: 'Upload a file →' })}
+      {/* Empty states — ONE permanently-mounted live region whose content
+          toggles. Conditionally-mounted role="status" regions appear
+          pre-populated, so assistive tech never announced them. */}
+      <div role="status">
+        {/* State A: Unfiltered empty — catalog is empty */}
+        {!isLoading && !isFetching && !isError
+          && debouncedQuery.trim().length === 0 && results.length === 0 && (
+          <div className="flex flex-col items-center gap-2 px-4 py-6">
+            <Inbox className="h-8 w-8 text-muted-foreground" aria-hidden="true" />
+            <p className="text-center text-sm font-semibold">
+              {t('search.catalogEmpty', { defaultValue: 'Your catalog is empty. Upload a dataset to get started.' })}
+            </p>
+            {/* builder-audit #338 SEARCH-01: only show the Upload CTA when the session can upload. */}
+            {canImport && (
+              <Button variant="ghost" size="sm" asChild>
+                <Link to="/import">
+                  {t('search.uploadCta', { defaultValue: 'Upload a file →' })}
+                </Link>
+              </Button>
+            )}
+            <Button variant="link" size="sm" className="text-muted-foreground text-xs" asChild>
+              <Link to="/collections">
+                {t('search.browseCatalogCta', { defaultValue: 'Browse public catalog →' })}
               </Link>
             </Button>
-          )}
-          <Button variant="link" size="sm" className="text-muted-foreground text-xs" asChild>
-            <Link to="/collections">
-              {t('search.browseCatalogCta', { defaultValue: 'Browse public catalog →' })}
-            </Link>
-          </Button>
-        </div>
-      )}
+          </div>
+        )}
 
-      {/* State B: Zero-result — query entered, no matches */}
-      {!isLoading && !isFetching && !isError
-        && debouncedQuery.trim().length > 0 && results.length === 0 && (
-        <div role="status" className="flex flex-col items-center gap-2 px-4 py-6">
-          <SearchX className="h-8 w-8 text-muted-foreground" aria-hidden="true" />
-          <p className="text-center text-sm font-semibold">
-            {t('search.zeroResultHeading', { defaultValue: "No datasets match '{{query}}'", query: debouncedQuery.trim() })}
-          </p>
-          <p className="text-center text-xs text-muted-foreground">
-            {t('search.zeroResultBody', { defaultValue: 'Try a different search term, or browse all datasets.' })}
-          </p>
-          <Button
-            variant="ghost"
-            size="sm"
-            aria-label={t('search.clearSearch', { defaultValue: 'Clear search and show all datasets' })}
-            onClick={() => setQuery('')}
-          >
-            {t('search.clearSearch', { defaultValue: 'Clear search' })}
-          </Button>
-        </div>
-      )}
+        {/* State B: Zero-result — query entered, no matches */}
+        {!isLoading && !isFetching && !isError
+          && debouncedQuery.trim().length > 0 && results.length === 0 && (
+          <div className="flex flex-col items-center gap-2 px-4 py-6">
+            <SearchX className="h-8 w-8 text-muted-foreground" aria-hidden="true" />
+            <p className="text-center text-sm font-semibold">
+              {t('search.zeroResultHeading', { defaultValue: "No datasets match '{{query}}'", query: debouncedQuery.trim() })}
+            </p>
+            <p className="text-center text-xs text-muted-foreground">
+              {t('search.zeroResultBody', { defaultValue: 'Try a different search term, or browse all datasets.' })}
+            </p>
+            <Button
+              variant="ghost"
+              size="sm"
+              aria-label={t('search.clearSearch', { defaultValue: 'Clear search and show all datasets' })}
+              onClick={() => setQuery('')}
+            >
+              {t('search.clearSearch', { defaultValue: 'Clear search' })}
+            </Button>
+          </div>
+        )}
+      </div>
 
       {/* ux(#776): no pointer-events/opacity freeze during debounced
           refetches — the pulse band above already signals them, and the

--- a/frontend/src/components/builder/EmptyStackState.tsx
+++ b/frontend/src/components/builder/EmptyStackState.tsx
@@ -236,7 +236,11 @@ export function EmptyStackState({ onOpenAddData, onAddDataset }: EmptyStackState
           <Search className="h-4 w-4" aria-hidden="true" />
         </button>
         <input
-          role="searchbox"
+          // fix(v1.6.0 audit D12): type="search" gives the searchbox role
+          // natively plus the browser's built-in Escape-clear, instead of the
+          // hand-rolled role="searchbox" on a plain text input. The manual
+          // Escape handler stays for engines (and jsdom) without native clear.
+          type="search"
           aria-label={t('unifiedStack.emptySearchInput', { defaultValue: 'Search datasets to add' })}
           placeholder={t('unifiedStack.emptySearchPlaceholder', { defaultValue: 'Search datasets, URLs, or files…' })}
           value={inlineQuery}

--- a/frontend/src/components/builder/FolderGroupRow.tsx
+++ b/frontend/src/components/builder/FolderGroupRow.tsx
@@ -86,6 +86,9 @@ export const FolderGroupRow = memo(function FolderGroupRow({
     onCommit: (next) => {
       if (next) onRenameGroup(groupId, next);
     },
+    // a11y(v1.6.0 audit A7): commit/cancel unmount the focused input — hand
+    // focus back to the row, matching the delete-confirm's focus return.
+    restoreFocus: () => document.getElementById(`stack-row-${groupId}`)?.focus(),
   });
 
   // Reset state on groupId change
@@ -120,6 +123,12 @@ export const FolderGroupRow = memo(function FolderGroupRow({
       onContextMenu={kebabMenu.onContextMenu}
       onKeyDown={(e) => {
         if (kebabMenu.handleContextMenuKey(e)) return;
+        // a11y(v1.6.0 audit A7, WCAG 2.1.1): keys from descendant controls
+        // (caret, eye, rename input, delete-confirm buttons) keep their native
+        // activation — the container only handles keys aimed at the row
+        // itself. AFTER the context-menu branch so Shift+F10 still works from
+        // a focused descendant.
+        if (e.target !== e.currentTarget) return;
         if (e.key === 'Enter') {
           e.preventDefault();
           onSelectGroup(groupId);

--- a/frontend/src/components/builder/FolderGroupRowWrapper.tsx
+++ b/frontend/src/components/builder/FolderGroupRowWrapper.tsx
@@ -1,6 +1,6 @@
 // builder-audit #338 STACK-05: extracted from UnifiedStackPanel.tsx into a sibling
 // file. Sortable wrapper for folder group rows.
-import { memo, useCallback } from 'react';
+import { memo, useCallback, useMemo } from 'react';
 import { useDndContext } from '@dnd-kit/core';
 import { useSortable } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
@@ -74,6 +74,13 @@ export const FolderGroupRowWrapper = memo(function FolderGroupRowWrapper({
     [onSelectGroup],
   );
 
+  // fix(v1.6.0 audit D7): a fresh object literal here re-broke the row memo on
+  // every wrapper render even when the drag state was unchanged.
+  const dragHandleProps = useMemo(
+    () => ({ attributes, listeners, setActivatorNodeRef }),
+    [attributes, listeners, setActivatorNodeRef],
+  );
+
   const displayName = layer.display_name ?? layer.dataset_name;
 
   return (
@@ -90,7 +97,7 @@ export const FolderGroupRowWrapper = memo(function FolderGroupRowWrapper({
         selected={selected}
         isExpanded={isExpanded}
         isDragging={isDragging}
-        dragHandleProps={{ attributes, listeners, setActivatorNodeRef }}
+        dragHandleProps={dragHandleProps}
         onSelectGroup={handleSelectGroup}
         onToggleExpand={onToggleExpand}
         onToggleVisibility={onToggleVisibility}

--- a/frontend/src/components/builder/HeatmapStyleControls.tsx
+++ b/frontend/src/components/builder/HeatmapStyleControls.tsx
@@ -155,10 +155,6 @@ interface SliderRowProps {
   max: number;
   step: number;
   onChange: (val: number) => void;
-  /** Fired on Radix onValueCommit (pointer-up / key release). Lets debounced
-   *  consumers flush the final value immediately instead of losing it when the
-   *  component unmounts before the debounce timer fires. */
-  onCommit?: (val: number) => void;
   /** Pre-computed display string. Takes precedence over `format`. */
   display?: string;
   /** Format shorthand: percent (0-1 → "50%"), px ("5px"), zoom ("3"). */
@@ -175,7 +171,7 @@ function formatValue(value: number, format?: 'percent' | 'px' | 'zoom'): string 
 }
 
 /** Shared slider row component used by heatmap controls and style editor. */
-export function SliderRow({ label, value, min, max, step, display, format, onChange, onCommit }: SliderRowProps) {
+export function SliderRow({ label, value, min, max, step, display, format, onChange }: SliderRowProps) {
   const displayValue = display ?? formatValue(value, format);
   return (
     <div className="flex items-center gap-2">
@@ -191,7 +187,6 @@ export function SliderRow({ label, value, min, max, step, display, format, onCha
         max={max}
         step={step}
         onValueChange={([v]) => onChange(v)}
-        onValueCommit={onCommit ? ([v]) => onCommit(v) : undefined}
         className="flex-1"
       />
       <span className="text-xs text-muted-foreground w-10 text-end">

--- a/frontend/src/components/builder/HeatmapStyleControls.tsx
+++ b/frontend/src/components/builder/HeatmapStyleControls.tsx
@@ -30,6 +30,7 @@ export const HeatmapStyleControls = memo(function HeatmapStyleControls({
 
   const weightColumn = (paint['_heatmap-weight-column'] as string) ?? NONE_VALUE;
   const rampName = (paint['_heatmap-ramp'] as string) ?? 'YlOrRd';
+  const reversed = paint['_heatmap-reversed'] === true;
   const radius = typeof paint['heatmap-radius'] === 'number' ? (paint['heatmap-radius'] as number) : 30;
   const intensity = typeof paint['heatmap-intensity'] === 'number' ? (paint['heatmap-intensity'] as number) : 1;
 
@@ -50,9 +51,20 @@ export const HeatmapStyleControls = memo(function HeatmapStyleControls({
     onPaintChange(layer.id, {
       ...paint,
       '_heatmap-ramp': name,
-      'heatmap-color': buildHeatmapColorExpression(name),
+      'heatmap-color': buildHeatmapColorExpression(name, reversed),
     });
-  }, [paint, layer.id, onPaintChange]);
+  }, [paint, layer.id, reversed, onPaintChange]);
+
+  // Reverse toggle: rebuild heatmap-color so the rendered ramp actually flips,
+  // and store the flag so the checkbox round-trips (was an inert default-false
+  // checkbox with no callback wired).
+  const handleReversedChange = useCallback((next: boolean) => {
+    onPaintChange(layer.id, {
+      ...paint,
+      '_heatmap-reversed': next,
+      'heatmap-color': buildHeatmapColorExpression(rampName, next),
+    });
+  }, [paint, layer.id, rampName, onPaintChange]);
 
   const handleRadiusChange = useCallback((val: number) => {
     onPaintChange(layer.id, { ...paint, 'heatmap-radius': val });
@@ -85,7 +97,13 @@ export const HeatmapStyleControls = memo(function HeatmapStyleControls({
       {/* Color ramp */}
       <div className="space-y-1">
         <div className="text-xs font-medium">{t('style.heatmap.colorRamp')}</div>
-        <ColorRampPicker rampName={rampName} onChange={handleRampChange} mode="graduated" />
+        <ColorRampPicker
+          rampName={rampName}
+          onChange={handleRampChange}
+          mode="graduated"
+          reversed={reversed}
+          onReversedChange={handleReversedChange}
+        />
       </div>
 
       {/* Radius */}
@@ -137,6 +155,10 @@ interface SliderRowProps {
   max: number;
   step: number;
   onChange: (val: number) => void;
+  /** Fired on Radix onValueCommit (pointer-up / key release). Lets debounced
+   *  consumers flush the final value immediately instead of losing it when the
+   *  component unmounts before the debounce timer fires. */
+  onCommit?: (val: number) => void;
   /** Pre-computed display string. Takes precedence over `format`. */
   display?: string;
   /** Format shorthand: percent (0-1 → "50%"), px ("5px"), zoom ("3"). */
@@ -153,7 +175,7 @@ function formatValue(value: number, format?: 'percent' | 'px' | 'zoom'): string 
 }
 
 /** Shared slider row component used by heatmap controls and style editor. */
-export function SliderRow({ label, value, min, max, step, display, format, onChange }: SliderRowProps) {
+export function SliderRow({ label, value, min, max, step, display, format, onChange, onCommit }: SliderRowProps) {
   const displayValue = display ?? formatValue(value, format);
   return (
     <div className="flex items-center gap-2">
@@ -169,6 +191,7 @@ export function SliderRow({ label, value, min, max, step, display, format, onCha
         max={max}
         step={step}
         onValueChange={([v]) => onChange(v)}
+        onValueCommit={onCommit ? ([v]) => onCommit(v) : undefined}
         className="flex-1"
       />
       <span className="text-xs text-muted-foreground w-10 text-end">

--- a/frontend/src/components/builder/LabelEditor.tsx
+++ b/frontend/src/components/builder/LabelEditor.tsx
@@ -187,6 +187,7 @@ export function LabelEditor({ columns, labelConfig, onLabelChange, geometryType 
           <div className="flex items-center gap-2">
             <span className="text-xs text-muted-foreground w-20">{t('labels.haloWidth')}</span>
             <Slider
+              aria-label={t('labels.haloWidth')}
               value={[labelConfig.haloWidth ?? 1.5]}
               min={0}
               max={4}
@@ -247,6 +248,7 @@ export function LabelEditor({ columns, labelConfig, onLabelChange, geometryType 
               <div className="flex items-center gap-2">
                 <span className="text-xs text-muted-foreground w-20">{t('labels.offsetX')}</span>
                 <Slider
+                  aria-label={t('labels.offsetX')}
                   value={[effectiveOffset[0]]}
                   min={-3}
                   max={3}
@@ -261,6 +263,7 @@ export function LabelEditor({ columns, labelConfig, onLabelChange, geometryType 
               <div className="flex items-center gap-2">
                 <span className="text-xs text-muted-foreground w-20">{t('labels.offsetY')}</span>
                 <Slider
+                  aria-label={t('labels.offsetY')}
                   value={[effectiveOffset[1]]}
                   min={-3}
                   max={3}
@@ -291,6 +294,7 @@ export function LabelEditor({ columns, labelConfig, onLabelChange, geometryType 
           <div className="flex items-center gap-2">
             <span className="text-xs text-muted-foreground w-20">{t('labels.minZoom')}</span>
             <Slider
+              aria-label={t('labels.minZoom')}
               value={[labelConfig.minZoom ?? 0]}
               min={0}
               max={(labelConfig.maxZoom ?? 22) - 1}
@@ -305,6 +309,7 @@ export function LabelEditor({ columns, labelConfig, onLabelChange, geometryType 
           <div className="flex items-center gap-2">
             <span className="text-xs text-muted-foreground w-20">{t('labels.maxZoom')}</span>
             <Slider
+              aria-label={t('labels.maxZoom')}
               value={[labelConfig.maxZoom ?? 22]}
               min={(labelConfig.minZoom ?? 0) + 1}
               max={22}

--- a/frontend/src/components/builder/LayerEditorPanel.tsx
+++ b/frontend/src/components/builder/LayerEditorPanel.tsx
@@ -9,6 +9,7 @@ import { RasterLayerControls } from './RasterLayerControls';
 import { InlineDeleteConfirm } from './row-chrome';
 import { cn } from '@/lib/utils';
 import { getLayerCapabilities } from '@/lib/layer-capabilities';
+import { getGeometryTypeLabel } from '@/i18n/labels';
 import { getRenderAsOptions, getCurrentRenderAs, hasCustomizedRenderAsStyle, type RenderAsId } from './renderAs';
 import { ColorizedGeometryIcon, getLayerColors, extractStyleHints } from '@/components/map/layer-icons';
 import type { FilterSpecification } from 'maplibre-gl';
@@ -73,6 +74,7 @@ interface LayerEditorPanelProps {
 // LayerEditorTypePill — small inline chip showing layer type in the header
 // ---------------------------------------------------------------------------
 function LayerEditorTypePill({ layer }: { layer: MapLayerResponse }) {
+  const { t } = useTranslation('builder');
   const caps = getLayerCapabilities(layer);
   const geometryType = layer.dataset_geometry_type;
   const renderMode = (layer.style_config as Record<string, unknown> | null)?.render_mode as string | undefined;
@@ -80,12 +82,20 @@ function LayerEditorTypePill({ layer }: { layer: MapLayerResponse }) {
   let label: string;
   if (caps.kind === 'raster' || caps.kind === 'vrt') {
     if (layer.is_dem) {
-      label = renderMode ? `DEM · ${renderMode}` : 'DEM';
+      // i18n: was the raw internal render_mode enum ('hillshade'/'terrain').
+      const modeLabel = renderMode === 'hillshade'
+        ? t('layerEditor.typePill.hillshade', { defaultValue: 'Hillshade' })
+        : renderMode === 'terrain'
+          ? t('layerEditor.typePill.terrain', { defaultValue: 'Terrain' })
+          : renderMode;
+      label = modeLabel ? `DEM · ${modeLabel}` : 'DEM';
     } else {
-      label = caps.kind === 'vrt' ? 'VRT' : 'Raster';
+      label = caps.kind === 'vrt' ? 'VRT' : t('search.raster', { defaultValue: 'Raster' });
     }
   } else {
-    label = geometryType ?? 'Vector';
+    label = geometryType
+      ? getGeometryTypeLabel(t, geometryType)
+      : t('search.vector', { defaultValue: 'Vector' });
   }
 
   return (

--- a/frontend/src/components/builder/LayerStyleEditor.tsx
+++ b/frontend/src/components/builder/LayerStyleEditor.tsx
@@ -2,6 +2,7 @@ import { useState, useMemo, useCallback, memo, lazy, Suspense, useEffect, useRef
 import { useTranslation } from 'react-i18next';
 import { AlertTriangle, RotateCcw } from 'lucide-react';
 import { Button } from '@/components/ui/button';
+import { InlineDeleteConfirm } from './row-chrome';
 import { SliderRow } from './HeatmapStyleControls';
 import { AdvancedJsonEditor } from './LayerStyleEditor/AdvancedJsonEditor';
 import { RenderModeSwitch } from './LayerStyleEditor/RenderModeSwitch';
@@ -301,6 +302,11 @@ export const LayerStyleEditor = memo(function LayerStyleEditor({
     const heatmapRamp = typeof nextPaint['_heatmap-ramp'] === 'string'
       ? nextPaint['_heatmap-ramp'] as string
       : builderConfig.heatmapRamp;
+    // Persist the ramp direction alongside the ramp name so the Reverse
+    // checkbox round-trips through save/reload.
+    const heatmapReversed = typeof nextPaint['_heatmap-reversed'] === 'boolean'
+      ? nextPaint['_heatmap-reversed'] as boolean
+      : builderConfig.heatmapReversed;
     const heatmapWeightColumn = typeof nextPaint['_heatmap-weight-column'] === 'string'
       ? nextPaint['_heatmap-weight-column'] as string
       : nextPaint['heatmap-weight'] === 1
@@ -308,10 +314,10 @@ export const LayerStyleEditor = memo(function LayerStyleEditor({
         : builderConfig.heatmapWeightColumn;
     onStyleConfigChange(
       layerId,
-      withBuilderConfig(layer.style_config, { heatmapRamp, heatmapWeightColumn }),
+      withBuilderConfig(layer.style_config, { heatmapRamp, heatmapReversed, heatmapWeightColumn }),
       stripLegacyBuilderPaint(nextPaint),
     );
-  }, [builderConfig.heatmapRamp, builderConfig.heatmapWeightColumn, layer.style_config, onStyleConfigChange]);
+  }, [builderConfig.heatmapRamp, builderConfig.heatmapReversed, builderConfig.heatmapWeightColumn, layer.style_config, onStyleConfigChange]);
 
   const handleSymbolConfigChange = useCallback((patch: SymbolStyleConfig) => {
     const nextSymbol = { ...symbolConfig, ...patch };
@@ -345,20 +351,31 @@ export const LayerStyleEditor = memo(function LayerStyleEditor({
   }, [layer.id, paint, onPaintChange]);
 
   const handleResetStyle = useCallback(() => {
+    // Every branch clears the zoom clamp — previously only the line branch
+    // did, so fill/point layers kept a stale _minzoom/_maxzoom after Reset
+    // and could stay invisible at every zoom.
+    const nextLayout = { ...layoutObj };
+    delete nextLayout['_minzoom'];
+    delete nextLayout['_maxzoom'];
     if (geomType === 'fill') {
       onStyleConfigChange(layer.id, null, FILL_DEFAULTS);
     } else if (geomType === 'line') {
-      const nextLayout = { ...layoutObj };
       delete nextLayout['line-dasharray'];
-      delete nextLayout['_minzoom'];
-      delete nextLayout['_maxzoom'];
       onStyleConfigChange(layer.id, null, LINE_DEFAULTS);
-      onLayoutChange(layer.id, nextLayout);
     } else {
       onStyleConfigChange(layer.id, null, CIRCLE_DEFAULTS);
     }
+    onLayoutChange(layer.id, nextLayout);
     onOpacityChange?.(layer.id, 1);
   }, [geomType, layer.id, layoutObj, onLayoutChange, onOpacityChange, onStyleConfigChange]);
+
+  // Reset destroys render mode + classification — gate it behind the builder's
+  // shared inline confirm (same pattern as the DEM editor's delete footer).
+  const [confirmReset, setConfirmReset] = useState(false);
+  const handleConfirmReset = useCallback(() => {
+    setConfirmReset(false);
+    handleResetStyle();
+  }, [handleResetStyle]);
 
   // Bumped by handleRevertToSaved to force-remount the data-driven editor.
   const [revertNonce, setRevertNonce] = useState(0);
@@ -487,7 +504,7 @@ export const LayerStyleEditor = memo(function LayerStyleEditor({
             variant="ghost"
             size="xs"
             className="shrink-0"
-            onClick={handleResetStyle}
+            onClick={() => setConfirmReset(true)}
             title={t('style.resetTitle')}
           >
             <RotateCcw className="h-3 w-3" />
@@ -495,6 +512,17 @@ export const LayerStyleEditor = memo(function LayerStyleEditor({
           </Button>
         }
       >
+        {confirmReset && (
+          <InlineDeleteConfirm
+            confirmId={`style-reset-confirm-${layer.id}`}
+            message={t('style.resetConfirmMessage')}
+            confirmLabel={t('style.resetConfirmAction')}
+            cancelLabel={t('style.resetConfirmCancel')}
+            onConfirm={handleConfirmReset}
+            onCancel={() => setConfirmReset(false)}
+            className="mx-0 mb-0"
+          />
+        )}
         <RenderModeSwitch {...editorProps} dispatchKey={dispatchKey} />
 
         {/* Master opacity — all geometry types; omitted when parent owns the opacity control */}
@@ -509,6 +537,15 @@ export const LayerStyleEditor = memo(function LayerStyleEditor({
               step={0.01}
               format="percent"
               onChange={setLocalOpacity}
+              // B10: commit the final value immediately on pointer-up/key
+              // release — the 100ms debounce alone discarded the last drag
+              // when the editor unmounted before the timer fired.
+              onCommit={(v) => {
+                clearTimeout(opacityTimerRef.current);
+                opacityFromPropRef.current = v;
+                setLocalOpacity(v);
+                onOpacityChange?.(layer.id, v);
+              }}
             />
           </>
         )}

--- a/frontend/src/components/builder/LayerStyleEditor.tsx
+++ b/frontend/src/components/builder/LayerStyleEditor.tsx
@@ -232,11 +232,24 @@ export const LayerStyleEditor = memo(function LayerStyleEditor({
     if (localOpacity === opacityFromPropRef.current) return;
     clearTimeout(opacityTimerRef.current);
     opacityTimerRef.current = setTimeout(() => {
+      opacityTimerRef.current = undefined;
       onOpacityChange(layer.id, localOpacity);
     }, 100);
     return () => clearTimeout(opacityTimerRef.current);
   // eslint-disable-next-line react-hooks/exhaustive-deps -- push opacity only on local/layer change; the sync setter is stable
   }, [localOpacity, layer.id]);
+  // B10: flush a still-debouncing value on unmount — the bare clearTimeout
+  // alone discarded the final slider movement when the editor closed before
+  // the 100ms window elapsed. (Commit-on-release was rejected: Radix fires
+  // onValueCommit per keyboard step, which reintroduces the PB-02 spam.)
+  const opacityFlushRef = useRef<(() => void) | undefined>(undefined);
+  opacityFlushRef.current = () => {
+    if (opacityTimerRef.current === undefined) return;
+    clearTimeout(opacityTimerRef.current);
+    opacityTimerRef.current = undefined;
+    onOpacityChange?.(layer.id, localOpacity);
+  };
+  useEffect(() => () => opacityFlushRef.current?.(), []);
 
   // builder-audit #338 DRY-01: forward map derived from the single BUILDER_PAINT_FIELDS
   // table (builder-paint-map.ts), which also backs handlePaintProp's reverse router
@@ -537,15 +550,6 @@ export const LayerStyleEditor = memo(function LayerStyleEditor({
               step={0.01}
               format="percent"
               onChange={setLocalOpacity}
-              // B10: commit the final value immediately on pointer-up/key
-              // release — the 100ms debounce alone discarded the last drag
-              // when the editor unmounted before the timer fired.
-              onCommit={(v) => {
-                clearTimeout(opacityTimerRef.current);
-                opacityFromPropRef.current = v;
-                setLocalOpacity(v);
-                onOpacityChange?.(layer.id, v);
-              }}
             />
           </>
         )}

--- a/frontend/src/components/builder/LayerStyleEditor/builder-paint-map.ts
+++ b/frontend/src/components/builder/LayerStyleEditor/builder-paint-map.ts
@@ -40,6 +40,7 @@ export const BUILDER_PAINT_FIELDS: readonly BuilderPaintField[] = [
   { builderKey: 'outlineWidthSaved', paintKey: '_outline-width-saved' },
   { builderKey: 'heightColumn', paintKey: '_height_column' },
   { builderKey: 'heatmapRamp', paintKey: '_heatmap-ramp' },
+  { builderKey: 'heatmapReversed', paintKey: '_heatmap-reversed' },
   { builderKey: 'heatmapWeightColumn', paintKey: '_heatmap-weight-column' },
 ] as const;
 

--- a/frontend/src/components/builder/PopupConfigEditor.tsx
+++ b/frontend/src/components/builder/PopupConfigEditor.tsx
@@ -8,7 +8,7 @@ import {
   useSensor,
   useSensors,
 } from '@dnd-kit/core';
-import type { DragEndEvent } from '@dnd-kit/core';
+import type { Announcements, DragEndEvent, ScreenReaderInstructions } from '@dnd-kit/core';
 import {
   SortableContext,
   verticalListSortingStrategy,
@@ -115,6 +115,39 @@ export function PopupConfigEditor({ columns, popupConfig, onPopupChange }: Popup
     useSensor(PointerSensor),
     useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }),
   );
+
+  // fix(#785): mirror MapBuilderPage's DndContext accessibility wiring —
+  // without it dnd-kit falls back to hardcoded-English announcements built
+  // from the draggable id. Field ids ARE the human-readable column names here,
+  // so they can be announced directly.
+  const dndAccessibility = useMemo(() => {
+    const position = (over: { id: string | number } | null): number | null => {
+      if (!over || !visibleFields) return null;
+      const index = visibleFields.indexOf(String(over.id));
+      return index >= 0 ? index + 1 : null;
+    };
+    const announcements: Announcements = {
+      onDragStart({ active }) {
+        return t('a11y.dragPickup', { name: String(active.id) });
+      },
+      onDragOver({ over }) {
+        const n = position(over);
+        if (n == null) return undefined;
+        return t('a11y.dragPosition', { n, total: visibleFields?.length ?? 0 });
+      },
+      onDragEnd({ active, over }) {
+        if (!over) return t('a11y.dragCancelled');
+        return t('a11y.dragDropped', { name: String(active.id), n: position(over) ?? 1 });
+      },
+      onDragCancel() {
+        return t('a11y.dragCancelled');
+      },
+    };
+    const screenReaderInstructions: ScreenReaderInstructions = {
+      draggable: t('a11y.dragInstructions'),
+    };
+    return { announcements, screenReaderInstructions };
+  }, [t, visibleFields]);
 
   const mode: 'all' | 'custom' = visibleFields === null ? 'all' : 'custom';
   const usedFields = useMemo(() => new Set(visibleFields ?? []), [visibleFields]);
@@ -267,6 +300,7 @@ export function PopupConfigEditor({ columns, popupConfig, onPopupChange }: Popup
               ) : (
                 <DndContext
                   sensors={sensors}
+                  accessibility={dndAccessibility}
                   collisionDetection={closestCenter}
                   onDragEnd={handleDragEnd}
                 >

--- a/frontend/src/components/builder/SharePanel.tsx
+++ b/frontend/src/components/builder/SharePanel.tsx
@@ -23,6 +23,17 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from '@/components/ui/alert-dialog';
 import { usePublishMap, useCreateShareToken, useRevokeShareToken, useMapShareToken, useUpdateShareToken } from '@/hooks/use-maps';
 import { checkMapVisibility } from '@/api/maps';
 import { useCreateEmbedToken, useMapEmbedTokens, useUpdateEmbedToken, useRevokeEmbedToken } from '@/components/builder/hooks/use-embed-tokens';
@@ -509,22 +520,41 @@ function ShareLinkSettings({
             </div>
           )}
 
-          {/* Revoke */}
+          {/* Revoke — destructive (kills the link AND every embed token), so it
+              gets the same AlertDialog confirm as the admin revoke actions
+              instead of firing on a bare click. */}
           <div className="pt-2 border-t">
-            <Button
-              variant="outline"
-              size="sm"
-              className="w-full text-destructive hover:text-destructive hover:bg-destructive/5"
-              onClick={handleRevokeShareLink}
-              disabled={revokeShareToken.isPending}
-            >
-              {revokeShareToken.isPending ? (
-                <Loader2 className="h-3.5 w-3.5 animate-spin me-1.5" />
-              ) : (
-                <Trash2 className="h-3.5 w-3.5 me-1.5" />
-              )}
-              {t('share.revokeShareLink')}
-            </Button>
+            <AlertDialog>
+              <AlertDialogTrigger asChild>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="w-full text-destructive hover:text-destructive hover:bg-destructive/5"
+                  disabled={revokeShareToken.isPending}
+                >
+                  {revokeShareToken.isPending ? (
+                    <Loader2 className="h-3.5 w-3.5 animate-spin me-1.5" />
+                  ) : (
+                    <Trash2 className="h-3.5 w-3.5 me-1.5" />
+                  )}
+                  {t('share.revokeShareLink')}
+                </Button>
+              </AlertDialogTrigger>
+              <AlertDialogContent>
+                <AlertDialogHeader>
+                  <AlertDialogTitle>{t('share.revokeConfirmTitle')}</AlertDialogTitle>
+                  <AlertDialogDescription>
+                    {t('share.revokeConfirmDescription')}
+                  </AlertDialogDescription>
+                </AlertDialogHeader>
+                <AlertDialogFooter>
+                  <AlertDialogCancel>{t('share.revokeConfirmCancel')}</AlertDialogCancel>
+                  <AlertDialogAction variant="destructive" onClick={handleRevokeShareLink}>
+                    {t('share.revokeConfirmAction')}
+                  </AlertDialogAction>
+                </AlertDialogFooter>
+              </AlertDialogContent>
+            </AlertDialog>
           </div>
         </div>
       )}

--- a/frontend/src/components/builder/SortableStackRow.tsx
+++ b/frontend/src/components/builder/SortableStackRow.tsx
@@ -1,6 +1,6 @@
 // builder-audit #338 STACK-05: extracted from UnifiedStackPanel.tsx into a sibling
 // file. Sortable wrapper for a loose layer or a folder-group child row.
-import { memo, useCallback } from 'react';
+import { memo, useCallback, useMemo } from 'react';
 import { useSortable } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
 import { StackRow } from '@/components/builder/StackRow';
@@ -39,6 +39,10 @@ interface SortableStackRowProps {
   isFresh?: boolean;
   // Phase 1199 STACK-01: "Copy N of M" duplicate label, null when not a duplicate
   disambiguationLabel?: string | null;
+  /** fix(v1.6.0 audit): non-null when this row is the LAST child of the named
+   *  group — deleting it or moving it out dissolves the group (#767 prune), so
+   *  the row's confirms must say so. */
+  dissolvesGroupName?: string | null;
   // fix(#430 V-17): true when this layer's dataset would be filtered out for the
   // map's audience (private/unpublished dataset on a public/shared map).
   audienceHidden?: boolean;
@@ -76,6 +80,7 @@ export const SortableStackRow = memo(function SortableStackRow({
   onCheckboxClick,
   isFresh,
   disambiguationLabel,
+  dissolvesGroupName,
   audienceHidden,
   drawsNothing,
   dragDisabled = false,
@@ -101,13 +106,20 @@ export const SortableStackRow = memo(function SortableStackRow({
     [onSelectLayer],
   );
 
+  // fix(v1.6.0 audit D7): a fresh object literal here re-broke StackRow's memo
+  // on every wrapper render even when the drag state was unchanged.
+  const dragHandleProps = useMemo(
+    () => ({ attributes, listeners, setActivatorNodeRef }),
+    [attributes, listeners, setActivatorNodeRef],
+  );
+
   return (
     <div ref={setNodeRef} style={style} data-dnd-over={isOver ? 'true' : undefined} data-row-id={layer.id}>
       <StackRow
         layer={layer}
         selected={selected}
         isDragging={isDragging}
-        dragHandleProps={{ attributes, listeners, setActivatorNodeRef }}
+        dragHandleProps={dragHandleProps}
         onSelectLayer={handleSelectLayer}
         onToggleVisibility={onToggleVisibility}
         onRemove={onRemove}
@@ -132,6 +144,7 @@ export const SortableStackRow = memo(function SortableStackRow({
         onCheckboxClick={onCheckboxClick}
         isFresh={isFresh}
         disambiguationLabel={disambiguationLabel}
+        dissolvesGroupName={dissolvesGroupName}
         audienceHidden={audienceHidden}
         drawsNothing={drawsNothing}
       />

--- a/frontend/src/components/builder/StackRow.tsx
+++ b/frontend/src/components/builder/StackRow.tsx
@@ -99,6 +99,10 @@ interface StackRowProps {
   // per-layer by UnifiedStackPanel from map-stack's shared helper. Null = not a
   // duplicate; render nothing.
   disambiguationLabel?: string | null;
+  /** fix(v1.6.0 audit): non-null when this row is the LAST child of the named
+   *  group — deleting it or moving it out also removes the group (#767 prune),
+   *  so the delete confirm says so and "Move out of group" gains a confirm. */
+  dissolvesGroupName?: string | null;
   // fix(#430 V-17): true when this layer's dataset would be silently filtered out
   // for the map's audience (private/unpublished dataset on a public/shared
   // map) — computed per-layer by UnifiedStackPanel via
@@ -148,11 +152,16 @@ export const StackRow = memo(function StackRow({
   onCheckboxClick,
   isFresh = false,
   disambiguationLabel = null,
+  dissolvesGroupName = null,
   audienceHidden = false,
   drawsNothing = false,
 }: StackRowProps) {
   const { t } = useTranslation('builder');
   const [confirmingDelete, setConfirmingDelete] = useState(false);
+  // fix(v1.6.0 audit): "Move out of group" on a group's LAST child dissolves
+  // the named group (#767 empty-group prune) — that deserves the same
+  // lightweight inline confirm the delete path already uses.
+  const [confirmingMoveOut, setConfirmingMoveOut] = useState(false);
   const [keyboardReorderActive, setKeyboardReorderActive] = useState(false);
   const kebabMenu = useKebabContextMenu();
 
@@ -303,10 +312,11 @@ export const StackRow = memo(function StackRow({
         // confirm (consumed) instead of falling through to ancestor Escape
         // handlers. The confirm handles its own Escape when focus is inside it;
         // this covers focus resting on the row.
-        if (e.key === 'Escape' && confirmingDelete) {
+        if (e.key === 'Escape' && (confirmingDelete || confirmingMoveOut)) {
           e.preventDefault();
           e.stopPropagation();
           setConfirmingDelete(false);
+          setConfirmingMoveOut(false);
         }
       }}
     >
@@ -659,8 +669,16 @@ export const StackRow = memo(function StackRow({
             </DropdownMenuItem>
             <DropdownMenuSeparator />
             {parentGroupId ? (
-              // Layer is already inside a group: show "Move out of group"
-              <DropdownMenuItem onSelect={() => onMoveLayerOutOfGroup?.(layer.id)}>
+              // Layer is already inside a group: show "Move out of group".
+              // fix(v1.6.0 audit): moving the LAST child out dissolves the
+              // named group — route through the inline confirm instead of
+              // destroying the group silently.
+              <DropdownMenuItem
+                onSelect={() => {
+                  if (dissolvesGroupName) setConfirmingMoveOut(true);
+                  else onMoveLayerOutOfGroup?.(layer.id);
+                }}
+              >
                 <FolderMinus className="h-3.5 w-3.5 me-2" aria-hidden="true" />
                 {t('stackRow.kebabMoveOutOfGroup', { defaultValue: 'Move out of group' })}
               </DropdownMenuItem>
@@ -703,7 +721,17 @@ export const StackRow = memo(function StackRow({
     {confirmingDelete && (
       <InlineDeleteConfirm
         confirmId={`confirm-delete-${layer.id}`}
-        message={t('layerEditor.confirmDelete.message', { defaultValue: 'Are you sure? This cannot be undone.' })}
+        // fix(v1.6.0 audit): deleting a group's last child also removes the
+        // named group (#767 prune) — the confirm must promise the whole effect.
+        message={
+          dissolvesGroupName
+            ? t('layerEditor.confirmDelete.messageDissolvesGroup', {
+                group: dissolvesGroupName,
+                defaultValue:
+                  'Are you sure? This cannot be undone, and the group "{{group}}" will also be removed.',
+              })
+            : t('layerEditor.confirmDelete.message', { defaultValue: 'Are you sure? This cannot be undone.' })
+        }
         confirmLabel={t('layerEditor.confirmDelete.delete', { defaultValue: 'Delete' })}
         cancelLabel={t('layerEditor.confirmDelete.keep', { defaultValue: 'Keep layer' })}
         onConfirm={() => {
@@ -714,6 +742,30 @@ export const StackRow = memo(function StackRow({
           setConfirmingDelete(false);
           // fix(#788): the confirm owned focus (autofocused Cancel button), so
           // dismissing it must hand focus back to the row instead of <body>.
+          document.getElementById(`stack-row-${layer.id}`)?.focus();
+        }}
+      />
+    )}
+
+    {/* fix(v1.6.0 audit): confirm before "Move out of group" dissolves the
+        named group (last-child case) — same shared inline confirm as delete. */}
+    {confirmingMoveOut && (
+      <InlineDeleteConfirm
+        confirmId={`confirm-move-out-${layer.id}`}
+        message={t('stackRow.moveOutConfirmMessage', {
+          group: dissolvesGroupName,
+          defaultValue:
+            'Move this layer out of "{{group}}"? The empty group will also be removed.',
+        })}
+        confirmLabel={t('stackRow.moveOutConfirmAction', { defaultValue: 'Move out' })}
+        cancelLabel={t('stackRow.moveOutConfirmCancel', { defaultValue: 'Keep in group' })}
+        onConfirm={() => {
+          onMoveLayerOutOfGroup?.(layer.id);
+          setConfirmingMoveOut(false);
+        }}
+        onCancel={() => {
+          setConfirmingMoveOut(false);
+          // fix(#788): hand focus back to the row instead of <body>.
           document.getElementById(`stack-row-${layer.id}`)?.focus();
         }}
       />

--- a/frontend/src/components/builder/StackRow.tsx
+++ b/frontend/src/components/builder/StackRow.tsx
@@ -171,6 +171,9 @@ export const StackRow = memo(function StackRow({
   } = useInlineRename({
     value: displayName,
     onCommit: (next) => onRename(layer.id, next),
+    // a11y(v1.6.0 audit A7): commit/cancel unmount the focused input — hand
+    // focus back to the row, matching the delete-confirm's focus return.
+    restoreFocus: () => document.getElementById(`stack-row-${layer.id}`)?.focus(),
   });
 
   // Derived label indicator.
@@ -281,6 +284,13 @@ export const StackRow = memo(function StackRow({
       onContextMenu={kebabMenu.onContextMenu}
       onKeyDown={(e) => {
         if (kebabMenu.handleContextMenuKey(e)) return;
+        // a11y(v1.6.0 audit A7, WCAG 2.1.1): only keys aimed at the row
+        // container itself belong to the row. Without this guard the
+        // Enter/Space preventDefault below cancelled native button activation
+        // on every descendant (eye toggle, kebab) and swallowed spaces typed
+        // into the rename input. Placed AFTER the context-menu branch so
+        // Shift+F10 still opens the kebab from a focused descendant.
+        if (e.target !== e.currentTarget) return;
         if (e.key === 'Enter') {
           e.preventDefault();
           onSelectLayer(layer.id);
@@ -371,6 +381,10 @@ export const StackRow = memo(function StackRow({
           <input
             ref={inputRef}
             type="text"
+            // a11y(v1.6.0 audit A7): the input had no accessible name while
+            // FolderGroupRow's did — mirror that pattern.
+            aria-label={t('stackRow.renameInputLabel', { defaultValue: 'Layer name' })}
+            placeholder={t('stackRow.renameInputLabel', { defaultValue: 'Layer name' })}
             data-testid="stack-row-rename-input"
             className="h-6 w-full min-w-0 border-b border-primary bg-transparent text-sm outline-none focus:ring-1 focus:ring-ring"
             value={nameValue}

--- a/frontend/src/components/builder/UnifiedStackPanel.tsx
+++ b/frontend/src/components/builder/UnifiedStackPanel.tsx
@@ -205,6 +205,11 @@ const SublayerRow = memo(function SublayerRow({
       )}
       onClick={() => onSelectLayer(sublayer.id)}
       onKeyDown={(e) => {
+        // a11y(v1.6.0 audit A7, WCAG 2.1.1): keys from the descendant eye
+        // toggle keep their native button activation — the container only
+        // handles keys aimed at the row itself. First-line is safe here: the
+        // sublayer row has no kebab/context-menu key handling.
+        if (e.target !== e.currentTarget) return;
         if (e.key === 'Enter' || e.key === ' ') {
           e.preventDefault();
           onSelectLayer(sublayer.id);

--- a/frontend/src/components/builder/UnifiedStackPanel.tsx
+++ b/frontend/src/components/builder/UnifiedStackPanel.tsx
@@ -148,6 +148,9 @@ interface UnifiedStackPanelProps {
   onBulkDelete: (ids: Set<string>) => void;
   /** Phase 1047-04 (PERF-03): forwarded from useBuilderLayers.isDeleting */
   isDeleting?: boolean;
+  /** fix(v1.6.0 audit A5): in-flight bulk-delete batch size, forwarded from
+   *  useBuilderLayers.deletingCount for the bar's "Deleting N layers…" label. */
+  deletingCount?: number;
   // Phase 1042 POL-15: freshLayerId — id of most recently added layer for entry animation
   freshLayerId?: string | null;
   /** Phase 1051 UX-03: basemap position in the unified stack. 'top' renders
@@ -358,6 +361,7 @@ export const UnifiedStackPanel = memo(function UnifiedStackPanel({
   onBulkUngroup,
   onBulkDelete,
   isDeleting = false,
+  deletingCount,
   freshLayerId = null,
   basemapPosition = 'bottom',
 }: UnifiedStackPanelProps) {
@@ -845,6 +849,15 @@ export const UnifiedStackPanel = memo(function UnifiedStackPanel({
                                 onShiftClick={onShiftClick}
                                 onCheckboxClick={onCheckboxClick}
                                 isFresh={child.id === freshLayerId}
+                                // fix(v1.6.0 audit): deleting/moving-out a
+                                // group's LAST child dissolves the named group
+                                // (the #767 empty-group prune) — tell the row
+                                // so its confirms can say so.
+                                dissolvesGroupName={
+                                  children.length === 1
+                                    ? (layer.display_name ?? layer.dataset_name)
+                                    : null
+                                }
                                 disambiguationLabel={disambiguationLabels.get(child.id) ?? null}
                                 audienceHidden={audienceHiddenLayerIds.has(child.id)}
                                 drawsNothing={drawsNothingLayerIds?.has(child.id) ?? false}
@@ -967,6 +980,7 @@ export const UnifiedStackPanel = memo(function UnifiedStackPanel({
           onBulkDelete={onBulkDelete}
           onBulkApplyStyle={onBulkApplyStyle}
           isDeleting={isDeleting}
+          deletingCount={deletingCount}
         />
       )}
     </div>

--- a/frontend/src/components/builder/UnifiedStackPanel.tsx
+++ b/frontend/src/components/builder/UnifiedStackPanel.tsx
@@ -557,6 +557,13 @@ export const UnifiedStackPanel = memo(function UnifiedStackPanel({
     [visibleStackLayers, groupMeta, layerSearch],
   );
 
+  // fix(v1.6.0 audit D2): a filter that matches nothing used to render a blank
+  // panel with no explanation. renderedRowIds covers DATA rows only — the
+  // basemap row is exempt from filtering and always renders — so size === 0
+  // while a search is active is exactly "no layer matches"; the basemap row
+  // stays visible below the message.
+  const noSearchMatches = !isEmpty && isSearchActive && renderedRowIds.size === 0;
+
   // ---------------------------------------------------------------------------
   // Basemap dock row — rendered in both empty and populated states.
   // In empty state it sits below the EmptyStackState content with a "BASEMAP"
@@ -720,6 +727,20 @@ export const UnifiedStackPanel = memo(function UnifiedStackPanel({
           </>
         ) : (
           <>
+            {/* fix(v1.6.0 audit D2): "no layers match" empty state — announced
+                via role="status" so screen readers hear the result count change. */}
+            {noSearchMatches && (
+              <p
+                data-testid="layer-search-no-matches"
+                role="status"
+                className="px-3 py-4 text-center text-xs text-muted-foreground"
+              >
+                {t('unifiedStack.searchNoMatches', {
+                  query: layerSearch.trim(),
+                  defaultValue: 'No layers match “{{query}}”',
+                })}
+              </p>
+            )}
             <SortableContext
               items={sortableIds}
               strategy={verticalListSortingStrategy}

--- a/frontend/src/components/builder/__tests__/AnalysisPanel.test.tsx
+++ b/frontend/src/components/builder/__tests__/AnalysisPanel.test.tsx
@@ -242,7 +242,7 @@ describe('AnalysisPanel', () => {
     renderPanel([rasterLayer, datasetLayer]);
     // The vector layer is selected rather than the raster that comes first.
     expect(screen.getByRole('button', { name: 'Preview' })).not.toBeDisabled();
-    expect(screen.getByText('Parcels')).toBeInTheDocument();
+    expect(screen.getAllByText('Parcels').length).toBeGreaterThan(0);
     expect(screen.queryByText('Sentinel-2 TCI')).not.toBeInTheDocument();
   });
 
@@ -268,7 +268,7 @@ describe('AnalysisPanel', () => {
     // The analysis endpoint accepts this, so hiding it would be a false
     // negative — the failure mode of classifying by renderer instead of source.
     expect(screen.getByRole('button', { name: 'Preview' })).not.toBeDisabled();
-    expect(screen.getByText('Parcels rendered oddly')).toBeInTheDocument();
+    expect(screen.getAllByText('Parcels rendered oddly').length).toBeGreaterThan(0);
   });
 
   it('does not offer Dissolve to viewers (fix #779)', async () => {
@@ -929,7 +929,7 @@ describe('AnalysisPanel — chat handoff prefill (#675)', () => {
       // The overlay still depicted the removed layer's preview.
       await waitFor(() => expect(onClearPreview).toHaveBeenCalled());
       // The selection falls back exactly as a fresh mount would.
-      expect(screen.getByText('Roads')).toBeInTheDocument();
+      expect(screen.getAllByText('Roads').length).toBeGreaterThan(0);
     });
 
     it('clears a stale overlay when the remembered layer left the map (#793 review)', async () => {
@@ -1323,7 +1323,7 @@ describe('AnalysisPanel — stack-selected layer (#772)', () => {
 
   it('targets the stack-selected layer instead of the first eligible one', async () => {
     renderPanel([datasetLayer, datasetLayer2], { selectedLayerId: 'l3' });
-    expect(screen.getByText('Roads')).toBeInTheDocument();
+    expect(screen.getAllByText('Roads').length).toBeGreaterThan(0);
 
     fireEvent.click(screen.getByRole('button', { name: 'Preview' }));
     await waitFor(() =>
@@ -1338,7 +1338,7 @@ describe('AnalysisPanel — stack-selected layer (#772)', () => {
     // The selection slot also carries raster layers, folder groups, and
     // sentinel ids like 'settings' — none of them may hijack the default.
     renderPanel([datasetLayer, rasterLayer], { selectedLayerId: 'l5' });
-    expect(screen.getByText('Parcels')).toBeInTheDocument();
+    expect(screen.getAllByText('Parcels').length).toBeGreaterThan(0);
   });
 
   it('yields to an explicit chat prefill', async () => {
@@ -1365,7 +1365,7 @@ describe('AnalysisPanel — stack-selected layer (#772)', () => {
       mapId: 'm1',
       selectedLayerId: 'l3',
     });
-    expect(screen.getByText('Roads')).toBeInTheDocument();
+    expect(screen.getAllByText('Roads').length).toBeGreaterThan(0);
     expect(screen.getByLabelText('Distance')).toHaveValue(750);
     expect(screen.getByLabelText('New dataset name')).toHaveValue('Draft name');
   });

--- a/frontend/src/components/builder/__tests__/AnalysisPanel.test.tsx
+++ b/frontend/src/components/builder/__tests__/AnalysisPanel.test.tsx
@@ -1447,6 +1447,17 @@ describe('AnalysisPanel — stack-selected layer (#772)', () => {
     expect(screen.getByText('Creating dataset…')).toBeInTheDocument();
   });
 
+  it('marks the clear-preview and add-to-map controls with explicit button types', () => {
+    // The panel is a <form> now — an unmarked <button> inside it submits.
+    renderPanel([datasetLayer], { hasPreview: true });
+    expect(
+      screen.getByRole('button', { name: 'Clear preview' }),
+    ).toHaveAttribute('type', 'button');
+    expect(
+      screen.getByRole('button', { name: 'Create dataset' }),
+    ).toHaveAttribute('type', 'button');
+  });
+
   it('clears a panel-owned overlay when the selection displaces the remembered layer', async () => {
     const onClearPreview = vi.fn();
     useAnalysisFormStore.getState().save('m1', {
@@ -1463,5 +1474,295 @@ describe('AnalysisPanel — stack-selected layer (#772)', () => {
     // The overlay depicts the displaced layer's preview — stale for the same
     // reason a vanished layer's would be.
     await waitFor(() => expect(onClearPreview).toHaveBeenCalled());
+  });
+});
+
+describe('AnalysisPanel — audit remediation (v1.6.0)', () => {
+  beforeEach(() => {
+    mockJobStatus.value = null;
+    mockJobStatus.error = null;
+    useAnalysisFormStore.setState({ forms: {} });
+    useAnalysisJobStore.setState({ job: null });
+    useAuthStore.setState({ token: null, refreshToken: null, user: null });
+    vi.mocked(previewAnalysis).mockClear();
+    vi.mocked(materializeAnalysis).mockClear();
+    mockToast.error.mockClear();
+    mockTerraDraw.instance.stop.mockClear();
+    mockTerraDraw.instance.addFeatures.mockClear();
+  });
+
+  it("does not warn 'another analysis' during its own run's tracking gaps", async () => {
+    // onAnalysisJobChange fires inside the mutationFn, setJobId only in
+    // onSuccess, and the first poll lands later still — during both gaps the
+    // tracked job is OURS, so the foreign-job banner must stay silent.
+    let resolveMaterialize!: (v: unknown) => void;
+    vi.mocked(materializeAnalysis).mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveMaterialize = resolve;
+        }) as never,
+    );
+    renderPanel([datasetLayer], { mapId: 'm1' });
+    fireEvent.change(screen.getByLabelText('New dataset name'), {
+      target: { value: 'Own run' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Create dataset' }));
+    await waitFor(() => expect(materializeAnalysis).toHaveBeenCalled());
+
+    // The page registers the job globally while the POST is still pending.
+    act(() => {
+      useAnalysisJobStore.setState({
+        job: { jobId: 'own-job', title: 'Own run', mapId: 'm1' },
+      });
+    });
+    expect(
+      screen.queryByText(
+        'Another analysis is still running — wait for it to finish.',
+      ),
+    ).not.toBeInTheDocument();
+
+    resolveMaterialize({ job_id: 'own-job', status: 'pending' });
+    await new Promise((r) => setTimeout(r, 0));
+    // onSuccess → first poll: jobId set, no status observed yet.
+    expect(
+      screen.queryByText(
+        'Another analysis is still running — wait for it to finish.',
+      ),
+    ).not.toBeInTheDocument();
+  });
+
+  it('Escape during a clip draw cancels the draw, not the panel', async () => {
+    const user = userEvent.setup();
+    renderPanel([datasetLayer], {
+      mapInstanceRef: { current: { on: vi.fn(), off: vi.fn() } as never },
+    });
+    await user.click(screen.getAllByRole('combobox')[1]);
+    await user.click(await screen.findByRole('option', { name: 'Clip' }));
+    await user.click(screen.getByRole('button', { name: 'Draw clip area' }));
+
+    // The Draw→Cancel swap moves focus onto Cancel — without this the
+    // keystroke below lands on <body> and never reaches the panel.
+    const cancel = screen.getByRole('button', { name: 'Cancel' });
+    expect(cancel).toHaveFocus();
+
+    // fireEvent returns false when preventDefault fired — the consumed
+    // Escape is what keeps BuilderRail's handler from closing the panel.
+    const notPrevented = fireEvent.keyDown(cancel, { key: 'Escape' });
+    expect(notPrevented).toBe(false);
+    expect(mockTerraDraw.instance.stop).toHaveBeenCalled();
+
+    // Back to the idle state, focus returned to the Draw button.
+    const draw = await screen.findByRole('button', { name: 'Draw clip area' });
+    expect(draw).toHaveFocus();
+  });
+
+  it('Escape without a pending draw is left for the rail to handle', () => {
+    renderPanel([datasetLayer]);
+    const notPrevented = fireEvent.keyDown(screen.getByLabelText('Distance'), {
+      key: 'Escape',
+    });
+    // Not consumed: closing the panel on Escape is BuilderRail's job.
+    expect(notPrevented).toBe(true);
+  });
+
+  it('keeps the cap attainable across a unit switch (100 000 m → feet)', async () => {
+    const user = userEvent.setup();
+    renderPanel([datasetLayer]);
+    fireEvent.change(screen.getByLabelText('Distance'), {
+      target: { value: '100000' },
+    });
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+
+    await user.click(screen.getAllByRole('combobox')[2]);
+    await user.click(await screen.findByRole('option', { name: 'feet' }));
+    // Was 328 084 ft (6-significant-digit round UP = 100 000.0032 m), which
+    // the panel then flagged invalid against its own stated maximum. The
+    // conversion now rounds DOWN to the cap in the target unit.
+    expect(screen.getByLabelText('Distance')).toHaveValue(328083.98);
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Preview' })).not.toBeDisabled();
+  });
+
+  it('caps the distance input at an attainable stated maximum', () => {
+    renderPanel([datasetLayer]);
+    // The max attribute matches the floored, attainable cap the range
+    // message states — 100 000 m is exact in metres.
+    expect(screen.getByLabelText('Distance')).toHaveAttribute('max', '100000');
+  });
+
+  it('submits Preview on Enter via the form (D10)', async () => {
+    renderPanel([datasetLayer]);
+    fireEvent.submit(screen.getByTestId('analysis-panel'));
+    await waitFor(() =>
+      expect(previewAnalysis).toHaveBeenCalledWith('ds1', {
+        operation: 'buffer',
+        distance_meters: 500,
+      }),
+    );
+  });
+
+  it('ignores a form submit while the inputs are invalid (D10)', () => {
+    renderPanel([datasetLayer]);
+    fireEvent.change(screen.getByLabelText('Distance'), {
+      target: { value: '0' },
+    });
+    fireEvent.submit(screen.getByTestId('analysis-panel'));
+    expect(previewAnalysis).not.toHaveBeenCalled();
+  });
+
+  it('explains the disabled Create button via a static hint (D6)', () => {
+    renderPanel([datasetLayer]);
+    const createButton = screen.getByRole('button', { name: 'Create dataset' });
+    expect(createButton).toBeDisabled();
+    expect(createButton).toHaveAttribute(
+      'aria-describedby',
+      'analysis-save-hint',
+    );
+    const hint = document.getElementById('analysis-save-hint');
+    expect(hint).toHaveTextContent(
+      'Enter a name for the new dataset to enable Create dataset.',
+    );
+    // Deliberately OUTSIDE the polite status region — a live region would
+    // narrate the hint on every keystroke.
+    expect(screen.getByRole('status')).not.toContainElement(hint);
+
+    // With the name typed, the reason (and describedby) go away.
+    fireEvent.change(screen.getByLabelText('New dataset name'), {
+      target: { value: 'Named' },
+    });
+    expect(createButton).not.toBeDisabled();
+    expect(createButton).not.toHaveAttribute('aria-describedby');
+  });
+
+  it('points the hint at the invalid parameters once a name exists (D6)', () => {
+    renderPanel([datasetLayer]);
+    fireEvent.change(screen.getByLabelText('New dataset name'), {
+      target: { value: 'Named' },
+    });
+    fireEvent.change(screen.getByLabelText('Distance'), {
+      target: { value: '0' },
+    });
+    expect(document.getElementById('analysis-save-hint')).toHaveTextContent(
+      'Complete the operation settings above to enable Create dataset.',
+    );
+  });
+
+  it('marks the panel Add to map used after one click', async () => {
+    mockJobStatus.value = { status: 'complete', dataset_id: 'out1' };
+    const onAddDataset = vi.fn();
+    renderPanel([datasetLayer], {
+      mapId: 'm1',
+      layerActions: { onAddDataset } as never,
+    });
+    fireEvent.change(screen.getByLabelText('New dataset name'), {
+      target: { value: 'Out' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Create dataset' }));
+
+    // The test i18n mock returns the raw template, uninterpolated.
+    const addButton = await screen.findByRole('button', {
+      name: 'Add "{{name}}" to map',
+    });
+    fireEvent.click(addButton);
+    expect(onAddDataset).toHaveBeenCalledTimes(1);
+
+    // Completion also raises the watcher's toast action — each affordance is
+    // single-use so the pair can't add the layer twice.
+    const usedButton = screen.getByRole('button', { name: 'Added to map' });
+    expect(usedButton).toBeDisabled();
+    fireEvent.click(usedButton);
+    expect(onAddDataset).toHaveBeenCalledTimes(1);
+  });
+
+  it('sets aria-busy on the pending Preview button', async () => {
+    let resolvePreview!: (v: unknown) => void;
+    vi.mocked(previewAnalysis).mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolvePreview = resolve;
+        }) as never,
+    );
+    renderPanel([datasetLayer]);
+    const previewButton = screen.getByRole('button', { name: 'Preview' });
+    expect(previewButton).not.toHaveAttribute('aria-busy');
+    fireEvent.click(previewButton);
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: 'Running…' })).toHaveAttribute(
+        'aria-busy',
+        'true',
+      ),
+    );
+    resolvePreview({
+      geojson: { type: 'FeatureCollection', features: [] },
+      feature_count: 0,
+      truncated: false,
+      bbox: null,
+    });
+    await waitFor(() =>
+      expect(
+        screen.getByRole('button', { name: 'Preview' }),
+      ).not.toHaveAttribute('aria-busy'),
+    );
+  });
+
+  it('sets aria-busy on the pending Create dataset button', async () => {
+    vi.mocked(materializeAnalysis).mockImplementationOnce(
+      () => new Promise(() => {}) as never,
+    );
+    renderPanel([datasetLayer]);
+    fireEvent.change(screen.getByLabelText('New dataset name'), {
+      target: { value: 'Busy' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Create dataset' }));
+    await waitFor(() =>
+      expect(
+        screen.getByRole('button', { name: 'Creating…' }),
+      ).toHaveAttribute('aria-busy', 'true'),
+    );
+  });
+
+  it('retries a failed mask restore on a later commit', async () => {
+    // The latch used to be set BEFORE the attempt, so one failure left the
+    // mask applied but never visible, with no retry — mirrors
+    // use-ephemeral-layers' retry-until-attached idiom now.
+    mockTerraDraw.instance.addFeatures.mockImplementationOnce(() => {
+      throw new Error('unsupported geometry');
+    });
+    useAnalysisFormStore.getState().save('m1', {
+      layerId: 'l1', operation: 'clip', distance: '500', distanceUnit: 'm',
+      mask: {
+        type: 'Polygon',
+        coordinates: [[[0, 0], [1, 0], [1, 1], [0, 0]]],
+      },
+      maskLayerId: '__none__', byField: '__none__', outputTitle: '',
+    });
+    const qc = new QueryClient({
+      defaultOptions: { mutations: { retry: false } },
+    });
+    const mapRef = { current: { on: vi.fn(), off: vi.fn() } };
+    // A fresh element each time — rerendering the SAME element reference
+    // hits React's same-element bailout and skips the subtree entirely.
+    const renderTree = () => (
+      <QueryClientProvider client={qc}>
+        <AnalysisPanel
+          layers={[datasetLayer]}
+          mapId="m1"
+          mapInstanceRef={mapRef as never}
+        />
+      </QueryClientProvider>
+    );
+    const view = render(renderTree());
+    // First attempt failed and tore itself down.
+    await waitFor(() =>
+      expect(mockTerraDraw.instance.addFeatures).toHaveBeenCalledTimes(1),
+    );
+    expect(mockTerraDraw.instance.stop).toHaveBeenCalled();
+
+    // The next commit retries and succeeds.
+    view.rerender(renderTree());
+    await waitFor(() =>
+      expect(mockTerraDraw.instance.addFeatures).toHaveBeenCalledTimes(2),
+    );
+    expect(mockTerraDraw.instance.setMode).toHaveBeenLastCalledWith('static');
   });
 });

--- a/frontend/src/components/builder/__tests__/BasemapGroupRow.test.tsx
+++ b/frontend/src/components/builder/__tests__/BasemapGroupRow.test.tsx
@@ -1,4 +1,5 @@
 import { fireEvent, render, screen } from '@/test/test-utils';
+import userEvent from '@testing-library/user-event';
 import { BasemapGroupRow } from '../BasemapGroupRow';
 import type { DraggableAttributes, DraggableSyntheticListeners } from '@dnd-kit/core';
 
@@ -72,6 +73,48 @@ function defaultProps(overrides: Partial<React.ComponentProps<typeof BasemapGrou
     ...overrides,
   };
 }
+
+// a11y(v1.6.0 audit A7, WCAG 2.1.1): Enter on the basemap caret was dead — the
+// row-container keydown preventDefaulted Enter/Space from descendants.
+describe('BasemapGroupRow keyboard operability (v1.6.0 audit A7)', () => {
+  it('Enter on the focused caret toggles expansion instead of selecting the row', async () => {
+    const user = userEvent.setup();
+    const onToggleExpand = vi.fn();
+    const onSelectGroup = vi.fn();
+    render(<BasemapGroupRow {...defaultProps({ groupId: 'bm', onToggleExpand, onSelectGroup })} />);
+
+    const caret = screen.getByRole('button', { name: 'Toggle basemap group' });
+    caret.focus();
+    await user.keyboard('{Enter}');
+
+    expect(onToggleExpand).toHaveBeenCalledOnce();
+    expect(onToggleExpand).toHaveBeenCalledWith('bm');
+    expect(onSelectGroup).not.toHaveBeenCalled();
+  });
+
+  it('Space on the focused eye toggles visibility instead of selecting the row', async () => {
+    const user = userEvent.setup();
+    const onToggleVisibility = vi.fn();
+    const onSelectGroup = vi.fn();
+    render(<BasemapGroupRow {...defaultProps({ groupId: 'bm', onToggleVisibility, onSelectGroup })} />);
+
+    const eye = screen.getByRole('button', { name: /Toggle visibility/i });
+    eye.focus();
+    await user.keyboard(' ');
+
+    expect(onToggleVisibility).toHaveBeenCalledOnce();
+    expect(onToggleVisibility).toHaveBeenCalledWith('bm');
+    expect(onSelectGroup).not.toHaveBeenCalled();
+  });
+
+  it('Enter on the row container itself still selects the basemap group', () => {
+    const onSelectGroup = vi.fn();
+    render(<BasemapGroupRow {...defaultProps({ groupId: 'bm', onSelectGroup })} />);
+
+    fireEvent.keyDown(document.getElementById('stack-row-bm')!, { key: 'Enter' });
+    expect(onSelectGroup).toHaveBeenCalledWith('bm');
+  });
+});
 
 describe('BasemapGroupRow', () => {
   it('Test 1: renders with ⊞ glyph in the type-icon cell', () => {

--- a/frontend/src/components/builder/__tests__/BuilderRail.test.tsx
+++ b/frontend/src/components/builder/__tests__/BuilderRail.test.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { fireEvent, screen, waitFor, within } from '@testing-library/react';
+import { fireEvent, screen, waitFor } from '@testing-library/react';
 import { render } from '@/test/test-utils';
 import { BuilderRail, type RailPanel } from '../BuilderRail';
 import * as availabilityModule from '@/hooks/use-ai-availability';
@@ -212,7 +212,11 @@ describe('fix(#788 item 5) — named aside landmarks', () => {
 });
 
 describe('MAP-22 — Notes presence indicator', () => {
-  it('renders presence dot when notes is non-empty', () => {
+  // The dot is decorative (aria-hidden); the state is exposed via the notes
+  // BUTTON's conditional accessible name (aria-label replaces the subtree, so
+  // a label on the span was never announced — and aria-label on a role-less
+  // span is invalid ARIA).
+  it('folds notes presence into the button accessible name and renders a decorative dot', () => {
     render(
       <BuilderRail
         activePanel={null}
@@ -225,15 +229,14 @@ describe('MAP-22 — Notes presence indicator', () => {
       />,
     );
 
-    const notesButton = screen.getByRole('button', { name: /notes/i });
-    const dot = within(notesButton).getByLabelText('Map has notes');
-    expect(dot).toBeInTheDocument();
-    expect(dot.className).toContain('size-1.5');
-    expect(dot.className).toContain('rounded-full');
-    expect(dot.className).toContain('bg-primary');
+    const notesButton = screen.getByRole('button', { name: 'Notes (map has notes)' });
+    const dot = notesButton.querySelector('[aria-hidden="true"].bg-primary');
+    expect(dot).not.toBeNull();
+    expect(dot!.className).toContain('size-1.5');
+    expect(dot!.className).toContain('rounded-full');
   });
 
-  it('does NOT render presence dot when notes is empty or whitespace', () => {
+  it('does NOT signal notes presence when notes is empty or whitespace', () => {
     const whitespaceVariants = ['', '   ', '\n', '\t\n  '];
 
     for (const notes of whitespaceVariants) {
@@ -249,7 +252,8 @@ describe('MAP-22 — Notes presence indicator', () => {
         />,
       );
 
-      expect(screen.queryByLabelText('Map has notes')).toBeNull();
+      expect(screen.queryByRole('button', { name: 'Notes (map has notes)' })).toBeNull();
+      expect(screen.getByRole('button', { name: 'Notes' })).toBeInTheDocument();
       unmount();
     }
   });
@@ -268,10 +272,10 @@ describe('MAP-22 — Notes presence indicator', () => {
     );
 
     const historyButton = screen.getByRole('button', { name: /history/i });
-    expect(within(historyButton).queryByLabelText('Map has notes')).toBeNull();
+    expect(historyButton.querySelector('[aria-hidden="true"].bg-primary')).toBeNull();
 
     const aiButton = screen.getByRole('button', { name: /ask ai/i });
-    expect(within(aiButton).queryByLabelText('Map has notes')).toBeNull();
+    expect(aiButton.querySelector('[aria-hidden="true"].bg-primary')).toBeNull();
   });
 });
 

--- a/frontend/src/components/builder/__tests__/BulkActionBar.test.tsx
+++ b/frontend/src/components/builder/__tests__/BulkActionBar.test.tsx
@@ -524,7 +524,7 @@ describe('BulkActionBar — bulk handler invocations (POL-09)', () => {
 // ---------------------------------------------------------------------------
 
 describe('BulkActionBar — isDeleting prop (PERF-03)', () => {
-  it('Test 20: isDeleting=true replaces Trash2 icon with Loader2 spinner in Delete confirm button area', () => {
+  it('Test 20: isDeleting=true replaces Trash2 icon with Loader2 spinner in Delete confirm button area', async () => {
     // When isDeleting=true, the confirm state shows the spinner in place of the trash icon.
     // We verify by checking for a component with animate-spin class (Loader2 pattern).
     const { container } = render(
@@ -539,9 +539,11 @@ describe('BulkActionBar — isDeleting prop (PERF-03)', () => {
     // The aria-live region should announce the deleting state.
     const liveRegion = container.querySelector('[aria-live="polite"]');
     expect(liveRegion).not.toBeNull();
-    // The live region text contains count or deleting key
-    const liveText = liveRegion?.textContent ?? '';
-    expect(liveText.length).toBeGreaterThan(0);
+    // fix(v1.6.0 audit): the live region mounts EMPTY and populates on the rAF
+    // tick, so the deleting text arrives asynchronously.
+    await waitFor(() => {
+      expect((liveRegion?.textContent ?? '').length).toBeGreaterThan(0);
+    });
   });
 
   it('Test 21: isDeleting=true sets aria-busy=true on the Delete button and disables it', () => {
@@ -609,16 +611,142 @@ describe('BulkActionBar — deletable count excludes group rows (fix #771)', () 
     expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument();
   });
 
-  it('the deleting state announces the deletable count, not the selection size', () => {
-    // 2 data layers + 1 group row; the batch actually deleting is 2.
+  it('the deleting state announces the hook-captured batch size, not the emptied selection', async () => {
+    // fix(v1.6.0 audit A5): while a delete is in flight the optimistic removal
+    // has ALREADY dropped the selected rows from `layers`, so the
+    // selection-derived deletable count is 0. The real bar renders the
+    // deletingCount the hook captured synchronously before the removal.
     const { container } = render(
       <BulkActionBar
-        {...makeProps({ selectedIds: new Set(['a', 'b', 'g1']) })}
+        {...makeProps({
+          selectedIds: new Set(['a', 'b', 'g1']),
+          // a + b optimistically removed; the emptied group row g1 pruned too
+          layers: [vecC, raster1],
+        })}
         isDeleting={true}
+        deletingCount={2}
       />,
     );
 
     const liveRegion = container.querySelector('[aria-live="polite"]');
-    expect(liveRegion?.textContent).toContain('bulkActions.deletingLayers 2');
+    // Live region populates on the rAF tick (mounts empty by design).
+    await waitFor(() => {
+      expect(liveRegion?.textContent).toContain('bulkActions.deletingLayers 2');
+    });
+    // The visible label and busy button also use the captured batch size.
+    expect(screen.getAllByText(/bulkActions.deletingLayers 2/).length).toBeGreaterThan(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// BulkActionBar — delete-confirm modal semantics + focus (v1.6.0 audit A3)
+// ---------------------------------------------------------------------------
+
+describe('BulkActionBar — delete-confirm modal semantics and exit focus (v1.6.0 audit A3)', () => {
+  function openConfirm() {
+    fireEvent.pointerDown(screen.getByTestId('bulk-action-overflow'), { button: 0, ctrlKey: false });
+    fireEvent.click(screen.getByTestId('bulk-action-delete'));
+  }
+
+  it('the confirm carries aria-modal="true"', () => {
+    render(<BulkActionBar {...makeProps({ selectedIds: new Set(['a', 'b']) })} />);
+    openConfirm();
+    expect(screen.getByRole('alertdialog')).toHaveAttribute('aria-modal', 'true');
+  });
+
+  it('Tab from the last control wraps to the first (focus trap)', () => {
+    render(<BulkActionBar {...makeProps({ selectedIds: new Set(['a', 'b']) })} />);
+    openConfirm();
+    const dialog = screen.getByRole('alertdialog');
+    const buttons = Array.from(dialog.querySelectorAll('button'));
+    expect(buttons.length).toBe(2);
+    const [cancelBtn, deleteBtn] = buttons;
+
+    deleteBtn.focus();
+    fireEvent.keyDown(dialog, { key: 'Tab' });
+    expect(document.activeElement).toBe(cancelBtn);
+
+    // Shift+Tab from the first wraps back to the last.
+    fireEvent.keyDown(dialog, { key: 'Tab', shiftKey: true });
+    expect(document.activeElement).toBe(deleteBtn);
+  });
+
+  it('Cancel restores focus into the bar instead of dropping it on <body>', async () => {
+    render(<BulkActionBar {...makeProps({ selectedIds: new Set(['a', 'b']) })} />);
+    openConfirm();
+    const dialog = screen.getByRole('alertdialog');
+    const cancelBtn = dialog.querySelectorAll('button')[0];
+    fireEvent.click(cancelBtn);
+
+    // Restore happens on a rAF tick; focus must land on a bar control (the
+    // visibility button is the first enabled control in the normal state).
+    await waitFor(() => {
+      expect(document.activeElement).not.toBe(document.body);
+      expect(screen.getByRole('toolbar').contains(document.activeElement)).toBe(true);
+    });
+  });
+
+  it('Escape restores focus into the bar', async () => {
+    render(<BulkActionBar {...makeProps({ selectedIds: new Set(['a', 'b']) })} />);
+    openConfirm();
+    fireEvent.keyDown(screen.getByRole('toolbar'), { key: 'Escape' });
+    expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument();
+    await waitFor(() => {
+      expect(document.activeElement).not.toBe(document.body);
+      expect(screen.getByRole('toolbar').contains(document.activeElement)).toBe(true);
+    });
+  });
+
+  it('confirming restores focus to a stable element while the trigger is unmounted', async () => {
+    // The pre-confirm trigger (overflow Delete item) unmounts on confirm; the
+    // deleting state's only button is disabled, so focus falls back to the bar
+    // itself (tabIndex=-1), never <body>.
+    const onBulkDelete = vi.fn();
+    const { rerender } = render(
+      <BulkActionBar
+        {...makeProps({ selectedIds: new Set(['a', 'b']) })}
+        onBulkDelete={onBulkDelete}
+      />,
+    );
+    openConfirm();
+    const dialog = screen.getByRole('alertdialog');
+    const deleteBtn = dialog.querySelectorAll('button')[1];
+    fireEvent.click(deleteBtn);
+    expect(onBulkDelete).toHaveBeenCalled();
+
+    // Simulate the hook flipping to the deleting state in the same interaction.
+    rerender(
+      <BulkActionBar
+        {...makeProps({ selectedIds: new Set(['a', 'b']), layers: [vecC, raster1] })}
+        onBulkDelete={onBulkDelete}
+        isDeleting={true}
+        deletingCount={2}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(document.activeElement).not.toBe(document.body);
+      expect(screen.getByRole('toolbar').contains(document.activeElement) ||
+        document.activeElement === screen.getByRole('toolbar')).toBe(true);
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// BulkActionBar — live region mounts empty (v1.6.0 audit)
+// ---------------------------------------------------------------------------
+
+describe('BulkActionBar — live region mounts empty then populates', () => {
+  it('is empty at mount and announces the selection on the rAF tick', async () => {
+    vi.useFakeTimers();
+    const { container } = render(<BulkActionBar {...makeProps({ selectedIds: new Set(['a', 'b']) })} />);
+    const liveRegion = container.querySelector('[aria-live="polite"]');
+    // Present-at-mount content is skipped by screen readers — must start empty.
+    expect(liveRegion?.textContent ?? '').toBe('');
+    await act(async () => {
+      vi.runAllTimers();
+    });
+    vi.useRealTimers();
+    expect(liveRegion?.textContent).toContain('bulkActions.liveAnnouncement 2');
   });
 });

--- a/frontend/src/components/builder/__tests__/DatasetSearchPanel.test.tsx
+++ b/frontend/src/components/builder/__tests__/DatasetSearchPanel.test.tsx
@@ -301,8 +301,10 @@ describe('DatasetSearchPanel', () => {
 
     render(<DatasetSearchPanel {...defaultProps()} />);
 
-    const statusEl = await screen.findByRole('status');
-    expect(statusEl).toBeInTheDocument();
+    // The live region is permanently mounted (content toggles), so wait for
+    // the empty-state copy to arrive rather than for the region itself.
+    expect(await screen.findByText(/Your catalog is empty/)).toBeInTheDocument();
+    const statusEl = screen.getByRole('status');
     expect(statusEl.textContent).toMatch(/Your catalog is empty/);
 
     // Upload CTA link
@@ -333,7 +335,7 @@ describe('DatasetSearchPanel', () => {
         features: [],
       });
       render(<DatasetSearchPanel {...defaultProps()} />);
-      expect(await screen.findByRole('status')).toBeInTheDocument();
+      expect(await screen.findByText(/Your catalog is empty/)).toBeInTheDocument();
       expect(screen.queryByRole('link', { name: /upload a file/i })).not.toBeInTheDocument();
     });
 
@@ -362,8 +364,10 @@ describe('DatasetSearchPanel', () => {
     vi.advanceTimersByTime(400);
     vi.useRealTimers();
 
-    const statusEl = await screen.findByRole('status');
-    // i18n mock returns defaultValue without interpolation, so assert patterns separately
+    // The live region is permanently mounted (content toggles) — wait for the
+    // zero-result copy itself.
+    expect(await screen.findByText(/No datasets match/)).toBeInTheDocument();
+    const statusEl = screen.getByRole('status');
     expect(statusEl.textContent).toMatch(/No datasets match/);
 
     // Clear search button resets the query

--- a/frontend/src/components/builder/__tests__/EmptyStackState.test.tsx
+++ b/frontend/src/components/builder/__tests__/EmptyStackState.test.tsx
@@ -139,6 +139,17 @@ describe('EmptyStackState', () => {
     expect(onOpenAddData).not.toHaveBeenCalled();
   });
 
+  // fix(v1.6.0 audit D12): the searchbox role comes natively from
+  // type="search" (plus the browser's built-in Escape-clear) instead of a
+  // hand-rolled role attribute on a text input.
+  it('Test 4b (D12): the inline search is a native type="search" input, not role="searchbox"', () => {
+    render(<EmptyStackState {...defaultProps()} />);
+
+    const input = screen.getByRole('searchbox');
+    expect(input).toHaveAttribute('type', 'search');
+    expect(input).not.toHaveAttribute('role');
+  });
+
   it('Test 5: renders SUGGESTED eyebrow label and list with correct aria attributes', async () => {
     render(<EmptyStackState {...defaultProps()} />);
 

--- a/frontend/src/components/builder/__tests__/FolderGroupRow.test.tsx
+++ b/frontend/src/components/builder/__tests__/FolderGroupRow.test.tsx
@@ -116,6 +116,9 @@ describe('FolderGroupRow keyboard operability (v1.6.0 audit A7)', () => {
 
     fireEvent.dblClick(screen.getByText('My Group'));
     const input = screen.getByRole('textbox', { name: 'Group name' });
+    // Let the hook's deferred focus+select() run before typing — otherwise it
+    // fires mid-type and the select() swallows already-typed characters.
+    await act(() => new Promise<void>((r) => requestAnimationFrame(() => r())));
     await user.clear(input);
     await user.type(input, 'a b');
     expect(input).toHaveValue('a b');
@@ -140,8 +143,14 @@ describe('FolderGroupRow keyboard operability (v1.6.0 audit A7)', () => {
 
     // The confirm mounts INSIDE the row div — its buttons' Enter/Space used to
     // bubble to the container keydown and be preventDefaulted (mouse-only).
+    // Radix returns focus to the kebab trigger asynchronously on menu close;
+    // wait it out so our focus() isn't stolen back before the keypress.
+    await act(() => new Promise<void>((r) => requestAnimationFrame(() => r())));
     const deleteBtn = screen.getByRole('button', { name: 'Delete all' });
-    deleteBtn.focus();
+    await vi.waitFor(() => {
+      deleteBtn.focus();
+      expect(deleteBtn).toHaveFocus();
+    });
     await user.keyboard('{Enter}');
 
     expect(props.onDeleteGroup).toHaveBeenCalledOnce();

--- a/frontend/src/components/builder/__tests__/FolderGroupRow.test.tsx
+++ b/frontend/src/components/builder/__tests__/FolderGroupRow.test.tsx
@@ -1,4 +1,5 @@
 import { act, fireEvent, render, screen, within } from '@/test/test-utils';
+import userEvent from '@testing-library/user-event';
 import { FolderGroupRow } from '../FolderGroupRow';
 import { useInlineRename } from '../useInlineRename';
 import type { DraggableAttributes, DraggableSyntheticListeners } from '@dnd-kit/core';
@@ -72,6 +73,100 @@ function defaultProps(overrides: Partial<React.ComponentProps<typeof FolderGroup
     ...overrides,
   };
 }
+
+// a11y(v1.6.0 audit A7, WCAG 2.1.1): the row-container keydown preventDefaulted
+// Enter/Space from descendants, so the caret, eye, rename input, and the
+// delete-confirm buttons were mouse-only. user-event 14 implements native
+// keyboard activation gated on defaultPrevented.
+describe('FolderGroupRow keyboard operability (v1.6.0 audit A7)', () => {
+  it('Enter on the focused caret toggles expansion instead of selecting the row', async () => {
+    const user = userEvent.setup();
+    const props = defaultProps();
+    render(<FolderGroupRow {...props} />);
+
+    const caret = screen.getByRole('button', { name: 'Toggle folder group' });
+    caret.focus();
+    await user.keyboard('{Enter}');
+
+    expect(props.onToggleExpand).toHaveBeenCalledOnce();
+    expect(props.onToggleExpand).toHaveBeenCalledWith('group-1');
+    expect(props.onSelectGroup).not.toHaveBeenCalled();
+  });
+
+  it('Space on the focused eye toggles visibility without toggling multi-selection', async () => {
+    const user = userEvent.setup();
+    const onCmdClick = vi.fn();
+    const props = defaultProps({ onCmdClick });
+    render(<FolderGroupRow {...props} />);
+
+    const eye = screen.getByRole('button', { name: 'Toggle visibility for My Group' });
+    eye.focus();
+    await user.keyboard(' ');
+
+    expect(props.onToggleVisibility).toHaveBeenCalledOnce();
+    expect(props.onToggleVisibility).toHaveBeenCalledWith('group-1');
+    expect(onCmdClick).not.toHaveBeenCalled();
+    expect(props.onSelectGroup).not.toHaveBeenCalled();
+  });
+
+  it('a space can be typed into the group rename input and Enter commits without re-firing the row action', async () => {
+    const user = userEvent.setup();
+    const props = defaultProps();
+    render(<FolderGroupRow {...props} />);
+
+    fireEvent.dblClick(screen.getByText('My Group'));
+    const input = screen.getByRole('textbox', { name: 'Group name' });
+    await user.clear(input);
+    await user.type(input, 'a b');
+    expect(input).toHaveValue('a b');
+
+    await user.keyboard('{Enter}');
+
+    expect(props.onRenameGroup).toHaveBeenCalledOnce();
+    expect(props.onRenameGroup).toHaveBeenCalledWith('group-1', 'a b');
+    expect(props.onSelectGroup).not.toHaveBeenCalled();
+  });
+
+  it('the delete confirm is keyboard-operable: Enter on "Delete all" deletes the group', async () => {
+    const user = userEvent.setup();
+    const props = defaultProps();
+    render(<FolderGroupRow {...props} />);
+
+    fireEvent.pointerDown(
+      screen.getByRole('button', { name: /Group options for/i }),
+      { button: 0, ctrlKey: false },
+    );
+    fireEvent.click(screen.getByRole('menuitem', { name: /Delete group/i }));
+
+    // The confirm mounts INSIDE the row div — its buttons' Enter/Space used to
+    // bubble to the container keydown and be preventDefaulted (mouse-only).
+    const deleteBtn = screen.getByRole('button', { name: 'Delete all' });
+    deleteBtn.focus();
+    await user.keyboard('{Enter}');
+
+    expect(props.onDeleteGroup).toHaveBeenCalledOnce();
+    expect(props.onDeleteGroup).toHaveBeenCalledWith('group-1');
+  });
+
+  it('the delete confirm cancel is keyboard-operable: Space on "Keep group" dismisses it', async () => {
+    const user = userEvent.setup();
+    const props = defaultProps();
+    render(<FolderGroupRow {...props} />);
+
+    fireEvent.pointerDown(
+      screen.getByRole('button', { name: /Group options for/i }),
+      { button: 0, ctrlKey: false },
+    );
+    fireEvent.click(screen.getByRole('menuitem', { name: /Delete group/i }));
+
+    const cancelBtn = screen.getByRole('button', { name: 'Keep group' });
+    cancelBtn.focus();
+    await user.keyboard(' ');
+
+    expect(props.onDeleteGroup).not.toHaveBeenCalled();
+    expect(screen.queryByRole('button', { name: 'Delete all' })).not.toBeInTheDocument();
+  });
+});
 
 describe('FolderGroupRow', () => {
   it('forwards grip keys to the dnd-kit keyboard activator (fix #759)', () => {

--- a/frontend/src/components/builder/__tests__/LayerStyleEditor.test.tsx
+++ b/frontend/src/components/builder/__tests__/LayerStyleEditor.test.tsx
@@ -162,12 +162,35 @@ describe('LayerStyleEditor - SP-05 pending preview banner gating', () => {
       />,
     );
 
+    // Reset now confirms before destroying render mode + classification:
+    // the header action opens the inline confirm, "Reset style" applies it.
     await user.click(screen.getByRole('button', { name: 'Reset' }));
+    expect(onStyleConfigChange).not.toHaveBeenCalled();
+    await user.click(screen.getByRole('button', { name: 'Reset style' }));
     expect(onStyleConfigChange).toHaveBeenCalledWith('layer-1', null, expect.objectContaining({
       'fill-color': expect.any(String),
       'fill-opacity': expect.any(Number),
     }));
     expect(onOpacityChange).toHaveBeenCalledWith('layer-1', 1);
+  });
+
+  it('section-header Reset can be cancelled without touching the style', async () => {
+    const onStyleConfigChange = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <LayerStyleEditor
+        layer={makeLayer({ dataset_geometry_type: 'Polygon' })}
+        onPaintChange={vi.fn()}
+        onOpacityChange={vi.fn()}
+        onStyleConfigChange={onStyleConfigChange}
+        onLayoutChange={vi.fn()}
+      />,
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Reset' }));
+    await user.click(screen.getByRole('button', { name: 'Keep style' }));
+    expect(onStyleConfigChange).not.toHaveBeenCalled();
+    expect(screen.queryByRole('button', { name: 'Reset style' })).toBeNull();
   });
 });
 
@@ -1358,7 +1381,9 @@ describe('LayerStyleEditor — EDIT-02 always-visible Reset in appearance sectio
       />,
     );
 
+    // Reset now confirms first — apply via the inline confirm's "Reset style".
     await user.click(screen.getByRole('button', { name: 'Reset' }));
+    await user.click(screen.getByRole('button', { name: 'Reset style' }));
     expect(onStyleConfigChange).toHaveBeenCalledWith('layer-1', null, expect.objectContaining({
       'fill-color': expect.any(String),
       'fill-opacity': expect.any(Number),

--- a/frontend/src/components/builder/__tests__/StackRow.test.tsx
+++ b/frontend/src/components/builder/__tests__/StackRow.test.tsx
@@ -1,4 +1,5 @@
-import { fireEvent, render, screen, within } from '@/test/test-utils';
+import { act, fireEvent, render, screen, within } from '@/test/test-utils';
+import userEvent from '@testing-library/user-event';
 import { StackRow } from '../StackRow';
 import { MAP_COLORS } from '@/lib/map-colors';
 import type { MapLayerResponse } from '@/types/api';
@@ -809,6 +810,142 @@ describe('Add to group sub-flow', () => {
       // Columns line shows the count (3)
       expect(sourceBlock).toHaveTextContent('3');
     });
+  });
+});
+
+// a11y(v1.6.0 audit A7, WCAG 2.1.1): the row-container keydown used to
+// preventDefault Enter/Space with no target guard, cancelling native button
+// activation on every descendant and swallowing spaces typed into the rename
+// input. user-event 14 implements real keyboard activation (gated on
+// defaultPrevented), so these prove the descendants work again.
+describe('row keydown target guard (v1.6.0 audit A7)', () => {
+  it('Space on the focused eye toggle activates it without toggling multi-selection', async () => {
+    const user = userEvent.setup();
+    const onToggleVisibility = vi.fn();
+    const onCmdClick = vi.fn();
+    const onSelectLayer = vi.fn();
+    render(
+      <StackRow {...defaultProps({ onToggleVisibility, onSelectLayer })} onCmdClick={onCmdClick} />,
+    );
+
+    const eye = screen.getByRole('button', { name: /Toggle visibility/i });
+    eye.focus();
+    await user.keyboard(' ');
+
+    expect(onToggleVisibility).toHaveBeenCalledOnce();
+    expect(onToggleVisibility).toHaveBeenCalledWith('layer-1');
+    expect(onCmdClick).not.toHaveBeenCalled();
+    expect(onSelectLayer).not.toHaveBeenCalled();
+  });
+
+  it('Enter on the focused eye toggle activates it instead of opening the layer editor', async () => {
+    const user = userEvent.setup();
+    const onToggleVisibility = vi.fn();
+    const onSelectLayer = vi.fn();
+    render(<StackRow {...defaultProps({ onToggleVisibility, onSelectLayer })} />);
+
+    const eye = screen.getByRole('button', { name: /Toggle visibility/i });
+    eye.focus();
+    await user.keyboard('{Enter}');
+
+    expect(onToggleVisibility).toHaveBeenCalledOnce();
+    expect(onSelectLayer).not.toHaveBeenCalled();
+  });
+
+  it('Enter and Space on the row container itself still select / multi-toggle', () => {
+    const onSelectLayer = vi.fn();
+    const onCmdClick = vi.fn();
+    render(<StackRow {...defaultProps({ onSelectLayer })} onCmdClick={onCmdClick} />);
+
+    const row = document.getElementById('stack-row-layer-1')!;
+    fireEvent.keyDown(row, { key: 'Enter' });
+    expect(onSelectLayer).toHaveBeenCalledWith('layer-1');
+    fireEvent.keyDown(row, { key: ' ' });
+    expect(onCmdClick).toHaveBeenCalledWith('layer-1');
+  });
+
+  it('Space on the drag grip arms reorder without toggling multi-selection', () => {
+    const onCmdClick = vi.fn();
+    render(<StackRow {...defaultProps()} onCmdClick={onCmdClick} />);
+
+    const grip = screen.getByRole('button', { name: /Drag to reorder/i });
+    fireEvent.keyDown(grip, { key: ' ' });
+
+    expect(grip).toHaveAttribute('aria-pressed', 'true');
+    expect(onCmdClick).not.toHaveBeenCalled();
+  });
+
+  it('a space can be typed into the rename input and Enter commits without re-firing the row action', async () => {
+    const user = userEvent.setup();
+    const onRename = vi.fn();
+    const onSelectLayer = vi.fn();
+    const layer = makeLayer({ id: 'sp-layer', dataset_name: 'Old' });
+    render(<StackRow {...defaultProps({ layer, onRename, onSelectLayer })} />);
+
+    fireEvent.dblClick(screen.getByText('Old'));
+    const input = screen.getByTestId('stack-row-rename-input');
+    await user.clear(input);
+    await user.type(input, 'a b');
+    expect(input).toHaveValue('a b');
+
+    await user.keyboard('{Enter}');
+
+    expect(onRename).toHaveBeenCalledOnce();
+    expect(onRename).toHaveBeenCalledWith('sp-layer', 'a b');
+    // The Enter that commits the rename must not double-fire into the row
+    // action and reopen the layer editor.
+    expect(onSelectLayer).not.toHaveBeenCalled();
+  });
+
+  it('the rename input has an accessible name', () => {
+    const layer = makeLayer({ id: 'aria-layer', dataset_name: 'Old' });
+    render(<StackRow {...defaultProps({ layer })} />);
+    fireEvent.dblClick(screen.getByText('Old'));
+    expect(screen.getByRole('textbox', { name: 'Layer name' })).toBe(
+      screen.getByTestId('stack-row-rename-input'),
+    );
+  });
+
+  it('Enter commits the first rename attempt after a previous Escape-cancel', () => {
+    // Escape unmounts the input without a blur, so escapeRef used to stay set
+    // and swallow the NEXT rename's first Enter.
+    const onRename = vi.fn();
+    const layer = makeLayer({ id: 'esc-enter', dataset_name: 'Old' });
+    render(<StackRow {...defaultProps({ layer, onRename })} />);
+
+    fireEvent.dblClick(screen.getByText('Old'));
+    fireEvent.keyDown(screen.getByTestId('stack-row-rename-input'), { key: 'Escape' });
+    expect(screen.queryByTestId('stack-row-rename-input')).not.toBeInTheDocument();
+    expect(onRename).not.toHaveBeenCalled();
+
+    fireEvent.dblClick(screen.getByText('Old'));
+    const input = screen.getByTestId('stack-row-rename-input');
+    fireEvent.change(input, { target: { value: 'New' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+
+    expect(onRename).toHaveBeenCalledOnce();
+    expect(onRename).toHaveBeenCalledWith('esc-enter', 'New');
+  });
+
+  it('commit and Escape-cancel hand focus back to the row', async () => {
+    const layer = makeLayer({ id: 'focus-back', dataset_name: 'Old' });
+    render(<StackRow {...defaultProps({ layer })} />);
+
+    // Commit path.
+    fireEvent.dblClick(screen.getByText('Old'));
+    fireEvent.keyDown(screen.getByTestId('stack-row-rename-input'), { key: 'Enter' });
+    await act(async () => {
+      await new Promise((r) => requestAnimationFrame(() => r(null)));
+    });
+    expect(document.activeElement?.id).toBe('stack-row-focus-back');
+
+    // Escape-cancel path.
+    fireEvent.dblClick(screen.getByText('Old'));
+    fireEvent.keyDown(screen.getByTestId('stack-row-rename-input'), { key: 'Escape' });
+    await act(async () => {
+      await new Promise((r) => requestAnimationFrame(() => r(null)));
+    });
+    expect(document.activeElement?.id).toBe('stack-row-focus-back');
   });
 });
 

--- a/frontend/src/components/builder/__tests__/UnifiedStackPanel.search.test.tsx
+++ b/frontend/src/components/builder/__tests__/UnifiedStackPanel.search.test.tsx
@@ -304,6 +304,57 @@ describe('UnifiedStackPanel — ENH-07: layer search/filter', () => {
     expect(document.getElementById('stack-row-x')).not.toBeInTheDocument();
   });
 
+  // fix(v1.6.0 audit D2): a filter matching nothing used to leave a blank panel.
+  it('shows a "no layers match" message when the filter matches nothing', () => {
+    render(<UnifiedStackPanel {...threeLayerProps} />);
+
+    expect(screen.queryByTestId('layer-search-no-matches')).not.toBeInTheDocument();
+
+    fireEvent.change(screen.getByRole('searchbox'), { target: { value: 'zzznomatch' } });
+
+    const msg = screen.getByTestId('layer-search-no-matches');
+    expect(msg).toHaveTextContent('No layers match “zzznomatch”');
+  });
+
+  it('hides the no-match message while rows match or the query is cleared', () => {
+    render(<UnifiedStackPanel {...threeLayerProps} />);
+    const input = screen.getByRole('searchbox');
+
+    fireEvent.change(input, { target: { value: 'alpha' } });
+    expect(screen.queryByTestId('layer-search-no-matches')).not.toBeInTheDocument();
+
+    fireEvent.change(input, { target: { value: 'zzz' } });
+    expect(screen.getByTestId('layer-search-no-matches')).toBeInTheDocument();
+
+    fireEvent.change(input, { target: { value: '' } });
+    expect(screen.queryByTestId('layer-search-no-matches')).not.toBeInTheDocument();
+  });
+
+  it('keeps the basemap dock row visible below the no-match message', () => {
+    const basemapGroup = {
+      id: 'basemap-group',
+      presetName: 'Positron',
+      providerLabel: 'OpenFreeMap',
+      visible: true,
+      opacity: 1,
+      sublayers: [],
+    };
+    render(
+      <UnifiedStackPanel
+        {...threeLayerProps}
+        basemapGroup={basemapGroup}
+        isBasemapExpanded={false}
+      />,
+    );
+
+    fireEvent.change(screen.getByRole('searchbox'), { target: { value: 'zzz' } });
+
+    // The basemap row is exempt from filtering, so the no-match state must
+    // coexist with it rather than replace the whole list.
+    expect(screen.getByTestId('layer-search-no-matches')).toBeInTheDocument();
+    expect(screen.getByTestId('basemap-group-row-basemap-group')).toBeInTheDocument();
+  });
+
   it('does not hide the basemap dock row when a search query is active', () => {
     const basemapGroup = {
       id: 'basemap-group',

--- a/frontend/src/components/builder/color-relief-sync.ts
+++ b/frontend/src/components/builder/color-relief-sync.ts
@@ -59,8 +59,9 @@ export function buildElevationExpression(
   rampName: string,
   elevMin = DEFAULT_ELEV_MIN,
   elevMax = DEFAULT_ELEV_MAX,
+  reversed = false,
 ): unknown[] {
-  const colors = getRampColors(rampName, STOP_COUNT);
+  const colors = getRampColors(rampName, STOP_COUNT, reversed);
   const step = (elevMax - elevMin) / (colors.length - 1);
   const expr: unknown[] = ['interpolate', ['linear'], ['elevation']];
   // Guard stops only make sense below the real domain; a ramp whose elevMin
@@ -111,6 +112,7 @@ export function syncColorReliefLayer(
     typeof input.paint['_hypso-ramp'] === 'string'
       ? (input.paint['_hypso-ramp'] as string)
       : 'Viridis';
+  const rampReversed = input.paint['_hypso-reversed'] === true;
 
   // Always recreate (remove then add) — color-relief-color is a ColorRampProperty;
   // setPaintProperty does not trigger the ramp texture re-bake (Pitfall 1).
@@ -129,7 +131,7 @@ export function syncColorReliefLayer(
     source: input.sourceId, // existing raster-dem source from hillshade-adapter
     layout: { visibility: input.visible ? 'visible' : 'none' },
     paint: {
-      'color-relief-color': buildElevationExpression(rampName),
+      'color-relief-color': buildElevationExpression(rampName, undefined, undefined, rampReversed),
       'color-relief-opacity': 0.7,
     },
   };

--- a/frontend/src/components/builder/hooks/__tests__/use-builder-save.test.ts
+++ b/frontend/src/components/builder/hooks/__tests__/use-builder-save.test.ts
@@ -452,7 +452,9 @@ describe('buildLayerDiff', () => {
   it('emits style_config: null when ungrouping a raster layer whose baseline carried folder-group markers', () => {
     const groupRow = makeLayer({
       id: 'group-1',
-      layer_type: 'group:folder',
+      // Synthetic group rows use the builder-local 'group:folder' type, which
+      // sits outside the persisted MapLayerType union (see GroupedLayer).
+      layer_type: 'group:folder' as unknown as MapLayerResponse['layer_type'],
       display_name: 'My Group',
       sort_order: 0,
     });

--- a/frontend/src/components/builder/hooks/__tests__/use-builder-save.test.ts
+++ b/frontend/src/components/builder/hooks/__tests__/use-builder-save.test.ts
@@ -443,6 +443,60 @@ describe('buildLayerDiff', () => {
 
     expect(result.diff.updated).toEqual([{ id: 'vector-1', style_config: null }]);
   });
+
+  // fix(#767 B8): ungrouping a raster layer clears the folder-group markers,
+  // compacting its style_config to null. The V-01 unmanaged-field guard used
+  // to swallow that null-out (rasters have no style editor), so no PATCH was
+  // emitted and the group resurrected on reload. Folder-group markers are
+  // managed for every layer type — the intentional clear must patch through.
+  it('emits style_config: null when ungrouping a raster layer whose baseline carried folder-group markers', () => {
+    const groupRow = makeLayer({
+      id: 'group-1',
+      layer_type: 'group:folder',
+      display_name: 'My Group',
+      sort_order: 0,
+    });
+    const rasterChild = makeLayer({
+      id: 'raster-1',
+      layer_type: 'raster_geolens',
+      dataset_geometry_type: null,
+      dataset_record_type: 'raster_dataset',
+      sort_order: 1,
+      parent_group_id: 'group-1',
+      style_config: null,
+    } as Partial<MapLayerResponse>);
+
+    // Baseline: grouped (prepareLayersForPersistence writes the builder
+    // folderGroup* markers onto the child). Current: ungrouped, markers
+    // cleared — style_config compacts back to null.
+    const ungrouped = makeLayer({
+      ...rasterChild,
+      sort_order: 0,
+      parent_group_id: null,
+      style_config: null,
+    } as Partial<MapLayerResponse>);
+
+    const result = buildLayerDiff([groupRow, rasterChild], [ungrouped]);
+
+    expect(result.diff.updated).toEqual(
+      expect.arrayContaining([expect.objectContaining({ id: 'raster-1', style_config: null })]),
+    );
+  });
+
+  it('still omits style_config for a raster null-out when the baseline had real (non-group) data', () => {
+    const baseline = makeLayer({
+      id: 'raster-2',
+      layer_type: 'raster_geolens',
+      dataset_geometry_type: null,
+      dataset_record_type: 'raster_dataset',
+      style_config: { someRasterKey: 'value' } as unknown as MapLayerResponse['style_config'],
+    });
+    const current = makeLayer({ ...baseline, style_config: null, opacity: 0.4 });
+
+    const result = buildLayerDiff([baseline], [current]);
+
+    expect(result.diff.updated).toEqual([{ id: 'raster-2', opacity: 0.4 }]);
+  });
 });
 
 describe('useBuilderSave', () => {

--- a/frontend/src/components/builder/hooks/use-builder-layers.ts
+++ b/frontend/src/components/builder/hooks/use-builder-layers.ts
@@ -29,7 +29,7 @@ import {
 // composes them and keeps its return surface identical so MapBuilderPage is
 // unchanged. PURE RELOCATION — see each hook for the verbatim handler bodies.
 import { useFolderGroupLayers } from '@/components/builder/hooks/use-folder-group-layers';
-import { useBulkLayerActions } from '@/components/builder/hooks/use-bulk-layer-actions';
+import { useBulkLayerActions, restoreFailedLayers } from '@/components/builder/hooks/use-bulk-layer-actions';
 import { useTerrainLayers } from '@/components/builder/hooks/use-terrain-layers';
 import { useRenderModeLayers } from '@/components/builder/hooks/use-render-mode-layers';
 import { useLayerStyleClipboard } from '@/components/builder/hooks/use-layer-style-clipboard';
@@ -147,6 +147,7 @@ export function useBuilderLayers(
     handleBulkUngroup,
     handleBulkDelete,
     isDeleting,
+    deletingCount,
   } = useBulkLayerActions({
     layersRef,
     setLocalLayers,
@@ -527,9 +528,14 @@ export function useBuilderLayers(
           toast.success(t('toasts.layerRemoved'));
         },
         onError: () => {
-          // Rollback: restore the prior localLayers snapshot so the user
-          // sees the layer reappear in the sidebar.
-          setLocalLayers(previousLayers);
+          // Rollback: re-insert the failed layer so the user sees it reappear.
+          // fix(v1.6.0 audit B6): NOT a wholesale previousLayers write — a
+          // concurrent edit (e.g. handleAddDataset onSuccess landing while the
+          // DELETE was in flight) must survive the rollback, otherwise the next
+          // save diff would ask the server to DELETE the just-added layer.
+          setLocalLayers((current) =>
+            restoreFailedLayers(current, previousLayers, new Set([layerId])),
+          );
           // HI-01: also restore terrain_config if the optimistic delete cleared it,
           // so a failed delete does not leave terrain silently disabled.
           if (clearedTerrainOnRemove) {
@@ -805,6 +811,16 @@ export function useBuilderLayers(
 
   const markDirty = useCallback(() => setHasUnsavedChanges(true), []);
 
+  // fix(v1.6.0 audit D7): identity-stable "is this row a folder group?" lookup.
+  // Reads through layersRef so callers (MapBuilderPage's memoized
+  // onToggleVisibility) do not have to depend on localLayers — a naive
+  // useCallback over localLayers re-creates on exactly the frames the row
+  // memoization is meant to skip.
+  const isFolderGroupRow = useCallback((layerId: string): boolean => {
+    const target = layersRef.current.find((l) => l.id === layerId);
+    return (target as GroupedLayer | undefined)?.layer_type === 'group:folder';
+  }, []);
+
   const dispatchLayerAction = useCallback((action: BuilderLayerAction) => {
     dispatchBuilderLayerAction(action, {
       setFilter: handleFilterChange,
@@ -982,5 +998,10 @@ export function useBuilderLayers(
     handleBulkDelete,
     // Phase 1047-04 (PERF-03): in-flight state for BulkActionBar spinner
     isDeleting,
+    // fix(v1.6.0 audit A5): in-flight batch size for the BulkActionBar label
+    deletingCount,
+    // fix(v1.6.0 audit D7): stable ref-reading predicate so MapBuilderPage's
+    // onToggleVisibility callback does not re-create on every layer change.
+    isFolderGroupRow,
   };
 }

--- a/frontend/src/components/builder/hooks/use-builder-save.ts
+++ b/frontend/src/components/builder/hooks/use-builder-save.ts
@@ -18,7 +18,10 @@ import type { MapBasemapConfig, MapLayerDiffRequest, MapLayerInput, MapLayerPatc
 import { usePluginStore } from '@/stores/map-plugin-store';
 import { useAuthStore } from '@/stores/auth-store';
 import { getDefaultPluginIds, resolveAvailablePluginIds, samePluginIds } from '@/components/map-plugins';
-import { prepareLayersForPersistence, type FolderGroupMeta } from '@/components/builder/folder-groups';
+// D5: the PNG export legend must render the same effective entry names as the
+// on-screen legend (per-entry legendLabel override > display name > dataset name).
+import { legendEntryName } from '@/components/map-plugins/builtin/LegendPlugin';
+import { getPersistedFolderGroup, prepareLayersForPersistence, type FolderGroupMeta } from '@/components/builder/folder-groups';
 import { normalizeDemStyleConfig } from '@/lib/dem-render-mode';
 import { MAP_COLORS } from '@/lib/map-colors';
 // fix(#430 V-01): capability gate used to detect fields the builder has no editor
@@ -471,6 +474,14 @@ export function buildLayerDiff(
     if (!baseline) continue;
 
     const unmanaged = unmanagedNullableFields(layer);
+    // fix(#767 B8): folder-group markers are written into style_config by
+    // prepareLayersForPersistence for EVERY layer type, so a baseline that
+    // carried them makes a null-out an intentional clear (ungrouping), not a
+    // "field never populated" artifact. Without this, ungrouping a raster
+    // layer never PATCHed (its empty style_config compacts to null and the
+    // V-01 guard below swallowed it) and the group resurrected on reload.
+    const baselineHadFolderGroup =
+      getPersistedFolderGroup({ style_config: baseline.style_config } as MapLayerResponse) !== null;
     const currentSnapshot = toLayerSnapshot(layer);
     const patch: MapLayerPatch = { id: layer.id };
     for (const field of PATCHABLE_LAYER_FIELDS) {
@@ -483,7 +494,13 @@ export function buildLayerDiff(
       // whatever it already has) instead of nulling real data. Only applies
       // in the null/erasure direction; a genuinely new non-null value for an
       // unmanaged field (shouldn't normally happen) still patches through.
-      if (currentValue == null && unmanaged.has(field)) continue;
+      // fix(#767 B8): style_config is exempt when the baseline carried
+      // folder-group markers — that null is a managed, deliberate erasure.
+      if (
+        currentValue == null &&
+        unmanaged.has(field) &&
+        !(field === 'style_config' && baselineHadFolderGroup)
+      ) continue;
 
       patch[field] = currentValue as never;
     }
@@ -852,7 +869,12 @@ export function useBuilderSave(state: SaveState) {
             cursorY += 12 * dpr;
             ctx.fillStyle = MAP_COLORS.exportImage.text;
             ctx.font = `600 ${14 * dpr}px system-ui, -apple-system, "Segoe UI", Roboto, sans-serif`;
-            ctx.fillText(t('export.legendHeader', { defaultValue: 'Legend' }), pad, cursorY);
+            // D5: honor the custom map-level legend title (ENH-06) like the
+            // on-screen legend; fall back to the localized default header.
+            const legendHeaderText = state.legendTitle?.trim()
+              ? state.legendTitle.trim()
+              : t('export.legendHeader', { defaultValue: 'Legend' });
+            ctx.fillText(legendHeaderText, pad, cursorY);
             cursorY += legendHeaderH;
             ctx.font = `400 ${13 * dpr}px system-ui, -apple-system, "Segoe UI", Roboto, sans-serif`;
             const swatchSize = 14 * dpr;
@@ -898,8 +920,10 @@ export function useBuilderSave(state: SaveState) {
               ctx.lineWidth = Math.max(1, dpr);
               ctx.strokeRect(pad, rowY, swatchSize, swatchSize);
               ctx.fillStyle = MAP_COLORS.exportImage.text;
+              // D5: was `display_name || dataset_name`, which dropped the
+              // per-entry legendLabel override the on-screen legend renders.
               ctx.fillText(
-                layer.display_name || layer.dataset_name,
+                legendEntryName(layer),
                 pad + swatchSize + 10 * dpr,
                 cursorY + (legendRowH - 13 * dpr) / 2,
               );

--- a/frontend/src/components/builder/hooks/use-bulk-layer-actions.ts
+++ b/frontend/src/components/builder/hooks/use-bulk-layer-actions.ts
@@ -55,6 +55,58 @@ interface UseBulkLayerActionsParams {
   mvtSourceLayerPrefix?: string | null;
 }
 
+// fix(v1.6.0 audit B6): failure-path restore that does NOT clobber concurrent
+// edits. Restoring the pre-delete snapshot wholesale discarded anything that
+// landed during the await (e.g. a handleAddDataset onSuccess), and the next
+// save's removed-computation then asked the server to DELETE the just-added
+// layer. Instead, recompute from CURRENT state: re-insert only the rows whose
+// deletes failed (at their old relative positions when cheap), plus any pruned
+// group container a failed child still points at, and leave every other
+// current row — including concurrent additions — untouched.
+export function restoreFailedLayers(
+  current: MapLayerResponse[],
+  previous: MapLayerResponse[],
+  failedIds: Set<string>,
+): MapLayerResponse[] {
+  const currentIds = new Set(current.map((l) => l.id));
+  const toRestore = previous.filter((l) => {
+    if (currentIds.has(l.id)) return false;
+    if (failedIds.has(l.id)) return true;
+    // Restore a pruned empty-group container whose failed child is returning.
+    return (
+      (l as GroupedLayer).layer_type === 'group:folder' &&
+      previous.some(
+        (child) =>
+          failedIds.has(child.id) &&
+          !currentIds.has(child.id) &&
+          (child as GroupedLayer).parent_group_id === l.id,
+      )
+    );
+  });
+  if (toRestore.length === 0) return current;
+
+  const prevIndex = new Map(previous.map((l, i) => [l.id, i] as const));
+  const next = [...current];
+  // Insert in previous-order so earlier restores anchor later ones.
+  toRestore.sort((a, b) => (prevIndex.get(a.id) ?? 0) - (prevIndex.get(b.id) ?? 0));
+  for (const row of toRestore) {
+    const rowPrevIdx = prevIndex.get(row.id) ?? Number.MAX_SAFE_INTEGER;
+    // Old position ≈ before the first current row that followed it in the
+    // previous order. Rows unknown to `previous` (concurrent additions) have
+    // no index and never force a displacement.
+    let insertAt = next.length;
+    for (let i = 0; i < next.length; i++) {
+      const idx = prevIndex.get(next[i].id);
+      if (idx !== undefined && idx > rowPrevIdx) {
+        insertAt = i;
+        break;
+      }
+    }
+    next.splice(insertAt, 0, row);
+  }
+  return next.map((l, i) => ({ ...l, sort_order: i }));
+}
+
 export function useBulkLayerActions({
   layersRef,
   setLocalLayers,
@@ -75,6 +127,11 @@ export function useBulkLayerActions({
 
   // Phase 1047-04 (PERF-03): tracks in-flight bulk-delete to gate BulkActionBar spinner
   const [isDeleting, setIsDeleting] = useState(false);
+  // fix(v1.6.0 audit A5): batch size captured synchronously in handleBulkDelete
+  // BEFORE the optimistic removal commits. Once that removal lands, the bar's
+  // selection-derived deletableCount is 0, so the deleting state must render
+  // this count instead ("Deleting 0 layers…" regression).
+  const [deletingCount, setDeletingCount] = useState(0);
 
   // ENH-03 (Phase 1201-01): apply one source style to every OTHER compatible
   // selected layer in a SINGLE setLocalLayers pass (no per-field clobber).
@@ -262,6 +319,9 @@ export function useBulkLayerActions({
     });
     setGroupMeta((prev) => ({ ...prev, [groupId]: { expanded: true } }));
     setHasUnsavedChanges(true);
+    // fix(v1.6.0 audit D13): the group action only toasted its skip paths —
+    // success was silent while delete and apply-style both confirm.
+    toast.success(t('toasts.bulkGrouped', { count: groupableLayers.length, name: groupName }));
     return true;
   }, [layersRef, setLocalLayers, setGroupMeta, setHasUnsavedChanges, t]);
 
@@ -295,7 +355,9 @@ export function useBulkLayerActions({
       return next.map((l, i) => ({ ...l, sort_order: i }));
     });
     setHasUnsavedChanges(true);
-  }, [layersRef, setLocalLayers, setHasUnsavedChanges]);
+    // fix(v1.6.0 audit D13): ungroup had no success feedback at all.
+    toast.success(t('toasts.bulkUngrouped', { count: selectedGroups.length }));
+  }, [layersRef, setLocalLayers, setHasUnsavedChanges, t]);
 
   const handleBulkDelete = useCallback(async (selectedIds: Set<string>): Promise<boolean> => {
     if (!mapId || selectedIds.size === 0) return false;
@@ -357,6 +419,10 @@ export function useBulkLayerActions({
     removePerLayerCompanions(mapInstanceRef.current, idsToDelete);
 
     // Phase 1047-04 (PERF-03): one batched call replaces N sequential DELETEs
+    // fix(v1.6.0 audit A5): capture the batch size for the bar's deleting label
+    // BEFORE isDeleting flips — the optimistic removal above already emptied
+    // the selection-derived count the bar would otherwise render.
+    setDeletingCount(idsToDelete.length);
     setIsDeleting(true);
     try {
       const result = await bulkDeleteLayersApi(mapId, idsToDelete);
@@ -375,8 +441,13 @@ export function useBulkLayerActions({
       }
 
       if (result.deleted.length === 0) {
-        // Full failure — rollback all layers
-        setLocalLayers(previousLayers);
+        // Full failure — restore the failed batch. fix(v1.6.0 audit B6): NOT a
+        // wholesale snapshot write — a concurrent edit (e.g. handleAddDataset
+        // landing during the await) must survive the rollback, otherwise the
+        // next save diff would DELETE the just-added layer.
+        setLocalLayers((current) =>
+          restoreFailedLayers(current, previousLayers, idsToDeleteSet),
+        );
         // HI-01: nothing was actually deleted, so restore terrain_config too.
         if (clearedTerrainOnBulk) {
           setLocalTerrainConfig(previousTerrainConfig);
@@ -386,19 +457,23 @@ export function useBulkLayerActions({
       }
 
       // Partial failure: keep deleted layers removed, restore failed layers.
-      // fix(#805): rebuild from previousLayers minus the actually-deleted rows.
-      // The old path merged the already-renumbered optimistic array with failed
-      // rows still carrying their ORIGINAL sort_order — interleaving two
-      // numbering schemes — so survivors slotted back at the wrong stack
-      // position, and the wrong order was then saved. previousLayers preserves
-      // the true relative order of every survivor. Empty groups are pruned like
-      // the optimistic path (#767): a group whose children all deleted
-      // successfully must not linger.
+      // fix(#805): survivors return at their previous relative positions, not
+      // interleaved between two numbering schemes.
+      // fix(v1.6.0 audit B6): recompute from CURRENT state instead of writing a
+      // stale previousLayers-derived array — a concurrent edit that landed
+      // during the await (e.g. handleAddDataset) must survive; only the rows
+      // whose deletes FAILED are re-inserted, and confirmed-deleted rows are
+      // dropped. Empty groups stay pruned like the optimistic path (#767)
+      // because restoreFailedLayers only revives a group container whose failed
+      // child is returning.
       const deletedIds = new Set(result.deleted);
-      setLocalLayers(
-        pruneEmptyFolderGroups(
-          previousLayers.filter((l) => !deletedIds.has(l.id)),
-        ).map((l, i) => ({ ...l, sort_order: i })),
+      const failedIds = new Set(result.failed.map((f) => f.id));
+      setLocalLayers((current) =>
+        restoreFailedLayers(
+          current.filter((l) => !deletedIds.has(l.id)),
+          previousLayers,
+          failedIds,
+        ),
       );
       // HI-01: the optimistic terrain clear assumed the WHOLE batch was deleted.
       // Re-evaluate against the layers that ACTUALLY remain after restoring the
@@ -451,5 +526,7 @@ export function useBulkLayerActions({
     handleBulkUngroup,
     handleBulkDelete,
     isDeleting,
+    // fix(v1.6.0 audit A5): batch size for the bar's "Deleting N layers…" label.
+    deletingCount,
   };
 }

--- a/frontend/src/components/builder/layer-adapters/heatmap-adapter.ts
+++ b/frontend/src/components/builder/layer-adapters/heatmap-adapter.ts
@@ -18,8 +18,8 @@ function finiteNumber(value: unknown): number | null {
 /** Build the default heatmap-color interpolation expression using a named ramp.
  *  The expression has transparent (rgba 0,0,0,0) at density 0 so low-density
  *  areas are fully transparent. */
-export function buildHeatmapColorExpression(rampName: string): unknown[] {
-  const colors = getRampColors(rampName, 5);
+export function buildHeatmapColorExpression(rampName: string, reversed = false): unknown[] {
+  const colors = getRampColors(rampName, 5, reversed);
   return [
     'interpolate', ['linear'], ['heatmap-density'],
     0,   MAP_COLORS.transparent,
@@ -73,7 +73,7 @@ export const heatmapAdapter: LayerAdapter = {
     const heatmapOpacity = storedHeatmapOpacity * (opacity ?? 1);
 
     // Use stored color expression or build the default
-    const heatmapColor: unknown = rawPaint['heatmap-color'] ?? buildHeatmapColorExpression(builder.heatmapRamp ?? DEFAULT_RAMP);
+    const heatmapColor: unknown = rawPaint['heatmap-color'] ?? buildHeatmapColorExpression(builder.heatmapRamp ?? DEFAULT_RAMP, builder.heatmapReversed ?? false);
 
     try {
       map.addLayer({
@@ -107,7 +107,7 @@ export const heatmapAdapter: LayerAdapter = {
       'heatmap-radius': rawPaint['heatmap-radius'] ?? HEATMAP_PAINT_DEFAULTS['heatmap-radius'],
       'heatmap-weight': rawPaint['heatmap-weight'] ?? HEATMAP_PAINT_DEFAULTS['heatmap-weight'],
       'heatmap-intensity': rawPaint['heatmap-intensity'] ?? HEATMAP_PAINT_DEFAULTS['heatmap-intensity'],
-      'heatmap-color': rawPaint['heatmap-color'] ?? buildHeatmapColorExpression(builder.heatmapRamp ?? DEFAULT_RAMP),
+      'heatmap-color': rawPaint['heatmap-color'] ?? buildHeatmapColorExpression(builder.heatmapRamp ?? DEFAULT_RAMP, builder.heatmapReversed ?? false),
     }, { ownedProperties: HEATMAP_OWNED_PAINT_PROPERTIES.filter((prop) => prop !== 'heatmap-opacity') });
 
     // Compound stored heatmap-opacity with master opacity. Single source of truth.

--- a/frontend/src/components/builder/layer-adapters/shared.ts
+++ b/frontend/src/components/builder/layer-adapters/shared.ts
@@ -8,9 +8,9 @@ export const CUSTOM_PAINT_PROPS = new Set([
   'outline-width', 'outline-color',
   '_fill-disabled', '_stroke-disabled',
   '_fill-opacity-saved', '_outline-width-saved',
-  '_heatmap-ramp', '_heatmap-weight-column',
+  '_heatmap-ramp', '_heatmap-reversed', '_heatmap-weight-column',
   '_height_column',
-  '_hypso-enabled', '_hypso-ramp',
+  '_hypso-enabled', '_hypso-ramp', '_hypso-reversed',
 ]);
 
 /** Canonical geometry family. `other` covers null/empty and tokens that are

--- a/frontend/src/components/builder/layer-adapters/shared.ts
+++ b/frontend/src/components/builder/layer-adapters/shared.ts
@@ -529,6 +529,7 @@ export const BUILDER_STYLE_KEY_ALIASES: Record<string, string> = {
   outline_color: 'outlineColor',
   outline_width: 'outlineWidth',
   heatmap_ramp: 'heatmapRamp',
+  heatmap_reversed: 'heatmapReversed',
   heatmap_weight_column: 'heatmapWeightColumn',
   height_column: 'heightColumn',
   height_scale: 'heightScale',

--- a/frontend/src/components/builder/useInlineRename.ts
+++ b/frontend/src/components/builder/useInlineRename.ts
@@ -18,9 +18,15 @@ interface UseInlineRenameOptions {
   value: string;
   /** Commit handler. Receives the trimmed name, or null when the field is empty. */
   onCommit: (next: string | null) => void;
+  /** a11y(v1.6.0 audit A7): hand focus back to the row (or rename trigger)
+   *  after commit or Escape-cancel — unmounting the focused input otherwise
+   *  drops focus to <body>. Deferred a frame and skipped when focus already
+   *  landed somewhere real (e.g. a blur-commit caused by clicking another
+   *  control must not steal that click's focus). */
+  restoreFocus?: () => void;
 }
 
-export function useInlineRename({ value, onCommit }: UseInlineRenameOptions) {
+export function useInlineRename({ value, onCommit, restoreFocus }: UseInlineRenameOptions) {
   const [editing, setEditing] = useState(false);
   const [nameValue, setNameValue] = useState('');
   const escapeRef = useRef(false);
@@ -45,9 +51,23 @@ export function useInlineRename({ value, onCommit }: UseInlineRenameOptions) {
   }, [editing]);
 
   const startRename = useCallback(() => {
+    // a11y(v1.6.0 audit A7): Escape unmounts the focused input, so no blur
+    // fires and commit() — the only other place escapeRef clears — never runs.
+    // Without this reset the first Enter of the NEXT rename was swallowed as
+    // a stale escape.
+    escapeRef.current = false;
     setNameValue(value);
     setEditing(true);
   }, [value]);
+
+  // a11y(v1.6.0 audit A7): see restoreFocus in the options doc above.
+  const restoreFocusAfterExit = useCallback(() => {
+    if (!restoreFocus) return;
+    requestAnimationFrame(() => {
+      const active = document.activeElement;
+      if (!active || active === document.body) restoreFocus();
+    });
+  }, [restoreFocus]);
 
   const commit = useCallback(() => {
     if (escapeRef.current) {
@@ -58,12 +78,13 @@ export function useInlineRename({ value, onCommit }: UseInlineRenameOptions) {
     committingRef.current = true;
     setEditing(false);
     onCommit(nameValue.trim() || null);
+    restoreFocusAfterExit();
     // committingRef stays true during the synchronous blur triggered by
     // setEditing(false); reset it async so a later genuine focus+blur is allowed.
     requestAnimationFrame(() => {
       committingRef.current = false;
     });
-  }, [nameValue, onCommit]);
+  }, [nameValue, onCommit, restoreFocusAfterExit]);
 
   const inputHandlers = {
     onChange: (e: ChangeEvent<HTMLInputElement>) => setNameValue(e.target.value),
@@ -77,6 +98,7 @@ export function useInlineRename({ value, onCommit }: UseInlineRenameOptions) {
         escapeRef.current = true;
         setEditing(false);
         setNameValue(value);
+        restoreFocusAfterExit();
       }
     },
     onClick: (e: MouseEvent<HTMLInputElement>) => e.stopPropagation(),

--- a/frontend/src/components/dataset/DatasetMap.tsx
+++ b/frontend/src/components/dataset/DatasetMap.tsx
@@ -1018,7 +1018,7 @@ export const DatasetMap = memo(function DatasetMap({
               {t('map.deleteFeatureDescription')}
               {selectedFeature?.gid != null && (
                 <span className="block mt-1 text-xs text-muted-foreground">
-                  Feature ID: {selectedFeature.gid}
+                  {t('map.featureId', { id: selectedFeature.gid, defaultValue: 'Feature ID: {{id}}' })}
                 </span>
               )}
             </AlertDialogDescription>

--- a/frontend/src/components/dataset/DatasetMap.tsx
+++ b/frontend/src/components/dataset/DatasetMap.tsx
@@ -43,6 +43,24 @@ import { logUnhandledMapError } from '@/lib/map-error-log';
 /** System columns excluded from the attribute form */
 const SYSTEM_COLUMNS = new Set(['gid', 'geom', 'geom_4326']);
 
+// audit(w3-maps B11): sources this component (and its hooks) add on top of the
+// basemap. The basemap-switch transformStyle below carries over ONLY these —
+// an allowlist. The previous denylist excluded just the id literally named
+// `basemap`, which only raster styles use; vector styles use provider source
+// ids, so switching vector → raster stacked the entire old vector basemap
+// (~100 layers) on top of the new one.
+const APP_SOURCE_IDS = new Set([
+  'vector-tile-source', // use-map-layers addVectorLayers
+  'raster-tile-source', // use-map-layers addRasterLayers
+  'drawn-overlay', // use-map-layers addOverlaySource
+  'bbox-source', // declarative <Source> below
+]);
+
+/** True for a source id owned by this app (incl. TerraDraw's `td-*` sources). */
+function isAppSourceId(id: string): boolean {
+  return APP_SOURCE_IDS.has(id) || id.startsWith('td-');
+}
+
 /**
  * Dataset detail map preview.
  *
@@ -164,12 +182,14 @@ export const DatasetMap = memo(function DatasetMap({
   // ``key={mapKey}`` remount can't stack listeners (which churned setState and
   // could freeze the tab when titiler is cold and the tile grid is a mix of
   // 200/204/error). Refs are reset whenever a new map mounts via handleLoad.
+  // audit(w3-maps): the same fire-once machinery now also backs the vector
+  // branch, which previously had no loading/error signal at all.
   const readyFiredRef = useRef(false);
   // Tracks a *confirmed* raster load (isSourceLoaded) vs a soft 204-only ready,
   // so a sparse-COG 204 doesn't permanently block the error/retry overlay.
   const readyConfirmedRef = useRef(false);
   const errorFiredRef = useRef(false);
-  const rasterListenersRef = useRef<{
+  const tileListenersRef = useRef<{
     error?: (e: { error: { message?: string; status?: number } }) => void;
     sourcedata?: (e: { sourceId?: string; isSourceLoaded?: boolean }) => void;
   }>({});
@@ -292,11 +312,11 @@ export const DatasetMap = memo(function DatasetMap({
     return () => {
       const map = mapRef.current;
       if (map) {
-        if (rasterListenersRef.current.error) {
-          map.off('error', rasterListenersRef.current.error);
+        if (tileListenersRef.current.error) {
+          map.off('error', tileListenersRef.current.error);
         }
-        if (rasterListenersRef.current.sourcedata) {
-          map.off('sourcedata', rasterListenersRef.current.sourcedata);
+        if (tileListenersRef.current.sourcedata) {
+          map.off('sourcedata', tileListenersRef.current.sourcedata);
         }
         // fix(#430 V-13): detach the re-arming data-tiles-loaded handlers symmetrically.
         if (tilesIdleMovestartHandlerRef.current) {
@@ -310,7 +330,7 @@ export const DatasetMap = memo(function DatasetMap({
           map.off('error', tileAuthErrorHandlerRef.current);
         }
       }
-      rasterListenersRef.current = {};
+      tileListenersRef.current = {};
     };
   }, []);
 
@@ -501,8 +521,10 @@ export const DatasetMap = memo(function DatasetMap({
         const customSources: Record<string, unknown> = {};
         const customLayers: unknown[] = [];
         if (_prev) {
+          // audit(w3-maps B11): allowlist app-owned sources/layers instead of
+          // denylisting the raster-style id `basemap` — see APP_SOURCE_IDS.
           for (const [id, src] of Object.entries(_prev.sources || {})) {
-            if (id === 'basemap' || next.sources?.[id]) continue;
+            if (!isAppSourceId(id) || next.sources?.[id]) continue;
             customSources[id] = src;
           }
           // Only carry over layers whose source exists in the merged style
@@ -513,6 +535,9 @@ export const DatasetMap = memo(function DatasetMap({
           for (const layer of _prev.layers || []) {
             if (next.layers?.some((l) => l.id === layer.id)) continue;
             const src = (layer as { source?: string }).source;
+            // App-owned = a TerraDraw layer or a layer drawing from an
+            // app-owned source; every basemap layer fails both checks.
+            if (!layer.id.startsWith('td-') && !(src && isAppSourceId(src))) continue;
             if (src && !mergedSourceIds.has(src)) continue;
             customLayers.push(layer);
           }
@@ -589,50 +614,60 @@ export const DatasetMap = memo(function DatasetMap({
       map.on('movestart', tilesIdleMovestartHandlerRef.current);
       map.on('idle', tilesIdleIdleHandlerRef.current);
 
+      // Fresh mount: detach any stale listeners and reset the fire-once guards.
+      if (tileListenersRef.current.error) {
+        map.off('error', tileListenersRef.current.error);
+      }
+      if (tileListenersRef.current.sourcedata) {
+        map.off('sourcedata', tileListenersRef.current.sourcedata);
+      }
+      readyFiredRef.current = false;
+      readyConfirmedRef.current = false;
+      errorFiredRef.current = false;
+      const tileStats = { total: 0, failed: 0 };
+
+      // Fire heroState transitions at most once per mount so repeated
+      // sourcedata/error events don't churn setState (freeze).
+      // `confirmed` marks a real source load (isSourceLoaded). A 204-only ready
+      // is "soft": it resolves the loading skeleton for a sparse remote COG but
+      // must NOT make success terminal — a later error threshold can override it.
+      const fireReadyOnce = (confirmed: boolean) => {
+        if (confirmed) readyConfirmedRef.current = true;
+        if (readyFiredRef.current || errorFiredRef.current) return;
+        readyFiredRef.current = true;
+        onMapReady?.();
+      };
+      const fireErrorOnce = () => {
+        // A confirmed load wins over sporadic tile errors; a soft 204-only
+        // ready does NOT block the error/retry overlay.
+        if (errorFiredRef.current || readyConfirmedRef.current) return;
+        errorFiredRef.current = true;
+        onTileError?.();
+      };
+
       // fix(#621): the dataset preview previously had NO vector-tile 401/403
       // handling — the most likely surface in the 7-hour silent-403 incident.
       // A stale sig kicks one throttled token re-mint, and a conclusively
       // dead session surfaces through the global signed-out handling (#628)
       // via the mint request itself.
+      // audit(w3-maps A2): recoverTileAuth() returning false is contractual —
+      // a recent re-mint didn't cure the error (revoked grant, expired embed
+      // token). Previously that return value was discarded and the surface
+      // stayed fully silent; now it falls through to the existing onTileError
+      // error path. Auth failures surface even after a confirmed load (unlike
+      // sporadic tile errors) because they break the whole tile surface.
       tileAuthErrorHandlerRef.current = (e: { error?: { status?: number } }) => {
         const s = e.error?.status;
-        if (s === 401 || s === 403) recoverTileAuth();
+        if (s !== 401 && s !== 403) return;
+        if (!recoverTileAuth() && !errorFiredRef.current) {
+          errorFiredRef.current = true;
+          onTileError?.();
+        }
       };
       map.on('error', tileAuthErrorHandlerRef.current);
 
       if (recordType === 'raster_dataset' || recordType === 'vrt_dataset') {
-        // Fresh mount: detach any stale listeners and reset the fire-once guards.
-        if (rasterListenersRef.current.error) {
-          map.off('error', rasterListenersRef.current.error);
-        }
-        if (rasterListenersRef.current.sourcedata) {
-          map.off('sourcedata', rasterListenersRef.current.sourcedata);
-        }
-        readyFiredRef.current = false;
-        readyConfirmedRef.current = false;
-        errorFiredRef.current = false;
-
         addRasterLayers(map);
-        const tileStats = { total: 0, failed: 0 };
-
-        // Fire heroState transitions at most once per mount so repeated
-        // sourcedata/error events don't churn setState (freeze).
-        // `confirmed` marks a real source load (isSourceLoaded). A 204-only ready
-        // is "soft": it resolves the loading skeleton for a sparse remote COG but
-        // must NOT make success terminal — a later error threshold can override it.
-        const fireReadyOnce = (confirmed: boolean) => {
-          if (confirmed) readyConfirmedRef.current = true;
-          if (readyFiredRef.current || errorFiredRef.current) return;
-          readyFiredRef.current = true;
-          onMapReady?.();
-        };
-        const fireErrorOnce = () => {
-          // A confirmed load wins over sporadic tile errors; a soft 204-only
-          // ready does NOT block the error/retry overlay.
-          if (errorFiredRef.current || readyConfirmedRef.current) return;
-          errorFiredRef.current = true;
-          onTileError?.();
-        };
 
         const handleRasterError = (e: { error: { message?: string; status?: number } }) => {
           const status = (e.error as { status?: number })?.status;
@@ -667,14 +702,51 @@ export const DatasetMap = memo(function DatasetMap({
 
         map.on('error', handleRasterError);
         map.on('sourcedata', handleRasterSourceData);
-        rasterListenersRef.current = {
+        tileListenersRef.current = {
           error: handleRasterError,
           sourcedata: handleRasterSourceData,
         };
       } else {
         addVectorLayers(map);
         addOverlaySource(map);
-        onMapReady?.();
+
+        // audit(w3-maps): the vector branch previously fired onMapReady
+        // unconditionally and attached no error listeners, so a vector
+        // preview had no loading/error state at all. Mirror the raster
+        // machinery: a soft ready keeps today's immediate-resolve behavior
+        // (a bbox-only dataset has no tiles to confirm), sourcedata confirms
+        // a real load, and repeated hard tile failures cross the same
+        // threshold into the existing onTileError error path. 4xx stays out
+        // of the count — 404 is an expected no-data tile outside the extent,
+        // and 401/403 belong to the tile-auth recovery handler above.
+        const handleVectorError = (e: { error: { message?: string; status?: number } }) => {
+          const status = e.error?.status;
+          if (status && status >= 400 && status < 500) return;
+          if (e.error?.message?.includes('vector-tile-source') ||
+              e.error?.message?.includes('Error: HTTP') ||
+              (status && status >= 500)) {
+            tileStats.failed++;
+            tileStats.total++;
+            if (tileStats.failed >= 3 ||
+                (tileStats.total >= 4 && tileStats.failed / tileStats.total > 0.5)) {
+              fireErrorOnce();
+            }
+          }
+        };
+        const handleVectorSourceData = (e: { sourceId?: string; isSourceLoaded?: boolean }) => {
+          if (e.sourceId === 'vector-tile-source' && e.isSourceLoaded) {
+            tileStats.total++;
+            fireReadyOnce(true);
+          }
+        };
+
+        map.on('error', handleVectorError);
+        map.on('sourcedata', handleVectorSourceData);
+        tileListenersRef.current = {
+          error: handleVectorError,
+          sourcedata: handleVectorSourceData,
+        };
+        fireReadyOnce(false);
       }
     },
     [recordType, addRasterLayers, addVectorLayers, addOverlaySource, onMapReady, onTileError, recoverTileAuth],

--- a/frontend/src/components/dataset/hooks/__tests__/use-hero-state.test.ts
+++ b/frontend/src/components/dataset/hooks/__tests__/use-hero-state.test.ts
@@ -46,9 +46,9 @@ describe('useHeroState', () => {
     expect(result.current.heroState).toBe('error');
   });
 
-  it('does not timeout for non-raster datasets', () => {
+  it('does not timeout for table datasets', () => {
     const { result } = renderHook(() =>
-      useHeroState({ datasetId: 'd1', recordType: 'vector_dataset', hasTileUrl: false }),
+      useHeroState({ datasetId: 'd1', recordType: 'table', hasTileUrl: false }),
     );
 
     act(() => {
@@ -56,6 +56,18 @@ describe('useHeroState', () => {
     });
 
     expect(result.current.heroState).toBe('loading');
+  });
+
+  it('times out for vector datasets that never report ready', () => {
+    const { result } = renderHook(() =>
+      useHeroState({ datasetId: 'd1', recordType: 'vector_dataset', hasTileUrl: false }),
+    );
+
+    act(() => {
+      vi.advanceTimersByTime(10_000);
+    });
+
+    expect(result.current.heroState).toBe('error');
   });
 
   it('transitions to loaded via onMapReady', () => {

--- a/frontend/src/components/dataset/hooks/use-hero-state.ts
+++ b/frontend/src/components/dataset/hooks/use-hero-state.ts
@@ -10,18 +10,21 @@ interface UseHeroStateOptions {
 
 export function useHeroState({ datasetId, recordType, hasTileUrl }: UseHeroStateOptions) {
   const isRasterOrVrt = recordType === 'raster_dataset' || recordType === 'vrt_dataset';
+  // Vector previews report readiness/errors too (soft-ready immediately, then
+  // confirm via sourcedata) — only table datasets have no hero map to track.
+  const tracksHero = isRasterOrVrt || recordType === 'vector_dataset';
   const [heroState, setHeroState] = useState<HeroState>('loading');
   const [retryCount, setRetryCount] = useState(0);
   const [mapKey, setMapKey] = useState(0);
 
-  // 10s timeout: if raster/VRT map never calls onMapReady, show error
+  // 10s timeout: if the tracked hero map never calls onMapReady, show error
   useEffect(() => {
-    if (!isRasterOrVrt || heroState !== 'loading') return;
+    if (!tracksHero || heroState !== 'loading') return;
     const timer = setTimeout(() => {
       setHeroState('error');
     }, 10_000);
     return () => clearTimeout(timer);
-  }, [heroState, isRasterOrVrt, datasetId]);
+  }, [heroState, tracksHero, datasetId]);
 
   // Retry handler for raster/VRT hero error state
   const handleRetry = useCallback(() => {
@@ -46,6 +49,7 @@ export function useHeroState({ datasetId, recordType, hasTileUrl }: UseHeroState
 
   return {
     isRasterOrVrt,
+    tracksHero,
     heroState,
     retryCount,
     mapKey,

--- a/frontend/src/components/dataset/hooks/use-hero-state.ts
+++ b/frontend/src/components/dataset/hooks/use-hero-state.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 
 export type HeroState = 'loading' | 'loaded' | 'error';
 
@@ -33,8 +33,13 @@ export function useHeroState({ datasetId, recordType, hasTileUrl }: UseHeroState
     setMapKey(prev => prev + 1);
   }, []);
 
-  // Reset hero state when dataset changes
+  // Reset hero state when the dataset CHANGES — skip the initial mount, where
+  // state is already fresh and a map that reports ready in the same commit
+  // (cached lazy chunk) would be clobbered back to 'loading'.
+  const mountedForRef = useRef(datasetId);
   useEffect(() => {
+    if (mountedForRef.current === datasetId) return;
+    mountedForRef.current = datasetId;
     setHeroState('loading');
     setRetryCount(0);
     setMapKey(0);

--- a/frontend/src/components/import/RegisterForm.tsx
+++ b/frontend/src/components/import/RegisterForm.tsx
@@ -178,7 +178,10 @@ export function RegisterForm() {
   return (
     <div className="grid min-h-[420px] overflow-hidden rounded-xl border border-border bg-card md:grid-cols-[280px_1fr]">
       {/* Left sidebar */}
-      <aside className="border-e border-border bg-surface-0 py-3">
+      <aside
+        aria-label={t('register.tablesSidebarLabel', { defaultValue: 'Discovered tables' })}
+        className="border-e border-border bg-surface-0 py-3"
+      >
         <div className="px-3 pb-2.5">
           <div className="relative">
             <Search className="absolute start-2.5 top-1/2 size-3.5 -translate-y-1/2 text-muted-foreground" />

--- a/frontend/src/components/import/WorkflowRail.tsx
+++ b/frontend/src/components/import/WorkflowRail.tsx
@@ -44,7 +44,10 @@ export function WorkflowRail({ mode, phase }: WorkflowRailProps) {
   const activeStep = PHASE_TO_STEP[phase];
 
   return (
-    <aside className="sticky top-28 flex flex-col gap-4">
+    <aside
+      aria-label={t('rail.asideLabel', { defaultValue: 'Import workflow' })}
+      className="sticky top-28 flex flex-col gap-4"
+    >
       {/* Workflow steps */}
       <div className="rounded-lg border border-border bg-card p-4">
         <p className="eyebrow mb-3">
@@ -122,7 +125,12 @@ function NonUploadRail({ mode }: { mode: 'register' | 'service' | 'stac' }) {
   const isStac = mode === 'stac';
 
   return (
-    <aside className="sticky top-28 flex flex-col gap-4">
+    // Same label as the upload-mode aside above — they are alternative
+    // branches of the one import-workflow sidebar landmark.
+    <aside
+      aria-label={t('rail.asideLabel', { defaultValue: 'Import workflow' })}
+      className="sticky top-28 flex flex-col gap-4"
+    >
       <div className="rounded-lg border border-border bg-card p-4">
         <p className="eyebrow mb-2">
           {isRegister

--- a/frontend/src/components/search/BboxMapPicker.tsx
+++ b/frontend/src/components/search/BboxMapPicker.tsx
@@ -87,7 +87,15 @@ export function BboxMapPicker({ onBboxSelected }: BboxMapPickerProps) {
 
   return (
     <div>
-      <div className="overflow-hidden rounded-md">
+      {/* audit(w3-maps): aria-label on <MapGL> is silently dropped —
+          @vis.gl/react-maplibre v8 forwards only id/ref/style, and MapLibre
+          labels its canvas "Map". Label the wrapper region instead (same
+          pattern as DatasetMap's shell). */}
+      <div
+        className="overflow-hidden rounded-md"
+        role="region"
+        aria-label={t('bbox.mapAriaLabel', { defaultValue: 'Bounding box map' })}
+      >
         <MapGL
           initialViewState={{ longitude: 0, latitude: 20, zoom: 1 }}
           style={{ width: '100%', height: 250 }}

--- a/frontend/src/components/search/SpatialFilterPanel.tsx
+++ b/frontend/src/components/search/SpatialFilterPanel.tsx
@@ -329,7 +329,15 @@ export function SpatialFilterPanel({
             </ToggleGroup>
 
             {/* Map */}
-            <div className="min-h-[300px] overflow-hidden rounded-lg border">
+            {/* audit(w3-maps): aria-label on <MapGL> is silently dropped —
+                @vis.gl/react-maplibre v8 forwards only id/ref/style, and
+                MapLibre labels its canvas "Map". Label the wrapper region
+                instead (same pattern as DatasetMap's shell). */}
+            <div
+              className="min-h-[300px] overflow-hidden rounded-lg border"
+              role="region"
+              aria-label={t('spatial.mapAriaLabel', { defaultValue: 'Search area map' })}
+            >
               <MapGL
                 initialViewState={savedViewport}
                 style={{ width: '100%', height: 300 }}

--- a/frontend/src/components/viewer/ViewerMap.tsx
+++ b/frontend/src/components/viewer/ViewerMap.tsx
@@ -1046,6 +1046,12 @@ export const ViewerMap = memo(function ViewerMap({
   return (
     <div
       className={`relative h-full w-full ${!mapReady ? 'bg-muted animate-pulse' : ''}`}
+      // audit(w3-maps): aria-label on <MapGL> is silently dropped —
+      // @vis.gl/react-maplibre v8 forwards only id/ref/style, and MapLibre
+      // labels its canvas "Map". Label the wrapper region instead (same
+      // pattern as DatasetMap's shell).
+      role="region"
+      aria-label={t('viewer.map.ariaLabel', { defaultValue: 'Map viewer' })}
       data-tiles-loaded={tilesIdle ? 'true' : 'false'}
       data-terrain-ready={terrainReady ? 'true' : 'false'}
     >
@@ -1062,7 +1068,6 @@ export const ViewerMap = memo(function ViewerMap({
         // handleLoad's error handler) stops double-logging a red AJAXError
         // console row.
         onError={logUnhandledMapError}
-        aria-label={t('viewer.map.ariaLabel', { defaultValue: 'Map viewer' })}
       >
         <NavigationControl position="top-right" />
         <FullscreenControl position="top-right" />

--- a/frontend/src/components/viewer/ViewerMap.tsx
+++ b/frontend/src/components/viewer/ViewerMap.tsx
@@ -465,7 +465,16 @@ export const ViewerMap = memo(function ViewerMap({
         // it lands, and a conclusively dead session surfaces through the
         // global signed-out handling (#628) via the mint request itself.
         if ((status === 401 || status === 403) && !isThirdPartyUrl(e.error?.url)) {
-          recoverTileAuth();
+          // audit(w3-maps A2): recoverTileAuth() returning false is
+          // contractual — a recent re-mint didn't cure the error (revoked
+          // grant, expired signature). Previously the return value was
+          // discarded and the surface stayed fully silent; fall through to
+          // the existing deduped tile-error toast instead.
+          if (!recoverTileAuth()) {
+            toast.error(t('viewer.mapError', { defaultValue: 'Map tile error — some layers may not display correctly.' }), {
+              id: 'viewer-map-error',
+            });
+          }
           return;
         }
         // Suppress expected no-data tiles (404) and other client errors

--- a/frontend/src/i18n/locales/de/builder.json
+++ b/frontend/src/i18n/locales/de/builder.json
@@ -891,7 +891,9 @@
     "bulkGroupNeedTwo": "Wähle mindestens 2 lose Ebenen aus, um sie zu gruppieren",
     "bulkGroupSkipped": "Einige ausgewählte Ebenen sind bereits gruppiert und können nicht erneut gruppiert werden",
     "bulkGroupSkippedGroupRow": "Gruppen können nicht gruppiert werden – entferne Gruppenzeilen aus deiner Auswahl und versuche es erneut",
-    "bulkDeleteOnlyGroupRows": "Gruppenzeilen können nicht per Massenaktion gelöscht werden – lösche eine Gruppe über das Menü ihrer Zeile"
+    "bulkDeleteOnlyGroupRows": "Gruppenzeilen können nicht per Massenaktion gelöscht werden – lösche eine Gruppe über das Menü ihrer Zeile",
+    "bulkGrouped": "{{count}} Ebenen in „{{name}}“ gruppiert",
+    "bulkUngrouped": "{{count}} Gruppen aufgelöst"
   },
   "builderMap": {
     "loading": "Karte wird geladen...",
@@ -1235,6 +1237,9 @@
     "kebabUngroup": "Gruppierung aufheben",
     "kebabDeleteGroup": "Gruppe löschen",
     "kebabMoveOutOfGroup": "Aus Gruppe verschieben",
+    "moveOutConfirmMessage": "Diesen Layer aus „{{group}}“ verschieben? Die leere Gruppe wird ebenfalls entfernt.",
+    "moveOutConfirmAction": "Verschieben",
+    "moveOutConfirmCancel": "In der Gruppe behalten",
     "labelsIndicator": "Beschriftungen an: {{column}}",
     "kebabGroupTrigger": "Gruppenoptionen für {{name}}",
     "kebabZoomToLayer": "Auf Ebene zoomen",
@@ -1340,6 +1345,7 @@
     },
     "confirmDelete": {
       "message": "Sind Sie sicher? Diese Aktion kann nicht rückgängig gemacht werden.",
+      "messageDissolvesGroup": "Sind Sie sicher? Diese Aktion kann nicht rückgängig gemacht werden, und die Gruppe „{{group}}“ wird ebenfalls entfernt.",
       "delete": "Löschen",
       "keep": "Layer behalten"
     },

--- a/frontend/src/i18n/locales/de/builder.json
+++ b/frontend/src/i18n/locales/de/builder.json
@@ -396,7 +396,10 @@
       "parseError": "Ungültiges JSON",
       "structureError": "Ausdruck muss ein Array sein, das mit einem bekannten Operator beginnt"
     },
-    "validatorUnavailable": "Dieses JSON konnte nicht validiert werden – vereinfachen Sie den Wert und versuchen Sie es erneut."
+    "validatorUnavailable": "Dieses JSON konnte nicht validiert werden – vereinfachen Sie den Wert und versuchen Sie es erneut.",
+    "resetConfirmMessage": "Stil dieses Layers zurücksetzen? Rendermodus und datengesteuerter Stil gehen verloren.",
+    "resetConfirmAction": "Stil zurücksetzen",
+    "resetConfirmCancel": "Stil behalten"
   },
   "filters": {
     "title": "Filter",
@@ -594,7 +597,8 @@
       "count": "Anzahl",
       "crs": "KRS",
       "attribution": "Namensnennung"
-    }
+    },
+    "table": "Tabelle"
   },
   "share": {
     "title": "Teilen",
@@ -677,7 +681,11 @@
     "regenerate": "Neu generieren",
     "regenerateLink": "Link neu generieren",
     "embedTokenForDomains": "Erstellen Sie ein Einbettungs-Token, um diese Einbettung auf bestimmte Domains zu beschränken.",
-    "createEmbedToken": "Einbettungs-Token erstellen"
+    "createEmbedToken": "Einbettungs-Token erstellen",
+    "revokeConfirmTitle": "Freigabelink widerrufen?",
+    "revokeConfirmDescription": "Der Link funktioniert sofort nicht mehr und alle Einbettungs-Tokens dieser Karte werden ungültig. Das kann nicht rückgängig gemacht werden.",
+    "revokeConfirmCancel": "Abbrechen",
+    "revokeConfirmAction": "Link widerrufen"
   },
   "chat": {
     "emptyState": "Beschreiben Sie Änderungen an Ihrer Karte in natürlicher Sprache.",
@@ -1215,7 +1223,6 @@
     "aiUnavailable": "KI nicht verfügbar",
     "aiUnavailableTitle": "KI ist nicht verfügbar",
     "aiUnavailableDescription": "Ein Administrator muss einen KI-Anbieter aktivieren, bevor Frag KI in diesem Builder verwendet werden kann.",
-    "notesPresent": "Karte hat Notizen",
     "aiDisabledTitle": "Die KI ist deaktiviert",
     "aiDisabledBody": "Ein Administrator hat die KI für diese Instanz deaktiviert.",
     "aiNoKeyTitle": "KI nicht konfiguriert",
@@ -1224,7 +1231,8 @@
     "aiPermissionBody": "Sie haben keine Berechtigung, den KI-Chat zu verwenden.",
     "aiGoToSettings": "Zu den Einstellungen",
     "aiConfigureSettings": "In den Einstellungen konfigurieren",
-    "closePanel": "Panel schließen"
+    "closePanel": "Panel schließen",
+    "notesButtonWithNotes": "Notizen (Karte hat Notizen)"
   },
   "stackRow": {
     "dragHandle": "Ziehen zum Neuanordnen von {{name}}",
@@ -1380,7 +1388,11 @@
     "deleteLayer": "Ebene löschen",
     "deleteLayerConfirmMessage": "Diese Ebene löschen? Das kann nicht rückgängig gemacht werden.",
     "deleteLayerConfirmAction": "Löschen",
-    "deleteLayerConfirmCancel": "Ebene behalten"
+    "deleteLayerConfirmCancel": "Ebene behalten",
+    "typePill": {
+      "hillshade": "Schummerung",
+      "terrain": "Gelände"
+    }
   },
   "settings": {
     "regionLabel": "Karteneinstellungen",

--- a/frontend/src/i18n/locales/de/builder.json
+++ b/frontend/src/i18n/locales/de/builder.json
@@ -1192,6 +1192,7 @@
     "listboxLabel": "Karten-Layer",
     "searchPlaceholder": "Layer filtern…",
     "searchAriaLabel": "Layer nach Name filtern",
+    "searchNoMatches": "Keine Layer entsprechen „{{query}}“",
     "emptyRegionLabel": "Keine Layer — loslegen",
     "emptySearchButton": "Suchen und Dialog „Daten hinzufügen“ öffnen",
     "emptySearchInput": "Datensätze zum Hinzufügen suchen",

--- a/frontend/src/i18n/locales/de/builder.json
+++ b/frontend/src/i18n/locales/de/builder.json
@@ -989,7 +989,11 @@
     "unitKilometers": "Kilometer",
     "unitFeet": "Fuß",
     "unitMiles": "Meilen",
-    "drawMaskPointerHint": "Zeichnen erfordert einen Zeiger. Zum Zuschneiden ohne Zeiger wählen Sie unten eine Polygonebene."
+    "drawMaskPointerHint": "Zeichnen erfordert einen Zeiger. Zum Zuschneiden ohne Zeiger wählen Sie unten eine Polygonebene.",
+    "saveHintNeedsName": "Geben Sie einen Namen für den neuen Datensatz ein, um „Datensatz erstellen“ zu aktivieren.",
+    "saveHintNeedsParams": "Vervollständigen Sie die Einstellungen der Operation oben, um „Datensatz erstellen“ zu aktivieren.",
+    "addedToMap": "Zur Karte hinzugefügt",
+    "openMap": "Karte öffnen"
   },
   "attributeForm": {
     "titleEdit": "Feature-Attribute bearbeiten",

--- a/frontend/src/i18n/locales/de/builder.json
+++ b/frontend/src/i18n/locales/de/builder.json
@@ -1225,6 +1225,7 @@
     "opacitySlider": "Deckkraft für {{name}}",
     "kebabTrigger": "Layer-Optionen für {{name}}",
     "kebabRenameLayer": "Layer umbenennen",
+    "renameInputLabel": "Layer-Name",
     "kebabDuplicate": "Duplizieren",
     "kebabDeleteLayer": "Layer löschen",
     "kebabAddToGroup": "Zur Gruppe hinzufügen…",

--- a/frontend/src/i18n/locales/de/common.json
+++ b/frontend/src/i18n/locales/de/common.json
@@ -567,7 +567,8 @@
     "exitFullscreen": "Vollbild beenden",
     "fullscreen": "Vollbild öffnen",
     "unsavedDiscarded": "Nicht gespeicherte Änderungen verworfen",
-    "zoomToExtent": "Auf Datensatzausdehnung zoomen"
+    "zoomToExtent": "Auf Datensatzausdehnung zoomen",
+    "featureId": "Feature-ID: {{id}}"
   },
   "moreActions": "Weitere Aktionen",
   "notSet": "Nicht gesetzt",

--- a/frontend/src/i18n/locales/de/dataset.json
+++ b/frontend/src/i18n/locales/de/dataset.json
@@ -424,6 +424,7 @@
     "noChanges": "Keine Schemaänderungen erkannt."
   },
   "map": {
+    "ariaLabel": "Datensatzkarte",
     "featureSaved": "Feature gespeichert",
     "featureSaveFailed": "Feature konnte nicht gespeichert werden",
     "featureUpdated": "Feature aktualisiert",

--- a/frontend/src/i18n/locales/de/dataset.json
+++ b/frontend/src/i18n/locales/de/dataset.json
@@ -446,7 +446,8 @@
     "featureNotSelectable": "Dieses Feature kann nicht zur Bearbeitung ausgewählt werden.",
     "fullscreen": "Vollbild aktivieren",
     "exitFullscreen": "Vollbild beenden",
-    "changeBasemap": "Basiskarte ändern"
+    "changeBasemap": "Basiskarte ändern",
+    "featureId": "Feature-ID: {{id}}"
   },
   "validation": {
     "title": "Validierungsstatus",

--- a/frontend/src/i18n/locales/de/import.json
+++ b/frontend/src/i18n/locales/de/import.json
@@ -234,7 +234,8 @@
       "type": "Typ",
       "spatial": "Räumlich",
       "nonSpatial": "Nicht räumlich"
-    }
+    },
+    "tablesSidebarLabel": "Erkannte Tabellen"
   },
   "layerPicker": {
     "title": "Layer auswählen",
@@ -483,7 +484,8 @@
     "comparedToUpload": "Im Vergleich zum Upload",
     "compareRegister": "Upload nimmt aus einer Datei auf. Registrieren zeigt auf eine vorhandene Tabelle — keine Duplizierung, aber die Tabelle muss in Ihrer Datenbank bleiben.",
     "compareStac": "Upload nimmt lokale Dateien auf. STAC-Import erkennt zuerst Remote-Assets und stellt ausgewählte Elemente dann für den Katalog bereit.",
-    "compareService": "Upload nimmt aus einer Datei auf. Service-URL ruft von einer Remote-API ab und importiert die Daten in GeoLens zur lokalen Kachelung und Abfrage."
+    "compareService": "Upload nimmt aus einer Datei auf. Service-URL ruft von einer Remote-API ab und importiert die Daten in GeoLens zur lokalen Kachelung und Abfrage.",
+    "asideLabel": "Import-Workflow"
   },
   "status": {
     "uploading": "Hochladen",

--- a/frontend/src/i18n/locales/de/import.json
+++ b/frontend/src/i18n/locales/de/import.json
@@ -423,7 +423,7 @@
     "columnCount_other": "{{value}} Spalten",
     "sheetOption": "{{name}} ({{rows}}, {{columns}})",
     "importProgress": "Importfortschritt",
-    "readyTitle_one": "1 Datensatz bereit",
+    "readyTitle_one": "{{count}} Datensatz bereit",
     "readyTitle_other": "{{count}} Datensätze bereit",
     "readyDescription": "Öffnen Sie fertige Datensätze direkt oder laden Sie weiter hoch, während die übrigen Aufträge abgeschlossen werden.",
     "kindRaster": "Rasterdatensatz",

--- a/frontend/src/i18n/locales/de/search.json
+++ b/frontend/src/i18n/locales/de/search.json
@@ -140,6 +140,7 @@
     "saveShort": "Speichern"
   },
   "bbox": {
+    "mapAriaLabel": "Karte des Begrenzungsrahmens",
     "noExtent": "Keine Ausdehnung",
     "instruction": "Klicken und ziehen, um einen Begrenzungsrahmen zu zeichnen",
     "loading": "Karte wird geladen..."
@@ -188,6 +189,7 @@
   "workspaceTitle": "GeoLens-Katalog durchsuchen",
   "spatial": {
     "title": "Suchbereich",
+    "mapAriaLabel": "Karte des Suchbereichs",
     "description": "Rechteck oder Polygon zeichnen, um Suchergebnisse auf einen bestimmten Bereich zu begrenzen.",
     "close": "Schließen",
     "rectangle": "Rechteck",

--- a/frontend/src/i18n/locales/en/builder.json
+++ b/frontend/src/i18n/locales/en/builder.json
@@ -1196,6 +1196,7 @@
     "listboxLabel": "Map layers",
     "searchPlaceholder": "Filter layers…",
     "searchAriaLabel": "Filter layers by name",
+    "searchNoMatches": "No layers match “{{query}}”",
     "emptyRegionLabel": "No layers — get started",
     "emptySearchButton": "Search and open Add Data modal",
     "emptySearchInput": "Search datasets to add",

--- a/frontend/src/i18n/locales/en/builder.json
+++ b/frontend/src/i18n/locales/en/builder.json
@@ -1230,6 +1230,7 @@
     "opacitySlider": "Opacity for {{name}}",
     "kebabTrigger": "Layer options for {{name}}",
     "kebabRenameLayer": "Rename layer",
+    "renameInputLabel": "Layer name",
     "kebabDuplicate": "Duplicate",
     "kebabDeleteLayer": "Delete layer",
     "kebabAddToGroup": "Add to group…",

--- a/frontend/src/i18n/locales/en/builder.json
+++ b/frontend/src/i18n/locales/en/builder.json
@@ -989,7 +989,11 @@
     "unitKilometers": "kilometers",
     "unitFeet": "feet",
     "unitMiles": "miles",
-    "drawMaskPointerHint": "Drawing needs a pointer. To clip without one, pick a polygon layer below."
+    "drawMaskPointerHint": "Drawing needs a pointer. To clip without one, pick a polygon layer below.",
+    "saveHintNeedsName": "Enter a name for the new dataset to enable Create dataset.",
+    "saveHintNeedsParams": "Complete the operation settings above to enable Create dataset.",
+    "addedToMap": "Added to map",
+    "openMap": "Open map"
   },
   "attributeForm": {
     "titleEdit": "Edit Feature Attributes",

--- a/frontend/src/i18n/locales/en/builder.json
+++ b/frontend/src/i18n/locales/en/builder.json
@@ -396,7 +396,10 @@
       "parseError": "Invalid JSON",
       "structureError": "Expression must be an array starting with a known operator"
     },
-    "validatorUnavailable": "This JSON could not be validated — simplify the value and try again."
+    "validatorUnavailable": "This JSON could not be validated — simplify the value and try again.",
+    "resetConfirmMessage": "Reset this layer’s style? Render mode and data-driven styling will be lost.",
+    "resetConfirmAction": "Reset style",
+    "resetConfirmCancel": "Keep style"
   },
   "filters": {
     "title": "Filters",
@@ -594,7 +597,8 @@
       "count": "Count",
       "crs": "CRS",
       "attribution": "Attribution"
-    }
+    },
+    "table": "Table"
   },
   "share": {
     "title": "Share",
@@ -677,7 +681,11 @@
     "regenerate": "Regenerate",
     "regenerateLink": "Regenerate link",
     "embedTokenForDomains": "Create an embed token to restrict this embed to specific domains.",
-    "createEmbedToken": "Create embed token"
+    "createEmbedToken": "Create embed token",
+    "revokeConfirmTitle": "Revoke share link?",
+    "revokeConfirmDescription": "The link will stop working immediately and any embed tokens for this map will be invalidated. This cannot be undone.",
+    "revokeConfirmCancel": "Cancel",
+    "revokeConfirmAction": "Revoke link"
   },
   "chat": {
     "emptyState": "Describe changes to your map using natural language.",
@@ -1220,7 +1228,6 @@
     "aiUnavailable": "AI unavailable",
     "aiUnavailableTitle": "AI is unavailable",
     "aiUnavailableDescription": "An administrator needs to enable an AI provider before Ask AI can be used in this builder.",
-    "notesPresent": "Map has notes",
     "aiDisabledTitle": "AI is disabled",
     "aiDisabledBody": "An administrator has disabled AI for this instance.",
     "aiNoKeyTitle": "AI not configured",
@@ -1228,7 +1235,8 @@
     "aiPermissionTitle": "AI unavailable",
     "aiPermissionBody": "You don't have permission to use AI chat.",
     "aiGoToSettings": "Go to Settings",
-    "aiConfigureSettings": "Configure in Settings"
+    "aiConfigureSettings": "Configure in Settings",
+    "notesButtonWithNotes": "Notes (map has notes)"
   },
   "stackRow": {
     "dragHandle": "Drag to reorder {{name}}",
@@ -1384,6 +1392,10 @@
       "title": "0 features in view — check your filter",
       "help": "The current filter matches nothing in the visible map area. Matches may exist off-screen — pan or zoom out, adjust a condition, or clear the filter.",
       "clear": "Clear filter"
+    },
+    "typePill": {
+      "hillshade": "Hillshade",
+      "terrain": "Terrain"
     }
   },
   "errors": {

--- a/frontend/src/i18n/locales/en/builder.json
+++ b/frontend/src/i18n/locales/en/builder.json
@@ -891,7 +891,9 @@
     "bulkGroupNeedTwo": "Select at least 2 loose layers to group",
     "bulkGroupSkipped": "Some selected layers are already grouped and can't be grouped again",
     "bulkGroupSkippedGroupRow": "Groups can't be grouped — remove any group rows from your selection and try again",
-    "bulkDeleteOnlyGroupRows": "Group rows can't be bulk-deleted — use a group's row menu to delete it"
+    "bulkDeleteOnlyGroupRows": "Group rows can't be bulk-deleted — use a group's row menu to delete it",
+    "bulkGrouped": "Grouped {{count}} layers into \"{{name}}\"",
+    "bulkUngrouped": "Ungrouped {{count}} groups"
   },
   "builderMap": {
     "loading": "Loading map...",
@@ -1240,6 +1242,9 @@
     "kebabUngroup": "Ungroup",
     "kebabDeleteGroup": "Delete group",
     "kebabMoveOutOfGroup": "Move out of group",
+    "moveOutConfirmMessage": "Move this layer out of \"{{group}}\"? The empty group will also be removed.",
+    "moveOutConfirmAction": "Move out",
+    "moveOutConfirmCancel": "Keep in group",
     "labelsIndicator": "Labels on: {{column}}",
     "kebabZoomToLayer": "Zoom to layer",
     "kebabAnalyzeLayer": "Analyze this layer",
@@ -1348,6 +1353,7 @@
     },
     "confirmDelete": {
       "message": "Are you sure? This cannot be undone.",
+      "messageDissolvesGroup": "Are you sure? This cannot be undone, and the group \"{{group}}\" will also be removed.",
       "delete": "Delete",
       "keep": "Keep layer"
     },

--- a/frontend/src/i18n/locales/en/common.json
+++ b/frontend/src/i18n/locales/en/common.json
@@ -222,7 +222,8 @@
     "exitFullscreen": "Exit fullscreen",
     "fullscreen": "Enter fullscreen",
     "unsavedDiscarded": "Unsaved changes discarded",
-    "zoomToExtent": "Zoom to dataset extent"
+    "zoomToExtent": "Zoom to dataset extent",
+    "featureId": "Feature ID: {{id}}"
   },
   "page": {
     "noSpatialExtent": "No spatial extent available"

--- a/frontend/src/i18n/locales/en/dataset.json
+++ b/frontend/src/i18n/locales/en/dataset.json
@@ -397,7 +397,8 @@
     "zoomToExtent": "Zoom to dataset extent",
     "fullscreen": "Enter fullscreen",
     "exitFullscreen": "Exit fullscreen",
-    "changeBasemap": "Change basemap"
+    "changeBasemap": "Change basemap",
+    "featureId": "Feature ID: {{id}}"
   },
   "contacts": {
     "title": "Contacts",

--- a/frontend/src/i18n/locales/en/dataset.json
+++ b/frontend/src/i18n/locales/en/dataset.json
@@ -375,6 +375,7 @@
     "noChanges": "No schema changes detected."
   },
   "map": {
+    "ariaLabel": "Dataset map",
     "featureSaved": "Feature saved",
     "featureSaveFailed": "Failed to save feature",
     "featureUpdated": "Feature updated",

--- a/frontend/src/i18n/locales/en/import.json
+++ b/frontend/src/i18n/locales/en/import.json
@@ -233,7 +233,8 @@
     "comparedToUpload": "Compared to Upload",
     "compareRegister": "Upload ingests from a file. Register points at an existing table — no duplication, but the table must stay in your database.",
     "compareStac": "Upload ingests local files. STAC imports discover remote assets first, then stages selected items for catalog use.",
-    "compareService": "Upload ingests from a file. Service URL fetches from a remote API and imports the data into GeoLens for local tiling and querying."
+    "compareService": "Upload ingests from a file. Service URL fetches from a remote API and imports the data into GeoLens for local tiling and querying.",
+    "asideLabel": "Import workflow"
   },
   "register": {
     "helpText": "Catalog existing PostGIS tables from your database as datasets in GeoLens. Use this when you have geographic data already in the database that wasn't imported through GeoLens. Selected tables will be added to the dataset catalog with automatic metadata detection.",
@@ -277,7 +278,8 @@
       "type": "Type",
       "spatial": "Spatial",
       "nonSpatial": "Non-spatial"
-    }
+    },
+    "tablesSidebarLabel": "Discovered tables"
   },
   "layerPicker": {
     "title": "Select Layer",

--- a/frontend/src/i18n/locales/en/import.json
+++ b/frontend/src/i18n/locales/en/import.json
@@ -473,7 +473,7 @@
     "columnCount_other": "{{value}} columns",
     "sheetOption": "{{name}} ({{rows}}, {{columns}})",
     "importProgress": "Import Progress",
-    "readyTitle_one": "1 dataset ready",
+    "readyTitle_one": "{{count}} dataset ready",
     "readyTitle_other": "{{count}} datasets ready",
     "readyDescription": "Open the finished datasets directly, or keep uploading while the rest of the jobs settle.",
     "kindRaster": "Raster dataset",

--- a/frontend/src/i18n/locales/en/search.json
+++ b/frontend/src/i18n/locales/en/search.json
@@ -141,6 +141,7 @@
   },
   "spatial": {
     "title": "Search area",
+    "mapAriaLabel": "Search area map",
     "description": "Draw a rectangle or polygon to limit search results to a specific area.",
     "close": "Close",
     "rectangle": "Rectangle",
@@ -154,6 +155,7 @@
     "clearArea": "Clear area"
   },
   "bbox": {
+    "mapAriaLabel": "Bounding box map",
     "noExtent": "No extent",
     "instruction": "Click and drag to draw a bounding box",
     "loading": "Loading map..."

--- a/frontend/src/i18n/locales/es/builder.json
+++ b/frontend/src/i18n/locales/es/builder.json
@@ -396,7 +396,10 @@
       "parseError": "JSON no válido",
       "structureError": "La expresión debe ser un arreglo que comience con un operador conocido"
     },
-    "validatorUnavailable": "No se pudo validar este JSON: simplifica el valor e inténtalo de nuevo."
+    "validatorUnavailable": "No se pudo validar este JSON: simplifica el valor e inténtalo de nuevo.",
+    "resetConfirmMessage": "¿Restablecer el estilo de esta capa? Se perderán el modo de renderizado y el estilo basado en datos.",
+    "resetConfirmAction": "Restablecer estilo",
+    "resetConfirmCancel": "Mantener estilo"
   },
   "filters": {
     "title": "Filtros",
@@ -594,7 +597,8 @@
       "count": "Recuento",
       "crs": "SRC",
       "attribution": "Atribución"
-    }
+    },
+    "table": "Tabla"
   },
   "share": {
     "title": "Compartir",
@@ -677,7 +681,11 @@
     "regenerate": "Regenerar",
     "regenerateLink": "Regenerar enlace",
     "embedTokenForDomains": "Crea un token de inserción para restringir esta inserción a dominios específicos.",
-    "createEmbedToken": "Crear token de inserción"
+    "createEmbedToken": "Crear token de inserción",
+    "revokeConfirmTitle": "¿Revocar el enlace compartido?",
+    "revokeConfirmDescription": "El enlace dejará de funcionar de inmediato y se invalidarán los tokens de inserción de este mapa. No se puede deshacer.",
+    "revokeConfirmCancel": "Cancelar",
+    "revokeConfirmAction": "Revocar enlace"
   },
   "chat": {
     "emptyState": "Describa cambios en su mapa usando lenguaje natural.",
@@ -1215,7 +1223,6 @@
     "aiUnavailable": "IA no disponible",
     "aiUnavailableTitle": "La IA no está disponible",
     "aiUnavailableDescription": "Un administrador debe habilitar un proveedor de IA antes de usar Preguntar a la IA en este builder.",
-    "notesPresent": "El mapa tiene notas",
     "aiDisabledTitle": "La IA está desactivada",
     "aiDisabledBody": "Un administrador ha desactivado la IA en esta instancia.",
     "aiNoKeyTitle": "IA no configurada",
@@ -1224,7 +1231,8 @@
     "aiPermissionBody": "No tienes permiso para usar el chat de IA.",
     "aiGoToSettings": "Ir a Configuración",
     "aiConfigureSettings": "Configurar en Configuración",
-    "closePanel": "Cerrar panel"
+    "closePanel": "Cerrar panel",
+    "notesButtonWithNotes": "Notas (el mapa tiene notas)"
   },
   "stackRow": {
     "dragHandle": "Arrastrar para reordenar {{name}}",
@@ -1380,7 +1388,11 @@
     "deleteLayer": "Eliminar capa",
     "deleteLayerConfirmMessage": "¿Eliminar esta capa? No se puede deshacer.",
     "deleteLayerConfirmAction": "Eliminar",
-    "deleteLayerConfirmCancel": "Mantener capa"
+    "deleteLayerConfirmCancel": "Mantener capa",
+    "typePill": {
+      "hillshade": "Sombreado",
+      "terrain": "Terreno"
+    }
   },
   "settings": {
     "regionLabel": "Configuración del mapa",

--- a/frontend/src/i18n/locales/es/builder.json
+++ b/frontend/src/i18n/locales/es/builder.json
@@ -1192,6 +1192,7 @@
     "listboxLabel": "Capas del mapa",
     "searchPlaceholder": "Filtrar capas…",
     "searchAriaLabel": "Filtrar capas por nombre",
+    "searchNoMatches": "Ninguna capa coincide con «{{query}}»",
     "emptyRegionLabel": "Sin capas — empezar",
     "emptySearchButton": "Buscar y abrir el cuadro Agregar datos",
     "emptySearchInput": "Buscar conjuntos de datos para agregar",

--- a/frontend/src/i18n/locales/es/builder.json
+++ b/frontend/src/i18n/locales/es/builder.json
@@ -1225,6 +1225,7 @@
     "opacitySlider": "Opacidad para {{name}}",
     "kebabTrigger": "Opciones de capa para {{name}}",
     "kebabRenameLayer": "Renombrar capa",
+    "renameInputLabel": "Nombre de la capa",
     "kebabDuplicate": "Duplicar",
     "kebabDeleteLayer": "Eliminar capa",
     "kebabAddToGroup": "Agregar al grupo…",

--- a/frontend/src/i18n/locales/es/builder.json
+++ b/frontend/src/i18n/locales/es/builder.json
@@ -989,7 +989,11 @@
     "unitKilometers": "kilómetros",
     "unitFeet": "pies",
     "unitMiles": "millas",
-    "drawMaskPointerHint": "Dibujar requiere un puntero. Para recortar sin él, elige una capa de polígonos abajo."
+    "drawMaskPointerHint": "Dibujar requiere un puntero. Para recortar sin él, elige una capa de polígonos abajo.",
+    "saveHintNeedsName": "Introduce un nombre para el nuevo conjunto de datos para activar Crear conjunto de datos.",
+    "saveHintNeedsParams": "Completa los ajustes de la operación de arriba para activar Crear conjunto de datos.",
+    "addedToMap": "Añadido al mapa",
+    "openMap": "Abrir mapa"
   },
   "attributeForm": {
     "titleEdit": "Editar atributos de la entidad",

--- a/frontend/src/i18n/locales/es/builder.json
+++ b/frontend/src/i18n/locales/es/builder.json
@@ -891,7 +891,9 @@
     "bulkGroupNeedTwo": "Selecciona al menos 2 capas sueltas para agrupar",
     "bulkGroupSkipped": "Algunas capas seleccionadas ya están agrupadas y no se pueden agrupar de nuevo",
     "bulkGroupSkippedGroupRow": "Los grupos no se pueden agrupar; quita las filas de grupo de tu selección e inténtalo de nuevo",
-    "bulkDeleteOnlyGroupRows": "Las filas de grupo no se pueden eliminar en bloque; usa el menú de la fila del grupo para eliminarlo"
+    "bulkDeleteOnlyGroupRows": "Las filas de grupo no se pueden eliminar en bloque; usa el menú de la fila del grupo para eliminarlo",
+    "bulkGrouped": "{{count}} capas agrupadas en «{{name}}»",
+    "bulkUngrouped": "{{count}} grupos desagrupados"
   },
   "builderMap": {
     "loading": "Cargando mapa...",
@@ -1235,6 +1237,9 @@
     "kebabUngroup": "Desagrupar",
     "kebabDeleteGroup": "Eliminar grupo",
     "kebabMoveOutOfGroup": "Mover fuera del grupo",
+    "moveOutConfirmMessage": "¿Mover esta capa fuera de «{{group}}»? El grupo vacío también se eliminará.",
+    "moveOutConfirmAction": "Mover fuera",
+    "moveOutConfirmCancel": "Mantener en el grupo",
     "labelsIndicator": "Etiquetas activadas: {{column}}",
     "kebabGroupTrigger": "Opciones de grupo para {{name}}",
     "kebabZoomToLayer": "Acercar a la capa",
@@ -1340,6 +1345,7 @@
     },
     "confirmDelete": {
       "message": "¿Está seguro? Esta acción no se puede deshacer.",
+      "messageDissolvesGroup": "¿Está seguro? Esta acción no se puede deshacer y el grupo «{{group}}» también se eliminará.",
       "delete": "Eliminar",
       "keep": "Conservar capa"
     },

--- a/frontend/src/i18n/locales/es/common.json
+++ b/frontend/src/i18n/locales/es/common.json
@@ -567,7 +567,8 @@
     "exitFullscreen": "Salir de pantalla completa",
     "fullscreen": "Pantalla completa",
     "unsavedDiscarded": "Cambios sin guardar descartados",
-    "zoomToExtent": "Zoom a la extensión del conjunto de datos"
+    "zoomToExtent": "Zoom a la extensión del conjunto de datos",
+    "featureId": "ID de entidad: {{id}}"
   },
   "moreActions": "Más acciones",
   "notSet": "No establecido",

--- a/frontend/src/i18n/locales/es/dataset.json
+++ b/frontend/src/i18n/locales/es/dataset.json
@@ -424,6 +424,7 @@
     "noChanges": "No se detectaron cambios de esquema."
   },
   "map": {
+    "ariaLabel": "Mapa del conjunto de datos",
     "featureSaved": "Entidad guardada",
     "featureSaveFailed": "Error al guardar la entidad",
     "featureUpdated": "Entidad actualizada",

--- a/frontend/src/i18n/locales/es/dataset.json
+++ b/frontend/src/i18n/locales/es/dataset.json
@@ -446,7 +446,8 @@
     "featureNotSelectable": "Esta entidad no se puede seleccionar para edición.",
     "fullscreen": "Pantalla completa",
     "exitFullscreen": "Salir de pantalla completa",
-    "changeBasemap": "Cambiar mapa base"
+    "changeBasemap": "Cambiar mapa base",
+    "featureId": "ID de entidad: {{id}}"
   },
   "validation": {
     "title": "Estado de validación",

--- a/frontend/src/i18n/locales/es/import.json
+++ b/frontend/src/i18n/locales/es/import.json
@@ -423,7 +423,7 @@
     "columnCount_other": "{{value}} columnas",
     "sheetOption": "{{name}} ({{rows}}, {{columns}})",
     "importProgress": "Progreso de importación",
-    "readyTitle_one": "1 conjunto listo",
+    "readyTitle_one": "{{count}} conjunto listo",
     "readyTitle_other": "{{count}} conjuntos listos",
     "readyDescription": "Abra directamente los conjuntos terminados o siga cargando mientras se completan los demás trabajos.",
     "kindRaster": "Conjunto ráster",

--- a/frontend/src/i18n/locales/es/import.json
+++ b/frontend/src/i18n/locales/es/import.json
@@ -234,7 +234,8 @@
       "type": "Tipo",
       "spatial": "Espacial",
       "nonSpatial": "No espacial"
-    }
+    },
+    "tablesSidebarLabel": "Tablas descubiertas"
   },
   "layerPicker": {
     "title": "Seleccionar capa",
@@ -483,7 +484,8 @@
     "comparedToUpload": "Comparado con la carga",
     "compareRegister": "La carga ingesta desde un archivo. Registrar apunta a una tabla existente — sin duplicación, pero la tabla debe permanecer en tu base de datos.",
     "compareStac": "La carga ingesta archivos locales. Las importaciones STAC descubren activos remotos primero, luego preparan los elementos seleccionados para el catálogo.",
-    "compareService": "La carga ingesta desde un archivo. La URL de servicio obtiene de una API remota e importa los datos a GeoLens para teselado y consultas locales."
+    "compareService": "La carga ingesta desde un archivo. La URL de servicio obtiene de una API remota e importa los datos a GeoLens para teselado y consultas locales.",
+    "asideLabel": "Flujo de importación"
   },
   "status": {
     "uploading": "Subiendo",

--- a/frontend/src/i18n/locales/es/search.json
+++ b/frontend/src/i18n/locales/es/search.json
@@ -140,6 +140,7 @@
     "saveShort": "Guardar"
   },
   "bbox": {
+    "mapAriaLabel": "Mapa del cuadro delimitador",
     "noExtent": "Sin extensión",
     "instruction": "Haz clic y arrastra para dibujar un cuadro delimitador",
     "loading": "Cargando mapa..."
@@ -188,6 +189,7 @@
   "workspaceTitle": "Buscar en el catálogo GeoLens",
   "spatial": {
     "title": "Área de búsqueda",
+    "mapAriaLabel": "Mapa del área de búsqueda",
     "description": "Dibuja un rectángulo o polígono para limitar los resultados de búsqueda a un área específica.",
     "close": "Cerrar",
     "rectangle": "Rectángulo",

--- a/frontend/src/i18n/locales/fr/builder.json
+++ b/frontend/src/i18n/locales/fr/builder.json
@@ -989,7 +989,11 @@
     "unitKilometers": "kilomètres",
     "unitFeet": "pieds",
     "unitMiles": "milles",
-    "drawMaskPointerHint": "Le dessin nécessite un pointeur. Pour découper sans, choisissez une couche de polygones ci-dessous."
+    "drawMaskPointerHint": "Le dessin nécessite un pointeur. Pour découper sans, choisissez une couche de polygones ci-dessous.",
+    "saveHintNeedsName": "Saisissez un nom pour le nouveau jeu de données pour activer Créer un jeu de données.",
+    "saveHintNeedsParams": "Renseignez les paramètres de l’opération ci-dessus pour activer Créer un jeu de données.",
+    "addedToMap": "Ajouté à la carte",
+    "openMap": "Ouvrir la carte"
   },
   "attributeForm": {
     "titleEdit": "Modifier les attributs de l'entité",

--- a/frontend/src/i18n/locales/fr/builder.json
+++ b/frontend/src/i18n/locales/fr/builder.json
@@ -1192,6 +1192,7 @@
     "listboxLabel": "Couches de la carte",
     "searchPlaceholder": "Filtrer les couches…",
     "searchAriaLabel": "Filtrer les couches par nom",
+    "searchNoMatches": "Aucune couche ne correspond à « {{query}} »",
     "emptyRegionLabel": "Aucune couche — commencer",
     "emptySearchButton": "Rechercher et ouvrir la fenêtre Ajouter des données",
     "emptySearchInput": "Rechercher des jeux de données à ajouter",

--- a/frontend/src/i18n/locales/fr/builder.json
+++ b/frontend/src/i18n/locales/fr/builder.json
@@ -891,7 +891,9 @@
     "bulkGroupNeedTwo": "Sélectionnez au moins 2 couches libres pour les regrouper",
     "bulkGroupSkipped": "Certaines couches sélectionnées sont déjà groupées et ne peuvent pas être regroupées à nouveau",
     "bulkGroupSkippedGroupRow": "Les groupes ne peuvent pas être regroupés ; retirez les lignes de groupe de votre sélection et réessayez",
-    "bulkDeleteOnlyGroupRows": "Les lignes de groupe ne peuvent pas être supprimées en masse ; utilisez le menu de la ligne du groupe pour le supprimer"
+    "bulkDeleteOnlyGroupRows": "Les lignes de groupe ne peuvent pas être supprimées en masse ; utilisez le menu de la ligne du groupe pour le supprimer",
+    "bulkGrouped": "{{count}} couches regroupées dans « {{name}} »",
+    "bulkUngrouped": "{{count}} groupes dissociés"
   },
   "builderMap": {
     "loading": "Chargement de la carte...",
@@ -1235,6 +1237,9 @@
     "kebabUngroup": "Dégrouper",
     "kebabDeleteGroup": "Supprimer le groupe",
     "kebabMoveOutOfGroup": "Déplacer hors du groupe",
+    "moveOutConfirmMessage": "Déplacer cette couche hors de « {{group}} » ? Le groupe vide sera également supprimé.",
+    "moveOutConfirmAction": "Déplacer hors du groupe",
+    "moveOutConfirmCancel": "Conserver dans le groupe",
     "labelsIndicator": "Étiquettes activées : {{column}}",
     "kebabGroupTrigger": "Options de groupe pour {{name}}",
     "kebabZoomToLayer": "Zoomer sur la couche",
@@ -1340,6 +1345,7 @@
     },
     "confirmDelete": {
       "message": "Êtes-vous sûr ? Cette action est irréversible.",
+      "messageDissolvesGroup": "Êtes-vous sûr ? Cette action est irréversible et le groupe « {{group}} » sera également supprimé.",
       "delete": "Supprimer",
       "keep": "Conserver la couche"
     },

--- a/frontend/src/i18n/locales/fr/builder.json
+++ b/frontend/src/i18n/locales/fr/builder.json
@@ -396,7 +396,10 @@
       "parseError": "JSON invalide",
       "structureError": "L'expression doit être un tableau commençant par un opérateur connu"
     },
-    "validatorUnavailable": "Ce JSON n'a pas pu être validé — simplifiez la valeur et réessayez."
+    "validatorUnavailable": "Ce JSON n'a pas pu être validé — simplifiez la valeur et réessayez.",
+    "resetConfirmMessage": "Réinitialiser le style de cette couche ? Le mode de rendu et le style basé sur les données seront perdus.",
+    "resetConfirmAction": "Réinitialiser le style",
+    "resetConfirmCancel": "Conserver le style"
   },
   "filters": {
     "title": "Filtres",
@@ -594,7 +597,8 @@
       "count": "Nombre",
       "crs": "SCR",
       "attribution": "Attribution"
-    }
+    },
+    "table": "Table"
   },
   "share": {
     "title": "Partager",
@@ -677,7 +681,11 @@
     "regenerate": "Régénérer",
     "regenerateLink": "Régénérer le lien",
     "embedTokenForDomains": "Créez un jeton d’intégration pour limiter cette intégration à des domaines spécifiques.",
-    "createEmbedToken": "Créer un jeton d’intégration"
+    "createEmbedToken": "Créer un jeton d’intégration",
+    "revokeConfirmTitle": "Révoquer le lien de partage ?",
+    "revokeConfirmDescription": "Le lien cessera de fonctionner immédiatement et les jetons d’intégration de cette carte seront invalidés. Cette action est irréversible.",
+    "revokeConfirmCancel": "Annuler",
+    "revokeConfirmAction": "Révoquer le lien"
   },
   "chat": {
     "emptyState": "Décrivez les modifications à apporter à votre carte en langage naturel.",
@@ -1215,7 +1223,6 @@
     "aiUnavailable": "IA indisponible",
     "aiUnavailableTitle": "L'IA est indisponible",
     "aiUnavailableDescription": "Un administrateur doit activer un fournisseur d'IA avant d'utiliser Demander à l'IA dans ce builder.",
-    "notesPresent": "La carte a des notes",
     "aiDisabledTitle": "L'IA est désactivée",
     "aiDisabledBody": "Un administrateur a désactivé l'IA pour cette instance.",
     "aiNoKeyTitle": "IA non configurée",
@@ -1224,7 +1231,8 @@
     "aiPermissionBody": "Vous n'avez pas l'autorisation d'utiliser le chat IA.",
     "aiGoToSettings": "Aller aux paramètres",
     "aiConfigureSettings": "Configurer dans les paramètres",
-    "closePanel": "Fermer le panneau"
+    "closePanel": "Fermer le panneau",
+    "notesButtonWithNotes": "Notes (la carte a des notes)"
   },
   "stackRow": {
     "dragHandle": "Glisser pour réorganiser {{name}}",
@@ -1380,7 +1388,11 @@
     "deleteLayer": "Supprimer le calque",
     "deleteLayerConfirmMessage": "Supprimer ce calque ? Cette action est irréversible.",
     "deleteLayerConfirmAction": "Supprimer",
-    "deleteLayerConfirmCancel": "Conserver le calque"
+    "deleteLayerConfirmCancel": "Conserver le calque",
+    "typePill": {
+      "hillshade": "Ombrage",
+      "terrain": "Terrain"
+    }
   },
   "settings": {
     "regionLabel": "Paramètres de carte",

--- a/frontend/src/i18n/locales/fr/builder.json
+++ b/frontend/src/i18n/locales/fr/builder.json
@@ -1225,6 +1225,7 @@
     "opacitySlider": "Opacité pour {{name}}",
     "kebabTrigger": "Options de couche pour {{name}}",
     "kebabRenameLayer": "Renommer la couche",
+    "renameInputLabel": "Nom de la couche",
     "kebabDuplicate": "Dupliquer",
     "kebabDeleteLayer": "Supprimer la couche",
     "kebabAddToGroup": "Ajouter au groupe…",

--- a/frontend/src/i18n/locales/fr/common.json
+++ b/frontend/src/i18n/locales/fr/common.json
@@ -567,7 +567,8 @@
     "exitFullscreen": "Quitter le plein écran",
     "fullscreen": "Plein écran",
     "unsavedDiscarded": "Modifications non sauvegardées ignorées",
-    "zoomToExtent": "Zoom sur l'étendue du jeu de données"
+    "zoomToExtent": "Zoom sur l'étendue du jeu de données",
+    "featureId": "ID d’entité : {{id}}"
   },
   "moreActions": "Plus d'actions",
   "notSet": "Non défini",

--- a/frontend/src/i18n/locales/fr/dataset.json
+++ b/frontend/src/i18n/locales/fr/dataset.json
@@ -446,7 +446,8 @@
     "featureNotSelectable": "Cette entité ne peut pas être sélectionnée pour l'édition.",
     "fullscreen": "Plein écran",
     "exitFullscreen": "Quitter le plein écran",
-    "changeBasemap": "Changer le fond de carte"
+    "changeBasemap": "Changer le fond de carte",
+    "featureId": "ID d’entité : {{id}}"
   },
   "validation": {
     "title": "Statut de validation",

--- a/frontend/src/i18n/locales/fr/dataset.json
+++ b/frontend/src/i18n/locales/fr/dataset.json
@@ -424,6 +424,7 @@
     "noChanges": "Aucune modification de schéma détectée."
   },
   "map": {
+    "ariaLabel": "Carte du jeu de données",
     "featureSaved": "Entité enregistrée",
     "featureSaveFailed": "Échec de l'enregistrement de l'entité",
     "featureUpdated": "Entité mise à jour",

--- a/frontend/src/i18n/locales/fr/import.json
+++ b/frontend/src/i18n/locales/fr/import.json
@@ -423,7 +423,7 @@
     "columnCount_other": "{{value}} colonnes",
     "sheetOption": "{{name}} ({{rows}}, {{columns}})",
     "importProgress": "Progression de l'importation",
-    "readyTitle_one": "1 jeu de données prêt",
+    "readyTitle_one": "{{count}} jeu de données prêt",
     "readyTitle_other": "{{count}} jeux de données prêts",
     "readyDescription": "Ouvrez directement les jeux terminés ou continuez à téléverser pendant que les autres tâches se terminent.",
     "kindRaster": "Jeu raster",

--- a/frontend/src/i18n/locales/fr/import.json
+++ b/frontend/src/i18n/locales/fr/import.json
@@ -234,7 +234,8 @@
       "type": "Type",
       "spatial": "Spatial",
       "nonSpatial": "Non spatial"
-    }
+    },
+    "tablesSidebarLabel": "Tables découvertes"
   },
   "layerPicker": {
     "title": "Sélectionner une couche",
@@ -483,7 +484,8 @@
     "comparedToUpload": "Comparé au chargement",
     "compareRegister": "Le chargement ingère depuis un fichier. L'enregistrement pointe vers une table existante — pas de duplication, mais la table doit rester dans votre base de données.",
     "compareStac": "Le chargement ingère des fichiers locaux. Les importations STAC découvrent d'abord les ressources distantes, puis préparent les éléments sélectionnés pour le catalogue.",
-    "compareService": "Le chargement ingère depuis un fichier. L'URL de service récupère depuis une API distante et importe les données dans GeoLens pour le tuilage et les requêtes locaux."
+    "compareService": "Le chargement ingère depuis un fichier. L'URL de service récupère depuis une API distante et importe les données dans GeoLens pour le tuilage et les requêtes locaux.",
+    "asideLabel": "Processus d’importation"
   },
   "status": {
     "uploading": "Téléversement",

--- a/frontend/src/i18n/locales/fr/search.json
+++ b/frontend/src/i18n/locales/fr/search.json
@@ -140,6 +140,7 @@
     "saveShort": "Enregistrer"
   },
   "bbox": {
+    "mapAriaLabel": "Carte du cadre de sélection",
     "noExtent": "Pas d'étendue",
     "instruction": "Cliquez et faites glisser pour dessiner un cadre de sélection",
     "loading": "Chargement de la carte..."
@@ -188,6 +189,7 @@
   "workspaceTitle": "Rechercher dans le catalogue GeoLens",
   "spatial": {
     "title": "Zone de recherche",
+    "mapAriaLabel": "Carte de la zone de recherche",
     "description": "Dessinez un rectangle ou un polygone pour limiter les résultats de recherche à une zone spécifique.",
     "close": "Fermer",
     "rectangle": "Rectangle",

--- a/frontend/src/lib/__tests__/map-error-log.test.ts
+++ b/frontend/src/lib/__tests__/map-error-log.test.ts
@@ -50,8 +50,25 @@ describe('logUnhandledMapError (fix #755)', () => {
     expect(errorSpy).toHaveBeenCalledWith(e.error);
   });
 
-  it('keeps the default single log for a raster-tiles 403 (outside the vector-tile scope)', () => {
-    const e = ajaxError(403, `${window.location.origin}/raster-tiles/cog/9/151/191.png`);
+  // audit(w3-maps A1): real raster/DEM URLs carry a second `/tiles/` segment
+  // (`/raster-tiles/{id}/tiles/{z}/{x}/{y}.png`), which previously satisfied
+  // the `/tiles/` match and misclassified raster auth errors as handled.
+  it('keeps the default single log for a raster-tiles 403 (real backend URL shape)', () => {
+    const e = ajaxError(403, `${window.location.origin}/raster-tiles/0b0af5ab-1f3e-4c1a-9d7e-8f1f0c9d2e11/tiles/9/151/191.png`);
+    logUnhandledMapError(e);
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+    expect(errorSpy).toHaveBeenCalledWith(e.error);
+  });
+
+  it('keeps the default single log for a relative raster-tiles 401', () => {
+    const e = ajaxError(401, '/raster-tiles/0b0af5ab-1f3e-4c1a-9d7e-8f1f0c9d2e11/tiles/9/151/191.png');
+    logUnhandledMapError(e);
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+    expect(errorSpy).toHaveBeenCalledWith(e.error);
+  });
+
+  it('keeps the default single log for a signed raster-tiles 403 (exclusion beats the sig= match)', () => {
+    const e = ajaxError(403, 'https://cdn.example.com/raster-tiles/0b0af5ab-1f3e-4c1a-9d7e-8f1f0c9d2e11/tiles/9/151/191.png?sig=abc');
     logUnhandledMapError(e);
     expect(errorSpy).toHaveBeenCalledTimes(1);
     expect(errorSpy).toHaveBeenCalledWith(e.error);
@@ -93,5 +110,13 @@ describe('isHandledTileAuthError (fix #755)', () => {
   it('requires a tile URL — a 403 without one stays loggable', () => {
     expect(isHandledTileAuthError({ error: { status: 403 } })).toBe(false);
     expect(isHandledTileAuthError(ajaxError(403, `${window.location.origin}/api/datasets/`))).toBe(false);
+  });
+
+  it('excludes raster-tiles URLs despite their second /tiles/ segment (audit w3-maps A1)', () => {
+    const rasterUrl = `${window.location.origin}/raster-tiles/0b0af5ab-1f3e-4c1a-9d7e-8f1f0c9d2e11/tiles/9/151/191.png`;
+    expect(isHandledTileAuthError(ajaxError(401, rasterUrl))).toBe(false);
+    expect(isHandledTileAuthError(ajaxError(403, rasterUrl))).toBe(false);
+    // Vector tile URLs stay handled after the exclusion.
+    expect(isHandledTileAuthError(ajaxError(403, `${window.location.origin}/api/tiles/data.t/1/2/3.pbf?sig=a`))).toBe(true);
   });
 });

--- a/frontend/src/lib/map-error-log.ts
+++ b/frontend/src/lib/map-error-log.ts
@@ -25,6 +25,12 @@ export interface MapLibreErrorLike {
  * raster `/raster-tiles/` paths do not match. */
 function isFirstPartyTileUrl(url: string | undefined): boolean {
   if (!url || !url.includes('/tiles/')) return false;
+  // audit(w3-maps A1): raster/DEM tile URLs are
+  // `/raster-tiles/{id}/tiles/{z}/{x}/{y}.png` — the second `/tiles/` segment
+  // matched above and misclassified raster 401/403s as handled. Raster auth
+  // rides the Authorization header (setTransformRequest), not the vector
+  // re-sign/re-mint path, so it is never "handled" here.
+  if (url.includes('/raster-tiles/')) return false;
   if (!/^https?:\/\//i.test(url)) return true;
   if (url.startsWith(`${window.location.origin}/`)) return true;
   return /[?&]sig=/.test(url);

--- a/frontend/src/lib/normalize-style-config.ts
+++ b/frontend/src/lib/normalize-style-config.ts
@@ -94,6 +94,7 @@ const PAINT_FALLBACK_FIELDS: PaintFallbackField[] = [
   { paintKeys: ['_outline-color', 'outline-color'], builderKey: 'outlineColor', type: 'string' },
   { paintKeys: ['_outline-width', 'outline-width'], builderKey: 'outlineWidth', type: 'number' },
   { paintKeys: ['_height_column'], builderKey: 'heightColumn', type: 'string' },
+  { paintKeys: ['_heatmap-reversed'], builderKey: 'heatmapReversed', type: 'boolean' },
 ];
 
 function resolvePaintFallback(
@@ -354,6 +355,7 @@ export function normalizeLayerStyleState(
     if (typeof builder.sigma === 'number') cleanPaint._sigma = builder.sigma;
     if (typeof builder.hypso_enabled === 'boolean') cleanPaint['_hypso-enabled'] = builder.hypso_enabled;
     if (typeof builder.hypso_ramp === 'string') cleanPaint['_hypso-ramp'] = builder.hypso_ramp;
+    if (typeof builder.hypso_reversed === 'boolean') cleanPaint['_hypso-reversed'] = builder.hypso_reversed;
   }
   return { style_config, paint: cleanPaint };
 }

--- a/frontend/src/pages/DatasetPage.tsx
+++ b/frontend/src/pages/DatasetPage.tsx
@@ -223,6 +223,7 @@ export function DatasetPage() {
 
   const {
     isRasterOrVrt,
+    tracksHero,
     heroState,
     retryCount,
     mapKey,
@@ -533,7 +534,7 @@ export function DatasetPage() {
             isDrawing ? 'h-[60vh]' : 'h-72 lg:h-96'
           )}
         >
-          {isRasterOrVrt && heroState === 'loading' && (
+          {tracksHero && heroState === 'loading' && (
             <Skeleton data-testid="hero-skeleton" className="absolute inset-0 z-10 rounded-lg" />
           )}
           <MapErrorBoundary>
@@ -563,7 +564,7 @@ export function DatasetPage() {
                 rasterTileUrl={dataset.raster?.tile_url}
                 tileVersion={dataset.updated_at}
                 onFeatureClick={setReadOnlyFeatureGid}
-                {...(isRasterOrVrt ? {
+                {...(tracksHero ? {
                   onMapReady,
                   onTileError,
                 } : {})}
@@ -575,7 +576,7 @@ export function DatasetPage() {
               {t('raster.noTiles')}
             </div>
           )}
-          {isRasterOrVrt && heroState === 'error' && (
+          {tracksHero && heroState === 'error' && (
             <div className="absolute inset-0 flex flex-col items-center justify-center bg-background/80 rounded-lg z-10">
               <AlertTriangle className="size-8 text-destructive mb-2" />
               <p className="text-sm text-muted-foreground mb-3">{t('raster.previewUnavailable')}</p>

--- a/frontend/src/pages/MapBuilderPage.tsx
+++ b/frontend/src/pages/MapBuilderPage.tsx
@@ -2004,7 +2004,14 @@ export function MapBuilderPage() {
                   disabled={btn.disabled}
                   data-unavailable={btn.unavailable || undefined}
                   title={btn.label}
-                  aria-label={btn.label}
+                  // MAP-22 rework: notes-presence folds into the button's own
+                  // accessible name (aria-label replaces the subtree, so a
+                  // label on the dot span was never exposed).
+                  aria-label={
+                    btn.id === 'notes' && dockNotes.trim().length > 0
+                      ? t('rail.notesButtonWithNotes', { defaultValue: 'Notes (map has notes)' })
+                      : btn.label
+                  }
                   aria-pressed={railPanel === btn.id}
                   // fix(#760): mirrors BuilderRail's feat(#682) job signal.
                   aria-busy={btn.id === 'analysis' && analysisJobRunning}
@@ -2022,12 +2029,14 @@ export function MapBuilderPage() {
                   ) : (
                     <btn.icon className="h-4 w-4" aria-hidden="true" />
                   )}
-                  {/* MAP-22: presence dot on mobile Notes button — mirrors BuilderRail.tsx:105-110.
-                      BuilderRail is hidden at <800px (isEditorHidden); this dot keeps MAP-22
-                      parity at 414×896. */}
+                  {/* MAP-22: presence dot on mobile Notes button — mirrors the
+                      BuilderRail rail-button dot (search for MAP-22 there).
+                      BuilderRail is hidden at <800px (isEditorHidden); this dot keeps
+                      MAP-22 parity at 414×896. Decorative: the state is announced via
+                      the button's conditional aria-label above. */}
                   {btn.id === 'notes' && dockNotes.trim().length > 0 && (
                     <span
-                      aria-label={t('rail.notesPresent', { defaultValue: 'Map has notes' })}
+                      aria-hidden="true"
                       className="absolute -top-0.5 -end-0.5 size-1.5 rounded-full bg-primary"
                     />
                   )}

--- a/frontend/src/pages/MapBuilderPage.tsx
+++ b/frontend/src/pages/MapBuilderPage.tsx
@@ -662,20 +662,24 @@ export function MapBuilderPage() {
   // set. Skipped while a bulk delete is in flight: its optimistic removal
   // must not eat the preserved-on-failure selection (a full-failure rollback
   // restores the rows in the same commit that clears isDeleting).
+  // fix(v1.6.0 audit B7): also intersect with selectableRowIds — a row hidden
+  // by the layer search or a collapsed group must leave the selection, or the
+  // bulk bar keeps acting on rows the user can no longer see.
   useEffect(() => {
     if (layers.isDeleting) return;
     setSelectedIds((prev) => {
       if (prev.size === 0) return prev;
       const liveIds = new Set(layers.localLayers.map((layer) => layer.id));
+      const selectable = new Set(selectableRowIds);
       let changed = false;
       const next = new Set<string>();
       for (const rowId of prev) {
-        if (liveIds.has(rowId)) next.add(rowId);
+        if (liveIds.has(rowId) && selectable.has(rowId)) next.add(rowId);
         else changed = true;
       }
       return changed ? next : prev;
     });
-  }, [layers.localLayers, layers.isDeleting]);
+  }, [layers.localLayers, layers.isDeleting, selectableRowIds]);
 
   // Phase 1041 + SP-04 (Phase 1045): multi-selection handlers driven by the
   // `computeNextSelection` pure helper. Anchor lives in `lastToggleAnchor` ref
@@ -990,6 +994,101 @@ export function MapBuilderPage() {
     // eslint-disable-next-line react-hooks/exhaustive-deps -- stable handlers
     [layers.handleToggleExpand, handlePlainSelectAnchor],
   );
+
+  // fix(v1.6.0 audit D7): the UnifiedStackPanel props below were inline lambdas
+  // re-created on every MapBuilderPage render, so the React.memo chain
+  // (UnifiedStackPanel → SortableStackRow → StackRow) never skipped a row
+  // render. dispatchLayerAction and the other deps here are the stable
+  // useCallbacks from use-builder-layers — NOT the per-render `layers` literal.
+  const handleRowToggleVisibility = useCallback((layerId: string) => {
+    // P1-09: a folder group row is a synthetic row, not a map layer. Route its
+    // eye toggle to toggle_group_visibility so every child (and its
+    // companions) follows; loose/child rows use set_visibility.
+    // fix(v1.6.0 audit D7): group-ness is read through the hook's ref-backed
+    // isFolderGroupRow predicate — a localLayers.find() here would force this
+    // callback (and every row) to re-create on exactly the frames the
+    // memoization targets.
+    if (layers.isFolderGroupRow(layerId)) {
+      layers.dispatchLayerAction({
+        type: 'toggle_group_visibility',
+        source: 'manual',
+        groupId: layerId,
+      });
+    } else {
+      layers.dispatchLayerAction({
+        type: 'set_visibility',
+        source: 'manual',
+        layerId,
+      });
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- stable handlers
+  }, [layers.isFolderGroupRow, layers.dispatchLayerAction]);
+
+  const handleRowReorder = useCallback((reorderedLayers: MapLayerResponse[]) => {
+    layers.dispatchLayerAction({
+      type: 'reorder_layers',
+      source: 'manual',
+      layers: reorderedLayers,
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- stable handlers
+  }, [layers.dispatchLayerAction]);
+
+  const handleRowOpacityChange = useCallback((layerId: string, opacity: number) => {
+    layers.dispatchLayerAction({
+      type: 'set_opacity',
+      source: 'manual',
+      layerId,
+      opacity,
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- stable handlers
+  }, [layers.dispatchLayerAction]);
+
+  const handleRowRemove = useCallback((layerId: string) => {
+    layers.dispatchLayerAction({
+      type: 'remove_layer',
+      source: 'manual',
+      layerId,
+      persistence: 'server',
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- stable handlers
+  }, [layers.dispatchLayerAction]);
+
+  const handleRowDuplicate = useCallback((layerId: string) => {
+    layers.dispatchLayerAction({
+      type: 'duplicate_rendering',
+      source: 'manual',
+      layerId,
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- stable handlers
+  }, [layers.dispatchLayerAction]);
+
+  const handleRowKeyboardReorder = useCallback(
+    (layerId: string, direction: 'up' | 'down') =>
+      direction === 'up'
+        ? layers.handleMoveUp(layerId)
+        : layers.handleMoveDown(layerId),
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- stable handlers
+    [layers.handleMoveUp, layers.handleMoveDown],
+  );
+
+  const handlePanelAddDataset = useCallback((datasetId: string) => {
+    layers.handleAddDataset(datasetId, (newLayerId) => {
+      handleSelectLayer(newLayerId);
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- stable handlers
+  }, [layers.handleAddDataset, handleSelectLayer]);
+
+  // handleToggleExpand already toggles-on-same-id (prev === id → close), so the
+  // old `expandedLayerId === 'settings' ? '' : 'settings'` ternary was
+  // redundant AND made the lambda depend on expandedLayerId.
+  const handlePanelSettingsClick = useCallback(() => {
+    layers.handleToggleExpand('settings');
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- stable handlers
+  }, [layers.handleToggleExpand]);
+
+  const handleSwapBasemapClick = useCallback(() => {
+    handleSelectLayer('basemap-group');
+  }, [handleSelectLayer]);
 
   // Phase 1040: DnD handlers hoisted from UnifiedStackPanel — same behavior,
   // lifted to MapBuilderPage so BuilderDialogs (catalog modal) shares the context.
@@ -1699,73 +1798,29 @@ export function MapBuilderPage() {
               drawsNothingLayerIds={drawsNothingLayerIds}
               selectedLayerId={layers.expandedLayerId}
               onSelectLayer={handleSelectLayer}
-              onToggleVisibility={(layerId) => {
-                // P1-09: a folder group row is a synthetic row, not a map layer.
-                // Route its eye toggle to toggle_group_visibility so every child
-                // (and its companions) follows; loose/child rows use set_visibility.
-                const target = layers.localLayers.find((l) => l.id === layerId);
-                if (target && isFolderGroupLayer(target)) {
-                  layers.dispatchLayerAction({
-                    type: 'toggle_group_visibility',
-                    source: 'manual',
-                    groupId: layerId,
-                  });
-                } else {
-                  layers.dispatchLayerAction({
-                    type: 'set_visibility',
-                    source: 'manual',
-                    layerId,
-                  });
-                }
-              }}
-              onReorder={(reorderedLayers) => layers.dispatchLayerAction({
-                type: 'reorder_layers',
-                source: 'manual',
-                layers: reorderedLayers,
-              })}
-              onOpacityChange={(layerId, opacity) => layers.dispatchLayerAction({
-                type: 'set_opacity',
-                source: 'manual',
-                layerId,
-                opacity,
-              })}
-              onRemove={(layerId) => layers.dispatchLayerAction({
-                type: 'remove_layer',
-                source: 'manual',
-                layerId,
-                persistence: 'server',
-              })}
+              // fix(v1.6.0 audit D7): the row handlers here are memoized
+              // useCallbacks (defined next to handleSelectLayer) — the previous
+              // inline lambdas re-created every render and defeated the
+              // UnifiedStackPanel → StackRow memo chain.
+              onToggleVisibility={handleRowToggleVisibility}
+              onReorder={handleRowReorder}
+              onOpacityChange={handleRowOpacityChange}
+              onRemove={handleRowRemove}
               onRename={layers.handleDisplayNameChange}
-              onDuplicate={(layerId) => layers.dispatchLayerAction({
-                type: 'duplicate_rendering',
-                source: 'manual',
-                layerId,
-              })}
+              onDuplicate={handleRowDuplicate}
               onZoomToLayer={layers.handleZoomToLayer}
               onAnalyzeLayer={handleAnalyzeLayer}
               onCopyStyle={layers.handleCopyStyle}
               onPasteStyle={layers.handlePasteStyle}
               onBulkApplyStyle={handleBulkApplyStyle}
               copiedStyleGeometryClass={layers.copiedStyleGeometryClass}
-              onKeyboardReorder={(layerId, direction) =>
-                direction === 'up'
-                  ? layers.handleMoveUp(layerId)
-                  : layers.handleMoveDown(layerId)
-              }
+              onKeyboardReorder={handleRowKeyboardReorder}
               // fix(#759): the keyboard reorder mode shares the pointer
               // path's aria-live region instead of staying silent.
               onAnnounce={announce}
               onAddDataClick={handleAddDataClick}
-              onAddDataset={(datasetId: string) => {
-                layers.handleAddDataset(datasetId, (newLayerId) => {
-                  handleSelectLayer(newLayerId);
-                });
-              }}
-              onSettingsClick={() => {
-                layers.handleToggleExpand(
-                  layers.expandedLayerId === 'settings' ? '' : 'settings',
-                );
-              }}
+              onAddDataset={handlePanelAddDataset}
+              onSettingsClick={handlePanelSettingsClick}
               isSettingsOpen={editorScene === 'settings'}
               activeDragId={dragActiveId}
               groupMeta={layers.groupMeta}
@@ -1775,7 +1830,7 @@ export function MapBuilderPage() {
               onToggleSublayerVisibility={handleToggleSublayerVisibility}
               onSublayerOpacityChange={handleSublayerOpacityChange}
               onToggleBasemapVisibility={handleToggleBasemapVisibility}
-              onSwapBasemap={() => handleSelectLayer('basemap-group')}
+              onSwapBasemap={handleSwapBasemapClick}
               onResetBasemapAppearance={handleResetBasemapAppearance}
               onRenameGroup={layers.handleRenameGroup}
               onAddLayerToGroup={handleAddLayerToFolderGroup}
@@ -1802,6 +1857,7 @@ export function MapBuilderPage() {
               onBulkUngroup={handleBulkUngroup}
               onBulkDelete={handleBulkDelete}
               isDeleting={layers.isDeleting}
+              deletingCount={layers.deletingCount}
               freshLayerId={layers.freshLayerId}
               basemapPosition={basemapState.config.basemap_position ?? 'bottom'}
             />

--- a/frontend/src/pages/PublicMapViewerPage.tsx
+++ b/frontend/src/pages/PublicMapViewerPage.tsx
@@ -151,7 +151,10 @@ export function PublicMapViewerPage() {
   };
 
   return (
-    <main id="map-viewport" className="w-full flex-1 min-h-0 relative overflow-hidden">
+    // This page renders inside AppLayout's <main id="main-content">, so it must
+    // not be a second <main> landmark. The id stays: MapErrorBoundary and CSS
+    // target #map-viewport, and the skip link keeps targeting #main-content.
+    <div id="map-viewport" className="w-full flex-1 min-h-0 relative overflow-hidden">
       <MapErrorBoundary className="absolute inset-0">
         <Suspense fallback={<LoadingState message={t('viewer.loading')} />}>
           <ViewerMap
@@ -193,6 +196,6 @@ export function PublicMapViewerPage() {
       {id && (
         <ViewerChatPanel mapId={id} layers={data.layers} mapInstanceRef={mapInstanceRef} />
       )}
-    </main>
+    </div>
   );
 }

--- a/frontend/src/pages/__tests__/DatasetPage.hero.test.tsx
+++ b/frontend/src/pages/__tests__/DatasetPage.hero.test.tsx
@@ -304,11 +304,16 @@ describe('DatasetPage hero state machine', () => {
     expect(screen.getByTestId('dataset-map')).toBeInTheDocument();
   });
 
-  it('renders DatasetMap directly for vector datasets (no skeleton, no error overlay)', () => {
+  it('vector datasets use the hero state machine: skeleton until onMapReady', async () => {
+    mockMapConfig.autoFireMapReady = true;
     setup({ record_type: 'vector_dataset' });
     render(<DatasetPage />, { route: '/datasets/dataset-1' });
 
-    expect(screen.getByTestId('dataset-map')).toBeInTheDocument();
+    // Flush the lazy DatasetMap import so the mock mounts and auto-fires
+    // onMapReady; running the 10s timeout timer here would race it.
+    await act(async () => {});
+
+    expect(screen.getByTestId('dataset-map')).toHaveAttribute('data-has-on-map-ready', 'true');
     expect(screen.queryByTestId('hero-skeleton')).not.toBeInTheDocument();
     expect(screen.queryByText('Preview unavailable')).not.toBeInTheDocument();
   });

--- a/frontend/src/pages/__tests__/DatasetPage.hero.test.tsx
+++ b/frontend/src/pages/__tests__/DatasetPage.hero.test.tsx
@@ -344,13 +344,24 @@ describe('DatasetPage hero state machine', () => {
     expect(screen.getByText('Tiles may still be processing')).toBeInTheDocument();
   });
 
-  it('vector datasets do not pass onMapReady/onTileError to DatasetMap', () => {
+  it('vector datasets pass onMapReady/onTileError to DatasetMap', () => {
     setup({ record_type: 'vector_dataset' });
     render(<DatasetPage />, { route: '/datasets/dataset-1' });
 
     const map = screen.getByTestId('dataset-map');
-    expect(map).toHaveAttribute('data-has-on-map-ready', 'false');
-    expect(map).toHaveAttribute('data-has-on-tile-error', 'false');
+    expect(map).toHaveAttribute('data-has-on-map-ready', 'true');
+    expect(map).toHaveAttribute('data-has-on-tile-error', 'true');
+  });
+
+  it('table datasets do not pass onMapReady/onTileError to DatasetMap', () => {
+    setup({ record_type: 'table' });
+    render(<DatasetPage />, { route: '/datasets/dataset-1' });
+
+    const map = screen.queryByTestId('dataset-map');
+    if (map) {
+      expect(map).toHaveAttribute('data-has-on-map-ready', 'false');
+      expect(map).toHaveAttribute('data-has-on-tile-error', 'false');
+    }
   });
 });
 

--- a/frontend/src/pages/admin/AdminSharedMapsPage.tsx
+++ b/frontend/src/pages/admin/AdminSharedMapsPage.tsx
@@ -167,7 +167,7 @@ function EmbedTokensSubTable({ mapId }: { mapId: string }) {
             </AlertDialogHeader>
             <AlertDialogFooter>
               <AlertDialogCancel>{t('embedTokens.bulkRevokeCancel')}</AlertDialogCancel>
-              <AlertDialogAction onClick={handleBulkRevoke}>{t('embedTokens.bulkRevokeConfirm')}</AlertDialogAction>
+              <AlertDialogAction variant="destructive" onClick={handleBulkRevoke}>{t('embedTokens.bulkRevokeConfirm')}</AlertDialogAction>
             </AlertDialogFooter>
           </AlertDialogContent>
         </AlertDialog>
@@ -402,7 +402,7 @@ export function AdminSharedMapsPage() {
                                 </AlertDialogHeader>
                                 <AlertDialogFooter>
                                   <AlertDialogCancel>{t('shareTokens.revokeDialogCancel')}</AlertDialogCancel>
-                                  <AlertDialogAction onClick={() => token.id && handleRevoke(token.id)}>
+                                  <AlertDialogAction variant="destructive" onClick={() => token.id && handleRevoke(token.id)}>
                                     {t('shareTokens.revokeDialogConfirm')}
                                   </AlertDialogAction>
                                 </AlertDialogFooter>

--- a/frontend/src/stores/analysis-job-store.ts
+++ b/frontend/src/stores/analysis-job-store.ts
@@ -1,5 +1,6 @@
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
+import { useAuthStore } from '@/stores/auth-store';
 
 export interface TrackedAnalysisJob {
   jobId: string;
@@ -31,6 +32,18 @@ export const useAnalysisJobStore = create<AnalysisJobState>()(
     version: 1,
   }),
 );
+
+// The tracked job is persisted browser state — without this it survives a
+// logout and the next account on the same browser inherits the previous
+// user's run (its title included), whose status endpoint then 401/403s
+// forever until the sweep. Keyed on user identity, not token, mirroring
+// analysis-form-store's guard: routine refresh-token rotation must not drop
+// a job mid-run.
+useAuthStore.subscribe((s, prev) => {
+  if (s.user?.id !== prev.user?.id) {
+    useAnalysisJobStore.getState().setJob(null);
+  }
+});
 
 /**
  * Add-to-map handler registered by MapBuilderPage while it is mounted.

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -881,6 +881,8 @@ export interface BuilderStyleConfig {
   outlineColor?: string;
   outlineWidth?: number;
   heatmapRamp?: string;
+  /** Heatmap color-ramp direction. Builder-private; true renders the ramp reversed. */
+  heatmapReversed?: boolean;
   heatmapWeightColumn?: string;
   heightColumn?: string;
   /** Multiplier applied to numeric heightColumn values for fill extrusions. */
@@ -941,6 +943,8 @@ export interface BuilderStyleConfig {
   hypso_enabled?: boolean;
   /** DEM hypsometric color-ramp name. Builder-private; read back into paint['_hypso-ramp'] on load. */
   hypso_ramp?: string;
+  /** DEM hypsometric ramp direction. Builder-private; read back into paint['_hypso-reversed'] on load. */
+  hypso_reversed?: boolean;
   /** Virtual builder folder-group membership. Stored on real layers; folder rows are reconstructed client-side. */
   folderGroupId?: string;
   folderGroupName?: string;

--- a/scripts/backup-entrypoint.sh
+++ b/scripts/backup-entrypoint.sh
@@ -21,8 +21,11 @@ set -euo pipefail
 #   S3_ACCESS_KEY_ID       S3 access key
 #   S3_SECRET_ACCESS_KEY   S3 secret key
 #   S3_REGION              S3 region (default: us-east-1)
-#   S3_ALLOW_HTTP          Allow HTTP for S3 (default: false)
 #   S3_ADDRESSING_STYLE    S3 addressing style: auto, path, virtual (default: auto)
+#
+# The uploader (awscli) follows whatever scheme S3_ENDPOINT carries — use an
+# http:// endpoint for plain-HTTP MinIO. There is no separate allow-http knob
+# here; S3_ALLOW_HTTP only affects the app's own object-storage client.
 # ==============================================================================
 
 BACKUP_DIR="/backups"
@@ -41,13 +44,31 @@ BACKUP_RETENTION_DAILY="${BACKUP_RETENTION_DAILY:-7}"
 BACKUP_RETENTION_WEEKLY="${BACKUP_RETENTION_WEEKLY:-4}"
 BACKUP_S3_ENABLED="${BACKUP_S3_ENABLED:-false}"
 S3_REGION="${S3_REGION:-us-east-1}"
-S3_ALLOW_HTTP="${S3_ALLOW_HTTP:-false}"
 
 mkdir -p "$DAILY_DIR" "$WEEKLY_DIR"
 
 log() {
     echo "[$(date '+%Y-%m-%d %H:%M:%S')] $*"
 }
+
+# Retention must be a positive integer: prune keeps only the newest N files,
+# so a retention of 0 would delete the dump this very cycle just produced and
+# then mark the cycle successful — a backup service that retains nothing.
+# Checked on every invocation (startup and cron --run-backup re-entry).
+for _ret_var in BACKUP_RETENTION_DAILY BACKUP_RETENTION_WEEKLY; do
+    eval "_ret_val=\$$_ret_var"
+    case "$_ret_val" in
+        ''|*[!0-9]*)
+            log "ERROR: ${_ret_var}='${_ret_val}' is not a plain integer"
+            exit 1
+            ;;
+    esac
+    if [ "$_ret_val" -lt 1 ]; then
+        log "ERROR: ${_ret_var}='${_ret_val}' must be >= 1 — a retention of 0 would delete each backup as soon as it is written"
+        exit 1
+    fi
+done
+unset _ret_var _ret_val
 
 # ---------------------------------------------------------------------------
 # pg_dump
@@ -61,14 +82,19 @@ run_backup() {
     log "Starting backup: ${filename}"
 
     export PGPASSWORD="${POSTGRES_PASSWORD}"
+    # Dump to a .tmp name and rename only on success: if pg_dump is killed
+    # mid-write (prod mem_limit OOM, container stop, disk full) a truncated
+    # file under the final name would sit in the retention window looking like
+    # a complete backup. The rename makes a *.dump file appear only atomically.
     if pg_dump -h "$POSTGRES_HOST" -U "$POSTGRES_USER" -d "$POSTGRES_DB" \
-        -Fc --no-owner --no-acl -f "$filepath"; then
+        -Fc --no-owner --no-acl -f "${filepath}.tmp"; then
+        mv "${filepath}.tmp" "$filepath"
         local size
         size="$(du -h "$filepath" | cut -f1)"
         log "Backup complete: ${filename} (${size})"
     else
         log "ERROR: pg_dump failed"
-        rm -f "$filepath"
+        rm -f "${filepath}.tmp"
         return 1
     fi
 
@@ -209,9 +235,13 @@ upload_to_s3() {
     local filepath="$1"
     local s3_key="$2"
 
+    # BACKUP_S3_ENABLED=true is a promise of an offsite copy; missing bucket
+    # or credentials mean that promise cannot be kept, so fail the cycle
+    # (keeping .last-success stale and the healthcheck honest) instead of
+    # skipping quietly and reporting success.
     if [ -z "${S3_BUCKET:-}" ] || [ -z "${S3_ACCESS_KEY_ID:-}" ] || [ -z "${S3_SECRET_ACCESS_KEY:-}" ]; then
-        log "WARNING: S3 upload enabled but credentials missing — skipping"
-        return 0
+        log "ERROR: BACKUP_S3_ENABLED=true but S3_BUCKET / S3_ACCESS_KEY_ID / S3_SECRET_ACCESS_KEY are not all set — offsite upload impossible"
+        return 1
     fi
 
     # Pass credentials via environment — not on argv (prevents secret leakage
@@ -383,10 +413,16 @@ sched_min="$(echo "$CRON_EXPR" | awk '{print $1}')"
 sched_hour="$(echo "$CRON_EXPR" | awk '{print $2}')"
 
 while true; do
-    sleep 60
+    # Sleep to just past the next minute boundary rather than a fixed 60s: a
+    # fixed sleep drifts by the loop's own per-iteration cost and can
+    # eventually skip the scheduled minute entirely.
+    sleep $((61 - 10#$(date '+%S')))
     current_hour="$(date '+%-H')"
     current_min="$(date '+%-M')"
-    if [ "$current_hour" = "$sched_hour" ] && [ "$current_min" = "$sched_min" ]; then
+    # Compare numerically in base 10 on both sides: a schedule written with a
+    # zero-padded minute (e.g. "05 2 * * *") passes validation but would never
+    # string-match date's unpadded "5".
+    if [ "$((10#$current_hour))" -eq "$((10#$sched_hour))" ] && [ "$((10#$current_min))" -eq "$((10#$sched_min))" ]; then
         run_backup || log "ERROR: Scheduled backup failed"
         sleep 60  # Avoid double-trigger within the same minute
     fi

--- a/scripts/backup-entrypoint.sh
+++ b/scripts/backup-entrypoint.sh
@@ -99,13 +99,18 @@ run_backup() {
 
     # BKP-01: archive the object-storage staging volume alongside the dump.
     # Named with the SAME timestamp as the dump so restore can pair them.
+    # A tar failure marks the cycle failed (like the S3 path below) rather than
+    # returning early: retention pruning further down must always run, and the
+    # `|| cycle_failed=1` also keeps `set -e` from aborting on the non-zero
+    # command substitution. The cycle then exits non-zero and `.last-success`
+    # is never touched, so the healthcheck sees the missed staging archive.
+    local cycle_failed=0
     local staging_archive=""
-    staging_archive="$(backup_staging "$timestamp")"
+    staging_archive="$(backup_staging "$timestamp")" || cycle_failed=1
 
     # S3 upload — record any failure but DON'T return yet. The local dump (and
     # the staging archive, if any) already landed on disk; retention pruning
     # below must still run so a transient S3 outage can't let them accumulate.
-    local cycle_failed=0
     if [ "$BACKUP_S3_ENABLED" = "true" ]; then
         local upload_failed=0
         upload_to_s3 "$filepath" "daily/${filename}" || upload_failed=1
@@ -169,8 +174,11 @@ backup_staging() {
         return 0
     fi
 
+    # tar's own stderr is left attached so its diagnostic (e.g. "file changed
+    # as we read it" when api/worker write temp files mid-archive) reaches the
+    # container log instead of vanishing.
     log "Archiving object storage: $(basename "$archive")" >&2
-    if tar czf "$archive" -C "$STAGING_DIR" . 2>/dev/null; then
+    if tar czf "$archive" -C "$STAGING_DIR" .; then
         local size
         size="$(du -h "$archive" | cut -f1)"
         log "Object-storage archive complete: $(basename "$archive") (${size})" >&2
@@ -180,8 +188,9 @@ backup_staging() {
         fi
         printf '%s\n' "$archive"
     else
-        log "WARNING: object-storage archive failed — staging backup skipped" >&2
+        log "ERROR: object-storage archive failed — this cycle will be reported as failed" >&2
         rm -f "$archive"
+        return 1
     fi
 }
 

--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -3,8 +3,11 @@
 # operator script). NOT sourced by scripts/install.sh: install.sh is a
 # self-contained single file streamed over `curl ... | sh` and byte-synced to the
 # getgeolens.com mirror, so it deliberately inlines its own copies of these
-# helpers. Keep the COMPOSE wrapper / wait_for_healthy / update_env_value logic
-# here in lockstep with install.sh's inlined versions.
+# helpers. Keep the COMPOSE wrapper / update_env_value logic here in lockstep
+# with install.sh's inlined versions. wait_for_healthy deliberately diverges:
+# install.sh's copy budgets 300s and returns a non-fatal rc=2 on timeout (first
+# boot under QEMU emulation), while this copy keeps a 90s budget for the
+# upgrade path where images and volumes already exist locally.
 #
 # This file has NO side effects on source: it only defines functions and the few
 # constants below. The caller sets COMPOSE_FILE before invoking compose().
@@ -113,7 +116,15 @@ semver_compare() {
 
 # Wait up to 90s for the stack to become healthy. The migrate one-shot must exit
 # 0; every healthcheck-having service must report (healthy). Surfaces the failing
-# service with a log tail on timeout/failure. Mirrors install.sh :158.
+# service with a log tail on timeout/failure. Diverges from install.sh's inlined
+# copy (300s budget, non-fatal rc=2 timeout) — see the header note above.
+#
+# Services still in `(health: starting)` when the budget runs out are treated
+# as converging, not failed: they sit inside their own declared start_period
+# (e.g. the backup service allows 10m for its first pg_dump of a large DB,
+# far beyond this 90s budget), so Docker has not judged them yet — and neither
+# should we. Only a service that is (unhealthy), restarting, or exited
+# non-zero fails the wait.
 wait_for_healthy() {
   attempts=18
   sleep_s=5
@@ -149,6 +160,25 @@ wait_for_healthy() {
     sleep "$sleep_s"
   done
 
+  # Budget spent — classify what is left. `(health: starting)` means the
+  # service is within its declared start_period and Docker has not ruled on it;
+  # failing the upgrade here would tell the operator to roll back a stack that
+  # is converging fine (a pre-existing install whose first backup pg_dump
+  # outlasts 90s hit exactly that). Warn and succeed when ONLY such services
+  # remain; anything (unhealthy)/restarting/exited-nonzero is a real failure.
+  remaining=$(compose ps --format '{{.Service}}|{{.Status}}' 2>/dev/null | grep -v '|.*(healthy)' | grep -v '|Exited (0)' | grep -v '^$' || true)
+  if [ -z "$remaining" ]; then
+    printf '\n'
+    return 0
+  fi
+  broken=$(printf '%s\n' "$remaining" | grep -v '(health: starting)' || true)
+  if [ -z "$broken" ]; then
+    printf '\n'
+    warn "these services are still starting after $((attempts * sleep_s))s but remain within their declared start_period:"
+    printf '%s\n' "$remaining" | sed 's/^/  /' >&2
+    warn "Docker will flag them (unhealthy) if they fail to converge; check later with: docker compose ps"
+    return 0
+  fi
   printf '\n' >&2
   warn "timed out after $((attempts * sleep_s))s waiting for services. Current status:"
   compose ps 2>&1 | sed 's/^/  /' >&2

--- a/scripts/restore.sh
+++ b/scripts/restore.sh
@@ -57,8 +57,11 @@ POSTGRES_USER="${POSTGRES_USER:-geolens}"
 POSTGRES_DB="${POSTGRES_DB:-geolens}"
 echo "Running pre-restore setup..."
 
+# ON_ERROR_STOP: this DDL is the last gate before --clean drops the live
+# database — a silently failed CREATE EXTENSION/SCHEMA here must abort the
+# restore, not surface later as a half-restored DB (init-db.sh sets it too).
 "${COMPOSE[@]}" exec -T db \
-    psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" <<EOSQL
+    psql -v ON_ERROR_STOP=1 -U "$POSTGRES_USER" -d "$POSTGRES_DB" <<EOSQL
 -- Extensions
 CREATE EXTENSION IF NOT EXISTS postgis;
 CREATE EXTENSION IF NOT EXISTS pg_trgm;
@@ -190,14 +193,22 @@ _dump_base="$(basename "$BACKUP_FILE")"
 # dump name is <db>_<YYYYmmdd_HHMMSS>.dump → extract the timestamp if present.
 _ts="$(printf '%s' "$_dump_base" | grep -oE '[0-9]{8}_[0-9]{6}' | head -n1 || true)"
 _staging_archive=""
+_staging_match="exact"
 if [ -n "$_ts" ] && [ -f "${_dump_dir}/staging-${_ts}.tar.gz" ]; then
     _staging_archive="${_dump_dir}/staging-${_ts}.tar.gz"
 elif ls "${_dump_dir}"/staging-*.tar.gz >/dev/null 2>&1; then
     _staging_archive="$(ls -t "${_dump_dir}"/staging-*.tar.gz 2>/dev/null | head -n1)"
+    _staging_match="fallback"
 fi
 if [ -n "$_staging_archive" ]; then
     echo ""
-    echo "NOTE: a matching object-storage archive was found:"
+    if [ "$_staging_match" = "fallback" ]; then
+        echo "WARNING: no object-storage archive matches this dump's timestamp (${_ts:-unrecognized})."
+        echo "         The NEWEST archive in the directory is listed below, but it was taken"
+        echo "         in a DIFFERENT backup cycle and may not pair with this dump:"
+    else
+        echo "NOTE: a matching object-storage archive was found:"
+    fi
     echo "        ${_staging_archive}"
     echo "      The database is restored, but staged source objects are NOT"
     echo "      auto-extracted. To restore them into the upload_staging volume, run"

--- a/scripts/restore.sh
+++ b/scripts/restore.sh
@@ -69,18 +69,6 @@ CREATE EXTENSION IF NOT EXISTS vector;
 CREATE SCHEMA IF NOT EXISTS catalog;
 CREATE SCHEMA IF NOT EXISTS data;
 
--- Read-only role for data schema access
-DO \$\$
-BEGIN
-    IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'geolens_reader') THEN
-        CREATE ROLE geolens_reader NOLOGIN;
-    END IF;
-END
-\$\$;
-GRANT USAGE ON SCHEMA data TO geolens_reader;
-GRANT SELECT ON ALL TABLES IN SCHEMA data TO geolens_reader;
-ALTER DEFAULT PRIVILEGES IN SCHEMA data GRANT SELECT ON TABLES TO geolens_reader;
-
 EOSQL
 
 echo "Stopping API to prevent write conflicts during restore..."
@@ -142,6 +130,41 @@ if [ "$RESTORE_RC" -ne 0 ]; then
     fi
 fi
 rm -f "$RESTORE_STDERR"
+
+# Re-apply geolens_reader grants AFTER pg_restore, not before: --clean drops
+# schema `data` (taking its ACLs and default privileges with it) and the dump
+# is -Fc --no-owner --no-acl, so nothing inside it re-grants. Granting before
+# the restore only decorated a schema that was about to be dropped, and the
+# reader role silently lost SELECT on every restored table.
+echo ""
+echo "Re-applying geolens_reader grants..."
+"${COMPOSE[@]}" exec -T db \
+    psql -v ON_ERROR_STOP=1 -U "$POSTGRES_USER" -d "$POSTGRES_DB" <<EOSQL
+DO \$\$
+BEGIN
+    IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'geolens_reader') THEN
+        CREATE ROLE geolens_reader NOLOGIN;
+    END IF;
+END
+\$\$;
+GRANT USAGE ON SCHEMA data TO geolens_reader;
+GRANT SELECT ON ALL TABLES IN SCHEMA data TO geolens_reader;
+ALTER DEFAULT PRIVILEGES IN SCHEMA data GRANT SELECT ON TABLES TO geolens_reader;
+EOSQL
+
+# Assert the grant actually took — a restore that leaves the reader role
+# without schema access breaks every read-only consumer until someone
+# notices, so fail loudly here instead.
+READER_USAGE="$("${COMPOSE[@]}" exec -T db \
+    psql -v ON_ERROR_STOP=1 -U "$POSTGRES_USER" -d "$POSTGRES_DB" -tAc \
+    "SELECT has_schema_privilege('geolens_reader', 'data', 'USAGE');" | tr -d '[:space:]')"
+if [ "$READER_USAGE" != "t" ]; then
+    echo "ERROR: geolens_reader has no USAGE on schema data after restore." >&2
+    echo "Re-run the grant block above manually and re-check with:" >&2
+    echo "  SELECT has_schema_privilege('geolens_reader', 'data', 'USAGE');" >&2
+    exit 1
+fi
+echo "geolens_reader grants verified."
 
 # Post-restore validation
 echo ""


### PR DESCRIPTION
Fixes every confirmed finding from the v1.6.0 pre-tag audit (two QA passes, static + live browser verification) ahead of cutting the tag.

## Release blockers
- **False "Upgrade FAILED" on upgrade to 1.6.0**: the new backup healthcheck keys on a `.last-success` marker that no pre-1.6.0 install has, and `wait_for_healthy`'s 90s budget counted `(health: starting)` as unhealthy. Services still inside their declared `start_period` are now treated as converging (warn + succeed if only those remain; genuinely unhealthy still fails).
- **Restore dropped every `geolens_reader` grant**: the grant block ran before `pg_restore --clean` dropped the schema. It now runs after, asserts `has_schema_privilege`, and the CI round-trip seeds a `data`-schema table and verifies reader access post-restore. RUNBOOK prose corrected.

## Backup/restore & CI
- Tar failure in staging backup no longer reports a successful cycle (`cycle_failed`, diagnostics unsuppressed); retention `>= 1` validated at boot; zero-padded cron minutes match; blank S3 creds fail loudly; dumps write temp-then-rename; restore fallback warns honestly; `ON_ERROR_STOP` on restore DDL; dead `S3_ALLOW_HTTP` knob removed.
- New `CI OK` aggregator job that inspects `needs.*.result` (skips pass, failures fail — no rubber-stamping); path-filter gaps closed (backend drift-test inputs, `core/config.py`, `examples/**`, `Makefile` + flatten script, `ci.yml` itself, `docker-compose.yml`, root `package.json`/lockfile); setup-node pin comments corrected; `prod-smoke` no longer cancels in-progress runs (release gating); dispatch input hoisted to env; semver-shaped tag guard in release.yml; `npm install -g npm@latest` removed from the OIDC publish job.

## Builder & maps
- Layer rows fully keyboard-operable (eyes, carets, rename incl. spaces and Enter-commit, inline delete confirms), with focus restore and user-event regression tests.
- Bulk delete announces the real in-flight count, its confirm has modal semantics + exit focus, selection prunes with visibility, partial-failure rollback preserves concurrent edits, group/ungroup toast on success, and dissolving a named group asks first.
- Raster tile 401/403s are no longer misclassified as handled; unrecoverable tile auth failures surface the existing error UI on the dataset preview and viewer; vector previews get loading/error states; basemap vector→raster switch no longer stacks the old style; the basemap-issue banner clears after recovery; feature popups open from the keyboard.
- Max-zoom clears no longer write 0; the last opacity movement is flushed on unmount; Reset confirms and clears zoom clamps on all geometry branches; the Reverse ramp option is wired end-to-end (including the backend builder-key alias maps and color-relief export parity).

## Analysis
- Escape mid-clip-draw cancels the draw instead of closing the panel; buffer unit conversion can no longer exceed the cap in the converted unit; Enter submits Preview; disabled Create explains itself; both "Add to map" affordances are single-use; the recorded collision warning is finally rendered; failure toasts carry an action; the persisted job store clears on identity change.
- Jobs stamp `completed_at` on all three terminal paths; the fence-miss cleanup probes (tenant-scoped) whether the output table was adopted before leaking it; timeout and size-cap messages name the limit and give operation-appropriate advice.

## a11y & i18n
- MapGL `aria-label` wrapper on all four naked map sites; live regions always mounted; unnamed asides/sliders/rename inputs named; nested `<main>` fixed (skip link intact); missing destructive variants and confirms added; hardcoded type literals translated.
- All new keys in en/es/fr/de; `readyTitle_one` uses `{{count}}` everywhere (French resolves `_one` at count 0); `map.featureId` translated in all four locales.

## Impacts
- No API schema changes (`openapi.json` untouched). New builder style keys `heatmap_reversed`/`hypso_reversed` round-trip through the existing `style_config.builder` canonicalization.
- `docker-compose*.yml`: backup service env cleanup only (`S3_ALLOW_HTTP` removed).
- Branch protection follow-up (settings, not in this PR): require the new `CI OK` context in place of the 7 skippable required contexts.

## Verification
- `cd frontend && npm run lint && npm run typecheck && npm run test:i18n && npx vitest run` — 3959 tests green
- Backend targeted: `uv run pytest tests/test_analysis_materialize.py tests/test_analysis_preview.py tests/test_maps_style_json.py tests/test_builder_alias_keys_drift.py tests/test_legacy_builder_paint_keys_drift.py tests/test_fe_sdk_type_drift.py tests/test_layering.py` — green; `ruff check` / `ruff format --check` clean
- `bash -n` on all touched scripts; workflow YAML parses; `scripts/tests/test-upgrading-doc-consistency.sh` 15/15