### PR TITLE
fix(export): return 4xx for colon in 'where' and validate layer_name before ogr2ogr

### DIFF
--- a/backend/app/processing/export/router.py
+++ b/backend/app/processing/export/router.py
@@ -90,6 +90,12 @@ async def _count_selected_features(
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail=str(e),
             )
+        # fix(#823): mirror parquet.py — text() reads ":name" as a bind param,
+        # so a colon inside a validated string literal (e.g. name = 'A:B' or an
+        # ISO timestamp) misparsed as an unbound parameter and 500'd. Escape to
+        # text()'s literal-colon form (\:); the real :limit/:minx binds below
+        # are added separately and stay unescaped.
+        safe_where = safe_where.replace(":", "\\:")
         clauses.append(f"({safe_where})")
     if bbox is not None and has_geometry and bbox[0] <= bbox[2]:
         # Envelope && only (superset of exact intersects) — errs toward 413.

--- a/backend/app/processing/ingest/layer_guard.py
+++ b/backend/app/processing/ingest/layer_guard.py
@@ -1,0 +1,64 @@
+"""Request-level layer_name validation for the ingest endpoints.
+
+fix(#823): a user-supplied ``layer_name`` (preview query param, vector commit
+body, fan-out request) is forwarded to GDAL argv as a positional token. The
+argv-level backstop lives in ``ogr.validate_layer_name_argv``; these helpers
+give the router endpoints clear 4xx responses before any job state changes.
+
+Kept out of ``router.py`` to respect the Phase 276 CODE-01 router LOC cap
+(decomposition preferred over allowlist growth).
+"""
+
+from typing import TYPE_CHECKING
+
+from fastapi import HTTPException, status
+
+if TYPE_CHECKING:
+    from app.platform.jobs.models import IngestJob
+
+
+def reject_option_like_layer_name(layer_name: str | None) -> None:
+    """422 for layer names starting with '-' (argument-injection hygiene)."""
+    if isinstance(layer_name, str) and layer_name.startswith("-"):
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail="Invalid layer_name: must not start with '-'",
+        )
+
+
+def known_layer_names(job: "IngestJob") -> set[str]:
+    """Normalise job.user_metadata['all_layers'] to a set of layer-name strings.
+
+    all_layers may be a list of dicts ({name: str, ...}) or a list of strings
+    depending on how the preview stored them. Returns an empty set when the
+    preview recorded no layer list (single-layer sources).
+    """
+    all_layers: list = (job.user_metadata or {}).get("all_layers") or []
+    if all_layers and isinstance(all_layers[0], dict):
+        return {lay.get("name", "") for lay in all_layers}
+    return set(all_layers)
+
+
+def validate_commit_layer_name(job: "IngestJob", layer_name: object) -> None:
+    """Guard the single-layer commit endpoint's layer_name (fix(#823)).
+
+    The value is stored in user_metadata and later reaches the worker's
+    ogr2ogr argv — unlike the fan-out endpoint, it previously had no
+    validation. Rejects option-like names outright and names absent from the
+    preview's all_layers when that list exists (single-layer sources never
+    record all_layers, so they get the dash guard only; the argv-level guard
+    in ogr.py backstops the worker regardless).
+    """
+    if not isinstance(layer_name, str) or not layer_name:
+        return
+    reject_option_like_layer_name(layer_name)
+    known = known_layer_names(job)
+    if known and layer_name not in known:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail={
+                "message": "Unknown layer name — not found in the uploaded file",
+                "unknown_layers": [layer_name],
+                "available_layers": sorted(known),
+            },
+        )

--- a/backend/app/processing/ingest/ogr.py
+++ b/backend/app/processing/ingest/ogr.py
@@ -119,6 +119,21 @@ class IngestionError(Exception):
     """Raised when an ingestion subprocess fails."""
 
 
+def validate_layer_name_argv(layer_name: str) -> None:
+    """Reject option-like layer names before they reach a GDAL argv.
+
+    fix(#823): layer names are appended to ogrinfo/ogr2ogr argv as positional
+    tokens. A value starting with '-' could be parsed by GDAL as a command-line
+    flag instead of a layer name (argument-injection hygiene; the argv is
+    exec'd directly, never a shell). Called by every spawner in this module
+    that forwards a layer name.
+    """
+    if layer_name.startswith("-"):
+        raise IngestionError(
+            f"Invalid layer name {layer_name!r}: must not start with '-'"
+        )
+
+
 # ---------------------------------------------------------------------------
 # Subprocess timeouts (R-5, R-9)
 # ---------------------------------------------------------------------------
@@ -427,6 +442,8 @@ async def run_ogrinfo(file_path: str, layer_name: str | None = None) -> OgrinfoR
     When multiple layers exist and no layer_name is specified, all_layers lists them.
     Tries JSON output first (GDAL 3.7+), falls back to text parsing.
     """
+    if layer_name:
+        validate_layer_name_argv(layer_name)
     if _is_parquet(file_path):
         from app.processing.ingest.parquet import parquet_info
 
@@ -507,6 +524,8 @@ async def run_ogrinfo_preview(
     Returns dict with keys: srid, geometry_type, layer_name, feature_count,
     columns, sample_rows, all_layers.
     """
+    if layer_name:
+        validate_layer_name_argv(layer_name)
     if _is_parquet(file_path):
         from app.processing.ingest.parquet import parquet_info
 
@@ -594,6 +613,8 @@ async def run_ogr2ogr(
 
     _validate_table_name(table_name)
     _validate_table_name(schema)
+    if layer_name:
+        validate_layer_name_argv(layer_name)
 
     if _is_parquet(file_path):
         from app.processing.ingest.parquet import load_parquet_to_postgis
@@ -739,6 +760,8 @@ async def run_ogr2ogr_service(
 
     _validate_table_name(table_name)
     _validate_table_name(schema)
+    if layer_name:
+        validate_layer_name_argv(layer_name)
     cmd = [
         "ogr2ogr",
         "-f",

--- a/backend/app/processing/ingest/router.py
+++ b/backend/app/processing/ingest/router.py
@@ -615,6 +615,15 @@ async def preview_file(
     For raster files: returns band count, CRS, resolution, compliance status.
     Only callable on jobs with status 'pending'.
     """
+    # fix(#823): layer_name is forwarded to ogrinfo argv as a positional
+    # token; reject option-like values here with a clear 422 (the spawner in
+    # ogr.py has a matching argv-level guard as defense in depth).
+    if layer_name and layer_name.startswith("-"):
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail="Invalid layer_name: must not start with '-'",
+        )
+
     job = await get_job_or_404(db, job_id, user)
 
     if job.status != "pending":
@@ -735,6 +744,19 @@ async def preview_file(
     )
 
 
+def _known_layer_names(job: "IngestJob") -> set[str]:
+    """Normalise job.user_metadata['all_layers'] to a set of layer-name strings.
+
+    all_layers may be a list of dicts ({name: str, ...}) or a list of strings
+    depending on how the preview stored them. Returns an empty set when the
+    preview recorded no layer list (single-layer sources).
+    """
+    all_layers: list = (job.user_metadata or {}).get("all_layers") or []
+    if all_layers and isinstance(all_layers[0], dict):
+        return {lay.get("name", "") for lay in all_layers}
+    return set(all_layers)
+
+
 def _pick_commit_subclass(job: "IngestJob") -> type[BaseCommitRequest]:
     """Return the CommitRequest subclass for the given job.
 
@@ -812,6 +834,31 @@ async def commit_import(
         # level. This branch only fires if a subclass adds stricter
         # per-field rules in a future phase.
         raise RequestValidationError(errors=e.errors())
+
+    # fix(#823): a vector commit's layer_name is stored in user_metadata and
+    # later reaches the worker's ogr2ogr argv unvalidated — unlike the fan-out
+    # endpoint, which checks all_layers. Guard both here: reject option-like
+    # names outright (argument-injection hygiene), and reject names absent
+    # from the preview's all_layers when that list exists (single-layer
+    # sources never record all_layers, so they get the dash guard only; the
+    # argv-level guard in ogr.py backstops the worker regardless).
+    requested_layer = getattr(commit, "layer_name", None)
+    if isinstance(requested_layer, str) and requested_layer:
+        if requested_layer.startswith("-"):
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+                detail="Invalid layer_name: must not start with '-'",
+            )
+        known_layers = _known_layer_names(job)
+        if known_layers and requested_layer not in known_layers:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+                detail={
+                    "message": "Unknown layer name — not found in the uploaded file",
+                    "unknown_layers": [requested_layer],
+                    "available_layers": sorted(known_layers),
+                },
+            )
 
     # Extract token only for service commits (ServiceCommitRequest is the
     # only subclass with a token field). AUTH-04: never persisted.
@@ -892,16 +939,9 @@ async def commit_fan_out(
         )
 
     # Validate all requested layer_names appear in the job's all_layers preview.
-    all_layers: list[str] = (job.user_metadata or {}).get("all_layers", [])
-    # all_layers may be a list of dicts ({name: str, ...}) or a list of strings
-    # depending on how the preview stored them. Normalise to a set of strings.
-    if all_layers and isinstance(all_layers[0], dict):
-        known_layer_names: set[str] = {
-            lay.get("name", "")
-            for lay in all_layers  # type: ignore[union-attr]
-        }
-    else:
-        known_layer_names = set(all_layers)  # type: ignore[arg-type]
+    # fix(#823): normalisation extracted to _known_layer_names, shared with the
+    # single-layer commit endpoint's new layer_name validation.
+    known_layer_names = _known_layer_names(job)
 
     unknown = [
         layer.layer_name

--- a/backend/app/processing/ingest/router.py
+++ b/backend/app/processing/ingest/router.py
@@ -36,6 +36,11 @@ from app.modules.auth.dependencies import get_current_active_user, require_permi
 from app.core.config import settings
 from app.core.db.tenant_session import defer_async_with_tenant
 from app.core.dependencies import get_db
+from app.processing.ingest.layer_guard import (
+    known_layer_names as known_layer_names_for,
+    reject_option_like_layer_name,
+    validate_commit_layer_name,
+)
 from app.processing.ingest.ogr import (
     IngestionError,
     detect_geometry_columns,
@@ -615,14 +620,8 @@ async def preview_file(
     For raster files: returns band count, CRS, resolution, compliance status.
     Only callable on jobs with status 'pending'.
     """
-    # fix(#823): layer_name is forwarded to ogrinfo argv as a positional
-    # token; reject option-like values here with a clear 422 (the spawner in
-    # ogr.py has a matching argv-level guard as defense in depth).
-    if layer_name and layer_name.startswith("-"):
-        raise HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
-            detail="Invalid layer_name: must not start with '-'",
-        )
+    # fix(#823): layer_name reaches ogrinfo argv; 422 option-like values.
+    reject_option_like_layer_name(layer_name)
 
     job = await get_job_or_404(db, job_id, user)
 
@@ -744,19 +743,6 @@ async def preview_file(
     )
 
 
-def _known_layer_names(job: "IngestJob") -> set[str]:
-    """Normalise job.user_metadata['all_layers'] to a set of layer-name strings.
-
-    all_layers may be a list of dicts ({name: str, ...}) or a list of strings
-    depending on how the preview stored them. Returns an empty set when the
-    preview recorded no layer list (single-layer sources).
-    """
-    all_layers: list = (job.user_metadata or {}).get("all_layers") or []
-    if all_layers and isinstance(all_layers[0], dict):
-        return {lay.get("name", "") for lay in all_layers}
-    return set(all_layers)
-
-
 def _pick_commit_subclass(job: "IngestJob") -> type[BaseCommitRequest]:
     """Return the CommitRequest subclass for the given job.
 
@@ -835,30 +821,9 @@ async def commit_import(
         # per-field rules in a future phase.
         raise RequestValidationError(errors=e.errors())
 
-    # fix(#823): a vector commit's layer_name is stored in user_metadata and
-    # later reaches the worker's ogr2ogr argv unvalidated — unlike the fan-out
-    # endpoint, which checks all_layers. Guard both here: reject option-like
-    # names outright (argument-injection hygiene), and reject names absent
-    # from the preview's all_layers when that list exists (single-layer
-    # sources never record all_layers, so they get the dash guard only; the
-    # argv-level guard in ogr.py backstops the worker regardless).
-    requested_layer = getattr(commit, "layer_name", None)
-    if isinstance(requested_layer, str) and requested_layer:
-        if requested_layer.startswith("-"):
-            raise HTTPException(
-                status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
-                detail="Invalid layer_name: must not start with '-'",
-            )
-        known_layers = _known_layer_names(job)
-        if known_layers and requested_layer not in known_layers:
-            raise HTTPException(
-                status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
-                detail={
-                    "message": "Unknown layer name — not found in the uploaded file",
-                    "unknown_layers": [requested_layer],
-                    "available_layers": sorted(known_layers),
-                },
-            )
+    # fix(#823): dash-guard + all_layers membership check for the commit's
+    # layer_name, which reaches the worker's ogr2ogr argv (see layer_guard).
+    validate_commit_layer_name(job, getattr(commit, "layer_name", None))
 
     # Extract token only for service commits (ServiceCommitRequest is the
     # only subclass with a token field). AUTH-04: never persisted.
@@ -939,9 +904,9 @@ async def commit_fan_out(
         )
 
     # Validate all requested layer_names appear in the job's all_layers preview.
-    # fix(#823): normalisation extracted to _known_layer_names, shared with the
-    # single-layer commit endpoint's new layer_name validation.
-    known_layer_names = _known_layer_names(job)
+    # fix(#823): normalisation extracted to layer_guard.known_layer_names,
+    # shared with the single-layer commit endpoint's new validation.
+    known_layer_names = known_layer_names_for(job)
 
     unknown = [
         layer.layer_name

--- a/backend/tests/test_export.py
+++ b/backend/tests/test_export.py
@@ -763,3 +763,100 @@ class TestExportFeatureCap:
             headers=admin_auth_header,
         )
         assert resp.status_code == 400
+
+
+# ---------------------------------------------------------------------------
+# Colon inside a where string literal — fix(#823)
+# ---------------------------------------------------------------------------
+
+
+class TestExportWhereColonLiteral:
+    """fix(#823): SQLAlchemy text() reads ":name" as a bind parameter, so a
+    validated where clause containing a colon inside a string literal (e.g.
+    name = 'A:B' or an ISO timestamp) used to blow up the bounded-count query
+    in _count_selected_features with an unbound-parameter error → 500.
+
+    parquet.py already escaped colons to text()'s literal form; the router's
+    count path now mirrors it. These tests lower the cap so the count query
+    actually executes against a real table.
+    """
+
+    @pytest.fixture
+    async def capped_text_dataset(self, test_db_session, monkeypatch):
+        """Real 3-row table with a varchar column, cap lowered to 2 so the
+        bounded filtered COUNT (the code path that 500'd) runs for real."""
+        from sqlalchemy import text
+
+        from app.processing.export import router as export_router
+
+        monkeypatch.setattr(export_router, "_MAX_EXPORT_FEATURES", 2)
+
+        table_name = f"exp_colon_{uuid.uuid4().hex[:12]}"
+        await test_db_session.execute(
+            text(
+                f"CREATE TABLE data.{table_name} "
+                "(gid serial PRIMARY KEY, name varchar, "
+                "geom geometry(Point, 4326), geom_4326 geometry(Point, 4326))"
+            )
+        )
+        # Values with a colon preceded by a NON-word character: SQLAlchemy's
+        # bind-param regex has a negative lookbehind for word chars, so
+        # '12:34' never misparsed — ' :34' is the shape that did. Inserted via
+        # real bind params so this fixture doesn't trip the same text() parse.
+        await test_db_session.execute(
+            text(
+                f"INSERT INTO data.{table_name} (name, geom, geom_4326) VALUES "
+                "(:n1, ST_SetSRID(ST_MakePoint(0, 0), 4326), "
+                " ST_SetSRID(ST_MakePoint(0, 0), 4326)), "
+                "(:n2, ST_SetSRID(ST_MakePoint(1, 1), 4326), "
+                " ST_SetSRID(ST_MakePoint(1, 1), 4326)), "
+                "(:n3, ST_SetSRID(ST_MakePoint(2, 2), 4326), "
+                " ST_SetSRID(ST_MakePoint(2, 2), 4326))"
+            ).bindparams(n1=" :34", n2=" :78", n3=" :12")
+        )
+        await test_db_session.commit()
+
+        admin_id = await get_user_id(test_db_session, "admin")
+        ds = await _create_dataset(
+            test_db_session,
+            created_by=admin_id,
+            name="ColonWhereDS",
+            table_name=table_name,
+            geometry_type="Point",
+            feature_count=3,
+            column_info=[
+                {"name": "gid", "type": "integer"},
+                {"name": "name", "type": "varchar"},
+            ],
+        )
+        yield ds
+        await test_db_session.execute(text(f"DROP TABLE IF EXISTS data.{table_name}"))
+        await test_db_session.commit()
+
+    @pytest.mark.anyio
+    async def test_colon_in_string_literal_not_500(
+        self, client: AsyncClient, admin_auth_header: dict, capped_text_dataset
+    ):
+        """A colon inside a quoted literal selects 1 of 3 rows (under the cap
+        of 2) and must export cleanly — previously this 500'd as an unbound
+        bind parameter in the count query."""
+        resp = await client.get(
+            f"/datasets/{capped_text_dataset.id}/export",
+            params={"where": "name = ' :34'"},
+            headers=admin_auth_header,
+        )
+        assert resp.status_code == 200, resp.text
+
+    @pytest.mark.anyio
+    async def test_colon_literal_selecting_over_cap_413(
+        self, client: AsyncClient, admin_auth_header: dict, capped_text_dataset
+    ):
+        """A colon literal that fails to narrow the selection still hits the
+        cap's 413 (proves the escaped clause executes, not that it is
+        silently dropped)."""
+        resp = await client.get(
+            f"/datasets/{capped_text_dataset.id}/export",
+            params={"where": "name != ' :99'"},
+            headers=admin_auth_header,
+        )
+        assert resp.status_code == 413

--- a/backend/tests/test_ingest_layer_name_guard.py
+++ b/backend/tests/test_ingest_layer_name_guard.py
@@ -1,0 +1,227 @@
+"""Tests for the fix(#823) layer_name guards.
+
+The v1.6.0 deep audit found that a user-supplied ``layer_name`` reached GDAL
+argv (ogrinfo/ogr2ogr) unvalidated. Two layers of defense were added:
+
+  1. Argv-level guard (``validate_layer_name_argv`` in ingest/ogr.py): every
+     spawner that forwards a layer name rejects option-like values (leading
+     '-') before building the command, so a crafted name can never be parsed
+     as a GDAL flag.
+  2. Router-level 4xx guards: POST /ingest/preview/{job_id} and
+     POST /ingest/commit/{job_id} reject a leading-dash layer_name with 422,
+     and the commit endpoint additionally validates the requested layer_name
+     against the preview's recorded ``all_layers`` (mirroring the existing
+     commit-fan-out check).
+
+Endpoint tests use a real test database (docker compose up db) and mock
+``queue_ingest_job`` so nothing hits Procrastinate or GDAL.
+"""
+
+import uuid
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import select
+
+from app.platform.jobs.models import IngestJob
+from app.processing.ingest.ogr import (
+    IngestionError,
+    run_ogr2ogr,
+    run_ogrinfo,
+    run_ogrinfo_preview,
+    validate_layer_name_argv,
+)
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: argv-level guard
+# ---------------------------------------------------------------------------
+
+
+class TestValidateLayerNameArgv:
+    def test_leading_dash_rejected(self):
+        with pytest.raises(IngestionError) as exc:
+            validate_layer_name_argv("-oo")
+        assert "must not start with '-'" in str(exc.value)
+
+    def test_double_dash_flag_rejected(self):
+        with pytest.raises(IngestionError):
+            validate_layer_name_argv("--config")
+
+    def test_normal_layer_name_accepted(self):
+        validate_layer_name_argv("buildings")
+        validate_layer_name_argv("roads_2024")
+
+    async def test_run_ogrinfo_rejects_before_spawn(self):
+        """The guard fires before any file access or subprocess spawn — the
+        path does not need to exist."""
+        with pytest.raises(IngestionError):
+            await run_ogrinfo("/nonexistent/file.gpkg", layer_name="-oo")
+
+    async def test_run_ogrinfo_preview_rejects_before_spawn(self):
+        with pytest.raises(IngestionError):
+            await run_ogrinfo_preview("/nonexistent/file.gpkg", layer_name="-oo")
+
+    async def test_run_ogr2ogr_rejects_before_spawn(self):
+        with pytest.raises(IngestionError):
+            await run_ogr2ogr(
+                "/nonexistent/file.gpkg",
+                "target_table",
+                "PG:dbname=unused",
+                layer_name="-lco",
+                schema="data",
+            )
+
+
+# ---------------------------------------------------------------------------
+# Endpoint tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def mock_queue_ingest_job():
+    """Prevent real task dispatch for the commit endpoint tests."""
+    with patch(
+        "app.processing.ingest.router.queue_ingest_job", new_callable=AsyncMock
+    ) as m:
+        yield m
+
+
+async def _admin_user_id(session) -> uuid.UUID:
+    from app.modules.auth.models import User
+
+    result = await session.execute(select(User).where(User.username == "admin"))
+    admin = result.scalar_one_or_none()
+    assert admin is not None, "Admin user not found in test DB"
+    return admin.id
+
+
+async def _make_pending_job(
+    session,
+    user_id: uuid.UUID,
+    all_layers: list[str] | None = None,
+    file_path: str = "/tmp/fake-test.gpkg",
+    source_filename: str = "test.gpkg",
+) -> IngestJob:
+    """Insert a pending vector IngestJob, optionally with all_layers recorded."""
+    user_metadata: dict = {"file_type": "vector"}
+    if all_layers is not None:
+        user_metadata["all_layers"] = all_layers
+    job = IngestJob(
+        source_filename=source_filename,
+        file_path=file_path,
+        status="pending",
+        created_by=user_id,
+        user_metadata=user_metadata,
+    )
+    session.add(job)
+    await session.commit()
+    await session.refresh(job)
+    return job
+
+
+class TestCommitLayerNameGuard:
+    async def test_leading_dash_layer_name_422(
+        self, client: AsyncClient, admin_auth_header: dict, test_db_session
+    ):
+        """A layer_name starting with '-' must never reach the worker."""
+        uid = await _admin_user_id(test_db_session)
+        job = await _make_pending_job(
+            test_db_session, uid, all_layers=["buildings", "roads"]
+        )
+        resp = await client.post(
+            f"/ingest/commit/{job.id}",
+            json={"title": "Dash Guard", "layer_name": "-oo"},
+            headers=admin_auth_header,
+        )
+        assert resp.status_code == 422
+        assert "must not start with '-'" in resp.json()["detail"]
+
+    async def test_unknown_layer_name_422_with_available_layers(
+        self, client: AsyncClient, admin_auth_header: dict, test_db_session
+    ):
+        """A layer_name absent from the preview's all_layers is rejected —
+        parity with the commit-fan-out endpoint."""
+        uid = await _admin_user_id(test_db_session)
+        job = await _make_pending_job(
+            test_db_session, uid, all_layers=["buildings", "roads"]
+        )
+        resp = await client.post(
+            f"/ingest/commit/{job.id}",
+            json={"title": "Unknown Layer", "layer_name": "nope"},
+            headers=admin_auth_header,
+        )
+        assert resp.status_code == 422
+        detail = resp.json()["detail"]
+        assert detail["unknown_layers"] == ["nope"]
+        assert detail["available_layers"] == ["buildings", "roads"]
+
+    async def test_known_layer_name_accepted(
+        self, client: AsyncClient, admin_auth_header: dict, test_db_session
+    ):
+        """A layer_name present in all_layers commits normally (202)."""
+        uid = await _admin_user_id(test_db_session)
+        job = await _make_pending_job(
+            test_db_session, uid, all_layers=["buildings", "roads"]
+        )
+        resp = await client.post(
+            f"/ingest/commit/{job.id}",
+            json={"title": "Known Layer", "layer_name": "roads"},
+            headers=admin_auth_header,
+        )
+        assert resp.status_code == 202
+
+    async def test_dict_shaped_all_layers_validated(
+        self, client: AsyncClient, admin_auth_header: dict, test_db_session
+    ):
+        """all_layers stored as dicts ({name, feature_count, ...}) — the real
+        preview shape — is normalised the same way as the fan-out endpoint."""
+        uid = await _admin_user_id(test_db_session)
+        job = await _make_pending_job(
+            test_db_session,
+            uid,
+            all_layers=[
+                {"name": "buildings", "feature_count": 10, "field_count": 3},
+                {"name": "roads", "feature_count": 5, "field_count": 2},
+            ],
+        )
+        resp = await client.post(
+            f"/ingest/commit/{job.id}",
+            json={"title": "Dict Layers", "layer_name": "nope"},
+            headers=admin_auth_header,
+        )
+        assert resp.status_code == 422
+        assert resp.json()["detail"]["available_layers"] == ["buildings", "roads"]
+
+    async def test_no_all_layers_skips_membership_check(
+        self, client: AsyncClient, admin_auth_header: dict, test_db_session
+    ):
+        """Single-layer sources never record all_layers; a stray (non-dash)
+        layer_name is only dash-guarded here — the argv-level guard in ogr.py
+        still backstops the worker."""
+        uid = await _admin_user_id(test_db_session)
+        job = await _make_pending_job(test_db_session, uid, all_layers=None)
+        resp = await client.post(
+            f"/ingest/commit/{job.id}",
+            json={"title": "No Layer List", "layer_name": "whatever"},
+            headers=admin_auth_header,
+        )
+        assert resp.status_code == 202
+
+
+class TestPreviewLayerNameGuard:
+    async def test_leading_dash_layer_name_422(
+        self, client: AsyncClient, admin_auth_header: dict, test_db_session
+    ):
+        """The preview endpoint forwards layer_name to ogrinfo argv; an
+        option-like value is rejected up front with a clear 422."""
+        uid = await _admin_user_id(test_db_session)
+        job = await _make_pending_job(test_db_session, uid)
+        resp = await client.post(
+            f"/ingest/preview/{job.id}",
+            params={"layer_name": "-features"},
+            headers=admin_auth_header,
+        )
+        assert resp.status_code == 422
+        assert "must not start with '-'" in resp.json()["detail"]


### PR DESCRIPTION
Two hardening fixes from the v1.6.0 deep audit. Closes #823.

## Fix 1 — export `where` with a colon returned 500

`_count_selected_features` (the fix(#430 BA-08) oversized-export cap in `backend/app/processing/export/router.py`) interpolated the canonical where fragment into a SQLAlchemy `text()` query without escaping colons. A validated literal with a colon preceded by a non-word character (e.g. `name = ' :34'` — note SQLAlchemy's bind regex has a negative lookbehind for word chars, so `'12:34'` was actually fine) misparsed as an unbound bind parameter and 500'd. The count path now escapes colons to `text()`'s literal form (`\:`), mirroring the handling `parquet.py` has had all along.

## Fix 2 — `layer_name` reached GDAL argv unvalidated

A user-supplied `layer_name` (preview query param, vector commit body) was appended to ogrinfo/ogr2ogr argv as a positional token with no validation. Not shell-exploitable (argv exec, no shell), but a leading-dash value could be parsed by GDAL as a flag. Now:

- **Argv-level guard** (`validate_layer_name_argv` in `backend/app/processing/ingest/ogr.py`): every spawner that forwards a layer name (`run_ogrinfo`, `run_ogrinfo_preview`, `run_ogr2ogr`, `run_ogr2ogr_service`) rejects values starting with `-` before building the command — backstops every caller, including reupload and fan-out workers.
- **Router-level 4xx** (`backend/app/processing/ingest/router.py`): `POST /ingest/preview/{job_id}` and `POST /ingest/commit/{job_id}` reject a leading-dash `layer_name` with 422, and the commit endpoint now validates the requested `layer_name` against the preview's recorded `all_layers` (mirroring the existing commit-fan-out check; the validation helpers live in a new `backend/app/processing/ingest/layer_guard.py` module — thin calls in the router keep it under the Phase 276 CODE-01 LOC cap). Single-layer sources never record `all_layers`, so they get the dash guard only, with the argv guard as the backstop.

## API/schema impact

None. No route signatures or response models changed; `scripts/dump_openapi.py --check` passes with the committed snapshot (no `backend/openapi.json` change).

## Tests

- `backend/tests/test_export.py::TestExportWhereColonLiteral` — colon-in-literal export returns 200 (and a non-narrowing colon filter still 413s, proving the escaped clause executes). Verified red against the unfixed code (500) before the fix.
- `backend/tests/test_ingest_layer_name_guard.py` (new) — unit coverage for the argv guard (including that it fires before any file access/spawn) plus endpoint coverage: leading-dash layer_name → 422 on preview and commit, unknown layer_name → 422 with `available_layers` (string- and dict-shaped `all_layers`), known layer_name → 202, no-`all_layers` commit unaffected.

## Verification

```
cd backend && uv run ruff check . && uv run ruff format --check .
cd backend && set -a && source ../.env.test && set +a && \
  uv run pytest tests/test_export.py tests/test_export_hardening.py \
    tests/test_export_parquet.py tests/test_ingest_layer_name_guard.py \
    tests/test_ingest_fan_out.py tests/test_ingest.py \
    tests/test_export_access.py tests/test_export_where_validator.py \
    tests/test_commit_revalidates_source_url.py -v
cd backend && PYTHONPATH=. uv run python scripts/dump_openapi.py --check
```

All passing locally (183 passed, 3 skipped across the suites above; ruff clean; OpenAPI snapshot unchanged).

https://claude.ai/code/session_01A8vNJqrsio7yP5vWNhauVg

