### PR TITLE
ci: make merge_group runs execute the gates before the queue is enabled

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,23 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  # fix(#1000): merge-queue runs. All three required contexts (Detect Changes,
+  # Pre-commit, CI OK) come from this workflow, so the queue cannot validate a
+  # candidate merge commit without it.
+  #
+  # Adding this line is the easy half. The job conditionals below are the
+  # reason the queue must NOT be enabled before they are fixed: 12 of them
+  # were gated on `needs.changes.outputs.X == 'true' || github.event_name ==
+  # 'push'`, and a merge_group event matches neither `push` nor
+  # `pull_request`, so every one of them would skip — while `ci-ok` counts a
+  # skip as a pass (correct for a path-filtered PR, catastrophic here). The
+  # queue would have reported green having tested nothing.
+  #
+  # A queue run validates a candidate merge commit against main the same way a
+  # push run validates the merged result, so both want the full matrix rather
+  # than a path-filtered subset. Every gated job below therefore reads
+  # `|| github.event_name == 'merge_group'` alongside its push clause.
+  merge_group:
   # Nightly full-matrix E2E: the e2e-test job below runs ONLY on `schedule`/
   # `workflow_dispatch` (it stays skipped on push/PR). PRs that can affect the
   # stack run the small e2e-smoke job instead (fix #825), so this cron remains
@@ -17,6 +34,14 @@ concurrency:
   # Include the event name so daily dependabot pushes stop cancelling the
   # scheduled run — every nightly for a week was cancelled this way, which is
   # how the e2e suite silently rotted (v1.6.0 audit N2 family).
+  #
+  # fix(#1000), checked rather than changed: this shape is already safe for the
+  # merge queue. Each queue entry runs on its own `gh-readonly-queue/main/pr-N-<sha>`
+  # ref, so `github.ref` alone puts every entry in a distinct group — two
+  # batches in flight cannot cancel each other, and a queue run and the PR run
+  # it came from differ in both ref and event name. `cancel-in-progress` stays
+  # true because the only thing that can now share a group is a re-run of the
+  # same queue entry.
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
   cancel-in-progress: true
 
@@ -44,6 +69,16 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
       - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706  # v4
         id: filter
+        # fix(#1000): the filter has nothing to diff against on merge_group and
+        # nothing to say either way. Git-diff detection (see the token note
+        # below) resolves its base from pull-request context or a push's
+        # before-SHA, and a `gh-readonly-queue/*` branch supplies neither. Every
+        # gated job below ORs in `merge_group` and so ignores these outputs
+        # there, which leaves one requirement: this job, a REQUIRED context,
+        # must still succeed. Skipping the step is how it does — the outputs
+        # come out empty, which is exactly as meaningful as anything the filter
+        # could have produced without a base.
+        if: github.event_name != 'merge_group'
         with:
           # fix(#546): empty token switches paths-filter to git-diff detection
           # (base.sha..merge-commit from the checkout), removing the GitHub API
@@ -224,7 +259,7 @@ jobs:
   backend-lint:
     name: Backend Lint
     needs: changes
-    if: needs.changes.outputs.backend == 'true' || github.event_name == 'push'
+    if: needs.changes.outputs.backend == 'true' || github.event_name == 'push' || github.event_name == 'merge_group'
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -316,7 +351,7 @@ jobs:
   installer-test:
     name: Installer Tag Resolution
     needs: changes
-    if: needs.changes.outputs.installer == 'true' || github.event_name == 'push'
+    if: needs.changes.outputs.installer == 'true' || github.event_name == 'push' || github.event_name == 'merge_group'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
@@ -375,7 +410,7 @@ jobs:
   backup-roundtrip:
     name: Backup Restore Round-trip
     needs: changes
-    if: needs.changes.outputs.backup == 'true' || github.event_name == 'push'
+    if: needs.changes.outputs.backup == 'true' || github.event_name == 'push' || github.event_name == 'merge_group'
     runs-on: ubuntu-latest
     env:
       PGHOST: localhost
@@ -634,7 +669,7 @@ jobs:
   openapi-snapshot:
     name: OpenAPI Snapshot Drift
     needs: changes
-    if: needs.changes.outputs.backend == 'true' || needs.changes.outputs.sdks == 'true' || github.event_name == 'push'
+    if: needs.changes.outputs.backend == 'true' || needs.changes.outputs.sdks == 'true' || github.event_name == 'push' || github.event_name == 'merge_group'
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -670,7 +705,7 @@ jobs:
   sdks-check:
     name: SDKs Drift Gate
     needs: changes
-    if: needs.changes.outputs.backend == 'true' || needs.changes.outputs.sdks == 'true' || github.event_name == 'push'
+    if: needs.changes.outputs.backend == 'true' || needs.changes.outputs.sdks == 'true' || github.event_name == 'push' || github.event_name == 'merge_group'
     runs-on: ubuntu-latest
     env:
       # Match the OpenAPI snapshot job's env so dump_openapi.py runs
@@ -770,7 +805,7 @@ jobs:
   cli-test:
     name: CLI Tests
     needs: changes
-    if: needs.changes.outputs.cli == 'true' || needs.changes.outputs.backend == 'true' || github.event_name == 'push'
+    if: needs.changes.outputs.cli == 'true' || needs.changes.outputs.backend == 'true' || github.event_name == 'push' || github.event_name == 'merge_group'
     runs-on: ubuntu-latest
     env:
       # CLI round-trip tests import the FastAPI app and exercise DB-backed
@@ -894,7 +929,7 @@ jobs:
   mcp-test:
     name: MCP Server Tests
     needs: changes
-    if: needs.changes.outputs.mcp == 'true' || github.event_name == 'push'
+    if: needs.changes.outputs.mcp == 'true' || github.event_name == 'push' || github.event_name == 'merge_group'
     runs-on: ubuntu-latest
     # Compose boot + image build for the live tier need headroom on a shared
     # runner; the e2e-smoke job uses the same budget for a larger stack.
@@ -963,7 +998,7 @@ jobs:
     needs: changes
     # Alembic-only changes must run the suite too — this condition absorbed the
     # deleted pytest-parallel-isolation job's trigger when that job folded in.
-    if: needs.changes.outputs.backend == 'true' || needs.changes.outputs.alembic == 'true' || github.event_name == 'push'
+    if: needs.changes.outputs.backend == 'true' || needs.changes.outputs.alembic == 'true' || github.event_name == 'push' || github.event_name == 'merge_group'
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -1141,7 +1176,7 @@ jobs:
   alembic-clean-db:
     name: Alembic Clean-DB Upgrade
     needs: changes
-    if: needs.changes.outputs.alembic == 'true' || github.event_name == 'push'
+    if: needs.changes.outputs.alembic == 'true' || github.event_name == 'push' || github.event_name == 'merge_group'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -1173,7 +1208,7 @@ jobs:
   frontend-lint:
     name: Frontend Lint & Typecheck
     needs: changes
-    if: needs.changes.outputs.frontend == 'true' || github.event_name == 'push'
+    if: needs.changes.outputs.frontend == 'true' || github.event_name == 'push' || github.event_name == 'merge_group'
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -1234,7 +1269,7 @@ jobs:
   frontend-test:
     name: Frontend Tests
     needs: changes
-    if: needs.changes.outputs.frontend == 'true' || github.event_name == 'push'
+    if: needs.changes.outputs.frontend == 'true' || github.event_name == 'push' || github.event_name == 'merge_group'
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -1315,7 +1350,7 @@ jobs:
   security-scan:
     name: Security Scan
     needs: changes
-    if: needs.changes.outputs.backend == 'true' || github.event_name == 'push'
+    if: needs.changes.outputs.backend == 'true' || github.event_name == 'push' || github.event_name == 'merge_group'
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -1348,6 +1383,20 @@ jobs:
   # This job always runs and inspects each needed job's actual result: failure
   # or cancelled fails it; skipped and success pass. Branch protection should
   # require THIS single context instead of the individual skippable jobs.
+  #
+  # fix(#1000): "skipped counts as pass" is right for a path-filtered PR and
+  # would be a hole in the merge queue, where a skip means "never ran against
+  # this candidate merge". It is not fixed HERE — the rule stays as it is —
+  # because the honest fix is upstream: every job in this list now actually
+  # RUNS on merge_group, so there is nothing to mis-credit. If you add a job to
+  # this aggregator, give it a merge_group clause too, or you have quietly
+  # reopened the hole.
+  #
+  # The non-gating jobs (runtime-extension-image-probe, accessibility,
+  # stac-validate, e2e-test, ai-evals) deliberately stay off merge_group. They
+  # are not in this list, so they gate nothing there and would only spend
+  # Actions minutes; the push-triggered ones still run when the batch lands on
+  # main, which is the same coverage they have today.
   ci-ok:
     name: CI OK
     needs:
@@ -1598,7 +1647,15 @@ jobs:
   e2e-smoke:
     name: E2E Smoke (core)
     needs: changes
-    if: github.event_name == 'pull_request' && needs.changes.outputs.e2e == 'true'
+    # fix(#1000): unconditional on merge_group — no path filter, because there
+    # is no reliable one there (see the `changes` job) and because the queue is
+    # the last gate before main. It is also the one job in `ci-ok` whose whole
+    # purpose is catching what a COMBINATION breaks: two PRs can each leave the
+    # core flows green alone and break one together, which is the failure a
+    # merge queue exists to stop.
+    if: >-
+      (github.event_name == 'pull_request' && needs.changes.outputs.e2e == 'true')
+      || github.event_name == 'merge_group'
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:

--- a/backend/tests/test_ci_merge_queue.py
+++ b/backend/tests/test_ci_merge_queue.py
@@ -98,8 +98,12 @@ def test_changes_job_does_not_pretend_to_have_filtered_the_queue():
     steps = _workflow()["jobs"]["changes"]["steps"]
     filter_steps = [s for s in steps if "paths-filter" in str(s.get("uses", ""))]
     assert len(filter_steps) == 1, "expected exactly one paths-filter step"
-    assert "merge_group" in str(filter_steps[0].get("if", "")), (
+    condition = " ".join(str(filter_steps[0].get("if", "")).split())
+    # fix(#1000 review): the NEGATIVE form specifically. A substring test for
+    # "merge_group" would keep passing if the condition were inverted to
+    # `== 'merge_group'`, i.e. if the step ran on exactly the event this test
+    # exists to exclude.
+    assert condition == "github.event_name != 'merge_group'", (
         "the paths-filter step must be skipped on merge_group; with no base to "
-        "diff against its outputs cannot be trusted, and a failure there fails "
-        "a required check"
+        f"diff against its outputs cannot be trusted. Found: {condition!r}"
     )

--- a/backend/tests/test_ci_merge_queue.py
+++ b/backend/tests/test_ci_merge_queue.py
@@ -1,0 +1,105 @@
+"""fix(#1000): a merge-queue run must actually run the gates it reports on.
+
+`ci-ok` counts a SKIPPED dependency as a pass. That is right for a
+path-filtered pull request and wrong in the merge queue, where a skip means
+"never ran against this candidate merge". Twelve jobs were gated on
+``needs.changes.outputs.X == 'true' || github.event_name == 'push'``, and a
+``merge_group`` event matches neither ``push`` nor ``pull_request``, so
+enabling the queue without touching those conditionals would have produced a
+green `CI OK` on a run that tested nothing.
+
+The fix is that every job feeding `ci-ok` runs on ``merge_group``. That is an
+invariant about a YAML file, which nothing enforces, so it is asserted here:
+add a job to the aggregator without a ``merge_group`` clause and this fails
+instead of silently reopening the hole after the queue is switched on.
+
+Deliberately NOT asserted: that the queue is enabled. That is a
+repository-admin setting, not a file in this repo.
+"""
+
+import pathlib
+
+import pytest
+import yaml
+
+CI = pathlib.Path(__file__).resolve().parents[2] / ".github" / "workflows" / "ci.yml"
+
+
+def _workflow() -> dict:
+    return yaml.safe_load(CI.read_text())
+
+
+def _triggers(wf: dict) -> dict:
+    # PyYAML resolves a bare `on:` key to the boolean True (YAML 1.1), so read
+    # both spellings rather than depending on which one this parser produced.
+    return wf.get("on") or wf.get(True) or {}
+
+
+def _runs_on_merge_group(job: dict) -> bool:
+    condition = job.get("if")
+    if condition is None:
+        return True  # unconditional job
+    return "merge_group" in str(condition)
+
+
+def test_ci_reacts_to_merge_group():
+    """Without this trigger, a queue run produces no checks and never merges."""
+    assert "merge_group" in _triggers(_workflow()), (
+        "ci.yml does not react to merge_group, but all three required contexts "
+        "come from it — the queue would wait forever for checks that never start"
+    )
+
+
+def test_every_required_gate_runs_in_the_queue():
+    """The one that matters: no dependency of ci-ok may skip on merge_group."""
+    jobs = _workflow()["jobs"]
+    skipping = [
+        name for name in jobs["ci-ok"]["needs"] if not _runs_on_merge_group(jobs[name])
+    ]
+    assert not skipping, (
+        "these ci-ok dependencies would SKIP on a merge_group run, and ci-ok "
+        "counts a skip as a pass — the queue would merge them untested: "
+        f"{sorted(skipping)}. Add `|| github.event_name == 'merge_group'` to "
+        "each one's `if:`."
+    )
+
+
+@pytest.mark.parametrize(
+    "job",
+    ["backend-test", "frontend-test", "e2e-smoke"],
+    ids=["backend", "frontend", "browser"],
+)
+def test_the_expensive_suites_are_among_them(job):
+    """#1000's acceptance names these three specifically.
+
+    A queue run whose Backend Tests and frontend suites skipped to a green
+    `CI OK` is the exact failure the issue was filed about, so pin them by name
+    rather than trusting the aggregator list to keep containing them.
+    """
+    jobs = _workflow()["jobs"]
+    assert job in jobs["ci-ok"]["needs"], f"{job} no longer gates CI OK"
+    assert _runs_on_merge_group(jobs[job]), f"{job} would skip on merge_group"
+
+
+def test_changes_job_does_not_pretend_to_have_filtered_the_queue():
+    """`dorny/paths-filter` has no base ref on merge_group.
+
+    It is configured with ``token: ''`` (git-diff detection, the #546 fix for
+    the API's transient 503s), and git-diff detection resolves its base from
+    pull-request context or a push's before-SHA. A ``gh-readonly-queue/*``
+    branch supplies neither. The step is skipped there so `Detect Changes` — a
+    REQUIRED context — still succeeds, and the empty outputs it leaves behind
+    are ignored because every consumer ORs in ``merge_group``.
+
+    If someone re-enables the filter on merge_group, its outputs become
+    load-bearing again and this assertion should be replaced by one that pins
+    whatever base it was given, not deleted.
+    """
+    steps = _workflow()["jobs"]["changes"]["steps"]
+    filter_steps = [s for s in steps if "paths-filter" in str(s.get("uses", ""))]
+    assert len(filter_steps) == 1, "expected exactly one paths-filter step"
+    assert "merge_group" in str(filter_steps[0].get("if", "")), (
+        "the paths-filter step must be skipped on merge_group; with no base to "
+        "diff against its outputs cannot be trusted, and a failure there fails "
+        "a required check"
+    )


### PR DESCRIPTION
Steps 1-4 of #1000. **Step 5 — enabling the queue — is a repository-admin action and is not in this PR.** Nothing here changes behaviour until someone flips it on; `merge_group:` in `on:` is inert while no queue exists.

## The trap this closes

Adding `merge_group:` to `on:` is one line. The conditionals underneath are why that line alone would have been actively dangerous:

- **12 of 25 jobs** were gated on `needs.changes.outputs.X == 'true' || github.event_name == 'push'`. A `merge_group` event matches neither `push` nor `pull_request`, so all twelve skip.
- `ci-ok` gates on `needs.*.result` and **treats `skipped` as pass** — correct for a path-filtered PR, catastrophic here.

Net result: a queue run in which nearly everything skipped, `CI OK` green, and code merged that was never tested. Not a stall anyone would notice.

## What changed

**Every one of `ci-ok`'s 17 dependencies now runs on `merge_group`.** Verified by parsing the file rather than by reading it:

| | on merge_group |
|---|---|
| `backend-lint` `backend-test` `installer-test` `backup-roundtrip` `openapi-snapshot` `sdks-check` `cli-test` `mcp-test` `alembic-clean-db` `frontend-lint` `frontend-test` `security-scan` | `\|\| github.event_name == 'merge_group'` added |
| `e2e-smoke` | runs **unconditionally** |
| `changes` `pre-commit` `version-coherence` `docs-contract` | already unconditional |

A queue run validates a candidate merge commit against `main` the same way a push run validates the merged result, so both want the full matrix rather than a path-filtered subset — which is why the issue's "treat `merge_group` like `push`" is the correct fix rather than a workaround.

`e2e-smoke` is unconditional rather than path-filtered (step 3 of the issue). There is no reliable filter to apply there, and it is the one gate whose purpose is catching what a *combination* breaks: two PRs can each leave the core flows green alone and break one together, which is the failure a merge queue exists to stop.

## `dorny/paths-filter` on a queue branch

It runs with `token: ''`, which switches it to git-diff detection — a deliberate #546 choice, because the API path's transient 503s failed this required check hard, and it should stay. Git-diff detection resolves its base from pull-request context or a push's before-SHA, and a `gh-readonly-queue/*` branch supplies neither.

The step is therefore **skipped on `merge_group`**. `Detect Changes` is a required context, so the job still has to succeed; skipping the step is how it does, and the empty outputs it leaves behind are ignored because every consumer ORs in `merge_group`. The alternative — feeding it `github.event.merge_group.base_sha` — would make its outputs load-bearing in a context #546 never contemplated, to produce a path-filtered subset the queue does not want anyway.

## Concurrency (step 4): checked, unchanged

`group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}` with `cancel-in-progress: true` is already safe. Each queue entry runs on its own `gh-readonly-queue/main/pr-N-<sha>` ref, so `github.ref` alone puts every entry in a distinct group: two batches in flight cannot cancel each other, and a queue run and the PR it came from differ in both ref and event name. Recorded as a comment so the next reader does not have to re-derive it.

## What deliberately stays off the queue

`runtime-extension-image-probe`, `accessibility`, `stac-validate`, `e2e-test`, `ai-evals`. None is in `ci-ok`, so none would gate anything in the queue — they would only spend Actions minutes, which the existing "pin-sha-probe-push-only" and per-PR-budget comments say the project cares about. The push-triggered ones still run when the batch lands on `main`, the same coverage they have today.

## The invariant is now a test

`backend/tests/test_ci_merge_queue.py` asserts that no `ci-ok` dependency can skip on `merge_group`, and pins `backend-test` / `frontend-test` / `e2e-smoke` by name because #1000's acceptance names them. Add a job to the aggregator without a `merge_group` clause and it fails — instead of quietly reopening the hole after the queue is switched on, when the symptom is a green check on an untested merge.

It does not assert that the queue is enabled; that is not a file in this repo.

## Verification

```
cd backend && uv run pytest tests/test_ci_merge_queue.py tests/test_phase_279_compose_ci.py \
  tests/test_ci_alembic_filter_paths.py -q      # 16 passed
```

Structural audit of the whole file (each `ci-ok` dependency's `if:` against `merge_group`) run in-session and reported clean for all 17.

**Cannot be verified end to end from here.** Acceptance items "a PR merged through the queue shows a `gh-readonly-queue/*` run in which Backend Tests actually ran" and "a deliberately broken PR is ejected" both require the queue to be on, which needs admin rights.

## Handover — what the admin does next

1. Merge this.
2. Settings → Branches → `main`: enable the merge queue with **batch size > 1** — the batching is where the throughput win is.

   Two config notes, both learned while this PR sat in the queue:

   `allow_update_branch` was **false** while `allow_auto_merge` was **true**, so GitHub would merge an armed PR but never offer to bring a stale one up to date. It has since been set to **true** — but measured afterwards, that did **not** stop the stalls: main moved and every armed PR was still `BEHIND`. The setting exposes the update affordance; it does not auto-update branches for auto-merge PRs. Under `strict: true` only one PR can land per main-move regardless, so the branches have to be serialized by hand. That is the whole case for the queue: it updates and tests a batch, instead of one PR per CI cycle.

   Note on `strict`: the issue records it as turned off on 2026-07-30, but branch protection currently reads `strict: true` with required contexts `Detect Changes`, `Pre-commit`, `CI OK` (read back from the API while writing this). So it does not need re-enabling — and its livelock is live right now: this PR's own siblings sat at `BEHIND` with auto-merge armed and did not advance until a manual `update-branch`. The queue supersedes `strict`; whether to leave it on alongside is your call.
3. Land one throwaway PR through the queue and confirm its `gh-readonly-queue/*` run shows Backend Tests and the frontend suites as **ran**, not skipped.

Worth timing for a quiet moment: once the queue is on, `--auto` enqueues rather than merges, merges serialize through the queue, and CI re-runs on a `gh-readonly-queue/*` branch — so it changes how every open PR lands.

Refs #1000


