### PR TITLE
chore(release): stamp lockfiles in bump and gate them in version-check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -697,7 +697,8 @@ jobs:
 
   # ---------- version coherence ----------
   # REL-04: assert every version site agrees (backend/cli/sdks×2/root+frontend
-  # package.json/openapi.json info.version/main.py fallback constant). Blocks a
+  # package.json/openapi.json info.version/main.py fallback constant/the 5
+  # lockfiles that embed the package's own version, fix(#877)). Blocks a
   # release where one site silently drifted from the rest. Pure stdlib (tomllib
   # + json + re); no DB, no Docker, runs on every push/PR.
   version-coherence:

--- a/Makefile
+++ b/Makefile
@@ -297,8 +297,10 @@ catalog-domain-discipline: ## Verify no external imports of catalog/datasets/dom
 # ----- Version management (REL-05) -----
 # `make bump VERSION=X.Y.Z` rewrites EVERY version site atomically (backend +
 # cli + sdks×2 + root/frontend package.json + openapi.json info.version + the
-# metadata fallback constant in main.py). The write side of the version
-# contract; `make version-check` is the read/verify side.
+# metadata fallback constant in main.py + the 5 lockfiles that embed the
+# package's own version — backend/mcp uv.lock and root/frontend/sdks-ts
+# package-lock.json, fix(#877)). The write side of the version contract;
+# `make version-check` is the read/verify side.
 bump: ## Rewrite all version sites to VERSION=X.Y.Z (single source of truth)
 ifndef VERSION
 	$(error VERSION is required: make bump VERSION=X.Y.Z)
@@ -307,8 +309,8 @@ endif
 
 # `make version-check` — version-coherence gate (REL-04). Reads every version
 # site (backend/cli/sdks×2/root+frontend package.json/openapi.json info.version/
-# main.py fallback constant) and exits non-zero if any disagree. Run in CI to
-# block a release where one site silently drifted from the rest.
+# main.py fallback constant/the 5 lockfiles) and exits non-zero if any disagree.
+# Run in CI to block a release where one site silently drifted from the rest.
 version-check: ## Assert all version sites agree (CI gate)
 	uv run --no-project python scripts/check_version_coherence.py
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -43,8 +43,11 @@ These run in CI and do not require manual checking:
 
 - **Source coherence** — `make version-check` (which runs
   `scripts/check_version_coherence.py`) asserts that every in-tree version site
-  agrees with the canonical `backend/pyproject.toml` version. The companion
-  writer, `scripts/bump_version.py`, enumerates the same set of sites.
+  agrees with the canonical `backend/pyproject.toml` version, including the five
+  lockfiles that embed the package's own version (`backend/uv.lock`,
+  `mcp/uv.lock`, and the root/`frontend`/`sdks/typescript` `package-lock.json`).
+  The companion writer, `scripts/bump_version.py`, stamps the same set of sites,
+  so no lockfile needs a hand edit at release time.
 - **Published coherence** — `.github/workflows/verify-published.yml` runs after
   a release and confirms, in a clean container, that PyPI `geolens` +
   `geolens-cli`, npm `@geolens/sdk`, the GHCR images, and the GitHub Release are

--- a/scripts/bump_version.py
+++ b/scripts/bump_version.py
@@ -21,6 +21,25 @@
                                            contract; check_docs_contract.py
                                            asserts it equals backend/pyproject)
 
+Every lockfile that embeds the package's own version is stamped too (fix(#877) —
+each of these had to be hand-stamped on past releases, and each was missed at
+least once):
+
+  - backend/uv.lock                        (the `geolens-backend` entry)
+  - mcp/uv.lock                            (`geolens-mcp` + the `geolens`
+                                           editable path entry for sdks/python)
+  - package-lock.json                      (root)
+  - frontend/package-lock.json
+  - sdks/typescript/package-lock.json      (each package-lock records its own
+                                           version TWICE: top-level and
+                                           packages."")
+
+The lockfiles are rewritten in place rather than by re-running `uv lock` /
+`npm install --package-lock-only`: a version bump changes no requirement, so the
+resolution is unchanged, and an in-place stamp needs neither uv/npm on PATH nor a
+network round-trip that could drag unrelated dependency churn into a release
+commit.
+
 The version MUST be a plain X.Y.Z semver (no suffixes) — the drift gate
 (`make version-check`) is a static equality check, and the SDK sync script
 forbids build/hash/timestamp suffixes.
@@ -54,6 +73,28 @@ PY_SDK_PYPROJECT = REPO_ROOT / "sdks" / "python" / "pyproject.toml"
 PY_SDK_GEN_CONFIG = REPO_ROOT / "sdks" / "python" / ".openapi-python-client.yaml"
 TS_SDK_PACKAGE = REPO_ROOT / "sdks" / "typescript" / "package.json"
 DOCS_CONTRACT = REPO_ROOT / "docs-contract.json"
+
+# --- Lockfiles (fix(#877)) ---------------------------------------------------
+# A uv.lock records the version of every LOCAL package it resolves: the project
+# itself, plus any editable path dependency inside this repo. mcp/ depends on
+# sdks/python, so its lock carries that package's version as well and both move
+# on a bump. Names are the `[project].name` of the owning pyproject — a rename
+# makes the bump fail loudly with "found 0" rather than skip a site.
+UV_LOCKS: tuple[tuple[Path, tuple[str, ...]], ...] = (
+    (REPO_ROOT / "backend" / "uv.lock", ("geolens-backend",)),
+    (REPO_ROOT / "mcp" / "uv.lock", ("geolens-mcp", "geolens")),
+)
+PACKAGE_LOCKS: tuple[Path, ...] = (
+    REPO_ROOT / "package-lock.json",
+    REPO_ROOT / "frontend" / "package-lock.json",
+    REPO_ROOT / "sdks" / "typescript" / "package-lock.json",
+)
+
+# `  "version": "..."` plus whatever follows the closing quote (a comma, maybe a
+# CR) so the line rebuilds byte-for-byte.
+_JSON_VERSION_LINE = re.compile(r'^(\s*"version": )"[^"]*"(.*)$')
+# The root entry of a lockfileVersion-3 `packages` map.
+_PACKAGE_LOCK_ROOT_ENTRY = re.compile(r'^\s*"": \{\s*$')
 
 
 def _rel(p: Path) -> str:
@@ -131,6 +172,63 @@ def _bump_top_level_json_version(path: Path, version: str) -> None:
     print(f"  {_rel(path)} (.version) -> {version}")
 
 
+def _bump_uv_lock(path: Path, package_names: tuple[str, ...], version: str) -> None:
+    # uv writes every entry as `[[package]]` / `name` / `version` / `source`, so
+    # anchoring on the header + name pins the one version line that belongs to
+    # this package — a same-named dependency string elsewhere can't match. The
+    # source is part of the match on purpose: only a LOCAL entry (this project or
+    # an in-repo path dep) tracks the repo version, so a package that ever became
+    # a registry dependency fails here loudly instead of being stamped wrong.
+    text = path.read_text()
+    for name in package_names:
+        pattern = re.compile(
+            rf'^(\[\[package\]\]\nname = "{re.escape(name)}"\nversion = )"[^"]*"'
+            rf"(\nsource = \{{ (?:editable|virtual|directory) )",
+            re.MULTILINE,
+        )
+        text, count = pattern.subn(rf'\g<1>"{version}"\g<2>', text, count=1)
+        if count != 1:
+            sys.exit(
+                f"ERROR: expected 1 local '{name}' [[package]] entry in {_rel(path)}, found {count}."
+            )
+    path.write_text(text)
+    for name in package_names:
+        print(f"  {_rel(path)} (package '{name}'.version) -> {version}")
+
+
+def _bump_package_lock(path: Path, version: str) -> None:
+    # npm records the package's own version twice — top-level and in the
+    # `packages` root entry — and keeps them in sync; stamping only one leaves
+    # the lock incoherent. Rewritten line-wise instead of via a json round-trip
+    # so the diff stays two lines and npm's exact formatting survives.
+    lines = path.read_text().split("\n")
+    top_idx: int | None = None
+    root_idx: int | None = None
+    in_root_entry = False
+    for i, line in enumerate(lines):
+        if _PACKAGE_LOCK_ROOT_ENTRY.match(line):
+            in_root_entry = True
+            continue
+        if not _JSON_VERSION_LINE.match(line):
+            continue
+        if in_root_entry:
+            root_idx = i
+            break
+        if top_idx is None:
+            top_idx = i
+    if top_idx is None or root_idx is None:
+        sys.exit(
+            f'ERROR: {_rel(path)} lacks a top-level "version" and/or a packages.""'
+            f' "version" line (expected the lockfileVersion 3 shape).'
+        )
+    for i in (top_idx, root_idx):
+        m = _JSON_VERSION_LINE.match(lines[i])
+        assert m is not None  # matched above
+        lines[i] = f'{m.group(1)}"{version}"{m.group(2)}'
+    path.write_text("\n".join(lines))
+    print(f'  {_rel(path)} (.version + packages."".version) -> {version}')
+
+
 def main(argv: list[str]) -> int:
     if len(argv) != 1:
         sys.exit("Usage: bump_version.py X.Y.Z")
@@ -150,6 +248,10 @@ def main(argv: list[str]) -> int:
     _bump_yaml_override(PY_SDK_GEN_CONFIG, version)
     _bump_package_json(TS_SDK_PACKAGE, version)
     _bump_top_level_json_version(DOCS_CONTRACT, version)
+    for lock, package_names in UV_LOCKS:
+        _bump_uv_lock(lock, package_names, version)
+    for lock in PACKAGE_LOCKS:
+        _bump_package_lock(lock, version)
     print(f"Done. Run `make version-check` to confirm coherence.")
     return 0
 

--- a/scripts/check_version_coherence.py
+++ b/scripts/check_version_coherence.py
@@ -23,6 +23,18 @@ Sites checked:
   - sdks/python/pyproject.toml              [project].version
   - sdks/python/.openapi-python-client.yaml package_version_override
   - sdks/typescript/package.json            .version
+  - backend/uv.lock                         package 'geolens-backend'.version
+  - mcp/uv.lock                             package 'geolens-mcp'.version and
+                                            package 'geolens'.version (the
+                                            editable sdks/python path dep)
+  - package-lock.json (root)                .version + packages."".version
+  - frontend/package-lock.json              .version + packages."".version
+  - sdks/typescript/package-lock.json       .version + packages."".version
+
+The lockfiles are checked because every one of them lagged a release at least
+once while `make bump` rewrote only the manifests (fix(#877)). Each site is read
+structurally — the package's OWN entry, not "the version string appears in the
+file" — since any dependency could coincidentally sit at the same version.
 
 The canonical version is backend/pyproject.toml — the distribution version the
 running app derives at runtime via importlib.metadata (REL-03). Every other
@@ -54,6 +66,20 @@ PY_SDK_PYPROJECT = REPO_ROOT / "sdks" / "python" / "pyproject.toml"
 PY_SDK_GEN_CONFIG = REPO_ROOT / "sdks" / "python" / ".openapi-python-client.yaml"
 TS_SDK_PACKAGE = REPO_ROOT / "sdks" / "typescript" / "package.json"
 CHANGELOG = REPO_ROOT / "CHANGELOG.md"
+
+# Lockfiles that embed the package's own version (fix(#877)). A uv.lock records
+# it for every LOCAL package it resolves — the project itself plus any editable
+# path dependency in this repo (mcp/ depends on sdks/python) — so both of mcp's
+# entries move on a bump. bump_version.py stamps this same set.
+UV_LOCKS: tuple[tuple[Path, tuple[str, ...]], ...] = (
+    (REPO_ROOT / "backend" / "uv.lock", ("geolens-backend",)),
+    (REPO_ROOT / "mcp" / "uv.lock", ("geolens-mcp", "geolens")),
+)
+PACKAGE_LOCKS: tuple[Path, ...] = (
+    REPO_ROOT / "package-lock.json",
+    REPO_ROOT / "frontend" / "package-lock.json",
+    REPO_ROOT / "sdks" / "typescript" / "package-lock.json",
+)
 
 
 def _rel(p: Path) -> str:
@@ -87,6 +113,35 @@ def _yaml_override_version(path: Path) -> str:
     if not m:
         sys.exit(f"ERROR: no package_version_override line in {_rel(path)}.")
     return m.group(1).strip()
+
+
+def _uv_lock_package_version(path: Path, name: str) -> str:
+    """The version uv.lock records for one LOCAL `[[package]]` entry."""
+    for pkg in tomllib.loads(path.read_text()).get("package", []):
+        if pkg.get("name") != name:
+            continue
+        source = pkg.get("source", {})
+        # Only a local entry (this project, or an in-repo path dep) carries the
+        # repo's version; a registry entry would be an unrelated published one.
+        if not any(k in source for k in ("editable", "virtual", "directory")):
+            sys.exit(
+                f"ERROR: '{name}' in {_rel(path)} is not a local package (source={source}); "
+                f"it no longer tracks this repo's version — update the UV_LOCKS list."
+            )
+        return pkg["version"]
+    sys.exit(f"ERROR: no '{name}' [[package]] entry in {_rel(path)}.")
+
+
+def _package_lock_versions(path: Path) -> tuple[str, str]:
+    """(top-level .version, packages[""].version) — npm records both."""
+    data = json.loads(path.read_text())
+    root = data.get("packages", {}).get("")
+    if "version" not in data or not isinstance(root, dict) or "version" not in root:
+        sys.exit(
+            f'ERROR: {_rel(path)} lacks a top-level "version" and/or a packages.""'
+            f' "version" (expected the lockfileVersion 3 shape).'
+        )
+    return data["version"], root["version"]
 
 
 def _changelog_section(version: str) -> str | None:
@@ -136,6 +191,15 @@ def main() -> int:
         _yaml_override_version(PY_SDK_GEN_CONFIG)
     )
     sites[f"{_rel(TS_SDK_PACKAGE)} (.version)"] = _package_json_version(TS_SDK_PACKAGE)
+    for lock, package_names in UV_LOCKS:
+        for name in package_names:
+            sites[f"{_rel(lock)} (package '{name}'.version)"] = (
+                _uv_lock_package_version(lock, name)
+            )
+    for lock in PACKAGE_LOCKS:
+        top, root = _package_lock_versions(lock)
+        sites[f"{_rel(lock)} (.version)"] = top
+        sites[f'{_rel(lock)} (packages."".version)'] = root
 
     # Canonical = backend distribution version (what the app derives at runtime).
     canonical = sites[f"{_rel(BACKEND_PYPROJECT)} ([project].version)"]


### PR DESCRIPTION
## What changed

`make bump VERSION=X.Y.Z` rewrote every version manifest but none of the five lockfiles that embed the package's own version, so every release hand-stamped them — and each one was missed at least once (the root `package-lock.json` sat at 1.5.1 through two releases; `mcp/uv.lock` was caught only by review on the 1.6.1 bump PR #876).

- `scripts/bump_version.py` now stamps all five lockfiles after the manifests.
- `scripts/check_version_coherence.py` reads each of them as a version site, so `make version-check` (a required CI job) goes red on a miss instead of the miss shipping.

Sites added to the gate — 10 → 19:

| Lockfile | Site(s) |
| --- | --- |
| `backend/uv.lock` | `[[package]] geolens-backend`.version |
| `mcp/uv.lock` | `geolens-mcp`.version **and** `geolens`.version (the editable `../sdks/python` path dep, whose version this bump also moves) |
| `package-lock.json` (root) | top-level `.version` **and** `packages."".version` |
| `frontend/package-lock.json` | same two |
| `sdks/typescript/package-lock.json` | same two |

Verified against the files rather than assumed: lockfileVersion 3 records the root package's version **twice** (top-level and under `packages.""`), and `mcp/uv.lock` carries a second repo-owned version because it resolves `sdks/python` as an editable path dependency. Both are stamped and both are gated independently.

Each site is read structurally (`tomllib` / `json`) — the package's *own* entry, never "the version string appears somewhere in the file" — so a dependency that happens to sit at the release version cannot satisfy the gate. Both scripts also refuse to touch a `uv.lock` entry that is not locally sourced (`editable`/`virtual`/`directory`), so a package that ever became a registry dependency fails loudly instead of being stamped with an unrelated version.

## Design choice: in-place stamp, not re-running the refreshers

A version bump changes no requirement, so the resolution is unchanged — an in-place stamp of the package's own entry is exactly what `uv lock` / `npm install --package-lock-only` would produce, minus the network round-trip that could drag unrelated dependency churn into a release commit. Proof it is equivalent: with the trial bump applied, `uv lock --check` passes in both `backend/` and `mcp/`; reverting only the lock's version line makes it fail (`The lockfile at uv.lock needs to be updated`), so uv does care about this field and agrees with what the script wrote.

## Gate evidence (red, then green)

Deliberate single-site sabotage, one per shape, each reverted after:

```
# mcp/uv.lock: geolens-mcp -> 1.6.0
FAIL: version drift detected. Canonical (backend/pyproject.toml) = '1.6.1'.
  - mcp/uv.lock (package 'geolens-mcp'.version): '1.6.0' != '1.6.1'

# package-lock.json: TOP-LEVEL only -> 1.5.1 (the real 1.6.1 miss)
FAIL: ...
  - package-lock.json (.version): '1.5.1' != '1.6.1'

# frontend/package-lock.json: packages."" ONLY -> 1.6.0
FAIL: ...
  - frontend/package-lock.json (packages."".version): '1.6.0' != '1.6.1'
```

Both halves of each package-lock are therefore gated independently. Green again after revert: `OK: all 19 version sites agree on 1.6.1.`

## Verification

| Command | Result |
| --- | --- |
| `make version-check` (current tree, 1.6.1) | pass — 19 sites agree; **no lockfile was lagging at HEAD**, nothing needed a catch-up stamp |
| `make bump VERSION=1.6.2` then `git diff --stat` | pass — every lockfile moves and nothing else does: `backend/uv.lock` 1 line, `mcp/uv.lock` 2, each `package-lock.json` 2; no dependency churn |
| `make version-check` at trial 1.6.2 | all 19 sites agree on 1.6.2; fails only on the expected missing `## [1.6.2]` CHANGELOG section |
| `cd backend && uv lock --check --offline` / `cd mcp && ...` | pass at the stamped 1.6.2; fails when the lock version is reverted by hand |
| `make bump VERSION=1.6.1` (round-trip back) | restores every site byte-identically; `git status --short` shows only the 5 files in this PR — no trial-bump residue |
| `python3 scripts/tests/test-changelog-gate.py` | 20 passed, 0 failed |
| `cd backend && uv run ruff check . && uv run ruff format --check .` | pass (846 files formatted; no backend Python touched) |

Docs/comments that enumerate the version sites are updated with the lockfiles: `Makefile` (both targets), the `version-coherence` job comment in `ci.yml`, `RELEASE.md`'s source-coherence bullet, and both script docstrings. No CHANGELOG entry — release tooling, not an operator-visible change (consistent with #866/#867/#872/#873).

Closes #877
