### PR TITLE
fix(export): filter an antimeridian bbox server-side instead of via -spat

### DIFF
--- a/backend/app/processing/export/ogr.py
+++ b/backend/app/processing/export/ogr.py
@@ -40,6 +40,40 @@ FORMAT_MAP: dict[str, dict[str, str]] = {
 }
 
 
+def bbox_where_sql(bbox: list[float], *, literal: bool = False) -> str:
+    """Build the ``geom_4326`` bbox predicate for a raw-SQL WHERE fragment.
+
+    Each envelope carries a ``&&`` index prefilter plus an exact
+    ``ST_Intersects``, mirroring the features read path
+    (``catalog/features/service.py``).
+
+    fix(#885): a west>east bbox crosses the antimeridian — ``parse_bbox``
+    documents it as valid input — and is emitted as ``[minx..180]`` OR
+    ``[-180..maxx]``. It stays a single predicate, so a feature whose own
+    geometry straddles the seam matches the OR once and is selected exactly
+    once. Shared with the GeoParquet writer (``export/parquet.py``) so the two
+    export paths cannot drift.
+
+    ``literal=True`` renders float literals instead of ``:minx``-style bind
+    parameters, for the ogr2ogr ``-where`` argument — a subprocess argv element
+    that cannot carry binds. Every bound goes through ``float()``, so the
+    rendered text is always a numeric literal (``parse_bbox`` has already
+    rejected NaN/Inf).
+    """
+    if literal:
+        minx, miny, maxx, maxy = (repr(float(v)) for v in bbox)
+    else:
+        minx, miny, maxx, maxy = ":minx", ":miny", ":maxx", ":maxy"
+
+    def envelope(west: str, east: str) -> str:
+        env = f"ST_MakeEnvelope({west}, {miny}, {east}, {maxy}, 4326)"
+        return f"(geom_4326 && {env} AND ST_Intersects(geom_4326, {env}))"
+
+    if bbox[0] > bbox[2]:
+        return f"({envelope(minx, '180')} OR {envelope('-180', maxx)})"
+    return envelope(minx, maxx)
+
+
 async def run_ogr2ogr_export(
     table_name: str,
     output_path: str,
@@ -60,7 +94,10 @@ async def run_ogr2ogr_export(
         schema: Source PostgreSQL schema. Required so exports cannot silently
             read a same-named table from the shared ``data`` schema.
         target_srs: Optional target CRS (e.g. "EPSG:3857").
-        bbox: Optional bounding box [minx, miny, maxx, maxy] in WGS84.
+        bbox: Optional bounding box [minx, miny, maxx, maxy] in WGS84. A
+            west>east box crosses the antimeridian and is filtered server-side
+            against ``geom_4326``, so callers must not pass a bbox for a layer
+            without geometry (the router drops it for non-spatial datasets).
         where: Optional SQL WHERE clause for attribute filtering.
         format_key: Format key from FORMAT_MAP for format-specific options.
 
@@ -85,7 +122,17 @@ async def run_ogr2ogr_export(
     if target_srs:
         cmd.extend(["-t_srs", target_srs])
 
-    if bbox:
+    if bbox and bbox[0] > bbox[2]:
+        # fix(#885): -spat takes ONE rectangle and GDAL reads its corners as an
+        # envelope, so an antimeridian-crossing `-spat 170 -20 -170 -15` silently
+        # became the complement band (lon -170..170) and dropped every feature the
+        # caller asked for. Push the two-envelope split into the server-side WHERE
+        # instead — one pass, so a seam-straddling feature is still emitted once
+        # (two -spat runs would emit it twice). Still select-not-clip: whole
+        # intersecting features with untouched geometry, unlike -clipsrc.
+        spatial_where = bbox_where_sql(bbox, literal=True)
+        where = f"{spatial_where} AND ({where})" if where else spatial_where
+    elif bbox:
         cmd.extend(
             [
                 "-spat",

--- a/backend/app/processing/export/parquet.py
+++ b/backend/app/processing/export/parquet.py
@@ -25,6 +25,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.core.async_io import run_in_thread_draining
 from app.core.config import settings
 from app.core.runtime.staging import ensure_staging_ready
+from app.processing.export.ogr import bbox_where_sql
 from app.processing.export.service import validate_where_clause
 from app.processing.export.where_validator import canonical_where
 from app.processing.ingest.metadata import _qtable, get_column_info
@@ -182,18 +183,10 @@ async def export_parquet(
         # the antimeridian split when minx > maxx (parse_bbox allows it). Using
         # only && would silently drop antimeridian boxes and return an
         # envelope-overlap superset instead of the rows actually in the bbox.
-        if bbox[0] > bbox[2]:
-            clauses.append(
-                "((geom_4326 && ST_MakeEnvelope(:minx, :miny, 180, :maxy, 4326)"
-                " AND ST_Intersects(geom_4326, ST_MakeEnvelope(:minx, :miny, 180, :maxy, 4326)))"
-                " OR (geom_4326 && ST_MakeEnvelope(-180, :miny, :maxx, :maxy, 4326)"
-                " AND ST_Intersects(geom_4326, ST_MakeEnvelope(-180, :miny, :maxx, :maxy, 4326))))"
-            )
-        else:
-            clauses.append(
-                "geom_4326 && ST_MakeEnvelope(:minx, :miny, :maxx, :maxy, 4326)"
-                " AND ST_Intersects(geom_4326, ST_MakeEnvelope(:minx, :miny, :maxx, :maxy, 4326))"
-            )
+        # fix(#885): the fragment now comes from the shared builder in
+        # export/ogr.py, so the ogr2ogr path splits identically instead of
+        # handing a degenerate rectangle to -spat.
+        clauses.append(bbox_where_sql(bbox))
         params.update(minx=bbox[0], miny=bbox[1], maxx=bbox[2], maxy=bbox[3])
     if safe_where is not None:
         # SQLAlchemy text() reads ":name" as a bind parameter; a colon inside a

--- a/backend/app/processing/export/router.py
+++ b/backend/app/processing/export/router.py
@@ -327,7 +327,12 @@ async def export_dataset_endpoint(
                 format,
                 schema=data_schema,
                 target_srs=target_crs,
-                bbox=bbox_parsed,
+                # fix(#885): an antimeridian bbox is filtered by a server-side
+                # geom_4326 predicate, so a bbox only travels with a dataset that
+                # HAS geometry. csv is the one ogr format a non-spatial dataset
+                # can reach (gate 6 blocks the rest), and -spat was already a
+                # no-op there ("Cannot set spatial filter: no geometry field").
+                bbox=bbox_parsed if dataset.geometry_type is not None else None,
                 where=where,
                 column_info=dataset.column_info,
             )

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1875,11 +1875,17 @@ def _point_ogr2ogr_at_test_db(request, monkeypatch):
     Opt-in: only tests marked with ``@pytest.mark.requires_ogr2ogr``
     (or a class-level ``pytestmark``) trigger the monkeypatch. All
     other tests are unaffected.
+
+    fix(#885): the export wrapper does ``from app.processing.ingest.ogr import
+    build_pg_conn_str`` at module scope, so it holds its OWN binding — patching
+    only the ingest module left ``run_ogr2ogr_export`` reading the dev/prod
+    database. Both bindings are redirected.
     """
     if "requires_ogr2ogr" not in request.keywords:
         return
 
     from app.core.config import settings as _settings
+    from app.processing.export import ogr as _export_ogr
     from app.processing.ingest import ogr as _ogr
 
     def _test_pg_conn_str() -> str:
@@ -1892,6 +1898,7 @@ def _point_ogr2ogr_at_test_db(request, monkeypatch):
         )
 
     monkeypatch.setattr(_ogr, "build_pg_conn_str", _test_pg_conn_str)
+    monkeypatch.setattr(_export_ogr, "build_pg_conn_str", _test_pg_conn_str)
 
 
 @pytest.fixture

--- a/backend/tests/test_export_antimeridian.py
+++ b/backend/tests/test_export_antimeridian.py
@@ -1,0 +1,429 @@
+"""fix(#885): an antimeridian-crossing (west>east) bbox must narrow an ogr2ogr
+export the same way it narrows /features and format=parquet.
+
+``parse_bbox`` documents west>east as valid, but ogr2ogr's ``-spat`` takes ONE
+rectangle and GDAL reads its corners as an envelope, so
+``-spat 170 -20 -170 -15`` silently became the *complement* band
+(lon -170..170): the export succeeded and dropped every feature the caller had
+asked for. A Fiji or Aleutians AOI came back empty from GPKG/GeoJSON/SHP/CSV
+while the same bbox returned rows from /features and from parquet.
+
+The command-shape and unit tests here run everywhere. The end-to-end format
+tests need a real ogr2ogr against the test PostGIS database, so they carry the
+usual ``requires_ogr2ogr`` pair (skip on GDAL-less dev hosts; CI installs
+gdal-bin).
+"""
+
+import csv
+import json
+import os
+import shutil
+import subprocess
+import uuid
+
+import pytest
+from sqlalchemy import text
+
+from app.processing.export.ogr import bbox_where_sql
+
+# Fiji-ish: 170°E .. 170°W, i.e. minx > maxx.
+CROSSING_BBOX = [170.0, -20.0, -170.0, -15.0]
+# The east half of the same box — a plain, non-crossing rectangle.
+EAST_HALF_BBOX = [170.0, -20.0, 180.0, -15.0]
+
+
+# ---------------------------------------------------------------------------
+# bbox_where_sql — pure unit
+# ---------------------------------------------------------------------------
+
+
+class TestBboxWhereSql:
+    def test_non_crossing_is_one_envelope(self):
+        sql = bbox_where_sql([1.0, 2.0, 3.0, 4.0])
+        assert sql.count("ST_MakeEnvelope") == 2  # && prefilter + ST_Intersects
+        assert " OR " not in sql
+        assert "ST_MakeEnvelope(:minx, :miny, :maxx, :maxy, 4326)" in sql
+        assert "geom_4326 &&" in sql
+        assert "ST_Intersects(geom_4326," in sql
+
+    def test_crossing_splits_at_the_seam(self):
+        sql = bbox_where_sql(CROSSING_BBOX)
+        assert " OR " in sql
+        # East half runs to +180, west half starts at -180.
+        assert "ST_MakeEnvelope(:minx, :miny, 180, :maxy, 4326)" in sql
+        assert "ST_MakeEnvelope(-180, :miny, :maxx, :maxy, 4326)" in sql
+        # Both halves keep the && index prefilter AND the exact intersects.
+        assert sql.count("geom_4326 &&") == 2
+        assert sql.count("ST_Intersects(geom_4326,") == 2
+
+    def test_literal_form_carries_no_bind_parameters(self):
+        sql = bbox_where_sql(CROSSING_BBOX, literal=True)
+        # ogr2ogr -where is a subprocess argv element: binds would never resolve.
+        assert ":" not in sql
+        assert "170.0" in sql and "-170.0" in sql
+        assert "ST_MakeEnvelope(170.0, -20.0, 180, -15.0, 4326)" in sql
+        assert "ST_MakeEnvelope(-180, -20.0, -170.0, -15.0, 4326)" in sql
+
+    def test_literal_form_forces_numeric_rendering(self):
+        """Every bound goes through float(), so nothing but a numeric literal
+        can reach the SQL text. Deliberately violates the list[float] annotation:
+        the point is that a non-numeric bound cannot be interpolated even if a
+        future caller stops honouring the type."""
+        sql = bbox_where_sql(["170", "-20", "-170", "-15"], literal=True)
+        assert "170.0" in sql
+        with pytest.raises(ValueError):
+            bbox_where_sql(["1); DROP TABLE t --", "-20", "10", "-15"], literal=True)
+
+
+# ---------------------------------------------------------------------------
+# ogr2ogr command shape — no DB, no GDAL
+# ---------------------------------------------------------------------------
+
+
+class TestExportCommandShape:
+    @pytest.fixture
+    def captured(self, monkeypatch):
+        """Capture the argv run_ogr2ogr_export would spawn."""
+        from app.processing.export import ogr as export_ogr
+
+        commands: list[tuple[str, ...]] = []
+
+        async def _capture(*args, **kwargs):
+            commands.append(args)
+
+            class _Proc:
+                returncode = 0
+
+            return _Proc()
+
+        async def _communicate(*args, **kwargs):
+            return b"", b""
+
+        monkeypatch.setattr(export_ogr.asyncio, "create_subprocess_exec", _capture)
+        monkeypatch.setattr(export_ogr, "_communicate_with_timeout", _communicate)
+        return commands
+
+    async def _run(self, tmp_path, **kwargs):
+        from app.processing.export.ogr import run_ogr2ogr_export
+
+        await run_ogr2ogr_export(
+            "roads",
+            str(tmp_path / "out.geojson"),
+            "GeoJSON",
+            schema="data",
+            **kwargs,
+        )
+
+    @pytest.mark.anyio
+    async def test_crossing_bbox_uses_where_not_spat(self, captured, tmp_path):
+        await self._run(tmp_path, bbox=CROSSING_BBOX)
+        cmd = captured[0]
+        # -spat would collapse to the complement band, so it must be gone.
+        assert "-spat" not in cmd
+        assert "-spat_srs" not in cmd
+        where = cmd[cmd.index("-where") + 1]
+        assert "ST_MakeEnvelope(170.0, -20.0, 180, -15.0, 4326)" in where
+        assert "ST_MakeEnvelope(-180, -20.0, -170.0, -15.0, 4326)" in where
+        assert " OR " in where
+
+    @pytest.mark.anyio
+    async def test_non_crossing_bbox_still_uses_spat(self, captured, tmp_path):
+        await self._run(tmp_path, bbox=EAST_HALF_BBOX)
+        cmd = captured[0]
+        assert "-where" not in cmd
+        spat = cmd.index("-spat")
+        assert list(cmd[spat : spat + 5]) == [
+            "-spat",
+            "170.0",
+            "-20.0",
+            "180.0",
+            "-15.0",
+        ]
+        assert cmd[cmd.index("-spat_srs") + 1] == "EPSG:4326"
+
+    @pytest.mark.anyio
+    async def test_crossing_bbox_ands_the_caller_where(self, captured, tmp_path):
+        await self._run(tmp_path, bbox=CROSSING_BBOX, where="pop > 15")
+        cmd = captured[0]
+        assert cmd.count("-where") == 1
+        where = cmd[cmd.index("-where") + 1]
+        assert where.endswith(" AND (pop > 15)")
+        assert " OR " in where
+
+    @pytest.mark.anyio
+    async def test_no_bbox_leaves_the_caller_where_alone(self, captured, tmp_path):
+        await self._run(tmp_path, where="pop > 15")
+        cmd = captured[0]
+        assert cmd[cmd.index("-where") + 1] == "pop > 15"
+        assert "-spat" not in cmd
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: real ogr2ogr, real PostGIS, every ogr-backed format
+# ---------------------------------------------------------------------------
+
+_OGR_TESTS = [
+    pytest.mark.skipif(
+        shutil.which("ogr2ogr") is None,
+        reason="ogr2ogr binary not available on host (runs in backend Docker image / CI)",
+    ),
+    pytest.mark.requires_ogr2ogr,
+]
+
+# name -> (WKT, pop). All linestrings: a shapefile holds one geometry type per
+# file, and "on_the_seam" has to be a line so it can straddle the antimeridian
+# in its own geometry — that is the feature a two-pass -spat split would emit
+# twice. "greenwich" sits in the middle of the band the broken -spat rectangle
+# collapsed to, so it pins the wrong-rows half of the bug, not just the
+# missing-rows half.
+_ROWS = {
+    "east_of_170": ("LINESTRING(174 -18, 176 -18)", 10),
+    "west_of_-170": ("LINESTRING(-176 -17, -174 -17)", 20),
+    "on_the_seam": ("LINESTRING(179 -17.5, -179 -17.5)", 30),
+    "greenwich": ("LINESTRING(-1 -17, 1 -17)", 40),
+    "outside_lat_band": ("LINESTRING(174 40, 176 40)", 50),
+}
+
+# column_info for the where-clause validator (export_dataset rejects a filter
+# when it has no column metadata to check the identifiers against).
+_COLUMN_INFO = [
+    {"name": "gid", "type": "integer"},
+    {"name": "name", "type": "varchar"},
+    {"name": "pop", "type": "integer"},
+]
+
+
+def _names_in(path: str) -> list[str]:
+    """Read the ``name`` column out of an exported artifact."""
+    if path.endswith(".csv"):
+        with open(path, newline="") as fh:
+            return sorted(row["name"] for row in csv.DictReader(fh))
+    # GPKG / SHP / GeoJSON: let GDAL normalise them to GeoJSON, then read it.
+    converted = os.path.join(os.path.dirname(path), f"read_{uuid.uuid4().hex[:8]}.json")
+    subprocess.run(
+        ["ogr2ogr", "-f", "GeoJSON", converted, path],
+        check=True,
+        capture_output=True,
+        timeout=120,
+    )
+    with open(converted) as fh:
+        return sorted(f["properties"]["name"] for f in json.load(fh)["features"])
+
+
+class TestAntimeridianExportEndToEnd:
+    pytestmark = _OGR_TESTS
+
+    @pytest.fixture
+    async def antimeridian_table(self, test_db_session, monkeypatch, tmp_path):
+        from app.processing.export import service as export_service
+
+        monkeypatch.setattr(
+            export_service.settings, "upload_staging_dir", str(tmp_path)
+        )
+
+        table = f"exp_am_{uuid.uuid4().hex[:12]}"
+        await test_db_session.execute(
+            text(
+                f"CREATE TABLE data.{table} (gid serial PRIMARY KEY, name varchar, "
+                "pop integer, geom geometry(Geometry, 4326), "
+                "geom_4326 geometry(Geometry, 4326))"
+            )
+        )
+        for name, (wkt, pop) in _ROWS.items():
+            await test_db_session.execute(
+                text(
+                    f"INSERT INTO data.{table} (name, pop, geom, geom_4326) VALUES "
+                    "(:n, :p, ST_GeomFromText(:w, 4326), ST_GeomFromText(:w, 4326))"
+                ).bindparams(n=name, p=pop, w=wkt)
+            )
+        await test_db_session.commit()
+        yield table
+        # Release any server-side cursor the test left open (the parquet writer
+        # streams), or the DROP hits asyncpg's "used by active queries".
+        await test_db_session.rollback()
+        await test_db_session.execute(text(f"DROP TABLE IF EXISTS data.{table}"))
+        await test_db_session.commit()
+
+    async def _export(self, table, format_key, **kwargs):
+        from app.processing.export.service import export_dataset
+
+        path, _filename, _media = await export_dataset(
+            table, "AM Dataset", format_key, schema="data", **kwargs
+        )
+        if format_key == "shp":
+            # export_dataset returns the ZIP; the .shp sits beside it.
+            return os.path.join(os.path.dirname(path), "export.shp")
+        return path
+
+    @pytest.mark.anyio
+    @pytest.mark.parametrize("format_key", ["gpkg", "geojson", "shp", "csv"])
+    async def test_crossing_bbox_exports_both_sides_of_the_seam(
+        self, antimeridian_table, format_key
+    ):
+        """The regression: every ogr-backed format used to come back without the
+        features inside the requested box."""
+        out = await self._export(antimeridian_table, format_key, bbox=CROSSING_BBOX)
+        assert _names_in(out) == ["east_of_170", "on_the_seam", "west_of_-170"]
+
+    @pytest.mark.anyio
+    @pytest.mark.parametrize("format_key", ["gpkg", "geojson", "shp", "csv"])
+    async def test_non_crossing_bbox_unchanged(self, antimeridian_table, format_key):
+        """-spat still serves the ordinary case: the east half selects only what
+        lies east of 170, and nothing at Greenwich or outside the lat band."""
+        out = await self._export(antimeridian_table, format_key, bbox=EAST_HALF_BBOX)
+        assert _names_in(out) == ["east_of_170", "on_the_seam"]
+
+    @pytest.mark.anyio
+    async def test_seam_feature_is_not_duplicated(self, antimeridian_table):
+        """A geometry that straddles the antimeridian intersects BOTH halves of
+        the split. The predicate is one OR in one pass, so it is exported once —
+        two appended -spat runs would emit it twice."""
+        out = await self._export(antimeridian_table, "geojson", bbox=CROSSING_BBOX)
+        with open(out) as fh:
+            features = json.load(fh)["features"]
+        assert [f["properties"]["name"] for f in features].count("on_the_seam") == 1
+        assert len(features) == 3
+
+    @pytest.mark.anyio
+    async def test_crossing_bbox_and_where_are_combined(self, antimeridian_table):
+        """The split predicate ANDs with the caller's attribute filter instead of
+        replacing it."""
+        out = await self._export(
+            antimeridian_table,
+            "geojson",
+            bbox=CROSSING_BBOX,
+            where="pop > 15",
+            column_info=_COLUMN_INFO,
+        )
+        assert _names_in(out) == ["on_the_seam", "west_of_-170"]
+
+    @pytest.mark.anyio
+    async def test_geometry_is_selected_not_clipped(self, antimeridian_table):
+        """-spat/-where select whole features; -clipsrc would have cut the seam
+        linestring at the box edge. Its coordinates must survive intact."""
+        out = await self._export(antimeridian_table, "geojson", bbox=CROSSING_BBOX)
+        with open(out) as fh:
+            features = json.load(fh)["features"]
+        seam = next(f for f in features if f["properties"]["name"] == "on_the_seam")
+        assert seam["geometry"]["coordinates"] == [[179.0, -17.5], [-179.0, -17.5]]
+
+    @pytest.mark.anyio
+    async def test_ogr_export_agrees_with_the_features_and_parquet_paths(
+        self, antimeridian_table, test_db_session
+    ):
+        """The asymmetry #885 is about: the same crossing bbox now selects the
+        same rows through /features, GeoParquet, and the ogr2ogr export."""
+        from app.modules.catalog.features.service import get_features
+        from app.processing.export.parquet import export_parquet
+
+        rows, _total = await get_features(
+            test_db_session,
+            antimeridian_table,
+            limit=100,
+            bbox=CROSSING_BBOX,
+        )
+        features_names = sorted(r["properties"]["name"] for r in rows)
+
+        parquet_path, _fn, _mt = await export_parquet(
+            test_db_session,
+            antimeridian_table,
+            "AM Dataset",
+            schema="data",
+            bbox=CROSSING_BBOX,
+        )
+        try:
+            import pyarrow.parquet as pq
+
+            parquet_names = sorted(
+                pq.read_table(parquet_path).column("name").to_pylist()
+            )
+        finally:
+            shutil.rmtree(os.path.dirname(parquet_path), ignore_errors=True)
+
+        ogr_names = _names_in(
+            await self._export(antimeridian_table, "gpkg", bbox=CROSSING_BBOX)
+        )
+
+        assert features_names == parquet_names == ogr_names
+        assert ogr_names == ["east_of_170", "on_the_seam", "west_of_-170"]
+
+
+# ---------------------------------------------------------------------------
+# A bbox must never reach the geom_4326 predicate on a geometry-less layer
+# ---------------------------------------------------------------------------
+
+
+class TestNonSpatialBboxIsDropped:
+    """A non-spatial dataset can only reach the ogr path as csv, and ``-spat``
+    was already a no-op there. The router drops the bbox for it so the
+    server-side geom_4326 predicate is never asked of a table without the
+    column (which would fail the whole translation)."""
+
+    @pytest.fixture
+    def captured_bbox(self, monkeypatch, tmp_path):
+        """Patch the router's export_dataset and record the bbox it receives."""
+        seen: dict = {}
+
+        async def _fake_export(
+            table_name,
+            dataset_name,
+            format_key,
+            *,
+            schema,
+            target_srs=None,
+            bbox=None,
+            where=None,
+            column_info=None,
+        ):
+            seen["bbox"] = bbox
+            path = tmp_path / f"{uuid.uuid4().hex}.out"
+            path.write_text("name\n")
+            return str(path), path.name, "text/csv"
+
+        monkeypatch.setattr("app.processing.export.router.export_dataset", _fake_export)
+        return seen
+
+    @pytest.mark.anyio
+    async def test_router_drops_bbox_for_non_spatial_dataset(
+        self, client, admin_auth_header, test_db_session, captured_bbox
+    ):
+        from tests.factories import get_user_id
+        from tests.test_export import _create_dataset
+
+        admin_id = await get_user_id(test_db_session, "admin")
+        ds = await _create_dataset(
+            test_db_session,
+            created_by=admin_id,
+            name="NonSpatialAmDS",
+            geometry_type=None,
+            record_type="table",
+        )
+        resp = await client.get(
+            f"/datasets/{ds.id}/export",
+            params={"format": "csv", "bbox": "170,-20,-170,-15"},
+            headers=admin_auth_header,
+        )
+        assert resp.status_code == 200
+        assert captured_bbox["bbox"] is None
+
+    @pytest.mark.anyio
+    async def test_router_keeps_bbox_for_spatial_dataset(
+        self, client, admin_auth_header, test_db_session, captured_bbox
+    ):
+        from tests.factories import get_user_id
+        from tests.test_export import _create_dataset
+
+        admin_id = await get_user_id(test_db_session, "admin")
+        ds = await _create_dataset(
+            test_db_session,
+            created_by=admin_id,
+            name="SpatialAmDS",
+            geometry_type="Point",
+        )
+        resp = await client.get(
+            f"/datasets/{ds.id}/export",
+            params={"format": "geojson", "bbox": "170,-20,-170,-15"},
+            headers=admin_auth_header,
+        )
+        assert resp.status_code == 200
+        assert captured_bbox["bbox"] == CROSSING_BBOX


### PR DESCRIPTION
## What changed

`ogr2ogr -spat` takes one rectangle, and GDAL reads the four numbers as a corner pair and derives an envelope from it. So `-spat 170 -20 -170 -15` did not match nothing — it matched the **complement**: `minx` and `maxx` sorted to `-170..170`, i.e. everything *except* the box the caller asked for. The export exited 0, so the user just got a file.

For a crossing box (`bbox[0] > bbox[2]`), `run_ogr2ogr_export` now drops `-spat` and pushes the two-envelope split into the server-side `-where` predicate the PostgreSQL driver already sends verbatim:

```
((geom_4326 && ST_MakeEnvelope(170.0, -20.0, 180, -15.0, 4326)
  AND ST_Intersects(geom_4326, ST_MakeEnvelope(170.0, -20.0, 180, -15.0, 4326)))
 OR (geom_4326 && ST_MakeEnvelope(-180, -20.0, -170.0, -15.0, 4326)
  AND ST_Intersects(geom_4326, ST_MakeEnvelope(-180, -20.0, -170.0, -15.0, 4326))))
```

An ordinary (non-crossing) box still goes through `-spat` byte-for-byte as before. When the caller also passed `where=`, the split is ANDed with it into the single `-where` argument.

Three smaller pieces come with it:

- The split fragment is now one builder, `bbox_where_sql()` in `export/ogr.py`, and the GeoParquet writer calls it instead of keeping its own copy — the two export paths can't drift apart again. `literal=True` renders float literals for the subprocess argv (which cannot carry bind parameters); the default renders `:minx`-style binds for the `text()` caller. Every bound goes through `float()`, so nothing but a numeric can reach the SQL text.
- The router drops the bbox for a **non-spatial** dataset. `-spat` was already a silent no-op there (`ERROR 1: Cannot set spatial filter: no geometry field present in layer`, exit 0), and `csv` is the only ogr format a geometry-less dataset can reach. Without this, a `geom_4326` predicate on a table with no such column would fail the whole translation → 500. Same `has_geometry` assumption the export cap's count and the `/features` bbox path already make.
- `conftest.py`'s `requires_ogr2ogr` redirect now patches both `build_pg_conn_str` bindings. `export/ogr.py` imports the name at module scope, so it held its own reference and `run_ogr2ogr_export` in a test was reading the **dev** database. Nothing exercised that before; the new end-to-end tests do.

## Why this shape and not `-clipsrc`

`-clipsrc` with a two-part MULTIPOLYGON does select the right features (verified — same 3 rows), but it *clips* geometry to the clip region. Measured on the same seam linestring:

```
=== -where (this PR) ===
seam LineString      [[179.0, -17.5], [-179.0, -17.5]]

=== -clipsrc MULTIPOLYGON ===
seam MultiLineString [[[179.0, -17.5], [170.0, -17.5]], [[-170.0, -17.5], [-179.0, -17.5]]]
```

The feature came back as a different geometry, cut at the box edges. That would change behavior for every bbox export, not just crossing ones. `-spat`/`-where` are select-not-clip, and the export must keep handing back whole features.

Two appended `-spat` runs (one per half) were the other option and were rejected on the duplicate constraint: a geometry that straddles the seam intersects **both** halves and would be written twice. A single `OR` predicate in one pass emits it once — pinned by `test_seam_feature_is_not_duplicated`.

`-sql` was not needed: the PostgreSQL driver passes `-where` straight into the server-side `WHERE`, and `run_ogr2ogr_export` already had a `-where` code path to reuse.

## Verification

All commands run on the host against the test Postgres (localhost:5434), on this branch.

**1. The bug, reproduced with real ogr2ogr against PostGIS** (5 linestrings: two inside the Fiji-ish box, one straddling the seam, one at Greenwich, one outside the latitude band):

```
$ ogr2ogr -f GeoJSON a.geojson "PG:..." data.probe885 -spat 170 -20 -170 -15 -spat_srs EPSG:4326
features: 1 ['seam_line']            # missed both features inside the box

$ ogr2ogr -f GeoJSON c.geojson "PG:..." data.probe885 -where "<the OR split>"
features: 3 ['east_of_170', 'seam_line', 'west_of_-170']    # correct, no duplicate

$ ogr2ogr -f GeoJSON d.geojson "PG:..." data.probe885 -clipsrc "MULTIPOLYGON(...)"
features: 3 ['east_of_170', 'seam_line', 'west_of_-170']    # correct set, but clipped
```

**2. The new tests fail without the fix.** Disabling only the new branch in `run_ogr2ogr_export` (`if False and bbox and ...`):

```
$ uv run pytest tests/test_export_antimeridian.py
tests/test_export_antimeridian.py ....F.F.FFFF....FF.F..                 [100%]
E  AssertionError: assert ['greenwich', 'on_the_seam'] == ['east_of_170', 'on_the_seam', 'west_of_-170']
9 failed, 13 passed
```

That left-hand side is the whole point: pre-fix, `bbox=170,-20,-170,-15` returned a feature at **longitude 0** and neither of the two features actually inside the box. Not just empty — wrong. All four non-crossing tests passed with the fix disabled, which is the no-regression half.

**3. The new tests pass with it:**

```
$ uv run pytest tests/test_export_antimeridian.py -q
22 passed, 43 warnings in 9.03s
```

Coverage: `bbox_where_sql` unit tests; command-shape tests (crossing → `-where`, no `-spat`; non-crossing → `-spat 170.0 -20.0 180.0 -15.0 -spat_srs EPSG:4326`, no `-where`; crossing + caller `where` → one ANDed `-where`); real ogr2ogr end-to-end for **gpkg / geojson / shp / csv** on both a crossing and a non-crossing bbox; seam feature emitted exactly once; seam geometry unclipped; the crossing bbox agreeing across `/features`, GeoParquet and the ogr export; and the router's bbox drop for a non-spatial dataset.

**4. Export, parquet, layering and Rule-1 structural files:**

```
$ uv run pytest tests/test_export_antimeridian.py tests/test_export.py tests/test_export_parquet.py \
    tests/test_export_parquet_writer.py tests/test_export_hardening.py tests/test_export_access.py \
    tests/test_export_temp_cleanup.py tests/test_layering.py tests/test_tenant_ingest_export_routing.py \
    tests/test_staging_runtime.py tests/test_rule1_structural.py -q
149 passed, 48 warnings in 47.66s
```

**5. Full backend suite:**

```
$ uv run pytest -n 4 -q
5975 passed, 81 skipped, 262 warnings in 648.92s (0:10:48)
```

**6. Backend gates:**

```
$ uv run ruff check .
All checks passed!
$ uv run ruff format --check .
847 files already formatted
```

## Impact

No schema, API surface or config change — `backend/openapi.json` and the SDKs are untouched. Behavior changes only for a bbox with `minx > maxx`, plus the dropped no-op `-spat` on a non-spatial csv export.

## Known gap, left out of scope

The export cap's bounded COUNT (`_count_selected_features`) still skips the bbox clause entirely for a crossing box (`bbox[0] <= bbox[2]` guard), so a dataset over the 5M-feature ceiling counts unfiltered and 413s on a crossing bbox that would have narrowed it under the cap. That is pre-existing, deliberately conservative (the clause is `&&`-only to keep the 5M-row scan cheap), and it is a ceiling behavior rather than the wrong-rows bug this PR fixes. Worth its own issue.

Closes #885
