### PR TITLE
test(backend): gate sync tests against async fixture dependencies

### DIFF
--- a/backend/tests/test_fixture_scope_structural.py
+++ b/backend/tests/test_fixture_scope_structural.py
@@ -1,6 +1,6 @@
 """Structural gate: no sync test may depend on an async fixture.
 
-fix(#1030/#1057): a sync test that reaches an async fixture does not merely
+fix(#1082): a sync test that reaches an async fixture does not merely
 fail itself. It poisons that fixture's FixtureDef for the rest of the xdist
 worker's session, and every later test that touches the fixture errors at
 setup with a bare `AssertionError`. One such test produced 951 errors in a
@@ -36,6 +36,11 @@ existed on its branch. #1057 then added two sync tests to a different class in
 the same module. Both PRs were green alone. The remedy was a per-class
 enumeration that was complete when written and silently incomplete a week
 later, so the thing worth checking in is the rule, not another entry.
+
+Sibling gates in the same neighbourhood, same idea: `test_rule1_structural.py`
+(visibility filters) and `test_rule2_structural.py` (GDAL/rasterio safe envs).
+This file deliberately fixes nothing it finds -- the first violation belongs
+to #1030.
 
 Known gap: this reads the AST, so it sees fixtures requested by parameter name
 and nothing else. A fixture pulled at runtime through
@@ -80,9 +85,22 @@ class _Scopes:
     """Fixtures, autouse names, and sync tests, keyed by scope.
 
     Scope is `_MODULE_SCOPE` or a class name. A class-level definition shadows
-    a module-level one of the same name, which shadows conftest -- getting this
-    wrong pools every class's fixtures together and reports sync tests as
-    exposed to autouse fixtures that never applied to them.
+    a module-level one of the same name, which shadows conftest.
+
+    fix(#1082): keying by scope is the load-bearing part of this file and it
+    reads like ceremony, so it is worth saying what happens without it. The
+    first version of this gate pooled every fixture in a file into one dict and
+    every sync test into one list. That is smaller and it is wrong: it reported
+    16 sync tests in `test_geometry_detection.py`, whose `_skip_no_db` autouse
+    fixture is class-level in `TestConstructPointGeometry` and
+    `TestConstructWktGeometry` while those tests live in
+    `TestDetectGeometryColumns` and never see it. Two false positives on a
+    clean main, which is how a gate gets switched off.
+
+    The same pooling also hid a true positive: two fixtures in one file can
+    share a name (a class-level sync override of a module-level async fixture
+    is exactly the remedy this gate recommends), and a flat dict keeps only the
+    last one.
     """
 
     def __init__(self, tree: ast.Module) -> None:

--- a/backend/tests/test_fixture_scope_structural.py
+++ b/backend/tests/test_fixture_scope_structural.py
@@ -1,0 +1,243 @@
+"""Structural gate: no sync test may depend on an async fixture.
+
+fix(#1030/#1057): a sync test that reaches an async fixture does not merely
+fail itself. It poisons that fixture's FixtureDef for the rest of the xdist
+worker's session, and every later test that touches the fixture errors at
+setup with a bare `AssertionError`. One such test produced 951 errors in a
+single CI run, none of which named the test that caused them.
+
+The mechanism is in pytest itself (9.1.1, `_pytest/fixtures.py`):
+
+    execute()  1222  self.addfinalizer(...)          # finalizer registered
+    execute()  1232  pytest_fixture_setup(...)       # raises at 1320, which is
+                                                     # BEFORE the try at 1327
+                                                     # that sets cached_result
+    finish()   1147  if self.cached_result is None:  # "Already finished. It is
+                         return                      #  assumed that finalizers
+                                                     #  cannot be added in this
+                                                     #  state." -- so _finalizers
+                                                     #  is never cleared
+    execute()  1221  assert not self._finalizers     # fails forever after
+
+So the FixtureDef is left in a state its own teardown refuses to clean, and
+the assertion that notices carries no message, no fixture name, and no test
+name. The failure is maximally loud and minimally informative, which is why
+this gate exists at the shape instead.
+
+There is no legitimate instance of this shape -- pytest fails it every time --
+so this gate has no allowlist. The two remedies are to shadow the fixture with
+a sync no-op for the class holding the sync tests (see `TestUserErrorMessage`
+in `test_analysis_materialize.py`), or to move the sync test to a class that
+already does.
+
+Why a gate rather than a fix at the two call sites: #1030 hit this, diagnosed
+it correctly, and shadowed the fixture for the only sync-test class that
+existed on its branch. #1057 then added two sync tests to a different class in
+the same module. Both PRs were green alone. The remedy was a per-class
+enumeration that was complete when written and silently incomplete a week
+later, so the thing worth checking in is the rule, not another entry.
+
+Known gap: this reads the AST, so it sees fixtures requested by parameter name
+and nothing else. A fixture pulled at runtime through
+`request.getfixturevalue("client")` is invisible to it. That path is not used
+in this suite today; if it starts being used, the gate goes quiet rather than
+loud, which is the failure direction to watch for.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+_TESTS = Path(__file__).parent
+_MODULE_SCOPE = "<module>"
+
+# Requested by name but never resolvable to a fixture in this tree.
+_PYTEST_BUILTINS = frozenset({"request", "self", "cls"})
+
+
+def _is_fixture(decorator: ast.expr) -> bool:
+    func = decorator.func if isinstance(decorator, ast.Call) else decorator
+    return ast.unparse(func).endswith("fixture")
+
+
+def _is_autouse(decorator: ast.expr) -> bool:
+    return isinstance(decorator, ast.Call) and any(
+        kw.arg == "autouse" and getattr(kw.value, "value", False) is True
+        for kw in decorator.keywords
+    )
+
+
+def _argnames(fn: ast.FunctionDef | ast.AsyncFunctionDef) -> list[str]:
+    args = fn.args
+    names = [a.arg for a in (*args.posonlyargs, *args.args, *args.kwonlyargs)]
+    return [n for n in names if n not in _PYTEST_BUILTINS]
+
+
+class _Scopes:
+    """Fixtures, autouse names, and sync tests, keyed by scope.
+
+    Scope is `_MODULE_SCOPE` or a class name. A class-level definition shadows
+    a module-level one of the same name, which shadows conftest -- getting this
+    wrong pools every class's fixtures together and reports sync tests as
+    exposed to autouse fixtures that never applied to them.
+    """
+
+    def __init__(self, tree: ast.Module) -> None:
+        self.fixtures: dict[str, dict[str, tuple[bool, list[str]]]] = {}
+        self.autouse: dict[str, list[str]] = {}
+        self.sync_tests: dict[str, list[tuple[str, list[str]]]] = {}
+        self._visit(tree.body, _MODULE_SCOPE)
+
+    def _visit(self, body: list[ast.stmt], scope: str) -> None:
+        for node in body:
+            if isinstance(node, ast.ClassDef) and node.name.startswith("Test"):
+                self._visit(node.body, node.name)
+            elif isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef):
+                if any(_is_fixture(d) for d in node.decorator_list):
+                    self.fixtures.setdefault(scope, {})[node.name] = (
+                        isinstance(node, ast.AsyncFunctionDef),
+                        _argnames(node),
+                    )
+                    if any(_is_autouse(d) for d in node.decorator_list):
+                        self.autouse.setdefault(scope, []).append(node.name)
+                elif node.name.startswith("test_") and isinstance(
+                    node, ast.FunctionDef
+                ):
+                    self.sync_tests.setdefault(scope, []).append(
+                        (node.name, _argnames(node))
+                    )
+
+
+def _conftest_scopes() -> _Scopes:
+    return _Scopes(ast.parse((_TESTS / "conftest.py").read_text(encoding="utf-8")))
+
+
+_CONFTEST = _conftest_scopes()
+_CONFTEST_FIXTURES = _CONFTEST.fixtures.get(_MODULE_SCOPE, {})
+
+
+def _resolve(name: str, scopes: _Scopes, scope: str) -> tuple[bool, list[str]] | None:
+    for candidate in (scope, _MODULE_SCOPE):
+        found = scopes.fixtures.get(candidate, {}).get(name)
+        if found is not None:
+            return found
+    return _CONFTEST_FIXTURES.get(name)
+
+
+def _reaches_async(
+    name: str, scopes: _Scopes, scope: str, seen: set[str] | None = None
+) -> str | None:
+    """Return the async fixture `name` transitively depends on, if any."""
+    seen = seen if seen is not None else set()
+    if name in seen:
+        return None
+    seen.add(name)
+    resolved = _resolve(name, scopes, scope)
+    if resolved is None:
+        return None
+    is_async, deps = resolved
+    if is_async:
+        return name
+    for dep in deps:
+        if hit := _reaches_async(dep, scopes, scope, seen):
+            return hit
+    return None
+
+
+def _offenders_in(path: Path) -> list[str]:
+    scopes = _Scopes(ast.parse(path.read_text(encoding="utf-8")))
+    offenders: list[str] = []
+    for scope, tests in scopes.sync_tests.items():
+        # Autouse fixtures that apply here: this scope's own, plus the module's
+        # when this scope is a class, plus conftest's.
+        applicable = list(scopes.autouse.get(scope, []))
+        if scope != _MODULE_SCOPE:
+            applicable += scopes.autouse.get(_MODULE_SCOPE, [])
+        applicable += _CONFTEST.autouse.get(_MODULE_SCOPE, [])
+        where = "module scope" if scope == _MODULE_SCOPE else scope
+        for test_name, requested in tests:
+            for root in (*applicable, *requested):
+                hit = _reaches_async(root, scopes, scope)
+                if hit is None:
+                    continue
+                how = "autouse " if root in applicable else ""
+                via = "" if hit == root else f" (via {root!r})"
+                offenders.append(
+                    f"{path.name}::{where}::{test_name} is sync but reaches "
+                    f"async {how}fixture {hit!r}{via}"
+                )
+                break
+    return offenders
+
+
+@pytest.mark.architecture
+def test_no_sync_test_depends_on_an_async_fixture() -> None:
+    offenders: list[str] = []
+    for path in sorted(_TESTS.rglob("test_*.py")):
+        offenders.extend(_offenders_in(path))
+
+    if offenders:
+        pytest.fail(
+            "A sync test reaches an async fixture. pytest errors its setup and "
+            "leaves the fixture's FixtureDef un-finalizable, so every later "
+            "test on the same xdist worker that touches it errors with a bare "
+            "AssertionError naming nothing.\n\n"
+            "Shadow the fixture with a sync no-op in the class holding the "
+            "sync test, or move the sync test to a class that already does "
+            "(see TestUserErrorMessage in test_analysis_materialize.py):\n\n"
+            "    @pytest.fixture(autouse=True)\n"
+            "    def <fixture_name>(self):\n"
+            "        yield\n\n" + "\n".join(offenders)
+        )
+
+
+@pytest.mark.architecture
+def test_the_gate_detects_the_shape_that_produced_951_errors() -> None:
+    """Pin the detector against the exact #1030/#1057 combination.
+
+    The gate passes on a clean tree, which is indistinguishable from a gate
+    that detects nothing. This reconstructs the shape in memory -- a
+    module-level async autouse fixture reaching `client` through a conftest
+    fixture, and a sync test in a class that does NOT shadow it -- and asserts
+    the detector fires, names the async fixture, and does NOT fire for the
+    class that does shadow it.
+    """
+    source = """
+import pytest
+
+@pytest.fixture(autouse=True)
+async def _release_analysis_job_slots(test_db_session):
+    yield
+
+class TestMaterializeWorker:
+    async def test_async_one(self, test_db_session): ...
+    def test_timeout_message_names_the_budget_that_fired(self, monkeypatch): ...
+
+class TestUserErrorMessage:
+    @pytest.fixture(autouse=True)
+    def _release_analysis_job_slots(self):
+        yield
+
+    def test_db_error_hides_generated_sql(self): ...
+"""
+    scopes = _Scopes(ast.parse(source))
+
+    unshadowed = _reaches_async(
+        "_release_analysis_job_slots", scopes, "TestMaterializeWorker"
+    )
+    assert unshadowed == "_release_analysis_job_slots"
+
+    # The class-level sync override is what kept these 5 tests green in the
+    # same CI run where the other class's 2 errored.
+    shadowed = _reaches_async(
+        "_release_analysis_job_slots", scopes, "TestUserErrorMessage"
+    )
+    assert shadowed is None
+
+    # And a sync test that asks for an async conftest fixture directly, with no
+    # autouse fixture involved at all.
+    direct = _Scopes(ast.parse("def test_x(client): ...\n"))
+    assert _reaches_async("client", direct, _MODULE_SCOPE) == "client"


### PR DESCRIPTION
Closes #1082.

## What

Adds `backend/tests/test_fixture_scope_structural.py`: a structural gate that fails when a sync test can reach an async fixture, whether through an autouse fixture in scope or through its own parameters. Same idea and neighbourhood as `test_rule1_structural.py` and `test_rule2_structural.py`.

Guard only. It deliberately does not fix the violation it finds — that belongs to #1030.

## Why

Batch 4's Backend Tests run produced **951 errors** (934 on rerun). Every one was an `AssertionError` at setup with no message, no fixture name, and no test name:

```
.venv/.../_pytest/fixtures.py:1221: in execute
    assert not self._finalizers
E   AssertionError
```

The cause was a single test, and it was not any of the 951.

`pytest_fixture_setup` raises for a sync-test-requests-async-fixture at `fixtures.py:1320`, which is **before** the `try` at 1327 that sets `cached_result`. By then `execute()` has already registered a finalizer at 1222. So the `FixtureDef` is left with `cached_result=None` and a non-empty `_finalizers` — precisely the state `finish()` refuses to clean:

```python
if self.cached_result is None:
    # Already finished. It is assumed that finalizers cannot be added in
    # this state.
    return
```

Its own error path violates the invariant that comment asserts, so `_finalizers` is never cleared and every later `execute()` of that fixture trips the assertion for the rest of the worker's session. Blast radius is purely ordering — the poisoner ran at 5% on gw0.

**This is an upstream pytest bug (9.1.1), not filed.** Flagging it here rather than reporting it; that call isn't mine to make.

## Why a gate and not a second shadow

Two PRs, each green alone. #1030 adds a module-level `async` autouse fixture reaching `client` through `test_db_session`, and **anticipated this** — it shadows the fixture with a sync no-op for `TestUserErrorMessage`, the only sync-test class on its branch, with a docstring predicting the exact failure. #1057 then added two sync tests to `TestMaterializeWorker`, a class that was fully async when #1030 was written.

CI shows both halves: the shadowed class's 5 sync tests **passed** in the same run where the unshadowed class's 2 errored.

So the existing remedy is a per-class enumeration that was complete when written and silently incomplete once another PR touched a different class in the same file. A second shadow repeats the enumeration; the file has six classes.

## Evidence the gate fires

Same worktree, same command, only `test_analysis_materialize.py` swapped.

**Green on main (`639b3d3c2`):**

```
tests/test_fixture_scope_structural.py::test_no_sync_test_depends_on_an_async_fixture PASSED
tests/test_fixture_scope_structural.py::test_the_gate_detects_the_shape_that_produced_951_errors PASSED
2 passed
```

**Red on batch-4's copy of that file:**

```
1 failed, 1 passed

E   Failed: A sync test reaches an async fixture. pytest errors its setup and leaves the
E   fixture's FixtureDef un-finalizable, so every later test on the same xdist worker that
E   touches it errors with a bare AssertionError naming nothing.
E
E   Shadow the fixture with a sync no-op in the class holding the sync test, or move the
E   sync test to a class that already does (see TestUserErrorMessage in
E   test_analysis_materialize.py):
E
E       @pytest.fixture(autouse=True)
E       def <fixture_name>(self):
E           yield
E
E   test_analysis_materialize.py::TestMaterializeWorker::test_timeout_message_names_the_budget_that_fired is sync but reaches async autouse fixture '_release_analysis_job_slots'
E   test_analysis_materialize.py::TestMaterializeWorker::test_analysis_timeouts_track_their_settings is sync but reaches async autouse fixture '_release_analysis_job_slots'
```

Two named lines with the remedy, in place of 951 nameless assertions. It does not flag the shadowed class.

## Scope model

Class shadows module shadows conftest, and this is the load-bearing part. The first version pooled every fixture in a file into one dict and every sync test into one list — smaller, and wrong twice over:

- **False positives.** It reported 16 sync tests in `test_geometry_detection.py`, whose `_skip_no_db` autouse fixture is class-level in `TestConstructPointGeometry`/`TestConstructWktGeometry` while those tests live in `TestDetectGeometryColumns` and never see it. Two false alarms on a clean main is how a gate gets switched off.
- **A hidden true positive.** Two fixtures in one file can share a name — a class-level sync override of a module-level async fixture is exactly the remedy this gate recommends — and a flat dict keeps only the last.

Both are recorded inline, because the pooled version is the obvious simplification and it looks correct.

## No allowlist

pytest fails this shape every time, so there is no legitimate instance to exempt.

## Notes

- Clean on `main` today. Adopting it now costs nothing, and that stops being true once #1030 lands.
- #1030 cannot merge in its current form regardless: rebased onto current main it fails its own CI, because main is where the sync tests are. So this is not racing #1030 — it can land first and #1030 will have to satisfy it.
- Static AST, so a fixture pulled through `request.getfixturevalue()` is invisible. Unused in this suite today, documented in the module docstring as the direction the gate fails quiet.
- The second test pins the detector against the #1030/#1057 shape, since a gate that passes on a clean tree is indistinguishable from one that detects nothing.

## Verification

- `uv run pytest tests/test_fixture_scope_structural.py` — 2 passed
- `uv run pytest -m architecture` — 40 passed, 1 skipped
- A/B above, run against the real batch-4 file rather than a reconstruction, then restored
- `ruff check` / `ruff format --check` — clean