### PR TITLE
chore(scripts): show the version-site list even when the CHANGELOG check fails

### DIFF
--- a/scripts/check_version_coherence.py
+++ b/scripts/check_version_coherence.py
@@ -207,16 +207,30 @@ def main() -> int:
     # Canonical = backend distribution version (what the app derives at runtime).
     canonical = sites[f"{_rel(BACKEND_PYPROJECT)} ([project].version)"]
 
-    offenders = {site: v for site, v in sites.items() if v != canonical}
+    # fix(#1019): print every site BEFORE any check can return. Both CHANGELOG
+    # failure paths used to sit above this listing, so a `make version-check`
+    # that failed on the CHANGELOG never said whether the lockfiles and
+    # manifests had stamped — which is the whole reason you run it mid-bump.
+    # For the same reason both halves are now collected and reported together
+    # instead of returning on the first.
+    print(
+        f"Version sites ({len(sites)}), "
+        f"canonical (backend/pyproject.toml) = {canonical}:"
+    )
+    for site, v in sites.items():
+        print(f"  [{'ok' if v == canonical else 'DRIFT'}] {site}: {v}")
 
+    failed = False
+
+    offenders = {site: v for site, v in sites.items() if v != canonical}
     if offenders:
+        failed = True
         sys.stderr.write(
             f"FAIL: version drift detected. Canonical (backend/pyproject.toml) = {canonical!r}.\n"
             f"Run `make bump VERSION={canonical}` to resync, or correct the offending site:\n"
         )
         for site, v in offenders.items():
             sys.stderr.write(f"  - {site}: {v!r} != {canonical!r}\n")
-        return 1
 
     # Mirror release.yml's awk: take the lines between this version's header and
     # the next `## [` one. Matching the header alone is not enough — an empty
@@ -224,6 +238,7 @@ def main() -> int:
     # takes the same git-log fallback as a missing one.
     body = _changelog_section(canonical)
     if body is None:
+        failed = True
         sys.stderr.write(
             f"FAIL: {_rel(CHANGELOG)} has no '## [{canonical}]' section.\n"
             f"release.yml extracts the release body by matching that exact header and\n"
@@ -231,21 +246,24 @@ def main() -> int:
             f"'## [Unreleased]' header to '## [{canonical}] - <date>' (keeping a fresh\n"
             f"empty Unreleased above it) and add the matching link reference.\n"
         )
-        return 1
-    if not body.strip():
+    elif not body.strip():
+        failed = True
         sys.stderr.write(
             f"FAIL: {_rel(CHANGELOG)}'s '## [{canonical}]' section is empty.\n"
             f"release.yml treats an empty section exactly like a missing one and\n"
             f"falls back to the raw git-log list. Write the release notes under that\n"
             f"header before tagging.\n"
         )
+    else:
+        lines = len([ln for ln in body.strip().splitlines() if ln.strip()])
+        print(
+            f"  [ok] {_rel(CHANGELOG)}: '## [{canonical}]' section present ({lines} lines)."
+        )
+
+    if failed:
         return 1
 
     print(f"OK: all {len(sites)} version sites agree on {canonical}.")
-    for site, v in sites.items():
-        print(f"  {site}: {v}")
-    lines = len([ln for ln in body.strip().splitlines() if ln.strip()])
-    print(f"  {_rel(CHANGELOG)}: '## [{canonical}]' section present ({lines} lines).")
     return 0
 
 


### PR DESCRIPTION
## What changed

`scripts/check_version_coherence.py` checks two independent things: that every version site agrees with the canonical `backend/pyproject.toml` version, and that `CHANGELOG.md` carries a populated `## [<version>]` section. Both CHANGELOG failure paths returned above the per-site print, so a failing `make version-check` told you the CHANGELOG was wrong and said nothing about whether the 19 version sites had stamped.

That is backwards for the one workflow the script exists to serve. During a trial bump the per-site list is exactly what you need to tell a lockfile that did not stamp from a CHANGELOG section you have not written yet.

- The per-site list now prints before any check can return, each site tagged `[ok]` or `[DRIFT]`.
- Drift and CHANGELOG verdicts are collected and both reported, instead of returning on the first.
- The `OK: all N version sites agree on X.` summary moved to the end, where it now means "both halves passed" rather than heading a list.

No change to exit-code semantics: 0 coherent, 1 drift, as the module docstring states.

## Schema / API / config impact

None. Stdlib-only script, no runtime code, no CI contract change — `.github/workflows/ci.yml:729` and `make version-check` only read the exit code.

## Verification

Clean tree:

```
python3 scripts/check_version_coherence.py   # exit 0, 19 sites + CHANGELOG line, then OK
python3 scripts/tests/test-changelog-gate.py # 20 passed, 0 failed
```

Failure paths, exercised by temporarily mangling the tree and restoring with `git checkout --`:

- CHANGELOG header renamed away: exit 1, all 19 sites still listed.
- Root `package.json` set to `9.9.9` **and** the CHANGELOG header renamed away: exit 1, both `FAIL:` blocks on stderr, `package.json` tagged `[DRIFT]` in the listing.

Closes #1019