### PR TITLE
sec(auth): API-key hardening — expiry, token_version staleness, deprecated query-param lane

### DIFF
--- a/.github/ARCHITECTURE.md
+++ b/.github/ARCHITECTURE.md
@@ -72,7 +72,7 @@ Each domain module follows a stable pattern — `router.py` → `service.py` →
 **Read / write (synchronous):**
 `client → frontend (/api proxy) → FastAPI app → middleware (auth) → root router → modules/<domain>/router.py → service.py → SQLAlchemy → PostGIS`.
 
-Auth is resolved in this order: **`Authorization` header → `?api_key=` query param → JWT → anonymous**. (The query-param fallback is excluded from OGC/Features reserved params.)
+Auth is resolved in this order: **`X-Api-Key` header → `?api_key=` query param → JWT Bearer → anonymous**. (The query-param fallback is excluded from OGC/Features reserved params. It is deprecated as of #821 — a key in the URL lands in access and proxy logs — and is kept only for clients that cannot send headers, e.g. XYZ tile URLs in desktop GIS tools.)
 
 **Search** (`modules/catalog/search/`) combines full-text (`pg_trgm`) and semantic
 (`pgvector`) ranking **in a single PostGIS query**, so results can be ranked by meaning

--- a/backend/alembic/versions/0029_api_key_hardening.py
+++ b/backend/alembic/versions/0029_api_key_hardening.py
@@ -1,0 +1,70 @@
+"""API-key hardening: optional expiry and owner key_epoch snapshot.
+
+fix(#821): API keys had no expiry and no staleness check, so a key lived
+forever unless manually revoked and a security event on the owner (role
+change, password change) left previously minted keys working.
+
+- ``api_keys.expires_at`` (timestamptz, nullable): NULL keeps the legacy
+  forever-key behavior; resolution rejects expired keys exactly like invalid
+  ones.
+- ``users.key_epoch`` (int, NOT NULL, default 1): API-key revocation
+  primitive, deliberately separate from ``token_version``. It is bumped only
+  on security events (password change, role change, SAML-to-local
+  conversion) — NOT on logout, which bumps ``token_version`` for JWT/session
+  hygiene but must not kill long-lived API keys.
+- ``api_keys.key_epoch`` (int, NOT NULL): snapshot of the owner's key_epoch
+  at mint time, checked against the owner's current value at resolution.
+  Existing keys are backfilled with each owner's CURRENT key_epoch so
+  security events after this upgrade invalidate keys minted before it.
+
+Revision ID: 0029_api_key_hardening
+Revises: 0028_oauth_email_verified_backfill
+Create Date: 2026-07-29
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0029_api_key_hardening"
+down_revision: Union[str, None] = "0028_oauth_email_verified_backfill"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "users",
+        sa.Column("key_epoch", sa.Integer(), server_default="1", nullable=False),
+        schema="catalog",
+    )
+    op.add_column(
+        "api_keys",
+        sa.Column("expires_at", sa.DateTime(timezone=True), nullable=True),
+        schema="catalog",
+    )
+    op.add_column(
+        "api_keys",
+        sa.Column("key_epoch", sa.Integer(), nullable=True),
+        schema="catalog",
+    )
+    # Every key has an owner (user_id is NOT NULL with ON DELETE CASCADE), so
+    # this backfill covers all rows and the NOT NULL flip below cannot fail.
+    # Owners were just stamped with key_epoch=1 by the server default above,
+    # but joining keeps the backfill correct even if that default changes.
+    op.execute(
+        """
+        UPDATE catalog.api_keys ak
+        SET key_epoch = u.key_epoch
+        FROM catalog.users u
+        WHERE ak.user_id = u.id
+        """
+    )
+    op.alter_column("api_keys", "key_epoch", nullable=False, schema="catalog")
+
+
+def downgrade() -> None:
+    op.drop_column("api_keys", "key_epoch", schema="catalog")
+    op.drop_column("api_keys", "expires_at", schema="catalog")
+    op.drop_column("users", "key_epoch", schema="catalog")

--- a/backend/app/api/main.py
+++ b/backend/app/api/main.py
@@ -446,24 +446,35 @@ without credentials; private/restricted datasets require one of:
 |--------|-------|
 | **API Key header** | `X-Api-Key: <key>` |
 | **JWT Bearer token** | `Authorization: Bearer <token>` |
-| **API Key query param** | `?api_key=<key>` |
+| **API Key query param** (deprecated) | `?api_key=<key>` |
 
 Priority: header API key > query param API key > JWT > anonymous.
+
+**The `?api_key=` query parameter is deprecated.** A key sent in the URL is
+recorded by server access logs and any proxy in between. Prefer the
+`X-Api-Key` header; keep the query parameter only for clients that cannot
+send headers (e.g. XYZ tile URLs in desktop GIS tools).
+
+API keys may carry an optional expiry (`expires_at` at mint time). Expired
+keys stop authenticating, and keys are also invalidated by security events
+on the owner's account (password change or role change). Logging out of the
+web UI does not affect API keys.
 
 ### GDAL / ogr2ogr with API Key
 
 ```bash
 # List collections (including private ones accessible to your key)
-ogrinfo "OAPIF:{your-server}/api/?api_key=YOUR_KEY"
+ogrinfo --config GDAL_HTTP_HEADERS "X-Api-Key: YOUR_KEY" "OAPIF:{your-server}/api/"
 
 # Download a private collection
-ogr2ogr -f GPKG out.gpkg "OAPIF:{your-server}/api/?api_key=YOUR_KEY" {collection-id}
+ogr2ogr -f GPKG out.gpkg --config GDAL_HTTP_HEADERS "X-Api-Key: YOUR_KEY" "OAPIF:{your-server}/api/" {collection-id}
 ```
 
 ### QGIS with API Key
 
 In the WFS / OGC API Features connection dialog, append `?api_key=YOUR_KEY`
-to the server URL.
+to the server URL (the connection dialog cannot send custom headers; this is
+the main remaining use of the deprecated query parameter).
 """
 
 _OPENAPI_TAGS = [

--- a/backend/app/modules/admin/router_operations.py
+++ b/backend/app/modules/admin/router_operations.py
@@ -38,6 +38,7 @@ def _api_key_response(key: ApiKey) -> AdminApiKeyListItem:
         name=key.name,
         fingerprint=key.fingerprint,
         is_active=key.is_active,
+        expires_at=key.expires_at,
         created_at=key.created_at,
         last_used_at=key.last_used_at,
     )
@@ -71,7 +72,9 @@ async def create_api_key(
     )
 
     try:
-        api_key, raw_key = await create_api_key_for_user(db, body.user_id, body.name)
+        api_key, raw_key = await create_api_key_for_user(
+            db, body.user_id, body.name, expires_at=body.expires_at
+        )
     except ApiKeyTargetUserNotFoundError as exc:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
@@ -88,6 +91,9 @@ async def create_api_key(
                 "name": body.name,
                 "fingerprint": api_key.fingerprint,
                 "target_user_id": str(body.user_id),
+                "expires_at": (
+                    api_key.expires_at.isoformat() if api_key.expires_at else None
+                ),
             },
             ip_address=get_client_ip(request),
         ),
@@ -99,6 +105,7 @@ async def create_api_key(
         key=raw_key,
         fingerprint=api_key.fingerprint,
         name=api_key.name,
+        expires_at=api_key.expires_at,
         created_at=api_key.created_at,
     )
 

--- a/backend/app/modules/admin/router_operations.py
+++ b/backend/app/modules/admin/router_operations.py
@@ -67,6 +67,7 @@ async def create_api_key(
     The raw key is returned only in this response and cannot be retrieved again.
     """
     from app.modules.auth.service import (
+        ApiKeyTargetUserInactiveError,
         ApiKeyTargetUserNotFoundError,
         create_api_key_for_user,
     )
@@ -79,6 +80,13 @@ async def create_api_key(
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="User not found",
+        ) from exc
+    except ApiKeyTargetUserInactiveError as exc:
+        # fix(#821 codex review): pending/suspended/deactivated owners cannot
+        # receive keys — a pre-approval key must not wake up privileged.
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="API keys can only be created for active users",
         ) from exc
     await audit_emit(
         db,

--- a/backend/app/modules/admin/schemas.py
+++ b/backend/app/modules/admin/schemas.py
@@ -4,9 +4,16 @@ import uuid
 from datetime import datetime
 from typing import Any, Literal
 
-from pydantic import BaseModel, EmailStr, Field, field_validator, model_validator
+from pydantic import (
+    AwareDatetime,
+    BaseModel,
+    EmailStr,
+    Field,
+    field_validator,
+    model_validator,
+)
 
-from app.modules.auth.schemas import UserResponse
+from app.modules.auth.schemas import UserResponse, validate_future_expiry
 from app.processing.ai.schemas import AIProbeReport
 
 VALID_ROLES = {"admin", "editor", "viewer"}
@@ -355,6 +362,15 @@ class AdminApiKeyCreateRequest(BaseModel):
         max_length=255,
         description="Human-readable label for the API key (e.g. 'CI pipeline', 'QGIS desktop').",
     )
+    expires_at: AwareDatetime | None = Field(
+        default=None,
+        description=(
+            "Optional expiry timestamp (RFC 3339, timezone-aware). Omit or null "
+            "for a non-expiring key; expired keys stop authenticating."
+        ),
+    )
+
+    _expires_at_future = field_validator("expires_at")(validate_future_expiry)
 
 
 class AdminApiKeyListItem(BaseModel):
@@ -366,6 +382,10 @@ class AdminApiKeyListItem(BaseModel):
     )
     is_active: bool = Field(
         description="Whether the key is active. Inactive keys cannot authenticate."
+    )
+    expires_at: datetime | None = Field(
+        default=None,
+        description="Expiry timestamp; null means the key does not expire.",
     )
     created_at: datetime = Field(description="Timestamp when the key was created.")
     last_used_at: datetime | None = Field(

--- a/backend/app/modules/admin/service.py
+++ b/backend/app/modules/admin/service.py
@@ -345,6 +345,15 @@ class AdminService:
         await self.db.execute(delete(UserRole).where(UserRole.user_id == user.id))
         self.db.add(UserRole(user_id=user.id, role_id=new_role.id))
 
+        # fix(#821): bump key_epoch so API keys minted under the old role stop
+        # resolving. Applies to promotion as well as demotion — a key must not
+        # silently change privilege level; the owner re-mints under the new
+        # role. token_version is deliberately NOT bumped here: JWTs are
+        # short-lived and role checks read live DB roles per request.
+        await self.db.execute(
+            update(User).where(User.id == user.id).values(key_epoch=User.key_epoch + 1)
+        )
+
     async def convert_saml_user_to_local(
         self, user_id: uuid.UUID, password: str
     ) -> tuple[User, str]:
@@ -418,10 +427,15 @@ class AdminService:
         #    request. The SAML JWT remains cryptographically valid until its
         #    natural expiry otherwise, which violates the SEC-S15 requirement
         #    that auth-provider conversion forces re-authentication.
+        #    fix(#821): also bump key_epoch — an auth-provider conversion is a
+        #    credential reset, so API keys minted before it stop resolving.
         await self.db.execute(
             update(User)
             .where(User.id == user_id)
-            .values(token_version=User.token_version + 1)
+            .values(
+                token_version=User.token_version + 1,
+                key_epoch=User.key_epoch + 1,
+            )
         )
 
         # 8. Belt-and-suspenders: also revoke any active refresh tokens so the

--- a/backend/app/modules/admin/service.py
+++ b/backend/app/modules/admin/service.py
@@ -339,6 +339,23 @@ class AdminService:
         if new_role is None:
             raise ValueError(f"Role '{new_role_name}' not found")
 
+        # fix(#821 codex review): an idempotent resubmission of the user's
+        # current role (e.g. a reconciliation-tool PATCH) is not a security
+        # event — skip the delete/recreate AND the key_epoch bump so it does
+        # not revoke the user's API keys. Queried explicitly rather than via
+        # user.roles to avoid depending on relationship load state.
+        current_role_names = set(
+            (
+                await self.db.execute(
+                    select(Role.name)
+                    .join(UserRole, UserRole.role_id == Role.id)
+                    .where(UserRole.user_id == user.id)
+                )
+            ).scalars()
+        )
+        if current_role_names == {new_role_name}:
+            return
+
         if new_role_name != "admin" and not viability_checked:
             await self._ensure_not_last_admin(user, "demote", lock_held=lock_held)
 
@@ -539,6 +556,14 @@ class AdminService:
 
         user.status = "active"
         user.is_active = True
+
+        # fix(#821 codex review): approval assigns the account's authority, so
+        # bump key_epoch — any key that existed while the account was pending
+        # (legacy/manual rows; minting for non-active users is now refused)
+        # must not wake up with the approved role's privileges. The row is
+        # locked (with_for_update above), so the in-place increment is
+        # race-free.
+        user.key_epoch += 1
 
         # A pending account should not normally own a role, but legacy/manual
         # rows may. Replace the complete assignment so the approved role is the

--- a/backend/app/modules/auth/dependencies.py
+++ b/backend/app/modules/auth/dependencies.py
@@ -60,7 +60,14 @@ def log_permission_denial(
 
 
 async def _resolve_api_key(request: Request, db: AsyncSession) -> User | None:
-    """Try to resolve a user from X-Api-Key header or api_key query parameter."""
+    """Try to resolve a user from X-Api-Key header or api_key query parameter.
+
+    The ``?api_key=`` query-parameter lane is DEPRECATED (#821): a credential
+    in the URL is written into access logs and any upstream proxy logs. It is
+    kept for external clients that cannot set headers (e.g. XYZ tile URLs in
+    desktop GIS tools) but new integrations must use the ``X-Api-Key`` header.
+    Resolution precedence is unchanged: header > query param.
+    """
     api_key = request.headers.get("X-Api-Key")
     if not api_key:
         api_key = request.query_params.get("api_key")
@@ -75,15 +82,26 @@ async def _resolve_api_key(request: Request, db: AsyncSession) -> User | None:
     api_key_obj = result.scalar_one_or_none()
     if api_key_obj is None:
         return None
+    now = datetime.now(timezone.utc)
+    # fix(#821): an expired key behaves exactly like an invalid one (and must
+    # not bump last_used_at below).
+    if api_key_obj.expires_at is not None and api_key_obj.expires_at <= now:
+        return None
+    # fix(#821): staleness gate on the owner's key_epoch — the API-key
+    # analogue of the JWT token_version check (SEC-S15), but on a dedicated
+    # counter bumped only by security events (password change, role change,
+    # SAML-to-local conversion). Logout bumps token_version, NOT key_epoch,
+    # so signing out of the web UI never kills long-lived API keys.
     user = api_key_obj.user
-    if user is None or not user.is_active or user.status != "active":
+    if user is None or api_key_obj.key_epoch != user.key_epoch:
+        return None
+    if not user.is_active or user.status != "active":
         return None
     # Only update last_used_at if it's been more than 60 seconds (reduce write amplification).
     # Use a separate session so we don't flush the request-scoped session early —
     # an early commit on `db` would release advisory locks the route handler
     # may still need, and would persist any uncommitted state from prior
     # dependencies before the route's own logic decides whether to commit.
-    now = datetime.now(timezone.utc)
     if api_key_obj.last_used_at is None or (now - api_key_obj.last_used_at) > timedelta(
         seconds=60
     ):

--- a/backend/app/modules/auth/models.py
+++ b/backend/app/modules/auth/models.py
@@ -126,6 +126,14 @@ class User(Base):
     token_version: Mapped[int] = mapped_column(
         Integer, default=1, server_default="1", nullable=False
     )
+    # fix(#821): API-key revocation primitive, deliberately separate from
+    # token_version. Bumped only on security events (password change, role
+    # change, SAML-to-local conversion) — NOT on logout, so a web logout does
+    # not kill long-lived API keys (CI, MCP, tile URLs). Keys snapshot this
+    # value at mint and stop resolving when it no longer matches.
+    key_epoch: Mapped[int] = mapped_column(
+        Integer, default=1, server_default="1", nullable=False
+    )
     auth_provider: Mapped[str] = mapped_column(
         String(20), server_default="local", nullable=False
     )
@@ -194,6 +202,17 @@ class ApiKey(Base):
     is_active: Mapped[bool] = mapped_column(
         Boolean, default=True, server_default="true"
     )
+    # fix(#821): optional expiry. NULL preserves the pre-0029 forever-key
+    # behavior; at resolution an expired key fails exactly like an invalid one.
+    expires_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    # fix(#821): snapshot of the owner's key_epoch at mint time. When the
+    # owner's key_epoch is bumped (password change, role change, SAML-to-local
+    # conversion — NOT logout), keys minted before the bump stop resolving.
+    # Migration 0029 backfills pre-existing keys with each owner's
+    # then-current epoch.
+    key_epoch: Mapped[int] = mapped_column(Integer, nullable=False)
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now()
     )

--- a/backend/app/modules/auth/router.py
+++ b/backend/app/modules/auth/router.py
@@ -634,6 +634,10 @@ async def logout(
     access JWT used for this logout call (and any other outstanding access JWTs)
     are rejected on the next authenticated request — closing the
     "logout doesn't invalidate the access JWT" gap.
+
+    fix(#821): logout deliberately does NOT bump key_epoch — API keys exist to
+    outlive browser sessions (CI, MCP servers, tile URLs), so session hygiene
+    must not revoke them. Security events (password change, role change) do.
     """
     service = AuthService(db)
     await service.revoke_all_tokens(current_user.id)
@@ -861,6 +865,7 @@ async def list_my_api_keys(
                 name=k.name,
                 fingerprint=k.fingerprint,
                 is_active=k.is_active,
+                expires_at=k.expires_at,
                 created_at=k.created_at,
                 last_used_at=k.last_used_at,
             )
@@ -898,7 +903,9 @@ async def create_my_api_key(
     )  # LAZY — preserved per D-17
     from app.modules.auth.service import create_api_key_for_user
 
-    api_key, raw_key = await create_api_key_for_user(db, current_user.id, body.name)
+    api_key, raw_key = await create_api_key_for_user(
+        db, current_user.id, body.name, expires_at=body.expires_at
+    )
 
     ip = get_client_ip(request)
     await audit_emit(
@@ -908,7 +915,13 @@ async def create_my_api_key(
             action="api_key.create",
             resource_type="api_key",
             resource_id=api_key.id,
-            details={"name": body.name, "fingerprint": api_key.fingerprint},
+            details={
+                "name": body.name,
+                "fingerprint": api_key.fingerprint,
+                "expires_at": (
+                    api_key.expires_at.isoformat() if api_key.expires_at else None
+                ),
+            },
             ip_address=ip,
         ),
     )
@@ -920,6 +933,7 @@ async def create_my_api_key(
         key=raw_key,
         fingerprint=api_key.fingerprint,
         name=api_key.name,
+        expires_at=api_key.expires_at,
         created_at=api_key.created_at,
     )
 
@@ -1007,12 +1021,16 @@ async def change_password(
     # for this user are invalidated on their next request. Password rotation
     # should force re-auth on every other device.
     #
+    # fix(#821): bump_key_epoch=True — a password change is a credential
+    # reset, so previously minted API keys are invalidated too (unlike plain
+    # logout, which leaves API keys alone).
+    #
     # commit=False: fold the token revocation into the same transaction as the
     # password hash mutation and audit row so all three land atomically. A crash
     # between commits would otherwise leave the user with bumped token_version
     # (all tokens rejected) but the new password not recorded, locking them out.
     service = AuthService(db)
-    await service.revoke_all_tokens(current_user.id, commit=False)
+    await service.revoke_all_tokens(current_user.id, commit=False, bump_key_epoch=True)
 
     ip = get_client_ip(request)
     await audit_emit(

--- a/backend/app/modules/auth/schemas.py
+++ b/backend/app/modules/auth/schemas.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
 import uuid
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Literal
 
-from pydantic import BaseModel, EmailStr, Field, field_validator
+from pydantic import AwareDatetime, BaseModel, EmailStr, Field, field_validator
 
 from app.modules.quota.schemas import UserQuotaUsage
 
@@ -212,10 +212,30 @@ class PermissionsResponse(BaseModel):
     )
 
 
+def validate_future_expiry(value: AwareDatetime | None) -> AwareDatetime | None:
+    """Reject an ``expires_at`` that is not in the future (#821).
+
+    Shared by the self-service and admin key-mint request schemas so both
+    surfaces refuse to mint an already-expired key.
+    """
+    if value is not None and value <= datetime.now(timezone.utc):
+        raise ValueError("expires_at must be in the future")
+    return value
+
+
 class ApiKeyCreateRequest(BaseModel):
     name: str = Field(
         min_length=1, max_length=255, description="Human-readable label for the API key"
     )
+    expires_at: AwareDatetime | None = Field(
+        default=None,
+        description=(
+            "Optional expiry timestamp (RFC 3339, timezone-aware). Omit or null "
+            "for a non-expiring key; expired keys stop authenticating."
+        ),
+    )
+
+    _expires_at_future = field_validator("expires_at")(validate_future_expiry)
 
 
 class ApiKeyCreateResponse(BaseModel):
@@ -225,6 +245,10 @@ class ApiKeyCreateResponse(BaseModel):
         description="Non-secret key identifier (prefix and last four characters)"
     )
     name: str
+    expires_at: datetime | None = Field(
+        default=None,
+        description="Expiry timestamp; null means the key does not expire",
+    )
     created_at: datetime
 
 
@@ -235,6 +259,10 @@ class ApiKeyListItem(BaseModel):
         description="Non-secret key identifier; null for keys created before fingerprint support"
     )
     is_active: bool
+    expires_at: datetime | None = Field(
+        default=None,
+        description="Expiry timestamp; null means the key does not expire",
+    )
     created_at: datetime
     last_used_at: datetime | None
 

--- a/backend/app/modules/auth/service.py
+++ b/backend/app/modules/auth/service.py
@@ -413,6 +413,17 @@ class ApiKeyTargetUserNotFoundError(LookupError):
     """The target user is absent from the caller's RLS-visible scope."""
 
 
+class ApiKeyTargetUserInactiveError(ValueError):
+    """The target user is not active, so an API key must not be minted.
+
+    fix(#821 codex review): a key minted for a pending account would be
+    blocked by the resolution-time status check while pending, then wake up
+    with the approved role's privileges at approval. Refusing the mint closes
+    that door at the earliest point (approve_user's key_epoch bump is the
+    belt-and-suspenders for keys that predate this guard).
+    """
+
+
 async def create_api_key_for_user(
     db: AsyncSession,
     user_id: uuid.UUID,
@@ -427,13 +438,19 @@ async def create_api_key_for_user(
     fix(#821): ``expires_at=None`` mints a non-expiring key (legacy behavior);
     the key also snapshots the owner's current key_epoch so a later security
     event (password change, role change, SAML-to-local conversion — NOT
-    logout) invalidates it.
+    logout) invalidates it. Minting requires an active owner.
     """
     owner = (
-        await db.execute(select(User.id, User.key_epoch).where(User.id == user_id))
+        await db.execute(
+            select(User.id, User.key_epoch, User.status).where(User.id == user_id)
+        )
     ).one_or_none()
     if owner is None:
         raise ApiKeyTargetUserNotFoundError("User not found")
+    if owner.status != "active":
+        raise ApiKeyTargetUserInactiveError(
+            "API keys can only be created for active users"
+        )
 
     raw_key = secrets.token_urlsafe(32)
     key_hash = hashlib.sha256(raw_key.encode()).hexdigest()

--- a/backend/app/modules/auth/service.py
+++ b/backend/app/modules/auth/service.py
@@ -278,7 +278,7 @@ class AuthService:
         return new_access, new_refresh
 
     async def revoke_all_tokens(
-        self, user_id: uuid.UUID, *, commit: bool = True
+        self, user_id: uuid.UUID, *, commit: bool = True, bump_key_epoch: bool = False
     ) -> int:
         """Revoke all active refresh tokens AND bump User.token_version (logout).
 
@@ -293,6 +293,10 @@ class AuthService:
                 revocation is durable. Pass commit=False when the caller wants to
                 fold revocation into a larger transaction (e.g. change_password,
                 where the password hash and audit row must land in the same commit).
+            bump_key_epoch: fix(#821) — also bump User.key_epoch, invalidating
+                every API key minted before the bump. Default False so plain
+                logout (session hygiene) never kills long-lived API keys; pass
+                True only from security-event callers (password change).
 
         Returns the new token_version value.
         """
@@ -306,11 +310,16 @@ class AuthService:
             .values(revoked=True)
         )
 
-        # 2. Atomically increment token_version so prior access JWTs are rejected.
+        # 2. Atomically increment token_version so prior access JWTs are
+        #    rejected (and key_epoch in the same UPDATE when requested, so a
+        #    security event revokes JWTs and API keys atomically).
+        values: dict = {"token_version": User.token_version + 1}
+        if bump_key_epoch:
+            values["key_epoch"] = User.key_epoch + 1
         version_result = await self.db.execute(
             update(User)
             .where(User.id == user_id)
-            .values(token_version=User.token_version + 1)
+            .values(**values)
             .returning(User.token_version)
         )
         new_version = version_result.scalar_one_or_none()
@@ -408,24 +417,34 @@ async def create_api_key_for_user(
     db: AsyncSession,
     user_id: uuid.UUID,
     name: str,
+    expires_at: datetime | None = None,
 ) -> tuple[ApiKey, str]:
     """Create an API key for a user. Returns (api_key, raw_key).
 
     The raw key is only available at creation time. Flushes but does
     NOT commit — caller controls the transaction.
+
+    fix(#821): ``expires_at=None`` mints a non-expiring key (legacy behavior);
+    the key also snapshots the owner's current key_epoch so a later security
+    event (password change, role change, SAML-to-local conversion — NOT
+    logout) invalidates it.
     """
-    visible_user_id = await db.scalar(select(User.id).where(User.id == user_id))
-    if visible_user_id is None:
+    owner = (
+        await db.execute(select(User.id, User.key_epoch).where(User.id == user_id))
+    ).one_or_none()
+    if owner is None:
         raise ApiKeyTargetUserNotFoundError("User not found")
 
     raw_key = secrets.token_urlsafe(32)
     key_hash = hashlib.sha256(raw_key.encode()).hexdigest()
     fingerprint = f"{raw_key[:8]}…{raw_key[-4:]}"
     api_key = ApiKey(
-        user_id=visible_user_id,
+        user_id=owner.id,
         key_hash=key_hash,
         fingerprint=fingerprint,
         name=name,
+        expires_at=expires_at,
+        key_epoch=owner.key_epoch,
     )
     db.add(api_key)
     await db.flush()

--- a/backend/app/modules/catalog/datasets/domain/helpers.py
+++ b/backend/app/modules/catalog/datasets/domain/helpers.py
@@ -69,6 +69,9 @@ def _build_raster_metadata(
     # Build tile and download URLs
     # tile_url_meta stays relative (used by map rendering in the browser)
     # connect URLs are absolute with api_key placeholder (for external GIS tools)
+    # fix(#821): the ?api_key= query lane is deprecated, but XYZ tile URLs in
+    # desktop GIS tools cannot send headers — this placeholder is the sanctioned
+    # remaining use of the lane.
     tile_url_path = f"/raster-tiles/{dataset.id}/tiles/{{z}}/{{x}}/{{y}}.png"
     tile_url_meta = tile_url_path
 

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -193,6 +193,19 @@
       },
       "AdminApiKeyCreateRequest": {
         "properties": {
+          "expires_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Optional expiry timestamp (RFC 3339, timezone-aware). Omit or null for a non-expiring key; expired keys stop authenticating.",
+            "title": "Expires At"
+          },
           "name": {
             "description": "Human-readable label for the API key (e.g. 'CI pipeline', 'QGIS desktop').",
             "maxLength": 255,
@@ -221,6 +234,19 @@
             "format": "date-time",
             "title": "Created At",
             "type": "string"
+          },
+          "expires_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Expiry timestamp; null means the key does not expire.",
+            "title": "Expires At"
           },
           "fingerprint": {
             "anyOf": [
@@ -1006,6 +1032,19 @@
       },
       "ApiKeyCreateRequest": {
         "properties": {
+          "expires_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Optional expiry timestamp (RFC 3339, timezone-aware). Omit or null for a non-expiring key; expired keys stop authenticating.",
+            "title": "Expires At"
+          },
           "name": {
             "description": "Human-readable label for the API key",
             "maxLength": 255,
@@ -1026,6 +1065,19 @@
             "format": "date-time",
             "title": "Created At",
             "type": "string"
+          },
+          "expires_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Expiry timestamp; null means the key does not expire",
+            "title": "Expires At"
           },
           "fingerprint": {
             "description": "Non-secret key identifier (prefix and last four characters)",
@@ -1063,6 +1115,19 @@
             "format": "date-time",
             "title": "Created At",
             "type": "string"
+          },
+          "expires_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Expiry timestamp; null means the key does not expire",
+            "title": "Expires At"
           },
           "fingerprint": {
             "anyOf": [
@@ -17474,7 +17539,7 @@
       "name": "GeoLens",
       "url": "https://github.com/geolens-io/geolens"
     },
-    "description": "## Overview\n\nGeoLens is a self-hosted spatial data catalog that ingests vector files\n(GeoPackage, Shapefile, GeoJSON, CSV), stores them in PostGIS, and exposes\nthem through OGC API endpoints.\n\n## OGC Conformance Classes\n\n* OGC API Common 1.0 -- Core, Landing Page, JSON, OAS 3.0\n* OGC API Features Part 1 -- Core, GeoJSON, OAS 3.0\n* OGC API Features Part 3 -- Filtering (CQL2-Text, CQL2-JSON)\n\n## QGIS Quick-start\n\n1. **Layer > Add Layer > WFS / OGC API Features**\n2. URL: `{your-server}/api/`\n3. GeoLens advertises collections automatically.\n\n## GDAL / ogr2ogr Quick-start\n\n```bash\n# List collections\nogrinfo OAPIF:{your-server}/api/\n\n# Download a collection to GeoPackage\nogr2ogr -f GPKG output.gpkg OAPIF:{your-server}/api/ {collection-id}\n```\n\n## Authentication\n\nGeoLens supports three authentication methods. Public datasets are accessible\nwithout credentials; private/restricted datasets require one of:\n\n| Method | Usage |\n|--------|-------|\n| **API Key header** | `X-Api-Key: <key>` |\n| **JWT Bearer token** | `Authorization: Bearer <token>` |\n| **API Key query param** | `?api_key=<key>` |\n\nPriority: header API key > query param API key > JWT > anonymous.\n\n### GDAL / ogr2ogr with API Key\n\n```bash\n# List collections (including private ones accessible to your key)\nogrinfo \"OAPIF:{your-server}/api/?api_key=YOUR_KEY\"\n\n# Download a private collection\nogr2ogr -f GPKG out.gpkg \"OAPIF:{your-server}/api/?api_key=YOUR_KEY\" {collection-id}\n```\n\n### QGIS with API Key\n\nIn the WFS / OGC API Features connection dialog, append `?api_key=YOUR_KEY`\nto the server URL.\n",
+    "description": "## Overview\n\nGeoLens is a self-hosted spatial data catalog that ingests vector files\n(GeoPackage, Shapefile, GeoJSON, CSV), stores them in PostGIS, and exposes\nthem through OGC API endpoints.\n\n## OGC Conformance Classes\n\n* OGC API Common 1.0 -- Core, Landing Page, JSON, OAS 3.0\n* OGC API Features Part 1 -- Core, GeoJSON, OAS 3.0\n* OGC API Features Part 3 -- Filtering (CQL2-Text, CQL2-JSON)\n\n## QGIS Quick-start\n\n1. **Layer > Add Layer > WFS / OGC API Features**\n2. URL: `{your-server}/api/`\n3. GeoLens advertises collections automatically.\n\n## GDAL / ogr2ogr Quick-start\n\n```bash\n# List collections\nogrinfo OAPIF:{your-server}/api/\n\n# Download a collection to GeoPackage\nogr2ogr -f GPKG output.gpkg OAPIF:{your-server}/api/ {collection-id}\n```\n\n## Authentication\n\nGeoLens supports three authentication methods. Public datasets are accessible\nwithout credentials; private/restricted datasets require one of:\n\n| Method | Usage |\n|--------|-------|\n| **API Key header** | `X-Api-Key: <key>` |\n| **JWT Bearer token** | `Authorization: Bearer <token>` |\n| **API Key query param** (deprecated) | `?api_key=<key>` |\n\nPriority: header API key > query param API key > JWT > anonymous.\n\n**The `?api_key=` query parameter is deprecated.** A key sent in the URL is\nrecorded by server access logs and any proxy in between. Prefer the\n`X-Api-Key` header; keep the query parameter only for clients that cannot\nsend headers (e.g. XYZ tile URLs in desktop GIS tools).\n\nAPI keys may carry an optional expiry (`expires_at` at mint time). Expired\nkeys stop authenticating, and keys are also invalidated by security events\non the owner's account (password change or role change). Logging out of the\nweb UI does not affect API keys.\n\n### GDAL / ogr2ogr with API Key\n\n```bash\n# List collections (including private ones accessible to your key)\nogrinfo --config GDAL_HTTP_HEADERS \"X-Api-Key: YOUR_KEY\" \"OAPIF:{your-server}/api/\"\n\n# Download a private collection\nogr2ogr -f GPKG out.gpkg --config GDAL_HTTP_HEADERS \"X-Api-Key: YOUR_KEY\" \"OAPIF:{your-server}/api/\" {collection-id}\n```\n\n### QGIS with API Key\n\nIn the WFS / OGC API Features connection dialog, append `?api_key=YOUR_KEY`\nto the server URL (the connection dialog cannot send custom headers; this is\nthe main remaining use of the deprecated query parameter).\n",
     "license": {
       "name": "Apache 2.0",
       "url": "https://www.apache.org/licenses/LICENSE-2.0"
@@ -24063,7 +24128,7 @@
     },
     "/auth/logout/": {
       "post": {
-        "description": "Revoke all refresh tokens and bump token_version for the current user.\n\nSEC-S15 (Phase 1062-01): revoke_all_tokens bumps User.token_version so the\naccess JWT used for this logout call (and any other outstanding access JWTs)\nare rejected on the next authenticated request \u2014 closing the\n\"logout doesn't invalidate the access JWT\" gap.",
+        "description": "Revoke all refresh tokens and bump token_version for the current user.\n\nSEC-S15 (Phase 1062-01): revoke_all_tokens bumps User.token_version so the\naccess JWT used for this logout call (and any other outstanding access JWTs)\nare rejected on the next authenticated request \u2014 closing the\n\"logout doesn't invalidate the access JWT\" gap.\n\nfix(#821): logout deliberately does NOT bump key_epoch \u2014 API keys exist to\noutlive browser sessions (CI, MCP servers, tile URLs), so session hygiene\nmust not revoke them. Security events (password change, role change) do.",
         "operationId": "logout_auth_logout__post",
         "responses": {
           "204": {

--- a/backend/tests/test_access_log_path_redaction.py
+++ b/backend/tests/test_access_log_path_redaction.py
@@ -2,6 +2,7 @@
 
 import pytest
 
+import app.api.middleware.logging as logging_mw
 from app.api.middleware.logging import safe_access_log_path
 
 
@@ -26,3 +27,43 @@ def test_safe_access_log_path(path: str, expected: str) -> None:
 
     assert logged_path == expected
     assert "SYNTHETIC_SENTINEL" not in logged_path
+
+
+@pytest.mark.anyio
+async def test_access_log_never_contains_query_credentials(monkeypatch) -> None:
+    """fix(#821): the deprecated ?api_key= lane puts the credential in the URL.
+
+    Our own access log line must never include the query string — the
+    middleware logs request.url.path only. This test pins that contract so a
+    future refactor that logs the full URL fails loudly.
+    """
+    from httpx import ASGITransport, AsyncClient
+    from starlette.applications import Starlette
+    from starlette.responses import PlainTextResponse
+    from starlette.routing import Route
+
+    events: list[tuple[str, dict]] = []
+
+    class _CaptureLogger:
+        def info(self, event: str, **kwargs) -> None:
+            events.append((event, kwargs))
+
+    monkeypatch.setattr(logging_mw, "access_logger", _CaptureLogger())
+
+    async def ok(_request):
+        return PlainTextResponse("ok")
+
+    app = Starlette(routes=[Route("/things", ok)])
+    app.add_middleware(logging_mw.RequestLoggingMiddleware)
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as http:
+        resp = await http.get("/things?api_key=SYNTHETIC_KEY_SENTINEL&x=1")
+
+    assert resp.status_code == 200
+    assert events, "middleware did not emit an access log event"
+    logged = repr(events)
+    assert "SYNTHETIC_KEY_SENTINEL" not in logged
+    assert "api_key" not in logged
+    assert events[0][1]["path"] == "/things"

--- a/backend/tests/test_admin_invariants_regression.py
+++ b/backend/tests/test_admin_invariants_regression.py
@@ -300,9 +300,10 @@ async def test_token_version_bumped_on_saml_to_local_conversion(
     test_db_session.add(oauth_acct)
     await test_db_session.commit()
 
-    # Record token_version before conversion
+    # Record token_version and key_epoch before conversion
     await test_db_session.refresh(saml_user)
     version_before = saml_user.token_version
+    epoch_before = saml_user.key_epoch
 
     # Execute conversion
     service = AdminService(test_db_session)
@@ -316,6 +317,12 @@ async def test_token_version_bumped_on_saml_to_local_conversion(
     assert user_after.token_version > version_before, (
         f"Expected token_version > {version_before}, got {user_after.token_version}. "
         "SAML-to-local conversion must bump token_version (SEC-S15)."
+    )
+    # fix(#821): key_epoch must bump too — an auth-provider conversion is a
+    # credential reset, so API keys minted before it must stop resolving.
+    assert user_after.key_epoch > epoch_before, (
+        f"Expected key_epoch > {epoch_before}, got {user_after.key_epoch}. "
+        "SAML-to-local conversion must bump key_epoch (#821)."
     )
 
 

--- a/backend/tests/test_api_key_auth.py
+++ b/backend/tests/test_api_key_auth.py
@@ -314,3 +314,273 @@ async def test_self_service_cannot_delete_another_users_key(client: AsyncClient)
     )
     # The endpoint filters by current_user.id, so another user's key is "not found"
     assert del_resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# fix(#821): expiry, token_version staleness, deprecated query-param lane
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_api_key_with_future_expiry_accepted_and_surfaced(client: AsyncClient):
+    """A key minted with a future expires_at authenticates and the expiry is
+    returned by both the create response and the listing."""
+    from datetime import datetime, timedelta, timezone
+
+    admin_headers = await get_auth_header(client, ADMIN_USER, ADMIN_PASS)
+    expiry = (datetime.now(timezone.utc) + timedelta(days=1)).isoformat()
+
+    resp = await client.post(
+        "/auth/api-keys/",
+        json={"name": "Expiring Key", "expires_at": expiry},
+        headers=admin_headers,
+    )
+    assert resp.status_code == 201
+    data = resp.json()
+    assert data["expires_at"] is not None
+
+    me_resp = await client.get("/auth/me/", headers={"X-Api-Key": data["key"]})
+    assert me_resp.status_code == 200
+
+    list_resp = await client.get("/auth/api-keys/", headers=admin_headers)
+    listed = {item["id"]: item for item in list_resp.json()["items"]}
+    assert listed[data["id"]]["expires_at"] is not None
+
+
+@pytest.mark.anyio
+async def test_api_key_null_expiry_accepted(client: AsyncClient):
+    """Omitting expires_at mints a non-expiring key (legacy behavior)."""
+    admin_headers = await get_auth_header(client, ADMIN_USER, ADMIN_PASS)
+
+    resp = await client.post(
+        "/auth/api-keys/",
+        json={"name": "Forever Key"},
+        headers=admin_headers,
+    )
+    assert resp.status_code == 201
+    data = resp.json()
+    assert data["expires_at"] is None
+
+    me_resp = await client.get("/auth/me/", headers={"X-Api-Key": data["key"]})
+    assert me_resp.status_code == 200
+
+
+@pytest.mark.anyio
+async def test_expired_api_key_rejected(client: AsyncClient, test_db_session):
+    """An expired key behaves exactly like an invalid one (401 / anonymous)."""
+    from datetime import datetime, timedelta, timezone
+
+    from sqlalchemy import update
+
+    from app.modules.auth.models import ApiKey
+
+    admin_headers = await get_auth_header(client, ADMIN_USER, ADMIN_PASS)
+
+    resp = await client.post(
+        "/auth/api-keys/",
+        json={"name": "Soon Expired"},
+        headers=admin_headers,
+    )
+    assert resp.status_code == 201
+    data = resp.json()
+    raw_key = data["key"]
+
+    # Sanity: the key works before expiry.
+    me_resp = await client.get("/auth/me/", headers={"X-Api-Key": raw_key})
+    assert me_resp.status_code == 200
+
+    # Force the key past its expiry (mint-time validation rejects past values,
+    # so an already-expired key can only be produced by time passing).
+    await test_db_session.execute(
+        update(ApiKey)
+        .where(ApiKey.id == uuid.UUID(data["id"]))
+        .values(expires_at=datetime.now(timezone.utc) - timedelta(seconds=1))
+    )
+    await test_db_session.commit()
+
+    # Required-auth endpoint: 401, exactly like an invalid key.
+    me_resp = await client.get("/auth/me/", headers={"X-Api-Key": raw_key})
+    assert me_resp.status_code == 401
+
+    # Optional-auth endpoint: anonymous fallback, exactly like an invalid key.
+    items_resp = await client.get(
+        "/collections/datasets/items",
+        headers={"X-Api-Key": raw_key},
+    )
+    assert items_resp.status_code == 200
+
+
+@pytest.mark.anyio
+async def test_mint_with_past_expiry_rejected(client: AsyncClient):
+    """Minting a key that is already expired is a validation error."""
+    from datetime import datetime, timedelta, timezone
+
+    admin_headers = await get_auth_header(client, ADMIN_USER, ADMIN_PASS)
+    past = (datetime.now(timezone.utc) - timedelta(days=1)).isoformat()
+
+    resp = await client.post(
+        "/auth/api-keys/",
+        json={"name": "Born Dead", "expires_at": past},
+        headers=admin_headers,
+    )
+    assert resp.status_code == 422
+
+    # Admin mint surface enforces the same rule.
+    me_resp = await client.get("/auth/me/", headers=admin_headers)
+    admin_id = me_resp.json()["id"]
+    resp = await client.post(
+        "/admin/api-keys/",
+        json={"user_id": admin_id, "name": "Born Dead", "expires_at": past},
+        headers=admin_headers,
+    )
+    assert resp.status_code == 422
+
+
+@pytest.mark.anyio
+async def test_stale_key_epoch_api_key_rejected(client: AsyncClient, test_db_session):
+    """A key minted before a key_epoch bump stops resolving after it."""
+    from sqlalchemy import update
+
+    from app.modules.auth.models import User
+
+    admin_headers = await get_auth_header(client, ADMIN_USER, ADMIN_PASS)
+    _viewer_headers, viewer_id = await _create_test_user(
+        client, admin_headers, "viewer"
+    )
+
+    resp = await client.post(
+        "/admin/api-keys/",
+        json={"user_id": viewer_id, "name": "Pre-Epoch-Bump Key"},
+        headers=admin_headers,
+    )
+    assert resp.status_code == 201
+    raw_key = resp.json()["key"]
+
+    # Matching key_epoch: the key authenticates.
+    me_resp = await client.get("/auth/me/", headers={"X-Api-Key": raw_key})
+    assert me_resp.status_code == 200
+
+    # Simulate a security-event bump (what password change / role change do).
+    await test_db_session.execute(
+        update(User)
+        .where(User.id == uuid.UUID(viewer_id))
+        .values(key_epoch=User.key_epoch + 1)
+    )
+    await test_db_session.commit()
+
+    me_resp = await client.get("/auth/me/", headers={"X-Api-Key": raw_key})
+    assert me_resp.status_code == 401
+
+
+@pytest.mark.anyio
+async def test_api_key_invalidated_by_role_change(client: AsyncClient):
+    """End-to-end: an admin role change invalidates previously minted keys."""
+    admin_headers = await get_auth_header(client, ADMIN_USER, ADMIN_PASS)
+    _viewer_headers, viewer_id = await _create_test_user(
+        client, admin_headers, "viewer"
+    )
+
+    resp = await client.post(
+        "/admin/api-keys/",
+        json={"user_id": viewer_id, "name": "Pre-Role-Change Key"},
+        headers=admin_headers,
+    )
+    assert resp.status_code == 201
+    raw_key = resp.json()["key"]
+
+    me_resp = await client.get("/auth/me/", headers={"X-Api-Key": raw_key})
+    assert me_resp.status_code == 200
+
+    # Admin changes the user's role (promotion and demotion both bump
+    # key_epoch — a key must not silently change privilege level).
+    patch_resp = await client.patch(
+        f"/admin/users/{viewer_id}",
+        json={"role": "editor"},
+        headers=admin_headers,
+    )
+    assert patch_resp.status_code == 200
+
+    me_resp = await client.get("/auth/me/", headers={"X-Api-Key": raw_key})
+    assert me_resp.status_code == 401
+
+
+@pytest.mark.anyio
+async def test_logout_does_not_invalidate_api_keys(client: AsyncClient):
+    """Regression (#821): plain logout bumps token_version but must leave
+    API keys working — keys exist to outlive browser sessions (CI, MCP,
+    tile URLs)."""
+    admin_headers = await get_auth_header(client, ADMIN_USER, ADMIN_PASS)
+    viewer_headers, _viewer_id = await _create_test_user(
+        client, admin_headers, "viewer"
+    )
+
+    resp = await client.post(
+        "/auth/api-keys/",
+        json={"name": "Survives Logout Key"},
+        headers=viewer_headers,
+    )
+    assert resp.status_code == 201
+    raw_key = resp.json()["key"]
+
+    logout_resp = await client.post("/auth/logout/", headers=viewer_headers)
+    assert logout_resp.status_code == 204
+
+    # The JWT used for the logout is now stale (token_version bumped)...
+    jwt_resp = await client.get("/auth/me/", headers=viewer_headers)
+    assert jwt_resp.status_code == 401
+
+    # ...but the API key still authenticates (key_epoch untouched).
+    key_resp = await client.get("/auth/me/", headers={"X-Api-Key": raw_key})
+    assert key_resp.status_code == 200
+
+
+@pytest.mark.anyio
+async def test_api_key_invalidated_by_password_change(client: AsyncClient):
+    """End-to-end: a real password change invalidates previously minted keys."""
+    admin_headers = await get_auth_header(client, ADMIN_USER, ADMIN_PASS)
+    viewer_headers, _viewer_id = await _create_test_user(
+        client, admin_headers, "viewer"
+    )
+
+    resp = await client.post(
+        "/auth/api-keys/",
+        json={"name": "Pre-Password-Change Key"},
+        headers=viewer_headers,
+    )
+    assert resp.status_code == 201
+    raw_key = resp.json()["key"]
+
+    me_resp = await client.get("/auth/me/", headers={"X-Api-Key": raw_key})
+    assert me_resp.status_code == 200
+
+    # _create_test_user's fixed password; the change bumps token_version.
+    change_resp = await client.post(
+        "/auth/change-password/",
+        json={
+            "current_password": "TestPass1234!",
+            "new_password": "NewTestPass5678!",
+        },
+        headers=viewer_headers,
+    )
+    assert change_resp.status_code == 204
+
+    me_resp = await client.get("/auth/me/", headers={"X-Api-Key": raw_key})
+    assert me_resp.status_code == 401
+
+
+@pytest.mark.anyio
+async def test_query_param_lane_still_authenticates(client: AsyncClient):
+    """The deprecated ?api_key= query lane keeps working (tile-URL clients)."""
+    admin_headers = await get_auth_header(client, ADMIN_USER, ADMIN_PASS)
+
+    resp = await client.post(
+        "/auth/api-keys/",
+        json={"name": "Query Lane Key"},
+        headers=admin_headers,
+    )
+    assert resp.status_code == 201
+    raw_key = resp.json()["key"]
+
+    me_resp = await client.get(f"/auth/me/?api_key={raw_key}")
+    assert me_resp.status_code == 200
+    assert me_resp.json()["username"] == ADMIN_USER

--- a/backend/tests/test_api_key_auth.py
+++ b/backend/tests/test_api_key_auth.py
@@ -505,6 +505,121 @@ async def test_api_key_invalidated_by_role_change(client: AsyncClient):
 
 
 @pytest.mark.anyio
+async def test_idempotent_role_patch_keeps_api_keys_valid(client: AsyncClient):
+    """Regression (#821 codex review): resubmitting the user's CURRENT role
+    (e.g. a reconciliation-tool PATCH) is not a security event and must not
+    bump key_epoch."""
+    admin_headers = await get_auth_header(client, ADMIN_USER, ADMIN_PASS)
+    _editor_headers, editor_id = await _create_test_user(
+        client, admin_headers, "editor"
+    )
+
+    resp = await client.post(
+        "/admin/api-keys/",
+        json={"user_id": editor_id, "name": "Idempotent PATCH Key"},
+        headers=admin_headers,
+    )
+    assert resp.status_code == 201
+    raw_key = resp.json()["key"]
+
+    me_resp = await client.get("/auth/me/", headers={"X-Api-Key": raw_key})
+    assert me_resp.status_code == 200
+
+    # PATCH the same role the user already has — a no-op, not a role change.
+    patch_resp = await client.patch(
+        f"/admin/users/{editor_id}",
+        json={"role": "editor"},
+        headers=admin_headers,
+    )
+    assert patch_resp.status_code == 200
+
+    me_resp = await client.get("/auth/me/", headers={"X-Api-Key": raw_key})
+    assert me_resp.status_code == 200
+
+
+@pytest.mark.anyio
+async def test_api_key_mint_rejected_for_pending_user(
+    client: AsyncClient, test_db_session
+):
+    """Regression (#821 codex review): keys cannot be minted for non-active
+    owners — a pre-approval key must not exist to wake up privileged later."""
+    from app.modules.auth.models import User
+
+    suffix = uuid.uuid4().hex[:8]
+    pending = User(
+        username=f"pending_apikey_{suffix}",
+        email=f"pending_apikey_{suffix}@example.com",
+        password_hash="unused",
+        status="pending",
+        is_active=False,
+    )
+    test_db_session.add(pending)
+    await test_db_session.commit()
+
+    admin_headers = await get_auth_header(client, ADMIN_USER, ADMIN_PASS)
+    resp = await client.post(
+        "/admin/api-keys/",
+        json={"user_id": str(pending.id), "name": "Pending Owner Key"},
+        headers=admin_headers,
+    )
+    assert resp.status_code == 409
+
+
+@pytest.mark.anyio
+async def test_pre_approval_key_does_not_survive_approval(
+    client: AsyncClient, test_db_session
+):
+    """Regression (#821 codex review): a key that existed while the account
+    was pending (legacy row predating the mint guard) must not start working
+    with the approved role's privileges — approve_user bumps key_epoch."""
+    import hashlib
+    import secrets
+
+    from app.modules.auth.models import ApiKey, User
+
+    suffix = uuid.uuid4().hex[:8]
+    pending = User(
+        username=f"pending_legacykey_{suffix}",
+        email=f"pending_legacykey_{suffix}@example.com",
+        password_hash="unused",
+        status="pending",
+        is_active=False,
+    )
+    test_db_session.add(pending)
+    await test_db_session.flush()
+
+    # Simulate a legacy key minted while the account was pending (the mint
+    # guard now refuses this path, so insert the row directly).
+    raw_key = secrets.token_urlsafe(32)
+    test_db_session.add(
+        ApiKey(
+            user_id=pending.id,
+            key_hash=hashlib.sha256(raw_key.encode()).hexdigest(),
+            fingerprint=f"{raw_key[:8]}…{raw_key[-4:]}",
+            name="Legacy Pre-Approval Key",
+            key_epoch=pending.key_epoch,
+        )
+    )
+    await test_db_session.commit()
+
+    # Pending owner: blocked by the status check.
+    me_resp = await client.get("/auth/me/", headers={"X-Api-Key": raw_key})
+    assert me_resp.status_code == 401
+
+    admin_headers = await get_auth_header(client, ADMIN_USER, ADMIN_PASS)
+    approve_resp = await client.post(
+        f"/admin/users/{pending.id}/approve/",
+        json={"role": "viewer"},
+        headers=admin_headers,
+    )
+    assert approve_resp.status_code == 200
+
+    # Approved owner: the epoch bump keeps the pre-approval key dead.
+    me_resp = await client.get("/auth/me/", headers={"X-Api-Key": raw_key})
+    assert me_resp.status_code == 401
+
+
+@pytest.mark.anyio
 async def test_logout_does_not_invalidate_api_keys(client: AsyncClient):
     """Regression (#821): plain logout bumps token_version but must leave
     API keys working — keys exist to outlive browser sessions (CI, MCP,

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -1077,7 +1077,9 @@ def test_open_core_decomposition_boundaries_stay_clean() -> None:
         "backend/app/modules/catalog/maps/router_sharing.py": 387,
         "backend/app/modules/catalog/search/query_params.py": 225,
         "backend/app/modules/catalog/search/router_saved.py": 100,
-        "backend/app/modules/admin/router_operations.py": 275,
+        # fix(#821): +6 lines — admin key mint accepts expires_at and surfaces
+        # it in the audit detail and response.
+        "backend/app/modules/admin/router_operations.py": 281,
         "backend/app/modules/settings/router_public.py": 150,
     }
     oversized = []

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -1077,9 +1077,9 @@ def test_open_core_decomposition_boundaries_stay_clean() -> None:
         "backend/app/modules/catalog/maps/router_sharing.py": 387,
         "backend/app/modules/catalog/search/query_params.py": 225,
         "backend/app/modules/catalog/search/router_saved.py": 100,
-        # fix(#821): +6 lines — admin key mint accepts expires_at and surfaces
-        # it in the audit detail and response.
-        "backend/app/modules/admin/router_operations.py": 281,
+        # fix(#821): +14 lines — admin key mint accepts expires_at (audit
+        # detail + response) and maps the inactive-owner mint refusal to 409.
+        "backend/app/modules/admin/router_operations.py": 289,
         "backend/app/modules/settings/router_public.py": 150,
     }
     oversized = []

--- a/frontend/src/components/settings/__tests__/MyApiKeySection.test.tsx
+++ b/frontend/src/components/settings/__tests__/MyApiKeySection.test.tsx
@@ -56,6 +56,7 @@ function makeKey(overrides: Partial<MyApiKeyResponse> = {}): MyApiKeyResponse {
     name: 'test-key',
     fingerprint: 'abcd1234…wxyz',
     is_active: true,
+    expires_at: null,
     created_at: '2026-01-01T00:00:00Z',
     last_used_at: null,
     ...overrides,

--- a/frontend/src/types/api.generated.ts
+++ b/frontend/src/types/api.generated.ts
@@ -877,6 +877,10 @@ export interface paths {
          *     access JWT used for this logout call (and any other outstanding access JWTs)
          *     are rejected on the next authenticated request — closing the
          *     "logout doesn't invalidate the access JWT" gap.
+         *
+         *     fix(#821): logout deliberately does NOT bump key_epoch — API keys exist to
+         *     outlive browser sessions (CI, MCP servers, tile URLs), so session hygiene
+         *     must not revoke them. Security events (password change, role change) do.
          */
         post: operations["logout_auth_logout__post"];
         delete?: never;
@@ -5123,6 +5127,11 @@ export interface components {
         /** AdminApiKeyCreateRequest */
         AdminApiKeyCreateRequest: {
             /**
+             * Expires At
+             * @description Optional expiry timestamp (RFC 3339, timezone-aware). Omit or null for a non-expiring key; expired keys stop authenticating.
+             */
+            expires_at?: string | null;
+            /**
              * Name
              * @description Human-readable label for the API key (e.g. 'CI pipeline', 'QGIS desktop').
              */
@@ -5142,6 +5151,11 @@ export interface components {
              * @description Timestamp when the key was created.
              */
             created_at: string;
+            /**
+             * Expires At
+             * @description Expiry timestamp; null means the key does not expire.
+             */
+            expires_at?: string | null;
             /**
              * Fingerprint
              * @description Non-secret key identifier; null for legacy keys.
@@ -5497,6 +5511,11 @@ export interface components {
         /** ApiKeyCreateRequest */
         ApiKeyCreateRequest: {
             /**
+             * Expires At
+             * @description Optional expiry timestamp (RFC 3339, timezone-aware). Omit or null for a non-expiring key; expired keys stop authenticating.
+             */
+            expires_at?: string | null;
+            /**
              * Name
              * @description Human-readable label for the API key
              */
@@ -5509,6 +5528,11 @@ export interface components {
              * Format: date-time
              */
             created_at: string;
+            /**
+             * Expires At
+             * @description Expiry timestamp; null means the key does not expire
+             */
+            expires_at?: string | null;
             /**
              * Fingerprint
              * @description Non-secret key identifier (prefix and last four characters)
@@ -5534,6 +5558,11 @@ export interface components {
              * Format: date-time
              */
             created_at: string;
+            /**
+             * Expires At
+             * @description Expiry timestamp; null means the key does not expire
+             */
+            expires_at?: string | null;
             /**
              * Fingerprint
              * @description Non-secret key identifier; null for keys created before fingerprint support

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -630,6 +630,7 @@ export interface ApiKeyResponse {
   name: string;
   fingerprint: string | null;
   is_active: boolean;
+  expires_at: string | null;
   created_at: string;
   last_used_at: string | null;
 }
@@ -639,6 +640,7 @@ export interface ApiKeyCreateResponse {
   key: string;
   fingerprint: string;
   name: string;
+  expires_at: string | null;
   created_at: string;
 }
 
@@ -647,6 +649,7 @@ export interface MyApiKeyResponse {
   name: string;
   fingerprint: string | null;
   is_active: boolean;
+  expires_at: string | null;
   created_at: string;
   last_used_at: string | null;
 }

--- a/sdks/python/geolens/api/auth/logout_auth_logout_post.py
+++ b/sdks/python/geolens/api/auth/logout_auth_logout_post.py
@@ -97,6 +97,10 @@ def sync_detailed(
     are rejected on the next authenticated request — closing the
     \"logout doesn't invalidate the access JWT\" gap.
 
+    fix(#821): logout deliberately does NOT bump key_epoch — API keys exist to
+    outlive browser sessions (CI, MCP servers, tile URLs), so session hygiene
+    must not revoke them. Security events (password change, role change) do.
+
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
@@ -127,6 +131,10 @@ def sync(
     are rejected on the next authenticated request — closing the
     \"logout doesn't invalidate the access JWT\" gap.
 
+    fix(#821): logout deliberately does NOT bump key_epoch — API keys exist to
+    outlive browser sessions (CI, MCP servers, tile URLs), so session hygiene
+    must not revoke them. Security events (password change, role change) do.
+
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
@@ -152,6 +160,10 @@ async def asyncio_detailed(
     access JWT used for this logout call (and any other outstanding access JWTs)
     are rejected on the next authenticated request — closing the
     \"logout doesn't invalidate the access JWT\" gap.
+
+    fix(#821): logout deliberately does NOT bump key_epoch — API keys exist to
+    outlive browser sessions (CI, MCP servers, tile URLs), so session hygiene
+    must not revoke them. Security events (password change, role change) do.
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -180,6 +192,10 @@ async def asyncio(
     access JWT used for this logout call (and any other outstanding access JWTs)
     are rejected on the next authenticated request — closing the
     \"logout doesn't invalidate the access JWT\" gap.
+
+    fix(#821): logout deliberately does NOT bump key_epoch — API keys exist to
+    outlive browser sessions (CI, MCP servers, tile URLs), so session hygiene
+    must not revoke them. Security events (password change, role change) do.
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.

--- a/sdks/python/geolens/models/admin_api_key_create_request.py
+++ b/sdks/python/geolens/models/admin_api_key_create_request.py
@@ -6,8 +6,12 @@ from typing import Any, TypeVar
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
 
+from ..types import UNSET, Unset
 
+from dateutil.parser import isoparse
+from typing import cast
 from uuid import UUID
+import datetime
 
 
 T = TypeVar("T", bound="AdminApiKeyCreateRequest")
@@ -19,16 +23,27 @@ class AdminApiKeyCreateRequest:
     Attributes:
         name (str): Human-readable label for the API key (e.g. 'CI pipeline', 'QGIS desktop').
         user_id (UUID): ID of the user the new API key will belong to.
+        expires_at (datetime.datetime | None | Unset): Optional expiry timestamp (RFC 3339, timezone-aware). Omit or
+            null for a non-expiring key; expired keys stop authenticating.
     """
 
     name: str
     user_id: UUID
+    expires_at: datetime.datetime | None | Unset = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
         name = self.name
 
         user_id = str(self.user_id)
+
+        expires_at: None | str | Unset
+        if isinstance(self.expires_at, Unset):
+            expires_at = UNSET
+        elif isinstance(self.expires_at, datetime.datetime):
+            expires_at = self.expires_at.isoformat()
+        else:
+            expires_at = self.expires_at
 
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
@@ -38,6 +53,8 @@ class AdminApiKeyCreateRequest:
                 "user_id": user_id,
             }
         )
+        if expires_at is not UNSET:
+            field_dict["expires_at"] = expires_at
 
         return field_dict
 
@@ -48,9 +65,27 @@ class AdminApiKeyCreateRequest:
 
         user_id = UUID(d.pop("user_id"))
 
+        def _parse_expires_at(data: object) -> datetime.datetime | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, str):
+                    raise TypeError()
+                expires_at_type_0 = isoparse(data)
+
+                return expires_at_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(datetime.datetime | None | Unset, data)
+
+        expires_at = _parse_expires_at(d.pop("expires_at", UNSET))
+
         admin_api_key_create_request = cls(
             name=name,
             user_id=user_id,
+            expires_at=expires_at,
         )
 
         admin_api_key_create_request.additional_properties = d

--- a/sdks/python/geolens/models/admin_api_key_list_item.py
+++ b/sdks/python/geolens/models/admin_api_key_list_item.py
@@ -6,6 +6,7 @@ from typing import Any, TypeVar
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
 
+from ..types import UNSET, Unset
 
 from dateutil.parser import isoparse
 from typing import cast
@@ -27,6 +28,7 @@ class AdminApiKeyListItem:
         last_used_at (datetime.datetime | None): Timestamp of the most recent successful authentication using this key.
         name (str): Human-readable label.
         user_id (UUID): Owning user's ID.
+        expires_at (datetime.datetime | None | Unset): Expiry timestamp; null means the key does not expire.
     """
 
     created_at: datetime.datetime
@@ -36,6 +38,7 @@ class AdminApiKeyListItem:
     last_used_at: datetime.datetime | None
     name: str
     user_id: UUID
+    expires_at: datetime.datetime | None | Unset = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
@@ -58,6 +61,14 @@ class AdminApiKeyListItem:
 
         user_id = str(self.user_id)
 
+        expires_at: None | str | Unset
+        if isinstance(self.expires_at, Unset):
+            expires_at = UNSET
+        elif isinstance(self.expires_at, datetime.datetime):
+            expires_at = self.expires_at.isoformat()
+        else:
+            expires_at = self.expires_at
+
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
@@ -71,6 +82,8 @@ class AdminApiKeyListItem:
                 "user_id": user_id,
             }
         )
+        if expires_at is not UNSET:
+            field_dict["expires_at"] = expires_at
 
         return field_dict
 
@@ -109,6 +122,23 @@ class AdminApiKeyListItem:
 
         user_id = UUID(d.pop("user_id"))
 
+        def _parse_expires_at(data: object) -> datetime.datetime | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, str):
+                    raise TypeError()
+                expires_at_type_0 = isoparse(data)
+
+                return expires_at_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(datetime.datetime | None | Unset, data)
+
+        expires_at = _parse_expires_at(d.pop("expires_at", UNSET))
+
         admin_api_key_list_item = cls(
             created_at=created_at,
             fingerprint=fingerprint,
@@ -117,6 +147,7 @@ class AdminApiKeyListItem:
             last_used_at=last_used_at,
             name=name,
             user_id=user_id,
+            expires_at=expires_at,
         )
 
         admin_api_key_list_item.additional_properties = d

--- a/sdks/python/geolens/models/api_key_create_request.py
+++ b/sdks/python/geolens/models/api_key_create_request.py
@@ -6,6 +6,12 @@ from typing import Any, TypeVar
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
 
+from ..types import UNSET, Unset
+
+from dateutil.parser import isoparse
+from typing import cast
+import datetime
+
 
 T = TypeVar("T", bound="ApiKeyCreateRequest")
 
@@ -15,13 +21,24 @@ class ApiKeyCreateRequest:
     """
     Attributes:
         name (str): Human-readable label for the API key
+        expires_at (datetime.datetime | None | Unset): Optional expiry timestamp (RFC 3339, timezone-aware). Omit or
+            null for a non-expiring key; expired keys stop authenticating.
     """
 
     name: str
+    expires_at: datetime.datetime | None | Unset = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
         name = self.name
+
+        expires_at: None | str | Unset
+        if isinstance(self.expires_at, Unset):
+            expires_at = UNSET
+        elif isinstance(self.expires_at, datetime.datetime):
+            expires_at = self.expires_at.isoformat()
+        else:
+            expires_at = self.expires_at
 
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
@@ -30,6 +47,8 @@ class ApiKeyCreateRequest:
                 "name": name,
             }
         )
+        if expires_at is not UNSET:
+            field_dict["expires_at"] = expires_at
 
         return field_dict
 
@@ -38,8 +57,26 @@ class ApiKeyCreateRequest:
         d = dict(src_dict)
         name = d.pop("name")
 
+        def _parse_expires_at(data: object) -> datetime.datetime | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, str):
+                    raise TypeError()
+                expires_at_type_0 = isoparse(data)
+
+                return expires_at_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(datetime.datetime | None | Unset, data)
+
+        expires_at = _parse_expires_at(d.pop("expires_at", UNSET))
+
         api_key_create_request = cls(
             name=name,
+            expires_at=expires_at,
         )
 
         api_key_create_request.additional_properties = d

--- a/sdks/python/geolens/models/api_key_create_response.py
+++ b/sdks/python/geolens/models/api_key_create_response.py
@@ -6,8 +6,10 @@ from typing import Any, TypeVar
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
 
+from ..types import UNSET, Unset
 
 from dateutil.parser import isoparse
+from typing import cast
 from uuid import UUID
 import datetime
 
@@ -24,6 +26,7 @@ class ApiKeyCreateResponse:
         id (UUID):
         key (str): The API key secret (shown only once)
         name (str):
+        expires_at (datetime.datetime | None | Unset): Expiry timestamp; null means the key does not expire
     """
 
     created_at: datetime.datetime
@@ -31,6 +34,7 @@ class ApiKeyCreateResponse:
     id: UUID
     key: str
     name: str
+    expires_at: datetime.datetime | None | Unset = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
@@ -44,6 +48,14 @@ class ApiKeyCreateResponse:
 
         name = self.name
 
+        expires_at: None | str | Unset
+        if isinstance(self.expires_at, Unset):
+            expires_at = UNSET
+        elif isinstance(self.expires_at, datetime.datetime):
+            expires_at = self.expires_at.isoformat()
+        else:
+            expires_at = self.expires_at
+
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
@@ -55,6 +67,8 @@ class ApiKeyCreateResponse:
                 "name": name,
             }
         )
+        if expires_at is not UNSET:
+            field_dict["expires_at"] = expires_at
 
         return field_dict
 
@@ -71,12 +85,30 @@ class ApiKeyCreateResponse:
 
         name = d.pop("name")
 
+        def _parse_expires_at(data: object) -> datetime.datetime | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, str):
+                    raise TypeError()
+                expires_at_type_0 = isoparse(data)
+
+                return expires_at_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(datetime.datetime | None | Unset, data)
+
+        expires_at = _parse_expires_at(d.pop("expires_at", UNSET))
+
         api_key_create_response = cls(
             created_at=created_at,
             fingerprint=fingerprint,
             id=id,
             key=key,
             name=name,
+            expires_at=expires_at,
         )
 
         api_key_create_response.additional_properties = d

--- a/sdks/python/geolens/models/api_key_list_item.py
+++ b/sdks/python/geolens/models/api_key_list_item.py
@@ -6,6 +6,7 @@ from typing import Any, TypeVar
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
 
+from ..types import UNSET, Unset
 
 from dateutil.parser import isoparse
 from typing import cast
@@ -26,6 +27,7 @@ class ApiKeyListItem:
         is_active (bool):
         last_used_at (datetime.datetime | None):
         name (str):
+        expires_at (datetime.datetime | None | Unset): Expiry timestamp; null means the key does not expire
     """
 
     created_at: datetime.datetime
@@ -34,6 +36,7 @@ class ApiKeyListItem:
     is_active: bool
     last_used_at: datetime.datetime | None
     name: str
+    expires_at: datetime.datetime | None | Unset = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
@@ -54,6 +57,14 @@ class ApiKeyListItem:
 
         name = self.name
 
+        expires_at: None | str | Unset
+        if isinstance(self.expires_at, Unset):
+            expires_at = UNSET
+        elif isinstance(self.expires_at, datetime.datetime):
+            expires_at = self.expires_at.isoformat()
+        else:
+            expires_at = self.expires_at
+
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
@@ -66,6 +77,8 @@ class ApiKeyListItem:
                 "name": name,
             }
         )
+        if expires_at is not UNSET:
+            field_dict["expires_at"] = expires_at
 
         return field_dict
 
@@ -102,6 +115,23 @@ class ApiKeyListItem:
 
         name = d.pop("name")
 
+        def _parse_expires_at(data: object) -> datetime.datetime | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, str):
+                    raise TypeError()
+                expires_at_type_0 = isoparse(data)
+
+                return expires_at_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(datetime.datetime | None | Unset, data)
+
+        expires_at = _parse_expires_at(d.pop("expires_at", UNSET))
+
         api_key_list_item = cls(
             created_at=created_at,
             fingerprint=fingerprint,
@@ -109,6 +139,7 @@ class ApiKeyListItem:
             is_active=is_active,
             last_used_at=last_used_at,
             name=name,
+            expires_at=expires_at,
         )
 
         api_key_list_item.additional_properties = d

--- a/sdks/typescript/src/client/sdk.gen.ts
+++ b/sdks/typescript/src/client/sdk.gen.ts
@@ -974,6 +974,10 @@ export const loginAuthLoginPost = <ThrowOnError extends boolean = false>(options
  * access JWT used for this logout call (and any other outstanding access JWTs)
  * are rejected on the next authenticated request — closing the
  * "logout doesn't invalidate the access JWT" gap.
+ *
+ * fix(#821): logout deliberately does NOT bump key_epoch — API keys exist to
+ * outlive browser sessions (CI, MCP servers, tile URLs), so session hygiene
+ * must not revoke them. Security events (password change, role change) do.
  */
 export const logoutAuthLogoutPost = <ThrowOnError extends boolean = false>(options?: Options<LogoutAuthLogoutPostData, ThrowOnError>): RequestResult<LogoutAuthLogoutPostResponses, LogoutAuthLogoutPostErrors, ThrowOnError> => (options?.client ?? client).post<LogoutAuthLogoutPostResponses, LogoutAuthLogoutPostErrors, ThrowOnError>({
     security: [

--- a/sdks/typescript/src/client/types.gen.ts
+++ b/sdks/typescript/src/client/types.gen.ts
@@ -143,6 +143,12 @@ export type AddDatasetsResponse = {
  */
 export type AdminApiKeyCreateRequest = {
     /**
+     * Expires At
+     *
+     * Optional expiry timestamp (RFC 3339, timezone-aware). Omit or null for a non-expiring key; expired keys stop authenticating.
+     */
+    expires_at?: string | null;
+    /**
      * Name
      *
      * Human-readable label for the API key (e.g. 'CI pipeline', 'QGIS desktop').
@@ -166,6 +172,12 @@ export type AdminApiKeyListItem = {
      * Timestamp when the key was created.
      */
     created_at: string;
+    /**
+     * Expires At
+     *
+     * Expiry timestamp; null means the key does not expire.
+     */
+    expires_at?: string | null;
     /**
      * Fingerprint
      *
@@ -626,6 +638,12 @@ export type AnalysisPreviewResponse = {
  */
 export type ApiKeyCreateRequest = {
     /**
+     * Expires At
+     *
+     * Optional expiry timestamp (RFC 3339, timezone-aware). Omit or null for a non-expiring key; expired keys stop authenticating.
+     */
+    expires_at?: string | null;
+    /**
      * Name
      *
      * Human-readable label for the API key
@@ -641,6 +659,12 @@ export type ApiKeyCreateResponse = {
      * Created At
      */
     created_at: string;
+    /**
+     * Expires At
+     *
+     * Expiry timestamp; null means the key does not expire
+     */
+    expires_at?: string | null;
     /**
      * Fingerprint
      *
@@ -671,6 +695,12 @@ export type ApiKeyListItem = {
      * Created At
      */
     created_at: string;
+    /**
+     * Expires At
+     *
+     * Expiry timestamp; null means the key does not expire
+     */
+    expires_at?: string | null;
     /**
      * Fingerprint
      *


### PR DESCRIPTION
Hardens the API-key lane per the 1.6.0 pre-tag audit finding. Three changes, one migration.

## What changed

**1. Optional expiry.** `api_keys` gains a nullable `expires_at` (timestamptz). NULL keeps today's forever-key behavior, so nothing changes for existing keys. At resolution an expired key behaves exactly like an invalid one: 401 on required-auth endpoints, anonymous fallback on optional-auth endpoints, and no `last_used_at` bump. Both mint surfaces (`POST /auth/api-keys/` and `POST /admin/api-keys/`) accept an optional `expires_at` (RFC 3339, timezone-aware, must be in the future — 422 otherwise), and the create/list responses surface it.

**2. `key_epoch` staleness check.** Users gain a `key_epoch` counter (default 1), deliberately separate from `token_version`. Each key snapshots the owner's `key_epoch` at mint; resolution rejects the key on mismatch. Migration 0029 backfills existing keys with each owner's current epoch, so security events after the upgrade invalidate keys minted before it.

Why not `token_version`: it is bumped by plain logout (`revoke_all_tokens`), so snapshotting it would have killed every API key on web sign-out. API keys exist to outlive sessions (CI, MCP servers, tile URLs). `key_epoch` is bumped only at security-event sites:

- **Password change** (`/auth/change-password/`) — via `revoke_all_tokens(bump_key_epoch=True)`, in the same atomic UPDATE as the token_version bump.
- **Admin role change** (`AdminService._update_user_role`, the PATCH `/admin/users/{id}` role path) — demotion *and* promotion: a key must not silently change privilege level; the owner re-mints under the new role. An idempotent PATCH that resubmits the user's current role short-circuits — no role-row churn, no epoch bump, keys stay valid (codex P2). `token_version` is not bumped here (unchanged behavior — JWTs are short-lived and role checks read live DB roles).
- **SAML-to-local conversion** (`convert_saml_user_to_local`, SEC-S15 CR-02) — a credential reset; bumped alongside the existing token_version bump.
- **Account approval** (`approve_user`) — approval assigns the account's authority, so it bumps key_epoch (codex P2). This is belt-and-suspenders: minting a key for a non-active owner is now refused outright (`ApiKeyTargetUserInactiveError`, 409 on the admin surface), so the bump only matters for keys that predate the guard (legacy/manual rows). Both shapes were taken because each is a few lines and they fail closed at different points.

Not bumped: **logout** (session hygiene — an explicit regression test pins that keys survive it), deactivation/suspension (keys already blocked by the `status != 'active'` check at resolution). There is no other admin "revoke all sessions" endpoint — `revoke_all_tokens`'s only callers are logout and password change.

**3. Query-param lane deprecated, not removed.** `_resolve_api_key()`'s docstring and the OpenAPI description now mark `?api_key=` deprecated with the log-exposure rationale. Resolution order is unchanged: `X-Api-Key` header > `api_key` query param > JWT Bearer > anonymous. The GDAL quick-start examples in the API description now use `GDAL_HTTP_HEADERS "X-Api-Key: ..."`; the QGIS WFS-dialog example keeps the query param (the dialog cannot send headers).

## Schema impact

- New migration `0029_api_key_hardening` on head `0028`: adds `catalog.users.key_epoch` (int NOT NULL server_default 1), `catalog.api_keys.expires_at` (timestamptz NULL), and `catalog.api_keys.key_epoch` (int, backfilled from the owner's `users.key_epoch`, then NOT NULL). Downgrade drops all three. Round-tripped (upgrade → downgrade → upgrade) and `alembic check` reports no drift.

## API impact

- `ApiKeyCreateRequest` / `AdminApiKeyCreateRequest`: new optional `expires_at` (past values 422).
- `ApiKeyCreateResponse`, `ApiKeyListItem`, `AdminApiKeyListItem`: new nullable `expires_at`.
- `key_epoch` is internal — not exposed on any request or response model.
- All three regen artifacts committed: `backend/openapi.json`, both generated SDKs (`make sdks`), `frontend/src/types/api.generated.ts`. Hand-typed frontend mirrors (`ApiKeyResponse`, `MyApiKeyResponse`, `ApiKeyCreateResponse` in `frontend/src/types/api.ts`) updated to match.
- No UI changes; the frontend does not yet offer an expiry field when minting.

## Query-lane usage audit (in-repo)

- `frontend/src/pages/PublicViewerPage.tsx` reads `api_key` from the viewer page's own URL, then forwards it via the `X-Api-Key` **header** for every backend call (`getSharedMap`, `getTileTokensBatch`, `fetchBoundedGeoJson`). `geojson-z.ts` moved to the header in #858. The frontend constructs no backend request URLs with `?api_key=`.
- `backend/app/modules/catalog/datasets/domain/helpers.py` emits the raster `tile_url_connect` with an `?api_key={your_key}` placeholder for external GIS tools — the sanctioned remaining lane user (XYZ tile requests cannot carry headers); now commented as such.
- Both hand-maintained SDK wrappers (`sdks/python/geolens/auth.py`, `sdks/typescript/src/auth.ts`) already refuse to expose the query lane (D-11). CLI and MCP go through the SDK header path. No `e2e/` usage.
- `.github/ARCHITECTURE.md` documented the lane; updated with the deprecation (and corrected the stated header name to `X-Api-Key`).

## Log exposure

Our own access log (`RequestLoggingMiddleware`) records only `request.url.path` — never the query string — and `uvicorn.access` is silenced in `logging_config.py`, so the backend never writes the query-lane credential to its logs. The structlog redactor already covers `api_key` field names and `url_redaction.py` covers `api_key` in logged source URLs. A new regression test pins the no-query-string contract on the access log.

**Operator concern (not fixable here):** nginx/upstream proxies log full request URIs, so a query-lane key still lands in *their* access logs. Self-hosters who use `?api_key=` should redact the parameter in their proxy log format or accept the exposure; worth a docs-site note.

## Verification

```
cd backend && uv run pytest tests/test_api_key_auth.py tests/test_access_log_path_redaction.py tests/test_admin_invariants_regression.py -q   # 37 passed
cd backend && uv run pytest tests/test_layering.py tests/test_auth.py tests/test_auth_refresh_logout.py tests/test_admin_user_operations.py tests/test_vector_tile_auth.py tests/test_phase_273_log_redaction.py -q   # 109 passed
alembic upgrade head && alembic downgrade -1 && alembic upgrade head && alembic check   # round-trip green, "No new upgrade operations detected" (scratch DB)
cd backend && uv run ruff check . && uv run ruff format --check .   # clean
uv run python scripts/dump_openapi.py --check && make sdks-check   # no drift after commit
cd frontend && npm run typecheck && npm run lint   # clean
cd frontend && npx vitest run src/api/__tests__/hand-typed-mirror-drift.test.ts src/components/settings/__tests__/MyApiKeySection.test.tsx   # 18 passed
pre-commit run --from-ref origin/main --to-ref HEAD   # all hooks pass
```

New tests: future-expiry accepted + surfaced in listing; NULL expiry accepted; expired key rejected (401 + anonymous fallback, forced past expiry via DB since mint-time validation rejects past values); past expiry 422 on both mint surfaces; direct key_epoch bump rejected and matching accepted; end-to-end admin role change invalidates a previously minted key; **idempotent same-role PATCH leaves keys valid**; end-to-end password change invalidates a previously minted key; **logout does NOT invalidate keys** (while the JWT used for the logout is correctly rejected); SAML-to-local conversion bumps key_epoch (assertion added to the existing SEC-S15 regression test); **minting for a pending owner is 409**; **a pre-approval key (inserted directly, simulating a legacy row) stays dead after approval**; deprecated query lane still authenticates; access log never contains query credentials.

The admin router grew 14 lines past its reviewed LOC cap in `test_layering.py` (expires_at pass-through + the 409 mapping); the cap was raised 275 → 289 with a `fix(#821)` comment rather than decomposing for that delta.

Closes #821

https://claude.ai/code/session_01A8vNJqrsio7yP5vWNhauVg
