### PR TITLE
fix(frontend): let the API answer CORS preflights behind a tunnel

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -102,6 +102,23 @@ export default defineConfig({
     // Only narrow the host allowlist when values are provided (tunnel/proxy
     // deployments); otherwise leave Vite's default behavior intact.
     ...(allowedHosts.length > 0 ? { allowedHosts } : {}),
+    // The API owns CORS policy for /api (CORS_ALLOWED_ORIGINS -> the FastAPI
+    // CORSMiddleware). Vite's own CORS middleware runs BEFORE the `/api` proxy
+    // below and short-circuits every preflight, so leaving it enabled means an
+    // OPTIONS never reaches the API: Vite answers 204 with no
+    // Access-Control-Allow-Origin and the browser blocks the real request.
+    //
+    // Since Vite 6 the `server.cors` default only allows localhost origins, so
+    // a dev server published behind a tunnel (see FRONTEND_ALLOWED_HOSTS above)
+    // breaks exactly the cross-origin callers it is meant to serve. The failure
+    // is invisible for simple GETs — those skip the preflight, get proxied, and
+    // come back with the API's correct headers — and only bites requests that
+    // carry an Authorization/X-Api-Key header and are therefore preflighted.
+    //
+    // `false` disables Vite's middleware entirely so OPTIONS is proxied to the
+    // API like any other method. This only ever removes CORS headers, never
+    // adds them, so it cannot loosen the dev server's exposure.
+    cors: false,
     fs: {
       allow: fsAllow,
     },


### PR DESCRIPTION
## Problem

A browser app on another origin cannot make authenticated calls to a GeoLens deployment whose Vite dev server is published behind a tunnel or reverse proxy, even when `CORS_ALLOWED_ORIGINS` is set correctly on the API.

Vite's own CORS middleware runs *before* the `/api` proxy in `server.proxy`, so it short-circuits the preflight and an `OPTIONS` never reaches the API. Since Vite 6 the `server.cors` default only allows localhost origins, so the dev server answers a cross-origin preflight with `204` and no `Access-Control-Allow-Origin`, and the browser blocks the real request.

Observed on a deployment with `CORS_ALLOWED_ORIGINS` correctly set:

```
# via the Vite dev server
OPTIONS /api/collections/datasets   ->  204, Allow-Methods: GET,HEAD,PUT,PATCH,POST,DELETE
                                        (no Access-Control-Allow-Origin)

# straight to the API
OPTIONS /api/collections/datasets   ->  200, access-control-allow-origin: https://<app-origin>
```

The failure is easy to misdiagnose because it is invisible for simple `GET`s: those skip the preflight, get proxied, and come back with the API's correct headers. It only bites requests carrying an `Authorization` or `X-Api-Key` header, which are preflighted. So an API client appears to reach the catalog while every authenticated call fails at the network layer, which surfaces in the browser as a generic "host may be unreachable, or may not allow cross-origin requests" error.

This pairs with the existing `FRONTEND_ALLOWED_HOSTS` support, which already exists so the dev server can be served behind a tunnel. Host allowlisting alone is not enough to make that configuration usable cross-origin.

## Change

Set `server.cors: false` in `frontend/vite.config.ts` so `OPTIONS` is proxied to the API like any other method, leaving `CORS_ALLOWED_ORIGINS` as the single source of truth for `/api` CORS policy.

This only ever removes CORS headers from the dev server, never adds them, so it cannot loosen the dev server's exposure. It is strictly more restrictive than the pre-Vite-6 default and differs from the current default only in dropping the built-in localhost allowance.

## Verification

Against a tunnelled deployment, before and after restarting the frontend:

- Preflight from the allowlisted origin now returns the API's `access-control-allow-origin`, `access-control-allow-headers` and `access-control-max-age`.
- An authenticated request now reaches the app and returns a real `401` for a bad token, instead of failing at the network layer.
- A non-allowlisted origin still receives no `access-control-allow-origin`.
- The SPA and `/@vite/client` still serve `200`; Vite starts clean.

Gates: `npm run lint` clean; `pre-commit run --all-files` all passed. `npm run typecheck` was run in the frontend container, where the only error is `hand-typed-mirror-drift.test.ts` failing to resolve `../../../../backend/openapi.json`, a container-mount artifact (the container mounts only `./frontend`) unrelated to this change.

No schema, API or config impact. No new translation keys.