### PR TITLE
fix(dataset): use fixed-height rows in AttributeTable to stop the AX-attached render loop

### DIFF
--- a/e2e/attribute-table-ax.spec.ts
+++ b/e2e/attribute-table-ax.spec.ts
@@ -1,0 +1,58 @@
+import { test, expect } from '@playwright/test';
+import { getAuthToken } from './helpers/catalog';
+
+const BASE_URL = process.env.E2E_BASE_URL ?? 'http://localhost:8080';
+
+// fix(#820): with the Chrome CDP Accessibility domain enabled (a real screen
+// reader, or any AX-attached automation), clicking the Data tab on a vector
+// dataset locked React in an infinite synchronous re-render loop — the
+// measureElement dynamic-measurement ref in AttributeTable fed back
+// measure→layout→re-render on every AX-tree pass. This spec replays that exact
+// trigger and asserts the page stays responsive.
+test.describe('AttributeTable with an accessibility client attached (#820)', () => {
+  let datasetId: string;
+
+  test.beforeAll(async () => {
+    const headers = { Authorization: `Bearer ${getAuthToken()}` };
+    const res = await fetch(`${BASE_URL}/api/datasets/?limit=10`, { headers });
+    expect(res.ok).toBe(true);
+    const data = await res.json();
+    const datasets = data.datasets ?? data.items ?? data;
+    const vector = datasets.filter(
+      (ds: { record_type?: string }) => ds.record_type === 'vector_dataset',
+    );
+    const ds = vector[0] ?? datasets[0];
+    expect(ds).toBeTruthy();
+    datasetId = ds.id;
+  });
+
+  test('Data tab stays responsive with the CDP Accessibility domain enabled', async ({
+    page,
+    context,
+  }) => {
+    await page.goto(`/datasets/${datasetId}`);
+    const dataTab = page.getByRole('tab', { name: 'Data', exact: true });
+    await dataTab.waitFor();
+
+    // The trigger: attach the AX tree, exactly like a screen reader or
+    // aria-snapshot tooling does. Without this the bug never fires.
+    const cdp = await context.newCDPSession(page);
+    await cdp.send('Accessibility.enable');
+
+    // noWaitAfter: if the renderer freezes, a normal click would hang the
+    // test inside the actionability wait instead of reaching the assertion.
+    await dataTab.click({ noWaitAfter: true, timeout: 5_000 });
+
+    // A frozen renderer never answers this CDP roundtrip; race it against a
+    // timeout so the failure mode is an assertion, not a test timeout.
+    const alive = await Promise.race([
+      page.title().then(() => true),
+      new Promise<boolean>((resolve) => setTimeout(() => resolve(false), 10_000)),
+    ]);
+    expect(alive, 'page froze after clicking the Data tab with AX attached').toBe(true);
+
+    // The table actually rendered — attribute rows are inside the virtualized
+    // body, and the table itself carries an accessible name.
+    await expect(page.getByRole('table').first()).toBeVisible({ timeout: 15_000 });
+  });
+});

--- a/frontend/src/components/dataset/AttributeTable.tsx
+++ b/frontend/src/components/dataset/AttributeTable.tsx
@@ -311,6 +311,12 @@ export function AttributeTable({ datasetId, canEdit = false, compact = false }: 
   // post-filter row model from TanStack Table — sort/filter state changes flow
   // through naturally on each render via `count: rows.length`.
   const rows = table.getRowModel().rows;
+  // fix(#820): fixed-height rows only — never reintroduce dynamic row
+  // measurement here. With a Chrome AX tree attached (screen reader, CDP
+  // Accessibility.enable), the measure→layout→re-render edge fed back
+  // synchronously and locked the page in an infinite render loop. Rows are
+  // visually fixed-height, so estimateSize is the row height; keep it in
+  // sync with the row styles.
   const virtualizer = useVirtualizer({
     count: rows.length,
     getScrollElement: () => parentRef.current,
@@ -468,10 +474,6 @@ export function AttributeTable({ datasetId, canEdit = false, compact = false }: 
                   return (
                     <TableRow
                       key={row.id}
-                      data-index={virtualRow.index}
-                      ref={(el) => {
-                        if (el) virtualizer.measureElement(el);
-                      }}
                       className={virtualRow.index % 2 === 1 ? 'bg-muted/30' : ''}
                       style={{
                         // Shift each rendered <tr> from its document-flow position

--- a/frontend/src/components/dataset/AttributeTable.tsx
+++ b/frontend/src/components/dataset/AttributeTable.tsx
@@ -337,6 +337,21 @@ export function AttributeTable({ datasetId, canEdit = false, compact = false }: 
   });
   const virtualItems = virtualizer.getVirtualItems();
 
+  // fix(#851): TanStack Virtual (virtual-core 3.17.x) does not include
+  // estimateSize in its measurement-cache deps (getMeasurementOptions covers
+  // count/padding/scrollMargin/getItemKey/enabled/lanes/gap only), so when
+  // the density toggle flips rowHeight 44↔28 the cells resize immediately but
+  // getTotalSize() and item offsets keep the old density. measure() is the
+  // documented reset: it clears the item-size cache and recomputes. Skip the
+  // mount pass — the initial layout is already built from the right size.
+  const prevCompactRef = useRef(compact);
+  useEffect(() => {
+    if (prevCompactRef.current !== compact) {
+      prevCompactRef.current = compact;
+      virtualizer.measure();
+    }
+  }, [compact, virtualizer]);
+
   const approximateTotal = data?.approximate_total ?? 0;
   const rowCount = data?.rows?.length ?? 0;
   const effectiveTotal = approximateTotal > 0 ? approximateTotal : rowCount;

--- a/frontend/src/components/dataset/AttributeTable.tsx
+++ b/frontend/src/components/dataset/AttributeTable.tsx
@@ -58,6 +58,7 @@ function InlineCellEditor({
   onSave,
   onCancel,
   isSaving,
+  compact,
 }: {
   initialValue: string;
   label: string;
@@ -66,6 +67,7 @@ function InlineCellEditor({
   onSave: (value: string) => void;
   onCancel: () => void;
   isSaving: boolean;
+  compact: boolean;
 }) {
   const inputRef = useRef<HTMLInputElement>(null);
   const [value, setValue] = useState(initialValue);
@@ -109,7 +111,10 @@ function InlineCellEditor({
         onChange={(e) => setValue(e.target.value)}
         onBlur={commit}
         onKeyDown={handleKeyDown}
-        className="h-7 text-xs px-1"
+        // fix(#820): the input must fit inside the fixed row height for its
+        // density mode (44px default / 28px compact) so an open editor cannot
+        // stretch the row past the virtualizer's per-mode row size.
+        className={`${compact ? 'h-6' : 'h-7'} text-xs px-1`}
         // fix(#458 E-39): name the editor (column + row) and tie the rejection
         // reason to the field so it isn't just a transient toast for SR users.
         aria-label={label}
@@ -257,6 +262,7 @@ export function AttributeTable({ datasetId, canEdit = false, compact = false }: 
                 setEditingCell(null);
               }}
               isSaving={updateFeature.isPending}
+              compact={compact}
             />
           );
         }
@@ -292,7 +298,7 @@ export function AttributeTable({ datasetId, canEdit = false, compact = false }: 
         return cellValue;
       },
     }));
-  }, [data?.columns, canEdit, handleCellSave, updateFeature.isPending, editError, t]);
+  }, [data?.columns, canEdit, compact, handleCellSave, updateFeature.isPending, editError, t]);
 
   // eslint-disable-next-line react-hooks/incompatible-library -- TanStack Table returns imperative helpers; this component keeps table state local.
   const table = useReactTable({
@@ -314,13 +320,19 @@ export function AttributeTable({ datasetId, canEdit = false, compact = false }: 
   // fix(#820): fixed-height rows only — never reintroduce dynamic row
   // measurement here. With a Chrome AX tree attached (screen reader, CDP
   // Accessibility.enable), the measure→layout→re-render edge fed back
-  // synchronously and locked the page in an infinite render loop. Rows are
-  // visually fixed-height, so estimateSize is the row height; keep it in
-  // sync with the row styles.
+  // synchronously and locked the page in an infinite render loop.
+  //
+  // The row height is enforced, not estimated: each body cell carries an
+  // explicit height class (h-11 / h-7 below) matching this value, and in a
+  // collapsed-border table an explicit cell height yields exactly that row
+  // pitch (measured in Chromium: 44/28px in both densities, editor open or
+  // not — the border is absorbed into the specified height). Keep rowHeight
+  // and the cell height classes in lockstep.
+  const rowHeight = compact ? 28 : 44;
   const virtualizer = useVirtualizer({
     count: rows.length,
     getScrollElement: () => parentRef.current,
-    estimateSize: () => 36,
+    estimateSize: () => rowHeight,
     overscan: 8,
   });
   const virtualItems = virtualizer.getVirtualItems();
@@ -350,7 +362,10 @@ export function AttributeTable({ datasetId, canEdit = false, compact = false }: 
     );
   }
 
-  const cellPadding = compact ? 'py-1 text-xs' : 'py-3';
+  // fix(#820): exact per-density cell height (py-0 + h-*) instead of padding,
+  // so real row pitch always equals `rowHeight` and the virtualizer's offset
+  // math stays correct without dynamic measurement.
+  const cellClass = compact ? 'h-7 py-0 text-xs' : 'h-11 py-0';
 
   return (
     <div className="space-y-3">
@@ -484,7 +499,7 @@ export function AttributeTable({ datasetId, canEdit = false, compact = false }: 
                       }}
                     >
                       {row.getVisibleCells().map((cell) => (
-                        <TableCell key={cell.id} className={`max-w-xs truncate ${cellPadding}`}>
+                        <TableCell key={cell.id} className={`max-w-xs truncate ${cellClass}`}>
                           {flexRender(cell.column.columnDef.cell, cell.getContext())}
                         </TableCell>
                       ))}

--- a/frontend/src/components/dataset/__tests__/AttributeTable.test.tsx
+++ b/frontend/src/components/dataset/__tests__/AttributeTable.test.tsx
@@ -96,8 +96,8 @@ describe('PERF-07: AttributeTable virtualization wiring', () => {
     expect(attributeTableSrc).toMatch(/virtualizer\.getTotalSize\(\)/);
   });
 
-  it('preserves cellPadding and existing column visibility logic', () => {
-    expect(attributeTableSrc).toMatch(/cellPadding/);
+  it('preserves per-density cell classes and existing column visibility logic', () => {
+    expect(attributeTableSrc).toMatch(/cellClass/);
     expect(attributeTableSrc).toMatch(/columnVisibility/);
   });
 
@@ -107,6 +107,16 @@ describe('PERF-07: AttributeTable virtualization wiring', () => {
   // measureElement reintroduces the freeze. Live coverage: e2e/attribute-table-ax.spec.ts.
   it('does not use measureElement / dynamic row measurement', () => {
     expect(attributeTableSrc).not.toContain('measureElement');
+  });
+
+  // fix(#820): with measurement gone, the virtualizer's row size and the
+  // rendered row height must agree by construction. The row height is derived
+  // from the density mode (44px default / 28px compact, measured in Chromium)
+  // and enforced on the cells via matching height classes (h-11 / h-7, py-0).
+  it('derives the virtualizer row size from the density mode and enforces it on the cells', () => {
+    expect(attributeTableSrc).toMatch(/rowHeight = compact \? 28 : 44/);
+    expect(attributeTableSrc).toMatch(/estimateSize: \(\) => rowHeight/);
+    expect(attributeTableSrc).toMatch(/compact \? 'h-7 py-0 text-xs' : 'h-11 py-0'/);
   });
 });
 

--- a/frontend/src/components/dataset/__tests__/AttributeTable.test.tsx
+++ b/frontend/src/components/dataset/__tests__/AttributeTable.test.tsx
@@ -118,6 +118,13 @@ describe('PERF-07: AttributeTable virtualization wiring', () => {
     expect(attributeTableSrc).toMatch(/estimateSize: \(\) => rowHeight/);
     expect(attributeTableSrc).toMatch(/compact \? 'h-7 py-0 text-xs' : 'h-11 py-0'/);
   });
+
+  // fix(#851): virtual-core does not invalidate its measurement cache when
+  // estimateSize changes, so a density toggle must explicitly call
+  // virtualizer.measure() or totals/offsets keep the old row height.
+  it('resets cached row sizes when the density mode changes', () => {
+    expect(attributeTableSrc).toMatch(/virtualizer\.measure\(\)/);
+  });
 });
 
 // ── fix(#458 E-35/E-39/E-51) source contracts ────────────────────────────────

--- a/frontend/src/components/dataset/__tests__/AttributeTable.test.tsx
+++ b/frontend/src/components/dataset/__tests__/AttributeTable.test.tsx
@@ -100,6 +100,14 @@ describe('PERF-07: AttributeTable virtualization wiring', () => {
     expect(attributeTableSrc).toMatch(/cellPadding/);
     expect(attributeTableSrc).toMatch(/columnVisibility/);
   });
+
+  // fix(#820): dynamic measurement (measureElement) fed back synchronously
+  // (measure→layout→re-render) when a Chrome AX tree was attached, freezing
+  // the page in an infinite render loop. Rows are fixed-height; reintroducing
+  // measureElement reintroduces the freeze. Live coverage: e2e/attribute-table-ax.spec.ts.
+  it('does not use measureElement / dynamic row measurement', () => {
+    expect(attributeTableSrc).not.toContain('measureElement');
+  });
 });
 
 // ── fix(#458 E-35/E-39/E-51) source contracts ────────────────────────────────


### PR DESCRIPTION
## What

Removes dynamic row measurement (`measureElement` + `data-index`) from `AttributeTable` and runs the virtualizer on truly fixed-height rows. Per Codex's review finding, the flat 36px estimate did not match the rendered rows (~45px default, ~25px compact, up to 53px with the editor open), so the follow-up commit derives the row height from the density mode (44px default / 28px compact) and enforces it by construction: body cells carry matching explicit height classes (`h-11` / `h-7` with `py-0`), and the inline editor input drops to `h-6` in compact mode so an open editor can never stretch a row. In a collapsed-border table an explicit cell height yields exactly that row pitch — measured in headless Chromium for both densities, editor open and closed. Compact rows go from ~25px to a 28px pitch; otherwise visuals are unchanged.

## Root cause

With the Chrome CDP `Accessibility` domain enabled (a real screen reader, or AX-attached automation), clicking the Data tab on a vector dataset locked the renderer at ~100% CPU in an infinite synchronous React re-render loop (`processRootScheduleInMicrotask → flushSyncWorkAcrossRoots → renderRootSync` spinning inside one microtask). The feedback edge was the dynamic-measurement ref callback: with the AX tree attached, measurement→layout→re-render fed back synchronously and never yielded, and never tripped React's max-update-depth guard because each pass was a fresh synchronous root render. Dropping `measureElement` removes the edge entirely. Dataset-size-independent and latent since at least 1.5.1.

## Tests

- Unit: source-contract tests locking `measureElement` out of `AttributeTable.tsx` and locking the rowHeight/estimateSize/cell-class agreement (same `?raw` pattern as the PERF-07 suite; jsdom can't reproduce the layout feedback).
- E2E: new `e2e/attribute-table-ax.spec.ts` replays the exact trigger — `context.newCDPSession(page)` + `Accessibility.enable`, click the Data tab on a vector dataset, assert `page.title()` still resolves and the table renders. Not added to a smoke bundle; runs in the full suite.

## Impact

Frontend-only. No schema, API, or config changes.

## Verification

- `cd frontend && npm ci && npm run lint` — pass
- `cd frontend && npm run typecheck` — pass
- `cd frontend && npx vitest run src/components/dataset` — 29 files, 201 tests pass

Closes #820

https://claude.ai/code/session_01A8vNJqrsio7yP5vWNhauVg
