### PR TITLE
fix(catalog): store antimeridian-crossing extents as two rings

### DIFF
--- a/backend/alembic/versions/0030_records_spatial_extent_type.py
+++ b/backend/alembic/versions/0030_records_spatial_extent_type.py
@@ -1,0 +1,91 @@
+"""Widen catalog.records.spatial_extent to generic geometry + a type CHECK.
+
+fix(#892): ``records.spatial_extent`` was ``geometry(Polygon, 4326)``. RFC 7946
+§5.2 and STAC express an antimeridian-crossing extent as a bbox with
+west > east, and a single planar 4326 ring cannot encode that -- so a dataset
+that genuinely straddles the seam could only register a globe-spanning
+-180..180 extent. The honest representation is two rings (``west..180`` and
+``-180..east``), which needs a column that accepts MULTIPOLYGON.
+
+The typmod becomes plain ``geometry(Geometry, 4326)`` rather than
+``geometry(MultiPolygon, 4326)`` on purpose: every existing non-crossing extent
+stays a POLYGON, byte-identical, with no blanket ``ST_Multi`` promotion.
+``chk_records_spatial_extent_type`` preserves the DB-level type guard the
+typmod used to provide -- it once caught a real bug where an extent-write path
+tried to store a POINT and 500'd.
+
+The GiST index ``idx_records_spatial_extent`` is rebuilt automatically by the
+ALTER COLUMN TYPE rewrite; it is not dropped or recreated here.
+
+Revision ID: 0030_records_spatial_extent_type
+Revises: 0029_api_key_hardening
+Create Date: 2026-07-30
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+from sqlalchemy import text
+
+revision: str = "0030_records_spatial_extent_type"
+down_revision: Union[str, None] = "0029_api_key_hardening"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+_COUNT_MULTIPOLYGON = (
+    "SELECT count(*) FROM catalog.records "
+    "WHERE spatial_extent IS NOT NULL "
+    "AND GeometryType(spatial_extent) = 'MULTIPOLYGON'"
+)
+
+
+def upgrade() -> None:
+    op.execute(
+        "ALTER TABLE catalog.records "
+        "ALTER COLUMN spatial_extent TYPE geometry(Geometry, 4326) "
+        "USING spatial_extent::geometry(Geometry, 4326)"
+    )
+    op.create_check_constraint(
+        "chk_records_spatial_extent_type",
+        "records",
+        "spatial_extent IS NULL OR "
+        "GeometryType(spatial_extent) IN ('POLYGON', 'MULTIPOLYGON')",
+        schema="catalog",
+    )
+
+
+def downgrade() -> None:
+    # Refuse rather than coerce. Narrowing the typmod back to POLYGON has no
+    # lossless answer for a two-ring seam extent: the only POLYGON that contains
+    # it is -180..180, which silently re-registers the globe-spanning extent this
+    # migration exists to eliminate. An operator downgrading the schema is told
+    # the data cannot round-trip instead of having it quietly widened.
+    bind = op.get_bind()
+    crossing = bind.execute(text(_COUNT_MULTIPOLYGON)).scalar_one()
+    if crossing:
+        raise RuntimeError(
+            f"{crossing} catalog.records row(s) hold a MULTIPOLYGON "
+            "spatial_extent, which geometry(Polygon, 4326) cannot store. "
+            "Downgrading would have to replace each one with its -180..180 "
+            "envelope, losing the antimeridian-crossing extent. Inspect them "
+            "with:\n"
+            "  SELECT id, title, ST_AsText(spatial_extent) FROM catalog.records "
+            "WHERE GeometryType(spatial_extent) = 'MULTIPOLYGON';\n"
+            "If that loss is acceptable, run this first, then re-run the "
+            "downgrade:\n"
+            "  UPDATE catalog.records SET spatial_extent = "
+            "ST_Envelope(spatial_extent) "
+            "WHERE GeometryType(spatial_extent) = 'MULTIPOLYGON';"
+        )
+
+    op.drop_constraint(
+        "chk_records_spatial_extent_type",
+        "records",
+        schema="catalog",
+        type_="check",
+    )
+    op.execute(
+        "ALTER TABLE catalog.records "
+        "ALTER COLUMN spatial_extent TYPE geometry(Polygon, 4326) "
+        "USING spatial_extent::geometry(Polygon, 4326)"
+    )

--- a/backend/app/core/geo.py
+++ b/backend/app/core/geo.py
@@ -5,15 +5,140 @@ from sqlalchemy import and_, func, or_
 from sqlalchemy.sql.elements import ColumnElement
 
 
+# fix(#892): tolerance for recognizing the two-ring seam form. Both rings are
+# written by our own code at the literal ±180 and round-trip through WKB as
+# exact float64, so this only absorbs serialization noise -- it is deliberately
+# far too tight to promote real-world coordinates that merely sit near the seam.
+_SEAM_TOL = 1e-9
+
+
+def _near(a: float, b: float) -> bool:
+    return abs(a - b) <= _SEAM_TOL
+
+
+def _seam_split_bbox(shape: object) -> tuple[float, float, float, float] | None:
+    """Recognize a two-ring antimeridian-split extent and return its spec bbox.
+
+    fix(#892): a dataset that straddles the antimeridian is stored as a
+    two-part MULTIPOLYGON -- one part running up to +180, the other starting at
+    -180, over the same latitude band (see ``0030_records_spatial_extent_type``
+    and the STAC import path in ``sources/stac_router.py``). Its planar bounds
+    are -180..180, which is the whole globe and not the extent anyone meant.
+
+    Returns ``(west, south, east, north)`` with ``west > east`` -- the RFC 7946
+    §5.2 / STAC form -- for exactly that shape, and ``None`` for everything
+    else, including a genuine two-part MULTIPOLYGON that merely happens to have
+    parts on both sides of the world.
+
+    Contract for future producers: the two halves must share one latitude band.
+    A rollup that unions two crossing extents with *different* latitude spans
+    produces two parts this function will not recognize, and the caller then
+    gets the honest but over-broad -180..180 planar bounds. Fold to a common
+    band (or build the two rings from an already-folded bbox via
+    :func:`bbox_to_extent_wkt`) if the west > east form is wanted.
+    """
+    geoms = getattr(shape, "geoms", None)
+    if geoms is None or len(geoms) != 2:
+        return None
+    first, second = (g.bounds for g in geoms)
+
+    # Orient the pair: `left` is the part flush against +180, `right` the part
+    # flush against -180. Both flags must hold, or this is not a seam split.
+    if _near(first[2], 180.0) and _near(second[0], -180.0):
+        left, right = first, second
+    elif _near(second[2], 180.0) and _near(first[0], -180.0):
+        left, right = second, first
+    else:
+        return None
+
+    # The two halves must share a latitude band (otherwise the parts are
+    # unrelated footprints that happen to touch the seam, not one crossing box)
+    # and must not overlap in longitude -- west > east is the defining property
+    # of the bbox we are about to emit, so refuse to invent it.
+    if not (_near(left[1], right[1]) and _near(left[3], right[3])):
+        return None
+    if left[0] <= right[2]:
+        return None
+
+    return (left[0], left[1], right[2], left[3])
+
+
 def extent_to_bbox(extent: object | None) -> list[float] | None:
-    """Convert a GeoAlchemy2 geometry extent to [minx, miny, maxx, maxy]."""
+    """Convert a geometry extent to an RFC 7946 §5.2 / STAC bbox.
+
+    Returns ``[west, south, east, north]``. For an antimeridian-crossing extent
+    stored in the two-ring form (see :func:`_seam_split_bbox`) that means
+    ``west > east`` -- the spec-mandated encoding, and the reason this function
+    exists rather than a bare ``.bounds`` read.
+
+    Callers that need monotonic bounds (``west <= east``) because they feed a
+    naive span subtraction, a planar WKT ring, or a viewer that cannot express
+    a crossing box must use :func:`extent_to_span_bbox` instead.
+    """
     if extent is None:
         return None
     try:
         shape = to_shape(extent)
+        seam = _seam_split_bbox(shape)
+        if seam is not None:
+            return list(seam)
         return list(shape.bounds)
     except Exception:  # broad: input is user-supplied; any geoalchemy/shapely parse failure should fall back to None
         return None
+
+
+def extent_to_span_bbox(extent: object | None) -> list[float] | None:
+    """Convert a geometry extent to monotonic planar bounds (``west <= east``).
+
+    fix(#892): the sibling of :func:`extent_to_bbox` for consumers that cannot
+    accept a west > east pair -- ``maxx - minx`` span arithmetic, planar WKT
+    polygon serialization, tile-source bounds. An antimeridian-crossing extent
+    is honestly -180..180 in this form: over-broad, but never inverted.
+    """
+    if extent is None:
+        return None
+    try:
+        return list(to_shape(extent).bounds)
+    except Exception:  # broad: input is user-supplied; any geoalchemy/shapely parse failure should fall back to None
+        return None
+
+
+def _ring(x0: float, south: float, x1: float, north: float) -> str:
+    return f"({x0} {south},{x1} {south},{x1} {north},{x0} {north},{x0} {south})"
+
+
+def bbox_to_extent_wkt(west: float, south: float, east: float, north: float) -> str:
+    """Build extent WKT for an RFC 7946 §5.2 bbox, splitting it at ±180.
+
+    fix(#892): the producer side of :func:`extent_to_bbox`. When ``west > east``
+    the bbox crosses the antimeridian, and the naive single ring
+    ``POLYGON((w s, e s, e n, w n, w s))`` silently becomes the complement: for
+    ``[170, -20, -170, -15]`` it is a valid rectangle spanning longitude
+    -170..170, so it covers 1700 deg² of the wrong side of the world instead of
+    the intended 100 and does not even contain the data it describes. Emit a
+    two-part MULTIPOLYGON instead -- ``west..180`` and ``-180..east`` over the
+    same latitude band -- which ``catalog.records.spatial_extent`` accepts as of
+    migration ``0030_records_spatial_extent_type`` and which
+    :func:`extent_to_bbox` reads back as the original ``west > east`` pair.
+    """
+    if west <= east:
+        return f"POLYGON({_ring(west, south, east, north)})"
+
+    # A crossing bbox whose west sits at +180 (or east at -180) has a zero-width
+    # half; emitting it anyway would store an invalid ring, which is the class of
+    # defect this helper exists to prevent. Keep only the halves with real width,
+    # and fall back to the full -180..180 band when neither has any -- an extent
+    # must never silently narrow to nothing.
+    halves = [
+        _ring(x0, south, x1, north)
+        for x0, x1 in ((west, 180.0), (-180.0, east))
+        if x0 < x1
+    ]
+    if not halves:
+        return f"POLYGON({_ring(-180.0, south, 180.0, north)})"
+    if len(halves) == 1:
+        return f"POLYGON({halves[0]})"
+    return f"MULTIPOLYGON({','.join(f'({h})' for h in halves)})"
 
 
 def make_bbox_filter(

--- a/backend/app/modules/catalog/datasets/domain/helpers.py
+++ b/backend/app/modules/catalog/datasets/domain/helpers.py
@@ -20,7 +20,7 @@ from app.modules.catalog.sources.provenance import (
     derive_last_edited,
     resolve_actor,
 )
-from app.core.geo import extent_to_bbox, wkt_is_geographic
+from app.core.geo import extent_to_span_bbox, wkt_is_geographic
 
 
 async def _load_actor_identities(
@@ -174,7 +174,14 @@ def dataset_to_response(
         n_dims=dataset.n_dims,
         z_min=dataset.z_min,
         z_max=dataset.z_max,
-        extent_bbox=extent_to_bbox(record.spatial_extent),
+        # fix(#892 codex P2): the SPAN, not the RFC 7946 spec bbox. This field is
+        # documented as "[minx, miny, maxx, maxy]" and its consumers are map
+        # viewers, not a standards serializer: DatasetMap draws an unguarded
+        # planar ring from it and calls fitBounds, so a west > east pair would
+        # paint the complementary 340° and hand MapLibre an inverted camera.
+        # The spec form is served where the spec demands it (STAC/OGC record
+        # bbox via extract_bbox, OGC collection extents), not here.
+        extent_bbox=extent_to_span_bbox(record.spatial_extent),
         column_info=dataset.column_info,
         quality_detail=dataset.quality_detail,
         license=record.license,

--- a/backend/app/modules/catalog/datasets/domain/models.py
+++ b/backend/app/modules/catalog/datasets/domain/models.py
@@ -58,6 +58,21 @@ class Record(Base):
             "temporal_start IS NULL OR temporal_end IS NULL OR temporal_start <= temporal_end",
             name="chk_temporal_ordering",
         ),
+        # fix(#892): the column typmod was widened from POLYGON to generic
+        # Geometry so a seam-crossing extent can be a two-ring MULTIPOLYGON;
+        # this constraint keeps the type guard the typmod used to provide. It
+        # once caught a real bug where an extent-write path tried to store a
+        # POINT and 500'd, so the allow-list stays deliberately narrow.
+        CheckConstraint(
+            "spatial_extent IS NULL OR "
+            "GeometryType(spatial_extent) IN ('POLYGON', 'MULTIPOLYGON')",
+            name="chk_records_spatial_extent_type",
+        ),
+        # fix(#892): known ceiling -- a two-part seam-crossing MULTIPOLYGON has
+        # a -180..180 GiST bounding box, so this index degrades to a
+        # full-candidate scan for those rows only. make_bbox_filter()'s
+        # ST_Intersects recheck still filters them correctly, so results stay
+        # right; they are just less indexed.
         Index(
             "idx_records_spatial_extent",
             "spatial_extent",
@@ -159,7 +174,15 @@ class Record(Base):
         # __table_args__ as idx_records_spatial_extent. Without this, GeoAlchemy2
         # would ALSO auto-create a same-named index, duplicating it in the model
         # metadata (harmless for migration-built DBs but breaks create_all()).
-        Geometry("POLYGON", srid=4326, spatial_index=False),
+        #
+        # fix(#892): plain Geometry (typmod geometry(Geometry,4326)) rather than
+        # POLYGON, so an antimeridian-crossing extent can be stored as the
+        # two-ring MULTIPOLYGON that RFC 7946 §5.2's west > east bbox
+        # corresponds to. Plain Geometry rather than MULTIPOLYGON keeps every
+        # non-crossing extent byte-identical as a POLYGON -- no blanket ST_Multi
+        # promotion. chk_records_spatial_extent_type below keeps the DB-level
+        # guard that a POINT/LINESTRING extent is still rejected.
+        Geometry(srid=4326, spatial_index=False),
         nullable=True,
     )
     temporal_start: Mapped[date | None] = mapped_column(Date, nullable=True)

--- a/backend/app/modules/catalog/datasets/domain/utils.py
+++ b/backend/app/modules/catalog/datasets/domain/utils.py
@@ -1,17 +1,17 @@
 """Shared dataset utility functions."""
 
-from geoalchemy2.shape import to_shape
-
+from app.core.geo import extent_to_bbox
 from app.modules.catalog.datasets.domain.models import Dataset
 
 
 def extract_bbox(dataset: Dataset) -> list[float] | None:
-    """Extract a bbox array from the dataset's record spatial_extent geometry."""
+    """Extract a bbox array from the dataset's record spatial_extent geometry.
+
+    fix(#892): delegates to ``extent_to_bbox`` so a seam-crossing extent yields
+    the RFC 7946 §5.2 west > east pair rather than a globe-spanning -180..180.
+    Both consumers want the spec form: the STAC/OGC record ``bbox``
+    (``search/service_records.py``) and the AI dataset-context ``extent_bbox``.
+    """
     if dataset.record and dataset.record.spatial_extent is not None:
-        try:
-            return list(to_shape(dataset.record.spatial_extent).bounds)
-        except (
-            Exception
-        ):  # broad: extent parse — geoalchemy/shapely errors fall back to None bbox
-            return None
+        return extent_to_bbox(dataset.record.spatial_extent)
     return None

--- a/backend/app/modules/catalog/maps/_router_helpers.py
+++ b/backend/app/modules/catalog/maps/_router_helpers.py
@@ -12,7 +12,7 @@ import structlog
 from fastapi import HTTPException, status
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.core.geo import extent_to_bbox
+from app.core.geo import extent_to_span_bbox
 from app.core.identity import Identity
 from app.modules.catalog.authorization import get_user_roles
 from app.modules.catalog.maps.models import Map, MapLayer
@@ -108,7 +108,13 @@ def _build_layer_response(
         dataset_name=meta.get("dataset_name", ""),
         dataset_geometry_type=meta.get("geometry_type"),
         dataset_table_name=meta.get("table_name", ""),
-        dataset_extent_bbox=extent_to_bbox(meta.get("extent")),
+        # fix(#892 codex P2): the SPAN, not the RFC 7946 spec bbox. Per MVT-06
+        # this value bounds tile fetching, and it lands in a MapLibre source
+        # `bounds` (map-sync.ts) where a west > east pair matches NO tile, so a
+        # seam-crossing layer would render blank. The two builder fit-bounds
+        # paths also skip an inverted bbox, which silently disables auto-fit and
+        # Zoom to Layer. -180..180 is over-broad but keeps all three working.
+        dataset_extent_bbox=extent_to_span_bbox(meta.get("extent")),
         dataset_column_info=meta.get("column_info"),
         dataset_feature_count=meta.get("feature_count"),
         dataset_sample_values=meta.get("sample_values"),

--- a/backend/app/modules/catalog/search/router.py
+++ b/backend/app/modules/catalog/search/router.py
@@ -42,8 +42,8 @@ from app.standards.ogc.utils import (
     parse_accept_languages,
 )
 from app.standards.ogc.errors import BAD_REQUEST_RESPONSE, ERROR_RESPONSES_PUBLIC
+from app.core.geo import extent_to_bbox
 from app.core.public_urls import get_public_api_url, get_public_app_url
-from geoalchemy2.shape import to_shape
 from app.modules.catalog.search.schemas import (
     FacetCountResponse,
     OGCCollectionMetadataResponse,
@@ -790,15 +790,19 @@ async def list_collections(
     for ds in datasets:
         extent = {}
         if ds.record.spatial_extent is not None:
-            try:
-                shape = to_shape(ds.record.spatial_extent)
-                bbox = list(shape.bounds)
+            # fix(#892): OGC API - Features collection extents use the GeoJSON
+            # bbox convention, so a seam-crossing extent must serve west > east
+            # rather than the globe-spanning -180..180 a bare .bounds read gave.
+            # extent_to_bbox returns None on a parse failure (was a warning log
+            # from the removed try/except), which degrades to no spatial extent.
+            bbox = extent_to_bbox(ds.record.spatial_extent)
+            if bbox is None:
+                logger.warning("Failed to serialize OGC bbox extent")
+            else:
                 extent["spatial"] = {
                     "bbox": [bbox],
                     "crs": "http://www.opengis.net/def/crs/OGC/1.3/CRS84",
                 }
-            except Exception:  # broad: extent parse — geoalchemy/shapely errors degrade to no-spatial extent
-                logger.warning("Failed to serialize OGC bbox extent", exc_info=True)
         if ds.record.temporal_start is not None or ds.record.temporal_end is not None:
             extent["temporal"] = {
                 "interval": [

--- a/backend/app/modules/catalog/sources/stac_router.py
+++ b/backend/app/modules/catalog/sources/stac_router.py
@@ -17,6 +17,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.standards.ogc.errors import BAD_GATEWAY_RESPONSE, ERROR_RESPONSES_WRITE
 
+from app.core.geo import bbox_to_extent_wkt
 from app.core.url_redaction import has_url_credentials, redact_url_credentials
 from app.modules.audit.service import AuditEvent, audit_emit
 from app.core.identity import Identity
@@ -544,8 +545,14 @@ async def stac_import(
                 spatial_extent = None
                 if item.bbox and len(item.bbox) >= 4:
                     w, s, e, n = item.bbox[:4]
-                    wkt = f"POLYGON(({w} {s},{e} {s},{e} {n},{w} {n},{w} {s}))"
-                    spatial_extent = func.ST_GeomFromText(wkt, 4326)
+                    # fix(#884): RFC 7946 §5.2 mandates west > east for a bbox
+                    # that crosses the antimeridian, so a remote [170,-20,-170,-15]
+                    # used to build a ring spanning longitude -170..170 -- the
+                    # complementary 340°, which does not even contain the data.
+                    # bbox_to_extent_wkt splits those at ±180.
+                    spatial_extent = func.ST_GeomFromText(
+                        bbox_to_extent_wkt(w, s, e, n), 4326
+                    )
 
                 record = Record(
                     title=item.title,

--- a/backend/app/processing/ai/metadata_service.py
+++ b/backend/app/processing/ai/metadata_service.py
@@ -10,7 +10,6 @@ import uuid
 from typing import TYPE_CHECKING
 
 import structlog
-from geoalchemy2.shape import to_shape
 from pydantic import BaseModel
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -21,6 +20,7 @@ from app.processing.ai.metadata_schemas import (
     SummaryDraftResponse,
 )
 from app.core.config import settings
+from app.core.geo import extent_to_bbox
 from app.platform.cache import tenant_cache_context_available, tenant_cache_key
 from app.platform.extensions import get_ai_provider
 from app.processing.embeddings.helpers import get_nearest_record_ids
@@ -105,14 +105,19 @@ async def _build_dataset_context(
         parts.append(f"Source organization: {record.source_organization}")
 
     if record.spatial_extent is not None:
-        try:
-            bounds = to_shape(record.spatial_extent).bounds
+        # fix(#892): the label below is literally "W, S, E, N", so the RFC 7946
+        # §5.2 spec bbox is the honest value -- a seam-crossing extent reads
+        # W > E rather than claiming a global -180..180 footprint. Spell the
+        # crossing out, because W > E alone reads as a typo to a summarizer.
+        bounds = extent_to_bbox(record.spatial_extent)
+        if bounds is None:
+            logger.debug("Failed to parse spatial bounds for AI context")
+        else:
+            crossing = " (crosses the antimeridian)" if bounds[0] > bounds[2] else ""
             parts.append(
                 f"Bounding box (W, S, E, N): {bounds[0]:.4f}, {bounds[1]:.4f}, "
-                f"{bounds[2]:.4f}, {bounds[3]:.4f}"
+                f"{bounds[2]:.4f}, {bounds[3]:.4f}{crossing}"
             )
-        except Exception:  # broad: bounds string is informational; any geometry parse failure should be skipped
-            logger.debug("Failed to parse spatial bounds for AI context", exc_info=True)
 
     if record.access_constraints:
         parts.append(f"Access constraints: {record.access_constraints}")

--- a/backend/app/processing/tiles/router.py
+++ b/backend/app/processing/tiles/router.py
@@ -22,11 +22,11 @@ from fastapi import (
     Response,
     status,
 )
-from geoalchemy2.shape import to_shape
 from sqlalchemy import select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import joinedload
 
+from app.core.geo import extent_to_span_bbox
 from app.core.identity import Identity
 from app.core.record_types import RASTER_FAMILY_RECORD_TYPES
 from app.modules.auth.dependencies import get_optional_user
@@ -1193,15 +1193,17 @@ def _build_tile_token_for_dataset(
     if dataset.record.record_type in RASTER_FAMILY_RECORD_TYPES:
         bounds = None
         if dataset.record.spatial_extent is not None:
-            try:
-                shape = to_shape(dataset.record.spatial_extent)
-                bounds = list(shape.bounds)  # [xmin, ymin, xmax, ymax]
-            except Exception:  # broad: extent parse is non-fatal; geoalchemy/shapely errors fall back to no-bounds
+            # fix(#892): the SPAN, not the RFC 7946 spec bbox. These bounds feed
+            # _raster_maxzoom_from_metadata's `maxx - minx` span arithmetic and
+            # the tile source's own bounds; a west > east pair makes the span
+            # negative, which collapses the derived maxzoom and bounds the
+            # source to nothing. -180..180 is over-broad but never inverted.
+            bounds = extent_to_span_bbox(dataset.record.spatial_extent)
+            if bounds is None:
                 logger.warning(
                     "Failed to parse spatial extent bounds",
                     dataset_id=str(dataset.id),
                 )
-                bounds = None
 
         return RasterTileToken(
             kind="raster",

--- a/backend/app/standards/dcat/service.py
+++ b/backend/app/standards/dcat/service.py
@@ -352,10 +352,20 @@ def record_to_dcat(
 
     # Spatial extent
     if record.spatial_extent:
-        try:
-            from geoalchemy2.shape import to_shape
+        from app.core.geo import extent_to_span_bbox
 
-            bounds = to_shape(record.spatial_extent).bounds
+        # fix(#892): dcat:bbox is a planar WKT ring, which cannot express
+        # RFC 7946's west > east crossing bbox -- a ring built from one silently
+        # becomes the complementary 340°. Take the monotonic span, so a
+        # seam-crossing extent serializes over-broad (-180..180) but honest.
+        # extent_to_span_bbox swallows geoalchemy/shapely parse failures and
+        # returns None, which degrades to no dcterms:spatial as before.
+        bounds = extent_to_span_bbox(record.spatial_extent)
+        if bounds is None:
+            logger.debug(
+                "DCAT spatial extent serialization failed", record_id=str(record.id)
+            )
+        else:
             result["dcterms:spatial"] = {
                 "@type": "dcterms:Location",
                 "dcat:bbox": (
@@ -366,10 +376,6 @@ def record_to_dcat(
                     f"{bounds[0]} {bounds[1]}))"
                 ),
             }
-        except Exception:  # broad: DCAT bbox serialize — geoalchemy/shapely errors degrade to no-spatial in catalog entry
-            logger.debug(
-                "DCAT spatial extent serialization failed", record_id=str(record.id)
-            )
 
     # Theme categories
     if record.theme_category:

--- a/backend/app/standards/dcat_us/service.py
+++ b/backend/app/standards/dcat_us/service.py
@@ -279,15 +279,20 @@ def _spatial_to_dcat_us3(record: Record) -> dict | None:
     if record.spatial_extent is None:
         return None
 
-    try:
-        from geoalchemy2.shape import to_shape
+    from app.core.geo import extent_to_span_bbox
 
-        min_x, min_y, max_x, max_y = to_shape(record.spatial_extent).bounds
-    except Exception:  # broad: DCAT-US bbox serialize degrades to absent spatial
+    # fix(#892): the bbox below is a planar WKT ring, which cannot express
+    # RFC 7946's west > east crossing bbox -- a ring built from one silently
+    # becomes the complementary 340°. Take the monotonic span, so a seam-crossing
+    # extent serializes over-broad (-180..180) but honest. extent_to_span_bbox
+    # swallows geoalchemy/shapely parse failures and returns None (no spatial).
+    bounds = extent_to_span_bbox(record.spatial_extent)
+    if bounds is None:
         logger.debug(
             "DCAT-US spatial extent serialization failed", record_id=str(record.id)
         )
         return None
+    min_x, min_y, max_x, max_y = bounds
 
     return {
         "@type": "Location",

--- a/backend/app/standards/geodcat_ap/service.py
+++ b/backend/app/standards/geodcat_ap/service.py
@@ -340,16 +340,21 @@ def _spatial_to_geodcat_ap(record: Record) -> dict | None:
     """Serialize the spatial extent as a dcterms:Location with GeoSPARQL WKT."""
     if record.spatial_extent is None:
         return None
-    try:
-        from geoalchemy2.shape import to_shape
+    from app.core.geo import extent_to_span_bbox
 
-        min_x, min_y, max_x, max_y = to_shape(record.spatial_extent).bounds
-    except Exception:  # broad: geoalchemy/shapely errors degrade to no spatial
+    # fix(#892): the GeoSPARQL wktLiteral below is a planar ring, which cannot
+    # express RFC 7946's west > east crossing bbox -- a ring built from one
+    # silently becomes the complementary 340°. Take the monotonic span, so a
+    # seam-crossing extent serializes over-broad (-180..180) but honest.
+    # extent_to_span_bbox swallows parse failures and returns None (no spatial).
+    bounds = extent_to_span_bbox(record.spatial_extent)
+    if bounds is None:
         logger.debug(
             "GeoDCAT-AP spatial extent serialization failed",
             record_id=str(record.id),
         )
         return None
+    min_x, min_y, max_x, max_y = bounds
 
     wkt = (
         f"POLYGON(({min_x} {min_y}, "

--- a/backend/tests/test_analysis_materialize.py
+++ b/backend/tests/test_analysis_materialize.py
@@ -2437,12 +2437,12 @@ class TestBufferAtDateline:
         # matches a bbox on the far side of the world.
         assert row.hits_france is False
 
-        # The registered extent must still satisfy the geometry(Polygon,4326)
-        # column, and stay finite. It is legitimately -180..180 here: the
-        # split parts really do touch both edges, and that column cannot hold
-        # the west > east bbox RFC 7946 § 5.2 uses for crossing extents. That
-        # representation gap is pre-existing and shared with directly ingested
-        # Fiji-area data — pinned, not fixed, by this test.
+        # The registered extent is still a single POLYGON and stays finite. It
+        # is -180..180 here because the split parts really do touch both edges
+        # and this writer folds them with ST_Extent. fix(#892) widened the
+        # column so a two-ring MULTIPOLYGON — and therefore the RFC 7946 § 5.2
+        # west > east bbox — is now storable, but teaching the analysis extent
+        # rollup to emit one is the separate follow-up; pinned, not fixed, here.
         extent = (
             await test_db_session.execute(
                 text(

--- a/backend/tests/test_antimeridian_extent.py
+++ b/backend/tests/test_antimeridian_extent.py
@@ -1,0 +1,374 @@
+"""fix(#892): antimeridian-crossing extent representation.
+
+``catalog.records.spatial_extent`` used to be ``geometry(Polygon, 4326)``, which
+cannot hold the west > east bbox RFC 7946 §5.2 and STAC use for a crossing
+extent. It is now generic ``geometry(Geometry, 4326)`` guarded by
+``chk_records_spatial_extent_type``, a seam-crossing extent is stored as a
+two-ring MULTIPOLYGON, and ``extent_to_bbox`` reads that back as west > east
+while ``extent_to_span_bbox`` keeps monotonic bounds for consumers that cannot
+take an inverted pair.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from geoalchemy2 import WKBElement, WKTElement
+from geoalchemy2.shape import from_shape
+from shapely import wkt as shapely_wkt
+from sqlalchemy import text
+from sqlalchemy.exc import IntegrityError
+
+from app.core.geo import bbox_to_extent_wkt, extent_to_bbox, extent_to_span_bbox
+
+# The canonical crossing case: a Fiji-area strip that spans the seam.
+FIJI_BBOX = (170.0, -20.0, -170.0, -15.0)
+
+ORDINARY_POLYGON = "POLYGON((0 0,10 0,10 5,0 5,0 0))"
+SEAM_MULTIPOLYGON = bbox_to_extent_wkt(*FIJI_BBOX)
+# Two real footprints on opposite sides of the world. Neither touches ±180, so
+# nothing about it may be read as a seam split.
+NON_SEAM_MULTIPOLYGON = (
+    "MULTIPOLYGON(((0 0,1 0,1 1,0 1,0 0)),((10 0,11 0,11 1,10 1,10 0)))"
+)
+# Both halves touch the seam, but over unrelated latitude bands — two separate
+# footprints, not one crossing box.
+SEAM_TOUCHING_DIFFERENT_LATITUDES = (
+    "MULTIPOLYGON(((170 -20,180 -20,180 -15,170 -15,170 -20)),"
+    "((-180 50,-170 50,-170 55,-180 55,-180 50)))"
+)
+# get_extent() pads a POINT/LINESTRING source into a tiny square so it satisfies
+# the polygon shape; that padding must survive both helpers untouched.
+DEGENERATE_PADDED_ENVELOPE = (
+    "POLYGON((-0.001 -0.001,0.001 -0.001,0.001 0.001,-0.001 0.001,-0.001 -0.001))"
+)
+
+
+def _extent(wkt: str) -> WKBElement:
+    """Build the WKB element form a loaded ORM column value actually has.
+
+    SQLAlchemy hands ``Record.spatial_extent`` to these helpers as a
+    ``WKBElement``, so the unit tests exercise that path rather than the WKT one
+    that only appears when a test hand-writes a literal.
+    """
+    return from_shape(shapely_wkt.loads(wkt), srid=4326)
+
+
+# ---------------------------------------------------------------------------
+# extent_to_bbox / extent_to_span_bbox
+# ---------------------------------------------------------------------------
+
+
+class TestExtentToBbox:
+    def test_ordinary_polygon_is_plain_bounds(self):
+        assert extent_to_bbox(_extent(ORDINARY_POLYGON)) == [0.0, 0.0, 10.0, 5.0]
+
+    def test_seam_crossing_multipolygon_returns_west_greater_than_east(self):
+        bbox = extent_to_bbox(_extent(SEAM_MULTIPOLYGON))
+        assert bbox == [170.0, -20.0, -170.0, -15.0]
+        assert bbox[0] > bbox[2]
+
+    def test_genuine_two_part_multipolygon_is_not_mistaken_for_a_crosser(self):
+        bbox = extent_to_bbox(_extent(NON_SEAM_MULTIPOLYGON))
+        assert bbox == [0.0, 0.0, 11.0, 1.0]
+        assert bbox[0] < bbox[2]
+
+    def test_seam_halves_over_different_latitudes_are_not_a_crosser(self):
+        bbox = extent_to_bbox(_extent(SEAM_TOUCHING_DIFFERENT_LATITUDES))
+        assert bbox == [-180.0, -20.0, 180.0, 55.0]
+
+    def test_whole_world_polygon_is_not_a_crosser(self):
+        whole = "POLYGON((-180 -90,180 -90,180 90,-180 90,-180 -90))"
+        assert extent_to_bbox(_extent(whole)) == [-180.0, -90.0, 180.0, 90.0]
+
+    def test_degenerate_padded_envelope_is_unchanged(self):
+        assert extent_to_bbox(_extent(DEGENERATE_PADDED_ENVELOPE)) == [
+            -0.001,
+            -0.001,
+            0.001,
+            0.001,
+        ]
+
+    def test_three_part_multipolygon_containing_a_seam_pair_is_not_a_crosser(self):
+        """The detector keys on exactly two parts; a third part means the pair is
+        no longer the whole extent, so the honest answer is the planar bounds."""
+        three = (
+            "MULTIPOLYGON(((170 -20,180 -20,180 -15,170 -15,170 -20)),"
+            "((-180 -20,-170 -20,-170 -15,-180 -15,-180 -20)),"
+            "((0 0,1 0,1 1,0 1,0 0)))"
+        )
+        assert extent_to_bbox(_extent(three)) == [-180.0, -20.0, 180.0, 1.0]
+
+    def test_wkt_element_form_agrees_with_the_wkb_form(self):
+        """to_shape accepts both element types; the detector must not care which."""
+        assert extent_to_bbox(WKTElement(SEAM_MULTIPOLYGON, srid=4326)) == [
+            170.0,
+            -20.0,
+            -170.0,
+            -15.0,
+        ]
+
+    def test_none_and_garbage_return_none(self):
+        assert extent_to_bbox(None) is None
+        assert extent_to_bbox("not-a-geometry") is None
+        assert extent_to_bbox(object()) is None
+
+
+class TestExtentToSpanBbox:
+    def test_ordinary_polygon_matches_the_spec_helper(self):
+        el = _extent(ORDINARY_POLYGON)
+        assert extent_to_span_bbox(el) == extent_to_bbox(el)
+
+    def test_seam_crossing_multipolygon_stays_monotonic(self):
+        bbox = extent_to_span_bbox(_extent(SEAM_MULTIPOLYGON))
+        # Over-broad, but never inverted — the property tile/WKT consumers need.
+        assert bbox == [-180.0, -20.0, 180.0, -15.0]
+        assert bbox[0] < bbox[2]
+
+    def test_degenerate_padded_envelope_is_unchanged(self):
+        assert extent_to_span_bbox(_extent(DEGENERATE_PADDED_ENVELOPE)) == [
+            -0.001,
+            -0.001,
+            0.001,
+            0.001,
+        ]
+
+    def test_none_and_garbage_return_none(self):
+        assert extent_to_span_bbox(None) is None
+        assert extent_to_span_bbox("not-a-geometry") is None
+
+
+class TestBboxToExtentWkt:
+    def test_non_crossing_bbox_stays_a_single_polygon_ring(self):
+        assert bbox_to_extent_wkt(1, 2, 3, 4) == "POLYGON((1 2,3 2,3 4,1 4,1 2))"
+
+    def test_crossing_bbox_becomes_two_rings_split_at_180(self):
+        shape = shapely_wkt.loads(bbox_to_extent_wkt(*FIJI_BBOX))
+        assert shape.geom_type == "MultiPolygon"
+        assert len(shape.geoms) == 2
+        assert shape.is_valid
+        # One half runs west..180, the other -180..east, over the same latitudes.
+        halves = sorted(g.bounds for g in shape.geoms)
+        assert halves == [(-180.0, -20.0, -170.0, -15.0), (170.0, -20.0, 180.0, -15.0)]
+
+    def test_round_trips_through_extent_to_bbox(self):
+        """The producer/reader pair is the contract every downstream fix leans on."""
+        for bbox in (FIJI_BBOX, (1.0, 2.0, 3.0, 4.0), (179.5, 0.0, -179.5, 1.0)):
+            wkt = bbox_to_extent_wkt(*bbox)
+            assert extent_to_bbox(_extent(wkt)) == list(bbox)
+
+    @pytest.mark.parametrize(
+        ("bbox", "expected_type", "expected_bounds"),
+        [
+            # west sits on the seam: the west..180 half has zero width.
+            ((180.0, -20.0, -170.0, -15.0), "Polygon", (-180.0, -20.0, -170.0, -15.0)),
+            # east sits on the seam: the -180..east half has zero width.
+            ((170.0, -20.0, -180.0, -15.0), "Polygon", (170.0, -20.0, 180.0, -15.0)),
+            # Both ends on the seam: fall back to the full band, never to nothing.
+            ((180.0, -20.0, -180.0, -15.0), "Polygon", (-180.0, -20.0, 180.0, -15.0)),
+        ],
+    )
+    def test_degenerate_crossing_halves_never_produce_an_invalid_ring(
+        self, bbox, expected_type, expected_bounds
+    ):
+        """A remote bbox with west == 180 (or east == -180) would otherwise emit a
+        zero-width ring — an invalid geometry, the exact defect class this helper
+        exists to prevent."""
+        shape = shapely_wkt.loads(bbox_to_extent_wkt(*bbox))
+        assert shape.is_valid
+        assert shape.geom_type == expected_type
+        assert shape.bounds == expected_bounds
+
+
+# ---------------------------------------------------------------------------
+# chk_records_spatial_extent_type (migration 0030)
+# ---------------------------------------------------------------------------
+
+
+async def _insert_record_with_extent(db, extent_wkt: str | None) -> uuid.UUID:
+    record_id = uuid.uuid4()
+    extent_sql = "NULL" if extent_wkt is None else "ST_GeomFromText(:wkt, 4326)"
+    params: dict[str, object] = {
+        "id": record_id,
+        "title": f"extent-type-{record_id}",
+    }
+    if extent_wkt is not None:
+        params["wkt"] = extent_wkt
+    await db.execute(
+        text(
+            "INSERT INTO catalog.records "
+            "(id, title, visibility, record_status, record_type, spatial_extent) "
+            "VALUES (:id, :title, 'private', 'draft', 'vector_dataset', "
+            f"{extent_sql})"  # noqa: S608 -- literal NULL or a bound-param call
+        ),
+        params,
+    )
+    return record_id
+
+
+@pytest.mark.anyio
+class TestSpatialExtentTypeConstraint:
+    async def test_polygon_and_multipolygon_are_accepted(
+        self, test_db_session, clean_tables
+    ):
+        del clean_tables
+        for wkt, expected in (
+            (ORDINARY_POLYGON, "POLYGON"),
+            (SEAM_MULTIPOLYGON, "MULTIPOLYGON"),
+            (NON_SEAM_MULTIPOLYGON, "MULTIPOLYGON"),
+            (None, None),
+        ):
+            record_id = await _insert_record_with_extent(test_db_session, wkt)
+            stored = (
+                await test_db_session.execute(
+                    text(
+                        "SELECT GeometryType(spatial_extent) AS gtype "
+                        "FROM catalog.records WHERE id = :rid"
+                    ).bindparams(rid=record_id)
+                )
+            ).scalar_one()
+            assert stored == expected
+
+    @pytest.mark.parametrize(
+        "wkt",
+        [
+            "POINT(1 2)",
+            "LINESTRING(0 0,1 1)",
+            "GEOMETRYCOLLECTION(POINT(1 2))",
+        ],
+    )
+    async def test_non_areal_extents_are_rejected(
+        self, test_db_session, clean_tables, wkt
+    ):
+        """The old POLYGON typmod caught an extent-write path that tried to store
+        a POINT; widening the column must not give that back up."""
+        del clean_tables
+        with pytest.raises(IntegrityError, match="chk_records_spatial_extent_type"):
+            async with test_db_session.begin_nested():
+                await _insert_record_with_extent(test_db_session, wkt)
+
+    async def test_column_typmod_is_generic_geometry(
+        self, test_db_session, clean_tables
+    ):
+        del clean_tables
+        row = (
+            await test_db_session.execute(
+                text(
+                    "SELECT type, srid FROM geometry_columns "
+                    "WHERE f_table_schema = 'catalog' AND f_table_name = 'records' "
+                    "AND f_geometry_column = 'spatial_extent'"
+                )
+            )
+        ).one()
+        assert row.type == "GEOMETRY"
+        assert row.srid == 4326
+
+    async def test_gist_index_survives_the_type_change(
+        self, test_db_session, clean_tables
+    ):
+        """The ALTER COLUMN TYPE rewrite rebuilds indexes; assert the GiST index
+        is still there rather than trusting that."""
+        del clean_tables
+        indexdef = (
+            await test_db_session.execute(
+                text(
+                    "SELECT indexdef FROM pg_indexes "
+                    "WHERE schemaname = 'catalog' AND tablename = 'records' "
+                    "AND indexname = 'idx_records_spatial_extent'"
+                )
+            )
+        ).scalar_one()
+        assert "USING gist" in indexdef
+
+
+# ---------------------------------------------------------------------------
+# Stored-extent spatial correctness (the property that actually matters)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_seam_extent_covers_the_data_and_not_the_complementary_340_degrees(
+    test_db_session, clean_tables
+):
+    """fix(#884)/fix(#892): what the old single ring actually did.
+
+    ``POLYGON((170 -20,-170 -20,-170 -15,170 -15,170 -20))`` is a *valid* simple
+    rectangle, not a self-intersecting one. Its defect is the area: it spans
+    longitude -170..170, so it covered 1700 deg² of the wrong side of the world
+    instead of the intended 100 deg², **missed the Fiji data it described**, and
+    matched anything in the same -20..-15 latitude band at any other longitude.
+
+    So the discriminating assertions are the Fiji hit (False under the old ring)
+    and the same-latitude South Atlantic miss (True under the old ring). A probe
+    over central France is *not* discriminating: at latitude 47 it fell outside
+    the old ring's latitude band too. It stays here only as a coarse check that
+    the extent has not gone global.
+    """
+    del clean_tables
+    record_id = await _insert_record_with_extent(test_db_session, SEAM_MULTIPOLYGON)
+    row = (
+        await test_db_session.execute(
+            text(
+                "SELECT GeometryType(spatial_extent) AS gtype,"
+                " ST_NumGeometries(spatial_extent) AS parts,"
+                " ST_IsValid(spatial_extent) AS valid,"
+                " ST_Area(spatial_extent) AS area,"
+                " ST_Intersects("
+                "   spatial_extent, ST_MakeEnvelope(177, -19, 179, -16, 4326)"
+                " ) AS hits_fiji,"
+                " ST_Intersects("
+                "   spatial_extent, ST_MakeEnvelope(-179, -19, -177, -16, 4326)"
+                " ) AS hits_east_of_seam,"
+                " ST_Intersects("
+                "   spatial_extent, ST_MakeEnvelope(-1, -19, 1, -16, 4326)"
+                " ) AS hits_south_atlantic,"
+                " ST_Intersects("
+                "   spatial_extent, ST_MakeEnvelope(1.5, 46.5, 2.5, 47.5, 4326)"
+                " ) AS hits_france"
+                " FROM catalog.records WHERE id = :rid"
+            ).bindparams(rid=record_id)
+        )
+    ).one()
+
+    assert row.gtype == "MULTIPOLYGON"
+    assert row.parts == 2
+    assert row.valid is True
+    # 10° west of the seam plus 10° east, over a 5° latitude band.
+    assert row.area == pytest.approx(100.0)
+    # Both halves of the strip are reachable.
+    assert row.hits_fiji is True
+    assert row.hits_east_of_seam is True
+    # The regression: the old ring matched this and every other longitude in the
+    # band, while missing the data itself.
+    assert row.hits_south_atlantic is False
+    assert row.hits_france is False
+
+
+@pytest.mark.anyio
+async def test_make_bbox_filter_finds_a_seam_extent_from_either_side(
+    test_db_session, clean_tables
+):
+    """The stored two-ring form has to stay reachable through the query path that
+    already splits a west > east *query* bbox — that pairing is why the geometry
+    column, not a pair of scalar bbox columns, is the right representation."""
+    del clean_tables
+    from app.core.geo import make_bbox_filter
+    from app.modules.catalog.datasets.domain.models import Record
+    from sqlalchemy import select
+
+    record_id = await _insert_record_with_extent(test_db_session, SEAM_MULTIPOLYGON)
+
+    async def _matches(bbox: list[float]) -> bool:
+        stmt = select(Record.id).where(
+            Record.id == record_id,
+            make_bbox_filter(Record.spatial_extent, bbox),
+        )
+        return (await test_db_session.execute(stmt)).scalar_one_or_none() is not None
+
+    # A crossing query bbox, and one bbox wholly inside each hemisphere half.
+    assert await _matches([175.0, -19.0, -175.0, -16.0]) is True
+    assert await _matches([175.0, -19.0, 179.0, -16.0]) is True
+    assert await _matches([-179.0, -19.0, -175.0, -16.0]) is True
+    # Central France stays a miss through the query path too.
+    assert await _matches([1.5, 46.5, 2.5, 47.5]) is False

--- a/backend/tests/test_antimeridian_extent.py
+++ b/backend/tests/test_antimeridian_extent.py
@@ -372,3 +372,58 @@ async def test_make_bbox_filter_finds_a_seam_extent_from_either_side(
     assert await _matches([-179.0, -19.0, -175.0, -16.0]) is True
     # Central France stays a miss through the query path too.
     assert await _matches([1.5, 46.5, 2.5, 47.5]) is False
+
+
+# ---------------------------------------------------------------------------
+# Which surfaces get which form
+# ---------------------------------------------------------------------------
+
+
+def test_map_layer_response_bbox_stays_monotonic():
+    """fix(#892 codex P2): ``dataset_extent_bbox`` is documented as
+    ``[minx, miny, maxx, maxy]`` and feeds map viewers, not a standards
+    serializer.
+
+    A west > east pair there breaks three things at once. MapLibre bounds the
+    layer's tile source to no tiles at all (``map-sync.ts``), so a seam-crossing
+    layer renders blank; the builder's auto-fit and Zoom to Layer both reject an
+    inverted bbox and silently do nothing. Build the response for real, so this
+    holds through any refactor of the helper.
+    """
+    from app.modules.catalog.maps._router_helpers import _build_layer_response
+    from app.modules.catalog.maps.models import MapLayer
+
+    layer = MapLayer(
+        id=uuid.uuid4(),
+        dataset_id=uuid.uuid4(),
+        display_name="Fiji Seam Crosser",
+        sort_order=0,
+        visible=True,
+        opacity=1.0,
+        paint={},
+        layout={},
+        filter=None,
+        label_config=None,
+        popup_config=None,
+        style_config=None,
+        show_in_legend=True,
+    )
+    resp = _build_layer_response(layer, {"extent": _extent(SEAM_MULTIPOLYGON)})
+    assert resp.dataset_extent_bbox == [-180.0, -20.0, 180.0, -15.0]
+    assert resp.dataset_extent_bbox[0] < resp.dataset_extent_bbox[2]
+
+
+def test_standards_record_bbox_keeps_the_spec_form():
+    """The mirror of the above, also behavioral: ``extract_bbox`` backs the
+    STAC/OGC record ``bbox``, which must NOT be moved to the span or a
+    seam-crossing dataset advertises a global footprint again."""
+    from types import SimpleNamespace
+
+    from app.modules.catalog.datasets.domain.utils import extract_bbox
+
+    dataset = SimpleNamespace(
+        record=SimpleNamespace(spatial_extent=_extent(SEAM_MULTIPOLYGON))
+    )
+    bbox = extract_bbox(dataset)
+    assert bbox == [170.0, -20.0, -170.0, -15.0]
+    assert bbox[0] > bbox[2]

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -1037,8 +1037,10 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # fix(#474): thread negotiated languages through catalog search, cache keys,
     # and OGC record serialization; fix(#475) adds Records array-query handling,
     # including collection IDs, plus response-header and documented 400 parity.
-    # Ratchet stays exact.
-    "backend/app/modules/catalog/search/router.py": 1428,
+    # fix(#892): +4 — the per-dataset OGC collection extent moved off a bare
+    # to_shape().bounds read onto extent_to_bbox() so a seam-crossing extent
+    # serves the RFC 7946 west > east bbox. Ratchet stays exact.
+    "backend/app/modules/catalog/search/router.py": 1432,
     # fix(#474): negotiate localized STAC record text; fix(#475) adds the
     # unassigned Collection and matching HTTP Link navigation. fix(#506): keep
     # validated STAC item responses wire-compatible with serializer output.
@@ -1053,8 +1055,11 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # pasted family literals. Same +1 on the stac and search routers.
     # fix(#868): +3 lines for the cluster cache-key SQL-semantics version
     # ("v2") so deploys that change cluster tile geometry invalidate Valkey.
-    # Merge of the two carve-outs: 2043 base + 3 + 1. Ratchet stays exact.
-    "backend/app/processing/tiles/router.py": 2047,
+    # fix(#892): +2 — the raster tile-token bounds moved onto
+    # extent_to_span_bbox() so a seam-crossing extent cannot feed a negative
+    # span into the maxzoom derivation.
+    # Merge of the carve-outs: 2043 base + 3 + 1 + 2. Ratchet stays exact.
+    "backend/app/processing/tiles/router.py": 2049,
 }
 
 

--- a/backend/tests/test_stac_import.py
+++ b/backend/tests/test_stac_import.py
@@ -515,6 +515,13 @@ class TestStacImport:
         assert row.hits_south_atlantic is False
         assert row.hits_france is False
 
+        # fix(#892 codex P2): the dataset payload's own extent_bbox stays
+        # monotonic, because DatasetMap draws an unguarded planar ring from it and
+        # calls fitBounds. The spec form lives on the STAC/OGC surfaces instead.
+        detail = await client.get(f"/datasets/{dataset_id}", headers=admin_auth_header)
+        assert detail.status_code == 200
+        assert detail.json()["extent_bbox"] == [-180.0, -20.0, 180.0, -15.0]
+
     async def test_import_duplicate_skipped(
         self,
         client: AsyncClient,

--- a/backend/tests/test_stac_import.py
+++ b/backend/tests/test_stac_import.py
@@ -14,6 +14,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from httpx import AsyncClient
+from sqlalchemy import text
 
 
 # ---------------------------------------------------------------------------
@@ -414,6 +415,105 @@ class TestStacImport:
         assert data["errors"] == 0
         assert data["results"][0]["status"] == "created"
         assert data["results"][0]["dataset_id"] is not None
+
+    async def test_import_antimeridian_bbox_stores_two_rings(
+        self,
+        client: AsyncClient,
+        admin_auth_header: dict,
+        mock_stac_ssrf,
+        test_db_session,
+    ):
+        """fix(#884): RFC 7946 §5.2 mandates west > east for a crossing bbox, and
+        the old code fed [170, -20, -170, -15] straight into
+        POLYGON((w s, e s, e n, w n, w s)). That ring is valid but spans longitude
+        -170..170: 1700 deg² on the wrong side of the world instead of the
+        intended 100, missing the Fiji data it was supposed to describe while
+        matching everything else in the -20..-15 latitude band.
+
+        Every other STAC fixture in this file is low-lon; this is the only
+        crossing one.
+        """
+        from geoalchemy2 import WKTElement
+
+        from app.core.geo import extent_to_bbox
+
+        item_id = f"antimeridian-{uuid.uuid4().hex[:8]}"
+        resp = await client.post(
+            "/services/stac/import",
+            json={
+                "url": "https://stac.example.com/v1",
+                "items": [
+                    {
+                        "id": item_id,
+                        "collection": "fiji-collection",
+                        "title": "Fiji Seam Crosser",
+                        "data_asset_href": (f"https://example.com/data/{item_id}.tif"),
+                        # west > east: the spec encoding of a crossing bbox.
+                        "bbox": [170, -20, -170, -15],
+                        "epsg": 4326,
+                        "keywords": [],
+                    }
+                ],
+                "visibility": "private",
+            },
+            headers=admin_auth_header,
+        )
+        assert resp.status_code == 200
+        assert resp.json()["created"] == 1
+        dataset_id = resp.json()["results"][0]["dataset_id"]
+
+        row = (
+            await test_db_session.execute(
+                text(
+                    "SELECT GeometryType(r.spatial_extent) AS gtype,"
+                    " ST_NumGeometries(r.spatial_extent) AS parts,"
+                    " ST_IsValid(r.spatial_extent) AS valid,"
+                    " ST_XMin(r.spatial_extent) AS xmin,"
+                    " ST_XMax(r.spatial_extent) AS xmax,"
+                    " ST_AsText(r.spatial_extent) AS extent_wkt,"
+                    " ST_Area(r.spatial_extent) AS area,"
+                    " ST_Intersects("
+                    "   r.spatial_extent, ST_MakeEnvelope(177, -19, 179, -16, 4326)"
+                    " ) AS hits_fiji,"
+                    " ST_Intersects("
+                    "   r.spatial_extent, ST_MakeEnvelope(-1, -19, 1, -16, 4326)"
+                    " ) AS hits_south_atlantic,"
+                    " ST_Intersects("
+                    "   r.spatial_extent, ST_MakeEnvelope(1.5, 46.5, 2.5, 47.5, 4326)"
+                    " ) AS hits_france"
+                    " FROM catalog.records r"
+                    " JOIN catalog.datasets d ON d.record_id = r.id"
+                    " WHERE d.id = :did"
+                ).bindparams(did=uuid.UUID(dataset_id))
+            )
+        ).one()
+
+        # Split at the seam into one part per hemisphere, each planar-valid.
+        assert row.gtype == "MULTIPOLYGON"
+        assert row.parts == 2
+        assert row.valid is True
+        # Every vertex stays inside the WGS84 domain.
+        assert row.xmin == -180.0
+        assert row.xmax == 180.0
+        # 10° west of the seam plus 10° east over a 5° band, not the old 1700.
+        assert row.area == pytest.approx(100.0)
+
+        # The served bbox is the spec form the item arrived in — a round trip,
+        # not a globe-spanning -180..180.
+        assert extent_to_bbox(WKTElement(row.extent_wkt, srid=4326)) == [
+            170.0,
+            -20.0,
+            -170.0,
+            -15.0,
+        ]
+
+        # The two assertions that discriminate old from new: the extent now covers
+        # the data it describes, and no longer covers the same latitude band on the
+        # far side of the world. (hits_france was False under the old ring too —
+        # latitude 47 fell outside the band — so it is only a sanity check.)
+        assert row.hits_fiji is True
+        assert row.hits_south_atlantic is False
+        assert row.hits_france is False
 
     async def test_import_duplicate_skipped(
         self,


### PR DESCRIPTION
`records.spatial_extent` was `geometry(Polygon, 4326)`. RFC 7946 §5.2 and STAC
express an antimeridian-crossing extent as a bbox with west > east, and a single
planar 4326 ring cannot encode that. So a dataset that genuinely straddles the
seam could only ever register a globe-spanning `-180..180` extent.

The STAC remote-import path fed a spec-compliant `[170, -20, -170, -15]` straight
into `POLYGON((w s, e s, e n, w n, w s))`. One correction to #884's description,
verified rather than assumed: that ring is **not** self-intersecting. It is a
valid simple rectangle spanning longitude -170..170, which is worse in a quieter
way. It covers 1700 deg² of the wrong side of the world instead of the intended
100, it does not contain the Fiji data it describes, and it matches anything else
in the same -20..-15 latitude band. Those are the properties the tests assert,
which is also why the "France" probe from the issue needed replacing. See the
Tests section.

The rest of the antimeridian class (#886, #887, #888, #891) builds on this, so
the representation and the shared helper are the substance here.

## What changed

### Schema: `0030_records_spatial_extent_type`

`catalog.records.spatial_extent` becomes `geometry(Geometry, 4326)`, plus a new
`chk_records_spatial_extent_type` CHECK limiting it to
`GeometryType(...) IN ('POLYGON','MULTIPOLYGON')` (NULL still allowed).
`spatial_index=False` and the explicit `idx_records_spatial_extent` GiST index in
`__table_args__` are unchanged; the `ALTER COLUMN TYPE` rewrite rebuilds the index
in place.

### Serving choke point: `backend/app/core/geo.py`

Three helpers. No class, no config.

`extent_to_bbox()` is the RFC 7946 §5.2 / STAC bbox. It now recognizes the
two-ring seam form (exactly two parts, one flush at +180 and one at -180, same
latitude band, non-overlapping in longitude) and returns west > east. Anything
else keeps the previous bare `.bounds` behavior, including the broad except that
falls back to `None`.

One contract detail for #886, documented in `_seam_split_bbox`'s docstring: the
two halves must share a single latitude band. A rollup that unions two crossing
extents with different latitude spans produces two parts the detector will not
recognize, and the caller then gets the honest but over-broad `-180..180`. Fold to
a common band first, or build the rings from an already-folded bbox through
`bbox_to_extent_wkt`.

`extent_to_span_bbox()` returns monotonic planar bounds (west <= east) for callers
that must not receive an inverted pair: span subtraction, planar WKT rings, tile
source bounds. A crossing extent is honestly `-180..180` in that form.

`bbox_to_extent_wkt()` is the producer. It splits a west > east bbox into
`west..180` and `-180..east`, and round-trips through `extent_to_bbox()`.

### Producer (#884)

`sources/stac_router.py` now calls `bbox_to_extent_wkt()` instead of pasting
`POLYGON((w s, e s, e n, w n, w s))`. `sources/adapters/stac.py` needs no sibling
branch: it only passes bbox *lists* through for collection browse and item search.
`stac_router.py:545` is the module's only extent writer.

### Readers redirected

Each with a deliberate spec-vs-span call:

| Site | Choice | Why |
| --- | --- | --- |
| `standards/ogc/router.py:316` | spec (already called `extent_to_bbox`) | OGC API - Features collection extents use the GeoJSON bbox convention |
| `modules/catalog/search/router.py:794` | spec | same, for the collection-list variant |
| `modules/catalog/datasets/domain/utils.py:12` (`extract_bbox`) | spec | both consumers are spec surfaces: the STAC/OGC record `bbox` and the AI dataset-context `extent_bbox` |
| `processing/ai/metadata_service.py:109` | spec, plus an explicit "(crosses the antimeridian)" note | the prompt label is literally "W, S, E, N", and `-180..180` would tell the model the dataset is global |
| `processing/tiles/router.py:1197` | span | feeds `_raster_maxzoom_from_metadata`'s `maxx - minx`, where a west > east pair goes negative and collapses the derived maxzoom. The same value is the tile source's own bounds |
| `standards/dcat/service.py:358` | span | `dcat:bbox` is a planar WKT ring, so a ring built from a west > east pair is the same complement bug in a different format |
| `standards/dcat_us/service.py:285` | span | same |
| `standards/geodcat_ap/service.py:346` | span | same, for the GeoSPARQL `wktLiteral` |

`modules/catalog/search/service_records.py:230` (`mapping(to_shape(...))` into a
GeoJSON `geometry`) needs no change. MultiPolygon is valid GeoJSON, confirmed
against `shapely.geometry.mapping` and against the sibling `ST_AsGeoJSON` path in
the same function.

## Why this representation

Three options were on the table in #892. This is option 1, with plain `Geometry`
rather than `MultiPolygon`:

1. A geometry column beats scalar `bbox_west`/`bbox_east`. `make_bbox_filter()` in
   `core/geo.py` already splits a west > east *query* bbox into two ORed
   envelopes, so a stored two-ring MULTIPOLYGON yields correct `ST_Intersects`
   results and keeps the GiST index in play. Scalar bbox columns cannot
   participate in the spatial filter at all, and they create two sources of truth
   that drift. `test_make_bbox_filter_finds_a_seam_extent_from_either_side` pins
   that pairing.
2. Plain `Geometry` typmod, not `MultiPolygon`. Every existing non-crossing extent
   stays a POLYGON, byte-identical. No blanket `ST_Multi` promotion, so no churn
   in the many tests that assert POLYGON WKT, and `get_extent`'s degenerate
   `ST_Expand` padding for POINT/LINESTRING inputs is untouched.
3. The CHECK constraint preserves a real guard. The old POLYGON typmod once caught
   a bug where an extent-write path tried to store a POINT and 500'd. Widening the
   column without the constraint would have given that up.

Known ceiling, documented inline on the index declaration: a two-part
seam-crossing MULTIPOLYGON has a `-180..180` GiST bounding box, so the index
degrades to a full-candidate scan for those rows only. The `ST_Intersects` recheck
still filters correctly, so results are right, just less indexed.

## Schema impact

Migration required. `0030_records_spatial_extent_type`, with
`down_revision = "0029_api_key_hardening"` (the previous head). One
`ALTER COLUMN TYPE` rewrite of `catalog.records` plus one CHECK.

`downgrade()` refuses rather than coerces. Narrowing back to POLYGON has no
lossless answer for a two-ring extent: the only POLYGON that contains it is
`-180..180`, which silently re-registers the globe-spanning extent this migration
exists to eliminate. So the downgrade counts MULTIPOLYGON rows and, if any exist,
raises with the SQL to inspect them and the explicit `ST_Envelope` UPDATE to run
if the operator accepts the loss. With no MULTIPOLYGON rows, which is every
pre-upgrade database, it downgrades cleanly.

No API or OpenAPI change. `make openapi-check` is clean and no SDK regen is
needed.

No wire-format change either. `extent_bbox` (dataset detail) and
`dataset_extent_bbox` (map layer) stay monotonic, so their documented
"[minx, miny, maxx, maxy]" contract remains accurate and no frontend work is a
prerequisite for merging. That is a correction from the first push; see the Codex
review section.

## Verification

All run on the host against Postgres at `localhost:5434`, not through
`docker compose exec api` (which bind-mounts the main checkout).

```
$ cd backend && uv run ruff check .
All checks passed!

$ cd backend && uv run ruff format --check .
848 files already formatted
```

Full backend suite:

```
$ uv run pytest -n 4 -q            # after the Codex fix below
6005 passed, 81 skipped, 262 warnings in 546.32s (0:09:06)
```

New and updated tests on their own, plus the DCAT serializers:

```
$ uv run pytest tests/test_antimeridian_extent.py tests/test_stac_import.py tests/test_layering.py tests/test_dcat.py tests/test_geodcat_ap.py -q
123 passed, 43 warnings in 33.55s
```

ORM/migration drift gate. This is `make alembic-check`'s in-suite equivalent: it
shells out to `alembic check` against a test DB migrated to head, so it exercises
`0030`.

```
$ uv run pytest "tests/test_dormant_tenancy_migration_roundtrip.py::TestAlembicCheckNoDrift::test_alembic_check_no_drift" -q
1 passed, 6 warnings in 2.69s
```

OpenAPI snapshot:

```
$ PYTHONPATH=. uv run python scripts/dump_openapi.py --check
EXIT=0
```

Manual migration round-trip on a throwaway database:

```
===== upgrade head
INFO  [alembic.runtime.migration] Running upgrade 0029_api_key_hardening -> 0030_records_spatial_extent_type, Widen catalog.records.spatial_extent to generic geometry + a type CHECK.
===== typmod after upgrade
GEOMETRY|4326
chk_records_spatial_extent_type
CREATE INDEX idx_records_spatial_extent ON catalog.records USING gist (spatial_extent)
===== downgrade -1 with NO multipolygon rows (should succeed)
INFO  [alembic.runtime.migration] Running downgrade 0030_records_spatial_extent_type -> 0029_api_key_hardening, ...
POLYGON
0
CREATE INDEX idx_records_spatial_extent ON catalog.records USING gist (spatial_extent)
===== re-upgrade, insert a MULTIPOLYGON, downgrade again (should REFUSE)
RuntimeError: 1 catalog.records row(s) hold a MULTIPOLYGON spatial_extent, which geometry(Polygon, 4326) cannot store. Downgrading would have to replace each one with its -180..180 envelope, losing the antimeridian-crossing extent. Inspect them with:
  SELECT id, title, ST_AsText(spatial_extent) FROM catalog.records WHERE GeometryType(spatial_extent) = 'MULTIPOLYGON';
If that loss is acceptable, run this first, then re-run the downgrade:
  UPDATE catalog.records SET spatial_extent = ST_Envelope(spatial_extent) WHERE GeometryType(spatial_extent) = 'MULTIPOLYGON';
downgrade exit code: 1
GEOMETRY
```

## Tests

`backend/tests/test_antimeridian_extent.py` is new:

- `extent_to_bbox` over an ordinary POLYGON, a two-part seam crosser (west >
  east), a genuine non-seam two-part MULTIPOLYGON, seam halves over *different*
  latitude bands, a whole-world POLYGON, a three-part MULTIPOLYGON that happens to
  contain a seam pair, a degenerate padded envelope, and None/garbage. The
  negative cases are the ones that matter: the detector must not invent a crossing
  bbox.
- `extent_to_span_bbox` stays monotonic on the crosser.
- `bbox_to_extent_wkt` round-trips through `extent_to_bbox`, and degenerate
  crossing inputs (`west == 180`, `east == -180`, both) drop the zero-width half
  instead of emitting an invalid ring.
- `chk_records_spatial_extent_type` accepts POLYGON, MULTIPOLYGON, and NULL, and
  rejects POINT, LINESTRING, and GEOMETRYCOLLECTION. The column typmod really is
  `GEOMETRY|4326`, and the GiST index survived the rewrite.
- The stored two-ring extent covers 100 deg², intersects a Fiji-area bbox and one
  just east of the seam, and misses a same-latitude bbox in the South Atlantic,
  both directly and through `make_bbox_filter`.

`backend/tests/test_stac_import.py` gains
`test_import_antimeridian_bbox_stores_two_rings`, which imports a west > east item
end to end (every other STAC fixture in the file is low-lon), then asserts a
2-part valid MULTIPOLYGON, `ST_Area` of 100 rather than 1700, a west > east served
bbox, `hits_fiji is True`, and `hits_south_atlantic is False`.

A note on the probe geometry, because the obvious test is a no-op. A bbox over
central France (lon 2, lat 47) does not discriminate: at latitude 47 it fell
outside the old ring's -20..-15 band too, so `hits_france is False` passes both
before and after the fix. The assertions that actually fail on the old ring are
`hits_fiji` (False before, since the old extent excluded lon 178) and
`hits_south_atlantic` (True before, at lon 0 in the same latitude band). Both
tests carry that reasoning inline so the France probe is not mistaken for the
regression guard.

`backend/tests/test_layering.py`: `_MODULE_LOC_CAPS` ratchets updated exactly
(`search/router.py` 1428 to 1432, `tiles/router.py` 2047 to 2049) with anchored
context.

`backend/tests/test_analysis_materialize.py` is comment-only. The existing
assertion that the analysis extent is still a POLYGON is unchanged and still
passes; teaching that rollup to emit a two-ring extent is a separate follow-up.
Only the prose claiming the column "cannot hold" a west > east bbox was corrected.

## Out of scope, and gaps found on the way

- No open issue owns the frontend side, and one is worth filing before anyone
  moves the map-facing fields to the spec form. Three unguarded or
  guard-and-skip consumers: `normalizeRasterBounds`
  (`layer-adapters/shared.ts:60`) has no `bounds[0] > bounds[2]` check, so an
  inverted bbox reaches a MapLibre source `bounds` (`map-sync.ts:1007`) that
  matches no tile; `DatasetMap.tsx:563` builds a planar ring from the bbox with
  no ordering check, and its `isLargeExtent` test (`lib/map-extent.ts:21`)
  computes `maxx - minx`, which goes negative and routes an inverted bbox into
  `fitBounds` instead of the large-extent `flyTo`. The builder's two fit-bounds
  sites (`BuilderMap.tsx:107`, `use-builder-layers.ts:438`) do guard, but by
  skipping, which silently disables auto-fit and Zoom to Layer.
- A zero-height bbox (`south == north`) still yields an invalid zero-area ring.
  That is pre-existing behavior on the non-crossing path, unchanged here, and now
  matched on the crossing path.
- The analysis-side extent fold (`platform/analysis_sql.py` and
  `processing/ingest/metadata.py`'s `get_extent`) still writes a `-180..180`
  POLYGON for a seam-crossing dataset. It can now write two rings, but does not
  yet. #886 / #891.
- The multi-record **rollup** folds are deliberately untouched, all owned by #886
  and its siblings. They fold many extents into one bbox, which is a different
  decision from reading a single record, and doing both in one PR would make the
  merge train collide. For the record, the full list I left alone:
  `modules/catalog/search/router.py:571` and `modules/catalog/collections/service.py:312`
  (`ST_Envelope(ST_Collect(...))`), `standards/stac/router.py:635-638` and `:855-858`
  (`ST_XMin/XMax(ST_Extent(...))`), and `processing/ai/service.py:549` (the
  map-spec centroid fold). None of them break under the widened column:
  `ST_Collect`/`ST_Extent` accept MULTIPOLYGON, and each still yields the same
  `-180..180` answer it did before.
- Four comments in out-of-scope files now assert something this PR makes false,
  and should be corrected by whoever lands the owning issue:
  `platform/analysis_sql.py:170-176` (the "needs a schema change" note that #892
  was filed from), `processing/ingest/metadata.py:343` and `:886`, and
  `modules/catalog/features/service.py:620`. All four still describe
  `spatial_extent` as a POLYGON-only column. Their code paths are unaffected:
  every one of them writes an `ST_Extent`-derived POLYGON, which the new CHECK
  still accepts.

## Codex review

One P2 finding, and it was right and worse than described, so it changed a
decision rather than just adding a guard.

**Finding.** With `extent_to_bbox` on `dataset_extent_bbox`, a seam-crossing
dataset made the builder's auto-fit and Zoom to Layer no-ops, because both sites
reject `bbox[0] > bbox[2]`.

**Verified further.** Two consumers Codex did not name are worse than a skipped
control. `map-sync.ts:1007` puts that same value into a MapLibre vector/raster
source `bounds`, where an inverted pair matches no tile, so the layer would
render blank. And on the dataset page, `DatasetMap.tsx:563` builds a planar ring
from `extent_bbox` with no ordering guard, which would *draw* the complementary
340° rectangle, plus `isLargeExtent` computes `maxx - minx` (negative here) and
so routes an inverted bbox into `fitBounds` rather than the large-extent `flyTo`.

**Resolution.** I had mis-classified both fields. They are not standards
surfaces: they are GeoLens's own payloads, documented as
`[minx, miny, maxx, maxy]`, read by map viewers. Both now use
`extent_to_span_bbox`:

- `modules/catalog/maps/_router_helpers.py:111` (`dataset_extent_bbox`, whose
  MVT-06 purpose is literally to bound tile fetching)
- `modules/catalog/datasets/domain/helpers.py:177` (`extent_bbox`)

The spec form stays exactly where a spec demands it: the STAC/OGC record `bbox`
via `extract_bbox`, the two OGC collection extents, and the AI prompt. So a
seam-crossing dataset now behaves in the viewer exactly as it does today
(over-broad `-180..180` fit, tiles fetched, controls working) while the standards
output is correct.

Two tests pin the split so it cannot be silently reverted, both behavioral
rather than source-grepping: `test_map_layer_response_bbox_stays_monotonic`
builds a real `MapLayerResponse` from a seam extent and asserts the bbox is
monotonic, and `test_standards_record_bbox_keeps_the_spec_form` asserts
`extract_bbox` still returns west > east. The STAC import test also now asserts
end to end that `GET /datasets/{id}` returns `extent_bbox == [-180, -20, 180, -15]`
for the crossing item.

A side effect worth noting: this removed the OpenAPI-description follow-up from
the list above. `[minx, miny, maxx, maxy]` is accurate again for both fields, so
no description edit and no SDK regen are needed.

Closes #892
Closes #884



