### PR TITLE
fix(builder): keep AI availability in loading state while permissions resolve

### DIFF
--- a/frontend/src/hooks/__tests__/use-ai-availability.test.tsx
+++ b/frontend/src/hooks/__tests__/use-ai-availability.test.tsx
@@ -18,10 +18,15 @@ const mocks = vi.hoisted(() => ({
   capabilities: new Set<string>(),
   isMultiTenant: false,
   editionLoading: false,
+  permissionsLoading: false,
 }));
 vi.mock('@/hooks/use-permissions', () => ({
   usePermissions: () => ({
-    can: (capability: string) => mocks.capabilities.has(capability),
+    // Mirrors the real hook: permissions are null while loading, so can()
+    // answers false for everything until the query resolves.
+    can: (capability: string) =>
+      !mocks.permissionsLoading && mocks.capabilities.has(capability),
+    isLoading: mocks.permissionsLoading,
   }),
 }));
 vi.mock('@/hooks/use-edition', () => ({
@@ -66,6 +71,7 @@ describe('useAIStatus / useAIAvailability — caching (SP-08)', () => {
     mocks.capabilities = new Set(['use_ai_chat', 'manage_users']);
     mocks.isMultiTenant = false;
     mocks.editionLoading = false;
+    mocks.permissionsLoading = false;
     useAuthStore.setState({
       token: 'test-token',
       refreshToken: null,
@@ -146,6 +152,7 @@ describe('useAIAvailability — CONSOLE-01 gating', () => {
     mocks.capabilities = new Set(['use_ai_chat', 'manage_users']);
     mocks.isMultiTenant = false;
     mocks.editionLoading = false;
+    mocks.permissionsLoading = false;
     mockGetAIStatus.mockResolvedValue({
       enabled: true,
       configured: true,
@@ -306,6 +313,7 @@ describe('useAIAvailability — reason field (Phase 1135 AI-02)', () => {
     mocks.capabilities = new Set(['use_ai_chat', 'manage_users']);
     mocks.isMultiTenant = false;
     mocks.editionLoading = false;
+    mocks.permissionsLoading = false;
     // Default auth state: admin token.
     useAuthStore.setState({
       token: 'admin-token',
@@ -426,6 +434,7 @@ describe('useAIAvailability — mode-aware status gate (fix #815)', () => {
     vi.clearAllMocks();
     mocks.isMultiTenant = false;
     mocks.editionLoading = false;
+    mocks.permissionsLoading = false;
     mockGetAIStatus.mockResolvedValue({
       enabled: true,
       configured: true,
@@ -499,6 +508,41 @@ describe('useAIAvailability — mode-aware status gate (fix #815)', () => {
     expect(mockGetAIAvailability).not.toHaveBeenCalled();
     expect(result.current.isLoading).toBe(true);
     expect(result.current.reason).toBeNull();
+  });
+
+  // fix(#818): can() answers false while the permissions query is loading, which
+  // used to settle reason='permission' with isLoading=false — a cold mount
+  // flashed the no-permission disabled state at permitted editors.
+  it('cold permissions load: surfaces isLoading with reason=null instead of a premature permission denial', () => {
+    mocks.permissionsLoading = true;
+    mocks.capabilities = new Set(['use_ai_chat']);
+    useAuthStore.setState({
+      token: 'editor-token',
+      refreshToken: null,
+      expiresAt: null,
+      user: {
+        id: 'u4',
+        username: 'editor',
+        email: 'editor@x',
+        roles: ['editor'],
+        is_active: true,
+        status: 'active',
+        last_login_at: null,
+        created_at: '',
+      },
+    });
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+
+    const { result } = renderHook(() => useAIAvailability(), {
+      wrapper: makeWrapper(qc),
+    });
+
+    expect(result.current.isLoading).toBe(true);
+    expect(result.current.reason).toBeNull();
+    expect(result.current.isAIAvailable).toBe(false);
+    // Neither probe fires before permissions resolve (can() gates both).
+    expect(mockGetAIStatus).not.toHaveBeenCalled();
+    expect(mockGetAIAvailability).not.toHaveBeenCalled();
   });
 
   it('single-tenant: a non-admin manage_users holder reads detailed admin status', async () => {

--- a/frontend/src/hooks/use-ai-availability.ts
+++ b/frontend/src/hooks/use-ai-availability.ts
@@ -60,7 +60,12 @@ export function useAIAvailability() {
   // then can hit the wrong endpoint (a 403 that lands in error telemetry).
   // Hold both probes until the edition is known.
   const editionResolved = !useEdition().isLoading;
-  const { can } = usePermissions();
+  // fix(#818): can() returns false while the permissions query is still
+  // loading, which settled reason='permission' with isLoading=false and
+  // flashed the no-permission disabled state at permitted editors on a cold
+  // mount. Fold the permissions query's loading into isLoading (mirroring
+  // how #816 folded the edition query's) so the spinner covers the window.
+  const { can, isLoading: permissionsLoading } = usePermissions();
   const canUse = can('use_ai_chat');
 
   // Status readers get the detailed admin status (provider/key info for the reason taxonomy).
@@ -80,7 +85,11 @@ export function useAIAvailability() {
   let isAIAvailable: boolean;
   let reason: AIUnavailableReason | null = null;
 
-  if (!canUse) {
+  if (permissionsLoading) {
+    // fix(#818): don't settle reason='permission' before permissions resolve —
+    // loading maps to reason=null (spinner via isLoading), per the taxonomy above.
+    isAIAvailable = false;
+  } else if (!canUse) {
     isAIAvailable = false;
     reason = 'permission';
   } else if (canReadStatus) {
@@ -102,8 +111,9 @@ export function useAIAvailability() {
   // disabled-state UI can show a spinner instead of premature "unavailable" copy.
   const activeQuery = canReadStatus ? adminStatus : availabilityQuery;
   const isLoading =
-    canUse &&
-    (!editionResolved || (activeQuery.fetchStatus !== 'idle' && activeQuery.isLoading));
+    permissionsLoading ||
+    (canUse &&
+      (!editionResolved || (activeQuery.fetchStatus !== 'idle' && activeQuery.isLoading)));
 
   return {
     ...activeQuery,


### PR DESCRIPTION
## Summary

Fixes the cold-mount flash where a permitted editor briefly saw the "You don't have permission to use AI chat" disabled state in BuilderRail (#818, found during the #816 review verification pass).

`useAIAvailability` derived `canUse` from `can('use_ai_chat')`, which answers `false` while the permissions query is still loading. That settled `reason='permission'` with `isLoading=false` (the `canUse &&` clause short-circuited the loading formula), so the disabled-state UI rendered the permission-denied copy before permissions resolved.

## Change

- `frontend/src/hooks/use-ai-availability.ts`: consume `usePermissions().isLoading` (already exposed by the hook), fold it into the returned `isLoading` — the same shape #816 used for the edition query — and keep `reason=null` during that window so the UI shows the spinner. `isLoading` stays false for anonymous sessions since the disabled permissions query never enters `isFetching`.
- `frontend/src/hooks/__tests__/use-ai-availability.test.tsx`: mock now mirrors the real hook (`can()` is false and `isLoading` is true while loading); new regression test asserts a cold permissions load surfaces `isLoading=true`, `reason=null`, and fires neither status probe.

No API, schema, or config impact.

Closes #818

## Verification

- `cd frontend && npx vitest run src/hooks/__tests__/use-ai-availability.test.tsx` — 18 passed
- `cd frontend && npx vitest run src/components/builder/__tests__/BuilderRail.test.tsx src/components/viewer/__tests__/ViewerChatPanel.test.tsx src/components/dataset/__tests__/DatasetChatPanel.test.tsx src/components/builder/__tests__/MapBuilderPage.notes-ai-rail.test.tsx` — 35 passed
- `cd frontend && npm run lint` — clean
- `cd frontend && npm run typecheck` — clean