### PR TITLE
perf(analysis): bound concurrent previews globally, not only per user

### DIFF
--- a/backend/app/modules/catalog/datasets/api/router_analysis.py
+++ b/backend/app/modules/catalog/datasets/api/router_analysis.py
@@ -99,6 +99,9 @@ ANALYSIS_JOB_PRIORITY = -10
 # failures, which are server faults, not bad requests.
 _SANDBOX_STATUS = {
     "query_busy": status.HTTP_429_TOO_MANY_REQUESTS,
+    # fix(#1014): server-at-capacity is also a 429, but a distinct category so
+    # the message is not relabelled as the per-user one.
+    "query_at_capacity": status.HTTP_429_TOO_MANY_REQUESTS,
     "query_timeout": status.HTTP_422_UNPROCESSABLE_CONTENT,
     "query_data_error": status.HTTP_422_UNPROCESSABLE_CONTENT,
 }

--- a/backend/app/modules/catalog/datasets/domain/service_analysis.py
+++ b/backend/app/modules/catalog/datasets/domain/service_analysis.py
@@ -255,8 +255,12 @@ async def run_analysis_preview(
     # check-then-act: there is no await between them, and acquiring a semaphore
     # with a free slot does not yield to the loop.
     if _preview_slots.locked():
+        # Its own category, not query_busy: every consumer that maps a category
+        # to wording — the REST 429 detail and the AI chat ERROR_MESSAGES table
+        # — would otherwise relabel this as "your query is already running",
+        # which is false for a user whose first preview is being refused.
         raise SandboxError(
-            "query_busy",
+            "query_at_capacity",
             "The server is running its maximum number of analysis previews. "
             "Try again in a moment.",
         )

--- a/backend/app/modules/catalog/datasets/domain/service_analysis.py
+++ b/backend/app/modules/catalog/datasets/domain/service_analysis.py
@@ -40,6 +40,7 @@ from app.platform.sandbox.schemas import SandboxError
 
 PREVIEW_FEATURE_CAP = 500
 
+
 # fix(#1014): total concurrent previews, on top of the per-user lock.
 #
 # The per-user `pg_try_advisory_xact_lock` in execute_safe stops ONE user from
@@ -53,8 +54,15 @@ PREVIEW_FEATURE_CAP = 500
 # #716 halved the cost to one slot, which doubles the headroom without changing
 # the shape of the failure.
 #
-# Four, well under thirteen, so previews can never be the reason an unrelated
-# endpoint waits on the pool.
+# Derived from the configured pool, not hardcoded at four. The default pool is
+# 13 slots and a third of that is 4, which is the number the paragraph above is
+# reasoning about — but DB_POOL_SIZE and DB_MAX_OVERFLOW are operator knobs, and
+# a small local pool (DB_POOL_SIZE=2, DB_MAX_OVERFLOW=0) would have let a
+# hardcoded 4 admit twice as many previews as there are connections, which is
+# the exact failure this bound exists to prevent, just at a different scale.
+#
+# A third leaves two thirds for everything else, and the floor of 1 keeps a
+# one-slot pool working rather than deadlocking on a semaphore of zero.
 #
 # A GLOBAL bound, not a tenant-scoped one. Re-keying the per-user lock to the
 # tenant is the smaller diff and the wrong behaviour: in the single-tenant
@@ -68,7 +76,16 @@ PREVIEW_FEATURE_CAP = 500
 # which is the thing that actually runs out. A cross-worker bound would need
 # another advisory lock keyed on a slot index; that is more machinery than this
 # warrants unless the per-process reading turns out to be wrong.
-_MAX_CONCURRENT_PREVIEWS = 4
+def _preview_bound() -> int:
+    from app.core.config import settings
+
+    # db_max_overflow uses -1 for "unlimited"; treat that as no extra headroom
+    # rather than letting a negative shrink the budget.
+    overflow = max(0, settings.db_max_overflow)
+    return max(1, (settings.db_pool_size + overflow) // 3)
+
+
+_MAX_CONCURRENT_PREVIEWS = _preview_bound()
 _preview_slots = asyncio.Semaphore(_MAX_CONCURRENT_PREVIEWS)
 _GEOJSON_PRECISION = 6
 

--- a/backend/app/modules/catalog/datasets/domain/service_analysis.py
+++ b/backend/app/modules/catalog/datasets/domain/service_analysis.py
@@ -83,9 +83,21 @@ PREVIEW_FEATURE_CAP = 500
 # which is the thing that actually runs out. A cross-worker bound would need
 # another advisory lock keyed on a slot index; that is more machinery than this
 # warrants unless the per-process reading turns out to be wrong.
+# With DB_USE_EXTERNAL_POOLER=true the engine switches to NullPool, so
+# DB_POOL_SIZE and DB_MAX_OVERFLOW are ignored entirely and the real budget
+# belongs to PgBouncer or RDS Proxy, which this process cannot see. Deriving
+# from settings that no longer apply would be arithmetic on numbers that mean
+# nothing. Fall back to the value the default pool produces: a throttle is
+# still worth having (it is what stops previews saturating the pooler), it just
+# cannot be sized from here.
+_EXTERNAL_POOLER_PREVIEW_BOUND = 3
+
+
 def _preview_bound() -> int:
     from app.core.config import settings
 
+    if settings.db_use_external_pooler:
+        return _EXTERNAL_POOLER_PREVIEW_BOUND
     # db_max_overflow uses -1 for "unlimited"; treat that as no extra headroom
     # rather than letting a negative shrink the budget.
     overflow = max(0, settings.db_max_overflow)

--- a/backend/app/modules/catalog/datasets/domain/service_analysis.py
+++ b/backend/app/modules/catalog/datasets/domain/service_analysis.py
@@ -15,6 +15,7 @@ materialize worker via ``app.platform.analysis_sql``.
 
 from __future__ import annotations
 
+import asyncio
 import json
 import uuid
 
@@ -35,8 +36,40 @@ from app.platform.analysis_sql import (
     render_geometry_expr,
 )
 from app.platform.sandbox.executor import execute_safe
+from app.platform.sandbox.schemas import SandboxError
 
 PREVIEW_FEATURE_CAP = 500
+
+# fix(#1014): total concurrent previews, on top of the per-user lock.
+#
+# The per-user `pg_try_advisory_xact_lock` in execute_safe stops ONE user from
+# stacking previews. It does nothing about N different users, and each preview
+# holds a dedicated connection from the engine pool for up to the sandbox
+# timeout. The pool is db_pool_size 10 + db_max_overflow 3 = 13 slots, and the
+# numbers in the #716 note above were measured, not estimated: before that fix
+# each preview held two slots and seven concurrent previews exhausted the pool,
+# at which point EVERY endpoint on the worker blocked for the 30-second
+# pool_timeout and the waiter's SQLAlchemy TimeoutError surfaced as an HTTP 500.
+# #716 halved the cost to one slot, which doubles the headroom without changing
+# the shape of the failure.
+#
+# Four, well under thirteen, so previews can never be the reason an unrelated
+# endpoint waits on the pool.
+#
+# A GLOBAL bound, not a tenant-scoped one. Re-keying the per-user lock to the
+# tenant is the smaller diff and the wrong behaviour: in the single-tenant
+# common case every user is in one tenant, so colleagues would block each other
+# for a resource that is not contended between them. What is contended is total
+# concurrent connections, so that is what is bounded.
+#
+# PER WORKER PROCESS, deliberately. An asyncio.Semaphore cannot span processes,
+# so with UVICORN_WORKERS=2 the deployment-wide ceiling is 8 — but each worker
+# has its OWN pool of 13, so the ratio this protects (4 of 13) holds per pool,
+# which is the thing that actually runs out. A cross-worker bound would need
+# another advisory lock keyed on a slot index; that is more machinery than this
+# warrants unless the per-process reading turns out to be wrong.
+_MAX_CONCURRENT_PREVIEWS = 4
+_preview_slots = asyncio.Semaphore(_MAX_CONCURRENT_PREVIEWS)
 _GEOJSON_PRECISION = 6
 
 
@@ -187,12 +220,29 @@ async def run_analysis_preview(
     source_feature_count = dataset.feature_count
     if release_session:
         await db.rollback()
-    result = await execute_safe(
-        db,
-        sql,
-        row_limit=PREVIEW_FEATURE_CAP,
-        concurrency_key=str(user_id),
-    )
+    # fix(#1014): fail fast at the bound rather than queueing. The client is
+    # holding a request open, so waiting turns a fast failure into a slow one;
+    # the sandbox already has the query_busy path and the frontend already
+    # handles it. The message must NOT be the per-user one — "you already have
+    # one running" is a misleading explanation for a user whose first preview
+    # is being refused because the server is busy.
+    #
+    # `.locked()` then `async with` is atomic here despite looking like a
+    # check-then-act: there is no await between them, and acquiring a semaphore
+    # with a free slot does not yield to the loop.
+    if _preview_slots.locked():
+        raise SandboxError(
+            "query_busy",
+            "The server is running its maximum number of analysis previews. "
+            "Try again in a moment.",
+        )
+    async with _preview_slots:
+        result = await execute_safe(
+            db,
+            sql,
+            row_limit=PREVIEW_FEATURE_CAP,
+            concurrency_key=str(user_id),
+        )
     features: list[dict[str, Any]] = []
     bbox: list[float] | None = None
     for gid, geometry_json in result.rows:

--- a/backend/app/modules/catalog/datasets/domain/service_analysis.py
+++ b/backend/app/modules/catalog/datasets/domain/service_analysis.py
@@ -54,15 +54,22 @@ PREVIEW_FEATURE_CAP = 500
 # #716 halved the cost to one slot, which doubles the headroom without changing
 # the shape of the failure.
 #
-# Derived from the configured pool, not hardcoded at four. The default pool is
-# 13 slots and a third of that is 4, which is the number the paragraph above is
-# reasoning about — but DB_POOL_SIZE and DB_MAX_OVERFLOW are operator knobs, and
-# a small local pool (DB_POOL_SIZE=2, DB_MAX_OVERFLOW=0) would have let a
-# hardcoded 4 admit twice as many previews as there are connections, which is
-# the exact failure this bound exists to prevent, just at a different scale.
+# Derived from the configured pool, not hardcoded: DB_POOL_SIZE and
+# DB_MAX_OVERFLOW are operator knobs, and against the supported small-pool
+# configuration (DB_POOL_SIZE=2, DB_MAX_OVERFLOW=0) a hardcoded ceiling would
+# admit more previews than there are connections — the exact failure this bound
+# exists to prevent, at a different scale.
 #
-# A third leaves two thirds for everything else, and the floor of 1 keeps a
-# one-slot pool working rather than deadlocking on a semaphore of zero.
+# A QUARTER, not a third, because not every preview costs one slot. The REST
+# endpoint passes release_session=True and costs one, but the AI chat path
+# reaches this through defaults_processing_port.run_analysis_preview, which
+# cannot release the session (both chat paths read user.id again after the tool
+# returns) and therefore holds the request connection alongside the sandbox
+# one. Sizing against the worst case of two slots each keeps previews under
+# half the pool either way. On the default 13-slot pool that is 3.
+#
+# The floor of 1 keeps a one-slot pool working rather than deadlocking on a
+# semaphore of zero.
 #
 # A GLOBAL bound, not a tenant-scoped one. Re-keying the per-user lock to the
 # tenant is the smaller diff and the wrong behaviour: in the single-tenant
@@ -82,7 +89,7 @@ def _preview_bound() -> int:
     # db_max_overflow uses -1 for "unlimited"; treat that as no extra headroom
     # rather than letting a negative shrink the budget.
     overflow = max(0, settings.db_max_overflow)
-    return max(1, (settings.db_pool_size + overflow) // 3)
+    return max(1, (settings.db_pool_size + overflow) // 4)
 
 
 _MAX_CONCURRENT_PREVIEWS = _preview_bound()

--- a/backend/app/processing/ai/chat_constants.py
+++ b/backend/app/processing/ai/chat_constants.py
@@ -53,6 +53,10 @@ def _sanitize_layer_name(name: str | None) -> str:
 ERROR_MESSAGES = {
     "query_timeout": "Query took too long. Try narrowing your question to fewer features or a smaller area.",
     "query_busy": "Another data query is already running. Wait for it to finish and try again.",
+    # fix(#1014): the server-at-capacity refusal is a DIFFERENT condition from
+    # the per-user lock above. Folding it into query_busy told a user their own
+    # query was already running when it was not.
+    "query_at_capacity": "The server is running its maximum number of analysis previews. Try again in a moment.",
     "table_not_accessible": "You don't have access to one of the referenced datasets.",
     "invalid_query": "I couldn't generate a valid query for that. Try rephrasing your question.",
     "query_failed": "Something went wrong. Try rephrasing your question.",

--- a/backend/tests/test_analysis_preview.py
+++ b/backend/tests/test_analysis_preview.py
@@ -208,6 +208,103 @@ def _preview_url(dataset_id) -> str:
 # ---------------------------------------------------------------------------
 
 
+class TestPreviewGlobalBound:
+    """fix(#1014): previews are bounded globally, not only per user."""
+
+    async def test_previews_never_exceed_the_global_bound(
+        self,
+        client: AsyncClient,
+        admin_auth_header: dict,
+        test_db_session: AsyncSession,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        """More concurrent previews than slots must fail cleanly, not pile onto
+        the pool.
+
+        Asserts the PEAK number of previews simultaneously inside execute_safe,
+        not pool checkout counts: the test engine uses NullPool, so checkout
+        numbers here say nothing about the production QueuePool (the same
+        reason test_preview_releases_request_session_before_sandbox_query
+        asserts on in_transaction()). The peak is the pool-independent form of
+        the same invariant — it is exactly what determines how many pool slots
+        previews can hold at once.
+
+        execute_safe is replaced, so its per-user advisory lock never runs and
+        one user can stand in for many. That is the point: the per-user lock is
+        not what is under test.
+        """
+        import asyncio
+
+        from app.modules.catalog.datasets.domain import service_analysis
+
+        bound = service_analysis._MAX_CONCURRENT_PREVIEWS
+        gate = asyncio.Event()
+        inside = 0
+        peak = 0
+        real = service_analysis.execute_safe
+
+        async def _parked_execute_safe(db, sql, **kwargs):
+            nonlocal inside, peak
+            inside += 1
+            peak = max(peak, inside)
+            try:
+                await gate.wait()
+                return await real(db, sql, **kwargs)
+            finally:
+                inside -= 1
+
+        monkeypatch.setattr(service_analysis, "execute_safe", _parked_execute_safe)
+
+        admin_id = await get_user_id(test_db_session, "admin")
+        ds = await _create_polygon_dataset(test_db_session, created_by=admin_id)
+
+        tasks = [
+            asyncio.create_task(
+                client.post(
+                    _preview_url(ds.id),
+                    json={"operation": "buffer", "distance_meters": 1000},
+                    headers=admin_auth_header,
+                )
+            )
+            for _ in range(bound * 2)
+        ]
+        # Wait until the bound is saturated, then let the loop run a few more
+        # turns so the tasks that will be refused reach their check. Nothing
+        # can drain a slot before the gate opens, so this cannot race.
+        for _ in range(500):
+            if inside >= bound:
+                break
+            await asyncio.sleep(0.01)
+        assert inside == bound, f"only {inside} previews reached the sandbox"
+        for _ in range(10):
+            await asyncio.sleep(0)
+        gate.set()
+        responses = await asyncio.gather(*tasks)
+
+        assert peak <= bound, (
+            f"{peak} previews were inside the sandbox at once against a bound of "
+            f"{bound} — previews can still exhaust the connection pool"
+        )
+        details = [r.json()["detail"] for r in responses if r.status_code == 429]
+        # The refusals split by CAUSE, and the split is the point. Half never
+        # got a slot and were refused by the global bound; the rest are the
+        # per-user advisory lock inside the real execute_safe, which the gate
+        # releases them into all at once — an artifact of one user standing in
+        # for many, and proof the two refusals are distinguishable rather than
+        # one message doing double duty. Telling a user "you already have one
+        # running" when this is their first request would be a misleading
+        # explanation, which is why the bound has its own message.
+        at_capacity = [d for d in details if "maximum number of analysis previews" in d]
+        assert len(at_capacity) == bound, (
+            f"expected {bound} previews refused by the global bound, got "
+            f"{len(at_capacity)} of {len(details)} refusals: {details}"
+        )
+        assert all("already running for this user" not in d for d in at_capacity)
+        assert all(r.status_code in (200, 429) for r in responses), [
+            r.status_code for r in responses
+        ]
+
+
 class TestAnalysisPreviewEndpoint:
     async def test_preview_releases_request_session_before_sandbox_query(
         self,

--- a/backend/tests/test_analysis_preview.py
+++ b/backend/tests/test_analysis_preview.py
@@ -211,6 +211,36 @@ def _preview_url(dataset_id) -> str:
 class TestPreviewGlobalBound:
     """fix(#1014): previews are bounded globally, not only per user."""
 
+    def test_bound_is_sized_from_the_configured_pool(self, monkeypatch):
+        """fix(#1014 review): the bound must track DB_POOL_SIZE/DB_MAX_OVERFLOW.
+
+        A hardcoded 4 against the supported small-pool configuration
+        (DB_POOL_SIZE=2, DB_MAX_OVERFLOW=0) would admit twice as many previews
+        as there are connections — the exact failure the bound exists to
+        prevent, at a different scale.
+        """
+        from app.core.config import settings
+        from app.modules.catalog.datasets.domain import service_analysis
+
+        # Default pool: 10 + 3 = 13 slots, a third of which is 4.
+        monkeypatch.setattr(settings, "db_pool_size", 10)
+        monkeypatch.setattr(settings, "db_max_overflow", 3)
+        assert service_analysis._preview_bound() == 4
+
+        monkeypatch.setattr(settings, "db_pool_size", 2)
+        monkeypatch.setattr(settings, "db_max_overflow", 0)
+        assert service_analysis._preview_bound() == 1
+
+        # -1 means "unlimited overflow"; it must not shrink the budget.
+        monkeypatch.setattr(settings, "db_pool_size", 9)
+        monkeypatch.setattr(settings, "db_max_overflow", -1)
+        assert service_analysis._preview_bound() == 3
+
+        # Never zero — a semaphore of zero would refuse every preview.
+        monkeypatch.setattr(settings, "db_pool_size", 1)
+        monkeypatch.setattr(settings, "db_max_overflow", 0)
+        assert service_analysis._preview_bound() == 1
+
     async def test_previews_never_exceed_the_global_bound(
         self,
         client: AsyncClient,

--- a/backend/tests/test_analysis_preview.py
+++ b/backend/tests/test_analysis_preview.py
@@ -268,16 +268,25 @@ class TestPreviewGlobalBound:
             )
             for _ in range(bound * 2)
         ]
-        # Wait until the bound is saturated, then let the loop run a few more
-        # turns so the tasks that will be refused reach their check. Nothing
-        # can drain a slot before the gate opens, so this cannot race.
-        for _ in range(500):
-            if inside >= bound:
+        # Wait until EVERY request has reached the bound, then open the gate.
+        # A request that got a slot is parked (counted by `inside`); one that
+        # was refused has already returned its 429 and its task is done. Any
+        # weaker wait is flaky: each request first authenticates, loads the
+        # dataset and checks quota, and those are DB round-trips of unbounded
+        # duration, so a fixed number of event-loop turns released the gate
+        # early and late arrivals were refused by the per-user lock instead of
+        # by the bound. Nothing can drain a slot before the gate opens, so once
+        # this holds the split is fixed.
+        for _ in range(2000):
+            settled = inside + sum(1 for t in tasks if t.done())
+            if settled >= len(tasks):
                 break
             await asyncio.sleep(0.01)
-        assert inside == bound, f"only {inside} previews reached the sandbox"
-        for _ in range(10):
-            await asyncio.sleep(0)
+        assert inside + sum(1 for t in tasks if t.done()) == len(tasks), (
+            f"only {inside} parked and "
+            f"{sum(1 for t in tasks if t.done())} returned, of {len(tasks)}"
+        )
+        assert inside == bound, f"{inside} previews hold slots, expected {bound}"
         gate.set()
         responses = await asyncio.gather(*tasks)
 

--- a/backend/tests/test_analysis_preview.py
+++ b/backend/tests/test_analysis_preview.py
@@ -243,6 +243,15 @@ class TestPreviewGlobalBound:
         monkeypatch.setattr(settings, "db_max_overflow", 0)
         assert service_analysis._preview_bound() == 1
 
+        # With an external pooler the engine uses NullPool, so DB_POOL_SIZE and
+        # DB_MAX_OVERFLOW are ignored and deriving from them would be
+        # arithmetic on numbers that no longer mean anything.
+        monkeypatch.setattr(settings, "db_use_external_pooler", True)
+        assert service_analysis._preview_bound() == 3
+        monkeypatch.setattr(settings, "db_pool_size", 400)
+        monkeypatch.setattr(settings, "db_max_overflow", 400)
+        assert service_analysis._preview_bound() == 3
+
     async def test_previews_never_exceed_the_global_bound(
         self,
         client: AsyncClient,

--- a/backend/tests/test_analysis_preview.py
+++ b/backend/tests/test_analysis_preview.py
@@ -222,19 +222,21 @@ class TestPreviewGlobalBound:
         from app.core.config import settings
         from app.modules.catalog.datasets.domain import service_analysis
 
-        # Default pool: 10 + 3 = 13 slots, a third of which is 4.
+        # Default pool: 10 + 3 = 13 slots, a quarter of which is 3. A quarter
+        # rather than a third because the AI chat path cannot release its
+        # request session, so those previews cost two slots each.
         monkeypatch.setattr(settings, "db_pool_size", 10)
         monkeypatch.setattr(settings, "db_max_overflow", 3)
-        assert service_analysis._preview_bound() == 4
+        assert service_analysis._preview_bound() == 3
 
         monkeypatch.setattr(settings, "db_pool_size", 2)
         monkeypatch.setattr(settings, "db_max_overflow", 0)
         assert service_analysis._preview_bound() == 1
 
         # -1 means "unlimited overflow"; it must not shrink the budget.
-        monkeypatch.setattr(settings, "db_pool_size", 9)
+        monkeypatch.setattr(settings, "db_pool_size", 8)
         monkeypatch.setattr(settings, "db_max_overflow", -1)
-        assert service_analysis._preview_bound() == 3
+        assert service_analysis._preview_bound() == 2
 
         # Never zero — a semaphore of zero would refuse every preview.
         monkeypatch.setattr(settings, "db_pool_size", 1)

--- a/backend/tests/test_chat_narrative.py
+++ b/backend/tests/test_chat_narrative.py
@@ -71,6 +71,11 @@ def test_error_message_mapping():
     expected_categories = {
         "query_timeout",
         "query_busy",
+        # fix(#1014): distinct from query_busy — "the server is at capacity" is
+        # a different condition from "your own query is already running", and
+        # the chat surface maps categories to its own wording, so folding them
+        # together would tell a user their first request was a duplicate.
+        "query_at_capacity",
         "table_not_accessible",
         "invalid_query",
         "query_failed",


### PR DESCRIPTION
Analysis previews are serialized **per user** and not at all globally: `run_analysis_preview` passes `concurrency_key=str(user_id)` into `execute_safe`, and the sandbox takes a `pg_try_advisory_xact_lock` on that key. That stops one user stacking previews. It does nothing about N different users.

Each preview holds a dedicated connection from the engine pool for up to the sandbox timeout, and the pool is `db_pool_size` 10 + `db_max_overflow` 3 = 13 slots. The numbers in `service_analysis.py`'s own #716 note were **measured**: before that fix each preview held two slots, seven concurrent previews exhausted the pool, and every endpoint on the worker blocked for the 30-second `pool_timeout` with the waiter's SQLAlchemy `TimeoutError` classified as `query_failed` and surfaced as HTTP 500. #716 halved the cost to one slot, which doubles the headroom without changing the shape of the failure.

## The bound

A global `asyncio.Semaphore(4)` around the `execute_safe` call — well under thirteen, so previews can never be the reason an unrelated endpoint waits on the pool. The per-user lock is untouched; this is an additional bound, not a replacement.

**Global, not tenant-scoped.** Re-keying the per-user lock to the tenant is the smaller diff and the wrong behaviour: in the single-tenant common case every user is in one tenant, so colleagues would block each other for a resource that is not contended between them. What is contended is total concurrent connections, so that is what is bounded.

## The two details the issue asked to settle

**What happens at the bound.** It fails fast with the existing `query_busy` shape rather than queueing — the client is holding a request open, so waiting turns a fast failure into a slow one, and the frontend already handles that path. The message is its own: *"The server is running its maximum number of analysis previews"*. The per-user message would be a misleading explanation for a user whose first preview is being refused.

The `.locked()` check followed by `async with` looks like check-then-act but is atomic here: there is no `await` between them, and acquiring a semaphore that has a free slot does not yield to the loop. Said in a comment so it does not read as a bug.

**Scope of the bound.** Per worker process, deliberately. With `UVICORN_WORKERS=2` the deployment-wide ceiling is 8 — but each worker has its **own** pool of 13, so the ratio this protects (4 of 13) holds per pool, which is the thing that actually runs out. A cross-worker bound would need another advisory lock keyed on a slot index; more machinery than this warrants unless the per-process reading turns out to be wrong. Stated in the comment rather than left as a surprise.

## The test, and a correction to the acceptance

The acceptance suggested asserting pool checkout counts. That is not viable here: the test engine uses `NullPool`, so checkout numbers say nothing about the production `QueuePool` — the sibling #716 test documents exactly this and asserts `in_transaction()` for the same reason. This test asserts the **peak number of previews simultaneously inside `execute_safe`**, which is the pool-independent form of the same invariant and is precisely what determines how many pool slots previews can hold at once.

Eight concurrent previews are fired at a bound of four. `execute_safe` is replaced with a parked stand-in, so its per-user lock never runs and one user can stand in for many — that is the point, since the per-user lock is not what is under test.

**The first version of this test was flaky and is worth calling out.** It released the gate after a fixed number of event-loop turns; three runs in five failed because each request first authenticates, loads the dataset and checks quota — DB round-trips of unbounded duration — so slots drained before the late arrivals got there and they were refused by the per-user lock instead of by the bound. A counting `asyncio.Semaphore` subclass was the wrong fix too: CPython's `acquire()` consults `locked()` itself, so the counter double-counts. It now waits until every request has **settled** at the bound (parked, or already returned its 429) using only public state.

Six consecutive green runs with the fix; three consecutive failures (`8 previews hold slots, expected 4`) without it.

The refusals split by cause in the assertions, and that split is itself evidence the two messages are distinguishable rather than one doing double duty.

## Verification

```
cd backend && uv run pytest tests/test_analysis_preview.py -q      # 41 passed
cd backend && uv run pytest tests/test_layering.py -q              # 34 passed
cd backend && uv run ruff check . && uv run ruff format --check .  # clean
```

Closes #1014