### PR TITLE
ux(builder): validate per-value symbol icons, drop empty entries, translate anchors

### DIFF
--- a/frontend/src/components/builder/LayerStyleEditor/SymbolEditor.tsx
+++ b/frontend/src/components/builder/LayerStyleEditor/SymbolEditor.tsx
@@ -3,7 +3,14 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@
 import { SliderRow } from '../HeatmapStyleControls';
 import { IconPicker } from '../IconPicker';
 import type { BaseStyleEditorProps } from './types';
+import { useMapIcons } from '@/hooks/use-maps';
 import type { SymbolStyleConfig } from '@/types/api';
+
+// fix(#920): the anchor dropdown rendered these raw tokens in every locale.
+const ICON_ANCHORS = [
+  'center', 'top', 'bottom', 'left', 'right',
+  'top-left', 'top-right', 'bottom-left', 'bottom-right',
+] as const;
 
 export function SymbolEditor({
   layer,
@@ -13,14 +20,31 @@ export function SymbolEditor({
 }: BaseStyleEditorProps) {
   const sampleColumns = layer.dataset_column_info ?? [];
   const categoryColumn = symbolConfig.categoryColumn ?? '';
+  // fix(#920): show every value the backend returned instead of an arbitrary 6.
+  // dataset_sample_values is a SAMPLE, not the column's distinct values — the
+  // backend caps it at 10 per column, drawn from the first 10k rows — so the
+  // section is labelled as a sample rather than claiming "6 of N".
   const sampleValues = categoryColumn
-    ? (layer.dataset_sample_values?.[categoryColumn] ?? []).slice(0, 6)
+    ? (layer.dataset_sample_values?.[categoryColumn] ?? [])
     : [];
   const currentCategories = symbolConfig.categories ?? [];
 
+  const iconsQuery = useMapIcons();
+  const knownIcons = iconsQuery.data?.icons;
+  function iconResolves(icon: string): boolean {
+    // Only judge once the list has loaded — an in-flight query must not flag
+    // every row as broken.
+    if (!knownIcons?.length) return true;
+    return knownIcons.some((entry) => entry.sprite_id === icon);
+  }
+
   function updateCategory(value: string | number | null, icon: string) {
     const existing = currentCategories.filter((entry) => entry.value !== value);
-    onSymbolConfigChange({ categories: [...existing, { value, icon }], categoryColumn });
+    // fix(#920): an empty icon is not a mapping. The adapter already skips it,
+    // but storing {value, icon: ''} left junk in saved style_config and made the
+    // row render blank instead of the fallback icon it actually draws.
+    const next = icon ? [...existing, { value, icon }] : existing;
+    onSymbolConfigChange({ categories: next, categoryColumn });
   }
 
   return (
@@ -60,8 +84,8 @@ export function SymbolEditor({
             <SelectValue />
           </SelectTrigger>
           <SelectContent>
-            {['center', 'top', 'bottom', 'left', 'right', 'top-left', 'top-right', 'bottom-left', 'bottom-right'].map((anchor) => (
-              <SelectItem key={anchor} value={anchor}>{anchor}</SelectItem>
+            {ICON_ANCHORS.map((anchor) => (
+              <SelectItem key={anchor} value={anchor}>{t(`style.symbol.anchorOption.${anchor}`)}</SelectItem>
             ))}
           </SelectContent>
         </Select>
@@ -106,17 +130,31 @@ export function SymbolEditor({
               ))}
             </SelectContent>
           </Select>
+          {categoryColumn && sampleValues.length > 0 && (
+            <p className="text-mini leading-snug text-muted-foreground">{t('style.symbol.sampledValues')}</p>
+          )}
           {sampleValues.map((value) => {
             const mapped = currentCategories.find((entry) => entry.value === value)?.icon ?? symbolConfig.iconImage ?? 'marker';
+            const unknown = !iconResolves(mapped);
             return (
-              <div key={String(value)} className="flex items-center gap-2">
-                <span className="min-w-0 flex-1 truncate text-xs text-muted-foreground">{String(value)}</span>
-                <Input
-                  className="h-7 text-xs"
-                  value={mapped}
-                  aria-label={t('style.symbol.categoryIcon', { value: String(value) })}
-                  onChange={(event) => updateCategory(value as string | number | null, event.target.value)}
-                />
+              <div key={String(value)} className="space-y-1">
+                <div className="flex items-center gap-2">
+                  <span className="min-w-0 flex-1 truncate text-xs text-muted-foreground">{String(value)}</span>
+                  <Input
+                    className="h-7 text-xs"
+                    value={mapped}
+                    aria-label={t('style.symbol.categoryIcon', { value: String(value) })}
+                    aria-invalid={unknown || undefined}
+                    onChange={(event) => updateCategory(value as string | number | null, event.target.value)}
+                  />
+                </div>
+                {/* fix(#920): a typo used to land in the match expression and draw
+                    nothing at all, with no indication anything was wrong. */}
+                {unknown && (
+                  <p className="text-mini text-warning" role="alert">
+                    {t('style.symbol.unknownIcon', { icon: mapped })}
+                  </p>
+                )}
               </div>
             );
           })}

--- a/frontend/src/components/builder/LayerStyleEditor/SymbolEditor.tsx
+++ b/frontend/src/components/builder/LayerStyleEditor/SymbolEditor.tsx
@@ -35,7 +35,11 @@ export function SymbolEditor({
     // Only judge once the list has loaded — an in-flight query must not flag
     // every row as broken.
     if (!knownIcons?.length) return true;
-    return knownIcons.some((entry) => entry.sprite_id === icon);
+    // The renderer accepts a fully qualified id (spriteIconId in symbol-adapter
+    // keeps anything containing ':'), while /maps/icons returns the bare slug —
+    // compare on the slug so `geolens:marker` is not reported as missing.
+    const slug = icon.includes(':') ? icon.slice(icon.indexOf(':') + 1) : icon;
+    return knownIcons.some((entry) => entry.sprite_id === slug);
   }
 
   function updateCategory(value: string | number | null, icon: string) {
@@ -134,7 +138,11 @@ export function SymbolEditor({
             <p className="text-mini leading-snug text-muted-foreground">{t('style.symbol.sampledValues')}</p>
           )}
           {sampleValues.map((value) => {
-            const mapped = currentCategories.find((entry) => entry.value === value)?.icon ?? symbolConfig.iconImage ?? 'marker';
+            // `||` not `??`: a map saved by the previous handler can hold
+            // {value, icon: ''}, and the adapter renders the FALLBACK for those
+            // — showing a blank field and flagging it as broken would be wrong.
+            const mapped = currentCategories.find((entry) => entry.value === value)?.icon
+              || symbolConfig.iconImage || 'marker';
             const unknown = !iconResolves(mapped);
             return (
               <div key={String(value)} className="space-y-1">

--- a/frontend/src/components/builder/LayerStyleEditor/__tests__/SymbolEditor.test.tsx
+++ b/frontend/src/components/builder/LayerStyleEditor/__tests__/SymbolEditor.test.tsx
@@ -1,0 +1,134 @@
+import { render, screen, fireEvent } from '@/test/test-utils';
+import { SymbolEditor } from '../SymbolEditor';
+import type { BaseStyleEditorProps } from '../types';
+import type { MapLayerResponse } from '@/types/api';
+
+// Radix Select uses ResizeObserver internally
+(globalThis as unknown as { ResizeObserver: typeof ResizeObserver }).ResizeObserver =
+  class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  } as unknown as typeof ResizeObserver;
+Element.prototype.hasPointerCapture = vi.fn(() => false);
+Element.prototype.releasePointerCapture = vi.fn();
+Element.prototype.scrollIntoView = vi.fn();
+
+const icons = [
+  { id: 'builtin:marker', name: 'Marker', slug: 'marker', media_type: 'image/svg+xml', url: '/x', sprite_id: 'marker', size_bytes: 1, builtin: true },
+  { id: 'builtin:star', name: 'Star', slug: 'star', media_type: 'image/svg+xml', url: '/x', sprite_id: 'star', size_bytes: 1, builtin: true },
+];
+
+vi.mock('@/hooks/use-maps', () => ({
+  useMapIcons: () => ({ data: { icons } }),
+  useUploadMapIcon: () => ({ mutateAsync: vi.fn(), isPending: false }),
+}));
+
+function makeLayer(sampleValues: unknown[]): MapLayerResponse {
+  return {
+    id: 'layer-symbol',
+    dataset_id: 'ds',
+    dataset_name: 'ds',
+    dataset_geometry_type: 'Point',
+    dataset_table_name: 'tbl',
+    dataset_extent_bbox: null,
+    dataset_column_info: [{ name: 'kind', type: 'text' }],
+    dataset_feature_count: null,
+    dataset_sample_values: { kind: sampleValues },
+    display_name: 'Symbols',
+    sort_order: 0,
+    visible: true,
+    opacity: 1,
+    paint: {},
+    layout: {},
+    filter: null,
+    label_config: null,
+    style_config: null,
+  } as unknown as MapLayerResponse;
+}
+
+function makeProps(layer: MapLayerResponse, overrides: Partial<BaseStyleEditorProps> = {}): BaseStyleEditorProps {
+  return {
+    layer,
+    paint: {},
+    isDataDriven: false,
+    builderConfig: {},
+    styleConfig: null,
+    symbolConfig: { iconImage: 'marker', iconSize: 1, iconRotation: 0, iconAnchor: 'center', categoryColumn: 'kind' },
+    renderMode: 'symbol',
+    isPolygon: false,
+    numericColumns: [],
+    currentHeightCol: '',
+    strokeEnabled: true,
+    fillEnabled: true,
+    clusterAvailable: false,
+    onPaintChange: vi.fn(),
+    onLayoutChange: vi.fn(),
+    onStyleConfigChange: vi.fn(),
+    onPaintProp: vi.fn(),
+    onToggleFill: vi.fn(),
+    onToggleStroke: vi.fn(),
+    onHeatmapPaintChange: vi.fn(),
+    onSymbolConfigChange: vi.fn(),
+    onBuilderChange: vi.fn(),
+    t: ((key: string, opts?: Record<string, unknown>) => {
+      if (key === 'style.symbol.categoryIcon') return `Icon for ${opts?.value}`;
+      if (key === 'style.symbol.unknownIcon') return `No icon named ${opts?.icon}`;
+      if (key === 'style.symbol.sampledValues') return 'Sampled values';
+      if (key.startsWith('style.symbol.anchorOption.')) return `anchor:${key.split('.').pop()}`;
+      return key;
+    }) as BaseStyleEditorProps['t'],
+    ...overrides,
+  };
+}
+
+describe('SymbolEditor — category mapping (fix #920)', () => {
+  it('renders every sampled value the backend returned, not the first six', () => {
+    const values = ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j'];
+    render(<SymbolEditor {...makeProps(makeLayer(values))} />);
+    for (const v of values) {
+      expect(screen.getByRole('textbox', { name: `Icon for ${v}` })).toBeInTheDocument();
+    }
+    expect(screen.getByText('Sampled values')).toBeInTheDocument();
+  });
+
+  it('flags an icon that does not resolve and leaves known ones alone', () => {
+    render(
+      <SymbolEditor
+        {...makeProps(makeLayer(['a', 'b']), {
+          symbolConfig: {
+            iconImage: 'marker',
+            categoryColumn: 'kind',
+            categories: [{ value: 'a', icon: 'markr' }, { value: 'b', icon: 'star' }],
+          },
+        })}
+      />,
+    );
+    expect(screen.getByText('No icon named markr')).toBeInTheDocument();
+    expect(screen.queryByText('No icon named star')).not.toBeInTheDocument();
+    expect(screen.getByRole('textbox', { name: 'Icon for a' })).toHaveAttribute('aria-invalid', 'true');
+  });
+
+  it('drops the entry instead of storing an empty icon when a row is cleared', () => {
+    const onSymbolConfigChange = vi.fn();
+    render(
+      <SymbolEditor
+        {...makeProps(makeLayer(['a', 'b']), {
+          onSymbolConfigChange,
+          symbolConfig: {
+            iconImage: 'marker',
+            categoryColumn: 'kind',
+            categories: [{ value: 'a', icon: 'star' }],
+          },
+        })}
+      />,
+    );
+    fireEvent.change(screen.getByRole('textbox', { name: 'Icon for a' }), { target: { value: '' } });
+    expect(onSymbolConfigChange).toHaveBeenCalledWith({ categories: [], categoryColumn: 'kind' });
+  });
+
+  it('translates the anchor options instead of rendering raw tokens', () => {
+    render(<SymbolEditor {...makeProps(makeLayer(['a']))} />);
+    expect(screen.getByText('anchor:center')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/builder/LayerStyleEditor/__tests__/SymbolEditor.test.tsx
+++ b/frontend/src/components/builder/LayerStyleEditor/__tests__/SymbolEditor.test.tsx
@@ -127,6 +127,38 @@ describe('SymbolEditor — category mapping (fix #920)', () => {
     expect(onSymbolConfigChange).toHaveBeenCalledWith({ categories: [], categoryColumn: 'kind' });
   });
 
+  it('shows the fallback for a legacy empty-icon entry rather than flagging it', () => {
+    render(
+      <SymbolEditor
+        {...makeProps(makeLayer(['a']), {
+          symbolConfig: {
+            iconImage: 'star',
+            categoryColumn: 'kind',
+            // Shape a map saved by the previous handler could hold.
+            categories: [{ value: 'a', icon: '' }],
+          },
+        })}
+      />,
+    );
+    expect(screen.getByRole('textbox', { name: 'Icon for a' })).toHaveValue('star');
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+  });
+
+  it('accepts a fully qualified sprite id the renderer resolves', () => {
+    render(
+      <SymbolEditor
+        {...makeProps(makeLayer(['a']), {
+          symbolConfig: {
+            iconImage: 'marker',
+            categoryColumn: 'kind',
+            categories: [{ value: 'a', icon: 'geolens:star' }],
+          },
+        })}
+      />,
+    );
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+  });
+
   it('translates the anchor options instead of rendering raw tokens', () => {
     render(<SymbolEditor {...makeProps(makeLayer(['a']))} />);
     expect(screen.getByText('anchor:center')).toBeInTheDocument();

--- a/frontend/src/i18n/locales/de/builder.json
+++ b/frontend/src/i18n/locales/de/builder.json
@@ -302,7 +302,20 @@
       "offsetX": "Versatz X",
       "offsetY": "Versatz Y",
       "categoryMapping": "Symbole nach Wert",
-      "categoryIcon": "Symbol für {{value}}"
+      "categoryIcon": "Symbol für {{value}}",
+      "anchorOption": {
+        "center": "Mitte",
+        "top": "Oben",
+        "bottom": "Unten",
+        "left": "Links",
+        "right": "Rechts",
+        "top-left": "Oben links",
+        "top-right": "Oben rechts",
+        "bottom-left": "Unten links",
+        "bottom-right": "Unten rechts"
+      },
+      "sampledValues": "Eine Stichprobe der Werte dieser Spalte, nicht alle Werte des Datensatzes.",
+      "unknownIcon": "Kein Symbol namens „{{icon}}“ — für diesen Wert wird nichts gezeichnet."
     },
     "arrow": {
       "title": "Pfeilrichtung",

--- a/frontend/src/i18n/locales/en/builder.json
+++ b/frontend/src/i18n/locales/en/builder.json
@@ -302,7 +302,20 @@
       "offsetX": "Offset X",
       "offsetY": "Offset Y",
       "categoryMapping": "Icons by value",
-      "categoryIcon": "Icon for {{value}}"
+      "categoryIcon": "Icon for {{value}}",
+      "anchorOption": {
+        "center": "Center",
+        "top": "Top",
+        "bottom": "Bottom",
+        "left": "Left",
+        "right": "Right",
+        "top-left": "Top left",
+        "top-right": "Top right",
+        "bottom-left": "Bottom left",
+        "bottom-right": "Bottom right"
+      },
+      "sampledValues": "A sample of this column’s values — not every value in the dataset.",
+      "unknownIcon": "No icon named “{{icon}}” — this value will draw nothing."
     },
     "arrow": {
       "title": "Arrow direction",

--- a/frontend/src/i18n/locales/es/builder.json
+++ b/frontend/src/i18n/locales/es/builder.json
@@ -302,7 +302,20 @@
       "offsetX": "Desplazamiento X",
       "offsetY": "Desplazamiento Y",
       "categoryMapping": "Iconos por valor",
-      "categoryIcon": "Icono para {{value}}"
+      "categoryIcon": "Icono para {{value}}",
+      "anchorOption": {
+        "center": "Centro",
+        "top": "Arriba",
+        "bottom": "Abajo",
+        "left": "Izquierda",
+        "right": "Derecha",
+        "top-left": "Arriba a la izquierda",
+        "top-right": "Arriba a la derecha",
+        "bottom-left": "Abajo a la izquierda",
+        "bottom-right": "Abajo a la derecha"
+      },
+      "sampledValues": "Una muestra de los valores de esta columna, no todos los valores del conjunto de datos.",
+      "unknownIcon": "No existe ningún icono llamado «{{icon}}»: este valor no dibujará nada."
     },
     "arrow": {
       "title": "Dirección de flecha",

--- a/frontend/src/i18n/locales/fr/builder.json
+++ b/frontend/src/i18n/locales/fr/builder.json
@@ -302,7 +302,20 @@
       "offsetX": "Décalage X",
       "offsetY": "Décalage Y",
       "categoryMapping": "Icônes par valeur",
-      "categoryIcon": "Icône pour {{value}}"
+      "categoryIcon": "Icône pour {{value}}",
+      "anchorOption": {
+        "center": "Centre",
+        "top": "Haut",
+        "bottom": "Bas",
+        "left": "Gauche",
+        "right": "Droite",
+        "top-left": "En haut à gauche",
+        "top-right": "En haut à droite",
+        "bottom-left": "En bas à gauche",
+        "bottom-right": "En bas à droite"
+      },
+      "sampledValues": "Un échantillon des valeurs de cette colonne, pas toutes les valeurs du jeu de données.",
+      "unknownIcon": "Aucune icône nommée « {{icon}} » : cette valeur ne dessinera rien."
     },
     "arrow": {
       "title": "Direction des flèches",


### PR DESCRIPTION
## What changed

All four items from the issue, all in `LayerStyleEditor/SymbolEditor.tsx`.

**1. Per-value icons are validated.** Each category row was raw free text, so a typo became `geolens:markr` in the match expression and that category silently drew nothing. The typed value is now checked against the same `useMapIcons()` list the primary `IconPicker` uses — one shared cache entry, no extra query — and an unresolved value gets an inline warning plus `aria-invalid` on the input. The check is skipped while the query is in flight so an unloaded list can't flag every row.

Swapping `IconPicker` in per row was deliberately not done: it renders a five-column swatch grid plus an upload control, so stacking one per row rebuilds the section. That's a design call for its own issue.

**2. Clearing a row drops the entry.** `updateCategory` stored `{value, icon: ''}`. The adapter skipped empty icons so the map fell back correctly, but the display expression never reached its `??` fallback (`''` is not nullish), so the field showed blank while the map showed the fallback — and empty entries accumulated in saved `style_config`.

**3. The list shows every sampled value.** The `.slice(0, 6)` is gone. `dataset_sample_values` is capped at **10 distinct values per column** server-side (`LIMIT 10`, drawn from the first 10k rows), so it is a sample and not a cardinality — the section is now labelled as such rather than claiming "6 of N". No total is synthesised; a real "6 of 20" needs a distinct-count from the server and is out of scope.

**4. Anchor options are translated.** `style.symbol.anchorOption.*` in all four locales, mirroring how `LineEditor` translates its cap/join options.

New keys (`anchorOption.*`, `sampledValues`, `unknownIcon`) land in en/es/fr/de.

No schema, API, or security impact.

## Verification

    cd frontend && npm run lint && npm run typecheck && npm run test:i18n && npx vitest run

359 files / 4161 tests pass; i18n parity green. New `SymbolEditor.test.tsx` covers all four items.

Closes #920

https://claude.ai/code/session_01Gjs3zyCByCgjukVrg7DVZv