### PR TITLE
fix(api): strip root_path in the slowapi lazy-route fallback

### DIFF
--- a/backend/app/api/main.py
+++ b/backend/app/api/main.py
@@ -772,7 +772,17 @@ def _find_route_handler_with_lazy_includes(routes, scope):
         return handler
     from fastapi.routing import iter_route_contexts
 
+    # Route regexes never include the ASGI root_path, and starlette's own
+    # matching strips it (starlette._utils.get_route_path — mirrored here to
+    # avoid the private import). Without this, rewrite-less deployments that
+    # keep the /api prefix via ROOT_PATH would silently lose the global
+    # default rate limit again (Codex P2 on #747).
     path = scope.get("path", "")
+    root_path = scope.get("root_path", "")
+    if root_path and path.startswith(root_path):
+        stripped = path[len(root_path) :]
+        if not stripped or stripped.startswith("/"):
+            path = stripped
     method = scope.get("method", "")
     for ctx in iter_route_contexts(list(routes)):
         path_regex = getattr(ctx, "path_regex", None)

--- a/backend/tests/test_middleware.py
+++ b/backend/tests/test_middleware.py
@@ -110,6 +110,33 @@ async def test_rate_limiting(client: AsyncClient):
         limiter._default_limits = original_limits
 
 
+def test_lazy_route_handler_resolution_strips_root_path():
+    """fix(#747 Codex P2): rewrite-less ROOT_PATH deployments keep the /api
+    prefix in scope['path']; the lazy-include fallback must strip root_path
+    the way starlette's matcher does, or nested routes resolve to no handler
+    and the global default rate limit silently stops applying to them."""
+    from app.api.main import _find_route_handler_with_lazy_includes, app
+
+    plain = {
+        "type": "http",
+        "method": "GET",
+        "path": "/conformance",
+        "root_path": "",
+        "headers": [],
+    }
+    prefixed = {
+        "type": "http",
+        "method": "GET",
+        "path": "/api/conformance",
+        "root_path": "/api",
+        "headers": [],
+    }
+    assert _find_route_handler_with_lazy_includes(app.routes, plain) is not None
+    assert _find_route_handler_with_lazy_includes(
+        app.routes, prefixed
+    ) is _find_route_handler_with_lazy_includes(app.routes, plain)
+
+
 @pytest.mark.anyio
 async def test_rate_limit_health_excluded(client: AsyncClient):
     """GET /health is not subject to the tight global default rate limit.


### PR DESCRIPTION
Follow-up to the Codex P2 on #747 (posted after that PR merged).

## What

The lazy-include fallback added in #747 matched route regexes against the raw `scope["path"]`. Route regexes never include the ASGI root_path, and starlette's own matcher strips it before comparing. In rewrite-less deployments that keep the `/api` prefix via ROOT_PATH (direct-container or custom reverse proxies; the checked nginx config rewrites the prefix away), the fallback resolved no handler and slowapi treated nested routes as exempt from the global default rate limit.

The fix mirrors starlette's `get_route_path` semantics inline (avoiding the private import): strip `root_path` only when the remainder is empty or starts with `/`.

## Verification

- New regression test `test_lazy_route_handler_resolution_strips_root_path` asserts a `/api`-prefixed scope with `root_path="/api"` resolves to the same handler as the unprefixed scope.
- `uv run pytest tests/test_middleware.py` passes (16 tests, including the existing global rate-limit test).
- ruff check and format pass.

https://claude.ai/code/session_01A8vNJqrsio7yP5vWNhauVg