### PR TITLE
test(sandbox): make the EXISTS rejection assertions independent of structlog

### DIFF
--- a/backend/tests/test_sec025_sandbox_allowlist.py
+++ b/backend/tests/test_sec025_sandbox_allowlist.py
@@ -27,21 +27,29 @@ from app.platform.sandbox.validator import validate_sql
 def _recording_validator_logger():
     """Collect the validator's structured rejection events, immune to caching.
 
-    fix(#1024): `structlog.testing.capture_logs()` cannot see these events.
-    `app/core/logging_config.py` configures structlog with
-    `cache_logger_on_first_use=True`, and `validator.py` binds its logger at
-    module import, so the first call that logs freezes the processor chain onto
-    that logger. Every later `capture_logs()` swaps the GLOBAL chain, which the
-    frozen logger no longer consults, and yields `[]` — the rejection still
-    happens, but the assertion reading the log sees nothing.
+    fix(#1024): `structlog.testing.capture_logs()` observes the GLOBAL
+    structlog configuration, so what it sees depends on what else ran earlier
+    in the same xdist worker rather than on the code under test. Under `-n 4`
+    it started yielding `[]` here while the rejection itself still happened,
+    which turned main red. The same file passes run alone, and two failing
+    runs disagreed on how many of the three broke.
 
-    That makes the failure purely a function of xdist worker assignment: these
-    tests passed when they landed and started failing once another test that
-    exercises `validate_sql` was scheduled ahead of them in the same worker.
+    The exact trigger was NOT pinned down, and this docstring deliberately
+    does not claim it was. Two people failed to reproduce it in a single
+    process, including forcing `setup_logging()` ahead of a warmed validator
+    logger and raising the stdlib root level. The leading candidate is
+    `cache_logger_on_first_use=True` in `app/core/logging_config.py` combined
+    with `validator.py` binding its logger at import, which matches the
+    symptom documented at test_tile_signing.py:648-656 — but it did not
+    demonstrate on structlog 25.5.0 even when that order was forced. Treat it
+    as unconfirmed if you are here debugging something similar.
 
-    Replacing the module global is caching-immune, because the call sites
-    resolve `logger` from module globals at call time. Same approach and same
-    reasoning as the tile_access assertion in test_tile_signing.py.
+    What IS established is the class of cause: an assertion about validator
+    behaviour should not read through global logging state that any other test
+    in the worker can mutate. Swapping the module global removes that
+    dependency outright, because the call sites resolve `logger` from module
+    globals at call time. That is why this is the right fix whether or not the
+    caching story turns out to be the trigger.
     """
     events: list[dict] = []
 
@@ -49,7 +57,10 @@ def _recording_validator_logger():
         def _record(self, event=None, **kwargs):
             events.append({"event": event, **kwargs})
 
-        debug = info = warning = error = critical = _record
+        # `exception` included deliberately: without it __getattr__ below would
+        # return a silent no-op, and an assertion would fail with an empty list
+        # — the exact confusing symptom this helper exists to remove.
+        debug = info = warning = error = critical = exception = _record
 
         def __getattr__(self, _name):
             # bind() and friends: no-op that supports chaining.

--- a/backend/tests/test_sec025_sandbox_allowlist.py
+++ b/backend/tests/test_sec025_sandbox_allowlist.py
@@ -14,11 +14,56 @@ RED → GREEN history:
 
 from __future__ import annotations
 
-import pytest
-from structlog.testing import capture_logs
+import contextlib
 
+import pytest
+
+from app.platform.sandbox import validator as _validator
 from app.platform.sandbox.schemas import SandboxError
 from app.platform.sandbox.validator import validate_sql
+
+
+@contextlib.contextmanager
+def _recording_validator_logger():
+    """Collect the validator's structured rejection events, immune to caching.
+
+    fix(#1024): `structlog.testing.capture_logs()` cannot see these events.
+    `app/core/logging_config.py` configures structlog with
+    `cache_logger_on_first_use=True`, and `validator.py` binds its logger at
+    module import, so the first call that logs freezes the processor chain onto
+    that logger. Every later `capture_logs()` swaps the GLOBAL chain, which the
+    frozen logger no longer consults, and yields `[]` — the rejection still
+    happens, but the assertion reading the log sees nothing.
+
+    That makes the failure purely a function of xdist worker assignment: these
+    tests passed when they landed and started failing once another test that
+    exercises `validate_sql` was scheduled ahead of them in the same worker.
+
+    Replacing the module global is caching-immune, because the call sites
+    resolve `logger` from module globals at call time. Same approach and same
+    reasoning as the tile_access assertion in test_tile_signing.py.
+    """
+    events: list[dict] = []
+
+    class _Recorder:
+        def _record(self, event=None, **kwargs):
+            events.append({"event": event, **kwargs})
+
+        debug = info = warning = error = critical = _record
+
+        def __getattr__(self, _name):
+            # bind() and friends: no-op that supports chaining.
+            def _noop(*args, **kwargs):
+                return self
+
+            return _noop
+
+    original = _validator.logger
+    _validator.logger = _Recorder()
+    try:
+        yield events
+    finally:
+        _validator.logger = original
 
 
 # ---------------------------------------------------------------------------
@@ -50,14 +95,14 @@ def _assert_rejects_function(sql: str, expected_function: str) -> None:
     function", which is exactly the confusion #538/#1017 are about. Reading the
     structured log's `function` field pins the reason.
     """
-    with capture_logs() as logs:
+    with _recording_validator_logger() as logs:
         with pytest.raises(SandboxError) as exc_info:
             validate_sql(sql)
     assert exc_info.value.category == "invalid_query"
     rejected = [
         entry.get("function")
         for entry in logs
-        if entry.get("event", "").startswith("sandbox.")
+        if str(entry.get("event") or "").startswith("sandbox.")
         and entry.get("function") is not None
     ]
     assert rejected == [expected_function], (


### PR DESCRIPTION
## What

Main is red. The push run at `6a94ef794e` failed two of the three EXISTS negative controls in `test_sec025_sandbox_allowlist.py`, and the next PR to update-branch onto it failed all three. This makes those three assertions independent of global logging state.

## The sandbox is not affected

`validate_sql` still rejects every one of these inputs, naming the expected function. Verified directly against `origin/main`:

```
sandbox.blocked_function          function=pg_sleep
sandbox.unlisted_function         function=current_version
sandbox.unlisted_postgis_function function=st_makeenvelope
```

All three raise `SandboxError`. That is also why the `pytest.raises` half of each assertion passed in the failing runs — what failed was the follow-up assertion reading *why* it was refused, which came back empty. `find_all(exp.Func)` was separately confirmed to yield both the `Exists` node and the `Anonymous` `pg_sleep`, so #1024's claim that the walk reaches into the subquery holds.

## Cause

The three negative controls landed with #1024 and pin the refusal reason by reading the structured log's `function` field, because `_assert_rejects` alone cannot distinguish "the function inside the subquery was caught" from "the enclosing EXISTS predicate was itself refused". That distinction is the whole point of #1017.

They read it via `structlog.testing.capture_logs()`, which observes the **global** structlog configuration. Whether it sees the validator's events therefore depends on what else ran earlier in the same xdist worker, not on the code under test. The file passes when run alone (106 passed) and fails under `-n 4`, and the two failing runs disagreed on how many of the three broke — two on main, three on the PR — which is the signature of worker assignment rather than a code change. Neither `validator.py` nor this test file has changed since #1024.

**The exact trigger is not pinned down, and this PR does not claim otherwise.** Two people independently failed to reproduce it in a single process. Attempts that all still captured the entry: `test_sandbox.py` then this file in one process; `test_phase_273_log_redaction.py` (the only test calling `setup_logging`) then this file; a direct probe running `capture_logs` fresh, then after `setup_logging()`, then after warming the validator's logger post-configure; and the same with the stdlib root level raised to CRITICAL. The leading candidate remains `cache_logger_on_first_use=True` combined with `validator.py` binding its logger at import, which matches the symptom documented at `test_tile_signing.py:648-656`, but it did not demonstrate on structlog 25.5.0 even with that order forced.

What is established is the symptom and the class of cause, not the mechanism. The docstring says so explicitly, so the next person debugging this does not re-walk a path already walked twice.

## Fix

Swap the validator's module-level `logger` for a recorder for the duration of the assertion. The call sites resolve `logger` from module globals at call time, so this cannot be defeated by structlog configuration, by `cache_logger_on_first_use`, or by any earlier test leaving global logging state behind. It restores the original in a `finally`.

This is the same approach, for the same reason, as the `tile_access` assertion in `test_tile_signing.py`.

The assertion still reads the log rather than being weakened to a plain "did it raise". `SandboxError`'s message is byte-identical for a blocked function and for an `exists` refusal ("Query uses a disallowed function"), so the log is the only place the function name appears. Weakening it would have kept the refusal claim and silently dropped the reason claim.

This is correct on its own merits regardless of the trigger: an assertion about validator behaviour should not read through global logging state that any other test in the worker can mutate.

## Verification

```
cd backend
uv run pytest tests/test_sec025_sandbox_allowlist.py    # 106 passed
uv run ruff check tests/test_sec025_sandbox_allowlist.py
uv run ruff format --check tests/test_sec025_sandbox_allowlist.py
```

RED check, run independently by two people with matching results: delete the `exp.Exists` skip from `validator.py` and the class goes **6 failed, 1 passed**, identical to the RED check taken when these controls first landed under `capture_logs`. All three negative controls still fail on a skip-removal regression, which is the entire reason they exist.

CI is the reproduction, having failed twice, so the CI result on this branch is the verdict.

## Scope

Test-only. No change to `validator.py` or any application code.