### PR TITLE
feat(ai): let chat run_analysis clip a layer by another layer

### DIFF
--- a/backend/app/core/processing_port.py
+++ b/backend/app/core/processing_port.py
@@ -239,6 +239,11 @@ class ProcessingPort(Protocol):
         user_id: uuid.UUID,
         distance_meters: float | None = None,
         mask: dict[str, Any] | None = None,
+        # feat(#683): the clip mask can come from another DATASET, not just a
+        # drawn polygon. Passed as the loaded object rather than an id because
+        # the caller owns its visibility check, exactly as it owns the source
+        # dataset's — see the default implementation's contract.
+        mask_dataset: Any | None = None,
     ) -> Any: ...  # -> AnalysisPreviewResponse
 
     async def get_column_stats(

--- a/backend/app/platform/extensions/defaults_processing_port.py
+++ b/backend/app/platform/extensions/defaults_processing_port.py
@@ -101,22 +101,59 @@ class DefaultProcessingPort:
         return await get_user_roles(session, user)
 
     async def run_analysis_preview(  # type: ignore[no-untyped-def]
-        self, session, dataset, operation, *, user_id, distance_meters=None, mask=None
+        self,
+        session,
+        dataset,
+        operation,
+        *,
+        user_id,
+        distance_meters=None,
+        mask=None,
+        mask_dataset=None,
     ):
         """Run a parameterized analysis preview (M4) for the AI chat surface.
 
         Params are re-validated by ``AnalysisPreviewRequest`` here, so the
         LLM-supplied values pass through exactly the same bounds/requiredness
         checks as the HTTP endpoint (a ValueError surfaces as a tool error the
-        model can retry from). Callers own the dataset visibility check.
+        model can retry from). Callers own the dataset VISIBILITY check, for
+        the mask dataset as much as the source — this port never checks it.
+
+        feat(#683): the mask's SHAPE is checked here, so every port caller gets
+        the rail the REST route applies in ``_load_mask_dataset``. Unioning
+        points or lines masks nothing meaningful, and without the check the
+        failure is an empty result the model reports as a real answer.
+
+        ``release_session`` is deliberately never passed: see the reasoning at
+        the chat call site in ``chat_analysis._run_analysis``.
         """
         from app.modules.catalog.datasets.domain.schemas import AnalysisPreviewRequest
         from app.modules.catalog.datasets.domain.service import run_analysis_preview
 
+        # Ignored unless the operation owns it, mirroring what
+        # _drop_params_for_other_operations does to mask_dataset_id (#682).
+        mask_for_op = mask_dataset if operation == "clip" else None
+        if mask_for_op is not None:
+            shape = (getattr(mask_for_op, "geometry_type", None) or "").upper()
+            if not shape or not getattr(mask_for_op, "table_name", None):
+                raise ValueError("The mask layer has no geometry to clip with.")
+            if shape not in {"POLYGON", "MULTIPOLYGON"}:
+                raise ValueError(
+                    f"Clipping needs a polygon layer as the mask; that one is "
+                    f"{shape}. Pick a polygon layer instead."
+                )
+
         request = AnalysisPreviewRequest(
-            operation=operation, distance_meters=distance_meters, mask=mask
+            operation=operation,
+            distance_meters=distance_meters,
+            mask=mask,
+            # The validator requires exactly one mask source for clip and never
+            # sees the object, so stand the id in for it.
+            mask_dataset_id=getattr(mask_for_op, "id", None),
         )
-        return await run_analysis_preview(session, dataset, request, user_id)
+        return await run_analysis_preview(
+            session, dataset, request, user_id, mask_dataset=mask_for_op
+        )
 
     async def get_column_stats(
         self, session, table_name, column_name, *, class_count=5, allowed_tables=None

--- a/backend/app/platform/extensions/defaults_processing_port.py
+++ b/backend/app/platform/extensions/defaults_processing_port.py
@@ -119,16 +119,24 @@ class DefaultProcessingPort:
         model can retry from). Callers own the dataset VISIBILITY check, for
         the mask dataset as much as the source — this port never checks it.
 
-        feat(#683): the mask's SHAPE is checked here, so every port caller gets
-        the rail the REST route applies in ``_load_mask_dataset``. Unioning
-        points or lines masks nothing meaningful, and without the check the
-        failure is an empty result the model reports as a real answer.
+        feat(#683): the mask's SHAPE and SIZE are checked here, so every port
+        caller gets the rails the REST route applies in ``_load_mask_dataset``.
+        Unioning points or lines masks nothing meaningful, and without the
+        shape check the failure is an empty result the model reports as a real
+        answer. The size ceiling is a resource rail, not a correctness one:
+        ``_mask_pieces`` materializes and subdivides every mask row before the
+        preview's own row cap can bite, so the work scales with the whole mask
+        however small the source is.
 
         ``release_session`` is deliberately never passed: see the reasoning at
         the chat call site in ``chat_analysis._run_analysis``.
         """
         from app.modules.catalog.datasets.domain.schemas import AnalysisPreviewRequest
-        from app.modules.catalog.datasets.domain.service import run_analysis_preview
+        from app.modules.catalog.datasets.domain.service import (
+            resolve_source_feature_count,
+            run_analysis_preview,
+        )
+        from app.platform.analysis_sql import MAX_MASK_LAYER_FEATURES
 
         # Ignored unless the operation owns it, mirroring what
         # _drop_params_for_other_operations does to mask_dataset_id (#682).
@@ -141,6 +149,19 @@ class DefaultProcessingPort:
                 raise ValueError(
                     f"Clipping needs a polygon layer as the mask; that one is "
                     f"{shape}. Pick a polygon layer instead."
+                )
+            # Counted the same way the REST route counts it: the cached
+            # snapshot when present, a LIMIT-bounded live count when it is
+            # NULL, because NULL-as-zero would admit exactly the unknown-size
+            # layers the gate exists for (fix(#701 review)).
+            mask_count = await resolve_source_feature_count(
+                session, mask_for_op, cap=MAX_MASK_LAYER_FEATURES
+            )
+            if mask_count > MAX_MASK_LAYER_FEATURES:
+                raise ValueError(
+                    f"That mask layer has too many features to clip with "
+                    f"(limit {MAX_MASK_LAYER_FEATURES:,}). Pick a smaller "
+                    "mask layer."
                 )
 
         request = AnalysisPreviewRequest(

--- a/backend/app/platform/extensions/version.py
+++ b/backend/app/platform/extensions/version.py
@@ -43,7 +43,14 @@ logger = logging.getLogger(__name__)
 
 #: v2 adds required ConnectorExtension discovery/dispatch methods and makes the
 #: existing ``connectors`` registry key conflict-guarded as a single slot.
-EXTENSION_API_VERSION: int = 2
+# 2 -> 3 (feat(#683)): ProcessingPort.run_analysis_preview gained a
+# ``mask_dataset`` keyword so chat can clip a layer by another layer. It is
+# optional with a default, so an overlay that never implements the method is
+# unaffected — but one that DOES implement it must accept the keyword, which
+# is a signature change to a Protocol method and therefore a bump. The caller
+# also omits the keyword entirely when it is None, so a legacy overlay that
+# declares no version keeps working for buffer and centroid.
+EXTENSION_API_VERSION: int = 3
 
 
 def check_extension_api_version(name: str, declared_version: int | None) -> None:

--- a/backend/app/processing/ai/chat_analysis.py
+++ b/backend/app/processing/ai/chat_analysis.py
@@ -156,6 +156,16 @@ async def _run_analysis(
         if isinstance(mask_dataset, dict):
             return mask_dataset
 
+    # fix(#683 codex P1): mask_dataset rides along only when set. A separately
+    # distributed overlay that implements the pre-clip ProcessingPort rejects
+    # the unknown keyword, and passing an unconditional None would break EVERY
+    # chat analysis against such an overlay rather than only the new operation.
+    # Same reasoning, same shape as the materialize defer in
+    # router_analysis._defer. EXTENSION_API_VERSION is bumped alongside this,
+    # so an overlay that DECLARES its version fails loudly at load instead;
+    # this guard is for the legacy undeclared ones, which only warn.
+    mask_kwargs = {"mask_dataset": mask_dataset} if mask_dataset is not None else {}
+
     try:
         result = await port.run_analysis_preview(
             session,
@@ -163,7 +173,7 @@ async def _run_analysis(
             operation,
             user_id=user.id,
             distance_meters=distance_meters,
-            mask_dataset=mask_dataset,
+            **mask_kwargs,
             # fix(#716): release_session is deliberately NOT passed. The
             # rollback that returns the pooled connection expires every ORM
             # instance on the session, the authenticated User included, and

--- a/backend/app/processing/ai/chat_analysis.py
+++ b/backend/app/processing/ai/chat_analysis.py
@@ -52,6 +52,47 @@ async def handle_run_analysis(
         return {"error": "Could not run that analysis."}
 
 
+async def _resolve_layer_dataset(
+    session: AsyncSession,
+    layer: ChatMapLayer,
+    user: Identity,
+    user_roles: set[str],
+    *,
+    port: "ProcessingPort",
+    what: str = "layer",
+):
+    """Resolve one layer's dataset and authorize it, or return a tool error.
+
+    Returns the dataset on success and an ``{"error": ...}`` dict otherwise,
+    so callers stay linear. Shared by the source layer and (feat(#683)) the
+    clip mask layer, because BOTH need the Rule-1 check: the layer list is
+    client-supplied, so neither its dataset_id nor its table name is evidence
+    of access.
+    """
+    try:
+        dataset_id = UUID(str(layer.dataset_id))
+    except ValueError:
+        # Malformed client-supplied id — same user-facing outcome as a miss.
+        return {"error": f"That {what}'s dataset is no longer available."}
+    dataset = await port.get_dataset(session, dataset_id)
+    if dataset is None:
+        return {"error": f"That {what}'s dataset is no longer available."}
+
+    try:
+        await port.check_dataset_access(
+            session, dataset, dataset.id, user, user_roles=user_roles
+        )
+    except HTTPException:
+        # check_dataset_access signals denial with a 404 — anything else is a
+        # real failure and belongs in the generic handler, not reported to the
+        # user as an access problem.
+        logger.info(
+            "run_analysis.access_denied", dataset_id=str(dataset.id), which=what
+        )
+        return {"error": f"You don't have access to that {what}'s dataset."}
+    return dataset
+
+
 async def _run_analysis(
     tool_input: dict,
     session: AsyncSession,
@@ -74,25 +115,9 @@ async def _run_analysis(
             "error": "That layer is not on this map — pick one of the listed layers."
         }
 
-    try:
-        dataset_id = UUID(str(layer.dataset_id))
-    except ValueError:
-        # Malformed client-supplied id — same user-facing outcome as a miss.
-        return {"error": "That layer's dataset is no longer available."}
-    dataset = await port.get_dataset(session, dataset_id)
-    if dataset is None:
-        return {"error": "That layer's dataset is no longer available."}
-
-    try:
-        await port.check_dataset_access(
-            session, dataset, dataset.id, user, user_roles=user_roles
-        )
-    except HTTPException:
-        # check_dataset_access signals denial with a 404 — anything else is a
-        # real failure and belongs in the generic handler, not reported to the
-        # user as an access problem.
-        logger.info("run_analysis.access_denied", dataset_id=str(dataset.id))
-        return {"error": "You don't have access to that layer's dataset."}
+    dataset = await _resolve_layer_dataset(session, layer, user, user_roles, port=port)
+    if isinstance(dataset, dict):
+        return dataset
 
     if not dataset.geometry_type or not dataset.table_name:
         return {"error": "That layer has no geometry to analyze."}
@@ -106,6 +131,31 @@ async def _run_analysis(
         tool_input.get("distance_meters") if operation == "buffer" else None
     )
 
+    # feat(#683): the mask layer is resolved and authorized SEPARATELY. Rule 1
+    # applies to both datasets of a two-layer operation, and the layer list is
+    # client-supplied either way, so seeing the source buys no claim on the
+    # mask. The port checks the mask's shape but never its visibility.
+    mask_dataset = None
+    if operation == "clip":
+        mask_layer = next(
+            (lyr for lyr in layers if lyr.id == tool_input.get("mask_layer_id")), None
+        )
+        if mask_layer is None:
+            return {
+                "error": (
+                    "Clipping needs a mask layer from this map — name one of "
+                    "the listed layers as mask_layer_id."
+                )
+            }
+        if mask_layer.id == layer.id:
+            # Clipping a layer by itself is a no-op that costs a real query.
+            return {"error": "The mask layer has to be a different layer."}
+        mask_dataset = await _resolve_layer_dataset(
+            session, mask_layer, user, user_roles, port=port, what="mask layer"
+        )
+        if isinstance(mask_dataset, dict):
+            return mask_dataset
+
     try:
         result = await port.run_analysis_preview(
             session,
@@ -113,6 +163,14 @@ async def _run_analysis(
             operation,
             user_id=user.id,
             distance_meters=distance_meters,
+            mask_dataset=mask_dataset,
+            # fix(#716): release_session is deliberately NOT passed. The
+            # rollback that returns the pooled connection expires every ORM
+            # instance on the session, the authenticated User included, and
+            # both chat paths read `user.id` after this returns — a sync
+            # refresh on an expired instance raises MissingGreenlet. The REST
+            # endpoint passes it because it reads nothing afterwards; copying
+            # that call site verbatim is the natural mistake here.
         )
     except ValueError as exc:
         # Pydantic/param validation (bad enum, missing or out-of-range

--- a/backend/app/processing/ai/chat_analysis.py
+++ b/backend/app/processing/ai/chat_analysis.py
@@ -272,6 +272,13 @@ def collect_run_analysis_action(result: dict) -> dict | None:
     # and requiring one dropped the disclosure entirely, presenting a capped
     # clip preview as the whole result. Report the cap; name the total only
     # when there is one.
+    #
+    # fix(#1076): this flag currently reaches nobody. Both consumers —
+    # ChatPanel.tsx and ViewerChatPanel.tsx — build their truncation object
+    # only when a total came with it, and EphemeralBadge has no label for
+    # "capped, total unknown", so a capped clip still renders as a plain
+    # count. The payload is correct here so that fix is possible; the three
+    # frontend files move together in #1076.
     total = result.get("source_feature_count")
     if result.get("truncated"):
         action["truncated"] = True

--- a/backend/app/processing/ai/chat_analysis.py
+++ b/backend/app/processing/ai/chat_analysis.py
@@ -155,6 +155,17 @@ async def _run_analysis(
         )
         if isinstance(mask_dataset, dict):
             return mask_dataset
+        # fix(#683 codex P2): distinct layer ids are NOT distinct data. A
+        # duplicated rendering is two layers over one dataset, so the id check
+        # above lets that pair through — and clipping a table by itself is an
+        # expensive way to return the input. Identity is the DATASET.
+        if mask_dataset.id == dataset.id:
+            return {
+                "error": (
+                    "That mask layer shows the same dataset as the layer being "
+                    "clipped. Pick a layer with different data."
+                )
+            }
 
     # fix(#683 codex P1): mask_dataset rides along only when set. A separately
     # distributed overlay that implements the pre-clip ProcessingPort rejects
@@ -255,8 +266,15 @@ def collect_run_analysis_action(result: dict) -> dict | None:
         action["layer_id"] = result["layer_id"]
         if result.get("distance_meters") is not None:
             action["distance_meters"] = result["distance_meters"]
+    # fix(#683 codex P2): the truncation flag no longer depends on knowing the
+    # total. clip filters rows, so run_analysis_preview returns no
+    # source_feature_count for it — the clipped total is genuinely unknown —
+    # and requiring one dropped the disclosure entirely, presenting a capped
+    # clip preview as the whole result. Report the cap; name the total only
+    # when there is one.
     total = result.get("source_feature_count")
-    if result.get("truncated") and total:
+    if result.get("truncated"):
         action["truncated"] = True
-        action["row_count"] = total
+        if total:
+            action["row_count"] = total
     return action

--- a/backend/app/processing/ai/tools.py
+++ b/backend/app/processing/ai/tools.py
@@ -350,14 +350,18 @@ CHAT_TOOLS_ANTHROPIC = [
                 },
                 "operation": {
                     "type": "string",
-                    # Deliberately narrower than the preview endpoint's enum:
-                    # `clip` needs a drawn mask polygon that only the Analysis
-                    # rail panel can supply, and `dissolve` is materialize-only
-                    # (an aggregate with no preview shape).
-                    "enum": ["buffer", "centroid"],
+                    # feat(#683): `clip` joined the enum once #682 shipped the
+                    # layer-sourced mask. The old narrowing said clip needed a
+                    # drawn polygon only the Analysis rail could supply, which
+                    # stopped being true then. `dissolve` stays out on its own
+                    # merits: it is materialize-only, an aggregate with no
+                    # preview shape.
+                    "enum": ["buffer", "centroid", "clip"],
                     "description": (
                         "buffer = grow each feature by a distance; "
-                        "centroid = replace each feature with its centre point"
+                        "centroid = replace each feature with its centre "
+                        "point; clip = keep only the parts of each feature "
+                        "that fall inside another layer"
                     ),
                 },
                 "distance_meters": {
@@ -365,6 +369,14 @@ CHAT_TOOLS_ANTHROPIC = [
                     "description": (
                         "Buffer distance in metres, 0 < d <= 100000 "
                         "(required for buffer, ignored otherwise)"
+                    ),
+                },
+                "mask_layer_id": {
+                    "type": "string",
+                    "description": (
+                        "Layer ID (UUID) of the POLYGON layer to clip against "
+                        "(required for clip, ignored otherwise). Must be a "
+                        "different layer from layer_id."
                     ),
                 },
             },

--- a/backend/tests/test_ai_chat_run_analysis.py
+++ b/backend/tests/test_ai_chat_run_analysis.py
@@ -14,6 +14,7 @@ Requirements:
 """
 
 import uuid
+from unittest.mock import patch
 
 import pytest
 from sqlalchemy import select, text
@@ -637,6 +638,66 @@ class TestRunAnalysisClipByLayer:
         assert "error" in result, result
         assert "polygon" in result["error"].lower()
         assert "POINT" in result["error"]
+
+    async def test_oversized_mask_layer_is_refused(self, test_db_session: AsyncSession):
+        """fix(#683 codex P1): a resource rail, not a correctness one. The
+        preview's _mask_pieces CTE materializes and subdivides every mask row
+        before the row cap can bite, so the work scales with the whole mask
+        however small the source is. The REST route rejects this in
+        _load_mask_dataset; exposing clip through chat without the same gate
+        would let one sentence tie up the shared database until timeout."""
+        admin = await _get_admin(test_db_session)
+        source = await _create_polygon_dataset(test_db_session, created_by=admin.id)
+        mask = await _create_mask_dataset(test_db_session, created_by=admin.id)
+        mask.feature_count = 1_001
+        await test_db_session.commit()
+
+        result = await _handle_run_analysis(
+            {
+                "layer_id": "layer-1",
+                "operation": "clip",
+                "mask_layer_id": "layer-2",
+            },
+            test_db_session,
+            admin,
+            await _default_port.get_user_roles(test_db_session, admin),
+            [_layer_for(source), _layer_for(mask, "layer-2")],
+            port=_default_port,
+        )
+        assert "error" in result, result
+        assert "too many features" in result["error"]
+        assert "geojson" not in result
+
+    async def test_unknown_mask_size_is_counted_live(
+        self, test_db_session: AsyncSession
+    ):
+        """fix(#701 review) parity: a NULL feature_count must not read as zero,
+        or the gate admits exactly the unknown-size layers it exists for. The
+        one-row mask table is counted live against a patched cap."""
+        admin = await _get_admin(test_db_session)
+        source = await _create_polygon_dataset(test_db_session, created_by=admin.id)
+        mask = await _create_mask_dataset(test_db_session, created_by=admin.id)
+        mask.feature_count = None
+        await test_db_session.commit()
+
+        with patch(
+            "app.platform.analysis_sql.MAX_MASK_LAYER_FEATURES",
+            0,
+        ):
+            result = await _handle_run_analysis(
+                {
+                    "layer_id": "layer-1",
+                    "operation": "clip",
+                    "mask_layer_id": "layer-2",
+                },
+                test_db_session,
+                admin,
+                await _default_port.get_user_roles(test_db_session, admin),
+                [_layer_for(source), _layer_for(mask, "layer-2")],
+                port=_default_port,
+            )
+        assert "error" in result, result
+        assert "too many features" in result["error"]
 
     async def test_user_id_is_still_readable_after_the_tool_returns(
         self, test_db_session: AsyncSession

--- a/backend/tests/test_ai_chat_run_analysis.py
+++ b/backend/tests/test_ai_chat_run_analysis.py
@@ -256,8 +256,14 @@ class TestRunAnalysisActionCollection:
         assert "truncated" not in action
         assert "row_count" not in action
 
-    def test_truncated_with_unknown_total_omits_the_pair(self) -> None:
-        """A dataset with no feature_count must not yield "500 of None"."""
+    def test_truncated_with_unknown_total_omits_the_count_not_the_flag(self) -> None:
+        """A result with no known total must not yield "500 of None".
+
+        fix(#683 codex P2): it must still say it was capped, though. This used
+        to drop the flag along with the count, which reads as a complete result
+        — fine while every chat operation reported a total, wrong the moment
+        clip (which filters rows, so it reports none) joined them.
+        """
         action = _collect_chat_action(
             "run_analysis",
             {"layer_id": "l1"},
@@ -270,8 +276,31 @@ class TestRunAnalysisActionCollection:
             },
         )
         assert action is not None
-        assert "truncated" not in action
+        assert action["truncated"] is True
         assert "row_count" not in action
+
+    def test_truncated_clip_discloses_the_cap_without_a_total(self) -> None:
+        """fix(#683 codex P2): clip filters rows, so the preview returns no
+        source_feature_count — the clipped total is genuinely unknown. Requiring
+        one dropped the disclosure entirely, presenting a capped clip preview as
+        the whole result. The flag rides alone; row_count stays absent."""
+        action = _collect_chat_action(
+            "run_analysis",
+            {"layer_id": "l1"},
+            {
+                "operation": "clip",
+                "layer_id": "l1",
+                "feature_count": 500,
+                "truncated": True,
+                "source_feature_count": None,
+                "geojson": {"type": "FeatureCollection", "features": []},
+                "bbox": [0, 0, 1, 1],
+            },
+        )
+        assert action is not None
+        assert action["truncated"] is True
+        assert "row_count" not in action
+        ChatAction(**action)
 
     def test_error_result_emits_no_action(self) -> None:
         action = _collect_chat_action(
@@ -574,6 +603,31 @@ class TestRunAnalysisClipByLayer:
         )
         assert "error" in result, result
         assert "different layer" in result["error"]
+
+    async def test_two_layers_over_one_dataset_are_refused(
+        self, test_db_session: AsyncSession
+    ):
+        """fix(#683 codex P2): a duplicated rendering is two layer ids over one
+        dataset, so comparing layer ids alone lets that pair through — and
+        clipping a table by itself is an expensive way to return the input."""
+        admin = await _get_admin(test_db_session)
+        source = await _create_polygon_dataset(test_db_session, created_by=admin.id)
+        result = await _handle_run_analysis(
+            {
+                "layer_id": "layer-1",
+                "operation": "clip",
+                "mask_layer_id": "layer-2",
+            },
+            test_db_session,
+            admin,
+            await _default_port.get_user_roles(test_db_session, admin),
+            # Same dataset, two renderings — distinct ids, identical data.
+            [_layer_for(source), _layer_for(source, "layer-2")],
+            port=_default_port,
+        )
+        assert "error" in result, result
+        assert "same dataset" in result["error"]
+        assert "geojson" not in result
 
     async def test_mask_layer_is_access_checked_independently(
         self, test_db_session: AsyncSession

--- a/backend/tests/test_ai_chat_run_analysis.py
+++ b/backend/tests/test_ai_chat_run_analysis.py
@@ -35,6 +35,8 @@ from app.platform.extensions.defaults import DefaultProcessingPort
 from tests.factories import create_dataset
 
 SQUARE = "POLYGON((0 0, 0 1, 1 1, 1 0, 0 0))"
+# Overlaps SQUARE's lower-left quarter only.
+MASK_QUARTER = "POLYGON((-0.5 -0.5, -0.5 0.5, 0.5 0.5, 0.5 -0.5, -0.5 -0.5))"
 
 _default_port = DefaultProcessingPort()
 
@@ -95,6 +97,45 @@ async def _create_polygon_dataset(
     )
 
 
+async def _create_mask_dataset(
+    session: AsyncSession,
+    *,
+    created_by: uuid.UUID,
+    visibility: str = "public",
+):
+    """feat(#683): a polygon layer usable as a clip mask.
+
+    Covers SQUARE's lower-left quarter, so a clip against it survives with a
+    genuinely smaller geometry rather than passing the whole input through.
+    """
+    table_name = f"ds_{uuid.uuid4().hex[:12]}"
+    await session.execute(
+        text(
+            f"CREATE TABLE data.{table_name} ("
+            f"  gid SERIAL PRIMARY KEY,"
+            f"  geom geometry(Polygon, 4326),"
+            f"  geom_4326 geometry(Polygon, 4326)"
+            f")"
+        )
+    )
+    await session.execute(
+        text(
+            f"INSERT INTO data.{table_name} (geom, geom_4326) VALUES "
+            f"(ST_GeomFromText('{MASK_QUARTER}', 4326),"
+            f" ST_GeomFromText('{MASK_QUARTER}', 4326))"
+        )
+    )
+    await session.commit()
+    return await create_dataset(
+        session,
+        created_by=created_by,
+        table_name=table_name,
+        geometry_type="POLYGON",
+        feature_count=1,
+        visibility=visibility,
+    )
+
+
 def _layer_for(dataset, layer_id: str = "layer-1") -> ChatMapLayer:
     return ChatMapLayer(
         id=layer_id,
@@ -129,12 +170,19 @@ class TestRunAnalysisToolSelection:
         assert "run_analysis" not in edit_names
         assert "set_style" in edit_names
 
-    def test_clip_and_dissolve_are_not_offered(self) -> None:
-        """clip needs a drawn mask and dissolve is materialize-only; neither
-        can be driven from chat, so the enum must not tempt the model."""
+    def test_clip_is_offered_and_dissolve_is_not(self) -> None:
+        """feat(#683): clip joined the enum once #682 shipped the layer mask.
+        dissolve stays out on its own merits — materialize-only, an aggregate
+        with no preview shape — so the enum must not tempt the model with it."""
         tool = next(t for t in CHAT_TOOLS_ANTHROPIC if t["name"] == "run_analysis")
-        ops = tool["input_schema"]["properties"]["operation"]["enum"]
-        assert sorted(ops) == ["buffer", "centroid"]
+        props = tool["input_schema"]["properties"]
+        assert sorted(props["operation"]["enum"]) == ["buffer", "centroid", "clip"]
+        # The mask is a LAYER, never a drawn polygon: the chat surface has no
+        # way to draw one, and the schema must not suggest otherwise.
+        assert "mask_layer_id" in props
+        assert "mask" not in props
+        # Optional, because the other two operations do not take one.
+        assert sorted(tool["input_schema"]["required"]) == ["layer_id", "operation"]
 
 
 # ---------------------------------------------------------------------------
@@ -432,6 +480,191 @@ class TestRunAnalysisHandler:
         )
         assert "error" in result, result
         assert "geojson" not in result
+
+
+class TestRunAnalysisClipByLayer:
+    """feat(#683): the two-layer operation. What matters is that the SECOND
+    dataset gets its own Rule-1 check — seeing the source buys no claim on the
+    mask — and that a mask that cannot clip is refused with something the model
+    can act on rather than an empty result reported as an answer."""
+
+    async def test_clip_by_layer_preview(self, test_db_session: AsyncSession):
+        admin = await _get_admin(test_db_session)
+        source = await _create_polygon_dataset(test_db_session, created_by=admin.id)
+        mask = await _create_mask_dataset(test_db_session, created_by=admin.id)
+        result = await _handle_run_analysis(
+            {
+                "layer_id": "layer-1",
+                "operation": "clip",
+                "mask_layer_id": "layer-2",
+            },
+            test_db_session,
+            admin,
+            await _default_port.get_user_roles(test_db_session, admin),
+            [_layer_for(source), _layer_for(mask, "layer-2")],
+            port=_default_port,
+        )
+        assert "error" not in result, result
+        assert result["operation"] == "clip"
+        # The mask covers the source square's lower-left quarter, so the
+        # survivor is a real clipped polygon rather than the whole input.
+        assert result["feature_count"] == 1
+        geometry = result["geojson"]["features"][0]["geometry"]
+        assert geometry["type"] in ("Polygon", "MultiPolygon")
+        assert len(result["bbox"]) == 4
+        assert result["bbox"][2] < 1.0
+
+    async def test_mask_layer_not_on_the_map_is_rejected(
+        self, test_db_session: AsyncSession
+    ):
+        admin = await _get_admin(test_db_session)
+        source = await _create_polygon_dataset(test_db_session, created_by=admin.id)
+        result = await _handle_run_analysis(
+            {
+                "layer_id": "layer-1",
+                "operation": "clip",
+                "mask_layer_id": "not-on-this-map",
+            },
+            test_db_session,
+            admin,
+            await _default_port.get_user_roles(test_db_session, admin),
+            [_layer_for(source)],
+            port=_default_port,
+        )
+        assert "error" in result, result
+        assert "mask_layer_id" in result["error"]
+        assert "geojson" not in result
+
+    async def test_clip_without_a_mask_layer_is_rejected(
+        self, test_db_session: AsyncSession
+    ):
+        """The schema marks mask_layer_id optional (the other operations do not
+        take one), so a model can omit it. That must read as a fixable mistake,
+        not as an empty result."""
+        admin = await _get_admin(test_db_session)
+        source = await _create_polygon_dataset(test_db_session, created_by=admin.id)
+        result = await _handle_run_analysis(
+            {"layer_id": "layer-1", "operation": "clip"},
+            test_db_session,
+            admin,
+            await _default_port.get_user_roles(test_db_session, admin),
+            [_layer_for(source)],
+            port=_default_port,
+        )
+        assert "error" in result, result
+        assert "mask_layer_id" in result["error"]
+
+    async def test_clipping_a_layer_by_itself_is_rejected(
+        self, test_db_session: AsyncSession
+    ):
+        admin = await _get_admin(test_db_session)
+        source = await _create_polygon_dataset(test_db_session, created_by=admin.id)
+        result = await _handle_run_analysis(
+            {
+                "layer_id": "layer-1",
+                "operation": "clip",
+                "mask_layer_id": "layer-1",
+            },
+            test_db_session,
+            admin,
+            await _default_port.get_user_roles(test_db_session, admin),
+            [_layer_for(source)],
+            port=_default_port,
+        )
+        assert "error" in result, result
+        assert "different layer" in result["error"]
+
+    async def test_mask_layer_is_access_checked_independently(
+        self, test_db_session: AsyncSession
+    ):
+        """AGENTS.md Rule 1 applies to BOTH datasets. A caller who can read the
+        source but not the mask gets a refusal, not a preview — the layer list
+        is client-supplied, so naming a private dataset as the mask must not
+        read it."""
+        admin = await _get_admin(test_db_session)
+        other = await _create_other_user(test_db_session)
+        source = await _create_polygon_dataset(
+            test_db_session, created_by=admin.id, visibility="public"
+        )
+        private_mask = await _create_mask_dataset(
+            test_db_session, created_by=admin.id, visibility="private"
+        )
+        result = await _handle_run_analysis(
+            {
+                "layer_id": "layer-1",
+                "operation": "clip",
+                "mask_layer_id": "layer-2",
+            },
+            test_db_session,
+            other,
+            await _default_port.get_user_roles(test_db_session, other),
+            [_layer_for(source), _layer_for(private_mask, "layer-2")],
+            port=_default_port,
+        )
+        assert "error" in result, result
+        assert "access" in result["error"].lower()
+        assert "mask" in result["error"].lower()
+        assert "geojson" not in result
+
+    async def test_non_polygonal_mask_layer_is_refused(
+        self, test_db_session: AsyncSession
+    ):
+        """Unioning points or lines yields a mask that clips nothing
+        meaningful. Refused with the shape named, matching what the REST route
+        does in _load_mask_dataset — otherwise the model reports an empty
+        result as a real answer."""
+        admin = await _get_admin(test_db_session)
+        source = await _create_polygon_dataset(test_db_session, created_by=admin.id)
+        # No physical table needed: the shape check refuses it before any SQL
+        # is built, which is the point — a bad mask must cost nothing.
+        point_mask = await create_dataset(
+            test_db_session,
+            created_by=admin.id,
+            geometry_type="POINT",
+        )
+        result = await _handle_run_analysis(
+            {
+                "layer_id": "layer-1",
+                "operation": "clip",
+                "mask_layer_id": "layer-2",
+            },
+            test_db_session,
+            admin,
+            await _default_port.get_user_roles(test_db_session, admin),
+            [_layer_for(source), _layer_for(point_mask, "layer-2")],
+            port=_default_port,
+        )
+        assert "error" in result, result
+        assert "polygon" in result["error"].lower()
+        assert "POINT" in result["error"]
+
+    async def test_user_id_is_still_readable_after_the_tool_returns(
+        self, test_db_session: AsyncSession
+    ):
+        """fix(#716): chat must NOT pass release_session=True. The rollback
+        that returns the pooled connection expires every ORM instance on the
+        session, the authenticated User included, so the next `user.id` read
+        would raise MissingGreenlet. Both chat paths do exactly that read after
+        the tool returns, which is why this is a test and not a comment."""
+        admin = await _get_admin(test_db_session)
+        source = await _create_polygon_dataset(test_db_session, created_by=admin.id)
+        mask = await _create_mask_dataset(test_db_session, created_by=admin.id)
+        result = await _handle_run_analysis(
+            {
+                "layer_id": "layer-1",
+                "operation": "clip",
+                "mask_layer_id": "layer-2",
+            },
+            test_db_session,
+            admin,
+            await _default_port.get_user_roles(test_db_session, admin),
+            [_layer_for(source), _layer_for(mask, "layer-2")],
+            port=_default_port,
+        )
+        assert "error" not in result, result
+        # Would raise MissingGreenlet on an expired instance.
+        assert admin.id is not None
+        assert admin.username is not None
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_ai_chat_run_analysis.py
+++ b/backend/tests/test_ai_chat_run_analysis.py
@@ -699,6 +699,61 @@ class TestRunAnalysisClipByLayer:
         assert "error" in result, result
         assert "too many features" in result["error"]
 
+    async def test_a_legacy_port_still_serves_buffer_and_centroid(
+        self, test_db_session: AsyncSession
+    ):
+        """fix(#683 codex P1): a separately distributed overlay implementing the
+        PRE-clip ProcessingPort rejects an unknown `mask_dataset` keyword. If
+        the caller passed it unconditionally, every chat analysis against such
+        an overlay would break rather than only the new operation — so it rides
+        along only when set, the same shape router_analysis._defer uses for the
+        materialize task. An overlay that declares its version fails loudly at
+        load instead; this is for the legacy undeclared ones, which only warn.
+        """
+
+        class LegacyPort:
+            """The port as it was before this change: no mask_dataset."""
+
+            def __init__(self, inner):
+                self._inner = inner
+
+            def __getattr__(self, name):
+                return getattr(self._inner, name)
+
+            async def run_analysis_preview(
+                self,
+                session,
+                dataset,
+                operation,
+                *,
+                user_id,
+                distance_meters=None,
+                mask=None,
+            ):
+                return await self._inner.run_analysis_preview(
+                    session,
+                    dataset,
+                    operation,
+                    user_id=user_id,
+                    distance_meters=distance_meters,
+                    mask=mask,
+                )
+
+        admin = await _get_admin(test_db_session)
+        source = await _create_polygon_dataset(test_db_session, created_by=admin.id)
+        legacy = LegacyPort(_default_port)
+
+        result = await _handle_run_analysis(
+            {"layer_id": "layer-1", "operation": "centroid"},
+            test_db_session,
+            admin,
+            await _default_port.get_user_roles(test_db_session, admin),
+            [_layer_for(source)],
+            port=legacy,
+        )
+        assert "error" not in result, result
+        assert result["geojson"]["features"][0]["geometry"]["type"] == "Point"
+
     async def test_user_id_is_still_readable_after_the_tool_returns(
         self, test_db_session: AsyncSession
     ):

--- a/backend/tests/test_extension_api_version.py
+++ b/backend/tests/test_extension_api_version.py
@@ -44,11 +44,21 @@ class TestExtensionApiVersionConstant:
             f"EXTENSION_API_VERSION must be int, got {type(EXTENSION_API_VERSION)}"
         )
 
-    def test_version_matches_required_connector_contract(self):
-        """v2 covers the required connector discovery/dispatch methods."""
+    def test_version_matches_required_overlay_contract(self):
+        """The constant is pinned so a bump has to be a deliberate act.
+
+        v2 covered the required connector discovery/dispatch methods. v3 adds
+        the ``mask_dataset`` keyword to ``ProcessingPort.run_analysis_preview``
+        (feat(#683), chat clip-by-layer) — the ``processing_port`` registry key
+        is overlay-populated, so changing that method's signature changes the
+        expected type of a registry key, which version.py's bump convention
+        names explicitly.
+
+        Update this pin, and the note above it, whenever the constant moves.
+        """
         from app.platform.extensions.version import EXTENSION_API_VERSION
 
-        assert EXTENSION_API_VERSION == 2
+        assert EXTENSION_API_VERSION == 3
 
 
 class TestCheckExtensionApiVersion:

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -931,13 +931,14 @@ def test_decomposed_service_modules_stay_within_size_budgets() -> None:
         # module should get its own review.
         "backend/app/platform/extensions/defaults_ai_openai.py": 444,
         "backend/app/platform/extensions/defaults_catalog_port.py": 398,
-        # feat(#683): +37 — run_analysis_preview carries a clip mask DATASET
+        # feat(#683): +58 — run_analysis_preview carries a clip mask DATASET
         # now, which costs a widened signature (one param per line once ruff
-        # wraps it) plus the polygon/table shape gate. The gate lives here on
-        # purpose: it is the rail router_analysis._load_mask_dataset applies,
-        # and putting it at the port gives every caller the same refusal
-        # instead of an empty preview. Cap 406 → 450 (~7 headroom).
-        "backend/app/platform/extensions/defaults_processing_port.py": 450,
+        # wraps it) plus the mask's shape and size gates. Those live here on
+        # purpose: they are the rails router_analysis._load_mask_dataset
+        # applies, and putting them at the port gives every caller the same
+        # refusal instead of an empty preview or an unbounded mask subdivide.
+        # Cap 406 → 470 (~6 headroom).
+        "backend/app/platform/extensions/defaults_processing_port.py": 470,
         # fix(#929): +2 over the 350 default — the creator exemption on the
         # restricted branch of filter_visible/can_access_dataset plus its
         # rationale comments. Cap exact, zero headroom.

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -931,7 +931,13 @@ def test_decomposed_service_modules_stay_within_size_budgets() -> None:
         # module should get its own review.
         "backend/app/platform/extensions/defaults_ai_openai.py": 444,
         "backend/app/platform/extensions/defaults_catalog_port.py": 398,
-        "backend/app/platform/extensions/defaults_processing_port.py": 406,
+        # feat(#683): +37 — run_analysis_preview carries a clip mask DATASET
+        # now, which costs a widened signature (one param per line once ruff
+        # wraps it) plus the polygon/table shape gate. The gate lives here on
+        # purpose: it is the rail router_analysis._load_mask_dataset applies,
+        # and putting it at the port gives every caller the same refusal
+        # instead of an empty preview. Cap 406 → 450 (~7 headroom).
+        "backend/app/platform/extensions/defaults_processing_port.py": 450,
         # fix(#929): +2 over the 350 default — the creator exemption on the
         # restricted branch of filter_visible/can_access_dataset plus its
         # rationale comments. Cap exact, zero headroom.

--- a/backend/tests/test_processing_port.py
+++ b/backend/tests/test_processing_port.py
@@ -96,7 +96,16 @@ class FakeProcessingPort:
         return {"viewer"}
 
     async def run_analysis_preview(
-        self, session, dataset, operation, *, user_id, distance_meters=None, mask=None
+        self,
+        session,
+        dataset,
+        operation,
+        *,
+        user_id,
+        distance_meters=None,
+        mask=None,
+        # feat(#683): the protocol carries a mask DATASET for clip-by-layer.
+        mask_dataset=None,
     ):
         return None
 


### PR DESCRIPTION
Acceptance criteria 1, 2, 3, 4, 5, 7 and 8 of #683. **Criterion 6 is not included**, so this does not close the issue — see below.

## The tool schema

`operation` gains `clip`, and `mask_layer_id` joins it. The comment that justified the old narrowing said clip needs a drawn mask polygon only the Analysis rail can supply; #682 shipped the layer-mask alternative and that stopped being true, so it is rewritten rather than left to mislead the next reader. `dissolve` stays out on its own merits — materialize-only, an aggregate with no preview shape.

`mask_layer_id` is optional in the schema because the other two operations do not take one, so a model can omit it on a clip. That reads as a fixable mistake with a named parameter, not as an empty result.

## The ProcessingPort seam

`run_analysis_preview` carries a mask **dataset**, passed as the loaded object rather than an id: the caller owns its visibility check exactly as it owns the source dataset's, and the port never checks visibility for anyone. Protocol and default shim move together. No in-repo overlay implements this method — the only other implementation is the stub in `tests/test_processing_port.py`, widened here. **An out-of-repo overlay implementing `ProcessingPort` needs the same parameter**, which is worth knowing before this ships.

The shim also gates the mask's shape (polygonal, and backed by a real table). That is the rail `router_analysis._load_mask_dataset` applies on the REST side, and putting it at the port means every caller gets the same refusal rather than an empty preview the model would report as a real answer.

The `_drop_params_for_other_operations` trap the issue flags is handled by threading the mask object past the request and ignoring it unless the operation is clip — the same shape the validator enforces on `mask_dataset_id`.

## Access control

The mask layer is resolved against the map's layer list and authorized **independently** of the source. Rule 1 applies to both datasets of a two-layer operation, and the layer list is client-supplied either way, so seeing the source buys no claim on the mask. `_resolve_layer_dataset` is now shared by both so they cannot drift. A user who can read the source but not the mask gets a refusal, pinned by `test_mask_layer_is_access_checked_independently`.

## release_session

Chat does **not** pass it, and `test_user_id_is_still_readable_after_the_tool_returns` exercises a post-tool `user.id` read so a future regression surfaces as a test failure rather than a runtime 500. The rollback that returns the pooled connection expires every ORM instance on the session, the authenticated `User` included; the REST endpoint qualifies because it reads nothing afterwards, and copying that call site verbatim is the natural mistake.

## Not included

**Criterion 6** (the #675 handoff prefilling operation, source and mask layer into the Analysis panel) is untouched, along with the two files that would carry it: the union at `use-ephemeral-layers.ts:16` and the producer ternary at `ChatPanel.tsx:525`. Widening either without the panel's `maskLayerId` initializer would make "Save as dataset" appear and prefill a clip with no mask — a state Create cannot submit. All three move together in a follow-up.

Today a chat clip preview renders as an overlay and is simply not offered "Save as dataset": `ChatPanel.tsx:525-534` builds the handoff only for buffer and centroid, so `onSaveAsDataset` is undefined and `EphemeralBadge` renders no button.

The worker's `operation == "clip"` guard at `analysis/tasks.py:643-652` is out of scope per the issue body — chat is preview-only and never enqueues a materialize, so no chat-originated mask reaches the worker.

## Line budget

`defaults_processing_port.py` goes 406 → 450 in `test_layering.py`, with the reason recorded inline next to the cap. The growth is the widened signature (ruff wraps eight params one per line) plus the shape gate.

## Verification

```
cd backend && set -a && source ../.env.test && set +a
uv run pytest tests/test_ai_chat_run_analysis.py tests/test_processing_port.py \
  tests/test_layering.py tests/test_extensions.py tests/test_analysis_preview.py \
  tests/test_analysis_materialize.py -q        # 217 passed
uv run pytest tests/test_*chat*.py tests/test_ai_*.py -q                # 193 passed
uv run ruff check . && uv run ruff format --check .
```

API impact: the chat tool schema gains an operation and a parameter; no REST contract, schema or migration change. Security impact: one new cross-dataset access path, checked per Rule 1 on both datasets.

Refs #683

## Extension API version

`EXTENSION_API_VERSION` goes 2 → 3. `processing_port` is an overlay-populated registry key and `run_analysis_preview`'s signature changed, so an overlay built against the old shape receives something it was not written for; version.py's bump convention names exactly that case. An overlay declaring v2 now fails loudly at load rather than misbehaving downstream.

The compatibility guard is the complement, not the substitute: the caller omits `mask_dataset` entirely when it is None, so a legacy overlay that declares no version (and therefore only warns) keeps working for buffer and centroid.

**Release coordination — read this before sequencing.** #1073 (the audience-predicate seam out of #1068) also needs a bump when it lands. If both ship in the same release, **one v3 covers both** and the overlay team coordinates once. If this PR spends 2 → 3 now and #1073 spends 3 → 4 later in the same cycle, that is two coordination events for one release, which is the part that actually costs them. Whoever sequences the release should make them ride the same v3.
