### PR TITLE
fix(tiles): re-mint tile tokens on tab return instead of after the 403 burst

### DIFF
--- a/frontend/src/components/builder/BuilderMap.tsx
+++ b/frontend/src/components/builder/BuilderMap.tsx
@@ -15,7 +15,7 @@ import { buildClusterTileUrl, buildSignedTileUrl, buildTileTransformRequest, isM
 import { useRemoteBasemapStyle } from '@/components/map/hooks/use-remote-basemap-style';
 import { logUnhandledMapError } from '@/lib/map-error-log';
 import { useTileTokens, useInvalidateTileTokens } from '@/hooks/use-tile-token';
-import { useTileAuthRecovery } from '@/hooks/use-tile-auth-recovery';
+import { useTileAuthRecovery, useVisibleTileTokenRefresh } from '@/hooks/use-tile-auth-recovery';
 import { useTileTokenError } from './hooks/use-tile-token-error';
 import { getEnvConfig } from '@/lib/env';
 import { pushReportEntry } from '@/lib/report';
@@ -567,6 +567,10 @@ export const BuilderMap = memo(function BuilderMap({
   // cached-token re-sign can't cure kicks one throttled token re-mint; the
   // token-sync effect re-signs sources when the fresh batch lands.
   const recoverTileAuth = useTileAuthRecovery(invalidateTileTokens);
+  // fix(#755): a tab backgrounded past the 900 s sig boundary comes back with
+  // stale tokens, so MapLibre's resumed fetches 403 before the handler above
+  // can heal them. Kick the same throttled re-mint on the visible edge.
+  useVisibleTileTokenRefresh(() => syncInputsRef.current.tokenMap.values(), recoverTileAuth);
 
   const handleLoad = useCallback(
     (e: MapLibreEvent) => {

--- a/frontend/src/components/builder/__tests__/BuilderMap.token-visibility-refresh.test.tsx
+++ b/frontend/src/components/builder/__tests__/BuilderMap.token-visibility-refresh.test.tsx
@@ -1,0 +1,250 @@
+// fix(#755): wiring pin for the proactive tile-token refresh. Tile sigs are
+// minted on 900 s `round_expiry()` boundaries, so a tab backgrounded for a few
+// minutes returns with an expired sig and MapLibre 403s every visible tile
+// before the reactive GUARD-03 / #621 handler heals the map. BuilderMap must
+// kick the SAME throttled re-mint on the visible edge of `visibilitychange`.
+//
+// The hook's own semantics (skew window, hidden-edge no-op, unmount detach) are
+// covered in hooks/__tests__/use-tile-auth-recovery.test.ts. This file pins the
+// CALL SITE: delete `useVisibleTileTokenRefresh(...)` from BuilderMap and these
+// fail. Uses the vi.hoisted fakeMap + @vis.gl/react-maplibre recipe from
+// BuilderMap.terrain-visibility.test.tsx.
+
+import type { ReactNode } from 'react';
+import { act, render } from '@/test/test-utils';
+import type { MapLayerResponse } from '@/types/api';
+import type { VectorTileToken } from '@/api/tiles';
+import { BuilderMap } from '../BuilderMap';
+
+vi.mock('@/hooks/use-settings', () => ({
+  useBasemaps: () => ({
+    data: [
+      {
+        id: 'openfreemap-positron',
+        label: 'Light',
+        url: 'https://tiles.example.com/styles/basic',
+        enabled: true,
+      },
+    ],
+  }),
+  useMapDefaults: () => ({ data: { center_lng: 0, center_lat: 0, zoom: 2 } }),
+  useTileConfig: () => ({ data: { cdn_base_url: null, mvt_source_layer_prefix: 'data' } }),
+  useEnabledPlugins: () => ({ data: [], isLoading: false }),
+}));
+
+const tileTokenState = vi.hoisted(() => ({
+  tokens: [] as Array<{ data: VectorTileToken | undefined; isLoading: boolean; isError: boolean }>,
+  invalidate: vi.fn(),
+}));
+
+vi.mock('@/hooks/use-tile-token', () => ({
+  // The re-mint the builder's recovery path calls: dropping the cached tile
+  // tokens is what forces a fresh sig.
+  useInvalidateTileTokens: () => tileTokenState.invalidate,
+  useTileTokens: () => tileTokenState.tokens,
+}));
+
+vi.mock('@/hooks/use-webgl-recovery', () => ({
+  useWebGLRecovery: () => ({ contextLost: false, reload: vi.fn() }),
+}));
+
+vi.mock('@/components/map/MapCoordReadout', () => ({ MapCoordReadout: () => null }));
+
+vi.mock('sonner', () => ({
+  toast: { error: vi.fn(), success: vi.fn(), warning: vi.fn() },
+}));
+
+// Stub the imperative style/layer writers — this test only cares that the
+// re-mint fires, not what the fake map's style ends up looking like.
+vi.mock('@/components/builder/map-sync', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/components/builder/map-sync')>();
+  return {
+    ...actual,
+    syncLayersToMap: vi.fn(),
+    applyBasemapConfigToMap: vi.fn(),
+    reorderBasemapLabels: vi.fn(),
+    reorderDataLayers: vi.fn(),
+    ensureRasterDemTerrainSource: vi.fn(),
+  };
+});
+
+type FakeMap = {
+  on: ReturnType<typeof vi.fn>;
+  off: ReturnType<typeof vi.fn>;
+  once: ReturnType<typeof vi.fn>;
+  setTransformRequest: ReturnType<typeof vi.fn>;
+  isStyleLoaded: ReturnType<typeof vi.fn>;
+  getCanvas: ReturnType<typeof vi.fn>;
+  setTerrain: ReturnType<typeof vi.fn>;
+  setProjection: ReturnType<typeof vi.fn>;
+  triggerRepaint: ReturnType<typeof vi.fn>;
+  getSource: ReturnType<typeof vi.fn>;
+  getLayer: ReturnType<typeof vi.fn>;
+  getStyle: ReturnType<typeof vi.fn>;
+  fitBounds: ReturnType<typeof vi.fn>;
+  getZoom: ReturnType<typeof vi.fn>;
+  setZoom: ReturnType<typeof vi.fn>;
+};
+
+const mapState = vi.hoisted(() => {
+  const handlers = new Map<string, Set<(payload?: unknown) => void>>();
+  const track = (event: string, handler: (payload?: unknown) => void) => {
+    const existing = handlers.get(event) ?? new Set();
+    existing.add(handler);
+    handlers.set(event, existing);
+  };
+  const fakeMap: FakeMap = {
+    on: vi.fn(track),
+    off: vi.fn((event: string, handler: (payload?: unknown) => void) => {
+      handlers.get(event)?.delete(handler);
+    }),
+    once: vi.fn(track),
+    setTransformRequest: vi.fn(),
+    isStyleLoaded: vi.fn(() => true),
+    getCanvas: vi.fn(() => ({ style: { cursor: '' }, addEventListener: vi.fn(), removeEventListener: vi.fn() })),
+    setTerrain: vi.fn(),
+    setProjection: vi.fn(),
+    triggerRepaint: vi.fn(),
+    getSource: vi.fn(() => null),
+    getLayer: vi.fn(() => null),
+    getStyle: vi.fn(() => ({ layers: [] })),
+    fitBounds: vi.fn(),
+    getZoom: vi.fn(() => 2),
+    setZoom: vi.fn(),
+  };
+  return { fakeMap, reset: () => handlers.clear() };
+});
+
+vi.mock('@vis.gl/react-maplibre', async () => {
+  const React = await import('react');
+  return {
+    Map: ({ children, onLoad }: { children?: ReactNode; onLoad?: (event: { target: FakeMap }) => void }) => {
+      React.useEffect(() => {
+        onLoad?.({ target: mapState.fakeMap });
+      }, [onLoad]);
+      return <div data-testid="mapgl">{children}</div>;
+    },
+    NavigationControl: () => null,
+    ScaleControl: () => null,
+  };
+});
+
+const DATASET_ID = 'ds-uuid-755';
+
+function vectorToken(expSeconds: number): VectorTileToken {
+  return { kind: 'vector', sig: 'sig-755', exp: expSeconds, scope: 'parcels', expires_in: 900 };
+}
+
+function makeVectorLayer(): MapLayerResponse {
+  return {
+    id: 'layer-755',
+    dataset_id: DATASET_ID,
+    dataset_name: 'Parcels',
+    dataset_geometry_type: 'Polygon',
+    dataset_table_name: 'parcels',
+    dataset_extent_bbox: null,
+    dataset_column_info: null,
+    dataset_feature_count: null,
+    dataset_sample_values: null,
+    display_name: null,
+    sort_order: 0,
+    visible: true,
+    opacity: 1,
+    paint: {},
+    layout: {},
+    filter: null,
+    label_config: null,
+    popup_config: null,
+    style_config: null,
+    layer_type: null,
+    dataset_record_type: 'vector_dataset',
+    show_in_legend: true,
+    is_dem: false,
+    dem_vertical_units: null,
+  } as unknown as MapLayerResponse;
+}
+
+function setVisibility(state: 'visible' | 'hidden') {
+  Object.defineProperty(document, 'visibilityState', { configurable: true, get: () => state });
+}
+
+async function renderBuilderMap() {
+  await act(async () => {
+    render(<BuilderMap layers={[makeVectorLayer()]} basemapStyle="openfreemap-positron" />);
+  });
+}
+
+describe('BuilderMap proactive tile-token refresh on tab return (fix #755)', () => {
+  beforeEach(() => {
+    mapState.reset();
+    tileTokenState.invalidate.mockClear();
+    setVisibility('visible');
+  });
+
+  afterEach(() => {
+    setVisibility('visible');
+  });
+
+  it('re-mints when the tab becomes visible with an expired sig', async () => {
+    tileTokenState.tokens = [
+      { data: vectorToken(Math.floor(Date.now() / 1000) - 120), isLoading: false, isError: false },
+    ];
+    await renderBuilderMap();
+    // Mount itself must not re-mint — the mount race is a separate concern.
+    expect(tileTokenState.invalidate).not.toHaveBeenCalled();
+
+    await act(async () => {
+      document.dispatchEvent(new Event('visibilitychange'));
+    });
+
+    expect(tileTokenState.invalidate).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not re-mint when the sig is still comfortably fresh', async () => {
+    tileTokenState.tokens = [
+      { data: vectorToken(Math.floor(Date.now() / 1000) + 900), isLoading: false, isError: false },
+    ];
+    await renderBuilderMap();
+
+    await act(async () => {
+      document.dispatchEvent(new Event('visibilitychange'));
+    });
+
+    expect(tileTokenState.invalidate).not.toHaveBeenCalled();
+  });
+
+  it('does not re-mint on the hidden edge (a paused map drops the setTiles reload)', async () => {
+    tileTokenState.tokens = [
+      { data: vectorToken(Math.floor(Date.now() / 1000) - 120), isLoading: false, isError: false },
+    ];
+    await renderBuilderMap();
+
+    setVisibility('hidden');
+    await act(async () => {
+      document.dispatchEvent(new Event('visibilitychange'));
+    });
+
+    expect(tileTokenState.invalidate).not.toHaveBeenCalled();
+  });
+
+  it('stops re-minting once the map unmounts (no leaked visibilitychange listener)', async () => {
+    tileTokenState.tokens = [
+      { data: vectorToken(Math.floor(Date.now() / 1000) - 120), isLoading: false, isError: false },
+    ];
+    let unmount: () => void = () => {};
+    await act(async () => {
+      ({ unmount } = render(
+        <BuilderMap layers={[makeVectorLayer()]} basemapStyle="openfreemap-positron" />,
+      ));
+    });
+
+    await act(async () => {
+      unmount();
+    });
+    await act(async () => {
+      document.dispatchEvent(new Event('visibilitychange'));
+    });
+
+    expect(tileTokenState.invalidate).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/dataset/DatasetMap.tsx
+++ b/frontend/src/components/dataset/DatasetMap.tsx
@@ -11,7 +11,7 @@ import { useFeatureEditing, showAllFeaturesInTiles } from '@/components/dataset/
 import { DrawingToolbar } from '@/components/drawing/DrawingToolbar';
 import { AttributeForm } from '@/components/drawing/AttributeForm';
 import { useTileToken, useInvalidateTileTokens } from '@/hooks/use-tile-token';
-import { useTileAuthRecovery } from '@/hooks/use-tile-auth-recovery';
+import { useTileAuthRecovery, useVisibleTileTokenRefresh } from '@/hooks/use-tile-auth-recovery';
 import { useMapLayers, getSourceLayerName } from '@/components/maps/hooks/use-map-layers';
 import { computeLargeExtentView, isLargeExtent } from '@/lib/map-extent';
 import { findElevationColumn } from '@/lib/geo-utils';
@@ -170,6 +170,10 @@ export const DatasetMap = memo(function DatasetMap({
   // token re-mint; the refreshed token re-renders the declarative <Source>
   // with a freshly signed URL.
   const recoverTileAuth = useTileAuthRecovery(invalidateTileTokens);
+  // fix(#755): a tab backgrounded past the 900 s sig boundary comes back with
+  // stale tokens, so MapLibre's resumed fetches 403 before the error handler
+  // can heal them. Kick the same throttled re-mint on the visible edge.
+  useVisibleTileTokenRefresh(() => [rawTileToken], recoverTileAuth);
   const tileAuthErrorHandlerRef = useRef<((e: { error?: { status?: number } }) => void) | null>(null);
   // fix(#430 V-13): dataset-detail preview map had no data-tiles-loaded signal at
   // all. Mirror the re-arming ViewerMap/BuilderMap behavior: false while a

--- a/frontend/src/components/viewer/ViewerMap.tsx
+++ b/frontend/src/components/viewer/ViewerMap.tsx
@@ -16,7 +16,7 @@ import { useRemoteBasemapStyle } from '@/components/map/hooks/use-remote-basemap
 import { logUnhandledMapError } from '@/lib/map-error-log';
 import { useWebGLRecovery } from '@/hooks/use-webgl-recovery';
 import { useInvalidateTileTokens } from '@/hooks/use-tile-token';
-import { useTileAuthRecovery } from '@/hooks/use-tile-auth-recovery';
+import { useTileAuthRecovery, useVisibleTileTokenRefresh } from '@/hooks/use-tile-auth-recovery';
 import { useViewerTokens } from '@/components/viewer/hooks/use-viewer-tokens';
 import { isViewerTerrainExpected, useViewerTerrain } from '@/components/viewer/hooks/use-viewer-terrain';
 import { FeaturePopup, type FeatureInfo } from '@/components/map/FeaturePopup';
@@ -189,6 +189,10 @@ export const ViewerMap = memo(function ViewerMap({
   // fix(#621): shared tile-auth recovery — a vector tile 401/403 kicks one
   // throttled token re-mint; the token-refresh effect below re-signs sources.
   const recoverTileAuth = useTileAuthRecovery(refreshTokens);
+  // fix(#755): a tab backgrounded past the 900 s sig boundary comes back with
+  // stale tokens, so MapLibre's resumed fetches 403 before the error handler
+  // can heal them. Kick the same throttled re-mint on the visible edge.
+  useVisibleTileTokenRefresh(() => tokenMap.values(), recoverTileAuth);
 
   // fix(#452): the bound DEM's LIVE visibility (legend eye toggle). Saved
   // visibility is handled inside the hook (HT-12); this covers the client-side

--- a/frontend/src/hooks/__tests__/use-tile-auth-recovery.test.ts
+++ b/frontend/src/hooks/__tests__/use-tile-auth-recovery.test.ts
@@ -1,5 +1,10 @@
 import { renderHook } from '@testing-library/react';
-import { useTileAuthRecovery } from '@/hooks/use-tile-auth-recovery';
+import {
+  hasExpiringVectorToken,
+  useTileAuthRecovery,
+  useVisibleTileTokenRefresh,
+} from '@/hooks/use-tile-auth-recovery';
+import type { TileToken } from '@/api/tiles';
 
 // fix(#621): one re-mint per cooldown window — MapLibre can fire dozens of
 // tile errors per pan, and hammering the mint endpoint cannot help. Errors in
@@ -55,5 +60,150 @@ describe('useTileAuthRecovery', () => {
     nowSpy.mockReturnValue(now + 31_000);
     expect(result.current()).toBe(true);
     expect(remint).toHaveBeenCalledTimes(2);
+  });
+});
+
+// fix(#755): tile sigs are minted on 900 s `round_expiry()` boundaries, so a tab
+// backgrounded for a few minutes routinely returns with an expired token and
+// MapLibre 403s every visible tile before the reactive handler heals the map.
+// The proactive path re-mints on the VISIBLE edge instead — on the hidden edge a
+// `setTiles` reload would be dropped by the paused TileManager (fix(#584)).
+
+function vectorToken(expSeconds: number): TileToken {
+  return { kind: 'vector', sig: 's', exp: expSeconds, scope: 'x', expires_in: 900 };
+}
+
+const rasterToken: TileToken = {
+  kind: 'raster',
+  tile_url: '/raster-tiles/x/tiles/{z}/{x}/{y}.png',
+  bounds: null,
+  minzoom: 0,
+  maxzoom: 18,
+  tile_size: 256,
+  format: 'png',
+};
+
+function setVisibility(state: 'visible' | 'hidden') {
+  Object.defineProperty(document, 'visibilityState', {
+    configurable: true,
+    get: () => state,
+  });
+}
+
+/** Unix-seconds `exp` relative to now, matching the mint endpoint's shape. */
+function expIn(seconds: number): number {
+  return Math.floor(Date.now() / 1000) + seconds;
+}
+
+describe('hasExpiringVectorToken (fix #755)', () => {
+  const now = 1_785_148_200_000; // ms
+  const nowS = now / 1000;
+
+  it('flags a token already past exp', () => {
+    expect(hasExpiringVectorToken([vectorToken(nowS - 1)], now)).toBe(true);
+  });
+
+  it('flags a token inside the 60s skew window', () => {
+    expect(hasExpiringVectorToken([vectorToken(nowS + 30)], now)).toBe(true);
+    expect(hasExpiringVectorToken([vectorToken(nowS + 60)], now)).toBe(true);
+  });
+
+  it('leaves a comfortably fresh token alone', () => {
+    expect(hasExpiringVectorToken([vectorToken(nowS + 61)], now)).toBe(false);
+    expect(hasExpiringVectorToken([vectorToken(nowS + 900)], now)).toBe(false);
+  });
+
+  it('ignores raster tokens (no exp — auth rides the Authorization header)', () => {
+    expect(hasExpiringVectorToken([rasterToken], now)).toBe(false);
+  });
+
+  it('ignores empty / absent entries', () => {
+    expect(hasExpiringVectorToken([], now)).toBe(false);
+    expect(hasExpiringVectorToken([undefined, null], now)).toBe(false);
+  });
+
+  it('flags the batch when ANY token in it is expiring', () => {
+    expect(
+      hasExpiringVectorToken([vectorToken(nowS + 900), rasterToken, vectorToken(nowS - 5)], now),
+    ).toBe(true);
+  });
+});
+
+describe('useVisibleTileTokenRefresh (fix #755)', () => {
+  afterEach(() => {
+    setVisibility('visible');
+    vi.restoreAllMocks();
+  });
+
+  it('re-mints on the visible edge when the token has expired (kills the 403 burst)', () => {
+    const recover = vi.fn(() => true);
+    const expired = vectorToken(expIn(-60));
+    renderHook(() => useVisibleTileTokenRefresh(() => [expired], recover));
+
+    setVisibility('visible');
+    document.dispatchEvent(new Event('visibilitychange'));
+
+    expect(recover).toHaveBeenCalledTimes(1);
+  });
+
+  it('does nothing while the tab is still hidden (setTiles reload would be dropped)', () => {
+    const recover = vi.fn(() => true);
+    const expired = vectorToken(expIn(-60));
+    renderHook(() => useVisibleTileTokenRefresh(() => [expired], recover));
+
+    setVisibility('hidden');
+    document.dispatchEvent(new Event('visibilitychange'));
+
+    expect(recover).not.toHaveBeenCalled();
+  });
+
+  it('does not re-mint when the tokens are still fresh', () => {
+    const recover = vi.fn(() => true);
+    const fresh = vectorToken(expIn(900));
+    renderHook(() => useVisibleTileTokenRefresh(() => [fresh], recover));
+
+    document.dispatchEvent(new Event('visibilitychange'));
+
+    expect(recover).not.toHaveBeenCalled();
+  });
+
+  it('reads the CURRENT tokens at event time, not the ones captured at mount', () => {
+    const recover = vi.fn(() => true);
+    let tokens: TileToken[] = [vectorToken(expIn(900))];
+    const { rerender } = renderHook(() => useVisibleTileTokenRefresh(() => tokens, recover));
+
+    document.dispatchEvent(new Event('visibilitychange'));
+    expect(recover).not.toHaveBeenCalled();
+
+    tokens = [vectorToken(expIn(-60))];
+    rerender();
+    document.dispatchEvent(new Event('visibilitychange'));
+    expect(recover).toHaveBeenCalledTimes(1);
+  });
+
+  it('detaches the listener on unmount', () => {
+    const recover = vi.fn(() => true);
+    const expired = vectorToken(expIn(-60));
+    const { unmount } = renderHook(() => useVisibleTileTokenRefresh(() => [expired], recover));
+
+    unmount();
+    document.dispatchEvent(new Event('visibilitychange'));
+
+    expect(recover).not.toHaveBeenCalled();
+  });
+
+  it('rides the shared recovery throttle instead of minting per visibility flip', () => {
+    // The proactive path is the SAME callback the 403 handler uses, so its
+    // cooldown bounds the mint rate across rapid tab switching.
+    const remint = vi.fn();
+    const expired = vectorToken(expIn(-60));
+    const { result } = renderHook(() => useTileAuthRecovery(remint));
+    renderHook(() => useVisibleTileTokenRefresh(() => [expired], result.current));
+
+    document.dispatchEvent(new Event('visibilitychange'));
+    document.dispatchEvent(new Event('visibilitychange'));
+    document.dispatchEvent(new Event('visibilitychange'));
+
+    expect(remint).toHaveBeenCalledTimes(1);
   });
 });

--- a/frontend/src/hooks/use-tile-auth-recovery.ts
+++ b/frontend/src/hooks/use-tile-auth-recovery.ts
@@ -1,4 +1,5 @@
-import { useCallback, useRef } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
+import type { TileToken } from '@/api/tiles';
 
 // fix(#621): one re-mint per cooldown window bounds the retry loop — MapLibre
 // can fire dozens of tile errors per pan, and a mint that just failed will not
@@ -41,4 +42,64 @@ export function useTileAuthRecovery(remint: () => void) {
     remint();
     return true;
   }, [remint]);
+}
+
+// fix(#755): a sig that expires seconds from now is already useless — MapLibre's
+// resumed tile requests would reach the server after the boundary. Treat any
+// vector token inside this window as due for a re-mint.
+const EXPIRY_SKEW_MS = 60_000;
+
+/**
+ * fix(#755): true when any vector token is past `exp` or within
+ * EXPIRY_SKEW_MS of it. Raster tokens carry no expiry (their `tile_url` is
+ * stable and auth rides the Authorization header), so they never qualify.
+ * `exp` is the unix-seconds expiry the mint endpoint stamps into the tile URL.
+ */
+export function hasExpiringVectorToken(
+  tokens: Iterable<TileToken | null | undefined>,
+  nowMs: number = Date.now(),
+): boolean {
+  for (const token of tokens) {
+    if (token?.kind !== 'vector') continue;
+    if (token.exp * 1000 - nowMs <= EXPIRY_SKEW_MS) return true;
+  }
+  return false;
+}
+
+/**
+ * fix(#755): re-mint tile tokens on the tab-return edge instead of after the
+ * 403 burst. Tile sigs are minted on `round_expiry()` 900 s boundaries, so a
+ * tab backgrounded for a few minutes routinely crosses one; MapLibre then
+ * resumes its fetches with the stale `sig` and every visible tile 403s before
+ * the reactive GUARD-03 / #621 handler heals the map.
+ *
+ * Deliberately the SAME `recover` callback the 403 handler uses, so this only
+ * pulls the existing re-mint forward: its 30 s cooldown / 10 s settle window
+ * still bound the mint rate, and a 403 that does slip through now lands inside
+ * the settle window, where it is reported suppressed instead of surfacing
+ * error UI.
+ *
+ * `getTokens` is read at event time (not captured), so the listener registers
+ * once and still sees the current token set.
+ *
+ * Fires on the VISIBLE edge only: MapLibre 5 drops a `setTiles` reload while
+ * the source's TileManager is paused (fix(#584)) and a hidden tab has no rAF,
+ * so re-minting while still hidden would silently no-op.
+ */
+export function useVisibleTileTokenRefresh(
+  getTokens: () => Iterable<TileToken | null | undefined>,
+  recover: () => boolean,
+): void {
+  const getTokensRef = useRef(getTokens);
+  getTokensRef.current = getTokens;
+
+  useEffect(() => {
+    const onVisibilityChange = () => {
+      if (document.visibilityState !== 'visible') return;
+      if (!hasExpiringVectorToken(getTokensRef.current())) return;
+      recover();
+    };
+    document.addEventListener('visibilitychange', onVisibilityChange);
+    return () => document.removeEventListener('visibilitychange', onVisibilityChange);
+  }, [recover]);
 }


### PR DESCRIPTION
Frontend only. No schema, API, or config impact. No new `t()` keys.

## Half 1 — proactive re-mint on tab return (the outstanding half)

Tile sigs are minted on `round_expiry()` 900 s boundaries (`backend/app/processing/tiles/signing.py`), so a signed URL lives 15–30 min. A tab backgrounded for a few minutes routinely crosses a boundary; on return MapLibre resumes its fetches with the stale `sig` and every visible vector tile 403s. The reactive GUARD-03 / #621 handler does heal the map, but only after a full round trip, and the burst is what the user and the problem report see.

`useVisibleTileTokenRefresh` now sits next to `useTileAuthRecovery` in `frontend/src/hooks/use-tile-auth-recovery.ts` and is called from the three surfaces that already own tile-auth recovery — `BuilderMap`, `ViewerMap`, `DatasetMap`. On the visible edge of `visibilitychange` it inspects the tokens the surface already holds (`exp` is on every vector token) and, when any is past expiry or within 60 s of it, kicks the **same** throttled re-mint the 403 handler uses. The fresh batch then flows through each surface's existing token→`setTiles` plumbing.

Three things this deliberately does *not* do:

- **No parallel refresh path.** It calls the surface's existing `recoverTileAuth`, so the existing 30 s cooldown / 10 s settle window still bounds the mint rate across rapid tab flipping, and a 403 that still slips through now arrives *inside* the settle window — where it is reported suppressed instead of surfacing error UI.
- **Nothing on the hidden edge.** MapLibre 5 drops a `setTiles` reload while the source's `TileManager` is paused (#584) and a hidden tab has no rAF, so a re-mint issued before the tab is back would silently no-op.
- **Nothing at mount.** The builder's mount-time token race is a separate concern; a test pins that mount does not re-mint.

The listener is removed on unmount, and `getTokens` is read at event time rather than captured, so the listener registers once and still sees the current token set.

Raster tokens are skipped — they carry no `exp` (stable `tile_url`, auth rides the `Authorization` header via `setTransformRequest`).

## Half 2 — handled 403s no longer double-log

Already shipped in #808: `logUnhandledMapError` (`frontend/src/lib/map-error-log.ts`) is the `<Map onError>` prop on all three surfaces and drops the react-maplibre wrapper's `console.error` fallback for exactly the handled first-party vector-tile 401/403 case, keeping it for everything else (raster/DEM, 404 no-data, 5xx, status-less style errors). Verified wired on all three surfaces and re-ran its check (`frontend/src/lib/__tests__/map-error-log.test.ts`, 14 tests) as part of this PR's gates. No further change was needed.

## Verification

All run from `frontend/`:

| Command | Result |
| --- | --- |
| `npx vitest run src/hooks/__tests__/use-tile-auth-recovery.test.ts` | pass — 16 tests |
| `npx vitest run src/components/builder/__tests__/BuilderMap.token-visibility-refresh.test.tsx` | pass — 4 tests |
| `npx vitest run src/lib/__tests__/map-error-log.test.ts src/hooks src/components/builder src/components/viewer src/components/dataset` | pass — 191 files / 2479 tests |
| `npx vitest run` (full suite) | pass — 354 files / 4121 tests |
| `npm run lint` | pass |
| `npm run typecheck` | pass |

Mutation-checked the wiring pin: commenting out the `useVisibleTileTokenRefresh(...)` call in `BuilderMap.tsx` fails `BuilderMap.token-visibility-refresh.test.tsx` (1 failed / 3 passed), so the call site cannot be deleted silently.

## Runnable checks left behind

- `frontend/src/hooks/__tests__/use-tile-auth-recovery.test.ts` — skew window boundaries (past `exp`, +30 s, +60 s in; +61 s out), raster/empty/absent entries ignored, visible edge fires, hidden edge does not, tokens read at event time not mount, listener detached on unmount, repeated visibility flips mint once.
- `frontend/src/components/builder/__tests__/BuilderMap.token-visibility-refresh.test.tsx` — the call site itself: expired sig + `visibilitychange` re-mints once, fresh sig does not, hidden edge does not, mount does not, unmounted map does not.
- `frontend/src/lib/__tests__/map-error-log.test.ts` — the existing double-log check (unchanged).

Closes #755
