### PR TITLE
fix(builder): clear the unsaved flag when a style Revert restores the saved state

### DIFF
--- a/frontend/src/components/builder/LayerEditorPanel.tsx
+++ b/frontend/src/components/builder/LayerEditorPanel.tsx
@@ -32,6 +32,10 @@ export interface LayerEditorHandlers {
   // boundaries (e.g. line→arrow leaving behind line-cap / line-join).
   onRenderModeChange?: (layerId: string, mode: RenderAsId) => void;
   onRemove: (layerId: string) => void;
+  /** fix(#913): called after a banner Revert so the page can re-derive whether
+   *  the map is still dirty (the revert itself routes through the ordinary
+   *  mutation handlers, which all mark it dirty). */
+  onRevertToSaved?: () => void;
 }
 
 interface LayerEditorPanelProps {
@@ -555,6 +559,7 @@ export const LayerEditorPanel = memo(function LayerEditorPanel({
                       onOpacityChange={handlers.onOpacityChange}
                       onStyleConfigChange={handlers.onStyleConfigChange}
                       onLayoutChange={handlers.onLayoutChange}
+                      onRevertToSaved={handlers.onRevertToSaved}
                     />
                   )}
                 </div>

--- a/frontend/src/components/builder/LayerStyleEditor.tsx
+++ b/frontend/src/components/builder/LayerStyleEditor.tsx
@@ -41,6 +41,13 @@ interface LayerStyleEditorProps {
   onOpacityChange?: (layerId: string, opacity: number) => void;
   onStyleConfigChange: (layerId: string, config: StyleConfig | null, paint: Record<string, unknown>, opts?: { replace?: boolean }) => void;
   onLayoutChange: (layerId: string, layout: Record<string, unknown>) => void;
+  /**
+   * fix(#913): banner Revert restores the baseline through the ordinary mutation
+   * handlers, each of which marks the map dirty — so the revert re-dirtied the
+   * map and the header kept claiming unsaved work. The owner of the baseline
+   * re-derives cleanliness here; it only clears when the WHOLE map is clean.
+   */
+  onRevertToSaved?: () => void;
 }
 
 // Re-export hasUnsavedStyleChanges so existing callers (tests etc.) can still
@@ -129,6 +136,7 @@ export const LayerStyleEditor = memo(function LayerStyleEditor({
   onOpacityChange,
   onStyleConfigChange,
   onLayoutChange,
+  onRevertToSaved,
 }: LayerStyleEditorProps) {
   const { t } = useTranslation('builder');
   const geomType = getLayerType(layer.dataset_geometry_type);
@@ -421,7 +429,9 @@ export const LayerStyleEditor = memo(function LayerStyleEditor({
     // Remount DataDrivenStyleEditor so its local ramp/mode/column re-seed from the
     // restored config instead of re-applying the just-discarded selection.
     setRevertNonce((n) => n + 1);
-  }, [savedLayer, layer.id, onStyleConfigChange, onLayoutChange, onOpacityChange, handleResetStyle]);
+    // The handlers above mark the map dirty; ask the baseline owner to recheck.
+    onRevertToSaved?.();
+  }, [savedLayer, layer.id, onStyleConfigChange, onLayoutChange, onOpacityChange, handleResetStyle, onRevertToSaved]);
 
   // fix(#916 review): symbol mode keeps circle paint on the layer, and the
   // switch back to Point restores style_config.savedCirclePaint, not

--- a/frontend/src/components/builder/LayerStyleEditor/utils.ts
+++ b/frontend/src/components/builder/LayerStyleEditor/utils.ts
@@ -31,7 +31,7 @@ export function hasUnsavedStyleChanges(
 // Small inline deep-equality for plain JSON-ish values (objects, arrays,
 // primitives, null). Sufficient for paint/layout/style_config which are JSON.
 // Avoids pulling in lodash for a one-call surface.
-function deepEqual(a: unknown, b: unknown): boolean {
+export function deepEqual(a: unknown, b: unknown): boolean {
   if (a === b) return true;
   if (a === null || b === null || typeof a !== 'object' || typeof b !== 'object') {
     return false;

--- a/frontend/src/components/builder/__tests__/MapBuilderPage.settings-wiring.test.tsx
+++ b/frontend/src/components/builder/__tests__/MapBuilderPage.settings-wiring.test.tsx
@@ -14,9 +14,10 @@ import { usePluginStore } from '@/stores/map-plugin-store';
 
 let mockMapData: Record<string, unknown>;
 
-const { mockSetHasUnsavedChanges, mockSetBasemapConfig } = vi.hoisted(() => ({
+const { mockSetHasUnsavedChanges, mockSetBasemapConfig, mockMarkDirty } = vi.hoisted(() => ({
   mockSetHasUnsavedChanges: vi.fn(),
   mockSetBasemapConfig: vi.fn(),
+  mockMarkDirty: vi.fn(),
 }));
 
 vi.mock('react-i18next', () => ({
@@ -148,7 +149,8 @@ vi.mock('@/components/builder/hooks/use-builder-layers', () => ({
     initialViewState: null,
     ephemeralResult: null,
     groupMeta: {},
-    markDirty: vi.fn(),
+    markDirty: mockMarkDirty,
+    requestCleanRecheck: vi.fn(),
     handleToggleExpand: vi.fn(),
     handleTabChange: vi.fn(),
     handlePaintChange: vi.fn(),
@@ -230,6 +232,7 @@ describe('MapBuilderPage settings wiring (plugin dirty + projection persistence)
     mockMapData = makeMapData();
     mockSetHasUnsavedChanges.mockClear();
     mockSetBasemapConfig.mockClear();
+    mockMarkDirty.mockClear();
     usePluginStore.getState().replace([]);
     localStorage.clear();
   });
@@ -240,7 +243,9 @@ describe('MapBuilderPage settings wiring (plugin dirty + projection persistence)
     const measureSwitch = await screen.findByRole('switch', { name: 'Enable measurement' });
     fireEvent.click(measureSwitch);
 
-    expect(mockSetHasUnsavedChanges).toHaveBeenCalledWith(true);
+    // fix(#913): page-owned dirt routes through markDirty, which also records
+    // that the clean-state recheck cannot re-derive it from server state.
+    expect(mockMarkDirty).toHaveBeenCalled();
   });
 
   it('F3: choosing Globe writes projection into the basemap config', async () => {

--- a/frontend/src/components/builder/hooks/__tests__/use-builder-layers.clean-recheck.test.ts
+++ b/frontend/src/components/builder/hooks/__tests__/use-builder-layers.clean-recheck.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect, vi } from 'vitest';
+import { act } from '@testing-library/react';
+import { renderHook } from '@/test/test-utils';
+import { useBuilderLayers } from '@/components/builder/hooks/use-builder-layers';
+import {
+  makeBuilderLayer,
+  makeBuilderMap,
+} from '@/components/builder/__tests__/fixtures/map-builder-fixtures';
+import type { MapResponse } from '@/types/api';
+
+type MaplibreMap = import('maplibre-gl').Map;
+
+/**
+ * fix(#913): a banner Revert restored the saved layer through the ordinary
+ * mutation handlers, all of which mark the map dirty — so the revert itself
+ * re-dirtied the map and the header kept claiming unsaved work. The recheck
+ * clears the flag only when the WHOLE map matches its saved state.
+ */
+function render(mapData: MapResponse) {
+  const mapRef = { current: null } as React.RefObject<MaplibreMap | null>;
+  return renderHook(() =>
+    useBuilderLayers(
+      mapData,
+      mapRef,
+      'map-1',
+      { mutate: vi.fn() } as unknown as Parameters<typeof useBuilderLayers>[3],
+      { mutate: vi.fn() } as unknown as Parameters<typeof useBuilderLayers>[4],
+      { current: () => {} } as unknown as Parameters<typeof useBuilderLayers>[5],
+    ),
+  );
+}
+
+describe('useBuilderLayers — clean-state recheck', () => {
+  it('clears the flag when a layer edit is undone back to the baseline', () => {
+    const layer = makeBuilderLayer();
+    const { result } = render(makeBuilderMap([layer]));
+
+    act(() => result.current.handlePaintChange(layer.id, { 'fill-color': '#123456' }));
+    expect(result.current.hasUnsavedChanges).toBe(true);
+
+    act(() => {
+      result.current.handlePaintChange(layer.id, layer.paint as Record<string, unknown>);
+      result.current.requestCleanRecheck();
+    });
+    expect(result.current.hasUnsavedChanges).toBe(false);
+  });
+
+  it('keeps the flag when another layer still has pending edits', () => {
+    const a = makeBuilderLayer({ id: 'layer-a' });
+    const b = makeBuilderLayer({ id: 'layer-b' });
+    const { result } = render(makeBuilderMap([a, b]));
+
+    act(() => {
+      result.current.handlePaintChange('layer-a', { 'fill-color': '#123456' });
+      result.current.handlePaintChange('layer-b', { 'fill-color': '#654321' });
+    });
+    act(() => {
+      result.current.handlePaintChange('layer-b', b.paint as Record<string, unknown>);
+      result.current.requestCleanRecheck();
+    });
+
+    expect(result.current.hasUnsavedChanges).toBe(true);
+  });
+
+  it('keeps the flag when the map name is still renamed', () => {
+    const layer = makeBuilderLayer();
+    const { result } = render(makeBuilderMap([layer]));
+
+    act(() => {
+      result.current.setLocalName('Renamed');
+      result.current.handlePaintChange(layer.id, { 'fill-color': '#123456' });
+    });
+    act(() => {
+      result.current.handlePaintChange(layer.id, layer.paint as Record<string, unknown>);
+      result.current.requestCleanRecheck();
+    });
+
+    expect(result.current.hasUnsavedChanges).toBe(true);
+  });
+
+  it('keeps the flag for an outstanding opacity change on another layer', () => {
+    const a = makeBuilderLayer({ id: 'layer-a' });
+    const b = makeBuilderLayer({ id: 'layer-b' });
+    const { result } = render(makeBuilderMap([a, b]));
+
+    act(() => {
+      result.current.handleOpacityChange('layer-a', 0.4);
+      result.current.handlePaintChange('layer-b', { 'fill-color': '#654321' });
+    });
+    act(() => {
+      result.current.handlePaintChange('layer-b', b.paint as Record<string, unknown>);
+      result.current.requestCleanRecheck();
+    });
+
+    expect(result.current.hasUnsavedChanges).toBe(true);
+  });
+
+  it('keeps the flag for page-owned dirt it cannot re-derive (markDirty)', () => {
+    const layer = makeBuilderLayer();
+    const { result } = render(makeBuilderMap([layer]));
+
+    act(() => {
+      result.current.markDirty();
+      result.current.handlePaintChange(layer.id, { 'fill-color': '#123456' });
+    });
+    act(() => {
+      result.current.handlePaintChange(layer.id, layer.paint as Record<string, unknown>);
+      result.current.requestCleanRecheck();
+    });
+
+    expect(result.current.hasUnsavedChanges).toBe(true);
+  });
+});

--- a/frontend/src/components/builder/hooks/use-builder-layers.ts
+++ b/frontend/src/components/builder/hooks/use-builder-layers.ts
@@ -10,6 +10,7 @@ import {
   type BuilderLayerAction,
 } from '@/components/builder/builder-action-contract';
 import { resolveBasemapId } from '@/lib/basemap-utils';
+import { deepEqual } from '@/components/builder/LayerStyleEditor/utils';
 import type { MapBasemapConfig, MapLayerResponse, MapResponse, MapTerrainConfig, StyleConfig } from '@/types/api';
 import type { useAddLayer, useRemoveLayer } from '@/hooks/use-maps';
 import { useEphemeralLayers } from '@/components/builder/hooks/use-ephemeral-layers';
@@ -38,6 +39,16 @@ import { useRenderModeLayers } from '@/components/builder/hooks/use-render-mode-
 import { useLayerStyleClipboard } from '@/components/builder/hooks/use-layer-style-clipboard';
 import { useTileConfig } from '@/hooks/use-settings';
 export { buildDuplicateRenderingInput } from '@/components/builder/hooks/builder-layer-mutations';
+
+// fix(#913): the hydrated shape of mapData.terrain_config, shared by the load
+// path and the clean-state recheck so the two cannot drift.
+function savedTerrainConfig(mapData: { terrain_config?: MapTerrainConfig | null }): MapTerrainConfig | null {
+  if (!mapData.terrain_config) return null;
+  return {
+    ...mapData.terrain_config,
+    exaggeration: normalizeTerrainExaggeration(mapData.terrain_config.exaggeration),
+  };
+}
 
 export function useBuilderLayers(
   mapData: MapResponse | undefined,
@@ -71,6 +82,18 @@ export function useBuilderLayers(
   const layersMapIdRef = useRef<string | null>(null);
   const [localBasemap, setLocalBasemap] = useState<string>('openfreemap-positron');
   const [hasUnsavedChanges, setHasUnsavedChanges] = useState(false);
+  // fix(#913): dirt this hook cannot re-derive from server state — plugin
+  // toggles and other page-owned edits that go through markDirty. recheckClean
+  // refuses to clear the flag while it is set; every reset back to "saved"
+  // clears it.
+  const opaqueDirtyRef = useRef(false);
+  const setHasUnsavedChangesTracked = useCallback(
+    (next: React.SetStateAction<boolean>) => {
+      if (next === false) opaqueDirtyRef.current = false;
+      setHasUnsavedChanges(next);
+    },
+    [],
+  );
   const [expandedLayerId, setExpandedLayerId] = useState<string | null>(null);
   const [activeEditorTab, setActiveEditorTab] = useState<'style' | 'filter' | 'labels' | 'popup' | null>(null);
   const [showBasemapLabels, setShowBasemapLabels] = useState(true);
@@ -233,6 +256,7 @@ export function useBuilderLayers(
       mapData.id !== layersMapIdRef.current
     ) {
       initializedRef.current = false;
+      opaqueDirtyRef.current = false;
       setHasUnsavedChanges(false);
     }
   }, [mapData]);
@@ -247,12 +271,7 @@ export function useBuilderLayers(
       setLocalBasemap(resolveBasemapId(mapData.basemap_style || 'positron'));
       setShowBasemapLabels(mapData.show_basemap_labels ?? true);
       _setBasemapConfigRaw(mapData.basemap_config ?? null);
-      setLocalTerrainConfig(mapData.terrain_config
-        ? {
-            ...mapData.terrain_config,
-            exaggeration: normalizeTerrainExaggeration(mapData.terrain_config.exaggeration),
-          }
-        : null);
+      setLocalTerrainConfig(savedTerrainConfig(mapData));
       setGroupMeta({
         ...hydrated.groupMeta,
         ...((mapData as { group_meta?: Record<string, { expanded: boolean }> }).group_meta ?? {}),
@@ -823,7 +842,57 @@ export function useBuilderLayers(
     );
   }, [addLayerMutation, mapId, t, saveBaselineSyncRef]);
 
-  const markDirty = useCallback(() => setHasUnsavedChanges(true), []);
+  const markDirty = useCallback(() => {
+    opaqueDirtyRef.current = true;
+    setHasUnsavedChanges(true);
+  }, []);
+
+  // fix(#913): a banner Revert restores the saved layer through the ordinary
+  // mutation handlers, and every one of those marks the map dirty — so the
+  // revert itself re-dirtied the map and nothing ever cleared the flag. Rather
+  // than special-casing the revert path, recompute: clear the flag only when
+  // every layer matches the saved baseline AND no map-level field diverges from
+  // server state. Comparing the full layer objects (not just paint/layout/
+  // style_config, which is all hasUnsavedStyleChanges covers) is what keeps an
+  // outstanding opacity change, reorder, rename, visibility toggle, or layer
+  // add/remove from reading as clean.
+  const computeMapIsClean = useCallback((): boolean => {
+    if (!mapData || opaqueDirtyRef.current) return false;
+
+    const baseline = savedLayerBaselineRef.current;
+    const current = layersRef.current;
+    if (current.length !== baseline.length) return false;
+    const savedById = new Map(baseline.map((l) => [l.id, l]));
+    for (let i = 0; i < current.length; i += 1) {
+      const saved = savedById.get(current[i].id);
+      // Order matters (sort_order is persisted), so compare position too.
+      if (!saved || saved.id !== baseline[i].id || !deepEqual(current[i], saved)) return false;
+    }
+
+    if (localName !== mapData.name) return false;
+    if (localDescription !== (mapData.description ?? '')) return false;
+    if (localLegendTitle !== (mapData.legend_title ?? null)) return false;
+    if (localBasemap !== resolveBasemapId(mapData.basemap_style || 'positron')) return false;
+    if (showBasemapLabels !== (mapData.show_basemap_labels ?? true)) return false;
+    if (!deepEqual(basemapConfig, mapData.basemap_config ?? null)) return false;
+    if (!deepEqual(localTerrainConfig, savedTerrainConfig(mapData))) return false;
+
+    return true;
+  }, [
+    mapData, localName, localDescription, localLegendTitle, localBasemap,
+    showBasemapLabels, basemapConfig, localTerrainConfig,
+  ]);
+
+  // The recheck must observe the reverted layers, so it runs in an effect after
+  // commit rather than inline in the revert handler. The nonce and the layer
+  // updates batch into the same render, so one request costs one pass.
+  const [recheckNonce, setRecheckNonce] = useState(0);
+  const requestCleanRecheck = useCallback(() => setRecheckNonce((n) => n + 1), []);
+  useEffect(() => {
+    if (recheckNonce === 0) return;
+    if (computeMapIsClean()) setHasUnsavedChanges(false);
+  // eslint-disable-next-line react-hooks/exhaustive-deps -- fires only on an explicit request
+  }, [recheckNonce]);
 
   // fix(v1.6.0 audit D7): identity-stable "is this row a folder group?" lookup.
   // Reads through layersRef so callers (MapBuilderPage's memoized
@@ -953,7 +1022,8 @@ export function useBuilderLayers(
     freshLayerId,
     savedLayerBaseline: savedLayerBaselineRef.current,
     localBasemap, setLocalBasemap,
-    hasUnsavedChanges, setHasUnsavedChanges,
+    hasUnsavedChanges, setHasUnsavedChanges: setHasUnsavedChangesTracked,
+    requestCleanRecheck,
     expandedLayerId,
     activeEditorTab,
     showBasemapLabels, setShowBasemapLabels,

--- a/frontend/src/pages/MapBuilderPage.tsx
+++ b/frontend/src/pages/MapBuilderPage.tsx
@@ -248,7 +248,6 @@ export function MapBuilderPage() {
     saveBaselineSyncRef,
   );
   const {
-    setHasUnsavedChanges,
     handleBulkVisibility: applyBulkVisibility,
     handleBulkOpacity: applyBulkOpacity,
     handleBulkGroup: applyBulkGroup,
@@ -483,12 +482,15 @@ export function MapBuilderPage() {
       layerId,
       persistence: 'server',
     }),
-  }), [dispatchLayerAction, handleRenderModeChange, handleTabChange]);
+    // fix(#913): the revert routes through the mutation handlers above, so the
+    // map is re-marked dirty on the way back to its saved state. Ask the
+    // baseline owner to re-derive; it clears only when the WHOLE map is clean.
+    onRevertToSaved: layers.requestCleanRecheck,
+  }), [dispatchLayerAction, handleRenderModeChange, handleTabChange, layers.requestCleanRecheck]);
 
-  const handleMarkDirty = useCallback(
-    () => { setHasUnsavedChanges(true); },
-    [setHasUnsavedChanges],
-  );
+  // fix(#913): route page-owned dirt through markDirty so the clean-state
+  // recheck knows it cannot re-derive this from server state.
+  const handleMarkDirty = layers.markDirty;
 
   // Plugin toggles live in a store outside the layer state that drives
   // hasUnsavedChanges, so wrap the toggle to mark the map dirty — otherwise the
@@ -497,9 +499,9 @@ export function MapBuilderPage() {
   const handleTogglePlugin = useCallback(
     (pluginId: string) => {
       togglePlugin(pluginId);
-      setHasUnsavedChanges(true);
+      layers.markDirty();
     },
-    [togglePlugin, setHasUnsavedChanges],
+    [togglePlugin, layers],
   );
 
   // Projection persists on basemap_config.projection. Route through the basemap


### PR DESCRIPTION
## What changed

Editing a layer's style, then clicking the "Pending style preview" banner's Revert, left the header on "Unsaved changes" and armed the beforeunload prompt even though nothing differed from the server.

`handleRevertToSaved` restores the baseline through the ordinary mutation handlers (`onStyleConfigChange`, `onLayoutChange`, `onOpacityChange`), and every layer mutation funnels through `applyLayerUpdate`, which calls `setHasUnsavedChanges(true)` unconditionally. So the revert re-marked the map dirty on its way back to clean, and nothing ever cleared the flag.

Rather than special-casing the revert path, the flag is now **recomputed**. A banner Revert calls `onRevertToSaved`, threaded from the page (which owns both `savedLayerBaselineRef` and `setHasUnsavedChanges`) through the editor handlers. The recheck clears the flag only when:

- every layer matches the saved baseline, compared as **whole layer objects** and in order, and
- no map-level field diverges from server state: name, description, legend title, basemap, basemap labels, `basemap_config`, `terrain_config`, and
- no page-owned dirt is outstanding.

Per the issue's warning, `hasUnsavedStyleChanges` is **not** reused as the cleanliness oracle — it compares only `paint`/`layout`/`style_config` and would report a false "Saved" whenever the outstanding dirt is an opacity change, reorder, rename, visibility toggle, or layer add/remove.

Page-owned dirt the hook cannot re-derive from server state (plugin toggles, and anything else going through `markDirty`) sets a flag that blocks the recheck outright, so a plugin-only edit can never be cleared by reverting a layer. The exported `setHasUnsavedChanges` clears that flag whenever it is set to `false`, so save and map-switch reset it.

The recheck runs in an effect rather than inline, so it observes the reverted layers after commit; the request nonce batches into the same render, so one revert costs one pass.

Terrain hydration moved into a shared `savedTerrainConfig(mapData)` helper so the load path and the recheck cannot drift.

No schema, API, or security impact.

## Verification

    cd frontend && npm run lint && npm run typecheck && npx vitest run

359 files / 4162 tests pass. New `use-builder-layers.clean-recheck.test.ts` covers all four acceptance cases (revert one layer → clean; two edited, one reverted → dirty; renamed map + reverted layer → dirty; opacity on layer A + revert layer B → dirty) plus the markDirty block. `MapBuilderPage.settings-wiring.test.tsx` F2 updated: the plugin toggle now asserts on `markDirty` rather than the raw setter.

Closes #913

https://claude.ai/code/session_01Gjs3zyCByCgjukVrg7DVZv