### PR TITLE
fix(tiles): convert cluster radius px to extent units and anchor the grid

### DIFF
--- a/backend/app/processing/tiles/router.py
+++ b/backend/app/processing/tiles/router.py
@@ -1588,7 +1588,10 @@ def _ensure_clusterable_dataset(meta: _DatasetMeta) -> None:
 def _cluster_cache_table_key(
     table_name: str, *, cluster_radius: int, cluster_max_zoom: int
 ) -> str:
-    return f"{table_name}:cluster:r{cluster_radius}:z{cluster_max_zoom}"
+    # fix(#868): "v2" versions the cluster SQL semantics. Bump it whenever
+    # _build_cluster_tile_query changes the emitted tile geometry/properties,
+    # or a deploy keeps serving stale-geometry cluster tiles until TTL expiry.
+    return f"{table_name}:cluster:v2:r{cluster_radius}:z{cluster_max_zoom}"
 
 
 async def _acquire_and_serve_tile(

--- a/backend/app/processing/tiles/service.py
+++ b/backend/app/processing/tiles/service.py
@@ -66,6 +66,15 @@ _CLUSTER_INPUT_LIMIT = 100000
 # 360/(extent*2^z) degrees of longitude at zoom z.
 _MVT_EXTENT = 4096
 
+# fix(#868): cluster_radius arrives in CSS/screen pixels (MapLibre clusterRadius
+# semantics, matching the client-side cluster path). Tiles display at 512 CSS px,
+# so one pixel covers _MVT_EXTENT / 512 = 8 extent units. The old bucket math
+# divided by the extent without this factor, treating pixels as extent units and
+# producing a grid ~8x finer than requested (overlapping cluster circles plus
+# unclustered singles leaking at low zoom).
+_TILE_DISPLAY_SIZE_PX = 512
+_CLUSTER_PX_TO_EXTENT_UNITS = _MVT_EXTENT / _TILE_DISPLAY_SIZE_PX
+
 # builder-audit #338 MVT-07: simplification tolerance schedule. Below this zoom the
 # geometry is simplified; at/above it the original geometry is served untouched.
 # (Distinct from _DEFAULT_NO_ATTR_BELOW_ZOOM, which happens to share the value 10
@@ -291,7 +300,15 @@ def _build_cluster_tile_query(
 
     Parameters at execution time:
     $1=z, $2=x, $3=y, $4=source layer name, $5=cluster max zoom,
-    $6=cluster radius in tile pixels.
+    $6=cluster radius in CSS/screen pixels (MapLibre ``clusterRadius``
+    semantics; converted to MVT extent units in-query via
+    ``_CLUSTER_PX_TO_EXTENT_UNITS`` — fix(#868)).
+
+    fix(#868): the bucket grid is anchored to absolute EPSG:3857 coordinates
+    (``floor(ST_X(geom) / bucket_size)``), not to the tile's own minx/miny.
+    Bucket size at a fixed zoom is identical for every tile, so anchoring
+    absolutely makes the grids of adjacent tiles line up instead of drifting
+    by each tile's origin offset (a seam artifact at tile borders).
 
     Cluster output follows the MapLibre client-side cluster property shape:
     clustered features carry ``point_count`` and ``point_count_abbreviated``;
@@ -341,8 +358,6 @@ bounds AS (
     SELECT
         _env.geom,
         ST_Transform(_env.geom, 4326) AS geom_4326,
-        ST_XMin(_env.geom) AS minx,
-        ST_YMin(_env.geom) AS miny,
         GREATEST(ST_XMax(_env.geom) - ST_XMin(_env.geom), 1.0) AS width,
         GREATEST(ST_YMax(_env.geom) - ST_YMin(_env.geom), 1.0) AS height
     FROM _env
@@ -360,17 +375,20 @@ bucketed AS (
     SELECT
         candidates.gid,
         candidates.geom_3857,
+        -- fix(#868): bucket size converts $6 (CSS px) to extent units before
+        -- scaling by tile width, and the grid anchors to absolute 3857 coords
+        -- so adjacent tiles at the same zoom share one grid.
         CASE
             WHEN $1::integer <= $5::integer THEN floor(
-                (ST_X(candidates.geom_3857) - bounds.minx)
-                / GREATEST(bounds.width * $6::float8 / 4096.0, 1.0)
+                ST_X(candidates.geom_3857)
+                / GREATEST(bounds.width * $6::float8 * {_CLUSTER_PX_TO_EXTENT_UNITS} / {_MVT_EXTENT}.0, 1.0)
             )::integer
             ELSE candidates.gid
         END AS bucket_x,
         CASE
             WHEN $1::integer <= $5::integer THEN floor(
-                (ST_Y(candidates.geom_3857) - bounds.miny)
-                / GREATEST(bounds.height * $6::float8 / 4096.0, 1.0)
+                ST_Y(candidates.geom_3857)
+                / GREATEST(bounds.height * $6::float8 * {_CLUSTER_PX_TO_EXTENT_UNITS} / {_MVT_EXTENT}.0, 1.0)
             )::integer
             ELSE candidates.gid
         END AS bucket_y
@@ -538,7 +556,9 @@ async def get_cluster_tile(
             and popups work past cluster max zoom.
         tile_columns: Phase 269 H-23 allowlist override (None / [] / list).
         additional_columns: Runtime opt-in columns (the ``cols=`` param).
-        cluster_radius: Cluster radius in tile pixels.
+        cluster_radius: Cluster radius in CSS/screen pixels (MapLibre
+            ``clusterRadius`` semantics; converted to MVT extent units
+            inside the query — fix(#868)).
         cluster_max_zoom: Maximum zoom level at which clustering is active.
         conn: Optional already-acquired asyncpg connection (see ``get_tile``
             docstring for DP-02 details; T-1209-10).

--- a/backend/app/processing/tiles/service.py
+++ b/backend/app/processing/tiles/service.py
@@ -335,10 +335,21 @@ def _build_cluster_tile_query(
     cross-tile cells exist there, and ring candidates would only consume
     the input cap before ownership discards them, starving the tile of its
     own points. Singles that only enter via the expanded ring drop out
-    through the ownership filter, and the MVT buffer grows with the radius
-    so owner-emitted geometry up to one bucket outside the tile is not
-    clipped. ``ORDER BY gid`` keeps candidate membership deterministic per
-    envelope.
+    through the ownership filter. ``ORDER BY gid`` keeps candidate
+    membership deterministic per envelope.
+
+    fix(#868, codex round 4 on PR #872): ownership filters BEFORE the
+    feature cap (in the ``grouped`` CTE), so neighbor-owned cells can never
+    consume the output budget and displace owned cells. And because a cell
+    owned via its anchor can have its centroid up to one bucket inside the
+    NEIGHBOR tile — where a client whose viewport covers the centroid but
+    not the owner tile would never see it (no MVT buffer helps a tile the
+    client never requests) — the emitted geometry is CLAMPED into the
+    owning tile, one MVT extent unit inside each edge. Maximum positional
+    error from the clamp: one bucket, i.e. the cluster radius in CSS px
+    (48 by default), deterministic, and zero for geometry already inside
+    the tile (all past-max-zoom points; every cell whose centroid is
+    in-tile).
 
     Cluster output follows the MapLibre client-side cluster property shape:
     clustered features carry ``point_count`` and ``point_count_abbreviated``;
@@ -460,38 +471,58 @@ bucketed AS (
         END AS bucket_y
     FROM candidates, grid
 ),
-cells AS (
+-- fix(#868, codex round 2 on PR #872): the ownership anchor is the cell
+-- ORIGIN (world_min + bucket index * bucket size) — pure grid geometry,
+-- independent of which points were scanned. Under input-cap saturation
+-- neighboring tiles can see different subsets of a shared cell; a
+-- data-dependent anchor (the round-1 centroid) could then land in either
+-- tile (double- or zero-emit). With the origin anchor the worst case
+-- degrades to an undercounted cluster in the owner tile, the same class
+-- any capped per-tile grid has. Past cluster max zoom the buckets are
+-- per-point, so the anchor is the point itself. Every member of a cell
+-- shares the cell's anchor, so the per-row anchor equals the per-cell one.
+anchored AS (
+    SELECT
+        bucketed.*,
+        CASE WHEN $1::integer <= $5::integer
+            THEN grid.world_min_x + bucketed.bucket_x * grid.bucket_w
+            ELSE ST_X(bucketed.geom_3857)
+        END AS anchor_x,
+        CASE WHEN $1::integer <= $5::integer
+            THEN grid.world_min_y + bucketed.bucket_y * grid.bucket_h
+            ELSE ST_Y(bucketed.geom_3857)
+        END AS anchor_y
+    FROM bucketed, grid
+),
+grouped AS (
     SELECT
         bucket_x,
         bucket_y,
         count(*)::integer AS raw_point_count,
         min(gid)::bigint AS source_gid,
         ST_Centroid(ST_Collect(geom_3857)) AS geom_3857
-    FROM bucketed
+    FROM anchored, bounds
+    -- fix(#868, codex round 4 on PR #872): ownership applies BEFORE the
+    -- feature cap. A cell is emitted by exactly ONE tile, the one whose
+    -- envelope contains the cell's ownership anchor — filtering here means
+    -- neighbor-owned cells can never consume the output budget and displace
+    -- owned cells. Half-open bounds on internal borders; inclusive upper
+    -- bounds on the world's east (x = 2^z - 1) and north (y = 0) edge
+    -- tiles, which have no neighbor to own an anchor sitting exactly on
+    -- the world boundary. Ring-only rows drop here too.
+    WHERE anchored.anchor_x >= ST_XMin(bounds.geom)
+      AND (
+        anchored.anchor_x < ST_XMax(bounds.geom)
+        OR ($2::integer = (1 << $1::integer) - 1
+            AND anchored.anchor_x <= ST_XMax(bounds.geom))
+      )
+      AND anchored.anchor_y >= ST_YMin(bounds.geom)
+      AND (
+        anchored.anchor_y < ST_YMax(bounds.geom)
+        OR ($3::integer = 0 AND anchored.anchor_y <= ST_YMax(bounds.geom))
+      )
     GROUP BY bucket_x, bucket_y
     LIMIT {_TILE_FEATURE_LIMIT}
-),
--- fix(#868, codex round 2 on PR #872): the ownership anchor is the cell
--- ORIGIN (bucket index * bucket size) — pure grid geometry, independent of
--- which points were scanned. Under input-cap saturation neighboring tiles
--- can see different subsets of a shared cell; a data-dependent anchor (the
--- round-1 centroid) could then land in either tile (double- or zero-emit).
--- With the origin anchor the worst case degrades to an undercounted
--- cluster in the owner tile, the same class any capped per-tile grid has.
--- Past cluster max zoom the buckets are per-point, so the anchor is the
--- point itself.
-grouped AS (
-    SELECT
-        cells.*,
-        CASE WHEN $1::integer <= $5::integer
-            THEN grid.world_min_x + cells.bucket_x * grid.bucket_w
-            ELSE ST_X(cells.geom_3857)
-        END AS anchor_x,
-        CASE WHEN $1::integer <= $5::integer
-            THEN grid.world_min_y + cells.bucket_y * grid.bucket_h
-            ELSE ST_Y(cells.geom_3857)
-        END AS anchor_y
-    FROM cells, grid
 ),
 features AS (
     SELECT
@@ -531,35 +562,26 @@ features AS (
         END AS expansion_zoom,
         grouped.source_gid{unclustered_attr_select},
         ST_AsMVTGeom(
-            grouped.geom_3857,
+            -- fix(#868, codex round 4 on PR #872): clamp the emitted point
+            -- into the owning tile, one MVT extent unit inside each edge.
+            -- Anchor ownership lets a cell's centroid fall up to one bucket
+            -- inside the NEIGHBOR tile; a viewport that covers the centroid
+            -- but not the owner tile never requests the owner tile, so
+            -- geometry left outside the tile would be invisible there (no
+            -- MVT buffer can fix an unrequested tile). Max positional
+            -- error: one bucket = the cluster radius in CSS px. This
+            -- supersedes the round-2 radius-scaled buffer — the emitted
+            -- geometry is now always in-tile.
+            ST_SetSRID(ST_MakePoint(
+                LEAST(GREATEST(ST_X(grouped.geom_3857), ST_XMin(bounds.geom) + bounds.width / {_MVT_EXTENT}.0), ST_XMax(bounds.geom) - bounds.width / {_MVT_EXTENT}.0),
+                LEAST(GREATEST(ST_Y(grouped.geom_3857), ST_YMin(bounds.geom) + bounds.height / {_MVT_EXTENT}.0), ST_YMax(bounds.geom) - bounds.height / {_MVT_EXTENT}.0)
+            ), 3857),
             bounds.geom::box2d,
             4096,
-            -- fix(#868, codex round 2): an owner-emitted cell's rendered
-            -- point can sit up to one bucket outside this tile (the anchor
-            -- is in-tile, the whole cell need not be). The buffer covers one
-            -- bucket in extent units (radius px * px-to-extent factor) plus
-            -- a float-safety margin; 256 stays the floor.
-            GREATEST(256, ceil($6::float8 * {_CLUSTER_PX_TO_EXTENT_UNITS})::integer + 16),
+            256,
             true
         ) AS geom
     FROM grouped{unclustered_attr_join}, bounds
-    -- fix(#868, codex P2 rounds on PR #872): a cell is emitted by exactly
-    -- ONE tile, the one whose envelope contains the cell's ownership anchor.
-    -- Half-open bounds on internal borders; inclusive upper bounds on the
-    -- world's east (x = 2^z - 1) and north (y = 0) edge tiles, which have no
-    -- neighbor to own an anchor sitting exactly on the world boundary.
-    -- Ring-only features drop here too: their anchor lies outside this tile.
-    WHERE grouped.anchor_x >= ST_XMin(bounds.geom)
-      AND (
-        grouped.anchor_x < ST_XMax(bounds.geom)
-        OR ($2::integer = (1 << $1::integer) - 1
-            AND grouped.anchor_x <= ST_XMax(bounds.geom))
-      )
-      AND grouped.anchor_y >= ST_YMin(bounds.geom)
-      AND (
-        grouped.anchor_y < ST_YMax(bounds.geom)
-        OR ($3::integer = 0 AND grouped.anchor_y <= ST_YMax(bounds.geom))
-      )
 )
 SELECT ST_AsMVT(features.*, $4::text, 4096, 'geom', 'gid')
 FROM features

--- a/backend/app/processing/tiles/service.py
+++ b/backend/app/processing/tiles/service.py
@@ -310,6 +310,19 @@ def _build_cluster_tile_query(
     absolutely makes the grids of adjacent tiles line up instead of drifting
     by each tile's origin offset (a seam artifact at tile borders).
 
+    fix(#868, codex P2 on PR #872): an anchored cell can straddle a tile
+    border, so the candidate scan covers the tile envelope EXPANDED by one
+    full bucket — every tile sees the complete membership of every cell that
+    overlaps it — and each cell is emitted by exactly one tile: the tile
+    whose envelope contains the cell centroid (half-open bounds, so a
+    centroid exactly on a border belongs to one tile only). ``ORDER BY gid``
+    keeps candidate membership deterministic when the input cap truncates,
+    so neighboring tiles compute the same centroid for a shared cell.
+    Singles that only enter via the expanded ring drop out through the same
+    ownership filter (a single's centroid is its own point, outside the
+    tile). The expansion grows the candidate scan by up to one bucket on
+    each side; the input cap semantics are unchanged.
+
     Cluster output follows the MapLibre client-side cluster property shape:
     clustered features carry ``point_count`` and ``point_count_abbreviated``;
     unclustered features omit those properties and carry ``source_gid``.
@@ -357,42 +370,64 @@ _env AS (
 bounds AS (
     SELECT
         _env.geom,
-        ST_Transform(_env.geom, 4326) AS geom_4326,
         GREATEST(ST_XMax(_env.geom) - ST_XMin(_env.geom), 1.0) AS width,
         GREATEST(ST_YMax(_env.geom) - ST_YMin(_env.geom), 1.0) AS height
     FROM _env
+),
+-- fix(#868): bucket sizes in 3857 meters. $6 (CSS px) converts to extent
+-- units before scaling by tile width, and the grid anchors to absolute 3857
+-- coords so adjacent tiles at the same zoom share one grid.
+grid AS (
+    SELECT
+        GREATEST(bounds.width * $6::float8 * {_CLUSTER_PX_TO_EXTENT_UNITS} / {_MVT_EXTENT}.0, 1.0) AS bucket_w,
+        GREATEST(bounds.height * $6::float8 * {_CLUSTER_PX_TO_EXTENT_UNITS} / {_MVT_EXTENT}.0, 1.0) AS bucket_h
+    FROM bounds
+),
+-- fix(#868, codex P2 on PR #872): scan envelope = tile + one full bucket, so
+-- a cell straddling the tile border is seen with its COMPLETE membership.
+-- Clamped to the world envelope BEFORE the 4326 transform: past the world
+-- edge proj wraps longitude and the transformed bbox inverts, dropping
+-- candidates. No data exists outside the world envelope, so the clamp
+-- loses nothing.
+scan AS (
+    SELECT ST_Transform(
+        ST_Intersection(
+            ST_Expand(bounds.geom, GREATEST(grid.bucket_w, grid.bucket_h)),
+            ST_TileEnvelope(0, 0, 0)
+        ),
+        4326
+    ) AS geom_4326
+    FROM bounds, grid
 ),
 candidates AS (
     SELECT
         t.gid,
         ST_Transform(ST_PointOnSurface(t.geom_4326), 3857) AS geom_3857
-    FROM {qualified_table} t, bounds
-    WHERE t.geom_4326 && bounds.geom_4326
+    FROM {qualified_table} t, scan
+    WHERE t.geom_4326 && scan.geom_4326
       AND NOT ST_IsEmpty(t.geom_4326)
+    -- fix(#868): deterministic under the input cap, so neighboring tiles
+    -- that both see a straddling cell agree on membership and centroid.
+    ORDER BY t.gid
     LIMIT {_CLUSTER_INPUT_LIMIT}
 ),
 bucketed AS (
     SELECT
         candidates.gid,
         candidates.geom_3857,
-        -- fix(#868): bucket size converts $6 (CSS px) to extent units before
-        -- scaling by tile width, and the grid anchors to absolute 3857 coords
-        -- so adjacent tiles at the same zoom share one grid.
         CASE
             WHEN $1::integer <= $5::integer THEN floor(
-                ST_X(candidates.geom_3857)
-                / GREATEST(bounds.width * $6::float8 * {_CLUSTER_PX_TO_EXTENT_UNITS} / {_MVT_EXTENT}.0, 1.0)
+                ST_X(candidates.geom_3857) / grid.bucket_w
             )::integer
             ELSE candidates.gid
         END AS bucket_x,
         CASE
             WHEN $1::integer <= $5::integer THEN floor(
-                ST_Y(candidates.geom_3857)
-                / GREATEST(bounds.height * $6::float8 * {_CLUSTER_PX_TO_EXTENT_UNITS} / {_MVT_EXTENT}.0, 1.0)
+                ST_Y(candidates.geom_3857) / grid.bucket_h
             )::integer
             ELSE candidates.gid
         END AS bucket_y
-    FROM candidates, bounds
+    FROM candidates, grid
 ),
 grouped AS (
     SELECT
@@ -450,6 +485,15 @@ features AS (
             true
         ) AS geom
     FROM grouped{unclustered_attr_join}, bounds
+    -- fix(#868, codex P2 on PR #872): ownership — a cell is emitted by
+    -- exactly ONE tile, the one whose envelope contains the cell centroid
+    -- (half-open, so a border centroid belongs to a single tile). This also
+    -- drops singles picked up only by the expanded scan ring: a single's
+    -- centroid is its own point, outside this tile.
+    WHERE ST_X(grouped.geom_3857) >= ST_XMin(bounds.geom)
+      AND ST_X(grouped.geom_3857) < ST_XMax(bounds.geom)
+      AND ST_Y(grouped.geom_3857) >= ST_YMin(bounds.geom)
+      AND ST_Y(grouped.geom_3857) < ST_YMax(bounds.geom)
 )
 SELECT ST_AsMVT(features.*, $4::text, 4096, 'geom', 'gid')
 FROM features

--- a/backend/app/processing/tiles/service.py
+++ b/backend/app/processing/tiles/service.py
@@ -304,31 +304,41 @@ def _build_cluster_tile_query(
     semantics; converted to MVT extent units in-query via
     ``_CLUSTER_PX_TO_EXTENT_UNITS`` — fix(#868)).
 
-    fix(#868): the bucket grid is anchored to absolute EPSG:3857 coordinates
-    (``floor(ST_X(geom) / bucket_size)``), not to the tile's own minx/miny.
-    Bucket size at a fixed zoom is identical for every tile, so anchoring
-    absolutely makes the grids of adjacent tiles line up instead of drifting
-    by each tile's origin offset (a seam artifact at tile borders).
+    fix(#868): the bucket grid is anchored to the WORLD MINIMUM in absolute
+    EPSG:3857 coordinates (``floor((ST_X(geom) - world_min) / bucket_size)``),
+    not to the tile's own minx/miny. Bucket size at a fixed zoom is identical
+    for every tile, so absolute anchoring makes the grids of adjacent tiles
+    line up instead of drifting by each tile's origin offset (a seam artifact
+    at tile borders). Anchoring at the world minimum (codex round 3) means
+    every in-world point yields an in-world cell origin: a 0-anchored grid
+    put the origin of a cell straddling the world's west/south edge outside
+    the world, so no tile owned that cell and points near lon -180 vanished.
 
     fix(#868, codex P2 rounds on PR #872): an anchored cell can straddle a
-    tile border, so the candidate scan covers the tile envelope EXPANDED by
-    one full bucket (clamped to the world envelope; see the scan CTE) and
-    each cell is emitted by exactly one tile — the tile whose envelope
-    contains the cell's ownership anchor, the cell ORIGIN (bucket index *
-    bucket size; the point itself past cluster max zoom). The anchor is
-    pure grid geometry, so ownership never depends on which candidates a
-    tile scanned: when the input cap saturates and neighbors see different
-    subsets of a shared cell, the worst case is an undercounted (or
-    missing) cluster from the owner tile — the degradation class any capped
-    per-tile grid has — never a cross-tile double- or zero-emit. Ownership
-    bounds are half-open on internal borders and inclusive on the world's
-    east/north edge tiles (no neighbor exists to own an anchor exactly on
-    the world boundary). Singles that only enter via the expanded ring drop
-    out through the same filter, and the MVT buffer grows with the radius
+    tile border, so at clustering zooms the candidate scan covers the tile
+    envelope EXPANDED by one full bucket (clamped to the world envelope; see
+    the scan CTE) and each cell is emitted by exactly one tile — the tile
+    whose envelope contains the cell's ownership anchor, the cell ORIGIN
+    (``world_min + bucket index * bucket size``; the point itself past
+    cluster max zoom). The anchor is pure grid geometry, so ownership never
+    depends on which candidates a tile scanned: when the input cap
+    saturates and neighbors see different subsets of a shared cell, the
+    worst case is an undercounted (or missing) cluster from the owner tile
+    — the degradation class any capped per-tile grid has — never a
+    cross-tile double- or zero-emit. World-min anchoring keeps every anchor
+    inside [world_min, world_max], so the inclusive lower bounds already
+    cover the west/south world edges; the east/north edge tiles use
+    inclusive UPPER bounds because an anchor can still land exactly on the
+    world maximum (a point at lon 180 past max zoom, or a bucket size that
+    divides the world width exactly). Internal borders stay half-open.
+    Past cluster max zoom the scan uses NO expansion (codex round 3): no
+    cross-tile cells exist there, and ring candidates would only consume
+    the input cap before ownership discards them, starving the tile of its
+    own points. Singles that only enter via the expanded ring drop out
+    through the ownership filter, and the MVT buffer grows with the radius
     so owner-emitted geometry up to one bucket outside the tile is not
     clipped. ``ORDER BY gid`` keeps candidate membership deterministic per
-    envelope. The expansion grows the candidate scan by up to one bucket on
-    each side; the input cap semantics are unchanged.
+    envelope.
 
     Cluster output follows the MapLibre client-side cluster property shape:
     clustered features carry ``point_count`` and ``point_count_abbreviated``;
@@ -382,24 +392,38 @@ bounds AS (
     FROM _env
 ),
 -- fix(#868): bucket sizes in 3857 meters. $6 (CSS px) converts to extent
--- units before scaling by tile width, and the grid anchors to absolute 3857
--- coords so adjacent tiles at the same zoom share one grid.
+-- units before scaling by tile width. The grid anchors to the WORLD MINIMUM
+-- (codex round 3 on PR #872): every tile at a zoom shares one grid, and any
+-- in-world point yields an in-world cell origin. A grid anchored at 0 put
+-- the origin of a cell straddling the world's west/south edge OUTSIDE the
+-- world, so no tile owned it and points near lon -180 vanished.
 grid AS (
     SELECT
         GREATEST(bounds.width * $6::float8 * {_CLUSTER_PX_TO_EXTENT_UNITS} / {_MVT_EXTENT}.0, 1.0) AS bucket_w,
-        GREATEST(bounds.height * $6::float8 * {_CLUSTER_PX_TO_EXTENT_UNITS} / {_MVT_EXTENT}.0, 1.0) AS bucket_h
+        GREATEST(bounds.height * $6::float8 * {_CLUSTER_PX_TO_EXTENT_UNITS} / {_MVT_EXTENT}.0, 1.0) AS bucket_h,
+        ST_XMin(ST_TileEnvelope(0, 0, 0)) AS world_min_x,
+        ST_YMin(ST_TileEnvelope(0, 0, 0)) AS world_min_y
     FROM bounds
 ),
 -- fix(#868, codex P2 on PR #872): scan envelope = tile + one full bucket, so
 -- a cell straddling the tile border is seen with its COMPLETE membership.
--- Clamped to the world envelope BEFORE the 4326 transform: past the world
--- edge proj wraps longitude and the transformed bbox inverts, dropping
--- candidates. No data exists outside the world envelope, so the clamp
--- loses nothing.
+-- Expansion applies at clustering zooms ONLY (codex round 3): past cluster
+-- max zoom no cross-tile cells exist, and lower-gid ring candidates would
+-- just consume the input cap before ownership discards them, starving the
+-- tile of its own points. Clamped to the world envelope BEFORE the 4326
+-- transform: past the world edge proj wraps longitude and the transformed
+-- bbox inverts, dropping candidates. No data exists outside the world
+-- envelope, so the clamp loses nothing.
 scan AS (
     SELECT ST_Transform(
         ST_Intersection(
-            ST_Expand(bounds.geom, GREATEST(grid.bucket_w, grid.bucket_h)),
+            ST_Expand(
+                bounds.geom,
+                CASE WHEN $1::integer <= $5::integer
+                    THEN GREATEST(grid.bucket_w, grid.bucket_h)
+                    ELSE 0.0
+                END
+            ),
             ST_TileEnvelope(0, 0, 0)
         ),
         4326
@@ -424,13 +448,13 @@ bucketed AS (
         candidates.geom_3857,
         CASE
             WHEN $1::integer <= $5::integer THEN floor(
-                ST_X(candidates.geom_3857) / grid.bucket_w
+                (ST_X(candidates.geom_3857) - grid.world_min_x) / grid.bucket_w
             )::integer
             ELSE candidates.gid
         END AS bucket_x,
         CASE
             WHEN $1::integer <= $5::integer THEN floor(
-                ST_Y(candidates.geom_3857) / grid.bucket_h
+                (ST_Y(candidates.geom_3857) - grid.world_min_y) / grid.bucket_h
             )::integer
             ELSE candidates.gid
         END AS bucket_y
@@ -460,11 +484,11 @@ grouped AS (
     SELECT
         cells.*,
         CASE WHEN $1::integer <= $5::integer
-            THEN cells.bucket_x * grid.bucket_w
+            THEN grid.world_min_x + cells.bucket_x * grid.bucket_w
             ELSE ST_X(cells.geom_3857)
         END AS anchor_x,
         CASE WHEN $1::integer <= $5::integer
-            THEN cells.bucket_y * grid.bucket_h
+            THEN grid.world_min_y + cells.bucket_y * grid.bucket_h
             ELSE ST_Y(cells.geom_3857)
         END AS anchor_y
     FROM cells, grid

--- a/backend/app/processing/tiles/service.py
+++ b/backend/app/processing/tiles/service.py
@@ -310,17 +310,24 @@ def _build_cluster_tile_query(
     absolutely makes the grids of adjacent tiles line up instead of drifting
     by each tile's origin offset (a seam artifact at tile borders).
 
-    fix(#868, codex P2 on PR #872): an anchored cell can straddle a tile
-    border, so the candidate scan covers the tile envelope EXPANDED by one
-    full bucket — every tile sees the complete membership of every cell that
-    overlaps it — and each cell is emitted by exactly one tile: the tile
-    whose envelope contains the cell centroid (half-open bounds, so a
-    centroid exactly on a border belongs to one tile only). ``ORDER BY gid``
-    keeps candidate membership deterministic when the input cap truncates,
-    so neighboring tiles compute the same centroid for a shared cell.
-    Singles that only enter via the expanded ring drop out through the same
-    ownership filter (a single's centroid is its own point, outside the
-    tile). The expansion grows the candidate scan by up to one bucket on
+    fix(#868, codex P2 rounds on PR #872): an anchored cell can straddle a
+    tile border, so the candidate scan covers the tile envelope EXPANDED by
+    one full bucket (clamped to the world envelope; see the scan CTE) and
+    each cell is emitted by exactly one tile — the tile whose envelope
+    contains the cell's ownership anchor, the cell ORIGIN (bucket index *
+    bucket size; the point itself past cluster max zoom). The anchor is
+    pure grid geometry, so ownership never depends on which candidates a
+    tile scanned: when the input cap saturates and neighbors see different
+    subsets of a shared cell, the worst case is an undercounted (or
+    missing) cluster from the owner tile — the degradation class any capped
+    per-tile grid has — never a cross-tile double- or zero-emit. Ownership
+    bounds are half-open on internal borders and inclusive on the world's
+    east/north edge tiles (no neighbor exists to own an anchor exactly on
+    the world boundary). Singles that only enter via the expanded ring drop
+    out through the same filter, and the MVT buffer grows with the radius
+    so owner-emitted geometry up to one bucket outside the tile is not
+    clipped. ``ORDER BY gid`` keeps candidate membership deterministic per
+    envelope. The expansion grows the candidate scan by up to one bucket on
     each side; the input cap semantics are unchanged.
 
     Cluster output follows the MapLibre client-side cluster property shape:
@@ -429,7 +436,7 @@ bucketed AS (
         END AS bucket_y
     FROM candidates, grid
 ),
-grouped AS (
+cells AS (
     SELECT
         bucket_x,
         bucket_y,
@@ -439,6 +446,28 @@ grouped AS (
     FROM bucketed
     GROUP BY bucket_x, bucket_y
     LIMIT {_TILE_FEATURE_LIMIT}
+),
+-- fix(#868, codex round 2 on PR #872): the ownership anchor is the cell
+-- ORIGIN (bucket index * bucket size) — pure grid geometry, independent of
+-- which points were scanned. Under input-cap saturation neighboring tiles
+-- can see different subsets of a shared cell; a data-dependent anchor (the
+-- round-1 centroid) could then land in either tile (double- or zero-emit).
+-- With the origin anchor the worst case degrades to an undercounted
+-- cluster in the owner tile, the same class any capped per-tile grid has.
+-- Past cluster max zoom the buckets are per-point, so the anchor is the
+-- point itself.
+grouped AS (
+    SELECT
+        cells.*,
+        CASE WHEN $1::integer <= $5::integer
+            THEN cells.bucket_x * grid.bucket_w
+            ELSE ST_X(cells.geom_3857)
+        END AS anchor_x,
+        CASE WHEN $1::integer <= $5::integer
+            THEN cells.bucket_y * grid.bucket_h
+            ELSE ST_Y(cells.geom_3857)
+        END AS anchor_y
+    FROM cells, grid
 ),
 features AS (
     SELECT
@@ -481,19 +510,32 @@ features AS (
             grouped.geom_3857,
             bounds.geom::box2d,
             4096,
-            256,
+            -- fix(#868, codex round 2): an owner-emitted cell's rendered
+            -- point can sit up to one bucket outside this tile (the anchor
+            -- is in-tile, the whole cell need not be). The buffer covers one
+            -- bucket in extent units (radius px * px-to-extent factor) plus
+            -- a float-safety margin; 256 stays the floor.
+            GREATEST(256, ceil($6::float8 * {_CLUSTER_PX_TO_EXTENT_UNITS})::integer + 16),
             true
         ) AS geom
     FROM grouped{unclustered_attr_join}, bounds
-    -- fix(#868, codex P2 on PR #872): ownership — a cell is emitted by
-    -- exactly ONE tile, the one whose envelope contains the cell centroid
-    -- (half-open, so a border centroid belongs to a single tile). This also
-    -- drops singles picked up only by the expanded scan ring: a single's
-    -- centroid is its own point, outside this tile.
-    WHERE ST_X(grouped.geom_3857) >= ST_XMin(bounds.geom)
-      AND ST_X(grouped.geom_3857) < ST_XMax(bounds.geom)
-      AND ST_Y(grouped.geom_3857) >= ST_YMin(bounds.geom)
-      AND ST_Y(grouped.geom_3857) < ST_YMax(bounds.geom)
+    -- fix(#868, codex P2 rounds on PR #872): a cell is emitted by exactly
+    -- ONE tile, the one whose envelope contains the cell's ownership anchor.
+    -- Half-open bounds on internal borders; inclusive upper bounds on the
+    -- world's east (x = 2^z - 1) and north (y = 0) edge tiles, which have no
+    -- neighbor to own an anchor sitting exactly on the world boundary.
+    -- Ring-only features drop here too: their anchor lies outside this tile.
+    WHERE grouped.anchor_x >= ST_XMin(bounds.geom)
+      AND (
+        grouped.anchor_x < ST_XMax(bounds.geom)
+        OR ($2::integer = (1 << $1::integer) - 1
+            AND grouped.anchor_x <= ST_XMax(bounds.geom))
+      )
+      AND grouped.anchor_y >= ST_YMin(bounds.geom)
+      AND (
+        grouped.anchor_y < ST_YMax(bounds.geom)
+        OR ($3::integer = 0 AND grouped.anchor_y <= ST_YMax(bounds.geom))
+      )
 )
 SELECT ST_AsMVT(features.*, $4::text, 4096, 'geom', 'gid')
 FROM features

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -1005,7 +1005,9 @@ _ROUTER_LOC_CAPS: dict[str, int] = {
     # south<=north bbox check, limit clamping). Ratchet stays exact.
     "backend/app/standards/stac/router.py": 1795,
     # Central tenant-bound scope resolution replaced duplicated inline logic.
-    "backend/app/processing/tiles/router.py": 2043,
+    # fix(#868): +3 lines for the cluster cache-key SQL-semantics version
+    # ("v2") so deploys that change cluster tile geometry invalidate Valkey.
+    "backend/app/processing/tiles/router.py": 2046,
 }
 
 

--- a/backend/tests/test_mvt_audit_fixes.py
+++ b/backend/tests/test_mvt_audit_fixes.py
@@ -211,11 +211,19 @@ def test_cluster_query_buckets_on_absolute_3857_grid():
     assert "ST_Y(candidates.geom_3857)" in query
     # The degenerate-size guard must survive the rework.
     assert "GREATEST(bounds.width * $6::float8" in query
-    # codex P2 (#872): straddling cells — expanded candidate scan,
-    # deterministic membership under the cap, centroid-ownership emission.
+    # codex P2 rounds (#872): straddling cells — expanded candidate scan,
+    # deterministic membership under the cap, and cell-ORIGIN anchor
+    # ownership (pure grid geometry, never dependent on the scanned subset).
     assert "ST_Expand(bounds.geom" in query
     assert "ORDER BY t.gid" in query
-    assert "ST_X(grouped.geom_3857) >= ST_XMin(bounds.geom)" in query
+    assert "cells.bucket_x * grid.bucket_w" in query
+    assert "grouped.anchor_x >= ST_XMin(bounds.geom)" in query
+    # World-edge tiles own boundary anchors via inclusive upper bounds.
+    assert "(1 << $1::integer) - 1" in query  # east edge: x = 2^z - 1
+    assert "$3::integer = 0" in query  # north edge: y = 0
+    # The MVT buffer scales with the radius so owner-emitted geometry up to
+    # one bucket outside the tile is not clipped.
+    assert "GREATEST(256, ceil($6::float8" in query
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_mvt_audit_fixes.py
+++ b/backend/tests/test_mvt_audit_fixes.py
@@ -185,6 +185,35 @@ def test_cluster_query_emits_positive_offset_gid():
 
 
 # ---------------------------------------------------------------------------
+# fix(#868): cluster bucket grid — px->extent conversion + absolute anchoring
+# ---------------------------------------------------------------------------
+
+
+def test_cluster_query_converts_px_radius_to_extent_units():
+    """fix(#868): $6 arrives in CSS/screen pixels but the grid lives in MVT
+    extent units. At 512 px tile display one pixel is 4096/512 = 8 extent
+    units; the old math skipped the factor and built a ~8x-too-fine grid
+    (overlapping clusters + unclustered singles leaking at low zoom)."""
+    assert service._CLUSTER_PX_TO_EXTENT_UNITS == 4096 / 512
+    query = _build_cluster_tile_query("places")
+    assert f"$6::float8 * {service._CLUSTER_PX_TO_EXTENT_UNITS}" in query
+
+
+def test_cluster_query_buckets_on_absolute_3857_grid():
+    """fix(#868): the bucket grid anchors to absolute EPSG:3857 coordinates,
+    not the tile's own minx/miny. Bucket size at a fixed zoom is identical
+    for every tile, so absolute anchoring is what makes adjacent tiles at
+    one zoom share a single aligned grid (no cluster seams at borders)."""
+    query = _build_cluster_tile_query("places")
+    assert "bounds.minx" not in query
+    assert "bounds.miny" not in query
+    assert "ST_X(candidates.geom_3857)" in query
+    assert "ST_Y(candidates.geom_3857)" in query
+    # The degenerate-size guard must survive the rework.
+    assert "GREATEST(bounds.width * $6::float8" in query
+
+
+# ---------------------------------------------------------------------------
 # fix(#394) B-019/VT-01: reupload purges the MVT tile cache post-commit
 # ---------------------------------------------------------------------------
 

--- a/backend/tests/test_mvt_audit_fixes.py
+++ b/backend/tests/test_mvt_audit_fixes.py
@@ -211,6 +211,11 @@ def test_cluster_query_buckets_on_absolute_3857_grid():
     assert "ST_Y(candidates.geom_3857)" in query
     # The degenerate-size guard must survive the rework.
     assert "GREATEST(bounds.width * $6::float8" in query
+    # codex P2 (#872): straddling cells — expanded candidate scan,
+    # deterministic membership under the cap, centroid-ownership emission.
+    assert "ST_Expand(bounds.geom" in query
+    assert "ORDER BY t.gid" in query
+    assert "ST_X(grouped.geom_3857) >= ST_XMin(bounds.geom)" in query
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_mvt_audit_fixes.py
+++ b/backend/tests/test_mvt_audit_fixes.py
@@ -216,22 +216,28 @@ def test_cluster_query_buckets_on_absolute_3857_grid():
     # ownership (pure grid geometry, never dependent on the scanned subset).
     assert "ST_Expand(" in query
     assert "ORDER BY t.gid" in query
-    assert "grouped.anchor_x >= ST_XMin(bounds.geom)" in query
+    assert "anchored.anchor_x >= ST_XMin(bounds.geom)" in query
     # codex round 3 (#872): the grid anchors to the WORLD MINIMUM, so every
     # in-world point yields an in-world cell origin (a 0-anchored grid lost
     # cells straddling lon -180 to ownership rejection).
     assert "ST_XMin(ST_TileEnvelope(0, 0, 0)) AS world_min_x" in query
     assert "(ST_X(candidates.geom_3857) - grid.world_min_x)" in query
-    assert "grid.world_min_x + cells.bucket_x * grid.bucket_w" in query
+    assert "grid.world_min_x + bucketed.bucket_x * grid.bucket_w" in query
     # codex round 3 (#872): no scan expansion past cluster max zoom — ring
     # rows would only burn the candidate cap before ownership drops them.
     assert "ELSE 0.0" in query
     # World-edge tiles own boundary anchors via inclusive upper bounds.
     assert "(1 << $1::integer) - 1" in query  # east edge: x = 2^z - 1
     assert "$3::integer = 0" in query  # north edge: y = 0
-    # The MVT buffer scales with the radius so owner-emitted geometry up to
-    # one bucket outside the tile is not clipped.
-    assert "GREATEST(256, ceil($6::float8" in query
+    # codex round 4 (#872): ownership must filter BEFORE the feature cap so
+    # neighbor-owned cells cannot consume the output budget.
+    assert query.index("anchored.anchor_x >= ST_XMin(bounds.geom)") < query.index(
+        "GROUP BY bucket_x, bucket_y"
+    )
+    # codex round 4 (#872): emitted geometry is clamped into the owning
+    # tile — an out-of-tile centroid would be invisible to a client whose
+    # viewport never requests the owner tile.
+    assert "LEAST(GREATEST(ST_X(grouped.geom_3857)" in query
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_mvt_audit_fixes.py
+++ b/backend/tests/test_mvt_audit_fixes.py
@@ -214,10 +214,18 @@ def test_cluster_query_buckets_on_absolute_3857_grid():
     # codex P2 rounds (#872): straddling cells — expanded candidate scan,
     # deterministic membership under the cap, and cell-ORIGIN anchor
     # ownership (pure grid geometry, never dependent on the scanned subset).
-    assert "ST_Expand(bounds.geom" in query
+    assert "ST_Expand(" in query
     assert "ORDER BY t.gid" in query
-    assert "cells.bucket_x * grid.bucket_w" in query
     assert "grouped.anchor_x >= ST_XMin(bounds.geom)" in query
+    # codex round 3 (#872): the grid anchors to the WORLD MINIMUM, so every
+    # in-world point yields an in-world cell origin (a 0-anchored grid lost
+    # cells straddling lon -180 to ownership rejection).
+    assert "ST_XMin(ST_TileEnvelope(0, 0, 0)) AS world_min_x" in query
+    assert "(ST_X(candidates.geom_3857) - grid.world_min_x)" in query
+    assert "grid.world_min_x + cells.bucket_x * grid.bucket_w" in query
+    # codex round 3 (#872): no scan expansion past cluster max zoom — ring
+    # rows would only burn the candidate cap before ownership drops them.
+    assert "ELSE 0.0" in query
     # World-edge tiles own boundary anchors via inclusive upper bounds.
     assert "(1 << $1::integer) - 1" in query  # east edge: x = 2^z - 1
     assert "$3::integer = 0" in query  # north edge: y = 0

--- a/backend/tests/test_tiles.py
+++ b/backend/tests/test_tiles.py
@@ -717,37 +717,47 @@ class TestClusterBucketSemantics:
     """
 
     @staticmethod
-    def _rows_sql(table_name: str, input_cap: int | None = None) -> str:
+    def _rows_sql(
+        table_name: str,
+        input_cap: int | None = None,
+        feature_cap: int | None = None,
+    ) -> str:
         """The shipped cluster query with ST_AsMVT swapped for a row SELECT.
 
         Reuses every CTE of _build_cluster_tile_query verbatim (bounds,
         candidates, bucketed, grouped, features) so the assertions exercise
         the exact SQL the endpoint executes; only the final MVT encode is
         replaced because the suite carries no MVT decoder dependency.
-        ``input_cap`` swaps the candidate LIMIT for a tiny value so tests
-        can saturate the cap without 100k fixture rows.
+        ``input_cap`` / ``feature_cap`` swap the candidate / feature LIMITs
+        for tiny values so tests can saturate the caps without huge
+        fixtures. ``mvt_x``/``mvt_y`` expose the emitted geometry in tile
+        coordinates ([0, 4096] means inside the tile).
         """
         from app.processing.tiles.service import (
             _CLUSTER_INPUT_LIMIT,
+            _TILE_FEATURE_LIMIT,
             _build_cluster_tile_query,
         )
 
         query = _build_cluster_tile_query(
             table_name, attr_columns=[{"name": "name", "type": "text"}]
         )
-        if input_cap is not None:
-            capped = query.replace(
-                f"LIMIT {_CLUSTER_INPUT_LIMIT}", f"LIMIT {input_cap}"
-            )
-            assert capped != query, "candidate LIMIT not found; update this test"
-            query = capped
+        for cap, current in (
+            (input_cap, _CLUSTER_INPUT_LIMIT),
+            (feature_cap, _TILE_FEATURE_LIMIT),
+        ):
+            if cap is not None:
+                capped = query.replace(f"LIMIT {current}", f"LIMIT {cap}")
+                assert capped != query, "LIMIT not found; update this test"
+                query = capped
         head, sep, _tail = query.rpartition("SELECT ST_AsMVT")
         assert sep, "cluster query tail changed; update this test's split point"
         # $4 (layer name) only appeared inside ST_AsMVT; keep it referenced so
         # the prepared statement still binds all six parameters.
         return head + (
             "SELECT $4::text AS layer_name, cluster, point_count,\n"
-            "    point_count_abbreviated, source_gid, name\n"
+            "    point_count_abbreviated, source_gid, name,\n"
+            "    ST_X(geom) AS mvt_x, ST_Y(geom) AS mvt_y\n"
             "FROM features\nWHERE geom IS NOT NULL"
         )
 
@@ -999,4 +1009,84 @@ class TestClusterBucketSemantics:
             await _cleanup_data_table(test_db_session, table_name)
 
         assert [r["name"] for r in rows] == ["west"]
+        assert rows[0]["cluster"] is None
+
+    async def test_emitted_geometry_is_clamped_into_owner_tile(self, test_db_session):
+        """fix(#868, codex round 4): a cell owned via its anchor can have a
+        raw centroid inside the NEIGHBOR tile; a viewport covering the
+        centroid but not the owner tile never requests the owner tile, so
+        out-of-tile geometry would be invisible. The emitted point is
+        clamped into the owning tile (here: its east edge), and the
+        neighbor still emits nothing for the cell."""
+        from app.processing.tiles.pool import get_tile_pool
+
+        table_name = f"cluster_clamp_{uuid.uuid4().hex[:8]}"
+        tile_w = _WEB_MERCATOR_WORLD_WIDTH / 4
+        bucket = tile_w * 48 * (4096 / 512) / 4096
+        border = -tile_w  # boundary between z2 tiles x=0 and x=1
+        points = (
+            ("pair_left", -10_038_754.0, 5_000_000.0),  # tile x=0 side
+            ("pair_right", -9_718_754.0, 5_000_000.0),  # tile x=1 side
+        )
+        # Same cell (its origin on the x=0 side: tile (0,1) owns it), but
+        # the pair's centroid falls on the x=1 side of the border.
+        cell = math.floor((points[0][1] - _WORLD_MIN) / bucket)
+        assert cell == math.floor((points[1][1] - _WORLD_MIN) / bucket)
+        assert _WORLD_MIN + cell * bucket < border
+        assert (points[0][1] + points[1][1]) / 2 > border
+        await _create_cluster_semantics_table(
+            test_db_session, table_name, points=points
+        )
+
+        try:
+            pool = get_tile_pool()
+            sql = self._rows_sql(table_name)
+            layer = f"data.{table_name}"
+            owner_rows = await pool.fetch(sql, 2, 0, 1, layer, 14, 48)
+            neighbor_rows = await pool.fetch(sql, 2, 1, 1, layer, 14, 48)
+        finally:
+            await _cleanup_data_table(test_db_session, table_name)
+
+        assert len(owner_rows) == 1
+        assert owner_rows[0]["cluster"] is True
+        assert owner_rows[0]["point_count"] == 2
+        # The emitted geometry lies within the owner tile's coordinate
+        # space, pulled to just inside its east edge (extent = 4096).
+        assert 0 <= owner_rows[0]["mvt_x"] <= 4096
+        assert owner_rows[0]["mvt_x"] >= 4090
+        assert 0 <= owner_rows[0]["mvt_y"] <= 4096
+        # The neighbor (which contains the raw centroid) emits nothing.
+        assert len(neighbor_rows) == 0
+
+    async def test_feature_cap_applies_after_ownership(self, test_db_session):
+        """fix(#868, codex round 4): the feature cap applies AFTER the
+        ownership filter, so neighbor-owned cells seen through the expanded
+        scan can never consume the output budget and displace this tile's
+        own cells."""
+        from app.processing.tiles.pool import get_tile_pool
+
+        table_name = f"cluster_fcap_{uuid.uuid4().hex[:8]}"
+        points = (
+            # Three neighbor-owned cells visible to tile (1,1)'s expanded
+            # scan (cell origins on the x=0 side of the z2 border).
+            ("ring_a", -10_038_754.0, 5_000_000.0),
+            ("ring_b", -10_700_000.0, 5_000_000.0),
+            ("ring_c", -10_700_000.0, 6_000_000.0),
+            # The tile's own cell; must survive a feature cap of 1.
+            ("interior", -5_000_000.0, 5_000_000.0),
+        )
+        await _create_cluster_semantics_table(
+            test_db_session, table_name, points=points
+        )
+
+        try:
+            pool = get_tile_pool()
+            sql = self._rows_sql(table_name, feature_cap=1)
+            rows = await pool.fetch(sql, 2, 1, 1, f"data.{table_name}", 14, 48)
+        finally:
+            await _cleanup_data_table(test_db_session, table_name)
+
+        # With ownership filtered before the cap, the single budgeted
+        # feature is the tile's own cell, not a discarded neighbor cell.
+        assert [r["name"] for r in rows] == ["interior"]
         assert rows[0]["cluster"] is None

--- a/backend/tests/test_tiles.py
+++ b/backend/tests/test_tiles.py
@@ -152,7 +152,9 @@ _CLUSTER_SEMANTICS_POINTS = (
 )
 
 
-async def _create_cluster_semantics_table(session, table_name: str) -> None:
+async def _create_cluster_semantics_table(
+    session, table_name: str, points=_CLUSTER_SEMANTICS_POINTS
+) -> None:
     """Point table holding the fix(#868) bucket-semantics fixture points."""
     await session.execute(
         text(
@@ -163,7 +165,7 @@ async def _create_cluster_semantics_table(session, table_name: str) -> None:
             f")"
         )
     )
-    for name, x, y in _CLUSTER_SEMANTICS_POINTS:
+    for name, x, y in points:
         await session.execute(
             text(
                 f"INSERT INTO data.{table_name} (name, geom_4326) VALUES ("
@@ -785,3 +787,49 @@ class TestClusterBucketSemantics:
         assert singles[0]["point_count"] is None
         assert singles[0]["source_gid"] is not None
         assert singles[0]["name"] == "lone"  # attr projection on singles
+
+    async def test_straddling_cell_emitted_by_exactly_one_tile(self, test_db_session):
+        """fix(#868, codex P2 on PR #872): a bucket cell straddling a tile
+        border is computed from its complete membership by both neighbors
+        (expanded candidate scan) and emitted by exactly one of them, the
+        tile whose envelope contains the cell centroid. A point in the
+        neighbor's interior never leaks into the other tile's output."""
+        from app.processing.tiles.pool import get_tile_pool
+
+        table_name = f"cluster_seam_{uuid.uuid4().hex[:8]}"
+        # z2 arithmetic: tile width = world/4, bucket = width * 48 px * 8/4096.
+        tile_w = _WEB_MERCATOR_WORLD_WIDTH / 4
+        bucket = tile_w * 48 * (4096 / 512) / 4096
+        border = -tile_w  # boundary between z2 tiles x=0 and x=1
+        points = (
+            ("pair_left", -10_218_754.0, 5_000_000.0),  # tile x=0 side
+            ("pair_right", -9_918_754.0, 5_000_000.0),  # tile x=1 side
+            ("interior", -5_000_000.0, 5_000_000.0),  # tile x=1 interior
+        )
+        # The pair shares one absolute bucket cell that straddles the border,
+        # and their centroid falls on the x=0 side: tile (0,1) owns the cell.
+        assert math.floor(points[0][1] / bucket) == math.floor(points[1][1] / bucket)
+        assert points[0][1] < border < points[1][1]
+        assert (points[0][1] + points[1][1]) / 2 < border
+        await _create_cluster_semantics_table(
+            test_db_session, table_name, points=points
+        )
+
+        try:
+            pool = get_tile_pool()
+            sql = self._rows_sql(table_name)
+            layer = f"data.{table_name}"
+            owner_rows = await pool.fetch(sql, 2, 0, 1, layer, 14, 48)
+            neighbor_rows = await pool.fetch(sql, 2, 1, 1, layer, 14, 48)
+        finally:
+            await _cleanup_data_table(test_db_session, table_name)
+
+        # Owning tile: exactly the straddling cluster with FULL membership.
+        assert len(owner_rows) == 1
+        assert owner_rows[0]["cluster"] is True
+        assert owner_rows[0]["point_count"] == 2
+        # Neighbor: only its interior single. The straddling cell is not
+        # re-emitted, and the expanded scan leaks nothing else.
+        assert len(neighbor_rows) == 1
+        assert neighbor_rows[0]["cluster"] is None
+        assert neighbor_rows[0]["name"] == "interior"

--- a/backend/tests/test_tiles.py
+++ b/backend/tests/test_tiles.py
@@ -716,19 +716,30 @@ class TestClusterBucketSemantics:
     """
 
     @staticmethod
-    def _rows_sql(table_name: str) -> str:
+    def _rows_sql(table_name: str, input_cap: int | None = None) -> str:
         """The shipped cluster query with ST_AsMVT swapped for a row SELECT.
 
         Reuses every CTE of _build_cluster_tile_query verbatim (bounds,
         candidates, bucketed, grouped, features) so the assertions exercise
         the exact SQL the endpoint executes; only the final MVT encode is
         replaced because the suite carries no MVT decoder dependency.
+        ``input_cap`` swaps the candidate LIMIT for a tiny value so tests
+        can saturate the cap without 100k fixture rows.
         """
-        from app.processing.tiles.service import _build_cluster_tile_query
+        from app.processing.tiles.service import (
+            _CLUSTER_INPUT_LIMIT,
+            _build_cluster_tile_query,
+        )
 
         query = _build_cluster_tile_query(
             table_name, attr_columns=[{"name": "name", "type": "text"}]
         )
+        if input_cap is not None:
+            capped = query.replace(
+                f"LIMIT {_CLUSTER_INPUT_LIMIT}", f"LIMIT {input_cap}"
+            )
+            assert capped != query, "candidate LIMIT not found; update this test"
+            query = capped
         head, sep, _tail = query.rpartition("SELECT ST_AsMVT")
         assert sep, "cluster query tail changed; update this test's split point"
         # $4 (layer name) only appeared inside ST_AsMVT; keep it referenced so
@@ -807,10 +818,11 @@ class TestClusterBucketSemantics:
             ("interior", -5_000_000.0, 5_000_000.0),  # tile x=1 interior
         )
         # The pair shares one absolute bucket cell that straddles the border,
-        # and their centroid falls on the x=0 side: tile (0,1) owns the cell.
+        # and the cell ORIGIN (the ownership anchor) falls on the x=0 side:
+        # tile (0,1) owns the cell.
         assert math.floor(points[0][1] / bucket) == math.floor(points[1][1] / bucket)
         assert points[0][1] < border < points[1][1]
-        assert (points[0][1] + points[1][1]) / 2 < border
+        assert math.floor(points[0][1] / bucket) * bucket < border
         await _create_cluster_semantics_table(
             test_db_session, table_name, points=points
         )
@@ -833,3 +845,93 @@ class TestClusterBucketSemantics:
         assert len(neighbor_rows) == 1
         assert neighbor_rows[0]["cluster"] is None
         assert neighbor_rows[0]["name"] == "interior"
+
+    async def test_world_edge_point_owned_by_edge_tile(self, test_db_session):
+        """fix(#868, codex round 2): a feature sitting exactly on the world's
+        east boundary is emitted by exactly one tile — the edge tile, whose
+        upper ownership bound is inclusive (no neighbor exists beyond the
+        world). Runs past cluster max zoom, where the ownership anchor is
+        the point itself: the only anchor that can land exactly on the
+        boundary (lon 180 transforms to exactly the world XMax; verified
+        against PostGIS/proj on the test DB)."""
+        from app.processing.tiles.pool import get_tile_pool
+
+        table_name = f"cluster_edge_{uuid.uuid4().hex[:8]}"
+        await test_db_session.execute(
+            text(
+                f"CREATE TABLE IF NOT EXISTS data.{table_name} ("
+                f"  gid SERIAL PRIMARY KEY,"
+                f"  name TEXT,"
+                f"  geom_4326 GEOMETRY(Point, 4326)"
+                f")"
+            )
+        )
+        # Inserted in 4326 directly so lon stays exactly 180.
+        await test_db_session.execute(
+            text(
+                f"INSERT INTO data.{table_name} (name, geom_4326) VALUES "
+                f"('edge', ST_SetSRID(ST_MakePoint(180, 85.05112877980659), 4326))"
+            )
+        )
+        await test_db_session.commit()
+
+        try:
+            pool = get_tile_pool()
+            sql = self._rows_sql(table_name)
+            layer = f"data.{table_name}"
+            rows_by_tile = {}
+            for tx, ty in ((0, 0), (1, 0), (0, 1), (1, 1)):
+                # cluster_max_zoom=0 < z=1: unclustered mode, point anchors.
+                rows_by_tile[(tx, ty)] = await pool.fetch(sql, 1, tx, ty, layer, 0, 48)
+        finally:
+            await _cleanup_data_table(test_db_session, table_name)
+
+        assert sum(len(r) for r in rows_by_tile.values()) == 1
+        assert len(rows_by_tile[(1, 0)]) == 1
+        assert rows_by_tile[(1, 0)][0]["cluster"] is None
+        assert rows_by_tile[(1, 0)][0]["name"] == "edge"
+
+    async def test_cap_divergence_emits_shared_cell_at_most_once(self, test_db_session):
+        """fix(#868, codex round 2): when the input cap truncates DIFFERENT
+        candidate subsets in neighboring tiles, the shared straddling cell
+        is still emitted by at most one tile (the anchor owner). The
+        degradation is an undercounted single in the owner tile, never a
+        cross-tile double-emit."""
+        from app.processing.tiles.pool import get_tile_pool
+
+        table_name = f"cluster_cap_{uuid.uuid4().hex[:8]}"
+        points = (
+            # gid 1: interior of tile (0,1) only — pushes the pair past a
+            # cap of 2 in that tile's scan but not in the neighbor's.
+            ("west_interior", -15_000_000.0, 5_000_000.0),
+            # gids 2 and 3: the straddling pair from the seam test.
+            ("pair_left", -10_218_754.0, 5_000_000.0),
+            ("pair_right", -9_918_754.0, 5_000_000.0),
+        )
+        await _create_cluster_semantics_table(
+            test_db_session, table_name, points=points
+        )
+
+        try:
+            pool = get_tile_pool()
+            sql = self._rows_sql(table_name, input_cap=2)
+            layer = f"data.{table_name}"
+            # Owner scan (ordered by gid, cap 2) sees gids 1,2,3 -> keeps 1,2:
+            # the owned straddling cell has only one visible member.
+            owner_rows = await pool.fetch(sql, 2, 0, 1, layer, 14, 48)
+            # Neighbor scan sees gids 2,3 -> keeps both: it computes the full
+            # cell but does not own its anchor.
+            neighbor_rows = await pool.fetch(sql, 2, 1, 1, layer, 14, 48)
+        finally:
+            await _cleanup_data_table(test_db_session, table_name)
+
+        # Owner: its interior single plus the UNDERCOUNTED cell (one member
+        # visible -> emitted as a single carrying that member's attributes).
+        assert sorted(r["name"] for r in owner_rows) == [
+            "pair_left",
+            "west_interior",
+        ]
+        assert all(r["cluster"] is None for r in owner_rows)
+        # Neighbor: nothing. Anchor ownership does not depend on the scanned
+        # subset, so the cell is never double-emitted.
+        assert len(neighbor_rows) == 0

--- a/backend/tests/test_tiles.py
+++ b/backend/tests/test_tiles.py
@@ -142,12 +142,13 @@ async def _cleanup_data_table(session, table_name: str) -> None:
 
 # fix(#868): coordinates for the cluster bucket-semantics regression test.
 # EPSG:3857 meters. pair_a/pair_b sit ~30 CSS px apart on a z0 tile (512 px
-# display), inside one absolute 48-px bucket; "lone" is far away in its own
-# bucket so it must come through as an unclustered single.
+# display), inside one 48-px bucket of the world-min-anchored grid; "lone"
+# is far away in its own bucket so it must come through as a single.
 _WEB_MERCATOR_WORLD_WIDTH = 40075016.6855785
+_WORLD_MIN = -_WEB_MERCATOR_WORLD_WIDTH / 2
 _CLUSTER_SEMANTICS_POINTS = (
-    ("pair_a", 300_000.0, 300_000.0),
-    ("pair_b", 2_648_145.0, 300_000.0),
+    ("pair_a", -800_000.0, 300_000.0),
+    ("pair_b", 1_548_145.0, 300_000.0),
     ("lone", -10_000_000.0, -5_000_000.0),
 )
 
@@ -765,13 +766,14 @@ class TestClusterBucketSemantics:
         assert 29.0 < pair_px < 31.0  # ~30 CSS px apart
         # Old math: tile-anchored grid, px treated as extent units (~5.5 px).
         old_bucket = _WEB_MERCATOR_WORLD_WIDTH * 48 / 4096
-        half_world = _WEB_MERCATOR_WORLD_WIDTH / 2
-        assert math.floor((xs[0] + half_world) / old_bucket) != math.floor(
-            (xs[1] + half_world) / old_bucket
+        assert math.floor((xs[0] - _WORLD_MIN) / old_bucket) != math.floor(
+            (xs[1] - _WORLD_MIN) / old_bucket
         ), "fixture points no longer demonstrate the pre-#868 split"
-        # New math: absolute grid, 48 real CSS px per bucket.
+        # New math: world-min-anchored grid, 48 real CSS px per bucket.
         new_bucket = _WEB_MERCATOR_WORLD_WIDTH * 48 * (4096 / 512) / 4096
-        assert math.floor(xs[0] / new_bucket) == math.floor(xs[1] / new_bucket)
+        assert math.floor((xs[0] - _WORLD_MIN) / new_bucket) == math.floor(
+            (xs[1] - _WORLD_MIN) / new_bucket
+        )
 
         try:
             pool = get_tile_pool()
@@ -803,8 +805,9 @@ class TestClusterBucketSemantics:
         """fix(#868, codex P2 on PR #872): a bucket cell straddling a tile
         border is computed from its complete membership by both neighbors
         (expanded candidate scan) and emitted by exactly one of them, the
-        tile whose envelope contains the cell centroid. A point in the
-        neighbor's interior never leaks into the other tile's output."""
+        tile whose envelope contains the cell's ownership anchor (the cell
+        origin). A point in the neighbor's interior never leaks into the
+        other tile's output."""
         from app.processing.tiles.pool import get_tile_pool
 
         table_name = f"cluster_seam_{uuid.uuid4().hex[:8]}"
@@ -817,12 +820,13 @@ class TestClusterBucketSemantics:
             ("pair_right", -9_918_754.0, 5_000_000.0),  # tile x=1 side
             ("interior", -5_000_000.0, 5_000_000.0),  # tile x=1 interior
         )
-        # The pair shares one absolute bucket cell that straddles the border,
-        # and the cell ORIGIN (the ownership anchor) falls on the x=0 side:
-        # tile (0,1) owns the cell.
-        assert math.floor(points[0][1] / bucket) == math.floor(points[1][1] / bucket)
+        # The pair shares one world-min-anchored bucket cell that straddles
+        # the border, and the cell ORIGIN (the ownership anchor) falls on the
+        # x=0 side: tile (0,1) owns the cell.
+        cell = math.floor((points[0][1] - _WORLD_MIN) / bucket)
+        assert cell == math.floor((points[1][1] - _WORLD_MIN) / bucket)
         assert points[0][1] < border < points[1][1]
-        assert math.floor(points[0][1] / bucket) * bucket < border
+        assert _WORLD_MIN + cell * bucket < border
         await _create_cluster_semantics_table(
             test_db_session, table_name, points=points
         )
@@ -935,3 +939,64 @@ class TestClusterBucketSemantics:
         # Neighbor: nothing. Anchor ownership does not depend on the scanned
         # subset, so the cell is never double-emitted.
         assert len(neighbor_rows) == 0
+
+    async def test_past_max_zoom_ring_does_not_starve_cap(self, test_db_session):
+        """fix(#868, codex round 3): past cluster max zoom nothing clusters,
+        so the scan uses NO envelope expansion. With expansion, lower-gid
+        neighbor points could consume the whole candidate cap and then all
+        be discarded as ring-only, leaving the tile empty — a starvation
+        mode the pre-PR tile-bounded scan never had."""
+        from app.processing.tiles.pool import get_tile_pool
+
+        table_name = f"cluster_ring_{uuid.uuid4().hex[:8]}"
+        points = (
+            # gids 1-3: just west of the z2 x=0/x=1 border — inside the
+            # would-be expansion ring of tile (1,1), outside the tile itself.
+            ("ring_1", -10_118_754.0, 5_000_000.0),
+            ("ring_2", -10_120_000.0, 5_000_000.0),
+            ("ring_3", -10_130_000.0, 5_000_000.0),
+            # gid 4: interior of tile (1,1). Highest gid: an expanded scan
+            # with cap 2 would pick two ring rows and drop this one.
+            ("interior", -5_000_000.0, 5_000_000.0),
+        )
+        await _create_cluster_semantics_table(
+            test_db_session, table_name, points=points
+        )
+
+        try:
+            pool = get_tile_pool()
+            # z=2 > cluster_max_zoom=1: unclustered mode, cap saturated at 2.
+            sql = self._rows_sql(table_name, input_cap=2)
+            rows = await pool.fetch(sql, 2, 1, 1, f"data.{table_name}", 1, 48)
+        finally:
+            await _cleanup_data_table(test_db_session, table_name)
+
+        # The tile's own point survives; the un-expanded scan never spends
+        # the cap on neighbor rows that ownership would discard.
+        assert [r["name"] for r in rows] == ["interior"]
+        assert rows[0]["cluster"] is None
+
+    async def test_west_edge_cell_is_owned(self, test_db_session):
+        """fix(#868, codex round 3): the grid anchors at the world minimum,
+        so the cell holding a point near lon -180 has an in-world origin
+        and IS owned by the west edge tile. A 0-anchored grid put that
+        cell's origin outside the world: no tile owned it and the point
+        vanished at clustering zooms."""
+        from app.processing.tiles.pool import get_tile_pool
+
+        table_name = f"cluster_west_{uuid.uuid4().hex[:8]}"
+        points = (("west", _WORLD_MIN + 1_000.0, 5_000_000.0),)
+        await _create_cluster_semantics_table(
+            test_db_session, table_name, points=points
+        )
+
+        try:
+            pool = get_tile_pool()
+            sql = self._rows_sql(table_name)
+            # Clustering zoom (z=1 <= cmz=14): ownership uses cell origins.
+            rows = await pool.fetch(sql, 1, 0, 0, f"data.{table_name}", 14, 48)
+        finally:
+            await _cleanup_data_table(test_db_session, table_name)
+
+        assert [r["name"] for r in rows] == ["west"]
+        assert rows[0]["cluster"] is None

--- a/backend/tests/test_tiles.py
+++ b/backend/tests/test_tiles.py
@@ -9,6 +9,7 @@ Requirements:
 """
 
 import gzip
+import math
 import time
 import uuid
 from unittest.mock import AsyncMock, patch
@@ -136,6 +137,42 @@ async def _create_multipoint_data_table(session, table_name: str) -> None:
 async def _cleanup_data_table(session, table_name: str) -> None:
     """Drop the test data table."""
     await session.execute(text(f"DROP TABLE IF EXISTS data.{table_name}"))
+    await session.commit()
+
+
+# fix(#868): coordinates for the cluster bucket-semantics regression test.
+# EPSG:3857 meters. pair_a/pair_b sit ~30 CSS px apart on a z0 tile (512 px
+# display), inside one absolute 48-px bucket; "lone" is far away in its own
+# bucket so it must come through as an unclustered single.
+_WEB_MERCATOR_WORLD_WIDTH = 40075016.6855785
+_CLUSTER_SEMANTICS_POINTS = (
+    ("pair_a", 300_000.0, 300_000.0),
+    ("pair_b", 2_648_145.0, 300_000.0),
+    ("lone", -10_000_000.0, -5_000_000.0),
+)
+
+
+async def _create_cluster_semantics_table(session, table_name: str) -> None:
+    """Point table holding the fix(#868) bucket-semantics fixture points."""
+    await session.execute(
+        text(
+            f"CREATE TABLE IF NOT EXISTS data.{table_name} ("
+            f"  gid SERIAL PRIMARY KEY,"
+            f"  name TEXT,"
+            f"  geom_4326 GEOMETRY(Point, 4326)"
+            f")"
+        )
+    )
+    for name, x, y in _CLUSTER_SEMANTICS_POINTS:
+        await session.execute(
+            text(
+                f"INSERT INTO data.{table_name} (name, geom_4326) VALUES ("
+                f"  :name,"
+                f"  ST_Transform(ST_SetSRID(ST_MakePoint(:x, :y), 3857), 4326)"
+                f")"
+            ),
+            {"name": name, "x": x, "y": y},
+        )
     await session.commit()
 
 
@@ -341,8 +378,9 @@ class TestTileEndpoint:
         assert resp.status_code == 200
         # fix(#403): the cluster endpoint now supports the cols= opt-in, so
         # its cache lookups carry a cols_key segment (empty without cols=).
+        # fix(#868): the key carries the cluster SQL semantic version (v2).
         mock_cache.get.assert_awaited_once_with(
-            f"{table_name}:cluster:r64:z12", 0, 0, 0, cols_key=""
+            f"{table_name}:cluster:v2:r64:z12", 0, 0, 0, cols_key=""
         )
 
     async def test_empty_tile_returns_204(
@@ -664,3 +702,86 @@ class TestTilePool:
             _validate_tile_table_name("table-name")
         with pytest.raises(ValueError):
             _validate_tile_table_name("Table_Name")
+
+
+@pytest.mark.usefixtures("_init_tile_pool_for_tests")
+class TestClusterBucketSemantics:
+    """fix(#868): SQL-level regression tests for the cluster bucket grid.
+
+    The shipped math treated cluster_radius (CSS px) as MVT extent units,
+    building a ~8x-too-fine grid: overlapping cluster circles plus
+    unclustered singles leaking at low zoom.
+    """
+
+    @staticmethod
+    def _rows_sql(table_name: str) -> str:
+        """The shipped cluster query with ST_AsMVT swapped for a row SELECT.
+
+        Reuses every CTE of _build_cluster_tile_query verbatim (bounds,
+        candidates, bucketed, grouped, features) so the assertions exercise
+        the exact SQL the endpoint executes; only the final MVT encode is
+        replaced because the suite carries no MVT decoder dependency.
+        """
+        from app.processing.tiles.service import _build_cluster_tile_query
+
+        query = _build_cluster_tile_query(
+            table_name, attr_columns=[{"name": "name", "type": "text"}]
+        )
+        head, sep, _tail = query.rpartition("SELECT ST_AsMVT")
+        assert sep, "cluster query tail changed; update this test's split point"
+        # $4 (layer name) only appeared inside ST_AsMVT; keep it referenced so
+        # the prepared statement still binds all six parameters.
+        return head + (
+            "SELECT $4::text AS layer_name, cluster, point_count,\n"
+            "    point_count_abbreviated, source_gid, name\n"
+            "FROM features\nWHERE geom IS NOT NULL"
+        )
+
+    async def test_radius_is_css_px_and_lone_point_stays_single(self, test_db_session):
+        """Two points ~30 px apart at z0 with radius 48 land in ONE cluster
+        (the pre-#868 math split them), and a lone point comes through as an
+        unclustered single carrying its projected attributes."""
+        from app.processing.tiles.pool import get_tile_pool
+
+        table_name = f"cluster_sem_{uuid.uuid4().hex[:8]}"
+        await _create_cluster_semantics_table(test_db_session, table_name)
+
+        # Spec of the regression in plain arithmetic (z0 tile = whole world).
+        xs = [_CLUSTER_SEMANTICS_POINTS[0][1], _CLUSTER_SEMANTICS_POINTS[1][1]]
+        pair_px = abs(xs[1] - xs[0]) / _WEB_MERCATOR_WORLD_WIDTH * 512
+        assert 29.0 < pair_px < 31.0  # ~30 CSS px apart
+        # Old math: tile-anchored grid, px treated as extent units (~5.5 px).
+        old_bucket = _WEB_MERCATOR_WORLD_WIDTH * 48 / 4096
+        half_world = _WEB_MERCATOR_WORLD_WIDTH / 2
+        assert math.floor((xs[0] + half_world) / old_bucket) != math.floor(
+            (xs[1] + half_world) / old_bucket
+        ), "fixture points no longer demonstrate the pre-#868 split"
+        # New math: absolute grid, 48 real CSS px per bucket.
+        new_bucket = _WEB_MERCATOR_WORLD_WIDTH * 48 * (4096 / 512) / 4096
+        assert math.floor(xs[0] / new_bucket) == math.floor(xs[1] / new_bucket)
+
+        try:
+            pool = get_tile_pool()
+            rows = await pool.fetch(
+                self._rows_sql(table_name),
+                0,  # z
+                0,  # x
+                0,  # y
+                f"data.{table_name}",
+                14,  # cluster_max_zoom
+                48,  # cluster_radius, CSS px
+            )
+        finally:
+            await _cleanup_data_table(test_db_session, table_name)
+
+        assert len(rows) == 2
+        clusters = [r for r in rows if r["cluster"]]
+        singles = [r for r in rows if not r["cluster"]]
+        assert len(clusters) == 1
+        assert clusters[0]["point_count"] == 2
+        assert clusters[0]["point_count_abbreviated"] == "2"
+        assert clusters[0]["name"] is None  # attrs stay off cluster features
+        assert len(singles) == 1
+        assert singles[0]["point_count"] is None
+        assert singles[0]["source_gid"] is not None
+        assert singles[0]["name"] == "lone"  # attr projection on singles


### PR DESCRIPTION
## What

Server-side cluster tiles (`/tiles/clusters/...`, the path any point dataset over 5000 features takes) built their bucket grid from `cluster_radius` as if the value were MVT extent units. It is CSS pixels: the router default `Query(48)` mirrors MapLibre's `clusterRadius` on the client-side path. At 512 px tile display one pixel is 4096/512 = 8 extent units, so the shipped grid was ~8x finer than intended. Cluster circles overlapped, and any point alone in a ~5.5 px cell leaked through as an unclustered single at low zoom.

Numbers from one z2 tile of the local meteorites dataset (the query's bucketing CTE verbatim):

| | clusters | singles | largest cluster |
|---|---|---|---|
| radius 44 as shipped | 187 | 568 | 801 |
| radius 352 (44 x 8) | 94 | 15 | 2826 |

## Changes

- `backend/app/processing/tiles/service.py`: scale `$6` (CSS px) by `_CLUSTER_PX_TO_EXTENT_UNITS` (4096/512, with the 512 px display assumption documented at the constant) inside `_build_cluster_tile_query`. The bucket grid now anchors to absolute EPSG:3857 coordinates instead of each tile's minx/miny, so adjacent tiles at one zoom share an aligned grid (bucket size at a fixed zoom is identical for every tile). The `GREATEST(..., 1.0)` degenerate-size guard stays. Docstrings now say CSS/screen px explicitly.
- `backend/app/processing/tiles/router.py`: **cache-key version bump.** `_cluster_cache_table_key` gains a SQL-semantics version component (`...:cluster:v2:r{r}:z{z}`), with a comment telling future editors to bump it when cluster SQL semantics change. Without it this deploy would keep serving stale-geometry cluster tiles from Valkey until TTL expiry. Old `:r{r}:z{z}` keys become garbage and age out on their TTL.
- `backend/tests/test_tiles.py`: SQL-level regression test. Two points ~30 CSS px apart at z0 with radius 48 land in ONE cluster (the pre-fix math split them; the test pins that arithmetic too), and a lone point comes through as an unclustered single carrying its projected attributes. It runs the shipped query's CTEs verbatim with only the final `ST_AsMVT` encode swapped for a row SELECT, since the suite carries no MVT decoder. The existing cache-key test now expects `:v2`.
- `backend/tests/test_mvt_audit_fixes.py`: query-shape tests pinning the px conversion factor and the absolute-grid anchoring.
- `backend/tests/test_layering.py`: the tiles router LOC ratchet moves 2043 -> 2046 with a written carve-out for the 3-line cache-key comment (the ratchet requires exact LOC).

No API change: the endpoint keeps px semantics and `Query(48, ge=1, le=256)`. Frontend untouched; the client-side bounded-geojson cluster path was already correct.

Cross-tile grid alignment is asserted structurally (bucketing uses absolute `ST_X`/`ST_Y`, no `bounds.minx`/`miny` subtraction). A semantic two-tile assertion would need one point to be a candidate in two tiles at once, which the per-tile bounds filter rules out, so it was skipped as disproportionate machinery.

## Review round 1 (codex P2, commit caf975491)

Anchoring the grid globally introduced a new seam bug: a bucket cell straddling a tile border was computed twice, each tile seeing only its own fragment (candidates were filtered to the tile envelope), so opposite-side points emitted as separate singles or undercounted clusters. Fixed by:

- expanding the candidate scan by one full bucket, clamped to the world envelope before the 4326 transform (past the world edge proj wraps longitude and the transformed bbox inverts, dropping candidates), so each tile sees the complete membership of every cell overlapping it;
- `ORDER BY gid` before the input cap, so neighboring tiles agree on a straddling cell's membership and centroid when the cap truncates;
- emitting each cell from exactly one tile: the one whose envelope contains the cell centroid (half-open bounds). Singles that only enter via the expanded ring drop out through the same filter, since a single's centroid is its own point.

Perf trade: the candidate scan now covers up to one bucket beyond the tile on each side (9.375% of the tile width per side at radius 48), and the deterministic ordering sorts the candidate set before the `LIMIT`. Cap semantics are unchanged.

New regression test: two points within one bucket width on opposite sides of a z2 tile border come out as one cluster (`point_count` 2) from the owning tile only; the neighbor emits nothing for that cell, and its interior point never leaks into the adjacent tile despite the expanded scan.

## Review round 2 (two codex P2s, commit 2b5cd0d9b)

**Cap saturation (service.py).** Round 1's centroid ownership was our design call, and codex is right that it breaks under cap saturation: when the candidate cap truncates different subsets in neighboring tiles (their scan envelopes differ), each tile's computed centroid for a shared cell can land on either side of the border, giving a double- or zero-emit. Preserving complete shared-cell membership under any finite cap is impossible, so instead ownership no longer depends on the data: the anchor is now the cell ORIGIN (bucket index times bucket size; the point itself past cluster max zoom), pure grid geometry that both neighbors always agree on. Worst case under cap saturation degrades to an undercounted (or missing) cluster in the owner tile, the same degradation class any capped per-tile grid has, never a cross-tile disagreement. Consequence handled: the owner-emitted rendered point can now sit up to one bucket outside the tile, so the ST_AsMVTGeom buffer scales with the radius (`GREATEST(256, ceil(px * 8) + 16)`), covering the `le=256` px extreme (2064 extent units).

Documented limit: cap-saturation undercount is inherent to a capped per-tile grid and predates this PR; asks to "fix" the undercount itself will get a documented-limits decline.

**World edge (service.py).** The strict upper bounds dropped a feature sitting exactly on the world's east/north boundary in the outermost tile, where no neighbor exists to own it (a regression vs pre-PR, and the same class exists for anchors). The east (`x = 2^z - 1`) and north (`y = 0`) edge tiles now use inclusive upper bounds; all internal borders stay half-open.

New tests: a point at lon 180 (which transforms to exactly the world XMax on PostGIS/proj, verified against the test DB) is emitted by exactly one tile, the edge tile; the round-1 seam test passes unchanged under anchor ownership (the cell origin lands on the same side its centroid did); a cap-divergence test injects a candidate cap of 2 so the neighbors see different subsets and shows the shared cell is emitted at most once, as an undercounted single from the owner tile.

## Review round 3 (two codex P2s, commit b21e48a23)

**West-edge vanish (service.py).** The grid was anchored at 0, so the origin of a cell straddling the world's west/south edge landed outside the world; the ownership lower bound rejected it in every tile and points near lon -180 vanished at clustering zooms. Fixed by construction: the grid now anchors at the world minimum (`bucket index = floor((x - world_min) / bucket)`, `anchor = world_min + index * bucket`), so any in-world point yields an in-world cell origin and the inclusive lower bounds cover the west/south edges with no special case. Re-derived the east/north inclusive upper bounds: still needed, since an anchor can land exactly on the world maximum (a point at lon 180 past max zoom, or a bucket size that divides the world width exactly, e.g. radius 64).

**Past-max-zoom ring starvation (service.py).** Past cluster max zoom nothing clusters, but the scan still used the expanded envelope; lower-gid neighbor rows could consume the entire candidate cap and then all be discarded as ring-only, leaving the tile empty - a failure mode the pre-PR tile-bounded scan never had. The expansion is now zero when `z > cluster_max_zoom` (no cross-tile cells exist there); clustering zooms keep the one-bucket expansion.

New tests: a point 1 km from lon -180 at a clustering zoom is emitted by the west edge tile (it vanished under the 0-anchored grid); a past-max-zoom scenario with three lower-gid neighbor points and an injected cap of 2 keeps the tile's own point (the expanded scan starved it); the seam, cap-divergence, and world-edge tests were re-derived for the world-min grid; query-shape assertions pin the new anchor expressions and the conditional expansion.

## Review round 4 (two codex P2s, commit 985ef1ad3)

**Visibility hole (service.py).** Anchor ownership lets a cell's centroid fall up to one bucket inside the NEIGHBOR tile; a client whose viewport covers the centroid but not the owner tile requests only the neighbor tile, where the cell is filtered out, so the cluster was invisible there. Codex is right that the MVT buffer cannot fix this (the client never requests the owner tile). Keeping anchor ownership (the cap-stable choice), the emitted geometry is now clamped into the owning tile, one MVT extent unit inside each edge. Maximum positional error from the clamp: one bucket, i.e. the cluster radius in CSS px (48 by default), deterministic, and zero for geometry already inside the tile - all past-max-zoom points and every cell whose centroid is in-tile. The round-2 radius-scaled MVT buffer is superseded and reverted to the plain 256, since emitted geometry is now always in-tile.

**Cap-before-ownership (service.py).** The feature `LIMIT` applied before the ownership predicate, so neighbor-owned cells seen through the expanded scan could consume the output budget and displace this tile's own cells. Ownership is per-row grid arithmetic (every member of a cell shares the cell's anchor), so it now filters in the aggregation CTE before `GROUP BY` and the cap. Unclustered/past-max-zoom semantics unchanged (buckets are per-point there; the anchor is the point).

New tests: a straddling cell whose raw centroid lands in the neighbor is emitted by the owner with its geometry inside the owner tile's extent (tile-space x clamped to just inside the east edge, asserted via `ST_X` on the MVT geometry) while the neighbor emits nothing; a feature-cap variant (injected cap of 1, three neighbor-owned cells plus one owned cell) keeps the tile's own cell.

## Verification (host, Postgres at localhost:5434)

- `uv run pytest tests/test_tiles.py tests/test_mvt_audit_fixes.py tests/test_dp02_read_path_binding.py` - 63 passed
- `uv run pytest tests/test_tile_gzip_offload_perf005.py tests/test_vector_tile_auth.py tests/test_dp_review_fixes.py tests/test_phase_275_demo_cluster.py` - 21 passed
- `uv run pytest tests -n 4` - full suite: 5922 passed, 81 skipped, 2 failed on the tiles-router LOC ratchet, which this change tripped; fixed via the carve-out above and re-verified with `uv run pytest tests/test_layering.py tests/test_tiles.py tests/test_mvt_audit_fixes.py` (76 passed)
- After the round-1 seam fix: `uv run pytest tests/test_tiles.py tests/test_mvt_audit_fixes.py tests/test_dp02_read_path_binding.py tests/test_layering.py` - 93 passed; adjacent tile files re-run - 21 passed
- After the round-2 anchor/edge fix: same targeted set - 95 passed; adjacent tile files - 21 passed
- After the round-3 world-min/starvation fix: same targeted set - 97 passed; adjacent tile files - 21 passed; rebased on origin/main (#869)
- After the round-4 clamp/cap-order fix: same targeted set - 99 passed; adjacent tile files - 21 passed; rebased on origin/main (#870, #865)
- `uv run ruff check .` and `uv run ruff format --check .` - clean after each round

## Notes

- Deploy note from the issue: demo.getgeolens.com picks this up at the next release/redeploy; the edge tile cache may need a purge then.
- Possible follow-up, deliberately not touched here: `expansion_zoom` is `LEAST($5+1, 22)` for every cluster, so clicking a z2 cluster targets cluster_max_zoom+1 (z15 by default) instead of the zoom where that cluster actually splits.

Closes #868

https://claude.ai/code/session_01A8vNJqrsio7yP5vWNhauVg
