### PR TITLE
fix(deps): bump react-router to 7.18.2 for the RSC CSRF backport

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -7869,9 +7869,9 @@
       }
     },
     "node_modules/react-router": {
-      "version": "7.18.1",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.1.tgz",
-      "integrity": "sha512-GDLgg3i3uM0aeJO3Fm+TCS+sDQ7gu12T6x0qdTEzcwqEfleci7JwugVNIF3U//0FWKnJT7ptG+20B2jfDqnZAg==",
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.2.tgz",
+      "integrity": "sha512-aUVMjFm3GAPTTZL7oYr5E7ETiqfQCHRLH+B+5afnICvf0r7kkK4eR6SMuwbSTJw/7t+12khT/Kahij49fqOCIg==",
       "license": "MIT",
       "dependencies": {
         "cookie": "^1.0.1",

--- a/scripts/js-audit-gate.mjs
+++ b/scripts/js-audit-gate.mjs
@@ -10,11 +10,13 @@ const ALLOWLIST = [
   {
     id: 'GHSA-qwww-vcr4-c8h2', // react-router RSC-mode CSRF (high)
     reason:
-      'Vulnerable code is react-router’s RSC server runtime; the frontend is a ' +
-      'Vite SPA using library-mode <BrowserRouter> (frontend/src/main.tsx) — no ' +
-      'RSC entry point exists, so the vulnerable code never executes. No patched ' +
-      '7.x exists yet (the only fix is the 8.3.0 major). Drop this entry when a ' +
-      '7.x backport ships or the router is upgraded to >=8.3.0.',
+      'Fixed in the installed version: react-router 7.18.2 backports the RSC ' +
+      'CSRF hardening (remix-run/react-router#15353), but the advisory range ' +
+      'still says <8.3.0, so npm audit flags it anyway. Defense in depth: the ' +
+      'frontend is a Vite SPA using library-mode <BrowserRouter> ' +
+      '(frontend/src/main.tsx) — no RSC entry point exists, so the vulnerable ' +
+      'code never executed even before the backport. Drop this entry when the ' +
+      'advisory range is corrected upstream or the router moves to >=8.3.0.',
     expires: '2026-09-01',
   },
   {


### PR DESCRIPTION
Resolves Dependabot alert #56 (GHSA-qwww-vcr4-c8h2, high — RSC-mode CSRF bypass).

react-router 7.18.2 (published 2026-07-28) backports the RSC CSRF hardening to the 7.x line via remix-run/react-router#15353, which is exactly what the #672 allowlist entry was waiting for. The GitHub/npm advisory range still lists everything below 8.3.0 as vulnerable, so npm audit flags 7.18.2 anyway — the `js-audit-gate.mjs` allowlist entry therefore stays, with its reason updated from 'no 7.x patch exists' to 'patched in installed version; advisory range is stale'. Drop the entry when the range is corrected upstream or on a future 8.x migration (#846 territory).

Exposure note: this frontend is a Vite SPA in library mode with no RSC entry point, so the vulnerable codepath never executed here; the bump is hygiene plus alert closure.

## Verification
- `node scripts/js-audit-gate.mjs` — passes (react-router + brace-expansion allowlisted, nothing unallowlisted)
- `cd frontend && npm run lint && npm run typecheck` — clean
- `npx vitest run` — 349 files / 4039 tests pass