### PR TITLE
chore(a11y): document the row shortcuts and extend the axe suite to the builder panels

### DIFF
--- a/e2e/accessibility.spec.ts
+++ b/e2e/accessibility.spec.ts
@@ -280,6 +280,55 @@ test.describe('Accessibility - WCAG 2AA', () => {
     expect(results.violations, formatViolations(results.violations)).toEqual([]);
   });
 
+  // fix(#806 item 2): the builder-page test above scans the builder with the editor
+  // closed, so neither the analysis panel nor any layer-editor tab was ever covered
+  // — including the live-region work #784/#782/#804 added. Both surfaces are reached
+  // by interaction rather than by URL, so they follow the Add Dataset dialog's shape
+  // and scope with .include() to keep them off what the page test already owns.
+  test('analysis panel has no accessibility violations', async ({ page }) => {
+    await page.goto(`/maps/${builderMapId}`);
+    await page.waitForLoadState('networkidle');
+    await expect(page.getByTestId('builder-sidebar')).toBeVisible({ timeout: 15_000 });
+
+    await page.getByRole('button', { name: 'Analysis', exact: true }).click();
+    await expect(page.getByTestId('analysis-panel')).toBeVisible({ timeout: 15_000 });
+
+    const results = await new AxeBuilder({ page })
+      .withTags(wcagTags)
+      .include('[data-testid="analysis-panel"]')
+      .analyze();
+
+    expect(results.violations, formatViolations(results.violations)).toEqual([]);
+  });
+
+  // The seeded layer is vector, so LayerEditorPanel resolves all four tabs and one
+  // layer exposes the whole surface. Each tab renders its own panel body and only
+  // the active one is in the DOM, so every tab needs its own scan.
+  for (const tab of ['Style', 'Filter', 'Labels', 'Popup'] as const) {
+    test(`layer editor ${tab} tab has no accessibility violations`, async ({ page }) => {
+      await page.goto(`/maps/${builderMapId}`);
+      await page.waitForLoadState('networkidle');
+      await expect(page.getByTestId('builder-sidebar')).toBeVisible({ timeout: 15_000 });
+
+      await page
+        .locator('[id^="stack-row-"]:not([id="stack-row-basemap-group"])')
+        .first()
+        .click();
+      const editor = page.getByTestId('builder-layer-editor');
+      await expect(editor).toBeVisible({ timeout: 15_000 });
+
+      await editor.getByRole('tab', { name: tab }).click();
+      await expect(editor.getByRole('tab', { name: tab })).toHaveAttribute('aria-selected', 'true');
+
+      const results = await new AxeBuilder({ page })
+        .withTags(wcagTags)
+        .include('[data-testid="builder-layer-editor"]')
+        .analyze();
+
+      expect(results.violations, formatViolations(results.violations)).toEqual([]);
+    });
+  }
+
   test('admin overview page has no accessibility violations', async ({ page }) => {
     await page.goto('/admin');
     await expect(

--- a/e2e/accessibility.spec.ts
+++ b/e2e/accessibility.spec.ts
@@ -293,9 +293,13 @@ test.describe('Accessibility - WCAG 2AA', () => {
     await page.getByRole('button', { name: 'Analysis', exact: true }).click();
     await expect(page.getByTestId('analysis-panel')).toBeVisible({ timeout: 15_000 });
 
+    // Scope to the rail panel, not the inner form: BuilderRail renders the panel
+    // title and close control as siblings of AnalysisPanel, and since the
+    // builder-page scan runs with the panel closed, that chrome would otherwise
+    // be covered nowhere.
     const results = await new AxeBuilder({ page })
       .withTags(wcagTags)
-      .include('[data-testid="analysis-panel"]')
+      .include('[data-rail-panel]')
       .analyze();
 
     expect(results.violations, formatViolations(results.violations)).toEqual([]);

--- a/frontend/src/components/builder/KeyboardShortcutsSheet.tsx
+++ b/frontend/src/components/builder/KeyboardShortcutsSheet.tsx
@@ -120,7 +120,11 @@ export function KeyboardShortcutsSheet({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="sm:max-w-sm">
+      {/* fix(#806, codex P2): DialogContent has no max height and no overflow of its
+          own, and it is vertically centred, so a sheet taller than the viewport
+          clips at both ends with nothing to scroll. Fifteen rows plus wrapped
+          translations reach that on a short window or with enlarged text. */}
+      <DialogContent className="sm:max-w-sm max-h-[85vh] overflow-y-auto">
         <DialogHeader>
           <DialogTitle>
             {t('a11y.shortcuts.title', { defaultValue: 'Keyboard shortcuts' })}

--- a/frontend/src/components/builder/KeyboardShortcutsSheet.tsx
+++ b/frontend/src/components/builder/KeyboardShortcutsSheet.tsx
@@ -103,7 +103,9 @@ export function KeyboardShortcutsSheet({
     },
     {
       id: 'rename',
-      label: t('a11y.shortcuts.rename', { defaultValue: 'Rename layer' }),
+      // The handler is on the layer-name span, not the row, so the label names the
+      // target: double-clicking the icon or empty row space selects instead.
+      label: t('a11y.shortcuts.rename', { defaultValue: 'Rename layer (double-click its name)' }),
       chord: 'Double-click',
     },
     {

--- a/frontend/src/components/builder/KeyboardShortcutsSheet.tsx
+++ b/frontend/src/components/builder/KeyboardShortcutsSheet.tsx
@@ -91,6 +91,21 @@ export function KeyboardShortcutsSheet({
       label: t('a11y.shortcuts.multiSelect', { defaultValue: 'Toggle layer in selection' }),
       chord: IS_MAC ? '⌘+Click' : 'Ctrl+Click',
     },
+    // fix(#806): Space on a focused row is the keyboard equivalent of the
+    // Cmd-click above (StackRow's `e.key === ' '` handler), and double-click
+    // renames. Both existed with no way to discover them from here — the
+    // keyboard one especially, since it was the only route for a keyboard-only
+    // user and the sheet documented multi-select as a pointer chord alone.
+    {
+      id: 'multi-select-key',
+      label: t('a11y.shortcuts.multiSelectKey', { defaultValue: 'Toggle layer in selection (focused row)' }),
+      chord: 'Space',
+    },
+    {
+      id: 'rename',
+      label: t('a11y.shortcuts.rename', { defaultValue: 'Rename layer' }),
+      chord: 'Double-click',
+    },
     {
       id: 'range-select',
       label: t('a11y.shortcuts.rangeSelect', { defaultValue: 'Select a range of layers' }),

--- a/frontend/src/components/builder/__tests__/KeyboardShortcutsSheet.test.tsx
+++ b/frontend/src/components/builder/__tests__/KeyboardShortcutsSheet.test.tsx
@@ -54,6 +54,9 @@ describe('KeyboardShortcutsSheet', () => {
 
     const renameRow = screen.getByTestId('shortcut-rename');
     expect(renameRow.querySelector('kbd')!.textContent).toMatch(/Double-click/i);
+    // The gesture is bound to the layer-name span, so the label has to say so —
+    // double-clicking the icon or empty row space selects instead of renaming.
+    expect(renameRow.textContent).toMatch(/name/i);
   });
 
   it('calls onOpenChange(false) when dialog requests close', () => {

--- a/frontend/src/components/builder/__tests__/KeyboardShortcutsSheet.test.tsx
+++ b/frontend/src/components/builder/__tests__/KeyboardShortcutsSheet.test.tsx
@@ -40,6 +40,22 @@ describe('KeyboardShortcutsSheet', () => {
     expect(screen.getByTestId('shortcut-legend')).toBeInTheDocument();
   });
 
+  // fix(#806 item 1): Space on a focused row toggles multi-selection (StackRow's
+  // `e.key === ' '` handler) and double-click renames. Both were undocumented; the
+  // keyboard one was the only route a keyboard-only user had, and the sheet listed
+  // multi-select as a pointer chord alone.
+  it('documents Space on a focused row and double-click-to-rename', () => {
+    render(<KeyboardShortcutsSheet open={true} onOpenChange={vi.fn()} />);
+
+    const spaceRow = screen.getByTestId('shortcut-multi-select-key');
+    expect(spaceRow.querySelector('kbd')!.textContent).toBe('Space');
+    // Distinct from the drag-handle row, which is scoped to the handle.
+    expect(screen.getByTestId('shortcut-reorder-toggle')).toBeInTheDocument();
+
+    const renameRow = screen.getByTestId('shortcut-rename');
+    expect(renameRow.querySelector('kbd')!.textContent).toMatch(/Double-click/i);
+  });
+
   it('calls onOpenChange(false) when dialog requests close', () => {
     const onOpenChange = vi.fn();
     render(<KeyboardShortcutsSheet open={true} onOpenChange={onOpenChange} />);

--- a/frontend/src/i18n/locales/de/builder.json
+++ b/frontend/src/i18n/locales/de/builder.json
@@ -1136,7 +1136,7 @@
       "escape": "Panel schließen / Auswahl aufheben / Sortiermodus beenden",
       "multiSelect": "Ebene zur Auswahl hinzufügen/entfernen",
       "multiSelectKey": "Ebene in der Auswahl umschalten (fokussierte Zeile)",
-      "rename": "Ebene umbenennen",
+      "rename": "Ebene umbenennen (Doppelklick auf den Namen)",
       "rangeSelect": "Einen Bereich von Ebenen auswählen",
       "extendSelect": "Auswahl erweitern (Stapel fokussiert)"
     },

--- a/frontend/src/i18n/locales/de/builder.json
+++ b/frontend/src/i18n/locales/de/builder.json
@@ -1135,6 +1135,8 @@
       "reorderMove": "Ebene nach oben / unten verschieben (Sortiermodus)",
       "escape": "Panel schließen / Auswahl aufheben / Sortiermodus beenden",
       "multiSelect": "Ebene zur Auswahl hinzufügen/entfernen",
+      "multiSelectKey": "Ebene in der Auswahl umschalten (fokussierte Zeile)",
+      "rename": "Ebene umbenennen",
       "rangeSelect": "Einen Bereich von Ebenen auswählen",
       "extendSelect": "Auswahl erweitern (Stapel fokussiert)"
     },

--- a/frontend/src/i18n/locales/en/builder.json
+++ b/frontend/src/i18n/locales/en/builder.json
@@ -1140,7 +1140,7 @@
       "escape": "Close panel / clear selection / exit reorder",
       "multiSelect": "Toggle layer in selection",
       "multiSelectKey": "Toggle layer in selection (focused row)",
-      "rename": "Rename layer",
+      "rename": "Rename layer (double-click its name)",
       "rangeSelect": "Select a range of layers",
       "extendSelect": "Extend selection (stack focused)"
     },

--- a/frontend/src/i18n/locales/en/builder.json
+++ b/frontend/src/i18n/locales/en/builder.json
@@ -1139,6 +1139,8 @@
       "reorderMove": "Move layer up / down (reorder mode)",
       "escape": "Close panel / clear selection / exit reorder",
       "multiSelect": "Toggle layer in selection",
+      "multiSelectKey": "Toggle layer in selection (focused row)",
+      "rename": "Rename layer",
       "rangeSelect": "Select a range of layers",
       "extendSelect": "Extend selection (stack focused)"
     },

--- a/frontend/src/i18n/locales/es/builder.json
+++ b/frontend/src/i18n/locales/es/builder.json
@@ -1136,7 +1136,7 @@
       "escape": "Cerrar panel / borrar selección / salir de reordenación",
       "multiSelect": "Alternar capa en la selección",
       "multiSelectKey": "Alternar la capa en la selección (fila enfocada)",
-      "rename": "Renombrar capa",
+      "rename": "Renombrar capa (doble clic en su nombre)",
       "rangeSelect": "Seleccionar un rango de capas",
       "extendSelect": "Ampliar selección (pila enfocada)"
     },

--- a/frontend/src/i18n/locales/es/builder.json
+++ b/frontend/src/i18n/locales/es/builder.json
@@ -1135,6 +1135,8 @@
       "reorderMove": "Mover capa arriba / abajo (modo de reordenación)",
       "escape": "Cerrar panel / borrar selección / salir de reordenación",
       "multiSelect": "Alternar capa en la selección",
+      "multiSelectKey": "Alternar la capa en la selección (fila enfocada)",
+      "rename": "Renombrar capa",
       "rangeSelect": "Seleccionar un rango de capas",
       "extendSelect": "Ampliar selección (pila enfocada)"
     },

--- a/frontend/src/i18n/locales/fr/builder.json
+++ b/frontend/src/i18n/locales/fr/builder.json
@@ -1135,6 +1135,8 @@
       "reorderMove": "Déplacer la couche vers le haut / bas (mode réorganisation)",
       "escape": "Fermer le panneau / effacer la sélection / quitter la réorganisation",
       "multiSelect": "Basculer la couche dans la sélection",
+      "multiSelectKey": "Ajouter ou retirer la couche de la sélection (ligne ciblée)",
+      "rename": "Renommer la couche",
       "rangeSelect": "Sélectionner une plage de couches",
       "extendSelect": "Étendre la sélection (pile active)"
     },

--- a/frontend/src/i18n/locales/fr/builder.json
+++ b/frontend/src/i18n/locales/fr/builder.json
@@ -1136,7 +1136,7 @@
       "escape": "Fermer le panneau / effacer la sélection / quitter la réorganisation",
       "multiSelect": "Basculer la couche dans la sélection",
       "multiSelectKey": "Ajouter ou retirer la couche de la sélection (ligne ciblée)",
-      "rename": "Renommer la couche",
+      "rename": "Renommer la couche (double-clic sur son nom)",
       "rangeSelect": "Sélectionner une plage de couches",
       "extendSelect": "Étendre la sélection (pile active)"
     },


### PR DESCRIPTION
Closes #806 (both items; they are unrelated to each other and simply share the issue).

## Item 1 — two undiscoverable bindings

`StackRow` maps Space on a focused row to `onCmdClick`, and double-click on the layer name to rename. Neither appeared in `KeyboardShortcutsSheet`. The keyboard one matters most: the sheet documented multi-select as ⌘/Ctrl+Click only, so the sole route available to a keyboard-only user was the one that was not written down.

The new Space row sits next to the pointer chord it mirrors and is scoped "(focused row)", which is what distinguishes it from the existing `Space / Enter` row scoped to the focused drag handle. Both new rows carry real values in en/es/fr/de — a `defaultValue` alone does not satisfy `npm run test:i18n`, which is the trap the file's own shape hides, since every existing row is written that way and renders fine in the browser before failing CI.

## Item 2 — axe coverage for the two interaction-reached surfaces

The existing builder-page scan runs with the editor closed, so neither `AnalysisPanel` nor any layer-editor tab was ever covered — including the live-region behaviour #784/#782/#804 added. Five new cases, following the Add Dataset dialog's three-step shape (navigate → wait for `builder-sidebar` → drive the opener → scan scoped with `.include()`):

- analysis panel, opened with the same opener `analysis.spec.ts` uses
- the Style, Filter, Labels and Popup tabs, opened with the same stack-row selector `builder-styling.spec.ts` uses

Scoped with `.include()` so they do not re-report violations the builder-page test already owns. No new fixture: the `beforeAll` map's seeded layer is vector, so `LayerEditorPanel` resolves all four tabs from that one layer. Each tab renders its own panel body and only the active one is in the DOM, so each gets its own scan.

## Verification

```
cd frontend && npm run lint && npm run typecheck && npm run test:i18n && npm run test:coverage
# 366 files, 4285 tests pass

npx playwright test e2e/accessibility.spec.ts --project=chromium -g "analysis panel|layer editor"
# 7 passed (5 new cases + setup/teardown), zero violations
```

The e2e run is valid from a worktree for these cases: the dev stack serves `main`'s app code, and the surfaces under scan are byte-identical to `main` on this branch (the diff touches the shortcuts sheet and locales, neither of which is inside the scanned regions).