### PR TITLE
fix(catalog): block a dataset visibility change that strands an internal map

### DIFF
--- a/backend/app/modules/catalog/datasets/domain/service_metadata.py
+++ b/backend/app/modules/catalog/datasets/domain/service_metadata.py
@@ -159,15 +159,30 @@ async def _apply_visibility_change(
     dataset_id: uuid.UUID,
     new_visibility: str,
 ) -> bool:
-    """Set record.visibility, blocking public→restricted when public maps depend on it."""
-    if new_visibility != "public" and record.visibility == "public":
-        from app.modules.catalog.maps.service import find_public_maps_using_dataset
+    """Set record.visibility, blocking a change that would strand a shared map.
 
-        public_maps = await find_public_maps_using_dataset(session, dataset_id)
-        if public_maps:
-            raise ValueError(
-                f"Cannot restrict visibility: dataset is used in public maps: {', '.join(public_maps)}"
-            )
+    fix(#931): the gate used to be ``new != public and old == public``, matching
+    a query that only knew about public maps. An internal map using the dataset
+    was invisible to both, so the flip succeeded and every signed-in viewer of
+    that map silently lost the layer. The helper now compares the before and
+    after audiences itself and returns nothing when the change strands nothing,
+    so no gate is needed here.
+    """
+    from app.modules.catalog.maps.service import (
+        find_maps_broken_by_dataset_visibility,
+    )
+
+    broken_maps = await find_maps_broken_by_dataset_visibility(
+        session,
+        dataset_id,
+        old_visibility=record.visibility,
+        new_visibility=new_visibility,
+    )
+    if broken_maps:
+        raise ValueError(
+            "Cannot restrict visibility: dataset is used in shared maps: "
+            f"{', '.join(broken_maps)}"
+        )
     record.visibility = new_visibility
     return True
 

--- a/backend/app/modules/catalog/datasets/domain/service_metadata.py
+++ b/backend/app/modules/catalog/datasets/domain/service_metadata.py
@@ -177,6 +177,8 @@ async def _apply_visibility_change(
         dataset_id,
         old_visibility=record.visibility,
         new_visibility=new_visibility,
+        record_status=record.record_status,
+        owner_id=record.created_by,
     )
     if broken_maps:
         raise ValueError(

--- a/backend/app/modules/catalog/maps/service.py
+++ b/backend/app/modules/catalog/maps/service.py
@@ -29,7 +29,7 @@ from app.modules.catalog.maps.service_layers import (
 from app.modules.catalog.maps.service_public import (
     _validate_share_token,
     create_share_token,
-    find_public_maps_using_dataset,
+    find_maps_broken_by_dataset_visibility,
     get_active_share_token,
     get_maps_for_dataset,
     get_shared_map,
@@ -72,7 +72,7 @@ __all__ = [
     "remove_layer",
     "remove_layers_bulk",
     "validate_public_visibility",
-    "find_public_maps_using_dataset",
+    "find_maps_broken_by_dataset_visibility",
     "create_share_token",
     "update_share_token",
     "get_active_share_token",

--- a/backend/app/modules/catalog/maps/service_public.py
+++ b/backend/app/modules/catalog/maps/service_public.py
@@ -86,6 +86,23 @@ _SHARED_MAP_AUDIENCES = ("public", "internal")
 # this is a total order, and "does this change strand someone" is a comparison
 # rather than a table of allowed moves.
 #
+# fix(#931 codex r5): this encodes the COMMUNITY ladder, matching
+# `DefaultPermissionExtension`. An overlay that narrows a rung — ABAC excluding
+# some active non-owner users from `internal`, say — makes the real audience
+# smaller than the rank assumes, and this guard cannot see that: the seam's
+# `filter_visible`/`can_access_dataset` both take a CONCRETE user, and a map's
+# audience is a set with no representative member to pass them. Answering it
+# properly needs a new protocol method and an EXTENSION_API_VERSION bump, which
+# is a larger change than this guard.
+#
+# The failure direction is what makes that acceptable. Narrowing the real
+# audience only ever makes this guard MORE conservative: it can refuse a move
+# that strands nobody, never permit one that strands someone. So an overlay
+# inherits a refusal that lies, not a silent break — the same class as the
+# grant and publication-status cases above, and the reason those were worth
+# fixing rather than urgent. An overlay that reshapes the ladder should extend
+# this the way #930 notes a cloud overlay must scope internal per-tenant.
+#
 # fix(#931 codex r1): `restricted` is a PARTIAL audience, not an absent one.
 # Treating it as unreachable made `restricted -> private` look like it stranded
 # nobody, when it drops the grant holders who could render the layer.

--- a/backend/app/modules/catalog/maps/service_public.py
+++ b/backend/app/modules/catalog/maps/service_public.py
@@ -92,17 +92,41 @@ _SHARED_MAP_AUDIENCES = ("public", "internal")
 _DATASET_AUDIENCE_RANK = {"private": 0, "restricted": 1, "internal": 2, "public": 3}
 
 
-def _reach_rank(map_visibility: str, dataset_visibility: str) -> int:
+def _reach_rank(
+    map_visibility: str, dataset_visibility: str, *, restricted_has_grants: bool
+) -> int:
     """How much of ``map_visibility``'s audience the dataset reaches.
 
     An internal map's audience is every signed-in user, and both ``internal``
     and ``public`` reach all of them — so the two tie there, which is what makes
     the public-to-internal move safe on an internal map and not on a public one.
+
+    fix(#931 codex r2): ``restricted`` only outranks ``private`` when grants
+    actually exist. A restricted dataset with no ``DatasetGrant`` rows — the
+    state you land in by flipping an ungranted dataset to restricted — reaches
+    nobody beyond its owner and admins, who keep access afterwards either way.
+    Ranking it 1 unconditionally blocked ``restricted -> private`` on a map
+    nothing was stranded on, which is a refusal that lies to the user.
     """
     rank = _DATASET_AUDIENCE_RANK.get(dataset_visibility, 0)
+    if dataset_visibility == "restricted" and not restricted_has_grants:
+        rank = _DATASET_AUDIENCE_RANK["private"]
     if map_visibility == "internal":
         return min(rank, _DATASET_AUDIENCE_RANK["internal"])
     return rank
+
+
+async def _dataset_has_grants(session: AsyncSession, dataset_id: uuid.UUID) -> bool:
+    """Whether any role holds a grant on this dataset.
+
+    fix(#931 codex r2): queried only when ``restricted`` is one of the two
+    visibilities in play, so the ordinary public/internal/private moves cost
+    nothing extra.
+    """
+    from app.modules.catalog.datasets.domain.models import DatasetGrant
+
+    stmt = select(DatasetGrant.dataset_id).where(DatasetGrant.dataset_id == dataset_id)
+    return (await session.execute(stmt.limit(1))).scalar_one_or_none() is not None
 
 
 async def find_maps_broken_by_dataset_visibility(
@@ -127,11 +151,18 @@ async def find_maps_broken_by_dataset_visibility(
 
     Empty = safe to apply.
     """
+    restricted_has_grants = False
+    if "restricted" in (old_visibility, new_visibility):
+        restricted_has_grants = await _dataset_has_grants(session, dataset_id)
     audiences = [
         visibility
         for visibility in _SHARED_MAP_AUDIENCES
-        if _reach_rank(visibility, new_visibility)
-        < _reach_rank(visibility, old_visibility)
+        if _reach_rank(
+            visibility, new_visibility, restricted_has_grants=restricted_has_grants
+        )
+        < _reach_rank(
+            visibility, old_visibility, restricted_has_grants=restricted_has_grants
+        )
     ]
     if not audiences:
         return []

--- a/backend/app/modules/catalog/maps/service_public.py
+++ b/backend/app/modules/catalog/maps/service_public.py
@@ -75,16 +75,59 @@ async def validate_public_visibility(
     return [row[0] for row in result.all()]
 
 
-async def find_public_maps_using_dataset(
-    session: AsyncSession, dataset_id: uuid.UUID
+# fix(#931): the two shared map audiences and what a dataset must be to reach
+# each. A private map has no audience beyond its owner and grantees, so a
+# dataset visibility change can never strand it.
+_SHARED_MAP_AUDIENCES = ("public", "internal")
+
+
+def _dataset_reaches(map_visibility: str, dataset_visibility: str) -> bool:
+    """Whether a dataset at this visibility is visible to a map's whole audience."""
+    if map_visibility == "public":
+        return dataset_visibility == "public"
+    if map_visibility == "internal":
+        return dataset_visibility in ("public", "internal")
+    return True
+
+
+async def find_maps_broken_by_dataset_visibility(
+    session: AsyncSession,
+    dataset_id: uuid.UUID,
+    *,
+    old_visibility: str,
+    new_visibility: str,
 ) -> list[str]:
-    """Return names of public maps that contain the given dataset. Empty = safe to restrict."""
+    """Names of shared maps that work at ``old_visibility`` and would not at ``new``.
+
+    fix(#931): this was ``find_public_maps_using_dataset``, which matched
+    ``Map.visibility == "public"`` only. An **internal** map using the dataset
+    was not matched, so the flip succeeded and every signed-in viewer of that
+    map silently lost the layer's tiles and features, with no signal to anyone.
+
+    Framed as a before/after comparison rather than a list of forbidden target
+    values, because #930 turned the rule into a matrix. An internal map keeps
+    working when its dataset moves from public to internal, and breaks only on
+    the move to private — a rule expressed against today's target value alone
+    would fire on a move that is in fact safe. It also means a dataset that was
+    already unreachable for an audience (a ``restricted`` one on an internal
+    map) does not produce a block for a change that strands nothing new.
+
+    Empty = safe to apply.
+    """
+    audiences = [
+        visibility
+        for visibility in _SHARED_MAP_AUDIENCES
+        if _dataset_reaches(visibility, old_visibility)
+        and not _dataset_reaches(visibility, new_visibility)
+    ]
+    if not audiences:
+        return []
     stmt = (
         select(Map.name)
         .select_from(MapLayer)
         .join(Map, MapLayer.map_id == Map.id)
         .where(MapLayer.dataset_id == dataset_id)
-        .where(Map.visibility == "public")
+        .where(Map.visibility.in_(audiences))
     )
     result = await session.execute(stmt)
     return [row[0] for row in result.all()]

--- a/backend/app/modules/catalog/maps/service_public.py
+++ b/backend/app/modules/catalog/maps/service_public.py
@@ -132,7 +132,7 @@ async def _has_affected_grant_holders(
     visibilities in play, so the ordinary public/internal/private moves cost
     nothing extra.
     """
-    from app.modules.auth.models import Role, UserRole
+    from app.modules.auth.models import Role, User, UserRole
     from app.modules.catalog.datasets.domain.models import DatasetGrant
 
     admin_user_ids = (
@@ -143,6 +143,20 @@ async def _has_affected_grant_holders(
     stmt = (
         select(UserRole.user_id)
         .join(DatasetGrant, DatasetGrant.role_id == UserRole.role_id)
+        # fix(#931 codex r4): the grant holder must be an account that can
+        # actually authenticate. `get_optional_user` rejects an inactive user
+        # before they can render a layer, so a grant whose only members are
+        # pending, suspended or deactivated reaches nobody — counting them made
+        # the guard block a move that strands no current viewer.
+        #
+        # Both columns, mirroring `auth/dependencies.py`'s
+        # `not user.is_active or user.status != "active"` exactly. The
+        # `chk_users_status_active_consistency` CHECK keeps them equal, so this
+        # is not two tests today — it is one test written the way the gate
+        # writes it, so the two cannot drift apart later.
+        .join(User, User.id == UserRole.user_id)
+        .where(User.is_active.is_(True))
+        .where(User.status == "active")
         .where(DatasetGrant.dataset_id == dataset_id)
         .where(UserRole.user_id.notin_(admin_user_ids))
     )

--- a/backend/app/modules/catalog/maps/service_public.py
+++ b/backend/app/modules/catalog/maps/service_public.py
@@ -116,16 +116,38 @@ def _reach_rank(
     return rank
 
 
-async def _dataset_has_grants(session: AsyncSession, dataset_id: uuid.UUID) -> bool:
-    """Whether any role holds a grant on this dataset.
+async def _has_affected_grant_holders(
+    session: AsyncSession, dataset_id: uuid.UUID, owner_id: uuid.UUID | None
+) -> bool:
+    """Whether a grant on this dataset reaches anyone who would LOSE access.
+
+    fix(#931 codex r3): a grant row is not an audience. A grant to an empty
+    role reaches nobody, and a grant whose only members are the dataset's owner
+    or an admin reaches nobody who loses anything — the owner keeps access
+    through the creator exemption and an admin bypasses the filter entirely. So
+    the question is not "does a grant exist" but "does a grant reach a user who
+    is neither", and only that user can be stranded by a move to private.
 
     fix(#931 codex r2): queried only when ``restricted`` is one of the two
     visibilities in play, so the ordinary public/internal/private moves cost
     nothing extra.
     """
+    from app.modules.auth.models import Role, UserRole
     from app.modules.catalog.datasets.domain.models import DatasetGrant
 
-    stmt = select(DatasetGrant.dataset_id).where(DatasetGrant.dataset_id == dataset_id)
+    admin_user_ids = (
+        select(UserRole.user_id)
+        .join(Role, Role.id == UserRole.role_id)
+        .where(Role.name == "admin")
+    )
+    stmt = (
+        select(UserRole.user_id)
+        .join(DatasetGrant, DatasetGrant.role_id == UserRole.role_id)
+        .where(DatasetGrant.dataset_id == dataset_id)
+        .where(UserRole.user_id.notin_(admin_user_ids))
+    )
+    if owner_id is not None:
+        stmt = stmt.where(UserRole.user_id != owner_id)
     return (await session.execute(stmt.limit(1))).scalar_one_or_none() is not None
 
 
@@ -135,6 +157,8 @@ async def find_maps_broken_by_dataset_visibility(
     *,
     old_visibility: str,
     new_visibility: str,
+    record_status: str,
+    owner_id: uuid.UUID | None,
 ) -> list[str]:
     """Names of shared maps that work at ``old_visibility`` and would not at ``new``.
 
@@ -151,9 +175,19 @@ async def find_maps_broken_by_dataset_visibility(
 
     Empty = safe to apply.
     """
+    # fix(#931 codex r3): an unpublished record is already invisible to every
+    # shared-map audience. `filter_visible`'s status gate is
+    # `published OR created_by == <caller>`, so a draft/ready/internal-status
+    # record reaches only its creator, and admins bypass the filter entirely —
+    # both keep access after any visibility change. Nobody is stranded, so a
+    # rank comparison here would invent a 422 for a move that costs nothing.
+    if record_status != "published":
+        return []
     restricted_has_grants = False
     if "restricted" in (old_visibility, new_visibility):
-        restricted_has_grants = await _dataset_has_grants(session, dataset_id)
+        restricted_has_grants = await _has_affected_grant_holders(
+            session, dataset_id, owner_id
+        )
     audiences = [
         visibility
         for visibility in _SHARED_MAP_AUDIENCES

--- a/backend/app/modules/catalog/maps/service_public.py
+++ b/backend/app/modules/catalog/maps/service_public.py
@@ -86,22 +86,21 @@ _SHARED_MAP_AUDIENCES = ("public", "internal")
 # this is a total order, and "does this change strand someone" is a comparison
 # rather than a table of allowed moves.
 #
-# fix(#931 codex r5): this encodes the COMMUNITY ladder, matching
+# fix(#1068): this encodes the COMMUNITY ladder, matching
 # `DefaultPermissionExtension`. An overlay that narrows a rung — ABAC excluding
 # some active non-owner users from `internal`, say — makes the real audience
 # smaller than the rank assumes, and this guard cannot see that: the seam's
 # `filter_visible`/`can_access_dataset` both take a CONCRETE user, and a map's
 # audience is a set with no representative member to pass them. Answering it
-# properly needs a new protocol method and an EXTENSION_API_VERSION bump, which
-# is a larger change than this guard.
+# properly needs a new protocol method and an EXTENSION_API_VERSION bump, so it
+# is tracked separately rather than folded into a visibility fix.
 #
-# The failure direction is what makes that acceptable. Narrowing the real
-# audience only ever makes this guard MORE conservative: it can refuse a move
-# that strands nobody, never permit one that strands someone. So an overlay
-# inherits a refusal that lies, not a silent break — the same class as the
-# grant and publication-status cases above, and the reason those were worth
-# fixing rather than urgent. An overlay that reshapes the ladder should extend
-# this the way #930 notes a cloud overlay must scope internal per-tenant.
+# The failure direction is why deferring it is safe. Narrowing the real audience
+# only ever makes this guard MORE conservative: it can refuse a move that
+# strands nobody, never permit one that strands someone. So an overlay inherits
+# a refusal that lies, not a silent break — the same class as the grant and
+# publication-status cases above, and the reason those were worth fixing rather
+# than urgent. See #1068 for the shape of the seam change.
 #
 # fix(#931 codex r1): `restricted` is a PARTIAL audience, not an absent one.
 # Treating it as unreachable made `restricted -> private` look like it stranded

--- a/backend/app/modules/catalog/maps/service_public.py
+++ b/backend/app/modules/catalog/maps/service_public.py
@@ -81,13 +81,28 @@ async def validate_public_visibility(
 _SHARED_MAP_AUDIENCES = ("public", "internal")
 
 
-def _dataset_reaches(map_visibility: str, dataset_visibility: str) -> bool:
-    """Whether a dataset at this visibility is visible to a map's whole audience."""
-    if map_visibility == "public":
-        return dataset_visibility == "public"
+# How much of a shared map's audience a dataset at each visibility reaches. The
+# four rungs nest — the owner is a grantee is a signed-in user is everyone — so
+# this is a total order, and "does this change strand someone" is a comparison
+# rather than a table of allowed moves.
+#
+# fix(#931 codex r1): `restricted` is a PARTIAL audience, not an absent one.
+# Treating it as unreachable made `restricted -> private` look like it stranded
+# nobody, when it drops the grant holders who could render the layer.
+_DATASET_AUDIENCE_RANK = {"private": 0, "restricted": 1, "internal": 2, "public": 3}
+
+
+def _reach_rank(map_visibility: str, dataset_visibility: str) -> int:
+    """How much of ``map_visibility``'s audience the dataset reaches.
+
+    An internal map's audience is every signed-in user, and both ``internal``
+    and ``public`` reach all of them — so the two tie there, which is what makes
+    the public-to-internal move safe on an internal map and not on a public one.
+    """
+    rank = _DATASET_AUDIENCE_RANK.get(dataset_visibility, 0)
     if map_visibility == "internal":
-        return dataset_visibility in ("public", "internal")
-    return True
+        return min(rank, _DATASET_AUDIENCE_RANK["internal"])
+    return rank
 
 
 async def find_maps_broken_by_dataset_visibility(
@@ -108,17 +123,15 @@ async def find_maps_broken_by_dataset_visibility(
     values, because #930 turned the rule into a matrix. An internal map keeps
     working when its dataset moves from public to internal, and breaks only on
     the move to private — a rule expressed against today's target value alone
-    would fire on a move that is in fact safe. It also means a dataset that was
-    already unreachable for an audience (a ``restricted`` one on an internal
-    map) does not produce a block for a change that strands nothing new.
+    would fire on a move that is in fact safe.
 
     Empty = safe to apply.
     """
     audiences = [
         visibility
         for visibility in _SHARED_MAP_AUDIENCES
-        if _dataset_reaches(visibility, old_visibility)
-        and not _dataset_reaches(visibility, new_visibility)
+        if _reach_rank(visibility, new_visibility)
+        < _reach_rank(visibility, old_visibility)
     ]
     if not audiences:
         return []

--- a/backend/tests/test_datasets.py
+++ b/backend/tests/test_datasets.py
@@ -520,8 +520,14 @@ class TestUpdateMetadata:
             ("public", "internal", "internal", False),
             # A private map has no audience beyond its owner and grantees.
             ("public", "private", "private", False),
-            # Already unreachable for that audience: nothing new breaks.
-            ("restricted", "internal", "private", False),
+            # fix(#931 codex r1): `restricted` is a PARTIAL audience, not an
+            # absent one. Grant holders could render this layer, and dropping to
+            # private takes it from them — the exact stranding this guard is for.
+            ("restricted", "internal", "private", True),
+            ("restricted", "public", "private", True),
+            # Widening never strands anyone.
+            ("restricted", "internal", "public", False),
+            ("private", "internal", "internal", False),
             # The public-map rule is unchanged — any move off public strands it.
             ("public", "public", "internal", True),
             ("public", "public", "private", True),

--- a/backend/tests/test_datasets.py
+++ b/backend/tests/test_datasets.py
@@ -11,6 +11,7 @@ Requirements:
 
 import uuid
 
+import pytest
 from httpx import AsyncClient
 
 from app.modules.catalog.maps.models import Map, MapLayer
@@ -481,6 +482,91 @@ class TestUpdateMetadata:
         )
         assert resp.status_code == 200
         assert resp.json()["visibility"] == "restricted"
+
+    async def _dataset_on_map(
+        self,
+        test_db_session,
+        admin_id,
+        *,
+        dataset_visibility: str,
+        map_visibility: str,
+        map_name: str,
+    ):
+        ds = await _create_dataset(
+            test_db_session,
+            created_by=admin_id,
+            visibility=dataset_visibility,
+            name=f"{map_name} DS",
+        )
+        map_obj = Map(name=map_name, visibility=map_visibility, created_by=admin_id)
+        test_db_session.add(map_obj)
+        await test_db_session.flush()
+        test_db_session.add(MapLayer(map_id=map_obj.id, dataset_id=ds.id, sort_order=0))
+        await test_db_session.commit()
+        return ds
+
+    @pytest.mark.parametrize(
+        ("dataset_visibility", "map_visibility", "new_visibility", "blocked"),
+        [
+            # fix(#931): the case the old query missed entirely. An internal map
+            # reaches every signed-in user, so a dataset dropping to private
+            # strands it — silently, before this.
+            ("public", "internal", "private", True),
+            ("internal", "internal", "private", True),
+            ("internal", "internal", "restricted", True),
+            # ...and the move that only looks like it strands one. #930 made
+            # internal a real dataset rung, so an internal map keeps working.
+            # A rule written against the target value alone would block this.
+            ("public", "internal", "internal", False),
+            # A private map has no audience beyond its owner and grantees.
+            ("public", "private", "private", False),
+            # Already unreachable for that audience: nothing new breaks.
+            ("restricted", "internal", "private", False),
+            # The public-map rule is unchanged — any move off public strands it.
+            ("public", "public", "internal", True),
+            ("public", "public", "private", True),
+        ],
+    )
+    async def test_visibility_change_blocks_exactly_the_maps_it_strands(
+        self,
+        client: AsyncClient,
+        admin_auth_header: dict,
+        test_db_session,
+        dataset_visibility: str,
+        map_visibility: str,
+        new_visibility: str,
+        blocked: bool,
+    ):
+        """fix(#931): the block is a before/after comparison, not a list of
+        forbidden target values.
+
+        ``find_public_maps_using_dataset`` matched ``Map.visibility == "public"``
+        only, and its caller gated on ``old == public``, so an internal map was
+        invisible to both halves. Once #930 made ``internal`` a real dataset
+        rung the rule became a matrix, and each row here is one cell of it.
+        """
+        admin_id = await _get_user_id(test_db_session, "admin")
+        map_name = f"Strand {map_visibility} {dataset_visibility} {new_visibility}"
+        ds = await self._dataset_on_map(
+            test_db_session,
+            admin_id,
+            dataset_visibility=dataset_visibility,
+            map_visibility=map_visibility,
+            map_name=map_name,
+        )
+
+        resp = await client.patch(
+            f"/datasets/{ds.id}",
+            json={"visibility": new_visibility},
+            headers=admin_auth_header,
+        )
+
+        if blocked:
+            assert resp.status_code == 422
+            assert map_name in resp.json()["detail"]
+        else:
+            assert resp.status_code == 200, resp.text
+            assert resp.json()["visibility"] == new_visibility
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_datasets.py
+++ b/backend/tests/test_datasets.py
@@ -506,23 +506,31 @@ class TestUpdateMetadata:
         await test_db_session.commit()
         return ds
 
-    async def test_a_granted_restricted_dataset_still_blocks_the_drop_to_private(
-        self,
-        client: AsyncClient,
-        admin_auth_header: dict,
-        test_db_session,
-    ):
-        """fix(#931 codex r1/r2): `restricted` is a partial audience when, and
-        only when, someone actually holds a grant.
-
-        With a grant row the layer really does render for those viewers, and
-        dropping to private takes it from them — the stranding this guard is
-        for. Without one the same move reaches nobody new, which is the
-        parametrised `restricted -> private` row above.
-        """
+    async def _grant_role(self, test_db_session, dataset_id, role_name: str):
         from app.modules.auth.models import Role
         from app.modules.catalog.datasets.domain.models import DatasetGrant
 
+        role = (
+            await test_db_session.execute(select(Role).where(Role.name == role_name))
+        ).scalar_one()
+        test_db_session.add(DatasetGrant(dataset_id=dataset_id, role_id=role.id))
+        await test_db_session.commit()
+
+    async def test_a_grant_reaching_a_real_viewer_blocks_the_drop_to_private(
+        self,
+        client: AsyncClient,
+        admin_auth_header: dict,
+        viewer_auth_header: dict,
+        test_db_session,
+    ):
+        """fix(#931 codex r1/r3): `restricted` is a partial audience when, and
+        only when, a grant reaches someone who would LOSE access.
+
+        The `viewer_auth_header` fixture mints a real viewer and assigns the
+        role, so the grant below reaches a user who is neither the owner nor an
+        admin. That user renders the layer today and stops after the move, which
+        is the stranding this guard exists for.
+        """
         admin_id = await _get_user_id(test_db_session, "admin")
         map_name = "Granted Restricted Map"
         ds = await self._dataset_on_map(
@@ -532,11 +540,7 @@ class TestUpdateMetadata:
             map_visibility="internal",
             map_name=map_name,
         )
-        role = (
-            await test_db_session.execute(select(Role).where(Role.name == "viewer"))
-        ).scalar_one()
-        test_db_session.add(DatasetGrant(dataset_id=ds.id, role_id=role.id))
-        await test_db_session.commit()
+        await self._grant_role(test_db_session, ds.id, "viewer")
 
         resp = await client.patch(
             f"/datasets/{ds.id}",
@@ -546,6 +550,69 @@ class TestUpdateMetadata:
 
         assert resp.status_code == 422
         assert map_name in resp.json()["detail"]
+
+    async def test_a_grant_to_an_empty_role_does_not_block(
+        self,
+        client: AsyncClient,
+        admin_auth_header: dict,
+        test_db_session,
+    ):
+        """fix(#931 codex r3): a grant row is not an audience.
+
+        No `editor_auth_header` here, so the editor role has no members and the
+        grant reaches nobody. Blocking would be a refusal that lies — the same
+        defect as the ungranted case, one level further in.
+        """
+        admin_id = await _get_user_id(test_db_session, "admin")
+        ds = await self._dataset_on_map(
+            test_db_session,
+            admin_id,
+            dataset_visibility="restricted",
+            map_visibility="internal",
+            map_name="Empty Grant Map",
+        )
+        await self._grant_role(test_db_session, ds.id, "editor")
+
+        resp = await client.patch(
+            f"/datasets/{ds.id}",
+            json={"visibility": "private"},
+            headers=admin_auth_header,
+        )
+
+        assert resp.status_code == 200, resp.text
+
+    async def test_an_unpublished_dataset_never_blocks(
+        self,
+        client: AsyncClient,
+        admin_auth_header: dict,
+        test_db_session,
+    ):
+        """fix(#931 codex r3): an unpublished record is already invisible to
+        every shared-map audience.
+
+        `filter_visible`'s status gate is `published OR created_by == <caller>`,
+        so a draft reaches only its creator, and admins bypass the filter — both
+        keep access after any visibility change. A rank comparison alone would
+        invent a 422 for a move that costs nothing.
+        """
+        admin_id = await _get_user_id(test_db_session, "admin")
+        ds = await self._dataset_on_map(
+            test_db_session,
+            admin_id,
+            dataset_visibility="public",
+            map_visibility="public",
+            map_name="Draft On Public Map",
+        )
+        ds.record.record_status = "draft"
+        await test_db_session.commit()
+
+        resp = await client.patch(
+            f"/datasets/{ds.id}",
+            json={"visibility": "private"},
+            headers=admin_auth_header,
+        )
+
+        assert resp.status_code == 200, resp.text
 
     @pytest.mark.parametrize(
         ("dataset_visibility", "map_visibility", "new_visibility", "blocked"),

--- a/backend/tests/test_datasets.py
+++ b/backend/tests/test_datasets.py
@@ -13,6 +13,7 @@ import uuid
 
 import pytest
 from httpx import AsyncClient
+from sqlalchemy import select
 
 from app.modules.catalog.maps.models import Map, MapLayer
 from tests.factories import (
@@ -505,6 +506,47 @@ class TestUpdateMetadata:
         await test_db_session.commit()
         return ds
 
+    async def test_a_granted_restricted_dataset_still_blocks_the_drop_to_private(
+        self,
+        client: AsyncClient,
+        admin_auth_header: dict,
+        test_db_session,
+    ):
+        """fix(#931 codex r1/r2): `restricted` is a partial audience when, and
+        only when, someone actually holds a grant.
+
+        With a grant row the layer really does render for those viewers, and
+        dropping to private takes it from them — the stranding this guard is
+        for. Without one the same move reaches nobody new, which is the
+        parametrised `restricted -> private` row above.
+        """
+        from app.modules.auth.models import Role
+        from app.modules.catalog.datasets.domain.models import DatasetGrant
+
+        admin_id = await _get_user_id(test_db_session, "admin")
+        map_name = "Granted Restricted Map"
+        ds = await self._dataset_on_map(
+            test_db_session,
+            admin_id,
+            dataset_visibility="restricted",
+            map_visibility="internal",
+            map_name=map_name,
+        )
+        role = (
+            await test_db_session.execute(select(Role).where(Role.name == "viewer"))
+        ).scalar_one()
+        test_db_session.add(DatasetGrant(dataset_id=ds.id, role_id=role.id))
+        await test_db_session.commit()
+
+        resp = await client.patch(
+            f"/datasets/{ds.id}",
+            json={"visibility": "private"},
+            headers=admin_auth_header,
+        )
+
+        assert resp.status_code == 422
+        assert map_name in resp.json()["detail"]
+
     @pytest.mark.parametrize(
         ("dataset_visibility", "map_visibility", "new_visibility", "blocked"),
         [
@@ -520,11 +562,12 @@ class TestUpdateMetadata:
             ("public", "internal", "internal", False),
             # A private map has no audience beyond its owner and grantees.
             ("public", "private", "private", False),
-            # fix(#931 codex r1): `restricted` is a PARTIAL audience, not an
-            # absent one. Grant holders could render this layer, and dropping to
-            # private takes it from them — the exact stranding this guard is for.
-            ("restricted", "internal", "private", True),
-            ("restricted", "public", "private", True),
+            # fix(#931 codex r2): a restricted dataset with NO grants reaches
+            # nobody beyond its owner and admins, who keep access either way —
+            # blocking that move would be a refusal that lies. The granted case
+            # is covered separately below, since it needs a grant row.
+            ("restricted", "internal", "private", False),
+            ("restricted", "public", "private", False),
             # Widening never strands anyone.
             ("restricted", "internal", "public", False),
             ("private", "internal", "internal", False),

--- a/backend/tests/test_datasets.py
+++ b/backend/tests/test_datasets.py
@@ -581,6 +581,71 @@ class TestUpdateMetadata:
 
         assert resp.status_code == 200, resp.text
 
+    async def test_a_grant_reaching_only_an_inactive_user_does_not_block(
+        self,
+        client: AsyncClient,
+        admin_auth_header: dict,
+        viewer_auth_header: dict,
+        test_db_session,
+    ):
+        """fix(#931 codex r4): a grant holder who cannot authenticate is not an
+        audience.
+
+        `get_optional_user` rejects a non-active account before it can render a
+        layer, so deactivating the only grant holder leaves nobody to strand —
+        and the same move that must block while they are active must stop
+        blocking once they are not. Both directions are asserted, because the
+        failure this guards against is a refusal that lies.
+
+        The grant goes to a role created for this test rather than to `viewer`:
+        the per-worker database is shared across tests, and earlier ones leave
+        active `viewer_<hex>` accounts behind, so granting `viewer` would reach
+        members this test cannot deactivate.
+        """
+        from app.modules.auth.models import Role, User, UserRole
+        from app.modules.catalog.datasets.domain.models import DatasetGrant
+
+        admin_id = await _get_user_id(test_db_session, "admin")
+        ds = await self._dataset_on_map(
+            test_db_session,
+            admin_id,
+            dataset_visibility="restricted",
+            map_visibility="internal",
+            map_name="Inactive Grant Map",
+        )
+
+        viewer_id = uuid.UUID(
+            (await client.get("/auth/me/", headers=viewer_auth_header)).json()["id"]
+        )
+        role = Role(name=f"grant-only-{uuid.uuid4().hex[:8]}")
+        test_db_session.add(role)
+        await test_db_session.flush()
+        test_db_session.add(UserRole(user_id=viewer_id, role_id=role.id))
+        test_db_session.add(DatasetGrant(dataset_id=ds.id, role_id=role.id))
+        await test_db_session.commit()
+
+        # Sole grant holder is active: the move strands them, so it is refused.
+        blocked = await client.patch(
+            f"/datasets/{ds.id}",
+            json={"visibility": "private"},
+            headers=admin_auth_header,
+        )
+        assert blocked.status_code == 422
+        assert "Inactive Grant Map" in blocked.json()["detail"]
+
+        viewer = await test_db_session.get(User, viewer_id)
+        viewer.is_active = False
+        viewer.status = "suspended"
+        await test_db_session.commit()
+
+        # Same move, same grant row — nobody left who could have rendered it.
+        allowed = await client.patch(
+            f"/datasets/{ds.id}",
+            json={"visibility": "private"},
+            headers=admin_auth_header,
+        )
+        assert allowed.status_code == 200, allowed.text
+
     async def test_an_unpublished_dataset_never_blocks(
         self,
         client: AsyncClient,

--- a/backend/tests/test_datasets.py
+++ b/backend/tests/test_datasets.py
@@ -516,6 +516,24 @@ class TestUpdateMetadata:
         test_db_session.add(DatasetGrant(dataset_id=dataset_id, role_id=role.id))
         await test_db_session.commit()
 
+    async def _grant_empty_role(self, test_db_session, dataset_id):
+        """Grant a role created here, so "it has no members" is a fact.
+
+        The seeded roles are shared: 22 test files mint `editor_<hex>` accounts
+        and 37 mint `viewer_<hex>`, all on the same per-worker database. A test
+        asserting a grant reaches NOBODY cannot borrow one of those — its
+        emptiness would depend on which files happened to run first, which is
+        true in file order and false under `-n 4`.
+        """
+        from app.modules.auth.models import Role
+        from app.modules.catalog.datasets.domain.models import DatasetGrant
+
+        role = Role(name=f"empty-grant-{uuid.uuid4().hex[:8]}")
+        test_db_session.add(role)
+        await test_db_session.flush()
+        test_db_session.add(DatasetGrant(dataset_id=dataset_id, role_id=role.id))
+        await test_db_session.commit()
+
     async def test_a_grant_reaching_a_real_viewer_blocks_the_drop_to_private(
         self,
         client: AsyncClient,
@@ -540,6 +558,12 @@ class TestUpdateMetadata:
             map_visibility="internal",
             map_name=map_name,
         )
+        # fix(#931): borrows the seeded `viewer` role deliberately. This asserts
+        # BLOCKED, so it needs the role to have a member — `viewer_auth_header`
+        # guarantees one, and the accounts other files leave on the shared
+        # worker DB only reinforce it. The direction is what makes the ambient
+        # dependency safe here; the empty-role case below cannot borrow and
+        # builds its own.
         await self._grant_role(test_db_session, ds.id, "viewer")
 
         resp = await client.patch(
@@ -559,9 +583,15 @@ class TestUpdateMetadata:
     ):
         """fix(#931 codex r3): a grant row is not an audience.
 
-        No `editor_auth_header` here, so the editor role has no members and the
-        grant reaches nobody. Blocking would be a refusal that lies — the same
-        defect as the ungranted case, one level further in.
+        The granted role is created here and never populated, so the grant
+        reaches nobody. Blocking would be a refusal that lies — the same defect
+        as the ungranted case, one level further in.
+
+        It must NOT borrow a seeded role. The first version granted `editor`
+        and reasoned "no `editor_auth_header` in this test, so it is empty",
+        which is a claim about the whole worker rather than about this test:
+        22 files mint editor accounts on the same database. It passed in file
+        order, where `test_datasets.py` runs first, and failed under `-n 4`.
         """
         admin_id = await _get_user_id(test_db_session, "admin")
         ds = await self._dataset_on_map(
@@ -571,7 +601,7 @@ class TestUpdateMetadata:
             map_visibility="internal",
             map_name="Empty Grant Map",
         )
-        await self._grant_role(test_db_session, ds.id, "editor")
+        await self._grant_empty_role(test_db_session, ds.id)
 
         resp = await client.patch(
             f"/datasets/{ds.id}",

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -865,8 +865,8 @@ def test_decomposed_service_modules_stay_within_size_budgets() -> None:
         # so the flip succeeded and every signed-in viewer of that map lost
         # the layer in silence. #930 made the rule a matrix, so the helper
         # compares the before and after audiences instead of listing
-        # forbidden target values. Cap 735 -> 877, exact.
-        "backend/app/modules/catalog/maps/service_public.py": 877,
+        # forbidden target values. Cap 735 -> 876, exact.
+        "backend/app/modules/catalog/maps/service_public.py": 876,
         "backend/app/modules/catalog/search/service_records.py": 500,
         # fix(#448): +~40 LOC — query-embedding hot-path deadline (asyncio.wait_for
         # wrapper) + the gated/approximated vector-only match COUNT in

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -865,8 +865,8 @@ def test_decomposed_service_modules_stay_within_size_budgets() -> None:
         # so the flip succeeded and every signed-in viewer of that map lost
         # the layer in silence. #930 made the rule a matrix, so the helper
         # compares the before and after audiences instead of listing
-        # forbidden target values. Cap 735 -> 811, exact.
-        "backend/app/modules/catalog/maps/service_public.py": 811,
+        # forbidden target values. Cap 735 -> 845, exact.
+        "backend/app/modules/catalog/maps/service_public.py": 845,
         "backend/app/modules/catalog/search/service_records.py": 500,
         # fix(#448): +~40 LOC — query-embedding hot-path deadline (asyncio.wait_for
         # wrapper) + the gated/approximated vector-only match COUNT in
@@ -905,8 +905,8 @@ def test_decomposed_service_modules_stay_within_size_budgets() -> None:
         # fix(#931): +7. _apply_visibility_change no longer carries its own
         # `new != public and old == public` gate — that gate is what hid the
         # internal-map case — and delegates the whole before/after audience
-        # comparison to the maps helper. Cap 480 -> 487, exact.
-        "backend/app/modules/catalog/datasets/domain/service_metadata.py": 487,
+        # comparison to the maps helper. Cap 480 -> 489, exact.
+        "backend/app/modules/catalog/datasets/domain/service_metadata.py": 489,
         # fix(#435 codex r1): +6 LOC in get_dataset_rows to probe schema existence
         # before degrading a 42P01 to an empty page. Postgres reports a missing
         # tenant data schema with the same code as a raster dataset's synthetic

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -859,7 +859,14 @@ def test_decomposed_service_modules_stay_within_size_budgets() -> None:
         # Hosted opaque-share isolation joins every token operation through
         # its RLS-visible Map/User parent (+9 LOC). Cap 720 -> 735 leaves
         # only six lines before the next required split review.
-        "backend/app/modules/catalog/maps/service_public.py": 735,
+        # fix(#931): +32. find_public_maps_using_dataset became
+        # find_maps_broken_by_dataset_visibility: an internal map using the
+        # dataset was matched by neither the old query nor its caller's gate,
+        # so the flip succeeded and every signed-in viewer of that map lost
+        # the layer in silence. #930 made the rule a matrix, so the helper
+        # compares the before and after audiences instead of listing
+        # forbidden target values. Cap 735 -> 767, exact.
+        "backend/app/modules/catalog/maps/service_public.py": 767,
         "backend/app/modules/catalog/search/service_records.py": 500,
         # fix(#448): +~40 LOC — query-embedding hot-path deadline (asyncio.wait_for
         # wrapper) + the gated/approximated vector-only match COUNT in
@@ -895,7 +902,11 @@ def test_decomposed_service_modules_stay_within_size_budgets() -> None:
         "backend/app/modules/catalog/datasets/domain/service_relationships.py": 620,
         # fix(#474): reject primary-language updates that collide with a
         # translated variant. Cap 460 -> 480 (~9 LOC headroom above 471).
-        "backend/app/modules/catalog/datasets/domain/service_metadata.py": 480,
+        # fix(#931): +7. _apply_visibility_change no longer carries its own
+        # `new != public and old == public` gate — that gate is what hid the
+        # internal-map case — and delegates the whole before/after audience
+        # comparison to the maps helper. Cap 480 -> 487, exact.
+        "backend/app/modules/catalog/datasets/domain/service_metadata.py": 487,
         # fix(#435 codex r1): +6 LOC in get_dataset_rows to probe schema existence
         # before degrading a 42P01 to an empty page. Postgres reports a missing
         # tenant data schema with the same code as a raster dataset's synthetic

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -865,8 +865,8 @@ def test_decomposed_service_modules_stay_within_size_budgets() -> None:
         # so the flip succeeded and every signed-in viewer of that map lost
         # the layer in silence. #930 made the rule a matrix, so the helper
         # compares the before and after audiences instead of listing
-        # forbidden target values. Cap 735 -> 780, exact.
-        "backend/app/modules/catalog/maps/service_public.py": 780,
+        # forbidden target values. Cap 735 -> 811, exact.
+        "backend/app/modules/catalog/maps/service_public.py": 811,
         "backend/app/modules/catalog/search/service_records.py": 500,
         # fix(#448): +~40 LOC — query-embedding hot-path deadline (asyncio.wait_for
         # wrapper) + the gated/approximated vector-only match COUNT in

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -865,8 +865,8 @@ def test_decomposed_service_modules_stay_within_size_budgets() -> None:
         # so the flip succeeded and every signed-in viewer of that map lost
         # the layer in silence. #930 made the rule a matrix, so the helper
         # compares the before and after audiences instead of listing
-        # forbidden target values. Cap 735 -> 767, exact.
-        "backend/app/modules/catalog/maps/service_public.py": 767,
+        # forbidden target values. Cap 735 -> 780, exact.
+        "backend/app/modules/catalog/maps/service_public.py": 780,
         "backend/app/modules/catalog/search/service_records.py": 500,
         # fix(#448): +~40 LOC — query-embedding hot-path deadline (asyncio.wait_for
         # wrapper) + the gated/approximated vector-only match COUNT in

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -865,8 +865,8 @@ def test_decomposed_service_modules_stay_within_size_budgets() -> None:
         # so the flip succeeded and every signed-in viewer of that map lost
         # the layer in silence. #930 made the rule a matrix, so the helper
         # compares the before and after audiences instead of listing
-        # forbidden target values. Cap 735 -> 860, exact.
-        "backend/app/modules/catalog/maps/service_public.py": 860,
+        # forbidden target values. Cap 735 -> 877, exact.
+        "backend/app/modules/catalog/maps/service_public.py": 877,
         "backend/app/modules/catalog/search/service_records.py": 500,
         # fix(#448): +~40 LOC — query-embedding hot-path deadline (asyncio.wait_for
         # wrapper) + the gated/approximated vector-only match COUNT in

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -865,8 +865,8 @@ def test_decomposed_service_modules_stay_within_size_budgets() -> None:
         # so the flip succeeded and every signed-in viewer of that map lost
         # the layer in silence. #930 made the rule a matrix, so the helper
         # compares the before and after audiences instead of listing
-        # forbidden target values. Cap 735 -> 845, exact.
-        "backend/app/modules/catalog/maps/service_public.py": 845,
+        # forbidden target values. Cap 735 -> 860, exact.
+        "backend/app/modules/catalog/maps/service_public.py": 860,
         "backend/app/modules/catalog/search/service_records.py": 500,
         # fix(#448): +~40 LOC — query-embedding hot-path deadline (asyncio.wait_for
         # wrapper) + the gated/approximated vector-only match COUNT in

--- a/backend/tests/test_maps.py
+++ b/backend/tests/test_maps.py
@@ -127,7 +127,7 @@ def test_maps_service_facade_exports_public_api() -> None:
         "add_layer",
         "remove_layer",
         "validate_public_visibility",
-        "find_public_maps_using_dataset",
+        "find_maps_broken_by_dataset_visibility",
         "create_share_token",
         "update_share_token",
         "get_active_share_token",

--- a/frontend/src/i18n/locales/de/common.json
+++ b/frontend/src/i18n/locales/de/common.json
@@ -133,6 +133,7 @@
     "analysisJobAlreadyRunning": "Deine vorherige Analyse läuft noch. Warte, bis sie abgeschlossen ist, bevor du eine neue startest.",
     "analysisVectorRequired": "Die Analyse benötigt einen Vektordatensatz – diese Ebene ist keiner.",
     "analysisMaskPolygonRequired": "Die Zuschneidemaske muss eine Polygon-Ebene sein.",
+    "datasetVisibilityBlockedByMaps": "Diese Karten teilen den Datensatz mit einem Publikum, das ihn verlieren würde: {{maps}}. Entfernen Sie dort den Layer oder schränken Sie zuerst diese Karten ein.",
     "analysisUnknownDissolveColumn": "Die Spalte „{{column}}“ existiert in diesem Datensatz nicht. Wähle ein anderes Gruppierungsfeld.",
     "corsWildcardNotAllowed": "Platzhalter-Ursprünge werden nicht akzeptiert. Anfragen mit Anmeldedaten erfordern jeden Ursprung vollständig, zum Beispiel https://example.com.",
     "duplicateSource": "Ein Datensatz aus dieser Quelle ist bereits registriert ({{title}}).",

--- a/frontend/src/i18n/locales/en/common.json
+++ b/frontend/src/i18n/locales/en/common.json
@@ -258,6 +258,7 @@
     "analysisJobAlreadyRunning": "Your previous analysis is still running. Wait for it to finish before starting another.",
     "analysisVectorRequired": "Analysis needs a vector dataset — this layer is not one.",
     "analysisMaskPolygonRequired": "The clip mask must be a polygon layer.",
+    "datasetVisibilityBlockedByMaps": "These maps share the dataset with an audience that would lose it: {{maps}}. Remove the layer there, or narrow those maps first.",
     "analysisUnknownDissolveColumn": "The column “{{column}}” does not exist on this dataset. Pick a different group-by field.",
     "corsWildcardNotAllowed": "Wildcard origins are not accepted. Credentialed requests require every origin listed in full, for example https://example.com.",
     "duplicateSource": "A dataset from this source is already registered ({{title}}).",

--- a/frontend/src/i18n/locales/es/common.json
+++ b/frontend/src/i18n/locales/es/common.json
@@ -133,6 +133,7 @@
     "analysisJobAlreadyRunning": "Tu análisis anterior sigue en curso. Espera a que termine antes de iniciar otro.",
     "analysisVectorRequired": "El análisis necesita un conjunto de datos vectorial; esta capa no lo es.",
     "analysisMaskPolygonRequired": "La máscara de recorte debe ser una capa de polígonos.",
+    "datasetVisibilityBlockedByMaps": "Estos mapas comparten el conjunto de datos con un público que lo perdería: {{maps}}. Quita la capa allí o restringe primero esos mapas.",
     "analysisUnknownDissolveColumn": "La columna «{{column}}» no existe en este conjunto de datos. Elige otro campo de agrupación.",
     "corsWildcardNotAllowed": "No se aceptan orígenes comodín. Las solicitudes con credenciales requieren cada origen indicado por completo, por ejemplo https://example.com.",
     "duplicateSource": "Ya hay un conjunto de datos registrado desde esta fuente ({{title}}).",

--- a/frontend/src/i18n/locales/fr/common.json
+++ b/frontend/src/i18n/locales/fr/common.json
@@ -133,6 +133,7 @@
     "analysisJobAlreadyRunning": "Votre analyse précédente est encore en cours. Attendez qu’elle se termine avant d’en lancer une autre.",
     "analysisVectorRequired": "L’analyse nécessite un jeu de données vectoriel — cette couche n’en est pas un.",
     "analysisMaskPolygonRequired": "Le masque de découpe doit être une couche de polygones.",
+    "datasetVisibilityBlockedByMaps": "Ces cartes partagent le jeu de données avec un public qui le perdrait : {{maps}}. Supprimez-y la couche, ou restreignez d'abord ces cartes.",
     "analysisUnknownDissolveColumn": "La colonne « {{column}} » n’existe pas dans ce jeu de données. Choisissez un autre champ de regroupement.",
     "corsWildcardNotAllowed": "Les origines génériques ne sont pas acceptées. Les requêtes avec identifiants exigent que chaque origine soit indiquée en entier, par exemple https://example.com.",
     "duplicateSource": "Un jeu de données provenant de cette source est déjà enregistré ({{title}}).",

--- a/frontend/src/lib/__tests__/error-map.test.ts
+++ b/frontend/src/lib/__tests__/error-map.test.ts
@@ -181,6 +181,22 @@ describe('API error localization boundary', () => {
     ).toContain('Flood Risk');
   });
 
+  // fix(#931 codex r5): `MapCreate.name` is length-bounded and NFC-normalized,
+  // nothing more, so a newline in a map name is valid input. Without the `s`
+  // flag `.` stopped at it and the whole list fell back to the generic 422 —
+  // losing exactly the part that makes the refusal actionable.
+  it('surfaces map names that legally contain a newline', () => {
+    expect(
+      classifyApiError(
+        'Cannot restrict visibility: dataset is used in shared maps: Flood\nRisk, Parcels',
+        422,
+      ),
+    ).toEqual({
+      key: 'errors.datasetVisibilityBlockedByMaps',
+      values: { maps: 'Flood\nRisk, Parcels' },
+    });
+  });
+
   it('retains unknown layer names through localized structured validation', () => {
     expect(
       translateApiErrorDetail(

--- a/frontend/src/lib/__tests__/error-map.test.ts
+++ b/frontend/src/lib/__tests__/error-map.test.ts
@@ -161,6 +161,26 @@ describe('API error localization boundary', () => {
     ).toBe('The submitted values are invalid.');
   });
 
+  // fix(#931): the backend names the offending maps precisely so a human can go
+  // and fix them; unmapped, that list fell through to the generic 422 string.
+  it('surfaces the maps a visibility change would strand', () => {
+    expect(
+      classifyApiError(
+        'Cannot restrict visibility: dataset is used in shared maps: Flood Risk, Parcels 2026',
+        422,
+      ),
+    ).toEqual({
+      key: 'errors.datasetVisibilityBlockedByMaps',
+      values: { maps: 'Flood Risk, Parcels 2026' },
+    });
+    expect(
+      translateApiErrorDetail(
+        'Cannot restrict visibility: dataset is used in shared maps: Flood Risk',
+        422,
+      ),
+    ).toContain('Flood Risk');
+  });
+
   it('retains unknown layer names through localized structured validation', () => {
     expect(
       translateApiErrorDetail(

--- a/frontend/src/lib/error-map.ts
+++ b/frontend/src/lib/error-map.ts
@@ -202,8 +202,14 @@ function descriptorForMessage(message: string, status: number): ApiErrorDescript
   // fix(#931): the backend names the offending maps precisely so a human can go
   // and fix them, and unmapped that list fell through to the generic 422 —
   // which drops exactly the part that makes the refusal actionable.
+  // fix(#931 codex r5): `s` (dotAll) because a map name may legally contain a
+  // newline — `MapCreate.name` is length-bounded and NFC-normalized, nothing
+  // more — and without it `.` stops at the line terminator, the match fails,
+  // and the actionable map list collapses to the generic 422. `$` is dropped
+  // for the same reason: with `m` absent it anchors at the end of input, but
+  // the trailing-newline allowance would still truncate.
   const strandedMaps = message.match(
-    /^Cannot restrict visibility: dataset is used in shared maps:\s*(.+)$/i,
+    /^Cannot restrict visibility: dataset is used in shared maps:\s*([\s\S]+)/i,
   );
   if (strandedMaps) {
     return {

--- a/frontend/src/lib/error-map.ts
+++ b/frontend/src/lib/error-map.ts
@@ -199,6 +199,19 @@ function descriptorForMessage(message: string, status: number): ApiErrorDescript
     };
   }
 
+  // fix(#931): the backend names the offending maps precisely so a human can go
+  // and fix them, and unmapped that list fell through to the generic 422 —
+  // which drops exactly the part that makes the refusal actionable.
+  const strandedMaps = message.match(
+    /^Cannot restrict visibility: dataset is used in shared maps:\s*(.+)$/i,
+  );
+  if (strandedMaps) {
+    return {
+      key: 'errors.datasetVisibilityBlockedByMaps',
+      values: { maps: strandedMaps[1] },
+    };
+  }
+
   return fallbackDescriptor(status);
 }
 


### PR DESCRIPTION
Closes #931. Step 4 of the #940 visibility ladder.

> **Merge after #1029 (#930).** The matrix below is only correct once `internal`
> is a real dataset rung. No file conflict — #930 edits `dataset.json`, this
> adds one key to `common.json`.

## Decision, recorded here for the issue

**Extend the backend block**, not a frontend confirm dialog. Grounds:

- It matches the precedent one rung up: a public map already hard-blocks, and an
  internal map's viewers lose the layer just as completely.
- A warning cannot be honest about its own scope. `GET /datasets/{id}/maps/` is
  RBAC-filtered by the caller and paginated at 50 (cap 200), so the dialog would
  under-report on exactly the datasets where it matters most.
- It makes the two gaps land together correctly. Extending the query makes the
  422's "public maps" wording wrong, and that string is what gap 1's regex
  matches — split across PRs, gap 1 ships a regex for a message that no longer
  exists.

## Gap 2 — internal maps broke silently

`find_public_maps_using_dataset` filtered on `Map.visibility == "public"` only,
and its caller gated on `new != "public" and old == "public"`. An internal map
was invisible to **both** halves, so the flip succeeded and every signed-in
viewer of that map lost the layer's tiles and features with no signal to anyone.

It is now `find_maps_broken_by_dataset_visibility`, and it compares the before
and after audiences rather than listing forbidden target values. #930 turned the
rule into a matrix, and a rule written against today's target value alone gets
cells wrong in both directions.

The four rungs nest — the owner is a grantee is a signed-in user is everyone —
so this is a total order, and "does this change strand someone" is a comparison
of how much of each map's audience the dataset reaches, before and after:

| dataset move | public map | internal map |
| --- | --- | --- |
| public → internal | blocked | **allowed** — the audience still reaches it |
| public → private | blocked | blocked |
| internal → private | blocked | blocked — invisible to the old gate |
| restricted → private | blocked | blocked — the grant holders lose it |
| restricted → public | allowed | allowed — widening strands nobody |

An internal map's audience is every signed-in user, and both `internal` and
`public` reach all of them, so the two tie there. That tie is the whole reason
public → internal is safe on an internal map and not on a public one.

A private map is never flagged: it has no audience beyond its owner and grantees.

The caller keeps no gate of its own — that gate is what hid the internal case —
and the helper returns an empty list when the change strands nothing.

Renamed through the façade per the layering rule (`maps/service.py` import +
`__all__`, and the `test_layering` name set).

## Gap 1 — the block was invisible in the UI

#976 routed the 422 into a toast with an inline comment deferring the localized
message here. `error-map.ts` now matches the refusal and routes it to
`errors.datasetVisibilityBlockedByMaps`, interpolating the map names — which the
backend returns precisely so a human can go and fix them, and which the generic
422 fallback dropped. Key added to all four locales.

## Verification

```
cd backend && set -a && source ../.env.test && set +a && uv run pytest \
  tests/test_datasets.py tests/test_maps.py tests/test_layering.py -q
  # 235 passed
cd backend && uv run ruff check . && uv run ruff format --check .
cd frontend && npm run lint && npm run typecheck && npm run test:i18n
cd frontend && npx vitest run src/lib src/components/dataset   # 1062 passed
```

`test_visibility_change_blocks_exactly_the_maps_it_strands` is parametrised over
eleven cells of the matrix, including the ones the old shape got wrong in each
direction and the moves that must stay allowed. The existing public-map tests are unchanged and still
pass, since the public rule did not move. LOC ratchets: `maps/service_public.py`
735 → 767, `datasets/domain/service_metadata.py` 480 → 487.

