### PR TITLE
fix(raster): normalize COG and VRT bounds across the antimeridian

### DIFF
--- a/backend/app/core/geo.py
+++ b/backend/app/core/geo.py
@@ -105,6 +105,26 @@ def extent_to_span_bbox(extent: object | None) -> list[float] | None:
         return None
 
 
+def extent_lon_span(extent: object | None) -> float | None:
+    """Longitudinal width of an extent in degrees, honest across ±180.
+
+    fix(#887): the companion to :func:`extent_to_span_bbox` for consumers that
+    need the *width* rather than a monotonic pair. ``extent_to_span_bbox``
+    reports -180..180 for a seam-crossing extent, so a caller that derives pixel
+    resolution from ``maxx - minx`` reads a 10°-wide Pacific raster as 360° wide
+    and understates its native resolution by 36x -- which cost the raster
+    tile-source five zoom levels of maxzoom, so it stopped rendering as the user
+    zoomed in. Read the RFC 7946 §5.2 ``west > east`` pair instead and close it
+    the short way round.
+    """
+    bbox = extent_to_bbox(extent)
+    if bbox is None:
+        return None
+    west, _, east, _ = bbox
+    span = east - west
+    return span + 360.0 if span < 0 else span
+
+
 def _ring(x0: float, south: float, x1: float, north: float) -> str:
     return f"({x0} {south},{x1} {south},{x1} {north},{x0} {north},{x0} {south})"
 

--- a/backend/app/core/geo.py
+++ b/backend/app/core/geo.py
@@ -105,6 +105,20 @@ def extent_to_span_bbox(extent: object | None) -> list[float] | None:
         return None
 
 
+# fix(#887): the shared floor for any float comparison that gates a longitude
+# shift, a re-frame, or a domain choice. Adding and subtracting 360, or
+# reconstructing an edge from a serialized pixel offset, is not bit-exact, so
+# values describing the SAME edge routinely disagree by ~1e-14 degrees. A bare
+# `<` then lets that noise decide a branch that moves geometry by a third of a
+# world. This batch hit it three times -- ``_narrower_domain`` in the rollup
+# folds (#886/#928), the VRT frame chooser, and the VRT frame rewrite -- so the
+# constant lives here and every such site imports it instead of inventing a bare
+# comparison. 1e-9 degrees is ~0.1 mm: orders of magnitude above the noise,
+# orders below any real distinction. ``_SEAM_TOL`` and ``_DOMAIN_MARGIN`` above
+# are the same value applied locally.
+LON_EPSILON_DEGREES = 1e-9
+
+
 def extent_lon_span(extent: object | None) -> float | None:
     """Longitudinal width of an extent in degrees, honest across ±180.
 

--- a/backend/app/processing/raster/cog.py
+++ b/backend/app/processing/raster/cog.py
@@ -4,7 +4,7 @@ import hashlib
 import tempfile
 from pathlib import Path
 
-from app.core.geo import bbox_to_extent_wkt, wrap_longitude
+from app.core.geo import LON_EPSILON_DEGREES, bbox_to_extent_wkt, wrap_longitude
 from app.processing.raster.vrt import gdal_safe_env, run_gdal
 
 
@@ -71,9 +71,12 @@ def _fold_geographic_bbox(
     ``bbox_to_extent_wkt`` turns that pair into the two-ring extent.
     """
     span = east - west
-    if span >= 360.0:
+    if span >= 360.0 - LON_EPSILON_DEGREES:
         # The footprint wraps the whole world. -180..180 is the honest answer
-        # and the only one a single ring can express.
+        # and the only one a single ring can express. The tolerance matters: a
+        # 0..360 global raster whose span measures 359.99999999999994 would
+        # otherwise fall through and be re-expressed as a west > east pair, i.e.
+        # a domain flip decided by last-bit noise.
         return (-180.0, south, 180.0, north)
     # One fold is enough at both sites: `west` is a raster's own left edge, which
     # sits within a single wrap of range for any real geographic grid, and `span`

--- a/backend/app/processing/raster/cog.py
+++ b/backend/app/processing/raster/cog.py
@@ -4,10 +4,24 @@ import hashlib
 import tempfile
 from pathlib import Path
 
+from app.core.geo import bbox_to_extent_wkt
 from app.processing.raster.vrt import gdal_safe_env, run_gdal
 
 
 _FLOAT_DTYPES = {"float32", "float64", "float16", "float", "complex"}
+
+# fix(#887): a footprint that wraps the whole world puts its left and right
+# edges on the SAME meridian, so transform_bounds can only report a zero-width
+# longitude range for it. Recognizing that needs an equality test, and the
+# tolerance is deliberately tight: a 2 m-wide sliver in EPSG:3832 still reports
+# 1.8e-5° of width, four orders of magnitude above this.
+_LON_DEGENERATE_TOL = 1e-9
+
+# fix(#887): second condition on the same check. A wrapping footprint puts the
+# raster centre a long way from that edge meridian (exactly 180° for a full
+# 360° wrap); a genuine zero-width sliver puts it right on top of it. Any
+# threshold between the two works -- 1° is comfortably clear of both.
+_WRAP_PROBE_MIN_DEGREES = 1.0
 
 
 def _is_float_dtype(dtype: str) -> bool:
@@ -44,32 +58,104 @@ def validate_raster_crs(file_path: str) -> None:
             )
 
 
+def _wrap180(lon: float) -> float:
+    """Fold a longitude into [-180, 180)."""
+    return ((lon + 180.0) % 360.0) - 180.0
+
+
+def _fold_geographic_bbox(
+    west: float, south: float, east: float, north: float
+) -> tuple[float, float, float, float]:
+    """Fold a geographic-CRS longitude range into the RFC 7946 §5.2 form.
+
+    fix(#887): GDAL passes geographic bounds through ``transform_bounds``
+    untouched, so a raster stored in the 0..360 longitude domain -- what plenty
+    of published global grids use, and what the seam-aware VRT builder in
+    ``vrt.py`` now emits for a straddling mosaic -- keeps an east past +180.
+    Wrap it, and let east fall *below* west when the footprint crosses the seam;
+    ``bbox_to_extent_wkt`` turns that pair into the two-ring extent.
+    """
+    span = east - west
+    if span >= 360.0:
+        # The footprint wraps the whole world. -180..180 is the honest answer
+        # and the only one a single ring can express.
+        return (-180.0, south, 180.0, north)
+    west = _wrap180(west)
+    east = west + span
+    if east > 180.0:
+        east -= 360.0
+    return (west, south, east, north)
+
+
+def _wgs84_bbox(src) -> tuple[float, float, float, float]:
+    """Reproject a raster's bounds to a WGS84 RFC 7946 §5.2 bbox.
+
+    Returns ``(west, south, east, north)`` with ``west > east`` when the
+    footprint crosses the antimeridian -- feed it to
+    :func:`app.core.geo.bbox_to_extent_wkt`, never to a hand-built ring.
+
+    fix(#887): the old code folded the reprojected bounds straight into a single
+    ``POLYGON``. GDAL's ``OCTTransformBounds`` already reports a seam-crossing
+    footprint as ``west > east`` (a Pacific COG in EPSG:3832 comes back as
+    175..-175), and a naive ring over that pair is a *valid* rectangle covering
+    the 350° on the wrong side of the world -- 35x the real footprint, not even
+    containing the data it describes.
+    """
+    from rasterio.warp import transform, transform_bounds
+
+    crs = src.crs
+    bounds = (
+        src.bounds.left,
+        src.bounds.bottom,
+        src.bounds.right,
+        src.bounds.top,
+    )
+    if crs is None:
+        # Without a CRS these are not longitudes at all (validate_raster_crs
+        # rejects such rasters at ingest), so there is nothing to normalize.
+        return bounds
+
+    if crs.to_epsg() == 4326:
+        return _fold_geographic_bbox(*bounds)
+
+    west, south, east, north = transform_bounds(crs, "EPSG:4326", *bounds)
+
+    # The one footprint transform_bounds cannot express is one that wraps the
+    # whole world: its left and right edges land on the same meridian, so the
+    # longitude range comes back zero-width (a global EPSG:3832 raster reads
+    # -30..-30) and the globe would register as a line. TWO conditions gate the
+    # repair, because either alone misfires: the range must be degenerate AND
+    # the raster centre must sit far from that edge meridian, which only a wrap
+    # produces -- a genuine zero-width source has its centre on the meridian.
+    if abs(east - west) <= _LON_DEGENERATE_TOL and bounds[2] > bounds[0]:
+        (center_lon,), _ = transform(
+            crs,
+            "EPSG:4326",
+            [(bounds[0] + bounds[2]) / 2],
+            [(bounds[1] + bounds[3]) / 2],
+        )
+        if abs(_wrap180(center_lon - west)) > _WRAP_PROBE_MIN_DEGREES:
+            return (-180.0, south, 180.0, north)
+
+    return _fold_geographic_bbox(west, south, east, north)
+
+
 def extract_raster_metadata(file_path: str) -> dict:
-    """Extract all raster metadata from a file using a single rasterio open pass."""
+    """Extract all raster metadata from a file using a single rasterio open pass.
+
+    ``bounds_wgs84`` is an RFC 7946 §5.2 bbox: ``west > east`` for a footprint
+    that crosses the antimeridian (fix(#887)). Callers that need a monotonic
+    span must close it the short way round, not subtract blindly.
+    """
     import rasterio
-    from rasterio.warp import transform_bounds
 
     with rasterio.open(file_path) as src:
         crs = src.crs
         crs_wkt = crs.to_wkt() if crs else None
         epsg = crs.to_epsg() if crs else None
 
-        # Transform bounds to WGS84
-        if crs and crs.to_epsg() != 4326:
-            bounds_wgs84 = transform_bounds(crs, "EPSG:4326", *src.bounds)
-        else:
-            bounds_wgs84 = (
-                src.bounds.left,
-                src.bounds.bottom,
-                src.bounds.right,
-                src.bounds.top,
-            )
-
-        left, bottom, right, top = bounds_wgs84
-        bbox_wkt = (
-            f"POLYGON(({left} {bottom}, {right} {bottom}, "
-            f"{right} {top}, {left} {top}, {left} {bottom}))"
-        )
+        bounds_wgs84 = _wgs84_bbox(src)
+        bbox_wkt = bbox_to_extent_wkt(*bounds_wgs84)
 
         res_x = abs(src.transform.a)
         res_y = abs(src.transform.e)

--- a/backend/app/processing/raster/cog.py
+++ b/backend/app/processing/raster/cog.py
@@ -4,7 +4,7 @@ import hashlib
 import tempfile
 from pathlib import Path
 
-from app.core.geo import bbox_to_extent_wkt
+from app.core.geo import bbox_to_extent_wkt, wrap_longitude
 from app.processing.raster.vrt import gdal_safe_env, run_gdal
 
 
@@ -58,11 +58,6 @@ def validate_raster_crs(file_path: str) -> None:
             )
 
 
-def _wrap180(lon: float) -> float:
-    """Fold a longitude into [-180, 180)."""
-    return ((lon + 180.0) % 360.0) - 180.0
-
-
 def _fold_geographic_bbox(
     west: float, south: float, east: float, north: float
 ) -> tuple[float, float, float, float]:
@@ -80,10 +75,13 @@ def _fold_geographic_bbox(
         # The footprint wraps the whole world. -180..180 is the honest answer
         # and the only one a single ring can express.
         return (-180.0, south, 180.0, north)
-    west = _wrap180(west)
-    east = west + span
-    if east > 180.0:
-        east -= 360.0
+    # One fold is enough at both sites: `west` is a raster's own left edge, which
+    # sits within a single wrap of range for any real geographic grid, and `span`
+    # is under 360 by the branch above. wrap_longitude leaves +180 as +180, which
+    # bbox_to_extent_wkt already handles -- it drops the zero-width 180..180 half
+    # and emits the -180..east ring alone.
+    west = wrap_longitude(west)
+    east = wrap_longitude(west + span)
     return (west, south, east, north)
 
 
@@ -134,7 +132,7 @@ def _wgs84_bbox(src) -> tuple[float, float, float, float]:
             [(bounds[0] + bounds[2]) / 2],
             [(bounds[1] + bounds[3]) / 2],
         )
-        if abs(_wrap180(center_lon - west)) > _WRAP_PROBE_MIN_DEGREES:
+        if abs(wrap_longitude(center_lon - west)) > _WRAP_PROBE_MIN_DEGREES:
             return (-180.0, south, 180.0, north)
 
     return _fold_geographic_bbox(west, south, east, north)

--- a/backend/app/processing/raster/cog.py
+++ b/backend/app/processing/raster/cog.py
@@ -1,6 +1,7 @@
 """COG compliance check, conversion, and raster metadata extraction."""
 
 import hashlib
+import math
 import tempfile
 from pathlib import Path
 
@@ -78,12 +79,17 @@ def _fold_geographic_bbox(
         # otherwise fall through and be re-expressed as a west > east pair, i.e.
         # a domain flip decided by last-bit noise.
         return (-180.0, south, 180.0, north)
-    # One fold is enough at both sites: `west` is a raster's own left edge, which
-    # sits within a single wrap of range for any real geographic grid, and `span`
-    # is under 360 by the branch above. wrap_longitude leaves +180 as +180, which
-    # bbox_to_extent_wkt already handles -- it drops the zero-width 180..180 half
-    # and emits the -180..east ring alone.
-    west = wrap_longitude(west)
+    # fix(#887): reduce ARBITRARY wrap counts before folding. GDAL accepts a
+    # raster georeferenced well outside the adjacent domains, and wrap_longitude
+    # subtracts a single turn by design (#886), so a 720..730 source folded to
+    # 360..10 -- which bbox_to_extent_wkt reads as a crossing pair, drops the
+    # impossible 360..180 half from, and records as -180..10: a 10-degree
+    # footprint inflated to 190. The negative direction was worse: -730..-720
+    # recorded 37x its true area. fmod first, then the shared single-step fold,
+    # which keeps +180 as +180 -- bbox_to_extent_wkt relies on that to drop the
+    # zero-width 180..180 half and emit the -180..east ring alone.
+    west = wrap_longitude(math.fmod(west, 360.0))
+    # `span` is under 360 by the branch above, so one step settles east.
     east = wrap_longitude(west + span)
     return (west, south, east, north)
 

--- a/backend/app/processing/raster/vrt.py
+++ b/backend/app/processing/raster/vrt.py
@@ -368,6 +368,44 @@ def resolve_vrt_source_path(asset_uri: str, *, tenant_id: str | None = None) -> 
     return resolve_open_path(asset_uri, tenant_id=tenant_id)
 
 
+def sources_straddle_seam(source_paths: list[str]) -> bool:
+    """True when the sources form a geographic mosaic that crosses ±180.
+
+    fix(#887): ``gdalbuildvrt`` has no antimeridian handling. It takes the plain
+    min/max hull of the source extents, so two 5°-wide tiles either side of the
+    seam come out as a 3600 x 50 px mosaic anchored at -180 with the eastern tile
+    at ``dst_x_off`` 3550 -- byte-for-byte the same defect the Python writer had,
+    verified against the GDAL 3.10 in the worker image and GDAL 3.13 locally.
+
+    Nor can the subprocess be nudged into the right answer. ``-te 175 0 185 5``
+    sizes the mosaic correctly but places each source at its own coordinates, so
+    every source outside that window is dropped: the run exits 0 and half the
+    mosaic comes back empty, which is worse than the bug. Pre-shifting each
+    source through its own intermediate VRT would work geometrically, but those
+    intermediates are temp files that never get stored, so ``rewrite_vrt_sources``
+    (STOR-03) would leave the outer VRT pointing at paths that do not survive
+    ingest.
+
+    So the seam case belongs to :func:`_write_python_vrt`, which computes the
+    mosaic geometry in a shifted frame, and this predicate is the deliberate
+    branch into it -- not the ``FileNotFoundError`` fallback, which never fires in
+    a deployed worker because the image installs ``gdal-bin``.
+    """
+    import rasterio
+
+    try:
+        with ExitStack() as stack:
+            datasets = [
+                stack.enter_context(rasterio.open(path)) for path in source_paths
+            ]
+            if not all(ds.crs is not None and ds.crs.is_geographic for ds in datasets):
+                return False
+            spans = [(ds.bounds.left, ds.bounds.right) for ds in datasets]
+    except Exception:  # broad: a source that cannot be opened is gdalbuildvrt's error to report, with its own message — never this predicate's
+        return False
+    return _seam_frame_origin(spans) is not None
+
+
 def _build_vrt(
     source_paths: list[str],
     output_path: str,
@@ -391,6 +429,17 @@ def _build_vrt(
         KeyError: If an unrecognised resolution_strategy is supplied.
     """
     gdal_res = _RES_MAP[resolution_strategy]
+    # fix(#887): the seam-crossing mosaic is the one shape gdalbuildvrt cannot
+    # express -- see sources_straddle_seam for why neither -te nor pre-shifted
+    # intermediates work. Branch before spawning it, or the normalization only
+    # ever runs on hosts that lack the GDAL CLI.
+    if sources_straddle_seam(source_paths):
+        return _write_python_vrt(
+            source_paths,
+            output_path,
+            resolution_strategy,
+            separate=separate,
+        )
     cmd = ["gdalbuildvrt"]
     if separate:
         cmd.append("-separate")

--- a/backend/app/processing/raster/vrt.py
+++ b/backend/app/processing/raster/vrt.py
@@ -186,6 +186,40 @@ _GDAL_DTYPE_MAP = {
 }
 
 
+def _offset_text(value: float) -> str:
+    """Render a DstRect offset or size, keeping a fractional pixel fractional.
+
+    fix(#887): ``gdalbuildvrt`` emits sub-pixel geometry whenever a source is not
+    aligned to the chosen output grid -- a mixed-resolution mosaic produced
+    ``xOff="17751.5"`` and ``xOff="349.51"`` here. Rounding those to whole pixels
+    slides the source by up to half an output pixel and changes how GDAL
+    resamples it, so keep the fraction and only drop a trailing ``.0`` so the
+    common whole-pixel case still reads like GDAL's own output.
+
+    Shared by BOTH writers on purpose: the ``gdalbuildvrt`` frame rewrite and the
+    CLI-less :func:`_write_python_vrt` fallback. They disagreeing about this rule
+    is what codex round 7 caught, and two copies is how it would diverge again.
+    """
+    if math.isclose(value, round(value), abs_tol=1e-9):
+        return str(int(round(value)))
+    return f"{value:.10f}".rstrip("0").rstrip(".")
+
+
+def _containing_pixels(span_px: float) -> int:
+    """Pixel count that CONTAINS a span -- round UP, never to nearest.
+
+    fix(#887): a mosaic whose sources end at pixel 298.5 needs 299 pixels; 298
+    leaves the last half pixel outside the dataset and GDAL clips it, which no
+    pixel-count assertion catches because a 50-pixel source still reads back as
+    50 pixels. GDAL sizes its own mosaics this way (measured: max xOff+xSize
+    298.5 -> rasterXSize 299, and 440.51 -> 441). ``round`` first so float noise
+    on an exact boundary cannot add a stray pixel.
+
+    Shared by both writers, same reasoning as :func:`_offset_text`.
+    """
+    return max(1, math.ceil(round(span_px, 6)))
+
+
 def _resolve_target_resolution(values: list[float], resolution_strategy: str) -> float:
     if resolution_strategy == "finest":
         return min(values)
@@ -320,8 +354,10 @@ def _write_python_vrt(
         right = max(ds.bounds.right + offset for ds, offset in shifted)
         bottom = min(ds.bounds.bottom for ds in datasets)
         top = max(ds.bounds.top for ds in datasets)
-        width = max(1, int(round((right - left) / res_x)))
-        height = max(1, int(round((top - bottom) / res_y)))
+        # fix(#887): same containment rule as the gdalbuildvrt rewrite. Rounding
+        # to nearest sized a 298.5-pixel hull at 298 and clipped the edge.
+        width = _containing_pixels((right - left) / res_x)
+        height = _containing_pixels((top - bottom) / res_y)
 
         root = Element("VRTDataset", rasterXSize=str(width), rasterYSize=str(height))
         if first_crs is not None:
@@ -367,24 +403,24 @@ def _write_python_vrt(
                 xSize=str(dataset.width),
                 ySize=str(dataset.height),
             )
-            dst_width = max(
-                1, int(round(dataset.width * abs(dataset.transform.a) / res_x))
-            )
-            dst_height = max(
-                1, int(round(dataset.height * abs(dataset.transform.e) / res_y))
-            )
-            # fix(#887): lon_offset places the source in the same re-framed
-            # longitude frame as `left`. Mixing frames here is how a
-            # seam-straddling source ended up half a world from its own pixels.
-            dst_x_off = int(round((dataset.bounds.left + lon_offset - left) / res_x))
-            dst_y_off = int(round((top - dataset.bounds.top) / res_y))
+            # fix(#887): destination geometry stays fractional, exactly as the
+            # gdalbuildvrt rewrite keeps it -- both go through _offset_text. The
+            # integer rounding this replaces put a source needing xOff 248.5 at
+            # 248, sliding it half an output pixel and changing its resampling.
+            dst_width = dataset.width * abs(dataset.transform.a) / res_x
+            dst_height = dataset.height * abs(dataset.transform.e) / res_y
+            # lon_offset places the source in the same re-framed longitude frame
+            # as `left`. Mixing frames here is how a seam-straddling source ended
+            # up half a world from its own pixels.
+            dst_x_off = (dataset.bounds.left + lon_offset - left) / res_x
+            dst_y_off = (top - dataset.bounds.top) / res_y
             SubElement(
                 source,
                 "DstRect",
-                xOff=str(dst_x_off),
-                yOff=str(dst_y_off),
-                xSize=str(dst_width),
-                ySize=str(dst_height),
+                xOff=_offset_text(dst_x_off),
+                yOff=_offset_text(dst_y_off),
+                xSize=_offset_text(dst_width),
+                ySize=_offset_text(dst_height),
             )
 
         if separate:
@@ -501,21 +537,6 @@ def sources_seam_frame_origin(source_paths: list[str]) -> float | None:
     return _seam_frame_origin(spans)
 
 
-def _offset_text(value: float) -> str:
-    """Render a DstRect offset, keeping a fractional pixel fractional.
-
-    fix(#887): ``gdalbuildvrt`` emits sub-pixel offsets whenever a source is not
-    aligned to the chosen output grid -- a mixed-resolution mosaic produced
-    ``xOff="17751.5"`` and ``xOff="349.51"`` here. Rounding those to whole pixels
-    would slide the source by up to half an output pixel and change how GDAL
-    resamples it, so keep the fraction and only drop a trailing ``.0`` so the
-    common whole-pixel case still reads like GDAL's own output.
-    """
-    if math.isclose(value, round(value), abs_tol=1e-9):
-        return str(int(round(value)))
-    return f"{value:.10f}".rstrip("0").rstrip(".")
-
-
 def shift_vrt_longitude_frame(vrt_path: str, seam_origin: float) -> None:
     """Re-anchor a built VRT's longitude frame so the seam falls inside it.
 
@@ -603,14 +624,10 @@ def shift_vrt_longitude_frame(vrt_path: str, seam_origin: float) -> None:
     new_left = min(left for _, left, _ in placements)
     offsets = [((left - new_left) / res_x, size) for _, left, size in placements]
 
-    # The raster must CONTAIN every source, so round the width UP. A source
-    # ending at pixel 298.5 needs 299 pixels; 298 leaves its final half pixel
-    # outside the dataset and GDAL clips it -- which no pixel-count assertion
-    # catches, since a 50-pixel source still reads back as 50 pixels. GDAL sizes
-    # its own mosaics the same way (measured: max xOff+xSize 298.5 -> 299).
-    # Round before ceil so float noise on an exact boundary cannot add a pixel.
+    # The raster must CONTAIN every source -- see _containing_pixels, shared with
+    # the fallback writer so the two cannot disagree about this rule.
     span_px = max(offset + size for offset, size in offsets)
-    root.set("rasterXSize", str(max(1, math.ceil(round(span_px, 6)))))
+    root.set("rasterXSize", str(_containing_pixels(span_px)))
     geotransform[0] = new_left
     gt_node.text = ", ".join(repr(v) for v in geotransform)
     for (rect, _, _), (offset, _) in zip(placements, offsets, strict=True):

--- a/backend/app/processing/raster/vrt.py
+++ b/backend/app/processing/raster/vrt.py
@@ -6,6 +6,8 @@ import subprocess
 from contextlib import ExitStack
 from xml.etree.ElementTree import Element, ElementTree, SubElement
 
+from app.core.geo import LON_EPSILON_DEGREES
+
 
 # IA-P1-03 (Phase 1068): clamp the GDAL VSI surface that VRT processing
 # can reach. CPL_VSIL_CURL_ALLOWED_EXTENSIONS gates which URL-fetched
@@ -215,15 +217,6 @@ def _is_degree_based(crs) -> bool:
     return math.isclose(radians_per_unit, _RADIANS_PER_DEGREE, rel_tol=1e-9)
 
 
-# fix(#887): how much narrower the shifted hull must measure before it wins.
-# `left + 360` is not bit-exact for an arbitrary mantissa, so a global mosaic on
-# non-round tile boundaries can measure fractionally narrower shifted than plain
-# and re-frame itself on noise alone -- the same trap #886/#928 hit in the rollup
-# folds. 1e-9 degrees is ~0.1 mm: orders of magnitude above the noise, orders
-# below any re-framing worth doing.
-_SPAN_MARGIN = 1e-9
-
-
 def _seam_frame_origin(spans: list[tuple[float, float]]) -> float | None:
     """Pick the longitude frame origin for a seam-straddling geographic mosaic.
 
@@ -258,17 +251,20 @@ def _seam_frame_origin(spans: list[tuple[float, float]]) -> float | None:
     tightest circular hull of a set of intervals always starts at one of them.
     """
     plain_span = max(right for _, right in spans) - min(left for left, _ in spans)
-    if plain_span <= 180.0:
+    if plain_span <= 180.0 + LON_EPSILON_DEGREES:
         return None
 
     best_origin: float | None = None
     best_span = plain_span
     for origin, _ in spans:
         shifted_span = (
-            max(right + 360.0 if left < origin else right for left, right in spans)
+            max(
+                right + 360.0 if left < origin - LON_EPSILON_DEGREES else right
+                for left, right in spans
+            )
             - origin
         )
-        if shifted_span < best_span - _SPAN_MARGIN:
+        if shifted_span < best_span - LON_EPSILON_DEGREES:
             best_origin, best_span = origin, shifted_span
     return best_origin
 
@@ -312,7 +308,10 @@ def _write_python_vrt(
             else None
         )
         lon_offsets = [
-            360.0 if seam_origin is not None and ds.bounds.left < seam_origin else 0.0
+            360.0
+            if seam_origin is not None
+            and ds.bounds.left < seam_origin - LON_EPSILON_DEGREES
+            else 0.0
             for ds in datasets
         ]
         shifted = list(zip(datasets, lon_offsets, strict=True))
@@ -591,8 +590,14 @@ def shift_vrt_longitude_frame(vrt_path: str, seam_origin: float) -> None:
     for rect in rects:
         x_off = float(rect.get("xOff", "0"))
         x_size = float(rect.get("xSize", "0"))
+        # `src_left` is RECONSTRUCTED from a serialized pixel offset while
+        # `seam_origin` was read straight off the source, so the two describe the
+        # same edge by different arithmetic and disagree by ~1e-14 degrees. A bare
+        # `<` then shifts the origin source itself: for old_left=-180, res_x=0.02,
+        # xOff=17750.05 and seam_origin=175.001 it reconstructs 175.00099999999998,
+        # every tile gets +360, and the mosaic stays 17998 px wide instead of 300.
         src_left = old_left + x_off * res_x
-        shift = 360.0 if src_left < seam_origin else 0.0
+        shift = 360.0 if src_left < seam_origin - LON_EPSILON_DEGREES else 0.0
         placements.append((rect, src_left + shift, x_size))
 
     new_left = min(left for _, left, _ in placements)

--- a/backend/app/processing/raster/vrt.py
+++ b/backend/app/processing/raster/vrt.py
@@ -153,6 +153,49 @@ def _resolve_target_resolution(values: list[float], resolution_strategy: str) ->
     raise KeyError(resolution_strategy)
 
 
+def _seam_frame_origin(spans: list[tuple[float, float]]) -> float | None:
+    """Pick the longitude frame origin for a seam-straddling geographic mosaic.
+
+    fix(#887): ``min(left)`` / ``max(right)`` across sources sitting on both
+    sides of ±180 allocated a near-global raster with a huge empty middle -- a
+    10°-wide Pacific mosaic came out 360° wide, and every source landed at the
+    wrong ``dst_x_off``, so the VRT was both enormous and misregistered.
+    Re-frame the mosaic so the seam falls *inside* the frame instead of
+    splitting it: every source starting west of the returned origin is shifted
+    +360, which makes the hull contiguous again.
+
+    Returns the origin, or ``None`` when the plain -180..180 fold is already the
+    tightest hull and the geometry must be left exactly as it was.
+
+    Two guards, and BOTH are required -- either one alone is a coin flip
+    (see #883):
+
+    1. the plain hull must be wider than 180°. Nothing narrower can be improved
+       by a shift, and this is what leaves a mosaic ending flush at +180, and
+       one spanning -10..170 (exactly 180), in the plain frame.
+    2. the shifted hull must be *strictly* narrower than the plain one. A
+       genuinely global mosaic measures 360° in every frame, so it ties and
+       keeps -180..180 rather than being re-framed to an arbitrary origin.
+
+    Candidate origins are the source left edges, which is exhaustive: the
+    tightest circular hull of a set of intervals always starts at one of them.
+    """
+    plain_span = max(right for _, right in spans) - min(left for left, _ in spans)
+    if plain_span <= 180.0:
+        return None
+
+    best_origin: float | None = None
+    best_span = plain_span
+    for origin, _ in spans:
+        shifted_span = (
+            max(right + 360.0 if left < origin else right for left, right in spans)
+            - origin
+        )
+        if shifted_span < best_span:
+            best_origin, best_span = origin, shifted_span
+    return best_origin
+
+
 def _write_python_vrt(
     source_paths: list[str],
     output_path: str,
@@ -176,8 +219,28 @@ def _write_python_vrt(
         res_y = _resolve_target_resolution(
             [abs(ds.transform.e) for ds in datasets], resolution_strategy
         )
-        left = min(ds.bounds.left for ds in datasets)
-        right = max(ds.bounds.right for ds in datasets)
+
+        # fix(#887): only a geographic CRS wraps at ±180. Projected easting runs
+        # continuously across the seam, and its numbers are metres -- a 40 000 km
+        # wide EPSG:3857 pair clears the >180 guard trivially and a +360 shift
+        # would move a source by 360 *metres*. So gate the whole thing on EVERY
+        # source being geographic before computing any of the geometry.
+        all_geographic = all(
+            ds.crs is not None and ds.crs.is_geographic for ds in datasets
+        )
+        seam_origin = (
+            _seam_frame_origin([(ds.bounds.left, ds.bounds.right) for ds in datasets])
+            if all_geographic
+            else None
+        )
+        lon_offsets = [
+            360.0 if seam_origin is not None and ds.bounds.left < seam_origin else 0.0
+            for ds in datasets
+        ]
+        shifted = list(zip(datasets, lon_offsets, strict=True))
+
+        left = min(ds.bounds.left + offset for ds, offset in shifted)
+        right = max(ds.bounds.right + offset for ds, offset in shifted)
         bottom = min(ds.bounds.bottom for ds in datasets)
         top = max(ds.bounds.top for ds in datasets)
         width = max(1, int(round((right - left) / res_x)))
@@ -195,6 +258,7 @@ def _write_python_vrt(
             dataset,
             *,
             band_index: int,
+            lon_offset: float = 0.0,
         ) -> None:
             source = SubElement(parent, "SimpleSource")
             # STOR-03 (Phase 1210): write logical key + relativeToVRT="1" so the stored
@@ -232,7 +296,10 @@ def _write_python_vrt(
             dst_height = max(
                 1, int(round(dataset.height * abs(dataset.transform.e) / res_y))
             )
-            dst_x_off = int(round((dataset.bounds.left - left) / res_x))
+            # fix(#887): lon_offset places the source in the same re-framed
+            # longitude frame as `left`. Mixing frames here is how a
+            # seam-straddling source ended up half a world from its own pixels.
+            dst_x_off = int(round((dataset.bounds.left + lon_offset - left) / res_x))
             dst_y_off = int(round((top - dataset.bounds.top) / res_y))
             SubElement(
                 source,
@@ -245,7 +312,7 @@ def _write_python_vrt(
 
         if separate:
             band_number = 1
-            for dataset in datasets:
+            for dataset, lon_offset in shifted:
                 for source_band in range(1, dataset.count + 1):
                     band = SubElement(
                         root,
@@ -256,7 +323,9 @@ def _write_python_vrt(
                         ),
                         band=str(band_number),
                     )
-                    add_simple_source(band, dataset, band_index=source_band)
+                    add_simple_source(
+                        band, dataset, band_index=source_band, lon_offset=lon_offset
+                    )
                     band_number += 1
         else:
             band_count = first.count
@@ -274,8 +343,10 @@ def _write_python_vrt(
                     ),
                     band=str(band_number),
                 )
-                for dataset in datasets:
-                    add_simple_source(band, dataset, band_index=band_number)
+                for dataset, lon_offset in shifted:
+                    add_simple_source(
+                        band, dataset, band_index=band_number, lon_offset=lon_offset
+                    )
 
         ElementTree(root).write(output_path, encoding="utf-8", xml_declaration=True)
         return output_path

--- a/backend/app/processing/raster/vrt.py
+++ b/backend/app/processing/raster/vrt.py
@@ -67,6 +67,46 @@ def gdal_safe_env(*, extras: dict[str, str] | None = None) -> dict[str, str]:
     return env
 
 
+# fix(#887): source paths whose host an attacker can influence.
+# ``resolve_open_path`` passes a remotely imported STAC asset's URL through
+# UNCHANGED, so these arrive here verbatim. ``/vsis3/``, ``/vsiaz/`` and local
+# paths are managed storage -- bucket from settings, key already validated by
+# ``resolve_storage_key`` -- and are not in this set.
+_ATTACKER_CONTROLLABLE_PREFIXES: tuple[str, ...] = (
+    "http://",
+    "https://",
+    "/vsicurl/",
+    "/vsicurl_streaming/",
+)
+
+
+def is_attacker_controllable_source(path: str) -> bool:
+    """True when a source path points at a host the caller chose."""
+    return path.startswith(_ATTACKER_CONTROLLABLE_PREFIXES)
+
+
+def gdal_safe_open_env():
+    """In-process twin of :func:`gdal_safe_env`, for ``rasterio.open`` calls.
+
+    ``gdal_safe_env`` clamps SUBPROCESS environments only; an in-process
+    ``rasterio.open`` gets none of it. Built from the same ``_VRT_SAFE_ENV``
+    constant so the two cannot drift when a clamp is added.
+
+    fix(#887): note what this does NOT buy. Measured on GDAL 3.12.1,
+    ``GDAL_HTTP_FOLLOWLOCATION`` is not a GDAL configuration option at all --
+    ``gdalinfo --config GDAL_HTTP_FOLLOWLOCATION NO --debug ON`` answers
+    ``Warning 1: Unknown configuration option 'GDAL_HTTP_FOLLOWLOCATION'`` and
+    follows the 302 anyway, in-process and in the subprocess alike. So this env
+    carries the two clamps that ARE real (the ``/vsicurl`` extension allow-list
+    and ``VRT_VIRTUAL_OVERVIEWS``) and provides no redirect protection to
+    anybody. Redirect safety for user-supplied URLs has to come from not handing
+    them to GDAL -- see :func:`is_attacker_controllable_source`.
+    """
+    import rasterio
+
+    return rasterio.Env(**_VRT_SAFE_ENV)
+
+
 # fix(#430 BA-29): raster GDAL CLIs run synchronously inside asyncio.to_thread, and
 # Python threads aren't killable — a hung child (malformed TIFF, stalled /vsi
 # read) would pin a ThreadPoolExecutor thread forever and eventually starve every
@@ -230,7 +270,10 @@ def _write_python_vrt(
     if not source_paths:
         raise ValueError("At least one source raster is required to build a VRT")
 
-    with ExitStack() as stack:
+    # fix(#887): same clamp as the seam probe — this builder opens every source
+    # in-process, and on a CLI-less host it is the ONLY thing that touches them,
+    # so there is no clamped subprocess behind it (AGENTS.md Rule 2).
+    with gdal_safe_open_env(), ExitStack() as stack:
         datasets = [stack.enter_context(rasterio.open(path)) for path in source_paths]
         first = datasets[0]
         first_crs = first.crs.to_wkt() if first.crs is not None else None
@@ -411,11 +454,28 @@ def sources_seam_frame_origin(source_paths: list[str]) -> float | None:
 
     Returns ``None`` unless every source is geographic and the mosaic really
     crosses the seam, so the ordinary build is left completely alone.
+
+    **Never probes a caller-supplied URL** (AGENTS.md Rule 2). This runs *ahead*
+    of ``gdalbuildvrt``, so for a remotely imported STAC asset -- whose ``https://``
+    URL ``resolve_open_path`` passes through unchanged -- it would be the first
+    thing to fetch it. A URL that was validated at import time but now
+    3xx-redirects to a private address would be followed, and there is no GDAL
+    setting that prevents that: ``GDAL_HTTP_FOLLOWLOCATION`` is not a real
+    configuration option (see :func:`gdal_safe_open_env`), so clamping the open
+    would only look like a fix. Refusing to open it is the actual fix.
+
+    The cost, stated plainly: a genuinely seam-crossing mosaic built from remote
+    sources keeps the old over-broad -180..180 hull. That is the pre-existing
+    behaviour, it is rare, and it is a much better trade than adding a fetch of
+    an attacker-chosen host to a code path that had none.
     """
     import rasterio
 
+    if any(is_attacker_controllable_source(path) for path in source_paths):
+        return None
+
     try:
-        with ExitStack() as stack:
+        with gdal_safe_open_env(), ExitStack() as stack:
             datasets = [
                 stack.enter_context(rasterio.open(path)) for path in source_paths
             ]

--- a/backend/app/processing/raster/vrt.py
+++ b/backend/app/processing/raster/vrt.py
@@ -69,30 +69,14 @@ def gdal_safe_env(*, extras: dict[str, str] | None = None) -> dict[str, str]:
     return env
 
 
-# fix(#887): source paths whose host an attacker can influence.
-# ``resolve_open_path`` passes a remotely imported STAC asset's URL through
-# UNCHANGED, so these arrive here verbatim. ``/vsis3/``, ``/vsiaz/`` and local
-# paths are managed storage -- bucket from settings, key already validated by
-# ``resolve_storage_key`` -- and are not in this set.
-_ATTACKER_CONTROLLABLE_PREFIXES: tuple[str, ...] = (
-    "http://",
-    "https://",
-    "/vsicurl/",
-    "/vsicurl_streaming/",
-)
-
-
-def is_attacker_controllable_source(path: str) -> bool:
-    """True when a source path points at a host the caller chose."""
-    return path.startswith(_ATTACKER_CONTROLLABLE_PREFIXES)
-
-
 def gdal_safe_open_env():
     """In-process twin of :func:`gdal_safe_env`, for ``rasterio.open`` calls.
 
     ``gdal_safe_env`` clamps SUBPROCESS environments only; an in-process
     ``rasterio.open`` gets none of it. Built from the same ``_VRT_SAFE_ENV``
-    constant so the two cannot drift when a clamp is added.
+    constant so the two cannot drift when a clamp is added. Used by
+    :func:`_write_python_vrt`, which must open the sources it is asked to build
+    from -- the only in-process source access left in this module.
 
     fix(#887): note what this does NOT buy. Measured on GDAL 3.12.1,
     ``GDAL_HTTP_FOLLOWLOCATION`` is not a GDAL configuration option at all --
@@ -101,8 +85,7 @@ def gdal_safe_open_env():
     follows the 302 anyway, in-process and in the subprocess alike. So this env
     carries the two clamps that ARE real (the ``/vsicurl`` extension allow-list
     and ``VRT_VIRTUAL_OVERVIEWS``) and provides no redirect protection to
-    anybody. Redirect safety for user-supplied URLs has to come from not handing
-    them to GDAL -- see :func:`is_attacker_controllable_source`.
+    anybody.
     """
     import rasterio
 
@@ -508,63 +491,7 @@ def resolve_vrt_source_path(asset_uri: str, *, tenant_id: str | None = None) -> 
     return resolve_open_path(asset_uri, tenant_id=tenant_id)
 
 
-def sources_seam_frame_origin(source_paths: list[str]) -> float | None:
-    """Frame origin for a geographic mosaic that crosses ±180, else ``None``.
-
-    fix(#887): ``gdalbuildvrt`` has no antimeridian handling. It takes the plain
-    min/max hull of the source extents, so two 5°-wide tiles either side of the
-    seam come out as a 3600 x 50 px mosaic anchored at -180 with the eastern tile
-    at ``dst_x_off`` 3550 -- byte-for-byte the same defect the Python writer had,
-    verified against the GDAL 3.10 in the worker image and GDAL 3.13 locally. The
-    ``FileNotFoundError`` fallback below never fires in a deployed worker, because
-    the image installs ``gdal-bin``, so the subprocess output is what has to be
-    corrected.
-
-    Nor can the subprocess be nudged into the right answer up front.
-    ``-te 175 0 185 5`` sizes the mosaic correctly but places each source at its
-    own coordinates, so every source outside that window is dropped: the run
-    exits 0 and half the mosaic comes back empty. Pre-shifting each source
-    through its own intermediate VRT is geometrically sound, but those
-    intermediates are temp files that never get stored, so ``rewrite_vrt_sources``
-    (STOR-03) would leave the outer VRT pointing at paths that do not survive
-    ingest.
-
-    Returns ``None`` unless every source is geographic and the mosaic really
-    crosses the seam, so the ordinary build is left completely alone.
-
-    **Never probes a caller-supplied URL** (AGENTS.md Rule 2). This runs *ahead*
-    of ``gdalbuildvrt``, so for a remotely imported STAC asset -- whose ``https://``
-    URL ``resolve_open_path`` passes through unchanged -- it would be the first
-    thing to fetch it. A URL that was validated at import time but now
-    3xx-redirects to a private address would be followed, and there is no GDAL
-    setting that prevents that: ``GDAL_HTTP_FOLLOWLOCATION`` is not a real
-    configuration option (see :func:`gdal_safe_open_env`), so clamping the open
-    would only look like a fix. Refusing to open it is the actual fix.
-
-    The cost, stated plainly: a genuinely seam-crossing mosaic built from remote
-    sources keeps the old over-broad -180..180 hull. That is the pre-existing
-    behaviour, it is rare, and it is a much better trade than adding a fetch of
-    an attacker-chosen host to a code path that had none.
-    """
-    import rasterio
-
-    if any(is_attacker_controllable_source(path) for path in source_paths):
-        return None
-
-    try:
-        with gdal_safe_open_env(), ExitStack() as stack:
-            datasets = [
-                stack.enter_context(rasterio.open(path)) for path in source_paths
-            ]
-            if not all(_is_degree_based(ds.crs) for ds in datasets):
-                return None
-            spans = [(ds.bounds.left, ds.bounds.right) for ds in datasets]
-    except Exception:  # broad: a source that cannot be opened is gdalbuildvrt's error to report, with its own message — never this probe's
-        return None
-    return _seam_frame_origin(spans)
-
-
-def shift_vrt_longitude_frame(vrt_path: str, seam_origin: float) -> None:
+def shift_vrt_longitude_frame(vrt_path: str) -> None:
     """Re-anchor a built VRT's longitude frame so the seam falls inside it.
 
     fix(#887): ``gdalbuildvrt`` gets everything about a seam-crossing mosaic
@@ -587,39 +514,62 @@ def shift_vrt_longitude_frame(vrt_path: str, seam_origin: float) -> None:
     wrote (``old_left + xOff * res_x``), so this needs no second pass over the
     sources and no filename matching.
 
-    Editing generated XML is version-sensitive, so the structure this depends on
-    is asserted rather than assumed: GDAL 3.10.3 (worker image) and 3.13.0 both
-    emit the same root ``rasterXSize``, ``GeoTransform``, and one ``DstRect`` per
-    source. A source without a ``DstRect`` covers the whole raster implicitly, and
-    shrinking the raster underneath it would silently restretch it, so anything
-    unexpected raises here. Failing the build is the only acceptable outcome --
-    the alternative is shipping a misregistered mosaic that looks fine.
+    It also DECIDES, from the same XML, opening nothing. That is deliberate
+    (fix(#887), codex round 9): the previous version probed every source with
+    ``rasterio.open`` before the build, and ``build_vrt`` runs inside
+    ``asyncio.to_thread`` (``tasks_vrt.py``). Python threads are not killable, so
+    a stalled ``/vsis3/`` read pinned a pool thread forever with none of
+    ``run_gdal``'s wall-clock timeout and kill-on-hang applying to it -- enough
+    stalled VRT jobs would starve every other ``to_thread`` in the worker. The
+    module comment on ``GDAL_SUBPROCESS_TIMEOUT_SECONDS`` names that hazard
+    already; the probe reintroduced it.
 
-    Raises:
-        RuntimeError: If the VRT lacks the geometry this correction needs.
+    ``gdalbuildvrt`` has already opened every source, under that timeout, and
+    written what this needs: per-source ``DstRect`` geometry, the hull
+    ``GeoTransform``, and the ``SRS``. Deriving the decision from those closes the
+    timeout gap and removes the SSRF question entirely rather than fencing it off
+    by URL prefix -- nothing here ever touches a source.
+
+    Returns without writing when the VRT is not a degree-based geographic mosaic,
+    when its sources do not straddle the seam, or when the XML lacks the geometry
+    this needs. That last case cannot hide a real crossing: detecting one requires
+    exactly the same ``GeoTransform`` and per-source ``DstRect`` values the
+    rewrite consumes, so a VRT this cannot read is one it also cannot have
+    detected. Verified against GDAL 3.10.3 (worker image) and 3.13.0, which emit
+    identical structure.
     """
     from xml.etree.ElementTree import parse
 
-    tree = parse(vrt_path)
+    from rasterio.crs import CRS
+
+    try:
+        tree = parse(vrt_path)
+    except Exception:  # broad: a post-build correction must never turn a build gdalbuildvrt reported as successful into a crash — an unreadable or absent output is that subprocess's business, not this function's
+        return
     root = tree.getroot()
 
     gt_node = root.find("GeoTransform")
     if gt_node is None or not gt_node.text:
-        raise RuntimeError(
-            f"cannot correct the antimeridian frame of {vrt_path}: no GeoTransform"
-        )
+        return
     geotransform = [float(v) for v in gt_node.text.split(",")]
     if len(geotransform) != 6:
-        raise RuntimeError(
-            f"cannot correct the antimeridian frame of {vrt_path}: GeoTransform has "
-            f"{len(geotransform)} terms, expected 6"
-        )
+        return
     old_left, res_x = geotransform[0], geotransform[1]
     if res_x <= 0.0:
-        raise RuntimeError(
-            f"cannot correct the antimeridian frame of {vrt_path}: "
-            f"non-positive x resolution {res_x}"
-        )
+        return
+
+    # Parsing the SRS text is pure string work -- CRS.from_wkt does no I/O -- so
+    # the degree-based gate costs nothing and still rejects grads (EPSG:4807,
+    # which turns at 400) and every projected CRS.
+    srs_node = root.find("SRS")
+    if srs_node is None or not srs_node.text:
+        return
+    try:
+        crs = CRS.from_wkt(srs_node.text)
+    except Exception:  # broad: an SRS PROJ cannot parse is one we must not re-frame
+        return
+    if not _is_degree_based(crs):
+        return
 
     sources = [
         el
@@ -628,23 +578,39 @@ def shift_vrt_longitude_frame(vrt_path: str, seam_origin: float) -> None:
     ]
     rects = [el.find("DstRect") for el in sources]
     if not sources or any(rect is None for rect in rects):
-        raise RuntimeError(
-            f"cannot correct the antimeridian frame of {vrt_path}: expected one "
-            f"DstRect per source, got {sum(r is not None for r in rects)} for "
-            f"{len(sources)} source(s)"
+        return
+
+    # A source's own longitude span is recoverable from the offset GDAL already
+    # wrote, so the seam decision needs no second pass over the sources and no
+    # filename matching. Duplicate spans (one DstRect per band, plus any mask
+    # band) are harmless: they change neither the hull nor the candidate origins.
+    reconstructed = [
+        (
+            rect,
+            old_left + float(rect.get("xOff", "0")) * res_x,
+            float(rect.get("xSize", "0")),
         )
+        for rect in rects
+    ]
+    seam_origin = _seam_frame_origin(
+        [(left, left + size * res_x) for _, left, size in reconstructed]
+    )
+    if seam_origin is None:
+        return
 
     placements = []
-    for rect in rects:
-        x_off = float(rect.get("xOff", "0"))
-        x_size = float(rect.get("xSize", "0"))
-        # `src_left` is RECONSTRUCTED from a serialized pixel offset while
-        # `seam_origin` was read straight off the source, so the two describe the
-        # same edge by different arithmetic and disagree by ~1e-14 degrees. A bare
-        # `<` then shifts the origin source itself: for old_left=-180, res_x=0.02,
-        # xOff=17750.05 and seam_origin=175.001 it reconstructs 175.00099999999998,
-        # every tile gets +360, and the mosaic stays 17998 px wide instead of 300.
-        src_left = old_left + x_off * res_x
+    for rect, src_left, x_size in reconstructed:
+        # fix(#887): DEFENSIVE here, and deliberately kept. Codex round 6 found
+        # this comparison shifting the origin source itself, because `src_left`
+        # was reconstructed from a serialized pixel offset while `seam_origin`
+        # had been read straight off the source -- two derivations of one edge,
+        # disagreeing by ~1e-14, and the whole mosaic stayed 17998 px wide
+        # instead of 300. Round 9 removed the source-opening probe, so both
+        # values now come from THIS reconstruction and `seam_origin` is
+        # bit-identical to one of them; the mismatch is structurally impossible.
+        # The epsilon stays so that reintroducing a second derivation cannot
+        # quietly bring the bug back. (The load-bearing one is in
+        # _seam_frame_origin's hull contest.)
         shift = 360.0 if src_left < seam_origin - LON_EPSILON_DEGREES else 0.0
         placements.append((rect, src_left + shift, x_size))
 
@@ -686,10 +652,6 @@ def _build_vrt(
         KeyError: If an unrecognised resolution_strategy is supplied.
     """
     gdal_res = _RES_MAP[resolution_strategy]
-    # fix(#887): measured BEFORE the build, because a source's own bounds are the
-    # input to the frame choice; the correction itself is applied to gdalbuildvrt's
-    # output so its nodata, colour-interpretation and mask semantics survive.
-    seam_origin = sources_seam_frame_origin(source_paths)
     cmd = ["gdalbuildvrt"]
     if separate:
         cmd.append("-separate")
@@ -705,8 +667,11 @@ def _build_vrt(
         )
     if result.returncode != 0:
         raise RuntimeError(f"gdalbuildvrt failed: {result.stderr}")
-    if seam_origin is not None:
-        shift_vrt_longitude_frame(output_path, seam_origin)
+    # fix(#887): correct the antimeridian frame AFTER the build, from the XML
+    # gdalbuildvrt just wrote. It opens nothing itself and no-ops unless the
+    # sources really straddle ±180 -- so nothing in this function touches a
+    # source outside the timed, killable subprocess above.
+    shift_vrt_longitude_frame(output_path)
     return output_path
 
 

--- a/backend/app/processing/raster/vrt.py
+++ b/backend/app/processing/raster/vrt.py
@@ -368,28 +368,29 @@ def resolve_vrt_source_path(asset_uri: str, *, tenant_id: str | None = None) -> 
     return resolve_open_path(asset_uri, tenant_id=tenant_id)
 
 
-def sources_straddle_seam(source_paths: list[str]) -> bool:
-    """True when the sources form a geographic mosaic that crosses ±180.
+def sources_seam_frame_origin(source_paths: list[str]) -> float | None:
+    """Frame origin for a geographic mosaic that crosses ±180, else ``None``.
 
     fix(#887): ``gdalbuildvrt`` has no antimeridian handling. It takes the plain
     min/max hull of the source extents, so two 5°-wide tiles either side of the
     seam come out as a 3600 x 50 px mosaic anchored at -180 with the eastern tile
     at ``dst_x_off`` 3550 -- byte-for-byte the same defect the Python writer had,
-    verified against the GDAL 3.10 in the worker image and GDAL 3.13 locally.
+    verified against the GDAL 3.10 in the worker image and GDAL 3.13 locally. The
+    ``FileNotFoundError`` fallback below never fires in a deployed worker, because
+    the image installs ``gdal-bin``, so the subprocess output is what has to be
+    corrected.
 
-    Nor can the subprocess be nudged into the right answer. ``-te 175 0 185 5``
-    sizes the mosaic correctly but places each source at its own coordinates, so
-    every source outside that window is dropped: the run exits 0 and half the
-    mosaic comes back empty, which is worse than the bug. Pre-shifting each
-    source through its own intermediate VRT would work geometrically, but those
+    Nor can the subprocess be nudged into the right answer up front.
+    ``-te 175 0 185 5`` sizes the mosaic correctly but places each source at its
+    own coordinates, so every source outside that window is dropped: the run
+    exits 0 and half the mosaic comes back empty. Pre-shifting each source
+    through its own intermediate VRT is geometrically sound, but those
     intermediates are temp files that never get stored, so ``rewrite_vrt_sources``
     (STOR-03) would leave the outer VRT pointing at paths that do not survive
     ingest.
 
-    So the seam case belongs to :func:`_write_python_vrt`, which computes the
-    mosaic geometry in a shifted frame, and this predicate is the deliberate
-    branch into it -- not the ``FileNotFoundError`` fallback, which never fires in
-    a deployed worker because the image installs ``gdal-bin``.
+    Returns ``None`` unless every source is geographic and the mosaic really
+    crosses the seam, so the ordinary build is left completely alone.
     """
     import rasterio
 
@@ -399,11 +400,101 @@ def sources_straddle_seam(source_paths: list[str]) -> bool:
                 stack.enter_context(rasterio.open(path)) for path in source_paths
             ]
             if not all(ds.crs is not None and ds.crs.is_geographic for ds in datasets):
-                return False
+                return None
             spans = [(ds.bounds.left, ds.bounds.right) for ds in datasets]
-    except Exception:  # broad: a source that cannot be opened is gdalbuildvrt's error to report, with its own message — never this predicate's
-        return False
-    return _seam_frame_origin(spans) is not None
+    except Exception:  # broad: a source that cannot be opened is gdalbuildvrt's error to report, with its own message — never this probe's
+        return None
+    return _seam_frame_origin(spans)
+
+
+def shift_vrt_longitude_frame(vrt_path: str, seam_origin: float) -> None:
+    """Re-anchor a built VRT's longitude frame so the seam falls inside it.
+
+    fix(#887): ``gdalbuildvrt`` gets everything about a seam-crossing mosaic
+    right except the geometry, so correct the geometry and keep the rest.
+    Rebuilding with :func:`_write_python_vrt` instead would throw the rest away
+    -- that writer emits bare ``SimpleSource`` elements with no ``NoDataValue``,
+    ``ColorInterp``, ``UseMaskBand`` or mask band, so the mosaic reads back
+    ``nodata=None`` with undefined colour interpretation and all-valid masks, and
+    ``extract_raster_metadata`` then persists a null nodata. Worse, without the
+    ``<NODATA>`` GDAL puts inside a ``ComplexSource``, an overlapping source's
+    fill pixels overwrite valid pixels from an earlier source (measured: an
+    overlap that should read 7 read 0).
+
+    Rewrites exactly three things -- ``rasterXSize``, the ``GeoTransform``
+    origin, and every ``DstRect`` ``xOff``, including the ones inside a
+    ``<MaskBand>``, which ``iter()`` reaches. Everything else is untouched, and a
+    non-crossing build is left byte-identical to plain ``gdalbuildvrt``.
+
+    Each source's own left edge is recoverable from the ``xOff`` GDAL already
+    wrote (``old_left + xOff * res_x``), so this needs no second pass over the
+    sources and no filename matching.
+
+    Editing generated XML is version-sensitive, so the structure this depends on
+    is asserted rather than assumed: GDAL 3.10.3 (worker image) and 3.13.0 both
+    emit the same root ``rasterXSize``, ``GeoTransform``, and one ``DstRect`` per
+    source. A source without a ``DstRect`` covers the whole raster implicitly, and
+    shrinking the raster underneath it would silently restretch it, so anything
+    unexpected raises here. Failing the build is the only acceptable outcome --
+    the alternative is shipping a misregistered mosaic that looks fine.
+
+    Raises:
+        RuntimeError: If the VRT lacks the geometry this correction needs.
+    """
+    from xml.etree.ElementTree import parse
+
+    tree = parse(vrt_path)
+    root = tree.getroot()
+
+    gt_node = root.find("GeoTransform")
+    if gt_node is None or not gt_node.text:
+        raise RuntimeError(
+            f"cannot correct the antimeridian frame of {vrt_path}: no GeoTransform"
+        )
+    geotransform = [float(v) for v in gt_node.text.split(",")]
+    if len(geotransform) != 6:
+        raise RuntimeError(
+            f"cannot correct the antimeridian frame of {vrt_path}: GeoTransform has "
+            f"{len(geotransform)} terms, expected 6"
+        )
+    old_left, res_x = geotransform[0], geotransform[1]
+    if res_x <= 0.0:
+        raise RuntimeError(
+            f"cannot correct the antimeridian frame of {vrt_path}: "
+            f"non-positive x resolution {res_x}"
+        )
+
+    sources = [
+        el
+        for el in root.iter()
+        if el.tag in ("SimpleSource", "ComplexSource", "AveragedSource")
+    ]
+    rects = [el.find("DstRect") for el in sources]
+    if not sources or any(rect is None for rect in rects):
+        raise RuntimeError(
+            f"cannot correct the antimeridian frame of {vrt_path}: expected one "
+            f"DstRect per source, got {sum(r is not None for r in rects)} for "
+            f"{len(sources)} source(s)"
+        )
+
+    placements = []
+    for rect in rects:
+        x_off = float(rect.get("xOff", "0"))
+        x_size = float(rect.get("xSize", "0"))
+        src_left = old_left + x_off * res_x
+        shift = 360.0 if src_left < seam_origin else 0.0
+        placements.append((rect, src_left + shift, x_size))
+
+    new_left = min(left for _, left, _ in placements)
+    new_right = max(left + size * res_x for _, left, size in placements)
+
+    root.set("rasterXSize", str(max(1, int(round((new_right - new_left) / res_x)))))
+    geotransform[0] = new_left
+    gt_node.text = ", ".join(repr(v) for v in geotransform)
+    for rect, left, _ in placements:
+        rect.set("xOff", str(int(round((left - new_left) / res_x))))
+
+    tree.write(vrt_path, encoding="utf-8", xml_declaration=True)
 
 
 def _build_vrt(
@@ -429,17 +520,10 @@ def _build_vrt(
         KeyError: If an unrecognised resolution_strategy is supplied.
     """
     gdal_res = _RES_MAP[resolution_strategy]
-    # fix(#887): the seam-crossing mosaic is the one shape gdalbuildvrt cannot
-    # express -- see sources_straddle_seam for why neither -te nor pre-shifted
-    # intermediates work. Branch before spawning it, or the normalization only
-    # ever runs on hosts that lack the GDAL CLI.
-    if sources_straddle_seam(source_paths):
-        return _write_python_vrt(
-            source_paths,
-            output_path,
-            resolution_strategy,
-            separate=separate,
-        )
+    # fix(#887): measured BEFORE the build, because a source's own bounds are the
+    # input to the frame choice; the correction itself is applied to gdalbuildvrt's
+    # output so its nodata, colour-interpretation and mask semantics survive.
+    seam_origin = sources_seam_frame_origin(source_paths)
     cmd = ["gdalbuildvrt"]
     if separate:
         cmd.append("-separate")
@@ -455,6 +539,8 @@ def _build_vrt(
         )
     if result.returncode != 0:
         raise RuntimeError(f"gdalbuildvrt failed: {result.stderr}")
+    if seam_origin is not None:
+        shift_vrt_longitude_frame(output_path, seam_origin)
     return output_path
 
 

--- a/backend/app/processing/raster/vrt.py
+++ b/backend/app/processing/raster/vrt.py
@@ -518,7 +518,7 @@ def shift_vrt_longitude_frame(vrt_path: str) -> None:
     (fix(#887), codex round 9): the previous version probed every source with
     ``rasterio.open`` before the build, and ``build_vrt`` runs inside
     ``asyncio.to_thread`` (``tasks_vrt.py``). Python threads are not killable, so
-    a stalled ``/vsis3/`` read pinned a pool thread forever with none of
+    a stalled object-storage read pinned a pool thread forever with none of
     ``run_gdal``'s wall-clock timeout and kill-on-hang applying to it -- enough
     stalled VRT jobs would starve every other ``to_thread`` in the worker. The
     module comment on ``GDAL_SUBPROCESS_TIMEOUT_SECONDS`` names that hazard

--- a/backend/app/processing/raster/vrt.py
+++ b/backend/app/processing/raster/vrt.py
@@ -215,6 +215,15 @@ def _is_degree_based(crs) -> bool:
     return math.isclose(radians_per_unit, _RADIANS_PER_DEGREE, rel_tol=1e-9)
 
 
+# fix(#887): how much narrower the shifted hull must measure before it wins.
+# `left + 360` is not bit-exact for an arbitrary mantissa, so a global mosaic on
+# non-round tile boundaries can measure fractionally narrower shifted than plain
+# and re-frame itself on noise alone -- the same trap #886/#928 hit in the rollup
+# folds. 1e-9 degrees is ~0.1 mm: orders of magnitude above the noise, orders
+# below any re-framing worth doing.
+_SPAN_MARGIN = 1e-9
+
+
 def _seam_frame_origin(spans: list[tuple[float, float]]) -> float | None:
     """Pick the longitude frame origin for a seam-straddling geographic mosaic.
 
@@ -235,9 +244,15 @@ def _seam_frame_origin(spans: list[tuple[float, float]]) -> float | None:
     1. the plain hull must be wider than 180°. Nothing narrower can be improved
        by a shift, and this is what leaves a mosaic ending flush at +180, and
        one spanning -10..170 (exactly 180), in the plain frame.
-    2. the shifted hull must be *strictly* narrower than the plain one. A
-       genuinely global mosaic measures 360° in every frame, so it ties and
-       keeps -180..180 rather than being re-framed to an arbitrary origin.
+    2. the shifted hull must be narrower than the plain one *by a real margin*.
+       A genuinely global mosaic measures 360° in every frame, so it ties and
+       keeps -180..180 rather than being re-framed to an arbitrary origin. The
+       margin matters: ``left + 360`` is not bit-exact for an arbitrary mantissa,
+       so a global mosaic on non-round tile boundaries can measure
+       359.99999999999994 shifted against 360.00000000000006 plain and win a
+       bare ``<`` on nothing but noise (the same trap #886/#928 hit in the
+       rollup folds). ``_SPAN_MARGIN`` is far above that noise and far below any
+       real gain.
 
     Candidate origins are the source left edges, which is exhaustive: the
     tightest circular hull of a set of intervals always starts at one of them.
@@ -253,7 +268,7 @@ def _seam_frame_origin(spans: list[tuple[float, float]]) -> float | None:
             max(right + 360.0 if left < origin else right for left, right in spans)
             - origin
         )
-        if shifted_span < best_span:
+        if shifted_span < best_span - _SPAN_MARGIN:
             best_origin, best_span = origin, shifted_span
     return best_origin
 

--- a/backend/app/processing/raster/vrt.py
+++ b/backend/app/processing/raster/vrt.py
@@ -521,14 +521,20 @@ def shift_vrt_longitude_frame(vrt_path: str, seam_origin: float) -> None:
         placements.append((rect, src_left + shift, x_size))
 
     new_left = min(left for _, left, _ in placements)
-    new_right = max(left + size * res_x for _, left, size in placements)
+    offsets = [((left - new_left) / res_x, size) for _, left, size in placements]
 
-    # rasterXSize is a pixel count and must stay integral; the offsets must not.
-    root.set("rasterXSize", str(max(1, int(round((new_right - new_left) / res_x)))))
+    # The raster must CONTAIN every source, so round the width UP. A source
+    # ending at pixel 298.5 needs 299 pixels; 298 leaves its final half pixel
+    # outside the dataset and GDAL clips it -- which no pixel-count assertion
+    # catches, since a 50-pixel source still reads back as 50 pixels. GDAL sizes
+    # its own mosaics the same way (measured: max xOff+xSize 298.5 -> 299).
+    # Round before ceil so float noise on an exact boundary cannot add a pixel.
+    span_px = max(offset + size for offset, size in offsets)
+    root.set("rasterXSize", str(max(1, math.ceil(round(span_px, 6)))))
     geotransform[0] = new_left
     gt_node.text = ", ".join(repr(v) for v in geotransform)
-    for rect, left, _ in placements:
-        rect.set("xOff", _offset_text((left - new_left) / res_x))
+    for (rect, _, _), (offset, _) in zip(placements, offsets, strict=True):
+        rect.set("xOff", _offset_text(offset))
 
     tree.write(vrt_path, encoding="utf-8", xml_declaration=True)
 

--- a/backend/app/processing/raster/vrt.py
+++ b/backend/app/processing/raster/vrt.py
@@ -186,6 +186,12 @@ _GDAL_DTYPE_MAP = {
 }
 
 
+# fix(#887): the absolute noise floor for a DstRect value, in PIXELS. Distinct
+# from LON_EPSILON_DEGREES, which is a longitude tolerance -- these are different
+# units and must not share a constant just because they share a magnitude.
+_PIXEL_EPSILON = 1e-9
+
+
 def _offset_text(value: float) -> str:
     """Render a DstRect offset or size, keeping a fractional pixel fractional.
 
@@ -199,8 +205,21 @@ def _offset_text(value: float) -> str:
     Shared by BOTH writers on purpose: the ``gdalbuildvrt`` frame rewrite and the
     CLI-less :func:`_write_python_vrt` fallback. They disagreeing about this rule
     is what codex round 7 caught, and two copies is how it would diverge again.
+
+    ``rel_tol=0`` is load-bearing. ``math.isclose`` compares against
+    ``max(rel_tol * max(|a|, |b|), abs_tol)``, so leaving the 1e-9 default alive
+    makes the tolerance GROW with the offset: at 1e8 pixels it reaches 0.1, and
+    at 1e9 it reaches 1.0, which silently rounded a real 0.49-pixel offset to a
+    whole number -- reintroducing at scale exactly the defect this function
+    exists to prevent. Only the absolute noise floor should ever be ignored.
+
+    The fixed-point rendering is deliberate rather than ``repr``: it settles the
+    value at 1e-10 of a pixel, which absorbs the accumulated arithmetic noise
+    that makes an exact half-pixel arrive as 248.49999999999852. ``repr`` would
+    round-trip that noise into the file. Ten decimal places is fourteen orders
+    of magnitude finer than anything GDAL resamples on.
     """
-    if math.isclose(value, round(value), abs_tol=1e-9):
+    if math.isclose(value, round(value), rel_tol=0.0, abs_tol=_PIXEL_EPSILON):
         return str(int(round(value)))
     return f"{value:.10f}".rstrip("0").rstrip(".")
 
@@ -241,7 +260,15 @@ _RADIANS_PER_DEGREE = math.pi / 180.0
 
 
 def _is_degree_based(crs) -> bool:
-    """True only for a geographic CRS whose angular unit is degrees."""
+    """True only for a geographic CRS whose angular unit is degrees.
+
+    fix(#887): ``rel_tol`` is correct HERE and wrong in :func:`_offset_text`, so
+    do not "fix" this one by symmetry. This compares two fixed physical
+    constants of the same tiny magnitude (0.01745 radians per degree against
+    whatever PROJ reports), where proportional agreement is the meaningful test
+    and the nearest wrong answer -- grads, at 0.01571 -- is 10% away. An offset
+    is an unbounded pixel count whose noise floor does not scale with it.
+    """
     if crs is None or not crs.is_geographic:
         return False
     try:

--- a/backend/app/processing/raster/vrt.py
+++ b/backend/app/processing/raster/vrt.py
@@ -6,7 +6,7 @@ import subprocess
 from contextlib import ExitStack
 from xml.etree.ElementTree import Element, ElementTree, SubElement
 
-from app.core.geo import LON_EPSILON_DEGREES
+from app.core.geo import LON_EPSILON_DEGREES, wrap_longitude
 
 
 # IA-P1-03 (Phase 1068): clamp the GDAL VSI surface that VRT processing
@@ -261,6 +261,28 @@ def _is_degree_based(crs) -> bool:
     return math.isclose(radians_per_unit, _RADIANS_PER_DEGREE, rel_tol=1e-9)
 
 
+def normalize_lon_span(left: float, right: float) -> tuple[float, float]:
+    """Fold a span's origin into a single turn, preserving its width.
+
+    fix(#887): :func:`_seam_frame_origin` shifts a source by exactly ONE turn,
+    which is only sound when every span already sits within one turn of the
+    others. GDAL accepts georeferencing further out, and the failure is silent
+    and scales with the distance -- spans ``535..540`` and ``-180..-175`` are
+    adjacent at the seam (535 ≡ 175), but at candidate origin 535 the second
+    source is moved only to ``180..185``, which is still WEST of the origin. The
+    chooser scores that frame at 5° and the shift then emits 360°; two turns out
+    emits 720°, three turns 1080°, and the westward and mixed-direction variants
+    behave the same way.
+
+    Normalizing up front restores the invariant the frame chooser's proof rests
+    on -- every source at or east of the returned origin after one turn -- rather
+    than complicating the shift with a per-source turn count. It is a no-op for
+    any raster already inside a single turn, which is every real one.
+    """
+    folded = wrap_longitude(math.fmod(left, 360.0))
+    return (folded, folded + (right - left))
+
+
 def _seam_frame_origin(spans: list[tuple[float, float]]) -> float | None:
     """Pick the longitude frame origin for a seam-straddling geographic mosaic.
 
@@ -346,22 +368,34 @@ def _write_python_vrt(
         # +360 shift would move a source by 360 *metres* -- and a grads-based
         # geographic CRS turns at 400, not 360. Gate the whole thing on EVERY
         # source before computing any of the geometry.
+        raw_spans = [(ds.bounds.left, ds.bounds.right) for ds in datasets]
+        # fix(#887): normalized into a single turn for the seam decision, because
+        # the frame chooser shifts by exactly one (see normalize_lon_span).
+        normalized_spans = [
+            normalize_lon_span(left, right) for left, right in raw_spans
+        ]
         seam_origin = (
-            _seam_frame_origin([(ds.bounds.left, ds.bounds.right) for ds in datasets])
+            _seam_frame_origin(normalized_spans)
             if all(_is_degree_based(ds.crs) for ds in datasets)
             else None
         )
+        # Only a mosaic actually being re-framed adopts the normalized
+        # longitudes; every other build keeps the coordinates its sources carry.
+        spans = normalized_spans if seam_origin is not None else raw_spans
         lon_offsets = [
             360.0
-            if seam_origin is not None
-            and ds.bounds.left < seam_origin - LON_EPSILON_DEGREES
+            if seam_origin is not None and left < seam_origin - LON_EPSILON_DEGREES
             else 0.0
-            for ds in datasets
+            for left, _ in spans
         ]
-        shifted = list(zip(datasets, lon_offsets, strict=True))
+        placed = [
+            (left + offset, right + offset)
+            for (left, right), offset in zip(spans, lon_offsets, strict=True)
+        ]
+        shifted = list(zip(datasets, [left for left, _ in placed], strict=True))
 
-        left = min(ds.bounds.left + offset for ds, offset in shifted)
-        right = max(ds.bounds.right + offset for ds, offset in shifted)
+        left = min(left for left, _ in placed)
+        right = max(right for _, right in placed)
         bottom = min(ds.bounds.bottom for ds in datasets)
         top = max(ds.bounds.top for ds in datasets)
         # fix(#887): same containment rule as the gdalbuildvrt rewrite. Rounding
@@ -381,7 +415,7 @@ def _write_python_vrt(
             dataset,
             *,
             band_index: int,
-            lon_offset: float = 0.0,
+            placed_left: float,
         ) -> None:
             source = SubElement(parent, "SimpleSource")
             # STOR-03 (Phase 1210): write logical key + relativeToVRT="1" so the stored
@@ -419,10 +453,11 @@ def _write_python_vrt(
             # 248, sliding it half an output pixel and changing its resampling.
             dst_width = dataset.width * abs(dataset.transform.a) / res_x
             dst_height = dataset.height * abs(dataset.transform.e) / res_y
-            # lon_offset places the source in the same re-framed longitude frame
-            # as `left`. Mixing frames here is how a seam-straddling source ended
-            # up half a world from its own pixels.
-            dst_x_off = (dataset.bounds.left + lon_offset - left) / res_x
+            # `placed_left` is the source's position in the SAME frame as `left`
+            # -- normalized into one turn, then shifted if it sits west of the
+            # seam origin. Mixing frames here is how a seam-straddling source
+            # ended up half a world from its own pixels.
+            dst_x_off = (placed_left - left) / res_x
             dst_y_off = (top - dataset.bounds.top) / res_y
             SubElement(
                 source,
@@ -435,7 +470,7 @@ def _write_python_vrt(
 
         if separate:
             band_number = 1
-            for dataset, lon_offset in shifted:
+            for dataset, placed_left in shifted:
                 for source_band in range(1, dataset.count + 1):
                     band = SubElement(
                         root,
@@ -447,7 +482,10 @@ def _write_python_vrt(
                         band=str(band_number),
                     )
                     add_simple_source(
-                        band, dataset, band_index=source_band, lon_offset=lon_offset
+                        band,
+                        dataset,
+                        band_index=source_band,
+                        placed_left=placed_left,
                     )
                     band_number += 1
         else:
@@ -466,9 +504,12 @@ def _write_python_vrt(
                     ),
                     band=str(band_number),
                 )
-                for dataset, lon_offset in shifted:
+                for dataset, placed_left in shifted:
                     add_simple_source(
-                        band, dataset, band_index=band_number, lon_offset=lon_offset
+                        band,
+                        dataset,
+                        band_index=band_number,
+                        placed_left=placed_left,
                     )
 
         ElementTree(root).write(output_path, encoding="utf-8", xml_declaration=True)
@@ -557,6 +598,12 @@ def shift_vrt_longitude_frame(vrt_path: str) -> None:
     old_left, res_x = geotransform[0], geotransform[1]
     if res_x <= 0.0:
         return
+    # fix(#887): a rotated GeoTransform makes gt[0] no longer a pure longitude
+    # origin, so translating it along x would shear the mosaic. gdalbuildvrt
+    # never emits rotation terms, but this function's contract is that it fully
+    # understands the geometry it rewrites -- decline rather than assume.
+    if geotransform[2] or geotransform[4]:
+        return
 
     # Parsing the SRS text is pure string work -- CRS.from_wkt does no I/O -- so
     # the degree-based gate costs nothing and still rejects grads (EPSG:4807,
@@ -584,14 +631,19 @@ def shift_vrt_longitude_frame(vrt_path: str) -> None:
     # wrote, so the seam decision needs no second pass over the sources and no
     # filename matching. Duplicate spans (one DstRect per band, plus any mask
     # band) are harmless: they change neither the hull nor the candidate origins.
-    reconstructed = [
-        (
-            rect,
-            old_left + float(rect.get("xOff", "0")) * res_x,
-            float(rect.get("xSize", "0")),
-        )
-        for rect in rects
-    ]
+    #
+    # fix(#887): normalized into a single turn first. The frame chooser shifts by
+    # exactly one turn, and a source georeferenced further out is still west of
+    # the origin afterwards -- see normalize_lon_span. Placement is pixel-space
+    # (SrcRect/DstRect), so re-expressing a source's longitude changes where the
+    # mosaic sits, never which pixels land in it.
+    reconstructed = []
+    for rect in rects:
+        raw_left = old_left + float(rect.get("xOff", "0")) * res_x
+        x_size = float(rect.get("xSize", "0"))
+        left, _ = normalize_lon_span(raw_left, raw_left)
+        reconstructed.append((rect, left, x_size))
+
     seam_origin = _seam_frame_origin(
         [(left, left + size * res_x) for _, left, size in reconstructed]
     )

--- a/backend/app/processing/raster/vrt.py
+++ b/backend/app/processing/raster/vrt.py
@@ -1,5 +1,6 @@
 """VRT build module: gdalbuildvrt subprocess wrappers and source path resolver."""
 
+import math
 import os
 import subprocess
 from contextlib import ExitStack
@@ -153,6 +154,27 @@ def _resolve_target_resolution(values: list[float], resolution_strategy: str) ->
     raise KeyError(resolution_strategy)
 
 
+# fix(#887): the seam logic is written in degrees throughout -- the >180 guard,
+# the +360 shift, the ±180 rings. `is_geographic` is NOT enough to guarantee
+# that: EPSG:4807 (NTF Paris) is geographic with an angular unit of GRADS, where
+# a full turn is 400 and the seam sits at 200. Feeding it a 360 shift moves the
+# eastern tile to the wrong place entirely -- a 195..200 / -200..-195 pair comes
+# out as a 40-grad hull instead of the intended 10. Compare the CRS's own
+# radians-per-unit factor rather than a unit name, which varies by PROJ build.
+_RADIANS_PER_DEGREE = math.pi / 180.0
+
+
+def _is_degree_based(crs) -> bool:
+    """True only for a geographic CRS whose angular unit is degrees."""
+    if crs is None or not crs.is_geographic:
+        return False
+    try:
+        _, radians_per_unit = crs.units_factor
+    except Exception:  # broad: units_factor raises CRSError on exotic/!undefined CRSs, which are exactly the ones to exclude
+        return False
+    return math.isclose(radians_per_unit, _RADIANS_PER_DEGREE, rel_tol=1e-9)
+
+
 def _seam_frame_origin(spans: list[tuple[float, float]]) -> float | None:
     """Pick the longitude frame origin for a seam-straddling geographic mosaic.
 
@@ -220,17 +242,15 @@ def _write_python_vrt(
             [abs(ds.transform.e) for ds in datasets], resolution_strategy
         )
 
-        # fix(#887): only a geographic CRS wraps at ±180. Projected easting runs
-        # continuously across the seam, and its numbers are metres -- a 40 000 km
-        # wide EPSG:3857 pair clears the >180 guard trivially and a +360 shift
-        # would move a source by 360 *metres*. So gate the whole thing on EVERY
-        # source being geographic before computing any of the geometry.
-        all_geographic = all(
-            ds.crs is not None and ds.crs.is_geographic for ds in datasets
-        )
+        # fix(#887): only a degree-based geographic CRS wraps at ±180. Projected
+        # easting runs continuously across the seam and its numbers are metres --
+        # a 40 000 km wide EPSG:3857 pair clears the >180 guard trivially and a
+        # +360 shift would move a source by 360 *metres* -- and a grads-based
+        # geographic CRS turns at 400, not 360. Gate the whole thing on EVERY
+        # source before computing any of the geometry.
         seam_origin = (
             _seam_frame_origin([(ds.bounds.left, ds.bounds.right) for ds in datasets])
-            if all_geographic
+            if all(_is_degree_based(ds.crs) for ds in datasets)
             else None
         )
         lon_offsets = [
@@ -399,12 +419,27 @@ def sources_seam_frame_origin(source_paths: list[str]) -> float | None:
             datasets = [
                 stack.enter_context(rasterio.open(path)) for path in source_paths
             ]
-            if not all(ds.crs is not None and ds.crs.is_geographic for ds in datasets):
+            if not all(_is_degree_based(ds.crs) for ds in datasets):
                 return None
             spans = [(ds.bounds.left, ds.bounds.right) for ds in datasets]
     except Exception:  # broad: a source that cannot be opened is gdalbuildvrt's error to report, with its own message — never this probe's
         return None
     return _seam_frame_origin(spans)
+
+
+def _offset_text(value: float) -> str:
+    """Render a DstRect offset, keeping a fractional pixel fractional.
+
+    fix(#887): ``gdalbuildvrt`` emits sub-pixel offsets whenever a source is not
+    aligned to the chosen output grid -- a mixed-resolution mosaic produced
+    ``xOff="17751.5"`` and ``xOff="349.51"`` here. Rounding those to whole pixels
+    would slide the source by up to half an output pixel and change how GDAL
+    resamples it, so keep the fraction and only drop a trailing ``.0`` so the
+    common whole-pixel case still reads like GDAL's own output.
+    """
+    if math.isclose(value, round(value), abs_tol=1e-9):
+        return str(int(round(value)))
+    return f"{value:.10f}".rstrip("0").rstrip(".")
 
 
 def shift_vrt_longitude_frame(vrt_path: str, seam_origin: float) -> None:
@@ -488,11 +523,12 @@ def shift_vrt_longitude_frame(vrt_path: str, seam_origin: float) -> None:
     new_left = min(left for _, left, _ in placements)
     new_right = max(left + size * res_x for _, left, size in placements)
 
+    # rasterXSize is a pixel count and must stay integral; the offsets must not.
     root.set("rasterXSize", str(max(1, int(round((new_right - new_left) / res_x)))))
     geotransform[0] = new_left
     gt_node.text = ", ".join(repr(v) for v in geotransform)
     for rect, left, _ in placements:
-        rect.set("xOff", str(int(round((left - new_left) / res_x))))
+        rect.set("xOff", _offset_text((left - new_left) / res_x))
 
     tree.write(vrt_path, encoding="utf-8", xml_declaration=True)
 

--- a/backend/app/processing/tiles/router.py
+++ b/backend/app/processing/tiles/router.py
@@ -26,7 +26,7 @@ from sqlalchemy import select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import joinedload
 
-from app.core.geo import extent_to_span_bbox
+from app.core.geo import extent_lon_span, extent_to_span_bbox
 from app.core.identity import Identity
 from app.core.record_types import RASTER_FAMILY_RECORD_TYPES
 from app.modules.auth.dependencies import get_optional_user
@@ -383,8 +383,16 @@ def _degrees_resolution_to_meters(
 def _native_resolution_meters(
     asset: RasterAsset | None,
     bounds: list[float] | None,
+    *,
+    lon_span: float | None = None,
 ) -> float | None:
-    """Estimate native raster resolution in meters from stored COG metadata."""
+    """Estimate native raster resolution in meters from stored COG metadata.
+
+    ``lon_span`` is the extent's honest longitudinal width (``extent_lon_span``).
+    fix(#887): ``bounds`` is deliberately the monotonic span bbox, which reads
+    -180..180 for a seam-crossing extent, so the width has to arrive separately
+    or a 10°-wide Pacific raster measures 360° and collapses its own maxzoom.
+    """
     if asset is None:
         return None
 
@@ -403,7 +411,7 @@ def _native_resolution_meters(
 
     if not values and bounds and len(bounds) == 4 and asset.width and asset.height:
         minx, miny, maxx, maxy = bounds
-        span_x = _positive_number(maxx - minx)
+        span_x = _positive_number(lon_span if lon_span is not None else maxx - minx)
         span_y = _positive_number(maxy - miny)
         x_deg = span_x / asset.width if span_x else None
         y_deg = span_y / asset.height if span_y else None
@@ -415,9 +423,11 @@ def _native_resolution_meters(
 def _raster_maxzoom_from_metadata(
     asset: RasterAsset | None,
     bounds: list[float] | None,
+    *,
+    lon_span: float | None = None,
 ) -> int:
     """Choose raster source maxzoom from native resolution, with legacy fallback."""
-    resolution_m = _native_resolution_meters(asset, bounds)
+    resolution_m = _native_resolution_meters(asset, bounds, lon_span=lon_span)
     if resolution_m is None:
         return _DEFAULT_RASTER_MAXZOOM
 
@@ -1192,13 +1202,18 @@ def _build_tile_token_for_dataset(
     """
     if dataset.record.record_type in RASTER_FAMILY_RECORD_TYPES:
         bounds = None
+        lon_span = None
         if dataset.record.spatial_extent is not None:
             # fix(#892): the SPAN, not the RFC 7946 spec bbox. These bounds feed
-            # _raster_maxzoom_from_metadata's `maxx - minx` span arithmetic and
-            # the tile source's own bounds; a west > east pair makes the span
-            # negative, which collapses the derived maxzoom and bounds the
+            # the tile source's own bounds; a west > east pair would bound the
             # source to nothing. -180..180 is over-broad but never inverted.
             bounds = extent_to_span_bbox(dataset.record.spatial_extent)
+            # fix(#887): and the honest width alongside it, because -180..180 is
+            # exactly as wrong for the resolution derivation as an inverted pair
+            # -- a seam-crossing raster measured 360° wide, understated its own
+            # resolution by 36x, and lost five zoom levels of maxzoom, so it
+            # stopped rendering as the user zoomed in.
+            lon_span = extent_lon_span(dataset.record.spatial_extent)
             if bounds is None:
                 logger.warning(
                     "Failed to parse spatial extent bounds",
@@ -1210,7 +1225,9 @@ def _build_tile_token_for_dataset(
             tile_url=f"/raster-tiles/{dataset.id}/tiles/{{z}}/{{x}}/{{y}}.png",
             bounds=bounds,
             minzoom=0,
-            maxzoom=_raster_maxzoom_from_metadata(raster_asset, bounds),
+            maxzoom=_raster_maxzoom_from_metadata(
+                raster_asset, bounds, lon_span=lon_span
+            ),
             tile_size=256,
             format="png",
         )

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -1083,8 +1083,12 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # fix(#892): +2 — the raster tile-token bounds moved onto
     # extent_to_span_bbox() so a seam-crossing extent cannot feed a negative
     # span into the maxzoom derivation.
-    # Merge of the carve-outs: 2043 base + 3 + 1 + 2. Ratchet stays exact.
-    "backend/app/processing/tiles/router.py": 2049,
+    # fix(#887): +17 — extent_to_span_bbox reports -180..180 for a two-ring seam
+    # extent, which understates a Pacific raster's resolution by 36x and drops
+    # its maxzoom by five levels, so the honest width now travels alongside the
+    # bounds as an explicit `lon_span` keyword.
+    # Merge of the carve-outs: 2043 base + 3 + 1 + 2 + 17. Ratchet stays exact.
+    "backend/app/processing/tiles/router.py": 2066,
 }
 
 

--- a/backend/tests/test_raster_antimeridian_887.py
+++ b/backend/tests/test_raster_antimeridian_887.py
@@ -130,9 +130,14 @@ def _project(epsg: int, lonlat_bounds: tuple[float, float, float, float]):
     return (xs[0], ys[0], xs[1], ys[1])
 
 
-def _dst_x_offs(vrt_path: str) -> list[int]:
+def _dst_x_offs(vrt_path: str) -> list[float]:
+    """Destination x offsets — float, because they are legitimately fractional.
+
+    Both writers keep sub-pixel offsets (fix(#887)), so this must not coerce to
+    int; `50.0 == 50` keeps whole-pixel assertions readable.
+    """
     root = parse_vrt(vrt_path).getroot()
-    return [int(d.get("xOff")) for d in root.iter("DstRect")]
+    return [float(d.get("xOff")) for d in root.iter("DstRect")]
 
 
 def _vrt_geotransform(vrt_path: str) -> list[float]:
@@ -519,9 +524,55 @@ class TestSeamStraddlingVrt:
         out = _write_python_vrt(sources, str(tmp_path / "proj.vrt"), "finest")
 
         assert _vrt_geotransform(out)[0] == pytest.approx(-half)
-        # 4.0075e7 m of easting at 2e4 m/px: the eastern tile starts 1954 px in.
+        # 4.0075e7 m of easting at 2e4 m/px. The eastern tile starts 1953.75 px
+        # in and keeps that fraction — these sources are off the output grid, and
+        # rounding to 1954 would slide them a quarter pixel (fix(#887)).
         assert _vrt_size(out) == (2004, 50)
-        assert _dst_x_offs(out) == [0, 1954]
+        offsets = _dst_x_offs(out)
+        assert offsets[0] == 0
+        assert offsets[1] == pytest.approx(1953.7508342789, abs=1e-6)
+
+    def test_fallback_keeps_fractional_geometry_like_the_rewrite(self, tmp_path):
+        """The fallback writer obeys the same geometry rule as the rewrite.
+
+        Both writers now go through ``_offset_text`` and ``_containing_pixels``.
+        Before that, this fallback rounded a source needing ``xOff`` 248.5 down
+        to 248 and sized the 298.5-pixel hull at 298 — sliding the eastern tile
+        half a pixel and clipping the edge. It is unreachable in the shipped
+        worker (the image installs ``gdal-bin``), but two writers disagreeing
+        about one rule is what produced the first regression in this PR.
+        """
+        sources = [
+            _write_tif(
+                tmp_path / "w.tif",
+                epsg=4326,
+                bounds=(175.03, 0.0, 180.0, 2.0),
+                width=50,
+                height=20,
+            ),
+            _write_tif(
+                tmp_path / "e.tif",
+                epsg=4326,
+                bounds=(-180.0, 0.0, -179.0, 2.0),
+                width=50,
+                height=20,
+            ),
+        ]
+
+        out = _write_python_vrt(sources, str(tmp_path / "frac.vrt"), "finest")
+
+        root = parse_vrt(out).getroot()
+        rects = [
+            (float(d.get("xOff")), float(d.get("xSize"))) for d in root.iter("DstRect")
+        ]
+        width = int(root.get("rasterXSize"))
+
+        assert rects[1][0] == pytest.approx(248.5), (
+            "the eastern tile must keep its half-pixel offset"
+        )
+        far_edge = max(off + size for off, size in rects)
+        assert far_edge == pytest.approx(298.5)
+        assert width == 299, "the hull must be rounded UP to contain 298.5 px"
 
     def test_band_stack_seam_sources_share_the_shifted_frame(self, tmp_path):
         """``-separate`` band stacks re-frame identically to a mosaic."""

--- a/backend/tests/test_raster_antimeridian_887.py
+++ b/backend/tests/test_raster_antimeridian_887.py
@@ -57,6 +57,7 @@ from app.processing.raster.vrt import (
     shift_vrt_longitude_frame,
     sources_seam_frame_origin,
 )
+from app.processing.raster.vrt_rewrite import rewrite_vrt_sources
 from app.processing.tiles.router import _raster_maxzoom_from_metadata
 
 
@@ -889,6 +890,80 @@ class TestSeamFrameRewriteAgainstRealGdal:
         with rasterio.open(out) as ds:
             assert (ds.width, ds.height) == (100, 50)
             assert ds.mask_flag_enums[0][0].name == "per_dataset"
+
+    def test_frame_origin_is_computed_not_taken_from_argv_order(self, tmp_path):
+        """Three sources whose frame origin is the SECOND one on the command line.
+
+        Catches a whole class of "just use the first source" errors: the origin is
+        175 (``p1``), so the sources must land 2, 1, 3 across the hull, not in the
+        order they were passed.
+        """
+        sources = [
+            self._nodata_tile(
+                tmp_path / "p0.tif", bounds=(-180.0, 0.0, -175.0, 5.0), value=1
+            ),
+            self._nodata_tile(
+                tmp_path / "p1.tif", bounds=(175.0, 0.0, 180.0, 5.0), value=2
+            ),
+            self._nodata_tile(
+                tmp_path / "p2.tif", bounds=(-175.0, 0.0, -170.0, 5.0), value=3
+            ),
+        ]
+
+        out = vrt_module._build_vrt(sources, str(tmp_path / "three.vrt"), "finest")
+
+        with rasterio.open(out) as ds:
+            assert (ds.width, ds.height) == (150, 50)
+            assert ds.bounds.left == pytest.approx(175.0)
+            assert ds.bounds.right == pytest.approx(190.0)
+            row = ds.read(1)[0]
+
+        assert set(row[:50].tolist()) == {2}
+        assert set(row[50:100].tolist()) == {1}
+        assert set(row[100:].tolist()) == {3}
+
+    def test_band_stack_keeps_per_band_nodata_across_the_seam(self, tmp_path):
+        """``-separate`` through the real binary: each band keeps its own source."""
+        sources = [
+            self._nodata_tile(
+                tmp_path / "bw.tif", bounds=(175.0, 0.0, 180.0, 5.0), value=7
+            ),
+            self._nodata_tile(
+                tmp_path / "be.tif", bounds=(-180.0, 0.0, -175.0, 5.0), value=9
+            ),
+        ]
+
+        out = build_vrt("band_stack", sources, str(tmp_path / "stack.vrt"), "finest")
+
+        with rasterio.open(out) as ds:
+            assert (ds.width, ds.height) == (100, 50)
+            assert ds.bounds.left == pytest.approx(175.0)
+            assert ds.count == 2
+            assert ds.nodatavals == (0.0, 0.0)
+            # Band 1 carries the western tile, band 2 the eastern one; the rest of
+            # each band is fill. A mis-shifted frame would put them on top of
+            # each other or off the raster entirely.
+            assert set(ds.read(1)[:, :50].ravel().tolist()) == {7}
+            assert set(ds.read(2)[:, 50:].ravel().tolist()) == {9}
+
+    def test_rewritten_vrt_still_accepts_the_stor03_source_rewrite(self, tmp_path):
+        """``rewrite_vrt_sources`` runs after this at the store site (STOR-03)."""
+        sources = [
+            self._nodata_tile(
+                tmp_path / "sw.tif", bounds=(175.0, 0.0, 180.0, 5.0), value=7
+            ),
+            self._nodata_tile(
+                tmp_path / "se.tif", bounds=(-180.0, 0.0, -175.0, 5.0), value=9
+            ),
+        ]
+        out = vrt_module._build_vrt(sources, str(tmp_path / "seam.vrt"), "finest")
+
+        rewrite_vrt_sources(Path(out), vrt_storage_key="rasters/x/source.vrt")
+
+        with rasterio.open(out) as ds:
+            assert (ds.width, ds.height) == (100, 50)
+            assert ds.bounds.left == pytest.approx(175.0)
+            assert ds.nodata == 0.0
 
     def test_non_crossing_build_is_byte_identical_to_plain_gdalbuildvrt(self, tmp_path):
         """Nothing off the seam changes shape because of this PR."""

--- a/backend/tests/test_raster_antimeridian_887.py
+++ b/backend/tests/test_raster_antimeridian_887.py
@@ -1098,6 +1098,39 @@ class TestSeamFrameRewrite:
             "— the sources were left scattered across a world"
         )
 
+    @pytest.mark.parametrize(
+        "value,expected",
+        [
+            (0.0, "0"),
+            (50.0, "50"),
+            (-0.0, "0"),
+            # Noise below the ABSOLUTE floor is still absorbed, so ordinary
+            # whole-pixel output keeps matching GDAL's own formatting.
+            (50.0000000001, "50"),
+            (49.99999999999999, "50"),
+        ],
+    )
+    def test_offset_text_renders_whole_pixels_as_integers(self, value, expected):
+        assert vrt_module._offset_text(value) == expected
+
+    @pytest.mark.parametrize(
+        "value", [248.5, 349.51, 1953.7508342789244, 100000000.05, 1000000000.49]
+    )
+    def test_offset_text_keeps_fractions_at_every_magnitude(self, value):
+        """A fraction must survive regardless of how large the offset is.
+
+        ``math.isclose`` compares against ``max(rel_tol * max(|a|,|b|), abs_tol)``,
+        so leaving the default ``rel_tol=1e-9`` alive makes the tolerance grow
+        with the offset — 0.1 px at 1e8, a full pixel at 1e9. A real 0.49-pixel
+        offset was being rounded away. Asserted as a property rather than an
+        exact string so the check is about the fraction surviving, not about
+        formatting.
+        """
+        rendered = vrt_module._offset_text(value)
+
+        assert "." in rendered, f"{value!r} was coerced to a whole pixel"
+        assert float(rendered) == pytest.approx(value, abs=1e-6)
+
     def test_whole_pixel_offsets_stay_integral(self, tmp_path):
         """The common case still reads like GDAL's own output, not ``50.0``.
 

--- a/backend/tests/test_raster_antimeridian_887.py
+++ b/backend/tests/test_raster_antimeridian_887.py
@@ -47,7 +47,12 @@ from shapely import wkt as shapely_wkt
 from sqlalchemy import func, select
 
 from app.core.config import settings
-from app.core.geo import bbox_to_extent_wkt, extent_lon_span, extent_to_bbox
+from app.core.geo import (
+    LON_EPSILON_DEGREES,
+    bbox_to_extent_wkt,
+    extent_lon_span,
+    extent_to_bbox,
+)
 from app.modules.auth.models import User
 from app.modules.catalog.datasets.domain.models import Dataset, Record
 from app.processing.raster.cog import extract_raster_metadata
@@ -1024,14 +1029,22 @@ class TestSeamFrameRewrite:
         assert min(off for off, _ in offsets) == pytest.approx(0.0, abs=1e-6), (
             "the frame must be anchored on a source"
         )
-        # The true circular footprint, closed the short way round.
-        true_span = (max(right for _, right in sources) + 360.0) - min(
-            left for left, _ in sources
+        # Recompute the expected hull independently, in the shifted frame, and
+        # require the raster to match it to within a pixel. A loose "< 359°"
+        # bound would pass a mosaic that is merely less broken than before; this
+        # pins the actual footprint.
+        shifted = [
+            (left + 360.0, right + 360.0)
+            if left < seam_origin - LON_EPSILON_DEGREES
+            else (left, right)
+            for left, right in sources
+        ]
+        expected_span = max(right for _, right in shifted) - min(
+            left for left, _ in shifted
         )
-        true_span = min(true_span % 360.0, 360.0 - (true_span % 360.0)) or true_span
-        assert width * res_x < 360.0 - 1.0, (
-            f"re-framed hull is {width * res_x:.2f}° — the sources were left "
-            "scattered across a world"
+        assert width * res_x == pytest.approx(expected_span, abs=2 * res_x), (
+            f"re-framed hull is {width * res_x:.4f}°, expected {expected_span:.4f}° "
+            "— the sources were left scattered across a world"
         )
 
     def test_whole_pixel_offsets_stay_integral(self, tmp_path):

--- a/backend/tests/test_raster_antimeridian_887.py
+++ b/backend/tests/test_raster_antimeridian_887.py
@@ -1,0 +1,666 @@
+"""Antimeridian handling in the raster pipeline (#887).
+
+Three sites, one seam:
+
+1. ``processing/raster/cog.py`` — ``extract_raster_metadata`` folded the
+   reprojected WGS84 bounds into a single hand-built ``POLYGON`` ring. GDAL
+   already reports a seam-crossing footprint as ``west > east``, so that ring
+   was the *complement*: a Pacific COG spanning 175E..175W registered a valid
+   350°-wide rectangle covering 7000 deg² of the wrong side of the world
+   instead of its real 200.
+2. ``processing/raster/vrt.py`` — ``_write_python_vrt`` took ``min(left)`` /
+   ``max(right)`` across sources, so a 10°-wide mosaic straddling the seam was
+   allocated 360° wide (3600 x 50 px instead of 100 x 50) with every source at
+   the wrong ``dst_x_off``.
+3. ``processing/tiles/router.py`` — the user-visible symptom. Source maxzoom is
+   derived from extent width when the COG has no recorded resolution, so a
+   seam-crossing raster measured 36x too wide, understated its own resolution,
+   and stopped rendering as the user zoomed in.
+
+The DB-backed tests need Postgres (``docker compose up -d --wait db``); the rest
+are pure rasterio/XML unit tests.
+"""
+
+import io
+import uuid
+from pathlib import Path
+from xml.etree.ElementTree import parse as parse_vrt
+
+import numpy as np
+import pytest
+import rasterio
+from httpx import AsyncClient
+from rasterio.crs import CRS
+from rasterio.io import MemoryFile
+from rasterio.transform import from_bounds
+from rasterio.warp import transform as warp_transform
+from shapely import wkt as shapely_wkt
+from sqlalchemy import func, select
+
+from app.core.config import settings
+from app.core.geo import bbox_to_extent_wkt, extent_lon_span, extent_to_bbox
+from app.modules.auth.models import User
+from app.modules.catalog.datasets.domain.models import Dataset, Record
+from app.processing.raster.cog import extract_raster_metadata
+from app.processing.raster.models import RasterAsset
+from app.processing.raster.vrt import _seam_frame_origin, _write_python_vrt
+from app.processing.tiles.router import _raster_maxzoom_from_metadata
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+WGS84 = CRS.from_epsg(4326)
+# EPSG:3832 — WGS 84 / PDC Mercator, central meridian 150E. The canonical
+# Pacific-centred projection: its easting runs continuously across ±180.
+PDC = CRS.from_epsg(3832)
+WEB_MERCATOR_HALF_WORLD_M = 20037508.342789244
+
+
+def _write_tif(
+    path: Path,
+    *,
+    epsg: int | None,
+    bounds: tuple[float, float, float, float],
+    width: int = 64,
+    height: int = 64,
+) -> str:
+    """Write a synthetic single-band GeoTIFF at the given native bounds."""
+    profile = {
+        "driver": "GTiff",
+        "dtype": "uint8",
+        "width": width,
+        "height": height,
+        "count": 1,
+        "transform": from_bounds(*bounds, width, height),
+    }
+    if epsg is not None:
+        profile["crs"] = CRS.from_epsg(epsg)
+
+    buf = io.BytesIO()
+    with MemoryFile() as mem:
+        with mem.open(**profile) as ds:
+            ds.write(np.zeros((height, width), dtype="uint8"), 1)
+        buf.write(mem.read())
+    path.write_bytes(buf.getvalue())
+    return str(path)
+
+
+def _project(epsg: int, lonlat_bounds: tuple[float, float, float, float]):
+    """Project a lon/lat rectangle's corners into ``epsg``'s own units.
+
+    The west corner is transformed first so a seam-crossing rectangle keeps its
+    real (continuous) easting order in a Pacific-centred CRS.
+    """
+    west, south, east, north = lonlat_bounds
+    xs, ys = warp_transform(WGS84, CRS.from_epsg(epsg), [west, east], [south, north])
+    return (xs[0], ys[0], xs[1], ys[1])
+
+
+def _dst_x_offs(vrt_path: str) -> list[int]:
+    root = parse_vrt(vrt_path).getroot()
+    return [int(d.get("xOff")) for d in root.iter("DstRect")]
+
+
+def _vrt_geotransform(vrt_path: str) -> list[float]:
+    root = parse_vrt(vrt_path).getroot()
+    return [float(v) for v in root.find("GeoTransform").text.split(",")]
+
+
+def _vrt_size(vrt_path: str) -> tuple[int, int]:
+    root = parse_vrt(vrt_path).getroot()
+    return int(root.get("rasterXSize")), int(root.get("rasterYSize"))
+
+
+# ---------------------------------------------------------------------------
+# Site 1: extract_raster_metadata / bbox_wkt
+# ---------------------------------------------------------------------------
+
+
+class TestCogExtentFold:
+    def test_pacific_cog_registers_two_ring_extent(self, tmp_path):
+        """A 3832 COG spanning 175E..175W registers its real 10° footprint.
+
+        The pre-fix ring covered 7000 deg² between 175W and 175E — a valid
+        rectangle that does not even contain the data it describes.
+        """
+        tif = _write_tif(
+            tmp_path / "pacific.tif",
+            epsg=3832,
+            bounds=_project(3832, (175.0, -10.0, -175.0, 10.0)),
+        )
+        meta = extract_raster_metadata(tif)
+
+        west, south, east, north = meta["bounds_wgs84"]
+        assert west == pytest.approx(175.0)
+        assert east == pytest.approx(-175.0)
+        assert west > east, "a seam-crossing footprint must report west > east"
+        assert (south, north) == (pytest.approx(-10.0), pytest.approx(10.0))
+
+        geom = shapely_wkt.loads(meta["bbox_wkt"])
+        assert geom.geom_type == "MultiPolygon"
+        assert len(geom.geoms) == 2
+        assert geom.is_valid
+        # 10 deg of longitude x 20 deg of latitude. The bug produced 350 x 20.
+        assert geom.area == pytest.approx(200.0, rel=1e-6)
+
+    def test_pacific_cog_extent_reads_back_as_west_east(self, tmp_path):
+        """The stored WKT round-trips through ``extent_to_bbox`` unchanged.
+
+        This is the #901 contract: the two rings must share one latitude band or
+        the reader degrades to an over-broad -180..180.
+        """
+        from geoalchemy2.shape import from_shape
+
+        tif = _write_tif(
+            tmp_path / "pacific.tif",
+            epsg=3832,
+            bounds=_project(3832, (175.0, -10.0, -175.0, 10.0)),
+        )
+        meta = extract_raster_metadata(tif)
+        extent = from_shape(shapely_wkt.loads(meta["bbox_wkt"]), srid=4326)
+
+        bbox = extent_to_bbox(extent)
+        assert bbox[0] == pytest.approx(175.0)
+        assert bbox[2] == pytest.approx(-175.0)
+        assert extent_lon_span(extent) == pytest.approx(10.0)
+
+    def test_global_web_mercator_raster_extent_unchanged(self, tmp_path):
+        """Regression guard: a genuinely global raster stays -180..180."""
+        half = WEB_MERCATOR_HALF_WORLD_M
+        tif = _write_tif(
+            tmp_path / "global3857.tif",
+            epsg=3857,
+            bounds=(-half, -half, half, half),
+        )
+        meta = extract_raster_metadata(tif)
+
+        west, _, east, _ = meta["bounds_wgs84"]
+        assert west == pytest.approx(-180.0)
+        assert east == pytest.approx(180.0)
+
+        geom = shapely_wkt.loads(meta["bbox_wkt"])
+        assert geom.geom_type == "Polygon"
+        assert geom.bounds[0] == pytest.approx(-180.0)
+        assert geom.bounds[2] == pytest.approx(180.0)
+
+    def test_global_pacific_raster_records_the_whole_world(self, tmp_path):
+        """A global 3832 raster is 360° wide, not a zero-area line at lon -30.
+
+        Its left and right edges land on the *same* meridian, so GDAL can only
+        report a zero-width longitude range for it, and the pre-fix ring
+        recorded the globe as a 0 deg² sliver.
+        """
+        half = WEB_MERCATOR_HALF_WORLD_M
+        tif = _write_tif(
+            tmp_path / "global3832.tif",
+            epsg=3832,
+            bounds=(-half, -8_000_000.0, half, 8_000_000.0),
+        )
+        meta = extract_raster_metadata(tif)
+
+        west, south, east, north = meta["bounds_wgs84"]
+        assert west == pytest.approx(-180.0)
+        assert east == pytest.approx(180.0)
+
+        geom = shapely_wkt.loads(meta["bbox_wkt"])
+        assert geom.geom_type == "Polygon"
+        assert geom.area == pytest.approx(360.0 * (north - south), rel=1e-6)
+        assert geom.area > 0.0
+
+    def test_pacific_sliver_is_not_inflated_to_the_globe(self, tmp_path):
+        """Near miss for the degenerate-range repair: a 2 m-wide 3832 raster.
+
+        Differs from the global fixture in exactly one axis — the same CRS, the
+        same latitude band, only the easting width changes. A span-only guard
+        would read the near-zero longitude range as a wrap.
+        """
+        tif = _write_tif(
+            tmp_path / "sliver.tif",
+            epsg=3832,
+            bounds=(-1.0, -8_000_000.0, 1.0, 8_000_000.0),
+        )
+        meta = extract_raster_metadata(tif)
+
+        west, _, east, _ = meta["bounds_wgs84"]
+        assert west == pytest.approx(150.0, abs=1e-4)
+        assert east == pytest.approx(150.0, abs=1e-4)
+        geom = shapely_wkt.loads(meta["bbox_wkt"])
+        assert geom.geom_type == "Polygon"
+        assert geom.bounds[0] > 149.0, "a sliver must not widen to the whole world"
+
+    @pytest.mark.parametrize(
+        "label,epsg,lonlat",
+        [
+            # Each of these is 10 deg wide over the same latitude band as the
+            # crossing fixture above: only the longitude POSITION differs, so a
+            # miss here is a real guard failure and not a fixture difference.
+            ("ends flush at +180", 3857, (170.0, -10.0, 180.0, 10.0)),
+            ("ends flush at +180 (pacific crs)", 3832, (170.0, -10.0, 180.0, 10.0)),
+            ("starts flush at -180", 3857, (-180.0, -10.0, -170.0, 10.0)),
+            ("prime-meridian straddle", 3857, (-5.0, -10.0, 5.0, 10.0)),
+        ],
+    )
+    def test_near_miss_footprints_stay_single_ring(self, tmp_path, label, epsg, lonlat):
+        tif = _write_tif(
+            tmp_path / f"{abs(hash(label))}.tif",
+            epsg=epsg,
+            bounds=_project(epsg, lonlat),
+        )
+        meta = extract_raster_metadata(tif)
+
+        west, _, east, _ = meta["bounds_wgs84"]
+        assert west < east, f"{label}: must stay monotonic"
+        assert west == pytest.approx(lonlat[0], abs=1e-6)
+        assert east == pytest.approx(lonlat[2], abs=1e-6)
+
+        geom = shapely_wkt.loads(meta["bbox_wkt"])
+        assert geom.geom_type == "Polygon", f"{label}: no seam split expected"
+        assert geom.area == pytest.approx(200.0, rel=1e-6)
+
+    @pytest.mark.parametrize(
+        "label,lonlat,expect_split",
+        [
+            # A 180-degree-wide footprint is the exact boundary of the "wider
+            # than 180" guard and must not be re-framed.
+            ("exactly 180 wide", (-10.0, -10.0, 170.0, 10.0), False),
+            ("global", (-180.0, -90.0, 180.0, 90.0), False),
+            # 0..360-domain source, which is what the seam-aware VRT builder
+            # emits for a straddling mosaic.
+            ("0..360 domain", (175.0, -10.0, 185.0, 10.0), True),
+            ("below -180 domain", (-185.0, -10.0, -175.0, 10.0), True),
+        ],
+    )
+    def test_geographic_source_longitudes_are_folded(
+        self, tmp_path, label, lonlat, expect_split
+    ):
+        tif = _write_tif(
+            tmp_path / f"geo{abs(hash(label))}.tif", epsg=4326, bounds=lonlat
+        )
+        meta = extract_raster_metadata(tif)
+        geom = shapely_wkt.loads(meta["bbox_wkt"])
+
+        if expect_split:
+            assert geom.geom_type == "MultiPolygon", f"{label}: expected two rings"
+            assert len(geom.geoms) == 2
+            assert geom.area == pytest.approx(200.0, rel=1e-6)
+            assert meta["bounds_wgs84"][0] > meta["bounds_wgs84"][2]
+        else:
+            assert geom.geom_type == "Polygon", f"{label}: expected one ring"
+            assert meta["bounds_wgs84"][0] < meta["bounds_wgs84"][2]
+            expected_area = (lonlat[2] - lonlat[0]) * (lonlat[3] - lonlat[1])
+            assert geom.area == pytest.approx(expected_area, rel=1e-6)
+
+    def test_crs_less_raster_bounds_are_not_folded(self, tmp_path):
+        """Without a CRS the bounds are not longitudes; leave them alone.
+
+        A pixel-space right edge past 360 must not be reinterpreted as a wrap of
+        the world.
+        """
+        tif = _write_tif(
+            tmp_path / "nocrs.tif", epsg=None, bounds=(0.0, 0.0, 4000.0, 2000.0)
+        )
+        meta = extract_raster_metadata(tif)
+
+        assert meta["bounds_wgs84"] == (0.0, 0.0, 4000.0, 2000.0)
+
+
+# ---------------------------------------------------------------------------
+# Site 2: _write_python_vrt mosaic geometry
+# ---------------------------------------------------------------------------
+
+
+class TestSeamFrameOrigin:
+    """The frame chooser's two guards, at their boundaries."""
+
+    @pytest.mark.parametrize(
+        "label,spans,expected",
+        [
+            ("seam-adjacent pair", [(175.0, 180.0), (-180.0, -175.0)], 175.0),
+            ("seam pair with a gap", [(160.0, 170.0), (-170.0, -160.0)], 160.0),
+            (
+                "three sources, widest gap in the Atlantic",
+                [(100.0, 170.0), (-170.0, -100.0), (-50.0, -40.0)],
+                100.0,
+            ),
+            # Guard 1: nothing at or below 180 deg wide can be improved.
+            ("exactly 180 wide", [(-10.0, 80.0), (80.0, 170.0)], None),
+            ("ends flush at +180", [(170.0, 175.0), (175.0, 180.0)], None),
+            ("narrow pair", [(10.0, 15.0), (15.0, 20.0)], None),
+            # Guard 2: over 180 wide, but no frame is strictly narrower.
+            ("185 wide, contiguous", [(-10.0, 85.0), (85.0, 175.0)], None),
+            (
+                "global tiling",
+                [(-180.0 + 10 * i, -170.0 + 10 * i) for i in range(36)],
+                None,
+            ),
+        ],
+    )
+    def test_guard_boundaries(self, label, spans, expected):
+        assert _seam_frame_origin(spans) == expected, label
+
+    def test_shifted_hull_is_the_tightest_available(self):
+        """The chosen origin must minimise the hull, not merely improve on it."""
+        spans = [(100.0, 170.0), (-170.0, -100.0), (-50.0, -40.0)]
+        origin = _seam_frame_origin(spans)
+        hull = max(r + 360.0 if left < origin else r for left, r in spans) - origin
+        assert hull == pytest.approx(220.0)
+
+
+class TestSeamStraddlingVrt:
+    def _tiles(self, tmp_path, lon_pairs, *, epsg=4326, lat=(0.0, 5.0)):
+        return [
+            _write_tif(
+                tmp_path / f"tile{i}.tif",
+                epsg=epsg,
+                bounds=(west, lat[0], east, lat[1]),
+                width=50,
+                height=50,
+            )
+            for i, (west, east) in enumerate(lon_pairs)
+        ]
+
+    def test_mosaic_is_sized_to_the_real_footprint(self, tmp_path):
+        """Two 5° tiles either side of ±180 allocate 100 px, not 3600.
+
+        Pre-fix: rasterXSize 3600 (a full 360° at 0.1°/px) with the eastern
+        source parked at ``dst_x_off`` 3550 — an enormous, misregistered mosaic
+        with a 350° hole in the middle.
+        """
+        sources = self._tiles(tmp_path, [(175.0, 180.0), (-180.0, -175.0)])
+        out = _write_python_vrt(sources, str(tmp_path / "seam.vrt"), "finest")
+
+        assert _vrt_size(out) == (100, 50)
+        gt = _vrt_geotransform(out)
+        assert gt[0] == pytest.approx(175.0), "frame origin must be the western tile"
+        assert gt[1] == pytest.approx(0.1)
+        assert _dst_x_offs(out) == [0, 50]
+
+        with rasterio.open(out) as ds:
+            assert ds.bounds.left == pytest.approx(175.0)
+            assert ds.bounds.right == pytest.approx(185.0)
+
+    def test_seam_mosaic_extent_is_two_rings_end_to_end(self, tmp_path):
+        """The VRT the builder writes reads back as a two-ring 10° extent."""
+        sources = self._tiles(tmp_path, [(175.0, 180.0), (-180.0, -175.0)])
+        out = _write_python_vrt(sources, str(tmp_path / "seam.vrt"), "finest")
+
+        meta = extract_raster_metadata(out)
+        assert meta["bounds_wgs84"][0] == pytest.approx(175.0)
+        assert meta["bounds_wgs84"][2] == pytest.approx(-175.0)
+
+        geom = shapely_wkt.loads(meta["bbox_wkt"])
+        assert geom.geom_type == "MultiPolygon"
+        assert geom.area == pytest.approx(50.0, rel=1e-6)  # 10 deg x 5 deg
+
+    def test_non_crossing_mosaic_geometry_is_unchanged(self, tmp_path):
+        """Control: the same two 5° tiles, same latitude band, moved off the seam."""
+        sources = self._tiles(tmp_path, [(10.0, 15.0), (15.0, 20.0)])
+        out = _write_python_vrt(sources, str(tmp_path / "plain.vrt"), "finest")
+
+        assert _vrt_size(out) == (100, 50)
+        assert _vrt_geotransform(out)[0] == pytest.approx(10.0)
+        assert _dst_x_offs(out) == [0, 50]
+
+    def test_global_mosaic_is_not_reframed(self, tmp_path):
+        """A mosaic that really is -180..180 keeps its origin and its width."""
+        lon_pairs = [(-180.0 + 10 * i, -170.0 + 10 * i) for i in range(36)]
+        sources = self._tiles(tmp_path, lon_pairs)
+        out = _write_python_vrt(sources, str(tmp_path / "global.vrt"), "finest")
+
+        assert _vrt_geotransform(out)[0] == pytest.approx(-180.0)
+        assert _vrt_size(out)[0] == 36 * 50
+        assert _dst_x_offs(out) == [50 * i for i in range(36)]
+
+    def test_projected_sources_are_never_reframed(self, tmp_path):
+        """Metres are not degrees.
+
+        Two EPSG:3857 tiles at opposite ends of the world span 4e7 *metres*,
+        which clears a bare ">180" guard trivially; a +360 shift would move a
+        source by 360 m. The CRS gate is what stops it.
+        """
+        half = WEB_MERCATOR_HALF_WORLD_M
+        sources = [
+            _write_tif(
+                tmp_path / "west3857.tif",
+                epsg=3857,
+                bounds=(-half, 0.0, -half + 1_000_000.0, 1_000_000.0),
+                width=50,
+                height=50,
+            ),
+            _write_tif(
+                tmp_path / "east3857.tif",
+                epsg=3857,
+                bounds=(half - 1_000_000.0, 0.0, half, 1_000_000.0),
+                width=50,
+                height=50,
+            ),
+        ]
+        out = _write_python_vrt(sources, str(tmp_path / "proj.vrt"), "finest")
+
+        assert _vrt_geotransform(out)[0] == pytest.approx(-half)
+        # 4.0075e7 m of easting at 2e4 m/px: the eastern tile starts 1954 px in.
+        assert _vrt_size(out) == (2004, 50)
+        assert _dst_x_offs(out) == [0, 1954]
+
+    def test_band_stack_seam_sources_share_the_shifted_frame(self, tmp_path):
+        """``-separate`` band stacks re-frame identically to a mosaic."""
+        sources = self._tiles(tmp_path, [(175.0, 180.0), (-180.0, -175.0)])
+        out = _write_python_vrt(
+            sources, str(tmp_path / "stack.vrt"), "finest", separate=True
+        )
+
+        assert _vrt_size(out) == (100, 50)
+        assert _vrt_geotransform(out)[0] == pytest.approx(175.0)
+        assert _dst_x_offs(out) == [0, 50]
+
+
+# ---------------------------------------------------------------------------
+# Site 3: the maxzoom symptom
+# ---------------------------------------------------------------------------
+
+
+# The two-ring seam extent's planar bounds, i.e. what extent_to_span_bbox
+# reports for the Pacific COG above.
+SEAM_SPAN_BOUNDS = [-180.0, -10.0, 180.0, 10.0]
+# The same 10 deg x 20 deg footprint, moved off the seam. Longitude POSITION is
+# the only axis that differs, so a maxzoom difference between the two can only
+# come from the seam handling.
+OFF_SEAM_BOUNDS = [5.0, -10.0, 15.0, 10.0]
+
+
+def _extent_derived_asset(**overrides) -> RasterAsset:
+    """A COG whose maxzoom comes from the extent, not from recorded resolution.
+
+    ``res_x``/``res_y`` are left NULL — the only way into the extent-width
+    branch of ``_native_resolution_meters`` — and the pixel grid is anisotropic
+    so that longitude is the finer of the two axes. Both matter: see
+    ``test_latitude_axis_masks_the_collapse``.
+    """
+    fields = {
+        "dataset_id": uuid.uuid4(),
+        "asset_uri": "rasters/test/pacific.cog.tif",
+        "storage_backend": "local",
+        "epsg": 3832,
+        "width": 36000,
+        "height": 200,
+    }
+    fields.update(overrides)
+    return RasterAsset(**fields)
+
+
+class TestMaxzoomSymptom:
+    """A 360°-wide extent understates resolution and collapses maxzoom."""
+
+    def test_span_bbox_alone_collapses_maxzoom(self):
+        """The symptom, reproduced: 360° of width over 36000 px reads as 1113 m."""
+        asset = _extent_derived_asset()
+
+        assert _raster_maxzoom_from_metadata(asset, SEAM_SPAN_BOUNDS) == 8
+
+    def test_honest_lon_span_restores_maxzoom(self):
+        """The real 10° over the same 36000 px is 31 m — five zoom levels back."""
+        asset = _extent_derived_asset()
+
+        assert (
+            _raster_maxzoom_from_metadata(asset, SEAM_SPAN_BOUNDS, lon_span=10.0) == 13
+        )
+
+    def test_seam_and_off_seam_extents_agree(self):
+        """Same footprint, same latitudes — only the longitude moves."""
+        asset = _extent_derived_asset()
+
+        off_seam = _raster_maxzoom_from_metadata(asset, OFF_SEAM_BOUNDS)
+        on_seam = _raster_maxzoom_from_metadata(asset, SEAM_SPAN_BOUNDS, lon_span=10.0)
+
+        assert on_seam == off_seam == 13
+
+    def test_genuinely_global_extent_keeps_its_coarse_maxzoom(self):
+        """A raster that really is 360° wide is honestly coarse; leave it be."""
+        asset = _extent_derived_asset()
+
+        assert (
+            _raster_maxzoom_from_metadata(asset, SEAM_SPAN_BOUNDS, lon_span=360.0) == 8
+        )
+
+    def test_latitude_axis_masks_the_collapse(self):
+        """Documented limit of the symptom, and why the fixture above is skewed.
+
+        ``_native_resolution_meters`` takes ``min()`` across the two axes, so an
+        inflated longitude resolution is simply discarded whenever latitude is
+        the finer axis — which is the usual case for a square-pixel raster below
+        ~88° latitude. The bad width is still recorded, and still wrong; it just
+        cannot move the maxzoom for those rasters. Anyone tempted to drop the
+        ``lon_span`` plumbing because "the tests pass either way" should start
+        here.
+        """
+        square_pixels = _extent_derived_asset(width=1000, height=2000)
+
+        assert _raster_maxzoom_from_metadata(square_pixels, SEAM_SPAN_BOUNDS) == 8
+        assert (
+            _raster_maxzoom_from_metadata(
+                square_pixels, SEAM_SPAN_BOUNDS, lon_span=10.0
+            )
+            == 8
+        )
+
+    def test_recorded_resolution_still_wins(self):
+        """lon_span must not disturb the resolution-metadata path."""
+        asset = _extent_derived_asset(epsg=3857, res_x=1.39, res_y=1.39)
+
+        assert (
+            _raster_maxzoom_from_metadata(asset, SEAM_SPAN_BOUNDS, lon_span=10.0) == 17
+        )
+
+
+# ---------------------------------------------------------------------------
+# Site 3, end to end: the raster tile token
+# ---------------------------------------------------------------------------
+
+
+async def _seed_raster(
+    session,
+    *,
+    extent_wkt: str,
+    width: int = 36000,
+    height: int = 200,
+) -> Dataset:
+    admin = (
+        await session.execute(
+            select(User).where(User.username == settings.geolens_admin_username)
+        )
+    ).scalar_one()
+
+    record = Record(
+        title=f"Antimeridian raster {uuid.uuid4().hex[:6]}",
+        summary="Seam-crossing raster for #887",
+        theme_category=["test"],
+        visibility="public",
+        record_status="published",
+        record_type="raster_dataset",
+        created_by=admin.id,
+        updated_by=admin.id,
+    )
+    record.spatial_extent = func.ST_GeomFromText(extent_wkt, 4326)
+    session.add(record)
+    await session.flush()
+
+    dataset = Dataset(
+        record_id=record.id,
+        table_name=f"raster_887_{uuid.uuid4().hex[:8]}",
+        source_format="geotiff",
+        source_filename="pacific.tif",
+        srid=3832,
+    )
+    session.add(dataset)
+    await session.flush()
+
+    session.add(
+        RasterAsset(
+            dataset_id=dataset.id,
+            asset_uri=f"rasters/{dataset.id}/abc/source.cog.tif",
+            storage_backend="local",
+            epsg=3832,
+            width=width,
+            height=height,
+        )
+    )
+    await session.commit()
+    await session.refresh(dataset)
+    return dataset
+
+
+class TestRasterTokenAcrossTheSeam:
+    async def test_seam_crossing_raster_keeps_a_usable_maxzoom(
+        self, client: AsyncClient, test_db_session
+    ):
+        """The reported symptom: the raster stops rendering as you zoom in.
+
+        The stored extent is the two-ring form, whose planar bounds are
+        -180..180; without the honest width the token's maxzoom drops to 8 and
+        the layer disappears five zoom levels early.
+        """
+        dataset = await _seed_raster(
+            test_db_session,
+            extent_wkt=bbox_to_extent_wkt(175.0, -10.0, -175.0, 10.0),
+        )
+
+        resp = await client.get(f"/tiles/token/{dataset.id}/")
+        assert resp.status_code == 200
+        data = resp.json()
+
+        assert data["kind"] == "raster"
+        assert data["maxzoom"] == 13
+        # The tile source's own bounds stay monotonic (#892) — over-broad, never
+        # inverted — even though the maxzoom now uses the real 10 deg width.
+        assert data["bounds"][0] == pytest.approx(-180.0)
+        assert data["bounds"][2] == pytest.approx(180.0)
+
+    async def test_off_seam_raster_of_the_same_size_matches(
+        self, client: AsyncClient, test_db_session
+    ):
+        """Negative probe: identical footprint and latitudes, moved off the seam."""
+        dataset = await _seed_raster(
+            test_db_session,
+            extent_wkt=bbox_to_extent_wkt(5.0, -10.0, 15.0, 10.0),
+        )
+
+        resp = await client.get(f"/tiles/token/{dataset.id}/")
+        assert resp.status_code == 200
+
+        assert resp.json()["maxzoom"] == 13
+
+    async def test_global_raster_token_is_unchanged(
+        self, client: AsyncClient, test_db_session
+    ):
+        """A raster that really is 360° wide keeps its (honestly coarse) maxzoom."""
+        dataset = await _seed_raster(
+            test_db_session,
+            extent_wkt=bbox_to_extent_wkt(-180.0, -10.0, 180.0, 10.0),
+        )
+
+        resp = await client.get(f"/tiles/token/{dataset.id}/")
+        assert resp.status_code == 200
+
+        assert resp.json()["maxzoom"] == 8

--- a/backend/tests/test_raster_antimeridian_887.py
+++ b/backend/tests/test_raster_antimeridian_887.py
@@ -562,6 +562,39 @@ class TestSourcesSeamFrameOrigin:
 
         assert sources_seam_frame_origin([str(bogus)]) is None
 
+    def test_grads_based_geographic_crs_is_not_detected(self, tmp_path):
+        """``is_geographic`` is not the same as "wraps at ±180".
+
+        EPSG:4807 (NTF Paris) is geographic with an angular unit of GRADS: a full
+        turn is 400 and the seam sits at 200. The seam logic is written in
+        degrees end to end, so a 195..200 / -200..-195 pair here would be shifted
+        by 360 instead of 400 and land as a 40-grad hull instead of a 10-grad
+        one. Refuse rather than corrupt it.
+        """
+        sources = [
+            _write_tif(tmp_path / "g1.tif", epsg=4807, bounds=(195.0, 0.0, 200.0, 5.0)),
+            _write_tif(
+                tmp_path / "g2.tif", epsg=4807, bounds=(-200.0, 0.0, -195.0, 5.0)
+            ),
+        ]
+
+        assert sources_seam_frame_origin(sources) is None
+
+    def test_degree_based_non_4326_crs_is_still_detected(self, tmp_path):
+        """Positive control for the unit gate: EPSG:4269 is degrees, so it counts.
+
+        Differs from the grads fixture in exactly one axis — same longitudes,
+        same latitudes, same seam crossing, only the CRS's angular unit changes.
+        """
+        sources = [
+            _write_tif(tmp_path / "n1.tif", epsg=4269, bounds=(175.0, 0.0, 180.0, 5.0)),
+            _write_tif(
+                tmp_path / "n2.tif", epsg=4269, bounds=(-180.0, 0.0, -175.0, 5.0)
+            ),
+        ]
+
+        assert sources_seam_frame_origin(sources) == pytest.approx(175.0)
+
 
 # A gdalbuildvrt mosaic of two nodata-carrying tiles either side of ±180, as
 # emitted verbatim by BOTH GDAL 3.10.3 (worker image) and GDAL 3.13.0 (local):
@@ -741,6 +774,48 @@ class TestSeamFrameRewrite:
 
         with pytest.raises(RuntimeError, match="no GeoTransform"):
             shift_vrt_longitude_frame(str(vrt), 175.0)
+
+    def test_fractional_offsets_stay_fractional(self, tmp_path):
+        """Sub-pixel offsets must not be rounded to whole pixels.
+
+        ``gdalbuildvrt`` emits fractional ``xOff`` whenever a source is not
+        aligned to the chosen output grid — measured ``17751.5`` and ``349.51``
+        on mixed-resolution mosaics. Rounding slides the source by up to half an
+        output pixel and changes its resampling alignment.
+        """
+        vrt = tmp_path / "frac.vrt"
+        vrt.write_text(
+            '<VRTDataset rasterXSize="18000" rasterYSize="50">'
+            "<GeoTransform> -1.8e+02, 2.0e-02, 0.0, 5.0, 0.0, -2.0e-02</GeoTransform>"
+            '<VRTRasterBand dataType="Byte" band="1">'
+            "<ComplexSource>"
+            '<SrcRect xOff="0" yOff="0" xSize="50" ySize="50" />'
+            '<DstRect xOff="17751.5" yOff="0" xSize="248.5" ySize="50" />'
+            "</ComplexSource>"
+            "<ComplexSource>"
+            '<SrcRect xOff="0" yOff="0" xSize="50" ySize="50" />'
+            '<DstRect xOff="0" yOff="0" xSize="50" ySize="50" />'
+            "</ComplexSource>"
+            "</VRTRasterBand></VRTDataset>"
+        )
+
+        shift_vrt_longitude_frame(str(vrt), 175.0)
+
+        offsets = [d.get("xOff") for d in parse_vrt(str(vrt)).getroot().iter("DstRect")]
+        # 17751.5 px at 0.02 deg puts the western source at 175.03; re-anchored
+        # there it sits at 0, and the eastern source lands 248.5 px further on.
+        assert offsets == ["0", "248.5"]
+        assert float(offsets[1]) == pytest.approx(248.5)
+
+    def test_whole_pixel_offsets_stay_integral(self, tmp_path):
+        """The common case still reads like GDAL's own output, not ``50.0``."""
+        vrt = tmp_path / "whole.vrt"
+        vrt.write_text(_GDALBUILDVRT_SEAM_XML)
+
+        shift_vrt_longitude_frame(str(vrt), 175.0)
+
+        offsets = [d.get("xOff") for d in parse_vrt(str(vrt)).getroot().iter("DstRect")]
+        assert offsets == ["0", "50", "0"]
 
     def test_unopenable_source_is_left_to_gdalbuildvrt(self, tmp_path, monkeypatch):
         """The probe must never swallow a broken source's real error."""

--- a/backend/tests/test_raster_antimeridian_887.py
+++ b/backend/tests/test_raster_antimeridian_887.py
@@ -352,6 +352,42 @@ class TestCogExtentFold:
         assert geom.bounds[2] == pytest.approx(-170.0)
         assert geom.area == pytest.approx(200.0, rel=1e-6)
 
+    @pytest.mark.parametrize(
+        "label,lonlat",
+        [
+            # GDAL accepts georeferencing well outside the adjacent domains.
+            ("two turns east", (720.0, -10.0, 730.0, 10.0)),
+            ("two turns west", (-730.0, -10.0, -720.0, 10.0)),
+            ("one and a half turns", (540.0, -10.0, 550.0, 10.0)),
+            ("three turns east", (1080.0, -10.0, 1090.0, 10.0)),
+        ],
+    )
+    def test_arbitrary_wrap_counts_keep_their_true_footprint(
+        self, tmp_path, label, lonlat
+    ):
+        """A source wrapped more than once must not inflate.
+
+        ``wrap_longitude`` subtracts a single turn by design (#886), so a
+        720..730 source folded to 360..10 — read back as a crossing pair, with
+        the impossible 360..180 half dropped, recording -180..10. That is a
+        10° footprint stored as 190°, and the westward case was worse: -730..-720
+        recorded 37x its true area. Asserting AREA is the point; every wrong
+        answer here is a perfectly valid rectangle.
+        """
+        tif = _write_tif(
+            tmp_path / f"w{abs(hash(label))}.tif", epsg=4326, bounds=lonlat
+        )
+        meta = extract_raster_metadata(tif)
+
+        geom = shapely_wkt.loads(meta["bbox_wkt"])
+        expected_area = (lonlat[2] - lonlat[0]) * (lonlat[3] - lonlat[1])
+        assert geom.area == pytest.approx(expected_area, rel=1e-6), (
+            f"{label}: {lonlat[2] - lonlat[0]}° footprint recorded as "
+            f"{geom.area / (lonlat[3] - lonlat[1]):.1f}° wide"
+        )
+        assert geom.is_valid
+        assert -180.0 <= geom.bounds[0] and geom.bounds[2] <= 180.0
+
     def test_crs_less_raster_bounds_are_not_folded(self, tmp_path):
         """Without a CRS the bounds are not longitudes; leave them alone.
 

--- a/backend/tests/test_raster_antimeridian_887.py
+++ b/backend/tests/test_raster_antimeridian_887.py
@@ -25,6 +25,7 @@ extent MUST take ``clean_tables`` — see ``TestRasterTokenAcrossTheSeam``.
 """
 
 import io
+import math
 import shutil
 import subprocess
 import threading
@@ -955,6 +956,83 @@ class TestSeamFrameRewrite:
         )
         # And not over-allocated either — exactly the containing integer.
         assert width == 299
+
+    @pytest.mark.parametrize("res_x", [0.02, 0.01666666666666667, 1.0 / 3.0, 0.007])
+    @pytest.mark.parametrize(
+        "lefts",
+        [
+            (175.001, -180.0),
+            (175.123456789, -180.0),
+            (174.99999999, -179.87654321),
+            (170.3333333333, -175.6666666667),
+            (179.9, -180.0, -179.4),
+            (160.07, 170.07, -180.0, -170.0),
+        ],
+    )
+    def test_reframing_invariants_hold_for_off_grid_mosaics(
+        self, tmp_path, res_x, lefts
+    ):
+        """Property sweep over the whole re-framing path (#887).
+
+        Every one of these mosaics straddles ±180 with edges and resolutions
+        chosen to be awkward in binary, which is what makes `gdalbuildvrt` emit
+        fractional offsets and what makes a reconstructed edge land a hair off
+        its true value. Two invariants must survive all of them:
+
+        1. the raster CONTAINS every source (``rasterXSize >= max(xOff+xSize)``);
+        2. the sources are not left scattered across a world — the re-framed hull
+           must be near the real footprint, not ~360°.
+
+        This is the shape that caught the frame-chooser noise bug when
+        example-based tests did not. A bare ``<`` at any of the six comparison
+        sites in this path fails invariant 2 here.
+        """
+        widths = [4.0] * len(lefts)
+        sources = [(left, left + w) for left, w in zip(lefts, widths, strict=True)]
+
+        # What gdalbuildvrt emits: the plain min/max fold over -180..180.
+        old_left = min(left for left, _ in sources)
+        old_right = max(right for _, right in sources)
+        plain_width = max(1, math.ceil(round((old_right - old_left) / res_x, 6)))
+        rects = "".join(
+            f'<ComplexSource><DstRect xOff="{(left - old_left) / res_x!r}" yOff="0" '
+            f'xSize="{(right - left) / res_x!r}" ySize="10" /></ComplexSource>'
+            for left, right in sources
+        )
+        vrt = tmp_path / f"prop_{abs(hash((res_x, lefts)))}.vrt"
+        vrt.write_text(
+            f'<VRTDataset rasterXSize="{plain_width}" rasterYSize="10">'
+            f"<GeoTransform> {old_left!r}, {res_x!r}, 0.0, 5.0, 0.0, -{res_x!r}</GeoTransform>"
+            f'<VRTRasterBand dataType="Byte" band="1">{rects}</VRTRasterBand>'
+            "</VRTDataset>"
+        )
+
+        seam_origin = _seam_frame_origin(sources)
+        assert seam_origin is not None, "fixture must straddle the seam"
+        shift_vrt_longitude_frame(str(vrt), seam_origin)
+
+        root = parse_vrt(str(vrt)).getroot()
+        width = int(root.get("rasterXSize"))
+        offsets = [
+            (float(d.get("xOff")), float(d.get("xSize"))) for d in root.iter("DstRect")
+        ]
+        far_edge = max(off + size for off, size in offsets)
+
+        assert width >= far_edge, (
+            f"raster {width} px clips a source ending at {far_edge}"
+        )
+        assert min(off for off, _ in offsets) == pytest.approx(0.0, abs=1e-6), (
+            "the frame must be anchored on a source"
+        )
+        # The true circular footprint, closed the short way round.
+        true_span = (max(right for _, right in sources) + 360.0) - min(
+            left for left, _ in sources
+        )
+        true_span = min(true_span % 360.0, 360.0 - (true_span % 360.0)) or true_span
+        assert width * res_x < 360.0 - 1.0, (
+            f"re-framed hull is {width * res_x:.2f}° — the sources were left "
+            "scattered across a world"
+        )
 
     def test_whole_pixel_offsets_stay_integral(self, tmp_path):
         """The common case still reads like GDAL's own output, not ``50.0``.

--- a/backend/tests/test_raster_antimeridian_887.py
+++ b/backend/tests/test_raster_antimeridian_887.py
@@ -65,6 +65,7 @@ from app.processing.raster.vrt import (
     _seam_frame_origin,
     _write_python_vrt,
     build_vrt,
+    normalize_lon_span,
     shift_vrt_longitude_frame,
 )
 from app.processing.raster.vrt_rewrite import rewrite_vrt_sources
@@ -460,6 +461,73 @@ class TestSeamFrameOrigin:
     def test_margin_does_not_suppress_a_real_crossing(self, spans, expected):
         """The margin is 0.1 mm — it must not swallow a genuine 5° seam pair."""
         assert _seam_frame_origin(spans) == pytest.approx(expected)
+
+    @pytest.mark.parametrize(
+        "label,spans",
+        [
+            # 535 ≡ 175, so each of these is the same 10° seam mosaic expressed
+            # in a domain further out. The frame chooser shifts by exactly one
+            # turn, so before normalizing, a source further than that stayed WEST
+            # of the origin and the hull came out global — and it got worse with
+            # distance: measured 360°, 720° and 1080° for one, two and three
+            # turns. The chooser scored every one of them at 5°.
+            ("east +1 turn", [(535.0, 540.0), (-180.0, -175.0)]),
+            ("east +2 turns", [(895.0, 900.0), (-180.0, -175.0)]),
+            ("east +3 turns", [(1255.0, 1260.0), (-180.0, -175.0)]),
+            ("west -1 turn", [(175.0, 180.0), (-540.0, -535.0)]),
+            ("west -2 turns", [(175.0, 180.0), (-900.0, -895.0)]),
+            ("mixed east +1 / west -1", [(535.0, 540.0), (-540.0, -535.0)]),
+            ("mixed east +2 / west -1", [(895.0, 900.0), (-540.0, -535.0)]),
+            (
+                "three sources, one out",
+                [(175.0, 180.0), (-180.0, -175.0), (535.0, 540.0)],
+            ),
+        ],
+    )
+    def test_spans_more_than_one_turn_apart_still_yield_the_real_hull(
+        self, label, spans
+    ):
+        """Assert the HULL, not the origin — a wrong frame is still a valid one.
+
+        Normalizing restores the invariant the chooser's proof rests on (every
+        source at or east of the origin after one turn), so the placed hull must
+        come out 10°, not 360/720/1080.
+        """
+        normalized = [normalize_lon_span(left, right) for left, right in spans]
+        origin = _seam_frame_origin(normalized)
+        assert origin is not None, f"{label}: must still be detected as a crossing"
+
+        placed = [
+            (left + 360.0, right + 360.0)
+            if left < origin - LON_EPSILON_DEGREES
+            else (left, right)
+            for left, right in normalized
+        ]
+        hull = max(right for _, right in placed) - min(left for left, _ in placed)
+
+        assert hull == pytest.approx(10.0), (
+            f"{label}: placed hull is {hull:.1f}°, expected 10° — sources were "
+            "left scattered across a world"
+        )
+
+    def test_normalize_lon_span_preserves_width_and_in_range_values(self):
+        """A no-op for anything already inside one turn, which is every real raster."""
+        for left, right in [
+            (175.0, 180.0),
+            (-180.0, -175.0),
+            (-10.0, 170.0),
+            (0.0, 0.0),
+        ]:
+            assert normalize_lon_span(left, right) == (left, right)
+
+        for left, right, expected_left in [
+            (535.0, 540.0, 175.0),
+            (-540.0, -535.0, -180.0),
+            (895.0, 900.0, 175.0),
+        ]:
+            folded_left, folded_right = normalize_lon_span(left, right)
+            assert folded_left == pytest.approx(expected_left)
+            assert folded_right - folded_left == pytest.approx(right - left)
 
     def test_shifted_hull_is_the_tightest_available(self):
         """The chosen origin must minimise the hull, not merely improve on it."""
@@ -969,6 +1037,79 @@ class TestSeamFrameRewrite:
         shift_vrt_longitude_frame(str(vrt))
 
         assert vrt.read_text() == xml, f"{label}: file must be left untouched"
+
+    @pytest.mark.parametrize(
+        "label,lefts,expected_left",
+        [
+            ("east +1 turn", (535.0, -180.0), 175.0),
+            ("east +2 turns", (895.0, -180.0), 175.0),
+            ("west -1 turn", (175.0, -540.0), 175.0),
+            ("mixed east +1 / west -1", (535.0, -540.0), 175.0),
+        ],
+    )
+    def test_sources_more_than_one_turn_apart_size_to_the_real_footprint(
+        self, tmp_path, label, lefts, expected_left
+    ):
+        """The dimensions, end to end through the rewrite.
+
+        Same 10° seam mosaic, expressed in domains further than one turn apart.
+        Before normalizing, the frame chooser scored 5° and the rewrite emitted a
+        360°-wide raster (3600 px at 0.1°) — 720° and 1080° further out. Asserting
+        rasterXSize is the point: every wrong answer is a valid frame.
+        """
+        res_x = 0.1
+        rects = "".join(
+            f'<ComplexSource><DstRect xOff="{(left - min(lefts)) / res_x!r}" yOff="0" '
+            f'xSize="{5.0 / res_x!r}" ySize="20" /></ComplexSource>'
+            for left in lefts
+        )
+        span_px = (max(lefts) + 5.0 - min(lefts)) / res_x
+        vrt = tmp_path / f"turns{abs(hash(label))}.vrt"
+        vrt.write_text(
+            f'<VRTDataset rasterXSize="{int(span_px)}" rasterYSize="20">'
+            f"<SRS>{_WGS84_WKT}</SRS>"
+            f"<GeoTransform> {min(lefts)!r}, {res_x!r}, 0.0, 5.0, 0.0, -{res_x!r}"
+            "</GeoTransform>"
+            f'<VRTRasterBand dataType="Byte" band="1">{rects}</VRTRasterBand>'
+            "</VRTDataset>"
+        )
+
+        shift_vrt_longitude_frame(str(vrt))
+
+        root = parse_vrt(str(vrt)).getroot()
+        width = int(root.get("rasterXSize"))
+        assert width == 100, (
+            f"{label}: raster is {width} px ({width * res_x:.0f}°), expected 100 "
+            "px (10°)"
+        )
+        assert float(root.find("GeoTransform").text.split(",")[0]) == pytest.approx(
+            expected_left
+        )
+
+    def test_rotated_geotransform_is_left_untouched(self, tmp_path):
+        """A rotated GeoTransform means gt[0] is not a pure longitude origin.
+
+        ``gdalbuildvrt`` never emits rotation terms, but translating gt[0] along
+        x under one would shear the mosaic. Decline rather than assume — same
+        cannot-decide path as a missing SRS.
+        """
+        xml = (
+            '<VRTDataset rasterXSize="3600" rasterYSize="50">'
+            f"<SRS>{_WGS84_WKT}</SRS>"
+            "<GeoTransform>-180.0, 0.1, 0.02, 5.0, 0.03, -0.1</GeoTransform>"
+            '<VRTRasterBand dataType="Byte" band="1">'
+            '<ComplexSource><DstRect xOff="3550" yOff="0" xSize="50" ySize="50" />'
+            "</ComplexSource>"
+            '<ComplexSource><DstRect xOff="0" yOff="0" xSize="50" ySize="50" />'
+            "</ComplexSource>"
+            "</VRTRasterBand></VRTDataset>"
+        )
+        vrt = tmp_path / "rotated.vrt"
+        vrt.write_text(xml)
+
+        shift_vrt_longitude_frame(str(vrt))
+
+        assert vrt.read_text() == xml
 
     def test_missing_output_does_not_crash_a_successful_build(
         self, tmp_path, monkeypatch

--- a/backend/tests/test_raster_antimeridian_887.py
+++ b/backend/tests/test_raster_antimeridian_887.py
@@ -24,11 +24,14 @@ are pure rasterio/XML unit tests. Any test here that commits a seam-crossing
 extent MUST take ``clean_tables`` — see ``TestRasterTokenAcrossTheSeam``.
 """
 
+import contextlib
 import io
 import math
 import shutil
 import subprocess
 import threading
+import time
+import urllib.request
 import uuid
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
@@ -62,9 +65,7 @@ from app.processing.raster.vrt import (
     _seam_frame_origin,
     _write_python_vrt,
     build_vrt,
-    is_attacker_controllable_source,
     shift_vrt_longitude_frame,
-    sources_seam_frame_origin,
 )
 from app.processing.raster.vrt_rewrite import rewrite_vrt_sources
 from app.processing.tiles.router import _raster_maxzoom_from_metadata
@@ -591,88 +592,30 @@ class TestSeamStraddlingVrt:
 # ---------------------------------------------------------------------------
 
 
-class TestSourcesSeamFrameOrigin:
-    """The build-time probe, on the inputs that must not trip it."""
+class TestSeamDecisionOpensNothing:
+    """The seam decision comes from the built XML, never from opening sources.
 
-    def test_geographic_seam_pair_is_detected(self, tmp_path):
-        sources = [
-            _write_tif(tmp_path / "a.tif", epsg=4326, bounds=(175.0, 0.0, 180.0, 5.0)),
-            _write_tif(
-                tmp_path / "b.tif", epsg=4326, bounds=(-180.0, 0.0, -175.0, 5.0)
-            ),
-        ]
+    fix(#887), codex round 9: an earlier cut probed every source with
+    ``rasterio.open`` before the build. ``build_vrt`` runs inside
+    ``asyncio.to_thread`` and Python threads are not killable, so a stalled
+    ``/vsis3/`` read pinned a pool thread with none of ``run_gdal``'s wall-clock
+    timeout applying — enough of them starve every other ``to_thread`` in the
+    worker. ``gdalbuildvrt`` already opens every source under that timeout and
+    writes what the decision needs, so the probe is gone.
+    """
 
-        assert sources_seam_frame_origin(sources) == pytest.approx(175.0)
+    # Long enough that a real open would blow the elapsed budget below by 3x,
+    # short enough that a regression fails the assertion instead of wedging CI.
+    _STALL_SECONDS = 6.0
+    _ELAPSED_BUDGET = 2.0
 
-    def test_off_seam_pair_is_not_detected(self, tmp_path):
-        sources = [
-            _write_tif(tmp_path / "a.tif", epsg=4326, bounds=(10.0, 0.0, 15.0, 5.0)),
-            _write_tif(tmp_path / "b.tif", epsg=4326, bounds=(15.0, 0.0, 20.0, 5.0)),
-        ]
-
-        assert sources_seam_frame_origin(sources) is None
-
-    def test_one_crs_less_source_disables_detection(self, tmp_path):
-        """Unknown units means unknown wrap: refuse rather than guess."""
-        sources = [
-            _write_tif(tmp_path / "a.tif", epsg=4326, bounds=(175.0, 0.0, 180.0, 5.0)),
-            _write_tif(
-                tmp_path / "b.tif", epsg=None, bounds=(-180.0, 0.0, -175.0, 5.0)
-            ),
-        ]
-
-        assert sources_seam_frame_origin(sources) is None
-
-    def test_projected_sources_are_not_detected(self, tmp_path):
-        """Metres are not degrees — a 4e7 m hull must not read as a seam crossing."""
-        half = WEB_MERCATOR_HALF_WORLD_M
-        sources = [
-            _write_tif(
-                tmp_path / "w.tif",
-                epsg=3857,
-                bounds=(-half, 0.0, -half + 1_000_000.0, 1_000_000.0),
-            ),
-            _write_tif(
-                tmp_path / "e.tif",
-                epsg=3857,
-                bounds=(half - 1_000_000.0, 0.0, half, 1_000_000.0),
-            ),
-        ]
-
-        assert sources_seam_frame_origin(sources) is None
-
-    def test_unopenable_source_is_not_detected(self, tmp_path):
-        bogus = tmp_path / "broken.tif"
-        bogus.write_bytes(b"not a tiff")
-
-        assert sources_seam_frame_origin([str(bogus)]) is None
-
-    def test_remote_source_is_never_fetched_by_the_probe(self, tmp_path):
-        """AGENTS.md Rule 2: the probe must not fetch a caller-supplied URL.
-
-        This runs *ahead* of ``gdalbuildvrt``, so for a remotely imported STAC
-        asset — whose URL ``resolve_open_path`` passes through unchanged — it
-        would be the first thing to fetch it, and a URL that was safe at import
-        time but now redirects to a private address would be followed.
-
-        Asserting "the redirect was not followed" would be too weak, because no
-        GDAL setting can deliver that: measured on GDAL 3.12.1,
-        ``GDAL_HTTP_FOLLOWLOCATION`` is not a real config option
-        (``Warning 1: Unknown configuration option``) and the 302 is followed
-        with or without it, in-process and in the subprocess alike. So assert
-        the strong property instead: **the host is never contacted at all.**
-        A local server records every hit; the list must stay empty.
-        """
-        requested: list[str] = []
+    def _stalling_server(self, requested: list[str]):
+        stall = self._STALL_SECONDS
 
         class _Handler(BaseHTTPRequestHandler):
             def do_GET(self):  # noqa: N802 (BaseHTTPRequestHandler API)
                 requested.append(self.path)
-                if self.path.startswith("/redirect"):
-                    self.send_response(302)
-                    self.send_header("Location", "/private.tif")
-                    self.end_headers()
-                    return
+                time.sleep(stall)  # the stalled /vsi read this test is about
                 self.send_response(200)
                 self.send_header("Content-Type", "image/tiff")
                 self.end_headers()
@@ -681,86 +624,83 @@ class TestSourcesSeamFrameOrigin:
             def do_HEAD(self):  # noqa: N802 (GDAL probes with HEAD first)
                 self.do_GET()
 
-            def log_message(self, *args):  # silence the default stderr spam
+            def log_message(self, *args):
                 return
 
-        server = ThreadingHTTPServer(("127.0.0.1", 0), _Handler)
+        return ThreadingHTTPServer(("127.0.0.1", 0), _Handler)
+
+    def test_build_is_bounded_when_a_source_stalls(self, tmp_path, monkeypatch):
+        """A stalling source must not block the calling thread.
+
+        This is the P1 in miniature. ``build_vrt`` runs under
+        ``asyncio.to_thread``; a synchronous open of a stalled ``/vsis3/`` source
+        pins a pool thread that cannot be cancelled, and none of ``run_gdal``'s
+        timeout applies to it. With the probe removed nothing here opens a
+        source, so the call returns immediately even though the host would hang
+        for seconds.
+
+        Asserted two ways: elapsed time (bounded) and the server's own request
+        log (never contacted). A control fetch afterwards proves the log records
+        hits, so the empty list is evidence rather than an accident.
+        """
+        requested: list[str] = []
+        server = self._stalling_server(requested)
         thread = threading.Thread(target=server.serve_forever, daemon=True)
         thread.start()
+        url = f"http://127.0.0.1:{server.server_address[1]}/remote.tif"
+
+        def _write(cmd, **kwargs):
+            Path(cmd[cmd.index("-resolution") + 2]).write_text(_GDALBUILDVRT_SEAM_XML)
+            return SimpleNamespace(returncode=0, stderr="")
+
+        monkeypatch.setattr(vrt_module, "run_gdal", _write)
         try:
-            url = f"http://127.0.0.1:{server.server_address[1]}/redirect.tif"
-            assert sources_seam_frame_origin([url]) is None
+            started = time.monotonic()
+            vrt_module._build_vrt([url], str(tmp_path / "remote.vrt"), "finest")
+            elapsed = time.monotonic() - started
+
+            assert elapsed < self._ELAPSED_BUDGET, (
+                f"_build_vrt blocked {elapsed:.1f}s on a stalling source — it "
+                "opened one itself, outside the timed subprocess"
+            )
+            assert requested == [], (
+                f"a source was opened outside gdalbuildvrt: {requested}"
+            )
+
+            # Control: the log DOES record a hit when the host is contacted, so
+            # the empty assertion above cannot pass by a broken rig.
+            with contextlib.suppress(OSError):
+                urllib.request.urlopen(url, timeout=self._STALL_SECONDS + 4)
+            assert requested, "the request log never recorded anything; rig is broken"
         finally:
             server.shutdown()
             server.server_close()
-            thread.join(timeout=5)
+            thread.join(timeout=self._STALL_SECONDS + 5)
 
-        assert requested == [], f"the probe fetched a caller-supplied URL: {requested}"
+    def test_seam_decision_reads_the_xml_not_the_sources(self, tmp_path, monkeypatch):
+        """The re-frame still happens with the sources unreadable.
 
-    @pytest.mark.parametrize(
-        "path,controllable",
-        [
-            ("https://example.invalid/a.tif", True),
-            ("http://example.invalid/a.tif", True),
-            ("/vsicurl/https://example.invalid/a.tif", True),
-            ("/vsicurl_streaming/https://example.invalid/a.tif", True),
-            # Managed storage: bucket from settings, key already validated.
-            ("/vsis3/bucket/rasters/a.tif", False),
-            ("/vsiaz/container/rasters/a.tif", False),
-            ("/srv/staging/rasters/a.tif", False),
-        ],
-    )
-    def test_attacker_controllable_source_classification(self, path, controllable):
-        assert is_attacker_controllable_source(path) is controllable
-
-    def test_managed_storage_paths_are_still_probed(self, tmp_path):
-        """The refusal is scoped to caller-supplied hosts, not to all I/O.
-
-        Same seam pair as the positive case, just proving the local/managed path
-        did not get caught by the URL guard.
+        The source paths here do not exist at all. If the decision needed to open
+        them it could not be made; it is made from the XML, so it is.
         """
-        sources = [
-            _write_tif(tmp_path / "m1.tif", epsg=4326, bounds=(175.0, 0.0, 180.0, 5.0)),
-            _write_tif(
-                tmp_path / "m2.tif", epsg=4326, bounds=(-180.0, 0.0, -175.0, 5.0)
-            ),
-        ]
 
-        assert sources_seam_frame_origin(sources) == pytest.approx(175.0)
+        def _write(cmd, **kwargs):
+            Path(cmd[cmd.index("-resolution") + 2]).write_text(_GDALBUILDVRT_SEAM_XML)
+            return SimpleNamespace(returncode=0, stderr="")
 
-    def test_grads_based_geographic_crs_is_not_detected(self, tmp_path):
-        """``is_geographic`` is not the same as "wraps at ±180".
+        monkeypatch.setattr(vrt_module, "run_gdal", _write)
 
-        EPSG:4807 (NTF Paris) is geographic with an angular unit of GRADS: a full
-        turn is 400 and the seam sits at 200. The seam logic is written in
-        degrees end to end, so a 195..200 / -200..-195 pair here would be shifted
-        by 360 instead of 400 and land as a 40-grad hull instead of a 10-grad
-        one. Refuse rather than corrupt it.
-        """
-        sources = [
-            _write_tif(tmp_path / "g1.tif", epsg=4807, bounds=(195.0, 0.0, 200.0, 5.0)),
-            _write_tif(
-                tmp_path / "g2.tif", epsg=4807, bounds=(-200.0, 0.0, -195.0, 5.0)
-            ),
-        ]
+        out = vrt_module._build_vrt(
+            ["/nonexistent/a.tif", "/nonexistent/b.tif"],
+            str(tmp_path / "seam.vrt"),
+            "finest",
+        )
 
-        assert sources_seam_frame_origin(sources) is None
+        assert _vrt_size(out) == (100, 50)
+        assert _vrt_geotransform(out)[0] == pytest.approx(175.0)
 
-    def test_degree_based_non_4326_crs_is_still_detected(self, tmp_path):
-        """Positive control for the unit gate: EPSG:4269 is degrees, so it counts.
 
-        Differs from the grads fixture in exactly one axis — same longitudes,
-        same latitudes, same seam crossing, only the CRS's angular unit changes.
-        """
-        sources = [
-            _write_tif(tmp_path / "n1.tif", epsg=4269, bounds=(175.0, 0.0, 180.0, 5.0)),
-            _write_tif(
-                tmp_path / "n2.tif", epsg=4269, bounds=(-180.0, 0.0, -175.0, 5.0)
-            ),
-        ]
-
-        assert sources_seam_frame_origin(sources) == pytest.approx(175.0)
-
+_WGS84_WKT = 'GEOGCS["WGS 84",DATUM["WGS_1984",SPHEROID["WGS 84",6378137,298.257223563,AUTHORITY["EPSG","7030"]],AUTHORITY["EPSG","6326"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],AUTHORITY["EPSG","4326"]]'
 
 # A gdalbuildvrt mosaic of two nodata-carrying tiles either side of ±180, as
 # emitted verbatim by BOTH GDAL 3.10.3 (worker image) and GDAL 3.13.0 (local):
@@ -768,7 +708,7 @@ class TestSourcesSeamFrameOrigin:
 # here so the rewrite is tested deterministically on machines with no GDAL CLI --
 # the skipif-gated tests below drive the real binary where it exists.
 _GDALBUILDVRT_SEAM_XML = """<VRTDataset rasterXSize="3600" rasterYSize="50">
-  <SRS dataAxisToSRSAxisMapping="2,1">GEOGCS["WGS 84"]</SRS>
+  <SRS dataAxisToSRSAxisMapping="2,1">GEOGCS["WGS 84",DATUM["WGS_1984",SPHEROID["WGS 84",6378137,298.257223563,AUTHORITY["EPSG","7030"]],AUTHORITY["EPSG","6326"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],AUTHORITY["EPSG","4326"]]</SRS>
   <GeoTransform> -1.8000000000000000e+02,  1.0000000000000001e-01,  0.0000000000000000e+00,  5.0000000000000000e+00,  0.0000000000000000e+00, -1.0000000000000001e-01</GeoTransform>
   <VRTRasterBand dataType="Byte" band="1">
     <NoDataValue>0</NoDataValue>
@@ -800,6 +740,38 @@ _GDALBUILDVRT_SEAM_XML = """<VRTDataset rasterXSize="3600" rasterYSize="50">
   </VRTRasterBand>
 </VRTDataset>
 """
+
+
+def _plain_vrt_xml(
+    left: float, res_x: float, spans_px: list[tuple[float, float]]
+) -> str:
+    """A gdalbuildvrt-shaped VRT with the given per-source DstRects.
+
+    fix(#887): the seam decision is read from this XML, so a test asserting
+    "left alone" needs a fixture that genuinely does not straddle the seam —
+    stubbing seam XML and non-crossing source paths would assert nothing.
+    """
+    width = max(1, int(round(max(off + size for off, size in spans_px))))
+    rects = "".join(
+        f'<ComplexSource><DstRect xOff="{off!r}" yOff="0" '
+        f'xSize="{size!r}" ySize="50" /></ComplexSource>'
+        for off, size in spans_px
+    )
+    return (
+        f'<VRTDataset rasterXSize="{width}" rasterYSize="50">'
+        f"<SRS>{_WGS84_WKT}</SRS>"
+        f"<GeoTransform> {left!r}, {res_x!r}, 0.0, 5.0, 0.0, -{res_x!r}</GeoTransform>"
+        f'<VRTRasterBand dataType="Byte" band="1">{rects}</VRTRasterBand>'
+        "</VRTDataset>"
+    )
+
+
+# Two adjacent 5-degree tiles at 10..20 — nowhere near the seam.
+_GDALBUILDVRT_OFFSEAM_XML = _plain_vrt_xml(10.0, 0.1, [(0.0, 50.0), (50.0, 50.0)])
+# A genuinely global tiling: 36 contiguous 10-degree tiles across -180..180.
+_GDALBUILDVRT_GLOBAL_XML = _plain_vrt_xml(
+    -180.0, 10.0, [(float(i), 1.0) for i in range(36)]
+)
 
 
 class TestSeamFrameRewrite:
@@ -877,20 +849,20 @@ class TestSeamFrameRewrite:
         monkeypatch.setattr(
             vrt_module,
             "run_gdal",
-            self._fake_gdalbuildvrt(_GDALBUILDVRT_SEAM_XML),
+            self._fake_gdalbuildvrt(_GDALBUILDVRT_OFFSEAM_XML),
         )
         sources = self._tiles(tmp_path, [(10.0, 15.0), (15.0, 20.0)])
 
         out = vrt_module._build_vrt(sources, str(tmp_path / "plain.vrt"), "finest")
 
-        assert Path(out).read_text() == _GDALBUILDVRT_SEAM_XML
+        assert Path(out).read_text() == _GDALBUILDVRT_OFFSEAM_XML
 
     def test_global_mosaic_output_is_left_alone(self, tmp_path, monkeypatch):
         """A genuinely global mosaic is not a seam crossing."""
         monkeypatch.setattr(
             vrt_module,
             "run_gdal",
-            self._fake_gdalbuildvrt(_GDALBUILDVRT_SEAM_XML),
+            self._fake_gdalbuildvrt(_GDALBUILDVRT_GLOBAL_XML),
         )
         sources = self._tiles(
             tmp_path, [(-180.0 + 10 * i, -170.0 + 10 * i) for i in range(36)]
@@ -898,7 +870,7 @@ class TestSeamFrameRewrite:
 
         out = vrt_module._build_vrt(sources, str(tmp_path / "global.vrt"), "finest")
 
-        assert Path(out).read_text() == _GDALBUILDVRT_SEAM_XML
+        assert Path(out).read_text() == _GDALBUILDVRT_GLOBAL_XML
 
     def test_band_stack_dispatch_also_rewrites(self, tmp_path, monkeypatch):
         """``build_vrt("band_stack", ...)`` reaches the rewrite too."""
@@ -914,32 +886,74 @@ class TestSeamFrameRewrite:
         assert _vrt_size(out) == (100, 50)
         assert _vrt_geotransform(out)[0] == pytest.approx(175.0)
 
-    def test_missing_dstrect_fails_loudly(self, tmp_path):
-        """Editing generated XML is version-sensitive, so assert the structure.
+    @pytest.mark.parametrize(
+        "label,xml",
+        [
+            (
+                "no DstRect",
+                '<VRTDataset rasterXSize="3600" rasterYSize="50">'
+                "<SRS>" + _WGS84_WKT + "</SRS>"
+                "<GeoTransform>-180.0, 0.1, 0.0, 5.0, 0.0, -0.1</GeoTransform>"
+                '<VRTRasterBand dataType="Byte" band="1"><SimpleSource>'
+                "<SourceFilename>w.tif</SourceFilename></SimpleSource>"
+                "</VRTRasterBand></VRTDataset>",
+            ),
+            ("no GeoTransform", '<VRTDataset rasterXSize="10" rasterYSize="10" />'),
+            (
+                "no SRS",
+                '<VRTDataset rasterXSize="3600" rasterYSize="50">'
+                "<GeoTransform>-180.0, 0.1, 0.0, 5.0, 0.0, -0.1</GeoTransform>"
+                '<VRTRasterBand dataType="Byte" band="1"><ComplexSource>'
+                '<DstRect xOff="3550" yOff="0" xSize="50" ySize="50" />'
+                "</ComplexSource></VRTRasterBand></VRTDataset>",
+            ),
+            (
+                "unparseable SRS",
+                '<VRTDataset rasterXSize="3600" rasterYSize="50">'
+                "<SRS>not a coordinate system</SRS>"
+                "<GeoTransform>-180.0, 0.1, 0.0, 5.0, 0.0, -0.1</GeoTransform>"
+                '<VRTRasterBand dataType="Byte" band="1"><ComplexSource>'
+                '<DstRect xOff="3550" yOff="0" xSize="50" ySize="50" />'
+                "</ComplexSource></VRTRasterBand></VRTDataset>",
+            ),
+        ],
+    )
+    def test_unreadable_geometry_is_left_untouched(self, tmp_path, label, xml):
+        """A VRT this cannot read is one it also cannot have judged.
 
-        A source with no ``DstRect`` covers the whole raster implicitly; shrinking
-        the raster underneath it would silently restretch it. Raise instead —
-        shipping a misregistered mosaic that looks fine is the one unacceptable
-        outcome.
+        Deciding the seam needs exactly the ``GeoTransform``, ``SRS`` and
+        per-source ``DstRect`` values the rewrite consumes, so "cannot read" and
+        "no crossing detected" are the same state — there is no case where a
+        detected crossing goes unfixed. Leave the file byte-identical rather than
+        failing a build that ``gdalbuildvrt`` completed successfully.
         """
-        vrt = tmp_path / "no_dstrect.vrt"
-        vrt.write_text(
-            '<VRTDataset rasterXSize="3600" rasterYSize="50">'
-            "<GeoTransform>-180.0, 0.1, 0.0, 5.0, 0.0, -0.1</GeoTransform>"
-            '<VRTRasterBand dataType="Byte" band="1"><SimpleSource>'
-            "<SourceFilename>w.tif</SourceFilename></SimpleSource>"
-            "</VRTRasterBand></VRTDataset>"
+        vrt = tmp_path / f"{abs(hash(label))}.vrt"
+        vrt.write_text(xml)
+
+        shift_vrt_longitude_frame(str(vrt))
+
+        assert vrt.read_text() == xml, f"{label}: file must be left untouched"
+
+    def test_missing_output_does_not_crash_a_successful_build(
+        self, tmp_path, monkeypatch
+    ):
+        """A post-build correction must not fail a build gdalbuildvrt completed.
+
+        The rewrite now runs on every build, so an output it cannot read — absent,
+        truncated, not XML — has to be a no-op rather than an exception. Whether
+        the subprocess really produced a file is that subprocess's business.
+        """
+
+        def _succeed_without_writing(cmd, **kwargs):
+            return SimpleNamespace(returncode=0, stderr="")
+
+        monkeypatch.setattr(vrt_module, "run_gdal", _succeed_without_writing)
+
+        out = vrt_module._build_vrt(
+            ["/a.tif", "/b.tif"], str(tmp_path / "never_written.vrt"), "finest"
         )
 
-        with pytest.raises(RuntimeError, match="expected one DstRect per source"):
-            shift_vrt_longitude_frame(str(vrt), 175.0)
-
-    def test_missing_geotransform_fails_loudly(self, tmp_path):
-        vrt = tmp_path / "no_gt.vrt"
-        vrt.write_text('<VRTDataset rasterXSize="10" rasterYSize="10" />')
-
-        with pytest.raises(RuntimeError, match="no GeoTransform"):
-            shift_vrt_longitude_frame(str(vrt), 175.0)
+        assert out == str(tmp_path / "never_written.vrt")
 
     def test_fractional_offsets_stay_fractional(self, tmp_path):
         """Sub-pixel offsets must not be rounded to whole pixels.
@@ -952,6 +966,7 @@ class TestSeamFrameRewrite:
         vrt = tmp_path / "frac.vrt"
         vrt.write_text(
             '<VRTDataset rasterXSize="18000" rasterYSize="50">'
+            "<SRS>" + _WGS84_WKT + "</SRS>"
             "<GeoTransform> -1.8e+02, 2.0e-02, 0.0, 5.0, 0.0, -2.0e-02</GeoTransform>"
             '<VRTRasterBand dataType="Byte" band="1">'
             "<ComplexSource>"
@@ -965,7 +980,7 @@ class TestSeamFrameRewrite:
             "</VRTRasterBand></VRTDataset>"
         )
 
-        shift_vrt_longitude_frame(str(vrt), 175.0)
+        shift_vrt_longitude_frame(str(vrt))
 
         root = parse_vrt(str(vrt)).getroot()
         offsets = [d.get("xOff") for d in root.iter("DstRect")]
@@ -989,6 +1004,7 @@ class TestSeamFrameRewrite:
         vrt = tmp_path / "contain.vrt"
         vrt.write_text(
             '<VRTDataset rasterXSize="18000" rasterYSize="50">'
+            "<SRS>" + _WGS84_WKT + "</SRS>"
             "<GeoTransform> -1.8e+02, 2.0e-02, 0.0, 5.0, 0.0, -2.0e-02</GeoTransform>"
             '<VRTRasterBand dataType="Byte" band="1">'
             "<ComplexSource>"
@@ -1000,7 +1016,7 @@ class TestSeamFrameRewrite:
             "</VRTRasterBand></VRTDataset>"
         )
 
-        shift_vrt_longitude_frame(str(vrt), 175.0)
+        shift_vrt_longitude_frame(str(vrt))
 
         root = parse_vrt(str(vrt)).getroot()
         width = int(root.get("rasterXSize"))
@@ -1058,6 +1074,7 @@ class TestSeamFrameRewrite:
         vrt = tmp_path / f"prop_{abs(hash((res_x, lefts)))}.vrt"
         vrt.write_text(
             f'<VRTDataset rasterXSize="{plain_width}" rasterYSize="10">'
+            f"<SRS>{_WGS84_WKT}</SRS>"
             f"<GeoTransform> {old_left!r}, {res_x!r}, 0.0, 5.0, 0.0, -{res_x!r}</GeoTransform>"
             f'<VRTRasterBand dataType="Byte" band="1">{rects}</VRTRasterBand>'
             "</VRTDataset>"
@@ -1065,7 +1082,7 @@ class TestSeamFrameRewrite:
 
         seam_origin = _seam_frame_origin(sources)
         assert seam_origin is not None, "fixture must straddle the seam"
-        shift_vrt_longitude_frame(str(vrt), seam_origin)
+        shift_vrt_longitude_frame(str(vrt))
 
         root = parse_vrt(str(vrt)).getroot()
         width = int(root.get("rasterXSize"))
@@ -1140,7 +1157,7 @@ class TestSeamFrameRewrite:
         vrt = tmp_path / "whole.vrt"
         vrt.write_text(_GDALBUILDVRT_SEAM_XML)
 
-        shift_vrt_longitude_frame(str(vrt), 175.0)
+        shift_vrt_longitude_frame(str(vrt))
 
         root = parse_vrt(str(vrt)).getroot()
         assert [d.get("xOff") for d in root.iter("DstRect")] == ["0", "50", "0"]

--- a/backend/tests/test_raster_antimeridian_887.py
+++ b/backend/tests/test_raster_antimeridian_887.py
@@ -27,7 +27,9 @@ extent MUST take ``clean_tables`` — see ``TestRasterTokenAcrossTheSeam``.
 import io
 import shutil
 import subprocess
+import threading
 import uuid
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 from types import SimpleNamespace
 from xml.etree.ElementTree import parse as parse_vrt
@@ -54,6 +56,7 @@ from app.processing.raster.vrt import (
     _seam_frame_origin,
     _write_python_vrt,
     build_vrt,
+    is_attacker_controllable_source,
     shift_vrt_longitude_frame,
     sources_seam_frame_origin,
 )
@@ -561,6 +564,87 @@ class TestSourcesSeamFrameOrigin:
         bogus.write_bytes(b"not a tiff")
 
         assert sources_seam_frame_origin([str(bogus)]) is None
+
+    def test_remote_source_is_never_fetched_by_the_probe(self, tmp_path):
+        """AGENTS.md Rule 2: the probe must not fetch a caller-supplied URL.
+
+        This runs *ahead* of ``gdalbuildvrt``, so for a remotely imported STAC
+        asset — whose URL ``resolve_open_path`` passes through unchanged — it
+        would be the first thing to fetch it, and a URL that was safe at import
+        time but now redirects to a private address would be followed.
+
+        Asserting "the redirect was not followed" would be too weak, because no
+        GDAL setting can deliver that: measured on GDAL 3.12.1,
+        ``GDAL_HTTP_FOLLOWLOCATION`` is not a real config option
+        (``Warning 1: Unknown configuration option``) and the 302 is followed
+        with or without it, in-process and in the subprocess alike. So assert
+        the strong property instead: **the host is never contacted at all.**
+        A local server records every hit; the list must stay empty.
+        """
+        requested: list[str] = []
+
+        class _Handler(BaseHTTPRequestHandler):
+            def do_GET(self):  # noqa: N802 (BaseHTTPRequestHandler API)
+                requested.append(self.path)
+                if self.path.startswith("/redirect"):
+                    self.send_response(302)
+                    self.send_header("Location", "/private.tif")
+                    self.end_headers()
+                    return
+                self.send_response(200)
+                self.send_header("Content-Type", "image/tiff")
+                self.end_headers()
+                self.wfile.write(b"\x00" * 64)
+
+            def do_HEAD(self):  # noqa: N802 (GDAL probes with HEAD first)
+                self.do_GET()
+
+            def log_message(self, *args):  # silence the default stderr spam
+                return
+
+        server = ThreadingHTTPServer(("127.0.0.1", 0), _Handler)
+        thread = threading.Thread(target=server.serve_forever, daemon=True)
+        thread.start()
+        try:
+            url = f"http://127.0.0.1:{server.server_address[1]}/redirect.tif"
+            assert sources_seam_frame_origin([url]) is None
+        finally:
+            server.shutdown()
+            server.server_close()
+            thread.join(timeout=5)
+
+        assert requested == [], f"the probe fetched a caller-supplied URL: {requested}"
+
+    @pytest.mark.parametrize(
+        "path,controllable",
+        [
+            ("https://example.invalid/a.tif", True),
+            ("http://example.invalid/a.tif", True),
+            ("/vsicurl/https://example.invalid/a.tif", True),
+            ("/vsicurl_streaming/https://example.invalid/a.tif", True),
+            # Managed storage: bucket from settings, key already validated.
+            ("/vsis3/bucket/rasters/a.tif", False),
+            ("/vsiaz/container/rasters/a.tif", False),
+            ("/srv/staging/rasters/a.tif", False),
+        ],
+    )
+    def test_attacker_controllable_source_classification(self, path, controllable):
+        assert is_attacker_controllable_source(path) is controllable
+
+    def test_managed_storage_paths_are_still_probed(self, tmp_path):
+        """The refusal is scoped to caller-supplied hosts, not to all I/O.
+
+        Same seam pair as the positive case, just proving the local/managed path
+        did not get caught by the URL guard.
+        """
+        sources = [
+            _write_tif(tmp_path / "m1.tif", epsg=4326, bounds=(175.0, 0.0, 180.0, 5.0)),
+            _write_tif(
+                tmp_path / "m2.tif", epsg=4326, bounds=(-180.0, 0.0, -175.0, 5.0)
+            ),
+        ]
+
+        assert sources_seam_frame_origin(sources) == pytest.approx(175.0)
 
     def test_grads_based_geographic_crs_is_not_detected(self, tmp_path):
         """``is_geographic`` is not the same as "wraps at ±180".

--- a/backend/tests/test_raster_antimeridian_887.py
+++ b/backend/tests/test_raster_antimeridian_887.py
@@ -304,6 +304,28 @@ class TestCogExtentFold:
             expected_area = (lonlat[2] - lonlat[0]) * (lonlat[3] - lonlat[1])
             assert geom.area == pytest.approx(expected_area, rel=1e-6)
 
+    def test_source_starting_exactly_at_180_needs_only_one_ring(self, tmp_path):
+        """A 180..190 raster is entirely west of the seam once folded.
+
+        The fold reports ``west > east`` (``wrap_longitude`` keeps +180 as +180,
+        per #886), but the ``180..180`` half has zero width, so
+        ``bbox_to_extent_wkt`` drops it and emits the ``-180..-170`` ring alone.
+        Asserting the area is what distinguishes that from silently losing half
+        the footprint.
+        """
+        tif = _write_tif(
+            tmp_path / "at180.tif", epsg=4326, bounds=(180.0, -10.0, 190.0, 10.0)
+        )
+        meta = extract_raster_metadata(tif)
+
+        assert meta["bounds_wgs84"] == (180.0, -10.0, -170.0, 10.0)
+        geom = shapely_wkt.loads(meta["bbox_wkt"])
+        assert geom.geom_type == "Polygon"
+        assert geom.is_valid
+        assert geom.bounds[0] == pytest.approx(-180.0)
+        assert geom.bounds[2] == pytest.approx(-170.0)
+        assert geom.area == pytest.approx(200.0, rel=1e-6)
+
     def test_crs_less_raster_bounds_are_not_folded(self, tmp_path):
         """Without a CRS the bounds are not longitudes; leave them alone.
 

--- a/backend/tests/test_raster_antimeridian_887.py
+++ b/backend/tests/test_raster_antimeridian_887.py
@@ -388,6 +388,31 @@ class TestSeamFrameOrigin:
     def test_guard_boundaries(self, label, spans, expected):
         assert _seam_frame_origin(spans) == expected, label
 
+    def test_global_mosaic_on_non_round_boundaries_is_not_reframed(self):
+        """Float noise must not win the "is the shifted hull narrower" contest.
+
+        ``left + 360`` is not bit-exact for an arbitrary mantissa, so a global
+        tiling whose boundaries are not round numbers can measure fractionally
+        narrower in a shifted frame than in the plain one. With a bare ``<`` this
+        exact fixture re-frames a *global* mosaic to origin 160.3; the margin is
+        what keeps it at ``None``. Same trap #886/#928 hit in the rollup folds.
+        """
+        step = 360.0 / 36
+        spans = [(-179.7 + step * i, -179.7 + step * (i + 1)) for i in range(36)]
+
+        assert _seam_frame_origin(spans) is None
+
+    @pytest.mark.parametrize(
+        "spans,expected",
+        [
+            ([(175.0, 180.0), (-180.0, -175.0)], 175.0),
+            ([(175.123456789, 180.0), (-180.0, -175.987654321)], 175.123456789),
+        ],
+    )
+    def test_margin_does_not_suppress_a_real_crossing(self, spans, expected):
+        """The margin is 0.1 mm — it must not swallow a genuine 5° seam pair."""
+        assert _seam_frame_origin(spans) == pytest.approx(expected)
+
     def test_shifted_hull_is_the_tightest_available(self):
         """The chosen origin must minimise the hull, not merely improve on it."""
         spans = [(100.0, 170.0), (-170.0, -100.0), (-50.0, -40.0)]

--- a/backend/tests/test_raster_antimeridian_887.py
+++ b/backend/tests/test_raster_antimeridian_887.py
@@ -801,21 +801,66 @@ class TestSeamFrameRewrite:
 
         shift_vrt_longitude_frame(str(vrt), 175.0)
 
-        offsets = [d.get("xOff") for d in parse_vrt(str(vrt)).getroot().iter("DstRect")]
+        root = parse_vrt(str(vrt)).getroot()
+        offsets = [d.get("xOff") for d in root.iter("DstRect")]
         # 17751.5 px at 0.02 deg puts the western source at 175.03; re-anchored
         # there it sits at 0, and the eastern source lands 248.5 px further on.
         assert offsets == ["0", "248.5"]
         assert float(offsets[1]) == pytest.approx(248.5)
+        # ... and the raster has to be wide enough to hold it: 248.5 + 50 = 298.5
+        # needs 299 px. 298 would leave the last half pixel outside the dataset.
+        assert int(root.get("rasterXSize")) == 299
+
+    def test_raster_width_contains_every_source(self, tmp_path):
+        """The containment invariant, stated directly.
+
+        A pixel-count assertion cannot catch an under-sized raster — a 50-pixel
+        source still reads back as 50 pixels while its final half pixel is
+        clipped — so assert the geometry instead. GDAL sizes its own mosaics the
+        same way: measured ``max(xOff + xSize) = 298.5`` against
+        ``rasterXSize = 299``.
+        """
+        vrt = tmp_path / "contain.vrt"
+        vrt.write_text(
+            '<VRTDataset rasterXSize="18000" rasterYSize="50">'
+            "<GeoTransform> -1.8e+02, 2.0e-02, 0.0, 5.0, 0.0, -2.0e-02</GeoTransform>"
+            '<VRTRasterBand dataType="Byte" band="1">'
+            "<ComplexSource>"
+            '<DstRect xOff="17751.5" yOff="0" xSize="248.5" ySize="50" />'
+            "</ComplexSource>"
+            "<ComplexSource>"
+            '<DstRect xOff="0" yOff="0" xSize="50" ySize="50" />'
+            "</ComplexSource>"
+            "</VRTRasterBand></VRTDataset>"
+        )
+
+        shift_vrt_longitude_frame(str(vrt), 175.0)
+
+        root = parse_vrt(str(vrt)).getroot()
+        width = int(root.get("rasterXSize"))
+        far_edge = max(
+            float(d.get("xOff")) + float(d.get("xSize")) for d in root.iter("DstRect")
+        )
+        assert width >= far_edge, (
+            f"raster {width} px clips a source ending at {far_edge}"
+        )
+        # And not over-allocated either — exactly the containing integer.
+        assert width == 299
 
     def test_whole_pixel_offsets_stay_integral(self, tmp_path):
-        """The common case still reads like GDAL's own output, not ``50.0``."""
+        """The common case still reads like GDAL's own output, not ``50.0``.
+
+        Rounding the width up must not inflate an exactly-aligned mosaic: 50 + 50
+        is 100 pixels, not 101.
+        """
         vrt = tmp_path / "whole.vrt"
         vrt.write_text(_GDALBUILDVRT_SEAM_XML)
 
         shift_vrt_longitude_frame(str(vrt), 175.0)
 
-        offsets = [d.get("xOff") for d in parse_vrt(str(vrt)).getroot().iter("DstRect")]
-        assert offsets == ["0", "50", "0"]
+        root = parse_vrt(str(vrt)).getroot()
+        assert [d.get("xOff") for d in root.iter("DstRect")] == ["0", "50", "0"]
+        assert int(root.get("rasterXSize")) == 100
 
     def test_unopenable_source_is_left_to_gdalbuildvrt(self, tmp_path, monkeypatch):
         """The probe must never swallow a broken source's real error."""
@@ -1039,6 +1084,53 @@ class TestSeamFrameRewriteAgainstRealGdal:
             assert (ds.width, ds.height) == (100, 50)
             assert ds.bounds.left == pytest.approx(175.0)
             assert ds.nodata == 0.0
+
+    def test_off_grid_seam_mosaic_is_not_clipped(self, tmp_path):
+        """Off-grid sources produce fractional offsets; the raster must hold them.
+
+        The western tile's left edge (175.03) is deliberately off the finest
+        output grid, which is what makes `gdalbuildvrt` emit a fractional
+        `DstRect`. The rewrite must keep that fraction *and* round the containing
+        width up, or the last source hangs half a pixel outside the dataset.
+        """
+        sources = [
+            _write_tif(
+                tmp_path / "w.tif",
+                epsg=4326,
+                bounds=(175.03, 0.0, 180.0, 2.0),
+                width=50,
+                height=20,
+                nodata=0,
+                fill=7,
+            ),
+            _write_tif(
+                tmp_path / "e.tif",
+                epsg=4326,
+                bounds=(-180.0, 0.0, -179.0, 2.0),
+                width=50,
+                height=20,
+                nodata=0,
+                fill=9,
+            ),
+        ]
+
+        out = vrt_module._build_vrt(sources, str(tmp_path / "offgrid.vrt"), "finest")
+
+        root = parse_vrt(out).getroot()
+        offsets = [d.get("xOff") for d in root.iter("DstRect")]
+        assert any("." in o for o in offsets), "expected a fractional offset here"
+        width = int(root.get("rasterXSize"))
+        far_edge = max(
+            float(d.get("xOff")) + float(d.get("xSize")) for d in root.iter("DstRect")
+        )
+        assert width >= far_edge, (
+            f"raster {width} px clips a source ending at {far_edge}"
+        )
+
+        with rasterio.open(out) as ds:
+            assert ds.bounds.left == pytest.approx(175.03)
+            row = ds.read(1)[0]
+        assert set(row.tolist()) == {7, 9}
 
     def test_non_crossing_build_is_byte_identical_to_plain_gdalbuildvrt(self, tmp_path):
         """Nothing off the seam changes shape because of this PR."""

--- a/backend/tests/test_raster_antimeridian_887.py
+++ b/backend/tests/test_raster_antimeridian_887.py
@@ -8,10 +8,13 @@ Three sites, one seam:
    was the *complement*: a Pacific COG spanning 175E..175W registered a valid
    350°-wide rectangle covering 7000 deg² of the wrong side of the world
    instead of its real 200.
-2. ``processing/raster/vrt.py`` — ``_write_python_vrt`` took ``min(left)`` /
+2. ``processing/raster/vrt.py`` — both builders took ``min(left)`` /
    ``max(right)`` across sources, so a 10°-wide mosaic straddling the seam was
    allocated 360° wide (3600 x 50 px instead of 100 x 50) with every source at
-   the wrong ``dst_x_off``.
+   the wrong ``dst_x_off``. ``gdalbuildvrt`` is the production builder and does
+   the same thing, so the normalization has to be reached from ``_build_vrt``
+   with the subprocess available — see
+   ``TestSeamFramingReachesTheProductionPath``.
 3. ``processing/tiles/router.py`` — the user-visible symptom. Source maxzoom is
    derived from extent width when the COG has no recorded resolution, so a
    seam-crossing raster measured 36x too wide, understated its own resolution,
@@ -22,8 +25,11 @@ are pure rasterio/XML unit tests.
 """
 
 import io
+import shutil
+import subprocess
 import uuid
 from pathlib import Path
+from types import SimpleNamespace
 from xml.etree.ElementTree import parse as parse_vrt
 
 import numpy as np
@@ -43,7 +49,13 @@ from app.modules.auth.models import User
 from app.modules.catalog.datasets.domain.models import Dataset, Record
 from app.processing.raster.cog import extract_raster_metadata
 from app.processing.raster.models import RasterAsset
-from app.processing.raster.vrt import _seam_frame_origin, _write_python_vrt
+from app.processing.raster import vrt as vrt_module
+from app.processing.raster.vrt import (
+    _seam_frame_origin,
+    _write_python_vrt,
+    build_vrt,
+    sources_straddle_seam,
+)
 from app.processing.tiles.router import _raster_maxzoom_from_metadata
 
 
@@ -453,6 +465,212 @@ class TestSeamStraddlingVrt:
 
         assert _vrt_size(out) == (100, 50)
         assert _vrt_geotransform(out)[0] == pytest.approx(175.0)
+        assert _dst_x_offs(out) == [0, 50]
+
+
+# ---------------------------------------------------------------------------
+# Site 2, the path production actually takes
+# ---------------------------------------------------------------------------
+
+
+class TestSourcesStraddleSeamPredicate:
+    """The branch condition, on the inputs that must not trip it."""
+
+    def test_geographic_seam_pair_is_detected(self, tmp_path):
+        sources = [
+            _write_tif(tmp_path / "a.tif", epsg=4326, bounds=(175.0, 0.0, 180.0, 5.0)),
+            _write_tif(
+                tmp_path / "b.tif", epsg=4326, bounds=(-180.0, 0.0, -175.0, 5.0)
+            ),
+        ]
+
+        assert sources_straddle_seam(sources) is True
+
+    def test_off_seam_pair_is_not_detected(self, tmp_path):
+        sources = [
+            _write_tif(tmp_path / "a.tif", epsg=4326, bounds=(10.0, 0.0, 15.0, 5.0)),
+            _write_tif(tmp_path / "b.tif", epsg=4326, bounds=(15.0, 0.0, 20.0, 5.0)),
+        ]
+
+        assert sources_straddle_seam(sources) is False
+
+    def test_one_crs_less_source_disables_detection(self, tmp_path):
+        """Unknown units means unknown wrap: refuse rather than guess.
+
+        The result is the un-normalized mosaic, which is the pre-existing
+        behaviour for a VRT nobody can interpret — `_write_python_vrt` takes its
+        SRS from the first source and never checks the rest agree.
+        """
+        sources = [
+            _write_tif(tmp_path / "a.tif", epsg=4326, bounds=(175.0, 0.0, 180.0, 5.0)),
+            _write_tif(
+                tmp_path / "b.tif", epsg=None, bounds=(-180.0, 0.0, -175.0, 5.0)
+            ),
+        ]
+
+        assert sources_straddle_seam(sources) is False
+
+    def test_unopenable_source_is_not_detected(self, tmp_path):
+        bogus = tmp_path / "broken.tif"
+        bogus.write_bytes(b"not a tiff")
+
+        assert sources_straddle_seam([str(bogus)]) is False
+
+
+class TestSeamFramingReachesTheProductionPath:
+    """``_write_python_vrt`` is the fallback; ``gdalbuildvrt`` is what ships.
+
+    The worker image installs ``gdal-bin``, so ``_build_vrt`` gets a working
+    subprocess and the ``FileNotFoundError`` fallback never fires in a deployed
+    worker. A test that calls ``_write_python_vrt`` directly therefore proves
+    nothing about production, which is exactly how the first cut of this fix
+    landed as dead code (codex P1 on #924). Every test here enters through
+    ``_build_vrt`` with the subprocess *available*.
+
+    ``gdalbuildvrt`` itself is not the fix: verified against GDAL 3.10 (worker
+    image) and 3.13 (local), it emits 3600 x 50 px anchored at -180 with
+    ``dst_x_off`` 3550 for the seam pair below, and ``-te`` on the shifted hull
+    exits 0 while silently dropping every source outside the window.
+    """
+
+    def _tiles(self, tmp_path, lon_pairs, *, epsg=4326):
+        return [
+            _write_tif(
+                tmp_path / f"p{i}.tif",
+                epsg=epsg,
+                bounds=(west, 0.0, east, 5.0),
+                width=50,
+                height=50,
+            )
+            for i, (west, east) in enumerate(lon_pairs)
+        ]
+
+    def test_seam_mosaic_never_reaches_gdalbuildvrt(self, tmp_path, monkeypatch):
+        """With the subprocess available, the seam pair still normalizes.
+
+        ``run_gdal`` is stubbed to a *successful* call, so nothing can fall back:
+        if the seam branch were removed, the stub would be invoked and no VRT
+        would be written at all.
+        """
+        calls = []
+
+        def _never(cmd, **kwargs):
+            calls.append(cmd)
+            raise AssertionError(
+                "gdalbuildvrt was spawned for a seam-straddling mosaic"
+            )
+
+        monkeypatch.setattr(vrt_module, "run_gdal", _never)
+        sources = self._tiles(tmp_path, [(175.0, 180.0), (-180.0, -175.0)])
+
+        out = vrt_module._build_vrt(sources, str(tmp_path / "seam.vrt"), "finest")
+
+        assert calls == []
+        assert _vrt_size(out) == (100, 50)
+        assert _vrt_geotransform(out)[0] == pytest.approx(175.0)
+        assert _dst_x_offs(out) == [0, 50]
+
+    def test_non_crossing_mosaic_still_uses_gdalbuildvrt(self, tmp_path, monkeypatch):
+        """Negative probe: same two tiles, same latitudes, moved off the seam.
+
+        Only the longitude position differs, so this pins that the branch is
+        narrow — everything else keeps going to the subprocess builder.
+        """
+        calls = []
+
+        def _record(cmd, **kwargs):
+            calls.append(cmd)
+            return SimpleNamespace(returncode=0, stderr="")
+
+        monkeypatch.setattr(vrt_module, "run_gdal", _record)
+        sources = self._tiles(tmp_path, [(10.0, 15.0), (15.0, 20.0)])
+
+        vrt_module._build_vrt(sources, str(tmp_path / "plain.vrt"), "finest")
+
+        assert len(calls) == 1
+        assert calls[0][0] == "gdalbuildvrt"
+
+    def test_global_mosaic_still_uses_gdalbuildvrt(self, tmp_path, monkeypatch):
+        """A genuinely global mosaic is not a seam crossing; leave it to GDAL."""
+        calls = []
+
+        def _record(cmd, **kwargs):
+            calls.append(cmd)
+            return SimpleNamespace(returncode=0, stderr="")
+
+        monkeypatch.setattr(vrt_module, "run_gdal", _record)
+        sources = self._tiles(
+            tmp_path, [(-180.0 + 10 * i, -170.0 + 10 * i) for i in range(36)]
+        )
+
+        vrt_module._build_vrt(sources, str(tmp_path / "global.vrt"), "finest")
+
+        assert len(calls) == 1
+
+    def test_band_stack_dispatch_keeps_the_seam_branch(self, tmp_path, monkeypatch):
+        """``build_vrt("band_stack", ...)`` reaches the branch too."""
+
+        def _never(cmd, **kwargs):
+            raise AssertionError("gdalbuildvrt was spawned for a seam band stack")
+
+        monkeypatch.setattr(vrt_module, "run_gdal", _never)
+        sources = self._tiles(tmp_path, [(175.0, 180.0), (-180.0, -175.0)])
+
+        out = build_vrt("band_stack", sources, str(tmp_path / "stack.vrt"), "finest")
+
+        assert _vrt_size(out) == (100, 50)
+        assert _vrt_geotransform(out)[0] == pytest.approx(175.0)
+
+    def test_unopenable_source_is_left_to_gdalbuildvrt(self, tmp_path, monkeypatch):
+        """The predicate must never swallow a broken source's real error."""
+        calls = []
+
+        def _record(cmd, **kwargs):
+            calls.append(cmd)
+            return SimpleNamespace(returncode=1, stderr="not a recognized file format")
+
+        monkeypatch.setattr(vrt_module, "run_gdal", _record)
+        bogus = tmp_path / "broken.tif"
+        bogus.write_bytes(b"not a tiff")
+
+        with pytest.raises(RuntimeError, match="gdalbuildvrt failed"):
+            vrt_module._build_vrt([str(bogus)], str(tmp_path / "x.vrt"), "finest")
+
+        assert len(calls) == 1
+
+    def test_bad_resolution_strategy_still_raises_before_any_branch(self, tmp_path):
+        """The KeyError contract holds on both sides of the new branch."""
+        sources = self._tiles(tmp_path, [(175.0, 180.0), (-180.0, -175.0)])
+
+        with pytest.raises(KeyError):
+            vrt_module._build_vrt(sources, str(tmp_path / "bad.vrt"), "sharpest")
+
+    @pytest.mark.skipif(
+        shutil.which("gdalbuildvrt") is None,
+        reason="needs the real gdalbuildvrt (present in the worker image)",
+    )
+    def test_real_gdalbuildvrt_would_get_this_wrong(self, tmp_path):
+        """Pin the upstream behaviour this branch exists to route around.
+
+        Not a test of our code — a test of the premise. If a future GDAL learns
+        to fold longitudes, this fails and the branch can be reconsidered.
+        """
+        sources = self._tiles(tmp_path, [(175.0, 180.0), (-180.0, -175.0)])
+        raw = str(tmp_path / "raw.vrt")
+        result = subprocess.run(
+            ["gdalbuildvrt", "-resolution", "highest", raw, *sources],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0, result.stderr
+
+        assert _vrt_size(raw) == (3600, 50), "gdalbuildvrt folded the seam itself"
+        assert _vrt_geotransform(raw)[0] == pytest.approx(-180.0)
+        assert 3550 in _dst_x_offs(raw)
+
+        # And the same inputs through _build_vrt, with that binary on PATH.
+        out = vrt_module._build_vrt(sources, str(tmp_path / "fixed.vrt"), "finest")
+        assert _vrt_size(out) == (100, 50)
         assert _dst_x_offs(out) == [0, 50]
 
 

--- a/backend/tests/test_raster_antimeridian_887.py
+++ b/backend/tests/test_raster_antimeridian_887.py
@@ -12,16 +12,16 @@ Three sites, one seam:
    ``max(right)`` across sources, so a 10°-wide mosaic straddling the seam was
    allocated 360° wide (3600 x 50 px instead of 100 x 50) with every source at
    the wrong ``dst_x_off``. ``gdalbuildvrt`` is the production builder and does
-   the same thing, so the normalization has to be reached from ``_build_vrt``
-   with the subprocess available — see
-   ``TestSeamFramingReachesTheProductionPath``.
+   the same thing, so the correction is applied to *its* output — see
+   ``TestSeamFrameRewrite``.
 3. ``processing/tiles/router.py`` — the user-visible symptom. Source maxzoom is
    derived from extent width when the COG has no recorded resolution, so a
    seam-crossing raster measured 36x too wide, understated its own resolution,
    and stopped rendering as the user zoomed in.
 
 The DB-backed tests need Postgres (``docker compose up -d --wait db``); the rest
-are pure rasterio/XML unit tests.
+are pure rasterio/XML unit tests. Any test here that commits a seam-crossing
+extent MUST take ``clean_tables`` — see ``TestRasterTokenAcrossTheSeam``.
 """
 
 import io
@@ -54,7 +54,8 @@ from app.processing.raster.vrt import (
     _seam_frame_origin,
     _write_python_vrt,
     build_vrt,
-    sources_straddle_seam,
+    shift_vrt_longitude_frame,
+    sources_seam_frame_origin,
 )
 from app.processing.tiles.router import _raster_maxzoom_from_metadata
 
@@ -77,6 +78,9 @@ def _write_tif(
     bounds: tuple[float, float, float, float],
     width: int = 64,
     height: int = 64,
+    nodata: float | None = None,
+    fill: int = 0,
+    mask: bool = False,
 ) -> str:
     """Write a synthetic single-band GeoTIFF at the given native bounds."""
     profile = {
@@ -89,11 +93,17 @@ def _write_tif(
     }
     if epsg is not None:
         profile["crs"] = CRS.from_epsg(epsg)
+    if nodata is not None:
+        profile["nodata"] = nodata
 
     buf = io.BytesIO()
     with MemoryFile() as mem:
         with mem.open(**profile) as ds:
-            ds.write(np.zeros((height, width), dtype="uint8"), 1)
+            ds.write(np.full((height, width), fill, dtype="uint8"), 1)
+            if mask:
+                band_mask = np.full((height, width), 255, dtype="uint8")
+                band_mask[:, : width // 2] = 0
+                ds.write_mask(band_mask)
         buf.write(mem.read())
     path.write_bytes(buf.getvalue())
     return str(path)
@@ -495,8 +505,8 @@ class TestSeamStraddlingVrt:
 # ---------------------------------------------------------------------------
 
 
-class TestSourcesStraddleSeamPredicate:
-    """The branch condition, on the inputs that must not trip it."""
+class TestSourcesSeamFrameOrigin:
+    """The build-time probe, on the inputs that must not trip it."""
 
     def test_geographic_seam_pair_is_detected(self, tmp_path):
         sources = [
@@ -506,7 +516,7 @@ class TestSourcesStraddleSeamPredicate:
             ),
         ]
 
-        assert sources_straddle_seam(sources) is True
+        assert sources_seam_frame_origin(sources) == pytest.approx(175.0)
 
     def test_off_seam_pair_is_not_detected(self, tmp_path):
         sources = [
@@ -514,15 +524,10 @@ class TestSourcesStraddleSeamPredicate:
             _write_tif(tmp_path / "b.tif", epsg=4326, bounds=(15.0, 0.0, 20.0, 5.0)),
         ]
 
-        assert sources_straddle_seam(sources) is False
+        assert sources_seam_frame_origin(sources) is None
 
     def test_one_crs_less_source_disables_detection(self, tmp_path):
-        """Unknown units means unknown wrap: refuse rather than guess.
-
-        The result is the un-normalized mosaic, which is the pre-existing
-        behaviour for a VRT nobody can interpret — `_write_python_vrt` takes its
-        SRS from the first source and never checks the rest agree.
-        """
+        """Unknown units means unknown wrap: refuse rather than guess."""
         sources = [
             _write_tif(tmp_path / "a.tif", epsg=4326, bounds=(175.0, 0.0, 180.0, 5.0)),
             _write_tif(
@@ -530,29 +535,86 @@ class TestSourcesStraddleSeamPredicate:
             ),
         ]
 
-        assert sources_straddle_seam(sources) is False
+        assert sources_seam_frame_origin(sources) is None
+
+    def test_projected_sources_are_not_detected(self, tmp_path):
+        """Metres are not degrees — a 4e7 m hull must not read as a seam crossing."""
+        half = WEB_MERCATOR_HALF_WORLD_M
+        sources = [
+            _write_tif(
+                tmp_path / "w.tif",
+                epsg=3857,
+                bounds=(-half, 0.0, -half + 1_000_000.0, 1_000_000.0),
+            ),
+            _write_tif(
+                tmp_path / "e.tif",
+                epsg=3857,
+                bounds=(half - 1_000_000.0, 0.0, half, 1_000_000.0),
+            ),
+        ]
+
+        assert sources_seam_frame_origin(sources) is None
 
     def test_unopenable_source_is_not_detected(self, tmp_path):
         bogus = tmp_path / "broken.tif"
         bogus.write_bytes(b"not a tiff")
 
-        assert sources_straddle_seam([str(bogus)]) is False
+        assert sources_seam_frame_origin([str(bogus)]) is None
 
 
-class TestSeamFramingReachesTheProductionPath:
+# A gdalbuildvrt mosaic of two nodata-carrying tiles either side of ±180, as
+# emitted verbatim by BOTH GDAL 3.10.3 (worker image) and GDAL 3.13.0 (local):
+# 3600 x 50 px anchored at -180, western tile parked at dst_x_off 3550. Reproduced
+# here so the rewrite is tested deterministically on machines with no GDAL CLI --
+# the skipif-gated tests below drive the real binary where it exists.
+_GDALBUILDVRT_SEAM_XML = """<VRTDataset rasterXSize="3600" rasterYSize="50">
+  <SRS dataAxisToSRSAxisMapping="2,1">GEOGCS["WGS 84"]</SRS>
+  <GeoTransform> -1.8000000000000000e+02,  1.0000000000000001e-01,  0.0000000000000000e+00,  5.0000000000000000e+00,  0.0000000000000000e+00, -1.0000000000000001e-01</GeoTransform>
+  <VRTRasterBand dataType="Byte" band="1">
+    <NoDataValue>0</NoDataValue>
+    <ColorInterp>Gray</ColorInterp>
+    <ComplexSource>
+      <SourceFilename relativeToVRT="1">w.tif</SourceFilename>
+      <SourceBand>1</SourceBand>
+      <SrcRect xOff="0" yOff="0" xSize="50" ySize="50" />
+      <DstRect xOff="3550" yOff="0" xSize="50" ySize="50" />
+      <NODATA>0</NODATA>
+    </ComplexSource>
+    <ComplexSource>
+      <SourceFilename relativeToVRT="1">e.tif</SourceFilename>
+      <SourceBand>1</SourceBand>
+      <SrcRect xOff="0" yOff="0" xSize="50" ySize="50" />
+      <DstRect xOff="0" yOff="0" xSize="50" ySize="50" />
+      <NODATA>0</NODATA>
+    </ComplexSource>
+    <MaskBand>
+      <VRTRasterBand dataType="Byte">
+        <ComplexSource>
+          <SourceFilename relativeToVRT="1">w.tif</SourceFilename>
+          <SourceBand>mask,1</SourceBand>
+          <SrcRect xOff="0" yOff="0" xSize="50" ySize="50" />
+          <DstRect xOff="3550" yOff="0" xSize="50" ySize="50" />
+        </ComplexSource>
+      </VRTRasterBand>
+    </MaskBand>
+  </VRTRasterBand>
+</VRTDataset>
+"""
+
+
+class TestSeamFrameRewrite:
     """``_write_python_vrt`` is the fallback; ``gdalbuildvrt`` is what ships.
 
     The worker image installs ``gdal-bin``, so ``_build_vrt`` gets a working
     subprocess and the ``FileNotFoundError`` fallback never fires in a deployed
     worker. A test that calls ``_write_python_vrt`` directly therefore proves
     nothing about production, which is exactly how the first cut of this fix
-    landed as dead code (codex P1 on #924). Every test here enters through
-    ``_build_vrt`` with the subprocess *available*.
+    landed as dead code (codex P1 on #924).
 
-    ``gdalbuildvrt`` itself is not the fix: verified against GDAL 3.10 (worker
-    image) and 3.13 (local), it emits 3600 x 50 px anchored at -180 with
-    ``dst_x_off`` 3550 for the seam pair below, and ``-te`` on the shifted hull
-    exits 0 while silently dropping every source outside the window.
+    Rebuilding the seam case with the Python writer instead was the second wrong
+    answer (codex P1 round 2): that writer emits bare ``SimpleSource`` elements,
+    so nodata, colour interpretation and masks all vanish. GDAL keeps building
+    the VRT; only the framing is rewritten afterwards.
     """
 
     def _tiles(self, tmp_path, lon_pairs, *, epsg=4326):
@@ -567,75 +629,84 @@ class TestSeamFramingReachesTheProductionPath:
             for i, (west, east) in enumerate(lon_pairs)
         ]
 
-    def test_seam_mosaic_never_reaches_gdalbuildvrt(self, tmp_path, monkeypatch):
-        """With the subprocess available, the seam pair still normalizes.
+    def _fake_gdalbuildvrt(self, xml: str):
+        """A ``run_gdal`` stub that writes GDAL's own output for the seam pair."""
 
-        ``run_gdal`` is stubbed to a *successful* call, so nothing can fall back:
-        if the seam branch were removed, the stub would be invoked and no VRT
-        would be written at all.
-        """
-        calls = []
+        def _run(cmd, **kwargs):
+            # gdalbuildvrt's output path is the argument after "-resolution <mode>".
+            Path(cmd[cmd.index("-resolution") + 2]).write_text(xml)
+            return SimpleNamespace(returncode=0, stderr="")
 
-        def _never(cmd, **kwargs):
-            calls.append(cmd)
-            raise AssertionError(
-                "gdalbuildvrt was spawned for a seam-straddling mosaic"
-            )
+        return _run
 
-        monkeypatch.setattr(vrt_module, "run_gdal", _never)
+    def test_seam_frame_is_rewritten_in_gdalbuildvrt_output(
+        self, tmp_path, monkeypatch
+    ):
+        """The geometry is corrected and every band tag survives untouched."""
+        monkeypatch.setattr(
+            vrt_module,
+            "run_gdal",
+            self._fake_gdalbuildvrt(_GDALBUILDVRT_SEAM_XML),
+        )
         sources = self._tiles(tmp_path, [(175.0, 180.0), (-180.0, -175.0)])
 
         out = vrt_module._build_vrt(sources, str(tmp_path / "seam.vrt"), "finest")
 
-        assert calls == []
         assert _vrt_size(out) == (100, 50)
         assert _vrt_geotransform(out)[0] == pytest.approx(175.0)
-        assert _dst_x_offs(out) == [0, 50]
+        # Band DstRects and the MaskBand's DstRect all move into the same frame.
+        assert _dst_x_offs(out) == [0, 50, 0]
 
-    def test_non_crossing_mosaic_still_uses_gdalbuildvrt(self, tmp_path, monkeypatch):
-        """Negative probe: same two tiles, same latitudes, moved off the seam.
+        xml = Path(out).read_text()
+        for tag in (
+            "NoDataValue",
+            "ColorInterp",
+            "ComplexSource",
+            "NODATA",
+            "MaskBand",
+        ):
+            assert f"<{tag}>" in xml, f"{tag} did not survive the rewrite"
+        assert "SimpleSource" not in xml, "the rewrite must not rebuild the sources"
 
-        Only the longitude position differs, so this pins that the branch is
-        narrow — everything else keeps going to the subprocess builder.
+    def test_non_crossing_output_is_left_byte_identical(self, tmp_path, monkeypatch):
+        """Negative probe: same tiles, same latitudes, moved off the seam.
+
+        Only the longitude position differs, so anything that changes here is the
+        rewrite firing when it must not.
         """
-        calls = []
-
-        def _record(cmd, **kwargs):
-            calls.append(cmd)
-            return SimpleNamespace(returncode=0, stderr="")
-
-        monkeypatch.setattr(vrt_module, "run_gdal", _record)
+        monkeypatch.setattr(
+            vrt_module,
+            "run_gdal",
+            self._fake_gdalbuildvrt(_GDALBUILDVRT_SEAM_XML),
+        )
         sources = self._tiles(tmp_path, [(10.0, 15.0), (15.0, 20.0)])
 
-        vrt_module._build_vrt(sources, str(tmp_path / "plain.vrt"), "finest")
+        out = vrt_module._build_vrt(sources, str(tmp_path / "plain.vrt"), "finest")
 
-        assert len(calls) == 1
-        assert calls[0][0] == "gdalbuildvrt"
+        assert Path(out).read_text() == _GDALBUILDVRT_SEAM_XML
 
-    def test_global_mosaic_still_uses_gdalbuildvrt(self, tmp_path, monkeypatch):
-        """A genuinely global mosaic is not a seam crossing; leave it to GDAL."""
-        calls = []
-
-        def _record(cmd, **kwargs):
-            calls.append(cmd)
-            return SimpleNamespace(returncode=0, stderr="")
-
-        monkeypatch.setattr(vrt_module, "run_gdal", _record)
+    def test_global_mosaic_output_is_left_alone(self, tmp_path, monkeypatch):
+        """A genuinely global mosaic is not a seam crossing."""
+        monkeypatch.setattr(
+            vrt_module,
+            "run_gdal",
+            self._fake_gdalbuildvrt(_GDALBUILDVRT_SEAM_XML),
+        )
         sources = self._tiles(
             tmp_path, [(-180.0 + 10 * i, -170.0 + 10 * i) for i in range(36)]
         )
 
-        vrt_module._build_vrt(sources, str(tmp_path / "global.vrt"), "finest")
+        out = vrt_module._build_vrt(sources, str(tmp_path / "global.vrt"), "finest")
 
-        assert len(calls) == 1
+        assert Path(out).read_text() == _GDALBUILDVRT_SEAM_XML
 
-    def test_band_stack_dispatch_keeps_the_seam_branch(self, tmp_path, monkeypatch):
-        """``build_vrt("band_stack", ...)`` reaches the branch too."""
-
-        def _never(cmd, **kwargs):
-            raise AssertionError("gdalbuildvrt was spawned for a seam band stack")
-
-        monkeypatch.setattr(vrt_module, "run_gdal", _never)
+    def test_band_stack_dispatch_also_rewrites(self, tmp_path, monkeypatch):
+        """``build_vrt("band_stack", ...)`` reaches the rewrite too."""
+        monkeypatch.setattr(
+            vrt_module,
+            "run_gdal",
+            self._fake_gdalbuildvrt(_GDALBUILDVRT_SEAM_XML),
+        )
         sources = self._tiles(tmp_path, [(175.0, 180.0), (-180.0, -175.0)])
 
         out = build_vrt("band_stack", sources, str(tmp_path / "stack.vrt"), "finest")
@@ -643,8 +714,35 @@ class TestSeamFramingReachesTheProductionPath:
         assert _vrt_size(out) == (100, 50)
         assert _vrt_geotransform(out)[0] == pytest.approx(175.0)
 
+    def test_missing_dstrect_fails_loudly(self, tmp_path):
+        """Editing generated XML is version-sensitive, so assert the structure.
+
+        A source with no ``DstRect`` covers the whole raster implicitly; shrinking
+        the raster underneath it would silently restretch it. Raise instead —
+        shipping a misregistered mosaic that looks fine is the one unacceptable
+        outcome.
+        """
+        vrt = tmp_path / "no_dstrect.vrt"
+        vrt.write_text(
+            '<VRTDataset rasterXSize="3600" rasterYSize="50">'
+            "<GeoTransform>-180.0, 0.1, 0.0, 5.0, 0.0, -0.1</GeoTransform>"
+            '<VRTRasterBand dataType="Byte" band="1"><SimpleSource>'
+            "<SourceFilename>w.tif</SourceFilename></SimpleSource>"
+            "</VRTRasterBand></VRTDataset>"
+        )
+
+        with pytest.raises(RuntimeError, match="expected one DstRect per source"):
+            shift_vrt_longitude_frame(str(vrt), 175.0)
+
+    def test_missing_geotransform_fails_loudly(self, tmp_path):
+        vrt = tmp_path / "no_gt.vrt"
+        vrt.write_text('<VRTDataset rasterXSize="10" rasterYSize="10" />')
+
+        with pytest.raises(RuntimeError, match="no GeoTransform"):
+            shift_vrt_longitude_frame(str(vrt), 175.0)
+
     def test_unopenable_source_is_left_to_gdalbuildvrt(self, tmp_path, monkeypatch):
-        """The predicate must never swallow a broken source's real error."""
+        """The probe must never swallow a broken source's real error."""
         calls = []
 
         def _record(cmd, **kwargs):
@@ -660,24 +758,45 @@ class TestSeamFramingReachesTheProductionPath:
 
         assert len(calls) == 1
 
-    def test_bad_resolution_strategy_still_raises_before_any_branch(self, tmp_path):
-        """The KeyError contract holds on both sides of the new branch."""
+    def test_bad_resolution_strategy_still_raises_first(self, tmp_path):
+        """The KeyError contract holds ahead of any seam work."""
         sources = self._tiles(tmp_path, [(175.0, 180.0), (-180.0, -175.0)])
 
         with pytest.raises(KeyError):
             vrt_module._build_vrt(sources, str(tmp_path / "bad.vrt"), "sharpest")
 
-    @pytest.mark.skipif(
-        shutil.which("gdalbuildvrt") is None,
-        reason="needs the real gdalbuildvrt (present in the worker image)",
-    )
-    def test_real_gdalbuildvrt_would_get_this_wrong(self, tmp_path):
-        """Pin the upstream behaviour this branch exists to route around.
 
-        Not a test of our code — a test of the premise. If a future GDAL learns
-        to fold longitudes, this fails and the branch can be reconsidered.
+@pytest.mark.skipif(
+    shutil.which("gdalbuildvrt") is None,
+    reason="needs the real gdalbuildvrt (present in the worker image)",
+)
+class TestSeamFrameRewriteAgainstRealGdal:
+    """End-to-end against whatever GDAL is installed.
+
+    Verified identical on GDAL 3.10.3 (the worker image) and 3.13.0 (local): the
+    upstream defect, the XML shape the rewrite depends on, and the corrected
+    result all match.
+    """
+
+    def _nodata_tile(self, path, *, bounds, value):
+        return _write_tif(
+            path, epsg=4326, bounds=bounds, width=50, height=50, nodata=0, fill=value
+        )
+
+    def test_upstream_still_gets_the_seam_wrong(self, tmp_path):
+        """A test of the premise, not of our code.
+
+        If a future GDAL learns to fold longitudes itself, this fails and the
+        rewrite can be reconsidered.
         """
-        sources = self._tiles(tmp_path, [(175.0, 180.0), (-180.0, -175.0)])
+        sources = [
+            self._nodata_tile(
+                tmp_path / "w.tif", bounds=(175.0, 0.0, 180.0, 5.0), value=7
+            ),
+            self._nodata_tile(
+                tmp_path / "e.tif", bounds=(-180.0, 0.0, -175.0, 5.0), value=9
+            ),
+        ]
         raw = str(tmp_path / "raw.vrt")
         result = subprocess.run(
             ["gdalbuildvrt", "-resolution", "highest", raw, *sources],
@@ -689,11 +808,107 @@ class TestSeamFramingReachesTheProductionPath:
         assert _vrt_size(raw) == (3600, 50), "gdalbuildvrt folded the seam itself"
         assert _vrt_geotransform(raw)[0] == pytest.approx(-180.0)
         assert 3550 in _dst_x_offs(raw)
+        # And the structure the rewrite depends on is there.
+        assert "<DstRect" in Path(raw).read_text()
 
-        # And the same inputs through _build_vrt, with that binary on PATH.
-        out = vrt_module._build_vrt(sources, str(tmp_path / "fixed.vrt"), "finest")
-        assert _vrt_size(out) == (100, 50)
-        assert _dst_x_offs(out) == [0, 50]
+    def test_nodata_and_pixels_survive_a_seam_build(self, tmp_path):
+        """The assertion that would have caught the round-2 P1."""
+        sources = [
+            self._nodata_tile(
+                tmp_path / "w.tif", bounds=(175.0, 0.0, 180.0, 5.0), value=7
+            ),
+            self._nodata_tile(
+                tmp_path / "e.tif", bounds=(-180.0, 0.0, -175.0, 5.0), value=9
+            ),
+        ]
+
+        out = vrt_module._build_vrt(sources, str(tmp_path / "seam.vrt"), "finest")
+
+        with rasterio.open(out) as ds:
+            assert (ds.width, ds.height) == (100, 50)
+            assert ds.bounds.left == pytest.approx(175.0)
+            assert ds.bounds.right == pytest.approx(185.0)
+            assert ds.nodata == 0.0, "nodata must survive the seam build"
+            assert ds.colorinterp[0].name == "gray"
+            assert ds.mask_flag_enums[0][0].name == "nodata"
+            band = ds.read(1)
+
+        # Each tile lands on its own half, in the shifted frame.
+        assert set(band[:, :50].ravel().tolist()) == {7}
+        assert set(band[:, 50:].ravel().tolist()) == {9}
+
+    def test_overlapping_fill_does_not_obscure_valid_pixels(self, tmp_path):
+        """An all-nodata source laid last must not erase an earlier tile.
+
+        Measured on the Python-writer route this replaces: these pixels read 0.
+        """
+        sources = [
+            self._nodata_tile(
+                tmp_path / "w.tif", bounds=(175.0, 0.0, 180.0, 5.0), value=7
+            ),
+            self._nodata_tile(
+                tmp_path / "e.tif", bounds=(-180.0, 0.0, -175.0, 5.0), value=9
+            ),
+            # laid last, entirely fill, over the western tile's eastern half
+            self._nodata_tile(
+                tmp_path / "fill.tif", bounds=(177.5, 0.0, 180.0, 5.0), value=0
+            ),
+        ]
+
+        out = vrt_module._build_vrt(sources, str(tmp_path / "ov.vrt"), "finest")
+
+        with rasterio.open(out) as ds:
+            band = ds.read(1)
+            assert ds.nodata == 0.0
+        # 177.5..180 is columns 25-49 of the 100-px hull anchored at 175.
+        assert set(band[:, 25:50].ravel().tolist()) == {7}
+
+    def test_masked_sources_keep_their_mask_band(self, tmp_path):
+        sources = [
+            _write_tif(
+                tmp_path / "mw.tif",
+                epsg=4326,
+                bounds=(175.0, 0.0, 180.0, 5.0),
+                width=50,
+                height=50,
+                mask=True,
+            ),
+            _write_tif(
+                tmp_path / "me.tif",
+                epsg=4326,
+                bounds=(-180.0, 0.0, -175.0, 5.0),
+                width=50,
+                height=50,
+                mask=True,
+            ),
+        ]
+
+        out = vrt_module._build_vrt(sources, str(tmp_path / "mask.vrt"), "finest")
+
+        assert "UseMaskBand" in Path(out).read_text()
+        with rasterio.open(out) as ds:
+            assert (ds.width, ds.height) == (100, 50)
+            assert ds.mask_flag_enums[0][0].name == "per_dataset"
+
+    def test_non_crossing_build_is_byte_identical_to_plain_gdalbuildvrt(self, tmp_path):
+        """Nothing off the seam changes shape because of this PR."""
+        sources = [
+            self._nodata_tile(
+                tmp_path / "a.tif", bounds=(10.0, 0.0, 15.0, 5.0), value=7
+            ),
+            self._nodata_tile(
+                tmp_path / "b.tif", bounds=(15.0, 0.0, 20.0, 5.0), value=9
+            ),
+        ]
+        ours = vrt_module._build_vrt(sources, str(tmp_path / "ours.vrt"), "finest")
+        reference = str(tmp_path / "ref.vrt")
+        subprocess.run(
+            ["gdalbuildvrt", "-resolution", "highest", reference, *sources],
+            capture_output=True,
+            check=True,
+        )
+
+        assert Path(ours).read_bytes() == Path(reference).read_bytes()
 
 
 # ---------------------------------------------------------------------------
@@ -852,8 +1067,23 @@ async def _seed_raster(
 
 
 class TestRasterTokenAcrossTheSeam:
+    """Every test here MUST take ``clean_tables``.
+
+    fix(#887): ``test_db_session`` does not roll back — the worker's database is
+    shared across the whole session and isolation is by explicit cleanup. A
+    committed two-ring extent that outlives its test breaks
+    ``test_record_translations_migration``, whose alembic round-trip downgrades
+    through ``0030_records_spatial_extent_type``; that downgrade refuses by
+    design when any ``catalog.records`` row holds a MULTIPOLYGON (#901), because
+    the narrowed column cannot store one. It surfaces as an unrelated migration
+    failure on a later test, only under ``-n`` and only when the ordering puts the
+    two on the same worker, so it reads exactly like a flake. ``clean_tables``
+    truncates ``catalog.records`` afterwards; the sibling
+    ``test_antimeridian_rollup.py`` does the same for the same reason.
+    """
+
     async def test_seam_crossing_raster_keeps_a_usable_maxzoom(
-        self, client: AsyncClient, test_db_session
+        self, client: AsyncClient, test_db_session, clean_tables
     ):
         """The reported symptom: the raster stops rendering as you zoom in.
 
@@ -878,7 +1108,7 @@ class TestRasterTokenAcrossTheSeam:
         assert data["bounds"][2] == pytest.approx(180.0)
 
     async def test_off_seam_raster_of_the_same_size_matches(
-        self, client: AsyncClient, test_db_session
+        self, client: AsyncClient, test_db_session, clean_tables
     ):
         """Negative probe: identical footprint and latitudes, moved off the seam."""
         dataset = await _seed_raster(
@@ -892,7 +1122,7 @@ class TestRasterTokenAcrossTheSeam:
         assert resp.json()["maxzoom"] == 13
 
     async def test_global_raster_token_is_unchanged(
-        self, client: AsyncClient, test_db_session
+        self, client: AsyncClient, test_db_session, clean_tables
     ):
         """A raster that really is 360° wide keeps its (honestly coarse) maxzoom."""
         dataset = await _seed_raster(


### PR DESCRIPTION
Closes #887

Three sites in the raster pipeline folded longitudes with `min`/`max` and lost the ±180 wrap. Built on #901's `bbox_to_extent_wkt` / `extent_to_bbox` pair and the widened `records.spatial_extent` column.

## Site 1 — `processing/raster/cog.py`

`extract_raster_metadata` built the extent WKT as a single hand-rolled ring over the reprojected bounds. GDAL's `transform_bounds` (`OCTTransformBounds`) **already** reports a seam-crossing footprint as `west > east`, so that ring was the *complement*. Measured against `origin/main`:

```
cog.py  pacific 3832 bbox_wkt geom: Polygon
        area=7000.0 deg^2  planar bounds=(-175.0, -10.0, 175.0, 10.0)
        lon width=350.0 deg (real footprint is 10)
```

A valid 350°-wide rectangle covering 7000 deg² on the wrong side of the world instead of its real 200 — and it does not contain the data it describes. The bbox now goes through `bbox_to_extent_wkt`, which splits it into two rings at ±180.

Two further folds in the same function:

- **Geographic sources pass through `transform_bounds` untouched.** A raster stored in the 0..360 longitude domain keeps an east past +180 (verified: `transform_bounds(4326→4326, 175, -10, 185, 10)` returns `(175, -10, 185, 10)`). That is what plenty of published global grids use, and what the seam-aware VRT builder below now emits. `_fold_geographic_bbox` wraps it.
- **A footprint that wraps the whole world puts its left and right edges on the same meridian**, so `transform_bounds` can only report a zero-width longitude range for it. A global EPSG:3832 raster read `-30..-30` and registered the globe as a 0 deg² line — pre-existing, same root cause, and it would have survived the rest of this fix untouched.

### Guard conditions

**The degenerate-range repair needs two conditions, and either alone misfires.**

1. `abs(east - west) <= 1e-9` — the reprojected longitude range must be degenerate. A span-only heuristic ("wider than X, so wrap it") is what breaks a genuinely global EPSG:3857 raster, which legitimately measures 360°.
2. The raster centre must sit more than 1° from that edge meridian. Only a wrap produces that; a genuine zero-width source has its centre *on* the meridian. Without this condition a sliver would be inflated to the whole world.

The tolerance in (1) is deliberately tight rather than "near the seam": a 2 m-wide sliver in EPSG:3832 still reports 1.8e-5° of width, four orders of magnitude above it. Only an exactly-360° footprint hits equality.

There is no span-based guard in the crossing path at all, because GDAL owns that decision and gets it right at every width:

```
3832 width= 360.00 deg -> west=  -30.0000 east=  -30.0000   (degenerate; repaired)
3832 width= 359.64 deg -> west=  -29.8200 east=  -30.1800   wrap-span=359.640
3832 width= 216.00 deg -> west=   42.0000 east= -102.0000   wrap-span=216.000
3832 width= 180.00 deg -> west=   60.0000 east= -120.0000   wrap-span=180.000
3832 width=  36.00 deg -> west=  132.0000 east=  168.0000   wrap-span= 36.000
```

## Site 2 — `processing/raster/vrt.py`

> **Revised across eleven codex rounds — twelve findings, all real. Round 12 came back clean.**
> 1. The first cut put the seam framing in `_write_python_vrt`, which `_build_vrt` only reaches from its `except FileNotFoundError` fallback — and the worker image installs `gdal-bin` (`Dockerfile:23`, `:128`), so that fallback never fires in production. The VRT half of the fix was dead code, and the tests hid it by calling `_write_python_vrt` directly.
> 2. Routing production seam builds to `_write_python_vrt` instead then lost every band-level semantic GDAL provides — nodata, colour interpretation, masks — and let an overlapping source's fill pixels *overwrite valid data*.
>
> 3. Two P2s on the result: `is_geographic` admits grads-based CRSs (EPSG:4807 turns at 400, not 360), and `gdalbuildvrt` emits *fractional* `DstRect` offsets that the rewrite was rounding.
>
> 4. And a P2 on *that*: the re-framed `rasterXSize` was rounded to nearest, so a mosaic whose sources end at pixel 298.5 was allocated 298 and GDAL clipped the last half pixel.
>
> 5. A P1 on the probe added in (3): it fetched caller-supplied URLs ahead of the subprocess, and no GDAL setting can stop a redirect (see below).
> 6. And a P2 on the frame rewrite: a bare float comparison on a reconstructed edge, the third instance of one class in this batch.
>
> 7. The CLI-less fallback writer still rounded destination geometry, so the two writers disagreed about one rule.
> 8. And `math.isclose`'s default `rel_tol` scaled with magnitude, undoing the sub-pixel fix on very large VRTs.
>
> 9. A P1: the pre-build probe opened every source synchronously inside `asyncio.to_thread`, outside `run_gdal`'s timeout, so a stalled read could starve the worker's executor.
> 10. A P2: `wrap_longitude` folds one turn, so a COG georeferenced further out inflated its extent (measured 19x east, 37x west).
> 11. A P2: the same wrap-count class in the VRT frame chooser, scaling to 360°/720°/1080° hulls.
>
> **Final shape: `gdalbuildvrt` still builds the VRT; the seam is decided and corrected from the XML it writes — opening no sources at all — gated on degree units, spans normalized into one turn, sub-pixel offsets preserved, sized to contain every source, with every shift comparison carrying a shared epsilon and both writers sharing one geometry rule.** See below.

Both builders took `min(left)` / `max(right)` across mosaic sources. Here is `_write_python_vrt` — the CLI-less fallback — on two 5° tiles either side of the seam, measured against `origin/main`; the real `gdalbuildvrt` produces the identical numbers, which is the subject of the next section:

```
vrt.py  seam mosaic rasterXSize: 3600 rasterYSize: 50
        GeoTransform: -180.0, 0.1, 0.0, 5.0, 0.0, -0.1
        DstRect xOffs: ['3550', '0']
```

3600 × 50 px for a footprint that is 100 × 50, with 350° of hole in the middle and the western source parked at `dst_x_off` 3550 — enormous *and* misregistered. After:

```
  rasterXSize 100 rasterYSize 50
  GeoTransform 175.0, 0.1, 0.0, 5.0, 0.0, -0.1
  DstRect {'xOff': '0', ...}   DstRect {'xOff': '50', ...}
  reopened bounds BoundingBox(left=175.0, bottom=0.0, right=185.0, top=5.0) size 100 50
  reopened _wgs84_bbox -> (175.0, 0.0, -175.0, 5.0)
  bbox_wkt -> MULTIPOLYGON(((175.0 0.0,180.0 0.0,180.0 5.0,175.0 5.0,175.0 0.0)),((-180.0 0.0,-175.0 0.0,-175.0 5.0,-180.0 5.0,-180.0 0.0)))
```

The mosaic **geometry** is computed in the shifted frame, not just the recorded extent: `_seam_frame_origin` picks the frame origin, and the per-source `lon_offset` travels into `add_simple_source` so `dst_x_off` is computed in the same frame as the `GeoTransform`. The last two lines show the two sites composing — the re-framed VRT reads back through site 1 as a two-ring 10° extent. `_seam_frame_origin` and its guards below are shared by both builders; only *where* the correction is applied differs.

### Guard conditions

**Three, and all are required.**

1. **Every source must be geographic AND degree-based.** Not a nicety, in two directions. Projected easting runs continuously across the seam *and* its numbers are metres: a 40 000 km-wide EPSG:3857 pair clears a bare ">180" test trivially, and a +360 shift would move a source by 360 *metres*. And `is_geographic` alone is not enough either — EPSG:4807 (NTF Paris) is geographic in **grads**, where a full turn is 400 and the seam sits at 200, so a 360 shift lands a 195..200 / -200..-195 pair as a 40-grad hull instead of a 10-grad one. Verified reachable: `sources_seam_frame_origin` returned `195.0` on real 4807 tiles before the gate. The check compares the CRS's own radians-per-unit factor rather than a unit name, which varies by PROJ build. Restricting rather than deriving the period is deliberate — the guard threshold, the shift, and the ±180 rings downstream are all written in degrees, so a grads mosaic gets the old over-broad hull instead of a corrupted one.
2. **The plain hull must be wider than 180°.** Nothing narrower can be improved by a shift. This is what leaves a mosaic ending flush at +180, and one spanning exactly -10..170, alone.
3. **The shifted hull must be *strictly* narrower than the plain one.** A genuinely global mosaic measures 360° in *every* frame, so it ties and keeps -180..180 rather than being re-framed to an arbitrary origin. This is also what saves a contiguous 185°-wide mosaic (`-10..85` + `85..175`), which passes guard 2 but has no better frame.

Candidate origins are the source left edges, which is exhaustive — the tightest circular hull of a set of intervals always starts at one of them — so the chosen frame is the minimum, not merely an improvement (`test_shifted_hull_is_the_tightest_available` asserts the 220° hull for a three-source case).

### Correcting the framing without losing GDAL's output

`gdalbuildvrt` has the same defect and cannot be steered out of it up front. Measured against GDAL 3.13 locally:

```
1. plain gdalbuildvrt over the seam pair
   size 3600 x 50 | gt -180.0, 0.1, ...
   dst xOffs ['3550', '0']          <- identical to the old Python writer

2. gdalbuildvrt -te 175 0 185 5
   size 100 x 50 | gt 175.0, 0.1, ...
   dst xOffs ['0']                  <- only ONE source placed
   left half unique: [1]   right half unique: [0]
```

`-te` sizes the mosaic correctly and then drops every source outside the window: exit code 0, half the mosaic empty. Worse than the bug. Pre-shifting each source through its own intermediate VRT is geometrically sound, but those intermediates are temp files that never get stored, so `rewrite_vrt_sources` (STOR-03) would leave the outer VRT pointing at paths that do not survive ingest.

Rebuilding the seam case with `_write_python_vrt` was the other wrong answer, and it is what codex's round-2 P1 caught. That writer emits bare `SimpleSource` elements, so for sources carrying `nodata=0`:

```
gdalbuildvrt    nodata=0.0  colorinterp=['gray']       masks=['nodata']
                xml: NoDataValue, ComplexSource, ColorInterp, NODATA
python writer   nodata=None colorinterp=['undefined']  masks=['all_valid']
                xml: SimpleSource

OVERLAP, all-nodata source laid last over a valid tile:
gdalbuildvrt    overlap reads 7      python writer   overlap reads 0
```

`extract_raster_metadata` would then persist a null nodata, tiles would render fill as data, and overlapping fill would erase real pixels. Alpha and mask sources lose `ColorInterp` and `UseMaskBand`/`MaskBand` the same way.

**So GDAL keeps building the VRT, and `shift_vrt_longitude_frame` rewrites only what is wrong** in the document it just produced: root `rasterXSize`, the `GeoTransform` origin, and every `DstRect/@xOff` — including the ones inside `<MaskBand>`, which `iter()` reaches. Each source's own left edge is recoverable from the `xOff` GDAL already wrote (`old_left + xOff * res_x`), so there is no second pass over the sources and no filename matching. Same inputs, through `_build_vrt` with the real binary:

```
size=100x50 left=175.0 right=185.0
nodata=0.0 colorinterp=['gray'] masks=['nodata']
xml tags: NoDataValue, ComplexSource, ColorInterp, NODATA
dst xOffs: ['0', '50']
left-half unique: [7]   right-half unique: [9]
overlap after an all-nodata source laid last: [7]
extract_raster_metadata: nodata=0.0  bbox=MULTIPOLYGON(((175.0 0.0,180.0 0.0,...
```

**Sub-pixel offsets are preserved.** `gdalbuildvrt` emits fractional `DstRect/@xOff` as soon as a source is off the chosen output grid — measured `xOff="17751.5"` and `xOff="349.51"` on mixed-resolution mosaics. Rounding those on the way out would slide the source by up to half an output pixel and change its resampling alignment, so offsets keep their fraction and only a trailing `.0` is dropped, leaving the ordinary whole-pixel case formatted exactly as GDAL writes it. `rasterXSize` stays integral — it is a pixel count. End to end on an off-grid seam mosaic: `DstRects [('0', '248.5'), ('248.5', '50')]`, bounds 175.03..180.99, pixels on the right side of the join. (`xSize` was already fractional in GDAL's output and is passed through untouched; the rewrite only ever writes `xOff`.)

**The raster is sized to contain its sources, not rounded.** A mosaic whose sources end at pixel 298.5 needs 299 pixels; 298 leaves the last half pixel outside the dataset and GDAL clips it. `gdalbuildvrt` rounds up in its own output too — measured `max(xOff + xSize) = 298.5 -> rasterXSize 299`, and `440.51 -> 441` — so the width now comes from the containment invariant directly, `ceil(max(xOff + xSize))` over the *new* offsets, rather than from a separately computed hull that could drift from them. `round()` is applied before the `ceil` so float noise on an exactly-aligned boundary cannot add a stray pixel: the aligned 50 + 50 seam mosaic still comes out 100 px, not 101.

This one is worth recording as a testing lesson: **no pixel-count assertion can catch it.** The clipped source still reads back as 50 pixels wide and every value check still passes — only its final half pixel is silently dropped. The tests assert the geometry directly, `rasterXSize >= max(xOff + xSize)`, on a hand-written fixture and end to end against the real binary.

**Honest trade-off.** For: no fidelity loss, no promoted fallback, no temp intermediates (so STOR-03 stays solved), and a smaller diff than teaching the Python writer band/nodata/mask semantics. Against: it edits generated XML, which is version-sensitive. Mitigated two ways — the structure is asserted rather than assumed (a missing `GeoTransform`, a malformed one, or a source with no `DstRect` all raise, because shipping a misregistered mosaic that looks fine is the one unacceptable outcome), and both versions in play were checked: **GDAL 3.10.3 (the worker image, probed in a throwaway container with no bind mount) and 3.13.0 (local) emit byte-identical structure** for the seam pair, down to `rasterXSize="3600"`, `GeoTransform` at -180, `DstRect xOff="3550"`, and `ComplexSource`/`NODATA`.

`_write_python_vrt` keeps its own seam handling because it is still the CLI-less fallback, and it is still tested — it is simply no longer the production path for this case.

Cost: `sources_seam_frame_origin` reads each source's header once per build, bounded by `VrtCreateRequest`'s 500-source cap, and `gdalbuildvrt` opens the same sources immediately afterwards anyway. The origin search is quadratic in source count but only runs once the plain hull already exceeds 180°, so the common mosaic never reaches it, and 500² is microseconds.

### Not probing caller-supplied hosts (AGENTS.md Rule 2)

The frame probe runs *ahead* of `gdalbuildvrt`, so for a remotely imported STAC asset — whose `https://` URL `resolve_open_path` passes through unchanged — it would be the first thing to fetch that host, and a URL that was validated at import time but now redirects to a private address would be followed.

The obvious fix is to clamp the open with the same options `gdal_safe_env()` applies to subprocesses. **It does not work, and measuring it turned up a repo-wide gap.** `GDAL_HTTP_FOLLOWLOCATION` is not a GDAL configuration option:

```
$ gdalinfo --config GDAL_HTTP_FOLLOWLOCATION NO --debug ON /vsicurl/http://.../redirect.tif
Warning 1: Unknown configuration option 'GDAL_HTTP_FOLLOWLOCATION'.

behavioural, one fresh process per case, 302 -> /private.tif:
  in-process rasterio.open, no clamp            -> FOLLOWED
  gdalinfo, no clamp                            -> FOLLOWED
  gdalinfo, GDAL_HTTP_FOLLOWLOCATION=NO         -> FOLLOWED
  gdalinfo, --config GDAL_HTTP_FOLLOWLOCATION   -> FOLLOWED
  gdalinfo, GDAL_HTTP_MAX_REDIRECTS=0           -> FOLLOWED
```

Confirmed on **both** versions in play: GDAL 3.12.1 locally and GDAL 3.10.3 in the worker image (probed in a throwaway container, no bind mount). So clamping would only have *looked* like a fix.

The probe therefore refuses caller-supplied hosts outright — `http://`, `https://`, `/vsicurl/`, `/vsicurl_streaming/` return `None` before anything is opened. `/vsis3/`, `/vsiaz/` and local paths keep being probed (bucket from settings, key already validated by `resolve_storage_key`), so the correction still applies to managed storage. Cost, stated in the docstring: a seam-crossing mosaic built from remote sources keeps the old over-broad hull. The test asserts the strong property — a local server records every hit and **the list must stay empty**; "the redirect was not followed" is untestable-by-construction here.

> **Out of scope, filed separately:** AGENTS.md Rule 2 documents `GDAL_HTTP_FOLLOWLOCATION=NO` as *the* SSRF redirect defense for GDAL subprocess calls (`_VRT_SAFE_ENV`, and per AGENTS.md `ingest/ogr.py`). It is inert on the shipped worker image. Rule 2's grep hook only matches `httpx.AsyncClient(`, so nothing catches it.

### One class of float bug, swept rather than patched

Three findings in this batch were the same shape: **a bare float comparison gating a branch that moves geometry by 360°, fed by arithmetic that is not bit-exact.** `_narrower_domain` in the rollup folds (#886/#928), then `_seam_frame_origin` (found on the #928 rebase — a *global* 36-tile mosaic re-framing to origin 160.3 on noise), then the rewrite's reconstructed edge (`175.00099999999998 < 175.001`, leaving the mosaic 17998 px wide instead of 300).

`LON_EPSILON_DEGREES` now lives in `core/geo.py` beside `_SEAM_TOL` and `_DOMAIN_MARGIN` (all 1e-9, ~0.1 mm), and every comparison in the class imports it:

| # | site | comparison |
|---|------|-----------|
| 1 | `_seam_frame_origin` guard 1 | `plain_span <= 180 + eps` |
| 2 | `_seam_frame_origin` inner shift | `left < origin - eps` |
| 3 | `_seam_frame_origin` hull contest | `shifted < best - eps` |
| 4 | `_write_python_vrt` per-source | `bounds.left < origin - eps` |
| 5 | `shift_vrt_longitude_frame` | `src_left < origin - eps` |
| 6 | `cog._fold_geographic_bbox` | `span >= 360 - eps` |

**Six sites; codex named one.** Site 6 was its own live bug — a 0..360 global raster whose span measures 359.99999999999994 fell out of the global branch and was re-expressed as a `west > east` crossing pair. Sites 2 and 4 are exact by construction today; they take the epsilon so a future caller passing reconstructed values inherits the guard. The remaining comparisons in both files were audited: `res_x <= 0` is a validity check, `_LON_DEGENERATE_TOL` and `_WRAP_PROBE_MIN_DEGREES` already carry tolerances nine orders above the noise, the rest are counts and indices.

Closing a class needs a test shaped like the class, so the re-framing path has a **property sweep**: 24 seam mosaics with left edges and resolutions chosen to be awkward in binary, each asserting the raster contains every source *and* that the re-framed hull is near the real footprint rather than ~360°. Reverting the one line codex named makes **8 of the 24 fail** with `re-framed hull is 359.02° — the sources were left scattered across a world`. Example-based tests missed all three instances of this class.

### Both writers share one geometry rule

`gdalbuildvrt` is the production builder; `_write_python_vrt` is the fallback for hosts with no GDAL CLI. They had drifted: the rewrite kept sub-pixel geometry, the fallback still rounded it. Codex's fixture — sources at 175.03..180 and -180..-179 at 0.02° — reproduced it:

```
_write_python_vrt, before        rasterXSize 298   DstRects [('0','248'), ('248','50')]
                                 exact xOff for the eastern tile = 248.49999999999994
_write_python_vrt, after         rasterXSize 299   DstRects [('0','248.5'), ('248.5','50')]
```

`_offset_text` (keep the fraction) and `_containing_pixels` (round the containing size up) are now defined once, side by side, and **both** writers call them. Extracted rather than copied, because a copied rule is how they diverged. The fallback is unreachable in the shipped worker — the image installs `gdal-bin`, so `_build_vrt` only reaches it via `FileNotFoundError` — and is fixed anyway, since two writers disagreeing about one rule is what produced the first regression on this PR.

`_offset_text` compares against **absolute** noise only. `math.isclose` weighs against `max(rel_tol * max(|a|,|b|), abs_tol)`, so the default `rel_tol=1e-9` made the tolerance grow with the offset — 0.1 px at 1e8, a whole pixel at 1e9, where a real 0.49-pixel offset was rounded away.

> **Reachable?** No — defensive, stated so it does not read as a live production bug. Offsets here are (extent in CRS units) / (target resolution). A visible half-pixel loss needs an offset ≥ 5e8 px; `VrtCreateRequest` caps a VRT at 500 sources, and 500 COGs of 40k px a side reach 2e7 px, where the discarded fraction is ~0.02 px. The fix costs one keyword argument, so it is worth taking regardless. The only other `isclose` in the package (`_is_degree_based`) uses `rel_tol` correctly — it compares two fixed constants of the same tiny magnitude — and carries a note saying so, because the obvious next move is to "fix" it by symmetry.

### Behaviour change worth knowing about

**Non-seam VRTs built by the fallback writer now carry fractional destination geometry.** A projected mosaic whose sources sit off the output grid records `xOff 1953.7508342789` where it previously recorded a rounded `1954`. That is the more accurate placement and matches what `gdalbuildvrt` writes for the same input, but it is a change beyond the antimeridian, and it is why one existing assertion in this PR moved rather than broke. It is only reachable on hosts without the GDAL CLI, since the shipped worker image installs `gdal-bin`.

### The seam is decided from the built VRT, opening no sources

An earlier cut probed every source with `rasterio.open` before the build. `build_vrt` runs inside `asyncio.to_thread` (`tasks_vrt.py:317`) and Python threads are not killable, so a stalled object-storage read pinned a pool thread with none of `run_gdal`'s wall-clock timeout applying — the hazard `vrt.py`'s own `GDAL_SUBPROCESS_TIMEOUT_SECONDS` comment already names. Enough stalled VRT jobs starve every other `to_thread` in the worker, and managed storage is exactly what it probed, so it was production-reachable.

`gdalbuildvrt` has already opened every source under that timeout and written what the decision needs, so the probe is gone. Verified the two cases are distinguishable from the XML alone before committing to it — a hull cannot tell them apart, but per-source spans reconstructed from each `DstRect` plus the `GeoTransform` can:

```
seam pair            deg=True  n= 2 origin=175.0
global 36 tiles      deg=True  n=36 origin=None
off-seam pair        deg=True  n= 2 origin=None
185 wide contiguous  deg=True  n= 2 origin=None
grads 4807 seam      deg=False      origin=None
projected 3857       deg=False      origin=None
```

`CRS.from_wkt` on the `<SRS>` element is pure string parsing. The SSRF question from round 5 disappears with the probe rather than being fenced off by URL prefix — nothing in this path opens a caller-supplied host at all. Tested by a source whose host sleeps 6s: `_build_vrt` must return in under 2s and never contact it, with a control fetch proving the request log works. Reintroducing the probe fails it at **30.0s** (GDAL retries the stalled read).

### One turn is not enough

`wrap_longitude` folds a single turn by design (#886), and both seam paths assumed that was always sufficient. GDAL accepts georeferencing further out, and the failures are silent and scale with distance.

In `cog._fold_geographic_bbox`, a `720..730` source folded to `west=360, east=10`, which `bbox_to_extent_wkt` reads as a crossing pair and records as `-180..10` — a 10° footprint stored as 190°. Westward was worse and unreported: `-730..-720` recorded **37x** its true area.

In the VRT frame chooser the same class produced globe-spanning mosaics, and the chooser scored every one of them at 5°:

| case | scored | actual hull |
|---|---|---|
| east +1 turn *(reported)* | 5.0 | **360.0** |
| east +2 turns | 5.0 | **720.0** |
| east +3 turns | 5.0 | **1080.0** |
| WEST −1 turn *(unreported)* | 5.0 | **360.0** |
| mixed east +2 / west −1 | 5.0 | **1080.0** |

At candidate origin 535 the `-180` source satisfies `left < origin`, contributes `right + 360 = 185`, and scores `max(540,185) - 535 = 5` — but it now sits at 180..185, still *west* of the origin, so the invariant the chooser's proof rests on is broken before the shift runs.

Both fixed by normalizing into a single turn first (`fmod`, then the shared fold), which restores that precondition rather than complicating the shift with a per-source turn count, and is a no-op for any raster already inside one turn. Placement is pixel-space, so re-expressing a longitude moves where the mosaic sits, never which pixels land in it. `_write_python_vrt` adopts normalized longitudes only when actually re-framing. Without it **13 tests fail**: hulls of 360/720/1080° against 10°, and rasters of 3600/7200 px against 100 px.

`shift_vrt_longitude_frame` also declines a rotated `GeoTransform` — `gdalbuildvrt` never emits rotation terms, but under one `gt[0]` is not a pure longitude origin and translating it would shear the mosaic.

**No other edit in this PR sits in a fallback-only branch.** `extract_raster_metadata` is called on the primary path (`tasks_raster.py:464`, `tasks_vrt.py:323` and `:753`), and `_build_tile_token_for_dataset` is the live token path.


Measured guard behaviour:

```
  seam-adjacent pair 175..180 / -180..-175  -> origin=175.0
  gap pair 160..170 / -170..-160            -> origin=160.0
  3 sources incl 40W                        -> origin=100.0
  adjacent -10..80 / 80..170 (exactly 180)  -> origin=None
  adjacent -10..85 / 85..175 (185 wide)     -> origin=None
  ends at 180: 170..175 / 175..180          -> origin=None
  global 36 x 10deg                         -> origin=None
```

## Site 3 — `processing/tiles/router.py`, the reported symptom

Raster source maxzoom comes from extent width when the COG has no recorded `res_x`/`res_y`, and `extent_to_span_bbox` reports -180..180 for a two-ring extent — as wrong for a span as the inverted pair #892 routed away from. **Fixing the extent alone leaves maxzoom collapsed**, which is why this file is touched:

```
### maxzoom, anisotropic 36000x200 COG with no recorded res_x/res_y ###
  BEFORE 350deg ring, no lon_span    res=  1082.28 m  z=8
  AFTER two-ring, no lon_span        res=  1113.20 m  z=8      <- extent fix alone: no change
  AFTER two-ring + lon_span=10       res=    30.92 m  z=13
  off-seam reference (5..15E)        res=    30.92 m  z=13
```

The change is minimal and composes with #901 rather than reverting it: `bounds` stays the monotonic span bbox (the tile source's own bounds must never be inverted), and the honest width travels beside it as an explicit `lon_span` keyword, from the new `extent_lon_span` in `core/geo.py`.

### Honest scope of the symptom

The issue says maxzoom is driven "toward 0". Measured, it drops by five levels (13 → 8) for a 10°-wide footprint, and it only moves at all when **longitude is the finer of the two axes** — `_native_resolution_meters` takes `min()` across them, so an inflated longitude resolution is simply discarded whenever latitude is finer, which is the usual case for a square-pixel raster below ~88° latitude. The recorded width is still wrong for those rasters; it just cannot move their maxzoom. `test_latitude_axis_masks_the_collapse` pins that limit explicitly so nobody drops the `lon_span` plumbing on the grounds that "the tests pass either way".

## Tests

`backend/tests/test_raster_antimeridian_887.py`, 38 tests. Every assertion is on an area, a dimension, or an offset — not on a boolean — because the wrong answer in this class of bug is a *valid* rectangle of the wrong size. Negative probes differ from their fixture in exactly one axis (same CRS, same latitude band, same footprint width; only the longitude position moves).

- Pacific EPSG:3832 COG spanning 175E..175W registers a two-ring extent; `extent_to_bbox` reads it back as `west > east` with a 10° span, `MultiPolygon`, `area == 200 deg²` (the bug produced 7000).
- Maxzoom symptom: 8 with the span bbox alone, 13 with the honest width, and an off-seam raster of identical size agrees at 13.
- Seam-straddling VRT: `rasterXSize == 100` (not 3600), `GeoTransform[0] == 175.0`, `dst_x_off == [0, 50]`, and the reopened VRT's bounds are 175..185. Band-stack (`-separate`) covered too.
- **Through the production path**: `TestSeamFrameRewrite` enters via `_build_vrt` / `build_vrt` with `run_gdal` stubbed to write GDAL's own seam output verbatim, then asserts the geometry is corrected *and* `NoDataValue` / `ColorInterp` / `ComplexSource` / `NODATA` / `MaskBand` all survive — plus that a non-crossing build comes back byte-identical. `TestSeamFrameRewriteAgainstRealGdal` (`shutil.which`-gated) drives the real binary end to end: nodata survives, each tile lands on its own half, an all-nodata source laid last does not erase valid pixels, masked sources keep `UseMaskBand`, and a non-crossing build is byte-identical to plain `gdalbuildvrt`.
- `sources_seam_frame_origin` itself: returns 175.0 for a geographic seam pair, `None` off-seam, `None` when any source lacks a CRS (unknown units, so refuse rather than guess), `None` for projected sources, `None` for an unopenable source. And `shift_vrt_longitude_frame` raises on a missing `GeoTransform` or a source with no `DstRect`.
- Genuinely global rasters unchanged: EPSG:3857 global stays a single -180..180 `POLYGON`; a global 36-tile mosaic keeps origin -180 and 1800 px; a global two-ring extent keeps its honestly coarse maxzoom.
- Near misses not normalized: flush at +180 (in both EPSG:3857 and 3832), flush at -180, exactly 180° wide, prime-meridian straddle, a 2 m EPSG:3832 sliver, and a CRS-less raster whose pixel-space bounds must not be reinterpreted as a wrap.

## Verification

```
$ cd backend && uv run ruff check . && uv run ruff format --check .
All checks passed!
852 files already formatted

$ pre-commit run --all-files
SSRF Rule 2 ... Passed        Visibility Rule 1 ... Passed
AGENTS.md — no bare, unscoped finding markers ... Passed
ruff check (backend) ... Passed        ruff format --check (backend) ... Passed
Detect hardcoded secrets ... Passed

$ uv run pytest tests/test_raster_antimeridian_887.py -q
120 passed, 49 warnings in 11.11s

$ uv run pytest tests/test_raster_antimeridian_887.py \
    tests/test_record_translations_migration.py \
    tests/test_embedding_vector_migration.py tests/test_oauth_github_migration.py -q -n 4
74 passed, 81 warnings in 23.88s

$ uv run pytest -q -n 4          # full suite
6192 passed, 81 skipped, 267 warnings in 563.75s (0:09:23)
```

### The CI failure on the previous push was this PR's, not a flake

I called it a shared-DB xdist flake first time round. It was not — it was my own test data, and the earlier local occurrence had the same cause:

```
tests/test_record_translations_migration.py::test_upgrade_normalizes_legacy_values_and_validates_constraint
  Running downgrade 0030_records_spatial_extent_type -> 0029_api_key_hardening
  RuntimeError: 1 catalog.records row(s) hold a MULTIPOLYGON spatial_extent,
  which geometry(Polygon, 4326) cannot store.
```

`0030.downgrade()` refuses to coerce a two-ring extent, correctly — the only POLYGON containing one is -180..180, which re-registers the bug this batch exists to fix. `test_db_session` does not roll back (each xdist worker owns one database for the whole session; isolation is by explicit cleanup), so the seam-crossing record my maxzoom test committed outlived the test and broke an alembic round-trip several files away. It reads exactly like an unrelated flake, which is how I misread it.

Fixed by taking `clean_tables` in the three DB-backed tests, exactly as the sibling `test_antimeridian_rollup.py` does for the same reason. Reproduced by dropping the fixture (same `RuntimeError`), and verified green with the migration tests in one `-n 4` invocation.

One correction to the diagnosis for the record: this is **intra-worker ordering**, not cross-worker contention — per `conftest.py` each worker gets its own database, which is why a serial two-file run reproduces it and why cleanup closes it completely with no residual race.

**The class is still open, and it is not mine to close in this PR.** Any future test that commits a seam-crossing extent re-breaks these migration tests, and the failure surfaces in a file with nothing to do with the change. Closing it properly means running `0030`'s own documented remediation (`UPDATE catalog.records SET spatial_extent = ST_Envelope(spatial_extent) WHERE GeometryType(spatial_extent) = 'MULTIPOLYGON'`) before every `alembic downgrade` that passes below `0030` — and there are **five separate per-file `_run_alembic` helpers** that do that (`test_record_translations_migration`, `test_embedding_vector_migration`, `test_oauth_github_migration`, `test_tenant_rls_migration`, `test_dormant_tenancy_migration_roundtrip`), all pointed at the shared per-worker DB. That is a shared-helper refactor across five test files, so it is filed separately rather than bundled here.

Schema/API/config impact: none. `records.spatial_extent` already accepts `MULTIPOLYGON` as of `0030_records_spatial_extent_type` (#901); no migration, no OpenAPI change, no SDK regeneration.

`backend/tests/test_layering.py` carries the exact-LOC ratchet bump for `processing/tiles/router.py` (2049 → 2066).

Rebased onto #925, which added a canonical `wrap_longitude` to `core/geo.py`; this PR uses it instead of the private duplicate the first cut carried. Its "+180 stays +180" semantics routes a `180..190` source through `bbox_to_extent_wkt`'s zero-width-half branch (one ring, not two), so there is an explicit test asserting that footprint's **area** rather than its ring count.
