### PR TITLE
fix(catalog): stop float noise flipping a rollup into the shifted domain

### DIFF
--- a/backend/app/core/geo.py
+++ b/backend/app/core/geo.py
@@ -151,6 +151,17 @@ def bbox_to_extent_wkt(west: float, south: float, east: float, north: float) -> 
 # tear apart (see _shifted_longitude_geom).
 _PRIME_MERIDIAN_WKT = "LINESTRING(0 -90,0 90)"
 
+# fix(#886): how much narrower the shifted domain must be before it is preferred.
+# Adding and subtracting 360 is not bit-exact, so the two domains disagree by up
+# to ~3e-14 degrees on the SAME footprint: `(-4.761789777127049 + 360) - 360`
+# comes back as `-4.761789777127035`, and the shifted span of an ordinary
+# prime-meridian-crossing extent (Europe, Africa, the UK) measured
+# 37.79687178320006 against a normal 37.796871783200075. Without a margin that
+# noise wins the comparison and rewrites a non-crossing bbox with drifted edges.
+# 1e-9 degrees is ~0.1 mm -- far above the noise, far below any real gain, and
+# the same floor _SEAM_TOL already uses.
+_DOMAIN_MARGIN = 1e-9
+
 
 def wrap_longitude(lng: float) -> float:
     """Fold a longitude from the shifted domain back into ``[-180, 180]``.
@@ -234,17 +245,29 @@ def _narrower_domain(
 ) -> list[float]:
     """Keep whichever longitude domain spans less, as an RFC 7946 §5.2 bbox.
 
-    A tie goes to the unshifted domain, so nothing that does not actually cross
-    the seam is ever re-expressed as ``west > east``.
+    A tie --- or anything inside ``_DOMAIN_MARGIN`` of one --- goes to the
+    unshifted domain, so nothing that does not actually cross the seam is ever
+    re-expressed, and an ordinary catalog's bbox stays byte-identical.
 
     Documented ceiling: this is not the true minimal covering range, which
     needs the largest gap anywhere on the circle rather than at one of two cut
-    points. Footprints at ``-170``, ``-15``, ``25`` and ``165`` have their
-    largest gap at ``-160..-20`` and could be covered in 220 degrees; both cut
-    points fall inside data, so this returns 330. Always a valid covering
-    range, sometimes broader than optimal --- never inverted, never partial.
+    points (-180 and 0). Footprints spanning ``-170..-160``, ``-20..-15``,
+    ``20..25`` and ``160..165`` have their largest gap at ``-160..-20`` and
+    could be covered in 220 degrees; both cut points fall inside data, so this
+    returns 325 (see ``test_documented_ceiling_is_covering_but_not_minimal``).
+    Always a valid covering range, sometimes broader than optimal --- never
+    inverted, never partial.
+
+    Second, smaller caveat: a winning shifted edge has been through a ``+360``
+    then ``-360`` round-trip, which is not bit-exact for an arbitrary mantissa,
+    so that edge can land up to ulp(512)/2 --- about 6e-14 degrees, 6
+    nanometres --- inside the true union. Not worth epsilon machinery: the
+    stored geometries are float64 too, so their own edges are fuzzy at the same
+    scale, and no consumer does an exact containment test against a rollup.
+    Widening the edge unconditionally would be the only sound correction and it
+    would put that noise into every crossing bbox, including the exact ones.
     """
-    if sxmax - sxmin < xmax - xmin:
+    if sxmax - sxmin < (xmax - xmin) - _DOMAIN_MARGIN:
         return [wrap_longitude(sxmin), ymin, wrap_longitude(sxmax), ymax]
     return [xmin, ymin, xmax, ymax]
 

--- a/backend/tests/test_antimeridian_rollup.py
+++ b/backend/tests/test_antimeridian_rollup.py
@@ -54,6 +54,16 @@ FIJI_SEAM_MULTIPOLYGON = bbox_to_extent_wkt(170.0, -20.0, -170.0, -15.0)
 # translate the whole footprint instead.
 EUROPE_LIKE = "POLYGON((-10 -20,30 -20,30 -15,-10 -15,-10 -20))"
 
+# The same shape with mantissas that survive neither +360 nor -360 intact. Found
+# by brute force; it is the case where the two domains measure the same footprint
+# differently and the shifted one wins on noise alone.
+_UGLY_W, _UGLY_E = -4.761789777127049, 33.035082006073026
+_UGLY_S, _UGLY_N = -74.15992890150827, -69.77548044709921
+UGLY_MERIDIAN_CROSSER = (
+    f"POLYGON(({_UGLY_W} {_UGLY_S},{_UGLY_E} {_UGLY_S},{_UGLY_E} {_UGLY_N},"
+    f"{_UGLY_W} {_UGLY_N},{_UGLY_W} {_UGLY_S}))"
+)
+
 
 # ---------------------------------------------------------------------------
 # merge_bboxes / rollup_bbox arithmetic (no DB)
@@ -171,6 +181,38 @@ class TestRollupRowHelpers:
         assert rollup_span_bbox([1.0, 2.0, 3.0, 4.0, 5.0, None]) is None
         assert rollup_bbox([1.0, 2.0, 3.0]) is None
         assert rollup_bbox(None) is None
+
+    def test_float_noise_cannot_flip_a_prime_meridian_extent(self):
+        """A Europe-shaped extent measures the *same* span in both domains, but
+        not to the last bit: `(-4.761789777127049 + 360) - 360` comes back as
+        `-4.761789777127035`, and the shifted span computed 37.79687178320006
+        against a normal 37.796871783200075. Without _DOMAIN_MARGIN that noise
+        wins the comparison and rewrites an ordinary, non-crossing bbox with
+        drifted edges. Found by brute-forcing the covering property over random
+        footprint sets."""
+        west, east = -4.761789777127049, 33.035082006073026
+        assert (east + 360.0) - (west + 360.0) < east - west  # the noise itself
+
+        bbox = rollup_bbox([west, -74.1, east, -69.7, west + 360.0, east + 360.0])
+        # Byte-identical to the input, not the round-tripped approximation.
+        assert bbox == [west, -74.1, east, -69.7]
+        assert bbox[0] != wrap_longitude(west + 360.0)
+
+    def test_a_real_narrowing_still_beats_the_margin(self):
+        """The margin must not swallow a genuine improvement. A tenth of a degree
+        is eight orders of magnitude above it.
+
+        This one also pins the documented residual: `359.95 - 360` is
+        `-0.05000000000001137`, so a winning shifted edge can sit ~1e-14 degrees
+        (a few nanometres) inside the true union. Correcting that soundly means
+        widening every crossing edge unconditionally, which would put the same
+        noise into the exact cases for no operational gain.
+        """
+        values = [-180.0, 0.0, 180.0, 1.0, 0.05, 359.95]
+        bbox = rollup_bbox(values)
+        assert bbox == pytest.approx([0.05, 0.0, -0.05, 1.0])
+        assert bbox[0] > bbox[2]
+        assert abs(bbox[2] - -0.05) < 6e-14
 
 
 # ---------------------------------------------------------------------------
@@ -291,6 +333,36 @@ class TestSqlRollup:
             )
         ).scalar_one()
         assert covered is True
+
+    async def test_postgis_shows_the_same_last_bit_asymmetry(
+        self, test_db_session, clean_tables
+    ):
+        """The margin is needed on the SQL side too, not just the Python fold.
+
+        ``ST_Translate(g, 360, 0)`` rounds exactly like Python's ``x + 360``, so
+        PostGIS hands back a shifted span of 37.79687178320006 against an
+        unshifted 37.796871783200075 for the same footprint --- a bare ``<``
+        picks the shifted domain for an extent that never crosses the seam. Both
+        paths funnel through one ``_narrower_domain``, so one margin covers
+        both; this pins that the *inputs* really do disagree, which is the part
+        a Python-only unit test cannot show.
+        """
+        del clean_tables
+        ids = await _insert_records(test_db_session, [UGLY_MERIDIAN_CROSSER])
+        row = (
+            await test_db_session.execute(
+                select(*rollup_bbox_columns(Record.spatial_extent)).where(
+                    Record.id.in_(ids)
+                )
+            )
+        ).one()
+        xmin, xmax, sxmin, sxmax = (float(row[i]) for i in (0, 2, 4, 5))
+
+        # PostGIS itself disagrees with itself, in the direction that matters.
+        assert sxmax - sxmin < xmax - xmin
+        # ...but not by enough to clear the margin, so the extent is untouched.
+        assert rollup_bbox(row[:6]) == [xmin, float(row[1]), xmax, float(row[3])]
+        assert rollup_bbox(row[:6])[0] != wrap_longitude(sxmin)
 
     async def test_a_non_crossing_catalog_is_unchanged(
         self, test_db_session, clean_tables


### PR DESCRIPTION
Follow-up to #925 (#886). That PR merged while this fix was still being verified, so it lands separately.

## The bug

Brute-forcing #925's covering property over 400 random footprint sets — prime-meridian crossers, seam-form records, global extents — turned up a failure with a **single** input: an ordinary Europe-shaped extent whose emitted bbox came back with drifted edges.

`(x + 360) - 360` is not always `x`, so `_narrower_domain` compares two spans that describe the *same* footprint and disagree in the last bits:

```
extent        -4.761789777127049 .. 33.035082006073026
normal span   37.796871783200075
shifted span  37.79687178320006     <- smaller, so the shifted domain won
emitted west  -4.761789777127035    <- drifted, on an extent that never crosses the seam
```

Nothing here crosses the antimeridian and nothing needs the shifted domain, but the bbox changes anyway. Every Europe / Africa / UK extent was a candidate, which makes it a quiet output change for ordinary catalogs rather than a crossing-only edge case.

## The fix

Require the shifted domain to beat the unshifted one by more than `_DOMAIN_MARGIN = 1e-9` degrees before preferring it. That is ~0.1 mm, the same floor `_SEAM_TOL` already uses in this module: four to eleven orders of magnitude above the noise (~6e-14) and far below any real narrowing. Non-crossing catalogs are byte-identical to pre-#925 again.

## It is not a Python-side quirk — the SQL path has it too

`ST_Translate(g, 360, 0)` rounds exactly like Python's `x + 360`, so PostGIS hands back the same skewed pair. Running the *production* `rollup_bbox_columns` expressions against a real geometry column holding that extent:

```
PostGIS returned:
  unshifted xmin/xmax : -4.761789777127049 33.035082006073026
  shifted   xmin/xmax : 355.23821022287297 393.035082006073
  unshifted span      : 37.796871783200075
  shifted   span      : 37.79687178320006
  bare '<' would pick shifted? True
  with margin picks shifted?   False

what the bare comparison WOULD have emitted:
  west=-4.761789777127035 east=33.035082006073026
what rollup_bbox emits now:
  west=-4.761789777127049 east=33.035082006073026
  byte-identical to the stored extent: True
```

Both paths funnel through the one `_narrower_domain` comparison, so the single margin covers both — this is not a Python-only fix. `test_postgis_shows_the_same_last_bit_asymmetry` pins the SQL half in CI: it inserts the extent, asserts PostGIS's own aggregates disagree in the direction that matters (`sxmax - sxmin < xmax - xmin`), and then asserts the emitted bbox is the stored extent byte-for-byte. A hand-built row cannot show that the aggregates themselves disagree, which is why the DB test earns its place next to the unit test.

## What is documented rather than corrected

When the shifted domain legitimately wins, its edges have still been through the round-trip, so an edge can sit up to `ulp(512)/2` (~6e-14 degrees) inside the true union. Re-running the brute force after the fix:

```
checked=800 sql_not_covering=39 py_not_covering=39
worst sql shortfall = 0.000e+00 deg
worst py  shortfall = 0.000e+00 deg
```

Those 39 fail the bitwise `ST_CoveredBy` predicate while PostGIS measures the geometric gap as exactly zero with `ST_Distance`. The only sound correction is widening every crossing edge unconditionally, which would push the same noise into the exact cases (`178.5` becoming `178.49999999999999`) for no operational gain — the stored geometries are float64 too, so their own edges are fuzzy at the same scale, and no consumer does an exact containment test against a rollup. The docstring now says so, and the SQL and Python folds agreeing 39/39 is a free cross-check that the two implementations still match.

## Tests

Three additions to `backend/tests/test_antimeridian_rollup.py` (33 → 36):

- `test_float_noise_cannot_flip_a_prime_meridian_extent` — asserts the noise exists (`(east + 360) - (west + 360) < east - west`) and that the emitted bbox is byte-identical to the input rather than the round-tripped approximation.
- `test_a_real_narrowing_still_beats_the_margin` — a 0.1-degree genuine improvement still wins, and pins the residual at `< 6e-14`.
- `test_postgis_shows_the_same_last_bit_asymmetry` — the DB half: PostGIS's own aggregates disagree the same way, and the extent survives untouched.

## Verification

```
$ cd backend && uv run ruff check . && uv run ruff format --check .
All checks passed!
851 files already formatted

$ uv run pytest tests/test_antimeridian_rollup.py -q
36 passed, 43 warnings in 6.90s

$ uv run pytest -n 4 -q          # full backend suite, rebased onto 8e63c095f
6072 passed, 81 skipped, 261 warnings in 561.34s (0:09:21)
```

No API shape change, no migration, no LOC-cap movement (this touches `core/geo.py` and a test file only).

Refs #886
