### PR TITLE
fix(analysis): split antimeridian-crossing buffer output at ±180

### DIFF
--- a/backend/app/platform/analysis_sql.py
+++ b/backend/app/platform/analysis_sql.py
@@ -78,6 +78,92 @@ NOT_EMPTY_PREDICATE = (
 MASK_SUBDIVIDE_MAX_VERTICES = 256
 
 
+# A planar longitude span wider than this means the geometry does not really
+# stretch that far — it wraps the antimeridian, since no 4326 geometry can
+# legitimately span more than 180° without also enclosing a pole. See
+# ``render_dateline_safe`` for why the guard has to be conditional.
+DATELINE_WRAP_SPAN_DEG = 180
+
+
+def render_dateline_safe(geom_expr: str, *, alias: str = "_dl") -> str:
+    """Split antimeridian-wrapping output of ``geom_expr`` at ±180.
+
+    fix(#697): ``ST_Buffer(...::geography, d)::geometry`` normalizes longitude
+    into [-180, 180], so a buffer that reaches across the antimeridian comes
+    back as ONE planar polygon carrying vertices on both sides of the seam.
+    Probed on PostGIS 3.6, a 10 km buffer of a point at lon 179.95 / lat 45
+    returns a self-intersecting POLYGON whose planar envelope is 359.99° wide.
+    Registration stores that envelope verbatim into ``records.spatial_extent``
+    (``ingest/metadata.py`` computes a bare ``ST_Extent``), so the saved dataset
+    published a near-global bbox on the datasets API and the OGC Features
+    collection extent, and the stored geometry itself matched a bbox query over
+    central France — a feature-level false positive, ~15 000 km off.
+
+    The split shifts into the 0..360 domain so the ring is coherent again, cuts
+    at x=180, translates the far side back by -360, and keeps the polygonal
+    components. The result is a valid multipart geometry inside [-180, 180].
+
+    ``ST_ShiftLongitude`` runs BEFORE ``ST_MakeValid``, and the order is
+    load-bearing. A wrapping ring is self-intersecting *in the planar domain*,
+    so validating first repairs an artefact of the wrap: it nodes the seam and
+    emits spurious slivers. Measured on a 10 km buffer at lon 179.95 — validate
+    first: 4 parts holding 97.9% of the expected area; shift first: 2 parts
+    holding 99.3%, the same ratio a non-crossing buffer of equal radius reaches
+    (the 0.7% deficit is ``ST_Buffer``'s own polygonal approximation of a
+    geodesic circle). ``ST_WrapX`` splits by intersection and does need valid
+    input, so the validation stays, just after the shift.
+
+    Two conditions gate the split, and both carry their own weight.
+
+    The planar span must exceed ``DATELINE_WRAP_SPAN_DEG``. A compact geometry
+    with vertices just inside +180 and just inside -180 has a planar span near
+    360°, so this is what "wraps" looks like from the outside; anything narrower
+    cannot be straddling the seam. Skipping the test entirely is not an option —
+    ``ST_ShiftLongitude`` maps negative longitudes to 180..360, so shifting
+    unconditionally splits ordinary geometry at the PRIME meridian instead: an
+    unguarded run over a 10 km buffer at lon 0 returned 2 parts covering 49x the
+    correct area. It also keeps the comparison below away from a float tie —
+    for a geometry lying wholly west of Greenwich the shift adds 360° to every
+    vertex, and the two spans then differ only by rounding.
+
+    Shifting must also NARROW the span. A geometry that encircles a pole
+    genuinely occupies every longitude, so its planar span is wide and stays
+    wide once shifted, and splitting it at the seam would only cut away area:
+    a 100 km buffer at lat 89.9 measured 347.3° planar / 349.9° shifted and is
+    correctly left alone, where a span-only test would have split it down to 93%
+    of its area. A seam-wrapping buffer collapses instead — 359.99° planar to
+    0.25° shifted — which is exactly the signal being tested for.
+
+    ``geom_expr`` is evaluated inside an ``OFFSET 0``-fenced subquery — the
+    same pull-up fence ``_wrap_not_empty`` and ``build_preview_sql`` use
+    (fix(#700 review)) — because the CASE references the geometry several
+    times, and the shifted copy is fenced the same way one level out so
+    ``ST_ShiftLongitude`` also runs once. Measured over 2 000 rows: naive
+    inlining 212 ms, this shape 136 ms, unsplit baseline 121 ms; on an
+    all-non-crossing workload the fenced form is within ~2% of the baseline.
+
+    NOT fixed here, and deliberately: a dataset that genuinely straddles the
+    seam still registers a -180..180 ``spatial_extent``, because the
+    ``geometry(Polygon, 4326)`` column cannot express the west > east bbox that
+    RFC 7946 § 5.2 and the STAC spec use for antimeridian-crossing extents.
+    That representation gap predates the analysis tools and equally affects
+    directly ingested Fiji-area data; it needs a schema change, not a wider
+    expression.
+    """
+    return (
+        "(SELECT CASE"
+        f" WHEN ST_XMax({alias}.g) - ST_XMin({alias}.g) > {DATELINE_WRAP_SPAN_DEG}"
+        f" AND ST_XMax({alias}.s) - ST_XMin({alias}.s)"
+        f" < ST_XMax({alias}.g) - ST_XMin({alias}.g)"
+        " THEN ST_CollectionExtract("
+        f"ST_WrapX(ST_MakeValid({alias}.s), 180, -360), 3)"
+        f" ELSE {alias}.g END"
+        f" FROM (SELECT {alias}_g.g, ST_ShiftLongitude({alias}_g.g) AS s"
+        f" FROM (SELECT {geom_expr} AS g OFFSET 0) AS {alias}_g"
+        f" OFFSET 0) AS {alias})"
+    )
+
+
 def render_clip_layer_join(mask_table_ref: str, *, src: str) -> tuple[str, str, str]:
     """Clip against a mask LAYER (fix(#693)); used by preview AND materialize.
 
@@ -226,8 +312,17 @@ def render_geometry_expr(
             raise ValueError(
                 f"buffer distance must be between 0 and {MAX_BUFFER_METERS:g} meters"
             )
+        # Buffer is the only operation here that round-trips through
+        # ::geography, and therefore the only one that can emit an
+        # antimeridian-wrapping geometry the source never had — hence the only
+        # one wrapped in render_dateline_safe (fix(#697)). Intersection (clip)
+        # and union (dissolve) can only shrink or merge longitudes that were
+        # already in range, and a planar centroid stays inside its input's
+        # envelope.
         return (
-            f"ST_Buffer(ST_MakeValid(geom_4326)::geography, {distance})::geometry",
+            render_dateline_safe(
+                f"ST_Buffer(ST_MakeValid(geom_4326)::geography, {distance})::geometry"
+            ),
             "",
         )
     if operation == "centroid":

--- a/backend/app/platform/analysis_sql.py
+++ b/backend/app/platform/analysis_sql.py
@@ -103,6 +103,25 @@ def render_dateline_safe(geom_expr: str, *, alias: str = "_dl") -> str:
     at x=180, translates the far side back by -360, and keeps the polygonal
     components. The result is a valid multipart geometry inside [-180, 180].
 
+    The decision is made PER POLYGON COMPONENT, not on the envelope of the whole
+    buffer (fix(#883 review)). One source feature can put components at both
+    seams — a ``MULTIPOINT`` holding (179.95, 45) and (0, 45) buffers to one
+    antimeridian-wrapping polygon plus one Greenwich-straddling polygon — and
+    those two want opposite treatment. Deciding once for the pair gets it wrong
+    either way, and which way depends on rounding: measured across a sweep of
+    the second point's longitude, the envelope test declined at lon ±0.05 and
+    left the antimeridian component self-intersecting and still hitting a bbox
+    over France, while at lon 0.0 it split the pair and blew the Greenwich
+    component up to 6 parts covering 11.6x the correct area, newly intersecting
+    a bbox at lon -100 that neither input was anywhere near. Splitting each
+    component on its own evidence gives 3 parts, exact area, and no remote hit.
+
+    ``ST_Dump`` then ``ST_CollectionHomogenize(ST_Collect(...))`` is what makes
+    that per-component pass type-preserving: the homogenize collapses a
+    single-component result back to POLYGON, so a component the guard declines
+    to touch comes out byte-identical rather than promoted to a one-part
+    MULTIPOLYGON.
+
     ``ST_ShiftLongitude`` runs BEFORE ``ST_MakeValid``, and the order is
     load-bearing. A wrapping ring is self-intersecting *in the planar domain*,
     so validating first repairs an artefact of the wrap: it nodes the seam and
@@ -113,7 +132,7 @@ def render_dateline_safe(geom_expr: str, *, alias: str = "_dl") -> str:
     geodesic circle). ``ST_WrapX`` splits by intersection and does need valid
     input, so the validation stays, just after the shift.
 
-    Two conditions gate the split, and both carry their own weight.
+    Two conditions gate a component's split, and both carry their own weight.
 
     The planar span must exceed ``DATELINE_WRAP_SPAN_DEG``. A compact geometry
     with vertices just inside +180 and just inside -180 has a planar span near
@@ -134,13 +153,19 @@ def render_dateline_safe(geom_expr: str, *, alias: str = "_dl") -> str:
     of its area. A seam-wrapping buffer collapses instead — 359.99° planar to
     0.25° shifted — which is exactly the signal being tested for.
 
+    The same span test also gates entry to the per-component pass at all, one
+    level out. It is a necessary condition: the envelope contains every
+    component, so if the envelope spans 180° or less then no component can span
+    more, and none can be wrapping. That makes the ordinary low-longitude buffer
+    a bare ``ELSE`` returning the geometry untouched, with no dump or re-collect
+    on the common path.
+
     ``geom_expr`` is evaluated inside an ``OFFSET 0``-fenced subquery — the
     same pull-up fence ``_wrap_not_empty`` and ``build_preview_sql`` use
     (fix(#700 review)) — because the CASE references the geometry several
-    times, and the shifted copy is fenced the same way one level out so
-    ``ST_ShiftLongitude`` also runs once. Measured over 2 000 rows: naive
-    inlining 212 ms, this shape 136 ms, unsplit baseline 121 ms; on an
-    all-non-crossing workload the fenced form is within ~2% of the baseline.
+    times, and the per-component shifted copy is fenced the same way so
+    ``ST_ShiftLongitude`` also runs once per component. ``EXPLAIN VERBOSE``
+    over 2 000 rows keeps ``ST_Buffer`` at one evaluation per row.
 
     NOT fixed here, and deliberately: a dataset that genuinely straddles the
     seam still registers a -180..180 ``spatial_extent``, because the
@@ -150,17 +175,33 @@ def render_dateline_safe(geom_expr: str, *, alias: str = "_dl") -> str:
     directly ingested Fiji-area data; it needs a schema change, not a wider
     expression.
     """
+    # Per-component split, innermost first: dump the buffer into components,
+    # pair each with its shifted copy behind an OFFSET 0 fence, decide per
+    # component, dump the split results so every collected element is a bare
+    # polygon, then re-collect and homogenize.
+    parts = (
+        f"SELECT (ST_Dump(CASE"
+        f" WHEN ST_XMax({alias}_c.c) - ST_XMin({alias}_c.c)"
+        f" > {DATELINE_WRAP_SPAN_DEG}"
+        f" AND ST_XMax({alias}_c.s) - ST_XMin({alias}_c.s)"
+        f" < ST_XMax({alias}_c.c) - ST_XMin({alias}_c.c)"
+        " THEN ST_CollectionExtract("
+        f"ST_WrapX(ST_MakeValid({alias}_c.s), 180, -360), 3)"
+        f" ELSE {alias}_c.c END)).geom AS p"
+        f" FROM (SELECT {alias}_d.c, ST_ShiftLongitude({alias}_d.c) AS s"
+        f" FROM (SELECT (ST_Dump({alias}.g)).geom AS c) AS {alias}_d"
+        f" OFFSET 0) AS {alias}_c"
+    )
+    split = (
+        f"(SELECT ST_CollectionHomogenize(ST_Collect({alias}_p.p))"
+        f" FROM ({parts}) AS {alias}_p)"
+    )
     return (
         "(SELECT CASE"
         f" WHEN ST_XMax({alias}.g) - ST_XMin({alias}.g) > {DATELINE_WRAP_SPAN_DEG}"
-        f" AND ST_XMax({alias}.s) - ST_XMin({alias}.s)"
-        f" < ST_XMax({alias}.g) - ST_XMin({alias}.g)"
-        " THEN ST_CollectionExtract("
-        f"ST_WrapX(ST_MakeValid({alias}.s), 180, -360), 3)"
+        f" THEN {split}"
         f" ELSE {alias}.g END"
-        f" FROM (SELECT {alias}_g.g, ST_ShiftLongitude({alias}_g.g) AS s"
-        f" FROM (SELECT {geom_expr} AS g OFFSET 0) AS {alias}_g"
-        f" OFFSET 0) AS {alias})"
+        f" FROM (SELECT {geom_expr} AS g OFFSET 0) AS {alias})"
     )
 
 

--- a/backend/tests/test_analysis_materialize.py
+++ b/backend/tests/test_analysis_materialize.py
@@ -18,6 +18,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 import app.core.db as core_db
 from app.modules.catalog.datasets.api import router_analysis
+from app.platform.analysis_sql import MAX_BUFFER_METERS
 from app.platform.jobs.models import IngestJob
 from app.processing.analysis.tasks import (
     MATERIALIZE_TIMEOUT,
@@ -30,7 +31,11 @@ from app.processing.analysis.tasks import (
 )
 
 from tests.factories import create_dataset, get_user_id
-from tests.test_analysis_preview import _create_mask_dataset, _create_polygon_dataset
+from tests.test_analysis_preview import (
+    _create_mask_dataset,
+    _create_point_dataset_at,
+    _create_polygon_dataset,
+)
 from tests.test_export_hardening import (
     _DEFAULT_PERMISSION_MATRIX,
     _put_permission_matrix,
@@ -2327,6 +2332,216 @@ class TestMaterializeWorker:
             )
         ).scalar_one()
         assert geom_type == "MULTIPOLYGON"
+
+
+# ---------------------------------------------------------------------------
+# Antimeridian and high-latitude edge fixtures (fix(#697))
+# ---------------------------------------------------------------------------
+
+
+async def _materialize_buffer(
+    session: AsyncSession, *, lon: float, lat: float, distance: float
+):
+    """Run a real buffer materialize over a one-point source at (lon, lat)."""
+    admin_id = await get_user_id(session, "admin")
+    src = await _create_point_dataset_at(session, created_by=admin_id, lon=lon, lat=lat)
+    job = await _create_job(session, admin_id)
+    await _materialize(
+        job_id=str(job.id),
+        dataset_id=str(src.id),
+        user_id=str(admin_id),
+        operation="buffer",
+        title=f"Buffer {uuid.uuid4().hex[:8]}",
+        distance_meters=distance,
+    )
+    await session.refresh(job)
+    assert job.status == "complete", job.error_message
+
+    from app.modules.catalog.datasets.domain.models import Dataset
+
+    out = await session.get(Dataset, job.dataset_id)
+    assert out is not None
+    return out
+
+
+class TestBufferAtDateline:
+    """Every other fixture in this suite is low-latitude and low-longitude,
+    which is precisely why #697 went unnoticed. These pin the seam.
+    """
+
+    async def test_buffer_across_dateline_is_split_not_wrapped(
+        self,
+        test_db_session: AsyncSession,
+    ):
+        """fix(#697): a 10 km buffer of a point at lon 179.95 used to register
+        as ONE self-intersecting polygon with vertices on both sides of ±180.
+        Probed before the fix: ST_IsValid false, planar envelope 359.99° wide
+        for a footprint 0.25° across, and the stored geometry ST_Intersects a
+        bbox over central France — a feature-level false positive ~15 000 km
+        out, reaching OGC /items, tile queries, and bbox-filtered exports.
+        """
+        out = await _materialize_buffer(
+            test_db_session, lon=179.95, lat=45.0, distance=10_000
+        )
+
+        row = (
+            await test_db_session.execute(
+                text(
+                    "SELECT GeometryType(geom_4326) AS gtype,"
+                    " ST_NumGeometries(geom_4326) AS parts,"
+                    " ST_IsValid(geom_4326) AS valid,"
+                    " ST_XMin(geom_4326) AS xmin,"
+                    " ST_XMax(geom_4326) AS xmax,"
+                    " ST_Intersects("
+                    "   geom_4326, ST_MakeEnvelope(2, 44.9, 3, 45.1, 4326)"
+                    " ) AS hits_france"
+                    f" FROM data.{out.table_name}"  # noqa: S608
+                )
+            )
+        ).one()
+
+        # Split at the seam into one part per hemisphere, each planar-valid.
+        assert row.gtype == "MULTIPOLYGON"
+        assert row.parts == 2
+        assert row.valid is True
+        # Every vertex stays inside the WGS84 domain — a shift-only fix would
+        # have left coordinates past 180 that no GeoJSON/tile consumer accepts.
+        assert row.xmin >= -180.0
+        assert row.xmax <= 180.0
+        # The defect that actually reached users: the geometry no longer
+        # matches a bbox on the far side of the world.
+        assert row.hits_france is False
+
+        # The registered extent must still satisfy the geometry(Polygon,4326)
+        # column, and stay finite. It is legitimately -180..180 here: the
+        # split parts really do touch both edges, and that column cannot hold
+        # the west > east bbox RFC 7946 § 5.2 uses for crossing extents. That
+        # representation gap is pre-existing and shared with directly ingested
+        # Fiji-area data — pinned, not fixed, by this test.
+        extent = (
+            await test_db_session.execute(
+                text(
+                    "SELECT GeometryType(spatial_extent) AS gtype,"
+                    " ST_XMin(spatial_extent) AS xmin,"
+                    " ST_XMax(spatial_extent) AS xmax"
+                    " FROM catalog.records WHERE id = :rid"
+                ).bindparams(rid=out.record_id)
+            )
+        ).one()
+        assert extent.gtype == "POLYGON"
+        assert extent.xmin >= -180.0
+        assert extent.xmax <= 180.0
+
+    async def test_buffer_away_from_dateline_is_untouched(
+        self,
+        test_db_session: AsyncSession,
+    ):
+        """The other half of fix(#697): the split must not fire on ordinary
+        input. ST_ShiftLongitude maps negative longitudes to 180..360, so an
+        unguarded normalization would cut geometry at the PRIME meridian — a
+        10 km buffer at lon 0 measured 2 parts covering 49x the correct area.
+        Straddling Greenwich is the case that catches it.
+        """
+        out = await _materialize_buffer(
+            test_db_session, lon=0.0, lat=45.0, distance=10_000
+        )
+
+        row = (
+            await test_db_session.execute(
+                text(
+                    "SELECT GeometryType(geom_4326) AS gtype,"
+                    " ST_IsValid(geom_4326) AS valid,"
+                    " ST_XMax(geom_4326) - ST_XMin(geom_4326) AS span"
+                    f" FROM data.{out.table_name}"  # noqa: S608
+                )
+            )
+        ).one()
+        assert row.gtype == "POLYGON"
+        assert row.valid is True
+        # ~0.25° across at lat 45 — a prime-meridian split would report ~360.
+        assert row.span == pytest.approx(0.2534, abs=0.01)
+
+        extent_span = (
+            await test_db_session.execute(
+                text(
+                    "SELECT ST_XMax(spatial_extent) - ST_XMin(spatial_extent)"
+                    " FROM catalog.records WHERE id = :rid"
+                ).bindparams(rid=out.record_id)
+            )
+        ).scalar_one()
+        assert extent_span == pytest.approx(0.2534, abs=0.01)
+
+    async def test_buffer_at_highest_reachable_latitude_does_not_wrap(
+        self,
+        test_db_session: AsyncSession,
+    ):
+        """Pinning test for the polar half of #697, which does NOT reproduce.
+
+        Two independent limits keep a pole-encircling buffer out of reach.
+        Vector ingest clips every geometry to the Web Mercator envelope
+        (``clip_to_mercator_bounds``, ±85.06° lat), so a genuinely polar source
+        cannot exist — probed via the API, a point at lat -89.95 ingests as
+        MULTIPOINT EMPTY and its buffer fails with "produced no features to
+        save". And at lat 85.06 the parallel is ~3 480 km around, so encircling
+        the pole needs a ~554 km radius, well past MAX_BUFFER_METERS (100 km).
+
+        So the maximum-radius buffer at the seam-free maximum latitude must come
+        back as a single unsplit polygon. If either limit ever moves — a larger
+        buffer cap, or ingest keeping polar geometry — this fails and the
+        pole-encircling case needs its own decision.
+        """
+        out = await _materialize_buffer(
+            test_db_session, lon=0.0, lat=85.06, distance=MAX_BUFFER_METERS
+        )
+
+        row = (
+            await test_db_session.execute(
+                text(
+                    "SELECT GeometryType(geom_4326) AS gtype,"
+                    " ST_IsValid(geom_4326) AS valid,"
+                    " ST_XMax(geom_4326) - ST_XMin(geom_4326) AS span,"
+                    " ST_YMax(geom_4326) AS ymax"
+                    f" FROM data.{out.table_name}"  # noqa: S608
+                )
+            )
+        ).one()
+        assert row.gtype == "POLYGON"
+        assert row.valid is True
+        # ~20.8° of longitude at this latitude, nowhere near a wrap.
+        assert row.span == pytest.approx(20.8, abs=1.0)
+        assert row.ymax < 90.0
+
+    async def test_pole_encircling_buffer_is_left_alone(
+        self,
+        test_db_session: AsyncSession,
+    ):
+        """The split's second guard condition, exercised directly.
+
+        A geometry that encircles a pole genuinely occupies every longitude, so
+        its planar span is wide for an honest reason and shifting it does not
+        narrow it. A span-only guard would have split such a buffer at the seam
+        and thrown away ~7% of its area. Unreachable through ingest today (see
+        the test above), so this drives the source table straight past ingest —
+        the guard has to hold on its own, not on an upstream clip.
+        """
+        out = await _materialize_buffer(
+            test_db_session, lon=0.0, lat=89.9, distance=MAX_BUFFER_METERS
+        )
+
+        row = (
+            await test_db_session.execute(
+                text(
+                    "SELECT GeometryType(geom_4326) AS gtype,"
+                    " ST_IsValid(geom_4326) AS valid,"
+                    " ST_XMax(geom_4326) - ST_XMin(geom_4326) AS span"
+                    f" FROM data.{out.table_name}"  # noqa: S608
+                )
+            )
+        ).one()
+        # Not promoted to MULTIPOLYGON: the guard declined to split.
+        assert row.gtype == "POLYGON"
+        assert row.valid is True
+        assert row.span > 180.0
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_analysis_materialize.py
+++ b/backend/tests/test_analysis_materialize.py
@@ -8,6 +8,7 @@ Requirements:
 """
 
 import asyncio
+import math
 import uuid
 from unittest.mock import AsyncMock, patch
 
@@ -35,6 +36,7 @@ from tests.test_analysis_preview import (
     _create_mask_dataset,
     _create_point_dataset_at,
     _create_polygon_dataset,
+    _create_wkt_dataset,
 )
 from tests.test_export_hardening import (
     _DEFAULT_PERMISSION_MATRIX,
@@ -2340,11 +2342,34 @@ class TestMaterializeWorker:
 
 
 async def _materialize_buffer(
-    session: AsyncSession, *, lon: float, lat: float, distance: float
+    session: AsyncSession,
+    *,
+    distance: float,
+    lon: float | None = None,
+    lat: float | None = None,
+    wkt: str | None = None,
+    column_type: str = "Point",
+    geometry_type: str = "POINT",
 ):
-    """Run a real buffer materialize over a one-point source at (lon, lat)."""
+    """Run a real buffer materialize over a one-row source geometry.
+
+    Pass either ``lon``/``lat`` for a single point, or ``wkt`` plus its PostGIS
+    ``column_type`` for a multipart source.
+    """
     admin_id = await get_user_id(session, "admin")
-    src = await _create_point_dataset_at(session, created_by=admin_id, lon=lon, lat=lat)
+    if wkt is not None:
+        src = await _create_wkt_dataset(
+            session,
+            created_by=admin_id,
+            wkt=wkt,
+            column_type=column_type,
+            geometry_type=geometry_type,
+        )
+    else:
+        assert lon is not None and lat is not None
+        src = await _create_point_dataset_at(
+            session, created_by=admin_id, lon=lon, lat=lat
+        )
     job = await _create_job(session, admin_id)
     await _materialize(
         job_id=str(job.id),
@@ -2538,10 +2563,83 @@ class TestBufferAtDateline:
                 )
             )
         ).one()
-        # Not promoted to MULTIPOLYGON: the guard declined to split.
+        # Not promoted to MULTIPOLYGON: the guard declined to split, and
+        # ST_CollectionHomogenize collapses the untouched single component back
+        # to POLYGON rather than leaving a one-part MULTIPOLYGON.
         assert row.gtype == "POLYGON"
         assert row.valid is True
         assert row.span > 180.0
+
+    async def test_one_feature_with_components_at_both_seams(
+        self,
+        test_db_session: AsyncSession,
+    ):
+        """fix(#883 review): the split decision has to be per component.
+
+        A MULTIPOINT holding (179.95, 45) and (0, 45) buffers to one
+        antimeridian-wrapping polygon plus one Greenwich-straddling polygon, and
+        those two want opposite treatment. Deciding once on the envelope of the
+        pair gets it wrong either way, and rounding picks which way: measured
+        over a sweep of the second point's longitude, the envelope test declined
+        at lon ±0.05 (leaving the antimeridian component self-intersecting and
+        still hitting a bbox over France) and split at lon 0.0 (blowing the
+        Greenwich component up to 6 parts covering 11.6x the correct area, newly
+        intersecting lon -100, where neither input sits).
+
+        Both seam positions are asserted here so a future envelope-level
+        shortcut cannot pass by getting only one of them right.
+        """
+        out = await _materialize_buffer(
+            test_db_session,
+            wkt="MULTIPOINT((179.95 45),(0 45))",
+            column_type="MultiPoint",
+            geometry_type="MULTIPOINT",
+            distance=10_000,
+        )
+
+        row = (
+            await test_db_session.execute(
+                text(
+                    "SELECT GeometryType(geom_4326) AS gtype,"
+                    " ST_NumGeometries(geom_4326) AS parts,"
+                    " ST_IsValid(geom_4326) AS valid,"
+                    " ST_XMin(geom_4326) AS xmin,"
+                    " ST_XMax(geom_4326) AS xmax,"
+                    " ST_Area(geom_4326::geography) AS area,"
+                    " ST_Intersects("
+                    "   geom_4326, ST_MakeEnvelope(2, 44.9, 3, 45.1, 4326)"
+                    " ) AS hits_france,"
+                    " ST_Intersects("
+                    "   geom_4326, ST_MakeEnvelope(-100, 44.9, -99, 45.1, 4326)"
+                    " ) AS hits_dakota,"
+                    # The Greenwich component must survive INTACT — a
+                    # prime-meridian split would leave nothing covering lon 0.
+                    " ST_Contains("
+                    "   geom_4326, ST_SetSRID(ST_MakePoint(0, 45), 4326)"
+                    " ) AS covers_greenwich,"
+                    " ST_Contains("
+                    "   geom_4326, ST_SetSRID(ST_MakePoint(179.95, 45), 4326)"
+                    " ) AS covers_seam"
+                    f" FROM data.{out.table_name}"  # noqa: S608
+                )
+            )
+        ).one()
+
+        # Antimeridian component cut in two, Greenwich component untouched.
+        assert row.gtype == "MULTIPOLYGON"
+        assert row.parts == 3
+        assert row.valid is True
+        assert row.xmin >= -180.0
+        assert row.xmax <= 180.0
+        # Neither source point is near lon 2-3 or lon -100.
+        assert row.hits_france is False
+        assert row.hits_dakota is False
+        # Both original centres still covered: nothing was shifted away.
+        assert row.covers_greenwich is True
+        assert row.covers_seam is True
+        # Two 10 km buffers at lat 45. The split adds a seam edge but removes no
+        # area, and a mangled Greenwich component measured 11.6x this.
+        assert row.area == pytest.approx(2 * math.pi * 10_000**2, rel=0.02)
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_analysis_preview.py
+++ b/backend/tests/test_analysis_preview.py
@@ -104,14 +104,21 @@ async def _create_point_dataset(
     )
 
 
-async def _create_point_dataset_at(
-    session: AsyncSession, *, created_by: uuid.UUID, lon: float, lat: float
+async def _create_wkt_dataset(
+    session: AsyncSession,
+    *,
+    created_by: uuid.UUID,
+    wkt: str,
+    column_type: str,
+    geometry_type: str,
 ):
-    """Create a one-row point dataset at an explicit longitude/latitude.
+    """Create a one-row dataset holding exactly ``wkt``.
 
     fix(#697): every other fixture in this suite sits at low latitude and low
     longitude, which is why antimeridian output went unnoticed. Callers pass the
     seam and high-latitude coordinates the analysis operations have to survive.
+    ``column_type`` is the PostGIS typmod (``Point`` / ``MultiPoint`` / ...) and
+    ``geometry_type`` the catalog's uppercase classification.
     """
     table_name = f"ds_{uuid.uuid4().hex[:12]}"
     await session.execute(
@@ -119,25 +126,38 @@ async def _create_point_dataset_at(
             f"CREATE TABLE data.{table_name} ("
             f"  gid SERIAL PRIMARY KEY,"
             f"  name TEXT,"
-            f"  geom geometry(Point, 4326),"
-            f"  geom_4326 geometry(Point, 4326)"
+            f"  geom geometry({column_type}, 4326),"
+            f"  geom_4326 geometry({column_type}, 4326)"
             f")"
         )
     )
     await session.execute(
         text(
             f"INSERT INTO data.{table_name} (name, geom, geom_4326) VALUES "  # noqa: S608
-            f"('p', ST_SetSRID(ST_MakePoint(:lon, :lat), 4326),"
-            f"      ST_SetSRID(ST_MakePoint(:lon, :lat), 4326))"
-        ).bindparams(lon=lon, lat=lat)
+            f"('p', ST_SetSRID(ST_GeomFromText(:wkt), 4326),"
+            f"      ST_SetSRID(ST_GeomFromText(:wkt), 4326))"
+        ).bindparams(wkt=wkt)
     )
     await session.commit()
     return await create_dataset(
         session,
         created_by=created_by,
         table_name=table_name,
-        geometry_type="POINT",
+        geometry_type=geometry_type,
         feature_count=1,
+    )
+
+
+async def _create_point_dataset_at(
+    session: AsyncSession, *, created_by: uuid.UUID, lon: float, lat: float
+):
+    """Create a one-row point dataset at an explicit longitude/latitude."""
+    return await _create_wkt_dataset(
+        session,
+        created_by=created_by,
+        wkt=f"POINT({lon} {lat})",
+        column_type="Point",
+        geometry_type="POINT",
     )
 
 
@@ -918,19 +938,31 @@ class TestBuildPreviewSql:
         from app.platform.analysis_sql import render_geometry_expr
 
         buffer_expr, _ = render_geometry_expr("buffer", distance_meters=500)
-        # The guard needs BOTH conditions: a wide planar span alone also
-        # describes a pole-encircling geometry, which must be left alone.
-        assert "ST_XMax(_dl.g) - ST_XMin(_dl.g) > 180" in buffer_expr
+        # fix(#883 review): the split decision is per polygon component, not on
+        # the envelope of the whole buffer — one feature can hold components at
+        # both seams, which want opposite treatment.
+        assert "ST_Dump" in buffer_expr
+        assert "ST_CollectionHomogenize(ST_Collect(_dl_p.p))" in buffer_expr
+        # The per-component guard needs BOTH conditions: a wide planar span
+        # alone also describes a pole-encircling component, which must be left
+        # alone.
+        assert "ST_XMax(_dl_c.c) - ST_XMin(_dl_c.c) > 180" in buffer_expr
         assert (
-            "ST_XMax(_dl.s) - ST_XMin(_dl.s) < ST_XMax(_dl.g) - ST_XMin(_dl.g)"
+            "ST_XMax(_dl_c.s) - ST_XMin(_dl_c.s) < ST_XMax(_dl_c.c) - ST_XMin(_dl_c.c)"
             in buffer_expr
         )
-        assert "ST_WrapX(ST_MakeValid(_dl.s), 180, -360)" in buffer_expr
+        assert "ST_WrapX(ST_MakeValid(_dl_c.s), 180, -360)" in buffer_expr
+        # The envelope span still gates ENTRY to the per-component pass. It is a
+        # necessary condition (the envelope contains every component), so the
+        # ordinary buffer never pays for the dump/re-collect.
+        assert "ST_XMax(_dl.g) - ST_XMin(_dl.g) > 180 THEN" in buffer_expr
+        assert "ELSE _dl.g END" in buffer_expr
         # ST_ShiftLongitude must run BEFORE ST_MakeValid: validating the
         # wrapped ring first nodes the seam into slivers.
         assert "ST_MakeValid(ST_ShiftLongitude" not in buffer_expr
-        # Both the buffer and the shifted copy stay behind an OFFSET 0 fence,
-        # so neither is re-evaluated per CASE reference (fix(#700 review)).
+        # The buffer and each component's shifted copy stay behind an OFFSET 0
+        # fence, so neither is re-evaluated per CASE reference (fix(#700
+        # review)). EXPLAIN VERBOSE holds ST_Buffer at one call per row.
         assert buffer_expr.count("ST_Buffer(") == 1
         assert buffer_expr.count("ST_ShiftLongitude(") == 1
         assert buffer_expr.count("OFFSET 0") == 2

--- a/backend/tests/test_analysis_preview.py
+++ b/backend/tests/test_analysis_preview.py
@@ -104,6 +104,43 @@ async def _create_point_dataset(
     )
 
 
+async def _create_point_dataset_at(
+    session: AsyncSession, *, created_by: uuid.UUID, lon: float, lat: float
+):
+    """Create a one-row point dataset at an explicit longitude/latitude.
+
+    fix(#697): every other fixture in this suite sits at low latitude and low
+    longitude, which is why antimeridian output went unnoticed. Callers pass the
+    seam and high-latitude coordinates the analysis operations have to survive.
+    """
+    table_name = f"ds_{uuid.uuid4().hex[:12]}"
+    await session.execute(
+        text(
+            f"CREATE TABLE data.{table_name} ("
+            f"  gid SERIAL PRIMARY KEY,"
+            f"  name TEXT,"
+            f"  geom geometry(Point, 4326),"
+            f"  geom_4326 geometry(Point, 4326)"
+            f")"
+        )
+    )
+    await session.execute(
+        text(
+            f"INSERT INTO data.{table_name} (name, geom, geom_4326) VALUES "  # noqa: S608
+            f"('p', ST_SetSRID(ST_MakePoint(:lon, :lat), 4326),"
+            f"      ST_SetSRID(ST_MakePoint(:lon, :lat), 4326))"
+        ).bindparams(lon=lon, lat=lat)
+    )
+    await session.commit()
+    return await create_dataset(
+        session,
+        created_by=created_by,
+        table_name=table_name,
+        geometry_type="POINT",
+        feature_count=1,
+    )
+
+
 async def _create_mask_dataset(
     session: AsyncSession,
     *,
@@ -873,6 +910,37 @@ class TestBuildPreviewSql:
         assert "ST_Buffer(ST_MakeValid(geom_4326)::geography, 500.0)::geometry" in sql
         assert 'FROM "data"."t1"' in sql
         assert "ORDER BY gid" in sql
+
+    def test_buffer_sql_is_dateline_safe(self):
+        """fix(#697): buffer output must go through the ±180 split, and only
+        buffer — clip and dissolve cannot introduce a wrap the source lacked,
+        and adding the guard there would be dead cost on every row."""
+        from app.platform.analysis_sql import render_geometry_expr
+
+        buffer_expr, _ = render_geometry_expr("buffer", distance_meters=500)
+        # The guard needs BOTH conditions: a wide planar span alone also
+        # describes a pole-encircling geometry, which must be left alone.
+        assert "ST_XMax(_dl.g) - ST_XMin(_dl.g) > 180" in buffer_expr
+        assert (
+            "ST_XMax(_dl.s) - ST_XMin(_dl.s) < ST_XMax(_dl.g) - ST_XMin(_dl.g)"
+            in buffer_expr
+        )
+        assert "ST_WrapX(ST_MakeValid(_dl.s), 180, -360)" in buffer_expr
+        # ST_ShiftLongitude must run BEFORE ST_MakeValid: validating the
+        # wrapped ring first nodes the seam into slivers.
+        assert "ST_MakeValid(ST_ShiftLongitude" not in buffer_expr
+        # Both the buffer and the shifted copy stay behind an OFFSET 0 fence,
+        # so neither is re-evaluated per CASE reference (fix(#700 review)).
+        assert buffer_expr.count("ST_Buffer(") == 1
+        assert buffer_expr.count("ST_ShiftLongitude(") == 1
+        assert buffer_expr.count("OFFSET 0") == 2
+
+        for op, kwargs in (
+            ("centroid", {}),
+            ("clip", {"mask": CLIP_MASK}),
+        ):
+            other_expr, _ = render_geometry_expr(op, **kwargs)
+            assert "ST_ShiftLongitude" not in other_expr
 
     def test_centroid_sql(self):
         req = AnalysisPreviewRequest(operation="centroid")


### PR DESCRIPTION
## Probe: REPRODUCED

Ran the issue's step 1 against the live dev stack (PostgreSQL 18.4, PostGIS 3.6.4, GEOS 3.13.1) before writing any code.

### 1. The property, in raw SQL

The pipeline's exact buffer expression (`backend/app/platform/analysis_sql.py`), at the seam and at a control longitude:

```
$ docker compose exec -T db psql -U geolens -d geolens -c "
WITH pts(label, p) AS (
  VALUES
    ('lon 179.95 / lat 45',   ST_SetSRID(ST_MakePoint(179.95, 45), 4326)),
    ('lon -179.95 / lat 45',  ST_SetSRID(ST_MakePoint(-179.95, 45), 4326)),
    ('lon 0 / lat 45 (control)', ST_SetSRID(ST_MakePoint(0, 45), 4326))
), buf AS (
  SELECT label, ST_Buffer(ST_MakeValid(p)::geography, 10000)::geometry AS g FROM pts
)
SELECT label, GeometryType(g) AS gtype, ST_IsValid(g) AS valid,
       round(ST_XMin(g)::numeric,4) AS xmin, round(ST_XMax(g)::numeric,4) AS xmax,
       round((ST_XMax(g)-ST_XMin(g))::numeric,4) AS lon_span
FROM buf ORDER BY label;"

NOTICE:  Self-intersection at or near point 179.92292972508764 45.087526887579678
NOTICE:  Self-intersection at or near point -179.92292972508764 45.087526887579678
          label           |  gtype  | valid |   xmin    |   xmax   | lon_span
--------------------------+---------+-------+-----------+----------+----------
 lon 0 / lat 45 (control) | POLYGON | t     |   -0.1267 |   0.1267 |   0.2534
 lon -179.95 / lat 45     | POLYGON | f     | -179.9942 | 179.9972 | 359.9913
 lon 179.95 / lat 45      | POLYGON | f     | -179.9972 | 179.9942 | 359.9913
```

One planar polygon, `ST_IsValid` false, 359.99° of longitude for a footprint 0.25° across.

### 2. The path, end to end through the API

A property probe is not a path probe, so the same case ran through upload → preview → commit → `POST /datasets/{id}/analysis/materialize/` on the running stack, for a point at lon 179.95 / lat 45 and a control at lon 0 / lat 45, buffer 10 000 m.

What registration actually stored:

```
$ docker compose exec -T db psql -U geolens -d geolens -c "
SELECT r.title, ST_AsText(r.spatial_extent) FROM catalog.records r
WHERE r.title LIKE 'probe697%' ORDER BY r.created_at;"

 probe697-antimeridian-buffer | POLYGON((-179.99716652352845 44.91009932434904,
                                        -179.99716652352845 45.08989888175428,
                                         179.99416216363664 45.08989888175428,
                                         179.99416216363664 44.91009932434904,
                                        -179.99716652352845 44.91009932434904))
 probe697-control-buffer      | POLYGON((-0.12669356827988 44.91010340202817, ...
                                         0.126715619774784 45.089894791474656, ...
```

What the published surfaces served:

```
=== control-buffer ===
  datasets API  extent_bbox = [-0.1267, 44.9101, 0.1267, 45.0899]     (span 0.2534°)
  OGC collection extent     = {"bbox": [[-0.1267, 44.9101, 0.1267, 45.0899]], "crs": ".../CRS84"}

=== antimeridian-buffer ===
  datasets API  extent_bbox = [-179.99716652352845, 44.91009932434904,
                               179.99416216363664, 45.08989888175428]  (span 359.9913°)
  OGC collection extent     = {"bbox": [[-179.99716652352845, 44.91009932434904,
                                         179.99416216363664, 45.08989888175428]], "crs": ".../CRS84"}
```

STAC Items are raster-only here (`_STAC_RECORD_TYPES = RASTER_FAMILY_RECORD_TYPES`), so a vector buffer never becomes a STAC Item; the vector bbox surfaces are the datasets API and the OGC Features collection extent, both shown above.

### 3. The part the issue did not predict

The extent is a symptom. The stored geometry is itself wrong, and it produces a **feature-level** false positive:

```
$ docker compose exec -T db psql -U geolens -d geolens -c "
WITH france AS (SELECT ST_MakeEnvelope(2, 44.95, 3, 45.05, 4326) AS env)
SELECT b.gid, (b.geom_4326 && f.env) AS bbox_hit,
       ST_Intersects(b.geom_4326, f.env) AS intersects_hit
FROM data.probe697_antimeridian_buffer b CROSS JOIN france f;"

 gid | bbox_hit | intersects_hit
-----+----------+----------------
   1 | t        | t
```

A 10 km buffer near Fiji intersects a bbox over central France, ~15 000 km away. That reaches `GET /collections/{id}/items?bbox=`, tile queries, and bbox-filtered exports, not only the record-level extent.

### 4. The polar half does NOT reproduce

Two independent limits keep a pole-encircling buffer out of reach, and I confirmed both:

- Vector ingest clips every geometry to the Web Mercator envelope (`clip_to_mercator_bounds`, ±85.06° lat). Probed through the API: a point at lat -89.95 ingests as `MULTIPOINT EMPTY`, and its buffer fails with "Analysis produced no features to save".
- At lat 85.06 the parallel is ~3 480 km around, so encircling the pole needs a ~554 km radius. `MAX_BUFFER_METERS` is 100 000.

A 100 km buffer at lat 85.06 measures 20.8° of longitude, nowhere near a wrap. So no polar fix; a pinning test instead.

## What changed

`render_dateline_safe` in `backend/app/platform/analysis_sql.py` wraps the buffer expression. It shifts a wrapping result into the 0..360 domain, cuts at x=180, translates the far side back by -360, and keeps the polygonal components:

```sql
(SELECT CASE
   WHEN ST_XMax(_dl.g) - ST_XMin(_dl.g) > 180
    AND ST_XMax(_dl.s) - ST_XMin(_dl.s) < ST_XMax(_dl.g) - ST_XMin(_dl.g)
   THEN ST_CollectionExtract(ST_WrapX(ST_MakeValid(_dl.s), 180, -360), 3)
   ELSE _dl.g END
 FROM (SELECT _dl_g.g, ST_ShiftLongitude(_dl_g.g) AS s
       FROM (SELECT <buffer> AS g OFFSET 0) AS _dl_g OFFSET 0) AS _dl)
```

Buffer is the only operation wrapped. It is the only one that round-trips through `::geography`, so it is the only one that can emit a wrap its source never had; intersection (clip) and union (dissolve) only shrink or merge longitudes already in range, and a planar centroid stays inside its input's envelope.

Four decisions worth reviewing, each measured rather than assumed:

**Both guard conditions are needed.** The span test keeps `ST_ShiftLongitude` away from ordinary geometry, which otherwise splits at the *prime* meridian: unguarded, a 10 km buffer at lon 0 returned 2 parts covering 49x the correct area. The "shifting must narrow the span" test spares a geometry that legitimately encircles a pole. Measured across the case matrix:

| case | raw span | shifted span | splits (both conditions) | splits (span only) |
|---|---|---|---|---|
| lon 179.95 lat 45, 10 km | 359.991 | 0.253 | yes | yes |
| lon -179.99 lat 0, 10 km | 359.982 | 0.179 | yes | yes |
| lon 180.0 lat -30, 50 km | 359.973 | 1.035 | yes | yes |
| lon 0 lat 45, 10 km | 0.253 | 359.991 | no | no |
| lon 0.001 lat 45, 100 km | 2.534 | 359.906 | no | no |
| lon 170 lat 45, 100 km | 2.537 | 2.537 | no | no |
| lon -170 lat 45, 100 km | 2.537 | 2.537 | no | no |
| lon 0 lat 85.06, 100 km | 20.816 | 358.275 | no | no |
| lon 0 lat 89.9, 100 km (polar cap) | 347.339 | 349.879 | **no** | **yes** (loses 7% of area) |

**`ST_ShiftLongitude` must run before `ST_MakeValid`.** A wrapping ring is self-intersecting in the planar domain, so validating first repairs an artefact of the wrap and nodes the seam into slivers. On the 10 km / lon 179.95 case: validate first gives 4 parts holding 97.9% of the expected area; shift first gives 2 parts holding 99.3%, the same ratio a non-crossing buffer of equal radius reaches (the 0.7% deficit is `ST_Buffer`'s own polygonal approximation of a geodesic circle).

**Non-crossing output is byte-identical**, verified with `ST_OrderingEquals` on every non-splitting row of that matrix, including the Greenwich straddle and both hemispheres. The buffer's cost profile therefore does not change for ordinary data.

**The `OFFSET 0` fences are load-bearing**, the same pull-up fence `_wrap_not_empty` and `build_preview_sql` already use (fix(#700 review)). `EXPLAIN VERBOSE` confirms `ST_Buffer` appears once, inside a single `Result` node at `loops=2000`.

Keeping the fix inside the expression rather than at each call site is deliberate: preview and materialize both consume `render_geometry_expr`, so parity is structural instead of something two call sites have to remember.

## Second pass: the decision is per polygon component (fix(#883 review))

codex caught that the guard above was evaluated on the envelope of the **whole** buffer result. One source feature can put components at both seams, and those want opposite treatment. A `MULTIPOINT` holding (179.95, 45) and (0, 45) buffers to one antimeridian-wrapping polygon plus one Greenwich-straddling polygon.

Deciding once for the pair gets it wrong either way, and rounding picks which way. Sweeping the second point's longitude against the envelope-level guard, with the France bbox at lon 2-3 and a second probe at lon -100 (`area_ratio` is against two ideal 10 km circles):

| 2nd point lon | cond1 | cond2 | split? | valid | parts | hits France | hits lon -100 | area ratio |
|---|---|---|---|---|---|---|---|---|
| -0.05 | t | **f** | no | **f** | 2 | **t** | **t** | 0.994 |
| 0.0 | t | t | yes | t | **6** | **t** | **t** | **11.650** |
| 0.5 | t | t | yes | t | 3 | f | f | 0.994 |
| -2.0 | t | t | yes | t | 3 | f | f | 0.994 |
| 2.0 | t | t | yes | t | 3 | t *(true positive: the buffer really is at lon 2)* | f | 0.994 |
| 10.0 | t | t | yes | t | 3 | f | f | 0.994 |

Both failure modes are real. At lon ±0.05 the envelope test declines and leaves the antimeridian component self-intersecting and still hitting France, which is exactly the hole this PR set out to close. At lon 0.0 it splits the pair and mangles the Greenwich component into 6 parts covering 11.6x the correct area, newly intersecting lon -100 where neither input sits.

The fix: `ST_Dump` the buffer into components, run the same two-condition guard against each component's own spans, then `ST_CollectionHomogenize(ST_Collect(...))`. The homogenize is what keeps the pass type-preserving, collapsing a single-component result back to POLYGON instead of leaving a one-part MULTIPOLYGON. The envelope span test survives one level out as the gate into the per-component pass: it is a *necessary* condition, since the envelope contains every component, so an ordinary buffer takes a bare `ELSE` and never pays for the dump or the re-collect.

Re-verified over a 16-case matrix driven by the real renderer (`render_geometry_expr` output, bound to each case's WKT):

| case | raw | fixed | parts | valid | identical | area vs raw |
|---|---|---|---|---|---|---|
| antimeridian single | POLYGON (invalid) | MULTIPOLYGON | 2 | t | f | 1.0000 |
| **mixed 179.95 + 0 (codex)** | MULTIPOLYGON (invalid) | MULTIPOLYGON | **3** | t | f | **1.0000** |
| mixed 179.95 + 0.05 | MULTIPOLYGON (invalid) | MULTIPOLYGON | 3 | t | f | 1.0000 |
| mixed 179.95 + -0.05 | MULTIPOLYGON (invalid) | MULTIPOLYGON | 3 | t | f | 1.0000 |
| mixed -179.95 + 0 | MULTIPOLYGON (invalid) | MULTIPOLYGON | 3 | t | f | 1.0000 |
| mixed 179.95 + 0 + -170 | MULTIPOLYGON (invalid) | MULTIPOLYGON | 4 | t | f | 1.0000 |
| ctrl lon 0 | POLYGON | POLYGON | 1 | t | **t** | 1.0000 |
| ctrl lon 0.001, 100 km | POLYGON | POLYGON | 1 | t | **t** | 1.0000 |
| ctrl lon 170, 100 km | POLYGON | POLYGON | 1 | t | **t** | 1.0000 |
| ctrl lon -170, 100 km | POLYGON | POLYGON | 1 | t | **t** | 1.0000 |
| ctrl lat 85.06, 100 km | POLYGON | POLYGON | 1 | t | **t** | 1.0000 |
| polar cap lat 89.9, 100 km | POLYGON | POLYGON | 1 | t | **t** | 1.0000 |
| polar cap lat -89.95, 100 km | POLYGON | POLYGON | 1 | t | **t** | 1.0000 |
| two far parts lon ±170 | MULTIPOLYGON | MULTIPOLYGON | 2 | t | **t** | 1.0000 |
| greenwich straddle pair | POLYGON | POLYGON | 1 | t | **t** | 1.0000 |
| LINESTRING across the seam | POLYGON | MULTIPOLYGON | 2 | t | f | 1.0000 |

Every crossing case is now exact (`area vs raw` 1.0000, not the 0.993 seam loss the envelope form showed), every vertex lands inside [-180, 180], and every non-crossing case is byte-identical. The two-far-parts case matters: its 340° envelope *does* enter the per-component pass, and it still comes back byte-identical, so the dump and re-collect round-trip is lossless. Both polar caps are untouched, so the second guard condition still earns its keep. And the LINESTRING case shows the fix is not point-specific.

**The performance fence held.** `EXPLAIN VERBOSE` over the same 2 000-row mixed table:

```
 Seq Scan on pg_temp.tmix (actual rows=2000.00 loops=1)
   Output: tmix.gid, (SubPlan 2)
   SubPlan 2
     ->  Subquery Scan on _dl (actual rows=1.00 loops=2000)
           Output: CASE WHEN ((st_xmax((_dl.g)::box3d) - st_xmin((_dl.g)::box3d)) > '180'::double precision)
                   THEN (SubPlan 1) ELSE _dl.g END
           ->  Result (actual rows=1.00 loops=2000)
                 Output: (st_buffer((st_makevalid(tmix.geom_4326))::geography, '10000'::double precision))::geometry
           SubPlan 1
             ->  Aggregate (actual rows=1.00 loops=285)
                   ->  Result (actual rows=2.00 loops=285)
                         ->  ProjectSet (actual rows=2.00 loops=285)
                               ->  Subquery Scan on _dl_d (actual rows=1.00 loops=285)
                                     ->  Result (actual rows=1.00 loops=285)
                                           ->  ProjectSet (actual rows=1.00 loops=285)
```

`st_buffer` is in one `Result` node at `loops=2000`, still once per row. The per-component `SubPlan 1` runs at `loops=285` only, the rows whose envelope actually spans past 180°, so the dump machinery is skipped on the common path. Interleaved timings over those 2 000 rows:

```
mixed workload (285/2000 rows crossing)
  A unsplit baseline                     45.9 ms
  B per-component split (this PR)        63.0 ms
  C envelope-level split (replaced)      62.6 ms

all-non-crossing workload (the common path)
  A unsplit baseline                     47.0 ms / 47.3 ms
  B per-component split (this PR)        48.2 ms
```

The per-component rewrite costs 0.4 ms over the envelope form it replaces, and the common path is unchanged at ~2% over baseline.

### Not addressed, deliberately

A dataset that genuinely straddles the seam still registers a -180..180 `spatial_extent`. `records.spatial_extent` is `geometry(Polygon, 4326)` and cannot hold the west > east bbox RFC 7946 § 5.2 and the STAC spec use for crossing extents; `extent_to_bbox` goes through shapely `.bounds`, which returns min-first by construction. After the split the two parts really do touch both edges, so -180..180 is the honest planar answer, where before it was a fabricated one. That representation gap predates the analysis tools and equally affects directly ingested Fiji-area data, so it needs a schema change rather than a wider expression. Documented in the `render_dateline_safe` docstring and pinned by the test.

## Tests

`backend/tests/test_analysis_preview.py`

- `_create_wkt_dataset` helper: a one-row dataset holding an arbitrary WKT at an explicit column type, with `_create_point_dataset_at` as a thin wrapper. Every existing fixture in the analysis suites is low-latitude and low-longitude, which is why this went unnoticed.
- `test_buffer_sql_is_dateline_safe`: pins the per-component structure (`ST_Dump`, `ST_CollectionHomogenize`), both per-component guard conditions, the envelope gate one level out, the `ST_ShiftLongitude`-then-`ST_MakeValid` order, single evaluation of the buffer and the shift, and that clip/centroid are *not* wrapped.

`backend/tests/test_analysis_materialize.py`, class `TestBufferAtDateline`, all five driving the real `_materialize` worker against Postgres:

- `test_buffer_across_dateline_is_split_not_wrapped` (lon 179.95): 2-part valid MULTIPOLYGON, every vertex inside [-180, 180], no longer intersects the France bbox, and the registered extent still satisfies the POLYGON column.
- `test_buffer_away_from_dateline_is_untouched` (lon 0): single POLYGON, ~0.25° span. Catches a prime-meridian split.
- `test_buffer_at_highest_reachable_latitude_does_not_wrap` (lat 85.06, 100 km): single unsplit POLYGON. Fails if either the buffer cap rises or ingest starts keeping polar geometry, at which point the pole-encircling case needs its own decision.
- `test_pole_encircling_buffer_is_left_alone` (lat 89.9, 100 km): stays POLYGON, so the second guard condition held and the homogenize kept the type.
- `test_one_feature_with_components_at_both_seams` (new, fix(#883 review)): `MULTIPOINT((179.95 45),(0 45))`. Asserts 3 parts, valid, inside [-180, 180], no France or lon -100 hit, area within 2% of two ideal circles, and `ST_Contains` for **both** original centres so a future envelope-level shortcut cannot pass by getting only one seam right.

Confirmed the first-pass fixture fails without the fix at all (reverted the one-line wrap):

```
tests/test_analysis_materialize.py::TestBufferAtDateline::test_buffer_across_dateline_is_split_not_wrapped FAILED
>       assert row.gtype == "MULTIPOLYGON"
E       AssertionError: assert 'POLYGON' == 'MULTIPOLYGON'
tests/test_analysis_preview.py::TestBuildPreviewSql::test_buffer_sql_is_dateline_safe FAILED
2 failed, 3 passed
```

And confirmed the new mixed-seam fixture fails against the **envelope-level version from the first commit** (temporarily restored that expression, re-ran):

```
tests/test_analysis_materialize.py::TestBufferAtDateline::test_one_feature_with_components_at_both_seams FAILED
>       assert row.parts == 3
E       AssertionError: assert 6 == 3
E        +  where 6 = ('MULTIPOLYGON', 6, True, -180.0, 180.0, 7320078083.14073,
E                       True, True, False, False).parts
1 failed
```

That tuple is (gtype, parts, valid, xmin, xmax, area, hits_france, hits_dakota, covers_greenwich, covers_seam). Area 7.32e9 against the correct 6.28e8 is the 11.6x blow-up, and `covers_greenwich` / `covers_seam` both False means the mangled output did not even contain its own two source points.

## Verification

```
cd backend && uv run ruff check .              → All checks passed!
cd backend && uv run ruff format --check .     → 846 files already formatted

# host, Postgres at localhost:5434
tests/test_analysis_materialize.py -k Dateline                     → 5 passed
tests/test_analysis_materialize.py tests/test_analysis_preview.py   → 102 passed
tests/test_ingest_metadata.py tests/test_metadata_roundtrip.py
  tests/test_ogc_collection_metadata.py tests/test_ai_chat_run_analysis.py
  tests/test_jobs_retry_analysis_copy.py tests/test_layering.py    → 84 passed
tests/test_stac_api.py tests/test_stac_integration.py tests/test_stac_serializer.py
  tests/test_stac_record_output.py tests/test_stac_validation.py
  tests/test_stac_search_validation.py tests/test_stac_datetime_filter.py
  tests/test_stac_visibility.py                                    → 115 passed
full suite (uv run pytest -n 4)                                    → 5953 passed, 81 skipped
```

Rebased onto `main` at `c22ba446b` (after #879/#880/#881/#882).

### Unrelated PostGIS quirk noticed while measuring

Worth recording because it distorts any "area vs an ideal circle" metric on multipart input, which is why the tables above compare fixed against raw instead. `ST_Buffer(::geography)` picks one planar working SRID for the whole input, so a multipart feature whose components are far apart in longitude gets buffered in a projection that suits neither:

```
one point (control)        ratio vs ideal 0.993
two points 0.2 deg apart   0.938
two points 10 deg apart    0.994
two points 90 deg apart    0.498   <-- half
two points 150 deg apart   0.994
```

Present in the raw buffer, before any of this PR's code, and unrelated to the antimeridian. Not touched here.

No schema, API, or config impact: the change is SQL inside an expression renderer, so `alembic-check` and the OpenAPI snapshot are untouched. All probe datasets and their `data.probe697_*` tables were deleted from the dev stack (verified 0 leftover records, 0 leftover tables); the terminal `catalog.ingest_jobs` rows have no deletion endpoint and will age out via retention.

Closes #697
