### PR TITLE
fix(backup): tolerate tar live-write skew instead of failing the cycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and releases use semantic versioning.
 
 ## [Unreleased]
 
+### Fixed
+
+- **A backup cycle no longer fails just because the instance was busy.**
+  Anything writing to object storage while the backup archived it made tar
+  report "file changed as we read it", and the cycle treated that warning
+  as fatal: it deleted the (fully written) archive and left the backup
+  container unhealthy under the new freshness probe. The warning now keeps
+  the archive and the cycle; only a fatal tar error (exit 2+) fails it.
+  (#843)
+
 ## [1.6.0] - 2026-07-28
 
 ### Added

--- a/backend/tests/test_backup_staging_tar_skew.py
+++ b/backend/tests/test_backup_staging_tar_skew.py
@@ -1,0 +1,93 @@
+"""fix(#843): backup_staging must tolerate tar's live-write-skew exit (1).
+
+GNU tar exits 1 ("some files differ", e.g. "file changed as we read it") when
+api/worker write to the staging volume mid-archive; the archive is still fully
+written and every quiescent file in it is sound. Only exit >= 2 is a fatal tar
+error. Before the fix, exit 1 deleted the archive and failed the cycle, so the
+fix(#712) freshness healthcheck sat unhealthy on any busy install.
+
+These tests run the REAL backup_staging function — extracted from
+scripts/backup-entrypoint.sh at test time so the harness cannot drift — against
+a stub tar forced to each exit code.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+from pathlib import Path
+
+from tests.repo_paths import repo_root
+
+REPO_ROOT = repo_root(__file__)
+SCRIPT = REPO_ROOT / "scripts" / "backup-entrypoint.sh"
+
+
+def _extract_backup_staging() -> str:
+    source = SCRIPT.read_text(encoding="utf-8")
+    match = re.search(r"^backup_staging\(\) \{.*?^\}", source, re.DOTALL | re.MULTILINE)
+    assert match, (
+        f"backup_staging() not found in {SCRIPT}; if the function was renamed "
+        f"or moved, update this test."
+    )
+    return match.group(0)
+
+
+def _run_cycle(
+    tmp_path: Path, tar_exit: int
+) -> tuple[subprocess.CompletedProcess, Path]:
+    staging = tmp_path / "staging"
+    daily = tmp_path / "daily"
+    weekly = tmp_path / "weekly"
+    bin_dir = tmp_path / "bin"
+    for d in (staging, daily, weekly, bin_dir):
+        d.mkdir()
+    (staging / "object.bin").write_bytes(b"payload")
+
+    # Stub tar mirrors real tar's exit-1 behavior: the archive IS written.
+    # Invocation shape is `tar czf <archive> -C <dir> .` so $2 is the archive.
+    tar_stub = bin_dir / "tar"
+    tar_stub.write_text(f'#!/bin/sh\necho stub-archive > "$2"\nexit {tar_exit}\n')
+    tar_stub.chmod(0o755)
+
+    harness = (
+        "set -euo pipefail\n"
+        'log() { echo "$@" >&2; }\n'
+        f'STAGING_DIR="{staging}"\n'
+        f'DAILY_DIR="{daily}"\n'
+        f'WEEKLY_DIR="{weekly}"\n'
+        f"{_extract_backup_staging()}\n"
+        'backup_staging "20260728_000000"\n'
+    )
+    result = subprocess.run(
+        ["bash", "-c", harness],
+        capture_output=True,
+        text=True,
+        env={"PATH": f"{bin_dir}:/usr/bin:/bin"},
+    )
+    archive = daily / "staging-20260728_000000.tar.gz"
+    return result, archive
+
+
+class TestBackupStagingTarSkew:
+    def test_tar_success_archives_and_prints_path(self, tmp_path: Path):
+        result, archive = _run_cycle(tmp_path, tar_exit=0)
+        assert result.returncode == 0, result.stderr
+        assert archive.exists()
+        assert str(archive) in result.stdout
+
+    def test_tar_live_write_skew_keeps_archive_and_succeeds(self, tmp_path: Path):
+        """Exit 1 = files changed mid-archive: warn, keep the archive, continue."""
+        result, archive = _run_cycle(tmp_path, tar_exit=1)
+        assert result.returncode == 0, result.stderr
+        assert archive.exists()
+        assert str(archive) in result.stdout
+        assert "WARNING" in result.stderr
+        assert "ERROR" not in result.stderr
+
+    def test_tar_fatal_error_removes_archive_and_fails(self, tmp_path: Path):
+        """Exit >= 2 = fatal tar error: the cycle must still fail."""
+        result, archive = _run_cycle(tmp_path, tar_exit=2)
+        assert result.returncode != 0
+        assert not archive.exists()
+        assert "ERROR: object-storage archive failed" in result.stderr

--- a/scripts/backup-entrypoint.sh
+++ b/scripts/backup-entrypoint.sh
@@ -130,7 +130,7 @@ run_backup() {
 
     # BKP-01: archive the object-storage staging volume alongside the dump.
     # Named with the SAME timestamp as the dump so restore can pair them.
-    # A tar failure marks the cycle failed (like the S3 path below) rather than
+    # A fatal tar failure marks the cycle failed (like the S3 path below) rather than
     # returning early: retention pruning further down must always run, and the
     # `|| cycle_failed=1` also keeps `set -e` from aborting on the non-zero
     # command substitution. The cycle then exits non-zero and `.last-success`
@@ -209,20 +209,31 @@ backup_staging() {
     # as we read it" when api/worker write temp files mid-archive) reaches the
     # container log instead of vanishing.
     log "Archiving object storage: $(basename "$archive")" >&2
-    if tar czf "$archive" -C "$STAGING_DIR" .; then
-        local size
-        size="$(du -h "$archive" | cut -f1)"
-        log "Object-storage archive complete: $(basename "$archive") (${size})" >&2
-        if [ "$(date '+%u')" = "7" ]; then
-            cp "$archive" "${WEEKLY_DIR}/$(basename "$archive")"
-            log "Weekly object-storage copy saved: $(basename "$archive")" >&2
-        fi
-        printf '%s\n' "$archive"
-    else
+    local tar_rc=0
+    tar czf "$archive" -C "$STAGING_DIR" . || tar_rc=$?
+    # fix(#843): GNU tar exit 1 means "some files differ" — api/worker wrote
+    # to staging mid-archive. The archive IS written and every quiescent file
+    # in it is sound; only files caught mid-write are fuzzy and re-archive
+    # next cycle. Failing the whole cycle on exit 1 traded a usable DB dump +
+    # near-complete staging archive for nothing, and on a busy install the
+    # freshness healthcheck sat unhealthy indefinitely. Only exit >= 2
+    # (fatal tar error) fails the cycle.
+    if [ "$tar_rc" -ge 2 ]; then
         log "ERROR: object-storage archive failed — this cycle will be reported as failed" >&2
         rm -f "$archive"
         return 1
     fi
+    if [ "$tar_rc" -eq 1 ]; then
+        log "WARNING: staging changed during archiving (tar exit 1) — archive kept; changed files re-archive next cycle" >&2
+    fi
+    local size
+    size="$(du -h "$archive" | cut -f1)"
+    log "Object-storage archive complete: $(basename "$archive") (${size})" >&2
+    if [ "$(date '+%u')" = "7" ]; then
+        cp "$archive" "${WEEKLY_DIR}/$(basename "$archive")"
+        log "Weekly object-storage copy saved: $(basename "$archive")" >&2
+    fi
+    printf '%s\n' "$archive"
 }
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

A backup cycle failed whenever anything wrote to the object-storage staging volume during the tar pass. GNU tar exits 1 for "file changed as we read it" — a warning, with the archive fully written — but `backup_staging()` treated any nonzero exit as fatal: it deleted the archive, failed the cycle, never touched `.last-success`, and the #712 freshness healthcheck reported the container unhealthy. Observed live on the demo VM minutes after the 1.6.0 redeploy: the initial on-startup cycle raced the freshly restarted api/worker during a 56-second tar of 1.2G; a re-run on the settled system passed and went healthy.

Tar's exit codes are now distinguished: 0 succeeds as before; 1 keeps the archive, logs a warning ("staging changed during archiving"), and continues the cycle — files caught mid-write re-archive next cycle; 2 and above deletes the partial archive and fails, as before.

## Tests

`backend/tests/test_backup_staging_tar_skew.py` extracts the real `backup_staging` function from the script at test time (no embedded copy to drift) and drives it with a stub tar at exits 0/1/2, asserting archive kept + cycle success on 1 and archive removed + cycle failure on 2. `bash -n` clean, ruff clean.

Closes #843
