### PR TITLE
fix(analysis): buffer each component in its own planar projection

### DIFF
--- a/backend/app/platform/analysis_sql.py
+++ b/backend/app/platform/analysis_sql.py
@@ -85,6 +85,14 @@ MASK_SUBDIVIDE_MAX_VERTICES = 256
 DATELINE_WRAP_SPAN_DEG = 180
 
 
+# A geography buffer projects its WHOLE input into one planar SRID chosen by
+# PostGIS's ``_ST_BestSRID``, and that choice is local to every component only
+# while the input fits inside a single UTM zone — 6° of longitude. Measured on
+# PostGIS 3.6, the switch away from the UTM zone happens exactly at a 6.0° span,
+# so the guard in ``render_geodesic_buffer`` tests ``>=``, not ``>``.
+BUFFER_LOCAL_SRID_SPAN_DEG = 6
+
+
 def render_dateline_safe(geom_expr: str, *, alias: str = "_dl") -> str:
     """Split antimeridian-wrapping output of ``geom_expr`` at ±180.
 
@@ -201,6 +209,135 @@ def render_dateline_safe(geom_expr: str, *, alias: str = "_dl") -> str:
         f" WHEN ST_XMax({alias}.g) - ST_XMin({alias}.g) > {DATELINE_WRAP_SPAN_DEG}"
         f" THEN {split}"
         f" ELSE {alias}.g END"
+        f" FROM (SELECT {geom_expr} AS g OFFSET 0) AS {alias})"
+    )
+
+
+def render_geodesic_buffer(
+    geom_expr: str, distance: float, *, alias: str = "_pb"
+) -> str:
+    """Render a metric buffer of ``geom_expr``, per component and dateline-safe.
+
+    fix(#891): ``ST_Buffer(...::geography, d)::geometry`` picks ONE planar
+    working SRID for the whole input via ``_ST_BestSRID``, so a multipart feature
+    whose components sit far apart in longitude is buffered in a projection that
+    suits at most one of them. Measured on PostGIS 3.6 over a two-point
+    ``MULTIPOINT`` at lat 45 with a 10 000 m buffer, reading the geodesic
+    distance from each source point to every vertex of the buffer part
+    containing it:
+
+        longitude span    SRID     produced radius (m)
+        under 6°          999031   9 997 - 10 004   single UTM zone
+        6° - 44.99°       999247   9 904 - 10 097
+        45° and up        999000   7 079 - 7 087    <- world Mercator
+        about 135° and up 999061   9 240 - 10 824   wide Lambert
+
+    At a 45° span PostGIS falls back to world Mercator, whose scale error is
+    1/cos(latitude), so the buffer comes back cos(φ) too small: the two-point
+    fixture at lat 45 held 49.9% of the correct area, and a component at lat 60
+    measured a 5 009 m radius for a requested 10 000 m — a quarter of its area.
+    Nothing errors and the output is valid, so nothing signals it.
+
+    Latitude span is harmless by contrast. Swept to an 80° span with the
+    longitude span held at 0, the SRID stayed on the UTM zone and the radius
+    stayed within 9 990 - 10 004 m, because transverse Mercator holds scale ≈ 1
+    along its central meridian at every latitude. So the guard tests the
+    LONGITUDE span only, the same quantity ``render_dateline_safe`` tests.
+
+    Three passes, and the order is load-bearing:
+
+    1. Buffer each component in a projection chosen for that component
+       (``ST_Dump`` -> per-part ``::geography``), then re-collect. The inner
+       dump of each part's buffer keeps every collected element a bare polygon:
+       ``ST_Collect`` of a ``POLYGON`` and a ``MULTIPOLYGON`` would yield a
+       ``GEOMETRYCOLLECTION``.
+    2. ``render_dateline_safe`` splits any component that wraps ±180. It has to
+       run BEFORE the dissolve: a wrapping component's buffer is
+       self-intersecting in the planar domain, and unioning it in that state
+       raises ``TopologyException: side location conflict at
+       179.90757318430857 44.915684255255684`` — the statement aborts outright.
+       That is the same ordering lesson as fix(#883), where validating before
+       shifting noded the seam into 4 slivers holding 97.9% of the area instead
+       of 2 parts holding 99.3%.
+    3. ``ST_UnaryUnion`` dissolves parts whose buffers overlap. Without it the
+       per-component pass regresses geometry that the whole-input buffer used to
+       merge: a ``MULTIPOINT`` with two points 0.05° apart plus a third 90° away
+       came back as 3 overlapping parts, ``ST_IsValid`` false, area 935 908 947
+       m² against a true union of 701 993 608 m² — the overlap counted twice.
+       ``ST_MakeValid`` is NOT a substitute; measured on the same input it kept
+       3 parts and cut the overlap out of one of them instead of merging,
+       landing on 468 078 270 m². The union is a no-op where nothing overlaps
+       (the fix(#883) seam fixture measures 623 944 052 m² and 3 parts either
+       way), which is why it can sit unconditionally on this branch.
+
+    Two cheap conditions on the SOURCE gate all of that, so an ordinary
+    single-part buffer takes a bare ``ELSE`` rendering exactly the fix(#883)
+    expression, with no dump, no re-collect and no union:
+
+    - ``ST_NumGeometries(...) > 1``. A single component has nothing to dump into,
+      so per-component buffering cannot differ from buffering the whole input.
+      This is what keeps single-part output byte-identical.
+    - the longitude span reaches ``BUFFER_LOCAL_SRID_SPAN_DEG``. Below that the
+      whole input fits one UTM zone and every component is already buffered in a
+      projection local to it (measured ±0.04%), while a dense multipart source —
+      up to 500 000 rows of it, per ``MAX_SOURCE_FEATURES`` — would otherwise pay
+      a dump plus a union per row for nothing.
+
+    Both conditions are necessary, not merely cheap: dropping the span test
+    also drops the guarantee that overlapping components stay rare on this
+    branch, and dropping the multipart test would put every large single-part
+    buffer through a dump that cannot change its result.
+
+    The guard reads the VALIDATED geometry, not the raw column, and that is what
+    the ``OFFSET 0`` fence buys. ``ST_MakeValid`` can raise the part count: a
+    self-intersecting ``POLYGON`` whose lobes sit 90° apart is one component as
+    stored and two after validation. Gating on the column would have read 1 and
+    sent it down the whole-input path — the exact case this function exists for.
+
+    NOT fixed here, and deliberately: a SINGLE component wider than one UTM zone
+    is still buffered in one non-local projection, because there is nothing to
+    dump it into. Measured, a 10 km buffer of ``LINESTRING(0 45, 90 45)`` — one
+    component, 90° wide — produces 85 485 981 084 m² against 134 146 143 319 m²
+    for the same line segmentized to 20 km and buffered piecewise, so 63.7% of
+    the correct area, before and after this change alike. Closing that needs the
+    buffer to subdivide within a component, which changes the vertex structure of
+    every large single-part output, so it wants its own decision.
+
+    ``geom_expr`` is evaluated inside an ``OFFSET 0``-fenced subquery, the same
+    pull-up fence the rest of this module uses (fix(#700 review)), because the
+    ``CASE`` references the source geometry five times.
+
+    Cost, from ``EXPLAIN ANALYZE`` over 2 000 rows against the pre-fix
+    expression. The guard itself is free: PostgreSQL short-circuits the ``AND``,
+    so single-part rows never reach the bbox scan (2 000 66-vertex polygons —
+    ``ST_NumGeometries`` alone 3.75 ms, the span test alone 7.34 ms, both
+    together 3.60 ms). What the common path does pay is this function's own
+    ``OFFSET 0`` fence: 335 ms -> 376 ms on those polygons (+20 µs/row), and
+    53 ms -> 38 ms on 2 000 bare points, where materializing ``ST_MakeValid``
+    once is cheaper than re-deriving it. The gated path costs 87 ms -> 116 ms
+    for 2 000 two-component rows and 586 ms -> 1 316 ms for 200 hundred-part
+    rows, the extra time being the per-part buffers plus the dissolve. On a
+    2 000-row mix (285 wide multipart) the per-component ``SubPlan`` ran at
+    ``loops=285`` and the whole-input ``SubPlan`` at ``loops=1715`` — both
+    ``ST_Buffer`` call sites are rendered, only one is reached per row.
+    """
+    per_component = (
+        f"(SELECT ST_CollectionHomogenize(ST_Collect({alias}_p.p))"
+        f" FROM (SELECT (ST_Dump("
+        f"ST_Buffer({alias}_c.c::geography, {distance})::geometry)).geom AS p"
+        f" FROM (SELECT (ST_Dump({alias}.g)).geom AS c) AS {alias}_c) AS {alias}_p)"
+    )
+    local = render_dateline_safe(per_component, alias=f"{alias}_m")
+    whole = render_dateline_safe(
+        f"ST_Buffer({alias}.g::geography, {distance})::geometry"
+    )
+    return (
+        "(SELECT CASE"
+        f" WHEN ST_NumGeometries({alias}.g) > 1"
+        f" AND ST_XMax({alias}.g) - ST_XMin({alias}.g)"
+        f" >= {BUFFER_LOCAL_SRID_SPAN_DEG}"
+        f" THEN ST_UnaryUnion({local})"
+        f" ELSE {whole} END"
         f" FROM (SELECT {geom_expr} AS g OFFSET 0) AS {alias})"
     )
 
@@ -354,18 +491,13 @@ def render_geometry_expr(
                 f"buffer distance must be between 0 and {MAX_BUFFER_METERS:g} meters"
             )
         # Buffer is the only operation here that round-trips through
-        # ::geography, and therefore the only one that can emit an
-        # antimeridian-wrapping geometry the source never had — hence the only
-        # one wrapped in render_dateline_safe (fix(#697)). Intersection (clip)
-        # and union (dissolve) can only shrink or merge longitudes that were
-        # already in range, and a planar centroid stays inside its input's
-        # envelope.
-        return (
-            render_dateline_safe(
-                f"ST_Buffer(ST_MakeValid(geom_4326)::geography, {distance})::geometry"
-            ),
-            "",
-        )
+        # ::geography, and therefore the only one that has to pick a planar
+        # working SRID (fix(#891)) and the only one that can emit an
+        # antimeridian-wrapping geometry the source never had (fix(#697)).
+        # Both live in render_geodesic_buffer. Intersection (clip) and union
+        # (dissolve) can only shrink or merge longitudes that were already in
+        # range, and a planar centroid stays inside its input's envelope.
+        return render_geodesic_buffer("ST_MakeValid(geom_4326)", distance), ""
     if operation == "centroid":
         return "ST_Centroid(ST_MakeValid(geom_4326))", ""
     if operation == "clip":

--- a/backend/tests/test_analysis_materialize.py
+++ b/backend/tests/test_analysis_materialize.py
@@ -2642,6 +2642,266 @@ class TestBufferAtDateline:
         assert row.area == pytest.approx(2 * math.pi * 10_000**2, rel=0.02)
 
 
+class TestBufferMultipartProjection:
+    """fix(#891): ``ST_Buffer(...::geography, d)`` picks ONE planar working SRID
+    for the whole input, so a multipart feature whose components sit far apart in
+    longitude is buffered in a projection local to at most one of them.
+    """
+
+    async def _radius_range(
+        self, session: AsyncSession, table_name: str, source_wkt: str
+    ) -> list[tuple[int, float, float]]:
+        """Geodesic distance from each source component to the vertices of the
+        output part covering it — the metric the bug actually distorts.
+
+        Area alone hides part of it: an equal-area fallback projection keeps the
+        total while deforming each component (measured 9 240 - 10 824 m for a
+        requested 10 000 m at a 150° span).
+        """
+        rows = (
+            await session.execute(
+                text(
+                    "WITH src AS (SELECT (ST_Dump("
+                    "  ST_SetSRID(ST_GeomFromText(:wkt), 4326))).path[1] AS ix,"
+                    " (ST_Dump(ST_SetSRID(ST_GeomFromText(:wkt), 4326))).geom AS p),"
+                    " out AS (SELECT (ST_Dump(geom_4326)).geom AS part"
+                    f"         FROM data.{table_name}),"  # noqa: S608
+                    " paired AS (SELECT src.ix, src.p, out.part FROM src, out"
+                    "            WHERE ST_Intersects(out.part, src.p))"
+                    " SELECT paired.ix AS ix,"
+                    "        min(ST_Distance(paired.p::geography,"
+                    "                        v.geom::geography)) AS min_r,"
+                    "        max(ST_Distance(paired.p::geography,"
+                    "                        v.geom::geography)) AS max_r"
+                    " FROM paired, LATERAL ST_DumpPoints(paired.part) AS v"
+                    " GROUP BY paired.ix ORDER BY paired.ix"
+                ).bindparams(wkt=source_wkt)
+            )
+        ).all()
+        return [(r.ix, r.min_r, r.max_r) for r in rows]
+
+    async def test_components_90_degrees_apart_keep_their_radius(
+        self,
+        test_db_session: AsyncSession,
+    ):
+        """The headline case. A two-point MULTIPOINT 90° apart at lat 45 spans
+        past the 45° mark where PostGIS falls back to world Mercator, whose
+        scale error is 1/cos(latitude). Measured before this fix: both
+        components came back with a 7 079 - 7 087 m radius for a requested
+        10 000 m, and the feature held 49.9% of the ideal circle area.
+        """
+        wkt = "MULTIPOINT((0 45),(90 45))"
+        out = await _materialize_buffer(
+            test_db_session,
+            wkt=wkt,
+            column_type="MultiPoint",
+            geometry_type="MULTIPOINT",
+            distance=10_000,
+        )
+
+        row = (
+            await test_db_session.execute(
+                text(
+                    "SELECT GeometryType(geom_4326) AS gtype,"
+                    " ST_NumGeometries(geom_4326) AS parts,"
+                    " ST_IsValid(geom_4326) AS valid,"
+                    " ST_Area(geom_4326::geography) AS area"
+                    f" FROM data.{out.table_name}"  # noqa: S608
+                )
+            )
+        ).one()
+        assert row.gtype == "MULTIPOLYGON"
+        assert row.parts == 2
+        assert row.valid is True
+        # vs the ideal circle area, not vs the unfixed output: #891 is precisely
+        # the pre-existing error that made fixed-vs-raw the only honest
+        # comparison in fix(#883).
+        assert row.area == pytest.approx(2 * math.pi * 10_000**2, rel=0.01)
+
+        radii = await self._radius_range(test_db_session, out.table_name, wkt)
+        assert len(radii) == 2
+        for _ix, min_r, max_r in radii:
+            assert min_r == pytest.approx(10_000, rel=0.005)
+            assert max_r == pytest.approx(10_000, rel=0.005)
+
+    async def test_component_at_high_latitude_is_not_shrunk(
+        self,
+        test_db_session: AsyncSession,
+    ):
+        """The worst measured case, and the one area ratios understate.
+
+        World Mercator's error is cos(latitude), so the further a component sits
+        from the equator the more it loses. Measured before the fix on
+        ``MULTIPOINT((0 0),(90 60))``: the equatorial component came back at
+        exactly 10 000 m while the lat-60 component measured 5 009 - 5 016 m —
+        a quarter of its intended area — and the pair together held 62.2% of
+        two ideal circles, which reads as a mild deficit rather than one
+        component being half size.
+        """
+        wkt = "MULTIPOINT((0 0),(90 60))"
+        out = await _materialize_buffer(
+            test_db_session,
+            wkt=wkt,
+            column_type="MultiPoint",
+            geometry_type="MULTIPOINT",
+            distance=10_000,
+        )
+
+        radii = await self._radius_range(test_db_session, out.table_name, wkt)
+        assert len(radii) == 2
+        for _ix, min_r, max_r in radii:
+            assert min_r == pytest.approx(10_000, rel=0.005)
+            assert max_r == pytest.approx(10_000, rel=0.005)
+
+    async def test_single_part_output_is_byte_identical_to_the_plain_buffer(
+        self,
+        test_db_session: AsyncSession,
+    ):
+        """A single component has nothing to dump into, so the per-component
+        pass must not run at all: the saved geometry has to match the bare
+        whole-input buffer byte for byte, not merely be spatially equal.
+
+        This is what keeps the fix(#883) exact assertions — and the polar
+        POLYGON fixture above — meaningful rather than accidentally satisfied.
+        """
+        for lon, lat in ((0.0, 45.0), (0.0, 85.06), (0.0, 89.9)):
+            out = await _materialize_buffer(
+                test_db_session, lon=lon, lat=lat, distance=10_000
+            )
+            same = (
+                await test_db_session.execute(
+                    text(
+                        "SELECT ST_AsEWKB(geom_4326) = ST_AsEWKB(ST_Buffer("
+                        "  ST_SetSRID(ST_MakePoint(:lon, :lat), 4326)::geography,"
+                        "  10000)::geometry) AS identical,"
+                        " GeometryType(geom_4326) AS gtype"
+                        f" FROM data.{out.table_name}"  # noqa: S608
+                    ).bindparams(lon=lon, lat=lat)
+                )
+            ).one()
+            assert same.identical is True, (lon, lat)
+            assert same.gtype == "POLYGON", (lon, lat)
+
+    async def test_narrow_multipart_stays_on_the_whole_input_path(
+        self,
+        test_db_session: AsyncSession,
+    ):
+        """Below ``BUFFER_LOCAL_SRID_SPAN_DEG`` the whole input already fits one
+        UTM zone, so the guard has to decline and leave the cheap path alone —
+        measured ±0.04% radius error there, against a dump plus a dissolve per
+        row for up to ``MAX_SOURCE_FEATURES['buffer']`` rows.
+        """
+        wkt = "MULTIPOINT((0 45),(2 45))"
+        out = await _materialize_buffer(
+            test_db_session,
+            wkt=wkt,
+            column_type="MultiPoint",
+            geometry_type="MULTIPOINT",
+            distance=10_000,
+        )
+        same = (
+            await test_db_session.execute(
+                text(
+                    "SELECT ST_AsEWKB(geom_4326) = ST_AsEWKB(ST_Buffer("
+                    "  ST_GeomFromText(:wkt, 4326)::geography, 10000)::geometry)"
+                    "   AS identical"
+                    f" FROM data.{out.table_name}"  # noqa: S608
+                ).bindparams(wkt=wkt)
+            )
+        ).one()
+        assert same.identical is True
+
+    async def test_overlapping_components_are_dissolved_not_stacked(
+        self,
+        test_db_session: AsyncSession,
+    ):
+        """The regression the per-component pass would introduce without the
+        ``ST_UnaryUnion``.
+
+        Buffering the whole input merges components whose buffers overlap;
+        buffering per component and collecting does not. Measured on this
+        fixture with the dissolve removed: 3 parts, ``ST_IsValid`` false, and
+        935 908 947 m² of area against a true 701 993 608 m² because the
+        overlap counted twice. ``ST_MakeValid`` is not a substitute — it cut the
+        overlap out of one part instead of merging, landing on 468 078 270 m².
+        """
+        out = await _materialize_buffer(
+            test_db_session,
+            wkt="MULTIPOINT((0 45),(0.05 45),(90 45))",
+            column_type="MultiPoint",
+            geometry_type="MULTIPOINT",
+            distance=10_000,
+        )
+        row = (
+            await test_db_session.execute(
+                text(
+                    "SELECT GeometryType(geom_4326) AS gtype,"
+                    " ST_NumGeometries(geom_4326) AS parts,"
+                    " ST_IsValid(geom_4326) AS valid,"
+                    " ST_Area(geom_4326::geography) AS area"
+                    f" FROM data.{out.table_name}"  # noqa: S608
+                )
+            )
+        ).one()
+        assert row.gtype == "MULTIPOLYGON"
+        # The two 0.05°-apart buffers merged; the distant one stayed separate.
+        assert row.parts == 2
+        assert row.valid is True
+        assert row.area == pytest.approx(701_993_608, rel=0.01)
+
+    async def test_seam_component_of_a_wide_multipart_is_still_split(
+        self,
+        test_db_session: AsyncSession,
+    ):
+        """Both passes on one feature, in the order that works.
+
+        A MULTIPOINT holding a seam-crossing component and one 100° away trips
+        the projection guard AND the fix(#883) seam guard. The seam split has to
+        run before the dissolve: unioning a component that still wraps ±180
+        raises ``TopologyException: side location conflict`` and aborts the
+        statement instead of saving anything.
+        """
+        wkt = "MULTIPOINT((179.95 45),(80 45))"
+        out = await _materialize_buffer(
+            test_db_session,
+            wkt=wkt,
+            column_type="MultiPoint",
+            geometry_type="MULTIPOINT",
+            distance=10_000,
+        )
+        row = (
+            await test_db_session.execute(
+                text(
+                    "SELECT GeometryType(geom_4326) AS gtype,"
+                    " ST_NumGeometries(geom_4326) AS parts,"
+                    " ST_IsValid(geom_4326) AS valid,"
+                    " ST_XMin(geom_4326) AS xmin,"
+                    " ST_XMax(geom_4326) AS xmax,"
+                    " ST_Area(geom_4326::geography) AS area,"
+                    " ST_Intersects("
+                    "   geom_4326, ST_MakeEnvelope(2, 44.9, 3, 45.1, 4326)"
+                    " ) AS hits_france"
+                    f" FROM data.{out.table_name}"  # noqa: S608
+                )
+            )
+        ).one()
+        # Seam component cut in two, distant component intact: 3 parts.
+        assert row.gtype == "MULTIPOLYGON"
+        assert row.parts == 3
+        assert row.valid is True
+        assert row.xmin >= -180.0
+        assert row.xmax <= 180.0
+        assert row.hits_france is False
+        assert row.area == pytest.approx(2 * math.pi * 10_000**2, rel=0.01)
+
+        radii = await self._radius_range(test_db_session, out.table_name, wkt)
+        # The seam component's own part is one half of the split, so only the
+        # distant component has a whole circle to measure. Both must be local.
+        assert radii
+        for _ix, _min_r, max_r in radii:
+            assert max_r == pytest.approx(10_000, rel=0.005)
+
+
 # ---------------------------------------------------------------------------
 # Error-message sanitization (pure, no DB)
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_analysis_preview.py
+++ b/backend/tests/test_analysis_preview.py
@@ -927,7 +927,11 @@ class TestBuildPreviewSql:
     def test_buffer_sql(self):
         req = AnalysisPreviewRequest(operation="buffer", distance_meters=500)
         sql = build_preview_sql('"data"."t1"', req)
-        assert "ST_Buffer(ST_MakeValid(geom_4326)::geography, 500.0)::geometry" in sql
+        # fix(#891): the validated source is hoisted behind an OFFSET 0 fence so
+        # the projection guard can read it, so the buffer takes `_pb.g` rather
+        # than the column expression.
+        assert "SELECT ST_MakeValid(geom_4326) AS g OFFSET 0) AS _pb" in sql
+        assert "ST_Buffer(_pb.g::geography, 500.0)::geometry" in sql
         assert 'FROM "data"."t1"' in sql
         assert "ORDER BY gid" in sql
 
@@ -962,10 +966,15 @@ class TestBuildPreviewSql:
         assert "ST_MakeValid(ST_ShiftLongitude" not in buffer_expr
         # The buffer and each component's shifted copy stay behind an OFFSET 0
         # fence, so neither is re-evaluated per CASE reference (fix(#700
-        # review)). EXPLAIN VERBOSE holds ST_Buffer at one call per row.
-        assert buffer_expr.count("ST_Buffer(") == 1
-        assert buffer_expr.count("ST_ShiftLongitude(") == 1
-        assert buffer_expr.count("OFFSET 0") == 2
+        # review)). fix(#891) adds a second projection strategy, so both the
+        # buffer and the seam pass now have two rendered call sites — one per
+        # branch of the projection CASE, never both on the same row. EXPLAIN
+        # ANALYZE over a 2 000-row mix (285 wide multipart rows, 1 715
+        # single-part) put the per-component SubPlan at loops=285 and the
+        # whole-input SubPlan at loops=1715.
+        assert buffer_expr.count("ST_Buffer(") == 2
+        assert buffer_expr.count("ST_ShiftLongitude(") == 2
+        assert buffer_expr.count("OFFSET 0") == 5
 
         for op, kwargs in (
             ("centroid", {}),
@@ -973,6 +982,50 @@ class TestBuildPreviewSql:
         ):
             other_expr, _ = render_geometry_expr(op, **kwargs)
             assert "ST_ShiftLongitude" not in other_expr
+
+    def test_buffer_sql_projects_each_component_locally(self):
+        """fix(#891): ``ST_Buffer(...::geography, d)`` picks ONE planar SRID for
+        the whole input, so a multipart feature spread across longitudes is
+        buffered in a projection that suits at most one of its components.
+        """
+        from app.platform.analysis_sql import (
+            BUFFER_LOCAL_SRID_SPAN_DEG,
+            render_geometry_expr,
+        )
+
+        buffer_expr, _ = render_geometry_expr("buffer", distance_meters=500)
+        # Both guard conditions on the SOURCE, not on the buffer output, and on
+        # the VALIDATED source specifically: ST_MakeValid can raise the part
+        # count (a self-intersecting POLYGON with lobes 90° apart is one
+        # component as stored, two after validation), so reading geom_4326
+        # directly would send exactly this case down the whole-input path. That
+        # is what the extra OFFSET 0 fence pays for.
+        assert "(SELECT ST_MakeValid(geom_4326) AS g OFFSET 0) AS _pb" in buffer_expr
+        assert "ST_NumGeometries(_pb.g) > 1" in buffer_expr
+        assert (
+            f"ST_XMax(_pb.g) - ST_XMin(_pb.g) >= {BUFFER_LOCAL_SRID_SPAN_DEG}"
+            in buffer_expr
+        )
+        assert "ST_NumGeometries(geom_4326)" not in buffer_expr
+        # Each component is buffered on its own, and each component's buffer is
+        # dumped so ST_Collect never mixes POLYGON with MULTIPOLYGON into a
+        # GEOMETRYCOLLECTION.
+        assert "ST_Dump(ST_Buffer(_pb_c.c::geography, 500.0)::geometry)" in buffer_expr
+        assert "(ST_Dump(_pb.g)).geom AS c" in buffer_expr
+        assert "ST_CollectionHomogenize(ST_Collect(_pb_p.p))" in buffer_expr
+        # Pass order: seam split (_pb_m) INSIDE the union, never the reverse —
+        # unioning a still-wrapping component raises a GEOS side-location
+        # conflict and aborts the statement.
+        union_at = buffer_expr.index("ST_UnaryUnion(")
+        split_at = buffer_expr.index("ST_WrapX(ST_MakeValid(_pb_m_c.s)")
+        assert union_at < split_at
+        # The common path is a bare ELSE: the whole-input buffer, wrapped in the
+        # fix(#883) seam pass and nothing else — no dump, no re-collect, no
+        # dissolve.
+        else_at = buffer_expr.index("ELSE (SELECT CASE WHEN ST_XMax(_dl.g)")
+        assert buffer_expr.count("ST_UnaryUnion(") == 1
+        assert union_at < else_at
+        assert "ST_Buffer(_pb.g::geography, 500.0)::geometry" in buffer_expr[else_at:]
 
     def test_centroid_sql(self):
         req = AnalysisPreviewRequest(operation="centroid")
@@ -1008,16 +1061,27 @@ class TestBuildPreviewSql:
         don't triple-evaluate it — while the base table stays a plain FROM
         item whose pkey index can satisfy ORDER BY and early-terminate at
         the sandbox row cap."""
+        # fix(#891): buffer renders TWO ST_Buffer call sites — one per branch of
+        # the projection CASE — and exactly one of them is reachable on any given
+        # row, which EXPLAIN ANALYZE confirms (a 2 000-row mix put the
+        # per-component SubPlan at loops=285 and the whole-input SubPlan at
+        # loops=1715, summing to 2 000, not 4 000).
         cases = {
-            "ST_Intersection": AnalysisPreviewRequest(operation="clip", mask=CLIP_MASK),
-            "ST_Buffer": AnalysisPreviewRequest(operation="buffer", distance_meters=10),
-            "ST_Centroid": AnalysisPreviewRequest(operation="centroid"),
+            "ST_Intersection": (
+                AnalysisPreviewRequest(operation="clip", mask=CLIP_MASK),
+                1,
+            ),
+            "ST_Buffer": (
+                AnalysisPreviewRequest(operation="buffer", distance_meters=10),
+                2,
+            ),
+            "ST_Centroid": (AnalysisPreviewRequest(operation="centroid"), 1),
         }
-        for fn, req in cases.items():
+        for fn, (req, call_sites) in cases.items():
             sql = build_preview_sql('"data"."t1"', req)
             assert "CROSS JOIN LATERAL (SELECT" in sql
             assert "OFFSET 0" in sql
-            assert sql.count(fn) == 1
+            assert sql.count(fn) == call_sites
             assert sql.endswith("ORDER BY gid")
 
     def test_clip_by_layer_sql_subdivides_instead_of_unioning(self):


### PR DESCRIPTION
## What changed

`ST_Buffer(geom::geography, d)::geometry` asks `_ST_BestSRID` for **one** planar working SRID and uses it for the whole input. The plan output makes the shape explicit — PostGIS rewrites the cast chain to

```
st_transform(st_buffer(st_transform(geometry(g::geography), _st_bestsrid(g::geography)), d), 4326)
```

so every component of a multipart feature is buffered in a projection chosen for the *envelope*, not for itself.

`render_geodesic_buffer()` in `backend/app/platform/analysis_sql.py` now dumps the validated source, buffers each component through its own `::geography` cast, re-collects, runs the existing #883 seam split, and dissolves with `ST_UnaryUnion`. `render_geometry_expr("buffer", ...)` is the single chokepoint both the preview (`service_analysis.build_preview_sql`) and the materialize worker (`processing/analysis/tasks.py`) call, so both paths pick it up.

Diff shape: `analysis_sql.py` +144/-12 (one new function; 19 lines of it are SQL, the rest is the docstring), `test_analysis_materialize.py` +260/-0 (6 behavioural tests), `test_analysis_preview.py` +74/-10 (one new SQL-shape test, three updated).

No schema, API, config, i18n or SDK impact — this is a rendered SQL expression behind `render_geometry_expr`, which is already the sole entry point for both the preview and the materialize worker.

## Reproduced first

The issue's table, reproduced verbatim against the dev DB (PostgreSQL 18.4, PostGIS 3.6.4, GEOS 3.13.1) on `main@cb22f5bb1` before any code changed:

```sql
WITH params(sep) AS (VALUES (0.2::float8),(10.0),(90.0),(150.0)),
src AS (
    SELECT sep, ST_SetSRID(ST_Collect(ST_MakePoint(0,45), ST_MakePoint(sep,45)),4326) AS g
    FROM params
),
buf AS (SELECT sep, ST_Buffer(ST_MakeValid(g)::geography, 10000)::geometry AS b FROM src)
SELECT sep AS separation_deg, GeometryType(b) AS gtype, ST_NumGeometries(b) AS parts,
       round(ST_Area(b::geography)::numeric,0) AS area_m2,
       round((ST_Area(b::geography) / (2*pi()*10000^2))::numeric,4) AS ratio_vs_ideal
FROM buf ORDER BY sep;

 separation_deg |    gtype     | parts |  area_m2  | ratio_vs_ideal
----------------+--------------+-------+-----------+----------------
            0.2 | POLYGON      |     1 | 589383310 |         0.9380
             10 | MULTIPOLYGON |     2 | 624289038 |         0.9936
             90 | MULTIPOLYGON |     2 | 313192925 |         0.4985
            150 | MULTIPOLYGON |     2 | 624289038 |         0.9936
```

Exact match to the reported 0.938 / 0.994 / **0.498** / 0.994. The mechanism came straight out:

```sql
SELECT sep, _ST_BestSRID(g::geography) AS whole_srid,
       _ST_BestSRID(ST_GeometryN(g,1)::geography) AS part1_srid,
       _ST_BestSRID(ST_GeometryN(g,2)::geography) AS part2_srid
FROM src ORDER BY sep;

 sep | whole_srid | part1_srid | part2_srid
-----+------------+------------+------------
 0.2 |     999031 |     999031 |     999031
  10 |     999247 |     999031 |     999032
  90 |     999000 |     999031 |     999046   <- 999000 = world Mercator
 150 |     999061 |     999031 |     999055
```

Two things fall out that the issue's table alone does not show. The 0.2° row is **not** a bug — at that separation the two circles overlap and the union is genuinely smaller than 2 π r², which is why it also stays 0.9380 after the fix. And the non-monotonic shape is not centroid-driven: it is a hard threshold, `_ST_BestSRID` dropping to world Mercator once the longitude span reaches 45°, then climbing back into a wide Lambert past ~135°.

`after` numbers below come from substituting the rendered expression — `render_geometry_expr("buffer", distance_meters=10000.0)[0]` with `geom_4326` bound to each fixture — into the same queries.

## Why this is not the antimeridian

Different failure, same expression. The seam bug (#697/#883) is about longitude normalization in the *output*. This one is about the projection chosen for the *input*, and it fires nowhere near ±180. Measured longitude-span sweep of a two-point `MULTIPOINT` at lat 45, 10 km buffer, reading the geodesic distance from each source point to every vertex of the output part containing it:

| longitude span | `_ST_BestSRID` | produced radius (m) |
| --- | --- | --- |
| under 6° | 999031 | 9 997 – 10 004 (single UTM zone) |
| 6° – 44.99° | 999247 | 9 904 – 10 097 |
| **45° and up** | **999000 (world Mercator)** | **7 079 – 7 087** |
| ~135° and up | 999061 | 9 240 – 10 824 (wide Lambert) |

The cliff is exactly at a 45.0° span (44.99° → 999247, 45.0° → 999000), and world Mercator's scale error is `1/cos(latitude)`, which is the whole story: `cos(45°)² = 0.5`.

The gate threshold sits at the *other* measured boundary — 6.0°, where PostGIS leaves the single-UTM-zone regime (5.999° → 999031, 6.0° → 999247), hence `>=` rather than `>`. Picking 6 rather than 45 is deliberate: it removes the ±1% band as well as the catastrophic tail, and it keeps a safety margin so a future PostGIS retune of `_ST_BestSRID` cannot silently reopen the half-area case.

Latitude span is harmless. Held at 0° longitude span and swept to an 80° latitude span, the SRID stayed on the UTM zone and the radius stayed within 9 990 – 10 004 m — transverse Mercator holds scale ≈ 1 along its central meridian at every latitude. So the guard tests longitude span only, the same quantity `render_dateline_safe` already tests.

## Pass ordering

Three passes, and the order is not free:

1. **Per-component buffer.** `ST_Dump` the validated source, buffer each part through its own `::geography`, dump each part's buffer (so `ST_Collect` never mixes `POLYGON` with `MULTIPOLYGON` into a `GEOMETRYCOLLECTION`), `ST_CollectionHomogenize(ST_Collect(...))`.
2. **Seam split** — the existing `render_dateline_safe`, unchanged.
3. **`ST_UnaryUnion`** to dissolve overlapping parts.

**2 before 3.** A component whose buffer wraps ±180 is self-intersecting *in the planar domain*, and unioning it in that state does not degrade gracefully — it aborts the statement:

```
ERROR:  lwgeom_unaryunion_prec: GEOS Error: TopologyException: side location
conflict at 179.90757318430857 44.915684255255684. This can occur if the input
geometry is invalid.
```

That is the same lesson #883 learned with `ST_ShiftLongitude` before `ST_MakeValid` (validate-first noded the seam into 4 slivers holding 97.9% of the area, against 2 parts holding 99.3%): the seam artefact has to be resolved before any GEOS overlay op touches the geometry.

**3 has to exist.** Buffering the whole input dissolved components whose buffers overlap; buffering per component and collecting does not. Measured on `MULTIPOINT((0 45),(0.05 45),(90 45))`, 10 km:

| dissolve | parts | `ST_IsValid` | area (m²) |
| --- | --- | --- | --- |
| none (`ST_Collect` only) | 3 | **false** | 935 908 947 (overlap counted twice) |
| `ST_MakeValid` | 3 | true | **468 078 270** (cut the overlap out of one part) |
| `ST_UnaryUnion` | 2 | true | **701 993 608** ✔ |

701 993 608 is the true answer: 390 028 685 (two overlapping circles unioned) + 311 964 923 (the distant circle). `ST_MakeValid` subtracts where a dissolve should merge, so it is not an alternative. The union is a no-op where nothing overlaps — the #883 seam fixture measures 623 944 052 m² and 3 parts with or without it — which is why it can sit unconditionally on this branch.

## Cost profile

Gated on two cheap conditions on the validated source: `ST_NumGeometries(...) > 1 AND ST_XMax(...) - ST_XMin(...) >= 6`. Single-part input takes a bare `ELSE` that renders exactly the #883 expression.

The guard is free — PostgreSQL short-circuits the `AND`, so single-part rows never reach the bbox scan. Over the same 2 000 66-vertex polygons: `ST_NumGeometries` alone 3.75 ms, the span test alone 7.34 ms, both together **3.60 ms**.

`EXPLAIN (ANALYZE, TIMING OFF)`, median of 3 warm runs, pre-fix expression vs this one, plus a third variant that is the pre-fix expression with only this function's extra `OFFSET 0` fence added, to attribute the delta:

| workload | before | fence only | after |
| --- | --- | --- | --- |
| 2 000 single-part POINT | 53.2 ms | 38.5 ms | **38.4 ms** |
| 2 000 single-part POLYGON (66 vertices) | 334.9 ms | 375.7 ms | **375.6 ms** |
| 2 000 two-part MULTIPOINT, 2° apart (under the gate) | 86.8 ms | — | **75.0 ms** |
| 2 000 two-part MULTIPOINT, 90° apart (gated) | 87.3 ms | — | **116.4 ms** |
| 200 × 100-part MULTIPOINT spanning 99° (gated) | 586.3 ms | — | **1 315.5 ms** |

So the common path's entire cost is the fence, +20 µs/row on 66-vertex polygons; on bare points it is *cheaper*, because materializing `ST_MakeValid` once beats re-deriving it. The gated path pays for the per-part buffers and the dissolve, bounded and only where the answer was wrong.

The last row is the honest worst case: 6.58 ms/row against 2.93 ms/row before, so a hypothetical source of 500 000 hundred-part features spanning 99° would blow the 300 s CTAS budget — as it already did before this change (1 465 s → 3 289 s). It is a 2.2x on a shape that was already past the ceiling, not a newly reachable failure, and `MAX_SOURCE_FEATURES["buffer"]` bounds feature count rather than part count either way.

Structural evidence — one `EXPLAIN ANALYZE` over a 2 000-row mix, 285 of them wide multipart:

```
Seq Scan on _c891_mixed (actual rows=2000.00 loops=1)
  SubPlan 6
    ->  Subquery Scan on _pb (loops=2000)
          SubPlan 3                                    <- per-component buffer
            ->  Subquery Scan on _pb_m (loops=285)
                          ->  Aggregate (loops=285)
                  SubPlan 1  -> (never executed)       <- seam split, no wrap present
          SubPlan 5                                    <- whole-input buffer
            ->  Subquery Scan on _dl (loops=1715)
                  SubPlan 4  -> (never executed)
```

285 + 1715 = 2000. Both `ST_Buffer` call sites are rendered; exactly one is reached per row. On the pure single-part table `SubPlan 3` reads `never executed` outright.

## Before / after

Same fixtures, same 10 km distance, `before` = the expression on `main@cb22f5bb1`. Ratio is against the ideal circle area (`π r²` per component), measured with:

```sql
SELECT label,
   round((ST_Area((<BEFORE>)::geography)
          / (pi()*10000^2*ST_NumGeometries(geom_4326)))::numeric,4) AS before_ratio,
   round((ST_Area((<AFTER>)::geography)
          / (pi()*10000^2*ST_NumGeometries(geom_4326)))::numeric,4) AS after_ratio,
   ST_AsEWKB(<BEFORE>) = ST_AsEWKB(<AFTER>) AS byte_identical
FROM _fixtures ORDER BY label;
```


| fixture | before | after | note |
| --- | --- | --- | --- |
| `MULTIPOINT((0 45),(0.2 45))` | 0.9380 | 0.9380 | byte-identical; the deficit is real overlap, not a bug |
| `MULTIPOINT((0 45),(10 45))` | 0.9936 | 0.9936 | area equal, radius tightened 9 904–10 097 → 9 997/10 003 |
| **`MULTIPOINT((0 45),(90 45))`** | **0.4985** | **0.9930** | the headline case |
| `MULTIPOINT((0 45),(150 45))` | 0.9936 | 0.9930 | equal-area SRID hid it; radius 9 240–10 824 → 9 997 |
| **`MULTIPOINT((0 0),(90 60))`** | **0.6216** | **0.9927** | lat-60 component 5 009 m → 10 000 m radius |
| `POINT(0 45)` | 0.9930 | 0.9930 | **byte-identical** |
| `POINT(0 89.9)` (polar) | 0.9936 | 0.9936 | **byte-identical**, still `POLYGON` |
| `MULTIPOINT((179.95 45),(0 45))` (#883) | 0.9936 | 0.9930 | 3 parts, valid, both centres covered |

The remaining 0.7% is `ST_Buffer`'s own polygonal approximation of a geodesic circle, the same figure #883 measured.

The `MULTIPOINT((0 0),(90 60))` row is why area ratios understate this: 0.6216 reads as a mild deficit, but the equatorial component was exact (Mercator scale 1 at the equator) while the lat-60 component held a **quarter** of its area. The per-component radius is the honest metric, and the new tests assert on it. Same fixtures, geodesic distance from each source component to every vertex of the output part covering it, requested radius 10 000 m:

```
                        |     BEFORE      |      AFTER
 fixture         part   |  min      max   |  min      max
------------------------+-----------------+-----------------
 sep 10 deg        1    |  9904    10097  |  9997     9997
 sep 10 deg        2    |  9971    10030  | 10003    10003
 sep 90 deg        1    |  7079     7087  |  9997     9997
 sep 90 deg        2    |  7079     7087  |  9997     9997
 sep 150 deg       1    |  9253    10814  |  9997     9997
 sep 150 deg       2    |  9240    10824  |  9997     9997
 lat 0 + lat 60    1    | 10000    10000  |  9990     9991
 lat 0 + lat 60    2    |  5009     5016  | 10000    10001
 883 seam fixture  1    |  9253    10813  |  9960     9998
 883 seam fixture  2    |  9253    10814  |  9997     9997
 single point           |  9997     9997  |  9997     9997
 polar 89.9             | 10000    10000  | 10000    10000
```

The `883 seam fixture` rows are worth calling out: at a 179.95° span the whole-input SRID was the wide Lambert, which is equal-area, so #883's area assertion at `rel=0.02` passed while both components were deformed ±8%. Per-component buffering fixes the shape too. (Component 1's 9 960 m minimum is the seam-split part, whose ring includes the ±180 cut edge.)

**Why #883's tables compared fixed-vs-raw rather than fixed-vs-ideal:** this bug was folded into every multipart number, so an ideal-circle baseline would have charged the antimeridian fix with a projection error it did not cause. With #891 fixed, fixed-vs-ideal is now the meaningful comparison, and the new tests use it (`rel=0.01` against `2 π r²`) instead of comparing against unfixed output.

## Verification

```
cd backend && uv run ruff check .          # All checks passed!
cd backend && uv run ruff format --check . # 846 files already formatted
```

```
pytest tests/test_analysis_preview.py tests/test_analysis_materialize.py
  109 passed, 43 warnings in 62.61s

pytest -k "MultipartProjection or Dateline" tests/test_analysis_materialize.py
  11 passed, 58 deselected in 13.50s     # 5 pre-existing #883 + 6 new

pytest -n 4                              # FULL backend suite
  5960 passed, 81 skipped, 264 warnings in 708.40s (0:11:48)
```

Every #883 fixture re-measured against the new expression and unchanged:

| #883 fixture | type | parts | valid | span | hits France |
| --- | --- | --- | --- | --- | --- |
| `POINT(179.95 45)` @10 km | MULTIPOLYGON | 2 | t | −180..180 | f |
| `POINT(0 45)` @10 km | POLYGON | 1 | t | 0.2534 | f |
| `POINT(0 85.06)` @100 km | POLYGON | 1 | t | 20.8158 | f |
| `POINT(0 89.9)` @100 km (polar) | POLYGON | 1 | t | 347.3388 | f |
| `MULTIPOINT((179.95 45),(0 45))` @10 km | MULTIPOLYGON | 3 | t | −180..180 | f |

Edge cases probed for GEOS exceptions and type drift — all valid, none raising: pole-encircling component plus a distant one, components at both −179 and +179, a `GEOMETRYCOLLECTION` with an `EMPTY` member, mixed-dimension collection, `GEOMETRYCOLLECTION EMPTY`, `MULTIPOINT EMPTY`, duplicate coincident points, and spans of exactly 5.999° / 6.0°.

## Not fixed here

A **single** component wider than one UTM zone is still buffered in one non-local projection — there is nothing to dump it into. A 10 km buffer of `LINESTRING(0 45, 90 45)` produces 85 485 981 084 m² against 134 146 143 319 m² for the same line segmentized to 20 km and buffered piecewise, so 63.7% of the correct area, identical before and after this change. Closing that means subdividing *within* a component, which changes the vertex structure of every large single-part output — its own decision, worth a follow-up issue.

`processing/ai/sql_generator.py` still teaches the unnormalized `ST_Buffer(geom_4326::geography, 1000)::geometry` pattern in the NL→SQL prompt; that is #886 and deliberately untouched here.

Closes #891
