### PR TITLE
test(builder): drop the real-timer delay from the StackRow rename test

### DIFF
--- a/frontend/src/components/builder/__tests__/StackRow.test.tsx
+++ b/frontend/src/components/builder/__tests__/StackRow.test.tsx
@@ -876,7 +876,22 @@ describe('row keydown target guard (v1.6.0 audit A7)', () => {
   });
 
   it('a space can be typed into the rename input and Enter commits without re-firing the row action', async () => {
-    const user = userEvent.setup();
+    // fix(#997): delay: null. user-event's default inserts a real-timer
+    // setTimeout(0) between keystrokes, and this is the only test in the file
+    // that types more than one — three keystrokes plus a clear, each yielding
+    // to the macrotask queue. Under the parallel full-suite run the worker
+    // competes for CPU and those yields stretch, which is what made this test
+    // (and only this test) fail roughly 1 run in 6 while passing 3/3 in
+    // isolation. The two siblings above keep the default: they fire a single
+    // key against a focused button, have never been seen to flake, and are
+    // worth keeping as controls.
+    //
+    // Not swapped to fireEvent, which is how the neighbouring rename tests are
+    // written. This block exists to prove real keyboard activation works again
+    // after the A7 fix, and that activation is gated on defaultPrevented —
+    // something only user-event models. Dropping the delay removes the timing
+    // dependence without giving up the dispatch semantics under test.
+    const user = userEvent.setup({ delay: null });
     const onRename = vi.fn();
     const onSelectLayer = vi.fn();
     const layer = makeLayer({ id: 'sp-layer', dataset_name: 'Old' });


### PR DESCRIPTION
## What changed

One line plus its rationale, in `src/components/builder/__tests__/StackRow.test.tsx`:

```ts
const user = userEvent.setup({ delay: null });
```

on *"a space can be typed into the rename input and Enter commits without re-firing the row action"*.

## Why this test and not the other two

Three of the file's 57 tests call `userEvent.setup()` — `:823`, `:842`, and this one. The first two fire a single `user.keyboard(...)` against a focused button and have never been seen to flake. This one runs `await user.clear(input)`, `await user.type(input, 'a b')`, an intermediate `expect(input).toHaveValue('a b')`, then `await user.keyboard('{Enter}')`.

user-event's default `delay: 0` still awaits a real `setTimeout(0)` between keystrokes, so this test yields to the macrotask queue four times where the siblings yield once. Under `npm run test:coverage` the worker competes for CPU and those yields stretch, which matches the observed signature: 1 failure in 6 full-suite runs on branches that touch neither `StackRow` nor anything it imports, against 3/3 passes in isolation.

`delay: null` removes the yields. The two siblings deliberately keep the default and stay as in-file controls.

## Why not fireEvent

The neighbouring rename tests use `fireEvent`, and swapping would be the smaller diff, but the block's header comment says what it is for: user-event 14 implements real keyboard activation *gated on `defaultPrevented`*, and these tests prove the descendants work again after the A7 row-keydown fix. `fireEvent.keyDown` does not model that gate, so the swap would keep the test green while removing what it tests. Dropping the delay takes out the timing dependence and leaves the dispatch semantics intact.

## Verification

`npx vitest run src/components/builder/__tests__/StackRow.test.tsx` — 57 passed, 3 consecutive runs.

`npm run test:coverage` — 366 files / 4284 tests passed, twice (once before this change, once after).

Per-test duration from `--reporter=verbose`, same machine, back to back:

| test | default delay | `delay: null` |
|---|---|---|
| Space on the focused eye toggle | 11ms | 9ms |
| Enter on the focused eye toggle | 7ms | 7ms |
| **the rename test** | **25ms** | **15ms** |

The two controls are unchanged inside noise; the fixed test drops ~10ms, which is the four real-timer yields going away.

Being straight about the limit of this evidence: green runs cannot prove a 1-in-6 flake is gone, and I have not reproduced the failure. The argument is mechanical — the test no longer depends on real-timer scheduling, and the two tests that still do are the ones that never flaked.

## Schema / API / security impact

None. Test-only.

Closes #997