### PR TITLE
fix(maps): export a builtin fill pattern as a solid fill

### DIFF
--- a/backend/app/modules/catalog/maps/style_json.py
+++ b/backend/app/modules/catalog/maps/style_json.py
@@ -1312,10 +1312,28 @@ _EXPRESSION_OUTPUT_POSITIONS: dict[str, tuple[int, int]] = {
     # produced the same disappearing polygon as a bare string.
     "image": (1, 1),
     "literal": (1, 1),
+    # fix(#917 codex r5): ["let", name, value, ..., result]. The binding VALUES
+    # sit at the same 2-step offset the branching forms use and the result is
+    # last, so `let` needs no special handling beyond the table — a `["var", n]`
+    # in the result reaches its binding, and reading the binding directly
+    # answers the question without resolving the reference. Binding NAMES land
+    # on the odd indices the stride skips, exactly like `match` labels.
+    "let": (2, 2),
 }
 
+# The forms whose LAST operand is also an output: a `case`/`match` fallback, and
+# a `let` result. `step` and `coalesce` are fully covered by their stride.
+_EXPRESSION_TRAILING_OUTPUT = frozenset({"case", "match", "let"})
 
-def _references_builtin_fill_pattern(value: Any) -> bool:
+# fix(#917 codex r5): a bound on how deep an authored expression is followed.
+# `_validate_style_dict` caps a paint dict at 64KB serialized, which still
+# allows nesting far past Python's recursion limit, and a RecursionError here
+# would be a 500 from the shared style endpoint. Anything this deep is not a
+# real pattern; stop descending and leave the value alone.
+_MAX_EXPRESSION_DEPTH = 32
+
+
+def _references_builtin_fill_pattern(value: Any, depth: int = 0) -> bool:
     """Whether a fill-pattern value can resolve to a builtin id.
 
     A plain string is checked directly. A branching expression is checked at its
@@ -1326,6 +1344,8 @@ def _references_builtin_fill_pattern(value: Any) -> bool:
     the builder's pattern control writes a single value, so anything else is
     hand-authored, and guessing wrong here silently flattens a working layer.
     """
+    if depth > _MAX_EXPRESSION_DEPTH:
+        return False
     if isinstance(value, str):
         return value in _BUILTIN_FILL_PATTERN_IDS
     if isinstance(value, dict):
@@ -1337,14 +1357,25 @@ def _references_builtin_fill_pattern(value: Any) -> bool:
         # Its outputs are the second element of each stop, plus `default`. The
         # first element is the input value being matched — data, like a `match`
         # label — so it is read at the same positions the array forms are.
-        outputs = [
-            stop[-1]
-            for stop in (value.get("stops") or [])
-            if isinstance(stop, (list, tuple)) and len(stop) >= 2
-        ]
+        # fix(#917 codex r5): `stops` is whatever the open-dict `paint` API was
+        # handed — `_validate_style_dict` only bounds its serialized size, so
+        # `{"stops": 1}` is stored today and iterating it would raise. A string
+        # is worse than an int here: it iterates silently, one character at a
+        # time. Anything that is not a list of pairs is not a function object,
+        # so treat it as non-matching and let the existing validator degrade it.
+        stops = value.get("stops")
+        outputs = (
+            [
+                stop[-1]
+                for stop in stops
+                if isinstance(stop, (list, tuple)) and len(stop) >= 2
+            ]
+            if isinstance(stops, (list, tuple))
+            else []
+        )
         if "default" in value:
             outputs.append(value["default"])
-        return any(_references_builtin_fill_pattern(out) for out in outputs)
+        return any(_references_builtin_fill_pattern(out, depth + 1) for out in outputs)
     if not (isinstance(value, list) and value and isinstance(value[0], str)):
         return False
     positions = _EXPRESSION_OUTPUT_POSITIONS.get(value[0])
@@ -1352,11 +1383,9 @@ def _references_builtin_fill_pattern(value: Any) -> bool:
         return False
     start, step = positions
     outputs = list(value[start::step])
-    # `case` and `match` end with a fallback that is also an output; `step` and
-    # `coalesce` have no trailing element the stride misses.
-    if value[0] in ("case", "match") and len(value) > start:
+    if value[0] in _EXPRESSION_TRAILING_OUTPUT and len(value) > start:
         outputs.append(value[-1])
-    return any(_references_builtin_fill_pattern(item) for item in outputs)
+    return any(_references_builtin_fill_pattern(item, depth + 1) for item in outputs)
 
 
 def _strip_builtin_fill_pattern(layer: dict[str, Any]) -> None:

--- a/backend/app/modules/catalog/maps/style_json.py
+++ b/backend/app/modules/catalog/maps/style_json.py
@@ -1288,162 +1288,33 @@ _BUILTIN_FILL_PATTERN_IDS = frozenset(
 )
 
 
-# fix(#917 codex r2/r3): where each branching expression puts its OUTPUTS, as
-# (start, step) over the operand list after the operator. Everything else in an
-# expression — property names, comparison operands, `match` labels — is data,
-# and a builtin id appearing there says nothing about what the expression
-# returns. Scanning every nested string flattened working layers to a solid
-# fill; ignoring lists entirely missed a builtin in a real output branch. Only
-# these four forms can yield an image id in MapLibre, and each has a documented
-# operand layout, so the positions are read rather than guessed.
-_EXPRESSION_OUTPUT_POSITIONS: dict[str, tuple[int, int]] = {
-    # ["case", cond, out, cond, out, ..., fallback]
-    "case": (2, 2),
-    # ["match", input, label, out, ..., fallback]
-    "match": (3, 2),
-    # ["step", input, out, stop, out, ...]
-    "step": (2, 2),
-    # ["coalesce", out, out, ...]
-    "coalesce": (1, 1),
-    # fix(#917 codex r3): the two forms that name an image DIRECTLY rather than
-    # branching to one. `["image", id]` is MapLibre's explicit image expression
-    # and `["literal", id]` is the constant form; both evaluate to their single
-    # operand, so a builtin wrapped in either reached the sprite unchanged and
-    # produced the same disappearing polygon as a bare string.
-    "image": (1, 1),
-    "literal": (1, 1),
-    # fix(#917 codex r5): ["let", name, value, ..., result]. The binding VALUES
-    # sit at the same 2-step offset the branching forms use and the result is
-    # last, so `let` needs no special handling beyond the table — a `["var", n]`
-    # in the result reaches its binding, and reading the binding directly
-    # answers the question without resolving the reference. Binding NAMES land
-    # on the odd indices the stride skips, exactly like `match` labels.
-    "let": (2, 2),
-}
+def _references_builtin_fill_pattern(value: Any) -> bool:
+    """Whether a fill-pattern value is a builtin id.
 
-# The forms whose LAST operand is also an output: a `case`/`match` fallback, and
-# a `let` result. `step` and `coalesce` are fully covered by their stride.
-_EXPRESSION_TRAILING_OUTPUT = frozenset({"case", "match", "let"})
+    A plain string only. A composite value — a data-driven expression or a
+    legacy function object — is left alone deliberately, and that is a design
+    decision rather than a coverage gap.
 
-# fix(#917 codex r5): a bound on how deep an authored expression is followed.
-# `_validate_style_dict` caps a paint dict at 64KB serialized, which still
-# allows nesting far past Python's recursion limit, and a RecursionError here
-# would be a 500 from the shared style endpoint. Anything this deep is not a
-# real pattern; stop descending and leave the value alone.
-_MAX_EXPRESSION_DEPTH = 32
+    fix(#917 codex r1-r6): eight review rounds built an expression reader here
+    and then established that it could not be made safe. MapLibre resolves a
+    missing pattern by SKIPPING it and firing `styleimagemissing`, which the
+    docs describe as the hook for supplying the image at runtime — so an export
+    that still names a builtin degrades and stays repairable by the consumer.
+    Stripping a working expression removes authored content that no downstream
+    hook can bring back. One failure is recoverable by design, the other is
+    permanent, and reading composites correctly was trading the permanent one
+    for the recoverable one: `["coalesce", ["image", builtin], ["image", other]]`
+    is MapLibre's own documented way to author a fallback, and the detector was
+    deleting it.
 
-
-def _references_builtin_fill_pattern(value: Any, depth: int = 0) -> bool:
-    """Whether a fill-pattern value can resolve to a builtin id.
-
-    A plain string is checked directly. A branching expression is checked at its
-    output positions only, recursively, so a nested expression in a branch is
-    followed and an id used as an operand or a `match` label is not. The two
-    direct forms — `image` and `literal` — name their image in the single
-    operand. Any other expression shape is treated as not referencing a builtin:
-    the builder's pattern control writes a single value, so anything else is
-    hand-authored, and guessing wrong here silently flattens a working layer.
+    Coverage is unaffected for the bug #917 reports. The BUILDER writes a plain
+    string (`fill-pattern-images.ts`), which is all GeoLens itself produces;
+    every composite reaches the column through style import or the open-dict
+    `paint` API, which makes it authored and the author's to own. A correct
+    composite reader is a MapLibre expression evaluator — a real feature with a
+    real spec, tracked separately, not a stopgap in a serializer.
     """
-    if depth > _MAX_EXPRESSION_DEPTH:
-        return False
-    if isinstance(value, str):
-        return value in _BUILTIN_FILL_PATTERN_IDS
-    if isinstance(value, dict):
-        # fix(#917 codex r4): MapLibre's LEGACY function object, still accepted
-        # for data-driven properties and preserved by both the style import and
-        # the open-dict `paint` API:
-        #   {"type": "categorical", "property": "kind",
-        #    "stops": [["x", "geolens-fill-grid"]], "default": "uploaded-a"}
-        # Its outputs are the second element of each stop, plus `default`. The
-        # first element is the input value being matched — data, like a `match`
-        # label — so it is read at the same positions the array forms are.
-        # fix(#917 codex r5): `stops` is whatever the open-dict `paint` API was
-        # handed — `_validate_style_dict` only bounds its serialized size, so
-        # `{"stops": 1}` is stored today and iterating it would raise. A string
-        # is worse than an int here: it iterates silently, one character at a
-        # time. Anything that is not a list of pairs is not a function object,
-        # so treat it as non-matching and let the existing validator degrade it.
-        stops = value.get("stops")
-        outputs = (
-            [
-                stop[-1]
-                for stop in stops
-                if isinstance(stop, (list, tuple)) and len(stop) >= 2
-            ]
-            if isinstance(stops, (list, tuple))
-            else []
-        )
-        if "default" in value:
-            outputs.append(value["default"])
-        return any(_references_builtin_fill_pattern(out, depth + 1) for out in outputs)
-    if not (isinstance(value, list) and value and isinstance(value[0], str)):
-        return False
-    positions = _EXPRESSION_OUTPUT_POSITIONS.get(value[0])
-    if positions is None:
-        return False
-    if value[0] == "coalesce":
-        # fix(#917 codex r6): `coalesce` is MapLibre's availability-aware
-        # fallback, and `["image", id]` evaluates to null when the sprite lacks
-        # that id — so `["coalesce", ["image", builtin], ["image", uploaded]]`
-        # is the CORRECT way to author a pattern with a fallback, and it already
-        # renders. It fails only when every operand is unavailable, so report a
-        # builtin here only when no operand offers a way out.
-        operands = value[1:]
-        return bool(operands) and all(
-            _references_builtin_fill_pattern(item, depth + 1) for item in operands
-        )
-    if value[0] == "let":
-        return _let_references_builtin(value, depth)
-    start, step = positions
-    outputs = list(value[start::step])
-    if value[0] in _EXPRESSION_TRAILING_OUTPUT and len(value) > start:
-        outputs.append(value[-1])
-    return any(_references_builtin_fill_pattern(item, depth + 1) for item in outputs)
-
-
-def _collect_var_names(value: Any, into: set[str]) -> None:
-    """Gather every ``["var", name]`` reference reachable in ``value``."""
-    if not isinstance(value, list):
-        return
-    if len(value) >= 2 and value[0] == "var" and isinstance(value[1], str):
-        into.add(value[1])
-        return
-    for item in value:
-        _collect_var_names(item, into)
-
-
-def _let_references_builtin(value: list, depth: int) -> bool:
-    """``["let", name, value, ..., result]`` — only the bindings the result USES.
-
-    fix(#917 codex r6): a binding the result never references cannot contribute
-    to what MapLibre renders, so
-    ``["let", "unused", ["image", builtin], ["image", uploaded]]`` resolves to
-    the uploaded image and works. Scanning every binding stripped it. Follow the
-    `var` references out of the result instead, transitively, since one binding
-    may reference another.
-    """
-    bindings = {
-        value[i]: value[i + 1]
-        for i in range(1, len(value) - 1, 2)
-        if isinstance(value[i], str)
-    }
-    result = value[-1] if len(value) > 1 else None
-    if _references_builtin_fill_pattern(result, depth + 1):
-        return True
-
-    seen: set[str] = set()
-    pending: set[str] = set()
-    _collect_var_names(result, pending)
-    while pending:
-        name = pending.pop()
-        if name in seen or name not in bindings:
-            continue
-        seen.add(name)
-        bound = bindings[name]
-        if _references_builtin_fill_pattern(bound, depth + 1):
-            return True
-        _collect_var_names(bound, pending)
-    return False
+    return isinstance(value, str) and value in _BUILTIN_FILL_PATTERN_IDS
 
 
 def _strip_builtin_fill_pattern(layer: dict[str, Any]) -> None:

--- a/backend/app/modules/catalog/maps/style_json.py
+++ b/backend/app/modules/catalog/maps/style_json.py
@@ -1305,6 +1305,13 @@ _EXPRESSION_OUTPUT_POSITIONS: dict[str, tuple[int, int]] = {
     "step": (2, 2),
     # ["coalesce", out, out, ...]
     "coalesce": (1, 1),
+    # fix(#917 codex r3): the two forms that name an image DIRECTLY rather than
+    # branching to one. `["image", id]` is MapLibre's explicit image expression
+    # and `["literal", id]` is the constant form; both evaluate to their single
+    # operand, so a builtin wrapped in either reached the sprite unchanged and
+    # produced the same disappearing polygon as a bare string.
+    "image": (1, 1),
+    "literal": (1, 1),
 }
 
 
@@ -1313,10 +1320,11 @@ def _references_builtin_fill_pattern(value: Any) -> bool:
 
     A plain string is checked directly. A branching expression is checked at its
     output positions only, recursively, so a nested expression in a branch is
-    followed and an id used as an operand or a `match` label is not. Any other
-    expression shape is treated as not referencing a builtin: the builder's
-    pattern control writes a single value, so anything else is hand-authored,
-    and guessing wrong here silently flattens a working layer.
+    followed and an id used as an operand or a `match` label is not. The two
+    direct forms — `image` and `literal` — name their image in the single
+    operand. Any other expression shape is treated as not referencing a builtin:
+    the builder's pattern control writes a single value, so anything else is
+    hand-authored, and guessing wrong here silently flattens a working layer.
     """
     if isinstance(value, str):
         return value in _BUILTIN_FILL_PATTERN_IDS

--- a/backend/app/modules/catalog/maps/style_json.py
+++ b/backend/app/modules/catalog/maps/style_json.py
@@ -1266,6 +1266,55 @@ def _strip_wrong_typed_values(layer: dict[str, Any], key: str) -> None:
         )
 
 
+# fix(#917): the builder's builtin fill patterns. Their images are generated and
+# registered in the browser by `layer-adapters/fill-pattern-images.ts`, so they
+# exist only inside a GeoLens session — the served sprite is indexed from the
+# `map_icons` table alone and has never contained them.
+_BUILTIN_FILL_PATTERN_PREFIX = "geolens-fill-"
+
+
+def _references_builtin_fill_pattern(value: Any) -> bool:
+    """Whether a fill-pattern value names a builtin, directly or in an expression."""
+    if isinstance(value, str):
+        return value.startswith(_BUILTIN_FILL_PATTERN_PREFIX)
+    if isinstance(value, list):
+        return any(_references_builtin_fill_pattern(item) for item in value)
+    return False
+
+
+def _strip_builtin_fill_pattern(layer: dict[str, Any]) -> None:
+    """Drop a builtin fill-pattern from an emitted layer, falling back to a colour.
+
+    fix(#917): an external MapLibre client loading the exported document asked
+    the sprite for an id it does not contain, got a missing-image warning, and
+    rendered no fill at all — a polygon layer that silently disappeared. In-app
+    surfaces never hit this because they go through the client-side adapter
+    registry, which generates the images in the browser.
+
+    A solid fill is the honest export of a pattern the document cannot carry.
+    Baking the five generators into the served sprite would keep exports
+    faithful, but a sprite is one shared atlas and cannot hold the per-layer
+    tint the client-side generator applies (#914), so that is not this fix.
+
+    Only the ``geolens-fill-*`` builtins are stripped. They are a closed set
+    this repo owns and knows to be absent from the sprite; any other value may
+    name a real ``map_icons`` sprite entry, and dropping it would break a style
+    that works.
+    """
+    paint = layer.get("paint")
+    if not isinstance(paint, dict):
+        return
+    if not _references_builtin_fill_pattern(paint.get("fill-pattern")):
+        return
+    del paint["fill-pattern"]
+    if "fill-color" not in paint:
+        paint["fill-color"] = DEFAULT_FILL_COLOR
+    logger.debug(
+        "Exported layer %s as a solid fill: builtin fill patterns are not in the sprite",
+        layer.get("id"),
+    )
+
+
 def _validate_emitted_style(style: dict[str, Any]) -> None:
     """Strip non-spec paint/layout properties from every emitted layer in place."""
     layers = style.get("layers")
@@ -1275,6 +1324,8 @@ def _validate_emitted_style(style: dict[str, Any]) -> None:
         if not isinstance(layer, dict):
             continue
         layer_type = layer.get("type")
+        if layer_type == "fill":
+            _strip_builtin_fill_pattern(layer)
         paint_allowed = _PAINT_PROPERTIES_BY_TYPE.get(layer_type)
         if paint_allowed is not None:
             _strip_unknown_properties(layer, "paint", paint_allowed)

--- a/backend/app/modules/catalog/maps/style_json.py
+++ b/backend/app/modules/catalog/maps/style_json.py
@@ -1381,11 +1381,69 @@ def _references_builtin_fill_pattern(value: Any, depth: int = 0) -> bool:
     positions = _EXPRESSION_OUTPUT_POSITIONS.get(value[0])
     if positions is None:
         return False
+    if value[0] == "coalesce":
+        # fix(#917 codex r6): `coalesce` is MapLibre's availability-aware
+        # fallback, and `["image", id]` evaluates to null when the sprite lacks
+        # that id — so `["coalesce", ["image", builtin], ["image", uploaded]]`
+        # is the CORRECT way to author a pattern with a fallback, and it already
+        # renders. It fails only when every operand is unavailable, so report a
+        # builtin here only when no operand offers a way out.
+        operands = value[1:]
+        return bool(operands) and all(
+            _references_builtin_fill_pattern(item, depth + 1) for item in operands
+        )
+    if value[0] == "let":
+        return _let_references_builtin(value, depth)
     start, step = positions
     outputs = list(value[start::step])
     if value[0] in _EXPRESSION_TRAILING_OUTPUT and len(value) > start:
         outputs.append(value[-1])
     return any(_references_builtin_fill_pattern(item, depth + 1) for item in outputs)
+
+
+def _collect_var_names(value: Any, into: set[str]) -> None:
+    """Gather every ``["var", name]`` reference reachable in ``value``."""
+    if not isinstance(value, list):
+        return
+    if len(value) >= 2 and value[0] == "var" and isinstance(value[1], str):
+        into.add(value[1])
+        return
+    for item in value:
+        _collect_var_names(item, into)
+
+
+def _let_references_builtin(value: list, depth: int) -> bool:
+    """``["let", name, value, ..., result]`` — only the bindings the result USES.
+
+    fix(#917 codex r6): a binding the result never references cannot contribute
+    to what MapLibre renders, so
+    ``["let", "unused", ["image", builtin], ["image", uploaded]]`` resolves to
+    the uploaded image and works. Scanning every binding stripped it. Follow the
+    `var` references out of the result instead, transitively, since one binding
+    may reference another.
+    """
+    bindings = {
+        value[i]: value[i + 1]
+        for i in range(1, len(value) - 1, 2)
+        if isinstance(value[i], str)
+    }
+    result = value[-1] if len(value) > 1 else None
+    if _references_builtin_fill_pattern(result, depth + 1):
+        return True
+
+    seen: set[str] = set()
+    pending: set[str] = set()
+    _collect_var_names(result, pending)
+    while pending:
+        name = pending.pop()
+        if name in seen or name not in bindings:
+            continue
+        seen.add(name)
+        bound = bindings[name]
+        if _references_builtin_fill_pattern(bound, depth + 1):
+            return True
+        _collect_var_names(bound, pending)
+    return False
 
 
 def _strip_builtin_fill_pattern(layer: dict[str, Any]) -> None:

--- a/backend/app/modules/catalog/maps/style_json.py
+++ b/backend/app/modules/catalog/maps/style_json.py
@@ -1289,12 +1289,19 @@ _BUILTIN_FILL_PATTERN_IDS = frozenset(
 
 
 def _references_builtin_fill_pattern(value: Any) -> bool:
-    """Whether a fill-pattern value names a builtin, directly or in an expression."""
-    if isinstance(value, str):
-        return value in _BUILTIN_FILL_PATTERN_IDS
-    if isinstance(value, list):
-        return any(_references_builtin_fill_pattern(item) for item in value)
-    return False
+    """Whether a fill-pattern value is a builtin id.
+
+    fix(#917 codex r2): a plain string only. Scanning a data-driven expression
+    for the ids treats every nested string as a possible output image, including
+    property names, comparison operands and ``match`` labels — so
+    ``["case", ["==", ["get", "kind"], "geolens-fill-grid"], "uploaded-a",
+    "uploaded-b"]`` can only ever return real sprite ids, and stripping it would
+    flatten a working layer to a solid fill. Telling an output branch from an
+    operand needs an expression evaluator, and the builder's pattern control
+    writes a single value, so there is nothing to gain by guessing: a
+    hand-authored expression is left exactly as authored.
+    """
+    return isinstance(value, str) and value in _BUILTIN_FILL_PATTERN_IDS
 
 
 def _strip_builtin_fill_pattern(layer: dict[str, Any]) -> None:

--- a/backend/app/modules/catalog/maps/style_json.py
+++ b/backend/app/modules/catalog/maps/style_json.py
@@ -1269,14 +1269,29 @@ def _strip_wrong_typed_values(layer: dict[str, Any], key: str) -> None:
 # fix(#917): the builder's builtin fill patterns. Their images are generated and
 # registered in the browser by `layer-adapters/fill-pattern-images.ts`, so they
 # exist only inside a GeoLens session — the served sprite is indexed from the
-# `map_icons` table alone and has never contained them.
-_BUILTIN_FILL_PATTERN_PREFIX = "geolens-fill-"
+# `map_icons` table alone and has never contained them. Mirrors
+# `FILL_PATTERN_IDS` in that module; keep the two in step.
+#
+# fix(#917 codex r1): matched exactly, never by the `geolens-fill-` prefix.
+# `create_icon_asset` derives a sprite slug from the uploaded filename, so an
+# icon named `geolens-fill-logo.png` becomes a real `map_icons` entry whose slug
+# carries that prefix — reserving it would strip a working pattern from every
+# exported style.
+_BUILTIN_FILL_PATTERN_IDS = frozenset(
+    {
+        "geolens-fill-hatch",
+        "geolens-fill-crosshatch",
+        "geolens-fill-diagonal",
+        "geolens-fill-dots",
+        "geolens-fill-grid",
+    }
+)
 
 
 def _references_builtin_fill_pattern(value: Any) -> bool:
     """Whether a fill-pattern value names a builtin, directly or in an expression."""
     if isinstance(value, str):
-        return value.startswith(_BUILTIN_FILL_PATTERN_PREFIX)
+        return value in _BUILTIN_FILL_PATTERN_IDS
     if isinstance(value, list):
         return any(_references_builtin_fill_pattern(item) for item in value)
     return False
@@ -1296,10 +1311,9 @@ def _strip_builtin_fill_pattern(layer: dict[str, Any]) -> None:
     faithful, but a sprite is one shared atlas and cannot hold the per-layer
     tint the client-side generator applies (#914), so that is not this fix.
 
-    Only the ``geolens-fill-*`` builtins are stripped. They are a closed set
-    this repo owns and knows to be absent from the sprite; any other value may
-    name a real ``map_icons`` sprite entry, and dropping it would break a style
-    that works.
+    Only the five builtin ids are stripped. They are a closed set this repo owns
+    and knows to be absent from the sprite; any other value may name a real
+    ``map_icons`` sprite entry, and dropping it would break a style that works.
     """
     paint = layer.get("paint")
     if not isinstance(paint, dict):

--- a/backend/app/modules/catalog/maps/style_json.py
+++ b/backend/app/modules/catalog/maps/style_json.py
@@ -1288,20 +1288,50 @@ _BUILTIN_FILL_PATTERN_IDS = frozenset(
 )
 
 
-def _references_builtin_fill_pattern(value: Any) -> bool:
-    """Whether a fill-pattern value is a builtin id.
+# fix(#917 codex r2/r3): where each branching expression puts its OUTPUTS, as
+# (start, step) over the operand list after the operator. Everything else in an
+# expression — property names, comparison operands, `match` labels — is data,
+# and a builtin id appearing there says nothing about what the expression
+# returns. Scanning every nested string flattened working layers to a solid
+# fill; ignoring lists entirely missed a builtin in a real output branch. Only
+# these four forms can yield an image id in MapLibre, and each has a documented
+# operand layout, so the positions are read rather than guessed.
+_EXPRESSION_OUTPUT_POSITIONS: dict[str, tuple[int, int]] = {
+    # ["case", cond, out, cond, out, ..., fallback]
+    "case": (2, 2),
+    # ["match", input, label, out, ..., fallback]
+    "match": (3, 2),
+    # ["step", input, out, stop, out, ...]
+    "step": (2, 2),
+    # ["coalesce", out, out, ...]
+    "coalesce": (1, 1),
+}
 
-    fix(#917 codex r2): a plain string only. Scanning a data-driven expression
-    for the ids treats every nested string as a possible output image, including
-    property names, comparison operands and ``match`` labels — so
-    ``["case", ["==", ["get", "kind"], "geolens-fill-grid"], "uploaded-a",
-    "uploaded-b"]`` can only ever return real sprite ids, and stripping it would
-    flatten a working layer to a solid fill. Telling an output branch from an
-    operand needs an expression evaluator, and the builder's pattern control
-    writes a single value, so there is nothing to gain by guessing: a
-    hand-authored expression is left exactly as authored.
+
+def _references_builtin_fill_pattern(value: Any) -> bool:
+    """Whether a fill-pattern value can resolve to a builtin id.
+
+    A plain string is checked directly. A branching expression is checked at its
+    output positions only, recursively, so a nested expression in a branch is
+    followed and an id used as an operand or a `match` label is not. Any other
+    expression shape is treated as not referencing a builtin: the builder's
+    pattern control writes a single value, so anything else is hand-authored,
+    and guessing wrong here silently flattens a working layer.
     """
-    return isinstance(value, str) and value in _BUILTIN_FILL_PATTERN_IDS
+    if isinstance(value, str):
+        return value in _BUILTIN_FILL_PATTERN_IDS
+    if not (isinstance(value, list) and value and isinstance(value[0], str)):
+        return False
+    positions = _EXPRESSION_OUTPUT_POSITIONS.get(value[0])
+    if positions is None:
+        return False
+    start, step = positions
+    outputs = list(value[start::step])
+    # `case` and `match` end with a fallback that is also an output; `step` and
+    # `coalesce` have no trailing element the stride misses.
+    if value[0] in ("case", "match") and len(value) > start:
+        outputs.append(value[-1])
+    return any(_references_builtin_fill_pattern(item) for item in outputs)
 
 
 def _strip_builtin_fill_pattern(layer: dict[str, Any]) -> None:

--- a/backend/app/modules/catalog/maps/style_json.py
+++ b/backend/app/modules/catalog/maps/style_json.py
@@ -1328,6 +1328,23 @@ def _references_builtin_fill_pattern(value: Any) -> bool:
     """
     if isinstance(value, str):
         return value in _BUILTIN_FILL_PATTERN_IDS
+    if isinstance(value, dict):
+        # fix(#917 codex r4): MapLibre's LEGACY function object, still accepted
+        # for data-driven properties and preserved by both the style import and
+        # the open-dict `paint` API:
+        #   {"type": "categorical", "property": "kind",
+        #    "stops": [["x", "geolens-fill-grid"]], "default": "uploaded-a"}
+        # Its outputs are the second element of each stop, plus `default`. The
+        # first element is the input value being matched — data, like a `match`
+        # label — so it is read at the same positions the array forms are.
+        outputs = [
+            stop[-1]
+            for stop in (value.get("stops") or [])
+            if isinstance(stop, (list, tuple)) and len(stop) >= 2
+        ]
+        if "default" in value:
+            outputs.append(value["default"])
+        return any(_references_builtin_fill_pattern(out) for out in outputs)
     if not (isinstance(value, list) and value and isinstance(value[0], str)):
         return False
     positions = _EXPRESSION_OUTPUT_POSITIONS.get(value[0])

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -1180,10 +1180,10 @@ def test_open_core_decomposition_boundaries_stay_clean() -> None:
         # fix(v1.6.0 audit): hypso_reversed flows into the color-relief
         # companion so exported ramps match the builder's Reverse toggle.
         # fix(#836): +1 for the RASTER_FAMILY_RECORD_TYPES import.
-        # fix(#917): +127 — builtin `geolens-fill-*` patterns are stripped at export
+        # fix(#917): +156 — builtin `geolens-fill-*` patterns are stripped at export
         # and fall back to a solid colour, since the served sprite is indexed from
         # `map_icons` alone and never contained them. Ratchet stays exact.
-        "backend/app/modules/catalog/maps/style_json.py": 1559,
+        "backend/app/modules/catalog/maps/style_json.py": 1588,
         "backend/app/modules/catalog/maps/style_import.py": 450,
         "backend/app/modules/catalog/maps/style_sanitizers.py": 200,
         "backend/app/modules/catalog/maps/router_assets.py": 126,

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -1180,10 +1180,12 @@ def test_open_core_decomposition_boundaries_stay_clean() -> None:
         # fix(v1.6.0 audit): hypso_reversed flows into the color-relief
         # companion so exported ramps match the builder's Reverse toggle.
         # fix(#836): +1 for the RASTER_FAMILY_RECORD_TYPES import.
-        # fix(#917): +214 — builtin `geolens-fill-*` patterns are stripped at export
-        # and fall back to a solid colour, since the served sprite is indexed from
-        # `map_icons` alone and never contained them. Ratchet stays exact.
-        "backend/app/modules/catalog/maps/style_json.py": 1646,
+        # fix(#917): +85 — builtin fill patterns are stripped at export and fall back
+        # to a solid colour. Plain strings only: composites are left as authored,
+        # because MapLibre skips a missing pattern and exposes styleimagemissing to
+        # repair it, while stripping a working expression is unrecoverable (#1069).
+        # Ratchet stays exact.
+        "backend/app/modules/catalog/maps/style_json.py": 1517,
         "backend/app/modules/catalog/maps/style_import.py": 450,
         "backend/app/modules/catalog/maps/style_sanitizers.py": 200,
         "backend/app/modules/catalog/maps/router_assets.py": 126,

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -1180,10 +1180,10 @@ def test_open_core_decomposition_boundaries_stay_clean() -> None:
         # fix(v1.6.0 audit): hypso_reversed flows into the color-relief
         # companion so exported ramps match the builder's Reverse toggle.
         # fix(#836): +1 for the RASTER_FAMILY_RECORD_TYPES import.
-        # fix(#917): +110 — builtin `geolens-fill-*` patterns are stripped at export
+        # fix(#917): +127 — builtin `geolens-fill-*` patterns are stripped at export
         # and fall back to a solid colour, since the served sprite is indexed from
         # `map_icons` alone and never contained them. Ratchet stays exact.
-        "backend/app/modules/catalog/maps/style_json.py": 1542,
+        "backend/app/modules/catalog/maps/style_json.py": 1559,
         "backend/app/modules/catalog/maps/style_import.py": 450,
         "backend/app/modules/catalog/maps/style_sanitizers.py": 200,
         "backend/app/modules/catalog/maps/router_assets.py": 126,

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -1180,10 +1180,10 @@ def test_open_core_decomposition_boundaries_stay_clean() -> None:
         # fix(v1.6.0 audit): hypso_reversed flows into the color-relief
         # companion so exported ramps match the builder's Reverse toggle.
         # fix(#836): +1 for the RASTER_FAMILY_RECORD_TYPES import.
-        # fix(#917): +156 — builtin `geolens-fill-*` patterns are stripped at export
+        # fix(#917): +214 — builtin `geolens-fill-*` patterns are stripped at export
         # and fall back to a solid colour, since the served sprite is indexed from
         # `map_icons` alone and never contained them. Ratchet stays exact.
-        "backend/app/modules/catalog/maps/style_json.py": 1588,
+        "backend/app/modules/catalog/maps/style_json.py": 1646,
         "backend/app/modules/catalog/maps/style_import.py": 450,
         "backend/app/modules/catalog/maps/style_sanitizers.py": 200,
         "backend/app/modules/catalog/maps/router_assets.py": 126,

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -1180,7 +1180,10 @@ def test_open_core_decomposition_boundaries_stay_clean() -> None:
         # fix(v1.6.0 audit): hypso_reversed flows into the color-relief
         # companion so exported ramps match the builder's Reverse toggle.
         # fix(#836): +1 for the RASTER_FAMILY_RECORD_TYPES import.
-        "backend/app/modules/catalog/maps/style_json.py": 1432,
+        # fix(#917): +51 — builtin `geolens-fill-*` patterns are stripped at export
+        # and fall back to a solid colour, since the served sprite is indexed from
+        # `map_icons` alone and never contained them. Ratchet stays exact.
+        "backend/app/modules/catalog/maps/style_json.py": 1483,
         "backend/app/modules/catalog/maps/style_import.py": 450,
         "backend/app/modules/catalog/maps/style_sanitizers.py": 200,
         "backend/app/modules/catalog/maps/router_assets.py": 126,

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -1180,10 +1180,10 @@ def test_open_core_decomposition_boundaries_stay_clean() -> None:
         # fix(v1.6.0 audit): hypso_reversed flows into the color-relief
         # companion so exported ramps match the builder's Reverse toggle.
         # fix(#836): +1 for the RASTER_FAMILY_RECORD_TYPES import.
-        # fix(#917): +51 — builtin `geolens-fill-*` patterns are stripped at export
+        # fix(#917): +65 — builtin `geolens-fill-*` patterns are stripped at export
         # and fall back to a solid colour, since the served sprite is indexed from
         # `map_icons` alone and never contained them. Ratchet stays exact.
-        "backend/app/modules/catalog/maps/style_json.py": 1483,
+        "backend/app/modules/catalog/maps/style_json.py": 1497,
         "backend/app/modules/catalog/maps/style_import.py": 450,
         "backend/app/modules/catalog/maps/style_sanitizers.py": 200,
         "backend/app/modules/catalog/maps/router_assets.py": 126,

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -1180,10 +1180,10 @@ def test_open_core_decomposition_boundaries_stay_clean() -> None:
         # fix(v1.6.0 audit): hypso_reversed flows into the color-relief
         # companion so exported ramps match the builder's Reverse toggle.
         # fix(#836): +1 for the RASTER_FAMILY_RECORD_TYPES import.
-        # fix(#917): +65 — builtin `geolens-fill-*` patterns are stripped at export
+        # fix(#917): +72 — builtin `geolens-fill-*` patterns are stripped at export
         # and fall back to a solid colour, since the served sprite is indexed from
         # `map_icons` alone and never contained them. Ratchet stays exact.
-        "backend/app/modules/catalog/maps/style_json.py": 1497,
+        "backend/app/modules/catalog/maps/style_json.py": 1504,
         "backend/app/modules/catalog/maps/style_import.py": 450,
         "backend/app/modules/catalog/maps/style_sanitizers.py": 200,
         "backend/app/modules/catalog/maps/router_assets.py": 126,

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -1180,10 +1180,10 @@ def test_open_core_decomposition_boundaries_stay_clean() -> None:
         # fix(v1.6.0 audit): hypso_reversed flows into the color-relief
         # companion so exported ramps match the builder's Reverse toggle.
         # fix(#836): +1 for the RASTER_FAMILY_RECORD_TYPES import.
-        # fix(#917): +102 — builtin `geolens-fill-*` patterns are stripped at export
+        # fix(#917): +110 — builtin `geolens-fill-*` patterns are stripped at export
         # and fall back to a solid colour, since the served sprite is indexed from
         # `map_icons` alone and never contained them. Ratchet stays exact.
-        "backend/app/modules/catalog/maps/style_json.py": 1534,
+        "backend/app/modules/catalog/maps/style_json.py": 1542,
         "backend/app/modules/catalog/maps/style_import.py": 450,
         "backend/app/modules/catalog/maps/style_sanitizers.py": 200,
         "backend/app/modules/catalog/maps/router_assets.py": 126,

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -1180,10 +1180,10 @@ def test_open_core_decomposition_boundaries_stay_clean() -> None:
         # fix(v1.6.0 audit): hypso_reversed flows into the color-relief
         # companion so exported ramps match the builder's Reverse toggle.
         # fix(#836): +1 for the RASTER_FAMILY_RECORD_TYPES import.
-        # fix(#917): +72 — builtin `geolens-fill-*` patterns are stripped at export
+        # fix(#917): +102 — builtin `geolens-fill-*` patterns are stripped at export
         # and fall back to a solid colour, since the served sprite is indexed from
         # `map_icons` alone and never contained them. Ratchet stays exact.
-        "backend/app/modules/catalog/maps/style_json.py": 1504,
+        "backend/app/modules/catalog/maps/style_json.py": 1534,
         "backend/app/modules/catalog/maps/style_import.py": 450,
         "backend/app/modules/catalog/maps/style_sanitizers.py": 200,
         "backend/app/modules/catalog/maps/router_assets.py": 126,

--- a/backend/tests/test_maps_style_json.py
+++ b/backend/tests/test_maps_style_json.py
@@ -2098,3 +2098,74 @@ def test_symbol_export_icon_allow_overlap_follows_label_toggle():
     exported_default = style_json._style_layer_for_map_layer(default, "src-1")
     primary_default = next(e for e in exported_default if e["type"] == "symbol")
     assert primary_default["layout"]["icon-allow-overlap"] is True
+
+
+# ---------------------------------------------------------------------------
+# fix(#917): builtin fill patterns are not in the served sprite
+# ---------------------------------------------------------------------------
+
+
+def _polygon_layer_with_pattern(pattern, **paint_extras):
+    return _layer(
+        dataset_geometry_type="POLYGON",
+        paint={"fill-pattern": pattern, **paint_extras},
+        label_config=None,
+        style_config=None,
+    )
+
+
+def _fill_paint(style):
+    return next(e for e in style["layers"] if e["type"] == "fill")["paint"]
+
+
+def test_builtin_fill_pattern_is_exported_as_a_solid_fill():
+    """The sprite is indexed from `map_icons` alone, so `geolens-fill-*` is not
+    in it — an external MapLibre client got a missing-image warning and rendered
+    no fill at all. In-app surfaces only work because the client-side adapter
+    registry generates the images in the browser.
+    """
+    style = build_maplibre_style(
+        _map(), [_polygon_layer_with_pattern("geolens-fill-hatch")]
+    )
+
+    paint = _fill_paint(style)
+    assert "fill-pattern" not in paint
+    assert paint["fill-color"] == style_json.DEFAULT_FILL_COLOR
+
+
+def test_stripping_a_builtin_pattern_keeps_an_authored_fill_color():
+    """The fallback colour is a default, not an override."""
+    style = build_maplibre_style(
+        _map(),
+        [_polygon_layer_with_pattern("geolens-fill-dots", **{"fill-color": "#94a3b8"})],
+    )
+
+    paint = _fill_paint(style)
+    assert "fill-pattern" not in paint
+    assert paint["fill-color"] == "#94a3b8"
+
+
+def test_a_builtin_pattern_inside_an_expression_is_stripped_too():
+    """A data-driven fill-pattern resolves to the same absent sprite ids."""
+    style = build_maplibre_style(
+        _map(),
+        [
+            _polygon_layer_with_pattern(
+                ["case", ["==", ["get", "kind"], "a"], "geolens-fill-grid", "other"]
+            )
+        ],
+    )
+
+    assert "fill-pattern" not in _fill_paint(style)
+
+
+def test_a_non_builtin_fill_pattern_is_left_alone():
+    """Only the closed `geolens-fill-*` set is known to be absent from the
+    sprite. Any other value may name a real `map_icons` entry, and dropping it
+    would break a style that works.
+    """
+    style = build_maplibre_style(
+        _map(), [_polygon_layer_with_pattern("some-uploaded-icon")]
+    )
+
+    assert _fill_paint(style)["fill-pattern"] == "some-uploaded-icon"

--- a/backend/tests/test_maps_style_json.py
+++ b/backend/tests/test_maps_style_json.py
@@ -2177,8 +2177,15 @@ def test_stripping_a_builtin_pattern_keeps_an_authored_fill_color():
             ],
             True,
         ),
+        # fix(#917 codex r3): the two DIRECT forms name their image in the
+        # single operand rather than branching to it, so a builtin wrapped in
+        # either reached the sprite unchanged.
+        (["image", "geolens-fill-grid"], True),
+        (["literal", "geolens-fill-dots"], True),
+        (["image", "uploaded-a"], False),
+        (["case", [">", 1, 0], ["image", "geolens-fill-hatch"], "up-b"], True),
         # An expression shape that cannot yield an image id is left alone.
-        (["literal", "geolens-fill-grid"], False),
+        (["zoom"], False),
     ],
 )
 def test_data_driven_fill_pattern_is_read_at_its_output_positions(pattern, stripped):

--- a/backend/tests/test_maps_style_json.py
+++ b/backend/tests/test_maps_style_json.py
@@ -1,6 +1,7 @@
 """Tests for saved map MapLibre style JSON import/export helpers."""
 
 import uuid
+from typing import Any
 from urllib.parse import parse_qs, urlsplit
 
 import pytest
@@ -2217,6 +2218,14 @@ def test_stripping_a_builtin_pattern_keeps_an_authored_fill_color():
         ),
         ({"stops": [["x", ["image", "geolens-fill-hatch"]]]}, True),
         ({"type": "exponential", "base": 2}, False),
+        # fix(#917 codex r5): ["let", name, value, ..., result]. Binding values
+        # sit at the same 2-step offset the branching forms use and the result
+        # is last, so reading the binding answers the question without resolving
+        # the `var` reference. Binding NAMES land on the skipped odd indices.
+        (["let", "p", "geolens-fill-grid", ["var", "p"]], True),
+        (["let", "p", "uploaded-a", "geolens-fill-dots"], True),
+        (["let", "p", "uploaded-a", ["var", "p"]], False),
+        (["let", "geolens-fill-grid", "uploaded-a", "uploaded-b"], False),
     ],
 )
 def test_data_driven_fill_pattern_is_read_at_its_output_positions(pattern, stripped):
@@ -2257,3 +2266,61 @@ def test_a_non_builtin_fill_pattern_is_left_alone(pattern):
     style = build_maplibre_style(_map(), [_polygon_layer_with_pattern(pattern)])
 
     assert _fill_paint(style)["fill-pattern"] == pattern
+
+
+@pytest.mark.parametrize(
+    "pattern",
+    [
+        # fix(#917 codex r5): `_validate_style_dict` bounds only the serialized
+        # SIZE of a paint dict, so the open-dict API stores these today. Before
+        # the type guard, exporting one raised from the shared style endpoint —
+        # turning tolerated-but-malformed stored data into a 500. A string is
+        # the nastiest of them: it iterates silently, one character at a time.
+        {"stops": 1},
+        {"stops": "geolens-fill-grid"},
+        {"stops": {"a": 1}},
+        {"stops": [1, 2, 3]},
+        {"stops": [["only-one-element"]]},
+    ],
+)
+def test_a_malformed_legacy_function_exports_instead_of_raising(pattern):
+    style = build_maplibre_style(_map(), [_polygon_layer_with_pattern(pattern)])
+
+    # Left as authored — not a function object, so not something to strip.
+    assert _fill_paint(style)["fill-pattern"] == pattern
+
+
+def test_a_pathologically_nested_expression_does_not_blow_the_stack():
+    """fix(#917 codex r5): the detector stops descending rather than raising.
+
+    `_validate_style_dict` bounds only the serialized size of a paint dict, and
+    64KB of `["coalesce", ...]` nests far past Python's recursion limit, so
+    without a depth bound this function would be the thing that 500s the shared
+    style endpoint.
+
+    Asserted against the detector, not `build_maplibre_style`, because the
+    export pipeline has its own recursion limit further down — a `copy.deepcopy`
+    that raises on the same input with or without this change. That is
+    pre-existing and out of scope here; what this pins is that the fill-pattern
+    guard does not ADD a crash path. The pipeline-level case below uses a depth
+    a real style could plausibly reach.
+    """
+    deep: Any = "geolens-fill-grid"
+    for _ in range(5000):
+        deep = ["coalesce", deep]
+
+    assert style_json._references_builtin_fill_pattern(deep) is False
+
+
+def test_a_deeply_but_plausibly_nested_pattern_still_exports():
+    """Nesting well past anything an author would write, but inside the
+    pipeline's own limits, so this exercises the whole export path."""
+    deep: Any = "geolens-fill-grid"
+    for _ in range(100):
+        deep = ["coalesce", deep]
+
+    style = build_maplibre_style(_map(), [_polygon_layer_with_pattern(deep)])
+
+    # Past the detector's depth bound, so it is left alone rather than stripped
+    # — the safe direction for a value nobody can have authored by hand.
+    assert _fill_paint(style)["fill-pattern"] == deep

--- a/backend/tests/test_maps_style_json.py
+++ b/backend/tests/test_maps_style_json.py
@@ -2145,25 +2145,59 @@ def test_stripping_a_builtin_pattern_keeps_an_authored_fill_color():
     assert paint["fill-color"] == "#94a3b8"
 
 
-def test_a_data_driven_fill_pattern_is_left_as_authored():
-    """fix(#917 codex r2): a builtin id inside an expression is not necessarily
-    an output image.
+@pytest.mark.parametrize(
+    ("pattern", "stripped"),
+    [
+        # fix(#917 codex r2): an id in an OPERAND or a `match` label says
+        # nothing about what the expression returns. Every branch here resolves
+        # to a real uploaded sprite id, so stripping would flatten a working
+        # layer to a solid fill.
+        (
+            ["case", ["==", ["get", "kind"], "geolens-fill-grid"], "up-a", "up-b"],
+            False,
+        ),
+        (["match", ["get", "kind"], "geolens-fill-grid", "up-a", "up-b"], False),
+        # fix(#917 codex r3): ...and an id in an OUTPUT branch really does
+        # resolve to an image the sprite does not contain, so ignoring lists
+        # wholesale left those layers broken for external clients.
+        (["case", ["==", ["get", "kind"], "a"], "geolens-fill-grid", "up-b"], True),
+        (["case", ["==", ["get", "kind"], "a"], "up-a", "geolens-fill-dots"], True),
+        (["match", ["get", "kind"], "x", "geolens-fill-hatch", "up-b"], True),
+        (["match", ["get", "kind"], "x", "up-a", "geolens-fill-dots"], True),
+        (["step", ["zoom"], "geolens-fill-grid", 10, "up-a"], True),
+        (["coalesce", "up-a", "geolens-fill-dots"], True),
+        # Nested expressions are followed through the output positions.
+        (
+            [
+                "match",
+                ["get", "k"],
+                "x",
+                ["case", [">", 1, 0], "geolens-fill-grid", "u"],
+                "u2",
+            ],
+            True,
+        ),
+        # An expression shape that cannot yield an image id is left alone.
+        (["literal", "geolens-fill-grid"], False),
+    ],
+)
+def test_data_driven_fill_pattern_is_read_at_its_output_positions(pattern, stripped):
+    """Only the four branching forms that can return an image id are inspected,
+    and only at their documented output operands.
 
-    Here it is a comparison operand, and every branch the expression can
-    actually return is a real uploaded sprite id — scanning nested strings would
-    strip a working layer down to a solid fill. Telling an output branch from an
-    operand needs an expression evaluator, and the builder's pattern control
-    writes a single value, so there is nothing to gain by guessing.
+    The builder's pattern control writes a single value, so any expression here
+    is hand-authored; guessing in either direction has a cost, and both were
+    paid before this shape: scanning every nested string flattened working
+    layers, and ignoring lists left genuinely broken ones broken.
     """
-    pattern = [
-        "case",
-        ["==", ["get", "kind"], "geolens-fill-grid"],
-        "uploaded-a",
-        "uploaded-b",
-    ]
     style = build_maplibre_style(_map(), [_polygon_layer_with_pattern(pattern)])
 
-    assert _fill_paint(style)["fill-pattern"] == pattern
+    paint = _fill_paint(style)
+    if stripped:
+        assert "fill-pattern" not in paint
+        assert paint["fill-color"] == style_json.DEFAULT_FILL_COLOR
+    else:
+        assert paint["fill-pattern"] == pattern
 
 
 @pytest.mark.parametrize(

--- a/backend/tests/test_maps_style_json.py
+++ b/backend/tests/test_maps_style_json.py
@@ -2145,18 +2145,25 @@ def test_stripping_a_builtin_pattern_keeps_an_authored_fill_color():
     assert paint["fill-color"] == "#94a3b8"
 
 
-def test_a_builtin_pattern_inside_an_expression_is_stripped_too():
-    """A data-driven fill-pattern resolves to the same absent sprite ids."""
-    style = build_maplibre_style(
-        _map(),
-        [
-            _polygon_layer_with_pattern(
-                ["case", ["==", ["get", "kind"], "a"], "geolens-fill-grid", "other"]
-            )
-        ],
-    )
+def test_a_data_driven_fill_pattern_is_left_as_authored():
+    """fix(#917 codex r2): a builtin id inside an expression is not necessarily
+    an output image.
 
-    assert "fill-pattern" not in _fill_paint(style)
+    Here it is a comparison operand, and every branch the expression can
+    actually return is a real uploaded sprite id — scanning nested strings would
+    strip a working layer down to a solid fill. Telling an output branch from an
+    operand needs an expression evaluator, and the builder's pattern control
+    writes a single value, so there is nothing to gain by guessing.
+    """
+    pattern = [
+        "case",
+        ["==", ["get", "kind"], "geolens-fill-grid"],
+        "uploaded-a",
+        "uploaded-b",
+    ]
+    style = build_maplibre_style(_map(), [_polygon_layer_with_pattern(pattern)])
+
+    assert _fill_paint(style)["fill-pattern"] == pattern
 
 
 @pytest.mark.parametrize(

--- a/backend/tests/test_maps_style_json.py
+++ b/backend/tests/test_maps_style_json.py
@@ -2166,7 +2166,11 @@ def test_stripping_a_builtin_pattern_keeps_an_authored_fill_color():
         (["match", ["get", "kind"], "x", "geolens-fill-hatch", "up-b"], True),
         (["match", ["get", "kind"], "x", "up-a", "geolens-fill-dots"], True),
         (["step", ["zoom"], "geolens-fill-grid", 10, "up-a"], True),
-        (["coalesce", "up-a", "geolens-fill-dots"], True),
+        # fix(#917 codex r6): corrected from True. `coalesce` returns the first
+        # NON-NULL operand, and a bare string constant is never null, so this
+        # always resolves to "up-a" and the builtin behind it is unreachable.
+        # The earlier expectation treated every operand as a possible output.
+        (["coalesce", "up-a", "geolens-fill-dots"], False),
         # Nested expressions are followed through the output positions.
         (
             [
@@ -2226,6 +2230,30 @@ def test_stripping_a_builtin_pattern_keeps_an_authored_fill_color():
         (["let", "p", "uploaded-a", "geolens-fill-dots"], True),
         (["let", "p", "uploaded-a", ["var", "p"]], False),
         (["let", "geolens-fill-grid", "uploaded-a", "uploaded-b"], False),
+        # fix(#917 codex r6): `coalesce` is MapLibre's availability-aware
+        # fallback — `["image", id]` is null when the sprite lacks it — so a
+        # builtin WITH a real fallback already renders and stripping it would
+        # replace a working expression with a solid fill. Only report when no
+        # operand offers a way out.
+        (
+            ["coalesce", ["image", "geolens-fill-grid"], ["image", "up-a"]],
+            False,
+        ),
+        (["coalesce", ["image", "up-a"], ["image", "geolens-fill-grid"]], False),
+        (
+            [
+                "coalesce",
+                ["image", "geolens-fill-grid"],
+                ["image", "geolens-fill-dots"],
+            ],
+            True,
+        ),
+        (["coalesce", "geolens-fill-grid"], True),
+        # ...and a `let` binding the result never references cannot contribute
+        # to what renders, so scanning every binding stripped working styles.
+        (["let", "unused", ["image", "geolens-fill-grid"], ["image", "up-a"]], False),
+        (["let", "a", "geolens-fill-grid", "b", ["var", "a"], ["var", "b"]], True),
+        (["let", "a", "geolens-fill-grid", "b", ["var", "a"], "up-a"], False),
     ],
 )
 def test_data_driven_fill_pattern_is_read_at_its_output_positions(pattern, stripped):

--- a/backend/tests/test_maps_style_json.py
+++ b/backend/tests/test_maps_style_json.py
@@ -1,7 +1,6 @@
 """Tests for saved map MapLibre style JSON import/export helpers."""
 
 import uuid
-from typing import Any
 from urllib.parse import parse_qs, urlsplit
 
 import pytest
@@ -2147,135 +2146,6 @@ def test_stripping_a_builtin_pattern_keeps_an_authored_fill_color():
 
 
 @pytest.mark.parametrize(
-    ("pattern", "stripped"),
-    [
-        # fix(#917 codex r2): an id in an OPERAND or a `match` label says
-        # nothing about what the expression returns. Every branch here resolves
-        # to a real uploaded sprite id, so stripping would flatten a working
-        # layer to a solid fill.
-        (
-            ["case", ["==", ["get", "kind"], "geolens-fill-grid"], "up-a", "up-b"],
-            False,
-        ),
-        (["match", ["get", "kind"], "geolens-fill-grid", "up-a", "up-b"], False),
-        # fix(#917 codex r3): ...and an id in an OUTPUT branch really does
-        # resolve to an image the sprite does not contain, so ignoring lists
-        # wholesale left those layers broken for external clients.
-        (["case", ["==", ["get", "kind"], "a"], "geolens-fill-grid", "up-b"], True),
-        (["case", ["==", ["get", "kind"], "a"], "up-a", "geolens-fill-dots"], True),
-        (["match", ["get", "kind"], "x", "geolens-fill-hatch", "up-b"], True),
-        (["match", ["get", "kind"], "x", "up-a", "geolens-fill-dots"], True),
-        (["step", ["zoom"], "geolens-fill-grid", 10, "up-a"], True),
-        # fix(#917 codex r6): corrected from True. `coalesce` returns the first
-        # NON-NULL operand, and a bare string constant is never null, so this
-        # always resolves to "up-a" and the builtin behind it is unreachable.
-        # The earlier expectation treated every operand as a possible output.
-        (["coalesce", "up-a", "geolens-fill-dots"], False),
-        # Nested expressions are followed through the output positions.
-        (
-            [
-                "match",
-                ["get", "k"],
-                "x",
-                ["case", [">", 1, 0], "geolens-fill-grid", "u"],
-                "u2",
-            ],
-            True,
-        ),
-        # fix(#917 codex r3): the two DIRECT forms name their image in the
-        # single operand rather than branching to it, so a builtin wrapped in
-        # either reached the sprite unchanged.
-        (["image", "geolens-fill-grid"], True),
-        (["literal", "geolens-fill-dots"], True),
-        (["image", "uploaded-a"], False),
-        (["case", [">", 1, 0], ["image", "geolens-fill-hatch"], "up-b"], True),
-        # An expression shape that cannot yield an image id is left alone.
-        (["zoom"], False),
-        # fix(#917 codex r4): MapLibre's LEGACY function object, still accepted
-        # for data-driven properties and preserved by style import and the
-        # open-dict paint API. Outputs are each stop's second element plus
-        # `default`; the first element is the matched INPUT, so it is data.
-        (
-            {
-                "type": "categorical",
-                "property": "kind",
-                "stops": [["x", "geolens-fill-grid"]],
-                "default": "up-a",
-            },
-            True,
-        ),
-        (
-            {
-                "type": "categorical",
-                "stops": [["x", "up-a"]],
-                "default": "geolens-fill-dots",
-            },
-            True,
-        ),
-        (
-            {
-                "type": "categorical",
-                "stops": [["geolens-fill-grid", "up-a"]],
-                "default": "up-b",
-            },
-            False,
-        ),
-        ({"stops": [["x", ["image", "geolens-fill-hatch"]]]}, True),
-        ({"type": "exponential", "base": 2}, False),
-        # fix(#917 codex r5): ["let", name, value, ..., result]. Binding values
-        # sit at the same 2-step offset the branching forms use and the result
-        # is last, so reading the binding answers the question without resolving
-        # the `var` reference. Binding NAMES land on the skipped odd indices.
-        (["let", "p", "geolens-fill-grid", ["var", "p"]], True),
-        (["let", "p", "uploaded-a", "geolens-fill-dots"], True),
-        (["let", "p", "uploaded-a", ["var", "p"]], False),
-        (["let", "geolens-fill-grid", "uploaded-a", "uploaded-b"], False),
-        # fix(#917 codex r6): `coalesce` is MapLibre's availability-aware
-        # fallback — `["image", id]` is null when the sprite lacks it — so a
-        # builtin WITH a real fallback already renders and stripping it would
-        # replace a working expression with a solid fill. Only report when no
-        # operand offers a way out.
-        (
-            ["coalesce", ["image", "geolens-fill-grid"], ["image", "up-a"]],
-            False,
-        ),
-        (["coalesce", ["image", "up-a"], ["image", "geolens-fill-grid"]], False),
-        (
-            [
-                "coalesce",
-                ["image", "geolens-fill-grid"],
-                ["image", "geolens-fill-dots"],
-            ],
-            True,
-        ),
-        (["coalesce", "geolens-fill-grid"], True),
-        # ...and a `let` binding the result never references cannot contribute
-        # to what renders, so scanning every binding stripped working styles.
-        (["let", "unused", ["image", "geolens-fill-grid"], ["image", "up-a"]], False),
-        (["let", "a", "geolens-fill-grid", "b", ["var", "a"], ["var", "b"]], True),
-        (["let", "a", "geolens-fill-grid", "b", ["var", "a"], "up-a"], False),
-    ],
-)
-def test_data_driven_fill_pattern_is_read_at_its_output_positions(pattern, stripped):
-    """Only the four branching forms that can return an image id are inspected,
-    and only at their documented output operands.
-
-    The builder's pattern control writes a single value, so any expression here
-    is hand-authored; guessing in either direction has a cost, and both were
-    paid before this shape: scanning every nested string flattened working
-    layers, and ignoring lists left genuinely broken ones broken.
-    """
-    style = build_maplibre_style(_map(), [_polygon_layer_with_pattern(pattern)])
-
-    paint = _fill_paint(style)
-    if stripped:
-        assert "fill-pattern" not in paint
-        assert paint["fill-color"] == style_json.DEFAULT_FILL_COLOR
-    else:
-        assert paint["fill-pattern"] == pattern
-
-
-@pytest.mark.parametrize(
     "pattern",
     [
         "some-uploaded-icon",
@@ -2299,56 +2169,37 @@ def test_a_non_builtin_fill_pattern_is_left_alone(pattern):
 @pytest.mark.parametrize(
     "pattern",
     [
-        # fix(#917 codex r5): `_validate_style_dict` bounds only the serialized
-        # SIZE of a paint dict, so the open-dict API stores these today. Before
-        # the type guard, exporting one raised from the shared style endpoint —
-        # turning tolerated-but-malformed stored data into a 500. A string is
-        # the nastiest of them: it iterates silently, one character at a time.
+        ["case", ["==", ["get", "kind"], "a"], "geolens-fill-grid", "up-b"],
+        ["match", ["get", "kind"], "x", "geolens-fill-hatch", "up-b"],
+        ["coalesce", ["image", "geolens-fill-grid"], ["image", "up-a"]],
+        ["let", "p", "geolens-fill-grid", ["var", "p"]],
+        ["image", "geolens-fill-grid"],
+        {"type": "categorical", "stops": [["x", "geolens-fill-grid"]], "default": "up"},
+        # Malformed shapes the open-dict `paint` API accepts today, since
+        # `_validate_style_dict` bounds only serialized size (#1069).
         {"stops": 1},
         {"stops": "geolens-fill-grid"},
-        {"stops": {"a": 1}},
-        {"stops": [1, 2, 3]},
-        {"stops": [["only-one-element"]]},
     ],
 )
-def test_a_malformed_legacy_function_exports_instead_of_raising(pattern):
+def test_a_composite_fill_pattern_is_left_exactly_as_authored(pattern):
+    """fix(#917): composites are deliberately untouched, not an unfinished case.
+
+    MapLibre SKIPS a missing pattern and fires `styleimagemissing`, documented
+    as the hook for supplying the image at runtime, so an export naming a
+    builtin degrades and stays repairable by the consumer. Stripping a working
+    expression removes authored content no downstream hook can recover — and
+    `["coalesce", ["image", builtin], ["image", other]]` is MapLibre's own
+    documented way to author a fallback, so it is working input.
+
+    One failure is recoverable by design and the other is permanent, which is
+    why the narrow rule is the safe one. The builder only ever writes a plain
+    string, so this costs nothing against the bug #917 reports; every value here
+    arrives through style import or the open-dict API. A correct reader is an
+    expression evaluator, tracked separately.
+
+    Iterating a malformed `stops` also cannot raise from the shared style
+    endpoint now that nothing descends into it (#1069).
+    """
     style = build_maplibre_style(_map(), [_polygon_layer_with_pattern(pattern)])
 
-    # Left as authored — not a function object, so not something to strip.
     assert _fill_paint(style)["fill-pattern"] == pattern
-
-
-def test_a_pathologically_nested_expression_does_not_blow_the_stack():
-    """fix(#917 codex r5): the detector stops descending rather than raising.
-
-    `_validate_style_dict` bounds only the serialized size of a paint dict, and
-    64KB of `["coalesce", ...]` nests far past Python's recursion limit, so
-    without a depth bound this function would be the thing that 500s the shared
-    style endpoint.
-
-    Asserted against the detector, not `build_maplibre_style`, because the
-    export pipeline has its own recursion limit further down — a `copy.deepcopy`
-    that raises on the same input with or without this change. That is
-    pre-existing and out of scope here; what this pins is that the fill-pattern
-    guard does not ADD a crash path. The pipeline-level case below uses a depth
-    a real style could plausibly reach.
-    """
-    deep: Any = "geolens-fill-grid"
-    for _ in range(5000):
-        deep = ["coalesce", deep]
-
-    assert style_json._references_builtin_fill_pattern(deep) is False
-
-
-def test_a_deeply_but_plausibly_nested_pattern_still_exports():
-    """Nesting well past anything an author would write, but inside the
-    pipeline's own limits, so this exercises the whole export path."""
-    deep: Any = "geolens-fill-grid"
-    for _ in range(100):
-        deep = ["coalesce", deep]
-
-    style = build_maplibre_style(_map(), [_polygon_layer_with_pattern(deep)])
-
-    # Past the detector's depth bound, so it is left alone rather than stripped
-    # — the safe direction for a value nobody can have authored by hand.
-    assert _fill_paint(style)["fill-pattern"] == deep

--- a/backend/tests/test_maps_style_json.py
+++ b/backend/tests/test_maps_style_json.py
@@ -2159,13 +2159,22 @@ def test_a_builtin_pattern_inside_an_expression_is_stripped_too():
     assert "fill-pattern" not in _fill_paint(style)
 
 
-def test_a_non_builtin_fill_pattern_is_left_alone():
-    """Only the closed `geolens-fill-*` set is known to be absent from the
-    sprite. Any other value may name a real `map_icons` entry, and dropping it
-    would break a style that works.
+@pytest.mark.parametrize(
+    "pattern",
+    [
+        "some-uploaded-icon",
+        # fix(#917 codex r1): `create_icon_asset` derives a sprite slug from the
+        # uploaded filename, so `geolens-fill-logo.png` becomes a real map_icons
+        # entry whose slug carries the builtin prefix. Reserving the prefix
+        # would strip a working pattern from every exported style.
+        "geolens-fill-logo-a1b2c3d4",
+    ],
+)
+def test_a_non_builtin_fill_pattern_is_left_alone(pattern):
+    """Only the five builtin ids are known to be absent from the sprite. Any
+    other value may name a real `map_icons` entry, and dropping it would break a
+    style that works.
     """
-    style = build_maplibre_style(
-        _map(), [_polygon_layer_with_pattern("some-uploaded-icon")]
-    )
+    style = build_maplibre_style(_map(), [_polygon_layer_with_pattern(pattern)])
 
-    assert _fill_paint(style)["fill-pattern"] == "some-uploaded-icon"
+    assert _fill_paint(style)["fill-pattern"] == pattern

--- a/backend/tests/test_maps_style_json.py
+++ b/backend/tests/test_maps_style_json.py
@@ -2186,6 +2186,37 @@ def test_stripping_a_builtin_pattern_keeps_an_authored_fill_color():
         (["case", [">", 1, 0], ["image", "geolens-fill-hatch"], "up-b"], True),
         # An expression shape that cannot yield an image id is left alone.
         (["zoom"], False),
+        # fix(#917 codex r4): MapLibre's LEGACY function object, still accepted
+        # for data-driven properties and preserved by style import and the
+        # open-dict paint API. Outputs are each stop's second element plus
+        # `default`; the first element is the matched INPUT, so it is data.
+        (
+            {
+                "type": "categorical",
+                "property": "kind",
+                "stops": [["x", "geolens-fill-grid"]],
+                "default": "up-a",
+            },
+            True,
+        ),
+        (
+            {
+                "type": "categorical",
+                "stops": [["x", "up-a"]],
+                "default": "geolens-fill-dots",
+            },
+            True,
+        ),
+        (
+            {
+                "type": "categorical",
+                "stops": [["geolens-fill-grid", "up-a"]],
+                "default": "up-b",
+            },
+            False,
+        ),
+        ({"stops": [["x", ["image", "geolens-fill-hatch"]]]}, True),
+        ({"type": "exponential", "base": 2}, False),
     ],
 )
 def test_data_driven_fill_pattern_is_read_at_its_output_positions(pattern, stripped):


### PR DESCRIPTION
Closes #917. Backend counterpart of the builder fill-pattern work (#910/#911/#914).

## What was broken

A polygon layer using a builtin fill pattern (`paint['fill-pattern'] = 'geolens-fill-hatch'`)
exported a `style.json` whose `sprite` is indexed from the `map_icons` table
alone and has never contained `geolens-fill-*`. In-app surfaces work only
because the client-side adapter registry generates those images in the browser
(`layer-adapters/fill-pattern-images.ts`); the exported document has no such
luck.

## What changed

Option 2 from the issue. `_validate_emitted_style` drops a builtin
`fill-pattern` from `fill` layers and falls back to `fill-color`, keeping an
authored colour when there is one and using `DEFAULT_FILL_COLOR` otherwise.

**Plain strings only.** A composite value — a data-driven expression or a legacy
function object — is left exactly as authored. Two narrowings from review:

- **Not the `geolens-fill-` prefix.** `create_icon_asset` derives a sprite slug
  from the uploaded filename, so an icon named `geolens-fill-logo.png` becomes a
  real `map_icons` entry carrying that prefix.
- **Not composites at all.** See below — this one is a deliberate design
  decision, not a coverage gap.

## Why composites are left alone

Two facts from the MapLibre GL JS docs:

- A missing pattern fires **`styleimagemissing`**, described in the docs as the
  hook to add the image "to prevent the image from being skipped". A dangling
  reference is **skipped, not fatal** — the layer still renders and a consumer
  can supply the image at runtime.
- **"Use a `coalesce` expression to display another image when a requested image
  is not available"** is a documented MapLibre example.

So the failure modes are asymmetric. Leaving a builtin in an export degrades and
**stays repairable**. Stripping a working expression removes authored content
that **no downstream hook can bring back**. Reading composites was trading the
permanent failure for the recoverable one — `["coalesce", ["image", builtin],
["image", other]]` is the sanctioned way to author a fallback, and the detector
was deleting it.

Coverage against the reported bug is unaffected: the **builder** writes a plain
string, which is all GeoLens itself produces. Every composite arrives through
style import or the open-dict `paint` API.

## On the review history

This PR ran nine codex rounds, and **every finding was correct against the
implementation as it stood** — both the gaps in rounds 2-7 and the false
positives in round 8. What changed is not their validity but the scope they were
correct about: fixing each one built a composite reader that outgrew what #917
specified ("the two-line stopgap"), and round 8 showed the model was wrong in a
way that destroyed valid input. Round 9 then produced two more, which is the
evidence that the surface was unbounded.

The narrower end state is the deliberate choice, made with the MapLibre
semantics above in hand — not a retreat from review.

Nothing learned is discarded. The expression semantics worked out across those
rounds (output positions per operator, `image` null-propagation, `coalesce`
short-circuit, `let` binding reachability, the 64KB depth problem) are recorded
on #917 so a real evaluator starts from them.

## Filed separately

**#1069** — `_validate_style_dict` bounds only serialized size, so
`{"fill-pattern": {"stops": 1}}` is storable today and any serializer that
descends into it 500s the shared style endpoint from stored data. Surfaced by
this work, live regardless of it.

## Verification

```
cd backend && set -a && source ../.env.test && set +a && uv run pytest \
  tests/test_maps_style_json.py tests/test_maps.py tests/test_layering.py -q
  # 275 passed
cd backend && uv run ruff check . && uv run ruff format --check .
```

Plain-string coverage kept: default colour on strip, an authored `fill-color`
surviving (the fallback is a default, not an override), and a non-builtin left
alone over both a plain uploaded slug and one whose filename gave it the builtin
prefix. The composite matrix is replaced by one test asserting every composite
shape — `case`, `match`, `coalesce`, `let`, `image`, legacy function, and the
malformed `{"stops": 1}` forms — exports byte-identical to what was authored.

`style_json.py` LOC ratchet 1432 → 1517.
