### PR TITLE
fix(admin): drop the legacy appearance redirect so the edition gate owns the tab

### DIFF
--- a/e2e/admin.spec.ts
+++ b/e2e/admin.spec.ts
@@ -228,17 +228,16 @@ test.describe('Admin Panel', () => {
   test('settings: appearance URL never renders the appearance tab on community', async ({ page }) => {
     await page.goto('/admin/settings/appearance');
 
-    // fix(#871): /admin/settings/appearance is currently shadowed by a static
-    // legacy redirect to /map for EVERY edition; the intended fix removes that
-    // route, after which AdminSettingsPage's edition gate sends community
-    // users to /general instead. This assertion is written as the INVARIANT
-    // that holds on both sides of that fix: a community admin never sees the
-    // appearance (branding) tab and lands on another valid settings tab. The
-    // exact destinations (community → general, enterprise → appearance) are
-    // pinned at the unit level in AdminSettingsPage.test.tsx — a community
-    // dev stack can only ever exhibit one edition in e2e.
-    await page.waitForURL(/\/admin\/settings\/(map|general)$/);
-    await expect(page.getByRole('heading', { level: 1 })).toBeVisible({ timeout: 10_000 });
+    // fix(#871): AdminSettingsPage's edition gate owns this URL now, so a
+    // community stack lands on /general (it used to be dragged to /map by a
+    // static legacy redirect that outranked `admin/settings/:tab`). The
+    // enterprise direction — same URL renders the branding tab — is pinned at
+    // the unit level in AdminSettingsPage.test.tsx, since the stack under
+    // test only ever has one edition.
+    await page.waitForURL('/admin/settings/general');
+    await expect(
+      page.getByRole('heading', { level: 1, name: 'General', exact: true }),
+    ).toBeVisible({ timeout: 10_000 });
     // The appearance tab's branding toggle must never render for community.
     await expect(page.locator('#show-badge')).toHaveCount(0);
 

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -1,0 +1,32 @@
+import { isValidElement, type ReactElement } from 'react';
+import { appRoutes } from './App';
+import { ALL_TAB_KEYS } from '@/pages/admin/AdminSettingsPage';
+
+// fix(#871): a legacy `admin/settings/appearance` → `/admin/settings/map`
+// redirect sat next to `admin/settings/:tab` for four months. React Router
+// ranks a fully static path above a dynamic one, so the redirect fired for
+// every edition and the enterprise branding tab was unreachable —
+// AdminSettingsPage's edition gate never saw the URL. The gating unit tests
+// mock `useParams`, so they cannot catch a re-added static route; this walks
+// the real route table instead.
+function collectPaths(node: unknown, out: string[] = []): string[] {
+  if (Array.isArray(node)) {
+    node.forEach(child => collectPaths(child, out));
+    return out;
+  }
+  if (!isValidElement(node)) return out;
+  const props = (node as ReactElement<{ path?: string; children?: unknown }>).props;
+  if (typeof props.path === 'string') out.push(props.path);
+  collectPaths(props.children, out);
+  return out;
+}
+
+describe('appRoutes', () => {
+  it('declares no static admin/settings route that shadows a real settings tab', () => {
+    const shadowing = collectPaths(appRoutes)
+      .map(path => /^\/?admin\/settings\/([^/:]+)$/.exec(path)?.[1])
+      .filter((tab): tab is string => tab !== undefined && (ALL_TAB_KEYS as readonly string[]).includes(tab));
+
+    expect(shadowing).toEqual([]);
+  });
+});

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -135,12 +135,16 @@ export const appRoutes = (
             {/* Redirects from old routes */}
             <Route path="admin/share-tokens" element={<Navigate to="/admin/shared-maps" replace />} />
             <Route path="admin/embed-tokens" element={<Navigate to="/admin/shared-maps" replace />} />
-            {/* Redirects from old routes */}
+            {/* Redirects from old routes.
+                fix(#871): no `admin/settings/appearance` entry here — a static
+                path outranks `admin/settings/:tab`, so the old
+                appearance→map redirect made the enterprise branding tab
+                unreachable. AdminSettingsPage's edition gate owns that URL
+                now (enterprise renders it, community sends it to general). */}
             <Route path="admin/settings/infrastructure" element={<Navigate to="/admin/overview" replace />} />
             <Route path="admin/general" element={<Navigate to="/admin/settings/general" replace />} />
             <Route path="admin/basemaps" element={<Navigate to="/admin/settings/map" replace />} />
             <Route path="admin/map-defaults" element={<Navigate to="/admin/settings/map" replace />} />
-            <Route path="admin/settings/appearance" element={<Navigate to="/admin/settings/map" replace />} />
             <Route path="admin/security" element={<Navigate to="/admin/settings/auth" replace />} />
             <Route path="admin/uploads" element={<Navigate to="/admin/settings/storage" replace />} />
             <Route path="admin/ai" element={<Navigate to="/admin/settings/ai" replace />} />

--- a/frontend/src/pages/admin/AdminSettingsPage.tsx
+++ b/frontend/src/pages/admin/AdminSettingsPage.tsx
@@ -28,7 +28,10 @@ import { useEdition } from '@/hooks/use-edition';
 import type { SettingItem } from '@/api/settings';
 import { useDocumentTitle } from '@/hooks/use-document-title';
 
-const ALL_TAB_KEYS = ['general', 'auth', 'ai', 'network', 'storage', 'map', 'permissions', 'appearance'] as const;
+// Exported for the App route-table guard (fix(#871)): a static
+// `admin/settings/<key>` route outranks `admin/settings/:tab`, so any static
+// path matching one of these keys silently steals the tab from this page.
+export const ALL_TAB_KEYS = ['general', 'auth', 'ai', 'network', 'storage', 'map', 'permissions', 'appearance'] as const;
 type TabKey = typeof ALL_TAB_KEYS[number];
 
 const TAB_LABELS: Record<TabKey, string> = {

--- a/frontend/src/pages/admin/__tests__/AdminSettingsPage.test.tsx
+++ b/frontend/src/pages/admin/__tests__/AdminSettingsPage.test.tsx
@@ -139,11 +139,12 @@ describe('AdminSettingsPage', () => {
   });
 
   // test(#828): the appearance tab's edition gate lives here (visibleTabs
-  // excludes 'appearance' unless isEnterprise). It is only testable at the
-  // unit level: e2e on a community stack never reaches this component for
-  // tab=appearance because a static legacy redirect in App.tsx (appearance →
-  // map) outranks the `admin/settings/:tab` route for every edition (see the
-  // PR #870 review finding). Both edition contexts are pinned below.
+  // excludes 'appearance' unless isEnterprise). Both edition directions are
+  // pinned below because e2e can only ever observe one of them — the stack
+  // under test has a single edition. fix(#871) removed the static
+  // appearance→map redirect from App.tsx that used to outrank
+  // `admin/settings/:tab` and keep this gate from ever seeing the URL; these
+  // two cases are what the route now delegates to.
   describe('appearance tab edition gating (#828)', () => {
     function renderAppearanceRoute() {
       mockUseParams.mockReturnValue({ tab: 'appearance' });


### PR DESCRIPTION
## What changed

Deleted the legacy `admin/settings/appearance` -> `/admin/settings/map` redirect from `frontend/src/App.tsx`. `AdminSettingsPage`'s own edition gate now owns that URL.

Verified before deleting that the gate really handles both directions (`AdminSettingsPage.tsx:82-89`): `visibleTabs` drops `appearance` unless `isEnterprise`, `activeTab` becomes null, and the page returns `<Navigate to="/admin/settings/general" replace />`. So community keeps a valid destination without the redirect, and enterprise renders the branding tab.

## Why

Two commits from adjacent days never met. `32c4cb60c` renamed the old basemaps "Appearance" tab to "Map" and left a redirect behind; `1f555a233` added the enterprise-only `SettingsAppearanceTab` at that same URL the next day. React Router ranks a fully static path above `admin/settings/:tab`, so the redirect fired for every edition. Enterprise admins clicking the sidebar's Appearance link landed on Map settings, and the branding tab could not be reached at all.

## Tests

- `frontend/src/App.test.tsx` (new): walks the real `appRoutes` element tree and fails on any static `admin/settings/<key>` path that collides with a key in `ALL_TAB_KEYS`. This is the only test that can catch a re-added redirect, because the gating tests in `AdminSettingsPage.test.tsx` mock `useParams` and never touch the route table. It also pre-empts the same collision for any future tab (`admin/settings/infrastructure` sits in that block today and is only harmless because `infrastructure` is not a tab key). `ALL_TAB_KEYS` is now exported so the guard cannot drift from the page.
- `e2e/admin.spec.ts`: the appearance test from #870 deliberately accepted `map|general` while the bug stood. Tightened to `/admin/settings/general` with a `General` heading assertion, and dropped the stale comment. The community invariants it already had (no `#show-badge`, no sidebar link) are unchanged.
- `AdminSettingsPage.test.tsx`: assertions were already written against the fixed behavior, so only the stale comment about the shadowing redirect needed rewriting.

## Verification

Ran from the worktree with `frontend/node_modules` symlinked from the main checkout.

| Command | Result |
| --- | --- |
| `npx vitest run src/App.test.tsx src/pages/admin/__tests__/AdminSettingsPage.test.tsx src/components/admin/__tests__/AdminSidebar.test.tsx` | pass, 22 tests |
| `npx vitest run src/pages/admin src/components/admin` | pass, 15 files / 113 tests |
| `npm run lint` | pass |
| `npm run typecheck` | pass |
| `npm run test:i18n` | pass (no new `t()` keys) |
| `E2E_BASE_URL=http://localhost:5174 npx playwright test e2e/admin.spec.ts --project=chromium` | pass, 15/15 |

Two negative checks, so neither new assertion is vacuously true:

- Re-added the redirect temporarily: `src/App.test.tsx` failed. Removed it again: passed.
- Ran the flipped e2e test against the unfixed dev stack on `:8080`: failed at `waitForURL('/admin/settings/general')`, because that build still redirects to `/map`.

The dev stack bind-mounts the main checkout's `./frontend`, so `:8080` cannot serve worktree code. The passing e2e run above went through a host Vite on `:5174` (`API_PROXY_TARGET=http://localhost:8001`) serving this branch against the same backend.

No schema, API, or config impact. Frontend routing only.

Closes #871

https://claude.ai/code/session_01X3H5TbsLerX6WdWaMx4RKS
