### PR TITLE
fix(tiles): surface raster tile auth failures and unify token refresh

### DIFF
--- a/frontend/src/components/builder/BuilderMap.tsx
+++ b/frontend/src/components/builder/BuilderMap.tsx
@@ -631,14 +631,14 @@ export const BuilderMap = memo(function BuilderMap({
       // real error has occurred (RES-3). Previously silenced in production.
       errorHandlerRef.current = (e: { error: { message?: string; status?: number; url?: string }; sourceId?: string }) => {
         const status = e.error?.status;
-        // fix(#890): a raster/DEM 401/403 has NO client-side cure — raster auth
-        // rides the Authorization header (setTransformRequest), so neither the
-        // GUARD-03 re-sign nor the #621 re-mint touches it. Claiming it
-        // "handled" (a suppressed warning) while logUnhandledMapError still
-        // console.errors the same failure is the #755 double-log shape, still
-        // live for raster/DEM. `isHandledTileAuthError` already excludes these,
-        // so the handler now agrees with it: report it as the unsuppressed
-        // error it is and let the toast + single console row own it.
+        // fix(#890): a raster/DEM 401/403 is not cured by anything the recovery
+        // path produces — raster auth rides the Authorization header
+        // (setTransformRequest), so neither the GUARD-03 re-sign nor a fresh sig
+        // reaches it. Reporting it "handled" (a suppressed warning) while
+        // logUnhandledMapError still console.errors the same failure is the #755
+        // double-log shape, still live for raster/DEM. `isHandledTileAuthError`
+        // already excludes these, so the handler now agrees with it: report the
+        // unsuppressed error it is and let the toast + single console row own it.
         const rasterAuthError = isRasterTileAuthError(e);
         // Capture EVERY map error into the problem-reporter buffer before the
         // suppression/early-return logic below — suppressed errors (expected
@@ -679,7 +679,7 @@ export const BuilderMap = memo(function BuilderMap({
               // the fresh batch, and a conclusively dead session surfaces
               // through the global signed-out handling (#628) via the mint
               // request itself.
-              // fix(#890, codex P1): the re-mint runs for raster too — the mint
+              // fix(#890) (codex P1): the re-mint runs for raster too — the mint
               // request goes through apiFetch, whose proactive refresh renews an
               // expiring JWT, and that Bearer is the ONLY thing that fixes a
               // raster 401. What must not happen is treating it as recovery: the

--- a/frontend/src/components/builder/BuilderMap.tsx
+++ b/frontend/src/components/builder/BuilderMap.tsx
@@ -644,6 +644,13 @@ export const BuilderMap = memo(function BuilderMap({
         // suppression/early-return logic below — suppressed errors (expected
         // no-data tiles, terrain/DEM mismatches) are frequently the actual bug
         // an engineer needs, so we flag rather than drop them here.
+        // fix(#890): an unsuppressed row here pairs with the `console` row
+        // initReportCapture derives from logUnhandledMapError's console.error —
+        // two rows per unrecovered failure. That is the buffer's long-standing
+        // shape for every error no surface recovers (any tile 5xx does the same;
+        // BuilderMap.raster-tile-auth.test.tsx pins the parity). Dropping either
+        // half for raster would cost the sourceId this row carries, or the
+        // devtools log the surfaces without a row of their own rely on.
         const isClientError = Boolean(status && status >= 400 && status < 500);
         const suppressedClientError = isClientError && !rasterAuthError;
         pushReportEntry({

--- a/frontend/src/components/builder/BuilderMap.tsx
+++ b/frontend/src/components/builder/BuilderMap.tsx
@@ -566,16 +566,16 @@ export const BuilderMap = memo(function BuilderMap({
   // fix(#621): shared tile-auth recovery — a vector tile 401/403 that the
   // cached-token re-sign can't cure kicks one throttled token re-mint; the
   // token-sync effect re-signs sources when the fresh batch lands.
-  const recoverTileAuth = useTileAuthRecovery(invalidateTileTokens);
+  // fix(#890): report every mint the recovery path actually kicks (suppressed),
+  // so a tab-return recovery still leaves a trace now that it no longer arrives
+  // wrapped in a 403 burst.
+  const recoverTileAuth = useTileAuthRecovery(invalidateTileTokens, (trigger) =>
+    reportTileTokenRemint('builder', trigger),
+  );
   // fix(#755): a tab backgrounded past the 900 s sig boundary comes back with
   // stale tokens, so MapLibre's resumed fetches 403 before the handler above
   // can heal them. Kick the same throttled re-mint on the visible edge.
-  // fix(#890): report it (suppressed) so the re-mint still leaves a trace.
-  useVisibleTileTokenRefresh(
-    () => syncInputsRef.current.tokenMap.values(),
-    recoverTileAuth,
-    () => reportTileTokenRemint('builder'),
-  );
+  useVisibleTileTokenRefresh(() => syncInputsRef.current.tokenMap.values(), recoverTileAuth);
 
   const handleLoad = useCallback(
     (e: MapLibreEvent) => {
@@ -663,15 +663,15 @@ export const BuilderMap = memo(function BuilderMap({
             // dataset) so MapLibre retries with a fresh sig, and suppress the
             // toast for that recoverable case. Raster sources and genuine
             // no-token cases return false and fall through to the toast below.
-            // fix(#890): skip the whole recovery claim for a raster/DEM tile —
-            // `resignVectorSourceForRetry` returns false for it and the re-mint
-            // does nothing, so the old `resigned || reminted` check reported a
-            // recovery that never happened and swallowed the toast.
             const map = mapRef.current;
             const failingSourceId = e.sourceId;
-            if (!rasterAuthError && map && failingSourceId) {
+            if (map && failingSourceId) {
               const { layers: l, tokenMap: tm, tileConfig: tc } = syncInputsRef.current;
-              const resigned = resignVectorSourceForRetry(map, failingSourceId, l, tm, tc);
+              // fix(#890): nothing here re-signs a raster/DEM source (its auth
+              // rides the Authorization header), so don't pretend to.
+              const resigned = rasterAuthError
+                ? false
+                : resignVectorSourceForRetry(map, failingSourceId, l, tm, tc);
               // fix(#621): the cached-token re-sign only cures the attach
               // race — when the sig itself has expired (stranded session),
               // it re-signs with the same stale sig forever. Also kick one
@@ -679,8 +679,15 @@ export const BuilderMap = memo(function BuilderMap({
               // the fresh batch, and a conclusively dead session surfaces
               // through the global signed-out handling (#628) via the mint
               // request itself.
+              // fix(#890, codex P1): the re-mint runs for raster too — the mint
+              // request goes through apiFetch, whose proactive refresh renews an
+              // expiring JWT, and that Bearer is the ONLY thing that fixes a
+              // raster 401. What must not happen is treating it as recovery: the
+              // fresh sig cannot help a raster tile, so a raster failure falls
+              // through to the toast below and is reported unsuppressed, instead
+              // of reading as handled next to logUnhandledMapError's console row.
               const reminted = recoverTileAuth();
-              if (resigned || reminted) {
+              if (!rasterAuthError && (resigned || reminted)) {
                 pushReportEntry({
                   severity: 'warning',
                   source: 'maplibre',

--- a/frontend/src/components/builder/BuilderMap.tsx
+++ b/frontend/src/components/builder/BuilderMap.tsx
@@ -13,12 +13,12 @@ import {
 } from '@/lib/basemap-utils';
 import { buildClusterTileUrl, buildSignedTileUrl, buildTileTransformRequest, isMvtSourceLayerConfigReady } from '@/lib/tile-utils';
 import { useRemoteBasemapStyle } from '@/components/map/hooks/use-remote-basemap-style';
-import { logUnhandledMapError } from '@/lib/map-error-log';
+import { isRasterTileAuthError, logUnhandledMapError } from '@/lib/map-error-log';
 import { useTileTokens, useInvalidateTileTokens } from '@/hooks/use-tile-token';
 import { useTileAuthRecovery, useVisibleTileTokenRefresh } from '@/hooks/use-tile-auth-recovery';
 import { useTileTokenError } from './hooks/use-tile-token-error';
 import { getEnvConfig } from '@/lib/env';
-import { pushReportEntry } from '@/lib/report';
+import { pushReportEntry, reportTileTokenRemint } from '@/lib/report';
 import { useAuthStore } from '@/stores/auth-store';
 import { useWebGLRecovery } from '@/hooks/use-webgl-recovery';
 import i18n from '@/i18n/i18n';
@@ -570,7 +570,12 @@ export const BuilderMap = memo(function BuilderMap({
   // fix(#755): a tab backgrounded past the 900 s sig boundary comes back with
   // stale tokens, so MapLibre's resumed fetches 403 before the handler above
   // can heal them. Kick the same throttled re-mint on the visible edge.
-  useVisibleTileTokenRefresh(() => syncInputsRef.current.tokenMap.values(), recoverTileAuth);
+  // fix(#890): report it (suppressed) so the re-mint still leaves a trace.
+  useVisibleTileTokenRefresh(
+    () => syncInputsRef.current.tokenMap.values(),
+    recoverTileAuth,
+    () => reportTileTokenRemint('builder'),
+  );
 
   const handleLoad = useCallback(
     (e: MapLibreEvent) => {
@@ -624,19 +629,29 @@ export const BuilderMap = memo(function BuilderMap({
       // Filter expected tile errors (no-data tiles outside extent) and
       // surface anything else as a deduped toast so the editor knows a
       // real error has occurred (RES-3). Previously silenced in production.
-      errorHandlerRef.current = (e: { error: { message?: string; status?: number }; sourceId?: string }) => {
+      errorHandlerRef.current = (e: { error: { message?: string; status?: number; url?: string }; sourceId?: string }) => {
         const status = e.error?.status;
+        // fix(#890): a raster/DEM 401/403 has NO client-side cure — raster auth
+        // rides the Authorization header (setTransformRequest), so neither the
+        // GUARD-03 re-sign nor the #621 re-mint touches it. Claiming it
+        // "handled" (a suppressed warning) while logUnhandledMapError still
+        // console.errors the same failure is the #755 double-log shape, still
+        // live for raster/DEM. `isHandledTileAuthError` already excludes these,
+        // so the handler now agrees with it: report it as the unsuppressed
+        // error it is and let the toast + single console row own it.
+        const rasterAuthError = isRasterTileAuthError(e);
         // Capture EVERY map error into the problem-reporter buffer before the
         // suppression/early-return logic below — suppressed errors (expected
         // no-data tiles, terrain/DEM mismatches) are frequently the actual bug
         // an engineer needs, so we flag rather than drop them here.
         const isClientError = Boolean(status && status >= 400 && status < 500);
+        const suppressedClientError = isClientError && !rasterAuthError;
         pushReportEntry({
-          severity: isClientError ? 'warning' : 'error',
+          severity: suppressedClientError ? 'warning' : 'error',
           source: 'maplibre',
           message: e.error?.message || (status ? `Map error (HTTP ${status})` : 'Map error'),
           detail: e.sourceId ? `source: ${e.sourceId}` : undefined,
-          suppressed: isClientError || shouldSuppressBuilderMapError(e.error),
+          suppressed: suppressedClientError || shouldSuppressBuilderMapError(e.error),
         });
         // Suppress expected no-data tiles (404) and other client errors
         if (status && status >= 400 && status < 500) {
@@ -648,9 +663,13 @@ export const BuilderMap = memo(function BuilderMap({
             // dataset) so MapLibre retries with a fresh sig, and suppress the
             // toast for that recoverable case. Raster sources and genuine
             // no-token cases return false and fall through to the toast below.
+            // fix(#890): skip the whole recovery claim for a raster/DEM tile —
+            // `resignVectorSourceForRetry` returns false for it and the re-mint
+            // does nothing, so the old `resigned || reminted` check reported a
+            // recovery that never happened and swallowed the toast.
             const map = mapRef.current;
             const failingSourceId = e.sourceId;
-            if (map && failingSourceId) {
+            if (!rasterAuthError && map && failingSourceId) {
               const { layers: l, tokenMap: tm, tileConfig: tc } = syncInputsRef.current;
               const resigned = resignVectorSourceForRetry(map, failingSourceId, l, tm, tc);
               // fix(#621): the cached-token re-sign only cures the attach

--- a/frontend/src/components/builder/__tests__/BuilderMap.raster-tile-auth.test.tsx
+++ b/frontend/src/components/builder/__tests__/BuilderMap.raster-tile-auth.test.tsx
@@ -197,13 +197,16 @@ function makeLayer(overrides: Partial<MapLayerResponse> = {}): MapLayerResponse 
   } as unknown as MapLayerResponse;
 }
 
+let errorSpy: ReturnType<typeof vi.spyOn>;
+
 async function renderBuilderMap(layer: MapLayerResponse) {
   await act(async () => {
     render(<BuilderMap layers={[layer]} basemapStyle="openfreemap-positron" />);
   });
-  // Drop the mount-time token→setTiles sync so the assertions below only see
-  // what the error handler did.
+  // Drop the mount-time token→setTiles sync (and anything React logged during
+  // it) so the assertions below only see what the error handler did.
   mapState.setTiles.mockClear();
+  errorSpy.mockClear();
 }
 
 /** Entries the surface handler pushed for a map error (report buffer rows). */
@@ -212,8 +215,6 @@ function pushedEntries() {
 }
 
 describe('BuilderMap raster/DEM tile auth errors (fix #890)', () => {
-  let errorSpy: ReturnType<typeof vi.spyOn>;
-
   beforeEach(() => {
     mapState.reset();
     tileTokenState.invalidate.mockClear();

--- a/frontend/src/components/builder/__tests__/BuilderMap.raster-tile-auth.test.tsx
+++ b/frontend/src/components/builder/__tests__/BuilderMap.raster-tile-auth.test.tsx
@@ -1,15 +1,17 @@
 // fix(#890): the #755 double-log shape was still live for raster/DEM tiles.
-// `isHandledTileAuthError` excludes `/raster-tiles/` (audit w3-maps A1) because
-// raster auth rides the Authorization header, so nothing the surface does can
-// recover it — but BuilderMap's own error handler called recoverTileAuth() for
-// EVERY 401/403 and reported a suppressed "re-mint requested" row (reminted is
-// true even though resignVectorSourceForRetry returned false), while the <Map>
-// onError fallback still console.errored the same failure. One suppressed yellow
-// next to one unsuppressed red, for a failure nobody was recovering.
+// `isHandledTileAuthError` excludes `/raster-tiles/` (audit w3-maps A1) because a
+// fresh tile sig cannot fix raster auth — that rides the Authorization header —
+// but BuilderMap's own error handler reported a suppressed "re-mint requested"
+// row anyway (`reminted` is true even though resignVectorSourceForRetry returned
+// false), while the <Map> onError fallback still console.errored the same
+// failure. One suppressed yellow next to one unsuppressed red, and the early
+// return swallowed the toast, for a failure nobody was recovering.
 //
-// The handler is now narrowed to agree with the predicate: a raster/DEM 401/403
-// is reported ONCE, unsuppressed, and surfaces the session-expired toast. The
-// vector path (GUARD-03 re-sign + #621 re-mint) is unchanged.
+// The handler now agrees with the predicate: a raster/DEM 401/403 is reported
+// ONCE, unsuppressed, and surfaces the session-expired toast. The re-mint itself
+// still runs — its apiFetch renews an expiring JWT, which IS what a raster 401
+// needs (codex P1 on this PR) — it just no longer counts as recovery. The vector
+// path (GUARD-03 re-sign + #621 re-mint) is unchanged.
 
 import type { ReactNode } from 'react';
 import { act, render } from '@/test/test-utils';
@@ -253,7 +255,7 @@ describe('BuilderMap raster/DEM tile auth errors (fix #890)', () => {
       mapState.onError?.(event);
     });
 
-    // fix(#890, codex P1): the re-mint still runs — its apiFetch renews an
+    // fix(#890) (codex P1): the re-mint still runs — its apiFetch renews an
     // expiring JWT, the one thing that can fix a raster 401 — but nothing about
     // it recovers the tile, so no recovery may be CLAIMED.
     expect(tileTokenState.invalidate).toHaveBeenCalledTimes(1);

--- a/frontend/src/components/builder/__tests__/BuilderMap.raster-tile-auth.test.tsx
+++ b/frontend/src/components/builder/__tests__/BuilderMap.raster-tile-auth.test.tsx
@@ -253,14 +253,19 @@ describe('BuilderMap raster/DEM tile auth errors (fix #890)', () => {
       mapState.onError?.(event);
     });
 
-    // No recovery was possible, so none may be claimed.
-    expect(tileTokenState.invalidate).not.toHaveBeenCalled();
+    // fix(#890, codex P1): the re-mint still runs — its apiFetch renews an
+    // expiring JWT, the one thing that can fix a raster 401 — but nothing about
+    // it recovers the tile, so no recovery may be CLAIMED.
+    expect(tileTokenState.invalidate).toHaveBeenCalledTimes(1);
     expect(pushedEntries()).toHaveLength(1);
     expect(pushedEntries()[0]).toMatchObject({ suppressed: false, severity: 'error', source: 'maplibre' });
     expect(pushedEntries().some((e) => String(e.message).includes('re-mint requested'))).toBe(false);
     // …and the single honest log is the wrapper's console.error.
     expect(errorSpy).toHaveBeenCalledTimes(1);
     expect(errorSpy).toHaveBeenCalledWith(event.error);
+    // The mint that did run is reported once, attributed to the error path.
+    expect(reportState.remint).toHaveBeenCalledTimes(1);
+    expect(reportState.remint).toHaveBeenCalledWith('builder', 'tile-error');
   });
 
   it('surfaces the auth toast for a raster 401 instead of swallowing it', async () => {

--- a/frontend/src/components/builder/__tests__/BuilderMap.raster-tile-auth.test.tsx
+++ b/frontend/src/components/builder/__tests__/BuilderMap.raster-tile-auth.test.tsx
@@ -289,6 +289,53 @@ describe('BuilderMap raster/DEM tile auth errors (fix #890)', () => {
     expect(mapState.setTiles).not.toHaveBeenCalled();
   });
 
+  // fix(#890): a raster auth failure is now recorded the same way an unrecovered
+  // 5xx tile error already was — one unsuppressed `maplibre` row from the handler
+  // plus the wrapper's console.error (which initReportCapture turns into a
+  // `console` row). That pairing is the buffer's shape for EVERY error no
+  // surface recovers, and it predates this PR; the #755 bug was a suppressed
+  // "recovered" row sitting next to it, not the pairing. Dropping either half
+  // for raster would cost the sourceId (the console row has none) or the devtools
+  // log (the surfaces without their own row have nothing else). This pins the
+  // parity so a future "dedupe raster" change has to face the 5xx case too.
+  it('records a raster 403 the same way an unrecovered 5xx is recorded', async () => {
+    const layer = makeLayer({ dataset_record_type: 'raster_dataset' });
+    await renderBuilderMap(layer);
+
+    const serverError = {
+      error: { message: 'AJAXError: (500)', status: 500, url: RASTER_TILE_URL },
+      sourceId: getSourceIdForLayer(layer),
+    };
+    act(() => {
+      mapState.fakeMap.emit('error', serverError);
+      mapState.onError?.(serverError);
+    });
+    const fiveHundred = pushedEntries();
+    const fiveHundredLogs = errorSpy.mock.calls.length;
+    // Guard against a vacuous comparison below.
+    expect(fiveHundred).toHaveLength(1);
+    expect(fiveHundred[0]).toMatchObject({ severity: 'error', suppressed: false });
+    expect(fiveHundredLogs).toBe(1);
+
+    reportState.push.mockClear();
+    errorSpy.mockClear();
+    const rasterError = {
+      error: { message: `AJAXError: (403): ${RASTER_TILE_URL}`, status: 403, url: RASTER_TILE_URL },
+      sourceId: getSourceIdForLayer(layer),
+    };
+    act(() => {
+      mapState.fakeMap.emit('error', rasterError);
+      mapState.onError?.(rasterError);
+    });
+
+    expect(pushedEntries()).toHaveLength(fiveHundred.length);
+    expect(pushedEntries()[0]).toMatchObject({
+      severity: fiveHundred[0].severity,
+      suppressed: fiveHundred[0].suppressed,
+    });
+    expect(errorSpy.mock.calls.length).toBe(fiveHundredLogs);
+  });
+
   it('still re-signs and re-mints a first-party VECTOR 403 (GUARD-03 / #621 intact)', async () => {
     const layer = makeLayer();
     const sourceId = getSourceIdForLayer(layer);

--- a/frontend/src/components/builder/__tests__/BuilderMap.raster-tile-auth.test.tsx
+++ b/frontend/src/components/builder/__tests__/BuilderMap.raster-tile-auth.test.tsx
@@ -1,0 +1,308 @@
+// fix(#890): the #755 double-log shape was still live for raster/DEM tiles.
+// `isHandledTileAuthError` excludes `/raster-tiles/` (audit w3-maps A1) because
+// raster auth rides the Authorization header, so nothing the surface does can
+// recover it — but BuilderMap's own error handler called recoverTileAuth() for
+// EVERY 401/403 and reported a suppressed "re-mint requested" row (reminted is
+// true even though resignVectorSourceForRetry returned false), while the <Map>
+// onError fallback still console.errored the same failure. One suppressed yellow
+// next to one unsuppressed red, for a failure nobody was recovering.
+//
+// The handler is now narrowed to agree with the predicate: a raster/DEM 401/403
+// is reported ONCE, unsuppressed, and surfaces the session-expired toast. The
+// vector path (GUARD-03 re-sign + #621 re-mint) is unchanged.
+
+import type { ReactNode } from 'react';
+import { act, render } from '@/test/test-utils';
+import type { MapLayerResponse } from '@/types/api';
+import type { VectorTileToken } from '@/api/tiles';
+import { getSourceIdForLayer } from '@/components/builder/map-sync';
+import { BuilderMap } from '../BuilderMap';
+
+vi.mock('@/hooks/use-settings', () => ({
+  useBasemaps: () => ({
+    data: [
+      {
+        id: 'openfreemap-positron',
+        label: 'Light',
+        url: 'https://tiles.example.com/styles/basic',
+        enabled: true,
+      },
+    ],
+  }),
+  useMapDefaults: () => ({ data: { center_lng: 0, center_lat: 0, zoom: 2 } }),
+  useTileConfig: () => ({ data: { cdn_base_url: null, mvt_source_layer_prefix: 'data' } }),
+  useEnabledPlugins: () => ({ data: [], isLoading: false }),
+}));
+
+const tileTokenState = vi.hoisted(() => ({
+  tokens: [] as Array<{ data: VectorTileToken | undefined; isLoading: boolean; isError: boolean }>,
+  invalidate: vi.fn(),
+}));
+
+vi.mock('@/hooks/use-tile-token', () => ({
+  useInvalidateTileTokens: () => tileTokenState.invalidate,
+  useTileTokens: () => tileTokenState.tokens,
+}));
+
+vi.mock('@/hooks/use-webgl-recovery', () => ({
+  useWebGLRecovery: () => ({ contextLost: false, reload: vi.fn() }),
+}));
+
+vi.mock('@/components/map/MapCoordReadout', () => ({ MapCoordReadout: () => null }));
+
+vi.mock('sonner', () => ({
+  toast: { error: vi.fn(), success: vi.fn(), warning: vi.fn() },
+}));
+
+// Capture the problem-reporter writes — the report buffer is where the double
+// log was visible, so the entries ARE the assertion surface here.
+const reportState = vi.hoisted(() => ({ push: vi.fn(), remint: vi.fn() }));
+vi.mock('@/lib/report', () => ({
+  pushReportEntry: reportState.push,
+  reportTileTokenRemint: reportState.remint,
+}));
+
+vi.mock('@/components/builder/map-sync', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/components/builder/map-sync')>();
+  return {
+    ...actual,
+    syncLayersToMap: vi.fn(),
+    applyBasemapConfigToMap: vi.fn(),
+    reorderBasemapLabels: vi.fn(),
+    reorderDataLayers: vi.fn(),
+    ensureRasterDemTerrainSource: vi.fn(),
+  };
+});
+
+import { toast } from 'sonner';
+import { useAuthStore } from '@/stores/auth-store';
+
+type FakeMap = {
+  on: ReturnType<typeof vi.fn>;
+  off: ReturnType<typeof vi.fn>;
+  once: ReturnType<typeof vi.fn>;
+  setTransformRequest: ReturnType<typeof vi.fn>;
+  isStyleLoaded: ReturnType<typeof vi.fn>;
+  getCanvas: ReturnType<typeof vi.fn>;
+  setTerrain: ReturnType<typeof vi.fn>;
+  setProjection: ReturnType<typeof vi.fn>;
+  triggerRepaint: ReturnType<typeof vi.fn>;
+  getSource: ReturnType<typeof vi.fn>;
+  getLayer: ReturnType<typeof vi.fn>;
+  getStyle: ReturnType<typeof vi.fn>;
+  fitBounds: ReturnType<typeof vi.fn>;
+  getZoom: ReturnType<typeof vi.fn>;
+  setZoom: ReturnType<typeof vi.fn>;
+  emit: (event: string, payload?: unknown) => void;
+};
+
+const mapState = vi.hoisted(() => {
+  const handlers = new Map<string, Set<(payload?: unknown) => void>>();
+  const track = (event: string, handler: (payload?: unknown) => void) => {
+    const existing = handlers.get(event) ?? new Set();
+    existing.add(handler);
+    handlers.set(event, existing);
+  };
+  const setTiles = vi.fn();
+  const state = {
+    setTiles,
+    // The <Map> `onError` prop, captured from the render so the test drives the
+    // REAL wiring (logUnhandledMapError) instead of assuming it.
+    onError: null as ((e: unknown) => void) | null,
+    fakeMap: {} as FakeMap,
+    reset: () => {
+      handlers.clear();
+      setTiles.mockClear();
+      state.onError = null;
+    },
+  };
+  state.fakeMap = {
+    on: vi.fn(track),
+    off: vi.fn((event: string, handler: (payload?: unknown) => void) => {
+      handlers.get(event)?.delete(handler);
+    }),
+    once: vi.fn(track),
+    setTransformRequest: vi.fn(),
+    isStyleLoaded: vi.fn(() => true),
+    getCanvas: vi.fn(() => ({ style: { cursor: '' }, addEventListener: vi.fn(), removeEventListener: vi.fn() })),
+    setTerrain: vi.fn(),
+    setProjection: vi.fn(),
+    triggerRepaint: vi.fn(),
+    getSource: vi.fn(() => ({ type: 'vector', setTiles })),
+    getLayer: vi.fn(() => null),
+    getStyle: vi.fn(() => ({ layers: [] })),
+    fitBounds: vi.fn(),
+    getZoom: vi.fn(() => 2),
+    setZoom: vi.fn(),
+    emit: (event: string, payload?: unknown) => {
+      for (const handler of Array.from(handlers.get(event) ?? [])) handler(payload);
+    },
+  };
+  return state;
+});
+
+vi.mock('@vis.gl/react-maplibre', async () => {
+  const React = await import('react');
+  return {
+    Map: ({
+      children,
+      onLoad,
+      onError,
+    }: {
+      children?: ReactNode;
+      onLoad?: (event: { target: FakeMap }) => void;
+      onError?: (e: unknown) => void;
+    }) => {
+      mapState.onError = onError ?? null;
+      React.useEffect(() => {
+        onLoad?.({ target: mapState.fakeMap });
+      }, [onLoad]);
+      return <div data-testid="mapgl">{children}</div>;
+    },
+    NavigationControl: () => null,
+    ScaleControl: () => null,
+  };
+});
+
+const DATASET_ID = 'ds-uuid-890';
+const RASTER_TILE_URL = `${window.location.origin}/raster-tiles/${DATASET_ID}/tiles/9/151/191.png`;
+
+function makeLayer(overrides: Partial<MapLayerResponse> = {}): MapLayerResponse {
+  return {
+    id: 'layer-890',
+    dataset_id: DATASET_ID,
+    dataset_name: 'Elevation',
+    dataset_geometry_type: 'Polygon',
+    dataset_table_name: 'elevation',
+    dataset_extent_bbox: null,
+    dataset_column_info: null,
+    dataset_feature_count: null,
+    dataset_sample_values: null,
+    display_name: null,
+    sort_order: 0,
+    visible: true,
+    opacity: 1,
+    paint: {},
+    layout: {},
+    filter: null,
+    label_config: null,
+    popup_config: null,
+    style_config: null,
+    layer_type: null,
+    dataset_record_type: 'vector_dataset',
+    show_in_legend: true,
+    is_dem: false,
+    dem_vertical_units: null,
+    ...(overrides as object),
+  } as unknown as MapLayerResponse;
+}
+
+async function renderBuilderMap(layer: MapLayerResponse) {
+  await act(async () => {
+    render(<BuilderMap layers={[layer]} basemapStyle="openfreemap-positron" />);
+  });
+  // Drop the mount-time token→setTiles sync so the assertions below only see
+  // what the error handler did.
+  mapState.setTiles.mockClear();
+}
+
+/** Entries the surface handler pushed for a map error (report buffer rows). */
+function pushedEntries() {
+  return reportState.push.mock.calls.map((call) => call[0] as Record<string, unknown>);
+}
+
+describe('BuilderMap raster/DEM tile auth errors (fix #890)', () => {
+  let errorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    mapState.reset();
+    tileTokenState.invalidate.mockClear();
+    reportState.push.mockClear();
+    reportState.remint.mockClear();
+    vi.mocked(toast.error).mockClear();
+    // A live session: the auth toast is gated on refreshToken (fix #628).
+    useAuthStore.setState({ refreshToken: 'refresh-token' });
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    tileTokenState.tokens = [
+      {
+        data: { kind: 'vector', sig: 'sig-890', exp: Math.floor(Date.now() / 1000) + 900, scope: 'elevation', expires_in: 900 },
+        isLoading: false,
+        isError: false,
+      },
+    ];
+  });
+
+  afterEach(() => {
+    errorSpy.mockRestore();
+    useAuthStore.setState({ refreshToken: null });
+  });
+
+  it('logs a raster 403 exactly once and never claims a re-sign/re-mint', async () => {
+    const layer = makeLayer({ dataset_record_type: 'raster_dataset' });
+    await renderBuilderMap(layer);
+
+    const event = {
+      error: { message: `AJAXError: (403): ${RASTER_TILE_URL}`, status: 403, url: RASTER_TILE_URL },
+      sourceId: getSourceIdForLayer(layer),
+    };
+    // Both halves of the double log: the surface's own map.on('error') handler
+    // AND the wrapper's onError fallback, for the same MapLibre event.
+    act(() => {
+      mapState.fakeMap.emit('error', event);
+      mapState.onError?.(event);
+    });
+
+    // No recovery was possible, so none may be claimed.
+    expect(tileTokenState.invalidate).not.toHaveBeenCalled();
+    expect(pushedEntries()).toHaveLength(1);
+    expect(pushedEntries()[0]).toMatchObject({ suppressed: false, severity: 'error', source: 'maplibre' });
+    expect(pushedEntries().some((e) => String(e.message).includes('re-mint requested'))).toBe(false);
+    // …and the single honest log is the wrapper's console.error.
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+    expect(errorSpy).toHaveBeenCalledWith(event.error);
+  });
+
+  it('surfaces the auth toast for a raster 401 instead of swallowing it', async () => {
+    const layer = makeLayer({ is_dem: true });
+    await renderBuilderMap(layer);
+
+    act(() => {
+      mapState.fakeMap.emit('error', {
+        error: { status: 401, url: RASTER_TILE_URL },
+        sourceId: getSourceIdForLayer(layer),
+      });
+    });
+
+    expect(toast.error).toHaveBeenCalledTimes(1);
+    expect(toast.error).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ id: 'builder-map-auth-error' }),
+    );
+    expect(mapState.setTiles).not.toHaveBeenCalled();
+  });
+
+  it('still re-signs and re-mints a first-party VECTOR 403 (GUARD-03 / #621 intact)', async () => {
+    const layer = makeLayer();
+    const sourceId = getSourceIdForLayer(layer);
+    await renderBuilderMap(layer);
+
+    const vectorUrl = `${window.location.origin}/api/tiles/data.elevation/9/151/191.pbf?sig=stale`;
+    const event = { error: { status: 403, url: vectorUrl }, sourceId };
+    act(() => {
+      mapState.fakeMap.emit('error', event);
+      mapState.onError?.(event);
+    });
+
+    expect(mapState.setTiles).toHaveBeenCalledTimes(1);
+    expect(tileTokenState.invalidate).toHaveBeenCalledTimes(1);
+    // Recovery IS claimed here, suppressed, and the wrapper stays silent so the
+    // recovered case reads as one row instead of two.
+    const entries = pushedEntries();
+    expect(entries).toHaveLength(2);
+    expect(entries[0]).toMatchObject({ suppressed: true, severity: 'warning' });
+    expect(entries[1]).toMatchObject({ suppressed: true });
+    expect(String(entries[1].message)).toContain('re-signed');
+    expect(errorSpy).not.toHaveBeenCalled();
+    expect(toast.error).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/dataset/DatasetMap.tsx
+++ b/frontend/src/components/dataset/DatasetMap.tsx
@@ -170,16 +170,16 @@ export const DatasetMap = memo(function DatasetMap({
   // fix(#621): shared tile-auth recovery — a tile 401/403 kicks one throttled
   // token re-mint; the refreshed token re-renders the declarative <Source>
   // with a freshly signed URL.
-  const recoverTileAuth = useTileAuthRecovery(invalidateTileTokens);
+  // fix(#890): report every mint the recovery path actually kicks (suppressed),
+  // so a tab-return recovery still leaves a trace now that it no longer arrives
+  // wrapped in a 403 burst.
+  const recoverTileAuth = useTileAuthRecovery(invalidateTileTokens, (trigger) =>
+    reportTileTokenRemint('dataset-preview', trigger),
+  );
   // fix(#755): a tab backgrounded past the 900 s sig boundary comes back with
   // stale tokens, so MapLibre's resumed fetches 403 before the error handler
   // can heal them. Kick the same throttled re-mint on the visible edge.
-  // fix(#890): report it (suppressed) so the re-mint still leaves a trace.
-  useVisibleTileTokenRefresh(
-    () => [rawTileToken],
-    recoverTileAuth,
-    () => reportTileTokenRemint('dataset-preview'),
-  );
+  useVisibleTileTokenRefresh(() => [rawTileToken], recoverTileAuth);
   // fix(#890): `url` is read to tell a raster/DEM auth failure (unrecoverable)
   // from a vector one (re-mintable).
   const tileAuthErrorHandlerRef = useRef<((e: { error?: { status?: number; url?: string } }) => void) | null>(null);
@@ -664,14 +664,16 @@ export const DatasetMap = memo(function DatasetMap({
       // stayed fully silent; now it falls through to the existing onTileError
       // error path. Auth failures surface even after a confirmed load (unlike
       // sporadic tile errors) because they break the whole tile surface.
-      // fix(#890): a raster/DEM 401/403 is not recoverable here either — raster
-      // auth rides the Authorization header, so the re-mint returns true
-      // ("handled") without changing anything and the preview stayed silent
-      // behind a blank raster. Route it straight to the error path.
+      // fix(#890): a raster/DEM 401/403 is not cured by a fresh sig — raster auth
+      // rides the Authorization header, so the re-mint returned true ("handled")
+      // without changing anything and the preview stayed silent behind a blank
+      // raster. Still kick the re-mint (its apiFetch renews an expiring JWT,
+      // which IS what a raster 401 needs — codex P1), but never let its `true`
+      // stand in for recovery: route a raster failure to the error path.
       tileAuthErrorHandlerRef.current = (e: { error?: { status?: number; url?: string } }) => {
         const s = e.error?.status;
         if (s !== 401 && s !== 403) return;
-        const recovering = !isRasterTileAuthError(e) && recoverTileAuth();
+        const recovering = recoverTileAuth() && !isRasterTileAuthError(e);
         if (!recovering && !errorFiredRef.current) {
           errorFiredRef.current = true;
           onTileError?.();

--- a/frontend/src/components/dataset/DatasetMap.tsx
+++ b/frontend/src/components/dataset/DatasetMap.tsx
@@ -37,7 +37,8 @@ import type { Feature, Geometry, GeoJsonProperties } from 'geojson';
 import 'maplibre-gl/dist/maplibre-gl.css';
 import { motionDuration } from '@/lib/reduced-motion';
 import { buildTileTransformRequest, isMvtSourceLayerConfigReady } from '@/lib/tile-utils';
-import { logUnhandledMapError } from '@/lib/map-error-log';
+import { isRasterTileAuthError, logUnhandledMapError } from '@/lib/map-error-log';
+import { reportTileTokenRemint } from '@/lib/report';
 
 /** System columns excluded from the attribute form */
 const SYSTEM_COLUMNS = new Set(['gid', 'geom', 'geom_4326']);
@@ -173,8 +174,15 @@ export const DatasetMap = memo(function DatasetMap({
   // fix(#755): a tab backgrounded past the 900 s sig boundary comes back with
   // stale tokens, so MapLibre's resumed fetches 403 before the error handler
   // can heal them. Kick the same throttled re-mint on the visible edge.
-  useVisibleTileTokenRefresh(() => [rawTileToken], recoverTileAuth);
-  const tileAuthErrorHandlerRef = useRef<((e: { error?: { status?: number } }) => void) | null>(null);
+  // fix(#890): report it (suppressed) so the re-mint still leaves a trace.
+  useVisibleTileTokenRefresh(
+    () => [rawTileToken],
+    recoverTileAuth,
+    () => reportTileTokenRemint('dataset-preview'),
+  );
+  // fix(#890): `url` is read to tell a raster/DEM auth failure (unrecoverable)
+  // from a vector one (re-mintable).
+  const tileAuthErrorHandlerRef = useRef<((e: { error?: { status?: number; url?: string } }) => void) | null>(null);
   // fix(#430 V-13): dataset-detail preview map had no data-tiles-loaded signal at
   // all. Mirror the re-arming ViewerMap/BuilderMap behavior: false while a
   // camera move is in flight, true once idle (no tiles loading / no
@@ -656,10 +664,15 @@ export const DatasetMap = memo(function DatasetMap({
       // stayed fully silent; now it falls through to the existing onTileError
       // error path. Auth failures surface even after a confirmed load (unlike
       // sporadic tile errors) because they break the whole tile surface.
-      tileAuthErrorHandlerRef.current = (e: { error?: { status?: number } }) => {
+      // fix(#890): a raster/DEM 401/403 is not recoverable here either — raster
+      // auth rides the Authorization header, so the re-mint returns true
+      // ("handled") without changing anything and the preview stayed silent
+      // behind a blank raster. Route it straight to the error path.
+      tileAuthErrorHandlerRef.current = (e: { error?: { status?: number; url?: string } }) => {
         const s = e.error?.status;
         if (s !== 401 && s !== 403) return;
-        if (!recoverTileAuth() && !errorFiredRef.current) {
+        const recovering = !isRasterTileAuthError(e) && recoverTileAuth();
+        if (!recovering && !errorFiredRef.current) {
           errorFiredRef.current = true;
           onTileError?.();
         }

--- a/frontend/src/components/dataset/DatasetMap.tsx
+++ b/frontend/src/components/dataset/DatasetMap.tsx
@@ -673,7 +673,8 @@ export const DatasetMap = memo(function DatasetMap({
       tileAuthErrorHandlerRef.current = (e: { error?: { status?: number; url?: string } }) => {
         const s = e.error?.status;
         if (s !== 401 && s !== 403) return;
-        const recovering = recoverTileAuth() && !isRasterTileAuthError(e);
+        const reminting = recoverTileAuth();
+        const recovering = reminting && !isRasterTileAuthError(e);
         if (!recovering && !errorFiredRef.current) {
           errorFiredRef.current = true;
           onTileError?.();

--- a/frontend/src/components/viewer/ViewerMap.tsx
+++ b/frontend/src/components/viewer/ViewerMap.tsx
@@ -13,7 +13,8 @@ import {
 } from '@/lib/basemap-utils';
 import { buildClusterTileUrl, buildSignedTileUrl, buildTileTransformRequest, getMvtSourceLayerName, isMvtSourceLayerConfigReady, isThirdPartyTileUrl, resolveTileBaseUrl } from '@/lib/tile-utils';
 import { useRemoteBasemapStyle } from '@/components/map/hooks/use-remote-basemap-style';
-import { logUnhandledMapError } from '@/lib/map-error-log';
+import { isRasterTileAuthError, logUnhandledMapError } from '@/lib/map-error-log';
+import { reportTileTokenRemint } from '@/lib/report';
 import { useWebGLRecovery } from '@/hooks/use-webgl-recovery';
 import { useInvalidateTileTokens } from '@/hooks/use-tile-token';
 import { useTileAuthRecovery, useVisibleTileTokenRefresh } from '@/hooks/use-tile-auth-recovery';
@@ -192,7 +193,12 @@ export const ViewerMap = memo(function ViewerMap({
   // fix(#755): a tab backgrounded past the 900 s sig boundary comes back with
   // stale tokens, so MapLibre's resumed fetches 403 before the error handler
   // can heal them. Kick the same throttled re-mint on the visible edge.
-  useVisibleTileTokenRefresh(() => tokenMap.values(), recoverTileAuth);
+  // fix(#890): report it (suppressed) so the re-mint still leaves a trace.
+  useVisibleTileTokenRefresh(
+    () => tokenMap.values(),
+    recoverTileAuth,
+    () => reportTileTokenRemint('viewer'),
+  );
 
   // fix(#452): the bound DEM's LIVE visibility (legend eye toggle). Saved
   // visibility is handled inside the hook (HT-12); this covers the client-side
@@ -404,7 +410,12 @@ export const ViewerMap = memo(function ViewerMap({
           // grant, expired signature). Previously the return value was
           // discarded and the surface stayed fully silent; fall through to
           // the existing deduped tile-error toast instead.
-          if (!recoverTileAuth()) {
+          // fix(#890): a raster/DEM tile auth failure never reaches the re-mint
+          // path — its auth rides the Authorization header, so the fresh token
+          // changes nothing. Skip the recovery attempt (which would return true
+          // and silence the surface) and surface the toast directly, matching
+          // `isHandledTileAuthError`, which keeps logging these.
+          if (isRasterTileAuthError(e) || !recoverTileAuth()) {
             toast.error(t('viewer.mapError', { defaultValue: 'Map tile error — some layers may not display correctly.' }), {
               id: 'viewer-map-error',
             });

--- a/frontend/src/components/viewer/ViewerMap.tsx
+++ b/frontend/src/components/viewer/ViewerMap.tsx
@@ -189,16 +189,16 @@ export const ViewerMap = memo(function ViewerMap({
   const { tokenMap, refreshTokens } = useViewerTokens({ layers, apiKey, embedToken });
   // fix(#621): shared tile-auth recovery — a vector tile 401/403 kicks one
   // throttled token re-mint; the token-refresh effect below re-signs sources.
-  const recoverTileAuth = useTileAuthRecovery(refreshTokens);
+  // fix(#890): report every mint the recovery path actually kicks (suppressed),
+  // so a tab-return recovery still leaves a trace now that it no longer arrives
+  // wrapped in a 403 burst.
+  const recoverTileAuth = useTileAuthRecovery(refreshTokens, (trigger) =>
+    reportTileTokenRemint('viewer', trigger),
+  );
   // fix(#755): a tab backgrounded past the 900 s sig boundary comes back with
   // stale tokens, so MapLibre's resumed fetches 403 before the error handler
   // can heal them. Kick the same throttled re-mint on the visible edge.
-  // fix(#890): report it (suppressed) so the re-mint still leaves a trace.
-  useVisibleTileTokenRefresh(
-    () => tokenMap.values(),
-    recoverTileAuth,
-    () => reportTileTokenRemint('viewer'),
-  );
+  useVisibleTileTokenRefresh(() => tokenMap.values(), recoverTileAuth);
 
   // fix(#452): the bound DEM's LIVE visibility (legend eye toggle). Saved
   // visibility is handled inside the hook (HT-12); this covers the client-side
@@ -410,12 +410,15 @@ export const ViewerMap = memo(function ViewerMap({
           // grant, expired signature). Previously the return value was
           // discarded and the surface stayed fully silent; fall through to
           // the existing deduped tile-error toast instead.
-          // fix(#890): a raster/DEM tile auth failure never reaches the re-mint
-          // path — its auth rides the Authorization header, so the fresh token
-          // changes nothing. Skip the recovery attempt (which would return true
-          // and silence the surface) and surface the toast directly, matching
+          // fix(#890): the re-mint still runs for a raster/DEM failure — the
+          // mint request goes through apiFetch, whose proactive refresh renews
+          // an expiring JWT, and that Bearer is the ONLY thing that fixes a
+          // raster 401 (fix(#890) codex P1). But a fresh sig cannot help a
+          // raster tile, so its `true` must not silence the surface the way it
+          // does for a vector tile: toast regardless, matching
           // `isHandledTileAuthError`, which keeps logging these.
-          if (isRasterTileAuthError(e) || !recoverTileAuth()) {
+          const recovering = recoverTileAuth();
+          if (isRasterTileAuthError(e) || !recovering) {
             toast.error(t('viewer.mapError', { defaultValue: 'Map tile error — some layers may not display correctly.' }), {
               id: 'viewer-map-error',
             });

--- a/frontend/src/components/viewer/__tests__/ViewerMap.raster-tile-auth.test.tsx
+++ b/frontend/src/components/viewer/__tests__/ViewerMap.raster-tile-auth.test.tsx
@@ -1,12 +1,13 @@
-// fix(#890): the viewer's first-party 401/403 branch called recoverTileAuth()
-// for every tile, raster included. A raster/DEM auth failure cannot be cured by
-// a fresh tile token (its auth rides the Authorization header attached in
-// setTransformRequest), so the re-mint returned true, the surface stayed silent,
-// and the only trace was the red console row logUnhandledMapError still emits
-// for `/raster-tiles/` URLs — a blank raster layer with no user-visible reason.
+// fix(#890): the viewer's first-party 401/403 branch treated recoverTileAuth()'s
+// `true` as recovery for every tile, raster included. A raster/DEM auth failure
+// cannot be cured by a fresh tile token (its auth rides the Authorization header
+// attached in setTransformRequest), so the surface stayed silent and the only
+// trace was the red console row logUnhandledMapError still emits for
+// `/raster-tiles/` URLs — a blank raster layer with no user-visible reason.
 //
-// Raster/DEM auth failures now skip the recovery attempt and surface the
-// tile-error toast; the vector path is unchanged.
+// The re-mint still runs (its apiFetch renews an expiring JWT, which IS what a
+// raster 401 needs — codex P1 on this PR), but a raster failure no longer counts
+// as recovered: it surfaces the tile-error toast. The vector path is unchanged.
 import type { ReactNode } from 'react';
 import { render, waitFor } from '@/test/test-utils';
 import type { SharedLayerResponse } from '@/types/api';
@@ -20,8 +21,8 @@ vi.mock('@/components/viewer/hooks/use-viewer-tokens', () => ({
   useViewerTokens: () => ({
     tokenMap: new Map([['dataset-dem', { kind: 'raster', tile_url: '/raster-tiles/dataset-dem/tiles/{z}/{x}/{y}.png' }]]),
     tokenError: false,
-    // The re-mint the recovery path would kick — asserting it stays untouched is
-    // the point of this spec.
+    // The re-mint the recovery path kicks — it must still fire for raster (the
+    // JWT refresh rides it) without silencing the surface.
     refreshTokens: tokenState.refreshTokens,
   }),
 }));
@@ -164,7 +165,7 @@ describe('ViewerMap raster/DEM tile auth errors (fix #890)', () => {
 
     mapState.fakeMap.emit('error', { error: { status: 403, url: RASTER_URL } });
 
-    // fix(#890, codex P1): the re-mint still runs — its apiFetch renews an
+    // fix(#890) (codex P1): the re-mint still runs — its apiFetch renews an
     // expiring JWT, which is what a raster 401/403 actually needs — but its
     // `true` must not silence the surface the way it does for a vector tile.
     expect(tokenState.refreshTokens).toHaveBeenCalledTimes(1);

--- a/frontend/src/components/viewer/__tests__/ViewerMap.raster-tile-auth.test.tsx
+++ b/frontend/src/components/viewer/__tests__/ViewerMap.raster-tile-auth.test.tsx
@@ -159,12 +159,15 @@ describe('ViewerMap raster/DEM tile auth errors (fix #890)', () => {
     vi.mocked(toast.error).mockClear();
   });
 
-  it('surfaces the tile-error toast for a raster 403 without attempting a re-mint', async () => {
+  it('surfaces the tile-error toast for a raster 403 instead of reading the re-mint as recovery', async () => {
     await renderViewer();
 
     mapState.fakeMap.emit('error', { error: { status: 403, url: RASTER_URL } });
 
-    expect(tokenState.refreshTokens).not.toHaveBeenCalled();
+    // fix(#890, codex P1): the re-mint still runs — its apiFetch renews an
+    // expiring JWT, which is what a raster 401/403 actually needs — but its
+    // `true` must not silence the surface the way it does for a vector tile.
+    expect(tokenState.refreshTokens).toHaveBeenCalledTimes(1);
     expect(toast.error).toHaveBeenCalledTimes(1);
     expect(toast.error).toHaveBeenCalledWith(
       expect.any(String),

--- a/frontend/src/components/viewer/__tests__/ViewerMap.raster-tile-auth.test.tsx
+++ b/frontend/src/components/viewer/__tests__/ViewerMap.raster-tile-auth.test.tsx
@@ -1,0 +1,185 @@
+// fix(#890): the viewer's first-party 401/403 branch called recoverTileAuth()
+// for every tile, raster included. A raster/DEM auth failure cannot be cured by
+// a fresh tile token (its auth rides the Authorization header attached in
+// setTransformRequest), so the re-mint returned true, the surface stayed silent,
+// and the only trace was the red console row logUnhandledMapError still emits
+// for `/raster-tiles/` URLs — a blank raster layer with no user-visible reason.
+//
+// Raster/DEM auth failures now skip the recovery attempt and surface the
+// tile-error toast; the vector path is unchanged.
+import type { ReactNode } from 'react';
+import { render, waitFor } from '@/test/test-utils';
+import type { SharedLayerResponse } from '@/types/api';
+
+vi.mock('sonner', () => ({
+  toast: { error: vi.fn(), success: vi.fn() },
+}));
+
+const tokenState = vi.hoisted(() => ({ refreshTokens: vi.fn() }));
+vi.mock('@/components/viewer/hooks/use-viewer-tokens', () => ({
+  useViewerTokens: () => ({
+    tokenMap: new Map([['dataset-dem', { kind: 'raster', tile_url: '/raster-tiles/dataset-dem/tiles/{z}/{x}/{y}.png' }]]),
+    tokenError: false,
+    // The re-mint the recovery path would kick — asserting it stays untouched is
+    // the point of this spec.
+    refreshTokens: tokenState.refreshTokens,
+  }),
+}));
+
+vi.mock('@/hooks/use-settings', () => ({
+  useBasemaps: () => ({ data: [] }),
+  useTileConfig: () => ({ data: { cdn_base_url: null } }),
+  useBranding: () => ({ data: undefined }),
+}));
+vi.mock('@/hooks/use-webgl-recovery', () => ({
+  useWebGLRecovery: () => ({ contextLost: false, reload: vi.fn() }),
+}));
+vi.mock('@/components/viewer/hooks/use-viewer-terrain', () => ({
+  useViewerTerrain: () => ({ terrainReady: false, reseedTerrainOnStyleLoad: vi.fn() }),
+  isViewerTerrainExpected: () => false,
+}));
+vi.mock('@/components/map/MapCoordReadout', () => ({ MapCoordReadout: () => null }));
+vi.mock('@/components/builder/map-sync', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/components/builder/map-sync')>();
+  return { ...actual, applyBasemapConfigToMap: vi.fn(), syncLayersToMap: vi.fn() };
+});
+vi.mock('@/lib/builder/basemap-style-mutation', () => ({ applySublayerOverrides: vi.fn() }));
+
+type FakeMap = Record<string, ReturnType<typeof vi.fn>> & {
+  emit: (event: string, payload?: unknown) => void;
+};
+
+const mapState = vi.hoisted(() => {
+  const handlers = new Map<string, Set<(payload?: unknown) => void>>();
+  const track = (event: string, handler: (payload?: unknown) => void) => {
+    const existing = handlers.get(event) ?? new Set();
+    existing.add(handler);
+    handlers.set(event, existing);
+  };
+  const canvas = { style: { cursor: '' }, addEventListener: vi.fn(), removeEventListener: vi.fn() };
+  const fakeMap = {
+    isStyleLoaded: vi.fn(() => true),
+    on: vi.fn(track),
+    once: vi.fn(track),
+    off: vi.fn((event: string, handler: (payload?: unknown) => void) => {
+      handlers.get(event)?.delete(handler);
+    }),
+    setTransformRequest: vi.fn(),
+    getLayer: vi.fn(() => ({ id: 'x' })),
+    getSource: vi.fn(() => null),
+    getStyle: vi.fn(() => ({ version: 8, sources: {}, layers: [] })),
+    queryRenderedFeatures: vi.fn(() => []),
+    getCanvas: vi.fn(() => canvas),
+    getZoom: vi.fn(() => 5),
+    easeTo: vi.fn(),
+    moveLayer: vi.fn(),
+    removeSource: vi.fn(),
+    setTerrain: vi.fn(),
+    setLayoutProperty: vi.fn(),
+    setPaintProperty: vi.fn(),
+    setFilter: vi.fn(),
+    addLayer: vi.fn(),
+    addSource: vi.fn(),
+    removeLayer: vi.fn(),
+    triggerRepaint: vi.fn(),
+    setLayerZoomRange: vi.fn(),
+    hasImage: vi.fn(() => true),
+    addImage: vi.fn(),
+    emit: (event: string, payload?: unknown) => {
+      for (const handler of Array.from(handlers.get(event) ?? [])) handler(payload);
+    },
+  } as unknown as FakeMap;
+  return { fakeMap, reset: () => handlers.clear() };
+});
+
+vi.mock('@vis.gl/react-maplibre', async () => {
+  const React = await import('react');
+  return {
+    Map: ({ children, onLoad }: { children?: ReactNode; onLoad?: (e: { target: FakeMap }) => void }) => {
+      React.useEffect(() => {
+        onLoad?.({ target: mapState.fakeMap });
+      }, [onLoad]);
+      return <div data-testid="mapgl">{children}</div>;
+    },
+    NavigationControl: () => null,
+    ScaleControl: () => null,
+    FullscreenControl: () => null,
+    AttributionControl: () => null,
+    TerrainControl: () => null,
+    Popup: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+  };
+});
+
+import { toast } from 'sonner';
+import { ViewerMap } from '../ViewerMap';
+
+const LAYER = {
+  id: 'dem-layer',
+  dataset_id: 'dataset-dem',
+  dataset_name: 'Elevation',
+  display_name: 'Elevation',
+  table_name: 'elevation',
+  geometry_type: 'RASTER',
+  column_info: null,
+  sort_order: 0,
+  visible: true,
+  opacity: 1,
+  paint: {},
+  layout: {},
+  filter: null,
+  label_config: null,
+  popup_config: null,
+  style_config: null,
+  tile_url: '',
+} as unknown as SharedLayerResponse;
+
+const RASTER_URL = `${window.location.origin}/raster-tiles/dataset-dem/tiles/9/151/191.png`;
+
+async function renderViewer() {
+  render(
+    <ViewerMap
+      layers={[LAYER]}
+      basemapStyle="openfreemap-positron"
+      basemapConfig={null}
+      showBasemapLabels={true}
+      terrainConfig={null}
+      initialViewState={{ center_lng: 0, center_lat: 0, zoom: 2, bearing: 0, pitch: 0 }}
+      visibleLayers={new Set(['dem-layer'])}
+    />,
+  );
+  await waitFor(() => {
+    expect(mapState.fakeMap.on).toHaveBeenCalledWith('error', expect.any(Function));
+  });
+}
+
+describe('ViewerMap raster/DEM tile auth errors (fix #890)', () => {
+  beforeEach(() => {
+    mapState.reset();
+    tokenState.refreshTokens.mockClear();
+    vi.mocked(toast.error).mockClear();
+  });
+
+  it('surfaces the tile-error toast for a raster 403 without attempting a re-mint', async () => {
+    await renderViewer();
+
+    mapState.fakeMap.emit('error', { error: { status: 403, url: RASTER_URL } });
+
+    expect(tokenState.refreshTokens).not.toHaveBeenCalled();
+    expect(toast.error).toHaveBeenCalledTimes(1);
+    expect(toast.error).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ id: 'viewer-map-error' }),
+    );
+  });
+
+  it('still re-mints for a first-party vector 403 and stays quiet (fix #621 intact)', async () => {
+    await renderViewer();
+
+    mapState.fakeMap.emit('error', {
+      error: { status: 403, url: `${window.location.origin}/api/tiles/data.elevation/9/151/191.pbf?sig=stale` },
+    });
+
+    expect(tokenState.refreshTokens).toHaveBeenCalledTimes(1);
+    expect(toast.error).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/viewer/__tests__/use-viewer-tokens.test.ts
+++ b/frontend/src/components/viewer/__tests__/use-viewer-tokens.test.ts
@@ -1,7 +1,23 @@
-import { act, renderHook } from '@testing-library/react';
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+// fix(#890): the viewer used to refresh tile tokens by a hand-rolled
+// `useState` + `setTimeout` loop while the builder and dataset preview used
+// TanStack Query — two opposite policies for one problem. Chrome throttles a
+// hidden tab's timers but still FIRES them, so the viewer's refresh could land
+// while hidden and push a fresh tile URL at a paused map (the dropped-`setTiles`
+// hazard from fix(#584)), while the TanStack surfaces did nothing at all until
+// the tab returned.
+//
+// The viewer is now on the same TanStack path, so these specs pin the unified
+// policy rather than the deleted timer machinery (the fix(#831) single-retry-timer
+// and fix(#850) late-rejection specs went with it — TanStack owns scheduling and
+// cancellation now):
+//   1. a HIDDEN tab performs zero refreshes (refetchIntervalInBackground: false)
+//   2. a VISIBLE tab refreshes at 80% of the shortest vector TTL
+//   3. the tab-return edge re-mints through the fix(#755) visible-edge hook
+//   4. a failed mint keeps retrying, and surfaces the token-error toast
+import { act, renderHook, waitFor } from '@/test/test-utils';
 import { getTileTokensBatch } from '@/api/tiles';
 import { useViewerTokens } from '@/components/viewer/hooks/use-viewer-tokens';
+import { useTileAuthRecovery, useVisibleTileTokenRefresh } from '@/hooks/use-tile-auth-recovery';
 import type { SharedLayerResponse } from '@/types/api';
 
 vi.mock('@/api/tiles', () => ({
@@ -16,110 +32,169 @@ vi.mock('react-i18next', () => ({
   useTranslation: () => ({ t: (key: string) => key }),
 }));
 
+import { toast } from 'sonner';
+
 const mockedGetTileTokensBatch = vi.mocked(getTileTokensBatch);
 
 const layers = [{ dataset_id: 'dataset-1' }] as unknown as SharedLayerResponse[];
 
-/** Flush pending microtasks (promise rejections) without advancing timers. */
-async function flushMicrotasks() {
-  await act(async () => {
-    await Promise.resolve();
-  });
+/** `expires_in` 300 s → the refresh interval is 300 * 800 = 240_000 ms. */
+const TTL_SECONDS = 300;
+const REFRESH_MS = TTL_SECONDS * 800;
+
+function batchResponse(expOffsetSeconds = 900) {
+  return {
+    tokens: {
+      'dataset-1': {
+        kind: 'vector' as const,
+        sig: 'sig-1',
+        exp: Math.floor(Date.now() / 1000) + expOffsetSeconds,
+        scope: 'dataset-1',
+        expires_in: TTL_SECONDS,
+      },
+    },
+  };
 }
 
-describe('useViewerTokens retry scheduling', () => {
+function setVisibility(state: 'visible' | 'hidden') {
+  Object.defineProperty(document, 'visibilityState', { configurable: true, get: () => state });
+}
+
+describe('useViewerTokens refresh policy (fix #890)', () => {
   beforeEach(() => {
-    vi.useFakeTimers();
     mockedGetTileTokensBatch.mockReset();
-    mockedGetTileTokensBatch.mockRejectedValue(new Error('mint endpoint down'));
+    mockedGetTileTokensBatch.mockResolvedValue(batchResponse());
+    vi.mocked(toast.error).mockClear();
+    setVisibility('visible');
   });
 
   afterEach(() => {
+    setVisibility('visible');
     vi.useRealTimers();
   });
 
-  // fix(#831): an out-of-band refreshTokens() during an outage must replace
-  // the pending retry timer, not add a second retry loop alongside it.
-  it('keeps a single retry timer when refreshTokens fires during an outage', async () => {
-    const { result, unmount } = renderHook(() => useViewerTokens({ layers }));
+  it('exposes the minted tokens as a token map', async () => {
+    const { result } = renderHook(() => useViewerTokens({ layers }));
 
-    // The mount fetch fails and arms the first backoff retry timer (5s).
-    await flushMicrotasks();
-    expect(mockedGetTileTokensBatch).toHaveBeenCalledTimes(1);
-    expect(vi.getTimerCount()).toBe(1);
-
-    // Out-of-band refresh (tile-auth recovery, visibility change) while the
-    // retry timer is still pending. It fails too and re-arms the backoff.
-    act(() => {
-      result.current.refreshTokens();
-    });
-    await flushMicrotasks();
-    expect(mockedGetTileTokensBatch).toHaveBeenCalledTimes(2);
-
-    // Only ONE retry timer may be pending: the stale 5s timer from the first
-    // failure must have been cleared when the 10s backoff was armed.
-    expect(vi.getTimerCount()).toBe(1);
-
-    // Advance past both the stale 5s slot and the live 10s backoff — exactly
-    // one retry fires. Before the fix both timers fired, doubling the loops.
-    await act(async () => {
-      await vi.advanceTimersByTimeAsync(10_000);
-    });
-    expect(mockedGetTileTokensBatch).toHaveBeenCalledTimes(3);
-
-    unmount();
+    await waitFor(() => expect(result.current.tokenMap.size).toBe(1));
+    expect(result.current.tokenMap.get('dataset-1')).toMatchObject({ kind: 'vector', sig: 'sig-1' });
+    expect(result.current.tokenError).toBe(false);
   });
 
-  // fix(#850): a cancelled generation whose request rejects late must not
-  // clear the newer generation's valid refresh timer from the shared ref.
-  it('preserves the new generation timer when a stale request rejects late', async () => {
-    type BatchResult = Awaited<ReturnType<typeof getTileTokensBatch>>;
-    const deferreds: Array<{
-      resolve: (value: BatchResult) => void;
-      reject: (reason: unknown) => void;
-    }> = [];
-    mockedGetTileTokensBatch.mockImplementation(
-      () =>
-        new Promise<BatchResult>((resolve, reject) => {
-          deferreds.push({ resolve, reject });
-        }),
-    );
+  it('skips the mint entirely when the map has no layers', () => {
+    renderHook(() => useViewerTokens({ layers: [] }));
+    expect(mockedGetTileTokensBatch).not.toHaveBeenCalled();
+  });
 
-    const layersB = [{ dataset_id: 'dataset-2' }] as unknown as SharedLayerResponse[];
-    const { rerender, unmount } = renderHook(
-      ({ l }: { l: SharedLayerResponse[] }) => useViewerTokens({ layers: l }),
-      { initialProps: { l: layers } },
-    );
+  // Fake timers are installed BEFORE the render in the two cadence specs: the
+  // refetch interval is scheduled during the mount fetch, and a timer created
+  // under real timers is never advanced by fake ones.
+  it('does NOT refresh while the tab is hidden', async () => {
+    vi.useFakeTimers();
+    setVisibility('hidden');
+    const { result } = renderHook(() => useViewerTokens({ layers }));
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    expect(result.current.tokenMap.size).toBe(1);
     expect(mockedGetTileTokensBatch).toHaveBeenCalledTimes(1);
 
-    // Deps change while the first request is still in flight: the old
-    // generation is cancelled and the new generation starts its own fetch.
-    rerender({ l: layersB });
+    // TanStack's interval timer still ticks; `refetchIntervalInBackground: false`
+    // makes it a no-op while document.visibilityState is 'hidden'.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(REFRESH_MS * 3);
+    });
+
+    expect(mockedGetTileTokensBatch).toHaveBeenCalledTimes(1);
+  });
+
+  it('refreshes on the TTL cadence while the tab is visible', async () => {
+    vi.useFakeTimers();
+    const { result } = renderHook(() => useViewerTokens({ layers }));
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    expect(result.current.tokenMap.size).toBe(1);
+    expect(mockedGetTileTokensBatch).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(REFRESH_MS + 1_000);
+    });
+
     expect(mockedGetTileTokensBatch).toHaveBeenCalledTimes(2);
+  });
 
-    // The new generation succeeds and arms its 80%-of-TTL refresh timer
-    // (300s * 800 = 240s).
-    await act(async () => {
-      deferreds[1].resolve({
-        tokens: {
-          'dataset-2': { kind: 'vector', sig: 's', exp: 1, scope: 'dataset-2', expires_in: 300 },
-        },
-      } as BatchResult);
+  it('re-mints on the visible edge when the sig has expired (the fix(#755) hook path)', async () => {
+    // An already-expired sig, i.e. the tab-return case the burst came from.
+    mockedGetTileTokensBatch.mockResolvedValue(batchResponse(-60));
+    const { result } = renderHook(() => {
+      const tokens = useViewerTokens({ layers });
+      const recover = useTileAuthRecovery(tokens.refreshTokens);
+      useVisibleTileTokenRefresh(() => tokens.tokenMap.values(), recover);
+      return tokens;
     });
-    expect(vi.getTimerCount()).toBe(1);
+    await waitFor(() => expect(result.current.tokenMap.size).toBe(1));
+    expect(mockedGetTileTokensBatch).toHaveBeenCalledTimes(1);
 
-    // The stale generation's request rejects late. It must not clear the new
-    // generation's timer or replace it with a dead (cancelled) callback.
     await act(async () => {
-      deferreds[0].reject(new Error('stale request failed'));
+      document.dispatchEvent(new Event('visibilitychange'));
     });
 
-    // The refresh timer must survive and actually fire the next fetch.
-    await act(async () => {
-      await vi.advanceTimersByTimeAsync(240_000);
-    });
-    expect(mockedGetTileTokensBatch).toHaveBeenCalledTimes(3);
+    await waitFor(() => expect(mockedGetTileTokensBatch).toHaveBeenCalledTimes(2));
+  });
 
-    unmount();
+  it('does not re-mint on the visible edge while the sig is still fresh', async () => {
+    const { result } = renderHook(() => {
+      const tokens = useViewerTokens({ layers });
+      const recover = useTileAuthRecovery(tokens.refreshTokens);
+      useVisibleTileTokenRefresh(() => tokens.tokenMap.values(), recover);
+      return tokens;
+    });
+    await waitFor(() => expect(result.current.tokenMap.size).toBe(1));
+
+    await act(async () => {
+      document.dispatchEvent(new Event('visibilitychange'));
+    });
+
+    expect(mockedGetTileTokensBatch).toHaveBeenCalledTimes(1);
+  });
+
+  it('refreshes on demand for the 401/403 recovery path', async () => {
+    const { result } = renderHook(() => useViewerTokens({ layers }));
+    await waitFor(() => expect(result.current.tokenMap.size).toBe(1));
+    const refreshTokens = result.current.refreshTokens;
+
+    await act(async () => {
+      refreshTokens();
+    });
+
+    expect(mockedGetTileTokensBatch).toHaveBeenCalledTimes(2);
+    // Stable identity: the map error handlers close over it once (fix #621).
+    expect(result.current.refreshTokens).toBe(refreshTokens);
+  });
+
+  it('surfaces the token-error toast and keeps retrying when the mint endpoint is down', async () => {
+    vi.useFakeTimers();
+    mockedGetTileTokensBatch.mockRejectedValue(new Error('mint endpoint down'));
+    const { result } = renderHook(() => useViewerTokens({ layers }));
+
+    // The bounded `retry: 3` backoff runs first, then the query settles as error.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(30_000);
+    });
+    expect(result.current.tokenError).toBe(true);
+    expect(toast.error).toHaveBeenCalledWith(
+      'viewer.tokenError',
+      expect.objectContaining({ id: 'viewer-token-error' }),
+    );
+    const attemptsAfterFailure = mockedGetTileTokensBatch.mock.calls.length;
+
+    // A failed query has no TTL to derive a cadence from, so the outage retry
+    // interval keeps it trying instead of leaving the viewer permanently blank.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(61_000);
+    });
+
+    expect(mockedGetTileTokensBatch.mock.calls.length).toBeGreaterThan(attemptsAfterFailure);
   });
 });

--- a/frontend/src/components/viewer/hooks/use-viewer-tokens.ts
+++ b/frontend/src/components/viewer/hooks/use-viewer-tokens.ts
@@ -1,44 +1,51 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef } from 'react';
+import { useQuery } from '@tanstack/react-query';
 import { useTranslation } from 'react-i18next';
 import { toast } from 'sonner';
 import { getTileTokensBatch } from '@/api/tiles';
-import type { TileToken, VectorTileToken } from '@/api/tiles';
+import type { TileToken, TileTokenBatchResponse } from '@/api/tiles';
+import { queryKeys } from '@/lib/query-keys';
 import type { SharedLayerResponse } from '@/types/api';
 
-/** Fetch tile tokens in a single batch using API key auth. */
-async function fetchTokensWithApiKey(
-  datasetIds: string[],
-  apiKey: string,
-  embedToken?: string,
-): Promise<Map<string, TileToken>> {
-  const response = await getTileTokensBatch(datasetIds, apiKey, embedToken);
-  const map = new Map<string, TileToken>();
-  for (const [datasetId, entry] of Object.entries(response.tokens)) {
-    if ('kind' in entry) {
-      map.set(datasetId, entry);
-    }
-  }
-  return map;
-}
+// fix(#890): while the mint endpoint is down, keep retrying at this cadence.
+// TanStack's bounded `retry` covers the fast attempts; this covers a longer
+// outage the way the deleted hand-rolled loop's backoff CAP did. Without it the
+// interval below would return false (no data → no TTL to derive) and a viewer
+// that failed its first mint would never recover on its own.
+const TOKEN_RETRY_INTERVAL_MS = 60_000;
 
-/** Fetch tile tokens in a single batch (anonymous / JWT / embed-token auth). */
-async function fetchTokensBatch(
-  datasetIds: string[],
-  embedToken?: string,
-): Promise<Map<string, TileToken>> {
-  const response = await getTileTokensBatch(datasetIds, undefined, embedToken);
-  const map = new Map<string, TileToken>();
-  for (const [datasetId, entry] of Object.entries(response.tokens)) {
-    if ('kind' in entry) {
-      map.set(datasetId, entry);
+/**
+ * Refresh at 80% of the minimum vector-token TTL, floored at 30 s. Raster
+ * tokens have no `expires_in` (their tile_url is stable), so a map with no
+ * vector tokens skips the refresh cycle entirely.
+ */
+function refreshIntervalMs(data: TileTokenBatchResponse | undefined): number | false {
+  let minTtl = Infinity;
+  for (const entry of Object.values(data?.tokens ?? {})) {
+    if ('kind' in entry && entry.kind === 'vector') {
+      minTtl = Math.min(minTtl, entry.expires_in);
     }
   }
-  return map;
+  if (!Number.isFinite(minTtl)) return false;
+  return Math.max(minTtl * 800, 30_000);
 }
 
 /**
  * Manages tile token fetching and auto-refresh for the viewer map.
  * Returns the current token map and whether a fetch error occurred.
+ *
+ * fix(#890): this used to be a hand-rolled `useState` + `setTimeout` loop, which
+ * gave the viewer the OPPOSITE refresh policy to the builder and dataset
+ * preview: Chrome throttles a hidden tab's timers but still fires them, so a
+ * refresh landing while hidden pushed a fresh token URL at a paused map — the
+ * dropped-`setTiles` hazard from fix(#584) — while the TanStack-based surfaces
+ * did nothing at all until the tab came back. It is now the same TanStack path
+ * the builder uses: `refetchIntervalInBackground: false` means a hidden tab gets
+ * ZERO refreshes, and the visible-edge re-mint (fix(#755) /
+ * `useVisibleTileTokenRefresh` in ViewerMap) owns the tab-return case. That
+ * deletes the timer/cancellation machinery behind fix(#831) and fix(#850)
+ * outright, and makes ViewerMap's existing `useInvalidateTileTokens()` (WebGL
+ * context restore, fix(#438) BLD-04) actually reach the viewer's tokens.
  */
 export function useViewerTokens({
   layers,
@@ -50,93 +57,52 @@ export function useViewerTokens({
   embedToken?: string;
 }) {
   const { t } = useTranslation('common');
-  const [tokenMap, setTokenMap] = useState<Map<string, TileToken>>(new Map());
-  const [tokenError, setTokenError] = useState(false);
-  const refreshTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  // fix(#621): latest fetchTokens, so the on-demand refresh below always runs
-  // the current effect generation's fetcher (or nothing after unmount).
-  const fetchRef = useRef<(() => void) | null>(null);
 
   const layerDatasetIds = useMemo(
     () => [...new Set(layers.map((l) => l.dataset_id).filter(Boolean))],
     [layers],
   );
+  // Sorted so a layer reorder reuses the cached batch instead of re-minting.
+  const sortedIds = useMemo(() => [...layerDatasetIds].sort().join(','), [layerDatasetIds]);
 
-  useEffect(() => {
-    // fix(#394) SH-04: embed mode no longer skips token fetching — the batch
-    // endpoint accepts X-Embed-Token, so embeds get the same raster/DEM tile
-    // descriptors (bounds, resolution-derived maxzoom) as normal viewers
-    // instead of building the terrain source from empty defaults.
-    if (layerDatasetIds.length === 0) return;
+  // fix(#394) SH-04: embed mode does not skip token fetching — the batch
+  // endpoint accepts X-Embed-Token, so embeds get the same raster/DEM tile
+  // descriptors (bounds, resolution-derived maxzoom) as normal viewers instead
+  // of building the terrain source from empty defaults.
+  const query = useQuery({
+    queryKey: queryKeys.tileTokens.viewerBatch(sortedIds, `${apiKey ?? ''}|${embedToken ?? ''}`),
+    queryFn: () => getTileTokensBatch(layerDatasetIds, apiKey, embedToken),
+    enabled: layerDatasetIds.length > 0,
+    staleTime: 60_000,
+    // Bounded backoff for a transient hiccup (parity with useTileTokens).
+    retry: 3,
+    refetchInterval: (q) =>
+      q.state.status === 'error' ? TOKEN_RETRY_INTERVAL_MS : refreshIntervalMs(q.state.data),
+    // fix(#890): explicit because it is the whole policy — a hidden tab must not
+    // refresh, since MapLibre drops the resulting setTiles reload while the
+    // source's TileManager is paused (fix(#584)).
+    refetchIntervalInBackground: false,
+  });
 
-    let cancelled = false;
-    let retryAttempt = 0;
-
-    async function fetchTokens() {
-      try {
-        const newMap = apiKey
-          ? await fetchTokensWithApiKey(layerDatasetIds, apiKey, embedToken)
-          : await fetchTokensBatch(layerDatasetIds, embedToken);
-
-        if (cancelled) return;
-        setTokenMap(newMap);
-        setTokenError(false);
-        retryAttempt = 0;
-
-        // Refresh at 80% of the minimum vector-token TTL. Raster tokens
-        // have no expires_in (the tile_url is stable), so if there are no
-        // vector tokens in the map, skip the refresh cycle entirely.
-        const vectorTtls = [...newMap.values()]
-          .filter((t): t is VectorTileToken => t.kind === 'vector')
-          .map((t) => t.expires_in);
-        if (vectorTtls.length > 0) {
-          const minTtl = Math.min(...vectorTtls);
-          const refreshMs = Math.max(minTtl * 800, 30_000);
-          if (refreshTimerRef.current) {
-            clearTimeout(refreshTimerRef.current);
-          }
-          refreshTimerRef.current = setTimeout(() => {
-            if (!cancelled) fetchTokens();
-          }, refreshMs);
-        }
-      } catch (err) {
-        // fix(#850): a cancelled generation rejecting late must not touch the
-        // shared timer ref — a newer effect generation may already own it, and
-        // clearing here would kill that generation's valid refresh timer.
-        if (cancelled) return;
-        if (import.meta.env.DEV) console.warn('ViewerMap: failed to fetch tile tokens', err);
-        setTokenError(true);
-        // Exponential backoff retry: 5s, 10s, 20s, 40s, capped at 60s
-        retryAttempt++;
-        const backoffMs = Math.min(5_000 * Math.pow(2, retryAttempt - 1), 60_000);
-        // fix(#831): clear the pending retry timer before arming a new one —
-        // out-of-band refreshes during outages multiplied retry loops.
-        if (refreshTimerRef.current) {
-          clearTimeout(refreshTimerRef.current);
-        }
-        refreshTimerRef.current = setTimeout(() => {
-          if (!cancelled) fetchTokens();
-        }, backoffMs);
-      }
+  // Identity is stable while TanStack's structural sharing keeps `data` stable
+  // (an unchanged sig across a refresh), so ViewerMap's token→setTiles effect
+  // only re-runs when a token actually rotated.
+  const tokenMap = useMemo(() => {
+    const map = new Map<string, TileToken>();
+    for (const [datasetId, entry] of Object.entries(query.data?.tokens ?? {})) {
+      if ('kind' in entry) map.set(datasetId, entry);
     }
+    return map;
+  }, [query.data]);
 
-    fetchTokens();
-    fetchRef.current = fetchTokens;
-
-    return () => {
-      cancelled = true;
-      fetchRef.current = null;
-      if (refreshTimerRef.current) {
-        clearTimeout(refreshTimerRef.current);
-        refreshTimerRef.current = null;
-      }
-    };
-  }, [embedToken, apiKey, layerDatasetIds]);
+  const tokenError = query.isError;
 
   // fix(#621): on-demand re-mint for the tile 401/403 recovery path. Stable
   // identity so map error handlers can depend on it without re-registering.
+  const refetchRef = useRef(query.refetch);
+  refetchRef.current = query.refetch;
   const refreshTokens = useCallback(() => {
-    fetchRef.current?.();
+    void refetchRef.current();
   }, []);
 
   // Surface tile token fetch failures as a user-visible toast

--- a/frontend/src/hooks/__tests__/use-tile-auth-recovery.test.ts
+++ b/frontend/src/hooks/__tests__/use-tile-auth-recovery.test.ts
@@ -206,4 +206,62 @@ describe('useVisibleTileTokenRefresh (fix #755)', () => {
 
     expect(remint).toHaveBeenCalledTimes(1);
   });
+
+  // fix(#890): the 403 burst this path replaced at least left warnings in the
+  // problem-report buffer as evidence that a recovery had happened. The reporter
+  // is INJECTED (not imported) so this module keeps no dependency on it.
+  it('reports the re-mint it requested', () => {
+    const recover = vi.fn(() => true);
+    const onRemintRequested = vi.fn();
+    const expired = vectorToken(expIn(-60));
+    renderHook(() => useVisibleTileTokenRefresh(() => [expired], recover, onRemintRequested));
+
+    document.dispatchEvent(new Event('visibilitychange'));
+
+    expect(recover).toHaveBeenCalledTimes(1);
+    expect(onRemintRequested).toHaveBeenCalledTimes(1);
+  });
+
+  it('reports nothing when it decides no re-mint is due', () => {
+    const recover = vi.fn(() => true);
+    const onRemintRequested = vi.fn();
+    const fresh = vectorToken(expIn(900));
+    const { unmount } = renderHook(() =>
+      useVisibleTileTokenRefresh(() => [fresh], recover, onRemintRequested),
+    );
+
+    // Fresh sig on the visible edge…
+    document.dispatchEvent(new Event('visibilitychange'));
+    // …and the hidden edge, which never re-mints at all.
+    setVisibility('hidden');
+    document.dispatchEvent(new Event('visibilitychange'));
+    setVisibility('visible');
+    unmount();
+    document.dispatchEvent(new Event('visibilitychange'));
+
+    expect(onRemintRequested).not.toHaveBeenCalled();
+  });
+
+  it('calls the LATEST reporter without re-registering the listener', () => {
+    const recover = vi.fn(() => true);
+    const first = vi.fn();
+    const second = vi.fn();
+    const expired = vectorToken(expIn(-60));
+    const addSpy = vi.spyOn(document, 'addEventListener');
+    const { rerender } = renderHook(
+      ({ report }: { report: () => void }) =>
+        useVisibleTileTokenRefresh(() => [expired], recover, report),
+      { initialProps: { report: first } },
+    );
+    const registrations = addSpy.mock.calls.filter(([event]) => event === 'visibilitychange').length;
+
+    rerender({ report: second });
+    document.dispatchEvent(new Event('visibilitychange'));
+
+    expect(first).not.toHaveBeenCalled();
+    expect(second).toHaveBeenCalledTimes(1);
+    expect(
+      addSpy.mock.calls.filter(([event]) => event === 'visibilitychange').length,
+    ).toBe(registrations);
+  });
 });

--- a/frontend/src/hooks/__tests__/use-tile-auth-recovery.test.ts
+++ b/frontend/src/hooks/__tests__/use-tile-auth-recovery.test.ts
@@ -61,6 +61,71 @@ describe('useTileAuthRecovery', () => {
     expect(result.current()).toBe(true);
     expect(remint).toHaveBeenCalledTimes(2);
   });
+
+  // fix(#890): telemetry lives here because this is the only place that knows a
+  // mint actually started — the returned boolean is `true` both for a fresh mint
+  // and for an error riding the settle window, and `false` mid-cooldown.
+  describe('onRemint telemetry (fix #890)', () => {
+    it('fires once per real mint, with the trigger that asked for it', () => {
+      const remint = vi.fn();
+      const onRemint = vi.fn();
+      const { result } = renderHook(() => useTileAuthRecovery(remint, onRemint));
+
+      expect(result.current('tab-return')).toBe(true);
+
+      expect(onRemint).toHaveBeenCalledTimes(1);
+      expect(onRemint).toHaveBeenCalledWith('tab-return');
+    });
+
+    it('defaults the trigger for the reactive tile-error path', () => {
+      const onRemint = vi.fn();
+      const { result } = renderHook(() => useTileAuthRecovery(vi.fn(), onRemint));
+
+      result.current();
+
+      expect(onRemint).toHaveBeenCalledWith('tile-error');
+    });
+
+    it('stays silent when the throttle swallows the call (no mint ran)', () => {
+      const remint = vi.fn();
+      const onRemint = vi.fn();
+      const now = Date.now();
+      const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(now);
+      const { result } = renderHook(() => useTileAuthRecovery(remint, onRemint));
+
+      expect(result.current('tab-return')).toBe(true);
+      // Settle window: returns true WITHOUT minting — reporting here would claim
+      // a rotation that never happened.
+      nowSpy.mockReturnValue(now + 5_000);
+      expect(result.current('tab-return')).toBe(true);
+      // Cooldown gap: returns false, still no mint.
+      nowSpy.mockReturnValue(now + 20_000);
+      expect(result.current('tab-return')).toBe(false);
+
+      expect(remint).toHaveBeenCalledTimes(1);
+      expect(onRemint).toHaveBeenCalledTimes(1);
+    });
+
+    it('calls the LATEST reporter without churning the callback identity', () => {
+      const first = vi.fn();
+      const second = vi.fn();
+      const remint = vi.fn();
+      const { result, rerender } = renderHook(
+        ({ report }: { report: (trigger: string) => void }) => useTileAuthRecovery(remint, report),
+        { initialProps: { report: first as (trigger: string) => void } },
+      );
+      const recover = result.current;
+
+      rerender({ report: second as (trigger: string) => void });
+      // Identity must survive an inline-arrow reporter: ViewerMap and DatasetMap
+      // list this callback in `handleLoad`'s deps.
+      expect(result.current).toBe(recover);
+      result.current();
+
+      expect(first).not.toHaveBeenCalled();
+      expect(second).toHaveBeenCalledTimes(1);
+    });
+  });
 });
 
 // fix(#755): tile sigs are minted on 900 s `round_expiry()` boundaries, so a tab
@@ -207,27 +272,28 @@ describe('useVisibleTileTokenRefresh (fix #755)', () => {
     expect(remint).toHaveBeenCalledTimes(1);
   });
 
-  // fix(#890): the 403 burst this path replaced at least left warnings in the
-  // problem-report buffer as evidence that a recovery had happened. The reporter
-  // is INJECTED (not imported) so this module keeps no dependency on it.
-  it('reports the re-mint it requested', () => {
+  // fix(#890): the trigger is what makes the re-mint traceable — the reactive
+  // 403 burst this path replaced at least left warnings behind as evidence that
+  // a recovery happened. `useTileAuthRecovery` turns it into one report per
+  // actual mint (see its onRemint suite above).
+  it('names itself as the trigger so the report can distinguish a tab return', () => {
     const recover = vi.fn(() => true);
-    const onRemintRequested = vi.fn();
     const expired = vectorToken(expIn(-60));
-    renderHook(() => useVisibleTileTokenRefresh(() => [expired], recover, onRemintRequested));
+    renderHook(() => useVisibleTileTokenRefresh(() => [expired], recover));
 
     document.dispatchEvent(new Event('visibilitychange'));
 
     expect(recover).toHaveBeenCalledTimes(1);
-    expect(onRemintRequested).toHaveBeenCalledTimes(1);
+    expect(recover).toHaveBeenCalledWith('tab-return');
   });
 
-  it('reports nothing when it decides no re-mint is due', () => {
-    const recover = vi.fn(() => true);
-    const onRemintRequested = vi.fn();
+  it('reports nothing through the recovery hook when no re-mint is due', () => {
+    const remint = vi.fn();
+    const onRemint = vi.fn();
     const fresh = vectorToken(expIn(900));
+    const { result } = renderHook(() => useTileAuthRecovery(remint, onRemint));
     const { unmount } = renderHook(() =>
-      useVisibleTileTokenRefresh(() => [fresh], recover, onRemintRequested),
+      useVisibleTileTokenRefresh(() => [fresh], result.current),
     );
 
     // Fresh sig on the visible edge…
@@ -239,29 +305,7 @@ describe('useVisibleTileTokenRefresh (fix #755)', () => {
     unmount();
     document.dispatchEvent(new Event('visibilitychange'));
 
-    expect(onRemintRequested).not.toHaveBeenCalled();
-  });
-
-  it('calls the LATEST reporter without re-registering the listener', () => {
-    const recover = vi.fn(() => true);
-    const first = vi.fn();
-    const second = vi.fn();
-    const expired = vectorToken(expIn(-60));
-    const addSpy = vi.spyOn(document, 'addEventListener');
-    const { rerender } = renderHook(
-      ({ report }: { report: () => void }) =>
-        useVisibleTileTokenRefresh(() => [expired], recover, report),
-      { initialProps: { report: first } },
-    );
-    const registrations = addSpy.mock.calls.filter(([event]) => event === 'visibilitychange').length;
-
-    rerender({ report: second });
-    document.dispatchEvent(new Event('visibilitychange'));
-
-    expect(first).not.toHaveBeenCalled();
-    expect(second).toHaveBeenCalledTimes(1);
-    expect(
-      addSpy.mock.calls.filter(([event]) => event === 'visibilitychange').length,
-    ).toBe(registrations);
+    expect(remint).not.toHaveBeenCalled();
+    expect(onRemint).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/hooks/use-tile-auth-recovery.ts
+++ b/frontend/src/hooks/use-tile-auth-recovery.ts
@@ -31,15 +31,30 @@ const REMINT_SETTLE_MS = 10_000;
  * kicked off, or the error is part of the burst that kicked it — suppress
  * per-surface error UI); false when errors persist after the re-mint had time
  * to land (it didn't cure them — fall through to existing error UI).
+ *
+ * fix(#890): `onRemint` fires exactly when this hook kicks a FRESH mint — never
+ * inside the settle window or the cooldown gap, where the returned boolean says
+ * nothing about whether a mint ran. That makes it the only honest place to
+ * report a re-mint from; `trigger` names the path that asked for one so the
+ * report distinguishes a tab return from a tile error. It is injected (not
+ * imported) so this module keeps no dependency beyond the TileToken type, and
+ * held in a ref so the returned callback keeps a stable identity — ViewerMap and
+ * DatasetMap list it in `handleLoad`'s deps.
  */
-export function useTileAuthRecovery(remint: () => void) {
+export function useTileAuthRecovery(
+  remint: () => void,
+  onRemint?: (trigger: string) => void,
+) {
   const lastAttemptRef = useRef(0);
-  return useCallback((): boolean => {
+  const onRemintRef = useRef(onRemint);
+  onRemintRef.current = onRemint;
+  return useCallback((trigger: string = 'tile-error'): boolean => {
     const elapsed = Date.now() - lastAttemptRef.current;
     if (elapsed < REMINT_SETTLE_MS) return true;
     if (elapsed < REMINT_COOLDOWN_MS) return false;
     lastAttemptRef.current = Date.now();
     remint();
+    onRemintRef.current?.(trigger);
     return true;
   }, [remint]);
 }
@@ -86,29 +101,22 @@ export function hasExpiringVectorToken(
  * the source's TileManager is paused (fix(#584)) and a hidden tab has no rAF,
  * so re-minting while still hidden would silently no-op.
  *
- * fix(#890): `onRemintRequested` restores the telemetry the old 403 burst gave
- * for free — the warnings it produced were at least evidence that a recovery
- * happened, and a proactive re-mint leaves none. It is INJECTED rather than
- * imported so this module keeps zero dependencies beyond the TileToken type.
- * It fires when this hook asks for a re-mint, not when one is confirmed: the
- * shared throttle may fold the request into an in-flight mint, hence "requested".
+ * fix(#890): passes the `tab-return` trigger so `useTileAuthRecovery`'s
+ * `onRemint` reports which path recovered — the 403 burst this replaced at
+ * least evidenced a recovery, and a proactive re-mint otherwise leaves none.
  */
 export function useVisibleTileTokenRefresh(
   getTokens: () => Iterable<TileToken | null | undefined>,
-  recover: () => boolean,
-  onRemintRequested?: () => void,
+  recover: (trigger?: string) => boolean,
 ): void {
   const getTokensRef = useRef(getTokens);
   getTokensRef.current = getTokens;
-  const onRemintRequestedRef = useRef(onRemintRequested);
-  onRemintRequestedRef.current = onRemintRequested;
 
   useEffect(() => {
     const onVisibilityChange = () => {
       if (document.visibilityState !== 'visible') return;
       if (!hasExpiringVectorToken(getTokensRef.current())) return;
-      recover();
-      onRemintRequestedRef.current?.();
+      recover('tab-return');
     };
     document.addEventListener('visibilitychange', onVisibilityChange);
     return () => document.removeEventListener('visibilitychange', onVisibilityChange);

--- a/frontend/src/hooks/use-tile-auth-recovery.ts
+++ b/frontend/src/hooks/use-tile-auth-recovery.ts
@@ -85,19 +85,30 @@ export function hasExpiringVectorToken(
  * Fires on the VISIBLE edge only: MapLibre 5 drops a `setTiles` reload while
  * the source's TileManager is paused (fix(#584)) and a hidden tab has no rAF,
  * so re-minting while still hidden would silently no-op.
+ *
+ * fix(#890): `onRemintRequested` restores the telemetry the old 403 burst gave
+ * for free — the warnings it produced were at least evidence that a recovery
+ * happened, and a proactive re-mint leaves none. It is INJECTED rather than
+ * imported so this module keeps zero dependencies beyond the TileToken type.
+ * It fires when this hook asks for a re-mint, not when one is confirmed: the
+ * shared throttle may fold the request into an in-flight mint, hence "requested".
  */
 export function useVisibleTileTokenRefresh(
   getTokens: () => Iterable<TileToken | null | undefined>,
   recover: () => boolean,
+  onRemintRequested?: () => void,
 ): void {
   const getTokensRef = useRef(getTokens);
   getTokensRef.current = getTokens;
+  const onRemintRequestedRef = useRef(onRemintRequested);
+  onRemintRequestedRef.current = onRemintRequested;
 
   useEffect(() => {
     const onVisibilityChange = () => {
       if (document.visibilityState !== 'visible') return;
       if (!hasExpiringVectorToken(getTokensRef.current())) return;
       recover();
+      onRemintRequestedRef.current?.();
     };
     document.addEventListener('visibilitychange', onVisibilityChange);
     return () => document.removeEventListener('visibilitychange', onVisibilityChange);

--- a/frontend/src/lib/__tests__/map-error-log.test.ts
+++ b/frontend/src/lib/__tests__/map-error-log.test.ts
@@ -5,7 +5,12 @@
 // react-maplibre wrapper's default `console.error(e.error)` for everything
 // else, so real failures stay visible in devtools and the problem report.
 
-import { isHandledTileAuthError, logUnhandledMapError } from '@/lib/map-error-log';
+import {
+  isHandledTileAuthError,
+  isRasterTileAuthError,
+  isRasterTileUrl,
+  logUnhandledMapError,
+} from '@/lib/map-error-log';
 
 function ajaxError(status: number, url: string) {
   return { error: { message: `AJAXError: (${status}): ${url}`, status, url } };
@@ -118,5 +123,47 @@ describe('isHandledTileAuthError (fix #755)', () => {
     expect(isHandledTileAuthError(ajaxError(403, rasterUrl))).toBe(false);
     // Vector tile URLs stay handled after the exclusion.
     expect(isHandledTileAuthError(ajaxError(403, `${window.location.origin}/api/tiles/data.t/1/2/3.pbf?sig=a`))).toBe(true);
+  });
+});
+
+// fix(#890): the surfaces' own error handlers claimed to have "handled" raster
+// 401/403s (re-mint requested) even though nothing there can cure them, which
+// left one suppressed report row next to the unsuppressed console row above.
+// They now share this predicate, so the two sides cannot disagree again.
+describe('isRasterTileAuthError (fix #890)', () => {
+  const rasterUrl = `${window.location.origin}/raster-tiles/0b0af5ab-1f3e-4c1a-9d7e-8f1f0c9d2e11/tiles/9/151/191.png`;
+  const vectorUrl = `${window.location.origin}/api/tiles/data.t/1/2/3.pbf?sig=a`;
+
+  it('matches raster/DEM tile auth statuses only', () => {
+    expect(isRasterTileAuthError(ajaxError(401, rasterUrl))).toBe(true);
+    expect(isRasterTileAuthError(ajaxError(403, rasterUrl))).toBe(true);
+    expect(isRasterTileAuthError(ajaxError(404, rasterUrl))).toBe(false);
+    expect(isRasterTileAuthError(ajaxError(500, rasterUrl))).toBe(false);
+  });
+
+  it('never matches a vector tile, a non-tile URL, or a status-less error', () => {
+    expect(isRasterTileAuthError(ajaxError(403, vectorUrl))).toBe(false);
+    expect(isRasterTileAuthError(ajaxError(403, `${window.location.origin}/api/datasets/`))).toBe(false);
+    expect(isRasterTileAuthError({ error: { status: 403 } })).toBe(false);
+    expect(isRasterTileAuthError({ error: { message: 'no status' } })).toBe(false);
+    expect(isRasterTileAuthError({})).toBe(false);
+  });
+
+  it('matches relative and CDN-fronted raster URLs alike', () => {
+    expect(isRasterTileAuthError(ajaxError(403, '/raster-tiles/abc/tiles/9/151/191.png'))).toBe(true);
+    expect(isRasterTileAuthError(ajaxError(403, 'https://cdn.example.com/raster-tiles/abc/tiles/9/151/191.png?sig=a'))).toBe(true);
+  });
+
+  it('is mutually exclusive with isHandledTileAuthError', () => {
+    for (const url of [rasterUrl, vectorUrl, '/raster-tiles/a/tiles/1/2/3.png', '/api/tiles/x/1/2/3.pbf']) {
+      const e = ajaxError(403, url);
+      expect(isRasterTileAuthError(e) && isHandledTileAuthError(e)).toBe(false);
+    }
+  });
+
+  it('classifies raster tile URLs regardless of status', () => {
+    expect(isRasterTileUrl(rasterUrl)).toBe(true);
+    expect(isRasterTileUrl(vectorUrl)).toBe(false);
+    expect(isRasterTileUrl(undefined)).toBe(false);
   });
 });

--- a/frontend/src/lib/map-error-log.ts
+++ b/frontend/src/lib/map-error-log.ts
@@ -18,6 +18,22 @@ export interface MapLibreErrorLike {
   error?: { message?: string; status?: number; url?: string };
 }
 
+/** True when `url` is a GeoLens raster/DEM tile request — the backend shape is
+ * `/raster-tiles/{id}/tiles/{z}/{x}/{y}.png`.
+ *
+ * audit(w3-maps A1): that second `/tiles/` segment satisfies the first-party
+ * vector match below, which misclassified raster 401/403s as handled. Raster
+ * auth rides the `Authorization` header attached by `setTransformRequest`, not
+ * the signed-tile `sig=` query param, so neither the cached-token re-sign nor a
+ * token re-mint can cure a raster auth failure.
+ *
+ * fix(#890): exported so the surfaces' own `error` handlers agree with
+ * `isHandledTileAuthError` on what "handled" means — the handlers used to claim
+ * recovery for raster while this module (correctly) still logged the failure. */
+export function isRasterTileUrl(url: string | undefined): boolean {
+  return !!url && url.includes('/raster-tiles/');
+}
+
 /** True when `url` targets a first-party GeoLens tile endpoint: a relative or
  * same-origin `/tiles/` path (`/api/tiles/…`, including `/tiles/clusters/…`),
  * or a CDN-fronted tile URL still carrying our signed-tile `sig=` param.
@@ -25,12 +41,7 @@ export interface MapLibreErrorLike {
  * raster `/raster-tiles/` paths do not match. */
 function isFirstPartyTileUrl(url: string | undefined): boolean {
   if (!url || !url.includes('/tiles/')) return false;
-  // audit(w3-maps A1): raster/DEM tile URLs are
-  // `/raster-tiles/{id}/tiles/{z}/{x}/{y}.png` — the second `/tiles/` segment
-  // matched above and misclassified raster 401/403s as handled. Raster auth
-  // rides the Authorization header (setTransformRequest), not the vector
-  // re-sign/re-mint path, so it is never "handled" here.
-  if (url.includes('/raster-tiles/')) return false;
+  if (isRasterTileUrl(url)) return false;
   if (!/^https?:\/\//i.test(url)) return true;
   if (url.startsWith(`${window.location.origin}/`)) return true;
   return /[?&]sig=/.test(url);
@@ -43,6 +54,18 @@ export function isHandledTileAuthError(e: MapLibreErrorLike): boolean {
   const status = e.error?.status;
   if (status !== 401 && status !== 403) return false;
   return isFirstPartyTileUrl(e.error?.url);
+}
+
+/** fix(#890): a 401/403 on a raster/DEM tile — the one tile-auth case NO
+ * surface can recover (see `isRasterTileUrl`). Surfaces use it to skip their
+ * vector re-sign / re-mint path so the failure surfaces once (toast + this
+ * module's `console.error`) instead of being reported as a suppressed
+ * "recovered" entry alongside an unsuppressed red console row (the #755
+ * double-log shape, still live for raster/DEM until this fix). */
+export function isRasterTileAuthError(e: MapLibreErrorLike): boolean {
+  const status = e.error?.status;
+  if (status !== 401 && status !== 403) return false;
+  return isRasterTileUrl(e.error?.url);
 }
 
 /** `onError` prop for @vis.gl/react-maplibre's <Map>: replicate the wrapper's

--- a/frontend/src/lib/query-keys.ts
+++ b/frontend/src/lib/query-keys.ts
@@ -201,6 +201,15 @@ export const queryKeys = {
   tileTokens: {
     token: (datasetId: string | undefined) => ['tile-token', datasetId] as const,
     batch: (sortedIds: string) => ['tile-tokens-batch', sortedIds] as const,
+    // fix(#890): the viewer's batch. Separate from `batch` because the viewer
+    // mints with an API key / embed token instead of the session JWT, and those
+    // grants scope differently — sharing one cache entry would serve a viewer
+    // tokens minted for someone else's scope. `auth` is that discriminator, and
+    // it stays out of bug reports because main.tsx's reportQueryKey serializes
+    // only the leading namespace segment. Keeping 'tile-tokens-batch' first also
+    // puts these under useInvalidateTileTokens' sweep (WebGL context restore).
+    viewerBatch: (sortedIds: string, auth: string) =>
+      ['tile-tokens-batch', 'viewer', sortedIds, auth] as const,
   },
 
   // -------------------------------------------------------------------------

--- a/frontend/src/lib/report/__tests__/report-buffer.test.ts
+++ b/frontend/src/lib/report/__tests__/report-buffer.test.ts
@@ -4,6 +4,7 @@ import {
   getReportEntries,
   pushReportEntry,
   reportNetworkError,
+  reportTileTokenRemint,
 } from '../report-buffer';
 
 beforeEach(() => {
@@ -53,5 +54,35 @@ describe('report buffer', () => {
     expect(offline.severity).toBe('error'); // status 0
     expect(notFound.severity).toBe('warning'); // 4xx
     expect(serverError.severity).toBe('error'); // 5xx
+  });
+});
+
+// fix(#890): #881 replaced the reactive 403 burst with a proactive tab-return
+// re-mint, which left no trace at all — the burst's warnings were at least
+// evidence that a recovery had happened. This tap restores that signal.
+describe('reportTileTokenRemint', () => {
+  it('records a suppressed entry naming the surface', () => {
+    reportTileTokenRemint('viewer');
+
+    const entries = getReportEntries();
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toMatchObject({ severity: 'info', source: 'maplibre', suppressed: true });
+    expect(entries[0].message).toContain('viewer');
+  });
+
+  it('keeps two surfaces re-minting at once as separate entries', () => {
+    reportTileTokenRemint('viewer');
+    reportTileTokenRemint('dataset-preview');
+
+    expect(getReportEntries()).toHaveLength(2);
+  });
+
+  it('collapses repeat re-mints from the same surface into a count', () => {
+    reportTileTokenRemint('builder');
+    reportTileTokenRemint('builder');
+
+    const entries = getReportEntries();
+    expect(entries).toHaveLength(1);
+    expect(entries[0].count).toBe(2);
   });
 });

--- a/frontend/src/lib/report/__tests__/report-buffer.test.ts
+++ b/frontend/src/lib/report/__tests__/report-buffer.test.ts
@@ -61,25 +61,33 @@ describe('report buffer', () => {
 // re-mint, which left no trace at all — the burst's warnings were at least
 // evidence that a recovery had happened. This tap restores that signal.
 describe('reportTileTokenRemint', () => {
-  it('records a suppressed entry naming the surface', () => {
-    reportTileTokenRemint('viewer');
+  it('records a suppressed entry naming the surface and the trigger', () => {
+    reportTileTokenRemint('viewer', 'tab-return');
 
     const entries = getReportEntries();
     expect(entries).toHaveLength(1);
     expect(entries[0]).toMatchObject({ severity: 'info', source: 'maplibre', suppressed: true });
     expect(entries[0].message).toContain('viewer');
+    expect(entries[0].message).toContain('tab-return');
   });
 
   it('keeps two surfaces re-minting at once as separate entries', () => {
-    reportTileTokenRemint('viewer');
-    reportTileTokenRemint('dataset-preview');
+    reportTileTokenRemint('viewer', 'tab-return');
+    reportTileTokenRemint('dataset-preview', 'tab-return');
 
     expect(getReportEntries()).toHaveLength(2);
   });
 
-  it('collapses repeat re-mints from the same surface into a count', () => {
-    reportTileTokenRemint('builder');
-    reportTileTokenRemint('builder');
+  it('keeps the tab-return and tile-error paths distinguishable', () => {
+    reportTileTokenRemint('builder', 'tab-return');
+    reportTileTokenRemint('builder', 'tile-error');
+
+    expect(getReportEntries()).toHaveLength(2);
+  });
+
+  it('collapses repeat re-mints from the same surface and trigger into a count', () => {
+    reportTileTokenRemint('builder', 'tile-error');
+    reportTileTokenRemint('builder', 'tile-error');
 
     const entries = getReportEntries();
     expect(entries).toHaveLength(1);

--- a/frontend/src/lib/report/index.ts
+++ b/frontend/src/lib/report/index.ts
@@ -2,6 +2,7 @@ export { redact } from './redact';
 export {
   pushReportEntry,
   reportNetworkError,
+  reportTileTokenRemint,
   clearReportEntries,
   getReportEntries,
   useReportEntries,

--- a/frontend/src/lib/report/report-buffer.ts
+++ b/frontend/src/lib/report/report-buffer.ts
@@ -119,6 +119,24 @@ export function reportNetworkError(opts: {
   });
 }
 
+/**
+ * fix(#890): convenience tap for the proactive tab-return tile-token re-mint
+ * (#755 / #881). The reactive 403 burst that re-mint replaced at least left
+ * evidence in this buffer that a recovery had happened; the visible-edge hook
+ * is silent, so a "tiles were briefly broken" report arrives with no trace of
+ * the token rotation. Suppressed — it is routine maintenance, never something
+ * to show the user — and `surface` is part of the message so two map surfaces
+ * re-minting at once don't collapse into one deduped entry.
+ */
+export function reportTileTokenRemint(surface: string): void {
+  pushReportEntry({
+    severity: 'info',
+    source: 'maplibre',
+    message: `Tile-token re-mint requested on tab return (${surface}, expiring signature)`,
+    suppressed: true,
+  });
+}
+
 function stringifyDetail(detail: unknown): string | undefined {
   if (detail == null) return undefined;
   if (typeof detail === 'string') return detail;

--- a/frontend/src/lib/report/report-buffer.ts
+++ b/frontend/src/lib/report/report-buffer.ts
@@ -120,19 +120,21 @@ export function reportNetworkError(opts: {
 }
 
 /**
- * fix(#890): convenience tap for the proactive tab-return tile-token re-mint
- * (#755 / #881). The reactive 403 burst that re-mint replaced at least left
- * evidence in this buffer that a recovery had happened; the visible-edge hook
- * is silent, so a "tiles were briefly broken" report arrives with no trace of
- * the token rotation. Suppressed — it is routine maintenance, never something
- * to show the user — and `surface` is part of the message so two map surfaces
- * re-minting at once don't collapse into one deduped entry.
+ * fix(#890): convenience tap for a tile-token re-mint. The reactive 403 burst
+ * the proactive tab-return re-mint (#755 / #881) replaced at least left evidence
+ * in this buffer that a recovery had happened; the visible-edge path is silent,
+ * so a "tiles were briefly broken" report arrives with no trace of the token
+ * rotation that fixed it. Called from `useTileAuthRecovery` only when a mint
+ * actually starts, so one entry means one mint. Suppressed — routine
+ * maintenance, never something to show the user — and both `surface` and
+ * `trigger` are in the message so concurrent surfaces and the tab-return vs
+ * tile-error paths stay separate entries instead of one deduped row.
  */
-export function reportTileTokenRemint(surface: string): void {
+export function reportTileTokenRemint(surface: string, trigger: string): void {
   pushReportEntry({
     severity: 'info',
     source: 'maplibre',
-    message: `Tile-token re-mint requested on tab return (${surface}, expiring signature)`,
+    message: `Tile tokens re-minted (${surface}, ${trigger})`,
     suppressed: true,
   });
 }


### PR DESCRIPTION
## What changed

`ST_Buffer(geom::geography, d)::geometry` asks `_ST_BestSRID` for **one** planar working SRID and uses it for the whole input. The plan output makes the shape explicit — PostGIS rewrites the cast chain to

```
st_transform(st_buffer(st_transform(geometry(g::geography), _st_bestsrid(g::geography)), d), 4326)
```

so every component of a multipart feature is buffered in a projection chosen for the *envelope*, not for itself.

`render_geodesic_buffer()` in `backend/app/platform/analysis_sql.py` now dumps the validated source, buffers each component through its own `::geography` cast, re-collects, runs the existing #883 seam split, and dissolves with `ST_UnaryUnion`. `render_geometry_expr("buffer", ...)` is the single chokepoint both the preview (`service_analysis.build_preview_sql`) and the materialize worker (`processing/analysis/tasks.py`) call, so both paths pick it up.

Diff shape: `analysis_sql.py` +144/-12 (one new function; 19 lines of it are SQL, the rest is the docstring), `test_analysis_materialize.py` +260/-0 (6 behavioural tests), `test_analysis_preview.py` +74/-10 (one new SQL-shape test, three updated).

No schema, API, config, i18n or SDK impact — this is a rendered SQL expression behind `render_geometry_expr`, which is already the sole entry point for both the preview and the materialize worker.

## Reproduced first

The issue's table, reproduced verbatim against the dev DB (PostgreSQL 18.4, PostGIS 3.6.4, GEOS 3.13.1) on `main@cb22f5bb1` before any code changed:

```sql
WITH params(sep) AS (VALUES (0.2::float8),(10.0),(90.0),(150.0)),
src AS (
    SELECT sep, ST_SetSRID(ST_Collect(ST_MakePoint(0,45), ST_MakePoint(sep,45)),4326) AS g
    FROM params
),
buf AS (SELECT sep, ST_Buffer(ST_MakeValid(g)::geography, 10000)::geometry AS b FROM src)
SELECT sep AS separation_deg, GeometryType(b) AS gtype, ST_NumGeometries(b) AS parts,
       round(ST_Area(b::geography)::numeric,0) AS area_m2,
       round((ST_Area(b::geography) / (2*pi()*10000^2))::numeric,4) AS ratio_vs_ideal
FROM buf ORDER BY sep;

 separation_deg |    gtype     | parts |  area_m2  | ratio_vs_ideal
----------------+--------------+-------+-----------+----------------
            0.2 | POLYGON      |     1 | 589383310 |         0.9380
             10 | MULTIPOLYGON |     2 | 624289038 |         0.9936
             90 | MULTIPOLYGON |     2 | 313192925 |         0.4985
            150 | MULTIPOLYGON |     2 | 624289038 |         0.9936
```

Exact match to the reported 0.938 / 0.994 / **0.498** / 0.994. The mechanism came straight out:

```sql
SELECT sep, _ST_BestSRID(g::geography) AS whole_srid,
       _ST_BestSRID(ST_GeometryN(g,1)::geography) AS part1_srid,
       _ST_BestSRID(ST_GeometryN(g,2)::geography) AS part2_srid
FROM src ORDER BY sep;

 sep | whole_srid | part1_srid | part2_srid
-----+------------+------------+------------
 0.2 |     999031 |     999031 |     999031
  10 |     999247 |     999031 |     999032
  90 |     999000 |     999031 |     999046   <- 999000 = world Mercator
 150 |     999061 |     999031 |     999055
```

Two things fall out that the issue's table alone does not show. The 0.2° row is **not** a bug — at that separation the two circles overlap and the union is genuinely smaller than 2 π r², which is why it also stays 0.9380 after the fix. And the non-monotonic shape is not centroid-driven: it is a hard threshold, `_ST_BestSRID` dropping to world Mercator once the longitude span reaches 45°, then climbing back into a wide Lambert past ~135°.

`after` numbers below come from substituting the rendered expression — `render_geometry_expr("buffer", distance_meters=10000.0)[0]` with `geom_4326` bound to each fixture — into the same queries.

## Why this is not the antimeridian

Different failure, same expression. The seam bug (#697/#883) is about longitude normalization in the *output*. This one is about the projection chosen for the *input*, and it fires nowhere near ±180. Measured longitude-span sweep of a two-point `MULTIPOINT` at lat 45, 10 km buffer, reading the geodesic distance from each source point to every vertex of the output part containing it:

| longitude span | `_ST_BestSRID` | produced radius (m) |
| --- | --- | --- |
| under 6° | 999031 | 9 997 – 10 004 (single UTM zone) |
| 6° – 44.99° | 999247 | 9 904 – 10 097 |
| **45° and up** | **999000 (world Mercator)** | **7 079 – 7 087** |
| ~135° and up | 999061 | 9 240 – 10 824 (wide Lambert) |

The cliff is exactly at a 45.0° span (44.99° → 999247, 45.0° → 999000), and world Mercator's scale error is `1/cos(latitude)`, which is the whole story: `cos(45°)² = 0.5`.

The gate threshold sits at the *other* measured boundary — 6.0°, where PostGIS leaves the single-UTM-zone regime (5.999° → 999031, 6.0° → 999247), hence `>=` rather than `>`. Picking 6 rather than 45 is deliberate: it removes the ±1% band as well as the catastrophic tail, and it keeps a safety margin so a future PostGIS retune of `_ST_BestSRID` cannot silently reopen the half-area case.

Latitude span is harmless. Held at 0° longitude span and swept to an 80° latitude span, the SRID stayed on the UTM zone and the radius stayed within 9 990 – 10 004 m — transverse Mercator holds scale ≈ 1 along its central meridian at every latitude. So the guard tests longitude span only, the same quantity `render_dateline_safe` already tests.

## Pass ordering

Three passes, and the order is not free:

1. **Per-component buffer.** `ST_Dump` the validated source, buffer each part through its own `::geography`, dump each part's buffer (so `ST_Collect` never mixes `POLYGON` with `MULTIPOLYGON` into a `GEOMETRYCOLLECTION`), `ST_CollectionHomogenize(ST_Collect(...))`.
2. **Seam split** — the existing `render_dateline_safe`, unchanged.
3. **`ST_UnaryUnion`** to dissolve overlapping parts.

**2 before 3.** A component whose buffer wraps ±180 is self-intersecting *in the planar domain*, and unioning it in that state does not degrade gracefully — it aborts the statement:

```
ERROR:  lwgeom_unaryunion_prec: GEOS Error: TopologyException: side location
conflict at 179.90757318430857 44.915684255255684. This can occur if the input
geometry is invalid.
```

That is the same lesson #883 learned with `ST_ShiftLongitude` before `ST_MakeValid` (validate-first noded the seam into 4 slivers holding 97.9% of the area, against 2 parts holding 99.3%): the seam artefact has to be resolved before any GEOS overlay op touches the geometry.

**3 has to exist.** Buffering the whole input dissolved components whose buffers overlap; buffering per component and collecting does not. Measured on `MULTIPOINT((0 45),(0.05 45),(90 45))`, 10 km:

| dissolve | parts | `ST_IsValid` | area (m²) |
| --- | --- | --- | --- |
| none (`ST_Collect` only) | 3 | **false** | 935 908 947 (overlap counted twice) |
| `ST_MakeValid` | 3 | true | **468 078 270** (cut the overlap out of one part) |
| `ST_UnaryUnion` | 2 | true | **701 993 608** ✔ |

701 993 608 is the true answer: 390 028 685 (two overlapping circles unioned) + 311 964 923 (the distant circle). `ST_MakeValid` subtracts where a dissolve should merge, so it is not an alternative. The union is a no-op where nothing overlaps — the #883 seam fixture measures 623 944 052 m² and 3 parts with or without it — which is why it can sit unconditionally on this branch.

## Cost profile

Gated on two cheap conditions on the validated source: `ST_NumGeometries(...) > 1 AND ST_XMax(...) - ST_XMin(...) >= 6`. Single-part input takes a bare `ELSE` that renders exactly the #883 expression.

The guard is free — PostgreSQL short-circuits the `AND`, so single-part rows never reach the bbox scan. Over the same 2 000 66-vertex polygons: `ST_NumGeometries` alone 3.75 ms, the span test alone 7.34 ms, both together **3.60 ms**.

`EXPLAIN (ANALYZE, TIMING OFF)`, median of 3 warm runs, pre-fix expression vs this one, plus a third variant that is the pre-fix expression with only this function's extra `OFFSET 0` fence added, to attribute the delta:

| workload | before | fence only | after |
| --- | --- | --- | --- |
| 2 000 single-part POINT | 53.2 ms | 38.5 ms | **38.4 ms** |
| 2 000 single-part POLYGON (66 vertices) | 334.9 ms | 375.7 ms | **375.6 ms** |
| 2 000 two-part MULTIPOINT, 2° apart (under the gate) | 86.8 ms | — | **75.0 ms** |
| 2 000 two-part MULTIPOINT, 90° apart (gated) | 87.3 ms | — | **116.4 ms** |
| 200 × 100-part MULTIPOINT spanning 99° (gated) | 586.3 ms | — | **1 315.5 ms** |

So the common path's entire cost is the fence, +20 µs/row on 66-vertex polygons; on bare points it is *cheaper*, because materializing `ST_MakeValid` once beats re-deriving it. The gated path pays for the per-part buffers and the dissolve, bounded and only where the answer was wrong.

The last row is the honest worst case: 6.58 ms/row against 2.93 ms/row before, so a hypothetical source of 500 000 hundred-part features spanning 99° would blow the 300 s CTAS budget — as it already did before this change (1 465 s → 3 289 s). It is a 2.2x on a shape that was already past the ceiling, not a newly reachable failure, and `MAX_SOURCE_FEATURES["buffer"]` bounds feature count rather than part count either way.

Structural evidence — one `EXPLAIN ANALYZE` over a 2 000-row mix, 285 of them wide multipart:

```
Seq Scan on _c891_mixed (actual rows=2000.00 loops=1)
  SubPlan 6
    ->  Subquery Scan on _pb (loops=2000)
          SubPlan 3                                    <- per-component buffer
            ->  Subquery Scan on _pb_m (loops=285)
                          ->  Aggregate (loops=285)
                  SubPlan 1  -> (never executed)       <- seam split, no wrap present
          SubPlan 5                                    <- whole-input buffer
            ->  Subquery Scan on _dl (loops=1715)
                  SubPlan 4  -> (never executed)
```

285 + 1715 = 2000. Both `ST_Buffer` call sites are rendered; exactly one is reached per row. On the pure single-part table `SubPlan 3` reads `never executed` outright.

## Before / after

Same fixtures, same 10 km distance, `before` = the expression on `main@cb22f5bb1`. Ratio is against the ideal circle area (`π r²` per component), measured with:

```sql
SELECT label,
   round((ST_Area((<BEFORE>)::geography)
          / (pi()*10000^2*ST_NumGeometries(geom_4326)))::numeric,4) AS before_ratio,
   round((ST_Area((<AFTER>)::geography)
          / (pi()*10000^2*ST_NumGeometries(geom_4326)))::numeric,4) AS after_ratio,
   ST_AsEWKB(<BEFORE>) = ST_AsEWKB(<AFTER>) AS byte_identical
FROM _fixtures ORDER BY label;
```


| fixture | before | after | note |
| --- | --- | --- | --- |
| `MULTIPOINT((0 45),(0.2 45))` | 0.9380 | 0.9380 | byte-identical; the deficit is real overlap, not a bug |
| `MULTIPOINT((0 45),(10 45))` | 0.9936 | 0.9936 | area equal, radius tightened 9 904–10 097 → 9 997/10 003 |
| **`MULTIPOINT((0 45),(90 45))`** | **0.4985** | **0.9930** | the headline case |
| `MULTIPOINT((0 45),(150 45))` | 0.9936 | 0.9930 | equal-area SRID hid it; radius 9 240–10 824 → 9 997 |
| **`MULTIPOINT((0 0),(90 60))`** | **0.6216** | **0.9927** | lat-60 component 5 009 m → 10 000 m radius |
| `POINT(0 45)` | 0.9930 | 0.9930 | **byte-identical** |
| `POINT(0 89.9)` (polar) | 0.9936 | 0.9936 | **byte-identical**, still `POLYGON` |
| `MULTIPOINT((179.95 45),(0 45))` (#883) | 0.9936 | 0.9930 | 3 parts, valid, both centres covered |

The remaining 0.7% is `ST_Buffer`'s own polygonal approximation of a geodesic circle, the same figure #883 measured.

The `MULTIPOINT((0 0),(90 60))` row is why area ratios understate this: 0.6216 reads as a mild deficit, but the equatorial component was exact (Mercator scale 1 at the equator) while the lat-60 component held a **quarter** of its area. The per-component radius is the honest metric, and the new tests assert on it. Same fixtures, geodesic distance from each source component to every vertex of the output part covering it, requested radius 10 000 m:

```
                        |     BEFORE      |      AFTER
 fixture         part   |  min      max   |  min      max
------------------------+-----------------+-----------------
 sep 10 deg        1    |  9904    10097  |  9997     9997
 sep 10 deg        2    |  9971    10030  | 10003    10003
 sep 90 deg        1    |  7079     7087  |  9997     9997
 sep 90 deg        2    |  7079     7087  |  9997     9997
 sep 150 deg       1    |  9253    10814  |  9997     9997
 sep 150 deg       2    |  9240    10824  |  9997     9997
 lat 0 + lat 60    1    | 10000    10000  |  9990     9991
 lat 0 + lat 60    2    |  5009     5016  | 10000    10001
 883 seam fixture  1    |  9253    10813  |  9960     9998
 883 seam fixture  2    |  9253    10814  |  9997     9997
 single point           |  9997     9997  |  9997     9997
 polar 89.9             | 10000    10000  | 10000    10000
```

The `883 seam fixture` rows are worth calling out: at a 179.95° span the whole-input SRID was the wide Lambert, which is equal-area, so #883's area assertion at `rel=0.02` passed while both components were deformed ±8%. Per-component buffering fixes the shape too. (Component 1's 9 960 m minimum is the seam-split part, whose ring includes the ±180 cut edge.)

**Why #883's tables compared fixed-vs-raw rather than fixed-vs-ideal:** this bug was folded into every multipart number, so an ideal-circle baseline would have charged the antimeridian fix with a projection error it did not cause. With #891 fixed, fixed-vs-ideal is now the meaningful comparison, and the new tests use it (`rel=0.01` against `2 π r²`) instead of comparing against unfixed output.

## Verification

```
cd backend && uv run ruff check .          # All checks passed!
cd backend && uv run ruff format --check . # 846 files already formatted
```

```
pytest tests/test_analysis_preview.py tests/test_analysis_materialize.py
  109 passed, 43 warnings in 62.61s

pytest -k "MultipartProjection or Dateline" tests/test_analysis_materialize.py
  11 passed, 58 deselected in 13.50s     # 5 pre-existing #883 + 6 new

pytest -n 4                              # FULL backend suite
  5960 passed, 81 skipped, 264 warnings in 708.40s (0:11:48)
```

Every #883 fixture re-measured against the new expression and unchanged:

| #883 fixture | type | parts | valid | span | hits France |
| --- | --- | --- | --- | --- | --- |
| `POINT(179.95 45)` @10 km | MULTIPOLYGON | 2 | t | −180..180 | f |
| `POINT(0 45)` @10 km | POLYGON | 1 | t | 0.2534 | f |
| `POINT(0 85.06)` @100 km | POLYGON | 1 | t | 20.8158 | f |
| `POINT(0 89.9)` @100 km (polar) | POLYGON | 1 | t | 347.3388 | f |
| `MULTIPOINT((179.95 45),(0 45))` @10 km | MULTIPOLYGON | 3 | t | −180..180 | f |

Edge cases probed for GEOS exceptions and type drift — all valid, none raising: pole-encircling component plus a distant one, components at both −179 and +179, a `GEOMETRYCOLLECTION` with an `EMPTY` member, mixed-dimension collection, `GEOMETRYCOLLECTION EMPTY`, `MULTIPOINT EMPTY`, duplicate coincident points, and spans of exactly 5.999° / 6.0°.

## Not fixed here

A **single** component wider than one UTM zone is still buffered in one non-local projection — there is nothing to dump it into. A 10 km buffer of `LINESTRING(0 45, 90 45)` produces 85 485 981 084 m² against 134 146 143 319 m² for the same line segmentized to 20 km and buffered piecewise, so 63.7% of the correct area, identical before and after this change. Closing that means subdividing *within* a component, which changes the vertex structure of every large single-part output — its own decision, worth a follow-up issue.

`processing/ai/sql_generator.py` still teaches the unnormalized `ST_Buffer(geom_4326::geography, 1000)::geometry` pattern in the NL→SQL prompt; that is #886 and deliberately untouched here.

Closes #891

---

## Codex review — both findings accepted and fixed (`b5ce65d9b`)

**P1 "Keep raster 401s on the JWT-refresh path" — real, and worse than it reads.** Verified the mechanism before accepting: the re-mint is `getTileTokensBatch` → `apiFetch` → `authenticatedRawFetch`, which calls `tryRefresh()` when the access token is within 30 s of expiry (`api/client.ts:142`), and `tryRefresh` writes a fresh token into `useAuthStore` — the same store `buildTileTransformRequest` reads at request time to attach the raster Bearer (`lib/tile-utils.ts:84`). So the "useless" re-mint was in fact the only thing renewing the credential a raster tile needs. Short-circuiting it would have left an expired-JWT raster layer unauthorized until an unrelated API call happened to refresh the session.

The fix keeps the re-mint running for raster in all three surfaces and narrows only the *claim*: `resigned` is forced false for raster (nothing re-signs a raster source), and `reminted === true` no longer suppresses the report or swallows the toast/error path. The builder's suppressed "recovered" row and the early `return` were always the actual bug — not the call.

Tests updated to pin the corrected behaviour: the builder spec now asserts the re-mint **is** kicked (`invalidate` once) *and* that no recovery is claimed; the viewer spec asserts `refreshTokens` is called *and* the toast still fires. Re-verified against a neutralized predicate: 3 of 5 raster specs fail without the fix.

**P2 "Report only when recovery actually starts a re-mint" — real.** The telemetry moved from `useVisibleTileTokenRefresh` into `useTileAuthRecovery`, the only place that knows a mint started: the returned boolean is `true` both for a fresh mint and for an error riding the 10 s settle window, and `false` mid-cooldown, so the visible-edge hook could log a rotation that never happened (rapid tab flips). `useTileAuthRecovery(remint, onRemint?)` now fires `onRemint(trigger)` only on the branch that calls `remint()`, the visible-edge path passes `'tab-return'` (default `'tile-error'`), and the entry reads `Tile tokens re-minted (<surface>, <trigger>)`. One entry means one mint, attributed to the path that asked for it — and the reactive path gets the same trace, which the viewer and dataset preview previously had none of.

`onRemint` is held in a ref so the returned callback keeps a stable identity: ViewerMap and DatasetMap list it in `handleLoad`'s deps, and an inline-arrow reporter would otherwise re-create the callback every render (re-registering the `visibilitychange` listener and churning the `<Map onLoad>` prop). There is a spec for that.

### Post-fix verification

```
$ cd frontend && npm run lint && npm run typecheck
(both clean)

$ npx vitest run <the 7 affected files>
 Test Files  7 passed (7)
      Tests  67 passed (67)

$ npm run test:coverage
 Test Files  357 passed (357)
      Tests  4148 passed (4148)
Statements   : 71.42% / Branches : 66.7% / Functions : 65.86% / Lines : 73.52%

$ npm run test:i18n
      Tests  4 passed (4)
$ npm run check:i18n:changed
No locale file changes detected.
```

### Codex re-review — one further finding, verified and dismissed with a test (`ed8cc2962`)

**P2 "Avoid recording raster auth failures twice"** — true that the buffer ends up with two rows (this handler's unsuppressed `maplibre` row plus the `console` row `initReportCapture` derives from `logUnhandledMapError`), but that pairing is the buffer's existing shape for *every* error no surface recovers, not something raster introduced: a tile 5xx does exactly the same on `main`. The new spec `records a raster 403 the same way an unrecovered 5xx is recorded` asserts identical shapes for both (1 report row, `severity: 'error'`, `suppressed: false`, plus 1 `console.error`) with hard counts so it cannot pass vacuously.

Collapsing to one path costs information either way: dropping this row loses `sourceId` (the only signal naming the failing layer — the console row has none), and dropping the console log for raster would leave ViewerMap and DatasetMap with **no** trace at all, since neither pushes a row of its own. The #755 complaint was a suppressed *"recovered"* row next to the red one, i.e. a recovered situation reading as a breakage; nothing recovers a raster tile here, so reading as a breakage is correct. A cross-source dedupe in the report buffer would fix the double-count for 5xx too and is filed as a follow-up rather than special-cased for raster. The reasoning is recorded in a comment at the push site.
