### PR TITLE
perf(analysis): scoped work_mem for the materialize CTAS, with a justified ceiling

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -306,6 +306,13 @@ FRONTEND_PORT=8080
 # independently. RAISE it only with headroom you have checked; the win is less
 # spill to pgsql_tmp on large dissolves.
 #
+# The budget is divided across WORKER_CONCURRENCY slots in kB, so it is never
+# exceeded by rounding; if the share would fall below PostgreSQL's 64kB minimum
+# the override is skipped rather than overshooting. The same transaction also
+# pins max_parallel_workers_per_gather to 1, because work_mem is granted to the
+# leader AND each parallel worker — without that pin a server configured for
+# more parallelism would multiply the ceiling.
+#
 # 0 disables the override entirely: no SET LOCAL is issued and analysis runs on
 # whatever work_mem your cluster is configured with. Use that rather than a very
 # small value if you have tuned work_mem yourself — GeoLens cannot read your

--- a/.env.example
+++ b/.env.example
@@ -304,9 +304,13 @@ FRONTEND_PORT=8080
 # LOWER it if you reduce DB_MEM_LIMIT or run more than one worker service — a
 # per-process divisor cannot bound replicas, so each one claims this budget
 # independently. RAISE it only with headroom you have checked; the win is less
-# spill to pgsql_tmp on large dissolves. A value at or below the cluster default
-# (8MB) leaves analysis on the cluster-wide work_mem.
-# Type: integer MB (minimum 1) | Default: 64
+# spill to pgsql_tmp on large dissolves.
+#
+# 0 disables the override entirely: no SET LOCAL is issued and analysis runs on
+# whatever work_mem your cluster is configured with. Use that rather than a very
+# small value if you have tuned work_mem yourself — GeoLens cannot read your
+# cluster's setting, so it cannot tell a deliberate low value from an accident.
+# Type: integer MB (0 disables) | Default: 64
 # ANALYSIS_MATERIALIZE_WORK_MEM_MB=64
 #
 # FastAPI memory cap.

--- a/.env.example
+++ b/.env.example
@@ -294,6 +294,21 @@ FRONTEND_PORT=8080
 # Type: Docker byte value | Default: 2g
 # DB_MEM_LIMIT=2g
 #
+# Per-slot work_mem for the analysis materialize CTAS, in MB. Sized against
+# DB_MEM_LIMIT above: the memory is allocated by the PostgreSQL backend, not by
+# the worker, and work_mem is per operation AND per backend, so one materialize
+# can allocate this value x2 plan nodes x2 backends. At the 64MB default that is
+# 256MB per worker replica, which sits inside a 2g database alongside
+# shared_buffers (512MB) and maintenance_work_mem (128MB).
+#
+# LOWER it if you reduce DB_MEM_LIMIT or run more than one worker service — a
+# per-process divisor cannot bound replicas, so each one claims this budget
+# independently. RAISE it only with headroom you have checked; the win is less
+# spill to pgsql_tmp on large dissolves. A value at or below the cluster default
+# (8MB) leaves analysis on the cluster-wide work_mem.
+# Type: integer MB (minimum 1) | Default: 64
+# ANALYSIS_MATERIALIZE_WORK_MEM_MB=64
+#
 # FastAPI memory cap.
 # Type: Docker byte value | Default: 2g
 # API_MEM_LIMIT=2g

--- a/.env.example
+++ b/.env.example
@@ -307,8 +307,11 @@ FRONTEND_PORT=8080
 # spill to pgsql_tmp on large dissolves.
 #
 # The budget is divided across WORKER_CONCURRENCY slots in kB, so it is never
-# exceeded by rounding; if the share would fall below PostgreSQL's 64kB minimum
-# the override is skipped rather than overshooting. The same transaction also
+# exceeded by rounding. If the share would fall below PostgreSQL's 64kB minimum
+# for work_mem, the application REFUSES TO START and names the arithmetic:
+# there is no honest outcome at that point, since the minimum overshoots the
+# budget and falling back to the cluster's value overshoots it further. The
+# same transaction also
 # pins max_parallel_workers_per_gather to 1, because work_mem is granted to the
 # leader AND each parallel worker — without that pin a server configured for
 # more parallelism would multiply the ceiling.

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -278,9 +278,16 @@ class Settings(BaseSettings):
     #
     # RAISE IT only with headroom you have checked: a larger DB_MEM_LIMIT, or a
     # single worker service. LOWER IT for a smaller database container or more
-    # worker replicas. Setting it at or below the cluster default (8MB) leaves
-    # analysis on the cluster-wide value, which is the pre-#1012 behaviour.
-    analysis_materialize_work_mem_mb: int = Field(default=64, gt=0)
+    # worker replicas.
+    #
+    # 0 disables the override: no SET LOCAL is issued and the CTAS runs on
+    # whatever work_mem the cluster is configured with, which is the pre-#1012
+    # behaviour. That sentinel exists because this process cannot read the
+    # connected cluster's work_mem, so it cannot know whether any particular
+    # floor would preserve that value or quietly raise it — an external cluster
+    # tuned below the bundled 8MB would have been raised by a clamp that
+    # claimed to leave it alone. Positive values are applied as given.
+    analysis_materialize_work_mem_mb: int = Field(default=64, ge=0)
 
     # fix(#434): finished ingest_jobs rows previously lived forever, so the
     # admin Jobs page accumulated stale test junk with no cleanup affordance.

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -571,6 +571,17 @@ class Settings(BaseSettings):
         if budget_kb <= 0:
             return self
         per_slot_kb = budget_kb // max(1, self.worker_concurrency)
+        # PostgreSQL's own ceiling for work_mem. A share above it fails at
+        # SET LOCAL, so every materialize would be recorded as a failed job —
+        # a boot failure names the cause once instead.
+        if per_slot_kb > 2147483647:
+            raise ValueError(
+                f"ANALYSIS_MATERIALIZE_WORK_MEM_MB="
+                f"{self.analysis_materialize_work_mem_mb} divided across "
+                f"WORKER_CONCURRENCY={self.worker_concurrency} is "
+                f"{per_slot_kb}kB per slot, above PostgreSQL's work_mem maximum "
+                "of 2147483647kB."
+            )
         if per_slot_kb < 64:
             raise ValueError(
                 f"ANALYSIS_MATERIALIZE_WORK_MEM_MB="

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -257,6 +257,31 @@ class Settings(BaseSettings):
     # someone an afternoon.
     analysis_registration_timeout_seconds: int = Field(default=600, gt=0)
 
+    # fix(#1012): per-slot work_mem budget for the materialize CTAS, in MB.
+    #
+    # Configurable because the safe value depends on two things this process
+    # cannot see. DB_MEM_LIMIT is a compose `mem_limit` and is never passed into
+    # the api or worker environment, so the backend cannot read the database's
+    # actual ceiling — and it is operator-tunable (docker-compose.prod.yml
+    # documents 1.5g, and an external PostgreSQL may be smaller still). Nor can
+    # a per-process divisor bound a deployment that runs more than one worker
+    # service against the `ingest` queue: each replica would claim this budget
+    # independently.
+    #
+    # The default is deliberately conservative rather than optimal. work_mem is
+    # per operation AND per backend, so one materialize can allocate this value
+    # times the memory-hungry nodes in its plan (at most 2 for these shapes)
+    # times the backends running it (2, since max_parallel_workers_per_gather is
+    # 1). At 64MB that is 256MB per worker replica, so even two replicas stay
+    # inside the default 2 GB alongside shared_buffers (512MB) and
+    # maintenance_work_mem (128MB).
+    #
+    # RAISE IT only with headroom you have checked: a larger DB_MEM_LIMIT, or a
+    # single worker service. LOWER IT for a smaller database container or more
+    # worker replicas. Setting it at or below the cluster default (8MB) leaves
+    # analysis on the cluster-wide value, which is the pre-#1012 behaviour.
+    analysis_materialize_work_mem_mb: int = Field(default=64, gt=0)
+
     # fix(#434): finished ingest_jobs rows previously lived forever, so the
     # admin Jobs page accumulated stale test junk with no cleanup affordance.
     # Terminal jobs (complete/failed/cancelled/fanned_out) older than this many

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -555,6 +555,35 @@ class Settings(BaseSettings):
         return ",".join(queues)
 
     @model_validator(mode="after")
+    def validate_materialize_work_mem_budget(self) -> "Settings":
+        """fix(#1012): refuse a budget that cannot be divided into legal shares.
+
+        The budget is split across WORKER_CONCURRENCY slots. If a share falls
+        below PostgreSQL's 64kB minimum for work_mem there is no honest
+        outcome at run time: issuing the minimum exceeds the budget, and
+        skipping the override leaves the cluster's own work_mem — usually
+        LARGER — in force for every slot, which overshoots by more still. A
+        1MB budget across 32 slots wants 32kB each; falling back to a bundled
+        8MB default would expose 256MB. Neither is what the operator asked
+        for, so the configuration is rejected at boot instead.
+        """
+        budget_kb = self.analysis_materialize_work_mem_mb * 1024
+        if budget_kb <= 0:
+            return self
+        per_slot_kb = budget_kb // max(1, self.worker_concurrency)
+        if per_slot_kb < 64:
+            raise ValueError(
+                f"ANALYSIS_MATERIALIZE_WORK_MEM_MB="
+                f"{self.analysis_materialize_work_mem_mb} divided across "
+                f"WORKER_CONCURRENCY={self.worker_concurrency} is "
+                f"{per_slot_kb}kB per slot, below PostgreSQL's 64kB minimum "
+                "for work_mem. Raise the budget, lower WORKER_CONCURRENCY, or "
+                "set ANALYSIS_MATERIALIZE_WORK_MEM_MB=0 to leave work_mem at "
+                "the cluster's own value."
+            )
+        return self
+
+    @model_validator(mode="after")
     def validate_provider_settings(self) -> "Settings":
         if self.storage_provider == "s3":
             missing: list[str] = []

--- a/backend/app/processing/analysis/tasks.py
+++ b/backend/app/processing/analysis/tasks.py
@@ -159,7 +159,7 @@ async def _apply_materialize_work_mem(session: AsyncSession) -> None:
     work_mem = _materialize_work_mem()
     if work_mem is None:
         return
-    # Pin parallelism first, so the budget arithmetic is true by construction
+    # Cap parallelism first, so the budget arithmetic is true by construction
     # rather than by assuming the server's configuration. work_mem is granted to
     # the leader AND to every parallel worker, so a server with
     # max_parallel_workers_per_gather above 1 — a customised bundled conf, or
@@ -167,7 +167,19 @@ async def _apply_materialize_work_mem(session: AsyncSession) -> None:
     # which db/postgresql.conf:73 constrains — would multiply the ceiling by a
     # number this process cannot see. One leader plus one worker is what the
     # budget in config.py is sized for.
-    await session.execute(text("SET LOCAL max_parallel_workers_per_gather = 1"))
+    #
+    # LEAST, not a plain assignment: an operator who set 0 has DISABLED parallel
+    # query, and raising them to 1 would hand this statement a worker and the
+    # CPU and memory that comes with it. Only ever lower. set_config's third
+    # argument is is_local, so this is transaction-scoped exactly like SET LOCAL
+    # — which cannot take an expression.
+    await session.execute(
+        text(
+            "SELECT set_config('max_parallel_workers_per_gather', "
+            "LEAST(current_setting('max_parallel_workers_per_gather')::int, 1)"
+            "::text, true)"
+        )
+    )
     await session.execute(text(f"SET LOCAL work_mem = '{work_mem}'"))
 
 

--- a/backend/app/processing/analysis/tasks.py
+++ b/backend/app/processing/analysis/tasks.py
@@ -103,8 +103,10 @@ def registration_timeout() -> str:
 # work_mem is per OPERATION and per BACKEND, so one plan can allocate several
 # multiples of it: at most 2 memory-hungry nodes for these shapes (dissolve is
 # one Sort feeding a GroupAggregate; buffer and centroid have none; clip has a
-# join), times 2 backends, since max_parallel_workers_per_gather = 1
-# (db/postgresql.conf:73) means a parallel plan runs the leader plus one worker.
+# join), times 2 backends. The second factor is guaranteed rather than assumed —
+# the override pins max_parallel_workers_per_gather to 1 for this transaction,
+# because db/postgresql.conf only governs the bundled database and says nothing
+# about an external one.
 #
 # THE CEILING IS AN OPERATOR SETTING, not a constant, because the two things
 # that decide what is safe are both invisible from here:
@@ -132,12 +134,18 @@ def registration_timeout() -> str:
 # the conservative default trades some of the win for a ceiling that cannot OOM
 # the database on a deployment this process cannot measure.
 #
-# There is deliberately NO floor. A floor at the bundled 8MB default would be
-# an assumption about the connected cluster that this process cannot check: an
-# external PostgreSQL tuned below 8MB would be RAISED by a clamp advertised as
-# leaving it alone, and an operator who wants less than 8MB per materialize
-# could not have it. ANALYSIS_MATERIALIZE_WORK_MEM_MB=0 is the honest way to
-# say "do not touch work_mem" — it skips the SET LOCAL entirely.
+# There is deliberately NO floor at the bundled 8MB default: that would be an
+# assumption about the connected cluster this process cannot check. An external
+# PostgreSQL tuned below 8MB would be RAISED by a clamp advertised as leaving it
+# alone, and an operator who wants less than 8MB per materialize could not have
+# it. ANALYSIS_MATERIALIZE_WORK_MEM_MB=0 is the honest way to say "do not touch
+# work_mem" — it skips the SET LOCAL entirely.
+#
+# The division is done in kB, not MB, so the budget is never exceeded by
+# rounding: a 1MB budget across 128 slots is 8kB each, not 1MB each. Below
+# PostgreSQL's own 64kB minimum the budget cannot be honoured at all, so the
+# override is skipped rather than silently overshot.
+_MIN_WORK_MEM_KB = 64
 
 
 async def _apply_materialize_work_mem(session: AsyncSession) -> None:
@@ -152,6 +160,15 @@ async def _apply_materialize_work_mem(session: AsyncSession) -> None:
     work_mem = _materialize_work_mem()
     if work_mem is None:
         return
+    # Pin parallelism first, so the budget arithmetic is true by construction
+    # rather than by assuming the server's configuration. work_mem is granted to
+    # the leader AND to every parallel worker, so a server with
+    # max_parallel_workers_per_gather above 1 — a customised bundled conf, or
+    # any external PostgreSQL reached through DATABASE_URL_OVERRIDE, neither of
+    # which db/postgresql.conf:73 constrains — would multiply the ceiling by a
+    # number this process cannot see. One leader plus one worker is what the
+    # budget in config.py is sized for.
+    await session.execute(text("SET LOCAL max_parallel_workers_per_gather = 1"))
     await session.execute(text(f"SET LOCAL work_mem = '{work_mem}'"))
 
 
@@ -159,13 +176,18 @@ def _materialize_work_mem() -> str | None:
     """Per-slot work_mem for the CTAS, or None to leave the cluster's alone."""
     from app.core.config import settings
 
-    budget = settings.analysis_materialize_work_mem_mb
-    if budget <= 0:
+    budget_kb = settings.analysis_materialize_work_mem_mb * 1024
+    if budget_kb <= 0:
         return None
-    # At least 1MB: the division must not round a configured budget down to a
-    # zero-size literal, which PostgreSQL would reject.
-    per_slot = max(1, budget // max(1, settings.worker_concurrency))
-    return f"{per_slot}MB"
+    per_slot_kb = budget_kb // max(1, settings.worker_concurrency)
+    if per_slot_kb < _MIN_WORK_MEM_KB:
+        # Honouring the budget would need a work_mem below what PostgreSQL
+        # accepts, so raising it at all would break the ceiling this setting
+        # exists to hold. Leave the cluster's value alone instead.
+        return None
+    if per_slot_kb % 1024 == 0:
+        return f"{per_slot_kb // 1024}MB"
+    return f"{per_slot_kb}kB"
 
 
 # fix(#694): post-CTAS backstop on the built output's on-disk size. The

--- a/backend/app/processing/analysis/tasks.py
+++ b/backend/app/processing/analysis/tasks.py
@@ -132,20 +132,40 @@ def registration_timeout() -> str:
 # the conservative default trades some of the win for a ceiling that cannot OOM
 # the database on a deployment this process cannot measure.
 #
-# The floor is the cluster default: at a high WORKER_CONCURRENCY the division
-# must never land BELOW 8MB, which would make analysis slower than leaving it
-# alone.
-_CLUSTER_DEFAULT_WORK_MEM_MB = 8
+# There is deliberately NO floor. A floor at the bundled 8MB default would be
+# an assumption about the connected cluster that this process cannot check: an
+# external PostgreSQL tuned below 8MB would be RAISED by a clamp advertised as
+# leaving it alone, and an operator who wants less than 8MB per materialize
+# could not have it. ANALYSIS_MATERIALIZE_WORK_MEM_MB=0 is the honest way to
+# say "do not touch work_mem" — it skips the SET LOCAL entirely.
 
 
-def _materialize_work_mem() -> str:
-    """Per-slot work_mem for the CTAS, as a PostgreSQL size literal."""
+async def _apply_materialize_work_mem(session: AsyncSession) -> None:
+    """Raise work_mem for the CTAS transaction, unless the operator opted out.
+
+    SET LOCAL, so it applies to this statement and reverts with the
+    transaction — the other seventy-nine connections keep the cluster default.
+    A global bump would not be safe in the same way. Lives here rather than
+    inline in _materialize so the opt-out branch does not push that function
+    past its complexity cap.
+    """
+    work_mem = _materialize_work_mem()
+    if work_mem is None:
+        return
+    await session.execute(text(f"SET LOCAL work_mem = '{work_mem}'"))
+
+
+def _materialize_work_mem() -> str | None:
+    """Per-slot work_mem for the CTAS, or None to leave the cluster's alone."""
     from app.core.config import settings
 
-    per_slot = settings.analysis_materialize_work_mem_mb // max(
-        1, settings.worker_concurrency
-    )
-    return f"{max(_CLUSTER_DEFAULT_WORK_MEM_MB, per_slot)}MB"
+    budget = settings.analysis_materialize_work_mem_mb
+    if budget <= 0:
+        return None
+    # At least 1MB: the division must not round a configured budget down to a
+    # zero-size literal, which PostgreSQL would reject.
+    per_slot = max(1, budget // max(1, settings.worker_concurrency))
+    return f"{per_slot}MB"
 
 
 # fix(#694): post-CTAS backstop on the built output's on-disk size. The
@@ -792,12 +812,7 @@ async def _materialize(
             await session.execute(
                 text(f"SET LOCAL statement_timeout = '{materialize_timeout()}'")
             )
-            # fix(#1012): SET LOCAL, so it applies to this statement and reverts
-            # with the transaction — the other seventy-nine connections keep the
-            # 8MB default. A global bump would not be safe in the same way.
-            await session.execute(
-                text(f"SET LOCAL work_mem = '{_materialize_work_mem()}'")
-            )
+            await _apply_materialize_work_mem(session)
             if operation == "dissolve":
                 # fix(#694): hash aggregation holds every group's union state
                 # in memory at once, so a grouped dissolve over enough

--- a/backend/app/processing/analysis/tasks.py
+++ b/backend/app/processing/analysis/tasks.py
@@ -94,36 +94,47 @@ def registration_timeout() -> str:
 #
 # WHICH BUDGET THIS COMES OUT OF. work_mem is allocated by the PostgreSQL
 # backend serving the session, so the memory lands in the `db` service, capped
-# by DB_MEM_LIMIT (default 2g). That 2 GB also holds shared_buffers (512MB),
+# by DB_MEM_LIMIT. That budget also holds shared_buffers (512MB),
 # maintenance_work_mem (128MB), and up to max_connections = 80 other backends
 # each entitled to their own work_mem. The worker's own WORKER_MEM_LIMIT is not
 # what constrains this; the Python side of materialize lives there, the sort
 # does not.
 #
-# work_mem is per OPERATION and per BACKEND, not per statement, so one plan can
-# allocate several multiples of it. Two multipliers apply here. The shapes carry
-# at most a couple of memory-hungry nodes (dissolve is one Sort feeding a
-# GroupAggregate, buffer and centroid have none, clip has a join), and
-# max_parallel_workers_per_gather = 1 (db/postgresql.conf:73) means a parallel
-# plan runs the leader plus one worker, each with its own allocation. Worst case
-# is therefore 128MB x 2 nodes x 2 backends = 512MB, which with shared_buffers
-# and maintenance_work_mem leaves roughly 900MB of the 2 GB for the remaining
-# backends. Measured on a 60k-polygon grouped dissolve the leader's sort took
-# 96MB and the parallel worker's 25kB, well inside that.
+# work_mem is per OPERATION and per BACKEND, so one plan can allocate several
+# multiples of it: at most 2 memory-hungry nodes for these shapes (dissolve is
+# one Sort feeding a GroupAggregate; buffer and centroid have none; clip has a
+# join), times 2 backends, since max_parallel_workers_per_gather = 1
+# (db/postgresql.conf:73) means a parallel plan runs the leader plus one worker.
 #
-# WHAT BOUNDS THE CONCURRENT COUNT. Not the admission cap — that is per user
-# (router_analysis.py) and gates entry to the QUEUE, not execution. Execution
-# is bounded by Procrastinate: a worker process runs at most
-# WORKER_CONCURRENCY jobs at once (default 1), so the budget below is split
-# across that worker's slots and concurrent materializes in one worker cannot
-# stack past it. What this does NOT bound is a deployment running a second
-# worker service; that is the open question in #695, and until it is answered
-# the ceiling assumes one worker service.
+# THE CEILING IS AN OPERATOR SETTING, not a constant, because the two things
+# that decide what is safe are both invisible from here:
+#
+#   - DB_MEM_LIMIT is a compose `mem_limit` and is never passed into this
+#     container's environment, so this process cannot read the database's
+#     ceiling. It is also tunable (docker-compose.prod.yml documents 1.5g) and
+#     an external PostgreSQL may be smaller again.
+#   - The divisor below bounds concurrent materializes inside ONE worker
+#     process. It cannot bound a deployment running several worker services
+#     against the `ingest` queue; each replica would claim the budget
+#     independently. Bounding that needs a deployment-wide admission mechanism,
+#     which is #695's open question.
+#
+# So the setting defaults low enough to be safe under both unknowns rather than
+# optimal under neither: 64MB is 256MB worst case per worker replica, so even
+# two replicas sit inside the default 2 GB alongside shared_buffers and
+# maintenance_work_mem. An operator with a bigger database container and one
+# worker can raise it; one with a smaller container or more replicas must lower
+# it. config.py carries the arithmetic.
+#
+# Measured on a 60k-polygon grouped dissolve with enable_hashagg = off, the
+# leader's sort wanted 96MB: at the 8MB default it spilled 70MB to disk, and at
+# 128MB it stayed in memory. 64MB does not eliminate that spill, it shrinks it —
+# the conservative default trades some of the win for a ceiling that cannot OOM
+# the database on a deployment this process cannot measure.
 #
 # The floor is the cluster default: at a high WORKER_CONCURRENCY the division
 # must never land BELOW 8MB, which would make analysis slower than leaving it
 # alone.
-_MATERIALIZE_WORK_MEM_MB = 128
 _CLUSTER_DEFAULT_WORK_MEM_MB = 8
 
 
@@ -131,7 +142,9 @@ def _materialize_work_mem() -> str:
     """Per-slot work_mem for the CTAS, as a PostgreSQL size literal."""
     from app.core.config import settings
 
-    per_slot = _MATERIALIZE_WORK_MEM_MB // max(1, settings.worker_concurrency)
+    per_slot = settings.analysis_materialize_work_mem_mb // max(
+        1, settings.worker_concurrency
+    )
     return f"{max(_CLUSTER_DEFAULT_WORK_MEM_MB, per_slot)}MB"
 
 

--- a/backend/app/processing/analysis/tasks.py
+++ b/backend/app/processing/analysis/tasks.py
@@ -142,10 +142,9 @@ def registration_timeout() -> str:
 # work_mem" — it skips the SET LOCAL entirely.
 #
 # The division is done in kB, not MB, so the budget is never exceeded by
-# rounding: a 1MB budget across 128 slots is 8kB each, not 1MB each. Below
-# PostgreSQL's own 64kB minimum the budget cannot be honoured at all, so the
-# override is skipped rather than silently overshot.
-_MIN_WORK_MEM_KB = 64
+# rounding: a 64MB budget across 128 slots is 512kB each, not 1MB each. A
+# budget too small to divide into legal shares is rejected at boot rather than
+# resolved at run time — see validate_materialize_work_mem_budget.
 
 
 async def _apply_materialize_work_mem(session: AsyncSession) -> None:
@@ -179,12 +178,11 @@ def _materialize_work_mem() -> str | None:
     budget_kb = settings.analysis_materialize_work_mem_mb * 1024
     if budget_kb <= 0:
         return None
+    # A share below PostgreSQL's 64kB minimum cannot happen: config.py's
+    # validate_materialize_work_mem_budget refuses to boot on it, because
+    # neither issuing the minimum (over budget) nor skipping the override
+    # (cluster's larger value, further over budget) honours the ceiling.
     per_slot_kb = budget_kb // max(1, settings.worker_concurrency)
-    if per_slot_kb < _MIN_WORK_MEM_KB:
-        # Honouring the budget would need a work_mem below what PostgreSQL
-        # accepts, so raising it at all would break the ceiling this setting
-        # exists to hold. Leave the cluster's value alone instead.
-        return None
     if per_slot_kb % 1024 == 0:
         return f"{per_slot_kb // 1024}MB"
     return f"{per_slot_kb}kB"

--- a/backend/app/processing/analysis/tasks.py
+++ b/backend/app/processing/analysis/tasks.py
@@ -81,6 +81,60 @@ def registration_timeout() -> str:
     return f"{settings.analysis_registration_timeout_seconds}s"
 
 
+# fix(#1012): per-statement work_mem for the materialize CTAS.
+#
+# The cluster-wide default is 8MB (db/postgresql.conf:93) — right for eighty
+# concurrent connections doing ordinary catalog queries, far too small for one
+# buffer or dissolve over hundreds of thousands of geometries, which spills to
+# pgsql_tmp long before it needs to. Dissolve wants it most: #694 turned off
+# hash aggregation there (it holds every group's union state in memory at once
+# and could OOM the shared db container), and the sorted aggregation that
+# replaces it is precisely what work_mem governs. Turning off hashagg without
+# raising work_mem trades an OOM risk for a guaranteed spill.
+#
+# WHICH BUDGET THIS COMES OUT OF. work_mem is allocated by the PostgreSQL
+# backend serving the session, so the memory lands in the `db` service, capped
+# by DB_MEM_LIMIT (default 2g). That 2 GB also holds shared_buffers (512MB),
+# maintenance_work_mem (128MB), and up to max_connections = 80 other backends
+# each entitled to their own work_mem. The worker's own WORKER_MEM_LIMIT is not
+# what constrains this; the Python side of materialize lives there, the sort
+# does not.
+#
+# work_mem is per OPERATION and per BACKEND, not per statement, so one plan can
+# allocate several multiples of it. Two multipliers apply here. The shapes carry
+# at most a couple of memory-hungry nodes (dissolve is one Sort feeding a
+# GroupAggregate, buffer and centroid have none, clip has a join), and
+# max_parallel_workers_per_gather = 1 (db/postgresql.conf:73) means a parallel
+# plan runs the leader plus one worker, each with its own allocation. Worst case
+# is therefore 128MB x 2 nodes x 2 backends = 512MB, which with shared_buffers
+# and maintenance_work_mem leaves roughly 900MB of the 2 GB for the remaining
+# backends. Measured on a 60k-polygon grouped dissolve the leader's sort took
+# 96MB and the parallel worker's 25kB, well inside that.
+#
+# WHAT BOUNDS THE CONCURRENT COUNT. Not the admission cap — that is per user
+# (router_analysis.py) and gates entry to the QUEUE, not execution. Execution
+# is bounded by Procrastinate: a worker process runs at most
+# WORKER_CONCURRENCY jobs at once (default 1), so the budget below is split
+# across that worker's slots and concurrent materializes in one worker cannot
+# stack past it. What this does NOT bound is a deployment running a second
+# worker service; that is the open question in #695, and until it is answered
+# the ceiling assumes one worker service.
+#
+# The floor is the cluster default: at a high WORKER_CONCURRENCY the division
+# must never land BELOW 8MB, which would make analysis slower than leaving it
+# alone.
+_MATERIALIZE_WORK_MEM_MB = 128
+_CLUSTER_DEFAULT_WORK_MEM_MB = 8
+
+
+def _materialize_work_mem() -> str:
+    """Per-slot work_mem for the CTAS, as a PostgreSQL size literal."""
+    from app.core.config import settings
+
+    per_slot = _MATERIALIZE_WORK_MEM_MB // max(1, settings.worker_concurrency)
+    return f"{max(_CLUSTER_DEFAULT_WORK_MEM_MB, per_slot)}MB"
+
+
 # fix(#694): post-CTAS backstop on the built output's on-disk size. The
 # enqueue gates read the cached feature_count snapshot, which can be stale;
 # this is the enforcement that can't be. Buffer is the motivating case: it
@@ -724,6 +778,12 @@ async def _materialize(
             )
             await session.execute(
                 text(f"SET LOCAL statement_timeout = '{materialize_timeout()}'")
+            )
+            # fix(#1012): SET LOCAL, so it applies to this statement and reverts
+            # with the transaction — the other seventy-nine connections keep the
+            # 8MB default. A global bump would not be safe in the same way.
+            await session.execute(
+                text(f"SET LOCAL work_mem = '{_materialize_work_mem()}'")
             )
             if operation == "dissolve":
                 # fix(#694): hash aggregation holds every group's union state

--- a/backend/tests/test_analysis_materialize.py
+++ b/backend/tests/test_analysis_materialize.py
@@ -2669,7 +2669,11 @@ class TestMaterializeWorker:
         # from db/postgresql.conf — which says nothing about an external server.
         par = [s for s in executed if "max_parallel_workers_per_gather" in s]
         assert len(par) == 1, par
-        assert par[0].startswith("SET LOCAL"), par[0]
+        # LEAST, never a plain assignment: an operator who set 0 has disabled
+        # parallel query, and raising them to 1 would hand this statement a
+        # worker they said no to. set_config(..., true) is transaction-scoped.
+        assert "LEAST" in par[0], par[0]
+        assert "set_config" in par[0] and ", true)" in par[0], par[0]
         assert executed.index(par[0]) < executed.index(ctas[0])
 
     async def test_work_mem_override_can_be_disabled(

--- a/backend/tests/test_analysis_materialize.py
+++ b/backend/tests/test_analysis_materialize.py
@@ -2669,13 +2669,36 @@ class TestMaterializeWorker:
         db container's exposure."""
         from app.core.config import settings
 
+        # Set the baseline rather than asserting the shipped default: settings
+        # is a module-level singleton, so ANALYSIS_MATERIALIZE_WORK_MEM_MB in
+        # the environment would otherwise decide this test's outcome.
+        monkeypatch.setattr(settings, "analysis_materialize_work_mem_mb", 64)
         monkeypatch.setattr(settings, "worker_concurrency", 1)
-        assert _materialize_work_mem() == "128MB"
+        assert _materialize_work_mem() == "64MB"
         monkeypatch.setattr(settings, "worker_concurrency", 4)
-        assert _materialize_work_mem() == "32MB"
+        assert _materialize_work_mem() == "16MB"
         # Never below the cluster default — a division that landed under 8MB
         # would make analysis slower than leaving work_mem alone.
         monkeypatch.setattr(settings, "worker_concurrency", 64)
+        assert _materialize_work_mem() == "8MB"
+
+    def test_work_mem_ceiling_is_operator_configurable(self, monkeypatch):
+        """fix(#1012 review): the safe value depends on DB_MEM_LIMIT and on how
+        many worker services consume the ingest queue, neither of which this
+        process can see — DB_MEM_LIMIT is a compose mem_limit and is never in
+        this container's environment. A hardcoded ceiling was therefore only
+        valid for the default 2 GB single-worker deployment, and could OOM a
+        smaller database or a scaled-out one."""
+        from app.core.config import settings
+
+        monkeypatch.setattr(settings, "worker_concurrency", 1)
+        monkeypatch.setattr(settings, "analysis_materialize_work_mem_mb", 16)
+        assert _materialize_work_mem() == "16MB"
+        monkeypatch.setattr(settings, "analysis_materialize_work_mem_mb", 256)
+        assert _materialize_work_mem() == "256MB"
+        # Below the cluster default it stays on the cluster-wide value, which
+        # is the pre-#1012 behaviour rather than a slower one.
+        monkeypatch.setattr(settings, "analysis_materialize_work_mem_mb", 2)
         assert _materialize_work_mem() == "8MB"
 
     async def test_worker_rechecks_size_caps_before_ctas(

--- a/backend/tests/test_analysis_materialize.py
+++ b/backend/tests/test_analysis_materialize.py
@@ -27,6 +27,7 @@ from app.platform.jobs.models import IngestJob
 from app.processing.analysis.tasks import (
     materialize_timeout,
     _complete_job_for_attempt,
+    _materialize_work_mem,
     _enforce_output_size,
     _fail_cancelled_job,
     _mark_job_failed,
@@ -2611,6 +2612,71 @@ class TestMaterializeWorker:
         monkeypatch.setattr(settings, "analysis_registration_timeout_seconds", 1800)
         assert materialize_timeout() == "1200s"
         assert registration_timeout() == "1800s"
+
+    async def test_ctas_scopes_work_mem_to_its_transaction(
+        self,
+        test_db_session: AsyncSession,
+    ):
+        """fix(#1012): the CTAS gets a raised work_mem, SET LOCAL so it reverts
+        with the transaction and the other connections keep the 8MB default.
+
+        Paired with the dissolve case below, which is the shape that most needs
+        it: #694's `enable_hashagg = off` forces sorted aggregation, and sorting
+        is exactly what work_mem governs.
+        """
+        executed: list[str] = []
+        from sqlalchemy.ext.asyncio import AsyncSession as _AS
+
+        real_execute = _AS.execute
+
+        async def spying_execute(self, statement, *args, **kwargs):
+            executed.append(str(statement))
+            return await real_execute(self, statement, *args, **kwargs)
+
+        admin_id = await get_user_id(test_db_session, "admin")
+        ds = await _create_polygon_dataset(test_db_session, created_by=admin_id)
+        job = await _create_job(test_db_session, admin_id)
+
+        with patch.object(_AS, "execute", spying_execute):
+            await _materialize(
+                job_id=str(job.id),
+                dataset_id=str(ds.id),
+                user_id=str(admin_id),
+                operation="dissolve",
+                title=f"WorkMem {uuid.uuid4().hex[:6]}",
+            )
+
+        await test_db_session.refresh(job)
+        assert job.status == "complete", job.error_message
+
+        work_mems = [s for s in executed if "work_mem" in s]
+        assert len(work_mems) == 1, f"expected one work_mem statement, got {work_mems}"
+        # SET LOCAL, never a plain SET: a session-level bump would outlive the
+        # transaction and follow the pooled connection to unrelated queries.
+        assert work_mems[0].startswith("SET LOCAL work_mem"), work_mems[0]
+        assert _materialize_work_mem() in work_mems[0]
+
+        ctas = [s for s in executed if s.startswith("CREATE TABLE")]
+        hashaggs = [s for s in executed if "enable_hashagg" in s]
+        # Ahead of the CTAS it is meant to serve, and in the same transaction as
+        # the hashagg flip whose sort it pays for.
+        assert executed.index(work_mems[0]) < executed.index(ctas[0])
+        assert executed.index(hashaggs[0]) < executed.index(ctas[0])
+
+    def test_work_mem_is_divided_across_worker_slots(self, monkeypatch):
+        """fix(#1012): the budget is per worker PROCESS, so parallel job slots
+        share it — otherwise raising WORKER_CONCURRENCY silently multiplies the
+        db container's exposure."""
+        from app.core.config import settings
+
+        monkeypatch.setattr(settings, "worker_concurrency", 1)
+        assert _materialize_work_mem() == "128MB"
+        monkeypatch.setattr(settings, "worker_concurrency", 4)
+        assert _materialize_work_mem() == "32MB"
+        # Never below the cluster default — a division that landed under 8MB
+        # would make analysis slower than leaving work_mem alone.
+        monkeypatch.setattr(settings, "worker_concurrency", 64)
+        assert _materialize_work_mem() == "8MB"
 
     async def test_worker_rechecks_size_caps_before_ctas(
         self,

--- a/backend/tests/test_analysis_materialize.py
+++ b/backend/tests/test_analysis_materialize.py
@@ -2739,13 +2739,13 @@ class TestMaterializeWorker:
         # cannot know whether such a floor preserves that value or raises it.
         monkeypatch.setattr(settings, "worker_concurrency", 128)
         assert _materialize_work_mem() == "512kB"
-        # Below PostgreSQL's 64kB minimum the budget cannot be honoured, so the
-        # override is skipped rather than silently overshot.
+        # Sub-megabyte shares are expressed in kB rather than rounded.
         monkeypatch.setattr(settings, "analysis_materialize_work_mem_mb", 1)
         monkeypatch.setattr(settings, "worker_concurrency", 8)
         assert _materialize_work_mem() == "128kB"
-        monkeypatch.setattr(settings, "worker_concurrency", 1024)
-        assert _materialize_work_mem() is None
+        # A share below PostgreSQL's 64kB minimum cannot reach here: it is
+        # refused at boot (test_config.py), because neither the minimum nor
+        # falling back to the cluster's value honours the budget.
 
     def test_work_mem_ceiling_is_operator_configurable(self, monkeypatch):
         """fix(#1012 review): the safe value depends on DB_MEM_LIMIT and on how

--- a/backend/tests/test_analysis_materialize.py
+++ b/backend/tests/test_analysis_materialize.py
@@ -2664,6 +2664,13 @@ class TestMaterializeWorker:
         # the hashagg flip whose sort it pays for.
         assert executed.index(work_mems[0]) < executed.index(ctas[0])
         assert executed.index(hashaggs[0]) < executed.index(ctas[0])
+        # fix(#1012 review): parallelism is pinned alongside it, so the "x2
+        # backends" the budget is sized for is guaranteed rather than assumed
+        # from db/postgresql.conf — which says nothing about an external server.
+        par = [s for s in executed if "max_parallel_workers_per_gather" in s]
+        assert len(par) == 1, par
+        assert par[0].startswith("SET LOCAL"), par[0]
+        assert executed.index(par[0]) < executed.index(ctas[0])
 
     async def test_work_mem_override_can_be_disabled(
         self,
@@ -2707,6 +2714,9 @@ class TestMaterializeWorker:
         assert not [s for s in executed if "work_mem" in s], (
             "work_mem was set despite the override being disabled"
         )
+        # The parallelism pin exists to protect the work_mem ceiling, so it
+        # must not fire when there is no ceiling to protect.
+        assert not [s for s in executed if "max_parallel_workers_per_gather" in s]
 
     def test_work_mem_is_divided_across_worker_slots(self, monkeypatch):
         """fix(#1012): the budget is per worker PROCESS, so parallel job slots
@@ -2722,12 +2732,20 @@ class TestMaterializeWorker:
         assert _materialize_work_mem() == "64MB"
         monkeypatch.setattr(settings, "worker_concurrency", 4)
         assert _materialize_work_mem() == "16MB"
-        # A large divisor floors at 1MB rather than rounding to a zero-size
-        # literal PostgreSQL would reject. No clamp to the bundled 8MB default:
+        # Divided in kB so the budget is never exceeded by rounding: 64MB
+        # across 128 slots is 512kB each, not 1MB each (which would be 128MB
+        # against a 64MB budget). No clamp to the bundled 8MB default either —
         # this process cannot read the connected cluster's work_mem, so it
         # cannot know whether such a floor preserves that value or raises it.
         monkeypatch.setattr(settings, "worker_concurrency", 128)
-        assert _materialize_work_mem() == "1MB"
+        assert _materialize_work_mem() == "512kB"
+        # Below PostgreSQL's 64kB minimum the budget cannot be honoured, so the
+        # override is skipped rather than silently overshot.
+        monkeypatch.setattr(settings, "analysis_materialize_work_mem_mb", 1)
+        monkeypatch.setattr(settings, "worker_concurrency", 8)
+        assert _materialize_work_mem() == "128kB"
+        monkeypatch.setattr(settings, "worker_concurrency", 1024)
+        assert _materialize_work_mem() is None
 
     def test_work_mem_ceiling_is_operator_configurable(self, monkeypatch):
         """fix(#1012 review): the safe value depends on DB_MEM_LIMIT and on how

--- a/backend/tests/test_analysis_materialize.py
+++ b/backend/tests/test_analysis_materialize.py
@@ -2651,6 +2651,8 @@ class TestMaterializeWorker:
 
         work_mems = [s for s in executed if "work_mem" in s]
         assert len(work_mems) == 1, f"expected one work_mem statement, got {work_mems}"
+        # Nothing is issued when the operator opts out — asserted separately in
+        # test_work_mem_override_can_be_disabled below.
         # SET LOCAL, never a plain SET: a session-level bump would outlive the
         # transaction and follow the pooled connection to unrelated queries.
         assert work_mems[0].startswith("SET LOCAL work_mem"), work_mems[0]
@@ -2662,6 +2664,49 @@ class TestMaterializeWorker:
         # the hashagg flip whose sort it pays for.
         assert executed.index(work_mems[0]) < executed.index(ctas[0])
         assert executed.index(hashaggs[0]) < executed.index(ctas[0])
+
+    async def test_work_mem_override_can_be_disabled(
+        self,
+        test_db_session: AsyncSession,
+        monkeypatch,
+    ):
+        """fix(#1012 review): 0 must issue NO statement, not a small one.
+
+        An operator who has tuned their own cluster needs a way to say "leave
+        work_mem alone"; a clamped small value would still raise the session
+        above a cluster configured below the bundled default.
+        """
+        from app.core.config import settings
+
+        monkeypatch.setattr(settings, "analysis_materialize_work_mem_mb", 0)
+
+        executed: list[str] = []
+        from sqlalchemy.ext.asyncio import AsyncSession as _AS
+
+        real_execute = _AS.execute
+
+        async def spying_execute(self, statement, *args, **kwargs):
+            executed.append(str(statement))
+            return await real_execute(self, statement, *args, **kwargs)
+
+        admin_id = await get_user_id(test_db_session, "admin")
+        ds = await _create_polygon_dataset(test_db_session, created_by=admin_id)
+        job = await _create_job(test_db_session, admin_id)
+
+        with patch.object(_AS, "execute", spying_execute):
+            await _materialize(
+                job_id=str(job.id),
+                dataset_id=str(ds.id),
+                user_id=str(admin_id),
+                operation="dissolve",
+                title=f"NoWorkMem {uuid.uuid4().hex[:6]}",
+            )
+
+        await test_db_session.refresh(job)
+        assert job.status == "complete", job.error_message
+        assert not [s for s in executed if "work_mem" in s], (
+            "work_mem was set despite the override being disabled"
+        )
 
     def test_work_mem_is_divided_across_worker_slots(self, monkeypatch):
         """fix(#1012): the budget is per worker PROCESS, so parallel job slots
@@ -2677,10 +2722,12 @@ class TestMaterializeWorker:
         assert _materialize_work_mem() == "64MB"
         monkeypatch.setattr(settings, "worker_concurrency", 4)
         assert _materialize_work_mem() == "16MB"
-        # Never below the cluster default — a division that landed under 8MB
-        # would make analysis slower than leaving work_mem alone.
-        monkeypatch.setattr(settings, "worker_concurrency", 64)
-        assert _materialize_work_mem() == "8MB"
+        # A large divisor floors at 1MB rather than rounding to a zero-size
+        # literal PostgreSQL would reject. No clamp to the bundled 8MB default:
+        # this process cannot read the connected cluster's work_mem, so it
+        # cannot know whether such a floor preserves that value or raises it.
+        monkeypatch.setattr(settings, "worker_concurrency", 128)
+        assert _materialize_work_mem() == "1MB"
 
     def test_work_mem_ceiling_is_operator_configurable(self, monkeypatch):
         """fix(#1012 review): the safe value depends on DB_MEM_LIMIT and on how
@@ -2696,10 +2743,14 @@ class TestMaterializeWorker:
         assert _materialize_work_mem() == "16MB"
         monkeypatch.setattr(settings, "analysis_materialize_work_mem_mb", 256)
         assert _materialize_work_mem() == "256MB"
-        # Below the cluster default it stays on the cluster-wide value, which
-        # is the pre-#1012 behaviour rather than a slower one.
-        monkeypatch.setattr(settings, "analysis_materialize_work_mem_mb", 2)
-        assert _materialize_work_mem() == "8MB"
+        # A deliberately small value is honoured, not clamped up: an external
+        # cluster may be tuned below the bundled 8MB, and a floor advertised as
+        # "leaves the cluster value alone" would silently raise it.
+        monkeypatch.setattr(settings, "analysis_materialize_work_mem_mb", 4)
+        assert _materialize_work_mem() == "4MB"
+        # 0 is the opt-out: no override at all.
+        monkeypatch.setattr(settings, "analysis_materialize_work_mem_mb", 0)
+        assert _materialize_work_mem() is None
 
     async def test_worker_rechecks_size_caps_before_ctas(
         self,

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -446,6 +446,15 @@ class TestSettingsConstraints:
         assert "32kB per slot" in message, message
         assert "64kB minimum" in message, message
 
+        # And above PostgreSQL's own work_mem maximum, for the same reason:
+        # every materialize would fail at SET LOCAL and be recorded as a
+        # failed job.
+        with pytest.raises(Exception) as exc_info:
+            _make_settings(
+                analysis_materialize_work_mem_mb=2097152, worker_concurrency=1
+            )
+        assert "work_mem maximum" in str(exc_info.value), str(exc_info.value)
+
         # The documented escape hatches both boot.
         assert (
             _make_settings(

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -432,6 +432,34 @@ class TestSettingsConstraints:
         with pytest.raises(Exception):
             _make_settings(**{field: value})
 
+    def test_undividable_work_mem_budget_is_refused_at_boot(self):
+        """fix(#1012 review): a budget too small to split into legal shares has
+        no honest run-time outcome.
+
+        Issuing PostgreSQL's 64kB minimum exceeds the budget; skipping the
+        override leaves the cluster's own work_mem — usually LARGER — in force
+        for every slot, overshooting by more. So it fails at boot.
+        """
+        with pytest.raises(Exception) as exc_info:
+            _make_settings(analysis_materialize_work_mem_mb=1, worker_concurrency=32)
+        message = str(exc_info.value)
+        assert "32kB per slot" in message, message
+        assert "64kB minimum" in message, message
+
+        # The documented escape hatches both boot.
+        assert (
+            _make_settings(
+                analysis_materialize_work_mem_mb=0, worker_concurrency=32
+            ).analysis_materialize_work_mem_mb
+            == 0
+        )
+        assert (
+            _make_settings(
+                analysis_materialize_work_mem_mb=64, worker_concurrency=32
+            ).worker_concurrency
+            == 32
+        )
+
     def test_documented_zero_and_negative_sentinels_remain_supported(self):
         s = _make_settings(
             tile_cache_ttl=0,

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -420,10 +420,8 @@ class TestSettingsConstraints:
             ("analysis_registration_timeout_seconds", 0),
             ("analysis_registration_timeout_seconds", -1),
             ("analysis_registration_timeout_seconds", "not-a-number"),
-
-            # fix(#1012): a zero or negative work_mem budget would render an
-            # invalid SET LOCAL and fail every materialize at run time.
-            ("analysis_materialize_work_mem_mb", 0),
+            # fix(#1012): 0 is a documented sentinel (leave work_mem alone),
+            # so only negatives are rejected.
             ("analysis_materialize_work_mem_mb", -1),
             ("ingest_jobs_retention_days", -1),
             ("smtp_port", 0),
@@ -440,11 +438,13 @@ class TestSettingsConstraints:
             ingest_jobs_retention_days=0,
             db_max_overflow=-1,
             db_pool_recycle=-1,
+            analysis_materialize_work_mem_mb=0,
         )
         assert s.tile_cache_ttl == 0
         assert s.ingest_jobs_retention_days == 0
         assert s.db_max_overflow == -1
         assert s.db_pool_recycle == -1
+        assert s.analysis_materialize_work_mem_mb == 0
 
     def test_worker_queues_are_trimmed_and_normalized(self):
         s = _make_settings(worker_queues=" priority, ingest ,raster ")

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -420,6 +420,11 @@ class TestSettingsConstraints:
             ("analysis_registration_timeout_seconds", 0),
             ("analysis_registration_timeout_seconds", -1),
             ("analysis_registration_timeout_seconds", "not-a-number"),
+
+            # fix(#1012): a zero or negative work_mem budget would render an
+            # invalid SET LOCAL and fail every materialize at run time.
+            ("analysis_materialize_work_mem_mb", 0),
+            ("analysis_materialize_work_mem_mb", -1),
             ("ingest_jobs_retention_days", -1),
             ("smtp_port", 0),
             ("smtp_port", 65536),

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -1179,6 +1179,17 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # of per-operation models would describe a shape visible_derived_from is
     # free to punch holes in. Ratchet exact at 1032.
     "backend/app/modules/catalog/datasets/domain/schemas.py": 1032,
+    # fix(#1012): crossed on the rebase, not in either branch. main grew this
+    # module past 900 while the work_mem branch was open, and the branch's +120
+    # (the SET LOCAL, its budget arithmetic and the boot-time validator) landed
+    # on top of that — so the gate fired for the first time on a merge result
+    # neither side had ever built. What the lines bought: work_mem is allocated
+    # per operation AND per backend, so the ceiling this file computes is the
+    # difference between one materialize using its stated budget and one using
+    # several multiples of it. The reasoning has to live next to the SET LOCAL,
+    # because a future reader tuning the number is exactly who needs it.
+    # Ratchet exact at 1031.
+    "backend/app/processing/analysis/tasks.py": 1031,
     # Tenant-owned media now crosses the shared logical-to-physical storage
     # seam; explicit storage-failure responses keep the runtime/OpenAPI contract
     # aligned. Keep the ratchet exact after the import/decorator expansion.


### PR DESCRIPTION
The materialize CTAS ran with the cluster-wide `work_mem = 8MB` (`db/postgresql.conf:93`). That is right for eighty concurrent connections doing ordinary catalog queries and far too small for a single buffer or dissolve over hundreds of thousands of geometries, which spills to `pgsql_tmp` long before it needs to.

Dissolve is the case that most wants this. #694 turned off hash aggregation there (it holds every group's union state in memory at once and could OOM the shared db container), and the sorted aggregation that replaces it is precisely what `work_mem` governs — so turning off hashagg without raising `work_mem` traded an OOM risk for a guaranteed spill.

## The change

One `SET LOCAL work_mem` alongside the existing `SET LOCAL statement_timeout` in the materialize transaction. `SET LOCAL` is what makes this safe in a way a global bump is not: it applies to that statement and reverts with the transaction, so the other seventy-nine connections keep the 8MB default and the pooled connection carries nothing onward.

## The ceiling, and which budget it comes out of

**128MB per worker process**, divided across `WORKER_CONCURRENCY` slots, floored at the 8MB cluster default.

`work_mem` is allocated by the PostgreSQL backend serving the session, so the memory lands in the **`db` service**, capped by `DB_MEM_LIMIT` (default `2g`). That 2 GB also holds `shared_buffers` (512MB), `maintenance_work_mem` (128MB), and up to `max_connections = 80` other backends each entitled to their own `work_mem`. The worker's `WORKER_MEM_LIMIT` is not what constrains it — the Python side of materialize lives there, the sort does not.

`work_mem` is per **operation** and per **backend**, so one plan allocates a multiple of it. Two multipliers apply: these shapes carry at most a couple of memory-hungry nodes (dissolve is one Sort feeding a GroupAggregate; buffer and centroid have none; clip has a join), and `max_parallel_workers_per_gather = 1` means a parallel plan runs the leader plus one worker, each with its own allocation. Worst case is 128MB x 2 nodes x 2 backends = **512MB**, leaving roughly 900MB of the 2 GB for the remaining backends.

## What bounds the concurrent count

Not the admission cap — that is per user (`router_analysis.py:292-320`) and gates entry to the **queue**, not execution. Execution is bounded by Procrastinate: a worker process runs at most `WORKER_CONCURRENCY` jobs at once (default 1, `config.py:203`). Dividing the budget by that setting is what keeps concurrent materializes inside one worker from stacking past the ceiling, so raising `WORKER_CONCURRENCY` cannot silently multiply the db container's exposure.

What this does **not** bound is a deployment running a second worker service. That is #695's open question, and until it is answered the ceiling assumes one worker service. Said plainly in the code comment rather than left implied.

## The dissolve check, measured

Against the test cluster, 60,000 buffered polygons in 400 groups, `enable_hashagg = off` in force — the acceptance criterion was to confirm the raised budget actually reduces spill rather than being consumed by an unrelated plan node.

```
work_mem 8MB     Sort Method: external merge  Disk: 70672kB
                 Worker 0: external merge  Disk: 23928kB
                 temp read=11825 written=11837
                 Execution Time: 4371 ms

work_mem 128MB   Sort Method: quicksort  Memory: 96224kB
                 Worker 0: quicksort  Memory: 25kB
                 no temp files
                 Execution Time: 4656 ms
```

The budget lands on the Sort the dissolve depends on. Wall clock did not improve on this fixture — it is dominated by `ST_Union` geometry work, and the temp files stayed in page cache on the test host. The eliminated spill is what matters on a real deployment, where `pgsql_tmp` shares the pgdata volume and `temp_file_limit` is 4GB (#959).

The 96MB the leader actually used is also a useful sanity check on the number: 128MB accommodates this shape without being generous.

## Tests

- `test_ctas_scopes_work_mem_to_its_transaction` — spies the executed statements (the pattern `test_dissolve_ctas_disables_hashagg` already uses): exactly one `work_mem` statement, it is `SET LOCAL` and not a plain `SET`, and it precedes the CTAS in the same transaction as the hashagg flip whose sort it pays for.
- `test_work_mem_is_divided_across_worker_slots` — 1 slot gives 128MB, 4 gives 32MB, 64 floors at 8MB.

## Verification

```
cd backend && uv run pytest tests/test_analysis_materialize.py -q          # 81 passed
cd backend && uv run ruff check . && uv run ruff format --check .          # clean
```

Closes #1012