### PR TITLE
ci: never cancel in-flight verify-published; semver-only prod-smoke tag trigger

### DIFF
--- a/.github/workflows/prod-smoke.yml
+++ b/.github/workflows/prod-smoke.yml
@@ -24,8 +24,11 @@ on:
       # on non-release tags. The second pattern keeps prerelease tags
       # (v1.5.0-rc.1) in the release chain — release.yml is gated on this
       # workflow's success and explicitly supports prerelease suffixes (#715).
+      # Globs cannot fully express semver (`*` matches zero or more of ANY
+      # character, so e.g. v1.2.3-foo_bar still slips through); the
+      # "Assert semver release tag" step below is the authoritative gate.
       - "v[0-9]+.[0-9]+.[0-9]+"
-      - "v[0-9]+.[0-9]+.[0-9]+-*"
+      - "v[0-9]+.[0-9]+.[0-9]+-[0-9A-Za-z]*"
   workflow_dispatch:
     inputs:
       version:
@@ -50,6 +53,23 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 40
     steps:
+      # Backstop for the tag globs above (fix #829): a glob still admits
+      # non-semver suffixes like v1.2.3- or v1.2.3-foo_bar, whose images
+      # publish.yml never pushes — the pull step below would retry for ~20 min
+      # and fail. Fail fast instead, using the exact regex from release.yml's
+      # "Assert semver-shaped tag" guard (keep the two in sync). A red run on a
+      # junk tag is correct and cheap: release.yml fires only on this
+      # workflow's SUCCESS, so nothing downstream advances.
+      - name: Assert semver release tag
+        if: github.event_name == 'push'
+        env:
+          TAG: ${{ github.ref_name }}
+        run: |
+          if ! printf '%s' "${TAG}" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$'; then
+            echo "::error::tag '${TAG}' is not a semver release tag; refusing to smoke"
+            exit 1
+          fi
+
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 
       - name: Resolve image tag to smoke

--- a/.github/workflows/prod-smoke.yml
+++ b/.github/workflows/prod-smoke.yml
@@ -19,7 +19,13 @@ name: Prod Compose Smoke
 on:
   push:
     tags:
-      - "v*"
+      # Semver release tags only (fix #829): bare "v*" also matched 4-digit GSD
+      # milestone tags (v1055, v1044, …), firing a full image-pull + E2E smoke
+      # on non-release tags. The second pattern keeps prerelease tags
+      # (v1.5.0-rc.1) in the release chain — release.yml is gated on this
+      # workflow's success and explicitly supports prerelease suffixes (#715).
+      - "v[0-9]+.[0-9]+.[0-9]+"
+      - "v[0-9]+.[0-9]+.[0-9]+-*"
   workflow_dispatch:
     inputs:
       version:

--- a/.github/workflows/verify-published.yml
+++ b/.github/workflows/verify-published.yml
@@ -25,9 +25,9 @@ on:
         required: false
         type: string
         default: 'latest'
-  # Auto-run after a gated publish completes. The two publish workflows finish at
-  # different times; the concurrency group below collapses the duplicate triggers
-  # into a single verify run once both are done.
+  # Auto-run after a gated publish completes. The publish workflows finish at
+  # different times; the concurrency group below queues duplicate triggers for
+  # the same version behind the in-flight verify (never cancelling it).
   workflow_run:
     workflows: ["Publish SDKs", "Publish CLI", "Publish MCP Server"]
     types: [completed]
@@ -35,11 +35,18 @@ on:
 permissions:
   contents: read
 
-# Collapse the two publish-completion triggers (and any manual run) for the same
-# version into one in-flight verify; a later trigger supersedes an earlier one.
+# Collapse the publish-completion triggers (and any manual run) for the same
+# version into the same group. cancel-in-progress stays FALSE (fix #829): with
+# `true`, a late-finishing publish job or a re-run could cancel the in-flight
+# verify for that version — masking exactly the publish-failure class this
+# workflow exists to catch (this bit during the 1.6.0 npm OIDC incident).
+# Duplicate triggers now queue behind the running verify (GitHub keeps only the
+# newest pending run per group), so an in-flight verify always finishes.
+# Verifying two different versions concurrently is fine — the group is
+# per-version.
 concurrency:
   group: verify-published-${{ inputs.version || github.event.workflow_run.head_branch || github.run_id }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 env:
   # Manual dispatch → the version input. workflow_run after a tag publish →


### PR DESCRIPTION
Two CI trigger fixes from #829.

## verify-published.yml: never cancel an in-flight verify

The workflow used `cancel-in-progress: true` over its concurrency group. When the last publish job finished late, or a re-run landed, the newer trigger cancelled the in-flight verify — masking exactly the publish-failure class this workflow exists to catch. This bit during the 1.6.0 npm OIDC incident.

The group was already scoped per version (`inputs.version || workflow_run.head_branch || run_id`), so verifying two different tags concurrently was never the problem. The fix is `cancel-in-progress: false`: duplicate triggers for the same version now queue behind the running verify instead of killing it, and GitHub keeps only the newest pending run per group, so the three publish-completion triggers still collapse to at most one queued follow-up. Comments updated to describe the new behavior.

## prod-smoke.yml: semver-only tag trigger

The trigger was bare `v*`, which also matches 4-digit GSD milestone tags (`v1055`, `v1044`, ...). Each such tag push fired a full GHCR image pull plus a prod-compose boot and Playwright E2E run for no reason. Tightened to:

```yaml
tags:
  - "v[0-9]+.[0-9]+.[0-9]+"
  - "v[0-9]+.[0-9]+.[0-9]+-*"
```

The second pattern is deliberate. release.yml is gated on this workflow's success (`workflow_run`) and explicitly supports prerelease tags — its semver assert allows a `-suffix` and #715 fixed RC release notes. A strictly numeric pattern would have silently dropped `v1.5.0-rc.1` out of the release chain: publish.yml (`v*.*.*`) would still push images, but prod-smoke would never run, so release.yml would never create the prerelease. Both patterns exclude dot-less milestone tags.

## Impacts

- No behavior change for normal release tags: `v1.6.0` still triggers prod-smoke, and verify-published still runs after the gated publishes.
- Milestone tags (`v1055`) no longer trigger prod-smoke.
- A verify run in flight can no longer be cancelled by a later trigger; the later trigger queues and runs afterward. Slightly more verify runs per release (up to two instead of one), which is cheap and the point.

## Other tag-triggered workflows (checked, not changed here)

- `publish.yml`, `publish-sdks.yml`, `publish-cli.yml`, `publish-mcp.yml`: all trigger on `v*.*.*`. That already excludes dot-less milestone tags like `v1055`, so no overmatch of the class in this issue. It is looser than semver (`vfoo.bar.baz` would match), but no such tags exist and tightening them is out of scope here.
- `release.yml`: no tag trigger — `workflow_run` on Prod Compose Smoke, with its own strict semver assert on `head_branch` as a backstop.
- `ci.yml`, `codeql.yml`, `dco.yml`, `dep-audit.yml`: no tag triggers.

## Verification

`actionlint` is not installed locally (`command -v actionlint` → not found), so the gate was a YAML parse of both files:

```
python3 -c "
import yaml
for f in ['.github/workflows/verify-published.yml', '.github/workflows/prod-smoke.yml']:
    d = yaml.safe_load(open(f))
    print(f, 'parses OK; name =', d['name'])
"
```

Result:

```
.github/workflows/verify-published.yml parses OK; name = Verify Published Packages
.github/workflows/prod-smoke.yml parses OK; name = Prod Compose Smoke
```

Glob syntax checked against GitHub's filter-pattern cheat sheet (`+` and `[]` are supported; the documented example is `v[12].[0-9]+.[0-9]+`) and against this repo's existing `v*.*.*` patterns. Pre-commit hooks (including check-yaml) passed on commit.

Closes #829

https://claude.ai/code/session_01A8vNJqrsio7yP5vWNhauVg
