### PR TITLE
fix(admin): gate the settings routes mode-aware to match require_settings_admin

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,7 +1,7 @@
 import { lazy, Suspense } from 'react';
 import { Route, Navigate, Outlet } from 'react-router';
 import { ProtectedRoute } from '@/components/auth/ProtectedRoute';
-import { AdminCapabilityRoute, AdminIndexRoute, AdminRoute } from '@/components/auth/AdminRoute';
+import { AdminCapabilityRoute, AdminIndexRoute, AdminRoute, AdminSettingsRoute } from '@/components/auth/AdminRoute';
 import { LandingFirstGuard } from '@/components/auth/LandingFirstGuard';
 import { EditorRoute } from '@/components/auth/EditorRoute';
 import { AppLayout } from '@/components/layout/AppLayout';
@@ -121,6 +121,12 @@ export const appRoutes = (
             <Route element={<AdminCapabilityRoute capability="manage_settings" />}>
               <Route path="admin/audit" element={<AdminAuditPage />} errorElement={<RouteErrorBoundary />} />
               <Route path="admin/saml" element={<AdminSamlPage />} errorElement={<RouteErrorBoundary />} />
+            </Route>
+            {/* fix(#817): the settings and config-ops APIs flip to
+                manage_tenants in multi-tenant mode, so their routes gate
+                mode-aware — plain manage_settings admitted per-tenant admins
+                whose every settings request 403s. */}
+            <Route element={<AdminSettingsRoute />}>
               {/* Settings — each tab is its own route */}
               <Route path="admin/settings" element={<Navigate to="/admin/settings/general" replace />} />
               <Route path="admin/settings/:tab" element={<AdminSettingsPage />} errorElement={<RouteErrorBoundary />} />

--- a/frontend/src/components/admin/AIStatusCard.tsx
+++ b/frontend/src/components/admin/AIStatusCard.tsx
@@ -4,6 +4,7 @@ import { Bot, ArrowRight } from 'lucide-react';
 import { useAIStatus, useEmbeddingStats } from '@/hooks/use-admin';
 import { usePermissions } from '@/hooks/use-permissions';
 import { useAIStatusReader } from '@/hooks/use-ai-status-reader';
+import { useSettingsAdmin } from '@/hooks/use-settings-admin';
 import { semanticBadgeColors } from '@/lib/status-colors';
 import {
   Card,
@@ -22,7 +23,9 @@ export function AIStatusCard() {
   // queries the backend 403s.
   const canReadAIStatus = useAIStatusReader();
   const canManageUsers = can('manage_users');
-  const canManageSettings = can('manage_settings');
+  // fix(#817): the settings link targets /admin/settings/ai, whose route gate
+  // is mode-aware (manage_tenants in multi-tenant) — match it.
+  const canAdminSettings = useSettingsAdmin();
   const { data: aiStatus, isLoading } = useAIStatus({ enabled: canReadAIStatus });
   // fix(#653): /admin/embedding-stats requires manage_users in BOTH tenancy
   // modes, so it keeps its own gate; the card gate alone would 403 for a
@@ -94,7 +97,7 @@ export function AIStatusCard() {
             )}
 
             {/* Link to settings */}
-            {canManageSettings && (
+            {canAdminSettings && (
               <div className="border-t pt-3">
                 <Link
                   to="/admin/settings/ai"

--- a/frontend/src/components/admin/AdminSidebar.tsx
+++ b/frontend/src/components/admin/AdminSidebar.tsx
@@ -41,6 +41,7 @@ import {
 import { useEdition } from '@/hooks/use-edition';
 import { useEnterpriseOnlyTabs } from '@/hooks/use-settings';
 import { usePermissions } from '@/hooks/use-permissions';
+import { useSettingsAdmin } from '@/hooks/use-settings-admin';
 import type { Capability } from '@/lib/capabilities';
 
 const overviewItems = [
@@ -121,8 +122,12 @@ export function AdminSidebar() {
   const { data: auditLogCount } = useAuditLogCount(canManageSettings);
   const { data: publishedMapCount } = usePublishedMapCount(canManageUsers);
   const { isEnterprise } = useEdition();
+  // fix(#817): the /settings/* API (including /settings/enterprise-tabs/)
+  // flips to manage_tenants in multi-tenant mode — gate the Settings nav
+  // group and its query on the mode-aware hook, not raw manage_settings.
+  const canAdminSettings = useSettingsAdmin();
   const { data: enterpriseTabsData } = useEnterpriseOnlyTabs({
-    enabled: canManageSettings,
+    enabled: canAdminSettings,
   });
 
   // Phase 279 ADMIN-03 (M-03): derive each Settings-tab's enterpriseOnly flag
@@ -139,7 +144,7 @@ export function AdminSidebar() {
   }));
 
   const visibleOverviewItems = overviewItems.filter(item => can(item.capability));
-  const visibleSettingsItems = canManageSettings
+  const visibleSettingsItems = canAdminSettings
     ? settingsItems.filter(item => !item.enterpriseOnly || isEnterprise)
     : [];
   const visibleOperationsItems = operationsItems.filter(

--- a/frontend/src/components/admin/__tests__/AIStatusCard.capabilities.test.tsx
+++ b/frontend/src/components/admin/__tests__/AIStatusCard.capabilities.test.tsx
@@ -23,6 +23,7 @@ vi.mock('@/hooks/use-edition', () => ({
     isEnterprise: false,
     isMultiTenant: mocks.isMultiTenant,
     isLoading: false,
+    isResolved: true,
   }),
 }));
 

--- a/frontend/src/components/admin/__tests__/AdminSidebar.test.tsx
+++ b/frontend/src/components/admin/__tests__/AdminSidebar.test.tsx
@@ -225,6 +225,30 @@ describe('AdminSidebar', () => {
     expect(useEnterpriseOnlyTabsMock).toHaveBeenCalledWith({ enabled: true });
   });
 
+  // fix(#817): the settings/config-ops APIs require manage_tenants in
+  // multi-tenant mode — a manage_settings-only per-tenant admin must not see
+  // the Settings group (every request behind those links 403s). Audit Log
+  // stays manage_settings in BOTH modes.
+  it('multi-tenant: hides the Settings group for a manage_settings-only admin', () => {
+    const multiTenant = {
+      isEnterprise: true,
+      edition: 'enterprise',
+      isMultiTenant: true,
+      isLoading: false,
+    };
+    // Two queued values: AdminSidebar's own useEdition call, then the
+    // useSettingsAdmin hook's internal call (in component order).
+    useEditionMock
+      .mockReturnValueOnce(multiTenant as never)
+      .mockReturnValueOnce(multiTenant as never);
+    renderSidebar();
+
+    expect(screen.queryByText('General')).toBeNull();
+    expect(screen.queryByText('Config Ops')).toBeNull();
+    expect(useEnterpriseOnlyTabsMock).toHaveBeenCalledWith({ enabled: false });
+    expect(screen.getByText('Audit Log')).toBeInTheDocument();
+  });
+
   it('shows total count badges and caps large counts at 999+ (#347 (ADM-02))', () => {
     counts.users = 62;
     counts.audit = 1500;

--- a/frontend/src/components/admin/__tests__/AdminSidebar.test.tsx
+++ b/frontend/src/components/admin/__tests__/AdminSidebar.test.tsx
@@ -49,7 +49,9 @@ vi.mock('@/hooks/use-permissions', () => ({
 const useEditionMock = vi.fn(() => ({
   isEnterprise: false,
   edition: 'community',
+  isMultiTenant: false,
   isLoading: false,
+  isResolved: true,
 }));
 
 vi.mock('@/hooks/use-edition', () => ({
@@ -235,6 +237,7 @@ describe('AdminSidebar', () => {
       edition: 'enterprise',
       isMultiTenant: true,
       isLoading: false,
+      isResolved: true,
     };
     // Two queued values: AdminSidebar's own useEdition call, then the
     // useSettingsAdmin hook's internal call (in component order).
@@ -277,7 +280,9 @@ describe('AdminSidebar SAML gating (Phase 217 SAML-10)', () => {
     useEditionMock.mockReturnValueOnce({
       isEnterprise: false,
       edition: 'community',
+      isMultiTenant: false,
       isLoading: false,
+      isResolved: true,
     });
     renderSidebar();
     // The "SAML SSO" label must NOT render and no <a> should target /admin/saml.
@@ -289,7 +294,9 @@ describe('AdminSidebar SAML gating (Phase 217 SAML-10)', () => {
     useEditionMock.mockReturnValueOnce({
       isEnterprise: true,
       edition: 'enterprise',
+      isMultiTenant: false,
       isLoading: false,
+      isResolved: true,
     });
     renderSidebar();
     // Both the human-readable label and the link href must be present.
@@ -326,7 +333,9 @@ describe('AdminSidebar server-driven enterpriseOnly tabs (Phase 279 ADMIN-03)', 
     useEditionMock.mockReturnValueOnce({
       isEnterprise: true,
       edition: 'enterprise',
+      isMultiTenant: false,
       isLoading: false,
+      isResolved: true,
     });
     renderSidebar();
     // "Appearance" is enterpriseOnly but enterprise edition sees ALL tabs.

--- a/frontend/src/components/auth/AdminRoute.tsx
+++ b/frontend/src/components/auth/AdminRoute.tsx
@@ -1,6 +1,8 @@
 import { Navigate, Outlet } from 'react-router';
 import { LoadingState } from '@/components/layout/LoadingState';
 import { usePermissions } from '@/hooks/use-permissions';
+import { useEdition } from '@/hooks/use-edition';
+import { useSettingsAdmin } from '@/hooks/use-settings-admin';
 import type { Capability } from '@/lib/capabilities';
 
 export function AdminRoute() {
@@ -17,6 +19,21 @@ export function AdminCapabilityRoute({ capability }: { capability: Capability })
 
   if (isLoading) return <LoadingState />;
   if (!can(capability)) return <Navigate to="/admin" replace />;
+
+  return <Outlet />;
+}
+
+// fix(#817): the /settings/* and /config-ops/* APIs are gated mode-aware
+// (manage_settings single-tenant, manage_tenants multi-tenant), so the route
+// gate must switch the same way — a plain manage_settings gate admitted
+// multi-tenant per-tenant admins whose every settings request 403s.
+export function AdminSettingsRoute() {
+  const { isLoading: permissionsLoading } = usePermissions();
+  const { isLoading: editionLoading } = useEdition();
+  const allowed = useSettingsAdmin();
+
+  if (permissionsLoading || editionLoading) return <LoadingState />;
+  if (!allowed) return <Navigate to="/admin" replace />;
 
   return <Outlet />;
 }

--- a/frontend/src/components/auth/AdminRoute.tsx
+++ b/frontend/src/components/auth/AdminRoute.tsx
@@ -7,11 +7,19 @@ import type { Capability } from '@/lib/capabilities';
 
 export function AdminRoute() {
   const { can, isLoading } = usePermissions();
+  const { isLoading: editionLoading } = useEdition();
+  const settingsAdmin = useSettingsAdmin();
 
   if (isLoading) return <LoadingState />;
-  if (!can('manage_users') && !can('manage_settings')) return <Navigate to="/" replace />;
+  if (can('manage_users') || can('manage_settings')) return <Outlet />;
+  // fix(#817): a multi-tenant fleet operator can hold manage_tenants without
+  // manage_users/manage_settings — admit them so the AdminSettingsRoute they
+  // are authorized for is reachable. Checked after the plain capabilities so
+  // the common single-tenant path never waits on the edition query.
+  if (editionLoading) return <LoadingState />;
+  if (settingsAdmin) return <Outlet />;
 
-  return <Outlet />;
+  return <Navigate to="/" replace />;
 }
 
 export function AdminCapabilityRoute({ capability }: { capability: Capability }) {
@@ -40,9 +48,15 @@ export function AdminSettingsRoute() {
 
 export function AdminIndexRoute() {
   const { can, isLoading } = usePermissions();
+  const { isLoading: editionLoading } = useEdition();
+  const settingsAdmin = useSettingsAdmin();
 
   if (isLoading) return <LoadingState />;
   if (can('manage_users')) return <Navigate to="/admin/overview" replace />;
   if (can('manage_settings')) return <Navigate to="/admin/audit" replace />;
+  // fix(#817): land a manage_tenants-only fleet operator on the settings
+  // pages they are authorized for (neither overview nor audit admits them).
+  if (editionLoading) return <LoadingState />;
+  if (settingsAdmin) return <Navigate to="/admin/settings/general" replace />;
   return <Navigate to="/" replace />;
 }

--- a/frontend/src/components/auth/__tests__/AdminRoute.test.tsx
+++ b/frontend/src/components/auth/__tests__/AdminRoute.test.tsx
@@ -4,11 +4,18 @@ import {
   AdminCapabilityRoute,
   AdminIndexRoute,
   AdminRoute,
+  AdminSettingsRoute,
 } from '../AdminRoute';
 
 const permissionState = vi.hoisted(() => ({
   manageUsers: false,
   manageSettings: false,
+  manageTenants: false,
+  isLoading: false,
+}));
+
+const editionState = vi.hoisted(() => ({
+  isMultiTenant: false,
   isLoading: false,
 }));
 
@@ -17,9 +24,21 @@ vi.mock('@/hooks/use-permissions', () => ({
     can: (capability: string) =>
       capability === 'manage_users'
         ? permissionState.manageUsers
-        : capability === 'manage_settings' && permissionState.manageSettings,
+        : capability === 'manage_settings'
+          ? permissionState.manageSettings
+          : capability === 'manage_tenants' && permissionState.manageTenants,
     isLoading: permissionState.isLoading,
     permissions: {},
+  }),
+}));
+
+vi.mock('@/hooks/use-edition', () => ({
+  useEdition: () => ({
+    edition: 'community',
+    features: [],
+    isEnterprise: false,
+    isMultiTenant: editionState.isMultiTenant,
+    isLoading: editionState.isLoading,
   }),
 }));
 
@@ -97,6 +116,67 @@ describe('AdminCapabilityRoute', () => {
     renderCapabilityRoute('manage_settings');
 
     expect(screen.getByText('Admin Index')).toBeInTheDocument();
+  });
+});
+
+// fix(#817): the settings/config-ops APIs require manage_settings in
+// single-tenant but manage_tenants in multi-tenant — the route gate must
+// switch the same way so per-tenant admins don't land on tabs whose every
+// request 403s.
+describe('AdminSettingsRoute', () => {
+  function renderSettingsRoute() {
+    return render(
+      <MemoryRouter initialEntries={['/admin/settings/ai']}>
+        <Routes>
+          <Route path="/admin" element={<div>Admin Index</div>} />
+          <Route element={<AdminSettingsRoute />}>
+            <Route path="/admin/settings/ai" element={<div>Settings Content</div>} />
+          </Route>
+        </Routes>
+      </MemoryRouter>,
+    );
+  }
+
+  beforeEach(() => {
+    permissionState.manageUsers = false;
+    permissionState.manageSettings = false;
+    permissionState.manageTenants = false;
+    permissionState.isLoading = false;
+    editionState.isMultiTenant = false;
+    editionState.isLoading = false;
+  });
+
+  it('single-tenant: admits manage_settings', () => {
+    permissionState.manageSettings = true;
+    renderSettingsRoute();
+
+    expect(screen.getByText('Settings Content')).toBeInTheDocument();
+  });
+
+  it('multi-tenant: redirects a manage_settings-only per-tenant admin to the admin index', () => {
+    editionState.isMultiTenant = true;
+    permissionState.manageSettings = true;
+    renderSettingsRoute();
+
+    expect(screen.getByText('Admin Index')).toBeInTheDocument();
+    expect(screen.queryByText('Settings Content')).not.toBeInTheDocument();
+  });
+
+  it('multi-tenant: admits manage_tenants', () => {
+    editionState.isMultiTenant = true;
+    permissionState.manageTenants = true;
+    renderSettingsRoute();
+
+    expect(screen.getByText('Settings Content')).toBeInTheDocument();
+  });
+
+  it('waits for the edition to load before deciding', () => {
+    editionState.isLoading = true;
+    permissionState.manageSettings = true;
+    renderSettingsRoute();
+
+    expect(screen.queryByText('Settings Content')).not.toBeInTheDocument();
+    expect(screen.queryByText('Admin Index')).not.toBeInTheDocument();
   });
 });
 

--- a/frontend/src/components/auth/__tests__/AdminRoute.test.tsx
+++ b/frontend/src/components/auth/__tests__/AdminRoute.test.tsx
@@ -17,7 +17,18 @@ const permissionState = vi.hoisted(() => ({
 const editionState = vi.hoisted(() => ({
   isMultiTenant: false,
   isLoading: false,
+  isResolved: true,
 }));
+
+function resetStates() {
+  permissionState.manageUsers = false;
+  permissionState.manageSettings = false;
+  permissionState.manageTenants = false;
+  permissionState.isLoading = false;
+  editionState.isMultiTenant = false;
+  editionState.isLoading = false;
+  editionState.isResolved = true;
+}
 
 vi.mock('@/hooks/use-permissions', () => ({
   usePermissions: () => ({
@@ -39,6 +50,7 @@ vi.mock('@/hooks/use-edition', () => ({
     isEnterprise: false,
     isMultiTenant: editionState.isMultiTenant,
     isLoading: editionState.isLoading,
+    isResolved: editionState.isResolved,
   }),
 }));
 
@@ -56,11 +68,7 @@ function renderAdminRoute(initialRoute = '/admin') {
 }
 
 describe('AdminRoute', () => {
-  beforeEach(() => {
-    permissionState.manageUsers = false;
-    permissionState.manageSettings = false;
-    permissionState.isLoading = false;
-  });
+  beforeEach(resetStates);
 
   it('redirects a user with no admin capability to the application', () => {
     renderAdminRoute();
@@ -82,6 +90,24 @@ describe('AdminRoute', () => {
 
     expect(screen.getByText('Admin Content')).toBeInTheDocument();
   });
+
+  // fix(#817): a multi-tenant fleet operator can hold manage_tenants alone —
+  // the enclosing admin gate must admit them so AdminSettingsRoute is
+  // reachable.
+  it('multi-tenant: admits a manage_tenants-only fleet operator', () => {
+    editionState.isMultiTenant = true;
+    permissionState.manageTenants = true;
+    renderAdminRoute();
+
+    expect(screen.getByText('Admin Content')).toBeInTheDocument();
+  });
+
+  it('multi-tenant: still redirects a manage_tenants-less user with no other capability', () => {
+    editionState.isMultiTenant = true;
+    renderAdminRoute();
+
+    expect(screen.getByText('App Home')).toBeInTheDocument();
+  });
 });
 
 describe('AdminCapabilityRoute', () => {
@@ -98,11 +124,7 @@ describe('AdminCapabilityRoute', () => {
     );
   }
 
-  beforeEach(() => {
-    permissionState.manageUsers = false;
-    permissionState.manageSettings = false;
-    permissionState.isLoading = false;
-  });
+  beforeEach(resetStates);
 
   it('renders the route when its specific capability is granted', () => {
     permissionState.manageSettings = true;
@@ -137,14 +159,7 @@ describe('AdminSettingsRoute', () => {
     );
   }
 
-  beforeEach(() => {
-    permissionState.manageUsers = false;
-    permissionState.manageSettings = false;
-    permissionState.manageTenants = false;
-    permissionState.isLoading = false;
-    editionState.isMultiTenant = false;
-    editionState.isLoading = false;
-  });
+  beforeEach(resetStates);
 
   it('single-tenant: admits manage_settings', () => {
     permissionState.manageSettings = true;
@@ -172,11 +187,25 @@ describe('AdminSettingsRoute', () => {
 
   it('waits for the edition to load before deciding', () => {
     editionState.isLoading = true;
+    editionState.isResolved = false;
     permissionState.manageSettings = true;
     renderSettingsRoute();
 
     expect(screen.queryByText('Settings Content')).not.toBeInTheDocument();
     expect(screen.queryByText('Admin Index')).not.toBeInTheDocument();
+  });
+
+  // fix(#817): an edition fetch failure must not fall back to the
+  // single-tenant capability — that would re-authorize the per-tenant admin
+  // whose every settings request 403s in multi-tenant.
+  it('fails closed when the edition query has failed', () => {
+    editionState.isLoading = false;
+    editionState.isResolved = false;
+    permissionState.manageSettings = true;
+    renderSettingsRoute();
+
+    expect(screen.getByText('Admin Index')).toBeInTheDocument();
+    expect(screen.queryByText('Settings Content')).not.toBeInTheDocument();
   });
 });
 
@@ -188,17 +217,14 @@ describe('AdminIndexRoute', () => {
           <Route path="/admin" element={<AdminIndexRoute />} />
           <Route path="/admin/overview" element={<div>User Admin</div>} />
           <Route path="/admin/audit" element={<div>Settings Admin</div>} />
+          <Route path="/admin/settings/general" element={<div>Settings Pages</div>} />
           <Route path="/" element={<div>App Home</div>} />
         </Routes>
       </MemoryRouter>,
     );
   }
 
-  beforeEach(() => {
-    permissionState.manageUsers = false;
-    permissionState.manageSettings = false;
-    permissionState.isLoading = false;
-  });
+  beforeEach(resetStates);
 
   it('prefers the user-management overview when available', () => {
     permissionState.manageUsers = true;
@@ -211,5 +237,14 @@ describe('AdminIndexRoute', () => {
     permissionState.manageSettings = true;
     renderIndex();
     expect(screen.getByText('Settings Admin')).toBeInTheDocument();
+  });
+
+  // fix(#817): neither overview nor audit admits a manage_tenants-only
+  // fleet operator — land them on the settings pages they can use.
+  it('multi-tenant: lands a manage_tenants-only fleet operator on the settings pages', () => {
+    editionState.isMultiTenant = true;
+    permissionState.manageTenants = true;
+    renderIndex();
+    expect(screen.getByText('Settings Pages')).toBeInTheDocument();
   });
 });

--- a/frontend/src/components/builder/BuilderRail.tsx
+++ b/frontend/src/components/builder/BuilderRail.tsx
@@ -13,7 +13,7 @@ import type { EphemeralAnalysisHandoff } from '@/components/builder/hooks/use-ep
 import type { ViewportContext } from '@/components/builder/chat-suggestions';
 import { HistoryPanel } from '@/components/builder/HistoryPanel';
 import { useAIAvailability } from '@/hooks/use-ai-availability';
-import { usePermissions } from '@/hooks/use-permissions';
+import { useSettingsAdmin } from '@/hooks/use-settings-admin';
 import { Textarea } from '@/components/ui/textarea';
 
 const ChatPanel = lazy(() => import('@/components/builder/ChatPanel').then(m => ({ default: m.ChatPanel })));
@@ -30,10 +30,11 @@ const AnalysisPanel = lazy(() => import('@/components/builder/AnalysisPanel').th
 function AIDisabledState() {
   const { t } = useTranslation('builder');
   const { reason, isLoading } = useAIAvailability();
-  // fix(#816): the CTA targets /admin/settings/ai, which AdminCapabilityRoute
-  // gates on manage_settings — show it only to users the route will admit
-  // (the old isAdmin flag no longer matches who sees detailed reasons).
-  const { can } = usePermissions();
+  // fix(#816): the CTA targets /admin/settings/ai — show it only to users
+  // the route will admit (the old isAdmin flag no longer matches who sees
+  // detailed reasons). fix(#817): the route gate is mode-aware (manage_tenants
+  // in multi-tenant), so gate through useSettingsAdmin, not raw manage_settings.
+  const canAdminSettings = useSettingsAdmin();
 
   // fix(#788 follow-up): one persistent live region whose CONTENT toggles —
   // the loading spinner and the disabled-state message used to be two
@@ -61,7 +62,7 @@ function AIDisabledState() {
   const ctaDefault = reason === 'env_disabled' ? 'Go to Settings'
     : reason === 'no_key' ? 'Configure in Settings'
     : '';
-  const showCTA = ctaKey !== null && can('manage_settings');
+  const showCTA = ctaKey !== null && canAdminSettings;
 
   return (
     <div

--- a/frontend/src/components/builder/__tests__/BuilderRail.test.tsx
+++ b/frontend/src/components/builder/__tests__/BuilderRail.test.tsx
@@ -62,6 +62,19 @@ vi.mock('@/hooks/use-permissions', () => ({
   }),
 }));
 
+// fix(#817): the CTA gate goes through useSettingsAdmin, which composes
+// usePermissions with useEdition — mock the edition side too.
+const editionMocks = vi.hoisted(() => ({ isMultiTenant: false }));
+vi.mock('@/hooks/use-edition', () => ({
+  useEdition: () => ({
+    edition: 'community',
+    features: [],
+    isEnterprise: false,
+    isMultiTenant: editionMocks.isMultiTenant,
+    isLoading: false,
+  }),
+}));
+
 function RailHarness({ showRail = true, aiAvailable = true }: { showRail?: boolean; aiAvailable?: boolean }) {
   const [activePanel, setActivePanel] = useState<RailPanel>(null);
   return (
@@ -329,6 +342,7 @@ describe('BuilderRail — disabled-state taxonomy (Phase 1135 AI-02)', () => {
     } as never);
     useAuthStore.setState({ token: null, user: null });
     permMocks.capabilities = new Set();
+    editionMocks.isMultiTenant = false;
   });
 
   afterEach(() => {
@@ -362,6 +376,38 @@ describe('BuilderRail — disabled-state taxonomy (Phase 1135 AI-02)', () => {
     render(<BuilderRail activePanel="ai" onPanelChange={vi.fn()} aiAvailable={false} notes="" onNotesChange={vi.fn()} />);
     expect(screen.getByText(/AI is disabled/i)).toBeInTheDocument();
     expect(screen.queryByRole('link', { name: /go to settings/i })).not.toBeInTheDocument();
+  });
+
+  // fix(#817): in multi-tenant mode the /admin/settings route (and the
+  // settings API behind it) requires manage_tenants, not manage_settings —
+  // the CTA must follow the same mode-aware gate.
+  it('multi-tenant: NO CTA for a manage_settings-only per-tenant admin', () => {
+    vi.spyOn(availabilityModule, 'useAIAvailability').mockReturnValue({
+      data: { enabled: false } as never,
+      isLoading: false,
+      isAIAvailable: false,
+      reason: 'env_disabled',
+    } as never);
+    editionMocks.isMultiTenant = true;
+    permMocks.capabilities = new Set(['manage_settings']);
+    useAuthStore.setState({ token: 't', user: { roles: ['admin'] } } as never);
+    render(<BuilderRail activePanel="ai" onPanelChange={vi.fn()} aiAvailable={false} notes="" onNotesChange={vi.fn()} />);
+    expect(screen.getByText(/AI is disabled/i)).toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: /go to settings/i })).not.toBeInTheDocument();
+  });
+
+  it('multi-tenant: shows the CTA for manage_tenants', () => {
+    vi.spyOn(availabilityModule, 'useAIAvailability').mockReturnValue({
+      data: { enabled: false } as never,
+      isLoading: false,
+      isAIAvailable: false,
+      reason: 'env_disabled',
+    } as never);
+    editionMocks.isMultiTenant = true;
+    permMocks.capabilities = new Set(['manage_tenants']);
+    useAuthStore.setState({ token: 't', user: { roles: ['admin'] } } as never);
+    render(<BuilderRail activePanel="ai" onPanelChange={vi.fn()} aiAvailable={false} notes="" onNotesChange={vi.fn()} />);
+    expect(screen.getByRole('link', { name: /go to settings/i })).toHaveAttribute('href', '/admin/settings/ai');
   });
 
   it("renders 'AI not configured' + 'Configure in Settings' CTA when reason='no_key' and caller holds manage_settings", () => {

--- a/frontend/src/components/builder/__tests__/BuilderRail.test.tsx
+++ b/frontend/src/components/builder/__tests__/BuilderRail.test.tsx
@@ -72,6 +72,7 @@ vi.mock('@/hooks/use-edition', () => ({
     isEnterprise: false,
     isMultiTenant: editionMocks.isMultiTenant,
     isLoading: false,
+    isResolved: true,
   }),
 }));
 

--- a/frontend/src/components/builder/__tests__/SharePanel.test.tsx
+++ b/frontend/src/components/builder/__tests__/SharePanel.test.tsx
@@ -126,6 +126,7 @@ function setup({
     isEnterprise: enterprise,
     isMultiTenant: false,
     isLoading: false,
+    isResolved: true,
   });
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   mockedUsePublishMap.mockReturnValue(mutationResult(publishMapFn as any));
@@ -974,6 +975,7 @@ describe('P2-01 explicit create-embed-token for public-only embeds', () => {
       isEnterprise: true,
       isMultiTenant: false,
       isLoading: false,
+      isResolved: true,
     });
     mockedUsePublishMap.mockReturnValue(mutationResult());
     mockedUseCreateShareToken.mockReturnValue(mutationResult(

--- a/frontend/src/components/layout/Navbar.tsx
+++ b/frontend/src/components/layout/Navbar.tsx
@@ -6,6 +6,7 @@ import { useTheme } from '@/components/theme-provider';
 import { useAuth } from '@/hooks/use-auth';
 import { useReportDialog } from '@/lib/report';
 import { usePermissions } from '@/hooks/use-permissions';
+import { useSettingsAdmin } from '@/hooks/use-settings-admin';
 import { useFeatureFlags } from '@/hooks/use-settings';
 import { Button } from '@/components/ui/button';
 import {
@@ -130,7 +131,10 @@ function UserMenu() {
   // #305: explicit light/dark override (default stays 'system', which
   // already honors prefers-color-scheme). resolvedTheme drives the icon/label.
   const { setTheme, resolvedTheme } = useTheme();
-  const canAccessAdmin = can('manage_users') || can('manage_settings');
+  // fix(#817): also admit a multi-tenant fleet operator (manage_tenants
+  // only) — the admin routes admit them via the same mode-aware predicate.
+  const settingsAdmin = useSettingsAdmin();
+  const canAccessAdmin = can('manage_users') || can('manage_settings') || settingsAdmin;
 
   // Anonymous: show sign-in button instead of user dropdown
   if (!user) {
@@ -256,7 +260,10 @@ function MobileNav() {
   const [collectionOpen, setCollectionOpen] = useState(false);
   const [mapOpen, setMapOpen] = useState(false);
   const [vrtOpen, setVrtOpen] = useState(false);
-  const canAccessAdmin = can('manage_users') || can('manage_settings');
+  // fix(#817): also admit a multi-tenant fleet operator (manage_tenants
+  // only) — the admin routes admit them via the same mode-aware predicate.
+  const settingsAdmin = useSettingsAdmin();
+  const canAccessAdmin = can('manage_users') || can('manage_settings') || settingsAdmin;
 
   // Auto-close sheet on navigation
   useEffect(() => {
@@ -385,7 +392,10 @@ function MobileNav() {
 export function Navbar() {
   const { t } = useTranslation();
   const { can } = usePermissions();
-  const canAccessAdmin = can('manage_users') || can('manage_settings');
+  // fix(#817): also admit a multi-tenant fleet operator (manage_tenants
+  // only) — the admin routes admit them via the same mode-aware predicate.
+  const settingsAdmin = useSettingsAdmin();
+  const canAccessAdmin = can('manage_users') || can('manage_settings') || settingsAdmin;
 
   return (
     // fix(#522): fixed (not sticky) so the navbar shares the viewport-fixed

--- a/frontend/src/components/layout/__tests__/AppLayout.test.tsx
+++ b/frontend/src/components/layout/__tests__/AppLayout.test.tsx
@@ -62,6 +62,7 @@ describe('AppLayout', () => {
       isEnterprise: false,
       isMultiTenant: false,
       isLoading: false,
+      isResolved: true,
     });
     mockedUseBranding.mockReturnValue({
       data: { show_badge: true },
@@ -215,6 +216,7 @@ describe('AppLayout', () => {
       isEnterprise: true,
       isMultiTenant: false,
       isLoading: false,
+      isResolved: true,
     });
     mockedUseBranding.mockReturnValue({
       data: { show_badge: false },
@@ -233,6 +235,7 @@ describe('AppLayout', () => {
       isEnterprise: true,
       isMultiTenant: false,
       isLoading: false,
+      isResolved: true,
     });
     mockedUseBranding.mockReturnValue({
       data: { show_badge: true },

--- a/frontend/src/components/layout/__tests__/AppLayout.test.tsx
+++ b/frontend/src/components/layout/__tests__/AppLayout.test.tsx
@@ -11,6 +11,7 @@ import { useAuthStore } from '@/stores/auth-store';
 const permissionState = vi.hoisted(() => ({
   manageUsers: false,
   manageSettings: false,
+  manageTenants: false,
 }));
 
 vi.mock('@/hooks/use-permissions', () => ({
@@ -18,7 +19,9 @@ vi.mock('@/hooks/use-permissions', () => ({
     can: (capability: string) =>
       capability === 'manage_users'
         ? permissionState.manageUsers
-        : capability === 'manage_settings' && permissionState.manageSettings,
+        : capability === 'manage_settings'
+          ? permissionState.manageSettings
+          : capability === 'manage_tenants' && permissionState.manageTenants,
     permissions: {},
     isLoading: false,
   }),
@@ -55,6 +58,7 @@ describe('AppLayout', () => {
   beforeEach(() => {
     permissionState.manageUsers = false;
     permissionState.manageSettings = false;
+    permissionState.manageTenants = false;
     useAuthStore.setState({ token: null, refreshToken: null, expiresAt: null, user: null });
     mockedUseEdition.mockReturnValue({
       edition: 'community',
@@ -84,6 +88,39 @@ describe('AppLayout', () => {
         last_login_at: null,
         created_at: '2026-01-01T00:00:00Z',
         roles: ['settings-operator'],
+      },
+    });
+
+    renderAppLayout();
+
+    expect(document.querySelector('a[href="/admin"]')).not.toBeNull();
+  });
+
+  // fix(#817): a multi-tenant fleet operator can hold manage_tenants alone —
+  // the admin routes admit them, so the navbar entry must be discoverable too.
+  it('shows the admin entry to a manage_tenants-only fleet operator in multi-tenant mode', () => {
+    permissionState.manageTenants = true;
+    mockedUseEdition.mockReturnValue({
+      edition: 'enterprise',
+      features: [],
+      isEnterprise: true,
+      isMultiTenant: true,
+      isLoading: false,
+      isResolved: true,
+    });
+    useAuthStore.setState({
+      token: 'token',
+      refreshToken: null,
+      expiresAt: Date.now() + 900_000,
+      user: {
+        id: 'fleet-operator',
+        username: 'fleet-operator',
+        email: 'fleet@example.com',
+        is_active: true,
+        status: 'active',
+        last_login_at: null,
+        created_at: '2026-01-01T00:00:00Z',
+        roles: ['fleet-operator'],
       },
     });
 

--- a/frontend/src/components/viewer/__tests__/ViewerMap.branding.test.tsx
+++ b/frontend/src/components/viewer/__tests__/ViewerMap.branding.test.tsx
@@ -98,6 +98,7 @@ describe('ViewerMap — SHARE-07 branding overlay', () => {
       isEnterprise: false,
       isMultiTenant: false,
       isLoading: false,
+      isResolved: true,
     });
     mockedUseBranding.mockReturnValue({
       data: { show_badge: true },
@@ -116,6 +117,7 @@ describe('ViewerMap — SHARE-07 branding overlay', () => {
       isEnterprise: true,
       isMultiTenant: false,
       isLoading: false,
+      isResolved: true,
     });
     mockedUseBranding.mockReturnValue({
       data: { show_badge: false },
@@ -133,6 +135,7 @@ describe('ViewerMap — SHARE-07 branding overlay', () => {
       isEnterprise: true,
       isMultiTenant: false,
       isLoading: false,
+      isResolved: true,
     });
     mockedUseBranding.mockReturnValue({
       data: { show_badge: true },
@@ -150,6 +153,7 @@ describe('ViewerMap — SHARE-07 branding overlay', () => {
       isEnterprise: false,
       isMultiTenant: false,
       isLoading: false,
+      isResolved: true,
     });
     mockedUseBranding.mockReturnValue({
       data: undefined,

--- a/frontend/src/hooks/use-edition.ts
+++ b/frontend/src/hooks/use-edition.ts
@@ -25,6 +25,12 @@ export function useEdition() {
     isEnterprise: data?.edition === 'enterprise',
     isMultiTenant: data?.tenancy_mode === 'multi_tenant',
     isLoading,
+    // fix(#817): true once the edition endpoint has answered (a response
+    // without tenancy_mode IS a resolved single-tenant deployment); false
+    // while loading or after a fetch failure. Consumers that must not guess
+    // the tenancy mode (useSettingsAdmin) fail closed on this instead of
+    // treating "not fetched yet" as single-tenant.
+    isResolved: data !== undefined,
   };
 }
 

--- a/frontend/src/hooks/use-settings-admin.ts
+++ b/frontend/src/hooks/use-settings-admin.ts
@@ -1,0 +1,18 @@
+import { usePermissions } from '@/hooks/use-permissions';
+import { useEdition } from '@/hooks/use-edition';
+
+// fix(#817): mirror the backend's require_settings_admin
+// (backend/app/modules/settings/router.py) and require_config_operator
+// (backend/app/platform/config_ops/router.py), which gate every /settings/*
+// and /config-ops/* endpoint on manage_settings in single-tenant deployments
+// but manage_tenants in multi-tenant. A default per-tenant admin holds
+// manage_settings without manage_tenants, so a plain manage_settings gate
+// admitted them to the Settings tabs where every read and save 403s. Every
+// surface that routes or links to /admin/settings/* or /admin/config-ops
+// must gate on this hook so the pattern can't drift per-component (same
+// pattern as useAIStatusReader for /admin/ai-status reads, #653).
+export function useSettingsAdmin(): boolean {
+  const { can } = usePermissions();
+  const { isMultiTenant } = useEdition();
+  return isMultiTenant ? can('manage_tenants') : can('manage_settings');
+}

--- a/frontend/src/hooks/use-settings-admin.ts
+++ b/frontend/src/hooks/use-settings-admin.ts
@@ -13,6 +13,12 @@ import { useEdition } from '@/hooks/use-edition';
 // pattern as useAIStatusReader for /admin/ai-status reads, #653).
 export function useSettingsAdmin(): boolean {
   const { can } = usePermissions();
-  const { isMultiTenant } = useEdition();
+  const { isMultiTenant, isResolved } = useEdition();
+  // fix(#817): fail closed until the tenancy mode is actually known. If
+  // permissions resolve before the edition query (or the edition fetch
+  // fails), assuming single-tenant would briefly authorize a multi-tenant
+  // per-tenant admin — recreating the dead links and 403s this hook exists
+  // to prevent.
+  if (!isResolved) return false;
   return isMultiTenant ? can('manage_tenants') : can('manage_settings');
 }

--- a/frontend/src/pages/__tests__/PublicViewerPage.test.tsx
+++ b/frontend/src/pages/__tests__/PublicViewerPage.test.tsx
@@ -145,6 +145,7 @@ describe('PublicViewerPage', () => {
       isEnterprise: true,
       isMultiTenant: false,
       isLoading: false,
+      isResolved: true,
     });
 
     mockedUseBranding.mockReturnValue({

--- a/frontend/src/pages/admin/__tests__/AdminSamlPage.test.tsx
+++ b/frontend/src/pages/admin/__tests__/AdminSamlPage.test.tsx
@@ -24,6 +24,7 @@ describe('AdminSamlPage', () => {
       isEnterprise: false,
       isMultiTenant: false,
       isLoading: false,
+      isResolved: true,
     });
 
     render(<AdminSamlPage />, { route: '/admin/saml' });
@@ -43,6 +44,7 @@ describe('AdminSamlPage', () => {
       isEnterprise: true,
       isMultiTenant: false,
       isLoading: false,
+      isResolved: true,
     });
 
     render(<AdminSamlPage />, { route: '/admin/saml' });
@@ -59,6 +61,7 @@ describe('AdminSamlPage', () => {
       isEnterprise: false,
       isMultiTenant: false,
       isLoading: true,
+      isResolved: false,
     });
 
     render(<AdminSamlPage />, { route: '/admin/saml' });
@@ -75,6 +78,7 @@ describe('AdminSamlPage', () => {
       isEnterprise: false,
       isMultiTenant: false,
       isLoading: false,
+      isResolved: true,
     });
 
     render(<AdminSamlPage />, { route: '/admin/saml' });


### PR DESCRIPTION
## Summary

In multi-tenant deployments, the `/settings/*` and `/config-ops/*` APIs (`require_settings_admin` in `backend/app/modules/settings/router.py`, `require_config_operator` in `backend/app/platform/config_ops/router.py`) and the `/admin/ai-status` write path all require `manage_tenants`, while the frontend route gate for `/admin/settings/:tab` was a plain `manage_settings` check in both modes. A default per-tenant admin (`manage_settings=True, manage_tenants=False` per `DEFAULT_ROLE_PERMISSIONS`) could open the AI settings tab — including via the #816 builder CTA — edit the form, and 403 on every read and save.

Frontend-only fix, no API or schema changes:

- New `useSettingsAdmin()` hook (`frontend/src/hooks/use-settings-admin.ts`) mirroring the backend mode-aware dependency: `manage_settings` single-tenant, `manage_tenants` multi-tenant. Same pattern as `useAIStatusReader` (#653).
- New `AdminSettingsRoute` gates `/admin/settings/:tab` (all tabs), the `/admin/settings` redirect, and `/admin/config-ops`. It waits for both the permissions and edition queries before deciding, then redirects to `/admin` when denied. `/admin/audit` stays under the plain `manage_settings` capability route (its backend is `manage_settings` in both modes).
- All surfaces that link to the settings pages now use the same gate so a denied admin never sees a dead link: the AdminSidebar Settings nav group (and its `/settings/enterprise-tabs/` query enable flag), the BuilderRail AI-disabled Settings CTA (#816), and the AIStatusCard "Manage AI settings" link.

Not touched: `/admin/saml` also fronts the mode-aware `/settings/oauth-providers` endpoints, but per-tenant SAML management semantics may differ under the enterprise overlay, so it is deliberately left on `manage_settings` rather than folded into this fix.

New tests: `AdminSettingsRoute` admit/deny/loading matrix across tenancy modes, multi-tenant BuilderRail CTA visibility, and a multi-tenant AdminSidebar case (Settings group hidden, enterprise-tabs query disabled, Audit Log still visible).

Closes #817

## Verification

- `cd frontend && npm run lint` — pass
- `cd frontend && npm run typecheck` — pass
- `cd frontend && npx vitest run src/components/auth/__tests__/AdminRoute.test.tsx src/components/builder/__tests__/BuilderRail.test.tsx src/components/admin/__tests__/AdminSidebar.test.tsx src/components/admin/__tests__/AIStatusCard.capabilities.test.tsx` — 52 passed
- `cd frontend && npx vitest run src/pages/admin src/components/admin/settings` — 77 passed