### PR TITLE
fix(catalog): serve the dataset extent bbox in the RFC 7946 spec form

### DIFF
--- a/backend/app/modules/catalog/datasets/domain/helpers.py
+++ b/backend/app/modules/catalog/datasets/domain/helpers.py
@@ -20,7 +20,7 @@ from app.modules.catalog.sources.provenance import (
     derive_last_edited,
     resolve_actor,
 )
-from app.core.geo import extent_to_span_bbox, wkt_is_geographic
+from app.core.geo import extent_to_bbox, wkt_is_geographic
 
 
 async def _load_actor_identities(
@@ -174,14 +174,18 @@ def dataset_to_response(
         n_dims=dataset.n_dims,
         z_min=dataset.z_min,
         z_max=dataset.z_max,
-        # fix(#892 codex P2): the SPAN, not the RFC 7946 spec bbox. This field is
-        # documented as "[minx, miny, maxx, maxy]" and its consumers are map
-        # viewers, not a standards serializer: DatasetMap draws an unguarded
-        # planar ring from it and calls fitBounds, so a west > east pair would
-        # paint the complementary 340° and hand MapLibre an inverted camera.
-        # The spec form is served where the spec demands it (STAC/OGC record
-        # bbox via extract_bbox, OGC collection extents), not here.
-        extent_bbox=extent_to_span_bbox(record.spatial_extent),
+        # fix(#1004): the RFC 7946 §5.2 spec bbox, west > east on a crossing.
+        # This was the span form under #892, when DatasetMap drew an unguarded
+        # planar ring and called fitBounds. #903 added the seam guards, and the
+        # span form then defeated them: extent_to_span_bbox flattens a Fiji
+        # extent to [-180, s, 180, n], which is bit-identical to a genuinely
+        # global dataset, so isLargeExtent fired first and no client-side test
+        # could tell the two apart. The seam information has to survive the
+        # wire. Do NOT flip the sibling `dataset_extent_bbox` in
+        # maps/_router_helpers.py: it bounds a vector tile source, where an
+        # inverted pair yields no tiles at all. One column, two contracts —
+        # both pinned in tests/test_antimeridian_extent.py.
+        extent_bbox=extent_to_bbox(record.spatial_extent),
         column_info=dataset.column_info,
         quality_detail=dataset.quality_detail,
         license=record.license,

--- a/backend/app/modules/catalog/datasets/domain/schemas.py
+++ b/backend/app/modules/catalog/datasets/domain/schemas.py
@@ -251,7 +251,11 @@ class DatasetResponse(BaseModel):
     )
     feature_count: int | None
     extent_bbox: list[float] | None = Field(
-        default=None, description="Bounding box [minx, miny, maxx, maxy]"
+        default=None,
+        description=(
+            "Bounding box [west, south, east, north] per RFC 7946 §5.2. "
+            "west > east on an antimeridian-crossing extent."
+        ),
     )
     column_info: list[ColumnInfo] | None = Field(
         default=None, description="Column names, types, and stats"

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -5081,7 +5081,7 @@
                 "type": "null"
               }
             ],
-            "description": "Bounding box [minx, miny, maxx, maxy]",
+            "description": "Bounding box [west, south, east, north] per RFC 7946 \u00a75.2. west > east on an antimeridian-crossing extent.",
             "title": "Extent Bbox"
           },
           "feature_count": {

--- a/backend/tests/test_antimeridian_extent.py
+++ b/backend/tests/test_antimeridian_extent.py
@@ -12,6 +12,7 @@ take an inverted pair.
 from __future__ import annotations
 
 import uuid
+from datetime import UTC, datetime
 
 import pytest
 from geoalchemy2 import WKBElement, WKTElement
@@ -420,6 +421,48 @@ def test_map_layer_response_bbox_stays_monotonic():
     resp = _build_layer_response(layer, {"extent": _extent(SEAM_MULTIPOLYGON)})
     assert resp.dataset_extent_bbox == [-180.0, -20.0, 180.0, -15.0]
     assert resp.dataset_extent_bbox[0] < resp.dataset_extent_bbox[2]
+
+
+def test_dataset_response_bbox_uses_the_spec_form():
+    """fix(#1004): the mirror of the pin above, on the same database column.
+
+    ``DatasetResponse.extent_bbox`` feeds the dataset detail page, whose three
+    camera/extent sites all carry #903 seam guards. The span form flattened a
+    crossing extent to ``[-180, s, 180, n]`` — bit-identical to what a genuinely
+    global dataset produces — so ``isLargeExtent`` fired first and the guards
+    were unreachable. The seam has to survive the wire.
+
+    These two tests sit together deliberately: one column, two consumers with
+    opposite requirements. A refactor that unifies them fails here.
+    """
+    from app.modules.catalog.datasets.domain.helpers import dataset_to_response
+    from app.modules.catalog.datasets.domain.models import Dataset, Record
+
+    now = datetime(2026, 7, 31, tzinfo=UTC)
+    record = Record(
+        id=uuid.uuid4(),
+        title="Fiji Seam Crosser",
+        visibility="public",
+        record_status="published",
+        record_type="vector_dataset",
+        spatial_extent=_extent(SEAM_MULTIPOLYGON),
+        created_at=now,
+        updated_at=now,
+    )
+    dataset = Dataset(
+        id=uuid.uuid4(),
+        record_id=record.id,
+        table_name="ds_fiji_seam",
+        srid=4326,
+        geometry_type="Point",
+        feature_count=3,
+        current_version=1,
+    )
+    dataset.record = record
+
+    resp = dataset_to_response(dataset)
+    assert resp.extent_bbox == [170.0, -20.0, -170.0, -15.0]
+    assert resp.extent_bbox[0] > resp.extent_bbox[2]
 
 
 def test_standards_record_bbox_keeps_the_spec_form():

--- a/backend/tests/test_stac_import.py
+++ b/backend/tests/test_stac_import.py
@@ -515,12 +515,14 @@ class TestStacImport:
         assert row.hits_south_atlantic is False
         assert row.hits_france is False
 
-        # fix(#892 codex P2): the dataset payload's own extent_bbox stays
-        # monotonic, because DatasetMap draws an unguarded planar ring from it and
-        # calls fitBounds. The spec form lives on the STAC/OGC surfaces instead.
+        # fix(#1004): the dataset payload's own extent_bbox is the RFC 7946 §5.2
+        # spec form too. It was monotonic under #892, when DatasetMap drew an
+        # unguarded planar ring; #903 added the seam guards, and the span form
+        # then flattened this extent to the globe-spanning pair that made those
+        # guards unreachable.
         detail = await client.get(f"/datasets/{dataset_id}", headers=admin_auth_header)
         assert detail.status_code == 200
-        assert detail.json()["extent_bbox"] == [-180.0, -20.0, 180.0, -15.0]
+        assert detail.json()["extent_bbox"] == [170.0, -20.0, -170.0, -15.0]
 
     async def test_import_duplicate_skipped(
         self,

--- a/frontend/src/components/dataset/__tests__/DatasetMap.test.tsx
+++ b/frontend/src/components/dataset/__tests__/DatasetMap.test.tsx
@@ -1,6 +1,39 @@
 import { render, screen, fireEvent } from '@/test/test-utils';
 import { DatasetMap } from '@/components/dataset/DatasetMap';
 
+// fix(#1004): what the map was actually told to draw and where to point. The
+// three camera/extent sites derive from the bbox prop alone, so recording the
+// props MapGL and Source receive is enough to pin all three.
+const mapSpy = vi.hoisted(() => ({
+  initialViewState: null as Record<string, unknown> | null,
+  sourceData: null as { features: { geometry: { coordinates: number[][][][] } }[] } | null,
+  fitBounds: vi.fn(),
+  flyTo: vi.fn(),
+  // Opt-in: driving onLoad instantiates the whole tile/recovery wiring, which
+  // the other blocks in this file neither need nor mock.
+  attachMapInstance: false,
+  reset() {
+    this.initialViewState = null;
+    this.sourceData = null;
+    this.fitBounds.mockReset();
+    this.flyTo.mockReset();
+    this.attachMapInstance = false;
+  },
+}));
+
+// Any method DatasetMap's onLoad reaches for resolves to a no-op; only the
+// camera calls are asserted.
+const fakeMap = vi.hoisted(
+  () =>
+    new Proxy({} as Record<string, unknown>, {
+      get(target, prop: string) {
+        if (prop === 'fitBounds' || prop === 'flyTo') return mapSpy[prop];
+        if (!(prop in target)) target[prop] = vi.fn();
+        return target[prop];
+      },
+    }),
+);
+
 const drawingState = vi.hoisted(() => ({
   isDrawing: false,
   activeMode: null as string | null,
@@ -14,22 +47,38 @@ const drawingState = vi.hoisted(() => ({
   isEditDirty: false,
 }));
 
-vi.mock('@vis.gl/react-maplibre', () => ({
-  Map: ({
-    children,
-    interactive,
-  }: {
-    children?: React.ReactNode;
-    interactive?: boolean;
-  }) => (
-    <div data-testid="mapgl" data-interactive={String(interactive)}>
-      {children}
-    </div>
-  ),
-  Source: ({ children }: { children?: React.ReactNode }) => children ?? null,
-  Layer: () => null,
-  NavigationControl: () => <div data-testid="nav-control" />,
-}));
+vi.mock('@vis.gl/react-maplibre', async () => {
+  const { useEffect } = await import('react');
+  return {
+    Map: ({
+      children,
+      interactive,
+      initialViewState,
+      onLoad,
+    }: {
+      children?: React.ReactNode;
+      interactive?: boolean;
+      initialViewState?: Record<string, unknown>;
+      onLoad?: (e: { target: unknown }) => void;
+    }) => {
+      mapSpy.initialViewState = initialViewState ?? null;
+      useEffect(() => {
+        if (mapSpy.attachMapInstance) onLoad?.({ target: fakeMap });
+      }, [onLoad]);
+      return (
+        <div data-testid="mapgl" data-interactive={String(interactive)}>
+          {children}
+        </div>
+      );
+    },
+    Source: ({ children, data }: { children?: React.ReactNode; data?: unknown }) => {
+      if (data !== undefined) mapSpy.sourceData = data as typeof mapSpy.sourceData;
+      return children ?? null;
+    },
+    Layer: () => null,
+    NavigationControl: () => <div data-testid="nav-control" />,
+  };
+});
 
 vi.mock('@/components/theme-provider', () => ({
   useTheme: () => ({ resolvedTheme: 'light' }),
@@ -463,5 +512,86 @@ describe('DatasetMap generic-geometry draw gating (fix #430 codex r18/r19)', () 
     );
     expect(vi.mocked(getAvailableModes)).toHaveBeenCalledWith('Point');
     expect(vi.mocked(getAvailableModes)).not.toHaveBeenCalledWith('GEOMETRY');
+  });
+});
+
+// fix(#1004): the dataset payload now carries the RFC 7946 §5.2 spec bbox, so a
+// seam-crossing extent arrives as west > east instead of flattened to
+// [-180, s, 180, n]. All three consumers here carry #903 seam handling that the
+// flattened pair made unreachable — isLargeExtent measured a 360° span and took
+// the large-extent branch every time.
+describe('DatasetMap antimeridian extent (fix #1004)', () => {
+  // The reproduction fixture: points at 179.5, -179.5 and 178.44 near Fiji.
+  const FIJI_BBOX: [number, number, number, number] = [178.44, -18.14, -179.5, -16.5];
+  const GLOBAL_BBOX: [number, number, number, number] = [-180, -18.14, 180, -16.5];
+
+  beforeEach(() => {
+    drawingState.isDrawing = false;
+    drawingState.activeMode = null;
+    mapSpy.reset();
+  });
+
+  function renderMap(bbox: [number, number, number, number]) {
+    return render(
+      <DatasetMap
+        bbox={bbox}
+        tableName="fiji_points"
+        geometryType="Point"
+        datasetId="dataset-fiji"
+      />,
+    );
+  }
+
+  it('fits the initial camera to the seam extent instead of the whole world', () => {
+    renderMap(FIJI_BBOX);
+
+    // The seam branch: bounds with east run past 180 for MapLibre to normalize.
+    expect(mapSpy.initialViewState).toMatchObject({ fitBoundsOptions: { padding: 60 } });
+    const bounds = (mapSpy.initialViewState as { bounds: number[][] }).bounds;
+    expect(bounds).toEqual([
+      [178.44, -18.14],
+      [180.5, -16.5],
+    ]);
+  });
+
+  it('still takes the large-extent branch for a genuinely global bbox', () => {
+    renderMap(GLOBAL_BBOX);
+
+    expect(mapSpy.initialViewState).not.toHaveProperty('bounds');
+    expect(mapSpy.initialViewState).toMatchObject({ zoom: expect.any(Number) });
+  });
+
+  it('draws the extent band as two rings split at the seam', () => {
+    renderMap(FIJI_BBOX);
+
+    const rings = mapSpy.sourceData!.features[0].geometry.coordinates;
+    expect(rings).toHaveLength(2);
+    const spans = rings.map((ring) => [ring[0][0][0], ring[0][2][0]]);
+    expect(spans).toEqual([
+      [178.44, 180],
+      [-180, -179.5],
+    ]);
+  });
+
+  it('draws one global rectangle for a genuinely global bbox', () => {
+    renderMap(GLOBAL_BBOX);
+
+    expect(mapSpy.sourceData!.features[0].geometry.coordinates).toHaveLength(1);
+  });
+
+  it('zooms to the seam extent rather than flying to a world view', () => {
+    mapSpy.attachMapInstance = true;
+    renderMap(FIJI_BBOX);
+
+    fireEvent.click(screen.getByTitle('Zoom to dataset extent'));
+
+    expect(mapSpy.flyTo).not.toHaveBeenCalled();
+    expect(mapSpy.fitBounds).toHaveBeenCalledWith(
+      [
+        [178.44, -18.14],
+        [180.5, -16.5],
+      ],
+      expect.objectContaining({ padding: 60 }),
+    );
   });
 });

--- a/frontend/src/types/api.generated.ts
+++ b/frontend/src/types/api.generated.ts
@@ -7209,7 +7209,7 @@ export interface components {
             data_vintage_start?: string | null;
             /**
              * Extent Bbox
-             * @description Bounding box [minx, miny, maxx, maxy]
+             * @description Bounding box [west, south, east, north] per RFC 7946 §5.2. west > east on an antimeridian-crossing extent.
              */
             extent_bbox?: number[] | null;
             /** Feature Count */

--- a/sdks/python/geolens/models/dataset_response.py
+++ b/sdks/python/geolens/models/dataset_response.py
@@ -48,7 +48,8 @@ class DatasetResponse:
         current_version (int | Unset): Monotonic version counter Default: 1.
         data_vintage_end (datetime.date | None | Unset): End of temporal coverage
         data_vintage_start (datetime.date | None | Unset): Start of temporal coverage
-        extent_bbox (list[float] | None | Unset): Bounding box [minx, miny, maxx, maxy]
+        extent_bbox (list[float] | None | Unset): Bounding box [west, south, east, north] per RFC 7946 §5.2. west > east
+            on an antimeridian-crossing extent.
         geometry_type (None | str | Unset): OGC geometry type, e.g. MultiPolygon
         has_generic_geometry (bool | Unset): True when the underlying column is generic GEOMETRY (created sketch
             datasets): the dataset accepts ANY geometry subtype on write regardless of the display geometry_type above.

--- a/sdks/typescript/src/client/types.gen.ts
+++ b/sdks/typescript/src/client/types.gen.ts
@@ -3014,7 +3014,7 @@ export type DatasetResponse = {
     /**
      * Extent Bbox
      *
-     * Bounding box [minx, miny, maxx, maxy]
+     * Bounding box [west, south, east, north] per RFC 7946 §5.2. west > east on an antimeridian-crossing extent.
      */
     extent_bbox?: Array<number> | null;
     /**


### PR DESCRIPTION
Closes #1004.

## The gap

Every piece was correct on its own. Storage holds the #901 two-ring split; OGC
emits the spec pair; `/api/datasets/` emitted the span form, which its own
`#892` docstring justifies as "over-broad, but never inverted".

The gap is where they meet. `extent_to_span_bbox` flattens a Fiji extent to
`[-180, -18.14, 180, -16.5]`, which is **bit-identical** to what a genuinely
global dataset at the same latitude band produces. `DatasetMap` tests
`isLargeExtent(bbox)` before it can reach its #903 seam branch, and the flattened
pair spans 360°, so the seam branch was unreachable and a 1.5° x 1.6° box near
Fiji previewed as a dashed band across the whole world.

This cannot be fixed client-side: `crossesAntimeridian` can only key on
`west > east`, and the flattened pair is monotonic. The seam information is
destroyed before serialization, so the producer has to stop destroying it.

Three sites were affected, not just the one the issue's snippet quotes:
`initialViewState` (what the reproduction hits), `handleZoomToExtent`, and
`bboxGeojson` (drawn via `splitBbox`, which returns one ring for anything that
does not cross).

## What changed

`dataset_to_response` uses `extent_to_bbox`. `frontend/src/lib/bbox.ts`'s header
names this as the sequencing it was written for: #934 first (closed via #980),
then one consumer at a time. This is the first consumer.

Also regenerates `backend/openapi.json`, `frontend/src/types/api.generated.ts`
and both SDKs, for the field description.

## What is deliberately NOT flipped

`dataset_extent_bbox` in `maps/_router_helpers.py` stays on the span form. It
feeds `map-sync.ts:243` → the vector tile source's `bounds`, where a `west > east`
pair bounds the source to no tiles and the layer renders blank. One database
column, two consumers with opposite requirements.

`extent_to_span_bbox` itself is unchanged, as are the raster tile-source bounds
and the three DCAT serializers.

## Consumer audit before the flip

`DatasetResponse.extent_bbox` reaches `DatasetMap` (fixed by this change) and
`SpatialExtentCard`, which prints the four numbers and does no span arithmetic.
`e2e/export-runtime.spec.ts` reads it through a `toBBox` helper that already
returns `null` on `minX > maxX` and falls back to computing the bbox from
feature positions. `dataset-validation-navigation.ts` only matches the field
name. Nothing else consumes it.

## Verification

```
cd backend && set -a && source ../.env.test && set +a && uv run pytest \
  tests/test_antimeridian_extent.py tests/test_antimeridian_rollup.py \
  tests/test_collections.py tests/test_fe_sdk_type_drift.py \
  tests/test_maps_style_json.py tests/test_processing_port.py \
  tests/test_stac_import.py tests/test_vrt_catalog_175.py tests/test_datasets.py -q
  # 250 passed
cd backend && uv run ruff check . && uv run ruff format --check .
make openapi-check
cd frontend && npm run lint && npm run typecheck
cd frontend && npx vitest run src/components/dataset src/lib/__tests__  # 924 passed
```

Backend: `test_dataset_response_bbox_uses_the_spec_form` is added directly
beside the existing `test_map_layer_response_bbox_stays_monotonic`, so the two
opposite contracts on one column sit together and a refactor that unifies them
fails loudly. `test_stac_import.py`'s pin is updated to the spec form rather
than worked around — its comment cited the unguarded-ring reasoning that #903
retired.

Frontend: `DatasetMap.test.tsx` gains a block covering all three sites against
the Fiji fixture, each paired with a genuinely global bbox that must still take
the large-extent branch — same code, two bboxes, opposite outcomes.
