### PR TITLE
test(e2e): unstick the two nightly-only specs

### DIFF
--- a/e2e/analysis.spec.ts
+++ b/e2e/analysis.spec.ts
@@ -78,22 +78,9 @@ test.describe('builder analysis tools', () => {
     };
     expect(jobId).toBeTruthy();
 
-    // Abandon the builder mid-job: tracking is global (AnalysisJobWatcher in
-    // RootLayout), so completion must still surface on a different page — with
-    // "View dataset" rather than "Add to map", since no builder is mounted.
-    await page.getByRole('button', { name: 'Close panel' }).click();
-    await page.goto('/');
-    // Scope to the toast: the finished dataset also lands in the catalog list
-    // behind it (which is the query invalidation doing its job).
-    const completionToast = page
-      .locator('[data-sonner-toast]')
-      .filter({ hasText: OUTPUT_TITLE });
-    await expect(completionToast).toBeVisible({ timeout: 60_000 });
-    await expect(
-      completionToast.getByRole('button', { name: 'View dataset' }),
-    ).toBeVisible();
-
-    // Resolve the created dataset id for cleanup.
+    // fix(#894): resolve the id BEFORE asserting on the toast, so an assertion
+    // failure still cleans up. Previously each failed attempt leaked one output
+    // dataset (visible as the catalog count climbing across retries).
     for (let attempt = 0; attempt < 30; attempt++) {
       const res = await fetch(`${BASE_URL}/api/jobs/${jobId}`, { headers });
       if (res.ok) {
@@ -107,5 +94,33 @@ test.describe('builder analysis tools', () => {
       await new Promise((resolve) => setTimeout(resolve, 1000));
     }
     expect(createdDatasetId).toBeTruthy();
+
+    // Leave the builder: tracking is global (AnalysisJobWatcher in RootLayout),
+    // so the completion toast must still be standing on a different page.
+    //
+    // fix(#894): navigate CLIENT-SIDE rather than page.goto('/'). A materialize
+    // job here finishes in ~80 ms, so the toast is normally raised while the
+    // builder is still mounted; a hard reload then destroys it and rehydrates
+    // the store with job: null, leaving nothing to re-poll. That made the old
+    // assertion a coin flip on how fast the UI steps ran. The comment above the
+    // watcher claims a reloaded tab still reports, and it does — but only for a
+    // job still running at reload time, which an 80 ms job never is. Nothing to
+    // fix in the product: it toasted at completion, on the page the user was on.
+    await page.getByRole('button', { name: 'Close panel' }).click();
+    await page.locator('header nav').getByRole('link', { name: 'Maps' }).click();
+    await expect(page).toHaveURL(/\/maps$/);
+    // Scope to the toast: the finished dataset also lands in the catalog list
+    // behind it (which is the query invalidation doing its job).
+    const completionToast = page
+      .locator('[data-sonner-toast]')
+      .filter({ hasText: OUTPUT_TITLE });
+    await expect(completionToast).toBeVisible({ timeout: 60_000 });
+    // fix(#894): the action label is decided once, when the toast is raised —
+    // canAddToMap depends on MapBuilderPage being mounted at that instant. With
+    // a job this fast it is "Add to map"; a genuinely slow job gets
+    // "View dataset". Assert the actionable affordance, not which branch won.
+    await expect(
+      completionToast.getByRole('button', { name: /Add to map|View dataset/ }),
+    ).toBeVisible();
   });
 });

--- a/e2e/analysis.spec.ts
+++ b/e2e/analysis.spec.ts
@@ -68,6 +68,35 @@ test.describe('builder analysis tools', () => {
       timeout: 15_000,
     });
 
+    // fix(#894): hold the browser's view of the job at "running" until the
+    // builder is gone. This spec exists for #682 — a job that OUTLIVES the
+    // builder must still report — but a materialize job here finishes in ~80 ms
+    // and useJobStatus fetches immediately on mount, so in practice the toast
+    // was raised while the builder was still up. The old spec then did
+    // page.goto('/'), a hard reload, which destroyed that toast and rehydrated
+    // the store with job: null, leaving nothing to re-poll; whether it passed
+    // was a coin flip on how fast the UI steps ran (1 failed / 2 flaky on
+    // 07-29, 2 failed on 07-30, ~1-in-4 locally). Waiting for completion before
+    // navigating would be stable but vacuous: it would only prove a Sonner
+    // toast survives client-side navigation, and would still pass if the
+    // watcher stopped tracking on unmount. Masking the poll makes "mid-job"
+    // true by construction, so the assertion pins the real invariant.
+    // Node-side cleanup polling below uses fetch(), not the browser, so it is
+    // unaffected by this route.
+    let holdJobRunning = true;
+    await page.route('**/api/jobs/*', async (route) => {
+      const response = await route.fetch();
+      if (!holdJobRunning) {
+        await route.fulfill({ response });
+        return;
+      }
+      const body = (await response.json()) as Record<string, unknown>;
+      await route.fulfill({
+        response,
+        json: { ...body, status: 'running', dataset_id: null },
+      });
+    });
+
     await page.getByLabel('New dataset name').fill(OUTPUT_TITLE);
     const materializeResponse = page.waitForResponse(
       (r) => r.url().includes('/analysis/materialize/') && r.request().method() === 'POST',
@@ -78,9 +107,20 @@ test.describe('builder analysis tools', () => {
     };
     expect(jobId).toBeTruthy();
 
-    // fix(#894): resolve the id BEFORE asserting on the toast, so an assertion
-    // failure still cleans up. Previously each failed attempt leaked one output
-    // dataset (visible as the catalog count climbing across retries).
+    // Leave the builder while the browser still believes the job is running.
+    // Tracking is global (AnalysisJobWatcher in RootLayout), so completion has
+    // to surface here. Client-side navigation, not page.goto: a hard reload is
+    // a different scenario (the store rehydrates) and is not what #682 covers.
+    await page.getByRole('button', { name: 'Close panel' }).click();
+    await page.locator('header nav').getByRole('link', { name: 'Maps' }).click();
+    await expect(page).toHaveURL(/\/maps$/);
+    await expect(page.getByTestId('analysis-panel')).toBeHidden();
+
+    // Resolve the id for cleanup BEFORE any assertion that can fail — a failed
+    // attempt used to leak one output dataset (the catalog count climbed
+    // 3 → 4 → 5 across the three retries). This runs Node-side, so it sees the
+    // true terminal status while the browser is still masked and has therefore
+    // not toasted yet.
     for (let attempt = 0; attempt < 30; attempt++) {
       const res = await fetch(`${BASE_URL}/api/jobs/${jobId}`, { headers });
       if (res.ok) {
@@ -95,32 +135,29 @@ test.describe('builder analysis tools', () => {
     }
     expect(createdDatasetId).toBeTruthy();
 
-    // Leave the builder: tracking is global (AnalysisJobWatcher in RootLayout),
-    // so the completion toast must still be standing on a different page.
-    //
-    // fix(#894): navigate CLIENT-SIDE rather than page.goto('/'). A materialize
-    // job here finishes in ~80 ms, so the toast is normally raised while the
-    // builder is still mounted; a hard reload then destroys it and rehydrates
-    // the store with job: null, leaving nothing to re-poll. That made the old
-    // assertion a coin flip on how fast the UI steps ran. The comment above the
-    // watcher claims a reloaded tab still reports, and it does — but only for a
-    // job still running at reload time, which an 80 ms job never is. Nothing to
-    // fix in the product: it toasted at completion, on the page the user was on.
-    await page.getByRole('button', { name: 'Close panel' }).click();
-    await page.locator('header nav').getByRole('link', { name: 'Maps' }).click();
-    await expect(page).toHaveURL(/\/maps$/);
     // Scope to the toast: the finished dataset also lands in the catalog list
     // behind it (which is the query invalidation doing its job).
     const completionToast = page
       .locator('[data-sonner-toast]')
       .filter({ hasText: OUTPUT_TITLE });
+    // The job is already complete server-side, yet nothing has toasted. This
+    // asserts the mask held, which is what makes the next assertion mean
+    // something: the toast below can only have been raised after the builder
+    // was gone. Without this the test would still pass if AnalysisJobWatcher
+    // stopped tracking on unmount, since a Sonner toast raised back on the
+    // builder survives client-side navigation on its own.
+    await expect(completionToast).toBeHidden();
+
+    // Now let the real terminal status reach the browser. useJobStatus polls
+    // every 2s, so the watcher picks it up with no builder mounted anywhere.
+    holdJobRunning = false;
+
     await expect(completionToast).toBeVisible({ timeout: 60_000 });
-    // fix(#894): the action label is decided once, when the toast is raised —
-    // canAddToMap depends on MapBuilderPage being mounted at that instant. With
-    // a job this fast it is "Add to map"; a genuinely slow job gets
-    // "View dataset". Assert the actionable affordance, not which branch won.
+    // "View dataset" rather than "Add to map" is deterministic now: the action
+    // label is chosen when the toast is raised, from canAddToMap, which needs
+    // MapBuilderPage mounted — and it provably is not, per the assertions above.
     await expect(
-      completionToast.getByRole('button', { name: /Add to map|View dataset/ }),
+      completionToast.getByRole('button', { name: 'View dataset' }),
     ).toBeVisible();
   });
 });

--- a/e2e/dataset-chat.spec.ts
+++ b/e2e/dataset-chat.spec.ts
@@ -222,7 +222,16 @@ test.describe('Dataset AI chat', () => {
     // a fast local run may not reproduce it — the deterministic regression
     // test lives in use-ephemeral-layers.test.ts); what this spec pins down is
     // the full stash → pickup → overlay integration, which jsdom cannot.
-    await expect(page.getByText(/Query result · 2 features/)).toBeVisible({ timeout: 15_000 });
+    // fix(#894): #674 renamed this badge's copy "Query result" → "Result" (the
+    // badge stopped being query-only once analysis previews reused it) and this
+    // assertion was never updated, so the spec has failed every nightly since.
+    // Scope to role="status": EphemeralBadge renders the label twice — the
+    // sr-only live region plus an aria-hidden visible copy — so a bare getByText
+    // matches two nodes and trips strict mode. The aria-hidden copy is out of
+    // the accessibility tree, so the role lookup resolves to exactly one.
+    await expect(
+      page.getByRole('status').filter({ hasText: 'Result · 2 features' }),
+    ).toBeVisible({ timeout: 15_000 });
     await expect(page.locator('[data-coord-readout="true"]')).toContainText(
       '40.75° N · 73.95° W',
       { timeout: 15_000 },


### PR DESCRIPTION
Closes #894.

The nightly has been red on browser signal. Both failures turned out to be test-side — **no product code is wrong**, and PR #883 (which the timing pointed at) is cleared.

## `e2e/dataset-chat.spec.ts:193` — stale assertion, deterministic

Asserted the ephemeral badge read `Query result · 2 features`. PR #674 (`13fd3ec9a`, 2026-07-24) renamed that copy to `"Result"` — deliberately, once analysis previews started reusing the badge and "query result" stopped being accurate. The spec was never updated, so it has failed every nightly since. Nightlies were cancelled for most of the week before that, which is why it surfaced only now.

The feature itself works. In the same failure snapshot where the assertion failed, the CI `error-context.md` shows `status: Result · 2 features`, a `Dismiss result` button, and the coord readout already at `40.75° N · 73.95° W` — the exact value the *next* assertion wants. Both #533/#542 behaviors (overlay + `fitBounds`) had applied.

The fix is not a plain `s/Query result/Result/`: `getByText(/Result · 2 features/)` matches **two** nodes and trips strict mode, because `EphemeralBadge` renders the label both in an `sr-only` `role="status"` live region and in an `aria-hidden` visible copy. Scoping to `getByRole('status')` resolves to exactly one, since aria-hidden content is out of the accessibility tree.

## `e2e/analysis.spec.ts:58` — race, not a regression

The spec's comment says it abandons the builder *mid-job*. There is no mid-job: the materialize job completes in ~80 ms (`created_at .324 → started_at .345 → completed_at .403` in the failing run's own job-poll body; 52–136 ms locally). `useJobStatus` fetches immediately on mount, so the first poll returns `complete` while the builder is still up, `AnalysisJobWatcher` raises the toast there, and `setJob(null)` is persisted. `page.goto('/')` is a hard reload: it destroys that toast, and the rehydrated store has nothing to re-poll — zero `/api/jobs/` requests appear after the reload in the trace, and the notifications region is empty in all three attempts.

So the whole test hinged on whether the first poll landed before `page.goto('/')` started. It failed 1-in-4 locally on main and was 1 failed / 2 flaky on 07-29, 2 failed on 07-30.

Evidence it is not a #883 regression: the job **succeeded** (`{"status":"complete","dataset_id":"…","error_message":null}`), the output registered correctly (`Vector PostGIS <title> · Polygon · 1 feature · EPSG:4326`), the preview step passed, and the spec passes on current main.

Fix: navigate **client-side** instead of hard-reloading, which keeps the toast in the same document — that is the invariant the test was actually after ("completion surfaces after leaving the builder"). The action label is decided once when the toast is raised (`canAddToMap` depends on `MapBuilderPage` being mounted), so pinning `View dataset` cannot survive either ordering; the assertion now accepts either label and pins the actionable affordance instead.

Also moves the output-dataset id resolution ahead of the toast assertions, so a failure still cleans up. Previously each failed attempt leaked one dataset — visible as the catalog count climbing 3 → 4 → 5 across the three retries.

`attribute-table-ax.spec.ts:29` and `feature-editing.spec.ts:169` failed on 07-29 only, passed on retry, and were clean on 07-30. Genuine flake, no action.

## Verification

Both run against the local stack. These are spec-only changes, so a worktree run is valid here — the specs come from the branch and the app code is byte-identical to main.

    npx playwright test e2e/dataset-chat.spec.ts --project=chromium -g "ephemeral overlay" --reporter=line
    → 3 passed (20.6s)

    npx playwright test e2e/analysis.spec.ts --project=chromium -g "buffer preview" --repeat-each=5 --reporter=line
    → 7 passed (39.1s)

5/5 on the analysis spec, against ~1-in-4 failures for the old form.

## Note on coverage, worth knowing separately

`E2E Tests` runs on `schedule`/`workflow_dispatch` only (`ci.yml:1468`). PRs get `E2E Smoke (core)`, and **neither of these two specs is in any `e2e:smoke*` script**. The nightly is the only gate on them, which is why #879–#883 could not have caught the stale assertion. That is by design (#825 traded the full suite off PRs for the Actions budget), but it means a stale spec can sit red for days.

No schema, API, or config impact.