### PR TITLE
fix(chat): disclose a capped preview when the total is unknown

### DIFF
--- a/frontend/src/components/builder/ChatPanel.tsx
+++ b/frontend/src/components/builder/ChatPanel.tsx
@@ -522,6 +522,10 @@ export function ChatPanel({
       // dropped the disclosure entirely — a capped clip preview then read as
       // complete. The total rides along when there is one; the badge picks its
       // wording from whether it arrived.
+      //
+      // The producer half is #1071: until that lands, collect_run_analysis_action
+      // still omits `truncated` whenever the total is absent, so this branch is
+      // correct and simply not yet reachable for a clip.
       const total = typeof action.row_count === 'number' ? action.row_count : undefined;
       const truncation = action.truncated === true
         ? { truncated: true, ...(total != null ? { totalCount: total } : {}) }

--- a/frontend/src/components/builder/ChatPanel.tsx
+++ b/frontend/src/components/builder/ChatPanel.tsx
@@ -516,9 +516,15 @@ export function ChatPanel({
       // fix(#674 audit): forward the truncation pair so EphemeralBadge can say
       // "500 of 10,651 features". Both query_data and run_analysis emit them
       // only when the server-side cap actually bit.
+      //
+      // fix(#1076): the flag no longer waits for the total. A clip filters
+      // rows, so the server reports no source total for it, and requiring one
+      // dropped the disclosure entirely — a capped clip preview then read as
+      // complete. The total rides along when there is one; the badge picks its
+      // wording from whether it arrived.
       const total = typeof action.row_count === 'number' ? action.row_count : undefined;
-      const truncation = action.truncated === true && total != null
-        ? { truncated: true, totalCount: total }
+      const truncation = action.truncated === true
+        ? { truncated: true, ...(total != null ? { totalCount: total } : {}) }
         : undefined;
       // feat(#675): a run_analysis action carries its reconstruction params so
       // the badge can offer "Save as dataset" (prefilled Analysis panel).

--- a/frontend/src/components/builder/EphemeralBadge.tsx
+++ b/frontend/src/components/builder/EphemeralBadge.tsx
@@ -21,15 +21,26 @@ interface EphemeralBadgeProps {
 export function EphemeralBadge({ featureCount, onDismiss, truncated, totalCount, onSaveAsDataset, className }: EphemeralBadgeProps) {
   const { t } = useTranslation('builder');
 
-  const countLabel = truncated && totalCount != null
-    ? t('ephemeralBadge.featureCountTruncated', {
-        count: featureCount,
-        // fix(#788): both numbers passed raw — the locale strings group them
-        // via {{count, number}}/{{total, number}} (one sentence, one grouping),
-        // and count keeps driving plural selection.
-        total: totalCount,
-        defaultValue: '{{count, number}} of {{total, number}} features',
-      })
+  // fix(#1076): three cases, not two. A clip filters rows, so the server
+  // cannot report a source total for it — the honest answer to "of how many?"
+  // is unknown. Falling back to the plain count there presented a capped
+  // preview as the complete result, which is #674's concern through a new
+  // door. Capped-with-a-total keeps its "N of M"; capped-without says so
+  // without inventing one.
+  const countLabel = truncated
+    ? totalCount != null
+      ? t('ephemeralBadge.featureCountTruncated', {
+          count: featureCount,
+          // fix(#788): both numbers passed raw — the locale strings group them
+          // via {{count, number}}/{{total, number}} (one sentence, one
+          // grouping), and count keeps driving plural selection.
+          total: totalCount,
+          defaultValue: '{{count, number}} of {{total, number}} features',
+        })
+      : t('ephemeralBadge.featureCountCapped', {
+          count: featureCount,
+          defaultValue: 'first {{count, number}} features',
+        })
     : t('ephemeralBadge.featureCount', { count: featureCount });
   const statusLabel = `${t('ephemeralBadge.queryResult')} · ${countLabel}`;
 

--- a/frontend/src/components/builder/__tests__/ChatPanel.test.tsx
+++ b/frontend/src/components/builder/__tests__/ChatPanel.test.tsx
@@ -195,6 +195,61 @@ describe('ChatPanel', () => {
     });
   });
 
+  // fix(#1076): a clip filters rows, so run_analysis reports no source total —
+  // the flag arrives alone. Requiring a total dropped it here and a capped
+  // clip preview reached the badge looking complete.
+  it('forwards a cap that arrives without a total', async () => {
+    const geojson = { type: 'FeatureCollection', features: [] };
+    const bbox = [-74, 40, -73, 41];
+
+    mockStreamChat.mockImplementation(async function* () {
+      yield {
+        event: 'actions',
+        data: {
+          actions: [
+            { type: 'show_query_result', geojson, bbox, truncated: true },
+          ],
+        },
+      };
+      yield { event: 'done', data: { explanation: 'Clipped' } };
+    });
+
+    const user = userEvent.setup();
+    const props = renderPanel();
+    await typeAndSend(user, 'clip the buildings to the flood zone');
+
+    await waitFor(() => {
+      expect(props.onQueryResult).toHaveBeenCalledWith(geojson, bbox, {
+        truncated: true,
+      });
+    });
+  });
+
+  // The other direction: an uncapped result must forward nothing, or the badge
+  // discloses a truncation that did not happen.
+  it('forwards no truncation for an uncapped result', async () => {
+    const geojson = { type: 'FeatureCollection', features: [] };
+    const bbox = [-74, 40, -73, 41];
+
+    mockStreamChat.mockImplementation(async function* () {
+      yield {
+        event: 'actions',
+        data: {
+          actions: [{ type: 'show_query_result', geojson, bbox, row_count: 12 }],
+        },
+      };
+      yield { event: 'done', data: { explanation: 'Clipped' } };
+    });
+
+    const user = userEvent.setup();
+    const props = renderPanel();
+    await typeAndSend(user, 'clip the buildings to the flood zone');
+
+    await waitFor(() => {
+      expect(props.onQueryResult).toHaveBeenCalledWith(geojson, bbox, undefined);
+    });
+  });
+
   it('dispatches the flyover only for the winning (last) query result (#534)', async () => {
     const geojson = { type: 'FeatureCollection', features: [] };
     const bbox = [-74, 40, -73, 41];

--- a/frontend/src/components/builder/__tests__/EphemeralBadge.test.tsx
+++ b/frontend/src/components/builder/__tests__/EphemeralBadge.test.tsx
@@ -28,6 +28,31 @@ describe('EphemeralBadge', () => {
     expect(screen.getByText('Result · 5,000 of 250,000 features')).toBeInTheDocument();
   });
 
+  // fix(#1076): a clip filters rows, so the server reports no source total for
+  // it and the honest answer to "of how many?" is unknown. Falling back to the
+  // plain count presented a capped preview as the complete result.
+  it('says the result was capped when no total is known', () => {
+    render(<EphemeralBadge featureCount={500} truncated onDismiss={vi.fn()} />);
+    expect(screen.getByText('Result · first 500 features')).toBeInTheDocument();
+  });
+
+  // The other direction matters as much: a badge that fires on an uncapped
+  // preview has traded a silent truncation for a wrong one.
+  it('says nothing about a cap when the preview was complete', () => {
+    render(<EphemeralBadge featureCount={500} onDismiss={vi.fn()} />);
+    expect(screen.getByText('Result · 500 features')).toBeInTheDocument();
+    expect(screen.queryByText(/first/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/of/)).not.toBeInTheDocument();
+  });
+
+  it('keeps the "N of M" form when the total IS known', () => {
+    render(
+      <EphemeralBadge featureCount={500} totalCount={10651} truncated onDismiss={vi.fn()} />
+    );
+    // Unchanged by #1076 — only the total-less case is new.
+    expect(screen.getByText('Result · 500 of 10,651 features')).toBeInTheDocument();
+  });
+
   // fix(#787 item 1): the badge sat at z-[8], under every z-10 PluginHost slot, so
   // an open plugin panel taller than the bottom-left offset covered it.
   it('stacks above the PluginHost slots', () => {

--- a/frontend/src/components/viewer/ViewerChatPanel.tsx
+++ b/frontend/src/components/viewer/ViewerChatPanel.tsx
@@ -168,11 +168,18 @@ export function ViewerChatPanel({ mapId, layers, mapInstanceRef }: ViewerChatPan
       if (!(minX < -180 || minY < -90 || maxX > 180 || maxY > 90 || minX > maxX || minY > maxY)) {
         // fix(#674 audit): forward the truncation pair so the badge discloses
         // "N of TOTAL" rather than presenting a capped overlay as complete.
+        //
+        // fix(#1076): and forward it without a total too. A clip filters rows,
+        // so the server reports none for it — requiring one dropped the
+        // disclosure and a capped clip read as complete. This surface matters
+        // most of the two: an embed or a shared link lands here.
         const total = typeof action.row_count === 'number' ? action.row_count : undefined;
         handleQueryResult(
           geojson as GeoJSON.FeatureCollection,
           [minX, minY, maxX, maxY],
-          action.truncated === true && total != null ? { truncated: true, totalCount: total } : undefined,
+          action.truncated === true
+            ? { truncated: true, ...(total != null ? { totalCount: total } : {}) }
+            : undefined,
         );
       }
     }

--- a/frontend/src/components/viewer/ViewerChatPanel.tsx
+++ b/frontend/src/components/viewer/ViewerChatPanel.tsx
@@ -173,6 +173,9 @@ export function ViewerChatPanel({ mapId, layers, mapInstanceRef }: ViewerChatPan
         // so the server reports none for it — requiring one dropped the
         // disclosure and a capped clip read as complete. This surface matters
         // most of the two: an embed or a shared link lands here.
+        //
+        // The producer half is #1071; until it lands this branch is correct and
+        // simply not yet reachable for a clip.
         const total = typeof action.row_count === 'number' ? action.row_count : undefined;
         handleQueryResult(
           geojson as GeoJSON.FeatureCollection,

--- a/frontend/src/components/viewer/__tests__/ViewerChatPanel.test.tsx
+++ b/frontend/src/components/viewer/__tests__/ViewerChatPanel.test.tsx
@@ -127,6 +127,79 @@ describe('ViewerChatPanel', () => {
     expect(screen.getByText('1 row')).toBeInTheDocument();
   });
 
+  // fix(#1076): the viewer is the surface an embed or a shared link lands on,
+  // so a silent truncation here reaches the widest audience. A clip reports no
+  // source total, and requiring one dropped the flag before the badge saw it.
+  it('forwards a cap that arrives without a total', async () => {
+    setAvailable(true);
+    mockStream.mockImplementation(async function* () {
+      yield {
+        event: 'actions',
+        data: {
+          actions: [
+            {
+              type: 'show_query_result',
+              geojson: { type: 'FeatureCollection', features: [] },
+              bbox: [-1, -1, 1, 1],
+              truncated: true,
+            },
+          ],
+        },
+      };
+      yield { event: 'done', data: { explanation: 'Clipped.' } };
+    });
+
+    renderPanel();
+    await userEvent.click(screen.getByRole('button', { name: 'Ask AI' }));
+    await userEvent.type(
+      screen.getByPlaceholderText('Ask about this map...'),
+      'clip the buildings',
+    );
+    await userEvent.click(screen.getByRole('button', { name: 'Send' }));
+
+    await screen.findByText('Clipped.');
+    expect(handleQueryResult).toHaveBeenCalledWith(
+      { type: 'FeatureCollection', features: [] },
+      [-1, -1, 1, 1],
+      { truncated: true },
+    );
+  });
+
+  it('forwards no truncation for an uncapped result', async () => {
+    setAvailable(true);
+    mockStream.mockImplementation(async function* () {
+      yield {
+        event: 'actions',
+        data: {
+          actions: [
+            {
+              type: 'show_query_result',
+              geojson: { type: 'FeatureCollection', features: [] },
+              bbox: [-1, -1, 1, 1],
+              row_count: 12,
+            },
+          ],
+        },
+      };
+      yield { event: 'done', data: { explanation: 'Clipped.' } };
+    });
+
+    renderPanel();
+    await userEvent.click(screen.getByRole('button', { name: 'Ask AI' }));
+    await userEvent.type(
+      screen.getByPlaceholderText('Ask about this map...'),
+      'clip the buildings',
+    );
+    await userEvent.click(screen.getByRole('button', { name: 'Send' }));
+
+    await screen.findByText('Clipped.');
+    expect(handleQueryResult).toHaveBeenCalledWith(
+      { type: 'FeatureCollection', features: [] },
+      [-1, -1, 1, 1],
+      undefined,
+    );
+  });
+
   it('applies only the winning (last) query result — no stale flyover (#534)', async () => {
     setAvailable(true);
     mockStream.mockImplementation(async function* () {

--- a/frontend/src/i18n/locales/de/builder.json
+++ b/frontend/src/i18n/locales/de/builder.json
@@ -1037,6 +1037,8 @@
     "dismiss": "Ergebnis verwerfen",
     "featureCountTruncated_one": "{{count, number}} von {{total, number}} Features",
     "featureCountTruncated_other": "{{count, number}} von {{total, number}} Features",
+    "featureCountCapped_one": "erstes {{count, number}} Feature",
+    "featureCountCapped_other": "erste {{count, number}} Features",
     "saveAsDataset": "Als Datensatz speichern…"
   },
   "plugins": {

--- a/frontend/src/i18n/locales/en/builder.json
+++ b/frontend/src/i18n/locales/en/builder.json
@@ -1036,6 +1036,8 @@
     "featureCount_other": "{{count, number}} features",
     "featureCountTruncated_one": "{{count, number}} of {{total, number}} features",
     "featureCountTruncated_other": "{{count, number}} of {{total, number}} features",
+    "featureCountCapped_one": "first {{count, number}} feature",
+    "featureCountCapped_other": "first {{count, number}} features",
     "dismiss": "Dismiss result",
     "saveAsDataset": "Save as dataset…"
   },

--- a/frontend/src/i18n/locales/es/builder.json
+++ b/frontend/src/i18n/locales/es/builder.json
@@ -1037,6 +1037,8 @@
     "dismiss": "Descartar resultado",
     "featureCountTruncated_one": "{{count, number}} de {{total, number}} entidades",
     "featureCountTruncated_other": "{{count, number}} de {{total, number}} entidades",
+    "featureCountCapped_one": "primera {{count, number}} entidad",
+    "featureCountCapped_other": "primeras {{count, number}} entidades",
     "saveAsDataset": "Guardar como conjunto de datos…"
   },
   "plugins": {

--- a/frontend/src/i18n/locales/fr/builder.json
+++ b/frontend/src/i18n/locales/fr/builder.json
@@ -1037,6 +1037,8 @@
     "dismiss": "Fermer le résultat",
     "featureCountTruncated_one": "{{count, number}} sur {{total, number}} entités",
     "featureCountTruncated_other": "{{count, number}} sur {{total, number}} entités",
+    "featureCountCapped_one": "{{count, number}} première entité",
+    "featureCountCapped_other": "{{count, number}} premières entités",
     "saveAsDataset": "Enregistrer comme jeu de données…"
   },
   "plugins": {


### PR DESCRIPTION
Closes #1076 — the frontend half of the truncation gap #1071 surfaced.

## The gap

A clip filters rows, so `run_analysis_preview` cannot report a source total for it: the clipped total is genuinely unknown before the clip runs. Every consumer required a total before disclosing anything, so a capped clip preview presented itself as the complete result — #674's concern arriving through the door #1071 opened by enabling clip from chat.

The backend half landed in #1071: the action reports the cap and names the total only when there is one. This is the rest.

## Three files, and they only work together

| File | Change |
|---|---|
| `ChatPanel.tsx` | forwards the flag without waiting for a total |
| `ViewerChatPanel.tsx` | same |
| `EphemeralBadge.tsx` | third case for "capped, total unknown" |

Forwarding from the two panels without the badge label renders an ordinary count, so a partial fix would look complete while a user hitting a capped clip still saw no cap. The badge is the load-bearing one.

The viewer panel matters most of the two — an embed or a shared link lands there, so a silent truncation on that surface reaches the widest audience. It was also the file I originally missed; codex named it on #1071.

## Both directions

The issue is explicit that a fix showing the badge for capped clips but also firing on uncapped ones has traded a silent truncation for a wrong one. Pinned accordingly:

- capped, no total → `Result · first 500 features`
- capped, total known → `Result · 500 of 10,651 features` (**unchanged**)
- not capped → `Result · 500 features`, and neither cap wording appears

Both panels have a forwards-it and a forwards-nothing test.

Verified rather than assumed: reverting the badge to its two-case form fails the new case and leaves the other six passing.

## i18n

`ephemeralBadge.featureCountCapped` in all four locales with `_one`/`_other`. The `_one` values interpolate `{{count}}` rather than hardcoding "1" — French resolves count 0 to `_one`, so a literal would render "1 entité" for zero.

## Verification

```
cd frontend
npm run test:i18n     # 4 passed — locale parity
npm run lint
npm run typecheck
npm run test:coverage # 367 files, 4365 tests
```

No backend, schema or API change.