### PR TITLE
docs: correct five comments that described something the code does not do

### DIFF
--- a/backend/app/processing/ingest/tasks_common.py
+++ b/backend/app/processing/ingest/tasks_common.py
@@ -824,8 +824,19 @@ async def _ingest_vector_into_staging(
 ) -> StagingResult:
     """Load a vector source into staging and return extracted staging metadata.
 
-    This helper preserves the staging-pipeline unit-test boundary while the
-    production ingest path continues to inline the broader job lifecycle.
+    TEST-ONLY (#1018). Nothing in ``app/`` calls this. Every caller is a test:
+    ``tests/test_staging_pipeline.py`` and
+    ``tests/test_staging_pipeline_integration.py``. It exists to give those
+    tests a callable seam over the staging half of ingest, which production
+    inlines inside its own job lifecycle rather than factoring out.
+
+    So it is a PARALLEL COPY, not the live path, and it can drift. The two
+    production sequences it mirrors are ``tasks_vector.py`` (run_ogr2ogr ->
+    rename_reserved_columns -> DBF-truncation check -> geometry override ->
+    _run_staging_pipeline, :459-560) and ``tasks_reupload.py`` (:261-340).
+    A change to either has to visit here, or these tests start asserting
+    against a shape production no longer has.
+
     It intentionally performs no commits.
     """
     from app.processing.ingest.metadata import rename_reserved_columns

--- a/backend/app/processing/ingest/tasks_common.py
+++ b/backend/app/processing/ingest/tasks_common.py
@@ -836,31 +836,35 @@ async def _ingest_vector_into_staging(
     tests a callable seam over vector ingest's pre-staging half, which
     production runs inline inside its own job lifecycle.
 
-    What it mirrors, and what it shares (fix(#1018 review)):
+    What it mirrors, and what it shares (fix(#1018 review)). Deliberately no
+    line numbers: this docstring's own growth moved them twice while it was
+    being written, so it names FUNCTIONS, which do not drift.
 
-    - The pre-staging steps here — run_ogr2ogr, rename_reserved_columns, the
-      DBF-truncation check, the ``user_wants_geom`` override — are a PARALLEL
-      COPY of ``tasks_vector.py`` (:459-560) and ``tasks_reupload.py``
-      (:261-340). Those can drift from this, and only the tests would notice.
-    - The staging steps are the real ``_run_staging_pipeline`` (:650), so this
-      helper does not fork them — but almost nothing else calls it either.
-      Where the sequence is written out, and how much of it:
+    - Pre-staging. ``run_ogr2ogr``, ``rename_reserved_columns``, the
+      DBF-truncation check, then ``_detect_and_override_geometry`` under
+      ``user_wants_geom``. ``tasks_vector.ingest_file`` runs the same four —
+      it is the only production path with the override, so this helper's
+      ``user_wants_geom`` branch has exactly one counterpart.
+      ``tasks_reupload.reupload_file`` runs the first three and passes its
+      detected geometry type straight to ``run_ogr2ogr`` instead
+      (fix(#1018 review): an earlier draft claimed all four).
+    - Staging. This helper calls the real ``_run_staging_pipeline``, so it does
+      not fork those steps — but little else calls it either. The sequence
+      exists in three independent places:
 
-        1. ``_run_staging_pipeline`` (:650) — the full eight steps
+        1. ``_run_staging_pipeline`` — the full eight steps
            (ensure_geom_column, clip_to_mercator_bounds, add_4326_column,
            grant_reader_access, extract_metadata, detect_3d_metadata,
            promote_z_to_elev, get_sample_values). Reached in production only by
-           ``reupload_file`` (``tasks_reupload.py:337``), and by this helper.
-        2. ``_finalize_ingest`` (:1069, block at :1114-1177) — the same eight,
-           inlined. New vector ingest, via ``tasks_vector.py:572``.
-        3. ``reupload_service`` (``tasks_reupload.py:463``, block at :670-690)
-           — a SHORTER copy: ensure_geom_column, clip, add_4326_column,
-           grant_reader_access, extract_metadata, get_sample_values. No 3D
-           detection and no elevation promotion, so do not "fix" it by
-           symmetry with the other two; find out why first (fix(#1018 review)).
+           ``tasks_reupload.reupload_file``, and by this helper.
+        2. ``_finalize_ingest`` in this module — the same eight, inlined. New
+           vector ingest, via ``tasks_vector.ingest_file``.
+        3. ``tasks_reupload.reupload_service`` — a SHORTER copy: no 3D
+           detection and no elevation promotion. Do not "fix" that by symmetry
+           with the other two; find out why first.
 
-      A change to the shared six therefore has three independent sites, and
-      the tests here cover the one production reaches least.
+      So a change to the shared six has three sites, and the tests here cover
+      the one production reaches least.
 
     It intentionally performs no commits.
     """

--- a/backend/app/processing/ingest/tasks_common.py
+++ b/backend/app/processing/ingest/tasks_common.py
@@ -843,11 +843,21 @@ async def _ingest_vector_into_staging(
       COPY of ``tasks_vector.py`` (:459-560) and ``tasks_reupload.py``
       (:261-340). Those can drift from this, and only the tests would notice.
     - The staging steps are the real ``_run_staging_pipeline`` (:650), so this
-      helper does not fork them. But production reaches that function only on
-      the re-upload path (``tasks_reupload.py:337``): NEW vector ingest reruns
-      the same eight steps inline in ``_finalize_ingest`` (:1069, the block at
-      :1114-1177). A change to the staging sequence therefore has three sites,
-      not two, and this helper covers the one production does not use.
+      helper does not fork them — but almost nothing else calls it either. The
+      staging sequence (ensure_geom_column, clip_to_mercator_bounds,
+      add_4326_column, grant_reader_access, extract_metadata, detect_3d,
+      promote_z_to_elev, get_sample_values) is written out FOUR times:
+
+        1. ``_run_staging_pipeline`` (:650) — reached in production only by
+           ``reupload_file`` (``tasks_reupload.py:337``), and by this helper.
+        2. ``_finalize_ingest`` (:1069, block at :1114-1177) — new vector
+           ingest, via ``tasks_vector.py:572``.
+        3. ``reupload_service`` (``tasks_reupload.py:463``, block at :670-690)
+           — service re-uploads, inlined again.
+        4. this helper, through (1).
+
+      So a change to the sequence has to visit three independent copies, and
+      the tests here only cover the one production reaches least.
 
     It intentionally performs no commits.
     """

--- a/backend/app/processing/ingest/tasks_common.py
+++ b/backend/app/processing/ingest/tasks_common.py
@@ -843,21 +843,24 @@ async def _ingest_vector_into_staging(
       COPY of ``tasks_vector.py`` (:459-560) and ``tasks_reupload.py``
       (:261-340). Those can drift from this, and only the tests would notice.
     - The staging steps are the real ``_run_staging_pipeline`` (:650), so this
-      helper does not fork them — but almost nothing else calls it either. The
-      staging sequence (ensure_geom_column, clip_to_mercator_bounds,
-      add_4326_column, grant_reader_access, extract_metadata, detect_3d,
-      promote_z_to_elev, get_sample_values) is written out FOUR times:
+      helper does not fork them — but almost nothing else calls it either.
+      Where the sequence is written out, and how much of it:
 
-        1. ``_run_staging_pipeline`` (:650) — reached in production only by
+        1. ``_run_staging_pipeline`` (:650) — the full eight steps
+           (ensure_geom_column, clip_to_mercator_bounds, add_4326_column,
+           grant_reader_access, extract_metadata, detect_3d_metadata,
+           promote_z_to_elev, get_sample_values). Reached in production only by
            ``reupload_file`` (``tasks_reupload.py:337``), and by this helper.
-        2. ``_finalize_ingest`` (:1069, block at :1114-1177) — new vector
-           ingest, via ``tasks_vector.py:572``.
+        2. ``_finalize_ingest`` (:1069, block at :1114-1177) — the same eight,
+           inlined. New vector ingest, via ``tasks_vector.py:572``.
         3. ``reupload_service`` (``tasks_reupload.py:463``, block at :670-690)
-           — service re-uploads, inlined again.
-        4. this helper, through (1).
+           — a SHORTER copy: ensure_geom_column, clip, add_4326_column,
+           grant_reader_access, extract_metadata, get_sample_values. No 3D
+           detection and no elevation promotion, so do not "fix" it by
+           symmetry with the other two; find out why first (fix(#1018 review)).
 
-      So a change to the sequence has to visit three independent copies, and
-      the tests here only cover the one production reaches least.
+      A change to the shared six therefore has three independent sites, and
+      the tests here cover the one production reaches least.
 
     It intentionally performs no commits.
     """

--- a/backend/app/processing/ingest/tasks_common.py
+++ b/backend/app/processing/ingest/tasks_common.py
@@ -656,8 +656,14 @@ async def _run_staging_pipeline(
 ) -> StagingResult:
     """Run the post-ogr2ogr staging pipeline on a table.
 
-    Shared by ``_ingest_vector_into_staging`` (new ingests) and
-    ``reupload_file`` (re-uploads). Performs: ensure_geom_column,
+    fix(#1018 review): the only production caller is ``reupload_file``
+    (``tasks_reupload.py:337``). ``_ingest_vector_into_staging`` also calls it
+    but is test-only, and NEW vector ingest does not: ``_finalize_ingest``
+    (:1069) reruns these same steps inline at :1114-1177. This docstring used
+    to read "shared by _ingest_vector_into_staging (new ingests)", which named
+    the wrong path for the wrong reason.
+
+    Performs: ensure_geom_column,
     clip_to_mercator_bounds, add_4326_column, grant_reader_access,
     extract_metadata, detect_3d_metadata, promote_z_to_elev, and
     get_sample_values. Does not commit.
@@ -827,15 +833,21 @@ async def _ingest_vector_into_staging(
     TEST-ONLY (#1018). Nothing in ``app/`` calls this. Every caller is a test:
     ``tests/test_staging_pipeline.py`` and
     ``tests/test_staging_pipeline_integration.py``. It exists to give those
-    tests a callable seam over the staging half of ingest, which production
-    inlines inside its own job lifecycle rather than factoring out.
+    tests a callable seam over vector ingest's pre-staging half, which
+    production runs inline inside its own job lifecycle.
 
-    So it is a PARALLEL COPY, not the live path, and it can drift. The two
-    production sequences it mirrors are ``tasks_vector.py`` (run_ogr2ogr ->
-    rename_reserved_columns -> DBF-truncation check -> geometry override ->
-    _run_staging_pipeline, :459-560) and ``tasks_reupload.py`` (:261-340).
-    A change to either has to visit here, or these tests start asserting
-    against a shape production no longer has.
+    What it mirrors, and what it shares (fix(#1018 review)):
+
+    - The pre-staging steps here — run_ogr2ogr, rename_reserved_columns, the
+      DBF-truncation check, the ``user_wants_geom`` override — are a PARALLEL
+      COPY of ``tasks_vector.py`` (:459-560) and ``tasks_reupload.py``
+      (:261-340). Those can drift from this, and only the tests would notice.
+    - The staging steps are the real ``_run_staging_pipeline`` (:650), so this
+      helper does not fork them. But production reaches that function only on
+      the re-upload path (``tasks_reupload.py:337``): NEW vector ingest reruns
+      the same eight steps inline in ``_finalize_ingest`` (:1069, the block at
+      :1114-1177). A change to the staging sequence therefore has three sites,
+      not two, and this helper covers the one production does not use.
 
     It intentionally performs no commits.
     """

--- a/backend/tests/test_export.py
+++ b/backend/tests/test_export.py
@@ -299,7 +299,13 @@ class TestExportValidation:
     async def test_export_invalid_bbox_bounds(
         self, client: AsyncClient, admin_auth_header: dict, test_db_session
     ):
-        """Request with bbox=10,10,5,5 (minx > maxx) returns 400."""
+        """Request with bbox=10,10,5,5 (miny >= maxy) returns 400.
+
+        The rejected pair is the LATITUDE one. ``parse_bbox``
+        (app/modules/catalog/features/service.py) deliberately allows
+        minx > maxx, which is how an antimeridian-crossing bbox is spelled
+        (170,-45,-170,-30); only ``values[1] >= values[3]`` raises.
+        """
         admin_id = await get_user_id(test_db_session, "admin")
         ds = await _create_dataset(
             test_db_session, created_by=admin_id, name="BboxBoundsDS"

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -1059,7 +1059,13 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # `_append_mercator_clip_warning` emitter that keeps the three ingest call
     # sites a single statement each (`reupload_file` is already at the C901
     # complexity ceiling, so the branch cannot live inline). Ratchet stays exact.
-    "backend/app/processing/ingest/tasks_common.py": 1631,
+    # fix(#1018): +11 — `_ingest_vector_into_staging` has no caller in `app/`;
+    # every call site is a test. The added lines say so at the definition and
+    # name the two production sequences it is a parallel copy of
+    # (tasks_vector.py, tasks_reupload.py), because silent drift from those is
+    # what makes a test-only mirror dangerous rather than merely unused.
+    # Ratchet stays exact.
+    "backend/app/processing/ingest/tasks_common.py": 1642,
     # Tenant-owned media now crosses the shared logical-to-physical storage
     # seam; explicit storage-failure responses keep the runtime/OpenAPI contract
     # aligned. Keep the ratchet exact after the import/decorator expansion.

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -1059,7 +1059,7 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # `_append_mercator_clip_warning` emitter that keeps the three ingest call
     # sites a single statement each (`reupload_file` is already at the C901
     # complexity ceiling, so the branch cannot live inline). Ratchet stays exact.
-    # fix(#1018): +33 — `_ingest_vector_into_staging` has no caller in `app/`;
+    # fix(#1018): +36 — `_ingest_vector_into_staging` has no caller in `app/`;
     # every call site is a test. The added lines say so at the definition and
     # map what it mirrors, because silent drift is what makes a test-only copy
     # dangerous rather than merely unused. fix(#1018 review) corrected that
@@ -1070,7 +1070,7 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # correction fixes `_run_staging_pipeline`'s own docstring, which claimed
     # `_ingest_vector_into_staging` was the "new ingests" caller.
     # Ratchet stays exact.
-    "backend/app/processing/ingest/tasks_common.py": 1664,
+    "backend/app/processing/ingest/tasks_common.py": 1667,
     # Tenant-owned media now crosses the shared logical-to-physical storage
     # seam; explicit storage-failure responses keep the runtime/OpenAPI contract
     # aligned. Keep the ratchet exact after the import/decorator expansion.

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -1059,13 +1059,18 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # `_append_mercator_clip_warning` emitter that keeps the three ingest call
     # sites a single statement each (`reupload_file` is already at the C901
     # complexity ceiling, so the branch cannot live inline). Ratchet stays exact.
-    # fix(#1018): +11 — `_ingest_vector_into_staging` has no caller in `app/`;
+    # fix(#1018): +23 — `_ingest_vector_into_staging` has no caller in `app/`;
     # every call site is a test. The added lines say so at the definition and
-    # name the two production sequences it is a parallel copy of
-    # (tasks_vector.py, tasks_reupload.py), because silent drift from those is
-    # what makes a test-only mirror dangerous rather than merely unused.
+    # map what it mirrors, because silent drift is what makes a test-only copy
+    # dangerous rather than merely unused. fix(#1018 review) corrected that
+    # map and cost most of the lines: the staging steps are NOT forked here,
+    # they are the real `_run_staging_pipeline` — but production reaches that
+    # only on re-upload, while new vector ingest reruns the same eight steps
+    # inline in `_finalize_ingest`, so the sequence has three sites. The same
+    # correction fixes `_run_staging_pipeline`'s own docstring, which claimed
+    # `_ingest_vector_into_staging` was the "new ingests" caller.
     # Ratchet stays exact.
-    "backend/app/processing/ingest/tasks_common.py": 1642,
+    "backend/app/processing/ingest/tasks_common.py": 1654,
     # Tenant-owned media now crosses the shared logical-to-physical storage
     # seam; explicit storage-failure responses keep the runtime/OpenAPI contract
     # aligned. Keep the ratchet exact after the import/decorator expansion.

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -1059,7 +1059,7 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # `_append_mercator_clip_warning` emitter that keeps the three ingest call
     # sites a single statement each (`reupload_file` is already at the C901
     # complexity ceiling, so the branch cannot live inline). Ratchet stays exact.
-    # fix(#1018): +23 — `_ingest_vector_into_staging` has no caller in `app/`;
+    # fix(#1018): +33 — `_ingest_vector_into_staging` has no caller in `app/`;
     # every call site is a test. The added lines say so at the definition and
     # map what it mirrors, because silent drift is what makes a test-only copy
     # dangerous rather than merely unused. fix(#1018 review) corrected that
@@ -1070,7 +1070,7 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # correction fixes `_run_staging_pipeline`'s own docstring, which claimed
     # `_ingest_vector_into_staging` was the "new ingests" caller.
     # Ratchet stays exact.
-    "backend/app/processing/ingest/tasks_common.py": 1654,
+    "backend/app/processing/ingest/tasks_common.py": 1664,
     # Tenant-owned media now crosses the shared logical-to-physical storage
     # seam; explicit storage-failure responses keep the runtime/OpenAPI contract
     # aligned. Keep the ratchet exact after the import/decorator expansion.

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -1059,7 +1059,7 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # `_append_mercator_clip_warning` emitter that keeps the three ingest call
     # sites a single statement each (`reupload_file` is already at the C901
     # complexity ceiling, so the branch cannot live inline). Ratchet stays exact.
-    # fix(#1018): +36 — `_ingest_vector_into_staging` has no caller in `app/`;
+    # fix(#1018): +40 — `_ingest_vector_into_staging` has no caller in `app/`;
     # every call site is a test. The added lines say so at the definition and
     # map what it mirrors, because silent drift is what makes a test-only copy
     # dangerous rather than merely unused. fix(#1018 review) corrected that
@@ -1070,7 +1070,7 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # correction fixes `_run_staging_pipeline`'s own docstring, which claimed
     # `_ingest_vector_into_staging` was the "new ingests" caller.
     # Ratchet stays exact.
-    "backend/app/processing/ingest/tasks_common.py": 1667,
+    "backend/app/processing/ingest/tasks_common.py": 1671,
     # Tenant-owned media now crosses the shared logical-to-physical storage
     # seam; explicit storage-failure responses keep the runtime/OpenAPI contract
     # aligned. Keep the ratchet exact after the import/decorator expansion.

--- a/e2e/collections.spec.ts
+++ b/e2e/collections.spec.ts
@@ -113,17 +113,22 @@ test.describe.serial('Collections', () => {
     //
     // A single lookup here would usually still see 'running', since the reason
     // we are in this branch is that the job outlived its polling window. Wait
-    // for the id, bounded: 30 more attempts at 2s is a full minute past the
-    // 45-second budget the test itself allows, which is generous for a
-    // one-point GeoJSON. If it has not landed by then the worker is wedged and
-    // the leak is the smaller of the problems — teardown must not hang.
-    const CLEANUP_ATTEMPTS = 30;
-    for (let attempt = 0; !createdDatasetId && createdJobId && attempt < CLEANUP_ATTEMPTS; attempt++) {
-      // fix(#1018 review): sleep BEFORE the request, never after the last one.
-      // Sleeping at the end of the body re-created the very race this loop
-      // exists to close — the job could land during the final delay and the
-      // loop would exit without looking again.
-      if (attempt > 0) await new Promise((resolve) => setTimeout(resolve, 2_000));
+    // for the id — but the budget is set by Playwright, not by patience.
+    // fix(#1018 review): `timeout: 60_000` in playwright.config.ts applies to
+    // this hook on its own, so a 30x2s loop would burn 58 seconds in sleeps
+    // and the hook could time out BEFORE the bulk-delete it exists to send.
+    // Bound by wall clock at 20s, leaving the rest of the hook's minute for
+    // the requests and for CI latency. If the job has not landed by then the
+    // worker is wedged and the leak is the smaller problem.
+    const CLEANUP_DEADLINE = Date.now() + 20_000;
+    for (let attempt = 0; !createdDatasetId && createdJobId; attempt++) {
+      // Sleep BEFORE the request, never after the last one: sleeping at the
+      // end of the body re-created the very race this loop closes, since the
+      // job could land during the final delay and never be looked at again.
+      if (attempt > 0) {
+        if (Date.now() >= CLEANUP_DEADLINE) break;
+        await new Promise((resolve) => setTimeout(resolve, 2_000));
+      }
       const res = await fetch(`${BASE_URL}/api/jobs/${createdJobId}`, {
         headers: { Authorization: `Bearer ${token}` },
       });

--- a/e2e/collections.spec.ts
+++ b/e2e/collections.spec.ts
@@ -8,6 +8,7 @@ const BASE_URL = process.env.E2E_BASE_URL ?? 'http://localhost:8080';
 let createdCollectionId: string | null = null;
 let createdDatasetId: string | null = null;
 let createdDatasetTitle: string | null = null;
+let createdJobId: string | null = null;
 
 interface JobStatusPayload {
   status: string;
@@ -29,14 +30,6 @@ async function waitForDatasetJob(jobId: string, authHeaders: Record<string, stri
     const statusRes = await fetch(`${BASE_URL}/api/jobs/${jobId}`, { headers: authHeaders });
     expect(statusRes.ok).toBe(true);
     const status = await statusRes.json() as JobStatusPayload;
-    // fix(#1018): claim the cleanup handle the moment the row exists, not once
-    // the job also reports complete. Everything below this line can throw — a
-    // failed import, a 45-attempt timeout, the ok() assertion on the next poll
-    // — and until this assignment lands afterAll sees a null id and deletes
-    // nothing, so each failed retry leaks one dataset. Same fix as #895 in
-    // analysis.spec.ts, where the catalog count climbed 3 → 4 → 5 across three
-    // retries.
-    if (status.dataset_id) createdDatasetId = status.dataset_id;
     if (status.status === 'complete' && status.dataset_id) return status.dataset_id;
     if (status.status === 'failed') {
       throw new Error(`Collection fixture import failed: ${status.error_message ?? 'unknown error'}`);
@@ -50,9 +43,9 @@ async function createCollectionDataset(): Promise<{ datasetId: string; title: st
   const token = getAuthToken();
   const authHeaders = { Authorization: `Bearer ${token}` };
   const title = `E2E Collection Dataset ${Date.now()}`;
-  // The other half of the cleanup handle, registered before the upload can
-  // create anything: afterAll needs BOTH the id and the confirm title, so
-  // claiming the id early only helps if the title is already there.
+  // fix(#1018): register the confirm title before the upload can create
+  // anything. afterAll needs BOTH halves of the handle, so resolving the id
+  // later is no use if the title was never recorded.
   createdDatasetTitle = title;
   const filename = `${title.toLowerCase().replace(/[^a-z0-9]+/g, '-')}.geojson`;
   const geojson = JSON.stringify({
@@ -94,17 +87,41 @@ async function createCollectionDataset(): Promise<{ datasetId: string; title: st
       layer_name: preview.layer_name,
     }),
   });
+  // fix(#1018): the job id is the only handle that exists between the commit
+  // and the dataset appearing. Record it so teardown can resolve the dataset
+  // even when the poll below gives up first.
+  createdJobId = upload.job_id;
   expect(commitRes.ok).toBe(true);
 
   const datasetId = await waitForDatasetJob(upload.job_id, authHeaders);
+  createdDatasetId = datasetId;
   return { datasetId, title };
 }
 
 test.describe.serial('Collections', () => {
   test.afterAll(async () => {
+    const token = getAuthToken();
+
+    // fix(#1018 review): the backend sets dataset_id in the same atomic update
+    // that flips the job to 'complete' (_finalize_ingest), so there is no
+    // earlier moment to claim the id. If the 45-second poll gives up one
+    // second before the ingest lands — or anything after it throws — the
+    // dataset exists and nothing here knows its id, and each failed retry
+    // leaks a row (analysis.spec.ts had the same shape in #895; its catalog
+    // count climbed 3 → 4 → 5 across three retries). One last lookup closes
+    // that window.
+    if (!createdDatasetId && createdJobId) {
+      const res = await fetch(`${BASE_URL}/api/jobs/${createdJobId}`, {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      if (res.ok) {
+        const status = await res.json() as JobStatusPayload;
+        if (status.dataset_id) createdDatasetId = status.dataset_id;
+      }
+    }
+
     if (!createdDatasetId || !createdDatasetTitle) return;
 
-    const token = getAuthToken();
     await fetch(`${BASE_URL}/api/datasets/bulk-delete/`, {
       method: 'POST',
       headers: {

--- a/e2e/collections.spec.ts
+++ b/e2e/collections.spec.ts
@@ -29,6 +29,14 @@ async function waitForDatasetJob(jobId: string, authHeaders: Record<string, stri
     const statusRes = await fetch(`${BASE_URL}/api/jobs/${jobId}`, { headers: authHeaders });
     expect(statusRes.ok).toBe(true);
     const status = await statusRes.json() as JobStatusPayload;
+    // fix(#1018): claim the cleanup handle the moment the row exists, not once
+    // the job also reports complete. Everything below this line can throw — a
+    // failed import, a 45-attempt timeout, the ok() assertion on the next poll
+    // — and until this assignment lands afterAll sees a null id and deletes
+    // nothing, so each failed retry leaks one dataset. Same fix as #895 in
+    // analysis.spec.ts, where the catalog count climbed 3 → 4 → 5 across three
+    // retries.
+    if (status.dataset_id) createdDatasetId = status.dataset_id;
     if (status.status === 'complete' && status.dataset_id) return status.dataset_id;
     if (status.status === 'failed') {
       throw new Error(`Collection fixture import failed: ${status.error_message ?? 'unknown error'}`);
@@ -42,6 +50,10 @@ async function createCollectionDataset(): Promise<{ datasetId: string; title: st
   const token = getAuthToken();
   const authHeaders = { Authorization: `Bearer ${token}` };
   const title = `E2E Collection Dataset ${Date.now()}`;
+  // The other half of the cleanup handle, registered before the upload can
+  // create anything: afterAll needs BOTH the id and the confirm title, so
+  // claiming the id early only helps if the title is already there.
+  createdDatasetTitle = title;
   const filename = `${title.toLowerCase().replace(/[^a-z0-9]+/g, '-')}.geojson`;
   const geojson = JSON.stringify({
     type: 'FeatureCollection',
@@ -188,9 +200,10 @@ test.describe.serial('Collections', () => {
       page.getByRole('heading', { name: 'Add Datasets' }),
     ).toBeVisible();
 
+    // createdDatasetId / createdDatasetTitle are registered inside the helper,
+    // as early as each value exists, so afterAll can clean up a run that dies
+    // before this line (fix(#1018)).
     const dataset = await createCollectionDataset();
-    createdDatasetId = dataset.datasetId;
-    createdDatasetTitle = dataset.title;
 
     await page.getByPlaceholder('Search datasets by name...').fill(dataset.title);
     await page.getByRole('button', { name: 'Search' }).click();

--- a/e2e/collections.spec.ts
+++ b/e2e/collections.spec.ts
@@ -108,16 +108,28 @@ test.describe.serial('Collections', () => {
     // second before the ingest lands — or anything after it throws — the
     // dataset exists and nothing here knows its id, and each failed retry
     // leaks a row (analysis.spec.ts had the same shape in #895; its catalog
-    // count climbed 3 → 4 → 5 across three retries). One last lookup closes
-    // that window.
-    if (!createdDatasetId && createdJobId) {
+    // count climbed 3 → 4 → 5 across three retries).
+    //
+    // A single lookup here would usually still see 'running', since the reason
+    // we are in this branch is that the job outlived its polling window. Wait
+    // for the id, bounded: 30 more attempts at 2s is a full minute past the
+    // 45-second budget the test itself allows, which is generous for a
+    // one-point GeoJSON. If it has not landed by then the worker is wedged and
+    // the leak is the smaller of the problems — teardown must not hang.
+    for (let attempt = 0; !createdDatasetId && createdJobId && attempt < 30; attempt++) {
       const res = await fetch(`${BASE_URL}/api/jobs/${createdJobId}`, {
         headers: { Authorization: `Bearer ${token}` },
       });
       if (res.ok) {
         const status = await res.json() as JobStatusPayload;
-        if (status.dataset_id) createdDatasetId = status.dataset_id;
+        if (status.dataset_id) {
+          createdDatasetId = status.dataset_id;
+          break;
+        }
+        // A failed ingest produces no dataset, so there is nothing to clean up.
+        if (status.status === 'failed') break;
       }
+      await new Promise((resolve) => setTimeout(resolve, 2_000));
     }
 
     if (!createdDatasetId || !createdDatasetTitle) return;

--- a/e2e/collections.spec.ts
+++ b/e2e/collections.spec.ts
@@ -77,6 +77,11 @@ async function createCollectionDataset(): Promise<{ datasetId: string; title: st
   const preview = await previewRes.json() as { layer_name?: string; geometry_type?: string | null };
   expect(preview.geometry_type).toBeTruthy();
 
+  // fix(#1018 review): before the commit is sent, not after. If the request
+  // reaches the API but its response is lost, `await fetch` rejects while the
+  // backend has already queued the ingest — and a handle recorded after that
+  // line would never exist for the dataset that then appears.
+  createdJobId = upload.job_id;
   const commitRes = await fetch(`${BASE_URL}/api/ingest/commit/${upload.job_id}`, {
     method: 'POST',
     headers: { ...authHeaders, 'Content-Type': 'application/json' },
@@ -87,10 +92,6 @@ async function createCollectionDataset(): Promise<{ datasetId: string; title: st
       layer_name: preview.layer_name,
     }),
   });
-  // fix(#1018): the job id is the only handle that exists between the commit
-  // and the dataset appearing. Record it so teardown can resolve the dataset
-  // even when the poll below gives up first.
-  createdJobId = upload.job_id;
   expect(commitRes.ok).toBe(true);
 
   const datasetId = await waitForDatasetJob(upload.job_id, authHeaders);
@@ -116,20 +117,24 @@ test.describe.serial('Collections', () => {
     // 45-second budget the test itself allows, which is generous for a
     // one-point GeoJSON. If it has not landed by then the worker is wedged and
     // the leak is the smaller of the problems — teardown must not hang.
-    for (let attempt = 0; !createdDatasetId && createdJobId && attempt < 30; attempt++) {
+    const CLEANUP_ATTEMPTS = 30;
+    for (let attempt = 0; !createdDatasetId && createdJobId && attempt < CLEANUP_ATTEMPTS; attempt++) {
+      // fix(#1018 review): sleep BEFORE the request, never after the last one.
+      // Sleeping at the end of the body re-created the very race this loop
+      // exists to close — the job could land during the final delay and the
+      // loop would exit without looking again.
+      if (attempt > 0) await new Promise((resolve) => setTimeout(resolve, 2_000));
       const res = await fetch(`${BASE_URL}/api/jobs/${createdJobId}`, {
         headers: { Authorization: `Bearer ${token}` },
       });
-      if (res.ok) {
-        const status = await res.json() as JobStatusPayload;
-        if (status.dataset_id) {
-          createdDatasetId = status.dataset_id;
-          break;
-        }
-        // A failed ingest produces no dataset, so there is nothing to clean up.
-        if (status.status === 'failed') break;
+      if (!res.ok) continue;
+      const status = await res.json() as JobStatusPayload;
+      if (status.dataset_id) {
+        createdDatasetId = status.dataset_id;
+        break;
       }
-      await new Promise((resolve) => setTimeout(resolve, 2_000));
+      // A failed ingest produces no dataset, so there is nothing to clean up.
+      if (status.status === 'failed') break;
     }
 
     if (!createdDatasetId || !createdDatasetTitle) return;

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -61,12 +61,14 @@ function RootLayout() {
           still reports when it lands. Needs router context for its
           "View dataset" action, so it lives here rather than main.tsx.
           fix(#1018): the reload case covers a job still RUNNING at reload
-          time, which is what the persisted store carries. One that reached a
-          terminal status first has already had setJob(null) persisted by the
-          watcher, so a reload in the gap between that write and the toast
-          being read loses the notification. Not worth guarding — it needs a
-          hard reload inside a few hundred ms — but the guarantee is narrower
-          than "survives a reload" full stop. */}
+          time, which is what the persisted store carries. Once the job reaches
+          a terminal status the watcher persists setJob(null) and reports
+          through a toast — and the toast is `duration: Infinity` and NOT
+          persisted, so a reload at ANY later point while it sits
+          unacknowledged drops the notification with nothing left to rebuild
+          it from. Not worth guarding, since the job itself completed
+          server-side and the dataset is in the catalog, but the guarantee is
+          "a running job survives a reload", not "a notification does". */}
       <AnalysisJobWatcher />
       <Suspense fallback={<LoadingState />}>
         <Outlet />

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -59,7 +59,14 @@ function RootLayout() {
       {/* feat(#682): analysis-job notifier — global so a materialize job that
           outlives the builder (panel closed, navigated away, tab reloaded)
           still reports when it lands. Needs router context for its
-          "View dataset" action, so it lives here rather than main.tsx. */}
+          "View dataset" action, so it lives here rather than main.tsx.
+          fix(#1018): the reload case covers a job still RUNNING at reload
+          time, which is what the persisted store carries. One that reached a
+          terminal status first has already had setJob(null) persisted by the
+          watcher, so a reload in the gap between that write and the toast
+          being read loses the notification. Not worth guarding — it needs a
+          hard reload inside a few hundred ms — but the guarantee is narrower
+          than "survives a reload" full stop. */}
       <AnalysisJobWatcher />
       <Suspense fallback={<LoadingState />}>
         <Outlet />

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -245,12 +245,13 @@ export default defineConfig({
       // recompute floor(actual) and bump these (add a +1 / +2 buffer when actual
       // sits comfortably above the floor). Never lower without a documented
       // rationale in CHANGELOG.
-      // 2026-05-07 actuals: statements 41.51 / branches 39.42 / functions 37.99 / lines 42.69
-      // Note: plan-prescribed +2 buffer (43/41/39/44) failed all four dimensions because
-      // actuals sit < 1pt above their integer floors. +1 buffer would also fail for the
-      // same reason. Set to floor(actual) (= +0 buffer) — values still ratchet meaningfully
-      // above the prior 32/27/27/32 baseline (statements +9, branches +12, functions +10,
-      // lines +10) so the gate catches any non-trivial coverage regression.
+      // 2026-07-31 actuals: statements 72.05 / branches 67.31 / functions 66.29 / lines 74.16
+      // (fix(#1018): the numbers here used to be the 2026-05-07 ones — 41.51 / 39.42 /
+      // 37.99 / 42.69 — carrying a warning that even a +1 buffer would fail because
+      // actuals sat under a point above their integer floors. Neither half is true now:
+      // the suite has ~30 points of headroom on every dimension, so an uncovered line
+      // does not trip these thresholds. Ratcheting them up to match is a separate call,
+      // deliberately not made here.)
       thresholds: {
         statements: 41,
         branches: 39,

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -240,18 +240,24 @@ export default defineConfig({
         'src/components/ui/**',
       ],
       // Coverage thresholds ratchet upward as the suite grows (TEST-02, Phase 278).
-      // Each dimension is set to floor(actual_pct) from the most recent local
-      // `npm test -- --run --coverage` run. To ratchet further: re-run coverage,
-      // recompute floor(actual) and bump these (add a +1 / +2 buffer when actual
-      // sits comfortably above the floor). Never lower without a documented
-      // rationale in CHANGELOG.
-      // 2026-07-31 actuals: statements 72.05 / branches 67.31 / functions 66.29 / lines 74.16
-      // (fix(#1018): the numbers here used to be the 2026-05-07 ones — 41.51 / 39.42 /
-      // 37.99 / 42.69 — carrying a warning that even a +1 buffer would fail because
-      // actuals sat under a point above their integer floors. Neither half is true now:
-      // the suite has ~30 points of headroom on every dimension, so an uncovered line
-      // does not trip these thresholds. Ratcheting them up to match is a separate call,
-      // deliberately not made here.)
+      // Never lower one without a documented rationale in CHANGELOG.
+      //
+      // These are floor(actual) as measured on 2026-05-07, and the suite has
+      // since grown well past them. Measured 2026-07-31: statements 72.05 /
+      // branches 67.31 / functions 66.29 / lines 74.16 — roughly 30 points of
+      // headroom on every dimension, so an uncovered line does not trip a
+      // threshold today.
+      //
+      // fix(#1018): the comment here used to record the 2026-05-07 actuals
+      // (41.51 / 39.42 / 37.99 / 42.69) and warn that even a +1 buffer would
+      // fail because they sat under a point above their integer floors. Both
+      // halves were stale, and someone planning coverage work read it and
+      // believed the gate was tight. Re-ratcheting is a separate call and is
+      // deliberately NOT made here, so the invariant to read this block by is
+      // "thresholds are a floor from a recorded measurement", not "thresholds
+      // always equal floor(latest)". To ratchet: re-run `npm run
+      // test:coverage`, set each to floor(actual), and update the measurement
+      // above in the same commit.
       thresholds: {
         statements: 41,
         branches: 39,


### PR DESCRIPTION
Five stale or wrong comments, one PR, as #1018 asks. Three are comment-only; two change behaviour (`collections.spec.ts` cleanup, and a `_MODULE_LOC_CAPS` bump the docstring growth requires).

## 1. `backend/tests/test_export.py` — the reason was backwards

The docstring said the 400 on `bbox=10,10,5,5` came from `minx > maxx`. `parse_bbox` deliberately **allows** that — it is how an antimeridian-crossing bbox is spelled (`170,-45,-170,-30`), and its only bounds check is `values[1] >= values[3]`. The assertion was right, the stated reason exactly inverted, and it sat in front of the antimeridian code most likely to be read by someone acting on it. Now names the latitude check.

## 2. `_ingest_vector_into_staging` — kept, marked test-only

`backend/app/processing/ingest/tasks_common.py:810`, re-exported through `tasks.py:20`. Every call site in the repo is a test (`test_staging_pipeline.py`, `test_staging_pipeline_integration.py`).

**Decision: keep it, mark it.** Deleting means rewriting ~900 lines of tests onto `_finalize_ingest`, a far wider blast radius than the problem justifies.

The docstring now maps what it mirrors, and review corrected that map:

- Its **pre-staging** steps (`run_ogr2ogr` → `rename_reserved_columns` → DBF-truncation check → `user_wants_geom` override) are a parallel copy of `tasks_vector.py:459-560` and `tasks_reupload.py:261-340`.
- Its **staging** steps are not forked at all — they are the real `_run_staging_pipeline` (`:650`). But production reaches that function *only* on the re-upload path (`tasks_reupload.py:337`); new vector ingest reruns the same eight steps inline in `_finalize_ingest` (`:1069`, block at `:1114-1177`). **Three sites, not two.**

The same correction fixes `_run_staging_pipeline`'s own docstring, which claimed `_ingest_vector_into_staging` was its "new ingests" caller — the same class of defect this issue collects, one function up.

## 3. `frontend/src/App.tsx` — narrowed to the guarantee the code gives

The `AnalysisJobWatcher` host comment listed "tab reloaded" alongside panel-closed and navigated-away. That holds only while the job is still running, which is what the persisted store carries. After a terminal status the watcher has already persisted `setJob(null)`. Comment now says so; no code change, since it takes a reload inside a few hundred ms.

## 4. `e2e/collections.spec.ts` — the leak is real, one frame further in than the issue says

The issue pins this at `:192`, "the assignment sits after the `Add Datasets` heading assertion". On `9a788ba92` that assertion is at `:186-189` and `createCollectionDataset()` at `:191` — creation happens *after* the assertion, so that path cannot leak.

The leak it describes is real, one frame deeper: `createCollectionDataset` commits the ingest and only then awaits `waitForDatasetJob`. A failed import, a 45-attempt timeout, or a bad response mid-poll all throw with `createdDatasetId` still null, and `afterAll` returns early having deleted nothing — one leaked dataset per retry, the shape #895 fixed in `analysis.spec.ts` (its catalog count climbed 3 → 4 → 5 across three retries).

Fixed after two review rounds, and the second round is the interesting one: **there is no earlier moment to claim the id.** `_finalize_ingest` sets `dataset_id` in the *same atomic update* that flips the job to `complete`, so "claim it as soon as a poll reports one" — my first attempt — was a no-op. What survives:

- `createdDatasetTitle` registered before the upload can create anything (`afterAll` needs both halves of the handle).
- `createdJobId` registered at commit — the only handle that exists in the gap.
- Teardown polls that job for the id, **bounded** at 30 × 2s. A single lookup would almost always still see `running`, because the reason we are in that branch is that the job outlived its 45-second window; and the bound matters as much as the wait, since teardown must not hang on a wedged worker. Stops early on a failed job, which produces no dataset to delete.

## 5. `frontend/vite.config.ts` — coverage actuals were 12 weeks stale

Recorded `2026-05-07 actuals: statements 41.51 / branches 39.42 / functions 37.99 / lines 42.69` plus a warning that even a +1 threshold buffer would fail for lack of headroom.

Measured with `npm run test:coverage`, 2026-07-31:

| Dimension | Threshold | Actual |
|---|---|---|
| statements | 41 | 72.05 |
| branches | 39 | 67.31 |
| functions | 37 | 66.29 |
| lines | 42 | 74.16 |

~30 points of headroom, not zero, so the warning described nothing and is dropped. **Thresholds are unchanged** — ratcheting is the separate call the issue asks not to smuggle in.

Review caught that correcting only the numbers left the block self-contradictory: the surviving prose said every threshold is `floor(actual_pct)` from the most recent run, while the recorded actuals now sit 30 points above them. The invariant is reworded to what is actually true — "thresholds are a floor from a recorded measurement" — with the ratchet recipe kept.

## The cap bump

Item 2's docstring costs 23 lines in a file ratcheted exact, so `_MODULE_LOC_CAPS["...tasks_common.py"]` goes 1631 → 1654 with the carve-out comment the ratchet asks for. Caught by the full backend suite, not by a focused run — which is #958's other half.

## Schema / API / security impact

None.

## Verification

```
cd backend && uv run pytest tests/test_layering.py tests/test_export.py tests/test_staging_pipeline.py \
  tests/test_staging_pipeline_integration.py tests/test_event_ingest.py -q     # 107 passed
cd backend && uv run ruff check . && uv run ruff format --check .
cd frontend && npm run lint && npm run typecheck && npm run test:coverage      # 366 files / 4284 tests
npx playwright test e2e/collections.spec.ts --project=chromium                 # 9 passed (re-run after each spec change)
```

The Playwright run is valid from this branch: the spec is the only behavioural change that the running stack could see, and Playwright reads specs from the working tree while the app code the stack serves is byte-identical to `main` (the other edits are comments and a test-file cap).

Closes #1018