### PR TITLE
ci: make axe and STAC conformance gate the merge queue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1441,11 +1441,16 @@ jobs:
   # this aggregator, give it a merge_group clause too, or you have quietly
   # reopened the hole.
   #
-  # The non-gating jobs (runtime-extension-image-probe, accessibility,
-  # stac-validate, e2e-test, ai-evals) deliberately stay off merge_group. They
-  # are not in this list, so they gate nothing there and would only spend
-  # Actions minutes; the push-triggered ones still run when the batch lands on
-  # main, which is the same coverage they have today.
+  # fix(#1096): accessibility and stac-validate USED TO be listed here as
+  # deliberately off merge_group. That reasoning held only while the queue was
+  # off. With it on, "still runs when the batch lands on main" meant they could
+  # not block the commit that broke them, and neither was in this list, so a
+  # failure gated nothing anywhere and just painted main red with no owner.
+  # Both now run on merge_group and appear below.
+  #
+  # Still deliberately off merge_group: runtime-extension-image-probe (builds
+  # images), e2e-test (the full nightly suite) and ai-evals (spends provider
+  # tokens). They are not in this list and gate nothing here.
   ci-ok:
     name: CI OK
     needs:
@@ -1478,6 +1483,11 @@ jobs:
       # fix(#825): PR-only browser gate; skipped (non-stack PRs, push, cron)
       # counts as pass below, failed blocks the merge.
       - e2e-smoke
+      # fix(#1096): skipped on PRs (both stay off pull_request), which the step
+      # below counts as pass, so per-PR cost stays zero. They RUN on
+      # merge_group and on push, and there a failure blocks.
+      - accessibility
+      - stac-validate
     # always() alone would rubber-stamp: it only guarantees this job RUNS.
     # The step below does the real gating on needs.*.result.
     if: always()
@@ -1887,9 +1897,16 @@ jobs:
     # auto-skips a job whose needs were skipped. The failure/cancelled guard
     # preserves the push gate: don't run the expensive a11y suite if an upstream
     # lint/test failed.
+    #
+    # fix(#1096): merge_group added, and this job joined ci-ok's needs. Before,
+    # axe ran ONLY on a push that had already happened, and gated nothing even
+    # then, because it was absent from the aggregator. An a11y regression landed
+    # on main and painted it red with no owner. In the queue it now runs against
+    # the candidate merge and a failure keeps it out. Costs ~4.7 min on the
+    # critical path, measured, and only after backend-test's 27.5.
     if: >-
       always()
-      && (github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')
+      && (github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || github.event_name == 'merge_group')
       && !contains(needs.*.result, 'failure')
       && !contains(needs.*.result, 'cancelled')
     runs-on: ubuntu-latest
@@ -1958,9 +1975,14 @@ jobs:
     # Same trigger/guard shape as the accessibility job above: force-run on
     # push(main), evaluate on schedule/dispatch despite skipped needs, and stay
     # off PRs (per-PR Actions budget = 0).
+    #
+    # fix(#1096): merge_group added here too, same reasoning. STAC conformance
+    # is a public API contract, and it previously could not block the commit
+    # that broke it. ~2.7 min, in parallel with axe, so it adds nothing to the
+    # critical path beyond what axe already costs.
     if: >-
       always()
-      && (github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')
+      && (github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || github.event_name == 'merge_group')
       && !contains(needs.*.result, 'failure')
       && !contains(needs.*.result, 'cancelled')
     runs-on: ubuntu-latest

--- a/backend/tests/test_ci_merge_queue.py
+++ b/backend/tests/test_ci_merge_queue.py
@@ -80,6 +80,40 @@ def _top_level_or_split(cond: str) -> list[str]:
     return [pp.strip() for pp in parts if pp.strip()]
 
 
+def _top_level_and_split(cond: str) -> list[str]:
+    """Split on ``&&`` at paren depth zero. Mirror of the ``||`` splitter."""
+    parts, depth, buf, i = [], 0, [], 0
+    while i < len(cond):
+        c = cond[i]
+        if c == "(":
+            depth += 1
+        elif c == ")":
+            depth -= 1
+        elif depth == 0 and cond.startswith("&&", i):
+            parts.append("".join(buf))
+            buf, i = [], i + 2
+            continue
+        buf.append(c)
+        i += 1
+    parts.append("".join(buf))
+    return [pp.strip() for pp in parts if pp.strip()]
+
+
+# fix(#1096): an upstream-health guard, not an event gate. These conjuncts ask
+# whether the jobs this one `needs` succeeded; they say nothing about which
+# event triggered the run.
+_UPSTREAM_STATUS_GUARD = re.compile(
+    r"^!?\s*contains\(\s*needs\.\*\.result\s*,\s*['\"][a-z]+['\"]\s*\)$"
+)
+
+
+def _is_upstream_status_guard(part: str) -> bool:
+    part = part.strip()
+    while _wraps_whole(part):
+        part = part[1:-1].strip()
+    return bool(_UPSTREAM_STATUS_GUARD.fullmatch(part))
+
+
 def _wraps_whole(part: str) -> bool:
     """True when the outer parens enclose the WHOLE expression.
 
@@ -109,6 +143,24 @@ def _satisfied_by_merge_group_alone(part: str) -> bool:
     So: unwrap enclosing parens, recurse through ``||``, and accept a leaf only
     when it is exactly the merge_group equality. Anything conjoined with it
     might be false and this cannot evaluate it.
+
+    **One conjunction is accepted (fix(#1096)):** an event allowlist AND'ed with
+    nothing but ``needs.*.result`` status guards, the shape ``accessibility``
+    and ``stac-validate`` use::
+
+        (push || schedule || workflow_dispatch || merge_group)
+        && !contains(needs.*.result, 'failure')
+        && !contains(needs.*.result, 'cancelled')
+
+    This is taught rather than waved through, per the note in
+    ``_runs_on_merge_group``. The safety argument is specific: a status guard
+    is not an event gate. It can only be false when a job in this one's
+    ``needs`` failed or was cancelled, and every such job (backend-lint,
+    backend-test, frontend-lint, frontend-test, security-scan) is itself a
+    ci-ok dependency. So the case where this conjunct suppresses the job is
+    exactly the case where ci-ok is already failing for another reason, and the
+    skip cannot manufacture a false all-clear. That is the property this file
+    protects; anything else conjoined in still returns False.
     """
     part = part.strip()
     while _wraps_whole(part):
@@ -116,6 +168,11 @@ def _satisfied_by_merge_group_alone(part: str) -> bool:
     branches = _top_level_or_split(part)
     if len(branches) > 1:
         return any(_satisfied_by_merge_group_alone(b) for b in branches)
+    conjuncts = _top_level_and_split(part)
+    if len(conjuncts) > 1:
+        others = [c for c in conjuncts if not _is_upstream_status_guard(c)]
+        # Exactly one non-guard conjunct, and merge_group alone satisfies it.
+        return len(others) == 1 and _satisfied_by_merge_group_alone(others[0])
     return bool(re.fullmatch(r"github\.event_name\s*==\s*['\"]merge_group['\"]", part))
 
 
@@ -290,6 +347,41 @@ def test_predicate_path_filtered_shape_runs():
     assert _runs_on_merge_group({"if": condition}) is True
 
 
+@pytest.mark.parametrize(
+    ("condition", "expected", "why"),
+    [
+        (
+            "(github.event_name == 'push' || github.event_name == 'merge_group')"
+            " && !contains(needs.*.result, 'failure')",
+            True,
+            "event allowlist AND upstream status guards — the #1096 shape",
+        ),
+        (
+            "github.event_name == 'merge_group'"
+            " && needs.changes.outputs.backend == 'true'",
+            False,
+            "the #1074 P1: a path-filter output is empty in the queue",
+        ),
+        (
+            "(github.event_name == 'push' || github.event_name == 'merge_group')"
+            " && needs.changes.outputs.e2e == 'true'",
+            False,
+            "allowlist AND a conjunct that is NOT an upstream status guard",
+        ),
+    ],
+)
+def test_predicate_accepts_only_the_taught_conjunction(condition, expected, why):
+    """fix(#1096) widened the predicate by exactly one shape. Pin the edges.
+
+    The accepted conjunction is safe only because a ``needs.*.result`` guard
+    can be false solely when a ci-ok dependency already failed. Swap that
+    conjunct for anything the predicate cannot evaluate and it must go back to
+    reporting False, or this has become the permissive rule the file exists to
+    prevent.
+    """
+    assert _runs_on_merge_group({"if": condition}) is expected, why
+
+
 def test_predicate_explicit_exclusion_skips():
     """`!=` is an exclusion, and a substring match reads it as permission —
     the same class of error as the `always()` one. The `paths-filter` STEP is
@@ -300,11 +392,21 @@ def test_predicate_explicit_exclusion_skips():
 def test_predicate_agrees_with_the_real_workflow():
     """Cross-check against ci.yml rather than only synthetic conditions: every
     job whose condition names merge_group must read as running, and the
-    push/schedule-only jobs must read as skipping."""
+    push/schedule-only jobs must read as skipping.
+
+    fix(#1096): accessibility and stac-validate moved OUT of the second list
+    and into ci-ok's needs, so they are now covered by the first loop. The
+    #1000 decision to keep them off merge_group was correct while the queue was
+    off, because they gated nothing there and would only have spent minutes.
+    With the queue on, "runs on main's push after the merge" meant they could
+    not block the commit that broke them. What remains off is genuinely
+    expensive or externally billed: the nightly e2e suite and the live-provider
+    evals.
+    """
     jobs = _workflow()["jobs"]
     for name in jobs["ci-ok"]["needs"]:
         assert _runs_on_merge_group(jobs[name]), f"{name} must run in the queue"
-    for name in ("e2e-test", "accessibility", "stac-validate"):
+    for name in ("e2e-test", "ai-evals"):
         assert not _runs_on_merge_group(jobs[name]), (
             f"{name} is deliberately off merge_group; if that changed, the "
             "non-gating-jobs decision in #1000 needs revisiting"


### PR DESCRIPTION
## What

`accessibility` (axe + keyboard-nav) and `stac-validate` ran only on `push`, `schedule` and `workflow_dispatch`, and neither appeared in `ci-ok`'s `needs`. Two consequences stacked:

- They never ran on a pull request, so a PR breaking keyboard navigation or STAC conformance showed a fully green check list.
- Even on the push run where they did execute, a failure blocked nothing. Branch protection requires `Detect Changes`, `Pre-commit` and `CI OK`, and these were in none of them.

So the only moment either ran was **after** the offending commit was on main, and the result had no owner. They are the sole automated check for two surfaces, one of them a public API contract.

## Change

`merge_group` added to each event allowlist, and both added to `ci-ok`'s `needs`.

They stay off `pull_request`, and `ci-ok` counts a skip as a pass, so **per-PR cost is unchanged at zero**. In the queue they run against the candidate merge, and a failure keeps it out.

## Cost, measured

From main's push run at `a90ed904a`:

| job | duration |
| --- | --- |
| Backend Tests | 27.5 min (long pole; both jobs `need` it) |
| Accessibility (axe) | 4.7 min |
| STAC conformance | 2.7 min |

The two run in parallel with each other, so the added critical path is **~4.7 min on a ~30 min queue entry**. I had earlier called this "nearly free", which was wrong; it is about +17%, and worth it to convert two post-mortem checks into real gates.

## The test asked for both of its changes

**The predicate rejected the new condition.** An event allowlist AND'ed with `!contains(needs.*.result, ...)` is not a bare `merge_group` disjunct, so `_runs_on_merge_group` returned False and the gate failed. Its docstring says what to do: *teach this function that shape or evaluate the expression, do not widen the fallback.*

It now accepts exactly one conjunction: an allowlist satisfied by `merge_group` alone, AND'ed with nothing but upstream status guards. That is safe for a specific reason rather than a general one. A `needs.*.result` guard can be false only when a job in this one's `needs` failed or was cancelled, and all five of those are themselves `ci-ok` dependencies. So the case where the guard suppresses the job is exactly the case where `ci-ok` is already failing, and the skip cannot manufacture a false all-clear. Anything else conjoined in still returns False, pinned by a new parametrized test that includes the #1074 conjunction P1.

**`test_predicate_agrees_with_the_real_workflow` asserted these two were deliberately off `merge_group`**, with a message telling whoever changed it to revisit the #1000 decision. Doing exactly that here. That decision was correct while the queue was off: they gated nothing in a queue that did not exist and would only have spent minutes. With the queue on, "still runs when the batch lands on main" means they cannot block the commit that broke them. What remains off is genuinely expensive or externally billed, so the list is now `e2e-test` and `ai-evals`.

## Verification

- `test_ci_merge_queue.py` 22 passed
- `test_ci_alembic_filter_paths.py`, `test_phase_279_compose_ci.py`, `test_layering.py` 50 passed
- `ruff check` / `format --check` clean, `ci.yml` parses at 25 jobs, `ci-ok` needs 19
- Predicate edges verified in both directions before and after the change

This PR rides the queue itself, so its own merge_group run is the first place the new gating executes.

Closes #1096