### PR TITLE
ux(builder): scope the duplicated opacity labels in the style editor

### DIFF
--- a/frontend/src/components/builder/HeatmapStyleControls.tsx
+++ b/frontend/src/components/builder/HeatmapStyleControls.tsx
@@ -135,7 +135,7 @@ export const HeatmapStyleControls = memo(function HeatmapStyleControls({
       {/* Opacity */}
       <div className="space-y-1">
         <SliderRow
-          label={t('style.heatmap.opacity', { defaultValue: 'Opacity' })}
+          label={t('style.heatmap.opacity', { defaultValue: 'Heatmap opacity' })}
           value={typeof paint['heatmap-opacity'] === 'number' ? (paint['heatmap-opacity'] as number) : 0.8}
           min={0}
           max={1}

--- a/frontend/src/components/builder/LayerStyleEditor.tsx
+++ b/frontend/src/components/builder/LayerStyleEditor.tsx
@@ -551,9 +551,11 @@ export const LayerStyleEditor = memo(function LayerStyleEditor({
         {/* Master opacity — all geometry types; omitted when parent owns the opacity control */}
         {onOpacityChange && (
           <>
-            <div className="text-xs font-medium mt-2 pt-2 border-t">{t('style.opacity')}</div>
+            {/* fix(#912): one "Layer opacity" row, no separate "Opacity" heading —
+                the per-geometry sliders above already say what they scope. */}
+            <div className="mt-2 pt-2 border-t" />
             <SliderRow
-              label={t('style.layer')}
+              label={t('style.layerOpacity')}
               value={localOpacity}
               min={0}
               max={1}

--- a/frontend/src/components/builder/LayerStyleEditor/CircleEditor.tsx
+++ b/frontend/src/components/builder/LayerStyleEditor/CircleEditor.tsx
@@ -43,7 +43,7 @@ export function CircleEditor({
         </>
       )}
       <ZoomExpressionEditor
-        label={t('style.opacity')}
+        label={t('style.pointOpacity')}
         value={getEditableNumericPaintValue(paint, 'circle-opacity', 1)}
         defaultValue={1}
         min={0} max={1} step={0.01} format="percent"

--- a/frontend/src/components/builder/LayerStyleEditor/FillEditor.tsx
+++ b/frontend/src/components/builder/LayerStyleEditor/FillEditor.tsx
@@ -68,7 +68,7 @@ export function FillEditor({
             />
           )}
           <SliderRow
-            label={t('style.opacity')}
+            label={t('style.fillOpacity')}
             value={getPaintValue(paint, 'fill-opacity', FILL_DEFAULTS['fill-opacity'])}
             min={0} max={1} step={0.01} format="percent"
             onChange={(val) => onPaintProp('fill-opacity', val)}

--- a/frontend/src/components/builder/LayerStyleEditor/LineEditor.tsx
+++ b/frontend/src/components/builder/LayerStyleEditor/LineEditor.tsx
@@ -52,7 +52,7 @@ export function LineEditor({
         </>
       )}
       <ZoomExpressionEditor
-        label={t('style.opacity')}
+        label={t('style.lineOpacity')}
         value={getEditableNumericPaintValue(paint, 'line-opacity', 1)}
         defaultValue={1}
         min={0} max={1} step={0.01} format="percent"

--- a/frontend/src/components/builder/LayerStyleEditor/__tests__/CircleEditor.test.tsx
+++ b/frontend/src/components/builder/LayerStyleEditor/__tests__/CircleEditor.test.tsx
@@ -66,7 +66,7 @@ function makeProps(layer: MapLayerResponse, overrides: Partial<BaseStyleEditorPr
       const labels: Record<string, string> = {
         'style.point': 'Point',
         'style.color': 'Color',
-        'style.opacity': 'Opacity',
+        'style.pointOpacity': 'Point opacity',
         'style.radius': 'Radius',
         'style.stroke': 'Stroke',
         'style.toggleStroke': 'Toggle stroke visibility',
@@ -86,7 +86,7 @@ describe('CircleEditor', () => {
 
     // Color label may appear more than once (for the circle color + stroke color)
     expect(screen.getAllByText('Color').length).toBeGreaterThan(0);
-    expect(screen.getByRole('slider', { name: 'Opacity' })).toBeInTheDocument();
+    expect(screen.getByRole('slider', { name: 'Point opacity' })).toBeInTheDocument();
     expect(screen.getByRole('slider', { name: 'Radius' })).toBeInTheDocument();
     expect(screen.getByLabelText('Toggle stroke visibility')).toBeInTheDocument();
   });
@@ -115,7 +115,7 @@ describe('CircleEditor', () => {
           t: (key: string, opts?: Record<string, unknown>) => {
             if (key === 'style.styledBy') return `Styled by: ${opts?.column}`;
             const labels: Record<string, string> = {
-              'style.point': 'Point', 'style.opacity': 'Opacity', 'style.radius': 'Radius',
+              'style.point': 'Point', 'style.pointOpacity': 'Point opacity', 'style.radius': 'Radius',
               'style.stroke': 'Stroke', 'style.toggleStroke': 'Toggle stroke visibility', 'style.width': 'Width',
             };
             return labels[key] ?? key;
@@ -140,7 +140,7 @@ describe('CircleEditor', () => {
           t: (key: string, opts?: Record<string, unknown>) => {
             if (key === 'style.radiusByColumn') return `Radius by: ${opts?.column}`;
             const labels: Record<string, string> = {
-              'style.point': 'Point', 'style.opacity': 'Opacity', 'style.radius': 'Radius',
+              'style.point': 'Point', 'style.pointOpacity': 'Point opacity', 'style.radius': 'Radius',
               'style.stroke': 'Stroke', 'style.toggleStroke': 'Toggle stroke visibility', 'style.width': 'Width',
             };
             return labels[key] ?? key;
@@ -166,7 +166,7 @@ describe('CircleEditor', () => {
       if (key === 'style.radiusByColumn') return `Radius by: ${opts?.column}`;
       if (key === 'style.styledBy') return `Styled by: ${opts?.column}`;
       const labels: Record<string, string> = {
-        'style.point': 'Point', 'style.color': 'Color', 'style.opacity': 'Opacity',
+        'style.point': 'Point', 'style.color': 'Color', 'style.pointOpacity': 'Point opacity',
         'style.radius': 'Radius', 'style.stroke': 'Stroke',
         'style.toggleStroke': 'Toggle stroke visibility', 'style.width': 'Width',
       };
@@ -189,7 +189,7 @@ describe('CircleEditor', () => {
     const t = (key: string, opts?: Record<string, unknown>) => {
       if (key === 'style.styledBy') return `Styled by: ${opts?.column}`;
       const labels: Record<string, string> = {
-        'style.point': 'Point', 'style.color': 'Color', 'style.opacity': 'Opacity',
+        'style.point': 'Point', 'style.color': 'Color', 'style.pointOpacity': 'Point opacity',
         'style.radius': 'Radius', 'style.stroke': 'Stroke',
         'style.toggleStroke': 'Toggle stroke visibility', 'style.width': 'Width',
       };

--- a/frontend/src/components/builder/LayerStyleEditor/__tests__/FillEditor.test.tsx
+++ b/frontend/src/components/builder/LayerStyleEditor/__tests__/FillEditor.test.tsx
@@ -71,7 +71,7 @@ function makeProps(layer: MapLayerResponse, overrides: Partial<BaseStyleEditorPr
         'style.fill': 'Fill',
         'style.toggleFill': 'Toggle fill visibility',
         'style.color': 'Color',
-        'style.opacity': 'Opacity',
+        'style.fillOpacity': 'Fill opacity',
         'style.stroke': 'Stroke',
         'style.toggleStroke': 'Toggle stroke visibility',
         'style.width': 'Width',
@@ -91,7 +91,7 @@ describe('FillEditor', () => {
 
     expect(screen.getByLabelText('Toggle fill visibility')).toBeInTheDocument();
     expect(screen.getByLabelText('Toggle stroke visibility')).toBeInTheDocument();
-    expect(screen.getByRole('slider', { name: 'Opacity' })).toBeInTheDocument();
+    expect(screen.getByRole('slider', { name: 'Fill opacity' })).toBeInTheDocument();
     // Color label appears for fill color and stroke color; both should be present
     expect(screen.getAllByText('Color').length).toBeGreaterThan(0);
   });
@@ -109,7 +109,7 @@ describe('FillEditor', () => {
     // Fill toggle still present
     expect(screen.getByLabelText('Toggle fill visibility')).toBeInTheDocument();
     // Fill opacity slider hidden when collapsed
-    expect(screen.queryByRole('slider', { name: 'Opacity' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('slider', { name: 'Fill opacity' })).not.toBeInTheDocument();
   });
 
   it('shows data-driven message instead of color picker when isDataDriven is true', () => {
@@ -162,7 +162,7 @@ describe('FillEditor', () => {
           t: (key: string) => {
             const labels: Record<string, string> = {
               'style.fill': 'Fill', 'style.toggleFill': 'Toggle fill visibility',
-              'style.color': 'Color', 'style.opacity': 'Opacity',
+              'style.color': 'Color', 'style.fillOpacity': 'Fill opacity',
               'style.stroke': 'Stroke', 'style.toggleStroke': 'Toggle stroke visibility',
               'style.width': 'Width', 'style.heightColumn': 'Height column',
               'style.none': 'None', 'style.styledBy': 'Styled by',
@@ -375,7 +375,7 @@ describe('FillEditor', () => {
           'style.fill': 'Fill',
           'style.toggleFill': 'Toggle fill visibility',
           'style.color': 'Color',
-          'style.opacity': 'Opacity',
+          'style.fillOpacity': 'Fill opacity',
           'style.stroke': 'Stroke',
           'style.toggleStroke': 'Toggle stroke visibility',
           'style.width': 'Width',
@@ -464,7 +464,7 @@ describe('FillEditor', () => {
       />,
     );
     expect(screen.getByLabelText('Toggle fill visibility')).toBeInTheDocument();
-    expect(screen.getByRole('slider', { name: 'Opacity' })).toBeInTheDocument();
+    expect(screen.getByRole('slider', { name: 'Fill opacity' })).toBeInTheDocument();
     expect(screen.getByLabelText('Toggle stroke visibility')).toBeInTheDocument();
   });
 

--- a/frontend/src/components/builder/LayerStyleEditor/__tests__/LineEditor.test.tsx
+++ b/frontend/src/components/builder/LayerStyleEditor/__tests__/LineEditor.test.tsx
@@ -66,7 +66,7 @@ function makeProps(layer: MapLayerResponse, overrides: Partial<BaseStyleEditorPr
       const labels: Record<string, string> = {
         'style.line': 'Line',
         'style.color': 'Color',
-        'style.opacity': 'Opacity',
+        'style.lineOpacity': 'Line opacity',
         'style.width': 'Width',
         'style.gapWidth': 'Gap',
         'style.blur': 'Blur',
@@ -95,7 +95,7 @@ describe('LineEditor', () => {
 
     // Line color is accessible via the Solid/Gradient toggle (LineGradientControls)
     expect(screen.getByRole('button', { name: 'Solid color' })).toBeInTheDocument();
-    expect(screen.getByRole('slider', { name: 'Opacity' })).toBeInTheDocument();
+    expect(screen.getByRole('slider', { name: 'Line opacity' })).toBeInTheDocument();
     expect(screen.getByRole('slider', { name: 'Width' })).toBeInTheDocument();
     expect(screen.getByRole('slider', { name: 'Gap' })).toBeInTheDocument();
     expect(screen.getByRole('slider', { name: 'Blur' })).toBeInTheDocument();
@@ -158,7 +158,7 @@ describe('LineEditor', () => {
           t: (key: string, opts?: Record<string, unknown>) => {
             if (key === 'style.widthByColumn') return `Width by: ${opts?.column}`;
             const labels: Record<string, string> = {
-              'style.line': 'Line', 'style.opacity': 'Opacity', 'style.gapWidth': 'Gap',
+              'style.line': 'Line', 'style.lineOpacity': 'Line opacity', 'style.gapWidth': 'Gap',
               'style.blur': 'Blur', 'style.offset': 'Offset', 'style.pattern': 'Pattern',
               'style.dash.solid': 'Solid', 'style.dash.dashed': 'Dashed',
               'style.dash.dotted': 'Dotted', 'style.dash.dashDot': 'Dash-dot',
@@ -211,7 +211,7 @@ describe('LineEditor', () => {
     render(<LineEditor {...makeProps(makeLineLayer(), {
       t: (key: string) => {
         const labels: Record<string, string> = {
-          'style.line': 'Line', 'style.color': 'Color', 'style.opacity': 'Opacity',
+          'style.line': 'Line', 'style.color': 'Color', 'style.lineOpacity': 'Line opacity',
           'style.width': 'Width', 'style.gapWidth': 'Gap', 'style.blur': 'Blur',
           'style.offset': 'Offset', 'style.pattern': 'Pattern',
           'style.dash.solid': 'Solid', 'style.dash.dashed': 'Dashed',
@@ -232,7 +232,7 @@ describe('LineEditor', () => {
     render(<LineEditor {...makeProps(makeLineLayer(), {
       t: (key: string) => {
         const labels: Record<string, string> = {
-          'style.line': 'Line', 'style.color': 'Color', 'style.opacity': 'Opacity',
+          'style.line': 'Line', 'style.color': 'Color', 'style.lineOpacity': 'Line opacity',
           'style.width': 'Width', 'style.gapWidth': 'Gap', 'style.blur': 'Blur',
           'style.offset': 'Offset', 'style.pattern': 'Pattern',
           'style.dash.solid': 'Solid', 'style.dash.dashed': 'Dashed',
@@ -258,7 +258,7 @@ describe('LineEditor', () => {
     render(<LineEditor {...makeProps(makeLineLayer(), {
       t: (key: string) => {
         const labels: Record<string, string> = {
-          'style.line': 'Line', 'style.color': 'Color', 'style.opacity': 'Opacity',
+          'style.line': 'Line', 'style.color': 'Color', 'style.lineOpacity': 'Line opacity',
           'style.width': 'Width', 'style.gapWidth': 'Gap', 'style.blur': 'Blur',
           'style.offset': 'Offset', 'style.pattern': 'Pattern',
           'style.dash.solid': 'Solid', 'style.dash.dashed': 'Dashed',
@@ -284,7 +284,7 @@ describe('LineEditor', () => {
     const onLayoutChange = vi.fn();
     const t = (key: string) => {
       const labels: Record<string, string> = {
-        'style.line': 'Line', 'style.color': 'Color', 'style.opacity': 'Opacity',
+        'style.line': 'Line', 'style.color': 'Color', 'style.lineOpacity': 'Line opacity',
         'style.width': 'Width', 'style.gapWidth': 'Gap', 'style.blur': 'Blur',
         'style.offset': 'Offset', 'style.pattern': 'Pattern',
         'style.dash.solid': 'Solid', 'style.dash.dashed': 'Dashed',
@@ -307,7 +307,7 @@ describe('LineEditor', () => {
     const onLayoutChange = vi.fn();
     const t = (key: string) => {
       const labels: Record<string, string> = {
-        'style.line': 'Line', 'style.color': 'Color', 'style.opacity': 'Opacity',
+        'style.line': 'Line', 'style.color': 'Color', 'style.lineOpacity': 'Line opacity',
         'style.width': 'Width', 'style.gapWidth': 'Gap', 'style.blur': 'Blur',
         'style.offset': 'Offset', 'style.pattern': 'Pattern',
         'style.dash.solid': 'Solid', 'style.dash.dashed': 'Dashed',
@@ -329,7 +329,7 @@ describe('LineEditor', () => {
   it('reads line-cap and line-join defaults from layer.layout and displays them', () => {
     const t = (key: string) => {
       const labels: Record<string, string> = {
-        'style.line': 'Line', 'style.color': 'Color', 'style.opacity': 'Opacity',
+        'style.line': 'Line', 'style.color': 'Color', 'style.lineOpacity': 'Line opacity',
         'style.width': 'Width', 'style.gapWidth': 'Gap', 'style.blur': 'Blur',
         'style.offset': 'Offset', 'style.pattern': 'Pattern',
         'style.dash.solid': 'Solid', 'style.dash.dashed': 'Dashed',

--- a/frontend/src/components/builder/__tests__/LayerStyleEditor.test.tsx
+++ b/frontend/src/components/builder/__tests__/LayerStyleEditor.test.tsx
@@ -464,7 +464,7 @@ describe('LayerStyleEditor - line paint controls', () => {
     );
 
     expect(screen.getByText('Color')).toBeInTheDocument();
-    expect(screen.getByRole('slider', { name: 'Opacity' })).toBeInTheDocument();
+    expect(screen.getByRole('slider', { name: 'Line opacity' })).toBeInTheDocument();
     expect(screen.getByRole('slider', { name: 'Width' })).toBeInTheDocument();
     expect(screen.getByRole('slider', { name: 'Gap' })).toBeInTheDocument();
     expect(screen.getByRole('slider', { name: 'Blur' })).toBeInTheDocument();
@@ -659,7 +659,7 @@ describe('LayerStyleEditor - circle zoom expression controls', () => {
       />,
     );
 
-    fireEvent.change(screen.getByLabelText('Opacity Stop 2 value'), { target: { value: '0.75' } });
+    fireEvent.change(screen.getByLabelText('Point opacity Stop 2 value'), { target: { value: '0.75' } });
 
     expect(onPaintChange).toHaveBeenCalledWith('layer-1', {
       'circle-color': '#ff0000',
@@ -1319,8 +1319,8 @@ describe('LayerStyleEditor - opacity slider debounce (PB-02)', () => {
       />,
     );
 
-    // Find the master opacity slider (aria-label = "Layer")
-    const slider = screen.getByRole('slider', { name: 'Layer' });
+    // Find the master opacity slider (aria-label = "Layer opacity")
+    const slider = screen.getByRole('slider', { name: 'Layer opacity' });
 
     // Simulate 3 rapid keydown events on the slider to change the value
     // Radix Slider responds to ArrowLeft/ArrowRight key events

--- a/frontend/src/i18n/locales/de/builder.json
+++ b/frontend/src/i18n/locales/de/builder.json
@@ -190,8 +190,10 @@
     "stroke": "Umriss",
     "line": "Linie",
     "point": "Punkt",
-    "opacity": "Deckkraft",
-    "layer": "Layer",
+    "fillOpacity": "Deckkraft der Fläche",
+    "lineOpacity": "Deckkraft der Linie",
+    "pointOpacity": "Deckkraft des Punkts",
+    "layerOpacity": "Deckkraft des Layers",
     "color": "Farbe",
     "width": "Breite",
     "gapWidth": "Lückenbreite",
@@ -314,7 +316,7 @@
       "colorRamp": "Farbverlauf",
       "radius": "Radius",
       "intensity": "Intensität",
-      "opacity": "Deckkraft"
+      "opacity": "Deckkraft der Heatmap"
     },
     "cluster": {
       "radius": "Cluster-Radius",

--- a/frontend/src/i18n/locales/en/builder.json
+++ b/frontend/src/i18n/locales/en/builder.json
@@ -190,8 +190,10 @@
     "stroke": "Stroke",
     "line": "Line",
     "point": "Point",
-    "opacity": "Opacity",
-    "layer": "Layer",
+    "fillOpacity": "Fill opacity",
+    "lineOpacity": "Line opacity",
+    "pointOpacity": "Point opacity",
+    "layerOpacity": "Layer opacity",
     "color": "Color",
     "width": "Width",
     "gapWidth": "Gap",
@@ -314,7 +316,7 @@
       "colorRamp": "Color ramp",
       "radius": "Radius",
       "intensity": "Intensity",
-      "opacity": "Opacity"
+      "opacity": "Heatmap opacity"
     },
     "cluster": {
       "radius": "Cluster radius",

--- a/frontend/src/i18n/locales/es/builder.json
+++ b/frontend/src/i18n/locales/es/builder.json
@@ -190,8 +190,10 @@
     "stroke": "Trazo",
     "line": "Línea",
     "point": "Punto",
-    "opacity": "Opacidad",
-    "layer": "Capa",
+    "fillOpacity": "Opacidad del relleno",
+    "lineOpacity": "Opacidad de la línea",
+    "pointOpacity": "Opacidad del punto",
+    "layerOpacity": "Opacidad de la capa",
     "color": "Color",
     "width": "Ancho",
     "gapWidth": "Ancho de hueco",
@@ -314,7 +316,7 @@
       "colorRamp": "Rampa de color",
       "radius": "Radio",
       "intensity": "Intensidad",
-      "opacity": "Opacidad"
+      "opacity": "Opacidad del mapa de calor"
     },
     "cluster": {
       "radius": "Radio de agrupación",

--- a/frontend/src/i18n/locales/fr/builder.json
+++ b/frontend/src/i18n/locales/fr/builder.json
@@ -190,8 +190,10 @@
     "stroke": "Contour",
     "line": "Ligne",
     "point": "Point",
-    "opacity": "Opacité",
-    "layer": "Couche",
+    "fillOpacity": "Opacité du remplissage",
+    "lineOpacity": "Opacité de la ligne",
+    "pointOpacity": "Opacité du point",
+    "layerOpacity": "Opacité de la couche",
     "color": "Couleur",
     "width": "Largeur",
     "gapWidth": "Largeur de l'écart",
@@ -314,7 +316,7 @@
       "colorRamp": "Palette de couleurs",
       "radius": "Rayon",
       "intensity": "Intensité",
-      "opacity": "Opacité"
+      "opacity": "Opacité de la carte de chaleur"
     },
     "cluster": {
       "radius": "Rayon d'agrégat",


### PR DESCRIPTION
## What changed

"Color, shape, and visibility" showed two controls labelled "Opacity", and three on line layers (the zoom-expression group header, the slider inside it, and the master "Opacity / Layer" pair). Both controls are real and distinct — the per-geometry paint value (`fill-opacity` / `line-opacity` / `circle-opacity`) and the master `layer.opacity` multiplier — so this relabels rather than removes.

- Per-geometry sliders: `style.fillOpacity` "Fill opacity", `style.lineOpacity` "Line opacity", `style.pointOpacity` "Point opacity", and `style.heatmap.opacity` now reads "Heatmap opacity".
- Master control: the extra "Opacity" heading is gone; the row is `style.layerOpacity` "Layer opacity". The separator rule it carried is kept.
- `style.opacity` and `style.layer` had no remaining call sites after the rename, so they are removed from all four locales; the four new keys are added to all four.

The issue predicted no test asserted these strings. Four test files did — via the `t` maps in `FillEditor`/`LineEditor`/`CircleEditor` tests and three `getByRole('slider', { name: ... })` lookups in `LayerStyleEditor.test.tsx`. All updated.

No schema, API, or security impact.

## Verification

    cd frontend && npm run lint && npm run typecheck && npm run test:i18n && npx vitest run

358 test files / 4157 tests pass; i18n parity gate green.

Closes #912

https://claude.ai/code/session_01Gjs3zyCByCgjukVrg7DVZv