### PR TITLE
fix(tiles): emit the real cluster split zoom as expansion_zoom

### DIFF
--- a/backend/app/processing/tiles/router.py
+++ b/backend/app/processing/tiles/router.py
@@ -1589,10 +1589,10 @@ def _ensure_clusterable_dataset(meta: _DatasetMeta) -> None:
 def _cluster_cache_table_key(
     table_name: str, *, cluster_radius: int, cluster_max_zoom: int
 ) -> str:
-    # fix(#868): "v2" versions the cluster SQL semantics. Bump it whenever
-    # _build_cluster_tile_query changes the emitted tile geometry/properties,
-    # or a deploy keeps serving stale-geometry cluster tiles until TTL expiry.
-    return f"{table_name}:cluster:v2:r{cluster_radius}:z{cluster_max_zoom}"
+    # fix(#868): the version tag pins the cluster SQL semantics. Bump it whenever
+    # _build_cluster_tile_query changes the emitted tile geometry/properties, or a
+    # deploy keeps serving stale cluster tiles until TTL expiry. v2 -> v3: #874.
+    return f"{table_name}:cluster:v3:r{cluster_radius}:z{cluster_max_zoom}"
 
 
 async def _acquire_and_serve_tile(

--- a/backend/app/processing/tiles/service.py
+++ b/backend/app/processing/tiles/service.py
@@ -351,6 +351,17 @@ def _build_cluster_tile_query(
     the tile (all past-max-zoom points; every cell whose centroid is
     in-tile).
 
+    fix(#874): ``expansion_zoom`` is derived per cluster instead of shipping
+    ``cluster_max_zoom + 1`` for every one of them. The bucket grid halves per
+    zoom, so the split zoom is the smallest zoom at which the cell's extreme
+    members fall in different cells of the same world-min-anchored grid —
+    exactly where this query would stop grouping them. Clamped to
+    ``cluster_max_zoom + 1`` (a cell that still holds together there expands
+    to raw points at the next zoom) and to MapLibre's ceiling of 22. Under
+    input-cap saturation the spread comes from the visible members only, so
+    the value can land later than the true split zoom — the pre-#874
+    behaviour — never earlier.
+
     Cluster output follows the MapLibre client-side cluster property shape:
     clustered features carry ``point_count`` and ``point_count_abbreviated``;
     unclustered features omit those properties and carry ``source_gid``.
@@ -500,6 +511,12 @@ grouped AS (
         bucket_y,
         count(*)::integer AS raw_point_count,
         min(gid)::bigint AS source_gid,
+        -- fix(#874): member spread, in exact double precision (ST_Extent would
+        -- return a float4-rounded box). Feeds the expansion_zoom derivation.
+        min(ST_X(geom_3857)) AS min_x,
+        max(ST_X(geom_3857)) AS max_x,
+        min(ST_Y(geom_3857)) AS min_y,
+        max(ST_Y(geom_3857)) AS max_y,
         ST_Centroid(ST_Collect(geom_3857)) AS geom_3857
     FROM anchored, bounds
     -- fix(#868, codex round 4 on PR #872): ownership applies BEFORE the
@@ -555,9 +572,27 @@ features AS (
                 THEN md5($1::text || ':' || $2::text || ':' || $3::text || ':' || grouped.bucket_x::text || ':' || grouped.bucket_y::text)
             ELSE NULL
         END AS cluster_id,
+        -- fix(#874): the zoom at which THIS cell actually splits, not a
+        -- constant. Bucket size halves per zoom, so the cell at zoom zz uses
+        -- bucket / 2^(zz - z) on the same world-min-anchored grid as the
+        -- `bucketed` CTE: the split zoom is the smallest zz where the cell's
+        -- extreme members no longer share one cell in x or in y. Nothing
+        -- clusters past cluster max zoom, so a cell that still holds together
+        -- there expands to raw points at $5 + 1; 22 is the MapLibre ceiling.
         CASE
             WHEN grouped.raw_point_count > 1 AND $1::integer <= $5::integer
-                THEN LEAST($5::integer + 1, 22)
+                THEN LEAST(COALESCE((
+                    SELECT min(zz)
+                    FROM generate_series($1::integer + 1, $5::integer) AS zz,
+                        LATERAL (SELECT
+                            GREATEST(grid.bucket_w / power(2::float8, zz - $1::integer), 1.0) AS bw,
+                            GREATEST(grid.bucket_h / power(2::float8, zz - $1::integer), 1.0) AS bh
+                        ) split
+                    WHERE floor((grouped.min_x - grid.world_min_x) / split.bw)
+                            <> floor((grouped.max_x - grid.world_min_x) / split.bw)
+                       OR floor((grouped.min_y - grid.world_min_y) / split.bh)
+                            <> floor((grouped.max_y - grid.world_min_y) / split.bh)
+                ), $5::integer + 1), 22)
             ELSE NULL
         END AS expansion_zoom,
         grouped.source_gid{unclustered_attr_select},
@@ -581,7 +616,7 @@ features AS (
             256,
             true
         ) AS geom
-    FROM grouped{unclustered_attr_join}, bounds
+    FROM grouped{unclustered_attr_join}, bounds, grid
 )
 SELECT ST_AsMVT(features.*, $4::text, 4096, 'geom', 'gid')
 FROM features

--- a/backend/tests/test_mvt_audit_fixes.py
+++ b/backend/tests/test_mvt_audit_fixes.py
@@ -240,6 +240,21 @@ def test_cluster_query_buckets_on_absolute_3857_grid():
     assert "LEAST(GREATEST(ST_X(grouped.geom_3857)" in query
 
 
+def test_cluster_query_derives_expansion_zoom_from_member_spread():
+    """fix(#874): expansion_zoom is the cluster's own split zoom, derived from
+    the member spread against the halving bucket grid — not the constant
+    cluster_max_zoom + 1 that made click-to-zoom jump from z2 to z15."""
+    query = _build_cluster_tile_query("places")
+    assert "THEN LEAST($5::integer + 1, 22)" not in query
+    # The cell's spread in exact double precision (not a float4 ST_Extent box).
+    assert "min(ST_X(geom_3857)) AS min_x" in query
+    # Smallest zoom above the current one where the extremes stop sharing a
+    # cell, with the bucket halved per zoom; falls back to $5 + 1, capped at 22.
+    assert "FROM generate_series($1::integer + 1, $5::integer) AS zz" in query
+    assert "grid.bucket_w / power(2::float8, zz - $1::integer)" in query
+    assert "), $5::integer + 1), 22)" in query
+
+
 # ---------------------------------------------------------------------------
 # fix(#394) B-019/VT-01: reupload purges the MVT tile cache post-commit
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_tiles.py
+++ b/backend/tests/test_tiles.py
@@ -381,9 +381,10 @@ class TestTileEndpoint:
         assert resp.status_code == 200
         # fix(#403): the cluster endpoint now supports the cols= opt-in, so
         # its cache lookups carry a cols_key segment (empty without cols=).
-        # fix(#868): the key carries the cluster SQL semantic version (v2).
+        # fix(#868): the key carries the cluster SQL semantic version, bumped to
+        # v3 by fix(#874) (per-cluster expansion_zoom) so deploys drop stale tiles.
         mock_cache.get.assert_awaited_once_with(
-            f"{table_name}:cluster:v2:r64:z12", 0, 0, 0, cols_key=""
+            f"{table_name}:cluster:v3:r64:z12", 0, 0, 0, cols_key=""
         )
 
     async def test_empty_tile_returns_204(
@@ -756,7 +757,7 @@ class TestClusterBucketSemantics:
         # the prepared statement still binds all six parameters.
         return head + (
             "SELECT $4::text AS layer_name, cluster, point_count,\n"
-            "    point_count_abbreviated, source_gid, name,\n"
+            "    point_count_abbreviated, expansion_zoom, source_gid, name,\n"
             "    ST_X(geom) AS mvt_x, ST_Y(geom) AS mvt_y\n"
             "FROM features\nWHERE geom IS NOT NULL"
         )
@@ -1057,6 +1058,72 @@ class TestClusterBucketSemantics:
         assert 0 <= owner_rows[0]["mvt_y"] <= 4096
         # The neighbor (which contains the raw centroid) emits nothing.
         assert len(neighbor_rows) == 0
+
+    async def test_expansion_zoom_is_the_cluster_split_zoom(self, test_db_session):
+        """fix(#874): expansion_zoom is the zoom at which THIS cluster stops
+        sharing one bucket cell, not the constant cluster_max_zoom + 1 the
+        query used to emit for every cluster (click-to-zoom on a z2
+        continent-sized cluster jumped straight to z15).
+
+        Three pairs, each alone in its own cell of one z2 tile, so one query
+        returns three clusters with three different honest values.
+        """
+        from app.processing.tiles.pool import get_tile_pool
+
+        table_name = f"cluster_expand_{uuid.uuid4().hex[:8]}"
+        # z2 grid: bucket = tile width * 48 CSS px * 8 extent units/px / 4096.
+        bucket = (_WEB_MERCATOR_WORLD_WIDTH / 4) * 48 * (4096 / 512) / 4096
+
+        # Cells 12/15/18 have their origins inside tile (2, 1, 1); y is shared
+        # within each pair, so only the x spread can split a cell. Inside cell
+        # k the zoom-(2+n) cell boundaries sit at offsets j/2^n, and
+        # floor((k + offset) * 2^n) == k * 2^n + floor(offset * 2^n), so the
+        # split zoom depends on the offsets alone, not on k.
+        def at(cell: int, offset: float) -> float:
+            return _WORLD_MIN + (cell + offset) * bucket
+
+        y = 5_000_000.0
+        points = (
+            # gid 1-2: offsets 0.4 / 0.6 straddle the cell's z3 midline.
+            ("wide_a", at(12, 0.4), y),
+            ("wide_b", at(12, 0.6), y),
+            # gid 3-4: offsets 0.1 / 0.105. floor(o * 2^n) first differs at
+            # n = 7 (12.8 vs 13.44), so this pair holds together until z9.
+            ("tight_a", at(15, 0.1), y),
+            ("tight_b", at(15, 0.105), y),
+            # gid 5-6: half a metre apart, with no cell boundary between them
+            # at any zoom <= 14 (the z14 bucket is ~229 m) — the pair never
+            # splits while clustering is active, so the clamp still applies.
+            ("never_a", at(18, 0.1), y),
+            ("never_b", at(18, 0.1) + 0.5, y),
+        )
+        await _create_cluster_semantics_table(
+            test_db_session, table_name, points=points
+        )
+
+        try:
+            pool = get_tile_pool()
+            rows = await pool.fetch(
+                self._rows_sql(table_name),
+                2,  # z
+                1,  # x
+                1,  # y
+                f"data.{table_name}",
+                14,  # cluster_max_zoom
+                48,  # cluster_radius, CSS px
+            )
+        finally:
+            await _cleanup_data_table(test_db_session, table_name)
+
+        assert len(rows) == 3
+        assert all(r["cluster"] is True and r["point_count"] == 2 for r in rows)
+        # Clusters carry no attributes, so key them by source_gid = min(gid).
+        # Pre-#874 every value here was 15.
+        assert {r["source_gid"]: r["expansion_zoom"] for r in rows} == {
+            1: 3,  # wide pair: splits at the very next zoom
+            3: 9,  # tight pair: 7 halvings of the bucket
+            5: 15,  # never splits by cluster_max_zoom -> cluster_max_zoom + 1
+        }
 
     async def test_feature_cap_applies_after_ownership(self, test_db_session):
         """fix(#868, codex round 4): the feature cap applies AFTER the


### PR DESCRIPTION
## What

Server cluster tiles emitted `expansion_zoom = LEAST(cluster_max_zoom + 1, 22)` for **every** cluster, so click-to-zoom on a continent-sized z2 cluster jumped straight to z15 instead of one meaningful step. MapLibre's client-side clustering returns the zoom at which that specific cluster splits; `frontend/src/components/map/cluster-interactions.ts` feeds the property straight into `easeTo`.

`_build_cluster_tile_query` now derives the value per cluster:

- `grouped` carries the cell's member spread (`min`/`max` of X and Y). Explicit aggregates rather than `ST_Extent`, whose box2d rounds through float4.
- `expansion_zoom` is the smallest zoom above the current one at which the extreme members stop sharing a cell of the same world-min-anchored grid #872 built. Bucket size halves per zoom, so the grid at zoom `zz` is `bucket / 2^(zz - z)` — the derived zoom is exactly where this query stops grouping the members.
- The clamps stay: `cluster_max_zoom + 1` (nothing clusters past that zoom, so a cell that still holds together there expands to raw points at the next one) and MapLibre's ceiling of 22.

No frontend change — the client already clamps the property to `[0, 22]`.

## Cache-key bump (v2 -> v3)

`_cluster_cache_table_key` in `backend/app/processing/tiles/router.py` goes `:cluster:v2:` -> `:cluster:v3:`. This is load-bearing: without it a deploy keeps serving Valkey-cached cluster tiles carrying the old constant until TTL expiry. Same reason #872 introduced the tag. The edit is line-neutral, so the exact LOC ratchet on `tiles/router.py` (2047) still holds.

## Degradation and cost

Under input-cap saturation the spread comes from the visible members only, so the value can land *later* than the true split zoom — the pre-fix behaviour — never earlier.

Cost, measured on a throwaway 200k-point table (dense z2 tile, 99 clusters, 5 runs each): **245 ms median before, 253 ms after**. The derivation runs once per emitted cell, and a clustering-zoom tile holds ~100-160 cells; past `cluster_max_zoom` the `CASE` never reaches it.

## Verification

All on the host against Postgres at localhost:5434.

- `cd backend && uv run ruff check .` -> `All checks passed!`
- `cd backend && uv run ruff format --check .` -> `846 files already formatted`
- `uv run pytest tests/test_tiles.py -k ClusterBucketSemantics` -> **9 passed** (8 existing #868 grid tests plus the new one)
- `uv run pytest tests/test_tiles.py tests/test_mvt_audit_fixes.py tests/test_tile_cache_cols_key.py tests/test_tile_cache_scope_sec009.py tests/test_tile_signing.py tests/test_vector_tile_auth.py tests/test_embed_tokens.py tests/test_tile_gzip_offload_perf005.py tests/test_layering.py tests/test_api_contract_openapi.py` -> **201 passed**
- Old-behaviour check: with the derivation swapped back for `LEAST($5 + 1, 22)`, the new test fails with `assert {1: 15, 3: 15, 5: 15} == {1: 3, 3: 9, 5: 15}`.

## Tests

`test_expansion_zoom_is_the_cluster_split_zoom` puts three pairs in three cells of one z2 tile, so a single query returns three clusters with three different honest values:

| pair | offsets within the cell | expansion_zoom |
| --- | --- | --- |
| wide | 0.4 / 0.6 (straddles the z3 midline) | 3 |
| tight | 0.1 / 0.105 (`floor(o * 2^n)` first differs at n=7) | 9 |
| never splits | 0.5 m apart, no boundary between them by z14 | 15 (the `cluster_max_zoom + 1` clamp) |

`test_cluster_query_derives_expansion_zoom_from_member_spread` pins the query shape next to the existing #868 shape tests, and the cache-key assertion in `test_cluster_tile_cache_key_includes_options` moves to v3.

No schema, API, or config impact.

Closes #874

## Deploy step

Purge the CDN tile cache at the deploy that ships this, same as #872 required. The `:v3` bump
invalidates the server-side Valkey key, but public tile *URLs* are keyed on the dataset's
`tile_version`, which does not move for a SQL-semantics change. On the default config the
exposure is small — `TILE_CACHE_TTL=300` plus a content-addressed ETag means the first
revalidation after five minutes picks up the new `expansion_zoom` — but the demo's Cloudflare
tile Cache Rule caches by URL at a longer edge TTL and needs an explicit purge.

Raised by the codex review on this PR; declined as a code change (threading a cluster-SQL
version constant into frontend URL construction is cross-layer coupling for a cosmetic
improvement that self-heals), recorded here instead so the purge is not forgotten.
