### PR TITLE
fix(frontend): a11y/UX follow-ups batch from the 1.6.0 pre-tag audit

### DIFF
--- a/frontend/src/api/__tests__/geojson-z.test.ts
+++ b/frontend/src/api/__tests__/geojson-z.test.ts
@@ -64,12 +64,17 @@ describe('fetchBoundedGeoJson', () => {
     );
   });
 
-  it('uses the API key query parameter for public API-key contexts', async () => {
+  // fix(#833): the API key must travel in the X-Api-Key header, never the
+  // query string (query strings land in server/proxy logs).
+  it('uses the X-Api-Key header for public API-key contexts', async () => {
     mockFetch.mockResolvedValueOnce(jsonResponse(boundedGeoJson));
 
     await fetchBoundedGeoJson('dataset-1', { apiKey: 'key 1' });
 
-    expect(mockFetch).toHaveBeenCalledWith('/api/datasets/dataset-1/features.geojson?api_key=key%201');
+    expect(mockFetch).toHaveBeenCalledWith(
+      '/api/datasets/dataset-1/features.geojson',
+      { headers: { 'X-Api-Key': 'key 1' } },
+    );
   });
 
   it('keeps fetchGeoJsonZ as a compatibility alias', async () => {
@@ -78,7 +83,10 @@ describe('fetchBoundedGeoJson', () => {
     const response = await fetchGeoJsonZ('dataset-1', { apiKey: 'key' });
 
     expect(response).toEqual(boundedGeoJson);
-    expect(mockFetch).toHaveBeenCalledWith('/api/datasets/dataset-1/features.geojson?api_key=key');
+    expect(mockFetch).toHaveBeenCalledWith(
+      '/api/datasets/dataset-1/features.geojson',
+      { headers: { 'X-Api-Key': 'key' } },
+    );
   });
 
   it('converts bounded GeoJSON responses to plain FeatureCollections for MapLibre', () => {

--- a/frontend/src/api/geojson-z.ts
+++ b/frontend/src/api/geojson-z.ts
@@ -69,7 +69,11 @@ export async function fetchBoundedGeoJson(
   }
 
   if (options?.apiKey) {
-    const res = await fetch(`${directFetchPath(datasetId)}?api_key=${encodeURIComponent(options.apiKey)}`);
+    // fix(#833): send the key in the X-Api-Key header (same form the embed
+    // path uses above) — a query-string credential lands in server/proxy logs.
+    const res = await fetch(directFetchPath(datasetId), {
+      headers: { 'X-Api-Key': options.apiKey },
+    });
     if (!res.ok) await throwLocalizedResponseError(res);
     return res.json() as Promise<BoundedGeoJsonResponse>;
   }

--- a/frontend/src/components/analysis/AnalysisJobWatcher.tsx
+++ b/frontend/src/components/analysis/AnalysisJobWatcher.tsx
@@ -105,8 +105,13 @@ export function AnalysisJobWatcher() {
                     analysisAddToMap.mapId === job.mapId
                   ) {
                     const added = useAnalysisAddedStore.getState();
-                    if (added.addedDatasetIds.includes(datasetId)) return;
-                    added.markAdded(datasetId);
+                    if (
+                      added.addedDatasetIds.includes(datasetId) ||
+                      added.pendingAddIds.includes(datasetId)
+                    ) {
+                      return;
+                    }
+                    added.markPending(datasetId);
                     analysisAddToMap.current(datasetId);
                   } else {
                     // View-dataset path: navigation is idempotent, no guard.

--- a/frontend/src/components/analysis/AnalysisJobWatcher.tsx
+++ b/frontend/src/components/analysis/AnalysisJobWatcher.tsx
@@ -7,7 +7,7 @@ import { queryKeys } from '@/lib/query-keys';
 import { ApiError } from '@/api/client';
 import { useJobStatus } from '@/components/import/hooks/use-ingest';
 import { useAnalysisFormStore } from '@/stores/analysis-form-store';
-import { analysisAddToMap, useAnalysisJobStore } from '@/stores/analysis-job-store';
+import { analysisAddToMap, useAnalysisAddedStore, useAnalysisJobStore } from '@/stores/analysis-job-store';
 
 /**
  * Global notifier for a materialize-analysis job (renders nothing).
@@ -66,10 +66,11 @@ export function AnalysisJobWatcher() {
         !!analysisAddToMap.current && analysisAddToMap.mapId === job.mapId;
       // Sonner dismisses a toast when its action is clicked, but the exit
       // animation leaves a window for a second click — and the panel's own
-      // "Add to map" button is a second affordance for the same add. Each
-      // affordance goes single-use after its click; the add itself stays
-      // repeatable elsewhere (adding a dataset twice is legitimate).
-      let addActionUsed = false;
+      // "Add to map" button is a second affordance for the same add.
+      // fix(#833): the single-use guard is the SHARED useAnalysisAddedStore
+      // (it used to be a local flag per affordance, so toast + panel button
+      // together added the layer twice); the add itself stays repeatable
+      // elsewhere (adding a dataset twice is legitimate).
       toast.success(
         job.title
           ? t('analysisTools.jobCompleteNamed', {
@@ -97,16 +98,18 @@ export function AnalysisJobWatcher() {
                   ? t('analysisTools.addToMap', { defaultValue: 'Add to map' })
                   : t('analysisTools.viewDataset', { defaultValue: 'View dataset' }),
                 onClick: () => {
-                  if (addActionUsed) return;
-                  addActionUsed = true;
                   // Re-check: the builder may have unmounted since this toast
                   // was raised.
                   if (
                     analysisAddToMap.current &&
                     analysisAddToMap.mapId === job.mapId
                   ) {
+                    const added = useAnalysisAddedStore.getState();
+                    if (added.addedDatasetIds.includes(datasetId)) return;
+                    added.markAdded(datasetId);
                     analysisAddToMap.current(datasetId);
                   } else {
+                    // View-dataset path: navigation is idempotent, no guard.
                     navigate(`/datasets/${datasetId}`);
                   }
                 },

--- a/frontend/src/components/analysis/__tests__/AnalysisJobWatcher.test.tsx
+++ b/frontend/src/components/analysis/__tests__/AnalysisJobWatcher.test.tsx
@@ -48,7 +48,7 @@ describe('AnalysisJobWatcher', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     useAnalysisJobStore.setState({ job: null });
-    useAnalysisAddedStore.setState({ addedDatasetIds: [] });
+    useAnalysisAddedStore.setState({ addedDatasetIds: [], pendingAddIds: [] });
     analysisAddToMap.current = null;
     analysisAddToMap.mapId = null;
   });
@@ -234,7 +234,7 @@ describe('AnalysisJobWatcher', () => {
     };
 
     // The panel button already added this dataset — the toast must not repeat.
-    useAnalysisAddedStore.getState().markAdded('ds9');
+    useAnalysisAddedStore.getState().confirmAdded('ds9');
     action.onClick();
     expect(onAdd).not.toHaveBeenCalled();
   });

--- a/frontend/src/components/analysis/__tests__/AnalysisJobWatcher.test.tsx
+++ b/frontend/src/components/analysis/__tests__/AnalysisJobWatcher.test.tsx
@@ -3,7 +3,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { toast } from 'sonner';
 import { AnalysisJobWatcher } from '../AnalysisJobWatcher';
 import { useAnalysisFormStore } from '@/stores/analysis-form-store';
-import { analysisAddToMap, useAnalysisJobStore } from '@/stores/analysis-job-store';
+import { analysisAddToMap, useAnalysisAddedStore, useAnalysisJobStore } from '@/stores/analysis-job-store';
 import { useAuthStore } from '@/stores/auth-store';
 import { useJobStatus } from '@/components/import/hooks/use-ingest';
 import { ApiError } from '@/api/client';
@@ -48,6 +48,7 @@ describe('AnalysisJobWatcher', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     useAnalysisJobStore.setState({ job: null });
+    useAnalysisAddedStore.setState({ addedDatasetIds: [] });
     analysisAddToMap.current = null;
     analysisAddToMap.mapId = null;
   });
@@ -213,6 +214,29 @@ describe('AnalysisJobWatcher', () => {
     action.onClick();
     action.onClick();
     expect(onAdd).toHaveBeenCalledTimes(1);
+  });
+
+  // fix(#833): the single-use guard is shared with the Analysis panel's own
+  // "Add to map" button — each affordance used to dedupe only against itself,
+  // so clicking the toast action and then the panel button added twice.
+  it('the toast action shares its single-use marker via useAnalysisAddedStore', async () => {
+    const onAdd = vi.fn();
+    analysisAddToMap.current = onAdd;
+    analysisAddToMap.mapId = 'm1';
+    useAnalysisJobStore.setState({ job: { jobId: 'j1', title: 'Buffered', mapId: 'm1' } });
+    mockJob({ status: 'complete', dataset_id: 'ds9' });
+    renderWatcher();
+
+    await waitFor(() => expect(toast.success).toHaveBeenCalled());
+    const action = vi.mocked(toast.success).mock.calls[0][1]?.action as {
+      label: string;
+      onClick: () => void;
+    };
+
+    // The panel button already added this dataset — the toast must not repeat.
+    useAnalysisAddedStore.getState().markAdded('ds9');
+    action.onClick();
+    expect(onAdd).not.toHaveBeenCalled();
   });
 
   it('surfaces the persisted warning_message beside the completion toast', async () => {

--- a/frontend/src/components/builder/AnalysisPanel.tsx
+++ b/frontend/src/components/builder/AnalysisPanel.tsx
@@ -26,7 +26,7 @@ import {
   type SavedAnalysisForm,
 } from '@/stores/analysis-form-store';
 import { useAuthStore } from '@/stores/auth-store';
-import { useAnalysisJobStore } from '@/stores/analysis-job-store';
+import { useAnalysisAddedStore, useAnalysisJobStore } from '@/stores/analysis-job-store';
 import { useMapDrawStore } from '@/stores/map-draw-store';
 import type { LayerActions } from '@/components/builder/ChatPanel';
 import { isAnalysableLayer } from '@/components/builder/analysis-eligibility';
@@ -289,12 +289,15 @@ export function AnalysisPanel({
       : '';
   });
   // A completed run raises TWO "Add to map" affordances (this button and the
-  // watcher's toast action) and both added — mark this one used after its
-  // click so a second click can't add the layer twice. Keyed on the dataset
-  // id, so a NEW run's completion re-enables it. Deliberately local: adding
-  // a dataset twice via other surfaces is legitimate, so no global
+  // watcher's toast action). fix(#833): the single-use marker is the SHARED
+  // useAnalysisAddedStore — a per-affordance flag deduped each button against
+  // itself but not against the other, so clicking the toast action and then
+  // this button added the layer twice. Keyed on the dataset id, so a NEW
+  // run's completion re-enables it. Scoped to the analysis affordances only:
+  // adding a dataset twice via other surfaces is legitimate, so no global
   // idempotency in onAddDataset.
-  const [addedDatasetId, setAddedDatasetId] = useState<string | null>(null);
+  const addedDatasetIds = useAnalysisAddedStore((s) => s.addedDatasetIds);
+  const markDatasetAdded = useAnalysisAddedStore((s) => s.markAdded);
   // fix(#793 review): a materialize can outlive the panel instance that
   // started it — closed during the POST, reopened before the response lands.
   // The mount-time initializers above see no tracked job yet, so a job that
@@ -1359,18 +1362,19 @@ export function AnalysisPanel({
                 size="sm"
                 className="w-full"
                 // Completion raises this button AND the watcher's toast
-                // action, and both added — mark this one used after its
-                // click. See addedDatasetId.
-                disabled={addedDatasetId === job.dataset_id}
+                // action. fix(#833): both share one single-use marker —
+                // see addedDatasetIds above.
+                disabled={addedDatasetIds.includes(job.dataset_id)}
                 onClick={() => {
                   if (!job.dataset_id) return;
+                  if (addedDatasetIds.includes(job.dataset_id)) return;
+                  markDatasetAdded(job.dataset_id);
                   layerActions.onAddDataset(job.dataset_id);
-                  setAddedDatasetId(job.dataset_id);
                 }}
               >
                 {/* fix(#764): name the dataset this adds — after a rail
                     round-trip or reload the field above may no longer say. */}
-                {addedDatasetId === job.dataset_id
+                {addedDatasetIds.includes(job.dataset_id)
                   ? t('analysisTools.addedToMap', { defaultValue: 'Added to map' })
                   : lastRunTitle
                     ? t('analysisTools.addToMapNamed', {

--- a/frontend/src/components/builder/AnalysisPanel.tsx
+++ b/frontend/src/components/builder/AnalysisPanel.tsx
@@ -297,7 +297,8 @@ export function AnalysisPanel({
   // adding a dataset twice via other surfaces is legitimate, so no global
   // idempotency in onAddDataset.
   const addedDatasetIds = useAnalysisAddedStore((s) => s.addedDatasetIds);
-  const markDatasetAdded = useAnalysisAddedStore((s) => s.markAdded);
+  const pendingAddIds = useAnalysisAddedStore((s) => s.pendingAddIds);
+  const markDatasetPending = useAnalysisAddedStore((s) => s.markPending);
   // fix(#793 review): a materialize can outlive the panel instance that
   // started it — closed during the POST, reopened before the response lands.
   // The mount-time initializers above see no tracked job yet, so a job that
@@ -1362,13 +1363,22 @@ export function AnalysisPanel({
                 size="sm"
                 className="w-full"
                 // Completion raises this button AND the watcher's toast
-                // action. fix(#833): both share one single-use marker —
-                // see addedDatasetIds above.
-                disabled={addedDatasetIds.includes(job.dataset_id)}
+                // action. fix(#833): both share one single-use guard —
+                // pending while the add mutation is in flight (re-armed if
+                // it fails), confirmed once it succeeds.
+                disabled={
+                  addedDatasetIds.includes(job.dataset_id) ||
+                  pendingAddIds.includes(job.dataset_id)
+                }
                 onClick={() => {
                   if (!job.dataset_id) return;
-                  if (addedDatasetIds.includes(job.dataset_id)) return;
-                  markDatasetAdded(job.dataset_id);
+                  if (
+                    addedDatasetIds.includes(job.dataset_id) ||
+                    pendingAddIds.includes(job.dataset_id)
+                  ) {
+                    return;
+                  }
+                  markDatasetPending(job.dataset_id);
                   layerActions.onAddDataset(job.dataset_id);
                 }}
               >

--- a/frontend/src/components/builder/BasemapSublayerEditorScene.tsx
+++ b/frontend/src/components/builder/BasemapSublayerEditorScene.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { ChevronRight } from 'lucide-react';
 import {
@@ -79,6 +79,14 @@ export function BasemapSublayerEditorScene({
   const { t } = useTranslation('builder');
   const [resetOpen, setResetOpen] = useState(false);
   const [confirmingReset, setConfirmingReset] = useState(false);
+  // fix(#833): the inline confirm owns focus (autofocused Cancel), so both
+  // exits must hand focus back to the reappearing "Reset to default" button
+  // instead of <body> — the focus return StackRow's delete confirm does.
+  // rAF: the button remounts on the state flip, so it does not exist yet at
+  // onConfirm/onCancel time.
+  const resetButtonRef = useRef<HTMLButtonElement>(null);
+  const focusResetButton = () =>
+    requestAnimationFrame(() => resetButtonRef.current?.focus());
 
   // Reset confirmingReset and resetOpen when sublayerId changes.
   // Without resetting resetOpen, navigating from sublayer A (with the RESET collapsible
@@ -300,6 +308,7 @@ export function BasemapSublayerEditorScene({
           <div className="px-4 py-2 border-b">
             {!confirmingReset ? (
               <Button
+                ref={resetButtonRef}
                 type="button"
                 variant="ghost"
                 className="w-full"
@@ -321,8 +330,12 @@ export function BasemapSublayerEditorScene({
                 onConfirm={() => {
                   onResetSublayer();
                   setConfirmingReset(false);
+                  focusResetButton();
                 }}
-                onCancel={() => setConfirmingReset(false)}
+                onCancel={() => {
+                  setConfirmingReset(false);
+                  focusResetButton();
+                }}
                 className="mx-0 mb-0"
               />
             )}

--- a/frontend/src/components/builder/BulkActionBar.tsx
+++ b/frontend/src/components/builder/BulkActionBar.tsx
@@ -72,6 +72,12 @@ export const BulkActionBar = memo(function BulkActionBar({
   const [confirmingDelete, setConfirmingDelete] = useState(false);
   const [mounted, setMounted] = useState(false);
   const confirmId = useId();
+  // fix(#833): the overflow items' aria-label overrides their subtree as the
+  // accessible name, so the inline disabled-reason hints were invisible to
+  // assistive tech. Exposing each hint via aria-describedby (only while it
+  // renders) keeps the short label as the name and surfaces the reason as the
+  // description.
+  const hintId = useId();
   const barRef = useRef<HTMLDivElement>(null);
   const confirmRef = useRef<HTMLDivElement>(null);
 
@@ -416,6 +422,7 @@ export const BulkActionBar = memo(function BulkActionBar({
                   data-testid="bulk-action-apply-style"
                   disabled={N < 2}
                   aria-label={t('bulkActions.applyStyleAriaLabel', { count: N })}
+                  aria-describedby={N < 2 ? `${hintId}-apply-style` : undefined}
                   onSelect={() => {
                     if (N >= 2) onBulkApplyStyle(selectedIds);
                   }}
@@ -426,7 +433,7 @@ export const BulkActionBar = memo(function BulkActionBar({
                   <span className="flex flex-col items-start">
                     {t('bulkActions.applyStyle')}
                     {N < 2 && (
-                      <span className="text-2xs text-muted-foreground">
+                      <span id={`${hintId}-apply-style`} className="text-2xs text-muted-foreground">
                         {t('bulkActions.applyStyleHint', { defaultValue: 'Select at least 2 layers' })}
                       </span>
                     )}
@@ -437,6 +444,7 @@ export const BulkActionBar = memo(function BulkActionBar({
                 data-testid="bulk-action-group"
                 disabled={!canGroup}
                 aria-label={t('bulkActions.groupAriaLabel', { count: N })}
+                aria-describedby={!canGroup ? `${hintId}-group` : undefined}
                 onSelect={() => {
                   if (canGroup) onBulkGroup(selectedIds);
                 }}
@@ -445,7 +453,7 @@ export const BulkActionBar = memo(function BulkActionBar({
                 <span className="flex flex-col items-start">
                   {t('bulkActions.group')}
                   {!canGroup && (
-                    <span className="text-2xs text-muted-foreground">
+                    <span id={`${hintId}-group`} className="text-2xs text-muted-foreground">
                       {t('bulkActions.groupHint', { defaultValue: 'Only ungrouped layers can be grouped' })}
                     </span>
                   )}
@@ -455,6 +463,7 @@ export const BulkActionBar = memo(function BulkActionBar({
                 data-testid="bulk-action-ungroup"
                 disabled={!canUngroup}
                 aria-label={t('bulkActions.ungroupAriaLabel', { count: N })}
+                aria-describedby={!canUngroup ? `${hintId}-ungroup` : undefined}
                 onSelect={() => {
                   if (canUngroup) onBulkUngroup(selectedIds);
                 }}
@@ -463,7 +472,7 @@ export const BulkActionBar = memo(function BulkActionBar({
                 <span className="flex flex-col items-start">
                   {t('bulkActions.ungroup')}
                   {!canUngroup && (
-                    <span className="text-2xs text-muted-foreground">
+                    <span id={`${hintId}-ungroup`} className="text-2xs text-muted-foreground">
                       {t('bulkActions.ungroupHint', { defaultValue: 'Select only group rows to ungroup' })}
                     </span>
                   )}
@@ -477,6 +486,7 @@ export const BulkActionBar = memo(function BulkActionBar({
                 // the handler filters them out, so confirming would delete nothing.
                 disabled={deletableCount === 0}
                 aria-label={t('bulkActions.deleteAriaLabel', { count: deletableCount })}
+                aria-describedby={deletableCount === 0 ? `${hintId}-delete` : undefined}
                 onSelect={(e) => {
                   // Keep the row from auto-closing the menu so the inline
                   // confirmation dialog appears in the toolbar below.
@@ -488,7 +498,7 @@ export const BulkActionBar = memo(function BulkActionBar({
                 <span className="flex flex-col items-start">
                   {t('bulkActions.delete')}
                   {deletableCount === 0 && (
-                    <span className="text-2xs text-muted-foreground">
+                    <span id={`${hintId}-delete`} className="text-2xs text-muted-foreground">
                       {t('bulkActions.deleteHint', { defaultValue: 'Group rows are deleted from their row menu' })}
                     </span>
                   )}

--- a/frontend/src/components/builder/DEMEditorScene.tsx
+++ b/frontend/src/components/builder/DEMEditorScene.tsx
@@ -1,4 +1,4 @@
-import { memo, useCallback, useMemo, useState } from 'react';
+import { memo, useCallback, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Slider } from '@/components/ui/slider';
 import { Label } from '@/components/ui/label';
@@ -156,6 +156,11 @@ export const DEMEditorScene = memo(function DEMEditorScene({
 }: DEMEditorSceneProps) {
   const { t } = useTranslation('builder');
   const [confirmDelete, setConfirmDelete] = useState(false);
+  // fix(#833): the inline confirm owns focus (autofocused Cancel), so
+  // dismissing it must hand focus back to the trigger instead of <body> —
+  // same return StackRow's delete confirm does. rAF: the button remounts on
+  // the state flip, so it does not exist yet at onCancel time.
+  const deleteButtonRef = useRef<HTMLButtonElement>(null);
   // 'hillshade' = visible relief overlay on; 'terrain' is the legacy persisted
   // value meaning "no visual overlay" — it does NOT control the 3D mesh, which
   // is bound separately through map-level terrain_config (isTerrainBound).
@@ -523,6 +528,7 @@ export const DEMEditorScene = memo(function DEMEditorScene({
       <footer className="shrink-0 border-t p-3 mt-auto">
         {!confirmDelete ? (
           <Button
+            ref={deleteButtonRef}
             type="button"
             variant="ghost"
             className="w-full text-destructive hover:text-destructive hover:bg-destructive/10"
@@ -542,7 +548,13 @@ export const DEMEditorScene = memo(function DEMEditorScene({
               onRemove(layer.id);
               setConfirmDelete(false);
             }}
-            onCancel={() => setConfirmDelete(false)}
+            onCancel={() => {
+              setConfirmDelete(false);
+              // fix(#833): hand focus back to the Delete-layer button instead
+              // of dropping to <body> (confirm removes the whole scene, so
+              // there is no surviving trigger to return to on that path).
+              requestAnimationFrame(() => deleteButtonRef.current?.focus());
+            }}
             className="mx-0 mb-0"
           />
         )}

--- a/frontend/src/components/builder/LayerStyleEditor.tsx
+++ b/frontend/src/components/builder/LayerStyleEditor.tsx
@@ -385,10 +385,19 @@ export const LayerStyleEditor = memo(function LayerStyleEditor({
   // Reset destroys render mode + classification — gate it behind the builder's
   // shared inline confirm (same pattern as the DEM editor's delete footer).
   const [confirmReset, setConfirmReset] = useState(false);
+  // fix(#833): the inline confirm owns focus (autofocused Cancel), so both
+  // exits must hand focus back to the always-mounted Reset trigger instead of
+  // <body> — the focus return StackRow's delete confirm does.
+  const resetButtonRef = useRef<HTMLButtonElement>(null);
   const handleConfirmReset = useCallback(() => {
     setConfirmReset(false);
     handleResetStyle();
+    resetButtonRef.current?.focus();
   }, [handleResetStyle]);
+  const handleCancelReset = useCallback(() => {
+    setConfirmReset(false);
+    resetButtonRef.current?.focus();
+  }, []);
 
   // Bumped by handleRevertToSaved to force-remount the data-driven editor.
   const [revertNonce, setRevertNonce] = useState(0);
@@ -513,6 +522,7 @@ export const LayerStyleEditor = memo(function LayerStyleEditor({
         )}
         headerAction={
           <Button
+            ref={resetButtonRef}
             type="button"
             variant="ghost"
             size="xs"
@@ -532,7 +542,7 @@ export const LayerStyleEditor = memo(function LayerStyleEditor({
             confirmLabel={t('style.resetConfirmAction')}
             cancelLabel={t('style.resetConfirmCancel')}
             onConfirm={handleConfirmReset}
-            onCancel={() => setConfirmReset(false)}
+            onCancel={handleCancelReset}
             className="mx-0 mb-0"
           />
         )}

--- a/frontend/src/components/builder/__tests__/AnalysisPanel.test.tsx
+++ b/frontend/src/components/builder/__tests__/AnalysisPanel.test.tsx
@@ -7,7 +7,7 @@ import { AnalysisPanel } from '../AnalysisPanel';
 import { ApiError } from '@/api/client';
 import { materializeAnalysis, previewAnalysis } from '@/api/analysis';
 import { useAnalysisFormStore } from '@/stores/analysis-form-store';
-import { useAnalysisJobStore } from '@/stores/analysis-job-store';
+import { useAnalysisAddedStore, useAnalysisJobStore } from '@/stores/analysis-job-store';
 import { useAuthStore } from '@/stores/auth-store';
 import type { MapLayerResponse, UserResponse } from '@/types/api';
 
@@ -224,7 +224,11 @@ beforeEach(() => {
 });
 
 describe('AnalysisPanel', () => {
-  beforeEach(() => useAnalysisJobStore.setState({ job: null }));
+  beforeEach(() => {
+    useAnalysisJobStore.setState({ job: null });
+    // fix(#833): the add-to-map single-use marker is a module-level store now.
+    useAnalysisAddedStore.setState({ addedDatasetIds: [] });
+  });
 
   it('treats a raster-only map as having no analysable layers (#720)', () => {
     renderPanel([rasterLayer, groupLayer]);
@@ -1672,6 +1676,29 @@ describe('AnalysisPanel — audit remediation (v1.6.0)', () => {
     expect(usedButton).toBeDisabled();
     fireEvent.click(usedButton);
     expect(onAddDataset).toHaveBeenCalledTimes(1);
+  });
+
+  // fix(#833): the single-use marker is shared with the watcher's toast
+  // action — each affordance used to dedupe only against itself, so clicking
+  // the toast action and then this button added the layer twice.
+  it('disables the panel Add to map when the toast action already added', async () => {
+    mockJobStatus.value = { status: 'complete', dataset_id: 'out1' };
+    const onAddDataset = vi.fn();
+    // The watcher's toast action performed the add.
+    useAnalysisAddedStore.getState().markAdded('out1');
+    renderPanel([datasetLayer], {
+      mapId: 'm1',
+      layerActions: { onAddDataset } as never,
+    });
+    fireEvent.change(screen.getByLabelText('New dataset name'), {
+      target: { value: 'Out' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Create dataset' }));
+
+    const usedButton = await screen.findByRole('button', { name: 'Added to map' });
+    expect(usedButton).toBeDisabled();
+    fireEvent.click(usedButton);
+    expect(onAddDataset).not.toHaveBeenCalled();
   });
 
   it('sets aria-busy on the pending Preview button', async () => {

--- a/frontend/src/components/builder/__tests__/AnalysisPanel.test.tsx
+++ b/frontend/src/components/builder/__tests__/AnalysisPanel.test.tsx
@@ -227,7 +227,7 @@ describe('AnalysisPanel', () => {
   beforeEach(() => {
     useAnalysisJobStore.setState({ job: null });
     // fix(#833): the add-to-map single-use marker is a module-level store now.
-    useAnalysisAddedStore.setState({ addedDatasetIds: [] });
+    useAnalysisAddedStore.setState({ addedDatasetIds: [], pendingAddIds: [] });
   });
 
   it('treats a raster-only map as having no analysable layers (#720)', () => {
@@ -1320,6 +1320,7 @@ describe('AnalysisPanel — stack-selected layer (#772)', () => {
     mockJobStatus.error = null;
     useAnalysisFormStore.setState({ forms: {} });
     useAnalysisJobStore.setState({ job: null });
+    useAnalysisAddedStore.setState({ addedDatasetIds: [], pendingAddIds: [] });
     useAuthStore.setState({ token: null, refreshToken: null, user: null });
     vi.mocked(previewAnalysis).mockClear();
     vi.mocked(materializeAnalysis).mockClear();
@@ -1487,6 +1488,7 @@ describe('AnalysisPanel — audit remediation (v1.6.0)', () => {
     mockJobStatus.error = null;
     useAnalysisFormStore.setState({ forms: {} });
     useAnalysisJobStore.setState({ job: null });
+    useAnalysisAddedStore.setState({ addedDatasetIds: [], pendingAddIds: [] });
     useAuthStore.setState({ token: null, refreshToken: null, user: null });
     vi.mocked(previewAnalysis).mockClear();
     vi.mocked(materializeAnalysis).mockClear();
@@ -1670,9 +1672,10 @@ describe('AnalysisPanel — audit remediation (v1.6.0)', () => {
     fireEvent.click(addButton);
     expect(onAddDataset).toHaveBeenCalledTimes(1);
 
-    // Completion also raises the watcher's toast action — each affordance is
-    // single-use so the pair can't add the layer twice.
-    const usedButton = screen.getByRole('button', { name: 'Added to map' });
+    // Completion also raises the watcher's toast action — the click claims a
+    // PENDING guard entry (confirmed only when the add mutation succeeds), so
+    // the pair can't add the layer twice while the request is in flight.
+    const usedButton = screen.getByRole('button', { name: 'Add "{{name}}" to map' });
     expect(usedButton).toBeDisabled();
     fireEvent.click(usedButton);
     expect(onAddDataset).toHaveBeenCalledTimes(1);
@@ -1685,7 +1688,7 @@ describe('AnalysisPanel — audit remediation (v1.6.0)', () => {
     mockJobStatus.value = { status: 'complete', dataset_id: 'out1' };
     const onAddDataset = vi.fn();
     // The watcher's toast action performed the add.
-    useAnalysisAddedStore.getState().markAdded('out1');
+    useAnalysisAddedStore.getState().confirmAdded('out1');
     renderPanel([datasetLayer], {
       mapId: 'm1',
       layerActions: { onAddDataset } as never,
@@ -1701,13 +1704,15 @@ describe('AnalysisPanel — audit remediation (v1.6.0)', () => {
     expect(onAddDataset).not.toHaveBeenCalled();
   });
 
-  // fix(#833 codex P2): the marker is set before the add mutation starts, so
-  // a failed add must unmark (handleAddDataset's onError) or the affordances
-  // stay retired with no retry path.
-  it('re-arms the panel Add to map when a failed add unmarks the dataset', async () => {
+  // fix(#833 codex P2): the guard is claimed (pending) before the add
+  // mutation starts, so a failed add must clear the pending claim
+  // (handleAddDataset's onError) or the affordances stay retired with no
+  // retry path. A confirmed entry is NOT cleared by failures — a failed
+  // catalog/chat/drag re-add of the same dataset can't un-retire the guard.
+  it('re-arms the panel Add to map when a failed add clears the pending claim', async () => {
     mockJobStatus.value = { status: 'complete', dataset_id: 'out1' };
     const onAddDataset = vi.fn();
-    useAnalysisAddedStore.getState().markAdded('out1');
+    useAnalysisAddedStore.getState().markPending('out1');
     renderPanel([datasetLayer], {
       mapId: 'm1',
       layerActions: { onAddDataset } as never,
@@ -1716,11 +1721,13 @@ describe('AnalysisPanel — audit remediation (v1.6.0)', () => {
       target: { value: 'Out' },
     });
     fireEvent.click(screen.getByRole('button', { name: 'Create dataset' }));
-    expect(await screen.findByRole('button', { name: 'Added to map' })).toBeDisabled();
+    expect(
+      await screen.findByRole('button', { name: 'Add "{{name}}" to map' }),
+    ).toBeDisabled();
 
-    // The add mutation failed — its onError unmarks the dataset.
+    // The add mutation failed — its onError clears the pending claim.
     act(() => {
-      useAnalysisAddedStore.getState().unmarkAdded('out1');
+      useAnalysisAddedStore.getState().clearPending('out1');
     });
 
     const retryButton = await screen.findByRole('button', {
@@ -1729,6 +1736,19 @@ describe('AnalysisPanel — audit remediation (v1.6.0)', () => {
     expect(retryButton).toBeEnabled();
     fireEvent.click(retryButton);
     expect(onAddDataset).toHaveBeenCalledTimes(1);
+  });
+
+  // fix(#833 codex round 6): clearPending only touches the pending claim — a
+  // failed NON-analysis add of the same dataset (which never claims one) must
+  // not un-retire a confirmed analysis add.
+  it('keeps a confirmed add retired when an unrelated add of the same dataset fails', () => {
+    const guard = useAnalysisAddedStore.getState();
+    guard.markPending('out1');
+    guard.confirmAdded('out1');
+    // handleAddDataset's onError for a failed catalog/chat/drag add.
+    useAnalysisAddedStore.getState().clearPending('out1');
+    expect(useAnalysisAddedStore.getState().addedDatasetIds).toContain('out1');
+    expect(useAnalysisAddedStore.getState().pendingAddIds).not.toContain('out1');
   });
 
   it('sets aria-busy on the pending Preview button', async () => {

--- a/frontend/src/components/builder/__tests__/AnalysisPanel.test.tsx
+++ b/frontend/src/components/builder/__tests__/AnalysisPanel.test.tsx
@@ -1701,6 +1701,36 @@ describe('AnalysisPanel — audit remediation (v1.6.0)', () => {
     expect(onAddDataset).not.toHaveBeenCalled();
   });
 
+  // fix(#833 codex P2): the marker is set before the add mutation starts, so
+  // a failed add must unmark (handleAddDataset's onError) or the affordances
+  // stay retired with no retry path.
+  it('re-arms the panel Add to map when a failed add unmarks the dataset', async () => {
+    mockJobStatus.value = { status: 'complete', dataset_id: 'out1' };
+    const onAddDataset = vi.fn();
+    useAnalysisAddedStore.getState().markAdded('out1');
+    renderPanel([datasetLayer], {
+      mapId: 'm1',
+      layerActions: { onAddDataset } as never,
+    });
+    fireEvent.change(screen.getByLabelText('New dataset name'), {
+      target: { value: 'Out' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Create dataset' }));
+    expect(await screen.findByRole('button', { name: 'Added to map' })).toBeDisabled();
+
+    // The add mutation failed — its onError unmarks the dataset.
+    act(() => {
+      useAnalysisAddedStore.getState().unmarkAdded('out1');
+    });
+
+    const retryButton = await screen.findByRole('button', {
+      name: 'Add "{{name}}" to map',
+    });
+    expect(retryButton).toBeEnabled();
+    fireEvent.click(retryButton);
+    expect(onAddDataset).toHaveBeenCalledTimes(1);
+  });
+
   it('sets aria-busy on the pending Preview button', async () => {
     let resolvePreview!: (v: unknown) => void;
     vi.mocked(previewAnalysis).mockImplementationOnce(

--- a/frontend/src/components/builder/__tests__/BasemapSublayerEditorScene.test.tsx
+++ b/frontend/src/components/builder/__tests__/BasemapSublayerEditorScene.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from '@/test/test-utils';
+import { fireEvent, render, screen, waitFor } from '@/test/test-utils';
 import { BasemapSublayerEditorScene, BasemapSublayerEditorFooter } from '../BasemapSublayerEditorScene';
 
 vi.mock('react-i18next', () => ({
@@ -153,6 +153,31 @@ describe('BasemapSublayerEditorScene', () => {
     expect(confirmResetBtn).toBeTruthy();
     fireEvent.click(confirmResetBtn!);
     expect(onResetSublayer).toHaveBeenCalledOnce();
+  });
+
+  // fix(#833): the inline confirm owns focus (autofocused Cancel) — both
+  // exits must hand focus back to the reappearing "Reset to default" button
+  // (next animation frame; it remounts) instead of dropping it on <body>.
+  it('dismissing the reset confirm returns focus to the Reset to default button', async () => {
+    render(<BasemapSublayerEditorScene {...defaultProps()} />);
+
+    fireEvent.click(screen.getByText('RESET').closest('button')!);
+    fireEvent.click(screen.getByRole('button', { name: /Reset to default/i }));
+    fireEvent.click(screen.getByRole('button', { name: /Keep customization/i }));
+
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: /Reset to default/i })).toHaveFocus(),
+    );
+
+    // Confirming also returns to the (reappearing) trigger.
+    fireEvent.click(screen.getByRole('button', { name: /Reset to default/i }));
+    const confirmBtn = screen
+      .getAllByRole('button')
+      .find((b) => b.textContent?.trim() === 'Reset');
+    fireEvent.click(confirmBtn!);
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: /Reset to default/i })).toHaveFocus(),
+    );
   });
 
   it('Test 12: footer renders ONE full-width "Back to basemap" ghost button; click calls onBackToBasemap()', () => {

--- a/frontend/src/components/builder/__tests__/BulkActionBar.test.tsx
+++ b/frontend/src/components/builder/__tests__/BulkActionBar.test.tsx
@@ -605,6 +605,13 @@ describe('BulkActionBar — deletable count excludes group rows (fix #771)', () 
     expect(deleteItem).toHaveAttribute('aria-disabled', 'true');
     // The inline hint states why (disabled menu items show no tooltip).
     expect(deleteItem.textContent).toContain('Group rows are deleted from their row menu');
+    // fix(#833): the item's aria-label overrides its subtree as the accessible
+    // name, so the hint must ALSO be exposed as the accessible description.
+    const hintId = deleteItem.getAttribute('aria-describedby');
+    expect(hintId).toBeTruthy();
+    expect(document.getElementById(hintId!)).toHaveTextContent(
+      'Group rows are deleted from their row menu',
+    );
 
     // Clicking the disabled item must NOT enter the confirmation state.
     fireEvent.click(deleteItem);

--- a/frontend/src/components/builder/__tests__/DEMEditorScene.test.tsx
+++ b/frontend/src/components/builder/__tests__/DEMEditorScene.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from '@/test/test-utils';
+import { fireEvent, render, screen, waitFor } from '@/test/test-utils';
 import { DEMEditorScene } from '../DEMEditorScene';
 import type { MapLayerResponse } from '@/types/api';
 
@@ -505,6 +505,20 @@ describe('DEMEditorScene', () => {
     // The DEMEditorScene renders a footer with a delete layer button
     const deleteBtn = screen.getByRole('button', { name: /Delete layer/i });
     expect(deleteBtn).toBeInTheDocument();
+  });
+
+  // fix(#833): the inline confirm owns focus (autofocused Cancel) —
+  // cancelling must hand focus back to the Delete-layer trigger instead of
+  // dropping it on <body>. (Confirm removes the whole scene, so there is no
+  // surviving trigger on that path.)
+  it('cancelling the delete confirm returns focus to the Delete layer button', async () => {
+    render(<DEMEditorScene {...defaultProps()} />);
+    fireEvent.click(screen.getByRole('button', { name: /Delete layer/i }));
+    fireEvent.click(screen.getByRole('button', { name: /Keep layer/i }));
+
+    // Focus returns on the next animation frame (the trigger remounts).
+    const deleteBtn = screen.getByRole('button', { name: /Delete layer/i });
+    await waitFor(() => expect(deleteBtn).toHaveFocus());
   });
 
   // --- CONTOUR LINES section: REMOVED in v1032 (CONTOUR-02 cut) ---

--- a/frontend/src/components/builder/__tests__/LayerStyleEditor.test.tsx
+++ b/frontend/src/components/builder/__tests__/LayerStyleEditor.test.tsx
@@ -191,6 +191,9 @@ describe('LayerStyleEditor - SP-05 pending preview banner gating', () => {
     await user.click(screen.getByRole('button', { name: 'Keep style' }));
     expect(onStyleConfigChange).not.toHaveBeenCalled();
     expect(screen.queryByRole('button', { name: 'Reset style' })).toBeNull();
+    // fix(#833): the confirm owned focus (autofocused Cancel) — dismissing it
+    // hands focus back to the Reset trigger instead of dropping to <body>.
+    expect(screen.getByRole('button', { name: 'Reset' })).toHaveFocus();
   });
 });
 

--- a/frontend/src/components/builder/__tests__/folder-groups.test.ts
+++ b/frontend/src/components/builder/__tests__/folder-groups.test.ts
@@ -3,6 +3,7 @@ import {
   hydrateFolderGroupLayers,
   prepareLayersForPersistence,
   pruneEmptyFolderGroups,
+  stampPersistedFolderGroupExpanded,
   resolveDropGroupMembership,
   type GroupedLayer,
 } from '../folder-groups';
@@ -103,6 +104,35 @@ describe('folder group persistence helpers', () => {
       folderGroupExpanded: true,
     });
     expect(persisted[1].style_config?.builder).toEqual({ outlineWidth: 2 });
+  });
+
+  // fix(#833 codex round 6): a group created this session has children with
+  // only parent_group_id — the post-save baseline must derive the marker the
+  // save just wrote, or every later save re-diffs those children against a
+  // marker-less baseline and emits a redundant style_config PATCH per child.
+  it('stamps derived markers onto children of a session-created group', () => {
+    const group = {
+      ...makeLayer({ id: 'group-1', display_name: 'Field layers' }),
+      layer_type: 'group:folder',
+    } as unknown as MapLayerResponse;
+    const newChild = {
+      ...makeLayer({ id: 'child-1', sort_order: 1 }),
+      parent_group_id: 'group-1',
+    } as GroupedLayer as MapLayerResponse;
+    const groupMeta = { 'group-1': { expanded: false } };
+
+    const stamped = stampPersistedFolderGroupExpanded([group, newChild], groupMeta);
+
+    const stampedChild = stamped.find((layer) => layer.id === 'child-1');
+    expect(stampedChild?.style_config?.builder).toMatchObject({
+      folderGroupId: 'group-1',
+      folderGroupName: 'Field layers',
+      folderGroupExpanded: false,
+    });
+    // The stamped marker must byte-match what prepareLayersForPersistence
+    // sent, so the next diff of an untouched group is empty.
+    const persisted = prepareLayersForPersistence([group, newChild], groupMeta);
+    expect(stampedChild?.style_config).toEqual(persisted[0].style_config);
   });
 });
 

--- a/frontend/src/components/builder/folder-groups.ts
+++ b/frontend/src/components/builder/folder-groups.ts
@@ -175,6 +175,31 @@ export function hydrateFolderGroupLayers(
   };
 }
 
+// fix(#833 codex): snapshot helper for the Save-diff baseline. The baseline
+// keeps the hydrated/local layer shape, but its persisted folderGroupExpanded
+// markers must reflect the collapse state that was just SAVED (the live
+// groupMeta), not the state the map loaded with — copying localLayers
+// verbatim after a collapse→save left the baseline saying "expanded", so the
+// following expand→save diffed empty and reload restored the stale collapse.
+// Layers without persisted markers, and groups without a groupMeta entry,
+// pass through as plain copies.
+export function stampPersistedFolderGroupExpanded(
+  layers: MapLayerResponse[],
+  groupMeta: Record<string, FolderGroupMeta> = {},
+): MapLayerResponse[] {
+  return layers.map((layer) => {
+    const persisted = getPersistedFolderGroup(layer);
+    const expanded = persisted ? groupMeta[persisted.id]?.expanded : undefined;
+    if (!persisted || expanded === undefined || persisted.expanded === expanded) {
+      return { ...layer };
+    }
+    return {
+      ...layer,
+      style_config: withPersistedFolderGroup(layer.style_config, { ...persisted, expanded }),
+    };
+  });
+}
+
 export function prepareLayersForPersistence(
   layers: MapLayerResponse[],
   groupMeta: Record<string, FolderGroupMeta> = {},

--- a/frontend/src/components/builder/folder-groups.ts
+++ b/frontend/src/components/builder/folder-groups.ts
@@ -187,15 +187,40 @@ export function stampPersistedFolderGroupExpanded(
   layers: MapLayerResponse[],
   groupMeta: Record<string, FolderGroupMeta> = {},
 ): MapLayerResponse[] {
+  // fix(#833 codex round 6): children of a group created THIS session carry
+  // only parent_group_id — no persisted marker yet — but the save that this
+  // baseline snapshots just wrote one (prepareLayersForPersistence derives it
+  // from the group row + groupMeta). Derive the same marker here, or every
+  // later save re-diffs those children against a marker-less baseline and
+  // emits a redundant style_config PATCH per child.
+  const groups = new Map<string, PersistedFolderGroup>();
+  for (const layer of layers) {
+    if (!isFolderGroupLayer(layer)) continue;
+    groups.set(layer.id, {
+      id: layer.id,
+      name: layer.display_name?.trim() || 'Group',
+      expanded: groupMeta[layer.id]?.expanded,
+    });
+  }
   return layers.map((layer) => {
     const persisted = getPersistedFolderGroup(layer);
-    const expanded = persisted ? groupMeta[persisted.id]?.expanded : undefined;
-    if (!persisted || expanded === undefined || persisted.expanded === expanded) {
-      return { ...layer };
+    if (persisted) {
+      const expanded = groupMeta[persisted.id]?.expanded;
+      if (expanded === undefined || persisted.expanded === expanded) {
+        return { ...layer };
+      }
+      return {
+        ...layer,
+        style_config: withPersistedFolderGroup(layer.style_config, { ...persisted, expanded }),
+      };
     }
+    if (isFolderGroupLayer(layer)) return { ...layer };
+    const parentGroupId = (layer as GroupedLayer).parent_group_id ?? null;
+    const folderGroup = parentGroupId ? groups.get(parentGroupId) ?? null : null;
+    if (!folderGroup) return { ...layer };
     return {
       ...layer,
-      style_config: withPersistedFolderGroup(layer.style_config, { ...persisted, expanded }),
+      style_config: withPersistedFolderGroup(layer.style_config, folderGroup),
     };
   });
 }

--- a/frontend/src/components/builder/hooks/__tests__/use-builder-layers.groups.test.ts
+++ b/frontend/src/components/builder/hooks/__tests__/use-builder-layers.groups.test.ts
@@ -45,11 +45,12 @@ function renderBuilderLayers(
 describe('useBuilderLayers — group_meta / groupMeta', () => {
 
   // Test 1: toggle expands
-  // Per CR-02 (commit 116fe289), toggle-expand is treated as a UI-only
-  // affordance and does NOT mark the map as dirty — `group_meta` is not
-  // persisted to the backend schema yet, so a false "unsaved" badge on
-  // expand/collapse was misleading and was removed. Once `group_meta`
-  // joins the API payload, restore the hasUnsavedChanges assertion below.
+  // Per CR-02 (commit 116fe289), the BASEMAP group's toggle-expand is a
+  // UI-only affordance and does NOT mark the map as dirty — it has no
+  // persisted carrier, so a false "unsaved" badge on expand/collapse was
+  // misleading. fix(#833): FOLDER groups do persist collapse state (the
+  // folderGroupExpanded marker), so their toggle DOES dirty — see the
+  // folder-group test below.
   it('handleToggleGroupExpand toggles groupMeta.basemap.expanded between true/false (UI-only; does NOT mark unsaved)', () => {
     const { result } = renderBuilderLayers(makeMapData());
     expect(result.current.groupMeta['basemap']).toBeUndefined();
@@ -76,6 +77,31 @@ describe('useBuilderLayers — group_meta / groupMeta', () => {
       result.current.handleToggleGroupExpand('g1');
     });
     expect(result.current.groupMeta['g1']).toEqual({ expanded: true });
+  });
+
+  // fix(#833): folder-group collapse state is persisted on children, so a
+  // collapse-only change must dirty the save — it used to reach the backend
+  // only when another edit rode along in the same save.
+  it('handleToggleGroupExpand on a FOLDER group marks the map unsaved', () => {
+    const child = makeMockLayer({
+      id: 'layer-1',
+      style_config: {
+        builder: {
+          folderGroupId: 'group-1',
+          folderGroupName: 'Field layers',
+          folderGroupExpanded: true,
+        },
+      } as StyleConfig,
+    });
+    const { result } = renderBuilderLayers(makeMapData([child]));
+    // Hydration synthesizes the group row from the child's persisted markers.
+    expect(result.current.localLayers.some((l) => l.id === 'group-1')).toBe(true);
+    expect(result.current.hasUnsavedChanges).toBe(false);
+
+    act(() => {
+      result.current.handleToggleGroupExpand('group-1');
+    });
+    expect(result.current.hasUnsavedChanges).toBe(true);
   });
 
   // Test 3: DEM terrain bind sets localTerrainConfig and marks unsaved

--- a/frontend/src/components/builder/hooks/__tests__/use-builder-save.test.ts
+++ b/frontend/src/components/builder/hooks/__tests__/use-builder-save.test.ts
@@ -7,6 +7,7 @@ import { MemoryRouter } from 'react-router';
 import { TooltipProvider } from '@/components/ui/tooltip';
 import { renderHook } from '@/test/test-utils';
 import { buildLayerDiff, useBuilderSave, __resetThumbnailDebounceForTests } from '@/components/builder/hooks/use-builder-save';
+import { stampPersistedFolderGroupExpanded } from '@/components/builder/folder-groups';
 import { usePluginStore } from '@/stores/map-plugin-store';
 import type { MapLayerResponse } from '@/types/api';
 import { queryKeys } from '@/lib/query-keys';
@@ -373,6 +374,81 @@ describe('buildLayerDiff', () => {
         },
       },
     ]);
+  });
+
+  // fix(#833 codex): collapse→save→expand→save round-trip. The post-save
+  // baseline used to be a verbatim copy of localLayers, whose markers still
+  // said "expanded" from load — so the collapse-save left a baseline the
+  // following expand-save could not diff against, and reload restored the
+  // stale collapsed state.
+  it('an expand saved after a saved collapse still reaches the diff (baseline round-trip)', () => {
+    const group = {
+      ...makeLayer({ id: 'group-1', display_name: 'Field layers' }),
+      layer_type: 'group:folder',
+    } as unknown as MapLayerResponse;
+    const child = {
+      ...makeLayer({
+        id: 'layer-1',
+        sort_order: 1,
+        style_config: {
+          builder: {
+            folderGroupId: 'group-1',
+            folderGroupName: 'Field layers',
+            folderGroupExpanded: true,
+          },
+        } as MapLayerResponse['style_config'],
+      }),
+      parent_group_id: 'group-1',
+    } as MapLayerResponse;
+
+    // Save 1 — collapse-only: the diff persists expanded=false.
+    const collapseSave = buildLayerDiff(
+      [group, child],
+      [group, child],
+      { 'group-1': { expanded: false } },
+    );
+    expect(collapseSave.diff.updated?.[0]?.style_config).toEqual({
+      builder: {
+        folderGroupId: 'group-1',
+        folderGroupName: 'Field layers',
+        folderGroupExpanded: false,
+      },
+    });
+
+    // Successful save snapshots the baseline with the SENT collapse state
+    // (stampPersistedFolderGroupExpanded — what handleSave and the
+    // baseline-refresh effect store), not the loaded markers.
+    const postSaveBaseline = stampPersistedFolderGroupExpanded(
+      [group, child],
+      { 'group-1': { expanded: false } },
+    );
+
+    // Save 2 — expand-only: must diff back to expanded=true.
+    const expandSave = buildLayerDiff(
+      postSaveBaseline,
+      [group, child],
+      { 'group-1': { expanded: true } },
+    );
+    expect(expandSave.diff.updated).toEqual([
+      {
+        id: 'layer-1',
+        style_config: {
+          builder: {
+            folderGroupId: 'group-1',
+            folderGroupName: 'Field layers',
+            folderGroupExpanded: true,
+          },
+        },
+      },
+    ]);
+
+    // And a same-state save after that stays empty (no #805 regression).
+    const noop = buildLayerDiff(
+      stampPersistedFolderGroupExpanded([group, child], { 'group-1': { expanded: true } }),
+      [group, child],
+      { 'group-1': { expanded: true } },
+    );
+    expect(noop.diff).toEqual({});
   });
 
   it('returns an empty diff for no-op layers', () => {

--- a/frontend/src/components/builder/hooks/__tests__/use-builder-save.test.ts
+++ b/frontend/src/components/builder/hooks/__tests__/use-builder-save.test.ts
@@ -329,10 +329,11 @@ describe('buildLayerDiff', () => {
     expect(result.diff).toEqual({});
   });
 
-  // fix(#805): collapse/expand is deliberately non-dirtying (see
-  // handleToggleGroupExpand) — a collapse-state-only change between the
-  // persisted marker and the live groupMeta must not produce a patch either.
-  it('a collapse-state-only change stays out of the diff (non-dirtying by design)', () => {
+  // fix(#833): collapse state is persisted on children, so a collapse-only
+  // change MUST reach the diff — it used to be stamped identically on both
+  // sides (the #805 fix over-corrected) and only persisted when another
+  // style_config edit rode along in the same save.
+  it('a collapse-state-only change emits the per-child style_config patch', () => {
     const group = {
       ...makeLayer({ id: 'group-1', display_name: 'Field layers' }),
       layer_type: 'group:folder',
@@ -360,7 +361,18 @@ describe('buildLayerDiff', () => {
       { 'group-1': { expanded: false } },
     );
 
-    expect(result.diff).toEqual({});
+    expect(result.diff.updated).toEqual([
+      {
+        id: 'layer-1',
+        style_config: {
+          builder: {
+            folderGroupId: 'group-1',
+            folderGroupName: 'Field layers',
+            folderGroupExpanded: false,
+          },
+        },
+      },
+    ]);
   });
 
   it('returns an empty diff for no-op layers', () => {

--- a/frontend/src/components/builder/hooks/use-builder-layers.ts
+++ b/frontend/src/components/builder/hooks/use-builder-layers.ts
@@ -25,6 +25,9 @@ import {
   pruneEmptyFolderGroups,
   type GroupedLayer,
 } from '@/components/builder/folder-groups';
+// fix(#833): folder-group collapse dirties the save (its state is persisted
+// on children); the basemap group's does not — the toggle needs to tell them apart.
+import { isFolderGroupLayer } from '@/lib/layer-capabilities';
 // STATE-02: cohesive handler clusters extracted into focused hooks. This hook
 // composes them and keeps its return surface identical so MapBuilderPage is
 // unchanged. PURE RELOCATION — see each hook for the verbatim handler bodies.
@@ -410,8 +413,15 @@ export function useBuilderLayers(
       ...prev,
       [groupId]: { expanded: !(prev[groupId]?.expanded ?? false) },
     }));
-    // Expansion is a local presentation preference; group membership/name are
-    // persisted when actual grouping changes.
+    // fix(#833): folder-group collapse state IS persisted (the
+    // folderGroupExpanded marker on each child's style_config), but a
+    // collapse-only change never dirtied the save, so it only reached the
+    // backend when another edit rode along and was lost on reload otherwise.
+    // The basemap group stays UI-only — it has no persisted carrier, so
+    // dirtying it would promise a save that stores nothing.
+    if (layersRef.current.some((l) => l.id === groupId && isFolderGroupLayer(l))) {
+      setHasUnsavedChanges(true);
+    }
   }, []);
 
   const handleZoomToLayer = useCallback((layerId: string) => {

--- a/frontend/src/components/builder/hooks/use-builder-layers.ts
+++ b/frontend/src/components/builder/hooks/use-builder-layers.ts
@@ -33,7 +33,6 @@ import { isFolderGroupLayer } from '@/lib/layer-capabilities';
 // unchanged. PURE RELOCATION — see each hook for the verbatim handler bodies.
 import { useFolderGroupLayers } from '@/components/builder/hooks/use-folder-group-layers';
 import { useBulkLayerActions, restoreFailedLayers } from '@/components/builder/hooks/use-bulk-layer-actions';
-import { useAnalysisAddedStore } from '@/stores/analysis-job-store';
 import { useTerrainLayers } from '@/components/builder/hooks/use-terrain-layers';
 import { useRenderModeLayers } from '@/components/builder/hooks/use-render-mode-layers';
 import { useLayerStyleClipboard } from '@/components/builder/hooks/use-layer-style-clipboard';
@@ -575,14 +574,6 @@ export function useBuilderLayers(
         { mapId, data: { dataset_id: datasetId, sort_order: 0 } },
         {
           onSuccess: (createdLayer) => {
-            // fix(#833 codex P2): settle the analysis add-to-map guard — a
-            // pending claim becomes confirmed. Gated on the claim so a
-            // non-analysis add of the same dataset keeps today's behavior
-            // (re-adding via other surfaces stays legitimate).
-            const addedGuard = useAnalysisAddedStore.getState();
-            if (addedGuard.pendingAddIds.includes(datasetId)) {
-              addedGuard.confirmAdded(datasetId);
-            }
             // P1-08: optimistically merge EVERY created layer into localLayers +
             // the saved baseline so it appears immediately, even while the map is
             // dirty — the API-refetch sync (apiLayers effect) is gated on
@@ -709,12 +700,10 @@ export function useBuilderLayers(
             }
           },
           onError: () => {
-            // fix(#833 codex P2): the analysis "Add to map" affordances claim
-            // a PENDING guard entry before this mutation starts; clear it on
-            // failure so they re-arm. Confirmed entries are untouched, so a
-            // failed catalog/chat/drag add (which never claims one) cannot
-            // un-retire an affordance whose own add already succeeded.
-            useAnalysisAddedStore.getState().clearPending(datasetId);
+            // fix(#833 codex P2): the analysis add-to-map guard settles in
+            // useAddLayer's GLOBAL callbacks (see use-maps.ts) — per-call
+            // callbacks here are dropped when a second add overlaps on the
+            // shared mutation observer.
             toast.error(t('toasts.layerAddFailed'));
           },
         },

--- a/frontend/src/components/builder/hooks/use-builder-layers.ts
+++ b/frontend/src/components/builder/hooks/use-builder-layers.ts
@@ -575,6 +575,14 @@ export function useBuilderLayers(
         { mapId, data: { dataset_id: datasetId, sort_order: 0 } },
         {
           onSuccess: (createdLayer) => {
+            // fix(#833 codex P2): settle the analysis add-to-map guard — a
+            // pending claim becomes confirmed. Gated on the claim so a
+            // non-analysis add of the same dataset keeps today's behavior
+            // (re-adding via other surfaces stays legitimate).
+            const addedGuard = useAnalysisAddedStore.getState();
+            if (addedGuard.pendingAddIds.includes(datasetId)) {
+              addedGuard.confirmAdded(datasetId);
+            }
             // P1-08: optimistically merge EVERY created layer into localLayers +
             // the saved baseline so it appears immediately, even while the map is
             // dirty — the API-refetch sync (apiLayers effect) is gated on
@@ -701,10 +709,12 @@ export function useBuilderLayers(
             }
           },
           onError: () => {
-            // fix(#833 codex P2): the analysis "Add to map" affordances mark
-            // their single-use guard before this mutation starts; unmark on
-            // failure so they stay retryable (no-op for non-analysis adds).
-            useAnalysisAddedStore.getState().unmarkAdded(datasetId);
+            // fix(#833 codex P2): the analysis "Add to map" affordances claim
+            // a PENDING guard entry before this mutation starts; clear it on
+            // failure so they re-arm. Confirmed entries are untouched, so a
+            // failed catalog/chat/drag add (which never claims one) cannot
+            // un-retire an affordance whose own add already succeeded.
+            useAnalysisAddedStore.getState().clearPending(datasetId);
             toast.error(t('toasts.layerAddFailed'));
           },
         },

--- a/frontend/src/components/builder/hooks/use-builder-layers.ts
+++ b/frontend/src/components/builder/hooks/use-builder-layers.ts
@@ -33,6 +33,7 @@ import { isFolderGroupLayer } from '@/lib/layer-capabilities';
 // unchanged. PURE RELOCATION — see each hook for the verbatim handler bodies.
 import { useFolderGroupLayers } from '@/components/builder/hooks/use-folder-group-layers';
 import { useBulkLayerActions, restoreFailedLayers } from '@/components/builder/hooks/use-bulk-layer-actions';
+import { useAnalysisAddedStore } from '@/stores/analysis-job-store';
 import { useTerrainLayers } from '@/components/builder/hooks/use-terrain-layers';
 import { useRenderModeLayers } from '@/components/builder/hooks/use-render-mode-layers';
 import { useLayerStyleClipboard } from '@/components/builder/hooks/use-layer-style-clipboard';
@@ -700,6 +701,10 @@ export function useBuilderLayers(
             }
           },
           onError: () => {
+            // fix(#833 codex P2): the analysis "Add to map" affordances mark
+            // their single-use guard before this mutation starts; unmark on
+            // failure so they stay retryable (no-op for non-analysis adds).
+            useAnalysisAddedStore.getState().unmarkAdded(datasetId);
             toast.error(t('toasts.layerAddFailed'));
           },
         },

--- a/frontend/src/components/builder/hooks/use-builder-save.ts
+++ b/frontend/src/components/builder/hooks/use-builder-save.ts
@@ -451,12 +451,24 @@ export function buildLayerDiff(
   currentLayers: MapLayerResponse[],
   groupMeta: Record<string, FolderGroupMeta> = {},
 ): LayerDiffResult {
-  // fix(#805): prepare BOTH sides with the same groupMeta. The baseline used to
-  // be prepared without it, so baseline children lacked the folderGroupExpanded
-  // marker while current children carried it — every save of a grouped map then
-  // emitted a spurious per-child style_config PATCH, silently persisting
-  // collapse state that is deliberately non-dirtying (see handleToggleGroupExpand).
-  const baselinePersistedLayers = prepareLayersForPersistence(baselineLayers, groupMeta);
+  // fix(#805): prepare BOTH sides through prepareLayersForPersistence so an
+  // unchanged grouped map diffs empty. The baseline used to be prepared
+  // without any groupMeta, so baseline children lacked the folderGroupExpanded
+  // marker while current children carried it — every save of a grouped map
+  // then emitted a spurious per-child style_config PATCH.
+  // fix(#833): the baseline is prepared with its OWN persisted collapse state
+  // (derived from the folderGroupExpanded markers it was loaded with), not the
+  // live groupMeta — stamping the live value on both sides hid every collapse
+  // change from the diff, so collapse-only edits persisted only when another
+  // style_config edit happened to ride along in the same save.
+  const baselineGroupMeta: Record<string, FolderGroupMeta> = {};
+  for (const layer of baselineLayers) {
+    const persisted = getPersistedFolderGroup(layer);
+    if (persisted?.expanded !== undefined) {
+      baselineGroupMeta[persisted.id] = { expanded: persisted.expanded };
+    }
+  }
+  const baselinePersistedLayers = prepareLayersForPersistence(baselineLayers, baselineGroupMeta);
   const currentPersistedLayers = prepareLayersForPersistence(currentLayers, groupMeta);
   const baselineById = new Map(baselinePersistedLayers.map((layer) => [layer.id, toLayerSnapshot(layer)]));
   const currentById = new Map(currentPersistedLayers.map((layer) => [layer.id, layer]));

--- a/frontend/src/components/builder/hooks/use-builder-save.ts
+++ b/frontend/src/components/builder/hooks/use-builder-save.ts
@@ -21,7 +21,7 @@ import { getDefaultPluginIds, resolveAvailablePluginIds, samePluginIds } from '@
 // D5: the PNG export legend must render the same effective entry names as the
 // on-screen legend (per-entry legendLabel override > display name > dataset name).
 import { legendEntryName } from '@/components/map-plugins/builtin/LegendPlugin';
-import { getPersistedFolderGroup, prepareLayersForPersistence, type FolderGroupMeta } from '@/components/builder/folder-groups';
+import { getPersistedFolderGroup, prepareLayersForPersistence, stampPersistedFolderGroupExpanded, type FolderGroupMeta } from '@/components/builder/folder-groups';
 import { normalizeDemStyleConfig } from '@/lib/dem-render-mode';
 import { MAP_COLORS } from '@/lib/map-colors';
 // fix(#430 V-01): capability gate used to detect fields the builder has no editor
@@ -606,9 +606,17 @@ export function useBuilderSave(state: SaveState) {
   const baselineLayersRef = useRef<MapLayerResponse[]>([]);
   useEffect(() => {
     if (!state.hasUnsavedChanges) {
-      baselineLayersRef.current = state.localLayers.map((layer) => ({ ...layer }));
+      // fix(#833 codex): stamp the live groupMeta expansion into the snapshot's
+      // persisted markers. After a save clears the dirty flag, localLayers'
+      // markers still carry the LOADED collapse state, so a verbatim copy made
+      // the just-saved collapse invisible to the next diff (expand→save then
+      // emitted nothing and reload restored the stale state).
+      baselineLayersRef.current = stampPersistedFolderGroupExpanded(
+        state.localLayers,
+        state.groupMeta,
+      );
     }
-  }, [state.hasUnsavedChanges, state.localLayers]);
+  }, [state.hasUnsavedChanges, state.localLayers, state.groupMeta]);
 
   // fix(#756): handleSave destructures `state` once at call time and then
   // awaits the network; this ref always points at the latest rendered state
@@ -746,7 +754,9 @@ export function useBuilderSave(state: SaveState) {
             // a full re-sync occurred. Surface it instead so the user knows to
             // double-check layer styling rather than trusting a clean save.
             await updateMap.mutateAsync({ id, data: fullReplacementPayload });
-            baselineLayersRef.current = localLayers.map((layer) => ({ ...layer }));
+            // fix(#833 codex): baseline carries the SENT collapse state, not
+            // the loaded markers — see the baseline effect above.
+            baselineLayersRef.current = stampPersistedFolderGroupExpanded(localLayers, groupMeta);
             toast.warning(t('toasts.mapSavedFullResync', {
               defaultValue: 'Map saved, but required a full re-sync. Please double-check layer styling.',
             }));
@@ -763,7 +773,9 @@ export function useBuilderSave(state: SaveState) {
         await updateMap.mutateAsync({ id, data: metadataPayload });
       }
 
-      baselineLayersRef.current = localLayers.map((layer) => ({ ...layer }));
+      // fix(#833 codex): baseline carries the SENT collapse state, not the
+      // loaded markers — see the baseline effect above.
+      baselineLayersRef.current = stampPersistedFolderGroupExpanded(localLayers, groupMeta);
       toast.success(t('toasts.mapSaved'));
       // fix(#756): the baseline above is the SENT snapshot; only clear the
       // dirty flag when nothing was edited during the network await —

--- a/frontend/src/hooks/__tests__/use-abort-signal.test.tsx
+++ b/frontend/src/hooks/__tests__/use-abort-signal.test.tsx
@@ -1,0 +1,36 @@
+import { StrictMode } from 'react';
+import { renderHook } from '@testing-library/react';
+import { useAbortSignal } from '@/hooks/use-abort-signal';
+
+// Flush pending microtasks (the deferred abort in the hook's cleanup).
+const flushMicrotasks = () => new Promise<void>((resolve) => { setTimeout(resolve, 0); });
+
+describe('useAbortSignal', () => {
+  it('aborts the signal on unmount', async () => {
+    const { result, unmount } = renderHook(() => useAbortSignal());
+    const signal = result.current;
+    expect(signal.aborted).toBe(false);
+
+    unmount();
+    await flushMicrotasks();
+    expect(signal.aborted).toBe(true);
+  });
+
+  // fix(#833): StrictMode's dev-only unmount/remount used to abort the one
+  // controller the consumer ever sees, silently cancelling the first real
+  // request in dev.
+  it('does not return a pre-aborted signal under StrictMode double-invoke', async () => {
+    const { result, unmount } = renderHook(() => useAbortSignal(), {
+      wrapper: StrictMode,
+    });
+    const signal = result.current;
+
+    await flushMicrotasks();
+    expect(signal.aborted).toBe(false);
+
+    // A real unmount must still abort.
+    unmount();
+    await flushMicrotasks();
+    expect(signal.aborted).toBe(true);
+  });
+});

--- a/frontend/src/hooks/use-abort-signal.ts
+++ b/frontend/src/hooks/use-abort-signal.ts
@@ -10,11 +10,23 @@ import { useEffect, useRef } from 'react';
  */
 export function useAbortSignal(): AbortSignal {
   const ref = useRef(new AbortController());
+  const mountedRef = useRef(false);
 
   useEffect(() => {
+    mountedRef.current = true;
     const controller = ref.current;
     return () => {
-      controller.abort();
+      mountedRef.current = false;
+      // fix(#833): under React StrictMode's dev-only unmount/remount, aborting
+      // synchronously here handed every consumer a permanently pre-aborted
+      // signal — no render happens between cleanup and re-setup, so a fresh
+      // controller could never reach them, and the first real request was
+      // silently cancelled. Defer the abort one microtask: StrictMode's
+      // re-setup runs synchronously in the same flush and flips mountedRef
+      // back, so only a real unmount aborts.
+      queueMicrotask(() => {
+        if (!mountedRef.current) controller.abort();
+      });
     };
   }, []);
 

--- a/frontend/src/hooks/use-maps.ts
+++ b/frontend/src/hooks/use-maps.ts
@@ -32,6 +32,7 @@ import type { ShareExpirationInput } from '@/api/maps';
 import type { MapUpdateRequest, MapLayerDiffRequest, MapLayerInput, MapBrowseParams } from '@/types/api';
 import { toast } from 'sonner';
 import i18n from '@/i18n/i18n';
+import { useAnalysisAddedStore } from '@/stores/analysis-job-store';
 
 export type { MapBrowseParams };
 
@@ -186,11 +187,24 @@ export function useAddLayer() {
   return useMutation({
     mutationFn: ({ mapId, data }: { mapId: string; data: MapLayerInput }) =>
       addLayerToMapApi(mapId, data),
+    // fix(#833 codex P2): the analysis add-to-map guard settles HERE, not in
+    // per-call mutate() callbacks — when two adds overlap, the shared
+    // mutation observer moves to the newer request and drops the earlier
+    // call's per-call callbacks, stranding a pending claim. These global
+    // callbacks run once per request. Both are no-ops unless an analysis
+    // affordance claimed a pending entry for this dataset.
     onSuccess: (_data, variables) => {
+      const guard = useAnalysisAddedStore.getState();
+      if (guard.pendingAddIds.includes(variables.data.dataset_id)) {
+        guard.confirmAdded(variables.data.dataset_id);
+      }
       qc.invalidateQueries({ queryKey: queryKeys.maps.detail(variables.mapId) });
       invalidateMapHistory(qc, variables.mapId);
     },
-    onError: () => { toast.error(i18n.t('builder:toasts.layerAddFailed')); },
+    onError: (_err, variables) => {
+      useAnalysisAddedStore.getState().clearPending(variables.data.dataset_id);
+      toast.error(i18n.t('builder:toasts.layerAddFailed'));
+    },
   });
 }
 

--- a/frontend/src/pages/MapBuilderPage.tsx
+++ b/frontend/src/pages/MapBuilderPage.tsx
@@ -708,7 +708,12 @@ export function MapBuilderPage() {
     const restored: string[] = [];
     for (const rowId of Array.from(parked)) {
       if (!liveIds.has(rowId)) { parked.delete(rowId); continue; }
-      if (selectable.has(rowId)) { parked.delete(rowId); restored.push(rowId); }
+      if (selectable.has(rowId)) { parked.delete(rowId); restored.push(rowId); continue; }
+      // fix(#833 codex round 5): a row stays parked only while the SEARCH
+      // hides it. If it is now hidden by a collapsed group instead (folder
+      // collapsed after parking, or the search cleared while collapsed), the
+      // collapse discards the selection — same rule as unparked rows above.
+      if (!searchHiddenIds?.has(rowId)) parked.delete(rowId);
     }
     setSelectedIds((prev) => {
       if (prev.size === 0 && restored.length === 0) return prev;

--- a/frontend/src/pages/MapBuilderPage.tsx
+++ b/frontend/src/pages/MapBuilderPage.tsx
@@ -181,9 +181,10 @@ export function MapBuilderPage() {
   const lastToggleAnchor = useRef<string | null>(null);
   // fix(#833): selected rows the layer search hides are parked here instead of
   // being pruned outright, and rejoin the selection when the search stops
-  // hiding them. Cleared on every explicit selection reset (Escape/outside
-  // click, drag-start, bulk actions) so stale parked rows cannot resurrect a
-  // selection the user already dismissed.
+  // hiding them. Cleared on every explicit selection interaction — Escape/
+  // outside click, drag-start, bulk actions, and (codex round 2) cmd/shift
+  // clicks, which replace the selection — so stale parked rows cannot
+  // resurrect a selection the user's gesture already discarded.
   const searchHiddenSelectionRef = useRef<Set<string>>(new Set());
   // fix(#771): the layer-search query is lifted here (hybrid-controlled on
   // UnifiedStackPanel) so selectableRowIds below can be derived from the
@@ -712,6 +713,10 @@ export function MapBuilderPage() {
   // so plain/shift/cmd clicks all coordinate from the same authoritative source.
   const handleCmdClick = useCallback((id: string) => {
     if (isBasemapBoundaryId(id)) return;
+    // fix(#833 codex round 2): an explicit selection gesture supersedes any
+    // search-parked rows — keeping them would resurrect rows the gesture
+    // discarded once the search clears (and a later bulk op would hit them).
+    searchHiddenSelectionRef.current.clear();
     setSelectedIds((prev) => {
       const { selection, anchor } = computeNextSelection(
         selectableRowIds,
@@ -727,6 +732,9 @@ export function MapBuilderPage() {
 
   const handleShiftClick = useCallback((id: string) => {
     if (isBasemapBoundaryId(id)) return;
+    // fix(#833 codex round 2): same as handleCmdClick — a range gesture
+    // replaces the selection, so parked rows must not outlive it.
+    searchHiddenSelectionRef.current.clear();
     setSelectedIds((prev) => {
       const { selection, anchor } = computeNextSelection(
         selectableRowIds,

--- a/frontend/src/pages/MapBuilderPage.tsx
+++ b/frontend/src/pages/MapBuilderPage.tsx
@@ -684,6 +684,27 @@ export function MapBuilderPage() {
     const liveIds = new Set(layers.localLayers.map((layer) => layer.id));
     const selectable = new Set(selectableRowIds);
     const parked = searchHiddenSelectionRef.current;
+    // fix(#833 codex round 3): park only rows the SEARCH itself hides, not any
+    // unselectable row while a search happens to be active — a child hidden by
+    // its collapsed group must stay pruned (restoring it on a later expand
+    // would resurrect a selection the collapse discarded). Recomputing the
+    // selectable set with every group forced expanded isolates the search
+    // predicate (computeSelectableRowIds stays the single source of truth):
+    // a live row absent from THIS set fails the search; one present here but
+    // missing from selectableRowIds is hidden by collapse alone.
+    let searchHiddenIds: Set<string> | null = null;
+    if (layerSearch.trim() !== '') {
+      const allExpanded: Record<string, { expanded: boolean }> = {};
+      for (const layer of layers.localLayers) {
+        if (isFolderGroupLayer(layer)) allExpanded[layer.id] = { expanded: true };
+      }
+      const matching = new Set(
+        computeSelectableRowIds(layers.localLayers, allExpanded, layerSearch),
+      );
+      searchHiddenIds = new Set(
+        layers.localLayers.filter((layer) => !matching.has(layer.id)).map((layer) => layer.id),
+      );
+    }
     const restored: string[] = [];
     for (const rowId of Array.from(parked)) {
       if (!liveIds.has(rowId)) { parked.delete(rowId); continue; }
@@ -696,10 +717,10 @@ export function MapBuilderPage() {
       for (const rowId of prev) {
         if (liveIds.has(rowId) && selectable.has(rowId)) { next.add(rowId); continue; }
         changed = true;
-        // Park only live rows hidden while a search is active (an add-only
-        // mutation, safe under a double-invoked updater); rows removed from
-        // the map or swallowed by a collapsed group with no search stay pruned.
-        if (liveIds.has(rowId) && layerSearch) parked.add(rowId);
+        // Park only live, search-hidden rows (an add-only mutation, safe under
+        // a double-invoked updater); rows removed from the map or swallowed by
+        // a collapsed group stay pruned for good.
+        if (liveIds.has(rowId) && searchHiddenIds?.has(rowId)) parked.add(rowId);
       }
       for (const rowId of restored) {
         if (!next.has(rowId)) { next.add(rowId); changed = true; }

--- a/frontend/src/pages/MapBuilderPage.tsx
+++ b/frontend/src/pages/MapBuilderPage.tsx
@@ -705,15 +705,22 @@ export function MapBuilderPage() {
         layers.localLayers.filter((layer) => !matching.has(layer.id)).map((layer) => layer.id),
       );
     }
+    // fix(#833 codex rounds 5+6): a row stays parked only while it would be
+    // selectable the moment the search cleared — the search must be what
+    // hides it AND its group must be expanded under the REAL group state. A
+    // collapse is a discarding gesture wherever it happens: after parking,
+    // while the search is active (even though the force-expanded
+    // searchHiddenIds still lists the row), or ordered the other way.
+    const selectableWithoutSearch = new Set(
+      computeSelectableRowIds(layers.localLayers, layers.groupMeta, ''),
+    );
     const restored: string[] = [];
     for (const rowId of Array.from(parked)) {
       if (!liveIds.has(rowId)) { parked.delete(rowId); continue; }
       if (selectable.has(rowId)) { parked.delete(rowId); restored.push(rowId); continue; }
-      // fix(#833 codex round 5): a row stays parked only while the SEARCH
-      // hides it. If it is now hidden by a collapsed group instead (folder
-      // collapsed after parking, or the search cleared while collapsed), the
-      // collapse discards the selection — same rule as unparked rows above.
-      if (!searchHiddenIds?.has(rowId)) parked.delete(rowId);
+      if (!searchHiddenIds?.has(rowId) || !selectableWithoutSearch.has(rowId)) {
+        parked.delete(rowId);
+      }
     }
     setSelectedIds((prev) => {
       if (prev.size === 0 && restored.length === 0) return prev;
@@ -732,7 +739,7 @@ export function MapBuilderPage() {
       }
       return changed ? next : prev;
     });
-  }, [layers.localLayers, layers.isDeleting, selectableRowIds, layerSearch]);
+  }, [layers.localLayers, layers.groupMeta, layers.isDeleting, selectableRowIds, layerSearch]);
 
   // Phase 1041 + SP-04 (Phase 1045): multi-selection handlers driven by the
   // `computeNextSelection` pure helper. Anchor lives in `lastToggleAnchor` ref

--- a/frontend/src/pages/MapBuilderPage.tsx
+++ b/frontend/src/pages/MapBuilderPage.tsx
@@ -179,6 +179,12 @@ export function MapBuilderPage() {
   // the Phase 1040 lift-DndContext architecture decision.
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
   const lastToggleAnchor = useRef<string | null>(null);
+  // fix(#833): selected rows the layer search hides are parked here instead of
+  // being pruned outright, and rejoin the selection when the search stops
+  // hiding them. Cleared on every explicit selection reset (Escape/outside
+  // click, drag-start, bulk actions) so stale parked rows cannot resurrect a
+  // selection the user already dismissed.
+  const searchHiddenSelectionRef = useRef<Set<string>>(new Set());
   // fix(#771): the layer-search query is lifted here (hybrid-controlled on
   // UnifiedStackPanel) so selectableRowIds below can be derived from the
   // RENDERED row set — a shift-click range must never sweep rows the search
@@ -665,21 +671,41 @@ export function MapBuilderPage() {
   // fix(v1.6.0 audit B7): also intersect with selectableRowIds — a row hidden
   // by the layer search or a collapsed group must leave the selection, or the
   // bulk bar keeps acting on rows the user can no longer see.
+  // fix(#833): rows hidden by the layer search leave the ACTIVE selection (B7
+  // stands: the bulk bar must not act on rows the user cannot see) but are
+  // parked and rejoin it when they become visible again — hiding used to
+  // prune them permanently. Parked rows are restored only once selectable
+  // again (search cleared/edited AND not inside a collapsed group); deleted
+  // rows are dropped for good. The park/restore bookkeeping lives outside the
+  // updater where it must be idempotent (StrictMode double-invokes updaters).
   useEffect(() => {
     if (layers.isDeleting) return;
+    const liveIds = new Set(layers.localLayers.map((layer) => layer.id));
+    const selectable = new Set(selectableRowIds);
+    const parked = searchHiddenSelectionRef.current;
+    const restored: string[] = [];
+    for (const rowId of Array.from(parked)) {
+      if (!liveIds.has(rowId)) { parked.delete(rowId); continue; }
+      if (selectable.has(rowId)) { parked.delete(rowId); restored.push(rowId); }
+    }
     setSelectedIds((prev) => {
-      if (prev.size === 0) return prev;
-      const liveIds = new Set(layers.localLayers.map((layer) => layer.id));
-      const selectable = new Set(selectableRowIds);
+      if (prev.size === 0 && restored.length === 0) return prev;
       let changed = false;
       const next = new Set<string>();
       for (const rowId of prev) {
-        if (liveIds.has(rowId) && selectable.has(rowId)) next.add(rowId);
-        else changed = true;
+        if (liveIds.has(rowId) && selectable.has(rowId)) { next.add(rowId); continue; }
+        changed = true;
+        // Park only live rows hidden while a search is active (an add-only
+        // mutation, safe under a double-invoked updater); rows removed from
+        // the map or swallowed by a collapsed group with no search stay pruned.
+        if (liveIds.has(rowId) && layerSearch) parked.add(rowId);
+      }
+      for (const rowId of restored) {
+        if (!next.has(rowId)) { next.add(rowId); changed = true; }
       }
       return changed ? next : prev;
     });
-  }, [layers.localLayers, layers.isDeleting, selectableRowIds]);
+  }, [layers.localLayers, layers.isDeleting, selectableRowIds, layerSearch]);
 
   // Phase 1041 + SP-04 (Phase 1045): multi-selection handlers driven by the
   // `computeNextSelection` pure helper. Anchor lives in `lastToggleAnchor` ref
@@ -733,11 +759,18 @@ export function MapBuilderPage() {
     handleCmdClick(id);
   }, [handleCmdClick]);
 
+  // fix(#833): every explicit selection reset also drops the search-parked
+  // rows — a dismissed selection must not resurrect when the search clears.
+  const resetMultiSelection = useCallback(() => {
+    setSelectedIds(new Set());
+    searchHiddenSelectionRef.current.clear();
+  }, []);
+
   // Phase 1041-02: clear-selection handler (used by UnifiedStackPanel's Escape/outside-click)
   const handleClearSelection = useCallback(() => {
-    setSelectedIds(new Set());
+    resetMultiSelection();
     lastToggleAnchor.current = null;
-  }, []);
+  }, [resetMultiSelection]);
 
   // Phase 1041-03: real bulk handlers — wired to use-builder-layers bulk ops.
   // Each dep is the specific stable useCallback from use-builder-layers, NOT the
@@ -746,8 +779,8 @@ export function MapBuilderPage() {
   // on every opacity-slider move, which fires at ~60fps (Phase 20260526-builder-audit #338 BLD-20260526-11).
   const handleBulkVisibility = useCallback((ids: Set<string>) => {
     applyBulkVisibility(ids);
-    setSelectedIds(new Set());
-  }, [applyBulkVisibility]);
+    resetMultiSelection();
+  }, [applyBulkVisibility, resetMultiSelection]);
 
   const handleBulkOpacity = useCallback((ids: Set<string>, opacity: number) => {
     // NOTE: Opacity slider fires onValueChange continuously during drag.
@@ -762,32 +795,32 @@ export function MapBuilderPage() {
     // fix(#392): only clear the selection when a group was
     // actually created; an ineligible selection must stay intact so the user
     // can see it, read the toast, and adjust instead of losing it silently. (audit B-004d/LM-04)
-    if (applyBulkGroup(ids)) setSelectedIds(new Set());
-  }, [applyBulkGroup]);
+    if (applyBulkGroup(ids)) resetMultiSelection();
+  }, [applyBulkGroup, resetMultiSelection]);
 
   const handleBulkUngroup = useCallback((ids: Set<string>) => {
     applyBulkUngroup(ids);
-    setSelectedIds(new Set());
-  }, [applyBulkUngroup]);
+    resetMultiSelection();
+  }, [applyBulkUngroup, resetMultiSelection]);
 
   // Phase 1201-01 ENH-03: apply one selected/copied style to compatible peers,
   // then clear the multi-selection (mirrors group/ungroup wrappers).
   const handleBulkApplyStyle = useCallback((ids: Set<string>) => {
     applyBulkApplyStyle(ids);
-    setSelectedIds(new Set());
-  }, [applyBulkApplyStyle]);
+    resetMultiSelection();
+  }, [applyBulkApplyStyle, resetMultiSelection]);
 
   const handleBulkDelete = useCallback((ids: Set<string>) => {
     applyBulkDelete(ids)
       .then((ok) => {
-        if (ok) setSelectedIds(new Set());
+        if (ok) resetMultiSelection();
         // on failure: selection preserved so user can retry
       })
       .catch(() => {
         // Error already toasted inside handleBulkDelete; swallow here to prevent
         // unhandled rejection if invalidateQueries throws after allSettled.
       });
-  }, [applyBulkDelete]);
+  }, [applyBulkDelete, resetMultiSelection]);
 
   // Derived: any row in selectedIds
   const isMultiSelectionActive = selectedIds.size > 0;
@@ -1097,7 +1130,7 @@ export function MapBuilderPage() {
     setDragActiveId(String(event.active.id));
     handleSelectLayer(null);
     // Phase 1041 POL-10: drag + multi-select are mutually exclusive. Clear selection at drag-start.
-    setSelectedIds(new Set());
+    resetMultiSelection();
     lastToggleAnchor.current = null;
     document.documentElement.classList.add('dragging-active');
     lastOverIdRef.current = null;
@@ -1106,7 +1139,7 @@ export function MapBuilderPage() {
     if (data?.source === 'catalog' && data.name) {
       announce(t('a11y.dragPickup', { name: data.name }));
     }
-  }, [handleSelectLayer, announce, t]);
+  }, [handleSelectLayer, announce, t, resetMultiSelection]);
 
   const handleDragEnd = useCallback((event: DragEndEvent) => {
     setDragActiveId(null);

--- a/frontend/src/stores/analysis-job-store.ts
+++ b/frontend/src/stores/analysis-job-store.ts
@@ -72,6 +72,7 @@ export const analysisAddToMap: {
 interface AnalysisAddedState {
   addedDatasetIds: string[];
   markAdded: (datasetId: string) => void;
+  unmarkAdded: (datasetId: string) => void;
 }
 
 export const useAnalysisAddedStore = create<AnalysisAddedState>()((set) => ({
@@ -81,5 +82,15 @@ export const useAnalysisAddedStore = create<AnalysisAddedState>()((set) => ({
       s.addedDatasetIds.includes(datasetId)
         ? s
         : { addedDatasetIds: [...s.addedDatasetIds, datasetId] },
+    ),
+  // fix(#833 codex P2): marking happens BEFORE the add mutation starts (so a
+  // double-click can't add twice), but the mutation can still fail. The add
+  // error path unmarks so both affordances become retryable; no-op when the
+  // add came from a non-analysis surface.
+  unmarkAdded: (datasetId) =>
+    set((s) =>
+      s.addedDatasetIds.includes(datasetId)
+        ? { addedDatasetIds: s.addedDatasetIds.filter((id) => id !== datasetId) }
+        : s,
     ),
 }));

--- a/frontend/src/stores/analysis-job-store.ts
+++ b/frontend/src/stores/analysis-job-store.ts
@@ -57,3 +57,29 @@ export const analysisAddToMap: {
   current: ((datasetId: string) => void) | null;
   mapId: string | null;
 } = { current: null, mapId: null };
+
+/**
+ * fix(#833): dataset ids already added to a map through an analysis
+ * "Add to map" affordance. A completed run raises TWO affordances (the
+ * watcher's toast action and the Analysis panel's button); each used to keep
+ * its own single-use flag, so clicking both added the layer twice. Shared
+ * here so either click retires both. A store (not a module Set) so the panel
+ * button re-renders to its "Added to map" state when the toast action does
+ * the add. Session-scoped and keyed on dataset id on purpose: a NEW run's
+ * completion re-enables both affordances, and adding the same dataset again
+ * via other surfaces stays legitimate.
+ */
+interface AnalysisAddedState {
+  addedDatasetIds: string[];
+  markAdded: (datasetId: string) => void;
+}
+
+export const useAnalysisAddedStore = create<AnalysisAddedState>()((set) => ({
+  addedDatasetIds: [],
+  markAdded: (datasetId) =>
+    set((s) =>
+      s.addedDatasetIds.includes(datasetId)
+        ? s
+        : { addedDatasetIds: [...s.addedDatasetIds, datasetId] },
+    ),
+}));

--- a/frontend/src/stores/analysis-job-store.ts
+++ b/frontend/src/stores/analysis-job-store.ts
@@ -70,27 +70,42 @@ export const analysisAddToMap: {
  * via other surfaces stays legitimate.
  */
 interface AnalysisAddedState {
+  /** Confirmed on the map — the add mutation succeeded (any surface). */
   addedDatasetIds: string[];
-  markAdded: (datasetId: string) => void;
-  unmarkAdded: (datasetId: string) => void;
+  /**
+   * fix(#833 codex P2): claimed by an analysis affordance whose add mutation
+   * is still in flight. The claim happens BEFORE the mutation starts (so a
+   * double-click can't add twice); success confirms it, failure clears it so
+   * the affordances re-arm. Split from addedDatasetIds so a FAILED add from a
+   * non-analysis surface (catalog/chat/drag never claim a pending entry) can
+   * never un-retire a confirmed one.
+   */
+  pendingAddIds: string[];
+  markPending: (datasetId: string) => void;
+  confirmAdded: (datasetId: string) => void;
+  clearPending: (datasetId: string) => void;
 }
 
 export const useAnalysisAddedStore = create<AnalysisAddedState>()((set) => ({
   addedDatasetIds: [],
-  markAdded: (datasetId) =>
+  pendingAddIds: [],
+  markPending: (datasetId) =>
     set((s) =>
-      s.addedDatasetIds.includes(datasetId)
+      s.pendingAddIds.includes(datasetId)
         ? s
-        : { addedDatasetIds: [...s.addedDatasetIds, datasetId] },
+        : { pendingAddIds: [...s.pendingAddIds, datasetId] },
     ),
-  // fix(#833 codex P2): marking happens BEFORE the add mutation starts (so a
-  // double-click can't add twice), but the mutation can still fail. The add
-  // error path unmarks so both affordances become retryable; no-op when the
-  // add came from a non-analysis surface.
-  unmarkAdded: (datasetId) =>
+  confirmAdded: (datasetId) =>
+    set((s) => ({
+      pendingAddIds: s.pendingAddIds.filter((id) => id !== datasetId),
+      addedDatasetIds: s.addedDatasetIds.includes(datasetId)
+        ? s.addedDatasetIds
+        : [...s.addedDatasetIds, datasetId],
+    })),
+  clearPending: (datasetId) =>
     set((s) =>
-      s.addedDatasetIds.includes(datasetId)
-        ? { addedDatasetIds: s.addedDatasetIds.filter((id) => id !== datasetId) }
+      s.pendingAddIds.includes(datasetId)
+        ? { pendingAddIds: s.pendingAddIds.filter((id) => id !== datasetId) }
         : s,
     ),
 }));


### PR DESCRIPTION
Fixes the seven grouped frontend correctness/a11y items from the 1.6.0 pre-tag audit.

## Changes

1. **InlineDeleteConfirm focus drops** — the DEM editor footer, basemap-sublayer reset, and style-editor reset confirms now hand focus back to their trigger on dismiss instead of dropping it on `<body>`, matching the layer-row site's `fix(#788)` pattern (rAF where the trigger remounts).
2. **BulkActionBar disabled-Delete hint invisible to AT** — the overflow items' `aria-label` overrides the subtree as the accessible name, so the inline disabled-reason hints never reached assistive tech. The hints (Delete plus the three sibling items with the same defect) are now exposed via `aria-describedby`.
3. **Analysis "Add to map" double-add** — the completion toast action and the panel button each kept their own single-use flag, so clicking both added the layer twice. The dedupe now lives in a shared `useAnalysisAddedStore` keyed on dataset id; a new run's dataset re-enables both, and adding the same dataset via other surfaces stays legitimate.
4. **Group collapse lost on collapse-only saves** — `buildLayerDiff` stamped the live `groupMeta` on both sides, so a collapse-only change never reached the diff and `handleToggleGroupExpand` never dirtied the save. The baseline is now prepared with its own persisted collapse state and folder-group toggles mark the map unsaved. The basemap group stays UI-only (no persisted carrier), and the #805 spurious-patch fix is preserved (unchanged grouped maps still diff empty).
5. **Stack filter permanently pruned multi-selections** — selected rows hidden by the layer search are parked and rejoin the selection when the search stops hiding them. The B7 invariant stands (the bulk bar never acts on hidden rows), and explicit selection resets (Escape/outside click, drag-start, bulk actions) drop the parked rows.
6. **API key in the query string** (`geojson-z.ts`) — the key now travels in the `X-Api-Key` header, the same form the embed-token path uses; query strings land in server/proxy logs.
7. **`use-abort-signal` pre-aborted under StrictMode** — the cleanup abort is deferred one microtask so the dev-only unmount/remount no longer cancels the first real request; real unmounts still abort.

No new translation keys; no API/schema/config impact.

Closes #833

## Verification

- `cd frontend && npm run lint` — pass
- `cd frontend && npm run typecheck` — pass
- `cd frontend && npx vitest run` — 349 files, 4023 tests, all pass (post-rebase on main)
- `cd frontend && npm run test:i18n` — pass
- Targeted suites extended: `geojson-z.test.ts`, new `use-abort-signal.test.tsx`, `AnalysisJobWatcher.test.tsx`, `AnalysisPanel.test.tsx`, `use-builder-save.test.ts`, `use-builder-layers.groups.test.ts`, `BulkActionBar.test.tsx`, `DEMEditorScene.test.tsx`, `BasemapSublayerEditorScene.test.tsx`, `LayerStyleEditor.test.tsx`
