### PR TITLE
fix(sandbox): admit the canonical geodesic buffer by whole-template match

### DIFF
--- a/backend/app/platform/analysis_sql.py
+++ b/backend/app/platform/analysis_sql.py
@@ -238,6 +238,17 @@ def render_dateline_safe(geom_expr: str, *, alias: str = "_dl") -> str:
     )
 
 
+# fix(#1001): this function has a SECOND consumer that most edits here will
+# not have in mind. The NL->SQL prompt embeds its output verbatim
+# (``processing/ai/sql_generator.py`` renders it at import time), and the SQL
+# sandbox admits the sixteen amplification-prone functions below ONLY inside a
+# subtree that is exactly what this renderer emits — ``_matches_canonical_buffer``
+# in ``platform/sandbox/validator.py`` re-renders the template and compares.
+# The match follows a shape change automatically, because both sides call this
+# function; what it cannot follow is a NEW function name that is itself unsafe
+# outside the template, since the exemption would then cover it. Weigh that
+# before adding one, and keep the default ``alias`` — a buffer rendered under
+# any other alias fails the match and the sandbox refuses it.
 def render_geodesic_buffer(
     geom_expr: str, distance: float, *, alias: str = "_pb"
 ) -> str:

--- a/backend/app/platform/sandbox/validator.py
+++ b/backend/app/platform/sandbox/validator.py
@@ -283,6 +283,18 @@ _ALLOWED_POSTGIS_FUNCTIONS: frozenset[str] = frozenset(
 )
 
 
+def _func_name(func: exp.Func) -> str:
+    """Canonical lowercase name of a function node.
+
+    Anonymous nodes carry the raw SQL identifier; named Func subclasses carry
+    sqlglot's own name, which may differ from the SQL keyword (see the
+    _ALLOWED_FUNCTIONS docs).
+    """
+    if isinstance(func, exp.Anonymous):
+        return func.name.lower() if hasattr(func, "name") else ""
+    return func.sql_name().lower() if hasattr(func, "sql_name") else ""
+
+
 def _validate_function_cost(func: exp.Func, fn_name: str, sql: str) -> None:
     """Reject function arguments that can amplify a one-row query into a DoS."""
     if fn_name in {"st_collect", "st_union"} and len(func.expressions) < 2:
@@ -296,6 +308,195 @@ def _validate_function_cost(func: exp.Func, fn_name: str, sql: str) -> None:
         raise SandboxError(
             "invalid_query", "Query uses an unbounded geometry complexity option"
         )
+
+
+# ---------------------------------------------------------------------------
+# fix(#1001): the canonical geodesic buffer, recognized whole.
+#
+# The NL->SQL prompt mandates render_geodesic_buffer's output verbatim for
+# metric buffers (sql_generator.py renders it at import time), and that
+# expression needs sixteen function names the fail-closed allowlist does not
+# carry — the banding, seam-splitting and dissolve machinery. So every buffer
+# question in the NL->SQL surface was refused.
+#
+# Admitting those names globally is not an option: st_dump, st_dumpsegments,
+# st_segmentize and generate_series are the row/vertex amplification classes
+# SEC-025 exists to keep out. #994 tried admitting them and bounding them with
+# per-call cost guards, and #1002 tried three rounds of recalibrating those
+# guards; each drew a real P1. The last one settles it — the buffer segmentizes
+# an alias, `_pb_d0.c0`, several derived levels from its input, so proving a
+# call's argument is safe and admitting the canonical buffer are contradictory
+# under any argument-inspection scheme. That is data-flow analysis, not a
+# predicate to tighten.
+#
+# So nothing is admitted per call. A subtree is exempted only when it is
+# EXACTLY what render_geodesic_buffer emits around its own input:
+#
+#   1. extract loosely — the input expression from the renderer's `AS g
+#      OFFSET 0` fence, the distance from its ST_Buffer call;
+#   2. verify exactly — re-render the template around that same input and
+#      require the two ASTs to be equal.
+#
+# Extraction may be wrong; verification cannot be, because a mismatch simply
+# fails closed. The scaffold's own literals (segmentize lengths, band widths,
+# ST_WrapX bounds) come from the reference render, so they cannot be chosen by
+# the caller, and the alias-rebinding attack (`FROM data.cities AS _pb_c(c)`)
+# cannot match because the template includes the derived-table scaffold that
+# binds those aliases.
+#
+# The input expression itself is NOT exempt. It is the model's, so its
+# functions, its cost guards and its tables are all validated normally.
+#
+# Both sides render through the same render_geodesic_buffer, so a renderer
+# change re-admits its own new shape and nothing else. That is the coupling
+# this whole incident was about, and it now runs in one direction only —
+# analysis_sql carries a pointer back here.
+# ---------------------------------------------------------------------------
+
+# render_geodesic_buffer's default alias. A buffer rendered under any other
+# alias fails the match and stays refused; the prompt only renders the default.
+_BUFFER_INPUT_ALIAS = "_pb"
+
+# Bound on how many subtrees may be re-rendered per statement. Each attempt
+# renders ~4 KB of SQL and parses it — measured at ~16 ms — so an adversarial
+# statement full of buffer-shaped scaffolds must not turn the validator itself
+# into the DoS. Eight covers a query buffering several layers, and nested
+# buffers well past anything the prompt teaches. Past the cap no further
+# exemption is granted, which fails closed.
+_MAX_BUFFER_MATCH_ATTEMPTS = 8
+
+
+def _numeric_normalized_sql(node: exp.Expression) -> str:
+    """Render `node`, with every numeric literal reduced to its float value.
+
+    `50000`, `50000.0` and `5e4` are the same buffer distance, and the model
+    may write any of them where the reference render writes one. Comparing
+    numeric literals by VALUE keeps the match from turning on spelling, while
+    every scaffold constant still has to agree exactly.
+    """
+    copy = node.copy()
+    for literal in copy.find_all(exp.Literal):
+        if not literal.is_number:
+            continue
+        try:
+            literal.set("this", repr(float(literal.this)))
+        except (TypeError, ValueError):  # pragma: no cover - defensive
+            pass
+    return copy.sql(dialect="postgres")
+
+
+def _buffer_shaped_root(node: exp.Expression) -> exp.Subquery | None:
+    """Cheap O(1) test for the renderer's outermost shape.
+
+    Only a node that passes this is worth extracting from, which keeps the
+    scan off every subquery in the statement.
+    """
+    if not isinstance(node, exp.Subquery) or node.alias:
+        return None
+    inner = node.this
+    if not isinstance(inner, exp.Select) or len(inner.expressions) != 1:
+        return None
+    if not isinstance(inner.expressions[0], exp.Case):
+        return None
+    # Direct children only, never find(): a nested FROM deeper in the tree must
+    # not stand in for this SELECT's own. The arg KEY for it has moved between
+    # sqlglot releases ("from" -> "from_"), so iterate rather than index.
+    source = next(
+        (child for child in inner.iter_expressions() if isinstance(child, exp.From)),
+        None,
+    )
+    fenced = source.this if source is not None else None
+    if not isinstance(fenced, exp.Subquery) or fenced.alias != _BUFFER_INPUT_ALIAS:
+        return None
+    return fenced
+
+
+def _extract_buffer_input(node: exp.Expression) -> tuple[exp.Expression, float] | None:
+    """Pull the input expression and the distance out of a buffer-shaped node.
+
+    Deliberately loose. Anything it gets wrong is caught by the exact
+    re-render in `_matches_canonical_buffer`.
+    """
+    fenced = _buffer_shaped_root(node)
+    if fenced is None:
+        return None
+    fenced_select = fenced.this
+    if not isinstance(fenced_select, exp.Select) or len(fenced_select.expressions) != 1:
+        return None
+    projection = fenced_select.expressions[0]
+    if not isinstance(projection, exp.Alias) or projection.alias != "g":
+        return None
+
+    for func in node.find_all(exp.Func):
+        if _func_name(func) != "st_buffer":
+            continue
+        args = func.expressions or list(func.args.values())
+        if len(args) < 2:
+            continue
+        distance = args[1]
+        if not isinstance(distance, exp.Literal) or not distance.is_number:
+            continue
+        try:
+            return projection.this, float(distance.this)
+        except (TypeError, ValueError):  # pragma: no cover - defensive
+            return None
+    return None
+
+
+def _matches_canonical_buffer(node: exp.Expression) -> exp.Expression | None:
+    """Return the buffer's input expression when `node` is the canonical buffer.
+
+    Returns None otherwise, including on any renderer or sqlglot failure, so
+    drift refuses the buffer rather than admitting an unverified subtree.
+    """
+    extracted = _extract_buffer_input(node)
+    if extracted is None:
+        return None
+    geom, distance = extracted
+
+    # Function-level import: keeps the sandbox importable without pulling the
+    # analysis renderer into contexts that never validate SQL.
+    from app.platform.analysis_sql import render_geodesic_buffer
+
+    # A renderer or sqlglot drift returns None below, which grants no
+    # exemption and so refuses the buffer — the failure direction that matters.
+    try:
+        rendered = render_geodesic_buffer(geom.sql(dialect="postgres"), distance)
+        expected = sqlglot.parse_one(rendered, dialect="postgres")
+    except Exception:  # broad: drift must fail CLOSED, never crash validation
+        return None
+    if expected is None:
+        return None
+    if _numeric_normalized_sql(expected) != _numeric_normalized_sql(node):
+        return None
+    return geom
+
+
+def _canonical_buffer_exempt_ids(stmt: exp.Expression) -> set[int]:
+    """Ids of the AST nodes that sit inside a verified canonical buffer.
+
+    Ids are safe as keys here because every node counted is reachable from
+    `stmt`, so it stays alive — and therefore uniquely addressed — for the
+    whole validation.
+    """
+    exempt: set[int] = set()
+    attempts = 0
+    for node in stmt.find_all(exp.Subquery):
+        if _buffer_shaped_root(node) is None:
+            continue
+        if attempts >= _MAX_BUFFER_MATCH_ATTEMPTS:
+            break
+        attempts += 1
+        geom = _matches_canonical_buffer(node)
+        if geom is None:
+            continue
+        # The input expression is the model's, so it keeps every check. Only
+        # the scaffold the renderer produced around it is exempt.
+        caller_supplied = {id(inner) for inner in geom.walk()}
+        for inner in node.walk():
+            if id(inner) not in caller_supplied:
+                exempt.add(id(inner))
+    return exempt
 
 
 def _reject_recursive_cte(stmt: exp.Expression, sql: str) -> None:
@@ -317,11 +518,13 @@ def _check_function_allowlist(stmt: exp.Expression, sql: str) -> None:
 
     Then apply fail-closed logic (order matters):
       1. BLOCKED  → always reject (defense-in-depth; checked before allowlist)
-      2. "st_" name → require the prompt-derived PostGIS allowlist
-      3. Other name → require _ALLOWED_FUNCTIONS
-      4. Allowed spatial functions → reject unbounded aggregate/complexity forms
-      5. Otherwise → reject (fail-closed)
+      2. Inside a verified canonical buffer → skip 3-5 (fix(#1001))
+      3. "st_" name → require the prompt-derived PostGIS allowlist
+      4. Other name → require _ALLOWED_FUNCTIONS
+      5. Allowed spatial functions → reject unbounded aggregate/complexity forms
+      6. Otherwise → reject (fail-closed)
     """
+    buffer_scaffold = _canonical_buffer_exempt_ids(stmt)
     for func in stmt.find_all(exp.Func):
         # fix(#538): sqlglot models AND/OR (exp.Connector) as Func subclasses,
         # so any compound condition (WHERE x AND y, JOIN ... ON a AND b,
@@ -338,14 +541,19 @@ def _check_function_allowlist(stmt: exp.Expression, sql: str) -> None:
         # is still caught below.
         if isinstance(func, exp.Exists):
             continue
-        if isinstance(func, exp.Anonymous):
-            fn_name = func.name.lower() if hasattr(func, "name") else ""
-        else:
-            fn_name = func.sql_name().lower() if hasattr(func, "sql_name") else ""
+        fn_name = _func_name(func)
 
         if fn_name in _BLOCKED_FUNCTIONS:
             logger.info("sandbox.blocked_function", sql=sql, function=fn_name)
             raise SandboxError("invalid_query", "Query uses a disallowed function")
+
+        # fix(#1001): the sixteen names the canonical geodesic buffer needs are
+        # admitted here and nowhere else. The BLOCKED check above still runs —
+        # nothing in the rendered scaffold can be a blocked function, and
+        # keeping the check unconditional means a renderer change could never
+        # smuggle one in.
+        if id(func) in buffer_scaffold:
+            continue
 
         if fn_name.startswith("st_"):
             if fn_name not in _ALLOWED_POSTGIS_FUNCTIONS:

--- a/backend/app/platform/sandbox/validator.py
+++ b/backend/app/platform/sandbox/validator.py
@@ -443,6 +443,47 @@ def _extract_buffer_input(node: exp.Expression) -> tuple[exp.Expression, float] 
     return None
 
 
+def _is_bounded_geometry_source(node: exp.Expression) -> bool:
+    """Whether `node` can only be a stored geometry, never a manufactured one.
+
+    fix(#1001 codex r1): the rendered scaffold assumes its input is a 4326
+    geometry, so its planar span is at most 360 degrees. It slices that span
+    into ~6-degree bands with `generate_series` and densifies it with
+    `ST_Segmentize`, both of which scale with the span. A stored `geom_4326`
+    column satisfies the assumption by construction. An arbitrary expression
+    does not, and two shapes reach past it without tripping any existing
+    guard:
+
+      ST_Buffer(ST_SetSRID(ST_MakePoint(0,0),4326), 1000000000)
+          a PLANAR buffer, so the radius is DEGREES — a two-billion-degree
+          span, hundreds of millions of bands, billions of vertices;
+      ST_Transform(geom_4326, 3857)
+          hands the scaffold metres with no large literal at all, so a
+          40-million-unit span segmentized at 0.1 is the same explosion.
+
+    Deciding this by inspecting the expression's functions is the units
+    problem #1002 died on, so the rule is structural instead: a bare column
+    reference, or a scalar subquery projecting one. Both shapes the prompt
+    teaches qualify — the `<GEOM>` template is substituted with a column, and
+    the worked example is `(SELECT geom_4326 FROM data.us_state_capitals
+    WHERE name = 'Denver')`. Everything else is refused, which is the right
+    failure direction: a refused buffer question beats an unbounded one.
+
+    The subquery's other clauses are not exempted by this; they stay under the
+    ordinary function allowlist and table checks like any other subquery.
+    """
+    if isinstance(node, exp.Column):
+        return True
+    if isinstance(node, exp.Subquery):
+        inner = node.this
+        if isinstance(inner, exp.Select) and len(inner.expressions) == 1:
+            projection = inner.expressions[0]
+            if isinstance(projection, exp.Alias):
+                projection = projection.this
+            return isinstance(projection, exp.Column)
+    return False
+
+
 def _matches_canonical_buffer(node: exp.Expression) -> exp.Expression | None:
     """Return the buffer's input expression when `node` is the canonical buffer.
 
@@ -489,6 +530,11 @@ def _canonical_buffer_exempt_ids(stmt: exp.Expression) -> set[int]:
         attempts += 1
         geom = _matches_canonical_buffer(node)
         if geom is None:
+            continue
+        # Matching the template is not sufficient on its own: the scaffold's
+        # cost is a function of its INPUT's planar span, so the input has to
+        # be a stored geometry rather than one the caller manufactured.
+        if not _is_bounded_geometry_source(geom):
             continue
         # The input expression is the model's, so it keeps every check. Only
         # the scaffold the renderer produced around it is exempt.

--- a/backend/app/platform/sandbox/validator.py
+++ b/backend/app/platform/sandbox/validator.py
@@ -443,7 +443,91 @@ def _extract_buffer_input(node: exp.Expression) -> tuple[exp.Expression, float] 
     return None
 
 
-def _is_bounded_geometry_source(node: exp.Expression) -> bool:
+# How many alias hops a buffer input's lineage may take before it is refused.
+# The prompt teaches zero or one; anything deeper is not a shape worth
+# resolving, and stopping is a refusal, not an admission.
+_MAX_LINEAGE_HOPS = 4
+
+
+def _named_sources(scope: exp.Expression, name: str) -> list[exp.Expression]:
+    """Sources in `scope` bound to `name` — a base table, CTE, or subquery.
+
+    A schema-less `exp.Table` is a REFERENCE to a CTE, not a base table (the
+    validator rejects every real-table schema but `data` elsewhere), so it is
+    skipped: counting `FROM x` alongside the CTE that defines `x` would make
+    every CTE name look ambiguous.
+    """
+    matches: list[exp.Expression] = []
+    for cte in scope.find_all(exp.CTE):
+        if cte.alias == name:
+            matches.append(cte.this)
+    for table in scope.find_all(exp.Table):
+        if table.db and (table.alias or table.name) == name:
+            matches.append(table)
+    for sub in scope.find_all(exp.Subquery):
+        if sub.alias == name:
+            matches.append(sub.this)
+    return matches
+
+
+def _sole_base_table(scope: exp.Expression) -> exp.Table | None:
+    """The one base table this scope's OWN from/join clause binds.
+
+    Direct sources only. The buffer scaffold is itself a stack of aliased
+    derived tables, so a `find_all` here would never see a single source.
+    """
+    if not isinstance(scope, exp.Select):
+        return None
+    sources: list[exp.Expression] = []
+    for child in scope.iter_expressions():
+        if isinstance(child, (exp.From, exp.Join)):
+            sources.append(child.this)
+    if len(sources) != 1:
+        return None
+    source = sources[0]
+    return source if isinstance(source, exp.Table) and source.db else None
+
+
+def _resolves_to_stored_column(scope: exp.Expression, column: exp.Column) -> bool:
+    """Whether `column` traces back to a column of a base table.
+
+    Fails closed on everything it cannot decide: an unknown qualifier, a name
+    bound in more than one place, a projection that is an expression rather
+    than a column, or a lineage deeper than `_MAX_LINEAGE_HOPS`.
+    """
+    for _ in range(_MAX_LINEAGE_HOPS):
+        qualifier, name = column.table, column.name
+        if not qualifier:
+            # Unqualified: only safe when the scope has exactly one base table
+            # and no alias indirection that could bind the name elsewhere.
+            return _sole_base_table(scope) is not None
+        sources = _named_sources(scope, qualifier)
+        if len(sources) != 1:
+            return False
+        source = sources[0]
+        if isinstance(source, exp.Table):
+            return True
+        if not isinstance(source, exp.Select):
+            return False
+        projection = next(
+            (
+                expr
+                for expr in source.expressions
+                if (expr.alias if isinstance(expr, exp.Alias) else expr.name) == name
+            ),
+            None,
+        )
+        if projection is None:
+            return False
+        if isinstance(projection, exp.Alias):
+            projection = projection.this
+        if not isinstance(projection, exp.Column):
+            return False
+        column, scope = projection, source
+    return False
+
+
+def _is_bounded_geometry_source(stmt: exp.Expression, node: exp.Expression) -> bool:
     """Whether `node` can only be a stored geometry, never a manufactured one.
 
     fix(#1001 codex r1): the rendered scaffold assumes its input is a 4326
@@ -469,18 +553,37 @@ def _is_bounded_geometry_source(node: exp.Expression) -> bool:
     WHERE name = 'Denver')`. Everything else is refused, which is the right
     failure direction: a refused buffer question beats an unbounded one.
 
+    fix(#1001 codex r2): a bare column is not enough on its own, because an
+    alias launders the expression back in —
+
+        WITH x AS (SELECT ST_Transform(geom_4326, 3857) AS g FROM data.cities)
+        SELECT <buffer of x.g> FROM x
+
+    puts a projected geometry behind a name that satisfies the column test,
+    while the `ST_Transform` sits OUTSIDE the exempt subtree and so passes the
+    allowlist on its own. So the column's lineage is resolved through CTE and
+    derived-table projections until it reaches a base table, and anything that
+    cannot be resolved that way is refused.
+
     The subquery's other clauses are not exempted by this; they stay under the
     ordinary function allowlist and table checks like any other subquery.
     """
     if isinstance(node, exp.Column):
-        return True
+        return _resolves_to_stored_column(stmt, node)
     if isinstance(node, exp.Subquery):
         inner = node.this
         if isinstance(inner, exp.Select) and len(inner.expressions) == 1:
             projection = inner.expressions[0]
             if isinstance(projection, exp.Alias):
                 projection = projection.this
-            return isinstance(projection, exp.Column)
+            if not isinstance(projection, exp.Column):
+                return False
+            # Resolve within the subquery: its own FROM is what binds the
+            # projection, and only falls back to the outer statement for a
+            # correlated reference.
+            return _resolves_to_stored_column(
+                inner, projection
+            ) or _resolves_to_stored_column(stmt, projection)
     return False
 
 
@@ -534,7 +637,7 @@ def _canonical_buffer_exempt_ids(stmt: exp.Expression) -> set[int]:
         # Matching the template is not sufficient on its own: the scaffold's
         # cost is a function of its INPUT's planar span, so the input has to
         # be a stored geometry rather than one the caller manufactured.
-        if not _is_bounded_geometry_source(geom):
+        if not _is_bounded_geometry_source(stmt, geom):
             continue
         # The input expression is the model's, so it keeps every check. Only
         # the scaffold the renderer produced around it is exempt.

--- a/backend/app/platform/sandbox/validator.py
+++ b/backend/app/platform/sandbox/validator.py
@@ -449,21 +449,40 @@ def _extract_buffer_input(node: exp.Expression) -> tuple[exp.Expression, float] 
 _MAX_LINEAGE_HOPS = 4
 
 
+# The managed 4326 geometry column. Ingest keeps a source dataset's ORIGINAL
+# `geom` in whatever CRS it arrived in and adds this one alongside
+# (`processing/ingest/service.py` probes for both), so "reached a base table"
+# is not the same as "reached a bounded geometry": a Web Mercator `s.geom` has
+# a 40-million-unit span and drives the scaffold's six-unit bands and 0.1-unit
+# segmentization exactly like a reprojection does (fix(#1001 codex r3)).
+_MANAGED_GEOMETRY_COLUMN = "geom_4326"
+
+
 def _named_sources(scope: exp.Expression, name: str) -> list[exp.Expression]:
     """Sources in `scope` bound to `name` — a base table, CTE, or subquery.
 
-    A schema-less `exp.Table` is a REFERENCE to a CTE, not a base table (the
-    validator rejects every real-table schema but `data` elsewhere), so it is
-    skipped: counting `FROM x` alongside the CTE that defines `x` would make
-    every CTE name look ambiguous.
+    Bindings only, never definitions. A CTE is reachable solely through a
+    from/join reference to it, and that reference is what carries the binding
+    name: `FROM bad AS x` binds `x` to `bad`, whatever a CTE literally named
+    `x` may also define. Scanning CTE definitions directly missed that
+    shadowing (fix(#1001 codex r3)) and double-counted the plain `FROM x` case
+    against its own definition.
     """
     matches: list[exp.Expression] = []
-    for cte in scope.find_all(exp.CTE):
-        if cte.alias == name:
-            matches.append(cte.this)
     for table in scope.find_all(exp.Table):
-        if table.db and (table.alias or table.name) == name:
-            matches.append(table)
+        if (table.alias or table.name) != name:
+            continue
+        if table.db:
+            matches.append(table)  # a real table in a real schema
+            continue
+        # Schema-less: a reference to a CTE, resolved by the CTE's own name
+        # rather than by the binding name.
+        definitions = [
+            cte.this for cte in scope.find_all(exp.CTE) if cte.alias == table.name
+        ]
+        if len(definitions) != 1:
+            return []  # unresolvable -> caller fails closed
+        matches.append(definitions[0])
     for sub in scope.find_all(exp.Subquery):
         if sub.alias == name:
             matches.append(sub.this)
@@ -500,13 +519,17 @@ def _resolves_to_stored_column(scope: exp.Expression, column: exp.Column) -> boo
         if not qualifier:
             # Unqualified: only safe when the scope has exactly one base table
             # and no alias indirection that could bind the name elsewhere.
-            return _sole_base_table(scope) is not None
+            return (
+                _sole_base_table(scope) is not None and name == _MANAGED_GEOMETRY_COLUMN
+            )
         sources = _named_sources(scope, qualifier)
         if len(sources) != 1:
             return False
         source = sources[0]
         if isinstance(source, exp.Table):
-            return True
+            # Terminal: a base-table column only counts as bounded when it is
+            # the managed 4326 column.
+            return name == _MANAGED_GEOMETRY_COLUMN
         if not isinstance(source, exp.Select):
             return False
         projection = next(

--- a/backend/app/platform/sandbox/validator.py
+++ b/backend/app/platform/sandbox/validator.py
@@ -458,95 +458,201 @@ _MAX_LINEAGE_HOPS = 4
 _MANAGED_GEOMETRY_COLUMN = "geom_4326"
 
 
-def _named_sources(scope: exp.Expression, name: str) -> list[exp.Expression]:
-    """Sources in `scope` bound to `name` — a base table, CTE, or subquery.
+def _own_sources(select: exp.Select) -> list[exp.Expression]:
+    """The from/join sources this SELECT itself binds.
 
-    Bindings only, never definitions. A CTE is reachable solely through a
-    from/join reference to it, and that reference is what carries the binding
-    name: `FROM bad AS x` binds `x` to `bad`, whatever a CTE literally named
-    `x` may also define. Scanning CTE definitions directly missed that
-    shadowing (fix(#1001 codex r3)) and double-counted the plain `FROM x` case
-    against its own definition.
+    Direct children only. `find_all` here would cross into every nested
+    scope, and the buffer scaffold is itself a stack of aliased derived
+    tables, so a subtree walk never sees a single source (fix(#1001 codex
+    r4)).
     """
-    matches: list[exp.Expression] = []
-    for table in scope.find_all(exp.Table):
-        if (table.alias or table.name) != name:
-            continue
-        if table.db:
-            matches.append(table)  # a real table in a real schema
-            continue
-        # Schema-less: a reference to a CTE, resolved by the CTE's own name
-        # rather than by the binding name.
-        definitions = [
-            cte.this for cte in scope.find_all(exp.CTE) if cte.alias == table.name
-        ]
-        if len(definitions) != 1:
-            return []  # unresolvable -> caller fails closed
-        matches.append(definitions[0])
-    for sub in scope.find_all(exp.Subquery):
-        if sub.alias == name:
-            matches.append(sub.this)
-    return matches
+    return [
+        child.this
+        for child in select.iter_expressions()
+        if isinstance(child, (exp.From, exp.Join))
+    ]
 
 
-def _sole_base_table(scope: exp.Expression) -> exp.Table | None:
-    """The one base table this scope's OWN from/join clause binds.
+def _binding_name(source: exp.Expression) -> str:
+    """The name a from/join source is bound to in its scope."""
+    if isinstance(source, exp.Table):
+        return source.alias or source.name
+    if isinstance(source, exp.Subquery):
+        return source.alias
+    return ""
 
-    Direct sources only. The buffer scaffold is itself a stack of aliased
-    derived tables, so a `find_all` here would never see a single source.
+
+def _cte_definition(select: exp.Select, name: str) -> exp.Expression | None:
+    """Resolve a CTE `name` against the WITH clauses in scope.
+
+    Walks outward, because a CTE declared on an enclosing SELECT is visible to
+    every SELECT beneath it. Returns None when the name is unknown or declared
+    more than once, so the caller fails closed.
     """
-    if not isinstance(scope, exp.Select):
+    node: exp.Expression | None = select
+    while node is not None:
+        if isinstance(node, exp.Select):
+            with_clause = next(
+                (
+                    child
+                    for child in node.iter_expressions()
+                    if isinstance(child, exp.With)
+                ),
+                None,
+            )
+            if with_clause is not None:
+                matches = [
+                    cte.this for cte in with_clause.expressions if cte.alias == name
+                ]
+                if len(matches) == 1:
+                    return matches[0]
+                if matches:
+                    return None
+        node = node.parent
+    return None
+
+
+def _resolve_binding(
+    select: exp.Select, name: str
+) -> tuple[exp.Expression, exp.Select] | None:
+    """Find what `name` is bound to, searching outward from `select`.
+
+    Lexical scoping, not a whole-statement search. An unrelated nested query
+    that happens to reuse an alias must not make an outer binding look
+    ambiguous (fix(#1001 codex r4)); walking outward is also what resolves the
+    correlated reference the buffer's own input fence relies on, since
+    `(SELECT s.geom_4326 AS g OFFSET 0) AS _pb` has no FROM of its own.
+
+    Returns the bound source and the scope that bound it, or None when the
+    name is unknown or bound more than once in one scope.
+    """
+    node: exp.Expression | None = select
+    while node is not None:
+        if isinstance(node, exp.Select):
+            matches = [src for src in _own_sources(node) if _binding_name(src) == name]
+            if len(matches) > 1:
+                return None
+            if matches:
+                return matches[0], node
+        node = node.parent
+    return None
+
+
+def _sole_base_table(select: exp.Select) -> exp.Table | None:
+    """The one base table the nearest binding scope declares.
+
+    Walks outward past scopes that bind nothing and stops at the first that
+    binds anything, which is how PostgreSQL resolves an unqualified name.
+
+    Known limit, and a deliberate one. A bare `geom_4326` handed to the buffer
+    at the top level is REFUSED, because the scaffold interposes its own
+    `(SELECT ... OFFSET 0) AS _pb` scope between the column and the real FROM,
+    and deciding whether the name belongs to `_pb` or to the outer table needs
+    the table's column list. The prompt teaches the qualified form
+    (`s.geom_4326`) for exactly this reason, and the same bare name INSIDE its
+    own subquery — the prompt's other worked shape — resolves normally,
+    because that subquery binds the base table itself.
+    """
+    node: exp.Expression | None = select
+    while node is not None:
+        if isinstance(node, exp.Select):
+            sources = _own_sources(node)
+            if sources:
+                if len(sources) != 1:
+                    return None
+                source = sources[0]
+                return source if isinstance(source, exp.Table) and source.db else None
+        node = node.parent
+    return None
+
+
+def _declares_column_aliases(source: exp.Expression) -> bool:
+    """Whether a source renames its columns positionally.
+
+    fix(#1001 codex r4): `FROM data.cities AS s(gid, name, geom_4326)` binds
+    the name `geom_4326` to whatever the THIRD physical column happens to be,
+    which may well be a projected `geom`. Deciding that needs the table's real
+    column order, which the validator does not have, so a positional alias
+    list fails closed.
+    """
+    alias = source.args.get("alias")
+    return bool(alias is not None and getattr(alias, "columns", None))
+
+
+def _terminal_column_is_bounded(source: exp.Table, name: str) -> bool:
+    """Whether `name` on base table `source` is the managed 4326 column."""
+    if _declares_column_aliases(source):
+        return False
+    return name == _MANAGED_GEOMETRY_COLUMN
+
+
+def _derived_select(source: exp.Expression, owner: exp.Select) -> exp.Select | None:
+    """The SELECT behind a non-base-table source, or None when undecidable."""
+    if _declares_column_aliases(source):
         return None
-    sources: list[exp.Expression] = []
-    for child in scope.iter_expressions():
-        if isinstance(child, (exp.From, exp.Join)):
-            sources.append(child.this)
-    if len(sources) != 1:
-        return None
-    source = sources[0]
-    return source if isinstance(source, exp.Table) and source.db else None
+    if isinstance(source, exp.Table):
+        # Schema-less: a reference to a CTE, resolved by the CTE's OWN name
+        # rather than by the binding name — `FROM bad AS x` binds x to bad
+        # (fix(#1001 codex r3)).
+        definition = _cte_definition(owner, source.name)
+        return definition if isinstance(definition, exp.Select) else None
+    if isinstance(source, exp.Subquery) and isinstance(source.this, exp.Select):
+        return source.this
+    return None
+
+
+def _projected_column(select: exp.Select, name: str) -> exp.Column | None:
+    """The column `select` projects as `name`, or None when it is not one."""
+    projection = next(
+        (
+            expr
+            for expr in select.expressions
+            if (expr.alias if isinstance(expr, exp.Alias) else expr.name) == name
+        ),
+        None,
+    )
+    if isinstance(projection, exp.Alias):
+        projection = projection.this
+    return projection if isinstance(projection, exp.Column) else None
 
 
 def _resolves_to_stored_column(scope: exp.Expression, column: exp.Column) -> bool:
-    """Whether `column` traces back to a column of a base table.
+    """Whether `column` traces back to the managed geometry column of a table.
 
     Fails closed on everything it cannot decide: an unknown qualifier, a name
-    bound in more than one place, a projection that is an expression rather
-    than a column, or a lineage deeper than `_MAX_LINEAGE_HOPS`.
+    bound more than once in one scope, a positional column-alias list, a
+    projection that is an expression rather than a column, or a lineage deeper
+    than `_MAX_LINEAGE_HOPS`.
     """
+    select = column.find_ancestor(exp.Select)
+    if select is None:
+        select = scope if isinstance(scope, exp.Select) else None
+    if select is None:
+        return False
+
     for _ in range(_MAX_LINEAGE_HOPS):
         qualifier, name = column.table, column.name
         if not qualifier:
-            # Unqualified: only safe when the scope has exactly one base table
-            # and no alias indirection that could bind the name elsewhere.
-            return (
-                _sole_base_table(scope) is not None and name == _MANAGED_GEOMETRY_COLUMN
-            )
-        sources = _named_sources(scope, qualifier)
-        if len(sources) != 1:
+            # Unqualified: only safe when the nearest binding scope declares
+            # exactly one base table, so there is nothing else it could be.
+            table = _sole_base_table(select)
+            return table is not None and _terminal_column_is_bounded(table, name)
+
+        bound = _resolve_binding(select, qualifier)
+        if bound is None:
             return False
-        source = sources[0]
-        if isinstance(source, exp.Table):
-            # Terminal: a base-table column only counts as bounded when it is
-            # the managed 4326 column.
-            return name == _MANAGED_GEOMETRY_COLUMN
-        if not isinstance(source, exp.Select):
+        source, owner = bound
+
+        if isinstance(source, exp.Table) and source.db:
+            return _terminal_column_is_bounded(source, name)
+
+        inner = _derived_select(source, owner)
+        if inner is None:
             return False
-        projection = next(
-            (
-                expr
-                for expr in source.expressions
-                if (expr.alias if isinstance(expr, exp.Alias) else expr.name) == name
-            ),
-            None,
-        )
+        projection = _projected_column(inner, name)
         if projection is None:
             return False
-        if isinstance(projection, exp.Alias):
-            projection = projection.this
-        if not isinstance(projection, exp.Column):
-            return False
-        column, scope = projection, source
+        column, select = projection, inner
     return False
 
 

--- a/backend/app/processing/ai/sql_generator.py
+++ b/backend/app/processing/ai/sql_generator.py
@@ -271,7 +271,7 @@ When the buffer GEOMETRY itself is needed, a bare ST_Buffer(geom::geography, met
 
 It is long but mechanical: it slices wide inputs into per-projection bands, splits antimeridian-crossing output at +/-180, and dissolves the parts. Do not abbreviate it, do not re-derive it, and do not substitute the bare ST_Buffer form.
 
-<GEOM> must be a stored geometry: a column reference like s.geom_4326, or a subquery selecting one like (SELECT geom_4326 FROM data.t WHERE name = 'X'). A reprojection, a nested buffer, or a constructed geometry is refused, because the expression's cost scales with its input's extent and only a stored 4326 geometry is bounded. Buffer the column, then transform the result if you need another CRS.
+<GEOM> must be the managed geom_4326 column: a reference like s.geom_4326, or a subquery selecting one like (SELECT geom_4326 FROM data.t WHERE name = 'X'). A reprojection, a nested buffer, a constructed geometry, or a dataset's original geom column in another CRS is refused, because the expression's cost scales with its input's extent and only geom_4326 is bounded. Buffer geom_4326, then transform the result if you need another CRS.
 
 ## Unit Conversions (apply in SQL, not after)
 

--- a/backend/app/processing/ai/sql_generator.py
+++ b/backend/app/processing/ai/sql_generator.py
@@ -271,6 +271,8 @@ When the buffer GEOMETRY itself is needed, a bare ST_Buffer(geom::geography, met
 
 It is long but mechanical: it slices wide inputs into per-projection bands, splits antimeridian-crossing output at +/-180, and dissolves the parts. Do not abbreviate it, do not re-derive it, and do not substitute the bare ST_Buffer form.
 
+<GEOM> must be a stored geometry: a column reference like s.geom_4326, or a subquery selecting one like (SELECT geom_4326 FROM data.t WHERE name = 'X'). A reprojection, a nested buffer, or a constructed geometry is refused, because the expression's cost scales with its input's extent and only a stored 4326 geometry is bounded. Buffer the column, then transform the result if you need another CRS.
+
 ## Unit Conversions (apply in SQL, not after)
 
 - Square meters to acres:        ST_Area(geom_4326::geography) / 4046.8564224

--- a/backend/app/processing/ai/sql_generator.py
+++ b/backend/app/processing/ai/sql_generator.py
@@ -271,7 +271,7 @@ When the buffer GEOMETRY itself is needed, a bare ST_Buffer(geom::geography, met
 
 It is long but mechanical: it slices wide inputs into per-projection bands, splits antimeridian-crossing output at +/-180, and dissolves the parts. Do not abbreviate it, do not re-derive it, and do not substitute the bare ST_Buffer form.
 
-<GEOM> must be the managed geom_4326 column: a reference like s.geom_4326, or a subquery selecting one like (SELECT geom_4326 FROM data.t WHERE name = 'X'). A reprojection, a nested buffer, a constructed geometry, or a dataset's original geom column in another CRS is refused, because the expression's cost scales with its input's extent and only geom_4326 is bounded. Buffer geom_4326, then transform the result if you need another CRS.
+<GEOM> must be the managed geom_4326 column, and it must be QUALIFIED: a reference like s.geom_4326, or a subquery selecting one like (SELECT geom_4326 FROM data.t WHERE name = 'X'). A bare geom_4326 passed straight to the expression is refused. A reprojection, a nested buffer, a constructed geometry, or a dataset's original geom column in another CRS is refused, because the expression's cost scales with its input's extent and only geom_4326 is bounded. Buffer geom_4326, then transform the result if you need another CRS.
 
 ## Unit Conversions (apply in SQL, not after)
 

--- a/backend/tests/test_ai_sql_prompt_935.py
+++ b/backend/tests/test_ai_sql_prompt_935.py
@@ -149,6 +149,9 @@ def test_prompt_states_the_bounded_input_rule():
     the same prompt-vs-validator disagreement this whole chain is about.
     """
     assert "<GEOM> must be the managed geom_4326 column" in SQL_SYSTEM_PROMPT
+    # fix(#1001 codex r4): the scaffold interposes its own scope, so a bare
+    # top-level column is undecidable and refused. The prompt has to say so.
+    assert "it must be QUALIFIED" in SQL_SYSTEM_PROMPT
     assert "s.geom_4326" in SQL_SYSTEM_PROMPT
     assert "A reprojection, a nested buffer, a constructed geometry" in (
         SQL_SYSTEM_PROMPT

--- a/backend/tests/test_ai_sql_prompt_935.py
+++ b/backend/tests/test_ai_sql_prompt_935.py
@@ -8,8 +8,6 @@ which removes the drift class by construction; these tests pin the wiring so
 a rewrite of the prompt cannot quietly reintroduce a hand-written copy.
 """
 
-import pytest
-
 from app.platform.analysis_sql import render_geodesic_buffer
 from app.processing.ai.sql_generator import SQL_SYSTEM_PROMPT
 
@@ -70,28 +68,25 @@ def test_every_buffer_in_the_prompt_is_generated_or_marked_wrong():
         )
 
 
-def test_rendered_buffer_expression_is_refused_until_1001_lands():
-    """fix(#1001): INVERTED, deliberately, and it must go back to asserting
-    admission when #1001 lands.
+def test_rendered_buffer_expression_validates():
+    """fix(#1001): the prompt mandates render_geodesic_buffer's output, so the
+    sandbox has to admit what the model is taught to emit.
 
-    #935 codex r1 admitted the buffer's functions and bounded them with cost
-    guards. #990 then rebuilt the renderer, and those guards — written against
-    the older shape — rejected the very expression the prompt mandates. Three
-    attempts to recalibrate them each drew a real P1 (see #1002), because
-    proving a target's units and admitting the canonical buffer are
-    contradictory under any target-inspection scheme: the buffer segmentizes
-    an alias, `_pb_d0.c0`, several derived levels from its input.
+    This test spent one release inverted. #935 codex r1 admitted the buffer's
+    functions and bounded them with per-call cost guards; #990 then rebuilt the
+    renderer and those guards, written against the older shape, rejected the
+    very expression the prompt mandates. Three attempts to recalibrate them
+    each drew a real P1 (#1002), because proving a call's argument is safe and
+    admitting the canonical buffer are contradictory under any
+    argument-inspection scheme — the buffer segmentizes an alias, `_pb_d0.c0`,
+    several derived levels from its input. #1003 took the guards and the
+    allowlist entries back out, which left the prompt teaching an expression
+    the sandbox refused, and this test asserting that refusal.
 
-    So the allowlist entries and the guards both came out. That leaves the
-    prompt still teaching the SAFE banded expression, which the sandbox now
-    refuses outright. The refusal is the point: the alternative was reverting
-    the prompt too, and `st_buffer` is allowlisted independently, so the model
-    would have emitted the bare `ST_Buffer(geom::geography, N)::geometry` form
-    and it would have EXECUTED — returning the world-spanning polygon across
-    ±180° that #883/#900/#990 fixed. A refused buffer question beats a
-    silently wrong overlay and bbox.
+    #1001 admits it a different way: nothing is allowlisted per call, and a
+    subtree is exempted only when it is exactly what the renderer emits around
+    its own input. So this asserts admission again.
     """
-    from app.platform.sandbox.schemas import SandboxError
     from app.platform.sandbox.validator import validate_sql
 
     denver = render_geodesic_buffer(
@@ -99,20 +94,26 @@ def test_rendered_buffer_expression_is_refused_until_1001_lands():
         50000,
     )
     # The prompt's worked example, as the model would emit it.
-    with pytest.raises(SandboxError):
-        validate_sql(
-            "SELECT p.name AS park_name\n"
-            "FROM data.national_parks p\n"
-            f"WHERE ST_Intersects(p.geom_4326, {denver})\n"
-            "LIMIT 100"
-        )
+    result = validate_sql(
+        "SELECT p.name AS park_name\n"
+        "FROM data.national_parks p\n"
+        f"WHERE ST_Intersects(p.geom_4326, {denver})\n"
+        "LIMIT 100"
+    )
+    # The buffer's scaffold contributes no table of its own; the two tables are
+    # the ones the model actually asked for.
+    assert result.tables == {
+        ("data", "national_parks"),
+        ("data", "us_state_capitals"),
+    }
+
     # A direct buffer-geometry request, the chat_geojson-shaped form.
     buffered = render_geodesic_buffer("s.geom_4326", 10000)
-    with pytest.raises(SandboxError):
-        validate_sql(
-            f"SELECT s.name, ST_AsGeoJSON({buffered}) AS geometry\n"
-            "FROM data.stations s\nLIMIT 100"
-        )
+    result = validate_sql(
+        f"SELECT s.name, ST_AsGeoJSON({buffered}) AS geometry\n"
+        "FROM data.stations s\nLIMIT 100"
+    )
+    assert result.tables == {("data", "stations")}
 
 
 def test_function_reference_line_declares_degrees():

--- a/backend/tests/test_ai_sql_prompt_935.py
+++ b/backend/tests/test_ai_sql_prompt_935.py
@@ -148,8 +148,11 @@ def test_prompt_states_the_bounded_input_rule():
     The model has to be told, or it emits a shape that is silently refused —
     the same prompt-vs-validator disagreement this whole chain is about.
     """
-    assert "<GEOM> must be a stored geometry" in SQL_SYSTEM_PROMPT
+    assert "<GEOM> must be the managed geom_4326 column" in SQL_SYSTEM_PROMPT
     assert "s.geom_4326" in SQL_SYSTEM_PROMPT
-    assert "A reprojection, a nested buffer, or a constructed geometry" in (
+    assert "A reprojection, a nested buffer, a constructed geometry" in (
         SQL_SYSTEM_PROMPT
     )
+    # fix(#1001 codex r3): a dataset's original projected geom column is the
+    # non-obvious one, so the prompt has to name it.
+    assert "original geom column in another CRS" in SQL_SYSTEM_PROMPT

--- a/backend/tests/test_ai_sql_prompt_935.py
+++ b/backend/tests/test_ai_sql_prompt_935.py
@@ -139,3 +139,17 @@ def test_no_bare_geography_buffer_taught_positively():
     for line in remainder.splitlines():
         if "::geography," in line and "ST_Buffer(" in line:
             assert _is_negative_teaching(line), line
+
+
+def test_prompt_states_the_bounded_input_rule():
+    """fix(#1001): the sandbox admits the rendered buffer only around a stored
+    geometry, because the expression's cost scales with its input's extent.
+
+    The model has to be told, or it emits a shape that is silently refused —
+    the same prompt-vs-validator disagreement this whole chain is about.
+    """
+    assert "<GEOM> must be a stored geometry" in SQL_SYSTEM_PROMPT
+    assert "s.geom_4326" in SQL_SYSTEM_PROMPT
+    assert "A reprojection, a nested buffer, or a constructed geometry" in (
+        SQL_SYSTEM_PROMPT
+    )

--- a/backend/tests/test_sec025_sandbox_allowlist.py
+++ b/backend/tests/test_sec025_sandbox_allowlist.py
@@ -946,6 +946,57 @@ class TestCanonicalBufferExemptionIsScoped:
             + ") FROM data.stations, data.cities"
         )
 
+    def test_rejects_an_alias_shadowing_a_safe_cte(self):
+        """fix(#1001 codex r3): `FROM bad AS x` binds x to `bad`, whatever a
+        CTE literally named x also defines. Resolving through CTE definitions
+        instead of through the from/join reference read the safe one."""
+        _assert_rejects(
+            "WITH x AS (SELECT s.geom_4326 AS g FROM data.safe s), "
+            "bad AS (SELECT ST_Transform(c.geom_4326, 3857) AS g "
+            "FROM data.cities c) "
+            "SELECT ST_AsGeoJSON(" + _canonical_buffer("x.g", 1000) + ") FROM bad AS x"
+        )
+
+    def test_admits_a_cte_reference_under_an_alias(self):
+        """The paired control: binding through the reference has to keep
+        working for the ordinary aliased case."""
+        _assert_allows(
+            "WITH good AS (SELECT geom_4326 AS g FROM data.cities) "
+            "SELECT ST_AsGeoJSON(" + _canonical_buffer("x.g", 1000) + ") FROM good AS x"
+        )
+
+    @pytest.mark.parametrize(
+        ("label", "sql"),
+        [
+            (
+                "qualified",
+                "SELECT ST_AsGeoJSON("
+                + _canonical_buffer("s.geom", 1000)
+                + ") FROM data.stations s",
+            ),
+            (
+                "unqualified",
+                "SELECT ST_AsGeoJSON("
+                + _canonical_buffer("geom", 1000)
+                + ") FROM data.stations",
+            ),
+            (
+                "through a CTE",
+                "WITH x AS (SELECT geom AS g FROM data.cities) "
+                "SELECT ST_AsGeoJSON(" + _canonical_buffer("x.g", 1000) + ") FROM x",
+            ),
+        ],
+    )
+    def test_rejects_a_base_column_that_is_not_the_managed_4326_column(
+        self, label, sql
+    ):
+        """fix(#1001 codex r3): reaching a base table is not enough. Ingest
+        keeps a dataset's ORIGINAL `geom` in whatever CRS it arrived in and
+        adds `geom_4326` alongside, so a Web Mercator `s.geom` has a
+        40-million-unit span and drives the scaffold exactly like a
+        reprojection does."""
+        _assert_rejects(sql)
+
     def test_rejects_an_unresolvable_qualifier(self):
         _assert_rejects(
             "SELECT ST_AsGeoJSON("
@@ -981,8 +1032,11 @@ class TestCanonicalBufferExemptionIsScoped:
 
     @staticmethod
     def _n_buffers(count: int) -> str:
+        # Distinct DISTANCES rather than distinct columns: only the managed
+        # geom_4326 column resolves as a bounded source, so varying the column
+        # would refuse them all for the wrong reason.
         buffers = ", ".join(
-            f"ST_AsGeoJSON({_canonical_buffer(f's.geom_{i}')}) AS g{i}"
+            f"ST_AsGeoJSON({_canonical_buffer('s.geom_4326', 1000 + i)}) AS g{i}"
             for i in range(count)
         )
         return f"SELECT {buffers} FROM data.stations s"

--- a/backend/tests/test_sec025_sandbox_allowlist.py
+++ b/backend/tests/test_sec025_sandbox_allowlist.py
@@ -727,6 +727,14 @@ class TestCanonicalGeodesicBufferAdmitted:
             "FROM data.stations s"
         )
 
+    def test_admits_a_subquery_input_whose_column_is_aliased(self):
+        """The bounded-source rule looks through the projection alias."""
+        _assert_allows(
+            "SELECT ST_AsGeoJSON("
+            + _canonical_buffer("(SELECT geom_4326 AS g FROM data.cities LIMIT 1)")
+            + ") FROM data.stations s"
+        )
+
     def test_the_gap_is_real(self):
         """Guards the guard: if this set ever empties, the tests below stop
         proving anything and the exemption has quietly become unnecessary."""
@@ -828,6 +836,45 @@ class TestCanonicalBufferExemptionIsScoped:
             "SELECT (SELECT CASE WHEN ST_XMax(_pb.g) - ST_XMin(_pb.g) >= 6 "
             "THEN ST_UnaryUnion(_pb.g) ELSE _pb.g END "
             "FROM (SELECT s.geom_4326 AS g OFFSET 0) AS _pb) FROM data.stations s"
+        )
+
+    @pytest.mark.parametrize(
+        ("label", "geom"),
+        [
+            # The reported payload. A PLANAR buffer, so 1000000000 is DEGREES:
+            # a two-billion-degree span, hundreds of millions of bands from the
+            # scaffold's generate_series, billions of vertices from its
+            # ST_Segmentize.
+            (
+                "planar buffer with a degrees radius",
+                "ST_Buffer(ST_SetSRID(ST_MakePoint(0,0),4326), 1000000000)",
+            ),
+            # The same explosion with no large literal anywhere: a projected
+            # geometry hands the scaffold metres.
+            ("reprojected input", "ST_Transform(s.geom_4326, 3857)"),
+            # A buffer of a buffer. Bounded in fact, since a geography buffer
+            # returns 4326, but proving that needs recursion, so it fails
+            # closed like anything else that is not a stored geometry.
+            ("nested canonical buffer", None),
+        ],
+    )
+    def test_rejects_an_unbounded_buffer_input(self, label, geom):
+        """fix(#1001 codex r1): matching the template is not sufficient. The
+        scaffold's cost is a function of its INPUT's planar span, so the input
+        has to be a stored geometry rather than one the caller manufactured."""
+        rendered = (
+            _canonical_buffer(_canonical_buffer("s.geom_4326", 1000), 2000)
+            if geom is None
+            else _canonical_buffer(geom, 1000)
+        )
+        _assert_rejects(f"SELECT ST_AsGeoJSON({rendered}) FROM data.stations s")
+
+    def test_rejects_a_wrapped_column_input(self):
+        """Even a harmless-looking wrapper is refused: deciding which wrappers
+        preserve a bounded span is the units problem #1002 died on."""
+        _assert_rejects(
+            f"SELECT ST_AsGeoJSON({_canonical_buffer('ST_MakeValid(s.geom_4326)')}) "
+            "FROM data.stations s"
         )
 
     def test_rejects_a_buffer_rendered_under_a_different_alias(self):

--- a/backend/tests/test_sec025_sandbox_allowlist.py
+++ b/backend/tests/test_sec025_sandbox_allowlist.py
@@ -18,7 +18,7 @@ import pytest
 from structlog.testing import capture_logs
 
 from app.platform.sandbox.schemas import SandboxError
-from app.platform.sandbox.validator import validate_sql
+from app.platform.sandbox.validator import _MAX_BUFFER_MATCH_ATTEMPTS, validate_sql
 
 
 # ---------------------------------------------------------------------------
@@ -546,6 +546,12 @@ class TestResourceAmplificationRejected:
 
     def test_rejects_unknown_postgis_function(self):
         _assert_rejects("SELECT ST_MakeEnvelope(0, 0, 1, 1, 4326)")
+        # fix(#1001): ST_GeneratePoints is the attacker-chosen-cardinality
+        # generator the allowlist comment cites. Kept alongside ST_MakeEnvelope
+        # rather than replacing it: #1001 admits the buffer's machinery only
+        # inside the rendered template, so ST_MakeEnvelope on its own is still
+        # an unknown spatial function and both belong here.
+        _assert_rejects("SELECT ST_GeneratePoints(geom_4326, 100) FROM data.cities")
 
     def test_rejects_oversized_generate_series(self):
         _assert_rejects("SELECT array_agg(i) FROM generate_series(1, 1000000000) AS i")
@@ -609,3 +615,243 @@ class TestResourceAmplificationRejected:
     )
     def test_rejects_unbounded_collection_builders(self, sql):
         _assert_rejects(sql)
+
+    def test_rejects_table_scanning_unary_st_collect_however_aliased(self):
+        """fix(#935 codex r2, restored by #1001): the canonical buffer's unary
+        ST_Collect is admitted by whole-template match, not by a per-call
+        exception. Hiding a table scan one derived level down — or borrowing
+        the renderer's own alias names — must not slip past."""
+        _assert_rejects(
+            "SELECT (SELECT ST_Collect(_pb_p.p) FROM "
+            "(SELECT geom_4326 AS p FROM data.cities) AS _pb_p) AS blob"
+        )
+
+    def test_rejects_tiny_or_dynamic_segmentize_length(self):
+        """fix(#935 codex r2, restored by #1001): ST_Segmentize's max-edge
+        argument controls vertex amplification. Outside the rendered template
+        the function is not allowlisted at all, so no argument saves it."""
+        _assert_rejects("SELECT ST_Segmentize(geom_4326, 1e-100) FROM data.cities")
+        _assert_rejects("SELECT ST_Segmentize(geom_4326, population) FROM data.cities")
+        # The lengths the renderer itself uses buy nothing on their own.
+        _assert_rejects(
+            "SELECT ST_Segmentize(geom_4326::geography, 20000) FROM data.cities LIMIT 5"
+        )
+
+    def test_rejects_table_scanning_st_dump(self):
+        """fix(#935 codex r3, restored by #1001): ST_Dump over a table is the
+        UNNEST row-amplification class."""
+        _assert_rejects(
+            "SELECT COUNT(*) FROM data.cities c "
+            "CROSS JOIN LATERAL ST_Dump(c.geom_4326) d"
+        )
+        _assert_rejects("SELECT (ST_Dump(geom_4326)).geom FROM data.cities")
+        _assert_rejects(
+            "SELECT COUNT(*) FROM data.roads r, LATERAL ST_DumpSegments(r.geom_4326) s"
+        )
+
+
+# ---------------------------------------------------------------------------
+# fix(#1001): the canonical geodesic buffer
+# ---------------------------------------------------------------------------
+
+
+def _canonical_buffer(geom: str = "s.geom_4326", distance: float = 10000) -> str:
+    from app.platform.analysis_sql import render_geodesic_buffer
+
+    return render_geodesic_buffer(geom, distance)
+
+
+def _unlisted_names_in_canonical_buffer() -> set[str]:
+    """Function names the rendered buffer uses that neither allowlist carries.
+
+    Derived from the renderer rather than hard-coded, so a renderer change
+    moves this set and the paired negative controls follow it.
+    """
+    import sqlglot
+    from sqlglot import exp
+
+    from app.platform.sandbox.validator import (
+        _ALLOWED_FUNCTIONS,
+        _ALLOWED_POSTGIS_FUNCTIONS,
+        _func_name,
+    )
+
+    parsed = sqlglot.parse_one(
+        f"SELECT {_canonical_buffer('geom_4326', 1000)} AS g FROM data.t",
+        dialect="postgres",
+    )
+    names: set[str] = set()
+    for func in parsed.find_all(exp.Func):
+        # Skipped by the walk itself, so not part of the gap this issue closes.
+        if isinstance(func, (exp.Connector, exp.Exists)):
+            continue
+        name = _func_name(func)
+        if name.startswith("st_"):
+            if name not in _ALLOWED_POSTGIS_FUNCTIONS:
+                names.add(name)
+        elif name not in _ALLOWED_FUNCTIONS:
+            names.add(name)
+    return names
+
+
+class TestCanonicalGeodesicBufferAdmitted:
+    """fix(#1001): the NL->SQL prompt mandates render_geodesic_buffer's output
+    verbatim, and the fail-closed allowlist refused it — every buffer question
+    in the surface was dead. The functions it needs are admitted only inside a
+    subtree that re-renders to exactly the same AST, never per call."""
+
+    def test_admits_the_rendered_buffer(self):
+        _assert_allows(
+            f"SELECT s.name, ST_AsGeoJSON({_canonical_buffer()}) AS geometry "
+            "FROM data.stations s LIMIT 100"
+        )
+
+    def test_admits_a_buffer_over_a_subquery_input(self):
+        _assert_allows(
+            "SELECT p.name FROM data.national_parks p WHERE ST_Intersects("
+            "p.geom_4326, "
+            + _canonical_buffer(
+                "(SELECT geom_4326 FROM data.us_state_capitals WHERE name = 'Denver')",
+                50000,
+            )
+            + ") LIMIT 100"
+        )
+
+    @pytest.mark.parametrize("spelling", ["10000", "10000.0", "1e4"])
+    def test_admits_every_spelling_of_the_same_distance(self, spelling):
+        """The model may write 1e4 where the renderer writes 10000. Numeric
+        literals compare by value, so the match does not turn on spelling."""
+        rendered = _canonical_buffer()
+        _assert_allows(
+            f"SELECT ST_AsGeoJSON({rendered.replace('10000', spelling)}) "
+            "FROM data.stations s"
+        )
+
+    def test_the_gap_is_real(self):
+        """Guards the guard: if this set ever empties, the tests below stop
+        proving anything and the exemption has quietly become unnecessary."""
+        assert len(_unlisted_names_in_canonical_buffer()) >= 10
+
+    @pytest.mark.parametrize("name", sorted(_unlisted_names_in_canonical_buffer()))
+    def test_each_readmitted_function_is_still_refused_on_its_own(self, name):
+        """The paired negative control for every function the buffer readmits.
+
+        Nothing was added to either allowlist, so each of these is still an
+        unlisted function the moment it appears outside the rendered template.
+        """
+        # sqlglot's canonical name for generate_series is not itself valid SQL.
+        call = "generate_series" if name == "exploding_generate_series" else name
+        _assert_rejects(f"SELECT {call}(geom_4326) FROM data.cities")
+
+    def test_the_scaffold_holds_no_blocked_function(self):
+        """A renderer change cannot smuggle a blocked function through the
+        exemption — the BLOCKED check runs inside a match too — but a tripwire
+        here fails at the renderer instead of at a user's query."""
+        import sqlglot
+        from sqlglot import exp
+
+        from app.platform.sandbox.validator import _BLOCKED_FUNCTIONS, _func_name
+
+        parsed = sqlglot.parse_one(
+            f"SELECT {_canonical_buffer('geom_4326', 1000)} AS g FROM data.t",
+            dialect="postgres",
+        )
+        used = {_func_name(func) for func in parsed.find_all(exp.Func)}
+        assert not (used & _BLOCKED_FUNCTIONS)
+
+
+class TestCanonicalBufferExemptionIsScoped:
+    """The exemption covers the rendered scaffold and nothing else."""
+
+    def test_rejects_a_disallowed_function_in_the_buffer_input(self):
+        """The input expression is the model's, so it keeps every check."""
+        _assert_rejects(
+            f"SELECT ST_AsGeoJSON({_canonical_buffer('ST_GeneratePoints(s.geom_4326, 100000)')}) "
+            "FROM data.stations s"
+        )
+
+    def test_rejects_a_blocked_function_in_the_buffer_input(self):
+        _assert_rejects(
+            f"SELECT ST_AsGeoJSON({_canonical_buffer('pg_read_file(s.path)')}) "
+            "FROM data.stations s"
+        )
+
+    def test_rejects_an_unbounded_generator_in_the_buffer_input(self):
+        _assert_rejects(
+            "SELECT ST_AsGeoJSON("
+            + _canonical_buffer("(SELECT i FROM generate_series(1, 1000000000) AS i)")
+            + ") FROM data.stations s"
+        )
+
+    def test_does_not_exempt_the_rest_of_the_query(self):
+        """A canonical buffer in one clause must not license anything in another."""
+        _assert_rejects(
+            f"SELECT ST_AsGeoJSON({_canonical_buffer()}) AS geometry, "
+            "ST_GeneratePoints(s.geom_4326, 100000) AS pts "
+            "FROM data.stations s"
+        )
+
+    def test_rejects_a_tampered_segmentize_length(self):
+        """One scaffold constant changed and the whole subtree fails the match.
+
+        1e-100 is the vertex-amplification payload #1002 chased with a numeric
+        floor; here it simply is not the rendered template.
+        """
+        tampered = _canonical_buffer().replace("20000)::geometry", "1e-100)::geometry")
+        assert tampered != _canonical_buffer()
+        _assert_rejects(
+            f"SELECT ST_AsGeoJSON({tampered}) FROM data.stations s",
+        )
+
+    def test_rejects_a_tampered_band_series(self):
+        """The banding series is bounded by a longitude span in the template;
+        swapping in a literal bound must not survive."""
+        rendered = _canonical_buffer()
+        tampered = rendered.replace(
+            "generate_series(0, GREATEST(", "generate_series(0, 1000000000 + GREATEST("
+        )
+        assert tampered != rendered
+        _assert_rejects(f"SELECT ST_AsGeoJSON({tampered}) FROM data.stations s")
+
+    def test_rejects_a_scaffold_borrowing_the_renderer_aliases(self):
+        """The alias-rebinding attack: the template includes the derived-table
+        scaffold that binds `_pb`, so a real table bound to those names is not
+        the rendered expression."""
+        _assert_rejects(
+            "SELECT ST_UnaryUnion(ST_Collect(_pb_p.p)) FROM "
+            "(SELECT (ST_Dump(c.geom_4326)).geom AS p FROM data.cities c) AS _pb_p"
+        )
+
+    def test_rejects_a_truncated_lookalike(self):
+        """Just wearing the renderer's input fence is not enough."""
+        _assert_rejects(
+            "SELECT (SELECT CASE WHEN ST_XMax(_pb.g) - ST_XMin(_pb.g) >= 6 "
+            "THEN ST_UnaryUnion(_pb.g) ELSE _pb.g END "
+            "FROM (SELECT s.geom_4326 AS g OFFSET 0) AS _pb) FROM data.stations s"
+        )
+
+    def test_rejects_a_buffer_rendered_under_a_different_alias(self):
+        """Only the renderer's default alias can match, which is what the
+        prompt emits; anything else fails closed."""
+        from app.platform.analysis_sql import render_geodesic_buffer
+
+        odd = render_geodesic_buffer("s.geom_4326", 10000, alias="_zz")
+        _assert_rejects(f"SELECT ST_AsGeoJSON({odd}) FROM data.stations s")
+
+    @staticmethod
+    def _n_buffers(count: int) -> str:
+        buffers = ", ".join(
+            f"ST_AsGeoJSON({_canonical_buffer(f's.geom_{i}')}) AS g{i}"
+            for i in range(count)
+        )
+        return f"SELECT {buffers} FROM data.stations s"
+
+    def test_up_to_the_cap_still_validates(self):
+        _assert_allows(self._n_buffers(_MAX_BUFFER_MATCH_ATTEMPTS))
+
+    def test_match_attempts_are_capped(self):
+        """Each match re-renders and re-parses ~4 KB of SQL, so a statement
+        stuffed with buffer-shaped scaffolds must not turn the validator into
+        the DoS. Past the cap nothing more is exempted, which fails closed —
+        a query carrying more buffers than the cap is refused, not slow."""
+        _assert_rejects(self._n_buffers(_MAX_BUFFER_MATCH_ATTEMPTS + 1))

--- a/backend/tests/test_sec025_sandbox_allowlist.py
+++ b/backend/tests/test_sec025_sandbox_allowlist.py
@@ -925,12 +925,6 @@ class TestCanonicalBufferExemptionIsScoped:
                 + _canonical_buffer("x.g", 1000)
                 + ") FROM (SELECT geom_4326 AS g FROM data.cities) AS x",
             ),
-            (
-                "unqualified column, one table in scope",
-                "SELECT ST_AsGeoJSON("
-                + _canonical_buffer("geom_4326", 10000)
-                + ") FROM data.stations",
-            ),
         ],
     )
     def test_admits_an_input_whose_lineage_reaches_a_base_table(self, label, sql):
@@ -944,6 +938,53 @@ class TestCanonicalBufferExemptionIsScoped:
             "SELECT ST_AsGeoJSON("
             + _canonical_buffer("geom_4326", 10000)
             + ") FROM data.stations, data.cities"
+        )
+
+    def test_rejects_a_bare_top_level_column(self):
+        """fix(#1001 codex r4): documented limit. The scaffold interposes its
+        own `(SELECT ... OFFSET 0) AS _pb` scope between the column and the
+        real FROM, so deciding whether a bare name belongs to `_pb` or to the
+        outer table needs the table's column list. The prompt teaches the
+        qualified form, and the bare name inside its OWN subquery still
+        resolves, because that subquery binds the base table itself."""
+        _assert_rejects(
+            "SELECT ST_AsGeoJSON("
+            + _canonical_buffer("geom_4326", 10000)
+            + ") FROM data.stations"
+        )
+
+    @pytest.mark.parametrize(
+        ("label", "prefix", "source"),
+        [
+            ("base table", "", "FROM data.cities AS s(gid, name, geom_4326)"),
+            (
+                "CTE reference",
+                "WITH x AS (SELECT geom_4326 FROM data.cities) ",
+                "FROM x AS s(geom_4326)",
+            ),
+        ],
+    )
+    def test_rejects_a_positional_column_alias_list(self, label, prefix, source):
+        """fix(#1001 codex r4): `AS s(gid, name, geom_4326)` binds the NAME
+        geom_4326 to whatever the third physical column is, which may be a
+        projected geom. Deciding that needs the table's real column order,
+        which the validator does not have."""
+        _assert_rejects(
+            prefix
+            + "SELECT ST_AsGeoJSON("
+            + _canonical_buffer("s.geom_4326", 1000)
+            + f") {source}"
+        )
+
+    def test_an_unrelated_nested_alias_does_not_refuse_the_buffer(self):
+        """fix(#1001 codex r4): binding resolution is lexical. A nested query
+        that happens to reuse an alias must not make the outer binding look
+        ambiguous — before this, adding `(SELECT count(*) FROM data.cities s)`
+        as a sibling projection refused a buffer that was fine."""
+        _assert_allows(
+            "SELECT ST_AsGeoJSON("
+            + _canonical_buffer("s.geom_4326", 1000)
+            + "), (SELECT count(*) FROM data.cities s) AS n FROM data.stations s"
         )
 
     def test_rejects_an_alias_shadowing_a_safe_cte(self):
@@ -1004,14 +1045,34 @@ class TestCanonicalBufferExemptionIsScoped:
             + ") FROM data.stations s"
         )
 
-    def test_a_two_hop_pass_through_is_refused(self):
-        """Documented limit rather than a goal. Sibling CTEs are not in each
-        other's scope for this resolver, so lineage stops at one hop and
-        stopping is a refusal. The prompt teaches zero hops or one."""
-        _assert_rejects(
+    def test_follows_a_two_hop_pass_through(self):
+        """Sibling CTEs are in scope for each other, so lineage crosses them.
+
+        fix(#1001 codex r4): the earlier resolver stopped at one hop and
+        refused this; walking WITH clauses outward from the scope that binds
+        the reference is what makes it resolve.
+        """
+        _assert_allows(
             "WITH a AS (SELECT geom_4326 AS g FROM data.cities), "
             "b AS (SELECT a.g AS g FROM a) "
             "SELECT ST_AsGeoJSON(" + _canonical_buffer("b.g", 1000) + ") FROM b"
+        )
+
+    def test_rejects_a_two_hop_laundered_input(self):
+        """The same two hops with a reprojection at the far end stay refused."""
+        _assert_rejects(
+            "WITH a AS (SELECT ST_Transform(geom_4326, 3857) AS g "
+            "FROM data.cities), b AS (SELECT a.g AS g FROM a) "
+            "SELECT ST_AsGeoJSON(" + _canonical_buffer("b.g", 1000) + ") FROM b"
+        )
+
+    def test_refuses_a_lineage_deeper_than_the_hop_cap(self):
+        """Stopping is a refusal, not an admission."""
+        _assert_rejects(
+            "WITH a AS (SELECT geom_4326 AS g FROM data.cities), "
+            "b AS (SELECT a.g AS g FROM a), c AS (SELECT b.g AS g FROM b), "
+            "d AS (SELECT c.g AS g FROM c), e AS (SELECT d.g AS g FROM d) "
+            "SELECT ST_AsGeoJSON(" + _canonical_buffer("e.g", 1000) + ") FROM e"
         )
 
     def test_rejects_a_wrapped_column_input(self):

--- a/backend/tests/test_sec025_sandbox_allowlist.py
+++ b/backend/tests/test_sec025_sandbox_allowlist.py
@@ -869,6 +869,100 @@ class TestCanonicalBufferExemptionIsScoped:
         )
         _assert_rejects(f"SELECT ST_AsGeoJSON({rendered}) FROM data.stations s")
 
+    @pytest.mark.parametrize(
+        ("label", "sql_template"),
+        [
+            # fix(#1001 codex r2): a bare column is not enough on its own. An
+            # alias launders the projected geometry back in, and the
+            # ST_Transform sits OUTSIDE the exempt subtree so it clears the
+            # allowlist on its own.
+            (
+                "CTE",
+                "WITH x AS (SELECT ST_Transform(geom_4326, 3857) AS g "
+                "FROM data.cities) SELECT ST_AsGeoJSON({buffer}) FROM x",
+            ),
+            (
+                "derived table",
+                "SELECT ST_AsGeoJSON({buffer}) FROM ("
+                "SELECT ST_Transform(geom_4326, 3857) AS g FROM data.cities) AS x",
+            ),
+            (
+                "two CTE hops",
+                "WITH a AS (SELECT ST_Transform(geom_4326, 3857) AS g "
+                "FROM data.cities), b AS (SELECT a.g AS g FROM a) "
+                "SELECT ST_AsGeoJSON({buffer2}) FROM b",
+            ),
+            (
+                "scalar subquery",
+                "SELECT ST_AsGeoJSON({subquery_buffer}) FROM data.stations s",
+            ),
+        ],
+    )
+    def test_rejects_a_laundered_buffer_input(self, label, sql_template):
+        _assert_rejects(
+            sql_template.format(
+                buffer=_canonical_buffer("x.g", 1000),
+                buffer2=_canonical_buffer("b.g", 1000),
+                subquery_buffer=_canonical_buffer(
+                    "(SELECT ST_Transform(geom_4326, 3857) AS g "
+                    "FROM data.cities LIMIT 1)",
+                    1000,
+                ),
+            )
+        )
+
+    @pytest.mark.parametrize(
+        ("label", "sql"),
+        [
+            (
+                "CTE pass-through",
+                "WITH x AS (SELECT geom_4326 AS g FROM data.cities) "
+                "SELECT ST_AsGeoJSON(" + _canonical_buffer("x.g", 1000) + ") FROM x",
+            ),
+            (
+                "derived-table pass-through",
+                "SELECT ST_AsGeoJSON("
+                + _canonical_buffer("x.g", 1000)
+                + ") FROM (SELECT geom_4326 AS g FROM data.cities) AS x",
+            ),
+            (
+                "unqualified column, one table in scope",
+                "SELECT ST_AsGeoJSON("
+                + _canonical_buffer("geom_4326", 10000)
+                + ") FROM data.stations",
+            ),
+        ],
+    )
+    def test_admits_an_input_whose_lineage_reaches_a_base_table(self, label, sql):
+        """The resolver has to follow a pass-through alias, or a CTE the model
+        wrote for readability would be refused for no reason."""
+        _assert_allows(sql)
+
+    def test_rejects_an_unqualified_column_with_two_tables_in_scope(self):
+        """Which table it came from is undecidable, so it fails closed."""
+        _assert_rejects(
+            "SELECT ST_AsGeoJSON("
+            + _canonical_buffer("geom_4326", 10000)
+            + ") FROM data.stations, data.cities"
+        )
+
+    def test_rejects_an_unresolvable_qualifier(self):
+        _assert_rejects(
+            "SELECT ST_AsGeoJSON("
+            + _canonical_buffer("zz.g", 1000)
+            + ") FROM data.stations s"
+        )
+
+    def test_a_two_hop_pass_through_is_refused(self):
+        """Documented limit rather than a goal. Sibling CTEs are not in each
+        other's scope for this resolver, so lineage stops at one hop and
+        stopping is a refusal. The prompt teaches zero hops or one."""
+        _assert_rejects(
+            "WITH a AS (SELECT geom_4326 AS g FROM data.cities), "
+            "b AS (SELECT a.g AS g FROM a) "
+            "SELECT ST_AsGeoJSON(" + _canonical_buffer("b.g", 1000) + ") FROM b"
+        )
+
     def test_rejects_a_wrapped_column_input(self):
         """Even a harmless-looking wrapper is refused: deciding which wrappers
         preserve a bounded span is the units problem #1002 died on."""


### PR DESCRIPTION
Readmits the canonical geodesic buffer to the NL→SQL sandbox. This is the one
live production defect in the backlog: reproduced against `9a788ba92`, every
buffer question in the surface is refused today.

## The shape of the fix

The prompt mandates `render_geodesic_buffer`'s output verbatim
(`sql_generator.py` renders it at import time), and that expression uses
sixteen function names neither allowlist carries, so `_check_function_allowlist`
rejected it on the first one the walk reached (`st_unaryunion`).

Allowlisting those names globally is what SEC-025 exists to prevent —
`st_dump`, `st_dumpsegments`, `st_segmentize` and `generate_series` are the
row/vertex amplification classes. #994 admitted them and bounded them with
per-call cost guards; #1002 spent three review rounds recalibrating those
guards and each fix opened the next hole. The last one settles it: the buffer
segmentizes an alias, `_pb_d0.c0`, several derived levels from its input, so
proving a call's argument is safe and admitting the canonical buffer are
contradictory under any argument-inspection scheme.

**So nothing is admitted per call.** A subtree is exempted from the name
allowlist and the cost guards only when it is exactly what the renderer emits
around its own input:

1. **extract loosely** — the input expression from the renderer's `AS g OFFSET 0`
   fence, the distance from its `ST_Buffer` call;
2. **verify exactly** — re-render the template around that same input and
   require the two ASTs to be equal.

Extraction is allowed to be wrong. Verification cannot be, because a mismatch
grants no exemption and the buffer stays refused. Numeric literals compare by
value, so `10000`, `10000.0` and `1e4` are the same distance while every
scaffold constant still has to agree exactly.

Three properties follow structurally rather than by argument inspection:

- **The scaffold's constants are not caller-chosen.** The segmentize lengths,
  band width and `ST_WrapX` bounds come from the reference render, so the
  `1e-100` vertex-amplification payload #1002 chased with a numeric floor
  simply is not the rendered template.
- **The alias-rebinding attack cannot match.** The template includes the
  derived-table scaffold that binds `_pb`, `_pb_d0`, `_pb_p`, so a real table
  bound to those names is not the rendered expression.
- **Amplification is bounded by one geometry, not by row count.** The banding
  series is bounded by a 4326 longitude span and the dumps run over a single
  fenced row geometry, because that is what the scaffold does — which is the
  property #994 tried and failed to prove one call at a time.

The input expression is **not** exempt. It is the model's, so its functions,
its cost guards and its tables are validated exactly as before; the buffer's
scaffold contributes no table of its own, which the admission tests assert.

## Security review notes

- `_BLOCKED_FUNCTIONS` is still checked **inside** a match. Nothing in the
  rendered scaffold can be a blocked function, and keeping the check
  unconditional means a renderer change could never smuggle one in. A test
  asserts the rendered scaffold holds none.
- The naive `ST_Buffer(geom::geography, N)::geometry` form is unchanged:
  `st_buffer` was always allowlisted, and the prompt still teaches it only as a
  negative (`test_no_bare_geography_buffer_taught_positively`). Nothing here
  reopens the ±180° regression #883/#900/#990 fixed.
- The distance literal is caller-chosen, as it already was for the
  independently-allowlisted `st_buffer`. It never reaches `ST_Segmentize`.
- Match attempts are capped at 8 per statement. Each re-renders and re-parses
  ~4 KB of SQL, measured at ~16 ms, so a statement stuffed with buffer-shaped
  scaffolds cannot turn the validator into the DoS. Past the cap nothing more
  is exempted, so the query is refused rather than slow — asserted by a test.

## Tests

`test_rendered_buffer_expression_is_refused_until_1001_lands` flips back to
asserting admission and is renamed `test_rendered_buffer_expression_validates`,
per the acceptance criteria.

**Every readmitted name ships a paired negative control.** Rather than a
hard-coded list, the controls are parametrized over the names derived from the
rendered buffer itself, so a renderer change moves the set and the controls
follow it. That yields exactly the sixteen names in the issue (the
seventeenth, `exists`, is #1017) and asserts each is still refused on its own.

Four of the five controls #1003 removed come back from `bf1696e5c`'s diff:
`test_rejects_table_scanning_unary_st_collect_however_aliased`,
`test_rejects_tiny_or_dynamic_segmentize_length`,
`test_rejects_table_scanning_st_dump`, and `ST_GeneratePoints` restored to
`test_rejects_unknown_postgis_function` — **alongside** `ST_MakeEnvelope`
rather than replacing it, since `st_makeenvelope` is not readmitted globally
here and both are valid unknowns.

The fifth, `test_allows_canonical_scale_segmentize`, is **not** restored, and
that is a deliberate consequence of the design rather than an oversight: it was
the positive control for a global `st_segmentize` admission with a numeric
floor, and this fix makes no such admission. `ST_Segmentize(geom, 20000)` on
its own stays refused, which is asserted as a third case inside
`test_rejects_tiny_or_dynamic_segmentize_length`. The positive control it
paired with is now the canonical-buffer admission itself.

New adversarial coverage: a disallowed, a blocked and an unbounded-generator
function in the buffer input; a canonical buffer not exempting a sibling
expression; a tampered segmentize length; a tampered band series; a scaffold
borrowing the renderer's aliases; a truncated lookalike; a buffer rendered
under a non-default alias; and the attempt cap in both directions.

## The coupling

`render_geodesic_buffer` now carries a comment pointing at the sandbox. Both
sides render through that one function, so a shape change re-admits its own new
shape and nothing else — but what the match cannot follow is a **new function
name** added to the renderer, since the exemption would then cover it. The
comment says exactly that, on the side that changes more often.

## Verification

```
cd backend && uv run pytest tests/test_ai_sql_prompt_935.py tests/test_sec025_sandbox_allowlist.py -v
cd backend && uv run pytest tests/test_sandbox.py tests/test_sandbox_tenant_schema.py \
  tests/test_sec025_sandbox_allowlist.py tests/test_ai_sql_prompt_935.py tests/test_sql_engine.py \
  tests/test_ai_chat.py tests/test_ai_chat_dataset.py tests/test_chat_narrative.py \
  tests/test_analysis_preview.py tests/test_analysis_materialize.py \
  tests/test_ai_chat_run_analysis.py tests/test_layering.py -q -n 4
# 461 passed
cd backend && uv run ruff check . && uv run ruff format --check .
```

No schema change, no OpenAPI change, no SDK regeneration.

Closes #1001
