### PR TITLE
chore(report): count distinct failures in the reporter badge

### DIFF
--- a/frontend/src/components/report/ReportProblemHost.tsx
+++ b/frontend/src/components/report/ReportProblemHost.tsx
@@ -1,7 +1,7 @@
 import { useTranslation } from 'react-i18next';
 import { LifeBuoy } from 'lucide-react';
 import { useAuthStore } from '@/stores/auth-store';
-import { useReportDialog, useReportEntries } from '@/lib/report';
+import { countDistinctFailures, useReportDialog, useReportEntries } from '@/lib/report';
 import { cn } from '@/lib/utils';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { ReportProblemWizard } from './ReportProblemWizard';
@@ -25,7 +25,9 @@ export function ReportProblemHost() {
 
   if (!token) return null;
 
-  const errorCount = entries.reduce((count, entry) => count + (entry.severity === 'error' ? 1 : 0), 0);
+  // fix(#908): distinct failures, not rows — one unrecovered map error writes
+  // both a `maplibre` row and a `console` row, and the badge used to read "2".
+  const errorCount = countDistinctFailures(entries);
   const hasErrors = errorCount > 0;
   const badge = errorCount > 9 ? '9+' : String(errorCount);
 

--- a/frontend/src/components/report/__tests__/ReportProblemHost.test.tsx
+++ b/frontend/src/components/report/__tests__/ReportProblemHost.test.tsx
@@ -34,6 +34,29 @@ describe('ReportProblemHost', () => {
     expect(screen.getByText('1')).toBeInTheDocument();
   });
 
+  // fix(#908): the badge counts distinct failures. An unrecovered tile error
+  // writes both a `maplibre` row (which carries the sourceId) and a `console`
+  // row from logUnhandledMapError, and it used to read "2" for one failure.
+  it('counts one failure for the maplibre + console pair a 5xx tile writes', async () => {
+    signIn();
+    render(<ReportProblemHost />);
+    pushReportEntry({
+      severity: 'error',
+      source: 'maplibre',
+      message: 'AJAXError: Internal Server Error (500)',
+      detail: 'source: dataset-abc',
+    });
+    pushReportEntry({
+      severity: 'error',
+      source: 'console',
+      message: 'AJAXError: Internal Server Error (500)',
+    });
+
+    const button = await screen.findByRole('button', { name: /report a problem/i });
+    expect(button).toBeInTheDocument();
+    expect(screen.getByText('1')).toBeInTheDocument();
+  });
+
   it('opens the wizard from the floating button', async () => {
     signIn();
     render(<ReportProblemHost />);

--- a/frontend/src/hooks/use-tile-token.ts
+++ b/frontend/src/hooks/use-tile-token.ts
@@ -41,6 +41,12 @@ export function useTileToken(datasetId: string | undefined) {
       return Math.max(d.expires_in * 800, 30_000);
     },
     staleTime: 60_000,
+    // fix(#908): explicit because it is the whole hidden-tab policy — a hidden
+    // tab must not refresh, since MapLibre drops the resulting setTiles reload
+    // while the source's TileManager is paused (fix(#584)). It matched the
+    // TanStack default before, which is exactly what made the #755 403 burst
+    // guaranteed rather than probabilistic.
+    refetchIntervalInBackground: false,
   });
 }
 
@@ -88,6 +94,9 @@ export function useTileTokens(datasetIds: string[]) {
       if (!isFinite(minVectorExpiry)) return false;
       return Math.max(minVectorExpiry * 800, 30_000);
     },
+    // fix(#908): see useTileToken above — the hidden-tab policy is stated at
+    // every site rather than inherited from the TanStack default.
+    refetchIntervalInBackground: false,
   });
 
   // Adapt the batch result into the { data, isLoading, isError } shape that

--- a/frontend/src/lib/report/__tests__/report-buffer.test.ts
+++ b/frontend/src/lib/report/__tests__/report-buffer.test.ts
@@ -124,6 +124,44 @@ describe('countDistinctFailures (fix #908)', () => {
     expect(countDistinctFailures(getReportEntries())).toBe(2);
   });
 
+  // codex on #908: MapLibre puts the failing tile URL in the AJAXError message,
+  // so without normalization one broken source counts once per visible tile and
+  // the badge still runs to 9+.
+  it('counts one failure for every failing tile of the same source', () => {
+    for (const [z, x, y] of [[12, 1205, 1539], [12, 1206, 1539], [12, 1205, 1540]]) {
+      pushReportEntry({
+        severity: 'error',
+        source: 'maplibre',
+        message: `AJAXError: Internal Server Error (500): /api/tiles/data.parcels/${z}/${x}/${y}.pbf?sig=abc`,
+      });
+    }
+
+    expect(getReportEntries()).toHaveLength(3);
+    expect(countDistinctFailures(getReportEntries())).toBe(1);
+  });
+
+  it('keeps two different failing sources apart', () => {
+    pushReportEntry({
+      severity: 'error',
+      source: 'maplibre',
+      message: 'AJAXError: Internal Server Error (500): /api/tiles/data.parcels/12/1/1.pbf',
+    });
+    pushReportEntry({
+      severity: 'error',
+      source: 'maplibre',
+      message: 'AJAXError: Internal Server Error (500): /api/tiles/data.roads/12/1/1.pbf',
+    });
+
+    expect(countDistinctFailures(getReportEntries())).toBe(2);
+  });
+
+  it('leaves a message with no tile coordinates alone', () => {
+    pushReportEntry({ severity: 'error', source: 'runtime', message: 'Cannot read x of undefined' });
+    pushReportEntry({ severity: 'error', source: 'runtime', message: 'Cannot read y of undefined' });
+
+    expect(countDistinctFailures(getReportEntries())).toBe(2);
+  });
+
   it('ignores warnings and info rows', () => {
     pushReportEntry({ severity: 'warning', source: 'maplibre', message: 'no-data tile (404)' });
     reportTileTokenRemint('builder', 'tab-return');

--- a/frontend/src/lib/report/__tests__/report-buffer.test.ts
+++ b/frontend/src/lib/report/__tests__/report-buffer.test.ts
@@ -254,6 +254,37 @@ describe('countDistinctFailures (fix #908)', () => {
     expect(countDistinctFailures(getReportEntries())).toBe(1);
   });
 
+  it('collapses a broken quadkey basemap at low zoom too', () => {
+    // A quadkey's length IS the zoom level, so zoom 1-5 keys are 1-5 digits.
+    for (const quadkey of ['0', '03', '031', '0313', '03131']) {
+      pushReportEntry({
+        severity: 'error',
+        source: 'maplibre',
+        message: `AJAXError: Not Found (404): https://tiles.example.com/${quadkey}.png`,
+        detail: 'source: basemap',
+      });
+    }
+
+    expect(countDistinctFailures(getReportEntries())).toBe(1);
+  });
+
+  it('does not collapse two sources that merely share a short path segment', () => {
+    pushReportEntry({
+      severity: 'error',
+      source: 'maplibre',
+      message: 'AJAXError: Not Found (404): https://a.example.com/2/style/tiles.json',
+      detail: 'source: a',
+    });
+    pushReportEntry({
+      severity: 'error',
+      source: 'maplibre',
+      message: 'AJAXError: Not Found (404): https://a.example.com/2/other/tiles.json',
+      detail: 'source: b',
+    });
+
+    expect(countDistinctFailures(getReportEntries())).toBe(2);
+  });
+
   it('collapses a broken bbox-addressed basemap to one failure', () => {
     for (const bbox of ['-20037508,0,0,20037508', '0,0,20037508,20037508']) {
       pushReportEntry({

--- a/frontend/src/lib/report/__tests__/report-buffer.test.ts
+++ b/frontend/src/lib/report/__tests__/report-buffer.test.ts
@@ -188,6 +188,29 @@ describe('countDistinctFailures (fix #908)', () => {
     expect(countDistinctFailures(getReportEntries())).toBe(2);
   });
 
+  // codex round 3 on #908: message-only correlation is for the maplibre/console
+  // pair. Two boundaries throwing the same common message from different panels
+  // are two failures. (Back-to-back identical rows are collapsed by the buffer
+  // itself, so this is the interleaved case — the one the key decides.)
+  it('keeps same-message failures from different panels apart', () => {
+    pushReportEntry({
+      severity: 'error',
+      source: 'react',
+      message: 'Cannot read properties of undefined',
+      detail: 'at LayerPanel',
+    });
+    pushReportEntry({ severity: 'error', source: 'runtime', message: 'unrelated' });
+    pushReportEntry({
+      severity: 'error',
+      source: 'react',
+      message: 'Cannot read properties of undefined',
+      detail: 'at AnalysisPanel',
+    });
+
+    expect(getReportEntries()).toHaveLength(3);
+    expect(countDistinctFailures(getReportEntries())).toBe(3);
+  });
+
   it('ignores warnings and info rows', () => {
     pushReportEntry({ severity: 'warning', source: 'maplibre', message: 'no-data tile (404)' });
     reportTileTokenRemint('builder', 'tab-return');

--- a/frontend/src/lib/report/__tests__/report-buffer.test.ts
+++ b/frontend/src/lib/report/__tests__/report-buffer.test.ts
@@ -347,6 +347,22 @@ describe('countDistinctFailures (fix #908)', () => {
     expect(countDistinctFailures(getReportEntries())).toBe(1);
   });
 
+  // codex round 7 on #908: {ratio} resolves to an @2x suffix on a retina
+  // display. Note what the buffer actually stores: redact() runs at capture and
+  // reads `/1539@2x.png` as an email, so the y coordinate is already gone by
+  // the time the key is computed.
+  it('collapses a retina source whose tiles carry an @2x suffix', () => {
+    for (const [x, y] of [[1205, 1539], [1206, 1539], [1205, 1540]]) {
+      pushReportEntry({
+        severity: 'error',
+        source: 'console',
+        message: `AJAXError: Not Found (404): https://tiles.example.com/12/${x}/${y}@2x.png`,
+      });
+    }
+
+    expect(countDistinctFailures(getReportEntries())).toBe(1);
+  });
+
   it('ignores warnings and info rows', () => {
     pushReportEntry({ severity: 'warning', source: 'maplibre', message: 'no-data tile (404)' });
     reportTileTokenRemint('builder', 'tab-return');

--- a/frontend/src/lib/report/__tests__/report-buffer.test.ts
+++ b/frontend/src/lib/report/__tests__/report-buffer.test.ts
@@ -500,6 +500,20 @@ describe('countDistinctFailures (fix #908)', () => {
     expect(countDistinctFailures(getReportEntries())).toBe(2);
   });
 
+  // codex round 16 on #908: a style may define a source id containing spaces,
+  // and stopping the parse at whitespace merged two of them.
+  it('keeps two sources apart when their ids share a first word', () => {
+    const message = 'AJAXError: Not Found (404): https://tiles.example.com/5/1/1.png';
+    // Interleaved: the buffer's own collapse compares the message and ignores
+    // detail, so back-to-back rows would merge before the key is ever computed.
+    pushReportEntry({ severity: 'error', source: 'maplibre', message, detail: 'source: terrain primary' });
+    pushReportEntry({ severity: 'error', source: 'runtime', message: 'unrelated' });
+    pushReportEntry({ severity: 'error', source: 'maplibre', message, detail: 'source: terrain fallback' });
+
+    // Two map sources plus the unrelated runtime error.
+    expect(countDistinctFailures(getReportEntries())).toBe(3);
+  });
+
   it('ignores warnings and info rows', () => {
     pushReportEntry({ severity: 'warning', source: 'maplibre', message: 'no-data tile (404)' });
     reportTileTokenRemint('builder', 'tab-return');

--- a/frontend/src/lib/report/__tests__/report-buffer.test.ts
+++ b/frontend/src/lib/report/__tests__/report-buffer.test.ts
@@ -333,18 +333,20 @@ describe('countDistinctFailures (fix #908)', () => {
     expect(countDistinctFailures(getReportEntries())).toBe(1);
   });
 
-  // codex round 6 on #908: MapLibre substitutes {prefix} wherever it appears,
-  // so it can be a path segment rather than a host label.
-  it('collapses a console-only source sharded by a path-segment prefix', () => {
-    for (const [prefix, x] of [['00', 1], ['a3', 2], ['ff', 3]] as const) {
+  // codex round 6/7 on #908: a resolved path-segment {prefix} cannot be told
+  // apart from a meaningful static segment in a single URL, so it is left
+  // alone — keeping two real sources distinct matters more to a problem
+  // reporter than collapsing a sharded one.
+  it('keeps two sources apart when they differ only by a short path segment', () => {
+    for (const region of ['ca', 'de']) {
       pushReportEntry({
         severity: 'error',
         source: 'console',
-        message: `AJAXError: Not Found (404): https://tiles.example.com/${prefix}/5/${x}/1.png`,
+        message: `AJAXError: Not Found (404): https://tiles.example.com/${region}/5/1/1.png`,
       });
     }
 
-    expect(countDistinctFailures(getReportEntries())).toBe(1);
+    expect(countDistinctFailures(getReportEntries())).toBe(2);
   });
 
   // codex round 7 on #908: {ratio} resolves to an @2x suffix on a retina

--- a/frontend/src/lib/report/__tests__/report-buffer.test.ts
+++ b/frontend/src/lib/report/__tests__/report-buffer.test.ts
@@ -298,6 +298,41 @@ describe('countDistinctFailures (fix #908)', () => {
     expect(countDistinctFailures(getReportEntries())).toBe(1);
   });
 
+  // codex round 5 on #908: MapLibre's {prefix} resolves to a per-tile shard
+  // label in the hostname, so one broken sharded basemap otherwise counts once
+  // per tile.
+  it('collapses a sharded basemap by source id and by hostname', () => {
+    for (const [shard, z, x, y] of [['a', 5, 1, 1], ['b7', 5, 2, 1], ['c', 5, 3, 1]] as const) {
+      pushReportEntry({
+        severity: 'error',
+        source: 'maplibre',
+        message: `AJAXError: Not Found (404): https://${shard}.tiles.example.com/${z}/${x}/${y}.png`,
+        detail: 'source: basemap',
+      });
+      // The console echo carries no source id, so it leans on the hostname
+      // normalization instead.
+      pushReportEntry({
+        severity: 'error',
+        source: 'console',
+        message: `AJAXError: Not Found (404): https://${shard}.tiles.example.com/${z}/${x}/${y}.png`,
+      });
+    }
+
+    expect(countDistinctFailures(getReportEntries())).toBe(1);
+  });
+
+  it('counts a console-only sharded failure once (viewer and preview)', () => {
+    for (const shard of ['a', 'b', 'c9']) {
+      pushReportEntry({
+        severity: 'error',
+        source: 'console',
+        message: `AJAXError: Not Found (404): https://${shard}.tiles.example.com/5/1/1.png`,
+      });
+    }
+
+    expect(countDistinctFailures(getReportEntries())).toBe(1);
+  });
+
   it('ignores warnings and info rows', () => {
     pushReportEntry({ severity: 'warning', source: 'maplibre', message: 'no-data tile (404)' });
     reportTileTokenRemint('builder', 'tab-return');

--- a/frontend/src/lib/report/__tests__/report-buffer.test.ts
+++ b/frontend/src/lib/report/__tests__/report-buffer.test.ts
@@ -474,6 +474,32 @@ describe('countDistinctFailures (fix #908)', () => {
     expect(countDistinctFailures(getReportEntries())).toBe(1);
   });
 
+  // codex round 15 on #908: an accepted template may label its coordinates
+  // (`/z/{z}/x/{x}/y/{y}`), which no consecutive-segment rule can see.
+  it('collapses coordinates carried behind path labels', () => {
+    for (const [x, y] of [[1205, 1539], [1206, 1539], [1205, 1540]]) {
+      pushReportEntry({
+        severity: 'error',
+        source: 'console',
+        message: `AJAXError: Not Found (404): https://tiles.example.com/z/12/x/${x}/y/${y}.png`,
+      });
+    }
+
+    expect(countDistinctFailures(getReportEntries())).toBe(1);
+  });
+
+  it('does not mistake a labelled version for a coordinate', () => {
+    for (const version of [1, 2]) {
+      pushReportEntry({
+        severity: 'error',
+        source: 'console',
+        message: `AJAXError: Not Found (404): https://tiles.example.com/v/${version}/z/12/x/1/y/1.png`,
+      });
+    }
+
+    expect(countDistinctFailures(getReportEntries())).toBe(2);
+  });
+
   it('ignores warnings and info rows', () => {
     pushReportEntry({ severity: 'warning', source: 'maplibre', message: 'no-data tile (404)' });
     reportTileTokenRemint('builder', 'tab-return');

--- a/frontend/src/lib/report/__tests__/report-buffer.test.ts
+++ b/frontend/src/lib/report/__tests__/report-buffer.test.ts
@@ -365,6 +365,21 @@ describe('countDistinctFailures (fix #908)', () => {
     expect(countDistinctFailures(getReportEntries())).toBe(1);
   });
 
+  // codex round 8 on #908: toMaplibreStyle gives every custom basemap the fixed
+  // source id `basemap`, so the id alone merged two different failing basemaps.
+  it('keeps two custom basemaps apart despite their shared source id', () => {
+    for (const host of ['a-tiles.example.com', 'b-tiles.example.com']) {
+      pushReportEntry({
+        severity: 'error',
+        source: 'maplibre',
+        message: `AJAXError: Not Found (404): https://${host}/5/1/1.png`,
+        detail: 'source: basemap',
+      });
+    }
+
+    expect(countDistinctFailures(getReportEntries())).toBe(2);
+  });
+
   it('ignores warnings and info rows', () => {
     pushReportEntry({ severity: 'warning', source: 'maplibre', message: 'no-data tile (404)' });
     reportTileTokenRemint('builder', 'tab-return');

--- a/frontend/src/lib/report/__tests__/report-buffer.test.ts
+++ b/frontend/src/lib/report/__tests__/report-buffer.test.ts
@@ -333,6 +333,20 @@ describe('countDistinctFailures (fix #908)', () => {
     expect(countDistinctFailures(getReportEntries())).toBe(1);
   });
 
+  // codex round 6 on #908: MapLibre substitutes {prefix} wherever it appears,
+  // so it can be a path segment rather than a host label.
+  it('collapses a console-only source sharded by a path-segment prefix', () => {
+    for (const [prefix, x] of [['00', 1], ['a3', 2], ['ff', 3]] as const) {
+      pushReportEntry({
+        severity: 'error',
+        source: 'console',
+        message: `AJAXError: Not Found (404): https://tiles.example.com/${prefix}/5/${x}/1.png`,
+      });
+    }
+
+    expect(countDistinctFailures(getReportEntries())).toBe(1);
+  });
+
   it('ignores warnings and info rows', () => {
     pushReportEntry({ severity: 'warning', source: 'maplibre', message: 'no-data tile (404)' });
     reportTileTokenRemint('builder', 'tab-return');

--- a/frontend/src/lib/report/__tests__/report-buffer.test.ts
+++ b/frontend/src/lib/report/__tests__/report-buffer.test.ts
@@ -301,36 +301,22 @@ describe('countDistinctFailures (fix #908)', () => {
   // codex round 5 on #908: MapLibre's {prefix} resolves to a per-tile shard
   // label in the hostname, so one broken sharded basemap otherwise counts once
   // per tile.
-  it('collapses a sharded basemap by source id and by hostname', () => {
-    for (const [shard, z, x, y] of [['a', 5, 1, 1], ['b7', 5, 2, 1], ['c', 5, 3, 1]] as const) {
+  // codex rounds 6-9 on #908: a resolved `{prefix}` shard cannot be told apart
+  // from a meaningful short label in a single URL — `a.tiles…` looks exactly
+  // like `ca.tiles…`, and both basemaps carry the fixed source id `basemap`.
+  // Guessing merged two genuinely different basemaps, so this keeps them
+  // distinct and accepts that one sharded source may be counted more than once.
+  it('keeps two basemaps apart when they differ only by a short host label', () => {
+    for (const region of ['ca', 'de']) {
       pushReportEntry({
         severity: 'error',
         source: 'maplibre',
-        message: `AJAXError: Not Found (404): https://${shard}.tiles.example.com/${z}/${x}/${y}.png`,
+        message: `AJAXError: Not Found (404): https://${region}.tiles.example.com/5/1/1.png`,
         detail: 'source: basemap',
       });
-      // The console echo carries no source id, so it leans on the hostname
-      // normalization instead.
-      pushReportEntry({
-        severity: 'error',
-        source: 'console',
-        message: `AJAXError: Not Found (404): https://${shard}.tiles.example.com/${z}/${x}/${y}.png`,
-      });
     }
 
-    expect(countDistinctFailures(getReportEntries())).toBe(1);
-  });
-
-  it('counts a console-only sharded failure once (viewer and preview)', () => {
-    for (const shard of ['a', 'b', 'c9']) {
-      pushReportEntry({
-        severity: 'error',
-        source: 'console',
-        message: `AJAXError: Not Found (404): https://${shard}.tiles.example.com/5/1/1.png`,
-      });
-    }
-
-    expect(countDistinctFailures(getReportEntries())).toBe(1);
+    expect(countDistinctFailures(getReportEntries())).toBe(2);
   });
 
   // codex round 6/7 on #908: a resolved path-segment {prefix} cannot be told

--- a/frontend/src/lib/report/__tests__/report-buffer.test.ts
+++ b/frontend/src/lib/report/__tests__/report-buffer.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import {
   clearReportEntries,
+  countDistinctFailures,
   getReportEntries,
   pushReportEntry,
   reportNetworkError,
@@ -92,5 +93,45 @@ describe('reportTileTokenRemint', () => {
     const entries = getReportEntries();
     expect(entries).toHaveLength(1);
     expect(entries[0].count).toBe(2);
+  });
+});
+
+// fix(#908): one unrecovered map failure writes two error rows — a `maplibre`
+// row carrying the sourceId and a `console` row derived from
+// logUnhandledMapError. Both are worth keeping; counting them both is not.
+describe('countDistinctFailures (fix #908)', () => {
+  it('counts one failure for the maplibre + console pair a 5xx tile writes', () => {
+    pushReportEntry({
+      severity: 'error',
+      source: 'maplibre',
+      message: 'AJAXError: Internal Server Error (500)',
+      detail: 'source: dataset-abc',
+    });
+    pushReportEntry({
+      severity: 'error',
+      source: 'console',
+      message: 'AJAXError: Internal Server Error (500)',
+    });
+
+    expect(getReportEntries()).toHaveLength(2);
+    expect(countDistinctFailures(getReportEntries())).toBe(1);
+  });
+
+  it('still counts genuinely different failures separately', () => {
+    pushReportEntry({ severity: 'error', source: 'maplibre', message: 'tile 500' });
+    pushReportEntry({ severity: 'error', source: 'runtime', message: 'Cannot read x of undefined' });
+
+    expect(countDistinctFailures(getReportEntries())).toBe(2);
+  });
+
+  it('ignores warnings and info rows', () => {
+    pushReportEntry({ severity: 'warning', source: 'maplibre', message: 'no-data tile (404)' });
+    reportTileTokenRemint('builder', 'tab-return');
+
+    expect(countDistinctFailures(getReportEntries())).toBe(0);
+  });
+
+  it('is zero on an empty buffer', () => {
+    expect(countDistinctFailures(getReportEntries())).toBe(0);
   });
 });

--- a/frontend/src/lib/report/__tests__/report-buffer.test.ts
+++ b/frontend/src/lib/report/__tests__/report-buffer.test.ts
@@ -366,6 +366,20 @@ describe('countDistinctFailures (fix #908)', () => {
     expect(countDistinctFailures(getReportEntries())).toBe(2);
   });
 
+  // codex round 10 on #908: a validator-accepted template may put a static
+  // suffix after the coordinates, which every shape-anchored rule missed.
+  it('collapses coordinates followed by a static path suffix', () => {
+    for (const [x, y] of [[1205, 1539], [1206, 1539], [1205, 1540]]) {
+      pushReportEntry({
+        severity: 'error',
+        source: 'console',
+        message: `AJAXError: Not Found (404): https://tiles.example.com/12/${x}/${y}/tile.png`,
+      });
+    }
+
+    expect(countDistinctFailures(getReportEntries())).toBe(1);
+  });
+
   it('ignores warnings and info rows', () => {
     pushReportEntry({ severity: 'warning', source: 'maplibre', message: 'no-data tile (404)' });
     reportTileTokenRemint('builder', 'tab-return');

--- a/frontend/src/lib/report/__tests__/report-buffer.test.ts
+++ b/frontend/src/lib/report/__tests__/report-buffer.test.ts
@@ -421,6 +421,18 @@ describe('countDistinctFailures (fix #908)', () => {
     expect(countDistinctFailures(getReportEntries())).toBe(1);
   });
 
+  it('keeps TileMatrixSet, which names the grid rather than a tile', () => {
+    for (const grid of ['EPSG:3857', 'EPSG:4326']) {
+      pushReportEntry({
+        severity: 'error',
+        source: 'console',
+        message: `AJAXError: Not Found (404): https://wmts.example.com/?TileMatrixSet=${grid}&TileMatrix=12&TileRow=1&TileCol=1`,
+      });
+    }
+
+    expect(countDistinctFailures(getReportEntries())).toBe(2);
+  });
+
   it('keeps a numeric source-defining param, which is not a coordinate', () => {
     for (const layer of [3, 4]) {
       pushReportEntry({

--- a/frontend/src/lib/report/__tests__/report-buffer.test.ts
+++ b/frontend/src/lib/report/__tests__/report-buffer.test.ts
@@ -140,6 +140,32 @@ describe('countDistinctFailures (fix #908)', () => {
     expect(countDistinctFailures(getReportEntries())).toBe(1);
   });
 
+  // codex round 2 on #908: dropping the whole query string merged two cluster
+  // layers over the same dataset, which are distinct sources.
+  it('keeps two cluster sources over one dataset apart', () => {
+    for (const radius of [50, 80]) {
+      pushReportEntry({
+        severity: 'error',
+        source: 'maplibre',
+        message: `AJAXError: Internal Server Error (500): /api/tiles/clusters/data.trees/12/1/1.pbf?cluster_radius=${radius}&sig=abc`,
+      });
+    }
+
+    expect(countDistinctFailures(getReportEntries())).toBe(2);
+  });
+
+  it('still collapses the same source across a rotated sig', () => {
+    for (const sig of ['abc', 'def']) {
+      pushReportEntry({
+        severity: 'error',
+        source: 'maplibre',
+        message: `AJAXError: Internal Server Error (500): /api/tiles/data.parcels/12/1/1.pbf?sig=${sig}&exp=1`,
+      });
+    }
+
+    expect(countDistinctFailures(getReportEntries())).toBe(1);
+  });
+
   it('keeps two different failing sources apart', () => {
     pushReportEntry({
       severity: 'error',

--- a/frontend/src/lib/report/__tests__/report-buffer.test.ts
+++ b/frontend/src/lib/report/__tests__/report-buffer.test.ts
@@ -406,6 +406,33 @@ describe('countDistinctFailures (fix #908)', () => {
     expect(countDistinctFailures(getReportEntries())).toBe(2);
   });
 
+  // codex round 12 on #908: a template can name the coordinate params anything.
+  // The standard names are covered; a value-based rule is not, because
+  // `?layer=3` is numeric and source-defining.
+  it('collapses coordinates carried under WMTS parameter names', () => {
+    for (const [row, col] of [[1539, 1205], [1539, 1206], [1540, 1205]]) {
+      pushReportEntry({
+        severity: 'error',
+        source: 'console',
+        message: `AJAXError: Not Found (404): https://wmts.example.com/?TileMatrix=12&TileRow=${row}&TileCol=${col}`,
+      });
+    }
+
+    expect(countDistinctFailures(getReportEntries())).toBe(1);
+  });
+
+  it('keeps a numeric source-defining param, which is not a coordinate', () => {
+    for (const layer of [3, 4]) {
+      pushReportEntry({
+        severity: 'error',
+        source: 'console',
+        message: `AJAXError: Not Found (404): https://tiles.example.com/tile?layer=${layer}&z=5&x=1&y=1`,
+      });
+    }
+
+    expect(countDistinctFailures(getReportEntries())).toBe(2);
+  });
+
   it('ignores warnings and info rows', () => {
     pushReportEntry({ severity: 'warning', source: 'maplibre', message: 'no-data tile (404)' });
     reportTileTokenRemint('builder', 'tab-return');

--- a/frontend/src/lib/report/__tests__/report-buffer.test.ts
+++ b/frontend/src/lib/report/__tests__/report-buffer.test.ts
@@ -380,6 +380,32 @@ describe('countDistinctFailures (fix #908)', () => {
     expect(countDistinctFailures(getReportEntries())).toBe(1);
   });
 
+  // codex round 11 on #908: a template may carry the whole tile address in the
+  // query string, which the custom-basemap validator accepts.
+  it('collapses a source whose coordinates ride the query string', () => {
+    for (const [x, y] of [[1205, 1539], [1206, 1539], [1205, 1540]]) {
+      pushReportEntry({
+        severity: 'error',
+        source: 'console',
+        message: `AJAXError: Not Found (404): https://tiles.example.com/tile?z=12&x=${x}&y=${y}`,
+      });
+    }
+
+    expect(countDistinctFailures(getReportEntries())).toBe(1);
+  });
+
+  it('keeps a source-defining query param while dropping the coordinates', () => {
+    for (const layer of ['roads', 'rivers']) {
+      pushReportEntry({
+        severity: 'error',
+        source: 'console',
+        message: `AJAXError: Not Found (404): https://wms.example.com/?layer=${layer}&Z=5&X=1&Y=1`,
+      });
+    }
+
+    expect(countDistinctFailures(getReportEntries())).toBe(2);
+  });
+
   it('ignores warnings and info rows', () => {
     pushReportEntry({ severity: 'warning', source: 'maplibre', message: 'no-data tile (404)' });
     reportTileTokenRemint('builder', 'tab-return');

--- a/frontend/src/lib/report/__tests__/report-buffer.test.ts
+++ b/frontend/src/lib/report/__tests__/report-buffer.test.ts
@@ -211,6 +211,62 @@ describe('countDistinctFailures (fix #908)', () => {
     expect(countDistinctFailures(getReportEntries())).toBe(3);
   });
 
+  // codex round 4 on #908: getSourceIdForLayer gives each cluster layer its own
+  // MapLibre source, so two broken layers over one dataset can fail with
+  // byte-identical URLs. Those are two failures.
+  it('keeps two failing map sources apart even with identical urls', () => {
+    const message = 'AJAXError: Internal Server Error (500): /api/tiles/data.trees/12/1/1.pbf';
+    // Interleaved with the console echo each one produces, which is also how
+    // they arrive: back-to-back rows are collapsed by the buffer itself, which
+    // compares the message and ignores detail.
+    for (const sourceId of ['layer-a-src', 'layer-b-src']) {
+      pushReportEntry({ severity: 'error', source: 'maplibre', message, detail: `source: ${sourceId}` });
+      pushReportEntry({ severity: 'error', source: 'console', message });
+    }
+
+    expect(getReportEntries()).toHaveLength(4);
+    // Two broken layers; both console echoes are the other halves.
+    expect(countDistinctFailures(getReportEntries())).toBe(2);
+  });
+
+  it('counts a console-only failure (viewer and dataset preview push no row)', () => {
+    pushReportEntry({
+      severity: 'error',
+      source: 'console',
+      message: 'AJAXError: Internal Server Error (500): /api/tiles/data.parcels/12/1/1.pbf',
+    });
+
+    expect(countDistinctFailures(getReportEntries())).toBe(1);
+  });
+
+  // codex round 4 on #908: an admin-configured remote style may address tiles by
+  // quadkey or bbox, where there is no z/x/y triple to normalize.
+  it('collapses a broken quadkey-addressed basemap to one failure', () => {
+    for (const quadkey of ['0313102310', '0313102311', '0313102312']) {
+      pushReportEntry({
+        severity: 'error',
+        source: 'maplibre',
+        message: `AJAXError: Not Found (404): https://tiles.example.com/${quadkey}.png`,
+        detail: 'source: basemap',
+      });
+    }
+
+    expect(countDistinctFailures(getReportEntries())).toBe(1);
+  });
+
+  it('collapses a broken bbox-addressed basemap to one failure', () => {
+    for (const bbox of ['-20037508,0,0,20037508', '0,0,20037508,20037508']) {
+      pushReportEntry({
+        severity: 'error',
+        source: 'maplibre',
+        message: `AJAXError: Not Found (404): https://wms.example.com/?service=WMS&bbox=${bbox}`,
+        detail: 'source: basemap',
+      });
+    }
+
+    expect(countDistinctFailures(getReportEntries())).toBe(1);
+  });
+
   it('ignores warnings and info rows', () => {
     pushReportEntry({ severity: 'warning', source: 'maplibre', message: 'no-data tile (404)' });
     reportTileTokenRemint('builder', 'tab-return');

--- a/frontend/src/lib/report/__tests__/report-buffer.test.ts
+++ b/frontend/src/lib/report/__tests__/report-buffer.test.ts
@@ -445,6 +445,35 @@ describe('countDistinctFailures (fix #908)', () => {
     expect(countDistinctFailures(getReportEntries())).toBe(2);
   });
 
+  // codex round 14 on #908: normalizing every numeric segment merged two
+  // sources that differ only by a numeric version, tenant, or region.
+  it('keeps a numeric version segment while still collapsing the coordinates', () => {
+    for (const version of [1, 2]) {
+      for (const [x, y] of [[1205, 1539], [1206, 1539]]) {
+        pushReportEntry({
+          severity: 'error',
+          source: 'console',
+          message: `AJAXError: Not Found (404): https://tiles.example.com/v/${version}/12/${x}/${y}.png`,
+        });
+      }
+    }
+
+    // Two sources, each with its tiles collapsed — not one, and not four.
+    expect(countDistinctFailures(getReportEntries())).toBe(2);
+  });
+
+  it('collapses a quadkey behind a numeric version segment', () => {
+    for (const quadkey of ['0313102310', '0313102311']) {
+      pushReportEntry({
+        severity: 'error',
+        source: 'console',
+        message: `AJAXError: Not Found (404): https://tiles.example.com/v/2/${quadkey}.png`,
+      });
+    }
+
+    expect(countDistinctFailures(getReportEntries())).toBe(1);
+  });
+
   it('ignores warnings and info rows', () => {
     pushReportEntry({ severity: 'warning', source: 'maplibre', message: 'no-data tile (404)' });
     reportTileTokenRemint('builder', 'tab-return');

--- a/frontend/src/lib/report/index.ts
+++ b/frontend/src/lib/report/index.ts
@@ -4,6 +4,7 @@ export {
   reportNetworkError,
   reportTileTokenRemint,
   clearReportEntries,
+  countDistinctFailures,
   getReportEntries,
   useReportEntries,
 } from './report-buffer';

--- a/frontend/src/lib/report/report-buffer.ts
+++ b/frontend/src/lib/report/report-buffer.ts
@@ -168,13 +168,11 @@ export function countDistinctFailures(list: ReportEntry[]): number {
     if (entry.severity !== 'error') continue;
     const message = failureKey(entry.message);
     if (entry.source === 'maplibre') {
-      // Prefer the MapLibre source id outright: it is the ground truth for
-      // "which thing is broken", and it sidesteps every way one source's tile
-      // URLs can differ from each other (coordinates, shard prefixes, rotating
-      // sigs). Fall back to the message for style and glyph errors, which
-      // carry no source.
-      const sourceId = sourceIdOf(entry);
-      mapFailures.add(sourceId ? `src\u0000${sourceId}` : `msg\u0000${message}`);
+      // Source id AND normalized message, not either alone. The id separates
+      // two cluster layers over one dataset, which fail with byte-identical
+      // URLs; the message separates two custom basemaps, which `toMaplibreStyle`
+      // both hands the fixed source id `basemap`. Neither is unique on its own.
+      mapFailures.add(`${message}\u0000${sourceIdOf(entry)}`);
       mapMessages.add(message);
     } else if (entry.source === 'console') {
       consoleOnly.add(message);

--- a/frontend/src/lib/report/report-buffer.ts
+++ b/frontend/src/lib/report/report-buffer.ts
@@ -139,6 +139,27 @@ export function reportTileTokenRemint(surface: string, trigger: string): void {
   });
 }
 
+/**
+ * fix(#908): how many distinct failures the buffer holds, not how many rows.
+ * Every unrecovered map error writes TWO error rows — a `maplibre` row from the
+ * surface handler (which carries the sourceId, so it cannot be dropped) and a
+ * `console` row derived from `logUnhandledMapError`'s console.error (which is
+ * the only trace the viewer and dataset preview leave at all). Both carry the
+ * same AJAXError message, so the message is the correlation key the rows
+ * already share, and counting distinct ones stops the badge reading "2 errors"
+ * for one broken tile source.
+ *
+ * Recurrences of the same message count once: the badge answers "how many
+ * things are wrong", and a tile source that fails again is the same thing.
+ */
+export function countDistinctFailures(list: ReportEntry[]): number {
+  const seen = new Set<string>();
+  for (const entry of list) {
+    if (entry.severity === 'error') seen.add(entry.message);
+  }
+  return seen.size;
+}
+
 function stringifyDetail(detail: unknown): string | undefined {
   if (detail == null) return undefined;
   if (typeof detail === 'string') return detail;

--- a/frontend/src/lib/report/report-buffer.ts
+++ b/frontend/src/lib/report/report-buffer.ts
@@ -246,8 +246,16 @@ function failureKey(message: string): string {
     // zoom-3 tile (`/031.png`) would stay a distinct key while a zoom-12 one
     // collapsed. Anchoring is what keeps a mid-path `/2/` from matching.
     .replace(/\/[0-3]+(@\d+x)?(\.\w+)?(?=[?\s]|$)/g, '/{quadkey}')
-    // …and only then the path-segment form of `{prefix}`, on what is left.
-    .replace(/\/[0-9a-f]{2}(?=\/)/gi, '/{prefix}')
+    // NOT the path-segment form of `{prefix}`. A resolved shard (`/a3/`) is
+    // indistinguishable from a meaningful static segment (`/ca/`, `/de/`) in a
+    // single URL — both are two hex-ish characters — so normalizing it merged
+    // two genuinely different sources into one. Between the two errors, the
+    // over-count is the safer one to keep: this is a problem REPORTER, and
+    // hiding a broken source is worse than counting a sharded one twice.
+    // A `{prefix}` in the HOST is still normalized above, where a one-or-two
+    // character first label is overwhelmingly a shard rather than a distinct
+    // host. Only console-only rows (viewer, dataset preview) are exposed at
+    // all; anything with a source id keys on that instead.
     .replace(/\?(\S*)/g, (_match, query: string) => {
       const kept = query
         .split('&')

--- a/frontend/src/lib/report/report-buffer.ts
+++ b/frontend/src/lib/report/report-buffer.ts
@@ -247,22 +247,46 @@ const VOLATILE_TILE_PARAMS = new Set([
 ]);
 
 function failureKey(message: string): string {
-  return message
-    // Every purely numeric path segment. That single rule covers each tile
-    // layout MapLibre supports — `{z}/{x}/{y}` with or without a static suffix
-    // (`/12/1205/1539/tile.png`), a leading numeric shard, and `{quadkey}`,
-    // which is all digits too. Anchoring on "is a number" rather than on a
-    // shape means a template this does not anticipate still normalizes.
-    // It also tolerates `redact()` having already eaten a `@2x` suffix as an
-    // email address (see the note above `pushReportEntry`): the surviving z/x
-    // segments still collapse.
-    .replace(/\/\d+(?=[/?.@\s]|$)/g, '/{n}')
-    .replace(/\?(\S*)/g, (_match, query: string) => {
-      const kept = query
-        .split('&')
-        .filter((pair) => pair && !VOLATILE_TILE_PARAMS.has(pair.split('=')[0].toLowerCase()));
-      return kept.length > 0 ? `?${kept.join('&')}` : '';
-    });
+  return stripVolatileParams(normalizeTileAddress(message));
+}
+
+/**
+ * Replace the tile address — and ONLY the tile address. Everything else in the
+ * path identifies the source: `/v/1/` and `/v/2/` are different sources even
+ * though both segments are numbers, so "normalize every numeric segment" is too
+ * broad, and a rule anchored on one exact URL shape is too narrow. This anchors
+ * on the shape that actually addresses a tile: three consecutive numeric
+ * segments (`{z}/{x}/{y}`) at the END of the path, with an extension and/or one
+ * static trailing segment allowed after them.
+ *
+ * The two passes exist because a regex prefers the LEFTmost match: allowing the
+ * trailing static segment up front lets `/v/1/12/1205/1539.png` match at `/1/12/1205`
+ * and swallow the version. Trying the tighter end-anchored form first pins the
+ * match to the right, and the looser form only runs when nothing matched.
+ */
+function normalizeTileAddress(message: string): string {
+  // `/12/1205/1539`, `/12/1205/1539.png`, or `/12/1205/[redacted-email]` (the
+  // `@2x` case, which redact() eats as an email), hard against the end or a query.
+  const withExtension = /\/\d+\/\d+\/(?:\d+(?:\.\w+)?|\[redacted-email\])(?=[?\s]|$)/g;
+  // `/12/1205/1539/tile.png` — coordinates followed by one static segment.
+  const withStaticSuffix = /\/\d+\/\d+\/\d+(?=\/[^/?\s]+(?:[?\s]|$))/g;
+  // A `{quadkey}`: one all-digit segment that IS the whole address.
+  const quadkey = /\/\d+(?:\.\w+)?(?=[?\s]|$)/g;
+
+  const xyz = message.replace(withExtension, '/{z}/{x}/{y}');
+  if (xyz !== message) return xyz;
+  const suffixed = message.replace(withStaticSuffix, '/{z}/{x}/{y}');
+  if (suffixed !== message) return suffixed;
+  return message.replace(quadkey, '/{tile}');
+}
+
+function stripVolatileParams(message: string): string {
+  return message.replace(/\?(\S*)/g, (_match, query: string) => {
+    const kept = query
+      .split('&')
+      .filter((pair) => pair && !VOLATILE_TILE_PARAMS.has(pair.split('=')[0].toLowerCase()));
+    return kept.length > 0 ? `?${kept.join('&')}` : '';
+  });
 }
 
 function stringifyDetail(detail: unknown): string | undefined {

--- a/frontend/src/lib/report/report-buffer.ts
+++ b/frontend/src/lib/report/report-buffer.ts
@@ -209,9 +209,9 @@ function sourceIdOf(entry: ReportEntry): string {
  *
  * Only the parts that vary WITHIN one source are dropped: the tile address in
  * each of MapLibre's supported forms — `{z}/{x}/{y}`, `{quadkey}`, the
- * `{bbox-epsg-3857}` query param, the `{prefix}` shard label, and the `{ratio}`
- * suffix a retina display resolves to `@2x`, all reachable through an
- * admin-configured remote style — and the rotating credential params.
+ * `{bbox-epsg-3857}` query param, and the `{ratio}` suffix a retina display
+ * resolves to `@2x`, all reachable through an admin-configured remote style —
+ * and the rotating credential params. NOT `{prefix}`; see below.
  * Everything that distinguishes one source from another stays — the rest of the
  * path, the status, and the `cols`/`cluster_radius`/`cluster_max_zoom` params.
  *
@@ -223,11 +223,6 @@ const VOLATILE_TILE_PARAMS = new Set(['sig', 'exp', 'scope', '_v', 'bbox', 'BBOX
 
 function failureKey(message: string): string {
   return message
-    // MapLibre's `{prefix}` resolves to two hex characters derived from the
-    // tile's x/y, and it may sit ANYWHERE in the template — a host label
-    // (`//a3.tiles…`) or a path segment (`/tiles/{prefix}/{z}/…`). Either way
-    // one sharded source otherwise yields a different URL per tile.
-    .replace(/(https?:\/\/)[0-9a-f]{1,2}\./gi, '$1{prefix}.')
     // Tile coordinates, anchored to the end of the path — that is where z/x/y
     // always sit, and anchoring is what keeps an all-numeric `{prefix}` segment
     // (`/00/5/1/1.png`) from being mistaken for the zoom.
@@ -244,16 +239,15 @@ function failureKey(message: string): string {
     // zoom-3 tile (`/031.png`) would stay a distinct key while a zoom-12 one
     // collapsed. Anchoring is what keeps a mid-path `/2/` from matching.
     .replace(/\/[0-3]+(@\d+x)?(\.\w+)?(?=[?\s]|$)/g, '/{quadkey}')
-    // NOT the path-segment form of `{prefix}`. A resolved shard (`/a3/`) is
-    // indistinguishable from a meaningful static segment (`/ca/`, `/de/`) in a
-    // single URL — both are two hex-ish characters — so normalizing it merged
-    // two genuinely different sources into one. Between the two errors, the
-    // over-count is the safer one to keep: this is a problem REPORTER, and
-    // hiding a broken source is worse than counting a sharded one twice.
-    // A `{prefix}` in the HOST is still normalized above, where a one-or-two
-    // character first label is overwhelmingly a shard rather than a distinct
-    // host. Only console-only rows (viewer, dataset preview) are exposed at
-    // all; anything with a source id keys on that instead.
+    // Deliberately NOT `{prefix}`, in the host or the path. A resolved shard
+    // (`a3.tiles…`, `/a3/`) is indistinguishable from a meaningful label
+    // (`ca.tiles…`, `/de/`) in a single URL — both are one or two hex-ish
+    // characters — and collapsing it merged two genuinely different basemaps.
+    // Between the two errors the over-count is the safer one to keep: this is a
+    // problem REPORTER, and hiding a broken source is worse than counting a
+    // sharded one more than once. So this function normalizes only what is
+    // unambiguously per-TILE — coordinates and credentials — and never guesses
+    // at what a host or path segment means.
     .replace(/\?(\S*)/g, (_match, query: string) => {
       const kept = query
         .split('&')

--- a/frontend/src/lib/report/report-buffer.ts
+++ b/frontend/src/lib/report/report-buffer.ts
@@ -223,15 +223,24 @@ function sourceIdOf(entry: ReportEntry): string {
  * it matters for the `console` rows the viewer and dataset preview leave
  * behind, which carry no source at all.
  */
-// Per-tile or rotating query params: the credential set, and every form
-// MapLibre can substitute a coordinate into. A template may put the whole tile
-// address in the query (`?z={z}&x={x}&y={y}`), which the custom-basemap
-// validator accepts, so those names are as per-tile as a path segment is.
-// Matched case-insensitively — the same params appear upper-cased in WMS-style
-// templates.
+// Per-tile or rotating query params: the credential set, plus the coordinate
+// names a tile template can use. A template may put the whole tile address in
+// the query (`?z={z}&x={x}&y={y}`), which the custom-basemap validator accepts,
+// so those are as per-tile as a path segment is. The `tile*`/`TileMatrix` names
+// are WMTS's. Matched case-insensitively, since the same params appear
+// upper-cased in WMS/WMTS-style templates.
+//
+// Names, not values. A parameter's VALUE being numeric does not make it a
+// coordinate — `?layer=3` is source-defining — and collapsing on that would
+// merge two different sources. A template using a name not on this list
+// (`?column={x}`) therefore over-counts rather than under-counts, which is the
+// same trade-off the host/path note below describes.
 const VOLATILE_TILE_PARAMS = new Set([
   'sig', 'exp', 'scope', '_v',
-  'z', 'x', 'y', 'bbox', 'quadkey',
+  'z', 'x', 'y', 'zoom', 'level',
+  'col', 'column', 'row',
+  'tilecol', 'tilerow', 'tilematrix', 'tilematrixset',
+  'bbox', 'quadkey',
 ]);
 
 function failureKey(message: string): string {

--- a/frontend/src/lib/report/report-buffer.ts
+++ b/frontend/src/lib/report/report-buffer.ts
@@ -155,9 +155,21 @@ export function reportTileTokenRemint(surface: string, trigger: string): void {
 export function countDistinctFailures(list: ReportEntry[]): number {
   const seen = new Set<string>();
   for (const entry of list) {
-    if (entry.severity === 'error') seen.add(failureKey(entry.message));
+    if (entry.severity === 'error') seen.add(entryKey(entry));
   }
   return seen.size;
+}
+
+/** The two sources that describe ONE failure between them — the pair this whole
+ * helper exists for. Only these correlate on the message alone. Every other
+ * source keys on its own identity too: two PanelErrorBoundary instances can
+ * throw the same common message from different panels, and those are two
+ * failures, not one. */
+const PAIRED_SOURCES: ReadonlySet<ReportSource> = new Set(['maplibre', 'console']);
+
+function entryKey(entry: ReportEntry): string {
+  if (PAIRED_SOURCES.has(entry.source)) return failureKey(entry.message);
+  return `${entry.source}\u0000${entry.message}\u0000${entry.detail ?? ''}`;
 }
 
 /**

--- a/frontend/src/lib/report/report-buffer.ts
+++ b/frontend/src/lib/report/report-buffer.ts
@@ -207,47 +207,35 @@ function sourceIdOf(entry: ReportEntry): string {
  * without this every failing tile of ONE broken source is its own key and the
  * badge still runs to 9+.
  *
- * Only the parts that vary WITHIN one source are dropped: the tile address in
- * each of MapLibre's supported forms — `{z}/{x}/{y}`, `{quadkey}`, the
- * `{bbox-epsg-3857}` query param, and the `{ratio}` suffix a retina display
- * resolves to `@2x`, all reachable through an admin-configured remote style —
- * and the rotating credential params. NOT `{prefix}`; see below.
- * Everything that distinguishes one source from another stays — the rest of the
- * path, the status, and the `cols`/`cluster_radius`/`cluster_max_zoom` params.
+ * Only what is unambiguously per-TILE is dropped: numeric path segments (the
+ * coordinates, in any layout) and the rotating credential params. Everything
+ * that identifies the source survives — the rest of the path, the host, the
+ * status, and the `cols`/`cluster_radius`/`cluster_max_zoom` params.
  *
- * A `maplibre` row keys on its source id instead and never needs this; it
- * matters for the `console` rows the viewer and dataset preview leave behind,
- * which carry no source at all.
+ * Deliberately NOT the `{prefix}` shard, in the host or the path. A resolved
+ * shard is indistinguishable from a meaningful short label in a single URL —
+ * `a.tiles…` looks exactly like `ca.tiles…`, `/a3/` like `/de/` — and
+ * collapsing it merged two genuinely different basemaps into one entry.
+ * Between the two errors, keep the over-count: this is a problem REPORTER, and
+ * hiding a broken source is worse than counting a sharded one more than once.
+ *
+ * A `maplibre` row keys on its source id as well and rarely needs any of this;
+ * it matters for the `console` rows the viewer and dataset preview leave
+ * behind, which carry no source at all.
  */
 const VOLATILE_TILE_PARAMS = new Set(['sig', 'exp', 'scope', '_v', 'bbox', 'BBOX']);
 
 function failureKey(message: string): string {
   return message
-    // Tile coordinates, anchored to the end of the path — that is where z/x/y
-    // always sit, and anchoring is what keeps an all-numeric `{prefix}` segment
-    // (`/00/5/1/1.png`) from being mistaken for the zoom.
-    // The `y` segment is an alternation because `redact()` runs FIRST, at
-    // capture time, and a retina tile ending `/1539@2x.png` looks exactly like
-    // an email address to it — so what actually reaches this function is
-    // `/12/1205/[redacted-email]`, with the coordinate already gone.
-    .replace(
-      /\/\d+\/\d+\/(?:\d+(?:@\d+x)?(?:\.\w+)?|\[redacted-email\])(?=[?\s]|$)/g,
-      '/{z}/{x}/{y}',
-    )
-    // A quadkey is the LAST path segment, one base-4 run whose length is the
-    // zoom level — so it is anchored at the end rather than length-gated, or a
-    // zoom-3 tile (`/031.png`) would stay a distinct key while a zoom-12 one
-    // collapsed. Anchoring is what keeps a mid-path `/2/` from matching.
-    .replace(/\/[0-3]+(@\d+x)?(\.\w+)?(?=[?\s]|$)/g, '/{quadkey}')
-    // Deliberately NOT `{prefix}`, in the host or the path. A resolved shard
-    // (`a3.tiles…`, `/a3/`) is indistinguishable from a meaningful label
-    // (`ca.tiles…`, `/de/`) in a single URL — both are one or two hex-ish
-    // characters — and collapsing it merged two genuinely different basemaps.
-    // Between the two errors the over-count is the safer one to keep: this is a
-    // problem REPORTER, and hiding a broken source is worse than counting a
-    // sharded one more than once. So this function normalizes only what is
-    // unambiguously per-TILE — coordinates and credentials — and never guesses
-    // at what a host or path segment means.
+    // Every purely numeric path segment. That single rule covers each tile
+    // layout MapLibre supports — `{z}/{x}/{y}` with or without a static suffix
+    // (`/12/1205/1539/tile.png`), a leading numeric shard, and `{quadkey}`,
+    // which is all digits too. Anchoring on "is a number" rather than on a
+    // shape means a template this does not anticipate still normalizes.
+    // It also tolerates `redact()` having already eaten a `@2x` suffix as an
+    // email address (see the note above `pushReportEntry`): the surviving z/x
+    // segments still collapse.
+    .replace(/\/\d+(?=[/?.@\s]|$)/g, '/{n}')
     .replace(/\?(\S*)/g, (_match, query: string) => {
       const kept = query
         .split('&')

--- a/frontend/src/lib/report/report-buffer.ts
+++ b/frontend/src/lib/report/report-buffer.ts
@@ -223,7 +223,16 @@ function sourceIdOf(entry: ReportEntry): string {
  * it matters for the `console` rows the viewer and dataset preview leave
  * behind, which carry no source at all.
  */
-const VOLATILE_TILE_PARAMS = new Set(['sig', 'exp', 'scope', '_v', 'bbox', 'BBOX']);
+// Per-tile or rotating query params: the credential set, and every form
+// MapLibre can substitute a coordinate into. A template may put the whole tile
+// address in the query (`?z={z}&x={x}&y={y}`), which the custom-basemap
+// validator accepts, so those names are as per-tile as a path segment is.
+// Matched case-insensitively — the same params appear upper-cased in WMS-style
+// templates.
+const VOLATILE_TILE_PARAMS = new Set([
+  'sig', 'exp', 'scope', '_v',
+  'z', 'x', 'y', 'bbox', 'quadkey',
+]);
 
 function failureKey(message: string): string {
   return message
@@ -239,7 +248,7 @@ function failureKey(message: string): string {
     .replace(/\?(\S*)/g, (_match, query: string) => {
       const kept = query
         .split('&')
-        .filter((pair) => pair && !VOLATILE_TILE_PARAMS.has(pair.split('=')[0]));
+        .filter((pair) => pair && !VOLATILE_TILE_PARAMS.has(pair.split('=')[0].toLowerCase()));
       return kept.length > 0 ? `?${kept.join('&')}` : '';
     });
 }

--- a/frontend/src/lib/report/report-buffer.ts
+++ b/frontend/src/lib/report/report-buffer.ts
@@ -210,9 +210,10 @@ function sourceIdOf(entry: ReportEntry): string {
  * badge still runs to 9+.
  *
  * Only the parts that vary WITHIN one source are dropped: the tile address in
- * each of MapLibre's supported forms (`{z}/{x}/{y}`, `{quadkey}`, the
- * `{bbox-epsg-3857}` query param, and the `{prefix}` shard label, all reachable
- * through an admin-configured remote style) and the rotating credential params.
+ * each of MapLibre's supported forms — `{z}/{x}/{y}`, `{quadkey}`, the
+ * `{bbox-epsg-3857}` query param, the `{prefix}` shard label, and the `{ratio}`
+ * suffix a retina display resolves to `@2x`, all reachable through an
+ * admin-configured remote style — and the rotating credential params.
  * Everything that distinguishes one source from another stays — the rest of the
  * path, the status, and the `cols`/`cluster_radius`/`cluster_max_zoom` params.
  *
@@ -232,12 +233,19 @@ function failureKey(message: string): string {
     // Tile coordinates, anchored to the end of the path — that is where z/x/y
     // always sit, and anchoring is what keeps an all-numeric `{prefix}` segment
     // (`/00/5/1/1.png`) from being mistaken for the zoom.
-    .replace(/\/\d+\/\d+\/\d+(\.\w+)?(?=[?\s]|$)/g, '/{z}/{x}/{y}')
+    // The `y` segment is an alternation because `redact()` runs FIRST, at
+    // capture time, and a retina tile ending `/1539@2x.png` looks exactly like
+    // an email address to it — so what actually reaches this function is
+    // `/12/1205/[redacted-email]`, with the coordinate already gone.
+    .replace(
+      /\/\d+\/\d+\/(?:\d+(?:@\d+x)?(?:\.\w+)?|\[redacted-email\])(?=[?\s]|$)/g,
+      '/{z}/{x}/{y}',
+    )
     // A quadkey is the LAST path segment, one base-4 run whose length is the
     // zoom level — so it is anchored at the end rather than length-gated, or a
     // zoom-3 tile (`/031.png`) would stay a distinct key while a zoom-12 one
     // collapsed. Anchoring is what keeps a mid-path `/2/` from matching.
-    .replace(/\/[0-3]+(\.\w+)?(?=[?\s]|$)/g, '/{quadkey}')
+    .replace(/\/[0-3]+(@\d+x)?(\.\w+)?(?=[?\s]|$)/g, '/{quadkey}')
     // …and only then the path-segment form of `{prefix}`, on what is left.
     .replace(/\/[0-9a-f]{2}(?=\/)/gi, '/{prefix}')
     .replace(/\?(\S*)/g, (_match, query: string) => {

--- a/frontend/src/lib/report/report-buffer.ts
+++ b/frontend/src/lib/report/report-buffer.ts
@@ -155,9 +155,23 @@ export function reportTileTokenRemint(surface: string, trigger: string): void {
 export function countDistinctFailures(list: ReportEntry[]): number {
   const seen = new Set<string>();
   for (const entry of list) {
-    if (entry.severity === 'error') seen.add(entry.message);
+    if (entry.severity === 'error') seen.add(failureKey(entry.message));
   }
   return seen.size;
+}
+
+/**
+ * fix(#908): collapse a message down to the failure it describes. MapLibre
+ * builds an AJAXError message as `AJAXError: <status> (<code>): <url>`, so
+ * without this every failing tile of ONE broken source is its own key and the
+ * badge still runs to 9+. Drop the per-tile `/{z}/{x}/{y}` triple and any query
+ * string (the signed `sig=` rotates on its own); the source path, the status,
+ * and every non-tile message survive untouched.
+ */
+function failureKey(message: string): string {
+  return message
+    .replace(/\/\d+\/\d+\/\d+(\.\w+)?/g, '/{z}/{x}/{y}')
+    .replace(/\?\S*/g, '');
 }
 
 function stringifyDetail(detail: unknown): string | undefined {

--- a/frontend/src/lib/report/report-buffer.ts
+++ b/frontend/src/lib/report/report-buffer.ts
@@ -153,23 +153,48 @@ export function reportTileTokenRemint(surface: string, trigger: string): void {
  * things are wrong", and a tile source that fails again is the same thing.
  */
 export function countDistinctFailures(list: ReportEntry[]): number {
-  const seen = new Set<string>();
+  // A `maplibre` row keys on its SOURCE as well as its message: two cluster
+  // layers over one dataset get their own MapLibre source (getSourceIdForLayer)
+  // and can fail with byte-identical URLs, and those are two broken layers.
+  const mapFailures = new Set<string>();
+  // …and the messages those rows already account for, so the `console` row
+  // derived from the same AJAXError is recognized as the other half of one
+  // failure rather than counted again.
+  const mapMessages = new Set<string>();
+  const consoleOnly = new Set<string>();
+  const others = new Set<string>();
+
   for (const entry of list) {
-    if (entry.severity === 'error') seen.add(entryKey(entry));
+    if (entry.severity !== 'error') continue;
+    const message = failureKey(entry.message);
+    if (entry.source === 'maplibre') {
+      mapFailures.add(`${message}\u0000${sourceIdOf(entry)}`);
+      mapMessages.add(message);
+    } else if (entry.source === 'console') {
+      consoleOnly.add(message);
+    } else {
+      // Every other source keys on its own identity too: two PanelErrorBoundary
+      // instances can throw the same common message from different panels, and
+      // those are two failures.
+      others.add(`${entry.source}\u0000${entry.message}\u0000${entry.detail ?? ''}`);
+    }
   }
-  return seen.size;
+
+  let count = mapFailures.size + others.size;
+  for (const message of consoleOnly) {
+    // Only a console row with no map row behind it is a failure of its own —
+    // that is the viewer and the dataset preview, which push no row at all.
+    if (!mapMessages.has(message)) count += 1;
+  }
+  return count;
 }
 
-/** The two sources that describe ONE failure between them — the pair this whole
- * helper exists for. Only these correlate on the message alone. Every other
- * source keys on its own identity too: two PanelErrorBoundary instances can
- * throw the same common message from different panels, and those are two
- * failures, not one. */
-const PAIRED_SOURCES: ReadonlySet<ReportSource> = new Set(['maplibre', 'console']);
-
-function entryKey(entry: ReportEntry): string {
-  if (PAIRED_SOURCES.has(entry.source)) return failureKey(entry.message);
-  return `${entry.source}\u0000${entry.message}\u0000${entry.detail ?? ''}`;
+/** The failing MapLibre source, as the surface handlers record it
+ * (`detail: "source: <id>"`). Empty when the error carries none — style and
+ * glyph errors do not. */
+function sourceIdOf(entry: ReportEntry): string {
+  const match = /(?:^|\s)source:\s*(\S+)/.exec(entry.detail ?? '');
+  return match?.[1] ?? '';
 }
 
 /**
@@ -178,17 +203,20 @@ function entryKey(entry: ReportEntry): string {
  * without this every failing tile of ONE broken source is its own key and the
  * badge still runs to 9+.
  *
- * Only the parts that vary WITHIN one source are dropped: the per-tile
- * `/{z}/{x}/{y}` triple and the rotating credential params. Everything that
+ * Only the parts that vary WITHIN one source are dropped: the tile address in
+ * each of MapLibre's supported forms (`{z}/{x}/{y}`, `{quadkey}`, and the
+ * `{bbox-epsg-3857}` query param, all reachable through an admin-configured
+ * remote style) and the rotating credential params. Everything that
  * distinguishes one source from another stays — the path, the status, and the
- * `cols`/`cluster_radius`/`cluster_max_zoom` params that make two cluster
- * layers over the same dataset genuinely different sources.
+ * `cols`/`cluster_radius`/`cluster_max_zoom` params.
  */
-const VOLATILE_TILE_PARAMS = new Set(['sig', 'exp', 'scope', '_v']);
+const VOLATILE_TILE_PARAMS = new Set(['sig', 'exp', 'scope', '_v', 'bbox', 'BBOX']);
 
 function failureKey(message: string): string {
   return message
     .replace(/\/\d+\/\d+\/\d+(\.\w+)?/g, '/{z}/{x}/{y}')
+    // A quadkey is one long base-4 run in the path, e.g. /0313102310.png.
+    .replace(/\/[0-3]{6,}(\.\w+)?/g, '/{quadkey}')
     .replace(/\?(\S*)/g, (_match, query: string) => {
       const kept = query
         .split('&')

--- a/frontend/src/lib/report/report-buffer.ts
+++ b/frontend/src/lib/report/report-buffer.ts
@@ -222,6 +222,17 @@ function sourceIdOf(entry: ReportEntry): string {
  * A `maplibre` row keys on its source id as well and rarely needs any of this;
  * it matters for the `console` rows the viewer and dataset preview leave
  * behind, which carry no source at all.
+ *
+ * Scope, deliberately: the custom-basemap validator accepts `{z}/{x}/{y}`
+ * ANYWHERE in a URL, so the set of shapes a remote style can produce is open
+ * ended. This handles GeoLens's own tile URLs exactly, plus the conventional
+ * remote layouts, and for anything stranger it degrades toward counting one
+ * source more than once. That direction is the deliberate one — under-counting
+ * would hide a broken source from a problem reporter. Keying those rows on a
+ * real source identity, rather than inferring it from a URL, is the change that
+ * would close the gap properly; it needs `logUnhandledMapError` to carry the
+ * `sourceId` it already receives into what it logs, which is a bigger change
+ * than a badge count warrants.
  */
 // Per-tile or rotating query params: the credential set, plus the coordinate
 // names a tile template can use. A template may put the whole tile address in
@@ -264,7 +275,13 @@ function failureKey(message: string): string {
  * and swallow the version. Trying the tighter end-anchored form first pins the
  * match to the right, and the looser form only runs when nothing matched.
  */
-function normalizeTileAddress(message: string): string {
+// A numeric segment directly behind a coordinate LABEL, as in
+// `/z/12/x/1205/y/1539.png`. Name-driven for the same reason the query rule is:
+// `/v/1/` is a version, not a coordinate, and only the label tells them apart.
+const LABELLED_COORD = /\/(z|x|y|zoom|level|col|column|row|tilecol|tilerow|tilematrix)\/\d+/gi;
+
+function normalizeTileAddress(raw: string): string {
+  const message = raw.replace(LABELLED_COORD, '/$1/{n}');
   // `/12/1205/1539`, `/12/1205/1539.png`, or `/12/1205/[redacted-email]` (the
   // `@2x` case, which redact() eats as an email), hard against the end or a query.
   const withExtension = /\/\d+\/\d+\/(?:\d+(?:\.\w+)?|\[redacted-email\])(?=[?\s]|$)/g;

--- a/frontend/src/lib/report/report-buffer.ts
+++ b/frontend/src/lib/report/report-buffer.ts
@@ -164,14 +164,25 @@ export function countDistinctFailures(list: ReportEntry[]): number {
  * fix(#908): collapse a message down to the failure it describes. MapLibre
  * builds an AJAXError message as `AJAXError: <status> (<code>): <url>`, so
  * without this every failing tile of ONE broken source is its own key and the
- * badge still runs to 9+. Drop the per-tile `/{z}/{x}/{y}` triple and any query
- * string (the signed `sig=` rotates on its own); the source path, the status,
- * and every non-tile message survive untouched.
+ * badge still runs to 9+.
+ *
+ * Only the parts that vary WITHIN one source are dropped: the per-tile
+ * `/{z}/{x}/{y}` triple and the rotating credential params. Everything that
+ * distinguishes one source from another stays — the path, the status, and the
+ * `cols`/`cluster_radius`/`cluster_max_zoom` params that make two cluster
+ * layers over the same dataset genuinely different sources.
  */
+const VOLATILE_TILE_PARAMS = new Set(['sig', 'exp', 'scope', '_v']);
+
 function failureKey(message: string): string {
   return message
     .replace(/\/\d+\/\d+\/\d+(\.\w+)?/g, '/{z}/{x}/{y}')
-    .replace(/\?\S*/g, '');
+    .replace(/\?(\S*)/g, (_match, query: string) => {
+      const kept = query
+        .split('&')
+        .filter((pair) => pair && !VOLATILE_TILE_PARAMS.has(pair.split('=')[0]));
+      return kept.length > 0 ? `?${kept.join('&')}` : '';
+    });
 }
 
 function stringifyDetail(detail: unknown): string | undefined {

--- a/frontend/src/lib/report/report-buffer.ts
+++ b/frontend/src/lib/report/report-buffer.ts
@@ -224,16 +224,22 @@ const VOLATILE_TILE_PARAMS = new Set(['sig', 'exp', 'scope', '_v', 'bbox', 'BBOX
 
 function failureKey(message: string): string {
   return message
-    // MapLibre's `{prefix}` resolves to one or two characters derived from the
-    // tile's x/y, as the FIRST host label — so one sharded source otherwise
-    // yields a different host per tile.
-    .replace(/(https?:\/\/)[a-z0-9]{1,2}\./gi, '$1{prefix}.')
-    .replace(/\/\d+\/\d+\/\d+(\.\w+)?/g, '/{z}/{x}/{y}')
+    // MapLibre's `{prefix}` resolves to two hex characters derived from the
+    // tile's x/y, and it may sit ANYWHERE in the template — a host label
+    // (`//a3.tiles…`) or a path segment (`/tiles/{prefix}/{z}/…`). Either way
+    // one sharded source otherwise yields a different URL per tile.
+    .replace(/(https?:\/\/)[0-9a-f]{1,2}\./gi, '$1{prefix}.')
+    // Tile coordinates, anchored to the end of the path — that is where z/x/y
+    // always sit, and anchoring is what keeps an all-numeric `{prefix}` segment
+    // (`/00/5/1/1.png`) from being mistaken for the zoom.
+    .replace(/\/\d+\/\d+\/\d+(\.\w+)?(?=[?\s]|$)/g, '/{z}/{x}/{y}')
     // A quadkey is the LAST path segment, one base-4 run whose length is the
     // zoom level — so it is anchored at the end rather than length-gated, or a
     // zoom-3 tile (`/031.png`) would stay a distinct key while a zoom-12 one
     // collapsed. Anchoring is what keeps a mid-path `/2/` from matching.
     .replace(/\/[0-3]+(\.\w+)?(?=[?\s]|$)/g, '/{quadkey}')
+    // …and only then the path-segment form of `{prefix}`, on what is left.
+    .replace(/\/[0-9a-f]{2}(?=\/)/gi, '/{prefix}')
     .replace(/\?(\S*)/g, (_match, query: string) => {
       const kept = query
         .split('&')

--- a/frontend/src/lib/report/report-buffer.ts
+++ b/frontend/src/lib/report/report-buffer.ts
@@ -215,8 +215,11 @@ const VOLATILE_TILE_PARAMS = new Set(['sig', 'exp', 'scope', '_v', 'bbox', 'BBOX
 function failureKey(message: string): string {
   return message
     .replace(/\/\d+\/\d+\/\d+(\.\w+)?/g, '/{z}/{x}/{y}')
-    // A quadkey is one long base-4 run in the path, e.g. /0313102310.png.
-    .replace(/\/[0-3]{6,}(\.\w+)?/g, '/{quadkey}')
+    // A quadkey is the LAST path segment, one base-4 run whose length is the
+    // zoom level — so it is anchored at the end rather than length-gated, or a
+    // zoom-3 tile (`/031.png`) would stay a distinct key while a zoom-12 one
+    // collapsed. Anchoring is what keeps a mid-path `/2/` from matching.
+    .replace(/\/[0-3]+(\.\w+)?(?=[?\s]|$)/g, '/{quadkey}')
     .replace(/\?(\S*)/g, (_match, query: string) => {
       const kept = query
         .split('&')

--- a/frontend/src/lib/report/report-buffer.ts
+++ b/frontend/src/lib/report/report-buffer.ts
@@ -197,8 +197,11 @@ export function countDistinctFailures(list: ReportEntry[]): number {
  * (`detail: "source: <id>"`). Empty when the error carries none — style and
  * glyph errors do not. */
 function sourceIdOf(entry: ReportEntry): string {
-  const match = /(?:^|\s)source:\s*(\S+)/.exec(entry.detail ?? '');
-  return match?.[1] ?? '';
+  // Everything after the marker, not just the first word: a style may define a
+  // source id containing spaces, and `terrain primary` / `terrain fallback`
+  // must not both truncate to `terrain`.
+  const match = /(?:^|\s)source:\s*(.+)$/.exec(entry.detail ?? '');
+  return match?.[1].trim() ?? '';
 }
 
 /**

--- a/frontend/src/lib/report/report-buffer.ts
+++ b/frontend/src/lib/report/report-buffer.ts
@@ -168,7 +168,13 @@ export function countDistinctFailures(list: ReportEntry[]): number {
     if (entry.severity !== 'error') continue;
     const message = failureKey(entry.message);
     if (entry.source === 'maplibre') {
-      mapFailures.add(`${message}\u0000${sourceIdOf(entry)}`);
+      // Prefer the MapLibre source id outright: it is the ground truth for
+      // "which thing is broken", and it sidesteps every way one source's tile
+      // URLs can differ from each other (coordinates, shard prefixes, rotating
+      // sigs). Fall back to the message for style and glyph errors, which
+      // carry no source.
+      const sourceId = sourceIdOf(entry);
+      mapFailures.add(sourceId ? `src\u0000${sourceId}` : `msg\u0000${message}`);
       mapMessages.add(message);
     } else if (entry.source === 'console') {
       consoleOnly.add(message);
@@ -204,16 +210,24 @@ function sourceIdOf(entry: ReportEntry): string {
  * badge still runs to 9+.
  *
  * Only the parts that vary WITHIN one source are dropped: the tile address in
- * each of MapLibre's supported forms (`{z}/{x}/{y}`, `{quadkey}`, and the
- * `{bbox-epsg-3857}` query param, all reachable through an admin-configured
- * remote style) and the rotating credential params. Everything that
- * distinguishes one source from another stays — the path, the status, and the
- * `cols`/`cluster_radius`/`cluster_max_zoom` params.
+ * each of MapLibre's supported forms (`{z}/{x}/{y}`, `{quadkey}`, the
+ * `{bbox-epsg-3857}` query param, and the `{prefix}` shard label, all reachable
+ * through an admin-configured remote style) and the rotating credential params.
+ * Everything that distinguishes one source from another stays — the rest of the
+ * path, the status, and the `cols`/`cluster_radius`/`cluster_max_zoom` params.
+ *
+ * A `maplibre` row keys on its source id instead and never needs this; it
+ * matters for the `console` rows the viewer and dataset preview leave behind,
+ * which carry no source at all.
  */
 const VOLATILE_TILE_PARAMS = new Set(['sig', 'exp', 'scope', '_v', 'bbox', 'BBOX']);
 
 function failureKey(message: string): string {
   return message
+    // MapLibre's `{prefix}` resolves to one or two characters derived from the
+    // tile's x/y, as the FIRST host label — so one sharded source otherwise
+    // yields a different host per tile.
+    .replace(/(https?:\/\/)[a-z0-9]{1,2}\./gi, '$1{prefix}.')
     .replace(/\/\d+\/\d+\/\d+(\.\w+)?/g, '/{z}/{x}/{y}')
     // A quadkey is the LAST path segment, one base-4 run whose length is the
     // zoom level — so it is anchored at the end rather than length-gated, or a

--- a/frontend/src/lib/report/report-buffer.ts
+++ b/frontend/src/lib/report/report-buffer.ts
@@ -239,7 +239,10 @@ const VOLATILE_TILE_PARAMS = new Set([
   'sig', 'exp', 'scope', '_v',
   'z', 'x', 'y', 'zoom', 'level',
   'col', 'column', 'row',
-  'tilecol', 'tilerow', 'tilematrix', 'tilematrixset',
+  // WMTS: TileMatrix is the zoom and TileRow/TileCol the coordinates, but
+  // TileMatrixSet names the GRID (EPSG:3857 vs EPSG:4326) and is therefore
+  // source-defining — two basemaps can differ by nothing else.
+  'tilecol', 'tilerow', 'tilematrix',
   'bbox', 'quadkey',
 ]);
 


### PR DESCRIPTION
## What changed

`ReportProblemHost` counted **rows** with `severity === 'error'`, and every unrecovered map error writes **two** of them:

1. a `maplibre` row from the surface handler, carrying `sourceId` (what makes a report actionable)
2. a `console` row derived from `logUnhandledMapError`'s `console.error` (the only trace the viewer and dataset preview leave at all)

Neither half can be dropped, so this takes the issue's primary ask: stop counting rows, count distinct failures. `ReportProblemHost.tsx:28` is the only call site that changed; the technical-details view still shows both rows.

## How a failure is identified

- **`maplibre` rows key on the source id AND the normalized message.** Neither is unique alone: two cluster layers over one dataset get their own MapLibre source and fail with byte-identical URLs, while two custom basemaps are both handed the fixed id `basemap` by `toMaplibreStyle()`.
- **`console` rows correlate by message** with a `maplibre` row when one exists, so the pair counts once. A console row with nothing behind it — viewer, dataset preview, which push no `maplibre` row — counts on its own.
- **Every other source keys on its own identity and detail**, so two `PanelErrorBoundary` instances throwing the same common message from different panels stay two failures.

## What the message normalizer does, and deliberately does not

It collapses only what is **unambiguously per-tile**: the tile address in MapLibre's supported forms (`{z}/{x}/{y}`, `{quadkey}` at any zoom, `{bbox-epsg-3857}`, and the `{ratio}` → `@2x` suffix) plus the rotating `sig`/`exp`/`scope`/`_v` params. `cols`, `cluster_radius` and `cluster_max_zoom` are kept — they distinguish real sources.

It does **not** touch host or path segments, and that is a decision rather than an omission. A resolved `{prefix}` shard is indistinguishable from a meaningful short label in a single URL: `a.tiles.example.com` looks exactly like `ca.tiles.example.com`, and `/a3/` like `/de/`. Earlier revisions of this PR tried to normalize both and each attempt merged two genuinely different basemaps into one badge entry. Between the two errors this keeps the **over**-count, because hiding a broken source is the worse failure for a tool whose whole job is surfacing problems. The reasoning lives in the code, not only here.

One quirk worth knowing for anyone touching this: `redact()` runs at capture, and it reads a retina tile path ending `/1539@2x.png` as an email address — so what reaches the key is `/12/1205/[redacted-email]`, with the coordinate already gone. The z/x/y rule accepts that placeholder as the `y` segment for exactly that reason.

**Not done: the stretch cross-source dedupe in `pushReportEntry`.** It needs a correlation key reliable enough to merge rows permanently; the count change gets the user-visible benefit without betting on one.

### Related nit from the same issue

`refetchIntervalInBackground: false` is now explicit at both sites in `hooks/use-tile-token.ts`, matching `use-viewer-tokens.ts:84`. Behavior is unchanged (it was the TanStack default) — but that default is what made the #755 403 burst guaranteed rather than probabilistic, so the policy should be stated, not inherited.

## Verification

    cd frontend && npx vitest run src/lib/report src/components/report
    cd frontend && npm run lint && npm run typecheck && npm run test:coverage   # 359 files, 4176 tests

Tests cover: the maplibre+console pair counting once (buffer level and through the rendered badge); every failing tile of one source counting once; two cluster sources over one dataset staying apart; two custom basemaps sharing the `basemap` id staying apart; two panels with the same message staying apart; quadkey (including low zoom), bbox and `@2x` normalization; and the host/path-label cases asserting the trade-off above explicitly.

Closes #908