### PR TITLE
ci: feed always-run jobs into the ci-ok aggregator

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1220,7 +1220,7 @@ jobs:
         run: uv run pip-audit --strict --desc
 
   # ---------- required-checks aggregator ----------
-  # Every job below is path-filtered (skippable via `if:`), and GitHub treats a
+  # Most jobs below are path-filtered (skippable via `if:`), and GitHub treats a
   # skipped required context as PASSING — the "main red while PRs green" hole.
   # This job always runs and inspects each needed job's actual result: failure
   # or cancelled fails it; skipped and success pass. Branch protection should
@@ -1228,6 +1228,8 @@ jobs:
   ci-ok:
     name: CI OK
     needs:
+      # Path-filtered jobs — these may legitimately skip on a PR; the gating
+      # step below counts skipped as pass.
       - backend-lint
       - backend-test
       - installer-test
@@ -1240,6 +1242,17 @@ jobs:
       - frontend-lint
       - frontend-test
       - security-scan
+      # fix(#824): always-run jobs must feed the aggregator too — before this,
+      # a failure in version-coherence/docs-contract/license-check could not
+      # block a merge (branch protection only sees CI OK). changes and
+      # pre-commit are included so the aggregator is complete on its own: a
+      # failed `changes` job skips every path-filtered job above, which would
+      # otherwise leave CI OK green having gated nothing.
+      - changes
+      - pre-commit
+      - version-coherence
+      - docs-contract
+      - license-check
     # always() alone would rubber-stamp: it only guarantees this job RUNS.
     # The step below does the real gating on needs.*.result.
     if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1243,16 +1243,17 @@ jobs:
       - frontend-test
       - security-scan
       # fix(#824): always-run jobs must feed the aggregator too — before this,
-      # a failure in version-coherence/docs-contract/license-check could not
-      # block a merge (branch protection only sees CI OK). changes and
-      # pre-commit are included so the aggregator is complete on its own: a
-      # failed `changes` job skips every path-filtered job above, which would
-      # otherwise leave CI OK green having gated nothing.
+      # a failure in version-coherence or docs-contract could not block a
+      # merge (branch protection only sees CI OK). changes and pre-commit are
+      # included so the aggregator is complete on its own: a failed `changes`
+      # job skips every path-filtered job above, which would otherwise leave
+      # CI OK green having gated nothing. license-check stays OUT on purpose:
+      # ADMIN-13 mandates it is advisory, and test_phase_279_compose_ci.py::
+      # test_license_check_job_is_non_blocking fails any `needs:` on it.
       - changes
       - pre-commit
       - version-coherence
       - docs-contract
-      - license-check
     # always() alone would rubber-stamp: it only guarantees this job RUNS.
     # The step below does the real gating on needs.*.result.
     if: always()


### PR DESCRIPTION
## What changed

`ci-ok` aggregates the path-filtered jobs behind the required "CI OK" status check, but its `needs` list left out jobs that run on every PR. `version-coherence` and `docs-contract` could fail without blocking a merge. They are now in the aggregator's `needs`. The gating step iterates `toJSON(needs)`, so the existing failure condition covers the new entries with no step changes; skipped still counts as pass for the path-filtered jobs.

I also folded in `changes` and `pre-commit`. Both already block through their own required contexts ("Detect Changes" and "Pre-commit" in branch protection), so nothing changes today. Folding them in makes the aggregator complete on its own, which is its stated design ("Branch protection should require THIS single context"), and it closes a cascade hole: when `changes` fails, every path-filtered job skips, and CI OK by itself would go green having gated nothing.

`license-check` was in the first revision of this PR but is deliberately NOT in the aggregator: ADMIN-13 mandates it stays advisory, and `backend/tests/test_phase_279_compose_ci.py::test_license_check_job_is_non_blocking` fails any job that lists it in `needs` (caught by review; a comment on the needs list now records the constraint).

## Audit: jobs not feeding ci-ok

Jobs in ci.yml that stay out of the aggregator:

- `license-check`: advisory by design per ADMIN-13; enforced by `test_phase_279_compose_ci.py::test_license_check_job_is_non_blocking`.
- `runtime-extension-image-probe`: push(main) and workflow_dispatch only; never runs on a PR.
- `e2e-test`: nightly schedule and workflow_dispatch only; per-PR browser budget is intentionally zero.
- `ai-evals`: schedule and dispatch only; calls the live Anthropic API.
- `accessibility`: push(main), schedule, and dispatch; not a PR job.
- `stac-validate`: same trigger shape as `accessibility`; not a PR job.

PR-triggered jobs in other workflow files. `needs` cannot cross workflows, so none of these can feed ci-ok; each can only block via its own branch-protection context:

- codeql.yml (`Analyze`): findings surface through code scanning; requiring it is a repo-settings decision.
- dep-audit.yml (`python-audit`, `js-audit`, `docker-audit`, `iac-scan`): deliberately advisory. A newly disclosed CVE reddens every open PR at once, so requiring it would block unrelated merges.
- dco.yml (`DCO sign-off check`): if it should block, its context has to be added to branch protection directly.

## Impacts

No triggers, steps, or job conditions change; the diff is the `needs` list and comments on `ci-ok`. After this lands, branch protection could drop "Detect Changes" and "Pre-commit" and require "CI OK" alone, since both now feed the aggregator. That is an operator decision and not part of this PR. Current required contexts, read via `gh api repos/geolens-io/geolens/branches/main/protection/required_status_checks`: Detect Changes, Pre-commit, CI OK.

## Verification

- `actionlint` is not installed locally (`command -v actionlint` came back empty).
- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"` parses clean, and a follow-up script asserted that all `ci-ok` needs entries reference defined jobs (23 jobs total in the file).
- Host-mode backend tests against the changed file (CI-style env vars, Postgres port 5434):
  - `uv run pytest tests/test_phase_279_compose_ci.py -v` — 6 passed, including `test_license_check_job_is_non_blocking`.
  - `uv run pytest tests/test_ci_alembic_filter_paths.py -v` — 4 passed.
- Pre-commit ran at commit time; `check yaml` passed.
- The live proof is this PR's own checks run: pull_request workflows execute from the PR's version of ci.yml, so the CI OK check on this PR already waits on the four added jobs.

Closes #824

https://claude.ai/code/session_01A8vNJqrsio7yP5vWNhauVg
