### PR TITLE
feat(analysis): spatial join, measure, select by location, and intersect

### DIFF
--- a/backend/app/modules/catalog/authorization.py
+++ b/backend/app/modules/catalog/authorization.py
@@ -168,6 +168,21 @@ async def _can_access_dataset_id(
     )
 
 
+# fix(#1097 review): every provenance param naming a dataset, mapped to the
+# params that DESCRIBE that dataset and must be dropped with it.
+#
+# The keys are what an unauthorized requester must not learn the value of; the
+# values are what would still describe the layer once its id was gone. An
+# operation that adds a dataset-id param adds a row here, and
+# test_every_dataset_id_param_is_redactable fails until it does — the check is
+# structural because the failure mode is silence: the leak looks like ordinary
+# provenance, and nothing errors.
+_DATASET_ID_PARAMS: dict[str, tuple[str, ...]] = {
+    "mask_dataset_id": (),
+    "join_dataset_id": ("join_fields",),
+}
+
+
 async def visible_derived_from(
     db: AsyncSession,
     derived_from: dict | None,
@@ -189,6 +204,16 @@ async def visible_derived_from(
     source's verdict. A returned dict is always a copy; the caller must not be
     able to mutate the record's JSONB through it.
 
+    fix(#1097 review): driven by ``_DATASET_ID_PARAMS`` rather than by a check
+    per id. Spatial join added ``join_dataset_id`` and this function kept
+    redacting only the mask, so a public join output derived through a PRIVATE
+    join layer published that layer's id — and ``join_fields`` with it, which
+    is the layer's column names. That is the same gap #765's review closed for
+    the mask, reopened by the next operation to carry a dataset id, which is
+    the argument for a table over another branch: an operation that adds one is
+    now a row here, and the structural test enforcing that lives in
+    ``test_analysis_provenance.py``.
+
     A source that has since been deleted also yields None: access to it can no
     longer be established, and the prose lineage on the record still reads.
     """
@@ -200,11 +225,18 @@ async def visible_derived_from(
         return None
 
     params = dict(derived_from.get("params") or {})
-    mask_id = params.get("mask_dataset_id")
-    if mask_id is not None and not await _can_access_dataset_id(
-        db, mask_id, user, user_roles
-    ):
-        params.pop("mask_dataset_id")
+    for id_param, dependent_params in _DATASET_ID_PARAMS.items():
+        dataset_id = params.get(id_param)
+        if dataset_id is None:
+            continue
+        if await _can_access_dataset_id(db, dataset_id, user, user_roles):
+            continue
+        params.pop(id_param)
+        # The id is not the only thing that describes the layer. Dropping
+        # join_dataset_id while keeping join_fields would still publish the
+        # private layer's column names, which is most of what its schema is.
+        for dependent in dependent_params:
+            params.pop(dependent, None)
     return {**derived_from, "params": params}
 
 

--- a/backend/app/modules/catalog/datasets/api/router_analysis.py
+++ b/backend/app/modules/catalog/datasets/api/router_analysis.py
@@ -373,8 +373,13 @@ async def analysis_preview_endpoint(
     join_dataset = None
     if body.join_dataset_id is not None:
         join_dataset = await _load_join_dataset(db, body.join_dataset_id, user)
-        if body.join_fields:
-            _validate_join_fields(dataset, join_dataset, body.join_fields)
+        # fix(#1097 review): unconditionally, matching materialize. The guard
+        # used to be `if body.join_fields`, but _validate_join_fields also
+        # checks the ALWAYS-generated join_count against the source's columns —
+        # so a source that already had a join_count column previewed fine and
+        # then failed Create on the identical form. Preview approving an output
+        # that Create refuses is worse than either verdict on its own.
+        _validate_join_fields(dataset, join_dataset, body.join_fields or [])
     try:
         return await run_analysis_preview(
             db,

--- a/backend/app/modules/catalog/datasets/api/router_analysis.py
+++ b/backend/app/modules/catalog/datasets/api/router_analysis.py
@@ -29,6 +29,7 @@ from app.modules.catalog.datasets.domain.service import (
 )
 from app.modules.quota.service import check_upload_quota
 from app.platform.analysis_sql import (
+    INTERSECT_OUTPUT_COLUMNS,
     MAX_MASK_LAYER_FEATURES,
     MAX_SOURCE_FEATURES,
     MEASURE_OUTPUT_COLUMNS,
@@ -224,6 +225,43 @@ def _validate_join_fields(source, join_dataset, join_fields: list[str]) -> None:
     _reject_generated_column_collision(source, spatial_join_output_columns(join_fields))
 
 
+def _column_names(dataset) -> set[str]:
+    return {col.get("name") for col in (dataset.column_info or []) if col}
+
+
+def _validate_intersect_columns(source, overlay) -> None:
+    """422 on any column an overlay would emit twice (fix(#956)).
+
+    An overlay is the first operation to carry columns from BOTH inputs onto
+    every output row, so a same-named column in the two layers is likely
+    rather than exotic — ``name``, ``id`` and ``area`` are all common. The CTAS
+    would fail it with an opaque "column specified more than once" after the
+    whole queue wait. Prefixing silently is the alternative, and it makes the
+    output columns unpredictable for anyone scripting against the result.
+    """
+    _reject_generated_column_collision(source, INTERSECT_OUTPUT_COLUMNS)
+    generated = sorted(_column_names(overlay) & set(INTERSECT_OUTPUT_COLUMNS))
+    if generated:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail=(
+                f"The overlay layer has a column named {generated[0]!r}, which "
+                "this operation generates. Rename it, or choose a different "
+                "layer."
+            ),
+        )
+    clashes = sorted(_column_names(source) & _column_names(overlay))
+    if clashes:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail=(
+                f"Both layers have a column named {clashes[0]!r}, and an "
+                "overlay carries columns from both. Rename one of them, or "
+                "choose a different layer."
+            ),
+        )
+
+
 @router.post("/{dataset_id}/analysis/preview/", response_model=AnalysisPreviewResponse)
 async def analysis_preview_endpoint(
     dataset_id: uuid.UUID,
@@ -332,6 +370,12 @@ async def _validate_materialize_params(
         _validate_join_fields(dataset, join_dataset, body.join_fields or [])
     if body.operation == "measure":
         _reject_generated_column_collision(dataset, MEASURE_OUTPUT_COLUMNS)
+    if body.operation == "intersect":
+        # Access check on the overlay layer, plus the column checks. Rule 1
+        # applies to BOTH datasets; the worker re-resolves the table and
+        # re-checks the collisions against the live columns after the queue.
+        overlay = await _load_mask_dataset(db, body.mask_dataset_id, user)
+        _validate_intersect_columns(dataset, overlay)
 
 
 @router.post(

--- a/backend/app/modules/catalog/datasets/api/router_analysis.py
+++ b/backend/app/modules/catalog/datasets/api/router_analysis.py
@@ -4,6 +4,7 @@ import re
 import uuid
 from collections.abc import Iterable
 from datetime import datetime, timedelta, timezone
+from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException, Request, status
 from sqlalchemy import and_, func, or_, select, text
@@ -378,6 +379,42 @@ async def _validate_materialize_params(
         _validate_intersect_columns(dataset, overlay)
 
 
+def _build_analysis_job_metadata(
+    body: AnalysisMaterializeRequest, dataset
+) -> dict[str, Any]:
+    """The params recorded on the job so Admin -> Jobs can diagnose a run.
+
+    "analysis-buffer failed" on its own says nothing. The drawn mask geometry
+    is deliberately NOT stored: it can be kilobytes, and a marker suffices.
+
+    Extracted from the handler rather than left inline (#1097 review): this is
+    the per-operation dispatch, so it is the block that grows every time an
+    operation is added, and it took the endpoint past ruff's C901 threshold at
+    the fourth one. Inline, the next operation would trip the same rule again
+    and the fix would be the same extraction done under more pressure. Nothing
+    here touches the request, the session, or the job row, so it lifts out
+    whole.
+    """
+    meta: dict[str, Any] = {
+        "operation": body.operation,
+        "source_dataset_id": str(dataset.id),
+        "title": body.title,
+    }
+    if body.distance_meters is not None:
+        meta["distance_meters"] = body.distance_meters
+    if body.by_field is not None:
+        meta["by_field"] = body.by_field
+    if body.operation == "clip":
+        meta["mask_source"] = "layer" if body.mask_dataset_id else "drawn"
+        if body.mask_dataset_id is not None:
+            meta["mask_dataset_id"] = str(body.mask_dataset_id)
+    if body.operation == "spatial_join":
+        meta["join_dataset_id"] = str(body.join_dataset_id)
+        if body.join_fields:
+            meta["join_fields"] = list(body.join_fields)
+    return meta
+
+
 @router.post(
     "/{dataset_id}/analysis/materialize/",
     response_model=AnalysisMaterializeResponse,
@@ -533,27 +570,7 @@ async def analysis_materialize_endpoint(
     job = await get_catalog_port().create_ingest_job(
         db, f"analysis-{body.operation}", "", user.id
     )
-    # Record the request params so Admin → Jobs can diagnose a failed run
-    # ("analysis-buffer failed" alone says nothing). The drawn mask geometry
-    # is deliberately NOT stored — it can be kilobytes; a marker suffices.
-    analysis_meta = {
-        "operation": body.operation,
-        "source_dataset_id": str(dataset.id),
-        "title": body.title,
-    }
-    if body.distance_meters is not None:
-        analysis_meta["distance_meters"] = body.distance_meters
-    if body.by_field is not None:
-        analysis_meta["by_field"] = body.by_field
-    if body.operation == "clip":
-        analysis_meta["mask_source"] = "layer" if body.mask_dataset_id else "drawn"
-        if body.mask_dataset_id is not None:
-            analysis_meta["mask_dataset_id"] = str(body.mask_dataset_id)
-    if body.operation == "spatial_join":
-        analysis_meta["join_dataset_id"] = str(body.join_dataset_id)
-        if body.join_fields:
-            analysis_meta["join_fields"] = list(body.join_fields)
-    job.user_metadata = {"analysis": analysis_meta}
+    job.user_metadata = {"analysis": _build_analysis_job_metadata(body, dataset)}
     # ux(#698): stamp a step so a pending job reads as "queued" rather than
     # being indistinguishable from a broken one. This matters more since #703
     # deliberately defers analysis below the default priority — a queued job

--- a/backend/app/modules/catalog/datasets/api/router_analysis.py
+++ b/backend/app/modules/catalog/datasets/api/router_analysis.py
@@ -498,10 +498,20 @@ def _build_analysis_job_metadata(
         meta["distance_meters"] = body.distance_meters
     if body.by_field is not None:
         meta["by_field"] = body.by_field
-    if body.operation == "clip":
+    # fix(#1097 review): the second layer is recorded for EVERY operation that
+    # consumes one, not just clip. Admin Jobs surfaces this metadata to
+    # diagnose a failed run, and select_by_location and intersect are both
+    # driven by a layer the operator could not otherwise identify — so a failure
+    # caused by that layer (re-uploaded mid-queue, wrong geometry, ungroupable
+    # column) showed only the operation, the source and the title.
+    #
+    # mask_source stays scoped to the operations that can take a DRAWN mask.
+    # intersect rejects one, so "layer" there would be a constant dressed up as
+    # a discriminator.
+    if body.mask_dataset_id is not None:
+        meta["mask_dataset_id"] = str(body.mask_dataset_id)
+    if body.operation in MASK_OPERATIONS:
         meta["mask_source"] = "layer" if body.mask_dataset_id else "drawn"
-        if body.mask_dataset_id is not None:
-            meta["mask_dataset_id"] = str(body.mask_dataset_id)
     if body.operation == "spatial_join":
         meta["join_dataset_id"] = str(body.join_dataset_id)
         if body.join_fields:

--- a/backend/app/modules/catalog/datasets/api/router_analysis.py
+++ b/backend/app/modules/catalog/datasets/api/router_analysis.py
@@ -2,6 +2,7 @@
 
 import re
 import uuid
+from collections.abc import Iterable
 from datetime import datetime, timedelta, timezone
 
 from fastapi import APIRouter, Depends, HTTPException, Request, status
@@ -29,6 +30,7 @@ from app.modules.quota.service import check_upload_quota
 from app.platform.analysis_sql import (
     MAX_MASK_LAYER_FEATURES,
     MAX_SOURCE_FEATURES,
+    MEASURE_OUTPUT_COLUMNS,
     render_mask_expr,
     spatial_join_output_columns,
 )
@@ -178,6 +180,30 @@ async def _load_join_dataset(
     return await _load_vector_dataset(db, join_dataset_id, user)
 
 
+def _reject_generated_column_collision(source, generated: Iterable[str]) -> None:
+    """422 when the source already has a column an operation would generate.
+
+    Every 1:1 operation's output is the source's own columns verbatim plus its
+    generated ones, so a source column of the same name reaches the CTAS twice
+    and fails it with an opaque "column specified more than once" — after the
+    whole queue wait. Named at enqueue instead. This is the shared form of the
+    guard dissolve applies to ``source_count`` in ``_validate_dissolve_by_field``
+    (fix(#954): measure and spatial_join both need it, so it lives in one place
+    rather than being re-derived per operation).
+    """
+    source_columns = {col.get("name") for col in (source.column_info or []) if col}
+    clashes = sorted(source_columns & set(generated))
+    if clashes:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail=(
+                f"The source dataset already has a column named {clashes[0]!r}, "
+                "which this operation would overwrite. Rename it, or choose a "
+                "different operation."
+            ),
+        )
+
+
 def _validate_join_fields(source, join_dataset, join_fields: list[str]) -> None:
     """422 on unknown join columns, or ones that would collide on output."""
     known = {col.get("name") for col in (join_dataset.column_info or []) if col}
@@ -187,21 +213,7 @@ def _validate_join_fields(source, join_dataset, join_fields: list[str]) -> None:
                 status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
                 detail=f"Unknown join column: {name!r}",
             )
-    # The output carries the source's own columns verbatim beside the generated
-    # ones, so a source column named join_count (or join_<field>) would reach
-    # the CTAS twice and fail it with "column specified more than once" after
-    # the queue wait. Same trap dissolve's by_field hits on source_count.
-    source_columns = {col.get("name") for col in (source.column_info or []) if col}
-    clashes = sorted(source_columns & set(spatial_join_output_columns(join_fields)))
-    if clashes:
-        raise HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
-            detail=(
-                f"The source dataset already has a column named {clashes[0]!r}, "
-                "which this join would overwrite. Rename it, or drop that "
-                "field from the join."
-            ),
-        )
+    _reject_generated_column_collision(source, spatial_join_output_columns(join_fields))
 
 
 @router.post("/{dataset_id}/analysis/preview/", response_model=AnalysisPreviewResponse)
@@ -308,6 +320,8 @@ async def _validate_materialize_params(
         # the table name and re-checks the collision against the live columns.
         join_dataset = await _load_join_dataset(db, body.join_dataset_id, user)
         _validate_join_fields(dataset, join_dataset, body.join_fields or [])
+    if body.operation == "measure":
+        _reject_generated_column_collision(dataset, MEASURE_OUTPUT_COLUMNS)
 
 
 @router.post(

--- a/backend/app/modules/catalog/datasets/api/router_analysis.py
+++ b/backend/app/modules/catalog/datasets/api/router_analysis.py
@@ -30,6 +30,7 @@ from app.platform.analysis_sql import (
     MAX_MASK_LAYER_FEATURES,
     MAX_SOURCE_FEATURES,
     render_mask_expr,
+    spatial_join_output_columns,
 )
 from app.platform.extensions import get_catalog_port
 from app.platform.jobs.defer_guard import (
@@ -160,6 +161,49 @@ async def _load_mask_dataset(
     return dataset
 
 
+async def _load_join_dataset(
+    db: AsyncSession, join_dataset_id: uuid.UUID, user: Identity
+):
+    """Fetch + visibility-check a spatial-join layer (fix(#953)).
+
+    Rule 1 applies to BOTH datasets of a two-layer operation, so this is the
+    same treatment ``_load_mask_dataset`` gives the clip mask. No geometry-type
+    requirement, unlike the mask: a join is meaningful in every direction —
+    points in polygons, polygons touching lines, polygons overlapping polygons
+    — and the count means the same thing in all of them. No size ceiling of its
+    own either: the join layer is probed through its GIST index once per source
+    row, so it is the SOURCE row count that drives the cost, and that is what
+    MAX_SOURCE_FEATURES['spatial_join'] bounds.
+    """
+    return await _load_vector_dataset(db, join_dataset_id, user)
+
+
+def _validate_join_fields(source, join_dataset, join_fields: list[str]) -> None:
+    """422 on unknown join columns, or ones that would collide on output."""
+    known = {col.get("name") for col in (join_dataset.column_info or []) if col}
+    for name in join_fields:
+        if not _SAFE_COLUMN_RE.match(name) or name not in known:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+                detail=f"Unknown join column: {name!r}",
+            )
+    # The output carries the source's own columns verbatim beside the generated
+    # ones, so a source column named join_count (or join_<field>) would reach
+    # the CTAS twice and fail it with "column specified more than once" after
+    # the queue wait. Same trap dissolve's by_field hits on source_count.
+    source_columns = {col.get("name") for col in (source.column_info or []) if col}
+    clashes = sorted(source_columns & set(spatial_join_output_columns(join_fields)))
+    if clashes:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail=(
+                f"The source dataset already has a column named {clashes[0]!r}, "
+                "which this join would overwrite. Rename it, or drop that "
+                "field from the join."
+            ),
+        )
+
+
 @router.post("/{dataset_id}/analysis/preview/", response_model=AnalysisPreviewResponse)
 async def analysis_preview_endpoint(
     dataset_id: uuid.UUID,
@@ -178,6 +222,11 @@ async def analysis_preview_endpoint(
         if body.mask_dataset_id is not None
         else None
     )
+    join_dataset = None
+    if body.join_dataset_id is not None:
+        join_dataset = await _load_join_dataset(db, body.join_dataset_id, user)
+        if body.join_fields:
+            _validate_join_fields(dataset, join_dataset, body.join_fields)
     try:
         return await run_analysis_preview(
             db,
@@ -185,6 +234,7 @@ async def analysis_preview_endpoint(
             body,
             user.id,
             mask_dataset=mask_dataset,
+            join_dataset=join_dataset,
             # fix(#716): safe here — `user.id` is evaluated above, and neither
             # this handler nor any middleware reads ORM state afterwards.
             release_session=True,
@@ -230,6 +280,36 @@ def _validate_dissolve_by_field(dataset, by_field: str) -> None:
         )
 
 
+async def _validate_materialize_params(
+    db: AsyncSession, dataset, body: AnalysisMaterializeRequest, user: Identity
+) -> None:
+    """Per-operation enqueue-time validation, so a bad request 422s fast.
+
+    Everything here fails BEFORE a job row exists — the alternative is a job
+    the user has to watch fail minutes later with an opaque database error.
+    Each check has a second, run-time half in the worker, because the queue
+    wait sits between the two and the world can move underneath it.
+    """
+    if body.operation == "clip" and body.mask_dataset_id is not None:
+        # Access + polygon checks happen here at enqueue time; the worker
+        # re-resolves the table name and re-validates it against _SAFE_TABLE.
+        await _load_mask_dataset(db, body.mask_dataset_id, user)
+    elif body.operation == "clip":
+        try:
+            render_mask_expr(body.mask or {})
+        except ValueError as exc:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_CONTENT, detail=str(exc)
+            ) from exc
+    if body.operation == "dissolve" and body.by_field is not None:
+        _validate_dissolve_by_field(dataset, body.by_field)
+    if body.operation == "spatial_join":
+        # Access + column checks, same as the clip mask; the worker re-resolves
+        # the table name and re-checks the collision against the live columns.
+        join_dataset = await _load_join_dataset(db, body.join_dataset_id, user)
+        _validate_join_fields(dataset, join_dataset, body.join_fields or [])
+
+
 @router.post(
     "/{dataset_id}/analysis/materialize/",
     response_model=AnalysisMaterializeResponse,
@@ -273,20 +353,7 @@ async def analysis_materialize_endpoint(
                 ),
             )
 
-    # Fail fast on invalid params before creating a job.
-    if body.operation == "clip" and body.mask_dataset_id is not None:
-        # Access + polygon checks happen here at enqueue time; the worker
-        # re-resolves the table name and re-validates it against _SAFE_TABLE.
-        await _load_mask_dataset(db, body.mask_dataset_id, user)
-    elif body.operation == "clip":
-        try:
-            render_mask_expr(body.mask or {})
-        except ValueError as exc:
-            raise HTTPException(
-                status_code=status.HTTP_422_UNPROCESSABLE_CONTENT, detail=str(exc)
-            ) from exc
-    if body.operation == "dissolve" and body.by_field is not None:
-        _validate_dissolve_by_field(dataset, body.by_field)
+    await _validate_materialize_params(db, dataset, body, user)
 
     # Best-effort dataset-count pre-check; the authoritative atomic
     # reservation happens at registration time in the worker.
@@ -414,6 +481,10 @@ async def analysis_materialize_endpoint(
         analysis_meta["mask_source"] = "layer" if body.mask_dataset_id else "drawn"
         if body.mask_dataset_id is not None:
             analysis_meta["mask_dataset_id"] = str(body.mask_dataset_id)
+    if body.operation == "spatial_join":
+        analysis_meta["join_dataset_id"] = str(body.join_dataset_id)
+        if body.join_fields:
+            analysis_meta["join_fields"] = list(body.join_fields)
     job.user_metadata = {"analysis": analysis_meta}
     # ux(#698): stamp a step so a pending job reads as "queued" rather than
     # being indistinguishable from a broken one. This matters more since #703
@@ -432,11 +503,16 @@ async def analysis_materialize_endpoint(
         # the pre-clip-by-layer code rejects unknown kwargs, and an
         # unconditional None would break EVERY materialize during a rolling
         # deploy instead of only the new feature.
-        extra_kwargs = (
-            {"mask_dataset_id": str(body.mask_dataset_id)}
-            if body.mask_dataset_id is not None
-            else {}
-        )
+        extra_kwargs: dict[str, object] = {}
+        if body.mask_dataset_id is not None:
+            extra_kwargs["mask_dataset_id"] = str(body.mask_dataset_id)
+        # Same rolling-deploy rule for the join params (fix(#953)): a worker
+        # still running pre-spatial-join code rejects unknown kwargs, so they
+        # ride along only when the operation actually uses them.
+        if body.join_dataset_id is not None:
+            extra_kwargs["join_dataset_id"] = str(body.join_dataset_id)
+            if body.join_fields:
+                extra_kwargs["join_fields"] = list(body.join_fields)
         await defer_async_with_tenant(
             get_catalog_port()
             .materialize_analysis_task()

--- a/backend/app/modules/catalog/datasets/api/router_analysis.py
+++ b/backend/app/modules/catalog/datasets/api/router_analysis.py
@@ -34,6 +34,7 @@ from app.platform.analysis_sql import (
     MAX_MASK_LAYER_FEATURES,
     MAX_SOURCE_FEATURES,
     MEASURE_OUTPUT_COLUMNS,
+    NON_GROUPABLE_COLUMN_TYPES,
     render_mask_expr,
     spatial_join_output_columns,
 )
@@ -85,7 +86,6 @@ MAX_ACTIVE_MATERIALIZES_PER_TENANT = 3
 # dissolve GROUP BY on such a column fails the CTAS with an opaque 42883
 # after the queue wait. GDAL maps nested GeoJSON objects to `json`, so
 # real uploads hit this. Rejected at enqueue with the column named.
-_NON_GROUPABLE_TYPES = {"json", "xml"}
 
 # fix(#695): Procrastinate ranks by per-job priority (DESC, default 0), not
 # by queue name — so a 300-second analysis CTAS enqueued first would
@@ -302,7 +302,7 @@ def _validate_intersect_columns(source, overlay) -> None:
     # dies after the queue wait with an error naming a generated alias the user
     # never wrote.
     #
-    # Refused at enqueue instead, which is what _NON_GROUPABLE_TYPES already
+    # Refused at enqueue instead, which is what NON_GROUPABLE_COLUMN_TYPES already
     # does for dissolve's by_field. Refusing rather than silently dropping the
     # column is the same choice the sibling guards above make: an overlay whose
     # output columns depend on which of them happened to be groupable is worse
@@ -315,7 +315,7 @@ def _validate_intersect_columns(source, overlay) -> None:
     ungroupable = sorted(
         (col.get("name"), str(col.get("type") or "").lower())
         for col in (overlay.column_info or [])
-        if col and str(col.get("type") or "").lower() in _NON_GROUPABLE_TYPES
+        if col and str(col.get("type") or "").lower() in NON_GROUPABLE_COLUMN_TYPES
     )
     if ungroupable:
         name, col_type = ungroupable[0]
@@ -395,7 +395,7 @@ def _validate_dissolve_by_field(dataset, by_field: str) -> None:
             detail="by_field conflicts with the generated 'source_count' column",
         )
     by_field_type = str(known_columns[by_field].get("type") or "").lower()
-    if by_field_type in _NON_GROUPABLE_TYPES:
+    if by_field_type in NON_GROUPABLE_COLUMN_TYPES:
         raise HTTPException(
             status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
             detail=(

--- a/backend/app/modules/catalog/datasets/api/router_analysis.py
+++ b/backend/app/modules/catalog/datasets/api/router_analysis.py
@@ -33,6 +33,7 @@ from app.platform.analysis_sql import (
     INTERSECT_OUTPUT_COLUMNS,
     MAX_MASK_LAYER_FEATURES,
     MAX_SOURCE_FEATURES,
+    INTERNAL_ALIAS_PREFIX,
     MEASURE_OUTPUT_COLUMNS,
     NON_GROUPABLE_COLUMN_TYPES,
     render_mask_expr,
@@ -312,6 +313,27 @@ def _validate_intersect_columns(source, overlay) -> None:
     # needs the aggregate to group by the two gids alone and join the overlay's
     # attributes back afterwards, which is a change to this query's shape
     # rather than a guard. Tracked separately.
+    # fix(#1097 review): a carried column may not sit in the alias namespace.
+    # Both layers, because an overlay carries columns from both and the inner
+    # aggregate names them in one select list alongside _gl_src_type; the
+    # overlay's are additionally re-listed inside _mask_pieces beside
+    # _gl_mask_gid and _gl_g. Checked against the PREFIX rather than the three
+    # alias names, so an alias added to that query later is covered without a
+    # second place to update.
+    reserved = sorted(
+        name
+        for name in (_column_names(source) | _column_names(overlay))
+        if name and name.startswith(INTERNAL_ALIAS_PREFIX)
+    )
+    if reserved:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail=(
+                f"Column {reserved[0]!r} uses the {INTERNAL_ALIAS_PREFIX!r} "
+                "prefix, which this operation reserves for its own internal "
+                "columns. Rename it, or choose a different layer."
+            ),
+        )
     ungroupable = sorted(
         (col.get("name"), str(col.get("type") or "").lower())
         for col in (overlay.column_info or [])

--- a/backend/app/modules/catalog/datasets/api/router_analysis.py
+++ b/backend/app/modules/catalog/datasets/api/router_analysis.py
@@ -289,6 +289,45 @@ def _validate_intersect_columns(source, overlay) -> None:
                 "choose a different layer."
             ),
         )
+    # fix(#1097 review): the OVERLAY's columns, and only the overlay's.
+    #
+    # render_intersect_pairs groups by `_src.gid, _mp._mask_gid` plus every
+    # carried overlay column. The source's columns need no grouping — gid is a
+    # real table's primary key, so PostgreSQL licenses them by functional
+    # dependency — but `_mask_pieces` is a CTE with no key, so each overlay
+    # column it carries has to be named in the GROUP BY explicitly. json and
+    # xml have no equality operator, so grouping on one fails the CTAS with
+    # SQLSTATE 42883, and it fails there rather than in the preview: the
+    # preview carries gid and source_gid only, so it succeeds and the operation
+    # dies after the queue wait with an error naming a generated alias the user
+    # never wrote.
+    #
+    # Refused at enqueue instead, which is what _NON_GROUPABLE_TYPES already
+    # does for dissolve's by_field. Refusing rather than silently dropping the
+    # column is the same choice the sibling guards above make: an overlay whose
+    # output columns depend on which of them happened to be groupable is worse
+    # for anyone scripting against the result than one that says no.
+    #
+    # Carrying these through an overlay is a real gap and is worth doing — it
+    # needs the aggregate to group by the two gids alone and join the overlay's
+    # attributes back afterwards, which is a change to this query's shape
+    # rather than a guard. Tracked separately.
+    ungroupable = sorted(
+        (col.get("name"), str(col.get("type") or "").lower())
+        for col in (overlay.column_info or [])
+        if col and str(col.get("type") or "").lower() in _NON_GROUPABLE_TYPES
+    )
+    if ungroupable:
+        name, col_type = ungroupable[0]
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail=(
+                f"The overlay layer's column {name!r} has type {col_type!r}, "
+                "which cannot be grouped, and an overlay carries every overlay "
+                "column onto its output. Choose a different layer, or remove "
+                "that column from it."
+            ),
+        )
 
 
 @router.post("/{dataset_id}/analysis/preview/", response_model=AnalysisPreviewResponse)

--- a/backend/app/modules/catalog/datasets/api/router_analysis.py
+++ b/backend/app/modules/catalog/datasets/api/router_analysis.py
@@ -16,6 +16,7 @@ from app.core.tenancy import is_multi_tenant
 from app.modules.auth.dependencies import get_current_active_user, require_permission
 from app.modules.catalog.authorization import check_dataset_access
 from app.modules.catalog.datasets.domain.schemas import (
+    MASK_OPERATIONS,
     AnalysisMaterializeRequest,
     AnalysisMaterializeResponse,
     AnalysisPreviewRequest,
@@ -139,9 +140,16 @@ _POLYGONAL_TYPES = {"POLYGON", "MULTIPOLYGON"}
 async def _load_mask_dataset(
     db: AsyncSession, mask_dataset_id: uuid.UUID, user: Identity
 ):
-    """Fetch + visibility-check a clip-mask dataset (Rule 1 applies to BOTH
+    """Fetch + visibility-check a mask dataset (Rule 1 applies to BOTH
     datasets of a two-layer operation) and require it to be polygonal —
-    unioning points/lines produces a mask that clips nothing meaningful."""
+    unioning points/lines produces a mask that clips nothing meaningful.
+
+    fix(#955): shared with select_by_location, which takes its selection
+    geometry from the same mask pair. Both ceilings apply there unchanged; the
+    over-limit message still says "to clip with", which reads slightly off for
+    a selection but is wired through error-map.ts and four locales, so it is
+    left alone rather than half-changed.
+    """
     dataset = await _load_vector_dataset(db, mask_dataset_id, user)
     if (dataset.geometry_type or "").upper() not in _POLYGONAL_TYPES:
         raise HTTPException(
@@ -302,11 +310,13 @@ async def _validate_materialize_params(
     Each check has a second, run-time half in the worker, because the queue
     wait sits between the two and the world can move underneath it.
     """
-    if body.operation == "clip" and body.mask_dataset_id is not None:
+    # fix(#955): select_by_location takes the same mask pair clip does, so it
+    # takes the same two checks. Rule 1 applies to BOTH datasets either way.
+    if body.operation in MASK_OPERATIONS and body.mask_dataset_id is not None:
         # Access + polygon checks happen here at enqueue time; the worker
         # re-resolves the table name and re-validates it against _SAFE_TABLE.
         await _load_mask_dataset(db, body.mask_dataset_id, user)
-    elif body.operation == "clip":
+    elif body.operation in MASK_OPERATIONS:
         try:
             render_mask_expr(body.mask or {})
         except ValueError as exc:

--- a/backend/app/modules/catalog/datasets/api/router_analysis.py
+++ b/backend/app/modules/catalog/datasets/api/router_analysis.py
@@ -223,7 +223,35 @@ def _validate_join_fields(source, join_dataset, join_fields: list[str]) -> None:
                 status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
                 detail=f"Unknown join column: {name!r}",
             )
-    _reject_generated_column_collision(source, spatial_join_output_columns(join_fields))
+    generated = spatial_join_output_columns(join_fields)
+    # fix(#1097 review): the generated names must be unique among THEMSELVES
+    # before they are checked against the source. A join layer with an ordinary
+    # column named `count` prefixes to `join_count`, the name this operation
+    # already generates for the match count — so the list holds it twice while
+    # the guard below, which only compares against the SOURCE, sees nothing
+    # wrong. Materialization then failed the CTAS with "column specified more
+    # than once" after the whole queue wait, and the preview was worse: it maps
+    # both values onto one property, so the transferred field silently
+    # overwrote the real match count.
+    #
+    # Written as a duplicate check rather than as "reject the field named
+    # `count`" because the collision is a property of the generated names, not
+    # of that one input: a change to the prefix or to the generated set moves
+    # which field collides, and this keeps holding. The other way a name can
+    # repeat, the same field requested twice, is already rejected by
+    # AnalysisMaterializeRequest and never reaches here.
+    duplicates = sorted({name for name in generated if generated.count(name) > 1})
+    if duplicates:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail=(
+                f"Two transferred columns would both be named {duplicates[0]!r} "
+                "in the result. Choose the field once, and rename it in the join "
+                "layer if its name collides with a column this operation "
+                "generates."
+            ),
+        )
+    _reject_generated_column_collision(source, generated)
 
 
 def _column_names(dataset) -> set[str]:

--- a/backend/app/modules/catalog/datasets/api/router_analysis.py
+++ b/backend/app/modules/catalog/datasets/api/router_analysis.py
@@ -334,6 +334,11 @@ def _validate_intersect_columns(source, overlay) -> None:
                 "columns. Rename it, or choose a different layer."
             ),
         )
+    # fix(#1097 review): SCALAR json/xml only. The snapshot stores an array
+    # column's type as 'ARRAY' with no element type, so json[]/xml[] are
+    # invisible here by construction; the worker's live-schema recheck
+    # (_ungroupable_type_name reads udt_name) is their sole guard, and the
+    # same applies to dissolve's by_field check above.
     ungroupable = sorted(
         (col.get("name"), str(col.get("type") or "").lower())
         for col in (overlay.column_info or [])

--- a/backend/app/modules/catalog/datasets/domain/schemas.py
+++ b/backend/app/modules/catalog/datasets/domain/schemas.py
@@ -903,21 +903,29 @@ class IngestionResult(BaseModel):
 # request validators (fix(#682): a stray mask_dataset_id sent alongside
 # buffer/centroid would otherwise be loaded — and could 404/422 the request
 # or fail the job — and distance's gt/le bounds fire on placeholder values).
+# fix(#955): values are tuples because a param can belong to more than one
+# operation — select_by_location takes its selection geometry from the same
+# `mask`/`mask_dataset_id` pair clip does, rather than a second spelling of the
+# same two fields.
 _ANALYSIS_PARAM_OWNERS = {
-    "distance_meters": "buffer",
-    "mask": "clip",
-    "mask_dataset_id": "clip",
-    "by_field": "dissolve",
-    "join_dataset_id": "spatial_join",
-    "join_fields": "spatial_join",
+    "distance_meters": ("buffer",),
+    "mask": ("clip", "select_by_location"),
+    "mask_dataset_id": ("clip", "select_by_location"),
+    "by_field": ("dissolve",),
+    "join_dataset_id": ("spatial_join",),
+    "join_fields": ("spatial_join",),
 }
+
+# Operations whose geometry comes from a drawn mask or a mask layer, exactly
+# one of the two.
+MASK_OPERATIONS = ("clip", "select_by_location")
 
 
 def _drop_params_for_other_operations(data: Any) -> Any:
     if isinstance(data, dict):
         op = data.get("operation")
         data = {
-            k: v for k, v in data.items() if _ANALYSIS_PARAM_OWNERS.get(k, op) == op
+            k: v for k, v in data.items() if op in _ANALYSIS_PARAM_OWNERS.get(k, (op,))
         }
     return data
 
@@ -932,10 +940,12 @@ def _require_analysis_params(request: Any) -> None:
     """
     if request.operation == "buffer" and request.distance_meters is None:
         raise ValueError("buffer requires distance_meters")
-    if request.operation == "clip" and (request.mask is None) == (
+    if request.operation in MASK_OPERATIONS and (request.mask is None) == (
         request.mask_dataset_id is None
     ):
-        raise ValueError("clip requires exactly one of mask or mask_dataset_id")
+        raise ValueError(
+            f"{request.operation} requires exactly one of mask or mask_dataset_id"
+        )
     if request.operation == "spatial_join":
         if request.join_dataset_id is None:
             raise ValueError("spatial_join requires join_dataset_id")
@@ -951,7 +961,9 @@ class AnalysisPreviewRequest(BaseModel):
     endpoint; per-operation requiredness is enforced by the validator.
     """
 
-    operation: Literal["buffer", "centroid", "clip", "spatial_join", "measure"]
+    operation: Literal[
+        "buffer", "centroid", "clip", "spatial_join", "measure", "select_by_location"
+    ]
     distance_meters: float | None = Field(
         default=None,
         gt=0,
@@ -961,14 +973,16 @@ class AnalysisPreviewRequest(BaseModel):
     mask: dict[str, Any] | None = Field(
         default=None,
         description=(
-            "GeoJSON Polygon or MultiPolygon geometry in EPSG:4326 (clip only)"
+            "GeoJSON Polygon or MultiPolygon geometry in EPSG:4326 "
+            "(clip and select_by_location)"
         ),
     )
     mask_dataset_id: uuid.UUID | None = Field(
         default=None,
         description=(
-            "Polygon dataset whose unioned features form the clip mask "
-            "(clip only; alternative to mask)"
+            "Polygon dataset supplying the mask geometry: the area clipped to, "
+            "or selected against (clip and select_by_location; alternative to "
+            "mask)"
         ),
     )
     join_dataset_id: uuid.UUID | None = Field(
@@ -1016,10 +1030,11 @@ class AnalysisPreviewResponse(BaseModel):
     match_count: int | None = Field(
         default=None,
         description=(
-            "spatial_join only: total intersecting source/join feature PAIRS "
-            "across the whole source, not just the previewed features. Null "
-            "for other operations, and when the count could not be computed "
-            "within the query budget"
+            "Exact total across the WHOLE source, not just the previewed "
+            "features: intersecting source/join feature PAIRS for "
+            "spatial_join, selected source features for select_by_location. "
+            "Null for other operations, and when the count could not be "
+            "computed within the query budget"
         ),
     )
 
@@ -1028,7 +1043,13 @@ class AnalysisMaterializeRequest(BaseModel):
     """Parameters for materializing an analysis result as a new dataset."""
 
     operation: Literal[
-        "buffer", "centroid", "clip", "dissolve", "spatial_join", "measure"
+        "buffer",
+        "centroid",
+        "clip",
+        "dissolve",
+        "spatial_join",
+        "measure",
+        "select_by_location",
     ]
     title: str = Field(min_length=1, max_length=500)
     distance_meters: float | None = Field(
@@ -1040,14 +1061,16 @@ class AnalysisMaterializeRequest(BaseModel):
     mask: dict[str, Any] | None = Field(
         default=None,
         description=(
-            "GeoJSON Polygon or MultiPolygon geometry in EPSG:4326 (clip only)"
+            "GeoJSON Polygon or MultiPolygon geometry in EPSG:4326 "
+            "(clip and select_by_location)"
         ),
     )
     mask_dataset_id: uuid.UUID | None = Field(
         default=None,
         description=(
-            "Polygon dataset whose unioned features form the clip mask "
-            "(clip only; alternative to mask)"
+            "Polygon dataset supplying the mask geometry: the area clipped to, "
+            "or selected against (clip and select_by_location; alternative to "
+            "mask)"
         ),
     )
     by_field: str | None = Field(

--- a/backend/app/modules/catalog/datasets/domain/schemas.py
+++ b/backend/app/modules/catalog/datasets/domain/schemas.py
@@ -951,7 +951,7 @@ class AnalysisPreviewRequest(BaseModel):
     endpoint; per-operation requiredness is enforced by the validator.
     """
 
-    operation: Literal["buffer", "centroid", "clip", "spatial_join"]
+    operation: Literal["buffer", "centroid", "clip", "spatial_join", "measure"]
     distance_meters: float | None = Field(
         default=None,
         gt=0,
@@ -1027,7 +1027,9 @@ class AnalysisPreviewResponse(BaseModel):
 class AnalysisMaterializeRequest(BaseModel):
     """Parameters for materializing an analysis result as a new dataset."""
 
-    operation: Literal["buffer", "centroid", "clip", "dissolve", "spatial_join"]
+    operation: Literal[
+        "buffer", "centroid", "clip", "dissolve", "spatial_join", "measure"
+    ]
     title: str = Field(min_length=1, max_length=500)
     distance_meters: float | None = Field(
         default=None,

--- a/backend/app/modules/catalog/datasets/domain/schemas.py
+++ b/backend/app/modules/catalog/datasets/domain/schemas.py
@@ -1047,10 +1047,15 @@ class AnalysisPreviewResponse(BaseModel):
         default=None,
         description=(
             "Exact total across the WHOLE source, not just the previewed "
-            "features: intersecting source/join feature PAIRS for "
-            "spatial_join, selected source features for select_by_location. "
-            "Null for other operations, and when the count could not be "
-            "computed within the query budget"
+            "features. What it counts is per-operation, so read it against "
+            "the operation you sent rather than as one number: "
+            "select_by_location gives the selected source features and "
+            "intersect gives the output pieces, and for both of those it IS "
+            "the output total; spatial_join gives intersecting source/join "
+            "PAIRS, which is NOT the output total, because the join keeps "
+            "every source row (use source_feature_count for that operation). "
+            "Null for operations that report no such total, and when the "
+            "count could not be computed within the query budget"
         ),
     )
 

--- a/backend/app/modules/catalog/datasets/domain/schemas.py
+++ b/backend/app/modules/catalog/datasets/domain/schemas.py
@@ -993,9 +993,12 @@ class AnalysisPreviewRequest(BaseModel):
     mask_dataset_id: uuid.UUID | None = Field(
         default=None,
         description=(
-            "Polygon dataset supplying the mask geometry: the area clipped to, "
-            "or selected against (clip and select_by_location; alternative to "
-            "mask)"
+            "Polygon dataset supplying the second layer: the area clipped to, "
+            "selected against, or overlaid with. For clip and "
+            "select_by_location it is the alternative to `mask`; for intersect "
+            "it is REQUIRED and `mask` is rejected, because an overlay carries "
+            "the second layer's attributes onto its output and a drawn polygon "
+            "has none."
         ),
     )
     join_dataset_id: uuid.UUID | None = Field(
@@ -1082,9 +1085,12 @@ class AnalysisMaterializeRequest(BaseModel):
     mask_dataset_id: uuid.UUID | None = Field(
         default=None,
         description=(
-            "Polygon dataset supplying the mask geometry: the area clipped to, "
-            "or selected against (clip and select_by_location; alternative to "
-            "mask)"
+            "Polygon dataset supplying the second layer: the area clipped to, "
+            "selected against, or overlaid with. For clip and "
+            "select_by_location it is the alternative to `mask`; for intersect "
+            "it is REQUIRED and `mask` is rejected, because an overlay carries "
+            "the second layer's attributes onto its output and a drawn polygon "
+            "has none."
         ),
     )
     by_field: str | None = Field(

--- a/backend/app/modules/catalog/datasets/domain/schemas.py
+++ b/backend/app/modules/catalog/datasets/domain/schemas.py
@@ -14,6 +14,7 @@ from pydantic import (
 
 from app.core.url_redaction import has_url_credentials
 from app.core.text import normalize_nfc as _nfc
+from app.platform.analysis_sql import MAX_SPATIAL_JOIN_FIELDS
 
 
 _COLUMN_NAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
@@ -907,6 +908,8 @@ _ANALYSIS_PARAM_OWNERS = {
     "mask": "clip",
     "mask_dataset_id": "clip",
     "by_field": "dissolve",
+    "join_dataset_id": "spatial_join",
+    "join_fields": "spatial_join",
 }
 
 
@@ -919,6 +922,28 @@ def _drop_params_for_other_operations(data: Any) -> Any:
     return data
 
 
+def _require_analysis_params(request: Any) -> None:
+    """Per-operation requiredness, shared by preview and materialize.
+
+    The two request models carry the same rules for every operation they have
+    in common, and drifting them apart is how a param ends up required on one
+    endpoint and optional on the other. ``dissolve``'s ``by_field`` is
+    genuinely optional and materialize-only, so it has nothing here.
+    """
+    if request.operation == "buffer" and request.distance_meters is None:
+        raise ValueError("buffer requires distance_meters")
+    if request.operation == "clip" and (request.mask is None) == (
+        request.mask_dataset_id is None
+    ):
+        raise ValueError("clip requires exactly one of mask or mask_dataset_id")
+    if request.operation == "spatial_join":
+        if request.join_dataset_id is None:
+            raise ValueError("spatial_join requires join_dataset_id")
+        fields = request.join_fields or []
+        if len(fields) != len(set(fields)):
+            raise ValueError("join_fields must not repeat a column")
+
+
 class AnalysisPreviewRequest(BaseModel):
     """Parameters for a synchronous analysis preview.
 
@@ -926,7 +951,7 @@ class AnalysisPreviewRequest(BaseModel):
     endpoint; per-operation requiredness is enforced by the validator.
     """
 
-    operation: Literal["buffer", "centroid", "clip"]
+    operation: Literal["buffer", "centroid", "clip", "spatial_join"]
     distance_meters: float | None = Field(
         default=None,
         gt=0,
@@ -946,6 +971,22 @@ class AnalysisPreviewRequest(BaseModel):
             "(clip only; alternative to mask)"
         ),
     )
+    join_dataset_id: uuid.UUID | None = Field(
+        default=None,
+        description=(
+            "Dataset to join against; each source feature gains a count of the "
+            "features from it that intersect (spatial_join only)"
+        ),
+    )
+    join_fields: list[str] | None = Field(
+        default=None,
+        max_length=MAX_SPATIAL_JOIN_FIELDS,
+        description=(
+            "Columns to copy from the intersecting join feature, prefixed "
+            "'join_' in the output. Ties break on the lowest join-layer gid "
+            "(spatial_join only)"
+        ),
+    )
 
     @model_validator(mode="before")
     @classmethod
@@ -954,12 +995,7 @@ class AnalysisPreviewRequest(BaseModel):
 
     @model_validator(mode="after")
     def _require_operation_params(self) -> "AnalysisPreviewRequest":
-        if self.operation == "buffer" and self.distance_meters is None:
-            raise ValueError("buffer requires distance_meters")
-        if self.operation == "clip" and (self.mask is None) == (
-            self.mask_dataset_id is None
-        ):
-            raise ValueError("clip requires exactly one of mask or mask_dataset_id")
+        _require_analysis_params(self)
         return self
 
 
@@ -977,12 +1013,21 @@ class AnalysisPreviewResponse(BaseModel):
             "null when the operation filters rows, e.g. clip)"
         ),
     )
+    match_count: int | None = Field(
+        default=None,
+        description=(
+            "spatial_join only: total intersecting source/join feature PAIRS "
+            "across the whole source, not just the previewed features. Null "
+            "for other operations, and when the count could not be computed "
+            "within the query budget"
+        ),
+    )
 
 
 class AnalysisMaterializeRequest(BaseModel):
     """Parameters for materializing an analysis result as a new dataset."""
 
-    operation: Literal["buffer", "centroid", "clip", "dissolve"]
+    operation: Literal["buffer", "centroid", "clip", "dissolve", "spatial_join"]
     title: str = Field(min_length=1, max_length=500)
     distance_meters: float | None = Field(
         default=None,
@@ -1008,6 +1053,22 @@ class AnalysisMaterializeRequest(BaseModel):
         max_length=63,
         description="Optional group-by column for dissolve",
     )
+    join_dataset_id: uuid.UUID | None = Field(
+        default=None,
+        description=(
+            "Dataset to join against; each source feature gains a count of the "
+            "features from it that intersect (spatial_join only)"
+        ),
+    )
+    join_fields: list[str] | None = Field(
+        default=None,
+        max_length=MAX_SPATIAL_JOIN_FIELDS,
+        description=(
+            "Columns to copy from the intersecting join feature, prefixed "
+            "'join_' in the output. Ties break on the lowest join-layer gid "
+            "(spatial_join only)"
+        ),
+    )
 
     @model_validator(mode="before")
     @classmethod
@@ -1016,12 +1077,7 @@ class AnalysisMaterializeRequest(BaseModel):
 
     @model_validator(mode="after")
     def _require_operation_params(self) -> "AnalysisMaterializeRequest":
-        if self.operation == "buffer" and self.distance_meters is None:
-            raise ValueError("buffer requires distance_meters")
-        if self.operation == "clip" and (self.mask is None) == (
-            self.mask_dataset_id is None
-        ):
-            raise ValueError("clip requires exactly one of mask or mask_dataset_id")
+        _require_analysis_params(self)
         return self
 
 

--- a/backend/app/modules/catalog/datasets/domain/schemas.py
+++ b/backend/app/modules/catalog/datasets/domain/schemas.py
@@ -910,14 +910,16 @@ class IngestionResult(BaseModel):
 _ANALYSIS_PARAM_OWNERS = {
     "distance_meters": ("buffer",),
     "mask": ("clip", "select_by_location"),
-    "mask_dataset_id": ("clip", "select_by_location"),
+    "mask_dataset_id": ("clip", "select_by_location", "intersect"),
     "by_field": ("dissolve",),
     "join_dataset_id": ("spatial_join",),
     "join_fields": ("spatial_join",),
 }
 
 # Operations whose geometry comes from a drawn mask or a mask layer, exactly
-# one of the two.
+# one of the two. fix(#956): intersect is deliberately NOT here — it takes a
+# LAYER only, because a drawn polygon carries no attributes to overlay with,
+# which would make it an expensive clip.
 MASK_OPERATIONS = ("clip", "select_by_location")
 
 
@@ -946,6 +948,11 @@ def _require_analysis_params(request: Any) -> None:
         raise ValueError(
             f"{request.operation} requires exactly one of mask or mask_dataset_id"
         )
+    # fix(#956): layer only, and required. `mask` is not an intersect param, so
+    # _drop_params_for_other_operations has already discarded any drawn one by
+    # the time this runs — this just insists on the layer that replaces it.
+    if request.operation == "intersect" and request.mask_dataset_id is None:
+        raise ValueError("intersect requires mask_dataset_id")
     if request.operation == "spatial_join":
         if request.join_dataset_id is None:
             raise ValueError("spatial_join requires join_dataset_id")
@@ -962,7 +969,13 @@ class AnalysisPreviewRequest(BaseModel):
     """
 
     operation: Literal[
-        "buffer", "centroid", "clip", "spatial_join", "measure", "select_by_location"
+        "buffer",
+        "centroid",
+        "clip",
+        "spatial_join",
+        "measure",
+        "select_by_location",
+        "intersect",
     ]
     distance_meters: float | None = Field(
         default=None,
@@ -1050,6 +1063,7 @@ class AnalysisMaterializeRequest(BaseModel):
         "spatial_join",
         "measure",
         "select_by_location",
+        "intersect",
     ]
     title: str = Field(min_length=1, max_length=500)
     distance_meters: float | None = Field(

--- a/backend/app/modules/catalog/datasets/domain/service_analysis.py
+++ b/backend/app/modules/catalog/datasets/domain/service_analysis.py
@@ -44,7 +44,6 @@ from app.platform.analysis_sql import (
     render_spatial_join_match_count,
     spatial_join_output_columns,
 )
-from app.platform.sandbox.schemas import SandboxError
 from app.platform.sandbox.executor import execute_safe
 from app.platform.sandbox.schemas import SandboxError
 

--- a/backend/app/modules/catalog/datasets/domain/service_analysis.py
+++ b/backend/app/modules/catalog/datasets/domain/service_analysis.py
@@ -34,7 +34,11 @@ from app.platform.analysis_sql import (
     NOT_EMPTY_PREDICATE,
     render_clip_layer_join,
     render_geometry_expr,
+    render_spatial_join,
+    render_spatial_join_match_count,
+    spatial_join_output_columns,
 )
+from app.platform.sandbox.schemas import SandboxError
 from app.platform.sandbox.executor import execute_safe
 from app.platform.sandbox.schemas import SandboxError
 
@@ -140,13 +144,27 @@ def build_preview_sql(
     table_ref: str,
     request: AnalysisPreviewRequest,
     mask_table_ref: str | None = None,
+    join_table_ref: str | None = None,
 ) -> str:
     """Render the preview SELECT for one operation. Pure; unit-testable.
 
-    ``table_ref`` (and ``mask_table_ref`` for layer-sourced clip masks) must
-    come from ``_safe_table_ref`` (logical ``data`` schema; the sandbox
-    executor rewrites it to the tenant schema in multi-tenant).
+    ``table_ref`` (and ``mask_table_ref`` for layer-sourced clip masks,
+    ``join_table_ref`` for spatial joins) must come from ``_safe_table_ref``
+    (logical ``data`` schema; the sandbox executor rewrites it to the tenant
+    schema in multi-tenant).
     """
+    extra_cols = ""
+    extra_joins = ""
+    if join_table_ref is not None:
+        # fix(#953): the join's whole result is columns, so unlike every other
+        # operation the preview MUST carry properties — the geometry it returns
+        # is the source layer unchanged, and without join_count on each feature
+        # the preview would render pixel-identical to the layer already on the
+        # map and show the user nothing.
+        cols, extra_joins = render_spatial_join(
+            join_table_ref, src="_src", join_fields=request.join_fields
+        )
+        extra_cols = f", {cols}"
     if mask_table_ref is not None:
         # fix(#693): layer-sourced clip previews subdivide the mask once and
         # join it per row instead of unioning the whole layer per request;
@@ -182,8 +200,10 @@ def build_preview_sql(
     return (
         f"{cte}SELECT gid,"
         f" ST_AsGeoJSON(_op.geom_out, {_GEOJSON_PRECISION}) AS geometry_json"
+        f"{extra_cols}"
         f" FROM {table_ref} AS _src"
         f" CROSS JOIN LATERAL {lateral} AS _op"
+        f"{extra_joins}"
         f"{filters}"
         f" ORDER BY gid"
     )
@@ -214,6 +234,7 @@ async def run_analysis_preview(
     user_id: uuid.UUID,
     *,
     mask_dataset: Dataset | None = None,
+    join_dataset: Dataset | None = None,
     release_session: bool = False,
 ) -> AnalysisPreviewResponse:
     """Execute a preview operation and assemble a GeoJSON FeatureCollection.
@@ -224,7 +245,9 @@ async def run_analysis_preview(
 
     ``mask_dataset`` (clip only) sources the mask from another dataset's
     unioned geometries; the CALLER owns its visibility check, exactly as it
-    owns the source dataset's.
+    owns the source dataset's. ``join_dataset`` (spatial_join only) is the same
+    contract for the layer being joined against — Rule 1 applies to BOTH
+    datasets of a two-layer operation.
 
     ``release_session`` returns the caller's pooled connection before the
     sandbox query (see below). OPT-IN, because the rollback that releases it
@@ -241,7 +264,17 @@ async def run_analysis_preview(
     mask_table_ref = (
         _safe_table_ref(mask_dataset.table_name) if mask_dataset is not None else None
     )
-    sql = build_preview_sql(table_ref, request, mask_table_ref)
+    join_table_ref = (
+        _safe_table_ref(join_dataset.table_name) if join_dataset is not None else None
+    )
+    sql = build_preview_sql(table_ref, request, mask_table_ref, join_table_ref)
+    # Column names for the properties the join adds, in the order the SELECT
+    # emits them (immediately after gid and the geometry).
+    join_columns = (
+        spatial_join_output_columns(request.join_fields)
+        if join_table_ref is not None
+        else []
+    )
     # fix(#716): read everything off the ORM objects BEFORE releasing the
     # session, then release it. `execute_safe` opens its own connection from the
     # same engine (it needs READ ONLY + SET LOCAL ROLE, which it cannot get on
@@ -285,7 +318,8 @@ async def run_analysis_preview(
         )
     features: list[dict[str, Any]] = []
     bbox: list[float] | None = None
-    for gid, geometry_json in result.rows:
+    for row in result.rows:
+        gid, geometry_json = row[0], row[1]
         if geometry_json is None:
             continue
         geometry = json.loads(geometry_json)
@@ -293,8 +327,10 @@ async def run_analysis_preview(
             # Empty results (e.g. a clip that only grazes a boundary).
             continue
         bbox = _extend_bbox(bbox, geometry.get("coordinates"))
+        properties: dict[str, Any] = {"gid": gid}
+        properties.update(zip(join_columns, row[2:]))
         features.append(
-            {"type": "Feature", "geometry": geometry, "properties": {"gid": gid}}
+            {"type": "Feature", "geometry": geometry, "properties": properties}
         )
     return AnalysisPreviewResponse(
         geojson={"type": "FeatureCollection", "features": features},
@@ -303,8 +339,43 @@ async def run_analysis_preview(
         bbox=bbox,
         # buffer/centroid are 1:1 per feature, so the source count IS the
         # output total and lets clients render "500 of N" on truncation.
+        # spatial_join is 1:1 too — it adds columns and keeps every row.
         # clip filters rows, so its total is unknowable without a second scan.
         source_feature_count=(
             source_feature_count if request.operation != "clip" else None
         ),
+        match_count=(
+            await _resolve_match_count(db, table_ref, join_table_ref, user_id)
+            if join_table_ref is not None
+            else None
+        ),
     )
+
+
+async def _resolve_match_count(
+    db: AsyncSession, table_ref: str, join_table_ref: str, user_id: uuid.UUID
+) -> int | None:
+    """Exact matched-pair total for a spatial join, or None when unavailable.
+
+    Its own statement, because the preview's row cap would otherwise make the
+    number a lie: summing per-row counts across 500 of 12,000 polygons answers
+    a question nobody asked, and nothing on the map says so (fix(#953)).
+
+    Degrades to None rather than failing the preview. It runs second, so it can
+    lose the sandbox's per-user lock to another request that arrived in between,
+    and it scans both layers so it can outrun the statement timeout on inputs
+    the capped geometry preview handles fine. Neither is a reason to throw away
+    a preview that already succeeded — and None is a value this response
+    already uses to mean "not computable", as source_feature_count does for
+    clip.
+    """
+    try:
+        result = await execute_safe(
+            db,
+            render_spatial_join_match_count(table_ref, join_table_ref),
+            row_limit=1,
+            concurrency_key=str(user_id),
+        )
+    except SandboxError:
+        return None
+    return int(result.rows[0][0]) if result.rows else None

--- a/backend/app/modules/catalog/datasets/domain/service_analysis.py
+++ b/backend/app/modules/catalog/datasets/domain/service_analysis.py
@@ -31,9 +31,11 @@ from app.modules.catalog.datasets.domain.schemas import (
     AnalysisPreviewResponse,
 )
 from app.platform.analysis_sql import (
+    MEASURE_OUTPUT_COLUMNS,
     NOT_EMPTY_PREDICATE,
     render_clip_layer_join,
     render_geometry_expr,
+    render_measure_columns,
     render_spatial_join,
     render_spatial_join_match_count,
     spatial_join_output_columns,
@@ -165,6 +167,12 @@ def build_preview_sql(
             join_table_ref, src="_src", join_fields=request.join_fields
         )
         extra_cols = f", {cols}"
+    elif request.operation == "measure":
+        # fix(#954): same reason — the measured value IS the result, and the
+        # geometry comes back unchanged, so the preview has to carry it as a
+        # property or show the user their own layer back.
+        cols, extra_joins = render_measure_columns(src="_src")
+        extra_cols = f", {cols}"
     if mask_table_ref is not None:
         # fix(#693): layer-sourced clip previews subdivide the mask once and
         # join it per row instead of unioning the whole layer per request;
@@ -207,6 +215,23 @@ def build_preview_sql(
         f"{filters}"
         f" ORDER BY gid"
     )
+
+
+def _preview_extra_columns(
+    request: AnalysisPreviewRequest, join_table_ref: str | None
+) -> list[str]:
+    """Property names the preview carries beyond ``gid``, in SELECT order.
+
+    Mirrors the ``extra_cols`` branches in ``build_preview_sql``: the rows come
+    back positional, so the two must agree or properties land under the wrong
+    names. One function per side rather than one shared renderer because the
+    SQL side needs table aliases the caller owns.
+    """
+    if join_table_ref is not None:
+        return spatial_join_output_columns(request.join_fields)
+    if request.operation == "measure":
+        return list(MEASURE_OUTPUT_COLUMNS)
+    return []
 
 
 def _extend_bbox(bbox: list[float] | None, coords: Any) -> list[float] | None:
@@ -268,13 +293,10 @@ async def run_analysis_preview(
         _safe_table_ref(join_dataset.table_name) if join_dataset is not None else None
     )
     sql = build_preview_sql(table_ref, request, mask_table_ref, join_table_ref)
-    # Column names for the properties the join adds, in the order the SELECT
-    # emits them (immediately after gid and the geometry).
-    join_columns = (
-        spatial_join_output_columns(request.join_fields)
-        if join_table_ref is not None
-        else []
-    )
+    # Names of the properties this operation adds, in the order the SELECT
+    # emits them (immediately after gid and the geometry). Must stay in step
+    # with build_preview_sql's extra_cols above — the rows come back positional.
+    extra_columns = _preview_extra_columns(request, join_table_ref)
     # fix(#716): read everything off the ORM objects BEFORE releasing the
     # session, then release it. `execute_safe` opens its own connection from the
     # same engine (it needs READ ONLY + SET LOCAL ROLE, which it cannot get on
@@ -328,7 +350,7 @@ async def run_analysis_preview(
             continue
         bbox = _extend_bbox(bbox, geometry.get("coordinates"))
         properties: dict[str, Any] = {"gid": gid}
-        properties.update(zip(join_columns, row[2:]))
+        properties.update(zip(extra_columns, row[2:]))
         features.append(
             {"type": "Feature", "geometry": geometry, "properties": properties}
         )

--- a/backend/app/modules/catalog/datasets/domain/service_analysis.py
+++ b/backend/app/modules/catalog/datasets/domain/service_analysis.py
@@ -374,7 +374,16 @@ async def run_analysis_preview(
     # fix(#956): intersect's exact total rides its own preview statement as a
     # trailing window column (see build_preview_sql). Read off any row — the
     # window is computed before the cap, so every row carries the true total.
-    inline_match_count: int | None = None
+    #
+    # fix(#1097 review): seeded to 0 for intersect rather than None. The window
+    # column rides ON the rows, so an intersect with no overlapping pairs has
+    # no row to read it off and would leave this None — reporting
+    # `match_count: null`, which the contract reserves for "could not be
+    # computed" (the count timed out). That makes a correct empty answer
+    # indistinguishable from a broken one, and empty is a perfectly ordinary
+    # result for two layers that do not overlap. execute_safe has already
+    # returned by here, so zero rows means zero pairs, and zero is the answer.
+    inline_match_count: int | None = 0 if request.operation == "intersect" else None
     for row in result.rows:
         if request.operation == "intersect":
             inline_match_count = int(row[-1])

--- a/backend/app/modules/catalog/datasets/domain/service_analysis.py
+++ b/backend/app/modules/catalog/datasets/domain/service_analysis.py
@@ -369,6 +369,20 @@ async def run_analysis_preview(
             row_limit=PREVIEW_FEATURE_CAP,
             concurrency_key=str(user_id),
         )
+        # fix(#1097 review): inside the same slot as the geometry query, not
+        # after it. Both open their own sandbox connection, so releasing the
+        # semaphore between them lets a finished preview admit the next caller
+        # while its count is still holding a connection — _MAX_CONCURRENT_
+        # PREVIEWS stops bounding connections and the pool it exists to protect
+        # can be exhausted anyway. The count is the likelier of the two to still
+        # be running: it is uncapped and scans both layers (see the timeout note
+        # on _resolve_match_count), while the geometry query stops at
+        # PREVIEW_FEATURE_CAP rows.
+        resolved_match_count = (
+            await _resolve_match_count(db, count_sql, user_id)
+            if count_sql is not None
+            else None
+        )
     features: list[dict[str, Any]] = []
     bbox: list[float] | None = None
     # fix(#956): intersect's exact total rides its own preview statement as a
@@ -419,9 +433,7 @@ async def run_analysis_preview(
         match_count=(
             inline_match_count
             if request.operation == "intersect"
-            else await _resolve_match_count(db, count_sql, user_id)
-            if count_sql is not None
-            else None
+            else resolved_match_count
         ),
     )
 

--- a/backend/app/modules/catalog/datasets/domain/service_analysis.py
+++ b/backend/app/modules/catalog/datasets/domain/service_analysis.py
@@ -266,9 +266,21 @@ def _json_safe(value: Any) -> Any:
     because it builds properties in SQL (``to_jsonb(t.*)``), where PostgreSQL
     renders bytea as a ``\\x``-prefixed hex string. Encode identically here, so
     the same column reads the same through both endpoints.
+
+    Recursive, because the driver returns CONTAINERS for array columns — a
+    ``bytea[]`` on a registered table comes back as a list of ``bytes``, and a
+    scalar-only check would wave the container through to the same 500
+    (round-14 review). ``to_jsonb`` renders that case as an array of hex
+    strings, so recursing with the same scalar encoding stays byte-identical
+    with the features API. Scalar driver types Pydantic serializes natively
+    (datetime, date, Decimal, UUID) pass through untouched.
     """
     if isinstance(value, (bytes, bytearray, memoryview)):
         return "\\x" + bytes(value).hex()
+    if isinstance(value, (list, tuple)):
+        return [_json_safe(v) for v in value]
+    if isinstance(value, dict):
+        return {k: _json_safe(v) for k, v in value.items()}
     return value
 
 

--- a/backend/app/modules/catalog/datasets/domain/service_analysis.py
+++ b/backend/app/modules/catalog/datasets/domain/service_analysis.py
@@ -31,10 +31,12 @@ from app.modules.catalog.datasets.domain.schemas import (
     AnalysisPreviewResponse,
 )
 from app.platform.analysis_sql import (
+    INTERSECT_SOURCE_GID_COLUMN,
     MEASURE_OUTPUT_COLUMNS,
     NOT_EMPTY_PREDICATE,
     render_clip_layer_join,
     render_geometry_expr,
+    render_intersect_preview,
     render_measure_columns,
     render_select_by_location_count,
     render_select_by_location_where,
@@ -157,6 +159,14 @@ def build_preview_sql(
     (logical ``data`` schema; the sandbox executor rewrites it to the tenant
     schema in multi-tenant).
     """
+    if request.operation == "intersect" and mask_table_ref is not None:
+        # Rendered whole in analysis_sql: an overlay is a JOIN with a GROUP BY,
+        # not a per-row expression, so it shares none of the lateral template
+        # below. See render_intersect_preview for why match_count rides this
+        # statement as a window rather than costing a second overlay.
+        return render_intersect_preview(
+            table_ref, mask_table_ref, geojson_precision=_GEOJSON_PRECISION
+        )
     extra_cols = ""
     extra_joins = ""
     if join_table_ref is not None:
@@ -241,6 +251,8 @@ def _preview_extra_columns(
         return spatial_join_output_columns(request.join_fields)
     if request.operation == "measure":
         return list(MEASURE_OUTPUT_COLUMNS)
+    if request.operation == "intersect":
+        return [INTERSECT_SOURCE_GID_COLUMN]
     return []
 
 
@@ -360,7 +372,13 @@ async def run_analysis_preview(
         )
     features: list[dict[str, Any]] = []
     bbox: list[float] | None = None
+    # fix(#956): intersect's exact total rides its own preview statement as a
+    # trailing window column (see build_preview_sql). Read off any row — the
+    # window is computed before the cap, so every row carries the true total.
+    inline_match_count: int | None = None
     for row in result.rows:
+        if request.operation == "intersect":
+            inline_match_count = int(row[-1])
         gid, geometry_json = row[0], row[1]
         if geometry_json is None:
             continue
@@ -391,7 +409,9 @@ async def run_analysis_preview(
             else None
         ),
         match_count=(
-            await _resolve_match_count(db, count_sql, user_id)
+            inline_match_count
+            if request.operation == "intersect"
+            else await _resolve_match_count(db, count_sql, user_id)
             if count_sql is not None
             else None
         ),
@@ -400,7 +420,7 @@ async def run_analysis_preview(
 
 # Operations that drop source rows, so the source's own feature count says
 # nothing about how many features the result has.
-_ROW_FILTERING_OPERATIONS = ("clip", "select_by_location")
+_ROW_FILTERING_OPERATIONS = ("clip", "select_by_location", "intersect")
 
 
 async def _resolve_match_count(

--- a/backend/app/modules/catalog/datasets/domain/service_analysis.py
+++ b/backend/app/modules/catalog/datasets/domain/service_analysis.py
@@ -34,6 +34,7 @@ from app.platform.analysis_sql import (
     INTERSECT_SOURCE_GID_COLUMN,
     MEASURE_OUTPUT_COLUMNS,
     NOT_EMPTY_PREDICATE,
+    linearized,
     render_clip_layer_join,
     render_geometry_expr,
     render_intersect_preview,
@@ -190,7 +191,7 @@ def build_preview_sql(
         # identity lateral keeps the query shape (and NOT_EMPTY_PREDICATE)
         # common with every other branch.
         cte = ""
-        lateral = "(SELECT geom_4326 AS geom_out OFFSET 0)"
+        lateral = f"(SELECT {linearized('geom_4326')} AS geom_out OFFSET 0)"
         where = render_select_by_location_where(mask_table_ref, src="_src")
     elif mask_table_ref is not None:
         # fix(#693): layer-sourced clip previews subdivide the mask once and
@@ -253,6 +254,22 @@ def _preview_extra_columns(
     if request.operation == "intersect":
         return [INTERSECT_SOURCE_GID_COLUMN]
     return []
+
+
+def _json_safe(value: Any) -> Any:
+    """Make one transferred property value JSON-serializable.
+
+    fix(#1097 review): a spatial join can transfer a ``bytea`` column, and the
+    sandbox hands its value back as raw ``bytes``, which Pydantic's JSON
+    serializer treats as UTF-8 and raises on for arbitrary byte sequences — a
+    valid preview would 500. The features browse API never has this problem
+    because it builds properties in SQL (``to_jsonb(t.*)``), where PostgreSQL
+    renders bytea as a ``\\x``-prefixed hex string. Encode identically here, so
+    the same column reads the same through both endpoints.
+    """
+    if isinstance(value, (bytes, bytearray, memoryview)):
+        return "\\x" + bytes(value).hex()
+    return value
 
 
 def _extend_bbox(bbox: list[float] | None, coords: Any) -> list[float] | None:
@@ -410,7 +427,9 @@ async def run_analysis_preview(
             continue
         bbox = _extend_bbox(bbox, geometry.get("coordinates"))
         properties: dict[str, Any] = {"gid": gid}
-        properties.update(zip(extra_columns, row[2:]))
+        properties.update(
+            (name, _json_safe(value)) for name, value in zip(extra_columns, row[2:])
+        )
         features.append(
             {"type": "Feature", "geometry": geometry, "properties": properties}
         )

--- a/backend/app/modules/catalog/datasets/domain/service_analysis.py
+++ b/backend/app/modules/catalog/datasets/domain/service_analysis.py
@@ -36,6 +36,8 @@ from app.platform.analysis_sql import (
     render_clip_layer_join,
     render_geometry_expr,
     render_measure_columns,
+    render_select_by_location_count,
+    render_select_by_location_where,
     render_spatial_join,
     render_spatial_join_match_count,
     spatial_join_output_columns,
@@ -173,7 +175,15 @@ def build_preview_sql(
         # property or show the user their own layer back.
         cols, extra_joins = render_measure_columns(src="_src")
         extra_cols = f", {cols}"
-    if mask_table_ref is not None:
+    if mask_table_ref is not None and request.operation == "select_by_location":
+        # fix(#955): a selection keeps whole geometries, so there is no
+        # intersection to render and the row filter IS the operation. The
+        # identity lateral keeps the query shape (and NOT_EMPTY_PREDICATE)
+        # common with every other branch.
+        cte = ""
+        lateral = "(SELECT geom_4326 AS geom_out OFFSET 0)"
+        where = render_select_by_location_where(mask_table_ref, src="_src")
+    elif mask_table_ref is not None:
         # fix(#693): layer-sourced clip previews subdivide the mask once and
         # join it per row instead of unioning the whole layer per request;
         # the union CTE remains the materialize shape (see
@@ -293,6 +303,16 @@ async def run_analysis_preview(
         _safe_table_ref(join_dataset.table_name) if join_dataset is not None else None
     )
     sql = build_preview_sql(table_ref, request, mask_table_ref, join_table_ref)
+    # The uncapped total that goes beside the capped preview, or None when the
+    # operation has no such number. Rendered here, with the table refs already
+    # in hand, and run after the geometry query below.
+    count_sql: str | None = None
+    if join_table_ref is not None:
+        count_sql = render_spatial_join_match_count(table_ref, join_table_ref)
+    elif request.operation == "select_by_location":
+        count_sql = render_select_by_location_count(
+            table_ref, mask_table_ref=mask_table_ref, mask=request.mask
+        )
     # Names of the properties this operation adds, in the order the SELECT
     # emits them (immediately after gid and the geometry). Must stay in step
     # with build_preview_sql's extra_cols above — the rows come back positional.
@@ -362,26 +382,38 @@ async def run_analysis_preview(
         # buffer/centroid are 1:1 per feature, so the source count IS the
         # output total and lets clients render "500 of N" on truncation.
         # spatial_join is 1:1 too — it adds columns and keeps every row.
-        # clip filters rows, so its total is unknowable without a second scan.
+        # clip and select_by_location filter rows, so their totals are
+        # unknowable from the source count. select_by_location answers the same
+        # question exactly, through match_count below.
         source_feature_count=(
-            source_feature_count if request.operation != "clip" else None
+            source_feature_count
+            if request.operation not in _ROW_FILTERING_OPERATIONS
+            else None
         ),
         match_count=(
-            await _resolve_match_count(db, table_ref, join_table_ref, user_id)
-            if join_table_ref is not None
+            await _resolve_match_count(db, count_sql, user_id)
+            if count_sql is not None
             else None
         ),
     )
 
 
+# Operations that drop source rows, so the source's own feature count says
+# nothing about how many features the result has.
+_ROW_FILTERING_OPERATIONS = ("clip", "select_by_location")
+
+
 async def _resolve_match_count(
-    db: AsyncSession, table_ref: str, join_table_ref: str, user_id: uuid.UUID
+    db: AsyncSession, count_sql: str, user_id: uuid.UUID
 ) -> int | None:
-    """Exact matched-pair total for a spatial join, or None when unavailable.
+    """Exact total for an operation whose result the preview cap would mislead
+    about, or None when it could not be computed.
 
     Its own statement, because the preview's row cap would otherwise make the
     number a lie: summing per-row counts across 500 of 12,000 polygons answers
     a question nobody asked, and nothing on the map says so (fix(#953)).
+    fix(#955) reuses it for the selected-record total, which has the same
+    shape — one uncapped aggregate beside a capped geometry preview.
 
     Degrades to None rather than failing the preview. It runs second, so it can
     lose the sandbox's per-user lock to another request that arrived in between,
@@ -394,7 +426,7 @@ async def _resolve_match_count(
     try:
         result = await execute_safe(
             db,
-            render_spatial_join_match_count(table_ref, join_table_ref),
+            count_sql,
             row_limit=1,
             concurrency_key=str(user_id),
         )

--- a/backend/app/platform/analysis_sql.py
+++ b/backend/app/platform/analysis_sql.py
@@ -22,6 +22,7 @@ TopologyException, with no user-side workaround.
 from __future__ import annotations
 
 import math
+import re
 from typing import Any
 
 import shapely
@@ -47,9 +48,15 @@ MAX_MASK_LAYER_FEATURES = 1_000
 # 422) and again in the worker right before the CTAS — the queue wait can be
 # long enough for a dataset to be re-uploaded past its cap (fix(#701
 # review)).
+# fix(#953): spatial_join probes the join layer once per source row, so its
+# cost is source rows x per-row index lookup rather than buffer's flat per-row
+# expression. 250k matches dissolve rather than buffer's 500k for that reason.
+# Note the router reads this with .get() and skips the gate when the key is
+# absent, so an operation missing here has NO ceiling, not a default one.
 MAX_SOURCE_FEATURES = {
     "dissolve": 250_000,
     "buffer": 500_000,
+    "spatial_join": 250_000,
 }
 
 _CLIP_MASK_TYPES = ("Polygon", "MultiPolygon")
@@ -576,6 +583,139 @@ def render_clip_layer_join(mask_table_ref: str, *, src: str) -> tuple[str, str, 
     return cte, lateral, where
 
 
+# fix(#953): the columns a spatial join adds to the source row.
+SPATIAL_JOIN_COUNT_COLUMN = "join_count"
+SPATIAL_JOIN_FIELD_PREFIX = "join_"
+
+# Transferred fields are capped because each one widens every output row and
+# the CTAS has a fixed time budget. Ten is well past the "which district is
+# this in" case the operation exists for.
+MAX_SPATIAL_JOIN_FIELDS = 10
+
+# Same rule dissolve applies to by_field (_validate_dissolve_by_field): a
+# user-selected column name must be identifier-shaped. That is what lets the
+# rendering below quote with plain double quotes — the pattern admits no quote
+# and no colon, so there is nothing for SQLAlchemy's text() bind-parameter
+# parser or for an identifier escape to get wrong. Cost of the rule: a column
+# named "Área" cannot be transferred, exactly as it cannot be dissolved on
+# today. Source columns are unaffected; they ride the carry-column path, which
+# quotes properly and carries every name (fix(#763)).
+_SPATIAL_JOIN_IDENT = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_]*$")
+
+
+def spatial_join_output_columns(join_fields: list[str] | None) -> list[str]:
+    """Names of the columns a spatial join generates, in output order.
+
+    Callers use this to reject a source dataset that already has a column of
+    the same name: the CTAS would otherwise fail with "column specified more
+    than once" after the queue wait, the same trap ``by_field`` hits on
+    dissolve's generated ``source_count``.
+    """
+    return [SPATIAL_JOIN_COUNT_COLUMN] + [
+        f"{SPATIAL_JOIN_FIELD_PREFIX}{name}" for name in (join_fields or [])
+    ]
+
+
+def render_spatial_join(
+    join_table_ref: str,
+    *,
+    src: str,
+    join_fields: list[str] | None = None,
+) -> tuple[str, str]:
+    """Spatial join against another LAYER (fix(#953)); preview AND materialize.
+
+    Returns ``(select_columns, join_clauses)`` for a source table aliased
+    ``src``. The geometry is NOT touched — a spatial join adds columns, so the
+    output geometry is the source feature verbatim (see ``render_geometry_expr``
+    for why it is not even ST_MakeValid'd).
+
+    Strictly 1:1. Two laterals, because the two halves want opposite things:
+
+    - The count lateral aggregates EVERY match, so it needs no tie-break and
+      always returns exactly one row (``CROSS JOIN``).
+    - The field lateral takes exactly one match under a stated tie-break —
+      **lowest join-layer gid** — via ``ORDER BY _j.gid LIMIT 1``. Without it a
+      point inside two overlapping polygons emits two rows for one source
+      feature, and materialize then dies on ``ADD PRIMARY KEY (gid)`` with a
+      constraint error rather than anything a user could act on. ``LEFT JOIN``
+      so a source row matching nothing keeps its row with NULL fields instead
+      of vanishing; dropping it would break the 1:1 property that lets
+      ``source_feature_count`` mean anything.
+
+    Deterministic beats cartographically ideal here: smallest-containing-polygon
+    would pick the city over the county for nested boundaries, but it costs an
+    ST_Area per matched pair and nothing in the issue asks for it.
+
+    The match predicate keeps the raw ``&&`` term on the bare columns so the
+    GIST index stays usable, then re-tests with ST_Intersects over made-valid
+    geometries — the same split ``render_geometry_expr`` uses for clip. Both
+    sides are made valid: one invalid ring in EITHER layer would otherwise
+    abort the whole statement with a GEOS TopologyException.
+
+    The explicit ``IS NOT NULL`` term is redundant and deliberate: ``&&``
+    against a NULL yields NULL, so an ungeometried join row already fails the
+    WHERE and cannot reach a count. Removing it changes no result (verified by
+    mutation). It stays because an arbitrary join layer IS partly ungeometried
+    — #700 made analysis OUTPUTS NULL-free, not arbitrary uploads — and the
+    next person to edit this predicate should not have to re-derive
+    three-valued logic to convince themselves those rows are handled.
+    """
+    fields = list(join_fields or [])
+    if len(fields) != len(set(fields)):
+        raise ValueError("join_fields contains duplicates")
+    if len(fields) > MAX_SPATIAL_JOIN_FIELDS:
+        raise ValueError(
+            f"At most {MAX_SPATIAL_JOIN_FIELDS} join fields may be transferred"
+        )
+    for name in fields:
+        if not _SPATIAL_JOIN_IDENT.match(name):
+            raise ValueError(f"Invalid join field name: {name!r}")
+
+    match = (
+        f"_j.geom_4326 IS NOT NULL"
+        f" AND _j.geom_4326 && {src}.geom_4326"
+        f" AND ST_Intersects("
+        f"ST_MakeValid(_j.geom_4326), ST_MakeValid({src}.geom_4326))"
+    )
+    columns = f"_jc.{SPATIAL_JOIN_COUNT_COLUMN}"
+    joins = (
+        f" CROSS JOIN LATERAL ("
+        f"SELECT count(*)::integer AS {SPATIAL_JOIN_COUNT_COLUMN}"
+        f" FROM {join_table_ref} AS _j WHERE {match}) AS _jc"
+    )
+    if fields:
+        picked = ", ".join(f'_j."{name}"' for name in fields)
+        joins += (
+            f" LEFT JOIN LATERAL (SELECT {picked}"
+            f" FROM {join_table_ref} AS _j WHERE {match}"
+            f" ORDER BY _j.gid LIMIT 1) AS _jf ON TRUE"
+        )
+        for name in fields:
+            columns += f', _jf."{name}" AS "{SPATIAL_JOIN_FIELD_PREFIX}{name}"'
+    return columns, joins
+
+
+def render_spatial_join_match_count(src_table_ref: str, join_table_ref: str) -> str:
+    """Count matched PAIRS across the WHOLE source (fix(#953)).
+
+    The geometry preview is capped at ``PREVIEW_FEATURE_CAP`` rows, so summing
+    its per-row counts would answer "how many points are in these 500 polygons"
+    while the map says nothing about the cap. That number is worse than none:
+    it looks like the answer. This runs as its own statement, bounded by the
+    sandbox statement timeout rather than by a row cap, since it returns one
+    row however large the inputs are.
+    """
+    return (
+        f"SELECT count(*)::bigint AS match_count"
+        f" FROM {src_table_ref} AS _src"
+        f" JOIN {join_table_ref} AS _j"
+        f" ON _j.geom_4326 && _src.geom_4326"
+        f" AND ST_Intersects("
+        f"ST_MakeValid(_j.geom_4326), ST_MakeValid(_src.geom_4326))"
+        f" WHERE _src.geom_4326 IS NOT NULL AND _j.geom_4326 IS NOT NULL"
+    )
+
+
 def render_mask_expr(mask: dict[str, Any]) -> str:
     """Render a validated clip mask as a PostGIS geometry expression.
 
@@ -643,6 +783,16 @@ def render_geometry_expr(
         return render_geodesic_buffer("ST_MakeValid(geom_4326)", distance), ""
     if operation == "centroid":
         return "ST_Centroid(ST_MakeValid(geom_4326))", ""
+    if operation == "spatial_join":
+        # fix(#953): a spatial join adds columns; the geometry is the source
+        # feature verbatim. Deliberately NOT ST_MakeValid'd, unlike every other
+        # operation here — those all transform the geometry anyway, so
+        # repairing the input first is free. Here the output IS the input, and
+        # silently returning a repaired copy would hand back a geometry the
+        # user never asked to change. Validity still gets handled where it
+        # actually matters, inside the join predicate (render_spatial_join).
+        # The join columns themselves come from render_spatial_join.
+        return "geom_4326", ""
     if operation == "clip":
         mask_expr = render_mask_expr(mask or {})
         # A clip that only grazes a boundary intersects at a lower dimension

--- a/backend/app/platform/analysis_sql.py
+++ b/backend/app/platform/analysis_sql.py
@@ -671,14 +671,35 @@ def render_spatial_join(
         if not _SPATIAL_JOIN_IDENT.match(name):
             raise ValueError(f"Invalid join field name: {name!r}")
 
+    # fix(#953): the JOIN side is tested RAW, deliberately. The module docstring's
+    # ST_MakeValid rule exists for OVERLAY operations — measured here, PostGIS
+    # 3.6 raises from ST_Intersection over a self-intersecting bowtie but
+    # ST_Intersects over the same geometry returns an answer, in either argument
+    # position, and the same answer the repaired geometry gives. Wrapping it
+    # costs a repair per CANDIDATE ROW, which the source-side hoist above cannot
+    # amortise because _j differs every row: on 32,186 meteorite points against
+    # 242 Natural Earth country polygons that was 33.68s versus 1.98s raw, both
+    # returning 30,712 pairs. Prevalidating the join layer in a MATERIALIZED CTE
+    # was tried and is worse — it wins nothing in that direction (5.22s) and
+    # loses the GIST index in the other, taking 0.21s to 12.88s.
     match = (
         f"_j.geom_4326 IS NOT NULL"
         f" AND _j.geom_4326 && {src}.geom_4326"
-        f" AND ST_Intersects("
-        f"ST_MakeValid(_j.geom_4326), ST_MakeValid({src}.geom_4326))"
+        f" AND ST_Intersects(_j.geom_4326, _sv.g)"
     )
     columns = f"_jc.{SPATIAL_JOIN_COUNT_COLUMN}"
     joins = (
+        # fix(#953): the source geometry is made valid ONCE PER SOURCE ROW here,
+        # not inside the predicate below. Inlined, it is re-evaluated per
+        # CANDIDATE PAIR — the same trap fix(#700) documents for the preview's
+        # geometry expression, and the OFFSET 0 fence against subquery pull-up
+        # is the same remedy. Measured on real data (242 Natural Earth country
+        # polygons x 32,186 meteorite points): inlined 28.36s, hoisted 0.20s,
+        # both returning 30,712 matches. The inlined form blew the sandbox's
+        # 10s statement timeout, so the preview 422'd on a pairing a user would
+        # obviously try.
+        f" CROSS JOIN LATERAL (SELECT ST_MakeValid({src}.geom_4326) AS g"
+        f" OFFSET 0) AS _sv"
         f" CROSS JOIN LATERAL ("
         f"SELECT count(*)::integer AS {SPATIAL_JOIN_COUNT_COLUMN}"
         f" FROM {join_table_ref} AS _j WHERE {match}) AS _jc"
@@ -704,15 +725,20 @@ def render_spatial_join_match_count(src_table_ref: str, join_table_ref: str) -> 
     it looks like the answer. This runs as its own statement, bounded by the
     sandbox statement timeout rather than by a row cap, since it returns one
     row however large the inputs are.
+
+    Built from ``render_spatial_join`` rather than from a second hand-written
+    predicate: a total that disagrees with the per-feature counts on the map is
+    the one failure mode this field cannot afford, and one renderer is what
+    makes disagreement impossible. It also inherits the per-source-row
+    ST_MakeValid hoist, without which this statement has the same 100x+
+    blow-up the per-row counts did.
     """
+    _, joins = render_spatial_join(join_table_ref, src="_src")
     return (
-        f"SELECT count(*)::bigint AS match_count"
-        f" FROM {src_table_ref} AS _src"
-        f" JOIN {join_table_ref} AS _j"
-        f" ON _j.geom_4326 && _src.geom_4326"
-        f" AND ST_Intersects("
-        f"ST_MakeValid(_j.geom_4326), ST_MakeValid(_src.geom_4326))"
-        f" WHERE _src.geom_4326 IS NOT NULL AND _j.geom_4326 IS NOT NULL"
+        f"SELECT COALESCE(sum(_jc.{SPATIAL_JOIN_COUNT_COLUMN}), 0)::bigint"
+        f" AS match_count"
+        f" FROM {src_table_ref} AS _src{joins}"
+        f" WHERE _src.geom_4326 IS NOT NULL"
     )
 
 

--- a/backend/app/platform/analysis_sql.py
+++ b/backend/app/platform/analysis_sql.py
@@ -667,6 +667,39 @@ INTERNAL_ALIAS_PREFIX = "_gl_"
 NON_GROUPABLE_COLUMN_TYPES = frozenset({"json", "xml"})
 
 
+def linearized(column: str) -> str:
+    """Wrap a geometry read so curved types never reach curve-intolerant SQL.
+
+    fix(#1097 review): WFS sources can store CURVED geometries — GeoServer's
+    MultiSurface/CompoundCurve layers ingest as-is, because ingest classifies
+    the dataset by the closest concrete linear type (metadata.py's
+    _ABSTRACT_TO_CONCRETE_GEOMETRY_TYPE) without touching the stored binary.
+    Three families of SQL these operations rely on then RAISE on such a row
+    (each verified against PostGIS 3.6): ``::geography`` ("Geography type does
+    not support MultiSurface"), ``ST_MakeValid`` ("unsupported geometry type"),
+    and ``ST_AsGeoJSON`` ("geometry type not supported" — GeoJSON has no
+    curves). ``ST_CurveToLine`` densifies arcs into the linear equivalent and
+    is an exact no-op on already-linear input, so every geometry read that
+    feeds one of those functions — or that passes through into preview GeoJSON
+    or a CTAS output table — goes through this wrapper.
+
+    This is deliberately NOT a repair (contrast ST_MakeValid): the catalog
+    already promises the linear type for these datasets, so the linearized
+    form is the declared shape, not a changed one.
+
+    WHERE predicates stay on the BARE column: ``&&`` (a bbox operator),
+    ``ST_Intersects``, ``ST_Dimension`` and ``ST_IsEmpty`` all accept curves
+    directly (verified), and wrapping the column there would defeat the GIST
+    index the predicates are shaped around.
+
+    These wraps are the analysis-scoped half of a wider class — tiles,
+    feature reads, and the pre-existing operations hit the same raises on
+    main. #1104 tracks normalizing ``geom_4326`` at ingest, after which this
+    helper becomes removable.
+    """
+    return f"ST_CurveToLine({column})"
+
+
 def render_intersect_pairs(
     src_table_ref: str,
     mask_table_ref: str,
@@ -727,7 +760,7 @@ def render_intersect_pairs(
         f"SELECT _o.gid AS _gl_mask_gid{mask_pick},"
         f" ST_Subdivide(_o._gl_g, {MASK_SUBDIVIDE_MAX_VERTICES}) AS geom"
         f" FROM (SELECT gid{mask_pick},"
-        f" ST_CollectionExtract(ST_MakeValid(geom_4326), 3) AS _gl_g"
+        f" ST_CollectionExtract(ST_MakeValid({linearized('geom_4326')}), 3) AS _gl_g"
         f" FROM {mask_table_ref} WHERE geom_4326 IS NOT NULL OFFSET 0) AS _o"
         f" WHERE NOT ST_IsEmpty(_o._gl_g))"
         f" SELECT (row_number() OVER ())::integer AS gid,"
@@ -735,13 +768,18 @@ def render_intersect_pairs(
         f" CASE WHEN _p._gl_src_type = 'LINESTRING'"
         f" THEN ST_LineMerge(_p.geom) ELSE _p.geom END AS geom"
         f" FROM (SELECT _src.gid AS {INTERSECT_SOURCE_GID_COLUMN},"
-        f" GeometryType(_src.geom_4326) AS _gl_src_type"
+        # linearized: GeometryType of a curved source reads COMPOUNDCURVE,
+        # which would silently skip the LINESTRING ST_LineMerge branch above.
+        # ST_Dimension below stays raw — it accepts curves and answers the
+        # same number either way.
+        f" GeometryType({linearized('_src.geom_4326')}) AS _gl_src_type"
         f"{src_sel}{mask_sel},"
         f" ST_Union(ST_CollectionExtract("
         f"ST_Intersection(_sv.g, _mp.geom),"
         f" ST_Dimension(_src.geom_4326) + 1)) AS geom"
         f" FROM {src_table_ref} AS _src"
-        f" CROSS JOIN LATERAL (SELECT ST_MakeValid(_src.geom_4326) AS g"
+        f" CROSS JOIN LATERAL (SELECT"
+        f" ST_MakeValid({linearized('_src.geom_4326')}) AS g"
         f" OFFSET 0) AS _sv"
         f" JOIN _mask_pieces AS _mp"
         f" ON _mp.geom && _src.geom_4326"
@@ -900,7 +938,8 @@ def render_measure_columns(*, src: str = "") -> tuple[str, str]:
     """
     prefix = f"{src}." if src else ""
     join = (
-        f" CROSS JOIN LATERAL (SELECT {prefix}geom_4326::geography AS g"
+        f" CROSS JOIN LATERAL"
+        f" (SELECT {linearized(f'{prefix}geom_4326')}::geography AS g"
         f" OFFSET 0) AS _mg"
     )
     columns = (
@@ -1052,7 +1091,8 @@ def render_spatial_join(
         # both returning 30,712 matches. The inlined form blew the sandbox's
         # 10s statement timeout, so the preview 422'd on a pairing a user would
         # obviously try.
-        f" CROSS JOIN LATERAL (SELECT ST_MakeValid({src}.geom_4326) AS g"
+        f" CROSS JOIN LATERAL"
+        f" (SELECT ST_MakeValid({linearized(f'{src}.geom_4326')}) AS g"
         f" OFFSET 0) AS _sv"
         f" CROSS JOIN LATERAL ("
         f"SELECT count(*)::integer AS {SPATIAL_JOIN_COUNT_COLUMN}"
@@ -1166,19 +1206,21 @@ def render_geometry_expr(
     if operation == "measure":
         # fix(#954): like spatial_join, measure adds columns and leaves the
         # geometry alone — see the spatial_join note below on why the output is
-        # NOT ST_MakeValid'd. The measured columns come from
-        # render_measure_columns.
-        return "geom_4326", ""
+        # NOT ST_MakeValid'd (linearized() explains why it IS linearized). The
+        # measured columns come from render_measure_columns.
+        return linearized("geom_4326"), ""
     if operation == "spatial_join":
         # fix(#953): a spatial join adds columns; the geometry is the source
-        # feature verbatim. Deliberately NOT ST_MakeValid'd, unlike every other
-        # operation here — those all transform the geometry anyway, so
+        # feature as stored. Deliberately NOT ST_MakeValid'd, unlike every
+        # other operation here — those all transform the geometry anyway, so
         # repairing the input first is free. Here the output IS the input, and
         # silently returning a repaired copy would hand back a geometry the
         # user never asked to change. Validity still gets handled where it
         # actually matters, inside the join predicate (render_spatial_join).
+        # Linearization is not that kind of change — a curved pass-through
+        # cannot be serialized to GeoJSON at all (see linearized()).
         # The join columns themselves come from render_spatial_join.
-        return "geom_4326", ""
+        return linearized("geom_4326"), ""
     if operation == "select_by_location":
         # fix(#955): the drawn-mask half of select-by-location. The geometry is
         # the source feature verbatim (like spatial_join/measure above, and NOT
@@ -1195,7 +1237,7 @@ def render_geometry_expr(
         # render_select_by_location_where).
         mask_expr = render_mask_expr(mask or {})
         return (
-            "geom_4326",
+            linearized("geom_4326"),
             f" WHERE geom_4326 && {mask_expr}"
             f" AND ST_Intersects(geom_4326, {mask_expr})",
         )

--- a/backend/app/platform/analysis_sql.py
+++ b/backend/app/platform/analysis_sql.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 
 import math
 import re
+from collections.abc import Sequence
 from typing import Any
 
 import shapely
@@ -42,8 +43,11 @@ MAX_MASK_LAYER_FEATURES = 1_000
 # fix(#694): per-operation source-size ceilings.
 # dissolve: ST_Union memory grows with input; ~1M polygons OOM-kills a 2 GB
 # db container, taking every connection with it — 250k keeps 4x headroom.
-# buffer: the only output-amplifying operation, and vector datasets carry no
-# byte quota, so bound the amplification source instead.
+# buffer: an output-amplifying operation, and vector datasets carry no byte
+# quota, so bound the amplification source instead. (fix(#956): buffer was
+# described here as the ONLY amplifying operation. Intersect amplifies too,
+# and along a different axis — buffer grows each geometry, intersect
+# multiplies ROWS.)
 # Enforced twice with LIMIT-bounded live counts: at enqueue (router, fast
 # 422) and again in the worker right before the CTAS — the queue wait can be
 # long enough for a dataset to be re-uploaded past its cap (fix(#701
@@ -62,12 +66,45 @@ MAX_MASK_LAYER_FEATURES = 1_000
 # into a second layer per source row — so it takes the same 250k. Note clip is
 # deliberately absent and therefore uncapped: its mask layer is what is bounded
 # (MAX_MASK_LAYER_FEATURES), not its source.
+# fix(#956): intersect is the only operation whose OUTPUT ROW COUNT is not
+# bounded by its source count, so its ceiling was measured rather than guessed.
+# Benchmarked against a 972-polygon / 249,804-vertex mask (the same yardstick
+# render_clip_layer_join's docstring uses, reproduced synthetically), varying
+# how many mask features each source overlaps:
+#
+#   sources   overlap   output rows      CTAS      output size
+#     1,000       4x          4,000     0.26s          3.6 MB
+#    10,000       4x         40,000      1.4s           35 MB
+#    50,000       4x        200,000     12.4s          174 MB
+#   150,000       4x        600,000     22.2s          521 MB
+#    10,000      58x        577,453     47.8s        1,235 MB
+#    10,000     145x              —      7.2s   ERROR: temp_file_limit (4 GB)
+#
+# The source count is NOT the binding constraint; the overlap factor is. At
+# 10k sources and heavy overlap the output already passes half of
+# MAX_OUTPUT_BYTES, and the 4326 rewrite roughly doubles the payload again, so
+# _enforce_output_size is what actually catches an amplifying run — no source
+# ceiling could. Extreme overlap dies earlier still, on PostgreSQL's own
+# temp_file_limit.
+#
+# 100k is therefore sized on the BENIGN case staying comfortably inside both
+# budgets (~400k rows, ~350 MB, ~15s, roughly 700 MB after the rewrite), while
+# anything pathological hits the 300s MATERIALIZE_TIMEOUT or the output check
+# instead of the box's memory. Half of dissolve's 250k because each source row
+# here does more work AND emits more than one output row.
+#
+# The obvious next suggestion is to lower this until it catches the 58x row.
+# Don't: no source ceiling separates those two runs, so the only value that
+# rejects the 47.8s job also rejects the benign 150k one that finishes in 22s.
+# That trades a cheap early-out for a false refusal. Leave the amplifying case
+# to _enforce_output_size, which measures the thing that actually varies.
 MAX_SOURCE_FEATURES = {
     "dissolve": 250_000,
     "buffer": 500_000,
     "spatial_join": 250_000,
     "measure": 1_000_000,
     "select_by_location": 250_000,
+    "intersect": 100_000,
 }
 
 _CLIP_MASK_TYPES = ("Polygon", "MultiPolygon")
@@ -592,6 +629,132 @@ def render_clip_layer_join(mask_table_ref: str, *, src: str) -> tuple[str, str, 
         f" WHERE geom_4326 && {src}.geom_4326)"
     )
     return cte, lateral, where
+
+
+# fix(#956): overlay output rows do not correspond 1:1 to source rows, so the
+# source gid cannot be the output key — the CTAS takes a generated one, like
+# dissolve. The source gid is carried as an ordinary attribute instead, which
+# is what makes an output piece traceable back to the feature it came from
+# ("which parcel is this 0.4 acres of flood zone?"). The overlay feature needs
+# no equivalent: its own attributes are already carried onto every row.
+INTERSECT_SOURCE_GID_COLUMN = "source_gid"
+INTERSECT_OUTPUT_COLUMNS = (INTERSECT_SOURCE_GID_COLUMN,)
+
+
+def render_intersect_pairs(
+    src_table_ref: str,
+    mask_table_ref: str,
+    *,
+    src_columns: Sequence[str] = (),
+    mask_columns: Sequence[str] = (),
+) -> str:
+    """One row per intersecting (source feature, overlay feature) PAIR (#956).
+
+    This is what separates an overlay from a clip. ``render_clip_layer_join``
+    aggregates every mask piece back to ONE geometry per source row, so a
+    parcel crossing three flood zones clips to a single feature. An overlay
+    wants three, each carrying its own zone's attributes, because the question
+    is "how many acres of THIS parcel fall in THAT zone".
+
+    ``src_columns`` and ``mask_columns`` must arrive ALREADY QUOTED, per this
+    module's rule that identifiers are the caller's responsibility. The caller
+    also guarantees they do not collide: the router rejects that at enqueue
+    (a duplicate output column fails the CTAS with an opaque "column specified
+    more than once"), so nothing here silently prefixes or renames.
+
+    Shape notes, each of which is load-bearing:
+
+    - The mask is subdivided by ``_mask_pieces`` for the reason
+      ``render_clip_layer_join`` documents (per-row cost tracks local overlap
+      instead of whole-mask complexity), but the grouping is by mask ``gid``,
+      NOT collapsed across the layer. Subdividing without re-grouping per mask
+      FEATURE would emit one row per PIECE, so a mask polygon that happened to
+      split into four would silently quadruple the output.
+    - ``ST_MakeValid`` on the source is hoisted into an ``OFFSET 0`` lateral so
+      it runs once per source row rather than once per candidate pair. Inlined,
+      it is #953's 28.4s-vs-0.2s trap, and worse here: this shape probes every
+      piece of every overlapping mask feature.
+    - ``GROUP BY _src.gid`` alone licenses the ungrouped ``_src.*`` references
+      (PostgreSQL recognizes functional dependency on a real table's primary
+      key). ``_mp`` is a CTE and has no key, so every ``_mp`` column that is
+      selected has to be grouped explicitly.
+    - ``ST_LineMerge`` on single-part LineString sources only, for the reason
+      spelled out in ``render_clip_layer_join``: ``ST_Union`` re-dissolves
+      adjacent polygons but does not sew line segments, so a line crossing a
+      piece seam would come back artificially fragmented.
+    - ``row_number()`` is evaluated after ``WHERE``, so the generated gids are
+      contiguous over the rows that survive the empty-geometry filter rather
+      than carrying its holes.
+
+    The cost of the generated key is that neither the preview nor the CTAS can
+    stop early: a window function has to see every row. The preview therefore
+    pays the full overlay before its cap applies, bounded by the sandbox
+    statement timeout rather than by the row limit.
+    """
+    src_sel = "".join(f", _src.{c}" for c in src_columns)
+    mask_sel = "".join(f", _mp.{c}" for c in mask_columns)
+    mask_pick = "".join(f", {c}" for c in mask_columns)
+    mask_group = "".join(f", _mp.{c}" for c in mask_columns)
+    outer_cols = "".join(f", _p.{c}" for c in (*src_columns, *mask_columns))
+    return (
+        f"WITH _mask_pieces AS MATERIALIZED ("
+        f"SELECT _o.gid AS _mask_gid{mask_pick},"
+        f" ST_Subdivide(_o.g, {MASK_SUBDIVIDE_MAX_VERTICES}) AS geom"
+        f" FROM (SELECT gid{mask_pick},"
+        f" ST_CollectionExtract(ST_MakeValid(geom_4326), 3) AS g"
+        f" FROM {mask_table_ref} WHERE geom_4326 IS NOT NULL OFFSET 0) AS _o"
+        f" WHERE NOT ST_IsEmpty(_o.g))"
+        f" SELECT (row_number() OVER ())::integer AS gid,"
+        f" _p.{INTERSECT_SOURCE_GID_COLUMN}{outer_cols},"
+        f" CASE WHEN _p._src_type = 'LINESTRING'"
+        f" THEN ST_LineMerge(_p.geom) ELSE _p.geom END AS geom"
+        f" FROM (SELECT _src.gid AS {INTERSECT_SOURCE_GID_COLUMN},"
+        f" GeometryType(_src.geom_4326) AS _src_type"
+        f"{src_sel}{mask_sel},"
+        f" ST_Union(ST_CollectionExtract("
+        f"ST_Intersection(_sv.g, _mp.geom),"
+        f" ST_Dimension(_src.geom_4326) + 1)) AS geom"
+        f" FROM {src_table_ref} AS _src"
+        f" CROSS JOIN LATERAL (SELECT ST_MakeValid(_src.geom_4326) AS g"
+        f" OFFSET 0) AS _sv"
+        f" JOIN _mask_pieces AS _mp"
+        f" ON _mp.geom && _src.geom_4326"
+        f" AND ST_Intersects(_mp.geom, _sv.g)"
+        f" GROUP BY _src.gid, _mp._mask_gid{mask_group}) AS _p"
+        f" WHERE _p.geom IS NOT NULL AND NOT ST_IsEmpty(_p.geom)"
+    )
+
+
+def render_intersect_preview(
+    src_table_ref: str, mask_table_ref: str, *, geojson_precision: int
+) -> str:
+    """The preview projection over ``render_intersect_pairs`` (fix(#956)).
+
+    An overlay is a JOIN with a GROUP BY, not a per-row expression, so it does
+    not fit the lateral template the other operations share — it renders whole
+    and the preview selects from it.
+
+    Only ``gid`` and ``source_gid`` are carried as properties. The preview
+    answers "what shape, and how many"; the saved dataset answers "with which
+    attributes". Threading both layers' column lists in here would buy
+    properties nothing on the map reads.
+
+    ``match_count`` is a WINDOW over this same statement, not a second one.
+    ``row_number()`` inside the pairs query has already forced every row to be
+    materialized, so ``count(*) OVER ()`` is free, whereas a separate aggregate
+    would mean running the most expensive operation twice. It is selected last
+    and sits outside the caller's extra-column list, so the positional zip that
+    builds properties stops before it and it never lands in one.
+    """
+    pairs = render_intersect_pairs(src_table_ref, mask_table_ref)
+    return (
+        f"SELECT gid,"
+        f" ST_AsGeoJSON(geom, {geojson_precision}) AS geometry_json,"
+        f" {INTERSECT_SOURCE_GID_COLUMN},"
+        f" count(*) OVER () AS match_count"
+        f" FROM ({pairs}) AS _ov"
+        f" ORDER BY gid"
+    )
 
 
 def render_select_by_location_where(mask_table_ref: str, *, src: str) -> str:

--- a/backend/app/platform/analysis_sql.py
+++ b/backend/app/platform/analysis_sql.py
@@ -640,6 +640,24 @@ def render_clip_layer_join(mask_table_ref: str, *, src: str) -> tuple[str, str, 
 INTERSECT_SOURCE_GID_COLUMN = "source_gid"
 INTERSECT_OUTPUT_COLUMNS = (INTERSECT_SOURCE_GID_COLUMN,)
 
+# fix(#1097 review): the prefix every INTERNAL column alias in a rendered
+# statement carries, and which a carried column may therefore not start with.
+#
+# The output-collision guards reserve names that reach the OUTPUT — join_count,
+# source_gid. They said nothing about the aliases a query invents on the way
+# there, so an overlay attribute named `_mask_gid`, `g` or `_src_type` landed in
+# the same select list as the alias of that name: `SELECT _o.gid AS _mask_gid,
+# "_mask_gid"`. The later `_mp._mask_gid` is then ambiguous and the CTAS fails,
+# after the queue wait, quoting a name the user never chose.
+#
+# A reserved PREFIX rather than a list of the three names. A list is correct
+# only for the aliases that exist when it is written, and this PR has already
+# watched two such lists fall behind (the provenance redaction, the picker
+# filters). Renaming the aliases into a namespace and reserving the namespace
+# means an alias added later is covered by construction, with no second place
+# to remember to update.
+INTERNAL_ALIAS_PREFIX = "_gl_"
+
 # Column types PostgreSQL cannot group by, because they have no equality
 # operator. Grouping on one fails with SQLSTATE 42883.
 #
@@ -706,18 +724,18 @@ def render_intersect_pairs(
     outer_cols = "".join(f", _p.{c}" for c in (*src_columns, *mask_columns))
     return (
         f"WITH _mask_pieces AS MATERIALIZED ("
-        f"SELECT _o.gid AS _mask_gid{mask_pick},"
-        f" ST_Subdivide(_o.g, {MASK_SUBDIVIDE_MAX_VERTICES}) AS geom"
+        f"SELECT _o.gid AS _gl_mask_gid{mask_pick},"
+        f" ST_Subdivide(_o._gl_g, {MASK_SUBDIVIDE_MAX_VERTICES}) AS geom"
         f" FROM (SELECT gid{mask_pick},"
-        f" ST_CollectionExtract(ST_MakeValid(geom_4326), 3) AS g"
+        f" ST_CollectionExtract(ST_MakeValid(geom_4326), 3) AS _gl_g"
         f" FROM {mask_table_ref} WHERE geom_4326 IS NOT NULL OFFSET 0) AS _o"
-        f" WHERE NOT ST_IsEmpty(_o.g))"
+        f" WHERE NOT ST_IsEmpty(_o._gl_g))"
         f" SELECT (row_number() OVER ())::integer AS gid,"
         f" _p.{INTERSECT_SOURCE_GID_COLUMN}{outer_cols},"
-        f" CASE WHEN _p._src_type = 'LINESTRING'"
+        f" CASE WHEN _p._gl_src_type = 'LINESTRING'"
         f" THEN ST_LineMerge(_p.geom) ELSE _p.geom END AS geom"
         f" FROM (SELECT _src.gid AS {INTERSECT_SOURCE_GID_COLUMN},"
-        f" GeometryType(_src.geom_4326) AS _src_type"
+        f" GeometryType(_src.geom_4326) AS _gl_src_type"
         f"{src_sel}{mask_sel},"
         f" ST_Union(ST_CollectionExtract("
         f"ST_Intersection(_sv.g, _mp.geom),"
@@ -728,7 +746,7 @@ def render_intersect_pairs(
         f" JOIN _mask_pieces AS _mp"
         f" ON _mp.geom && _src.geom_4326"
         f" AND ST_Intersects(_mp.geom, _sv.g)"
-        f" GROUP BY _src.gid, _mp._mask_gid{mask_group}) AS _p"
+        f" GROUP BY _src.gid, _mp._gl_mask_gid{mask_group}) AS _p"
         f" WHERE _p.geom IS NOT NULL AND NOT ST_IsEmpty(_p.geom)"
     )
 

--- a/backend/app/platform/analysis_sql.py
+++ b/backend/app/platform/analysis_sql.py
@@ -640,6 +640,14 @@ def render_clip_layer_join(mask_table_ref: str, *, src: str) -> tuple[str, str, 
 INTERSECT_SOURCE_GID_COLUMN = "source_gid"
 INTERSECT_OUTPUT_COLUMNS = (INTERSECT_SOURCE_GID_COLUMN,)
 
+# Column types PostgreSQL cannot group by, because they have no equality
+# operator. Grouping on one fails with SQLSTATE 42883.
+#
+# Here rather than in either caller: dissolve's by_field guard (the router) and
+# intersect's overlay guards (the router at enqueue, the worker again after the
+# queue wait) all need it, and the worker must not import from the API layer.
+NON_GROUPABLE_COLUMN_TYPES = frozenset({"json", "xml"})
+
 
 def render_intersect_pairs(
     src_table_ref: str,

--- a/backend/app/platform/analysis_sql.py
+++ b/backend/app/platform/analysis_sql.py
@@ -58,11 +58,16 @@ MAX_MASK_LAYER_FEATURES = 1_000
 # its ceiling is the most generous. It exists at all because the router reads
 # this dict with .get() and skips the gate when a key is absent, which would
 # leave the operation with NO ceiling rather than a default one.
+# fix(#955): select_by_location has spatial_join's cost shape — one GIST probe
+# into a second layer per source row — so it takes the same 250k. Note clip is
+# deliberately absent and therefore uncapped: its mask layer is what is bounded
+# (MAX_MASK_LAYER_FEATURES), not its source.
 MAX_SOURCE_FEATURES = {
     "dissolve": 250_000,
     "buffer": 500_000,
     "spatial_join": 250_000,
     "measure": 1_000_000,
+    "select_by_location": 250_000,
 }
 
 _CLIP_MASK_TYPES = ("Polygon", "MultiPolygon")
@@ -589,6 +594,85 @@ def render_clip_layer_join(mask_table_ref: str, *, src: str) -> tuple[str, str, 
     return cte, lateral, where
 
 
+def render_select_by_location_where(mask_table_ref: str, *, src: str) -> str:
+    """Row filter for select-by-location against a mask LAYER (fix(#955)).
+
+    A selection keeps whole source geometries, so unlike ``render_clip_layer_join``
+    there is no intersection lateral downstream. That makes this EXISTS the
+    ENTIRE operation, and it has to be exact on its own.
+
+    Clip's row filter is ``&&`` alone, which admits any source row whose
+    ENVELOPE overlaps a mask envelope. Clip survives that because rows missing
+    the true predicate intersect to NULL/EMPTY and the not-empty filter drops
+    them. Copy it verbatim into a selection and an L-shaped or concave mask
+    selects the features sitting in its notch, which is this operation's
+    signature bug. So ``&&`` stays as the index-drivable prefilter and a real
+    ``ST_Intersects`` is added beside it.
+
+    Both operands are RAW columns. ``ST_Intersects`` accepts invalid geometry
+    (unlike ``ST_Intersection``, which raises) and agrees with the repaired
+    answer, so no ``ST_MakeValid`` is needed — and adding one would be actively
+    harmful here rather than merely wasteful: inside a correlated subquery it
+    re-evaluates per CANDIDATE PAIR instead of per row, which measured 28.4s
+    against 0.2s on #953's join before the ``OFFSET 0`` hoist. Nothing to hoist
+    in this shape, because there is no expression left to evaluate.
+
+    Like clip, the probe targets the RAW mask table rather than a subdivided
+    CTE: it keeps real join statistics in both directions, where the CTE costs
+    a linear piece scan per source row (2.4s vs 0.25s when the mask sits at the
+    high end of the gid order).
+
+    ``ST_Dimension(...) = 2`` keeps the mask polygonal per ROW.
+    ``_load_mask_dataset`` already rejects a non-polygonal mask DATASET, but the
+    catalog classifies ``geometry_type`` from the FIRST feature (fix(#682)), so
+    a "POLYGON" layer can still hold point and line rows — and clip drops those
+    in ``_mask_pieces``. Without this term, selecting and clipping against one
+    layer would disagree about what the mask is. It does NOT chase the narrower
+    case of a degenerate polygon that ``ST_MakeValid`` would shed to a line;
+    that needs the per-row repair ruled out above.
+
+    NULL geometry on either side falls out of ``&&`` by three-valued logic
+    rather than by an explicit guard.
+    """
+    return (
+        f" WHERE EXISTS (SELECT 1 FROM {mask_table_ref} AS _sel"
+        f" WHERE _sel.geom_4326 && {src}.geom_4326"
+        f" AND ST_Intersects(_sel.geom_4326, {src}.geom_4326)"
+        f" AND ST_Dimension(_sel.geom_4326) = 2)"
+    )
+
+
+def render_select_by_location_count(
+    src_table_ref: str, *, mask_table_ref: str | None, mask: dict[str, Any] | None
+) -> str:
+    """Exact selected-record total, uncapped by the preview limit (fix(#955)).
+
+    The record list is this operation's deliverable, so its SIZE cannot be the
+    500 the geometry preview stops at. This is the second, uncapped statement
+    that answers it.
+
+    Rebuilds the row filter by calling the SAME renderer the preview calls for
+    whichever mask path is in play, rather than restating the predicate, so the
+    number under the map and the features on it cannot describe different sets.
+    That is #953's lesson, where a separately written count statement drifted
+    from the per-row one.
+
+    The trailing not-NULL/not-empty pair is what ``NOT_EMPTY_PREDICATE`` does
+    for the preview, restated against the source column because a selection's
+    lateral is the identity. A test pins the total against the feature list
+    rather than leaving the agreement to this paragraph.
+    """
+    if mask_table_ref is not None:
+        where = render_select_by_location_where(mask_table_ref, src="_src")
+    else:
+        _, where = render_geometry_expr("select_by_location", mask=mask)
+    return (
+        f"SELECT count(*)::bigint AS match_count"
+        f" FROM {src_table_ref} AS _src{where}"
+        f" AND _src.geom_4326 IS NOT NULL AND NOT ST_IsEmpty(_src.geom_4326)"
+    )
+
+
 # fix(#954): the columns a measure adds to the source row. Metres on the wire,
 # matching the buffer distance convention the panel's unit picker converts for
 # (AnalysisPanel's BUFFER_UNIT_METERS). ST_Area(geography) returns square
@@ -879,6 +963,26 @@ def render_geometry_expr(
         # actually matters, inside the join predicate (render_spatial_join).
         # The join columns themselves come from render_spatial_join.
         return "geom_4326", ""
+    if operation == "select_by_location":
+        # fix(#955): the drawn-mask half of select-by-location. The geometry is
+        # the source feature verbatim (like spatial_join/measure above, and NOT
+        # ST_MakeValid'd for the same reason), so the operation is entirely its
+        # WHERE.
+        #
+        # Unlike clip's inline predicate below, ST_MakeValid is left off the
+        # source side. Clip repairs there because its geometry expression feeds
+        # ST_Intersection, which RAISES on invalid input, and the filter has to
+        # agree with what the expression will compute; a selection computes
+        # nothing, and ST_Intersects accepts invalid geometry directly. Leaving
+        # it off is also what keeps this path's row set identical to the mask-
+        # LAYER path, where the repair is unaffordable (see
+        # render_select_by_location_where).
+        mask_expr = render_mask_expr(mask or {})
+        return (
+            "geom_4326",
+            f" WHERE geom_4326 && {mask_expr}"
+            f" AND ST_Intersects(geom_4326, {mask_expr})",
+        )
     if operation == "clip":
         mask_expr = render_mask_expr(mask or {})
         # A clip that only grazes a boundary intersects at a lower dimension

--- a/backend/app/platform/analysis_sql.py
+++ b/backend/app/platform/analysis_sql.py
@@ -53,10 +53,16 @@ MAX_MASK_LAYER_FEATURES = 1_000
 # expression. 250k matches dissolve rather than buffer's 500k for that reason.
 # Note the router reads this with .get() and skips the gate when the key is
 # absent, so an operation missing here has NO ceiling, not a default one.
+# fix(#954): measure is the cheapest operation here — one geography cast and
+# two accessor calls per row, no output amplification and no second layer — so
+# its ceiling is the most generous. It exists at all because the router reads
+# this dict with .get() and skips the gate when a key is absent, which would
+# leave the operation with NO ceiling rather than a default one.
 MAX_SOURCE_FEATURES = {
     "dissolve": 250_000,
     "buffer": 500_000,
     "spatial_join": 250_000,
+    "measure": 1_000_000,
 }
 
 _CLIP_MASK_TYPES = ("Polygon", "MultiPolygon")
@@ -583,6 +589,54 @@ def render_clip_layer_join(mask_table_ref: str, *, src: str) -> tuple[str, str, 
     return cte, lateral, where
 
 
+# fix(#954): the columns a measure adds to the source row. Metres on the wire,
+# matching the buffer distance convention the panel's unit picker converts for
+# (AnalysisPanel's BUFFER_UNIT_METERS). ST_Area(geography) returns square
+# metres and ST_Length(geography) metres, so the SQL converts nothing.
+MEASURE_AREA_COLUMN = "area_sqm"
+MEASURE_LENGTH_COLUMN = "length_m"
+MEASURE_OUTPUT_COLUMNS = (MEASURE_AREA_COLUMN, MEASURE_LENGTH_COLUMN)
+
+
+def render_measure_columns(*, src: str = "") -> tuple[str, str]:
+    """Render the measured columns and the cast that feeds them (fix(#954)).
+
+    Returns ``(select_columns, join_clause)`` in the same shape
+    ``render_spatial_join`` uses, so the preview and the CTAS compose them
+    identically.
+
+    BOTH columns are emitted for every geometry type, rather than picking one
+    from the catalog's ``geometry_type``. That column is classified from the
+    dataset's FIRST feature (the same trap fix(#682) documents for clip masks),
+    so a table typed POLYGON can legitimately hold line rows, and branching on
+    it would silently measure the wrong thing for the rest of the table.
+    Emitting both is honest instead: ``ST_Length`` of a polygon is 0 and
+    ``ST_Area`` of a line is 0, so each row carries its meaningful measure and a
+    zero, and a mixed table measures correctly throughout.
+
+    The ``::geography`` cast is hoisted into its own lateral behind an
+    ``OFFSET 0`` fence so it runs ONCE per row and feeds both accessors —
+    inlined, the two references cast the geometry twice. Same fix(#700) shape
+    the preview's geometry expression and the #953 join predicate use; the cast
+    is the expensive part on large inputs, which the issue flags directly.
+
+    geography, not planar: it measures on the spheroid, so an unprojected
+    dataset gets a correct answer with none of the projection juggling the
+    buffer path needs, and an antimeridian-crossing polygon measures correctly
+    where planar area does not.
+    """
+    prefix = f"{src}." if src else ""
+    join = (
+        f" CROSS JOIN LATERAL (SELECT {prefix}geom_4326::geography AS g"
+        f" OFFSET 0) AS _mg"
+    )
+    columns = (
+        f"ST_Area(_mg.g)::double precision AS {MEASURE_AREA_COLUMN},"
+        f" ST_Length(_mg.g)::double precision AS {MEASURE_LENGTH_COLUMN}"
+    )
+    return columns, join
+
+
 # fix(#953): the columns a spatial join adds to the source row.
 SPATIAL_JOIN_COUNT_COLUMN = "join_count"
 SPATIAL_JOIN_FIELD_PREFIX = "join_"
@@ -809,6 +863,12 @@ def render_geometry_expr(
         return render_geodesic_buffer("ST_MakeValid(geom_4326)", distance), ""
     if operation == "centroid":
         return "ST_Centroid(ST_MakeValid(geom_4326))", ""
+    if operation == "measure":
+        # fix(#954): like spatial_join, measure adds columns and leaves the
+        # geometry alone — see the spatial_join note below on why the output is
+        # NOT ST_MakeValid'd. The measured columns come from
+        # render_measure_columns.
+        return "geom_4326", ""
     if operation == "spatial_join":
         # fix(#953): a spatial join adds columns; the geometry is the source
         # feature verbatim. Deliberately NOT ST_MakeValid'd, unlike every other

--- a/backend/app/platform/analysis_sql.py
+++ b/backend/app/platform/analysis_sql.py
@@ -914,6 +914,15 @@ def render_measure_columns(*, src: str = "") -> tuple[str, str]:
 SPATIAL_JOIN_COUNT_COLUMN = "join_count"
 SPATIAL_JOIN_FIELD_PREFIX = "join_"
 
+# PostgreSQL's NAMEDATALEN - 1. An identifier longer than this is truncated
+# with a NOTICE rather than refused, so a guard that compares untruncated names
+# is comparing strings the database will never see. Confirmed on the server
+# (SELECT current_setting('max_identifier_length')) rather than taken on faith.
+#
+# Bytes, strictly — but every name this bounds is ASCII, because
+# _SAFE_COLUMN_RE gates the join fields that can be named in a request.
+MAX_IDENTIFIER_LENGTH = 63
+
 # Transferred fields are capped because each one widens every output row and
 # the CTAS has a fixed time budget. Ten is well past the "which district is
 # this in" case the operation exists for.
@@ -937,9 +946,27 @@ def spatial_join_output_columns(join_fields: list[str] | None) -> list[str]:
     the same name: the CTAS would otherwise fail with "column specified more
     than once" after the queue wait, the same trap ``by_field`` hits on
     dissolve's generated ``source_count``.
+
+    fix(#1097 review): TRUNCATED to PostgreSQL's identifier limit, because that
+    is the name the CTAS will actually create. Verified against the server
+    rather than assumed: max_identifier_length is 63, and a longer alias is
+    silently truncated to it (a NOTICE, not an error), quoted or not.
+
+    Two join fields sharing their first 58 characters therefore prefix to
+    strings that differ here and are the SAME column in the output, so the
+    uniqueness check below passed and the CTAS failed after the queue wait. One
+    overlong alias can also truncate ONTO an existing source column without the
+    collision check noticing.
+
+    Truncating here rather than rejecting long names keeps the guards comparing
+    what the database will compare, and keeps every consumer — the router's two
+    checks, the worker's recheck, and this list's own uniqueness rule — reading
+    one set of names. Source columns need no such treatment: they already exist
+    in a table, so the server truncated them when it was created.
     """
     return [SPATIAL_JOIN_COUNT_COLUMN] + [
-        f"{SPATIAL_JOIN_FIELD_PREFIX}{name}" for name in (join_fields or [])
+        f"{SPATIAL_JOIN_FIELD_PREFIX}{name}"[:MAX_IDENTIFIER_LENGTH]
+        for name in (join_fields or [])
     ]
 
 

--- a/backend/app/processing/analysis/provenance.py
+++ b/backend/app/processing/analysis/provenance.py
@@ -87,6 +87,7 @@ def _operation_phrase(
     source: str,
     params: Mapping[str, Any],
     mask_title: str | None,
+    join_title: str | None = None,
 ) -> str:
     """The clause naming the operation and its parameters.
 
@@ -113,6 +114,30 @@ def _operation_phrase(
         if by_field:
             return f"Dissolved from {source} by {by_field}"
         return f"Dissolved from {source} into a single feature"
+    # fix(#1097 review): the four operations this branch adds had no branch, so
+    # they fell through to the generic fallback and their sentences named only
+    # the source. That sentence is a product surface — the dataset page shows
+    # it, search indexes it, and DCAT exports it — so an overlay whose whole
+    # point is the second layer was described without mentioning one.
+    if operation == "spatial_join":
+        target = _quoted(join_title) if join_title else "another layer"
+        fields = params.get("join_fields")
+        if fields:
+            return (
+                f"Joined from {source} against {target}, "
+                f"transferring {', '.join(fields)}"
+            )
+        return f"Joined from {source} against {target}"
+    if operation == "intersect":
+        target = _quoted(mask_title) if mask_title else "another layer"
+        return f"Intersected from {source} with {target}"
+    if operation == "select_by_location":
+        if params.get("mask_source") == "layer":
+            target = _quoted(mask_title) if mask_title else "another layer"
+            return f"Selected from {source} by {target}"
+        return f"Selected from {source} by a drawn area"
+    if operation == "measure":
+        return f"Measurements computed from {source}"
     return f"{operation.replace('_', ' ').capitalize()} applied to {source}"
 
 
@@ -124,6 +149,7 @@ def build_lineage_sentence(
     actor: str,
     created_at: datetime,
     mask_title: str | None = None,
+    join_title: str | None = None,
 ) -> str:
     """A human sentence describing how this dataset was produced.
 
@@ -131,7 +157,9 @@ def build_lineage_sentence(
     ``dcterms:provenance`` and the dataset page shows it verbatim.
     """
     params = params or {}
-    phrase = _operation_phrase(operation, _quoted(source_title), params, mask_title)
+    phrase = _operation_phrase(
+        operation, _quoted(source_title), params, mask_title, join_title
+    )
     return f"{phrase}, created by {actor} on {created_at.date().isoformat()}."
 
 
@@ -243,11 +271,14 @@ async def apply_analysis_provenance(
         return
 
     source_title = await _record_title(session, source_dataset_id)
-    mask_title = (
-        await _record_title(session, params.get("mask_dataset_id"))
-        if params.get("mask_source") == "layer"
-        else None
-    )
+    # fix(#1097 review): keyed off the ID being present, not off the
+    # mask_source discriminator. intersect takes a layer and has no
+    # mask_source — the discriminator only distinguishes drawn from layer for
+    # the operations that can be either — so gating on it meant an overlay's
+    # title was never resolved and its sentence said "another layer" for a
+    # layer whose title was one query away.
+    mask_title = await _record_title(session, params.get("mask_dataset_id"))
+    join_title = await _record_title(session, params.get("join_dataset_id"))
 
     record.lineage_summary = build_lineage_sentence(
         operation=operation,
@@ -256,6 +287,7 @@ async def apply_analysis_provenance(
         actor=await _actor_label(session, user_id),
         created_at=now,
         mask_title=mask_title,
+        join_title=join_title,
     )
     record.derived_from = build_derived_from(
         source_dataset_id=source_dataset_id,

--- a/backend/app/processing/analysis/provenance.py
+++ b/backend/app/processing/analysis/provenance.py
@@ -120,13 +120,22 @@ def _operation_phrase(
     # it, search indexes it, and DCAT exports it — so an overlay whose whole
     # point is the second layer was described without mentioning one.
     if operation == "spatial_join":
+        # fix(#1097 review): the transferred field names are NOT named here.
+        #
+        # This sentence is stored once on the record and served to every
+        # requester who can see the output — the dataset page returns it raw,
+        # search indexes it, and three DCAT services export it. None of them
+        # pass it through visible_derived_from, which is what access-checks the
+        # structured provenance per requester.
+        #
+        # So anything the redaction treats as sensitive cannot appear in this
+        # prose, because prose has no per-requester form. join_fields is listed
+        # in _DATASET_ID_PARAMS as a dependent of join_dataset_id precisely
+        # because it describes a layer the requester may not be allowed to see:
+        # a column list is most of a schema. The previous round put it here
+        # while making the sentence more useful, which routed it around the
+        # redaction added for exactly this.
         target = _quoted(join_title) if join_title else "another layer"
-        fields = params.get("join_fields")
-        if fields:
-            return (
-                f"Joined from {source} against {target}, "
-                f"transferring {', '.join(fields)}"
-            )
         return f"Joined from {source} against {target}"
     if operation == "intersect":
         target = _quoted(mask_title) if mask_title else "another layer"

--- a/backend/app/processing/analysis/provenance.py
+++ b/backend/app/processing/analysis/provenance.py
@@ -29,7 +29,27 @@ logger = structlog.get_logger(__name__)
 
 # Params carried into the sentence and the reference. Mirrors the analysis
 # metadata the router records on the job, minus the bookkeeping keys.
-PARAM_KEYS = ("distance_meters", "by_field", "mask_source", "mask_dataset_id")
+#
+# fix(#1097 review): the spatial-join pair was missing. _materialize passes
+# join_dataset_id and join_fields to apply_analysis_provenance, and this filter
+# silently dropped both — so a join's durable lineage recorded the source and
+# the operation and neither the layer it joined against nor the columns it
+# transferred, which is most of what makes a join reproducible.
+#
+# This list is the STORAGE contract, and that has a consequence worth stating
+# where the keys are: anything added here becomes visible to every requester
+# who can see the output, so a key naming a dataset must also appear in
+# _DATASET_ID_PARAMS in catalog/authorization.py, which access-checks each one
+# per requester. test_every_dataset_id_param_is_redactable enforces exactly
+# that pairing, and it reads THIS tuple.
+PARAM_KEYS = (
+    "distance_meters",
+    "by_field",
+    "mask_source",
+    "mask_dataset_id",
+    "join_dataset_id",
+    "join_fields",
+)
 
 
 def _format_metres(value: Any) -> str:

--- a/backend/app/processing/analysis/tasks.py
+++ b/backend/app/processing/analysis/tasks.py
@@ -33,9 +33,11 @@ from app.core.tenancy import is_multi_tenant
 from app.platform.analysis_sql import (
     MAX_MASK_LAYER_FEATURES,
     MAX_SOURCE_FEATURES,
+    MEASURE_OUTPUT_COLUMNS,
     NOT_EMPTY_PREDICATE,
     render_clip_layer_join,
     render_geometry_expr,
+    render_measure_columns,
     render_spatial_join,
     spatial_join_output_columns,
 )
@@ -358,6 +360,37 @@ async def _count_features_bounded(
     return int(result.scalar_one())
 
 
+def _generated_columns(
+    operation: str, join_fields: list[str] | None
+) -> tuple[str, ...]:
+    """Columns an operation adds to the output beside the carried source ones."""
+    if operation == "measure":
+        return MEASURE_OUTPUT_COLUMNS
+    if operation == "spatial_join":
+        return tuple(spatial_join_output_columns(join_fields))
+    return ()
+
+
+def _reject_output_column_collision(
+    carry_cols: list[str], generated: tuple[str, ...]
+) -> None:
+    """Worker-side half of the router's enqueue guard.
+
+    The router validates against ``column_info``, a catalog snapshot, and the
+    queue wait sits between that and the live column list held here — so the
+    check runs again against the real columns. Without it the CTAS fails on an
+    opaque "column specified more than once" after the whole wait
+    (fix(#953), extended to measure by fix(#954)).
+    """
+    clashes = sorted(set(carry_cols) & set(generated))
+    if clashes:
+        raise ValueError(
+            "The source dataset already has a column named "
+            f"{clashes[0]!r}, which this operation would overwrite. "
+            "Rename it, or choose a different operation."
+        )
+
+
 async def _resolve_layer_table_ref(
     session: AsyncSession,
     dataset_cls: Any,
@@ -670,6 +703,16 @@ def _build_materialize_select(
     join_fields: list[str] | None = None,
 ) -> str:
     """Render the SELECT that produces the output table's rows."""
+    if operation == "measure":
+        # fix(#954): the same renderer the preview uses, so a saved measurement
+        # equals the one the user approved rather than being recomputed by a
+        # second expression that could drift.
+        measure_cols, measure_join = render_measure_columns(src="_src")
+        cols = "".join(f"_src.{_sql_quote_ident(c)}, " for c in carry_cols)
+        return _wrap_not_empty(
+            f"SELECT _src.gid, {cols}_src.geom_4326 AS geom, {measure_cols}"
+            f" FROM {src_ref} AS _src{measure_join}"
+        )
     if operation == "spatial_join" and join_table_ref is not None:
         # fix(#953): the same two laterals the preview uses, so the saved
         # dataset and the approved preview agree row for row — including the
@@ -884,21 +927,9 @@ async def _materialize(
                 if operation != "dissolve"
                 else []
             )
-            if operation == "spatial_join":
-                # The router 422s this at enqueue; repeating it here is the
-                # same defense-in-depth as re-matching _SAFE_IDENT above, and
-                # this is the one place holding the live column list. Without
-                # it the CTAS fails on "column specified more than once" after
-                # the whole queue wait (fix(#953)).
-                clashes = sorted(
-                    set(carry_cols) & set(spatial_join_output_columns(join_fields))
-                )
-                if clashes:
-                    raise ValueError(
-                        "The source dataset already has a column named "
-                        f"{clashes[0]!r}, which this join would overwrite. "
-                        "Rename it, or drop that field from the join."
-                    )
+            _reject_output_column_collision(
+                carry_cols, _generated_columns(operation, join_fields)
+            )
             select_sql = _build_materialize_select(
                 src_ref,
                 operation,

--- a/backend/app/processing/analysis/tasks.py
+++ b/backend/app/processing/analysis/tasks.py
@@ -61,6 +61,8 @@ logger = structlog.stdlib.get_logger(__name__)
 
 _SAFE_IDENT = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_]*$")
 _SAFE_TABLE = re.compile(r"^[a-z0-9_]+$")
+# Mirrors _POLYGONAL_TYPES in router_analysis: a mask layer must be polygonal.
+_POLYGONAL = {"POLYGON", "MULTIPOLYGON"}
 
 
 # The preview path is bounded (10s sandbox timeout, 500-row cap); the CTAS
@@ -545,6 +547,7 @@ async def _resolve_layer_table_ref(
     schema: str,
     *,
     label: str,
+    require_polygonal: bool = False,
 ) -> tuple[str, str]:
     """Re-resolve a secondary layer at run time: ``(table_ref, table_name)``.
 
@@ -569,6 +572,19 @@ async def _resolve_layer_table_ref(
         raise ValueError(f"{label.capitalize()} dataset not found")
     if not _SAFE_TABLE.match(layer.table_name):
         raise ValueError(f"Invalid {label} table name")
+    # fix(#1097 review): the geometry requirement is re-applied here, not just
+    # at enqueue. The router's _load_mask_dataset refuses a non-polygonal mask,
+    # but a re-upload can turn that layer into points or lines while the job
+    # waits in the queue — and the swap updates Dataset.geometry_type, so the
+    # stale value the router checked is not the one the CTAS would run against.
+    # Nothing downstream notices: the mask expression simply matches no rows,
+    # and the job dies on "Analysis produced no features", which sends the user
+    # looking at their data rather than at the layer that changed under them.
+    if require_polygonal and (layer.geometry_type or "").upper() not in _POLYGONAL:
+        raise ValueError(
+            f"The {label} layer is no longer a polygon layer. It may have been "
+            "re-uploaded since this analysis was queued."
+        )
     return f'"{schema}"."{layer.table_name}"', layer.table_name
 
 
@@ -1064,7 +1080,12 @@ async def _materialize(
             mask_table_name: str | None = None
             if mask_dataset_id is not None:
                 mask_table_ref, mask_table_name = await _resolve_layer_table_ref(
-                    session, Dataset, mask_dataset_id, _schema, label="mask"
+                    session,
+                    Dataset,
+                    mask_dataset_id,
+                    _schema,
+                    label="mask",
+                    require_polygonal=True,
                 )
             join_table_ref: str | None = None
             # fix(#1097 review): the plain name is kept now, not discarded. The

--- a/backend/app/processing/analysis/tasks.py
+++ b/backend/app/processing/analysis/tasks.py
@@ -512,6 +512,27 @@ async def _reject_missing_join_fields(
         )
 
 
+def _ungroupable_type_name(data_type: str | None, udt_name: str | None) -> str | None:
+    """The display name of a non-groupable column type, or None if groupable.
+
+    fix(#1097 review): information_schema reports EVERY array column's
+    data_type as 'ARRAY'; the element type only surfaces in udt_name, with a
+    leading underscore ('_json' for json[]). An exact data_type comparison
+    therefore admitted json[]/xml[] columns straight into GROUP BY, where
+    PostgreSQL cannot apply equality to them (SQLSTATE 42883, verified) — and
+    the catalog snapshot has the same blind spot, so the failure landed after
+    the queue wait. Elements, not arrays: int[]/text[] have equality and group
+    fine, so rejecting 'ARRAY' wholesale would refuse layers that work.
+    """
+    dt = str(data_type or "").lower()
+    if dt in NON_GROUPABLE_COLUMN_TYPES:
+        return dt
+    udt = str(udt_name or "").lower()
+    if udt.startswith("_") and udt[1:] in NON_GROUPABLE_COLUMN_TYPES:
+        return f"{udt[1:]}[]"
+    return None
+
+
 async def _reject_ungroupable_overlay_columns(
     session: AsyncSession, schema: str, table_name: str
 ) -> None:
@@ -524,7 +545,9 @@ async def _reject_ungroupable_overlay_columns(
     than trusted from the snapshot. A replacement that introduces a json or xml
     column would otherwise reach ``render_intersect_pairs``, which names every
     carried overlay column in its GROUP BY, and fail the CTAS with SQLSTATE
-    42883.
+    42883. Array forms (json[]/xml[]) can ONLY be caught here: the snapshot
+    stores 'ARRAY' with no element type, so the router admits them and this
+    recheck is the sole guard (see _ungroupable_type_name).
 
     Types, not names: reading the live names already happens and would not have
     caught this, because the column that breaks the query is one whose NAME is
@@ -532,20 +555,55 @@ async def _reject_ungroupable_overlay_columns(
     """
     rows = await session.execute(
         text(
-            "SELECT column_name, data_type FROM information_schema.columns "
+            "SELECT column_name, data_type, udt_name "
+            "FROM information_schema.columns "
             "WHERE table_schema = :schema AND table_name = :table_name "
             "AND column_name NOT IN ('gid', 'geom', 'geom_4326') "
             "ORDER BY ordinal_position"
         ).bindparams(schema=schema, table_name=table_name)
     )
-    for name, data_type in rows:
-        if str(data_type or "").lower() in NON_GROUPABLE_COLUMN_TYPES:
+    for name, data_type, udt_name in rows:
+        bad = _ungroupable_type_name(data_type, udt_name)
+        if bad is not None:
             raise ValueError(
                 f"The overlay layer's column {name!r} has type "
-                f"{str(data_type).lower()!r}, which cannot be grouped, and an "
+                f"{bad!r}, which cannot be grouped, and an "
                 "overlay carries every overlay column onto its output. Choose "
                 "a different layer, or remove that column from it."
             )
+
+
+async def _reject_ungroupable_by_field(
+    session: AsyncSession, schema: str, table_name: str, by_field: str
+) -> None:
+    """Dissolve's GROUP BY column must be groupable on the LIVE schema.
+
+    fix(#1097 review): the same shape as the overlay recheck above, one
+    operation over — dissolve names ``by_field`` in its GROUP BY, the router
+    checked it against the snapshot, and the snapshot cannot see a json[]
+    element type ('ARRAY'). One query answers both failure modes: a column the
+    re-upload dropped, and one whose live type has no equality operator.
+    """
+    row = (
+        await session.execute(
+            text(
+                "SELECT data_type, udt_name FROM information_schema.columns "
+                "WHERE table_schema = :schema AND table_name = :table_name "
+                "AND column_name = :column_name"
+            ).bindparams(schema=schema, table_name=table_name, column_name=by_field)
+        )
+    ).first()
+    if row is None:
+        raise ValueError(
+            f"Column {by_field!r} no longer exists on the source layer. It "
+            "may have been re-uploaded since this analysis was queued."
+        )
+    bad = _ungroupable_type_name(row[0], row[1])
+    if bad is not None:
+        raise ValueError(
+            f"Column {by_field!r} has type {bad!r} and can't be used to "
+            "group features. Choose a column with comparable values."
+        )
 
 
 async def _resolve_layer_table_ref(
@@ -1096,8 +1154,12 @@ async def _materialize(
                 raise ValueError("Source dataset not found")
             if not _SAFE_TABLE.match(src.table_name):
                 raise ValueError("Invalid source table name")
-            if by_field is not None and not _SAFE_IDENT.match(by_field):
-                raise ValueError("Invalid dissolve column name")
+            if by_field is not None:
+                if not _SAFE_IDENT.match(by_field):
+                    raise ValueError("Invalid dissolve column name")
+                await _reject_ungroupable_by_field(
+                    session, _schema, src.table_name, by_field
+                )
             src_ref = f'"{_schema}"."{src.table_name}"'
 
             # Layer-sourced clip mask: re-resolve the table name at run time

--- a/backend/app/processing/analysis/tasks.py
+++ b/backend/app/processing/analysis/tasks.py
@@ -38,6 +38,7 @@ from app.platform.analysis_sql import (
     render_clip_layer_join,
     render_geometry_expr,
     render_measure_columns,
+    render_select_by_location_where,
     render_spatial_join,
     spatial_join_output_columns,
 )
@@ -746,6 +747,21 @@ def _build_materialize_select(
         return _wrap_not_empty(
             f"SELECT 1 AS gid, COUNT(*)::integer AS source_count, "
             f"{union_expr} AS geom FROM {src_ref}"
+        )
+    if operation == "select_by_location" and mask_table_ref is not None:
+        # fix(#955): whole source rows, filtered. No lateral and no CTE, so
+        # unlike the clip branch below there is nothing for the not-empty
+        # filter to catch downstream — _wrap_not_empty applies it to the source
+        # geometry directly, which is what the output geometry IS.
+        #
+        # The DRAWN-mask half needs no branch at all: render_geometry_expr
+        # returns ("geom_4326", <where>) and the generic tail below is already
+        # the right shape.
+        where = render_select_by_location_where(mask_table_ref, src="_src")
+        cols = "".join(f"_src.{_sql_quote_ident(c)}, " for c in carry_cols)
+        return _wrap_not_empty(
+            f"SELECT _src.gid, {cols}_src.geom_4326 AS geom"
+            f" FROM {src_ref} AS _src{where}"
         )
     if operation == "clip" and mask_table_ref is not None:
         # fix(#719): the same subdivided-mask join the preview uses. This used

--- a/backend/app/processing/analysis/tasks.py
+++ b/backend/app/processing/analysis/tasks.py
@@ -31,6 +31,7 @@ from app.core.db.tenant_schema import tenant_data_schema
 from app.core.db.tenant_session import current_tenant_var, tenant_task
 from app.core.tenancy import is_multi_tenant
 from app.platform.analysis_sql import (
+    INTERNAL_ALIAS_PREFIX,
     INTERSECT_OUTPUT_COLUMNS,
     MAX_MASK_LAYER_FEATURES,
     MAX_SOURCE_FEATURES,
@@ -394,6 +395,110 @@ def _reject_output_column_collision(
             "The source dataset already has a column named "
             f"{clashes[0]!r}, which this operation would overwrite. "
             "Rename it, or choose a different operation."
+        )
+
+
+async def _resolve_and_validate_columns(
+    session: AsyncSession,
+    *,
+    schema: str,
+    operation: str,
+    src_table_name: str,
+    mask_table_name: str | None,
+    join_table_name: str | None,
+    join_fields: list[str] | None,
+) -> tuple[list[str], list[str]]:
+    """The live-schema rechecks, run together after the queue wait.
+
+    Every guard in here has an enqueue-time twin in the router that reads
+    ``column_info``, a catalog SNAPSHOT. The queue wait sits between the two and
+    a re-upload can replace either layer in that window, so each one runs again
+    against the real columns. Returns the carried column lists the CTAS is
+    built from, because resolving them is how most of these are checked.
+
+    Extracted in fix(#1097 review) rather than raising the C901 threshold on
+    ``_materialize``: the set has grown to five checks over two layers, and
+    they share a subject that the surrounding job bookkeeping does not.
+    """
+    carry_cols = (
+        await _list_carry_columns(session, schema, src_table_name)
+        if operation != "dissolve"
+        else []
+    )
+    _reject_output_column_collision(
+        carry_cols, _generated_columns(operation, join_fields)
+    )
+    if operation == "intersect":
+        _reject_reserved_alias_columns(carry_cols)
+    if operation == "spatial_join" and join_table_name is not None:
+        await _reject_missing_join_fields(session, schema, join_table_name, join_fields)
+    # fix(#956): an overlay carries columns from BOTH inputs, so it is the only
+    # operation that also needs the second layer's live column list — and the
+    # only one where two same-named columns are likely rather than exotic.
+    mask_carry_cols: list[str] = []
+    if operation == "intersect" and mask_table_name is not None:
+        mask_carry_cols = await _list_carry_columns(session, schema, mask_table_name)
+        _reject_output_column_collision(
+            carry_cols, (*mask_carry_cols, *INTERSECT_OUTPUT_COLUMNS)
+        )
+        _reject_output_column_collision(mask_carry_cols, INTERSECT_OUTPUT_COLUMNS)
+        _reject_reserved_alias_columns(mask_carry_cols)
+        await _reject_ungroupable_overlay_columns(session, schema, mask_table_name)
+    return carry_cols, mask_carry_cols
+
+
+def _reject_reserved_alias_columns(carry_cols: list[str]) -> None:
+    """Worker-side half of the reserved-alias guard.
+
+    fix(#1097 review): the router checked a catalog snapshot; a re-upload can
+    introduce a column in the alias namespace before the job runs. Same window
+    as the two rechecks below, and cheap, because the live column list is
+    already in hand here.
+    """
+    reserved = sorted(c for c in carry_cols if c.startswith(INTERNAL_ALIAS_PREFIX))
+    if reserved:
+        raise ValueError(
+            f"Column {reserved[0]!r} uses the {INTERNAL_ALIAS_PREFIX!r} prefix, "
+            "which this operation reserves for its own internal columns. "
+            "Rename it, or choose a different layer."
+        )
+
+
+async def _reject_missing_join_fields(
+    session: AsyncSession, schema: str, table_name: str, join_fields: list[str] | None
+) -> None:
+    """The transferred fields must still exist on the join layer.
+
+    fix(#1097 review): the router validated them against column_info at
+    enqueue, and the worker re-resolved the join layer's TABLE without ever
+    re-checking its COLUMNS. A re-upload that drops or renames a requested
+    field left render_spatial_join referencing a column that is no longer
+    there, so the CTAS failed after the whole queue wait with a database error
+    naming a column the user had legitimately selected when they asked.
+
+    The sibling rechecks beside this one exist for exactly that window; this
+    one was the gap in the set.
+    """
+    if not join_fields:
+        return
+    live = set(
+        (
+            await session.execute(
+                text(
+                    "SELECT column_name FROM information_schema.columns "
+                    "WHERE table_schema = :schema AND table_name = :table_name"
+                ).bindparams(schema=schema, table_name=table_name)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    missing = sorted(set(join_fields) - live)
+    if missing:
+        raise ValueError(
+            f"The join layer no longer has a column named {missing[0]!r}. It "
+            "may have been re-uploaded since this analysis was queued. Choose "
+            "the fields again."
         )
 
 
@@ -962,8 +1067,13 @@ async def _materialize(
                     session, Dataset, mask_dataset_id, _schema, label="mask"
                 )
             join_table_ref: str | None = None
+            # fix(#1097 review): the plain name is kept now, not discarded. The
+            # transferred fields have to be re-checked against this layer's
+            # LIVE columns, and information_schema takes a name rather than the
+            # quoted ref.
+            join_table_name: str | None = None
             if join_dataset_id is not None:
-                join_table_ref, _ = await _resolve_layer_table_ref(
+                join_table_ref, join_table_name = await _resolve_layer_table_ref(
                     session, Dataset, join_dataset_id, _schema, label="join"
                 )
 
@@ -995,34 +1105,15 @@ async def _materialize(
             # same row) for the entire build.
             out_ref = f'"{_schema}"."{out_table}"'
 
-            carry_cols = (
-                await _list_carry_columns(session, _schema, src.table_name)
-                if operation != "dissolve"
-                else []
+            carry_cols, mask_carry_cols = await _resolve_and_validate_columns(
+                session,
+                schema=_schema,
+                operation=operation,
+                src_table_name=src.table_name,
+                mask_table_name=mask_table_name,
+                join_table_name=join_table_name,
+                join_fields=join_fields,
             )
-            _reject_output_column_collision(
-                carry_cols, _generated_columns(operation, join_fields)
-            )
-            # fix(#956): an overlay carries columns from BOTH inputs, so it is
-            # the only operation that also needs the second layer's live column
-            # list — and the only one where two same-named columns are likely
-            # rather than exotic. Same two-sided story as the guard above: the
-            # router checked the catalog snapshot at enqueue, this re-checks the
-            # real columns after the queue wait.
-            mask_carry_cols: list[str] = []
-            if operation == "intersect" and mask_table_name is not None:
-                mask_carry_cols = await _list_carry_columns(
-                    session, _schema, mask_table_name
-                )
-                _reject_output_column_collision(
-                    carry_cols, (*mask_carry_cols, *INTERSECT_OUTPUT_COLUMNS)
-                )
-                _reject_output_column_collision(
-                    mask_carry_cols, INTERSECT_OUTPUT_COLUMNS
-                )
-                await _reject_ungroupable_overlay_columns(
-                    session, _schema, mask_table_name
-                )
             select_sql = _build_materialize_select(
                 src_ref,
                 operation,

--- a/backend/app/processing/analysis/tasks.py
+++ b/backend/app/processing/analysis/tasks.py
@@ -35,6 +35,7 @@ from app.platform.analysis_sql import (
     MAX_MASK_LAYER_FEATURES,
     MAX_SOURCE_FEATURES,
     MEASURE_OUTPUT_COLUMNS,
+    NON_GROUPABLE_COLUMN_TYPES,
     NOT_EMPTY_PREDICATE,
     render_clip_layer_join,
     render_geometry_expr,
@@ -394,6 +395,42 @@ def _reject_output_column_collision(
             f"{clashes[0]!r}, which this operation would overwrite. "
             "Rename it, or choose a different operation."
         )
+
+
+async def _reject_ungroupable_overlay_columns(
+    session: AsyncSession, schema: str, table_name: str
+) -> None:
+    """Worker-side half of the router's ungroupable-overlay guard.
+
+    fix(#1097 review): the enqueue guard reads ``column_info``, a catalog
+    snapshot, and a re-upload can replace the overlay between enqueue and the
+    job running — the same window ``_reject_output_column_collision`` exists
+    for, and the reason the carry-column list beside it is read live rather
+    than trusted from the snapshot. A replacement that introduces a json or xml
+    column would otherwise reach ``render_intersect_pairs``, which names every
+    carried overlay column in its GROUP BY, and fail the CTAS with SQLSTATE
+    42883.
+
+    Types, not names: reading the live names already happens and would not have
+    caught this, because the column that breaks the query is one whose NAME is
+    unremarkable.
+    """
+    rows = await session.execute(
+        text(
+            "SELECT column_name, data_type FROM information_schema.columns "
+            "WHERE table_schema = :schema AND table_name = :table_name "
+            "AND column_name NOT IN ('gid', 'geom', 'geom_4326') "
+            "ORDER BY ordinal_position"
+        ).bindparams(schema=schema, table_name=table_name)
+    )
+    for name, data_type in rows:
+        if str(data_type or "").lower() in NON_GROUPABLE_COLUMN_TYPES:
+            raise ValueError(
+                f"The overlay layer's column {name!r} has type "
+                f"{str(data_type).lower()!r}, which cannot be grouped, and an "
+                "overlay carries every overlay column onto its output. Choose "
+                "a different layer, or remove that column from it."
+            )
 
 
 async def _resolve_layer_table_ref(
@@ -982,6 +1019,9 @@ async def _materialize(
                 )
                 _reject_output_column_collision(
                     mask_carry_cols, INTERSECT_OUTPUT_COLUMNS
+                )
+                await _reject_ungroupable_overlay_columns(
+                    session, _schema, mask_table_name
                 )
             select_sql = _build_materialize_select(
                 src_ref,

--- a/backend/app/processing/analysis/tasks.py
+++ b/backend/app/processing/analysis/tasks.py
@@ -63,6 +63,13 @@ _SAFE_IDENT = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_]*$")
 _SAFE_TABLE = re.compile(r"^[a-z0-9_]+$")
 # Mirrors _POLYGONAL_TYPES in router_analysis: a mask layer must be polygonal.
 _POLYGONAL = {"POLYGON", "MULTIPOLYGON"}
+# Mirrors MASK_OPERATIONS in catalog/datasets/domain/schemas.py: the operations
+# whose second input can be a DRAWN polygon rather than a layer. Duplicated
+# rather than imported because processing/ must not import from
+# app.modules.catalog (PROCESS-02), the same reason _POLYGONAL is duplicated.
+# intersect is absent deliberately: it takes a layer only, so the discriminator
+# would be a constant there.
+_DRAWN_MASK_OPERATIONS = ("clip", "select_by_location")
 
 
 # The preview path is bounded (10s sandbox timeout, 500-row cap); the CTAS
@@ -1260,9 +1267,22 @@ async def _materialize(
                 params={
                     "distance_meters": distance_meters,
                     "by_field": by_field,
+                    # fix(#1097 review): every operation that can take a
+                    # DRAWN mask, not clip alone. The drawn geometry itself is
+                    # deliberately excluded from provenance (it can be
+                    # kilobytes), so for a drawn select_by_location this
+                    # discriminator was the only trace that an area shaped the
+                    # selection at all — without it those params serialise
+                    # empty and the lineage says a selection happened by no
+                    # visible means.
+                    #
+                    # The sibling of the job-metadata fix in the previous
+                    # round. That one was the writer the review named; this is
+                    # the other writer of the same fact, and fixing only the
+                    # named one is what left this behind.
                     "mask_source": (
                         ("layer" if mask_dataset_id else "drawn")
-                        if operation == "clip"
+                        if operation in _DRAWN_MASK_OPERATIONS
                         else None
                     ),
                     "mask_dataset_id": mask_dataset_id,

--- a/backend/app/processing/analysis/tasks.py
+++ b/backend/app/processing/analysis/tasks.py
@@ -547,7 +547,7 @@ async def _resolve_layer_table_ref(
     schema: str,
     *,
     label: str,
-    require_polygonal: bool = False,
+    require_geometry: str | None = None,
 ) -> tuple[str, str]:
     """Re-resolve a secondary layer at run time: ``(table_ref, table_name)``.
 
@@ -573,16 +573,33 @@ async def _resolve_layer_table_ref(
     if not _SAFE_TABLE.match(layer.table_name):
         raise ValueError(f"Invalid {label} table name")
     # fix(#1097 review): the geometry requirement is re-applied here, not just
-    # at enqueue. The router's _load_mask_dataset refuses a non-polygonal mask,
-    # but a re-upload can turn that layer into points or lines while the job
-    # waits in the queue — and the swap updates Dataset.geometry_type, so the
-    # stale value the router checked is not the one the CTAS would run against.
-    # Nothing downstream notices: the mask expression simply matches no rows,
-    # and the job dies on "Analysis produced no features", which sends the user
-    # looking at their data rather than at the layer that changed under them.
-    if require_polygonal and (layer.geometry_type or "").upper() not in _POLYGONAL:
+    # at enqueue. A re-upload can change what a layer IS while the job waits in
+    # the queue, and the swap updates Dataset.geometry_type, so the value the
+    # router checked is not the one the CTAS runs against.
+    #
+    # Two strengths, because the two layers want different things.
+    #
+    # "polygonal" is the mask's: _load_mask_dataset refuses points and lines,
+    # since unioning them produces a mask that clips nothing meaningful.
+    # Nothing downstream notices if that changes — the mask expression simply
+    # matches no rows, and the job dies on "Analysis produced no features",
+    # which sends the user to look at their own data rather than at the layer
+    # that changed underneath them.
+    #
+    # "any" is the join layer's. A spatial join counts in any direction, so
+    # points and lines stay valid and only the absence of geometry is fatal:
+    # a re-upload from a non-spatial source sets geometry_type to None and
+    # builds a table with no geom_4326 at all, and render_spatial_join
+    # references _j.geom_4326 (fix(#1097 review)).
+    geometry_type = (layer.geometry_type or "").upper()
+    if require_geometry == "polygonal" and geometry_type not in _POLYGONAL:
         raise ValueError(
             f"The {label} layer is no longer a polygon layer. It may have been "
+            "re-uploaded since this analysis was queued."
+        )
+    if require_geometry == "any" and not geometry_type:
+        raise ValueError(
+            f"The {label} layer no longer has geometry. It may have been "
             "re-uploaded since this analysis was queued."
         )
     return f'"{schema}"."{layer.table_name}"', layer.table_name
@@ -1085,7 +1102,7 @@ async def _materialize(
                     mask_dataset_id,
                     _schema,
                     label="mask",
-                    require_polygonal=True,
+                    require_geometry="polygonal",
                 )
             join_table_ref: str | None = None
             # fix(#1097 review): the plain name is kept now, not discarded. The
@@ -1095,7 +1112,12 @@ async def _materialize(
             join_table_name: str | None = None
             if join_dataset_id is not None:
                 join_table_ref, join_table_name = await _resolve_layer_table_ref(
-                    session, Dataset, join_dataset_id, _schema, label="join"
+                    session,
+                    Dataset,
+                    join_dataset_id,
+                    _schema,
+                    label="join",
+                    require_geometry="any",
                 )
 
             await _recheck_size_caps(

--- a/backend/app/processing/analysis/tasks.py
+++ b/backend/app/processing/analysis/tasks.py
@@ -38,6 +38,7 @@ from app.platform.analysis_sql import (
     MEASURE_OUTPUT_COLUMNS,
     NON_GROUPABLE_COLUMN_TYPES,
     NOT_EMPTY_PREDICATE,
+    linearized,
     render_clip_layer_join,
     render_geometry_expr,
     render_intersect_pairs,
@@ -916,7 +917,8 @@ def _build_materialize_select(
         measure_cols, measure_join = render_measure_columns(src="_src")
         cols = "".join(f"_src.{_sql_quote_ident(c)}, " for c in carry_cols)
         return _wrap_not_empty(
-            f"SELECT _src.gid, {cols}_src.geom_4326 AS geom, {measure_cols}"
+            f"SELECT _src.gid, {cols}{linearized('_src.geom_4326')} AS geom,"
+            f" {measure_cols}"
             f" FROM {src_ref} AS _src{measure_join}"
         )
     if operation == "spatial_join" and join_table_ref is not None:
@@ -929,7 +931,8 @@ def _build_materialize_select(
         )
         cols = "".join(f"_src.{_sql_quote_ident(c)}, " for c in carry_cols)
         return _wrap_not_empty(
-            f"SELECT _src.gid, {cols}_src.geom_4326 AS geom, {join_cols}"
+            f"SELECT _src.gid, {cols}{linearized('_src.geom_4326')} AS geom,"
+            f" {join_cols}"
             f" FROM {src_ref} AS _src{joins}"
         )
     if operation == "dissolve":
@@ -960,12 +963,12 @@ def _build_materialize_select(
         # geometry directly, which is what the output geometry IS.
         #
         # The DRAWN-mask half needs no branch at all: render_geometry_expr
-        # returns ("geom_4326", <where>) and the generic tail below is already
-        # the right shape.
+        # returns the linearized pass-through and its <where>, and the generic
+        # tail below is already the right shape.
         where = render_select_by_location_where(mask_table_ref, src="_src")
         cols = "".join(f"_src.{_sql_quote_ident(c)}, " for c in carry_cols)
         return _wrap_not_empty(
-            f"SELECT _src.gid, {cols}_src.geom_4326 AS geom"
+            f"SELECT _src.gid, {cols}{linearized('_src.geom_4326')} AS geom"
             f" FROM {src_ref} AS _src{where}"
         )
     if operation == "clip" and mask_table_ref is not None:

--- a/backend/app/processing/analysis/tasks.py
+++ b/backend/app/processing/analysis/tasks.py
@@ -31,12 +31,14 @@ from app.core.db.tenant_schema import tenant_data_schema
 from app.core.db.tenant_session import current_tenant_var, tenant_task
 from app.core.tenancy import is_multi_tenant
 from app.platform.analysis_sql import (
+    INTERSECT_OUTPUT_COLUMNS,
     MAX_MASK_LAYER_FEATURES,
     MAX_SOURCE_FEATURES,
     MEASURE_OUTPUT_COLUMNS,
     NOT_EMPTY_PREDICATE,
     render_clip_layer_join,
     render_geometry_expr,
+    render_intersect_pairs,
     render_measure_columns,
     render_select_by_location_where,
     render_spatial_join,
@@ -369,6 +371,8 @@ def _generated_columns(
         return MEASURE_OUTPUT_COLUMNS
     if operation == "spatial_join":
         return tuple(spatial_join_output_columns(join_fields))
+    if operation == "intersect":
+        return INTERSECT_OUTPUT_COLUMNS
     return ()
 
 
@@ -399,8 +403,12 @@ async def _resolve_layer_table_ref(
     schema: str,
     *,
     label: str,
-) -> str:
-    """Re-resolve a secondary layer's table ref at run time (fix(#953)).
+) -> tuple[str, str]:
+    """Re-resolve a secondary layer at run time: ``(table_ref, table_name)``.
+
+    fix(#953); fix(#956) added the bare name to the return, because an overlay
+    reads that layer's live columns out of ``information_schema``, which takes
+    a plain name rather than the quoted ref every other caller wants.
 
     Both two-layer operations need this — clip against a mask layer, and
     spatial_join against a join layer — with the same trust model: access was
@@ -419,7 +427,7 @@ async def _resolve_layer_table_ref(
         raise ValueError(f"{label.capitalize()} dataset not found")
     if not _SAFE_TABLE.match(layer.table_name):
         raise ValueError(f"Invalid {label} table name")
-    return f'"{schema}"."{layer.table_name}"'
+    return f'"{schema}"."{layer.table_name}"', layer.table_name
 
 
 async def _recheck_size_caps(
@@ -702,8 +710,23 @@ def _build_materialize_select(
     mask_table_ref: str | None = None,
     join_table_ref: str | None = None,
     join_fields: list[str] | None = None,
+    mask_carry_cols: list[str] | None = None,
 ) -> str:
     """Render the SELECT that produces the output table's rows."""
+    if operation == "intersect" and mask_table_ref is not None:
+        # fix(#956): the only branch whose output rows are not 1:1 with source
+        # rows, so it is also the only one besides dissolve that generates its
+        # own gid — the unconditional ADD PRIMARY KEY (gid) below would die on
+        # duplicates otherwise. The empty-geometry filter is inside the
+        # renderer for the same reason clip's is (fix(#719 review)):
+        # _enforce_output_size measures the CTAS before the post-CTAS DELETE
+        # can shrink it.
+        return render_intersect_pairs(
+            src_ref,
+            mask_table_ref,
+            src_columns=[_sql_quote_ident(c) for c in carry_cols],
+            mask_columns=[_sql_quote_ident(c) for c in (mask_carry_cols or [])],
+        )
     if operation == "measure":
         # fix(#954): the same renderer the preview uses, so a saved measurement
         # equals the one the user approved rather than being recomputed by a
@@ -895,20 +918,17 @@ async def _materialize(
             # Layer-sourced clip mask: re-resolve the table name at run time
             # (access was checked at enqueue by the router, same trust model
             # as the source dataset).
-            mask_table_ref = (
-                await _resolve_layer_table_ref(
+            mask_table_ref: str | None = None
+            mask_table_name: str | None = None
+            if mask_dataset_id is not None:
+                mask_table_ref, mask_table_name = await _resolve_layer_table_ref(
                     session, Dataset, mask_dataset_id, _schema, label="mask"
                 )
-                if mask_dataset_id is not None
-                else None
-            )
-            join_table_ref = (
-                await _resolve_layer_table_ref(
+            join_table_ref: str | None = None
+            if join_dataset_id is not None:
+                join_table_ref, _ = await _resolve_layer_table_ref(
                     session, Dataset, join_dataset_id, _schema, label="join"
                 )
-                if join_dataset_id is not None
-                else None
-            )
 
             await _recheck_size_caps(
                 session,
@@ -946,6 +966,23 @@ async def _materialize(
             _reject_output_column_collision(
                 carry_cols, _generated_columns(operation, join_fields)
             )
+            # fix(#956): an overlay carries columns from BOTH inputs, so it is
+            # the only operation that also needs the second layer's live column
+            # list — and the only one where two same-named columns are likely
+            # rather than exotic. Same two-sided story as the guard above: the
+            # router checked the catalog snapshot at enqueue, this re-checks the
+            # real columns after the queue wait.
+            mask_carry_cols: list[str] = []
+            if operation == "intersect" and mask_table_name is not None:
+                mask_carry_cols = await _list_carry_columns(
+                    session, _schema, mask_table_name
+                )
+                _reject_output_column_collision(
+                    carry_cols, (*mask_carry_cols, *INTERSECT_OUTPUT_COLUMNS)
+                )
+                _reject_output_column_collision(
+                    mask_carry_cols, INTERSECT_OUTPUT_COLUMNS
+                )
             select_sql = _build_materialize_select(
                 src_ref,
                 operation,
@@ -956,6 +993,7 @@ async def _materialize(
                 mask_table_ref=mask_table_ref,
                 join_table_ref=join_table_ref,
                 join_fields=join_fields,
+                mask_carry_cols=mask_carry_cols,
             )
             await session.execute(
                 text(f"SET LOCAL statement_timeout = '{materialize_timeout()}'")

--- a/backend/app/processing/analysis/tasks.py
+++ b/backend/app/processing/analysis/tasks.py
@@ -36,6 +36,8 @@ from app.platform.analysis_sql import (
     NOT_EMPTY_PREDICATE,
     render_clip_layer_join,
     render_geometry_expr,
+    render_spatial_join,
+    spatial_join_output_columns,
 )
 from app.processing.analysis.provenance import apply_analysis_provenance
 from app.platform.jobs.heartbeat import (
@@ -356,6 +358,36 @@ async def _count_features_bounded(
     return int(result.scalar_one())
 
 
+async def _resolve_layer_table_ref(
+    session: AsyncSession,
+    dataset_cls: Any,
+    dataset_id: str,
+    schema: str,
+    *,
+    label: str,
+) -> str:
+    """Re-resolve a secondary layer's table ref at run time (fix(#953)).
+
+    Both two-layer operations need this — clip against a mask layer, and
+    spatial_join against a join layer — with the same trust model: access was
+    checked at enqueue by the router, and the table name is re-matched against
+    ``_SAFE_TABLE`` here because the queue wait sits between the two.
+
+    ``dataset_cls`` is passed in rather than imported: ``processing/`` must not
+    import from ``app.modules.catalog.*`` (PROCESS-02), so the caller hands
+    over what it got from ``ProcessingPort.get_dataset_orm_class()``.
+    """
+    result = await session.execute(
+        select(dataset_cls).where(dataset_cls.id == uuid.UUID(dataset_id))
+    )
+    layer = result.scalar_one_or_none()
+    if layer is None or not layer.table_name:
+        raise ValueError(f"{label.capitalize()} dataset not found")
+    if not _SAFE_TABLE.match(layer.table_name):
+        raise ValueError(f"Invalid {label} table name")
+    return f'"{schema}"."{layer.table_name}"'
+
+
 async def _recheck_size_caps(
     session: AsyncSession,
     *,
@@ -634,8 +666,23 @@ def _build_materialize_select(
     by_field: str | None,
     carry_cols: list[str],
     mask_table_ref: str | None = None,
+    join_table_ref: str | None = None,
+    join_fields: list[str] | None = None,
 ) -> str:
     """Render the SELECT that produces the output table's rows."""
+    if operation == "spatial_join" and join_table_ref is not None:
+        # fix(#953): the same two laterals the preview uses, so the saved
+        # dataset and the approved preview agree row for row — including the
+        # tie-break, which is the difference between one output row per source
+        # feature and a duplicate-gid CTAS that dies on ADD PRIMARY KEY below.
+        join_cols, joins = render_spatial_join(
+            join_table_ref, src="_src", join_fields=join_fields
+        )
+        cols = "".join(f"_src.{_sql_quote_ident(c)}, " for c in carry_cols)
+        return _wrap_not_empty(
+            f"SELECT _src.gid, {cols}_src.geom_4326 AS geom, {join_cols}"
+            f" FROM {src_ref} AS _src{joins}"
+        )
     if operation == "dissolve":
         # ST_MakeValid: one invalid ring would abort the whole union.
         # ST_CollectionExtract: a union over mixed geometry types returns a
@@ -700,6 +747,8 @@ async def _materialize(
     mask: dict[str, Any] | None = None,
     mask_dataset_id: str | None = None,
     by_field: str | None = None,
+    join_dataset_id: str | None = None,
+    join_fields: list[str] | None = None,
 ) -> None:
     """Core materialize logic; separated from the task wrapper for tests."""
     from app.core.db import async_session
@@ -787,17 +836,20 @@ async def _materialize(
             # Layer-sourced clip mask: re-resolve the table name at run time
             # (access was checked at enqueue by the router, same trust model
             # as the source dataset).
-            mask_table_ref: str | None = None
-            if mask_dataset_id is not None:
-                mask_result = await session.execute(
-                    select(Dataset).where(Dataset.id == uuid.UUID(mask_dataset_id))
+            mask_table_ref = (
+                await _resolve_layer_table_ref(
+                    session, Dataset, mask_dataset_id, _schema, label="mask"
                 )
-                mask_ds = mask_result.scalar_one_or_none()
-                if mask_ds is None or not mask_ds.table_name:
-                    raise ValueError("Mask dataset not found")
-                if not _SAFE_TABLE.match(mask_ds.table_name):
-                    raise ValueError("Invalid mask table name")
-                mask_table_ref = f'"{_schema}"."{mask_ds.table_name}"'
+                if mask_dataset_id is not None
+                else None
+            )
+            join_table_ref = (
+                await _resolve_layer_table_ref(
+                    session, Dataset, join_dataset_id, _schema, label="join"
+                )
+                if join_dataset_id is not None
+                else None
+            )
 
             await _recheck_size_caps(
                 session,
@@ -832,6 +884,21 @@ async def _materialize(
                 if operation != "dissolve"
                 else []
             )
+            if operation == "spatial_join":
+                # The router 422s this at enqueue; repeating it here is the
+                # same defense-in-depth as re-matching _SAFE_IDENT above, and
+                # this is the one place holding the live column list. Without
+                # it the CTAS fails on "column specified more than once" after
+                # the whole queue wait (fix(#953)).
+                clashes = sorted(
+                    set(carry_cols) & set(spatial_join_output_columns(join_fields))
+                )
+                if clashes:
+                    raise ValueError(
+                        "The source dataset already has a column named "
+                        f"{clashes[0]!r}, which this join would overwrite. "
+                        "Rename it, or drop that field from the join."
+                    )
             select_sql = _build_materialize_select(
                 src_ref,
                 operation,
@@ -840,6 +907,8 @@ async def _materialize(
                 by_field=by_field,
                 carry_cols=carry_cols,
                 mask_table_ref=mask_table_ref,
+                join_table_ref=join_table_ref,
+                join_fields=join_fields,
             )
             await session.execute(
                 text(f"SET LOCAL statement_timeout = '{materialize_timeout()}'")
@@ -938,6 +1007,8 @@ async def _materialize(
                         else None
                     ),
                     "mask_dataset_id": mask_dataset_id,
+                    "join_dataset_id": join_dataset_id,
+                    "join_fields": join_fields or None,
                 },
             )
             await _complete_job_for_attempt(
@@ -1016,6 +1087,8 @@ async def materialize_analysis(
     mask: dict[str, Any] | None = None,
     mask_dataset_id: str | None = None,
     by_field: str | None = None,
+    join_dataset_id: str | None = None,
+    join_fields: list[str] | None = None,
 ) -> None:
     """Procrastinate entry point for async analysis materialization."""
     await _materialize(
@@ -1028,4 +1101,6 @@ async def materialize_analysis(
         mask=mask,
         mask_dataset_id=mask_dataset_id,
         by_field=by_field,
+        join_dataset_id=join_dataset_id,
+        join_fields=join_fields,
     )

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -866,6 +866,35 @@
             "description": "Buffer distance in meters (buffer only)",
             "title": "Distance Meters"
           },
+          "join_dataset_id": {
+            "anyOf": [
+              {
+                "format": "uuid",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Dataset to join against; each source feature gains a count of the features from it that intersect (spatial_join only)",
+            "title": "Join Dataset Id"
+          },
+          "join_fields": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "maxItems": 10,
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Columns to copy from the intersecting join feature, prefixed 'join_' in the output. Ties break on the lowest join-layer gid (spatial_join only)",
+            "title": "Join Fields"
+          },
           "mask": {
             "anyOf": [
               {
@@ -876,7 +905,7 @@
                 "type": "null"
               }
             ],
-            "description": "GeoJSON Polygon or MultiPolygon geometry in EPSG:4326 (clip only)",
+            "description": "GeoJSON Polygon or MultiPolygon geometry in EPSG:4326 (clip and select_by_location)",
             "title": "Mask"
           },
           "mask_dataset_id": {
@@ -889,7 +918,7 @@
                 "type": "null"
               }
             ],
-            "description": "Polygon dataset whose unioned features form the clip mask (clip only; alternative to mask)",
+            "description": "Polygon dataset supplying the mask geometry: the area clipped to, or selected against (clip and select_by_location; alternative to mask)",
             "title": "Mask Dataset Id"
           },
           "operation": {
@@ -897,7 +926,11 @@
               "buffer",
               "centroid",
               "clip",
-              "dissolve"
+              "dissolve",
+              "spatial_join",
+              "measure",
+              "select_by_location",
+              "intersect"
             ],
             "title": "Operation",
             "type": "string"
@@ -953,6 +986,35 @@
             "description": "Buffer distance in meters (buffer only)",
             "title": "Distance Meters"
           },
+          "join_dataset_id": {
+            "anyOf": [
+              {
+                "format": "uuid",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Dataset to join against; each source feature gains a count of the features from it that intersect (spatial_join only)",
+            "title": "Join Dataset Id"
+          },
+          "join_fields": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "maxItems": 10,
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Columns to copy from the intersecting join feature, prefixed 'join_' in the output. Ties break on the lowest join-layer gid (spatial_join only)",
+            "title": "Join Fields"
+          },
           "mask": {
             "anyOf": [
               {
@@ -963,7 +1025,7 @@
                 "type": "null"
               }
             ],
-            "description": "GeoJSON Polygon or MultiPolygon geometry in EPSG:4326 (clip only)",
+            "description": "GeoJSON Polygon or MultiPolygon geometry in EPSG:4326 (clip and select_by_location)",
             "title": "Mask"
           },
           "mask_dataset_id": {
@@ -976,14 +1038,18 @@
                 "type": "null"
               }
             ],
-            "description": "Polygon dataset whose unioned features form the clip mask (clip only; alternative to mask)",
+            "description": "Polygon dataset supplying the mask geometry: the area clipped to, or selected against (clip and select_by_location; alternative to mask)",
             "title": "Mask Dataset Id"
           },
           "operation": {
             "enum": [
               "buffer",
               "centroid",
-              "clip"
+              "clip",
+              "spatial_join",
+              "measure",
+              "select_by_location",
+              "intersect"
             ],
             "title": "Operation",
             "type": "string"
@@ -1020,6 +1086,18 @@
             "additionalProperties": true,
             "title": "Geojson",
             "type": "object"
+          },
+          "match_count": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Exact total across the WHOLE source, not just the previewed features: intersecting source/join feature PAIRS for spatial_join, selected source features for select_by_location. Null for other operations, and when the count could not be computed within the query budget",
+            "title": "Match Count"
           },
           "source_feature_count": {
             "anyOf": [

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -918,7 +918,7 @@
                 "type": "null"
               }
             ],
-            "description": "Polygon dataset supplying the mask geometry: the area clipped to, or selected against (clip and select_by_location; alternative to mask)",
+            "description": "Polygon dataset supplying the second layer: the area clipped to, selected against, or overlaid with. For clip and select_by_location it is the alternative to `mask`; for intersect it is REQUIRED and `mask` is rejected, because an overlay carries the second layer's attributes onto its output and a drawn polygon has none.",
             "title": "Mask Dataset Id"
           },
           "operation": {
@@ -1038,7 +1038,7 @@
                 "type": "null"
               }
             ],
-            "description": "Polygon dataset supplying the mask geometry: the area clipped to, or selected against (clip and select_by_location; alternative to mask)",
+            "description": "Polygon dataset supplying the second layer: the area clipped to, selected against, or overlaid with. For clip and select_by_location it is the alternative to `mask`; for intersect it is REQUIRED and `mask` is rejected, because an overlay carries the second layer's attributes onto its output and a drawn polygon has none.",
             "title": "Mask Dataset Id"
           },
           "operation": {

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -1096,7 +1096,7 @@
                 "type": "null"
               }
             ],
-            "description": "Exact total across the WHOLE source, not just the previewed features: intersecting source/join feature PAIRS for spatial_join, selected source features for select_by_location. Null for other operations, and when the count could not be computed within the query budget",
+            "description": "Exact total across the WHOLE source, not just the previewed features. What it counts is per-operation, so read it against the operation you sent rather than as one number: select_by_location gives the selected source features and intersect gives the output pieces, and for both of those it IS the output total; spatial_join gives intersecting source/join PAIRS, which is NOT the output total, because the join keeps every source row (use source_feature_count for that operation). Null for operations that report no such total, and when the count could not be computed within the query budget",
             "title": "Match Count"
           },
           "source_feature_count": {

--- a/backend/tests/test_analysis_curved_sources.py
+++ b/backend/tests/test_analysis_curved_sources.py
@@ -292,11 +292,14 @@ class TestBinaryJoinFields:
         admin_auth_header: dict,
         test_db_session: AsyncSession,
     ):
-        """A transferred bytea value arrives hex-encoded, not as raw bytes.
+        """Transferred bytea values arrive hex-encoded, not as raw bytes.
 
         Raw bytes raise inside Pydantic's JSON serializer, turning a valid
-        preview into a 500. The encoding matches ``to_jsonb``'s (which the
-        features browse API serves for the same column): ``\\x`` + hex.
+        preview into a 500 — and a ``bytea[]`` column comes back as a LIST of
+        bytes, so the encoder must recurse into containers, not just handle
+        the scalar (round-14 review). Both encodings match ``to_jsonb``'s
+        (which the features browse API serves for the same columns):
+        ``\\x`` + hex, and an array of the same.
         """
         admin_id = await get_user_id(test_db_session, "admin")
         points = await _create_layer(
@@ -315,14 +318,16 @@ class TestBinaryJoinFields:
             created_by=admin_id,
             column_type="Polygon",
             geometry_type="POLYGON",
-            extra_columns="blob BYTEA,",
+            extra_columns="blob BYTEA, blobs BYTEA[],",
             values_sql=(
                 "('zone', decode('deadbeef', 'hex'),"
+                " ARRAY[decode('dead', 'hex'), decode('beef', 'hex')],"
                 " ST_MakeEnvelope(0,0,1,1,4326), ST_MakeEnvelope(0,0,1,1,4326))"
             ),
             column_info=[
                 {"name": "name", "type": "text"},
                 {"name": "blob", "type": "bytea"},
+                {"name": "blobs", "type": "bytea[]"},
             ],
             feature_count=1,
         )
@@ -332,7 +337,7 @@ class TestBinaryJoinFields:
             json={
                 "operation": "spatial_join",
                 "join_dataset_id": str(polys.id),
-                "join_fields": ["blob"],
+                "join_fields": ["blob", "blobs"],
             },
             headers=admin_auth_header,
         )
@@ -340,3 +345,4 @@ class TestBinaryJoinFields:
         features = resp.json()["geojson"]["features"]
         assert len(features) == 1
         assert features[0]["properties"]["join_blob"] == "\\xdeadbeef"
+        assert features[0]["properties"]["join_blobs"] == ["\\xdead", "\\xbeef"]

--- a/backend/tests/test_analysis_curved_sources.py
+++ b/backend/tests/test_analysis_curved_sources.py
@@ -1,0 +1,342 @@
+"""Curved-geometry sources and binary property values (#1097 review).
+
+WFS ingest admits CURVED geometries — GeoServer MultiSurface/CompoundCurve
+layers load as stored, and ingest classifies the dataset by the closest
+concrete linear type without rewriting the rows (metadata.py's
+_ABSTRACT_TO_CONCRETE_GEOMETRY_TYPE). Verified against PostGIS 3.6:
+``::geography``, ``ST_MakeValid`` and ``ST_AsGeoJSON`` all RAISE on curved
+input, so without ``linearized()`` (analysis_sql) every operation in this file
+either 500s its preview or fails its CTAS on a dataset the app admits.
+
+The bytea test pins the OTHER preview serialization hazard from the same
+review round: a transferred ``bytea`` value reaching Pydantic as raw bytes.
+
+Requirements:
+  - Docker database must be running (docker compose up db)
+"""
+
+import uuid
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.processing.analysis.tasks import _materialize
+
+from tests.factories import get_user_id
+from tests.test_analysis_materialize import _create_job
+from tests.test_analysis_spatial_join import _create_layer
+
+# A full circle of radius 0.5 centred on (0.5, 0), stored as the curved
+# MULTISURFACE/CURVEPOLYGON type a GeoServer WFS layer ingests as.
+CURVED_POLYGON = (
+    "ST_GeomFromText('MULTISURFACE(CURVEPOLYGON(CIRCULARSTRING("
+    "0 0,0.5 0.5,1 0,0.5 -0.5,0 0)))', 4326)"
+)
+# A line with a genuine arc segment, stored as COMPOUNDCURVE.
+CURVED_LINE = (
+    "ST_GeomFromText('COMPOUNDCURVE((0 0,1 1),CIRCULARSTRING(1 1,2 2,3 1))', 4326)"
+)
+LINEAR_GEOJSON_TYPES = {
+    "Point",
+    "MultiPoint",
+    "LineString",
+    "MultiLineString",
+    "Polygon",
+    "MultiPolygon",
+    "GeometryCollection",
+}
+
+
+def _preview_url(dataset_id) -> str:
+    return f"/datasets/{dataset_id}/analysis/preview/"
+
+
+async def _create_curved_polygon_layer(session: AsyncSession, *, created_by):
+    return await _create_layer(
+        session,
+        created_by=created_by,
+        column_type="Geometry",
+        # What ingest records for a MultiSurface source (metadata.py).
+        geometry_type="MULTIPOLYGON",
+        values_sql=f"('circle', {CURVED_POLYGON}, {CURVED_POLYGON})",
+        feature_count=1,
+    )
+
+
+class TestCurvedSources:
+    async def test_measure_preview_answers_for_a_curved_source(
+        self,
+        client: AsyncClient,
+        admin_auth_header: dict,
+        test_db_session: AsyncSession,
+    ):
+        """A curved dataset measures instead of 500ing, with correct numbers.
+
+        Ground truth is PostGIS's own measure of the linearized geometry, so
+        the assertion pins the plumbing rather than circle-area maths.
+        """
+        admin_id = await get_user_id(test_db_session, "admin")
+        ds = await _create_layer(
+            test_db_session,
+            created_by=admin_id,
+            column_type="Geometry",
+            geometry_type="MULTIPOLYGON",
+            values_sql=(
+                f"('circle', {CURVED_POLYGON}, {CURVED_POLYGON}),"
+                f"('arc', {CURVED_LINE}, {CURVED_LINE})"
+            ),
+            feature_count=2,
+        )
+
+        resp = await client.post(
+            _preview_url(ds.id),
+            json={"operation": "measure"},
+            headers=admin_auth_header,
+        )
+        assert resp.status_code == 200, resp.text
+        features = resp.json()["geojson"]["features"]
+        got = {
+            f["properties"]["gid"]: (
+                f["properties"]["area_sqm"],
+                f["properties"]["length_m"],
+            )
+            for f in features
+        }
+        expected = {
+            gid: (a, ln)
+            for gid, a, ln in (
+                await test_db_session.execute(
+                    text(
+                        f"SELECT gid,"  # noqa: S608
+                        f" ST_Area(ST_CurveToLine(geom_4326)::geography),"
+                        f" ST_Length(ST_CurveToLine(geom_4326)::geography)"
+                        f" FROM data.{ds.table_name} ORDER BY gid"
+                    )
+                )
+            ).all()
+        }
+        assert set(got) == set(expected) == {1, 2}
+        for gid, (area, length) in got.items():
+            assert area == pytest.approx(expected[gid][0], rel=1e-6)
+            assert length == pytest.approx(expected[gid][1], rel=1e-6)
+        # The pass-through geometry serialized as a LINEAR GeoJSON type —
+        # GeoJSON has no curved types, so anything else could not have been
+        # emitted at all.
+        assert {f["geometry"]["type"] for f in features} <= LINEAR_GEOJSON_TYPES
+
+    async def test_spatial_join_preview_joins_onto_a_curved_source(
+        self,
+        client: AsyncClient,
+        admin_auth_header: dict,
+        test_db_session: AsyncSession,
+    ):
+        """The per-source-row ST_MakeValid hoist accepts a curved source."""
+        admin_id = await get_user_id(test_db_session, "admin")
+        src = await _create_curved_polygon_layer(test_db_session, created_by=admin_id)
+        points = await _create_layer(
+            test_db_session,
+            created_by=admin_id,
+            column_type="Point",
+            geometry_type="POINT",
+            values_sql=(
+                "('inside', ST_SetSRID(ST_MakePoint(0.5, 0.2), 4326),"
+                " ST_SetSRID(ST_MakePoint(0.5, 0.2), 4326)),"
+                "('outside', ST_SetSRID(ST_MakePoint(5, 5), 4326),"
+                " ST_SetSRID(ST_MakePoint(5, 5), 4326))"
+            ),
+            feature_count=2,
+        )
+
+        resp = await client.post(
+            _preview_url(src.id),
+            json={
+                "operation": "spatial_join",
+                "join_dataset_id": str(points.id),
+                "join_fields": ["name"],
+            },
+            headers=admin_auth_header,
+        )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        features = body["geojson"]["features"]
+        assert len(features) == 1
+        assert features[0]["properties"]["join_count"] == 1
+        assert features[0]["properties"]["join_name"] == "inside"
+        assert body["match_count"] == 1
+        assert features[0]["geometry"]["type"] in LINEAR_GEOJSON_TYPES
+
+    async def test_select_by_location_serializes_a_curved_selection(
+        self,
+        client: AsyncClient,
+        admin_auth_header: dict,
+        test_db_session: AsyncSession,
+    ):
+        """A drawn mask selecting a curved row must serialize that row."""
+        admin_id = await get_user_id(test_db_session, "admin")
+        src = await _create_curved_polygon_layer(test_db_session, created_by=admin_id)
+
+        resp = await client.post(
+            _preview_url(src.id),
+            json={
+                "operation": "select_by_location",
+                "mask": {
+                    "type": "Polygon",
+                    "coordinates": [[[-1, -1], [2, -1], [2, 1], [-1, 1], [-1, -1]]],
+                },
+            },
+            headers=admin_auth_header,
+        )
+        assert resp.status_code == 200, resp.text
+        features = resp.json()["geojson"]["features"]
+        assert [f["properties"]["gid"] for f in features] == [1]
+        assert features[0]["geometry"]["type"] in LINEAR_GEOJSON_TYPES
+
+    async def test_intersect_preview_with_curved_source_and_curved_mask(
+        self,
+        client: AsyncClient,
+        admin_auth_header: dict,
+        test_db_session: AsyncSession,
+    ):
+        """Both intersect wrap sites at once: curved mask prep, curved source.
+
+        The COMPOUNDCURVE source also pins the LINESTRING type check — read
+        raw it would say 'COMPOUNDCURVE', silently skipping ST_LineMerge, so a
+        LINEAR output type here proves the check reads the linearized form.
+        """
+        admin_id = await get_user_id(test_db_session, "admin")
+        src = await _create_layer(
+            test_db_session,
+            created_by=admin_id,
+            column_type="Geometry",
+            geometry_type="MULTILINESTRING",
+            values_sql=f"('arc', {CURVED_LINE}, {CURVED_LINE})",
+            feature_count=1,
+        )
+        # Curved TYPE with a plain square ring: still MultiSurface to every
+        # curve-intolerant function, which is what the mask pipeline must
+        # survive.
+        mask_wkt = "ST_GeomFromText('MULTISURFACE(((0 0,2 0,2 2,0 2,0 0)))', 4326)"
+        mask = await _create_layer(
+            test_db_session,
+            created_by=admin_id,
+            column_type="Geometry",
+            geometry_type="MULTIPOLYGON",
+            values_sql=f"('square', {mask_wkt}, {mask_wkt})",
+            feature_count=1,
+        )
+
+        resp = await client.post(
+            _preview_url(src.id),
+            json={"operation": "intersect", "mask_dataset_id": str(mask.id)},
+            headers=admin_auth_header,
+        )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        features = body["geojson"]["features"]
+        assert len(features) == 1
+        assert body["match_count"] == 1
+        assert features[0]["geometry"]["type"] in (
+            "LineString",
+            "MultiLineString",
+        )
+
+    async def test_materialize_saves_linear_geometry_from_a_curved_source(
+        self,
+        test_db_session: AsyncSession,
+    ):
+        """The CTAS stores the linearized geometry, not the curved original.
+
+        A curved geometry written into the derived table would fail that
+        LAYER's tiles and feature reads later — the whole reason the
+        pass-through output is linearized rather than only the casts.
+        """
+        admin_id = await get_user_id(test_db_session, "admin")
+        ds = await _create_curved_polygon_layer(test_db_session, created_by=admin_id)
+        job = await _create_job(test_db_session, admin_id)
+
+        await _materialize(
+            job_id=str(job.id),
+            dataset_id=str(ds.id),
+            user_id=str(admin_id),
+            operation="measure",
+            title=f"Curved measure {uuid.uuid4().hex[:6]}",
+        )
+
+        await test_db_session.refresh(job)
+        assert job.status == "complete", job.error_message
+
+        from app.modules.catalog.datasets.domain.models import Dataset
+
+        new_ds = await test_db_session.get(Dataset, job.dataset_id)
+        assert new_ds is not None
+        rows = (
+            await test_db_session.execute(
+                text(
+                    f"SELECT GeometryType(geom), area_sqm"  # noqa: S608
+                    f" FROM data.{new_ds.table_name}"
+                )
+            )
+        ).all()
+        assert len(rows) == 1
+        geom_type, area = rows[0]
+        assert geom_type in ("POLYGON", "MULTIPOLYGON")
+        assert area > 0
+
+
+class TestBinaryJoinFields:
+    async def test_spatial_join_preview_encodes_a_bytea_join_field(
+        self,
+        client: AsyncClient,
+        admin_auth_header: dict,
+        test_db_session: AsyncSession,
+    ):
+        """A transferred bytea value arrives hex-encoded, not as raw bytes.
+
+        Raw bytes raise inside Pydantic's JSON serializer, turning a valid
+        preview into a 500. The encoding matches ``to_jsonb``'s (which the
+        features browse API serves for the same column): ``\\x`` + hex.
+        """
+        admin_id = await get_user_id(test_db_session, "admin")
+        points = await _create_layer(
+            test_db_session,
+            created_by=admin_id,
+            column_type="Point",
+            geometry_type="POINT",
+            values_sql=(
+                "('probe', ST_SetSRID(ST_MakePoint(0.5, 0.5), 4326),"
+                " ST_SetSRID(ST_MakePoint(0.5, 0.5), 4326))"
+            ),
+            feature_count=1,
+        )
+        polys = await _create_layer(
+            test_db_session,
+            created_by=admin_id,
+            column_type="Polygon",
+            geometry_type="POLYGON",
+            extra_columns="blob BYTEA,",
+            values_sql=(
+                "('zone', decode('deadbeef', 'hex'),"
+                " ST_MakeEnvelope(0,0,1,1,4326), ST_MakeEnvelope(0,0,1,1,4326))"
+            ),
+            column_info=[
+                {"name": "name", "type": "text"},
+                {"name": "blob", "type": "bytea"},
+            ],
+            feature_count=1,
+        )
+
+        resp = await client.post(
+            _preview_url(points.id),
+            json={
+                "operation": "spatial_join",
+                "join_dataset_id": str(polys.id),
+                "join_fields": ["blob"],
+            },
+            headers=admin_auth_header,
+        )
+        assert resp.status_code == 200, resp.text
+        features = resp.json()["geojson"]["features"]
+        assert len(features) == 1
+        assert features[0]["properties"]["join_blob"] == "\\xdeadbeef"

--- a/backend/tests/test_analysis_intersect.py
+++ b/backend/tests/test_analysis_intersect.py
@@ -17,6 +17,7 @@ Requirements:
 """
 
 import uuid
+from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
@@ -755,6 +756,45 @@ class TestColumnCollisions:
         )
         assert resp.status_code == 422
         assert INTERSECT_SOURCE_GID_COLUMN in resp.text
+
+
+class TestJobMetadata:
+    """fix(#1097 review): Admin Jobs reads this to diagnose a failed run."""
+
+    def _meta(self, operation: str, **kwargs):
+        from app.modules.catalog.datasets.api.router_analysis import (
+            _build_analysis_job_metadata,
+        )
+        from app.modules.catalog.datasets.domain.schemas import (
+            AnalysisMaterializeRequest,
+        )
+
+        body = AnalysisMaterializeRequest(operation=operation, title="t", **kwargs)
+        return _build_analysis_job_metadata(
+            body, SimpleNamespace(id=uuid.uuid4(), table_name="src")
+        )
+
+    def test_every_operation_that_takes_a_layer_records_it(self):
+        """It was recorded for clip alone. select_by_location and intersect are
+        both driven by a second layer, so a run that failed BECAUSE of that
+        layer — re-uploaded mid-queue, wrong geometry, ungroupable column —
+        showed an operator only the operation, the source and the title."""
+        layer_id = uuid.uuid4()
+        for operation in ("clip", "select_by_location", "intersect"):
+            meta = self._meta(operation, mask_dataset_id=layer_id)
+            assert meta["mask_dataset_id"] == str(layer_id), operation
+
+    def test_the_drawn_marker_stays_where_a_drawn_mask_is_possible(self):
+        """mask_source discriminates drawn from layer, so it belongs only to
+        the operations that accept a drawn mask. intersect rejects one, and a
+        constant dressed as a discriminator is worse than its absence."""
+        layer_id = uuid.uuid4()
+        assert self._meta("clip", mask_dataset_id=layer_id)["mask_source"] == "layer"
+        assert (
+            self._meta("select_by_location", mask_dataset_id=layer_id)["mask_source"]
+            == "layer"
+        )
+        assert "mask_source" not in self._meta("intersect", mask_dataset_id=layer_id)
 
 
 class TestAccessControl:

--- a/backend/tests/test_analysis_intersect.py
+++ b/backend/tests/test_analysis_intersect.py
@@ -600,7 +600,7 @@ class TestColumnCollisions:
                 str(zones.id),
                 "data",
                 label="mask",
-                require_polygonal=True,
+                require_geometry="polygonal",
             )
         assert "polygon" in str(excinfo.value).lower()
 
@@ -622,7 +622,7 @@ class TestColumnCollisions:
             str(zones.id),
             "data",
             label="mask",
-            require_polygonal=True,
+            require_geometry="polygonal",
         )
         assert name == zones.table_name
 

--- a/backend/tests/test_analysis_intersect.py
+++ b/backend/tests/test_analysis_intersect.py
@@ -686,6 +686,49 @@ class TestColumnCollisions:
             test_db_session, "data", zones.table_name
         )
 
+    async def test_a_json_array_overlay_column_is_rejected_with_its_real_type(
+        self, test_db_session: AsyncSession
+    ):
+        """fix(#1097 review): arrays hide their element type from data_type.
+
+        information_schema reports a json[] column's data_type as 'ARRAY', so
+        the exact comparison the scalar guard makes never fires, and the
+        snapshot the router reads has the same blind spot — this recheck is
+        the ONLY layer that can see the element type (udt_name '_json').
+        GROUP BY on json[] fails with SQLSTATE 42883 exactly like scalar json.
+        int[] has equality and must still pass, so the check names elements,
+        not arrays.
+        """
+        from app.processing.analysis.tasks import (
+            _reject_ungroupable_overlay_columns,
+        )
+
+        admin_id = await get_user_id(test_db_session, "admin")
+        zones = await _create_zones(test_db_session, created_by=admin_id)
+        await test_db_session.execute(
+            text(
+                f"ALTER TABLE data.{zones.table_name} "  # noqa: S608
+                f"ADD COLUMN props json[], ADD COLUMN tags int[]"
+            )
+        )
+        await test_db_session.commit()
+
+        with pytest.raises(ValueError) as excinfo:
+            await _reject_ungroupable_overlay_columns(
+                test_db_session, "data", zones.table_name
+            )
+        assert "props" in str(excinfo.value)
+        assert "json[]" in str(excinfo.value)
+
+        # int[] alone passes: drop the hostile column and the layer is fine.
+        await test_db_session.execute(
+            text(f"ALTER TABLE data.{zones.table_name} DROP COLUMN props")  # noqa: S608
+        )
+        await test_db_session.commit()
+        await _reject_ungroupable_overlay_columns(
+            test_db_session, "data", zones.table_name
+        )
+
     def test_an_ungroupable_SOURCE_column_is_still_allowed(self):
         """The guard is deliberately one-sided, so pin the side it lets through.
 

--- a/backend/tests/test_analysis_intersect.py
+++ b/backend/tests/test_analysis_intersect.py
@@ -472,6 +472,58 @@ class TestColumnCollisions:
         assert "props" in resp.text
         assert "json" in resp.text
 
+    async def test_an_overlay_that_gains_a_json_column_after_enqueue_is_caught(
+        self, test_db_session: AsyncSession
+    ):
+        """fix(#1097 review): the enqueue guard reads a catalog SNAPSHOT.
+
+        A re-upload can replace the overlay between enqueue and the job
+        running, so a layer that passed the router can be grouping-hostile by
+        the time the worker builds the CTAS. That is the same window
+        _reject_output_column_collision exists for, and why the carry-column
+        list beside it is read live rather than trusted from column_info.
+
+        Types, not names: the live NAME list is already read here and would not
+        have caught this, because the column that breaks the query has a
+        perfectly ordinary name.
+        """
+        from app.processing.analysis.tasks import (
+            _reject_ungroupable_overlay_columns,
+        )
+
+        admin_id = await get_user_id(test_db_session, "admin")
+        zones = await _create_zones(test_db_session, created_by=admin_id)
+        # column_info still says text-only — the snapshot the router would read.
+        assert all(c.get("type") != "json" for c in (zones.column_info or [])), (
+            "fixture drifted: the snapshot must look clean for this to mean anything"
+        )
+        await test_db_session.execute(
+            text(f"ALTER TABLE data.{zones.table_name} ADD COLUMN props json")  # noqa: S608
+        )
+        await test_db_session.commit()
+
+        with pytest.raises(ValueError) as excinfo:
+            await _reject_ungroupable_overlay_columns(
+                test_db_session, "data", zones.table_name
+            )
+        assert "props" in str(excinfo.value)
+        assert "json" in str(excinfo.value)
+
+    async def test_a_groupable_overlay_passes_the_live_recheck(
+        self, test_db_session: AsyncSession
+    ):
+        """The negative control: the live recheck must not refuse ordinary
+        layers, or every intersect would fail at the worker."""
+        from app.processing.analysis.tasks import (
+            _reject_ungroupable_overlay_columns,
+        )
+
+        admin_id = await get_user_id(test_db_session, "admin")
+        zones = await _create_zones(test_db_session, created_by=admin_id)
+        await _reject_ungroupable_overlay_columns(
+            test_db_session, "data", zones.table_name
+        )
+
     def test_an_ungroupable_SOURCE_column_is_still_allowed(self):
         """The guard is deliberately one-sided, so pin the side it lets through.
 

--- a/backend/tests/test_analysis_intersect.py
+++ b/backend/tests/test_analysis_intersect.py
@@ -570,6 +570,69 @@ class TestColumnCollisions:
         assert carry == ["parcel"]
         assert mask_carry == ["zone"]
 
+    async def test_an_overlay_that_stops_being_polygonal_is_caught(
+        self, test_db_session: AsyncSession
+    ):
+        """fix(#1097 review): the polygon requirement is re-applied live.
+
+        The router refuses a non-polygonal mask at enqueue, but a re-upload can
+        turn that layer into points or lines while the job waits — and the swap
+        updates Dataset.geometry_type, so the value the router checked is not
+        the one the CTAS would run against.
+
+        Nothing downstream notices on its own: the mask expression simply
+        matches no rows and the job dies on "Analysis produced no features",
+        which sends the user looking at their own data rather than at the layer
+        that changed underneath them.
+        """
+        from app.modules.catalog.datasets.domain.models import Dataset
+        from app.processing.analysis.tasks import _resolve_layer_table_ref
+
+        admin_id = await get_user_id(test_db_session, "admin")
+        zones = await _create_zones(test_db_session, created_by=admin_id)
+        zones.geometry_type = "POINT"
+        await test_db_session.commit()
+
+        with pytest.raises(ValueError) as excinfo:
+            await _resolve_layer_table_ref(
+                test_db_session,
+                Dataset,
+                str(zones.id),
+                "data",
+                label="mask",
+                require_polygonal=True,
+            )
+        assert "polygon" in str(excinfo.value).lower()
+
+    async def test_a_polygonal_overlay_passes_the_live_geometry_recheck(
+        self, test_db_session: AsyncSession
+    ):
+        """The negative control, and the guard on the flag: an unchanged
+        polygon layer resolves, and a JOIN layer is not held to this rule at
+        all (a spatial join counts in any direction — see the spatial-join
+        picker, which offers points)."""
+        from app.modules.catalog.datasets.domain.models import Dataset
+        from app.processing.analysis.tasks import _resolve_layer_table_ref
+
+        admin_id = await get_user_id(test_db_session, "admin")
+        zones = await _create_zones(test_db_session, created_by=admin_id)
+        ref, name = await _resolve_layer_table_ref(
+            test_db_session,
+            Dataset,
+            str(zones.id),
+            "data",
+            label="mask",
+            require_polygonal=True,
+        )
+        assert name == zones.table_name
+
+        zones.geometry_type = "POINT"
+        await test_db_session.commit()
+        # Same layer, same non-polygon type, resolved WITHOUT the flag: fine.
+        await _resolve_layer_table_ref(
+            test_db_session, Dataset, str(zones.id), "data", label="join"
+        )
+
     async def test_an_overlay_that_gains_a_json_column_after_enqueue_is_caught(
         self, test_db_session: AsyncSession
     ):

--- a/backend/tests/test_analysis_intersect.py
+++ b/backend/tests/test_analysis_intersect.py
@@ -19,6 +19,8 @@ Requirements:
 import uuid
 from unittest.mock import patch
 
+import pytest
+from fastapi import HTTPException
 from httpx import AsyncClient
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -424,6 +426,84 @@ class TestColumnCollisions:
         )
         assert resp.status_code == 422
         assert "name" in resp.text
+
+    async def test_an_ungroupable_overlay_column_is_rejected_at_enqueue(
+        self,
+        client: AsyncClient,
+        admin_auth_header: dict,
+        test_db_session: AsyncSession,
+    ):
+        """fix(#1097 review): json and xml have no equality operator.
+
+        render_intersect_pairs groups by the two gids plus every carried
+        OVERLAY column — the source's columns ride the functional dependency on
+        _src.gid, but _mask_pieces is a CTE with no key, so its columns must be
+        named in the GROUP BY. Grouping on json fails the CTAS with SQLSTATE
+        42883, and it fails only there: the preview carries gid and source_gid
+        alone, so it succeeds first and the operation dies after the queue wait
+        quoting a generated alias the user never wrote.
+        """
+        admin_id = await get_user_id(test_db_session, "admin")
+        zones = await _create_zones(test_db_session, created_by=admin_id)
+        bar = await _create_bar(test_db_session, created_by=admin_id)
+        # Physical column AND catalog snapshot: the guard reads column_info,
+        # and the worker that would hit 42883 reads the live table.
+        await test_db_session.execute(
+            text(f"ALTER TABLE data.{zones.table_name} ADD COLUMN props json")  # noqa: S608
+        )
+        zones.column_info = [
+            {"name": "zone", "type": "text"},
+            {"name": "props", "type": "json"},
+        ]
+        await test_db_session.commit()
+
+        resp = await client.post(
+            _materialize_url(bar.id),
+            json={
+                "operation": "intersect",
+                "mask_dataset_id": str(zones.id),
+                "title": "Nope",
+            },
+            headers=admin_auth_header,
+        )
+        assert resp.status_code == 422
+        # Names the column and its type: "cannot be grouped" with no referent
+        # sends the operator looking through both layers by hand.
+        assert "props" in resp.text
+        assert "json" in resp.text
+
+    def test_an_ungroupable_SOURCE_column_is_still_allowed(self):
+        """The guard is deliberately one-sided, so pin the side it lets through.
+
+        A json column on the SOURCE never reaches the GROUP BY: _src.gid is a
+        real table's primary key, so PostgreSQL licenses every other _src
+        column by functional dependency. Rejecting both sides would refuse
+        overlays that work.
+
+        Against the validator rather than the endpoint: enqueueing needs the
+        task queue, so an HTTP assertion here would be reading a 503 from the
+        broker as evidence about column rules.
+        """
+        from types import SimpleNamespace
+
+        from app.modules.catalog.datasets.api.router_analysis import (
+            _validate_intersect_columns,
+        )
+
+        source = SimpleNamespace(
+            column_info=[
+                {"name": "parcel", "type": "text"},
+                {"name": "props", "type": "json"},
+            ]
+        )
+        overlay = SimpleNamespace(column_info=[{"name": "zone", "type": "text"}])
+        _validate_intersect_columns(source, overlay)
+
+        # And the mirror image is refused, which is what makes the pass above
+        # a statement about WHICH side rather than about json in general.
+        with pytest.raises(HTTPException) as excinfo:
+            _validate_intersect_columns(overlay, source)
+        assert "props" in str(excinfo.value.detail)
 
     async def test_a_source_column_named_source_gid_is_rejected(
         self,

--- a/backend/tests/test_analysis_intersect.py
+++ b/backend/tests/test_analysis_intersect.py
@@ -472,6 +472,104 @@ class TestColumnCollisions:
         assert "props" in resp.text
         assert "json" in resp.text
 
+    async def test_an_overlay_column_in_the_alias_namespace_is_rejected(
+        self,
+        client: AsyncClient,
+        admin_auth_header: dict,
+        test_db_session: AsyncSession,
+    ):
+        """fix(#1097 review): the output guards reserved OUTPUT names only.
+
+        render_intersect_pairs invents internal aliases on the way to that
+        output, and a carried column of the same name lands in the same select
+        list: `SELECT _o.gid AS _gl_mask_gid, "_gl_mask_gid"`. The later
+        reference is then ambiguous and the CTAS fails after the queue wait,
+        quoting a name the user never chose.
+
+        The aliases live in a reserved PREFIX now and the prefix is what is
+        rejected, so an alias added to that query later is covered without a
+        list to keep in step.
+        """
+        admin_id = await get_user_id(test_db_session, "admin")
+        bar = await _create_bar(test_db_session, created_by=admin_id)
+        zones = await _create_zones(test_db_session, created_by=admin_id)
+        zones.column_info = [
+            {"name": "zone", "type": "text"},
+            {"name": "_gl_mask_gid", "type": "integer"},
+        ]
+        await test_db_session.commit()
+
+        resp = await client.post(
+            _materialize_url(bar.id),
+            json={
+                "operation": "intersect",
+                "mask_dataset_id": str(zones.id),
+                "title": "Nope",
+            },
+            headers=admin_auth_header,
+        )
+        assert resp.status_code == 422
+        assert "_gl_" in resp.text
+
+    async def test_the_alias_prefix_guard_runs_again_on_live_columns(
+        self, test_db_session: AsyncSession
+    ):
+        """The worker half, for the re-upload window. Same reasoning as the
+        ungroupable-type recheck below it: the router read a snapshot.
+
+        Driven through _resolve_and_validate_columns rather than the leaf
+        guard. Calling the guard directly proves it rejects a bad list and
+        proves nothing about whether anything hands it one — deleting the call
+        site left such a test green, which is how this test was written the
+        first time.
+        """
+        from app.processing.analysis.tasks import _resolve_and_validate_columns
+
+        admin_id = await get_user_id(test_db_session, "admin")
+        bar = await _create_bar(test_db_session, created_by=admin_id)
+        zones = await _create_zones(test_db_session, created_by=admin_id)
+        await test_db_session.execute(
+            text(
+                f"ALTER TABLE data.{zones.table_name} "  # noqa: S608
+                f"ADD COLUMN _gl_src_type TEXT"
+            )
+        )
+        await test_db_session.commit()
+
+        with pytest.raises(ValueError) as excinfo:
+            await _resolve_and_validate_columns(
+                test_db_session,
+                schema="data",
+                operation="intersect",
+                src_table_name=bar.table_name,
+                mask_table_name=zones.table_name,
+                join_table_name=None,
+                join_fields=None,
+            )
+        assert "_gl_" in str(excinfo.value)
+
+    async def test_ordinary_overlay_columns_pass_the_alias_guard(
+        self, test_db_session: AsyncSession
+    ):
+        """The negative control, through the same entry point."""
+        from app.processing.analysis.tasks import _resolve_and_validate_columns
+
+        admin_id = await get_user_id(test_db_session, "admin")
+        bar = await _create_bar(test_db_session, created_by=admin_id)
+        zones = await _create_zones(test_db_session, created_by=admin_id)
+
+        carry, mask_carry = await _resolve_and_validate_columns(
+            test_db_session,
+            schema="data",
+            operation="intersect",
+            src_table_name=bar.table_name,
+            mask_table_name=zones.table_name,
+            join_table_name=None,
+            join_fields=None,
+        )
+        assert carry == ["parcel"]
+        assert mask_carry == ["zone"]
+
     async def test_an_overlay_that_gains_a_json_column_after_enqueue_is_caught(
         self, test_db_session: AsyncSession
     ):

--- a/backend/tests/test_analysis_intersect.py
+++ b/backend/tests/test_analysis_intersect.py
@@ -88,7 +88,11 @@ async def _create_zones(
 
 
 async def _create_bar(
-    session: AsyncSession, *, created_by: uuid.UUID, visibility: str = "public"
+    session: AsyncSession,
+    *,
+    created_by: uuid.UUID,
+    visibility: str = "public",
+    wkt: str = BAR_WKT,
 ):
     bar = await _create_layer(
         session,
@@ -97,8 +101,7 @@ async def _create_bar(
         geometry_type="POLYGON",
         visibility=visibility,
         values_sql=(
-            f"('bar', ST_GeomFromText('{BAR_WKT}', 4326),"
-            f" ST_GeomFromText('{BAR_WKT}', 4326))"
+            f"('bar', ST_GeomFromText('{wkt}', 4326), ST_GeomFromText('{wkt}', 4326))"
         ),
         column_info=[{"name": "parcel", "type": "text"}],
     )
@@ -295,6 +298,43 @@ class TestPreview:
         assert body["source_feature_count"] is None
         # The exact pair total rides the same statement as a window column.
         assert body["match_count"] == 3
+
+    async def test_match_count_is_zero_not_null_when_nothing_overlaps(
+        self,
+        client: AsyncClient,
+        admin_auth_header: dict,
+        test_db_session: AsyncSession,
+    ):
+        """fix(#1097 review): an empty result is an ANSWER, not a failure.
+
+        match_count is null in the contract when the total could not be
+        computed — a timed-out count. intersect's total rides its preview
+        statement as a window column, so with no overlapping pairs there is no
+        row to read it off, and it defaulted to null. That made "these two
+        layers do not overlap" (an ordinary result) indistinguishable from
+        "the server gave up", and the panel renders those differently.
+        """
+        admin_id = await get_user_id(test_db_session, "admin")
+        zones = await _create_zones(test_db_session, created_by=admin_id)
+        # Same shape as the overlapping fixture, parked far away: the query
+        # runs and returns cleanly, it just finds nothing.
+        far = await _create_bar(
+            test_db_session,
+            created_by=admin_id,
+            wkt="POLYGON((100 40, 101 40, 101 41, 100 41, 100 40))",
+        )
+
+        resp = await client.post(
+            _preview_url(far.id),
+            json={"operation": "intersect", "mask_dataset_id": str(zones.id)},
+            headers=admin_auth_header,
+        )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["geojson"]["features"] == []
+        assert body["feature_count"] == 0
+        assert body["match_count"] == 0, "zero pairs is a computed answer"
+        assert body["match_count"] is not None
 
     async def test_match_count_is_exact_beyond_the_preview_cap(
         self,

--- a/backend/tests/test_analysis_intersect.py
+++ b/backend/tests/test_analysis_intersect.py
@@ -1,0 +1,560 @@
+"""Intersect/overlay: new geometry from two layers (#956).
+
+One test per acceptance criterion on the issue.
+
+The fixture throughout is a 3x1 bar laid across three side-by-side unit
+squares. It is the shape that separates an overlay from a clip: a clip returns
+ONE feature (the bar trimmed to the union of the zones), an overlay returns
+THREE, each carrying its own zone's attributes.
+
+    +---+---+---+
+    | A | B | C |   mask: three 1x1 zones
+    +---+---+---+
+    #############   source: one 3x1 bar crossing all three
+
+Requirements:
+  - Docker database must be running (docker compose up db)
+"""
+
+import uuid
+from unittest.mock import patch
+
+from httpx import AsyncClient
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.platform.analysis_sql import (
+    INTERSECT_SOURCE_GID_COLUMN,
+    MAX_SOURCE_FEATURES,
+)
+from app.processing.analysis.tasks import _materialize
+
+from tests.factories import get_user_id
+from tests.test_analysis_materialize import _create_job
+from tests.test_analysis_spatial_join import _create_layer
+
+BAR_WKT = "POLYGON((0 0, 3 0, 3 1, 0 1, 0 0))"
+
+
+def _preview_url(dataset_id) -> str:
+    return f"/datasets/{dataset_id}/analysis/preview/"
+
+
+def _materialize_url(dataset_id) -> str:
+    return f"/datasets/{dataset_id}/analysis/materialize/"
+
+
+def _zone_values(count: int = 3) -> str:
+    """``count`` side-by-side unit squares named A, B, C, ..."""
+    return ",".join(
+        f"('{chr(65 + i)}',"
+        f" ST_MakeEnvelope({i}, 0, {i + 1}, 1, 4326),"
+        f" ST_MakeEnvelope({i}, 0, {i + 1}, 1, 4326))"
+        for i in range(count)
+    )
+
+
+async def _create_zones(
+    session: AsyncSession,
+    *,
+    created_by: uuid.UUID,
+    count: int = 3,
+    visibility: str = "public",
+    name_column: str = "zone",
+):
+    zones = await _create_layer(
+        session,
+        created_by=created_by,
+        column_type="Geometry",
+        geometry_type="POLYGON",
+        visibility=visibility,
+        feature_count=count,
+        values_sql=_zone_values(count),
+        column_info=[{"name": name_column, "type": "text"}],
+    )
+    # The shared helper always creates a physical "name" column, and the worker
+    # reads LIVE columns rather than column_info — so without this both layers
+    # would carry "name" and the collision guard would (correctly) reject every
+    # overlay. Rename to whatever this fixture claims in column_info.
+    if name_column != "name":
+        await session.execute(
+            text(
+                f"ALTER TABLE data.{zones.table_name} "  # noqa: S608
+                f"RENAME COLUMN name TO {name_column}"
+            )
+        )
+        await session.commit()
+    return zones
+
+
+async def _create_bar(
+    session: AsyncSession, *, created_by: uuid.UUID, visibility: str = "public"
+):
+    bar = await _create_layer(
+        session,
+        created_by=created_by,
+        column_type="Geometry",
+        geometry_type="POLYGON",
+        visibility=visibility,
+        values_sql=(
+            f"('bar', ST_GeomFromText('{BAR_WKT}', 4326),"
+            f" ST_GeomFromText('{BAR_WKT}', 4326))"
+        ),
+        column_info=[{"name": "parcel", "type": "text"}],
+    )
+    await session.execute(
+        text(
+            f"ALTER TABLE data.{bar.table_name} "  # noqa: S608
+            "RENAME COLUMN name TO parcel"
+        )
+    )
+    await session.commit()
+    return bar
+
+
+class TestPairwiseRows:
+    async def test_one_source_over_three_zones_yields_three_rows(
+        self,
+        test_db_session: AsyncSession,
+    ):
+        """Criterion 3, the one that distinguishes this from clip.
+
+        Clip aggregates every mask piece back to one geometry per source row.
+        An overlay must not: three zones, three rows, each carrying ITS zone's
+        attribute and only its own third of the bar.
+        """
+        admin_id = await get_user_id(test_db_session, "admin")
+        zones = await _create_zones(test_db_session, created_by=admin_id)
+        bar = await _create_bar(test_db_session, created_by=admin_id)
+        job = await _create_job(test_db_session, admin_id)
+
+        await _materialize(
+            job_id=str(job.id),
+            dataset_id=str(bar.id),
+            user_id=str(admin_id),
+            operation="intersect",
+            title=f"Overlay {uuid.uuid4().hex[:6]}",
+            mask_dataset_id=str(zones.id),
+        )
+        await test_db_session.refresh(job)
+        assert job.status == "complete", job.error_message
+
+        from app.modules.catalog.datasets.domain.models import Dataset
+
+        out = await test_db_session.get(Dataset, job.dataset_id)
+        assert out is not None
+        assert out.feature_count == 3
+
+        rows = (
+            await test_db_session.execute(
+                text(
+                    f"SELECT gid, source_gid, parcel, zone, ST_Area(geom_4326)"  # noqa: S608
+                    f" FROM data.{out.table_name} ORDER BY zone"
+                )
+            )
+        ).all()
+        assert [r[3] for r in rows] == ["A", "B", "C"]
+        # Every row traces back to the one source feature...
+        assert {r[1] for r in rows} == {1}
+        assert {r[2] for r in rows} == {"bar"}
+        # ...and each carries a third of the bar, not the whole thing.
+        for row in rows:
+            assert row[4] == 1.0
+
+    async def test_the_output_gid_is_generated_not_the_source_gid(
+        self,
+        test_db_session: AsyncSession,
+    ):
+        """Criterion 2: three rows sharing one source gid would fail the
+        unconditional ADD PRIMARY KEY (gid) outright — the job dies, it is not
+        a subtle data-quality issue. Pinned at materialize, where the ALTER
+        actually runs, not just in a preview."""
+        admin_id = await get_user_id(test_db_session, "admin")
+        zones = await _create_zones(test_db_session, created_by=admin_id)
+        bar = await _create_bar(test_db_session, created_by=admin_id)
+        job = await _create_job(test_db_session, admin_id)
+
+        await _materialize(
+            job_id=str(job.id),
+            dataset_id=str(bar.id),
+            user_id=str(admin_id),
+            operation="intersect",
+            title=f"Keyed {uuid.uuid4().hex[:6]}",
+            mask_dataset_id=str(zones.id),
+        )
+        await test_db_session.refresh(job)
+        assert job.status == "complete", job.error_message
+
+        from app.modules.catalog.datasets.domain.models import Dataset
+
+        out = await test_db_session.get(Dataset, job.dataset_id)
+        gids = (
+            (
+                await test_db_session.execute(
+                    text(f"SELECT gid FROM data.{out.table_name} ORDER BY gid")  # noqa: S608
+                )
+            )
+            .scalars()
+            .all()
+        )
+        assert list(gids) == [1, 2, 3], "generated key, contiguous, no duplicates"
+
+        pk_count = (
+            await test_db_session.execute(
+                text(
+                    "SELECT count(*) FROM pg_constraint "
+                    "WHERE conrelid = ('data.' || :t)::regclass AND contype = 'p'"
+                ).bindparams(t=out.table_name)
+            )
+        ).scalar_one()
+        assert pk_count == 1
+
+    async def test_a_mask_polygon_that_subdivides_still_yields_one_row(
+        self,
+        test_db_session: AsyncSession,
+    ):
+        """The trap inside the trap.
+
+        The mask is subdivided into <=256-vertex pieces for the performance
+        reason render_clip_layer_join documents. Grouping by piece instead of
+        by mask FEATURE would silently multiply the output by however many
+        pieces a polygon happened to split into. This zone is a single ~2000-
+        vertex circle, so it definitely subdivides, and it must still produce
+        exactly one output row.
+        """
+        admin_id = await get_user_id(test_db_session, "admin")
+        big = await _create_layer(
+            test_db_session,
+            created_by=admin_id,
+            column_type="Geometry",
+            geometry_type="POLYGON",
+            values_sql=(
+                "('circle',"
+                " ST_Buffer(ST_SetSRID(ST_MakePoint(1.5, 0.5), 4326), 2,"
+                " 'quad_segs=512'),"
+                " ST_Buffer(ST_SetSRID(ST_MakePoint(1.5, 0.5), 4326), 2,"
+                " 'quad_segs=512'))"
+            ),
+            column_info=[{"name": "zone", "type": "text"}],
+        )
+        vertices = (
+            await test_db_session.execute(
+                text(f"SELECT ST_NPoints(geom_4326) FROM data.{big.table_name}")  # noqa: S608
+            )
+        ).scalar_one()
+        assert vertices > 256, "fixture must exceed the subdivide threshold"
+
+        bar = await _create_bar(test_db_session, created_by=admin_id)
+        job = await _create_job(test_db_session, admin_id)
+        await _materialize(
+            job_id=str(job.id),
+            dataset_id=str(bar.id),
+            user_id=str(admin_id),
+            operation="intersect",
+            title=f"Subdivided {uuid.uuid4().hex[:6]}",
+            mask_dataset_id=str(big.id),
+        )
+        await test_db_session.refresh(job)
+        assert job.status == "complete", job.error_message
+
+        from app.modules.catalog.datasets.domain.models import Dataset
+
+        out = await test_db_session.get(Dataset, job.dataset_id)
+        assert out.feature_count == 1, "one mask FEATURE, one row, however it split"
+
+
+class TestPreview:
+    async def test_preview_rows_carry_distinct_generated_gids(
+        self,
+        client: AsyncClient,
+        admin_auth_header: dict,
+        test_db_session: AsyncSession,
+    ):
+        """Criterion 4: preview and materialize must agree on what a row is.
+
+        Selecting the source gid here would show three features all claiming
+        gid 1 — nothing crashes, and the map silently lies about identity.
+        """
+        admin_id = await get_user_id(test_db_session, "admin")
+        zones = await _create_zones(test_db_session, created_by=admin_id)
+        bar = await _create_bar(test_db_session, created_by=admin_id)
+
+        resp = await client.post(
+            _preview_url(bar.id),
+            json={"operation": "intersect", "mask_dataset_id": str(zones.id)},
+            headers=admin_auth_header,
+        )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        features = body["geojson"]["features"]
+        assert [f["properties"]["gid"] for f in features] == [1, 2, 3]
+        # ...and each still points back at the source feature it came from.
+        assert {f["properties"][INTERSECT_SOURCE_GID_COLUMN] for f in features} == {1}
+        assert body["feature_count"] == 3
+        # A row-multiplying operation cannot report a source total.
+        assert body["source_feature_count"] is None
+        # The exact pair total rides the same statement as a window column.
+        assert body["match_count"] == 3
+
+    async def test_match_count_is_exact_beyond_the_preview_cap(
+        self,
+        client: AsyncClient,
+        admin_auth_header: dict,
+        test_db_session: AsyncSession,
+    ):
+        """The window is computed before the row cap, so the total is the real
+        one even when the feature list is truncated."""
+        from app.modules.catalog.datasets.domain.service_analysis import (
+            PREVIEW_FEATURE_CAP,
+        )
+
+        admin_id = await get_user_id(test_db_session, "admin")
+        # 600 zones in a row; the bar crosses the first three, so widen it.
+        zones = await _create_zones(
+            test_db_session, created_by=admin_id, count=PREVIEW_FEATURE_CAP + 100
+        )
+        wide = "POLYGON((0 0, 600 0, 600 1, 0 1, 0 0))"
+        src = await _create_layer(
+            test_db_session,
+            created_by=admin_id,
+            column_type="Geometry",
+            geometry_type="POLYGON",
+            values_sql=(
+                f"('wide', ST_GeomFromText('{wide}', 4326),"
+                f" ST_GeomFromText('{wide}', 4326))"
+            ),
+            column_info=[{"name": "parcel", "type": "text"}],
+        )
+        await test_db_session.execute(
+            text(
+                f"ALTER TABLE data.{src.table_name} "  # noqa: S608
+                "RENAME COLUMN name TO parcel"
+            )
+        )
+        await test_db_session.commit()
+
+        resp = await client.post(
+            _preview_url(src.id),
+            json={"operation": "intersect", "mask_dataset_id": str(zones.id)},
+            headers=admin_auth_header,
+        )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["truncated"] is True
+        assert body["feature_count"] == PREVIEW_FEATURE_CAP
+        assert body["match_count"] == PREVIEW_FEATURE_CAP + 100
+
+
+class TestColumnCollisions:
+    async def test_a_column_in_both_layers_is_rejected_at_enqueue(
+        self,
+        client: AsyncClient,
+        admin_auth_header: dict,
+        test_db_session: AsyncSession,
+    ):
+        """Criterion 5: an overlay carries columns from BOTH inputs, so a
+        same-named column is likely rather than exotic. The CTAS would fail it
+        with an opaque "column specified more than once" after the queue wait;
+        name it at enqueue instead."""
+        admin_id = await get_user_id(test_db_session, "admin")
+        # Both layers call their text column "name".
+        zones = await _create_zones(
+            test_db_session, created_by=admin_id, name_column="name"
+        )
+        bar = await _create_layer(
+            test_db_session,
+            created_by=admin_id,
+            column_type="Geometry",
+            geometry_type="POLYGON",
+            values_sql=(
+                f"('bar', ST_GeomFromText('{BAR_WKT}', 4326),"
+                f" ST_GeomFromText('{BAR_WKT}', 4326))"
+            ),
+            column_info=[{"name": "name", "type": "text"}],
+        )
+
+        resp = await client.post(
+            _materialize_url(bar.id),
+            json={
+                "operation": "intersect",
+                "mask_dataset_id": str(zones.id),
+                "title": "Nope",
+            },
+            headers=admin_auth_header,
+        )
+        assert resp.status_code == 422
+        assert "name" in resp.text
+
+    async def test_a_source_column_named_source_gid_is_rejected(
+        self,
+        client: AsyncClient,
+        admin_auth_header: dict,
+        test_db_session: AsyncSession,
+    ):
+        """The generated column has the same problem as dissolve's
+        source_count."""
+        admin_id = await get_user_id(test_db_session, "admin")
+        zones = await _create_zones(test_db_session, created_by=admin_id)
+        bar = await _create_layer(
+            test_db_session,
+            created_by=admin_id,
+            column_type="Geometry",
+            geometry_type="POLYGON",
+            extra_columns="source_gid INTEGER,",
+            values_sql=(
+                f"('bar', 7, ST_GeomFromText('{BAR_WKT}', 4326),"
+                f" ST_GeomFromText('{BAR_WKT}', 4326))"
+            ),
+            column_info=[
+                {"name": "parcel", "type": "text"},
+                {"name": "source_gid", "type": "integer"},
+            ],
+        )
+
+        resp = await client.post(
+            _materialize_url(bar.id),
+            json={
+                "operation": "intersect",
+                "mask_dataset_id": str(zones.id),
+                "title": "Nope",
+            },
+            headers=admin_auth_header,
+        )
+        assert resp.status_code == 422
+        assert INTERSECT_SOURCE_GID_COLUMN in resp.text
+
+
+class TestAccessControl:
+    async def test_an_overlay_layer_the_caller_cannot_see_is_a_404(
+        self,
+        client: AsyncClient,
+        editor_auth_header: dict,
+        test_db_session: AsyncSession,
+    ):
+        """Criterion 8: Rule 1 applies to BOTH datasets, on preview and
+        materialize alike."""
+        admin_id = await get_user_id(test_db_session, "admin")
+        bar = await _create_bar(test_db_session, created_by=admin_id)
+        private_zones = await _create_zones(
+            test_db_session, created_by=admin_id, visibility="private"
+        )
+
+        for url in (_preview_url(bar.id), _materialize_url(bar.id)):
+            resp = await client.post(
+                url,
+                json={
+                    "operation": "intersect",
+                    "mask_dataset_id": str(private_zones.id),
+                    "title": "Nope",
+                },
+                headers=editor_auth_header,
+            )
+            assert resp.status_code == 404, f"{url}: {resp.text}"
+
+
+class TestEnqueueValidation:
+    async def test_oversized_source_rejected_at_enqueue(
+        self,
+        client: AsyncClient,
+        admin_auth_header: dict,
+        test_db_session: AsyncSession,
+    ):
+        """Criterion 6's first half. The router reads MAX_SOURCE_FEATURES with
+        .get(), so a missing key would leave the row-multiplying operation with
+        NO ceiling — the entry existing is half the assertion."""
+        assert "intersect" in MAX_SOURCE_FEATURES
+        admin_id = await get_user_id(test_db_session, "admin")
+        zones = await _create_zones(test_db_session, created_by=admin_id)
+        bar = await _create_bar(test_db_session, created_by=admin_id)
+        bar.feature_count = MAX_SOURCE_FEATURES["intersect"] + 1
+        await test_db_session.commit()
+
+        resp = await client.post(
+            _materialize_url(bar.id),
+            json={
+                "operation": "intersect",
+                "mask_dataset_id": str(zones.id),
+                "title": "Too big",
+            },
+            headers=admin_auth_header,
+        )
+        assert resp.status_code == 422
+        assert "too large" in resp.text
+
+    async def test_an_overlay_requires_a_layer(
+        self,
+        client: AsyncClient,
+        admin_auth_header: dict,
+        test_db_session: AsyncSession,
+    ):
+        """Layer only: a drawn polygon carries no attributes to overlay with,
+        which would make it an expensive clip. `mask` is not an intersect
+        param, so a drawn one is dropped and the request then fails for want of
+        the layer."""
+        admin_id = await get_user_id(test_db_session, "admin")
+        bar = await _create_bar(test_db_session, created_by=admin_id)
+
+        for body in (
+            {"operation": "intersect"},
+            {
+                "operation": "intersect",
+                "mask": {
+                    "type": "Polygon",
+                    "coordinates": [[[0, 0], [1, 0], [1, 1], [0, 0]]],
+                },
+            },
+        ):
+            resp = await client.post(
+                _preview_url(bar.id), json=body, headers=admin_auth_header
+            )
+            assert resp.status_code == 422, resp.text
+
+
+class TestOutputSize:
+    async def test_row_amplification_trips_the_output_ceiling(
+        self,
+        test_db_session: AsyncSession,
+    ):
+        """Criterion 7: the existing output-size tests grow GEOMETRY. This one
+        grows ROW COUNT instead, which is the axis only this operation moves.
+
+        One small source over 200 zones is 200 output rows from 1 input row —
+        the shape no MAX_SOURCE_FEATURES value can bound, and therefore the
+        shape _enforce_output_size has to be the thing that catches.
+        """
+        admin_id = await get_user_id(test_db_session, "admin")
+        zones = await _create_zones(test_db_session, created_by=admin_id, count=200)
+        wide = "POLYGON((0 0, 200 0, 200 1, 0 1, 0 0))"
+        src = await _create_layer(
+            test_db_session,
+            created_by=admin_id,
+            column_type="Geometry",
+            geometry_type="POLYGON",
+            values_sql=(
+                f"('wide', ST_GeomFromText('{wide}', 4326),"
+                f" ST_GeomFromText('{wide}', 4326))"
+            ),
+            column_info=[{"name": "parcel", "type": "text"}],
+        )
+        await test_db_session.execute(
+            text(
+                f"ALTER TABLE data.{src.table_name} "  # noqa: S608
+                "RENAME COLUMN name TO parcel"
+            )
+        )
+        await test_db_session.commit()
+        job = await _create_job(test_db_session, admin_id)
+
+        with patch("app.processing.analysis.tasks.MAX_OUTPUT_BYTES", 1):
+            await _materialize(
+                job_id=str(job.id),
+                dataset_id=str(src.id),
+                user_id=str(admin_id),
+                operation="intersect",
+                title=f"Too big {uuid.uuid4().hex[:6]}",
+                mask_dataset_id=str(zones.id),
+            )
+
+        await test_db_session.refresh(job)
+        assert job.status == "failed"
+        assert job.dataset_id is None

--- a/backend/tests/test_analysis_materialize.py
+++ b/backend/tests/test_analysis_materialize.py
@@ -1746,6 +1746,40 @@ class TestMaterializeWorker:
         assert new_ds is not None
         assert new_ds.feature_count == 1
 
+    async def test_dissolve_by_a_json_array_field_fails_with_a_clear_message(
+        self,
+        test_db_session: AsyncSession,
+    ):
+        """fix(#1097 review): the by_field guard has the overlay guard's array
+        blind spot. The router's snapshot says 'ARRAY' for a json[] column, so
+        enqueue admits it, and without the worker's live recheck the dissolve
+        CTAS dies on SQLSTATE 42883 after the queue wait with an error naming
+        nothing the user chose. Through _materialize rather than the helper,
+        so the test proves the recheck is actually wired into the job path.
+        """
+        admin_id = await get_user_id(test_db_session, "admin")
+        ds = await _create_polygon_dataset(test_db_session, created_by=admin_id)
+        await test_db_session.execute(
+            text(f"ALTER TABLE data.{ds.table_name} ADD COLUMN props json[]")  # noqa: S608
+        )
+        await test_db_session.commit()
+        job = await _create_job(test_db_session, admin_id)
+
+        await _materialize(
+            job_id=str(job.id),
+            dataset_id=str(ds.id),
+            user_id=str(admin_id),
+            operation="dissolve",
+            by_field="props",
+            title=f"Dissolved {uuid.uuid4().hex[:6]}",
+        )
+
+        await test_db_session.refresh(job)
+        assert job.status == "failed"
+        assert "props" in (job.error_message or "")
+        assert "json[]" in (job.error_message or "")
+        assert "42883" not in (job.error_message or "")
+
     async def test_missing_source_marks_job_failed(
         self,
         test_db_session: AsyncSession,

--- a/backend/tests/test_analysis_measure.py
+++ b/backend/tests/test_analysis_measure.py
@@ -1,0 +1,316 @@
+"""Measurement: area and length as computed columns (#954).
+
+One test per acceptance criterion on the issue.
+
+Requirements:
+  - Docker database must be running (docker compose up db)
+"""
+
+import uuid
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.platform.analysis_sql import MAX_SOURCE_FEATURES
+from app.processing.analysis.tasks import _materialize
+
+from tests.factories import get_user_id
+from tests.test_analysis_materialize import _create_job
+from tests.test_analysis_spatial_join import _create_layer
+
+# 1 degree of latitude is ~111.32 km; a 1x1 degree box at the equator is
+# therefore ~1.23e10 m². The tolerance is deliberately loose (2%) because the
+# exact value depends on the spheroid, and the point of the assertion is that
+# the number is a real geodesic measure rather than degrees-squared.
+TOLERANCE = 0.02
+
+
+def _preview_url(dataset_id) -> str:
+    return f"/datasets/{dataset_id}/analysis/preview/"
+
+
+def _materialize_url(dataset_id) -> str:
+    return f"/datasets/{dataset_id}/analysis/materialize/"
+
+
+class TestMeasurePreview:
+    async def test_area_and_length_match_postgis_ground_truth(
+        self,
+        client: AsyncClient,
+        admin_auth_header: dict,
+        test_db_session: AsyncSession,
+    ):
+        """Criterion 2: both measures match an independently computed number.
+
+        Ground truth comes from PostGIS itself rather than a hardcoded
+        constant, so the assertion pins the operation's plumbing (right column,
+        right geometry, geography not planar) instead of re-deriving spheroid
+        maths in the test.
+        """
+        admin_id = await get_user_id(test_db_session, "admin")
+        ds = await _create_layer(
+            test_db_session,
+            created_by=admin_id,
+            column_type="Geometry",
+            geometry_type="POLYGON",
+            values_sql=(
+                "('box', ST_MakeEnvelope(0,0,1,1,4326), ST_MakeEnvelope(0,0,1,1,4326)),"
+                "('line',"
+                " ST_GeomFromText('LINESTRING(0 0, 1 0)', 4326),"
+                " ST_GeomFromText('LINESTRING(0 0, 1 0)', 4326))"
+            ),
+            feature_count=2,
+        )
+
+        resp = await client.post(
+            _preview_url(ds.id),
+            json={"operation": "measure"},
+            headers=admin_auth_header,
+        )
+        assert resp.status_code == 200, resp.text
+        got = {
+            f["properties"]["gid"]: (
+                f["properties"]["area_sqm"],
+                f["properties"]["length_m"],
+            )
+            for f in resp.json()["geojson"]["features"]
+        }
+
+        expected = {
+            gid: (a, ln)
+            for gid, a, ln in (
+                await test_db_session.execute(
+                    text(
+                        f"SELECT gid, ST_Area(geom_4326::geography), "  # noqa: S608
+                        f"ST_Length(geom_4326::geography) "
+                        f"FROM data.{ds.table_name} ORDER BY gid"
+                    )
+                )
+            ).all()
+        }
+        assert set(got) == set(expected)
+        for gid, (area, length) in got.items():
+            exp_area, exp_length = expected[gid]
+            assert area == pytest.approx(exp_area, rel=1e-6)
+            assert length == pytest.approx(exp_length, rel=1e-6)
+
+        # The polygon has area and no length; the line the reverse. Both
+        # columns are emitted for both rows (see render_measure_columns on why
+        # the catalog's geometry_type is not trusted to pick one).
+        assert got[1][0] > 0 and got[1][1] == 0
+        assert got[2][0] == 0 and got[2][1] > 0
+        # Sanity that this is metres, not degrees: a 1x1 degree box at the
+        # equator is ~1.23e10 m2, which degrees-squared (1.0) would never be.
+        assert got[1][0] == pytest.approx(1.23e10, rel=TOLERANCE)
+
+    async def test_antimeridian_polygon_measures_correctly(
+        self,
+        client: AsyncClient,
+        admin_auth_header: dict,
+        test_db_session: AsyncSession,
+    ):
+        """Criterion 5: a polygon crossing +/-180 measures as the small box it
+        is, not the ~359-degree-wide one its planar envelope suggests.
+
+        This is the whole reason the renderer casts to geography. The same
+        shape measured planar spans nearly the globe.
+        """
+        admin_id = await get_user_id(test_db_session, "admin")
+        # 2 degrees wide, straddling the seam: 179 -> -179.
+        ds = await _create_layer(
+            test_db_session,
+            created_by=admin_id,
+            column_type="Geometry",
+            geometry_type="POLYGON",
+            values_sql=(
+                "('seam',"
+                " ST_GeomFromText('POLYGON((179 0, 179 1, -179 1, -179 0, 179 0))',"
+                " 4326),"
+                " ST_GeomFromText('POLYGON((179 0, 179 1, -179 1, -179 0, 179 0))',"
+                " 4326))"
+            ),
+        )
+
+        resp = await client.post(
+            _preview_url(ds.id),
+            json={"operation": "measure"},
+            headers=admin_auth_header,
+        )
+        assert resp.status_code == 200, resp.text
+        area = resp.json()["geojson"]["features"][0]["properties"]["area_sqm"]
+
+        # A 2x1 degree box near the equator is ~2.46e10 m2. The planar reading
+        # of the same ring is 358 degrees wide — a different answer by two
+        # orders of magnitude, which is what this pins against.
+        assert area == pytest.approx(2 * 1.23e10, rel=0.05)
+        planar_degrees = (
+            await test_db_session.execute(
+                text(f"SELECT ST_Area(geom_4326) FROM data.{ds.table_name}")  # noqa: S608
+            )
+        ).scalar_one()
+        assert planar_degrees > 300, "fixture must actually straddle the seam"
+
+    async def test_null_and_empty_geometries_produce_no_feature(
+        self,
+        client: AsyncClient,
+        admin_auth_header: dict,
+        test_db_session: AsyncSession,
+    ):
+        """Criterion 4: the decided value for a NULL/empty source geometry in
+        the PREVIEW is 'no feature at all' — not a zero, and not a null-valued
+        row.
+
+        That is the answer that agrees with materialize, where _wrap_not_empty
+        and the post-CTAS DELETE remove those rows outright, so the saved
+        dataset and the approved preview describe the same set of features.
+        """
+        admin_id = await get_user_id(test_db_session, "admin")
+        ds = await _create_layer(
+            test_db_session,
+            created_by=admin_id,
+            column_type="Geometry",
+            geometry_type="POLYGON",
+            values_sql=(
+                "('real', ST_MakeEnvelope(0,0,1,1,4326), ST_MakeEnvelope(0,0,1,1,4326)),"
+                "('nullgeom', NULL, NULL),"
+                "('empty',"
+                " ST_GeomFromText('POLYGON EMPTY', 4326),"
+                " ST_GeomFromText('POLYGON EMPTY', 4326))"
+            ),
+            feature_count=3,
+        )
+
+        resp = await client.post(
+            _preview_url(ds.id),
+            json={"operation": "measure"},
+            headers=admin_auth_header,
+        )
+        assert resp.status_code == 200, resp.text
+        features = resp.json()["geojson"]["features"]
+        assert [f["properties"]["gid"] for f in features] == [1]
+        assert resp.json()["feature_count"] == 1
+
+
+class TestMeasureEnqueue:
+    async def test_generated_column_collision_rejected(
+        self,
+        client: AsyncClient,
+        admin_auth_header: dict,
+        test_db_session: AsyncSession,
+    ):
+        """Criterion 3, mirroring dissolve's source_count guard."""
+        admin_id = await get_user_id(test_db_session, "admin")
+        ds = await _create_layer(
+            test_db_session,
+            created_by=admin_id,
+            column_type="Geometry",
+            geometry_type="POLYGON",
+            extra_columns="area_sqm DOUBLE PRECISION,",
+            values_sql=(
+                "('box', 1.0, ST_MakeEnvelope(0,0,1,1,4326),"
+                " ST_MakeEnvelope(0,0,1,1,4326))"
+            ),
+            column_info=[
+                {"name": "name", "type": "text"},
+                {"name": "area_sqm", "type": "double precision"},
+            ],
+        )
+
+        resp = await client.post(
+            _materialize_url(ds.id),
+            json={"operation": "measure", "title": "Nope"},
+            headers=admin_auth_header,
+        )
+        assert resp.status_code == 422
+        assert "area_sqm" in resp.text
+
+    async def test_oversized_source_rejected_at_enqueue(
+        self,
+        client: AsyncClient,
+        admin_auth_header: dict,
+        test_db_session: AsyncSession,
+    ):
+        """Criterion 6: measure has a MAX_SOURCE_FEATURES entry that fires.
+
+        Without the entry the router's .get() skips the gate entirely rather
+        than applying a default, so the operation would have NO ceiling.
+        """
+        assert "measure" in MAX_SOURCE_FEATURES
+        admin_id = await get_user_id(test_db_session, "admin")
+        ds = await _create_layer(
+            test_db_session,
+            created_by=admin_id,
+            column_type="Geometry",
+            geometry_type="POLYGON",
+            values_sql=(
+                "('box', ST_MakeEnvelope(0,0,1,1,4326), ST_MakeEnvelope(0,0,1,1,4326))"
+            ),
+        )
+        ds.feature_count = MAX_SOURCE_FEATURES["measure"] + 1
+        await test_db_session.commit()
+
+        resp = await client.post(
+            _materialize_url(ds.id),
+            json={"operation": "measure", "title": "Too big"},
+            headers=admin_auth_header,
+        )
+        assert resp.status_code == 422
+        assert "too large" in resp.text
+
+
+class TestMeasureWorker:
+    async def test_materialize_carries_the_measured_columns(
+        self,
+        test_db_session: AsyncSession,
+    ):
+        """The saved dataset carries both measures and agrees with the preview
+        renderer, since both go through render_measure_columns."""
+        admin_id = await get_user_id(test_db_session, "admin")
+        ds = await _create_layer(
+            test_db_session,
+            created_by=admin_id,
+            column_type="Geometry",
+            geometry_type="POLYGON",
+            values_sql=(
+                "('box', ST_MakeEnvelope(0,0,1,1,4326),"
+                " ST_MakeEnvelope(0,0,1,1,4326)),"
+                "('nullgeom', NULL, NULL)"
+            ),
+            feature_count=2,
+        )
+        job = await _create_job(test_db_session, admin_id)
+
+        await _materialize(
+            job_id=str(job.id),
+            dataset_id=str(ds.id),
+            user_id=str(admin_id),
+            operation="measure",
+            title=f"Measured {uuid.uuid4().hex[:6]}",
+        )
+
+        await test_db_session.refresh(job)
+        assert job.status == "complete", job.error_message
+
+        from app.modules.catalog.datasets.domain.models import Dataset
+
+        new_ds = await test_db_session.get(Dataset, job.dataset_id)
+        assert new_ds is not None
+        # The NULL-geometry row is gone, so criterion 4 needs no materialize
+        # fixture of its own.
+        assert new_ds.feature_count == 1
+        assert new_ds.geometry_type == "POLYGON"
+
+        rows = (
+            await test_db_session.execute(
+                text(
+                    f"SELECT name, area_sqm, length_m FROM data.{new_ds.table_name}"  # noqa: S608
+                )
+            )
+        ).all()
+        assert len(rows) == 1
+        name, area, length = rows[0]
+        assert name == "box"
+        assert area == pytest.approx(1.23e10, rel=TOLERANCE)
+        assert length == 0

--- a/backend/tests/test_analysis_preview.py
+++ b/backend/tests/test_analysis_preview.py
@@ -438,6 +438,70 @@ class TestPreviewGlobalBound:
             r.status_code for r in responses
         ]
 
+    async def test_the_exact_count_query_holds_a_slot_too(
+        self,
+        client: AsyncClient,
+        admin_auth_header: dict,
+        test_db_session: AsyncSession,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        """fix(#1097 review): the second sandbox query counts against the bound.
+
+        Operations that report an exact total run TWO sandbox statements, each
+        opening its own connection. The count used to run after the semaphore
+        was released, so a preview could admit the next caller while still
+        holding a connection — the bound would stop describing how many
+        connections previews can hold, which is the only reason it exists.
+
+        The count is the likelier of the two to still be running when the
+        geometry query returns: it is uncapped and scans both inputs, while the
+        geometry query stops at PREVIEW_FEATURE_CAP rows.
+
+        Asserted through `.locked()` against a one-slot semaphore rather than
+        by counting: locked() is unambiguous at a bound of one, and the bound
+        is what is under test, not the arithmetic that sizes it.
+        """
+        import asyncio
+
+        from app.modules.catalog.datasets.domain import service_analysis
+
+        monkeypatch.setattr(service_analysis, "_preview_slots", asyncio.Semaphore(1))
+        real = service_analysis.execute_safe
+        held: list[bool] = []
+
+        async def _recording_execute_safe(db, sql, **kwargs):
+            held.append(service_analysis._preview_slots.locked())
+            return await real(db, sql, **kwargs)
+
+        monkeypatch.setattr(service_analysis, "execute_safe", _recording_execute_safe)
+
+        admin_id = await get_user_id(test_db_session, "admin")
+        src = await _create_polygon_dataset(test_db_session, created_by=admin_id)
+        mask = await _create_mask_dataset(
+            test_db_session, created_by=admin_id, wkt=SQUARE
+        )
+
+        resp = await client.post(
+            _preview_url(src.id),
+            json={
+                "operation": "select_by_location",
+                "mask_dataset_id": str(mask.id),
+            },
+            headers=admin_auth_header,
+        )
+        assert resp.status_code == 200, resp.text
+        # The exact total is what makes this a two-statement operation; without
+        # it the test would pass on a single query and prove nothing.
+        assert resp.json()["match_count"] == 1
+
+        assert len(held) == 2, (
+            f"expected a geometry query and a count query, saw {len(held)}"
+        )
+        assert held == [True, True], (
+            "a sandbox query ran outside the preview semaphore: previews can "
+            "hold more connections than the bound allows"
+        )
+
 
 class TestAnalysisPreviewEndpoint:
     async def test_preview_releases_request_session_before_sandbox_query(

--- a/backend/tests/test_analysis_provenance.py
+++ b/backend/tests/test_analysis_provenance.py
@@ -428,57 +428,84 @@ class TestDerivedFromParamsVisibility:
         assert visible["params"]["join_dataset_id"] == str(join.id)
         assert visible["params"]["join_fields"] == ["parcel_owner"]
 
-    def test_every_dataset_id_param_is_redactable(self):
-        """Structural: the redaction table must cover every dataset id the
-        worker actually writes into provenance params.
+    async def test_a_spatial_join_records_the_layer_and_fields_it_used(
+        self, test_db_session: AsyncSession
+    ):
+        """fix(#1097 review): end to end, through the real worker.
 
-        This gap has now happened twice — the mask in #765, the join layer in
-        #1097 — and both times the code was correct for the operations that
-        existed when it was written. The failure mode is silence: an
-        unredacted id looks like ordinary provenance and nothing errors, so
-        the next operation to carry one would ship the same leak.
-
-        Parsed from the source rather than asserted against a hand-kept list,
-        because a hand-kept list is the thing that fell behind.
+        The unit-level whitelist check above says the key is allowed through.
+        This says it actually arrives, because the two are separable: the
+        params reach apply_analysis_provenance and are then filtered, so a
+        whitelist assertion alone would have passed throughout the window when
+        nothing was being stored.
         """
-        import ast
-        import pathlib
+        from tests.test_analysis_spatial_join import (
+            _create_probe_points,
+            _create_two_overlapping_polygons,
+        )
 
+        admin_id = await get_user_id(test_db_session, "admin")
+        points = await _create_probe_points(test_db_session, created_by=admin_id)
+        polys = await _create_two_overlapping_polygons(
+            test_db_session, created_by=admin_id
+        )
+        job = await _create_job(test_db_session, admin_id)
+
+        await _materialize(
+            job_id=str(job.id),
+            dataset_id=str(points.id),
+            user_id=str(admin_id),
+            operation="spatial_join",
+            title=f"Joined {uuid.uuid4().hex[:6]}",
+            join_dataset_id=str(polys.id),
+            join_fields=["name", "pop"],
+        )
+        await test_db_session.refresh(job)
+        assert job.status == "complete", job.error_message
+
+        out = await test_db_session.get(Dataset, job.dataset_id)
+        record = await _record_of(test_db_session, out)
+        assert record.derived_from is not None
+        params = record.derived_from["params"]
+        # The layer it joined against, and the columns it copied. Without both,
+        # the lineage cannot explain where the join_* columns came from.
+        assert params["join_dataset_id"] == str(polys.id)
+        assert params["join_fields"] == ["name", "pop"]
+
+    def test_every_dataset_id_param_is_redactable(self):
+        """Structural: everything STORED that names a dataset must be
+        access-checked per requester.
+
+        fix(#1097 review): this reads PARAM_KEYS now, not the params dict at
+        the _materialize call site. The first version parsed the call site and
+        was checking the wrong layer — join_dataset_id was passed there and
+        then dropped by build_derived_from's PARAM_KEYS filter, so it never
+        reached records.derived_from at all. The test passed, and it was
+        confirming a pairing between two things that had no bearing on what
+        was stored.
+
+        PARAM_KEYS is the storage contract, so it is the one that matters: a
+        key added there becomes visible to every requester who can see the
+        output. This is also why the redaction and the whitelist have to move
+        together — adding join_dataset_id to PARAM_KEYS without the matching
+        _DATASET_ID_PARAMS row is precisely how a private join layer's id would
+        reach an unauthorised reader.
+
+        The failure mode is silence: an unredacted id looks like ordinary
+        provenance and nothing errors.
+        """
         from app.modules.catalog.authorization import _DATASET_ID_PARAMS
+        from app.processing.analysis.provenance import PARAM_KEYS
 
-        source = pathlib.Path("app/processing/analysis/tasks.py").read_text(
-            encoding="utf-8"
+        stored_ids = {k for k in PARAM_KEYS if k.endswith("_dataset_id")}
+        assert stored_ids, (
+            "no *_dataset_id keys in PARAM_KEYS — either the naming convention "
+            "changed or this test has stopped checking anything"
         )
-        written: set[str] = set()
-        for node in ast.walk(ast.parse(source)):
-            # The params= dict handed to apply_analysis_provenance.
-            if not isinstance(node, ast.Call):
-                continue
-            func = node.func
-            name = (
-                func.attr
-                if isinstance(func, ast.Attribute)
-                else getattr(func, "id", "")
-            )
-            if name != "apply_analysis_provenance":
-                continue
-            for kw in node.keywords:
-                if kw.arg != "params" or not isinstance(kw.value, ast.Dict):
-                    continue
-                for key in kw.value.keys:
-                    if isinstance(key, ast.Constant) and isinstance(key.value, str):
-                        if key.value.endswith("_dataset_id"):
-                            written.add(key.value)
-
-        assert written, (
-            "found no *_dataset_id keys in the provenance params — the parse "
-            "stopped matching the source, so this test is no longer checking "
-            "anything"
-        )
-        missing = written - set(_DATASET_ID_PARAMS)
+        missing = stored_ids - set(_DATASET_ID_PARAMS)
         assert not missing, (
-            f"{sorted(missing)} reach provenance params but are not in "
-            "_DATASET_ID_PARAMS, so they are published to requesters who "
+            f"{sorted(missing)} are stored in records.derived_from but are not "
+            "in _DATASET_ID_PARAMS, so they are published to requesters who "
             "cannot access the dataset they name. Add a row (and list any "
             "param that DESCRIBES that dataset as a dependent, the way "
             "join_fields hangs off join_dataset_id)."

--- a/backend/tests/test_analysis_provenance.py
+++ b/backend/tests/test_analysis_provenance.py
@@ -357,6 +357,133 @@ class TestDerivedFromParamsVisibility:
         assert visible is not None
         assert visible["params"]["mask_dataset_id"] == str(mask.id)
 
+    async def test_a_private_join_layer_takes_its_column_names_with_it(
+        self, test_db_session: AsyncSession
+    ):
+        """fix(#1097 review): the mask was not the last dataset id in params.
+
+        Spatial join carries join_dataset_id, and the redaction covered only
+        the mask — so a public join output derived through a PRIVATE join layer
+        published that layer's id to every viewer.
+
+        join_fields goes with it. Dropping the id alone would still publish the
+        private layer's column names, which is most of what its schema is: an
+        id you cannot resolve is a weaker disclosure than the list of fields
+        someone chose to copy out of it.
+        """
+        from app.modules.catalog.authorization import visible_derived_from
+
+        admin_id = await get_user_id(test_db_session, "admin")
+        source = await _create_polygon_dataset(
+            test_db_session, created_by=admin_id, visibility="public"
+        )
+        join = await _create_polygon_dataset(
+            test_db_session, created_by=admin_id, visibility="private"
+        )
+        reference = {
+            "dataset_id": str(source.id),
+            "operation": "spatial_join",
+            "params": {
+                "join_dataset_id": str(join.id),
+                "join_fields": ["parcel_owner", "assessed_value"],
+            },
+            "created_at": "2026-07-31T00:00:00+00:00",
+        }
+
+        anonymous = await visible_derived_from(test_db_session, reference, None, set())
+        assert anonymous is not None
+        assert "join_dataset_id" not in anonymous["params"]
+        assert "join_fields" not in anonymous["params"]
+        # The record's own JSONB is untouched — this redacts a copy per
+        # requester, it does not destroy the provenance.
+        assert reference["params"]["join_fields"] == ["parcel_owner", "assessed_value"]
+
+    async def test_a_visible_join_layer_keeps_its_fields(
+        self, test_db_session: AsyncSession
+    ):
+        """The guard on the redaction above: it must key off ACCESS, not off
+        the param existing. An owner reading their own output still gets the
+        lineage that makes it reproducible."""
+        from app.modules.catalog.authorization import visible_derived_from
+
+        admin_id = await get_user_id(test_db_session, "admin")
+        source = await _create_polygon_dataset(
+            test_db_session, created_by=admin_id, visibility="public"
+        )
+        join = await _create_polygon_dataset(
+            test_db_session, created_by=admin_id, visibility="public"
+        )
+        reference = {
+            "dataset_id": str(source.id),
+            "operation": "spatial_join",
+            "params": {
+                "join_dataset_id": str(join.id),
+                "join_fields": ["parcel_owner"],
+            },
+            "created_at": "2026-07-31T00:00:00+00:00",
+        }
+
+        visible = await visible_derived_from(test_db_session, reference, None, set())
+        assert visible is not None
+        assert visible["params"]["join_dataset_id"] == str(join.id)
+        assert visible["params"]["join_fields"] == ["parcel_owner"]
+
+    def test_every_dataset_id_param_is_redactable(self):
+        """Structural: the redaction table must cover every dataset id the
+        worker actually writes into provenance params.
+
+        This gap has now happened twice — the mask in #765, the join layer in
+        #1097 — and both times the code was correct for the operations that
+        existed when it was written. The failure mode is silence: an
+        unredacted id looks like ordinary provenance and nothing errors, so
+        the next operation to carry one would ship the same leak.
+
+        Parsed from the source rather than asserted against a hand-kept list,
+        because a hand-kept list is the thing that fell behind.
+        """
+        import ast
+        import pathlib
+
+        from app.modules.catalog.authorization import _DATASET_ID_PARAMS
+
+        source = pathlib.Path("app/processing/analysis/tasks.py").read_text(
+            encoding="utf-8"
+        )
+        written: set[str] = set()
+        for node in ast.walk(ast.parse(source)):
+            # The params= dict handed to apply_analysis_provenance.
+            if not isinstance(node, ast.Call):
+                continue
+            func = node.func
+            name = (
+                func.attr
+                if isinstance(func, ast.Attribute)
+                else getattr(func, "id", "")
+            )
+            if name != "apply_analysis_provenance":
+                continue
+            for kw in node.keywords:
+                if kw.arg != "params" or not isinstance(kw.value, ast.Dict):
+                    continue
+                for key in kw.value.keys:
+                    if isinstance(key, ast.Constant) and isinstance(key.value, str):
+                        if key.value.endswith("_dataset_id"):
+                            written.add(key.value)
+
+        assert written, (
+            "found no *_dataset_id keys in the provenance params — the parse "
+            "stopped matching the source, so this test is no longer checking "
+            "anything"
+        )
+        missing = written - set(_DATASET_ID_PARAMS)
+        assert not missing, (
+            f"{sorted(missing)} reach provenance params but are not in "
+            "_DATASET_ID_PARAMS, so they are published to requesters who "
+            "cannot access the dataset they name. Add a row (and list any "
+            "param that DESCRIBES that dataset as a dependent, the way "
+            "join_fields hangs off join_dataset_id)."
+        )
+
 
 class TestStacDerivedFromLink:
     """The STAC half.

--- a/backend/tests/test_analysis_provenance.py
+++ b/backend/tests/test_analysis_provenance.py
@@ -245,6 +245,84 @@ class TestMaterializedProvenance:
             'Clipped from "Parcels" to "Flood Zone", created by admin on 2026-07-31.'
         )
 
+    def test_every_operation_names_its_second_layer(self):
+        """fix(#1097 review): the four new operations had no branch, so they
+        fell through to "<operation> applied to <source>".
+
+        That sentence is a product surface — the dataset page renders it,
+        search indexes it, and DCAT exports it — so an overlay whose entire
+        point is the second layer was described without naming one.
+        """
+        cases = [
+            (
+                "spatial_join",
+                {"join_dataset_id": "x", "join_fields": ["owner", "value"]},
+                {"join_title": "Parcels Registry"},
+                'Joined from "Points" against "Parcels Registry", '
+                "transferring owner, value",
+            ),
+            (
+                "spatial_join",
+                {"join_dataset_id": "x"},
+                {"join_title": "Parcels Registry"},
+                'Joined from "Points" against "Parcels Registry"',
+            ),
+            (
+                "intersect",
+                {"mask_dataset_id": "x"},
+                {"mask_title": "Zones"},
+                'Intersected from "Points" with "Zones"',
+            ),
+            (
+                "select_by_location",
+                {"mask_source": "layer", "mask_dataset_id": "x"},
+                {"mask_title": "Zones"},
+                'Selected from "Points" by "Zones"',
+            ),
+            (
+                "select_by_location",
+                {"mask_source": "drawn"},
+                {},
+                'Selected from "Points" by a drawn area',
+            ),
+            ("measure", {}, {}, 'Measurements computed from "Points"'),
+        ]
+        for operation, params, titles, expected in cases:
+            sentence = build_lineage_sentence(
+                operation=operation,
+                source_title="Points",
+                params=params,
+                actor="admin",
+                created_at=datetime(2026, 7, 31),
+                **titles,
+            )
+            assert sentence == (f"{expected}, created by admin on 2026-07-31."), (
+                f"{operation} with {params!r} rendered as {sentence!r}"
+            )
+            # The fallback is what these branches exist to avoid.
+            assert "applied to" not in sentence, operation
+
+    def test_a_second_layer_whose_title_is_gone_still_reads_as_a_sentence(self):
+        """A deleted or unreadable layer yields no title, and a bare UUID would
+        not read. Same treatment clip already gave it, extended to the
+        operations that now name a layer."""
+        for operation, params in (
+            ("spatial_join", {"join_dataset_id": "x"}),
+            ("intersect", {"mask_dataset_id": "x"}),
+            ("select_by_location", {"mask_source": "layer", "mask_dataset_id": "x"}),
+        ):
+            sentence = build_lineage_sentence(
+                operation=operation,
+                source_title="Points",
+                params=params,
+                actor="admin",
+                created_at=datetime(2026, 7, 31),
+            )
+            assert "another layer" in sentence, operation
+            assert "x" not in sentence.replace("Intersected", "").replace(
+                "transferring", ""
+            ), f"{operation} leaked an id into the sentence: {sentence!r}"
+
 
 class TestDerivedFromVisibility:
     async def test_detail_omits_derived_from_without_access_to_the_source(

--- a/backend/tests/test_analysis_provenance.py
+++ b/backend/tests/test_analysis_provenance.py
@@ -472,6 +472,62 @@ class TestDerivedFromParamsVisibility:
         assert params["join_dataset_id"] == str(polys.id)
         assert params["join_fields"] == ["name", "pop"]
 
+    async def test_a_drawn_selection_still_records_that_it_was_drawn(
+        self, test_db_session: AsyncSession
+    ):
+        """fix(#1097 review): mask_source was recorded for clip alone.
+
+        The drawn geometry itself is deliberately kept out of provenance — it
+        can be kilobytes — so this discriminator is the ONLY trace that an area
+        shaped the selection. Without it a drawn select_by_location serialised
+        empty params: a lineage saying a selection happened by no visible
+        means.
+        """
+        from tests.test_analysis_preview import _create_polygon_dataset
+
+        admin_id = await get_user_id(test_db_session, "admin")
+        source = await _create_polygon_dataset(test_db_session, created_by=admin_id)
+        job = await _create_job(test_db_session, admin_id)
+
+        await _materialize(
+            job_id=str(job.id),
+            dataset_id=str(source.id),
+            user_id=str(admin_id),
+            operation="select_by_location",
+            title=f"Selected {uuid.uuid4().hex[:6]}",
+            mask={
+                "type": "Polygon",
+                "coordinates": [[[0, 0], [0, 1], [1, 1], [1, 0], [0, 0]]],
+            },
+        )
+        await test_db_session.refresh(job)
+        assert job.status == "complete", job.error_message
+
+        out = await test_db_session.get(Dataset, job.dataset_id)
+        record = await _record_of(test_db_session, out)
+        assert record.derived_from["params"]["mask_source"] == "drawn"
+
+    def test_both_writers_of_mask_source_agree_on_which_operations_have_one(self):
+        """The two writers of this fact must not drift.
+
+        The router records it on the job (Admin Jobs reads that to diagnose a
+        run) and the worker records it in provenance (the durable lineage).
+        They are separate constants because processing/ cannot import from
+        app.modules.catalog (PROCESS-02), and separate constants are how the
+        previous round's fix landed in one writer and not the other.
+
+        Pinned rather than deduplicated, since the import boundary is the
+        reason the duplication exists.
+        """
+        from app.modules.catalog.datasets.domain.schemas import MASK_OPERATIONS
+        from app.processing.analysis.tasks import _DRAWN_MASK_OPERATIONS
+
+        assert set(_DRAWN_MASK_OPERATIONS) == set(MASK_OPERATIONS), (
+            "the job metadata and the durable provenance disagree about which "
+            "operations can take a drawn mask, so one of them is recording a "
+            "discriminator the other omits"
+        )
+
     def test_every_dataset_id_param_is_redactable(self):
         """Structural: everything STORED that names a dataset must be
         access-checked per requester.

--- a/backend/tests/test_analysis_provenance.py
+++ b/backend/tests/test_analysis_provenance.py
@@ -258,13 +258,6 @@ class TestMaterializedProvenance:
                 "spatial_join",
                 {"join_dataset_id": "x", "join_fields": ["owner", "value"]},
                 {"join_title": "Parcels Registry"},
-                'Joined from "Points" against "Parcels Registry", '
-                "transferring owner, value",
-            ),
-            (
-                "spatial_join",
-                {"join_dataset_id": "x"},
-                {"join_title": "Parcels Registry"},
                 'Joined from "Points" against "Parcels Registry"',
             ),
             (
@@ -301,6 +294,39 @@ class TestMaterializedProvenance:
             )
             # The fallback is what these branches exist to avoid.
             assert "applied to" not in sentence, operation
+
+    def test_the_sentence_never_names_a_private_layers_columns(self):
+        """fix(#1097 review): lineage_summary has no per-requester form.
+
+        It is stored once and served raw — the dataset page returns it, search
+        indexes it, three DCAT services export it — and none of those pass it
+        through visible_derived_from, which is what access-checks the
+        structured provenance per requester.
+
+        So anything the redaction treats as sensitive must not reach this
+        prose. join_fields is a dependent of join_dataset_id in
+        _DATASET_ID_PARAMS precisely because a column list is most of a
+        schema, and the previous round routed it around that redaction while
+        making the sentence more useful.
+        """
+        from app.modules.catalog.authorization import _DATASET_ID_PARAMS
+
+        sentence = build_lineage_sentence(
+            operation="spatial_join",
+            source_title="Points",
+            params={
+                "join_dataset_id": "x",
+                "join_fields": ["parcel_owner", "assessed_value"],
+            },
+            actor="admin",
+            created_at=datetime(2026, 7, 31),
+            join_title="Parcels Registry",
+        )
+        assert "parcel_owner" not in sentence
+        assert "assessed_value" not in sentence
+        # And the reason, stated where it can rot loudly: these are the keys
+        # the redaction drops, so they are the keys prose may not carry.
+        assert "join_fields" in _DATASET_ID_PARAMS["join_dataset_id"]
 
     def test_a_second_layer_whose_title_is_gone_still_reads_as_a_sentence(self):
         """A deleted or unreadable layer yields no title, and a bare UUID would

--- a/backend/tests/test_analysis_select_by_location.py
+++ b/backend/tests/test_analysis_select_by_location.py
@@ -1,0 +1,667 @@
+"""Select by location: keep the source features that hit a mask (#955).
+
+One test per acceptance criterion on the issue.
+
+The fixture that carries most of them is an L-shaped mask. Its envelope is a
+3x3 square but its geometry covers only the bottom bar and the left bar, so a
+feature parked in the notch overlaps the envelope and misses the geometry.
+That is the exact shape a bbox-only filter gets wrong, and it is why this
+operation could not simply reuse ``render_clip_layer_join``'s WHERE.
+
+    3 +---+
+      | L |          notch = x(1,3] y(1,3]
+    1 |   +-------+  a feature here passes && and fails ST_Intersects
+      |           |
+    0 +-----------+
+      0     1     3
+
+Requirements:
+  - Docker database must be running (docker compose up db)
+"""
+
+import json
+import uuid
+
+from httpx import AsyncClient
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.modules.catalog.datasets.domain.service_analysis import PREVIEW_FEATURE_CAP
+from app.platform.analysis_sql import MAX_SOURCE_FEATURES
+from app.processing.analysis.tasks import _materialize
+
+from tests.factories import get_user_id
+from tests.test_analysis_materialize import _create_job
+from tests.test_analysis_spatial_join import _create_layer
+
+# The L, as WKT and as GeoJSON. Both mask paths must agree on the same shape,
+# so they are written once here rather than per test.
+L_WKT = "POLYGON((0 0, 3 0, 3 1, 1 1, 1 3, 0 3, 0 0))"
+L_GEOJSON = {
+    "type": "Polygon",
+    "coordinates": [[[0, 0], [3, 0], [3, 1], [1, 1], [1, 3], [0, 3], [0, 0]]],
+}
+
+# A polygon straddling the mask's right edge: x 2->4 against a bar ending at
+# x=3. Clip would return the x 2->3 half; a selection must return all of it.
+STRADDLER_WKT = "POLYGON((2 0.5, 4 0.5, 4 0.8, 2 0.8, 2 0.5))"
+
+
+def _preview_url(dataset_id) -> str:
+    return f"/datasets/{dataset_id}/analysis/preview/"
+
+
+def _materialize_url(dataset_id) -> str:
+    return f"/datasets/{dataset_id}/analysis/materialize/"
+
+
+async def _create_mask_layer(
+    session: AsyncSession, *, created_by: uuid.UUID, visibility: str = "public"
+):
+    """A one-row mask layer holding the L."""
+    return await _create_layer(
+        session,
+        created_by=created_by,
+        column_type="Geometry",
+        geometry_type="POLYGON",
+        visibility=visibility,
+        values_sql=(
+            f"('L', ST_GeomFromText('{L_WKT}', 4326), ST_GeomFromText('{L_WKT}', 4326))"
+        ),
+    )
+
+
+async def _create_probe_features(
+    session: AsyncSession, *, created_by: uuid.UUID, visibility: str = "public"
+):
+    """Four source rows covering every branch of the predicate.
+
+    gid 1 hits the mask, gid 2 sits in the notch (the bbox trap), gid 3 is
+    outside the envelope entirely, gid 4 has no geometry at all.
+    """
+    return await _create_layer(
+        session,
+        created_by=created_by,
+        column_type="Geometry",
+        geometry_type="POINT",
+        visibility=visibility,
+        feature_count=4,
+        values_sql=(
+            "('inside', ST_SetSRID(ST_MakePoint(0.5, 0.5), 4326),"
+            " ST_SetSRID(ST_MakePoint(0.5, 0.5), 4326)),"
+            "('in_notch', ST_SetSRID(ST_MakePoint(2, 2), 4326),"
+            " ST_SetSRID(ST_MakePoint(2, 2), 4326)),"
+            "('far_away', ST_SetSRID(ST_MakePoint(10, 10), 4326),"
+            " ST_SetSRID(ST_MakePoint(10, 10), 4326)),"
+            "('nullgeom', NULL, NULL)"
+        ),
+    )
+
+
+def _selected_gids(payload: dict) -> list:
+    return [f["properties"]["gid"] for f in payload["geojson"]["features"]]
+
+
+class TestSelectionIsExact:
+    async def test_a_feature_in_the_notch_is_not_selected(
+        self,
+        client: AsyncClient,
+        admin_auth_header: dict,
+        test_db_session: AsyncSession,
+    ):
+        """Criterion 2, the headline: envelope overlap is not selection.
+
+        gid 2 sits at (2,2), inside the mask's 3x3 bounding box and outside
+        the L itself. Clip's ``EXISTS (... WHERE geom_4326 && _src.geom_4326)``
+        admits it; only the real ST_Intersects term rejects it.
+        """
+        admin_id = await get_user_id(test_db_session, "admin")
+        mask = await _create_mask_layer(test_db_session, created_by=admin_id)
+        src = await _create_probe_features(test_db_session, created_by=admin_id)
+
+        resp = await client.post(
+            _preview_url(src.id),
+            json={"operation": "select_by_location", "mask_dataset_id": str(mask.id)},
+            headers=admin_auth_header,
+        )
+        assert resp.status_code == 200, resp.text
+        assert _selected_gids(resp.json()) == [1]
+
+        # Prove the fixture actually exercises the trap rather than passing
+        # because nothing overlapped: the bbox-only predicate takes gid 2 too.
+        bbox_only = (
+            (
+                await test_db_session.execute(
+                    text(
+                        f"SELECT s.gid FROM data.{src.table_name} AS s "  # noqa: S608
+                        f"WHERE EXISTS (SELECT 1 FROM data.{mask.table_name} AS m "
+                        f"WHERE m.geom_4326 && s.geom_4326) ORDER BY s.gid"
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+        assert list(bbox_only) == [1, 2], "fixture no longer exercises the bbox trap"
+
+    async def test_a_drawn_mask_selects_the_same_features(
+        self,
+        client: AsyncClient,
+        admin_auth_header: dict,
+        test_db_session: AsyncSession,
+    ):
+        """The inline-mask path is exact too, and agrees with the layer path.
+
+        The two render different SQL (a WHERE against a literal geometry vs an
+        EXISTS against a table), so "same shape, same answer" is a property
+        worth asserting rather than assuming.
+        """
+        admin_id = await get_user_id(test_db_session, "admin")
+        src = await _create_probe_features(test_db_session, created_by=admin_id)
+
+        resp = await client.post(
+            _preview_url(src.id),
+            json={"operation": "select_by_location", "mask": L_GEOJSON},
+            headers=admin_auth_header,
+        )
+        assert resp.status_code == 200, resp.text
+        assert _selected_gids(resp.json()) == [1]
+
+    async def test_an_invalid_source_geometry_still_answers(
+        self,
+        client: AsyncClient,
+        admin_auth_header: dict,
+        test_db_session: AsyncSession,
+    ):
+        """Neither predicate repairs its operands, so this pins the assumption
+        that lets them skip it: ST_Intersects accepts invalid geometry and
+        agrees with the repaired answer.
+
+        A bowtie is self-intersecting and therefore invalid. ST_Intersection
+        raises on it (which is why clip repairs first); ST_Intersects does not.
+        If that ever stops holding, this test fails rather than the operation
+        silently dropping rows.
+        """
+        admin_id = await get_user_id(test_db_session, "admin")
+        bowtie = "POLYGON((0.2 0.2, 0.8 0.8, 0.8 0.2, 0.2 0.8, 0.2 0.2))"
+        src = await _create_layer(
+            test_db_session,
+            created_by=admin_id,
+            column_type="Geometry",
+            geometry_type="POLYGON",
+            values_sql=(
+                f"('bowtie', ST_GeomFromText('{bowtie}', 4326),"
+                f" ST_GeomFromText('{bowtie}', 4326))"
+            ),
+        )
+        assert not (
+            await test_db_session.execute(
+                text(
+                    f"SELECT ST_IsValid(geom_4326) FROM data.{src.table_name}"  # noqa: S608
+                )
+            )
+        ).scalar_one(), "fixture must actually be invalid"
+
+        mask = await _create_mask_layer(test_db_session, created_by=admin_id)
+        resp = await client.post(
+            _preview_url(src.id),
+            json={"operation": "select_by_location", "mask_dataset_id": str(mask.id)},
+            headers=admin_auth_header,
+        )
+        assert resp.status_code == 200, resp.text
+        assert _selected_gids(resp.json()) == [1]
+
+    async def test_a_non_polygonal_mask_row_does_not_select(
+        self,
+        client: AsyncClient,
+        admin_auth_header: dict,
+        test_db_session: AsyncSession,
+    ):
+        """The ST_Dimension term, and the reason it exists.
+
+        _load_mask_dataset rejects a non-polygonal mask DATASET, but the
+        catalog classifies geometry_type from the FIRST feature (fix(#682)), so
+        a POLYGON-typed layer can still hold a line row. Clip drops those in
+        _mask_pieces; without the dimension term a selection would honour them,
+        and clipping and selecting against one layer would disagree.
+        """
+        admin_id = await get_user_id(test_db_session, "admin")
+        mask = await _create_layer(
+            test_db_session,
+            created_by=admin_id,
+            column_type="Geometry",
+            geometry_type="POLYGON",  # classified from row 1, which IS a polygon
+            feature_count=2,
+            values_sql=(
+                f"('L', ST_GeomFromText('{L_WKT}', 4326),"
+                f" ST_GeomFromText('{L_WKT}', 4326)),"
+                "('stray_line',"
+                " ST_GeomFromText('LINESTRING(1.5 1.5, 2.5 2.5)', 4326),"
+                " ST_GeomFromText('LINESTRING(1.5 1.5, 2.5 2.5)', 4326))"
+            ),
+        )
+        src = await _create_probe_features(test_db_session, created_by=admin_id)
+
+        resp = await client.post(
+            _preview_url(src.id),
+            json={"operation": "select_by_location", "mask_dataset_id": str(mask.id)},
+            headers=admin_auth_header,
+        )
+        assert resp.status_code == 200, resp.text
+        # gid 2 sits at (2,2), ON the stray line. It stays unselected.
+        assert _selected_gids(resp.json()) == [1]
+
+
+class TestGeometriesSurviveWhole:
+    async def test_the_selected_geometry_equals_the_source_geometry(
+        self,
+        client: AsyncClient,
+        admin_auth_header: dict,
+        test_db_session: AsyncSession,
+    ):
+        """Criterion 3, and the line between this operation and clip.
+
+        The straddler pokes out past the mask's right edge. A clip returns the
+        overlap; a selection returns the feature.
+        """
+        admin_id = await get_user_id(test_db_session, "admin")
+        mask = await _create_mask_layer(test_db_session, created_by=admin_id)
+        src = await _create_layer(
+            test_db_session,
+            created_by=admin_id,
+            column_type="Geometry",
+            geometry_type="POLYGON",
+            values_sql=(
+                f"('straddler', ST_GeomFromText('{STRADDLER_WKT}', 4326),"
+                f" ST_GeomFromText('{STRADDLER_WKT}', 4326))"
+            ),
+        )
+
+        selected = await client.post(
+            _preview_url(src.id),
+            json={"operation": "select_by_location", "mask_dataset_id": str(mask.id)},
+            headers=admin_auth_header,
+        )
+        assert selected.status_code == 200, selected.text
+        features = selected.json()["geojson"]["features"]
+        assert len(features) == 1
+
+        equals_source = (
+            await test_db_session.execute(
+                text(
+                    "SELECT ST_Equals(geom_4326, "  # noqa: S608
+                    "ST_SetSRID(ST_GeomFromGeoJSON(:g), 4326)) "
+                    f"FROM data.{src.table_name} WHERE gid = 1"
+                ).bindparams(g=json.dumps(features[0]["geometry"]))
+            )
+        ).scalar_one()
+        assert equals_source, "selection must not modify the geometry"
+
+        # And the contrast: a clip of the same pair does change it.
+        clipped = await client.post(
+            _preview_url(src.id),
+            json={"operation": "clip", "mask_dataset_id": str(mask.id)},
+            headers=admin_auth_header,
+        )
+        assert clipped.status_code == 200, clipped.text
+        assert (
+            clipped.json()["geojson"]["features"][0]["geometry"]
+            != features[0]["geometry"]
+        ), "fixture must straddle the mask edge for this contrast to mean anything"
+
+
+class TestNullGeometries:
+    async def test_null_rows_in_either_layer_neither_crash_nor_select(
+        self,
+        client: AsyncClient,
+        admin_auth_header: dict,
+        test_db_session: AsyncSession,
+    ):
+        """Criterion 6. The source fixture already carries a NULL row (gid 4);
+        this adds one on the mask side too.
+
+        Neither predicate carries an explicit IS NOT NULL guard: `&&` yields
+        NULL against a NULL operand and PostgreSQL's three-valued logic drops
+        the row. Asserted rather than argued, because a redundant-looking guard
+        is exactly the kind of thing a later edit removes.
+        """
+        admin_id = await get_user_id(test_db_session, "admin")
+        mask = await _create_layer(
+            test_db_session,
+            created_by=admin_id,
+            column_type="Geometry",
+            geometry_type="POLYGON",
+            feature_count=2,
+            values_sql=(
+                f"('L', ST_GeomFromText('{L_WKT}', 4326),"
+                f" ST_GeomFromText('{L_WKT}', 4326)),"
+                "('nullgeom', NULL, NULL)"
+            ),
+        )
+        src = await _create_probe_features(test_db_session, created_by=admin_id)
+
+        resp = await client.post(
+            _preview_url(src.id),
+            json={"operation": "select_by_location", "mask_dataset_id": str(mask.id)},
+            headers=admin_auth_header,
+        )
+        assert resp.status_code == 200, resp.text
+        assert _selected_gids(resp.json()) == [1]
+        assert resp.json()["feature_count"] == 1
+        # The count runs its own statement, so it needs its own proof that the
+        # NULL rows did not reach it.
+        assert resp.json()["match_count"] == 1
+
+
+class TestSelectedCount:
+    async def test_the_count_is_exact_beyond_the_preview_cap(
+        self,
+        client: AsyncClient,
+        admin_auth_header: dict,
+        test_db_session: AsyncSession,
+    ):
+        """Criterion 5: the deliverable is the record list, so its SIZE cannot
+        be a capped number.
+
+        The preview truncates at PREVIEW_FEATURE_CAP; match_count comes from a
+        second, uncapped statement built from the same WHERE.
+        """
+        admin_id = await get_user_id(test_db_session, "admin")
+        mask = await _create_mask_layer(test_db_session, created_by=admin_id)
+        total = PREVIEW_FEATURE_CAP + 25
+        # Points spread along y inside the mask's left bar (x=0.5, y 0->3),
+        # plus one in the notch that must not be counted.
+        src = await _create_layer(
+            test_db_session,
+            created_by=admin_id,
+            column_type="Geometry",
+            geometry_type="POINT",
+            feature_count=total + 1,
+            values_sql=(
+                "('notch', ST_SetSRID(ST_MakePoint(2, 2), 4326),"
+                " ST_SetSRID(ST_MakePoint(2, 2), 4326))"
+            ),
+        )
+        await test_db_session.execute(
+            text(
+                f"INSERT INTO data.{src.table_name} (name, geom, geom_4326) "  # noqa: S608
+                "SELECT 'p' || i,"
+                " ST_SetSRID(ST_MakePoint(0.5, i * 0.005), 4326),"
+                " ST_SetSRID(ST_MakePoint(0.5, i * 0.005), 4326)"
+                " FROM generate_series(1, :n) AS i"
+            ).bindparams(n=total)
+        )
+        await test_db_session.commit()
+
+        resp = await client.post(
+            _preview_url(src.id),
+            json={"operation": "select_by_location", "mask_dataset_id": str(mask.id)},
+            headers=admin_auth_header,
+        )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["truncated"] is True
+        assert body["feature_count"] == PREVIEW_FEATURE_CAP
+        assert body["match_count"] == total, "the notch point must not be counted"
+        # A row-filtering operation cannot report a source total (clip's rule).
+        assert body["source_feature_count"] is None
+
+    async def test_the_count_matches_the_feature_list_under_the_cap(
+        self,
+        client: AsyncClient,
+        admin_auth_header: dict,
+        test_db_session: AsyncSession,
+    ):
+        """The count statement is rendered separately from the preview, so this
+        pins the two to the same answer on the same inputs — including the
+        NULL-geometry row, which neither may count."""
+        admin_id = await get_user_id(test_db_session, "admin")
+        mask = await _create_mask_layer(test_db_session, created_by=admin_id)
+        src = await _create_probe_features(test_db_session, created_by=admin_id)
+
+        for body in (
+            {"operation": "select_by_location", "mask_dataset_id": str(mask.id)},
+            {"operation": "select_by_location", "mask": L_GEOJSON},
+        ):
+            resp = await client.post(
+                _preview_url(src.id), json=body, headers=admin_auth_header
+            )
+            assert resp.status_code == 200, resp.text
+            payload = resp.json()
+            assert payload["match_count"] == payload["feature_count"] == 1
+
+
+class TestAccessControl:
+    async def test_a_mask_layer_the_caller_cannot_see_is_a_404(
+        self,
+        client: AsyncClient,
+        editor_auth_header: dict,
+        test_db_session: AsyncSession,
+    ):
+        """Criterion 4: Rule 1 applies to BOTH datasets. Read on the source and
+        not on the mask is a 404, on preview and materialize alike."""
+        admin_id = await get_user_id(test_db_session, "admin")
+        src = await _create_probe_features(test_db_session, created_by=admin_id)
+        private_mask = await _create_mask_layer(
+            test_db_session, created_by=admin_id, visibility="private"
+        )
+
+        for url in (_preview_url(src.id), _materialize_url(src.id)):
+            resp = await client.post(
+                url,
+                json={
+                    "operation": "select_by_location",
+                    "mask_dataset_id": str(private_mask.id),
+                    "title": "Nope",
+                },
+                headers=editor_auth_header,
+            )
+            assert resp.status_code == 404, f"{url}: {resp.text}"
+
+    async def test_a_private_source_is_a_404_even_with_a_visible_mask(
+        self,
+        client: AsyncClient,
+        editor_auth_header: dict,
+        test_db_session: AsyncSession,
+    ):
+        """The other direction of the same rule."""
+        admin_id = await get_user_id(test_db_session, "admin")
+        private_src = await _create_probe_features(
+            test_db_session, created_by=admin_id, visibility="private"
+        )
+        mask = await _create_mask_layer(test_db_session, created_by=admin_id)
+
+        resp = await client.post(
+            _preview_url(private_src.id),
+            json={
+                "operation": "select_by_location",
+                "mask_dataset_id": str(mask.id),
+            },
+            headers=editor_auth_header,
+        )
+        assert resp.status_code == 404, resp.text
+
+
+class TestEnqueueValidation:
+    async def test_oversized_source_rejected_at_enqueue(
+        self,
+        client: AsyncClient,
+        admin_auth_header: dict,
+        test_db_session: AsyncSession,
+    ):
+        """Criterion 7. The router reads MAX_SOURCE_FEATURES with .get(), so a
+        missing key leaves the operation with NO ceiling rather than a default
+        one — the entry existing is half the assertion."""
+        assert "select_by_location" in MAX_SOURCE_FEATURES
+        admin_id = await get_user_id(test_db_session, "admin")
+        mask = await _create_mask_layer(test_db_session, created_by=admin_id)
+        src = await _create_probe_features(test_db_session, created_by=admin_id)
+        src.feature_count = MAX_SOURCE_FEATURES["select_by_location"] + 1
+        await test_db_session.commit()
+
+        resp = await client.post(
+            _materialize_url(src.id),
+            json={
+                "operation": "select_by_location",
+                "mask_dataset_id": str(mask.id),
+                "title": "Too big",
+            },
+            headers=admin_auth_header,
+        )
+        assert resp.status_code == 422
+        assert "too large" in resp.text
+
+    async def test_exactly_one_mask_source_is_required(
+        self,
+        client: AsyncClient,
+        admin_auth_header: dict,
+        test_db_session: AsyncSession,
+    ):
+        """Neither mask nor both: the same rule clip carries, now shared."""
+        admin_id = await get_user_id(test_db_session, "admin")
+        mask = await _create_mask_layer(test_db_session, created_by=admin_id)
+        src = await _create_probe_features(test_db_session, created_by=admin_id)
+
+        neither = await client.post(
+            _preview_url(src.id),
+            json={"operation": "select_by_location"},
+            headers=admin_auth_header,
+        )
+        assert neither.status_code == 422, neither.text
+
+        both = await client.post(
+            _preview_url(src.id),
+            json={
+                "operation": "select_by_location",
+                "mask": L_GEOJSON,
+                "mask_dataset_id": str(mask.id),
+            },
+            headers=admin_auth_header,
+        )
+        assert both.status_code == 422, both.text
+
+    async def test_mask_params_are_still_dropped_for_other_operations(
+        self,
+        client: AsyncClient,
+        admin_auth_header: dict,
+        test_db_session: AsyncSession,
+    ):
+        """_ANALYSIS_PARAM_OWNERS values became tuples to let two operations
+        share the mask pair. A stray mask_dataset_id on a centroid must still
+        be dropped rather than resolved — a private id here would 404 if the
+        widening had accidentally made the params global."""
+        admin_id = await get_user_id(test_db_session, "admin")
+        src = await _create_probe_features(test_db_session, created_by=admin_id)
+        private_mask = await _create_mask_layer(
+            test_db_session, created_by=admin_id, visibility="private"
+        )
+
+        resp = await client.post(
+            _preview_url(src.id),
+            json={
+                "operation": "centroid",
+                "mask_dataset_id": str(private_mask.id),
+            },
+            headers=admin_auth_header,
+        )
+        assert resp.status_code == 200, resp.text
+
+
+class TestMaterialize:
+    async def test_the_saved_dataset_carries_whole_geometries_and_columns(
+        self,
+        test_db_session: AsyncSession,
+    ):
+        """The worker uses the same renderer as the preview, so the saved
+        dataset is the approved selection rather than a second answer."""
+        admin_id = await get_user_id(test_db_session, "admin")
+        mask = await _create_mask_layer(test_db_session, created_by=admin_id)
+        src = await _create_layer(
+            test_db_session,
+            created_by=admin_id,
+            column_type="Geometry",
+            geometry_type="POLYGON",
+            feature_count=3,
+            values_sql=(
+                f"('straddler', ST_GeomFromText('{STRADDLER_WKT}', 4326),"
+                f" ST_GeomFromText('{STRADDLER_WKT}', 4326)),"
+                "('notch',"
+                " ST_GeomFromText('POLYGON((2 2, 2.5 2, 2.5 2.5, 2 2.5, 2 2))', 4326),"
+                " ST_GeomFromText('POLYGON((2 2, 2.5 2, 2.5 2.5, 2 2.5, 2 2))',"
+                " 4326)),"
+                "('nullgeom', NULL, NULL)"
+            ),
+        )
+        job = await _create_job(test_db_session, admin_id)
+
+        await _materialize(
+            job_id=str(job.id),
+            dataset_id=str(src.id),
+            user_id=str(admin_id),
+            operation="select_by_location",
+            title=f"Selected {uuid.uuid4().hex[:6]}",
+            mask_dataset_id=str(mask.id),
+        )
+
+        await test_db_session.refresh(job)
+        assert job.status == "complete", job.error_message
+
+        from app.modules.catalog.datasets.domain.models import Dataset
+
+        out = await test_db_session.get(Dataset, job.dataset_id)
+        assert out is not None
+        assert out.feature_count == 1
+
+        rows = (
+            await test_db_session.execute(
+                text(
+                    f"SELECT o.gid, o.name,"  # noqa: S608
+                    f" ST_Equals(o.geom_4326, s.geom_4326)"
+                    f" FROM data.{out.table_name} AS o"
+                    f" JOIN data.{src.table_name} AS s ON s.gid = o.gid"
+                )
+            )
+        ).all()
+        assert len(rows) == 1
+        gid, name, same_geom = rows[0]
+        assert (gid, name) == (1, "straddler")
+        assert same_geom, "materialize must not clip the selected geometry"
+
+    async def test_a_drawn_mask_materializes_through_the_generic_branch(
+        self,
+        test_db_session: AsyncSession,
+    ):
+        """The inline path adds no branch to _build_materialize_select; it
+        rides render_geometry_expr's identity expression and _wrap_not_empty.
+        Worth its own test precisely because nothing in the worker names it."""
+        admin_id = await get_user_id(test_db_session, "admin")
+        src = await _create_probe_features(test_db_session, created_by=admin_id)
+        job = await _create_job(test_db_session, admin_id)
+
+        await _materialize(
+            job_id=str(job.id),
+            dataset_id=str(src.id),
+            user_id=str(admin_id),
+            operation="select_by_location",
+            title=f"Drawn {uuid.uuid4().hex[:6]}",
+            mask=L_GEOJSON,
+        )
+
+        await test_db_session.refresh(job)
+        assert job.status == "complete", job.error_message
+
+        from app.modules.catalog.datasets.domain.models import Dataset
+
+        out = await test_db_session.get(Dataset, job.dataset_id)
+        assert out is not None
+        assert out.feature_count == 1
+        names = (
+            (
+                await test_db_session.execute(
+                    text(f"SELECT name FROM data.{out.table_name}")  # noqa: S608
+                )
+            )
+            .scalars()
+            .all()
+        )
+        assert list(names) == ["inside"]

--- a/backend/tests/test_analysis_spatial_join.py
+++ b/backend/tests/test_analysis_spatial_join.py
@@ -61,7 +61,11 @@ async def _create_layer(
             f")"
         )
     )
-    cols = "name, " + extra_columns.replace(" TEXT,", ",").replace(" INTEGER,", ",")
+    # Column NAMES from the declarations: the first token of each
+    # comma-separated entry. Stripping known type keywords instead broke the
+    # moment a two-word type appeared (DOUBLE PRECISION).
+    extra_names = [d.strip().split()[0] for d in extra_columns.split(",") if d.strip()]
+    cols = "".join(f"{n}, " for n in ["name", *extra_names])
     await session.execute(
         text(
             f"INSERT INTO data.{table_name} ({cols} geom, geom_4326) "  # noqa: S608

--- a/backend/tests/test_analysis_spatial_join.py
+++ b/backend/tests/test_analysis_spatial_join.py
@@ -215,6 +215,86 @@ class TestSpatialJoinPreview:
         # The source's NULL-geometry row produced no feature and no error.
         assert 4 not in counts
 
+    async def test_invalid_join_geometry_neither_raises_nor_changes_the_count(
+        self,
+        client: AsyncClient,
+        admin_auth_header: dict,
+        test_db_session: AsyncSession,
+    ):
+        """The join side is tested RAW, without ST_MakeValid — see the note in
+        render_spatial_join for the 33.68s-vs-1.98s measurement behind that.
+
+        This pins the safety half of that trade: a self-intersecting bowtie in
+        the join layer must not abort the statement (which ST_Intersection over
+        the same geometry does), and must produce the count the repaired
+        geometry would.
+        """
+        admin_id = await get_user_id(test_db_session, "admin")
+        # Bowtie crossing at (1,1): two lobes, left and right, and the region
+        # directly below the crossing belongs to neither.
+        bowtie = await _create_layer(
+            test_db_session,
+            created_by=admin_id,
+            column_type="Geometry",
+            geometry_type="POLYGON",
+            values_sql=(
+                "('bowtie',"
+                " ST_GeomFromText('POLYGON((0 0, 2 2, 2 0, 0 2, 0 0))', 4326),"
+                " ST_GeomFromText('POLYGON((0 0, 2 2, 2 0, 0 2, 0 0))', 4326))"
+            ),
+        )
+        assert not (
+            await test_db_session.execute(
+                text(
+                    f"SELECT ST_IsValid(geom_4326) "  # noqa: S608
+                    f"FROM data.{bowtie.table_name} LIMIT 1"
+                )
+            )
+        ).scalar_one(), "fixture must actually be invalid or this proves nothing"
+
+        probes = await _create_layer(
+            test_db_session,
+            created_by=admin_id,
+            column_type="Point",
+            geometry_type="POINT",
+            values_sql=(
+                # Inside the left lobe.
+                "('in_lobe', ST_SetSRID(ST_MakePoint(0.3,1.0),4326),"
+                " ST_SetSRID(ST_MakePoint(0.3,1.0),4326)),"
+                # Below the crossing: inside the bbox, inside NEITHER lobe.
+                "('between', ST_SetSRID(ST_MakePoint(1,0.5),4326),"
+                " ST_SetSRID(ST_MakePoint(1,0.5),4326))"
+            ),
+            feature_count=2,
+        )
+
+        resp = await client.post(
+            _preview_url(probes.id),
+            json={"operation": "spatial_join", "join_dataset_id": str(bowtie.id)},
+            headers=admin_auth_header,
+        )
+        assert resp.status_code == 200, resp.text
+        counts = {
+            f["properties"]["gid"]: f["properties"]["join_count"]
+            for f in resp.json()["geojson"]["features"]
+        }
+
+        # Ground truth from the REPAIRED geometry: the raw predicate must agree.
+        expected = {
+            gid: (
+                await test_db_session.execute(
+                    text(
+                        f"SELECT count(*) FROM data.{bowtie.table_name} b "  # noqa: S608
+                        f"JOIN data.{probes.table_name} p ON p.gid = :gid "
+                        f"WHERE ST_Intersects(ST_MakeValid(b.geom_4326), p.geom_4326)"
+                    ).bindparams(gid=gid)
+                )
+            ).scalar_one()
+            for gid in counts
+        }
+        assert counts == expected
+        assert set(counts.values()) == {0, 1}, counts
+
     async def test_match_count_covers_the_whole_source_not_the_cap(
         self,
         client: AsyncClient,

--- a/backend/tests/test_analysis_spatial_join.py
+++ b/backend/tests/test_analysis_spatial_join.py
@@ -1,0 +1,597 @@
+"""Spatial join: point-in-polygon count and attribute transfer (#953).
+
+One test per acceptance criterion on the issue, plus the two enqueue-time
+validations that keep a bad request from becoming a job that fails minutes
+later with a database error.
+
+Requirements:
+  - Docker database must be running (docker compose up db)
+"""
+
+import uuid
+from unittest.mock import AsyncMock, patch
+
+from httpx import AsyncClient
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.modules.catalog.datasets.api import router_analysis
+from app.modules.catalog.datasets.domain.service_analysis import PREVIEW_FEATURE_CAP
+from app.platform.analysis_sql import MAX_SOURCE_FEATURES
+from app.processing.analysis.tasks import _materialize
+
+from tests.factories import create_dataset, get_user_id
+from tests.test_analysis_materialize import _create_job
+
+
+def _preview_url(dataset_id) -> str:
+    return f"/datasets/{dataset_id}/analysis/preview/"
+
+
+def _materialize_url(dataset_id) -> str:
+    return f"/datasets/{dataset_id}/analysis/materialize/"
+
+
+async def _create_layer(
+    session: AsyncSession,
+    *,
+    created_by: uuid.UUID,
+    values_sql: str,
+    column_type: str,
+    geometry_type: str,
+    extra_columns: str = "",
+    column_info: list[dict] | None = None,
+    visibility: str = "public",
+    feature_count: int = 1,
+):
+    """Create a dataset whose table is populated by a literal VALUES clause.
+
+    ``values_sql`` is inserted verbatim after ``VALUES`` and must supply
+    ``(name, geom, geom_4326)`` plus whatever ``extra_columns`` declares.
+    """
+    table_name = f"ds_{uuid.uuid4().hex[:12]}"
+    await session.execute(
+        text(
+            f"CREATE TABLE data.{table_name} ("
+            f"  gid SERIAL PRIMARY KEY,"
+            f"  name TEXT,"
+            f"  {extra_columns}"
+            f"  geom geometry({column_type}, 4326),"
+            f"  geom_4326 geometry({column_type}, 4326)"
+            f")"
+        )
+    )
+    cols = "name, " + extra_columns.replace(" TEXT,", ",").replace(" INTEGER,", ",")
+    await session.execute(
+        text(
+            f"INSERT INTO data.{table_name} ({cols} geom, geom_4326) "  # noqa: S608
+            f"VALUES {values_sql}"
+        )
+    )
+    await session.commit()
+    return await create_dataset(
+        session,
+        created_by=created_by,
+        table_name=table_name,
+        geometry_type=geometry_type,
+        feature_count=feature_count,
+        visibility=visibility,
+        column_info=column_info or [{"name": "name", "type": "text"}],
+    )
+
+
+async def _create_two_overlapping_polygons(
+    session: AsyncSession, *, created_by: uuid.UUID, visibility: str = "public"
+):
+    """Two 1x1 polygons overlapping in x=[0.5, 1], plus a NULL-geometry row.
+
+    A point at x=0.75 falls inside BOTH, which is the duplicate-row case the
+    tie-break exists for. The NULL row must never inflate a count.
+    """
+    return await _create_layer(
+        session,
+        created_by=created_by,
+        column_type="Geometry",
+        geometry_type="POLYGON",
+        extra_columns="pop INTEGER,",
+        values_sql=(
+            "('poly_a', 100, ST_MakeEnvelope(0,0,1,1,4326),"
+            " ST_MakeEnvelope(0,0,1,1,4326)),"
+            "('poly_b', 200, ST_MakeEnvelope(0.5,0,1.5,1,4326),"
+            " ST_MakeEnvelope(0.5,0,1.5,1,4326)),"
+            "('nullgeom', 999, NULL, NULL)"
+        ),
+        column_info=[
+            {"name": "name", "type": "text"},
+            {"name": "pop", "type": "integer"},
+        ],
+        visibility=visibility,
+        feature_count=3,
+    )
+
+
+async def _create_probe_points(
+    session: AsyncSession, *, created_by: uuid.UUID, visibility: str = "public"
+):
+    """Three points plus a NULL-geometry row.
+
+    ``in_both`` sits in the overlap, ``in_a_only`` in one polygon, ``outside``
+    in neither — so one fixture covers the tie-break, the ordinary match, and
+    the no-match row that must survive as 1:1 output.
+    """
+    return await _create_layer(
+        session,
+        created_by=created_by,
+        column_type="Point",
+        geometry_type="POINT",
+        values_sql=(
+            "('in_both', ST_SetSRID(ST_MakePoint(0.75,0.5),4326),"
+            " ST_SetSRID(ST_MakePoint(0.75,0.5),4326)),"
+            "('in_a_only', ST_SetSRID(ST_MakePoint(0.25,0.5),4326),"
+            " ST_SetSRID(ST_MakePoint(0.25,0.5),4326)),"
+            "('outside', ST_SetSRID(ST_MakePoint(50,50),4326),"
+            " ST_SetSRID(ST_MakePoint(50,50),4326)),"
+            "('nullgeom', NULL, NULL)"
+        ),
+        visibility=visibility,
+        feature_count=4,
+    )
+
+
+class TestSpatialJoinPreview:
+    async def test_overlap_yields_one_row_under_the_tie_break(
+        self,
+        client: AsyncClient,
+        admin_auth_header: dict,
+        test_db_session: AsyncSession,
+    ):
+        """Criterion 2, preview half: a point inside two overlapping polygons
+        produces exactly ONE feature, counting both, carrying the lowest-gid
+        polygon's attributes."""
+        admin_id = await get_user_id(test_db_session, "admin")
+        points = await _create_probe_points(test_db_session, created_by=admin_id)
+        polys = await _create_two_overlapping_polygons(
+            test_db_session, created_by=admin_id
+        )
+
+        resp = await client.post(
+            _preview_url(points.id),
+            json={
+                "operation": "spatial_join",
+                "join_dataset_id": str(polys.id),
+                "join_fields": ["name", "pop"],
+            },
+            headers=admin_auth_header,
+        )
+        assert resp.status_code == 200, resp.text
+        features = resp.json()["geojson"]["features"]
+
+        by_gid = {f["properties"]["gid"]: f["properties"] for f in features}
+        # The NULL-geometry source row is dropped; the other three survive.
+        assert len(features) == 3
+        # One row, both polygons counted, poly_a (lower gid) wins the tie.
+        assert by_gid[1]["join_count"] == 2
+        assert by_gid[1]["join_name"] == "poly_a"
+        assert by_gid[1]["join_pop"] == 100
+        assert by_gid[2]["join_count"] == 1
+        # The unmatched point KEEPS its row: the operation is 1:1.
+        assert by_gid[3]["join_count"] == 0
+        assert by_gid[3]["join_name"] is None
+
+    async def test_null_geometries_neither_crash_nor_inflate_counts(
+        self,
+        client: AsyncClient,
+        admin_auth_header: dict,
+        test_db_session: AsyncSession,
+    ):
+        """Criterion 3: both fixtures carry a NULL-geometry row. The join
+        layer's must not be counted, and the source's must not fail the run.
+
+        What makes this hold is PostGIS three-valued logic, not the explicit
+        IS NOT NULL term in the predicate — removing that term keeps this test
+        green (checked by mutation). The behaviour is what the criterion asks
+        for, so the behaviour is what is pinned here.
+        """
+        admin_id = await get_user_id(test_db_session, "admin")
+        points = await _create_probe_points(test_db_session, created_by=admin_id)
+        polys = await _create_two_overlapping_polygons(
+            test_db_session, created_by=admin_id
+        )
+
+        resp = await client.post(
+            _preview_url(points.id),
+            json={"operation": "spatial_join", "join_dataset_id": str(polys.id)},
+            headers=admin_auth_header,
+        )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        counts = {
+            f["properties"]["gid"]: f["properties"]["join_count"]
+            for f in body["geojson"]["features"]
+        }
+        # 2 real polygons match the overlap point, NOT 3 — the NULL row in the
+        # join layer is excluded rather than silently counted.
+        assert counts == {1: 2, 2: 1, 3: 0}
+        # The source's NULL-geometry row produced no feature and no error.
+        assert 4 not in counts
+
+    async def test_match_count_covers_the_whole_source_not_the_cap(
+        self,
+        client: AsyncClient,
+        admin_auth_header: dict,
+        test_db_session: AsyncSession,
+    ):
+        """Criterion 1: with more source features than PREVIEW_FEATURE_CAP the
+        geometry preview truncates, but match_count reports the true total.
+
+        This is the whole reason the count is a separate statement: summing the
+        previewed rows would answer for 500 of them and look like the answer.
+        """
+        admin_id = await get_user_id(test_db_session, "admin")
+        n = PREVIEW_FEATURE_CAP + 1
+        table_name = f"ds_{uuid.uuid4().hex[:12]}"
+        await test_db_session.execute(
+            text(
+                f"CREATE TABLE data.{table_name} ("
+                f"  gid SERIAL PRIMARY KEY, name TEXT,"
+                f"  geom geometry(Point, 4326),"
+                f"  geom_4326 geometry(Point, 4326))"
+            )
+        )
+        # n points spread across the unit square, so every one of them falls
+        # inside poly_a and exactly the ones past x=0.5 also fall inside poly_b.
+        await test_db_session.execute(
+            text(
+                f"INSERT INTO data.{table_name} (name, geom, geom_4326) "  # noqa: S608
+                f"SELECT 'p' || i,"
+                f" ST_SetSRID(ST_MakePoint(i::float/{n}, 0.5), 4326),"
+                f" ST_SetSRID(ST_MakePoint(i::float/{n}, 0.5), 4326)"
+                f" FROM generate_series(1, {n}) AS i"
+            )
+        )
+        await test_db_session.commit()
+        source = await create_dataset(
+            test_db_session,
+            created_by=admin_id,
+            table_name=table_name,
+            geometry_type="POINT",
+            feature_count=n,
+            column_info=[{"name": "name", "type": "text"}],
+        )
+        polys = await _create_two_overlapping_polygons(
+            test_db_session, created_by=admin_id
+        )
+
+        resp = await client.post(
+            _preview_url(source.id),
+            json={"operation": "spatial_join", "join_dataset_id": str(polys.id)},
+            headers=admin_auth_header,
+        )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+
+        assert body["truncated"] is True
+        assert body["feature_count"] == PREVIEW_FEATURE_CAP
+        assert body["source_feature_count"] == n
+
+        # Ground truth, computed independently of the code under test.
+        expected = (
+            await test_db_session.execute(
+                text(
+                    f"SELECT count(*) FROM data.{table_name} s "  # noqa: S608
+                    f"JOIN data.{polys.table_name} p "
+                    f"ON ST_Intersects(s.geom_4326, p.geom_4326)"
+                )
+            )
+        ).scalar_one()
+        assert body["match_count"] == expected
+        # Not the capped number, and not a per-row count either.
+        assert body["match_count"] > PREVIEW_FEATURE_CAP
+
+    async def test_join_dataset_visibility_is_enforced(
+        self,
+        client: AsyncClient,
+        editor_auth_header: dict,
+        test_db_session: AsyncSession,
+    ):
+        """Criterion 4: Rule 1 applies to BOTH datasets. Read on the source and
+        not on the join layer is a 404, not a join the caller cannot see."""
+        admin_id = await get_user_id(test_db_session, "admin")
+        points = await _create_probe_points(test_db_session, created_by=admin_id)
+        private_polys = await _create_two_overlapping_polygons(
+            test_db_session, created_by=admin_id, visibility="private"
+        )
+
+        for url in (_preview_url(points.id), _materialize_url(points.id)):
+            resp = await client.post(
+                url,
+                json={
+                    "operation": "spatial_join",
+                    "join_dataset_id": str(private_polys.id),
+                    "title": "Nope",
+                },
+                headers=editor_auth_header,
+            )
+            assert resp.status_code == 404, f"{url}: {resp.text}"
+
+    async def test_join_params_are_dropped_for_other_operations(
+        self,
+        client: AsyncClient,
+        admin_auth_header: dict,
+        test_db_session: AsyncSession,
+    ):
+        """A stray join_dataset_id on a centroid must be ignored, not loaded —
+        the _ANALYSIS_PARAM_OWNERS contract (fix(#682)) extended to the new
+        params. A private id here would 404 if it were being resolved."""
+        admin_id = await get_user_id(test_db_session, "admin")
+        points = await _create_probe_points(test_db_session, created_by=admin_id)
+        private_polys = await _create_two_overlapping_polygons(
+            test_db_session, created_by=admin_id, visibility="private"
+        )
+
+        resp = await client.post(
+            _preview_url(points.id),
+            json={
+                "operation": "centroid",
+                "join_dataset_id": str(private_polys.id),
+                "join_fields": ["name"],
+            },
+            headers=admin_auth_header,
+        )
+        assert resp.status_code == 200, resp.text
+        props = resp.json()["geojson"]["features"][0]["properties"]
+        assert "join_count" not in props
+        assert resp.json()["match_count"] is None
+
+
+class TestSpatialJoinEnqueueValidation:
+    async def test_unknown_join_column_rejected(
+        self,
+        client: AsyncClient,
+        admin_auth_header: dict,
+        test_db_session: AsyncSession,
+    ):
+        admin_id = await get_user_id(test_db_session, "admin")
+        points = await _create_probe_points(test_db_session, created_by=admin_id)
+        polys = await _create_two_overlapping_polygons(
+            test_db_session, created_by=admin_id
+        )
+
+        resp = await client.post(
+            _materialize_url(points.id),
+            json={
+                "operation": "spatial_join",
+                "join_dataset_id": str(polys.id),
+                "join_fields": ["not_a_column"],
+                "title": "Nope",
+            },
+            headers=admin_auth_header,
+        )
+        assert resp.status_code == 422
+        assert "not_a_column" in resp.text
+
+    async def test_generated_column_collision_rejected(
+        self,
+        client: AsyncClient,
+        admin_auth_header: dict,
+        test_db_session: AsyncSession,
+    ):
+        """A source that already has a join_count column would reach the CTAS
+        twice and fail it with "column specified more than once" after the
+        whole queue wait. Named at enqueue instead."""
+        admin_id = await get_user_id(test_db_session, "admin")
+        source = await _create_layer(
+            test_db_session,
+            created_by=admin_id,
+            column_type="Point",
+            geometry_type="POINT",
+            extra_columns="join_count INTEGER,",
+            values_sql=(
+                "('p', 7, ST_SetSRID(ST_MakePoint(0.75,0.5),4326),"
+                " ST_SetSRID(ST_MakePoint(0.75,0.5),4326))"
+            ),
+            column_info=[
+                {"name": "name", "type": "text"},
+                {"name": "join_count", "type": "integer"},
+            ],
+        )
+        polys = await _create_two_overlapping_polygons(
+            test_db_session, created_by=admin_id
+        )
+
+        resp = await client.post(
+            _materialize_url(source.id),
+            json={
+                "operation": "spatial_join",
+                "join_dataset_id": str(polys.id),
+                "title": "Nope",
+            },
+            headers=admin_auth_header,
+        )
+        assert resp.status_code == 422
+        assert "join_count" in resp.text
+
+    async def test_oversized_source_rejected_at_enqueue(
+        self,
+        client: AsyncClient,
+        admin_auth_header: dict,
+        test_db_session: AsyncSession,
+    ):
+        """Criterion 5: spatial_join has a MAX_SOURCE_FEATURES entry and the
+        enqueue-time 422 fires. Without the entry the router's .get() would
+        skip the gate entirely rather than apply a default."""
+        assert "spatial_join" in MAX_SOURCE_FEATURES
+        admin_id = await get_user_id(test_db_session, "admin")
+        points = await _create_probe_points(test_db_session, created_by=admin_id)
+        polys = await _create_two_overlapping_polygons(
+            test_db_session, created_by=admin_id
+        )
+        # The cached snapshot is what the gate reads first.
+        points.feature_count = MAX_SOURCE_FEATURES["spatial_join"] + 1
+        await test_db_session.commit()
+
+        resp = await client.post(
+            _materialize_url(points.id),
+            json={
+                "operation": "spatial_join",
+                "join_dataset_id": str(polys.id),
+                "title": "Too big",
+            },
+            headers=admin_auth_header,
+        )
+        assert resp.status_code == 422
+        assert "too large" in resp.text
+
+    async def test_missing_join_dataset_id_rejected(
+        self,
+        client: AsyncClient,
+        admin_auth_header: dict,
+        test_db_session: AsyncSession,
+    ):
+        admin_id = await get_user_id(test_db_session, "admin")
+        points = await _create_probe_points(test_db_session, created_by=admin_id)
+
+        resp = await client.post(
+            _preview_url(points.id),
+            json={"operation": "spatial_join"},
+            headers=admin_auth_header,
+        )
+        assert resp.status_code == 422
+
+    async def test_job_metadata_records_the_join(
+        self,
+        client: AsyncClient,
+        admin_auth_header: dict,
+        test_db_session: AsyncSession,
+    ):
+        """Admin → Jobs has to be able to say what a failed run was doing."""
+        admin_id = await get_user_id(test_db_session, "admin")
+        points = await _create_probe_points(test_db_session, created_by=admin_id)
+        polys = await _create_two_overlapping_polygons(
+            test_db_session, created_by=admin_id
+        )
+
+        with patch.object(router_analysis, "defer_async_with_tenant", AsyncMock()):
+            resp = await client.post(
+                _materialize_url(points.id),
+                json={
+                    "operation": "spatial_join",
+                    "join_dataset_id": str(polys.id),
+                    "join_fields": ["name"],
+                    "title": f"Joined {uuid.uuid4().hex[:6]}",
+                },
+                headers=admin_auth_header,
+            )
+        assert resp.status_code == 200, resp.text
+
+        from app.platform.jobs.models import IngestJob
+
+        job = await test_db_session.get(IngestJob, uuid.UUID(resp.json()["job_id"]))
+        meta = job.user_metadata["analysis"]
+        assert meta["operation"] == "spatial_join"
+        assert meta["join_dataset_id"] == str(polys.id)
+        assert meta["join_fields"] == ["name"]
+        # Release the per-user active-job slot for later tests (shared DB).
+        # The patched defer leaves this job pending forever, and the endpoint
+        # allows one active analysis job per user — so without this every
+        # later materialize in the run earns a 429 instead of testing itself.
+        job.status = "failed"
+        await test_db_session.commit()
+
+
+class TestSpatialJoinWorker:
+    async def test_materialize_creates_a_tileable_1to1_dataset(
+        self,
+        test_db_session: AsyncSession,
+    ):
+        """Criteria 2 (materialize half) and 6: one row per source feature, the
+        tie-break agreeing with the preview, source attributes carried, and an
+        output that registers with a real geometry type.
+
+        The duplicate-row failure this pins is not subtle: two rows for one
+        source gid violate ADD PRIMARY KEY (gid) and the job dies on a
+        constraint error rather than anything a user could act on.
+        """
+        admin_id = await get_user_id(test_db_session, "admin")
+        points = await _create_probe_points(test_db_session, created_by=admin_id)
+        polys = await _create_two_overlapping_polygons(
+            test_db_session, created_by=admin_id
+        )
+        job = await _create_job(test_db_session, admin_id)
+
+        await _materialize(
+            job_id=str(job.id),
+            dataset_id=str(points.id),
+            user_id=str(admin_id),
+            operation="spatial_join",
+            title=f"Points in polys {uuid.uuid4().hex[:6]}",
+            join_dataset_id=str(polys.id),
+            join_fields=["name", "pop"],
+        )
+
+        await test_db_session.refresh(job)
+        assert job.status == "complete", job.error_message
+
+        from app.modules.catalog.datasets.domain.models import Dataset
+
+        new_ds = await test_db_session.get(Dataset, job.dataset_id)
+        assert new_ds is not None
+        # 3 of the 4 source rows: the NULL-geometry one is dropped, and NOT a
+        # 4th row from the overlap point matching two polygons.
+        assert new_ds.feature_count == 3
+        assert new_ds.geometry_type == "POINT"
+
+        rows = (
+            await test_db_session.execute(
+                text(
+                    f"SELECT gid, name, join_count, join_name, join_pop, "  # noqa: S608
+                    f"GeometryType(geom_4326) "
+                    f"FROM data.{new_ds.table_name} ORDER BY gid"
+                )
+            )
+        ).all()
+        assert rows == [
+            (1, "in_both", 2, "poly_a", 100, "POINT"),
+            (2, "in_a_only", 1, "poly_a", 100, "POINT"),
+            (3, "outside", 0, None, None, "POINT"),
+        ]
+
+    async def test_worker_rejects_a_collision_the_router_did_not_see(
+        self,
+        test_db_session: AsyncSession,
+    ):
+        """The router validates against column_info, a catalog snapshot. The
+        worker holds the LIVE column list, and the queue wait sits between
+        them — so the collision check runs again there, with a message rather
+        than a raw "column specified more than once"."""
+        admin_id = await get_user_id(test_db_session, "admin")
+        source = await _create_layer(
+            test_db_session,
+            created_by=admin_id,
+            column_type="Point",
+            geometry_type="POINT",
+            extra_columns="join_count INTEGER,",
+            values_sql=(
+                "('p', 7, ST_SetSRID(ST_MakePoint(0.75,0.5),4326),"
+                " ST_SetSRID(ST_MakePoint(0.75,0.5),4326))"
+            ),
+            # Stale snapshot: the router would see nothing wrong here.
+            column_info=[{"name": "name", "type": "text"}],
+        )
+        polys = await _create_two_overlapping_polygons(
+            test_db_session, created_by=admin_id
+        )
+        job = await _create_job(test_db_session, admin_id)
+
+        await _materialize(
+            job_id=str(job.id),
+            dataset_id=str(source.id),
+            user_id=str(admin_id),
+            operation="spatial_join",
+            title=f"Collides {uuid.uuid4().hex[:6]}",
+            join_dataset_id=str(polys.id),
+        )
+
+        await test_db_session.refresh(job)
+        assert job.status == "failed"
+        assert "join_count" in (job.error_message or "")

--- a/backend/tests/test_analysis_spatial_join.py
+++ b/backend/tests/test_analysis_spatial_join.py
@@ -579,6 +579,77 @@ class TestSpatialJoinEnqueueValidation:
         assert resp.status_code == 422
         assert "must not repeat a column" in resp.text
 
+    async def test_join_fields_colliding_only_after_truncation_are_rejected(
+        self,
+        client: AsyncClient,
+        admin_auth_header: dict,
+        test_db_session: AsyncSession,
+    ):
+        """fix(#1097 review): the guards must compare what PostgreSQL compares.
+
+        max_identifier_length is 63 and a longer alias is TRUNCATED with a
+        notice rather than refused. Two join fields sharing their first 58
+        characters therefore prefix to strings that differ in Python and are
+        the same column in the output — so the uniqueness check passed and the
+        CTAS failed after the queue wait.
+
+        Preview did not catch it either: it consumes the values positionally,
+        so it succeeds on the very request Create cannot save.
+        """
+        admin_id = await get_user_id(test_db_session, "admin")
+        # 58 shared characters, then a difference that truncation eats.
+        base = "z" * 58
+        a, b = f"{base}_alpha", f"{base}_beta"
+        assert len(f"join_{a}") > 63 and f"join_{a}"[:63] == f"join_{b}"[:63]
+
+        points = await _create_probe_points(test_db_session, created_by=admin_id)
+        polys = await _create_layer(
+            test_db_session,
+            created_by=admin_id,
+            column_type="Geometry",
+            geometry_type="POLYGON",
+            extra_columns=f"{a} TEXT, {b} TEXT,",
+            values_sql=(
+                "('poly_a', 'x', 'y', ST_MakeEnvelope(0,0,1,1,4326),"
+                " ST_MakeEnvelope(0,0,1,1,4326))"
+            ),
+            column_info=[
+                {"name": "name", "type": "text"},
+                {"name": a, "type": "text"},
+                {"name": b, "type": "text"},
+            ],
+        )
+
+        resp = await client.post(
+            _materialize_url(points.id),
+            json={
+                "operation": "spatial_join",
+                "join_dataset_id": str(polys.id),
+                "join_fields": [a, b],
+                "title": "Nope",
+            },
+            headers=admin_auth_header,
+        )
+        assert resp.status_code == 422, resp.text
+        assert "join_" in resp.text
+
+    def test_generated_join_names_never_exceed_the_identifier_limit(self):
+        """The property behind the test above, stated directly.
+
+        Asserted against the constant rather than a literal 63 so this stays
+        true if the server's NAMEDATALEN ever differs — and the constant itself
+        is checked against the live server in the SQL-rendering tests.
+        """
+        from app.platform.analysis_sql import (
+            MAX_IDENTIFIER_LENGTH,
+            spatial_join_output_columns,
+        )
+
+        generated = spatial_join_output_columns(["x" * 80, "short"])
+        assert all(len(name) <= MAX_IDENTIFIER_LENGTH for name in generated)
+        # Truncation must not damage names that already fit.
+        assert "join_short" in generated
+
     async def test_a_count_only_join_is_validated_on_the_preview_path_too(
         self,
         client: AsyncClient,

--- a/backend/tests/test_analysis_spatial_join.py
+++ b/backend/tests/test_analysis_spatial_join.py
@@ -11,6 +11,7 @@ Requirements:
 import uuid
 from unittest.mock import AsyncMock, patch
 
+import pytest
 from httpx import AsyncClient
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -577,6 +578,73 @@ class TestSpatialJoinEnqueueValidation:
         )
         assert resp.status_code == 422
         assert "must not repeat a column" in resp.text
+
+    async def test_a_join_field_dropped_after_enqueue_is_caught_before_the_ctas(
+        self,
+        test_db_session: AsyncSession,
+    ):
+        """fix(#1097 review): the transferred fields were validated at enqueue
+        against column_info and never again.
+
+        The worker re-resolved the join layer's TABLE but not its COLUMNS, so a
+        re-upload that drops or renames a requested field left
+        render_spatial_join referencing a column that no longer exists — and
+        the CTAS failed after the whole queue wait, naming a column the user
+        had legitimately selected when they asked for it.
+
+        The sibling live rechecks beside this one exist for exactly that
+        window. This one was the gap in the set.
+        """
+        from app.processing.analysis.tasks import _resolve_and_validate_columns
+
+        admin_id = await get_user_id(test_db_session, "admin")
+        points = await _create_probe_points(test_db_session, created_by=admin_id)
+        polys = await _create_two_overlapping_polygons(
+            test_db_session, created_by=admin_id
+        )
+        # Present at enqueue, gone by the time the job runs.
+        await test_db_session.execute(
+            text(f"ALTER TABLE data.{polys.table_name} DROP COLUMN pop")  # noqa: S608
+        )
+        await test_db_session.commit()
+
+        # Through the composition point, not the leaf guard: a test that calls
+        # the guard directly stays green when the call site is deleted.
+        with pytest.raises(ValueError) as excinfo:
+            await _resolve_and_validate_columns(
+                test_db_session,
+                schema="data",
+                operation="spatial_join",
+                src_table_name=points.table_name,
+                mask_table_name=None,
+                join_table_name=polys.table_name,
+                join_fields=["name", "pop"],
+            )
+        assert "pop" in str(excinfo.value)
+
+    async def test_join_fields_that_still_exist_pass_the_live_recheck(
+        self,
+        test_db_session: AsyncSession,
+    ):
+        """The negative control: the recheck must not refuse an unchanged join
+        layer, or every attribute transfer would fail at the worker."""
+        from app.processing.analysis.tasks import _resolve_and_validate_columns
+
+        admin_id = await get_user_id(test_db_session, "admin")
+        points = await _create_probe_points(test_db_session, created_by=admin_id)
+        polys = await _create_two_overlapping_polygons(
+            test_db_session, created_by=admin_id
+        )
+        for fields in (["name", "pop"], None):
+            await _resolve_and_validate_columns(
+                test_db_session,
+                schema="data",
+                operation="spatial_join",
+                src_table_name=points.table_name,
+                mask_table_name=None,
+                join_table_name=polys.table_name,
+                join_fields=fields,
+            )
 
     async def test_oversized_source_rejected_at_enqueue(
         self,

--- a/backend/tests/test_analysis_spatial_join.py
+++ b/backend/tests/test_analysis_spatial_join.py
@@ -579,6 +579,102 @@ class TestSpatialJoinEnqueueValidation:
         assert resp.status_code == 422
         assert "must not repeat a column" in resp.text
 
+    async def test_a_count_only_join_is_validated_on_the_preview_path_too(
+        self,
+        client: AsyncClient,
+        admin_auth_header: dict,
+        test_db_session: AsyncSession,
+    ):
+        """fix(#1097 review): Preview must not approve what Create refuses.
+
+        The preview path guarded the validator behind `if body.join_fields`,
+        but that validator also checks the ALWAYS-generated join_count against
+        the source's columns. A source that already had a join_count column
+        therefore previewed happily and then failed Create on the identical
+        form — the worst split, because the user has been told it works.
+        """
+        admin_id = await get_user_id(test_db_session, "admin")
+        source = await _create_layer(
+            test_db_session,
+            created_by=admin_id,
+            column_type="Point",
+            geometry_type="POINT",
+            extra_columns="join_count INTEGER,",
+            values_sql=(
+                "('p', 7, ST_SetSRID(ST_MakePoint(0.75,0.5),4326),"
+                " ST_SetSRID(ST_MakePoint(0.75,0.5),4326))"
+            ),
+            column_info=[
+                {"name": "name", "type": "text"},
+                {"name": "join_count", "type": "integer"},
+            ],
+        )
+        polys = await _create_two_overlapping_polygons(
+            test_db_session, created_by=admin_id
+        )
+        body = {"operation": "spatial_join", "join_dataset_id": str(polys.id)}
+
+        # No join_fields at all: the count is still generated.
+        preview = await client.post(
+            _preview_url(source.id), json=body, headers=admin_auth_header
+        )
+        assert preview.status_code == 422, preview.text
+        assert "join_count" in preview.text
+
+        # And the two paths agree, which is the actual invariant.
+        materialize = await client.post(
+            _materialize_url(source.id),
+            json={**body, "title": "Nope"},
+            headers=admin_auth_header,
+        )
+        assert materialize.status_code == preview.status_code
+
+    async def test_a_join_layer_that_loses_its_geometry_is_caught(
+        self,
+        test_db_session: AsyncSession,
+    ):
+        """fix(#1097 review): points and lines stay valid, no geometry does not.
+
+        A spatial join counts in any direction, so the join layer is
+        deliberately NOT held to the mask's polygon rule. But a re-upload from
+        a non-spatial source sets geometry_type to None and builds a table with
+        no geom_4326 at all, and render_spatial_join references _j.geom_4326 —
+        so the job died on a database error after the queue wait.
+        """
+        from app.modules.catalog.datasets.domain.models import Dataset
+        from app.processing.analysis.tasks import _resolve_layer_table_ref
+
+        admin_id = await get_user_id(test_db_session, "admin")
+        polys = await _create_two_overlapping_polygons(
+            test_db_session, created_by=admin_id
+        )
+
+        # A POINT join layer resolves: direction does not matter to a join.
+        polys.geometry_type = "POINT"
+        await test_db_session.commit()
+        await _resolve_layer_table_ref(
+            test_db_session,
+            Dataset,
+            str(polys.id),
+            "data",
+            label="join",
+            require_geometry="any",
+        )
+
+        # No geometry at all does not.
+        polys.geometry_type = None
+        await test_db_session.commit()
+        with pytest.raises(ValueError) as excinfo:
+            await _resolve_layer_table_ref(
+                test_db_session,
+                Dataset,
+                str(polys.id),
+                "data",
+                label="join",
+                require_geometry="any",
+            )
+        assert "geometry" in str(excinfo.value).lower()
+
     async def test_a_join_field_dropped_after_enqueue_is_caught_before_the_ctas(
         self,
         test_db_session: AsyncSession,

--- a/backend/tests/test_analysis_spatial_join.py
+++ b/backend/tests/test_analysis_spatial_join.py
@@ -495,6 +495,89 @@ class TestSpatialJoinEnqueueValidation:
         assert resp.status_code == 422
         assert "join_count" in resp.text
 
+    async def test_join_field_prefixing_onto_the_count_column_rejected(
+        self,
+        client: AsyncClient,
+        admin_auth_header: dict,
+        test_db_session: AsyncSession,
+    ):
+        """fix(#1097 review): the generated names must not collide with EACH
+        OTHER, only with the source.
+
+        A join layer with an ordinary column named `count` prefixes to
+        `join_count`, which is the name the operation already generates for the
+        match count. The guard above compares the generated names against the
+        SOURCE's columns, so nothing noticed that the list contained the same
+        name twice. Materialization then emitted two `join_count` columns and
+        failed the CTAS after the whole queue wait, and the preview was worse:
+        both values landed on one property, so the transferred field silently
+        overwrote the real match count.
+        """
+        admin_id = await get_user_id(test_db_session, "admin")
+        points = await _create_probe_points(test_db_session, created_by=admin_id)
+        polys = await _create_layer(
+            test_db_session,
+            created_by=admin_id,
+            column_type="Geometry",
+            geometry_type="POLYGON",
+            extra_columns='"count" INTEGER,',
+            values_sql=(
+                "('poly_a', 100, ST_MakeEnvelope(0,0,1,1,4326),"
+                " ST_MakeEnvelope(0,0,1,1,4326))"
+            ),
+            column_info=[
+                {"name": "name", "type": "text"},
+                {"name": "count", "type": "integer"},
+            ],
+            feature_count=1,
+        )
+
+        resp = await client.post(
+            _materialize_url(points.id),
+            json={
+                "operation": "spatial_join",
+                "join_dataset_id": str(polys.id),
+                "join_fields": ["count"],
+                "title": "Nope",
+            },
+            headers=admin_auth_header,
+        )
+        assert resp.status_code == 422
+        assert "join_count" in resp.text
+
+    async def test_the_same_join_field_twice_rejected(
+        self,
+        client: AsyncClient,
+        admin_auth_header: dict,
+        test_db_session: AsyncSession,
+    ):
+        """The other way the same field arrives twice, caught a layer earlier.
+
+        AnalysisMaterializeRequest already rejects a repeated join_fields entry,
+        so this never reaches the router's collision guard. Pinned because the
+        rule had no test: without one, the schema validator could be relaxed and
+        the only signal would be a CTAS failing on a duplicate column after the
+        whole queue wait.
+        """
+        admin_id = await get_user_id(test_db_session, "admin")
+        points = await _create_probe_points(test_db_session, created_by=admin_id)
+        polys = await _create_two_overlapping_polygons(
+            test_db_session, created_by=admin_id
+        )
+
+        resp = await client.post(
+            _materialize_url(points.id),
+            json={
+                "operation": "spatial_join",
+                "join_dataset_id": str(polys.id),
+                "join_fields": ["pop", "pop"],
+                "title": "Nope",
+            },
+            headers=admin_auth_header,
+        )
+        assert resp.status_code == 422
+        assert "must not repeat a column" in resp.text
+
     async def test_oversized_source_rejected_at_enqueue(
         self,
         client: AsyncClient,

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -843,11 +843,12 @@ def test_decomposed_service_modules_stay_within_size_budgets() -> None:
         # app.platform.analysis_sql as it landed, so what remains here is the
         # preview ORCHESTRATION — which branch feeds which renderer, and how the
         # positional rows become properties — not SQL. Two folds during the
-        # wave (#955's count builder, #956's preview projection) kept it under
-        # this cap once each before it stopped fitting. 375 leaves ~10 lines;
-        # an eighth operation should split the per-operation dispatch out
-        # rather than raise this again.
-        "backend/app/modules/catalog/datasets/domain/service_analysis.py": 375,
+        # wave (#955's count builder, #956's preview projection) each bought
+        # one more operation's worth of room before it stopped fitting.
+        # 310 on main + 145 for the four operations = 455. The per-operation
+        # dispatch is now the majority of the file, so an eighth operation
+        # should split that out rather than raise this again.
+        "backend/app/modules/catalog/datasets/domain/service_analysis.py": 455,
         "backend/app/modules/catalog/maps/service_crud.py": 550,
         # fix(#474, #475): localized ranking/eager loading plus the OGC
         # ids/externalIds filters cross the default by nine lines. Keep the
@@ -1188,19 +1189,39 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # keeping: `params` stays untyped deliberately, because it is the
     # operation's parameter dict AND it is redacted per requester, so a union
     # of per-operation models would describe a shape visible_derived_from is
-    # free to punch holes in. Ratchet exact at 1032.
-    "backend/app/modules/catalog/datasets/domain/schemas.py": 1032,
-    # fix(#1012): crossed on the rebase, not in either branch. main grew this
-    # module past 900 while the work_mem branch was open, and the branch's +120
-    # (the SET LOCAL, its budget arithmetic and the boot-time validator) landed
-    # on top of that — so the gate fired for the first time on a merge result
-    # neither side had ever built. What the lines bought: work_mem is allocated
-    # per operation AND per backend, so the ceiling this file computes is the
-    # difference between one materialize using its stated budget and one using
-    # several multiples of it. The reasoning has to live next to the SET LOCAL,
-    # because a future reader tuning the number is exactly who needs it.
-    # Ratchet exact at 1031.
-    "backend/app/processing/analysis/tasks.py": 1031,
+    # free to punch holes in.
+    # +95 — the four analysis operations. Each one adds a value to both
+    # AnalysisOperation Literals, a params field with its bounds, and its row
+    # in _ANALYSIS_PARAM_OWNERS, which is what makes a param submitted to the
+    # wrong operation a 422 instead of a silently ignored key. 1032 -> 1127.
+    "backend/app/modules/catalog/datasets/domain/schemas.py": 1127,
+    # --- entered by the inclusion rule, feat(#953/#954/#955/#956) ----------
+    # Both cross 1000 for the first time here, and both cross it for the same
+    # reason: the four operations are deliberately concentrated rather than
+    # spread. Every rendered statement lives in analysis_sql (662 -> 1173) so
+    # the preview path and the materialize worker cannot drift apart on what
+    # SQL they run, which is the whole reason the module exists in platform/
+    # instead of in either caller. tasks.py grows by one branch per operation
+    # for the same reason: the CTAS shape is decided in one place. Splitting
+    # either one per-operation would trade this module's size for the drift it
+    # was built to prevent, so the growth is the design working.
+    #
+    # What that costs, stated plainly rather than left for the next reader:
+    # analysis_sql is now the largest module under platform/ and roughly 40%
+    # of it is the four operations added here. The split is filed as #1089 —
+    # by OPERATION FAMILY (overlay, measure, transform), with the shared
+    # fences, ceilings and antimeridian helpers staying central. Never by
+    # CALLER: giving the preview path and the worker their own rendering
+    # modules recreates exactly the drift this module exists to prevent, so
+    # #1089 says to reject that proposal on sight.
+    "backend/app/platform/analysis_sql.py": 1173,
+    # tasks.py carries growth from BOTH sides of this rebase, so the number is
+    # re-measured rather than taken from either. #1012 added the scoped
+    # work_mem (the SET LOCAL, its budget arithmetic and the boot-time
+    # validator); this branch added one CTAS branch per operation. Each cap was
+    # correct for the tree that produced it and neither is correct for the
+    # merge, which is the conflict doing its job.
+    "backend/app/processing/analysis/tasks.py": 1191,
     # Tenant-owned media now crosses the shared logical-to-physical storage
     # seam; explicit storage-failure responses keep the runtime/OpenAPI contract
     # aligned. Keep the ratchet exact after the import/decorator expansion.

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -1234,7 +1234,14 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # queue wait — and the worker must not import from the API layer. Putting
     # it in either caller would have meant duplicating the set, which is how
     # the two halves of a guard drift apart.
-    "backend/app/platform/analysis_sql.py": 1173,
+    #
+    # fix(#1097 review): +18 for INTERNAL_ALIAS_PREFIX and its reasoning. The
+    # output-collision guards reserved names that reach the OUTPUT and said
+    # nothing about the aliases a query invents on the way there, so an overlay
+    # column named `_mask_gid` landed in the same select list as that alias. The
+    # aliases moved into a namespace and the namespace is reserved, which is
+    # what makes an alias added later safe without a list to keep in step.
+    "backend/app/platform/analysis_sql.py": 1191,
     # tasks.py carries growth from BOTH sides of this rebase, so the number is
     # re-measured rather than taken from either. #1012 added the scoped
     # work_mem (the SET LOCAL, its budget arithmetic and the boot-time
@@ -1249,7 +1256,14 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # _reject_output_column_collision beside it exists for. Types rather than
     # names, because the live name list was already read there and would not
     # have caught it: the column that breaks the CTAS has an ordinary name.
-    "backend/app/processing/analysis/tasks.py": 1231,
+    #
+    # fix(#1097 review): +91 for the live-schema rechecks. Two more guards (the
+    # reserved-alias prefix, and re-checking transferred join fields against the
+    # join layer's live columns) plus _resolve_and_validate_columns, which the
+    # set moved into rather than raising _materialize's C901 threshold: five
+    # checks over two layers share a subject the surrounding job bookkeeping
+    # does not.
+    "backend/app/processing/analysis/tasks.py": 1322,
     # Tenant-owned media now crosses the shared logical-to-physical storage
     # seam; explicit storage-failure responses keep the runtime/OpenAPI contract
     # aligned. Keep the ratchet exact after the import/decorator expansion.

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -1207,7 +1207,12 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # AnalysisOperation Literals, a params field with its bounds, and its row
     # in _ANALYSIS_PARAM_OWNERS, which is what makes a param submitted to the
     # wrong operation a 422 instead of a silently ignored key. 1032 -> 1127.
-    "backend/app/modules/catalog/datasets/domain/schemas.py": 1127,
+    # fix(#1097 review): +6 for the mask_dataset_id description, on both
+    # request models. It said the field applied to clip and select_by_location
+    # and was an alternative to `mask`, while the validator requires it for
+    # every intersect and rejects a drawn mask there — so the generated SDK
+    # docs led clients to requests that always 422.
+    "backend/app/modules/catalog/datasets/domain/schemas.py": 1133,
     # --- entered by the inclusion rule, feat(#953/#954/#955/#956) ----------
     # Both cross 1000 for the first time here, and both cross it for the same
     # reason: the four operations are deliberately concentrated rather than
@@ -1270,7 +1275,12 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # job waits, and nothing downstream notices: the mask matches no rows and
     # the job dies on "produced no features", pointing the user at their data
     # instead of at the layer that changed.
-    "backend/app/processing/analysis/tasks.py": 1343,
+    #
+    # fix(#1097 review): +22 for the second geometry strength. The mask must
+    # still be polygonal; the JOIN layer must only still be spatial, because a
+    # join counts in any direction — but a re-upload from a non-spatial source
+    # leaves no geom_4326 for render_spatial_join to reference.
+    "backend/app/processing/analysis/tasks.py": 1365,
     # Tenant-owned media now crosses the shared logical-to-physical storage
     # seam; explicit storage-failure responses keep the runtime/OpenAPI contract
     # aligned. Keep the ratchet exact after the import/decorator expansion.

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -845,10 +845,14 @@ def test_decomposed_service_modules_stay_within_size_budgets() -> None:
         # positional rows become properties — not SQL. Two folds during the
         # wave (#955's count builder, #956's preview projection) each bought
         # one more operation's worth of room before it stopped fitting.
-        # 310 on main + 145 for the four operations = 455. The per-operation
+        # 310 on main + 144 for the four operations = 454. The per-operation
         # dispatch is now the majority of the file, so an eighth operation
         # should split that out rather than raise this again.
-        "backend/app/modules/catalog/datasets/domain/service_analysis.py": 455,
+        # This budget is a ceiling rather than an exact ratchet, so it would
+        # pass at 455 with the file at 454. Set to the measured value anyway:
+        # the spare line is what the no-headroom rule on _MODULE_LOC_CAPS
+        # calls the seed of the next raise.
+        "backend/app/modules/catalog/datasets/domain/service_analysis.py": 454,
         "backend/app/modules/catalog/maps/service_crud.py": 550,
         # fix(#474, #475): localized ranking/eager loading plus the OGC
         # ids/externalIds filters cross the default by nine lines. Keep the

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -1263,7 +1263,14 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # set moved into rather than raising _materialize's C901 threshold: five
     # checks over two layers share a subject the surrounding job bookkeeping
     # does not.
-    "backend/app/processing/analysis/tasks.py": 1322,
+    #
+    # fix(#1097 review): +21 for re-applying the polygon requirement on the
+    # mask layer at resolve time. The router refuses a non-polygonal mask at
+    # enqueue and a re-upload can change that layer's geometry_type while the
+    # job waits, and nothing downstream notices: the mask matches no rows and
+    # the job dies on "produced no features", pointing the user at their data
+    # instead of at the layer that changed.
+    "backend/app/processing/analysis/tasks.py": 1343,
     # Tenant-owned media now crosses the shared logical-to-physical storage
     # seam; explicit storage-failure responses keep the runtime/OpenAPI contract
     # aligned. Keep the ratchet exact after the import/decorator expansion.

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -1227,6 +1227,13 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # CALLER: giving the preview path and the worker their own rendering
     # modules recreates exactly the drift this module exists to prevent, so
     # #1089 says to reject that proposal on sight.
+    #
+    # fix(#1097 review): +8 for NON_GROUPABLE_COLUMN_TYPES. It lives here
+    # because three guards need it — dissolve's by_field in the router,
+    # intersect's overlay at enqueue, and the worker's live recheck after the
+    # queue wait — and the worker must not import from the API layer. Putting
+    # it in either caller would have meant duplicating the set, which is how
+    # the two halves of a guard drift apart.
     "backend/app/platform/analysis_sql.py": 1173,
     # tasks.py carries growth from BOTH sides of this rebase, so the number is
     # re-measured rather than taken from either. #1012 added the scoped
@@ -1234,7 +1241,15 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # validator); this branch added one CTAS branch per operation. Each cap was
     # correct for the tree that produced it and neither is correct for the
     # merge, which is the conflict doing its job.
-    "backend/app/processing/analysis/tasks.py": 1191,
+    #
+    # fix(#1097 review): +40 on top of that, for
+    # _reject_ungroupable_overlay_columns — the worker half of the overlay type
+    # guard. The router validates a catalog SNAPSHOT and a re-upload can
+    # replace the overlay before the job runs, the same window
+    # _reject_output_column_collision beside it exists for. Types rather than
+    # names, because the live name list was already read there and would not
+    # have caught it: the column that breaks the CTAS has an ordinary name.
+    "backend/app/processing/analysis/tasks.py": 1231,
     # Tenant-owned media now crosses the shared logical-to-physical storage
     # seam; explicit storage-failure responses keep the runtime/OpenAPI contract
     # aligned. Keep the ratchet exact after the import/decorator expansion.

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -1329,7 +1329,15 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # geometry columns (measure, spatial_join, select_by_location) so a curved
     # source row is stored linear — a curved geometry written into the derived
     # table would fail that layer's tiles and feature reads later.
-    "backend/app/processing/analysis/tasks.py": 1388,
+    #
+    # fix(#1097 review): +62 for the array-element half of the ungroupable
+    # guards. information_schema stores an array column's data_type as
+    # 'ARRAY', so json[]/xml[] passed the exact scalar comparison and failed
+    # the CTAS with 42883 after the queue wait; _ungroupable_type_name reads
+    # udt_name ('_json') as well, and the same check now also covers
+    # dissolve's by_field, which had the identical blind spot plus no live
+    # recheck at all.
+    "backend/app/processing/analysis/tasks.py": 1450,
     # Tenant-owned media now crosses the shared logical-to-physical storage
     # seam; explicit storage-failure responses keep the runtime/OpenAPI contract
     # aligned. Keep the ratchet exact after the import/decorator expansion.

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -1212,7 +1212,13 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # and was an alternative to `mask`, while the validator requires it for
     # every intersect and rejects a drawn mask there — so the generated SDK
     # docs led clients to requests that always 422.
-    "backend/app/modules/catalog/datasets/domain/schemas.py": 1133,
+    # fix(#1097 review): +5 for the match_count description, which said the
+    # field is null for anything but spatial_join and select_by_location while
+    # intersect returns it. This is the SOURCE the SDKs and the hand-typed
+    # frontend mirror are generated from or checked against, so it had been
+    # corrected in the mirror and left wrong here — backwards, and the reason
+    # the wrong text shipped into both SDKs.
+    "backend/app/modules/catalog/datasets/domain/schemas.py": 1138,
     # --- entered by the inclusion rule, feat(#953/#954/#955/#956) ----------
     # Both cross 1000 for the first time here, and both cross it for the same
     # reason: the four operations are deliberately concentrated rather than

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -845,14 +845,18 @@ def test_decomposed_service_modules_stay_within_size_budgets() -> None:
         # positional rows become properties — not SQL. Two folds during the
         # wave (#955's count builder, #956's preview projection) each bought
         # one more operation's worth of room before it stopped fitting.
-        # 310 on main + 144 for the four operations = 454. The per-operation
-        # dispatch is now the majority of the file, so an eighth operation
-        # should split that out rather than raise this again.
-        # This budget is a ceiling rather than an exact ratchet, so it would
-        # pass at 455 with the file at 454. Set to the measured value anyway:
+        # 310 on main + 144 for the four operations = 454, then +9 for the
+        # #1097-review note on why intersect's match_count seeds to 0 rather
+        # than None (an empty overlay is an ANSWER; None is reserved for a
+        # count that could not be computed, and the panel renders those
+        # differently). The per-operation dispatch is now the majority of the
+        # file, so an eighth operation should split that out rather than raise
+        # this again.
+        # This budget is a ceiling rather than an exact ratchet, so a stale
+        # higher number would still pass. Set to the measured value anyway:
         # the spare line is what the no-headroom rule on _MODULE_LOC_CAPS
         # calls the seed of the next raise.
-        "backend/app/modules/catalog/datasets/domain/service_analysis.py": 454,
+        "backend/app/modules/catalog/datasets/domain/service_analysis.py": 463,
         "backend/app/modules/catalog/maps/service_crud.py": 550,
         # fix(#474, #475): localized ranking/eager loading plus the OGC
         # ids/externalIds filters cross the default by nine lines. Keep the

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -852,11 +852,16 @@ def test_decomposed_service_modules_stay_within_size_budgets() -> None:
         # differently). The per-operation dispatch is now the majority of the
         # file, so an eighth operation should split that out rather than raise
         # this again.
+        # Then +12 for the #1097-review fix that moves the exact-count query
+        # inside the preview semaphore: 6 lines of code and the note explaining
+        # that BOTH statements open a sandbox connection, so releasing the slot
+        # between them let a finished preview admit the next caller while still
+        # holding one — the bound stopped bounding the thing it exists for.
         # This budget is a ceiling rather than an exact ratchet, so a stale
         # higher number would still pass. Set to the measured value anyway:
         # the spare line is what the no-headroom rule on _MODULE_LOC_CAPS
         # calls the seed of the next raise.
-        "backend/app/modules/catalog/datasets/domain/service_analysis.py": 463,
+        "backend/app/modules/catalog/datasets/domain/service_analysis.py": 475,
         "backend/app/modules/catalog/maps/service_crud.py": 550,
         # fix(#474, #475): localized ranking/eager loading plus the OGC
         # ids/externalIds filters cross the default by nine lines. Keep the

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -868,7 +868,13 @@ def test_decomposed_service_modules_stay_within_size_budgets() -> None:
         # representation) and linearizing the select-by-location layer-path
         # identity lateral, the one pass-through geometry this module renders
         # itself rather than through render_geometry_expr.
-        "backend/app/modules/catalog/datasets/domain/service_analysis.py": 494,
+        #
+        # Then +12 making _json_safe recursive: a bytea[] column comes back as
+        # a LIST of bytes, which the scalar check waved through to the same
+        # 500 (round-14 review). to_jsonb renders that as an array of hex
+        # strings, so recursing with the same scalar encoding keeps the two
+        # endpoints byte-identical.
+        "backend/app/modules/catalog/datasets/domain/service_analysis.py": 506,
         "backend/app/modules/catalog/maps/service_crud.py": 550,
         # fix(#474, #475): localized ranking/eager loading plus the OGC
         # ids/externalIds filters cross the default by nine lines. Keep the

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -1246,7 +1246,15 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # column named `_mask_gid` landed in the same select list as that alias. The
     # aliases moved into a namespace and the namespace is reserved, which is
     # what makes an alias added later safe without a list to keep in step.
-    "backend/app/platform/analysis_sql.py": 1191,
+    #
+    # fix(#1097 review): +27 for MAX_IDENTIFIER_LENGTH and truncating the
+    # generated join names to it. PostgreSQL truncates an over-long identifier
+    # with a NOTICE rather than refusing it, so the uniqueness and
+    # source-collision guards were comparing strings the database would never
+    # see. The comment carries the empirical check (max_identifier_length is
+    # 63) and why source columns need no equivalent — they already exist in a
+    # table, so the server truncated them at creation.
+    "backend/app/platform/analysis_sql.py": 1218,
     # tasks.py carries growth from BOTH sides of this rebase, so the number is
     # re-measured rather than taken from either. #1012 added the scoped
     # work_mem (the SET LOCAL, its budget arithmetic and the boot-time

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -837,6 +837,17 @@ def test_decomposed_service_modules_stay_within_size_budgets() -> None:
     }
     private_service_default_line_budget = 350
     private_service_line_budget_allowlist = {
+        # M4 phase-2 grew this from three analysis operations to seven
+        # (#953 spatial_join, #954 measure, #955 select_by_location, #956
+        # intersect). Every rendered statement was pushed down into
+        # app.platform.analysis_sql as it landed, so what remains here is the
+        # preview ORCHESTRATION — which branch feeds which renderer, and how the
+        # positional rows become properties — not SQL. Two folds during the
+        # wave (#955's count builder, #956's preview projection) kept it under
+        # this cap once each before it stopped fitting. 375 leaves ~10 lines;
+        # an eighth operation should split the per-operation dispatch out
+        # rather than raise this again.
+        "backend/app/modules/catalog/datasets/domain/service_analysis.py": 375,
         "backend/app/modules/catalog/maps/service_crud.py": 550,
         # fix(#474, #475): localized ranking/eager loading plus the OGC
         # ids/externalIds filters cross the default by nine lines. Keep the

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -861,7 +861,14 @@ def test_decomposed_service_modules_stay_within_size_budgets() -> None:
         # higher number would still pass. Set to the measured value anyway:
         # the spare line is what the no-headroom rule on _MODULE_LOC_CAPS
         # calls the seed of the next raise.
-        "backend/app/modules/catalog/datasets/domain/service_analysis.py": 475,
+        #
+        # Then +19 for the #1097-review preview-serialization fixes: _json_safe
+        # (a transferred bytea value reaches Pydantic as raw bytes and raises;
+        # encode as to_jsonb's hex form so both endpoints serve the same
+        # representation) and linearizing the select-by-location layer-path
+        # identity lateral, the one pass-through geometry this module renders
+        # itself rather than through render_geometry_expr.
+        "backend/app/modules/catalog/datasets/domain/service_analysis.py": 494,
         "backend/app/modules/catalog/maps/service_crud.py": 550,
         # fix(#474, #475): localized ranking/eager loading plus the OGC
         # ids/externalIds filters cross the default by nine lines. Keep the
@@ -1260,7 +1267,17 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # see. The comment carries the empirical check (max_identifier_length is
     # 63) and why source columns need no equivalent — they already exist in a
     # table, so the server truncated them at creation.
-    "backend/app/platform/analysis_sql.py": 1218,
+    #
+    # fix(#1097 review): +42 for linearized() and its call sites. WFS sources
+    # can store curved geometries (MultiSurface/CompoundCurve) that ingest
+    # admits but ::geography, ST_MakeValid and ST_AsGeoJSON all raise on, so
+    # every geometry read feeding one of those — or passing through into
+    # preview GeoJSON or a CTAS — goes through one ST_CurveToLine wrapper. The
+    # bulk of the lines is the helper's docstring recording which functions
+    # raise, which tolerate curves, why WHERE predicates stay on the bare
+    # column (the GIST index), and that #1104 (ingest-level normalization)
+    # is what eventually retires the helper.
+    "backend/app/platform/analysis_sql.py": 1260,
     # tasks.py carries growth from BOTH sides of this rebase, so the number is
     # re-measured rather than taken from either. #1012 added the scoped
     # work_mem (the SET LOCAL, its budget arithmetic and the boot-time
@@ -1301,7 +1318,12 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # discriminator is the only trace a drawn selection leaves — the constant
     # is duplicated from schemas because PROCESS-02 forbids the import, and a
     # test pins the two copies together.
-    "backend/app/processing/analysis/tasks.py": 1385,
+    #
+    # fix(#1097 review): +3 for linearizing the three pass-through CTAS
+    # geometry columns (measure, spatial_join, select_by_location) so a curved
+    # source row is stored linear — a curved geometry written into the derived
+    # table would fail that layer's tiles and feature reads later.
+    "backend/app/processing/analysis/tasks.py": 1388,
     # Tenant-owned media now crosses the shared logical-to-physical storage
     # seam; explicit storage-failure responses keep the runtime/OpenAPI contract
     # aligned. Keep the ratchet exact after the import/decorator expansion.

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -1294,7 +1294,14 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # still be polygonal; the JOIN layer must only still be spatial, because a
     # join counts in any direction — but a re-upload from a non-spatial source
     # leaves no geom_4326 for render_spatial_join to reference.
-    "backend/app/processing/analysis/tasks.py": 1365,
+    #
+    # fix(#1097 review): +20 for _DRAWN_MASK_OPERATIONS and the note on why
+    # mask_source belongs to every operation that can take a drawn mask. The
+    # drawn geometry is deliberately excluded from provenance, so that
+    # discriminator is the only trace a drawn selection leaves — the constant
+    # is duplicated from schemas because PROCESS-02 forbids the import, and a
+    # test pins the two copies together.
+    "backend/app/processing/analysis/tasks.py": 1385,
     # Tenant-owned media now crosses the shared logical-to-physical storage
     # seam; explicit storage-failure responses keep the runtime/OpenAPI contract
     # aligned. Keep the ratchet exact after the import/decorator expansion.

--- a/frontend/src/components/analysis/__tests__/AnalysisJobWatcher.test.tsx
+++ b/frontend/src/components/analysis/__tests__/AnalysisJobWatcher.test.tsx
@@ -63,6 +63,7 @@ describe('AnalysisJobWatcher', () => {
     useAnalysisFormStore.getState().save('m1', {
       layerId: 'l1', operation: 'buffer', distance: '500', distanceUnit: 'm',
       mask: null, maskLayerId: '__none__', byField: '__none__',
+      joinLayerId: '__none__', joinField: '__none__',
       outputTitle: 'Walkshed',
     });
     useAnalysisJobStore.setState({ job: { jobId: 'j1', title: 'Walkshed', mapId: 'm1' } });
@@ -79,6 +80,7 @@ describe('AnalysisJobWatcher', () => {
     useAnalysisFormStore.getState().save('m1', {
       layerId: 'l1', operation: 'buffer', distance: '500', distanceUnit: 'm',
       mask: null, maskLayerId: '__none__', byField: '__none__',
+      joinLayerId: '__none__', joinField: '__none__',
       outputTitle: 'Walkshed',
     });
     useAnalysisJobStore.setState({ job: { jobId: 'j1', title: 'Walkshed', mapId: 'm1' } });
@@ -93,6 +95,7 @@ describe('AnalysisJobWatcher', () => {
     useAnalysisFormStore.getState().save('m1', {
       layerId: 'l1', operation: 'buffer', distance: '500', distanceUnit: 'm',
       mask: null, maskLayerId: '__none__', byField: '__none__',
+      joinLayerId: '__none__', joinField: '__none__',
       outputTitle: 'My next run',
       // The panel stamps this whenever the form changes mid-run.
       runDisowned: true,
@@ -110,6 +113,7 @@ describe('AnalysisJobWatcher', () => {
     useAnalysisFormStore.getState().save('m1', {
       layerId: 'l1', operation: 'buffer', distance: '500', distanceUnit: 'm',
       mask: null, maskLayerId: '__none__', byField: '__none__',
+      joinLayerId: '__none__', joinField: '__none__',
       outputTitle: 'Walkshed',
       runDisowned: true,
     });
@@ -124,6 +128,7 @@ describe('AnalysisJobWatcher', () => {
     useAnalysisFormStore.getState().save('m1', {
       layerId: 'l1', operation: 'buffer', distance: '500', distanceUnit: 'm',
       mask: null, maskLayerId: '__none__', byField: '__none__',
+      joinLayerId: '__none__', joinField: '__none__',
       outputTitle: 'Walkshed',
     });
     useAnalysisJobStore.setState({ job: { jobId: 'j1', title: 'Walkshed', mapId: 'm1' } });
@@ -163,6 +168,7 @@ describe('AnalysisJobWatcher', () => {
     useAnalysisFormStore.getState().save('m1', {
       layerId: 'l1', operation: 'buffer', distance: '500', distanceUnit: 'm',
       mask: null, maskLayerId: '__none__', byField: '__none__',
+      joinLayerId: '__none__', joinField: '__none__',
       outputTitle: 'Walkshed',
     });
     useAnalysisJobStore.setState({ job: { jobId: 'j1', title: 'Buffered', mapId: 'm1' } });
@@ -237,6 +243,7 @@ describe('AnalysisJobWatcher', () => {
     useAnalysisFormStore.getState().save('m1', {
       layerId: 'l1', operation: 'buffer', distance: '500', distanceUnit: 'm',
       mask: null, maskLayerId: '__none__', byField: '__none__',
+      joinLayerId: '__none__', joinField: '__none__',
       outputTitle: 'Walkshed',
     });
     useAnalysisJobStore.setState({ job: { jobId: 'j1', title: 'Buffered', mapId: 'm1' } });
@@ -273,6 +280,7 @@ describe('AnalysisJobWatcher', () => {
     useAnalysisFormStore.getState().save('m1', {
       layerId: 'l1', operation: 'buffer', distance: '500', distanceUnit: 'm',
       mask: null, maskLayerId: '__none__', byField: '__none__',
+      joinLayerId: '__none__', joinField: '__none__',
       outputTitle: 'Walkshed',
     });
     useAnalysisJobStore.setState({ job: { jobId: 'j1', title: 'Buffered', mapId: 'm1' } });
@@ -361,6 +369,7 @@ describe('AnalysisJobWatcher', () => {
     useAnalysisFormStore.getState().save('m1', {
       layerId: 'l1', operation: 'buffer', distance: '500', distanceUnit: 'm',
       mask: null, maskLayerId: '__none__', byField: '__none__',
+      joinLayerId: '__none__', joinField: '__none__',
       outputTitle: 'Walkshed',
     });
     useAnalysisJobStore.setState({ job: { jobId: 'j1', title: 'Buffered', mapId: 'm1' } });
@@ -392,6 +401,7 @@ describe('AnalysisJobWatcher', () => {
     useAnalysisFormStore.getState().save('m1', {
       layerId: 'l1', operation: 'buffer', distance: '500', distanceUnit: 'm',
       mask: null, maskLayerId: '__none__', byField: '__none__',
+      joinLayerId: '__none__', joinField: '__none__',
       outputTitle: 'Walkshed',
     });
     useAnalysisJobStore.setState({ job: { jobId: 'j1', title: 'Buffered', mapId: 'm1' } });
@@ -413,6 +423,7 @@ describe('AnalysisJobWatcher', () => {
     useAnalysisFormStore.getState().save('m1', {
       layerId: 'l1', operation: 'buffer', distance: '500', distanceUnit: 'm',
       mask: null, maskLayerId: '__none__', byField: '__none__',
+      joinLayerId: '__none__', joinField: '__none__',
       outputTitle: 'Walkshed',
     });
     useAnalysisJobStore.setState({ job: { jobId: 'j1', title: 'Buffered', mapId: 'm1' } });

--- a/frontend/src/components/builder/AnalysisPanel.tsx
+++ b/frontend/src/components/builder/AnalysisPanel.tsx
@@ -1130,7 +1130,16 @@ export function AnalysisPanel({
     (operation !== 'intersect' || !!maskLayer) &&
     // feat(#953): a join with nothing to join against is not a runnable form —
     // reflect it here rather than letting the click earn a 422.
-    (operation !== 'spatial_join' || !!joinLayer);
+    (operation !== 'spatial_join' || !!joinLayer) &&
+    // fix(#1097 review): and the transferred field has to still be one the
+    // picker would offer. Clearing it when the source changes handles the way
+    // it went stale in practice; this handles the rest, because the field and
+    // the rule that validates it depend on two different layers and either can
+    // move underneath it. Submission is gated on the state agreeing with the
+    // menu rather than on enumerating the ways they can disagree.
+    (operation !== 'spatial_join' ||
+      joinField === BY_FIELD_NONE ||
+      joinFieldColumns.includes(joinField.replace(/^col:/, '')));
   const canRun =
     !!selectedLayer?.dataset_id &&
     !previewMutation.isPending &&
@@ -1205,6 +1214,17 @@ export function AnalysisPanel({
             // carry to another — it may not exist there (422 from the API) or
             // silently group by a same-named field.
             setByField(BY_FIELD_NONE);
+            // fix(#1097 review): the transferred field is the same problem and
+            // was left out of this reset. It belongs to the JOIN layer, so it
+            // survives a source change intact — but whether it is usable
+            // depends on the SOURCE, since join_<name> has to not collide with
+            // a source column. Picking `zone` against a source with no
+            // join_zone and then switching to one that has it left the menu
+            // filtering `zone` out while the state still held it, and the
+            // request still went (and earned a 422). A join layer can't join
+            // against itself either, so the layer goes with the field.
+            if (v === joinLayerId) setJoinLayerId(MASK_LAYER_NONE);
+            setJoinField(BY_FIELD_NONE);
           }}
         >
           <SelectTrigger id="analysis-layer" className="w-full">

--- a/frontend/src/components/builder/AnalysisPanel.tsx
+++ b/frontend/src/components/builder/AnalysisPanel.tsx
@@ -49,6 +49,23 @@ const POLYGONAL_GEOMETRY_TYPES = new Set(['POLYGON', 'MULTIPOLYGON']);
 // spatial_join is absent on purpose: it reports match_count too, but as a
 // count of matched pairs beside a result that keeps every source row.
 const ROW_FILTERING_OPERATIONS = ['clip', 'select_by_location', 'intersect'] as const;
+// fix(#1097 review): a column the server will refuse must not be offered.
+//
+// These mirror router_analysis.py. _SAFE_COLUMN_RE gates any column named as a
+// group key or a transferred field, so `Área`, `2020_pop` and `:id` are all
+// rejected there — GDAL launders only case, `-` and `#`, so ingested tables
+// hold names like those routinely (see _list_carry_columns on why they are
+// still CARRIED; being carried and being nameable in a request are different
+// questions). _NON_GROUPABLE_TYPES rejects json and xml as group keys.
+//
+// The picker filtered exactly one of these before: dissolve dropped
+// `source_count`. Everything else was offered and then refused on submit, so
+// the only way to learn a field was unusable was to run the operation. Both
+// pickers share the rule now rather than the join picker learning it alone —
+// the finding named the join picker, but the gap is in what the pickers know
+// about the server's rules, and dissolve had the same hole.
+const SAFE_COLUMN_RE = /^[a-zA-Z_][a-zA-Z0-9_]*$/;
+const NON_GROUPABLE_COLUMN_TYPES = new Set(['json', 'xml']);
 // ux(#686): buffer distances are metres on the wire; the picker converts so a
 // user thinking in feet or miles doesn't have to.
 const BUFFER_UNIT_METERS = { m: 1, km: 1000, ft: 0.3048, mi: 1609.344 } as const;
@@ -654,15 +671,31 @@ export function AnalysisPanel({
     operation === 'dissolve' ? (selectedLayer?.dataset_id ?? '') : '',
   );
   const byFieldColumns = (datasetDetail.data?.column_info ?? [])
-    .map((c) => c.name)
-    // The dissolve output already emits a generated source_count column.
-    .filter((name) => name !== 'source_count');
+    .filter(
+      (c) =>
+        SAFE_COLUMN_RE.test(c.name) &&
+        // The dissolve output already emits a generated source_count column.
+        c.name !== 'source_count' &&
+        // A group key needs an equality operator; json and xml have none.
+        !NON_GROUPABLE_COLUMN_TYPES.has(String(c.type ?? '').toLowerCase()),
+    )
+    .map((c) => c.name);
   // Columns of the JOIN layer, not the source — these are what gets copied
   // across. Fetched only while a join layer is actually selected.
   const joinDatasetDetail = useDataset(
     operation === 'spatial_join' ? (joinLayer?.dataset_id ?? '') : '',
   );
-  const joinFieldColumns = (joinDatasetDetail.data?.column_info ?? []).map((c) => c.name);
+  const joinFieldColumns = (joinDatasetDetail.data?.column_info ?? [])
+    .filter(
+      (c) =>
+        SAFE_COLUMN_RE.test(c.name) &&
+        // Transferred fields are prefixed 'join_', so a field named 'count'
+        // would land on the generated join_count column. Compared against the
+        // generated name rather than against the literal 'count', so it keeps
+        // holding if the prefix or the generated set changes.
+        `join_${c.name}` !== 'join_count',
+    )
+    .map((c) => c.name);
 
   const stopDrawing = useCallback(() => {
     drawRef.current?.stop();

--- a/frontend/src/components/builder/AnalysisPanel.tsx
+++ b/frontend/src/components/builder/AnalysisPanel.tsx
@@ -211,7 +211,12 @@ export function AnalysisPanel({
           (l) => l.id === remembered.layerId && isAnalysableLayer(l),
         ) ||
         (remembered.maskLayerId !== MASK_LAYER_NONE &&
-          !layers.some((l) => l.id === remembered.maskLayerId))
+          !layers.some((l) => l.id === remembered.maskLayerId)) ||
+        // fix(#1097 review): a vanished JOIN layer strands the overlay for the
+        // same reason a vanished mask layer does — the drawn result depicts a
+        // pairing that can no longer be reproduced.
+        (remembered.joinLayerId !== MASK_LAYER_NONE &&
+          !layers.some((l) => l.id === remembered.joinLayerId))
       );
     })(),
   );
@@ -242,12 +247,29 @@ export function AnalysisPanel({
   // feat(#953): the layer a spatial join counts against. MASK_LAYER_NONE is
   // reused as the shared "no layer picked" sentinel rather than a second
   // identically-valued constant.
-  const [joinLayerId, setJoinLayerId] = useState(MASK_LAYER_NONE);
+  // fix(#1097 review): restored from the snapshot on the same terms as
+  // maskLayerId — a join layer cannot be the source layer, and a remembered
+  // layer that has since left the map falls back to the sentinel.
+  const [joinLayerId, setJoinLayerId] = useState(() =>
+    savedForm &&
+    savedForm.joinLayerId !== initialLayerId &&
+    layers.some((l) => l.id === savedForm.joinLayerId)
+      ? savedForm.joinLayerId
+      : MASK_LAYER_NONE,
+  );
   // One transferable column, or none. The API takes a list and the backend
   // handles up to MAX_SPATIAL_JOIN_FIELDS; the panel offers a single Select
   // because that is the "which district is this point in" case, and it needs
   // no multi-select primitive that does not exist here yet.
-  const [joinField, setJoinField] = useState(BY_FIELD_NONE);
+  // fix(#1097 review): the field names a column of the JOIN layer, so it is
+  // restorable exactly when that layer was — not on the source layer's terms
+  // like byField below. If the join layer fell back to the sentinel above,
+  // a remembered column of it means nothing.
+  const [joinField, setJoinField] = useState(() =>
+    savedForm && joinLayerId !== MASK_LAYER_NONE
+      ? savedForm.joinField
+      : BY_FIELD_NONE,
+  );
   const [byField, setByField] = useState(
     // ux(#772)/fix(#680) parity: a remembered group-by column belongs to the
     // remembered layer — it must not carry to a stack-selected one.
@@ -362,6 +384,8 @@ export function AnalysisPanel({
     mask,
     maskLayerId,
     byField,
+    joinLayerId,
+    joinField,
     outputTitle,
     runDisowned: formEditedRef.current,
   };
@@ -897,7 +921,22 @@ export function AnalysisPanel({
         );
         return;
       }
-      const total = result.source_feature_count;
+      // fix(#1097 review): which total the server sent, and what it MEANS.
+      // For 1:1 operations it sends source_feature_count and the notice says
+      // "source features". For the row-filtering ones (select_by_location,
+      // intersect) the source count cannot describe the output, so it sends
+      // null there and the exact OUTPUT total as match_count instead — which
+      // this read used to discard, leaving the user the generic cap message
+      // despite the server having paid for an exact count.
+      //
+      // Keyed off source_feature_count being null rather than off an operation
+      // list: spatial_join sends BOTH (it keeps every source row, and its
+      // match_count is how many of them found a match), so preferring
+      // match_count wherever present would relabel its total wrongly. A ninth
+      // operation needs no change here.
+      const sourceTotal = result.source_feature_count ?? null;
+      const matchedTotal = sourceTotal == null ? (result.match_count ?? null) : null;
+      const total = sourceTotal ?? matchedTotal;
       const bbox = result.bbox as [number, number, number, number];
       if (result.truncated) {
         onPreviewResult?.(result.geojson, bbox, {
@@ -910,7 +949,19 @@ export function AnalysisPanel({
       }
       if (result.truncated) {
         toast.info(
-          total != null
+          matchedTotal != null
+            ? t('analysisTools.truncatedNoticeMatched', {
+                // fix(#1097 review): a separate string, not the same one with
+                // a different number. This total is the OUTPUT row count, so
+                // calling it "source features" would misdescribe it — for
+                // intersect it is not even a count of source rows, since one
+                // source feature can produce several output pieces.
+                defaultValue:
+                  'Showing the first {{count, number}} of {{total, number}} matching features',
+                count: result.feature_count,
+                total: matchedTotal,
+              })
+            : total != null
             ? t('analysisTools.truncatedNoticeTotal', {
                 // fix(#680 review): "source features" — the total is the
                 // source dataset's COUNT(*), which can exceed the number of

--- a/frontend/src/components/builder/AnalysisPanel.tsx
+++ b/frontend/src/components/builder/AnalysisPanel.tsx
@@ -41,6 +41,14 @@ const MASK_LAYER_NONE = '__none__';
 // backend/app/modules/catalog/datasets/api/router_analysis.py — the server
 // rejects any other mask dataset with a 422.
 const POLYGONAL_GEOMETRY_TYPES = new Set(['POLYGON', 'MULTIPOLYGON']);
+// fix(#1097 review): mirrors _ROW_FILTERING_OPERATIONS in
+// backend/app/modules/catalog/datasets/domain/service_analysis.py. These drop
+// or multiply source rows, so the source's feature count says nothing about
+// the output and the server sends null for it. They are also the operations
+// whose match_count IS the output total, which is what this list selects for.
+// spatial_join is absent on purpose: it reports match_count too, but as a
+// count of matched pairs beside a result that keeps every source row.
+const ROW_FILTERING_OPERATIONS = ['clip', 'select_by_location', 'intersect'] as const;
 // ux(#686): buffer distances are metres on the wire; the picker converts so a
 // user thinking in feet or miles doesn't have to.
 const BUFFER_UNIT_METERS = { m: 1, km: 1000, ft: 0.3048, mi: 1609.344 } as const;
@@ -929,14 +937,29 @@ export function AnalysisPanel({
       // this read used to discard, leaving the user the generic cap message
       // despite the server having paid for an exact count.
       //
-      // Keyed off source_feature_count being null rather than off an operation
-      // list: spatial_join sends BOTH (it keeps every source row, and its
-      // match_count is how many of them found a match), so preferring
-      // match_count wherever present would relabel its total wrongly. A ninth
-      // operation needs no change here.
-      const sourceTotal = result.source_feature_count ?? null;
-      const matchedTotal = sourceTotal == null ? (result.match_count ?? null) : null;
-      const total = sourceTotal ?? matchedTotal;
+      // fix(#1097 review): keyed off the OPERATION, not off source_feature_count
+      // being null. Null has two causes, and only one of them means "read
+      // match_count instead": the operation filters rows, or the dataset's
+      // cached feature_count snapshot is simply absent (legacy imports,
+      // register_existing_table). A spatial_join on a dataset with no snapshot
+      // hits the second, and its match_count is a count of matched PAIRS — one
+      // source row can match many join rows, so it runs LARGER than the output,
+      // which for a 1:1 join is the source row count. Inferring from null
+      // reported and stored that pair count as the output total.
+      //
+      // Reading `operation` after the seq guard above is what makes this the
+      // operation that produced `result`: any input change bumps the sequence,
+      // so a response that outlived its inputs has already returned.
+      //
+      // A ninth operation lands in the else branch and gets the source total.
+      // That is the safe default and it is deliberately not automatic: what
+      // match_count MEANS is per-operation, so a new one owes this list a
+      // decision rather than inheriting a guess.
+      const filtersRows = ROW_FILTERING_OPERATIONS.includes(
+        operation as (typeof ROW_FILTERING_OPERATIONS)[number],
+      );
+      const matchedTotal = filtersRows ? (result.match_count ?? null) : null;
+      const total = matchedTotal ?? result.source_feature_count ?? null;
       const bbox = result.bbox as [number, number, number, number];
       if (result.truncated) {
         onPreviewResult?.(result.geojson, bbox, {

--- a/frontend/src/components/builder/AnalysisPanel.tsx
+++ b/frontend/src/components/builder/AnalysisPanel.tsx
@@ -65,6 +65,10 @@ const ROW_FILTERING_OPERATIONS = ['clip', 'select_by_location', 'intersect'] as 
 // the finding named the join picker, but the gap is in what the pickers know
 // about the server's rules, and dissolve had the same hole.
 const SAFE_COLUMN_RE = /^[a-zA-Z_][a-zA-Z0-9_]*$/;
+// Mirrors MAX_IDENTIFIER_LENGTH in backend/app/platform/analysis_sql.py:
+// PostgreSQL's NAMEDATALEN - 1. Safe as a character count here because
+// SAFE_COLUMN_RE above has already restricted these names to ASCII.
+const MAX_IDENTIFIER_LENGTH = 63;
 const NON_GROUPABLE_COLUMN_TYPES = new Set(['json', 'xml']);
 // ux(#686): buffer distances are metres on the wire; the picker converts so a
 // user thinking in feet or miles doesn't have to.
@@ -700,7 +704,14 @@ export function AnalysisPanel({
       // Every rejection below is about the name the field would LAND on, not
       // the name it has, so all of them compare the generated form. That is
       // what keeps them true if the prefix or the generated set changes.
-      const generated = `join_${c.name}`;
+      //
+      // fix(#1097 review): truncated first, mirroring
+      // spatial_join_output_columns. PostgreSQL truncates an identifier past
+      // 63 bytes with a notice rather than refusing it, so the name the
+      // comparisons below need is the truncated one — an over-long alias can
+      // land on a source column that the untruncated string does not match,
+      // and the picker would offer a field the server then rejects.
+      const generated = `join_${c.name}`.slice(0, MAX_IDENTIFIER_LENGTH);
       // Would overwrite the generated match count.
       if (generated === 'join_count') return false;
       // Would arrive twice: once from the source, once from the join.

--- a/frontend/src/components/builder/AnalysisPanel.tsx
+++ b/frontend/src/components/builder/AnalysisPanel.tsx
@@ -239,6 +239,15 @@ export function AnalysisPanel({
       ? savedForm.maskLayerId
       : MASK_LAYER_NONE,
   );
+  // feat(#953): the layer a spatial join counts against. MASK_LAYER_NONE is
+  // reused as the shared "no layer picked" sentinel rather than a second
+  // identically-valued constant.
+  const [joinLayerId, setJoinLayerId] = useState(MASK_LAYER_NONE);
+  // One transferable column, or none. The API takes a list and the backend
+  // handles up to MAX_SPATIAL_JOIN_FIELDS; the panel offers a single Select
+  // because that is the "which district is this point in" case, and it needs
+  // no multi-select primitive that does not exist here yet.
+  const [joinField, setJoinField] = useState(BY_FIELD_NONE);
   const [byField, setByField] = useState(
     // ux(#772)/fix(#680) parity: a remembered group-by column belongs to the
     // remembered layer — it must not carry to a stack-selected one.
@@ -250,15 +259,17 @@ export function AnalysisPanel({
     if (!prefill) return savedForm?.outputTitle ?? '';
     const layer = layers.find((l) => l.id === prefill.layerId);
     const base = layer?.display_name ?? layer?.dataset_name ?? '';
-    const opLabel =
-      prefill.operation === 'buffer'
-        ? t('analysisTools.opBuffer', { defaultValue: 'Buffer' })
-        : prefill.operation === 'centroid'
-          ? t('analysisTools.opCentroid', { defaultValue: 'Centroids' })
-          : prefill.operation === 'clip'
-            ? t('analysisTools.opClip', { defaultValue: 'Clip' })
-            : t('analysisTools.opDissolve', { defaultValue: 'Dissolve' });
-    return [base, opLabel].filter(Boolean).join(' — ');
+    // feat(#953): a lookup, not a ternary chain. The chain's final else read
+    // "Dissolve", so every operation added after it was silently labelled
+    // Dissolve in the suggested title until someone extended the chain too.
+    const opLabel: Record<AnalysisOperation, string> = {
+      buffer: t('analysisTools.opBuffer', { defaultValue: 'Buffer' }),
+      centroid: t('analysisTools.opCentroid', { defaultValue: 'Centroids' }),
+      clip: t('analysisTools.opClip', { defaultValue: 'Clip' }),
+      dissolve: t('analysisTools.opDissolve', { defaultValue: 'Dissolve' }),
+      spatial_join: t('analysisTools.opSpatialJoin', { defaultValue: 'Spatial join' }),
+    };
+    return [base, opLabel[prefill.operation]].filter(Boolean).join(' — ');
   });
   // fix(#760): rehydrate a still-tracked materialize for THIS map so a
   // reopened (or reloaded) panel shows the status line and completion
@@ -534,6 +545,14 @@ export function AnalysisPanel({
     maskLayerId !== MASK_LAYER_NONE
       ? maskLayerOptions.find((l) => l.id === maskLayerId)
       : undefined;
+  // feat(#953): a join works in every direction — points in polygons, polygons
+  // over polygons, lines crossing polygons — so unlike the clip mask above
+  // there is no geometry-type filter, only "not the source layer".
+  const joinLayerOptions = datasetLayers.filter((l) => l.id !== layerId);
+  const joinLayer =
+    joinLayerId !== MASK_LAYER_NONE
+      ? joinLayerOptions.find((l) => l.id === joinLayerId)
+      : undefined;
   // Only fetched while dissolve is selected (enabled gates on a non-empty id).
   const datasetDetail = useDataset(
     operation === 'dissolve' ? (selectedLayer?.dataset_id ?? '') : '',
@@ -542,6 +561,12 @@ export function AnalysisPanel({
     .map((c) => c.name)
     // The dissolve output already emits a generated source_count column.
     .filter((name) => name !== 'source_count');
+  // Columns of the JOIN layer, not the source — these are what gets copied
+  // across. Fetched only while a join layer is actually selected.
+  const joinDatasetDetail = useDataset(
+    operation === 'spatial_join' ? (joinLayer?.dataset_id ?? '') : '',
+  );
+  const joinFieldColumns = (joinDatasetDetail.data?.column_info ?? []).map((c) => c.name);
 
   const stopDrawing = useCallback(() => {
     drawRef.current?.stop();
@@ -632,12 +657,27 @@ export function AnalysisPanel({
   const maskLayerGone =
     maskLayerId !== MASK_LAYER_NONE &&
     !maskLayerOptions.some((l) => l.id === maskLayerId);
+  // feat(#953): a vanished join layer is an input change on the same terms.
+  const joinLayerGone =
+    joinLayerId !== MASK_LAYER_NONE &&
+    !joinLayerOptions.some((l) => l.id === joinLayerId);
   useEffect(() => {
-    if (!selectedLayerGone && !maskLayerGone) return;
+    if (!selectedLayerGone && !maskLayerGone && !joinLayerGone) return;
     handleInputsChanged();
     if (selectedLayerGone) setLayerId(firstEligibleId);
     if (maskLayerGone) setMaskLayerId(MASK_LAYER_NONE);
-  }, [selectedLayerGone, maskLayerGone, firstEligibleId, handleInputsChanged]);
+    if (joinLayerGone) {
+      setJoinLayerId(MASK_LAYER_NONE);
+      // The field list belonged to the layer that just went away.
+      setJoinField(BY_FIELD_NONE);
+    }
+  }, [
+    selectedLayerGone,
+    maskLayerGone,
+    joinLayerGone,
+    firstEligibleId,
+    handleInputsChanged,
+  ]);
 
   // Stop any active draw when the panel unmounts.
   useEffect(() => stopDrawing, [stopDrawing]);
@@ -749,6 +789,14 @@ export function AnalysisPanel({
           ...(operation === 'clip' && !mask && maskLayer?.dataset_id
             ? { mask_dataset_id: maskLayer.dataset_id }
             : {}),
+          ...(operation === 'spatial_join' && joinLayer?.dataset_id
+            ? {
+                join_dataset_id: joinLayer.dataset_id,
+                ...(joinField !== BY_FIELD_NONE
+                  ? { join_fields: [joinField.replace(/^col:/, '')] }
+                  : {}),
+              }
+            : {}),
         },
         controller.signal,
       );
@@ -855,6 +903,14 @@ export function AnalysisPanel({
         ...(operation === 'dissolve' && byField !== BY_FIELD_NONE
           ? { by_field: byField.replace(/^col:/, '') }
           : {}),
+        ...(operation === 'spatial_join' && joinLayer?.dataset_id
+          ? {
+              join_dataset_id: joinLayer.dataset_id,
+              ...(joinField !== BY_FIELD_NONE
+                ? { join_fields: [joinField.replace(/^col:/, '')] }
+                : {}),
+            }
+          : {}),
       });
       // fix(#793 review): mark the job as this instance's own BEFORE the
       // store learns about it — the adoption effect must not treat it as a
@@ -886,7 +942,10 @@ export function AnalysisPanel({
 
   const paramsValid =
     (operation !== 'buffer' || distanceValid) &&
-    (operation !== 'clip' || !!mask || !!maskLayer);
+    (operation !== 'clip' || !!mask || !!maskLayer) &&
+    // feat(#953): a join with nothing to join against is not a runnable form —
+    // reflect it here rather than letting the click earn a 422.
+    (operation !== 'spatial_join' || !!joinLayer);
   const canRun =
     !!selectedLayer?.dataset_id &&
     !previewMutation.isPending &&
@@ -1012,6 +1071,9 @@ export function AnalysisPanel({
             <SelectItem value="clip">
               {t('analysisTools.opClip', { defaultValue: 'Clip' })}
             </SelectItem>
+            <SelectItem value="spatial_join">
+              {t('analysisTools.opSpatialJoin', { defaultValue: 'Spatial join' })}
+            </SelectItem>
             {/* fix(#779): dissolve has no preview by design, and the whole
                 materialize block is hidden without the upload permission — a
                 viewer picking it got a form with no actions and a hint
@@ -1032,6 +1094,82 @@ export function AnalysisPanel({
           </p>
         )}
       </div>
+
+      {operation === 'spatial_join' && (
+        <>
+          <div className="space-y-1.5">
+            <Label className="text-xs" htmlFor="analysis-join-layer">
+              {t('analysisTools.joinLayerLabel', { defaultValue: 'Join with layer' })}
+            </Label>
+            <Select
+              value={joinLayerId}
+              onValueChange={(v) => {
+                handleInputsChanged();
+                setJoinLayerId(v);
+                // The column list comes from the join layer, so a remembered
+                // field cannot survive changing which layer that is.
+                setJoinField(BY_FIELD_NONE);
+              }}
+            >
+              <SelectTrigger id="analysis-join-layer" className="w-full">
+                <SelectValue
+                  placeholder={t('analysisTools.joinLayerPlaceholder', {
+                    defaultValue: 'Choose a layer',
+                  })}
+                />
+              </SelectTrigger>
+              <SelectContent>
+                {joinLayerOptions.map((l) => (
+                  <SelectItem key={l.id} value={l.id}>
+                    {l.display_name ?? l.dataset_name ?? l.id}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            <p className="text-xs text-muted-foreground">
+              {t('analysisTools.spatialJoinHint', {
+                defaultValue:
+                  'Each feature gains a join_count of the features it intersects. Overlaps count every match but still produce one row.',
+              })}
+            </p>
+          </div>
+
+          <div className="space-y-1.5">
+            <Label className="text-xs" htmlFor="analysis-join-field">
+              {t('analysisTools.joinFieldLabel', {
+                defaultValue: 'Copy a field across (optional)',
+              })}
+            </Label>
+            <Select
+              value={joinField}
+              onValueChange={(v) => {
+                handleInputsChanged();
+                setJoinField(v);
+              }}
+              disabled={!joinLayer}
+            >
+              <SelectTrigger id="analysis-join-field" className="w-full">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value={BY_FIELD_NONE}>
+                  {t('analysisTools.joinFieldNone', {
+                    defaultValue: 'Count only',
+                  })}
+                </SelectItem>
+                {joinFieldColumns.map((name) => (
+                  // Same 'col:' prefix as the dissolve picker, for the same
+                  // reason: a real column named '__none__' must not collide
+                  // with the sentinel.
+                  <SelectItem key={name} value={`col:${name}`}>
+                    {name}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+        </>
+      )}
 
       {operation === 'dissolve' && (
         <div className="space-y-1.5">

--- a/frontend/src/components/builder/AnalysisPanel.tsx
+++ b/frontend/src/components/builder/AnalysisPanel.tsx
@@ -268,6 +268,7 @@ export function AnalysisPanel({
       clip: t('analysisTools.opClip', { defaultValue: 'Clip' }),
       dissolve: t('analysisTools.opDissolve', { defaultValue: 'Dissolve' }),
       spatial_join: t('analysisTools.opSpatialJoin', { defaultValue: 'Spatial join' }),
+      measure: t('analysisTools.opMeasure', { defaultValue: 'Measure' }),
     };
     return [base, opLabel[prefill.operation]].filter(Boolean).join(' — ');
   });
@@ -1074,6 +1075,9 @@ export function AnalysisPanel({
             <SelectItem value="spatial_join">
               {t('analysisTools.opSpatialJoin', { defaultValue: 'Spatial join' })}
             </SelectItem>
+            <SelectItem value="measure">
+              {t('analysisTools.opMeasure', { defaultValue: 'Measure' })}
+            </SelectItem>
             {/* fix(#779): dissolve has no preview by design, and the whole
                 materialize block is hidden without the upload permission — a
                 viewer picking it got a form with no actions and a hint
@@ -1094,6 +1098,15 @@ export function AnalysisPanel({
           </p>
         )}
       </div>
+
+      {operation === 'measure' && (
+        <p className="text-xs text-muted-foreground">
+          {t('analysisTools.measureHint', {
+            defaultValue:
+              'Adds area_sqm and length_m to every feature, measured on the globe. Polygons get an area and lines a length; the other reads 0.',
+          })}
+        </p>
+      )}
 
       {operation === 'spatial_join' && (
         <>

--- a/frontend/src/components/builder/AnalysisPanel.tsx
+++ b/frontend/src/components/builder/AnalysisPanel.tsx
@@ -666,9 +666,18 @@ export function AnalysisPanel({
     joinLayerId !== MASK_LAYER_NONE
       ? joinLayerOptions.find((l) => l.id === joinLayerId)
       : undefined;
-  // Only fetched while dissolve is selected (enabled gates on a non-empty id).
+  // fix(#1097 review): spatial_join needs the SOURCE's columns too, not just
+  // dissolve. A transferred field lands as join_<name>, so a source that
+  // already has join_zone — routinely, because it is the output of an earlier
+  // spatial join — collides with a join layer's `zone`, and the server rejects
+  // both Preview and Create with a 422 the picker gave no warning of.
   const datasetDetail = useDataset(
-    operation === 'dissolve' ? (selectedLayer?.dataset_id ?? '') : '',
+    operation === 'dissolve' || operation === 'spatial_join'
+      ? (selectedLayer?.dataset_id ?? '')
+      : '',
+  );
+  const sourceColumnNames = new Set(
+    (datasetDetail.data?.column_info ?? []).map((c) => c.name),
   );
   const byFieldColumns = (datasetDetail.data?.column_info ?? [])
     .filter(
@@ -686,15 +695,18 @@ export function AnalysisPanel({
     operation === 'spatial_join' ? (joinLayer?.dataset_id ?? '') : '',
   );
   const joinFieldColumns = (joinDatasetDetail.data?.column_info ?? [])
-    .filter(
-      (c) =>
-        SAFE_COLUMN_RE.test(c.name) &&
-        // Transferred fields are prefixed 'join_', so a field named 'count'
-        // would land on the generated join_count column. Compared against the
-        // generated name rather than against the literal 'count', so it keeps
-        // holding if the prefix or the generated set changes.
-        `join_${c.name}` !== 'join_count',
-    )
+    .filter((c) => {
+      if (!SAFE_COLUMN_RE.test(c.name)) return false;
+      // Every rejection below is about the name the field would LAND on, not
+      // the name it has, so all of them compare the generated form. That is
+      // what keeps them true if the prefix or the generated set changes.
+      const generated = `join_${c.name}`;
+      // Would overwrite the generated match count.
+      if (generated === 'join_count') return false;
+      // Would arrive twice: once from the source, once from the join.
+      if (sourceColumnNames.has(generated)) return false;
+      return true;
+    })
     .map((c) => c.name);
 
   const stopDrawing = useCallback(() => {

--- a/frontend/src/components/builder/AnalysisPanel.tsx
+++ b/frontend/src/components/builder/AnalysisPanel.tsx
@@ -272,6 +272,7 @@ export function AnalysisPanel({
       select_by_location: t('analysisTools.opSelectByLocation', {
         defaultValue: 'Select by location',
       }),
+      intersect: t('analysisTools.opIntersect', { defaultValue: 'Intersect' }),
     };
     return [base, opLabel[prefill.operation]].filter(Boolean).join(' — ');
   });
@@ -553,6 +554,11 @@ export function AnalysisPanel({
   // layer pair clip does, and the API takes it in the same two fields, so the
   // panel shares the controls rather than growing a second spelling of them.
   const usesMask = operation === 'clip' || operation === 'select_by_location';
+  // feat(#956): intersect shares the layer PICKER but not the draw block — a
+  // drawn polygon carries no attributes to overlay with, which would make it an
+  // expensive clip. The API reflects that too: `mask` is not an intersect
+  // param, only `mask_dataset_id`.
+  const usesMaskLayer = usesMask || operation === 'intersect';
   // The controls are shared; the words cannot be. "Draw clip area" under a
   // selection names an operation the user did not pick.
   const maskCopy =
@@ -567,16 +573,36 @@ export function AnalysisPanel({
           layerLabel: t('analysisTools.selectLayerLabel', {
             defaultValue: 'Or select against a layer',
           }),
+          layerNone: t('analysisTools.clipLayerNone', {
+            defaultValue: 'None — draw on the map',
+          }),
           pointerHint: t('analysisTools.drawSelectionPointerHint', {
             defaultValue:
               'Drawing needs a pointer. To select without one, pick a polygon layer below.',
           }),
         }
+      : operation === 'intersect'
+        ? {
+            // draw/areaSet/pointerHint are unused here: intersect renders the
+            // picker below but never the draw block above it.
+            draw: '',
+            areaSet: '',
+            pointerHint: '',
+            layerLabel: t('analysisTools.overlayLayerLabel', {
+              defaultValue: 'Overlay with layer',
+            }),
+            layerNone: t('analysisTools.overlayLayerNone', {
+              defaultValue: 'Choose a layer',
+            }),
+          }
       : {
           draw: t('analysisTools.drawMask', { defaultValue: 'Draw clip area' }),
           areaSet: t('analysisTools.maskSet', { defaultValue: 'Clip area set' }),
           layerLabel: t('analysisTools.clipLayerLabel', {
             defaultValue: 'Or clip to a layer',
+          }),
+          layerNone: t('analysisTools.clipLayerNone', {
+            defaultValue: 'None — draw on the map',
           }),
           pointerHint: t('analysisTools.drawMaskPointerHint', {
             defaultValue:
@@ -824,7 +850,7 @@ export function AnalysisPanel({
           operation: operation as Exclude<AnalysisOperation, 'dissolve'>,
           ...(operation === 'buffer' ? { distance_meters: distanceValue } : {}),
           ...(usesMask && mask ? { mask } : {}),
-          ...(usesMask && !mask && maskLayer?.dataset_id
+          ...(usesMaskLayer && !mask && maskLayer?.dataset_id
             ? { mask_dataset_id: maskLayer.dataset_id }
             : {}),
           ...(operation === 'spatial_join' && joinLayer?.dataset_id
@@ -935,7 +961,7 @@ export function AnalysisPanel({
         title,
         ...(operation === 'buffer' ? { distance_meters: distanceValue } : {}),
         ...(usesMask && mask ? { mask } : {}),
-        ...(usesMask && !mask && maskLayer?.dataset_id
+        ...(usesMaskLayer && !mask && maskLayer?.dataset_id
           ? { mask_dataset_id: maskLayer.dataset_id }
           : {}),
         ...(operation === 'dissolve' && byField !== BY_FIELD_NONE
@@ -981,6 +1007,8 @@ export function AnalysisPanel({
   const paramsValid =
     (operation !== 'buffer' || distanceValid) &&
     (!usesMask || !!mask || !!maskLayer) &&
+    // feat(#956): layer only, so there is no drawn fallback to fall back to.
+    (operation !== 'intersect' || !!maskLayer) &&
     // feat(#953): a join with nothing to join against is not a runnable form —
     // reflect it here rather than letting the click earn a 422.
     (operation !== 'spatial_join' || !!joinLayer);
@@ -1123,6 +1151,9 @@ export function AnalysisPanel({
                 defaultValue: 'Select by location',
               })}
             </SelectItem>
+            <SelectItem value="intersect">
+              {t('analysisTools.opIntersect', { defaultValue: 'Intersect' })}
+            </SelectItem>
             {/* fix(#779): dissolve has no preview by design, and the whole
                 materialize block is hidden without the upload permission — a
                 viewer picking it got a form with no actions and a hint
@@ -1143,6 +1174,15 @@ export function AnalysisPanel({
           </p>
         )}
       </div>
+
+      {operation === 'intersect' && (
+        <p className="text-xs text-muted-foreground">
+          {t('analysisTools.intersectHint', {
+            defaultValue:
+              'Cuts new features where the two layers overlap, one per overlapping pair, carrying columns from both. Use Measure afterwards for overlap area.',
+          })}
+        </p>
+      )}
 
       {operation === 'select_by_location' && (
         <p className="text-xs text-muted-foreground">
@@ -1422,7 +1462,7 @@ export function AnalysisPanel({
         </div>
       )}
 
-      {usesMask && (
+      {usesMaskLayer && (
         <div className="space-y-1.5">
           <Label className="text-xs" htmlFor="analysis-mask-layer">
             {maskCopy.layerLabel}
@@ -1443,11 +1483,7 @@ export function AnalysisPanel({
               <SelectValue />
             </SelectTrigger>
             <SelectContent>
-              <SelectItem value={MASK_LAYER_NONE}>
-                {t('analysisTools.clipLayerNone', {
-                  defaultValue: 'None — draw on the map',
-                })}
-              </SelectItem>
+              <SelectItem value={MASK_LAYER_NONE}>{maskCopy.layerNone}</SelectItem>
               {/* fix(#779): say why the list is empty instead of showing a
                   dropdown with a lone "None" entry. */}
               {maskLayerOptions.length === 0 && (

--- a/frontend/src/components/builder/AnalysisPanel.tsx
+++ b/frontend/src/components/builder/AnalysisPanel.tsx
@@ -269,6 +269,9 @@ export function AnalysisPanel({
       dissolve: t('analysisTools.opDissolve', { defaultValue: 'Dissolve' }),
       spatial_join: t('analysisTools.opSpatialJoin', { defaultValue: 'Spatial join' }),
       measure: t('analysisTools.opMeasure', { defaultValue: 'Measure' }),
+      select_by_location: t('analysisTools.opSelectByLocation', {
+        defaultValue: 'Select by location',
+      }),
     };
     return [base, opLabel[prefill.operation]].filter(Boolean).join(' — ');
   });
@@ -546,6 +549,40 @@ export function AnalysisPanel({
     maskLayerId !== MASK_LAYER_NONE
       ? maskLayerOptions.find((l) => l.id === maskLayerId)
       : undefined;
+  // feat(#955): select_by_location takes its geometry from the same drawn-or-
+  // layer pair clip does, and the API takes it in the same two fields, so the
+  // panel shares the controls rather than growing a second spelling of them.
+  const usesMask = operation === 'clip' || operation === 'select_by_location';
+  // The controls are shared; the words cannot be. "Draw clip area" under a
+  // selection names an operation the user did not pick.
+  const maskCopy =
+    operation === 'select_by_location'
+      ? {
+          draw: t('analysisTools.drawSelectionArea', {
+            defaultValue: 'Draw selection area',
+          }),
+          areaSet: t('analysisTools.selectionAreaSet', {
+            defaultValue: 'Selection area set',
+          }),
+          layerLabel: t('analysisTools.selectLayerLabel', {
+            defaultValue: 'Or select against a layer',
+          }),
+          pointerHint: t('analysisTools.drawSelectionPointerHint', {
+            defaultValue:
+              'Drawing needs a pointer. To select without one, pick a polygon layer below.',
+          }),
+        }
+      : {
+          draw: t('analysisTools.drawMask', { defaultValue: 'Draw clip area' }),
+          areaSet: t('analysisTools.maskSet', { defaultValue: 'Clip area set' }),
+          layerLabel: t('analysisTools.clipLayerLabel', {
+            defaultValue: 'Or clip to a layer',
+          }),
+          pointerHint: t('analysisTools.drawMaskPointerHint', {
+            defaultValue:
+              'Drawing needs a pointer. To clip without one, pick a polygon layer below.',
+          }),
+        };
   // feat(#953): a join works in every direction — points in polygons, polygons
   // over polygons, lines crossing polygons — so unlike the clip mask above
   // there is no geometry-type filter, only "not the source layer".
@@ -786,8 +823,8 @@ export function AnalysisPanel({
           // canRun blocks dissolve from the preview path.
           operation: operation as Exclude<AnalysisOperation, 'dissolve'>,
           ...(operation === 'buffer' ? { distance_meters: distanceValue } : {}),
-          ...(operation === 'clip' && mask ? { mask } : {}),
-          ...(operation === 'clip' && !mask && maskLayer?.dataset_id
+          ...(usesMask && mask ? { mask } : {}),
+          ...(usesMask && !mask && maskLayer?.dataset_id
             ? { mask_dataset_id: maskLayer.dataset_id }
             : {}),
           ...(operation === 'spatial_join' && joinLayer?.dataset_id
@@ -897,8 +934,8 @@ export function AnalysisPanel({
         operation,
         title,
         ...(operation === 'buffer' ? { distance_meters: distanceValue } : {}),
-        ...(operation === 'clip' && mask ? { mask } : {}),
-        ...(operation === 'clip' && !mask && maskLayer?.dataset_id
+        ...(usesMask && mask ? { mask } : {}),
+        ...(usesMask && !mask && maskLayer?.dataset_id
           ? { mask_dataset_id: maskLayer.dataset_id }
           : {}),
         ...(operation === 'dissolve' && byField !== BY_FIELD_NONE
@@ -943,7 +980,7 @@ export function AnalysisPanel({
 
   const paramsValid =
     (operation !== 'buffer' || distanceValid) &&
-    (operation !== 'clip' || !!mask || !!maskLayer) &&
+    (!usesMask || !!mask || !!maskLayer) &&
     // feat(#953): a join with nothing to join against is not a runnable form —
     // reflect it here rather than letting the click earn a 422.
     (operation !== 'spatial_join' || !!joinLayer);
@@ -1049,10 +1086,13 @@ export function AnalysisPanel({
           onValueChange={(v) => {
             handleInputsChanged();
             const next = v as AnalysisOperation;
-            if (next !== 'clip') {
+            if (next !== 'clip' && next !== 'select_by_location') {
               // fix(#680): leaving clip mode must drop the retained mask —
               // the static-mode TerraDraw layers otherwise stay visible on
-              // the map under operations that ignore them.
+              // the map under operations that ignore them. feat(#955): clip
+              // and select_by_location both use the mask, so switching
+              // BETWEEN them keeps the drawn area instead of making the user
+              // redraw the same polygon.
               setMask(null);
               stopDrawing();
             }
@@ -1078,6 +1118,11 @@ export function AnalysisPanel({
             <SelectItem value="measure">
               {t('analysisTools.opMeasure', { defaultValue: 'Measure' })}
             </SelectItem>
+            <SelectItem value="select_by_location">
+              {t('analysisTools.opSelectByLocation', {
+                defaultValue: 'Select by location',
+              })}
+            </SelectItem>
             {/* fix(#779): dissolve has no preview by design, and the whole
                 materialize block is hidden without the upload permission — a
                 viewer picking it got a form with no actions and a hint
@@ -1098,6 +1143,15 @@ export function AnalysisPanel({
           </p>
         )}
       </div>
+
+      {operation === 'select_by_location' && (
+        <p className="text-xs text-muted-foreground">
+          {t('analysisTools.selectByLocationHint', {
+            defaultValue:
+              'Keeps the features that touch the area, whole and unchanged. Use Create dataset to save the list, then export it.',
+          })}
+        </p>
+      )}
 
       {operation === 'measure' && (
         <p className="text-xs text-muted-foreground">
@@ -1301,15 +1355,13 @@ export function AnalysisPanel({
         </div>
       )}
 
-      {operation === 'clip' && maskLayer == null && (
+      {usesMask && maskLayer == null && (
         <div className="space-y-1.5">
           {/* fix(#754): no htmlFor here — a <label for> pointed at a button
               OVERRIDES the button's own text in the accessible-name
               computation, so Cancel and Clear were both announced as "Draw
               clip area". The buttons below are self-labeling. */}
-          <Label className="text-xs">
-            {t('analysisTools.drawMask', { defaultValue: 'Draw clip area' })}
-          </Label>
+          <Label className="text-xs">{maskCopy.draw}</Label>
           {isDrawing ? (
             <div className="space-y-1.5">
               <p className="text-xs text-muted-foreground">
@@ -1330,7 +1382,7 @@ export function AnalysisPanel({
           ) : mask ? (
             <div className="flex items-center justify-between gap-2">
               <span className="text-xs text-muted-foreground">
-                {t('analysisTools.maskSet', { defaultValue: 'Clip area set' })}
+                {maskCopy.areaSet}
               </span>
               <Button
                 ref={clearMaskButtonRef}
@@ -1358,27 +1410,22 @@ export function AnalysisPanel({
                 onClick={startDrawing}
                 disabled={!mapInstance}
               >
-                {t('analysisTools.drawMask', { defaultValue: 'Draw clip area' })}
+                {maskCopy.draw}
               </Button>
               {/* ux(#686): drawing is pointer-only. Name the keyboard-reachable
                   alternative instead of leaving it to be discovered. */}
               <p className="text-xs text-muted-foreground">
-                {t('analysisTools.drawMaskPointerHint', {
-                  defaultValue:
-                    'Drawing needs a pointer. To clip without one, pick a polygon layer below.',
-                })}
+                {maskCopy.pointerHint}
               </p>
             </div>
           )}
         </div>
       )}
 
-      {operation === 'clip' && (
+      {usesMask && (
         <div className="space-y-1.5">
           <Label className="text-xs" htmlFor="analysis-mask-layer">
-            {t('analysisTools.clipLayerLabel', {
-              defaultValue: 'Or clip to a layer',
-            })}
+            {maskCopy.layerLabel}
           </Label>
           <Select
             value={maskLayerId}

--- a/frontend/src/components/builder/__tests__/AnalysisPanel.test.tsx
+++ b/frontend/src/components/builder/__tests__/AnalysisPanel.test.tsx
@@ -2264,18 +2264,139 @@ describe('AnalysisPanel select by location (feat(#955))', () => {
     ]);
   });
 
-  it('still drops a drawn area when leaving for an operation that ignores it', async () => {
+  it('still tears the drawn area off the map when leaving for centroid', async () => {
     const user = userEvent.setup();
+    mockTerraDraw.instance.stop.mockClear();
     seedDrawnClipMask();
-    // mapId is what keys the saved form; without it there is nothing to restore.
-    renderPanel([datasetLayer, datasetLayer2], { mapId: 'm1' });
+    // A map ref is required for BOTH halves: it is what makes the restore
+    // construct a TerraDraw instance, and therefore what makes the teardown
+    // observable at all.
+    renderPanel([datasetLayer, datasetLayer2], {
+      mapId: 'm1',
+      mapInstanceRef: { current: { on: vi.fn(), off: vi.fn() } as never },
+    });
+    await waitFor(() =>
+      expect(mockTerraDraw.instance.addFeatures).toHaveBeenCalled(),
+    );
 
-    // fix(#680)'s rule survives the widening: the retained mask must go when
-    // the next operation has no use for it, or its map layers linger.
+    // fix(#680)'s rule survives the widening: the retained polygon's TerraDraw
+    // layers must come off the map when the next operation ignores them.
+    // Asserted through stop() rather than through the request body — the body
+    // omits `mask` for centroid anyway, so it cannot tell the two apart.
     await pickOperation(user, 'Centroids');
+    await waitFor(() => expect(mockTerraDraw.instance.stop).toHaveBeenCalled());
+
+    fireEvent.click(screen.getByRole('button', { name: 'Preview' }));
+    await waitFor(() => expect(previewAnalysis).toHaveBeenCalled());
+    expect(previewRequest()).toEqual(['ds1', { operation: 'centroid' }]);
+  });
+});
+
+describe('AnalysisPanel intersect (feat(#956))', () => {
+  beforeEach(() => {
+    useAnalysisJobStore.setState({ job: null });
+    useAnalysisAddedStore.setState({ addedDatasetIds: [], pendingAddIds: [] });
+    useAnalysisFormStore.setState({ forms: {} });
+    vi.clearAllMocks();
+  });
+
+  async function pickIntersect(user: ReturnType<typeof userEvent.setup>) {
+    await user.click(screen.getAllByRole('combobox')[1]);
+    await user.click(await screen.findByRole('option', { name: 'Intersect' }));
+  }
+
+  function previewRequest() {
+    return vi.mocked(previewAnalysis).mock.calls[0].slice(0, 2);
+  }
+
+  it('offers a layer picker and no way to draw', async () => {
+    const user = userEvent.setup();
+    renderPanel([datasetLayer, datasetLayer2]);
+    await pickIntersect(user);
+
+    // A drawn polygon carries no attributes to overlay with, so the API takes
+    // a layer only and the panel must not offer the alternative.
+    expect(screen.getByLabelText('Overlay with layer')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Draw clip area' })).toBeNull();
+    expect(
+      screen.queryByRole('button', { name: 'Draw selection area' }),
+    ).toBeNull();
+  });
+
+  it('cannot preview until a layer is picked', async () => {
+    const user = userEvent.setup();
+    renderPanel([datasetLayer, datasetLayer2]);
+    await pickIntersect(user);
+
+    // No drawn fallback exists, so the empty picker is genuinely blocking.
+    expect(screen.getByRole('button', { name: 'Preview' })).toBeDisabled();
+
+    await user.click(screen.getByLabelText('Overlay with layer'));
+    await user.click(await screen.findByRole('option', { name: 'Roads' }));
+
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: 'Preview' })).toBeEnabled(),
+    );
+  });
+
+  it('sends mask_dataset_id and never a drawn mask', async () => {
+    const user = userEvent.setup();
+    renderPanel([datasetLayer, datasetLayer2]);
+    await pickIntersect(user);
+
+    await user.click(screen.getByLabelText('Overlay with layer'));
+    await user.click(await screen.findByRole('option', { name: 'Roads' }));
     fireEvent.click(screen.getByRole('button', { name: 'Preview' }));
 
     await waitFor(() => expect(previewAnalysis).toHaveBeenCalled());
-    expect(previewRequest()).toEqual(['ds1', { operation: 'centroid' }]);
+    expect(previewRequest()).toEqual([
+      'ds1',
+      { operation: 'intersect', mask_dataset_id: 'ds2' },
+    ]);
+  });
+
+  it('tears a drawn area carried over from clip off the map', async () => {
+    const user = userEvent.setup();
+    mockTerraDraw.instance.stop.mockClear();
+    useAnalysisFormStore.getState().save('m1', {
+      layerId: 'l1', operation: 'clip', distance: '500', distanceUnit: 'm',
+      mask: { type: 'Polygon', coordinates: [[[0, 0], [1, 0], [1, 1], [0, 0]]] },
+      maskLayerId: '__none__', byField: '__none__', outputTitle: '',
+    });
+    renderPanel([datasetLayer, datasetLayer2], {
+      mapId: 'm1',
+      mapInstanceRef: { current: { on: vi.fn(), off: vi.fn() } as never },
+    });
+    await waitFor(() =>
+      expect(mockTerraDraw.instance.addFeatures).toHaveBeenCalled(),
+    );
+
+    // Unlike clip -> select_by_location, this switch has to clear the polygon:
+    // intersect ignores a drawn mask, so a retained one would sit on the map
+    // depicting nothing. The request body cannot prove it (usesMask already
+    // excludes intersect), so assert the teardown itself.
+    await pickIntersect(user);
+    await waitFor(() => expect(mockTerraDraw.instance.stop).toHaveBeenCalled());
+
+    await user.click(screen.getByLabelText('Overlay with layer'));
+    await user.click(await screen.findByRole('option', { name: 'Roads' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Preview' }));
+    await waitFor(() => expect(previewAnalysis).toHaveBeenCalled());
+    expect(previewRequest()).toEqual([
+      'ds1',
+      { operation: 'intersect', mask_dataset_id: 'ds2' },
+    ]);
+  });
+
+  it('offers only polygon layers to overlay with', async () => {
+    const user = userEvent.setup();
+    renderPanel([datasetLayer, datasetLayer2, pointLayer]);
+    await pickIntersect(user);
+
+    // _load_mask_dataset requires a polygonal layer, so filter here rather
+    // than let the pick earn a 422.
+    await user.click(screen.getByLabelText('Overlay with layer'));
+    expect(await screen.findByRole('option', { name: 'Roads' })).toBeInTheDocument();
+    expect(screen.queryByRole('option', { name: 'Bus stops' })).toBeNull();
   });
 });

--- a/frontend/src/components/builder/__tests__/AnalysisPanel.test.tsx
+++ b/frontend/src/components/builder/__tests__/AnalysisPanel.test.tsx
@@ -2038,3 +2038,121 @@ describe('AnalysisPanel — audit remediation (v1.6.0)', () => {
     expect(mockTerraDraw.instance.setMode).toHaveBeenLastCalledWith('static');
   });
 });
+
+describe('AnalysisPanel spatial join (feat(#953))', () => {
+  beforeEach(() => {
+    useAnalysisJobStore.setState({ job: null });
+    useAnalysisAddedStore.setState({ addedDatasetIds: [], pendingAddIds: [] });
+    useAnalysisFormStore.setState({ forms: {} });
+    vi.clearAllMocks();
+  });
+
+  async function pickSpatialJoin(user: ReturnType<typeof userEvent.setup>) {
+    // Combobox order: layer, operation.
+    await user.click(screen.getAllByRole('combobox')[1]);
+    await user.click(await screen.findByRole('option', { name: 'Spatial join' }));
+  }
+
+  /** The (datasetId, body) of the first preview call.
+   *
+   * Deliberately the first TWO arguments rather than toHaveBeenCalledWith:
+   * #787 item 3 adds a third AbortSignal argument on a separate branch, and
+   * these tests are about the request body, which is the same either way.
+   */
+  function previewRequest() {
+    return vi.mocked(previewAnalysis).mock.calls[0].slice(0, 2);
+  }
+
+  it('offers every other layer as a join target, not only polygons', async () => {
+    const user = userEvent.setup();
+    // pointLayer is excluded from the CLIP mask picker by the ux(#698) filter;
+    // a join counts in any direction, so it must be offered here.
+    renderPanel([datasetLayer, datasetLayer2, pointLayer]);
+    await pickSpatialJoin(user);
+
+    await user.click(screen.getAllByRole('combobox')[2]);
+    expect(await screen.findByRole('option', { name: 'Bus stops' })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'Roads' })).toBeInTheDocument();
+    // The source layer cannot join against itself.
+    expect(screen.queryByRole('option', { name: 'Parcels' })).toBeNull();
+  });
+
+  it('cannot preview until a join layer is picked', async () => {
+    const user = userEvent.setup();
+    renderPanel([datasetLayer, datasetLayer2]);
+    await pickSpatialJoin(user);
+
+    expect(screen.getByRole('button', { name: 'Preview' })).toBeDisabled();
+
+    await user.click(screen.getAllByRole('combobox')[2]);
+    await user.click(await screen.findByRole('option', { name: 'Roads' }));
+
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: 'Preview' })).toBeEnabled(),
+    );
+  });
+
+  it('sends join_dataset_id alone when no field is transferred', async () => {
+    const user = userEvent.setup();
+    renderPanel([datasetLayer, datasetLayer2]);
+    await pickSpatialJoin(user);
+
+    await user.click(screen.getAllByRole('combobox')[2]);
+    await user.click(await screen.findByRole('option', { name: 'Roads' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Preview' }));
+
+    await waitFor(() => expect(previewAnalysis).toHaveBeenCalled());
+    expect(previewRequest()).toEqual([
+      'ds1',
+      { operation: 'spatial_join', join_dataset_id: 'ds2' },
+    ]);
+  });
+
+  it('sends join_fields when a column is chosen', async () => {
+    const user = userEvent.setup();
+    renderPanel([datasetLayer, datasetLayer2]);
+    await pickSpatialJoin(user);
+
+    await user.click(screen.getAllByRole('combobox')[2]);
+    await user.click(await screen.findByRole('option', { name: 'Roads' }));
+    // Third combobox is the field picker, populated from the JOIN layer.
+    await user.click(screen.getAllByRole('combobox')[3]);
+    await user.click(await screen.findByRole('option', { name: 'name' }));
+
+    fireEvent.change(screen.getByLabelText('New dataset name'), {
+      target: { value: 'Parcels with road names' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Create dataset' }));
+
+    await waitFor(() =>
+      expect(materializeAnalysis).toHaveBeenCalledWith('ds1', {
+        operation: 'spatial_join',
+        title: 'Parcels with road names',
+        join_dataset_id: 'ds2',
+        join_fields: ['name'],
+      }),
+    );
+  });
+
+  it('drops the chosen field when the join layer changes', async () => {
+    const user = userEvent.setup();
+    renderPanel([datasetLayer, datasetLayer2, pointLayer]);
+    await pickSpatialJoin(user);
+
+    await user.click(screen.getAllByRole('combobox')[2]);
+    await user.click(await screen.findByRole('option', { name: 'Roads' }));
+    await user.click(screen.getAllByRole('combobox')[3]);
+    await user.click(await screen.findByRole('option', { name: 'name' }));
+
+    // Switching layers must not carry a column that belonged to the old one.
+    await user.click(screen.getAllByRole('combobox')[2]);
+    await user.click(await screen.findByRole('option', { name: 'Bus stops' }));
+
+    fireEvent.click(screen.getByRole('button', { name: 'Preview' }));
+    await waitFor(() => expect(previewAnalysis).toHaveBeenCalled());
+    expect(previewRequest()).toEqual([
+      'ds1',
+      { operation: 'spatial_join', join_dataset_id: 'ds4' },
+    ]);
+  });
+});

--- a/frontend/src/components/builder/__tests__/AnalysisPanel.test.tsx
+++ b/frontend/src/components/builder/__tests__/AnalysisPanel.test.tsx
@@ -2283,6 +2283,39 @@ describe('AnalysisPanel spatial join (feat(#953))', () => {
     expect(screen.queryByRole('option', { name: 'zone' })).toBeNull();
   });
 
+  it('does not keep a join field the new source makes invalid (#1097 review)', async () => {
+    // The field belongs to the JOIN layer, so a source change leaves it
+    // intact — but whether it is USABLE depends on the source, since
+    // join_<name> must not collide with a source column. ds1 has join_zone and
+    // the others do not, so picking `zone` against a ds2 source and then
+    // switching the source to ds1 left the menu filtering `zone` out while the
+    // state still held it. The request went anyway and earned a 422.
+    //
+    // The join layer is a THIRD layer on purpose: switching the source onto
+    // the join layer also clears it (nothing joins against itself), which
+    // would mask whether the FIELD was cleared on its own.
+    const user = userEvent.setup();
+    renderPanel([datasetLayer2, pointLayer, datasetLayer]);
+    await user.click(screen.getAllByRole('combobox')[1]);
+    await user.click(await screen.findByRole('option', { name: 'Spatial join' }));
+    await user.click(screen.getAllByRole('combobox')[2]);
+    await user.click(await screen.findByRole('option', { name: 'Bus stops' }));
+    await user.click(screen.getAllByRole('combobox')[3]);
+    await user.click(await screen.findByRole('option', { name: 'zone' }));
+
+    // Switch the SOURCE to the layer that already carries join_zone.
+    await user.click(screen.getAllByRole('combobox')[0]);
+    await user.click(await screen.findByRole('option', { name: 'Parcels' }));
+
+    vi.mocked(previewAnalysis).mockClear();
+    fireEvent.click(screen.getByRole('button', { name: 'Preview' }));
+    await waitFor(() => expect(previewAnalysis).toHaveBeenCalled());
+    const body = vi.mocked(previewAnalysis).mock.calls[0][1] as {
+      join_fields?: string[];
+    };
+    expect(body.join_fields ?? []).not.toContain('zone');
+  });
+
   it('cannot preview until a join layer is picked', async () => {
     const user = userEvent.setup();
     renderPanel([datasetLayer, datasetLayer2]);

--- a/frontend/src/components/builder/__tests__/AnalysisPanel.test.tsx
+++ b/frontend/src/components/builder/__tests__/AnalysisPanel.test.tsx
@@ -2156,3 +2156,126 @@ describe('AnalysisPanel spatial join (feat(#953))', () => {
     ]);
   });
 });
+
+describe('AnalysisPanel select by location (feat(#955))', () => {
+  beforeEach(() => {
+    useAnalysisJobStore.setState({ job: null });
+    useAnalysisAddedStore.setState({ addedDatasetIds: [], pendingAddIds: [] });
+    useAnalysisFormStore.setState({ forms: {} });
+    vi.clearAllMocks();
+  });
+
+  async function pickOperation(
+    user: ReturnType<typeof userEvent.setup>,
+    name: string,
+  ) {
+    await user.click(screen.getAllByRole('combobox')[1]);
+    await user.click(await screen.findByRole('option', { name }));
+  }
+
+  function previewRequest() {
+    return vi.mocked(previewAnalysis).mock.calls[0].slice(0, 2);
+  }
+
+  it('names the selection, not the clip, in the shared mask controls', async () => {
+    const user = userEvent.setup();
+    renderPanel([datasetLayer, datasetLayer2]);
+    await pickOperation(user, 'Select by location');
+
+    // The controls are clip's; the wording must not be.
+    expect(screen.getByRole('button', { name: 'Draw selection area' })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Draw clip area' })).toBeNull();
+    expect(screen.getByLabelText('Or select against a layer')).toBeInTheDocument();
+  });
+
+  it('offers only polygon layers to select against', async () => {
+    const user = userEvent.setup();
+    // The selection geometry has to be an area, so this keeps clip's ux(#698)
+    // filter rather than spatial_join's any-direction rule.
+    renderPanel([datasetLayer, datasetLayer2, pointLayer]);
+    await pickOperation(user, 'Select by location');
+
+    await user.click(screen.getByLabelText('Or select against a layer'));
+    expect(await screen.findByRole('option', { name: 'Roads' })).toBeInTheDocument();
+    expect(screen.queryByRole('option', { name: 'Bus stops' })).toBeNull();
+  });
+
+  it('cannot preview until an area is drawn or a layer is picked', async () => {
+    const user = userEvent.setup();
+    renderPanel([datasetLayer, datasetLayer2]);
+    await pickOperation(user, 'Select by location');
+
+    expect(screen.getByRole('button', { name: 'Preview' })).toBeDisabled();
+
+    await user.click(screen.getByLabelText('Or select against a layer'));
+    await user.click(await screen.findByRole('option', { name: 'Roads' }));
+
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: 'Preview' })).toBeEnabled(),
+    );
+  });
+
+  it('sends mask_dataset_id on the same two fields clip uses', async () => {
+    const user = userEvent.setup();
+    renderPanel([datasetLayer, datasetLayer2]);
+    await pickOperation(user, 'Select by location');
+
+    await user.click(screen.getByLabelText('Or select against a layer'));
+    await user.click(await screen.findByRole('option', { name: 'Roads' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Preview' }));
+
+    await waitFor(() => expect(previewAnalysis).toHaveBeenCalled());
+    expect(previewRequest()).toEqual([
+      'ds1',
+      { operation: 'select_by_location', mask_dataset_id: 'ds2' },
+    ]);
+  });
+
+  // The DRAWN mask, not the layer picker: only the drawn one is cleared by the
+  // operation switch, so it is the only one these two tests can tell apart.
+  const drawnMask = {
+    type: 'Polygon' as const,
+    coordinates: [[[0, 0], [1, 0], [1, 1], [0, 0]]],
+  };
+  function seedDrawnClipMask() {
+    useAnalysisFormStore.getState().save('m1', {
+      layerId: 'l1', operation: 'clip', distance: '500', distanceUnit: 'm',
+      mask: drawnMask,
+      maskLayerId: '__none__', byField: '__none__', outputTitle: '',
+    });
+  }
+
+  it('keeps a drawn area when switching between clip and select', async () => {
+    const user = userEvent.setup();
+    seedDrawnClipMask();
+    // mapId is what keys the saved form; without it there is nothing to restore.
+    renderPanel([datasetLayer, datasetLayer2], { mapId: 'm1' });
+
+    // Both operations take the same geometry, so switching must not make the
+    // user redraw the polygon they already have.
+    await pickOperation(user, 'Select by location');
+    expect(screen.getByText('Selection area set')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Preview' }));
+
+    await waitFor(() => expect(previewAnalysis).toHaveBeenCalled());
+    expect(previewRequest()).toEqual([
+      'ds1',
+      { operation: 'select_by_location', mask: drawnMask },
+    ]);
+  });
+
+  it('still drops a drawn area when leaving for an operation that ignores it', async () => {
+    const user = userEvent.setup();
+    seedDrawnClipMask();
+    // mapId is what keys the saved form; without it there is nothing to restore.
+    renderPanel([datasetLayer, datasetLayer2], { mapId: 'm1' });
+
+    // fix(#680)'s rule survives the widening: the retained mask must go when
+    // the next operation has no use for it, or its map layers linger.
+    await pickOperation(user, 'Centroids');
+    fireEvent.click(screen.getByRole('button', { name: 'Preview' }));
+
+    await waitFor(() => expect(previewAnalysis).toHaveBeenCalled());
+    expect(previewRequest()).toEqual(['ds1', { operation: 'centroid' }]);
+  });
+});

--- a/frontend/src/components/builder/__tests__/AnalysisPanel.test.tsx
+++ b/frontend/src/components/builder/__tests__/AnalysisPanel.test.tsx
@@ -496,6 +496,70 @@ describe('AnalysisPanel', () => {
     );
   });
 
+  it('names the exact OUTPUT total for a row-filtering preview (#1097 review)', async () => {
+    // select_by_location and intersect send source_feature_count: null (the
+    // source count cannot describe how many rows survive) and the exact output
+    // total as match_count. Before this the panel read only
+    // source_feature_count, so the server paid for an uncapped count and the
+    // user still got the generic cap message.
+    vi.mocked(previewAnalysis).mockResolvedValueOnce({
+      geojson: { type: 'FeatureCollection', features: [] },
+      feature_count: 500,
+      truncated: true,
+      bbox: [0, 0, 1, 1],
+      source_feature_count: null,
+      match_count: 2838,
+    });
+    renderPanel([datasetLayer]);
+    mockT.mockClear();
+    mockToast.info.mockClear();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Preview' }));
+    await waitFor(() => expect(mockToast.info).toHaveBeenCalled());
+
+    // A distinct string, not truncatedNoticeTotal with a different number:
+    // this total is output rows, and for intersect one source feature can
+    // produce several, so "source features" would misdescribe it.
+    expect(mockT).toHaveBeenCalledWith(
+      'analysisTools.truncatedNoticeMatched',
+      expect.objectContaining({ count: 500, total: 2838 }),
+    );
+    expect(mockT).not.toHaveBeenCalledWith(
+      'analysisTools.truncatedNotice',
+      expect.anything(),
+    );
+  });
+
+  it('keeps the SOURCE total for spatial join, which also sends match_count (#1097 review)', async () => {
+    // The guard on the fix above. spatial_join sends BOTH: it keeps every
+    // source row, and its match_count is how many of them found a match.
+    // Preferring match_count wherever present would relabel 10,651 source
+    // features as 30,712 "matching" ones.
+    vi.mocked(previewAnalysis).mockResolvedValueOnce({
+      geojson: { type: 'FeatureCollection', features: [] },
+      feature_count: 500,
+      truncated: true,
+      bbox: [0, 0, 1, 1],
+      source_feature_count: 10651,
+      match_count: 30712,
+    });
+    renderPanel([datasetLayer]);
+    mockT.mockClear();
+    mockToast.info.mockClear();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Preview' }));
+    await waitFor(() => expect(mockToast.info).toHaveBeenCalled());
+
+    expect(mockT).toHaveBeenCalledWith(
+      'analysisTools.truncatedNoticeTotal',
+      expect.objectContaining({ count: 500, total: 10651 }),
+    );
+    expect(mockT).not.toHaveBeenCalledWith(
+      'analysisTools.truncatedNoticeMatched',
+      expect.anything(),
+    );
+  });
+
   it('raises no truncation notice for a complete preview', async () => {
     // fix(#699 codex P2): wait on a signal belonging to THIS request. The
     // `previewAnalysis` mock is shared and never cleared between tests, so
@@ -1081,6 +1145,7 @@ describe('AnalysisPanel — chat handoff prefill (#675)', () => {
       useAnalysisFormStore.getState().save('m1', {
         layerId: 'l1', operation: 'buffer', distance: '500', distanceUnit: 'm',
         mask: null, maskLayerId: '__none__', byField: '__none__',
+        joinLayerId: '__none__', joinField: '__none__',
         outputTitle: 'Walkshed',
       });
       useAnalysisJobStore.setState({
@@ -1136,7 +1201,7 @@ describe('AnalysisPanel — chat handoff prefill (#675)', () => {
       useAnalysisFormStore.getState().save('m1', {
         layerId: 'deleted-layer', operation: 'buffer', distance: '750',
         distanceUnit: 'm', mask: null, maskLayerId: '__none__',
-        byField: '__none__', outputTitle: '',
+        byField: '__none__', joinLayerId: '__none__', joinField: '__none__', outputTitle: '',
       });
       renderPanel([datasetLayer], {
         mapId: 'm1',
@@ -1155,7 +1220,7 @@ describe('AnalysisPanel — chat handoff prefill (#675)', () => {
       useAnalysisFormStore.getState().save('m1', {
         layerId: 'deleted-layer', operation: 'buffer', distance: '750',
         distanceUnit: 'm', mask: null, maskLayerId: '__none__',
-        byField: '__none__', outputTitle: '',
+        byField: '__none__', joinLayerId: '__none__', joinField: '__none__', outputTitle: '',
       });
       // The slot holds a NEWER chat result (no analysis-panel provenance) —
       // opening Analysis must not wipe it just because the remembered layer
@@ -1251,7 +1316,8 @@ describe('AnalysisPanel — chat handoff prefill (#675)', () => {
           type: 'Polygon',
           coordinates: [[[0, 0], [1, 0], [1, 1], [0, 0]]],
         },
-        maskLayerId: '__none__', byField: '__none__', outputTitle: '',
+        maskLayerId: '__none__', byField: '__none__',
+      joinLayerId: '__none__', joinField: '__none__', outputTitle: '',
       });
       // The lazy BuilderMap has not loaded yet — the ref is empty at mount.
       const mapRef = { current: null as unknown };
@@ -1292,7 +1358,8 @@ describe('AnalysisPanel — chat handoff prefill (#675)', () => {
           type: 'Polygon',
           coordinates: [[[0, 0], [1, 0], [1, 1], [0, 0]]],
         },
-        maskLayerId: '__none__', byField: '__none__', outputTitle: '',
+        maskLayerId: '__none__', byField: '__none__',
+      joinLayerId: '__none__', joinField: '__none__', outputTitle: '',
       });
       renderPanel([datasetLayer], {
         mapId: 'm1',
@@ -1315,7 +1382,7 @@ describe('AnalysisPanel — chat handoff prefill (#675)', () => {
       };
       useAnalysisFormStore.getState().save('m1', {
         layerId: 'l1', operation: 'clip', distance: '500', distanceUnit: 'm',
-        mask, maskLayerId: '__none__', byField: '__none__', outputTitle: '',
+        mask, maskLayerId: '__none__', byField: '__none__', joinLayerId: '__none__', joinField: '__none__', outputTitle: '',
       });
       // A map that actually tracks its style.load handlers: the fix
       // subscribes for the lifetime of the mask, and the unsubscribe half
@@ -1424,7 +1491,7 @@ describe('AnalysisPanel — chat handoff prefill (#675)', () => {
       useAnalysisFormStore.getState().save('m1', {
         layerId: 'l1', operation: 'buffer', distance: '750',
         distanceUnit: 'm', mask: null, maskLayerId: '__none__',
-        byField: '__none__', outputTitle: 'New draft', runDisowned: true,
+        byField: '__none__', joinLayerId: '__none__', joinField: '__none__', outputTitle: 'New draft', runDisowned: true,
       });
       useAnalysisJobStore.setState({
         job: { jobId: 'old-job', title: 'Old run', mapId: 'm1' },
@@ -1448,7 +1515,7 @@ describe('AnalysisPanel — chat handoff prefill (#675)', () => {
       useAnalysisFormStore.getState().save('m1', {
         layerId: 'l1', operation: 'buffer', distance: '750',
         distanceUnit: 'm', mask: null, maskLayerId: '__none__',
-        byField: '__none__', outputTitle: 'New draft', runDisowned: true,
+        byField: '__none__', joinLayerId: '__none__', joinField: '__none__', outputTitle: 'New draft', runDisowned: true,
       });
       renderPanel([datasetLayer], { mapId: 'm1' });
       act(() => {
@@ -1559,6 +1626,7 @@ describe('AnalysisPanel — stack-selected layer (#772)', () => {
     useAnalysisFormStore.getState().save('m1', {
       layerId: 'l1', operation: 'buffer', distance: '750', distanceUnit: 'm',
       mask: null, maskLayerId: '__none__', byField: '__none__',
+      joinLayerId: '__none__', joinField: '__none__',
       outputTitle: 'Draft name',
     });
     renderPanel([datasetLayer, datasetLayer2], {
@@ -1574,6 +1642,7 @@ describe('AnalysisPanel — stack-selected layer (#772)', () => {
     useAnalysisFormStore.getState().save('m1', {
       layerId: 'l1', operation: 'dissolve', distance: '500', distanceUnit: 'm',
       mask: null, maskLayerId: '__none__', byField: 'col:name',
+      joinLayerId: '__none__', joinField: '__none__',
       outputTitle: 'Dissolved',
     });
     renderPanel([datasetLayer, datasetLayer2], {
@@ -1593,7 +1662,7 @@ describe('AnalysisPanel — stack-selected layer (#772)', () => {
   it('clears a remembered mask layer the selection displaces into the source slot', () => {
     useAnalysisFormStore.getState().save('m1', {
       layerId: 'l1', operation: 'clip', distance: '500', distanceUnit: 'm',
-      mask: null, maskLayerId: 'l3', byField: '__none__', outputTitle: '',
+      mask: null, maskLayerId: 'l3', byField: '__none__', joinLayerId: '__none__', joinField: '__none__', outputTitle: '',
     });
     renderPanel([datasetLayer, datasetLayer2], {
       mapId: 'm1',
@@ -1611,6 +1680,7 @@ describe('AnalysisPanel — stack-selected layer (#772)', () => {
     useAnalysisFormStore.getState().save('m1', {
       layerId: 'l1', operation: 'buffer', distance: '500', distanceUnit: 'm',
       mask: null, maskLayerId: '__none__', byField: '__none__',
+      joinLayerId: '__none__', joinField: '__none__',
       outputTitle: 'Run name',
     });
     useAnalysisJobStore.setState({
@@ -1635,6 +1705,7 @@ describe('AnalysisPanel — stack-selected layer (#772)', () => {
     useAnalysisFormStore.getState().save('m1', {
       layerId: 'l1', operation: 'buffer', distance: '500', distanceUnit: 'm',
       mask: null, maskLayerId: '__none__', byField: '__none__',
+      joinLayerId: '__none__', joinField: '__none__',
       outputTitle: 'Run name',
     });
     useAnalysisJobStore.setState({
@@ -1662,7 +1733,7 @@ describe('AnalysisPanel — stack-selected layer (#772)', () => {
     const onClearPreview = vi.fn();
     useAnalysisFormStore.getState().save('m1', {
       layerId: 'l1', operation: 'buffer', distance: '750', distanceUnit: 'm',
-      mask: null, maskLayerId: '__none__', byField: '__none__', outputTitle: '',
+      mask: null, maskLayerId: '__none__', byField: '__none__', joinLayerId: '__none__', joinField: '__none__', outputTitle: '',
     });
     renderPanel([datasetLayer, datasetLayer2], {
       mapId: 'm1',
@@ -2006,7 +2077,8 @@ describe('AnalysisPanel — audit remediation (v1.6.0)', () => {
         type: 'Polygon',
         coordinates: [[[0, 0], [1, 0], [1, 1], [0, 0]]],
       },
-      maskLayerId: '__none__', byField: '__none__', outputTitle: '',
+      maskLayerId: '__none__', byField: '__none__',
+      joinLayerId: '__none__', joinField: '__none__', outputTitle: '',
     });
     const qc = new QueryClient({
       defaultOptions: { mutations: { retry: false } },
@@ -2155,6 +2227,37 @@ describe('AnalysisPanel spatial join (feat(#953))', () => {
       { operation: 'spatial_join', join_dataset_id: 'ds4' },
     ]);
   });
+
+  it('restores the join layer and field after a remount (#1097 review)', async () => {
+    const user = userEvent.setup();
+    // mapId is what keys the remembered form — without it the panel persists
+    // nothing and this test would pass against any implementation.
+    const layerSet = [datasetLayer, datasetLayer2, pointLayer];
+    const { unmount } = renderPanel(layerSet, { mapId: 'm1' });
+    await pickSpatialJoin(user);
+    await user.click(screen.getAllByRole('combobox')[2]);
+    await user.click(await screen.findByRole('option', { name: 'Roads' }));
+    await user.click(screen.getAllByRole('combobox')[3]);
+    await user.click(await screen.findByRole('option', { name: 'name' }));
+
+    // Closing the rail (or crossing the responsive breakpoint) unmounts the
+    // panel. Before this both inputs came back as their sentinels, so the
+    // restored spatial-join form was unrunnable with its required layer
+    // silently cleared — while the mask layer next to it survived.
+    unmount();
+    renderPanel(layerSet, { mapId: 'm1' });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Preview' }));
+    await waitFor(() => expect(previewAnalysis).toHaveBeenCalled());
+    expect(previewRequest()).toEqual([
+      'ds1',
+      {
+        operation: 'spatial_join',
+        join_dataset_id: 'ds2',
+        join_fields: ['name'],
+      },
+    ]);
+  });
 });
 
 describe('AnalysisPanel select by location (feat(#955))', () => {
@@ -2241,7 +2344,8 @@ describe('AnalysisPanel select by location (feat(#955))', () => {
     useAnalysisFormStore.getState().save('m1', {
       layerId: 'l1', operation: 'clip', distance: '500', distanceUnit: 'm',
       mask: drawnMask,
-      maskLayerId: '__none__', byField: '__none__', outputTitle: '',
+      maskLayerId: '__none__', byField: '__none__',
+      joinLayerId: '__none__', joinField: '__none__', outputTitle: '',
     });
   }
 
@@ -2361,7 +2465,8 @@ describe('AnalysisPanel intersect (feat(#956))', () => {
     useAnalysisFormStore.getState().save('m1', {
       layerId: 'l1', operation: 'clip', distance: '500', distanceUnit: 'm',
       mask: { type: 'Polygon', coordinates: [[[0, 0], [1, 0], [1, 1], [0, 0]]] },
-      maskLayerId: '__none__', byField: '__none__', outputTitle: '',
+      maskLayerId: '__none__', byField: '__none__',
+      joinLayerId: '__none__', joinField: '__none__', outputTitle: '',
     });
     renderPanel([datasetLayer, datasetLayer2], {
       mapId: 'm1',

--- a/frontend/src/components/builder/__tests__/AnalysisPanel.test.tsx
+++ b/frontend/src/components/builder/__tests__/AnalysisPanel.test.tsx
@@ -116,25 +116,37 @@ vi.mock('@/api/analysis', () => ({
     .mockResolvedValue({ job_id: 'job1', status: 'pending' }),
 }));
 
+const SHARED_COLUMNS = [
+  { name: 'name', type: 'text' },
+  // Must be filtered out — collides with the generated output column.
+  { name: 'source_count', type: 'integer' },
+  // fix(#1097 review): every remaining shape the server refuses. GDAL
+  // launders only case, '-' and '#', so ingested tables hold names like
+  // these routinely; they are carried into analysis output but cannot be
+  // NAMED in a request, because _SAFE_COLUMN_RE gates group keys and
+  // transferred fields.
+  { name: 'Área', type: 'text' },
+  { name: '2020_pop', type: 'integer' },
+  // Prefixes to the generated join_count column.
+  { name: 'count', type: 'integer' },
+  // No equality operator, so it cannot be a group key.
+  { name: 'props', type: 'json' },
+  // Transferable on its own; the SOURCE below is what makes it collide.
+  { name: 'zone', type: 'text' },
+];
+
+// fix(#1097 review): keyed on the dataset id. A join field's collision is a
+// relationship between the two layers, so a mock that hands both the same
+// columns cannot express it — ds1 is the source and already carries a
+// join_zone (routine, since it is what an earlier spatial join leaves behind),
+// while ds2 is the join layer offering a plain `zone`.
 vi.mock('@/components/dataset/hooks/use-dataset', () => ({
-  useDataset: vi.fn(() => ({
+  useDataset: vi.fn((datasetId?: string) => ({
     data: {
-      column_info: [
-        { name: 'name', type: 'text' },
-        // Must be filtered out — collides with the generated output column.
-        { name: 'source_count', type: 'integer' },
-        // fix(#1097 review): every remaining shape the server refuses. GDAL
-        // launders only case, '-' and '#', so ingested tables hold names like
-        // these routinely; they are carried into analysis output but cannot be
-        // NAMED in a request, because _SAFE_COLUMN_RE gates group keys and
-        // transferred fields.
-        { name: 'Área', type: 'text' },
-        { name: '2020_pop', type: 'integer' },
-        // Prefixes to the generated join_count column.
-        { name: 'count', type: 'integer' },
-        // No equality operator, so it cannot be a group key.
-        { name: 'props', type: 'json' },
-      ],
+      column_info:
+        datasetId === 'ds1'
+          ? [...SHARED_COLUMNS, { name: 'join_zone', type: 'text' }]
+          : SHARED_COLUMNS,
     },
   })),
 }));
@@ -2264,6 +2276,11 @@ describe('AnalysisPanel spatial join (feat(#953))', () => {
     for (const refused of ['count', 'Área', '2020_pop']) {
       expect(screen.queryByRole('option', { name: refused })).toBeNull();
     }
+    // fix(#1097 review): and the one that depends on the OTHER layer. `zone`
+    // is transferable in itself; it is refused because the source already has
+    // a join_zone, so the transfer would arrive twice. A picker that reads
+    // only the join layer cannot see this.
+    expect(screen.queryByRole('option', { name: 'zone' })).toBeNull();
   });
 
   it('cannot preview until a join layer is picked', async () => {

--- a/frontend/src/components/builder/__tests__/AnalysisPanel.test.tsx
+++ b/frontend/src/components/builder/__tests__/AnalysisPanel.test.tsx
@@ -123,6 +123,17 @@ vi.mock('@/components/dataset/hooks/use-dataset', () => ({
         { name: 'name', type: 'text' },
         // Must be filtered out — collides with the generated output column.
         { name: 'source_count', type: 'integer' },
+        // fix(#1097 review): every remaining shape the server refuses. GDAL
+        // launders only case, '-' and '#', so ingested tables hold names like
+        // these routinely; they are carried into analysis output but cannot be
+        // NAMED in a request, because _SAFE_COLUMN_RE gates group keys and
+        // transferred fields.
+        { name: 'Área', type: 'text' },
+        { name: '2020_pop', type: 'integer' },
+        // Prefixes to the generated join_count column.
+        { name: 'count', type: 'integer' },
+        // No equality operator, so it cannot be a group key.
+        { name: 'props', type: 'json' },
       ],
     },
   })),
@@ -929,6 +940,24 @@ describe('AnalysisPanel', () => {
         by_field: 'name',
       }),
     );
+  });
+
+  it('offers no dissolve group column the server would refuse (#1097 review)', async () => {
+    // The review named the JOIN picker, but the gap was in what the pickers
+    // know about the server's rules, and dissolve had the same hole: it
+    // filtered source_count and nothing else, so a json column (no equality
+    // operator, so it cannot be a group key) and the identifier-shape
+    // rejections were all offered and then refused on submit.
+    const user = userEvent.setup();
+    renderPanel([datasetLayer]);
+    await user.click(screen.getAllByRole('combobox')[1]);
+    await user.click(await screen.findByRole('option', { name: 'Dissolve' }));
+
+    await user.click(screen.getAllByRole('combobox')[2]);
+    expect(await screen.findByRole('option', { name: 'name' })).toBeInTheDocument();
+    for (const refused of ['source_count', 'props', 'Área', '2020_pop']) {
+      expect(screen.queryByRole('option', { name: refused })).toBeNull();
+    }
   });
 
   it('resets the dissolve group field when the source layer changes (fix(#680))', async () => {
@@ -2216,6 +2245,25 @@ describe('AnalysisPanel spatial join (feat(#953))', () => {
     expect(screen.getByRole('option', { name: 'Roads' })).toBeInTheDocument();
     // The source layer cannot join against itself.
     expect(screen.queryByRole('option', { name: 'Parcels' })).toBeNull();
+  });
+
+  it('offers no join field the server would refuse (#1097 review)', async () => {
+    // The picker used to list every column of the join layer. Three classes of
+    // them can never run: `count` prefixes onto the generated join_count
+    // column, and `Área`/`2020_pop` fail _SAFE_COLUMN_RE. Offering them meant
+    // the only way to learn a field was unusable was to submit and read a 422.
+    const user = userEvent.setup();
+    renderPanel([datasetLayer, datasetLayer2]);
+    await pickSpatialJoin(user);
+    await user.click(screen.getAllByRole('combobox')[2]);
+    await user.click(await screen.findByRole('option', { name: 'Roads' }));
+
+    await user.click(screen.getAllByRole('combobox')[3]);
+    // The one usable column is still offered — this filters, it does not empty.
+    expect(await screen.findByRole('option', { name: 'name' })).toBeInTheDocument();
+    for (const refused of ['count', 'Área', '2020_pop']) {
+      expect(screen.queryByRole('option', { name: refused })).toBeNull();
+    }
   });
 
   it('cannot preview until a join layer is picked', async () => {

--- a/frontend/src/components/builder/__tests__/AnalysisPanel.test.tsx
+++ b/frontend/src/components/builder/__tests__/AnalysisPanel.test.tsx
@@ -133,6 +133,8 @@ const SHARED_COLUMNS = [
   { name: 'props', type: 'json' },
   // Transferable on its own; the SOURCE below is what makes it collide.
   { name: 'zone', type: 'text' },
+  // Long enough that `join_` + this exceeds the 63-byte identifier limit.
+  { name: `${'q'.repeat(58)}_alpha`, type: 'text' },
 ];
 
 // fix(#1097 review): keyed on the dataset id. A join field's collision is a
@@ -145,7 +147,15 @@ vi.mock('@/components/dataset/hooks/use-dataset', () => ({
     data: {
       column_info:
         datasetId === 'ds1'
-          ? [...SHARED_COLUMNS, { name: 'join_zone', type: 'text' }]
+          ? [
+              ...SHARED_COLUMNS,
+              { name: 'join_zone', type: 'text' },
+              // fix(#1097 review): 63 chars — what `join_` + LONG_JOIN_FIELD
+              // becomes once PostgreSQL truncates it. The untruncated alias
+              // does not match this, so a picker comparing untruncated names
+              // offers the field and the server refuses it.
+              { name: `join_${'q'.repeat(58)}`.slice(0, 63), type: 'text' },
+            ]
           : SHARED_COLUMNS,
     },
   })),
@@ -2276,6 +2286,12 @@ describe('AnalysisPanel spatial join (feat(#953))', () => {
     for (const refused of ['count', 'Área', '2020_pop']) {
       expect(screen.queryByRole('option', { name: refused })).toBeNull();
     }
+    // fix(#1097 review): and the one that only collides AFTER truncation.
+    // `join_` + this field is 64 chars; PostgreSQL cuts it to 63, which is
+    // exactly a column ds1 already has. Comparing untruncated names misses it.
+    expect(
+      screen.queryByRole('option', { name: `${'q'.repeat(58)}_alpha` }),
+    ).toBeNull();
     // fix(#1097 review): and the one that depends on the OTHER layer. `zone`
     // is transferable in itself; it is refused because the source already has
     // a join_zone, so the transfer would arrive twice. A picker that reads

--- a/frontend/src/components/builder/__tests__/AnalysisPanel.test.tsx
+++ b/frontend/src/components/builder/__tests__/AnalysisPanel.test.tsx
@@ -502,6 +502,7 @@ describe('AnalysisPanel', () => {
     // total as match_count. Before this the panel read only
     // source_feature_count, so the server paid for an uncapped count and the
     // user still got the generic cap message.
+    const user = userEvent.setup();
     vi.mocked(previewAnalysis).mockResolvedValueOnce({
       geojson: { type: 'FeatureCollection', features: [] },
       feature_count: 500,
@@ -510,7 +511,15 @@ describe('AnalysisPanel', () => {
       source_feature_count: null,
       match_count: 2838,
     });
-    renderPanel([datasetLayer]);
+    renderPanel([datasetLayer, datasetLayer2]);
+    // fix(#1097 review): the operation is now what selects match_count, so
+    // this test has to run one. It previously proved less than it read: with
+    // the panel on its default buffer, the assertion passed on the null
+    // source count alone and would have passed for EVERY operation.
+    await user.click(screen.getAllByRole('combobox')[1]);
+    await user.click(await screen.findByRole('option', { name: 'Select by location' }));
+    await user.click(screen.getAllByRole('combobox')[2]);
+    await user.click(await screen.findByRole('option', { name: 'Roads' }));
     mockT.mockClear();
     mockToast.info.mockClear();
 
@@ -532,9 +541,10 @@ describe('AnalysisPanel', () => {
 
   it('keeps the SOURCE total for spatial join, which also sends match_count (#1097 review)', async () => {
     // The guard on the fix above. spatial_join sends BOTH: it keeps every
-    // source row, and its match_count is how many of them found a match.
+    // source row, and its match_count counts matched PAIRS.
     // Preferring match_count wherever present would relabel 10,651 source
     // features as 30,712 "matching" ones.
+    const user = userEvent.setup();
     vi.mocked(previewAnalysis).mockResolvedValueOnce({
       geojson: { type: 'FeatureCollection', features: [] },
       feature_count: 500,
@@ -543,7 +553,11 @@ describe('AnalysisPanel', () => {
       source_feature_count: 10651,
       match_count: 30712,
     });
-    renderPanel([datasetLayer]);
+    renderPanel([datasetLayer, datasetLayer2]);
+    await user.click(screen.getAllByRole('combobox')[1]);
+    await user.click(await screen.findByRole('option', { name: 'Spatial join' }));
+    await user.click(screen.getAllByRole('combobox')[2]);
+    await user.click(await screen.findByRole('option', { name: 'Roads' }));
     mockT.mockClear();
     mockToast.info.mockClear();
 
@@ -557,6 +571,61 @@ describe('AnalysisPanel', () => {
     expect(mockT).not.toHaveBeenCalledWith(
       'analysisTools.truncatedNoticeMatched',
       expect.anything(),
+    );
+  });
+
+  it('reports NO total for a spatial join whose source count is missing (#1097 review)', async () => {
+    // The case that made keying off `source_feature_count == null` wrong.
+    // Null has a second cause that has nothing to do with the operation: the
+    // dataset's cached feature_count snapshot is absent (legacy imports,
+    // register_existing_table). A spatial join on such a dataset sends null
+    // AND a match_count, and that match_count counts PAIRS — 30,712 of them
+    // behind a 1:1 result whose real total is the source row count. Inferring
+    // from null announced and stored 30,712 as the output total, a number
+    // larger than the result can possibly be.
+    //
+    // No total is the honest answer here: the server could not supply one.
+    const user = userEvent.setup();
+    vi.mocked(previewAnalysis).mockResolvedValueOnce({
+      geojson: { type: 'FeatureCollection', features: [] },
+      feature_count: 500,
+      truncated: true,
+      bbox: [0, 0, 1, 1],
+      source_feature_count: null,
+      match_count: 30712,
+    });
+    const onPreviewResult = vi.fn();
+    renderPanel([datasetLayer, datasetLayer2], { onPreviewResult });
+    await user.click(screen.getAllByRole('combobox')[1]);
+    await user.click(await screen.findByRole('option', { name: 'Spatial join' }));
+    await user.click(screen.getAllByRole('combobox')[2]);
+    await user.click(await screen.findByRole('option', { name: 'Roads' }));
+    mockT.mockClear();
+    mockToast.info.mockClear();
+    onPreviewResult.mockClear();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Preview' }));
+    await waitFor(() => expect(mockToast.info).toHaveBeenCalled());
+
+    // The generic cap notice, which names no total at all.
+    expect(mockT).toHaveBeenCalledWith(
+      'analysisTools.truncatedNotice',
+      expect.objectContaining({ count: 500 }),
+    );
+    expect(mockT).not.toHaveBeenCalledWith(
+      'analysisTools.truncatedNoticeMatched',
+      expect.anything(),
+    );
+    expect(mockT).not.toHaveBeenCalledWith(
+      'analysisTools.truncatedNoticeTotal',
+      expect.anything(),
+    );
+    // And the pair count is not stored on the overlay either, where it would
+    // outlive the toast as a badge.
+    expect(onPreviewResult).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      expect.objectContaining({ truncated: true, totalCount: undefined }),
     );
   });
 

--- a/frontend/src/i18n/locales/de/builder.json
+++ b/frontend/src/i18n/locales/de/builder.json
@@ -975,6 +975,7 @@
     "opCentroid": "Zentroide",
     "opClip": "Zuschneiden",
     "opSpatialJoin": "Räumliche Verknüpfung",
+    "opMeasure": "Messen",
     "distanceLabel": "Entfernung",
     "distanceOutOfRange": "Geben Sie eine Entfernung größer als 0 und höchstens {{max}} {{unit}} ein.",
     "drawMask": "Zuschneidebereich zeichnen",
@@ -1030,7 +1031,8 @@
     "joinLayerPlaceholder": "Ebene auswählen",
     "spatialJoinHint": "Jedes Feature erhält einen join_count der Features, die es schneidet. Überlappungen zählen jede Übereinstimmung, ergeben aber trotzdem nur eine Zeile.",
     "joinFieldLabel": "Ein Feld übernehmen (optional)",
-    "joinFieldNone": "Nur zählen"
+    "joinFieldNone": "Nur zählen",
+    "measureHint": "Fügt jedem Feature area_sqm und length_m hinzu, auf dem Globus gemessen. Polygone erhalten eine Fläche und Linien eine Länge; der andere Wert ist 0."
   },
   "attributeForm": {
     "titleEdit": "Feature-Attribute bearbeiten",

--- a/frontend/src/i18n/locales/de/builder.json
+++ b/frontend/src/i18n/locales/de/builder.json
@@ -974,6 +974,7 @@
     "opBuffer": "Puffer",
     "opCentroid": "Zentroide",
     "opClip": "Zuschneiden",
+    "opSpatialJoin": "Räumliche Verknüpfung",
     "distanceLabel": "Entfernung",
     "distanceOutOfRange": "Geben Sie eine Entfernung größer als 0 und höchstens {{max}} {{unit}} ein.",
     "drawMask": "Zuschneidebereich zeichnen",
@@ -1024,7 +1025,12 @@
     "saveHintNeedsName": "Geben Sie einen Namen für den neuen Datensatz ein, um „Datensatz erstellen“ zu aktivieren.",
     "saveHintNeedsParams": "Vervollständigen Sie die Einstellungen der Operation oben, um „Datensatz erstellen“ zu aktivieren.",
     "addedToMap": "Zur Karte hinzugefügt",
-    "openMap": "Karte öffnen"
+    "openMap": "Karte öffnen",
+    "joinLayerLabel": "Mit Ebene verknüpfen",
+    "joinLayerPlaceholder": "Ebene auswählen",
+    "spatialJoinHint": "Jedes Feature erhält einen join_count der Features, die es schneidet. Überlappungen zählen jede Übereinstimmung, ergeben aber trotzdem nur eine Zeile.",
+    "joinFieldLabel": "Ein Feld übernehmen (optional)",
+    "joinFieldNone": "Nur zählen"
   },
   "attributeForm": {
     "titleEdit": "Feature-Attribute bearbeiten",

--- a/frontend/src/i18n/locales/de/builder.json
+++ b/frontend/src/i18n/locales/de/builder.json
@@ -976,6 +976,7 @@
     "opClip": "Zuschneiden",
     "opSpatialJoin": "Räumliche Verknüpfung",
     "opMeasure": "Messen",
+    "opSelectByLocation": "Nach Lage auswählen",
     "distanceLabel": "Entfernung",
     "distanceOutOfRange": "Geben Sie eine Entfernung größer als 0 und höchstens {{max}} {{unit}} ein.",
     "drawMask": "Zuschneidebereich zeichnen",
@@ -1032,7 +1033,12 @@
     "spatialJoinHint": "Jedes Feature erhält einen join_count der Features, die es schneidet. Überlappungen zählen jede Übereinstimmung, ergeben aber trotzdem nur eine Zeile.",
     "joinFieldLabel": "Ein Feld übernehmen (optional)",
     "joinFieldNone": "Nur zählen",
-    "measureHint": "Fügt jedem Feature area_sqm und length_m hinzu, auf dem Globus gemessen. Polygone erhalten eine Fläche und Linien eine Länge; der andere Wert ist 0."
+    "measureHint": "Fügt jedem Feature area_sqm und length_m hinzu, auf dem Globus gemessen. Polygone erhalten eine Fläche und Linien eine Länge; der andere Wert ist 0.",
+    "selectByLocationHint": "Behält die Objekte, die den Bereich berühren, vollständig und unverändert. Mit Datensatz erstellen die Liste speichern und anschließend exportieren.",
+    "drawSelectionArea": "Auswahlbereich zeichnen",
+    "selectionAreaSet": "Auswahlbereich festgelegt",
+    "selectLayerLabel": "Oder anhand einer Ebene auswählen",
+    "drawSelectionPointerHint": "Zum Zeichnen wird ein Zeigegerät benötigt. Ohne Zeigegerät unten eine Polygon-Ebene wählen."
   },
   "attributeForm": {
     "titleEdit": "Feature-Attribute bearbeiten",

--- a/frontend/src/i18n/locales/de/builder.json
+++ b/frontend/src/i18n/locales/de/builder.json
@@ -977,6 +977,7 @@
     "opSpatialJoin": "Räumliche Verknüpfung",
     "opMeasure": "Messen",
     "opSelectByLocation": "Nach Lage auswählen",
+    "opIntersect": "Verschneiden",
     "distanceLabel": "Entfernung",
     "distanceOutOfRange": "Geben Sie eine Entfernung größer als 0 und höchstens {{max}} {{unit}} ein.",
     "drawMask": "Zuschneidebereich zeichnen",
@@ -1038,7 +1039,10 @@
     "drawSelectionArea": "Auswahlbereich zeichnen",
     "selectionAreaSet": "Auswahlbereich festgelegt",
     "selectLayerLabel": "Oder anhand einer Ebene auswählen",
-    "drawSelectionPointerHint": "Zum Zeichnen wird ein Zeigegerät benötigt. Ohne Zeigegerät unten eine Polygon-Ebene wählen."
+    "drawSelectionPointerHint": "Zum Zeichnen wird ein Zeigegerät benötigt. Ohne Zeigegerät unten eine Polygon-Ebene wählen.",
+    "intersectHint": "Erzeugt neue Objekte dort, wo sich die beiden Ebenen überlappen, eines je Überlappungspaar, mit den Spalten beider Ebenen. Für die Überlappungsfläche anschließend Messen verwenden.",
+    "overlayLayerLabel": "Mit Ebene verschneiden",
+    "overlayLayerNone": "Ebene auswählen"
   },
   "attributeForm": {
     "titleEdit": "Feature-Attribute bearbeiten",

--- a/frontend/src/i18n/locales/de/builder.json
+++ b/frontend/src/i18n/locales/de/builder.json
@@ -1010,6 +1010,8 @@
     "byFieldNone": "Keine Gruppierung — alles zusammenführen",
     "truncatedNoticeTotal_one": "Das erste von {{total, number}} Quell-Features wird angezeigt",
     "truncatedNoticeTotal_other": "Die ersten {{count, number}} von {{total, number}} Quell-Features werden angezeigt",
+    "truncatedNoticeMatched_one": "Das erste von {{total, number}} übereinstimmenden Features wird angezeigt",
+    "truncatedNoticeMatched_other": "Die ersten {{count, number}} von {{total, number}} übereinstimmenden Features werden angezeigt",
     "clipLayerLabel": "Oder an einer Ebene zuschneiden",
     "clipLayerNone": "Keine — auf der Karte zeichnen",
     "clipLayerEmpty": "Keine Polygon-Ebenen auf dieser Karte",

--- a/frontend/src/i18n/locales/en/builder.json
+++ b/frontend/src/i18n/locales/en/builder.json
@@ -975,6 +975,7 @@
     "opCentroid": "Centroids",
     "opClip": "Clip",
     "opSpatialJoin": "Spatial join",
+    "opMeasure": "Measure",
     "distanceLabel": "Distance",
     "distanceOutOfRange": "Enter a distance greater than 0 and no more than {{max}} {{unit}}.",
     "drawMask": "Draw clip area",
@@ -1030,7 +1031,8 @@
     "joinLayerPlaceholder": "Choose a layer",
     "spatialJoinHint": "Each feature gains a join_count of the features it intersects. Overlaps count every match but still produce one row.",
     "joinFieldLabel": "Copy a field across (optional)",
-    "joinFieldNone": "Count only"
+    "joinFieldNone": "Count only",
+    "measureHint": "Adds area_sqm and length_m to every feature, measured on the globe. Polygons get an area and lines a length; the other reads 0."
   },
   "attributeForm": {
     "titleEdit": "Edit Feature Attributes",

--- a/frontend/src/i18n/locales/en/builder.json
+++ b/frontend/src/i18n/locales/en/builder.json
@@ -977,6 +977,7 @@
     "opSpatialJoin": "Spatial join",
     "opMeasure": "Measure",
     "opSelectByLocation": "Select by location",
+    "opIntersect": "Intersect",
     "distanceLabel": "Distance",
     "distanceOutOfRange": "Enter a distance greater than 0 and no more than {{max}} {{unit}}.",
     "drawMask": "Draw clip area",
@@ -1038,7 +1039,10 @@
     "drawSelectionArea": "Draw selection area",
     "selectionAreaSet": "Selection area set",
     "selectLayerLabel": "Or select against a layer",
-    "drawSelectionPointerHint": "Drawing needs a pointer. To select without one, pick a polygon layer below."
+    "drawSelectionPointerHint": "Drawing needs a pointer. To select without one, pick a polygon layer below.",
+    "intersectHint": "Cuts new features where the two layers overlap, one per overlapping pair, carrying columns from both. Use Measure afterwards for overlap area.",
+    "overlayLayerLabel": "Overlay with layer",
+    "overlayLayerNone": "Choose a layer"
   },
   "attributeForm": {
     "titleEdit": "Edit Feature Attributes",

--- a/frontend/src/i18n/locales/en/builder.json
+++ b/frontend/src/i18n/locales/en/builder.json
@@ -976,6 +976,7 @@
     "opClip": "Clip",
     "opSpatialJoin": "Spatial join",
     "opMeasure": "Measure",
+    "opSelectByLocation": "Select by location",
     "distanceLabel": "Distance",
     "distanceOutOfRange": "Enter a distance greater than 0 and no more than {{max}} {{unit}}.",
     "drawMask": "Draw clip area",
@@ -1032,7 +1033,12 @@
     "spatialJoinHint": "Each feature gains a join_count of the features it intersects. Overlaps count every match but still produce one row.",
     "joinFieldLabel": "Copy a field across (optional)",
     "joinFieldNone": "Count only",
-    "measureHint": "Adds area_sqm and length_m to every feature, measured on the globe. Polygons get an area and lines a length; the other reads 0."
+    "measureHint": "Adds area_sqm and length_m to every feature, measured on the globe. Polygons get an area and lines a length; the other reads 0.",
+    "selectByLocationHint": "Keeps the features that touch the area, whole and unchanged. Use Create dataset to save the list, then export it.",
+    "drawSelectionArea": "Draw selection area",
+    "selectionAreaSet": "Selection area set",
+    "selectLayerLabel": "Or select against a layer",
+    "drawSelectionPointerHint": "Drawing needs a pointer. To select without one, pick a polygon layer below."
   },
   "attributeForm": {
     "titleEdit": "Edit Feature Attributes",

--- a/frontend/src/i18n/locales/en/builder.json
+++ b/frontend/src/i18n/locales/en/builder.json
@@ -1010,6 +1010,8 @@
     "byFieldNone": "No grouping — merge everything",
     "truncatedNoticeTotal_one": "Showing the first of {{total, number}} source features",
     "truncatedNoticeTotal_other": "Showing the first {{count, number}} of {{total, number}} source features",
+    "truncatedNoticeMatched_one": "Showing the first of {{total, number}} matching features",
+    "truncatedNoticeMatched_other": "Showing the first {{count, number}} of {{total, number}} matching features",
     "clipLayerLabel": "Or clip to a layer",
     "clipLayerNone": "None — draw on the map",
     "clipLayerEmpty": "No polygon layers on this map",

--- a/frontend/src/i18n/locales/en/builder.json
+++ b/frontend/src/i18n/locales/en/builder.json
@@ -974,6 +974,7 @@
     "opBuffer": "Buffer",
     "opCentroid": "Centroids",
     "opClip": "Clip",
+    "opSpatialJoin": "Spatial join",
     "distanceLabel": "Distance",
     "distanceOutOfRange": "Enter a distance greater than 0 and no more than {{max}} {{unit}}.",
     "drawMask": "Draw clip area",
@@ -1024,7 +1025,12 @@
     "saveHintNeedsName": "Enter a name for the new dataset to enable Create dataset.",
     "saveHintNeedsParams": "Complete the operation settings above to enable Create dataset.",
     "addedToMap": "Added to map",
-    "openMap": "Open map"
+    "openMap": "Open map",
+    "joinLayerLabel": "Join with layer",
+    "joinLayerPlaceholder": "Choose a layer",
+    "spatialJoinHint": "Each feature gains a join_count of the features it intersects. Overlaps count every match but still produce one row.",
+    "joinFieldLabel": "Copy a field across (optional)",
+    "joinFieldNone": "Count only"
   },
   "attributeForm": {
     "titleEdit": "Edit Feature Attributes",

--- a/frontend/src/i18n/locales/es/builder.json
+++ b/frontend/src/i18n/locales/es/builder.json
@@ -974,6 +974,7 @@
     "opBuffer": "Zona de influencia",
     "opCentroid": "Centroides",
     "opClip": "Recortar",
+    "opSpatialJoin": "Unión espacial",
     "distanceLabel": "Distancia",
     "distanceOutOfRange": "Introduce una distancia mayor que 0 y no superior a {{max}} {{unit}}.",
     "drawMask": "Dibujar área de recorte",
@@ -1024,7 +1025,12 @@
     "saveHintNeedsName": "Introduce un nombre para el nuevo conjunto de datos para activar Crear conjunto de datos.",
     "saveHintNeedsParams": "Completa los ajustes de la operación de arriba para activar Crear conjunto de datos.",
     "addedToMap": "Añadido al mapa",
-    "openMap": "Abrir mapa"
+    "openMap": "Abrir mapa",
+    "joinLayerLabel": "Unir con la capa",
+    "joinLayerPlaceholder": "Elige una capa",
+    "spatialJoinHint": "Cada entidad recibe un join_count de las entidades que interseca. Los solapamientos cuentan todas las coincidencias, pero aun así producen una sola fila.",
+    "joinFieldLabel": "Copiar un campo (opcional)",
+    "joinFieldNone": "Solo contar"
   },
   "attributeForm": {
     "titleEdit": "Editar atributos de la entidad",

--- a/frontend/src/i18n/locales/es/builder.json
+++ b/frontend/src/i18n/locales/es/builder.json
@@ -977,6 +977,7 @@
     "opSpatialJoin": "Unión espacial",
     "opMeasure": "Medir",
     "opSelectByLocation": "Seleccionar por ubicación",
+    "opIntersect": "Intersecar",
     "distanceLabel": "Distancia",
     "distanceOutOfRange": "Introduce una distancia mayor que 0 y no superior a {{max}} {{unit}}.",
     "drawMask": "Dibujar área de recorte",
@@ -1038,7 +1039,10 @@
     "drawSelectionArea": "Dibujar área de selección",
     "selectionAreaSet": "Área de selección definida",
     "selectLayerLabel": "O seleccionar con una capa",
-    "drawSelectionPointerHint": "Dibujar requiere un puntero. Para seleccionar sin él, elige una capa de polígonos abajo."
+    "drawSelectionPointerHint": "Dibujar requiere un puntero. Para seleccionar sin él, elige una capa de polígonos abajo.",
+    "intersectHint": "Crea entidades nuevas donde las dos capas se solapan, una por cada par solapado, con las columnas de ambas. Usa Medir después para obtener el área de solape.",
+    "overlayLayerLabel": "Superponer con la capa",
+    "overlayLayerNone": "Elige una capa"
   },
   "attributeForm": {
     "titleEdit": "Editar atributos de la entidad",

--- a/frontend/src/i18n/locales/es/builder.json
+++ b/frontend/src/i18n/locales/es/builder.json
@@ -975,6 +975,7 @@
     "opCentroid": "Centroides",
     "opClip": "Recortar",
     "opSpatialJoin": "Unión espacial",
+    "opMeasure": "Medir",
     "distanceLabel": "Distancia",
     "distanceOutOfRange": "Introduce una distancia mayor que 0 y no superior a {{max}} {{unit}}.",
     "drawMask": "Dibujar área de recorte",
@@ -1030,7 +1031,8 @@
     "joinLayerPlaceholder": "Elige una capa",
     "spatialJoinHint": "Cada entidad recibe un join_count de las entidades que interseca. Los solapamientos cuentan todas las coincidencias, pero aun así producen una sola fila.",
     "joinFieldLabel": "Copiar un campo (opcional)",
-    "joinFieldNone": "Solo contar"
+    "joinFieldNone": "Solo contar",
+    "measureHint": "Añade area_sqm y length_m a cada entidad, medidas sobre el globo. Los polígonos obtienen un área y las líneas una longitud; la otra queda en 0."
   },
   "attributeForm": {
     "titleEdit": "Editar atributos de la entidad",

--- a/frontend/src/i18n/locales/es/builder.json
+++ b/frontend/src/i18n/locales/es/builder.json
@@ -1010,6 +1010,8 @@
     "byFieldNone": "Sin agrupación — combinar todo",
     "truncatedNoticeTotal_one": "Mostrando la primera de {{total, number}} entidades de origen",
     "truncatedNoticeTotal_other": "Mostrando las primeras {{count, number}} de {{total, number}} entidades de origen",
+    "truncatedNoticeMatched_one": "Mostrando la primera de {{total, number}} entidades coincidentes",
+    "truncatedNoticeMatched_other": "Mostrando las primeras {{count, number}} de {{total, number}} entidades coincidentes",
     "clipLayerLabel": "O recortar con una capa",
     "clipLayerNone": "Ninguna — dibujar en el mapa",
     "clipLayerEmpty": "No hay capas de polígonos en este mapa",

--- a/frontend/src/i18n/locales/es/builder.json
+++ b/frontend/src/i18n/locales/es/builder.json
@@ -976,6 +976,7 @@
     "opClip": "Recortar",
     "opSpatialJoin": "Unión espacial",
     "opMeasure": "Medir",
+    "opSelectByLocation": "Seleccionar por ubicación",
     "distanceLabel": "Distancia",
     "distanceOutOfRange": "Introduce una distancia mayor que 0 y no superior a {{max}} {{unit}}.",
     "drawMask": "Dibujar área de recorte",
@@ -1032,7 +1033,12 @@
     "spatialJoinHint": "Cada entidad recibe un join_count de las entidades que interseca. Los solapamientos cuentan todas las coincidencias, pero aun así producen una sola fila.",
     "joinFieldLabel": "Copiar un campo (opcional)",
     "joinFieldNone": "Solo contar",
-    "measureHint": "Añade area_sqm y length_m a cada entidad, medidas sobre el globo. Los polígonos obtienen un área y las líneas una longitud; la otra queda en 0."
+    "measureHint": "Añade area_sqm y length_m a cada entidad, medidas sobre el globo. Los polígonos obtienen un área y las líneas una longitud; la otra queda en 0.",
+    "selectByLocationHint": "Conserva las entidades que tocan el área, completas y sin cambios. Usa Crear conjunto de datos para guardar la lista y luego expórtala.",
+    "drawSelectionArea": "Dibujar área de selección",
+    "selectionAreaSet": "Área de selección definida",
+    "selectLayerLabel": "O seleccionar con una capa",
+    "drawSelectionPointerHint": "Dibujar requiere un puntero. Para seleccionar sin él, elige una capa de polígonos abajo."
   },
   "attributeForm": {
     "titleEdit": "Editar atributos de la entidad",

--- a/frontend/src/i18n/locales/fr/builder.json
+++ b/frontend/src/i18n/locales/fr/builder.json
@@ -1010,6 +1010,8 @@
     "byFieldNone": "Sans regroupement — tout fusionner",
     "truncatedNoticeTotal_one": "Affichage de la première des {{total, number}} entités sources",
     "truncatedNoticeTotal_other": "Affichage des {{count, number}} premières entités sur {{total, number}} entités sources",
+    "truncatedNoticeMatched_one": "Affichage de la première entité sur {{total, number}} entités correspondantes",
+    "truncatedNoticeMatched_other": "Affichage des {{count, number}} premières entités sur {{total, number}} entités correspondantes",
     "clipLayerLabel": "Ou découper selon une couche",
     "clipLayerNone": "Aucune — dessiner sur la carte",
     "clipLayerEmpty": "Aucune couche de polygones sur cette carte",

--- a/frontend/src/i18n/locales/fr/builder.json
+++ b/frontend/src/i18n/locales/fr/builder.json
@@ -977,6 +977,7 @@
     "opSpatialJoin": "Jointure spatiale",
     "opMeasure": "Mesurer",
     "opSelectByLocation": "Sélectionner par emplacement",
+    "opIntersect": "Intersecter",
     "distanceLabel": "Distance",
     "distanceOutOfRange": "Saisissez une distance supérieure à 0 et d’au plus {{max}} {{unit}}.",
     "drawMask": "Dessiner la zone de découpe",
@@ -1038,7 +1039,10 @@
     "drawSelectionArea": "Dessiner la zone de sélection",
     "selectionAreaSet": "Zone de sélection définie",
     "selectLayerLabel": "Ou sélectionner avec une couche",
-    "drawSelectionPointerHint": "Le dessin nécessite un pointeur. Pour sélectionner sans pointeur, choisissez une couche de polygones ci-dessous."
+    "drawSelectionPointerHint": "Le dessin nécessite un pointeur. Pour sélectionner sans pointeur, choisissez une couche de polygones ci-dessous.",
+    "intersectHint": "Crée de nouvelles entités là où les deux couches se chevauchent, une par paire, portant les colonnes des deux. Utilisez Mesurer ensuite pour la surface de chevauchement.",
+    "overlayLayerLabel": "Superposer avec la couche",
+    "overlayLayerNone": "Choisissez une couche"
   },
   "attributeForm": {
     "titleEdit": "Modifier les attributs de l'entité",

--- a/frontend/src/i18n/locales/fr/builder.json
+++ b/frontend/src/i18n/locales/fr/builder.json
@@ -976,6 +976,7 @@
     "opClip": "Découper",
     "opSpatialJoin": "Jointure spatiale",
     "opMeasure": "Mesurer",
+    "opSelectByLocation": "Sélectionner par emplacement",
     "distanceLabel": "Distance",
     "distanceOutOfRange": "Saisissez une distance supérieure à 0 et d’au plus {{max}} {{unit}}.",
     "drawMask": "Dessiner la zone de découpe",
@@ -1032,7 +1033,12 @@
     "spatialJoinHint": "Chaque entité reçoit un join_count des entités qu'elle intersecte. Les chevauchements comptent toutes les correspondances mais ne produisent qu'une seule ligne.",
     "joinFieldLabel": "Copier un champ (facultatif)",
     "joinFieldNone": "Compter uniquement",
-    "measureHint": "Ajoute area_sqm et length_m à chaque entité, mesurées sur le globe. Les polygones reçoivent une aire et les lignes une longueur ; l'autre vaut 0."
+    "measureHint": "Ajoute area_sqm et length_m à chaque entité, mesurées sur le globe. Les polygones reçoivent une aire et les lignes une longueur ; l'autre vaut 0.",
+    "selectByLocationHint": "Conserve les entités qui touchent la zone, entières et inchangées. Utilisez Créer un jeu de données pour enregistrer la liste, puis exportez-la.",
+    "drawSelectionArea": "Dessiner la zone de sélection",
+    "selectionAreaSet": "Zone de sélection définie",
+    "selectLayerLabel": "Ou sélectionner avec une couche",
+    "drawSelectionPointerHint": "Le dessin nécessite un pointeur. Pour sélectionner sans pointeur, choisissez une couche de polygones ci-dessous."
   },
   "attributeForm": {
     "titleEdit": "Modifier les attributs de l'entité",

--- a/frontend/src/i18n/locales/fr/builder.json
+++ b/frontend/src/i18n/locales/fr/builder.json
@@ -975,6 +975,7 @@
     "opCentroid": "Centroïdes",
     "opClip": "Découper",
     "opSpatialJoin": "Jointure spatiale",
+    "opMeasure": "Mesurer",
     "distanceLabel": "Distance",
     "distanceOutOfRange": "Saisissez une distance supérieure à 0 et d’au plus {{max}} {{unit}}.",
     "drawMask": "Dessiner la zone de découpe",
@@ -1030,7 +1031,8 @@
     "joinLayerPlaceholder": "Choisissez une couche",
     "spatialJoinHint": "Chaque entité reçoit un join_count des entités qu'elle intersecte. Les chevauchements comptent toutes les correspondances mais ne produisent qu'une seule ligne.",
     "joinFieldLabel": "Copier un champ (facultatif)",
-    "joinFieldNone": "Compter uniquement"
+    "joinFieldNone": "Compter uniquement",
+    "measureHint": "Ajoute area_sqm et length_m à chaque entité, mesurées sur le globe. Les polygones reçoivent une aire et les lignes une longueur ; l'autre vaut 0."
   },
   "attributeForm": {
     "titleEdit": "Modifier les attributs de l'entité",

--- a/frontend/src/i18n/locales/fr/builder.json
+++ b/frontend/src/i18n/locales/fr/builder.json
@@ -974,6 +974,7 @@
     "opBuffer": "Zone tampon",
     "opCentroid": "Centroïdes",
     "opClip": "Découper",
+    "opSpatialJoin": "Jointure spatiale",
     "distanceLabel": "Distance",
     "distanceOutOfRange": "Saisissez une distance supérieure à 0 et d’au plus {{max}} {{unit}}.",
     "drawMask": "Dessiner la zone de découpe",
@@ -1024,7 +1025,12 @@
     "saveHintNeedsName": "Saisissez un nom pour le nouveau jeu de données pour activer Créer un jeu de données.",
     "saveHintNeedsParams": "Renseignez les paramètres de l’opération ci-dessus pour activer Créer un jeu de données.",
     "addedToMap": "Ajouté à la carte",
-    "openMap": "Ouvrir la carte"
+    "openMap": "Ouvrir la carte",
+    "joinLayerLabel": "Joindre à la couche",
+    "joinLayerPlaceholder": "Choisissez une couche",
+    "spatialJoinHint": "Chaque entité reçoit un join_count des entités qu'elle intersecte. Les chevauchements comptent toutes les correspondances mais ne produisent qu'une seule ligne.",
+    "joinFieldLabel": "Copier un champ (facultatif)",
+    "joinFieldNone": "Compter uniquement"
   },
   "attributeForm": {
     "titleEdit": "Modifier les attributs de l'entité",

--- a/frontend/src/stores/__tests__/analysis-form-store.test.ts
+++ b/frontend/src/stores/__tests__/analysis-form-store.test.ts
@@ -10,6 +10,8 @@ const form = {
   mask: null,
   maskLayerId: '__none__',
   byField: '__none__',
+  joinLayerId: '__none__',
+  joinField: '__none__',
   outputTitle: 'Walkshed',
 };
 

--- a/frontend/src/stores/analysis-form-store.ts
+++ b/frontend/src/stores/analysis-form-store.ts
@@ -18,6 +18,13 @@ export interface SavedAnalysisForm {
   mask: GeoJSON.Polygon | null;
   maskLayerId: string;
   byField: string;
+  /** fix(#1097 review): the spatial-join inputs persist for the same reason
+   *  maskLayerId does. Without them, closing the rail (or crossing the
+   *  responsive breakpoint, which unmounts the panel) reset both to their
+   *  sentinels, and a restored spatial-join form came back unrunnable with
+   *  its required layer silently cleared. */
+  joinLayerId: string;
+  joinField: string;
   outputTitle: string;
   /** fix(#793 review): true when the form was edited AFTER the last run
    *  started — the run (and its completion) no longer owns these fields, so

--- a/frontend/src/types/api.generated.ts
+++ b/frontend/src/types/api.generated.ts
@@ -5425,7 +5425,7 @@ export interface components {
             } | null;
             /**
              * Mask Dataset Id
-             * @description Polygon dataset supplying the mask geometry: the area clipped to, or selected against (clip and select_by_location; alternative to mask)
+             * @description Polygon dataset supplying the second layer: the area clipped to, selected against, or overlaid with. For clip and select_by_location it is the alternative to `mask`; for intersect it is REQUIRED and `mask` is rejected, because an overlay carries the second layer's attributes onto its output and a drawn polygon has none.
              */
             mask_dataset_id?: string | null;
             /**
@@ -5481,7 +5481,7 @@ export interface components {
             } | null;
             /**
              * Mask Dataset Id
-             * @description Polygon dataset supplying the mask geometry: the area clipped to, or selected against (clip and select_by_location; alternative to mask)
+             * @description Polygon dataset supplying the second layer: the area clipped to, selected against, or overlaid with. For clip and select_by_location it is the alternative to `mask`; for intersect it is REQUIRED and `mask` is rejected, because an overlay carries the second layer's attributes onto its output and a drawn polygon has none.
              */
             mask_dataset_id?: string | null;
             /**

--- a/frontend/src/types/api.generated.ts
+++ b/frontend/src/types/api.generated.ts
@@ -5505,7 +5505,7 @@ export interface components {
             };
             /**
              * Match Count
-             * @description Exact total across the WHOLE source, not just the previewed features: intersecting source/join feature PAIRS for spatial_join, selected source features for select_by_location. Null for other operations, and when the count could not be computed within the query budget
+             * @description Exact total across the WHOLE source, not just the previewed features. What it counts is per-operation, so read it against the operation you sent rather than as one number: select_by_location gives the selected source features and intersect gives the output pieces, and for both of those it IS the output total; spatial_join gives intersecting source/join PAIRS, which is NOT the output total, because the join keeps every source row (use source_feature_count for that operation). Null for operations that report no such total, and when the count could not be computed within the query budget
              */
             match_count?: number | null;
             /**

--- a/frontend/src/types/api.generated.ts
+++ b/frontend/src/types/api.generated.ts
@@ -5407,22 +5407,32 @@ export interface components {
              */
             distance_meters?: number | null;
             /**
+             * Join Dataset Id
+             * @description Dataset to join against; each source feature gains a count of the features from it that intersect (spatial_join only)
+             */
+            join_dataset_id?: string | null;
+            /**
+             * Join Fields
+             * @description Columns to copy from the intersecting join feature, prefixed 'join_' in the output. Ties break on the lowest join-layer gid (spatial_join only)
+             */
+            join_fields?: string[] | null;
+            /**
              * Mask
-             * @description GeoJSON Polygon or MultiPolygon geometry in EPSG:4326 (clip only)
+             * @description GeoJSON Polygon or MultiPolygon geometry in EPSG:4326 (clip and select_by_location)
              */
             mask?: {
                 [key: string]: unknown;
             } | null;
             /**
              * Mask Dataset Id
-             * @description Polygon dataset whose unioned features form the clip mask (clip only; alternative to mask)
+             * @description Polygon dataset supplying the mask geometry: the area clipped to, or selected against (clip and select_by_location; alternative to mask)
              */
             mask_dataset_id?: string | null;
             /**
              * Operation
              * @enum {string}
              */
-            operation: "buffer" | "centroid" | "clip" | "dissolve";
+            operation: "buffer" | "centroid" | "clip" | "dissolve" | "spatial_join" | "measure" | "select_by_location" | "intersect";
             /** Title */
             title: string;
         };
@@ -5453,22 +5463,32 @@ export interface components {
              */
             distance_meters?: number | null;
             /**
+             * Join Dataset Id
+             * @description Dataset to join against; each source feature gains a count of the features from it that intersect (spatial_join only)
+             */
+            join_dataset_id?: string | null;
+            /**
+             * Join Fields
+             * @description Columns to copy from the intersecting join feature, prefixed 'join_' in the output. Ties break on the lowest join-layer gid (spatial_join only)
+             */
+            join_fields?: string[] | null;
+            /**
              * Mask
-             * @description GeoJSON Polygon or MultiPolygon geometry in EPSG:4326 (clip only)
+             * @description GeoJSON Polygon or MultiPolygon geometry in EPSG:4326 (clip and select_by_location)
              */
             mask?: {
                 [key: string]: unknown;
             } | null;
             /**
              * Mask Dataset Id
-             * @description Polygon dataset whose unioned features form the clip mask (clip only; alternative to mask)
+             * @description Polygon dataset supplying the mask geometry: the area clipped to, or selected against (clip and select_by_location; alternative to mask)
              */
             mask_dataset_id?: string | null;
             /**
              * Operation
              * @enum {string}
              */
-            operation: "buffer" | "centroid" | "clip";
+            operation: "buffer" | "centroid" | "clip" | "spatial_join" | "measure" | "select_by_location" | "intersect";
         };
         /**
          * AnalysisPreviewResponse
@@ -5483,6 +5503,11 @@ export interface components {
             geojson: {
                 [key: string]: unknown;
             };
+            /**
+             * Match Count
+             * @description Exact total across the WHOLE source, not just the previewed features: intersecting source/join feature PAIRS for spatial_join, selected source features for select_by_location. Null for other operations, and when the count could not be computed within the query budget
+             */
+            match_count?: number | null;
             /**
              * Source Feature Count
              * @description Total feature count of the source dataset (1:1 operations only; null when the operation filters rows, e.g. clip)

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -1921,16 +1921,19 @@ export type AnalysisOperation =
   | 'dissolve'
   | 'spatial_join'
   | 'measure'
-  | 'select_by_location';
+  | 'select_by_location'
+  | 'intersect';
 
 export interface AnalysisPreviewRequest {
   operation: Exclude<AnalysisOperation, 'dissolve'>;
   /** Buffer distance in meters (buffer only). */
   distance_meters?: number;
-  /** GeoJSON Polygon/MultiPolygon mask in EPSG:4326 (clip and select_by_location). */
+  /** GeoJSON Polygon/MultiPolygon mask in EPSG:4326 (clip and select_by_location).
+   * NOT accepted for intersect, which takes a layer only. */
   mask?: GeoJSON.Polygon | GeoJSON.MultiPolygon;
-  /** Polygon dataset supplying the mask geometry: the area clipped to, or
-   * selected against (clip and select_by_location; alternative to mask). */
+  /** Polygon dataset supplying the second layer: the area clipped to, selected
+   * against, or overlaid with (clip, select_by_location, intersect; the
+   * alternative to mask for the first two, and required for intersect). */
   mask_dataset_id?: string;
   /** Layer to join against; each source feature gains a join_count (spatial_join only). */
   join_dataset_id?: string;
@@ -1958,10 +1961,12 @@ export interface AnalysisMaterializeRequest {
   operation: AnalysisOperation;
   title: string;
   distance_meters?: number;
-  /** GeoJSON Polygon/MultiPolygon mask in EPSG:4326 (clip and select_by_location). */
+  /** GeoJSON Polygon/MultiPolygon mask in EPSG:4326 (clip and select_by_location).
+   * NOT accepted for intersect, which takes a layer only. */
   mask?: GeoJSON.Polygon | GeoJSON.MultiPolygon;
-  /** Polygon dataset supplying the mask geometry: the area clipped to, or
-   * selected against (clip and select_by_location; alternative to mask). */
+  /** Polygon dataset supplying the second layer: the area clipped to, selected
+   * against, or overlaid with (clip, select_by_location, intersect; the
+   * alternative to mask for the first two, and required for intersect). */
   mask_dataset_id?: string;
   by_field?: string;
   /** Layer to join against; each source feature gains a join_count (spatial_join only). */

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -1914,7 +1914,13 @@ export interface MapLayerBulkDeleteResponse {
 }
 
 /** M4 analysis tools: parameterized PostGIS operations. */
-export type AnalysisOperation = 'buffer' | 'centroid' | 'clip' | 'dissolve' | 'spatial_join';
+export type AnalysisOperation =
+  | 'buffer'
+  | 'centroid'
+  | 'clip'
+  | 'dissolve'
+  | 'spatial_join'
+  | 'measure';
 
 export interface AnalysisPreviewRequest {
   operation: Exclude<AnalysisOperation, 'dissolve'>;

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -1920,15 +1920,17 @@ export type AnalysisOperation =
   | 'clip'
   | 'dissolve'
   | 'spatial_join'
-  | 'measure';
+  | 'measure'
+  | 'select_by_location';
 
 export interface AnalysisPreviewRequest {
   operation: Exclude<AnalysisOperation, 'dissolve'>;
   /** Buffer distance in meters (buffer only). */
   distance_meters?: number;
-  /** GeoJSON Polygon/MultiPolygon mask in EPSG:4326 (clip only). */
+  /** GeoJSON Polygon/MultiPolygon mask in EPSG:4326 (clip and select_by_location). */
   mask?: GeoJSON.Polygon | GeoJSON.MultiPolygon;
-  /** Polygon dataset whose unioned features form the clip mask (clip only; alternative to mask). */
+  /** Polygon dataset supplying the mask geometry: the area clipped to, or
+   * selected against (clip and select_by_location; alternative to mask). */
   mask_dataset_id?: string;
   /** Layer to join against; each source feature gains a join_count (spatial_join only). */
   join_dataset_id?: string;
@@ -1944,9 +1946,10 @@ export interface AnalysisPreviewResponse {
   /** Source dataset total (1:1 ops only; null when the op filters rows, e.g. clip). */
   source_feature_count?: number | null;
   /**
-   * spatial_join only: intersecting source/join PAIRS across the whole source,
-   * not just the previewed features. Null for other operations, and when the
-   * count could not be computed within the query budget.
+   * Exact total across the WHOLE source, not just the previewed features:
+   * intersecting source/join PAIRS for spatial_join, selected source features
+   * for select_by_location. Null for other operations, and when the count
+   * could not be computed within the query budget.
    */
   match_count?: number | null;
 }
@@ -1955,8 +1958,10 @@ export interface AnalysisMaterializeRequest {
   operation: AnalysisOperation;
   title: string;
   distance_meters?: number;
+  /** GeoJSON Polygon/MultiPolygon mask in EPSG:4326 (clip and select_by_location). */
   mask?: GeoJSON.Polygon | GeoJSON.MultiPolygon;
-  /** Polygon dataset whose unioned features form the clip mask (clip only; alternative to mask). */
+  /** Polygon dataset supplying the mask geometry: the area clipped to, or
+   * selected against (clip and select_by_location; alternative to mask). */
   mask_dataset_id?: string;
   by_field?: string;
   /** Layer to join against; each source feature gains a join_count (spatial_join only). */

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -1949,10 +1949,18 @@ export interface AnalysisPreviewResponse {
   /** Source dataset total (1:1 ops only; null when the op filters rows, e.g. clip). */
   source_feature_count?: number | null;
   /**
-   * Exact total across the WHOLE source, not just the previewed features:
-   * intersecting source/join PAIRS for spatial_join, selected source features
-   * for select_by_location. Null for other operations, and when the count
-   * could not be computed within the query budget.
+   * Exact total across the WHOLE source, not just the previewed features.
+   * Null for operations that report no such total, and when the count could
+   * not be computed within the query budget.
+   *
+   * What it counts is per-operation, so read it against the operation you
+   * sent rather than treating it as one number:
+   * - select_by_location: selected source features. IS the output total.
+   * - intersect: output pieces. IS the output total.
+   * - spatial_join: intersecting source/join PAIRS. NOT the output total —
+   *   the join keeps every source row, so one source row matching four join
+   *   rows contributes 4 here and 1 to the result. Use source_feature_count
+   *   for that operation's total.
    */
   match_count?: number | null;
 }

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -1914,7 +1914,7 @@ export interface MapLayerBulkDeleteResponse {
 }
 
 /** M4 analysis tools: parameterized PostGIS operations. */
-export type AnalysisOperation = 'buffer' | 'centroid' | 'clip' | 'dissolve';
+export type AnalysisOperation = 'buffer' | 'centroid' | 'clip' | 'dissolve' | 'spatial_join';
 
 export interface AnalysisPreviewRequest {
   operation: Exclude<AnalysisOperation, 'dissolve'>;
@@ -1924,6 +1924,10 @@ export interface AnalysisPreviewRequest {
   mask?: GeoJSON.Polygon | GeoJSON.MultiPolygon;
   /** Polygon dataset whose unioned features form the clip mask (clip only; alternative to mask). */
   mask_dataset_id?: string;
+  /** Layer to join against; each source feature gains a join_count (spatial_join only). */
+  join_dataset_id?: string;
+  /** Columns copied from the intersecting join feature, prefixed 'join_' (spatial_join only). */
+  join_fields?: string[];
 }
 
 export interface AnalysisPreviewResponse {
@@ -1933,6 +1937,12 @@ export interface AnalysisPreviewResponse {
   bbox: number[] | null;
   /** Source dataset total (1:1 ops only; null when the op filters rows, e.g. clip). */
   source_feature_count?: number | null;
+  /**
+   * spatial_join only: intersecting source/join PAIRS across the whole source,
+   * not just the previewed features. Null for other operations, and when the
+   * count could not be computed within the query budget.
+   */
+  match_count?: number | null;
 }
 
 export interface AnalysisMaterializeRequest {
@@ -1943,6 +1953,10 @@ export interface AnalysisMaterializeRequest {
   /** Polygon dataset whose unioned features form the clip mask (clip only; alternative to mask). */
   mask_dataset_id?: string;
   by_field?: string;
+  /** Layer to join against; each source feature gains a join_count (spatial_join only). */
+  join_dataset_id?: string;
+  /** Columns copied from the intersecting join feature, prefixed 'join_' (spatial_join only). */
+  join_fields?: string[];
 }
 
 export interface AnalysisMaterializeResponse {

--- a/sdks/python/geolens/models/analysis_materialize_request.py
+++ b/sdks/python/geolens/models/analysis_materialize_request.py
@@ -35,16 +35,22 @@ class AnalysisMaterializeRequest:
         title (str):
         by_field (None | str | Unset): Optional group-by column for dissolve
         distance_meters (float | None | Unset): Buffer distance in meters (buffer only)
+        join_dataset_id (None | Unset | UUID): Dataset to join against; each source feature gains a count of the
+            features from it that intersect (spatial_join only)
+        join_fields (list[str] | None | Unset): Columns to copy from the intersecting join feature, prefixed 'join_' in
+            the output. Ties break on the lowest join-layer gid (spatial_join only)
         mask (AnalysisMaterializeRequestMaskType0 | None | Unset): GeoJSON Polygon or MultiPolygon geometry in EPSG:4326
-            (clip only)
-        mask_dataset_id (None | Unset | UUID): Polygon dataset whose unioned features form the clip mask (clip only;
-            alternative to mask)
+            (clip and select_by_location)
+        mask_dataset_id (None | Unset | UUID): Polygon dataset supplying the mask geometry: the area clipped to, or
+            selected against (clip and select_by_location; alternative to mask)
     """
 
     operation: AnalysisMaterializeRequestOperation
     title: str
     by_field: None | str | Unset = UNSET
     distance_meters: float | None | Unset = UNSET
+    join_dataset_id: None | Unset | UUID = UNSET
+    join_fields: list[str] | None | Unset = UNSET
     mask: AnalysisMaterializeRequestMaskType0 | None | Unset = UNSET
     mask_dataset_id: None | Unset | UUID = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
@@ -69,6 +75,23 @@ class AnalysisMaterializeRequest:
             distance_meters = UNSET
         else:
             distance_meters = self.distance_meters
+
+        join_dataset_id: None | str | Unset
+        if isinstance(self.join_dataset_id, Unset):
+            join_dataset_id = UNSET
+        elif isinstance(self.join_dataset_id, UUID):
+            join_dataset_id = str(self.join_dataset_id)
+        else:
+            join_dataset_id = self.join_dataset_id
+
+        join_fields: list[str] | None | Unset
+        if isinstance(self.join_fields, Unset):
+            join_fields = UNSET
+        elif isinstance(self.join_fields, list):
+            join_fields = self.join_fields
+
+        else:
+            join_fields = self.join_fields
 
         mask: dict[str, Any] | None | Unset
         if isinstance(self.mask, Unset):
@@ -98,6 +121,10 @@ class AnalysisMaterializeRequest:
             field_dict["by_field"] = by_field
         if distance_meters is not UNSET:
             field_dict["distance_meters"] = distance_meters
+        if join_dataset_id is not UNSET:
+            field_dict["join_dataset_id"] = join_dataset_id
+        if join_fields is not UNSET:
+            field_dict["join_fields"] = join_fields
         if mask is not UNSET:
             field_dict["mask"] = mask
         if mask_dataset_id is not UNSET:
@@ -133,6 +160,40 @@ class AnalysisMaterializeRequest:
             return cast(float | None | Unset, data)
 
         distance_meters = _parse_distance_meters(d.pop("distance_meters", UNSET))
+
+        def _parse_join_dataset_id(data: object) -> None | Unset | UUID:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, str):
+                    raise TypeError()
+                join_dataset_id_type_0 = UUID(data)
+
+                return join_dataset_id_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(None | Unset | UUID, data)
+
+        join_dataset_id = _parse_join_dataset_id(d.pop("join_dataset_id", UNSET))
+
+        def _parse_join_fields(data: object) -> list[str] | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, list):
+                    raise TypeError()
+                join_fields_type_0 = cast(list[str], data)
+
+                return join_fields_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(list[str] | None | Unset, data)
+
+        join_fields = _parse_join_fields(d.pop("join_fields", UNSET))
 
         def _parse_mask(
             data: object,
@@ -175,6 +236,8 @@ class AnalysisMaterializeRequest:
             title=title,
             by_field=by_field,
             distance_meters=distance_meters,
+            join_dataset_id=join_dataset_id,
+            join_fields=join_fields,
             mask=mask,
             mask_dataset_id=mask_dataset_id,
         )

--- a/sdks/python/geolens/models/analysis_materialize_request.py
+++ b/sdks/python/geolens/models/analysis_materialize_request.py
@@ -41,8 +41,10 @@ class AnalysisMaterializeRequest:
             the output. Ties break on the lowest join-layer gid (spatial_join only)
         mask (AnalysisMaterializeRequestMaskType0 | None | Unset): GeoJSON Polygon or MultiPolygon geometry in EPSG:4326
             (clip and select_by_location)
-        mask_dataset_id (None | Unset | UUID): Polygon dataset supplying the mask geometry: the area clipped to, or
-            selected against (clip and select_by_location; alternative to mask)
+        mask_dataset_id (None | Unset | UUID): Polygon dataset supplying the second layer: the area clipped to, selected
+            against, or overlaid with. For clip and select_by_location it is the alternative to `mask`; for intersect it is
+            REQUIRED and `mask` is rejected, because an overlay carries the second layer's attributes onto its output and a
+            drawn polygon has none.
     """
 
     operation: AnalysisMaterializeRequestOperation

--- a/sdks/python/geolens/models/analysis_materialize_request_operation.py
+++ b/sdks/python/geolens/models/analysis_materialize_request_operation.py
@@ -1,6 +1,15 @@
 from typing import Literal, cast
 
-AnalysisMaterializeRequestOperation = Literal["buffer", "centroid", "clip", "dissolve"]
+AnalysisMaterializeRequestOperation = Literal[
+    "buffer",
+    "centroid",
+    "clip",
+    "dissolve",
+    "intersect",
+    "measure",
+    "select_by_location",
+    "spatial_join",
+]
 
 ANALYSIS_MATERIALIZE_REQUEST_OPERATION_VALUES: set[
     AnalysisMaterializeRequestOperation
@@ -9,6 +18,10 @@ ANALYSIS_MATERIALIZE_REQUEST_OPERATION_VALUES: set[
     "centroid",
     "clip",
     "dissolve",
+    "intersect",
+    "measure",
+    "select_by_location",
+    "spatial_join",
 }
 
 

--- a/sdks/python/geolens/models/analysis_preview_request.py
+++ b/sdks/python/geolens/models/analysis_preview_request.py
@@ -40,8 +40,10 @@ class AnalysisPreviewRequest:
                 the output. Ties break on the lowest join-layer gid (spatial_join only)
             mask (AnalysisPreviewRequestMaskType0 | None | Unset): GeoJSON Polygon or MultiPolygon geometry in EPSG:4326
                 (clip and select_by_location)
-            mask_dataset_id (None | Unset | UUID): Polygon dataset supplying the mask geometry: the area clipped to, or
-                selected against (clip and select_by_location; alternative to mask)
+            mask_dataset_id (None | Unset | UUID): Polygon dataset supplying the second layer: the area clipped to, selected
+                against, or overlaid with. For clip and select_by_location it is the alternative to `mask`; for intersect it is
+                REQUIRED and `mask` is rejected, because an overlay carries the second layer's attributes onto its output and a
+                drawn polygon has none.
     """
 
     operation: AnalysisPreviewRequestOperation

--- a/sdks/python/geolens/models/analysis_preview_request.py
+++ b/sdks/python/geolens/models/analysis_preview_request.py
@@ -34,14 +34,20 @@ class AnalysisPreviewRequest:
         Attributes:
             operation (AnalysisPreviewRequestOperation):
             distance_meters (float | None | Unset): Buffer distance in meters (buffer only)
+            join_dataset_id (None | Unset | UUID): Dataset to join against; each source feature gains a count of the
+                features from it that intersect (spatial_join only)
+            join_fields (list[str] | None | Unset): Columns to copy from the intersecting join feature, prefixed 'join_' in
+                the output. Ties break on the lowest join-layer gid (spatial_join only)
             mask (AnalysisPreviewRequestMaskType0 | None | Unset): GeoJSON Polygon or MultiPolygon geometry in EPSG:4326
-                (clip only)
-            mask_dataset_id (None | Unset | UUID): Polygon dataset whose unioned features form the clip mask (clip only;
-                alternative to mask)
+                (clip and select_by_location)
+            mask_dataset_id (None | Unset | UUID): Polygon dataset supplying the mask geometry: the area clipped to, or
+                selected against (clip and select_by_location; alternative to mask)
     """
 
     operation: AnalysisPreviewRequestOperation
     distance_meters: float | None | Unset = UNSET
+    join_dataset_id: None | Unset | UUID = UNSET
+    join_fields: list[str] | None | Unset = UNSET
     mask: AnalysisPreviewRequestMaskType0 | None | Unset = UNSET
     mask_dataset_id: None | Unset | UUID = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
@@ -58,6 +64,23 @@ class AnalysisPreviewRequest:
             distance_meters = UNSET
         else:
             distance_meters = self.distance_meters
+
+        join_dataset_id: None | str | Unset
+        if isinstance(self.join_dataset_id, Unset):
+            join_dataset_id = UNSET
+        elif isinstance(self.join_dataset_id, UUID):
+            join_dataset_id = str(self.join_dataset_id)
+        else:
+            join_dataset_id = self.join_dataset_id
+
+        join_fields: list[str] | None | Unset
+        if isinstance(self.join_fields, Unset):
+            join_fields = UNSET
+        elif isinstance(self.join_fields, list):
+            join_fields = self.join_fields
+
+        else:
+            join_fields = self.join_fields
 
         mask: dict[str, Any] | None | Unset
         if isinstance(self.mask, Unset):
@@ -84,6 +107,10 @@ class AnalysisPreviewRequest:
         )
         if distance_meters is not UNSET:
             field_dict["distance_meters"] = distance_meters
+        if join_dataset_id is not UNSET:
+            field_dict["join_dataset_id"] = join_dataset_id
+        if join_fields is not UNSET:
+            field_dict["join_fields"] = join_fields
         if mask is not UNSET:
             field_dict["mask"] = mask
         if mask_dataset_id is not UNSET:
@@ -108,6 +135,40 @@ class AnalysisPreviewRequest:
             return cast(float | None | Unset, data)
 
         distance_meters = _parse_distance_meters(d.pop("distance_meters", UNSET))
+
+        def _parse_join_dataset_id(data: object) -> None | Unset | UUID:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, str):
+                    raise TypeError()
+                join_dataset_id_type_0 = UUID(data)
+
+                return join_dataset_id_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(None | Unset | UUID, data)
+
+        join_dataset_id = _parse_join_dataset_id(d.pop("join_dataset_id", UNSET))
+
+        def _parse_join_fields(data: object) -> list[str] | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, list):
+                    raise TypeError()
+                join_fields_type_0 = cast(list[str], data)
+
+                return join_fields_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(list[str] | None | Unset, data)
+
+        join_fields = _parse_join_fields(d.pop("join_fields", UNSET))
 
         def _parse_mask(data: object) -> AnalysisPreviewRequestMaskType0 | None | Unset:
             if data is None:
@@ -146,6 +207,8 @@ class AnalysisPreviewRequest:
         analysis_preview_request = cls(
             operation=operation,
             distance_meters=distance_meters,
+            join_dataset_id=join_dataset_id,
+            join_fields=join_fields,
             mask=mask,
             mask_dataset_id=mask_dataset_id,
         )

--- a/sdks/python/geolens/models/analysis_preview_request_operation.py
+++ b/sdks/python/geolens/models/analysis_preview_request_operation.py
@@ -1,11 +1,23 @@
 from typing import Literal, cast
 
-AnalysisPreviewRequestOperation = Literal["buffer", "centroid", "clip"]
+AnalysisPreviewRequestOperation = Literal[
+    "buffer",
+    "centroid",
+    "clip",
+    "intersect",
+    "measure",
+    "select_by_location",
+    "spatial_join",
+]
 
 ANALYSIS_PREVIEW_REQUEST_OPERATION_VALUES: set[AnalysisPreviewRequestOperation] = {
     "buffer",
     "centroid",
     "clip",
+    "intersect",
+    "measure",
+    "select_by_location",
+    "spatial_join",
 }
 
 

--- a/sdks/python/geolens/models/analysis_preview_response.py
+++ b/sdks/python/geolens/models/analysis_preview_response.py
@@ -28,9 +28,12 @@ class AnalysisPreviewResponse:
         geojson (AnalysisPreviewResponseGeojson):
         truncated (bool):
         bbox (list[float] | None | Unset):
-        match_count (int | None | Unset): Exact total across the WHOLE source, not just the previewed features:
-            intersecting source/join feature PAIRS for spatial_join, selected source features for select_by_location. Null
-            for other operations, and when the count could not be computed within the query budget
+        match_count (int | None | Unset): Exact total across the WHOLE source, not just the previewed features. What it
+            counts is per-operation, so read it against the operation you sent rather than as one number: select_by_location
+            gives the selected source features and intersect gives the output pieces, and for both of those it IS the output
+            total; spatial_join gives intersecting source/join PAIRS, which is NOT the output total, because the join keeps
+            every source row (use source_feature_count for that operation). Null for operations that report no such total,
+            and when the count could not be computed within the query budget
         source_feature_count (int | None | Unset): Total feature count of the source dataset (1:1 operations only; null
             when the operation filters rows, e.g. clip)
     """

--- a/sdks/python/geolens/models/analysis_preview_response.py
+++ b/sdks/python/geolens/models/analysis_preview_response.py
@@ -28,6 +28,9 @@ class AnalysisPreviewResponse:
         geojson (AnalysisPreviewResponseGeojson):
         truncated (bool):
         bbox (list[float] | None | Unset):
+        match_count (int | None | Unset): Exact total across the WHOLE source, not just the previewed features:
+            intersecting source/join feature PAIRS for spatial_join, selected source features for select_by_location. Null
+            for other operations, and when the count could not be computed within the query budget
         source_feature_count (int | None | Unset): Total feature count of the source dataset (1:1 operations only; null
             when the operation filters rows, e.g. clip)
     """
@@ -36,6 +39,7 @@ class AnalysisPreviewResponse:
     geojson: AnalysisPreviewResponseGeojson
     truncated: bool
     bbox: list[float] | None | Unset = UNSET
+    match_count: int | None | Unset = UNSET
     source_feature_count: int | None | Unset = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
@@ -55,6 +59,12 @@ class AnalysisPreviewResponse:
         else:
             bbox = self.bbox
 
+        match_count: int | None | Unset
+        if isinstance(self.match_count, Unset):
+            match_count = UNSET
+        else:
+            match_count = self.match_count
+
         source_feature_count: int | None | Unset
         if isinstance(self.source_feature_count, Unset):
             source_feature_count = UNSET
@@ -72,6 +82,8 @@ class AnalysisPreviewResponse:
         )
         if bbox is not UNSET:
             field_dict["bbox"] = bbox
+        if match_count is not UNSET:
+            field_dict["match_count"] = match_count
         if source_feature_count is not UNSET:
             field_dict["source_feature_count"] = source_feature_count
 
@@ -107,6 +119,15 @@ class AnalysisPreviewResponse:
 
         bbox = _parse_bbox(d.pop("bbox", UNSET))
 
+        def _parse_match_count(data: object) -> int | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(int | None | Unset, data)
+
+        match_count = _parse_match_count(d.pop("match_count", UNSET))
+
         def _parse_source_feature_count(data: object) -> int | None | Unset:
             if data is None:
                 return data
@@ -123,6 +144,7 @@ class AnalysisPreviewResponse:
             geojson=geojson,
             truncated=truncated,
             bbox=bbox,
+            match_count=match_count,
             source_feature_count=source_feature_count,
         )
 

--- a/sdks/typescript/src/client/types.gen.ts
+++ b/sdks/typescript/src/client/types.gen.ts
@@ -660,7 +660,7 @@ export type AnalysisPreviewResponse = {
     /**
      * Match Count
      *
-     * Exact total across the WHOLE source, not just the previewed features: intersecting source/join feature PAIRS for spatial_join, selected source features for select_by_location. Null for other operations, and when the count could not be computed within the query budget
+     * Exact total across the WHOLE source, not just the previewed features. What it counts is per-operation, so read it against the operation you sent rather than as one number: select_by_location gives the selected source features and intersect gives the output pieces, and for both of those it IS the output total; spatial_join gives intersecting source/join PAIRS, which is NOT the output total, because the join keeps every source row (use source_feature_count for that operation). Null for operations that report no such total, and when the count could not be computed within the query budget
      */
     match_count?: number | null;
     /**

--- a/sdks/typescript/src/client/types.gen.ts
+++ b/sdks/typescript/src/client/types.gen.ts
@@ -539,9 +539,21 @@ export type AnalysisMaterializeRequest = {
      */
     distance_meters?: number | null;
     /**
+     * Join Dataset Id
+     *
+     * Dataset to join against; each source feature gains a count of the features from it that intersect (spatial_join only)
+     */
+    join_dataset_id?: string | null;
+    /**
+     * Join Fields
+     *
+     * Columns to copy from the intersecting join feature, prefixed 'join_' in the output. Ties break on the lowest join-layer gid (spatial_join only)
+     */
+    join_fields?: Array<string> | null;
+    /**
      * Mask
      *
-     * GeoJSON Polygon or MultiPolygon geometry in EPSG:4326 (clip only)
+     * GeoJSON Polygon or MultiPolygon geometry in EPSG:4326 (clip and select_by_location)
      */
     mask?: {
         [key: string]: unknown;
@@ -549,13 +561,13 @@ export type AnalysisMaterializeRequest = {
     /**
      * Mask Dataset Id
      *
-     * Polygon dataset whose unioned features form the clip mask (clip only; alternative to mask)
+     * Polygon dataset supplying the mask geometry: the area clipped to, or selected against (clip and select_by_location; alternative to mask)
      */
     mask_dataset_id?: string | null;
     /**
      * Operation
      */
-    operation: 'buffer' | 'centroid' | 'clip' | 'dissolve';
+    operation: 'buffer' | 'centroid' | 'clip' | 'dissolve' | 'spatial_join' | 'measure' | 'select_by_location' | 'intersect';
     /**
      * Title
      */
@@ -594,9 +606,21 @@ export type AnalysisPreviewRequest = {
      */
     distance_meters?: number | null;
     /**
+     * Join Dataset Id
+     *
+     * Dataset to join against; each source feature gains a count of the features from it that intersect (spatial_join only)
+     */
+    join_dataset_id?: string | null;
+    /**
+     * Join Fields
+     *
+     * Columns to copy from the intersecting join feature, prefixed 'join_' in the output. Ties break on the lowest join-layer gid (spatial_join only)
+     */
+    join_fields?: Array<string> | null;
+    /**
      * Mask
      *
-     * GeoJSON Polygon or MultiPolygon geometry in EPSG:4326 (clip only)
+     * GeoJSON Polygon or MultiPolygon geometry in EPSG:4326 (clip and select_by_location)
      */
     mask?: {
         [key: string]: unknown;
@@ -604,13 +628,13 @@ export type AnalysisPreviewRequest = {
     /**
      * Mask Dataset Id
      *
-     * Polygon dataset whose unioned features form the clip mask (clip only; alternative to mask)
+     * Polygon dataset supplying the mask geometry: the area clipped to, or selected against (clip and select_by_location; alternative to mask)
      */
     mask_dataset_id?: string | null;
     /**
      * Operation
      */
-    operation: 'buffer' | 'centroid' | 'clip';
+    operation: 'buffer' | 'centroid' | 'clip' | 'spatial_join' | 'measure' | 'select_by_location' | 'intersect';
 };
 
 /**
@@ -633,6 +657,12 @@ export type AnalysisPreviewResponse = {
     geojson: {
         [key: string]: unknown;
     };
+    /**
+     * Match Count
+     *
+     * Exact total across the WHOLE source, not just the previewed features: intersecting source/join feature PAIRS for spatial_join, selected source features for select_by_location. Null for other operations, and when the count could not be computed within the query budget
+     */
+    match_count?: number | null;
     /**
      * Source Feature Count
      *

--- a/sdks/typescript/src/client/types.gen.ts
+++ b/sdks/typescript/src/client/types.gen.ts
@@ -561,7 +561,7 @@ export type AnalysisMaterializeRequest = {
     /**
      * Mask Dataset Id
      *
-     * Polygon dataset supplying the mask geometry: the area clipped to, or selected against (clip and select_by_location; alternative to mask)
+     * Polygon dataset supplying the second layer: the area clipped to, selected against, or overlaid with. For clip and select_by_location it is the alternative to `mask`; for intersect it is REQUIRED and `mask` is rejected, because an overlay carries the second layer's attributes onto its output and a drawn polygon has none.
      */
     mask_dataset_id?: string | null;
     /**
@@ -628,7 +628,7 @@ export type AnalysisPreviewRequest = {
     /**
      * Mask Dataset Id
      *
-     * Polygon dataset supplying the mask geometry: the area clipped to, or selected against (clip and select_by_location; alternative to mask)
+     * Polygon dataset supplying the second layer: the area clipped to, selected against, or overlaid with. For clip and select_by_location it is the alternative to `mask`; for intersect it is REQUIRED and `mask` is rejected, because an overlay carries the second layer's attributes onto its output and a drawn polygon has none.
      */
     mask_dataset_id?: string | null;
     /**


### PR DESCRIPTION
## The performance fix comes first, because it is the easiest thing here to skim past

Spatial join's predicate used to build its geometry expressions inside the join
condition, where the planner pulled them up and evaluated them once per
candidate PAIR rather than once per row. Fencing the expression in
`CROSS JOIN LATERAL (SELECT expr AS x OFFSET 0)` blocks subquery pull-up and
restores per-row evaluation.

Measured on the same dataset and query, before and after:

```
28.36s  ->  0.20s
```

`OFFSET 0` is a no-op to a reader and a planner barrier to PostgreSQL. It is
the single load-bearing idiom in this SQL, it appears again in intersect, and
it is three characters wide. That is why it is at the top of this description
and in the first commit rather than somewhere in the middle of the diff.

## Why these four are one PR

Every one of the four adds a value to the same `Literal`, so every one of them
rewrites `openapi.json`, `api.generated.ts`, `types.gen.ts` and both
`analysis_*_request_operation.py` enums. There is no subset that avoids the
collision. Landing them separately means four rebases, four regenerations and
four CI cycles, all of the cost sitting in generated files.

The stronger reason is that they are not independent:

| symbol | introduced | consumed |
|---|---|---|
| `MASK_OPERATIONS` | select_by_location | intersect |
| `_ROW_FILTERING_OPERATIONS` | select_by_location | intersect |
| `_resolve_layer_table_ref` | spatial_join | intersect |
| `_resolve_match_count` | spatial_join | select_by_location, intersect |

Reviewed one at a time, `_resolve_match_count` gets read in three shapes, two
of which never ship. The `MAX_SOURCE_FEATURES` comment is a single argument
written across four changes. The `service_analysis.py` line-budget raise only
justifies itself once all four exist. Splitting them for review is the
artificial move.

## Commit shape

Four code-only commits, then one `chore(sdks)` regeneration.

Generated files appear in exactly one commit. A rebase therefore has one
conflict surface instead of four, and it is a surface that must be resolved by
running `make openapi && make sdks`, never by editing the conflict text. Please
do not ask for the regeneration to be folded back into each commit.

Review commit by commit and the 1,600 lines of application code arrive as four
structurally identical pieces rather than one wall.

### What the regeneration rule bought, concretely

This is not an appeal to a convention. It already caught something once during
this work, on #1045, the PR this branch was based on.

Rebasing that branch onto main conflicted in exactly one file,
`sdks/typescript/src/client/index.ts`, which is a single line holding 1,862
generated exports. There is no side of that a person can merge by reading it.

Taking the branch side verbatim and moving on would have looked completely
clean. It also would have carried five exports for `tiles/raster-auth-check`, a
route main removed while that branch was open. Running `make sdks` deleted
them. `make sdks-check` does fail on exactly that, so the mistake would have
surfaced, but a full CI cycle later and reading as a bug in the branch.

The other half is worth stating because it distinguishes two failure modes that
look identical in a conflict marker: `make openapi` regenerated
`backend/openapi.json` byte for byte identical. The schema merged correctly on
its own. Only the barrel file needed rebuilding. A generated file conflicting
mechanically is not the same thing as a schema that actually diverged, and the
regeneration is what tells them apart.

## The operations

**Spatial join** attaches fields from a second layer to each source row. Its
cost shape is one GIST probe per source row, which is where the `OFFSET 0`
hoist above matters.

**Measure** adds area and length as computed columns. It emits both columns
always, rather than branching on the layer's geometry type, because
`geometry_type` is classified from the first feature only. That is the trap
`fix(#682)` documents, and branching on it would quietly measure the wrong
thing for every row after the first.

**Select by location** keeps whole features that touch a mask layer. It looks
like a clip that skips the clipping, and writing it that way is wrong: clip's
row filter is `&&` alone, a bounding-box test, which survives only because rows
that miss go on to intersect to NULL or EMPTY and get dropped downstream. A
selection has no such downstream, so a bounding-box filter would select
features that fall in the notch of an L-shaped mask and never touch it. The
fixture is an L, and it asserts that the bounding-box predicate on its own
still takes the notch feature, so the test cannot rot into one that passes for
the wrong reason.

**Intersect** produces one row per intersecting source and overlay feature
pair. Grouping is by the overlay's gid rather than by piece, `ST_MakeValid` is
hoisted into an `OFFSET 0` lateral so it runs once per row, and `row_number()`
is evaluated after the WHERE so output gids are contiguous.

## Sizing the intersect ceiling

The issue asks for a ceiling sized on the product of the two inputs.
`MAX_SOURCE_FEATURES` cannot express a product, so the number was measured
rather than guessed. Benchmarked against a 972-polygon, 249,804-vertex overlay:

| sources | overlap | output rows | CTAS | size |
|--:|--:|--:|--:|--:|
| 1,000 | 4x | 4,000 | 0.26s | 3.6 MB |
| 10,000 | 4x | 40,000 | 1.4s | 35 MB |
| 50,000 | 4x | 200,000 | 12.4s | 174 MB |
| 150,000 | 4x | 600,000 | 22.2s | 521 MB |
| 10,000 | 58x | 577,453 | 47.8s | 1,235 MB |
| 10,000 | 145x | died | 7.2s | `temp_file_limit` (4 GB) |

A 15x smaller source count is the more expensive job. No source ceiling
separates those two runs, so the only value that would reject the 47.8s job
also rejects the benign 150k one that finishes in 22s. The input cap stays at
100k as a cheap early exit and `_enforce_output_size` remains the real bound.
The full table sits beside the constant so the next reader does not re-derive
it.

## Module size

Four line-count ratchets move, and all of the growth is this branch rather than
main:

```
analysis_sql.py        662 -> 1165   newly crosses the 1000-line inclusion gate
processing/tasks.py    891 -> 1071   newly crosses it too
schemas.py            1032 -> 1127   existing ratchet moved
service_analysis.py    310 ->  455   decomposed-service budget raised
```

The two that newly cross 1000 do so for one reason. Every rendered statement
lives in `analysis_sql` so that the preview path and the materialize worker
cannot disagree about what SQL they run, and `tasks.py` decides every CTAS
shape in one place. Splitting either per-operation would trade module size for
exactly the drift they exist to prevent.

That is an argument for the growth, not a claim it is free. `analysis_sql` is
now the largest module under `platform/`. The split is filed as #1089, by
operation family rather than by caller, and the ratchet entry points at it.

## Verification

Backend suite 6,721 passed, frontend 4,506 passed across 369 files. Typecheck,
lint, i18n locale parity, `make openapi-check` and `make sdks-check` all clean.
New `t()` keys added to all four locales.

Mutation-checked rather than assumed: removing `ST_Intersects` from select by
location fails 6 tests, removing the `ST_Dimension = 2` guard fails 1. Two
panel tests that claimed to verify drawn-mask teardown were asserting the
request body, which omits `mask` for these operations anyway, so they passed
with the teardown disabled. Both were rewritten against `TerraDraw.stop` and
both now fail under mutation.

## Why verification is SQL-level rather than browser-level

The wave plan asks for each operation to be exercised on a real map in a
browser. That did not happen, and the honest account is that the blocker moved
twice while this work was in flight rather than that it was skipped.

This branch adds no migration of its own. It is pure SQL rendering plus the
panel that drives it, so it needs nothing from the database that main does not
already have. For most of the work the shared development database sat behind
the head this branch's base required, and taking it forward would have put it
ahead of the image the other parallel sessions were running, which the MIG-02
guard turns into a refusal to boot. One database serving several branches at
different heads can satisfy one of them at a time.

The substitution was therefore chosen rather than settled for, and it is aimed
at the failure mode a browser would actually have caught here. The one real
defect found by live QA in this batch was a performance cliff at scale, on
spatial join, so the shipped renderers were imported from `analysis_sql.py`,
meaning the SQL under test is the SQL that ships rather than a restatement of
it, and run against real development data at real sizes. Every answer was then
cross-checked against an independently shaped query carrying none of the same
machinery: no subdivision, no `OFFSET 0` hoist, no dimension filter, no
`row_number()`. Two implementations that share no structure agreeing on the
answer is a stronger correctness signal than one rendered map.

| check | naive query | shipped renderer |
|---|---|---|
| meteorites selected, 32,186 x 294 | 2,838 | 2,838 |
| lakes selected, 412 x 294 | 295 | 295 |
| overlay pairs | 359 | 359 |

Measure over 22,324 Manhattan buildings took 442ms. Select by location's
preview took 180ms and its exact uncapped count 1,083ms. Intersect's pairwise
render took 108ms, produced valid geometry throughout and zero empty results.

The last row is the useful one. Select by location reports 295 lakes touching
a state, and intersect turns those same 295 sources into 359 pieces. The two
operations agree on which features participate and differ by exactly the
pairwise split, which is the documented distinction between them, confirmed
against real data rather than asserted.

Closes #953
Closes #954
Closes #955
Closes #956
