### PR TITLE
fix: pre-tag deep-audit batch for 1.6.0

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -331,15 +331,21 @@ FRONTEND_PORT=8080
 # BACKUP_SCHEDULE=0 2 * * *
 
 # Number of daily backups to retain locally
+# Must be >= 1 — the backup service refuses to start otherwise (a retention
+# of 0 would delete each backup as soon as it was written).
 # Type: integer | Default: 7
 # BACKUP_RETENTION_DAILY=7
 
 # Number of weekly (Sunday) backups to retain locally
+# Must be >= 1 — the backup service refuses to start otherwise.
 # Type: integer | Default: 4
 # BACKUP_RETENTION_WEEKLY=4
 
 # Enable off-site backup upload to S3-compatible storage
 # Uses the same S3_* credentials configured in Infrastructure Providers section.
+# When true, S3_BUCKET, S3_ACCESS_KEY_ID, and S3_SECRET_ACCESS_KEY must all be
+# set — a blank credential fails the backup cycle (container turns unhealthy)
+# instead of silently skipping the offsite upload.
 # Type: boolean | Default: false
 # BACKUP_S3_ENABLED=false
 

--- a/.github/workflows/publish-sdks.yml
+++ b/.github/workflows/publish-sdks.yml
@@ -161,7 +161,7 @@ jobs:
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0
         with:
-          # Node 24 ships npm 11.x — OIDC Trusted Publishing requires npm >= 11.5.1.
+          # fix(#819): Node 24 ships npm 11.x — OIDC Trusted Publishing requires npm >= 11.5.1.
           # Node 22 (npm 10.x) cannot authenticate; there is no NODE_AUTH_TOKEN
           # fallback on the publish step, so the npm version IS the auth path.
           node-version: 24

--- a/.github/workflows/publish-sdks.yml
+++ b/.github/workflows/publish-sdks.yml
@@ -161,7 +161,10 @@ jobs:
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0
         with:
-          node-version: 22
+          # Node 24 ships npm 11.x — OIDC Trusted Publishing requires npm >= 11.5.1.
+          # Node 22 (npm 10.x) cannot authenticate; there is no NODE_AUTH_TOKEN
+          # fallback on the publish step, so the npm version IS the auth path.
+          node-version: 24
           registry-url: 'https://registry.npmjs.org'
           cache: npm
           cache-dependency-path: sdks/typescript/package-lock.json
@@ -215,8 +218,8 @@ jobs:
         # Trusted Publishing: the workflow's `id-token: write` permission plus the npm
         # trusted publisher configured for @geolens/sdk (geolens-io/geolens · this
         # workflow, no environment) let npm authenticate via OIDC — no NPM_TOKEN secret.
-        # npm >= 11.5.1 (installed above) also generates + attaches provenance
-        # automatically, so no explicit --provenance flag is needed. OIDC + provenance
+        # npm >= 11.5.1 (from Node 24 in setup-node above) also generates + attaches
+        # provenance automatically, so no explicit --provenance flag is needed. OIDC + provenance
         # both require a public source repository (it is). `--access public` is kept for
         # the scoped package. NPM_TOKEN secret is now unused (kept as a manual fallback).
         run: npm publish --access public

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,7 +53,7 @@ Avoid bare, unscoped finding ids that only resolve in a private tracker.
 
 ## Testing Guidelines
 
-Backend tests use pytest with AnyIO; files follow `test_*.py`. Coverage in `backend/pyproject.toml` has a 60% minimum (`fail_under`). For DB-backed tests, start Postgres with `docker compose up -d --wait db`; follow `.env.test.example` and `.github/workflows/ci.yml` for CI-style variables.
+Backend tests use pytest with AnyIO; files follow `test_*.py`. Coverage in `backend/pyproject.toml` has an 80% minimum (`fail_under`). For DB-backed tests, start Postgres with `docker compose up -d --wait db`; follow `.env.test.example` and `.github/workflows/ci.yml` for CI-style variables.
 
 Frontend tests use Vitest and Testing Library as `*.test.ts(x)` files or under `__tests__/`. E2E tests use Playwright and follow `*.spec.ts` in `e2e/`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and releases use semantic versioning.
 
 ## [Unreleased]
 
+### Security
+
+- **Map sharing surfaces are gated tighter.** The visibility-check
+  endpoint now requires map ownership — its response names non-public
+  dataset titles, which read access alone should not reveal — and
+  creating or managing embed tokens requires the same `edit_metadata`
+  capability as creating the share link the token accompanies.
+
 ### Fixed
 
 - **Upgrading no longer reports a false "Upgrade FAILED".** The new backup
@@ -35,7 +43,17 @@ and releases use semantic versioning.
   authentication failure that can't be recovered now surfaces the map's
   error state on the dataset preview and viewer instead of failing
   silently. Vector previews gained the same loading and error states
-  rasters already had.
+  rasters already had. A *recovering* session no longer trips that error
+  state: every tile error in the burst that triggered a token re-mint
+  used to count as a failed recovery, flashing "Preview unavailable"
+  over a map that was about to render — errors now surface only if they
+  persist after the re-mint had time to land.
+- **Private raster layers render for signed-in users in the shared-map
+  viewer**, which never attached the auth header raster tiles need
+  (the builder and dataset preview already did).
+- **Backups no longer accumulate orphaned temp files.** A dump
+  interrupted mid-write left a `.dump.tmp` file no retention pass would
+  ever delete; each cycle now clears leftovers at start.
 - **Bulk delete announces the real count while deleting**, its
   confirmation prompt behaves as a proper dialog, selection no longer
   survives on rows hidden by search or a collapsed group, and a partial
@@ -53,6 +71,13 @@ and releases use semantic versioning.
   at every zoom), the last movement of an opacity slider isn't lost when
   the editor closes, Reset asks before destroying a configured style,
   and the "Reverse" ramp option actually reverses DEM and heatmap ramps.
+- **Applying the Advanced JSON editor no longer resets the layer's zoom
+  range.** Apply wrote the editor's copy of the layout back wholesale,
+  and that copy has the zoom bounds stripped — so an Apply with no edits
+  at all silently wiped a configured min/max zoom back to the defaults.
+  (#770)
+- **Folder groups no longer produce phantom legend entries**, on screen
+  or in the PNG export. (#769)
 
 ### Changed
 
@@ -85,13 +110,22 @@ and releases use semantic versioning.
 - **The backup container reports unhealthy when backups stop
   succeeding**, not just when its loop dies — operators see a red
   container instead of discovering stale backups during a restore.
-  (#800)
+  Freshness is judged against the new `BACKUP_MAX_AGE_MINUTES` setting
+  (default 1560 minutes = 26 hours, sized for the default daily
+  schedule); operators on a non-daily `BACKUP_SCHEDULE` must set it to
+  roughly 1.5× their backup interval. (#800)
 - **Destructive confirms are consistently ordered** (safe action left,
   destructive right) across the builder, and revoking a share link asks
   first. (#809)
 - **Builder accessibility batch**: accessible names on maps, sliders and
   rename inputs, live regions that announce reliably, translated drag
   announcements, and honest inline-confirm semantics. (#804, #810)
+- **The Add Data dialog stays open across adds**, so several datasets
+  can be added in one pass; the layer editor opens on the last added
+  layer once the dialog closes instead of landing behind it. (#776)
+- **The first-run empty state matches a stock install**: the copy no
+  longer points at starter datasets and an Upload button a fresh
+  install doesn't have, in all four languages. (#780)
 - **Analysis correctness batch**: terminal job writes are fenced,
   renamed outputs surface correctly, the output size check measures the
   real output, the stack selection is honored, and a drawn clip mask
@@ -100,6 +134,13 @@ and releases use semantic versioning.
   a required job fails instead of skipping, path filters that actually
   cover the files jobs read (including the root `package.json`, so a
   Playwright bump runs the suites again), and workflow hardening.
+
+### Dependencies
+
+- Routine runtime updates: anthropic, sqlglot, boto3, cachetools,
+  prometheus-fastapi-instrumentator, and sse-starlette on the backend;
+  the React and TanStack ecosystems, lucide-react, and Tailwind tooling
+  on the frontend.
 
 ## [1.5.1] - 2026-07-27
 

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -390,8 +390,9 @@ docker inspect --format '{{.State.Health.Status}}' $(docker compose ps -q backup
 
 `healthy` means a backup cycle **fully succeeded recently** — it is not a
 liveness probe. The entrypoint touches `/backups/.last-success` only after
-`pg_dump`, end-to-end verification (`pg_restore -f /dev/null`), and the S3
-upload (when `BACKUP_S3_ENABLED=true`) all succeed. The healthcheck fails when
+`pg_dump`, end-to-end verification (`pg_restore -f /dev/null`), the
+object-storage staging archive (when the staging volume is mounted and
+non-empty), and the S3 upload (when `BACKUP_S3_ENABLED=true`) all succeed. The healthcheck fails when
 that marker is missing or older than `BACKUP_MAX_AGE_MINUTES` (default `1560`
 minutes = 26 hours, the default daily schedule plus slack). A container whose
 backups quietly stop succeeding therefore turns `unhealthy` roughly one missed
@@ -427,7 +428,7 @@ docker compose logs -f backup
 | `Object-storage archive complete: staging-<ts>.tar.gz (<size>)` | `upload_staging` archived alongside the dump |
 | `Backup cycle complete` | Full cycle (dump + staging + S3 if enabled) finished |
 | `ERROR: S3 upload failed for <key>` | Offsite upload failed; cycle returns non-zero |
-| `WARNING: object-storage archive failed — staging backup skipped` | Staging tar failed; DB dump is still good |
+| `ERROR: object-storage archive failed — this cycle will be reported as failed` | Staging tar failed; the cycle fails and the service turns `unhealthy` at the next freshness probe |
 | `ERROR: pg_dump failed` | DB dump failed; no artifacts written for this cycle |
 
 A healthy cycle produces at least `Backup complete` and `Backup cycle complete`.

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -154,9 +154,10 @@ dump**. Schema migrations move forward only.
 # 1. Re-pin the previous version in .env (edit the GEOLENS_VERSION= line):
 #    GEOLENS_VERSION=1.2.3      # the version you upgraded FROM
 
-# 2. Restore the pre-upgrade dump. scripts/restore.sh validates the dump with
-#    `pg_restore --list`, stops api/worker, and runs `pg_restore` (it always
-#    restarts api/worker afterward). Pass the dump file the upgrade created:
+# 2. Restore the pre-upgrade dump. scripts/restore.sh validates the dump
+#    end-to-end (`pg_restore -f /dev/null`), stops api/worker, and runs
+#    `pg_restore` (it always restarts api/worker afterward). Pass the dump
+#    file the upgrade created:
 ./scripts/restore.sh backups/pre-upgrade/<db>_pre_<old>_to_<new>_<timestamp>.dump
 
 # 3. Bring the previous version back up:
@@ -192,6 +193,14 @@ Notes:
   they reference. The staging archive captures the local `upload_staging` volume
   only; deployments that offload objects to an external S3/MinIO bucket must back
   that bucket up separately.
+- The backup service **fails fast on misconfiguration** (since 1.6.0): a
+  `BACKUP_RETENTION_DAILY`/`BACKUP_RETENTION_WEEKLY` below 1 makes the
+  container exit at boot (it would delete each backup as soon as it was
+  written), and `BACKUP_S3_ENABLED=true` with `S3_BUCKET`,
+  `S3_ACCESS_KEY_ID`, or `S3_SECRET_ACCESS_KEY` unset fails the backup cycle
+  instead of silently skipping the offsite upload. Either misconfiguration
+  surfaces as a restarting/unhealthy `backup` container after an upgrade —
+  fix the `.env` values; the rest of the stack is unaffected.
 - The upgrade flow takes its own **pre-upgrade** dump under
   `backups/pre-upgrade/` independently of the scheduled backup service, so you
   always have a known-good restore point for the upgrade you just ran.

--- a/backend/app/modules/catalog/maps/router_sharing.py
+++ b/backend/app/modules/catalog/maps/router_sharing.py
@@ -184,11 +184,18 @@ async def visibility_check_endpoint(
     user: Identity = Depends(require_permission("edit_metadata")),
     db: AsyncSession = Depends(get_db),
 ) -> VisibilityCheckResponse:
-    """Check if a map has non-public datasets. Informational only."""
+    """Check if a map has non-public datasets. Informational only.
+
+    Owner-or-admin like the other sharing mutations: the response names
+    non-public dataset titles, which read access alone must not reveal.
+    Read access is checked first so unreadable maps keep answering 404
+    (SEC-007 existence-hiding); readable non-owners get 403.
+    """
     map_obj = await get_map(db, map_id)
     if map_obj is None:
         raise HTTPException(status_code=404, detail="Map not found")
     await _check_map_read_access(map_obj, user, db)
+    await check_map_ownership(map_obj, user, db)
     non_public_names = await validate_public_visibility(db, map_id)
     return VisibilityCheckResponse(
         non_public_datasets=non_public_names,

--- a/backend/app/modules/embed_tokens/router.py
+++ b/backend/app/modules/embed_tokens/router.py
@@ -70,7 +70,7 @@ router = APIRouter(
 async def create_embed_token_endpoint(
     map_id: uuid.UUID,
     body: EmbedTokenCreate,
-    # Same permission gate as share_map_endpoint: an embed token outranks the
+    # fix(#819): same permission gate as share_map_endpoint — an embed token outranks the
     # share link it accompanies (anonymous tile capability), so minting or
     # managing one must never be gated weaker than creating the share link.
     user: Identity = Depends(require_permission("edit_metadata")),

--- a/backend/app/modules/embed_tokens/router.py
+++ b/backend/app/modules/embed_tokens/router.py
@@ -24,7 +24,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.modules.audit.service import AuditEvent, audit_emit
 from app.core.identity import Identity
-from app.modules.auth.dependencies import get_current_active_user
+from app.modules.auth.dependencies import require_permission
 from app.core.dependencies import get_db
 from app.modules.embed_tokens.schemas import (
     EmbedTokenCreate,
@@ -70,7 +70,10 @@ router = APIRouter(
 async def create_embed_token_endpoint(
     map_id: uuid.UUID,
     body: EmbedTokenCreate,
-    user: Identity = Depends(get_current_active_user),
+    # Same permission gate as share_map_endpoint: an embed token outranks the
+    # share link it accompanies (anonymous tile capability), so minting or
+    # managing one must never be gated weaker than creating the share link.
+    user: Identity = Depends(require_permission("edit_metadata")),
     db: AsyncSession = Depends(get_db),
 ) -> EmbedTokenCreatedResponse:
     """Create an embed token scoped to a map's current layers.
@@ -124,7 +127,7 @@ async def create_embed_token_endpoint(
 @router.get("/", response_model=EmbedTokenListResponse)
 async def list_embed_tokens_endpoint(
     map_id: uuid.UUID,
-    user: Identity = Depends(get_current_active_user),
+    user: Identity = Depends(require_permission("edit_metadata")),
     db: AsyncSession = Depends(get_db),
 ) -> EmbedTokenListResponse:
     """List all embed tokens for a map."""
@@ -148,7 +151,7 @@ async def update_embed_token_endpoint(
     map_id: uuid.UUID,
     token_id: uuid.UUID,
     body: EmbedTokenUpdate,
-    user: Identity = Depends(get_current_active_user),
+    user: Identity = Depends(require_permission("edit_metadata")),
     db: AsyncSession = Depends(get_db),
 ) -> EmbedTokenResponse:
     """Update embed token allowed_origins.
@@ -196,7 +199,7 @@ async def update_embed_token_endpoint(
 async def revoke_embed_token_endpoint(
     map_id: uuid.UUID,
     token_id: uuid.UUID,
-    user: Identity = Depends(get_current_active_user),
+    user: Identity = Depends(require_permission("edit_metadata")),
     db: AsyncSession = Depends(get_db),
 ) -> EmbedTokenResponse:
     """Revoke an embed token."""

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -46535,7 +46535,7 @@
     },
     "/maps/{map_id}/visibility-check/": {
       "get": {
-        "description": "Check if a map has non-public datasets. Informational only.",
+        "description": "Check if a map has non-public datasets. Informational only.\n\nOwner-or-admin like the other sharing mutations: the response names\nnon-public dataset titles, which read access alone must not reveal.\nRead access is checked first so unreadable maps keep answering 404\n(SEC-007 existence-hiding); readable non-owners get 403.",
         "operationId": "visibility_check_endpoint_maps__map_id__visibility_check__get",
         "parameters": [
           {

--- a/backend/tests/test_embed_tokens.py
+++ b/backend/tests/test_embed_tokens.py
@@ -2238,3 +2238,30 @@ class TestBulkRevokeTenantFilter:
             f"belonging to tenant_b (token id={token_b_id}). Expected 0 — "
             "cross-tenant revocation must be blocked."
         )
+
+
+@pytest.mark.anyio
+async def test_embed_token_endpoints_require_edit_metadata(
+    client: AsyncClient, admin_auth_header: dict
+):
+    """Embed tokens are anonymous tile capabilities that outrank the share
+    link they accompany, so every CRUD endpoint carries the same
+    edit_metadata gate as share-link creation. A viewer gets 403 from the
+    permission dependency before any map lookup (404 would mean the gate is
+    missing and ownership answered instead)."""
+    from .conftest import _create_test_user
+
+    viewer_headers, _ = await _create_test_user(client, admin_auth_header, "viewer")
+    base = f"/maps/{uuid.uuid4()}/embed-tokens"
+    token_id = uuid.uuid4()
+
+    resp = await client.post(f"{base}/", json={}, headers=viewer_headers)
+    assert resp.status_code == 403, resp.text
+    resp = await client.get(f"{base}/", headers=viewer_headers)
+    assert resp.status_code == 403, resp.text
+    resp = await client.patch(
+        f"{base}/{token_id}/", json={"allowed_origins": None}, headers=viewer_headers
+    )
+    assert resp.status_code == 403, resp.text
+    resp = await client.delete(f"{base}/{token_id}/", headers=viewer_headers)
+    assert resp.status_code == 403, resp.text

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -1073,7 +1073,8 @@ def test_open_core_decomposition_boundaries_stay_clean() -> None:
         "backend/app/modules/catalog/maps/style_sanitizers.py": 200,
         "backend/app/modules/catalog/maps/router_assets.py": 126,
         # fix(#526 B-048): the card-route SPA-redirect fallback shell.
-        "backend/app/modules/catalog/maps/router_sharing.py": 380,
+        # fix(#819): visibility-check owner-or-admin gate + rationale docstring.
+        "backend/app/modules/catalog/maps/router_sharing.py": 387,
         "backend/app/modules/catalog/search/query_params.py": 225,
         "backend/app/modules/catalog/search/router_saved.py": 100,
         "backend/app/modules/admin/router_operations.py": 275,

--- a/backend/tests/test_maps_visibility_check_authz_sec007.py
+++ b/backend/tests/test_maps_visibility_check_authz_sec007.py
@@ -80,3 +80,33 @@ async def test_visibility_check_allows_admin(
     )
 
     assert resp.status_code == 200
+
+
+@pytest.mark.anyio
+async def test_visibility_check_rejects_non_owner_editor_on_public_map(
+    client: AsyncClient, admin_auth_header: dict, test_db_session
+):
+    """ATTACK: read access is not enough. The response names non-public
+    dataset titles, so the endpoint is owner-or-admin like the other sharing
+    routes — a non-owner editor is refused (403) even on a PUBLIC (readable)
+    map; unreadable maps keep the SEC-007 404."""
+    import uuid as _uuid
+
+    from app.modules.catalog.maps.models import Map
+
+    owner_headers, _ = await _create_test_user(client, admin_auth_header, "editor")
+    attacker_headers, _ = await _create_test_user(client, admin_auth_header, "editor")
+    map_id = await _create_private_map(client, owner_headers)
+
+    m = await test_db_session.get(Map, _uuid.UUID(map_id))
+    m.visibility = "public"
+    await test_db_session.commit()
+
+    resp = await client.get(
+        f"/maps/{map_id}/visibility-check/", headers=attacker_headers
+    )
+
+    assert resp.status_code == 403, (
+        f"a non-owner editor read a public map's visibility-check "
+        f"(non-public dataset titles), got {resp.status_code}: {resp.text}"
+    )

--- a/frontend/src/components/viewer/ViewerMap.tsx
+++ b/frontend/src/components/viewer/ViewerMap.tsx
@@ -15,6 +15,7 @@ import {
 import { buildClusterTileUrl, buildSignedTileUrl, getMvtSourceLayerName, isMvtSourceLayerConfigReady, resolveTileBaseUrl } from '@/lib/tile-utils';
 import { logUnhandledMapError } from '@/lib/map-error-log';
 import { useWebGLRecovery } from '@/hooks/use-webgl-recovery';
+import { useAuthStore } from '@/stores/auth-store';
 import { useInvalidateTileTokens } from '@/hooks/use-tile-token';
 import { useTileAuthRecovery } from '@/hooks/use-tile-auth-recovery';
 import { useViewerTokens } from '@/components/viewer/hooks/use-viewer-tokens';
@@ -438,6 +439,13 @@ export const ViewerMap = memo(function ViewerMap({
         const headers: Record<string, string> = {};
         if (embedToken && !isThirdPartyUrl(url)) {
           headers['X-Embed-Token'] = embedToken;
+        } else if (absUrl.includes('/raster-tiles/') && !isThirdPartyUrl(url)) {
+          // Raster tiles carry no signed URL (unlike vector tiles), so a
+          // signed-in viewer needs the Bearer header here just like
+          // BuilderMap/DatasetMap — without it, private rasters fail on the
+          // viewer surface (incl. builder "View as viewer").
+          const token = useAuthStore.getState().token;
+          if (token) headers.Authorization = `Bearer ${token}`;
         }
         return { url: absUrl, headers };
       });

--- a/frontend/src/components/viewer/ViewerMap.tsx
+++ b/frontend/src/components/viewer/ViewerMap.tsx
@@ -440,7 +440,7 @@ export const ViewerMap = memo(function ViewerMap({
         if (embedToken && !isThirdPartyUrl(url)) {
           headers['X-Embed-Token'] = embedToken;
         } else if (absUrl.includes('/raster-tiles/') && !isThirdPartyUrl(url)) {
-          // Raster tiles carry no signed URL (unlike vector tiles), so a
+          // fix(#819): raster tiles carry no signed URL (unlike vector tiles), so a
           // signed-in viewer needs the Bearer header here just like
           // BuilderMap/DatasetMap — without it, private rasters fail on the
           // viewer surface (incl. builder "View as viewer").

--- a/frontend/src/hooks/__tests__/use-tile-auth-recovery.test.ts
+++ b/frontend/src/hooks/__tests__/use-tile-auth-recovery.test.ts
@@ -2,7 +2,9 @@ import { renderHook } from '@testing-library/react';
 import { useTileAuthRecovery } from '@/hooks/use-tile-auth-recovery';
 
 // fix(#621): one re-mint per cooldown window — MapLibre can fire dozens of
-// tile errors per pan, and hammering the mint endpoint cannot help.
+// tile errors per pan, and hammering the mint endpoint cannot help. Errors in
+// the settle window ride the pending re-mint (true); errors that persist past
+// it mean the re-mint didn't cure them (false).
 
 describe('useTileAuthRecovery', () => {
   afterEach(() => {
@@ -17,12 +19,28 @@ describe('useTileAuthRecovery', () => {
     expect(remint).toHaveBeenCalledTimes(1);
   });
 
-  it('suppresses further re-mints inside the cooldown window', () => {
+  it('suppresses error UI for the rest of the burst while the re-mint settles', () => {
     const remint = vi.fn();
+    const now = Date.now();
+    const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(now);
     const { result } = renderHook(() => useTileAuthRecovery(remint));
 
     expect(result.current()).toBe(true);
-    expect(result.current()).toBe(false);
+    nowSpy.mockReturnValue(now + 500);
+    expect(result.current()).toBe(true);
+    nowSpy.mockReturnValue(now + 9_000);
+    expect(result.current()).toBe(true);
+    expect(remint).toHaveBeenCalledTimes(1);
+  });
+
+  it('reports failure when errors persist after the settle window', () => {
+    const remint = vi.fn();
+    const now = Date.now();
+    const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(now);
+    const { result } = renderHook(() => useTileAuthRecovery(remint));
+
+    expect(result.current()).toBe(true);
+    nowSpy.mockReturnValue(now + 15_000);
     expect(result.current()).toBe(false);
     expect(remint).toHaveBeenCalledTimes(1);
   });

--- a/frontend/src/hooks/use-tile-auth-recovery.ts
+++ b/frontend/src/hooks/use-tile-auth-recovery.ts
@@ -4,7 +4,7 @@ import { useCallback, useRef } from 'react';
 // can fire dozens of tile errors per pan, and a mint that just failed will not
 // succeed milliseconds later.
 const REMINT_COOLDOWN_MS = 30_000;
-// Settle window: how long after kicking a re-mint we keep treating errors as
+// fix(#819): settle window — how long after kicking a re-mint we keep treating errors as
 // "the same burst the re-mint is about to cure". MapLibre fires one error per
 // failing tile, so tiles 2..N of the burst that *triggered* the re-mint arrive
 // while the mint request + token→setTiles plumbing are still in flight.

--- a/frontend/src/hooks/use-tile-auth-recovery.ts
+++ b/frontend/src/hooks/use-tile-auth-recovery.ts
@@ -4,6 +4,15 @@ import { useCallback, useRef } from 'react';
 // can fire dozens of tile errors per pan, and a mint that just failed will not
 // succeed milliseconds later.
 const REMINT_COOLDOWN_MS = 30_000;
+// Settle window: how long after kicking a re-mint we keep treating errors as
+// "the same burst the re-mint is about to cure". MapLibre fires one error per
+// failing tile, so tiles 2..N of the burst that *triggered* the re-mint arrive
+// while the mint request + token→setTiles plumbing are still in flight.
+// Treating those as "cooldown" latched a false error overlay over a map the
+// re-mint was about to fix. Errors that persist past this window mean the
+// fresh token didn't cure them (revoked grant, expired embed token) — those
+// fall through to the surface's error UI.
+const REMINT_SETTLE_MS = 10_000;
 
 /**
  * fix(#621): shared vector-tile auth recovery for every map surface (builder,
@@ -17,16 +26,18 @@ const REMINT_COOLDOWN_MS = 30_000;
  * session (401 + refresh-401) triggers the global signed-out handling (#628)
  * instead of a per-surface toast.
  *
- * Returns true when a re-mint was kicked off (recovery in progress — suppress
- * per-surface error UI); false while in cooldown (a recent re-mint didn't
- * cure the error — fall through to existing error UI).
+ * Returns true while recovery is plausibly in progress (a re-mint was just
+ * kicked off, or the error is part of the burst that kicked it — suppress
+ * per-surface error UI); false when errors persist after the re-mint had time
+ * to land (it didn't cure them — fall through to existing error UI).
  */
 export function useTileAuthRecovery(remint: () => void) {
   const lastAttemptRef = useRef(0);
   return useCallback((): boolean => {
-    const now = Date.now();
-    if (now - lastAttemptRef.current < REMINT_COOLDOWN_MS) return false;
-    lastAttemptRef.current = now;
+    const elapsed = Date.now() - lastAttemptRef.current;
+    if (elapsed < REMINT_SETTLE_MS) return true;
+    if (elapsed < REMINT_COOLDOWN_MS) return false;
+    lastAttemptRef.current = Date.now();
     remint();
     return true;
   }, [remint]);

--- a/frontend/src/i18n/locales/de/builder.json
+++ b/frontend/src/i18n/locales/de/builder.json
@@ -257,6 +257,7 @@
     },
     "pattern": "Muster",
     "extrusionRange": "Bereich: {{min}}–{{max}}, {{count}} Objekte",
+    "heightColumn": "Höhenspalte",
     "heightColumnRemoved": "Die Höhenspalte „{{column}}“ wurde beim erneuten Hochladen entfernt. Wählen Sie eine neue Spalte aus oder setzen Sie diese Einstellung zurück.",
     "lineEnds": "Linienenden",
     "lineCap": "Ende",

--- a/frontend/src/i18n/locales/en/builder.json
+++ b/frontend/src/i18n/locales/en/builder.json
@@ -257,6 +257,7 @@
     },
     "pattern": "Pattern",
     "extrusionRange": "Range: {{min}}–{{max}}, {{count}} features",
+    "heightColumn": "Height column",
     "heightColumnRemoved": "Height column “{{column}}” was removed during re-upload. Select a new column or clear this setting.",
     "lineEnds": "Line ends",
     "lineCap": "Cap",

--- a/frontend/src/i18n/locales/es/builder.json
+++ b/frontend/src/i18n/locales/es/builder.json
@@ -257,6 +257,7 @@
     },
     "pattern": "Patrón",
     "extrusionRange": "Rango: {{min}}–{{max}}, {{count}} elementos",
+    "heightColumn": "Columna de altura",
     "heightColumnRemoved": "La columna de altura «{{column}}» se eliminó durante la recarga. Seleccione una nueva columna o borre este ajuste.",
     "lineEnds": "Extremos de línea",
     "lineCap": "Extremo",

--- a/frontend/src/i18n/locales/fr/builder.json
+++ b/frontend/src/i18n/locales/fr/builder.json
@@ -257,6 +257,7 @@
     },
     "pattern": "Motif",
     "extrusionRange": "Plage : {{min}}–{{max}}, {{count}} entités",
+    "heightColumn": "Colonne de hauteur",
     "heightColumnRemoved": "La colonne de hauteur « {{column}} » a été supprimée lors du rechargement. Sélectionnez une nouvelle colonne ou effacez ce paramètre.",
     "lineEnds": "Extrémités de ligne",
     "lineCap": "Extrémité",

--- a/frontend/src/types/api.generated.ts
+++ b/frontend/src/types/api.generated.ts
@@ -3758,6 +3758,11 @@ export interface paths {
         /**
          * Visibility Check Endpoint
          * @description Check if a map has non-public datasets. Informational only.
+         *
+         *     Owner-or-admin like the other sharing mutations: the response names
+         *     non-public dataset titles, which read access alone must not reveal.
+         *     Read access is checked first so unreadable maps keep answering 404
+         *     (SEC-007 existence-hiding); readable non-owners get 403.
          */
         get: operations["visibility_check_endpoint_maps__map_id__visibility_check__get"];
         put?: never;

--- a/scripts/backup-entrypoint.sh
+++ b/scripts/backup-entrypoint.sh
@@ -79,6 +79,11 @@ run_backup() {
     local filename="${POSTGRES_DB}_${timestamp}.dump"
     local filepath="${DAILY_DIR}/${filename}"
 
+    # Orphaned .tmp dumps (pg_dump killed mid-write) match no prune glob and
+    # would accumulate forever; a new cycle starting means no dump is in
+    # flight, so any leftover .tmp is garbage.
+    rm -f "${DAILY_DIR}"/*.dump.tmp
+
     log "Starting backup: ${filename}"
 
     export PGPASSWORD="${POSTGRES_PASSWORD}"

--- a/scripts/backup-entrypoint.sh
+++ b/scripts/backup-entrypoint.sh
@@ -79,7 +79,7 @@ run_backup() {
     local filename="${POSTGRES_DB}_${timestamp}.dump"
     local filepath="${DAILY_DIR}/${filename}"
 
-    # Orphaned .tmp dumps (pg_dump killed mid-write) match no prune glob and
+    # fix(#819): orphaned .tmp dumps (pg_dump killed mid-write) match no prune glob and
     # would accumulate forever; a new cycle starting means no dump is in
     # flight, so any leftover .tmp is garbage.
     rm -f "${DAILY_DIR}"/*.dump.tmp

--- a/sdks/python/geolens/api/maps/visibility_check_endpoint_maps_map_id_visibility_check_get.py
+++ b/sdks/python/geolens/api/maps/visibility_check_endpoint_maps_map_id_visibility_check_get.py
@@ -106,6 +106,11 @@ def sync_detailed(
 
      Check if a map has non-public datasets. Informational only.
 
+    Owner-or-admin like the other sharing mutations: the response names
+    non-public dataset titles, which read access alone must not reveal.
+    Read access is checked first so unreadable maps keep answering 404
+    (SEC-007 existence-hiding); readable non-owners get 403.
+
     Args:
         map_id (UUID):
 
@@ -137,6 +142,11 @@ def sync(
 
      Check if a map has non-public datasets. Informational only.
 
+    Owner-or-admin like the other sharing mutations: the response names
+    non-public dataset titles, which read access alone must not reveal.
+    Read access is checked first so unreadable maps keep answering 404
+    (SEC-007 existence-hiding); readable non-owners get 403.
+
     Args:
         map_id (UUID):
 
@@ -162,6 +172,11 @@ async def asyncio_detailed(
     """Visibility Check Endpoint
 
      Check if a map has non-public datasets. Informational only.
+
+    Owner-or-admin like the other sharing mutations: the response names
+    non-public dataset titles, which read access alone must not reveal.
+    Read access is checked first so unreadable maps keep answering 404
+    (SEC-007 existence-hiding); readable non-owners get 403.
 
     Args:
         map_id (UUID):
@@ -191,6 +206,11 @@ async def asyncio(
     """Visibility Check Endpoint
 
      Check if a map has non-public datasets. Informational only.
+
+    Owner-or-admin like the other sharing mutations: the response names
+    non-public dataset titles, which read access alone must not reveal.
+    Read access is checked first so unreadable maps keep answering 404
+    (SEC-007 existence-hiding); readable non-owners get 403.
 
     Args:
         map_id (UUID):

--- a/sdks/typescript/src/client/sdk.gen.ts
+++ b/sdks/typescript/src/client/sdk.gen.ts
@@ -4156,6 +4156,11 @@ export const uploadThumbnailMapsMapIdThumbnailPut = <ThrowOnError extends boolea
  * Visibility Check Endpoint
  *
  * Check if a map has non-public datasets. Informational only.
+ *
+ * Owner-or-admin like the other sharing mutations: the response names
+ * non-public dataset titles, which read access alone must not reveal.
+ * Read access is checked first so unreadable maps keep answering 404
+ * (SEC-007 existence-hiding); readable non-owners get 403.
  */
 export const visibilityCheckEndpointMapsMapIdVisibilityCheckGet = <ThrowOnError extends boolean = false>(options: Options<VisibilityCheckEndpointMapsMapIdVisibilityCheckGetData, ThrowOnError>): RequestResult<VisibilityCheckEndpointMapsMapIdVisibilityCheckGetResponses, VisibilityCheckEndpointMapsMapIdVisibilityCheckGetErrors, ThrowOnError> => (options.client ?? client).get<VisibilityCheckEndpointMapsMapIdVisibilityCheckGetResponses, VisibilityCheckEndpointMapsMapIdVisibilityCheckGetErrors, ThrowOnError>({
     security: [


### PR DESCRIPTION
Pre-tag fixes from the full deep-dive audit of main @ 213ffcb58 (six-dimension code sweep + live browser pass). Three items block the v1.6.0 tag; the rest are small, high-value folds found by the same sweep.

## Tag blockers

- **npm SDK publish could not authenticate.** #813 removed the `npm install -g npm@latest` step from `publish-sdks.yml` but kept Node 22 (npm 10.x). npm OIDC Trusted Publishing requires npm >= 11.5.1 and the publish step has no `NODE_AUTH_TOKEN` fallback, so `@geolens/sdk@1.6.0` would have failed after everything else published. Now Node 24 (npm 11), with the stale comments corrected.
- **CHANGELOG `Unreleased` was missing shipped changes** that `release.yml` publishes verbatim as the Release body: all of #801 (#770 JSON-apply zoom reset, #769 phantom legend groups, #780 first-run empty-state copy), the Add-Data-stays-open flow (#776), and the `BACKUP_MAX_AGE_MINUTES` name in the backup healthcheck entry. Added, plus a Dependencies note.
- **Tile-auth recovery misread its own cooldown (new in 1.6.0).** MapLibre fires one error per failing tile, so tiles 2..N of the burst that triggered a token re-mint returned `false` ("cooldown") and latched a permanent "Preview unavailable" overlay on the dataset preview — over a map the in-flight re-mint was about to fix — and raised the viewer's error toast on the same happy path. Errors inside a 10 s settle window now ride the pending re-mint; only errors that persist past it fall through to the error UI. Hook tests updated to pin all three phases.

## Access-control hardening (latent, predates 1.6.0)

- `GET /maps/{id}/visibility-check/` is now owner-or-admin like its four file-siblings — its response names non-public dataset titles, which read access alone should not reveal. Unreadable maps keep answering 404 (SEC-007 existence-hiding); readable non-owners get 403. Regression test added.
- Embed-token CRUD now carries the same `edit_metadata` gate as `share_map_endpoint`: an embed token is an anonymous tile capability that outranks the share link it accompanies, so it must not be gated weaker. Regression test asserts 403 (permission gate) rather than 404 (ownership) on all four endpoints.

## Also

- ViewerMap attaches `Authorization: Bearer` for `/raster-tiles/` like BuilderMap/DatasetMap — private rasters now render for signed-in users on the viewer surface (incl. builder "View as viewer").
- `backup-entrypoint.sh` clears orphaned `*.dump.tmp` files at cycle start (they match no prune glob, so a killed `pg_dump` leaked one forever).
- `builder:style.heightColumn` added to all four locales (was `defaultValue`-only).
- Docs: UPGRADING/RUNBOOK/`.env.example` cover the backup fail-fast behaviors new in 1.6.0 (retention must be >= 1 at boot; S3 enabled with blank credentials fails the cycle); the staging-tar failure log-marker row and the freshness success criteria are corrected; restore validation is described as `pg_restore -f /dev/null` everywhere; AGENTS.md's stale 60% coverage floor reads 80%.

## API/schema impact

- OpenAPI + generated SDKs: description text of the visibility-check operation only (regenerated in this PR).
- Behavioral: embed-token CRUD returns 403 for callers without `edit_metadata`; visibility-check returns 403 for readable non-owners (previously 200). Both endpoints are only reachable from owner-facing sharing UI, so no frontend change is needed.

## Verification

- `cd frontend && npm run typecheck && npm run lint && npx vitest run` — 346 files / 3972 tests green, plus `npm run test:i18n`.
- `cd backend && uv run ruff check . && uv run ruff format --check .` — clean.
- Backend (dev DB): `pytest tests/test_maps_visibility_check_authz_sec007.py tests/test_embed_tokens.py tests/test_shared_map_embed_scope.py tests/test_embed_revocation_by_map.py tests/test_embed_token_expiry_cache.py tests/test_embed_tokens_origin_bypass.py tests/test_embed_frame_policy.py tests/test_embed_framing_csp.py tests/test_embed_tokens_csp_no_wildcard.py tests/test_redirect_slashes.py tests/test_maps.py` — 224 passed.
- `make openapi` regenerated; `cd sdks/typescript && npm run build && npm test` green.
- `bash -n scripts/backup-entrypoint.sh` clean.