### PR TITLE
fix(builder): let a builder clear actually clear

### DIFF
--- a/frontend/src/components/builder/LayerStyleEditor.tsx
+++ b/frontend/src/components/builder/LayerStyleEditor.tsx
@@ -262,7 +262,23 @@ export const LayerStyleEditor = memo(function LayerStyleEditor({
   );
 
   const updateBuilderConfig = useCallback((patch: BuilderStyleConfig, nextPaint: Record<string, unknown> = paint) => {
-    onStyleConfigChange(layer.id, withBuilderConfig(layer.style_config, patch), stripLegacyBuilderPaint(nextPaint));
+    const nextConfig = withBuilderConfig(layer.style_config, patch);
+    const strippedPaint = stripLegacyBuilderPaint(nextPaint);
+    // A patch that EMPTIES the builder has to replace, not merge. withBuilderConfig
+    // drops the builder key once every field compacts away (collapsing the whole
+    // config to null when nothing else is left), and handleStyleConfigChange reads a
+    // missing builder as "keep the existing one" — so the default merge silently
+    // undoes the clear. That is the same collapse #1022 hit with the fill-color
+    // stash, and it reached three controls here: the fill and stroke visibility
+    // switches sprang straight back on, and a line gradient survived switching to
+    // Solid. Detected centrally because `onBuilderChange` is one prop shared by every
+    // builder control, so a per-caller flag would have to be threaded through all of
+    // them and would go stale the next time a control learns to clear a key.
+    if (!nextConfig?.builder && layer.style_config?.builder) {
+      onStyleConfigChange(layer.id, nextConfig, strippedPaint, { replace: true });
+      return;
+    }
+    onStyleConfigChange(layer.id, nextConfig, strippedPaint);
   }, [layer.id, layer.style_config, paint, onStyleConfigChange]);
 
   const handlePaintProp = useCallback((key: string, value: unknown) => {

--- a/frontend/src/components/builder/__tests__/LayerStyleEditor.test.tsx
+++ b/frontend/src/components/builder/__tests__/LayerStyleEditor.test.tsx
@@ -204,6 +204,117 @@ describe('LayerStyleEditor - SP-05 pending preview banner gating', () => {
   });
 });
 
+// Every builder control writes through updateBuilderConfig, so a patch that empties
+// the builder has to REPLACE: withBuilderConfig drops the builder key and
+// handleStyleConfigChange reads a missing builder as "keep the existing one", which
+// silently undoes the clear. Three controls reached that state.
+describe('LayerStyleEditor - builder clears actually clear', () => {
+  const editorProps = (layer: MapLayerResponse, onStyleConfigChange: () => void) => ({
+    layer,
+    savedLayer: layer,
+    onPaintChange: vi.fn(),
+    onOpacityChange: vi.fn(),
+    onStyleConfigChange,
+    onLayoutChange: vi.fn(),
+  });
+
+  it('switching a gradient line back to Solid replaces, so lineGradient cannot return', async () => {
+    const onStyleConfigChange = vi.fn();
+    const user = userEvent.setup();
+    const stops = [{ position: 0, color: '#000000' }, { position: 1, color: '#ffffff' }];
+    // A fresh line layer has builder: null, so the gradient is the ONLY builder key
+    // and removing it empties the config.
+    const layer = makeLayer({
+      dataset_geometry_type: 'LineString',
+      paint: { 'line-color': '#abcdef', 'line-gradient': stopsToLineGradientExpression(stops) },
+      style_config: { builder: { lineGradient: { stops } } } as unknown as MapLayerResponse['style_config'],
+    });
+
+    render(<LayerStyleEditor {...editorProps(layer, onStyleConfigChange)} />);
+    // "Solid color" is the gradient-mode toggle; the bare "Solid" button is a dash preset.
+    await user.click(screen.getByRole('button', { name: 'Solid color' }));
+
+    const last = onStyleConfigChange.mock.calls[onStyleConfigChange.mock.calls.length - 1];
+    expect(last[1]).toBeNull();
+    expect(last[3]).toEqual({ replace: true });
+  });
+
+  it('an ordinary builder edit still merges — replace is only for clears', async () => {
+    const onStyleConfigChange = vi.fn();
+    const user = userEvent.setup();
+    const layer = makeLayer({
+      dataset_geometry_type: 'LineString',
+      paint: { 'line-color': '#abcdef' },
+      style_config: { builder: { outlineColor: '#112233' } } as unknown as MapLayerResponse['style_config'],
+    });
+
+    render(<LayerStyleEditor {...editorProps(layer, onStyleConfigChange)} />);
+    await user.click(screen.getByRole('button', { name: 'Gradient' }));
+
+    const last = onStyleConfigChange.mock.calls[onStyleConfigChange.mock.calls.length - 1];
+    expect(last[1]?.builder?.lineGradient).toBeTruthy();
+    // 3 args, no opts: the funnel's merge must keep the live layer's builder.
+    expect(last).toHaveLength(3);
+  });
+});
+
+// The fill/stroke visibility switches stash a value in the builder and clear it on
+// the way back, which is how the collapse above was found.
+describe('LayerStyleEditor - visibility toggles clear their own builder stash', () => {
+  const toggleProps = (layer: MapLayerResponse, onStyleConfigChange: () => void) => ({
+    layer,
+    savedLayer: layer,
+    onPaintChange: vi.fn(),
+    onOpacityChange: vi.fn(),
+    onStyleConfigChange,
+    onLayoutChange: vi.fn(),
+  });
+
+  it('re-enabling fill replaces the config so fillDisabled cannot survive', async () => {
+    const onStyleConfigChange = vi.fn();
+    const user = userEvent.setup();
+    // The stash is the ONLY builder content, which is what a layer looks like after
+    // toggling fill off with no other builder-backed edit.
+    const layer = makeLayer({
+      dataset_geometry_type: 'Polygon',
+      paint: { 'fill-color': '#3b82f6', 'fill-opacity': 0 },
+      style_config: { builder: { fillDisabled: true, fillOpacitySaved: 0.8 } } as MapLayerResponse['style_config'],
+    });
+
+    render(<LayerStyleEditor {...toggleProps(layer, onStyleConfigChange)} />);
+    await user.click(screen.getByLabelText('Toggle fill visibility'));
+
+    expect(onStyleConfigChange).toHaveBeenCalledWith(
+      'layer-1',
+      null,
+      expect.objectContaining({ 'fill-opacity': 0.8 }),
+      { replace: true },
+    );
+  });
+
+  it('re-enabling stroke on a circle layer replaces the config too', async () => {
+    const onStyleConfigChange = vi.fn();
+    const user = userEvent.setup();
+    // Circle is the geometry whose re-enable patch is stash-only: the polygon branch
+    // writes outlineWidth back, which keeps the builder non-empty by accident.
+    const layer = makeLayer({
+      dataset_geometry_type: 'Point',
+      paint: { 'circle-color': '#3b82f6', 'circle-radius': 5, 'circle-stroke-width': 0 },
+      style_config: { builder: { strokeDisabled: true, outlineWidthSaved: 2 } } as MapLayerResponse['style_config'],
+    });
+
+    render(<LayerStyleEditor {...toggleProps(layer, onStyleConfigChange)} />);
+    await user.click(screen.getByLabelText('Toggle stroke visibility'));
+
+    expect(onStyleConfigChange).toHaveBeenCalledWith(
+      'layer-1',
+      null,
+      expect.objectContaining({ 'circle-stroke-width': 2 }),
+      { replace: true },
+    );
+  });
+});
+
 describe('LayerStyleEditor - B-010 Advanced JSON strips builder-private keys', () => {
   it('hides _-prefixed + legacy builder keys from the Advanced Paint JSON textarea', async () => {
     const user = userEvent.setup();


### PR DESCRIPTION
No issue — this is a session finding from the #910/#918 work, split out because it is a separate defect with a separate cause. It is the same collapse #1022 (06b32dcd6) hit with the fill-colour stash, reaching three more controls.

## What was wrong

Every builder control writes through `updateBuilderConfig`. When a patch **empties** the builder, `withBuilderConfig` drops the builder key — collapsing the whole config to `null` once nothing else is left — and `handleStyleConfigChange` reads a missing builder as "keep the existing one". So the default merge put back exactly what the user had just cleared.

Three controls reached that state. Each was live-reproduced against main, not inferred:

- **Point layer, stroke toggle off then on.** The switch springs straight back off, and a save persists `stroke_disabled: true`.
- **Line layer, Gradient then Solid.** The mode button *looks* right, because it reads paint — but `builder.lineGradient` is still saved, and a reload brings the gradient back.
- **Polygon fill toggle.** Same shape, but a fresh polygon carries seeded `outlineColor`/`outlineWidth` that keep the config non-empty, so this third one is defensive rather than a live repro.

Reachability turns on geometry, which is why the first attempt at reproducing it failed: a fresh polygon seeds `builder: {outline_color, outline_width}` so the config never empties, while a fresh point (MULTIPOINT) and line (MULTILINESTRING) layer arrive with `builder: null`. The test only discriminated after switching to a line layer.

## The fix

Detect the emptying patch centrally and `replace` for that case only. Ordinary edits keep the merge, which re-reads the live layer's builder.

Central rather than per-caller because `onBuilderChange` is a **single prop shared by every builder control**: a per-call flag would have to be threaded through all of them, and would go stale the next time a control learns to clear a key. That is the same reasoning #1022 landed on for its paint rule, arrived at independently here.

## Verification

```
cd frontend && npm run typecheck && npm run lint
npx vitest run src/components/builder/__tests__/LayerStyleEditor.test.tsx   # 74 pass
```

Fail-before, re-measured against this branch's rebase onto `06b32dcd6` (main's `LayerStyleEditor.tsx` swapped in, tests kept):

```
× switching a gradient line back to Solid replaces, so lineGradient cannot return
× re-enabling fill replaces the config so fillDisabled cannot survive
× re-enabling stroke on a circle layer replaces the config too
3 failed | 71 passed
```

Worth re-stating because #1022 rewrote large parts of this file after the fix was first written: the three tests still discriminate on top of it.
