### PR TITLE
fix(ci): diff a PR against its merge base, not its frozen base sha

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,13 @@ jobs:
       backup: ${{ steps.filter.outputs.backup }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          # fix(#1094): the default depth-1 clone grafts the checked-out commit
+          # as a shallow boundary, and git then reports it as having NO parents:
+          # `git rev-parse HEAD^1` dies with "ambiguous argument". Depth 2 is the
+          # minimum that materialises the merge ref's two parents, which is all
+          # the base resolution below needs.
+          fetch-depth: 2
       # fix(#1094): resolve the PR diff base ourselves. paths-filter's no-token
       # path diffs `pull_request.base.sha .. merge-commit`, and base.sha is
       # frozen at PR-open time while GitHub recomputes the merge ref every time
@@ -77,10 +84,9 @@ jobs:
       #
       # checkout leaves us on refs/pull/N/merge, whose FIRST parent is the base
       # branch tip as of when that ref was built. Diffing against it yields the
-      # PR's own changes and nothing else. rev-parse reads the parent out of the
-      # merge commit itself, so this needs no extra fetch depth, and
-      # paths-filter's ensureRefAvailable does `fetch --depth=1 origin <sha>`
-      # for the base it is handed.
+      # PR's own changes and nothing else. This needs the fetch-depth: 2 above;
+      # paths-filter's own ensureRefAvailable then finds the base locally rather
+      # than re-fetching it.
       - name: Resolve the PR diff base
         id: diffbase
         if: github.event_name == 'pull_request'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,28 @@ jobs:
       backup: ${{ steps.filter.outputs.backup }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+      # fix(#1094): resolve the PR diff base ourselves. paths-filter's no-token
+      # path diffs `pull_request.base.sha .. merge-commit`, and base.sha is
+      # frozen at PR-open time while GitHub recomputes the merge ref every time
+      # main moves. So the diff grew to include everything that landed since:
+      # #1027 changed 4 files and the filter reported 117, turning Backend Tests
+      # on for other people's backend/** work. Coverage got WIDER the staler a
+      # branch was, which is backwards.
+      #
+      # checkout leaves us on refs/pull/N/merge, whose FIRST parent is the base
+      # branch tip as of when that ref was built. Diffing against it yields the
+      # PR's own changes and nothing else. rev-parse reads the parent out of the
+      # merge commit itself, so this needs no extra fetch depth, and
+      # paths-filter's ensureRefAvailable does `fetch --depth=1 origin <sha>`
+      # for the base it is handed.
+      - name: Resolve the PR diff base
+        id: diffbase
+        if: github.event_name == 'pull_request'
+        run: |
+          set -euo pipefail
+          base="$(git rev-parse HEAD^1)"
+          echo "Diffing against first parent of the merge ref: $base"
+          echo "sha=$base" >> "$GITHUB_OUTPUT"
       - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706  # v4
         id: filter
         # fix(#1000): the filter has nothing to diff against on merge_group and
@@ -80,10 +102,19 @@ jobs:
         # could have produced without a base.
         if: github.event_name != 'merge_group'
         with:
-          # fix(#546): empty token switches paths-filter to git-diff detection
-          # (base.sha..merge-commit from the checkout), removing the GitHub API
-          # call whose transient 503s failed this required check hard.
+          # fix(#546): empty token switches paths-filter to git-diff detection,
+          # removing the GitHub API call whose transient 503s failed this
+          # required check hard. fix(#1094) supplies the base that detection
+          # diffs from; without it the action falls back to the stale
+          # pull_request.base.sha.
           token: ''
+          # fix(#1094): empty on push and merge_group, where the action's own
+          # defaults (before-SHA / merge_group.base_sha) are already right.
+          # The action logs "'base' input parameter is ignored when action is
+          # triggered by pull request event" — that warning is wrong on this
+          # path: main.ts resolves `base || baseSha || defaultBranch`, so an
+          # explicit base takes precedence. Only the API path ignores it.
+          base: ${{ steps.diffbase.outputs.sha }}
           filters: |
             backend:
               - 'backend/**'

--- a/backend/tests/test_ci_alembic_filter_paths.py
+++ b/backend/tests/test_ci_alembic_filter_paths.py
@@ -174,6 +174,75 @@ class TestAlembicFilterGlobs:
         )
 
 
+class TestPullRequestDiffBase:
+    """fix(#1094): the PR diff base must not be the stale pull_request.base.sha."""
+
+    def _changes_steps(self) -> list[dict]:
+        with CI_YML_PATH.open() as fh:
+            ci: dict[str, Any] = yaml.safe_load(fh)
+        return ci["jobs"]["changes"]["steps"]
+
+    def test_paths_filter_is_given_an_explicit_base(self):
+        """Without a `base` input the action uses pull_request.base.sha.
+
+        That value is frozen when the PR is opened, while GitHub rebuilds the
+        refs/pull/N/merge ref every time main moves, so the diff silently grows
+        to include everything that landed in between. #1027 changed 4 files and
+        its filter reported 117, which switched Backend Tests on for unrelated
+        backend/** work and made a green job say nothing about the PR.
+        """
+        steps = self._changes_steps()
+        filter_step = next(
+            (s for s in steps if "dorny/paths-filter" in str(s.get("uses", ""))),
+            None,
+        )
+        assert filter_step is not None, "paths-filter step not found in changes job"
+
+        base = str(filter_step.get("with", {}).get("base", "")).strip()
+        assert base, (
+            "The paths-filter step has no 'base' input, so it falls back to the "
+            "stale pull_request.base.sha and a PR's filter diff grows as main "
+            "moves underneath it. See #1094."
+        )
+
+        producer_ids = {str(s.get("id", "")) for s in steps if s.get("id")}
+        referenced = re.findall(r"steps\.([A-Za-z0-9_-]+)\.outputs", base)
+        assert referenced, (
+            f"'base' should come from a step output that resolves a merge base; "
+            f"got {base!r}."
+        )
+        missing = [r for r in referenced if r not in producer_ids]
+        assert not missing, (
+            f"'base' references step id(s) {missing} that do not exist in the "
+            f"changes job. Known ids: {sorted(producer_ids)}"
+        )
+
+    def test_diff_base_is_resolved_from_the_merge_ref_parent(self):
+        """The resolver must derive the base from the merge ref, not the payload.
+
+        Reading github.event.pull_request.base.sha back out of the payload would
+        reintroduce #1094 with extra steps.
+        """
+        steps = self._changes_steps()
+        resolver = next(
+            (s for s in steps if str(s.get("id", "")) == "diffbase"),
+            None,
+        )
+        assert resolver is not None, (
+            "No step with id 'diffbase' in the changes job. Something removed "
+            "the #1094 base resolver."
+        )
+        script = str(resolver.get("run", ""))
+        assert "HEAD^1" in script, (
+            "The diff-base resolver no longer reads the merge ref's first "
+            f"parent. Script was:\n{script}"
+        )
+        assert "base.sha" not in script.replace(" ", ""), (
+            "The diff-base resolver reads pull_request.base.sha, which is the "
+            "stale value #1094 exists to stop using."
+        )
+
+
 class TestBackendFilterCoversReferencedScripts:
     """fix(#1088): guard the backend filter against the skipped-suite trap."""
 


### PR DESCRIPTION
## The bug

`paths-filter` runs with `token: ''` (fix(#546), to keep a required check off a flaky API call), which puts it on git-diff detection. That path diffs `pull_request.base.sha .. merge-commit`.

`base.sha` is frozen when the PR is opened. GitHub rebuilds `refs/pull/N/merge` every time main moves. So the diff accumulates everything that landed in between.

#1027 changed four files and its filter reported 117:

```
GitHub token is not available - changes will be detected using git diff
Detected 117 changed files
```

The extras were other people's `backend/**` work, and that is what switched Backend Tests on. Reproduced exactly: `git diff f0113cdfa <merge-tree(06b32dcd6, a1c033382)>` gives 117 files.

## Why it matters more than wasted minutes

A green job can be entirely about someone else's code. #1027's `Backend Tests -> pass` was not the suite vetting #1027.

Worse, coverage ran **inverse to freshness**. The closer a branch was to main, the narrower its computed diff and the fewer jobs ran. Update-branching immediately before merging handed a PR the least filtering it would ever get, at the moment the result mattered most. #1027 read `skipping` earlier in the day and `pass` later, same four files, driven only by drift.

## The fix

`checkout` leaves the job on `refs/pull/N/merge`, whose first parent is the base tip as of when that ref was built. `HEAD^1..HEAD` is therefore the PR's own content and nothing else.

It needs `fetch-depth: 2`. A depth-1 clone grafts the checked-out commit as a shallow boundary and git reports it as **parentless**, so `rev-parse HEAD^1` dies with `ambiguous argument`. Depth 2 materialises the merge ref's two parents, which is all this needs; `paths-filter`'s `ensureRefAvailable` then finds the base locally instead of re-fetching.

Untouched on purpose: `push` keeps the action's before-SHA default, `merge_group` keeps `merge_group.base_sha`. Both are already right, and the queue skips this step entirely.

One trap worth recording. The action logs `'base' input parameter is ignored when action is triggered by pull request event`. That warning is wrong on this path: `main.ts:117` resolves `base || baseSha || defaultBranch`, so an explicit base wins. Only the API path discards it. Read at the pinned sha, not from the docs.

## Verification

The first push of this branch asserted in a code comment that no extra fetch depth was needed. That was wrong, and this PR's own `Detect Changes` job failed on it:

```
fatal: ambiguous argument 'HEAD^1': unknown revision or path not in the working tree
Required jobs failed or were cancelled: changes
```

Fixed in `e5b8e6ad9`. The check that matters is this PR's own `Detect Changes` log reporting a file count matching what it actually changes, rather than everything since branch point, and it is the only place the fix executes.

Locally: 8 tests in `test_ci_alembic_filter_paths.py`, with A/B on the new guard — deleting the `base:` line fails it with the stale-base explanation. `ci.yml` parses at 25 jobs with all five triggers intact.

## Guard

Two assertions in `test_ci_alembic_filter_paths.py`, which already parses this workflow:

- the filter step must carry a `base` wired to a step id that exists in the job
- the resolver must read `HEAD^1` and must not reach back into the payload for `base.sha`

Closes #1094