### PR TITLE
chore(release): bump version to 1.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,34 @@ and releases use semantic versioning.
 
 ## [Unreleased]
 
+## [1.6.1] - 2026-07-29
+
+### Added
+
+- **Maps saved with a globe projection now render as globes everywhere.**
+  The shared-map viewer, embeds, and dataset previews applied the default
+  Mercator projection regardless of what the map was saved with; they now
+  honor the saved projection. (#845)
+
+### Security
+
+- **API keys expire and go stale with their owner.** Keys now carry an
+  expiry, are invalidated when the owner's key epoch rotates, and the
+  deprecated query-parameter lane is scoped down. (#864)
+- **react-router bumped to 7.18.2** for the upstream RSC CSRF backport.
+- **Admin settings routes are gated mode-aware**, matching the backend's
+  `require_settings_admin` — a route no longer renders for a role the API
+  would reject. (#857)
+
 ### Fixed
 
+- **Clusters no longer pile on top of each other.** The server-side cluster
+  grid read the cluster radius in tile units instead of screen pixels,
+  producing a grid roughly eight times finer than intended: overlapping
+  cluster bubbles and single features leaking through at low zoom. The
+  radius now converts to tile units correctly, the grid is anchored
+  consistently across tiles, and each cluster is owned by exactly one
+  tile. (#868)
 - **A backup cycle no longer fails just because the instance was busy.**
   Anything writing to object storage while the backup archived it made tar
   report "file changed as we read it", and the cycle treated that warning
@@ -16,6 +42,25 @@ and releases use semantic versioning.
   container unhealthy under the new freshness probe. The warning now keeps
   the archive and the cycle; only a fatal tar error (exit 2+) fails it.
   (#843)
+- **Silent frontend errors now reach the problem reporter.** Errors caught
+  by boundary components used to disappear; they are included in problem
+  reports, and the theme provider no longer throws when browser storage is
+  blocked. (#818)
+- **The builder's Ask-AI entry no longer flashes "unavailable" while
+  permissions load** — it stays in a loading state until the answer is
+  known. (#817)
+- **Attribute tables no longer lock up with a screen reader attached.**
+  Dynamic row measurement fed an accessibility-tree render loop; rows are
+  fixed-height now. (#830)
+- **Mid-edit admin settings survive a background refetch** instead of
+  being clobbered by the incoming server state. (#823)
+- **Exports validate their inputs**: a stray colon in a `where` filter or
+  a bad layer name returns a clear 4xx instead of an ogr2ogr failure.
+  (#832, #833)
+- Assorted accessibility and UX follow-ups from the 1.6.0 pre-tag audit:
+  keyboard and label fixes across admin and builder surfaces, plain layer
+  names in Ask-AI suggestions, and a cleared token-refresh retry timer in
+  the shared-map viewer's failure path. (#820, #831, #834)
 
 ## [1.6.0] - 2026-07-28
 
@@ -1398,7 +1443,8 @@ regression-covered fixes:
 - Initial public release of the GeoLens catalog, API, map builder, CLI, SDKs,
   Docker development stack, and public documentation entrypoints.
 
-[Unreleased]: https://github.com/geolens-io/geolens/compare/v1.6.0...HEAD
+[Unreleased]: https://github.com/geolens-io/geolens/compare/v1.6.1...HEAD
+[1.6.1]: https://github.com/geolens-io/geolens/compare/v1.6.0...v1.6.1
 [1.6.0]: https://github.com/geolens-io/geolens/compare/v1.5.1...v1.6.0
 [1.5.1]: https://github.com/geolens-io/geolens/compare/v1.5.0...v1.5.1
 [1.5.0]: https://github.com/geolens-io/geolens/compare/v1.4.13...v1.5.0

--- a/backend/app/api/main.py
+++ b/backend/app/api/main.py
@@ -580,7 +580,7 @@ _is_production = settings.is_production
 # no metadata to read. We fall back to the current published line so import never
 # crashes. Keep this fallback in lockstep with backend/pyproject.toml — it is one
 # of the sites `make bump` rewrites.
-_FALLBACK_APP_VERSION = "1.6.0"
+_FALLBACK_APP_VERSION = "1.6.1"
 
 
 def _resolve_app_version() -> str:

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -17547,7 +17547,7 @@
     "summary": "PostGIS-native geospatial data catalog with OGC API Features and Records support",
     "termsOfService": "https://github.com/geolens-io/geolens/blob/main/LICENSE",
     "title": "GeoLens API",
-    "version": "1.6.0"
+    "version": "1.6.1"
   },
   "openapi": "3.1.0",
   "paths": {

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geolens-backend"
-version = "1.6.0"
+version = "1.6.1"
 description = "PostGIS-native GIS data catalog"
 # Docker image (Dockerfile) ships python:3.14-slim (see the Dockerfile FROM for
 # the exact patch pin) as the project's tested runtime.

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -850,7 +850,7 @@ wheels = [
 
 [[package]]
 name = "geolens-backend"
-version = "1.6.0"
+version = "1.6.1"
 source = { virtual = "." }
 dependencies = [
     { name = "alembic" },

--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "geolens-cli"
-version = "1.6.0"
+version = "1.6.1"
 description = "Apache-2.0 command-line interface for the GeoLens API. Login, scan, publish, and export STAC against any GeoLens instance."
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/docs-contract.json
+++ b/docs-contract.json
@@ -1,6 +1,6 @@
 {
   "_comment": "Canonical cross-surface facts for the GeoLens README, marketing site (getgeolens.com/src), and docs site (getgeolens.com/docs). Validated against scripts/install.sh + backend/pyproject.toml by scripts/check_docs_contract.py (geolens CI). The getgeolens.com repo vendors a copy and enforces the same `forbidden` list in its own CI. See docs-internal/DOC-CONSISTENCY-STRATEGY for the full design. Edit a fact ONCE here (and in its canonical source) — the gates make every surface follow.",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "install": {
     "oneLiner": "curl -fsSL https://getgeolens.com/install.sh | sh",
     "sourceBuild": "bash scripts/install.sh",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "1.6.0",
+      "version": "1.6.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.6.0",
+  "version": "1.6.1",
   "type": "module",
   "license": "Apache-2.0",
   "author": "Carto Concepts, LLC",

--- a/mcp/pyproject.toml
+++ b/mcp/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "geolens-mcp"
-version = "1.6.0"
+version = "1.6.1"
 description = "Apache-2.0 read-only Model Context Protocol (MCP) server for GeoLens. Lets coding agents discover datasets, inspect schemas, and ask spatial questions against any GeoLens instance."
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/mcp/uv.lock
+++ b/mcp/uv.lock
@@ -225,7 +225,7 @@ wheels = [
 
 [[package]]
 name = "geolens"
-version = "1.6.0"
+version = "1.6.1"
 source = { editable = "../sdks/python" }
 dependencies = [
     { name = "attrs" },
@@ -242,7 +242,7 @@ requires-dist = [
 
 [[package]]
 name = "geolens-mcp"
-version = "1.6.0"
+version = "1.6.1"
 source = { editable = "." }
 dependencies = [
     { name = "geolens" },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "geolens",
-  "version": "1.5.1",
+  "version": "1.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "geolens",
-      "version": "1.5.1",
+      "version": "1.6.1",
       "license": "Apache-2.0",
       "devDependencies": {
         "@axe-core/playwright": "^4.12.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "geolens",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "private": true,
   "license": "Apache-2.0",
   "author": "Carto Concepts, LLC",

--- a/sdks/python/.openapi-python-client.yaml
+++ b/sdks/python/.openapi-python-client.yaml
@@ -4,7 +4,7 @@ project_name_override: geolens
 package_name_override: geolens
 # Rewritten on every `make sdks` run by scripts/sync_sdk_versions.py to match
 # backend/openapi.json info.version. Do not edit by hand.
-package_version_override: 1.6.0
+package_version_override: 1.6.1
 
 # Cleaner enum output (matches our pydantic v2 backend's enum emission).
 literal_enums: true

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "geolens"
-version = "1.6.0"
+version = "1.6.1"
 description = "Auto-generated Python SDK for the GeoLens API. Typed clients with Bearer + API-key auth helpers."
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/sdks/typescript/package-lock.json
+++ b/sdks/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@geolens/sdk",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@geolens/sdk",
-      "version": "1.6.0",
+      "version": "1.6.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@hey-api/client-fetch": "0.13.1"

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@geolens/sdk",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "Auto-generated TypeScript SDK for the GeoLens API. Typed clients with Bearer + API-key auth helpers.",
   "license": "Apache-2.0",
   "author": "Carto Concepts, LLC",


### PR DESCRIPTION
Version bump for the v1.6.1 patch release.

- `make bump VERSION=1.6.1` across all version sites, plus the three lockfiles the bump script does not touch (backend/uv.lock, sdks/typescript/package-lock.json, frontend/package-lock.json).
- CHANGELOG: closed Unreleased as [1.6.1] - 2026-07-29. Ships the globe projection on viewer surfaces (#845), the server-side cluster grid fix (#868), API-key hardening (#864), the react-router CSRF backport, the mode-aware admin settings gate (#857), the backup tar live-write fix (#843), and the pre-tag audit fix batches.

No schema or API changes beyond the version fields. Verification: `make version-check` green locally; pre-commit hooks green.

https://claude.ai/code/session_01A8vNJqrsio7yP5vWNhauVg