### PR TITLE
fix(ai): give verb classification one owner in builder chat

### DIFF
--- a/backend/app/processing/ai/chat_service.py
+++ b/backend/app/processing/ai/chat_service.py
@@ -274,10 +274,13 @@ You are a map editing assistant. The user has a map with these layers:
     -- "find datasets about flood zones", "is there a layer for parcels",
     "search for census data". Use search_datasets. query_data can only reach
     layers already on the map, so a catalog lookup sent there fails.
-  - The object is a LAYER, or its labels -- "show the layer", "show @Parks",
-    "hide the labels", "show only @Parks" when @Parks is a LAYER among
-    several. Use toggle_visibility. set_filter cannot hide a sibling layer;
-    it only filters features inside one.
+  - The object is a LAYER -- "show the layer", "show @Parks", "hide @Roads",
+    "show only @Parks" when @Parks is a LAYER among several. Use
+    toggle_visibility. set_filter cannot hide a sibling layer; it only
+    filters features inside one.
+  - The object is a layer's LABELS -- "hide the labels", "turn the labels
+    off", "label them by name". Use set_label, with column null to turn
+    labels off. toggle_visibility would hide the layer's features too.
   - The object is the DATA in a layer, and the request asks for something
     ANSWERED from it (counts, statistics, spatial relationships, distances,
     finding features). QUESTION verbs -- show, find, list, which, what,
@@ -290,7 +293,8 @@ You are a map editing assistant. The user has a map with these layers:
   - "show" is a QUESTION verb by default: "show me the ADA accessible
     stations" asks for a list, not a map change. Three exceptions, all
     CHANGE, and all of them have the MAP as the object rather than the data:
-    - a LAYER or its labels, per the rule above -- use toggle_visibility.
+    - a LAYER, per the rule above -- use toggle_visibility; its LABELS --
+      use set_label.
     - NARROWING to a feature PREDICATE -- "show only the accessible ones",
       "just the ones on the A line" -- use set_filter.
     - BROADENING an existing filter -- "show all", "show everything again",

--- a/backend/app/processing/ai/chat_service.py
+++ b/backend/app/processing/ai/chat_service.py
@@ -276,9 +276,18 @@ You are a map editing assistant. The user has a map with these layers:
     make -- ask to CHANGE the map (colors, filters, labels, visibility,
     add/remove layers). Use the map editing tools.
     "Filter to ADA accessible stations on the A line" is a CHANGE.
-  - "show" on its own is a QUESTION verb, not a filter request. Only the
-    explicit narrowing forms -- "show only", "hide everything else", "just the
-    ..." -- are CHANGE.
+  - "show" is a QUESTION verb by default: "show me the ADA accessible
+    stations" asks for a list, not a map change. Three exceptions, all
+    CHANGE, and each is recognizable because the object is the MAP rather
+    than the data:
+    - a LAYER or its labels is the object -- "show the layer", "show
+      @Parks", "hide the labels" -- use toggle_visibility.
+    - NARROWING -- "show only", "hide everything else", "just the ..." --
+      use set_filter.
+    - BROADENING an existing filter -- "show all", "show everything again",
+      "show all the features" -- use set_filter with a null expression to
+      CLEAR the filter. Answering that one as a question leaves the
+      persistent filter in place, which is not what was asked.
   - A request that names a geometry OPERATION is a TRANSFORM whichever verb
     introduces it, and outranks both lists above.
 - query_data takes a natural language question -- the server generates and

--- a/backend/app/processing/ai/chat_service.py
+++ b/backend/app/processing/ai/chat_service.py
@@ -265,10 +265,22 @@ You are a map editing assistant. The user has a map with these layers:
   Example filters: ["==", ["get", "status"], "active"], ["all", [">", ["get", "population"], 50000], ["==", ["get", "state"], "CA"]]
 - For compound requests that include both a question and a map change, use both query_data and editing tools in a single response.
 - To add a new layer, first use search_datasets to find the dataset, then use add_layer with the dataset_id.
-- When the user asks a QUESTION about their data (counts, statistics, spatial
-  relationships, distances, finding features), use the query_data tool.
-- When the user asks to CHANGE the map (colors, filters, labels, visibility,
-  add/remove layers), use the map editing tools.
+- Tool selection is decided HERE, by the verb the user used. The tool
+  descriptions say what each tool does; they do not decide which phrasing
+  wins.
+  - QUESTION verbs -- show, find, list, which, what, where, how many, how much
+    -- ask for something ANSWERED from the data (counts, statistics, spatial
+    relationships, distances, finding features). Use the query_data tool.
+    "Show me the ADA accessible stations served by the A line" is a QUESTION.
+  - CHANGE verbs -- filter, style, color, label, hide, show only, change, set,
+    make -- ask to CHANGE the map (colors, filters, labels, visibility,
+    add/remove layers). Use the map editing tools.
+    "Filter to ADA accessible stations on the A line" is a CHANGE.
+  - "show" on its own is a QUESTION verb, not a filter request. Only the
+    explicit narrowing forms -- "show only", "hide everything else", "just the
+    ..." -- are CHANGE.
+  - A request that names a geometry OPERATION is a TRANSFORM whichever verb
+    introduces it, and outranks both lists above.
 - query_data takes a natural language question -- the server generates and
   executes the SQL safely.
 - When the user asks to TRANSFORM a layer's geometry -- buffer ("within 500 m

--- a/backend/app/processing/ai/chat_service.py
+++ b/backend/app/processing/ai/chat_service.py
@@ -268,22 +268,31 @@ You are a map editing assistant. The user has a map with these layers:
 - Tool selection is decided HERE, by the verb the user used. The tool
   descriptions say what each tool does; they do not decide which phrasing
   wins.
-  - QUESTION verbs -- show, find, list, which, what, where, how many, how much
-    -- ask for something ANSWERED from the data (counts, statistics, spatial
-    relationships, distances, finding features). Use the query_data tool.
+  Read the OBJECT of the request first, then the verb. The object decides
+  which family; the verb decides which tool inside it.
+  - The object is the CATALOG (a dataset, not something already on the map)
+    -- "find datasets about flood zones", "is there a layer for parcels",
+    "search for census data". Use search_datasets. query_data can only reach
+    layers already on the map, so a catalog lookup sent there fails.
+  - The object is a LAYER, or its labels -- "show the layer", "show @Parks",
+    "hide the labels", "show only @Parks" when @Parks is a LAYER among
+    several. Use toggle_visibility. set_filter cannot hide a sibling layer;
+    it only filters features inside one.
+  - The object is the DATA in a layer, and the request asks for something
+    ANSWERED from it (counts, statistics, spatial relationships, distances,
+    finding features). QUESTION verbs -- show, find, list, which, what,
+    where, how many, how much. Use query_data.
     "Show me the ADA accessible stations served by the A line" is a QUESTION.
-  - CHANGE verbs -- filter, style, color, label, hide, show only, change, set,
-    make -- ask to CHANGE the map (colors, filters, labels, visibility,
-    add/remove layers). Use the map editing tools.
+  - The object is the MAP's appearance -- colors, filters, labels,
+    visibility, adding or removing layers. CHANGE verbs -- filter, style,
+    color, label, hide, change, set, make. Use the map editing tools.
     "Filter to ADA accessible stations on the A line" is a CHANGE.
   - "show" is a QUESTION verb by default: "show me the ADA accessible
     stations" asks for a list, not a map change. Three exceptions, all
-    CHANGE, and each is recognizable because the object is the MAP rather
-    than the data:
-    - a LAYER or its labels is the object -- "show the layer", "show
-      @Parks", "hide the labels" -- use toggle_visibility.
-    - NARROWING -- "show only", "hide everything else", "just the ..." --
-      use set_filter.
+    CHANGE, and all of them have the MAP as the object rather than the data:
+    - a LAYER or its labels, per the rule above -- use toggle_visibility.
+    - NARROWING to a feature PREDICATE -- "show only the accessible ones",
+      "just the ones on the A line" -- use set_filter.
     - BROADENING an existing filter -- "show all", "show everything again",
       "show all the features" -- use set_filter with a null expression to
       CLEAR the filter. Answering that one as a question leaves the

--- a/backend/app/processing/ai/tools.py
+++ b/backend/app/processing/ai/tools.py
@@ -134,8 +134,13 @@ CHAT_TOOLS_ANTHROPIC = [
             "Set replace_paint=true only when paint contains the complete "
             "desired paint object. Use the correct paint property for the "
             "geometry type: fill-color for polygons, line-color for lines, "
-            "circle-color for points. Do NOT use this for data-driven coloring "
-            "-- use set_data_driven_style instead."
+            "circle-color for points. Data-driven coloring (a colour that "
+            # fix(#549 codex r1): reworded from "Do NOT use this for ... use
+            # set_data_driven_style instead". The pointer is a CAPABILITY
+            # difference and stays, but the old phrasing read as
+            # request-classification prose, which is the shape the routing
+            # guard now rejects.
+            "varies by column value) belongs to set_data_driven_style."
         ),
         "input_schema": {
             "type": "object",
@@ -320,10 +325,15 @@ CHAT_TOOLS_ANTHROPIC = [
     {
         "name": "query_data",
         "description": (
-            "Query the user's map data using SQL. Use this when the user asks "
-            "a question about their data (counts, statistics, spatial analysis, "
-            "finding features, distances, areas, etc.). Do NOT use this for map "
-            "styling or layer management -- use the other tools for that."
+            # fix(#549 codex r1): behavioural only. This description used to
+            # classify user phrasing too ("use this when the user asks a
+            # question", "do NOT use this for map styling"), competing with
+            # the system prompt's verb classes from a second site without
+            # naming any sibling tool.
+            "Query the user's map data using SQL. The server generates the "
+            "SQL from a natural language question and executes it safely, so "
+            "the result is a table of values plus an optional highlight "
+            "overlay -- never a persistent map change."
         ),
         "input_schema": {
             "type": "object",

--- a/backend/app/processing/ai/tools.py
+++ b/backend/app/processing/ai/tools.py
@@ -94,7 +94,14 @@ CHAT_TOOLS_ANTHROPIC = [
     {
         "name": "set_filter",
         "description": (
-            "Set or clear a filter on a map layer. Pass a MapLibre filter "
+            # fix(#549): a pointer, not a second copy of the rule. This tool
+            # carried no routing guidance at all while run_analysis carried
+            # some, which is how "show me the ..." landed on a persistent
+            # layer filter instead of a query result.
+            "Set or clear a filter on a map layer. This is the map-edit path: "
+            "it changes what the map shows and persists on save. The system "
+            "prompt's verb classes decide when a request routes here. "
+            "Pass a MapLibre filter "
             "expression array to filter features, or null to clear the filter. "
             "Always reference columns with the expression form "
             '["get", "column"] -- never bare field names. '
@@ -332,14 +339,18 @@ CHAT_TOOLS_ANTHROPIC = [
     {
         "name": "run_analysis",
         "description": (
+            # fix(#549): behavioural only. This description used to classify
+            # user phrasing -- it cited "show the centre point of each parcel"
+            # as a transform request while the system prompt left "show"
+            # unclassified, so the model read verb classes from two competing
+            # sites. The system prompt is now the single owner of verb
+            # classification; nothing here may re-litigate which phrasing wins.
             "Run a parameterized PostGIS geometry operation on a layer and "
-            "show the result on the map as a temporary preview. Use this for "
-            "requests that TRANSFORM geometry -- 'buffer the schools by 500 "
-            "metres', 'show the centre point of each parcel'. Use query_data "
-            "instead for questions ANSWERED from the data (counts, sums, "
-            "which/where/how many). The preview is temporary and is not "
-            "saved. Do NOT tell the user where to save it -- the tool result "
-            "says what they need to know, and the surfaces differ."
+            "draw the result on the map as a temporary preview. buffer grows "
+            "each feature by a distance; centroid replaces each feature with "
+            "its centre point. The preview is temporary and is not saved. "
+            "Do NOT tell the user where to save it -- the tool result says "
+            "what they need to know, and the surfaces differ."
         ),
         "input_schema": {
             "type": "object",

--- a/backend/tests/test_ai_chat_verb_routing_549.py
+++ b/backend/tests/test_ai_chat_verb_routing_549.py
@@ -67,11 +67,33 @@ def test_prompt_classifies_the_question_verbs(verb):
 
 
 @pytest.mark.parametrize(
-    "verb", ["filter", "style", "color", "label", "hide", "show only", "change"]
+    "verb", ["filter", "style", "color", "label", "hide", "change", "set", "make"]
 )
 def test_prompt_classifies_the_change_verbs(verb):
     change_block = _prompt().split("CHANGE verbs")[1].split('"show" is a QUESTION')[0]
     assert verb in change_block
+
+
+def test_prompt_reads_the_object_before_the_verb():
+    """fix(#549 codex r1): verb alone is not enough. "find datasets about
+    flood zones" is a QUESTION verb whose object is the CATALOG, and
+    query_data can only reach layers already on the map, so routing on the
+    verb turned a valid catalog lookup into a failed SQL question."""
+    prompt = _prompt()
+    assert "Read the OBJECT of the request first" in prompt
+    assert "The object is the CATALOG" in prompt
+    assert "find datasets about flood zones" in prompt
+    assert "search_datasets" in prompt
+
+
+def test_prompt_keeps_layer_narrowing_on_the_visibility_tool():
+    """fix(#549 codex r1): "show only @Parks" among several layers means hide
+    the others. set_filter cannot do that — it only filters features inside
+    one layer — so the two narrowing cases have to be told apart."""
+    prompt = _prompt()
+    assert '"show only @Parks" when @Parks is a LAYER' in prompt
+    assert "cannot hide a sibling layer" in prompt
+    assert "NARROWING to a feature PREDICATE" in prompt
 
 
 def test_prompt_carries_both_acceptance_phrasings():
@@ -97,7 +119,7 @@ def test_prompt_settles_bare_show():
         # (frontend ChatPanel.test.tsx). Routing it to query_data would query a
         # hidden layer instead of making it visible.
         ("visibility", '"show the layer"'),
-        ("narrowing", '"show only"'),
+        ("feature narrowing", '"show only the accessible ones"'),
         # fix(#549 codex r1): with a filter already applied, "show all features
         # again" asks to CLEAR it. Answering it as a question returns a
         # temporary result and leaves the persistent filter in place.

--- a/backend/tests/test_ai_chat_verb_routing_549.py
+++ b/backend/tests/test_ai_chat_verb_routing_549.py
@@ -1,0 +1,149 @@
+"""fix(#549): exactly one site classifies user verbs for chat tool selection.
+
+"Show the ADA accessible stations served by the A line" applied a persistent
+layer filter while "Run a query selecting ..." returned a query result, so a
+user could not predict which of two very different outcomes natural phrasing
+would give them.
+
+The guidance that should have caught it already existed in the system prompt,
+but neither of its two buckets contained "show" — and the one place "show" WAS
+classified pointed the other way, in ``run_analysis``'s tool description, which
+cited "show the centre point of each parcel" as a transform request. So the
+model read verb classes from two competing sites while ``set_filter``, the tool
+that actually fired, carried no routing guidance at all.
+
+These tests pin the resolution: the system prompt owns verb classification,
+tool descriptions stay behavioural, and a later edit to one cannot silently
+reverse the routing by contradicting the other.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.processing.ai.chat_service import build_chat_system_prompt
+from app.processing.ai.schemas import ChatMapLayer
+from app.processing.ai.tools import CHAT_TOOLS_ANTHROPIC
+
+
+def _prompt() -> str:
+    return build_chat_system_prompt(
+        [
+            ChatMapLayer(
+                id="layer-1",
+                name="Stations",
+                dataset_id="ds-1",
+                dataset_table_name="data.ds_stations",
+                geometry_type="Point",
+                visible=True,
+            )
+        ]
+    )
+
+
+def _description(name: str) -> str:
+    for tool in CHAT_TOOLS_ANTHROPIC:
+        if tool["name"] == name:
+            return tool["description"]
+    raise AssertionError(f"no tool named {name!r}")
+
+
+# --- The prompt owns verb classification -----------------------------------
+
+
+def test_prompt_declares_itself_the_owner():
+    """A tool description that starts classifying phrasing again is the
+    regression; the prompt says out loud that it decides."""
+    prompt = _prompt()
+    assert "Tool selection is decided HERE" in prompt
+
+
+@pytest.mark.parametrize(
+    "verb", ["show", "find", "list", "which", "what", "where", "how many"]
+)
+def test_prompt_classifies_the_question_verbs(verb):
+    question_block = _prompt().split("QUESTION verbs")[1].split("CHANGE verbs")[0]
+    assert verb in question_block
+
+
+@pytest.mark.parametrize(
+    "verb", ["filter", "style", "color", "label", "hide", "show only", "change"]
+)
+def test_prompt_classifies_the_change_verbs(verb):
+    change_block = _prompt().split("CHANGE verbs")[1].split('"show" on its own')[0]
+    assert verb in change_block
+
+
+def test_prompt_carries_both_acceptance_phrasings():
+    """The reported pair, so the split is anchored to the observed misroute
+    rather than to an abstract rule."""
+    prompt = _prompt()
+    assert "Show me the ADA accessible stations served by the A line" in prompt
+    assert "Filter to ADA accessible stations on the A line" in prompt
+
+
+def test_prompt_settles_bare_show():
+    """Bare "show" is the whole defect: it read as plausible under both
+    buckets and was listed in neither."""
+    prompt = _prompt()
+    assert '"show" on its own is a QUESTION verb' in prompt
+    assert "show only" in prompt
+
+
+def test_prompt_keeps_transform_outranking_the_verb_lists():
+    """Asking to "show the centre point of each parcel" still has to reach
+    run_analysis, and it is a QUESTION verb over a geometry operation."""
+    prompt = _prompt()
+    assert "names a geometry OPERATION is a TRANSFORM" in prompt
+    assert "run_analysis, NOT query_data" in prompt
+
+
+# --- Tool descriptions stay behavioural ------------------------------------
+
+
+# The two tools on the QUESTION/TRANSFORM side of the split. A description
+# that names one of these is choosing between the question path and the
+# map-edit path — the choice the system prompt owns.
+#
+# Deliberately narrower than "no description may name any sibling". Two
+# existing cross-references are not verb classification and stay: set_style
+# points at set_data_driven_style (a CAPABILITY difference — both are CHANGE
+# tools), and add_layer points at search_datasets (a SEQUENCING step — you
+# need a dataset_id first). Neither says anything about which user phrasing
+# wins, which is the thing that was being decided in two places.
+_ROUTING_SIDE_TOOLS = ("query_data", "run_analysis")
+
+
+def test_no_tool_description_routes_across_the_split():
+    """The single-owner rule, enforced structurally."""
+    offenders = {
+        tool["name"]: sorted(
+            other
+            for other in _ROUTING_SIDE_TOOLS
+            if other != tool["name"] and other in tool["description"]
+        )
+        for tool in CHAT_TOOLS_ANTHROPIC
+    }
+    offenders = {name: hits for name, hits in offenders.items() if hits}
+    assert not offenders, (
+        "tool descriptions must not decide which phrasing reaches the question "
+        f"path; move it to the system prompt's verb classes: {offenders}"
+    )
+
+
+def test_run_analysis_no_longer_teaches_show_as_a_transform_verb():
+    description = _description("run_analysis")
+    assert "show the centre point" not in description
+    # It still has to say what the operations do.
+    assert "buffer" in description
+    assert "centroid" in description
+
+
+def test_set_filter_points_at_the_prompt():
+    """The tool that actually fired on the misroute carried no guidance at all;
+    it now cross-references the rule instead of restating it."""
+    description = _description("set_filter")
+    assert "map-edit path" in description
+    assert "system prompt's verb classes" in description
+    # A pointer, not a second copy: no verb list of its own.
+    assert "QUESTION" not in description

--- a/backend/tests/test_ai_chat_verb_routing_549.py
+++ b/backend/tests/test_ai_chat_verb_routing_549.py
@@ -86,6 +86,16 @@ def test_prompt_reads_the_object_before_the_verb():
     assert "search_datasets" in prompt
 
 
+def test_prompt_separates_label_visibility_from_layer_visibility():
+    """fix(#549 codex r2): toggle_visibility's schema only shows or hides the
+    whole layer, so routing "hide the labels" there removes the features too.
+    Labels are turned off with set_label(column: null)."""
+    prompt = _prompt()
+    assert "The object is a layer's LABELS" in prompt
+    assert "column null to turn" in prompt
+    assert "would hide the layer's features too" in prompt
+
+
 def test_prompt_keeps_layer_narrowing_on_the_visibility_tool():
     """fix(#549 codex r1): "show only @Parks" among several layers means hide
     the others. set_filter cannot do that — it only filters features inside

--- a/backend/tests/test_ai_chat_verb_routing_549.py
+++ b/backend/tests/test_ai_chat_verb_routing_549.py
@@ -70,7 +70,7 @@ def test_prompt_classifies_the_question_verbs(verb):
     "verb", ["filter", "style", "color", "label", "hide", "show only", "change"]
 )
 def test_prompt_classifies_the_change_verbs(verb):
-    change_block = _prompt().split("CHANGE verbs")[1].split('"show" on its own')[0]
+    change_block = _prompt().split("CHANGE verbs")[1].split('"show" is a QUESTION')[0]
     assert verb in change_block
 
 
@@ -86,8 +86,33 @@ def test_prompt_settles_bare_show():
     """Bare "show" is the whole defect: it read as plausible under both
     buckets and was listed in neither."""
     prompt = _prompt()
-    assert '"show" on its own is a QUESTION verb' in prompt
-    assert "show only" in prompt
+    assert '"show" is a QUESTION verb by default' in prompt
+
+
+@pytest.mark.parametrize(
+    ("shape", "phrase"),
+    [
+        # fix(#549 codex r1): "show the layer" is the phrase the builder
+        # contract already uses for toggle_visibility
+        # (frontend ChatPanel.test.tsx). Routing it to query_data would query a
+        # hidden layer instead of making it visible.
+        ("visibility", '"show the layer"'),
+        ("narrowing", '"show only"'),
+        # fix(#549 codex r1): with a filter already applied, "show all features
+        # again" asks to CLEAR it. Answering it as a question returns a
+        # temporary result and leaves the persistent filter in place.
+        ("broadening", '"show all"'),
+    ],
+)
+def test_prompt_carves_the_map_shaped_uses_of_show_back_out(shape, phrase):
+    prompt = _prompt()
+    assert phrase in prompt, shape
+
+
+def test_prompt_names_the_tool_for_each_show_exception():
+    prompt = _prompt()
+    assert "toggle_visibility" in prompt
+    assert "null expression to" in prompt
 
 
 def test_prompt_keeps_transform_outranking_the_verb_lists():
@@ -113,6 +138,24 @@ def test_prompt_keeps_transform_outranking_the_verb_lists():
 # wins, which is the thing that was being decided in two places.
 _ROUTING_SIDE_TOOLS = ("query_data", "run_analysis")
 
+# fix(#549 codex r1): naming a sibling is not the only way to classify
+# phrasing. query_data's own description said "use this when the user asks a
+# question about their data ... do NOT use this for map styling", which
+# competes with the prompt's verb classes from a second site while naming no
+# tool at all. These are the prose shapes that do it.
+#
+# Heuristics, and they are worth being honest about: no assertion over free
+# text can prove a description says nothing about routing. What they cover is
+# the shape the incident actually took — a description telling the model which
+# KIND OF REQUEST belongs to it. A reviewer is still the backstop.
+_ROUTING_PROSE_MARKERS = (
+    "when the user asks",
+    "use the other tools",
+    "for requests that",
+    "instead for",
+    "do not use this for",
+)
+
 
 def test_no_tool_description_routes_across_the_split():
     """The single-owner rule, enforced structurally."""
@@ -128,6 +171,28 @@ def test_no_tool_description_routes_across_the_split():
     assert not offenders, (
         "tool descriptions must not decide which phrasing reaches the question "
         f"path; move it to the system prompt's verb classes: {offenders}"
+    )
+
+
+def test_no_tool_description_classifies_requests_for_itself():
+    """A description does not have to name a sibling to compete with the rule.
+
+    Catches the self-classification form: telling the model which kind of
+    request belongs to this tool is the same claim, made from the same second
+    site.
+    """
+    offenders = {
+        tool["name"]: sorted(
+            marker
+            for marker in _ROUTING_PROSE_MARKERS
+            if marker in tool["description"].lower()
+        )
+        for tool in CHAT_TOOLS_ANTHROPIC
+    }
+    offenders = {name: hits for name, hits in offenders.items() if hits}
+    assert not offenders, (
+        "tool descriptions must describe behaviour, not classify user "
+        f"phrasing; move it to the system prompt's verb classes: {offenders}"
     )
 
 

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -820,7 +820,11 @@ def test_decomposed_service_modules_stay_within_size_budgets() -> None:
         # via _build_chat_actions (re-exported here for streaming.py) so one
         # invalid action drops with a note instead of failing the whole turn.
         # Cap raised 440 -> 446 (~4 LOC headroom).
-        "backend/app/processing/ai/chat_service.py": 446,
+        # fix(#549): +9 LOC — the system prompt now owns verb classification
+        # outright, reading the request's OBJECT (catalog / layer / data / map
+        # appearance) before its verb, so the tool descriptions stop
+        # re-litigating which phrasing wins. Cap raised 446 -> 456.
+        "backend/app/processing/ai/chat_service.py": 456,
         # fix(#836): defaults.py is the facade over the extensions-defaults
         # split (defaults_*.py sub-modules discovered below). Pure re-exports —
         # a new Default* class costs a few lines here.


### PR DESCRIPTION
## What changed

Three sites, one rule.

**`chat_service.py` — the system prompt now owns verb classification and says
so.** The QUESTION/CHANGE split that already lived there gains the ambiguous
verbs spelled out, the reported phrasing pair as worked examples, and bare
"show" settled explicitly as a QUESTION verb with only the narrowing forms
("show only", "hide everything else", "just the ...") counting as CHANGE.
Geometry operations outrank both lists, so "show the centre point of each
parcel" still reaches `run_analysis`.

**`tools.py`, `run_analysis` — stops classifying phrasing.** It dropped
"show the centre point of each parcel" and the "Use query_data instead for
questions ANSWERED from the data" cross-reference, and now describes only what
the tool does and what its output looks like.

**`tools.py`, `set_filter` — gains a pointer, not a second copy.** It carried
no routing guidance at all, which is how "show me the ..." landed on a
persistent layer filter. It now says it is the map-edit path and defers to the
prompt's verb classes.

## Why not just add the guidance

The issue's original premise was wrong and the body says so: the QUESTION/CHANGE
prose already existed at `chat_service.py:268-273`. It did not catch this
phrasing because "show" is in neither of its buckets, while `run_analysis`'s
description taught "show" as a transform verb. Adding a third copy of the rule
would have left three sites able to contradict each other.

## The structural test

`test_no_tool_description_routes_across_the_split` fails any tool description
that names `query_data` or `run_analysis` — the two tools on the
question/transform side of the split. That is deliberately narrower than "no
description may name any sibling", because two existing cross-references are
not verb classification and stay:

- `set_style` → `set_data_driven_style` is a **capability** difference; both
  are CHANGE tools.
- `add_layer` → `search_datasets` is a **sequencing** step; you need a
  `dataset_id` first.

Neither says anything about which user phrasing wins. The exemption is by name
with the reason in the test, so a future edit has to argue with it.

## Scope and blast radius

Only the builder surface with edit rights can reach `set_filter`.
`select_chat_tools` hands `CHAT_TOOLS_READONLY` (`query_data` + `run_analysis`)
to any caller that cannot edit, and dataset-scoped chat additionally passes
`has_map=False`, which drops `run_analysis` too. So the ambiguity is not
reachable from viewer chat or dataset chat, and the fix cannot regress them:
`set_filter` is not in the read-only set, so those surfaces see only the
prompt's verb classes, and every class they can act on routes to `query_data`.

## Verification

```
cd backend && uv run pytest tests/test_ai_chat_verb_routing_549.py -v
cd backend && uv run pytest tests/test_ai_chat_verb_routing_549.py tests/test_chat_narrative.py \
  tests/test_sql_engine.py tests/test_ai_chat.py tests/test_ai_chat_actions_phase1135.py \
  tests/test_ai_chat_dataset.py tests/test_ai_chat_run_analysis.py tests/test_layering.py -q -n 4
# 169 passed
cd backend && uv run ruff check . && uv run ruff format --check .
```

**Live provider verification is NOT included and has to be run by a human.**
The issue's recipe needs the builder against a live provider, and there is no
tool-selection harness yet (`test_sql_generation_evals.py` calls
`generate_sql()` directly and never runs the tool-calling loop; building one is
#1007). This branch was developed in a worktree, where the running stack serves
`main`'s code, so any result from it would be meaningless. The recipe, for
whoever runs it:

1. Open a map in the builder as a user with edit rights, on a layer whose
   columns support the phrasing.
2. In fresh conversations, send "Show the ADA accessible stations served by
   the A line" and "Filter to ADA accessible stations on the A line".
3. Confirm the emitted tool is `query_data` for the first and `set_filter` for
   the second.
4. Repeat "show the centre point of each parcel" and confirm it still reaches
   `run_analysis`.
5. Repeat the "show" phrasing against viewer chat and dataset chat to confirm
   neither surface changed behaviour.

No schema change, no OpenAPI change, no SDK regeneration.

Closes #549
