### PR TITLE
feat(cli): add analysis preview and materialize commands

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -2,7 +2,7 @@
 
 Apache-2.0 command-line interface for the [GeoLens](https://github.com/geolens-io/geolens) API.
 
-Login, scan local directories of spatial data, apply manifest-driven catalogs, publish vector or raster files, and export STAC metadata against any GeoLens instance.
+Login, scan local directories of spatial data, apply manifest-driven catalogs, publish vector or raster files, run PostGIS analysis operations, and export STAC metadata against any GeoLens instance.
 
 See [docs.getgeolens.com](https://docs.getgeolens.com/) for the full command reference.
 
@@ -18,6 +18,8 @@ geolens schema --output geolens-manifest-v1.schema.json
 geolens apply --dry-run geolens.yaml
 geolens apply geolens.yaml
 geolens publish ./data/cities.geojson
+geolens analysis preview <dataset-id> --operation buffer --distance 500 > ring.geojson
+geolens analysis materialize <dataset-id> --operation buffer --distance 500 --title "500 m ring"
 geolens export stac <dataset-id> -o cities.stac.json
 ```
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -19,7 +19,7 @@ geolens apply --dry-run geolens.yaml
 geolens apply geolens.yaml
 geolens publish ./data/cities.geojson
 geolens analysis preview <dataset-id> --operation buffer --distance 500 > ring.geojson
-geolens analysis materialize <dataset-id> --operation buffer --distance 500 --title "500 m ring"
+geolens analysis materialize <dataset-id> --operation buffer --distance 500 --title "500 m ring"  # waits for the job; --timeout to bound it
 geolens export stac <dataset-id> -o cities.stac.json
 ```
 

--- a/cli/geolens_cli/analysis.py
+++ b/cli/geolens_cli/analysis.py
@@ -24,15 +24,19 @@ from ._sdk_helpers import call_sdk, unwrap
 #: unit picker (AnalysisPanel converts feet/miles before it POSTs).
 DISTANCE_UNIT = "metres"
 
-#: fix(#685 review): publish's 120s poll default is far too short here. The
-#: server gives a materialize 300s of processing on its own
-#: (MATERIALIZE_TIMEOUT, backend/app/processing/analysis/tasks.py), and #703
-#: deliberately queues analysis BELOW uploads, so a legitimate run can sit
-#: waiting for minutes before it starts. Ten minutes covers both with room.
-#: A constant rather than a --timeout option on purpose: the flag is worth
-#: adding when someone has a job that legitimately outlives this, and not
-#: before.
-POLL_TIMEOUT_SECONDS: float = 600.0
+#: fix(#685 review): publish's 120s poll default is far too short here, and so
+#: was the 600s that replaced it. The queue is the reason: #703 deliberately
+#: ranks analysis BELOW uploads, so on a busy instance a perfectly healthy job
+#: can sit pending for as long as the upload backlog lasts, and any fixed
+#: wall-clock guess turns that into a false failure for automation.
+#:
+#: So the ceiling is not a guess about how long work takes — it is the point
+#: past which waiting cannot help. The server's own stale-job sweep fails a
+#: job whose lease has expired after an hour (see the sweep notes in
+#: backend/app/processing/analysis/tasks.py), so an hour is the longest a job
+#: can be alive-but-unresolved. Ctrl+C remains the way out of a wait the user
+#: no longer wants.
+POLL_TIMEOUT_SECONDS: float = 3600.0
 
 
 def _mask_dataset_arg(mask_dataset_id: Optional[str]) -> Any:
@@ -121,11 +125,14 @@ def run_materialize(client: Any, dataset_id: str, request: Any) -> Any:
 
 
 def job_status(client: Any, job_id: str) -> Optional[str]:
-    """The job's current status, or None when it cannot be read.
+    """The job's current status, or None when the status could not be READ.
 
     Used only to word the failure: ``resolve_dataset_id`` collapses "the job
-    failed" and "the poll ran out" into the same ``None``, and those two
-    deserve different sentences even though both mean "no dataset".
+    failed", "the poll ran out" and "the job endpoint would not answer" into
+    the same ``None``, and those deserve different sentences even though all
+    three mean "no dataset". None here is specifically the third case — an
+    unreadable status, not a healthy job — so the caller must not report it as
+    a timeout (fix(#685 review)).
     """
     from geolens.api.admin import get_job_status_jobs_job_id_get
 

--- a/cli/geolens_cli/analysis.py
+++ b/cli/geolens_cli/analysis.py
@@ -15,6 +15,7 @@ call goes through the generated SDK functions.
 """
 from __future__ import annotations
 
+import math
 from typing import Any, Optional
 from uuid import UUID
 
@@ -39,6 +40,21 @@ DISTANCE_UNIT = "metres"
 #: bound of its own, and hitting it reports honestly that the job is unfinished
 #: rather than failed.
 POLL_FOREVER: float = float("inf")
+
+
+def require_finite(value: Optional[float], flag: str) -> Optional[float]:
+    """Reject NaN/Infinity before they reach the wire (fix(#685 review)).
+
+    Click parses ``nan``, ``inf`` and overflowing literals like ``1e309`` into
+    real float values, and JSON has no way to spell any of them: the encoder
+    downstream either emits non-standard tokens or raises from inside the SDK,
+    neither of which reads as "that argument was not a number".
+    """
+    if value is None:
+        return None
+    if not math.isfinite(value):
+        raise ValueError(f"{flag} must be a finite number")
+    return value
 
 
 def _mask_dataset_arg(mask_dataset_id: Optional[str]) -> Any:
@@ -68,6 +84,7 @@ def build_preview_request(
     from geolens.models.analysis_preview_request import AnalysisPreviewRequest
     from geolens.types import UNSET
 
+    distance_meters = require_finite(distance_meters, "--distance")
     return AnalysisPreviewRequest(
         operation=operation,  # type: ignore[arg-type]  # the SDK enum is the authority
         distance_meters=UNSET if distance_meters is None else distance_meters,
@@ -87,6 +104,7 @@ def build_materialize_request(
     from geolens.models.analysis_materialize_request import AnalysisMaterializeRequest
     from geolens.types import UNSET
 
+    distance_meters = require_finite(distance_meters, "--distance")
     return AnalysisMaterializeRequest(
         operation=operation,  # type: ignore[arg-type]  # the SDK enum is the authority
         title=title,

--- a/cli/geolens_cli/analysis.py
+++ b/cli/geolens_cli/analysis.py
@@ -19,7 +19,9 @@ import math
 from typing import Any, Optional
 from uuid import UUID
 
-from ._sdk_helpers import call_sdk, unwrap
+import typer
+
+from ._sdk_helpers import EXIT_AUTH, call_sdk, unwrap
 
 #: Distances are metres on the wire, matching the API and the map builder's
 #: unit picker (AnalysisPanel converts feet/miles before it POSTs).
@@ -144,30 +146,47 @@ def run_materialize(client: Any, dataset_id: str, request: Any) -> Any:
     return unwrap(resp, expected=200)
 
 
-def job_status(client: Any, job_id: str) -> Optional[str]:
-    """The job's current status, or None when the status could not be READ.
+def job_snapshot(client: Any, job_id: str) -> tuple[Optional[str], Optional[str]]:
+    """``(status, dataset_id)`` for a job, or ``(None, None)`` when unreadable.
 
-    Used only to word the failure: ``resolve_dataset_id`` collapses "the job
-    failed", "the poll ran out" and "the job endpoint would not answer" into
-    the same ``None``, and those deserve different sentences even though all
-    three mean "no dataset". None here is specifically the third case — an
-    unreadable status, not a healthy job — so the caller must not report it as
-    a timeout (fix(#685 review)).
+    ``resolve_dataset_id`` collapses "the job failed", "the poll ran out" and
+    "the job endpoint would not answer" into one ``None``, and those deserve
+    different sentences even though all three mean "no dataset" (fix(#685
+    review)).
+
+    The dataset id rides along because the job can finish between the poll's
+    last look and this one: the status response carries the id, and discarding
+    it would report a completed job as unfinished.
+
+    A 401/403 is raised rather than reported, so the exit code matches what
+    actually went wrong (D-32) instead of collapsing into the generic one.
     """
     from geolens.api.admin import get_job_status_jobs_job_id_get
 
     try:
         job_uuid = UUID(str(job_id))
     except ValueError:
-        return None
+        return None, None
     resp = call_sdk(
         get_job_status_jobs_job_id_get.sync_detailed,
         job_id=job_uuid,
         client=client,
     )
-    if int(resp.status_code) != 200:
-        return None
-    return getattr(resp.parsed, "status", None)
+    code = int(resp.status_code)
+    if code in (401, 403):
+        typer.secho(
+            "Authentication failed while reading the job status. "
+            "Run `geolens login` first.",
+            fg="red",
+            err=True,
+        )
+        raise typer.Exit(EXIT_AUTH)
+    if code != 200:
+        return None, None
+    dataset_id = getattr(resp.parsed, "dataset_id", None)
+    return getattr(resp.parsed, "status", None), (
+        str(dataset_id) if dataset_id else None
+    )
 
 
 def preview_geojson(response: Any) -> dict:

--- a/cli/geolens_cli/analysis.py
+++ b/cli/geolens_cli/analysis.py
@@ -24,19 +24,21 @@ from ._sdk_helpers import call_sdk, unwrap
 #: unit picker (AnalysisPanel converts feet/miles before it POSTs).
 DISTANCE_UNIT = "metres"
 
-#: fix(#685 review): publish's 120s poll default is far too short here, and so
-#: was the 600s that replaced it. The queue is the reason: #703 deliberately
-#: ranks analysis BELOW uploads, so on a busy instance a perfectly healthy job
-#: can sit pending for as long as the upload backlog lasts, and any fixed
-#: wall-clock guess turns that into a false failure for automation.
+#: fix(#685 review): there is no defensible fixed wait, so the default is not
+#: one. publish's 120s, then 600s, then an hour were each a guess about how
+#: long the work takes, and the queue makes that unanswerable. #703 ranks
+#: analysis below uploads, and the server states the consequence outright in
+#: no_live_procrastinate_job() (backend/app/platform/jobs/router.py): a job
+#: Procrastinate still holds is "simply waiting ... with no upper bound", and
+#: failing it at the one-hour mark would be "both a lie and a loss". A CLI
+#: that gives up first tells automation the analysis produced nothing while
+#: the server is still going to produce it.
 #:
-#: So the ceiling is not a guess about how long work takes — it is the point
-#: past which waiting cannot help. The server's own stale-job sweep fails a
-#: job whose lease has expired after an hour (see the sweep notes in
-#: backend/app/processing/analysis/tasks.py), so an hour is the longest a job
-#: can be alive-but-unresolved. Ctrl+C remains the way out of a wait the user
-#: no longer wants.
-POLL_TIMEOUT_SECONDS: float = 3600.0
+#: So --wait waits for a terminal state. Ctrl+C is the way out of a wait the
+#: user no longer wants; --timeout is the way out for automation that needs a
+#: bound of its own, and hitting it reports honestly that the job is unfinished
+#: rather than failed.
+POLL_FOREVER: float = float("inf")
 
 
 def _mask_dataset_arg(mask_dataset_id: Optional[str]) -> Any:

--- a/cli/geolens_cli/analysis.py
+++ b/cli/geolens_cli/analysis.py
@@ -24,6 +24,16 @@ from ._sdk_helpers import call_sdk, unwrap
 #: unit picker (AnalysisPanel converts feet/miles before it POSTs).
 DISTANCE_UNIT = "metres"
 
+#: fix(#685 review): publish's 120s poll default is far too short here. The
+#: server gives a materialize 300s of processing on its own
+#: (MATERIALIZE_TIMEOUT, backend/app/processing/analysis/tasks.py), and #703
+#: deliberately queues analysis BELOW uploads, so a legitimate run can sit
+#: waiting for minutes before it starts. Ten minutes covers both with room.
+#: A constant rather than a --timeout option on purpose: the flag is worth
+#: adding when someone has a job that legitimately outlives this, and not
+#: before.
+POLL_TIMEOUT_SECONDS: float = 600.0
+
 
 def _mask_dataset_arg(mask_dataset_id: Optional[str]) -> Any:
     """Coerce a mask dataset id to the UUID the SDK models declare."""
@@ -108,6 +118,29 @@ def run_materialize(client: Any, dataset_id: str, request: Any) -> Any:
         body=request,
     )
     return unwrap(resp, expected=200)
+
+
+def job_status(client: Any, job_id: str) -> Optional[str]:
+    """The job's current status, or None when it cannot be read.
+
+    Used only to word the failure: ``resolve_dataset_id`` collapses "the job
+    failed" and "the poll ran out" into the same ``None``, and those two
+    deserve different sentences even though both mean "no dataset".
+    """
+    from geolens.api.admin import get_job_status_jobs_job_id_get
+
+    try:
+        job_uuid = UUID(str(job_id))
+    except ValueError:
+        return None
+    resp = call_sdk(
+        get_job_status_jobs_job_id_get.sync_detailed,
+        job_id=job_uuid,
+        client=client,
+    )
+    if int(resp.status_code) != 200:
+        return None
+    return getattr(resp.parsed, "status", None)
 
 
 def preview_geojson(response: Any) -> dict:

--- a/cli/geolens_cli/analysis.py
+++ b/cli/geolens_cli/analysis.py
@@ -1,0 +1,157 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Analysis commands — preview a PostGIS operation, or save it as a dataset.
+
+Hand-maintained — NOT regenerated. Pure SDK pass-through (D-25, D-28): the
+backend at ``backend/app/modules/catalog/datasets/api/router_analysis.py``
+owns every rule, and the CLI carries no copy of them.
+
+That includes the operation list. ``--operation`` is handed to the SDK
+unchanged rather than validated against a literal here, so the generated
+enum stays the single authority and a new backend operation reaches the CLI
+with the next ``make sdks`` instead of a second list to keep in step (#685).
+
+OCCLI-06 invariant: zero direct ``httpx`` / ``requests`` imports — every HTTP
+call goes through the generated SDK functions.
+"""
+from __future__ import annotations
+
+from typing import Any, Optional
+from uuid import UUID
+
+from ._sdk_helpers import call_sdk, unwrap
+
+#: Distances are metres on the wire, matching the API and the map builder's
+#: unit picker (AnalysisPanel converts feet/miles before it POSTs).
+DISTANCE_UNIT = "metres"
+
+
+def _mask_dataset_arg(mask_dataset_id: Optional[str]) -> Any:
+    """Coerce a mask dataset id to the UUID the SDK models declare."""
+    from geolens.types import UNSET
+
+    if not mask_dataset_id:
+        return UNSET
+    try:
+        return UUID(mask_dataset_id)
+    except ValueError as exc:
+        raise ValueError(f"--mask-dataset is not a valid id: {mask_dataset_id}") from exc
+
+
+def build_preview_request(
+    operation: str,
+    *,
+    distance_meters: Optional[float] = None,
+    mask_dataset_id: Optional[str] = None,
+) -> Any:
+    """Build an AnalysisPreviewRequest, omitting the params that were not given.
+
+    Unset beats null: the request model is deliberately flat and the server
+    strips params belonging to other operations, so sending an explicit null
+    for every unused field would only make the wire payload noisier.
+    """
+    from geolens.models.analysis_preview_request import AnalysisPreviewRequest
+    from geolens.types import UNSET
+
+    return AnalysisPreviewRequest(
+        operation=operation,  # type: ignore[arg-type]  # the SDK enum is the authority
+        distance_meters=UNSET if distance_meters is None else distance_meters,
+        mask_dataset_id=_mask_dataset_arg(mask_dataset_id),
+    )
+
+
+def build_materialize_request(
+    operation: str,
+    title: str,
+    *,
+    distance_meters: Optional[float] = None,
+    mask_dataset_id: Optional[str] = None,
+    by_field: Optional[str] = None,
+) -> Any:
+    """Build an AnalysisMaterializeRequest. See build_preview_request on UNSET."""
+    from geolens.models.analysis_materialize_request import AnalysisMaterializeRequest
+    from geolens.types import UNSET
+
+    return AnalysisMaterializeRequest(
+        operation=operation,  # type: ignore[arg-type]  # the SDK enum is the authority
+        title=title,
+        distance_meters=UNSET if distance_meters is None else distance_meters,
+        mask_dataset_id=_mask_dataset_arg(mask_dataset_id),
+        by_field=UNSET if by_field is None else by_field,
+    )
+
+
+def run_preview(client: Any, dataset_id: str, request: Any) -> Any:
+    """POST the preview and return the parsed AnalysisPreviewResponse."""
+    from geolens.api.datasets_analysis import (
+        analysis_preview_endpoint_datasets_dataset_id_analysis_preview_post as _preview,
+    )
+
+    resp = call_sdk(
+        _preview.sync_detailed,
+        dataset_id=dataset_id,
+        client=client,
+        body=request,
+    )
+    return unwrap(resp, expected=200)
+
+
+def run_materialize(client: Any, dataset_id: str, request: Any) -> Any:
+    """POST the materialize request and return the parsed job response."""
+    from geolens.api.datasets_analysis import (
+        analysis_materialize_endpoint_datasets_dataset_id_analysis_materialize_post as _materialize,
+    )
+
+    resp = call_sdk(
+        _materialize.sync_detailed,
+        dataset_id=dataset_id,
+        client=client,
+        body=request,
+    )
+    return unwrap(resp, expected=200)
+
+
+def preview_geojson(response: Any) -> dict:
+    """The FeatureCollection from a preview response, as a plain dict.
+
+    The generated model wraps it in an attrs class whose ``to_dict`` gives the
+    GeoJSON back verbatim; a caller piping stdout into a .geojson file needs
+    that, not the envelope.
+    """
+    geojson = getattr(response, "geojson", None)
+    if geojson is None:
+        return {"type": "FeatureCollection", "features": []}
+    to_dict = getattr(geojson, "to_dict", None)
+    return to_dict() if callable(to_dict) else dict(geojson)
+
+
+def render_geojson(payload: dict, *, compact: bool = False) -> str:
+    """Format the FeatureCollection for stdout.
+
+    Same contract as ``geolens export stac`` (D-27: pretty with sorted keys
+    by default, single-line under ``--compact``), and the same implementation,
+    so the two commands cannot drift into different JSON shapes.
+    """
+    from .export_stac import render_stac_json
+
+    return render_stac_json(payload, compact=compact)
+
+
+def truncation_warning(response: Any) -> Optional[str]:
+    """Message for a capped preview, or None when the result is complete.
+
+    The cap is silent in the GeoJSON itself, so a scripted caller that only
+    reads stdout would treat the first 500 features as the whole answer.
+    """
+    if not getattr(response, "truncated", False):
+        return None
+    shown = getattr(response, "feature_count", None)
+    total = getattr(response, "source_feature_count", None)
+    if total:
+        return (
+            f"Preview capped at {shown} of {total} source features. "
+            "Use `geolens analysis materialize` to run over every feature."
+        )
+    return (
+        f"Preview capped at {shown} features. "
+        "Use `geolens analysis materialize` to run over every feature."
+    )

--- a/cli/geolens_cli/main.py
+++ b/cli/geolens_cli/main.py
@@ -922,16 +922,25 @@ def analysis_materialize(
     response = _analysis.run_materialize(sdk.client, dataset_id, request)
     job_id = str(getattr(response, "job_id", "") or "")
 
-    resolved: Optional[str] = None
-    if wait:
-        resolved = _publish.resolve_dataset_id(sdk.client, job_id)
-        if resolved is None:
-            # The job outlived the poll window or failed outright; the URL
-            # falls back to the job-search form so the user can follow it up.
-            state.output.warn(
-                "The job did not resolve a dataset before the poll timed out. "
-                f"Check its status with `geolens jobs` or GET /jobs/{job_id}."
-            )
+    if not wait:
+        # Nothing was polled, so there is no dataset to name yet — report the
+        # job id rather than a URL for a dataset that may not exist.
+        if state.output.json_mode:
+            state.output.json({"job_id": job_id, "dataset_id": None, "url": None})
+        else:
+            state.output.success(f"Analysis job queued: {job_id}")
+        return
+
+    resolved = _publish.resolve_dataset_id(sdk.client, job_id)
+    if resolved is None:
+        # resolve_dataset_id returns None for BOTH a failed job and a poll
+        # timeout, and a script that asked us to wait must not read either as
+        # success. Exit non-zero and name the job so it can be followed up.
+        state.output.error(
+            f"Analysis job {job_id} produced no dataset. It either failed or is "
+            "still running; check GET /jobs/" + job_id + " for its status."
+        )
+        raise typer.Exit(EXIT_GENERIC)
 
     url = _publish.construct_dataset_url(
         instance, dataset_id=resolved, job_id=job_id

--- a/cli/geolens_cli/main.py
+++ b/cli/geolens_cli/main.py
@@ -18,6 +18,7 @@ from typing import Annotated, Optional
 import typer
 from rich.table import Table
 
+from . import analysis as _analysis
 from . import auth as _auth
 from . import config as _config
 from . import export_stac as _export_stac
@@ -30,6 +31,8 @@ from ._sdk_helpers import EXIT_AUTH, EXIT_GENERIC, EXIT_USAGE, call_sdk, unwrap
 app = typer.Typer(no_args_is_help=True, rich_markup_mode="rich", help="GeoLens CLI")
 export_app = typer.Typer(no_args_is_help=True, help="Export commands")
 app.add_typer(export_app, name="export")
+analysis_app = typer.Typer(no_args_is_help=True, help="Analysis commands")
+app.add_typer(analysis_app, name="analysis")
 
 
 @dataclass
@@ -797,3 +800,143 @@ def export_stac(
             _export_stac.render_stac_json(stac_item, compact=compact),
             nl=False,
         )
+
+
+@analysis_app.command("preview")
+def analysis_preview(
+    ctx: typer.Context,
+    dataset_id: Annotated[str, typer.Argument(help="Source dataset id")],
+    operation: Annotated[
+        str,
+        typer.Option(
+            "--operation",
+            help="buffer, centroid or clip (the server rejects anything else)",
+        ),
+    ],
+    distance: Annotated[
+        Optional[float],
+        typer.Option("--distance", help="Buffer distance in METRES (buffer only)"),
+    ] = None,
+    mask_dataset: Annotated[
+        Optional[str],
+        typer.Option(
+            "--mask-dataset",
+            help="Polygon dataset id whose features form the clip mask (clip only)",
+        ),
+    ] = None,
+    compact: Annotated[
+        bool,
+        typer.Option("--compact", help="Single-line JSON for piping to jq"),
+    ] = False,
+) -> None:
+    """Run an analysis operation and print the resulting GeoJSON.
+
+    Nothing is created: the preview is computed and returned, capped at the
+    server's preview limit. The cap is announced on stderr so stdout stays a
+    valid GeoJSON document you can redirect straight into a file.
+    """
+    state: AppState = ctx.obj
+    sdk = state.sdk()
+
+    try:
+        request = _analysis.build_preview_request(
+            operation,
+            distance_meters=distance,
+            mask_dataset_id=mask_dataset,
+        )
+    except ValueError as exc:
+        state.output.error(str(exc))
+        raise typer.Exit(EXIT_USAGE) from exc
+
+    response = _analysis.run_preview(sdk.client, dataset_id, request)
+
+    warning = _analysis.truncation_warning(response)
+    if warning:
+        state.output.warn(warning)
+
+    typer.echo(
+        _analysis.render_geojson(_analysis.preview_geojson(response), compact=compact),
+        nl=False,
+    )
+
+
+@analysis_app.command("materialize")
+def analysis_materialize(
+    ctx: typer.Context,
+    dataset_id: Annotated[str, typer.Argument(help="Source dataset id")],
+    operation: Annotated[
+        str,
+        typer.Option(
+            "--operation",
+            help="buffer, centroid, clip or dissolve (the server rejects anything else)",
+        ),
+    ],
+    title: Annotated[
+        str, typer.Option("--title", help="Title for the dataset that will be created")
+    ],
+    distance: Annotated[
+        Optional[float],
+        typer.Option("--distance", help="Buffer distance in METRES (buffer only)"),
+    ] = None,
+    mask_dataset: Annotated[
+        Optional[str],
+        typer.Option(
+            "--mask-dataset",
+            help="Polygon dataset id whose features form the clip mask (clip only)",
+        ),
+    ] = None,
+    by_field: Annotated[
+        Optional[str],
+        typer.Option("--by-field", help="Group-by column (dissolve only)"),
+    ] = None,
+    wait: Annotated[
+        bool,
+        typer.Option("--wait/--no-wait", help="Poll the job until the dataset exists"),
+    ] = True,
+) -> None:
+    """Run an analysis operation over the whole dataset and save the result.
+
+    The work is queued: the server runs one analysis job per user at a time,
+    so this returns a job id. With ``--wait`` (default) it polls until the new
+    dataset resolves, exactly as ``geolens publish`` does.
+    """
+    state: AppState = ctx.obj
+    instance = state.active_instance()
+    if not instance:
+        state.output.error("No instance configured. Run `geolens login <url>` first.")
+        raise typer.Exit(EXIT_AUTH)
+    sdk = state.sdk()
+
+    try:
+        request = _analysis.build_materialize_request(
+            operation,
+            title,
+            distance_meters=distance,
+            mask_dataset_id=mask_dataset,
+            by_field=by_field,
+        )
+    except ValueError as exc:
+        state.output.error(str(exc))
+        raise typer.Exit(EXIT_USAGE) from exc
+
+    response = _analysis.run_materialize(sdk.client, dataset_id, request)
+    job_id = str(getattr(response, "job_id", "") or "")
+
+    resolved: Optional[str] = None
+    if wait:
+        resolved = _publish.resolve_dataset_id(sdk.client, job_id)
+        if resolved is None:
+            # The job outlived the poll window or failed outright; the URL
+            # falls back to the job-search form so the user can follow it up.
+            state.output.warn(
+                "The job did not resolve a dataset before the poll timed out. "
+                f"Check its status with `geolens jobs` or GET /jobs/{job_id}."
+            )
+
+    url = _publish.construct_dataset_url(
+        instance, dataset_id=resolved, job_id=job_id
+    )
+    if state.output.json_mode:
+        state.output.json({"job_id": job_id, "dataset_id": resolved, "url": url})
+        return
+    state.output.success(url)

--- a/cli/geolens_cli/main.py
+++ b/cli/geolens_cli/main.py
@@ -931,15 +931,27 @@ def analysis_materialize(
             state.output.success(f"Analysis job queued: {job_id}")
         return
 
-    resolved = _publish.resolve_dataset_id(sdk.client, job_id)
+    resolved = _publish.resolve_dataset_id(
+        sdk.client, job_id, timeout=_analysis.POLL_TIMEOUT_SECONDS
+    )
     if resolved is None:
         # resolve_dataset_id returns None for BOTH a failed job and a poll
-        # timeout, and a script that asked us to wait must not read either as
-        # success. Exit non-zero and name the job so it can be followed up.
-        state.output.error(
-            f"Analysis job {job_id} produced no dataset. It either failed or is "
-            "still running; check GET /jobs/" + job_id + " for its status."
-        )
+        # that ran out, and a script that asked us to wait must not read
+        # either as success. Read the status back so the two get different
+        # sentences; both still exit non-zero, because neither produced the
+        # dataset the caller waited for.
+        status = _analysis.job_status(sdk.client, job_id)
+        if status == "failed":
+            state.output.error(
+                f"Analysis job {job_id} failed. Its error is on the job record: "
+                f"GET /jobs/{job_id}."
+            )
+        else:
+            state.output.error(
+                f"Analysis job {job_id} did not finish within "
+                f"{int(_analysis.POLL_TIMEOUT_SECONDS)}s and may still be running. "
+                f"Check GET /jobs/{job_id}."
+            )
         raise typer.Exit(EXIT_GENERIC)
 
     url = _publish.construct_dataset_url(

--- a/cli/geolens_cli/main.py
+++ b/cli/geolens_cli/main.py
@@ -946,11 +946,18 @@ def analysis_materialize(
                 f"Analysis job {job_id} failed. Its error is on the job record: "
                 f"GET /jobs/{job_id}."
             )
+        elif status is None:
+            # The status endpoint would not answer (auth, 404, 5xx), so the
+            # job's fate is unknown — do not assert a timeout it may not have
+            # hit (fix(#685 review)).
+            state.output.error(
+                f"Analysis job {job_id} could not be read back, so its outcome "
+                f"is unknown. Check GET /jobs/{job_id}."
+            )
         else:
             state.output.error(
-                f"Analysis job {job_id} did not finish within "
-                f"{int(_analysis.POLL_TIMEOUT_SECONDS)}s and may still be running. "
-                f"Check GET /jobs/{job_id}."
+                f"Analysis job {job_id} was still {status} after "
+                f"{int(_analysis.POLL_TIMEOUT_SECONDS)}s. Check GET /jobs/{job_id}."
             )
         raise typer.Exit(EXIT_GENERIC)
 

--- a/cli/geolens_cli/main.py
+++ b/cli/geolens_cli/main.py
@@ -978,8 +978,14 @@ def analysis_materialize(
         # either as success. Read the status back so the two get different
         # sentences; both still exit non-zero, because neither produced the
         # dataset the caller waited for.
-        status = _analysis.job_status(poll_client, job_id)
-        if status == "failed":
+        status, late_dataset_id = _analysis.job_snapshot(poll_client, job_id)
+        if late_dataset_id:
+            # The job finished between the poll's last look and this one, and
+            # the status response carries the id (fix(#685 review)). Reporting
+            # a completed job as unfinished would be the worst answer of the
+            # three.
+            resolved = late_dataset_id
+        elif status == "failed":
             state.output.error(
                 f"Analysis job {job_id} failed. Its error is on the job record: "
                 f"GET /jobs/{job_id}."
@@ -1000,7 +1006,8 @@ def analysis_materialize(
                 f"Analysis job {job_id} was still {status} after {int(timeout or 0)}s "
                 f"and has not finished. Check GET /jobs/{job_id}."
             )
-        raise typer.Exit(EXIT_GENERIC)
+        if resolved is None:
+            raise typer.Exit(EXIT_GENERIC)
 
     url = _publish.construct_dataset_url(
         instance, dataset_id=resolved, job_id=job_id

--- a/cli/geolens_cli/main.py
+++ b/cli/geolens_cli/main.py
@@ -960,8 +960,15 @@ def analysis_materialize(
             state.output.success(f"Analysis job queued: {job_id}")
         return
 
+    # fix(#685 review): the deadline below is only checked BETWEEN polls, so a
+    # request that stalls after connecting would outlive the bound the caller
+    # asked for. The SDK builds its httpx client with timeout=None (no limit at
+    # all, not httpx's 5s default), so give the polling client the same bound.
+    # A float rather than an httpx.Timeout because OCCLI-06 forbids importing
+    # httpx here; httpx accepts either.
+    poll_client = sdk.client if timeout is None else sdk.client.with_timeout(timeout)
     resolved = _publish.resolve_dataset_id(
-        sdk.client,
+        poll_client,
         job_id,
         timeout=_analysis.POLL_FOREVER if timeout is None else timeout,
     )
@@ -971,7 +978,7 @@ def analysis_materialize(
         # either as success. Read the status back so the two get different
         # sentences; both still exit non-zero, because neither produced the
         # dataset the caller waited for.
-        status = _analysis.job_status(sdk.client, job_id)
+        status = _analysis.job_status(poll_client, job_id)
         if status == "failed":
             state.output.error(
                 f"Analysis job {job_id} failed. Its error is on the job record: "

--- a/cli/geolens_cli/main.py
+++ b/cli/geolens_cli/main.py
@@ -836,6 +836,12 @@ def analysis_preview(
     valid GeoJSON document you can redirect straight into a file.
     """
     state: AppState = ctx.obj
+    # fix(#685 review): without this, state.sdk() raises BadParameter and the
+    # missing instance exits 2 (usage) while the sibling materialize command
+    # exits 3 (auth) for the identical condition.
+    if not state.active_instance():
+        state.output.error("No instance configured. Run `geolens login <url>` first.")
+        raise typer.Exit(EXIT_AUTH)
     sdk = state.sdk()
 
     try:
@@ -916,6 +922,12 @@ def analysis_materialize(
     if not instance:
         state.output.error("No instance configured. Run `geolens login <url>` first.")
         raise typer.Exit(EXIT_AUTH)
+    # fix(#685 review): `timeout or POLL_FOREVER` read an explicit 0 as "no
+    # bound", the opposite of what it asks for. A zero or negative wait is a
+    # usage error — --no-wait is the way to not wait.
+    if timeout is not None and timeout <= 0:
+        state.output.error("--timeout must be greater than 0; use --no-wait to skip waiting.")
+        raise typer.Exit(EXIT_USAGE)
     sdk = state.sdk()
 
     try:
@@ -943,7 +955,9 @@ def analysis_materialize(
         return
 
     resolved = _publish.resolve_dataset_id(
-        sdk.client, job_id, timeout=timeout or _analysis.POLL_FOREVER
+        sdk.client,
+        job_id,
+        timeout=_analysis.POLL_FOREVER if timeout is None else timeout,
     )
     if resolved is None:
         # resolve_dataset_id returns None for BOTH a failed job and a poll

--- a/cli/geolens_cli/main.py
+++ b/cli/geolens_cli/main.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import getpass
 import json
+import math
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Annotated, Optional
@@ -925,8 +926,13 @@ def analysis_materialize(
     # fix(#685 review): `timeout or POLL_FOREVER` read an explicit 0 as "no
     # bound", the opposite of what it asks for. A zero or negative wait is a
     # usage error — --no-wait is the way to not wait.
-    if timeout is not None and timeout <= 0:
-        state.output.error("--timeout must be greater than 0; use --no-wait to skip waiting.")
+    # `inf` and overflowing literals like 1e309 parse as a real float, so a
+    # bound the caller asked for would silently become no bound at all.
+    if timeout is not None and (timeout <= 0 or not math.isfinite(timeout)):
+        state.output.error(
+            "--timeout must be a finite number greater than 0; "
+            "use --no-wait to skip waiting."
+        )
         raise typer.Exit(EXIT_USAGE)
     sdk = state.sdk()
 

--- a/cli/geolens_cli/main.py
+++ b/cli/geolens_cli/main.py
@@ -893,12 +893,23 @@ def analysis_materialize(
         bool,
         typer.Option("--wait/--no-wait", help="Poll the job until the dataset exists"),
     ] = True,
+    timeout: Annotated[
+        Optional[float],
+        typer.Option(
+            "--timeout",
+            help=(
+                "Seconds to wait before giving up (default: until the job "
+                "finishes, however long it queues)"
+            ),
+        ),
+    ] = None,
 ) -> None:
     """Run an analysis operation over the whole dataset and save the result.
 
-    The work is queued: the server runs one analysis job per user at a time,
-    so this returns a job id. With ``--wait`` (default) it polls until the new
-    dataset resolves, exactly as ``geolens publish`` does.
+    The work is queued, and analysis is queued BELOW uploads on purpose, so a
+    healthy job can wait behind a busy instance's backlog with no upper bound.
+    ``--wait`` (the default) therefore waits for the job to finish rather than
+    for a fixed number of seconds; pass ``--timeout`` to bound it, or Ctrl+C.
     """
     state: AppState = ctx.obj
     instance = state.active_instance()
@@ -932,7 +943,7 @@ def analysis_materialize(
         return
 
     resolved = _publish.resolve_dataset_id(
-        sdk.client, job_id, timeout=_analysis.POLL_TIMEOUT_SECONDS
+        sdk.client, job_id, timeout=timeout or _analysis.POLL_FOREVER
     )
     if resolved is None:
         # resolve_dataset_id returns None for BOTH a failed job and a poll
@@ -955,9 +966,12 @@ def analysis_materialize(
                 f"is unknown. Check GET /jobs/{job_id}."
             )
         else:
+            # Only reachable with an explicit --timeout: the default waits for
+            # a terminal state. Unfinished is not failed, and the wording says
+            # so (fix(#685 review)).
             state.output.error(
-                f"Analysis job {job_id} was still {status} after "
-                f"{int(_analysis.POLL_TIMEOUT_SECONDS)}s. Check GET /jobs/{job_id}."
+                f"Analysis job {job_id} was still {status} after {int(timeout or 0)}s "
+                f"and has not finished. Check GET /jobs/{job_id}."
             )
         raise typer.Exit(EXIT_GENERIC)
 

--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -33,7 +33,11 @@ dependencies = [
   "tomli_w>=1.0.0,<2.0.0",
   "platformdirs>=4.0.0,<5.0.0",
   "structlog>=25.0.0,<26.0.0",
-  "geolens>=1.2.0,<2.0.0",
+  # fix(#685 review): 1.5.0 is the first SDK carrying
+  # geolens.api.datasets_analysis; `geolens analysis` raises
+  # ModuleNotFoundError against anything older, and 1.2.0 satisfied the old
+  # floor.
+  "geolens>=1.5.0,<2.0.0",
 ]
 
 [project.optional-dependencies]

--- a/cli/tests/test_analysis.py
+++ b/cli/tests/test_analysis.py
@@ -270,7 +270,7 @@ class TestAnalysisMaterializeCli:
         assert result.exit_code == 0, result.output
         assert "job-1" in result.output
 
-    def test_a_job_that_produces_no_dataset_exits_non_zero(
+    def test_a_failed_job_exits_non_zero_and_says_so(
         self, runner, tmp_xdg_home, mock_keyring, monkeypatch
     ) -> None:
         """fix(#685 review): resolve_dataset_id returns None for a FAILED job
@@ -285,6 +285,7 @@ class TestAnalysisMaterializeCli:
         monkeypatch.setattr(
             "geolens_cli.publish.resolve_dataset_id", lambda c, j, **kw: None
         )
+        monkeypatch.setattr("geolens_cli.analysis.job_status", lambda c, j: "failed")
 
         result = runner.invoke(
             app,
@@ -299,7 +300,77 @@ class TestAnalysisMaterializeCli:
             ],
         )
         assert result.exit_code == 1, result.output
+        assert "failed" in result.output
         assert "job-1" in result.output
+
+    def test_a_still_running_job_is_not_reported_as_failed(
+        self, runner, tmp_xdg_home, mock_keyring, monkeypatch
+    ) -> None:
+        """fix(#685 review): a materialize gets 300s of processing server-side
+        and queues below uploads, so outliving the poll is not the same as
+        failing. Still exit non-zero (no dataset), but do not call it failed."""
+        from geolens_cli.main import app
+
+        _seed_login("https://x.example.com/api", mock_keyring)
+        monkeypatch.setattr(
+            "geolens_cli.analysis.run_materialize", lambda c, d, r: _FakeJob()
+        )
+        monkeypatch.setattr(
+            "geolens_cli.publish.resolve_dataset_id", lambda c, j, **kw: None
+        )
+        monkeypatch.setattr("geolens_cli.analysis.job_status", lambda c, j: "running")
+
+        result = runner.invoke(
+            app,
+            [
+                "analysis",
+                "materialize",
+                "ds-1",
+                "--operation",
+                "centroid",
+                "--title",
+                "Centroids",
+            ],
+        )
+        assert result.exit_code == 1, result.output
+        assert "may still be running" in result.output
+        assert "failed" not in result.output
+
+    def test_the_poll_waits_longer_than_the_server_side_budget(
+        self, runner, tmp_xdg_home, mock_keyring, monkeypatch
+    ) -> None:
+        """publish's 120s default is shorter than MATERIALIZE_TIMEOUT (300s)."""
+        from geolens_cli.analysis import POLL_TIMEOUT_SECONDS
+        from geolens_cli.main import app
+
+        assert POLL_TIMEOUT_SECONDS > 300
+
+        seen: dict = {}
+
+        def _capture(client, job_id, **kwargs):
+            seen.update(kwargs)
+            return "ds-new"
+
+        _seed_login("https://x.example.com/api", mock_keyring)
+        monkeypatch.setattr(
+            "geolens_cli.analysis.run_materialize", lambda c, d, r: _FakeJob()
+        )
+        monkeypatch.setattr("geolens_cli.publish.resolve_dataset_id", _capture)
+
+        result = runner.invoke(
+            app,
+            [
+                "analysis",
+                "materialize",
+                "ds-1",
+                "--operation",
+                "centroid",
+                "--title",
+                "Centroids",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        assert seen["timeout"] == POLL_TIMEOUT_SECONDS
 
     def test_json_mode_emits_the_job_and_dataset_ids(
         self, runner, tmp_xdg_home, mock_keyring, monkeypatch

--- a/cli/tests/test_analysis.py
+++ b/cli/tests/test_analysis.py
@@ -102,6 +102,18 @@ class TestRequestBuilders:
         with pytest.raises(ValueError, match="not a valid id"):
             build_preview_request("clip", mask_dataset_id="not-a-uuid")
 
+    @pytest.mark.parametrize("bad", [float("nan"), float("inf"), float("-inf")])
+    def test_a_non_finite_distance_is_rejected_before_serialization(
+        self, bad: float
+    ) -> None:
+        """fix(#685 review): Click parses nan/inf/1e309 into real floats, and
+        JSON cannot spell any of them — the failure would otherwise surface
+        from inside the SDK's encoder."""
+        from geolens_cli.analysis import build_preview_request
+
+        with pytest.raises(ValueError, match="finite"):
+            build_preview_request("buffer", distance_meters=bad)
+
 
 # ---------------------------------------------------------------------------
 # Preview rendering
@@ -453,6 +465,40 @@ class TestAnalysisMaterializeCli:
         )
         assert result.exit_code == 0, result.output
         assert seen["timeout"] == 30.0
+
+    def test_a_non_finite_timeout_is_a_usage_error(
+        self, runner, tmp_xdg_home, mock_keyring, monkeypatch
+    ) -> None:
+        """fix(#685 review): --timeout inf parses fine and would turn an
+        explicitly bounded wait into an unbounded one."""
+        from geolens_cli.main import app
+
+        _seed_login("https://x.example.com/api", mock_keyring)
+
+        def _must_not_poll(*args, **kwargs):  # pragma: no cover - failure path
+            raise AssertionError("--timeout inf must not start an unbounded poll")
+
+        monkeypatch.setattr(
+            "geolens_cli.analysis.run_materialize", lambda c, d, r: _FakeJob()
+        )
+        monkeypatch.setattr("geolens_cli.publish.resolve_dataset_id", _must_not_poll)
+
+        result = runner.invoke(
+            app,
+            [
+                "analysis",
+                "materialize",
+                "ds-1",
+                "--operation",
+                "centroid",
+                "--title",
+                "Centroids",
+                "--timeout",
+                "inf",
+            ],
+        )
+        assert result.exit_code == 2, result.output
+        assert "finite" in result.output
 
     def test_a_zero_timeout_is_a_usage_error_not_an_endless_wait(
         self, runner, tmp_xdg_home, mock_keyring, monkeypatch

--- a/cli/tests/test_analysis.py
+++ b/cli/tests/test_analysis.py
@@ -310,7 +310,9 @@ class TestAnalysisMaterializeCli:
         monkeypatch.setattr(
             "geolens_cli.publish.resolve_dataset_id", lambda c, j, **kw: None
         )
-        monkeypatch.setattr("geolens_cli.analysis.job_status", lambda c, j: "failed")
+        monkeypatch.setattr(
+            "geolens_cli.analysis.job_snapshot", lambda c, j: ("failed", None)
+        )
 
         result = runner.invoke(
             app,
@@ -343,7 +345,9 @@ class TestAnalysisMaterializeCli:
         monkeypatch.setattr(
             "geolens_cli.publish.resolve_dataset_id", lambda c, j, **kw: None
         )
-        monkeypatch.setattr("geolens_cli.analysis.job_status", lambda c, j: "running")
+        monkeypatch.setattr(
+            "geolens_cli.analysis.job_snapshot", lambda c, j: ("running", None)
+        )
 
         result = runner.invoke(
             app,
@@ -364,6 +368,43 @@ class TestAnalysisMaterializeCli:
         assert "has not finished" in result.output
         assert "failed" not in result.output
 
+    def test_a_job_that_finishes_during_the_final_read_is_a_success(
+        self, runner, tmp_xdg_home, mock_keyring, monkeypatch
+    ) -> None:
+        """fix(#685 review): the job can finish between the poll's last look
+        and the status re-read, and that response carries the dataset id.
+        Reporting it as unfinished would be the worst of the three answers."""
+        from geolens_cli.main import app
+
+        _seed_login("https://x.example.com/api", mock_keyring)
+        monkeypatch.setattr(
+            "geolens_cli.analysis.run_materialize", lambda c, d, r: _FakeJob()
+        )
+        monkeypatch.setattr(
+            "geolens_cli.publish.resolve_dataset_id", lambda c, j, **kw: None
+        )
+        monkeypatch.setattr(
+            "geolens_cli.analysis.job_snapshot",
+            lambda c, j: ("complete", "ds-late"),
+        )
+
+        result = runner.invoke(
+            app,
+            [
+                "analysis",
+                "materialize",
+                "ds-1",
+                "--operation",
+                "centroid",
+                "--title",
+                "Centroids",
+                "--timeout",
+                "30",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        assert "/datasets/ds-late" in result.output
+
     def test_an_unreadable_status_is_not_reported_as_a_timeout(
         self, runner, tmp_xdg_home, mock_keyring, monkeypatch
     ) -> None:
@@ -379,7 +420,9 @@ class TestAnalysisMaterializeCli:
         monkeypatch.setattr(
             "geolens_cli.publish.resolve_dataset_id", lambda c, j, **kw: None
         )
-        monkeypatch.setattr("geolens_cli.analysis.job_status", lambda c, j: None)
+        monkeypatch.setattr(
+            "geolens_cli.analysis.job_snapshot", lambda c, j: (None, None)
+        )
 
         result = runner.invoke(
             app,

--- a/cli/tests/test_analysis.py
+++ b/cli/tests/test_analysis.py
@@ -1,0 +1,304 @@
+"""feat(#685): `geolens analysis preview` / `materialize` with a mocked SDK.
+
+Hand-maintained — NOT regenerated. Covers the request builders (which params
+are sent and which stay UNSET), the preview renderer and its truncation
+notice, and both command bodies wired into main.py.
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+
+SAMPLE_GEOJSON: dict = {
+    "type": "FeatureCollection",
+    "features": [
+        {
+            "type": "Feature",
+            "geometry": {"type": "Point", "coordinates": [0, 0]},
+            "properties": {"gid": 1},
+        }
+    ],
+}
+
+
+class _FakeGeoJson:
+    """Stands in for the generated attrs model, which exposes to_dict()."""
+
+    def to_dict(self) -> dict:
+        return SAMPLE_GEOJSON
+
+
+class _FakePreview:
+    def __init__(self, *, truncated=False, feature_count=1, source_feature_count=None):
+        self.geojson = _FakeGeoJson()
+        self.truncated = truncated
+        self.feature_count = feature_count
+        self.source_feature_count = source_feature_count
+
+
+class _FakeJob:
+    def __init__(self, job_id="job-1"):
+        self.job_id = job_id
+        self.status = "pending"
+
+
+def _seed_login(instance: str, mock_keyring: dict) -> None:
+    from geolens_cli import config as _config
+
+    mock_keyring[("geolens", instance)] = "tok-abc"
+    _config.write_default_instance(instance, username="alice")
+
+
+# ---------------------------------------------------------------------------
+# Request builders
+# ---------------------------------------------------------------------------
+
+
+class TestRequestBuilders:
+    def test_buffer_preview_sends_only_the_distance(self) -> None:
+        from geolens_cli.analysis import build_preview_request
+
+        body = build_preview_request("buffer", distance_meters=500).to_dict()
+        assert body == {"operation": "buffer", "distance_meters": 500}
+
+    def test_clip_preview_sends_the_mask_dataset_as_a_uuid(self) -> None:
+        from geolens_cli.analysis import build_preview_request
+
+        mask = "6d4c1b1e-2f3a-4d5b-8c7e-9a0b1c2d3e4f"
+        body = build_preview_request("clip", mask_dataset_id=mask).to_dict()
+        assert body == {"operation": "clip", "mask_dataset_id": mask}
+
+    def test_centroid_preview_sends_nothing_but_the_operation(self) -> None:
+        from geolens_cli.analysis import build_preview_request
+
+        assert build_preview_request("centroid").to_dict() == {"operation": "centroid"}
+
+    def test_dissolve_materialize_sends_the_group_column(self) -> None:
+        from geolens_cli.analysis import build_materialize_request
+
+        body = build_materialize_request(
+            "dissolve", "Counties", by_field="state"
+        ).to_dict()
+        assert body == {
+            "operation": "dissolve",
+            "title": "Counties",
+            "by_field": "state",
+        }
+
+    def test_an_unknown_operation_is_passed_through_untouched(self) -> None:
+        """The SDK's generated enum is the authority (#685). A CLI-side list
+        would have to be updated for every new backend operation, and would
+        reject one the server already supports."""
+        from geolens_cli.analysis import build_preview_request
+
+        body = build_preview_request("spatial_join").to_dict()
+        assert body["operation"] == "spatial_join"
+
+    def test_a_malformed_mask_dataset_id_is_rejected_before_the_request(self) -> None:
+        from geolens_cli.analysis import build_preview_request
+
+        with pytest.raises(ValueError, match="not a valid id"):
+            build_preview_request("clip", mask_dataset_id="not-a-uuid")
+
+
+# ---------------------------------------------------------------------------
+# Preview rendering
+# ---------------------------------------------------------------------------
+
+
+class TestPreviewRendering:
+    def test_geojson_is_unwrapped_from_the_response_envelope(self) -> None:
+        from geolens_cli.analysis import preview_geojson
+
+        assert preview_geojson(_FakePreview()) == SAMPLE_GEOJSON
+
+    def test_an_empty_response_still_renders_a_feature_collection(self) -> None:
+        from geolens_cli.analysis import preview_geojson
+
+        empty = _FakePreview()
+        empty.geojson = None
+        assert preview_geojson(empty) == {"type": "FeatureCollection", "features": []}
+
+    def test_no_warning_for_a_complete_preview(self) -> None:
+        from geolens_cli.analysis import truncation_warning
+
+        assert truncation_warning(_FakePreview()) is None
+
+    def test_a_capped_preview_names_both_numbers(self) -> None:
+        from geolens_cli.analysis import truncation_warning
+
+        message = truncation_warning(
+            _FakePreview(truncated=True, feature_count=500, source_feature_count=22324)
+        )
+        assert "500 of 22324" in message
+
+    def test_a_capped_preview_without_a_total_still_warns(self) -> None:
+        from geolens_cli.analysis import truncation_warning
+
+        message = truncation_warning(_FakePreview(truncated=True, feature_count=500))
+        assert "500" in message
+
+
+# ---------------------------------------------------------------------------
+# CLI command bodies
+# ---------------------------------------------------------------------------
+
+
+class TestAnalysisPreviewCli:
+    def test_geojson_goes_to_stdout(
+        self, runner, tmp_xdg_home, mock_keyring, monkeypatch
+    ) -> None:
+        from geolens_cli.main import app
+
+        _seed_login("https://x.example.com", mock_keyring)
+        monkeypatch.setattr(
+            "geolens_cli.analysis.run_preview", lambda c, d, r: _FakePreview()
+        )
+
+        result = runner.invoke(
+            app,
+            ["analysis", "preview", "ds-1", "--operation", "buffer", "--distance", "500"],
+        )
+        assert result.exit_code == 0, result.output
+        assert json.loads(result.output)["type"] == "FeatureCollection"
+
+    def test_stdout_stays_parseable_when_the_preview_is_capped(
+        self, runner, tmp_xdg_home, mock_keyring, monkeypatch
+    ) -> None:
+        """The cap notice is stderr-only: a caller redirecting stdout into a
+        .geojson file must not get a sentence in the middle of it."""
+        from geolens_cli.main import app
+
+        _seed_login("https://x.example.com", mock_keyring)
+        monkeypatch.setattr(
+            "geolens_cli.analysis.run_preview",
+            lambda c, d, r: _FakePreview(
+                truncated=True, feature_count=500, source_feature_count=22324
+            ),
+        )
+
+        result = runner.invoke(
+            app,
+            ["--quiet", "analysis", "preview", "ds-1", "--operation", "centroid"],
+        )
+        assert result.exit_code == 0, result.output
+        assert json.loads(result.output)["type"] == "FeatureCollection"
+
+    def test_a_malformed_mask_dataset_exits_2(
+        self, runner, tmp_xdg_home, mock_keyring, monkeypatch
+    ) -> None:
+        from geolens_cli.main import app
+
+        _seed_login("https://x.example.com", mock_keyring)
+
+        result = runner.invoke(
+            app,
+            [
+                "analysis",
+                "preview",
+                "ds-1",
+                "--operation",
+                "clip",
+                "--mask-dataset",
+                "nope",
+            ],
+        )
+        assert result.exit_code == 2, result.output
+
+
+class TestAnalysisMaterializeCli:
+    def test_wait_resolves_the_dataset_url(
+        self, runner, tmp_xdg_home, mock_keyring, monkeypatch
+    ) -> None:
+        from geolens_cli.main import app
+
+        _seed_login("https://x.example.com/api", mock_keyring)
+        monkeypatch.setattr(
+            "geolens_cli.analysis.run_materialize", lambda c, d, r: _FakeJob()
+        )
+        monkeypatch.setattr(
+            "geolens_cli.publish.resolve_dataset_id", lambda c, j, **kw: "ds-new"
+        )
+
+        result = runner.invoke(
+            app,
+            [
+                "analysis",
+                "materialize",
+                "ds-1",
+                "--operation",
+                "buffer",
+                "--distance",
+                "500",
+                "--title",
+                "Buffered lakes",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        assert "/datasets/ds-new" in result.output
+
+    def test_no_wait_returns_the_job_form_without_polling(
+        self, runner, tmp_xdg_home, mock_keyring, monkeypatch
+    ) -> None:
+        from geolens_cli.main import app
+
+        _seed_login("https://x.example.com/api", mock_keyring)
+        monkeypatch.setattr(
+            "geolens_cli.analysis.run_materialize", lambda c, d, r: _FakeJob()
+        )
+
+        def _must_not_poll(*args, **kwargs):  # pragma: no cover - failure path
+            raise AssertionError("--no-wait must not poll the job endpoint")
+
+        monkeypatch.setattr("geolens_cli.publish.resolve_dataset_id", _must_not_poll)
+
+        result = runner.invoke(
+            app,
+            [
+                "analysis",
+                "materialize",
+                "ds-1",
+                "--operation",
+                "centroid",
+                "--title",
+                "Centroids",
+                "--no-wait",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        assert "job_id=job-1" in result.output
+
+    def test_json_mode_emits_the_job_and_dataset_ids(
+        self, runner, tmp_xdg_home, mock_keyring, monkeypatch
+    ) -> None:
+        from geolens_cli.main import app
+
+        _seed_login("https://x.example.com/api", mock_keyring)
+        monkeypatch.setattr(
+            "geolens_cli.analysis.run_materialize", lambda c, d, r: _FakeJob()
+        )
+        monkeypatch.setattr(
+            "geolens_cli.publish.resolve_dataset_id", lambda c, j, **kw: "ds-new"
+        )
+
+        result = runner.invoke(
+            app,
+            [
+                "--json",
+                "analysis",
+                "materialize",
+                "ds-1",
+                "--operation",
+                "buffer",
+                "--distance",
+                "500",
+                "--title",
+                "Buffered lakes",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.output)
+        assert payload["job_id"] == "job-1"
+        assert payload["dataset_id"] == "ds-new"

--- a/cli/tests/test_analysis.py
+++ b/cli/tests/test_analysis.py
@@ -333,17 +333,50 @@ class TestAnalysisMaterializeCli:
             ],
         )
         assert result.exit_code == 1, result.output
-        assert "may still be running" in result.output
+        assert "still running" in result.output
         assert "failed" not in result.output
+
+    def test_an_unreadable_status_is_not_reported_as_a_timeout(
+        self, runner, tmp_xdg_home, mock_keyring, monkeypatch
+    ) -> None:
+        """fix(#685 review): a 401/404/5xx on GET /jobs/{id} also yields None
+        from the poll. Claiming the job outlived the wait asserts something
+        that was never established."""
+        from geolens_cli.main import app
+
+        _seed_login("https://x.example.com/api", mock_keyring)
+        monkeypatch.setattr(
+            "geolens_cli.analysis.run_materialize", lambda c, d, r: _FakeJob()
+        )
+        monkeypatch.setattr(
+            "geolens_cli.publish.resolve_dataset_id", lambda c, j, **kw: None
+        )
+        monkeypatch.setattr("geolens_cli.analysis.job_status", lambda c, j: None)
+
+        result = runner.invoke(
+            app,
+            [
+                "analysis",
+                "materialize",
+                "ds-1",
+                "--operation",
+                "centroid",
+                "--title",
+                "Centroids",
+            ],
+        )
+        assert result.exit_code == 1, result.output
+        assert "outcome is unknown" in result.output
 
     def test_the_poll_waits_longer_than_the_server_side_budget(
         self, runner, tmp_xdg_home, mock_keyring, monkeypatch
     ) -> None:
-        """publish's 120s default is shorter than MATERIALIZE_TIMEOUT (300s)."""
+        """The wait is bounded by the server's stale-job sweep, not by a guess
+        at how long the work takes: the queue #703 imposes is unbounded."""
         from geolens_cli.analysis import POLL_TIMEOUT_SECONDS
         from geolens_cli.main import app
 
-        assert POLL_TIMEOUT_SECONDS > 300
+        assert POLL_TIMEOUT_SECONDS >= 3600
 
         seen: dict = {}
 

--- a/cli/tests/test_analysis.py
+++ b/cli/tests/test_analysis.py
@@ -466,6 +466,50 @@ class TestAnalysisMaterializeCli:
         assert result.exit_code == 0, result.output
         assert seen["timeout"] == 30.0
 
+    def test_an_explicit_timeout_also_bounds_each_request(
+        self, runner, tmp_xdg_home, mock_keyring, monkeypatch
+    ) -> None:
+        """fix(#685 review): the poll deadline is only checked between
+        iterations, and the SDK builds its httpx client with no request
+        timeout at all, so a stalled response would outlive --timeout."""
+        from geolens_cli.main import app
+
+        bounded: dict = {}
+
+        class _Bounded:
+            def with_timeout(self, value):  # pragma: no cover - trivial
+                bounded["value"] = value
+                return self
+
+        _seed_login("https://x.example.com/api", mock_keyring)
+        monkeypatch.setattr(
+            "geolens_cli.main.AppState.sdk",
+            lambda self: type("S", (), {"client": _Bounded()})(),
+        )
+        monkeypatch.setattr(
+            "geolens_cli.analysis.run_materialize", lambda c, d, r: _FakeJob()
+        )
+        monkeypatch.setattr(
+            "geolens_cli.publish.resolve_dataset_id", lambda c, j, **kw: "ds-new"
+        )
+
+        result = runner.invoke(
+            app,
+            [
+                "analysis",
+                "materialize",
+                "ds-1",
+                "--operation",
+                "centroid",
+                "--title",
+                "Centroids",
+                "--timeout",
+                "30",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        assert bounded["value"] == 30.0
+
     def test_a_non_finite_timeout_is_a_usage_error(
         self, runner, tmp_xdg_home, mock_keyring, monkeypatch
     ) -> None:

--- a/cli/tests/test_analysis.py
+++ b/cli/tests/test_analysis.py
@@ -208,6 +208,19 @@ class TestAnalysisPreviewCli:
         assert result.exit_code == 2, result.output
 
 
+    def test_no_instance_exits_with_the_auth_code(
+        self, runner, tmp_xdg_home, mock_keyring
+    ) -> None:
+        """fix(#685 review): materialize maps this to EXIT_AUTH; preview let
+        state.sdk() raise BadParameter and exited 2 for the same condition."""
+        from geolens_cli.main import app
+
+        result = runner.invoke(
+            app, ["analysis", "preview", "ds-1", "--operation", "centroid"]
+        )
+        assert result.exit_code == 3, result.output
+
+
 class TestAnalysisMaterializeCli:
     def test_wait_resolves_the_dataset_url(
         self, runner, tmp_xdg_home, mock_keyring, monkeypatch
@@ -440,6 +453,40 @@ class TestAnalysisMaterializeCli:
         )
         assert result.exit_code == 0, result.output
         assert seen["timeout"] == 30.0
+
+    def test_a_zero_timeout_is_a_usage_error_not_an_endless_wait(
+        self, runner, tmp_xdg_home, mock_keyring, monkeypatch
+    ) -> None:
+        """fix(#685 review): `timeout or POLL_FOREVER` read an explicit 0 as
+        "no bound", which is the opposite of what it asks for."""
+        from geolens_cli.main import app
+
+        _seed_login("https://x.example.com/api", mock_keyring)
+
+        def _must_not_poll(*args, **kwargs):  # pragma: no cover - failure path
+            raise AssertionError("--timeout 0 must not start an unbounded poll")
+
+        monkeypatch.setattr(
+            "geolens_cli.analysis.run_materialize", lambda c, d, r: _FakeJob()
+        )
+        monkeypatch.setattr("geolens_cli.publish.resolve_dataset_id", _must_not_poll)
+
+        result = runner.invoke(
+            app,
+            [
+                "analysis",
+                "materialize",
+                "ds-1",
+                "--operation",
+                "centroid",
+                "--title",
+                "Centroids",
+                "--timeout",
+                "0",
+            ],
+        )
+        assert result.exit_code == 2, result.output
+        assert "--no-wait" in result.output
 
     def test_json_mode_emits_the_job_and_dataset_ids(
         self, runner, tmp_xdg_home, mock_keyring, monkeypatch

--- a/cli/tests/test_analysis.py
+++ b/cli/tests/test_analysis.py
@@ -330,10 +330,13 @@ class TestAnalysisMaterializeCli:
                 "centroid",
                 "--title",
                 "Centroids",
+                "--timeout",
+                "30",
             ],
         )
         assert result.exit_code == 1, result.output
         assert "still running" in result.output
+        assert "has not finished" in result.output
         assert "failed" not in result.output
 
     def test_an_unreadable_status_is_not_reported_as_a_timeout(
@@ -368,15 +371,14 @@ class TestAnalysisMaterializeCli:
         assert result.exit_code == 1, result.output
         assert "outcome is unknown" in result.output
 
-    def test_the_poll_waits_longer_than_the_server_side_budget(
+    def test_the_default_wait_has_no_deadline(
         self, runner, tmp_xdg_home, mock_keyring, monkeypatch
     ) -> None:
-        """The wait is bounded by the server's stale-job sweep, not by a guess
-        at how long the work takes: the queue #703 imposes is unbounded."""
-        from geolens_cli.analysis import POLL_TIMEOUT_SECONDS
+        """The queue #703 imposes is unbounded, and the server refuses to fail
+        a job that is merely waiting in it, so any fixed deadline here would
+        report a job the server is still going to finish as producing
+        nothing."""
         from geolens_cli.main import app
-
-        assert POLL_TIMEOUT_SECONDS >= 3600
 
         seen: dict = {}
 
@@ -403,7 +405,41 @@ class TestAnalysisMaterializeCli:
             ],
         )
         assert result.exit_code == 0, result.output
-        assert seen["timeout"] == POLL_TIMEOUT_SECONDS
+        assert seen["timeout"] == float("inf")
+
+    def test_an_explicit_timeout_bounds_the_wait(
+        self, runner, tmp_xdg_home, mock_keyring, monkeypatch
+    ) -> None:
+        from geolens_cli.main import app
+
+        seen: dict = {}
+
+        def _capture(client, job_id, **kwargs):
+            seen.update(kwargs)
+            return "ds-new"
+
+        _seed_login("https://x.example.com/api", mock_keyring)
+        monkeypatch.setattr(
+            "geolens_cli.analysis.run_materialize", lambda c, d, r: _FakeJob()
+        )
+        monkeypatch.setattr("geolens_cli.publish.resolve_dataset_id", _capture)
+
+        result = runner.invoke(
+            app,
+            [
+                "analysis",
+                "materialize",
+                "ds-1",
+                "--operation",
+                "centroid",
+                "--title",
+                "Centroids",
+                "--timeout",
+                "30",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        assert seen["timeout"] == 30.0
 
     def test_json_mode_emits_the_job_and_dataset_ids(
         self, runner, tmp_xdg_home, mock_keyring, monkeypatch

--- a/cli/tests/test_analysis.py
+++ b/cli/tests/test_analysis.py
@@ -239,7 +239,7 @@ class TestAnalysisMaterializeCli:
         assert result.exit_code == 0, result.output
         assert "/datasets/ds-new" in result.output
 
-    def test_no_wait_returns_the_job_form_without_polling(
+    def test_no_wait_reports_the_job_id_without_polling(
         self, runner, tmp_xdg_home, mock_keyring, monkeypatch
     ) -> None:
         from geolens_cli.main import app
@@ -268,7 +268,38 @@ class TestAnalysisMaterializeCli:
             ],
         )
         assert result.exit_code == 0, result.output
-        assert "job_id=job-1" in result.output
+        assert "job-1" in result.output
+
+    def test_a_job_that_produces_no_dataset_exits_non_zero(
+        self, runner, tmp_xdg_home, mock_keyring, monkeypatch
+    ) -> None:
+        """fix(#685 review): resolve_dataset_id returns None for a FAILED job
+        as well as a timeout. Exiting 0 there would tell a script the analysis
+        succeeded."""
+        from geolens_cli.main import app
+
+        _seed_login("https://x.example.com/api", mock_keyring)
+        monkeypatch.setattr(
+            "geolens_cli.analysis.run_materialize", lambda c, d, r: _FakeJob()
+        )
+        monkeypatch.setattr(
+            "geolens_cli.publish.resolve_dataset_id", lambda c, j, **kw: None
+        )
+
+        result = runner.invoke(
+            app,
+            [
+                "analysis",
+                "materialize",
+                "ds-1",
+                "--operation",
+                "centroid",
+                "--title",
+                "Centroids",
+            ],
+        )
+        assert result.exit_code == 1, result.output
+        assert "job-1" in result.output
 
     def test_json_mode_emits_the_job_and_dataset_ids(
         self, runner, tmp_xdg_home, mock_keyring, monkeypatch


### PR DESCRIPTION
Scripting users had to drop to the generated SDK to run an analysis operation. Two commands close that, against the four shipped operations.

```
geolens analysis preview <dataset-id> --operation buffer --distance 500 > ring.geojson
geolens analysis materialize <dataset-id> --operation buffer --distance 500 --title "500 m ring"
```

`preview` prints the FeatureCollection on stdout with the same JSON contract `export stac` uses (pretty and sorted by default, `--compact` for piping into jq). A capped preview announces itself on stderr, not in the middle of the document, so the redirect above stays a valid `.geojson` file.

`materialize` queues the job and, with `--wait` (the default), polls it through the same `resolve_dataset_id` helper `geolens publish` uses, printing the new dataset's URL. `--no-wait` returns the job-search URL form. `--json` emits `{job_id, dataset_id, url}`.

Options are the ones the API takes: `--distance` in metres (buffer), `--mask-dataset` (clip), `--by-field` (dissolve), `--title` (materialize).

## The operation list lives in the SDK, not here

`--operation` is a plain string handed to the SDK unchanged. A `Literal` in the CLI would have to be updated for every new backend operation, and in the meantime would reject one the server already supports. The generated enum is the authority, so #953 through #956 each reach the CLI with the `make sdks` in their own PR. A malformed `--mask-dataset` is still rejected locally with exit 2, since that is a client-side parse rather than a server rule.

No API, schema, or security impact. No SDK regeneration: both endpoints were already generated.

Closes #685.

## Verification

```
cd cli && uv run --extra dev python -m pytest -q     # 253 passed (17 new)
uv run --extra dev ruff check geolens_cli/analysis.py tests/test_analysis.py
grep -rE '^(import|from) (httpx|requests)' geolens_cli/   # OCCLI-06: no hits
```

17 new tests cover the request builders (which params are sent, which stay UNSET, and that an unknown operation passes through), the GeoJSON unwrapping and truncation notice, and both command bodies including the `--no-wait` path asserting it never polls.