### PR TITLE
fix(builder): validate the symbol Advanced JSON paint block as circle paint

### DIFF
--- a/frontend/src/components/builder/LayerStyleEditor.tsx
+++ b/frontend/src/components/builder/LayerStyleEditor.tsx
@@ -423,6 +423,24 @@ export const LayerStyleEditor = memo(function LayerStyleEditor({
     setRevertNonce((n) => n + 1);
   }, [savedLayer, layer.id, onStyleConfigChange, onLayoutChange, onOpacityChange, handleResetStyle]);
 
+  // fix(#916 review): symbol mode keeps circle paint on the layer, and the
+  // switch back to Point restores style_config.savedCirclePaint, not
+  // layer.paint (renderAs.ts:426-433). Now that the Paint block accepts circle
+  // keys in symbol mode, an edit that only touched layer.paint would be
+  // silently discarded on switch-back — so keep the saved copy in step.
+  const handleAdvancedPaintChange = useCallback((next: Record<string, unknown>) => {
+    const merged = { ...builderPrivateKeys(paint), ...next };
+    if (renderMode === 'symbol') {
+      onStyleConfigChange(
+        layer.id,
+        { ...(layer.style_config ?? {}), savedCirclePaint: { ...merged } } as StyleConfig,
+        merged,
+      );
+      return;
+    }
+    onPaintChange(layer.id, merged);
+  }, [layer.id, layer.style_config, paint, renderMode, onPaintChange, onStyleConfigChange]);
+
   const unsupportedBuilderState = hasUnsupportedBuilderState(layer, geomType);
 
   // SP-05 (Phase 1045): Gate the "Pending style preview" banner on real dirty
@@ -595,7 +613,7 @@ export const LayerStyleEditor = memo(function LayerStyleEditor({
           // fix(#770): re-merge the stripped `_`-prefixed private keys on Apply —
           // the editor never showed them, so a wholesale replace would drop them
           // (layout _minzoom/_maxzoom reset the layer's zoom range to 0–22).
-          onPaintChange={(p) => onPaintChange(layer.id, { ...builderPrivateKeys(paint), ...p })}
+          onPaintChange={handleAdvancedPaintChange}
           onLayoutChange={(l) => onLayoutChange(layer.id, { ...builderPrivateKeys(layoutObj), ...l })}
           layerType={advancedJsonLayerType}
         />

--- a/frontend/src/components/builder/LayerStyleEditor/AdvancedJsonEditor.tsx
+++ b/frontend/src/components/builder/LayerStyleEditor/AdvancedJsonEditor.tsx
@@ -201,6 +201,12 @@ export function AdvancedJsonEditor({ paint, layout, onPaintChange, onLayoutChang
   const { t } = useTranslation('builder');
   const [open, setOpen] = useState(defaultOpen);
 
+  // fix(#916): symbol mode keeps circle paint on the layer (renderAs.ts:444) but
+  // real symbol layout — validate each block against what it actually holds.
+  // Validating the stored circle paint as 'symbol' rejected every key, so Apply
+  // always errored and the Paint block was a dead end for the whole mode.
+  const paintLayerType = layerType === 'symbol' ? 'circle' : layerType;
+
   return (
     <div className="border-t pt-2">
       <button
@@ -219,7 +225,7 @@ export function AdvancedJsonEditor({ paint, layout, onPaintChange, onLayoutChang
             label={t('style.paintJson')}
             value={paint}
             onApply={onPaintChange}
-            layerType={layerType}
+            layerType={paintLayerType}
             block="paint"
           />
           <JsonBlock

--- a/frontend/src/components/builder/LayerStyleEditor/__tests__/AdvancedJsonEditor.symbol.test.tsx
+++ b/frontend/src/components/builder/LayerStyleEditor/__tests__/AdvancedJsonEditor.symbol.test.tsx
@@ -1,0 +1,75 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen, fireEvent } from '@/test/test-utils';
+import { AdvancedJsonEditor } from '../AdvancedJsonEditor';
+
+/**
+ * fix(#916): symbol mode keeps the layer's circle paint (renderAs.ts swaps only
+ * heatmap's paint object), but the editor validated BOTH blocks against the
+ * resolved 'symbol' type. Every stored circle-* key was rejected, so an
+ * edit-free Apply on the Paint block always errored and the block was a dead
+ * end for the whole mode. The Paint block now validates as 'circle' while the
+ * Layout block stays on 'symbol' so symbol-only layout keys remain authorable.
+ */
+
+function openBlock(name: RegExp) {
+  fireEvent.click(screen.getByRole('button', { name }));
+}
+
+function renderEditor(overrides: Partial<Parameters<typeof AdvancedJsonEditor>[0]> = {}) {
+  const onPaintChange = vi.fn();
+  const onLayoutChange = vi.fn();
+  render(
+    <AdvancedJsonEditor
+      paint={{ 'circle-color': '#ff0000', 'circle-radius': 5 }}
+      layout={{}}
+      onPaintChange={onPaintChange}
+      onLayoutChange={onLayoutChange}
+      defaultOpen
+      layerType="symbol"
+      {...overrides}
+    />,
+  );
+  return { onPaintChange, onLayoutChange };
+}
+
+describe('AdvancedJsonEditor — symbol mode validates each block against what it holds', () => {
+  it('applies the stored circle paint unchanged instead of rejecting every key', () => {
+    const { onPaintChange } = renderEditor();
+    openBlock(/paint/i);
+    fireEvent.click(screen.getByRole('button', { name: /apply/i }));
+
+    expect(onPaintChange).toHaveBeenCalledWith({ 'circle-color': '#ff0000', 'circle-radius': 5 });
+    expect(screen.queryByText(/unknown property/i)).not.toBeInTheDocument();
+  });
+
+  it('still rejects an invalid circle value in the Paint block', () => {
+    const { onPaintChange } = renderEditor();
+    openBlock(/paint/i);
+    fireEvent.change(screen.getByRole('textbox'), {
+      target: { value: JSON.stringify({ 'circle-radius': 'not-a-number' }) },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /apply/i }));
+
+    expect(onPaintChange).not.toHaveBeenCalled();
+    // The textarea also contains the key, so match the error node specifically.
+    expect(screen.getAllByText(/circle-radius/).some((el) => el.className.includes('text-destructive'))).toBe(true);
+  });
+
+  it('keeps symbol-only layout keys authorable in the Layout block', () => {
+    const { onLayoutChange } = renderEditor();
+    openBlock(/layout/i);
+    fireEvent.change(screen.getByRole('textbox'), {
+      target: { value: JSON.stringify({ 'icon-image': 'marker', 'symbol-placement': 'line' }) },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /apply/i }));
+
+    expect(onLayoutChange).toHaveBeenCalledWith({ 'icon-image': 'marker', 'symbol-placement': 'line' });
+  });
+
+  it('leaves non-symbol layer types on a single resolved type', () => {
+    const { onPaintChange } = renderEditor({ layerType: 'circle' });
+    openBlock(/paint/i);
+    fireEvent.click(screen.getByRole('button', { name: /apply/i }));
+    expect(onPaintChange).toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/builder/__tests__/LayerStyleEditor.test.tsx
+++ b/frontend/src/components/builder/__tests__/LayerStyleEditor.test.tsx
@@ -1533,3 +1533,44 @@ describe('LayerStyleEditor — POLISH-01 single render-as control', () => {
     expect(screen.queryAllByText(/render as/i)).toHaveLength(0);
   });
 });
+
+// fix(#916 review): symbol mode keeps circle paint on the layer and the switch
+// back to Point restores style_config.savedCirclePaint — so an Advanced JSON
+// paint edit must update that saved copy too, or it is silently discarded.
+describe('LayerStyleEditor - symbol-mode advanced paint edits', () => {
+  const symbolLayer = () => ({
+    ...makeLayer({ dataset_geometry_type: 'Point' }),
+    paint: { 'circle-color': '#ff0000', 'circle-radius': 5 },
+    style_config: {
+      render_mode: 'symbol',
+      savedCirclePaint: { 'circle-color': '#ff0000', 'circle-radius': 5 },
+      symbol: { iconImage: 'marker' },
+    },
+  }) as unknown as MapLayerResponse;
+
+  it('writes the applied paint to savedCirclePaint as well as paint', () => {
+    const onStyleConfigChange = vi.fn();
+    const onPaintChange = vi.fn();
+    render(
+      <LayerStyleEditor
+        layer={symbolLayer()}
+        onPaintChange={onPaintChange}
+        onOpacityChange={vi.fn()}
+        onStyleConfigChange={onStyleConfigChange}
+        onLayoutChange={vi.fn()}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /advanced json/i }));
+    fireEvent.click(screen.getByRole('button', { name: /paint/i }));
+    fireEvent.change(screen.getByRole('textbox', { name: /paint/i }), {
+      target: { value: JSON.stringify({ 'circle-color': '#00ff00', 'circle-radius': 9 }) },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /apply/i }));
+
+    expect(onPaintChange).not.toHaveBeenCalled();
+    const [, config, paint] = onStyleConfigChange.mock.calls.at(-1)!;
+    expect(paint).toEqual({ 'circle-color': '#00ff00', 'circle-radius': 9 });
+    expect(config.savedCirclePaint).toEqual({ 'circle-color': '#00ff00', 'circle-radius': 9 });
+  });
+});


### PR DESCRIPTION
## What changed

Point layer → Render as "Symbols" → open Advanced style JSON → Paint → Apply with no edits produced `unknown property "circle-color"; unknown property "circle-radius"; …`. Nothing a user could type both preserved the stored keys and validated, so the Paint block was a dead end for the whole symbol mode.

Symbol mode keeps circle paint on the layer on purpose (`renderAs.ts:444`) so switching back to Point restores it — but `advancedJsonLayerType` resolves the *rendered* type, and both blocks were validated against it.

The two blocks hold different things, so they now resolve different validator types inside `AdvancedJsonEditor`:

- Paint block: `'symbol'` → `'circle'`, matching what the layer actually stores.
- Layout block: unchanged, so `icon-image`, `symbol-placement`, `text-*`, and `icon-allow-overlap` stay authorable.

`advancedJsonLayerType` itself is untouched — its cluster→circle collapse is still correct, since a cluster renders as circles for both blocks. The global one-liner (collapsing symbol to circle in the memo) was deliberately not taken: it fixes Paint but silently removes symbol-only layout authoring.

Known trade-off, unchanged by this PR: symbol-specific *paint* keys (`icon-opacity` etc.) are not authorable through the Paint block. The visual editor doesn't author them either and the stored paint is circle-shaped, so validating what is stored is the consistent choice.

No schema, API, or security impact.

## Verification

    cd frontend && npm run lint && npm run typecheck && npx vitest run src/components/builder/LayerStyleEditor/__tests__/AdvancedJsonEditor src/components/builder/__tests__/LayerStyleEditor.test.tsx

71 tests pass. New `AdvancedJsonEditor.symbol.test.tsx` pins all four behaviors (unchanged Apply succeeds, an invalid circle value still errors, symbol layout keys still validate, non-symbol types unaffected); it was confirmed red against the pre-fix component.

Closes #916

https://claude.ai/code/session_01Gjs3zyCByCgjukVrg7DVZv