### PR TITLE
fix(migrations): guard 0029's downgrade against dropping key expiry and epoch state

### DIFF
--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -233,7 +233,7 @@ upgrade is what fixes that, and the only way to reach it is to downgrade below
 > | Migration | What its `downgrade()` does |
 > |---|---|
 > | 0030 | **Refuses** while any `catalog.records` row holds a MULTIPOLYGON `spatial_extent` — i.e. any antimeridian-crossing footprint, which the current schema exists to store |
-> | 0029 | **Discards** `api_keys.expires_at` and both `key_epoch` columns. The re-upgrade recreates them as NULL and 1, turning time-limited keys into permanent ones and un-revoking keys that a `key_epoch` bump had invalidated |
+> | 0029 | **Refuses** while any API key carries an expiry or any user's `key_epoch` has been bumped. Dropping `api_keys.expires_at` and both `key_epoch` columns would turn time-limited keys into permanent ones and un-revoke keys a `key_epoch` bump had invalidated; the error message lists the affected keys and the SQL that revokes them |
 > | 0027 | **Refuses** while any dataset uses a `parquet`, `json`, `xlsx`, or `xls` source format — all currently supported |
 > | 0022 | **Discards** `tenant_id` on `catalog.audit_logs` and `catalog.ingest_jobs`. The re-upgrade re-derives it from each row's live parent, so rows whose parent is gone lose tenant attribution permanently |
 > | 0021, 0020 | **Refuse** when two tenants share a collection name, OAuth subject, or `datasets.table_name` — all legal under the current per-tenant scoping |
@@ -339,9 +339,15 @@ SQL
 from the dump.** A failed downgrade does not roll back the ones that already
 succeeded. Several of these migrations do index work inside Alembic's
 `autocommit_block()` (0020, 0021, 0022 among them), which commits the DDL
-preceding it, so a refusal at 0021 leaves you past 0029's and 0022's discards
-with no transaction to undo them. Drop and recreate the target database, then
+preceding it, so a refusal at 0021 leaves you past 0022's discards with no
+transaction to undo them. Drop and recreate the target database, then
 re-run 2a and 2b against the untouched dump before attempting anything else.
+
+0029 is the one place where the order works in your favour: walking back from
+head it is reached second, before any of the discarding migrations, so its
+refusal stops the run while the database is still whole. Deal with its
+remediation there rather than discovering the loss after a refusal further
+down (fix(#1016) — it used to drop those columns silently).
 The dump file itself is never modified, so nothing is lost by restarting — but
 continuing in a half-downgraded database is how a recovery turns into a second
 incident.
@@ -1024,8 +1030,9 @@ been accepted.
 
 Rolling the schema back (`alembic downgrade`) is rare — the supported
 recovery paths are restore-from-backup (§2/§3) and the upgrade rollback
-quick-reference in UPGRADING.md. When you do downgrade, one migration can
-refuse by design.
+quick-reference in UPGRADING.md. When you do downgrade, several migrations
+refuse by design rather than discard state the re-upgrade cannot rebuild. The
+two you are most likely to meet are documented in full below.
 
 ### Downgrading past `0030_records_spatial_extent_type` fails when antimeridian-crossing extents exist
 
@@ -1064,7 +1071,43 @@ non-crossing multipart extent loses its part structure and reports the
 bounding box around all parts. Both persist until the schema is upgraded
 again and the extents recomputed.
 
-Two other migrations refuse on downgrade for the same reason (blocking data
+### Downgrading past `0029_api_key_hardening` fails when API keys carry expiry or revocation state
+
+Migration 0029 added `api_keys.expires_at` (optional key expiry) and the
+`key_epoch` pair that makes an epoch bump revoke previously minted keys. Its
+`downgrade()` **refuses** rather than dropping them, because dropping them
+fails in the unsafe direction: with no expiry column an already-expired key
+resolves as a permanent one, and with no `key_epoch` pair a key revoked by an
+epoch bump resolves again. Nothing errors when that happens — the schema is
+valid and the deployment is quietly less secure than it looks.
+
+It refuses when any `catalog.api_keys` row has a non-null `expires_at`, or any
+`catalog.users` row has `key_epoch > 1`. The error message carries the counts
+and the query below. List the keys that would come back live:
+
+```sql
+SELECT ak.id, ak.user_id, ak.expires_at, ak.key_epoch, u.key_epoch AS owner_epoch
+FROM catalog.api_keys ak
+JOIN catalog.users u ON u.id = ak.user_id
+WHERE ak.expires_at IS NOT NULL OR ak.key_epoch <> u.key_epoch;
+```
+
+Revoking them is almost always what you want, rather than accepting their
+resurrection. That, plus clearing the epoch state, lets the downgrade proceed:
+
+```sql
+DELETE FROM catalog.api_keys ak USING catalog.users u
+WHERE ak.user_id = u.id
+  AND (ak.expires_at IS NOT NULL OR ak.key_epoch <> u.key_epoch);
+UPDATE catalog.users SET key_epoch = 1;
+```
+
+**What is actually lost:** the deleted keys, permanently. Their owners must
+mint new ones, which is the correct outcome — an expired or revoked key should
+not survive a schema rollback. What you avoid is the alternative, where those
+same keys keep working and nobody is told.
+
+Two further migrations refuse on downgrade for the same reason (blocking data
 exists that the older schema cannot represent safely): `0010` while GitHub
 OAuth providers exist, and `0005` while tenant-scoped data exists. Both print
 their own remediation in the error message; neither is auto-coerced.

--- a/backend/alembic/versions/0029_api_key_hardening.py
+++ b/backend/alembic/versions/0029_api_key_hardening.py
@@ -102,7 +102,15 @@ def downgrade() -> None:
     # than SHARE because the drops below need it anyway — taking it up front
     # avoids a lock upgrade, and env.py wraps the whole run in one transaction,
     # so it is held until the downgrade ends.
-    op.execute("LOCK TABLE catalog.api_keys, catalog.users IN ACCESS EXCLUSIVE MODE")
+    #
+    # users BEFORE api_keys, matching the order every writer already takes:
+    # create_api_key_for_user reads catalog.users and then inserts into
+    # catalog.api_keys (app/modules/auth/service.py). Locking the other way
+    # round lets a concurrent mint hold users while it waits for api_keys while
+    # this holds api_keys and waits for users — which PostgreSQL resolves by
+    # aborting one of them, rather than by making the mint queue behind the
+    # migration.
+    op.execute("LOCK TABLE catalog.users, catalog.api_keys IN ACCESS EXCLUSIVE MODE")
     expiring, bumped, affected = bind.execute(text(_COUNT_KEY_STATE)).one()
     if expiring or bumped:
         raise RuntimeError(

--- a/backend/alembic/versions/0029_api_key_hardening.py
+++ b/backend/alembic/versions/0029_api_key_hardening.py
@@ -95,6 +95,14 @@ def downgrade() -> None:
     # inside `autocommit_block()`, which commits the DDL preceding it, so a
     # refusal at 0021 does not roll back what 0029 already dropped.
     bind = op.get_bind()
+    # Lock before counting, or the count is only a snapshot: the ACCESS SHARE
+    # a SELECT takes does not block an API-key insert or a key_epoch update, so
+    # a writer could commit between the count and the DROP COLUMNs and have its
+    # state discarded by a guard that never saw it. ACCESS EXCLUSIVE rather
+    # than SHARE because the drops below need it anyway — taking it up front
+    # avoids a lock upgrade, and env.py wraps the whole run in one transaction,
+    # so it is held until the downgrade ends.
+    op.execute("LOCK TABLE catalog.api_keys, catalog.users IN ACCESS EXCLUSIVE MODE")
     expiring, bumped, affected = bind.execute(text(_COUNT_KEY_STATE)).one()
     if expiring or bumped:
         raise RuntimeError(

--- a/backend/alembic/versions/0029_api_key_hardening.py
+++ b/backend/alembic/versions/0029_api_key_hardening.py
@@ -26,11 +26,27 @@ from typing import Sequence, Union
 
 import sqlalchemy as sa
 from alembic import op
+from sqlalchemy import text
 
 revision: str = "0029_api_key_hardening"
 down_revision: Union[str, None] = "0028_oauth_email_verified_backfill"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
+
+# fix(#1016): the state the downgrade would silently discard.
+#
+# ``users.key_epoch > 1`` is the right coarse test for revocation state:
+# ``api_keys.key_epoch`` is a mint-time snapshot of the owner's value, so if no
+# owner has ever been bumped past the default of 1, no revocation has happened
+# and there is nothing to lose.
+_COUNT_KEY_STATE = """
+SELECT
+    (SELECT count(*) FROM catalog.api_keys WHERE expires_at IS NOT NULL),
+    (SELECT count(*) FROM catalog.users WHERE key_epoch > 1),
+    (SELECT count(*) FROM catalog.api_keys ak
+       JOIN catalog.users u ON u.id = ak.user_id
+      WHERE ak.expires_at IS NOT NULL OR ak.key_epoch <> u.key_epoch)
+"""
 
 
 def upgrade() -> None:
@@ -65,6 +81,44 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
+    # fix(#1016): refuse rather than drop. Both columns carry security state and
+    # losing them fails in the unsafe direction — an expired key comes back as a
+    # permanent one, and a key revoked by an epoch bump comes back live. Neither
+    # raises: the downgrade succeeds, the schema is valid, and the deployment is
+    # quietly less secure than the operator believes.
+    #
+    # This matters despite downgrades being rare, because the one documented
+    # procedure that reaches this migration is the multi-tenant fresh-cluster DR
+    # path (`alembic downgrade 0016`, RUNBOOK § disaster recovery) — run on
+    # someone's worst day, usually for the first time. It is also not covered by
+    # the later refusals: several migrations between here and 0020 do index work
+    # inside `autocommit_block()`, which commits the DDL preceding it, so a
+    # refusal at 0021 does not roll back what 0029 already dropped.
+    bind = op.get_bind()
+    expiring, bumped, affected = bind.execute(text(_COUNT_KEY_STATE)).one()
+    if expiring or bumped:
+        raise RuntimeError(
+            f"{expiring} API key(s) carry an expiry and {bumped} user(s) have "
+            f"had their key_epoch bumped; {affected} key(s) would come back "
+            "live or permanent if these columns were dropped. Dropping "
+            "api_keys.expires_at removes the expiry check, so an already-"
+            "expired key resolves as a forever key; dropping the key_epoch "
+            "pair removes the revocation check (#821), so keys revoked by an "
+            "epoch bump resolve again. Inspect the exact keys with:\n"
+            "  SELECT ak.id, ak.user_id, ak.expires_at, ak.key_epoch,\n"
+            "         u.key_epoch AS owner_epoch\n"
+            "  FROM catalog.api_keys ak\n"
+            "  JOIN catalog.users u ON u.id = ak.user_id\n"
+            "  WHERE ak.expires_at IS NOT NULL OR ak.key_epoch <> u.key_epoch;\n"
+            "Revoking them is almost always what you want, rather than "
+            "accepting their resurrection. To do that and clear the epoch "
+            "state, run this first, then re-run the downgrade:\n"
+            "  DELETE FROM catalog.api_keys ak USING catalog.users u\n"
+            "  WHERE ak.user_id = u.id\n"
+            "    AND (ak.expires_at IS NOT NULL OR ak.key_epoch <> u.key_epoch);\n"
+            "  UPDATE catalog.users SET key_epoch = 1;"
+        )
+
     op.drop_column("api_keys", "key_epoch", schema="catalog")
     op.drop_column("api_keys", "expires_at", schema="catalog")
     op.drop_column("users", "key_epoch", schema="catalog")

--- a/backend/tests/alembic_helpers.py
+++ b/backend/tests/alembic_helpers.py
@@ -12,6 +12,10 @@ database, so a single-file run never shows it).
 This module is the one place that knows about refuse-to-coerce downgrades:
 
 - ``0030``: normalized automatically before every downgrade (see below).
+- ``0029_api_key_hardening``: refuses while any API key carries an expiry or
+  any user's ``key_epoch`` has been bumped (fix(#1016)). Also normalized
+  automatically — see ``_API_KEY_STATE_NORMALIZATION`` for why this one is
+  auto-cleaned while the two below are not.
 - ``0010_oauth_github_provider_type``: refuses while GitHub OAuth providers
   exist. Not auto-cleaned — deleting provider rows is semantic test state,
   and the only test that creates them (test_oauth_github_migration) manages
@@ -62,8 +66,59 @@ $$;
 """
 
 
-def normalize_seam_extents() -> None:
-    """Collapse MULTIPOLYGON spatial_extents so downgrades can cross 0030."""
+# fix(#1016): the remediation 0029's own error message prescribes, minus the
+# DELETE — a test database's keys are fixture noise, so clearing the state is
+# enough and there is no need to destroy rows a sibling test may still read.
+#
+# WHY this one is auto-cleaned while 0010 and 0005 are documented-only. Those
+# two are semantic test state, created by the single test that cares about
+# them. Expiring keys and epoch bumps are not: they are created by ordinary
+# auth tests with no relationship to migrations
+# (``test_api_key_with_future_expiry_accepted_and_surfaced`` and
+# ``test_stale_key_epoch_api_key_rejected`` in test_api_key_auth.py, both of
+# which commit and neither of which cleans up), while more than twenty
+# downgrade call sites across six files cross 0029 on their way to 0004/0005/
+# 0009. Leaving it documented would reproduce #933 exactly: whichever
+# migration test happened to share an xdist worker with the auth suite would
+# fail, in a file that has nothing to do with API keys.
+#
+# The same "never lift this into application code" caveat as above applies —
+# in production the refusal is the feature.
+# Each column is guarded independently so this stays a no-op at any schema
+# revision, including a second downgrade step from an already-downgraded state.
+_API_KEY_STATE_NORMALIZATION = """
+DO $$
+BEGIN
+    IF to_regclass('catalog.api_keys') IS NOT NULL AND EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_schema = 'catalog' AND table_name = 'api_keys'
+          AND column_name = 'expires_at'
+    ) THEN
+        UPDATE catalog.api_keys SET expires_at = NULL WHERE expires_at IS NOT NULL;
+    END IF;
+    IF to_regclass('catalog.users') IS NOT NULL AND EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_schema = 'catalog' AND table_name = 'users'
+          AND column_name = 'key_epoch'
+    ) THEN
+        UPDATE catalog.users SET key_epoch = 1 WHERE key_epoch <> 1;
+    END IF;
+    -- api_keys.key_epoch is a mint-time snapshot of the owner's value; realign
+    -- it so the two stay mutually consistent for any test that reads them
+    -- after a downgrade/re-upgrade roundtrip.
+    IF to_regclass('catalog.api_keys') IS NOT NULL AND EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_schema = 'catalog' AND table_name = 'api_keys'
+          AND column_name = 'key_epoch'
+    ) THEN
+        UPDATE catalog.api_keys SET key_epoch = 1 WHERE key_epoch <> 1;
+    END IF;
+END
+$$;
+"""
+
+
+def _execute_normalization(sql: str) -> None:
     from app.core.config import settings
 
     engine = sqlalchemy.create_engine(
@@ -71,13 +126,23 @@ def normalize_seam_extents() -> None:
     )
     try:
         with engine.connect() as conn:
-            conn.execute(sqlalchemy.text(_SEAM_EXTENT_NORMALIZATION))
+            conn.execute(sqlalchemy.text(sql))
     finally:
         engine.dispose()
 
 
+def normalize_seam_extents() -> None:
+    """Collapse MULTIPOLYGON spatial_extents so downgrades can cross 0030."""
+    _execute_normalization(_SEAM_EXTENT_NORMALIZATION)
+
+
+def normalize_api_key_state() -> None:
+    """Clear key expiry and epoch bumps so downgrades can cross 0029."""
+    _execute_normalization(_API_KEY_STATE_NORMALIZATION)
+
+
 def run_alembic(
-    *args: str, extra_env: dict | None = None
+    *args: str, extra_env: dict | None = None, normalize: bool = True
 ) -> subprocess.CompletedProcess:
     """Run an alembic command via subprocess against the per-worker TEST DB.
 
@@ -88,16 +153,21 @@ def run_alembic(
     SHARED main DB (``postgres`` on CI), which would corrupt sibling workers
     and the drift check.
 
-    Every ``downgrade`` is preceded by ``normalize_seam_extents()`` — with the
-    current head at/above 0030, even a plain ``downgrade -1`` crosses the
-    refuse-to-coerce guard on its first step, so the normalization runs
-    unconditionally rather than parsing the revision graph (it is idempotent
-    and free when no seam extents exist).
+    Every ``downgrade`` is preceded by ``normalize_seam_extents()`` and
+    ``normalize_api_key_state()`` — with the current head at/above 0030, even a
+    plain ``downgrade -1`` crosses a refuse-to-coerce guard on its first step,
+    so the normalizations run unconditionally rather than parsing the revision
+    graph (both are idempotent and free when the state they clear is absent).
+
+    ``normalize=False`` skips them. It exists for the tests that assert a guard
+    actually FIRES; nothing else should pass it, because skipping the
+    normalization is how the cross-file failures in #933 happened.
     """
     from app.core.config import settings
 
-    if args and args[0] == "downgrade":
+    if normalize and args and args[0] == "downgrade":
         normalize_seam_extents()
+        normalize_api_key_state()
 
     env = os.environ.copy()
     env["PYTHONPATH"] = str(_BACKEND_DIR)

--- a/backend/tests/test_alembic_helpers.py
+++ b/backend/tests/test_alembic_helpers.py
@@ -1,24 +1,36 @@
 """Tests for the shared alembic runner (fix(#933)).
 
-Proves the seam-extent normalization does its one job: a committed
-antimeridian-crossing (MULTIPOLYGON) ``spatial_extent`` no longer makes a
-downgrade past ``0030_records_spatial_extent_type`` fail for whichever
-unrelated migration test happens to share the xdist worker.
+Proves each normalization does its one job, so that committed state no longer
+makes a downgrade past a refuse-to-coerce migration fail for whichever
+unrelated migration test happens to share the xdist worker:
+
+- an antimeridian-crossing (MULTIPOLYGON) ``spatial_extent`` past
+  ``0030_records_spatial_extent_type``
+- an expiring API key or a bumped ``key_epoch`` past
+  ``0029_api_key_hardening`` (fix(#1016))
+
+The 0029 tests also cover the guard itself: that it fires on a database
+holding that state, and that a clean database still downgrades.
 """
 
 from __future__ import annotations
 
 import uuid
+from datetime import datetime, timedelta, timezone
 from importlib.metadata import entry_points
 from pathlib import Path
 
 import pytest
 from sqlalchemy import text
 
-from tests.alembic_helpers import run_alembic
+from tests.alembic_helpers import normalize_seam_extents, run_alembic
 from tests.factories import create_dataset, get_user_id
 
 pytestmark = pytest.mark.anyio
+
+# 0029 is the revision under test; downgrading TO it leaves it applied, so the
+# guard must be crossed by going one step further back.
+_PRE_API_KEY_HARDENING = "0028_oauth_email_verified_backfill"
 
 
 def _enterprise_migrations_present() -> bool:
@@ -82,3 +94,131 @@ async def test_seam_extent_no_longer_breaks_downgrade_past_0030(test_db_session)
         )
     # The seeded row survives with its extent collapsed to the envelope —
     # acceptable loss in a test database, which is the helper's whole premise.
+
+
+async def _seed_expiring_key(session, *, epoch_bump: bool) -> None:
+    """Give the admin user an API key with an expiry, optionally bumping the
+    owner's key_epoch — the two states 0029's downgrade refuses to drop."""
+    admin_id = await get_user_id(session, "admin")
+    await session.execute(
+        text(
+            """
+            INSERT INTO catalog.api_keys
+                (user_id, key_hash, name, is_active, expires_at, key_epoch)
+            SELECT :uid, :hash, :name, true, :expires, u.key_epoch
+            FROM catalog.users u WHERE u.id = :uid
+            """
+        ),
+        {
+            "uid": str(admin_id),
+            "hash": f"guard-{uuid.uuid4().hex}",
+            "name": "1016 guard fixture",
+            "expires": datetime.now(timezone.utc) + timedelta(days=1),
+        },
+    )
+    if epoch_bump:
+        await session.execute(
+            text("UPDATE catalog.users SET key_epoch = key_epoch + 1 WHERE id = :uid"),
+            {"uid": str(admin_id)},
+        )
+    await session.commit()
+
+
+@pytest.mark.skipif(
+    _enterprise_migrations_present(),
+    reason="OSS migration round-trip runs in the no-overlay migration job",
+)
+async def test_downgrade_past_0029_refuses_while_key_state_exists(test_db_session):
+    """fix(#1016): the guard fires, and its message is actionable.
+
+    ``normalize=False`` deliberately bypasses the runner's cleanup so the
+    refusal itself is what is under test.
+    """
+    await _seed_expiring_key(test_db_session, epoch_bump=True)
+    # 0030 is crossed on the way to 0029, so clear ITS state explicitly —
+    # otherwise a seam extent left by a sibling test in this worker would fire
+    # the wrong guard and the assertions below would test nothing.
+    normalize_seam_extents()
+
+    try:
+        down = run_alembic("downgrade", _PRE_API_KEY_HARDENING, normalize=False)
+        assert down.returncode != 0, (
+            "0029 downgraded with expiry and epoch state present — expired keys "
+            "would come back permanent and epoch-revoked keys would come back "
+            f"live:\nstdout:\n{down.stdout}\nstderr:\n{down.stderr}"
+        )
+        combined = down.stdout + down.stderr
+        # The counts, the inspection query, and the opt-out SQL: an operator
+        # hitting this on a DR day needs all three without leaving the terminal.
+        assert "API key(s) carry an expiry" in combined
+        assert "SELECT ak.id, ak.user_id, ak.expires_at" in combined
+        assert "DELETE FROM catalog.api_keys" in combined
+        assert "UPDATE catalog.users SET key_epoch = 1" in combined
+    finally:
+        up = run_alembic("upgrade", "head")
+        assert up.returncode == 0, (
+            f"re-upgrade to head failed:\nstdout:\n{up.stdout}\nstderr:\n{up.stderr}"
+        )
+
+
+@pytest.mark.skipif(
+    _enterprise_migrations_present(),
+    reason="OSS migration round-trip runs in the no-overlay migration job",
+)
+async def test_key_state_no_longer_breaks_downgrade_past_0029(test_db_session):
+    """fix(#1016): the same state, absorbed by the runner.
+
+    This is the #933 shape. ``test_api_key_auth.py`` commits both an expiring
+    key and a key_epoch bump and cleans up neither, so without the
+    normalization every downgrade crossing 0029 — six files, twenty-plus call
+    sites, all of them heading for 0004/0005/0009 — would fail depending only
+    on which xdist worker the auth suite landed on.
+    """
+    await _seed_expiring_key(test_db_session, epoch_bump=True)
+
+    try:
+        down = run_alembic("downgrade", _PRE_API_KEY_HARDENING)
+        assert down.returncode == 0, (
+            "downgrade past 0029 failed despite API-key state normalization:\n"
+            f"stdout:\n{down.stdout}\nstderr:\n{down.stderr}"
+        )
+    finally:
+        up = run_alembic("upgrade", "head")
+        assert up.returncode == 0, (
+            f"re-upgrade to head failed:\nstdout:\n{up.stdout}\nstderr:\n{up.stderr}"
+        )
+
+
+@pytest.mark.skipif(
+    _enterprise_migrations_present(),
+    reason="OSS migration round-trip runs in the no-overlay migration job",
+)
+async def test_clean_database_still_downgrades_past_0029(test_db_session):
+    """fix(#1016): the guard is state-dependent, not a blanket refusal.
+
+    Runs with ``normalize=False`` so nothing clears state on the way through —
+    a database that never held an expiry or an epoch bump downgrades on its
+    own, which is what makes the refusal above meaningful.
+    """
+    await test_db_session.execute(
+        text(
+            "UPDATE catalog.api_keys SET expires_at = NULL WHERE expires_at IS NOT NULL"
+        )
+    )
+    await test_db_session.execute(
+        text("UPDATE catalog.users SET key_epoch = 1 WHERE key_epoch <> 1")
+    )
+    await test_db_session.commit()
+    normalize_seam_extents()  # see the note in the refusal test above
+
+    try:
+        down = run_alembic("downgrade", _PRE_API_KEY_HARDENING, normalize=False)
+        assert down.returncode == 0, (
+            "a database with no key expiry or epoch state was still refused:\n"
+            f"stdout:\n{down.stdout}\nstderr:\n{down.stderr}"
+        )
+    finally:
+        up = run_alembic("upgrade", "head")
+        assert up.returncode == 0, (
+            f"re-upgrade to head failed:\nstdout:\n{up.stdout}\nstderr:\n{up.stderr}"
+        )


### PR DESCRIPTION
`0029_api_key_hardening` downgraded by dropping three columns with no guard. Both dropped columns carry security state, and losing them fails in the unsafe direction:

- with no `api_keys.expires_at`, key resolution has no expiry to check, so a time-limited key that has already passed its expiry comes back as a permanent key
- with no `key_epoch` pair, the revocation comparison (#821) disappears, so keys revoked by an epoch bump come back live

Neither raises. The downgrade succeeds, the schema is valid, and the deployment is quietly less secure than the operator believes — on the one documented procedure that reaches this migration (`alembic downgrade 0016`, the multi-tenant fresh-cluster DR path), run on someone's worst day.

## The guard

Mirrors 0030's refusal: count first, then raise a `RuntimeError` naming the counts, the query that lists the exact keys that would come back live, and the SQL that revokes them. It refuses when any `catalog.api_keys` row has a non-null `expires_at`, or any `catalog.users` row has `key_epoch > 1`. The second is the right coarse test because `api_keys.key_epoch` is a mint-time snapshot of the owner's value: if no owner has ever been bumped past the default of 1, no revocation state exists to lose.

The remediation offered is the one an operator most likely wants — delete the affected keys rather than accept their resurrection — plus the `UPDATE catalog.users SET key_epoch = 1` needed to clear the second condition, since deleting keys alone leaves the guard still refusing.

## Treatment in `alembic_helpers.py`: auto-clean, and why

The issue asked for this to be decided in the PR. **Auto-cleaned, alongside 0030 — not documented-only alongside 0010/0005.**

Those two are semantic test state, created by the single test that cares about them. This is not. `test_api_key_auth.py` commits both an expiring key (`test_api_key_with_future_expiry_accepted_and_surfaced`) and a `key_epoch` bump (`test_stale_key_epoch_api_key_rejected`) as ordinary auth coverage, cleans up neither, and has no relationship to migrations. Meanwhile more than twenty downgrade call sites across six files cross 0029 on their way to 0004/0005/0009.

Leaving it documented would reproduce #933 exactly, so I measured it rather than arguing it. With the normalization disabled:

```
$ uv run pytest tests/test_api_key_auth.py tests/test_dormant_tenancy_migration_roundtrip.py
AssertionError: setup downgrade to 0005 failed: RuntimeError: 2 API key(s) carry an
expiry and 4 user(s) have had their key_epoch bumped; 6 key(s) would come back live
or permanent if these columns were dropped.
```

A file with nothing to do with API keys, failing on which xdist worker the auth suite landed on. That is the failure mode #933 existed to end.

The normalization clears the state rather than deleting rows (a test database's keys are fixture noise, and there is no need to destroy rows a sibling test may still read), and each column is guarded independently so it is a no-op at any schema revision.

`run_alembic` gained `normalize=False` for the tests that assert a guard actually fires. Nothing else should pass it, and the docstring says so.

## Tests

Three new tests in `test_alembic_helpers.py`:

- the guard fires on a database holding an expiring key and a bumped epoch, and the message carries the counts, the inspection query, and the opt-out SQL
- the same state is absorbed by the runner (the #933 shape)
- a clean database still downgrades — run with `normalize=False` so nothing clears state on the way through, which is what makes the refusal meaningful

The two `normalize=False` tests call `normalize_seam_extents()` explicitly first: 0030 is crossed on the way to 0029, so a seam extent left by a sibling test in the same worker would fire the wrong guard and the assertions would test nothing.

## Schema impact

Downgrade-path only. No column, index, or constraint changes; `alembic check` reports no new upgrade operations. The upgrade path is untouched.

## Verification

```
cd backend && uv run pytest tests/test_alembic_helpers.py -v                       # 4 passed
cd backend && uv run pytest tests/test_api_key_auth.py \
    tests/test_dormant_tenancy_migration_roundtrip.py                              # 34 passed
cd backend && PYTHONPATH=. uv run alembic check                                    # No new upgrade operations detected
cd backend && uv run ruff check . && uv run ruff format --check .                   # clean
```

Closes #1016