### PR TITLE
feat(analysis): sync the analysis job across tabs and dedup its completion

### DIFF
--- a/frontend/src/components/analysis/AnalysisJobWatcher.tsx
+++ b/frontend/src/components/analysis/AnalysisJobWatcher.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router';
 import { useQueryClient } from '@tanstack/react-query';
@@ -7,7 +7,12 @@ import { queryKeys } from '@/lib/query-keys';
 import { ApiError } from '@/api/client';
 import { useJobStatus } from '@/components/import/hooks/use-ingest';
 import { useAnalysisFormStore } from '@/stores/analysis-form-store';
-import { analysisAddToMap, useAnalysisAddedStore, useAnalysisJobStore } from '@/stores/analysis-job-store';
+import {
+  analysisAddToMap,
+  useAnalysisAddedStore,
+  useAnalysisJobStore,
+  type TrackedAnalysisJob,
+} from '@/stores/analysis-job-store';
 
 /**
  * Global notifier for a materialize-analysis job (renders nothing).
@@ -20,8 +25,14 @@ import { analysisAddToMap, useAnalysisAddedStore, useAnalysisJobStore } from '@/
 export function AnalysisJobWatcher() {
   const { t } = useTranslation('builder');
   const job = useAnalysisJobStore((s) => s.job);
+  const completedAt = useAnalysisJobStore((s) => s.completedAt);
   const claimCompletion = useAnalysisJobStore((s) => s.claimCompletion);
   const clearJobIfCurrent = useAnalysisJobStore((s) => s.clearJobIfCurrent);
+  // Runs whose terminal status this tab has already acted on, so neither the
+  // effect below nor the propagated-clear cleanup repeats itself.
+  const handledRef = useRef<Set<string>>(new Set());
+  // The job as of the previous render, so a disappearance is detectable.
+  const lastSeenRef = useRef<TrackedAnalysisJob | null>(null);
   const queryClient = useQueryClient();
   const navigate = useNavigate();
   // Shares its query key with the Analysis panel, so both watching costs one poll.
@@ -60,6 +71,15 @@ export function AnalysisJobWatcher() {
     // staleness rule of its own; it mirrors the server's verdict.
     if (status !== 'complete' && status !== 'failed') return;
 
+    // Once per job per tab. The clear used to be synchronous, so a re-run
+    // simply fell out at `if (!job)`; now the claim is awaited, and any render
+    // in between re-enters — including the one the claim's own store write
+    // causes, and the one a fresh `t` identity causes on every render. This
+    // also subsumes StrictMode's double invoke, which is why the effect needs
+    // no cleanup-based guard.
+    if (handledRef.current.has(job.jobId)) return;
+    handledRef.current.add(job.jobId);
+
     // fix(#1008 codex P2): the cache invalidation is deliberately NOT behind
     // the claim below. Every document owns its own QueryClient and the app
     // disables refetch-on-window-focus, so gating this would leave every tab
@@ -75,12 +95,7 @@ export function AnalysisJobWatcher() {
     // arbiter rather than a timing accident, so it also holds for a tab that
     // reloads after another already reported.
     const tracked = job;
-    let superseded = false;
-    void claimCompletion(tracked.jobId).then((claimed) => {
-      // The effect re-ran while the claim was in flight (StrictMode, or a new
-      // poll response). That run owns the outcome; acting here would double
-      // whatever it already did.
-      if (superseded) return;
+    void claimCompletion(tracked.jobId, status).then((claimed) => {
       if (claimed) {
         // Stable id so a re-run (StrictMode's double invoke) replaces the toast
         // instead of stacking a second one. That collapses duplicates WITHIN a
@@ -202,9 +217,6 @@ export function AnalysisJobWatcher() {
       }
       void clearJobIfCurrent(tracked.jobId);
     });
-    return () => {
-      superseded = true;
-    };
   }, [
     job,
     status,
@@ -216,6 +228,28 @@ export function AnalysisJobWatcher() {
     clearJobIfCurrent,
     t,
   ]);
+
+  // fix(#1008 codex P2): the clear propagates, so a tab that was throttled
+  // through the terminal poll simply watches its tracked job vanish. Its
+  // effect above then returns at `if (!job)` and it never runs the cleanup
+  // that is document-local: its own QueryClient (focus refetching is off, so
+  // nothing else refreshes it) and its own remembered form title. The claim
+  // carries the status precisely so a tab that did not observe the run's end
+  // still knows what kind of end it was.
+  useEffect(() => {
+    const previous = lastSeenRef.current;
+    lastSeenRef.current = job;
+    if (job || !previous) return;
+    // This tab reported the run itself, so it already did all of this.
+    if (handledRef.current.has(previous.jobId)) return;
+    // A clear with no claim behind it is a logout or an identity change, not
+    // a completion — nothing was created and nothing needs refreshing.
+    if (completedAt?.jobId !== previous.jobId) return;
+    if (completedAt.status !== 'complete') return;
+    queryClient.invalidateQueries({ queryKey: queryKeys.datasets.all });
+    queryClient.invalidateQueries({ queryKey: queryKeys.search.all });
+    useAnalysisFormStore.getState().clearTitleForMap(previous.mapId);
+  }, [job, completedAt, queryClient]);
 
   return null;
 }

--- a/frontend/src/components/analysis/AnalysisJobWatcher.tsx
+++ b/frontend/src/components/analysis/AnalysisJobWatcher.tsx
@@ -44,7 +44,7 @@ export function AnalysisJobWatcher() {
       // (#793 review): restoring it would re-enable Create with the finished
       // run's name.
       useAnalysisFormStore.getState().clearTitleForMap(job.mapId);
-      clearJobIfCurrent(job.jobId);
+      void clearJobIfCurrent(job.jobId);
       return;
     }
     // Only a terminal status stops tracking — deliberately no client-side
@@ -200,7 +200,7 @@ export function AnalysisJobWatcher() {
       if (status === 'complete') {
         useAnalysisFormStore.getState().clearTitleForMap(tracked.mapId);
       }
-      clearJobIfCurrent(tracked.jobId);
+      void clearJobIfCurrent(tracked.jobId);
     });
     return () => {
       superseded = true;

--- a/frontend/src/components/analysis/AnalysisJobWatcher.tsx
+++ b/frontend/src/components/analysis/AnalysisJobWatcher.tsx
@@ -28,9 +28,14 @@ export function AnalysisJobWatcher() {
   const completedAt = useAnalysisJobStore((s) => s.completedAt);
   const claimCompletion = useAnalysisJobStore((s) => s.claimCompletion);
   const clearJobIfCurrent = useAnalysisJobStore((s) => s.clearJobIfCurrent);
-  // Runs whose terminal status this tab has already acted on, so neither the
-  // effect below nor the propagated-clear cleanup repeats itself.
+  // Runs whose terminal status this tab has already acted on, so the effect
+  // below does not re-enter for one it is already seeing through.
   const handledRef = useRef<Set<string>>(new Set());
+  // Runs this tab has already refreshed its caches for.
+  const refreshedRef = useRef<Set<string>>(new Set());
+  // Runs whose remembered form title this tab has already settled — retired,
+  // or deliberately kept because the run failed.
+  const titleRetiredRef = useRef<Set<string>>(new Set());
   // The job as of the previous render, so a departure is detectable.
   const lastSeenRef = useRef<TrackedAnalysisJob | null>(null);
   // A departed job still owed its document-local cleanup, waiting for the
@@ -58,6 +63,7 @@ export function AnalysisJobWatcher() {
       // (#793 review): restoring it would re-enable Create with the finished
       // run's name.
       useAnalysisFormStore.getState().clearTitleForMap(job.mapId);
+      titleRetiredRef.current.add(job.jobId);
       void clearJobIfCurrent(job.jobId);
       return;
     }
@@ -89,6 +95,7 @@ export function AnalysisJobWatcher() {
     // but the winner showing a catalog that omits the dataset just created.
     // Reporting is what must happen once; refreshing must happen everywhere.
     if (status === 'complete') {
+      refreshedRef.current.add(job.jobId);
       queryClient.invalidateQueries({ queryKey: queryKeys.datasets.all });
       queryClient.invalidateQueries({ queryKey: queryKeys.search.all });
     }
@@ -215,6 +222,10 @@ export function AnalysisJobWatcher() {
       //
       // Outside the claim: a tab that lost still has to stop offering the
       // finished run's name and re-enable its own Create button.
+      // Settled either way: a failed run KEEPS its name for the retry, which
+      // is a decision, not an omission — the departure handler below must not
+      // second-guess it.
+      titleRetiredRef.current.add(tracked.jobId);
       if (status === 'complete') {
         useAnalysisFormStore.getState().clearTitleForMap(tracked.mapId);
       }
@@ -236,48 +247,52 @@ export function AnalysisJobWatcher() {
   // through the terminal poll simply watches its tracked job go away. The
   // effect above then returns at `if (!job)` and it never runs the cleanup
   // that is document-local: its own QueryClient (focus refetching is off, so
-  // nothing else refreshes it) and its own remembered form title. The claim
-  // carries the status precisely so a tab that did not observe the run's end
-  // still knows what kind of end it was.
+  // nothing else refreshes it) and its own remembered form title.
   //
-  // fix(#1008 codex P2, second pass): "went away" is not "became null". A tab
-  // that resumes after another cleared job1 and started job2 rehydrates from
-  // the latest payload and can go straight from job1 to job2, never rendering
-  // null in between. And the claim need not arrive on the same render, so the
-  // departed job waits in a ref until one names it.
+  // The two halves have DIFFERENT keys, which is what earlier passes kept
+  // getting wrong by handling them together.
+  //
+  // Refreshing is keyed on the CLAIM and is not job-specific: one
+  // invalidation re-reads the whole catalog, so a tab suspended across
+  // several runs needs exactly one, for whichever claim it can see.
+  //
+  // Retiring the remembered title is keyed on the DEPARTURE of the run this
+  // tab was showing, because that title is what its form would reopen with.
+  // It deliberately does not wait for a claim: the claim and the clear are
+  // separate persisted writes and arrive in either order, and a job swept by
+  // the retention sweep (401/403/404) departs with no claim at all. Keeping a
+  // finished run's name invites an accidental duplicate, so an unexplained
+  // departure retires it — the same reading the `gone` branch above already
+  // takes in whichever tab observes the sweep itself. A claim that says the
+  // run FAILED is the one case that keeps the name, for the retry.
   useEffect(() => {
     const previous = lastSeenRef.current;
     lastSeenRef.current = job;
     if (
       previous &&
       previous.jobId !== job?.jobId &&
-      // This tab reported the run itself, so it already did all of this.
-      !handledRef.current.has(previous.jobId)
+      !titleRetiredRef.current.has(previous.jobId)
     ) {
       // At most one: the store tracks a single run, so an older departed job
-      // has had its claim slot overwritten and can never be matched by id.
+      // has already been superseded here.
       pendingCleanupRef.current = previous;
     }
-    // fix(#1008 codex P2, third pass): keyed on the CLAIM, not on which job
-    // departed. A tab suspended across two whole runs resumes to a claim
-    // naming the second while it remembers the first, and matching ids would
-    // then refresh for neither — leaving it a catalog missing both outputs,
-    // with focus refetching disabled and nothing else to correct it.
-    //
-    // Refreshing is not job-specific anyway: an invalidation re-reads the
-    // whole catalog, so one is enough however many runs it slept through.
-    if (!completedAt || handledRef.current.has(completedAt.jobId)) return;
-    handledRef.current.add(completedAt.jobId);
-    if (completedAt.status !== 'complete') return;
-    queryClient.invalidateQueries({ queryKey: queryKeys.datasets.all });
-    queryClient.invalidateQueries({ queryKey: queryKeys.search.all });
-    // The remembered title IS job-specific — it belongs to the run this tab
-    // was showing, and only that run's completion retires it.
-    const pending = pendingCleanupRef.current;
-    if (pending && pending.jobId === completedAt.jobId) {
-      pendingCleanupRef.current = null;
-      useAnalysisFormStore.getState().clearTitleForMap(pending.mapId);
+
+    if (completedAt && !refreshedRef.current.has(completedAt.jobId)) {
+      refreshedRef.current.add(completedAt.jobId);
+      if (completedAt.status === 'complete') {
+        queryClient.invalidateQueries({ queryKey: queryKeys.datasets.all });
+        queryClient.invalidateQueries({ queryKey: queryKeys.search.all });
+      }
     }
+
+    const pending = pendingCleanupRef.current;
+    if (!pending) return;
+    pendingCleanupRef.current = null;
+    titleRetiredRef.current.add(pending.jobId);
+    const claim = completedAt?.jobId === pending.jobId ? completedAt : null;
+    if (claim?.status === 'failed') return;
+    useAnalysisFormStore.getState().clearTitleForMap(pending.mapId);
   }, [job, completedAt, queryClient]);
 
   return null;

--- a/frontend/src/components/analysis/AnalysisJobWatcher.tsx
+++ b/frontend/src/components/analysis/AnalysisJobWatcher.tsx
@@ -59,8 +59,24 @@ export function AnalysisJobWatcher() {
     // staleness rule of its own; it mirrors the server's verdict.
     if (status !== 'complete' && status !== 'failed') return;
 
+    // feat(#1008): with two builders open, both tabs poll this job and both
+    // reach here. Exactly one may report it — the claim is a written, durable
+    // arbiter rather than a timing accident, so it also holds for a tab that
+    // reloads after another already reported.
+    if (!useAnalysisJobStore.getState().claimCompletion(job.jobId)) {
+      // Still clear locally: this tab's Create button has to re-enable, and
+      // its remembered title belongs to a run that is over either way.
+      if (status === 'complete') {
+        useAnalysisFormStore.getState().clearTitleForMap(job.mapId);
+      }
+      setJob(null);
+      return;
+    }
+
     // Stable id so a re-run (StrictMode's double invoke) replaces the toast
-    // instead of stacking a second one.
+    // instead of stacking a second one. That collapses duplicates WITHIN a
+    // tab only — each tab has its own toaster, which is why the claim above
+    // is what makes it one across tabs.
     const toastId = `analysis-job-${job.jobId}`;
     if (status === 'complete') {
       queryClient.invalidateQueries({ queryKey: queryKeys.datasets.all });

--- a/frontend/src/components/analysis/AnalysisJobWatcher.tsx
+++ b/frontend/src/components/analysis/AnalysisJobWatcher.tsx
@@ -31,8 +31,11 @@ export function AnalysisJobWatcher() {
   // Runs whose terminal status this tab has already acted on, so neither the
   // effect below nor the propagated-clear cleanup repeats itself.
   const handledRef = useRef<Set<string>>(new Set());
-  // The job as of the previous render, so a disappearance is detectable.
+  // The job as of the previous render, so a departure is detectable.
   const lastSeenRef = useRef<TrackedAnalysisJob | null>(null);
+  // A departed job still owed its document-local cleanup, waiting for the
+  // claim that says how it ended.
+  const pendingCleanupRef = useRef<TrackedAnalysisJob | null>(null);
   const queryClient = useQueryClient();
   const navigate = useNavigate();
   // Shares its query key with the Analysis panel, so both watching costs one poll.
@@ -230,25 +233,42 @@ export function AnalysisJobWatcher() {
   ]);
 
   // fix(#1008 codex P2): the clear propagates, so a tab that was throttled
-  // through the terminal poll simply watches its tracked job vanish. Its
+  // through the terminal poll simply watches its tracked job go away. The
   // effect above then returns at `if (!job)` and it never runs the cleanup
   // that is document-local: its own QueryClient (focus refetching is off, so
   // nothing else refreshes it) and its own remembered form title. The claim
   // carries the status precisely so a tab that did not observe the run's end
   // still knows what kind of end it was.
+  //
+  // fix(#1008 codex P2, second pass): "went away" is not "became null". A tab
+  // that resumes after another cleared job1 and started job2 rehydrates from
+  // the latest payload and can go straight from job1 to job2, never rendering
+  // null in between. And the claim need not arrive on the same render, so the
+  // departed job waits in a ref until one names it.
   useEffect(() => {
     const previous = lastSeenRef.current;
     lastSeenRef.current = job;
-    if (job || !previous) return;
-    // This tab reported the run itself, so it already did all of this.
-    if (handledRef.current.has(previous.jobId)) return;
-    // A clear with no claim behind it is a logout or an identity change, not
-    // a completion — nothing was created and nothing needs refreshing.
-    if (completedAt?.jobId !== previous.jobId) return;
+    if (
+      previous &&
+      previous.jobId !== job?.jobId &&
+      // This tab reported the run itself, so it already did all of this.
+      !handledRef.current.has(previous.jobId)
+    ) {
+      // At most one: the store tracks a single run, so an older pending job
+      // has had its claim slot overwritten and can never be matched again.
+      pendingCleanupRef.current = previous;
+    }
+    const pending = pendingCleanupRef.current;
+    // No claim naming it means a logout or an identity change rather than a
+    // completion — nothing was created, so nothing needs refreshing. Keep it
+    // pending in case the claim is still on its way.
+    if (!pending || completedAt?.jobId !== pending.jobId) return;
+    pendingCleanupRef.current = null;
+    handledRef.current.add(pending.jobId);
     if (completedAt.status !== 'complete') return;
     queryClient.invalidateQueries({ queryKey: queryKeys.datasets.all });
     queryClient.invalidateQueries({ queryKey: queryKeys.search.all });
-    useAnalysisFormStore.getState().clearTitleForMap(previous.mapId);
+    useAnalysisFormStore.getState().clearTitleForMap(pending.mapId);
   }, [job, completedAt, queryClient]);
 
   return null;

--- a/frontend/src/components/analysis/AnalysisJobWatcher.tsx
+++ b/frontend/src/components/analysis/AnalysisJobWatcher.tsx
@@ -280,10 +280,14 @@ export function AnalysisJobWatcher() {
 
     if (completedAt && !refreshedRef.current.has(completedAt.jobId)) {
       refreshedRef.current.add(completedAt.jobId);
-      if (completedAt.status === 'complete') {
-        queryClient.invalidateQueries({ queryKey: queryKeys.datasets.all });
-        queryClient.invalidateQueries({ queryKey: queryKeys.search.all });
-      }
+      // fix(#1008 codex P2): deliberately NOT gated on the status. A tab
+      // suspended while one run succeeded and a later one failed resumes to
+      // the failed claim only, and gating here would leave it a catalog
+      // missing the first run's dataset with nothing to correct it. A refetch
+      // after a failure costs one request; a permanently stale catalog does
+      // not correct itself.
+      queryClient.invalidateQueries({ queryKey: queryKeys.datasets.all });
+      queryClient.invalidateQueries({ queryKey: queryKeys.search.all });
     }
 
     const pending = pendingCleanupRef.current;

--- a/frontend/src/components/analysis/AnalysisJobWatcher.tsx
+++ b/frontend/src/components/analysis/AnalysisJobWatcher.tsx
@@ -254,21 +254,30 @@ export function AnalysisJobWatcher() {
       // This tab reported the run itself, so it already did all of this.
       !handledRef.current.has(previous.jobId)
     ) {
-      // At most one: the store tracks a single run, so an older pending job
-      // has had its claim slot overwritten and can never be matched again.
+      // At most one: the store tracks a single run, so an older departed job
+      // has had its claim slot overwritten and can never be matched by id.
       pendingCleanupRef.current = previous;
     }
-    const pending = pendingCleanupRef.current;
-    // No claim naming it means a logout or an identity change rather than a
-    // completion — nothing was created, so nothing needs refreshing. Keep it
-    // pending in case the claim is still on its way.
-    if (!pending || completedAt?.jobId !== pending.jobId) return;
-    pendingCleanupRef.current = null;
-    handledRef.current.add(pending.jobId);
+    // fix(#1008 codex P2, third pass): keyed on the CLAIM, not on which job
+    // departed. A tab suspended across two whole runs resumes to a claim
+    // naming the second while it remembers the first, and matching ids would
+    // then refresh for neither — leaving it a catalog missing both outputs,
+    // with focus refetching disabled and nothing else to correct it.
+    //
+    // Refreshing is not job-specific anyway: an invalidation re-reads the
+    // whole catalog, so one is enough however many runs it slept through.
+    if (!completedAt || handledRef.current.has(completedAt.jobId)) return;
+    handledRef.current.add(completedAt.jobId);
     if (completedAt.status !== 'complete') return;
     queryClient.invalidateQueries({ queryKey: queryKeys.datasets.all });
     queryClient.invalidateQueries({ queryKey: queryKeys.search.all });
-    useAnalysisFormStore.getState().clearTitleForMap(pending.mapId);
+    // The remembered title IS job-specific — it belongs to the run this tab
+    // was showing, and only that run's completion retires it.
+    const pending = pendingCleanupRef.current;
+    if (pending && pending.jobId === completedAt.jobId) {
+      pendingCleanupRef.current = null;
+      useAnalysisFormStore.getState().clearTitleForMap(pending.mapId);
+    }
   }, [job, completedAt, queryClient]);
 
   return null;

--- a/frontend/src/components/analysis/AnalysisJobWatcher.tsx
+++ b/frontend/src/components/analysis/AnalysisJobWatcher.tsx
@@ -20,7 +20,8 @@ import { analysisAddToMap, useAnalysisAddedStore, useAnalysisJobStore } from '@/
 export function AnalysisJobWatcher() {
   const { t } = useTranslation('builder');
   const job = useAnalysisJobStore((s) => s.job);
-  const setJob = useAnalysisJobStore((s) => s.setJob);
+  const claimCompletion = useAnalysisJobStore((s) => s.claimCompletion);
+  const clearJobIfCurrent = useAnalysisJobStore((s) => s.clearJobIfCurrent);
   const queryClient = useQueryClient();
   const navigate = useNavigate();
   // Shares its query key with the Analysis panel, so both watching costs one poll.
@@ -43,7 +44,7 @@ export function AnalysisJobWatcher() {
       // (#793 review): restoring it would re-enable Create with the finished
       // run's name.
       useAnalysisFormStore.getState().clearTitleForMap(job.mapId);
-      setJob(null);
+      clearJobIfCurrent(job.jobId);
       return;
     }
     // Only a terminal status stops tracking — deliberately no client-side
@@ -59,138 +60,162 @@ export function AnalysisJobWatcher() {
     // staleness rule of its own; it mirrors the server's verdict.
     if (status !== 'complete' && status !== 'failed') return;
 
+    // fix(#1008 codex P2): the cache invalidation is deliberately NOT behind
+    // the claim below. Every document owns its own QueryClient and the app
+    // disables refetch-on-window-focus, so gating this would leave every tab
+    // but the winner showing a catalog that omits the dataset just created.
+    // Reporting is what must happen once; refreshing must happen everywhere.
+    if (status === 'complete') {
+      queryClient.invalidateQueries({ queryKey: queryKeys.datasets.all });
+      queryClient.invalidateQueries({ queryKey: queryKeys.search.all });
+    }
+
     // feat(#1008): with two builders open, both tabs poll this job and both
     // reach here. Exactly one may report it — the claim is a written, durable
     // arbiter rather than a timing accident, so it also holds for a tab that
     // reloads after another already reported.
-    if (!useAnalysisJobStore.getState().claimCompletion(job.jobId)) {
-      // Still clear locally: this tab's Create button has to re-enable, and
-      // its remembered title belongs to a run that is over either way.
-      if (status === 'complete') {
-        useAnalysisFormStore.getState().clearTitleForMap(job.mapId);
-      }
-      setJob(null);
-      return;
-    }
-
-    // Stable id so a re-run (StrictMode's double invoke) replaces the toast
-    // instead of stacking a second one. That collapses duplicates WITHIN a
-    // tab only — each tab has its own toaster, which is why the claim above
-    // is what makes it one across tabs.
-    const toastId = `analysis-job-${job.jobId}`;
-    if (status === 'complete') {
-      queryClient.invalidateQueries({ queryKey: queryKeys.datasets.all });
-      queryClient.invalidateQueries({ queryKey: queryKeys.search.all });
-      const datasetId = data?.dataset_id;
-      const canAddToMap =
-        !!analysisAddToMap.current && analysisAddToMap.mapId === job.mapId;
-      // Sonner dismisses a toast when its action is clicked, but the exit
-      // animation leaves a window for a second click — and the panel's own
-      // "Add to map" button is a second affordance for the same add.
-      // fix(#833): the single-use guard is the SHARED useAnalysisAddedStore
-      // (it used to be a local flag per affordance, so toast + panel button
-      // together added the layer twice); the add itself stays repeatable
-      // elsewhere (adding a dataset twice is legitimate).
-      toast.success(
-        job.title
-          ? t('analysisTools.jobCompleteNamed', {
-              defaultValue: '“{{title}}” is ready',
-              title: job.title,
-            })
-          : t('analysisTools.jobComplete', { defaultValue: 'Dataset created' }),
-        {
-          id: toastId,
-          // fix(#725): the default bottom-right placement lands exactly on
-          // the rail panel's own "Add to map" button, and with an infinite
-          // duration the overlap is permanent, leaving the button visible
-          // but unclickable. When a builder for this map is mounted, raise
-          // the notification top-center, clear of the right rail; everywhere
-          // else the default corner stays.
-          position: canAddToMap ? ('top-center' as const) : undefined,
-          // A long job lands when attention has moved on, so the default 4s
-          // notification is one the user is likely to miss entirely. The
-          // Toaster is configured with closeButton, so this stays until
-          // acknowledged.
-          duration: Infinity,
-          action: datasetId
-            ? {
-                label: canAddToMap
-                  ? t('analysisTools.addToMap', { defaultValue: 'Add to map' })
-                  : t('analysisTools.viewDataset', { defaultValue: 'View dataset' }),
-                onClick: () => {
-                  // Re-check: the builder may have unmounted since this toast
-                  // was raised.
-                  if (
-                    analysisAddToMap.current &&
-                    analysisAddToMap.mapId === job.mapId
-                  ) {
-                    const added = useAnalysisAddedStore.getState();
-                    if (
-                      added.addedDatasetIds.includes(datasetId) ||
-                      added.pendingAddIds.includes(datasetId)
-                    ) {
-                      return;
-                    }
-                    added.markPending(datasetId);
-                    analysisAddToMap.current(datasetId);
-                  } else {
-                    // View-dataset path: navigation is idempotent, no guard.
-                    navigate(`/datasets/${datasetId}`);
+    const tracked = job;
+    let superseded = false;
+    void claimCompletion(tracked.jobId).then((claimed) => {
+      // The effect re-ran while the claim was in flight (StrictMode, or a new
+      // poll response). That run owns the outcome; acting here would double
+      // whatever it already did.
+      if (superseded) return;
+      if (claimed) {
+        // Stable id so a re-run (StrictMode's double invoke) replaces the toast
+        // instead of stacking a second one. That collapses duplicates WITHIN a
+        // tab only — each tab has its own toaster, which is why the claim above
+        // is what makes it one across tabs.
+        const toastId = `analysis-job-${job.jobId}`;
+        if (status === 'complete') {
+          const datasetId = data?.dataset_id;
+          const canAddToMap =
+            !!analysisAddToMap.current && analysisAddToMap.mapId === job.mapId;
+          // Sonner dismisses a toast when its action is clicked, but the exit
+          // animation leaves a window for a second click — and the panel's own
+          // "Add to map" button is a second affordance for the same add.
+          // fix(#833): the single-use guard is the SHARED useAnalysisAddedStore
+          // (it used to be a local flag per affordance, so toast + panel button
+          // together added the layer twice); the add itself stays repeatable
+          // elsewhere (adding a dataset twice is legitimate).
+          toast.success(
+            job.title
+              ? t('analysisTools.jobCompleteNamed', {
+                  defaultValue: '“{{title}}” is ready',
+                  title: job.title,
+                })
+              : t('analysisTools.jobComplete', { defaultValue: 'Dataset created' }),
+            {
+              id: toastId,
+              // fix(#725): the default bottom-right placement lands exactly on
+              // the rail panel's own "Add to map" button, and with an infinite
+              // duration the overlap is permanent, leaving the button visible
+              // but unclickable. When a builder for this map is mounted, raise
+              // the notification top-center, clear of the right rail; everywhere
+              // else the default corner stays.
+              position: canAddToMap ? ('top-center' as const) : undefined,
+              // A long job lands when attention has moved on, so the default 4s
+              // notification is one the user is likely to miss entirely. The
+              // Toaster is configured with closeButton, so this stays until
+              // acknowledged.
+              duration: Infinity,
+              action: datasetId
+                ? {
+                    label: canAddToMap
+                      ? t('analysisTools.addToMap', { defaultValue: 'Add to map' })
+                      : t('analysisTools.viewDataset', { defaultValue: 'View dataset' }),
+                    onClick: () => {
+                      // Re-check: the builder may have unmounted since this toast
+                      // was raised.
+                      if (
+                        analysisAddToMap.current &&
+                        analysisAddToMap.mapId === job.mapId
+                      ) {
+                        const added = useAnalysisAddedStore.getState();
+                        if (
+                          added.addedDatasetIds.includes(datasetId) ||
+                          added.pendingAddIds.includes(datasetId)
+                        ) {
+                          return;
+                        }
+                        added.markPending(datasetId);
+                        analysisAddToMap.current(datasetId);
+                      } else {
+                        // View-dataset path: navigation is idempotent, no guard.
+                        navigate(`/datasets/${datasetId}`);
+                      }
+                    },
                   }
-                },
-              }
-            : undefined,
-        },
-      );
-      // The backend persists a collision note (e.g. the output was renamed
-      // to avoid clobbering an existing dataset) in warning_message; surface
-      // it beside the success toast, mirroring the upload path's
-      // JobProgress warning. Raw message, same as JobProgress — it is
-      // operator-facing server prose with no client-side template.
-      if (data?.warning_message) {
-        toast.warning(data.warning_message, {
-          id: `${toastId}-warning`,
-          duration: Infinity,
-        });
+                : undefined,
+            },
+          );
+          // The backend persists a collision note (e.g. the output was renamed
+          // to avoid clobbering an existing dataset) in warning_message; surface
+          // it beside the success toast, mirroring the upload path's
+          // JobProgress warning. Raw message, same as JobProgress — it is
+          // operator-facing server prose with no client-side template.
+          if (data?.warning_message) {
+            toast.warning(data.warning_message, {
+              id: `${toastId}-warning`,
+              duration: Infinity,
+            });
+          }
+        } else {
+          const message = data?.error_message;
+          // Interpolate the detail through i18n rather than concatenating onto
+          // t(): check:i18n:toast-strings flags any toast call whose first
+          // argument opens with a quote or backtick, template literals included.
+          toast.error(
+            message
+              ? t('analysisTools.jobFailedDetail', {
+                  message,
+                  defaultValue: 'Analysis job failed: {{message}}',
+                })
+              : t('analysisTools.jobFailed', { defaultValue: 'Analysis job failed' }),
+            {
+              id: toastId,
+              duration: Infinity,
+              // Mirror the success branch's recovery action: the failure toast
+              // dead-ended with no way back to the run. Opening the map lands on
+              // the Analysis panel's remembered form — the failed run's name is
+              // deliberately kept there for the retry.
+              action: job.mapId
+                ? {
+                    label: t('analysisTools.openMap', { defaultValue: 'Open map' }),
+                    onClick: () => navigate(`/maps/${job.mapId}`),
+                  }
+                : undefined,
+            },
+          );
+        }
       }
-    } else {
-      const message = data?.error_message;
-      // Interpolate the detail through i18n rather than concatenating onto
-      // t(): check:i18n:toast-strings flags any toast call whose first
-      // argument opens with a quote or backtick, template literals included.
-      toast.error(
-        message
-          ? t('analysisTools.jobFailedDetail', {
-              message,
-              defaultValue: 'Analysis job failed: {{message}}',
-            })
-          : t('analysisTools.jobFailed', { defaultValue: 'Analysis job failed' }),
-        {
-          id: toastId,
-          duration: Infinity,
-          // Mirror the success branch's recovery action: the failure toast
-          // dead-ended with no way back to the run. Opening the map lands on
-          // the Analysis panel's remembered form — the failed run's name is
-          // deliberately kept there for the retry.
-          action: job.mapId
-            ? {
-                label: t('analysisTools.openMap', { defaultValue: 'Open map' }),
-                onClick: () => navigate(`/maps/${job.mapId}`),
-              }
-            : undefined,
-        },
-      );
-    }
-    // fix(#793 review): the remembered form title belongs to a finished run —
-    // restoring it on the panel's next mount would re-enable Create with the
-    // old name and invite an identically-named duplicate. Success only: a
-    // failed run created nothing, and the user most likely retries it under
-    // the same name.
-    if (status === 'complete') {
-      useAnalysisFormStore.getState().clearTitleForMap(job.mapId);
-    }
-    setJob(null);
-  }, [job, status, gone, data, queryClient, navigate, setJob, t]);
+      // fix(#793 review): the remembered form title belongs to a finished run —
+      // restoring it on the panel's next mount would re-enable Create with the
+      // old name and invite an identically-named duplicate. Success only: a
+      // failed run created nothing, and the user most likely retries it under
+      // the same name.
+      //
+      // Outside the claim: a tab that lost still has to stop offering the
+      // finished run's name and re-enable its own Create button.
+      if (status === 'complete') {
+        useAnalysisFormStore.getState().clearTitleForMap(tracked.mapId);
+      }
+      clearJobIfCurrent(tracked.jobId);
+    });
+    return () => {
+      superseded = true;
+    };
+  }, [
+    job,
+    status,
+    gone,
+    data,
+    queryClient,
+    navigate,
+    claimCompletion,
+    clearJobIfCurrent,
+    t,
+  ]);
 
   return null;
 }

--- a/frontend/src/components/analysis/__tests__/AnalysisJobWatcher.test.tsx
+++ b/frontend/src/components/analysis/__tests__/AnalysisJobWatcher.test.tsx
@@ -3,7 +3,12 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { toast } from 'sonner';
 import { AnalysisJobWatcher } from '../AnalysisJobWatcher';
 import { useAnalysisFormStore } from '@/stores/analysis-form-store';
-import { analysisAddToMap, useAnalysisAddedStore, useAnalysisJobStore } from '@/stores/analysis-job-store';
+import {
+  ANALYSIS_JOB_STORAGE_KEY,
+  analysisAddToMap,
+  useAnalysisAddedStore,
+  useAnalysisJobStore,
+} from '@/stores/analysis-job-store';
 import { useAuthStore } from '@/stores/auth-store';
 import { useJobStatus } from '@/components/import/hooks/use-ingest';
 import { ApiError } from '@/api/client';
@@ -47,7 +52,8 @@ function mockJob(data: unknown, error: unknown = null) {
 describe('AnalysisJobWatcher', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    useAnalysisJobStore.setState({ job: null });
+    useAnalysisJobStore.setState({ job: null, completedAt: null });
+    localStorage.removeItem(ANALYSIS_JOB_STORAGE_KEY);
     useAnalysisAddedStore.setState({ addedDatasetIds: [], pendingAddIds: [] });
     analysisAddToMap.current = null;
     analysisAddToMap.mapId = null;
@@ -148,6 +154,75 @@ describe('AnalysisJobWatcher', () => {
     // A long job lands after attention has moved on — the notification has to wait.
     expect(options?.duration).toBe(Infinity);
     expect(useAnalysisJobStore.getState().job).toBeNull();
+  });
+
+  // feat(#1008): two builders open means two watchers polling the same job.
+  // Without a claim each raises its own toast and its own invalidation — the
+  // per-job toastId only collapses StrictMode's double invoke within one tab.
+  it('stays silent when another tab already claimed the completion', async () => {
+    useAnalysisFormStore.getState().save('m1', {
+      layerId: 'l1', operation: 'buffer', distance: '500', distanceUnit: 'm',
+      mask: null, maskLayerId: '__none__', byField: '__none__',
+      outputTitle: 'Walkshed',
+    });
+    useAnalysisJobStore.setState({ job: { jobId: 'j1', title: 'Buffered', mapId: 'm1' } });
+    // Seeded AFTER the setState above, which writes the store through and
+    // would otherwise flatten the foreign claim back to null.
+    localStorage.setItem(
+      ANALYSIS_JOB_STORAGE_KEY,
+      JSON.stringify({
+        state: {
+          job: { jobId: 'j1', title: 'Buffered', mapId: 'm1' },
+          completedAt: { jobId: 'j1', tabId: 'some-other-tab', at: Date.now() },
+        },
+        version: 1,
+      }),
+    );
+    const invalidate = vi.spyOn(QueryClient.prototype, 'invalidateQueries');
+    mockJob({ status: 'complete', dataset_id: 'ds9' });
+
+    renderWatcher();
+
+    await waitFor(() => expect(useAnalysisJobStore.getState().job).toBeNull());
+    expect(toast.success).not.toHaveBeenCalled();
+    expect(invalidate).not.toHaveBeenCalled();
+    // The local cleanup still runs: this tab's Create button has to re-enable,
+    // and the finished run's name must not come back with it.
+    expect(useAnalysisFormStore.getState().forms['m1']?.outputTitle).toBe('');
+    invalidate.mockRestore();
+  });
+
+  it('stays silent on a FAILED job another tab already claimed', async () => {
+    useAnalysisJobStore.setState({ job: { jobId: 'j1', title: 'Buffered', mapId: 'm1' } });
+    localStorage.setItem(
+      ANALYSIS_JOB_STORAGE_KEY,
+      JSON.stringify({
+        state: {
+          job: { jobId: 'j1', title: 'Buffered', mapId: 'm1' },
+          completedAt: { jobId: 'j1', tabId: 'some-other-tab', at: Date.now() },
+        },
+        version: 1,
+      }),
+    );
+    mockJob({ status: 'failed', dataset_id: null, error_message: 'no features' });
+
+    renderWatcher();
+
+    await waitFor(() => expect(useAnalysisJobStore.getState().job).toBeNull());
+    expect(toast.error).not.toHaveBeenCalled();
+  });
+
+  it('reports and invalidates exactly once when it wins the claim', async () => {
+    useAnalysisJobStore.setState({ job: { jobId: 'j1', title: 'Buffered', mapId: 'm1' } });
+    const invalidate = vi.spyOn(QueryClient.prototype, 'invalidateQueries');
+    mockJob({ status: 'complete', dataset_id: 'ds9' });
+
+    renderWatcher();
+
+    await waitFor(() => expect(toast.success).toHaveBeenCalledTimes(1));
+    // Datasets and search, one apiece.
+    expect(invalidate).toHaveBeenCalledTimes(2);
+    invalidate.mockRestore();
   });
 
   it('offers Add to map only when a builder for that map is mounted', async () => {

--- a/frontend/src/components/analysis/__tests__/AnalysisJobWatcher.test.tsx
+++ b/frontend/src/components/analysis/__tests__/AnalysisJobWatcher.test.tsx
@@ -1,4 +1,4 @@
-import { render, waitFor } from '@testing-library/react';
+import { act, render, waitFor } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { toast } from 'sonner';
 import { AnalysisJobWatcher } from '../AnalysisJobWatcher';
@@ -225,6 +225,61 @@ describe('AnalysisJobWatcher', () => {
     await waitFor(() => expect(toast.success).toHaveBeenCalledTimes(1));
     // Datasets and search, one apiece.
     expect(invalidate).toHaveBeenCalledTimes(2);
+    invalidate.mockRestore();
+  });
+
+  // fix(#1008 codex P2): a tab throttled through the terminal poll never sees
+  // it — the job simply vanishes when the reporting tab's clear propagates.
+  // Its QueryClient and its remembered form title are document-local, so
+  // without this it keeps a catalog that omits the new dataset and reopens the
+  // form with the finished run's name.
+  it('runs its local cleanup when another tab clears a completed job', async () => {
+    useAnalysisFormStore.getState().save('m1', {
+      layerId: 'l1', operation: 'buffer', distance: '500', distanceUnit: 'm',
+      mask: null, maskLayerId: '__none__', byField: '__none__',
+      outputTitle: 'Walkshed',
+    });
+    useAnalysisJobStore.setState({ job: { jobId: 'j1', title: 'Buffered', mapId: 'm1' } });
+    // Still running as far as this tab knows.
+    mockJob({ status: 'running', dataset_id: null });
+    const invalidate = vi.spyOn(QueryClient.prototype, 'invalidateQueries');
+    renderWatcher();
+    expect(invalidate).not.toHaveBeenCalled();
+
+    // The reporting tab's claim and clear arrive together through the mirror.
+    act(() => {
+      useAnalysisJobStore.setState({
+        job: null,
+        completedAt: {
+          jobId: 'j1',
+          tabId: 'some-other-tab',
+          status: 'complete',
+          at: Date.now(),
+        },
+      });
+    });
+
+    await waitFor(() => expect(invalidate).toHaveBeenCalledTimes(2));
+    expect(useAnalysisFormStore.getState().forms['m1']?.outputTitle).toBe('');
+    // Reporting still belongs to the tab that claimed it.
+    expect(toast.success).not.toHaveBeenCalled();
+    invalidate.mockRestore();
+  });
+
+  it('does not refresh when the job is cleared without a completion claim', async () => {
+    useAnalysisJobStore.setState({ job: { jobId: 'j1', title: 'Buffered', mapId: 'm1' } });
+    mockJob({ status: 'running', dataset_id: null });
+    const invalidate = vi.spyOn(QueryClient.prototype, 'invalidateQueries');
+    renderWatcher();
+
+    // A logout or an identity change clears the job with no claim behind it —
+    // nothing was created, so there is nothing to refresh.
+    act(() => {
+      useAnalysisJobStore.setState({ job: null, completedAt: null });
+    });
+
+    await waitFor(() => expect(useAnalysisJobStore.getState().job).toBeNull());
+    expect(invalidate).not.toHaveBeenCalled();
     invalidate.mockRestore();
   });
 

--- a/frontend/src/components/analysis/__tests__/AnalysisJobWatcher.test.tsx
+++ b/frontend/src/components/analysis/__tests__/AnalysisJobWatcher.test.tsx
@@ -326,6 +326,33 @@ describe('AnalysisJobWatcher', () => {
     invalidate.mockRestore();
   });
 
+  // fix(#1008 codex P2, third pass): a tab suspended across two whole runs
+  // resumes to a claim naming the second while it still remembers the first.
+  // Refreshing is not job-specific — one invalidation re-reads the whole
+  // catalog — so it has to fire on the claim it can see, not on an id match.
+  it('refreshes on a claim for a run it never tracked', async () => {
+    useAnalysisJobStore.setState({ job: { jobId: 'j1', title: 'Buffered', mapId: 'm1' } });
+    mockJob({ status: 'running', dataset_id: null });
+    const invalidate = vi.spyOn(QueryClient.prototype, 'invalidateQueries');
+    renderWatcher();
+
+    // It slept through j1 finishing, j2 starting, and j2 finishing.
+    act(() => {
+      useAnalysisJobStore.setState({
+        job: null,
+        completedAt: {
+          jobId: 'j2',
+          tabId: 'some-other-tab',
+          status: 'complete',
+          at: Date.now(),
+        },
+      });
+    });
+
+    await waitFor(() => expect(invalidate).toHaveBeenCalledTimes(2));
+    invalidate.mockRestore();
+  });
+
   it('does not refresh when the job is cleared without a completion claim', async () => {
     useAnalysisJobStore.setState({ job: { jobId: 'j1', title: 'Buffered', mapId: 'm1' } });
     mockJob({ status: 'running', dataset_id: null });

--- a/frontend/src/components/analysis/__tests__/AnalysisJobWatcher.test.tsx
+++ b/frontend/src/components/analysis/__tests__/AnalysisJobWatcher.test.tsx
@@ -266,6 +266,66 @@ describe('AnalysisJobWatcher', () => {
     invalidate.mockRestore();
   });
 
+  // fix(#1008 codex P2, second pass): a resuming tab rehydrates from the
+  // latest payload, so it can go straight from job1 to job2 without ever
+  // rendering null. job1's cleanup is owed all the same.
+  it('runs the cleanup when a completed job is replaced by the next one', async () => {
+    useAnalysisFormStore.getState().save('m1', {
+      layerId: 'l1', operation: 'buffer', distance: '500', distanceUnit: 'm',
+      mask: null, maskLayerId: '__none__', byField: '__none__',
+      outputTitle: 'Walkshed',
+    });
+    useAnalysisJobStore.setState({ job: { jobId: 'j1', title: 'Buffered', mapId: 'm1' } });
+    mockJob({ status: 'running', dataset_id: null });
+    const invalidate = vi.spyOn(QueryClient.prototype, 'invalidateQueries');
+    renderWatcher();
+
+    act(() => {
+      useAnalysisJobStore.setState({
+        job: { jobId: 'j2', title: 'Next run', mapId: 'm1' },
+        completedAt: {
+          jobId: 'j1',
+          tabId: 'some-other-tab',
+          status: 'complete',
+          at: Date.now(),
+        },
+      });
+    });
+
+    await waitFor(() => expect(invalidate).toHaveBeenCalledTimes(2));
+    expect(useAnalysisFormStore.getState().forms['m1']?.outputTitle).toBe('');
+    // ...and the replacement run is still being tracked.
+    expect(useAnalysisJobStore.getState().job?.jobId).toBe('j2');
+    invalidate.mockRestore();
+  });
+
+  it('waits for the claim when it arrives after the job is replaced', async () => {
+    useAnalysisJobStore.setState({ job: { jobId: 'j1', title: 'Buffered', mapId: 'm1' } });
+    mockJob({ status: 'running', dataset_id: null });
+    const invalidate = vi.spyOn(QueryClient.prototype, 'invalidateQueries');
+    renderWatcher();
+
+    // The two storage writes need not land on one render.
+    act(() => {
+      useAnalysisJobStore.setState({ job: { jobId: 'j2', title: 'Next', mapId: 'm1' } });
+    });
+    expect(invalidate).not.toHaveBeenCalled();
+
+    act(() => {
+      useAnalysisJobStore.setState({
+        completedAt: {
+          jobId: 'j1',
+          tabId: 'some-other-tab',
+          status: 'complete',
+          at: Date.now(),
+        },
+      });
+    });
+
+    await waitFor(() => expect(invalidate).toHaveBeenCalledTimes(2));
+    invalidate.mockRestore();
+  });
+
   it('does not refresh when the job is cleared without a completion claim', async () => {
     useAnalysisJobStore.setState({ job: { jobId: 'j1', title: 'Buffered', mapId: 'm1' } });
     mockJob({ status: 'running', dataset_id: null });

--- a/frontend/src/components/analysis/__tests__/AnalysisJobWatcher.test.tsx
+++ b/frontend/src/components/analysis/__tests__/AnalysisJobWatcher.test.tsx
@@ -353,6 +353,89 @@ describe('AnalysisJobWatcher', () => {
     invalidate.mockRestore();
   });
 
+  // fix(#1008 codex P2, fourth pass): claim and clear are separate persisted
+  // writes and arrive in either order, and a swept job departs with no claim
+  // at all. Retiring the remembered title therefore keys on the departure of
+  // the run this tab was showing, not on a claim turning up to explain it.
+  it('retires the remembered title when the claim lands before the clear', async () => {
+    useAnalysisFormStore.getState().save('m1', {
+      layerId: 'l1', operation: 'buffer', distance: '500', distanceUnit: 'm',
+      mask: null, maskLayerId: '__none__', byField: '__none__',
+      outputTitle: 'Walkshed',
+    });
+    useAnalysisJobStore.setState({ job: { jobId: 'j1', title: 'Buffered', mapId: 'm1' } });
+    mockJob({ status: 'running', dataset_id: null });
+    renderWatcher();
+
+    // The claim's storage event is processed first...
+    act(() => {
+      useAnalysisJobStore.setState({
+        completedAt: {
+          jobId: 'j1',
+          tabId: 'some-other-tab',
+          status: 'complete',
+          at: Date.now(),
+        },
+      });
+    });
+    // ...and the clear arrives on its own.
+    act(() => {
+      useAnalysisJobStore.setState({ job: null });
+    });
+
+    await waitFor(() =>
+      expect(useAnalysisFormStore.getState().forms['m1']?.outputTitle).toBe(''),
+    );
+  });
+
+  it('retires the remembered title when a swept job departs with no claim', async () => {
+    useAnalysisFormStore.getState().save('m1', {
+      layerId: 'l1', operation: 'buffer', distance: '500', distanceUnit: 'm',
+      mask: null, maskLayerId: '__none__', byField: '__none__',
+      outputTitle: 'Walkshed',
+    });
+    useAnalysisJobStore.setState({ job: { jobId: 'j1', title: 'Buffered', mapId: 'm1' } });
+    mockJob({ status: 'running', dataset_id: null });
+    renderWatcher();
+
+    // Another tab got the 401/403/404 and cleared. No claim is ever written
+    // for a swept run, so waiting for one would keep the name forever.
+    act(() => {
+      useAnalysisJobStore.setState({ job: null });
+    });
+
+    await waitFor(() =>
+      expect(useAnalysisFormStore.getState().forms['m1']?.outputTitle).toBe(''),
+    );
+  });
+
+  it('keeps the remembered title when the claim says the run failed', async () => {
+    useAnalysisFormStore.getState().save('m1', {
+      layerId: 'l1', operation: 'buffer', distance: '500', distanceUnit: 'm',
+      mask: null, maskLayerId: '__none__', byField: '__none__',
+      outputTitle: 'Walkshed',
+    });
+    useAnalysisJobStore.setState({ job: { jobId: 'j1', title: 'Buffered', mapId: 'm1' } });
+    mockJob({ status: 'running', dataset_id: null });
+    renderWatcher();
+
+    act(() => {
+      useAnalysisJobStore.setState({
+        job: null,
+        completedAt: {
+          jobId: 'j1',
+          tabId: 'some-other-tab',
+          status: 'failed',
+          at: Date.now(),
+        },
+      });
+    });
+
+    await waitFor(() => expect(useAnalysisJobStore.getState().job).toBeNull());
+    // Nothing was created — re-entering the name to retry would be pure loss.
+    expect(useAnalysisFormStore.getState().forms['m1']?.outputTitle).toBe('Walkshed');
+  });
+
   it('does not refresh when the job is cleared without a completion claim', async () => {
     useAnalysisJobStore.setState({ job: { jobId: 'j1', title: 'Buffered', mapId: 'm1' } });
     mockJob({ status: 'running', dataset_id: null });

--- a/frontend/src/components/analysis/__tests__/AnalysisJobWatcher.test.tsx
+++ b/frontend/src/components/analysis/__tests__/AnalysisJobWatcher.test.tsx
@@ -185,7 +185,10 @@ describe('AnalysisJobWatcher', () => {
 
     await waitFor(() => expect(useAnalysisJobStore.getState().job).toBeNull());
     expect(toast.success).not.toHaveBeenCalled();
-    expect(invalidate).not.toHaveBeenCalled();
+    // fix(#1008 codex P2): the claim dedups REPORTING, not refreshing. This
+    // tab has its own QueryClient and focus-refetch is off, so skipping the
+    // invalidation would leave it showing a catalog without the new dataset.
+    expect(invalidate).toHaveBeenCalledTimes(2);
     // The local cleanup still runs: this tab's Create button has to re-enable,
     // and the finished run's name must not come back with it.
     expect(useAnalysisFormStore.getState().forms['m1']?.outputTitle).toBe('');
@@ -212,7 +215,7 @@ describe('AnalysisJobWatcher', () => {
     expect(toast.error).not.toHaveBeenCalled();
   });
 
-  it('reports and invalidates exactly once when it wins the claim', async () => {
+  it('reports exactly once and invalidates its own caches when it wins', async () => {
     useAnalysisJobStore.setState({ job: { jobId: 'j1', title: 'Buffered', mapId: 'm1' } });
     const invalidate = vi.spyOn(QueryClient.prototype, 'invalidateQueries');
     mockJob({ status: 'complete', dataset_id: 'ds9' });

--- a/frontend/src/components/analysis/__tests__/AnalysisJobWatcher.test.tsx
+++ b/frontend/src/components/analysis/__tests__/AnalysisJobWatcher.test.tsx
@@ -436,6 +436,32 @@ describe('AnalysisJobWatcher', () => {
     expect(useAnalysisFormStore.getState().forms['m1']?.outputTitle).toBe('Walkshed');
   });
 
+  // fix(#1008 codex P2, fifth pass): a tab suspended while one run succeeded
+  // and a later one failed resumes to the failed claim only. Gating the
+  // refresh on the status would leave it a catalog missing the first run's
+  // dataset, with nothing to correct it.
+  it('refreshes on a failed claim too, since an earlier run may have succeeded', async () => {
+    useAnalysisJobStore.setState({ job: { jobId: 'j1', title: 'Buffered', mapId: 'm1' } });
+    mockJob({ status: 'running', dataset_id: null });
+    const invalidate = vi.spyOn(QueryClient.prototype, 'invalidateQueries');
+    renderWatcher();
+
+    act(() => {
+      useAnalysisJobStore.setState({
+        job: null,
+        completedAt: {
+          jobId: 'j2',
+          tabId: 'some-other-tab',
+          status: 'failed',
+          at: Date.now(),
+        },
+      });
+    });
+
+    await waitFor(() => expect(invalidate).toHaveBeenCalledTimes(2));
+    invalidate.mockRestore();
+  });
+
   it('does not refresh when the job is cleared without a completion claim', async () => {
     useAnalysisJobStore.setState({ job: { jobId: 'j1', title: 'Buffered', mapId: 'm1' } });
     mockJob({ status: 'running', dataset_id: null });

--- a/frontend/src/stores/__tests__/analysis-job-store.cross-tab.test.ts
+++ b/frontend/src/stores/__tests__/analysis-job-store.cross-tab.test.ts
@@ -107,18 +107,18 @@ describe('analysis-job-store completion claim', () => {
 
   it('is granted to the first caller and recorded in storage', async () => {
     await expect(
-      useAnalysisJobStore.getState().claimCompletion('job-1'),
+      useAnalysisJobStore.getState().claimCompletion('job-1', 'complete'),
     ).resolves.toBe(true);
     expect(storedState().completedAt).toMatchObject({ jobId: 'job-1' });
   });
 
   it('stays granted to the tab that won it', async () => {
-    await useAnalysisJobStore.getState().claimCompletion('job-1');
+    await useAnalysisJobStore.getState().claimCompletion('job-1', 'complete');
 
     // StrictMode invokes the watcher effect twice; the tab that already
     // reported must not silence itself on the second pass.
     await expect(
-      useAnalysisJobStore.getState().claimCompletion('job-1'),
+      useAnalysisJobStore.getState().claimCompletion('job-1', 'complete'),
     ).resolves.toBe(true);
   });
 
@@ -127,7 +127,7 @@ describe('analysis-job-store completion claim', () => {
     // clear, run again. A tab that has never tracked job-2 has no business
     // reporting it, which the stale-claim rule below depends on.
     await useAnalysisJobStore.getState().setJob(job);
-    await useAnalysisJobStore.getState().claimCompletion('job-1');
+    await useAnalysisJobStore.getState().claimCompletion('job-1', 'complete');
     await useAnalysisJobStore.getState().clearJobIfCurrent('job-1');
 
     await useAnalysisJobStore
@@ -135,7 +135,7 @@ describe('analysis-job-store completion claim', () => {
       .setJob({ jobId: 'job-2', title: 'Next run', mapId: 'map-1' });
 
     await expect(
-      useAnalysisJobStore.getState().claimCompletion('job-2'),
+      useAnalysisJobStore.getState().claimCompletion('job-2', 'complete'),
     ).resolves.toBe(true);
   });
 
@@ -146,11 +146,16 @@ describe('analysis-job-store completion claim', () => {
   it('refuses a stale run whose claim slot a newer one already owns', async () => {
     seedStorage({
       job: null,
-      completedAt: { jobId: 'job-2', tabId: 'some-other-tab', at: Date.now() },
+      completedAt: {
+        jobId: 'job-2',
+        tabId: 'some-other-tab',
+        status: 'complete' as const,
+        at: Date.now(),
+      },
     });
 
     await expect(
-      useAnalysisJobStore.getState().claimCompletion('job-1'),
+      useAnalysisJobStore.getState().claimCompletion('job-1', 'complete'),
     ).resolves.toBe(false);
     expect(storedState().completedAt).toMatchObject({ jobId: 'job-2' });
   });
@@ -158,10 +163,10 @@ describe('analysis-job-store completion claim', () => {
   it('grants exactly one of two tabs the same completion', async () => {
     const tabB = await openSecondTab();
 
-    const wonInA = await useAnalysisJobStore.getState().claimCompletion('job-1');
+    const wonInA = await useAnalysisJobStore.getState().claimCompletion('job-1', 'complete');
     const wonInB = await tabB.useAnalysisJobStore
       .getState()
-      .claimCompletion('job-1');
+      .claimCompletion('job-1', 'complete');
 
     expect(wonInA).toBe(true);
     expect(wonInB).toBe(false);
@@ -170,7 +175,7 @@ describe('analysis-job-store completion claim', () => {
   });
 
   it('holds across a reload, so a returning tab does not report again', async () => {
-    await useAnalysisJobStore.getState().claimCompletion('job-1');
+    await useAnalysisJobStore.getState().claimCompletion('job-1', 'complete');
 
     // A reload is a new module instance reading the same storage — which is
     // exactly what the second tab above is, so it doubles as the durability
@@ -178,7 +183,7 @@ describe('analysis-job-store completion claim', () => {
     const reloaded = await openSecondTab();
 
     await expect(
-      reloaded.useAnalysisJobStore.getState().claimCompletion('job-1'),
+      reloaded.useAnalysisJobStore.getState().claimCompletion('job-1', 'complete'),
     ).resolves.toBe(false);
   });
 
@@ -187,7 +192,7 @@ describe('analysis-job-store completion claim', () => {
 
     // A duplicate toast is a far better failure than a broken watcher effect.
     await expect(
-      useAnalysisJobStore.getState().claimCompletion('job-1'),
+      useAnalysisJobStore.getState().claimCompletion('job-1', 'complete'),
     ).resolves.toBe(true);
   });
 });
@@ -222,7 +227,7 @@ describe('analysis-job-store claim atomicity', () => {
     });
 
     await expect(
-      useAnalysisJobStore.getState().claimCompletion('job-1'),
+      useAnalysisJobStore.getState().claimCompletion('job-1', 'complete'),
     ).resolves.toBe(true);
 
     expect(request).toHaveBeenCalledWith(
@@ -238,7 +243,7 @@ describe('analysis-job-store claim atomicity', () => {
     // not the feature — a duplicate toast on a genuine tie is the behaviour
     // that shipped before any of this.
     await expect(
-      useAnalysisJobStore.getState().claimCompletion('job-1'),
+      useAnalysisJobStore.getState().claimCompletion('job-1', 'complete'),
     ).resolves.toBe(true);
   });
 });
@@ -302,7 +307,7 @@ describe('analysis-job-store write merging', () => {
     // ...while another tab finished it, started job-2, and persisted that.
     seedStorage({ job: newer, completedAt: null });
 
-    await useAnalysisJobStore.getState().claimCompletion(job.jobId);
+    await useAnalysisJobStore.getState().claimCompletion(job.jobId, 'complete');
 
     // Claiming must carry storage's job through rather than republish job-1.
     expect(storedState().job).toEqual(newer);
@@ -316,7 +321,12 @@ describe('analysis-job-store write merging', () => {
   it('starting a run keeps a claim another tab wrote', async () => {
     seedStorage({
       job: null,
-      completedAt: { jobId: 'job-0', tabId: 'some-other-tab', at: 1 },
+      completedAt: {
+        jobId: 'job-0',
+        tabId: 'some-other-tab',
+        status: 'complete' as const,
+        at: 1,
+      },
     });
 
     await useAnalysisJobStore.getState().setJob(job);
@@ -347,7 +357,7 @@ describe('analysis-job-store storage failure', () => {
     // A duplicate notification beats never telling the user their dataset is
     // ready, so the degraded answer is "report it".
     await expect(
-      useAnalysisJobStore.getState().claimCompletion('job-1'),
+      useAnalysisJobStore.getState().claimCompletion('job-1', 'complete'),
     ).resolves.toBe(true);
   });
 

--- a/frontend/src/stores/__tests__/analysis-job-store.cross-tab.test.ts
+++ b/frontend/src/stores/__tests__/analysis-job-store.cross-tab.test.ts
@@ -122,13 +122,37 @@ describe('analysis-job-store completion claim', () => {
     ).resolves.toBe(true);
   });
 
-  it('grants each job its own claim', async () => {
-    await expect(
-      useAnalysisJobStore.getState().claimCompletion('job-1'),
-    ).resolves.toBe(true);
+  it('grants the next run its own claim once it is the tracked one', async () => {
+    // The real sequence, because the claim slot holds one entry: run, report,
+    // clear, run again. A tab that has never tracked job-2 has no business
+    // reporting it, which the stale-claim rule below depends on.
+    await useAnalysisJobStore.getState().setJob(job);
+    await useAnalysisJobStore.getState().claimCompletion('job-1');
+    await useAnalysisJobStore.getState().clearJobIfCurrent('job-1');
+
+    await useAnalysisJobStore
+      .getState()
+      .setJob({ jobId: 'job-2', title: 'Next run', mapId: 'map-1' });
+
     await expect(
       useAnalysisJobStore.getState().claimCompletion('job-2'),
     ).resolves.toBe(true);
+  });
+
+  // fix(#1008 codex P2): a throttled tab resuming after the run it holds was
+  // cleared, and a later one already reported. Overwriting the newer claim
+  // would re-report a finished run AND re-arm the newer one for a second
+  // claim by whichever tab is still observing it.
+  it('refuses a stale run whose claim slot a newer one already owns', async () => {
+    seedStorage({
+      job: null,
+      completedAt: { jobId: 'job-2', tabId: 'some-other-tab', at: Date.now() },
+    });
+
+    await expect(
+      useAnalysisJobStore.getState().claimCompletion('job-1'),
+    ).resolves.toBe(false);
+    expect(storedState().completedAt).toMatchObject({ jobId: 'job-2' });
   });
 
   it('grants exactly one of two tabs the same completion', async () => {
@@ -202,7 +226,7 @@ describe('analysis-job-store claim atomicity', () => {
     ).resolves.toBe(true);
 
     expect(request).toHaveBeenCalledWith(
-      'geolens-analysis-completion',
+      'geolens-analysis-job-write',
       expect.any(Function),
     );
   });
@@ -225,10 +249,10 @@ describe('analysis-job-store guarded clear', () => {
     localStorage.clear();
   });
 
-  it('clears the job it was asked about', () => {
+  it('clears the job it was asked about', async () => {
     useAnalysisJobStore.setState({ job });
 
-    useAnalysisJobStore.getState().clearJobIfCurrent(job.jobId);
+    await useAnalysisJobStore.getState().clearJobIfCurrent(job.jobId);
 
     expect(useAnalysisJobStore.getState().job).toBeNull();
   });
@@ -237,17 +261,17 @@ describe('analysis-job-store guarded clear', () => {
   // no longer this tab's own business. A backgrounded tab whose timers were
   // throttled can process a terminal response long after another tab started
   // the NEXT run.
-  it('leaves a newer run alone', () => {
+  it('leaves a newer run alone', async () => {
     const newer = { jobId: 'job-2', title: 'Next run', mapId: 'map-1' };
     useAnalysisJobStore.setState({ job: newer });
 
-    useAnalysisJobStore.getState().clearJobIfCurrent('job-1');
+    await useAnalysisJobStore.getState().clearJobIfCurrent('job-1');
 
     expect(useAnalysisJobStore.getState().job).toEqual(newer);
     expect(storedState().job).toEqual(newer);
   });
 
-  it('clears this tab even when storage tracks nothing', () => {
+  it('clears this tab even when storage tracks nothing', async () => {
     // The mirror already carried another tab's clear through storage; this
     // tab's in-memory copy still has to go.
     useAnalysisJobStore.setState({ job });
@@ -256,7 +280,7 @@ describe('analysis-job-store guarded clear', () => {
       JSON.stringify({ state: { job: null, completedAt: null }, version: 1 }),
     );
 
-    useAnalysisJobStore.getState().clearJobIfCurrent(job.jobId);
+    await useAnalysisJobStore.getState().clearJobIfCurrent(job.jobId);
 
     expect(useAnalysisJobStore.getState().job).toBeNull();
   });
@@ -285,21 +309,56 @@ describe('analysis-job-store write merging', () => {
 
     // Which is what leaves the guarded clear able to see job-2 and stand down;
     // before the merge it read back its own job-1 and cleared it.
-    useAnalysisJobStore.getState().clearJobIfCurrent(job.jobId);
+    await useAnalysisJobStore.getState().clearJobIfCurrent(job.jobId);
     expect(storedState().job).toEqual(newer);
   });
 
-  it('starting a run keeps a claim another tab wrote', () => {
+  it('starting a run keeps a claim another tab wrote', async () => {
     seedStorage({
       job: null,
       completedAt: { jobId: 'job-0', tabId: 'some-other-tab', at: 1 },
     });
 
-    useAnalysisJobStore.getState().setJob(job);
+    await useAnalysisJobStore.getState().setJob(job);
 
     expect(storedState().job).toEqual(job);
     // Dropping the claim would re-arm a completion another tab already
     // reported, so the next tab to look would toast it a second time.
     expect(storedState().completedAt).toMatchObject({ jobId: 'job-0' });
+  });
+});
+
+// fix(#1008 codex P2): the watcher awaits these, so a rejection would leave a
+// finished job neither reported nor cleared, with Create disabled until a
+// reload. Storage that throws on write is the realistic trigger — a disabled
+// storage partition, or an exhausted quota.
+describe('analysis-job-store storage failure', () => {
+  beforeEach(() => {
+    useAnalysisJobStore.setState({ job: null, completedAt: null });
+    localStorage.clear();
+  });
+  afterEach(() => vi.restoreAllMocks());
+
+  it('reports rather than going silent when the claim cannot be persisted', async () => {
+    vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+      throw new DOMException('quota', 'QuotaExceededError');
+    });
+
+    // A duplicate notification beats never telling the user their dataset is
+    // ready, so the degraded answer is "report it".
+    await expect(
+      useAnalysisJobStore.getState().claimCompletion('job-1'),
+    ).resolves.toBe(true);
+  });
+
+  it('settles the clear rather than rejecting it', async () => {
+    useAnalysisJobStore.setState({ job });
+    vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+      throw new DOMException('quota', 'QuotaExceededError');
+    });
+
+    await expect(
+      useAnalysisJobStore.getState().clearJobIfCurrent(job.jobId),
+    ).resolves.toBeUndefined();
   });
 });

--- a/frontend/src/stores/__tests__/analysis-job-store.cross-tab.test.ts
+++ b/frontend/src/stores/__tests__/analysis-job-store.cross-tab.test.ts
@@ -416,3 +416,49 @@ describe('analysis-job-store identity-scoped clear', () => {
     expect(storedState().job).toBeNull();
   });
 });
+
+// fix(#1008 codex P2): the lock callback can wait behind another tab's write,
+// so reading the identity inside it would stamp the run as belonging to
+// whoever signed in during the wait — and the scoped clear would then
+// dutifully preserve the previous account's run for them.
+describe('analysis-job-store ownership capture', () => {
+  beforeEach(() => {
+    useAnalysisJobStore.setState({ job: null, completedAt: null });
+    useAuthStore.setState({ token: null, refreshToken: null, user: null });
+    localStorage.clear();
+  });
+  afterEach(() => {
+    Reflect.deleteProperty(navigator, 'locks');
+    vi.restoreAllMocks();
+  });
+
+  it('does not hand the previous account’s run to the one that replaced it', async () => {
+    let release!: () => void;
+    const held = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    Object.defineProperty(navigator, 'locks', {
+      value: {
+        request: async <T,>(_name: string, callback: () => T) => {
+          await held;
+          return callback();
+        },
+      },
+      configurable: true,
+    });
+
+    useAuthStore.setState({ user: { id: 'u1' } as UserResponse });
+    const pending = useAnalysisJobStore.getState().setJob(job);
+
+    // The account switches while the write is still queued behind the lock.
+    useAuthStore.setState({ user: { id: 'u2' } as UserResponse });
+    release();
+    await pending;
+
+    // Reading the identity inside the callback would have stamped this run
+    // 'u2', and u1's queued sign-out clear would then have spared it — leaving
+    // u2 tracking a run they never started. Stamped 'u1', it is cleared.
+    expect(storedState().job).toBeNull();
+    expect(useAnalysisJobStore.getState().job).toBeNull();
+  });
+});

--- a/frontend/src/stores/__tests__/analysis-job-store.cross-tab.test.ts
+++ b/frontend/src/stores/__tests__/analysis-job-store.cross-tab.test.ts
@@ -1,0 +1,157 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { waitFor } from '@testing-library/react';
+import {
+  ANALYSIS_JOB_STORAGE_KEY,
+  useAnalysisJobStore,
+  type TrackedAnalysisJob,
+} from '@/stores/analysis-job-store';
+
+// feat(#1008): two mechanisms that are easy to conflate.
+//
+// The MIRROR keeps every tab's view of the in-flight job current, so a second
+// builder knows a run is already going and its Create button is disabled
+// (`analysisJobRunning` in the Analysis panel is a live store subscription).
+//
+// The CLAIM is what dedups. Three tabs mirroring the same job all still poll
+// it to completion, and each has its own toaster, so the mirror alone yields
+// three toasts and three cache invalidations. Exactly one tab may report, and
+// the arbiter has to be a written value rather than whoever polled first.
+
+const job: TrackedAnalysisJob = {
+  jobId: 'job-1',
+  title: 'Buffered parcels',
+  mapId: 'map-1',
+};
+
+/** Write the payload another tab would have left behind. */
+function seedStorage(state: Record<string, unknown>) {
+  localStorage.setItem(
+    ANALYSIS_JOB_STORAGE_KEY,
+    JSON.stringify({ state, version: 1 }),
+  );
+}
+
+function storedState(): Record<string, unknown> {
+  return JSON.parse(localStorage.getItem(ANALYSIS_JOB_STORAGE_KEY)!).state;
+}
+
+/**
+ * A second tab: a fresh module instance with its own tab id, sharing this
+ * realm's localStorage. Importing the module again is the only way to get a
+ * distinct claimant, since the store is a module singleton by design.
+ */
+async function openSecondTab() {
+  vi.resetModules();
+  return await import('@/stores/analysis-job-store');
+}
+
+describe('analysis-job-store cross-tab mirror', () => {
+  beforeEach(() => {
+    useAnalysisJobStore.setState({ job: null, completedAt: null });
+    localStorage.clear();
+  });
+  afterEach(() => vi.restoreAllMocks());
+
+  it('rehydrates when the analysis-job key changes in another tab', () => {
+    const spy = vi
+      .spyOn(useAnalysisJobStore.persist, 'rehydrate')
+      .mockResolvedValue();
+
+    window.dispatchEvent(
+      new StorageEvent('storage', { key: ANALYSIS_JOB_STORAGE_KEY }),
+    );
+
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  it('ignores storage events for unrelated keys', () => {
+    const spy = vi
+      .spyOn(useAnalysisJobStore.persist, 'rehydrate')
+      .mockResolvedValue();
+
+    window.dispatchEvent(new StorageEvent('storage', { key: 'geolens-auth' }));
+
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it('picks up a run another tab started, without a reload', async () => {
+    expect(useAnalysisJobStore.getState().job).toBeNull();
+
+    seedStorage({ job, completedAt: null });
+    window.dispatchEvent(
+      new StorageEvent('storage', { key: ANALYSIS_JOB_STORAGE_KEY }),
+    );
+
+    // The Analysis panel subscribes to `!!s.job`, so this is what disables its
+    // Create button in the tab that did not start the run.
+    await waitFor(() => expect(useAnalysisJobStore.getState().job).toEqual(job));
+  });
+
+  it('propagates a clear, so ending a run in one tab re-enables the others', async () => {
+    useAnalysisJobStore.setState({ job });
+
+    seedStorage({ job: null, completedAt: null });
+    window.dispatchEvent(
+      new StorageEvent('storage', { key: ANALYSIS_JOB_STORAGE_KEY }),
+    );
+
+    await waitFor(() => expect(useAnalysisJobStore.getState().job).toBeNull());
+  });
+});
+
+describe('analysis-job-store completion claim', () => {
+  beforeEach(() => {
+    useAnalysisJobStore.setState({ job: null, completedAt: null });
+    localStorage.clear();
+  });
+
+  it('is granted to the first caller and recorded in storage', () => {
+    expect(useAnalysisJobStore.getState().claimCompletion('job-1')).toBe(true);
+    expect(storedState().completedAt).toMatchObject({ jobId: 'job-1' });
+  });
+
+  it('stays granted to the tab that won it', () => {
+    useAnalysisJobStore.getState().claimCompletion('job-1');
+
+    // StrictMode invokes the watcher effect twice; the tab that already
+    // reported must not silence itself on the second pass.
+    expect(useAnalysisJobStore.getState().claimCompletion('job-1')).toBe(true);
+  });
+
+  it('grants each job its own claim', () => {
+    expect(useAnalysisJobStore.getState().claimCompletion('job-1')).toBe(true);
+    expect(useAnalysisJobStore.getState().claimCompletion('job-2')).toBe(true);
+  });
+
+  it('grants exactly one of two tabs the same completion', async () => {
+    const tabB = await openSecondTab();
+
+    const wonInA = useAnalysisJobStore.getState().claimCompletion('job-1');
+    const wonInB = tabB.useAnalysisJobStore.getState().claimCompletion('job-1');
+
+    expect(wonInA).toBe(true);
+    expect(wonInB).toBe(false);
+    // ...and the loser did not overwrite the winner's record on its way out.
+    expect(storedState().completedAt).toMatchObject({ jobId: 'job-1' });
+  });
+
+  it('holds across a reload, so a returning tab does not report again', async () => {
+    useAnalysisJobStore.getState().claimCompletion('job-1');
+
+    // A reload is a new module instance reading the same storage — which is
+    // exactly what the second tab above is, so it doubles as the durability
+    // case the timing-based alternative could not give.
+    const reloaded = await openSecondTab();
+
+    expect(reloaded.useAnalysisJobStore.getState().claimCompletion('job-1')).toBe(
+      false,
+    );
+  });
+
+  it('reports no claim rather than throwing when storage is unreadable', () => {
+    localStorage.setItem(ANALYSIS_JOB_STORAGE_KEY, 'not json');
+
+    // A duplicate toast is a far better failure than a broken watcher effect.
+    expect(() => useAnalysisJobStore.getState().claimCompletion('job-1')).not.toThrow();
+  });
+});

--- a/frontend/src/stores/__tests__/analysis-job-store.cross-tab.test.ts
+++ b/frontend/src/stores/__tests__/analysis-job-store.cross-tab.test.ts
@@ -105,29 +105,39 @@ describe('analysis-job-store completion claim', () => {
     localStorage.clear();
   });
 
-  it('is granted to the first caller and recorded in storage', () => {
-    expect(useAnalysisJobStore.getState().claimCompletion('job-1')).toBe(true);
+  it('is granted to the first caller and recorded in storage', async () => {
+    await expect(
+      useAnalysisJobStore.getState().claimCompletion('job-1'),
+    ).resolves.toBe(true);
     expect(storedState().completedAt).toMatchObject({ jobId: 'job-1' });
   });
 
-  it('stays granted to the tab that won it', () => {
-    useAnalysisJobStore.getState().claimCompletion('job-1');
+  it('stays granted to the tab that won it', async () => {
+    await useAnalysisJobStore.getState().claimCompletion('job-1');
 
     // StrictMode invokes the watcher effect twice; the tab that already
     // reported must not silence itself on the second pass.
-    expect(useAnalysisJobStore.getState().claimCompletion('job-1')).toBe(true);
+    await expect(
+      useAnalysisJobStore.getState().claimCompletion('job-1'),
+    ).resolves.toBe(true);
   });
 
-  it('grants each job its own claim', () => {
-    expect(useAnalysisJobStore.getState().claimCompletion('job-1')).toBe(true);
-    expect(useAnalysisJobStore.getState().claimCompletion('job-2')).toBe(true);
+  it('grants each job its own claim', async () => {
+    await expect(
+      useAnalysisJobStore.getState().claimCompletion('job-1'),
+    ).resolves.toBe(true);
+    await expect(
+      useAnalysisJobStore.getState().claimCompletion('job-2'),
+    ).resolves.toBe(true);
   });
 
   it('grants exactly one of two tabs the same completion', async () => {
     const tabB = await openSecondTab();
 
-    const wonInA = useAnalysisJobStore.getState().claimCompletion('job-1');
-    const wonInB = tabB.useAnalysisJobStore.getState().claimCompletion('job-1');
+    const wonInA = await useAnalysisJobStore.getState().claimCompletion('job-1');
+    const wonInB = await tabB.useAnalysisJobStore
+      .getState()
+      .claimCompletion('job-1');
 
     expect(wonInA).toBe(true);
     expect(wonInB).toBe(false);
@@ -136,22 +146,118 @@ describe('analysis-job-store completion claim', () => {
   });
 
   it('holds across a reload, so a returning tab does not report again', async () => {
-    useAnalysisJobStore.getState().claimCompletion('job-1');
+    await useAnalysisJobStore.getState().claimCompletion('job-1');
 
     // A reload is a new module instance reading the same storage — which is
     // exactly what the second tab above is, so it doubles as the durability
     // case the timing-based alternative could not give.
     const reloaded = await openSecondTab();
 
-    expect(reloaded.useAnalysisJobStore.getState().claimCompletion('job-1')).toBe(
-      false,
-    );
+    await expect(
+      reloaded.useAnalysisJobStore.getState().claimCompletion('job-1'),
+    ).resolves.toBe(false);
   });
 
-  it('reports no claim rather than throwing when storage is unreadable', () => {
+  it('reports no claim rather than throwing when storage is unreadable', async () => {
     localStorage.setItem(ANALYSIS_JOB_STORAGE_KEY, 'not json');
 
     // A duplicate toast is a far better failure than a broken watcher effect.
-    expect(() => useAnalysisJobStore.getState().claimCompletion('job-1')).not.toThrow();
+    await expect(
+      useAnalysisJobStore.getState().claimCompletion('job-1'),
+    ).resolves.toBe(true);
+  });
+});
+
+describe('analysis-job-store claim atomicity', () => {
+  beforeEach(() => {
+    useAnalysisJobStore.setState({ job: null, completedAt: null });
+    localStorage.clear();
+  });
+  afterEach(() => {
+    Reflect.deleteProperty(navigator, 'locks');
+    vi.restoreAllMocks();
+  });
+
+  // fix(#1008 codex P2): the read/write/read sequence is not atomic by itself.
+  // `A reads empty, B reads empty, A writes, A reads back A, B writes, B reads
+  // back B` leaves both tabs holding a winning claim, and localStorage
+  // serializing individual operations does not prevent it. Web Locks is what
+  // makes the sequence mutually exclusive across documents.
+  //
+  // The race itself cannot be staged here — two tabs are two processes, and a
+  // single JS realm runs `attempt()` to completion before the other caller
+  // starts. So pin the mechanism: the claim must go through the lock.
+  it('runs the claim inside a Web Lock', async () => {
+    const request = vi.fn(
+      <T,>(_name: string, callback: () => T | Promise<T>) =>
+        Promise.resolve(callback()),
+    );
+    Object.defineProperty(navigator, 'locks', {
+      value: { request },
+      configurable: true,
+    });
+
+    await expect(
+      useAnalysisJobStore.getState().claimCompletion('job-1'),
+    ).resolves.toBe(true);
+
+    expect(request).toHaveBeenCalledWith(
+      'geolens-analysis-completion',
+      expect.any(Function),
+    );
+  });
+
+  it('still claims when Web Locks is unavailable', async () => {
+    expect('locks' in navigator).toBe(false);
+
+    // Older browsers and non-DOM environments lose the tie-breaking guarantee,
+    // not the feature — a duplicate toast on a genuine tie is the behaviour
+    // that shipped before any of this.
+    await expect(
+      useAnalysisJobStore.getState().claimCompletion('job-1'),
+    ).resolves.toBe(true);
+  });
+});
+
+describe('analysis-job-store guarded clear', () => {
+  beforeEach(() => {
+    useAnalysisJobStore.setState({ job: null, completedAt: null });
+    localStorage.clear();
+  });
+
+  it('clears the job it was asked about', () => {
+    useAnalysisJobStore.setState({ job });
+
+    useAnalysisJobStore.getState().clearJobIfCurrent(job.jobId);
+
+    expect(useAnalysisJobStore.getState().job).toBeNull();
+  });
+
+  // fix(#1008 codex P1): the clear propagates now, so an unconditional one is
+  // no longer this tab's own business. A backgrounded tab whose timers were
+  // throttled can process a terminal response long after another tab started
+  // the NEXT run.
+  it('leaves a newer run alone', () => {
+    const newer = { jobId: 'job-2', title: 'Next run', mapId: 'map-1' };
+    useAnalysisJobStore.setState({ job: newer });
+
+    useAnalysisJobStore.getState().clearJobIfCurrent('job-1');
+
+    expect(useAnalysisJobStore.getState().job).toEqual(newer);
+    expect(storedState().job).toEqual(newer);
+  });
+
+  it('clears this tab even when storage tracks nothing', () => {
+    // The mirror already carried another tab's clear through storage; this
+    // tab's in-memory copy still has to go.
+    useAnalysisJobStore.setState({ job });
+    localStorage.setItem(
+      ANALYSIS_JOB_STORAGE_KEY,
+      JSON.stringify({ state: { job: null, completedAt: null }, version: 1 }),
+    );
+
+    useAnalysisJobStore.getState().clearJobIfCurrent(job.jobId);
+
+    expect(useAnalysisJobStore.getState().job).toBeNull();
   });
 });

--- a/frontend/src/stores/__tests__/analysis-job-store.cross-tab.test.ts
+++ b/frontend/src/stores/__tests__/analysis-job-store.cross-tab.test.ts
@@ -261,3 +261,45 @@ describe('analysis-job-store guarded clear', () => {
     expect(useAnalysisJobStore.getState().job).toBeNull();
   });
 });
+
+// fix(#1008 codex P1): every write to this store persists the WHOLE snapshot,
+// so a write meaning to change one field silently republishes this tab's copy
+// of the other. Harmless in one tab; corrupting across several.
+describe('analysis-job-store write merging', () => {
+  beforeEach(() => {
+    useAnalysisJobStore.setState({ job: null, completedAt: null });
+    localStorage.clear();
+  });
+
+  it('does not resurrect a job another tab has already replaced', async () => {
+    const newer = { jobId: 'job-2', title: 'Next run', mapId: 'map-1' };
+    // This tab was throttled and still holds job-1...
+    useAnalysisJobStore.setState({ job });
+    // ...while another tab finished it, started job-2, and persisted that.
+    seedStorage({ job: newer, completedAt: null });
+
+    await useAnalysisJobStore.getState().claimCompletion(job.jobId);
+
+    // Claiming must carry storage's job through rather than republish job-1.
+    expect(storedState().job).toEqual(newer);
+
+    // Which is what leaves the guarded clear able to see job-2 and stand down;
+    // before the merge it read back its own job-1 and cleared it.
+    useAnalysisJobStore.getState().clearJobIfCurrent(job.jobId);
+    expect(storedState().job).toEqual(newer);
+  });
+
+  it('starting a run keeps a claim another tab wrote', () => {
+    seedStorage({
+      job: null,
+      completedAt: { jobId: 'job-0', tabId: 'some-other-tab', at: 1 },
+    });
+
+    useAnalysisJobStore.getState().setJob(job);
+
+    expect(storedState().job).toEqual(job);
+    // Dropping the claim would re-arm a completion another tab already
+    // reported, so the next tab to look would toast it a second time.
+    expect(storedState().completedAt).toMatchObject({ jobId: 'job-0' });
+  });
+});

--- a/frontend/src/stores/__tests__/analysis-job-store.cross-tab.test.ts
+++ b/frontend/src/stores/__tests__/analysis-job-store.cross-tab.test.ts
@@ -5,6 +5,8 @@ import {
   useAnalysisJobStore,
   type TrackedAnalysisJob,
 } from '@/stores/analysis-job-store';
+import { useAuthStore } from '@/stores/auth-store';
+import type { UserResponse } from '@/types/api';
 
 // feat(#1008): two mechanisms that are easy to conflate.
 //
@@ -331,7 +333,8 @@ describe('analysis-job-store write merging', () => {
 
     await useAnalysisJobStore.getState().setJob(job);
 
-    expect(storedState().job).toEqual(job);
+    // setJob stamps the owning identity; nobody is signed in here.
+    expect(storedState().job).toEqual({ ...job, userId: null });
     // Dropping the claim would re-arm a completion another tab already
     // reported, so the next tab to look would toast it a second time.
     expect(storedState().completedAt).toMatchObject({ jobId: 'job-0' });
@@ -370,5 +373,46 @@ describe('analysis-job-store storage failure', () => {
     await expect(
       useAnalysisJobStore.getState().clearJobIfCurrent(job.jobId),
     ).resolves.toBeUndefined();
+  });
+});
+
+// fix(#1008 codex P2): the identity-change clear propagates now, so a dormant
+// tab processing a stale auth event must not reach past the account it is
+// cleaning up after and delete the one that replaced it.
+describe('analysis-job-store identity-scoped clear', () => {
+  beforeEach(() => {
+    useAnalysisJobStore.setState({ job: null, completedAt: null });
+    useAuthStore.setState({ token: null, refreshToken: null, user: null });
+    localStorage.clear();
+  });
+
+  it('clears the run belonging to the account that signed out', async () => {
+    useAuthStore.setState({ user: { id: 'u1' } as UserResponse });
+    await useAnalysisJobStore.getState().setJob(job);
+
+    await useAnalysisJobStore.getState().clearJobForUser('u1');
+
+    expect(storedState().job).toBeNull();
+  });
+
+  it('leaves the next account’s run alone', async () => {
+    // u2 signed in and started a run; a dormant tab only now processes u1's
+    // sign-out. Clearing here would stop tracking a job still running.
+    useAuthStore.setState({ user: { id: 'u2' } as UserResponse });
+    await useAnalysisJobStore.getState().setJob(job);
+
+    await useAnalysisJobStore.getState().clearJobForUser('u1');
+
+    expect(storedState().job).toMatchObject({ jobId: 'job-1', userId: 'u2' });
+  });
+
+  it('clears an unstamped run, whose owner cannot be established', async () => {
+    // Written before the stamp existed: leaving it tracked under whoever signs
+    // in next is the worse reading of an unknown.
+    seedStorage({ job: { ...job }, completedAt: null });
+
+    await useAnalysisJobStore.getState().clearJobForUser('u1');
+
+    expect(storedState().job).toBeNull();
   });
 });

--- a/frontend/src/stores/analysis-job-store.ts
+++ b/frontend/src/stores/analysis-job-store.ts
@@ -8,6 +8,11 @@ export interface TrackedAnalysisJob {
   title: string;
   /** Map the job was started from; enables the "Add to map" action. */
   mapId: string | null;
+  /** fix(#1008 codex P2): who started it. The identity-change clear
+   *  propagates now, so a dormant tab processing a stale auth event would
+   *  otherwise delete the account that replaced it — including a run that is
+   *  still going server-side. Stamped by `setJob`, not by callers. */
+  userId?: string | null;
 }
 
 /**
@@ -36,6 +41,14 @@ interface PersistedAnalysisJobState {
 
 interface AnalysisJobState extends PersistedAnalysisJobState {
   setJob: (job: TrackedAnalysisJob | null) => Promise<void>;
+  /**
+   * Drop the tracked job, but only if it belongs to ``userId``.
+   *
+   * fix(#1008 codex P2): the identity-change clear used to be this tab's own
+   * business. Now it propagates, so a delayed handler must not reach past the
+   * account it is cleaning up after.
+   */
+  clearJobForUser: (userId: string | null) => Promise<void>;
   /**
    * Try to become the one tab that reports this job's completion.
    *
@@ -192,7 +205,24 @@ export const useAnalysisJobStore = create<AnalysisJobState>()(
           // too, or a clear that read "no newer job" moments earlier overwrites
           // this one with null.
           withLock(() => {
-            set(mergeWith(readPersisted(), { job }));
+            // Stamped here rather than by callers: every caller would have to
+            // remember, and forgetting reads as "belongs to nobody".
+            const owned = job
+              ? { ...job, userId: useAuthStore.getState().user?.id ?? null }
+              : null;
+            set(mergeWith(readPersisted(), { job: owned }));
+          }, undefined),
+        clearJobForUser: (userId) =>
+          withLock(() => {
+            const persisted = readPersisted();
+            const tracked = persisted.job;
+            // A job with no owner predates the stamp, so its provenance is
+            // unknown — clearing is the safe reading, since the alternative
+            // leaves the previous account's run tracked under a new one.
+            if (tracked && tracked.userId !== undefined && tracked.userId !== userId) {
+              return;
+            }
+            set(mergeWith(persisted, { job: null }));
           }, undefined),
         claimCompletion: (jobId, status) =>
           // fix(#1008 codex P2): the read/write/read below is NOT atomic on its
@@ -280,7 +310,7 @@ if (typeof window !== 'undefined') {
 // a job mid-run.
 useAuthStore.subscribe((s, prev) => {
   if (s.user?.id !== prev.user?.id) {
-    void useAnalysisJobStore.getState().setJob(null);
+    void useAnalysisJobStore.getState().clearJobForUser(prev.user?.id ?? null);
   }
 });
 

--- a/frontend/src/stores/analysis-job-store.ts
+++ b/frontend/src/stores/analysis-job-store.ts
@@ -31,12 +31,22 @@ interface AnalysisJobState {
   /**
    * Try to become the one tab that reports this job's completion.
    *
-   * Returns true exactly once across every open tab, and keeps returning true
+   * Resolves true exactly once across every open tab, and keeps resolving true
    * for the tab that won (so a StrictMode double-invoke does not lose its own
    * claim). See the storage listener below for why a mirror alone is not
    * enough.
    */
-  claimCompletion: (jobId: string) => boolean;
+  claimCompletion: (jobId: string) => Promise<boolean>;
+  /**
+   * Stop tracking ``jobId``, unless a newer run already owns the slot.
+   *
+   * fix(#1008 codex P1): the clear propagates now, so an unconditional one is
+   * no longer this tab's business alone. A backgrounded tab whose timers were
+   * throttled can process a terminal response long after another tab started
+   * the NEXT analysis; clearing then erases the newer job everywhere and
+   * re-enables Create while the server job is still running.
+   */
+  clearJobIfCurrent: (jobId: string) => void;
 }
 
 export const ANALYSIS_JOB_STORAGE_KEY = 'geolens-analysis-job';
@@ -45,27 +55,32 @@ export const ANALYSIS_JOB_STORAGE_KEY = 'geolens-analysis-job';
 const TAB_ID =
   globalThis.crypto?.randomUUID?.() ?? `tab-${Math.random().toString(36).slice(2)}`;
 
+/** Web Locks name guarding the claim's read/write/read sequence. */
+const COMPLETION_LOCK = 'geolens-analysis-completion';
+
 /**
- * Read the claim straight out of storage rather than off in-memory state.
+ * Read persisted state straight out of storage rather than off in-memory state.
  *
  * The mirror below is event-driven and therefore always a beat behind; the
- * stored value is the only view that is current at the instant of the claim.
- * Reaching for `localStorage` directly matches what the persist middleware
- * uses by default — if this store ever names a different storage, this has to
- * follow it.
+ * stored value is the only view that is current at the instant of a claim or a
+ * clear. Reaching for `localStorage` directly matches what the persist
+ * middleware uses by default — if this store ever names a different storage,
+ * this has to follow it.
  */
-function readPersistedClaim(): AnalysisCompletionClaim | null {
+function readPersisted(): {
+  job?: TrackedAnalysisJob | null;
+  completedAt?: AnalysisCompletionClaim | null;
+} {
   try {
     const raw = localStorage.getItem(ANALYSIS_JOB_STORAGE_KEY);
-    if (!raw) return null;
-    const parsed = JSON.parse(raw) as {
-      state?: { completedAt?: AnalysisCompletionClaim | null };
-    };
-    return parsed.state?.completedAt ?? null;
+    if (!raw) return {};
+    return (
+      (JSON.parse(raw) as { state?: ReturnType<typeof readPersisted> }).state ?? {}
+    );
   } catch {
     // Storage disabled, quota-exceeded, or a payload from a future version.
-    // Losing the arbiter means duplicate toasts, not a broken app.
-    return null;
+    // Losing this view means a duplicate toast, not a broken app.
+    return {};
   }
 }
 
@@ -86,21 +101,42 @@ export const useAnalysisJobStore = create<AnalysisJobState>()(
       job: null,
       completedAt: null,
       setJob: (job) => set({ job }),
-      claimCompletion: (jobId) => {
-        const existing = readPersistedClaim();
-        if (existing?.jobId === jobId) {
-          // Someone already reported this one. Ours only if we were the one.
-          return existing.tabId === TAB_ID;
+      claimCompletion: async (jobId) => {
+        const attempt = () => {
+          const existing = readPersisted().completedAt;
+          if (existing?.jobId === jobId) {
+            // Already reported. Ours only if we were the one who did it.
+            return existing.tabId === TAB_ID;
+          }
+          set({ completedAt: { jobId, tabId: TAB_ID, at: Date.now() } });
+          const settled = readPersisted().completedAt;
+          return settled?.jobId === jobId && settled.tabId === TAB_ID;
+        };
+        // fix(#1008 codex P2): the read/write/read above is NOT atomic on its
+        // own, and the tempting argument that it is does not survive contact
+        // with an interleaving. localStorage serializes individual operations,
+        // not a sequence of them, so `A reads empty, B reads empty, A writes,
+        // A reads back A, B writes, B reads back B` leaves both tabs holding
+        // what looks like a winning claim — which is exactly the simultaneous
+        // completion this exists to dedup. Web Locks is the primitive that
+        // actually makes the sequence mutually exclusive across same-origin
+        // documents, so run it under one.
+        const locks = globalThis.navigator?.locks;
+        if (!locks) {
+          // No Web Locks (older browser, or a non-DOM environment). The
+          // sequence is still right in every staggered case, which is the
+          // common one; the residual loss is a duplicate toast on a genuine
+          // tie, i.e. the behaviour before any of this existed.
+          return attempt();
         }
-        set({ completedAt: { jobId, tabId: TAB_ID, at: Date.now() } });
-        // Last writer wins, and the read-back is the arbiter: if two tabs got
-        // past the check above simultaneously, only one of them reads its own
-        // id back. Checking first AND re-reading is what makes it exactly one
-        // — the check alone loses to a genuine race, and the read-back alone
-        // lets a tab that writes and reads before the other tab writes come
-        // out true as well.
-        const settled = readPersistedClaim();
-        return settled?.jobId === jobId && settled.tabId === TAB_ID;
+        return await locks.request(COMPLETION_LOCK, attempt);
+      },
+      clearJobIfCurrent: (jobId) => {
+        const persistedJob = readPersisted().job;
+        // Only bail when storage names a DIFFERENT run: a null there means
+        // nothing is tracked, and this tab's in-memory copy still has to go.
+        if (persistedJob && persistedJob.jobId !== jobId) return;
+        set({ job: null });
       },
     }),
     {

--- a/frontend/src/stores/analysis-job-store.ts
+++ b/frontend/src/stores/analysis-job-store.ts
@@ -50,6 +50,9 @@ const TAB_ID =
  *
  * The mirror below is event-driven and therefore always a beat behind; the
  * stored value is the only view that is current at the instant of the claim.
+ * Reaching for `localStorage` directly matches what the persist middleware
+ * uses by default — if this store ever names a different storage, this has to
+ * follow it.
  */
 function readPersistedClaim(): AnalysisCompletionClaim | null {
   try {
@@ -125,6 +128,12 @@ export const useAnalysisJobStore = create<AnalysisJobState>()(
  * still poll it to completion, and each raises its own toast (`toastId` is
  * per-job, and each tab has its own toaster). That is what `claimCompletion`
  * above is for.
+ *
+ * No write-back loop here, which is worth stating because it is the obvious
+ * worry: zustand's `hydrate()` applies the storage payload through the store's
+ * RAW setter and only calls `setItem` when a migration ran. A rehydrate is
+ * therefore silent, so it cannot bounce a storage event back at the tab that
+ * started it.
  */
 if (typeof window !== 'undefined') {
   window.addEventListener('storage', (e) => {

--- a/frontend/src/stores/analysis-job-store.ts
+++ b/frontend/src/stores/analysis-job-store.ts
@@ -21,6 +21,10 @@ export interface AnalysisCompletionClaim {
   /** Whichever tab wrote it. Two tabs can observe the same terminal poll in
    *  the same millisecond, so the timestamp alone cannot identify a claimant. */
   tabId: string;
+  /** fix(#1008 codex P2): how the run ended. A tab that never observed the
+   *  terminal poll itself still has document-local cleanup to do once the
+   *  claim reaches it, and complete and failed call for different cleanup. */
+  status: 'complete' | 'failed';
   at: number;
 }
 
@@ -40,7 +44,10 @@ interface AnalysisJobState extends PersistedAnalysisJobState {
    * claim). See the storage listener below for why a mirror alone is not
    * enough.
    */
-  claimCompletion: (jobId: string) => Promise<boolean>;
+  claimCompletion: (
+    jobId: string,
+    status: 'complete' | 'failed',
+  ) => Promise<boolean>;
   /**
    * Stop tracking ``jobId``, unless a newer run already owns the slot.
    *
@@ -187,7 +194,7 @@ export const useAnalysisJobStore = create<AnalysisJobState>()(
           withLock(() => {
             set(mergeWith(readPersisted(), { job }));
           }, undefined),
-        claimCompletion: (jobId) =>
+        claimCompletion: (jobId, status) =>
           // fix(#1008 codex P2): the read/write/read below is NOT atomic on its
           // own, and the tempting argument that it is does not survive contact
           // with an interleaving. localStorage serializes individual
@@ -210,7 +217,7 @@ export const useAnalysisJobStore = create<AnalysisJobState>()(
             if (existing && persisted.job?.jobId !== jobId) return false;
             set(
               mergeWith(persisted, {
-                completedAt: { jobId, tabId: TAB_ID, at: Date.now() },
+                completedAt: { jobId, tabId: TAB_ID, status, at: Date.now() },
               }),
             );
             const settled = readPersisted().completedAt;

--- a/frontend/src/stores/analysis-job-store.ts
+++ b/frontend/src/stores/analysis-job-store.ts
@@ -10,9 +10,60 @@ export interface TrackedAnalysisJob {
   mapId: string | null;
 }
 
+/**
+ * feat(#1008): the written claim on a job's completion.
+ *
+ * Only the most recent one is kept — the store tracks a single job at a time,
+ * so an older claim can never be consulted again.
+ */
+export interface AnalysisCompletionClaim {
+  jobId: string;
+  /** Whichever tab wrote it. Two tabs can observe the same terminal poll in
+   *  the same millisecond, so the timestamp alone cannot identify a claimant. */
+  tabId: string;
+  at: number;
+}
+
 interface AnalysisJobState {
   job: TrackedAnalysisJob | null;
+  completedAt: AnalysisCompletionClaim | null;
   setJob: (job: TrackedAnalysisJob | null) => void;
+  /**
+   * Try to become the one tab that reports this job's completion.
+   *
+   * Returns true exactly once across every open tab, and keeps returning true
+   * for the tab that won (so a StrictMode double-invoke does not lose its own
+   * claim). See the storage listener below for why a mirror alone is not
+   * enough.
+   */
+  claimCompletion: (jobId: string) => boolean;
+}
+
+export const ANALYSIS_JOB_STORAGE_KEY = 'geolens-analysis-job';
+
+/** Identifies this tab for the lifetime of the document. */
+const TAB_ID =
+  globalThis.crypto?.randomUUID?.() ?? `tab-${Math.random().toString(36).slice(2)}`;
+
+/**
+ * Read the claim straight out of storage rather than off in-memory state.
+ *
+ * The mirror below is event-driven and therefore always a beat behind; the
+ * stored value is the only view that is current at the instant of the claim.
+ */
+function readPersistedClaim(): AnalysisCompletionClaim | null {
+  try {
+    const raw = localStorage.getItem(ANALYSIS_JOB_STORAGE_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as {
+      state?: { completedAt?: AnalysisCompletionClaim | null };
+    };
+    return parsed.state?.completedAt ?? null;
+  } catch {
+    // Storage disabled, quota-exceeded, or a payload from a future version.
+    // Losing the arbiter means duplicate toasts, not a broken app.
+    return null;
+  }
 }
 
 /**
@@ -27,11 +78,60 @@ interface AnalysisJobState {
  * Singular by design: the API allows one active analysis job per user.
  */
 export const useAnalysisJobStore = create<AnalysisJobState>()(
-  persist((set) => ({ job: null, setJob: (job) => set({ job }) }), {
-    name: 'geolens-analysis-job',
-    version: 1,
-  }),
+  persist(
+    (set) => ({
+      job: null,
+      completedAt: null,
+      setJob: (job) => set({ job }),
+      claimCompletion: (jobId) => {
+        const existing = readPersistedClaim();
+        if (existing?.jobId === jobId) {
+          // Someone already reported this one. Ours only if we were the one.
+          return existing.tabId === TAB_ID;
+        }
+        set({ completedAt: { jobId, tabId: TAB_ID, at: Date.now() } });
+        // Last writer wins, and the read-back is the arbiter: if two tabs got
+        // past the check above simultaneously, only one of them reads its own
+        // id back. Checking first AND re-reading is what makes it exactly one
+        // — the check alone loses to a genuine race, and the read-back alone
+        // lets a tab that writes and reads before the other tab writes come
+        // out true as well.
+        const settled = readPersistedClaim();
+        return settled?.jobId === jobId && settled.tabId === TAB_ID;
+      },
+    }),
+    {
+      name: ANALYSIS_JOB_STORAGE_KEY,
+      // Deliberately NOT bumped for `completedAt`: the default shallow merge
+      // leaves the field at its initial null when an older payload omits it,
+      // and a bump would discard a job that was in flight across the deploy.
+      version: 1,
+    },
+  ),
 );
+
+/**
+ * feat(#1008): cross-tab mirror.
+ *
+ * Two builders open on the same map each poll the same materialize job, and
+ * neither knows about the other: the second tab's Create button stays enabled
+ * and earns a 429 rendered as generic rate limiting. The `storage` event fires
+ * only in the tabs that did NOT write, so rehydrating here is what lets tab B
+ * learn that tab A started a run — `analysisJobRunning` in the Analysis panel
+ * is a live subscription, so the button disables without a reload. It also
+ * propagates the identity-change clear.
+ *
+ * The mirror on its own dedups nothing: three tabs mirroring the same job all
+ * still poll it to completion, and each raises its own toast (`toastId` is
+ * per-job, and each tab has its own toaster). That is what `claimCompletion`
+ * above is for.
+ */
+if (typeof window !== 'undefined') {
+  window.addEventListener('storage', (e) => {
+    if (e.key !== ANALYSIS_JOB_STORAGE_KEY) return;
+    void useAnalysisJobStore.persist.rehydrate();
+  });
+}
 
 // The tracked job is persisted browser state — without this it survives a
 // logout and the next account on the same browser inherits the previous

--- a/frontend/src/stores/analysis-job-store.ts
+++ b/frontend/src/stores/analysis-job-store.ts
@@ -200,18 +200,25 @@ export const useAnalysisJobStore = create<AnalysisJobState>()(
       return {
         job: null,
         completedAt: null,
-        setJob: (job) =>
+        setJob: (job) => {
+          // fix(#1008 codex P2): read the identity NOW, not inside the lock
+          // callback. That callback can wait behind another tab's write, and
+          // an account switch in the meantime would stamp this run as
+          // belonging to whoever arrived — which the scoped clear below would
+          // then dutifully preserve for them.
+          //
+          // Stamped here rather than by callers: every caller would have to
+          // remember, and forgetting reads as "belongs to nobody".
+          const owned = job
+            ? { ...job, userId: useAuthStore.getState().user?.id ?? null }
+            : null;
           // fix(#1008 codex P1): a job START has to serialize against a clear
           // too, or a clear that read "no newer job" moments earlier overwrites
           // this one with null.
-          withLock(() => {
-            // Stamped here rather than by callers: every caller would have to
-            // remember, and forgetting reads as "belongs to nobody".
-            const owned = job
-              ? { ...job, userId: useAuthStore.getState().user?.id ?? null }
-              : null;
+          return withLock(() => {
             set(mergeWith(readPersisted(), { job: owned }));
-          }, undefined),
+          }, undefined);
+        },
         clearJobForUser: (userId) =>
           withLock(() => {
             const persisted = readPersisted();

--- a/frontend/src/stores/analysis-job-store.ts
+++ b/frontend/src/stores/analysis-job-store.ts
@@ -24,9 +24,13 @@ export interface AnalysisCompletionClaim {
   at: number;
 }
 
-interface AnalysisJobState {
+/** The fields that reach storage; the actions below are not serializable. */
+interface PersistedAnalysisJobState {
   job: TrackedAnalysisJob | null;
   completedAt: AnalysisCompletionClaim | null;
+}
+
+interface AnalysisJobState extends PersistedAnalysisJobState {
   setJob: (job: TrackedAnalysisJob | null) => void;
   /**
    * Try to become the one tab that reports this job's completion.
@@ -85,6 +89,25 @@ function readPersisted(): {
 }
 
 /**
+ * Choose between the persisted value and the in-memory one, preferring the
+ * in-memory OBJECT whenever the two describe the same thing.
+ *
+ * `readPersisted` parses fresh objects out of JSON every call, so returning
+ * them unconditionally would hand React a new identity on every write and
+ * re-run every effect subscribed to this store — including the watcher's, for
+ * a value that did not change. `undefined` means storage had nothing to say.
+ */
+function pick<T extends object>(
+  persisted: T | null | undefined,
+  current: T | null,
+  same: (a: T, b: T) => boolean,
+): T | null {
+  if (persisted === undefined) return current;
+  if (persisted && current && same(persisted, current)) return current;
+  return persisted;
+}
+
+/**
  * The one in-flight materialize job being tracked for notification.
  *
  * Persisted because the whole point is surviving what a long job outlives:
@@ -97,48 +120,75 @@ function readPersisted(): {
  */
 export const useAnalysisJobStore = create<AnalysisJobState>()(
   persist(
-    (set) => ({
-      job: null,
-      completedAt: null,
-      setJob: (job) => set({ job }),
-      claimCompletion: async (jobId) => {
-        const attempt = () => {
-          const existing = readPersisted().completedAt;
-          if (existing?.jobId === jobId) {
-            // Already reported. Ours only if we were the one who did it.
-            return existing.tabId === TAB_ID;
-          }
-          set({ completedAt: { jobId, tabId: TAB_ID, at: Date.now() } });
-          const settled = readPersisted().completedAt;
-          return settled?.jobId === jobId && settled.tabId === TAB_ID;
+    (set, get) => {
+      /**
+       * fix(#1008 codex P1): every `set` here persists the WHOLE snapshot,
+       * so a write that means to change one field silently republishes this
+       * tab's copy of the other. That is harmless in one tab and corrupting
+       * across several: a throttled tab still holding `job1` would restore it
+       * over another tab's newer `job2` just by claiming a completion. So
+       * refresh whatever a write is not changing from storage first.
+       *
+       * Falls back to in-memory when storage has no entry to offer (first
+       * write of the session, or storage unreadable) — the alternative is
+       * nulling a field on the strength of a failed read.
+       */
+      const merged = (patch: Partial<PersistedAnalysisJobState>) => {
+        const persisted = readPersisted();
+        const current = get();
+        return {
+          job: pick(persisted.job, current.job, (a, b) => a.jobId === b.jobId),
+          completedAt: pick(
+            persisted.completedAt,
+            current.completedAt,
+            (a, b) => a.jobId === b.jobId && a.tabId === b.tabId,
+          ),
+          ...patch,
         };
-        // fix(#1008 codex P2): the read/write/read above is NOT atomic on its
-        // own, and the tempting argument that it is does not survive contact
-        // with an interleaving. localStorage serializes individual operations,
-        // not a sequence of them, so `A reads empty, B reads empty, A writes,
-        // A reads back A, B writes, B reads back B` leaves both tabs holding
-        // what looks like a winning claim — which is exactly the simultaneous
-        // completion this exists to dedup. Web Locks is the primitive that
-        // actually makes the sequence mutually exclusive across same-origin
-        // documents, so run it under one.
-        const locks = globalThis.navigator?.locks;
-        if (!locks) {
-          // No Web Locks (older browser, or a non-DOM environment). The
-          // sequence is still right in every staggered case, which is the
-          // common one; the residual loss is a duplicate toast on a genuine
-          // tie, i.e. the behaviour before any of this existed.
-          return attempt();
-        }
-        return await locks.request(COMPLETION_LOCK, attempt);
-      },
-      clearJobIfCurrent: (jobId) => {
-        const persistedJob = readPersisted().job;
-        // Only bail when storage names a DIFFERENT run: a null there means
-        // nothing is tracked, and this tab's in-memory copy still has to go.
-        if (persistedJob && persistedJob.jobId !== jobId) return;
-        set({ job: null });
-      },
-    }),
+      };
+      return {
+        job: null,
+        completedAt: null,
+        setJob: (job) => set(merged({ job })),
+        claimCompletion: async (jobId) => {
+          const attempt = () => {
+            const existing = readPersisted().completedAt;
+            if (existing?.jobId === jobId) {
+              // Already reported. Ours only if we were the one who did it.
+              return existing.tabId === TAB_ID;
+            }
+            set(merged({ completedAt: { jobId, tabId: TAB_ID, at: Date.now() } }));
+            const settled = readPersisted().completedAt;
+            return settled?.jobId === jobId && settled.tabId === TAB_ID;
+          };
+          // fix(#1008 codex P2): the read/write/read above is NOT atomic on its
+          // own, and the tempting argument that it is does not survive contact
+          // with an interleaving. localStorage serializes individual operations,
+          // not a sequence of them, so `A reads empty, B reads empty, A writes,
+          // A reads back A, B writes, B reads back B` leaves both tabs holding
+          // what looks like a winning claim — which is exactly the simultaneous
+          // completion this exists to dedup. Web Locks is the primitive that
+          // actually makes the sequence mutually exclusive across same-origin
+          // documents, so run it under one.
+          const locks = globalThis.navigator?.locks;
+          if (!locks) {
+            // No Web Locks (older browser, or a non-DOM environment). The
+            // sequence is still right in every staggered case, which is the
+            // common one; the residual loss is a duplicate toast on a genuine
+            // tie, i.e. the behaviour before any of this existed.
+            return attempt();
+          }
+          return await locks.request(COMPLETION_LOCK, attempt);
+        },
+        clearJobIfCurrent: (jobId) => {
+          const persistedJob = readPersisted().job;
+          // Only bail when storage names a DIFFERENT run: a null there means
+          // nothing is tracked, and this tab's in-memory copy still has to go.
+          if (persistedJob && persistedJob.jobId !== jobId) return;
+          set(merged({ job: null }));
+        },
+      };
+    },
     {
       name: ANALYSIS_JOB_STORAGE_KEY,
       // Deliberately NOT bumped for `completedAt`: the default shallow merge

--- a/frontend/src/stores/analysis-job-store.ts
+++ b/frontend/src/stores/analysis-job-store.ts
@@ -31,7 +31,7 @@ interface PersistedAnalysisJobState {
 }
 
 interface AnalysisJobState extends PersistedAnalysisJobState {
-  setJob: (job: TrackedAnalysisJob | null) => void;
+  setJob: (job: TrackedAnalysisJob | null) => Promise<void>;
   /**
    * Try to become the one tab that reports this job's completion.
    *
@@ -50,7 +50,7 @@ interface AnalysisJobState extends PersistedAnalysisJobState {
    * the NEXT analysis; clearing then erases the newer job everywhere and
    * re-enables Create while the server job is still running.
    */
-  clearJobIfCurrent: (jobId: string) => void;
+  clearJobIfCurrent: (jobId: string) => Promise<void>;
 }
 
 export const ANALYSIS_JOB_STORAGE_KEY = 'geolens-analysis-job';
@@ -59,8 +59,8 @@ export const ANALYSIS_JOB_STORAGE_KEY = 'geolens-analysis-job';
 const TAB_ID =
   globalThis.crypto?.randomUUID?.() ?? `tab-${Math.random().toString(36).slice(2)}`;
 
-/** Web Locks name guarding the claim's read/write/read sequence. */
-const COMPLETION_LOCK = 'geolens-analysis-completion';
+/** Web Locks name serializing every read-modify-write on this record. */
+const ANALYSIS_JOB_LOCK = 'geolens-analysis-job-write';
 
 /**
  * Read persisted state straight out of storage rather than off in-memory state.
@@ -108,6 +108,33 @@ function pick<T extends object>(
 }
 
 /**
+ * Run a read-modify-write on the shared record under mutual exclusion.
+ *
+ * Web Locks is the only primitive that serializes a SEQUENCE of storage
+ * operations across same-origin documents; localStorage serializes each
+ * operation on its own and nothing more.
+ *
+ * fix(#1008 codex P2): never rejects. The watcher awaits these, and a
+ * rejection there would leave a finished job neither reported nor cleared,
+ * with Create disabled until a reload. `fallback` is what a broken storage
+ * layer should degrade to — for a claim that is `true`, because a duplicate
+ * notification beats never telling the user their dataset is ready.
+ */
+async function withLock<T>(run: () => T, fallback: T): Promise<T> {
+  try {
+    const locks = globalThis.navigator?.locks;
+    // No Web Locks (older browser, or a non-DOM environment). The sequence is
+    // still right in every staggered case, which is the common one; the
+    // residual loss is a duplicate toast on a genuine tie, i.e. the behaviour
+    // that shipped before any of this.
+    if (!locks) return run();
+    return await locks.request(ANALYSIS_JOB_LOCK, run);
+  } catch {
+    return fallback;
+  }
+}
+
+/**
  * The one in-flight materialize job being tracked for notification.
  *
  * Persisted because the whole point is surviving what a long job outlives:
@@ -122,19 +149,23 @@ export const useAnalysisJobStore = create<AnalysisJobState>()(
   persist(
     (set, get) => {
       /**
-       * fix(#1008 codex P1): every `set` here persists the WHOLE snapshot,
-       * so a write that means to change one field silently republishes this
-       * tab's copy of the other. That is harmless in one tab and corrupting
-       * across several: a throttled tab still holding `job1` would restore it
-       * over another tab's newer `job2` just by claiming a completion. So
-       * refresh whatever a write is not changing from storage first.
+       * fix(#1008 codex P1): every `set` here persists the WHOLE snapshot, so
+       * a write that means to change one field silently republishes this tab's
+       * copy of the other. Harmless in one tab, corrupting across several: a
+       * throttled tab still holding `job1` would restore it over another tab's
+       * newer `job2` just by claiming a completion.
        *
-       * Falls back to in-memory when storage has no entry to offer (first
-       * write of the session, or storage unreadable) — the alternative is
-       * nulling a field on the strength of a failed read.
+       * Takes the snapshot the caller already read, so a decision and the
+       * write it justifies can never straddle two different reads.
+       *
+       * Falls back to in-memory when storage has nothing to offer (first write
+       * of the session, or an unreadable read) — the alternative is nulling a
+       * field on the strength of a failed read.
        */
-      const merged = (patch: Partial<PersistedAnalysisJobState>) => {
-        const persisted = readPersisted();
+      const mergeWith = (
+        persisted: ReturnType<typeof readPersisted>,
+        patch: Partial<PersistedAnalysisJobState>,
+      ) => {
         const current = get();
         return {
           job: pick(persisted.job, current.job, (a, b) => a.jobId === b.jobId),
@@ -149,44 +180,50 @@ export const useAnalysisJobStore = create<AnalysisJobState>()(
       return {
         job: null,
         completedAt: null,
-        setJob: (job) => set(merged({ job })),
-        claimCompletion: async (jobId) => {
-          const attempt = () => {
-            const existing = readPersisted().completedAt;
+        setJob: (job) =>
+          // fix(#1008 codex P1): a job START has to serialize against a clear
+          // too, or a clear that read "no newer job" moments earlier overwrites
+          // this one with null.
+          withLock(() => {
+            set(mergeWith(readPersisted(), { job }));
+          }, undefined),
+        claimCompletion: (jobId) =>
+          // fix(#1008 codex P2): the read/write/read below is NOT atomic on its
+          // own, and the tempting argument that it is does not survive contact
+          // with an interleaving. localStorage serializes individual
+          // operations, not a sequence of them, so `A reads empty, B reads
+          // empty, A writes, A reads back A, B writes, B reads back B` leaves
+          // both tabs holding what looks like a winning claim — exactly the
+          // simultaneous completion this exists to dedup.
+          withLock(() => {
+            const persisted = readPersisted();
+            const existing = persisted.completedAt;
             if (existing?.jobId === jobId) {
               // Already reported. Ours only if we were the one who did it.
               return existing.tabId === TAB_ID;
             }
-            set(merged({ completedAt: { jobId, tabId: TAB_ID, at: Date.now() } }));
+            // fix(#1008 codex P2): a claim naming a DIFFERENT run, while the
+            // tracked run is not ours either, means this tab is late — a
+            // throttled tab resuming after the run it is holding was cleared
+            // and a later one already completed. Overwriting would re-report a
+            // finished run and re-arm the newer one for a second claim.
+            if (existing && persisted.job?.jobId !== jobId) return false;
+            set(
+              mergeWith(persisted, {
+                completedAt: { jobId, tabId: TAB_ID, at: Date.now() },
+              }),
+            );
             const settled = readPersisted().completedAt;
             return settled?.jobId === jobId && settled.tabId === TAB_ID;
-          };
-          // fix(#1008 codex P2): the read/write/read above is NOT atomic on its
-          // own, and the tempting argument that it is does not survive contact
-          // with an interleaving. localStorage serializes individual operations,
-          // not a sequence of them, so `A reads empty, B reads empty, A writes,
-          // A reads back A, B writes, B reads back B` leaves both tabs holding
-          // what looks like a winning claim — which is exactly the simultaneous
-          // completion this exists to dedup. Web Locks is the primitive that
-          // actually makes the sequence mutually exclusive across same-origin
-          // documents, so run it under one.
-          const locks = globalThis.navigator?.locks;
-          if (!locks) {
-            // No Web Locks (older browser, or a non-DOM environment). The
-            // sequence is still right in every staggered case, which is the
-            // common one; the residual loss is a duplicate toast on a genuine
-            // tie, i.e. the behaviour before any of this existed.
-            return attempt();
-          }
-          return await locks.request(COMPLETION_LOCK, attempt);
-        },
-        clearJobIfCurrent: (jobId) => {
-          const persistedJob = readPersisted().job;
-          // Only bail when storage names a DIFFERENT run: a null there means
-          // nothing is tracked, and this tab's in-memory copy still has to go.
-          if (persistedJob && persistedJob.jobId !== jobId) return;
-          set(merged({ job: null }));
-        },
+          }, true),
+        clearJobIfCurrent: (jobId) =>
+          withLock(() => {
+            const persisted = readPersisted();
+            // Only stand down when storage names a DIFFERENT run: a null there
+            // means nothing is tracked and this tab's copy still has to go.
+            if (persisted.job && persisted.job.jobId !== jobId) return;
+            set(mergeWith(persisted, { job: null }));
+          }, undefined),
       };
     },
     {
@@ -236,7 +273,7 @@ if (typeof window !== 'undefined') {
 // a job mid-run.
 useAuthStore.subscribe((s, prev) => {
   if (s.user?.id !== prev.user?.id) {
-    useAnalysisJobStore.getState().setJob(null);
+    void useAnalysisJobStore.getState().setJob(null);
   }
 });
 


### PR DESCRIPTION
Two builders open on the same map each poll the same materialize job, each raise a completion toast, and each invalidate the catalog cache. The second tab also does not know the first has a run in flight, so its Create button stays enabled and the user earns a 429 rendered as generic rate limiting.

This is the second time the item has been filed — it was item 6 of #698 and closed without shipping.

## Mechanism 1, the mirror

A `storage` listener on `geolens-analysis-job` that rehydrates when another tab writes, the same shape `auth-store.ts:113-129` already ships. `analysisJobRunning` in the Analysis panel (`AnalysisPanel.tsx:505`) is a live store subscription, so tab B's Create button disables without a reload, and a clear propagates the same way. **No change to `AnalysisPanel.tsx` was needed** — the subscription was already there.

## Mechanism 2, the claim

The mirror dedups nothing: three tabs mirroring one job all still poll it to completion, and each has its own toaster (`toastId` is per job, which only collapses StrictMode's double invoke *within* a tab).

`completedAt` is a written claim on the persisted record. A tab checks for an existing claim on that `jobId`, writes its own if there is none, then reads back; the read-back is the arbiter, since localStorage writes serialize per origin.

Both halves are load-bearing. The check alone loses a genuine race (two tabs both see no claim). The read-back alone lets a tab that writes and reads before the other tab writes come out true as well, so both would report. Together, exactly one.

The record carries the writing tab's id, not a bare timestamp: two tabs can observe the same terminal poll in the same millisecond, and a timestamp then cannot say whose claim survived.

Being written rather than timed is also what makes it durable — a tab that reloads after another already reported reads the existing claim and stays silent.

## Schema note

The persisted `version` is deliberately **not** bumped for the new field. Zustand's default shallow merge leaves `completedAt` at its initial `null` when an older payload omits it, and a bump would discard a job that was in flight across the deploy.

## Tests

`src/stores/__tests__/analysis-job-store.cross-tab.test.ts` is new — the mirror half in the style of `auth-store.cross-tab.test.ts`, and the claim half as its own thing, because a mirror test is not a dedup test. The two-tab case drives a genuinely second store instance (`vi.resetModules()` + re-import, so it gets its own tab id) against the shared `localStorage`, which is the only way to get a distinct claimant out of a module singleton. The same trick doubles as the reload-durability case.

Deliberately a sibling file rather than an extension of `analysis-job-store.test.ts`: #699 (PR #1037) creates that file, this creates no file it owns, and the split matches the `auth-store.test.ts` / `auth-store.cross-tab.test.ts` precedent the issue points at. The two PRs do not touch a shared file.

`AnalysisJobWatcher.test.tsx` gains the claim behaviour end to end: silent on a completion and on a failure another tab claimed (with the local cleanup still running so Create re-enables), and exactly one toast plus exactly two invalidations when it wins. Verified by mutation — disabling the claim gate fails both silence tests.

## Verification

```
cd frontend
npx vitest run src/stores/__tests__/analysis-job-store.cross-tab.test.ts \
  src/components/analysis/__tests__/AnalysisJobWatcher.test.tsx
npm run lint && npm run typecheck && npm run test:coverage   # 367 files, 4297 tests
```

No new `t()` keys, so locale parity is unaffected. No backend, schema or API impact.

Closes #1008