### PR TITLE
fix(frontend): wire silent error boundaries into the problem report and guard ThemeProvider storage access

### DIFF
--- a/frontend/src/components/__tests__/theme-provider.test.tsx
+++ b/frontend/src/components/__tests__/theme-provider.test.tsx
@@ -1,0 +1,65 @@
+// fix(#834): ThemeProvider must survive storage-blocked contexts (Safari
+// private-mode iframes, strict cookie settings) where any localStorage access
+// throws — previously this crashed before React mounted (white screen on the
+// embed surface).
+import { render, screen, fireEvent } from '@testing-library/react';
+import { ThemeProvider, useTheme } from '../theme-provider';
+
+function ThemeConsumer() {
+  const { theme, setTheme } = useTheme();
+  return (
+    <div>
+      <span data-testid="theme">{theme}</span>
+      <button onClick={() => setTheme('dark')}>go dark</button>
+    </div>
+  );
+}
+
+describe('ThemeProvider storage-blocked fallback', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('renders with the default theme when localStorage.getItem throws', () => {
+    vi.spyOn(Storage.prototype, 'getItem').mockImplementation(() => {
+      throw new Error('SecurityError: storage blocked');
+    });
+
+    render(
+      <ThemeProvider defaultTheme="light">
+        <ThemeConsumer />
+      </ThemeProvider>,
+    );
+
+    expect(screen.getByTestId('theme')).toHaveTextContent('light');
+  });
+
+  it('setTheme still updates in-memory when localStorage.setItem throws', () => {
+    vi.spyOn(Storage.prototype, 'getItem').mockImplementation(() => {
+      throw new Error('SecurityError: storage blocked');
+    });
+    vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+      throw new Error('SecurityError: storage blocked');
+    });
+
+    render(
+      <ThemeProvider defaultTheme="light">
+        <ThemeConsumer />
+      </ThemeProvider>,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'go dark' }));
+    expect(screen.getByTestId('theme')).toHaveTextContent('dark');
+  });
+
+  it('reads the stored theme when storage is available', () => {
+    localStorage.setItem('geolens-theme', 'dark');
+    render(
+      <ThemeProvider defaultTheme="light">
+        <ThemeConsumer />
+      </ThemeProvider>,
+    );
+    expect(screen.getByTestId('theme')).toHaveTextContent('dark');
+    localStorage.removeItem('geolens-theme');
+  });
+});

--- a/frontend/src/components/error/LazyLoadErrorBoundary.tsx
+++ b/frontend/src/components/error/LazyLoadErrorBoundary.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { AlertCircle, Loader2 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { logger } from '@/lib/logger';
+import { pushReportEntry } from '@/lib/report';
 
 interface LazyLoadErrorBoundaryState {
   hasError: boolean;
@@ -79,6 +80,14 @@ export class LazyLoadErrorBoundary extends Component<
 
   componentDidCatch(error: Error, errorInfo: ErrorInfo): void {
     logger.error('[LazyLoadErrorBoundary]', error, errorInfo);
+    // fix(#834): feed the problem-report buffer like the other boundaries so a
+    // crash behind this boundary doesn't produce an empty report.
+    pushReportEntry({
+      severity: 'error',
+      source: 'react',
+      message: error.message || 'Lazy load failure',
+      detail: errorInfo.componentStack ?? error.stack ?? undefined,
+    });
 
     // Auto-retry once for chunk load errors
     if (isChunkLoadError(error) && this.state.retryCount < 1) {

--- a/frontend/src/components/error/RouteErrorBoundary.tsx
+++ b/frontend/src/components/error/RouteErrorBoundary.tsx
@@ -1,13 +1,27 @@
+import { useEffect } from 'react';
 import { useRouteError, useNavigate } from 'react-router';
 import { useTranslation } from 'react-i18next';
 import { ErrorState } from '@/components/layout/ErrorState';
 import { Button } from '@/components/ui/button';
+import { pushReportEntry } from '@/lib/report';
 import { ErrorReportButton } from './ErrorReportButton';
 
 export function RouteErrorBoundary() {
   const error = useRouteError();
   const navigate = useNavigate();
   const { t } = useTranslation('common');
+
+  // fix(#834): feed the problem-report buffer like the other boundaries so a
+  // route crash doesn't produce an empty report.
+  useEffect(() => {
+    pushReportEntry({
+      severity: 'error',
+      source: 'react',
+      message:
+        error instanceof Error ? error.message || 'Route error' : 'Route error',
+      detail: error instanceof Error ? error.stack : String(error),
+    });
+  }, [error]);
 
   const message =
     error instanceof Error

--- a/frontend/src/components/error/__tests__/ErrorBoundaries.test.tsx
+++ b/frontend/src/components/error/__tests__/ErrorBoundaries.test.tsx
@@ -3,10 +3,13 @@ import { AppErrorBoundary } from '../AppErrorBoundary';
 import { MapErrorBoundary } from '../MapErrorBoundary';
 import { LazyLoadErrorBoundary } from '../LazyLoadErrorBoundary';
 import { RouteErrorBoundary } from '../RouteErrorBoundary';
+import { PluginErrorBoundary } from '@/components/map-plugins/PluginErrorBoundary';
 import { GEOLENS_BUG_REPORT_URL } from '@/lib/external-links';
+import { getReportEntries, clearReportEntries } from '@/lib/report';
 
 // Suppress React error boundary console.error noise in tests
 beforeEach(() => {
+  clearReportEntries();
   vi.spyOn(console, 'error').mockImplementation(() => {});
 });
 
@@ -132,6 +135,47 @@ describe('LazyLoadErrorBoundary', () => {
     expect(screen.getByText('Failed to load')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /try again/i })).toBeInTheDocument();
   });
+
+  // fix(#834): silent boundary — must feed the problem-report buffer
+  it('records the crash in the problem-report buffer', () => {
+    render(
+      <LazyLoadErrorBoundary>
+        <ThrowingChild error={new Error('Lazy crash')} />
+      </LazyLoadErrorBoundary>,
+    );
+    expect(getReportEntries()).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ source: 'react', message: 'Lazy crash' }),
+      ]),
+    );
+  });
+});
+
+// --- PluginErrorBoundary ---
+
+describe('PluginErrorBoundary', () => {
+  it('shows plugin error fallback when child throws', () => {
+    render(
+      <PluginErrorBoundary pluginId="test-plugin">
+        <ThrowingChild />
+      </PluginErrorBoundary>,
+    );
+    expect(screen.queryByText('Test error')).not.toBeInTheDocument();
+  });
+
+  // fix(#834): silent boundary — must feed the problem-report buffer
+  it('records the crash in the problem-report buffer', () => {
+    render(
+      <PluginErrorBoundary pluginId="test-plugin">
+        <ThrowingChild error={new Error('Plugin crash')} />
+      </PluginErrorBoundary>,
+    );
+    expect(getReportEntries()).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ source: 'react', message: 'Plugin crash' }),
+      ]),
+    );
+  });
 });
 
 // --- RouteErrorBoundary ---
@@ -159,6 +203,16 @@ describe('RouteErrorBoundary', () => {
     expect(screen.getByRole('link', { name: /file a bug/i })).toHaveAttribute(
       'href',
       GEOLENS_BUG_REPORT_URL,
+    );
+  });
+
+  // fix(#834): silent boundary — must feed the problem-report buffer
+  it('records the route error in the problem-report buffer', () => {
+    render(<RouteErrorBoundary />);
+    expect(getReportEntries()).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ source: 'react', message: 'Route error' }),
+      ]),
     );
   });
 });

--- a/frontend/src/components/map-plugins/PluginErrorBoundary.tsx
+++ b/frontend/src/components/map-plugins/PluginErrorBoundary.tsx
@@ -1,6 +1,7 @@
 import { Component, type ErrorInfo, type ReactNode } from 'react';
 import i18n from '@/i18n/i18n';
 import { logger } from '@/lib/logger';
+import { pushReportEntry } from '@/lib/report';
 
 /** Isolates plugin crashes so one broken plugin doesn't take down the host */
 export class PluginErrorBoundary extends Component<
@@ -15,6 +16,14 @@ export class PluginErrorBoundary extends Component<
 
   componentDidCatch(error: Error, info: ErrorInfo) {
     logger.error(`Plugin "${this.props.pluginId}" crashed:`, error, info.componentStack);
+    // fix(#834): feed the problem-report buffer like the other boundaries so a
+    // plugin crash doesn't produce an empty report.
+    pushReportEntry({
+      severity: 'error',
+      source: 'react',
+      message: error.message || `Plugin "${this.props.pluginId}" crash`,
+      detail: info.componentStack ?? error.stack ?? undefined,
+    });
   }
 
   render() {

--- a/frontend/src/components/theme-provider.tsx
+++ b/frontend/src/components/theme-provider.tsx
@@ -26,13 +26,33 @@ function getSystemTheme(): 'dark' | 'light' {
     : 'light';
 }
 
+// fix(#834): localStorage access throws in storage-blocked contexts (Safari
+// private-mode iframes, strict cookie settings) — exactly the embed surface.
+// Guard reads/writes so the app still mounts with an in-memory theme, matching
+// how theme-init.js and the persisted zustand stores tolerate blocked storage.
+function readStoredTheme(storageKey: string): Theme | null {
+  try {
+    return localStorage.getItem(storageKey) as Theme | null;
+  } catch {
+    return null;
+  }
+}
+
+function writeStoredTheme(storageKey: string, theme: Theme): void {
+  try {
+    localStorage.setItem(storageKey, theme);
+  } catch {
+    // Storage blocked — theme still applies in-memory for this session.
+  }
+}
+
 export function ThemeProvider({
   children,
   defaultTheme = 'system',
   storageKey = 'geolens-theme', // Must match FOUC script in index.html
 }: ThemeProviderProps) {
   const [theme, setThemeState] = useState<Theme>(
-    () => (localStorage.getItem(storageKey) as Theme) || defaultTheme,
+    () => readStoredTheme(storageKey) || defaultTheme,
   );
 
   const [resolvedTheme, setResolvedTheme] = useState<'dark' | 'light'>(() =>
@@ -67,7 +87,7 @@ export function ThemeProvider({
   }, [theme]);
 
   const setTheme = (t: Theme) => {
-    localStorage.setItem(storageKey, t);
+    writeStoredTheme(storageKey, t);
     setThemeState(t);
   };
 


### PR DESCRIPTION
## Summary

Two resilience fixes from the 1.6.0 pre-tag audit (#834):

**Silent error boundaries.** Three of the six error boundaries (LazyLoadErrorBoundary, RouteErrorBoundary, PluginErrorBoundary) logged crashes but never fed the problem-report buffer, so a crash behind them produced an empty problem report. They now call `pushReportEntry` with the same `source: 'react'` shape the App/Map/Panel boundaries already use. RouteErrorBoundary is a function component, so it pushes from a `useEffect` keyed on the route error.

**ThemeProvider storage-blocked white screen.** `ThemeProvider` read `localStorage` unguarded in its state initializer and wrote it unguarded in `setTheme`. In storage-blocked contexts (Safari private-mode iframes, strict cookie settings — the embed surface) that access throws before React mounts, leaving a white screen. Reads/writes are now wrapped in try/catch with an in-memory fallback, matching how `theme-init.js` and the persisted zustand stores already tolerate blocked storage.

No API, schema, or config impact.

## Files touched

- `frontend/src/components/error/LazyLoadErrorBoundary.tsx`
- `frontend/src/components/error/RouteErrorBoundary.tsx`
- `frontend/src/components/map-plugins/PluginErrorBoundary.tsx`
- `frontend/src/components/theme-provider.tsx`
- `frontend/src/components/error/__tests__/ErrorBoundaries.test.tsx` (capture-path assertions for the three fixed boundaries)
- `frontend/src/components/__tests__/theme-provider.test.tsx` (new: storage-blocked fallback tests)

## Verification

- `cd frontend && npm run lint` — pass
- `cd frontend && npm run typecheck` — pass
- `cd frontend && npx vitest run src/components/__tests__/theme-provider.test.tsx src/components/error/__tests__/ErrorBoundaries.test.tsx` — 19 tests pass
- `cd frontend && npx vitest run src/components/map-plugins/__tests__` — 20 tests pass

Closes #834