### PR TITLE
fix(sandbox): admit EXISTS subqueries in the SQL validator

### DIFF
--- a/backend/app/platform/sandbox/validator.py
+++ b/backend/app/platform/sandbox/validator.py
@@ -331,6 +331,13 @@ def _check_function_allowlist(stmt: exp.Expression, sql: str) -> None:
         # side of an AND/OR is still caught below.
         if isinstance(func, exp.Connector):
             continue
+        # fix(#1017): sqlglot reaches EXISTS through the same Func path (#538),
+        # so every EXISTS subquery was rejected as an unlisted "function".
+        # EXISTS is a subquery predicate, not a callable — and find_all walks
+        # its operand regardless, so a disallowed function inside the subquery
+        # is still caught below.
+        if isinstance(func, exp.Exists):
+            continue
         if isinstance(func, exp.Anonymous):
             fn_name = func.name.lower() if hasattr(func, "name") else ""
         else:

--- a/backend/tests/test_sec025_sandbox_allowlist.py
+++ b/backend/tests/test_sec025_sandbox_allowlist.py
@@ -15,6 +15,7 @@ RED → GREEN history:
 from __future__ import annotations
 
 import pytest
+from structlog.testing import capture_logs
 
 from app.platform.sandbox.schemas import SandboxError
 from app.platform.sandbox.validator import validate_sql
@@ -39,6 +40,30 @@ def _assert_rejects(
     )
     if expected_message is not None:
         assert exc_info.value.user_message == expected_message
+
+
+def _assert_rejects_function(sql: str, expected_function: str) -> None:
+    """Assert validate_sql rejects `sql` and names `expected_function` as the cause.
+
+    Plain `_assert_rejects` cannot tell "the function inside the subquery was
+    caught" from "the enclosing predicate was itself refused as an unlisted
+    function", which is exactly the confusion #538/#1017 are about. Reading the
+    structured log's `function` field pins the reason.
+    """
+    with capture_logs() as logs:
+        with pytest.raises(SandboxError) as exc_info:
+            validate_sql(sql)
+    assert exc_info.value.category == "invalid_query"
+    rejected = [
+        entry.get("function")
+        for entry in logs
+        if entry.get("event", "").startswith("sandbox.")
+        and entry.get("function") is not None
+    ]
+    assert rejected == [expected_function], (
+        f"Expected rejection on {expected_function!r} but the validator "
+        f"reported {rejected!r} for SQL: {sql!r}"
+    )
 
 
 def _assert_allows(sql: str) -> None:
@@ -447,6 +472,65 @@ class TestBooleanOperatorsAllowed:
     def test_rejects_unlisted_spatial_function_inside_and(self):
         _assert_rejects(
             "SELECT name FROM data.cities WHERE ST_EvilThing(geom_4326) AND pop > 1"
+        )
+
+
+class TestExistsSubqueryAllowed:
+    """EXISTS is a subquery predicate, not a callable — but sqlglot models
+    exp.Exists on the same Func path that trapped AND/OR (#538), so the
+    fail-closed walk rejected every EXISTS subquery as function "exists"
+    (#1017; fix skips Exists nodes, whose operands are still walked)."""
+
+    def test_allows_exists_subquery(self):
+        _assert_allows(
+            "SELECT name FROM data.t AS a "
+            "WHERE EXISTS (SELECT 1 FROM data.u AS b WHERE b.id = a.id)"
+        )
+
+    def test_allows_not_exists_subquery(self):
+        _assert_allows(
+            "SELECT name FROM data.t AS a "
+            "WHERE NOT EXISTS (SELECT 1 FROM data.u AS b WHERE b.id = a.id)"
+        )
+
+    def test_allows_exists_with_allowed_functions_inside(self):
+        _assert_allows(
+            "SELECT c.name FROM data.cities AS c "
+            "WHERE EXISTS (SELECT 1 FROM data.parks AS p "
+            "WHERE ST_Intersects(p.geom_4326, c.geom_4326) AND LOWER(p.name) = 'x')"
+        )
+
+    def test_rejects_blocked_function_inside_exists(self):
+        """Skipping the Exists node must NOT hide functions in its subquery."""
+        _assert_rejects_function(
+            "SELECT name FROM data.t AS a "
+            "WHERE EXISTS (SELECT 1 FROM data.u AS b WHERE pg_sleep(1) IS NULL)",
+            "pg_sleep",
+        )
+
+    def test_rejects_unlisted_function_inside_exists(self):
+        _assert_rejects_function(
+            "SELECT name FROM data.t AS a "
+            "WHERE EXISTS (SELECT version() FROM data.u AS b WHERE b.id = a.id)",
+            "current_version",
+        )
+
+    def test_rejects_unlisted_spatial_function_inside_exists(self):
+        _assert_rejects_function(
+            "SELECT name FROM data.t AS a "
+            "WHERE EXISTS (SELECT 1 FROM data.u AS b "
+            "WHERE ST_MakeEnvelope(0, 0, 1, 1, 4326) IS NOT NULL)",
+            "st_makeenvelope",
+        )
+
+    def test_rejects_recursive_cte_inside_exists(self):
+        """The other tree-wide guards still reach into an EXISTS subquery."""
+        _assert_rejects(
+            "SELECT name FROM data.t AS a WHERE EXISTS ("
+            "WITH RECURSIVE bomb(n) AS ("
+            "SELECT 1 UNION ALL SELECT n + 1 FROM bomb WHERE n < 1000000000"
+            ") SELECT n FROM bomb)",
+            expected_message="Recursive queries are not allowed",
         )
 
 


### PR DESCRIPTION
## What changed

`_check_function_allowlist` walks `stmt.find_all(exp.Func)` and requires every
node's canonical name to be allowlisted. sqlglot models `exp.Exists` as an
`exp.Func` subclass, so the walk yielded it as function `exists`, a name that is
in neither `_ALLOWED_FUNCTIONS` nor `_ALLOWED_POSTGIS_FUNCTIONS`. Every `EXISTS`
subquery was therefore refused on `main`:

```
sandbox.unlisted_function  function=exists
SandboxError: Query uses a disallowed function
```

`exp.Exists` is now skipped beside the `exp.Connector` skip that #538 added for
the identical trap with `AND`/`OR`. `EXISTS` is a subquery predicate, not a
callable, and `find_all` still walks its operand, so a disallowed function
inside the subquery is caught on its own node.

## Security impact

No widening. The skip suppresses the check for one predicate node; every node
inside the subquery is still validated. Three negative controls cover that: a
blocked function (`pg_sleep`), an unlisted function (`version()`), and an
unlisted spatial function (`ST_MakeEnvelope`) placed inside the `EXISTS`
subquery are all still rejected, and a recursive CTE inside `EXISTS` still trips
the recursive-CTE guard.

Those controls assert the validator's logged `function` field, not just that
something raised. Without that, they would pass on the pre-fix `exists`
refusal and prove nothing. Verified by stashing the validator change: six of the
seven new tests fail without it.

## Scope

This does not admit the canonical geodesic buffer; `exists` is one of the
seventeen names that expression needs, and the other sixteen are #1001.

## Verification

```
cd backend && uv run pytest tests/test_sec025_sandbox_allowlist.py tests/test_sandbox.py tests/test_sandbox_tenant_schema.py -q
# 162 passed
cd backend && uv run ruff check . && uv run ruff format --check .
```

Closes #1017
