### PR TITLE
fix(builder): abort a closed panel's preview and hold the map in state

### DIFF
--- a/frontend/src/api/analysis.ts
+++ b/frontend/src/api/analysis.ts
@@ -9,10 +9,14 @@ import type {
 export async function previewAnalysis(
   datasetId: string,
   body: AnalysisPreviewRequest,
+  // fix(#787 item 3): callers cancel a preview they no longer want. apiFetch
+  // composes this with its own request timeout, so whichever fires first wins.
+  signal?: AbortSignal,
 ): Promise<AnalysisPreviewResponse> {
   return apiFetch<AnalysisPreviewResponse>(`/datasets/${datasetId}/analysis/preview/`, {
     method: 'POST',
     body: JSON.stringify(body),
+    signal,
   });
 }
 

--- a/frontend/src/components/builder/AnalysisPanel.tsx
+++ b/frontend/src/components/builder/AnalysisPanel.tsx
@@ -422,6 +422,22 @@ export function AnalysisPanel({
     },
     [],
   );
+  // fix(#787 item 10): the clip Draw button gated on `mapInstanceRef.current`
+  // read during render. Ref assignments don't re-render, so the button could
+  // stay dead until an unrelated state change happened to re-render the panel.
+  // Mirror the instance into state from an effect — the legal place to read a
+  // ref — using the same no-dep-array, retry-every-commit idiom as the mask
+  // effects below, which is what reaches the moment the lazy map exists. The
+  // initializer covers the common case (map already loaded when the panel
+  // opens) so a mount does not spend an extra commit settling this.
+  const [mapInstance, setMapInstance] = useState<MaplibreMap | null>(
+    () => mapInstanceRef?.current ?? null,
+  );
+  // eslint-disable-next-line react-hooks/exhaustive-deps -- deliberately runs every commit (the ref object never changes identity, only its contents); the prev === map bailout is what stops the update chain
+  useEffect(() => {
+    const map = mapInstanceRef?.current ?? null;
+    setMapInstance((prev) => (prev === map ? prev : map));
+  });
   const restoredMaskDrawnRef = useRef(false);
   useEffect(() => {
     if (restoredMaskDrawnRef.current) return;
@@ -555,6 +571,11 @@ export function AnalysisPanel({
   // change bumps the sequence (so an in-flight response knows it has been
   // superseded) and clears the overlay + badge outright.
   const previewSeqRef = useRef(0);
+  // fix(#787 item 3): closing the panel mid-preview suppressed the result
+  // callbacks but left the request running. The controller for the preview in
+  // flight, aborted on unmount and when a newer preview supersedes it.
+  const previewAbortRef = useRef<AbortController | null>(null);
+  useEffect(() => () => previewAbortRef.current?.abort(), []);
   const jobIdRef = useRef(jobId);
   jobIdRef.current = jobId;
   // fix(#793 review): an input change while the materialize POST is still on the
@@ -701,15 +722,24 @@ export function AnalysisPanel({
         throw new Error(
           t('analysisTools.noLayerSelected', { defaultValue: 'No layer selected' }),
         );
-      return previewAnalysis(datasetId, {
-        // canRun blocks dissolve from the preview path.
-        operation: operation as Exclude<AnalysisOperation, 'dissolve'>,
-        ...(operation === 'buffer' ? { distance_meters: distanceValue } : {}),
-        ...(operation === 'clip' && mask ? { mask } : {}),
-        ...(operation === 'clip' && !mask && maskLayer?.dataset_id
-          ? { mask_dataset_id: maskLayer.dataset_id }
-          : {}),
-      });
+      // The seq guard already drops a superseded response; aborting stops the
+      // abandoned request from finishing its sandbox query as well.
+      previewAbortRef.current?.abort();
+      const controller = new AbortController();
+      previewAbortRef.current = controller;
+      return previewAnalysis(
+        datasetId,
+        {
+          // canRun blocks dissolve from the preview path.
+          operation: operation as Exclude<AnalysisOperation, 'dissolve'>,
+          ...(operation === 'buffer' ? { distance_meters: distanceValue } : {}),
+          ...(operation === 'clip' && mask ? { mask } : {}),
+          ...(operation === 'clip' && !mask && maskLayer?.dataset_id
+            ? { mask_dataset_id: maskLayer.dataset_id }
+            : {}),
+        },
+        controller.signal,
+      );
     },
     // fix(#793 review): the error path checks the sequence too — a
     // rejection from a request whose inputs were already abandoned must not
@@ -1155,7 +1185,7 @@ export function AnalysisPanel({
                 variant="outline"
                 size="sm"
                 onClick={startDrawing}
-                disabled={!mapInstanceRef?.current}
+                disabled={!mapInstance}
               >
                 {t('analysisTools.drawMask', { defaultValue: 'Draw clip area' })}
               </Button>

--- a/frontend/src/components/builder/AnalysisPanel.tsx
+++ b/frontend/src/components/builder/AnalysisPanel.tsx
@@ -757,6 +757,14 @@ export function AnalysisPanel({
     // rejection from a request whose inputs were already abandoned must not
     // raise "Analysis failed" over a newer, possibly successful preview.
     onError: (error: Error, { seq }) => {
+      // fix(#787 item 3): a preview this panel cancelled is not a failure to
+      // report. The seq guard alone does not cover the unmount abort, which
+      // aborts WITHOUT bumping the sequence, and the callback still fires
+      // (the rejection outlives the commit that unsubscribed the observer) —
+      // so closing the panel mid-preview raised "Analysis failed" over the
+      // builder. A timeout is not caught here: safeFetch turns TimeoutError
+      // into a normalized ApiError, and only a caller abort keeps this name.
+      if (error.name === 'AbortError') return;
       if (seq !== previewSeqRef.current) return;
       toast.error(
         error.message ||

--- a/frontend/src/components/builder/AnalysisPanel.tsx
+++ b/frontend/src/components/builder/AnalysisPanel.tsx
@@ -591,6 +591,12 @@ export function AnalysisPanel({
   ownsPreviewRef.current = previewSource === 'analysis-panel' || !!prefill;
   const handleInputsChanged = useCallback(() => {
     previewSeqRef.current += 1;
+    // fix(#787 item 3): the sequence bump only makes the response ineligible
+    // to be drawn. Abort here too, or the abandoned request keeps its sandbox
+    // query running to the request timeout — and because canRun gates on
+    // isPending, that also blocks the replacement preview the user is trying
+    // to run, so the abort at the head of the next mutation can never fire.
+    previewAbortRef.current?.abort();
     formEditedRef.current = true;
     if (ownsPreviewRef.current) onClearPreview?.();
     // fix(#764): a finished run's "Dataset created" + name must not survive

--- a/frontend/src/components/builder/AnalysisPanel.tsx
+++ b/frontend/src/components/builder/AnalysisPanel.tsx
@@ -574,6 +574,11 @@ export function AnalysisPanel({
   // fix(#787 item 3): closing the panel mid-preview suppressed the result
   // callbacks but left the request running. The controller for the preview in
   // flight, aborted on unmount and when a newer preview supersedes it.
+  // Scope: this cancels the CLIENT half. The preview endpoint does not watch
+  // Request.is_disconnected(), so the sandbox statement behind an abandoned
+  // request still runs to its own timeout, holding the per-user advisory lock
+  // until then. Server-side cancellation on disconnect is a backend change,
+  // not this batch's.
   const previewAbortRef = useRef<AbortController | null>(null);
   useEffect(() => () => previewAbortRef.current?.abort(), []);
   const jobIdRef = useRef(jobId);
@@ -592,10 +597,10 @@ export function AnalysisPanel({
   const handleInputsChanged = useCallback(() => {
     previewSeqRef.current += 1;
     // fix(#787 item 3): the sequence bump only makes the response ineligible
-    // to be drawn. Abort here too, or the abandoned request keeps its sandbox
-    // query running to the request timeout — and because canRun gates on
-    // isPending, that also blocks the replacement preview the user is trying
-    // to run, so the abort at the head of the next mutation can never fire.
+    // to be drawn; the mutation stays pending until the abandoned request
+    // settles. canRun gates on isPending, so without this abort the user
+    // cannot start the replacement preview they just changed the inputs for,
+    // and the abort at the head of the next mutation therefore never fires.
     previewAbortRef.current?.abort();
     formEditedRef.current = true;
     if (ownsPreviewRef.current) onClearPreview?.();
@@ -728,8 +733,9 @@ export function AnalysisPanel({
         throw new Error(
           t('analysisTools.noLayerSelected', { defaultValue: 'No layer selected' }),
         );
-      // The seq guard already drops a superseded response; aborting stops the
-      // abandoned request from finishing its sandbox query as well.
+      // Belt and braces: handleInputsChanged already aborted whatever this
+      // preview supersedes, but a caller that reaches here without one (a
+      // resubmit on unchanged inputs) must not leave the old fetch pending.
       previewAbortRef.current?.abort();
       const controller = new AbortController();
       previewAbortRef.current = controller;

--- a/frontend/src/components/builder/__tests__/AnalysisPanel.test.tsx
+++ b/frontend/src/components/builder/__tests__/AnalysisPanel.test.tsx
@@ -520,6 +520,35 @@ describe('AnalysisPanel', () => {
     expect(signal?.aborted).toBe(true);
   });
 
+  it('closing the panel mid-preview raises no error toast (#787 item 3)', async () => {
+    // The unmount abort rejects the fetch, but the rejection lands a microtask
+    // later — after React has finished the commit that unsubscribed TanStack's
+    // observer, which is what suppresses the option callbacks. Pinned because
+    // the alternative is an "Analysis failed" toast over a panel the user
+    // deliberately closed.
+    vi.mocked(previewAnalysis).mockImplementationOnce(
+      ((_id: string, _body: unknown, signal?: AbortSignal) =>
+        new Promise((_resolve, reject) => {
+          signal?.addEventListener('abort', () =>
+            reject(new DOMException('Aborted', 'AbortError')),
+          );
+        })) as never,
+    );
+    mockToast.error.mockClear();
+    const { unmount } = renderPanel([datasetLayer]);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Preview' }));
+    await waitFor(() => expect(previewAnalysis).toHaveBeenCalled());
+
+    unmount();
+    // Let the rejection and any queued callbacks run.
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(mockToast.error).not.toHaveBeenCalled();
+  });
+
   it('aborts a preview whose inputs changed under it (#787 item 3)', async () => {
     // The sequence guard only stops the response being drawn. Preview stays
     // disabled while the mutation is pending, so an un-aborted request also

--- a/frontend/src/components/builder/__tests__/AnalysisPanel.test.tsx
+++ b/frontend/src/components/builder/__tests__/AnalysisPanel.test.tsx
@@ -9,6 +9,7 @@ import { materializeAnalysis, previewAnalysis } from '@/api/analysis';
 import { useAnalysisFormStore } from '@/stores/analysis-form-store';
 import { useAnalysisAddedStore, useAnalysisJobStore } from '@/stores/analysis-job-store';
 import { useAuthStore } from '@/stores/auth-store';
+import type { Map as MaplibreMap } from 'maplibre-gl';
 import type { MapLayerResponse, UserResponse } from '@/types/api';
 
 // fix(#760): the rehydration tests need a controllable job status; the real
@@ -317,7 +318,7 @@ describe('AnalysisPanel', () => {
       expect(previewAnalysis).toHaveBeenCalledWith('ds1', {
         operation: 'buffer',
         distance_meters: 500,
-      });
+      }, expect.any(AbortSignal));
     });
     await waitFor(() => {
       expect(onPreviewResult).toHaveBeenCalledWith(
@@ -465,7 +466,7 @@ describe('AnalysisPanel', () => {
       expect(previewAnalysis).toHaveBeenCalledWith('ds1', {
         operation: 'clip',
         mask_dataset_id: 'ds2',
-      }),
+      }, expect.any(AbortSignal)),
     );
   });
 
@@ -500,6 +501,55 @@ describe('AnalysisPanel', () => {
     expect(drawButton).not.toHaveAttribute('id');
   });
 
+  it('aborts a preview still on the wire when the panel closes (#787 item 3)', async () => {
+    let signal: AbortSignal | undefined;
+    vi.mocked(previewAnalysis).mockImplementationOnce(
+      ((_id: string, _body: unknown, s?: AbortSignal) => {
+        signal = s;
+        // Never settles, so the request is still in flight at unmount.
+        return new Promise(() => {});
+      }) as never,
+    );
+    const { unmount } = renderPanel([datasetLayer]);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Preview' }));
+    await waitFor(() => expect(previewAnalysis).toHaveBeenCalled());
+    expect(signal?.aborted).toBe(false);
+
+    unmount();
+    expect(signal?.aborted).toBe(true);
+  });
+
+  it('picks up a map that arrives after mount (#787 item 10)', async () => {
+    // The panel mounts before the lazy map finishes loading, and the ref it
+    // is handed is filled in by assignment — which re-renders nothing. The
+    // button has to follow the instance the panel holds in state.
+    const user = userEvent.setup();
+    const mapRef = { current: null as MaplibreMap | null };
+    const qc = new QueryClient({
+      defaultOptions: { mutations: { retry: false } },
+    });
+    // A fresh element each time: rerendering the same reference hits React's
+    // same-element bailout and skips the subtree.
+    const renderTree = () => (
+      <QueryClientProvider client={qc}>
+        <AnalysisPanel layers={[datasetLayer]} mapInstanceRef={mapRef} />
+      </QueryClientProvider>
+    );
+    const view = render(renderTree());
+    await user.click(screen.getAllByRole('combobox')[1]);
+    await user.click(await screen.findByRole('option', { name: 'Clip' }));
+    expect(screen.getByRole('button', { name: 'Draw clip area' })).toBeDisabled();
+
+    mapRef.current = { on: vi.fn(), off: vi.fn() } as unknown as MaplibreMap;
+    view.rerender(renderTree());
+    await waitFor(() =>
+      expect(
+        screen.getByRole('button', { name: 'Draw clip area' }),
+      ).not.toBeDisabled(),
+    );
+  });
+
   it('converts the buffer distance from the selected unit to meters (#686)', async () => {
     const user = userEvent.setup();
     renderPanel([datasetLayer]);
@@ -519,7 +569,7 @@ describe('AnalysisPanel', () => {
       expect(previewAnalysis).toHaveBeenCalledWith('ds1', {
         operation: 'buffer',
         distance_meters: 2 * 1609.344,
-      }),
+      }, expect.any(AbortSignal)),
     );
   });
 
@@ -541,7 +591,7 @@ describe('AnalysisPanel', () => {
       expect(previewAnalysis).toHaveBeenCalledWith('ds1', {
         operation: 'buffer',
         distance_meters: 100,
-      }),
+      }, expect.any(AbortSignal)),
     );
 
     // And back — a clean round trip, no drift.
@@ -643,7 +693,7 @@ describe('AnalysisPanel — chat handoff prefill (#675)', () => {
       expect(previewAnalysis).toHaveBeenCalledWith('ds2', {
         operation: 'buffer',
         distance_meters: 750,
-      });
+      }, expect.any(AbortSignal));
     });
   });
 
@@ -657,7 +707,7 @@ describe('AnalysisPanel — chat handoff prefill (#675)', () => {
     await waitFor(() => {
       expect(previewAnalysis).toHaveBeenCalledWith('ds1', {
         operation: 'centroid',
-      });
+      }, expect.any(AbortSignal));
     });
   });
 
@@ -672,7 +722,7 @@ describe('AnalysisPanel — chat handoff prefill (#675)', () => {
       expect(previewAnalysis).toHaveBeenCalledWith('ds1', {
         operation: 'buffer',
         distance_meters: 250,
-      });
+      }, expect.any(AbortSignal));
     });
   });
 
@@ -1335,7 +1385,7 @@ describe('AnalysisPanel — stack-selected layer (#772)', () => {
       expect(previewAnalysis).toHaveBeenCalledWith('ds2', {
         operation: 'buffer',
         distance_meters: 500,
-      }),
+      }, expect.any(AbortSignal)),
     );
   });
 
@@ -1356,7 +1406,7 @@ describe('AnalysisPanel — stack-selected layer (#772)', () => {
       expect(previewAnalysis).toHaveBeenCalledWith('ds1', {
         operation: 'buffer',
         distance_meters: 750,
-      }),
+      }, expect.any(AbortSignal)),
     );
   });
 
@@ -1603,7 +1653,7 @@ describe('AnalysisPanel — audit remediation (v1.6.0)', () => {
       expect(previewAnalysis).toHaveBeenCalledWith('ds1', {
         operation: 'buffer',
         distance_meters: 500,
-      }),
+      }, expect.any(AbortSignal)),
     );
   });
 

--- a/frontend/src/components/builder/__tests__/AnalysisPanel.test.tsx
+++ b/frontend/src/components/builder/__tests__/AnalysisPanel.test.tsx
@@ -520,6 +520,28 @@ describe('AnalysisPanel', () => {
     expect(signal?.aborted).toBe(true);
   });
 
+  it('aborts a preview whose inputs changed under it (#787 item 3)', async () => {
+    // The sequence guard only stops the response being drawn. Preview stays
+    // disabled while the mutation is pending, so an un-aborted request also
+    // blocks the replacement the user is reaching for.
+    let signal: AbortSignal | undefined;
+    vi.mocked(previewAnalysis).mockImplementationOnce(
+      ((_id: string, _body: unknown, s?: AbortSignal) => {
+        signal = s;
+        return new Promise(() => {});
+      }) as never,
+    );
+    renderPanel([datasetLayer]);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Preview' }));
+    await waitFor(() => expect(previewAnalysis).toHaveBeenCalled());
+
+    fireEvent.change(screen.getByLabelText('Distance'), {
+      target: { value: '750' },
+    });
+    expect(signal?.aborted).toBe(true);
+  });
+
   it('picks up a map that arrives after mount (#787 item 10)', async () => {
     // The panel mounts before the lazy map finishes loading, and the ref it
     // is handed is filled in by assignment — which re-renders nothing. The


### PR DESCRIPTION
Two items from the #787 audit batch, carved out ahead of the analysis-operation wave so they land before `AnalysisPanel.tsx` starts collecting new operations.

**Item 3 — a closed panel's preview kept running.** TanStack suppresses observer callbacks after unmount, so the result was dropped, but the request itself ran to completion and held its sandbox query open. `previewAnalysis` now takes an optional `AbortSignal`; `apiFetch` already composes a caller signal with its own request timeout (`AbortSignal.any`), so this is threading rather than new cancellation machinery. The panel aborts on unmount, and also when a newer preview supersedes an in-flight one — the sequence guard already dropped that response, this stops the work as well.

**Item 10 — the clip Draw button read a ref during render.** `disabled={!mapInstanceRef?.current}` was evaluated in the render pass, and a ref assignment re-renders nothing, so the button could stay dead until an unrelated state change happened to commit. The instance now lives in state: seeded from the ref at mount (the common case, where the map loaded before the panel opened) and resynced from a no-dep-array effect, the same retry-every-commit idiom the mask-overlay effects above it use.

Refs #787 — closes items 3 and 10 only. Items 1, 5, 6 and 9 live in other files and stay open.

No API, schema, or security impact. No new translation keys.

## Verification

```
cd frontend
npm run lint          # clean
npm run typecheck     # clean
npm run test:coverage # 366 files, 4286 tests, all passing
```

Two new tests in `AnalysisPanel.test.tsx`: one asserts the signal handed to `previewAnalysis` is aborted by the unmount, the other that a map arriving after mount enables the Draw button. The ten existing `previewAnalysis` call assertions gained `expect.any(AbortSignal)` for the new third argument.