### PR TITLE
fix(a11y): announce Advanced JSON errors and name the style-editor selects

### DIFF
--- a/frontend/src/components/builder/DataDrivenStyleEditor.tsx
+++ b/frontend/src/components/builder/DataDrivenStyleEditor.tsx
@@ -749,7 +749,7 @@ export function DataDrivenStyleEditor({
       <div className="flex items-center gap-2">
         <span className="text-xs text-muted-foreground w-20">{t('dataDriven.mode')}</span>
         <Select value={mode} onValueChange={(v) => handleModeChange(v as 'categorical' | 'graduated')}>
-          <SelectTrigger className="h-7 text-xs flex-1">
+          <SelectTrigger className="h-7 text-xs flex-1" aria-label={t('dataDriven.mode')}>
             <SelectValue />
           </SelectTrigger>
           <SelectContent>
@@ -771,7 +771,7 @@ export function DataDrivenStyleEditor({
             value={target}
             onValueChange={(v) => handleTargetChange(v as 'color' | 'radius' | 'width')}
           >
-            <SelectTrigger className="h-7 text-xs flex-1">
+            <SelectTrigger className="h-7 text-xs flex-1" aria-label={t('dataDriven.target')}>
               <SelectValue />
             </SelectTrigger>
             <SelectContent>
@@ -792,7 +792,7 @@ export function DataDrivenStyleEditor({
       <div className="flex items-center gap-2">
         <span className="text-xs text-muted-foreground w-20">{t('dataDriven.column')}</span>
         <Select value={column} onValueChange={handleColumnChange}>
-          <SelectTrigger className="h-7 text-xs flex-1">
+          <SelectTrigger className="h-7 text-xs flex-1" aria-label={t('dataDriven.column')}>
             <SelectValue placeholder={t('dataDriven.selectColumn')} />
           </SelectTrigger>
           <SelectContent>
@@ -948,7 +948,7 @@ export function DataDrivenStyleEditor({
           <div className="flex items-center gap-2">
             <span className="text-xs text-muted-foreground w-20">{t('dataDriven.method')}</span>
             <Select value={method} onValueChange={(v) => setMethod(v as ClassificationMethod)}>
-              <SelectTrigger className="h-7 text-xs flex-1">
+              <SelectTrigger className="h-7 text-xs flex-1" aria-label={t('dataDriven.method')}>
                 <SelectValue />
               </SelectTrigger>
               <SelectContent>

--- a/frontend/src/components/builder/HeatmapStyleControls.tsx
+++ b/frontend/src/components/builder/HeatmapStyleControls.tsx
@@ -80,7 +80,7 @@ export const HeatmapStyleControls = memo(function HeatmapStyleControls({
       <div className="space-y-1">
         <div className="text-xs font-medium">{t('style.heatmap.weight')}</div>
         <Select value={weightColumn} onValueChange={handleWeightColumnChange}>
-          <SelectTrigger className="h-8 text-xs">
+          <SelectTrigger className="h-8 text-xs" aria-label={t('style.heatmap.weight')}>
             <SelectValue placeholder={t('style.heatmap.weightNone')} />
           </SelectTrigger>
           <SelectContent>

--- a/frontend/src/components/builder/LayerStyleEditor/AdvancedJsonEditor.tsx
+++ b/frontend/src/components/builder/LayerStyleEditor/AdvancedJsonEditor.tsx
@@ -1,9 +1,10 @@
-import { useState } from 'react';
+import { useId, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { ChevronDown, ChevronRight, Code } from 'lucide-react';
 import { validateStyleMin } from '@maplibre/maplibre-gl-style-spec';
 import { Button } from '@/components/ui/button';
 import { Textarea } from '@/components/ui/textarea';
+import { cn } from '@/lib/utils';
 
 // fix(#431 codex r2): a mixed-geometry (GEOMETRY sentinel) layer's paint and
 // layout span three MapLibre layer types — the adapter fans the same dict out
@@ -113,6 +114,8 @@ function JsonBlock({ label, value, onApply, layerType, block }: JsonBlockProps) 
   const [editing, setEditing] = useState(false);
   const [text, setText] = useState('');
   const [error, setError] = useState<string | null>(null);
+  const contentId = useId();
+  const errorId = useId();
 
   function handleOpen() {
     setText(JSON.stringify(value, null, 2));
@@ -151,31 +154,34 @@ function JsonBlock({ label, value, onApply, layerType, block }: JsonBlockProps) 
     }
   }
 
-  if (!editing) {
-    return (
-      <div>
-        <button
-          type="button"
-          className="cursor-pointer text-xs text-muted-foreground hover:text-foreground underline"
-          onClick={handleOpen}
-        >
-          {label}
-        </button>
-      </div>
-    );
-  }
-
+  // fix(#921): one disclosure button that stays mounted, so its expanded state is
+  // reportable; the error is announced and wired to the textarea.
   return (
     <div className="space-y-1.5">
-      <div className="text-xs font-medium text-muted-foreground">{label}</div>
+      <button
+        type="button"
+        className={cn(
+          'cursor-pointer text-xs hover:text-foreground',
+          editing ? 'font-medium text-muted-foreground' : 'text-muted-foreground underline',
+        )}
+        onClick={() => (editing ? setEditing(false) : handleOpen())}
+        aria-expanded={editing}
+        aria-controls={contentId}
+      >
+        {label}
+      </button>
+      {!editing ? null : (
+      <div id={contentId} className="space-y-1.5">
       <Textarea
         className="text-xs font-mono resize-y min-h-[80px]"
         value={text}
         onChange={(e) => { setText(e.target.value); setError(null); }}
         spellCheck={false}
         aria-label={t('style.jsonTextareaAriaLabel', { block: label })}
+        aria-invalid={error ? true : undefined}
+        aria-describedby={error ? errorId : undefined}
       />
-      {error && <div className="text-xs text-destructive">{error}</div>}
+      {error && <div id={errorId} role="alert" className="text-xs text-destructive">{error}</div>}
       <div className="flex gap-1.5">
         <Button size="sm" className="h-6 text-xs px-2" onClick={handleApply}>
           {t('style.jsonApply')}
@@ -184,6 +190,8 @@ function JsonBlock({ label, value, onApply, layerType, block }: JsonBlockProps) 
           {t('style.jsonCancel')}
         </Button>
       </div>
+      </div>
+      )}
     </div>
   );
 }
@@ -200,6 +208,7 @@ export interface AdvancedJsonEditorProps {
 export function AdvancedJsonEditor({ paint, layout, onPaintChange, onLayoutChange, defaultOpen = false, layerType }: AdvancedJsonEditorProps) {
   const { t } = useTranslation('builder');
   const [open, setOpen] = useState(defaultOpen);
+  const blocksId = useId();
 
   // fix(#916): symbol mode keeps circle paint on the layer (renderAs.ts:444) but
   // real symbol layout — validate each block against what it actually holds.
@@ -214,13 +223,14 @@ export function AdvancedJsonEditor({ paint, layout, onPaintChange, onLayoutChang
         className="flex cursor-pointer items-center gap-1 text-xs font-medium text-muted-foreground hover:text-foreground w-full"
         onClick={() => setOpen((v) => !v)}
         aria-expanded={open}
+        aria-controls={blocksId}
       >
         {open ? <ChevronDown className="h-3 w-3" /> : <ChevronRight className="h-3 w-3 rtl-mirror" />}
         <Code className="h-3 w-3" />
         {t('style.advancedJson')}
       </button>
       {open && (
-        <div className="mt-2 space-y-3">
+        <div id={blocksId} className="mt-2 space-y-3">
           <JsonBlock
             label={t('style.paintJson')}
             value={paint}

--- a/frontend/src/components/builder/LayerStyleEditor/AdvancedJsonEditor.tsx
+++ b/frontend/src/components/builder/LayerStyleEditor/AdvancedJsonEditor.tsx
@@ -117,10 +117,20 @@ function JsonBlock({ label, value, onApply, layerType, block }: JsonBlockProps) 
   const contentId = useId();
   const errorId = useId();
 
-  function handleOpen() {
-    setText(JSON.stringify(value, null, 2));
+  // fix(#921 review): collapsing the block must not throw away a draft. Seed
+  // the text only when there is nothing to preserve; Apply and Cancel are the
+  // two explicit exits that reset it.
+  function handleToggle() {
+    if (editing) { setEditing(false); return; }
+    if (text === '') setText(JSON.stringify(value, null, 2));
     setError(null);
     setEditing(true);
+  }
+
+  function handleCancel() {
+    setText('');
+    setError(null);
+    setEditing(false);
   }
 
   function handleApply() {
@@ -147,6 +157,7 @@ function JsonBlock({ label, value, onApply, layerType, block }: JsonBlockProps) 
         }
       }
       onApply(parsed);
+      setText('');
       setError(null);
       setEditing(false);
     } catch {
@@ -164,34 +175,35 @@ function JsonBlock({ label, value, onApply, layerType, block }: JsonBlockProps) 
           'cursor-pointer text-xs hover:text-foreground',
           editing ? 'font-medium text-muted-foreground' : 'text-muted-foreground underline',
         )}
-        onClick={() => (editing ? setEditing(false) : handleOpen())}
+        onClick={handleToggle}
         aria-expanded={editing}
         aria-controls={contentId}
       >
         {label}
       </button>
-      {!editing ? null : (
-      <div id={contentId} className="space-y-1.5">
-      <Textarea
-        className="text-xs font-mono resize-y min-h-[80px]"
-        value={text}
-        onChange={(e) => { setText(e.target.value); setError(null); }}
-        spellCheck={false}
-        aria-label={t('style.jsonTextareaAriaLabel', { block: label })}
-        aria-invalid={error ? true : undefined}
-        aria-describedby={error ? errorId : undefined}
-      />
-      {error && <div id={errorId} role="alert" className="text-xs text-destructive">{error}</div>}
-      <div className="flex gap-1.5">
-        <Button size="sm" className="h-6 text-xs px-2" onClick={handleApply}>
-          {t('style.jsonApply')}
-        </Button>
-        <Button size="sm" variant="ghost" className="h-6 text-xs px-2" onClick={() => setEditing(false)}>
-          {t('style.jsonCancel')}
-        </Button>
+      {/* fix(#921 review): the aria-controls target stays mounted and `hidden`
+          while collapsed — an id reference that resolves to nothing is exactly
+          what AT hits when it meets the collapsed trigger. */}
+      <div id={contentId} hidden={!editing} className="space-y-1.5">
+        <Textarea
+          className="text-xs font-mono resize-y min-h-[80px]"
+          value={text}
+          onChange={(e) => { setText(e.target.value); setError(null); }}
+          spellCheck={false}
+          aria-label={t('style.jsonTextareaAriaLabel', { block: label })}
+          aria-invalid={error ? true : undefined}
+          aria-describedby={error ? errorId : undefined}
+        />
+        {error && <div id={errorId} role="alert" className="text-xs text-destructive">{error}</div>}
+        <div className="flex gap-1.5">
+          <Button size="sm" className="h-6 text-xs px-2" onClick={handleApply}>
+            {t('style.jsonApply')}
+          </Button>
+          <Button size="sm" variant="ghost" className="h-6 text-xs px-2" onClick={handleCancel}>
+            {t('style.jsonCancel')}
+          </Button>
+        </div>
       </div>
-      </div>
-      )}
     </div>
   );
 }
@@ -229,8 +241,7 @@ export function AdvancedJsonEditor({ paint, layout, onPaintChange, onLayoutChang
         <Code className="h-3 w-3" />
         {t('style.advancedJson')}
       </button>
-      {open && (
-        <div id={blocksId} className="mt-2 space-y-3">
+      <div id={blocksId} hidden={!open} className="mt-2 space-y-3">
           <JsonBlock
             label={t('style.paintJson')}
             value={paint}
@@ -245,8 +256,7 @@ export function AdvancedJsonEditor({ paint, layout, onPaintChange, onLayoutChang
             layerType={layerType}
             block="layout"
           />
-        </div>
-      )}
+      </div>
     </div>
   );
 }

--- a/frontend/src/components/builder/LayerStyleEditor/FillEditor.tsx
+++ b/frontend/src/components/builder/LayerStyleEditor/FillEditor.tsx
@@ -97,7 +97,7 @@ export function FillEditor({
               onBuilderChange({ heightColumn: val === '' || val === '__none__' ? undefined : val });
             }}
           >
-            <SelectTrigger className="h-8 text-xs w-36">
+            <SelectTrigger className="h-8 text-xs w-36" aria-label={t('style.heightColumn', { defaultValue: 'Height column' })}>
               <SelectValue placeholder={t('style.none', { defaultValue: 'None' })} />
             </SelectTrigger>
             <SelectContent>

--- a/frontend/src/components/builder/LayerStyleEditor/RasterStretchControls.tsx
+++ b/frontend/src/components/builder/LayerStyleEditor/RasterStretchControls.tsx
@@ -106,7 +106,7 @@ export function RasterStretchControls({
                   which 422s anything not in that frozenset. There is no codegen guard — adding or
                   renaming a colormap on either side must be mirrored here (and vice-versa). */}
               <Select value={currentColormap} onValueChange={(v) => onPaintProp('_colormap', v)}>
-                <SelectTrigger className="h-8 text-xs flex-1">
+                <SelectTrigger className="h-8 text-xs flex-1" aria-label={t('style.raster.colormapLabel', { defaultValue: 'Colormap' })}>
                   <SelectValue />
                 </SelectTrigger>
                 <SelectContent>
@@ -131,7 +131,7 @@ export function RasterStretchControls({
               {t('style.raster.stretchLabel', { defaultValue: 'Stretch' })}
             </span>
             <Select value={currentStretch} onValueChange={(v) => onPaintProp('_stretch', v)}>
-              <SelectTrigger className="h-8 text-xs flex-1">
+              <SelectTrigger className="h-8 text-xs flex-1" aria-label={t('style.raster.stretchLabel', { defaultValue: 'Stretch' })}>
                 <SelectValue />
               </SelectTrigger>
               <SelectContent>

--- a/frontend/src/components/builder/LayerStyleEditor/SymbolEditor.tsx
+++ b/frontend/src/components/builder/LayerStyleEditor/SymbolEditor.tsx
@@ -84,7 +84,7 @@ export function SymbolEditor({
           value={symbolConfig.iconAnchor ?? 'center'}
           onValueChange={(value) => onSymbolConfigChange({ iconAnchor: value as SymbolStyleConfig['iconAnchor'] })}
         >
-          <SelectTrigger className="h-8 text-xs w-36">
+          <SelectTrigger className="h-8 text-xs w-36" aria-label={t('style.symbol.anchor')}>
             <SelectValue />
           </SelectTrigger>
           <SelectContent>
@@ -124,7 +124,7 @@ export function SymbolEditor({
               categories: value === '__none__' ? undefined : currentCategories,
             })}
           >
-            <SelectTrigger className="h-8 text-xs">
+            <SelectTrigger className="h-8 text-xs" aria-label={t('style.symbol.categoryMapping')}>
               <SelectValue />
             </SelectTrigger>
             <SelectContent>

--- a/frontend/src/components/builder/LayerStyleEditor/__tests__/AdvancedJsonEditor.a11y.test.tsx
+++ b/frontend/src/components/builder/LayerStyleEditor/__tests__/AdvancedJsonEditor.a11y.test.tsx
@@ -43,9 +43,38 @@ describe('AdvancedJsonEditor accessibility', () => {
     expect(document.getElementById(controlled)).not.toBeNull();
   });
 
+  it('keeps a draft when the block is collapsed and reopened', () => {
+    const trigger = open();
+    fireEvent.click(trigger);
+    fireEvent.change(screen.getByRole('textbox'), {
+      target: { value: '{"fill-color": "#00ff00"' },
+    });
+    fireEvent.click(trigger);
+    fireEvent.click(trigger);
+    expect(screen.getByRole('textbox')).toHaveValue('{"fill-color": "#00ff00"');
+  });
+
+  it('discards the draft on an explicit Cancel', () => {
+    const trigger = open();
+    fireEvent.click(trigger);
+    fireEvent.change(screen.getByRole('textbox'), { target: { value: '{"nope"' } });
+    fireEvent.click(screen.getByRole('button', { name: /cancel/i }));
+    fireEvent.click(trigger);
+    expect(screen.getByRole('textbox')).toHaveValue(JSON.stringify({ 'fill-color': '#ff0000' }, null, 2));
+  });
+
+  it('keeps every aria-controls target mounted while collapsed', () => {
+    const trigger = open();
+    // Collapsed block: the referenced element must still exist.
+    expect(document.getElementById(trigger.getAttribute('aria-controls')!)).not.toBeNull();
+    const outer = screen.getByRole('button', { name: /advanced json/i });
+    fireEvent.click(outer);
+    expect(document.getElementById(outer.getAttribute('aria-controls')!)).not.toBeNull();
+  });
+
   it('gives the outer Advanced JSON trigger an aria-controls target', () => {
     open();
-    const outer = screen.getByRole('button', { name: /style\.advancedJson|advanced/i });
+    const outer = screen.getByRole('button', { name: /advanced json/i });
     expect(outer).toHaveAttribute('aria-expanded', 'true');
     expect(document.getElementById(outer.getAttribute('aria-controls')!)).not.toBeNull();
   });

--- a/frontend/src/components/builder/LayerStyleEditor/__tests__/AdvancedJsonEditor.a11y.test.tsx
+++ b/frontend/src/components/builder/LayerStyleEditor/__tests__/AdvancedJsonEditor.a11y.test.tsx
@@ -1,0 +1,52 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen, fireEvent } from '@/test/test-utils';
+import { AdvancedJsonEditor } from '../AdvancedJsonEditor';
+
+/**
+ * fix(#921): validation errors were rendered in a bare div, so pressing Apply
+ * told a screen-reader user nothing, and the disclosure triggers never reported
+ * their expanded state.
+ */
+describe('AdvancedJsonEditor accessibility', () => {
+  function open() {
+    render(
+      <AdvancedJsonEditor
+        paint={{ 'fill-color': '#ff0000' }}
+        layout={{}}
+        onPaintChange={vi.fn()}
+        onLayoutChange={vi.fn()}
+        defaultOpen
+        layerType="fill"
+      />,
+    );
+    return screen.getByRole('button', { name: /paint/i });
+  }
+
+  it('announces a validation error and wires it to the textarea', () => {
+    fireEvent.click(open());
+    const textarea = screen.getByRole('textbox');
+    fireEvent.change(textarea, { target: { value: JSON.stringify({ 'line-color': '#fff' }) } });
+    fireEvent.click(screen.getByRole('button', { name: /apply/i }));
+
+    const alert = screen.getByRole('alert');
+    expect(alert).toBeInTheDocument();
+    expect(textarea).toHaveAttribute('aria-invalid', 'true');
+    expect(textarea).toHaveAttribute('aria-describedby', alert.id);
+  });
+
+  it('reports the block disclosure state and controls its content', () => {
+    const trigger = open();
+    expect(trigger).toHaveAttribute('aria-expanded', 'false');
+    fireEvent.click(trigger);
+    expect(trigger).toHaveAttribute('aria-expanded', 'true');
+    const controlled = trigger.getAttribute('aria-controls')!;
+    expect(document.getElementById(controlled)).not.toBeNull();
+  });
+
+  it('gives the outer Advanced JSON trigger an aria-controls target', () => {
+    open();
+    const outer = screen.getByRole('button', { name: /style\.advancedJson|advanced/i });
+    expect(outer).toHaveAttribute('aria-expanded', 'true');
+    expect(document.getElementById(outer.getAttribute('aria-controls')!)).not.toBeNull();
+  });
+});


### PR DESCRIPTION
## What changed

**1. Advanced JSON errors are announced.** The validation error rendered in a bare `<div className="text-xs text-destructive">` with no role, and the textarea had no `aria-invalid`/`aria-describedby` — a screen-reader user pressed Apply and heard nothing. The error now carries `role="alert"` (the pattern `ZoomExpressionEditor.tsx:325` already uses) and the textarea points at it via `aria-describedby`.

**2. Disclosure state is reported.** Each Paint/Layout block previously swapped its trigger button out for the editor on open, so there was no element left to carry `aria-expanded`. Each block now keeps one mounted toggle with `aria-expanded` + `aria-controls`, and the outer Advanced JSON collapsible gained the `aria-controls` it was missing.

**3. Ten `SelectTrigger`s get accessible names.** Their computed name was just the current value ("center", "Quantile"). Each now takes its adjacent visual label as `aria-label`, reusing the existing i18n string — no new keys:

- `FillEditor.tsx` (height column)
- `SymbolEditor.tsx` (anchor, category column)
- `HeatmapStyleControls.tsx` (weight column)
- `RasterStretchControls.tsx` (colormap, stretch)
- `DataDrivenStyleEditor.tsx` (mode, target, column, method)

**Flagged, not changed** (per the issue): Cancel still discards typed JSON with no dirty check. Left as-is deliberately; worth a decision of its own.

No schema, API, or security impact.

## Verification

    cd frontend && npm run lint && npm run typecheck && npm run test:coverage

New `AdvancedJsonEditor.a11y.test.tsx` pins the alert wiring and both disclosure contracts.

One unrelated flake: `StackRow.test.tsx > "a space can be typed into the rename input…"` fails intermittently under the full parallel run and passes in isolation. Confirmed it fails the same way on a clean `origin/main` worktree with this diff stashed, so it is not from this change.

Closes #921

https://claude.ai/code/session_01Gjs3zyCByCgjukVrg7DVZv