### PR TITLE
revert(sandbox): drop #994's allowlist entries and cost guards, keep its prompt

### DIFF
--- a/backend/app/platform/sandbox/validator.py
+++ b/backend/app/platform/sandbox/validator.py
@@ -171,14 +171,6 @@ _ALLOWED_FUNCTIONS: frozenset[str] = frozenset(
         "greatest",
         "least",
         "width_bucket",
-        # fix(#935): GENERATE_SERIES → sqlglot sql_name
-        # "exploding_generate_series". Named here so it clears the fail-closed
-        # allowlist, but _validate_function_cost only admits the EXACT series
-        # call the canonical geodesic buffer expression emits (bounded by a
-        # 4326 longitude span, at most ~61 terms); every other
-        # generate_series — literal, dynamic, or composed — stays rejected.
-        "exploding_generate_series",
-        "generate_series",  # Anonymous-node spelling on some sqlglot paths
         "pi",
         "degrees",
         "radians",
@@ -287,161 +279,17 @@ _ALLOWED_POSTGIS_FUNCTIONS: frozenset[str] = frozenset(
         "st_within",
         "st_x",
         "st_y",
-        # fix(#935): the prompt now mandates render_geodesic_buffer's output
-        # for metric buffers, so the sandbox must admit exactly the machinery
-        # that expression uses — the prompt is this allowlist's source of
-        # truth, and tests/test_ai_sql_prompt_935.py round-trips the rendered
-        # expression through validate_sql so the two cannot drift.
-        "st_collectionextract",
-        "st_collectionhomogenize",
-        # st_dump/st_dumpsegments clear the name allowlist but are admitted
-        # only in table-free subtrees (see _validate_function_cost) — as a
-        # set-returning source over a table they are the UNNEST amplification
-        # class (fix(#935 codex r3)).
-        "st_dump",
-        "st_dumpsegments",
-        "st_intersection",
-        "st_isempty",
-        "st_makeenvelope",
-        "st_makevalid",
-        "st_numgeometries",
-        "st_segmentize",
-        "st_shiftlongitude",
-        "st_unaryunion",
-        "st_wrapx",
-        "st_xmax",
-        "st_xmin",
-        "st_ymax",
-        "st_ymin",
     }
 )
 
 
-_GENERATE_SERIES_NAMES = frozenset({"generate_series", "exploding_generate_series"})
-
-
-def _normalized_func_sql(func: exp.Func) -> str:
-    """Whitespace-collapsed lowercase SQL of a function node, for comparison."""
-    import re as _re
-
-    return _re.sub(r"\s+", " ", func.sql(dialect="postgres")).lower()
-
-
-_canonical_series_cache: frozenset[str] | None = None
-
-
-def _canonical_band_series_shapes() -> frozenset[str]:
-    """The generate_series call(s) the canonical geodesic buffer emits.
-
-    fix(#935): the NL->SQL prompt mandates copying ``render_geodesic_buffer``'s
-    output verbatim, and that expression slices wide inputs into longitude
-    bands with a series bounded by a 4326 longitude span (at most ~61 terms).
-    Rendering it here and extracting the series call keeps the admission in
-    lockstep with ``analysis_sql`` — a renderer change re-admits its own new
-    shape automatically, and everything else keeps failing closed. Both sides
-    of the comparison go through the same sqlglot parse/render, so the match
-    is exact, not textual guesswork.
-    """
-    global _canonical_series_cache
-    if _canonical_series_cache is not None:
-        return _canonical_series_cache
-
-    # Function-level import: keeps sandbox importable without pulling the
-    # analysis renderer at module import in contexts that never validate SQL.
-    from app.platform.analysis_sql import render_geodesic_buffer
-
-    shapes: set[str] = set()
-    try:
-        parsed = sqlglot.parse_one(
-            f"SELECT {render_geodesic_buffer('geom_4326', 1)}", dialect="postgres"
-        )
-    except Exception:  # broad: a renderer/sqlglot drift must fail CLOSED (empty shape set rejects every series), never crash validation  # pragma: no cover
-        parsed = None
-    if parsed is not None:
-        for fn in parsed.find_all(exp.Func):
-            if isinstance(fn, exp.Anonymous):
-                name = fn.name.lower() if hasattr(fn, "name") else ""
-            else:
-                name = fn.sql_name().lower() if hasattr(fn, "sql_name") else ""
-            if name in _GENERATE_SERIES_NAMES:
-                shapes.add(_normalized_func_sql(fn))
-    _canonical_series_cache = frozenset(shapes)
-    return _canonical_series_cache
-
-
-def _select_subtree_scans_a_table(func: exp.Func) -> bool:
-    """True when the function's nearest enclosing SELECT reads any table.
-
-    fix(#935 codex r2): scopes the unary ``ST_Collect`` exception to the
-    canonical geodesic buffer shape without brittle text matching. In that
-    expression the aggregate re-collects a dump of ONE fenced row geometry —
-    its enclosing SELECT's whole subtree contains derived subqueries only,
-    never a table — so its memory is bounded by geometry the outer query
-    already reads. A collect whose enclosing SELECT (including nested derived
-    tables) scans a real table aggregates unbounded rows and stays rejected,
-    however it is aliased.
-    """
-    sel = func.find_ancestor(exp.Select)
-    if sel is None:
-        return True  # fail closed: no recognizable scope
-    return any(True for _ in sel.find_all(exp.Table))
-
-
 def _validate_function_cost(func: exp.Func, fn_name: str, sql: str) -> None:
     """Reject function arguments that can amplify a one-row query into a DoS."""
-    # fix(#935): generate_series is admitted ONLY in the exact bounded form
-    # the canonical geodesic buffer expression emits; every other use — big
-    # literals, dynamic bounds from table columns, generator composition — is
-    # the amplification class SEC-025 rejects.
-    if fn_name in _GENERATE_SERIES_NAMES:
-        if _normalized_func_sql(func) not in _canonical_band_series_shapes():
-            logger.info("sandbox.non_canonical_generate_series", sql=sql)
-            raise SandboxError("invalid_query", "Query uses a disallowed row generator")
-    # fix(#935 codex r2): ST_Segmentize's max-edge argument controls vertex
-    # amplification — a tiny or dynamic length manufactures an enormous
-    # vertex count before any outer LIMIT applies. Require a numeric literal
-    # of at least 1000 (the canonical buffer uses 20 000 metres; 1000 in any
-    # unit the sandbox serves cannot amplify).
-    if fn_name == "st_segmentize":
-        length = func.expressions[1] if len(func.expressions) > 1 else None
-        segmentize_ok = (
-            isinstance(length, exp.Literal)
-            and length.is_number
-            and float(length.this) >= 1000
-        )
-        if not segmentize_ok:
-            logger.info("sandbox.unbounded_segmentize", sql=sql)
-            raise SandboxError(
-                "invalid_query", "Query uses an unbounded geometry complexity option"
-            )
-
-    # Unary spatial aggregates. Unary ST_Union (the superlinear dissolve) is
-    # always rejected. fix(#935 codex r2): unary ST_Collect is admitted only
-    # when its enclosing SELECT scans no table — the canonical geodesic
-    # buffer's re-collect of a single fenced row geometry — so a whole-table
-    # ST_Collect(geom) stays rejected however it is nested or aliased.
-    if fn_name == "st_union" and len(func.expressions) < 2:
+    if fn_name in {"st_collect", "st_union"} and len(func.expressions) < 2:
         logger.info("sandbox.unbounded_spatial_aggregate", sql=sql, function=fn_name)
         raise SandboxError(
             "invalid_query", "Query uses an unbounded collection aggregate"
         )
-    if fn_name == "st_collect" and len(func.expressions) < 2:
-        if _select_subtree_scans_a_table(func):
-            logger.info(
-                "sandbox.unbounded_spatial_aggregate", sql=sql, function=fn_name
-            )
-            raise SandboxError(
-                "invalid_query", "Query uses an unbounded collection aggregate"
-            )
-
-    # fix(#935 codex r3): ST_Dump/ST_DumpSegments over a table are the UNNEST
-    # row-amplification class — every component of every geometry expands
-    # before the outer LIMIT applies. The canonical buffer only ever dumps a
-    # single fenced row geometry, whose enclosing SELECT scans no table.
-    if fn_name in {"st_dump", "st_dumpsegments"}:
-        if _select_subtree_scans_a_table(func):
-            logger.info("sandbox.table_scanning_dump", sql=sql, function=fn_name)
-            raise SandboxError("invalid_query", "Query uses an unbounded row generator")
 
     if fn_name == "st_buffer" and len(func.expressions) > 2:
         logger.info("sandbox.custom_buffer_segments", sql=sql)

--- a/backend/tests/test_ai_sql_prompt_935.py
+++ b/backend/tests/test_ai_sql_prompt_935.py
@@ -8,6 +8,8 @@ which removes the drift class by construction; these tests pin the wiring so
 a rewrite of the prompt cannot quietly reintroduce a hand-written copy.
 """
 
+import pytest
+
 from app.platform.analysis_sql import render_geodesic_buffer
 from app.processing.ai.sql_generator import SQL_SYSTEM_PROMPT
 
@@ -68,13 +70,28 @@ def test_every_buffer_in_the_prompt_is_generated_or_marked_wrong():
         )
 
 
-def test_rendered_buffer_expression_passes_the_sandbox_validator():
-    """fix(#935 codex r1): the prompt mandates copying the expression
-    verbatim, so the sandbox's fail-closed allowlist must admit every
-    function it uses — otherwise the exact SQL the prompt teaches raises
-    invalid_query and no buffer question can execute. Rendering live keeps
-    this in lockstep with analysis_sql; a renderer change that introduces a
-    new function fails here until the validator admits it."""
+def test_rendered_buffer_expression_is_refused_until_1001_lands():
+    """fix(#1001): INVERTED, deliberately, and it must go back to asserting
+    admission when #1001 lands.
+
+    #935 codex r1 admitted the buffer's functions and bounded them with cost
+    guards. #990 then rebuilt the renderer, and those guards — written against
+    the older shape — rejected the very expression the prompt mandates. Three
+    attempts to recalibrate them each drew a real P1 (see #1002), because
+    proving a target's units and admitting the canonical buffer are
+    contradictory under any target-inspection scheme: the buffer segmentizes
+    an alias, `_pb_d0.c0`, several derived levels from its input.
+
+    So the allowlist entries and the guards both came out. That leaves the
+    prompt still teaching the SAFE banded expression, which the sandbox now
+    refuses outright. The refusal is the point: the alternative was reverting
+    the prompt too, and `st_buffer` is allowlisted independently, so the model
+    would have emitted the bare `ST_Buffer(geom::geography, N)::geometry` form
+    and it would have EXECUTED — returning the world-spanning polygon across
+    ±180° that #883/#900/#990 fixed. A refused buffer question beats a
+    silently wrong overlay and bbox.
+    """
+    from app.platform.sandbox.schemas import SandboxError
     from app.platform.sandbox.validator import validate_sql
 
     denver = render_geodesic_buffer(
@@ -82,18 +99,20 @@ def test_rendered_buffer_expression_passes_the_sandbox_validator():
         50000,
     )
     # The prompt's worked example, as the model would emit it.
-    validate_sql(
-        "SELECT p.name AS park_name\n"
-        "FROM data.national_parks p\n"
-        f"WHERE ST_Intersects(p.geom_4326, {denver})\n"
-        "LIMIT 100"
-    )
+    with pytest.raises(SandboxError):
+        validate_sql(
+            "SELECT p.name AS park_name\n"
+            "FROM data.national_parks p\n"
+            f"WHERE ST_Intersects(p.geom_4326, {denver})\n"
+            "LIMIT 100"
+        )
     # A direct buffer-geometry request, the chat_geojson-shaped form.
     buffered = render_geodesic_buffer("s.geom_4326", 10000)
-    validate_sql(
-        f"SELECT s.name, ST_AsGeoJSON({buffered}) AS geometry\n"
-        "FROM data.stations s\nLIMIT 100"
-    )
+    with pytest.raises(SandboxError):
+        validate_sql(
+            f"SELECT s.name, ST_AsGeoJSON({buffered}) AS geometry\n"
+            "FROM data.stations s\nLIMIT 100"
+        )
 
 
 def test_function_reference_line_declares_degrees():

--- a/backend/tests/test_sec025_sandbox_allowlist.py
+++ b/backend/tests/test_sec025_sandbox_allowlist.py
@@ -461,10 +461,7 @@ class TestResourceAmplificationRejected:
         )
 
     def test_rejects_unknown_postgis_function(self):
-        # fix(#935): ST_MakeEnvelope joined the allowlist (canonical buffer
-        # machinery); ST_GeneratePoints — the attacker-chosen-cardinality
-        # generator the allowlist comment cites — stands in as the unknown.
-        _assert_rejects("SELECT ST_GeneratePoints(geom_4326, 100) FROM data.cities")
+        _assert_rejects("SELECT ST_MakeEnvelope(0, 0, 1, 1, 4326)")
 
     def test_rejects_oversized_generate_series(self):
         _assert_rejects("SELECT array_agg(i) FROM generate_series(1, 1000000000) AS i")
@@ -528,37 +525,3 @@ class TestResourceAmplificationRejected:
     )
     def test_rejects_unbounded_collection_builders(self, sql):
         _assert_rejects(sql)
-
-    def test_rejects_table_scanning_unary_st_collect_however_aliased(self):
-        """fix(#935 codex r2): the unary ST_Collect exception is scoped to the
-        canonical buffer's table-free re-collect. Hiding the table scan one
-        derived level down (or borrowing the canonical alias names) must not
-        slip past."""
-        _assert_rejects(
-            "SELECT (SELECT ST_Collect(_pb_p.p) FROM "
-            "(SELECT geom_4326 AS p FROM data.cities) AS _pb_p) AS blob"
-        )
-
-    def test_rejects_tiny_or_dynamic_segmentize_length(self):
-        """fix(#935 codex r2): ST_Segmentize's max-edge argument controls
-        vertex amplification; only large numeric literals pass."""
-        _assert_rejects("SELECT ST_Segmentize(geom_4326, 1e-100) FROM data.cities")
-        _assert_rejects("SELECT ST_Segmentize(geom_4326, population) FROM data.cities")
-
-    def test_allows_canonical_scale_segmentize(self):
-        validate_sql(
-            "SELECT ST_Segmentize(geom_4326::geography, 20000) FROM data.cities LIMIT 5"
-        )
-
-    def test_rejects_table_scanning_st_dump(self):
-        """fix(#935 codex r3): ST_Dump over a table is the UNNEST
-        row-amplification class; only the canonical buffer's table-free dump
-        of a single fenced geometry is admitted."""
-        _assert_rejects(
-            "SELECT COUNT(*) FROM data.cities c "
-            "CROSS JOIN LATERAL ST_Dump(c.geom_4326) d"
-        )
-        _assert_rejects("SELECT (ST_Dump(geom_4326)).geom FROM data.cities")
-        _assert_rejects(
-            "SELECT COUNT(*) FROM data.roads r, LATERAL ST_DumpSegments(r.geom_4326) s"
-        )


### PR DESCRIPTION
Restores `main`, red since #994 landed, which blocks #980, #981 and #965 — all three codex-clean and waiting on nothing else.

Refs #1001, which carries the redo.

## Why a revert and not a fix

#994's cost guards were written against the buffer expression as `render_geodesic_buffer` emitted it *before* #990 rebuilt that renderer to band wide inputs. The two merged 93 minutes apart and never ran together, because `strict` was off. All three guards reject the canonical buffer the prompt instructs the model to copy verbatim.

I tried recalibrating them in place (#1002). Three rounds, three real P1s, each fix opening the next:

1. Exempting function-backed FROM sources let a correlated lateral dump scan an outer table: `SELECT x.geom FROM data.cities c CROSS JOIN LATERAL (SELECT d.geom FROM ST_DumpSegments(c.geom_4326) d) x`.
2. Inferring degrees from "not a geography cast" admitted projected geometry, where `ST_Segmentize(ST_Transform(geom_4326, 3857), 0.01)` is one centimetre.
3. Gating that on `ST_Transform` still admitted a geography cast behind a derived-column alias: `WITH g AS (SELECT geom_4326::geography AS x FROM data.cities) SELECT ST_Segmentize(x, 0.01) FROM g`.

The third closes the door. The canonical buffer's own segmentize target is an alias, `_pb_d0.c0`, several derived levels from its input, so "prove the target's units" and "admit the canonical buffer" are contradictory under any target-inspection scheme. The same indirection defeats deciding whether a correlated source traces to a real relation, because the buffer's input legitimately does. That is data-flow analysis, and it does not belong in a hotfix for a red `main`.

## Why this is the stricter endpoint

#994 **added** `st_dump`, `st_dumpsegments`, `st_segmentize`, `generate_series` and `st_unaryunion` to the PostGIS allowlist to support the buffer, then added the cost guards to bound them. Removing both puts those amplification-prone functions back outside the fail-closed allowlist entirely. The sandbox here is stricter than `main` is today, not looser.

## Why #994's prompt change stays

This is the part I got wrong first time round, and review caught it.

A full revert restores the hand-written buffer teaching, and `st_buffer` is allowlisted independently of #994 — `test_allows_st_buffer` confirms `ST_Buffer(geom_4326::geography, 1000)::geometry` passes. So a full revert would instruct the model to emit the bare form **and it would execute**, returning the world-spanning or zone-distorted polygon that #883, #900 and #990 fixed. The "fails closed" claim I made for the full revert was simply false.

Keeping the prompt means the model emits the *safe* banded expression and the sandbox refuses it outright. A refused buffer question beats a silently wrong chat overlay and bbox.

So the user-visible effect is: buffer questions in chat now return an error instead of a wrong answer, until #1001 lands. Nothing else in NL→SQL changes.

## What is untouched

`render_geodesic_buffer` and the analysis-side buffer path that calls it directly are not affected. This is limited to the sandbox allowlist, the cost guards, and their tests.

`test_rendered_buffer_expression_*` is inverted to assert the refusal, with a docstring saying it must go back to asserting admission when #1001 lands, so the temporary state cannot quietly become permanent.

## The redo

#1001. The tractable design is matching the whole rendered template with the input as a single hole, rather than characterising the expression one function at a time. The canonical shapes are input-independent, measured across three different inputs, which is what makes it work:

```
st_collect:      3 shapes, input-independent
st_dumpsegments: 1 shape,  input-independent
st_segmentize:   2 shapes, input-independent
st_dump:         7 shapes, one embeds the buffer distance
```

`_canonical_band_series_shapes` already does this for `generate_series`, so the precedent is in the file. Two changes from #1002 are worth carrying over and are recorded on the issue: skipping `exp.Exists` in the callable walk (the #538 `exp.Connector` class, one node type over) and `st_dimension` in the allowlist.

## Verification

```
cd backend && set -a && source ../.env.test && set +a
uv run pytest tests/test_sec025_sandbox_allowlist.py tests/test_sandbox.py tests/test_ai_sql_prompt_935.py -q   # 154 passed
uv run pytest -q -n 4                                                                                          # full suite
uv run ruff check . && uv run ruff format --check .
```
