### PR TITLE
fix(sandbox): recalibrate the amplification guards to the banded buffer renderer

### DIFF
--- a/backend/app/platform/sandbox/validator.py
+++ b/backend/app/platform/sandbox/validator.py
@@ -276,6 +276,10 @@ _ALLOWED_POSTGIS_FUNCTIONS: frozenset[str] = frozenset(
         "st_centroid",
         "st_collect",
         "st_contains",
+        # fix(#1001): #990's banding branches on ST_Dimension to segmentize
+        # lines and areas differently. It reads one geometry's topological
+        # dimension and returns a small int — no rows, no amplification.
+        "st_dimension",
         "st_distance",
         "st_dwithin",
         "st_intersects",
@@ -380,11 +384,22 @@ def _select_subtree_scans_a_table(func: exp.Func) -> bool:
     already reads. A collect whose enclosing SELECT (including nested derived
     tables) scans a real table aggregates unbounded rows and stays rejected,
     however it is aliased.
+
+    fix(#1001): a set-returning function in FROM position parses as an
+    ``exp.Table`` whose ``this`` is the function, so counting every
+    ``exp.Table`` read ``FROM ST_DumpSegments(...)`` and ``FROM
+    generate_series(...)`` as table scans. #990's sub-zone banding put both in
+    the aggregate's own scope, which made the canonical buffer reject itself.
+    A function call is not a relation, and its own amplification is policed by
+    the generate_series shape check and the ST_Dump guard below. Only a named
+    relation counts here; anything unrecognized still does, to fail closed.
     """
     sel = func.find_ancestor(exp.Select)
     if sel is None:
         return True  # fail closed: no recognizable scope
-    return any(True for _ in sel.find_all(exp.Table))
+    return any(
+        True for tbl in sel.find_all(exp.Table) if not isinstance(tbl.this, exp.Func)
+    )
 
 
 def _validate_function_cost(func: exp.Func, fn_name: str, sql: str) -> None:
@@ -400,14 +415,28 @@ def _validate_function_cost(func: exp.Func, fn_name: str, sql: str) -> None:
     # fix(#935 codex r2): ST_Segmentize's max-edge argument controls vertex
     # amplification — a tiny or dynamic length manufactures an enormous
     # vertex count before any outer LIMIT applies. Require a numeric literal
-    # of at least 1000 (the canonical buffer uses 20 000 metres; 1000 in any
-    # unit the sandbox serves cannot amplify).
+    # no finer than the floor for its unit.
+    #
+    # fix(#1001): that floor was a flat 1000 on the assumption that the sandbox
+    # only ever segmentized in metres. #990's banding added a degree-unit call
+    # for areal input (ST_Segmentize(geom, 0.1), ~11 km) alongside the existing
+    # geography one (ST_Segmentize(geom::geography, 20000)), and 0.1 tripped a
+    # metres floor. The cast picks the unit: geography is metres, bare geometry
+    # is SRID units, i.e. degrees for the 4326 the sandbox serves. 0.01° keeps
+    # the two overloads bounded to comparable vertex budgets over a global
+    # extent — 40 075 km / 1000 m is ~40k vertices, 360° / 0.01° is 36k — so
+    # neither unit is the cheap way past the guard.
     if fn_name == "st_segmentize":
         length = func.expressions[1] if len(func.expressions) > 1 else None
+        target = func.expressions[0] if func.expressions else None
+        in_metres = (
+            isinstance(target, exp.Cast) and "geography" in target.to.sql().lower()
+        )
+        floor = 1000.0 if in_metres else 0.01
         segmentize_ok = (
             isinstance(length, exp.Literal)
             and length.is_number
-            and float(length.this) >= 1000
+            and float(length.this) >= floor
         )
         if not segmentize_ok:
             logger.info("sandbox.unbounded_segmentize", sql=sql)
@@ -482,6 +511,14 @@ def _check_function_allowlist(stmt: exp.Expression, sql: str) -> None:
         # their operands regardless, so a disallowed function inside either
         # side of an AND/OR is still caught below.
         if isinstance(func, exp.Connector):
+            continue
+        # fix(#1001): sqlglot models EXISTS as a Func subclass too, so #990's
+        # banding predicate (EXISTS (SELECT 1 FROM ST_DumpSegments(...)))
+        # parsed as an unlisted function named "exists". EXISTS is a
+        # short-circuiting predicate that yields one boolean, not a callable,
+        # and find_all still walks its subquery — every function and table in
+        # there is checked on its own merits below.
+        if isinstance(func, exp.Exists):
             continue
         if isinstance(func, exp.Anonymous):
             fn_name = func.name.lower() if hasattr(func, "name") else ""

--- a/backend/app/platform/sandbox/validator.py
+++ b/backend/app/platform/sandbox/validator.py
@@ -402,8 +402,46 @@ def _select_subtree_scans_a_table(func: exp.Func) -> bool:
     )
 
 
-def _validate_function_cost(func: exp.Func, fn_name: str, sql: str) -> None:
-    """Reject function arguments that can amplify a one-row query into a DoS."""
+def _statement_reprojects_off_4326(stmt: exp.Expression) -> bool:
+    """True when the statement reprojects to anything but a literal 4326.
+
+    fix(#1001 codex r1): the segmentize floor infers its unit from the target,
+    but ST_Transform is allowlisted, so a bare geometry is not necessarily in
+    degrees — ST_Transform(geom_4326, 3857) makes 0.01 a centimetre, and a
+    world-scale feature at that edge length is billions of vertices. Alias
+    indirection makes the target's own CRS unknowable in general (the banded
+    renderer segmentizes ``_pb_d0.c0``, several derived levels from its input),
+    so this asks the whole statement instead: any reprojection away from 4326,
+    or to an SRID we cannot read as a literal, forces the metres floor on every
+    segmentize in the query. The canonical buffer reprojects via ``::geography``
+    casts and contains no ST_Transform, so it is unaffected.
+    """
+    for fn in stmt.find_all(exp.Func):
+        if isinstance(fn, exp.Anonymous):
+            name = fn.name.lower() if hasattr(fn, "name") else ""
+        else:
+            name = fn.sql_name().lower() if hasattr(fn, "sql_name") else ""
+        if name != "st_transform":
+            continue
+        srid = fn.expressions[1] if len(fn.expressions) > 1 else None
+        known_4326 = (
+            isinstance(srid, exp.Literal)
+            and srid.is_number
+            and str(srid.this) == "4326"
+        )
+        if not known_4326:
+            return True
+    return False
+
+
+def _validate_function_cost(
+    func: exp.Func, fn_name: str, sql: str, reprojected: bool = True
+) -> None:
+    """Reject function arguments that can amplify a one-row query into a DoS.
+
+    ``reprojected`` defaults to True so a caller that forgets to pass it gets
+    the strict metres floor rather than the relaxed degrees one.
+    """
     # fix(#935): generate_series is admitted ONLY in the exact bounded form
     # the canonical geodesic buffer expression emits; every other use — big
     # literals, dynamic bounds from table columns, generator composition — is
@@ -426,13 +464,17 @@ def _validate_function_cost(func: exp.Func, fn_name: str, sql: str) -> None:
     # the two overloads bounded to comparable vertex budgets over a global
     # extent — 40 075 km / 1000 m is ~40k vertices, 360° / 0.01° is 36k — so
     # neither unit is the cheap way past the guard.
+    #
+    # fix(#1001 codex r1): "not a geography cast" does NOT imply degrees; a
+    # projected geometry is in the projection's units. Only a statement with no
+    # reprojection away from 4326 gets the degrees floor.
     if fn_name == "st_segmentize":
         length = func.expressions[1] if len(func.expressions) > 1 else None
         target = func.expressions[0] if func.expressions else None
         in_metres = (
             isinstance(target, exp.Cast) and "geography" in target.to.sql().lower()
         )
-        floor = 1000.0 if in_metres else 0.01
+        floor = 0.01 if not in_metres and not reprojected else 1000.0
         segmentize_ok = (
             isinstance(length, exp.Literal)
             and length.is_number
@@ -503,6 +545,9 @@ def _check_function_allowlist(stmt: exp.Expression, sql: str) -> None:
       4. Allowed spatial functions → reject unbounded aggregate/complexity forms
       5. Otherwise → reject (fail-closed)
     """
+    # Computed once per statement: the segmentize floor needs to know whether
+    # anything here leaves 4326, since that changes what its length means.
+    reprojected = _statement_reprojects_off_4326(stmt)
     for func in stmt.find_all(exp.Func):
         # fix(#538): sqlglot models AND/OR (exp.Connector) as Func subclasses,
         # so any compound condition (WHERE x AND y, JOIN ... ON a AND b,
@@ -541,7 +586,7 @@ def _check_function_allowlist(stmt: exp.Expression, sql: str) -> None:
             logger.info("sandbox.unlisted_function", sql=sql, function=fn_name)
             raise SandboxError("invalid_query", "Query uses a disallowed function")
 
-        _validate_function_cost(func, fn_name, sql)
+        _validate_function_cost(func, fn_name, sql, reprojected)
 
 
 def validate_sql(sql: str) -> ValidatedQuery:

--- a/backend/tests/test_sec025_sandbox_allowlist.py
+++ b/backend/tests/test_sec025_sandbox_allowlist.py
@@ -613,6 +613,33 @@ class TestResourceAmplificationRejected:
             "SELECT ST_Segmentize(geom_4326::geography, 999) FROM data.cities"
         )
 
+    def test_degrees_floor_needs_a_statement_that_stays_in_4326(self):
+        """fix(#1001 codex r1): "not a geography cast" does not mean degrees.
+        ST_Transform is allowlisted, so a bare geometry can be projected, where
+        0.01 is a centimetre and a world-scale feature is billions of vertices.
+        A reprojection anywhere in the statement forces the metres floor."""
+        _assert_rejects(
+            "SELECT ST_Segmentize(ST_Transform(geom_4326, 3857), 0.01) FROM data.cities"
+        )
+        _assert_rejects(
+            "SELECT ST_Segmentize(ST_Transform(geom_4326, 3857), 0.1) FROM data.cities"
+        )
+        # The metres floor is still satisfiable on a projected target.
+        validate_sql(
+            "SELECT ST_Segmentize(ST_Transform(geom_4326, 3857), 1000) "
+            "FROM data.cities LIMIT 5"
+        )
+        # A non-literal SRID is unreadable, so it fails closed the same way.
+        _assert_rejects(
+            "SELECT ST_Segmentize(ST_Transform(geom_4326, srid_col), 0.1) "
+            "FROM data.cities"
+        )
+        # An explicit no-op transform to 4326 is still degrees.
+        validate_sql(
+            "SELECT ST_Segmentize(ST_Transform(geom_4326, 4326), 0.1) "
+            "FROM data.cities LIMIT 5"
+        )
+
     def test_allows_canonical_scale_segmentize(self):
         validate_sql(
             "SELECT ST_Segmentize(geom_4326::geography, 20000) FROM data.cities LIMIT 5"

--- a/backend/tests/test_sec025_sandbox_allowlist.py
+++ b/backend/tests/test_sec025_sandbox_allowlist.py
@@ -539,11 +539,79 @@ class TestResourceAmplificationRejected:
             "(SELECT geom_4326 AS p FROM data.cities) AS _pb_p) AS blob"
         )
 
+    def test_from_position_function_is_not_a_table_scan(self):
+        """fix(#1001): a set-returning function in FROM position parses as an
+        exp.Table wrapping the function, which the scope check used to count as
+        a relation. #990's banding put ST_DumpSegments and generate_series in
+        the aggregate's own scope and the canonical buffer began rejecting
+        itself. Neither reads a relation, so neither may trip the guard."""
+        validate_sql(
+            "SELECT ST_Collect(s.geom) FROM "
+            "ST_DumpSegments(ST_MakeEnvelope(0, 0, 1, 1, 4326)) AS s"
+        )
+
+    def test_exists_subquery_contents_are_still_validated(self):
+        """fix(#1001): EXISTS is skipped as a callable, so prove the walk still
+        reaches inside it. A blocked function and an unbounded aggregate hidden
+        in the subquery must both still reject."""
+        _assert_rejects(
+            "SELECT name FROM data.cities c WHERE EXISTS "
+            "(SELECT 1 FROM data.roads r WHERE r.tag = pg_read_file('/etc/passwd'))"
+        )
+        _assert_rejects(
+            "SELECT name FROM data.cities c WHERE EXISTS "
+            "(SELECT ST_Union(geom_4326) FROM data.roads)"
+        )
+
+    def test_from_position_function_does_not_mask_a_real_table_scan(self):
+        """The paired negative control: a genuine relation in the same scope
+        still rejects, so #1001 narrowed the check without opening a hole. The
+        function-source exemption must not generalise, including when a real
+        relation sits beside a function in the same FROM."""
+        _assert_rejects(
+            "SELECT ST_Collect(d.geom) FROM data.cities c, "
+            "LATERAL ST_DumpSegments(c.geom_4326) AS d"
+        )
+        _assert_rejects(
+            "SELECT (SELECT ST_Collect(x.p) FROM "
+            "(SELECT c.geom_4326 AS p FROM data.cities c, "
+            "generate_series(0, 5) AS g(i)) AS x) AS blob"
+        )
+
+    def test_exists_over_a_relation_still_counts_as_a_scan(self):
+        """fix(#1001): EXISTS is skipped as a callable, not as a scope. A table
+        read inside one still counts for the scan check, so the unary
+        ST_Collect exception stays closed."""
+        _assert_rejects(
+            "SELECT (SELECT ST_Collect(p.g) FROM (SELECT geom_4326 AS g "
+            "FROM data.cities WHERE EXISTS (SELECT 1 FROM data.roads)) AS p)"
+        )
+
     def test_rejects_tiny_or_dynamic_segmentize_length(self):
         """fix(#935 codex r2): ST_Segmentize's max-edge argument controls
         vertex amplification; only large numeric literals pass."""
         _assert_rejects("SELECT ST_Segmentize(geom_4326, 1e-100) FROM data.cities")
         _assert_rejects("SELECT ST_Segmentize(geom_4326, population) FROM data.cities")
+
+    def test_segmentize_floor_follows_the_unit(self):
+        """fix(#1001): the floor was a flat 1000 on a metres assumption. #990
+        segmentizes areal input in degrees, so the geography cast picks the
+        unit. A degree length still has a floor, and metres still needs 1000 —
+        a bare-geometry pass must not become the way to smuggle 1e-9 in."""
+        # Degrees (bare geometry): a floor, not the absence of one. #990's
+        # canonical 0.1 passes; amplifying and dynamic lengths do not.
+        validate_sql("SELECT ST_Segmentize(geom_4326, 0.1) FROM data.cities LIMIT 5")
+        _assert_rejects("SELECT ST_Segmentize(geom_4326, 0.0001) FROM data.cities")
+        _assert_rejects("SELECT ST_Segmentize(geom_4326, 1e-100) FROM data.cities")
+        _assert_rejects("SELECT ST_Segmentize(geom_4326, population) FROM data.cities")
+        # Metres (geography cast): unchanged, and the degrees floor must not
+        # leak onto it — 0.1 would be 10 cm there.
+        _assert_rejects(
+            "SELECT ST_Segmentize(geom_4326::geography, 0.1) FROM data.cities"
+        )
+        _assert_rejects(
+            "SELECT ST_Segmentize(geom_4326::geography, 999) FROM data.cities"
+        )
 
     def test_allows_canonical_scale_segmentize(self):
         validate_sql(


### PR DESCRIPTION
Restores `main`, which is red on `test_ai_sql_prompt_935.py::test_rendered_buffer_expression_passes_the_sandbox_validator`.

Closes #1001.

## What broke

#990 rewrote `render_geodesic_buffer` to slice wide buffer inputs into sub-zone bands. #994 added the SEC-025 amplification guards, which were written against the render shape that existed before that rewrite, together with the live-rendering test that catches the mismatch. Both PRs were green and neither is wrong on its own. They were never green together: #990 merged at 22:06Z, and #994 merged at 23:39Z with a head that does not contain it. Branch protection had `strict` off at the time to drain a merge livelock, so nothing forced #994 to re-test against the newer `main`.

The practical effect is worse than a red test. All three guards reject the canonical buffer expression that the NL→SQL prompt instructs the model to copy verbatim, so no buffer question could execute at all.

## Changes

**`_select_subtree_scans_a_table` no longer counts a function as a relation.** sqlglot parses a set-returning function in FROM position as an `exp.Table` whose `this` is the function, so `FROM ST_DumpSegments(...)` and `FROM generate_series(...)` both read as table scans. #990's banding put them in the aggregate's own scope, so the unary `ST_Collect` exception stopped applying and the buffer rejected itself. The real relation was never in that scope, only further up the ancestor chain. Only a named relation counts now; anything unrecognized still counts, so the check stays fail-closed.

**`exp.Exists` is skipped as a callable.** #990's banding predicate uses `EXISTS (SELECT 1 FROM ST_DumpSegments(...) ...)`, and sqlglot models `exp.Exists` as a `Func` subclass, so the allowlist saw an unlisted function named `exists`. This is the same trap #538 hit with `AND`/`OR`, and it takes the same fix. `find_all` still walks the subquery, so its contents are validated on their own merits.

**The `ST_Segmentize` floor follows the unit.** It was a flat `>= 1000`, reasoning that "1000 in any unit the sandbox serves cannot amplify." #990 added a degree-unit call for areal input, `ST_Segmentize(geom, 0.1)`, which is about 11 km but far below a metres floor. The geography cast now picks the unit: metres keep the 1000 floor, bare geometry gets 0.01°, roughly 1.1 km. A full 360° span segmentizes to about 36k vertices at that floor, and it is 10x finer than the canonical 0.1.

**`st_dimension` added to the PostGIS allowlist**, which #990's areal/linear branch needs. It reads one geometry's topological dimension and returns a small int.

## Security impact

Three of these loosen a fail-closed guard, so each ships with a paired negative control rather than only the passing case:

- A genuine relation in the same scope as a FROM-position function still rejects, so the narrowed table check cannot be used to hide a table scan.
- A blocked function and an unbounded aggregate hidden inside an `EXISTS` subquery both still reject, proving the walk reaches inside it.
- `1e-9` degrees still rejects, and the metres floor is unchanged, so the bare-geometry path does not become a way to smuggle a tiny length past the guard.

No schema, API, or config impact.

## Verification

```
cd backend && set -a && source ../.env.test && set +a
uv run pytest tests/test_sec025_sandbox_allowlist.py tests/test_ai_sql_prompt_935.py tests/test_sandbox.py -q   # 162 passed
uv run pytest -q -n 4                                                                                          # full suite
uv run ruff check . && uv run ruff format --check .
```

## Follow-up

Guards that encode the shape of a generated template are coupled to that generator, and nothing in the repo expresses that coupling. Someone editing `render_geodesic_buffer` gets no signal that sandbox guards depend on its output. #1001 notes a comment at the renderer pointing back at the guards as a cheap improvement, and #1000 (merge queue) is the structural fix for the class of failure that let this land.
