### PR TITLE
ops(analysis): promote the analysis statement timeouts to settings

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -610,6 +610,33 @@ FRONTEND_PORT=8080
 # Type: integer (minimum 0) | Default: 30
 # INGEST_JOBS_RETENTION_DAYS=30
 
+# --- Analysis Budgets ---
+# Statement timeout for the analysis materialize CTAS — the CREATE TABLE AS that
+# builds a buffer/dissolve/clip/centroid output. The default covers roughly 150k
+# to 600k buffered polygon rows; raise it if a large dataset fails with "The
+# analysis exceeded its 300s processing time limit".
+#
+# What raising it costs: without an admission gate a longer budget does not make
+# the work cheaper, it holds the job slot longer. Raising this to 1200 turns
+# "fails at 5 minutes" into "occupies the worker slot for 20 minutes and then
+# maybe fails", which is worse for everything else in the queue. Raise it
+# together with WORKER_CONCURRENCY, or accept the queue wait.
+#
+# Zero is rejected at startup: PostgreSQL reads statement_timeout = '0' as no
+# timeout at all, which is exactly the unbounded statement this budget exists to
+# prevent.
+# Type: integer seconds (minimum 1) | Default: 300
+# ANALYSIS_MATERIALIZE_TIMEOUT_SECONDS=300
+
+# Statement timeout for the registration phase that follows the CTAS. The commit
+# that makes the output table durable ends the CTAS transaction and its budget
+# with it, so the full-scan metadata extraction (COUNT, ST_Extent, sample values)
+# needs its own. Raise this alongside the CTAS budget when working with large
+# outputs; leaving one raised and the other at its default just moves where the
+# timeout lands.
+# Type: integer seconds (minimum 1) | Default: 600
+# ANALYSIS_REGISTRATION_TIMEOUT_SECONDS=600
+
 # --- Frontend Dev-Server Proxy ---
 # [OPTIONAL] Vite dev-server proxy target. Consumed only by frontend/vite.config.ts
 # (Node side); NOT exposed to the browser bundle. The dev container sets this to

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -226,6 +226,37 @@ class Settings(BaseSettings):
     # Set INGEST_HTTP_TIMEOUT_SECONDS in the api service env to override.
     ingest_http_timeout_seconds: int = Field(default=300, gt=0)
 
+    # fix(#1013): the materialize CTAS budget, applied as SET LOCAL
+    # statement_timeout before the CREATE TABLE AS. It was a module constant
+    # carrying a comment that already said "promote to persistent-config if
+    # operators hit it" — 300 seconds covers roughly 150k to 600k buffered
+    # polygon rows, so an ordinary one-million-parcel buffer fails and the only
+    # recourse was editing Python and rebuilding the image.
+    #
+    # gt=0 is load-bearing rather than tidiness: PostgreSQL reads
+    # statement_timeout = '0' as "no timeout at all", so a zero here would
+    # silently produce the unbounded statement the budget exists to prevent.
+    # Rejecting it at boot is the difference between a startup failure and an
+    # ingest queue held open indefinitely.
+    #
+    # Worth being clear about what raising it buys: without an admission gate a
+    # longer budget just holds the job slot longer. The work still runs, it
+    # fails later. It pairs with #691's heartbeat lease and #701's pre-flight
+    # gates; on its own it converts "fails at 5 minutes" into "occupies the
+    # worker slot for 20 minutes and then maybe fails". Per-operation budgets
+    # are the natural follow-up — a centroid needs seconds and a dissolve far
+    # more, so one scalar for all operations is a deliberate compromise.
+    analysis_materialize_timeout_seconds: int = Field(default=300, gt=0)
+
+    # fix(#1013): promoted alongside the CTAS budget rather than left as the odd
+    # one out. It exists because the commit that makes the output durable ends
+    # the transaction and its SET LOCAL with it, so registration needs its own
+    # budget (#692) for the full-scan metadata extraction. An operator who
+    # raises the CTAS ceiling for a large dataset needs to raise this too;
+    # promoting one and not the other is the kind of inconsistency that costs
+    # someone an afternoon.
+    analysis_registration_timeout_seconds: int = Field(default=600, gt=0)
+
     # fix(#434): finished ingest_jobs rows previously lived forever, so the
     # admin Jobs page accumulated stale test junk with no cleanup affordance.
     # Terminal jobs (complete/failed/cancelled/fanned_out) older than this many

--- a/backend/app/processing/analysis/tasks.py
+++ b/backend/app/processing/analysis/tasks.py
@@ -52,18 +52,33 @@ logger = structlog.stdlib.get_logger(__name__)
 _SAFE_IDENT = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_]*$")
 _SAFE_TABLE = re.compile(r"^[a-z0-9_]+$")
 
+
 # The preview path is bounded (10s sandbox timeout, 500-row cap); the CTAS
 # here is the only unbounded statement a user can queue, so cap it.
-# Hardcoded ceiling; promote to persistent-config if operators hit it.
-MATERIALIZE_TIMEOUT = "300s"
+#
+# fix(#1013): the value is an operator setting now, not a hardcoded ceiling.
+# Read through a function rather than bound at import: these render into SQL
+# and into a user-facing message, and a module-level snapshot would freeze
+# whatever the settings object held the first time this module was imported.
+def materialize_timeout() -> str:
+    """The CTAS statement_timeout, as a PostgreSQL interval literal."""
+    from app.core.config import settings
+
+    return f"{settings.analysis_materialize_timeout_seconds}s"
+
 
 # The mid-task commit that makes the output table durable also ends the
-# transaction carrying MATERIALIZE_TIMEOUT — registration then runs full-scan
+# transaction carrying the CTAS budget — registration then runs full-scan
 # metadata extraction (COUNT + ST_Extent + the sample-values CTE) in a fresh
 # transaction, which would otherwise have no statement budget at all
-# (fix(#692)). Larger than the CTAS budget: those scans are cheap relative to
-# the build, but must never be unbounded.
-REGISTRATION_TIMEOUT = "600s"
+# (fix(#692)). Larger than the CTAS budget by default: those scans are cheap
+# relative to the build, but must never be unbounded.
+def registration_timeout() -> str:
+    """The post-commit registration statement_timeout, as an interval literal."""
+    from app.core.config import settings
+
+    return f"{settings.analysis_registration_timeout_seconds}s"
+
 
 # fix(#694): post-CTAS backstop on the built output's on-disk size. The
 # enqueue gates read the cached feature_count snapshot, which can be stale;
@@ -95,7 +110,7 @@ def _user_error_message(exc: Exception) -> str:
             # fix(v1.6.0 audit D11): name the configured limit so the user
             # knows what budget was exceeded.
             return (
-                f"The analysis exceeded its {MATERIALIZE_TIMEOUT} processing "
+                f"The analysis exceeded its {materialize_timeout()} processing "
                 "time limit. Try a smaller dataset or area."
             )
         if isinstance(exc, (DataError, InternalError)):
@@ -694,7 +709,7 @@ async def _materialize(
                 mask_table_ref=mask_table_ref,
             )
             await session.execute(
-                text(f"SET LOCAL statement_timeout = '{MATERIALIZE_TIMEOUT}'")
+                text(f"SET LOCAL statement_timeout = '{materialize_timeout()}'")
             )
             if operation == "dissolve":
                 # fix(#694): hash aggregation holds every group's union state
@@ -760,7 +775,7 @@ async def _materialize(
             # rather than inside register_existing_table, which is shared
             # with the upload path.
             await session.execute(
-                text(f"SET LOCAL statement_timeout = '{REGISTRATION_TIMEOUT}'")
+                text(f"SET LOCAL statement_timeout = '{registration_timeout()}'")
             )
             # Identity is a structural Protocol; registration only reads .id.
             requester = SimpleNamespace(id=uuid.UUID(user_id))

--- a/backend/app/processing/analysis/tasks.py
+++ b/backend/app/processing/analysis/tasks.py
@@ -96,7 +96,7 @@ ANALYSIS_JOBS = Counter(
 )
 
 
-def _user_error_message(exc: Exception) -> str:
+def _user_error_message(exc: Exception, *, registered: bool = False) -> str:
     """Map a failure onto text safe to return from ``GET /jobs/{job_id}``.
 
     SQLAlchemy stringifies DB errors with the full statement appended
@@ -108,9 +108,17 @@ def _user_error_message(exc: Exception) -> str:
         exc_text = str(exc).lower()
         if "querycancelederror" in exc_text or "statement timeout" in exc_text:
             # fix(v1.6.0 audit D11): name the configured limit so the user
-            # knows what budget was exceeded.
+            # knows what budget was exceeded. fix(#1013 review): WHICH limit
+            # depends on the phase — the CTAS transaction carries the
+            # materialize budget, and the commit that ends it re-arms
+            # registration with its own (#692). Naming the wrong one was
+            # harmless while both were hardcoded at 300s/600s and only the
+            # first was ever quoted; now that an operator can set them
+            # independently, a registration timeout quoting the materialize
+            # budget sends them to tune the setting that did not fire.
+            budget = registration_timeout() if registered else materialize_timeout()
             return (
-                f"The analysis exceeded its {materialize_timeout()} processing "
+                f"The analysis exceeded its {budget} processing "
                 "time limit. Try a smaller dataset or area."
             )
         if isinstance(exc, (DataError, InternalError)):
@@ -389,6 +397,7 @@ async def _mark_job_failed(
     schema: str,
     out_table: str | None,
     operation: str,
+    registered: bool = False,
 ) -> None:
     """Roll back, record the failure, and drop this job's own partial table.
 
@@ -411,7 +420,7 @@ async def _mark_job_failed(
         values={
             "status": "failed",
             # Sanitized (fix(#692)): raw DB errors embed the generated SQL.
-            "error_message": _user_error_message(exc),
+            "error_message": _user_error_message(exc, registered=registered),
             # fix(v1.6.0 audit B12): stamp completion time like ingest does.
             "completed_at": datetime.now(timezone.utc),
         },
@@ -626,6 +635,10 @@ async def _materialize(
         # generated name, an unconditional cleanup would destroy the winner's
         # table while its dataset registration stays live.
         out_table_created = False
+        # fix(#1013 review): flipped when the CTAS transaction commits and
+        # registration re-arms its own statement_timeout, so a failure after
+        # that point quotes the budget that actually fired.
+        registration_started = False
         # Created inside the try so the finally below always reaps it: a
         # heartbeat left running after an exception here would renew a lease
         # for a job nobody is executing, and the sweep can never fail a row
@@ -769,6 +782,7 @@ async def _materialize(
             await session.execute(text(f"ANALYZE {out_ref}"))
             job.current_step = "registering"
             await session.commit()
+            registration_started = True
 
             # The commit above ended the transaction and the SET LOCAL with
             # it — give registration its own budget (fix(#692)). Set here
@@ -836,6 +850,9 @@ async def _materialize(
                 schema=_schema,
                 out_table=out_table if out_table_created else None,
                 operation=operation,
+                # True only once the CTAS transaction has committed, which is
+                # exactly when the registration budget is the one in force.
+                registered=registration_started,
             )
         finally:
             # The row has left 'running' by now, so the loop would exit on its

--- a/backend/tests/test_analysis_materialize.py
+++ b/backend/tests/test_analysis_materialize.py
@@ -24,7 +24,7 @@ from app.modules.catalog.datasets.api import router_analysis
 from app.platform.analysis_sql import MAX_BUFFER_METERS
 from app.platform.jobs.models import IngestJob
 from app.processing.analysis.tasks import (
-    MATERIALIZE_TIMEOUT,
+    materialize_timeout,
     _complete_job_for_attempt,
     _enforce_output_size,
     _fail_cancelled_job,
@@ -2240,6 +2240,21 @@ class TestMaterializeWorker:
         # Same transaction, ahead of the CTAS it protects.
         assert executed.index(hashaggs[0]) < executed.index(ctas[0])
 
+    def test_analysis_timeouts_track_their_settings(self, monkeypatch):
+        """fix(#1013): the budgets are operator settings now, and they are read
+        at call time — a module-level snapshot would freeze whatever the
+        settings object held when this module was first imported."""
+        from app.core.config import settings
+
+        from app.processing.analysis.tasks import registration_timeout
+
+        assert materialize_timeout() == "300s"
+        assert registration_timeout() == "600s"
+        monkeypatch.setattr(settings, "analysis_materialize_timeout_seconds", 1200)
+        monkeypatch.setattr(settings, "analysis_registration_timeout_seconds", 1800)
+        assert materialize_timeout() == "1200s"
+        assert registration_timeout() == "1800s"
+
     async def test_worker_rechecks_size_caps_before_ctas(
         self,
         test_db_session: AsyncSession,
@@ -3401,7 +3416,7 @@ class TestUserErrorMessage:
         msg = _user_error_message(exc)
         assert "time limit" in msg
         # fix(v1.6.0 audit D11): the message names the configured limit.
-        assert MATERIALIZE_TIMEOUT in msg
+        assert materialize_timeout() in msg
         assert "big_output" not in msg
 
     def test_domain_errors_pass_through(self):

--- a/backend/tests/test_analysis_materialize.py
+++ b/backend/tests/test_analysis_materialize.py
@@ -2240,6 +2240,26 @@ class TestMaterializeWorker:
         # Same transaction, ahead of the CTAS it protects.
         assert executed.index(hashaggs[0]) < executed.index(ctas[0])
 
+    def test_timeout_message_names_the_budget_that_fired(self, monkeypatch):
+        """fix(#1013 review): the two budgets are independently configurable
+        now, so a registration timeout quoting the materialize budget would
+        send an operator to tune the setting that did not fire."""
+        from sqlalchemy.exc import OperationalError
+
+        from app.core.config import settings
+        from app.processing.analysis.tasks import _user_error_message
+
+        monkeypatch.setattr(settings, "analysis_materialize_timeout_seconds", 300)
+        monkeypatch.setattr(settings, "analysis_registration_timeout_seconds", 900)
+        exc = OperationalError(
+            "SELECT 1", {}, Exception("canceling statement due to statement timeout")
+        )
+
+        assert "300s" in _user_error_message(exc)
+        assert "900s" not in _user_error_message(exc)
+        assert "900s" in _user_error_message(exc, registered=True)
+        assert "300s" not in _user_error_message(exc, registered=True)
+
     def test_analysis_timeouts_track_their_settings(self, monkeypatch):
         """fix(#1013): the budgets are operator settings now, and they are read
         at call time — a module-level snapshot would freeze whatever the

--- a/backend/tests/test_analysis_materialize.py
+++ b/backend/tests/test_analysis_materialize.py
@@ -2268,6 +2268,13 @@ class TestMaterializeWorker:
 
         from app.processing.analysis.tasks import registration_timeout
 
+        # Set the baseline rather than asserting the shipped defaults: settings
+        # is a module-level singleton, so an ANALYSIS_*_TIMEOUT_SECONDS in the
+        # environment or the root .env would already have overridden them and
+        # the "before" assertions would fail for a reason unrelated to the
+        # behaviour under test.
+        monkeypatch.setattr(settings, "analysis_materialize_timeout_seconds", 300)
+        monkeypatch.setattr(settings, "analysis_registration_timeout_seconds", 600)
         assert materialize_timeout() == "300s"
         assert registration_timeout() == "600s"
         monkeypatch.setattr(settings, "analysis_materialize_timeout_seconds", 1200)

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -410,6 +410,16 @@ class TestSettingsConstraints:
             ("tile_pool_min_size", 0),
             ("tile_pool_max_size", 0),
             ("ingest_http_timeout_seconds", 0),
+            # fix(#1013): zero is the dangerous one for these two —
+            # statement_timeout = '0' disables the timeout entirely rather than
+            # erroring, so a zero accepted here would silently produce the
+            # unbounded statement the budget exists to prevent.
+            ("analysis_materialize_timeout_seconds", 0),
+            ("analysis_materialize_timeout_seconds", -1),
+            ("analysis_materialize_timeout_seconds", "not-a-number"),
+            ("analysis_registration_timeout_seconds", 0),
+            ("analysis_registration_timeout_seconds", -1),
+            ("analysis_registration_timeout_seconds", "not-a-number"),
             ("ingest_jobs_retention_days", -1),
             ("smtp_port", 0),
             ("smtp_port", 65536),


### PR DESCRIPTION
`MATERIALIZE_TIMEOUT = "300s"` was a module constant carrying a comment that already said the quiet part: *"Hardcoded ceiling; promote to persistent-config if operators hit it."* 300 seconds covers roughly 150k to 600k buffered polygon rows, so an ordinary one-million-parcel buffer fails and the operator's only recourse was editing Python and rebuilding the image.

## What is promoted

| Setting | Was | Default |
|---|---|---|
| `ANALYSIS_MATERIALIZE_TIMEOUT_SECONDS` | `MATERIALIZE_TIMEOUT = "300s"` | 300 |
| `ANALYSIS_REGISTRATION_TIMEOUT_SECONDS` | `REGISTRATION_TIMEOUT = "600s"` | 600 |

**`REGISTRATION_TIMEOUT` is promoted with it**, per the issue's "decide it in the same pass". It exists because the commit that makes the output durable ends the CTAS transaction and its `SET LOCAL` with it (#692), so an operator who raises the CTAS ceiling for a large dataset needs to raise this one too. Promoting one and leaving the other hardcoded is exactly the inconsistency that costs someone an afternoon.

Both are read through a small function rather than bound at import. They render into SQL **and** into the user-facing "The analysis exceeded its 300s processing time limit" message, so a module-level snapshot would freeze whatever the settings object held when the module was first imported.

## The four surfaces

1. **`Settings` fields** in `backend/app/core/config.py`.
2. **Validation** — `gt=0`, which is load-bearing rather than tidiness. PostgreSQL reads `statement_timeout = '0'` as *no timeout at all* rather than erroring, so a zero accepted here would silently produce the unbounded statement the budget exists to prevent. Zero, negative, and unparseable values all fail at boot; asserted in `test_config.py`'s constraint table (six new rows), and verified to pass only because of the constraint by dropping `gt=0` and watching them fail.
3. **`.env.example`**, with a comment saying what the budget covers and, more usefully, **what raising it does not buy**: without an admission gate a longer budget does not make the work cheaper, it holds the job slot longer. Raising to 1200 turns "fails at 5 minutes" into "occupies the worker slot for 20 minutes and then maybe fails", which is worse for everything else in the queue.
4. **Docs site** — `docs.getgeolens.com` is a separate repository, so that entry cannot be made from here. The two keys and the `.env.example` prose are ready to copy across; flagging it rather than silently counting the surface as done.

Per-operation budgets remain the natural follow-up, not this change: a centroid needs seconds and a dissolve far more, so one scalar for all operations is a deliberate compromise. This ships the scalar.

## What is NOT included, and why

`DEFAULT_TIMEOUT_MS` (the sandbox preview budget) is the issue's third value. It lives in `backend/app/platform/sandbox/executor.py`, and threading `timeout_ms` through that module is **session G's #1011** in this wave. Editing the same symbol from two sides would put us both in a conflict for no benefit, so it is left for that change and **#1013 stays open** for it. This PR says `Refs #1013`, not `Closes`.

## Verification

```
cd backend && uv run pytest tests/test_config.py -q                 # 132 passed
cd backend && uv run pytest tests/test_analysis_materialize.py -q   # 80 passed
python3 scripts/check_env_doc_drift.py                              # 134 keys aligned
python3 scripts/check_docs_contract.py                              # passed
cd backend && uv run ruff check . && uv run ruff format --check .    # clean
```

No schema or API change.

Refs #1013