### PR TITLE
ops(backup): warn at startup when offsite upload is disabled

### DIFF
--- a/scripts/backup-entrypoint.sh
+++ b/scripts/backup-entrypoint.sh
@@ -412,6 +412,24 @@ log "Schedule: ${CRON_EXPR}"
 log "Retention: ${BACKUP_RETENTION_DAILY} daily, ${BACKUP_RETENTION_WEEKLY} weekly"
 log "S3 upload: ${BACKUP_S3_ENABLED}"
 
+# fix(#798): BACKUP_S3_ENABLED defaults to false, and "S3 upload: false" reads
+# as configuration output rather than as the exposure it describes. The
+# deployment that most needs the warning is exactly the one that never
+# configured anything, so say plainly what the default means.
+#
+# Startup only, not per cycle: a nightly warning in the logs of a deliberately
+# local-only install is noise that trains operators to ignore the log. It costs
+# nothing when offsite upload is on, because it does not print then.
+if [ "$BACKUP_S3_ENABLED" != "true" ]; then
+    log "WARNING: offsite backup upload is DISABLED (BACKUP_S3_ENABLED is not 'true')."
+    log "WARNING:   Backups are written to the same host, and usually the same physical"
+    log "WARNING:   disk, as the database. Losing that disk loses the data AND every"
+    log "WARNING:   backup of it in one event."
+    log "WARNING:   Enable the offsite copy (RUNBOOK.md, section 1, \"Offsite (S3) upload\")"
+    log "WARNING:   or point the backup volume at different storage before relying on"
+    log "WARNING:   this for disaster recovery."
+fi
+
 # Run an initial backup on startup
 run_backup || log "ERROR: Initial backup failed"
 


### PR DESCRIPTION
Re-scoped by the issue on 2026-07-31: both remedies the original body asked for already shipped. `upload_to_s3()` exists and refuses loudly when `BACKUP_S3_ENABLED=true` is set without a bucket or credentials, and `RUNBOOK.md` § 1 documents the offsite upload and opens with the single-disk warning. What was left is one thing.

## The gap

`BACKUP_S3_ENABLED` defaults to `false`, and on startup the service logs `S3 upload: false` — a plain info line among the schedule and retention lines. It reads as configuration output, not as the exposure it describes. An operator who never opened the RUNBOOK sees nothing that reads as a warning, and the deployment that most needs the warning is exactly the one that never configured anything.

The startup block now says plainly what the disabled default means: backups are being written to the same host, and usually the same physical disk, as the database, so one disk loss takes the data and every backup of it together. It points at `RUNBOOK.md` § 1 "Offsite (S3) upload" for turning the offsite copy on.

**Startup only, not per cycle.** A nightly warning in the logs of a deliberately local-only install is noise that trains operators to ignore the log. It costs nothing when offsite upload is enabled, because it does not print then.

## Verification

```
bash -n scripts/backup-entrypoint.sh
```

Then a manual run of the startup path against the test Postgres, backgrounded and stopped once the initial backup began (by which point the startup block has flushed):

- `BACKUP_S3_ENABLED=false` — the warning block prints ahead of the first backup.
- `BACKUP_S3_ENABLED=true` — zero `WARNING` lines.

One caveat on how that was run, since it matters: `BACKUP_DIR` is hardcoded to `/backups` on this base, which is not writable on the host, so the manual run used a copy of the script with `${BACKUP_DIR:-/backups}` applied. Only the backup directory differed; the startup block under test is byte-identical.

## The automated test, and why it is not in this PR

That same hardcoded `BACKUP_DIR` is why there is no assertion here. The startup path is reached only by the first-run entry point, not by the `--run-backup` cron re-entry, and it never exits on its own (it ends in cron or a sleep loop), so exercising it means running the script with its backup directory redirected. The `${BACKUP_DIR:-/backups}` default that makes this possible is introduced by **#995** (PR #1027, in review).

The leg is written and waiting: it backgrounds the entrypoint, stops it once the initial backup begins, and asserts the warning fires with `BACKUP_S3_ENABLED=false` — naming the single-disk exposure and the RUNBOOK — and stays silent with `=true`. It lands as a follow-up commit here once #1027 is on main, or as a small follow-up PR if this merges first. Flagging it rather than quietly shipping the change untested.

The issue's own checklist names no test surface for this item. Its second box (confirm the demo VM sets `BACKUP_S3_ENABLED=true`) is explicitly deployment configuration, not repo work, and is untouched here.

Closes #798