### PR TITLE
fix(admin): gate the AI availability probe on the mode-aware status capability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,7 +69,10 @@ and releases use semantic versioning.
   users who can read AI status get the detailed signal, everyone else
   with chat access uses the public one — previously the split keyed on
   the admin flag, which could probe an endpoint the backend rejects and
-  skip users it would allow. (#815)
+  skip users it would allow. Probes now also wait for the deployment
+  mode to be known instead of guessing. The disabled-state Settings
+  shortcut shows only for users who can open admin settings, and lands
+  on the AI tab instead of General. (#815)
 - **Feature popups open from the keyboard in the shared-map viewer**,
   matching the builder.
 - **A cancelled or fenced-off analysis job cleans up its orphan output

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,11 @@ and releases use semantic versioning.
   checks**, so operators who can read AI status always see the card, and
   users without that capability no longer fire requests the backend
   rejects. (#653)
+- **The builder chat availability probe follows that same capability**:
+  users who can read AI status get the detailed signal, everyone else
+  with chat access uses the public one — previously the split keyed on
+  the admin flag, which could probe an endpoint the backend rejects and
+  skip users it would allow. (#815)
 - **Feature popups open from the keyboard in the shared-map viewer**,
   matching the builder.
 - **A cancelled or fenced-off analysis job cleans up its orphan output

--- a/frontend/src/components/builder/BuilderRail.tsx
+++ b/frontend/src/components/builder/BuilderRail.tsx
@@ -13,7 +13,7 @@ import type { EphemeralAnalysisHandoff } from '@/components/builder/hooks/use-ep
 import type { ViewportContext } from '@/components/builder/chat-suggestions';
 import { HistoryPanel } from '@/components/builder/HistoryPanel';
 import { useAIAvailability } from '@/hooks/use-ai-availability';
-import { useAuthStore } from '@/stores/auth-store';
+import { usePermissions } from '@/hooks/use-permissions';
 import { Textarea } from '@/components/ui/textarea';
 
 const ChatPanel = lazy(() => import('@/components/builder/ChatPanel').then(m => ({ default: m.ChatPanel })));
@@ -21,7 +21,8 @@ const AnalysisPanel = lazy(() => import('@/components/builder/AnalysisPanel').th
 
 /**
  * Structured disabled-state for the AI rail panel.
- * Renders per-reason copy + admin-only Settings CTA per UI-SPEC Surface 3 (Phase 1135 AI-02).
+ * Renders per-reason copy per UI-SPEC Surface 3 (Phase 1135 AI-02), plus a
+ * Settings CTA for users the admin-settings route will actually admit.
  *
  * Consumes useAIAvailability() internally — TanStack Query deduplicates so there is no
  * extra network call vs. the parent's derivation; the hook just reads the cached result.
@@ -29,7 +30,10 @@ const AnalysisPanel = lazy(() => import('@/components/builder/AnalysisPanel').th
 function AIDisabledState() {
   const { t } = useTranslation('builder');
   const { reason, isLoading } = useAIAvailability();
-  const isAdmin = useAuthStore((s) => s.isAdmin());
+  // fix(#816): the CTA targets /admin/settings/ai, which AdminCapabilityRoute
+  // gates on manage_settings — show it only to users the route will admit
+  // (the old isAdmin flag no longer matches who sees detailed reasons).
+  const { can } = usePermissions();
 
   // fix(#788 follow-up): one persistent live region whose CONTENT toggles —
   // the loading spinner and the disabled-state message used to be two
@@ -57,7 +61,7 @@ function AIDisabledState() {
   const ctaDefault = reason === 'env_disabled' ? 'Go to Settings'
     : reason === 'no_key' ? 'Configure in Settings'
     : '';
-  const showCTA = ctaKey !== null && isAdmin;
+  const showCTA = ctaKey !== null && can('manage_settings');
 
   return (
     <div
@@ -75,7 +79,9 @@ function AIDisabledState() {
           <p className="text-sm text-muted-foreground text-center max-w-[18rem]">{t(bodyKey, { defaultValue: bodyDefault })}</p>
           {showCTA && (
             <Button variant="outline" size="sm" asChild>
-              <Link to="/admin/settings?tab=ai">{t(ctaKey!, { defaultValue: ctaDefault })}</Link>
+              {/* fix(#816): the ?tab=ai form redirected to the General tab —
+                  the settings route is /admin/settings/:tab */}
+              <Link to="/admin/settings/ai">{t(ctaKey!, { defaultValue: ctaDefault })}</Link>
             </Button>
           )}
         </>

--- a/frontend/src/components/builder/__tests__/BuilderRail.test.tsx
+++ b/frontend/src/components/builder/__tests__/BuilderRail.test.tsx
@@ -53,6 +53,15 @@ vi.mock('@/stores/auth-store', async () => {
   return { useAuthStore: store };
 });
 
+// fix(#816): the Settings CTA gates on can('manage_settings') — the
+// capability the /admin/settings route enforces — not the isAdmin flag.
+const permMocks = vi.hoisted(() => ({ capabilities: new Set<string>() }));
+vi.mock('@/hooks/use-permissions', () => ({
+  usePermissions: () => ({
+    can: (capability: string) => permMocks.capabilities.has(capability),
+  }),
+}));
+
 function RailHarness({ showRail = true, aiAvailable = true }: { showRail?: boolean; aiAvailable?: boolean }) {
   const [activePanel, setActivePanel] = useState<RailPanel>(null);
   return (
@@ -319,56 +328,62 @@ describe('BuilderRail — disabled-state taxonomy (Phase 1135 AI-02)', () => {
       status: 'success',
     } as never);
     useAuthStore.setState({ token: null, user: null });
+    permMocks.capabilities = new Set();
   });
 
   afterEach(() => {
     vi.restoreAllMocks();
   });
 
-  it("renders 'AI is disabled' + 'Go to Settings' CTA when reason='env_disabled' and isAdmin", () => {
+  it("renders 'AI is disabled' + 'Go to Settings' CTA when reason='env_disabled' and caller holds manage_settings", () => {
     vi.spyOn(availabilityModule, 'useAIAvailability').mockReturnValue({
       data: { enabled: false, configured: false } as never,
       isLoading: false,
       isAIAvailable: false,
       reason: 'env_disabled',
     } as never);
+    permMocks.capabilities = new Set(['manage_settings']);
     useAuthStore.setState({ token: 't', user: { roles: ['admin'] } } as never);
     render(<BuilderRail activePanel="ai" onPanelChange={vi.fn()} aiAvailable={false} notes="" onNotesChange={vi.fn()} />);
     expect(screen.getByText(/AI is disabled/i)).toBeInTheDocument();
-    expect(screen.getByRole('link', { name: /go to settings/i })).toBeInTheDocument();
+    const cta = screen.getByRole('link', { name: /go to settings/i });
+    // fix(#816): the ?tab=ai form bounced to the General tab via the bare-path redirect.
+    expect(cta).toHaveAttribute('href', '/admin/settings/ai');
   });
 
-  it("renders 'AI is disabled' but NO CTA when reason='env_disabled' and NOT isAdmin", () => {
+  it("renders 'AI is disabled' but NO CTA without manage_settings (even for the admin role flag)", () => {
     vi.spyOn(availabilityModule, 'useAIAvailability').mockReturnValue({
       data: { enabled: false } as never,
       isLoading: false,
       isAIAvailable: false,
       reason: 'env_disabled',
     } as never);
-    useAuthStore.setState({ token: 't', user: { roles: ['member'] } } as never);
+    useAuthStore.setState({ token: 't', user: { roles: ['admin'] } } as never);
     render(<BuilderRail activePanel="ai" onPanelChange={vi.fn()} aiAvailable={false} notes="" onNotesChange={vi.fn()} />);
     expect(screen.getByText(/AI is disabled/i)).toBeInTheDocument();
     expect(screen.queryByRole('link', { name: /go to settings/i })).not.toBeInTheDocument();
   });
 
-  it("renders 'AI not configured' + 'Configure in Settings' CTA when reason='no_key' and isAdmin", () => {
+  it("renders 'AI not configured' + 'Configure in Settings' CTA when reason='no_key' and caller holds manage_settings", () => {
     vi.spyOn(availabilityModule, 'useAIAvailability').mockReturnValue({
       isLoading: false,
       isAIAvailable: false,
       reason: 'no_key',
     } as never);
+    permMocks.capabilities = new Set(['manage_settings']);
     useAuthStore.setState({ token: 't', user: { roles: ['admin'] } } as never);
     render(<BuilderRail activePanel="ai" onPanelChange={vi.fn()} aiAvailable={false} notes="" onNotesChange={vi.fn()} />);
     expect(screen.getByText(/AI not configured/i)).toBeInTheDocument();
     expect(screen.getByRole('link', { name: /configure in settings/i })).toBeInTheDocument();
   });
 
-  it("renders 'AI unavailable' + NO CTA when reason='permission' regardless of isAdmin", () => {
+  it("renders 'AI unavailable' + NO CTA when reason='permission' regardless of capabilities", () => {
     vi.spyOn(availabilityModule, 'useAIAvailability').mockReturnValue({
       isLoading: false,
       isAIAvailable: false,
       reason: 'permission',
     } as never);
+    permMocks.capabilities = new Set(['manage_settings']);
     useAuthStore.setState({ token: 't', user: { roles: ['admin'] } } as never);
     render(<BuilderRail activePanel="ai" onPanelChange={vi.fn()} aiAvailable={false} notes="" onNotesChange={vi.fn()} />);
     // The status container has the 'AI unavailable' title; use data-ai-reason to scope

--- a/frontend/src/hooks/__tests__/use-ai-availability.test.tsx
+++ b/frontend/src/hooks/__tests__/use-ai-availability.test.tsx
@@ -17,6 +17,7 @@ vi.mock('@/api/maps', () => ({
 const mocks = vi.hoisted(() => ({
   capabilities: new Set<string>(),
   isMultiTenant: false,
+  editionLoading: false,
 }));
 vi.mock('@/hooks/use-permissions', () => ({
   usePermissions: () => ({
@@ -29,7 +30,7 @@ vi.mock('@/hooks/use-edition', () => ({
     features: [],
     isEnterprise: false,
     isMultiTenant: mocks.isMultiTenant,
-    isLoading: false,
+    isLoading: mocks.editionLoading,
   }),
 }));
 
@@ -64,6 +65,7 @@ describe('useAIStatus / useAIAvailability — caching (SP-08)', () => {
     vi.clearAllMocks();
     mocks.capabilities = new Set(['use_ai_chat', 'manage_users']);
     mocks.isMultiTenant = false;
+    mocks.editionLoading = false;
     useAuthStore.setState({
       token: 'test-token',
       refreshToken: null,
@@ -143,6 +145,7 @@ describe('useAIAvailability — CONSOLE-01 gating', () => {
     vi.clearAllMocks();
     mocks.capabilities = new Set(['use_ai_chat', 'manage_users']);
     mocks.isMultiTenant = false;
+    mocks.editionLoading = false;
     mockGetAIStatus.mockResolvedValue({
       enabled: true,
       configured: true,
@@ -302,6 +305,7 @@ describe('useAIAvailability — reason field (Phase 1135 AI-02)', () => {
     // Default: a status reader who can also use chat; individual tests override.
     mocks.capabilities = new Set(['use_ai_chat', 'manage_users']);
     mocks.isMultiTenant = false;
+    mocks.editionLoading = false;
     // Default auth state: admin token.
     useAuthStore.setState({
       token: 'admin-token',
@@ -421,6 +425,7 @@ describe('useAIAvailability — mode-aware status gate (fix #815)', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mocks.isMultiTenant = false;
+    mocks.editionLoading = false;
     mockGetAIStatus.mockResolvedValue({
       enabled: true,
       configured: true,
@@ -470,6 +475,30 @@ describe('useAIAvailability — mode-aware status gate (fix #815)', () => {
     await waitFor(() => expect(result.current.isAIAvailable).toBe(true));
     expect(mockGetAIStatus).toHaveBeenCalledTimes(1);
     expect(mockGetAIAvailability).not.toHaveBeenCalled();
+  });
+
+  it('holds BOTH probes while the edition query is loading (no wrong-endpoint 403), surfacing isLoading', () => {
+    // Until the edition resolves, tenancy mode reads as single-tenant, so a
+    // manage_users holder in a multi-tenant deployment would probe the admin
+    // endpoint and 403. Neither endpoint may fire before the mode is known.
+    mocks.editionLoading = true;
+    mocks.capabilities = new Set(['use_ai_chat', 'manage_users']);
+    useAuthStore.setState({
+      token: 'admin-token',
+      refreshToken: null,
+      expiresAt: null,
+      user: adminUser,
+    });
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+
+    const { result } = renderHook(() => useAIAvailability(), {
+      wrapper: makeWrapper(qc),
+    });
+
+    expect(mockGetAIStatus).not.toHaveBeenCalled();
+    expect(mockGetAIAvailability).not.toHaveBeenCalled();
+    expect(result.current.isLoading).toBe(true);
+    expect(result.current.reason).toBeNull();
   });
 
   it('single-tenant: a non-admin manage_users holder reads detailed admin status', async () => {

--- a/frontend/src/hooks/__tests__/use-ai-availability.test.tsx
+++ b/frontend/src/hooks/__tests__/use-ai-availability.test.tsx
@@ -12,10 +12,25 @@ vi.mock('@/api/maps', () => ({
   getAIAvailability: vi.fn(),
 }));
 
-// Mutable mock so individual tests can override the `can` return value.
-const mockCan = vi.fn(() => true);
+// fix(#815): the hook branches on useAIStatusReader (capabilities + edition),
+// not the isAdmin flag — mock both sides with per-test mutable state.
+const mocks = vi.hoisted(() => ({
+  capabilities: new Set<string>(),
+  isMultiTenant: false,
+}));
 vi.mock('@/hooks/use-permissions', () => ({
-  usePermissions: () => ({ can: mockCan }),
+  usePermissions: () => ({
+    can: (capability: string) => mocks.capabilities.has(capability),
+  }),
+}));
+vi.mock('@/hooks/use-edition', () => ({
+  useEdition: () => ({
+    edition: 'community',
+    features: [],
+    isEnterprise: false,
+    isMultiTenant: mocks.isMultiTenant,
+    isLoading: false,
+  }),
 }));
 
 import { getAIStatus } from '@/api/admin';
@@ -47,6 +62,8 @@ const adminUser = {
 describe('useAIStatus / useAIAvailability — caching (SP-08)', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mocks.capabilities = new Set(['use_ai_chat', 'manage_users']);
+    mocks.isMultiTenant = false;
     useAuthStore.setState({
       token: 'test-token',
       refreshToken: null,
@@ -124,6 +141,8 @@ describe('useAIStatus / useAIAvailability — caching (SP-08)', () => {
 describe('useAIAvailability — CONSOLE-01 gating', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mocks.capabilities = new Set(['use_ai_chat', 'manage_users']);
+    mocks.isMultiTenant = false;
     mockGetAIStatus.mockResolvedValue({
       enabled: true,
       configured: true,
@@ -154,7 +173,7 @@ describe('useAIAvailability — CONSOLE-01 gating', () => {
   it('authed viewer WITHOUT use_ai_chat: fires NEITHER endpoint — query stays idle, reason=permission', async () => {
     // A genuine viewer lacks use_ai_chat → no admin status probe AND no public
     // availability probe (P1-11: no 403 console noise for viewers).
-    mockCan.mockReturnValue(false);
+    mocks.capabilities = new Set();
     useAuthStore.setState({
       token: 'viewer-token',
       refreshToken: null,
@@ -185,7 +204,7 @@ describe('useAIAvailability — CONSOLE-01 gating', () => {
   });
 
   it('P1-11: non-admin editor WITH use_ai_chat fires the public availability endpoint, NOT admin status', async () => {
-    mockCan.mockReturnValue(true);
+    mocks.capabilities = new Set(['use_ai_chat']);
     mockGetAIAvailability.mockResolvedValue({ available: true });
     useAuthStore.setState({
       token: 'editor-token',
@@ -214,7 +233,7 @@ describe('useAIAvailability — CONSOLE-01 gating', () => {
   });
 
   it('P1-11: non-admin editor sees a safe disabled state (reason=no_key) when AI is not configured', async () => {
-    mockCan.mockReturnValue(true);
+    mocks.capabilities = new Set(['use_ai_chat']);
     mockGetAIAvailability.mockResolvedValue({ available: false });
     useAuthStore.setState({
       token: 'editor-token',
@@ -280,8 +299,9 @@ describe('useAIAvailability — CONSOLE-01 gating', () => {
 describe('useAIAvailability — reason field (Phase 1135 AI-02)', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    // Reset can mock to default (true) for each test; individual tests override.
-    mockCan.mockReturnValue(true);
+    // Default: a status reader who can also use chat; individual tests override.
+    mocks.capabilities = new Set(['use_ai_chat', 'manage_users']);
+    mocks.isMultiTenant = false;
     // Default auth state: admin token.
     useAuthStore.setState({
       token: 'admin-token',
@@ -335,8 +355,9 @@ describe('useAIAvailability — reason field (Phase 1135 AI-02)', () => {
 
   // Test C
   it('reason is "permission" when enabled + configured but caller lacks use_ai_chat', async () => {
-    // Override can to return false for this test (permission denied)
-    mockCan.mockReturnValue(false);
+    // A status reader without use_ai_chat: the status query still resolves,
+    // but chat stays permission-denied.
+    mocks.capabilities = new Set(['manage_users']);
     mockGetAIStatus.mockResolvedValue({
       enabled: true,
       configured: true,
@@ -389,5 +410,93 @@ describe('useAIAvailability — reason field (Phase 1135 AI-02)', () => {
     // Query is in loading state (pending, not yet resolved)
     expect(result.current.isLoading).toBe(true);
     expect(result.current.reason).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// fix(#815): the status branch follows useAIStatusReader, not the isAdmin flag
+// ---------------------------------------------------------------------------
+
+describe('useAIAvailability — mode-aware status gate (fix #815)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.isMultiTenant = false;
+    mockGetAIStatus.mockResolvedValue({
+      enabled: true,
+      configured: true,
+      provider: 'openai',
+      model: 'gpt-4',
+    } as never);
+    mockGetAIAvailability.mockResolvedValue({ available: true });
+  });
+
+  it('multi-tenant: admin-flagged user WITHOUT manage_tenants falls back to the public endpoint (no 403 probe)', async () => {
+    mocks.isMultiTenant = true;
+    // manage_users is not enough in multi-tenant mode — the backend requires
+    // manage_tenants there, so probing admin status would just 403.
+    mocks.capabilities = new Set(['use_ai_chat', 'manage_users']);
+    useAuthStore.setState({
+      token: 'admin-token',
+      refreshToken: null,
+      expiresAt: null,
+      user: adminUser,
+    });
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+
+    const { result } = renderHook(() => useAIAvailability(), {
+      wrapper: makeWrapper(qc),
+    });
+
+    await waitFor(() => expect(result.current.isAIAvailable).toBe(true));
+    expect(mockGetAIStatus).not.toHaveBeenCalled();
+    expect(mockGetAIAvailability).toHaveBeenCalledTimes(1);
+  });
+
+  it('multi-tenant: manage_tenants holder reads detailed admin status', async () => {
+    mocks.isMultiTenant = true;
+    mocks.capabilities = new Set(['use_ai_chat', 'manage_tenants']);
+    useAuthStore.setState({
+      token: 'admin-token',
+      refreshToken: null,
+      expiresAt: null,
+      user: adminUser,
+    });
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+
+    const { result } = renderHook(() => useAIAvailability(), {
+      wrapper: makeWrapper(qc),
+    });
+
+    await waitFor(() => expect(result.current.isAIAvailable).toBe(true));
+    expect(mockGetAIStatus).toHaveBeenCalledTimes(1);
+    expect(mockGetAIAvailability).not.toHaveBeenCalled();
+  });
+
+  it('single-tenant: a non-admin manage_users holder reads detailed admin status', async () => {
+    mocks.capabilities = new Set(['use_ai_chat', 'manage_users']);
+    useAuthStore.setState({
+      token: 'editor-token',
+      refreshToken: null,
+      expiresAt: null,
+      user: {
+        id: 'u5',
+        username: 'ops',
+        email: 'ops@x',
+        roles: ['editor'],
+        is_active: true,
+        status: 'active',
+        last_login_at: null,
+        created_at: '',
+      },
+    });
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+
+    const { result } = renderHook(() => useAIAvailability(), {
+      wrapper: makeWrapper(qc),
+    });
+
+    await waitFor(() => expect(result.current.isAIAvailable).toBe(true));
+    expect(mockGetAIStatus).toHaveBeenCalledTimes(1);
+    expect(mockGetAIAvailability).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/hooks/use-ai-availability.ts
+++ b/frontend/src/hooks/use-ai-availability.ts
@@ -1,6 +1,7 @@
 import { useQuery } from '@tanstack/react-query';
 import { useAIStatus } from '@/hooks/use-admin';
 import { useAIStatusReader } from '@/hooks/use-ai-status-reader';
+import { useEdition } from '@/hooks/use-edition';
 import { usePermissions } from '@/hooks/use-permissions';
 import { useAuthStore } from '@/stores/auth-store';
 import { getAIAvailability } from '@/api/maps';
@@ -54,17 +55,22 @@ export function useAIAvailability() {
   // fix(#815): branch on the backend's actual gate (mode-aware capability),
   // not the isAdmin flag — the flag both over- and under-selected.
   const canReadStatus = useAIStatusReader();
+  // fix(#816): canReadStatus derives from the edition query's tenancy mode,
+  // which reads as single-tenant until that query settles — probing before
+  // then can hit the wrong endpoint (a 403 that lands in error telemetry).
+  // Hold both probes until the edition is known.
+  const editionResolved = !useEdition().isLoading;
   const { can } = usePermissions();
   const canUse = can('use_ai_chat');
 
   // Status readers get the detailed admin status (provider/key info for the reason taxonomy).
-  const adminStatus = useAIStatus({ enabled: !!token && canReadStatus });
+  const adminStatus = useAIStatus({ enabled: !!token && editionResolved && canReadStatus });
   // Other editors holding use_ai_chat read the public-safe availability signal.
   // Viewers (!canUse) fire nothing — avoids 403 console noise.
   const availabilityQuery = useQuery({
     queryKey: queryKeys.maps.aiAvailability,
     queryFn: getAIAvailability,
-    enabled: !!token && !canReadStatus && canUse,
+    enabled: !!token && editionResolved && !canReadStatus && canUse,
     staleTime: 60_000,
     gcTime: 5 * 60_000,
   });
@@ -95,7 +101,9 @@ export function useAIAvailability() {
   // Surface the loading/error state of whichever query is actually active so the
   // disabled-state UI can show a spinner instead of premature "unavailable" copy.
   const activeQuery = canReadStatus ? adminStatus : availabilityQuery;
-  const isLoading = canUse && activeQuery.fetchStatus !== 'idle' && activeQuery.isLoading;
+  const isLoading =
+    canUse &&
+    (!editionResolved || (activeQuery.fetchStatus !== 'idle' && activeQuery.isLoading));
 
   return {
     ...activeQuery,

--- a/frontend/src/hooks/use-ai-availability.ts
+++ b/frontend/src/hooks/use-ai-availability.ts
@@ -1,5 +1,6 @@
 import { useQuery } from '@tanstack/react-query';
 import { useAIStatus } from '@/hooks/use-admin';
+import { useAIStatusReader } from '@/hooks/use-ai-status-reader';
 import { usePermissions } from '@/hooks/use-permissions';
 import { useAuthStore } from '@/stores/auth-store';
 import { getAIAvailability } from '@/api/maps';
@@ -11,9 +12,12 @@ import { queryKeys } from '@/lib/query-keys';
  *
  * ## Two readiness sources (builder-audit #338 P1-11)
  *
- * - **Admins** read the detailed `/api/admin/ai-status/` endpoint (provider, key
+ * - **AI-status readers** (the mode-aware capability mirrored by
+ *   `useAIStatusReader()` — fix(#815): was gated on the `isAdmin` flag, which
+ *   403'd capability-less admins and skipped capability-holding non-admins)
+ *   read the detailed `/api/admin/ai-status/` endpoint (provider, key
  *   presence) so the disabled-state UI can distinguish `env_disabled` vs `no_key`.
- * - **Non-admin editors holding `use_ai_chat`** read the public-safe
+ * - **Other editors holding `use_ai_chat`** read the public-safe
  *   `/api/ai/availability/` endpoint, which returns only a boolean and leaks no
  *   provider/key detail. This lets a permitted editor open builder chat when AI
  *   is enabled and configured — previously the hook returned `false` for every
@@ -31,9 +35,9 @@ import { queryKeys } from '@/lib/query-keys';
  *
  * Precedence (first match wins):
  *   1. `permission`    — caller lacks `use_ai_chat` (no endpoint was queried)
- *   2. `env_disabled`  — admin only: AI_ENABLED=false at the instance level
- *   3. `no_key`        — AI enabled but no provider API key configured (admin
- *                        distinguishes this; non-admins see it for any
+ *   2. `env_disabled`  — status readers only: AI_ENABLED=false at the instance level
+ *   3. `no_key`        — AI enabled but no provider API key configured (status
+ *                        readers distinguish this; other callers see it for any
  *                        not-available signal, since the public endpoint
  *                        intentionally collapses env_disabled/no_key)
  *   4. `null`          — either `isAIAvailable === true` (AI fully available)
@@ -47,18 +51,20 @@ export type AIUnavailableReason = 'env_disabled' | 'no_key' | 'permission';
 
 export function useAIAvailability() {
   const token = useAuthStore((s) => s.token);
-  const isAdmin = useAuthStore((s) => s.isAdmin());
+  // fix(#815): branch on the backend's actual gate (mode-aware capability),
+  // not the isAdmin flag — the flag both over- and under-selected.
+  const canReadStatus = useAIStatusReader();
   const { can } = usePermissions();
   const canUse = can('use_ai_chat');
 
-  // Admins read the detailed admin status (provider/key info for the reason taxonomy).
-  const adminStatus = useAIStatus({ enabled: !!token && isAdmin });
-  // Non-admin editors holding use_ai_chat read the public-safe availability signal.
+  // Status readers get the detailed admin status (provider/key info for the reason taxonomy).
+  const adminStatus = useAIStatus({ enabled: !!token && canReadStatus });
+  // Other editors holding use_ai_chat read the public-safe availability signal.
   // Viewers (!canUse) fire nothing — avoids 403 console noise.
   const availabilityQuery = useQuery({
     queryKey: queryKeys.maps.aiAvailability,
     queryFn: getAIAvailability,
-    enabled: !!token && !isAdmin && canUse,
+    enabled: !!token && !canReadStatus && canUse,
     staleTime: 60_000,
     gcTime: 5 * 60_000,
   });
@@ -71,7 +77,7 @@ export function useAIAvailability() {
   if (!canUse) {
     isAIAvailable = false;
     reason = 'permission';
-  } else if (isAdmin) {
+  } else if (canReadStatus) {
     isAIAvailable = Boolean(adminData?.enabled && adminData?.configured);
     if (!isAIAvailable && adminData !== undefined) {
       reason = !adminData.enabled ? 'env_disabled' : 'no_key';
@@ -79,7 +85,7 @@ export function useAIAvailability() {
   } else {
     isAIAvailable = Boolean(availabilityQuery.data?.available);
     // The public endpoint collapses env_disabled/no_key into a single boolean;
-    // surface the more common "not configured" cause to non-admins (who cannot
+    // surface the more common "not configured" cause to non-readers (who cannot
     // act on either, and never see the admin Settings CTA).
     if (!isAIAvailable && availabilityQuery.data !== undefined) {
       reason = 'no_key';
@@ -88,7 +94,7 @@ export function useAIAvailability() {
 
   // Surface the loading/error state of whichever query is actually active so the
   // disabled-state UI can show a spinner instead of premature "unavailable" copy.
-  const activeQuery = isAdmin ? adminStatus : availabilityQuery;
+  const activeQuery = canReadStatus ? adminStatus : availabilityQuery;
   const isLoading = canUse && activeQuery.fetchStatus !== 'idle' && activeQuery.isLoading;
 
   return {


### PR DESCRIPTION
Closes #815.

`useAIAvailability` picked between the detailed `/admin/ai-status` probe and the public `/ai/availability` signal using the `isAdmin` flag, but the backend gates the admin endpoint on the capability mirrored by `useAIStatusReader()` (added in #814 for #653). The flag both over-selected (admin-flagged users without the capability fired a probe that 403s) and under-selected (capability-holding non-admins never read the detailed status).

## Change

- Branch on `useAIStatusReader()` instead of `isAdmin` in `use-ai-availability.ts`; comment pass to match.
- Test file moved to the capability-set + edition mock pattern from the #653 tests; three new regression cases cover both directions of the old mismatch.
- CHANGELOG entry under Unreleased.

## Verification

- `npx vitest run src/hooks/__tests__/use-ai-availability.test.tsx` — 16 passed
- Consumer suites (builder/viewer/dataset/maps/import/admin) — 2495 passed
- `npm run lint`, `npm run typecheck`, `make public-surface-check` — clean
