### PR TITLE
fix(builder): tighten the clean-state recheck against four false verdicts

### DIFF
--- a/frontend/src/components/builder/__tests__/MapBuilderPage.settings-wiring.test.tsx
+++ b/frontend/src/components/builder/__tests__/MapBuilderPage.settings-wiring.test.tsx
@@ -14,10 +14,11 @@ import { usePluginStore } from '@/stores/map-plugin-store';
 
 let mockMapData: Record<string, unknown>;
 
-const { mockSetHasUnsavedChanges, mockSetBasemapConfig, mockMarkDirty } = vi.hoisted(() => ({
+const { mockSetHasUnsavedChanges, mockSetBasemapConfig, mockMarkDirty, mockMarkOpaqueDirty } = vi.hoisted(() => ({
   mockSetHasUnsavedChanges: vi.fn(),
   mockSetBasemapConfig: vi.fn(),
   mockMarkDirty: vi.fn(),
+  mockMarkOpaqueDirty: vi.fn(),
 }));
 
 vi.mock('react-i18next', () => ({
@@ -150,6 +151,7 @@ vi.mock('@/components/builder/hooks/use-builder-layers', () => ({
     ephemeralResult: null,
     groupMeta: {},
     markDirty: mockMarkDirty,
+    markOpaqueDirty: mockMarkOpaqueDirty,
     requestCleanRecheck: vi.fn(),
     handleToggleExpand: vi.fn(),
     handleTabChange: vi.fn(),
@@ -233,6 +235,7 @@ describe('MapBuilderPage settings wiring (plugin dirty + projection persistence)
     mockSetHasUnsavedChanges.mockClear();
     mockSetBasemapConfig.mockClear();
     mockMarkDirty.mockClear();
+    mockMarkOpaqueDirty.mockClear();
     usePluginStore.getState().replace([]);
     localStorage.clear();
   });
@@ -243,9 +246,9 @@ describe('MapBuilderPage settings wiring (plugin dirty + projection persistence)
     const measureSwitch = await screen.findByRole('switch', { name: 'Enable measurement' });
     fireEvent.click(measureSwitch);
 
-    // fix(#913): page-owned dirt routes through markDirty, which also records
-    // that the clean-state recheck cannot re-derive it from server state.
-    expect(mockMarkDirty).toHaveBeenCalled();
+    // fix(#913): plugin state lives in its own store, so it is OPAQUE dirt —
+    // the clean-state recheck cannot re-derive it from server data.
+    expect(mockMarkOpaqueDirty).toHaveBeenCalled();
   });
 
   it('F3: choosing Globe writes projection into the basemap config', async () => {

--- a/frontend/src/components/builder/hooks/__tests__/use-builder-layers.clean-recheck.test.ts
+++ b/frontend/src/components/builder/hooks/__tests__/use-builder-layers.clean-recheck.test.ts
@@ -113,37 +113,30 @@ describe('useBuilderLayers — clean-state recheck', () => {
     expect(result.current.hasUnsavedChanges).toBe(false);
   });
 
-  it('keeps the flag for a whitespace-only description edit that saves as null', () => {
-    const layer = makeBuilderLayer();
-    const { result } = render(makeBuilderMap([layer]));
+  // Text fields hydrate RAW but save as `value.trim() || null`, so "dirty" means
+  // "saving would change the stored value" — not raw inequality, and not trimmed
+  // equality either.
+  describe.each([
+    ['untouched whitespace in the saved value', '  notes  ', (d: string) => d, false],
+    ['the user trimming that whitespace', '  notes  ', () => 'notes', true],
+    ['a whitespace-only local value over an empty server one', null, () => '   ', false],
+    ['a whitespace-only local value over a real server one', '  x  ', () => '   ', true],
+  ])('description: %s', (_name, saved, edit, expectDirty) => {
+    it(`reports ${expectDirty ? 'dirty' : 'clean'}`, () => {
+      const layer = makeBuilderLayer();
+      const { result } = render({ ...makeBuilderMap([layer]), description: saved } as MapResponse);
 
-    // handleSave persists localDescription.trim() || null, so '   ' against a
-    // null server description is NOT a pending change.
-    act(() => {
-      result.current.setLocalDescription('   ');
-      result.current.handlePaintChange(layer.id, { 'fill-color': '#123456' });
+      act(() => {
+        result.current.setLocalDescription(edit(saved ?? ''));
+        result.current.handlePaintChange(layer.id, { 'fill-color': '#123456' });
+      });
+      act(() => {
+        result.current.handlePaintChange(layer.id, layer.paint as Record<string, unknown>);
+        result.current.requestCleanRecheck();
+      });
+
+      expect(result.current.hasUnsavedChanges).toBe(expectDirty);
     });
-    act(() => {
-      result.current.handlePaintChange(layer.id, layer.paint as Record<string, unknown>);
-      result.current.requestCleanRecheck();
-    });
-
-    expect(result.current.hasUnsavedChanges).toBe(false);
-  });
-
-  it('ignores untouched surrounding whitespace in a saved description', () => {
-    // The hook hydrates localDescription from the RAW server value, so trimming
-    // only the local side left such maps permanently dirty.
-    const layer = makeBuilderLayer();
-    const { result } = render({ ...makeBuilderMap([layer]), description: '  notes  ' } as MapResponse);
-
-    act(() => result.current.handlePaintChange(layer.id, { 'fill-color': '#123456' }));
-    act(() => {
-      result.current.handlePaintChange(layer.id, layer.paint as Record<string, unknown>);
-      result.current.requestCleanRecheck();
-    });
-
-    expect(result.current.hasUnsavedChanges).toBe(false);
   });
 
   it('keeps the flag when a folder expansion is still pending', () => {

--- a/frontend/src/components/builder/hooks/__tests__/use-builder-layers.clean-recheck.test.ts
+++ b/frontend/src/components/builder/hooks/__tests__/use-builder-layers.clean-recheck.test.ts
@@ -131,6 +131,21 @@ describe('useBuilderLayers — clean-state recheck', () => {
     expect(result.current.hasUnsavedChanges).toBe(false);
   });
 
+  it('ignores untouched surrounding whitespace in a saved description', () => {
+    // The hook hydrates localDescription from the RAW server value, so trimming
+    // only the local side left such maps permanently dirty.
+    const layer = makeBuilderLayer();
+    const { result } = render({ ...makeBuilderMap([layer]), description: '  notes  ' } as MapResponse);
+
+    act(() => result.current.handlePaintChange(layer.id, { 'fill-color': '#123456' }));
+    act(() => {
+      result.current.handlePaintChange(layer.id, layer.paint as Record<string, unknown>);
+      result.current.requestCleanRecheck();
+    });
+
+    expect(result.current.hasUnsavedChanges).toBe(false);
+  });
+
   it('keeps the flag when a folder expansion is still pending', () => {
     // Folder expansion IS persisted (prepareLayersForPersistence reads groupMeta),
     // so a still-expanded folder must not read as clean.

--- a/frontend/src/components/builder/hooks/__tests__/use-builder-layers.clean-recheck.test.ts
+++ b/frontend/src/components/builder/hooks/__tests__/use-builder-layers.clean-recheck.test.ts
@@ -152,6 +152,25 @@ describe('useBuilderLayers — clean-state recheck', () => {
     expect(result.current.hasUnsavedChanges).toBe(true);
   });
 
+  it('ignores the UI-only basemap row expansion', () => {
+    // handleToggleGroupExpand writes a groupMeta entry for the basemap row but
+    // deliberately does NOT dirty the map — it has no persisted carrier — so a
+    // whole-object compare would pin the flag on forever.
+    const layer = makeBuilderLayer();
+    const { result } = render(makeBuilderMap([layer]));
+
+    act(() => {
+      result.current.handleToggleGroupExpand('basemap-group');
+      result.current.handlePaintChange(layer.id, { 'fill-color': '#123456' });
+    });
+    act(() => {
+      result.current.handlePaintChange(layer.id, layer.paint as Record<string, unknown>);
+      result.current.requestCleanRecheck();
+    });
+
+    expect(result.current.hasUnsavedChanges).toBe(false);
+  });
+
   it('keeps the flag for page-owned dirt it cannot re-derive (markOpaqueDirty)', () => {
     const layer = makeBuilderLayer();
     const { result } = render(makeBuilderMap([layer]));

--- a/frontend/src/components/builder/hooks/__tests__/use-builder-layers.clean-recheck.test.ts
+++ b/frontend/src/components/builder/hooks/__tests__/use-builder-layers.clean-recheck.test.ts
@@ -6,7 +6,7 @@ import {
   makeBuilderLayer,
   makeBuilderMap,
 } from '@/components/builder/__tests__/fixtures/map-builder-fixtures';
-import type { MapResponse } from '@/types/api';
+import type { MapLayerResponse, MapResponse } from '@/types/api';
 
 type MaplibreMap = import('maplibre-gl').Map;
 
@@ -95,12 +95,69 @@ describe('useBuilderLayers — clean-state recheck', () => {
     expect(result.current.hasUnsavedChanges).toBe(true);
   });
 
-  it('keeps the flag for page-owned dirt it cannot re-derive (markDirty)', () => {
+  it('clears the flag after a re-derivable edit is put back (markDirty)', () => {
+    const layer = makeBuilderLayer();
+    const { result } = render(makeBuilderMap([layer]));
+
+    // MapTitleBar / basemap controls mark dirty for fields the hook DOES compare;
+    // treating those as opaque made the indicator unclearable for the session.
+    act(() => {
+      result.current.markDirty();
+      result.current.handlePaintChange(layer.id, { 'fill-color': '#123456' });
+    });
+    act(() => {
+      result.current.handlePaintChange(layer.id, layer.paint as Record<string, unknown>);
+      result.current.requestCleanRecheck();
+    });
+
+    expect(result.current.hasUnsavedChanges).toBe(false);
+  });
+
+  it('keeps the flag for a whitespace-only description edit that saves as null', () => {
+    const layer = makeBuilderLayer();
+    const { result } = render(makeBuilderMap([layer]));
+
+    // handleSave persists localDescription.trim() || null, so '   ' against a
+    // null server description is NOT a pending change.
+    act(() => {
+      result.current.setLocalDescription('   ');
+      result.current.handlePaintChange(layer.id, { 'fill-color': '#123456' });
+    });
+    act(() => {
+      result.current.handlePaintChange(layer.id, layer.paint as Record<string, unknown>);
+      result.current.requestCleanRecheck();
+    });
+
+    expect(result.current.hasUnsavedChanges).toBe(false);
+  });
+
+  it('keeps the flag when a folder expansion is still pending', () => {
+    // Folder expansion IS persisted (prepareLayersForPersistence reads groupMeta),
+    // so a still-expanded folder must not read as clean.
+    const group = { ...makeBuilderLayer({ id: 'group-1' }), layer_type: 'group:folder' } as unknown as MapLayerResponse;
+    const child = makeBuilderLayer({ id: 'layer-1' });
+    const { result } = render(makeBuilderMap([group, child]));
+
+    act(() => {
+      result.current.handleToggleGroupExpand('group-1');
+      result.current.handlePaintChange('layer-1', { 'fill-color': '#123456' });
+    });
+    expect(result.current.hasUnsavedChanges).toBe(true);
+
+    act(() => {
+      result.current.handlePaintChange('layer-1', child.paint as Record<string, unknown>);
+      result.current.requestCleanRecheck();
+    });
+
+    expect(result.current.hasUnsavedChanges).toBe(true);
+  });
+
+  it('keeps the flag for page-owned dirt it cannot re-derive (markOpaqueDirty)', () => {
     const layer = makeBuilderLayer();
     const { result } = render(makeBuilderMap([layer]));
 
     act(() => {
-      result.current.markDirty();
+      result.current.markOpaqueDirty();
       result.current.handlePaintChange(layer.id, { 'fill-color': '#123456' });
     });
     act(() => {

--- a/frontend/src/components/builder/hooks/use-builder-layers.ts
+++ b/frontend/src/components/builder/hooks/use-builder-layers.ts
@@ -40,6 +40,15 @@ import { useLayerStyleClipboard } from '@/components/builder/hooks/use-layer-sty
 import { useTileConfig } from '@/hooks/use-settings';
 export { buildDuplicateRenderingInput } from '@/components/builder/hooks/builder-layer-mutations';
 
+// True when a local text field and its saved value would persist identically.
+// The save payload is `value.trim() || null`, and the field hydrates raw.
+function sameSavedText(local: string | null | undefined, saved: string | null | undefined): boolean {
+  const l = local ?? '';
+  const r = saved ?? '';
+  if (l === r) return true;
+  return l.trim() === '' && r.trim() === '';
+}
+
 // fix(#913 review): the hydrated shape of mapData's folder-expansion state,
 // mirroring the load path below (hydrated markers overlaid with group_meta).
 function savedGroupMeta(mapData: MapResponse): Record<string, { expanded: boolean }> {
@@ -890,10 +899,14 @@ export function useBuilderLayers(
     // `localDescription.trim() || null`, and a trimmed-or-null legend title, so
     // an untrimmed local value would otherwise read as permanently dirty.
     if (localName && localName !== mapData.name) return false;
-    const savedDescription = mapData.description ?? null;
-    if ((localDescription.trim() || null) !== (savedDescription?.trim() || null)) return false;
-    const savedLegend = mapData.legend_title ?? null;
-    if ((localLegendTitle?.trim() || null) !== (savedLegend?.trim() || null)) return false;
+    // Text fields hydrate RAW but save trimmed-or-null, so neither a raw compare
+    // nor a trimmed one is right on its own: a raw compare calls an untouched
+    // server value with surrounding whitespace dirty forever, while a trimmed
+    // compare calls a real user edit (removing that whitespace) clean. Dirty
+    // means "saving would change the stored value": identical text is clean, and
+    // so is any pair that both persist as null.
+    if (!sameSavedText(localDescription, mapData.description)) return false;
+    if (!sameSavedText(localLegendTitle, mapData.legend_title)) return false;
     if (localBasemap !== resolveBasemapId(mapData.basemap_style || 'positron')) return false;
     if (showBasemapLabels !== (mapData.show_basemap_labels ?? true)) return false;
     if (!deepEqual(basemapConfig, mapData.basemap_config ?? null)) return false;

--- a/frontend/src/components/builder/hooks/use-builder-layers.ts
+++ b/frontend/src/components/builder/hooks/use-builder-layers.ts
@@ -890,7 +890,8 @@ export function useBuilderLayers(
     // `localDescription.trim() || null`, and a trimmed-or-null legend title, so
     // an untrimmed local value would otherwise read as permanently dirty.
     if (localName && localName !== mapData.name) return false;
-    if ((localDescription.trim() || null) !== (mapData.description ?? null)) return false;
+    const savedDescription = mapData.description ?? null;
+    if ((localDescription.trim() || null) !== (savedDescription?.trim() || null)) return false;
     const savedLegend = mapData.legend_title ?? null;
     if ((localLegendTitle?.trim() || null) !== (savedLegend?.trim() || null)) return false;
     if (localBasemap !== resolveBasemapId(mapData.basemap_style || 'positron')) return false;

--- a/frontend/src/components/builder/hooks/use-builder-layers.ts
+++ b/frontend/src/components/builder/hooks/use-builder-layers.ts
@@ -900,7 +900,14 @@ export function useBuilderLayers(
     // fix(#913 review): folder expansion is persisted (prepareLayersForPersistence
     // reads groupMeta), and handleToggleGroupExpand marks the map dirty — without
     // this an expand-then-revert reported clean and the expansion was lost.
-    if (!deepEqual(groupMeta, savedGroupMeta(mapData))) return false;
+    // Compare ONLY persisted folder rows: the basemap row also writes a groupMeta
+    // entry, deliberately without dirtying (it has no persisted carrier), so a
+    // whole-object compare could never match and would pin the flag on.
+    const savedMeta = savedGroupMeta(mapData);
+    for (const layer of current) {
+      if (!isFolderGroupLayer(layer)) continue;
+      if ((groupMeta[layer.id]?.expanded ?? false) !== (savedMeta[layer.id]?.expanded ?? false)) return false;
+    }
 
     return true;
   }, [

--- a/frontend/src/components/builder/hooks/use-builder-layers.ts
+++ b/frontend/src/components/builder/hooks/use-builder-layers.ts
@@ -40,6 +40,15 @@ import { useLayerStyleClipboard } from '@/components/builder/hooks/use-layer-sty
 import { useTileConfig } from '@/hooks/use-settings';
 export { buildDuplicateRenderingInput } from '@/components/builder/hooks/builder-layer-mutations';
 
+// fix(#913 review): the hydrated shape of mapData's folder-expansion state,
+// mirroring the load path below (hydrated markers overlaid with group_meta).
+function savedGroupMeta(mapData: MapResponse): Record<string, { expanded: boolean }> {
+  return {
+    ...hydrateFolderGroupLayers(mapData.layers ?? []).groupMeta,
+    ...((mapData as { group_meta?: Record<string, { expanded: boolean }> }).group_meta ?? {}),
+  };
+}
+
 // fix(#913): the hydrated shape of mapData.terrain_config, shared by the load
 // path and the clean-state recheck so the two cannot drift.
 function savedTerrainConfig(mapData: { terrain_config?: MapTerrainConfig | null }): MapTerrainConfig | null {
@@ -842,7 +851,14 @@ export function useBuilderLayers(
     );
   }, [addLayerMutation, mapId, t, saveBaselineSyncRef]);
 
-  const markDirty = useCallback(() => {
+  const markDirty = useCallback(() => setHasUnsavedChanges(true), []);
+
+  // fix(#913 review): the opaque flag is only for state this hook CANNOT compare
+  // against server data — dock notes and plugin toggles live outside it. Marking
+  // re-derivable edits (map name, description, basemap) opaque made the unsaved
+  // indicator unclearable for the rest of the session once any of them was
+  // touched, even after the value was put back.
+  const markOpaqueDirty = useCallback(() => {
     opaqueDirtyRef.current = true;
     setHasUnsavedChanges(true);
   }, []);
@@ -869,30 +885,48 @@ export function useBuilderLayers(
       if (!saved || saved.id !== baseline[i].id || !deepEqual(current[i], saved)) return false;
     }
 
-    if (localName !== mapData.name) return false;
-    if (localDescription !== (mapData.description ?? '')) return false;
-    if (localLegendTitle !== (mapData.legend_title ?? null)) return false;
+    // fix(#913 review): compare the SAVE payload's normalization, not the raw
+    // local strings — handleSave persists `localName || undefined`,
+    // `localDescription.trim() || null`, and a trimmed-or-null legend title, so
+    // an untrimmed local value would otherwise read as permanently dirty.
+    if (localName && localName !== mapData.name) return false;
+    if ((localDescription.trim() || null) !== (mapData.description ?? null)) return false;
+    const savedLegend = mapData.legend_title ?? null;
+    if ((localLegendTitle?.trim() || null) !== (savedLegend?.trim() || null)) return false;
     if (localBasemap !== resolveBasemapId(mapData.basemap_style || 'positron')) return false;
     if (showBasemapLabels !== (mapData.show_basemap_labels ?? true)) return false;
     if (!deepEqual(basemapConfig, mapData.basemap_config ?? null)) return false;
     if (!deepEqual(localTerrainConfig, savedTerrainConfig(mapData))) return false;
+    // fix(#913 review): folder expansion is persisted (prepareLayersForPersistence
+    // reads groupMeta), and handleToggleGroupExpand marks the map dirty — without
+    // this an expand-then-revert reported clean and the expansion was lost.
+    if (!deepEqual(groupMeta, savedGroupMeta(mapData))) return false;
 
     return true;
   }, [
     mapData, localName, localDescription, localLegendTitle, localBasemap,
-    showBasemapLabels, basemapConfig, localTerrainConfig,
+    showBasemapLabels, basemapConfig, localTerrainConfig, groupMeta,
   ]);
 
   // The recheck must observe the reverted layers, so it runs in an effect after
   // commit rather than inline in the revert handler. The nonce and the layer
   // updates batch into the same render, so one request costs one pass.
   const [recheckNonce, setRecheckNonce] = useState(0);
-  const requestCleanRecheck = useCallback(() => setRecheckNonce((n) => n + 1), []);
+  const recheckPendingRef = useRef(false);
+  const requestCleanRecheck = useCallback(() => {
+    recheckPendingRef.current = true;
+    setRecheckNonce((n) => n + 1);
+  }, []);
+  // fix(#913 review): a request stays pending until it actually finds the map
+  // clean, and re-runs whenever the saved baselines it compares against change.
+  // A save invalidates the map-detail query, so a revert racing the refetch used
+  // to compare against stale server data, fail once, and never retry.
   useEffect(() => {
-    if (recheckNonce === 0) return;
-    if (computeMapIsClean()) setHasUnsavedChanges(false);
-  // eslint-disable-next-line react-hooks/exhaustive-deps -- fires only on an explicit request
-  }, [recheckNonce]);
+    if (recheckNonce === 0 || !recheckPendingRef.current) return;
+    if (!computeMapIsClean()) return;
+    recheckPendingRef.current = false;
+    setHasUnsavedChanges(false);
+  }, [recheckNonce, computeMapIsClean]);
 
   // fix(v1.6.0 audit D7): identity-stable "is this row a folder group?" lookup.
   // Reads through layersRef so callers (MapBuilderPage's memoized
@@ -1073,6 +1107,7 @@ export function useBuilderLayers(
     handleToggleLegend,
     handleDismissEphemeral,
     markDirty,
+    markOpaqueDirty,
     chatLayerActions,
     // Bulk operation handlers (Phase 1041 Plan 03)
     handleBulkVisibility,

--- a/frontend/src/pages/MapBuilderPage.tsx
+++ b/frontend/src/pages/MapBuilderPage.tsx
@@ -488,9 +488,11 @@ export function MapBuilderPage() {
     onRevertToSaved: layers.requestCleanRecheck,
   }), [dispatchLayerAction, handleRenderModeChange, handleTabChange, layers.requestCleanRecheck]);
 
-  // fix(#913): route page-owned dirt through markDirty so the clean-state
-  // recheck knows it cannot re-derive this from server state.
-  const handleMarkDirty = layers.markDirty;
+  // fix(#913 review): the dock's notes live in page state the layers hook cannot
+  // compare against server data, so this is the OPAQUE marker. Controls whose
+  // fields the hook does compare (map name/description via MapTitleBar, basemap
+  // swap/remove) use the plain markDirty instead.
+  const handleMarkDirty = layers.markOpaqueDirty;
 
   // Plugin toggles live in a store outside the layer state that drives
   // hasUnsavedChanges, so wrap the toggle to mark the map dirty — otherwise the
@@ -499,7 +501,8 @@ export function MapBuilderPage() {
   const handleTogglePlugin = useCallback(
     (pluginId: string) => {
       togglePlugin(pluginId);
-      layers.markDirty();
+      // Plugin state lives in its own store — not re-derivable here.
+      layers.markOpaqueDirty();
     },
     [togglePlugin, layers],
   );


### PR DESCRIPTION
## What changed

Follow-up to the review on #988 (issue #913), which landed with four open findings. All four are in the map-cleanliness recompute the banner Revert triggers.

**1. Folder expansion was not compared** (the only one that loses data). Expansion state is persisted — `prepareLayersForPersistence` reads `groupMeta` — and `handleToggleGroupExpand` marks the map dirty. But `computeMapIsClean` compared layers and map fields only, so expanding a saved folder, then editing and reverting a child's style, reported clean; the flag cleared, `useBuilderSave` stamped the unsaved expansion into its baseline, and the change was dropped. `groupMeta` is now compared against the hydrated saved shape via a shared `savedGroupMeta(mapData)` helper, mirroring the load path so the two cannot drift.

**2. Opaque dirt was over-applied.** `markDirty` set `opaqueDirtyRef`, which blocks the recheck outright — but `MapTitleBar` (name/description) and the basemap swap/remove handlers call it, and those fields *are* compared. Once any of them fired, the unsaved indicator could never clear for the rest of the session, even with the map matching the server. The opaque flag is now its own marker, `markOpaqueDirty`, used only where the hook genuinely cannot compare: the dock's notes (page state) and plugin toggles (separate store). `markDirty` is a plain dirty mark again.

**3. Normalization did not match the save payload.** `handleSave` persists `localName || undefined`, `localDescription.trim() || null`, and a trimmed-or-null legend title. Comparing the raw local strings meant a description saved with surrounding whitespace (or a whitespace-only one) reported the map permanently dirty. The comparison now normalizes the same way the payload does.

**4. A failed recheck never retried.** The effect fired only on the nonce, so a revert racing the post-save refetch compared against stale `mapData`, failed once, and left the indicator stuck. A request now stays pending until it actually finds the map clean, and re-runs when the saved baselines it compares against change.

No schema, API, or security impact.

## Verification

    cd frontend && npm run lint && npm run typecheck && npx vitest run

363 files / 4212 tests. Four new pins in `use-builder-layers.clean-recheck.test.ts`, each confirmed red against the pre-fix hook: re-derivable edit put back clears; whitespace-only description clears; pending folder expansion stays dirty; opaque dirt stays dirty. `MapBuilderPage.settings-wiring.test.tsx` F2 now asserts the plugin toggle uses `markOpaqueDirty`.

One unrelated flake: `StackRow.test.tsx > "a space can be typed into the rename input…"` fails intermittently under the full parallel run and passes in isolation; it reproduces on a clean `origin/main` with this diff stashed.

Refs #913

https://claude.ai/code/session_01Gjs3zyCByCgjukVrg7DVZv