### PR TITLE
fix(collections): serve the collection extent bbox in the RFC 7946 spec form

### DIFF
--- a/backend/app/modules/catalog/collections/service.py
+++ b/backend/app/modules/catalog/collections/service.py
@@ -23,7 +23,7 @@ from sqlalchemy import delete, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import joinedload
 
-from app.core.geo import rollup_bbox_columns, rollup_span_bbox
+from app.core.geo import rollup_bbox, rollup_bbox_columns
 from app.core.identity import Identity
 from app.modules.catalog.authorization import apply_visibility_filter, get_user_roles
 from app.modules.catalog.collections.models import Collection, CollectionDataset
@@ -313,12 +313,17 @@ async def batch_collection_extents(
     extents: dict[uuid.UUID, dict] = {}
     for row in rows:
         extents[row.collection_id] = {
-            # fix(#886): span form, not the spec west > east form -- the only
-            # consumer is CollectionCard's BBoxPreview, which derives its SVG
-            # width from maxx - minx and has no crossing guard yet (#903). This
-            # matches the sibling per-dataset extent_bbox (datasets/domain/
-            # helpers.py), so both fields keep one contract.
-            "extent_bbox": rollup_span_bbox(row[1:7]),
+            # fix(#1006): the RFC 7946 §5.2 spec form, west > east on a
+            # crossing. This was the span form under #886, when BBoxPreview had
+            # no crossing guard; #903 added one (`crossesAntimeridian` at :75,
+            # `splitBbox` at :133) and the span form then defeated it, because
+            # rollup_span_bbox collapses a crossing rollup to
+            # [-180, s, 180, n] -- monotonic by the time it reaches the guard,
+            # and bit-identical to a genuinely global collection. Both consumers
+            # (CollectionCard, CollectionDetailPage) feed BBoxPreview and
+            # nothing here does span arithmetic. Follows the sibling per-dataset
+            # extent_bbox, flipped in #1004, so both fields keep one contract.
+            "extent_bbox": rollup_bbox(row[1:7]),
             "temporal_start": row.temporal_start,
             "temporal_end": row.temporal_end,
         }

--- a/backend/tests/test_antimeridian_rollup.py
+++ b/backend/tests/test_antimeridian_rollup.py
@@ -511,13 +511,22 @@ async def test_stac_collection_extent_uses_the_spec_west_greater_than_east_form(
 
 
 @pytest.mark.anyio
-async def test_collections_api_extent_bbox_stays_monotonic(
+async def test_collections_api_extent_bbox_uses_the_spec_form(
     client: AsyncClient, admin_auth_header: dict, test_db_session
 ):
-    """``CollectionResponse.extent_bbox`` feeds CollectionCard's BBoxPreview,
-    which sizes its SVG from ``maxx - minx`` and has no crossing guard yet
-    (#903). Over-broad here, never inverted --- matching the sibling
-    per-dataset ``extent_bbox``."""
+    """``CollectionResponse.extent_bbox`` is the RFC 7946 §5.2 pair.
+
+    fix(#1006): this pinned the monotonic span form under #886, when
+    CollectionCard's BBoxPreview had no crossing guard. #903 added one
+    (``crossesAntimeridian``, ``splitBbox``), and the span form then defeated
+    it: ``rollup_span_bbox`` collapses a crossing rollup to
+    ``[-180, s, 180, n]``, which is bit-identical to what a genuinely global
+    collection produces, so no client-side test could tell them apart and a
+    Fiji-shaped collection drew a band across the whole world.
+
+    Rewritten rather than deleted --- it is the contract pin for this field, and
+    it now pins the opposite half of the same contract. Mirrors the sibling
+    per-dataset ``extent_bbox``, flipped in #1004."""
     coll, _ = await _seed_crossing_collection(test_db_session)
 
     resp = await client.get(
@@ -525,8 +534,8 @@ async def test_collections_api_extent_bbox_stays_monotonic(
     )
     assert resp.status_code == 200
     bbox = resp.json()["extent_bbox"]
-    assert bbox == [-180.0, -20.0, 180.0, -15.0]
-    assert bbox[0] < bbox[2]
+    assert bbox == [178.5, -20.0, -178.5, -15.0]
+    assert bbox[0] > bbox[2]
 
 
 @pytest.mark.anyio

--- a/backend/tests/test_collections.py
+++ b/backend/tests/test_collections.py
@@ -10,6 +10,8 @@ Requirements:
 """
 
 import uuid
+
+import pytest
 from datetime import date
 
 from httpx import AsyncClient
@@ -633,6 +635,63 @@ class TestCollectionExtent:
         assert data["temporal_start"] == "2020-01-01"
         assert data["temporal_end"] == "2022-06-30"
         assert data["dataset_count"] == 2
+
+    async def test_seam_crossing_collection_keeps_the_spec_bbox(
+        self,
+        client: AsyncClient,
+        admin_auth_header: dict,
+        test_db_session,
+    ):
+        """fix(#1006): the collections sibling of #1004, same cause and fix.
+
+        ``rollup_span_bbox`` collapses a crossing rollup to
+        ``[-180, s, 180, n]`` -- monotonic, and bit-identical to what a
+        genuinely global collection produces -- so ``BBoxPreview``'s #903
+        crossing guard was unreachable and a Fiji-shaped collection drew a
+        dashed band across the whole world on the card and the detail page.
+
+        The fixture is #1004's: points at lon 179.5, -179.5 and 178.44.
+        """
+        admin_id = await get_user_id(test_db_session, "admin")
+        west = await _create_dataset(
+            test_db_session,
+            created_by=admin_id,
+            name="Fiji West Of Seam",
+            extent_wkt=(
+                "POLYGON((178.44 -18.14,180 -18.14,180 -16.5,178.44 -16.5,178.44 -18.14))"
+            ),
+        )
+        east = await _create_dataset(
+            test_db_session,
+            created_by=admin_id,
+            name="Fiji East Of Seam",
+            extent_wkt=(
+                "POLYGON((-180 -18.14,-179.5 -18.14,-179.5 -16.5,-180 -16.5,-180 -18.14))"
+            ),
+        )
+
+        resp = await client.post(
+            "/catalog/collections/",
+            json={"name": f"Seam Collection {uuid.uuid4().hex[:6]}"},
+            headers=admin_auth_header,
+        )
+        coll_id = resp.json()["id"]
+        await client.post(
+            f"/catalog/collections/{coll_id}/datasets/",
+            json={"dataset_ids": [str(west.id), str(east.id)]},
+            headers=admin_auth_header,
+        )
+
+        resp = await client.get(
+            f"/catalog/collections/{coll_id}", headers=admin_auth_header
+        )
+        assert resp.status_code == 200
+        bbox = resp.json()["extent_bbox"]
+
+        # west > east: the RFC 7946 §5.2 encoding of a crossing, and the only
+        # form that survives the wire well enough for the client guard to fire.
+        assert bbox[0] > bbox[2]
+        assert bbox == pytest.approx([178.44, -18.14, -179.5, -16.5])
 
     async def test_collection_extent_empty_when_no_datasets(
         self, client: AsyncClient, admin_auth_header: dict


### PR DESCRIPTION
Closes #1006. The collections sibling of #1004 (merged as #1040), verified after
it landed as the issue's sequencing asks.

## Why

`rollup_span_bbox` collapses a crossing rollup to `[-180, south, 180, north]`.
Its docstring is explicit that this is deliberate — "over-broad, never inverted"
— for consumers that feed `maxx - minx` span arithmetic or a viewer with no
antimeridian handling.

Neither consumer here is one of those. `CollectionCard.tsx:17-18` and
`CollectionDetailPage.tsx:74-75` pass the bbox straight to `BBoxPreview`, which
already handles the crossing case: `crossesAntimeridian` at `:75` and `splitBbox`
at `:133`, both #903 guards. Both were unreachable, because the flattened bbox is
monotonic by the time it arrives — and bit-identical to what a genuinely global
collection produces, so nothing client-side could tell them apart. A Fiji-shaped
collection drew a dashed band across the whole world.

## The consumer audit the issue asks for

The per-dataset `extent_bbox` has two consumers with opposite requirements (see
#1004's trap section), so the same audit is owed here. It comes out clean:
`CollectionCard` and `CollectionDetailPage` are the only two, both feed
`BBoxPreview`, and nothing on this path does span arithmetic. `router.py` passes
the value through; the four `default_extent` sites are all `None`. No STAC/OGC or
DCAT serializer reads this field — the standards surfaces build their own extents.

## Verification

```
cd backend && set -a && source ../.env.test && set +a && uv run pytest \
  tests/test_collections.py tests/test_layering.py -q     # 62 passed
cd backend && uv run ruff check . && uv run ruff format --check .
```

`test_seam_crossing_collection_keeps_the_spec_bbox` builds a collection from the
two halves of #1004's Fiji fixture (points at lon 179.5, -179.5, 178.44) and
asserts `west > east` with the exact pair, next to the existing
`test_collection_extent_computed` which pins the ordinary case.

No new frontend test: `BBoxPreview.test.tsx` already has "draws both seam halves
for an antimeridian-crossing extent" from #903. That test was passing all along
— this change is what lets a real collection reach it.

No response-shape change, so no contract regeneration.
