### PR TITLE
test(builder): close the focus race in the keyboard-delete test

### DIFF
--- a/frontend/src/components/builder/__tests__/FolderGroupRow.test.tsx
+++ b/frontend/src/components/builder/__tests__/FolderGroupRow.test.tsx
@@ -143,12 +143,24 @@ describe('FolderGroupRow keyboard operability (v1.6.0 audit A7)', () => {
 
     // The confirm mounts INSIDE the row div — its buttons' Enter/Space used to
     // bubble to the container keydown and be preventDefaulted (mouse-only).
-    // Radix returns focus to the kebab trigger asynchronously on menu close;
-    // wait it out so our focus() isn't stolen back before the keypress.
-    await act(() => new Promise<void>((r) => requestAnimationFrame(() => r())));
+    //
+    // fix(#1100): two things reach for focus after this render, and which one
+    // lands last is a race. Radix returns focus to the kebab trigger
+    // asynchronously on menu close, and the confirm autofocuses "Keep group".
+    // The old wait — one rAF, then a waitFor that focused and asserted — closed
+    // neither: waitFor proves focus AT THE MOMENT IT CHECKS, and a restore
+    // still pending could land between that check and the keypress below. On a
+    // loaded CI runner it did, and Enter went to the kebab, so this failed as
+    // "expected vi.fn() to be called once, but got 0 times" — a call-count
+    // error for what was really a focus problem.
+    //
+    // Take focus and require it to SURVIVE a full macrotask instead. Once
+    // focusing sticks across a flush, every pending restore has already run,
+    // so there is nothing left to steal it before the keypress.
     const deleteBtn = screen.getByRole('button', { name: 'Delete all' });
-    await vi.waitFor(() => {
+    await vi.waitFor(async () => {
       deleteBtn.focus();
+      await act(() => new Promise<void>((r) => setTimeout(r, 0)));
       expect(deleteBtn).toHaveFocus();
     });
     await user.keyboard('{Enter}');


### PR DESCRIPTION
Closes #1100.

`FolderGroupRow.test.tsx` → "the delete confirm is keyboard-operable" fails intermittently on loaded runners with

```
AssertionError: expected "vi.fn()" to be called once, but got 0 times
```

which reads as a behaviour failure and is not one. Enter never reached the button.

## The race

Two things reach for focus after the kebab menu closes, and which lands last is not determined: Radix returns focus to the menu trigger asynchronously on close, and the inline confirm autofocuses its "Keep group" button.

The old guard was one `requestAnimationFrame`, then a `vi.waitFor` that focused "Delete all" and asserted `toHaveFocus()`. That closes neither window. `waitFor` proves focus *at the moment it checks* and returns synchronously on its first successful attempt, so a restore still pending lands during `user.keyboard('{Enter}')`, which yields to the event loop. Enter goes to the trigger and `onDeleteGroup` is never called.

The fix takes focus and requires it to survive a full macrotask, retrying until it does. Once focusing sticks across a flush, every pending restore has already run, so nothing is left to steal it before the keypress.

## Why now

It did not start failing, it started being **run**. The merge queue does no path filtering: on `merge_group` every gated job runs regardless of which paths the PR touched, so backend-only PRs now execute the frontend suite. This flake dequeued #1026, a backend-only change, after a full queue run — its own PR checks were green because the path filter skipped Frontend Tests there.

Any other latent frontend flake now has the same reach. This is the first one to surface.

## Verification

Rather than re-running until it looked stable, I occupied the exact window. Stealing focus one macrotask after the button is first focused:

```ts
screen.getByRole('button', { name: 'Delete all' }).addEventListener(
  'focus', () => setTimeout(() => kebab.focus(), 0), { once: true });
```

reproduces the CI error verbatim against the old wait and passes against this one. That harness is not committed; it is how the change was proven.

Also run: the file 5x green, `npm run lint`, `npm run typecheck`.

## Scope

Test-only. No product code changes.

The sibling Space-on-"Keep group" test has the same shape and is deliberately untouched: its second assertion requires the confirm to have been dismissed, which cannot happen unless the key landed, so a stolen focus fails it rather than passing it vacuously.