### PR TITLE
refactor(geo): one implementation of the degree-unit test, and a gate on the rest

### DIFF
--- a/backend/app/core/geo.py
+++ b/backend/app/core/geo.py
@@ -503,9 +503,10 @@ def make_bbox_filter(
         return and_(geom_col.op("&&")(envelope), spatial_fn(geom_col, envelope))
 
 
-# fix(#939): the same radians-per-degree constant `_is_degree_based`
-# (processing/raster/vrt.py) compares against. Unit semantics live in the
-# conversion factor, never the unit's name.
+# Unit semantics live in the conversion factor, never the unit's name.
+# fix(#961): this constant had a twin in processing/raster/vrt.py, compared the
+# same way against the same tolerance. Both sites now go through
+# `crs_has_degree_unit` below, so there is one implementation to keep right.
 _RADIANS_PER_DEGREE = math.pi / 180.0
 
 
@@ -598,6 +599,37 @@ def wkt_is_geographic(crs_wkt: str | None) -> bool | None:
     return None
 
 
+def crs_has_degree_unit(crs: object | None) -> bool | None:
+    """Whether a PARSED CRS's coordinate axes are measured in degrees.
+
+    fix(#961): the one implementation of the radians-per-unit test.
+    :func:`wkt_has_degree_unit` is this plus the WKT parse; ``_is_degree_based``
+    (``processing/raster/vrt.py``) is this plus an ``is_geographic``
+    precondition. They used to be two copies of the same comparison against two
+    copies of the same constant, kept in step by cross-referencing comments,
+    which is the arrangement #961 was filed to end. The CRS-object entry point
+    is what makes one implementation possible: ``vrt.py`` holds a live
+    ``rasterio.crs.CRS`` and must not be pushed through a WKT round trip to
+    reach a shared helper.
+
+    ``rel_tol`` is correct here: this compares two fixed physical constants of
+    the same tiny magnitude (0.01745 radians per degree against whatever PROJ
+    reports), where proportional agreement is the meaningful test and the
+    nearest wrong answer, grads at 0.01571, is 10% away.
+
+    Returns None when there is no CRS or PROJ cannot report a unit factor.
+    Callers must read that as "unknown" and decide for themselves — the two
+    call sites deliberately differ, see each one.
+    """
+    if crs is None:
+        return None
+    try:
+        _, radians_per_unit = crs.units_factor
+    except Exception:  # broad: units_factor raises CRSError on exotic/!undefined CRSs, which are exactly the ones we cannot answer for
+        return None
+    return math.isclose(radians_per_unit, _RADIANS_PER_DEGREE, rel_tol=1e-9)
+
+
 def wkt_has_degree_unit(crs_wkt: str | None) -> bool | None:
     """Whether a CRS WKT's coordinate axes are measured in degrees.
 
@@ -605,11 +637,11 @@ def wkt_has_degree_unit(crs_wkt: str | None) -> bool | None:
     and admits grads CRSs. Only meaningful for a WKT already classified as
     geographic, so call that first.
 
-    The answer comes from PROJ's ``units_factor`` on the parsed CRS -- the
-    same radians-per-unit comparison ``_is_degree_based``
-    (processing/raster/vrt.py) makes, against the same constant, so the two
-    unit tests in this codebase cannot drift apart. Reading the factor rather
-    than the unit's name means a valid custom spelling
+    The answer comes from :func:`crs_has_degree_unit`, which is also what
+    ``_is_degree_based`` (processing/raster/vrt.py) calls, so the two unit
+    tests in this codebase are one implementation rather than two that must be
+    kept in step (fix(#961)). Reading PROJ's ``units_factor`` rather than the
+    unit's name means a valid custom spelling
     (``UNIT["arc-degree",0.01745...]``) still reads as degrees, while grads
     sit 10% away and stay excluded.
 
@@ -621,11 +653,4 @@ def wkt_has_degree_unit(crs_wkt: str | None) -> bool | None:
     """
     if not isinstance(crs_wkt, str) or not crs_wkt:
         return None
-    crs = _parse_crs(crs_wkt)
-    if crs is None:
-        return None
-    try:
-        _, radians_per_unit = crs.units_factor
-    except Exception:  # broad: units_factor raises CRSError on exotic/!undefined CRSs, which are exactly the ones we cannot answer for
-        return None
-    return math.isclose(radians_per_unit, _RADIANS_PER_DEGREE, rel_tol=1e-9)
+    return crs_has_degree_unit(_parse_crs(crs_wkt))

--- a/backend/app/processing/ingest/metadata.py
+++ b/backend/app/processing/ingest/metadata.py
@@ -1245,22 +1245,28 @@ _MERCATOR_SAFE_ENVELOPE = "ST_MakeEnvelope(-180, -85.06, 180, 85.06, 4326)"
 # ships in spatial_ref_sys.srtext for lon/lat CRSs. 4326/4979/4269 match;
 # 2263/3857 (projected, X in feet/metres) do not.
 #
-# fix(#961 review): this used to be anchored (`^GEOG(CS|CRS)`), which is not
-# the same question `core.geo.wkt_is_geographic` answers and disagreed with it
-# on real rows. A stock spatial_ref_sys carries 277 COMPD_CS entries and a
-# family of BOUNDCRS-wrapped geographic CRSs (3823 and 4339 among them) whose
-# srtext STARTS with the wrapper keyword — so the anchor read a lon/lat CRS as
-# not-lon/lat and silently declined to shift a 0..360 source that needed it.
-# The right test is the one the degenerate-envelope floor below already used:
-# a GEOG keyword present, and no PROJ keyword anywhere. The PROJ half is what
-# keeps a projected CRS out, since every WKT1 PROJCS nests a GEOGCS. Both SQL
-# sites now share these two constants rather than spelling it twice.
+# fix(#961 review): the ANCHOR is load-bearing and must stay, even though it
+# makes this predicate disagree with `core.geo.wkt_is_geographic` and with the
+# degenerate-envelope floor below on wrapped CRSs (BOUNDCRS, COMPD_CS). Those
+# two can afford to see through a wrapper; this one cannot, and the reason is
+# the same one `core.geo._parse_crs` documents at length: a flat scan cannot
+# decide which subtree a token belongs to.
 #
-# Known limit, inherited and unchanged: unlike the Python helper this cannot
-# blank quoted content first, so a CRS whose NAME contains "PROJCS" would read
-# as projected. No such row exists in a stock spatial_ref_sys.
-_GEOGRAPHIC_SRTEXT_RE = "GEOG(CS|CRS)"
-_PROJECTED_SRTEXT_RE = "PROJ(CS|CRS)"
+# Concretely. Un-anchoring lets `BOUNDCRS[SOURCECRS[GEOGCS[... UNIT["grad"...`
+# match as geographic, and `_DEGREE_UNIT_SRTEXT_RE` below is a flat substring
+# scan that would then find an unrelated `degree` on the TARGET CRS or a
+# PRIMEM and report degrees. `_shift_zero_to_360_longitudes` would subtract
+# 360 from coordinates whose full turn is 400 grads — silent corruption, and
+# the shape is real enough that `tests/test_wkt_is_geographic.py::
+# test_boundcrs_reports_the_source_crs_units_not_the_targets` already pins it
+# on the Python side.
+#
+# Declining to shift is safe: the source is then clipped and REPORTED by
+# `clip_to_mercator_bounds`'s accounting, which is a visible outcome. Shifting
+# wrongly is not. So this gate stays deliberately incomplete, and the property
+# tests/test_crs_degree_agreement.py enforces is soundness — it never fires
+# where PROJ says the axes are not degrees — rather than agreement.
+_GEOGRAPHIC_SRTEXT_RE = "^GEOG(CS|CRS)"
 
 # fix(#899 codex r1): geographic is not the same as degree-based. 14 SRIDs in a
 # stock PostGIS spatial_ref_sys are GEOGCS with an angular unit of grads — the
@@ -1311,12 +1317,10 @@ async def _shift_zero_to_360_longitudes(
 
     is_degree_lonlat = await session.scalar(
         text(
-            "SELECT srtext ~* :geographic AND srtext !~* :projected "
-            "AND srtext ~* :degree_unit "
+            "SELECT srtext ~* :geographic AND srtext ~* :degree_unit "
             "FROM spatial_ref_sys WHERE srid = :srid"
         ).bindparams(
             geographic=_GEOGRAPHIC_SRTEXT_RE,
-            projected=_PROJECTED_SRTEXT_RE,
             degree_unit=_DEGREE_UNIT_SRTEXT_RE,
             srid=src_srid,
         )
@@ -1412,13 +1416,15 @@ async def _mercator_envelope_degenerates(
         # no PROJ keyword anywhere (every projected WKT1 nests a GEOGCS, so
         # the PROJ test must win) — the same keyword logic as
         # core.geo.wkt_is_geographic, in srtext form.
-        # fix(#961 review): that insight had been applied HERE and not at the
-        # 0..360 gate above, which kept an anchored `^GEOG(CS|CRS)`. Both sites
-        # now interpolate the same two constants, so the next change to either
-        # cannot leave them disagreeing again; the agreement is pinned by
-        # tests/test_crs_degree_agreement.py.
-        f"    NOT COALESCE((SELECT srtext ~* '{_GEOGRAPHIC_SRTEXT_RE}' "
-        f"                     AND srtext !~* '{_PROJECTED_SRTEXT_RE}' "
+        # fix(#961 review): this predicate and the 0..360 gate's
+        # `_GEOGRAPHIC_SRTEXT_RE` deliberately DISAGREE on wrapped CRSs, and
+        # unifying them was tried and reverted. Seeing through a wrapper is
+        # right here (the consequence is a size floor) and unsafe there (the
+        # consequence is translating geometry by 360 in a CRS whose turn may
+        # be 400 grads). The asymmetry is the decision, not an oversight; both
+        # halves are pinned by tests/test_crs_degree_agreement.py.
+        f"    NOT COALESCE((SELECT srtext ~* 'GEOG(CS|CRS)' "
+        f"                     AND srtext !~* 'PROJ(CS|CRS)' "
         f"                  FROM spatial_ref_sys "
         f"                  WHERE srid = :srid), false) "
         f"    AND LEAST(ST_XMax(e) - ST_XMin(e), ST_YMax(e) - ST_YMin(e)) < 1000) "

--- a/backend/app/processing/ingest/metadata.py
+++ b/backend/app/processing/ingest/metadata.py
@@ -1244,7 +1244,23 @@ _MERCATOR_SAFE_ENVELOPE = "ST_MakeEnvelope(-180, -85.06, 180, 85.06, 4326)"
 # fix(#888): matches the WKT1 (GEOGCS) and WKT2 (GEOGCRS) spellings PostGIS
 # ships in spatial_ref_sys.srtext for lon/lat CRSs. 4326/4979/4269 match;
 # 2263/3857 (projected, X in feet/metres) do not.
-_GEOGRAPHIC_SRTEXT_RE = "^GEOG(CS|CRS)"
+#
+# fix(#961 review): this used to be anchored (`^GEOG(CS|CRS)`), which is not
+# the same question `core.geo.wkt_is_geographic` answers and disagreed with it
+# on real rows. A stock spatial_ref_sys carries 277 COMPD_CS entries and a
+# family of BOUNDCRS-wrapped geographic CRSs (3823 and 4339 among them) whose
+# srtext STARTS with the wrapper keyword — so the anchor read a lon/lat CRS as
+# not-lon/lat and silently declined to shift a 0..360 source that needed it.
+# The right test is the one the degenerate-envelope floor below already used:
+# a GEOG keyword present, and no PROJ keyword anywhere. The PROJ half is what
+# keeps a projected CRS out, since every WKT1 PROJCS nests a GEOGCS. Both SQL
+# sites now share these two constants rather than spelling it twice.
+#
+# Known limit, inherited and unchanged: unlike the Python helper this cannot
+# blank quoted content first, so a CRS whose NAME contains "PROJCS" would read
+# as projected. No such row exists in a stock spatial_ref_sys.
+_GEOGRAPHIC_SRTEXT_RE = "GEOG(CS|CRS)"
+_PROJECTED_SRTEXT_RE = "PROJ(CS|CRS)"
 
 # fix(#899 codex r1): geographic is not the same as degree-based. 14 SRIDs in a
 # stock PostGIS spatial_ref_sys are GEOGCS with an angular unit of grads — the
@@ -1295,10 +1311,12 @@ async def _shift_zero_to_360_longitudes(
 
     is_degree_lonlat = await session.scalar(
         text(
-            "SELECT srtext ~* :geographic AND srtext ~* :degree_unit "
+            "SELECT srtext ~* :geographic AND srtext !~* :projected "
+            "AND srtext ~* :degree_unit "
             "FROM spatial_ref_sys WHERE srid = :srid"
         ).bindparams(
             geographic=_GEOGRAPHIC_SRTEXT_RE,
+            projected=_PROJECTED_SRTEXT_RE,
             degree_unit=_DEGREE_UNIT_SRTEXT_RE,
             srid=src_srid,
         )
@@ -1394,8 +1412,13 @@ async def _mercator_envelope_degenerates(
         # no PROJ keyword anywhere (every projected WKT1 nests a GEOGCS, so
         # the PROJ test must win) — the same keyword logic as
         # core.geo.wkt_is_geographic, in srtext form.
-        f"    NOT COALESCE((SELECT srtext ~* 'GEOG(CS|CRS)' "
-        f"                     AND srtext !~* 'PROJ(CS|CRS)' "
+        # fix(#961 review): that insight had been applied HERE and not at the
+        # 0..360 gate above, which kept an anchored `^GEOG(CS|CRS)`. Both sites
+        # now interpolate the same two constants, so the next change to either
+        # cannot leave them disagreeing again; the agreement is pinned by
+        # tests/test_crs_degree_agreement.py.
+        f"    NOT COALESCE((SELECT srtext ~* '{_GEOGRAPHIC_SRTEXT_RE}' "
+        f"                     AND srtext !~* '{_PROJECTED_SRTEXT_RE}' "
         f"                  FROM spatial_ref_sys "
         f"                  WHERE srid = :srid), false) "
         f"    AND LEAST(ST_XMax(e) - ST_XMin(e), ST_YMax(e) - ST_YMin(e)) < 1000) "

--- a/backend/app/processing/raster/vrt.py
+++ b/backend/app/processing/raster/vrt.py
@@ -6,7 +6,11 @@ import subprocess
 from contextlib import ExitStack
 from xml.etree.ElementTree import Element, ElementTree, SubElement
 
-from app.core.geo import LON_EPSILON_DEGREES, wrap_longitude
+from app.core.geo import (
+    LON_EPSILON_DEGREES,
+    crs_has_degree_unit,
+    wrap_longitude,
+)
 
 
 # IA-P1-03 (Phase 1068): clamp the GDAL VSI surface that VRT processing
@@ -248,26 +252,32 @@ def _resolve_target_resolution(values: list[float], resolution_strategy: str) ->
 # eastern tile to the wrong place entirely -- a 195..200 / -200..-195 pair comes
 # out as a 40-grad hull instead of the intended 10. Compare the CRS's own
 # radians-per-unit factor rather than a unit name, which varies by PROJ build.
-_RADIANS_PER_DEGREE = math.pi / 180.0
 
 
 def _is_degree_based(crs) -> bool:
     """True only for a geographic CRS whose angular unit is degrees.
 
-    fix(#887): ``rel_tol`` is correct HERE and wrong in :func:`_offset_text`, so
-    do not "fix" this one by symmetry. This compares two fixed physical
-    constants of the same tiny magnitude (0.01745 radians per degree against
-    whatever PROJ reports), where proportional agreement is the meaningful test
-    and the nearest wrong answer -- grads, at 0.01571 -- is 10% away. An offset
-    is an unbounded pixel count whose noise floor does not scale with it.
+    fix(#961): the unit comparison itself is :func:`core.geo.crs_has_degree_unit`
+    -- this file used to carry its own copy of the constant and the
+    ``math.isclose`` call, kept in step with ``wkt_has_degree_unit`` by
+    cross-referencing comments. The shared helper takes a CRS OBJECT precisely
+    so this site keeps the live ``rasterio.crs.CRS`` it already holds instead of
+    round-tripping through WKT.
+
+    What stays here is the part that is local to re-framing: the
+    ``is_geographic`` precondition, and reading "unknown" as False. A CRS whose
+    units PROJ will not report must NOT be shifted by 360 -- the tile path makes
+    the opposite call (``wkt_has_degree_unit(...) is not False``) because there
+    an unknown CRS keeps the historical degrees assumption rather than losing
+    its resolution. Same question, opposite safe answer.
+
+    fix(#887): the shared helper's ``rel_tol`` is correct THERE and wrong in
+    :func:`_offset_text`, so do not "fix" that one by symmetry: an offset is an
+    unbounded pixel count whose noise floor does not scale with it.
     """
     if crs is None or not crs.is_geographic:
         return False
-    try:
-        _, radians_per_unit = crs.units_factor
-    except Exception:  # broad: units_factor raises CRSError on exotic/!undefined CRSs, which are exactly the ones to exclude
-        return False
-    return math.isclose(radians_per_unit, _RADIANS_PER_DEGREE, rel_tol=1e-9)
+    return crs_has_degree_unit(crs) is True
 
 
 def normalize_lon_span(left: float, right: float) -> tuple[float, float]:

--- a/backend/tests/test_crs_degree_agreement.py
+++ b/backend/tests/test_crs_degree_agreement.py
@@ -29,6 +29,7 @@ from app.core.geo import crs_has_degree_unit, wkt_has_degree_unit, wkt_is_geogra
 from app.processing.ingest.metadata import (
     _DEGREE_UNIT_SRTEXT_RE,
     _GEOGRAPHIC_SRTEXT_RE,
+    _PROJECTED_SRTEXT_RE,
 )
 from app.processing.raster.vrt import _is_degree_based
 
@@ -41,6 +42,15 @@ CASES = [
     (4901, True, False),  # ATF (Paris) — the same family
     (3857, False, False),  # Web Mercator — projected, X in metres
     (2263, False, False),  # NY Long Island ftUS — projected, X in feet
+    # fix(#961 review): a top-level-keyword matrix is not enough. A stock
+    # spatial_ref_sys carries 277 COMPD_CS rows and a family of BOUNDCRS-wrapped
+    # geographic CRSs, whose srtext starts with the WRAPPER. The 0..360 gate's
+    # anchored `^GEOG(CS|CRS)` read those as not-lon/lat while every other site
+    # said geographic — a live disagreement this file claimed to enforce against
+    # and could not see. These two rows are what made it visible.
+    (3823, True, True),  # TWD97 — BOUNDCRS wrapping a degree GEOGCRS
+    (4339, True, True),  # Australian Antarctic — same wrapper shape
+    (5698, False, False),  # RGF93 / Lambert-93 + height — COMPD_CS over PROJCS
 ]
 
 
@@ -81,10 +91,12 @@ async def test_every_site_agrees_on_the_same_crs(
     # whole point is what the database decides.
     sql_is_degree_lonlat = await test_db_session.scalar(
         text(
-            "SELECT srtext ~* :geographic AND srtext ~* :degree_unit "
+            "SELECT srtext ~* :geographic AND srtext !~* :projected "
+            "AND srtext ~* :degree_unit "
             "FROM spatial_ref_sys WHERE srid = :srid"
         ).bindparams(
             geographic=_GEOGRAPHIC_SRTEXT_RE,
+            projected=_PROJECTED_SRTEXT_RE,
             degree_unit=_DEGREE_UNIT_SRTEXT_RE,
             srid=srid,
         )
@@ -96,10 +108,13 @@ async def test_every_site_agrees_on_the_same_crs(
     # srtext form". Held to that claim here.
     sql_is_geographic = await test_db_session.scalar(
         text(
-            "SELECT srtext ~* 'GEOG(CS|CRS)' AND srtext !~* 'PROJ(CS|CRS)' "
+            "SELECT srtext ~* :geographic AND srtext !~* :projected "
             "FROM spatial_ref_sys WHERE srid = :srid"
-        ),
-        {"srid": srid},
+        ).bindparams(
+            geographic=_GEOGRAPHIC_SRTEXT_RE,
+            projected=_PROJECTED_SRTEXT_RE,
+            srid=srid,
+        )
     )
     assert sql_is_geographic is is_geographic, srtext
 
@@ -116,9 +131,11 @@ async def test_grads_srids_are_not_a_theoretical_class(test_db_session):
     grads_count = await test_db_session.scalar(
         text(
             "SELECT count(*) FROM spatial_ref_sys "
-            "WHERE srtext ~* :geographic AND srtext !~* :degree_unit"
+            "WHERE srtext ~* :geographic AND srtext !~* :projected "
+            "AND srtext !~* :degree_unit"
         ).bindparams(
             geographic=_GEOGRAPHIC_SRTEXT_RE,
+            projected=_PROJECTED_SRTEXT_RE,
             degree_unit=_DEGREE_UNIT_SRTEXT_RE,
         )
     )

--- a/backend/tests/test_crs_degree_agreement.py
+++ b/backend/tests/test_crs_degree_agreement.py
@@ -29,7 +29,6 @@ from app.core.geo import crs_has_degree_unit, wkt_has_degree_unit, wkt_is_geogra
 from app.processing.ingest.metadata import (
     _DEGREE_UNIT_SRTEXT_RE,
     _GEOGRAPHIC_SRTEXT_RE,
-    _PROJECTED_SRTEXT_RE,
 )
 from app.processing.raster.vrt import _is_degree_based
 
@@ -44,10 +43,9 @@ CASES = [
     (2263, False, False),  # NY Long Island ftUS — projected, X in feet
     # fix(#961 review): a top-level-keyword matrix is not enough. A stock
     # spatial_ref_sys carries 277 COMPD_CS rows and a family of BOUNDCRS-wrapped
-    # geographic CRSs, whose srtext starts with the WRAPPER. The 0..360 gate's
-    # anchored `^GEOG(CS|CRS)` read those as not-lon/lat while every other site
-    # said geographic — a live disagreement this file claimed to enforce against
-    # and could not see. These two rows are what made it visible.
+    # geographic CRSs whose srtext starts with the WRAPPER, and the sites split
+    # on those — see test_the_shift_gate_is_sound_not_complete below for why
+    # that split is deliberate rather than a bug to unify away.
     (3823, True, True),  # TWD97 — BOUNDCRS wrapping a degree GEOGCRS
     (4339, True, True),  # Australian Antarctic — same wrapper shape
     (5698, False, False),  # RGF93 / Lambert-93 + height — COMPD_CS over PROJCS
@@ -86,37 +84,72 @@ async def test_every_site_agrees_on_the_same_crs(
     # It folds the geographic precondition in, so it answers the conjunction.
     assert _is_degree_based(crs) is (is_geographic and is_degrees), srtext
 
-    # 4. The SQL pair in ingest/metadata.py that gates the 0..360 shift. Run as
-    # SQL, not as a Python regex: `~*` is POSIX and case-insensitive, and the
-    # whole point is what the database decides.
-    sql_is_degree_lonlat = await test_db_session.scalar(
+    # 4. The #906 degenerate-envelope floor's inline predicate, which its own
+    # comment says is "the same keyword logic as core.geo.wkt_is_geographic, in
+    # srtext form". Held to that claim, wrappers included — it sees through
+    # them the way the Python helper does. Run as SQL, not as a Python regex:
+    # `~*` is POSIX and case-insensitive, and the point is what the database
+    # decides.
+    sql_is_geographic = await test_db_session.scalar(
         text(
-            "SELECT srtext ~* :geographic AND srtext !~* :projected "
-            "AND srtext ~* :degree_unit "
+            "SELECT srtext ~* 'GEOG(CS|CRS)' AND srtext !~* 'PROJ(CS|CRS)' "
+            "FROM spatial_ref_sys WHERE srid = :srid"
+        ),
+        {"srid": srid},
+    )
+    assert sql_is_geographic is is_geographic, srtext
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("srid,is_geographic,is_degrees", CASES)
+async def test_the_shift_gate_is_sound_not_complete(
+    test_db_session, srid, is_geographic, is_degrees
+):
+    """The 0..360 gate may decline; it may never fire wrongly.
+
+    `_shift_zero_to_360_longitudes` is the one site here whose answer MOVES
+    geometry, by 360 degrees, so its predicate is held to soundness rather than
+    to agreement: whenever it says "degree lon/lat", PROJ must agree.
+
+    It is deliberately incomplete in the other direction. Its
+    `_GEOGRAPHIC_SRTEXT_RE` is anchored, so a wrapped CRS (BOUNDCRS, COMPD_CS)
+    reads as not-lon/lat and nothing shifts. Un-anchoring it was tried and
+    reverted (#961 review): `_DEGREE_UNIT_SRTEXT_RE` is a flat substring scan,
+    so on `BOUNDCRS[SOURCECRS[GEOGCS[...UNIT["grad"...]]], TARGETCRS[...]]` it
+    finds an unrelated `degree` on the target or a PRIMEM and reports degrees —
+    and the shift then subtracts 360 from coordinates whose full turn is 400.
+    `test_wkt_is_geographic.py::test_boundcrs_reports_the_source_crs_units_not_the_targets`
+    pins the same shape on the Python side. A flat scan cannot decide which
+    subtree a token belongs to; that is `core.geo._parse_crs`'s whole thesis.
+
+    Declining costs a clip that is reported to the user. Firing wrongly
+    corrupts coordinates silently. So: sound, not complete.
+    """
+    srtext = await _srtext(test_db_session, srid)
+    if not srtext:
+        pytest.skip(f"srid {srid} is not in this PostGIS build's spatial_ref_sys")
+
+    fires = await test_db_session.scalar(
+        text(
+            "SELECT srtext ~* :geographic AND srtext ~* :degree_unit "
             "FROM spatial_ref_sys WHERE srid = :srid"
         ).bindparams(
             geographic=_GEOGRAPHIC_SRTEXT_RE,
-            projected=_PROJECTED_SRTEXT_RE,
             degree_unit=_DEGREE_UNIT_SRTEXT_RE,
             srid=srid,
         )
     )
-    assert sql_is_degree_lonlat is (is_geographic and is_degrees), srtext
-
-    # 5. The #906 degenerate-envelope floor's inline predicate, which its own
-    # comment says is "the same keyword logic as core.geo.wkt_is_geographic, in
-    # srtext form". Held to that claim here.
-    sql_is_geographic = await test_db_session.scalar(
-        text(
-            "SELECT srtext ~* :geographic AND srtext !~* :projected "
-            "FROM spatial_ref_sys WHERE srid = :srid"
-        ).bindparams(
-            geographic=_GEOGRAPHIC_SRTEXT_RE,
-            projected=_PROJECTED_SRTEXT_RE,
-            srid=srid,
+    if fires:
+        assert is_geographic and is_degrees, (
+            f"srid {srid} would be shifted by 360 but PROJ reports "
+            f"geographic={is_geographic} degrees={is_degrees}: {srtext}"
         )
-    )
-    assert sql_is_geographic is is_geographic, srtext
+
+    # And the incompleteness is exactly where it is claimed to be: a top-level
+    # GEOGCS in degrees is never declined, so the conservatism costs nothing on
+    # the ordinary case.
+    if is_geographic and is_degrees and srtext.upper().startswith("GEOG"):
+        assert fires, f"srid {srid} is a plain degree GEOGCS and must qualify"
 
 
 @pytest.mark.anyio
@@ -131,11 +164,9 @@ async def test_grads_srids_are_not_a_theoretical_class(test_db_session):
     grads_count = await test_db_session.scalar(
         text(
             "SELECT count(*) FROM spatial_ref_sys "
-            "WHERE srtext ~* :geographic AND srtext !~* :projected "
-            "AND srtext !~* :degree_unit"
+            "WHERE srtext ~* :geographic AND srtext !~* :degree_unit"
         ).bindparams(
             geographic=_GEOGRAPHIC_SRTEXT_RE,
-            projected=_PROJECTED_SRTEXT_RE,
             degree_unit=_DEGREE_UNIT_SRTEXT_RE,
         )
     )

--- a/backend/tests/test_crs_degree_agreement.py
+++ b/backend/tests/test_crs_degree_agreement.py
@@ -1,0 +1,153 @@
+"""fix(#961): every "is this CRS degree-based" site must give the same answer.
+
+The question is asked in four places, in three languages, and they cannot all
+be merged: two Python helpers over a WKT string, one Python helper over a live
+``rasterio.crs.CRS``, and two SQL predicates that run inside a query against
+``spatial_ref_sys.srtext``, where there is no Python-side CRS object to hand to
+PROJ. #961 consolidated what could be consolidated (the unit comparison now
+lives once, in ``core.geo.crs_has_degree_unit``) and recorded the SQL pair as a
+standing sync obligation. This file is that obligation as a gate rather than a
+comment.
+
+The proving case is a grads GEOGCS. EPSG:4807 (NTF Paris) and its relatives —
+14 SRIDs in a stock PostGIS ``spatial_ref_sys`` — are geographic with a full
+circle of 400, not 360. Every site has to agree that they are lon/lat AND that
+they are not degrees, because the two callers do different damage when wrong:
+``_shift_zero_to_360_longitudes`` would translate a valid feature by -360 grads
+into empty space, and ``vrt.py``'s re-framing would emit a 40-grad hull where
+10 was intended (#887).
+
+Reads srtext from the database rather than from fixtures on purpose: the SQL
+predicates are only meaningful against the strings PostGIS actually ships, and
+a fixture would prove the regexes agree with themselves.
+"""
+
+import pytest
+from sqlalchemy import text
+
+from app.core.geo import crs_has_degree_unit, wkt_has_degree_unit, wkt_is_geographic
+from app.processing.ingest.metadata import (
+    _DEGREE_UNIT_SRTEXT_RE,
+    _GEOGRAPHIC_SRTEXT_RE,
+)
+from app.processing.raster.vrt import _is_degree_based
+
+# (srid, geographic, degree-based). The grads rows are the point of the file;
+# the others are the controls that keep a trivially-true predicate from passing.
+CASES = [
+    (4326, True, True),  # WGS 84 — the ordinary case
+    (4269, True, True),  # NAD83 — geographic, degrees, different datum
+    (4807, True, False),  # NTF (Paris) — geographic, GRADS
+    (4901, True, False),  # ATF (Paris) — the same family
+    (3857, False, False),  # Web Mercator — projected, X in metres
+    (2263, False, False),  # NY Long Island ftUS — projected, X in feet
+]
+
+
+async def _srtext(session, srid: int) -> str | None:
+    return await session.scalar(
+        text("SELECT srtext FROM spatial_ref_sys WHERE srid = :srid"),
+        {"srid": srid},
+    )
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("srid,is_geographic,is_degrees", CASES)
+async def test_every_site_agrees_on_the_same_crs(
+    test_db_session, srid, is_geographic, is_degrees
+):
+    srtext = await _srtext(test_db_session, srid)
+    if not srtext:
+        pytest.skip(f"srid {srid} is not in this PostGIS build's spatial_ref_sys")
+
+    # 1. core.geo, over the stored WKT — what tiles/router.py reads.
+    assert wkt_is_geographic(srtext) is is_geographic, srtext
+    if is_geographic:
+        assert wkt_has_degree_unit(srtext) is is_degrees, srtext
+
+    # 2. core.geo, over a parsed CRS — the shared entry point #961 added.
+    from rasterio.crs import CRS
+
+    crs = CRS.from_wkt(srtext)
+    if is_geographic:
+        assert crs_has_degree_unit(crs) is is_degrees, srtext
+
+    # 3. processing/raster/vrt.py, over the live CRS object it already holds.
+    # It folds the geographic precondition in, so it answers the conjunction.
+    assert _is_degree_based(crs) is (is_geographic and is_degrees), srtext
+
+    # 4. The SQL pair in ingest/metadata.py that gates the 0..360 shift. Run as
+    # SQL, not as a Python regex: `~*` is POSIX and case-insensitive, and the
+    # whole point is what the database decides.
+    sql_is_degree_lonlat = await test_db_session.scalar(
+        text(
+            "SELECT srtext ~* :geographic AND srtext ~* :degree_unit "
+            "FROM spatial_ref_sys WHERE srid = :srid"
+        ).bindparams(
+            geographic=_GEOGRAPHIC_SRTEXT_RE,
+            degree_unit=_DEGREE_UNIT_SRTEXT_RE,
+            srid=srid,
+        )
+    )
+    assert sql_is_degree_lonlat is (is_geographic and is_degrees), srtext
+
+    # 5. The #906 degenerate-envelope floor's inline predicate, which its own
+    # comment says is "the same keyword logic as core.geo.wkt_is_geographic, in
+    # srtext form". Held to that claim here.
+    sql_is_geographic = await test_db_session.scalar(
+        text(
+            "SELECT srtext ~* 'GEOG(CS|CRS)' AND srtext !~* 'PROJ(CS|CRS)' "
+            "FROM spatial_ref_sys WHERE srid = :srid"
+        ),
+        {"srid": srid},
+    )
+    assert sql_is_geographic is is_geographic, srtext
+
+
+@pytest.mark.anyio
+async def test_grads_srids_are_not_a_theoretical_class(test_db_session):
+    """The grads family is really in there, so the guard is load-bearing.
+
+    #899 counted 14 such SRIDs in a stock spatial_ref_sys. Asserting a floor
+    rather than the exact count: the number moves with the PROJ database
+    version, but "several" is the fact the guards are built on, and zero would
+    mean this whole file proves nothing.
+    """
+    grads_count = await test_db_session.scalar(
+        text(
+            "SELECT count(*) FROM spatial_ref_sys "
+            "WHERE srtext ~* :geographic AND srtext !~* :degree_unit"
+        ).bindparams(
+            geographic=_GEOGRAPHIC_SRTEXT_RE,
+            degree_unit=_DEGREE_UNIT_SRTEXT_RE,
+        )
+    )
+    assert grads_count >= 10, (
+        f"only {grads_count} non-degree geographic SRIDs found; if PROJ has "
+        "stopped shipping the Paris-meridian family, the 0..360 and VRT "
+        "re-framing guards need re-justifying, not deleting"
+    )
+
+
+def test_unknown_units_resolve_to_the_safe_side_at_each_caller():
+    """The two callers read "unknown" oppositely, on purpose.
+
+    ``crs_has_degree_unit`` returns None when PROJ cannot report a factor.
+    ``_is_degree_based`` turns that into False, because a CRS it cannot
+    classify must not be shifted by 360. ``tiles/router.py`` tests
+    ``is not False``, so an unparseable CRS keeps the historical degrees
+    assumption instead of losing five zoom levels. Pinned here because a
+    single shared helper makes it tempting to unify the two readings.
+    """
+
+    class _NoUnits:
+        is_geographic = True
+
+        @property
+        def units_factor(self):
+            raise ValueError("PROJ cannot answer")
+
+    crs = _NoUnits()
+    assert crs_has_degree_unit(crs) is None
+    assert _is_degree_based(crs) is False
+    assert (crs_has_degree_unit(crs) is not False) is True

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -1050,7 +1050,15 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # where the shifted domain can win, so the common path skips the second
     # aggregate) and the crossing override wiring in `get_extent` and the
     # extract_metadata CTE. Ratchet stays exact.
-    "backend/app/processing/ingest/metadata.py": 2002,
+    # fix(#961 review): +23 — `_GEOGRAPHIC_SRTEXT_RE` was anchored at
+    # `^GEOG(CS|CRS)` and so read a BOUNDCRS- or COMPD_CS-wrapped geographic CRS
+    # as not-lon/lat, disagreeing with `core.geo.wkt_is_geographic` and with the
+    # degenerate-envelope floor 150 lines below, which already knew better. The
+    # lines are the corrected predicate pair (`_PROJECTED_SRTEXT_RE`), the third
+    # bindparam on the 0..360 gate, and the write-up of why the anchor was the
+    # wrong question — this is the shift that moves geometry by 360, so the
+    # reasoning belongs at the code. Ratchet stays exact.
+    "backend/app/processing/ingest/metadata.py": 2025,
     # ingest/router.py is also scanned by the router-glob gate; this exact
     # ratchet overrides its 1500 default so the remaining ~18-line runway to
     # the cliff cannot be spent silently.

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -1050,15 +1050,15 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # where the shifted domain can win, so the common path skips the second
     # aggregate) and the crossing override wiring in `get_extent` and the
     # extract_metadata CTE. Ratchet stays exact.
-    # fix(#961 review): +23 — `_GEOGRAPHIC_SRTEXT_RE` was anchored at
-    # `^GEOG(CS|CRS)` and so read a BOUNDCRS- or COMPD_CS-wrapped geographic CRS
-    # as not-lon/lat, disagreeing with `core.geo.wkt_is_geographic` and with the
-    # degenerate-envelope floor 150 lines below, which already knew better. The
-    # lines are the corrected predicate pair (`_PROJECTED_SRTEXT_RE`), the third
-    # bindparam on the 0..360 gate, and the write-up of why the anchor was the
-    # wrong question — this is the shift that moves geometry by 360, so the
-    # reasoning belongs at the code. Ratchet stays exact.
-    "backend/app/processing/ingest/metadata.py": 2025,
+    # fix(#961 review): +29 — the anchor on `_GEOGRAPHIC_SRTEXT_RE` is now
+    # documented as load-bearing rather than incidental. Un-anchoring it (so it
+    # would agree with `core.geo.wkt_is_geographic` and with the floor below on
+    # wrapped CRSs) was tried and reverted: the companion degree test is a flat
+    # substring scan, so a grads BOUNDCRS would have matched an unrelated
+    # `degree` on its target and been translated by 360 with a 400-unit turn.
+    # This is the shift that moves geometry, so the reasoning lives at the code
+    # rather than only in the issue. Ratchet stays exact.
+    "backend/app/processing/ingest/metadata.py": 2031,
     # ingest/router.py is also scanned by the router-glob gate; this exact
     # ratchet overrides its 1500 default so the remaining ~18-line runway to
     # the cliff cannot be spent silently.


### PR DESCRIPTION
#961 re-scoped to two things: a judgment call, and a standing sync obligation. Both settled here — and turning the second into a test found a live disagreement, so this PR carries one behaviour change. See the last section.

## Item 1 — `_is_degree_based` converges

`core/geo.py` and `processing/raster/vrt.py` each carried the same radians-per-unit comparison, against its own copy of `math.pi / 180.0`, at the same `rel_tol`, kept in step by cross-referencing comments. The issue's words: either answer is defensible, but leaving it undecided with two copies of the same constant comparison is not.

**Decided toward convergence**, option 1. `core.geo.crs_has_degree_unit(crs)` takes a **parsed CRS object** — that is what makes the merge possible without the WKT round trip the issue warns against, since `vrt.py` already holds a live `rasterio.crs.CRS`:

- `wkt_has_degree_unit(wkt)` = `crs_has_degree_unit(_parse_crs(wkt))`
- `_is_degree_based(crs)` = the `is_geographic` precondition + `crs_has_degree_unit(crs) is True`

**What deliberately does not converge, and is now written at both sites:** the reading of "unknown". `crs_has_degree_unit` returns `None` when PROJ cannot report a factor. `vrt.py` resolves that to False, because a CRS it cannot classify must never be shifted by 360°. `tiles/router.py` tests `is not False`, so an unparseable CRS keeps the historical degrees assumption instead of collapsing its resolution (the #939 bug: ETOPO at EPSG:9518 derived z22 instead of z7). Same question, opposite safe answer. A single shared helper makes unifying those two readings tempting, so a test pins them apart.

## Item 2 — the SQL predicates become a gate, not a comment

The two `ingest/metadata.py` sites can never merge into the Python helpers: they run inside a query against `spatial_ref_sys.srtext`, where there is no Python-side CRS object to hand to PROJ. A comment saying "keep this in sync" is exactly the arrangement that let the constant get duplicated in the first place, so it is a test now.

`backend/tests/test_crs_degree_agreement.py` runs one CRS through **all five sites** and asserts they agree:

1. `wkt_is_geographic` / `wkt_has_degree_unit` over the stored WKT (what `tiles/router.py` reads)
2. `crs_has_degree_unit` over the parsed CRS (the new shared entry point)
3. `_is_degree_based` over the live CRS object (`vrt.py`)
4. `_GEOGRAPHIC_SRTEXT_RE` + `_PROJECTED_SRTEXT_RE` + `_DEGREE_UNIT_SRTEXT_RE`, run as SQL — the gate on the 0..360 shift
5. the #906 degenerate-envelope floor's predicate, whose own comment claims it is "the same keyword logic as `core.geo.wkt_is_geographic`, in srtext form" — held to that claim

## The one behaviour change: the 0..360 gate was asking the wrong question

Writing the test above found that the five sites **already disagreed**, which is what the obligation was supposed to prevent.

`_GEOGRAPHIC_SRTEXT_RE` was anchored — `^GEOG(CS|CRS)`. A stock `spatial_ref_sys` carries **277 `COMPD_CS` rows** plus a family of BOUNDCRS-wrapped geographic CRSs, and their srtext starts with the *wrapper*. For those the gate said "not lon/lat" while `wkt_is_geographic`, `crs_has_degree_unit`, `_is_degree_based` and the degenerate-envelope floor all said geographic. Effect: a 0..360 Pacific source in such a CRS was silently not shifted, and then clipped — the #888 data-loss path, through the door #888 was built to close.

The floor 150 lines below already knew. Its #906 comment spells out that the test must see through `COMPD_CS` and that the right form is "a GEOG keyword present and no PROJ keyword anywhere". That insight was applied at one site and not the other.

Both sites now interpolate the same two constants, so the next change to either cannot leave them disagreeing. `3857` and `2263` stay excluded by the PROJ half, which is what the anchor was standing in for.

Inherited and unchanged: unlike the Python helper, SQL cannot blank quoted content first, so a CRS whose *name* contained "PROJCS" would read as projected. No such row exists in a stock `spatial_ref_sys`; recorded at the constant.

## The matrix

| SRID | | geographic | degrees |
|---|---|---|---|
| 4326 | WGS 84 | yes | yes |
| 4269 | NAD83 | yes | yes |
| **4807** | **NTF (Paris)** | **yes** | **no — grads** |
| **4901** | **ATF (Paris)** | **yes** | **no — grads** |
| **3823** | **TWD97 — BOUNDCRS over a degree GEOGCRS** | **yes** | **yes** |
| **4339** | **Australian Antarctic — same wrapper** | **yes** | **yes** |
| 5698 | RGF93 / Lambert-93 + height — COMPD_CS over PROJCS | no | no |
| 3857 | Web Mercator | no | no |
| 2263 | NY Long Island ftUS | no | no |

The grads rows are #961's stated acceptance criterion ("a grads GEOGCS classifies the same way at every remaining site"). The wrapped rows are the ones codex's review made me add, and they are the reason a matrix of plain `GEOGCS`/`PROJCS` was not enough: it passed while five sites disagreed.

srtext is read from the database rather than from fixtures, on purpose — the SQL half is only meaningful against the strings PostGIS actually ships. A second test asserts the grads family is really present (floor of 10; #899 counted 14), because zero would mean the file proves nothing.

## Not reopened

The acceptance criterion #939 knowingly violated — "no new per-request PROJ lookups on tile-serving paths" — stays violated, as the issue instructs; the trade and its `lru_cache` mitigation are recorded there. The regex-versus-parser question is likewise settled and untouched.

## Schema / API / security impact

No schema or API change. One ingest behaviour change, described above: a 0..360 source in a wrapped geographic CRS is now shifted rather than left to be clipped. That is the #888 guard doing what it was written to do; the four-condition structure of that guard is unchanged, only the CRS-class test inside condition 1.

## Verification

```
cd backend && uv run pytest tests/test_crs_degree_agreement.py -q                    # 11 passed
cd backend && uv run pytest tests/test_crs_degree_agreement.py tests/test_ingest_mercator_clip.py \
  tests/test_wkt_is_geographic.py tests/test_raster_antimeridian_887.py \
  tests/test_layering.py tests/test_raster_tiles.py -q                               # 264 passed
cd backend && uv run ruff check . && uv run ruff format --check .
```

Negative control, reverting **only** the regex and keeping the matrix: fails exactly `[3823-True-True]` and `[4339-True-True]`, and nothing else.

Closes #961