### PR TITLE
fix(sandbox): reject nested DML and thread timeout_ms through the wrapper

### DIFF
--- a/backend/app/platform/sandbox/__init__.py
+++ b/backend/app/platform/sandbox/__init__.py
@@ -15,7 +15,7 @@ import structlog
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.identity import Identity
-from app.platform.sandbox.executor import execute_safe
+from app.platform.sandbox.executor import DEFAULT_TIMEOUT_MS, execute_safe
 from app.platform.sandbox.schemas import SandboxError, SandboxResult
 from app.platform.sandbox.validator import (
     build_table_allowlist,
@@ -34,6 +34,7 @@ async def validate_and_execute(
     user: Identity | None,
     *,
     row_limit: int = 1000,
+    timeout_ms: int = DEFAULT_TIMEOUT_MS,
     restrict_tables: frozenset[str] | None = None,
 ) -> SandboxResult:
     """Validate and safely execute a SQL query.
@@ -49,6 +50,10 @@ async def validate_and_execute(
         db: Async database session.
         user: Current user (None for anonymous).
         row_limit: Maximum rows to return (default 1000).
+        timeout_ms: Statement timeout in milliseconds, applied as SET LOCAL
+            statement_timeout on the execution connection (default 10000).
+            Callers that need a tighter budget than the shared default — a
+            synchronous request path, say — pass a smaller value.
         restrict_tables: Optional surface-level scope: when set, the effective
             allowlist is the INTERSECTION of the user's RBAC allowlist with
             this set — it can only narrow access, never widen it. Used by
@@ -88,6 +93,7 @@ async def validate_and_execute(
             db,
             validated.sql,
             row_limit=row_limit,
+            timeout_ms=timeout_ms,
             concurrency_key=concurrency_key,
         )
 

--- a/backend/app/platform/sandbox/validator.py
+++ b/backend/app/platform/sandbox/validator.py
@@ -777,6 +777,37 @@ def _canonical_buffer_exempt_ids(stmt: exp.Expression) -> set[int]:
     return exempt
 
 
+# Statement types that write. `validate_sql` isinstance-checks only the ROOT
+# node, so before #1011 any of these nested inside a CTE or a scalar subquery
+# passed validation — `WITH x AS (INSERT ... RETURNING a) SELECT a FROM x` was
+# accepted, and only `SET TRANSACTION READ ONLY` in `execute_safe` stopped it
+# from running. Listed explicitly rather than by sqlglot base class: `exp.DDL`
+# and `exp.DML` do not partition the way the names suggest (Insert is both,
+# Drop and Alter are neither), so an explicit tuple is what stays fail-closed
+# across sqlglot upgrades.
+_MUTATING_STATEMENTS: tuple[type[exp.Expression], ...] = (
+    exp.Insert,
+    exp.Update,
+    exp.Delete,
+    exp.Merge,
+    exp.Copy,
+    exp.Create,
+    exp.Drop,
+    exp.Alter,
+    exp.Command,  # sqlglot's catch-all for statements it does not model
+)
+
+
+def _reject_nested_mutation(stmt: exp.Expression, sql: str) -> None:
+    """Reject write statements found anywhere in the tree, not just at the root."""
+    node = stmt.find(*_MUTATING_STATEMENTS)
+    if node is not None:
+        logger.info(
+            "sandbox.nested_mutation", sql=sql, statement_type=type(node).__name__
+        )
+        raise SandboxError("invalid_query", "Only SELECT queries are allowed")
+
+
 def _reject_recursive_cte(stmt: exp.Expression, sql: str) -> None:
     """Reject recursive CTEs, which are unbounded row generators."""
     if any(
@@ -880,6 +911,8 @@ def validate_sql(sql: str) -> ValidatedQuery:
     if stmt.find(exp.Into):
         logger.info("sandbox.select_into", sql=sql)
         raise SandboxError("invalid_query", "Only SELECT queries are allowed")
+
+    _reject_nested_mutation(stmt, sql)
 
     _reject_recursive_cte(stmt, sql)
 

--- a/backend/tests/test_sandbox.py
+++ b/backend/tests/test_sandbox.py
@@ -10,6 +10,7 @@ Covers:
 
 from __future__ import annotations
 
+import contextlib
 import logging
 import uuid
 
@@ -110,6 +111,62 @@ class TestRejectSelectInto:
         with pytest.raises(SandboxError) as exc_info:
             validate_sql("SELECT * INTO new_table FROM data.cities")
         assert exc_info.value.category == "invalid_query"
+
+
+class TestRejectNestedMutation:
+    """fix(#1011): the SELECT-only check inspects the root node, so a write
+    statement nested inside a CTE or a scalar subquery used to validate. Only
+    SET TRANSACTION READ ONLY in execute_safe stopped it from running, which
+    made a one-line change to how that transaction opens the difference
+    between defense-in-depth and arbitrary writes."""
+
+    @pytest.mark.parametrize(
+        "sql",
+        [
+            # The reported payload.
+            "WITH x AS (INSERT INTO data.foo (a) VALUES (1) RETURNING a) "
+            "SELECT a FROM x",
+            "WITH x AS (UPDATE data.foo SET a = 1 RETURNING a) SELECT a FROM x",
+            "WITH x AS (DELETE FROM data.foo RETURNING a) SELECT a FROM x",
+            "WITH x AS (MERGE INTO data.foo t USING data.bar s ON t.a = s.a "
+            "WHEN MATCHED THEN UPDATE SET a = s.a RETURNING t.a) SELECT a FROM x",
+            # DDL nests the same way, and the validator docstring already
+            # promises to reject CREATE and DROP.
+            "WITH x AS (CREATE TABLE data.evil AS SELECT 1) SELECT 1",
+            "WITH x AS (CREATE VIEW data.v AS SELECT 1) SELECT 1",
+            "WITH x AS (DROP TABLE data.foo) SELECT 1",
+            # Two levels deep: a CTE inside a CTE.
+            "WITH outer_cte AS ("
+            "WITH inner_cte AS (INSERT INTO data.foo (a) VALUES (1) RETURNING a) "
+            "SELECT a FROM inner_cte) SELECT a FROM outer_cte",
+            # Not a CTE at all: a scalar subquery in the WHERE clause.
+            "SELECT * FROM data.t WHERE id = ("
+            "WITH y AS (DELETE FROM data.u RETURNING id) SELECT id FROM y)",
+        ],
+    )
+    def test_rejects_nested_write(self, sql):
+        with pytest.raises(SandboxError) as exc_info:
+            validate_sql(sql)
+        # The sandbox's own refusal, not a database error.
+        assert exc_info.value.category == "invalid_query"
+        assert exc_info.value.user_message == "Only SELECT queries are allowed"
+
+    def test_allows_ordinary_read_only_cte(self):
+        """The guard must not cost the read-only CTEs the generator emits."""
+        result = validate_sql(
+            "WITH big AS (SELECT name, pop FROM data.cities WHERE pop > 500000) "
+            "SELECT COUNT(*) FROM big"
+        )
+        assert isinstance(result, ValidatedQuery)
+        assert result.cte_names == {"big"}
+
+    def test_allows_nested_read_only_ctes(self):
+        result = validate_sql(
+            "WITH outer_cte AS ("
+            "WITH inner_cte AS (SELECT a FROM data.foo) SELECT a FROM inner_cte"
+            ") SELECT a FROM outer_cte"
+        )
+        assert result.cte_names == {"outer_cte", "inner_cte"}
 
 
 class TestRejectMultiStatement:
@@ -471,6 +528,98 @@ class TestTimeoutHandling:
             timeout_ms=5000,
         )
         assert result.row_count == 1
+
+
+@contextlib.contextmanager
+def _record_statements():
+    """Capture every statement issued on the sandbox execution engine.
+
+    execute_safe takes its own connection from the engine pool rather than the
+    caller's session, so a session-level hook would see nothing.
+    """
+    import app.core.db as db_module
+    from sqlalchemy import event
+
+    statements: list[str] = []
+
+    def _on_execute(conn, cursor, statement, parameters, context, executemany):
+        statements.append(statement)
+
+    engine = db_module.engine.sync_engine
+    event.listen(engine, "before_cursor_execute", _on_execute)
+    try:
+        yield statements
+    finally:
+        event.remove(engine, "before_cursor_execute", _on_execute)
+
+
+def _stub_execute_safe(captured: dict[str, object]):
+    """Return an execute_safe stand-in that records the kwargs it was given."""
+
+    async def _fake(db, sql, **kwargs):
+        captured.update(kwargs)
+        captured["sql"] = sql
+        return SandboxResult(rows=[], columns=[], row_count=0, truncated=False)
+
+    return _fake
+
+
+async def _stub_allowlist(db, user):
+    return {"cities"}
+
+
+class TestTimeoutThreading:
+    """fix(#1011): execute_safe has always taken timeout_ms, but the public
+    wrapper did not expose it, so every caller silently got the 10 s default
+    and none could ask for less."""
+
+    async def test_explicit_timeout_reaches_statement_timeout(
+        self, client, test_db_session
+    ):
+        with _record_statements() as statements:
+            await execute_safe(test_db_session, "SELECT 1 AS ok", timeout_ms=250)
+        assert "SET LOCAL statement_timeout = '250'" in statements
+
+    async def test_default_timeout_reaches_statement_timeout(
+        self, client, test_db_session
+    ):
+        from app.platform.sandbox.executor import DEFAULT_TIMEOUT_MS
+
+        with _record_statements() as statements:
+            await execute_safe(test_db_session, "SELECT 1 AS ok")
+        assert f"SET LOCAL statement_timeout = '{DEFAULT_TIMEOUT_MS}'" in statements
+
+    async def test_wrapper_threads_explicit_timeout(self, monkeypatch):
+        """validate_and_execute must hand its timeout_ms to execute_safe."""
+        captured: dict[str, object] = {}
+        monkeypatch.setattr(
+            "app.platform.sandbox.execute_safe", _stub_execute_safe(captured)
+        )
+        monkeypatch.setattr(
+            "app.platform.sandbox.build_table_allowlist", _stub_allowlist
+        )
+
+        await validate_and_execute(
+            "SELECT name FROM data.cities", None, None, timeout_ms=1500
+        )
+        assert captured["timeout_ms"] == 1500
+
+    async def test_wrapper_defaults_to_executor_default(self, monkeypatch):
+        """Omitting timeout_ms must keep every existing caller byte-identical."""
+        from app.platform.sandbox.executor import DEFAULT_TIMEOUT_MS
+
+        captured: dict[str, object] = {}
+        monkeypatch.setattr(
+            "app.platform.sandbox.execute_safe", _stub_execute_safe(captured)
+        )
+        monkeypatch.setattr(
+            "app.platform.sandbox.build_table_allowlist", _stub_allowlist
+        )
+
+        await validate_and_execute("SELECT name FROM data.cities", None, None)
+        assert captured["timeout_ms"] == DEFAULT_TIMEOUT_MS
+        assert captured["row_limit"] == 1000
+        assert captured["concurrency_key"] == "anonymous"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Two mechanical gaps in the read-only SQL sandbox, both reproduced against
`9a788ba92`.

## 1. `validate_sql` accepted a writable CTE

`validate_sql` isinstance-checks only the **root** node against
`exp.Select/Union/Intersect/Except`. Nothing walked the tree, so a write
statement nested inside a CTE — or a scalar subquery — validated:

```python
>>> validate_sql("WITH x AS (INSERT INTO data.foo (a) VALUES (1) RETURNING a) SELECT a FROM x")
ValidatedQuery(tables={('data', 'foo'), ('', 'x')}, cte_names={'x'})   # accepted
```

The only thing stopping that statement from executing is `SET TRANSACTION READ
ONLY` in `execute_safe`. That control works, so this is defense-in-depth rather
than an open hole — but it is the *only* control, and any future path that runs
validated SQL outside that transaction turns a one-line regression into
arbitrary writes.

`_reject_nested_mutation` now walks the tree, mirroring the existing
`exp.Into` check.

**Two deliberate departures from the issue's list, both flagged rather than
assumed:**

- The set includes `exp.Create`, `exp.Drop` and `exp.Copy` alongside
  `Insert/Update/Delete/Merge/Command`. `WITH x AS (CREATE TABLE data.evil AS
  SELECT 1) SELECT 1`, `WITH x AS (CREATE VIEW ...) SELECT 1` and `WITH x AS
  (DROP TABLE data.foo) SELECT 1` all validate on `main` today — same defect,
  same nesting path — and the validator's own docstring already says it
  "Rejects: INSERT, UPDATE, DELETE, DROP, CREATE".
- The list is explicit rather than keyed on `exp.DDL` / `exp.DML`. Those base
  classes do not partition the way the names suggest in sqlglot 30.14:
  `Insert` is both, `Drop` and `Alter` are neither. An explicit tuple is what
  stays fail-closed across sqlglot upgrades.

`ALTER ... ` and `TRUNCATE` inside a CTE fail to parse, so they never reach the
walk; `exp.Alter` is listed anyway for the same fail-closed reason.

## 2. `timeout_ms` was not threaded through `validate_and_execute`

`execute_safe` has always accepted `timeout_ms` and applied it as `SET LOCAL
statement_timeout`, but the public wrapper exposed only `row_limit` and
`restrict_tables`, so every caller silently got the 10 s default and none could
ask for less. Added as a keyword-only parameter defaulting to
`DEFAULT_TIMEOUT_MS` and passed through.

No production caller passes it, so existing behaviour is byte-identical. #565
needs it: a synchronous raw-SQL endpoint wants a tighter budget than 10 s.

## Security impact

Tightening only. No new function, table or statement form is admitted; the
read-only CTEs the SQL generator emits are covered by passing cases, including
a CTE nested inside a CTE.

## Verification

```
cd backend && uv run pytest tests/test_sandbox.py tests/test_sandbox_tenant_schema.py \
  tests/test_sec025_sandbox_allowlist.py tests/test_sql_engine.py tests/test_ai_chat.py \
  tests/test_ai_chat_dataset.py tests/test_ai_chat_actions_phase1135.py \
  tests/test_chat_narrative.py -q -n 4
# 256 passed
cd backend && uv run ruff check . && uv run ruff format --check .
```

No schema change, no OpenAPI change, no SDK regeneration.

Closes #1011
