### PR TITLE
fix(builder): report the true category count and scope the mixed-geometry ramp

### DIFF
--- a/frontend/src/components/builder/DataDrivenStyleEditor.tsx
+++ b/frontend/src/components/builder/DataDrivenStyleEditor.tsx
@@ -34,6 +34,7 @@ import {
   manualBreaks,
 } from '@/lib/classification';
 import { MAP_COLORS } from '@/lib/map-colors';
+import { classifyGeometry } from '@/components/builder/layer-adapters/shared';
 import { isNumericColumn } from '@/lib/column-utils';
 import type { MapLayerResponse, StyleConfig } from '@/types/api';
 
@@ -378,9 +379,14 @@ export function DataDrivenStyleEditor({
     columnForCategorical ? layer.dataset_id : undefined,
     columnForCategorical,
   );
+  // fix(#960): categorical mode needs the stats endpoint too. useColumnValues pages
+  // at 100 (500 max), so its length is a page size, not a cardinality — the warning
+  // read "100 categories" on a column with thousands and the swatch list stopped at
+  // 100 with nothing saying so. `distinct_count` is exact and full-table (#315).
+  const columnForStats = columnForGraduated ?? columnForCategorical;
   const { data: statsData } = useColumnStats(
-    columnForGraduated ? layer.dataset_id : undefined,
-    columnForGraduated,
+    columnForStats ? layer.dataset_id : undefined,
+    columnForStats,
   );
 
   // std-dev classification needs both mean and σ. The current stats endpoint
@@ -713,8 +719,18 @@ export function DataDrivenStyleEditor({
     [styleConfig, geomType, layerPaint, layerId, onStyleConfigChange, colorDebounceRef],
   );
 
+  // fix(#960): the honest counts. `values` is one page (100 by default, 500 max);
+  // `distinct_count` is the exact full-table cardinality. The advice triggers on the
+  // true count, and when the swatch list is only a prefix of it, the copy says so.
+  const shownCategories = valuesData?.values.length ?? 0;
+  const distinctCategories = mode === 'categorical' ? statsData?.distinct_count ?? null : null;
+  const totalCategories = distinctCategories ?? shownCategories;
+  const categoriesTruncated = distinctCategories != null && distinctCategories > shownCategories;
   const hasTooManyCategories =
-    mode === 'categorical' && valuesData && valuesData.values.length > 20;
+    mode === 'categorical' && !!valuesData && totalCategories > 20;
+  // fix(#952): the same `classifyGeometry(...) === 'other'` test getColorProperty
+  // already makes — GEOMETRY / GEOMETRYCOLLECTION, i.e. created and sketch datasets.
+  const isMixedGeometry = classifyGeometry(layer.dataset_geometry_type) === 'other';
   const noCompatibleColumns = filteredColumns.length === 0;
   const selectedColumnMissing = Boolean(column) && !columns.some((c) => c.name === column);
   const graduatedStatsUnavailable =
@@ -816,6 +832,18 @@ export function DataDrivenStyleEditor({
           {mode === 'categorical'
             ? t('dataDriven.noTextColumnsHelp')
             : t('dataDriven.noNumericColumnsHelp')}
+        </p>
+      )}
+
+      {/* fix(#952): a ramp on a mixed-geometry layer writes one colour property,
+          chosen by geometry — 'other' resolves to fill-color — and the mixed adapter
+          then filters that key out of the line and circle sublayers. So only the
+          polygons classify, while the legend shows the full classification as though
+          it applied to everything. The multi-property fix is unscheduled; say which
+          features the colours reach so the mismatch is explicable. */}
+      {isMixedGeometry && (
+        <p className="rounded-md bg-muted px-2 py-1.5 text-mini leading-snug text-muted-foreground">
+          {t('dataDriven.mixedGeometryColorScope')}
         </p>
       )}
 
@@ -1055,7 +1083,12 @@ export function DataDrivenStyleEditor({
 
       {hasTooManyCategories && (
         <p className="rounded-md bg-warning/15 px-2 py-1.5 text-mini leading-snug text-warning">
-          {t('dataDriven.categoriesWarning', { count: valuesData.values.length })}
+          {categoriesTruncated
+            ? t('dataDriven.categoriesTruncatedWarning', {
+                count: totalCategories,
+                shown: shownCategories,
+              })
+            : t('dataDriven.categoriesWarning', { count: totalCategories })}
         </p>
       )}
     </div>

--- a/frontend/src/components/builder/DataDrivenStyleEditor.tsx
+++ b/frontend/src/components/builder/DataDrivenStyleEditor.tsx
@@ -34,7 +34,7 @@ import {
   manualBreaks,
 } from '@/lib/classification';
 import { MAP_COLORS } from '@/lib/map-colors';
-import { classifyGeometry } from '@/components/builder/layer-adapters/shared';
+import { isGenericGeometryType } from '@/components/builder/layer-adapters/shared';
 import { isNumericColumn } from '@/lib/column-utils';
 import type { MapLayerResponse, StyleConfig } from '@/types/api';
 
@@ -728,9 +728,12 @@ export function DataDrivenStyleEditor({
   const categoriesTruncated = distinctCategories != null && distinctCategories > shownCategories;
   const hasTooManyCategories =
     mode === 'categorical' && !!valuesData && totalCategories > 20;
-  // fix(#952): the same `classifyGeometry(...) === 'other'` test getColorProperty
-  // already makes — GEOMETRY / GEOMETRYCOLLECTION, i.e. created and sketch datasets.
-  const isMixedGeometry = classifyGeometry(layer.dataset_geometry_type) === 'other';
+  // fix(#952): the mixed-ADAPTER predicate, not classifyGeometry(...) === 'other'.
+  // Both catch GEOMETRY / GEOMETRYCOLLECTION (created and sketch datasets), but
+  // 'other' also swallows null and exotic types like CURVE, which resolveAdapterType
+  // routes to the plain fill adapter — telling those layers that their line and point
+  // sublayers keep their colours would describe sublayers that do not exist.
+  const isMixedGeometry = isGenericGeometryType(layer.dataset_geometry_type);
   const noCompatibleColumns = filteredColumns.length === 0;
   const selectedColumnMissing = Boolean(column) && !columns.some((c) => c.name === column);
   const graduatedStatsUnavailable =

--- a/frontend/src/components/builder/__tests__/DataDrivenStyleEditor.test.tsx
+++ b/frontend/src/components/builder/__tests__/DataDrivenStyleEditor.test.tsx
@@ -1120,7 +1120,9 @@ describe('DataDrivenStyleEditor', () => {
       expect(screen.getByText(/Colors apply to polygon features/)).toBeInTheDocument();
     });
 
-    it.each(['Polygon', 'MultiLineString', 'Point'])('does NOT show the hint for %s', (gt) => {
+    // Only the two generic sentinels route to the mixed adapter; an exotic or absent
+    // type keeps the plain fill fallback and has no line/point sublayers to describe.
+    it.each(['Polygon', 'MultiLineString', 'Point', 'CURVE', ''])('does NOT show the hint for %s', (gt) => {
       renderWithGeometry(gt);
       expect(screen.queryByText(/Colors apply to polygon features/)).toBeNull();
     });

--- a/frontend/src/components/builder/__tests__/DataDrivenStyleEditor.test.tsx
+++ b/frontend/src/components/builder/__tests__/DataDrivenStyleEditor.test.tsx
@@ -1050,4 +1050,79 @@ describe('DataDrivenStyleEditor', () => {
       expect(picker.textContent).toContain(SAVED_RAMP);
     });
   });
+
+  // fix(#960): the values endpoint pages at 100 (500 max), so its length is a page
+  // size. The warning used to report it as the category count, and the swatch list
+  // stopped there with nothing saying it was a prefix.
+  describe('#960 honest category counts', () => {
+    const PAGE = Array.from({ length: 100 }, (_, i) => `cat${i}`);
+
+    function renderCategorical(distinctCount: number | null) {
+      mockUseColumnValues.mockReturnValue(hookData({ values: PAGE, count: PAGE.length }));
+      mockUseColumnStats.mockReturnValue(
+        (distinctCount == null
+          ? noData()
+          : hookData({ distinct_count: distinctCount, data_type: 'categorical' })
+        ) as unknown as ReturnType<typeof useColumnStats>,
+      );
+      render(
+        <DataDrivenStyleEditor
+          layer={makeLayer({ style_config: { mode: 'categorical', column: 'typeA', ramp: 'Set2' } })}
+          onStyleConfigChange={vi.fn()}
+        />,
+      );
+    }
+
+    it('reports the true distinct count and says the list is a prefix', () => {
+      renderCategorical(4000);
+      const warning = screen.getByText(/4,?000 categories/);
+      expect(warning).toBeInTheDocument();
+      expect(warning.textContent).toMatch(/first 100/);
+      expect(screen.queryByText(/^100 categories/)).toBeNull();
+    });
+
+    it('keeps the plain warning when the page holds every category', () => {
+      renderCategorical(100);
+      const warning = screen.getByText(/100 categories/);
+      expect(warning.textContent).not.toMatch(/first/);
+    });
+
+    it('falls back to the page length when no stats are available', () => {
+      renderCategorical(null);
+      expect(screen.getByText(/100 categories/)).toBeInTheDocument();
+    });
+
+    it('calls useColumnStats for the categorical column, not only the graduated one', () => {
+      renderCategorical(4000);
+      expect(mockUseColumnStats).toHaveBeenCalledWith('ds-1', 'typeA');
+    });
+  });
+
+  // fix(#952): a ramp on a mixed-geometry layer only colours the polygons, because
+  // getColorProperty resolves 'other' to fill-color and the mixed adapter filters
+  // that key out of the line and circle sublayers.
+  describe('#952 mixed-geometry colour scope hint', () => {
+    function renderWithGeometry(geometryType: string) {
+      mockUseColumnValues.mockReturnValue(hookData({ values: ['a', 'b'], count: 2 }));
+      render(
+        <DataDrivenStyleEditor
+          layer={makeLayer({
+            dataset_geometry_type: geometryType,
+            style_config: { mode: 'categorical', column: 'typeA', ramp: 'Set2' },
+          })}
+          onStyleConfigChange={vi.fn()}
+        />,
+      );
+    }
+
+    it.each(['GEOMETRY', 'GEOMETRYCOLLECTION'])('shows the hint for %s', (gt) => {
+      renderWithGeometry(gt);
+      expect(screen.getByText(/Colors apply to polygon features/)).toBeInTheDocument();
+    });
+
+    it.each(['Polygon', 'MultiLineString', 'Point'])('does NOT show the hint for %s', (gt) => {
+      renderWithGeometry(gt);
+      expect(screen.queryByText(/Colors apply to polygon features/)).toBeNull();
+    });
+  });
 });

--- a/frontend/src/i18n/locales/de/builder.json
+++ b/frontend/src/i18n/locales/de/builder.json
@@ -524,6 +524,8 @@
     "manualBreaksInvalid": "Geben Sie mindestens einen Grenzwert in streng aufsteigender Reihenfolge ein.",
     "classes": "Klassen",
     "categoriesWarning": "{{count}} Kategorien -- erwägen Sie den abgestuften Modus für viele Werte.",
+    "categoriesTruncatedWarning": "{{count}} Kategorien – die ersten {{shown}} werden angezeigt; für viele Werte empfiehlt sich der abgestufte Modus.",
+    "mixedGeometryColorScope": "Farben gelten für Polygone. Linien und Punkte behalten ihre aktuelle Farbe.",
     "target": "Ziel",
     "targetColor": "Farbe",
     "targetRadius": "Radius",

--- a/frontend/src/i18n/locales/en/builder.json
+++ b/frontend/src/i18n/locales/en/builder.json
@@ -524,6 +524,8 @@
     "manualBreaksInvalid": "Enter at least one break value in strictly ascending order.",
     "classes": "Classes",
     "categoriesWarning": "{{count}} categories -- consider using graduated mode for many values.",
+    "categoriesTruncatedWarning": "{{count}} categories -- showing the first {{shown}}; consider using graduated mode for many values.",
+    "mixedGeometryColorScope": "Colors apply to polygon features. Lines and points keep their current color.",
     "target": "Target",
     "targetColor": "Color",
     "targetRadius": "Radius",

--- a/frontend/src/i18n/locales/es/builder.json
+++ b/frontend/src/i18n/locales/es/builder.json
@@ -524,6 +524,8 @@
     "manualBreaksInvalid": "Introduce al menos un valor de corte en orden estrictamente ascendente.",
     "classes": "Clases",
     "categoriesWarning": "{{count}} categorías -- considere usar el modo graduado para muchos valores.",
+    "categoriesTruncatedWarning": "{{count}} categorías: se muestran las primeras {{shown}}; considera el modo graduado para muchos valores.",
+    "mixedGeometryColorScope": "Los colores se aplican a los polígonos. Las líneas y los puntos mantienen su color actual.",
     "target": "Objetivo",
     "targetColor": "Color",
     "targetRadius": "Radio",

--- a/frontend/src/i18n/locales/fr/builder.json
+++ b/frontend/src/i18n/locales/fr/builder.json
@@ -524,6 +524,8 @@
     "manualBreaksInvalid": "Saisissez au moins une valeur de seuil dans un ordre strictement croissant.",
     "classes": "Classes",
     "categoriesWarning": "{{count}} catégories — envisagez le mode gradué pour de nombreuses valeurs.",
+    "categoriesTruncatedWarning": "{{count}} catégories : les {{shown}} premières sont affichées ; envisagez le mode gradué pour de nombreuses valeurs.",
+    "mixedGeometryColorScope": "Les couleurs s’appliquent aux polygones. Les lignes et les points conservent leur couleur actuelle.",
     "target": "Cible",
     "targetColor": "Couleur",
     "targetRadius": "Rayon",


### PR DESCRIPTION
Closes #960 and #952 (the stopgap it scopes itself to). One PR because both changes land in `DataDrivenStyleEditor` and would otherwise conflict on rebase.

## #960 — the count was a page size

The categorical editor called only `useColumnValues`, whose `limit` defaults to 100 and caps at 500, then rendered that length as the number of categories. On a column with 4,000 distinct values the warning read "100 categories" and the swatch list silently stopped at 100.

The re-scoped issue is right that nothing needed building: `GET /api/datasets/{id}/columns/{col}/stats/` has returned an exact, full-table, unsampled `distinct_count` since #315, it is typed on both sides, and `useColumnStats` was already imported here — just gated to graduated mode. So:

- the hook now runs for the categorical column too (one extra request per column selection, cached by the existing `staleTime`),
- the "consider graduated mode" advice triggers on the true count,
- when the rendered swatches are only a prefix, the copy says which prefix,
- when the page holds every category, the old wording stands.

Frontend only. No backend change, no migration, no OpenAPI or SDK regeneration. The anonymous-viewer question the issue records is untouched — both column endpoints still use `check_dataset_access`, and widening that is a Rule 1 decision, not a side effect of this.

## #952 — the stopgap, not the full fix

A ramp on a `GEOMETRY` / `GEOMETRYCOLLECTION` layer writes exactly one colour property, chosen by geometry. `classifyGeometry` returns `'other'` for both sentinels, `getColorProperty` falls through to `fill-color`, and `mixedLinePaint` / `mixedPointPaint` then run `filterPaintForLayerType` for `'line'` and `'circle'`, which drop that key. So the polygons classify, the lines and points keep their colours, and the legend shows the full classification as though it applied to every feature.

This ships the hint the issue scoped, in the same muted style as the section's other hints, gated on the same `classifyGeometry(...) === 'other'` test `getColorProperty` already makes. **No paint behaviour changes.** The full multi-property fix stays unscheduled — it has to return more than one property from `getColorProperty`, and all ten call sites assume exactly one, with the three clear paths being the awkward ones.

## Verification

```
cd frontend && npm run lint && npm run typecheck && npm run test:i18n && npm run test:coverage
# 366 files, 4298 tests pass

npx vitest run src/components/builder/__tests__/DataDrivenStyleEditor.test.tsx
# 34 tests (9 new)
```

New tests: the truncated case (page at the cap, `distinct_count` well above it), the exact case, the no-stats fallback, that the stats hook is called for the categorical column, and the mixed hint appearing for both generic sentinels and for neither Polygon, MultiLineString nor Point. Four new locale entries across en/es/fr/de.