### PR TITLE
fix: pre-tag follow-up batch for 1.6.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,10 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  # Include the event name so daily dependabot pushes stop cancelling the
+  # scheduled run — every nightly for a week was cancelled this way, which is
+  # how the e2e suite silently rotted (v1.6.0 audit N2 family).
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
   cancel-in-progress: true
 
 # Least-privilege default for every job; no job needs write (publishing lives

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,11 +61,10 @@ and releases use semantic versioning.
   before committing, and leaving public warns that existing share links
   will stop working. Changes that don't cross that boundary keep their
   one-click behavior. (#778)
-- **Admin AI status surfaces respect multi-tenant permissions** — they
-  now gate on the same mode-aware capability the backend checks
-  (`manage_tenants` in multi-tenant, `manage_users` otherwise), so fleet
-  operators see the AI status card and user-managers no longer fire
-  requests the backend rejects. (#653)
+- **Admin AI status surfaces gate on the same capability the backend
+  checks**, so operators who can read AI status always see the card, and
+  users without that capability no longer fire requests the backend
+  rejects. (#653)
 - **Feature popups open from the keyboard in the shared-map viewer**,
   matching the builder.
 - **A cancelled or fenced-off analysis job cleans up its orphan output

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,25 @@ and releases use semantic versioning.
 
 ### Changed
 
+- **Crossing the public boundary on a shared map now asks first.** Making
+  a map public shows which layers will stay hidden from the audience
+  before committing, and leaving public warns that existing share links
+  will stop working. Changes that don't cross that boundary keep their
+  one-click behavior. (#778)
+- **Admin AI status surfaces respect multi-tenant permissions** — they
+  now gate on the same mode-aware capability the backend checks
+  (`manage_tenants` in multi-tenant, `manage_users` otherwise), so fleet
+  operators see the AI status card and user-managers no longer fire
+  requests the backend rejects. (#653)
+- **Feature popups open from the keyboard in the shared-map viewer**,
+  matching the builder.
+- **A cancelled or fenced-off analysis job cleans up its orphan output
+  table** when no dataset adopted it — and never drops a table another
+  actor did adopt.
+- **The nightly CI run no longer gets cancelled by daily dependency
+  merges**, and the runbook now states plainly that default local
+  backups share the database host's disk, pointing at the offsite
+  upload section. (#798)
 - **The backup container reports unhealthy when backups stop
   succeeding**, not just when its loop dies — operators see a red
   container instead of discovering stale backups during a restore.

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -73,6 +73,13 @@ Default retention: 7 daily, 4 weekly (set `BACKUP_RETENTION_DAILY` /
 
 ### Offsite (S3) upload
 
+> **Warning — single-disk exposure.** By default the `backup_data` volume lives
+> on the same host (and usually the same disk) as the database volume. Losing
+> that disk loses the data **and every backup of it** in one event. Treat the
+> local dumps as a convenience tier only: enable the S3 offsite upload below,
+> or point `backup_data` at a different physical disk, before relying on this
+> for disaster recovery.
+
 Offsite upload is **opt-in**. To enable it, set in `.env`:
 
 ```

--- a/backend/app/processing/analysis/tasks.py
+++ b/backend/app/processing/analysis/tasks.py
@@ -133,8 +133,9 @@ async def _fail_cancelled_job(
     still 'running', so the final registration commit (which atomically
     persists the dataset and flips the row to 'complete') has not happened,
     and any committed output table is an unregistered orphan — safe to drop.
-    If the fence misses, the job already reached a terminal state and the
-    table must be left alone.
+    If the fence misses, the job already reached a terminal state; the table
+    is dropped only when the adoption probe proves no dataset registered it
+    (fix(v1.6.0 audit B13)).
     """
     from app.core.db import async_session
 
@@ -166,6 +167,27 @@ async def _fail_cancelled_job(
             },
         ):
             await session.rollback()
+            # fix(v1.6.0 audit B13): mirror _mark_job_failed's fence-miss
+            # cleanup — a swept row leaves an unregistered orphan that used
+            # to leak permanently here. Probe for an adopting dataset row;
+            # no row means the DROP is safe. If the probe itself errors,
+            # prefer leaking the table to dropping a registered dataset's
+            # storage.
+            if out_table is not None:
+                adopted = True
+                try:
+                    adopted = await _output_table_adopted(session, out_table)
+                except Exception:  # broad: prefer leak over loss
+                    logger.warning("analysis.adoption_probe_failed", job_id=job_id)
+                    await session.rollback()
+                if not adopted:
+                    try:
+                        await session.execute(
+                            text(f'DROP TABLE IF EXISTS "{schema}"."{out_table}"')
+                        )
+                        await session.commit()
+                    except Exception:  # broad: best-effort cleanup of the orphan
+                        await session.rollback()
             return
         await session.commit()
         if out_table is not None:
@@ -298,14 +320,24 @@ async def _complete_job_for_attempt(
     await session.rollback()
     logger.warning("analysis.complete_write_superseded", job_id=job_id)
     # The build commit made the output table durable, and the rollback above
-    # discarded its only registration. Only this worker registers or
-    # completes the job (retry=0), so the table is a provable orphan — drop
-    # it instead of leaking it.
+    # discarded this attempt's registration. fix(v1.6.0 audit B13): mirror
+    # _mark_job_failed's fence-miss cleanup — gate the drop on the adoption
+    # probe so a dataset row committed by any other actor keeps its storage,
+    # and prefer leaking the table over dropping one the probe can't clear.
+    adopted = True
     try:
-        await session.execute(text(f'DROP TABLE IF EXISTS "{schema}"."{out_table}"'))
-        await session.commit()
-    except Exception:  # broad: best-effort cleanup of the orphaned output
+        adopted = await _output_table_adopted(session, out_table)
+    except Exception:  # broad: prefer leak over loss
+        logger.warning("analysis.adoption_probe_failed", job_id=job_id)
         await session.rollback()
+    if not adopted:
+        try:
+            await session.execute(
+                text(f'DROP TABLE IF EXISTS "{schema}"."{out_table}"')
+            )
+            await session.commit()
+        except Exception:  # broad: best-effort cleanup of the orphaned output
+            await session.rollback()
 
 
 async def _output_table_adopted(session: AsyncSession, out_table: str) -> bool:

--- a/backend/tests/test_analysis_materialize.py
+++ b/backend/tests/test_analysis_materialize.py
@@ -21,6 +21,7 @@ from app.modules.catalog.datasets.api import router_analysis
 from app.platform.jobs.models import IngestJob
 from app.processing.analysis.tasks import (
     MATERIALIZE_TIMEOUT,
+    _complete_job_for_attempt,
     _enforce_output_size,
     _fail_cancelled_job,
     _mark_job_failed,
@@ -1007,6 +1008,138 @@ class TestMaterializeWorker:
 
         await test_db_session.refresh(job)
         assert job.status == "complete"
+        left = (
+            await test_db_session.execute(
+                text("SELECT to_regclass(:ref)").bindparams(ref=f"data.{table_name}")
+            )
+        ).scalar_one()
+        assert left is not None
+
+    async def test_fence_missed_cancel_drops_unadopted_table(
+        self,
+        test_db_session: AsyncSession,
+    ):
+        """fix(v1.6.0 audit B13): the cancel path's fence-miss branch used to
+        skip cleanup entirely — a sweep that failed the row before the
+        cancel bookkeeping ran left the committed output table leaking
+        forever. It now runs the same adoption probe as _mark_job_failed and
+        drops the table when no dataset row adopted it."""
+        admin_id = await get_user_id(test_db_session, "admin")
+        table_name = f"orphan_{uuid.uuid4().hex[:12]}"
+        await test_db_session.execute(
+            text(f"CREATE TABLE data.{table_name} (gid SERIAL PRIMARY KEY)")
+        )
+        await test_db_session.commit()
+        job = await _create_job(test_db_session, admin_id)
+        job.status = "failed"
+        job.error_message = "Stale: heartbeat lease expired"
+        await test_db_session.commit()
+        assert job.attempt_id is not None
+
+        async with core_db.async_session() as working_session:
+            await _fail_cancelled_job(
+                working_session,
+                job_id=str(job.id),
+                attempt_id=job.attempt_id,
+                schema="data",
+                out_table=table_name,
+                operation="centroid",
+            )
+
+        await test_db_session.refresh(job)
+        # The sweep's terminal state and message survive the fence miss...
+        assert job.status == "failed"
+        assert job.error_message == "Stale: heartbeat lease expired"
+        # ...and the unadopted table was dropped, not leaked.
+        left = (
+            await test_db_session.execute(
+                text("SELECT to_regclass(:ref)").bindparams(ref=f"data.{table_name}")
+            )
+        ).scalar_one()
+        assert left is None
+
+    async def test_fence_missed_cancel_keeps_adopted_table(
+        self,
+        test_db_session: AsyncSession,
+    ):
+        """fix(v1.6.0 audit B13): the leak-over-loss side of the cancel
+        path's new probe — when the row went terminal via a real completion
+        (dataset row adopted the table), the fence-missed cancel must leave
+        the live dataset's storage alone."""
+        admin_id = await get_user_id(test_db_session, "admin")
+        table_name = f"ds_{uuid.uuid4().hex[:12]}"
+        await test_db_session.execute(
+            text(f"CREATE TABLE data.{table_name} (gid SERIAL PRIMARY KEY)")
+        )
+        await test_db_session.commit()
+        await create_dataset(
+            test_db_session,
+            created_by=admin_id,
+            table_name=table_name,
+        )
+        job = await _create_job(test_db_session, admin_id)
+        job.status = "complete"
+        await test_db_session.commit()
+        assert job.attempt_id is not None
+
+        async with core_db.async_session() as working_session:
+            await _fail_cancelled_job(
+                working_session,
+                job_id=str(job.id),
+                attempt_id=job.attempt_id,
+                schema="data",
+                out_table=table_name,
+                operation="centroid",
+            )
+
+        await test_db_session.refresh(job)
+        assert job.status == "complete"
+        left = (
+            await test_db_session.execute(
+                text("SELECT to_regclass(:ref)").bindparams(ref=f"data.{table_name}")
+            )
+        ).scalar_one()
+        assert left is not None
+
+    async def test_fence_missed_completion_keeps_adopted_table(
+        self,
+        test_db_session: AsyncSession,
+    ):
+        """fix(v1.6.0 audit B13): the complete path's fence-miss branch used
+        to drop the output table unconditionally. It is now gated on the
+        same adoption probe — a dataset row committed by another actor for
+        this table name keeps its storage."""
+        admin_id = await get_user_id(test_db_session, "admin")
+        table_name = f"ds_{uuid.uuid4().hex[:12]}"
+        await test_db_session.execute(
+            text(f"CREATE TABLE data.{table_name} (gid SERIAL PRIMARY KEY)")
+        )
+        await test_db_session.commit()
+        adopting = await create_dataset(
+            test_db_session,
+            created_by=admin_id,
+            table_name=table_name,
+        )
+        job = await _create_job(test_db_session, admin_id)
+        job.status = "failed"
+        job.error_message = "Stale: heartbeat lease expired"
+        await test_db_session.commit()
+        assert job.attempt_id is not None
+
+        async with core_db.async_session() as session:
+            await _complete_job_for_attempt(
+                session,
+                job_id=str(job.id),
+                attempt_id=job.attempt_id,
+                dataset_id=adopting.id,
+                schema="data",
+                out_table=table_name,
+                operation="centroid",
+            )
+
+        await test_db_session.refresh(job)
+        assert job.status == "failed"
+        assert job.error_message == "Stale: heartbeat lease expired"
         left = (
             await test_db_session.execute(
                 text("SELECT to_regclass(:ref)").bindparams(ref=f"data.{table_name}")

--- a/frontend/src/components/admin/AIStatusCard.tsx
+++ b/frontend/src/components/admin/AIStatusCard.tsx
@@ -3,6 +3,7 @@ import { Link } from 'react-router';
 import { Bot, ArrowRight } from 'lucide-react';
 import { useAIStatus, useEmbeddingStats } from '@/hooks/use-admin';
 import { usePermissions } from '@/hooks/use-permissions';
+import { useAIStatusReader } from '@/hooks/use-ai-status-reader';
 import { semanticBadgeColors } from '@/lib/status-colors';
 import {
   Card,
@@ -15,12 +16,22 @@ import { Badge } from '@/components/ui/badge';
 export function AIStatusCard() {
   const { t } = useTranslation('admin');
   const { can } = usePermissions();
+  // fix(#653): /admin/ai-status is gated by require_ai_status_reader, which
+  // switches from manage_users to manage_tenants in multi-tenant mode — a
+  // manage_users-only gate hid the card from multi-tenant operators and fired
+  // queries the backend 403s.
+  const canReadAIStatus = useAIStatusReader();
   const canManageUsers = can('manage_users');
   const canManageSettings = can('manage_settings');
-  const { data: aiStatus, isLoading } = useAIStatus({ enabled: canManageUsers });
-  const { data: embeddingStats } = useEmbeddingStats({ enabled: canManageUsers });
+  const { data: aiStatus, isLoading } = useAIStatus({ enabled: canReadAIStatus });
+  // fix(#653): /admin/embedding-stats requires manage_users in BOTH tenancy
+  // modes, so it keeps its own gate; the card gate alone would 403 for a
+  // manage_tenants-only operator.
+  const { data: embeddingStats } = useEmbeddingStats({
+    enabled: canReadAIStatus && canManageUsers,
+  });
 
-  if (!canManageUsers || isLoading || !aiStatus) return null;
+  if (!canReadAIStatus || isLoading || !aiStatus) return null;
 
   return (
     <Card>

--- a/frontend/src/components/admin/__tests__/AIStatusCard.capabilities.test.tsx
+++ b/frontend/src/components/admin/__tests__/AIStatusCard.capabilities.test.tsx
@@ -3,6 +3,7 @@ import { AIStatusCard } from '@/components/admin/AIStatusCard';
 
 const mocks = vi.hoisted(() => ({
   capabilities: new Set<string>(),
+  isMultiTenant: false,
   useAIStatus: vi.fn(),
   useEmbeddingStats: vi.fn(),
 }));
@@ -10,6 +11,18 @@ const mocks = vi.hoisted(() => ({
 vi.mock('@/hooks/use-permissions', () => ({
   usePermissions: () => ({
     can: (capability: string) => mocks.capabilities.has(capability),
+  }),
+}));
+
+// fix(#653): the card gate goes through useAIStatusReader, which composes
+// usePermissions with useEdition — mock the edition side too.
+vi.mock('@/hooks/use-edition', () => ({
+  useEdition: () => ({
+    edition: 'community',
+    features: [],
+    isEnterprise: false,
+    isMultiTenant: mocks.isMultiTenant,
+    isLoading: false,
   }),
 }));
 
@@ -23,6 +36,7 @@ describe('AIStatusCard capability gates', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mocks.capabilities = new Set(['manage_users']);
+    mocks.isMultiTenant = false;
     mocks.useAIStatus.mockReturnValue({
       data: {
         configured: true,
@@ -52,5 +66,42 @@ describe('AIStatusCard capability gates', () => {
     expect(mocks.useAIStatus).toHaveBeenCalledWith({ enabled: false });
     expect(mocks.useEmbeddingStats).toHaveBeenCalledWith({ enabled: false });
     expect(screen.queryByText('AI Status')).not.toBeInTheDocument();
+  });
+
+  // fix(#653): /admin/ai-status is gated by require_ai_status_reader — the
+  // capability flips from manage_users to manage_tenants in multi-tenant mode.
+  it('multi-tenant: manage_users alone hides the card and fires no queries', () => {
+    mocks.isMultiTenant = true;
+    mocks.capabilities = new Set(['manage_users']);
+
+    render(<AIStatusCard />);
+
+    expect(mocks.useAIStatus).toHaveBeenCalledWith({ enabled: false });
+    expect(mocks.useEmbeddingStats).toHaveBeenCalledWith({ enabled: false });
+    expect(screen.queryByText('AI Status')).not.toBeInTheDocument();
+  });
+
+  it('multi-tenant: manage_tenants without manage_users shows the card', () => {
+    mocks.isMultiTenant = true;
+    mocks.capabilities = new Set(['manage_tenants']);
+
+    render(<AIStatusCard />);
+
+    expect(mocks.useAIStatus).toHaveBeenCalledWith({ enabled: true });
+    // fix(#653): /admin/embedding-stats stays manage_users in both modes —
+    // a manage_tenants-only operator would 403, so the query stays disabled.
+    expect(mocks.useEmbeddingStats).toHaveBeenCalledWith({ enabled: false });
+    expect(screen.getByText('AI Status')).toBeInTheDocument();
+  });
+
+  it('multi-tenant: manage_tenants plus manage_users also loads coverage', () => {
+    mocks.isMultiTenant = true;
+    mocks.capabilities = new Set(['manage_tenants', 'manage_users']);
+
+    render(<AIStatusCard />);
+
+    expect(mocks.useAIStatus).toHaveBeenCalledWith({ enabled: true });
+    expect(mocks.useEmbeddingStats).toHaveBeenCalledWith({ enabled: true });
+    expect(screen.getByText('AI Status')).toBeInTheDocument();
   });
 });

--- a/frontend/src/components/admin/settings/SettingsAITab.tsx
+++ b/frontend/src/components/admin/settings/SettingsAITab.tsx
@@ -16,7 +16,7 @@ import { useSettingsForm } from './useSettingsForm';
 import { useApiKeyStatus } from '@/hooks/use-settings';
 import { useEmbeddingStats, useBackfillEmbeddings, useUpdateSemanticSearch } from '@/hooks/use-admin';
 import { usePermissions } from '@/hooks/use-permissions';
-import { useEdition } from '@/hooks/use-edition';
+import { useAIStatusReader } from '@/hooks/use-ai-status-reader';
 import { detectEmbeddingDims } from '@/api/settings';
 import type { SettingItem } from '@/api/settings';
 import { probeAIStatus } from '@/api/admin';
@@ -47,13 +47,14 @@ export function SettingsAITab({ settings, envOnly, onSave, onReset, isSaving, on
   const { t } = useTranslation('admin');
   const { can } = usePermissions();
   const canManageUsers = can('manage_users');
-  const { isMultiTenant } = useEdition();
-  // fix(#652): mirror the backend's require_ai_status_reader, which switches
-  // from manage_users to manage_tenants in multi-tenant deployments.
-  const canProbe = isMultiTenant ? can('manage_tenants') : canManageUsers;
+  // fix(#653): the #652 inline gate moved into the shared useAIStatusReader
+  // hook so ai-status surfaces can't drift from require_ai_status_reader again.
+  const canProbe = useAIStatusReader();
   const { data: keyStatus } = useApiKeyStatus();
-  // Coverage/backfill are manage_users operations. A settings-only operator
-  // can configure embeddings without issuing forbidden operational probes.
+  // Coverage/backfill are manage_users operations in BOTH tenancy modes
+  // (see /admin/embedding-stats + /admin/backfill-embeddings) — deliberately
+  // NOT useAIStatusReader (#653). A settings-only operator can configure
+  // embeddings without issuing forbidden operational probes.
   const { data: embeddingStatsData } = useEmbeddingStats({ enabled: canManageUsers });
   const embeddingStats = canManageUsers ? embeddingStatsData : undefined;
   const backfill = useBackfillEmbeddings();

--- a/frontend/src/components/admin/settings/__tests__/SettingsAITab.test.tsx
+++ b/frontend/src/components/admin/settings/__tests__/SettingsAITab.test.tsx
@@ -179,6 +179,8 @@ describe('SettingsAITab — Test Connection probe (#635)', () => {
 
   // fix(#652): require_ai_status_reader switches to manage_tenants in
   // multi-tenant mode — the button gate must switch with it.
+  // fix(#653): the gate now flows through the shared useAIStatusReader hook;
+  // these tests exercise the real hook via the mocked permission/edition hooks.
   it('multi-tenant: manage_users alone does NOT show the button', () => {
     hoisted.isMultiTenant = true;
     hoisted.canManageUsers = true;
@@ -193,6 +195,19 @@ describe('SettingsAITab — Test Connection probe (#635)', () => {
     hoisted.canManageTenants = true;
     renderTab();
     expect(screen.getByRole('button', { name: /Test Connection/ })).toBeInTheDocument();
+  });
+
+  // fix(#653): /admin/embedding-stats + /admin/backfill-embeddings require
+  // manage_users in BOTH tenancy modes — unlike the ai-status reader gate,
+  // the coverage block must NOT unlock for a manage_tenants-only operator.
+  it('multi-tenant: manage_tenants alone keeps embedding coverage disabled', () => {
+    hoisted.isMultiTenant = true;
+    hoisted.canManageUsers = false;
+    hoisted.canManageTenants = true;
+    renderTab();
+    expect(hoisted.useEmbeddingStats).toHaveBeenCalledWith({ enabled: false });
+    expect(screen.queryByText('Embedding Coverage')).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Generate Missing' })).not.toBeInTheDocument();
   });
 
   // fix(#652): the probe tests PERSISTED settings — a dirty form must not

--- a/frontend/src/components/builder/BulkActionBar.tsx
+++ b/frontend/src/components/builder/BulkActionBar.tsx
@@ -247,7 +247,7 @@ export const BulkActionBar = memo(function BulkActionBar({
         // ------------------------------------------------------------------
         // Confirmation state
         // ------------------------------------------------------------------
-        // eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-noninteractive-element-interactions
+        // eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions
         <div
           ref={confirmRef}
           role="alertdialog"

--- a/frontend/src/components/builder/SharePanel.tsx
+++ b/frontend/src/components/builder/SharePanel.tsx
@@ -914,6 +914,44 @@ export function ShareDialog({
   const isPublic = visibility === 'public';
   const canUseAdvancedSharing = isEnterprise;
 
+  // fix(#778): visibility change awaiting user confirmation. Non-null only while
+  // the confirm AlertDialog is open; the radio's checked state stays on the
+  // current `visibility` prop until the mutation actually succeeds, so
+  // cancelling leaves the old selection intact.
+  const [pendingVisibility, setPendingVisibility] = useState<MapVisibility | null>(null);
+
+  // fix(#778): layers hidden from the audience of the visibility being confirmed
+  // (not the current one — before a private→public change the current-visibility
+  // list is always empty). Same predicate as the post-change warning below.
+  const pendingAudienceHiddenLayers = useMemo(
+    () =>
+      pendingVisibility
+        ? layers
+            .filter((layer) => isLayerHiddenFromMapAudience(layer, pendingVisibility))
+            .map((layer) => layer.display_name ?? layer.dataset_name)
+        : [],
+    [layers, pendingVisibility],
+  );
+
+  function handleVisibilitySelect(newVisibility: MapVisibility) {
+    if (newVisibility === visibility) return;
+    // fix(#778): transitions that cross the public boundary need explicit
+    // confirmation — going public exposes the map to anyone with a link, and
+    // leaving public kills existing share links (clearSharedState below).
+    // Private↔internal keeps the original one-click behavior.
+    if (newVisibility === 'public' || visibility === 'public') {
+      setPendingVisibility(newVisibility);
+      return;
+    }
+    void handleVisibilityChange(newVisibility);
+  }
+
+  async function handleConfirmVisibilityChange() {
+    const next = pendingVisibility;
+    setPendingVisibility(null);
+    if (next) await handleVisibilityChange(next);
+  }
+
   async function handleVisibilityChange(newVisibility: MapVisibility) {
     if (newVisibility === visibility) return;
     try {
@@ -1072,7 +1110,7 @@ export function ShareDialog({
                         ? 'ring-2 ring-ring border-primary bg-primary/5'
                         : 'border-border hover:border-muted-foreground/30 hover:bg-accent/50',
                     )}
-                    onClick={() => handleVisibilityChange(opt.value)}
+                    onClick={() => handleVisibilitySelect(opt.value)}
                     disabled={publishMap.isPending}
                   >
                     <Icon className={cn('h-4 w-4 mt-0.5 shrink-0', opt.iconClass)} />
@@ -1088,6 +1126,66 @@ export function ShareDialog({
               <p className="text-xs text-muted-foreground mt-2">{t('share.makePublicHint', { defaultValue: 'Make this map public to generate a share link' })}</p>
             )}
           </div>
+
+          {/* fix(#778): crossing the public boundary is confirmed before the
+              mutation runs — going public was previously one un-confirmed click,
+              and leaving public silently killed existing share links. Same
+              AlertDialog structure as the revoke confirm above; only the
+              leave-public action is destructive-styled (it breaks live links). */}
+          <AlertDialog
+            open={pendingVisibility !== null}
+            onOpenChange={(dialogOpen) => {
+              if (!dialogOpen) setPendingVisibility(null);
+            }}
+          >
+            <AlertDialogContent>
+              {pendingVisibility === 'public' ? (
+                <>
+                  <AlertDialogHeader>
+                    <AlertDialogTitle>{t('share.makePublicConfirmTitle')}</AlertDialogTitle>
+                    <AlertDialogDescription>
+                      {t('share.makePublicConfirmDescription')}
+                    </AlertDialogDescription>
+                  </AlertDialogHeader>
+                  {pendingAudienceHiddenLayers.length > 0 && (
+                    <div
+                      data-testid="share-confirm-audience-hidden-warning"
+                      className="flex items-start gap-2 rounded-md border border-warning/30 bg-warning/5 px-3 py-2 text-xs text-foreground"
+                    >
+                      <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0 text-warning" aria-hidden="true" />
+                      <p>
+                        {t('share.audienceHiddenWarning', {
+                          count: pendingAudienceHiddenLayers.length,
+                          layers: pendingAudienceHiddenLayers.join(', '),
+                        })}
+                      </p>
+                    </div>
+                  )}
+                  <AlertDialogFooter>
+                    <AlertDialogCancel>{t('share.visibilityConfirmCancel')}</AlertDialogCancel>
+                    <AlertDialogAction onClick={handleConfirmVisibilityChange}>
+                      {t('share.makePublicConfirmAction')}
+                    </AlertDialogAction>
+                  </AlertDialogFooter>
+                </>
+              ) : (
+                <>
+                  <AlertDialogHeader>
+                    <AlertDialogTitle>{t('share.leavePublicConfirmTitle')}</AlertDialogTitle>
+                    <AlertDialogDescription>
+                      {t('share.leavePublicConfirmDescription')}
+                    </AlertDialogDescription>
+                  </AlertDialogHeader>
+                  <AlertDialogFooter>
+                    <AlertDialogCancel>{t('share.visibilityConfirmCancel')}</AlertDialogCancel>
+                    <AlertDialogAction variant="destructive" onClick={handleConfirmVisibilityChange}>
+                      {t('share.leavePublicConfirmAction')}
+                    </AlertDialogAction>
+                  </AlertDialogFooter>
+                </>
+              )}
+            </AlertDialogContent>
+          </AlertDialog>
 
           {publishMap.isPending && (
             <div className="flex items-center gap-2 text-xs text-muted-foreground">

--- a/frontend/src/components/builder/__tests__/SharePanel.test.tsx
+++ b/frontend/src/components/builder/__tests__/SharePanel.test.tsx
@@ -84,6 +84,9 @@ function setup({
   updateShareTokenFn = vi.fn().mockResolvedValue({}),
   shareExpires = null,
   createEmbedTokenFn,
+  visibility = 'public',
+  layers,
+  publishMapFn = vi.fn().mockResolvedValue({}),
 }: {
   enterprise?: boolean;
   hasShareToken?: boolean;
@@ -98,6 +101,10 @@ function setup({
   shareExpires?: string | null;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   createEmbedTokenFn?: (...args: any[]) => any;
+  visibility?: ComponentProps<typeof ShareDialog>['visibility'];
+  layers?: ComponentProps<typeof ShareDialog>['layers'];
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  publishMapFn?: (...args: any[]) => any;
 } = {}) {
   const createShareToken = vi.fn().mockResolvedValue({
     token: 'share-token',
@@ -120,7 +127,8 @@ function setup({
     isMultiTenant: false,
     isLoading: false,
   });
-  mockedUsePublishMap.mockReturnValue(mutationResult());
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  mockedUsePublishMap.mockReturnValue(mutationResult(publishMapFn as any));
   mockedUseCreateShareToken.mockReturnValue(mutationResult(createShareToken));
   mockedUseRevokeShareToken.mockReturnValue(mutationResult());
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -172,15 +180,16 @@ function setup({
   render(
     <ShareDialog
       mapId="map-1"
-      visibility="public"
+      visibility={visibility}
       open
       onOpenChange={vi.fn()}
       hasUnsavedChanges={hasUnsavedChanges}
       saveStatus={saveStatus}
+      layers={layers}
     />,
   );
 
-  return { createShareToken, createEmbedToken: createEmbedToken as ReturnType<typeof vi.fn>, updateEmbedTokenFn, updateShareTokenFn };
+  return { createShareToken, createEmbedToken: createEmbedToken as ReturnType<typeof vi.fn>, updateEmbedTokenFn, updateShareTokenFn, publishMapFn };
 }
 
 describe('ShareDialog edition gates', () => {
@@ -1001,5 +1010,109 @@ describe('P2-01 explicit create-embed-token for public-only embeds', () => {
     await waitFor(() => {
       expect(createEmbedToken).toHaveBeenCalledWith({ mapId: 'map-1' });
     });
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/*  fix(#778): confirm visibility changes that cross the public        */
+/*  boundary before mutating                                           */
+/* ------------------------------------------------------------------ */
+
+describe('fix(#778) public-boundary visibility confirmation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const privateLayer = {
+    id: 'layer-1',
+    dataset_id: 'ds-1',
+    dataset_name: 'Secret parcels',
+    display_name: null,
+    dataset_visibility: 'private',
+    dataset_status: 'published',
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } as any;
+
+  it('private→public opens the confirm dialog and only mutates on confirm', async () => {
+    const user = userEvent.setup();
+    const { publishMapFn } = setup({
+      visibility: 'private',
+      hasShareToken: false,
+      layers: [privateLayer],
+    });
+
+    await user.click(screen.getByRole('radio', { name: /anyone with the link/i }));
+
+    // Dialog is open, nothing has mutated yet.
+    const dialog = await screen.findByRole('alertdialog');
+    expect(publishMapFn).not.toHaveBeenCalled();
+    // The audience-hidden layer list is surfaced inside the dialog body,
+    // computed against the TARGET (public) visibility.
+    expect(screen.getByTestId('share-confirm-audience-hidden-warning')).toHaveTextContent(
+      'Secret parcels',
+    );
+    expect(dialog).toHaveTextContent(/make this map public\?/i);
+
+    await user.click(screen.getByRole('button', { name: /^make public$/i }));
+
+    await waitFor(() => {
+      expect(publishMapFn).toHaveBeenCalledOnce();
+    });
+    expect(publishMapFn).toHaveBeenCalledWith({ id: 'map-1', visibility: 'public' });
+  });
+
+  it('cancelling the private→public confirm fires no mutation and keeps the old selection', async () => {
+    const user = userEvent.setup();
+    const { publishMapFn } = setup({ visibility: 'private', hasShareToken: false });
+
+    await user.click(screen.getByRole('radio', { name: /anyone with the link/i }));
+    await screen.findByRole('alertdialog');
+
+    await user.click(screen.getByRole('button', { name: /^cancel$/i }));
+
+    await waitFor(() => {
+      expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument();
+    });
+    expect(publishMapFn).not.toHaveBeenCalled();
+    // Checked state never flipped — the map is still private.
+    expect(screen.getByRole('radio', { name: /only you/i })).toHaveAttribute(
+      'aria-checked',
+      'true',
+    );
+    expect(screen.getByRole('radio', { name: /anyone with the link/i })).toHaveAttribute(
+      'aria-checked',
+      'false',
+    );
+  });
+
+  it('leaving public warns that existing share links stop working, with a destructive confirm', async () => {
+    const user = userEvent.setup();
+    const { publishMapFn } = setup({ visibility: 'public' });
+
+    await user.click(screen.getByRole('radio', { name: /only you/i }));
+
+    const dialog = await screen.findByRole('alertdialog');
+    expect(publishMapFn).not.toHaveBeenCalled();
+    expect(dialog).toHaveTextContent(/share links and embed codes will stop working/i);
+
+    await user.click(screen.getByRole('button', { name: /stop public sharing/i }));
+
+    await waitFor(() => {
+      expect(publishMapFn).toHaveBeenCalledOnce();
+    });
+    expect(publishMapFn).toHaveBeenCalledWith({ id: 'map-1', visibility: 'private' });
+  });
+
+  it('a non-boundary change (private→internal) mutates immediately without a dialog', async () => {
+    const user = userEvent.setup();
+    const { publishMapFn } = setup({ visibility: 'private', hasShareToken: false });
+
+    await user.click(screen.getByRole('radio', { name: /all team members/i }));
+
+    await waitFor(() => {
+      expect(publishMapFn).toHaveBeenCalledOnce();
+    });
+    expect(publishMapFn).toHaveBeenCalledWith({ id: 'map-1', visibility: 'internal' });
+    expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/components/viewer/ViewerMap.tsx
+++ b/frontend/src/components/viewer/ViewerMap.tsx
@@ -653,19 +653,9 @@ export const ViewerMap = memo(function ViewerMap({
       return null;
     };
 
-    const handleClick = (e: MapMouseEvent) => {
-      const hits = queryInteractiveFeatures(map, e.point);
-      if (hits === null) {
-        setPopupInfo(null);
-        return;
-      }
-
-      const clusterHit = findClusterHit(hits);
-      if (clusterHit) {
-        handleClusterHit(clusterHit.feature, clusterHit.hit, e.lngLat);
-        return;
-      }
-
+    // Shared by mouse click and the keyboard handler below so keyboard users
+    // get the same non-cluster feature popups as mouse users.
+    const mapFeatureHits = (hits: ReturnType<MaplibreMap['queryRenderedFeatures']>): FeatureInfo[] => {
       const mapped: FeatureInfo[] = [];
       for (const feature of hits) {
         const hit = lookupHitLayer(feature.layer.id);
@@ -682,6 +672,23 @@ export const ViewerMap = memo(function ViewerMap({
           zoomAtClick: map.getZoom(),
         });
       }
+      return mapped;
+    };
+
+    const handleClick = (e: MapMouseEvent) => {
+      const hits = queryInteractiveFeatures(map, e.point);
+      if (hits === null) {
+        setPopupInfo(null);
+        return;
+      }
+
+      const clusterHit = findClusterHit(hits);
+      if (clusterHit) {
+        handleClusterHit(clusterHit.feature, clusterHit.hit, e.lngLat);
+        return;
+      }
+
+      const mapped = mapFeatureHits(hits);
 
       if (mapped.length > 0) {
         setPopupInfo({
@@ -710,9 +717,24 @@ export const ViewerMap = memo(function ViewerMap({
       const hits = queryInteractiveFeatures(map, point);
       if (hits === null) return;
       const clusterHit = findClusterHit(hits);
-      if (!clusterHit) return;
+      if (clusterHit) {
+        event.preventDefault();
+        handleClusterHit(clusterHit.feature, clusterHit.hit, null);
+        return;
+      }
+      // Keyboard parity with BuilderMap: the popup was mouse-only for
+      // non-cluster features — Enter/Space was a no-op unless the
+      // centre-of-canvas hit happened to be a cluster. Mirror handleClick's
+      // mapping so keyboard users can open the same feature popup.
+      const mapped = mapFeatureHits(hits);
+      if (mapped.length === 0) return;
       event.preventDefault();
-      handleClusterHit(clusterHit.feature, clusterHit.hit, null);
+      const lngLat = map.unproject(point);
+      setPopupInfo({
+        longitude: lngLat.lng,
+        latitude: lngLat.lat,
+        features: mapped,
+      });
     };
 
     let canvasForKeyboard: HTMLCanvasElement | null = null;

--- a/frontend/src/hooks/use-ai-status-reader.ts
+++ b/frontend/src/hooks/use-ai-status-reader.ts
@@ -1,0 +1,18 @@
+import { usePermissions } from '@/hooks/use-permissions';
+import { useEdition } from '@/hooks/use-edition';
+
+// fix(#653): mirror the backend's require_ai_status_reader
+// (backend/app/modules/admin/router.py), which gates /admin/ai-status on
+// manage_users in single-tenant deployments but manage_tenants in
+// multi-tenant. Every frontend surface that reads AI status must gate on
+// this hook so the pattern can't drift per-component again (it was first
+// inlined for #652, then missed twice).
+//
+// Scope note: this covers /admin/ai-status ONLY. /admin/embedding-stats and
+// /admin/backfill-embeddings require manage_users in BOTH modes — do not
+// swap their gates to this hook.
+export function useAIStatusReader(): boolean {
+  const { can } = usePermissions();
+  const { isMultiTenant } = useEdition();
+  return isMultiTenant ? can('manage_tenants') : can('manage_users');
+}

--- a/frontend/src/i18n/locales/de/builder.json
+++ b/frontend/src/i18n/locales/de/builder.json
@@ -685,7 +685,14 @@
     "revokeConfirmTitle": "Freigabelink widerrufen?",
     "revokeConfirmDescription": "Der Link funktioniert sofort nicht mehr und alle Einbettungs-Tokens dieser Karte werden ungültig. Das kann nicht rückgängig gemacht werden.",
     "revokeConfirmCancel": "Abbrechen",
-    "revokeConfirmAction": "Link widerrufen"
+    "revokeConfirmAction": "Link widerrufen",
+    "visibilityConfirmCancel": "Abbrechen",
+    "makePublicConfirmTitle": "Diese Karte öffentlich machen?",
+    "makePublicConfirmDescription": "Jeder mit dem Link kann diese Karte ansehen.",
+    "makePublicConfirmAction": "Öffentlich machen",
+    "leavePublicConfirmTitle": "Öffentliche Freigabe beenden?",
+    "leavePublicConfirmDescription": "Bestehende Freigabelinks und Einbettungscodes funktionieren sofort nicht mehr.",
+    "leavePublicConfirmAction": "Öffentliche Freigabe beenden"
   },
   "chat": {
     "emptyState": "Beschreiben Sie Änderungen an Ihrer Karte in natürlicher Sprache.",

--- a/frontend/src/i18n/locales/en/builder.json
+++ b/frontend/src/i18n/locales/en/builder.json
@@ -685,7 +685,14 @@
     "revokeConfirmTitle": "Revoke share link?",
     "revokeConfirmDescription": "The link will stop working immediately and any embed tokens for this map will be invalidated. This cannot be undone.",
     "revokeConfirmCancel": "Cancel",
-    "revokeConfirmAction": "Revoke link"
+    "revokeConfirmAction": "Revoke link",
+    "visibilityConfirmCancel": "Cancel",
+    "makePublicConfirmTitle": "Make this map public?",
+    "makePublicConfirmDescription": "Anyone with the link will be able to view this map.",
+    "makePublicConfirmAction": "Make public",
+    "leavePublicConfirmTitle": "Stop sharing publicly?",
+    "leavePublicConfirmDescription": "Existing share links and embed codes will stop working immediately.",
+    "leavePublicConfirmAction": "Stop public sharing"
   },
   "chat": {
     "emptyState": "Describe changes to your map using natural language.",

--- a/frontend/src/i18n/locales/es/builder.json
+++ b/frontend/src/i18n/locales/es/builder.json
@@ -685,7 +685,14 @@
     "revokeConfirmTitle": "¿Revocar el enlace compartido?",
     "revokeConfirmDescription": "El enlace dejará de funcionar de inmediato y se invalidarán los tokens de inserción de este mapa. No se puede deshacer.",
     "revokeConfirmCancel": "Cancelar",
-    "revokeConfirmAction": "Revocar enlace"
+    "revokeConfirmAction": "Revocar enlace",
+    "visibilityConfirmCancel": "Cancelar",
+    "makePublicConfirmTitle": "¿Hacer público este mapa?",
+    "makePublicConfirmDescription": "Cualquier persona con el enlace podrá ver este mapa.",
+    "makePublicConfirmAction": "Hacer público",
+    "leavePublicConfirmTitle": "¿Dejar de compartir públicamente?",
+    "leavePublicConfirmDescription": "Los enlaces para compartir y los códigos de inserción existentes dejarán de funcionar de inmediato.",
+    "leavePublicConfirmAction": "Dejar de compartir públicamente"
   },
   "chat": {
     "emptyState": "Describa cambios en su mapa usando lenguaje natural.",

--- a/frontend/src/i18n/locales/fr/builder.json
+++ b/frontend/src/i18n/locales/fr/builder.json
@@ -685,7 +685,14 @@
     "revokeConfirmTitle": "Révoquer le lien de partage ?",
     "revokeConfirmDescription": "Le lien cessera de fonctionner immédiatement et les jetons d’intégration de cette carte seront invalidés. Cette action est irréversible.",
     "revokeConfirmCancel": "Annuler",
-    "revokeConfirmAction": "Révoquer le lien"
+    "revokeConfirmAction": "Révoquer le lien",
+    "visibilityConfirmCancel": "Annuler",
+    "makePublicConfirmTitle": "Rendre cette carte publique ?",
+    "makePublicConfirmDescription": "Toute personne disposant du lien pourra voir cette carte.",
+    "makePublicConfirmAction": "Rendre publique",
+    "leavePublicConfirmTitle": "Arrêter le partage public ?",
+    "leavePublicConfirmDescription": "Les liens de partage et les codes d'intégration existants cesseront de fonctionner immédiatement.",
+    "leavePublicConfirmAction": "Arrêter le partage public"
   },
   "chat": {
     "emptyState": "Décrivez les modifications à apporter à votre carte en langage naturel.",


### PR DESCRIPTION
Small pull-forward batch folded into 1.6.0 before tagging.

Closes #778 — crossing the public boundary in the Share panel now confirms first: making a map public previews the audience-hidden layer list (computed against the target visibility, which the old post-hoc warning could not do), and leaving public warns that existing share links stop resolving. Non-boundary changes keep one-click behavior.

Closes #653 — the AI status card and settings probe gate on the same mode-aware capability the backend checks (new shared `useAIStatusReader()`; the #652 site refactored onto it). Scope correction found during the fix: `/admin/embedding-stats` and backfill require plain `manage_users` in both tenancy modes, so that block correctly keeps its existing gate — switching it as the issue suggested would have introduced new 403s.

Also:
- The scheduled CI run no longer shares a concurrency group with pushes — every nightly for the past week was cancelled by daily dependency merges, which is how the e2e suite rotted unseen (same family as the audit's N2).
- RUNBOOK: explicit single-disk warning — default local backups share the database host's disk; points at the offsite S3 section (partial #798; the off-host default remains open).
- Viewer feature popups open from the keyboard, matching the builder's recent fix.
- The analysis cancel path and the complete path's fence-miss now run the same adoption probe as the fail path before dropping an orphan output table — the complete path previously dropped unconditionally, which could destroy a table another actor had adopted. Three new regression tests.

Not included: #697 (antimeridian buffer) — a live probe confirmed the corruption but showed the invalid geometry, not the extent, is the root cause; the honest fix is M-sized (normalized MULTIPOLYGON output). Evidence and scoped design posted on the issue.

## Verification
- `cd frontend && npm run lint && npm run typecheck && npm run test:i18n` — clean
- `npx vitest run` SharePanel / AIStatusCard / SettingsAITab / BulkActionBar — 95 passed
- `uv run pytest tests/test_analysis_materialize.py` — 58 passed
- Workflow YAML parses; RUNBOOK doc-consistency 15/15