### PR TITLE
test(notifications): make the secret-leak log assertions able to fail

### DIFF
--- a/backend/tests/_logging_state.py
+++ b/backend/tests/_logging_state.py
@@ -1,0 +1,65 @@
+"""Save and restore everything ``setup_logging()`` mutates.
+
+fix(#1064 codex r2): ``setup_logging()`` does not only touch the root logger.
+Reading ``app/core/logging_config.py:103-112`` line by line, it clears root's
+handlers, then clears handlers and rewrites ``propagate`` on ``uvicorn``,
+``uvicorn.error`` and ``uvicorn.access``. A teardown that restores only root
+leaves those three changed — measured, a caller's ``uvicorn.access`` goes in
+with ``propagate=True`` and comes back out with ``propagate=False``.
+
+Two earlier rounds of this same mistake are why the list is derived from the
+source rather than from memory. The first restored root but not the structlog
+processor chain, which silently dropped ``_redact_sensitive_fields``. The
+second restored the chain but not these three loggers. The rule: to undo a
+function, read what it actually mutates and restore that list — not what its
+name suggests, and not the one thing that broke last time.
+
+Restoring what was there, rather than resetting to a library default, is the
+point. A reset still changes state the caller established, so it trades one
+order-dependence for another and can strip app behaviour a later test relies
+on. Repairing a leak that was already there when the test arrived is a
+different job, and belongs to the conftest guard in #1066.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import logging
+from collections.abc import Iterator
+
+import structlog
+
+# Every logger setup_logging() reaches, from logging_config.py:103-112.
+# "" is the root logger.
+_MUTATED_LOGGERS = ("", "uvicorn", "uvicorn.error", "uvicorn.access")
+
+
+@contextlib.contextmanager
+def preserved_logging_state() -> Iterator[None]:
+    """Restore the logging state ``setup_logging()`` changes, exactly as found.
+
+    Covers the stdlib side (handlers, ``propagate`` and level, for root and
+    each named logger) and the structlog side (the whole config, including the
+    processor chain). Callers still have to invoke ``setup_logging()`` inside
+    the test body themselves — pytest swaps ``sys.stdout``/``stderr`` for the
+    call phase only, so a handler created during fixture setup binds to a
+    stream capsys is not capturing.
+    """
+    saved_loggers = {
+        name: (
+            logging.getLogger(name).handlers[:],
+            logging.getLogger(name).propagate,
+            logging.getLogger(name).level,
+        )
+        for name in _MUTATED_LOGGERS
+    }
+    saved_structlog = dict(structlog.get_config())
+    try:
+        yield
+    finally:
+        structlog.configure(**saved_structlog)
+        for name, (handlers, propagate, level) in saved_loggers.items():
+            logger = logging.getLogger(name)
+            logger.handlers[:] = handlers
+            logger.propagate = propagate
+            logger.setLevel(level)

--- a/backend/tests/_logging_state.py
+++ b/backend/tests/_logging_state.py
@@ -29,6 +29,8 @@ from collections.abc import Iterator
 
 import structlog
 
+from app.core.logging_config import setup_logging
+
 # Every logger setup_logging() reaches, from logging_config.py:103-112.
 # "" is the root logger.
 _MUTATED_LOGGERS = ("", "uvicorn", "uvicorn.error", "uvicorn.access")
@@ -63,3 +65,39 @@ def preserved_logging_state() -> Iterator[None]:
             logger.handlers[:] = handlers
             logger.propagate = propagate
             logger.setLevel(level)
+
+
+@contextlib.contextmanager
+def configured_logging(
+    *, json_logs: bool = True, log_level: str = "DEBUG"
+) -> Iterator[None]:
+    """``setup_logging()`` inside a preserved window, with the freeze disarmed.
+
+    fix(#1064 codex r4): use this rather than ``preserved_logging_state()``
+    directly whenever the window CALLS ``setup_logging()``. Restoring the
+    config on exit is not enough on its own, because ``setup_logging()`` turns
+    ``cache_logger_on_first_use`` ON, and a module-level logger that emits
+    while it is on freezes its ``BoundLoggerLazyProxy`` against the
+    then-current chain. That bind lives on the proxy object, not in the config,
+    so no amount of restoring undoes it — the logger is simply invisible to
+    every later ``capture_logs()`` in the worker. It is the #1063 mechanism.
+
+    **The order is the entire reason this is a separate helper.** The disable
+    has to land AFTER ``setup_logging()``; ``preserved_logging_state()`` cannot
+    do the job by configuring before it yields, because ``setup_logging()``
+    would immediately turn caching back on. A caller composing the two by hand
+    gets that wrong silently — nothing fails, the freeze just happens.
+
+    Turning caching off keeps the processor chain and the stdlib routing
+    ``setup_logging()`` installed; only the freezing goes. The original value
+    is restored on exit like everything else.
+
+    Enter it INSIDE the test body, never in fixture setup: pytest swaps
+    ``sys.stdout``/``sys.stderr`` for the call phase only, so a handler built
+    during setup binds to a stream ``capsys`` is not capturing and every write
+    fails with ``--- Logging error ---`` instead of landing anywhere assertable.
+    """
+    with preserved_logging_state():
+        setup_logging(json_logs=json_logs, log_level=log_level)
+        structlog.configure(cache_logger_on_first_use=False)
+        yield

--- a/backend/tests/test_notification_channels.py
+++ b/backend/tests/test_notification_channels.py
@@ -81,18 +81,30 @@ def _live_logs(capsys: pytest.CaptureFixture[str]) -> Any:
     a stream that is not the one being captured and every write fails with
     ``--- Logging error ---`` instead of landing anywhere assertable.
 
-    On exit the root handlers and level are restored, and structlog is reset
-    to LIBRARY defaults rather than to whatever was configured before. That is
-    deliberate and it is not the same thing: `reset_defaults()` leaves
-    `cache_logger_on_first_use` False, which is the safe end of the range,
-    whereas faithfully restoring a prior True would hand the next test the
-    exact global that makes capture go blind. Leaking that state onward is the
-    failure class this construction exists to close.
+    On exit the root handlers, the root level and the structlog config are all
+    put back exactly as they were.
+
+    fix(#1064 codex r1): an earlier version called `structlog.reset_defaults()`
+    instead, reasoning that the library default leaves
+    `cache_logger_on_first_use` False and is therefore the safe end. That was
+    wrong, and wrong in a security-relevant direction: `reset_defaults()`
+    replaces the WHOLE chain, so it drops `_redact_sensitive_fields` and the
+    stdlib routing `setup_logging` installed, and any later test on the worker
+    would log unredacted. Restoring what was actually there is the only
+    version that leaves no trace — resetting to a default is still changing
+    state the caller established.
+
+    Captured at DEBUG, not INFO (fix(#1064 codex r1)): a channel logging a
+    revealed credential at debug level would otherwise be filtered out before
+    this saw it, and the test would pass while a deployment running
+    LOG_LEVEL=DEBUG emitted the secret. The assertions this replaced used
+    `caplog.at_level(logging.DEBUG)`, so anything narrower is a regression.
     """
     root = logging.getLogger()
     saved_handlers = root.handlers[:]
     saved_level = root.level
-    setup_logging(json_logs=True, log_level="INFO")
+    saved_structlog = dict(structlog.get_config())
+    setup_logging(json_logs=True, log_level="DEBUG")
     records: list[str] = []
     live = _LiveLogs(records)
     try:
@@ -116,7 +128,7 @@ def _live_logs(capsys: pytest.CaptureFixture[str]) -> Any:
                 continue
             if isinstance(parsed, dict) and "event" in parsed:
                 records.append(line)
-        structlog.reset_defaults()
+        structlog.configure(**saved_structlog)
         root.handlers[:] = saved_handlers
         root.setLevel(saved_level)
 

--- a/backend/tests/test_notification_channels.py
+++ b/backend/tests/test_notification_channels.py
@@ -81,9 +81,13 @@ def _live_logs(capsys: pytest.CaptureFixture[str]) -> Any:
     a stream that is not the one being captured and every write fails with
     ``--- Logging error ---`` instead of landing anywhere assertable.
 
-    Root handlers and the structlog config are restored on exit, because
-    leaking global logging state into later tests is the same failure class
-    this construction exists to close.
+    On exit the root handlers and level are restored, and structlog is reset
+    to LIBRARY defaults rather than to whatever was configured before. That is
+    deliberate and it is not the same thing: `reset_defaults()` leaves
+    `cache_logger_on_first_use` False, which is the safe end of the range,
+    whereas faithfully restoring a prior True would hand the next test the
+    exact global that makes capture go blind. Leaking that state onward is the
+    failure class this construction exists to close.
     """
     root = logging.getLogger()
     saved_handlers = root.handlers[:]

--- a/backend/tests/test_notification_channels.py
+++ b/backend/tests/test_notification_channels.py
@@ -9,12 +9,16 @@ Covers:
 
 from __future__ import annotations
 
+import contextlib
+import json
 import logging
 from typing import Any
 from unittest.mock import patch
 
 import pytest
+import structlog
 
+from app.core.logging_config import setup_logging
 from app.platform.extensions.protocols import Notification
 
 # ---------------------------------------------------------------------------
@@ -30,6 +34,87 @@ _TEST_NOTIFICATION = Notification(
 
 _SECRET_PASSWORD = "s3cr3t-smtp-pass"
 _SECRET_WEBHOOK = "webhook-hmac-secret"
+
+# Emitted through the same structlog path the channels would use, to prove the
+# channel is live before anything is asserted about its contents.
+_LIVENESS_MARKER = "notification_log_liveness_probe"
+
+
+class _LiveLogs:
+    """Real log output for one test, with a liveness proof attached.
+
+    fix(#1064): replaces a loop over ``caplog.records`` that asserted a secret
+    was absent from each record. caplog captures ZERO structlog records in
+    this suite, so the loop body never ran and the assertion passed vacuously
+    — it has never been able to fail, and would not have fired if the leak it
+    guards against actually happened.
+
+    Reads real emitted output rather than using a recorder, deliberately: a
+    recorder can only observe a logger that already exists, and
+    ``smtp_channel.py`` has none. This tripwire has to catch a logger nobody
+    has written yet.
+    """
+
+    def __init__(self, records: list[str]) -> None:
+        self._records = records
+
+    def assert_no_secrets(self, *secrets: str) -> None:
+        """Both halves. The first is the one that was missing."""
+        assert any(_LIVENESS_MARKER in r for r in self._records), (
+            "log channel is not live: no structured record arrived, so a leak "
+            "assertion here would pass vacuously. That missing check is why "
+            "the previous caplog version never tested anything."
+        )
+        for secret in secrets:
+            offenders = [r for r in self._records if secret in r]
+            assert not offenders, (
+                f"secret leaked into log output: {secret!r} in {offenders}"
+            )
+
+
+@contextlib.contextmanager
+def _live_logs(capsys: pytest.CaptureFixture[str]) -> Any:
+    """Configure real logging bound to the captured stream, then restore it.
+
+    Must be entered INSIDE the test body. pytest swaps ``sys.stdout``/``stderr``
+    for the call phase only, so a handler created during fixture setup binds to
+    a stream that is not the one being captured and every write fails with
+    ``--- Logging error ---`` instead of landing anywhere assertable.
+
+    Root handlers and the structlog config are restored on exit, because
+    leaking global logging state into later tests is the same failure class
+    this construction exists to close.
+    """
+    root = logging.getLogger()
+    saved_handlers = root.handlers[:]
+    saved_level = root.level
+    setup_logging(json_logs=True, log_level="INFO")
+    records: list[str] = []
+    live = _LiveLogs(records)
+    try:
+        yield live
+    finally:
+        structlog.stdlib.get_logger("app.platform.notifications.liveness").info(
+            _LIVENESS_MARKER
+        )
+        captured = capsys.readouterr()
+        for line in (captured.out + captured.err).splitlines():
+            line = line.strip()
+            if not line.startswith("{"):
+                # pytest writes tracebacks to the same stream; a traceback
+                # carrying a secret is a different finding from a LOG carrying
+                # one. A traceback rendered INTO a record is still caught,
+                # because format_exc_info puts it inside the JSON.
+                continue
+            try:
+                parsed = json.loads(line)
+            except ValueError:
+                continue
+            if isinstance(parsed, dict) and "event" in parsed:
+                records.append(line)
+        structlog.reset_defaults()
+        root.handlers[:] = saved_handlers
+        root.setLevel(saved_level)
 
 
 # ---------------------------------------------------------------------------
@@ -260,7 +345,7 @@ async def test_smtp_no_login_when_no_username(monkeypatch: pytest.MonkeyPatch) -
 
 @pytest.mark.anyio
 async def test_smtp_password_not_in_logs(
-    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:
     """T-1229-04: SMTP password must not appear in any log output."""
     import smtplib
@@ -296,13 +381,10 @@ async def test_smtp_password_not_in_logs(
 
     from app.platform.notifications.smtp_channel import send_email
 
-    with caplog.at_level(logging.DEBUG):
+    with _live_logs(capsys) as logs:
         await send_email(_TEST_NOTIFICATION)
 
-    for record in caplog.records:
-        assert _SECRET_PASSWORD not in record.getMessage(), (
-            f"SMTP password must not appear in log: {record.getMessage()!r}"
-        )
+    logs.assert_no_secrets(_SECRET_PASSWORD)
 
 
 @pytest.mark.anyio
@@ -495,7 +577,7 @@ async def test_webhook_raises_on_non_2xx(monkeypatch: pytest.MonkeyPatch) -> Non
 
 @pytest.mark.anyio
 async def test_webhook_secret_not_in_logs(
-    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:
     """T-1229-04: Webhook secret must not appear in any log output."""
     from pydantic import SecretStr
@@ -523,13 +605,10 @@ async def test_webhook_secret_not_in_logs(
 
     from app.platform.notifications.webhook_channel import post_webhook
 
-    with caplog.at_level(logging.DEBUG):
+    with _live_logs(capsys) as logs:
         await post_webhook(_TEST_NOTIFICATION)
 
-    for record in caplog.records:
-        assert _SECRET_WEBHOOK not in record.getMessage(), (
-            f"Webhook secret must not appear in log: {record.getMessage()!r}"
-        )
+    logs.assert_no_secrets(_SECRET_WEBHOOK)
 
 
 @pytest.mark.anyio
@@ -746,7 +825,7 @@ async def test_env_sink_no_channels_configured_returns_silently(
 
 @pytest.mark.anyio
 async def test_env_sink_all_failed_error_message_has_no_secrets_in_logs(
-    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:
     """T-1229-04: Secrets must not appear in logs during channel failures."""
     from pydantic import SecretStr
@@ -781,14 +860,11 @@ async def test_env_sink_all_failed_error_message_has_no_secrets_in_logs(
         )
 
         sink = EnvConfiguredNotificationSink()
-        with caplog.at_level(logging.DEBUG):
+        with _live_logs(capsys) as logs:
             with pytest.raises(NotificationDeliveryError):
                 await sink.deliver(_TEST_NOTIFICATION)
 
-    for record in caplog.records:
-        msg = record.getMessage()
-        assert _SECRET_PASSWORD not in msg, f"Password in log: {msg!r}"
-        assert _SECRET_WEBHOOK not in msg, f"Webhook secret in log: {msg!r}"
+    logs.assert_no_secrets(_SECRET_PASSWORD, _SECRET_WEBHOOK)
 
 
 @pytest.mark.anyio

--- a/backend/tests/test_notification_channels.py
+++ b/backend/tests/test_notification_channels.py
@@ -103,6 +103,17 @@ def _live_logs(capsys: pytest.CaptureFixture[str]) -> Any:
     """
     with preserved_logging_state():
         setup_logging(json_logs=True, log_level="DEBUG")
+        # fix(#1064 codex r3): setup_logging turns cache_logger_on_first_use
+        # ON. Any module-level logger that emits while it is on FREEZES its
+        # BoundLoggerLazyProxy against the then-current chain, and restoring
+        # the config on exit cannot undo a proxy-local bind — that logger is
+        # then invisible to every later capture_logs() in the worker.
+        # Measured: a proxy capture_logs could see before this helper ran was
+        # invisible afterwards. That is the #1063 mechanism, so leaving it
+        # would have this test manufacture the very hazard it exists to catch.
+        # Turning caching back off keeps the chain and the routing; only the
+        # freezing goes.
+        structlog.configure(cache_logger_on_first_use=False)
         records: list[str] = []
         live = _LiveLogs(records)
         try:

--- a/backend/tests/test_notification_channels.py
+++ b/backend/tests/test_notification_channels.py
@@ -17,8 +17,7 @@ from unittest.mock import patch
 import pytest
 import structlog
 
-from app.core.logging_config import setup_logging
-from tests._logging_state import preserved_logging_state
+from tests._logging_state import configured_logging
 from app.platform.extensions.protocols import Notification
 
 # ---------------------------------------------------------------------------
@@ -82,8 +81,11 @@ def _live_logs(capsys: pytest.CaptureFixture[str]) -> Any:
     ``--- Logging error ---`` instead of landing anywhere assertable.
 
     On exit every logger `setup_logging()` touches is put back exactly as it
-    was, via `preserved_logging_state()` — root AND the three uvicorn loggers,
-    handlers, propagate and level, plus the whole structlog config.
+    was, via `configured_logging()` — root AND the three uvicorn loggers,
+    handlers, propagate and level, plus the whole structlog config. That helper
+    also disables `cache_logger_on_first_use` for the window, which is what
+    stops this test from freezing a module-level proxy and manufacturing the
+    very hazard it exists to catch (#1063's mechanism).
 
     fix(#1064 codex r1): an earlier version called `structlog.reset_defaults()`
     instead, reasoning that the library default leaves
@@ -101,19 +103,10 @@ def _live_logs(capsys: pytest.CaptureFixture[str]) -> Any:
     LOG_LEVEL=DEBUG emitted the secret. The assertions this replaced used
     `caplog.at_level(logging.DEBUG)`, so anything narrower is a regression.
     """
-    with preserved_logging_state():
-        setup_logging(json_logs=True, log_level="DEBUG")
-        # fix(#1064 codex r3): setup_logging turns cache_logger_on_first_use
-        # ON. Any module-level logger that emits while it is on FREEZES its
-        # BoundLoggerLazyProxy against the then-current chain, and restoring
-        # the config on exit cannot undo a proxy-local bind — that logger is
-        # then invisible to every later capture_logs() in the worker.
-        # Measured: a proxy capture_logs could see before this helper ran was
-        # invisible afterwards. That is the #1063 mechanism, so leaving it
-        # would have this test manufacture the very hazard it exists to catch.
-        # Turning caching back off keeps the chain and the routing; only the
-        # freezing goes.
-        structlog.configure(cache_logger_on_first_use=False)
+    # fix(#1064 codex r4): the setup_logging call and the cache disable that has
+    # to follow it now live together in configured_logging(); composing them
+    # here by hand is the ordering trap that helper exists to remove.
+    with configured_logging(log_level="DEBUG"):
         records: list[str] = []
         live = _LiveLogs(records)
         try:

--- a/backend/tests/test_notification_channels.py
+++ b/backend/tests/test_notification_channels.py
@@ -11,7 +11,6 @@ from __future__ import annotations
 
 import contextlib
 import json
-import logging
 from typing import Any
 from unittest.mock import patch
 
@@ -19,6 +18,7 @@ import pytest
 import structlog
 
 from app.core.logging_config import setup_logging
+from tests._logging_state import preserved_logging_state
 from app.platform.extensions.protocols import Notification
 
 # ---------------------------------------------------------------------------
@@ -81,8 +81,9 @@ def _live_logs(capsys: pytest.CaptureFixture[str]) -> Any:
     a stream that is not the one being captured and every write fails with
     ``--- Logging error ---`` instead of landing anywhere assertable.
 
-    On exit the root handlers, the root level and the structlog config are all
-    put back exactly as they were.
+    On exit every logger `setup_logging()` touches is put back exactly as it
+    was, via `preserved_logging_state()` — root AND the three uvicorn loggers,
+    handlers, propagate and level, plus the whole structlog config.
 
     fix(#1064 codex r1): an earlier version called `structlog.reset_defaults()`
     instead, reasoning that the library default leaves
@@ -100,37 +101,31 @@ def _live_logs(capsys: pytest.CaptureFixture[str]) -> Any:
     LOG_LEVEL=DEBUG emitted the secret. The assertions this replaced used
     `caplog.at_level(logging.DEBUG)`, so anything narrower is a regression.
     """
-    root = logging.getLogger()
-    saved_handlers = root.handlers[:]
-    saved_level = root.level
-    saved_structlog = dict(structlog.get_config())
-    setup_logging(json_logs=True, log_level="DEBUG")
-    records: list[str] = []
-    live = _LiveLogs(records)
-    try:
-        yield live
-    finally:
-        structlog.stdlib.get_logger("app.platform.notifications.liveness").info(
-            _LIVENESS_MARKER
-        )
-        captured = capsys.readouterr()
-        for line in (captured.out + captured.err).splitlines():
-            line = line.strip()
-            if not line.startswith("{"):
-                # pytest writes tracebacks to the same stream; a traceback
-                # carrying a secret is a different finding from a LOG carrying
-                # one. A traceback rendered INTO a record is still caught,
-                # because format_exc_info puts it inside the JSON.
-                continue
-            try:
-                parsed = json.loads(line)
-            except ValueError:
-                continue
-            if isinstance(parsed, dict) and "event" in parsed:
-                records.append(line)
-        structlog.configure(**saved_structlog)
-        root.handlers[:] = saved_handlers
-        root.setLevel(saved_level)
+    with preserved_logging_state():
+        setup_logging(json_logs=True, log_level="DEBUG")
+        records: list[str] = []
+        live = _LiveLogs(records)
+        try:
+            yield live
+        finally:
+            structlog.stdlib.get_logger("app.platform.notifications.liveness").info(
+                _LIVENESS_MARKER
+            )
+            captured = capsys.readouterr()
+            for line in (captured.out + captured.err).splitlines():
+                line = line.strip()
+                if not line.startswith("{"):
+                    # pytest writes tracebacks to the same stream; a traceback
+                    # carrying a secret is a different finding from a LOG
+                    # carrying one. A traceback rendered INTO a record is still
+                    # caught, because format_exc_info puts it inside the JSON.
+                    continue
+                try:
+                    parsed = json.loads(line)
+                except ValueError:
+                    continue
+                if isinstance(parsed, dict) and "event" in parsed:
+                    records.append(line)
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_phase_273_log_redaction.py
+++ b/backend/tests/test_phase_273_log_redaction.py
@@ -5,12 +5,11 @@ Pins the v13.13 closure of M-65. Even if a developer accidentally logs
 reaching stdout / log aggregators.
 """
 
-import logging
-
 import pytest
 import structlog
 
 from app.core.logging_config import _redact_sensitive_fields, setup_logging
+from tests._logging_state import preserved_logging_state
 
 
 # ---------------------------------------------------------------------------
@@ -111,22 +110,14 @@ def restore_logging_state():
     fixture setup binds to a stream capsys is not capturing. Saving here and
     restoring on teardown is the part that can live in a fixture.
 
-    fix(#1064 codex r1): restores the previous structlog config rather than
-    calling `reset_defaults()`. The library default drops
-    `_redact_sensitive_fields` and the stdlib routing, so resetting would
-    leave later tests on the worker logging unredacted — trading one
-    order-dependence for a worse one.
+    fix(#1064 codex r1/r2): restores the previous structlog config rather than
+    calling `reset_defaults()` — the library default drops
+    `_redact_sensitive_fields` and the stdlib routing — and covers the three
+    uvicorn loggers `setup_logging()` also rewrites, not just root. Both live
+    in `preserved_logging_state()` so there is one shape to be wrong.
     """
-    root = logging.getLogger()
-    saved_handlers = root.handlers[:]
-    saved_level = root.level
-    saved_structlog = dict(structlog.get_config())
-    try:
+    with preserved_logging_state():
         yield
-    finally:
-        structlog.configure(**saved_structlog)
-        root.handlers[:] = saved_handlers
-        root.setLevel(saved_level)
 
 
 def test_integration_token_redacted_in_log_output(capsys, restore_logging_state):

--- a/backend/tests/test_phase_273_log_redaction.py
+++ b/backend/tests/test_phase_273_log_redaction.py
@@ -110,14 +110,21 @@ def restore_logging_state():
     `sys.stdout`/`stderr` for the call phase only, so a handler created during
     fixture setup binds to a stream capsys is not capturing. Saving here and
     restoring on teardown is the part that can live in a fixture.
+
+    fix(#1064 codex r1): restores the previous structlog config rather than
+    calling `reset_defaults()`. The library default drops
+    `_redact_sensitive_fields` and the stdlib routing, so resetting would
+    leave later tests on the worker logging unredacted — trading one
+    order-dependence for a worse one.
     """
     root = logging.getLogger()
     saved_handlers = root.handlers[:]
     saved_level = root.level
+    saved_structlog = dict(structlog.get_config())
     try:
         yield
     finally:
-        structlog.reset_defaults()
+        structlog.configure(**saved_structlog)
         root.handlers[:] = saved_handlers
         root.setLevel(saved_level)
 

--- a/backend/tests/test_phase_273_log_redaction.py
+++ b/backend/tests/test_phase_273_log_redaction.py
@@ -5,6 +5,8 @@ Pins the v13.13 closure of M-65. Even if a developer accidentally logs
 reaching stdout / log aggregators.
 """
 
+import logging
+
 import pytest
 import structlog
 
@@ -94,7 +96,33 @@ def test_processor_handles_empty_dict():
 # ---------------------------------------------------------------------------
 
 
-def test_integration_token_redacted_in_log_output(capsys):
+@pytest.fixture
+def restore_logging_state():
+    """Undo the global logging state the test below leaves behind.
+
+    fix(#1064): `setup_logging()` replaces the root handlers and sets
+    `cache_logger_on_first_use=True`, and nothing here put either back — so
+    every test after this one in the same worker inherited both. That is the
+    leaked-global class this file's own subject matter is about, and the
+    caching half is what makes a later `capture_logs()` see nothing.
+
+    The call itself has to stay in the test body: pytest swaps
+    `sys.stdout`/`stderr` for the call phase only, so a handler created during
+    fixture setup binds to a stream capsys is not capturing. Saving here and
+    restoring on teardown is the part that can live in a fixture.
+    """
+    root = logging.getLogger()
+    saved_handlers = root.handlers[:]
+    saved_level = root.level
+    try:
+        yield
+    finally:
+        structlog.reset_defaults()
+        root.handlers[:] = saved_handlers
+        root.setLevel(saved_level)
+
+
+def test_integration_token_redacted_in_log_output(capsys, restore_logging_state):
     """End-to-end: configure structlog via setup_logging, log a token,
     verify the raw token does NOT appear and [REDACTED] DOES."""
     setup_logging(json_logs=True, log_level="INFO")

--- a/backend/tests/test_phase_273_log_redaction.py
+++ b/backend/tests/test_phase_273_log_redaction.py
@@ -8,8 +8,8 @@ reaching stdout / log aggregators.
 import pytest
 import structlog
 
-from app.core.logging_config import _redact_sensitive_fields, setup_logging
-from tests._logging_state import preserved_logging_state
+from app.core.logging_config import _redact_sensitive_fields
+from tests._logging_state import configured_logging
 
 
 # ---------------------------------------------------------------------------
@@ -95,9 +95,9 @@ def test_processor_handles_empty_dict():
 # ---------------------------------------------------------------------------
 
 
-@pytest.fixture
-def restore_logging_state():
-    """Undo the global logging state the test below leaves behind.
+def test_integration_token_redacted_in_log_output(capsys):
+    """End-to-end: configure structlog via setup_logging, log a token,
+    verify the raw token does NOT appear and [REDACTED] DOES.
 
     fix(#1064): `setup_logging()` replaces the root handlers and sets
     `cache_logger_on_first_use=True`, and nothing here put either back — so
@@ -105,31 +105,26 @@ def restore_logging_state():
     leaked-global class this file's own subject matter is about, and the
     caching half is what makes a later `capture_logs()` see nothing.
 
-    The call itself has to stay in the test body: pytest swaps
+    fix(#1064 codex r4): `configured_logging()` replaces a fixture that only
+    saved and restored. Restoring was never sufficient on its own — while
+    caching is on, any module-level proxy emitting inside the window freezes
+    permanently, and a proxy-local bind survives every restore. The helper
+    disables caching after `setup_logging()`, which is the only order that
+    works, and this file was one `logger.info` away from being the test that
+    demonstrated it.
+
+    It stays a context manager in the body rather than a fixture: pytest swaps
     `sys.stdout`/`stderr` for the call phase only, so a handler created during
-    fixture setup binds to a stream capsys is not capturing. Saving here and
-    restoring on teardown is the part that can live in a fixture.
-
-    fix(#1064 codex r1/r2): restores the previous structlog config rather than
-    calling `reset_defaults()` — the library default drops
-    `_redact_sensitive_fields` and the stdlib routing — and covers the three
-    uvicorn loggers `setup_logging()` also rewrites, not just root. Both live
-    in `preserved_logging_state()` so there is one shape to be wrong.
+    fixture setup binds to a stream capsys is not capturing.
     """
-    with preserved_logging_state():
-        yield
+    with configured_logging(log_level="INFO"):
+        logger = structlog.stdlib.get_logger("test.redaction")
+        logger.info(
+            "auth_attempt", token="my-supersecret-jwt-token-value", user_id="alice"
+        )
 
-
-def test_integration_token_redacted_in_log_output(capsys, restore_logging_state):
-    """End-to-end: configure structlog via setup_logging, log a token,
-    verify the raw token does NOT appear and [REDACTED] DOES."""
-    setup_logging(json_logs=True, log_level="INFO")
-
-    logger = structlog.stdlib.get_logger("test.redaction")
-    logger.info("auth_attempt", token="my-supersecret-jwt-token-value", user_id="alice")
-
-    captured = capsys.readouterr()
-    out = captured.out + captured.err  # log destination depends on handler config
+        captured = capsys.readouterr()
+        out = captured.out + captured.err  # destination depends on handler config
 
     # The raw token must NOT appear
     assert "my-supersecret-jwt-token-value" not in out, (

--- a/backend/tests/test_sec025_sandbox_allowlist.py
+++ b/backend/tests/test_sec025_sandbox_allowlist.py
@@ -63,9 +63,12 @@ def _recording_validator_logger():
     similar. A snapshot-and-restore guard CANNOT repair a proxy frozen while
     it was off-guard, because the cache is on the proxy rather than in the
     config; preventing the freeze is the only thing that closes the class
-    (#1066). And a helper that calls `setup_logging()` will seed this unless
-    it turns caching back off inside its own window — which is what
-    `tests/_logging_state.py` and the notification capture helper now do.
+    (#1066). And a helper that calls `setup_logging()` will seed this unless it
+    turns caching back off AFTER that call — order matters, since
+    `setup_logging()` turns it on. Use `configured_logging()` from
+    `tests/_logging_state.py`, which owns both steps; its sibling
+    `preserved_logging_state()` only snapshots and restores, so composing that
+    one with `setup_logging()` by hand leaves the freeze armed (#1064 codex r4).
     """
     events: list[dict] = []
 

--- a/backend/tests/test_sec025_sandbox_allowlist.py
+++ b/backend/tests/test_sec025_sandbox_allowlist.py
@@ -34,22 +34,38 @@ def _recording_validator_logger():
     which turned main red. The same file passes run alone, and two failing
     runs disagreed on how many of the three broke.
 
-    The exact trigger was NOT pinned down, and this docstring deliberately
-    does not claim it was. Two people failed to reproduce it in a single
-    process, including forcing `setup_logging()` ahead of a warmed validator
-    logger and raising the stdlib root level. The leading candidate is
-    `cache_logger_on_first_use=True` in `app/core/logging_config.py` combined
-    with `validator.py` binding its logger at import, which matches the
-    symptom documented at test_tile_signing.py:648-656 — but it did not
-    demonstrate on structlog 25.5.0 even when that order was forced. Treat it
-    as unconfirmed if you are here debugging something similar.
+    fix(#1064 codex r3): the trigger IS now pinned down, and this paragraph
+    used to say it was not. It is a CONJUNCTION, which is why five separate
+    reproduction attempts came back empty — each had one half:
 
-    What IS established is the class of cause: an assertion about validator
-    behaviour should not read through global logging state that any other test
-    in the worker can mutate. Swapping the module global removes that
-    dependency outright, because the call sites resolve `logger` from module
-    globals at call time. That is why this is the right fix whether or not the
-    caching story turns out to be the trigger.
+        `cache_logger_on_first_use=True` is in force
+        AND a module-level logger EMITS during that window.
+
+    The emit is what matters. Enabling caching alone does nothing; the proxy
+    only freezes when it is first used. On that first call a
+    `BoundLoggerLazyProxy` binds itself to the chain in force and caches the
+    result ON THE PROXY OBJECT, so reapplying a config afterwards cannot undo
+    it — that logger is invisible to every later `capture_logs()` in the
+    worker. Measured against a module logger: `capture_logs` saw 1 record
+    before, 0 after something emitted through it while caching was on.
+
+    `setup_logging()` turns caching on, so anything that calls it and then
+    logs seeds this. That is the same symptom documented at
+    test_tile_signing.py:648-656.
+
+    The fix below is unchanged and still right. Removing the dependency
+    outright — the call sites resolve `logger` from module globals at call
+    time, so swapping it is immune regardless — is stronger than avoiding one
+    known trigger, and it was the correct call when the trigger was unknown.
+    Knowing the mechanism does not make a narrower fix preferable.
+
+    Two consequences worth knowing if you are here debugging something
+    similar. A snapshot-and-restore guard CANNOT repair a proxy frozen while
+    it was off-guard, because the cache is on the proxy rather than in the
+    config; preventing the freeze is the only thing that closes the class
+    (#1066). And a helper that calls `setup_logging()` will seed this unless
+    it turns caching back off inside its own window — which is what
+    `tests/_logging_state.py` and the notification capture helper now do.
     """
     events: list[dict] = []
 


### PR DESCRIPTION
**Not a regression fix.** These three assertions have never been able to fail.
The gap has been open since the tests landed, and it went unnoticed because a
disconnected tripwire and a working one look identical from the outside.

## What was wrong

Three assertions guard a credential against reaching the logs — the SMTP
password after `send_email`, the webhook secret after `post_webhook`, and both
after `EnvConfiguredNotificationSink.deliver`. All three:

```python
for record in caplog.records:
    assert _SECRET_PASSWORD not in record.getMessage()
```

`caplog.records` is empty, so the loop body never runs and the assertion passes
vacuously. Measured, not inferred:

| emitter | records caplog sees |
|---|---|
| stdlib `logging` | 1 |
| structlog, before `setup_logging()` | **0** |
| structlog, after `setup_logging()` | **0** |

`logging_config.py` wires `LoggerFactory` + `ProcessorFormatter.wrap_for_formatter`,
which should bridge to stdlib — but `setup_logging()` replaces the root handlers
and caplog's handler goes with them.

## Demonstrated in both directions

Added a structlog line to `smtp_channel.py` logging the password, which is the
literal regression these tests guard against:

- **Old assertion, verbatim:** `CAPLOG_RECORDS: 0` — **passed**.
- **New assertion:** failed with
  `secret leaked into log output: 's3cr3t-smtp-pass' in ['{"event": "smtp auth as s3cr3t-smtp-pass", "logger": "app.platform.notifications.smtp_channel", ...}']`

Nothing is leaking today — `smtp_channel.py` has no logger at all. The problem
is that the guard against a future one cannot fire, and the codebase uses
structlog everywhere, so the future logger is exactly the kind caplog cannot see.

## The fix

Each site reads real emitted output and asserts **both** directions: that a
marker sent through the same structlog path arrives, and that no secret appears
in any record that did. The liveness half is the one that was missing, and its
absence is precisely what made the original vacuous — the same refusal-versus-
admission point as #1063, one level up.

Real output rather than a recorder, deliberately. A recorder — #1063's approach
— can only observe a logger that already exists, and `smtp_channel.py` has
none. This tripwire has to catch a logger nobody has written yet.

## Two things the construction has to get right

Both found by measurement, both non-obvious, both would have silently
reintroduced the vacuity:

**`setup_logging()` runs inside the test body, not a fixture.** pytest swaps
`sys.stdout`/`stderr` for the call phase only, so a handler created during
fixture setup binds to a stream that is not the captured one. Every write then
fails with `--- Logging error ---` and lands nowhere assertable. The first
version used a fixture and the liveness check caught it.

**Only JSON records count, not the whole stream.** pytest writes tracebacks to
the same place, and a traceback carrying a secret is a different finding from a
log carrying one — an earlier version failed on exactly that false positive. A
traceback rendered INTO a record is still caught, because `format_exc_info`
puts it inside the JSON.

Root handlers and the structlog config are restored on exit, since leaking
global logging state into later tests is the same failure class this closes.

## Scope

Test-only, one file, three call sites. No application code touched.

Found by the sweep for other assertions exposed to #1063's failure class. That
sweep also found `test_reupload_swap_lock_retry.py:207-209` (negative assertion
over `capture_logs`, not currently vacuous) and seven presence-asserting sites
that fail loudly if blinded — both judged not worth a PR.

## Verification

```
cd backend && uv run pytest tests/test_notification_channels.py \
  tests/test_phase_273_log_redaction.py tests/test_layering.py -q -n 4
# 72 passed
cd backend && uv run ruff check . && uv run ruff format --check .
```

CI will be red on the sec025 EXISTS tests until #1063 lands; that is main's
current state, unrelated to this diff.

Closes #1064
