### PR TITLE
fix(ci): stamp per-image OCI titles on published images

### DIFF
--- a/.github/workflows/dep-audit.yml
+++ b/.github/workflows/dep-audit.yml
@@ -48,7 +48,11 @@ jobs:
         run: uv run --with pip-licenses pip-licenses --fail-on="GPL-3.0-only;GPL-3.0;GPL-2.0;AGPL-3.0;SSPL-1.0;BSL-1.1"
 
       # Extend the BLOCKING license gate to the CLI + Python SDK (same allowlist).
-      # Both ship their own uv.lock; `--project` resolves each locked env.
+      # fix(#932): unlike the backend and MCP gates above, these two run against
+      # an UNLOCKED resolution — cli/ and sdks/python/ deliberately gitignore
+      # uv.lock (cli/.gitignore, sdks/python/.gitignore) and have never
+      # committed one, so each run audits whatever resolves that day. That is
+      # acceptable for a copyleft block, but it is not a pinned-tree audit.
       - name: License gate — CLI (block strong/network copyleft)
         working-directory: cli
         run: uv run --with pip-licenses pip-licenses --fail-on="GPL-3.0-only;GPL-3.0;GPL-2.0;AGPL-3.0;SSPL-1.0;BSL-1.1"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -89,7 +89,14 @@ jobs:
             # unreleased candidate (same spirit as #325 gating release.yml's
             # isPrerelease). Fresh `:latest` pulls must track the last GA.
             type=raw,value=latest,enable=${{ github.event_name == 'push' && github.ref_type == 'tag' && !contains(github.ref_name, '-') }}
+          # fix(#932): --label overrides Dockerfile LABEL, and metadata-action's
+          # defaults derive title from the REPO name — without the explicit
+          # title below, all four published images reported title=geolens and
+          # the per-stage Dockerfile titles were discarded. The Dockerfile
+          # LABEL blocks stay: they are the only metadata source on non-publish
+          # build paths (local docker build, compose).
           labels: |
+            org.opencontainers.image.title=${{ matrix.image }}
             org.opencontainers.image.description=${{ matrix.description }}
             org.opencontainers.image.licenses=Apache-2.0
             org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}


### PR DESCRIPTION
## What

One-line fix from #932 (verified correct in the issue body): add `org.opencontainers.image.title=${{ matrix.image }}` to the metadata-action `labels:` input in `publish.yml`. Without it, metadata-action's default derives `title` from the repository name, `--label` overrides Dockerfile `LABEL`, and all four published images report `title=geolens` — the per-stage Dockerfile titles never survive publication. `description` already escapes the default the same way; `title` now does too.

**Dockerfile LABEL decision (as the issue asks the PR to state):** the per-stage `LABEL` blocks are KEPT. On non-publish build paths (local `docker build`, compose builds) they are the only source of title/licenses/source metadata; a comment above the `labels:` block in `publish.yml` records that they are overridden on the publish path so nobody assumes the labels there are decorative or vice versa.

Also the related dep-audit correction from the issue: the comment above the CLI/SDK license gates claimed both "ship their own uv.lock". Neither does — `cli/.gitignore` and `sdks/python/.gitignore` both ignore `uv.lock` by design, and neither lockfile has ever been committed — so those two gates audit an unlocked, resolve-at-CI-time tree. The comment now says exactly that, which stops it reading as a contradiction of the `mcp/uv.lock` gate directly above it.

Per the issue, #893 item 3 (adding a version LABEL) is a false premise and is deliberately NOT acted on: registry images already carry `version` from metadata-action defaults.

## Impact

Published-image metadata only; no runtime behavior change. Takes effect on the next tag publish.

## Verification

- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/publish.yml')); yaml.safe_load(open('.github/workflows/dep-audit.yml'))"` — both parse.
- Dry-run reasoning: the metadata step's `labels:` list is passed verbatim to `build-push-action` at `publish.yml:155`; explicit entries win over metadata-action defaults (documented precedence, and the mechanism `description` already relies on in this same block). `matrix.image` holds exactly `geolens-api`/`geolens-worker`/`geolens-frontend`/`geolens-backup` (`publish.yml:38-47`), so each image's title matches its Dockerfile stage title. The next `v*.*.*` tag publish will show `title=geolens-api` etc. on the registry, replacing `title=geolens`.

Closes #932