### PR TITLE
chore: gate mcp/uv.lock, guard cluster click zoom, and correct four spatial_extent comments

### DIFF
--- a/.github/workflows/dep-audit.yml
+++ b/.github/workflows/dep-audit.yml
@@ -32,6 +32,14 @@ jobs:
           cache-dependency-glob: "backend/uv.lock"
       - name: Verify lockfile in sync
         run: uv lock --check
+      # fix(#889): mcp/ is the other project with its own uv.lock, and it had no
+      # full-lock gate at all — which is why it silently lagged two releases
+      # while the backend lock's drift eventually surfaced. `make version-check`
+      # (#877) asserts only the version FIELDS in both locks; this catches
+      # dependency-tree drift.
+      - name: Verify lockfile in sync — MCP server
+        working-directory: mcp
+        run: uv lock --check
       - name: Export locked prod requirements
         run: uv export --locked --no-dev --format requirements-txt -o /tmp/reqs.txt
       - name: pip-audit (OSV + PyPI advisory DB)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,6 +25,14 @@ The React/Vite frontend is in `frontend/src/`: `components/`, `pages/`, `hooks/`
 - Frontend: `cd frontend && npx vitest run src/path/foo.test.ts`.
 - E2E: `npx playwright test e2e/foo.spec.ts --project=chromium` (stack must be running).
 
+### Working from a git worktree
+
+The dev stack bind-mounts the MAIN checkout (`./frontend` → `/app`, and `backend/app` → `/app/app` with `--reload`), so `localhost:8080` always serves `main` no matter which branch your worktree is on. Running `npx playwright test` from a worktree therefore validates code you did not write. Treat the result as meaningless: it has produced a false FAILURE, and the symmetric case is worse, because a worktree change that breaks e2e passes when the stack never had it. To exercise worktree app code, run Vite on the host at `:5174` with `API_PROXY_TARGET=http://localhost:8001` and point `E2E_BASE_URL` at it.
+
+One exception: a spec-only change (editing `e2e/*.spec.ts` with no app-code change) is validly testable from a worktree, because Playwright reads the specs from your worktree while the app code stays byte-identical to `main`.
+
+The host backend recipe above is also unrunnable verbatim from a worktree — the sandbox refuses `source` on a path outside the worktree and denies reading `.env*`. Copy `.env.test` into the worktree instead (it is gitignored; delete it when you are done) and run pytest from a wrapper script.
+
 ## Architecture
 
 Services (`docker-compose.yml`): Nginx (prod proxy; Vite proxy in dev) fronts the FastAPI `api` (catalog, search, OGC/STAC, vector tiles) and Titiler (COG raster tiles). A `worker` runs GDAL/ogr2ogr ingestion, dispatched via the Procrastinate job queue that lives *inside* PostgreSQL (no separate broker). PostgreSQL 18 (PostGIS + pgvector + pg_trgm) is the single source of truth; object storage is MinIO/S3; Valkey is the tile/query cache.

--- a/backend/app/modules/catalog/features/service.py
+++ b/backend/app/modules/catalog/features/service.py
@@ -617,12 +617,14 @@ async def _refresh_count_and_extent(
     Returns (feature_count, extent_wkt) in a single query instead of the
     5 queries that extract_metadata() runs.
     """
-    # fix(#430 BA-18): records.spatial_extent is a POLYGON column, but ST_Extent of a
-    # single point / axis-collinear points casts to POINT / LINESTRING, which the
-    # column rejects (previously the caller silently skipped storing it, leaving a
-    # stale/NULL extent). ST_Expand always returns the bounding-box POLYGON, so we
-    # pad ONLY the degenerate (non-polygon) cases into a valid sub-mm-padded
-    # polygon; genuine polygon extents are returned byte-identical (no epsilon).
+    # fix(#430 BA-18): records.spatial_extent admits only POLYGON or MULTIPOLYGON
+    # (fix(#892) widened the typmod to geometry(Geometry, 4326) and moved the type
+    # guard into chk_records_spatial_extent_type), but ST_Extent of a single point /
+    # axis-collinear points casts to POINT / LINESTRING, which is still rejected
+    # (previously the caller silently skipped storing it, leaving a stale/NULL
+    # extent). ST_Expand always returns the bounding-box POLYGON, so we pad ONLY the
+    # degenerate (non-polygon) cases into a valid sub-mm-padded polygon; genuine
+    # polygon extents are returned byte-identical (no epsilon).
     result = await session.execute(
         text(
             f"SELECT COUNT(*), "

--- a/backend/app/platform/analysis_sql.py
+++ b/backend/app/platform/analysis_sql.py
@@ -176,12 +176,14 @@ def render_dateline_safe(geom_expr: str, *, alias: str = "_dl") -> str:
     over 2 000 rows keeps ``ST_Buffer`` at one evaluation per row.
 
     NOT fixed here, and deliberately: a dataset that genuinely straddles the
-    seam still registers a -180..180 ``spatial_extent``, because the
-    ``geometry(Polygon, 4326)`` column cannot express the west > east bbox that
-    RFC 7946 § 5.2 and the STAC spec use for antimeridian-crossing extents.
-    That representation gap predates the analysis tools and equally affects
-    directly ingested Fiji-area data; it needs a schema change, not a wider
-    expression.
+    seam still registers a -180..180 ``spatial_extent``. The column can now
+    hold the two-ring MULTIPOLYGON that the west > east bbox of RFC 7946 § 5.2
+    and the STAC spec corresponds to — #901 widened the typmod to
+    ``geometry(Geometry, 4326)`` and added ``chk_records_spatial_extent_type``
+    to allow POLYGON or MULTIPOLYGON — but the extent-write paths still store a
+    single ``ST_Extent``-derived POLYGON. What remains is the write side, not
+    the schema; it predates the analysis tools and equally affects directly
+    ingested Fiji-area data.
     """
     # Per-component split, innermost first: dump the buffer into components,
     # pair each with its shifted copy behind an OFFSET 0 fence, decide per

--- a/backend/app/platform/analysis_sql.py
+++ b/backend/app/platform/analysis_sql.py
@@ -176,14 +176,15 @@ def render_dateline_safe(geom_expr: str, *, alias: str = "_dl") -> str:
     over 2 000 rows keeps ``ST_Buffer`` at one evaluation per row.
 
     NOT fixed here, and deliberately: a dataset that genuinely straddles the
-    seam still registers a -180..180 ``spatial_extent``. The column can now
-    hold the two-ring MULTIPOLYGON that the west > east bbox of RFC 7946 § 5.2
-    and the STAC spec corresponds to — #901 widened the typmod to
-    ``geometry(Geometry, 4326)`` and added ``chk_records_spatial_extent_type``
-    to allow POLYGON or MULTIPOLYGON — but the extent-write paths still store a
-    single ``ST_Extent``-derived POLYGON. What remains is the write side, not
-    the schema; it predates the analysis tools and equally affects directly
-    ingested Fiji-area data.
+    seam still registers a -180..180 ``spatial_extent``. The column is no longer
+    what stops it — fix(#892) widened the typmod to ``geometry(Geometry, 4326)``
+    with ``chk_records_spatial_extent_type`` allowing POLYGON or MULTIPOLYGON,
+    which is the two-ring form RFC 7946 § 5.2's west > east bbox corresponds to,
+    and the STAC harvest path already stores it. What flattens the extent here
+    is the derivation: this path registers ``ST_Extent``, one envelope over
+    everything, so a two-lobed result collapses to the full span. That predates
+    the analysis tools and equally affects directly ingested Fiji-area data; it
+    needs a seam-aware extent derivation, not a wider column.
     """
     # Per-component split, innermost first: dump the buffer into components,
     # pair each with its shifted copy behind an OFFSET 0 fence, decide per

--- a/backend/app/processing/ingest/metadata.py
+++ b/backend/app/processing/ingest/metadata.py
@@ -341,11 +341,11 @@ async def get_extent(
 ) -> str | None:
     """Get the 4326 bbox extent as POLYGON WKT (or None for empty tables).
 
-    fix(#430 BA-18): records.spatial_extent is a POLYGON column. ST_Extent of a single
-    point / axis-collinear points casts to POINT / LINESTRING, which the column
-    rejects (crashing the reupload swap that stores this verbatim). Pad ONLY the
-    degenerate cases into a valid sub-mm polygon; genuine polygon extents are
-    returned byte-identical, matching refresh_dataset_metadata so the two paths agree.
+    fix(#430 BA-18): spatial_extent admits POLYGON or MULTIPOLYGON only (fix(#892):
+    typmod geometry(Geometry, 4326) + chk_records_spatial_extent_type). ST_Extent of a
+    single point / axis-collinear points casts to a rejected POINT / LINESTRING, crashing
+    the reupload swap that stores this verbatim. Pad ONLY the degenerate cases into a valid
+    sub-mm polygon; genuine extents stay byte-identical, matching refresh_dataset_metadata.
     """
     _validate_table_name(table_name)
     result = await session.execute(
@@ -884,7 +884,7 @@ async def extract_metadata(
                             LIMIT 1
                         ) AS geometry_type,
                         -- fix(#430 BA-18): pad only degenerate (point/line) extents
-                        -- into a valid POLYGON the spatial_extent column accepts.
+                        -- into a POLYGON; spatial_extent rejects POINT/LINESTRING.
                         CASE
                             WHEN ST_Extent(geom_4326) IS NULL THEN NULL
                             WHEN GeometryType(ST_Extent(geom_4326)::geometry) = 'POLYGON'

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -132,15 +132,14 @@ export const appRoutes = (
               <Route path="admin/settings/:tab" element={<AdminSettingsPage />} errorElement={<RouteErrorBoundary />} />
               <Route path="admin/config-ops" element={<AdminConfigOpsPage />} errorElement={<RouteErrorBoundary />} />
             </Route>
-            {/* Redirects from old routes */}
-            <Route path="admin/share-tokens" element={<Navigate to="/admin/shared-maps" replace />} />
-            <Route path="admin/embed-tokens" element={<Navigate to="/admin/shared-maps" replace />} />
             {/* Redirects from old routes.
-                fix(#871): no `admin/settings/appearance` entry here — a static
-                path outranks `admin/settings/:tab`, so the old
+                fix(#871): no `admin/settings/appearance` entry in this block — a
+                static path outranks `admin/settings/:tab`, so the old
                 appearance→map redirect made the enterprise branding tab
                 unreachable. AdminSettingsPage's edition gate owns that URL
                 now (enterprise renders it, community sends it to general). */}
+            <Route path="admin/share-tokens" element={<Navigate to="/admin/shared-maps" replace />} />
+            <Route path="admin/embed-tokens" element={<Navigate to="/admin/shared-maps" replace />} />
             <Route path="admin/settings/infrastructure" element={<Navigate to="/admin/overview" replace />} />
             <Route path="admin/general" element={<Navigate to="/admin/settings/general" replace />} />
             <Route path="admin/basemaps" element={<Navigate to="/admin/settings/map" replace />} />

--- a/frontend/src/components/map/__tests__/cluster-interactions.test.ts
+++ b/frontend/src/components/map/__tests__/cluster-interactions.test.ts
@@ -1,4 +1,5 @@
 import {
+  CLUSTER_ZOOM_CEILING,
   activateClusterFeature,
   clusterAggregateFeatureInfo,
   clusterFeatureCoordinates,
@@ -99,5 +100,94 @@ describe('cluster interactions', () => {
       center: [-72, 41],
       zoom: 12,
     }));
+  });
+
+  it('fix(#893): recentres without zooming when expansion zoom is already the current zoom', async () => {
+    // z22 with cluster_max_zoom=22 clamps expansion_zoom to the zoom the
+    // cluster is drawn at, and the map is at MapLibre's own ceiling, so no
+    // zoom can split it. Centring is the whole available response.
+    const map = {
+      getSource: vi.fn(),
+      getZoom: vi.fn(() => CLUSTER_ZOOM_CEILING),
+      easeTo: vi.fn(),
+    };
+    const feature = {
+      properties: { point_count: 7, expansion_zoom: CLUSTER_ZOOM_CEILING },
+      geometry: { type: 'Point', coordinates: [178.4, -18.1] },
+    };
+
+    await expect(activateClusterFeature(map as never, feature, 'source-stops')).resolves.toBe(true);
+
+    expect(map.easeTo).toHaveBeenCalledWith({
+      center: [178.4, -18.1],
+      zoom: CLUSTER_ZOOM_CEILING,
+      duration: 500,
+    });
+  });
+
+  it('fix(#893): never eases backwards when a stale parent tile reports a shallower expansion zoom', async () => {
+    // An overzoomed parent cluster tile still drawn while its replacement loads
+    // carries the expansion zoom of the level it was cut at. Honouring it would
+    // throw the user out of the view they were zooming into.
+    const map = {
+      getSource: vi.fn(),
+      getZoom: vi.fn(() => 20),
+      easeTo: vi.fn(),
+    };
+    const feature = {
+      properties: { point_count: 90, expansion_zoom: 15 },
+      geometry: { type: 'Point', coordinates: [-73.9, 40.7] },
+    };
+
+    await activateClusterFeature(map as never, feature, 'source-stops');
+
+    expect(map.easeTo).toHaveBeenCalledWith(expect.objectContaining({ zoom: 20 }));
+  });
+
+  it('fix(#893): the no-expansion-hint fallback still steps forward and stops at the ceiling', async () => {
+    const deep = {
+      getSource: vi.fn(() => undefined),
+      getZoom: vi.fn(() => CLUSTER_ZOOM_CEILING),
+      easeTo: vi.fn(),
+    };
+    const shallow = {
+      getSource: vi.fn(() => undefined),
+      getZoom: vi.fn(() => 6),
+      easeTo: vi.fn(),
+    };
+    const feature = {
+      properties: { point_count: 12 },
+      geometry: { type: 'Point', coordinates: [1, 2] },
+    };
+
+    await activateClusterFeature(shallow as never, feature, 'source-stops');
+    expect(shallow.easeTo).toHaveBeenCalledWith(expect.objectContaining({ zoom: 8 }));
+
+    await activateClusterFeature(deep as never, feature, 'source-stops');
+    expect(deep.easeTo).toHaveBeenCalledWith(
+      expect.objectContaining({ zoom: CLUSTER_ZOOM_CEILING }),
+    );
+  });
+
+  it('fix(#893): a failed GeoJSON expansion lookup falls back without losing ground', async () => {
+    const getClusterExpansionZoom = vi.fn((
+      _clusterId: number,
+      callback: (error: Error | null, zoom: number) => void,
+    ) => {
+      callback(new Error('no such cluster'), Number.NaN);
+    });
+    const map = {
+      getSource: vi.fn(() => ({ getClusterExpansionZoom })),
+      getZoom: vi.fn(() => 9),
+      easeTo: vi.fn(),
+    };
+    const feature = {
+      properties: { point_count: 32, cluster_id: 4 },
+      geometry: { type: 'Point', coordinates: [-72, 41] },
+    };
+
+    await activateClusterFeature(map as never, feature, 'source-stops');
+
+    expect(map.easeTo).toHaveBeenCalledWith(expect.objectContaining({ zoom: 11 }));
   });
 });

--- a/frontend/src/components/map/cluster-interactions.ts
+++ b/frontend/src/components/map/cluster-interactions.ts
@@ -97,6 +97,15 @@ export function clusterAggregateFeatureInfo(
   };
 }
 
+// MapLibre's own zoom ceiling, and the value the tile server clamps
+// `expansion_zoom` to (see `backend/app/processing/tiles/service.py`). Named so
+// the ceiling case below is greppable instead of a repeated literal.
+export const CLUSTER_ZOOM_CEILING = 22;
+
+function clampClusterZoom(zoom: number) {
+  return Math.min(Math.max(zoom, 0), CLUSTER_ZOOM_CEILING);
+}
+
 async function clusterExpansionZoom(
   map: Pick<MaplibreMap, 'getSource' | 'getZoom'>,
   feature: ClusterFeatureLike,
@@ -104,7 +113,7 @@ async function clusterExpansionZoom(
 ) {
   const properties = feature.properties ?? {};
   const explicitZoom = numericProperty(properties, 'expansion_zoom');
-  if (explicitZoom != null) return Math.min(Math.max(explicitZoom, 0), 22);
+  if (explicitZoom != null) return clampClusterZoom(explicitZoom);
 
   const clusterId = numericProperty(properties, 'cluster_id');
   const source = map.getSource(sourceId) as ClusterSourceWithExpansion | undefined;
@@ -112,15 +121,15 @@ async function clusterExpansionZoom(
     return new Promise<number>((resolve) => {
       source.getClusterExpansionZoom!(clusterId, (error, zoom) => {
         if (error || !Number.isFinite(zoom)) {
-          resolve(Math.min((map.getZoom?.() ?? 0) + 2, 22));
+          resolve(clampClusterZoom((map.getZoom?.() ?? 0) + 2));
           return;
         }
-        resolve(Math.min(Math.max(zoom, 0), 22));
+        resolve(clampClusterZoom(zoom));
       });
     });
   }
 
-  return Math.min((map.getZoom?.() ?? 0) + 2, 22);
+  return clampClusterZoom((map.getZoom?.() ?? 0) + 2);
 }
 
 export async function activateClusterFeature(
@@ -130,7 +139,18 @@ export async function activateClusterFeature(
 ) {
   const center = clusterFeatureCoordinates(feature);
   if (!center) return false;
-  const zoom = await clusterExpansionZoom(map, feature, sourceId);
+  const target = await clusterExpansionZoom(map, feature, sourceId);
+  // fix(#893): ease to the expansion zoom only when it is deeper than where we
+  // already are. Two ways it is not. At CLUSTER_ZOOM_CEILING with
+  // cluster_max_zoom=22 the server's now-honest value (#882) IS the current
+  // zoom. And a parent cluster tile still drawn overzoomed while its
+  // replacement loads reports the shallow expansion zoom of the level it was
+  // cut at, which used to ease the user BACKWARDS out of the view they were
+  // zooming into. Falling back to the current zoom recentres without moving the
+  // zoom — at the ceiling no zoom can split the cluster, so recentring is the
+  // whole honest response, and a click can never lose ground.
+  const currentZoom = map.getZoom?.() ?? 0;
+  const zoom = target > currentZoom ? target : currentZoom;
   map.easeTo({
     center,
     zoom,

--- a/scripts/check_version_coherence.py
+++ b/scripts/check_version_coherence.py
@@ -2,8 +2,11 @@
 
 Reads the version from every place the project records one and exits non-zero
 if any disagree, printing the offending site(s). This is the READ/verify side of
-the version contract; scripts/bump_version.py is the WRITE side — they enumerate
-the same set of sites.
+the version contract; scripts/bump_version.py is the WRITE side. One site the
+bump writes is verified elsewhere rather than here: docs-contract.json's
+`.version` is asserted against backend/pyproject.toml by
+scripts/check_docs_contract.py, so the two enumerations differ by that entry —
+no coverage gap, but do not read this list as the bump's mirror image.
 
 Also asserts CHANGELOG.md carries a `## [<version>]` section for the canonical
 version. .github/workflows/release.yml extracts the release body by matching


### PR DESCRIPTION
A mixed chore batch: one real gate, one real behavior fix, and four comment corrections. Each item is its own commit so any one can be reverted alone.

## 1. `mcp/uv.lock` had no lock-sync gate (`Closes #889`)

`.github/workflows/dep-audit.yml` ran `uv lock --check` under the job's `working-directory: backend` default, so `mcp/` — the only other project with its own `uv.lock` — was never checked. `make version-check` (#877) asserts the version *fields* in both locks, but a dependency-tree drift in `mcp/uv.lock` stayed ungated, which is how it slipped two releases unnoticed. Added a symmetrical step with `working-directory: mcp`, verified green on the current lock.

## 2. Worktree recipes in AGENTS.md (#893 item 1)

New `### Working from a git worktree` next to the existing single-test recipes. Three facts, all of which cost real time: the dev stack bind-mounts the **main** checkout, so `localhost:8080` serves `main` whatever branch a worktree is on and Playwright run from a worktree validates code nobody wrote; the host-Vite recipe that does work; and the spec-only exception (editing `e2e/*.spec.ts` with no app-code change *is* validly testable in place, which is how #895 was verified). Plus a note that the documented host pytest recipe cannot be `source`d verbatim from a worktree, and the copy-in workaround.

Every claim was checked against the tree rather than transcribed: `API_PROXY_TARGET` in `frontend/vite.config.ts:13`, `E2E_BASE_URL` in `playwright.config.ts:14`, `--reload --reload-dir /app/app` at `docker-compose.yml:336`, the two bind mounts at `:289`/`:555`, `API_PORT=8001` in `.env.example`, and `.env.test` matching `.gitignore`'s `.env.*`.

## 3. Cluster click could ease you backwards (#893 item 2)

`activateClusterFeature` handed `expansion_zoom` straight to `easeTo` with no comparison against the zoom the map is already at.

**The reported case** is the ceiling: at z22 with `cluster_max_zoom=22`, the server's now-honest value (#882) clamps to the zoom the cluster is drawn at, so the click can only pan and the cluster never breaks apart. **Nothing can zoom out of that one** — MapLibre's default `maxZoom` is 22 (the app never overrides it) and the server clusters all the way there, so no zoom exists that splits the cluster. I chose **recentre without zooming**: it is the whole honest response available, and inventing a nudge the map would immediately clamp away would be a lie about what happened. The value of the guard here is that the case is now a deliberate branch with the reasoning attached, instead of an accident of arithmetic.

**The case the guard actually fixes** turned up while checking the first one, and is worse. With the default `cluster_max_zoom=14`, a z14 tile's clusters carry `expansion_zoom: 15` (the `generate_series($1+1, $5)` split search is empty at the max, so it falls through to `cluster_max_zoom + 1`). Zoom to 20 and MapLibre keeps drawing the **overzoomed z14 parent** until the z20 tile lands — and those cluster features stay queryable, so a click reads `expansion_zoom: 15` against a current zoom of 20. The old code eased the user **backwards** to 15, out of the view they were zooming into. `target > currentZoom ? target : currentZoom` makes a cluster click unable to lose ground.

To be exact about the evidence: that is traced through the code and the constants above, and pinned by a unit test that fails without the guard — I did not reproduce it in a browser. The window is also not necessarily brief; if the deep tile 403s (the tile-token race), the overzoomed parent stays on screen.

Also names the repeated `22` as `CLUSTER_ZOOM_CEILING` and routes the three clamps through one helper, so the ceiling case is greppable.

Four cases added to `cluster-interactions.test.ts`. The backwards case is a genuine regression test — with the guard reverted it fails (evidence below); the ceiling case passes either way by design, and is there to pin the decision.

## 4. Stale `spatial_extent` comments (#904, the comment half)

#901 widened `catalog.records.spatial_extent` to `geometry(Geometry,4326)` plus `chk_records_spatial_extent_type`, which admits POLYGON **or MULTIPOLYGON**. Four comments still told the reader it is POLYGON-only — including the one in `platform/analysis_sql.py` that #892 was filed from, which claimed the column "cannot express the west > east bbox". It can now; what remains is the write side.

- `backend/app/platform/analysis_sql.py` — the `_dateline_safe_buffer` note
- `backend/app/processing/ingest/metadata.py` — `get_extent`'s docstring and the SQL comment in the fast-path CTE
- `backend/app/modules/catalog/features/service.py` — `_refresh_count_and_extent`

No behavior change: all four write `ST_Extent`-derived POLYGONs, which the CHECK still accepts. Each comment's actual point — a degenerate POINT/LINESTRING extent is still rejected and must be padded — is kept; only the claim about the column's type is corrected. **Both `metadata.py` edits are line-neutral**, so its exact LOC ratchet (1856) does not move and this stays a comment-only PR.

## 5. Two nits (#893 items 6 and 8)

`check_version_coherence.py` claimed it and `bump_version.py` "enumerate the same set of sites". They differ by exactly one: the bump writes `docs-contract.json`'s `.version`, which `check_docs_contract.py` asserts against `backend/pyproject.toml` instead. No coverage gap, but the docstring reads as a guarantee the file does not make.

`App.tsx` had two consecutive `{/* Redirects from old routes */}` headers with routes between them belonging to the same block. Merged into the one header that also carries the `fix(#871)` note. No route moved relative to another, so matching is unchanged.

## Dropped: #893 item 3 (image version metadata) — the premise is false

The published images already carry `org.opencontainers.image.version`. `publish.yml`'s "Build and push" step passes `labels: ${{ steps.meta.outputs.labels }}`, and `docker/metadata-action`'s default label set includes `version`, `revision`, `created` and `url`. `build-push-action`'s `--label` flags override Dockerfile `LABEL`s, so adding one to the Dockerfile would be shadowed on the publish path and empty everywhere else — strictly worse than absent. Verified against the real registry, all four images:

```
$ docker buildx imagetools inspect ghcr.io/geolens-io/geolens-api:1.6.1 --format '{{ json .Image }}'
### geolens-api
  org.opencontainers.image.title = 'geolens'
  org.opencontainers.image.version = '1.6.1'
  org.opencontainers.image.description = 'PostGIS-native GIS data catalog API'
### geolens-worker
  org.opencontainers.image.title = 'geolens'
  org.opencontainers.image.version = '1.6.1'
  org.opencontainers.image.description = 'PostGIS-native GIS data catalog worker'
### geolens-backup
  org.opencontainers.image.title = 'geolens'
  org.opencontainers.image.version = '1.6.1'
  org.opencontainers.image.description = 'Automated pg_dump backup service with S3 offload'
### geolens-frontend
  org.opencontainers.image.title = 'geolens'
  org.opencontainers.image.version = '1.6.1'
  org.opencontainers.image.description = 'PostGIS-native GIS data catalog frontend'
```

An image pulled by digest is therefore identifiable, and no new version site is introduced — which also means nothing needed registering in `bump_version.py` / `check_version_coherence.py`.

That same output turned up a real defect worth its own issue, left out of this PR: **`org.opencontainers.image.title` is `geolens` on all four images**. The Dockerfile sets a distinct per-image title (`geolens-api`, `geolens-worker`, `geolens-backup`, `geolens-frontend`), but `metadata-action` defaults `title` to the repository name and its label wins, so the Dockerfile's four titles are silently discarded. `description` survives only because `publish.yml` sets it explicitly from `matrix.description`; `title` is not in that list. One line to fix (`org.opencontainers.image.title=${{ matrix.image }}` in the `meta` step) but it changes published metadata, so it wants its own issue.

## Issue status

`Closes #889`.

**#893 and #904 stay open** — both are grouped issues and only part of each is addressed here.

- #893: items **1, 2, 6, 8** done. Item **3** dropped as a false premise (above). Items **4, 5, 7** (coverage thresholds, low-zoom cluster tile latency, `version-check` observability) untouched — they need decisions, not edits. Items **9–15** from the follow-up comment untouched.
- #904: the **four comments** are done. The `alembic check` cannot see CHECK constraints half, the zero-height-bbox nit, and the `downgrade()` operator note for RUNBOOK.md remain.

## Verification

Backend suite, full, from this worktree — run twice, once before rebasing onto #925 and once after (the count moves because #925 added tests):

```
$ uv run pytest -n 4 -q      # base a6570a69b
6036 passed, 81 skipped, 264 warnings in 608.92s (0:10:08)

$ uv run pytest -n 4 -q      # base 0176bfce2 (#925)
6069 passed, 81 skipped, 264 warnings in 601.34s (0:10:01)
```

```
$ cd backend && uv run ruff check .
All checks passed!
$ uv run ruff format --check .
851 files already formatted
```

```
$ python3 scripts/check_version_coherence.py
OK: all 19 version sites agree on 1.6.1.
...
  CHANGELOG.md: '## [1.6.1]' section present (47 lines).
```

The new gate, on this PR's own CI run (job `Python audit (uv)`, 31s, pass):

```
Verify lockfile in sync — MCP server  Run uv lock --check
Verify lockfile in sync — MCP server  Using CPython 3.14.4
Verify lockfile in sync — MCP server  Resolved 40 packages in 1ms
```

A gate nobody has seen fail is not a gate, so: add one unlocked dependency to `mcp/pyproject.toml` and it does fail, then passes again once reverted.

```
$ cd mcp && uv lock --check          # with "tabulate>=0.9" added to dependencies
Resolved 41 packages in 327ms
The lockfile at `uv.lock` needs to be updated, but `--check` was provided.
EXIT=1

$ cd mcp && uv lock --check          # restored
Resolved 40 packages in 4ms
EXIT=0
```

```
$ cd frontend && npm run lint
> eslint .
$ npm run typecheck
> tsc -b --noEmit
$ npx vitest run src/components/map/__tests__/cluster-interactions.test.ts
 Test Files  1 passed (1)
      Tests  9 passed (9)
$ npm run test:coverage
 Test Files  358 passed (358)
      Tests  4157 passed (4157)
Statements   : 71.51% ( 15116/21137 )
Branches     : 66.77% ( 12306/18428 )
Functions    : 65.91% ( 3583/5436 )
Lines        : 73.62% ( 13616/18493 )
```

Sidebar on #893 item 4, which I did not touch: the thresholds are `41/39/37/42`, so the headroom is ~30 points, not the "~0 by design" the `vite.config.ts` comment describes. That comment records 2026-05-07 actuals of `41.51/39.42/37.99/42.69`; the suite has since gained roughly 30 points on every dimension. The item's premise (stale) holds; its stated consequence (a global threshold trips on any uncovered line) has not been true for a while.

The new backwards-ease case proves it is a regression test, not decoration — with `const zoom = target > currentZoom ? target : currentZoom` reverted to `const zoom = target`:

```
× fix(#893): never eases backwards when a stale parent tile reports a shallower expansion zoom 2ms
AssertionError: expected "vi.fn()" to be called with arguments: [ ObjectContaining {"zoom": 20} ]
      Tests  1 failed | 8 passed (9)
```

No API surface moved, so `make openapi-check` / `make sdks-check` are not implicated. No Playwright run: this branch is not spec-only, so per the very recipe item 2 documents, e2e from a worktree would have tested `main`.
