### PR TITLE
fix(builder): four polish items from the 2026-07-27 audit

### DIFF
--- a/frontend/src/components/builder/BuilderMap.tsx
+++ b/frontend/src/components/builder/BuilderMap.tsx
@@ -1311,6 +1311,9 @@ export const BuilderMap = memo(function BuilderMap({
   if (prevVisibleBoundsKeyRef.current === undefined) {
     prevVisibleBoundsKeyRef.current = visibleLayerBoundsKey(getVisibleLayerBounds(layers));
   }
+  // fix(#787 item 6): id of the live "return to previous view" toast, so a second
+  // auto-fit replaces the offer instead of stacking a stale one.
+  const returnToViewToastRef = useRef<string | number | undefined>(undefined);
 
   // Auto-fit to visible layers (skip on initial load if saved view exists)
   useEffect(() => {
@@ -1325,7 +1328,8 @@ export const BuilderMap = memo(function BuilderMap({
     prevVisibleBoundsKeyRef.current = visibleBoundsKey;
 
     // First auto-fit trigger: skip if we have a saved view to restore
-    if (!initialFitDoneRef.current) {
+    const isFirstFit = !initialFitDoneRef.current;
+    if (isFirstFit) {
       initialFitDoneRef.current = true;
       if (hasSavedView) return; // MapGL already positioned via initialViewState
     }
@@ -1336,6 +1340,16 @@ export const BuilderMap = memo(function BuilderMap({
     if (!layerCountChanged) return;
     if (!visibleBounds || !visibleBoundsChanged) return;
 
+    // fix(#787 item 6): the fit used to move the camera with no way back. Capture
+    // it first and offer a one-shot return. Not on the very first fit — there is no
+    // view the user chose yet, so the offer would just be page-load noise.
+    const previousCamera = {
+      center: map.getCenter(),
+      zoom: map.getZoom(),
+      bearing: map.getBearing(),
+      pitch: map.getPitch(),
+    };
+
     map.fitBounds(
       visibleBounds,
       { padding: 40, maxZoom: 18, duration: 0 },
@@ -1344,6 +1358,28 @@ export const BuilderMap = memo(function BuilderMap({
     // Clamp zoom to 2+ so tiles render (ST_AsMVT fails at z0/z1 for complex geometries)
     if (map.getZoom() < 2) {
       map.setZoom(2);
+    }
+
+    if (!isFirstFit) {
+      // Replace rather than stack: a second auto-fit makes the older offer stale,
+      // and its camera is no longer the one the user was looking at.
+      if (returnToViewToastRef.current !== undefined) toast.dismiss(returnToViewToastRef.current);
+      returnToViewToastRef.current = toast(t('map.autoFitMoved'), {
+        // Longer than the default: an auto-fit usually rides along with another
+        // toast ("Layer removed"), and sonner collapses the stack, so a 4s offer
+        // can expire while it is still hidden behind the one in front.
+        duration: 10_000,
+        action: {
+          label: t('map.returnToPreviousView'),
+          onClick: () => {
+            mapRef.current?.easeTo({ ...previousCamera, duration: 400 });
+            if (returnToViewToastRef.current !== undefined) {
+              toast.dismiss(returnToViewToastRef.current);
+              returnToViewToastRef.current = undefined;
+            }
+          },
+        },
+      });
     }
   // Phase 1051 IN-01 (iter-2): no longer reads popupInvalidationKey — the
   // effect short-circuits on unchanged layer count and unchanged visible

--- a/frontend/src/components/builder/BuilderMap.tsx
+++ b/frontend/src/components/builder/BuilderMap.tsx
@@ -1394,6 +1394,13 @@ export const BuilderMap = memo(function BuilderMap({
   onMapRefLatest.current = onMapRef;
   useEffect(() => {
     return () => {
+      // fix(#787 item 6): the Toaster outlives the route change, so a live
+      // "return to previous view" offer would follow the user to an unrelated page
+      // and ease a torn-down map on click.
+      if (returnToViewToastRef.current !== undefined) {
+        toast.dismiss(returnToViewToastRef.current);
+        returnToViewToastRef.current = undefined;
+      }
       if (mapRef.current && errorHandlerRef.current) {
         mapRef.current.off('error', errorHandlerRef.current);
       }

--- a/frontend/src/components/builder/EphemeralBadge.tsx
+++ b/frontend/src/components/builder/EphemeralBadge.tsx
@@ -44,8 +44,11 @@ export function EphemeralBadge({ featureCount, onDismiss, truncated, totalCount,
     return () => cancelAnimationFrame(frame);
   }, [statusLabel]);
 
+  // fix(#787 item 1): z-20, above the z-10 PluginHost slots. The bottom-left slot
+  // is offset to clear this badge, but a panel taller than that offset overlaps it
+  // and the z-index decided — the badge lost.
   return (
-    <div className={cn('absolute bottom-8 start-4 z-[8] flex items-center gap-2 rounded-md bg-background/95 backdrop-blur-sm border shadow-sm px-3 py-1.5 text-xs', className)}>
+    <div className={cn('absolute bottom-8 start-4 z-20 flex items-center gap-2 rounded-md bg-background/95 backdrop-blur-sm border shadow-sm px-3 py-1.5 text-xs', className)}>
       <span className="h-2 w-2 rounded-full bg-warning shrink-0" />
       <span role="status" className="sr-only">{announcedLabel}</span>
       {/* fix(#784): aria-hidden so browse mode doesn't read the badge text

--- a/frontend/src/components/builder/HistoryPanel.tsx
+++ b/frontend/src/components/builder/HistoryPanel.tsx
@@ -1,5 +1,6 @@
-import { AlertCircle, Clock3, History, Loader2, type LucideIcon } from 'lucide-react';
+import { AlertCircle, Clock3, History, Loader2, RotateCcw, type LucideIcon } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
+import { Button } from '@/components/ui/button';
 import { useMapHistory } from '@/hooks/use-maps';
 import { formatProvenanceTime } from '@/lib/provenance-attribution';
 import { cn } from '@/lib/utils';
@@ -16,11 +17,13 @@ function HistoryPanelState({
   title,
   description,
   role,
+  action,
 }: {
   icon: LucideIcon;
   title: string;
   description?: string;
   role?: 'status' | 'alert';
+  action?: React.ReactNode;
 }) {
   return (
     <div
@@ -38,6 +41,7 @@ function HistoryPanelState({
       {description && (
         <p className="max-w-56 text-xs leading-5 text-muted-foreground">{description}</p>
       )}
+      {action}
     </div>
   );
 }
@@ -120,10 +124,17 @@ export function HistoryPanel({ mapId, limit = 50, className }: HistoryPanelProps
       <HistoryPanelState
         icon={AlertCircle}
         title={t('history.errorTitle', { defaultValue: 'History could not be loaded' })}
-        description={t('history.errorDescription', {
-          defaultValue: 'Try closing and reopening this panel.',
-        })}
+        description={t('history.errorDescription')}
         role="alert"
+        // fix(#787 item 9): the copy used to tell people to close and reopen the
+        // panel. Refetching is what that did, so offer the button instead —
+        // same affordance as DatasetSearchPanel's error state.
+        action={(
+          <Button type="button" variant="ghost" size="sm" onClick={() => historyQuery.refetch()}>
+            <RotateCcw className="me-1 h-3.5 w-3.5" aria-hidden="true" />
+            {t('history.retry')}
+          </Button>
+        )}
       />
     );
   }

--- a/frontend/src/components/builder/__tests__/EphemeralBadge.test.tsx
+++ b/frontend/src/components/builder/__tests__/EphemeralBadge.test.tsx
@@ -27,4 +27,11 @@ describe('EphemeralBadge', () => {
     );
     expect(screen.getByText('Result · 5,000 of 250,000 features')).toBeInTheDocument();
   });
+
+  // fix(#787 item 1): the badge sat at z-[8], under every z-10 PluginHost slot, so
+  // an open plugin panel taller than the bottom-left offset covered it.
+  it('stacks above the PluginHost slots', () => {
+    const { container } = render(<EphemeralBadge featureCount={1} onDismiss={vi.fn()} />);
+    expect(container.firstElementChild).toHaveClass('z-20');
+  });
 });

--- a/frontend/src/components/builder/__tests__/HistoryPanel.test.tsx
+++ b/frontend/src/components/builder/__tests__/HistoryPanel.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@/test/test-utils';
+import { fireEvent, render, screen } from '@/test/test-utils';
 import { useMapHistory } from '@/hooks/use-maps';
 import { HistoryPanel } from '../HistoryPanel';
 import type { MapHistoryEntryResponse, MapHistoryListResponse } from '@/types/api';
@@ -9,6 +9,8 @@ vi.mock('@/hooks/use-maps', () => ({
 
 const mockedUseMapHistory = vi.mocked(useMapHistory);
 
+const refetch = vi.fn();
+
 function mockHistoryQuery(overrides: {
   data?: MapHistoryListResponse;
   isLoading?: boolean;
@@ -18,6 +20,7 @@ function mockHistoryQuery(overrides: {
     data: overrides.data,
     isLoading: overrides.isLoading ?? false,
     isError: overrides.isError ?? false,
+    refetch,
   } as never);
 }
 
@@ -75,6 +78,19 @@ describe('HistoryPanel', () => {
     render(<HistoryPanel mapId="map-1" />);
 
     expect(screen.getByRole('alert')).toHaveTextContent('History could not be loaded');
+  });
+
+  // fix(#787 item 9): the error state told people to close and reopen the panel
+  // instead of offering the retry the panel could do itself.
+  it('offers a Try again button in the error state that refetches', () => {
+    mockHistoryQuery({ isError: true });
+
+    render(<HistoryPanel mapId="map-1" />);
+
+    const retry = screen.getByRole('button', { name: 'Try again' });
+    expect(screen.getByRole('alert')).not.toHaveTextContent('closing and reopening');
+    fireEvent.click(retry);
+    expect(refetch).toHaveBeenCalledTimes(1);
   });
 
   it('renders populated history entries with relative time and summary text', () => {

--- a/frontend/src/components/dataset/hooks/__tests__/use-dataset.test.ts
+++ b/frontend/src/components/dataset/hooks/__tests__/use-dataset.test.ts
@@ -191,7 +191,7 @@ describe('useDeleteDataset', () => {
     return { result, qc: captured as QueryClient };
   }
 
-  it('cancels the deleted dataset own queries and never invalidates or removes them', async () => {
+  it('marks the deleted dataset own queries stale without fetching them', async () => {
     mockDeleteDataset.mockResolvedValueOnce({ message: 'ok' } as never);
     const { result, qc } = renderWithClient();
     const cancel = vi.spyOn(qc, 'cancelQueries');
@@ -206,11 +206,12 @@ describe('useDeleteDataset', () => {
       queryKeys.datasets.maps('ds-1'),
     ]) {
       expect(cancel).toHaveBeenCalledWith({ queryKey });
+      // Stale, but explicitly not refetched: the observers are still mounted here.
+      expect(invalidate).toHaveBeenCalledWith({ queryKey, refetchType: 'none' });
       expect(invalidate).not.toHaveBeenCalledWith({ queryKey });
     }
-    // Removing an ACTIVE query makes its observer rebuild and fetch. The detail
-    // page is still mounted when this runs (the caller navigates afterwards), and
-    // a live run measured that as one more 404 than leaving the entry alone.
+    // Removing an ACTIVE query makes its observer rebuild and fetch — a live run
+    // measured that as one more 404 than marking it stale.
     expect(remove).not.toHaveBeenCalled();
   });
 

--- a/frontend/src/components/dataset/hooks/__tests__/use-dataset.test.ts
+++ b/frontend/src/components/dataset/hooks/__tests__/use-dataset.test.ts
@@ -10,16 +10,23 @@ vi.mock('@/api/datasets', async (importOriginal) => {
     getDataset: vi.fn(),
     getDatasetRows: vi.fn(),
     reuploadCommit: vi.fn(),
+    deleteDataset: vi.fn(),
   };
 });
 
-import { getDataset, getDatasetRows, reuploadCommit } from '@/api/datasets';
-import { useDataset, useDatasetRows, useReuploadCommit } from '@/components/dataset/hooks/use-dataset';
+import { getDataset, getDatasetRows, reuploadCommit, deleteDataset } from '@/api/datasets';
+import {
+  useDataset,
+  useDatasetRows,
+  useReuploadCommit,
+  useDeleteDataset,
+} from '@/components/dataset/hooks/use-dataset';
 import { queryKeys } from '@/lib/query-keys';
 
 const mockGetDataset = vi.mocked(getDataset);
 const mockGetDatasetRows = vi.mocked(getDatasetRows);
 const mockReuploadCommit = vi.mocked(reuploadCommit);
+const mockDeleteDataset = vi.mocked(deleteDataset);
 
 describe('useDataset', () => {
   beforeEach(() => {
@@ -160,5 +167,70 @@ describe('useReuploadCommit', () => {
     expect(spy).not.toHaveBeenCalledWith({
       queryKey: queryKeys.ingest.jobStatusByDataset('ds-1'),
     });
+  });
+});
+
+/**
+ * fix(#787 item 5): deleting a dataset fired three refetches at the resource that
+ * had just been deleted — `/datasets/:id`, plus `/related/` and `/maps/`, which sit
+ * under the ['datasets'] prefix the list invalidation matches. All three 404'd.
+ */
+describe('useDeleteDataset', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  function renderWithClient() {
+    let captured: QueryClient | null = null;
+    const { result } = renderHook(() => {
+      const qc = useQueryClient();
+      const ref = useRef<QueryClient | null>(null);
+      if (ref.current === null) ref.current = qc;
+      captured = ref.current;
+      return useDeleteDataset();
+    });
+    if (!captured) throw new Error('QueryClient capture failed');
+    return { result, qc: captured as QueryClient };
+  }
+
+  it('cancels the deleted dataset own queries and never invalidates or removes them', async () => {
+    mockDeleteDataset.mockResolvedValueOnce({ message: 'ok' } as never);
+    const { result, qc } = renderWithClient();
+    const cancel = vi.spyOn(qc, 'cancelQueries');
+    const remove = vi.spyOn(qc, 'removeQueries');
+    const invalidate = vi.spyOn(qc, 'invalidateQueries');
+
+    await result.current.mutateAsync({ datasetId: 'ds-1', confirmName: 'Test' });
+
+    for (const queryKey of [
+      queryKeys.datasets.detail('ds-1'),
+      queryKeys.datasets.related('ds-1'),
+      queryKeys.datasets.maps('ds-1'),
+    ]) {
+      expect(cancel).toHaveBeenCalledWith({ queryKey });
+      expect(invalidate).not.toHaveBeenCalledWith({ queryKey });
+    }
+    // Removing an ACTIVE query makes its observer rebuild and fetch. The detail
+    // page is still mounted when this runs (the caller navigates afterwards), and
+    // a live run measured that as one more 404 than leaving the entry alone.
+    expect(remove).not.toHaveBeenCalled();
+  });
+
+  it('keeps the dataset-list invalidation off the deleted id', async () => {
+    mockDeleteDataset.mockResolvedValueOnce({ message: 'ok' } as never);
+    const { result, qc } = renderWithClient();
+    const invalidate = vi.spyOn(qc, 'invalidateQueries');
+
+    await result.current.mutateAsync({ datasetId: 'ds-1', confirmName: 'Test' });
+
+    const listCall = invalidate.mock.calls.find(
+      ([filters]) => filters?.queryKey === queryKeys.datasets.all,
+    );
+    expect(listCall).toBeDefined();
+    const predicate = listCall![0]!.predicate!;
+    // related/ and maps/ for the deleted dataset match the ['datasets'] prefix.
+    expect(predicate({ queryKey: queryKeys.datasets.related('ds-1') } as never)).toBe(false);
+    expect(predicate({ queryKey: queryKeys.datasets.maps('ds-1') } as never)).toBe(false);
+    // Everything else under the prefix still refetches.
+    expect(predicate({ queryKey: queryKeys.datasets.all } as never)).toBe(true);
+    expect(predicate({ queryKey: queryKeys.datasets.related('ds-2') } as never)).toBe(true);
   });
 });

--- a/frontend/src/components/dataset/hooks/use-dataset.ts
+++ b/frontend/src/components/dataset/hooks/use-dataset.ts
@@ -97,16 +97,22 @@ export function useDeleteDataset() {
       // the ['datasets'] prefix the list invalidation matches. Cancel all three and
       // keep the list invalidation off the deleted id.
       //
-      // Cancel, do NOT remove, the detail query: the caller navigates away after
-      // this resolves, so its observer is still mounted here, and removing an
-      // active query makes the observer rebuild it and fetch — measured as one
-      // more 404 than doing nothing. The stale entry ages out via gcTime instead.
+      // `refetchType: 'none'`, not a plain invalidate and not a remove. The caller
+      // navigates away only after this resolves, so the detail observer is still
+      // mounted: a plain invalidate refetches it, and removing an active query makes
+      // the observer rebuild and fetch — both measured as a 404. Marking it stale
+      // without fetching puts nothing in flight now AND still forces a real request
+      // if the user comes back to the URL, so browser Back gets a not-found instead
+      // of a cached ghost of the dataset it just deleted.
       const deadKeys = [
         queryKeys.datasets.detail(variables.datasetId),
         queryKeys.datasets.related(variables.datasetId),
         queryKeys.datasets.maps(variables.datasetId),
       ];
-      for (const queryKey of deadKeys) qc.cancelQueries({ queryKey });
+      for (const queryKey of deadKeys) {
+        qc.cancelQueries({ queryKey });
+        qc.invalidateQueries({ queryKey, refetchType: 'none' });
+      }
       qc.invalidateQueries({
         queryKey: queryKeys.datasets.all,
         predicate: (query) => query.queryKey[1] !== variables.datasetId,

--- a/frontend/src/components/dataset/hooks/use-dataset.ts
+++ b/frontend/src/components/dataset/hooks/use-dataset.ts
@@ -92,8 +92,25 @@ export function useDeleteDataset() {
     mutationFn: ({ datasetId, confirmName }: { datasetId: string; confirmName: string }) =>
       deleteDataset(datasetId, confirmName),
     onSuccess: (_data, variables) => {
-      qc.invalidateQueries({ queryKey: queryKeys.datasets.detail(variables.datasetId) });
-      qc.invalidateQueries({ queryKey: queryKeys.datasets.all });
+      // fix(#787 item 5): invalidating fired three refetches at a dataset that no
+      // longer exists — its detail query, plus related/ and maps/, which live under
+      // the ['datasets'] prefix the list invalidation matches. Cancel all three and
+      // keep the list invalidation off the deleted id.
+      //
+      // Cancel, do NOT remove, the detail query: the caller navigates away after
+      // this resolves, so its observer is still mounted here, and removing an
+      // active query makes the observer rebuild it and fetch — measured as one
+      // more 404 than doing nothing. The stale entry ages out via gcTime instead.
+      const deadKeys = [
+        queryKeys.datasets.detail(variables.datasetId),
+        queryKeys.datasets.related(variables.datasetId),
+        queryKeys.datasets.maps(variables.datasetId),
+      ];
+      for (const queryKey of deadKeys) qc.cancelQueries({ queryKey });
+      qc.invalidateQueries({
+        queryKey: queryKeys.datasets.all,
+        predicate: (query) => query.queryKey[1] !== variables.datasetId,
+      });
       qc.invalidateQueries({ queryKey: queryKeys.search.all });
       qc.invalidateQueries({ queryKey: queryKeys.admin.stats });
     },

--- a/frontend/src/i18n/locales/de/builder.json
+++ b/frontend/src/i18n/locales/de/builder.json
@@ -8,7 +8,9 @@
     "opacityModified": "Deckkraft angepasst"
   },
   "map": {
-    "ariaLabel": "Kartenerstellung"
+    "ariaLabel": "Kartenerstellung",
+    "autoFitMoved": "Die Ansicht wurde an die sichtbaren Ebenen angepasst",
+    "returnToPreviousView": "Zurück zur vorherigen Ansicht"
   },
   "mapNameLabel": "Kartenname",
   "descriptionLabel": "Kartenbeschreibung",
@@ -1093,12 +1095,13 @@
     "emptyTitle": "Noch kein Bearbeitungsverlauf",
     "emptyDescription": "Der Verlauf beginnt, nachdem gespeicherte Bearbeitungen für diese Karte aufgezeichnet wurden.",
     "errorTitle": "Verlauf konnte nicht geladen werden",
-    "errorDescription": "Schließen und erneut öffnen Sie dieses Panel.",
+    "errorDescription": "Prüfe deine Verbindung und versuche es erneut.",
     "notAvailableTitle": "Speichern Sie diese Karte, um den Verlauf zu sehen",
     "notAvailableDescription": "Der Bearbeitungsverlauf ist verfügbar, nachdem die Karte gespeichert wurde.",
     "unknownTime": "Unbekannte Zeit",
     "unknownActor": "Unbekannter Benutzer",
-    "actorTarget": "{{actor}} - {{target}}"
+    "actorTarget": "{{actor}} - {{target}}",
+    "retry": "Erneut versuchen"
   },
   "dock": {
     "askAi": "KI fragen",

--- a/frontend/src/i18n/locales/en/builder.json
+++ b/frontend/src/i18n/locales/en/builder.json
@@ -8,7 +8,9 @@
     "opacityModified": "Opacity adjusted"
   },
   "map": {
-    "ariaLabel": "Map builder"
+    "ariaLabel": "Map builder",
+    "autoFitMoved": "The view moved to fit the visible layers",
+    "returnToPreviousView": "Return to previous view"
   },
   "mapNameLabel": "Map name",
   "descriptionLabel": "Map description",
@@ -1097,12 +1099,13 @@
     "emptyTitle": "No edit history yet",
     "emptyDescription": "History starts after saved edits are recorded for this map.",
     "errorTitle": "History could not be loaded",
-    "errorDescription": "Try closing and reopening this panel.",
+    "errorDescription": "Check your connection, then try again.",
     "notAvailableTitle": "Save this map to see history",
     "notAvailableDescription": "Edit history is available after the map exists.",
     "unknownTime": "Unknown time",
     "unknownActor": "Unknown user",
-    "actorTarget": "{{actor}} - {{target}}"
+    "actorTarget": "{{actor}} - {{target}}",
+    "retry": "Try again"
   },
   "dock": {
     "askAi": "Ask AI",

--- a/frontend/src/i18n/locales/es/builder.json
+++ b/frontend/src/i18n/locales/es/builder.json
@@ -8,7 +8,9 @@
     "opacityModified": "Opacidad ajustada"
   },
   "map": {
-    "ariaLabel": "Constructor de mapas"
+    "ariaLabel": "Constructor de mapas",
+    "autoFitMoved": "La vista se ajustó a las capas visibles",
+    "returnToPreviousView": "Volver a la vista anterior"
   },
   "mapNameLabel": "Nombre del mapa",
   "descriptionLabel": "Descripción del mapa",
@@ -1093,12 +1095,13 @@
     "emptyTitle": "Aún no hay historial de edición",
     "emptyDescription": "El historial comienza después de que se registren ediciones guardadas para este mapa.",
     "errorTitle": "No se pudo cargar el historial",
-    "errorDescription": "Intente cerrar y volver a abrir este panel.",
+    "errorDescription": "Comprueba tu conexión y vuelve a intentarlo.",
     "notAvailableTitle": "Guarde este mapa para ver el historial",
     "notAvailableDescription": "El historial de edición está disponible después de que el mapa exista.",
     "unknownTime": "Tiempo desconocido",
     "unknownActor": "Usuario desconocido",
-    "actorTarget": "{{actor}} - {{target}}"
+    "actorTarget": "{{actor}} - {{target}}",
+    "retry": "Intentar de nuevo"
   },
   "dock": {
     "askAi": "Preguntar a IA",

--- a/frontend/src/i18n/locales/fr/builder.json
+++ b/frontend/src/i18n/locales/fr/builder.json
@@ -8,7 +8,9 @@
     "opacityModified": "Opacité ajustée"
   },
   "map": {
-    "ariaLabel": "Constructeur de carte"
+    "ariaLabel": "Constructeur de carte",
+    "autoFitMoved": "La vue s’est ajustée aux couches visibles",
+    "returnToPreviousView": "Revenir à la vue précédente"
   },
   "mapNameLabel": "Nom de la carte",
   "descriptionLabel": "Description de la carte",
@@ -1093,12 +1095,13 @@
     "emptyTitle": "Aucun historique de modification",
     "emptyDescription": "L'historique commence après l'enregistrement des modifications pour cette carte.",
     "errorTitle": "Impossible de charger l'historique",
-    "errorDescription": "Essayez de fermer et rouvrir ce panneau.",
+    "errorDescription": "Vérifiez votre connexion, puis réessayez.",
     "notAvailableTitle": "Enregistrez cette carte pour voir l'historique",
     "notAvailableDescription": "L'historique de modification est disponible après la création de la carte.",
     "unknownTime": "Heure inconnue",
     "unknownActor": "Utilisateur inconnu",
-    "actorTarget": "{{actor}} - {{target}}"
+    "actorTarget": "{{actor}} - {{target}}",
+    "retry": "Réessayer"
   },
   "dock": {
     "askAi": "Demander à l'IA",


### PR DESCRIPTION
Closes items 1, 5, 6 and 9 of #787. Items 3 and 10 are out of scope here (both `AnalysisPanel`) and stay open on the issue.

## Item 1 — the result chip drew under the Legend panel

`EphemeralBadge` sat at `z-[8]`, under every `z-10` `PluginHost` slot. The bottom-left slot is offset to clear the badge, but a panel taller than that offset overlaps it and the z-index decides. `z-20`, matching the other map overlays (`MapTitlePill`, the BuilderMap warning box).

## Item 5 — dataset delete fired three 404 refetches

`useDeleteDataset` invalidated the deleted dataset's detail query, and `related/` + `maps/` sit under the `['datasets']` prefix its list invalidation matches, so all three refetched a resource that had just been deleted. Now: cancel those three, and keep the list invalidation off the deleted id via a predicate.

Cancel rather than remove, which the live check settled: the caller navigates away only after `mutateAsync` resolves, so the detail observer is still mounted when this runs, and removing an *active* query makes the observer rebuild it and fetch. Removing left one 404 where cancelling leaves none. Measured on a throwaway ingested dataset, deleted through the real dialog:

```
cancel + remove + predicate  ->  1 404  ["/api/datasets/{id}"]
cancel + predicate           ->  0 404s, 0 console errors     <- shipped
main                         ->  3 404s (detail, related/, maps/)
```

The stale cache entry ages out through `gcTime` instead.

## Item 6 — auto-fit jumped the viewport with no way back

The auto-fit effect captures the camera (center, zoom, bearing, pitch) before `fitBounds` and offers a one-shot "Return to previous view" through the existing toast-with-action pattern.

- Not on the first fit: there is no view the user chose yet, so the offer would be page-load noise.
- A second auto-fit dismisses the older offer rather than stacking it — its camera is no longer the one the user was looking at.
- The toast is dismissed once used.
- It runs longer than the default 4s. An auto-fit usually rides along with another toast ("Layer removed"), sonner collapses the stack, and the offer was expiring while it was still hidden behind the one in front. Found in QA, not in review.

Live: removing a layer whose extent drove the fit moved the camera to `42.80° N · 75.82° W · z 6.6`; the offer survived the sibling toast; clicking it returned the camera to `20.00° N · 0.00° E · z 2.0` and dismissed itself. No toast on page load.

## Item 9 — the history panel told people to close and reopen it

Refetching is what closing and reopening did, so the error state now carries the same "Try again" button `DatasetSearchPanel` uses, and the description says what to check instead of prescribing a workaround.

## Verification

```
cd frontend && npm run lint && npm run typecheck && npm run test:i18n && npm run test:coverage
# 366 files, 4288 tests pass
```

New tests: the badge's stacking context; the delete hook's cancel/predicate behaviour, including that it never removes an active query and that the predicate excludes only the deleted id; the history panel's retry button and that it calls `refetch`. Eight new locale entries across en/es/fr/de (two `map.*`, two `history.*`), plus a reworded `history.errorDescription`.

Item 6 has no unit test — the auto-fit path needs a live maplibre camera, and the QA run above is the check. Screenshots on request; the camera readouts above are from that run.