### PR TITLE
fix(builder): register fill-pattern images in the mixed-geometry adapter

### DIFF
--- a/frontend/src/components/builder/layer-adapters/__tests__/mixed-adapter.test.ts
+++ b/frontend/src/components/builder/layer-adapters/__tests__/mixed-adapter.test.ts
@@ -6,6 +6,7 @@ import {
   mixedLinesLayerId,
   mixedPointsLayerId,
 } from '../mixed-adapter';
+import { FILL_PATTERN_IDS } from '../fill-pattern-images';
 import type { AdapterLayerInput } from '../types';
 
 /**
@@ -28,6 +29,8 @@ function createMockMap(opts: { layerExists?: boolean } = {}) {
     setPaintProperty: vi.fn(),
     getLayoutProperty: vi.fn().mockReturnValue(undefined),
     getPaintProperty: vi.fn().mockReturnValue(undefined),
+    hasImage: vi.fn().mockReturnValue(false),
+    addImage: vi.fn(),
   };
 }
 
@@ -158,6 +161,30 @@ describe('mixed adapter — syncPaint self-heals missing sublayers', () => {
     const map = createMockMap({ layerExists: false });
     mixedAdapter.syncPaint(map as unknown as import('maplibre-gl').Map, makeInput());
     expect(map.addLayer).toHaveBeenCalledTimes(4);
+  });
+});
+
+// fix(#919): the fill sublayer syncs the whole FILL_OWNED_PAINT_PROPERTIES set,
+// fill-pattern included, so the pattern images must be registered — otherwise a
+// patterned polygon family renders empty.
+describe('mixed adapter — fill-pattern images are registered', () => {
+  it('addLayers calls addImage for each fill-pattern id', () => {
+    const map = createMockMap();
+    mixedAdapter.addLayers(map as unknown as import('maplibre-gl').Map, makeInput());
+    expect(map.addImage).toHaveBeenCalledTimes(FILL_PATTERN_IDS.length);
+  });
+
+  it('syncPaint calls addImage for each fill-pattern id', () => {
+    const map = createMockMap({ layerExists: true });
+    mixedAdapter.syncPaint(map as unknown as import('maplibre-gl').Map, makeInput({ paint: { 'fill-pattern': 'geolens-fill-hatch' } }));
+    expect(map.addImage).toHaveBeenCalledTimes(FILL_PATTERN_IDS.length);
+  });
+
+  it('skips ids already present in the image registry', () => {
+    const map = createMockMap();
+    map.hasImage.mockReturnValue(true);
+    mixedAdapter.addLayers(map as unknown as import('maplibre-gl').Map, makeInput());
+    expect(map.addImage).not.toHaveBeenCalled();
   });
 });
 

--- a/frontend/src/components/builder/layer-adapters/mixed-adapter.ts
+++ b/frontend/src/components/builder/layer-adapters/mixed-adapter.ts
@@ -14,6 +14,7 @@ import {
 // the standalone adapters' owned-property sets and defaults instead of duplicating them.
 import { CIRCLE_OWNED_PAINT_PROPERTIES } from './circle-adapter';
 import { FILL_OWNED_PAINT_PROPERTIES, OUTLINE_OWNED_PAINT_PROPERTIES } from './fill-adapter';
+import { ensureFillPatternImages } from './fill-pattern-images';
 import { LINE_OWNED_LAYOUT_PROPERTIES, LINE_OWNED_PAINT_PROPERTIES } from './line-adapter';
 import { DEFAULT_CIRCLE_PAINT, DEFAULT_FILL_PAINT } from './builder-defaults';
 
@@ -261,6 +262,11 @@ export const mixedAdapter: LayerAdapter = {
   type: 'mixed',
 
   addLayers(map: MaplibreMap, input: AdapterLayerInput): void {
+    // fix(#919): syncFillLayer syncs the whole FILL_OWNED_PAINT_PROPERTIES set,
+    // fill-pattern included, so the pattern images must be registered here too —
+    // otherwise a patterned polygon family draws nothing. syncPaint routes
+    // through addLayers, so this one call covers both entry points.
+    ensureFillPatternImages(map);
     try {
       addFillLayer(map, input);
       addOutlineLayer(map, input);


### PR DESCRIPTION
## What changed

On a mixed-geometry layer (`GEOMETRY` / `GEOMETRYCOLLECTION`), a `fill-pattern` in paint made the polygon family render empty. `mixed-adapter.ts` syncs the whole `FILL_OWNED_PAINT_PROPERTIES` set onto its fill sublayer, `fill-pattern` included, and `filterPaintForLayerType(paint, 'fill')` keeps the key — but it was the only fill-rendering adapter that never called `ensureFillPatternImages`, so MapLibre had no image registered under the id and drew nothing.

One call at the top of `addLayers`. `syncPaint` self-heals through `addLayers`, so that single call covers both entry points; the test pins both.

The pattern picker stays hidden for these layers (`isPolygon` is a `.includes('POLYGON')` test both generic sentinels fail), so the key only arrives via Advanced JSON, an AI style action, or a pasted style. Reachable, just not from the picker.

No schema, API, or security impact.

## Verification

    cd frontend && npm run lint && npm run typecheck && npx vitest run src/components/builder/layer-adapters/__tests__/mixed-adapter.test.ts src/components/builder/__tests__/layer-adapters.test.ts

124 tests pass. Three new pins mirror the standalone fill adapter's registration tests: addLayers registers, syncPaint registers, and the `hasImage` idempotency gate still skips.

Closes #919

https://claude.ai/code/session_01Gjs3zyCByCgjukVrg7DVZv