### PR TITLE
ci(integration): batch 8 — #1090, #1092, #1027

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,7 +103,9 @@ jobs:
               # nginx/CSP/Dockerfile regressions). Specific files only — NOT
               # frontend/src/** — so ordinary frontend PRs stay backend-skipped.
               - 'frontend/nginx.conf'
-              - 'frontend/Dockerfile'
+              # fix(#1088): 'frontend/Dockerfile' was here and matched nothing —
+              # INF-10 deleted that file and test_phase_272_dockerfile.py keeps
+              # it deleted. A dead glob is silent in both directions.
               - 'frontend/Dockerfile.dev'
               - 'frontend/docker-entrypoint.sh'
               - 'frontend/index.html'
@@ -112,6 +114,16 @@ jobs:
               - 'frontend/src/lib/basemap-utils.ts'
               - 'frontend/src/lib/capabilities.ts'
               - 'frontend/src/components/builder/layer-adapters/shared.ts'
+              # fix(#1088): repo-root scripts that backend tests read by literal
+              # path. #1027 changed backup-entrypoint.sh and its own regression
+              # test (test_backup_staging_tar_skew.py) never ran — the backup
+              # filter covered the script, but nothing pulled in the backend
+              # suite that asserts against it. Backup Restore Round-trip went
+              # green while the test written to catch that break sat skipped.
+              # backend/scripts/* needs no entry here; backend/** covers it.
+              # test_ci_alembic_filter_paths.py now enforces both directions.
+              - 'scripts/backup-entrypoint.sh'
+              - 'scripts/init-db.sh'
               # fix(#561): a change to this workflow can alter HOW Backend Tests
               # runs (e.g. the -n4 parallelization / coverage core), so the suite
               # must run on PRs that touch it — otherwise CI-config changes ship

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -78,12 +78,20 @@ Artifacts land at:
 
 Default retention: 7 daily, 4 weekly (set `BACKUP_RETENTION_DAILY` /
 `BACKUP_RETENTION_WEEKLY` in `.env` to override). The count applies to the
-`.dump` files; the paired `staging-*.tar.gz` and `globals-*.sql` artifacts are
-pruned when the dump they belong with ages out. Retention therefore evicts whole
-backup sets, and a companion artifact never outlives its dump — which matters
-because a cycle can produce a dump without a companion (an empty staging volume,
-or a failed `pg_dumpall`), and counting each kind separately would then prune
-complete sets while leaving orphans behind.
+`.dump` files, ordered by the timestamp in the filename; the paired
+`staging-*.tar.gz` and `globals-*.sql` artifacts are pruned when the dump they
+belong with ages out. Retention therefore evicts whole backup sets, and a
+companion artifact never outlives its dump — which matters because a cycle can
+produce a dump without a companion (an empty staging volume, or a failed
+`pg_dumpall`), and counting each kind separately would prune complete sets while
+leaving orphans behind.
+
+One exception: the **newest complete set** — a dump that still has its globals
+dump — is held back on top of the window, so a directory can hold `keep` + 1
+dumps. A run of `pg_dumpall` failures still produces valid database dumps each
+cycle, and without the exemption those would walk the last restorable-onto-a-
+fresh-cluster set out of retention while the healthcheck was already reporting
+the problem. The cost is one extra dump plus a few KB of SQL.
 
 ### Offsite (S3) upload
 

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -64,7 +64,7 @@ The staging archive is omitted silently when the `upload_staging` volume is abse
 or empty (fresh install with no uploaded datasets).
 
 The globals dump is the piece a database-only `pg_dump` can never give back, and
-it is what makes the fresh-cluster restore in [§ 2](#multi-tenant-role-reconstruction-after-a-fresh-cluster-restore)
+it is what makes the fresh-cluster role reconstruction in [§ 2](#2-restore--bundled-postgres-mode)
 work. It contains **role password verifiers**, so it is written mode `0600` and
 must keep the same protection as the dump itself wherever it is copied. A
 `pg_dumpall` failure fails the whole cycle: a backup set that cannot restore its
@@ -456,8 +456,8 @@ directory as the dump — here `./restore`). For the staging archive it prints t
 `docker run` line above with the real paths filled in; copy the printed command
 from the restore output rather than hand-editing it. For the globals dump it
 reports, **before** anything destructive runs, which roles the target cluster is
-missing — replay it first if that list is non-empty (see
-[§ multi-tenant role reconstruction](#multi-tenant-role-reconstruction-after-a-fresh-cluster-restore)).
+missing — replay it first if that list is non-empty, following the role
+reconstruction procedure earlier in this section.
 
 ### Finding the dump to restore
 

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -842,14 +842,20 @@ Determine what was lost:
 # List all daily dumps in the backup_data volume, newest first
 docker compose exec backup sh -c 'ls -lt /backups/daily/*.dump'
 
-# Copy the chosen dump (and its paired staging archive) out of the volume.
+# Copy the chosen dump and BOTH its paired artifacts out of the volume — the
+# globals dump included, or a fresh-cluster restore has no roles to replay and
+# restore.sh cannot report which ones are missing.
 # Replace <project> with your Compose project name (see `docker volume ls`).
-mkdir -p ./restore
+# umask 077: globals-*.sql holds role password verifiers.
+mkdir -p ./restore && chmod 700 ./restore
 docker run --rm \
   -v <project>_backup_data:/backups:ro \
   -v "$(pwd)/restore":/out \
-  alpine sh -c 'cp /backups/daily/geolens_<YYYYmmdd_HHMMSS>.dump /out/ && \
-                cp /backups/daily/staging-<YYYYmmdd_HHMMSS>.tar.gz /out/ 2>/dev/null; ls -lh /out'
+  alpine sh -c 'umask 077; \
+                cp /backups/daily/geolens_<YYYYmmdd_HHMMSS>.dump /out/ && \
+                cp /backups/daily/staging-<YYYYmmdd_HHMMSS>.tar.gz /out/ 2>/dev/null; \
+                cp /backups/daily/globals-<YYYYmmdd_HHMMSS>.sql /out/ 2>/dev/null; \
+                ls -lh /out'
 
 # Validate the candidate dump before restoring. Omit the filename to read
 # stdin: PG 18 rejects the literal `-` with `could not open input file "-"`,

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -52,15 +52,23 @@ BACKUP_SCHEDULE=0 3 * * *    # 03:00 daily — must be in "M H * * *" form
 
 ### What each backup cycle captures
 
-Each cycle produces two paired artifacts with matching timestamps:
+Each cycle produces three paired artifacts with matching timestamps:
 
 | Artifact | Format | What it contains |
 |---|---|---|
 | `<db>_<YYYYmmdd_HHMMSS>.dump` | `pg_dump -Fc` custom-format | Full database (schema + data), restorable via `pg_restore` |
 | `staging-<YYYYmmdd_HHMMSS>.tar.gz` | tar.gz | Contents of the `upload_staging` volume (source files, rasters, COGs) |
+| `globals-<YYYYmmdd_HHMMSS>.sql` | `pg_dumpall --globals-only` plain SQL | Cluster roles, their passwords, and cluster-wide grants |
 
 The staging archive is omitted silently when the `upload_staging` volume is absent
 or empty (fresh install with no uploaded datasets).
+
+The globals dump is the piece a database-only `pg_dump` can never give back, and
+it is what makes the fresh-cluster restore in [§ 2](#multi-tenant-role-reconstruction-after-a-fresh-cluster-restore)
+work. It contains **role password verifiers**, so it is written mode `0600` and
+must keep the same protection as the dump itself wherever it is copied. A
+`pg_dumpall` failure fails the whole cycle: a backup set that cannot restore its
+roles should not be reported as a good one.
 
 ### Retention
 
@@ -69,8 +77,10 @@ Artifacts land at:
 - Weekly (every Sunday): `backup_data` volume → `/backups/weekly/`
 
 Default retention: 7 daily, 4 weekly (set `BACKUP_RETENTION_DAILY` /
-`BACKUP_RETENTION_WEEKLY` in `.env` to override). Retention prunes both
-`.dump` files and their paired `staging-*.tar.gz` archives.
+`BACKUP_RETENTION_WEEKLY` in `.env` to override). Retention prunes all three
+artifact kinds on the same counts — `.dump` files, their paired
+`staging-*.tar.gz` archives, and their paired `globals-*.sql` dumps — so a
+globals dump never outlives the dump it belongs with.
 
 ### Offsite (S3) upload
 
@@ -161,24 +171,31 @@ Run both before starting API, worker, or tile traffic.
 
 **Step 1 — put the roles on the new cluster.**
 
-The clean way is a globals dump captured from the source cluster while it is
-still reachable, or from a replica. Take one now if your backup cycle has no
-`pg_dumpall --globals-only` artifact — it is the piece a database-only
-`pg_dump` can never give back.
+Use the `globals-<timestamp>.sql` artifact that the backup cycle wrote next to
+the dump you are restoring. It is captured automatically, from the source
+cluster, at the moment of the dump — matching timestamps mean the roles and the
+data belong to the same point in time. Replay it **before** `pg_restore`:
 
 ```bash
 # Load .env so $POSTGRES_USER / $POSTGRES_DB are set in this shell.
 set -a; . ./.env; set +a
 
-# On the source cluster. umask 077 because --globals-only emits role password
-# verifiers: under a default 022 umask this file lands world-readable. Store it
-# with the same protection as the dump itself, or add --no-role-passwords and
-# reset the login passwords during recovery instead.
+# On the new cluster, BEFORE pg_restore. Substitute the timestamp of the dump
+# you are restoring; both files sit in /backups/daily (or weekly) together.
+docker compose exec -T db psql -U "$POSTGRES_USER" -d postgres \
+  < globals-<YYYYmmdd_HHMMSS>.sql
+```
+
+If the source cluster is still reachable and you would rather capture roles as
+of now than as of the dump, take a fresh globals dump instead:
+
+```bash
+# umask 077 because --globals-only emits role password verifiers: under a
+# default 022 umask this file lands world-readable. Store it with the same
+# protection as the dump itself, or add --no-role-passwords and reset the login
+# passwords during recovery instead.
 (umask 077; docker compose exec -T db \
   pg_dumpall --globals-only -U "$POSTGRES_USER" > globals.sql)
-
-# On the new cluster, BEFORE pg_restore.
-docker compose exec -T db psql -U "$POSTGRES_USER" -d postgres < globals.sql
 ```
 
 For managed/external Postgres there is no `db` container to exec into: drop the

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -77,10 +77,13 @@ Artifacts land at:
 - Weekly (every Sunday): `backup_data` volume → `/backups/weekly/`
 
 Default retention: 7 daily, 4 weekly (set `BACKUP_RETENTION_DAILY` /
-`BACKUP_RETENTION_WEEKLY` in `.env` to override). Retention prunes all three
-artifact kinds on the same counts — `.dump` files, their paired
-`staging-*.tar.gz` archives, and their paired `globals-*.sql` dumps — so a
-globals dump never outlives the dump it belongs with.
+`BACKUP_RETENTION_WEEKLY` in `.env` to override). The count applies to the
+`.dump` files; the paired `staging-*.tar.gz` and `globals-*.sql` artifacts are
+pruned when the dump they belong with ages out. Retention therefore evicts whole
+backup sets, and a companion artifact never outlives its dump — which matters
+because a cycle can produce a dump without a companion (an empty staging volume,
+or a failed `pg_dumpall`), and counting each kind separately would then prune
+complete sets while leaving orphans behind.
 
 ### Offsite (S3) upload
 
@@ -139,16 +142,20 @@ self-hosted Docker Compose deployment).
 1. Validates the dump with `pg_restore -f /dev/null` — reads every data block
    and aborts if the file is corrupt or truncated. (`--list` would only read the
    table of contents, which a truncated archive still passes.)
-2. Creates required extensions and schemas in the database.
-3. Stops `api` and `worker` to prevent write conflicts.
-4. Runs `pg_restore --clean --if-exists --no-owner` against the bundled `db` container.
-5. Re-applies the `geolens_reader` grants on schema `data` and asserts they took
+2. Reports any sibling `globals-<timestamp>.sql`, naming the roles it defines
+   that the target cluster is missing. This happens **before** anything
+   destructive, because replaying globals is a pre-restore step. It is a
+   warning, not a gate: a same-cluster restore already has its roles.
+3. Creates required extensions and schemas in the database.
+4. Stops `api` and `worker` to prevent write conflicts.
+5. Runs `pg_restore --clean --if-exists --no-owner` against the bundled `db` container.
+6. Re-applies the `geolens_reader` grants on schema `data` and asserts they took
    (`has_schema_privilege`). `--clean` drops the schema together with its ACLs
    and default privileges, and the dump carries no ACLs (`--no-acl`), so the
    grants must be rebuilt after every restore.
-6. Restarts `api` and `worker` on exit (including on failure — via a trap).
-7. Runs a post-restore row-count check (`catalog.records`, `catalog.datasets`).
-8. Auto-detects any sibling `staging-<timestamp>.tar.gz` next to the dump and
+7. Restarts `api` and `worker` on exit (including on failure — via a trap).
+8. Runs a post-restore row-count check (`catalog.records`, `catalog.datasets`).
+9. Auto-detects any sibling `staging-<timestamp>.tar.gz` next to the dump and
    prints the exact manual object-storage extract command.
 
 **Never** use `psql < <dump>` on a custom-format (`-Fc`) dump file — it is binary,
@@ -174,16 +181,20 @@ Run both before starting API, worker, or tile traffic.
 Use the `globals-<timestamp>.sql` artifact that the backup cycle wrote next to
 the dump you are restoring. It is captured automatically, from the source
 cluster, at the moment of the dump — matching timestamps mean the roles and the
-data belong to the same point in time. Replay it **before** `pg_restore`:
+data belong to the same point in time.
+
+Like the dump, it lives inside the `backup_data` volume, so copy it to the host
+first (step 0 of [full restore](#step-by-step-full-restore-db--object-storage)
+extracts all three artifacts together), then replay it **before** `pg_restore`:
 
 ```bash
 # Load .env so $POSTGRES_USER / $POSTGRES_DB are set in this shell.
 set -a; . ./.env; set +a
 
 # On the new cluster, BEFORE pg_restore. Substitute the timestamp of the dump
-# you are restoring; both files sit in /backups/daily (or weekly) together.
+# you are restoring; ./restore is where step 0 put the extracted artifacts.
 docker compose exec -T db psql -U "$POSTGRES_USER" -d postgres \
-  < globals-<YYYYmmdd_HHMMSS>.sql
+  < ./restore/globals-<YYYYmmdd_HHMMSS>.sql
 ```
 
 If the source cluster is still reachable and you would rather capture roles as
@@ -398,20 +409,26 @@ a misconfigured restore fails loudly rather than serving cross-tenant data.
 
 With the default backup service, dumps are written to the **`backup_data` named
 volume** at `/backups/daily`, **not** to a host directory. `restore.sh` takes a
-**host file path**, so first copy the chosen dump (and its paired
-`staging-<timestamp>.tar.gz`) out of the volume, then restore from that copy.
+**host file path**, so first copy the chosen dump and its two paired artifacts
+(`staging-<timestamp>.tar.gz`, `globals-<timestamp>.sql`) out of the volume,
+then restore from that copy. Copying all three keeps them siblings on the host,
+which is how `restore.sh` finds them.
 
 ```bash
 # 0. Copy the chosen backup out of the backup_data volume to the host.
 #    Replace <project> with your Compose project name (see `docker volume ls`;
 #    the volume is <project>_backup_data) and the timestamp with the one you
 #    picked from "Finding the dump to restore" below.
-mkdir -p ./restore
+#    umask 077: the globals file holds role password verifiers, so the copy
+#    must not be readable by other users on the host either.
+mkdir -p ./restore && chmod 700 ./restore
 docker run --rm \
   -v <project>_backup_data:/backups:ro \
   -v "$(pwd)/restore":/out \
-  alpine sh -c 'cp /backups/daily/geolens_<YYYYmmdd_HHMMSS>.dump /out/ && \
+  alpine sh -c 'umask 077; \
+                cp /backups/daily/geolens_<YYYYmmdd_HHMMSS>.dump /out/ && \
                 cp /backups/daily/staging-<YYYYmmdd_HHMMSS>.tar.gz /out/ 2>/dev/null; \
+                cp /backups/daily/globals-<YYYYmmdd_HHMMSS>.sql /out/ 2>/dev/null; \
                 ls -lh /out'
 
 # 1. Restore the database from the extracted dump.
@@ -426,10 +443,13 @@ docker run --rm \
   alpine sh -c 'cd /staging && tar xzf /restore/staging-<YYYYmmdd_HHMMSS>.tar.gz'
 ```
 
-`restore.sh` auto-detects the sibling staging archive (matched by timestamp, in the
-same directory as the dump — here `./restore`) and prints the `docker run` line
-above with the real paths filled in. Copy the printed command from the restore
-output rather than hand-editing it.
+`restore.sh` auto-detects both siblings (matched by timestamp, in the same
+directory as the dump — here `./restore`). For the staging archive it prints the
+`docker run` line above with the real paths filled in; copy the printed command
+from the restore output rather than hand-editing it. For the globals dump it
+reports, **before** anything destructive runs, which roles the target cluster is
+missing — replay it first if that list is non-empty (see
+[§ multi-tenant role reconstruction](#multi-tenant-role-reconstruction-after-a-fresh-cluster-restore)).
 
 ### Finding the dump to restore
 

--- a/backend/tests/test_ci_alembic_filter_paths.py
+++ b/backend/tests/test_ci_alembic_filter_paths.py
@@ -1,4 +1,4 @@
-"""OCG-02: Alembic paths-filter guard test.
+"""OCG-02: ci.yml paths-filter guard tests.
 
 Parses the alembic filter list from .github/workflows/ci.yml and asserts:
 1. Every glob in the alembic filter matches at least one real file on disk
@@ -7,16 +7,21 @@ Parses the alembic filter list from .github/workflows/ci.yml and asserts:
 3. At least one glob covers real model modules (e.g. backend/app/core/db/models.py
    or the backend/app/**/models.py family) so a model-only PR triggers alembic check.
 
+It also guards the ``backend`` filter (fix(#1088)): every ``scripts/`` file a
+backend test reads by literal path must be in that filter, or the suite that
+asserts against the file skips on the very PR that changes it.
+
 These tests run locally (filesystem + YAML parse only; no Docker, no DB).
 They are the locally-verifiable proof of the CI fix (OCG-02).
 
-References: OCG-02
+References: OCG-02, #1088
 """
 
 from __future__ import annotations
 
 import glob
 import pathlib
+import re
 from typing import Any
 
 import yaml
@@ -30,8 +35,8 @@ REPO_ROOT = pathlib.Path(__file__).parent.parent.parent
 CI_YML_PATH = REPO_ROOT / ".github" / "workflows" / "ci.yml"
 
 
-def _parse_alembic_filter_globs() -> list[str]:
-    """Return the list of path globs from the 'alembic' filter in ci.yml."""
+def _parse_filter_globs(filter_name: str) -> list[str]:
+    """Return the list of path globs from a named paths-filter in ci.yml."""
     with CI_YML_PATH.open() as fh:
         ci: dict[str, Any] = yaml.safe_load(fh)
 
@@ -53,9 +58,36 @@ def _parse_alembic_filter_globs() -> list[str]:
     filters_raw = filter_step.get("with", {}).get("filters", "")
     filters: dict[str, list[str]] = yaml.safe_load(filters_raw)
 
-    alembic_globs: list[str] = filters.get("alembic", [])
-    assert alembic_globs, "alembic filter is empty — expected at least one glob"
-    return alembic_globs
+    globs: list[str] = filters.get(filter_name, [])
+    assert globs, f"{filter_name} filter is empty — expected at least one glob"
+    return globs
+
+
+def _parse_alembic_filter_globs() -> list[str]:
+    """Return the list of path globs from the 'alembic' filter in ci.yml."""
+    return _parse_filter_globs("alembic")
+
+
+def _scripts_referenced_by_backend_tests() -> dict[str, list[str]]:
+    """Map each ``scripts/`` path a backend test names to the tests naming it.
+
+    Literal-path reads only. A test that shells out to a script it never names
+    is invisible here, which is the limit of this guard, not a reason to skip it.
+    """
+    pattern = re.compile(r"scripts/[A-Za-z0-9_./-]+\.(?:sh|py|yml|yaml)")
+    found: dict[str, list[str]] = {}
+    tests_dir = REPO_ROOT / "backend" / "tests"
+    for path in sorted(tests_dir.rglob("*")):
+        if not path.is_file() or path.suffix not in {".py", ".sh"}:
+            continue
+        try:
+            text = path.read_text(encoding="utf-8", errors="ignore")
+        except OSError:  # pragma: no cover - unreadable file
+            continue
+        for ref in set(pattern.findall(text)):
+            if (REPO_ROOT / ref).is_file():
+                found.setdefault(ref, []).append(path.name)
+    return found
 
 
 # ---------------------------------------------------------------------------
@@ -139,4 +171,62 @@ class TestAlembicFilterGlobs:
         assert any("backend/alembic/**" in g for g in globs), (
             f"backend/alembic/** is missing from the alembic filter. "
             f"Current globs: {globs}"
+        )
+
+
+class TestBackendFilterCoversReferencedScripts:
+    """fix(#1088): guard the backend filter against the skipped-suite trap."""
+
+    def test_every_backend_glob_matches_at_least_one_real_file(self):
+        """No dead globs in the backend filter.
+
+        Caught a real one while #1088 was being written: two backend/scripts/
+        entrypoints were added here as 'scripts/...' paths, which match nothing
+        (backend/** already covers them). A dead glob is silent — it neither
+        triggers the job nor reports an error.
+        """
+        globs = _parse_filter_globs("backend")
+        missing = [
+            g for g in globs if not glob.glob(str(REPO_ROOT / g), recursive=True)
+        ]
+        assert not missing, (
+            "These globs in the 'backend' paths-filter match NO real files:\n"
+            + "\n".join(f"  - {g}" for g in missing)
+        )
+
+    def test_scripts_read_by_backend_tests_are_in_the_backend_filter(self):
+        """Every scripts/ file a backend test reads must trigger Backend Tests.
+
+        #1027 changed scripts/backup-entrypoint.sh. The backup filter covered
+        the script, so Backup Restore Round-trip ran and passed; the backend
+        filter did not, so test_backup_staging_tar_skew.py — the test written
+        to catch exactly that breakage — was skipped on the PR that broke it.
+        A skipped required job reads as green, which is how the PR looked
+        ready to merge.
+        """
+        referenced = _scripts_referenced_by_backend_tests()
+        assert referenced, (
+            "Found no scripts/ references in backend/tests — the scan is "
+            "probably broken, since several tests read them by literal path."
+        )
+
+        globs = _parse_filter_globs("backend")
+        covered: set[str] = set()
+        for pattern in globs:
+            for match in glob.glob(str(REPO_ROOT / pattern), recursive=True):
+                covered.add(str(pathlib.Path(match).relative_to(REPO_ROOT)))
+
+        uncovered = {
+            ref: tests for ref, tests in referenced.items() if ref not in covered
+        }
+        assert not uncovered, (
+            "These scripts/ files are read by backend tests but are NOT in the "
+            "'backend' paths-filter in .github/workflows/ci.yml. A PR changing "
+            "only one of them skips Backend Tests, so the test that asserts "
+            "against it never runs:\n"
+            + "\n".join(
+                f"  - {ref}  (read by {', '.join(sorted(tests))})"
+                for ref, tests in sorted(uncovered.items())
+            )
+            + "\n\nAdd each path to the 'backend' filter."
         )

--- a/frontend/src/components/builder/LayerStyleEditor.tsx
+++ b/frontend/src/components/builder/LayerStyleEditor.tsx
@@ -262,7 +262,23 @@ export const LayerStyleEditor = memo(function LayerStyleEditor({
   );
 
   const updateBuilderConfig = useCallback((patch: BuilderStyleConfig, nextPaint: Record<string, unknown> = paint) => {
-    onStyleConfigChange(layer.id, withBuilderConfig(layer.style_config, patch), stripLegacyBuilderPaint(nextPaint));
+    const nextConfig = withBuilderConfig(layer.style_config, patch);
+    const strippedPaint = stripLegacyBuilderPaint(nextPaint);
+    // A patch that EMPTIES the builder has to replace, not merge. withBuilderConfig
+    // drops the builder key once every field compacts away (collapsing the whole
+    // config to null when nothing else is left), and handleStyleConfigChange reads a
+    // missing builder as "keep the existing one" — so the default merge silently
+    // undoes the clear. That is the same collapse #1022 hit with the fill-color
+    // stash, and it reached three controls here: the fill and stroke visibility
+    // switches sprang straight back on, and a line gradient survived switching to
+    // Solid. Detected centrally because `onBuilderChange` is one prop shared by every
+    // builder control, so a per-caller flag would have to be threaded through all of
+    // them and would go stale the next time a control learns to clear a key.
+    if (!nextConfig?.builder && layer.style_config?.builder) {
+      onStyleConfigChange(layer.id, nextConfig, strippedPaint, { replace: true });
+      return;
+    }
+    onStyleConfigChange(layer.id, nextConfig, strippedPaint);
   }, [layer.id, layer.style_config, paint, onStyleConfigChange]);
 
   const handlePaintProp = useCallback((key: string, value: unknown) => {

--- a/frontend/src/components/builder/__tests__/LayerStyleEditor.test.tsx
+++ b/frontend/src/components/builder/__tests__/LayerStyleEditor.test.tsx
@@ -204,6 +204,117 @@ describe('LayerStyleEditor - SP-05 pending preview banner gating', () => {
   });
 });
 
+// Every builder control writes through updateBuilderConfig, so a patch that empties
+// the builder has to REPLACE: withBuilderConfig drops the builder key and
+// handleStyleConfigChange reads a missing builder as "keep the existing one", which
+// silently undoes the clear. Three controls reached that state.
+describe('LayerStyleEditor - builder clears actually clear', () => {
+  const editorProps = (layer: MapLayerResponse, onStyleConfigChange: () => void) => ({
+    layer,
+    savedLayer: layer,
+    onPaintChange: vi.fn(),
+    onOpacityChange: vi.fn(),
+    onStyleConfigChange,
+    onLayoutChange: vi.fn(),
+  });
+
+  it('switching a gradient line back to Solid replaces, so lineGradient cannot return', async () => {
+    const onStyleConfigChange = vi.fn();
+    const user = userEvent.setup();
+    const stops = [{ position: 0, color: '#000000' }, { position: 1, color: '#ffffff' }];
+    // A fresh line layer has builder: null, so the gradient is the ONLY builder key
+    // and removing it empties the config.
+    const layer = makeLayer({
+      dataset_geometry_type: 'LineString',
+      paint: { 'line-color': '#abcdef', 'line-gradient': stopsToLineGradientExpression(stops) },
+      style_config: { builder: { lineGradient: { stops } } } as unknown as MapLayerResponse['style_config'],
+    });
+
+    render(<LayerStyleEditor {...editorProps(layer, onStyleConfigChange)} />);
+    // "Solid color" is the gradient-mode toggle; the bare "Solid" button is a dash preset.
+    await user.click(screen.getByRole('button', { name: 'Solid color' }));
+
+    const last = onStyleConfigChange.mock.calls[onStyleConfigChange.mock.calls.length - 1];
+    expect(last[1]).toBeNull();
+    expect(last[3]).toEqual({ replace: true });
+  });
+
+  it('an ordinary builder edit still merges — replace is only for clears', async () => {
+    const onStyleConfigChange = vi.fn();
+    const user = userEvent.setup();
+    const layer = makeLayer({
+      dataset_geometry_type: 'LineString',
+      paint: { 'line-color': '#abcdef' },
+      style_config: { builder: { outlineColor: '#112233' } } as unknown as MapLayerResponse['style_config'],
+    });
+
+    render(<LayerStyleEditor {...editorProps(layer, onStyleConfigChange)} />);
+    await user.click(screen.getByRole('button', { name: 'Gradient' }));
+
+    const last = onStyleConfigChange.mock.calls[onStyleConfigChange.mock.calls.length - 1];
+    expect(last[1]?.builder?.lineGradient).toBeTruthy();
+    // 3 args, no opts: the funnel's merge must keep the live layer's builder.
+    expect(last).toHaveLength(3);
+  });
+});
+
+// The fill/stroke visibility switches stash a value in the builder and clear it on
+// the way back, which is how the collapse above was found.
+describe('LayerStyleEditor - visibility toggles clear their own builder stash', () => {
+  const toggleProps = (layer: MapLayerResponse, onStyleConfigChange: () => void) => ({
+    layer,
+    savedLayer: layer,
+    onPaintChange: vi.fn(),
+    onOpacityChange: vi.fn(),
+    onStyleConfigChange,
+    onLayoutChange: vi.fn(),
+  });
+
+  it('re-enabling fill replaces the config so fillDisabled cannot survive', async () => {
+    const onStyleConfigChange = vi.fn();
+    const user = userEvent.setup();
+    // The stash is the ONLY builder content, which is what a layer looks like after
+    // toggling fill off with no other builder-backed edit.
+    const layer = makeLayer({
+      dataset_geometry_type: 'Polygon',
+      paint: { 'fill-color': '#3b82f6', 'fill-opacity': 0 },
+      style_config: { builder: { fillDisabled: true, fillOpacitySaved: 0.8 } } as MapLayerResponse['style_config'],
+    });
+
+    render(<LayerStyleEditor {...toggleProps(layer, onStyleConfigChange)} />);
+    await user.click(screen.getByLabelText('Toggle fill visibility'));
+
+    expect(onStyleConfigChange).toHaveBeenCalledWith(
+      'layer-1',
+      null,
+      expect.objectContaining({ 'fill-opacity': 0.8 }),
+      { replace: true },
+    );
+  });
+
+  it('re-enabling stroke on a circle layer replaces the config too', async () => {
+    const onStyleConfigChange = vi.fn();
+    const user = userEvent.setup();
+    // Circle is the geometry whose re-enable patch is stash-only: the polygon branch
+    // writes outlineWidth back, which keeps the builder non-empty by accident.
+    const layer = makeLayer({
+      dataset_geometry_type: 'Point',
+      paint: { 'circle-color': '#3b82f6', 'circle-radius': 5, 'circle-stroke-width': 0 },
+      style_config: { builder: { strokeDisabled: true, outlineWidthSaved: 2 } } as MapLayerResponse['style_config'],
+    });
+
+    render(<LayerStyleEditor {...toggleProps(layer, onStyleConfigChange)} />);
+    await user.click(screen.getByLabelText('Toggle stroke visibility'));
+
+    expect(onStyleConfigChange).toHaveBeenCalledWith(
+      'layer-1',
+      null,
+      expect.objectContaining({ 'circle-stroke-width': 2 }),
+      { replace: true },
+    );
+  });
+});
+
 describe('LayerStyleEditor - B-010 Advanced JSON strips builder-private keys', () => {
   it('hides _-prefixed + legacy builder keys from the Advanced Paint JSON textarea', async () => {
     const user = userEvent.setup();

--- a/scripts/backup-entrypoint.sh
+++ b/scripts/backup-entrypoint.sh
@@ -264,7 +264,7 @@ backup_staging() {
     local size
     size="$(du -h "$archive" | cut -f1)"
     log "Object-storage archive complete: $(basename "$archive") (${size})" >&2
-    if [ "$CYCLE_IS_WEEKLY" -eq 1 ]; then
+    if [ "${CYCLE_IS_WEEKLY:-0}" -eq 1 ]; then
         cp "$archive" "${WEEKLY_DIR}/$(basename "$archive")"
         log "Weekly object-storage copy saved: $(basename "$archive")" >&2
     fi

--- a/scripts/backup-entrypoint.sh
+++ b/scripts/backup-entrypoint.sh
@@ -82,6 +82,14 @@ unset _ret_var _ret_val
 run_backup() {
     local timestamp
     timestamp="$(date '+%Y%m%d_%H%M%S')"
+    # fix(#995 review): decide "is this a weekly cycle?" ONCE, with the
+    # timestamp that names the cycle, and reuse it for every artifact. Each one
+    # used to re-ask the weekday at the moment it was written, so a Sunday
+    # cycle that crossed midnight — a 23:59 schedule, or a large staging
+    # archive — could copy the dump into weekly/ and then answer Monday for its
+    # companions, leaving a weekly dump with no paired globals.
+    CYCLE_IS_WEEKLY=0
+    [ "$(date '+%u')" = "7" ] && CYCLE_IS_WEEKLY=1
     local filename="${POSTGRES_DB}_${timestamp}.dump"
     local filepath="${DAILY_DIR}/${filename}"
 
@@ -132,7 +140,7 @@ run_backup() {
     log "Backup verified: ${filename} fully readable"
 
     # Weekly copy on Sundays
-    if [ "$(date '+%u')" = "7" ]; then
+    if [ "$CYCLE_IS_WEEKLY" -eq 1 ]; then
         cp "$filepath" "${WEEKLY_DIR}/${filename}"
         log "Weekly copy saved: ${filename}"
     fi
@@ -171,7 +179,7 @@ run_backup() {
         if [ -n "$globals_dump" ]; then
             upload_to_s3 "$globals_dump" "daily/$(basename "$globals_dump")" || upload_failed=1
         fi
-        if [ "$(date '+%u')" = "7" ]; then
+        if [ "$CYCLE_IS_WEEKLY" -eq 1 ]; then
             upload_to_s3 "$filepath" "weekly/${filename}" || upload_failed=1
             if [ -n "$staging_archive" ]; then
                 upload_to_s3 "$staging_archive" "weekly/$(basename "$staging_archive")" || upload_failed=1
@@ -256,7 +264,7 @@ backup_staging() {
     local size
     size="$(du -h "$archive" | cut -f1)"
     log "Object-storage archive complete: $(basename "$archive") (${size})" >&2
-    if [ "$(date '+%u')" = "7" ]; then
+    if [ "$CYCLE_IS_WEEKLY" -eq 1 ]; then
         cp "$archive" "${WEEKLY_DIR}/$(basename "$archive")"
         log "Weekly object-storage copy saved: $(basename "$archive")" >&2
     fi
@@ -313,7 +321,7 @@ backup_globals() {
     local size
     size="$(du -h "$globals_file" | cut -f1)"
     log "Cluster globals complete: $(basename "$globals_file") (${size})" >&2
-    if [ "$(date '+%u')" = "7" ]; then
+    if [ "$CYCLE_IS_WEEKLY" -eq 1 ]; then
         # Same .tmp-then-rename as the daily artifact, and for the same reason:
         # a container killed mid-`cp` never reaches the failure branch, so
         # copying straight to the final name would leave a truncated file under

--- a/scripts/backup-entrypoint.sh
+++ b/scripts/backup-entrypoint.sh
@@ -371,22 +371,86 @@ upload_to_s3() {
 # there is the copy order, not the backup order); and `find -printf` is a GNU
 # extension, so mtime ordering made this function silently unrunnable outside
 # the container — including in scripts/tests/test-backup-restore-roundtrip.sh,
-# which is documented as a standalone local tool. `<db>_<YYYYmmdd_HHMMSS>.dump`
-# sorts oldest-first lexicographically.
+# which is documented as a standalone local tool.
+#
+# Sorted on the EXTRACTED timestamp, not the whole path: the database name is
+# the prefix, so sorting the path puts it ahead of the timestamp, and after a
+# POSTGRES_DB rename to a lexically earlier name every fresh dump would sort as
+# the oldest and be pruned first. Files whose name carries no timestamp are not
+# ours; they are neither counted nor deleted.
+#
+# Emits "<timestamp>\t<path>" lines, oldest first.
+dump_listing() {
+    local dir="$1"
+    local dump ts
+    find "$dir" -maxdepth 1 -name "*.dump" -type f | while IFS= read -r dump; do
+        ts="$(printf '%s' "${dump##*/}" | sed -nE 's/^.*_([0-9]{8}_[0-9]{6})\.dump$/\1/p')"
+        [ -n "$ts" ] || continue
+        printf '%s\t%s\n' "$ts" "$dump"
+    done | sort
+}
+
+# fix(#995): the timestamp of the newest set that is COMPLETE — a dump with the
+# globals dump that pairs with it. prune_old_backups keeps that one out of the
+# retention window.
+#
+# Without the exemption a run of pg_dumpall failures walks every complete set
+# out of retention: each failed cycle still produces a valid dump (discarding it
+# would make the failure strictly worse — data without roles beats nothing), so
+# it counts toward the window and evicts an older complete set, whose globals
+# then goes with it as an orphan. After a full window of failures the operator
+# has been told loudly every cycle (`.last-success` stale, healthcheck
+# unhealthy) and still has dumps, but nothing that restores onto a fresh
+# cluster. Holding one complete set back costs at most one extra dump plus a
+# few KB of SQL and is the difference between a degraded DR path and none.
+newest_complete_ts() {
+    local dir="$1"
+    local globals ts best=""
+    for globals in "$dir"/globals-*.sql; do
+        [ -f "$globals" ] || continue
+        ts="$(printf '%s' "${globals##*/}" | sed -nE 's/^globals-([0-9]{8}_[0-9]{6})\.sql$/\1/p')"
+        [ -n "$ts" ] || continue
+        find "$dir" -maxdepth 1 -name "*_${ts}.dump" -type f | grep -q . || continue
+        if [ -z "$best" ] || [ "$ts" \> "$best" ]; then
+            best="$ts"
+        fi
+    done
+    printf '%s' "$best"
+}
+
 prune_old_backups() {
     local dir="$1"
     local keep="$2"
 
-    local count
-    count="$(find "$dir" -maxdepth 1 -name "*.dump" -type f | wc -l)"
-    if [ "$count" -gt "$keep" ]; then
-        local to_remove=$((count - keep))
-        log "Pruning ${to_remove} old backup(s) from ${dir}"
-        find "$dir" -maxdepth 1 -name "*.dump" -type f | sort | \
-            head -n "$to_remove" | while IFS= read -r stale; do
-                rm -f "$stale"
-            done
+    local listing
+    listing="$(dump_listing "$dir")"
+    [ -n "$listing" ] || return 0
+
+    # The protected set is held back IN ADDITION to the retention window, not
+    # inside it: letting it occupy a slot would mean a retention of 1 keeps the
+    # complete set and throws away the newest dump, which is the wrong trade.
+    # So a directory holds at most `keep` + 1 dumps.
+    local protect
+    protect="$(newest_complete_ts "$dir")"
+
+    local candidates
+    if [ -n "$protect" ]; then
+        candidates="$(printf '%s\n' "$listing" | grep -v "^${protect}	" || true)"
+    else
+        candidates="$listing"
     fi
+    [ -n "$candidates" ] || return 0
+
+    local count
+    count="$(printf '%s\n' "$candidates" | wc -l | tr -d ' ')"
+    [ "$count" -gt "$keep" ] || return 0
+
+    local to_remove=$((count - keep))
+    log "Pruning ${to_remove} old backup(s) from ${dir}"
+    printf '%s\n' "$candidates" | head -n "$to_remove" | cut -f2- | \
+        while IFS= read -r stale; do
+            rm -f "$stale"
+        done
 }
 
 # BKP-01 / fix(#995): companion artifacts (the object-storage archive and the

--- a/scripts/backup-entrypoint.sh
+++ b/scripts/backup-entrypoint.sh
@@ -87,8 +87,9 @@ run_backup() {
 
     # fix(#819): orphaned .tmp dumps (pg_dump killed mid-write) match no prune glob and
     # would accumulate forever; a new cycle starting means no dump is in
-    # flight, so any leftover .tmp is garbage.
-    rm -f "${DAILY_DIR}"/*.dump.tmp
+    # flight, so any leftover .tmp is garbage. fix(#995): the globals dump
+    # writes through the same .tmp-then-rename path and needs the same sweep.
+    rm -f "${DAILY_DIR}"/*.dump.tmp "${DAILY_DIR}"/globals-*.sql.tmp
 
     log "Starting backup: ${filename}"
 
@@ -183,15 +184,14 @@ run_backup() {
         fi
     fi
 
-    # Retention runs regardless of S3 outcome (dumps and their paired staging
-    # archives share retention counts) — local backups must be pruned even when
-    # the offsite upload failed, or backup_data fills up during an S3 outage.
+    # Retention runs regardless of S3 outcome (dumps set the window; their
+    # companions follow) — local backups must be pruned even when the offsite
+    # upload failed, or backup_data fills up during an S3 outage.
     prune_old_backups "$DAILY_DIR" "$BACKUP_RETENTION_DAILY"
     prune_old_backups "$WEEKLY_DIR" "$BACKUP_RETENTION_WEEKLY"
-    prune_old_staging "$DAILY_DIR" "$BACKUP_RETENTION_DAILY"
-    prune_old_staging "$WEEKLY_DIR" "$BACKUP_RETENTION_WEEKLY"
-    prune_old_globals "$DAILY_DIR" "$BACKUP_RETENTION_DAILY"
-    prune_old_globals "$WEEKLY_DIR" "$BACKUP_RETENTION_WEEKLY"
+    # Must run after prune_old_backups — it prunes by what that just left.
+    prune_orphaned_companions "$DAILY_DIR"
+    prune_orphaned_companions "$WEEKLY_DIR"
 
     # Surface the S3 failure now that retention has run, so the cycle is still
     # reported as failed (non-zero) to the cron / sleep-loop caller.
@@ -282,14 +282,21 @@ backup_globals() {
     local globals_file="${DAILY_DIR}/globals-${timestamp}.sql"
 
     log "Dumping cluster globals: $(basename "$globals_file")" >&2
+    # fix(#995): write to .tmp and rename on success, for the same reason the
+    # dump does. A container killed mid-write (OOM, `compose stop`) never
+    # reaches the cleanup below, so writing straight to the final name would
+    # leave a truncated globals file sitting next to a complete dump, looking
+    # like the valid paired artifact. The rename makes globals-*.sql appear
+    # only atomically; the .tmp is swept at the top of the next cycle.
     local rc=0
     (umask 077; pg_dumpall -h "$POSTGRES_HOST" -U "$POSTGRES_USER" \
-        --globals-only > "$globals_file") || rc=$?
+        --globals-only > "${globals_file}.tmp") || rc=$?
     if [ "$rc" -ne 0 ]; then
         log "ERROR: pg_dumpall --globals-only failed (exit ${rc}) — roles could not be captured, so this cycle will be reported as failed" >&2
-        rm -f "$globals_file"
+        rm -f "${globals_file}.tmp"
         return 1
     fi
+    mv "${globals_file}.tmp" "$globals_file"
 
     local size
     size="$(du -h "$globals_file" | cut -f1)"
@@ -358,52 +365,61 @@ upload_to_s3() {
 # ---------------------------------------------------------------------------
 # Retention pruning
 # ---------------------------------------------------------------------------
+# Ordered by the timestamp in the filename, not by mtime. Two reasons: the
+# embedded timestamp is the cycle's identity, while mtime is whenever the file
+# was last written (the weekly copies all carry their `cp` time, so mtime order
+# there is the copy order, not the backup order); and `find -printf` is a GNU
+# extension, so mtime ordering made this function silently unrunnable outside
+# the container — including in scripts/tests/test-backup-restore-roundtrip.sh,
+# which is documented as a standalone local tool. `<db>_<YYYYmmdd_HHMMSS>.dump`
+# sorts oldest-first lexicographically.
 prune_old_backups() {
     local dir="$1"
     local keep="$2"
 
     local count
-    count="$(find "$dir" -name "*.dump" -type f | wc -l)"
+    count="$(find "$dir" -maxdepth 1 -name "*.dump" -type f | wc -l)"
     if [ "$count" -gt "$keep" ]; then
         local to_remove=$((count - keep))
         log "Pruning ${to_remove} old backup(s) from ${dir}"
-        find "$dir" -name "*.dump" -type f -printf '%T+ %p\n' | \
-            sort | head -n "$to_remove" | awk '{print $2}' | \
-            xargs rm -f
+        find "$dir" -maxdepth 1 -name "*.dump" -type f | sort | \
+            head -n "$to_remove" | while IFS= read -r stale; do
+                rm -f "$stale"
+            done
     fi
 }
 
-# BKP-01: prune object-storage archives with the same retention policy as dumps.
-prune_old_staging() {
+# BKP-01 / fix(#995): companion artifacts (the object-storage archive and the
+# globals dump) are pruned by PAIRING, not by their own count.
+#
+# Counting them independently looked equivalent and is not, because a companion
+# can be absent for a cycle that still produces a dump: backup_staging skips a
+# missing or empty staging mount, and a failed pg_dumpall leaves a good dump
+# with no globals. Once the counts diverge, `keep the newest N of each` prunes
+# a dump whose companion is younger than N and therefore survives — so after
+# enough such cycles every complete set is gone while the orphans remain.
+#
+# The dumps are the primary artifact and prune_old_backups is the authority on
+# retention. This runs AFTER it and drops any companion whose dump is no longer
+# there, which keeps the invariant that matters for a restore: every companion
+# present has the dump it pairs with.
+prune_orphaned_companions() {
     local dir="$1"
-    local keep="$2"
 
-    local count
-    count="$(find "$dir" -name "staging-*.tar.gz" -type f | wc -l)"
-    if [ "$count" -gt "$keep" ]; then
-        local to_remove=$((count - keep))
-        log "Pruning ${to_remove} old object-storage archive(s) from ${dir}"
-        find "$dir" -name "staging-*.tar.gz" -type f -printf '%T+ %p\n' | \
-            sort | head -n "$to_remove" | awk '{print $2}' | \
-            xargs rm -f
-    fi
-}
-
-# fix(#995): prune globals dumps on the same retention counts as the dumps they
-# pair with, so a globals file never outlives its dump (or vice versa).
-prune_old_globals() {
-    local dir="$1"
-    local keep="$2"
-
-    local count
-    count="$(find "$dir" -name "globals-*.sql" -type f | wc -l)"
-    if [ "$count" -gt "$keep" ]; then
-        local to_remove=$((count - keep))
-        log "Pruning ${to_remove} old globals dump(s) from ${dir}"
-        find "$dir" -name "globals-*.sql" -type f -printf '%T+ %p\n' | \
-            sort | head -n "$to_remove" | awk '{print $2}' | \
-            xargs rm -f
-    fi
+    local companion base ts
+    for companion in "$dir"/staging-*.tar.gz "$dir"/globals-*.sql; do
+        # Unmatched globs expand to themselves; -f skips those.
+        [ -f "$companion" ] || continue
+        base="$(basename "$companion")"
+        # Anchored at the end, like restore.sh's parse.
+        ts="$(printf '%s' "$base" | sed -nE 's/^.*-([0-9]{8}_[0-9]{6})\..*$/\1/p')"
+        # A name we cannot pair is left alone rather than guessed at.
+        [ -n "$ts" ] || continue
+        if ! find "$dir" -maxdepth 1 -name "*_${ts}.dump" -type f | grep -q .; then
+            log "Pruning orphaned ${base} from ${dir} (its dump has aged out)"
+            rm -f "$companion"
+        fi
+    done
 }
 
 # ---------------------------------------------------------------------------

--- a/scripts/backup-entrypoint.sh
+++ b/scripts/backup-entrypoint.sh
@@ -5,7 +5,9 @@ set -euo pipefail
 # GeoLens Automated Backup Entrypoint
 # ==============================================================================
 # Runs pg_dump on a cron schedule with daily/weekly retention and optional
-# S3 upload. Designed for the default-on Docker Compose backup service.
+# S3 upload. Each cycle also captures the cluster globals (roles + cluster-wide
+# grants), which a database-only pg_dump cannot carry. Designed for the
+# default-on Docker Compose backup service.
 #
 # Environment variables (set in docker-compose.yml):
 #   POSTGRES_USER          Database username
@@ -28,7 +30,11 @@ set -euo pipefail
 # here; S3_ALLOW_HTTP only affects the app's own object-storage client.
 # ==============================================================================
 
-BACKUP_DIR="/backups"
+# Overridable only so scripts/tests/test-backup-restore-roundtrip.sh can drive a
+# real cycle into a temp directory instead of re-implementing one. Nothing in
+# either compose file sets it, so every deployment gets /backups. Same shape as
+# STAGING_DIR below.
+BACKUP_DIR="${BACKUP_DIR:-/backups}"
 DAILY_DIR="${BACKUP_DIR}/daily"
 WEEKLY_DIR="${BACKUP_DIR}/weekly"
 
@@ -139,6 +145,14 @@ run_backup() {
     local staging_archive=""
     staging_archive="$(backup_staging "$timestamp")" || cycle_failed=1
 
+    # fix(#995): cluster globals (roles, their passwords, and cluster-wide
+    # grants) alongside the dump. A database-only pg_dump can never restore
+    # them, so without this artifact the fresh-cluster path in RUNBOOK § 2 has
+    # no input. Unlike the staging archive there is no partial-success case, so
+    # any failure marks the cycle failed the way the S3 path does.
+    local globals_dump=""
+    globals_dump="$(backup_globals "$timestamp")" || cycle_failed=1
+
     # S3 upload — record any failure but DON'T return yet. The local dump (and
     # the staging archive, if any) already landed on disk; retention pruning
     # below must still run so a transient S3 outage can't let them accumulate.
@@ -148,10 +162,19 @@ run_backup() {
         if [ -n "$staging_archive" ]; then
             upload_to_s3 "$staging_archive" "daily/$(basename "$staging_archive")" || upload_failed=1
         fi
+        # The globals dump goes offsite with the dump it pairs with: an operator
+        # rebuilding on a fresh cluster is doing so precisely because the local
+        # disk is gone, so a globals artifact that only exists there is no use.
+        if [ -n "$globals_dump" ]; then
+            upload_to_s3 "$globals_dump" "daily/$(basename "$globals_dump")" || upload_failed=1
+        fi
         if [ "$(date '+%u')" = "7" ]; then
             upload_to_s3 "$filepath" "weekly/${filename}" || upload_failed=1
             if [ -n "$staging_archive" ]; then
                 upload_to_s3 "$staging_archive" "weekly/$(basename "$staging_archive")" || upload_failed=1
+            fi
+            if [ -n "$globals_dump" ]; then
+                upload_to_s3 "$globals_dump" "weekly/$(basename "$globals_dump")" || upload_failed=1
             fi
         fi
         if [ "$upload_failed" -eq 1 ]; then
@@ -167,6 +190,8 @@ run_backup() {
     prune_old_backups "$WEEKLY_DIR" "$BACKUP_RETENTION_WEEKLY"
     prune_old_staging "$DAILY_DIR" "$BACKUP_RETENTION_DAILY"
     prune_old_staging "$WEEKLY_DIR" "$BACKUP_RETENTION_WEEKLY"
+    prune_old_globals "$DAILY_DIR" "$BACKUP_RETENTION_DAILY"
+    prune_old_globals "$WEEKLY_DIR" "$BACKUP_RETENTION_WEEKLY"
 
     # Surface the S3 failure now that retention has run, so the cycle is still
     # reported as failed (non-zero) to the cron / sleep-loop caller.
@@ -234,6 +259,50 @@ backup_staging() {
         log "Weekly object-storage copy saved: $(basename "$archive")" >&2
     fi
     printf '%s\n' "$archive"
+}
+
+# ---------------------------------------------------------------------------
+# fix(#995): cluster globals (roles + cluster-wide grants)
+# ---------------------------------------------------------------------------
+# Writes globals-<timestamp>.sql next to the dump, same timestamp so a restore
+# can pair them. Prints the path on stdout (consumed by run_backup); all human
+# logging goes to stderr so it never contaminates that path.
+#
+# umask 077 is not optional. `pg_dumpall --globals-only` emits role password
+# verifiers; under the default 022 umask the file lands world-readable in the
+# backup volume and, with BACKUP_S3_ENABLED=true, in the bucket. The subshell
+# scopes the umask to the redirect that creates the file and nothing else —
+# this is the form RUNBOOK § "Multi-tenant role reconstruction" documents.
+#
+# Unlike backup_staging there is no salvageable partial: a truncated globals
+# file replays as a partial set of roles, which is worse than none, so any
+# non-zero exit discards it and fails the cycle.
+backup_globals() {
+    local timestamp="$1"
+    local globals_file="${DAILY_DIR}/globals-${timestamp}.sql"
+
+    log "Dumping cluster globals: $(basename "$globals_file")" >&2
+    local rc=0
+    (umask 077; pg_dumpall -h "$POSTGRES_HOST" -U "$POSTGRES_USER" \
+        --globals-only > "$globals_file") || rc=$?
+    if [ "$rc" -ne 0 ]; then
+        log "ERROR: pg_dumpall --globals-only failed (exit ${rc}) — roles could not be captured, so this cycle will be reported as failed" >&2
+        rm -f "$globals_file"
+        return 1
+    fi
+
+    local size
+    size="$(du -h "$globals_file" | cut -f1)"
+    log "Cluster globals complete: $(basename "$globals_file") (${size})" >&2
+    if [ "$(date '+%u')" = "7" ]; then
+        # cp carries the source's 0600 across (measured on both busybox and
+        # GNU cp), but the weekly copy is the one an operator reaches for
+        # months later, so pin the mode instead of inheriting it.
+        cp "$globals_file" "${WEEKLY_DIR}/$(basename "$globals_file")"
+        chmod 600 "${WEEKLY_DIR}/$(basename "$globals_file")"
+        log "Weekly globals copy saved: $(basename "$globals_file")" >&2
+    fi
+    printf '%s\n' "$globals_file"
 }
 
 # ---------------------------------------------------------------------------
@@ -315,6 +384,23 @@ prune_old_staging() {
         local to_remove=$((count - keep))
         log "Pruning ${to_remove} old object-storage archive(s) from ${dir}"
         find "$dir" -name "staging-*.tar.gz" -type f -printf '%T+ %p\n' | \
+            sort | head -n "$to_remove" | awk '{print $2}' | \
+            xargs rm -f
+    fi
+}
+
+# fix(#995): prune globals dumps on the same retention counts as the dumps they
+# pair with, so a globals file never outlives its dump (or vice versa).
+prune_old_globals() {
+    local dir="$1"
+    local keep="$2"
+
+    local count
+    count="$(find "$dir" -name "globals-*.sql" -type f | wc -l)"
+    if [ "$count" -gt "$keep" ]; then
+        local to_remove=$((count - keep))
+        log "Pruning ${to_remove} old globals dump(s) from ${dir}"
+        find "$dir" -name "globals-*.sql" -type f -printf '%T+ %p\n' | \
             sort | head -n "$to_remove" | awk '{print $2}' | \
             xargs rm -f
     fi

--- a/scripts/backup-entrypoint.sh
+++ b/scripts/backup-entrypoint.sh
@@ -296,7 +296,17 @@ backup_globals() {
         rm -f "${globals_file}.tmp"
         return 1
     fi
-    mv "${globals_file}.tmp" "$globals_file"
+    # Every publish step is checked explicitly. This function always runs inside
+    # a `$(...) || cycle_failed=1` command substitution, which suspends `set -e`
+    # for its whole body — so an unchecked `mv` or `cp` failing (read-only
+    # volume, ENOSPC) would fall through to the final printf, return success,
+    # and let the cycle touch .last-success with no globals artifact beside a
+    # valid dump.
+    if ! mv "${globals_file}.tmp" "$globals_file"; then
+        log "ERROR: could not publish $(basename "$globals_file") — is the backup volume writable and not full?" >&2
+        rm -f "${globals_file}.tmp"
+        return 1
+    fi
 
     local size
     size="$(du -h "$globals_file" | cut -f1)"
@@ -304,9 +314,15 @@ backup_globals() {
     if [ "$(date '+%u')" = "7" ]; then
         # cp carries the source's 0600 across (measured on both busybox and
         # GNU cp), but the weekly copy is the one an operator reaches for
-        # months later, so pin the mode instead of inheriting it.
-        cp "$globals_file" "${WEEKLY_DIR}/$(basename "$globals_file")"
-        chmod 600 "${WEEKLY_DIR}/$(basename "$globals_file")"
+        # months later, so pin the mode instead of inheriting it. Checked for
+        # the same reason as the mv above: a half-written weekly copy beside a
+        # good weekly dump is worse than none, so discard it and fail.
+        local weekly_copy="${WEEKLY_DIR}/$(basename "$globals_file")"
+        if ! cp "$globals_file" "$weekly_copy" || ! chmod 600 "$weekly_copy"; then
+            log "ERROR: could not write the weekly globals copy to ${WEEKLY_DIR}" >&2
+            rm -f "$weekly_copy"
+            return 1
+        fi
         log "Weekly globals copy saved: $(basename "$globals_file")" >&2
     fi
     printf '%s\n' "$globals_file"

--- a/scripts/backup-entrypoint.sh
+++ b/scripts/backup-entrypoint.sh
@@ -88,8 +88,10 @@ run_backup() {
     # fix(#819): orphaned .tmp dumps (pg_dump killed mid-write) match no prune glob and
     # would accumulate forever; a new cycle starting means no dump is in
     # flight, so any leftover .tmp is garbage. fix(#995): the globals dump
-    # writes through the same .tmp-then-rename path and needs the same sweep.
-    rm -f "${DAILY_DIR}"/*.dump.tmp "${DAILY_DIR}"/globals-*.sql.tmp
+    # writes through the same .tmp-then-rename path, in both directories, and
+    # needs the same sweep.
+    rm -f "${DAILY_DIR}"/*.dump.tmp "${DAILY_DIR}"/globals-*.sql.tmp \
+        "${WEEKLY_DIR}"/globals-*.sql.tmp
 
     log "Starting backup: ${filename}"
 
@@ -312,15 +314,23 @@ backup_globals() {
     size="$(du -h "$globals_file" | cut -f1)"
     log "Cluster globals complete: $(basename "$globals_file") (${size})" >&2
     if [ "$(date '+%u')" = "7" ]; then
-        # cp carries the source's 0600 across (measured on both busybox and
-        # GNU cp), but the weekly copy is the one an operator reaches for
-        # months later, so pin the mode instead of inheriting it. Checked for
-        # the same reason as the mv above: a half-written weekly copy beside a
-        # good weekly dump is worse than none, so discard it and fail.
+        # Same .tmp-then-rename as the daily artifact, and for the same reason:
+        # a container killed mid-`cp` never reaches the failure branch, so
+        # copying straight to the final name would leave a truncated file under
+        # the weekly globals filename beside an already-published weekly dump,
+        # where a recovery would take it for the valid paired artifact.
+        #
+        # cp carries the source's 0600 across (measured on both busybox and GNU
+        # cp), but the weekly copy is the one an operator reaches for months
+        # later, so pin the mode rather than inheriting it, and do it before the
+        # rename so the file is never visible under its final name at a wider
+        # mode.
         local weekly_copy="${WEEKLY_DIR}/$(basename "$globals_file")"
-        if ! cp "$globals_file" "$weekly_copy" || ! chmod 600 "$weekly_copy"; then
+        if ! cp "$globals_file" "${weekly_copy}.tmp" \
+            || ! chmod 600 "${weekly_copy}.tmp" \
+            || ! mv "${weekly_copy}.tmp" "$weekly_copy"; then
             log "ERROR: could not write the weekly globals copy to ${WEEKLY_DIR}" >&2
-            rm -f "$weekly_copy"
+            rm -f "${weekly_copy}.tmp"
             return 1
         fi
         log "Weekly globals copy saved: $(basename "$globals_file")" >&2

--- a/scripts/restore.sh
+++ b/scripts/restore.sh
@@ -55,6 +55,57 @@ echo ""
 # Configuration with defaults
 POSTGRES_USER="${POSTGRES_USER:-geolens}"
 POSTGRES_DB="${POSTGRES_DB:-geolens}"
+
+# Sibling-artifact lookup. Both the object-storage archive and the globals dump
+# are written by backup-entrypoint.sh next to the dump with the SAME timestamp,
+# so one parse serves both (the staging block near the end of this script reuses
+# these). dump name is <db>_<YYYYmmdd_HHMMSS>.dump.
+_dump_dir="$(cd "$(dirname "$BACKUP_FILE")" && pwd)"
+_dump_base="$(basename "$BACKUP_FILE")"
+# Anchored at the END of the name. The old leftmost `grep -oE ... | head -n1`
+# matched inside $POSTGRES_DB whenever the database name carried its own
+# 8-digit_6-digit run, silently sending every sibling lookup down the
+# unpaired-fallback path.
+_ts="$(printf '%s' "$_dump_base" | sed -nE 's/^.*_([0-9]{8}_[0-9]{6})(\..*)?$/\1/p' || true)"
+
+# fix(#995): roles are cluster objects and travel in globals-<ts>.sql, never in
+# the dump. Report BEFORE the destructive --clean rather than after: replaying
+# globals is a pre-restore step, and on a fresh cluster a restore that runs
+# without it lands every object owned by the restoring user with no tenant
+# grants. Non-fatal — a same-cluster restore (the common case) already has its
+# roles, and only the roles the globals dump would actually create are checked.
+_globals_dump=""
+if [ -n "$_ts" ] && [ -f "${_dump_dir}/globals-${_ts}.sql" ]; then
+    _globals_dump="${_dump_dir}/globals-${_ts}.sql"
+fi
+if [ -n "$_globals_dump" ]; then
+    # Unquoted identifiers only: pg_dumpall quotes names that need it, and the
+    # GeoLens roles never do. Restricting to [A-Za-z0-9_] also keeps the names
+    # safe to inline in the query below.
+    _globals_roles="$(grep -oE '^CREATE ROLE [A-Za-z0-9_]+' "$_globals_dump" | awk '{print $3}' | sort -u || true)"
+    if [ -n "$_globals_roles" ]; then
+        _role_array="$(printf '%s\n' "$_globals_roles" | sed "s/.*/'&'/" | paste -sd, -)"
+        _missing_roles="$("${COMPOSE[@]}" exec -T db \
+            psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" -tAc \
+            "SELECT r FROM unnest(ARRAY[${_role_array}]::text[]) r
+             WHERE NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = r);" \
+            2>/dev/null | tr -d '\r' | paste -sd' ' - || true)"
+        if [ -n "${_missing_roles// /}" ]; then
+            echo "WARNING: this cluster is missing roles that the paired globals dump defines:"
+            echo "           ${_missing_roles}"
+            echo "         Replay them BEFORE continuing, or restored objects will carry"
+            echo "         neither their owners nor their grants (RUNBOOK.md"
+            echo "         §\"Multi-tenant role reconstruction after a fresh-cluster restore\"):"
+            echo ""
+            echo "           docker compose exec -T db psql -U \"\$POSTGRES_USER\" -d postgres \\"
+            echo "             < ${_globals_dump}"
+            echo ""
+        else
+            echo "Paired globals dump found (${_globals_dump##*/}); every role it defines already exists."
+        fi
+    fi
+fi
+
 echo "Running pre-restore setup..."
 
 # ON_ERROR_STOP: this DDL is the last gate before --clean drops the live
@@ -188,10 +239,7 @@ echo "Restore complete."
 # If we can spot
 # the matching archive, point the operator at it rather than silently dropping
 # the staged objects.
-_dump_dir="$(cd "$(dirname "$BACKUP_FILE")" && pwd)"
-_dump_base="$(basename "$BACKUP_FILE")"
-# dump name is <db>_<YYYYmmdd_HHMMSS>.dump → extract the timestamp if present.
-_ts="$(printf '%s' "$_dump_base" | grep -oE '[0-9]{8}_[0-9]{6}' | head -n1 || true)"
+# _dump_dir / _ts are parsed once before the restore (see the globals block).
 _staging_archive=""
 _staging_match="exact"
 if [ -n "$_ts" ] && [ -f "${_dump_dir}/staging-${_ts}.tar.gz" ]; then

--- a/scripts/tests/test-backup-restore-roundtrip.sh
+++ b/scripts/tests/test-backup-restore-roundtrip.sh
@@ -10,6 +10,10 @@
 #      restored row counts match the source EXACTLY.
 #   2. Object-storage round-trip — tar a staging dir (as backup-entrypoint.sh
 #      does), extract it elsewhere, assert the file tree + contents survive.
+#   3. Real backup cycle (#995) — RUN backup-entrypoint.sh --run-backup against a
+#      temp BACKUP_DIR and assert the globals artifact: paired timestamp, mode
+#      0600 (it holds role password verifiers), and that a failing pg_dumpall
+#      fails the cycle without touching .last-success.
 #
 # Both THROWAWAY databases are ALWAYS dropped on exit (trap), success or fail.
 # This connects to the already-running test Postgres (localhost:5434 via
@@ -51,7 +55,7 @@ PGUSER="${POSTGRES_USER:-geolens}"
 export PGPASSWORD="${POSTGRES_PASSWORD:-geolens}"
 ADMIN_DB="${POSTGRES_DB:-geolens}"
 
-for bin in pg_dump pg_restore psql createdb dropdb; do
+for bin in pg_dump pg_dumpall pg_restore psql createdb dropdb; do
     command -v "$bin" >/dev/null 2>&1 || { echo "SKIP: $bin not found on PATH"; exit 0; }
 done
 
@@ -94,7 +98,7 @@ echo ""
 # ------------------------------------------------------------------------------
 # 1. BUNDLED MODE — DB round-trip via pg_dump/pg_restore (restore.sh flags)
 # ------------------------------------------------------------------------------
-echo "[1/4] Creating source DB and seeding known rows (bundled mode)..."
+echo "[1/5] Creating source DB and seeding known rows (bundled mode)..."
 createdb -h "$PGHOST" -p "$PGPORT" -U "$PGUSER" "$SRC_DB"
 
 # Mirror the app's catalog schema shape just enough to be representative.
@@ -112,7 +116,7 @@ SRC_RECORDS="$(psql -h "$PGHOST" -p "$PGPORT" -U "$PGUSER" -d "$SRC_DB" -tAc "SE
 SRC_DATASETS="$(psql -h "$PGHOST" -p "$PGPORT" -U "$PGUSER" -d "$SRC_DB" -tAc "SELECT COUNT(*) FROM catalog.datasets;")"
 echo "      source counts: records=${SRC_RECORDS} datasets=${SRC_DATASETS}"
 
-echo "[2/4] pg_dump -Fc, then pg_restore into a fresh DB (restore.sh flags)..."
+echo "[2/5] pg_dump -Fc, then pg_restore into a fresh DB (restore.sh flags)..."
 pg_dump -h "$PGHOST" -p "$PGPORT" -U "$PGUSER" -d "$SRC_DB" \
     -Fc --no-owner --no-acl -f "$DUMP_FILE"
 [ -s "$DUMP_FILE" ] || fail "dump file is empty"
@@ -173,7 +177,7 @@ echo ""
 # ------------------------------------------------------------------------------
 # 2. Object-storage (staging) round-trip — mirrors backup-entrypoint.sh tar step
 # ------------------------------------------------------------------------------
-echo "[3/4] Object-storage (staging) tar round-trip..."
+echo "[3/5] Object-storage (staging) tar round-trip..."
 STAGING_SRC="${WORKDIR}/staging-src"
 STAGING_DST="${WORKDIR}/staging-dst"
 mkdir -p "$STAGING_SRC/nested" "$STAGING_DST"
@@ -199,10 +203,10 @@ echo ""
 #       pg_restore flags (NOT via restore.sh's docker-compose-exec path, which
 #       does not apply to an external DB). Simulates a provider-native restore.
 #   (b) Object-storage recovery — extract the staging archive produced in
-#       step [3/4] into a fresh location.
+#       step [3/5] into a fresh location.
 #   (c) Functional-pairing assert — DB rows match source; objects are present.
 
-echo "[4/4] MANAGED MODE — provider-snapshot DB + object-storage recovery..."
+echo "[4/5] MANAGED MODE — provider-snapshot DB + object-storage recovery..."
 STAGING_MANAGED="${WORKDIR}/staging-managed"
 mkdir -p "$STAGING_MANAGED"
 
@@ -234,7 +238,7 @@ echo "      snapshot DB counts: records=${SNAP_RECORDS} datasets=${SNAP_DATASETS
 echo "      managed-mode DB recovery OK (provider-snapshot rows match source)."
 
 # (b) Restore the object-storage archive into a fresh staging location.
-#     Reuses the archive produced in step [3/4] — same archive the backup
+#     Reuses the archive produced in step [3/5] — same archive the backup
 #     entrypoint uploads to S3 for an operator to retrieve during DR.
 tar xzf "$ARCHIVE" -C "$STAGING_MANAGED"
 diff -r "$STAGING_SRC" "$STAGING_MANAGED" >/dev/null \
@@ -246,7 +250,98 @@ echo "      managed-mode object-storage recovery OK — staging files present an
 echo "PASS [MANAGED MODE]: provider-snapshot DB (records=${SNAP_RECORDS} datasets=${SNAP_DATASETS}) + object-storage archive verified."
 echo ""
 
+# ------------------------------------------------------------------------------
+# 4. fix(#995): REAL backup cycle — globals artifact, its mode, and its pairing
+# ------------------------------------------------------------------------------
+# The legs above mirror what backup-entrypoint.sh does. This one RUNS it
+# (`--run-backup`, BACKUP_DIR pointed at a temp dir), because the property being
+# guarded is a property of that script and not of pg_dumpall: the globals dump
+# carries role password verifiers, so a lost `umask 077` publishes them
+# world-readable into the backup volume and, with offsite upload on, into the
+# bucket. A mirrored copy here would assert the umask of the copy.
+echo "[5/5] Real backup cycle — globals artifact (pairing, mode, failure path)..."
+CYCLE_BACKUPS="${WORKDIR}/cycle-backups"
+CYCLE_STAGING="${WORKDIR}/cycle-staging"
+mkdir -p "$CYCLE_BACKUPS" "$CYCLE_STAGING/nested"
+echo "cog-bytes" > "$CYCLE_STAGING/a.tif"
+
+# Deliberately permissive so a dropped `umask 077` in the script would show up
+# as a 0644 artifact rather than being masked by a strict ambient umask.
+umask 022
+
+run_cycle() {
+    env BACKUP_DIR="$CYCLE_BACKUPS" STAGING_DIR="$CYCLE_STAGING" \
+        POSTGRES_HOST="$PGHOST" PGPORT="$PGPORT" \
+        POSTGRES_USER="$PGUSER" POSTGRES_PASSWORD="$PGPASSWORD" \
+        POSTGRES_DB="$SRC_DB" BACKUP_S3_ENABLED=false \
+        PATH="$1" \
+        bash "${REPO_ROOT}/scripts/backup-entrypoint.sh" --run-backup
+}
+
+CYCLE_LOG="${WORKDIR}/cycle.log"
+if ! run_cycle "$PATH" > "$CYCLE_LOG" 2>&1; then
+    cat "$CYCLE_LOG" >&2
+    fail "backup cycle exited non-zero"
+fi
+
+CYCLE_DUMP="$(find "${CYCLE_BACKUPS}/daily" -name '*.dump' -type f | head -1)"
+[ -n "$CYCLE_DUMP" ] || fail "cycle produced no dump"
+# Anchored at the END of the name, the way restore.sh parses it: the database
+# name is the prefix and may itself contain digit runs (this test's throwaway
+# names do), so a leftmost match can land inside the db name instead.
+CYCLE_TS="$(basename "$CYCLE_DUMP" .dump | sed -nE 's/^.*_([0-9]{8}_[0-9]{6})$/\1/p')"
+[ -n "$CYCLE_TS" ] || fail "could not parse a timestamp out of $(basename "$CYCLE_DUMP")"
+
+# Pairing: the globals artifact must carry the DUMP's timestamp, not its own
+# `date` call — restore.sh matches them by exact filename.
+GLOBALS_FILE="${CYCLE_BACKUPS}/daily/globals-${CYCLE_TS}.sql"
+[ -f "$GLOBALS_FILE" ] \
+    || fail "no globals dump paired with the dump's timestamp (expected $(basename "$GLOBALS_FILE"))"
+[ -s "$GLOBALS_FILE" ] || fail "globals dump is empty"
+grep -q "^CREATE ROLE" "$GLOBALS_FILE" \
+    || fail "globals dump contains no CREATE ROLE — it is not a real --globals-only dump"
+
+# Mode: `ls -l` rather than stat, whose flags differ between BSD and GNU.
+GLOBALS_MODE="$(ls -l "$GLOBALS_FILE" | cut -c1-10)"
+[ "$GLOBALS_MODE" = "-rw-------" ] \
+    || fail "globals dump is ${GLOBALS_MODE}, expected -rw------- (umask 077 lost — role password verifiers are world-readable)"
+echo "      globals artifact OK — $(basename "$GLOBALS_FILE"), mode ${GLOBALS_MODE}, paired timestamp."
+
+[ -f "${CYCLE_BACKUPS}/.last-success" ] || fail "successful cycle did not write .last-success"
+LAST_SUCCESS_BEFORE="$(ls -l "${CYCLE_BACKUPS}/.last-success")"
+
+# Failure path: a pg_dumpall that fails must fail the CYCLE (an unrestorable-
+# roles backup is not a good backup), leaving .last-success at its old value so
+# the freshness healthcheck goes unhealthy. Shadow pg_dumpall on PATH — the stub
+# name does not shadow pg_dump, so the dump itself still succeeds and this
+# isolates the globals step.
+STUB_BIN="${WORKDIR}/stub-bin"
+mkdir -p "$STUB_BIN"
+printf '#!/bin/sh\necho "simulated pg_dumpall failure" >&2\nexit 1\n' > "${STUB_BIN}/pg_dumpall"
+chmod +x "${STUB_BIN}/pg_dumpall"
+
+FAIL_LOG="${WORKDIR}/cycle-fail.log"
+set +e
+run_cycle "${STUB_BIN}:${PATH}" > "$FAIL_LOG" 2>&1
+FAIL_RC=$?
+set -e
+[ "$FAIL_RC" -ne 0 ] || {
+    cat "$FAIL_LOG" >&2
+    fail "cycle returned 0 despite pg_dumpall failing — an unrestorable-roles backup was reported as good"
+}
+grep -q "pg_dumpall --globals-only failed" "$FAIL_LOG" \
+    || fail "cycle failed but never logged why the globals dump could not be captured"
+[ "$(ls -l "${CYCLE_BACKUPS}/.last-success")" = "$LAST_SUCCESS_BEFORE" ] \
+    || fail ".last-success was touched by a cycle whose globals dump failed"
+# The partial file must not be left behind: a truncated globals dump replays as
+# a partial set of roles, which is worse than having none.
+[ -z "$(find "${CYCLE_BACKUPS}/daily" -name 'globals-*.sql' -size 0 2>/dev/null)" ] \
+    || fail "a failed globals dump left an empty artifact behind"
+echo "      failure path OK — cycle non-zero, .last-success untouched, no partial artifact."
+echo ""
+
 echo "=== PASS: backup+restore round-trip verified (bundled + managed modes) ==="
 echo "    bundled DB: records=${SRC_RECORDS}==${DST_RECORDS}, datasets=${SRC_DATASETS}==${DST_DATASETS}"
 echo "    managed snapshot: records=${SRC_RECORDS}==${SNAP_RECORDS}, datasets=${SRC_DATASETS}==${SNAP_DATASETS}"
+echo "    globals: $(basename "$GLOBALS_FILE") mode ${GLOBALS_MODE}, failure path fails the cycle"
 # trap drops all three throwaway DBs on exit.

--- a/scripts/tests/test-backup-restore-roundtrip.sh
+++ b/scripts/tests/test-backup-restore-roundtrip.sh
@@ -366,9 +366,10 @@ if ! env BACKUP_RETENTION_DAILY=1 BACKUP_RETENTION_WEEKLY=1 \
     cat "$ORPHAN_LOG" >&2
     fail "retention-1 cycle exited non-zero"
 fi
+# keep=1 plus the held-back complete set = 2 dumps.
 REMAINING_DUMPS="$(find "${CYCLE_BACKUPS}/daily" -name '*.dump' -type f | wc -l | tr -d ' ')"
-[ "$REMAINING_DUMPS" = "1" ] \
-    || fail "expected retention to leave exactly 1 dump, found ${REMAINING_DUMPS}"
+[ "$REMAINING_DUMPS" = "2" ] \
+    || fail "expected retention to leave 2 dumps (1 kept + 1 protected complete set), found ${REMAINING_DUMPS}"
 for g in "${CYCLE_BACKUPS}"/daily/globals-*.sql; do
     [ -f "$g" ] || continue
     g_ts="$(basename "$g" | sed -nE 's/^.*-([0-9]{8}_[0-9]{6})\..*$/\1/p')"
@@ -376,6 +377,51 @@ for g in "${CYCLE_BACKUPS}"/daily/globals-*.sql; do
         || fail "globals-${g_ts}.sql outlived its dump — companions are not pruning by pairing"
 done
 echo "      pairing OK — every surviving globals dump still has the dump it pairs with."
+
+# fix(#995) review: a run of pg_dumpall failures must not walk the last
+# complete set out of retention. Each failed cycle still writes a valid dump,
+# so at retention 1 those dumps would otherwise evict the only dump that has a
+# globals file, and the orphan sweep would then take the globals with it —
+# leaving an operator with backups that cannot restore onto a fresh cluster.
+COMPLETE_TS="$(basename "$(find "${CYCLE_BACKUPS}/daily" -name 'globals-*.sql' | head -1)" | sed -nE 's/^.*-([0-9]{8}_[0-9]{6})\..*$/\1/p')"
+[ -n "$COMPLETE_TS" ] || fail "no complete set to protect before the failure run"
+for _ in 1 2 3; do
+    sleep 1
+    env BACKUP_RETENTION_DAILY=1 BACKUP_RETENTION_WEEKLY=1 \
+        BACKUP_DIR="$CYCLE_BACKUPS" STAGING_DIR="$CYCLE_STAGING" \
+        POSTGRES_HOST="$PGHOST" PGPORT="$PGPORT" \
+        POSTGRES_USER="$PGUSER" POSTGRES_PASSWORD="$PGPASSWORD" \
+        POSTGRES_DB="$SRC_DB" BACKUP_S3_ENABLED=false PATH="${STUB_BIN}:${PATH}" \
+        bash "${REPO_ROOT}/scripts/backup-entrypoint.sh" --run-backup > /dev/null 2>&1 || true
+done
+[ -f "${CYCLE_BACKUPS}/daily/globals-${COMPLETE_TS}.sql" ] \
+    || fail "three failed cycles at retention 1 evicted the last complete set's globals"
+find "${CYCLE_BACKUPS}/daily" -maxdepth 1 -name "*_${COMPLETE_TS}.dump" -type f | grep -q . \
+    || fail "three failed cycles at retention 1 evicted the last complete set's dump"
+echo "      protection OK — the newest complete set survived a run of globals failures."
+
+# fix(#995) review: retention orders by the timestamp EXTRACTED from the name,
+# not by the whole path. The database name is the prefix, so a path sort ranks
+# it ahead of the timestamp: after a POSTGRES_DB rename to a lexically earlier
+# name, every fresh dump sorts as the oldest and is pruned while the obsolete
+# ones are kept. These two fixtures only differ in which order they land under
+# each rule — `aaa_` is NEWER but sorts first by path.
+SORT_BACKUPS="${WORKDIR}/sort-backups"
+mkdir -p "${SORT_BACKUPS}/daily"
+: > "${SORT_BACKUPS}/daily/zzz_20260101_000000.dump"
+: > "${SORT_BACKUPS}/daily/aaa_20260102_000000.dump"
+env BACKUP_RETENTION_DAILY=1 BACKUP_RETENTION_WEEKLY=1 \
+    BACKUP_DIR="$SORT_BACKUPS" STAGING_DIR="$CYCLE_STAGING" \
+    POSTGRES_HOST="$PGHOST" PGPORT="$PGPORT" \
+    POSTGRES_USER="$PGUSER" POSTGRES_PASSWORD="$PGPASSWORD" \
+    POSTGRES_DB="$SRC_DB" BACKUP_S3_ENABLED=false \
+    bash "${REPO_ROOT}/scripts/backup-entrypoint.sh" --run-backup > /dev/null 2>&1 \
+    || fail "sort-order cycle exited non-zero"
+[ -f "${SORT_BACKUPS}/daily/aaa_20260102_000000.dump" ] \
+    || fail "retention pruned the NEWER dump because its database-name prefix sorts first"
+[ ! -f "${SORT_BACKUPS}/daily/zzz_20260101_000000.dump" ] \
+    || fail "retention kept the older dump — pruning is not ordered by the embedded timestamp"
+echo "      ordering OK — retention follows the embedded timestamp, not the database-name prefix."
 echo ""
 
 echo "=== PASS: backup+restore round-trip verified (bundled + managed modes) ==="

--- a/scripts/tests/test-backup-restore-roundtrip.sh
+++ b/scripts/tests/test-backup-restore-roundtrip.sh
@@ -492,6 +492,47 @@ WEEKLY_TS="$(basename "$WEEKLY_GLOBALS" | sed -nE 's/^.*-([0-9]{8}_[0-9]{6})\..*
 find "${SUNDAY_BACKUPS}/weekly" -maxdepth 1 -name "*_${WEEKLY_TS}.dump" -type f | grep -q . \
     || fail "the weekly globals copy does not pair with a weekly dump"
 echo "      weekly copy OK — paired, mode ${WEEKLY_MODE}, no leftover .tmp."
+
+# fix(#995) review: a Sunday cycle that crosses midnight must not produce a
+# weekly dump with no paired globals. This stub answers 7 for the FIRST weekday
+# question and 1 for every one after, which is exactly what a 23:59 schedule or
+# a slow staging archive looks like. The cycle has to decide once and stick to
+# it, so all three artifacts land in weekly/ or none do.
+MIDNIGHT_STUB_BIN="${WORKDIR}/stub-midnight"
+mkdir -p "$MIDNIGHT_STUB_BIN"
+cat > "${MIDNIGHT_STUB_BIN}/date" <<'MIDSTUB'
+#!/bin/sh
+case "$*" in
+  "+%u")
+    n=$(cat "$WEEKDAY_CALLS" 2>/dev/null || echo 0)
+    n=$((n + 1)); echo "$n" > "$WEEKDAY_CALLS"
+    if [ "$n" -eq 1 ]; then echo 7; else echo 1; fi
+    exit 0;;
+esac
+for real in /bin/date /usr/bin/date; do [ -x "$real" ] && exec "$real" "$@"; done
+exit 127
+MIDSTUB
+chmod +x "${MIDNIGHT_STUB_BIN}/date"
+
+MIDNIGHT_BACKUPS="${WORKDIR}/midnight-backups"
+mkdir -p "$MIDNIGHT_BACKUPS"
+env BACKUP_DIR="$MIDNIGHT_BACKUPS" STAGING_DIR="$CYCLE_STAGING" \
+    POSTGRES_HOST="$PGHOST" PGPORT="$PGPORT" \
+    POSTGRES_USER="$PGUSER" POSTGRES_PASSWORD="$PGPASSWORD" \
+    POSTGRES_DB="$SRC_DB" BACKUP_S3_ENABLED=false \
+    WEEKDAY_CALLS="${WORKDIR}/weekday-calls" PATH="${MIDNIGHT_STUB_BIN}:${PATH}" \
+    bash "${REPO_ROOT}/scripts/backup-entrypoint.sh" --run-backup > /dev/null 2>&1 \
+    || fail "midnight-crossing cycle exited non-zero"
+
+MID_WEEKLY_DUMP="$(find "${MIDNIGHT_BACKUPS}/weekly" -name '*.dump' -type f | head -1)"
+if [ -n "$MID_WEEKLY_DUMP" ]; then
+    MID_TS="$(basename "$MID_WEEKLY_DUMP" .dump | sed -nE 's/^.*_([0-9]{8}_[0-9]{6})$/\1/p')"
+    [ -f "${MIDNIGHT_BACKUPS}/weekly/globals-${MID_TS}.sql" ] \
+        || fail "a weekly dump landed with no paired globals — the weekly decision was re-evaluated mid-cycle"
+    echo "      midnight crossing OK — the weekly decision held for every artifact."
+else
+    fail "the midnight-crossing cycle produced no weekly dump, so the pairing was not exercised"
+fi
 echo ""
 
 echo "=== PASS: backup+restore round-trip verified (bundled + managed modes) ==="

--- a/scripts/tests/test-backup-restore-roundtrip.sh
+++ b/scripts/tests/test-backup-restore-roundtrip.sh
@@ -349,6 +349,41 @@ grep -q "pg_dumpall --globals-only failed" "$FAIL_LOG" \
     || fail "a failed globals dump left its .tmp behind"
 echo "      failure path OK — cycle non-zero, .last-success untouched, no partial artifact."
 
+# fix(#995) review: publishing failures must fail the cycle too. backup_globals
+# always runs inside a `$(...) || cycle_failed=1` command substitution, which
+# suspends `set -e` for its whole body, so an unchecked `mv` (read-only volume,
+# ENOSPC) would fall through and report a healthy cycle with no globals artifact
+# beside a valid dump. The stub fails ONLY for globals paths, so the dump's own
+# mv still succeeds and this isolates the publish step.
+MV_STUB_BIN="${WORKDIR}/stub-mv"
+mkdir -p "$MV_STUB_BIN"
+cat > "${MV_STUB_BIN}/mv" <<'MVSTUB'
+#!/bin/sh
+case "$*" in *globals-*) echo "simulated mv failure" >&2; exit 1;; esac
+for real in /bin/mv /usr/bin/mv; do [ -x "$real" ] && exec "$real" "$@"; done
+exit 127
+MVSTUB
+chmod +x "${MV_STUB_BIN}/mv"
+
+sleep 1
+touch "$LAST_SUCCESS_MARKER"
+MV_LOG="${WORKDIR}/cycle-mv.log"
+set +e
+run_cycle "${MV_STUB_BIN}:${PATH}" > "$MV_LOG" 2>&1
+MV_RC=$?
+set -e
+[ "$MV_RC" -ne 0 ] || {
+    cat "$MV_LOG" >&2
+    fail "cycle returned 0 despite the globals dump never being published"
+}
+grep -q "could not publish" "$MV_LOG" \
+    || fail "cycle failed but never logged that the globals dump could not be published"
+[ ! "${CYCLE_BACKUPS}/.last-success" -nt "$LAST_SUCCESS_MARKER" ] \
+    || fail ".last-success was touched by a cycle that could not publish its globals dump"
+[ -z "$(find "${CYCLE_BACKUPS}/daily" -name 'globals-*.sql.tmp' 2>/dev/null)" ] \
+    || fail "a failed publish left the globals .tmp behind"
+echo "      publish failure OK — an unpublished globals dump fails the cycle."
+
 # fix(#995) review: companions prune by PAIRING, not by their own count. The
 # failure path above is exactly how the counts diverge — a good dump with no
 # globals — so with count-based pruning a retention window of 1 keeps the

--- a/scripts/tests/test-backup-restore-roundtrip.sh
+++ b/scripts/tests/test-backup-restore-roundtrip.sh
@@ -457,6 +457,41 @@ env BACKUP_RETENTION_DAILY=1 BACKUP_RETENTION_WEEKLY=1 \
 [ ! -f "${SORT_BACKUPS}/daily/zzz_20260101_000000.dump" ] \
     || fail "retention kept the older dump — pruning is not ordered by the embedded timestamp"
 echo "      ordering OK — retention follows the embedded timestamp, not the database-name prefix."
+
+# fix(#995) review: the Sunday branch is unreachable six days a week, so the
+# weekly globals copy would otherwise ship untested. Shadow `date` so only
+# `+%u` answers 7 and every other format delegates, which keeps the artifact
+# timestamps real.
+DATE_STUB_BIN="${WORKDIR}/stub-date"
+mkdir -p "$DATE_STUB_BIN"
+cat > "${DATE_STUB_BIN}/date" <<'DATESTUB'
+#!/bin/sh
+case "$*" in "+%u") echo 7; exit 0;; esac
+for real in /bin/date /usr/bin/date; do [ -x "$real" ] && exec "$real" "$@"; done
+exit 127
+DATESTUB
+chmod +x "${DATE_STUB_BIN}/date"
+
+SUNDAY_BACKUPS="${WORKDIR}/sunday-backups"
+mkdir -p "$SUNDAY_BACKUPS"
+env BACKUP_DIR="$SUNDAY_BACKUPS" STAGING_DIR="$CYCLE_STAGING" \
+    POSTGRES_HOST="$PGHOST" PGPORT="$PGPORT" \
+    POSTGRES_USER="$PGUSER" POSTGRES_PASSWORD="$PGPASSWORD" \
+    POSTGRES_DB="$SRC_DB" BACKUP_S3_ENABLED=false PATH="${DATE_STUB_BIN}:${PATH}" \
+    bash "${REPO_ROOT}/scripts/backup-entrypoint.sh" --run-backup > /dev/null 2>&1 \
+    || fail "Sunday cycle exited non-zero"
+
+WEEKLY_GLOBALS="$(find "${SUNDAY_BACKUPS}/weekly" -name 'globals-*.sql' -type f | head -1)"
+[ -n "$WEEKLY_GLOBALS" ] || fail "the Sunday cycle wrote no weekly globals copy"
+WEEKLY_MODE="$(ls -l "$WEEKLY_GLOBALS" | cut -c1-10)"
+[ "$WEEKLY_MODE" = "-rw-------" ] \
+    || fail "the weekly globals copy is ${WEEKLY_MODE}, expected -rw------- (role password verifiers)"
+[ -z "$(find "${SUNDAY_BACKUPS}/weekly" -name 'globals-*.sql.tmp' 2>/dev/null)" ] \
+    || fail "the weekly globals copy left its .tmp behind"
+WEEKLY_TS="$(basename "$WEEKLY_GLOBALS" | sed -nE 's/^.*-([0-9]{8}_[0-9]{6})\..*$/\1/p')"
+find "${SUNDAY_BACKUPS}/weekly" -maxdepth 1 -name "*_${WEEKLY_TS}.dump" -type f | grep -q . \
+    || fail "the weekly globals copy does not pair with a weekly dump"
+echo "      weekly copy OK — paired, mode ${WEEKLY_MODE}, no leftover .tmp."
 echo ""
 
 echo "=== PASS: backup+restore round-trip verified (bundled + managed modes) ==="

--- a/scripts/tests/test-backup-restore-roundtrip.sh
+++ b/scripts/tests/test-backup-restore-roundtrip.sh
@@ -308,7 +308,6 @@ GLOBALS_MODE="$(ls -l "$GLOBALS_FILE" | cut -c1-10)"
 echo "      globals artifact OK — $(basename "$GLOBALS_FILE"), mode ${GLOBALS_MODE}, paired timestamp."
 
 [ -f "${CYCLE_BACKUPS}/.last-success" ] || fail "successful cycle did not write .last-success"
-LAST_SUCCESS_BEFORE="$(ls -l "${CYCLE_BACKUPS}/.last-success")"
 
 # Failure path: a pg_dumpall that fails must fail the CYCLE (an unrestorable-
 # roles backup is not a good backup), leaving .last-success at its old value so
@@ -319,6 +318,15 @@ STUB_BIN="${WORKDIR}/stub-bin"
 mkdir -p "$STUB_BIN"
 printf '#!/bin/sh\necho "simulated pg_dumpall failure" >&2\nexit 1\n' > "${STUB_BIN}/pg_dumpall"
 chmod +x "${STUB_BIN}/pg_dumpall"
+
+# Artifact names carry a whole-second timestamp, so back-to-back cycles reuse
+# one name and silently overwrite each other — which would leave the pairing
+# check below with a single set and nothing to prove. Sleep past the boundary.
+sleep 1
+# A marker file rather than a stringified `ls -l`: ls prints minute-granularity
+# times, so a re-touch inside the same minute would compare equal.
+LAST_SUCCESS_MARKER="${WORKDIR}/last-success-marker"
+touch "$LAST_SUCCESS_MARKER"
 
 FAIL_LOG="${WORKDIR}/cycle-fail.log"
 set +e
@@ -331,13 +339,43 @@ set -e
 }
 grep -q "pg_dumpall --globals-only failed" "$FAIL_LOG" \
     || fail "cycle failed but never logged why the globals dump could not be captured"
-[ "$(ls -l "${CYCLE_BACKUPS}/.last-success")" = "$LAST_SUCCESS_BEFORE" ] \
+[ ! "${CYCLE_BACKUPS}/.last-success" -nt "$LAST_SUCCESS_MARKER" ] \
     || fail ".last-success was touched by a cycle whose globals dump failed"
 # The partial file must not be left behind: a truncated globals dump replays as
 # a partial set of roles, which is worse than having none.
 [ -z "$(find "${CYCLE_BACKUPS}/daily" -name 'globals-*.sql' -size 0 2>/dev/null)" ] \
     || fail "a failed globals dump left an empty artifact behind"
+[ -z "$(find "${CYCLE_BACKUPS}/daily" -name 'globals-*.sql.tmp' 2>/dev/null)" ] \
+    || fail "a failed globals dump left its .tmp behind"
 echo "      failure path OK — cycle non-zero, .last-success untouched, no partial artifact."
+
+# fix(#995) review: companions prune by PAIRING, not by their own count. The
+# failure path above is exactly how the counts diverge — a good dump with no
+# globals — so with count-based pruning a retention window of 1 keeps the
+# newest dump while the older globals, being the only one of its kind, survives
+# as an orphan. Drive that with BACKUP_RETENTION_DAILY=1: the first cycle's
+# dump ages out, so its globals must go with it.
+sleep 1  # distinct timestamp again, for the same reason as above
+ORPHAN_LOG="${WORKDIR}/cycle-orphan.log"
+if ! env BACKUP_RETENTION_DAILY=1 BACKUP_RETENTION_WEEKLY=1 \
+    BACKUP_DIR="$CYCLE_BACKUPS" STAGING_DIR="$CYCLE_STAGING" \
+    POSTGRES_HOST="$PGHOST" PGPORT="$PGPORT" \
+    POSTGRES_USER="$PGUSER" POSTGRES_PASSWORD="$PGPASSWORD" \
+    POSTGRES_DB="$SRC_DB" BACKUP_S3_ENABLED=false \
+    bash "${REPO_ROOT}/scripts/backup-entrypoint.sh" --run-backup > "$ORPHAN_LOG" 2>&1; then
+    cat "$ORPHAN_LOG" >&2
+    fail "retention-1 cycle exited non-zero"
+fi
+REMAINING_DUMPS="$(find "${CYCLE_BACKUPS}/daily" -name '*.dump' -type f | wc -l | tr -d ' ')"
+[ "$REMAINING_DUMPS" = "1" ] \
+    || fail "expected retention to leave exactly 1 dump, found ${REMAINING_DUMPS}"
+for g in "${CYCLE_BACKUPS}"/daily/globals-*.sql; do
+    [ -f "$g" ] || continue
+    g_ts="$(basename "$g" | sed -nE 's/^.*-([0-9]{8}_[0-9]{6})\..*$/\1/p')"
+    find "${CYCLE_BACKUPS}/daily" -maxdepth 1 -name "*_${g_ts}.dump" -type f | grep -q . \
+        || fail "globals-${g_ts}.sql outlived its dump — companions are not pruning by pairing"
+done
+echo "      pairing OK — every surviving globals dump still has the dump it pairs with."
 echo ""
 
 echo "=== PASS: backup+restore round-trip verified (bundled + managed modes) ==="


### PR DESCRIPTION
Integration batch. **Do not merge this PR.** It exists to run CI once on the combination; each member is then merged individually so it keeps its own squash commit and its own issue link. This branch is deleted either way.

Base is `ffb7dd6ee`. Members, with heads pinned:

| PR | head | what |
| --- | --- | --- |
| #1090 | `e4f526c51` | backend paths-filter covers root scripts backend tests read |
| #1092 | `7b0e383f3` | a builder clear actually clears |
| #1027 | `a1c033382` | `pg_dumpall --globals-only` in the backup cycle |

## Why these three ride together

#1090 and #1027 are the pair that individual CI structurally cannot check. #1027 changes `scripts/backup-entrypoint.sh`, and on its own PR Backend Tests **skipped**, because the `backend` paths-filter had no `scripts/` entries. So `test_backup_staging_tar_skew.py`, which exists to catch a break in that exact script, never ran, and the PR read as ready. #1090 is the filter fix.

In this tree the filter change and the script change are present together, so `changes.backend` resolves TRUE off `scripts/backup-entrypoint.sh` and Backend Tests runs against it for the first time. Verified by evaluating the merged `ci.yml` filters against this branch's own diff.

## Pre-flight

Local, on the pinned base, pushing nothing:

- three-way merge clean, no conflict in combination
- `ruff check` and `ruff format --check` clean, 869 files
- 133 backend tests across the layering gate, both ci.yml filter guards, the backup skew test, and the dockerfile/compose/docker-audit suites
- `npm run typecheck` and `npm run lint` clean
- 4490 frontend tests

A pre-flight GO means this is worth a CI cycle. It is not a prediction that CI passes: it does not run the backend suite, which is the long pole and the thing this batch is actually here to exercise.

## Coverage this run does NOT have

This is a `pull_request` event, so `accessibility`, `stac-validate` and the full `e2e-test` suite do not run. Those first meet the combination on main's push run after the members land, and `e2e-test` never runs on a merge at all. Green here means the PR-visible combination is tested, not that the combination is tested.

Refs #1088