### PR TITLE
test(ci): parse the merge_group conditions instead of scanning them

### DIFF
--- a/backend/tests/test_ci_merge_queue.py
+++ b/backend/tests/test_ci_merge_queue.py
@@ -51,30 +51,40 @@ def _runs_on_merge_group(job: dict) -> bool:
     the run, and ``always() && <clause>`` still evaluates ``<clause>``. So it is
     stripped before looking at event context — treating its presence as "runs
     everywhere" would report ``e2e-test`` and ``accessibility`` as running in
-    the queue when their event allowlists provably exclude it, and a guard that
-    is wrong toward "all clear" is worse than no guard because you stop looking.
+    the queue when their event allowlists provably exclude it.
 
-    After that: no ``github.event_name`` comparison at all means no event gate,
-    so the job runs. Comparisons present mean the job runs only if
-    ``merge_group`` is among the permitted ones.
+    After stripping: nothing left means no gate at all, so the job runs. A
+    ``github.event_name`` comparison means the job runs only if ``merge_group``
+    is among the permitted ones.
 
-    Known limit, stated rather than papered over: this reads the SET of event
-    comparisons, not the boolean structure around them. A condition that
-    permits `merge_group` inside one branch of an `||` while a sibling `&&`
-    excludes it would be read as running. No such condition exists in
-    ``ci.yml``, and the honest fix if one appears is to evaluate the
-    expression, not to add another special case here.
+    **Anything else is reported as NOT running** (fix(#1074 review), a P1). The
+    tempting reading — "no event comparison, therefore no event gate, therefore
+    it runs" — is wrong for the shape this repo actually uses. A bare
+    ``needs.changes.outputs.backend == 'true'`` has no event clause, but the
+    ``changes`` job deliberately SKIPS its paths-filter step on ``merge_group``
+    (it has no base ref to diff), so those outputs are empty there and the job
+    skips. Reading that as "runs" is precisely the false all-clear this guard
+    exists to prevent, in the guard itself.
+
+    So the default is conservative: a condition this cannot prove runs is
+    reported as skipping. That direction is deliberate. A false alarm costs
+    someone ten minutes of looking; a false all-clear costs an untested merge
+    and nobody looks at all. If a legitimate new shape trips it, the answer is
+    to teach this function that shape — or evaluate the expression properly —
+    not to widen the fallback.
     """
     condition = job.get("if")
     if condition is None:
-        return True  # unconditional job
-    cond = " ".join(str(condition).split()).replace("always()", "")
+        return True  # no gate
+    cond = " ".join(str(condition).split()).replace("always()", "").strip()
+    if not cond or cond == "&&":
+        return True  # bare always()
     if "merge_group" in _EVENT_NE.findall(cond):
         return False  # explicitly excluded
     permitted = _EVENT_EQ.findall(cond)
-    if not permitted:
-        return True  # no event gate
-    return "merge_group" in permitted
+    if permitted:
+        return "merge_group" in permitted
+    return False  # unrecognised: cannot prove it runs, so report it
 
 
 def test_ci_reacts_to_merge_group():
@@ -215,3 +225,26 @@ def test_predicate_agrees_with_the_real_workflow():
             f"{name} is deliberately off merge_group; if that changed, the "
             "non-gating-jobs decision in #1000 needs revisiting"
         )
+
+
+def test_predicate_bare_output_condition_reports_as_skipping():
+    """fix(#1074 review), P1. The shape that made "no event comparison means
+    no event gate" wrong.
+
+    `changes` skips its paths-filter step on merge_group — it has no base ref
+    to diff — so `needs.changes.outputs.*` are EMPTY there and a job gated only
+    on one of them really does skip. Reading it as running is the false
+    all-clear this whole file exists to prevent, reproduced inside the guard.
+    """
+    condition = "needs.changes.outputs.backend == 'true'"
+    assert _runs_on_merge_group({"if": condition}) is False
+
+
+def test_predicate_unrecognised_condition_reports_as_skipping():
+    """The general form of the same rule: what cannot be proven to run is
+    reported. A false alarm costs ten minutes; a false all-clear costs an
+    untested merge and nobody looks."""
+    assert (
+        _runs_on_merge_group({"if": "github.repository == 'geolens-io/geolens'"})
+        is False
+    )

--- a/backend/tests/test_ci_merge_queue.py
+++ b/backend/tests/test_ci_merge_queue.py
@@ -43,6 +43,64 @@ _EVENT_EQ = re.compile(r"github\.event_name\s*==\s*['\"]([^'\"]+)['\"]")
 _EVENT_NE = re.compile(r"github\.event_name\s*!=\s*['\"]([^'\"]+)['\"]")
 
 
+def _top_level_or_split(cond: str) -> list[str]:
+    """Split on ``||`` at paren depth zero. Nested groups stay intact."""
+    parts, depth, buf, i = [], 0, [], 0
+    while i < len(cond):
+        c = cond[i]
+        if c == "(":
+            depth += 1
+        elif c == ")":
+            depth -= 1
+        elif depth == 0 and cond.startswith("||", i):
+            parts.append("".join(buf))
+            buf, i = [], i + 2
+            continue
+        buf.append(c)
+        i += 1
+    parts.append("".join(buf))
+    return [pp.strip() for pp in parts if pp.strip()]
+
+
+def _wraps_whole(part: str) -> bool:
+    """True when the outer parens enclose the WHOLE expression.
+
+    `(a || b)` does; `(a) && (b)` does not, and stripping its outer characters
+    would produce `a) && (b`.
+    """
+    if not (part.startswith("(") and part.endswith(")")):
+        return False
+    depth = 0
+    for i, c in enumerate(part):
+        depth += (c == "(") - (c == ")")
+        if depth == 0 and i < len(part) - 1:
+            return False
+    return depth == 0
+
+
+def _satisfied_by_merge_group_alone(part: str) -> bool:
+    """True when this branch is satisfied by ``merge_group`` and nothing else.
+
+    fix(#1074 review), a second P1. Asking "does `merge_group` appear among the
+    equality comparisons" accepted it wherever it sat, including inside a
+    conjunction: ``github.event_name == 'merge_group' && needs.changes.outputs
+    .backend == 'true'`` returned True, while the `changes` job leaves that
+    output empty in the queue so the gate really skips. The equality appearing
+    is not the equality deciding.
+
+    So: unwrap enclosing parens, recurse through ``||``, and accept a leaf only
+    when it is exactly the merge_group equality. Anything conjoined with it
+    might be false and this cannot evaluate it.
+    """
+    part = part.strip()
+    while _wraps_whole(part):
+        part = part[1:-1].strip()
+    branches = _top_level_or_split(part)
+    if len(branches) > 1:
+        return any(_satisfied_by_merge_group_alone(b) for b in branches)
+    return bool(re.fullmatch(r"github\.event_name\s*==\s*['\"]merge_group['\"]", part))
+
+
 def _runs_on_merge_group(job: dict) -> bool:
     """Whether ``job``'s ``if:`` lets it run on a ``merge_group`` event.
 
@@ -53,38 +111,37 @@ def _runs_on_merge_group(job: dict) -> bool:
     everywhere" would report ``e2e-test`` and ``accessibility`` as running in
     the queue when their event allowlists provably exclude it.
 
-    After stripping: nothing left means no gate at all, so the job runs. A
-    ``github.event_name`` comparison means the job runs only if ``merge_group``
-    is among the permitted ones.
+    After stripping: nothing left means no gate at all, so the job runs.
+    Otherwise the condition is split into top-level ``||`` disjuncts, and the
+    job is reported as running only when **some disjunct is satisfied by
+    merge_group alone** — the shape every gated job in ``ci.yml`` actually
+    uses. A disjunct that conjoins the equality with anything else does not
+    count, because the other conjunct may be false and this cannot evaluate it.
 
-    **Anything else is reported as NOT running** (fix(#1074 review), a P1). The
-    tempting reading — "no event comparison, therefore no event gate, therefore
-    it runs" — is wrong for the shape this repo actually uses. A bare
-    ``needs.changes.outputs.backend == 'true'`` has no event clause, but the
-    ``changes`` job deliberately SKIPS its paths-filter step on ``merge_group``
-    (it has no base ref to diff), so those outputs are empty there and the job
-    skips. Reading that as "runs" is precisely the false all-clear this guard
-    exists to prevent, in the guard itself.
+    **Everything else is reported as NOT running.** Two P1s came from the
+    opposite default. A bare ``needs.changes.outputs.backend == 'true'`` has no
+    event clause at all, but ``changes`` skips its paths-filter step in the
+    queue so those outputs are empty and the job skips. And the equality
+    appearing inside a conjunction is not the equality deciding. Both read as
+    "runs" under a permissive rule, which is the green-CI-OK-over-skipped-gates
+    failure this file exists to detect.
 
-    So the default is conservative: a condition this cannot prove runs is
-    reported as skipping. That direction is deliberate. A false alarm costs
-    someone ten minutes of looking; a false all-clear costs an untested merge
-    and nobody looks at all. If a legitimate new shape trips it, the answer is
-    to teach this function that shape — or evaluate the expression properly —
-    not to widen the fallback.
+    The direction is deliberate: a false alarm costs someone ten minutes; a
+    false all-clear costs an untested merge and nobody looks. If a legitimate
+    new shape trips it, teach this function that shape or evaluate the
+    expression — do not widen the fallback.
     """
     condition = job.get("if")
     if condition is None:
         return True  # no gate
     cond = " ".join(str(condition).split()).replace("always()", "").strip()
-    if not cond or cond == "&&":
+    while cond.startswith("&&"):
+        cond = cond[2:].strip()
+    if not cond:
         return True  # bare always()
     if "merge_group" in _EVENT_NE.findall(cond):
         return False  # explicitly excluded
-    permitted = _EVENT_EQ.findall(cond)
-    if permitted:
-        return "merge_group" in permitted
-    return False  # unrecognised: cannot prove it runs, so report it
+    return any(_satisfied_by_merge_group_alone(p) for p in _top_level_or_split(cond))
 
 
 def test_ci_reacts_to_merge_group():
@@ -248,3 +305,33 @@ def test_predicate_unrecognised_condition_reports_as_skipping():
         _runs_on_merge_group({"if": "github.repository == 'geolens-io/geolens'"})
         is False
     )
+
+
+def test_predicate_merge_group_inside_a_conjunction_reports_as_skipping():
+    """fix(#1074 review), the second P1. The equality APPEARING is not the
+    equality DECIDING. `changes` leaves its outputs empty in the queue, so this
+    gate really skips — and a membership test called it running."""
+    condition = (
+        "github.event_name == 'merge_group' && needs.changes.outputs.backend == 'true'"
+    )
+    assert _runs_on_merge_group({"if": condition}) is False
+
+
+def test_predicate_merge_group_in_a_parenthesised_disjunct_runs():
+    """The control: a real disjunct satisfied by merge_group alone still runs,
+    including when the whole allowlist is wrapped in parens."""
+    condition = (
+        "always() && (github.event_name == 'push' "
+        "|| github.event_name == 'merge_group')"
+    )
+    assert _runs_on_merge_group({"if": condition}) is True
+
+
+def test_predicate_nested_conjunction_beside_a_clean_disjunct_runs():
+    """A conjunctive branch does not poison a sibling that stands alone —
+    e2e-smoke is exactly this shape."""
+    condition = (
+        "(github.event_name == 'pull_request' && needs.changes.outputs.e2e == 'true') "
+        "|| github.event_name == 'merge_group'"
+    )
+    assert _runs_on_merge_group({"if": condition}) is True

--- a/backend/tests/test_ci_merge_queue.py
+++ b/backend/tests/test_ci_merge_queue.py
@@ -18,6 +18,7 @@ repository-admin setting, not a file in this repo.
 """
 
 import pathlib
+import re
 
 import pytest
 import yaml
@@ -35,11 +36,45 @@ def _triggers(wf: dict) -> dict:
     return wf.get("on") or wf.get(True) or {}
 
 
+# fix(#1051 follow-up): PARSE, DON'T SCAN. The first version of this predicate
+# asked `"merge_group" in condition`, which is a substring match on an
+# expression language and gets two shapes wrong in opposite directions.
+_EVENT_EQ = re.compile(r"github\.event_name\s*==\s*['\"]([^'\"]+)['\"]")
+_EVENT_NE = re.compile(r"github\.event_name\s*!=\s*['\"]([^'\"]+)['\"]")
+
+
 def _runs_on_merge_group(job: dict) -> bool:
+    """Whether ``job``'s ``if:`` lets it run on a ``merge_group`` event.
+
+    ``always()`` is a STATUS-check function: it means "run even if the jobs I
+    need failed or were cancelled". It says nothing about which event triggered
+    the run, and ``always() && <clause>`` still evaluates ``<clause>``. So it is
+    stripped before looking at event context — treating its presence as "runs
+    everywhere" would report ``e2e-test`` and ``accessibility`` as running in
+    the queue when their event allowlists provably exclude it, and a guard that
+    is wrong toward "all clear" is worse than no guard because you stop looking.
+
+    After that: no ``github.event_name`` comparison at all means no event gate,
+    so the job runs. Comparisons present mean the job runs only if
+    ``merge_group`` is among the permitted ones.
+
+    Known limit, stated rather than papered over: this reads the SET of event
+    comparisons, not the boolean structure around them. A condition that
+    permits `merge_group` inside one branch of an `||` while a sibling `&&`
+    excludes it would be read as running. No such condition exists in
+    ``ci.yml``, and the honest fix if one appears is to evaluate the
+    expression, not to add another special case here.
+    """
     condition = job.get("if")
     if condition is None:
         return True  # unconditional job
-    return "merge_group" in str(condition)
+    cond = " ".join(str(condition).split()).replace("always()", "")
+    if "merge_group" in _EVENT_NE.findall(cond):
+        return False  # explicitly excluded
+    permitted = _EVENT_EQ.findall(cond)
+    if not permitted:
+        return True  # no event gate
+    return "merge_group" in permitted
 
 
 def test_ci_reacts_to_merge_group():
@@ -107,3 +142,76 @@ def test_changes_job_does_not_pretend_to_have_filtered_the_queue():
         "the paths-filter step must be skipped on merge_group; with no base to "
         f"diff against its outputs cannot be trusted. Found: {condition!r}"
     )
+
+
+# ---------------------------------------------------------------------------
+# The predicate itself. fix(#1051 follow-up): the first version substring-matched
+# "merge_group" in the condition, which cried wolf on `always()` — reporting a
+# job as skipping when it always runs. The obvious repair, also matching
+# "always()", would have been worse: it reports `always() && (event_name ==
+# 'push' || ...)` as running when that provably skips in the queue, turning a
+# false alarm into a false all-clear in the one tool meant to answer step 1 of a
+# queue incident. Neither is fixable by adding literals to a string match, which
+# is the actual lesson. These four cases exist to stop the next person trying.
+# ---------------------------------------------------------------------------
+
+
+def test_predicate_bare_always_runs():
+    """`always()` is a status check, not an event gate. `ci-ok` is this shape."""
+    assert _runs_on_merge_group({"if": "always()"}) is True
+
+
+def test_predicate_always_with_allowlist_excluding_merge_group_skips():
+    """The shape the naive `always()` repair got backwards. `e2e-test` and
+    `accessibility` are both written this way and both skip in the queue."""
+    condition = (
+        "always() && (github.event_name == 'push' "
+        "|| github.event_name == 'schedule' "
+        "|| github.event_name == 'workflow_dispatch') "
+        "&& !contains(needs.*.result, 'failure')"
+    )
+    assert _runs_on_merge_group({"if": condition}) is False
+
+
+def test_predicate_always_with_allowlist_including_merge_group_runs():
+    condition = (
+        "always() && (github.event_name == 'push' "
+        "|| github.event_name == 'merge_group')"
+    )
+    assert _runs_on_merge_group({"if": condition}) is True
+
+
+def test_predicate_no_condition_runs():
+    """`changes`, `pre-commit`, `version-coherence` and `docs-contract`."""
+    assert _runs_on_merge_group({}) is True
+
+
+def test_predicate_path_filtered_shape_runs():
+    """The twelve gated jobs #1051 fixed, in their actual written form."""
+    condition = (
+        "needs.changes.outputs.backend == 'true' "
+        "|| github.event_name == 'push' "
+        "|| github.event_name == 'merge_group'"
+    )
+    assert _runs_on_merge_group({"if": condition}) is True
+
+
+def test_predicate_explicit_exclusion_skips():
+    """`!=` is an exclusion, and a substring match reads it as permission —
+    the same class of error as the `always()` one. The `paths-filter` STEP is
+    written this way; no job is today, and the predicate should not care."""
+    assert _runs_on_merge_group({"if": "github.event_name != 'merge_group'"}) is False
+
+
+def test_predicate_agrees_with_the_real_workflow():
+    """Cross-check against ci.yml rather than only synthetic conditions: every
+    job whose condition names merge_group must read as running, and the
+    push/schedule-only jobs must read as skipping."""
+    jobs = _workflow()["jobs"]
+    for name in jobs["ci-ok"]["needs"]:
+        assert _runs_on_merge_group(jobs[name]), f"{name} must run in the queue"
+    for name in ("e2e-test", "accessibility", "stac-validate"):
+        assert not _runs_on_merge_group(jobs[name]), (
+            f"{name} is deliberately off merge_group; if that changed, the "
+            "non-gating-jobs decision in #1000 needs revisiting"
+        )

--- a/backend/tests/test_ci_merge_queue.py
+++ b/backend/tests/test_ci_merge_queue.py
@@ -133,12 +133,21 @@ def _runs_on_merge_group(job: dict) -> bool:
     """
     condition = job.get("if")
     if condition is None:
-        return True  # no gate
-    cond = " ".join(str(condition).split()).replace("always()", "").strip()
+        return True  # no `if:` key at all — no gate
+    raw = " ".join(str(condition).split())
+    if not raw:
+        # fix(#1074 review): `if: ""` is NOT the same as no `if:`. GitHub
+        # evaluates an empty condition as falsy and skips the job, while
+        # normalisation made it indistinguishable from the bare always() case
+        # and reported it as running — the same false all-clear again.
+        return False
+    cond = raw.replace("always()", "").strip()
     while cond.startswith("&&"):
         cond = cond[2:].strip()
     if not cond:
-        return True  # bare always()
+        # Nothing left, and the original was not empty: what got stripped was
+        # always(). Checked explicitly rather than inferred from emptiness.
+        return "always()" in raw
     if "merge_group" in _EVENT_NE.findall(cond):
         return False  # explicitly excluded
     return any(_satisfied_by_merge_group_alone(p) for p in _top_level_or_split(cond))
@@ -335,3 +344,14 @@ def test_predicate_nested_conjunction_beside_a_clean_disjunct_runs():
         "|| github.event_name == 'merge_group'"
     )
     assert _runs_on_merge_group({"if": condition}) is True
+
+
+def test_predicate_explicitly_empty_if_reports_as_skipping():
+    """fix(#1074 review), third finding. `if: ""` is not the same as no `if:`.
+    GitHub evaluates an empty condition as falsy and skips the job; the
+    normalised form was indistinguishable from bare `always()` and reported it
+    as running."""
+    assert _runs_on_merge_group({"if": ""}) is False
+    assert _runs_on_merge_group({"if": "   "}) is False
+    # The control: a genuinely absent `if:` still means no gate.
+    assert _runs_on_merge_group({}) is True

--- a/backend/tests/test_ci_merge_queue.py
+++ b/backend/tests/test_ci_merge_queue.py
@@ -15,6 +15,24 @@ instead of silently reopening the hole after the queue is switched on.
 
 Deliberately NOT asserted: that the queue is enabled. That is a
 repository-admin setting, not a file in this repo.
+
+Two GitHub behaviours this file depends on, both of which read the opposite
+way at a glance:
+
+- ``always()`` is a STATUS check, not an event gate. It means "run even if
+  the jobs I need failed or were cancelled" and says nothing about which
+  event triggered the run. ``always() && <clause>`` still evaluates
+  ``<clause>``, so ``e2e-test`` and ``accessibility`` — both written that
+  way with allowlists excluding ``merge_group`` — really do skip in the
+  queue.
+- ``if: ""`` is FALSY, and is not the same as omitting ``if:``. An empty or
+  whitespace-only condition evaluates false and the job skips, where a
+  missing ``if:`` key means no gate at all and the job runs. The natural
+  reading is that both mean "no condition"; only one does.
+
+Both were false all-clears in this file's own predicate before they were
+written down (fix(#1074 review)), which is the argument for recording them
+here rather than in a commit message.
 """
 
 import pathlib


### PR DESCRIPTION
Follow-up to #1051. The guard I shipped there string-matches an expression language, and it is wrong in both directions.

## The bug

```python
return "merge_group" in str(condition)
```

`ci-ok`'s condition is a bare `always()`, so this reports it as **skipping** when it always runs. Dormant today — the assertion only walks `ci-ok`'s dependencies, none of which use that idiom — but it means the tool built to answer step 1 of a queue incident ("did the gates actually run, or did they skip to a green CI OK?") can cry wolf and send you hunting a hole that is not there.

## The repair that would have been worse

The obvious fix is to also match `"always()"`. **Do not.** `always()` is a *status-check* function — it means "run even if the jobs I need failed or were cancelled" — and says nothing about event context. `always() && <clause>` still evaluates `<clause>`. Two jobs in this file are written exactly that way:

```yaml
e2e-test:
  if: always() && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && ...
accessibility:
  if: always() && (github.event_name == 'push' || github.event_name == 'schedule' || ...) && ...
```

Neither allowlist contains `merge_group`. Both provably skip in the queue. Matching `"always()"` reports both as running — turning a false alarm into a **false all-clear**, in the one tool meant to catch the silent failure. A guard that is wrong toward "all clear" is worse than no guard, because you stop looking.

No amount of adding literals separates a bare `always()` from `always() && <allowlist excluding merge_group>` from `github.event_name == 'merge_group'`. They differ structurally, not lexically. **Parse, don't scan.**

## What it does now

1. Strip the `always()` term — orthogonal to event context.
2. `github.event_name != 'merge_group'` anywhere → excluded. (A substring match reads an exclusion as permission: the same class of error one layer down.)
3. No `github.event_name ==` comparisons in what remains → no event gate, the job runs.
4. Comparisons present → the job runs only if `merge_group` is among them.

**Documented limit, in the docstring rather than papered over:** this reads the *set* of comparisons, not the boolean structure around them. A condition permitting `merge_group` in one `||` branch while a sibling `&&` excludes it would read as running. No such condition exists in `ci.yml`, and the note says the honest fix if one appears is to evaluate the expression — not to add another special case.

## Verification

Six predicate cases: bare `always()`; `always()` with an allowlist excluding `merge_group`; one including it; no condition; the twelve gated jobs' real written form; and `!=`. Plus a cross-check against the actual workflow asserting every `ci-ok` dependency reads as running and `e2e-test` / `accessibility` / `stac-validate` read as skipping.

That last one also **pins the non-gating-jobs decision from #1000** — if someone moves one of those onto `merge_group`, the test says to revisit the decision rather than silently accepting the flip.

**RED-checked against both wrong predicates**, verifying *why* each fails rather than only that it does:

| injected predicate | fails | 
|---|---|
| original substring match | `bare_always_runs`, `explicit_exclusion_skips` |
| the `always()`-matching repair | `always_with_allowlist_excluding_merge_group_skips`, `explicit_exclusion_skips`, `agrees_with_the_real_workflow` |

The third of those reports `AssertionError: e2e-test is deliberately off merge_group` — the false all-clear caught on the real workflow, not only on a synthetic condition. Correct predicate: **13 passed**.

## Impact

Test-only, one file. No workflow change, no runtime code, no behaviour change to the queue itself.

```
cd backend && uv run pytest tests/test_ci_merge_queue.py -q   # 13 passed
cd backend && uv run ruff check . && uv run ruff format --check .
```