### PR TITLE
test(backend): late-bind fixture-redirected helpers and guard the import shape

### DIFF
--- a/backend/app/api/main.py
+++ b/backend/app/api/main.py
@@ -27,7 +27,10 @@ from app.observability.metrics import init_metrics
 from app.platform.cache.provider import init_tile_cache
 
 # settings already imported above for the tempdir override — do NOT reimport
-from app.core.db import async_session, engine
+# fix(#909): async_session/engine are late-bound inside each function that
+# uses them. A module-scope `from app.core.db import ...` snapshots the
+# dev-DB objects before the test fixture rebinds app.core.db, so lifespan
+# seed functions in tests would silently hit the dev database.
 from app.core.db.tenant_session import tenant_job_context
 from app.core.logging_config import setup_logging
 from app.core.tenancy import is_multi_tenant
@@ -81,6 +84,8 @@ async def seed_roles() -> None:
     unique constraint and crashing the loser's startup *before* the admin-seed
     lock is ever reached.
     """
+    from app.core.db import async_session  # fix(#909): late-bind for tests
+
     async with async_session() as session:
         await session.execute(
             text("SELECT pg_advisory_xact_lock(:k)"), {"k": _SEED_LOCK_KEY}
@@ -135,6 +140,8 @@ async def seed_initial_admin() -> None:
     xact-scoped advisory lock makes exactly one worker seed; the rest see
     count>0 and no-op. The lock releases when the session's transaction ends.
     """
+    from app.core.db import async_session  # fix(#909): late-bind for tests
+
     async with async_session() as session:
         await session.execute(
             text("SELECT pg_advisory_xact_lock(:k)"), {"k": _SEED_LOCK_KEY}
@@ -190,6 +197,7 @@ async def sweep_stale_jobs_once(
     ``ingest_jobs`` reads and writes. Recovery is best-effort per tenant: one
     broken tenant must not prevent the remaining tenants from being swept.
     """
+    from app.core.db import async_session  # fix(#909): late-bind for tests
     from app.platform.jobs.router import fail_stale_jobs
 
     if not is_multi_tenant():
@@ -255,6 +263,8 @@ async def sweep_stale_jobs_once(
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
+    from app.core.db import engine  # fix(#909): late-bind for tests
+
     for attempt in range(1, 4):
         try:
             async with engine.connect() as conn:

--- a/backend/app/core/db/rls.py
+++ b/backend/app/core/db/rls.py
@@ -318,7 +318,10 @@ async def apply_tenancy_rls_from_engine(*, verify_runtime_role: bool = True) -> 
         may pass ``verify_runtime_role=False`` while preparing the schema; API
         and worker bootstrap always use the default verification.
     """
-    from app.core.db.session import engine
+    # fix(#909): via the app.core.db façade, not app.core.db.session — the test
+    # fixture reassigns the façade attribute, so importing from the origin
+    # module resolves the un-patched dev-database engine even when late-bound.
+    from app.core.db import engine
 
     async with engine.connect() as conn:
         # Use AUTOCOMMIT so each ALTER TABLE is its own implicit transaction

--- a/backend/app/core/db/tenant_schema.py
+++ b/backend/app/core/db/tenant_schema.py
@@ -230,7 +230,8 @@ async def apply_tenant_data_schema_from_engine(tenant_id: str) -> None:
     The SECURITY DEFINER function runs in one ordinary transaction.  Tenant
     creation paths must instead pass their existing session directly.
     """
-    from app.core.db.session import engine
+    # fix(#909): façade import — see the note in rls.py.
+    from app.core.db import engine
 
     async with engine.begin() as conn:
         await apply_tenant_data_schema(conn, tenant_id)
@@ -238,7 +239,8 @@ async def apply_tenant_data_schema_from_engine(tenant_id: str) -> None:
 
 async def deprovision_tenant_data_schema_from_engine(tenant_id: str) -> None:
     """Deprovision an already-deleted tenant using the global engine."""
-    from app.core.db.session import engine
+    # fix(#909): façade import — see the note in rls.py.
+    from app.core.db import engine
 
     async with engine.begin() as conn:
         await deprovision_tenant_data_schema(conn, tenant_id)
@@ -274,7 +276,8 @@ def tenant_shard_id(tenant_id: str | None) -> str | None:
     from sqlalchemy import text as sa_text
     from sqlalchemy.pool import NullPool
 
-    from app.core.db.session import engine as _engine
+    # fix(#909): façade import — see the note in rls.py.
+    from app.core.db import engine as _engine
 
     async def _fetch() -> str:
         from sqlalchemy.ext.asyncio import create_async_engine

--- a/backend/app/core/dependencies.py
+++ b/backend/app/core/dependencies.py
@@ -3,10 +3,14 @@ from collections.abc import AsyncGenerator
 from fastapi import Request
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.core.db import async_session
-
 
 async def get_db() -> AsyncGenerator[AsyncSession, None]:
+    # fix(#909): late-bind — a module-scope `from app.core.db import
+    # async_session` snapshots the dev-DB factory before the test fixture
+    # rebinds app.core.db.async_session, silently pointing tests at the
+    # wrong database. test_layering.py enforces this for the whole tree.
+    from app.core.db import async_session
+
     async with async_session() as session:
         try:
             yield session

--- a/backend/app/observability/health/service.py
+++ b/backend/app/observability/health/service.py
@@ -10,7 +10,6 @@ import structlog
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.core.db import engine
 
 logger = structlog.stdlib.get_logger(__name__)
 
@@ -58,6 +57,8 @@ async def _check_database() -> None:
     We additionally run a tiny query against the catalog schema so a
     genuinely unhealthy DB (hung, wrong schema, locks) reports as degraded.
     """
+    from app.core.db import engine  # fix(#909): late-bind for tests
+
     async with engine.connect() as conn:
         # Cheap connectivity check
         await conn.execute(text("SELECT 1"))

--- a/backend/app/processing/ai/token_usage.py
+++ b/backend/app/processing/ai/token_usage.py
@@ -11,7 +11,7 @@ from sqlalchemy import DateTime, ForeignKey, Index, Integer, Text, func
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import Mapped, mapped_column
 
-from app.core.db import Base, async_session
+from app.core.db import Base
 
 logger = structlog.stdlib.get_logger(__name__)
 
@@ -69,6 +69,11 @@ async def record_token_usage(
     of the request lifecycle and is semantically correct — the tokens were
     already spent, so the record must survive even a later request rollback.
     """
+    # fix(#909): late-bind so the test fixture's rebinding of
+    # app.core.db.async_session is honored; a module-scope import snapshots
+    # the dev-DB factory.
+    from app.core.db import async_session
+
     try:
         async with async_session() as session:
             session.add(

--- a/backend/app/processing/embeddings/backfill.py
+++ b/backend/app/processing/embeddings/backfill.py
@@ -193,9 +193,9 @@ async def backfill_embeddings(session: AsyncSession, *, force: bool = False) -> 
 if __name__ == "__main__":
     import asyncio
 
-    from app.core.db import async_session
-
     async def _run():
+        from app.core.db import async_session  # fix(#909): late-bind
+
         async with async_session() as session:
             result = await backfill_embeddings(session)
             logger.info("Backfill complete", result=result)

--- a/backend/app/processing/export/ogr.py
+++ b/backend/app/processing/export/ogr.py
@@ -3,12 +3,16 @@
 import asyncio
 import os
 
+# fix(#909): build_pg_conn_str is deliberately NOT imported at module scope.
+# The test fixture redirects app.processing.ingest.ogr.build_pg_conn_str at
+# the origin; a module-scope `from ... import` here snapshots the dev-DB
+# helper past that patch, which once sent a test's ogr2ogr export at the dev
+# database (#898). Late-bind at call scope (test_layering.py enforces this).
 from app.processing.ingest.ogr import (
     OGR2OGR_FILE_TIMEOUT_SECONDS,
     IngestionError,
     _communicate_with_timeout,
     _tenant_reader_subprocess_env,
-    build_pg_conn_str,
 )
 
 
@@ -105,6 +109,7 @@ async def run_ogr2ogr_export(
         ExportError: If ogr2ogr exits with non-zero code.
     """
     from app.processing.ingest.metadata import _validate_table_name
+    from app.processing.ingest.ogr import build_pg_conn_str
 
     _validate_table_name(table_name)
     _validate_table_name(schema)

--- a/backend/app/processing/ingest/tasks.py
+++ b/backend/app/processing/ingest/tasks.py
@@ -26,7 +26,11 @@ from app.processing.ingest.tasks_common import (  # noqa: F401
 )
 
 # -- Re-export infrastructure helpers used by sub-modules (for test mocking) --
-from app.core.db import async_session  # noqa: F401
+# fix(#909): async_session is deliberately NOT re-exported here. A module-scope
+# `from app.core.db import async_session` snapshots the dev-DB factory past the
+# test fixture's rebinding of app.core.db, and a re-export invites consumers to
+# inherit that snapshot. Late-bind at call scope instead (test_layering.py
+# enforces this).
 from app.platform.cache.tiles import invalidate_catalog_cache  # noqa: F401
 from app.platform.storage import get_storage  # noqa: F401
 from app.processing.embeddings.helpers import defer_embedding  # noqa: F401

--- a/backend/app/processing/ingest/tasks_vrt.py
+++ b/backend/app/processing/ingest/tasks_vrt.py
@@ -28,7 +28,7 @@ from app.platform.jobs.heartbeat import (
     stop_ingest_job_heartbeat,
     update_ingest_job_for_attempt,
 )
-from app.core.db import async_session, tenant_task
+from app.core.db import tenant_task
 from app.processing.embeddings.helpers import defer_embedding
 from app.processing.raster.cog import extract_raster_metadata, sha256_file
 from app.processing.raster.quicklook import generate_quicklook
@@ -229,6 +229,7 @@ async def ingest_vrt(
     import shutil
     import tempfile
 
+    from app.core.db import async_session  # fix(#909): late-bind for tests
     from app.platform.extensions import get_processing_port
     from app.platform.jobs.models import IngestJob
     from app.processing.raster.models import RasterAsset
@@ -554,6 +555,8 @@ async def regenerate_vrt(
     work and reopened for the metadata updates.
     """
     import asyncio
+
+    from app.core.db import async_session  # fix(#909): late-bind for tests
 
     _bind_task_log_context(
         task_name="regenerate_vrt",

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1876,16 +1876,17 @@ def _point_ogr2ogr_at_test_db(request, monkeypatch):
     (or a class-level ``pytestmark``) trigger the monkeypatch. All
     other tests are unaffected.
 
-    fix(#885): the export wrapper does ``from app.processing.ingest.ogr import
-    build_pg_conn_str`` at module scope, so it holds its OWN binding — patching
-    only the ingest module left ``run_ogr2ogr_export`` reading the dev/prod
-    database. Both bindings are redirected.
+    fix(#885): the export wrapper used to do ``from app.processing.ingest.ogr
+    import build_pg_conn_str`` at module scope, holding its OWN binding —
+    patching only the ingest module left ``run_ogr2ogr_export`` reading the
+    dev/prod database. fix(#909): the export wrapper now late-binds at call
+    scope (enforced by test_layering.py), so the origin-module patch below is
+    the single binding again.
     """
     if "requires_ogr2ogr" not in request.keywords:
         return
 
     from app.core.config import settings as _settings
-    from app.processing.export import ogr as _export_ogr
     from app.processing.ingest import ogr as _ogr
 
     def _test_pg_conn_str() -> str:
@@ -1898,7 +1899,6 @@ def _point_ogr2ogr_at_test_db(request, monkeypatch):
         )
 
     monkeypatch.setattr(_ogr, "build_pg_conn_str", _test_pg_conn_str)
-    monkeypatch.setattr(_export_ogr, "build_pg_conn_str", _test_pg_conn_str)
 
 
 @pytest.fixture

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1620,11 +1620,8 @@ async def client(tmp_path):
     db_module.engine = test_engine
     db_module.async_session = test_session_factory
 
-    # Patch health service module's engine reference
-    import app.observability.health.service as health_service_module
-
-    original_health_engine = health_service_module.engine
-    health_service_module.engine = test_engine
+    # fix(#909): the health service late-binds engine from app.core.db, so
+    # the db_module patch above covers it — no per-module re-point needed.
 
     # Override the get_db dependency
     from app.core.dependencies import get_db
@@ -1688,7 +1685,6 @@ async def client(tmp_path):
     app.dependency_overrides.clear()
     db_module.engine = original_engine
     db_module.async_session = original_session
-    health_service_module.engine = original_health_engine
     storage_provider_module._storage = original_storage
     settings.upload_staging_dir = original_upload_staging_dir
     tempfile.tempdir = original_tempdir

--- a/backend/tests/test_ai_token_budget_daily.py
+++ b/backend/tests/test_ai_token_budget_daily.py
@@ -127,7 +127,10 @@ async def test_record_token_usage_commits_own_session(monkeypatch):
             events["committed"] += 1
 
     monkeypatch.setattr(
-        "app.processing.ai.token_usage.async_session", lambda: _FakeSession()
+        # fix(#909): record_token_usage now late-binds async_session from the
+        # origin module, so the patch targets app.core.db, not the consumer.
+        "app.core.db.async_session",
+        lambda: _FakeSession(),
     )
 
     # First arg (caller session) is intentionally ignored — pass a sentinel that

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -1709,14 +1709,14 @@ def test_no_module_level_provider_sdk_imports_in_processing() -> None:
 
 
 # fix(#909): env-sensitive helpers that test fixtures redirect by assigning to
-# the ORIGIN module. A module-scope `from <origin> import <name>` snapshots the
-# object into the importing module's own namespace, so the fixture's patch
-# never reaches it — and the test silently reads or WRITES the dev database
-# while passing (the #898 export-ogr incident). Call sites must late-bind
-# (`from <origin> import <name>` inside the function) so the origin module's
-# current attribute is resolved at call time.
+# the module the fixture actually patches. A module-scope `from <module> import
+# <name>` snapshots the object into the importing module's own namespace, so
+# the fixture's patch never reaches it — and the test silently reads or WRITES
+# the dev database while passing (the #898 export-ogr incident). Call sites
+# must late-bind (`from <module> import <name>` inside the function) so the
+# patched module's current attribute is resolved at call time.
 #
-# Maps origin module -> redirected symbol names. Extend this when a fixture
+# Maps patched module -> redirected symbol names. Extend this when a fixture
 # starts redirecting another module-scope-importable helper.
 _FIXTURE_REDIRECTED_SYMBOLS: dict[str, frozenset[str]] = {
     # fix(#909 codex review): engine included — the client fixture reassigns
@@ -1724,23 +1724,41 @@ _FIXTURE_REDIRECTED_SYMBOLS: dict[str, frozenset[str]] = {
     # escapes the redirect exactly like async_session (the health-service
     # probe was the live instance).
     "app.core.db": frozenset({"async_session", "engine"}),
-    "app.core.db.session": frozenset({"async_session", "engine"}),
     "app.processing.ingest.ogr": frozenset({"build_pg_conn_str"}),
 }
 
-# The one sanctioned module-scope binding: app/core/db/__init__.py re-exports
-# from app.core.db.session, and that package attribute is exactly what the
-# conftest fixture patches (`db_module.async_session = ...`), so the façade
-# must keep its binding for the patch to have a target.
+# fix(#909 codex review): the conftest fixture patches the FAÇADE attributes
+# (`app.core.db.engine` / `.async_session`), never the origin module's, so
+# importing these from `app.core.db.session` escapes the redirect at ANY
+# scope — late-binding does not save it, because the attribute it late-binds
+# against was never patched. `app/core/db/rls.py` used to do exactly that and
+# would open a dev-database connection from inside a test. These imports are
+# therefore banned outright and must go through the façade.
+_UNPATCHED_ORIGIN_SYMBOLS: dict[str, frozenset[str]] = {
+    "app.core.db.session": frozenset({"async_session", "engine"}),
+}
+
+# The one sanctioned binding: app/core/db/__init__.py re-exports from
+# app.core.db.session, and that package attribute is exactly what the conftest
+# fixture patches (`db_module.async_session = ...`), so the façade must keep
+# its binding for the patch to have a target.
 _FIXTURE_REDIRECT_ALLOWED_FILES = frozenset({"app/core/db/__init__.py"})
 
 
-def _module_scope_redirected_imports(tree: ast.AST) -> list[tuple[int, str, str]]:
-    """Return (lineno, origin-module, symbol) for module-scope offenders.
+def _redirect_escaping_imports(tree: ast.AST) -> list[tuple[int, str, str, str]]:
+    """Return (lineno, origin-module, symbol, reason) for offending imports.
 
-    Module scope means anywhere outside a function body — class bodies and
-    conditional/try blocks at module level still bind at import time and
-    escape fixture patches exactly the same way.
+    Two distinct failure modes:
+
+    - ``module-scope``: the symbol IS patched on this module, but a
+      module-scope ``from <origin> import <name>`` snapshots it at import
+      time. Module scope means anywhere outside a function body — class
+      bodies and conditional/try blocks at module level bind at import time
+      and escape the patch the same way. Late-binding inside the function
+      fixes these.
+    - ``unpatched-origin``: the fixture never patches this module's
+      attribute, so the import escapes at every scope. Only switching to the
+      patched façade fixes these.
     """
     inside_functions: set[ast.AST] = set()
     for node in ast.walk(tree):
@@ -1749,24 +1767,32 @@ def _module_scope_redirected_imports(tree: ast.AST) -> list[tuple[int, str, str]
                 if child is not node:
                     inside_functions.add(child)
 
-    offenders: list[tuple[int, str, str]] = []
+    offenders: list[tuple[int, str, str, str]] = []
     for node in ast.walk(tree):
         if not isinstance(node, ast.ImportFrom) or node.module is None:
             continue
-        if node in inside_functions:
-            continue
-        forbidden = _FIXTURE_REDIRECTED_SYMBOLS.get(node.module)
-        if not forbidden:
-            continue
-        for alias in node.names:
-            if alias.name in forbidden:
-                offenders.append((node.lineno, node.module, alias.name))
-    return offenders
+        at_module_scope = node not in inside_functions
+        for forbidden, reason in (
+            (_UNPATCHED_ORIGIN_SYMBOLS.get(node.module), "unpatched-origin"),
+            (
+                _FIXTURE_REDIRECTED_SYMBOLS.get(node.module)
+                if at_module_scope
+                else None,
+                "module-scope",
+            ),
+        ):
+            if not forbidden:
+                continue
+            for alias in node.names:
+                if alias.name in forbidden:
+                    offenders.append((node.lineno, node.module, alias.name, reason))
+    # ast.walk is breadth-first, so sort for a stable, source-ordered report.
+    return sorted(offenders)
 
 
 @pytest.mark.architecture
-def test_no_module_scope_imports_of_fixture_redirected_helpers() -> None:
-    """fix(#909): forbid module-scope `from X import name` for redirected helpers.
+def test_no_imports_that_escape_the_fixture_db_redirect() -> None:
+    """fix(#909): no import path may resolve the un-patched dev-database engine.
 
     AST-based rather than git grep so untracked files are covered and
     multi-name import lists (`from app.core.db import async_session,
@@ -1784,15 +1810,17 @@ def test_no_module_scope_imports_of_fixture_redirected_helpers() -> None:
         if rel in _FIXTURE_REDIRECT_ALLOWED_FILES:
             continue
         tree = ast.parse(path.read_text(), filename=rel)
-        for lineno, module, symbol in _module_scope_redirected_imports(tree):
-            failures.append(f"{rel}:{lineno}: `from {module} import {symbol}`")
+        for lineno, module, symbol, reason in _redirect_escaping_imports(tree):
+            failures.append(
+                f"{rel}:{lineno}: `from {module} import {symbol}` ({reason})"
+            )
 
     assert not failures, (
-        "Module-scope import of a fixture-redirected helper found. These "
-        "symbols are reassigned on their origin module by test fixtures; a "
-        "module-scope `from ... import` snapshots the un-patched object and "
-        "silently points tests at the dev database. Late-bind inside the "
-        "function instead (see #909):\n" + "\n".join(failures)
+        "Import(s) that escape the test fixture's database redirect, so the "
+        "test silently reads or writes the DEV database while passing (see "
+        "#909). `module-scope`: late-bind the import inside the function. "
+        "`unpatched-origin`: import from the `app.core.db` façade, which is "
+        "what the fixture patches:\n" + "\n".join(failures)
     )
 
 
@@ -1804,8 +1832,28 @@ def test_fixture_redirect_guard_catches_seeded_violation() -> None:
         "def ok():\n"
         "    from app.core.db import async_session\n"
     )
-    offenders = _module_scope_redirected_imports(seeded)
-    assert offenders == [(2, "app.core.db", "async_session")]
+    assert _redirect_escaping_imports(seeded) == [
+        (2, "app.core.db", "async_session", "module-scope")
+    ]
+
+
+def test_fixture_redirect_guard_catches_unpatched_origin_at_any_scope() -> None:
+    """fix(#909 codex review): late-binding does NOT rescue an import from
+    ``app.core.db.session``. conftest reassigns ``app.core.db.engine``, not
+    ``app.core.db.session.engine``, so the deferred lookup still resolves the
+    dev-database engine — the shape ``rls.apply_tenancy_rls_from_engine`` had.
+    Both scopes must be reported, and the façade equivalent must not be."""
+    seeded = ast.parse(
+        "from app.core.db.session import engine\n"
+        "def late():\n"
+        "    from app.core.db.session import engine\n"
+        "def facade():\n"
+        "    from app.core.db import engine\n"
+    )
+    assert _redirect_escaping_imports(seeded) == [
+        (1, "app.core.db.session", "engine", "unpatched-origin"),
+        (3, "app.core.db.session", "engine", "unpatched-origin"),
+    ]
 
 
 def _manifest_backend_files() -> list[Path]:

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -1719,8 +1719,12 @@ def test_no_module_level_provider_sdk_imports_in_processing() -> None:
 # Maps origin module -> redirected symbol names. Extend this when a fixture
 # starts redirecting another module-scope-importable helper.
 _FIXTURE_REDIRECTED_SYMBOLS: dict[str, frozenset[str]] = {
-    "app.core.db": frozenset({"async_session"}),
-    "app.core.db.session": frozenset({"async_session"}),
+    # fix(#909 codex review): engine included — the client fixture reassigns
+    # db_module.engine to the test engine, so a module-scope engine binding
+    # escapes the redirect exactly like async_session (the health-service
+    # probe was the live instance).
+    "app.core.db": frozenset({"async_session", "engine"}),
+    "app.core.db.session": frozenset({"async_session", "engine"}),
     "app.processing.ingest.ogr": frozenset({"build_pg_conn_str"}),
 }
 

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -1026,7 +1026,7 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # fix(#836): the five path-gated additions. Caps are exact (zero headroom),
     # matching the #435 convention: growth needs a reviewed carve-out here,
     # shrinking must lower the cap in the same commit.
-    "backend/app/api/main.py": 1282,
+    "backend/app/api/main.py": 1292,
     "backend/app/modules/catalog/maps/schemas.py": 1312,
     # fix(#888): +117. `clip_to_mercator_bounds` used to lose data twice over
     # in silence — it clipped away everything east of lon 180 in a 0..360
@@ -1706,6 +1706,102 @@ def test_no_module_level_provider_sdk_imports_in_processing() -> None:
             f"git grep failed unexpectedly: rc={result.returncode}\n"
             f"stderr: {result.stderr}"
         )
+
+
+# fix(#909): env-sensitive helpers that test fixtures redirect by assigning to
+# the ORIGIN module. A module-scope `from <origin> import <name>` snapshots the
+# object into the importing module's own namespace, so the fixture's patch
+# never reaches it — and the test silently reads or WRITES the dev database
+# while passing (the #898 export-ogr incident). Call sites must late-bind
+# (`from <origin> import <name>` inside the function) so the origin module's
+# current attribute is resolved at call time.
+#
+# Maps origin module -> redirected symbol names. Extend this when a fixture
+# starts redirecting another module-scope-importable helper.
+_FIXTURE_REDIRECTED_SYMBOLS: dict[str, frozenset[str]] = {
+    "app.core.db": frozenset({"async_session"}),
+    "app.core.db.session": frozenset({"async_session"}),
+    "app.processing.ingest.ogr": frozenset({"build_pg_conn_str"}),
+}
+
+# The one sanctioned module-scope binding: app/core/db/__init__.py re-exports
+# from app.core.db.session, and that package attribute is exactly what the
+# conftest fixture patches (`db_module.async_session = ...`), so the façade
+# must keep its binding for the patch to have a target.
+_FIXTURE_REDIRECT_ALLOWED_FILES = frozenset({"app/core/db/__init__.py"})
+
+
+def _module_scope_redirected_imports(tree: ast.AST) -> list[tuple[int, str, str]]:
+    """Return (lineno, origin-module, symbol) for module-scope offenders.
+
+    Module scope means anywhere outside a function body — class bodies and
+    conditional/try blocks at module level still bind at import time and
+    escape fixture patches exactly the same way.
+    """
+    inside_functions: set[ast.AST] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            for child in ast.walk(node):
+                if child is not node:
+                    inside_functions.add(child)
+
+    offenders: list[tuple[int, str, str]] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.ImportFrom) or node.module is None:
+            continue
+        if node in inside_functions:
+            continue
+        forbidden = _FIXTURE_REDIRECTED_SYMBOLS.get(node.module)
+        if not forbidden:
+            continue
+        for alias in node.names:
+            if alias.name in forbidden:
+                offenders.append((node.lineno, node.module, alias.name))
+    return offenders
+
+
+@pytest.mark.architecture
+def test_no_module_scope_imports_of_fixture_redirected_helpers() -> None:
+    """fix(#909): forbid module-scope `from X import name` for redirected helpers.
+
+    AST-based rather than git grep so untracked files are covered and
+    multi-name import lists (`from app.core.db import async_session,
+    tenant_task`) cannot slip through.
+
+    Negative-control: temporarily add `from app.core.db import async_session`
+    at the top of any module under backend/app/, run this test, confirm it
+    fails with the offending file:line surfaced. Revert. (Automated as
+    test_fixture_redirect_guard_catches_seeded_violation below.)
+    """
+    app_root = _backend_path("app")
+    failures: list[str] = []
+    for path in sorted(app_root.rglob("*.py")):
+        rel = path.relative_to(BACKEND_ROOT).as_posix()
+        if rel in _FIXTURE_REDIRECT_ALLOWED_FILES:
+            continue
+        tree = ast.parse(path.read_text(), filename=rel)
+        for lineno, module, symbol in _module_scope_redirected_imports(tree):
+            failures.append(f"{rel}:{lineno}: `from {module} import {symbol}`")
+
+    assert not failures, (
+        "Module-scope import of a fixture-redirected helper found. These "
+        "symbols are reassigned on their origin module by test fixtures; a "
+        "module-scope `from ... import` snapshots the un-patched object and "
+        "silently points tests at the dev database. Late-bind inside the "
+        "function instead (see #909):\n" + "\n".join(failures)
+    )
+
+
+def test_fixture_redirect_guard_catches_seeded_violation() -> None:
+    """The guard must fail on a seeded module-scope offender (issue #909 §3)."""
+    seeded = ast.parse(
+        "import uuid\n"
+        "from app.core.db import Base, async_session\n"
+        "def ok():\n"
+        "    from app.core.db import async_session\n"
+    )
+    offenders = _module_scope_redirected_imports(seeded)
+    assert offenders == [(2, "app.core.db", "async_session")]
 
 
 def _manifest_backend_files() -> list[Path]:

--- a/backend/tests/test_regenerate_vrt_integration.py
+++ b/backend/tests/test_regenerate_vrt_integration.py
@@ -146,17 +146,13 @@ async def vrt_db_state(
     (_create_vrt_dataset_rows), minus distribution rows and source_dataset_ids
     parameter handling.
     """
-    import app.core.db as db_module
-    import app.processing.ingest.tasks_vrt as tasks_vrt_module
     from app.modules.catalog.datasets.domain.models import Dataset, Record
     from app.platform.jobs.models import IngestJob
     from app.processing.raster.models import RasterAsset
 
-    # CRITICAL: tasks_vrt.py imports async_session at module level. The
-    # `client` fixture patches db_module.async_session to the test factory,
-    # but that does NOT update the binding in tasks_vrt. Without this
-    # re-patch, regenerate_vrt opens a session on the production engine.
-    monkeypatch.setattr(tasks_vrt_module, "async_session", db_module.async_session)
+    # fix(#909): tasks_vrt now late-binds async_session from app.core.db,
+    # which the `client` fixture already patches to the test factory — the
+    # per-module re-patch this comment used to defend is gone by design.
 
     session = test_db_session
     source_uris = list(source_tifs.keys())  # ["rasters/src-1/source.cog.tif", ...]

--- a/backend/tests/test_seed_admin_concurrency.py
+++ b/backend/tests/test_seed_admin_concurrency.py
@@ -22,7 +22,6 @@ import asyncio
 import pytest
 from sqlalchemy import func, select, text
 
-import app.api.main as main_module
 import app.core.db as db_module
 from app.api.main import (
     DEFAULT_ROLES,
@@ -59,10 +58,9 @@ async def _assert_blocks_until_lock_released(seed_coro_factory):
 
 
 async def test_seed_initial_admin_blocks_on_advisory_lock(test_db_session, monkeypatch):
-    # seed_initial_admin() resolves `async_session` from app.api.main's namespace;
-    # the client fixture only patches app.core.db.async_session, so repoint the
-    # seed at the same test engine — otherwise it writes to the default DB.
-    monkeypatch.setattr(main_module, "async_session", db_module.async_session)
+    # fix(#909): seed_initial_admin() now late-binds async_session from
+    # app.core.db, which the client fixture already patches — no per-module
+    # repoint needed.
 
     # Fresh-DB state (count==0) — the only state the prod guard seeds in. CASCADE
     # clears user_roles; the roles table survives (the client fixture seeded the
@@ -90,7 +88,8 @@ async def test_seed_roles_blocks_on_advisory_lock(test_db_session, monkeypatch):
     # blocks regardless of whether rows already exist — and truncating
     # catalog.roles CASCADE would strip the admin's role link without the fixture
     # re-linking it, poisoning the shared per-worker DB for later tests.
-    monkeypatch.setattr(main_module, "async_session", db_module.async_session)
+    # fix(#909): seed_roles late-binds async_session from app.core.db, which
+    # the client fixture already patches — no per-module repoint needed.
 
     await _assert_blocks_until_lock_released(seed_roles)
 

--- a/backend/tests/test_seed_bootstrap_identity.py
+++ b/backend/tests/test_seed_bootstrap_identity.py
@@ -44,8 +44,12 @@ async def test_seed_roles_selects_scalars_without_loading_unscoped_users(monkeyp
     from app.modules.auth.models import Role
 
     session = _RecordingSeedSession()
+    # fix(#909): seed_roles late-binds async_session from app.core.db,
+    # so the patch targets the origin module, not app.api.main.
+    import app.core.db as db_module
+
     monkeypatch.setattr(
-        main,
+        db_module,
         "async_session",
         lambda: _SeedSessionContext(session),
     )

--- a/backend/tests/test_tenant_job_recovery.py
+++ b/backend/tests/test_tenant_job_recovery.py
@@ -49,7 +49,8 @@ async def test_api_sweeper_scopes_each_tenant_and_continues_after_failure():
     with (
         patch.object(main_module, "is_multi_tenant", return_value=True),
         patch("app.core.tenancy.is_multi_tenant", return_value=True),
-        patch.object(main_module, "async_session", session_factory),
+        # fix(#909): sweep_stale_jobs_once late-binds from app.core.db
+        patch("app.core.db.async_session", session_factory),
         patch(
             "app.platform.jobs.router.fail_stale_jobs",
             side_effect=fake_fail_stale_jobs,
@@ -109,7 +110,8 @@ async def test_api_sweeper_aggregates_detailed_tenant_outcomes():
 
     with (
         patch.object(main_module, "is_multi_tenant", return_value=True),
-        patch.object(main_module, "async_session", session_factory),
+        # fix(#909): sweep_stale_jobs_once late-binds from app.core.db
+        patch("app.core.db.async_session", session_factory),
         patch("app.platform.jobs.router.fail_stale_jobs", cleanup),
     ):
         details = await main_module.sweep_stale_jobs_once(detailed=True)
@@ -136,7 +138,8 @@ async def test_api_sweeper_preserves_single_tenant_one_shot():
 
     with (
         patch.object(main_module, "is_multi_tenant", return_value=False),
-        patch.object(main_module, "async_session", session_factory),
+        # fix(#909): sweep_stale_jobs_once late-binds from app.core.db
+        patch("app.core.db.async_session", session_factory),
         patch("app.platform.jobs.router.fail_stale_jobs", fail_stale_jobs),
     ):
         assert await main_module.sweep_stale_jobs_once() == (4, 5)

--- a/backend/tests/test_vrt_source_management_174.py
+++ b/backend/tests/test_vrt_source_management_174.py
@@ -638,7 +638,8 @@ class TestRegenerateVrtTask:
 
             with (
                 patch(
-                    "app.processing.ingest.tasks_vrt.async_session"
+                    # fix(#909): tasks_vrt late-binds; patch the origin
+                    "app.core.db.async_session"
                 ) as mock_async_session,
                 patch(
                     "app.processing.ingest.tasks_vrt.build_vrt",
@@ -703,7 +704,8 @@ class TestRegenerateVrtTask:
 
             with (
                 patch(
-                    "app.processing.ingest.tasks_vrt.async_session"
+                    # fix(#909): tasks_vrt late-binds; patch the origin
+                    "app.core.db.async_session"
                 ) as mock_async_session,
                 patch(
                     "app.processing.ingest.tasks_vrt.build_vrt",
@@ -819,7 +821,8 @@ class TestRegenerateVrtTask:
 
             with (
                 patch(
-                    "app.processing.ingest.tasks_vrt.async_session"
+                    # fix(#909): tasks_vrt late-binds; patch the origin
+                    "app.core.db.async_session"
                 ) as mock_async_session,
                 patch(
                     "app.processing.ingest.tasks_vrt.build_vrt",
@@ -981,7 +984,8 @@ class TestRegenerateVrtTask:
 
             with (
                 patch(
-                    "app.processing.ingest.tasks_vrt.async_session"
+                    # fix(#909): tasks_vrt late-binds; patch the origin
+                    "app.core.db.async_session"
                 ) as mock_async_session,
                 patch(
                     "app.processing.ingest.tasks_vrt.build_vrt",


### PR DESCRIPTION
## What changed

**The three live bindings from the issue, plus two more the new guard found:**

- `backend/app/api/main.py` — module-scope `from app.core.db import async_session, engine` removed; each seed/sweep function and `lifespan` late-binds.
- `backend/app/core/dependencies.py` — `get_db` late-binds.
- `backend/app/processing/ai/token_usage.py` — `record_token_usage` late-binds (`Base` stays module-scope; it is not redirected).
- `backend/app/processing/ingest/tasks_vrt.py` — the issue listed this as a re-export; it actually USES the binding in `ingest_vrt`/`regenerate_vrt` (6 call sites). Both now late-bind.
- `backend/app/processing/embeddings/backfill.py` — found by the guard: `__main__` block held a module-scope binding.
- `backend/app/processing/ingest/tasks.py` — the `# noqa: F401` re-export removed (no consumers; comment explains why it must not return).
- `backend/app/processing/export/ogr.py` — `build_pg_conn_str` moved to call scope; the conftest double-patch from #898 collapses back to a single origin-module patch.

**The guard (`backend/tests/test_layering.py`):** `test_no_module_scope_imports_of_fixture_redirected_helpers`, AST-based rather than the git-grep template so untracked files and multi-name import lists are covered. Seed list per the issue: `async_session` (origins `app.core.db`, `app.core.db.session`) and `build_pg_conn_str` (`app.processing.ingest.ogr`). `app/core/db/__init__.py` is the one allowlisted binding — the package attribute is exactly what conftest patches. `test_fixture_redirect_guard_catches_seeded_violation` proves a seeded `from app.core.db import async_session` is caught (issue acceptance §3).

**Tests that patched the removed snapshot bindings** (the anti-pattern itself) now patch the origin or drop the redundant re-point: `test_seed_admin_concurrency`, `test_seed_bootstrap_identity`, `test_tenant_job_recovery`, `test_regenerate_vrt_integration`, `test_vrt_source_management_174`, `test_ai_token_budget_daily`. `api/main.py`'s LOC ratchet updated (1282 → 1292).

## Verification

- Full backend suite at CI scale: `pytest -n 4` → **6194 passed, 81 skipped, 0 failed** (the six initially failing tests were all patchers of removed bindings; fixed as above and re-run green at scale — this bug class is xdist-sensitive).
- Guard negative-control: seeded violation fails with file:line surfaced.
- `ruff check` / `ruff format --check` clean.

Closes #909

https://claude.ai/code/session_0137kuVTWx8moBoHd1yJiKDd