### PR TITLE
ops(analysis): per-tenant cap on active materialize jobs

### DIFF
--- a/backend/app/modules/catalog/datasets/api/router_analysis.py
+++ b/backend/app/modules/catalog/datasets/api/router_analysis.py
@@ -5,7 +5,7 @@ import uuid
 from datetime import datetime, timedelta, timezone
 
 from fastapi import APIRouter, Depends, HTTPException, Request, status
-from sqlalchemy import and_, func, or_, select
+from sqlalchemy import and_, func, or_, select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.db.tenant_session import current_tenant_var, defer_async_with_tenant
@@ -312,6 +312,33 @@ async def analysis_materialize_endpoint(
     # The client deliberately applies no staleness rule of its own
     # (AnalysisJobWatcher.tsx): it mirrors job status from the API, and on a
     # released lease the next create attempt simply succeeds server-side.
+    # fix(#1015): serialize admission per tenant before counting anything.
+    # Without it the caps are check-then-insert: N users in one tenant can all
+    # read a count below the ceiling, then all create a job, and the tenant
+    # ends up over by however many callers arrived together — precisely the
+    # unbounded-concurrency case the ceiling exists to stop, and the one #1012's
+    # raised work_mem makes expensive. A transaction-scoped advisory lock held
+    # until this request commits makes the count-then-create sequence atomic.
+    #
+    # Blocking rather than pg_try_advisory_xact_lock (the sandbox's shape at
+    # executor.py): concurrent admissions should queue for the microseconds this
+    # takes, not fail. The critical section is a COUNT and an INSERT.
+    #
+    # In single-tenant mode the key is constant, so this serializes every
+    # analysis admission on the deployment. That is the correct reading — there
+    # is one tenant — and admissions are rare and short. It also incidentally
+    # hardens the per-user cap below, which the comment there describes as soft.
+    await db.execute(
+        text("SELECT pg_advisory_xact_lock(hashtextextended(:admission_key, 0))"),
+        {
+            "admission_key": (
+                f"geolens:analysis-admission:{current_tenant_var.get()}"
+                if is_multi_tenant()
+                else "geolens:analysis-admission"
+            )
+        },
+    )
+
     lease_cutoff = datetime.now(timezone.utc) - timedelta(
         seconds=MATERIALIZE_LEASE_SECONDS
     )

--- a/backend/app/modules/catalog/datasets/api/router_analysis.py
+++ b/backend/app/modules/catalog/datasets/api/router_analysis.py
@@ -8,9 +8,10 @@ from fastapi import APIRouter, Depends, HTTPException, Request, status
 from sqlalchemy import and_, func, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.core.db.tenant_session import defer_async_with_tenant
+from app.core.db.tenant_session import current_tenant_var, defer_async_with_tenant
 from app.core.dependencies import get_db
 from app.core.identity import Identity
+from app.core.tenancy import is_multi_tenant
 from app.modules.auth.dependencies import get_current_active_user, require_permission
 from app.modules.catalog.authorization import check_dataset_access
 from app.modules.catalog.datasets.domain.schemas import (
@@ -51,6 +52,28 @@ router = APIRouter(
 )
 
 _SAFE_COLUMN_RE = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_]*$")
+
+# fix(#1015): ceiling on active materializes for one tenant, above the
+# one-per-user cap rather than replacing it. The two answer different
+# questions — "are you already running one?" and "is your organisation using
+# more than its share?" — so both stay, with 429 details that say which was
+# hit.
+#
+# Why a tenant needs its own ceiling: the per-user cap lets a tenant with N
+# users hold N active CTASes, and #1012 raises the per-statement work_mem that
+# each of those would claim. A raised ceiling times an unbounded count is the
+# same outage in a new place.
+#
+# Three: with the default WORKER_CONCURRENCY of 1 that is one running plus two
+# queued, so a single tenant cannot monopolise the queue while still being able
+# to line work up. On a deployment that raises WORKER_CONCURRENCY it bounds
+# genuinely concurrent CTASes to three per tenant, which is the count #1012's
+# work_mem division is sized against.
+#
+# A module constant, not a Settings field, for the same reason as the ingest
+# caps: four surfaces for a limit nobody has asked to tune yet. #1013 is the
+# issue that establishes the promotion pattern.
+MAX_ACTIVE_MATERIALIZES_PER_TENANT = 3
 
 # fix(#766): PostgreSQL has no equality operator for these types, so a
 # dissolve GROUP BY on such a column fails the CTAS with an opaque 42883
@@ -292,31 +315,54 @@ async def analysis_materialize_endpoint(
     lease_cutoff = datetime.now(timezone.utc) - timedelta(
         seconds=MATERIALIZE_LEASE_SECONDS
     )
+    # fix(#1015): the liveness rule is shared by both caps rather than
+    # reinvented for the tenant one. All three properties documented above are
+    # load-bearing and apply identically at tenant scope.
+    active_predicate = (
+        # fix(#682 review): the analysis marker in user_metadata, NOT
+        # source_filename — uploads copy the user's own filename into that
+        # column, so an upload named "analysis-data.geojson" would lock the
+        # uploader out of analysis. The metadata below is written in the
+        # same transaction as the job row, so this never misses one.
+        IngestJob.user_metadata.has_key("analysis"),
+        or_(
+            IngestJob.status == "pending",
+            and_(
+                IngestJob.status == "running",
+                func.coalesce(IngestJob.heartbeat_at, IngestJob.started_at)
+                >= lease_cutoff,
+            ),
+        ),
+    )
     active = await db.scalar(
         select(func.count())
         .select_from(IngestJob)
-        .where(
-            IngestJob.created_by == user.id,
-            # fix(#682 review): the analysis marker in user_metadata, NOT
-            # source_filename — uploads copy the user's own filename into that
-            # column, so an upload named "analysis-data.geojson" would lock the
-            # uploader out of analysis. The metadata below is written in the
-            # same transaction as the job row, so this never misses one.
-            IngestJob.user_metadata.has_key("analysis"),
-            or_(
-                IngestJob.status == "pending",
-                and_(
-                    IngestJob.status == "running",
-                    func.coalesce(IngestJob.heartbeat_at, IngestJob.started_at)
-                    >= lease_cutoff,
-                ),
-            ),
-        )
+        .where(IngestJob.created_by == user.id, *active_predicate)
     )
     if active:
         raise HTTPException(
             status_code=status.HTTP_429_TOO_MANY_REQUESTS,
             detail="An analysis job is already running; wait for it to finish",
+        )
+
+    # fix(#1015): the tenant ceiling above the per-user cap. In single-tenant
+    # mode there is one tenant by definition, so the unfiltered count IS the
+    # tenant's — which also avoids depending on whether the database stamps
+    # tenant_id as NULL or as a fixed value there. IngestJob.tenant_id is
+    # already indexed (ix_catalog_ingest_jobs_tenant_id), so the multi-tenant
+    # filter needs no schema work.
+    tenant_stmt = select(func.count()).select_from(IngestJob).where(*active_predicate)
+    if is_multi_tenant():
+        tenant_stmt = tenant_stmt.where(IngestJob.tenant_id == current_tenant_var.get())
+    tenant_active = await db.scalar(tenant_stmt)
+    if tenant_active and tenant_active >= MAX_ACTIVE_MATERIALIZES_PER_TENANT:
+        raise HTTPException(
+            status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+            detail=(
+                "Your organization already has "
+                f"{MAX_ACTIVE_MATERIALIZES_PER_TENANT} analysis jobs running or "
+                "queued; wait for one to finish"
+            ),
         )
 
     job = await get_catalog_port().create_ingest_job(

--- a/backend/tests/test_analysis_materialize.py
+++ b/backend/tests/test_analysis_materialize.py
@@ -33,6 +33,7 @@ from app.processing.analysis.tasks import (
     _user_error_message,
 )
 
+from tests.conftest import _create_test_user
 from tests.factories import create_dataset, get_user_id
 from tests.test_analysis_preview import (
     _create_mask_dataset,
@@ -61,6 +62,58 @@ async def _create_job(session: AsyncSession, user_id: uuid.UUID) -> IngestJob:
     await session.commit()
     await session.refresh(job)
     return job
+
+
+async def _create_other_user_id(client: AsyncClient, admin_headers: dict) -> uuid.UUID:
+    """A second user in the same tenant, for the tenant-cap tests."""
+    _headers, user_id = await _create_test_user(client, admin_headers, "viewer")
+    return uuid.UUID(user_id)
+
+
+async def _fill_tenant_analysis_slots(
+    session: AsyncSession, user_id: uuid.UUID, target: int
+) -> list[IngestJob]:
+    """Top the tenant's active-analysis count up to ``target``.
+
+    Counts what is already active rather than assuming zero: the worker
+    database is shared across this file's tests, and a sibling that left a job
+    behind would otherwise make these pass or fail for the wrong reason.
+    """
+    from datetime import datetime, timedelta, timezone
+
+    from sqlalchemy import and_, func, or_
+
+    cutoff = datetime.now(timezone.utc) - timedelta(
+        seconds=router_analysis.MATERIALIZE_LEASE_SECONDS
+    )
+    existing = await session.scalar(
+        select(func.count())
+        .select_from(IngestJob)
+        .where(
+            IngestJob.user_metadata.has_key("analysis"),
+            or_(
+                IngestJob.status == "pending",
+                and_(
+                    IngestJob.status == "running",
+                    func.coalesce(IngestJob.heartbeat_at, IngestJob.started_at)
+                    >= cutoff,
+                ),
+            ),
+        )
+    )
+    created: list[IngestJob] = []
+    for _ in range(max(0, target - (existing or 0))):
+        job = await _create_job(session, user_id)
+        job.user_metadata = {"analysis": {"operation": "buffer"}}
+        created.append(job)
+    await session.commit()
+    return created
+
+
+async def _release_jobs(session: AsyncSession, jobs: list[IngestJob]) -> None:
+    for job in jobs:
+        job.status = "failed"
+    await session.commit()
 
 
 # ---------------------------------------------------------------------------
@@ -188,6 +241,100 @@ class TestMaterializeEndpoint:
         job.status = "failed"
         upload.status = "failed"
         await test_db_session.commit()
+
+    async def test_tenant_cap_refuses_a_second_user_and_names_itself(
+        self,
+        client: AsyncClient,
+        admin_auth_header: dict,
+        test_db_session: AsyncSession,
+    ):
+        """fix(#1015): the per-user cap let a tenant with N users hold N active
+        CTASes. A tenant ceiling sits above it, and its 429 has to say which
+        cap was hit — the per-user message would be a lie here, since this
+        user has nothing running.
+
+        The filler jobs are left `pending`, which also covers the status-only
+        branch of the shared predicate: a pending job has never been claimed,
+        so heartbeat_at and started_at are both NULL and any cutoff comparison
+        would silently drop it from the count.
+        """
+        admin_id = await get_user_id(test_db_session, "admin")
+        ds = await _create_polygon_dataset(test_db_session, created_by=admin_id)
+        other_id = await _create_other_user_id(client, admin_auth_header)
+        filler = await _fill_tenant_analysis_slots(
+            test_db_session,
+            other_id,
+            router_analysis.MAX_ACTIVE_MATERIALIZES_PER_TENANT,
+        )
+
+        try:
+            with patch.object(router_analysis, "defer_async_with_tenant", AsyncMock()):
+                resp = await client.post(
+                    _materialize_url(ds.id),
+                    json={"operation": "centroid", "title": "Over tenant cap"},
+                    headers=admin_auth_header,
+                )
+            # If the cap ever regresses this request succeeds, and the job it
+            # creates would hold THIS user's slot for every sibling test in the
+            # shared worker database — the #933 failure mode. Release it before
+            # asserting.
+            if resp.status_code == 200:
+                leaked = await test_db_session.get(
+                    IngestJob, uuid.UUID(resp.json()["job_id"])
+                )
+                leaked.status = "failed"
+                await test_db_session.commit()
+            assert resp.status_code == 429, resp.text
+            detail = resp.json()["detail"]
+            assert "organization" in detail, detail
+            # Distinguishable from the per-user cap, which this user has not hit.
+            assert "already running; wait for it to finish" not in detail, detail
+        finally:
+            await _release_jobs(test_db_session, filler)
+
+    async def test_tenant_cap_stale_lease_releases_a_slot(
+        self,
+        client: AsyncClient,
+        admin_auth_header: dict,
+        test_db_session: AsyncSession,
+    ):
+        """fix(#1015): the tenant cap shares the heartbeat lease rather than
+        inventing a liveness rule, so a hard-killed worker (SIGKILL/OOM) gives
+        its slot back here too instead of holding the whole tenant out until
+        the 60-minute JOB_TIMEOUT_SECONDS backstop."""
+        from datetime import datetime, timedelta, timezone
+
+        admin_id = await get_user_id(test_db_session, "admin")
+        ds = await _create_polygon_dataset(test_db_session, created_by=admin_id)
+        other_id = await _create_other_user_id(client, admin_auth_header)
+        filler = await _fill_tenant_analysis_slots(
+            test_db_session,
+            other_id,
+            router_analysis.MAX_ACTIVE_MATERIALIZES_PER_TENANT,
+        )
+        dead = filler[-1]
+        dead.status = "running"
+        dead.created_at = datetime.now(timezone.utc) - timedelta(minutes=10)
+        dead.started_at = datetime.now(timezone.utc) - timedelta(minutes=10)
+        dead.heartbeat_at = datetime.now(timezone.utc) - timedelta(minutes=10)
+        await test_db_session.commit()
+
+        admitted_id = None
+        try:
+            with patch.object(router_analysis, "defer_async_with_tenant", AsyncMock()):
+                resp = await client.post(
+                    _materialize_url(ds.id),
+                    json={"operation": "centroid", "title": "Past dead worker"},
+                    headers=admin_auth_header,
+                )
+            assert resp.status_code == 200, resp.text
+            admitted_id = uuid.UUID(resp.json()["job_id"])
+        finally:
+            await _release_jobs(test_db_session, filler)
+            if admitted_id is not None:
+                admitted = await test_db_session.get(IngestJob, admitted_id)
+                admitted.status = "failed"
+                await test_db_session.commit()
 
     async def test_old_pending_job_still_blocks(
         self,

--- a/backend/tests/test_analysis_materialize.py
+++ b/backend/tests/test_analysis_materialize.py
@@ -292,6 +292,80 @@ class TestMaterializeEndpoint:
         finally:
             await _release_jobs(test_db_session, filler)
 
+    async def test_tenant_admission_takes_a_serializing_lock(
+        self,
+        client: AsyncClient,
+        admin_auth_header: dict,
+        test_db_session: AsyncSession,
+    ):
+        """fix(#1015): admission is a reservation, not a check-then-insert.
+
+        Without serialization, simultaneous callers in one tenant all read the
+        same count below the ceiling and all create a job, so the tenant ends
+        up over by however many arrived together — the unbounded concurrency
+        the ceiling exists to stop, and what #1012's raised work_mem makes
+        expensive.
+
+        This asserts the MECHANISM rather than racing real requests. Under
+        ASGITransport the interleaving is not controllable: a four-way race
+        against the unfixed code reproduced the overshoot once in three runs,
+        so an outcome assertion would pass while the bug was present, which is
+        worse than no test. What is deterministic, and what the fix actually
+        is, is that a transaction-scoped advisory lock is taken BEFORE either
+        count runs.
+        """
+        executed: list[str] = []
+        from sqlalchemy.ext.asyncio import AsyncSession as _AS
+
+        real_execute = _AS.execute
+        real_scalar = _AS.scalar
+
+        async def spying_execute(self, statement, *args, **kwargs):
+            executed.append(str(statement))
+            return await real_execute(self, statement, *args, **kwargs)
+
+        # Both counts go through .scalar(), not .execute() — spying only the
+        # latter would record the lock and none of what it is protecting.
+        async def spying_scalar(self, statement, *args, **kwargs):
+            executed.append(str(statement))
+            return await real_scalar(self, statement, *args, **kwargs)
+
+        admin_id = await get_user_id(test_db_session, "admin")
+        ds = await _create_polygon_dataset(test_db_session, created_by=admin_id)
+
+        with patch.object(router_analysis, "defer_async_with_tenant", AsyncMock()):
+            with (
+                patch.object(_AS, "execute", spying_execute),
+                patch.object(_AS, "scalar", spying_scalar),
+            ):
+                resp = await client.post(
+                    _materialize_url(ds.id),
+                    json={"operation": "centroid", "title": "Lock order"},
+                    headers=admin_auth_header,
+                )
+        assert resp.status_code == 200, resp.text
+        job = await test_db_session.get(IngestJob, uuid.UUID(resp.json()["job_id"]))
+        job.status = "failed"
+        await test_db_session.commit()
+
+        locks = [s for s in executed if "pg_advisory_xact_lock" in s]
+        assert len(locks) == 1, f"expected one admission lock, got {locks}"
+        # xact-scoped, so it is held until this request commits and therefore
+        # spans the count AND the insert. A session-level lock would be
+        # released too early and a `try` variant would fail instead of queueing.
+        assert "pg_try_advisory_xact_lock" not in locks[0], locks[0]
+
+        counts = [
+            i
+            for i, stmt in enumerate(executed)
+            if "count" in stmt.lower() and "ingest_jobs" in stmt
+        ]
+        assert counts, "neither admission count ran"
+        assert executed.index(locks[0]) < counts[0], (
+            "the admission lock is taken after the count — the count is still a "
+            "snapshot another caller can have invalidated"
+        )
+
     async def test_tenant_cap_stale_lease_releases_a_slot(
         self,
         client: AsyncClient,


### PR DESCRIPTION
The materialize admission cap counted only the requesting user's active jobs (`router_analysis.py:295-315`), so a tenant with N users could hold N active CTASes regardless of what the host can absorb. That matters more now than when the item was filed, because the sibling split on scoped `work_mem` (#1012) raises the per-statement memory each of those would claim — a raised ceiling times an unbounded count is the same outage in a new place.

#691 has shipped, so this was unblocked.

## The decision the issue left open

**Both caps stay.** The per-user cap answers "are you already running one?" and the tenant cap answers "is your organization using more than its share?" — different questions, so collapsing them would lose one. That means two 429 details, and they say which was hit: the tenant one names the organization and the limit, so a user with nothing of their own running is not told "an analysis job is already running".

## The number

`MAX_ACTIVE_MATERIALIZES_PER_TENANT = 3`. With the default `WORKER_CONCURRENCY` of 1 that is one running plus two queued, so a single tenant cannot monopolize the queue while still being able to line work up. On a deployment that raises `WORKER_CONCURRENCY`, it bounds genuinely concurrent CTASes to three per tenant — which is the count #1012's `work_mem` division is sized against.

A module constant rather than a `Settings` field, for the same reason as the ingest caps: four surfaces for a limit nobody has asked to tune yet. #1013 establishes the promotion pattern.

## The predicate is shared, not reinvented

#691 replaced status-only counting with a heartbeat lease, and the tenant cap had to use that rule rather than inventing a second one. The pending/running predicate is now lifted into a single tuple that both counts apply, so all three load-bearing properties hold identically at tenant scope:

1. a running job whose lease has gone stale releases the slot (hard-killed worker), instead of holding the whole tenant out until the 60-minute `JOB_TIMEOUT_SECONDS` backstop
2. the pending branch stays status-only — a pending job has never been claimed, so `heartbeat_at` and `started_at` are both NULL and any cutoff comparison would silently drop it
3. the marker is `user_metadata.has_key("analysis")`, never `source_filename`

Elapsed-time counting is not reintroduced.

## Tenant scoping

Single-tenant mode takes the unfiltered count — that deployment has one tenant by definition, so the count IS the tenant's, and it avoids depending on whether the database stamps `tenant_id` as NULL or as a fixed value there. Multi-tenant filters on `IngestJob.tenant_id`, which already exists and is already indexed (`ix_catalog_ingest_jobs_tenant_id`), so there is **no schema work**.

## Tests

- `test_tenant_cap_refuses_a_second_user_and_names_itself` — a second user in the tenant holds the cap in `pending` jobs (which also exercises the status-only branch), and this user's request 429s with a detail that is distinguishable from the per-user message
- `test_tenant_cap_stale_lease_releases_a_slot` — one of the filler jobs is a hard-killed worker (stale heartbeat), and the request is admitted

Both verified to fail with the cap removed.

Two notes on the shared worker database, since this file's tests already collide there. The filler helper **counts what is already active** and tops up rather than assuming zero, so a sibling that left a job behind cannot make these pass or fail for the wrong reason. And the refusal test releases the job it would create if the cap ever regresses — otherwise a regression would hold this user's per-user slot for every sibling test, which is the #933 failure mode.

## Verification

```
cd backend && uv run pytest tests/test_analysis_materialize.py -q       # 81 passed
cd backend && uv run pytest tests/test_layering.py -q                   # 34 passed
cd backend && uv run ruff check . && uv run ruff format --check .       # clean
```

No schema or API-contract change: the 429 status is unchanged, only a new detail string.

Closes #1015