### PR TITLE
fix(builder): refresh the session JWT on tab return for raster-only maps

### DIFF
--- a/frontend/src/components/builder/BuilderMap.tsx
+++ b/frontend/src/components/builder/BuilderMap.tsx
@@ -13,7 +13,7 @@ import {
 } from '@/lib/basemap-utils';
 import { buildClusterTileUrl, buildSignedTileUrl, buildTileTransformRequest, isMvtSourceLayerConfigReady, refreshRasterTileSources } from '@/lib/tile-utils';
 import { useRemoteBasemapStyle } from '@/components/map/hooks/use-remote-basemap-style';
-import { isRasterTileAuthError, logUnhandledMapError } from '@/lib/map-error-log';
+import { isRasterTileAuthError, isRefreshableRasterAuthError, logUnhandledMapError } from '@/lib/map-error-log';
 import { useTileTokens, useInvalidateTileTokens } from '@/hooks/use-tile-token';
 import { isSessionRenewalPending, useTileAuthRecovery, useVisibleTileTokenRefresh } from '@/hooks/use-tile-auth-recovery';
 import { useTileTokenError } from './hooks/use-tile-token-error';
@@ -656,7 +656,10 @@ export const BuilderMap = memo(function BuilderMap({
         // fix(#907): a raster auth failure while a session renewal is running is
         // the visibility race, not a dead session — the post-rotation reload is
         // about to cure it, so it reports like any other transient.
-        const rasterAuthDuringRenewal = rasterAuthError && isSessionRenewalPending();
+        // Only a 401 — a raster 403 is an upstream denial a fresh JWT cannot
+        // cure, so it must still surface.
+        const rasterAuthDuringRenewal =
+          isRefreshableRasterAuthError(e) && isSessionRenewalPending();
         const isClientError = Boolean(status && status >= 400 && status < 500);
         const suppressedClientError = isClientError && (!rasterAuthError || rasterAuthDuringRenewal);
         pushReportEntry({

--- a/frontend/src/components/builder/BuilderMap.tsx
+++ b/frontend/src/components/builder/BuilderMap.tsx
@@ -11,7 +11,7 @@ import {
   toMaplibreStyle,
   BLANK_BASEMAP_ID,
 } from '@/lib/basemap-utils';
-import { buildClusterTileUrl, buildSignedTileUrl, buildTileTransformRequest, isMvtSourceLayerConfigReady } from '@/lib/tile-utils';
+import { buildClusterTileUrl, buildSignedTileUrl, buildTileTransformRequest, isMvtSourceLayerConfigReady, refreshRasterTileSources } from '@/lib/tile-utils';
 import { useRemoteBasemapStyle } from '@/components/map/hooks/use-remote-basemap-style';
 import { isRasterTileAuthError, logUnhandledMapError } from '@/lib/map-error-log';
 import { useTileTokens, useInvalidateTileTokens } from '@/hooks/use-tile-token';
@@ -575,7 +575,9 @@ export const BuilderMap = memo(function BuilderMap({
   // fix(#755): a tab backgrounded past the 900 s sig boundary comes back with
   // stale tokens, so MapLibre's resumed fetches 403 before the handler above
   // can heal them. Kick the same throttled re-mint on the visible edge.
-  useVisibleTileTokenRefresh(() => syncInputsRef.current.tokenMap.values(), recoverTileAuth);
+  useVisibleTileTokenRefresh(() => syncInputsRef.current.tokenMap.values(), recoverTileAuth, () =>
+    refreshRasterTileSources(mapRef.current),
+  );
 
   const handleLoad = useCallback(
     (e: MapLibreEvent) => {

--- a/frontend/src/components/builder/BuilderMap.tsx
+++ b/frontend/src/components/builder/BuilderMap.tsx
@@ -15,7 +15,7 @@ import { buildClusterTileUrl, buildSignedTileUrl, buildTileTransformRequest, isM
 import { useRemoteBasemapStyle } from '@/components/map/hooks/use-remote-basemap-style';
 import { isRasterTileAuthError, logUnhandledMapError } from '@/lib/map-error-log';
 import { useTileTokens, useInvalidateTileTokens } from '@/hooks/use-tile-token';
-import { useTileAuthRecovery, useVisibleTileTokenRefresh } from '@/hooks/use-tile-auth-recovery';
+import { isSessionRenewalPending, useTileAuthRecovery, useVisibleTileTokenRefresh } from '@/hooks/use-tile-auth-recovery';
 import { useTileTokenError } from './hooks/use-tile-token-error';
 import { getEnvConfig } from '@/lib/env';
 import { pushReportEntry, reportTileTokenRemint } from '@/lib/report';
@@ -653,8 +653,12 @@ export const BuilderMap = memo(function BuilderMap({
         // BuilderMap.raster-tile-auth.test.tsx pins the parity). Dropping either
         // half for raster would cost the sourceId this row carries, or the
         // devtools log the surfaces without a row of their own rely on.
+        // fix(#907): a raster auth failure while a session renewal is running is
+        // the visibility race, not a dead session — the post-rotation reload is
+        // about to cure it, so it reports like any other transient.
+        const rasterAuthDuringRenewal = rasterAuthError && isSessionRenewalPending();
         const isClientError = Boolean(status && status >= 400 && status < 500);
-        const suppressedClientError = isClientError && !rasterAuthError;
+        const suppressedClientError = isClientError && (!rasterAuthError || rasterAuthDuringRenewal);
         pushReportEntry({
           severity: suppressedClientError ? 'warning' : 'error',
           source: 'maplibre',
@@ -707,6 +711,9 @@ export const BuilderMap = memo(function BuilderMap({
                 return;
               }
             }
+            // fix(#907): don't tell the user to reload the page for a raster
+            // 401 that a renewal already in flight is seconds from healing.
+            if (rasterAuthDuringRenewal) return;
             // fix(#628): once the session is conclusively dead the global
             // signed-out dialog owns the UX — the stale reload-toast is
             // noise on top of it. Keep it only while a session exists.

--- a/frontend/src/components/dataset/DatasetMap.tsx
+++ b/frontend/src/components/dataset/DatasetMap.tsx
@@ -36,7 +36,7 @@ import type { Map as MaplibreMap } from 'maplibre-gl';
 import type { Feature, Geometry, GeoJsonProperties } from 'geojson';
 import 'maplibre-gl/dist/maplibre-gl.css';
 import { motionDuration } from '@/lib/reduced-motion';
-import { buildTileTransformRequest, isMvtSourceLayerConfigReady } from '@/lib/tile-utils';
+import { buildTileTransformRequest, isMvtSourceLayerConfigReady, refreshRasterTileSources } from '@/lib/tile-utils';
 import { isRasterTileAuthError, logUnhandledMapError } from '@/lib/map-error-log';
 import { reportTileTokenRemint } from '@/lib/report';
 
@@ -179,7 +179,9 @@ export const DatasetMap = memo(function DatasetMap({
   // fix(#755): a tab backgrounded past the 900 s sig boundary comes back with
   // stale tokens, so MapLibre's resumed fetches 403 before the error handler
   // can heal them. Kick the same throttled re-mint on the visible edge.
-  useVisibleTileTokenRefresh(() => [rawTileToken], recoverTileAuth);
+  useVisibleTileTokenRefresh(() => [rawTileToken], recoverTileAuth, () =>
+    refreshRasterTileSources(mapRef.current),
+  );
   // fix(#890): `url` is read to tell a raster/DEM auth failure (unrecoverable)
   // from a vector one (re-mintable).
   const tileAuthErrorHandlerRef = useRef<((e: { error?: { status?: number; url?: string } }) => void) | null>(null);

--- a/frontend/src/components/dataset/DatasetMap.tsx
+++ b/frontend/src/components/dataset/DatasetMap.tsx
@@ -37,7 +37,7 @@ import type { Feature, Geometry, GeoJsonProperties } from 'geojson';
 import 'maplibre-gl/dist/maplibre-gl.css';
 import { motionDuration } from '@/lib/reduced-motion';
 import { buildTileTransformRequest, isMvtSourceLayerConfigReady, refreshRasterTileSources } from '@/lib/tile-utils';
-import { isRasterTileAuthError, logUnhandledMapError } from '@/lib/map-error-log';
+import { isRasterTileAuthError, isRefreshableRasterAuthError, logUnhandledMapError } from '@/lib/map-error-log';
 import { reportTileTokenRemint } from '@/lib/report';
 
 /** System columns excluded from the attribute form */
@@ -680,7 +680,9 @@ export const DatasetMap = memo(function DatasetMap({
         // renewal is in flight — that renewal is what fixes it, and its
         // post-rotation reload retries the tiles.
         const recovering =
-          reminting && (!isRasterTileAuthError(e) || isSessionRenewalPending());
+          reminting &&
+          (!isRasterTileAuthError(e) ||
+            (isRefreshableRasterAuthError(e) && isSessionRenewalPending()));
         if (!recovering && !errorFiredRef.current) {
           errorFiredRef.current = true;
           onTileError?.();
@@ -708,7 +710,7 @@ export const DatasetMap = memo(function DatasetMap({
           // and this listener is independent of the auth handler above, so
           // without this it still latched the permanent error overlay that the
           // reload cannot clear.
-          if ((status === 401 || status === 403) && isSessionRenewalPending()) return;
+          if (status === 401 && isSessionRenewalPending()) return;
           if (e.error?.message?.includes('raster-tile-source') ||
               e.error?.message?.includes('Error: HTTP') ||
               status === 404 ||

--- a/frontend/src/components/dataset/DatasetMap.tsx
+++ b/frontend/src/components/dataset/DatasetMap.tsx
@@ -703,6 +703,12 @@ export const DatasetMap = memo(function DatasetMap({
             fireReadyOnce(false);
             return;
           }
+          // fix(#907): a 401/403 lost to the tab-return refresh race is not a
+          // broken source — the post-rotation reload retries it moments later,
+          // and this listener is independent of the auth handler above, so
+          // without this it still latched the permanent error overlay that the
+          // reload cannot clear.
+          if ((status === 401 || status === 403) && isSessionRenewalPending()) return;
           if (e.error?.message?.includes('raster-tile-source') ||
               e.error?.message?.includes('Error: HTTP') ||
               status === 404 ||

--- a/frontend/src/components/dataset/DatasetMap.tsx
+++ b/frontend/src/components/dataset/DatasetMap.tsx
@@ -11,7 +11,7 @@ import { useFeatureEditing, showAllFeaturesInTiles } from '@/components/dataset/
 import { DrawingToolbar } from '@/components/drawing/DrawingToolbar';
 import { AttributeForm } from '@/components/drawing/AttributeForm';
 import { useTileToken, useInvalidateTileTokens } from '@/hooks/use-tile-token';
-import { useTileAuthRecovery, useVisibleTileTokenRefresh } from '@/hooks/use-tile-auth-recovery';
+import { isSessionRenewalPending, useTileAuthRecovery, useVisibleTileTokenRefresh } from '@/hooks/use-tile-auth-recovery';
 import { useMapLayers, getSourceLayerName } from '@/components/maps/hooks/use-map-layers';
 import { computeLargeExtentView, isLargeExtent } from '@/lib/map-extent';
 import { findElevationColumn } from '@/lib/geo-utils';
@@ -676,7 +676,11 @@ export const DatasetMap = memo(function DatasetMap({
         const s = e.error?.status;
         if (s !== 401 && s !== 403) return;
         const reminting = recoverTileAuth();
-        const recovering = reminting && !isRasterTileAuthError(e);
+        // fix(#907): a raster auth error counts as recovering while a session
+        // renewal is in flight — that renewal is what fixes it, and its
+        // post-rotation reload retries the tiles.
+        const recovering =
+          reminting && (!isRasterTileAuthError(e) || isSessionRenewalPending());
         if (!recovering && !errorFiredRef.current) {
           errorFiredRef.current = true;
           onTileError?.();

--- a/frontend/src/components/viewer/ViewerMap.tsx
+++ b/frontend/src/components/viewer/ViewerMap.tsx
@@ -11,7 +11,7 @@ import {
   resolveBasemapId,
   BLANK_BASEMAP_ID,
 } from '@/lib/basemap-utils';
-import { buildClusterTileUrl, buildSignedTileUrl, buildTileTransformRequest, getMvtSourceLayerName, isMvtSourceLayerConfigReady, isThirdPartyTileUrl, resolveTileBaseUrl } from '@/lib/tile-utils';
+import { buildClusterTileUrl, buildSignedTileUrl, buildTileTransformRequest, getMvtSourceLayerName, isMvtSourceLayerConfigReady, isThirdPartyTileUrl, refreshRasterTileSources, resolveTileBaseUrl } from '@/lib/tile-utils';
 import { useRemoteBasemapStyle } from '@/components/map/hooks/use-remote-basemap-style';
 import { isRasterTileAuthError, logUnhandledMapError } from '@/lib/map-error-log';
 import { reportTileTokenRemint } from '@/lib/report';
@@ -198,7 +198,9 @@ export const ViewerMap = memo(function ViewerMap({
   // fix(#755): a tab backgrounded past the 900 s sig boundary comes back with
   // stale tokens, so MapLibre's resumed fetches 403 before the error handler
   // can heal them. Kick the same throttled re-mint on the visible edge.
-  useVisibleTileTokenRefresh(() => tokenMap.values(), recoverTileAuth);
+  useVisibleTileTokenRefresh(() => tokenMap.values(), recoverTileAuth, () =>
+    refreshRasterTileSources(mapRef.current),
+  );
 
   // fix(#452): the bound DEM's LIVE visibility (legend eye toggle). Saved
   // visibility is handled inside the hook (HT-12); this covers the client-side

--- a/frontend/src/components/viewer/ViewerMap.tsx
+++ b/frontend/src/components/viewer/ViewerMap.tsx
@@ -13,7 +13,7 @@ import {
 } from '@/lib/basemap-utils';
 import { buildClusterTileUrl, buildSignedTileUrl, buildTileTransformRequest, getMvtSourceLayerName, isMvtSourceLayerConfigReady, isThirdPartyTileUrl, refreshRasterTileSources, resolveTileBaseUrl } from '@/lib/tile-utils';
 import { useRemoteBasemapStyle } from '@/components/map/hooks/use-remote-basemap-style';
-import { isRasterTileAuthError, logUnhandledMapError } from '@/lib/map-error-log';
+import { isRasterTileAuthError, isRefreshableRasterAuthError, logUnhandledMapError } from '@/lib/map-error-log';
 import { reportTileTokenRemint } from '@/lib/report';
 import { useWebGLRecovery } from '@/hooks/use-webgl-recovery';
 import { useInvalidateTileTokens } from '@/hooks/use-tile-token';
@@ -424,7 +424,8 @@ export const ViewerMap = memo(function ViewerMap({
           // thing that DOES fix a raster 401, and whose post-rotation reload is
           // about to retry these tiles.
           const rasterUnrecoverable =
-            isRasterTileAuthError(e) && !isSessionRenewalPending();
+            isRasterTileAuthError(e) &&
+            !(isRefreshableRasterAuthError(e) && isSessionRenewalPending());
           if (rasterUnrecoverable || (!isRasterTileAuthError(e) && !recovering)) {
             toast.error(t('viewer.mapError', { defaultValue: 'Map tile error — some layers may not display correctly.' }), {
               id: 'viewer-map-error',

--- a/frontend/src/components/viewer/ViewerMap.tsx
+++ b/frontend/src/components/viewer/ViewerMap.tsx
@@ -17,7 +17,7 @@ import { isRasterTileAuthError, logUnhandledMapError } from '@/lib/map-error-log
 import { reportTileTokenRemint } from '@/lib/report';
 import { useWebGLRecovery } from '@/hooks/use-webgl-recovery';
 import { useInvalidateTileTokens } from '@/hooks/use-tile-token';
-import { useTileAuthRecovery, useVisibleTileTokenRefresh } from '@/hooks/use-tile-auth-recovery';
+import { isSessionRenewalPending, useTileAuthRecovery, useVisibleTileTokenRefresh } from '@/hooks/use-tile-auth-recovery';
 import { useViewerTokens } from '@/components/viewer/hooks/use-viewer-tokens';
 import { isViewerTerrainExpected, useViewerTerrain } from '@/components/viewer/hooks/use-viewer-terrain';
 import { FeaturePopup, type FeatureInfo } from '@/components/map/FeaturePopup';
@@ -420,7 +420,12 @@ export const ViewerMap = memo(function ViewerMap({
           // does for a vector tile: toast regardless, matching
           // `isHandledTileAuthError`, which keeps logging these.
           const recovering = recoverTileAuth();
-          if (isRasterTileAuthError(e) || !recovering) {
+          // fix(#907): …unless a session renewal is in flight, which is the one
+          // thing that DOES fix a raster 401, and whose post-rotation reload is
+          // about to retry these tiles.
+          const rasterUnrecoverable =
+            isRasterTileAuthError(e) && !isSessionRenewalPending();
+          if (rasterUnrecoverable || (!isRasterTileAuthError(e) && !recovering)) {
             toast.error(t('viewer.mapError', { defaultValue: 'Map tile error — some layers may not display correctly.' }), {
               id: 'viewer-map-error',
             });

--- a/frontend/src/hooks/__tests__/use-tile-auth-recovery.test.ts
+++ b/frontend/src/hooks/__tests__/use-tile-auth-recovery.test.ts
@@ -1,4 +1,4 @@
-import { renderHook } from '@testing-library/react';
+import { act, renderHook } from '@testing-library/react';
 import {
   hasExpiringSession,
   hasExpiringVectorToken,
@@ -225,7 +225,7 @@ describe('hasExpiringSession (fix #907)', () => {
 describe('useVisibleTileTokenRefresh (fix #755)', () => {
   afterEach(() => {
     setVisibility('visible');
-    useAuthStore.setState({ expiresAt: null });
+    useAuthStore.setState({ token: null, expiresAt: null });
     vi.mocked(tryRefresh).mockReset();
     vi.mocked(tryRefresh).mockResolvedValue(true);
     vi.restoreAllMocks();
@@ -389,6 +389,45 @@ describe('useVisibleTileTokenRefresh (fix #755)', () => {
     resolveRefresh(true);
     await Promise.resolve();
     await Promise.resolve();
+    expect(onCredentialRenewed).toHaveBeenCalledTimes(1);
+  });
+
+  // codex round 2 on #964: tryRefresh RESOLVES false on a transient failure, so
+  // reloading unconditionally would retry against the same stale Bearer.
+  it('does not reload when the refresh failed and nothing rotated', async () => {
+    const recover = vi.fn(() => true);
+    const onCredentialRenewed = vi.fn();
+    vi.mocked(tryRefresh).mockResolvedValueOnce(false);
+    useAuthStore.setState({ token: 'stale', expiresAt: Date.now() + 10_000 });
+    renderHook(() =>
+      useVisibleTileTokenRefresh(() => [rasterToken], recover, onCredentialRenewed),
+    );
+
+    document.dispatchEvent(new Event('visibilitychange'));
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(onCredentialRenewed).not.toHaveBeenCalled();
+  });
+
+  // …but the mint `recover` kicks may rotate it a moment later, and that
+  // rotation has to reload the tiles too, or the holes stay until the user pans.
+  it('reloads when a concurrent mint rotates the token after our attempt failed', async () => {
+    const recover = vi.fn(() => true);
+    const onCredentialRenewed = vi.fn();
+    vi.mocked(tryRefresh).mockResolvedValueOnce(false);
+    useAuthStore.setState({ token: 'stale', expiresAt: Date.now() + 10_000 });
+    renderHook(() =>
+      useVisibleTileTokenRefresh(() => [rasterToken], recover, onCredentialRenewed),
+    );
+
+    document.dispatchEvent(new Event('visibilitychange'));
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(onCredentialRenewed).not.toHaveBeenCalled();
+
+    act(() => useAuthStore.setState({ token: 'rotated-by-the-mint' }));
+
     expect(onCredentialRenewed).toHaveBeenCalledTimes(1);
   });
 

--- a/frontend/src/hooks/__tests__/use-tile-auth-recovery.test.ts
+++ b/frontend/src/hooks/__tests__/use-tile-auth-recovery.test.ts
@@ -1,6 +1,7 @@
 import { act, renderHook } from '@testing-library/react';
 import {
   hasExpiringSession,
+  isSessionRenewalPending,
   hasExpiringVectorToken,
   useTileAuthRecovery,
   useVisibleTileTokenRefresh,
@@ -456,6 +457,33 @@ describe('useVisibleTileTokenRefresh (fix #755)', () => {
     act(() => useAuthStore.setState({ token: null }));
 
     expect(onCredentialRenewed).not.toHaveBeenCalled();
+  });
+
+  // codex on #964: with the reload in place a raster 401 from the visibility
+  // race heals on its own, but the surfaces still told the user to reload the
+  // page. This is the window they use to suppress that.
+  it('marks a renewal pending for the surfaces, time-boxed', async () => {
+    const recover = vi.fn(() => true);
+    let resolveRefresh: (value: boolean) => void = () => {};
+    vi.mocked(tryRefresh).mockReturnValueOnce(
+      new Promise<boolean>((resolve) => {
+        resolveRefresh = resolve;
+      }),
+    );
+    useAuthStore.setState({ token: 'stale', expiresAt: Date.now() + 10_000 });
+    renderHook(() => useVisibleTileTokenRefresh(() => [rasterToken], recover));
+
+    const startedAt = Date.now();
+    document.dispatchEvent(new Event('visibilitychange'));
+
+    // Pending from the moment the renewal starts — the race 401s arrive before
+    // it resolves, which is the whole point.
+    expect(isSessionRenewalPending(startedAt)).toBe(true);
+    resolveRefresh(true);
+    await Promise.resolve();
+
+    // …and bounded, so a revoked grant that 403s long after still surfaces.
+    expect(isSessionRenewalPending(startedAt + 60_000)).toBe(false);
   });
 
   it('does not touch raster sources when only a vector sig is expiring', async () => {

--- a/frontend/src/hooks/__tests__/use-tile-auth-recovery.test.ts
+++ b/frontend/src/hooks/__tests__/use-tile-auth-recovery.test.ts
@@ -7,6 +7,9 @@ import {
 } from '@/hooks/use-tile-auth-recovery';
 import type { TileToken } from '@/api/tiles';
 import { useAuthStore } from '@/stores/auth-store';
+import { tryRefresh } from '@/api/client';
+
+vi.mock('@/api/client', () => ({ tryRefresh: vi.fn(async () => true) }));
 
 // fix(#621): one re-mint per cooldown window — MapLibre can fire dozens of
 // tile errors per pan, and hammering the mint endpoint cannot help. Errors in
@@ -223,6 +226,8 @@ describe('useVisibleTileTokenRefresh (fix #755)', () => {
   afterEach(() => {
     setVisibility('visible');
     useAuthStore.setState({ expiresAt: null });
+    vi.mocked(tryRefresh).mockReset();
+    vi.mocked(tryRefresh).mockResolvedValue(true);
     vi.restoreAllMocks();
   });
 
@@ -357,6 +362,50 @@ describe('useVisibleTileTokenRefresh (fix #755)', () => {
     document.dispatchEvent(new Event('visibilitychange'));
 
     expect(recover).not.toHaveBeenCalled();
+  });
+
+  // fix(#907) (codex P1): renewing the credential does not retry the raster
+  // tiles that already 401'd — MapLibre resumes its fetches the moment the tab
+  // is visible and races the refresh, and a raster descriptor is unchanged
+  // across one, so nothing in the token→setTiles plumbing reloads them.
+  it('reloads raster sources AFTER the credential renewal resolves', async () => {
+    const recover = vi.fn(() => true);
+    const onCredentialRenewed = vi.fn();
+    let resolveRefresh: (value: boolean) => void = () => {};
+    vi.mocked(tryRefresh).mockReturnValueOnce(
+      new Promise<boolean>((resolve) => {
+        resolveRefresh = resolve;
+      }),
+    );
+    useAuthStore.setState({ expiresAt: Date.now() + 10_000 });
+    renderHook(() =>
+      useVisibleTileTokenRefresh(() => [rasterToken], recover, onCredentialRenewed),
+    );
+
+    document.dispatchEvent(new Event('visibilitychange'));
+
+    // Not before: reloading against the stale Bearer would just 401 again.
+    expect(onCredentialRenewed).not.toHaveBeenCalled();
+    resolveRefresh(true);
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(onCredentialRenewed).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not touch raster sources when only a vector sig is expiring', async () => {
+    const recover = vi.fn(() => true);
+    const onCredentialRenewed = vi.fn();
+    useAuthStore.setState({ expiresAt: Date.now() + 3_600_000 });
+    renderHook(() =>
+      useVisibleTileTokenRefresh(() => [vectorToken(expIn(-60))], recover, onCredentialRenewed),
+    );
+
+    document.dispatchEvent(new Event('visibilitychange'));
+    await Promise.resolve();
+
+    expect(recover).toHaveBeenCalledWith('tab-return');
+    expect(tryRefresh).not.toHaveBeenCalled();
+    expect(onCredentialRenewed).not.toHaveBeenCalled();
   });
 
   it('still does nothing on the hidden edge when only the session is expiring', () => {

--- a/frontend/src/hooks/__tests__/use-tile-auth-recovery.test.ts
+++ b/frontend/src/hooks/__tests__/use-tile-auth-recovery.test.ts
@@ -486,6 +486,37 @@ describe('useVisibleTileTokenRefresh (fix #755)', () => {
     expect(isSessionRenewalPending(startedAt + 60_000)).toBe(false);
   });
 
+  // codex on #964: refreshAccessToken rides an unbounded fetch, so a fixed
+  // deadline could expire mid-flight and let a delayed raster 401 latch
+  // DatasetMap's permanent error overlay for tiles the rotation then heals.
+  it('stays pending for as long as the refresh is actually in flight', async () => {
+    const recover = vi.fn(() => true);
+    let settle: (value: boolean) => void = () => {};
+    vi.mocked(tryRefresh).mockReturnValueOnce(
+      new Promise<boolean>((resolve) => {
+        settle = resolve;
+      }),
+    );
+    useAuthStore.setState({ token: 'stale', expiresAt: Date.now() + 10_000 });
+    renderHook(() => useVisibleTileTokenRefresh(() => [rasterToken], recover));
+
+    const startedAt = Date.now();
+    document.dispatchEvent(new Event('visibilitychange'));
+
+    // Well past the post-settle grace window, still in flight → still pending.
+    expect(isSessionRenewalPending(startedAt + 30_000)).toBe(true);
+    // …but not forever: a hung refresh must not silence the map for the rest
+    // of the session.
+    expect(isSessionRenewalPending(startedAt + 120_000)).toBe(false);
+
+    settle(true);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    // Settled: back to the bounded grace window.
+    expect(isSessionRenewalPending(Date.now() + 60_000)).toBe(false);
+  });
+
   it('does not touch raster sources when only a vector sig is expiring', async () => {
     const recover = vi.fn(() => true);
     const onCredentialRenewed = vi.fn();

--- a/frontend/src/hooks/__tests__/use-tile-auth-recovery.test.ts
+++ b/frontend/src/hooks/__tests__/use-tile-auth-recovery.test.ts
@@ -437,6 +437,27 @@ describe('useVisibleTileTokenRefresh (fix #755)', () => {
     expect(onCredentialRenewed).toHaveBeenCalledTimes(1);
   });
 
+  // codex on #964: a dead session ends in `logout()`, which moves the token to
+  // null. Treating that as a rotation would refetch every raster tile with no
+  // Authorization header — a second 401 burst under the signed-out dialog.
+  it('does not treat a logout as a credential renewal', async () => {
+    const recover = vi.fn(() => true);
+    const onCredentialRenewed = vi.fn();
+    vi.mocked(tryRefresh).mockResolvedValueOnce(true);
+    useAuthStore.setState({ token: 'stale', expiresAt: Date.now() + 10_000 });
+    renderHook(() =>
+      useVisibleTileTokenRefresh(() => [rasterToken], recover, onCredentialRenewed),
+    );
+
+    document.dispatchEvent(new Event('visibilitychange'));
+    await Promise.resolve();
+    await Promise.resolve();
+
+    act(() => useAuthStore.setState({ token: null }));
+
+    expect(onCredentialRenewed).not.toHaveBeenCalled();
+  });
+
   it('does not touch raster sources when only a vector sig is expiring', async () => {
     const recover = vi.fn(() => true);
     const onCredentialRenewed = vi.fn();

--- a/frontend/src/hooks/__tests__/use-tile-auth-recovery.test.ts
+++ b/frontend/src/hooks/__tests__/use-tile-auth-recovery.test.ts
@@ -1,10 +1,12 @@
 import { renderHook } from '@testing-library/react';
 import {
+  hasExpiringSession,
   hasExpiringVectorToken,
   useTileAuthRecovery,
   useVisibleTileTokenRefresh,
 } from '@/hooks/use-tile-auth-recovery';
 import type { TileToken } from '@/api/tiles';
+import { useAuthStore } from '@/stores/auth-store';
 
 // fix(#621): one re-mint per cooldown window — MapLibre can fire dozens of
 // tile errors per pan, and hammering the mint endpoint cannot help. Errors in
@@ -194,9 +196,33 @@ describe('hasExpiringVectorToken (fix #755)', () => {
   });
 });
 
+describe('hasExpiringSession (fix #907)', () => {
+  const now = 1_785_148_200_000; // ms
+
+  it('flags a session already past expiry', () => {
+    expect(hasExpiringSession(now - 1, now)).toBe(true);
+  });
+
+  it('flags a session inside the 60s skew window', () => {
+    expect(hasExpiringSession(now + 30_000, now)).toBe(true);
+    expect(hasExpiringSession(now + 60_000, now)).toBe(true);
+  });
+
+  it('leaves a comfortably fresh session alone', () => {
+    expect(hasExpiringSession(now + 60_001, now)).toBe(false);
+    expect(hasExpiringSession(now + 900_000, now)).toBe(false);
+  });
+
+  it('treats an absent expiry as not expiring (anonymous / embed-token surfaces)', () => {
+    expect(hasExpiringSession(null, now)).toBe(false);
+    expect(hasExpiringSession(undefined, now)).toBe(false);
+  });
+});
+
 describe('useVisibleTileTokenRefresh (fix #755)', () => {
   afterEach(() => {
     setVisibility('visible');
+    useAuthStore.setState({ expiresAt: null });
     vi.restoreAllMocks();
   });
 
@@ -307,5 +333,40 @@ describe('useVisibleTileTokenRefresh (fix #755)', () => {
 
     expect(remint).not.toHaveBeenCalled();
     expect(onRemint).not.toHaveBeenCalled();
+  });
+
+  // fix(#907): raster/DEM tiles carry the session JWT in an Authorization
+  // header, so a raster-only map has no `exp` for hasExpiringVectorToken to
+  // see. Without the session half of the gate it 401s its whole tile surface
+  // once on tab return.
+  it('re-mints for a raster-only map whose session JWT is expiring', () => {
+    const recover = vi.fn(() => true);
+    useAuthStore.setState({ expiresAt: Date.now() + 10_000 });
+    renderHook(() => useVisibleTileTokenRefresh(() => [rasterToken], recover));
+
+    document.dispatchEvent(new Event('visibilitychange'));
+
+    expect(recover).toHaveBeenCalledWith('tab-return');
+  });
+
+  it('leaves a raster-only map alone while its session JWT is fresh', () => {
+    const recover = vi.fn(() => true);
+    useAuthStore.setState({ expiresAt: Date.now() + 3_600_000 });
+    renderHook(() => useVisibleTileTokenRefresh(() => [rasterToken], recover));
+
+    document.dispatchEvent(new Event('visibilitychange'));
+
+    expect(recover).not.toHaveBeenCalled();
+  });
+
+  it('still does nothing on the hidden edge when only the session is expiring', () => {
+    const recover = vi.fn(() => true);
+    useAuthStore.setState({ expiresAt: Date.now() + 10_000 });
+    renderHook(() => useVisibleTileTokenRefresh(() => [rasterToken], recover));
+
+    setVisibility('hidden');
+    document.dispatchEvent(new Event('visibilitychange'));
+
+    expect(recover).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/hooks/__tests__/use-tile-auth-recovery.test.ts
+++ b/frontend/src/hooks/__tests__/use-tile-auth-recovery.test.ts
@@ -374,10 +374,15 @@ describe('useVisibleTileTokenRefresh (fix #755)', () => {
     let resolveRefresh: (value: boolean) => void = () => {};
     vi.mocked(tryRefresh).mockReturnValueOnce(
       new Promise<boolean>((resolve) => {
-        resolveRefresh = resolve;
+        // A real refresh writes the rotated token into the store before it
+        // resolves; the token comparison is what this path trusts.
+        resolveRefresh = (value) => {
+          useAuthStore.setState({ token: 'rotated' });
+          resolve(value);
+        };
       }),
     );
-    useAuthStore.setState({ expiresAt: Date.now() + 10_000 });
+    useAuthStore.setState({ token: 'stale', expiresAt: Date.now() + 10_000 });
     renderHook(() =>
       useVisibleTileTokenRefresh(() => [rasterToken], recover, onCredentialRenewed),
     );
@@ -392,12 +397,13 @@ describe('useVisibleTileTokenRefresh (fix #755)', () => {
     expect(onCredentialRenewed).toHaveBeenCalledTimes(1);
   });
 
-  // codex round 2 on #964: tryRefresh RESOLVES false on a transient failure, so
-  // reloading unconditionally would retry against the same stale Bearer.
+  // codex on #964: `tryRefresh` resolves `!!token`, so it comes back TRUE for a
+  // transient failure that left the stale token in place. Reloading on that
+  // boolean would retry against the same Bearer and 401 again.
   it('does not reload when the refresh failed and nothing rotated', async () => {
     const recover = vi.fn(() => true);
     const onCredentialRenewed = vi.fn();
-    vi.mocked(tryRefresh).mockResolvedValueOnce(false);
+    vi.mocked(tryRefresh).mockResolvedValueOnce(true);
     useAuthStore.setState({ token: 'stale', expiresAt: Date.now() + 10_000 });
     renderHook(() =>
       useVisibleTileTokenRefresh(() => [rasterToken], recover, onCredentialRenewed),
@@ -415,7 +421,7 @@ describe('useVisibleTileTokenRefresh (fix #755)', () => {
   it('reloads when a concurrent mint rotates the token after our attempt failed', async () => {
     const recover = vi.fn(() => true);
     const onCredentialRenewed = vi.fn();
-    vi.mocked(tryRefresh).mockResolvedValueOnce(false);
+    vi.mocked(tryRefresh).mockResolvedValueOnce(true);
     useAuthStore.setState({ token: 'stale', expiresAt: Date.now() + 10_000 });
     renderHook(() =>
       useVisibleTileTokenRefresh(() => [rasterToken], recover, onCredentialRenewed),

--- a/frontend/src/hooks/use-tile-auth-recovery.ts
+++ b/frontend/src/hooks/use-tile-auth-recovery.ts
@@ -99,6 +99,32 @@ export function hasExpiringSession(
   return expiresAt != null && expiresAt - nowMs <= EXPIRY_SKEW_MS;
 }
 
+// fix(#907): how long to keep watching for a rotation after our own refresh
+// attempt failed. Bounded so a permanently dead session leaves no listener
+// behind; the reactive 401 path still owns anything slower than this.
+const RENEWAL_WATCH_MS = 30_000;
+
+/** Run `reload` once the session token has actually rotated — immediately when
+ * our own refresh produced the new one, otherwise on the first store change a
+ * concurrent mint's refresh writes, and never if neither happens. */
+function reloadOnTokenRotation(reload: () => void): void {
+  const tokenBefore = useAuthStore.getState().token;
+  void tryRefresh().then((refreshed) => {
+    if (refreshed || useAuthStore.getState().token !== tokenBefore) {
+      reload();
+      return;
+    }
+    let unsubscribe: (() => void) | null = null;
+    const timer = setTimeout(() => unsubscribe?.(), RENEWAL_WATCH_MS);
+    unsubscribe = useAuthStore.subscribe((state) => {
+      if (state.token === tokenBefore) return;
+      clearTimeout(timer);
+      unsubscribe?.();
+      reload();
+    });
+  });
+}
+
 /**
  * fix(#755): re-mint tile tokens on the tab-return edge instead of after the
  * 403 burst. Tile sigs are minted on `round_expiry()` 900 s boundaries, so a
@@ -147,10 +173,14 @@ export function useVisibleTileTokenRefresh(
         // own — MapLibre resumes its fetches as soon as the tab is visible and
         // races the refresh, and a raster descriptor does not change across
         // one, so nothing in the token→setTiles plumbing retries the tiles that
-        // 401'd. Wait for the renewal, then reload them explicitly. `recover`'s
-        // own mint collapses into this same refresh (the module-level in-flight
-        // singleton in api/client.ts), so this costs no extra request.
-        void tryRefresh().then(() => onCredentialRenewedRef.current?.());
+        // 401'd. Reload them explicitly, but only once the token has ACTUALLY
+        // rotated: `tryRefresh` resolves false on a transient failure (offline,
+        // 429), and reloading against the same stale Bearer would just 401
+        // again. `recover`'s own mint collapses into this same refresh (the
+        // in-flight singleton in api/client.ts), so this costs no extra request
+        // — and when our attempt is the one that fails, that mint's later
+        // rotation is what the store subscription below picks up.
+        reloadOnTokenRotation(() => onCredentialRenewedRef.current?.());
       }
       recover('tab-return');
     };

--- a/frontend/src/hooks/use-tile-auth-recovery.ts
+++ b/frontend/src/hooks/use-tile-auth-recovery.ts
@@ -107,6 +107,13 @@ export function hasExpiringSession(
 // 403s long after any renewal window and must still surface.
 const RENEWAL_SUPPRESS_MS = 10_000;
 
+// A hard ceiling on how long an in-flight renewal can keep suppressing.
+// `refreshAccessToken` rides an unbounded fetch, so without this a hung request
+// would silence raster auth errors for the rest of the session.
+const RENEWAL_MAX_MS = 60_000;
+
+let renewalInFlight = false;
+let renewalDeadline = 0;
 let renewalPendingUntil = 0;
 
 /**
@@ -118,6 +125,13 @@ let renewalPendingUntil = 0;
  * demonstrably is.
  */
 export function isSessionRenewalPending(nowMs: number = Date.now()): boolean {
+  // Tied to the refresh PROMISE, not to a fixed deadline: a slow
+  // `/auth/refresh/` (or a slow stale raster request) can outlast any window
+  // picked in advance, and a 401 arriving in that gap would latch DatasetMap's
+  // permanent error overlay for tiles the eventual rotation heals. The grace
+  // period after it settles covers the reload and the errors the race already
+  // queued.
+  if (renewalInFlight && nowMs < renewalDeadline) return true;
   return nowMs < renewalPendingUntil;
 }
 
@@ -137,6 +151,8 @@ const RENEWAL_WATCH_MS = 30_000;
  * 401 against the same Bearer. */
 function reloadOnTokenRotation(reload: () => void): void {
   const tokenBefore = useAuthStore.getState().token;
+  renewalInFlight = true;
+  renewalDeadline = Date.now() + RENEWAL_MAX_MS;
   renewalPendingUntil = Date.now() + RENEWAL_SUPPRESS_MS;
   const reloadAndExtend = () => {
     // Cover the errors already queued by the race, which arrive just after the
@@ -151,6 +167,8 @@ function reloadOnTokenRotation(reload: () => void): void {
   // dialog. Only a non-null, different token is a rotation.
   const isRotation = (token: string | null) => token !== null && token !== tokenBefore;
   void tryRefresh().then(() => {
+    renewalInFlight = false;
+    renewalPendingUntil = Date.now() + RENEWAL_SUPPRESS_MS;
     if (isRotation(useAuthStore.getState().token)) {
       reloadAndExtend();
       return;

--- a/frontend/src/hooks/use-tile-auth-recovery.ts
+++ b/frontend/src/hooks/use-tile-auth-recovery.ts
@@ -99,6 +99,28 @@ export function hasExpiringSession(
   return expiresAt != null && expiresAt - nowMs <= EXPIRY_SKEW_MS;
 }
 
+// fix(#907): how long a raster/DEM auth failure stays attributable to a
+// renewal we are actively running. MapLibre resumes its fetches the instant the
+// tab is visible and can 401 before the refresh lands, so those errors are the
+// expected shape of the race, not a dead session — and the post-rotation reload
+// is about to cure them. Time-boxed rather than open-ended: a revoked grant
+// 403s long after any renewal window and must still surface.
+const RENEWAL_SUPPRESS_MS = 10_000;
+
+let renewalPendingUntil = 0;
+
+/**
+ * fix(#907): true while a visible-edge session renewal is in flight (or has
+ * just reloaded the raster sources). The surfaces' error handlers use it to
+ * stop telling the user to reload the page for a raster 401 that is seconds
+ * from healing on its own. #890 made those failures unsuppressed because
+ * NOTHING could cure them; this narrows that to the window where something
+ * demonstrably is.
+ */
+export function isSessionRenewalPending(nowMs: number = Date.now()): boolean {
+  return nowMs < renewalPendingUntil;
+}
+
 // fix(#907): how long to keep watching for a rotation after our own refresh
 // attempt failed. Bounded so a permanently dead session leaves no listener
 // behind; the reactive 401 path still owns anything slower than this.
@@ -115,6 +137,13 @@ const RENEWAL_WATCH_MS = 30_000;
  * 401 against the same Bearer. */
 function reloadOnTokenRotation(reload: () => void): void {
   const tokenBefore = useAuthStore.getState().token;
+  renewalPendingUntil = Date.now() + RENEWAL_SUPPRESS_MS;
+  const reloadAndExtend = () => {
+    // Cover the errors already queued by the race, which arrive just after the
+    // reload is issued.
+    renewalPendingUntil = Date.now() + RENEWAL_SUPPRESS_MS;
+    reload();
+  };
   // A CHANGED token is not automatically a renewed one: when the session turns
   // out to be dead, `notifySessionExpired` logs out and moves the token to
   // null. Reloading on that would refetch every raster tile with no
@@ -123,7 +152,7 @@ function reloadOnTokenRotation(reload: () => void): void {
   const isRotation = (token: string | null) => token !== null && token !== tokenBefore;
   void tryRefresh().then(() => {
     if (isRotation(useAuthStore.getState().token)) {
-      reload();
+      reloadAndExtend();
       return;
     }
     let unsubscribe: (() => void) | null = null;
@@ -132,7 +161,7 @@ function reloadOnTokenRotation(reload: () => void): void {
       if (!isRotation(state.token)) return;
       clearTimeout(timer);
       unsubscribe?.();
-      reload();
+      reloadAndExtend();
     });
   });
 }

--- a/frontend/src/hooks/use-tile-auth-recovery.ts
+++ b/frontend/src/hooks/use-tile-auth-recovery.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef } from 'react';
 import type { TileToken } from '@/api/tiles';
 import { useAuthStore } from '@/stores/auth-store';
+import { tryRefresh } from '@/api/client';
 
 // fix(#621): one re-mint per cooldown window bounds the retry loop — MapLibre
 // can fire dozens of tile errors per pan, and a mint that just failed will not
@@ -125,22 +126,31 @@ export function hasExpiringSession(
 export function useVisibleTileTokenRefresh(
   getTokens: () => Iterable<TileToken | null | undefined>,
   recover: (trigger?: string) => boolean,
+  onCredentialRenewed?: () => void,
 ): void {
   const getTokensRef = useRef(getTokens);
   getTokensRef.current = getTokens;
+  const onCredentialRenewedRef = useRef(onCredentialRenewed);
+  onCredentialRenewedRef.current = onCredentialRenewed;
 
   useEffect(() => {
     const onVisibilityChange = () => {
       if (document.visibilityState !== 'visible') return;
-      // fix(#907): the session JWT counts too. The re-mint routes through
-      // apiFetch, whose proactive refresh writes a fresh token into the store
-      // the raster Bearer header reads — so invalidating a raster-only map's
-      // token query is exactly what renews its tile credential.
-      if (
-        !hasExpiringVectorToken(getTokensRef.current()) &&
-        !hasExpiringSession(useAuthStore.getState().expiresAt)
-      ) {
-        return;
+      // fix(#907): the session JWT counts too. Raster/DEM tiles authenticate
+      // with it through `buildTileTransformRequest`'s Authorization header,
+      // not a signed sig, so `hasExpiringVectorToken` can never see their
+      // credential expire and a raster-only map had nothing to trigger on.
+      const sessionExpiring = hasExpiringSession(useAuthStore.getState().expiresAt);
+      if (!hasExpiringVectorToken(getTokensRef.current()) && !sessionExpiring) return;
+      if (sessionExpiring) {
+        // fix(#907) (codex P1): renewing the credential is not enough on its
+        // own — MapLibre resumes its fetches as soon as the tab is visible and
+        // races the refresh, and a raster descriptor does not change across
+        // one, so nothing in the token→setTiles plumbing retries the tiles that
+        // 401'd. Wait for the renewal, then reload them explicitly. `recover`'s
+        // own mint collapses into this same refresh (the module-level in-flight
+        // singleton in api/client.ts), so this costs no extra request.
+        void tryRefresh().then(() => onCredentialRenewedRef.current?.());
       }
       recover('tab-return');
     };

--- a/frontend/src/hooks/use-tile-auth-recovery.ts
+++ b/frontend/src/hooks/use-tile-auth-recovery.ts
@@ -106,11 +106,17 @@ const RENEWAL_WATCH_MS = 30_000;
 
 /** Run `reload` once the session token has actually rotated — immediately when
  * our own refresh produced the new one, otherwise on the first store change a
- * concurrent mint's refresh writes, and never if neither happens. */
+ * concurrent mint's refresh writes, and never if neither happens.
+ *
+ * The token comparison is the ONLY evidence used. `tryRefresh` resolves
+ * `!!useAuthStore.getState().token` (api/client.ts), so it answers "is there
+ * still a token", not "did it rotate" — it comes back true for a transient
+ * failure that left the stale one in place, and reloading on that would just
+ * 401 against the same Bearer. */
 function reloadOnTokenRotation(reload: () => void): void {
   const tokenBefore = useAuthStore.getState().token;
-  void tryRefresh().then((refreshed) => {
-    if (refreshed || useAuthStore.getState().token !== tokenBefore) {
+  void tryRefresh().then(() => {
+    if (useAuthStore.getState().token !== tokenBefore) {
       reload();
       return;
     }

--- a/frontend/src/hooks/use-tile-auth-recovery.ts
+++ b/frontend/src/hooks/use-tile-auth-recovery.ts
@@ -115,15 +115,21 @@ const RENEWAL_WATCH_MS = 30_000;
  * 401 against the same Bearer. */
 function reloadOnTokenRotation(reload: () => void): void {
   const tokenBefore = useAuthStore.getState().token;
+  // A CHANGED token is not automatically a renewed one: when the session turns
+  // out to be dead, `notifySessionExpired` logs out and moves the token to
+  // null. Reloading on that would refetch every raster tile with no
+  // Authorization header at all — a second 401 burst, on top of the signed-out
+  // dialog. Only a non-null, different token is a rotation.
+  const isRotation = (token: string | null) => token !== null && token !== tokenBefore;
   void tryRefresh().then(() => {
-    if (useAuthStore.getState().token !== tokenBefore) {
+    if (isRotation(useAuthStore.getState().token)) {
       reload();
       return;
     }
     let unsubscribe: (() => void) | null = null;
     const timer = setTimeout(() => unsubscribe?.(), RENEWAL_WATCH_MS);
     unsubscribe = useAuthStore.subscribe((state) => {
-      if (state.token === tokenBefore) return;
+      if (!isRotation(state.token)) return;
       clearTimeout(timer);
       unsubscribe?.();
       reload();

--- a/frontend/src/hooks/use-tile-auth-recovery.ts
+++ b/frontend/src/hooks/use-tile-auth-recovery.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef } from 'react';
 import type { TileToken } from '@/api/tiles';
+import { useAuthStore } from '@/stores/auth-store';
 
 // fix(#621): one re-mint per cooldown window bounds the retry loop — MapLibre
 // can fire dozens of tile errors per pan, and a mint that just failed will not
@@ -37,8 +38,8 @@ const REMINT_SETTLE_MS = 10_000;
  * nothing about whether a mint ran. That makes it the only honest place to
  * report a re-mint from; `trigger` names the path that asked for one so the
  * report distinguishes a tab return from a tile error. It is injected (not
- * imported) so this module keeps no dependency beyond the TileToken type, and
- * held in a ref so the returned callback keeps a stable identity — ViewerMap and
+ * imported) so this hook stays free of any reporting dependency, and held in a
+ * ref so the returned callback keeps a stable identity — ViewerMap and
  * DatasetMap list it in `handleLoad`'s deps.
  */
 export function useTileAuthRecovery(
@@ -82,6 +83,22 @@ export function hasExpiringVectorToken(
 }
 
 /**
+ * fix(#907): true when the session access token is at or inside the same skew
+ * window. Raster/DEM tiles authenticate with that JWT through
+ * `buildTileTransformRequest`'s Authorization header, not with a signed tile
+ * sig, so `hasExpiringVectorToken` can never see their credential expire — a
+ * raster-only map has nothing that qualifies and 401s its whole tile surface
+ * once on tab return. `null` (anonymous / embed-token surfaces) is not
+ * expiring: there is no session credential to renew.
+ */
+export function hasExpiringSession(
+  expiresAt: number | null | undefined,
+  nowMs: number = Date.now(),
+): boolean {
+  return expiresAt != null && expiresAt - nowMs <= EXPIRY_SKEW_MS;
+}
+
+/**
  * fix(#755): re-mint tile tokens on the tab-return edge instead of after the
  * 403 burst. Tile sigs are minted on `round_expiry()` 900 s boundaries, so a
  * tab backgrounded for a few minutes routinely crosses one; MapLibre then
@@ -115,7 +132,16 @@ export function useVisibleTileTokenRefresh(
   useEffect(() => {
     const onVisibilityChange = () => {
       if (document.visibilityState !== 'visible') return;
-      if (!hasExpiringVectorToken(getTokensRef.current())) return;
+      // fix(#907): the session JWT counts too. The re-mint routes through
+      // apiFetch, whose proactive refresh writes a fresh token into the store
+      // the raster Bearer header reads — so invalidating a raster-only map's
+      // token query is exactly what renews its tile credential.
+      if (
+        !hasExpiringVectorToken(getTokensRef.current()) &&
+        !hasExpiringSession(useAuthStore.getState().expiresAt)
+      ) {
+        return;
+      }
       recover('tab-return');
     };
     document.addEventListener('visibilitychange', onVisibilityChange);

--- a/frontend/src/lib/__tests__/map-error-log.test.ts
+++ b/frontend/src/lib/__tests__/map-error-log.test.ts
@@ -9,6 +9,7 @@ import {
   isHandledTileAuthError,
   isRasterTileAuthError,
   isRasterTileUrl,
+  isRefreshableRasterAuthError,
   logUnhandledMapError,
 } from '@/lib/map-error-log';
 import { isSessionRenewalPending } from '@/hooks/use-tile-auth-recovery';
@@ -201,9 +202,36 @@ describe('logUnhandledMapError during a session renewal (fix #907)', () => {
     expect(errorSpy).not.toHaveBeenCalled();
   });
 
+  // codex on #907: Titiler and its object store pass a genuine 403 through, and
+  // a fresh JWT cannot cure that. Suppressing it would leave the preview blank
+  // with no overlay once the window closed.
+  it('still logs a raster 403 during a renewal', () => {
+    vi.mocked(isSessionRenewalPending).mockReturnValue(true);
+    logUnhandledMapError(ajaxError(403, '/raster-tiles/abc/tiles/12/1/1.png'));
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+  });
+
   it('still logs a non-auth raster failure during a renewal', () => {
     vi.mocked(isSessionRenewalPending).mockReturnValue(true);
     logUnhandledMapError(ajaxError(500, '/raster-tiles/abc/tiles/12/1/1.png'));
     expect(errorSpy).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('isRefreshableRasterAuthError (fix #907)', () => {
+  it('is true only for a raster 401', () => {
+    expect(isRefreshableRasterAuthError(ajaxError(401, '/raster-tiles/a/tiles/1/1/1.png'))).toBe(true);
+  });
+
+  it('is false for a raster 403 — an upstream denial a refresh cannot cure', () => {
+    expect(isRefreshableRasterAuthError(ajaxError(403, '/raster-tiles/a/tiles/1/1/1.png'))).toBe(false);
+  });
+
+  it('is false for a vector 401, which the re-sign path owns', () => {
+    expect(isRefreshableRasterAuthError(ajaxError(401, '/api/tiles/data.x/1/1/1.pbf'))).toBe(false);
+  });
+
+  it('is false for a non-auth raster failure', () => {
+    expect(isRefreshableRasterAuthError(ajaxError(500, '/raster-tiles/a/tiles/1/1/1.png'))).toBe(false);
   });
 });

--- a/frontend/src/lib/__tests__/map-error-log.test.ts
+++ b/frontend/src/lib/__tests__/map-error-log.test.ts
@@ -11,6 +11,11 @@ import {
   isRasterTileUrl,
   logUnhandledMapError,
 } from '@/lib/map-error-log';
+import { isSessionRenewalPending } from '@/hooks/use-tile-auth-recovery';
+
+vi.mock('@/hooks/use-tile-auth-recovery', () => ({
+  isSessionRenewalPending: vi.fn(() => false),
+}));
 
 function ajaxError(status: number, url: string) {
   return { error: { message: `AJAXError: (${status}): ${url}`, status, url } };
@@ -165,5 +170,40 @@ describe('isRasterTileAuthError (fix #890)', () => {
     expect(isRasterTileUrl(rasterUrl)).toBe(true);
     expect(isRasterTileUrl(vectorUrl)).toBe(false);
     expect(isRasterTileUrl(undefined)).toBe(false);
+  });
+});
+
+// fix(#907): a raster 401 is unrecoverable — EXCEPT while a session renewal is
+// in flight, which is the one thing that fixes it. Logging it then would leave
+// an unsuppressed red report entry for a tab return that healed itself.
+describe('logUnhandledMapError during a session renewal (fix #907)', () => {
+  let errorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    vi.mocked(isSessionRenewalPending).mockReturnValue(false);
+  });
+
+  afterEach(() => {
+    errorSpy.mockRestore();
+  });
+
+  const rasterAuthError = ajaxError(401, '/raster-tiles/abc/tiles/12/1/1.png');
+
+  it('logs a raster 401 when no renewal is running', () => {
+    logUnhandledMapError(rasterAuthError);
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('stays silent for a raster 401 while a renewal is running', () => {
+    vi.mocked(isSessionRenewalPending).mockReturnValue(true);
+    logUnhandledMapError(rasterAuthError);
+    expect(errorSpy).not.toHaveBeenCalled();
+  });
+
+  it('still logs a non-auth raster failure during a renewal', () => {
+    vi.mocked(isSessionRenewalPending).mockReturnValue(true);
+    logUnhandledMapError(ajaxError(500, '/raster-tiles/abc/tiles/12/1/1.png'));
+    expect(errorSpy).toHaveBeenCalledTimes(1);
   });
 });

--- a/frontend/src/lib/__tests__/tile-utils.test.ts
+++ b/frontend/src/lib/__tests__/tile-utils.test.ts
@@ -5,6 +5,7 @@ import {
   getMvtSourceLayerName,
   isMvtSourceLayerConfigReady,
   isThirdPartyTileUrl,
+  refreshRasterTileSources,
 } from '@/lib/tile-utils';
 import { useAuthStore } from '@/stores/auth-store';
 
@@ -332,5 +333,56 @@ describe('buildTileTransformRequest', () => {
     expect(transform('https://cdn.example.com/api/tiles/x.mvt').headers).toEqual({
       'X-Embed-Token': 'embed-tok',
     });
+  });
+});
+
+// fix(#907) (codex P1): a raster descriptor does not change when the session
+// JWT rotates, so nothing in the token→setTiles plumbing retries the tiles that
+// 401'd while MapLibre raced the refresh. This is the explicit reload.
+describe('refreshRasterTileSources (fix #907)', () => {
+  function fakeMap(sources: Record<string, { type: string }>) {
+    return {
+      getStyle: () => ({ sources }),
+      refreshTiles: vi.fn(),
+    };
+  }
+
+  it('reloads raster and raster-dem sources, and nothing else', () => {
+    const map = fakeMap({
+      'raster-a': { type: 'raster' },
+      'dem-b': { type: 'raster-dem' },
+      'vector-c': { type: 'vector' },
+      'geojson-d': { type: 'geojson' },
+    });
+
+    expect(refreshRasterTileSources(map)).toBe(2);
+    expect(map.refreshTiles.mock.calls.map(([id]) => id)).toEqual(['raster-a', 'dem-b']);
+  });
+
+  it('is a no-op without a map, and survives a torn-down style', () => {
+    expect(refreshRasterTileSources(null)).toBe(0);
+    expect(
+      refreshRasterTileSources({
+        getStyle: () => {
+          throw new Error('style is not done loading');
+        },
+        refreshTiles: vi.fn(),
+      }),
+    ).toBe(0);
+  });
+
+  it('keeps going when one source is torn down mid-refresh', () => {
+    const refreshTiles = vi.fn((id: string) => {
+      if (id === 'raster-a') throw new Error('source removed');
+    });
+    const map = {
+      getStyle: () => ({
+        sources: { 'raster-a': { type: 'raster' }, 'raster-b': { type: 'raster' } },
+      }),
+      refreshTiles,
+    };
+
+    expect(refreshRasterTileSources(map)).toBe(1);
+    expect(refreshTiles).toHaveBeenCalledTimes(2);
   });
 });

--- a/frontend/src/lib/map-error-log.ts
+++ b/frontend/src/lib/map-error-log.ts
@@ -11,6 +11,8 @@
 // Passing `logUnhandledMapError` as the <Map> `onError` prop keeps the
 // wrapper's default log for everything else and drops ONLY that handled case.
 
+import { isSessionRenewalPending } from '@/hooks/use-tile-auth-recovery';
+
 /** Structural subset of MapLibre's ErrorEvent that this module inspects.
  * MapLibre attaches `status`/`url` to AJAXError instances raised by tile
  * fetches; plain style/runtime errors carry neither. */
@@ -71,8 +73,17 @@ export function isRasterTileAuthError(e: MapLibreErrorLike): boolean {
 /** `onError` prop for @vis.gl/react-maplibre's <Map>: replicate the wrapper's
  * default `console.error` fallback, except for handled first-party tile-auth
  * 401/403s, which log nothing — the surface's `map.on('error')` handler
- * recovers those and reports them (suppressed) where applicable. */
+ * recovers those and reports them (suppressed) where applicable.
+ *
+ * fix(#907): a raster/DEM 401 is now handled too, but only while a session
+ * renewal is in flight — that renewal is what fixes it, and the post-rotation
+ * reload retries the tiles. Without this the surfaces suppress their own row
+ * while this fallback still console.errors the same failure, which
+ * `initReportCapture` turns into an unsuppressed red entry: the #755
+ * double-log shape, for a tab return that healed itself. Outside that window a
+ * raster auth failure is unrecoverable and still logs, exactly as #890 made it. */
 export function logUnhandledMapError(e: MapLibreErrorLike): void {
   if (isHandledTileAuthError(e)) return;
+  if (isRasterTileAuthError(e) && isSessionRenewalPending()) return;
   console.error(e.error);
 }

--- a/frontend/src/lib/map-error-log.ts
+++ b/frontend/src/lib/map-error-log.ts
@@ -58,6 +58,16 @@ export function isHandledTileAuthError(e: MapLibreErrorLike): boolean {
   return isFirstPartyTileUrl(e.error?.url);
 }
 
+/** fix(#907): the raster tile-auth case a session refresh can actually cure —
+ * a 401, i.e. the credential expired. A 403 is an upstream denial (Titiler or
+ * its object store passes that status through), so a fresh JWT changes
+ * nothing: suppressing it during a renewal would hide a real failure behind a
+ * window that then closes with no further request, leaving a blank map and no
+ * error overlay. */
+export function isRefreshableRasterAuthError(e: MapLibreErrorLike): boolean {
+  return e.error?.status === 401 && isRasterTileUrl(e.error?.url);
+}
+
 /** fix(#890): a 401/403 on a raster/DEM tile — the one tile-auth case NO
  * surface can recover (see `isRasterTileUrl`). Surfaces use it to skip their
  * vector re-sign / re-mint path so the failure surfaces once (toast + this
@@ -84,6 +94,6 @@ export function isRasterTileAuthError(e: MapLibreErrorLike): boolean {
  * raster auth failure is unrecoverable and still logs, exactly as #890 made it. */
 export function logUnhandledMapError(e: MapLibreErrorLike): void {
   if (isHandledTileAuthError(e)) return;
-  if (isRasterTileAuthError(e) && isSessionRenewalPending()) return;
+  if (isRefreshableRasterAuthError(e) && isSessionRenewalPending()) return;
   console.error(e.error);
 }

--- a/frontend/src/lib/tile-utils.ts
+++ b/frontend/src/lib/tile-utils.ts
@@ -204,3 +204,46 @@ export function buildClusterTileUrl(
     ...(cols ? { cols } : {}),
   });
 }
+
+/**
+ * fix(#907): reload every raster/DEM source's tiles after the session JWT has
+ * been renewed.
+ *
+ * Renewing the credential is not enough on its own. MapLibre resumes its own
+ * tile fetches the moment the tab is visible, which races the refresh round
+ * trip, so some raster requests still go out with the old Bearer and 401. A
+ * raster descriptor does not change across a refresh (its `tile_url` is stable
+ * and auth rides the Authorization header), so nothing in the token→setTiles
+ * plumbing fires and those errored tiles are never retried — the map keeps the
+ * holes until the user pans.
+ *
+ * `refreshTiles` is MapLibre's own reload-in-place API (the same one #584 uses
+ * to survive a paused TileManager) and needs no URL change, so this is
+ * idempotent and safe to call when nothing failed.
+ */
+export function refreshRasterTileSources(map: MaplibreMapLike | null | undefined): number {
+  if (!map) return 0;
+  let sources: Record<string, { type?: string }> | undefined;
+  try {
+    sources = map.getStyle?.()?.sources as Record<string, { type?: string }> | undefined;
+  } catch {
+    return 0; // style torn down mid-refresh
+  }
+  let refreshed = 0;
+  for (const [sourceId, source] of Object.entries(sources ?? {})) {
+    if (source?.type !== 'raster' && source?.type !== 'raster-dem') continue;
+    try {
+      map.refreshTiles?.(sourceId);
+      refreshed += 1;
+    } catch {
+      /* source removed between the read and the refresh */
+    }
+  }
+  return refreshed;
+}
+
+/** The structural subset of the MapLibre map that `refreshRasterTileSources` uses. */
+export interface MaplibreMapLike {
+  getStyle?: () => { sources?: Record<string, unknown> } | undefined;
+  refreshTiles?: (sourceId: string) => void;
+}


### PR DESCRIPTION
## What changed

Raster and DEM tiles authenticate with the session JWT via `buildTileTransformRequest`'s `Authorization` header, not with a signed tile sig. `hasExpiringVectorToken` only inspects `kind === 'vector'` tokens, so on a map with no vector layers the visible-edge refresh never fired and every DEM/raster tile 401'd once after a long hidden period.

This is a gate-condition change, not new machinery:

- `hasExpiringSession(expiresAt, nowMs)` in `hooks/use-tile-auth-recovery.ts` — the session-JWT half of the same 60 s skew window. `null` (anonymous / embed-token surfaces) is not expiring.
- `useVisibleTileTokenRefresh` fires when either the vector sig **or** the session JWT is inside that window.

The re-mint path is untouched. `RasterTileToken` is a real token kind returned by the same batch mint, so a raster-only map still has a live `useTileTokens` query; invalidating it re-runs `getTileTokensBatch` → `apiFetch` → `tryRefresh()`, which writes the fresh token into the store the raster `Bearer` header reads. The existing 30 s cooldown / 10 s settle still bound the mint rate, and it stays on the **visible** edge because MapLibre drops a `setTiles` reload while the tab is paused (#584).

## Security impact

None beyond the intent: no credential is broadened, and no refresh happens while signed out (`expiresAt === null` is a no-op).

## Verification

    cd frontend && npx vitest run src/hooks/__tests__/use-tile-auth-recovery.test.ts   # 29 passed
    cd frontend && npx vitest run src/components/viewer/__tests__/use-viewer-tokens.test.ts src/components/builder/__tests__/BuilderMap.token-visibility-refresh.test.tsx   # 12 passed
    cd frontend && npm run lint && npm run typecheck

Three new hook tests cover the raster-only map: expiring session re-mints, fresh session does not, and the hidden edge still no-ops.

Closes #907