### PR TITLE
fix(maps): give the map thumbnail its own timestamp

### DIFF
--- a/backend/alembic/versions/0031_maps_thumbnail_updated_at.py
+++ b/backend/alembic/versions/0031_maps_thumbnail_updated_at.py
@@ -1,0 +1,45 @@
+"""Give the map thumbnail its own timestamp, separate from the map's.
+
+fix(#1005): ``catalog.maps.updated_at`` was doing double duty as the thumbnail
+cache version. ``MapCard``/``MapCardGrid`` pass it to ``useMapThumbnail`` as the
+``?v=`` version and part of the query key, so a re-captured thumbnail only shows
+after an edit because ``updated_at`` moved. But the same upload endpoints serve
+the lazy backfill that fires when an owner first opens a thumbnail-less map in
+the builder, editing nothing -- and that write bumped ``updated_at`` too, which
+reordered the "Last updated" gallery for what was a read.
+
+The backend cannot tell the two flows apart: one ``captureThumbnail`` call
+drives both, and it uploads two images (the 400x250 thumbnail and the 1200x630
+OG card), so each backfill bumped ``updated_at`` twice.
+
+``thumbnail_updated_at`` splits the two meanings. It is nullable rather than
+backfilled from ``updated_at``: the frontend falls back to ``updated_at`` when
+it is null, so existing maps keep exactly the cache version they have today,
+and a backfill would only invent a timestamp that is already available.
+
+Revision ID: 0031_maps_thumbnail_updated_at
+Revises: 0030_records_spatial_extent_type
+Create Date: 2026-07-31
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0031_maps_thumbnail_updated_at"
+down_revision: Union[str, None] = "0030_records_spatial_extent_type"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "maps",
+        sa.Column("thumbnail_updated_at", sa.DateTime(timezone=True), nullable=True),
+        schema="catalog",
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("maps", "thumbnail_updated_at", schema="catalog")

--- a/backend/app/modules/catalog/maps/models.py
+++ b/backend/app/modules/catalog/maps/models.py
@@ -112,6 +112,18 @@ class Map(Base):
     # Preview thumbnail — storage key (e.g. "maps/thumbnails/{id}.jpg")
     thumbnail_uri: Mapped[str | None] = mapped_column(Text, nullable=True)
 
+    # fix(#1005): the thumbnail's own cache version. `updated_at` used to do
+    # double duty here, which meant the lazy backfill on first builder open —
+    # a read, editing nothing — bumped the map's edit timestamp and reordered
+    # the "Last updated" gallery. Splitting the two meanings is the only fix
+    # that keeps both correct: the card still busts its cache when the image is
+    # re-captured after an edit, without the capture claiming the map changed.
+    # Nullable, and the frontend falls back to `updated_at`, so maps written
+    # before this column keep a stable version rather than losing one.
+    thumbnail_updated_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+
     # OG/social-card image — storage key (e.g. "maps/og-images/{id}.jpg")
     # Added in migration 0001_baseline (SHARE-08 Path A). Separate from thumbnail_uri
     # because the OG image is 1200x630 and exceeds the 100KB thumbnail cap.

--- a/backend/app/modules/catalog/maps/router.py
+++ b/backend/app/modules/catalog/maps/router.py
@@ -18,7 +18,7 @@ from fastapi import (
     Response,
     status,
 )
-from sqlalchemy import select
+from sqlalchemy import select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.modules.audit.service import AuditEvent, audit_emit
@@ -74,7 +74,7 @@ from app.modules.catalog.maps.service import (
     update_map,
     validate_public_visibility,
 )
-from app.modules.catalog.maps.models import MapLayer
+from app.modules.catalog.maps.models import Map, MapLayer
 from app.modules.catalog.maps.service import remove_layers_bulk
 from app.modules.embed_tokens.service import (
     revoke_embed_tokens_by_map,
@@ -871,6 +871,42 @@ async def duplicate_map_endpoint(
     )
 
 
+async def _record_image_capture(
+    db: AsyncSession, map_id: uuid.UUID, **image_columns: str
+) -> None:
+    """Persist a captured map image without marking the map edited.
+
+    fix(#1005): ``updated_at`` was doing double duty as the thumbnail cache
+    version — ``MapCard``/``MapCardGrid`` pass it to ``useMapThumbnail`` as the
+    ``?v=`` version — so the lazy backfill that fires when an owner first opens
+    a thumbnail-less map in the builder, editing nothing, bumped the map's edit
+    timestamp and reordered the "Last updated" gallery. ``thumbnail_updated_at``
+    splits the two meanings.
+
+    Dropping the endpoints' explicit ``map_obj.updated_at = ...`` is NOT enough,
+    and this is the part that is easy to get wrong: ``Map.updated_at`` carries
+    ``onupdate=func.now()``, so *any* update to the row bumps it. Measured — the
+    gallery still reordered with the assignment removed. Setting ``updated_at``
+    to its own column value is the explicit-value form that suppresses the
+    ``onupdate``: it happens in the database, so it neither invents a timestamp
+    nor clobbers a concurrent edit's.
+
+    ``synchronize_session=False`` because both callers return 204 and never read
+    the ORM object back.
+    """
+    await db.execute(
+        update(Map)
+        .where(Map.id == map_id)
+        .values(
+            thumbnail_updated_at=datetime.now(UTC),
+            updated_at=Map.updated_at,
+            **image_columns,
+        )
+        .execution_options(synchronize_session=False)
+    )
+    await db.commit()
+
+
 @router.put(
     "/{map_id}/thumbnail/",
     status_code=status.HTTP_204_NO_CONTENT,
@@ -964,9 +1000,7 @@ async def upload_thumbnail(
             detail="Thumbnail storage unavailable",
         )
 
-    map_obj.thumbnail_uri = storage_key
-    map_obj.updated_at = datetime.now(UTC)
-    await db.commit()
+    await _record_image_capture(db, map_id, thumbnail_uri=storage_key)
     return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 
@@ -1099,9 +1133,7 @@ async def upload_og_image(
             detail="OG image storage unavailable",
         )
 
-    map_obj.og_image_uri = storage_key
-    map_obj.updated_at = datetime.now(UTC)
-    await db.commit()
+    await _record_image_capture(db, map_id, og_image_uri=storage_key)
     return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 

--- a/backend/app/modules/catalog/maps/schemas.py
+++ b/backend/app/modules/catalog/maps/schemas.py
@@ -1080,6 +1080,10 @@ class MapSummaryResponse(BaseModel):
     description: str | None
     visibility: MapVisibility
     thumbnail_url: str | None = None
+    # fix(#1005): the thumbnail's cache version, separate from the map's edit
+    # timestamp. Null for maps whose thumbnail predates the column; the card
+    # falls back to `updated_at` so it keeps a stable version either way.
+    thumbnail_updated_at: datetime | None = None
     layer_count: int
     created_by_username: str | None = None
     created_at: datetime

--- a/backend/app/modules/catalog/maps/service_crud.py
+++ b/backend/app/modules/catalog/maps/service_crud.py
@@ -223,6 +223,7 @@ async def list_maps(
                 "thumbnail_url": f"/maps/{map_obj.id}/thumbnail/"
                 if map_obj.thumbnail_uri
                 else None,
+                "thumbnail_updated_at": map_obj.thumbnail_updated_at,
                 "layer_count": row[1],
                 "created_by_username": row[2],
                 "created_at": map_obj.created_at,

--- a/backend/app/modules/catalog/maps/service_public.py
+++ b/backend/app/modules/catalog/maps/service_public.py
@@ -693,6 +693,7 @@ async def get_maps_for_dataset(
                 "thumbnail_url": f"/maps/{map_obj.id}/thumbnail/"
                 if map_obj.thumbnail_uri
                 else None,
+                "thumbnail_updated_at": map_obj.thumbnail_updated_at,
                 "layer_count": row[1],
                 "created_by_username": row[2],
                 "created_at": map_obj.created_at,

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -10000,6 +10000,18 @@
             "title": "Name",
             "type": "string"
           },
+          "thumbnail_updated_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Thumbnail Updated At"
+          },
           "thumbnail_url": {
             "anyOf": [
               {

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -1027,7 +1027,9 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # matching the #435 convention: growth needs a reviewed carve-out here,
     # shrinking must lower the cap in the same commit.
     "backend/app/api/main.py": 1292,
-    "backend/app/modules/catalog/maps/schemas.py": 1312,
+    # fix(#1005): +4 — MapSummaryResponse gains thumbnail_updated_at, the
+    # thumbnail cache version split out of updated_at. Ratchet stays exact.
+    "backend/app/modules/catalog/maps/schemas.py": 1316,
     # fix(#888): +117. `clip_to_mercator_bounds` used to lose data twice over
     # in silence — it clipped away everything east of lon 180 in a 0..360
     # source, and it reduced valid polar geometry to EMPTY without telling
@@ -1063,7 +1065,11 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # Tenant-owned media now crosses the shared logical-to-physical storage
     # seam; explicit storage-failure responses keep the runtime/OpenAPI contract
     # aligned. Keep the ratchet exact after the import/decorator expansion.
-    "backend/app/modules/catalog/maps/router.py": 1385,
+    # fix(#1005): +32 — _record_image_capture, the shared write for both
+    # image-upload endpoints. Its docstring carries the part that is easy to
+    # get wrong: Map.updated_at has onupdate=func.now(), so dropping the
+    # explicit assignment does not stop the bump. Ratchet stays exact.
+    "backend/app/modules/catalog/maps/router.py": 1417,
     # fix(#474): thread negotiated languages through catalog search, cache keys,
     # and OGC record serialization; fix(#475) adds Records array-query handling,
     # including collection IDs, plus response-header and documented 400 parity.

--- a/backend/tests/test_maps.py
+++ b/backend/tests/test_maps.py
@@ -3139,25 +3139,58 @@ class TestMapThumbnail:
         )
         assert resp.status_code == 204
 
-    async def test_upload_thumbnail_bumps_updated_at(
-        self, client: AsyncClient, admin_auth_header: dict
+    @staticmethod
+    async def _summary(client: AsyncClient, headers: dict, map_id: str) -> dict:
+        """The map's row as the gallery sees it (MapSummaryResponse).
+
+        ``thumbnail_updated_at`` is a card concern, so it rides the summary
+        shape rather than the full ``MapResponse``.
+        """
+        resp = await client.get("/maps/", headers=headers)
+        assert resp.status_code == 200
+        return next(m for m in resp.json()["maps"] if m["id"] == map_id)
+
+    @pytest.mark.parametrize(
+        ("path", "payload_key"),
+        [("thumbnail", "data_uri"), ("og-image", "data_uri")],
+    )
+    async def test_image_upload_versions_the_thumbnail_not_the_map(
+        self,
+        client: AsyncClient,
+        admin_auth_header: dict,
+        path: str,
+        payload_key: str,
     ):
-        """Thumbnail refreshes must invalidate map-card thumbnail caches."""
+        """Thumbnail refreshes must invalidate map-card thumbnail caches.
+
+        fix(#1005): the cache version moved to its own column. ``updated_at``
+        carried both meanings, so the lazy backfill that fires when an owner
+        first opens a thumbnail-less map in the builder — a read, editing
+        nothing — bumped the map's edit timestamp and reordered the "Last
+        updated" gallery. Both halves are pinned here: the card must still get
+        a new version, and the map must not come back looking edited.
+
+        One ``captureThumbnail`` call uploads both images, so the OG endpoint is
+        parametrised in rather than left as the half that still bumps.
+        """
         created = await _create_map(client, admin_auth_header)
         map_id = created["id"]
         before = created["updated_at"]
+        assert await self._summary(client, admin_auth_header, map_id) is not None
 
         resp = await client.put(
-            f"/maps/{map_id}/thumbnail/",
-            json={"data_uri": _valid_png_data_uri()},
+            f"/maps/{map_id}/{path}/",
+            json={payload_key: _valid_png_data_uri()},
             headers=admin_auth_header,
         )
         assert resp.status_code == 204
 
-        refreshed = await client.get(f"/maps/{map_id}", headers=admin_auth_header)
+        summary = await self._summary(client, admin_auth_header, map_id)
+        assert summary["thumbnail_updated_at"] is not None
 
+        refreshed = await client.get(f"/maps/{map_id}", headers=admin_auth_header)
         assert refreshed.status_code == 200
-        assert refreshed.json()["updated_at"] != before
+        assert refreshed.json()["updated_at"] == before
 
     async def test_get_thumbnail_after_upload(
         self, client: AsyncClient, admin_auth_header: dict

--- a/frontend/src/components/maps/MapCard.tsx
+++ b/frontend/src/components/maps/MapCard.tsx
@@ -25,7 +25,15 @@ export interface MapCardProps {
 export const MapCard = memo(function MapCard({ map, onDelete }: MapCardProps) {
   const { t } = useTranslation();
   const [imgError, setImgError] = useState(false);
-  const thumbnailSrc = useMapThumbnail(map.thumbnail_url, map.updated_at);
+  // fix(#1005): version on the thumbnail's own timestamp. `updated_at` used to
+  // serve both meanings, so the lazy backfill that fires when an owner first
+  // opens a thumbnail-less map bumped the map's edit time and reordered the
+  // "Last updated" gallery. Fall back to `updated_at` for maps captured before
+  // the column existed, so they keep a stable version rather than losing one.
+  const thumbnailSrc = useMapThumbnail(
+    map.thumbnail_url,
+    map.thumbnail_updated_at ?? map.updated_at,
+  );
 
   return (
     <Card

--- a/frontend/src/components/maps/MapCardGrid.tsx
+++ b/frontend/src/components/maps/MapCardGrid.tsx
@@ -19,7 +19,15 @@ import { VisibilityIcon } from './VisibilityIcon';
 export const MapCardGrid = memo(function MapCardGrid({ map, onDelete }: MapCardProps) {
   const { t } = useTranslation();
   const [imgError, setImgError] = useState(false);
-  const thumbnailSrc = useMapThumbnail(map.thumbnail_url, map.updated_at);
+  // fix(#1005): version on the thumbnail's own timestamp. `updated_at` used to
+  // serve both meanings, so the lazy backfill that fires when an owner first
+  // opens a thumbnail-less map bumped the map's edit time and reordered the
+  // "Last updated" gallery. Fall back to `updated_at` for maps captured before
+  // the column existed, so they keep a stable version rather than losing one.
+  const thumbnailSrc = useMapThumbnail(
+    map.thumbnail_url,
+    map.thumbnail_updated_at ?? map.updated_at,
+  );
 
   return (
     <Card className="flex flex-col overflow-hidden hover:shadow-md hover:border-primary/20 hover:bg-accent/50 transition-[color,background-color,box-shadow,border-color,opacity] duration-200 ease-out">

--- a/frontend/src/components/maps/__tests__/MapCard.test.tsx
+++ b/frontend/src/components/maps/__tests__/MapCard.test.tsx
@@ -22,6 +22,7 @@ function makeMap(overrides: Partial<MapSummaryResponse> = {}): MapSummaryRespons
     created_at: '2026-01-01T00:00:00Z',
     updated_at: '2026-01-02T00:00:00Z',
     thumbnail_url: '/api/maps/map-1/thumbnail/',
+    thumbnail_updated_at: null,
     created_by_username: 'testuser',
     ...overrides,
   };
@@ -101,5 +102,40 @@ describe('MapCardGrid', () => {
     const img = screen.getByRole('img');
     fireEvent.error(img);
     expect(screen.queryByRole('img')).not.toBeInTheDocument();
+  });
+});
+
+// fix(#1005): the thumbnail cache version moved off `updated_at`, which was
+// carrying two meanings — a lazy backfill on first builder open reordered the
+// "Last updated" gallery for what was a read.
+describe.each([
+  ['MapCard', MapCard],
+  ['MapCardGrid', MapCardGrid],
+])('%s thumbnail cache version', (_name, Component) => {
+  beforeEach(() => {
+    mockUseMapThumbnail.mockReturnValue('blob:http://localhost/fake-thumb');
+  });
+
+  it("versions on the thumbnail's own timestamp when it has one", () => {
+    render(
+      <Component
+        map={makeMap({ thumbnail_updated_at: '2026-03-04T05:06:07Z' })}
+        onDelete={() => {}}
+      />,
+    );
+
+    expect(mockUseMapThumbnail).toHaveBeenCalledWith(
+      '/api/maps/map-1/thumbnail/',
+      '2026-03-04T05:06:07Z',
+    );
+  });
+
+  it('falls back to updated_at for a thumbnail captured before the column existed', () => {
+    render(<Component map={makeMap({ thumbnail_updated_at: null })} onDelete={() => {}} />);
+
+    expect(mockUseMapThumbnail).toHaveBeenCalledWith(
+      '/api/maps/map-1/thumbnail/',
+      '2026-01-02T00:00:00Z',
+    );
   });
 });

--- a/frontend/src/types/api.generated.ts
+++ b/frontend/src/types/api.generated.ts
@@ -9171,6 +9171,8 @@ export interface components {
             layer_count: number;
             /** Name */
             name: string;
+            /** Thumbnail Updated At */
+            thumbnail_updated_at?: string | null;
             /** Thumbnail Url */
             thumbnail_url?: string | null;
             /**

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -1130,6 +1130,10 @@ export interface MapSummaryResponse {
   description: string | null;
   visibility: MapVisibility;
   thumbnail_url: string | null;
+  /** fix(#1005): the thumbnail's cache version, separate from the map's edit
+   * timestamp. Null for maps whose thumbnail predates the column — fall back to
+   * `updated_at` so the card keeps a stable version either way. */
+  thumbnail_updated_at: string | null;
   layer_count: number;
   created_by_username: string | null;
   created_at: string;

--- a/sdks/python/geolens/models/map_summary_response.py
+++ b/sdks/python/geolens/models/map_summary_response.py
@@ -31,6 +31,7 @@ class MapSummaryResponse:
         updated_at (datetime.datetime):
         visibility (MapVisibility):
         created_by_username (None | str | Unset):
+        thumbnail_updated_at (datetime.datetime | None | Unset):
         thumbnail_url (None | str | Unset):
     """
 
@@ -42,6 +43,7 @@ class MapSummaryResponse:
     updated_at: datetime.datetime
     visibility: MapVisibility
     created_by_username: None | str | Unset = UNSET
+    thumbnail_updated_at: datetime.datetime | None | Unset = UNSET
     thumbnail_url: None | str | Unset = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
@@ -67,6 +69,14 @@ class MapSummaryResponse:
         else:
             created_by_username = self.created_by_username
 
+        thumbnail_updated_at: None | str | Unset
+        if isinstance(self.thumbnail_updated_at, Unset):
+            thumbnail_updated_at = UNSET
+        elif isinstance(self.thumbnail_updated_at, datetime.datetime):
+            thumbnail_updated_at = self.thumbnail_updated_at.isoformat()
+        else:
+            thumbnail_updated_at = self.thumbnail_updated_at
+
         thumbnail_url: None | str | Unset
         if isinstance(self.thumbnail_url, Unset):
             thumbnail_url = UNSET
@@ -88,6 +98,8 @@ class MapSummaryResponse:
         )
         if created_by_username is not UNSET:
             field_dict["created_by_username"] = created_by_username
+        if thumbnail_updated_at is not UNSET:
+            field_dict["thumbnail_updated_at"] = thumbnail_updated_at
         if thumbnail_url is not UNSET:
             field_dict["thumbnail_url"] = thumbnail_url
 
@@ -126,6 +138,27 @@ class MapSummaryResponse:
             d.pop("created_by_username", UNSET)
         )
 
+        def _parse_thumbnail_updated_at(
+            data: object,
+        ) -> datetime.datetime | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, str):
+                    raise TypeError()
+                thumbnail_updated_at_type_0 = isoparse(data)
+
+                return thumbnail_updated_at_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(datetime.datetime | None | Unset, data)
+
+        thumbnail_updated_at = _parse_thumbnail_updated_at(
+            d.pop("thumbnail_updated_at", UNSET)
+        )
+
         def _parse_thumbnail_url(data: object) -> None | str | Unset:
             if data is None:
                 return data
@@ -144,6 +177,7 @@ class MapSummaryResponse:
             updated_at=updated_at,
             visibility=visibility,
             created_by_username=created_by_username,
+            thumbnail_updated_at=thumbnail_updated_at,
             thumbnail_url=thumbnail_url,
         )
 

--- a/sdks/typescript/src/client/types.gen.ts
+++ b/sdks/typescript/src/client/types.gen.ts
@@ -5750,6 +5750,10 @@ export type MapSummaryResponse = {
      */
     name: string;
     /**
+     * Thumbnail Updated At
+     */
+    thumbnail_updated_at?: string | null;
+    /**
      * Thumbnail Url
      */
     thumbnail_url?: string | null;


### PR DESCRIPTION
Closes #1005. **Migration — leaving this for the coordinator to merge.**

## The bug

`updated_at` was doing double duty as the thumbnail cache version.
`MapCard.tsx:28` and `MapCardGrid.tsx:22` pass it to `useMapThumbnail`, which
appends it as `?v=` and puts it in the query key, so a thumbnail re-captured
after an edit only appears because `updated_at` moved. That half is
load-bearing, which is why the obvious one-line fix is a regression.

The same two endpoints also serve the lazy backfill: `maybeAutoCaptureThumbnail`
fires when an owner opens a thumbnail-less map in the builder, editing nothing,
and that write reordered the "Last updated" gallery. One `captureThumbnail` call
drives both flows and uploads two images (400x250 thumbnail + 1200x630 OG card),
so each backfill bumped `updated_at` twice — and nothing versions the OG image
on read, so that second bump bought nothing at all.

## What changed

- `Map.thumbnail_updated_at`, nullable `timestamptz`, migration
  `0031_maps_thumbnail_updated_at`.
- Both `upload_thumbnail` and `upload_og_image` write it instead of `updated_at`.
- `MapSummaryResponse` carries it; mirrored in the hand-typed
  `frontend/src/types/api.ts` and regenerated into `openapi.json`,
  `api.generated.ts` and both SDKs.
- Both card call sites version on `thumbnail_updated_at ?? updated_at`, so a map
  captured before the column keeps a stable version rather than losing
  cache-busting entirely.

Not backfilled from `updated_at` on purpose: the frontend falls back to it
anyway, so a backfill would only invent a timestamp that is already available.

## The part the issue's step 2 would have missed

Dropping the endpoints' explicit `map_obj.updated_at = datetime.now(UTC)` does
**not** stop the bump. `Map.updated_at` carries `onupdate=func.now()`
(`models.py:148-150`), so *any* update to the row bumps it. Measured, with the
assignment removed and nothing else changed:

```
AssertionError: assert '2026-07-31T13:43:32.519252Z' == '2026-07-31T13:43:32.454139Z'
```

So both endpoints now go through one `_record_image_capture` helper that sets
`updated_at` to its own column value. That is the explicit-value form which
suppresses the `onupdate`, and because it happens in the database it neither
invents a timestamp nor clobbers a concurrent edit's. The docstring records
this, since "just stop assigning it" is the natural next edit.

## Verification

```
cd backend && set -a && source ../.env.test && set +a && uv run pytest \
  tests/test_maps.py tests/test_maps_visibility_check_authz_sec007.py \
  tests/test_builder_audit_p0p1_sharing.py \
  tests/test_dormant_tenancy_migration_roundtrip.py \
  tests/test_check_constraint_parity.py tests/test_layering.py -q
  # 189 passed (+34 layering)
cd backend && uv run ruff check . && uv run ruff format --check .
cd frontend && npm run lint && npm run typecheck
cd frontend && npm run test:coverage   # 366 files, 4288 tests passed
```

`alembic check` reports no drift (`TestAlembicCheckNoDrift`), which is the
`make alembic-check` gate run against the test DB — `make alembic-check` itself
targets the dev container, which serves `main`'s code from a worktree.

`test_upload_thumbnail_bumps_updated_at` is rewritten, not deleted, keeping its
docstring's intent. It is now parametrised across both upload endpoints and
asserts both halves: the card gets a new version, and the map does not come back
looking edited. LOC ratchets move for `maps/router.py` (1385 → 1417) and
`maps/schemas.py` (1312 → 1316), exact as the gate requires.
