### PR TITLE
fix(catalog): pad a degenerate bbox instead of building a zero-area extent ring

### DIFF
--- a/backend/app/core/geo.py
+++ b/backend/app/core/geo.py
@@ -151,6 +151,30 @@ def _ring(x0: float, south: float, x1: float, north: float) -> str:
     return f"({x0} {south},{x1} {south},{x1} {north},{x0} {north},{x0} {south})"
 
 
+# fix(#944): a span this narrow is degenerate, and the sliver it is widened to.
+# Both come from :func:`seam_extent_wkt_for_table`, which hit the same problem
+# one caller upstream first; 1e-9 is also the magnitude the ``ST_Expand`` calls
+# in ``processing/ingest/metadata.py`` and ``catalog/features/service.py`` use
+# on POINT/LINESTRING extents, so a padded extent produced here is
+# indistinguishable in size from one produced by ingest.
+_DEGENERATE_SPAN = 1e-12
+_DEGENERATE_PAD = 1e-9
+
+
+def _pad_degenerate(low: float, high: float, limit: float) -> tuple[float, float]:
+    """Widen a zero-span axis to a sliver, without leaving ``±limit``.
+
+    Padding outward is what the ``ST_Expand`` callers do, but an axis sitting
+    exactly on its domain edge (a point on the antimeridian, or at a pole) has
+    no room on one side, so the pad is clamped and the sliver grows inward
+    instead. Non-degenerate spans are returned untouched, so a genuine bbox
+    never moves by an epsilon.
+    """
+    if high - low >= _DEGENERATE_SPAN:
+        return low, high
+    return max(-limit, low - _DEGENERATE_PAD), min(limit, high + _DEGENERATE_PAD)
+
+
 def bbox_to_extent_wkt(west: float, south: float, east: float, north: float) -> str:
     """Build extent WKT for an RFC 7946 §5.2 bbox, splitting it at ±180.
 
@@ -164,8 +188,19 @@ def bbox_to_extent_wkt(west: float, south: float, east: float, north: float) -> 
     same latitude band -- which ``catalog.records.spatial_extent`` accepts as of
     migration ``0030_records_spatial_extent_type`` and which
     :func:`extent_to_bbox` reads back as the original ``west > east`` pair.
+
+    fix(#944): a degenerate axis is padded to a sliver first. A bbox with
+    ``south == north`` (a single point, or a run of points on one parallel)
+    otherwise yields four collinear vertices -- zero area, and not a valid
+    polygon -- and the same applies to a zero-width non-crossing bbox. Only the
+    width case was guarded before, and only on the crossing branch. Padding
+    rather than rejecting follows the producers, which already ``ST_Expand``
+    degenerate POINT/LINESTRING extents by the same 1e-9; rejecting would turn
+    a working ingest into a failed one for data the schema stores happily.
     """
+    south, north = _pad_degenerate(south, north, 90.0)
     if west <= east:
+        west, east = _pad_degenerate(west, east, 180.0)
         return f"POLYGON({_ring(west, south, east, north)})"
 
     # A crossing bbox whose west sits at +180 (or east at -180) has a zero-width
@@ -414,13 +449,12 @@ async def seam_extent_wkt_for_table(
         crossing = True
     if not crossing:
         return None
-    # Mirror the callers' degenerate padding (their non-crossing path runs
-    # ST_Expand 1e-9 on POINT/LINESTRING extents): a crossing extent can
-    # never be zero-width, but a single-parallel source is zero-height and
-    # would produce invalid zero-height rings. Related: #944.
-    if north - south < 1e-12:
-        south -= 1e-9
-        north += 1e-9
+    # fix(#944): the zero-height pad this function used to carry moved into
+    # bbox_to_extent_wkt, which now pads both axes for every caller. Keeping a
+    # copy here would not double-pad (this one widens the span past the 1e-12
+    # trigger, so the helper's would never fire) — it would be worse, leaving
+    # the helper's version dead on this path and two copies of one convention
+    # to keep in sync.
     # fix(#934 codex r2): a fold whose west lands exactly on +180 (rows at
     # planar 180 and -170), or whose east lands on -180, has a zero-width
     # half. bbox_to_extent_wkt drops such halves, which is correct for its

--- a/backend/app/core/geo.py
+++ b/backend/app/core/geo.py
@@ -169,6 +169,10 @@ def _pad_degenerate(low: float, high: float, limit: float) -> tuple[float, float
     no room on one side, so the pad is clamped and the sliver grows inward
     instead. Non-degenerate spans are returned untouched, so a genuine bbox
     never moves by an epsilon.
+
+    Callers must reject a non-finite bbox first: NaN compares False against
+    everything, so it would fall past the span test into the clamp and
+    ``max``/``min`` would quietly substitute the domain edge.
     """
     if high - low >= _DEGENERATE_SPAN:
         return low, high
@@ -197,7 +201,20 @@ def bbox_to_extent_wkt(west: float, south: float, east: float, north: float) -> 
     rather than rejecting follows the producers, which already ``ST_Expand``
     degenerate POINT/LINESTRING extents by the same 1e-9; rejecting would turn
     a working ingest into a failed one for data the schema stores happily.
+
+    fix(#944 codex r1): a non-finite coordinate is refused outright. NaN
+    compares False against every test below, so it reaches the clamp and
+    ``max``/``min`` substitute the domain edge; a NaN longitude also fails
+    ``west <= east``, then loses both crossing halves to the ``x0 < x1``
+    filter and lands on the full -180..180 fallback. Either way a malformed
+    bbox (``StacImportItem.bbox`` is an unconstrained float list) would be
+    silently recorded as an almost-global extent. "An extent must never
+    silently narrow to nothing" has a mirror, and this is it. STAC import
+    isolates each item in a savepoint and records the failure per item, so
+    raising costs the batch nothing.
     """
+    if not all(math.isfinite(v) for v in (west, south, east, north)):
+        raise ValueError(f"bbox must be finite, got ({west}, {south}, {east}, {north})")
     south, north = _pad_degenerate(south, north, 90.0)
     if west <= east:
         west, east = _pad_degenerate(west, east, 180.0)

--- a/backend/tests/test_antimeridian_extent.py
+++ b/backend/tests/test_antimeridian_extent.py
@@ -254,6 +254,31 @@ class TestBboxToExtentWkt:
         """
         assert extent_to_bbox(_extent(bbox_to_extent_wkt(*bbox))) == list(bbox)
 
+    @pytest.mark.parametrize(
+        "bbox",
+        [
+            # NaN latitude: falls past the span test into the clamp, where
+            # max/min substitute -90/+90.
+            (1.0, float("nan"), 3.0, float("nan")),
+            # NaN longitude: fails `west <= east`, then loses both crossing
+            # halves to the `x0 < x1` filter and lands on the full-band
+            # fallback. Pre-dates the padding; same silent globalisation.
+            (float("nan"), 1.0, float("nan"), 4.0),
+            (1.0, float("-inf"), 3.0, float("inf")),
+        ],
+    )
+    def test_a_non_finite_bbox_is_refused_not_widened_to_the_globe(self, bbox):
+        """fix(#944 codex r1): NaN compares False against everything.
+
+        Every guard in this helper is an ordered comparison, so a NaN slips
+        through all of them and comes out the far side as an almost-global
+        extent — from a malformed STAC bbox, since ``StacImportItem.bbox`` is
+        an unconstrained float list. "An extent must never silently narrow to
+        nothing" has a mirror, and this is it.
+        """
+        with pytest.raises(ValueError, match="finite"):
+            bbox_to_extent_wkt(*bbox)
+
 
 # ---------------------------------------------------------------------------
 # chk_records_spatial_extent_type (migration 0030)

--- a/backend/tests/test_antimeridian_extent.py
+++ b/backend/tests/test_antimeridian_extent.py
@@ -25,6 +25,9 @@ from app.core.geo import bbox_to_extent_wkt, extent_to_bbox, extent_to_span_bbox
 # The canonical crossing case: a Fiji-area strip that spans the seam.
 FIJI_BBOX = (170.0, -20.0, -170.0, -15.0)
 
+# fix(#944): the sliver bbox_to_extent_wkt widens a degenerate axis to.
+PAD = 1e-9
+
 ORDINARY_POLYGON = "POLYGON((0 0,10 0,10 5,0 5,0 0))"
 SEAM_MULTIPOLYGON = bbox_to_extent_wkt(*FIJI_BBOX)
 # Two real footprints on opposite sides of the world. Neither touches ±180, so
@@ -188,6 +191,68 @@ class TestBboxToExtentWkt:
         assert shape.is_valid
         assert shape.geom_type == expected_type
         assert shape.bounds == expected_bounds
+
+    @pytest.mark.parametrize(
+        ("bbox", "expected_type", "expected_bounds"),
+        [
+            # A run of points on one parallel: zero height, non-crossing.
+            ((1.0, 2.0, 3.0, 2.0), "Polygon", (1.0, 2.0 - PAD, 3.0, 2.0 + PAD)),
+            # The same, crossing the seam — both halves must stay valid.
+            (
+                (170.0, -20.0, -170.0, -20.0),
+                "MultiPolygon",
+                (-180.0, -20.0 - PAD, 180.0, -20.0 + PAD),
+            ),
+            # A meridian-aligned run: zero width, non-crossing.
+            ((5.0, 1.0, 5.0, 4.0), "Polygon", (5.0 - PAD, 1.0, 5.0 + PAD, 4.0)),
+            # A single point: degenerate on both axes at once.
+            (
+                (5.0, 6.0, 5.0, 6.0),
+                "Polygon",
+                (5.0 - PAD, 6.0 - PAD, 5.0 + PAD, 6.0 + PAD),
+            ),
+            # On the antimeridian, where an outward pad would leave the domain:
+            # the sliver grows inward instead of emitting longitude 180.000…001.
+            ((180.0, 1.0, 180.0, 4.0), "Polygon", (180.0 - PAD, 1.0, 180.0, 4.0)),
+            ((-180.0, 1.0, -180.0, 4.0), "Polygon", (-180.0, 1.0, -180.0 + PAD, 4.0)),
+            # The same at a pole.
+            ((1.0, 90.0, 3.0, 90.0), "Polygon", (1.0, 90.0 - PAD, 3.0, 90.0)),
+            ((1.0, -90.0, 3.0, -90.0), "Polygon", (1.0, -90.0, 3.0, -90.0 + PAD)),
+        ],
+    )
+    def test_degenerate_span_is_padded_to_a_valid_ring(
+        self, bbox, expected_type, expected_bounds
+    ):
+        """fix(#944): a zero-span axis builds four collinear points — zero area,
+        and not a valid polygon.
+
+        Only the width case was guarded before, and only on the crossing
+        branch, so a single-parallel source stored an invalid ring through the
+        STAC import path. Pad both axes on both branches, following the
+        ``ST_Expand`` convention the producer paths already use.
+        """
+        shape = shapely_wkt.loads(bbox_to_extent_wkt(*bbox))
+        assert shape.is_valid
+        assert shape.geom_type == expected_type
+        assert shape.bounds == pytest.approx(expected_bounds)
+        assert shape.area > 0
+
+    @pytest.mark.parametrize(
+        "bbox",
+        [
+            FIJI_BBOX,
+            (1.0, 2.0, 3.0, 4.0),
+            (179.5, 0.0, -179.5, 1.0),
+            (0.0, 0.0, 1e-9, 1e-9),
+        ],
+    )
+    def test_padding_never_moves_a_genuine_bbox(self, bbox):
+        """The pad triggers below 1e-12, so a real extent round-trips exactly.
+
+        The last case is the tightest bbox the ``ST_Expand`` producers emit: it
+        must be treated as genuine, not re-padded.
+        """
+        assert extent_to_bbox(_extent(bbox_to_extent_wkt(*bbox))) == list(bbox)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #944. Split out of #904; pre-existing, not a regression from #901.

## The defect

`bbox_to_extent_wkt` builds `POLYGON((w s, e s, e s, w s, w s))` when
`south == north` — four collinear vertices, zero area, not a valid polygon.

The *width* case was already guarded, but only on the crossing branch (drop
zero-width halves, fall back to the full band). The non-crossing branch at
`geo.py:168-169` returned its ring directly and was unguarded in **both**
dimensions.

Of the three callers, `seam_extent_wkt_for_table` pre-pads and a raster
footprint always has real extent, so the live exposure is
`catalog/sources/stac_router.py:554`, which passes `item.bbox` through
unvalidated. A STAC item describing a single point, or a scanline of points on
one parallel, stored an invalid ring directly.

## What changed

Pad both axes, on both branches, adopting the convention #934 established one
caller upstream rather than inventing a second one: trigger on a span below
`1e-12`, widen by `1e-9` in each direction. `1e-9` is also the magnitude the
`ST_Expand` calls in `processing/ingest/metadata.py` and
`catalog/features/service.py` use on degenerate POINT/LINESTRING extents, so a
padded extent produced here is indistinguishable in size from one produced by
ingest.

One addition to #934's version: the pad is clamped to the coordinate domain. An
axis sitting exactly on its edge — a point on the antimeridian, or at a pole —
has no room outward, and padding it unclamped would emit longitude
`180.000000001`. The sliver grows inward instead.

Rejecting was the alternative and is closed: `chk_records_spatial_extent_type`
admits POLYGON, so an invalid zero-area ring stores happily today, and anything
that starts rejecting it turns a working ingest into a failed one.

Second edit, per the issue: `seam_extent_wkt_for_table` drops its own copy of
the pad. Leaving both is not a double-pad (the seam pad widens the span past the
`1e-12` trigger, so the helper's never fires) — it is worse, because the
caller's copy stays the one that runs and the helper's becomes dead code on that
path, with two copies of one convention to keep in sync. That is what the
"Related: #944" note in #934's comment was flagging as temporary.

## Verification

```
cd backend && set -a && source ../.env.test && set +a && uv run pytest \
  tests/test_antimeridian_extent.py tests/test_antimeridian_rollup.py \
  tests/test_extent_producers_934.py tests/test_export_antimeridian.py \
  tests/test_raster_antimeridian_887.py tests/test_stor_vsi_seam_lint.py -q
  # 41 + 193 passed
cd backend && uv run ruff check . && uv run ruff format --check .
```

`TestBboxToExtentWkt` gains two parametrised tests. The first covers zero height
non-crossing, zero height crossing (both halves stay valid), zero width
non-crossing, a single point degenerate on both axes at once, and the four
domain-edge cases where the pad clamps. All assert `is_valid`, the geometry
type, the padded bounds, and `area > 0`.

The second pins that padding never moves a genuine bbox, including a `1e-9`-span
bbox — the tightest the `ST_Expand` producers emit, which must read as genuine
rather than be re-padded.
