### PR TITLE
feat(builder): tint fill patterns with the layer fill colour

### DIFF
--- a/frontend/src/components/builder/LayerStyleEditor/utils.ts
+++ b/frontend/src/components/builder/LayerStyleEditor/utils.ts
@@ -1,5 +1,5 @@
 import { MAP_COLORS } from '@/lib/map-colors';
-import { fillPatternFromPaint } from '@/lib/fill-pattern-preview';
+import { fillPatternFromPaint, fillPatternTint } from '@/lib/fill-pattern-preview';
 import type { BuilderStyleConfig, MapLayerResponse, StyleConfig } from '@/types/api';
 
 // ---------------------------------------------------------------------------
@@ -129,6 +129,7 @@ export function stylePreviewStyle(layer: MapLayerResponse) {
       opacity: layer.opacity,
       fillOpacity: typeof paint['fill-opacity'] === 'number' ? paint['fill-opacity'] as number : undefined,
       fillPattern: fillPatternFromPaint(paint),
+      fillPatternColor: fillPatternTint(paint, layer.style_config?.builder),
       strokeWidth: typeof layer.style_config?.builder?.outlineWidth === 'number'
         ? layer.style_config.builder.outlineWidth
         : typeof paint['_outline-width'] === 'number'

--- a/frontend/src/components/builder/__tests__/layer-adapters.test.ts
+++ b/frontend/src/components/builder/__tests__/layer-adapters.test.ts
@@ -1540,10 +1540,72 @@ describe('fillAdapter', () => {
     const input = makeInput({
       id: 'fp4',
       layerId: 'layer-fp4',
-      paint: { 'fill-color': '#3b82f6', 'fill-pattern': 'geolens-fill-hatch' },
+      paint: { 'fill-pattern': 'geolens-fill-hatch' },
     });
     fillAdapter.syncPaint(map, input);
     expect(map.setPaintProperty).toHaveBeenCalledWith('layer-fp4', 'fill-pattern', 'geolens-fill-hatch');
+  });
+
+  // ── fix(#914): the tint swap happens on the way into MapLibre only ──────────
+  it('syncPaint writes the TINTED pattern id when a fill colour is resolvable', () => {
+    (map.getLayer as ReturnType<typeof vi.fn>).mockImplementation((id: string) => {
+      if (id === 'layer-fp4t' || id === 'layer-fp4t-outline') return { id };
+      return null;
+    });
+    (map.getPaintProperty as ReturnType<typeof vi.fn>).mockReturnValue(undefined);
+    const paint = { 'fill-pattern': 'geolens-fill-hatch' };
+    const input = makeInput({
+      id: 'fp4t',
+      layerId: 'layer-fp4t',
+      paint,
+      style_config: { builder: { fillColorSaved: '#ff0000' } },
+    } as Partial<AdapterLayerInput> & { style_config: { builder: Record<string, unknown> } });
+    fillAdapter.syncPaint(map, input);
+
+    expect(map.setPaintProperty).toHaveBeenCalledWith(
+      'layer-fp4t', 'fill-pattern', 'geolens-fill-hatch#ff0000',
+    );
+    expect(map.addImage).toHaveBeenCalledWith('geolens-fill-hatch#ff0000', expect.anything());
+    // INVARIANT: the tinted id is a runtime registry key. The layer's own paint —
+    // what gets saved, sent over the wire and exported to style.json — is untouched.
+    expect(paint['fill-pattern']).toBe('geolens-fill-hatch');
+    expect(input.paint['fill-pattern']).toBe('geolens-fill-hatch');
+  });
+
+  it('addLayers keeps the plain id in the input paint while adding the tinted layer', () => {
+    const paint = { 'fill-pattern': 'geolens-fill-dots', 'fill-opacity': 0.3 };
+    const input = makeInput({
+      id: 'fp4a',
+      layerId: 'layer-fp4a',
+      sourceId: 'source-fp4a',
+      sourceLayer: 'data.test_table',
+      paint,
+      style_config: { builder: { fillColorSaved: '#00ff00' } },
+    } as Partial<AdapterLayerInput> & { style_config: { builder: Record<string, unknown> } });
+    fillAdapter.addLayers(map, input);
+
+    const fillCall = (map.addLayer as ReturnType<typeof vi.fn>).mock.calls
+      .find((c: unknown[]) => (c[0] as { type: string }).type === 'fill');
+    expect((fillCall![0] as { paint: Record<string, unknown> }).paint['fill-pattern'])
+      .toBe('geolens-fill-dots#00ff00');
+    expect(paint['fill-pattern']).toBe('geolens-fill-dots');
+  });
+
+  it('leaves the pattern untinted when no fill colour is resolvable', () => {
+    (map.getLayer as ReturnType<typeof vi.fn>).mockImplementation((id: string) => {
+      if (id === 'layer-fp4n' || id === 'layer-fp4n-outline') return { id };
+      return null;
+    });
+    (map.getPaintProperty as ReturnType<typeof vi.fn>).mockReturnValue(undefined);
+    const input = makeInput({
+      id: 'fp4n',
+      layerId: 'layer-fp4n',
+      paint: { 'fill-pattern': 'geolens-fill-grid' },
+    });
+    fillAdapter.syncPaint(map, input);
+    expect(map.setPaintProperty).toHaveBeenCalledWith(
+      'layer-fp4n', 'fill-pattern', 'geolens-fill-grid',
+    );
   });
 
   it('syncPaint clears fill-pattern (sets undefined) when fill-pattern key is absent (restores solid fill)', () => {

--- a/frontend/src/components/builder/hooks/__tests__/use-layer-map-sync.test.ts
+++ b/frontend/src/components/builder/hooks/__tests__/use-layer-map-sync.test.ts
@@ -15,6 +15,7 @@ import React from 'react';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
 import { useLayerMapSync, clearExcludedPaintOnMap } from '../use-layer-map-sync';
+import { fillPatternTint } from '@/lib/fill-pattern-preview';
 import type { MapLayerResponse, StyleConfig } from '@/types/api';
 import type { Map as MaplibreMap } from 'maplibre-gl';
 
@@ -1008,6 +1009,32 @@ describe('useLayerMapSync — handleStyleConfigChange fill-pattern cleanup (#918
     expect(updated.paint?.['fill-pattern']).toBe('geolens-fill-hatch');
     const builder = (updated.style_config as { builder?: Record<string, unknown> } | null)?.builder;
     expect(builder?.fillColorSaved).toBeUndefined();
+  });
+
+  // fix(#914): the drop above is what makes the tint correct, so pin the two
+  // together. `fillPatternTint` prefers a string `fill-color` in paint over the
+  // stash, so leaving the target's colour there — which is what MapLibre would
+  // tolerate, since the pattern wins visually either way — tints the pasted
+  // pattern the TARGET's blue on the map and all three legend surfaces instead of
+  // the red the user copied. Nothing else would catch that: both halves pass
+  // their own tests, and only the composition is wrong.
+  it('leaves a pasted pattern tinting the copied colour, not the target one', () => {
+    const { result, layers } = renderWith(
+      makeLayer({ dataset_geometry_type: 'Polygon', paint: { 'fill-color': '#0000ff' } }),
+    );
+
+    act(() => {
+      result.current.handleStyleConfigChange(
+        LAYER_ID,
+        { builder: { fillColorSaved: '#ff0000' } } as StyleConfig,
+        { 'fill-color': '#0000ff', 'fill-pattern': 'geolens-fill-hatch' },
+      );
+    });
+
+    const updated = layers().find((l) => l.id === LAYER_ID)!;
+    const builder = (updated.style_config as { builder?: { fillColorSaved?: string } } | null)
+      ?.builder;
+    expect(fillPatternTint(updated.paint, builder)).toBe('#ff0000');
   });
 });
 

--- a/frontend/src/components/builder/layer-adapters/__tests__/fill-pattern-images.test.ts
+++ b/frontend/src/components/builder/layer-adapters/__tests__/fill-pattern-images.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { FILL_PATTERN_IDS, makeFillPatternImage, ensureFillPatternImages } from '../fill-pattern-images';
+import {
+  FILL_PATTERN_IDS,
+  makeFillPatternImage,
+  ensureFillPatternImages,
+  ensureTintedFillPatternImage,
+} from '../fill-pattern-images';
 
 // ──────────────────────────────────────────────────────────────────────────────
 describe('FILL_PATTERN_IDS', () => {
@@ -126,5 +131,83 @@ describe('ensureFillPatternImages', () => {
         expect(options.sdf).not.toBe(true);
       }
     }
+  });
+});
+
+// ──────────────────────────────────────────────────────────────────────────────
+// fix(#914): tinted variants. The generators used to hardcode rgb(80,80,80), so a
+// pattern never followed the layer's fill colour and read as "my fill disappeared"
+// on a light basemap.
+describe('ensureTintedFillPatternImage', () => {
+  function makeMap(existing: string[] = []) {
+    const have = new Set(existing);
+    return {
+      hasImage: vi.fn((id: string) => have.has(id)),
+      addImage: vi.fn((id: string) => have.add(id)),
+    };
+  }
+
+  it('registers a tinted variant under a colour-namespaced id and returns it', () => {
+    const map = makeMap();
+    const id = ensureTintedFillPatternImage(
+      map as never, 'geolens-fill-hatch', '#1d4ed8',
+    );
+    expect(id).toBe('geolens-fill-hatch#1d4ed8');
+    expect(map.addImage).toHaveBeenCalledWith('geolens-fill-hatch#1d4ed8', expect.anything());
+  });
+
+  it('paints the tint into the tile pixels', () => {
+    const tinted = makeFillPatternImage('geolens-fill-hatch', [255, 0, 0]);
+    const plain = makeFillPatternImage('geolens-fill-hatch');
+    // First opaque pixel of each: red vs the legacy grey.
+    const firstOpaque = (img: { data: Uint8ClampedArray }) => {
+      for (let i = 0; i < img.data.length; i += 4) {
+        if (img.data[i + 3] === 255) return [img.data[i], img.data[i + 1], img.data[i + 2]];
+      }
+      return null;
+    };
+    expect(firstOpaque(tinted)).toEqual([255, 0, 0]);
+    expect(firstOpaque(plain)).toEqual([80, 80, 80]);
+  });
+
+  it('is idempotent — an already-registered tint is not re-added', () => {
+    const map = makeMap(['geolens-fill-hatch#1d4ed8']);
+    ensureTintedFillPatternImage(map as never, 'geolens-fill-hatch', '#1d4ed8');
+    expect(map.addImage).not.toHaveBeenCalled();
+  });
+
+  it('normalises case so one tile serves #1D4ED8 and #1d4ed8', () => {
+    const map = makeMap();
+    const upper = ensureTintedFillPatternImage(map as never, 'geolens-fill-hatch', '#1D4ED8');
+    const lower = ensureTintedFillPatternImage(map as never, 'geolens-fill-hatch', '#1d4ed8');
+    expect(upper).toBe(lower);
+    expect(map.addImage).toHaveBeenCalledTimes(1);
+  });
+
+  it('expands 3-digit hex', () => {
+    const map = makeMap();
+    expect(ensureTintedFillPatternImage(map as never, 'geolens-fill-hatch', '#f00'))
+      .toBe('geolens-fill-hatch#ff0000');
+  });
+
+  it('falls back to the plain id when there is no tint, when the colour is not hex, and for unknown ids', () => {
+    const map = makeMap();
+    expect(ensureTintedFillPatternImage(map as never, 'geolens-fill-hatch', undefined))
+      .toBe('geolens-fill-hatch');
+    // A data-driven expression stringifies to something that is not a colour.
+    expect(ensureTintedFillPatternImage(map as never, 'geolens-fill-hatch', 'rgb(1,2,3)'))
+      .toBe('geolens-fill-hatch');
+    expect(ensureTintedFillPatternImage(map as never, 'some-sprite-id', '#ff0000'))
+      .toBe('some-sprite-id');
+    expect(map.addImage).not.toHaveBeenCalled();
+  });
+
+  it('returns the plain id when addImage throws', () => {
+    const map = {
+      hasImage: vi.fn(() => false),
+      addImage: vi.fn(() => { throw new Error('style not loaded'); }),
+    };
+    expect(ensureTintedFillPatternImage(map as never, 'geolens-fill-hatch', '#ff0000'))
+      .toBe('geolens-fill-hatch');
   });
 });

--- a/frontend/src/components/builder/layer-adapters/fill-adapter.ts
+++ b/frontend/src/components/builder/layer-adapters/fill-adapter.ts
@@ -11,7 +11,8 @@ import {
   syncOwnedPaintProperties,
 } from './shared';
 import { MAP_COLORS } from '@/lib/map-colors';
-import { ensureFillPatternImages } from './fill-pattern-images';
+import { ensureFillPatternImages, ensureTintedFillPatternImage } from './fill-pattern-images';
+import { fillPatternTint } from '@/lib/fill-pattern-preview';
 // builder-audit #338 DRY-06: extrusion min-zoom (14) and opacity cap (0.85) come from the
 // single builder-defaults source of truth (shared with renderAs + backend mirror).
 import { DEFAULT_EXTRUSION_MIN_ZOOM, DEFAULT_EXTRUSION_OPACITY_CAP } from './builder-defaults';
@@ -82,6 +83,24 @@ function resolveExtrusionFillColor(
     : MAP_COLORS.default.fill;
 }
 
+/**
+ * fix(#914): swap a built-in `fill-pattern` for its tinted variant on the way into
+ * MapLibre, so the pattern draws in the layer's fill colour instead of a fixed grey.
+ * Returns a copy; `rawPaint` (and therefore saved paint, the wire format and
+ * exported style.json) keeps the plain id.
+ */
+export function withTintedFillPattern(
+  map: MaplibreMap,
+  rawPaint: Record<string, unknown>,
+  builder: { fillColorSaved?: string },
+  paint: Record<string, unknown>,
+): Record<string, unknown> {
+  const id = paint['fill-pattern'];
+  if (typeof id !== 'string') return paint;
+  const tinted = ensureTintedFillPatternImage(map, id, fillPatternTint(rawPaint, builder));
+  return tinted === id ? paint : { ...paint, 'fill-pattern': tinted };
+}
+
 function getExtrusionOptions(input: AdapterLayerInput) {
   const builder = getBuilderStyleConfig(input);
   const heightScale = finiteNumber(builder.heightScale) ?? 1;
@@ -120,6 +139,7 @@ export const fillAdapter: LayerAdapter = {
       if (strokeDisabled) {
         effectiveFillPaint['fill-outline-color'] = MAP_COLORS.transparent;
       }
+      const tintedFillPaint = withTintedFillPattern(map, rawPaint, builder, effectiveFillPaint);
       // BUG-01: honor input.visible at initial add so callers that don't
       // immediately follow up with syncVisibility (e.g. swapLayerOnMap for
       // render-mode switches, the raster re-add branch in
@@ -136,7 +156,7 @@ export const fillAdapter: LayerAdapter = {
         type: 'fill',
         source: sourceId,
         ...(input.sourceType !== 'geojson' && { 'source-layer': sourceLayer }),
-        paint: effectiveFillPaint,
+        paint: tintedFillPaint,
         layout: initialLayout,
       });
       finalizeLayer(map, layerId, rawPaint, 'fill', opacity ?? 1, filter, hasExpressions);
@@ -202,7 +222,7 @@ export const fillAdapter: LayerAdapter = {
     ensureFillPatternImages(map);
     const outlineId = `${input.layerId}-outline`;
     if (map.getLayer(layerId)) {
-      syncOwnedPaintProperties(map, layerId, rawPaint, {
+      syncOwnedPaintProperties(map, layerId, withTintedFillPattern(map, rawPaint, builder, rawPaint), {
         geomType: 'fill',
         ownedProperties: FILL_OWNED_PAINT_PROPERTIES,
       });

--- a/frontend/src/components/builder/layer-adapters/fill-pattern-images.ts
+++ b/frontend/src/components/builder/layer-adapters/fill-pattern-images.ts
@@ -16,6 +16,12 @@ export type FillPatternId = typeof FILL_PATTERN_IDS[number];
 /** Shared tile size for all built-in patterns (16×16, seamlessly tileable). */
 const TILE = 16;
 
+export type Rgb = readonly [number, number, number];
+type PatternImage = { width: number; height: number; data: Uint8ClampedArray };
+
+/** The pre-#914 fixed pattern colour, still used when no tint is resolvable. */
+export const DEFAULT_PATTERN_RGB: Rgb = [80, 80, 80];
+
 /** RGBA pixel writer helper: sets a pixel at (x, y) in a TILE×TILE data array. */
 function setPixel(data: Uint8ClampedArray, x: number, y: number, r: number, g: number, b: number, a: number) {
   const i = (y * TILE + x) * 4;
@@ -26,12 +32,12 @@ function setPixel(data: Uint8ClampedArray, x: number, y: number, r: number, g: n
 }
 
 /** Horizontal hatch lines (every 4 pixels). */
-function makeHatch(): { width: number; height: number; data: Uint8ClampedArray } {
+function makeHatch(rgb: Rgb): PatternImage {
   const data = new Uint8ClampedArray(TILE * TILE * 4);
   for (let y = 0; y < TILE; y++) {
     for (let x = 0; x < TILE; x++) {
       if (y % 4 === 0) {
-        setPixel(data, x, y, 80, 80, 80, 255);
+        setPixel(data, x, y, rgb[0], rgb[1], rgb[2], 255);
       }
     }
   }
@@ -39,14 +45,14 @@ function makeHatch(): { width: number; height: number; data: Uint8ClampedArray }
 }
 
 /** True diagonal crosshatch: 45-degree lines in both directions (/ and \). */
-function makeCrosshatch(): { width: number; height: number; data: Uint8ClampedArray } {
+function makeCrosshatch(rgb: Rgb): PatternImage {
   const data = new Uint8ClampedArray(TILE * TILE * 4);
   for (let y = 0; y < TILE; y++) {
     for (let x = 0; x < TILE; x++) {
       // Forward diagonal (/) and backward diagonal (\), spaced every 4 pixels.
       // `(x - y + TILE * 4) % 4` avoids negative modulo on any JS engine.
       if ((x + y) % 4 === 0 || (x - y + TILE * 4) % 4 === 0) {
-        setPixel(data, x, y, 80, 80, 80, 255);
+        setPixel(data, x, y, rgb[0], rgb[1], rgb[2], 255);
       }
     }
   }
@@ -54,13 +60,13 @@ function makeCrosshatch(): { width: number; height: number; data: Uint8ClampedAr
 }
 
 /** 45-degree diagonal lines (bottom-left to top-right, wrapping at tile edge). */
-function makeDiagonal(): { width: number; height: number; data: Uint8ClampedArray } {
+function makeDiagonal(rgb: Rgb): PatternImage {
   const data = new Uint8ClampedArray(TILE * TILE * 4);
   for (let y = 0; y < TILE; y++) {
     for (let x = 0; x < TILE; x++) {
       // Lines appear every 4 pixels along the diagonal; wrap with modulo for seamless tiling
       if ((x + y) % 4 === 0) {
-        setPixel(data, x, y, 80, 80, 80, 255);
+        setPixel(data, x, y, rgb[0], rgb[1], rgb[2], 255);
       }
     }
   }
@@ -68,13 +74,13 @@ function makeDiagonal(): { width: number; height: number; data: Uint8ClampedArra
 }
 
 /** Regular dot grid (dots every 4 pixels, 2×2 dot size). */
-function makeDots(): { width: number; height: number; data: Uint8ClampedArray } {
+function makeDots(rgb: Rgb): PatternImage {
   const data = new Uint8ClampedArray(TILE * TILE * 4);
   for (let y = 0; y < TILE; y++) {
     for (let x = 0; x < TILE; x++) {
       // 2×2 dot at multiples of 4
       if (x % 4 < 2 && y % 4 < 2) {
-        setPixel(data, x, y, 80, 80, 80, 255);
+        setPixel(data, x, y, rgb[0], rgb[1], rgb[2], 255);
       }
     }
   }
@@ -82,19 +88,19 @@ function makeDots(): { width: number; height: number; data: Uint8ClampedArray } 
 }
 
 /** Grid: 1px lines at every 4 pixels on both axes. */
-function makeGrid(): { width: number; height: number; data: Uint8ClampedArray } {
+function makeGrid(rgb: Rgb): PatternImage {
   const data = new Uint8ClampedArray(TILE * TILE * 4);
   for (let y = 0; y < TILE; y++) {
     for (let x = 0; x < TILE; x++) {
       if (x % 4 === 0 || y % 4 === 0) {
-        setPixel(data, x, y, 80, 80, 80, 255);
+        setPixel(data, x, y, rgb[0], rgb[1], rgb[2], 255);
       }
     }
   }
   return { width: TILE, height: TILE, data };
 }
 
-const GENERATORS: Record<string, () => { width: number; height: number; data: Uint8ClampedArray }> = {
+const GENERATORS: Record<string, (rgb: Rgb) => PatternImage> = {
   'geolens-fill-hatch': makeHatch,
   'geolens-fill-crosshatch': makeCrosshatch,
   'geolens-fill-diagonal': makeDiagonal,
@@ -103,10 +109,10 @@ const GENERATORS: Record<string, () => { width: number; height: number; data: Ui
 };
 
 /** Generate the ImageData-like object for a given fill pattern id. */
-export function makeFillPatternImage(id: string): { width: number; height: number; data: Uint8ClampedArray } {
+export function makeFillPatternImage(id: string, rgb: Rgb = DEFAULT_PATTERN_RGB): PatternImage {
   const gen = GENERATORS[id];
   if (!gen) throw new Error(`[fill-pattern-images] Unknown pattern id: ${id}`);
-  return gen();
+  return gen(rgb);
 }
 
 /**
@@ -123,4 +129,55 @@ export function ensureFillPatternImages(map: MaplibreMap): void {
       if (import.meta.env.DEV) console.warn('[map-sync] Fill pattern registration failed:', e);
     }
   }
+}
+
+/**
+ * fix(#914): the runtime id for a pattern drawn in `color`, registering the tinted
+ * tile on first use. Returns the plain id when there is no tint to apply or the
+ * colour is not a hex string we can turn into pixels, which keeps every existing
+ * saved map rendering exactly as before.
+ *
+ * INVARIANT: the returned id is a MapLibre registry key, never a style value.
+ * Saved paint, the wire format and exported style.json all keep the plain
+ * `geolens-fill-*` id — a tinted id names an image that exists only inside the
+ * one browser session that happened to have that layer open.
+ */
+export function ensureTintedFillPatternImage(
+  map: MaplibreMap,
+  id: string,
+  color: string | undefined,
+): string {
+  if (!GENERATORS[id] || !color) return id;
+  const rgb = hexToRgb(color);
+  if (!rgb) return id;
+  const tintedId = tintedFillPatternId(id, rgb);
+  try {
+    if (!map.hasImage?.(tintedId)) map.addImage(tintedId, makeFillPatternImage(id, rgb));
+  } catch (e) {
+    if (import.meta.env.DEV) console.warn('[map-sync] Tinted fill pattern registration failed:', e);
+    return id;
+  }
+  return tintedId;
+}
+
+/** `geolens-fill-hatch#1d4ed8` — normalised so `#1D4ED8` and `#1d4ed8` share a tile. */
+function tintedFillPatternId(id: string, rgb: Rgb): string {
+  const hex = rgb.map((c) => c.toString(16).padStart(2, '0')).join('');
+  return `${id}#${hex}`;
+}
+
+/**
+ * Strict 6- or 3-digit hex to RGB. Deliberately narrow: every colour the builder
+ * writes is `#rrggbb` (MAP_COLORS and react-colorful both), and anything else
+ * falls back to the untinted tile rather than guessing.
+ */
+function hexToRgb(color: string): Rgb | null {
+  const m = /^#([0-9a-f]{6}|[0-9a-f]{3})$/i.exec(color.trim());
+  if (!m) return null;
+  const hex = m[1].length === 3 ? m[1].replace(/./g, (c) => c + c) : m[1];
+  return [
+    parseInt(hex.slice(0, 2), 16),
+    parseInt(hex.slice(2, 4), 16),
+    parseInt(hex.slice(4, 6), 16),
+  ];
 }

--- a/frontend/src/components/builder/layer-adapters/mixed-adapter.ts
+++ b/frontend/src/components/builder/layer-adapters/mixed-adapter.ts
@@ -5,6 +5,7 @@ import type { AdapterLayerInput, LayerAdapter } from './types';
 import {
   filterPaintForLayerType,
   finalizeLayer,
+  getBuilderStyleConfig,
   getExpressionSafeOpacity,
   syncOwnedLayoutProperties,
   syncOwnedPaintProperties,
@@ -13,7 +14,11 @@ import {
 // builder-audit #338 ADAPT-03 precedent (cluster-adapter): sibling sublayers reuse
 // the standalone adapters' owned-property sets and defaults instead of duplicating them.
 import { CIRCLE_OWNED_PAINT_PROPERTIES } from './circle-adapter';
-import { FILL_OWNED_PAINT_PROPERTIES, OUTLINE_OWNED_PAINT_PROPERTIES } from './fill-adapter';
+import {
+  FILL_OWNED_PAINT_PROPERTIES,
+  OUTLINE_OWNED_PAINT_PROPERTIES,
+  withTintedFillPattern,
+} from './fill-adapter';
 import { ensureFillPatternImages } from './fill-pattern-images';
 import { LINE_OWNED_LAYOUT_PROPERTIES, LINE_OWNED_PAINT_PROPERTIES } from './line-adapter';
 import { DEFAULT_CIRCLE_PAINT, DEFAULT_FILL_PAINT } from './builder-defaults';
@@ -92,9 +97,12 @@ const DEFAULT_MIXED_LINE_PAINT = {
 // both the add-time and sync-time paths. The layer's stored paint typically only
 // carries fill-* keys (GEOMETRY seeds as the polygon family), so the line/point
 // sublayers fall back to defaults until family-specific keys are authored.
-function mixedFillPaint(input: AdapterLayerInput): Record<string, unknown> {
+function mixedFillPaint(map: MaplibreMap, input: AdapterLayerInput): Record<string, unknown> {
   const paint = filterPaintForLayerType(input.paint, 'fill');
-  return Object.keys(paint).length > 0 ? paint : { ...DEFAULT_FILL_PAINT };
+  const effective = Object.keys(paint).length > 0 ? paint : { ...DEFAULT_FILL_PAINT };
+  // fix(#914): the same tint swap the fill adapter makes. A patterned mixed layer
+  // would otherwise be the one surface still drawing the fixed grey.
+  return withTintedFillPattern(map, input.paint, getBuilderStyleConfig(input), effective);
 }
 
 function mixedLinePaint(input: AdapterLayerInput): Record<string, unknown> {
@@ -155,7 +163,7 @@ function addFillLayer(map: MaplibreMap, input: AdapterLayerInput) {
     source: input.sourceId,
     ...sourceLayerSpec(input),
     filter,
-    paint: mixedFillPaint(input),
+    paint: mixedFillPaint(map, input),
     layout: initialLayout(input),
   });
   finalizeLayer(map, input.layerId, input.paint, 'fill', input.opacity ?? 1, filter, hasExpressions);
@@ -211,7 +219,7 @@ function addPointsLayer(map: MaplibreMap, input: AdapterLayerInput) {
 
 function syncFillLayer(map: MaplibreMap, input: AdapterLayerInput) {
   if (!map.getLayer(input.layerId)) return;
-  syncOwnedPaintProperties(map, input.layerId, mixedFillPaint(input), {
+  syncOwnedPaintProperties(map, input.layerId, mixedFillPaint(map, input), {
     geomType: 'fill',
     ownedProperties: FILL_OWNED_PAINT_PROPERTIES,
   });

--- a/frontend/src/components/map-plugins/builtin/LegendPlugin.tsx
+++ b/frontend/src/components/map-plugins/builtin/LegendPlugin.tsx
@@ -9,7 +9,7 @@ import {
   HeatmapLegend,
 } from '@/components/map/LegendEntries';
 import type { SwatchStyle } from '@/components/map/LegendEntries';
-import { fillPatternFromPaint } from '@/lib/fill-pattern-preview';
+import { fillPatternFromPaint, fillPatternTint } from '@/lib/fill-pattern-preview';
 import type { MapLayerResponse, StyleConfig } from '@/types/api';
 import { MAP_COLORS } from '@/lib/map-colors';
 import { parseStepOrInterpolate } from '@/lib/normalize-style-config';
@@ -29,6 +29,8 @@ function getSwatchStyleFromPaint(
   paint: Record<string, unknown> | undefined,
   geometryType: string | null | undefined,
   masterOpacity: number,
+  // fix(#914): the builder block carries the fill-pattern tint stash.
+  builder?: { fillColorSaved?: string },
 ): SwatchStyle {
   const gt = (inferGeometryType(paint, geometryType) ?? '').toUpperCase();
   const strokeDisabled = !!paint?.['_stroke-disabled'];
@@ -46,7 +48,15 @@ function getSwatchStyleFromPaint(
       : paint?.['fill-opacity'];
   const fillOpacity = typeof rawFillOp === 'number' ? rawFillOp : undefined;
 
-  return { outlineColor, strokeDisabled, opacity: masterOpacity, fillOpacity, strokeWidth, fillPattern: fillPatternFromPaint(paint) };
+  return {
+    outlineColor,
+    strokeDisabled,
+    opacity: masterOpacity,
+    fillOpacity,
+    strokeWidth,
+    fillPattern: fillPatternFromPaint(paint),
+    fillPatternColor: fillPatternTint(paint, builder),
+  };
 }
 
 /** Extract colors and breaks from a paint color expression for the legend. */
@@ -265,7 +275,9 @@ const LegendLayerEntry = memo(function LegendLayerEntry({
   try {
     const opacity = layer.opacity ?? 1;
     const effectiveGeom = inferGeometryType(layer.paint, layer.dataset_geometry_type);
-    const swatchStyle = getSwatchStyleFromPaint(layer.paint, effectiveGeom, opacity);
+    const swatchStyle = getSwatchStyleFromPaint(
+      layer.paint, effectiveGeom, opacity, layer.style_config?.builder,
+    );
     const weightCol = layer.paint?.['_heatmap-weight-column'] as string | undefined;
     // ENH-06: per-entry legendLabel override wins over display/dataset name.
     const entryName = legendEntryName(layer);

--- a/frontend/src/components/map/LegendEntries.tsx
+++ b/frontend/src/components/map/LegendEntries.tsx
@@ -15,6 +15,13 @@ export interface SwatchStyle {
   strokeWidth?: number;
   /** fix(#951): paint['fill-pattern'] — the polygon chip draws the pattern, not a solid block. */
   fillPattern?: string;
+  /**
+   * fix(#914): the colour the MAP draws that pattern in, from fillPatternTint().
+   * The chip's own `color` cannot be trusted for a patterned layer: a pattern
+   * deletes fill-color from paint, so whatever derived that colour fell back to a
+   * default while the map tints from the stash.
+   */
+  fillPatternColor?: string;
 }
 
 /** Compute compound opacity style from swatch style. */
@@ -69,7 +76,11 @@ export function GeometrySwatch({ geometryType, color, style: s }: GeometrySwatch
   const borderColor = !s?.strokeDisabled ? (s?.outlineColor ?? MAP_COLORS.legendOutline) : undefined;
   const style: React.CSSProperties = {
     ...(s?.fillPattern
-      ? { color, backgroundColor: 'transparent', ...patternPreviewStyle(s.fillPattern) }
+      ? {
+          color: s.fillPatternColor ?? color,
+          backgroundColor: 'transparent',
+          ...patternPreviewStyle(s.fillPattern),
+        }
       : { backgroundColor: color }),
     ...(borderColor ? { borderColor } : {}),
     ...(s?.strokeWidth ? { borderWidth: s.strokeWidth } : {}),

--- a/frontend/src/components/map/__tests__/LegendEntries.test.tsx
+++ b/frontend/src/components/map/__tests__/LegendEntries.test.tsx
@@ -38,6 +38,21 @@ describe('GeometrySwatch — patterned polygons', () => {
     expect(swatch.style.color).toBe('rgb(255, 90, 95)');
   });
 
+  // fix(#914): the map tints the pattern with the layer's fill colour, which for a
+  // patterned layer lives in the fillColorSaved stash rather than in paint — so the
+  // chip has to draw that colour, not whatever its own `color` fell back to.
+  it('draws the pattern in the colour the map tints it with, not the chip colour', () => {
+    const { container } = render(
+      <CategoricalLegend
+        geometryType="Polygon"
+        categories={[{ value: 'a', label: 'A', color: '#ff5a5f' }]}
+        style={{ fillPattern: 'geolens-fill-hatch', fillPatternColor: '#1d4ed8' }}
+      />,
+    );
+    const swatch = container.querySelector('[aria-hidden="true"]') as HTMLElement;
+    expect(swatch.style.color).toBe('rgb(29, 78, 216)');
+  });
+
   it('leaves unpatterned polygons on the solid chip', () => {
     const { container } = render(
       <CategoricalLegend

--- a/frontend/src/components/map/__tests__/layer-icons.test.tsx
+++ b/frontend/src/components/map/__tests__/layer-icons.test.tsx
@@ -184,6 +184,38 @@ describe('patterned polygon swatch (fix #951)', () => {
     expect(chip.style.color).toBe('rgb(255, 90, 95)');
   });
 
+  // fix(#914): same agreement requirement as the legend chip.
+  it('draws the pattern in the map tint when one is resolved', () => {
+    const { container } = render(
+      <ColorizedGeometryIcon
+        geometryType="POLYGON"
+        colors={['#ff5a5f']}
+        layerId="x"
+        styleHints={{ fillPattern: 'geolens-fill-dots', fillPatternColor: '#1d4ed8' }}
+      />,
+    );
+    expect((container.firstElementChild as HTMLElement).style.color).toBe('rgb(29, 78, 216)');
+  });
+
+  it('extractStyleHints resolves the tint from the fillColorSaved stash', () => {
+    // A pattern deletes fill-color from paint (EDIT-05), so the stash is the only
+    // place the layer's colour survives.
+    expect(
+      extractStyleHints({ 'fill-pattern': 'geolens-fill-grid' }, {}, 'POLYGON', 1, {
+        builder: { fillColorSaved: '#1d4ed8' },
+      }).fillPatternColor,
+    ).toBe('#1d4ed8');
+    // A layer that still carries both keys (older clients) tints from paint.
+    expect(
+      extractStyleHints({ 'fill-pattern': 'geolens-fill-grid', 'fill-color': '#ff0000' }, {}, 'POLYGON')
+        .fillPatternColor,
+    ).toBe('#ff0000');
+    // Nothing to tint with -> undefined, and every consumer falls back to grey.
+    expect(
+      extractStyleHints({ 'fill-pattern': 'geolens-fill-grid' }, {}, 'POLYGON').fillPatternColor,
+    ).toBeUndefined();
+  });
+
   it('extractStyleHints picks fill-pattern up from polygon paint', () => {
     expect(
       extractStyleHints({ 'fill-pattern': 'geolens-fill-grid' }, {}, 'POLYGON').fillPattern,

--- a/frontend/src/components/map/layer-icons.tsx
+++ b/frontend/src/components/map/layer-icons.tsx
@@ -3,7 +3,7 @@ import { Circle, Pentagon, Grid3x3, Layers } from 'lucide-react';
 import { getColorProperty, getRampColors } from '@/lib/color-ramps';
 import { getLayerCapabilities } from '@/lib/layer-capabilities';
 import { MAP_COLORS } from '@/lib/map-colors';
-import { fillPatternFromPaint, patternPreviewStyle } from '@/lib/fill-pattern-preview';
+import { fillPatternFromPaint, fillPatternTint, patternPreviewStyle } from '@/lib/fill-pattern-preview';
 import type { MapLayerResponse } from '@/types/api';
 
 /** Darken a hex color by reducing each channel by ~30% for outline contrast */
@@ -24,6 +24,7 @@ export interface StyleHints {
   radius?: number;           // circle-radius raw value — map to SVG size hint
   isHeatmap?: boolean;       // render_mode === 'heatmap' — triggers radial gradient icon
   fillPattern?: string;      // fix(#951): paint['fill-pattern'] — the swatch draws the pattern
+  fillPatternColor?: string; // fix(#914): the colour the MAP tints that pattern with
 }
 
 /**
@@ -35,7 +36,8 @@ export function extractStyleHints(
   layout: Record<string, unknown>,
   geometryType: string | null,
   opacity?: number,
-  styleConfig?: { render_mode?: string } | null,
+  // fix(#914): `builder` is read for the fill-pattern tint stash.
+  styleConfig?: { render_mode?: string; builder?: { fillColorSaved?: string } } | null,
 ): StyleHints {
   const gt = (geometryType ?? '').toUpperCase();
   const hints: StyleHints = {};
@@ -74,6 +76,9 @@ export function extractStyleHints(
   // above — a GEOMETRY / GEOMETRYCOLLECTION layer renders a fill sublayer via
   // the mixed adapter and gets the shape icon, but matches neither branch.
   hints.fillPattern = fillPatternFromPaint(paint);
+  // fix(#914): a pattern deletes fill-color, so `colors[0]` below falls back to a
+  // default while the map tints from the stash — resolve the map's colour here.
+  hints.fillPatternColor = fillPatternTint(paint, styleConfig?.builder);
 
   if (gt.includes('POINT')) {
     if (!paint['_stroke-disabled']) {
@@ -194,7 +199,7 @@ function ShapeIcon({ colors, layerId, opacityStyle, styleHints, isPoint, discret
       <span
         className="inline-block h-3.5 w-3.5 shrink-0 rounded-sm border"
         style={{
-          color: colors[0] ?? MAP_COLORS.icon.fallback,
+          color: styleHints.fillPatternColor ?? colors[0] ?? MAP_COLORS.icon.fallback,
           borderColor: showOutline ? (styleHints.strokeColor ?? MAP_COLORS.icon.outline) : 'transparent',
           ...patternPreviewStyle(styleHints.fillPattern),
           ...opacityStyle,

--- a/frontend/src/components/viewer/LayerLegend.tsx
+++ b/frontend/src/components/viewer/LayerLegend.tsx
@@ -10,7 +10,7 @@ import {
   HeatmapLegend,
 } from '@/components/map/LegendEntries';
 import type { SwatchStyle } from '@/components/map/LegendEntries';
-import { fillPatternFromPaint } from '@/lib/fill-pattern-preview';
+import { fillPatternFromPaint, fillPatternTint } from '@/lib/fill-pattern-preview';
 import { Eye, EyeOff, Layers, X } from 'lucide-react';
 import { parseStepOrInterpolate } from '@/lib/normalize-style-config';
 import { MAP_COLORS } from '@/lib/map-colors';
@@ -61,7 +61,14 @@ function viewerSwatchStyle(layer: SharedLayerResponse): SwatchStyle {
     ? layer.paint?.['circle-opacity']
     : gt.includes('LINE') ? layer.paint?.['line-opacity'] : layer.paint?.['fill-opacity'];
   const fillOpacity = typeof rawFillOp === 'number' ? rawFillOp : undefined;
-  return { outlineColor, opacity: layer.opacity ?? 1, fillOpacity, strokeWidth, fillPattern: fillPatternFromPaint(layer.paint ?? undefined) };
+  return {
+    outlineColor,
+    opacity: layer.opacity ?? 1,
+    fillOpacity,
+    strokeWidth,
+    fillPattern: fillPatternFromPaint(layer.paint ?? undefined),
+    fillPatternColor: fillPatternTint(layer.paint ?? undefined, layer.style_config?.builder),
+  };
 }
 
 function parsePaintColors(paintColorValue: unknown): { colors: string[]; breaks: number[] } | null {

--- a/frontend/src/lib/__tests__/fill-pattern-preview.tint.test.ts
+++ b/frontend/src/lib/__tests__/fill-pattern-preview.tint.test.ts
@@ -1,0 +1,38 @@
+/**
+ * fix(#910, codex P2): `fillPatternTint` resolves the colour a built-in pattern draws
+ * in, and its `builder` argument is DECLARED `{ fillColorSaved?: string }` while the
+ * runtime value comes from an open `style_config` that gets serialized-size validation
+ * only. Handing a non-string through fed a junk tint to `ensureTintedFillPatternImage`,
+ * whose throw is swallowed by fillAdapter.addLayers' catch — so the entire layer failed
+ * to build rather than merely losing its tint. Caught only when #914 and #910 were
+ * composed: each half passed its own suite.
+ */
+import { describe, it, expect } from 'vitest';
+import { fillPatternTint } from '@/lib/fill-pattern-preview';
+
+describe('fillPatternTint', () => {
+  it('prefers a solid paint colour', () => {
+    expect(fillPatternTint({ 'fill-color': '#abcdef' }, { fillColorSaved: '#0f0' })).toBe('#abcdef');
+  });
+
+  it('falls back to the stash when a pattern owns the fill', () => {
+    expect(fillPatternTint({ 'fill-pattern': 'geolens-fill-hatch' }, { fillColorSaved: '#0f0' })).toBe('#0f0');
+  });
+
+  it('ignores an expression-valued paint colour, which cannot be a tint', () => {
+    const ramp = ['match', ['get', 'k'], 'a', '#f00', '#0f0'];
+    expect(fillPatternTint({ 'fill-color': ramp }, { fillColorSaved: '#0f0' })).toBe('#0f0');
+  });
+
+  it.each([[42], [{ r: 1 }], [['#fff']], [true], [null]])(
+    'returns undefined for a non-string stash (%o) rather than passing junk on',
+    (junk) => {
+      const builder = { fillColorSaved: junk } as unknown as { fillColorSaved?: string };
+      expect(fillPatternTint({ 'fill-pattern': 'geolens-fill-hatch' }, builder)).toBeUndefined();
+    },
+  );
+
+  it('returns undefined when there is nothing to tint with', () => {
+    expect(fillPatternTint({}, undefined)).toBeUndefined();
+  });
+});

--- a/frontend/src/lib/fill-pattern-preview.ts
+++ b/frontend/src/lib/fill-pattern-preview.ts
@@ -63,3 +63,32 @@ export function fillPatternFromPaint(paint: Record<string, unknown> | undefined)
     ? value
     : undefined;
 }
+
+/**
+ * fix(#914): the colour a built-in fill pattern draws in — the layer's own fill
+ * colour, wherever it currently lives.
+ *
+ * A pattern deletes `fill-color` from paint (EDIT-05), so for any layer patterned
+ * through the picker the colour is in the `fillColorSaved` stash (#910). `paint`
+ * still wins when it holds a string, which covers maps saved by older clients that
+ * carry both keys. Returns undefined when there is nothing to tint with, and every
+ * consumer then falls back to the fixed grey — map and previews alike.
+ *
+ * The map adapter and the three preview surfaces all resolve the tint through this
+ * one function; a surface left reading its own colour would disagree with the map,
+ * which is the #951 class of bug this enhancement could otherwise reintroduce.
+ */
+export function fillPatternTint(
+  paint: Record<string, unknown> | undefined,
+  builder: { fillColorSaved?: string } | undefined,
+): string | undefined {
+  const painted = paint?.['fill-color'];
+  if (typeof painted === 'string') return painted;
+  // fix(#910, codex P2): the stash is DECLARED string but arrives from an open
+  // `style_config` that gets serialized-size validation only, so an API-authored or
+  // imported layer can hold a number or object here. Returning that fed a junk tint
+  // into `ensureTintedFillPatternImage`, whose throw is swallowed by `addLayers`' catch
+  // — so the whole layer silently failed to build, not just the tint. Every other
+  // reader of this stash applies the same check.
+  return typeof builder?.fillColorSaved === 'string' ? builder.fillColorSaved : undefined;
+}


### PR DESCRIPTION
Closes #914 (the tinting half; the legend/swatch mismatch was #951, shipped in #979).

## What was wrong

The five pattern tiles were generated with a hardcoded `rgb(80,80,80)`, and `makeFillPatternImage(id)` took no colour at all. Meanwhile the picker swatches preview each pattern in `currentColor`, so the control promises the pattern will follow the fill colour. It never did — and at the default 0.3 fill opacity a 1px grey line on a light basemap reads as "my fill disappeared".

## What changed

The generators take an `rgb`, and tinted variants register lazily under colour-namespaced ids (`geolens-fill-hatch#1d4ed8`) the first time a layer needs one. The plain ids stay registered, so any layer without a resolvable tint — and every existing saved map — renders exactly as before.

**The swap happens on the way into `addLayer` / `setPaintProperty`, nowhere else.** A tinted id is a MapLibre registry key, not a style value: saved `paint`, the wire format and exported `style.json` all keep the plain id, because a tinted id names an image that exists only inside the one browser session that had that layer open. The issue asks for a test rather than a comment on this and it gets three — the two adapter paths assert the input paint object is untouched after the call, and a live save confirms it end to end. It matters because #917 already ships builtin pattern ids the served sprite does not contain; a leaked tinted id would make that strictly worse.

**One tint resolver, four consumers.** `fillPatternTint(paint, builder)` returns the fill colour from `paint` when it holds a string (older clients that carry both keys), else #910's `fillColorSaved` stash, which is where the colour lives once a pattern owns the fill. The map adapter, the legend chip (builder and viewer), the layer-list swatch and the style-editor header swatch all read it. That is the whole point of doing it this way: a surface left deriving its own colour would draw something the map does not, which is the #951 class of bug this enhancement could otherwise have reintroduced.

The mixed-geometry adapter goes through the same swap. It renders a fill sublayer for `GEOMETRY` / `GEOMETRYCOLLECTION` layers and would have been the one surface still drawing grey.

**The resolver rejects a stash it cannot use.** `builder.fillColorSaved` is declared `string` but arrives from an open `style_config` that gets serialized-size validation only, so an API-authored or imported layer can hold a number or object there. Passing one through fed a junk tint to `ensureTintedFillPatternImage`, and its throw is swallowed by `fillAdapter.addLayers`' catch — so the whole layer silently failed to build, not merely its tint. Found only by composing this branch with #1022, whose own junk-stash tests went from green to `expected undefined to be defined`; neither branch's suite could see it alone. Pinned now by direct `fillPatternTint` unit tests over `42` / `{r:1}` / `['#fff']` / `true` / `null`.

## Interaction with the export strip (#1054 / #917)

#1054 strips a builtin `fill-pattern` from the exported `style.json` and emits a solid fill instead, because those five images are generated in the browser and are not in the served sprite. That is the right pairing for this change rather than a conflict with it: in-app the pattern draws tinted, and the exported document falls back to a solid fill **of the same colour**, since both sides resolve it from `fillColorSaved` — the tint via `fillPatternTint`, the export via the seed added in #1022. A sprite could not have carried the tint anyway; it is one shared atlas and the tint is per-layer, which is exactly the reason #1054 documents for not baking the generators into it.

## Not in scope

The tile line weight. Patterns are still 1px at the layer's fill opacity, so a tinted hatch at the 0.3 default is more legible than grey but still subtle — the issue's "2px at full alpha" alternative was the descope path if tinting did not happen, and changing it now would restyle every existing patterned map. Worth its own decision if the tint alone does not settle the visibility half of the report.

## Verification

```
cd frontend && npm run lint && npm run typecheck && npm run test:coverage
# 369 files, 4486 tests pass

npx vitest run src/components/builder/layer-adapters/__tests__/fill-pattern-images.test.ts \
  src/components/builder/__tests__/layer-adapters.test.ts \
  src/lib/__tests__/fill-pattern-preview.tint.test.ts \
  src/components/map/__tests__/LegendEntries.test.tsx \
  src/components/map/__tests__/layer-icons.test.tsx
```

New tests: tinted-id namespacing, case normalisation, 3-digit hex expansion, idempotency, the pixel colour actually changing, and the four fallbacks (no tint / non-hex / unknown id / `addImage` throwing); the never-persisted invariant on both adapter paths; the tint agreement on the legend chip and layer-list swatch, including that `extractStyleHints` resolves the colour from the stash; `fillPatternTint` directly, including every non-string stash shape; and one test that a **pasted** pattern tints the colour the user copied rather than the target's old one. It began as a cross-branch check against #1022 (now merged as 06b32dcd6): without that PR's fill-colour drop, `fill-color` survives in paint, `fillPatternTint` prefers it, and the map plus all three legend surfaces silently agree on the wrong colour (`expected '#0000ff' to be '#ff0000'`). It stays as the regression guard for that pairing.

Live, on a red polygon layer over the dev stack:

- hatch on a red layer draws **red** hatching (the same layer hatched near-invisible grey before),
- it survives save and reload, where the only colour left is the stash (`paint` is `{fill-opacity, fill-pattern}`),
- saved `paint` carries `geolens-fill-hatch`, not the tinted id,
- legend chip and layer-list swatch draw the same red,
- zero console errors.

The **viewer** surface is verified the same way, unauthenticated through a share token (`/m/{token}`): the polygons draw red hatching, the legend chip's computed style resolves to `rgb(255, 0, 0)` over a red `repeating-linear-gradient`, and there are no console errors. The saved layer at that point carries `{fill-opacity, fill-pattern}` with no `fill-color` at all, so the only place that red can have come from is the `fillColorSaved` stash — which is the whole point of routing every surface through one resolver.
