### PR TITLE
chore(release): v1.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,18 +14,19 @@ and releases use semantic versioning.
 - **Four new analysis operations: spatial join, measure, select by location,
   and intersect.** They join buffer, centroid, clip, and dissolve in the
   builder's analysis panel: preview the result on the map, then materialize it
-  as a new dataset. Spatial join and select by location take a predicate
-  (intersects, contains, within, and friends); measure adds computed
-  area/length/perimeter columns; intersect writes the pairwise overlay with
-  attributes from both sides. (#1097)
+  as a new dataset. Spatial join and select by location match on intersection;
+  measure adds computed `area_sqm` and `length_m` columns; intersect writes
+  the pairwise overlay with attributes from both sides. (#1097)
 - **Materialized analysis outputs record where they came from.** Each output
   dataset carries the operation, its parameters, and the source dataset ids it
   was derived from, visible in the dataset detail. (#1045)
 - **An analysis job started in one tab is visible in all of them**, and its
   completion notifies once instead of once per tab. (#1043)
 - **The CLI can run analyses**: `geolens analysis preview` and
-  `geolens analysis materialize` cover the server's operations from scripts.
-  (#1050)
+  `geolens analysis materialize` drive buffer, centroid, clip, dissolve,
+  measure, select by location, and intersect from scripts. Spatial join is
+  not yet drivable from the CLI — it requires a join dataset the CLI has no
+  flag for (#1105). (#1050)
 - **Builder chat can clip a layer by another layer** ("clip roads to the city
   boundary") through the same analysis pipeline. (#1071)
 - **API keys now carry a scope.** A key is minted as `full` or `read_only`;
@@ -165,7 +166,8 @@ and releases use semantic versioning.
   extent; the dataset-preview guard is bypassed by large extents. (#903)
 - Metrics report per-worker registries only; Prometheus multiprocess mode is
   not yet adopted. (#651)
-- The CLI's analysis help text still lists only buffer, centroid, and clip.
+- The CLI cannot run a spatial join (no flag for the required join dataset),
+  and its analysis help text still lists only buffer, centroid, and clip.
   (#1105)
 
 ## [1.6.1] - 2026-07-29

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,72 @@ and releases use semantic versioning.
 
 ## [Unreleased]
 
+## [1.7.0] - 2026-08-01
+
+### Added
+
+- **Four new analysis operations: spatial join, measure, select by location,
+  and intersect.** They join buffer, centroid, clip, and dissolve in the
+  builder's analysis panel: preview the result on the map, then materialize it
+  as a new dataset. Spatial join and select by location take a predicate
+  (intersects, contains, within, and friends); measure adds computed
+  area/length/perimeter columns; intersect writes the pairwise overlay with
+  attributes from both sides. (#1097)
+- **Materialized analysis outputs record where they came from.** Each output
+  dataset carries the operation, its parameters, and the source dataset ids it
+  was derived from, visible in the dataset detail. (#1045)
+- **An analysis job started in one tab is visible in all of them**, and its
+  completion notifies once instead of once per tab. (#1043)
+- **The CLI can run analyses**: `geolens analysis preview` and
+  `geolens analysis materialize` cover the server's operations from scripts.
+  (#1050)
+- **Builder chat can clip a layer by another layer** ("clip roads to the city
+  boundary") through the same analysis pipeline. (#1071)
+- **API keys now carry a scope.** A key is minted as `full` or `read_only`;
+  read-only keys can fetch data but not mutate it. Existing keys keep full
+  access. (#1055)
+- **Raster tiles work for API-key clients.** The tile template returned by the
+  token endpoint is signed, so private rasters render outside a browser
+  session (QGIS, scripts, embeds driven by a key). (#1059)
+- **Datasets can be internal**: visible to any signed-in user without a
+  per-user grant, sitting between private and public. Visibility is edited
+  from the dataset's Access tab, and a change that would break a shared map
+  is blocked with a message naming the map. (#1029, #976, #1056)
+- **Fill patterns pick up the layer's fill color** instead of rendering only
+  in their baked-in color, and the pattern shows on the legend chip and
+  layer-list swatch. (#1091, #979)
+- **Backups now capture cluster roles.** Each cycle writes a
+  `globals-<timestamp>.sql` next to the dump (`pg_dumpall --globals-only`),
+  which is what makes a restore onto a fresh cluster able to rebuild roles
+  and their passwords. The backup service also warns at startup when offsite
+  upload is disabled. (#1027, #1062)
+- **Parquet ingest is bounded**: a file that expands past the total row or
+  cell cap is refused up front instead of exhausting the worker. (#1038)
+
+### Changed
+
+- **Extents that cross the antimeridian are now served in RFC 7946 spec
+  form** — a bbox with west > east (e.g. `[178, -19, -178, -17]` for Fiji)
+  at the dataset and collection endpoints, instead of a flattened
+  `[-180, …, 180]` span. Clients that assume west ≤ east need to handle the
+  wrap. (#1040, #1060)
+- **Antimeridian handling was reworked end to end**: ingest shifts 0..360
+  sources into ±180 and reports Mercator-clamp drops in the job result
+  (#899), crossing extents are stored as two rings (#901), extent rollups
+  fold on the circle instead of across the globe (#925, #928, #980), exports
+  filter a crossing bbox server-side (#898, #969), buffers project each
+  component in its own planar projection and split output at ±180 (#883,
+  #900, #990, #986), and COG/VRT bounds are normalized (#924).
+- **Analysis is bounded under load**: a per-tenant cap on active materialize
+  jobs (#1053), a global bound on concurrent previews (#1061), statement
+  timeouts configurable via environment settings (#1057), materialize
+  `work_mem` scoped to the session with a justified ceiling (#1048), and the
+  per-user materialize slot held on a heartbeat lease so a dead worker frees
+  it (#972).
+- **A runaway query can no longer fill the database volume**: the bundled
+  Postgres sets `temp_file_limit`, so a spill fails that query instead of
+  the cluster. (#962)
+
 ### Removed
 
 - **`GET /tiles/raster-auth-check/` is gone from the API contract and both
@@ -31,6 +97,76 @@ and releases use semantic versioning.
   fetches, and fetching only managed storage in the raster pipeline;
   deployments that need a hard redirect bound for user-supplied service
   URLs should enforce it with worker egress rules. (#937)
+
+### Security
+
+- **The SQL sandbox validator was tightened**: nested DML inside CTEs is
+  rejected, `timeout_ms` is threaded through the execution wrapper (#1026),
+  EXISTS subqueries are admitted rather than forcing raw-SQL fallbacks
+  (#1024), and the canonical geodesic buffer template is matched whole
+  (#1036).
+- **A dataset owner setting restricted visibility no longer needs a grant to
+  their own dataset** — the creator is exempt from the grant check that
+  otherwise locks everyone out. (#970)
+
+### Fixed
+
+- **The style editor keeps fill color and fill pattern mutually exclusive in
+  both directions** — picking one clears the other, instead of a pattern
+  silently deleting the stored color. (#1022)
+- **Clearing the builder actually clears it**: the style editor no longer
+  resurrects the cleared layer's persisted state. (#1092)
+- **The unsaved-changes flag tells the truth**: a style Revert that restores
+  the saved state clears it, and four false-dirty verdicts in the clean-state
+  recheck are fixed. (#988, #999)
+- **Categorical styling reports the true category count** and scopes the
+  color ramp correctly on mixed-geometry layers. (#1058)
+- **Advanced JSON paint for symbol layers is validated as circle paint**
+  (#977), its errors are announced to screen readers, and the style-editor
+  selects have accessible names (#984). Per-value symbol icons are validated
+  and empty entries dropped (#982).
+- **Exports render a builtin fill pattern as a solid fill** instead of
+  dropping the layer's styling. (#1054)
+- **Map thumbnails update when the map changes** — the thumbnail carries its
+  own timestamp instead of riding the map's. (#1052)
+- **Tile tokens are re-minted when a backgrounded tab returns**, instead of
+  after a burst of 403s, and raster tile auth failures surface instead of
+  rendering blank. (#881, #897, #964)
+- **Cluster popups report the real split zoom** (`expansion_zoom`), so
+  click-to-expand lands where the cluster actually breaks apart. (#882)
+- **Degree CRSs are classified from the stored WKT** rather than assuming
+  only EPSG:4326 is geographic. (#963)
+- **A single-point dataset gets a padded extent** instead of a zero-area
+  ring that some consumers refused. (#1032)
+- **Builder chat discloses when a preview is capped** and the total row
+  count is unknown. (#1079)
+- **The dev server answers CORS preflights behind a tunnel**, so remote
+  development against the API works again. (#1102)
+
+### Upgrade notes
+
+- **Restart the backup container once after upgrading** (any full stack
+  restart covers it). The backup daemon reads its entrypoint at container
+  start, so an already-running daemon keeps the old cycle and will not
+  produce the new `globals-*.sql` role dump until it restarts.
+- Two endpoints changed shape as described above: antimeridian-crossing
+  extent bboxes are now spec-form (west > east), and
+  `GET /tiles/raster-auth-check/` is gone from the contract.
+
+### Known issues
+
+- Curved geometries (MultiSurface/CompoundCurve) break tiles, feature reads,
+  and analysis operations; ingest-time normalization is planned. (#1104)
+- `lineage_summary` on a materialized output can name a source layer the
+  requester cannot see. (#1103)
+- Intersect refuses layers with json/xml attribute columns instead of
+  carrying them through the overlay. (#1099)
+- Some frontend map surfaces still misrender a seam-crossing (west > east)
+  extent; the dataset-preview guard is bypassed by large extents. (#903)
+- Metrics report per-worker registries only; Prometheus multiprocess mode is
+  not yet adopted. (#651)
+- The CLI's analysis help text still lists only buffer, centroid, and clip.
+  (#1105)
 
 ## [1.6.1] - 2026-07-29
 
@@ -1468,7 +1604,8 @@ regression-covered fixes:
 - Initial public release of the GeoLens catalog, API, map builder, CLI, SDKs,
   Docker development stack, and public documentation entrypoints.
 
-[Unreleased]: https://github.com/geolens-io/geolens/compare/v1.6.1...HEAD
+[Unreleased]: https://github.com/geolens-io/geolens/compare/v1.7.0...HEAD
+[1.7.0]: https://github.com/geolens-io/geolens/compare/v1.6.1...v1.7.0
 [1.6.1]: https://github.com/geolens-io/geolens/compare/v1.6.0...v1.6.1
 [1.6.0]: https://github.com/geolens-io/geolens/compare/v1.5.1...v1.6.0
 [1.5.1]: https://github.com/geolens-io/geolens/compare/v1.5.0...v1.5.1

--- a/backend/app/api/main.py
+++ b/backend/app/api/main.py
@@ -590,7 +590,7 @@ _is_production = settings.is_production
 # no metadata to read. We fall back to the current published line so import never
 # crashes. Keep this fallback in lockstep with backend/pyproject.toml — it is one
 # of the sites `make bump` rewrites.
-_FALLBACK_APP_VERSION = "1.6.1"
+_FALLBACK_APP_VERSION = "1.7.0"
 
 
 def _resolve_app_version() -> str:

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -17792,7 +17792,7 @@
     "summary": "PostGIS-native geospatial data catalog with OGC API Features and Records support",
     "termsOfService": "https://github.com/geolens-io/geolens/blob/main/LICENSE",
     "title": "GeoLens API",
-    "version": "1.6.1"
+    "version": "1.7.0"
   },
   "openapi": "3.1.0",
   "paths": {

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geolens-backend"
-version = "1.6.1"
+version = "1.7.0"
 description = "PostGIS-native GIS data catalog"
 # Docker image (Dockerfile) ships python:3.14-slim (see the Dockerfile FROM for
 # the exact patch pin) as the project's tested runtime.

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -850,7 +850,7 @@ wheels = [
 
 [[package]]
 name = "geolens-backend"
-version = "1.6.1"
+version = "1.7.0"
 source = { virtual = "." }
 dependencies = [
     { name = "alembic" },

--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "geolens-cli"
-version = "1.6.1"
+version = "1.7.0"
 description = "Apache-2.0 command-line interface for the GeoLens API. Login, scan, publish, and export STAC against any GeoLens instance."
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/docs-contract.json
+++ b/docs-contract.json
@@ -1,6 +1,6 @@
 {
   "_comment": "Canonical cross-surface facts for the GeoLens README, marketing site (getgeolens.com/src), and docs site (getgeolens.com/docs). Validated against scripts/install.sh + backend/pyproject.toml by scripts/check_docs_contract.py (geolens CI). The getgeolens.com repo vendors a copy and enforces the same `forbidden` list in its own CI. See docs-internal/DOC-CONSISTENCY-STRATEGY for the full design. Edit a fact ONCE here (and in its canonical source) — the gates make every surface follow.",
-  "version": "1.6.1",
+  "version": "1.7.0",
   "install": {
     "oneLiner": "curl -fsSL https://getgeolens.com/install.sh | sh",
     "sourceBuild": "bash scripts/install.sh",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "1.6.1",
+  "version": "1.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "1.6.1",
+      "version": "1.7.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.6.1",
+  "version": "1.7.0",
   "type": "module",
   "license": "Apache-2.0",
   "author": "Carto Concepts, LLC",

--- a/mcp/pyproject.toml
+++ b/mcp/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "geolens-mcp"
-version = "1.6.1"
+version = "1.7.0"
 description = "Apache-2.0 read-only Model Context Protocol (MCP) server for GeoLens. Lets coding agents discover datasets, inspect schemas, and ask spatial questions against any GeoLens instance."
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/mcp/uv.lock
+++ b/mcp/uv.lock
@@ -225,7 +225,7 @@ wheels = [
 
 [[package]]
 name = "geolens"
-version = "1.6.1"
+version = "1.7.0"
 source = { editable = "../sdks/python" }
 dependencies = [
     { name = "attrs" },
@@ -242,7 +242,7 @@ requires-dist = [
 
 [[package]]
 name = "geolens-mcp"
-version = "1.6.1"
+version = "1.7.0"
 source = { editable = "." }
 dependencies = [
     { name = "geolens" },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "geolens",
-  "version": "1.6.1",
+  "version": "1.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "geolens",
-      "version": "1.6.1",
+      "version": "1.7.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@axe-core/playwright": "^4.12.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "geolens",
-  "version": "1.6.1",
+  "version": "1.7.0",
   "private": true,
   "license": "Apache-2.0",
   "author": "Carto Concepts, LLC",

--- a/sdks/python/.openapi-python-client.yaml
+++ b/sdks/python/.openapi-python-client.yaml
@@ -4,7 +4,7 @@ project_name_override: geolens
 package_name_override: geolens
 # Rewritten on every `make sdks` run by scripts/sync_sdk_versions.py to match
 # backend/openapi.json info.version. Do not edit by hand.
-package_version_override: 1.6.1
+package_version_override: 1.7.0
 
 # Cleaner enum output (matches our pydantic v2 backend's enum emission).
 literal_enums: true

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "geolens"
-version = "1.6.1"
+version = "1.7.0"
 description = "Auto-generated Python SDK for the GeoLens API. Typed clients with Bearer + API-key auth helpers."
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/sdks/typescript/package-lock.json
+++ b/sdks/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@geolens/sdk",
-  "version": "1.6.1",
+  "version": "1.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@geolens/sdk",
-      "version": "1.6.1",
+      "version": "1.7.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@hey-api/client-fetch": "0.13.1"

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@geolens/sdk",
-  "version": "1.6.1",
+  "version": "1.7.0",
   "description": "Auto-generated TypeScript SDK for the GeoLens API. Typed clients with Bearer + API-key auth helpers.",
   "license": "Apache-2.0",
   "author": "Carto Concepts, LLC",


### PR DESCRIPTION
Cuts v1.7.0 from `8340ef1ea`, the sha the full pre-release plan ran against.

## What this PR contains

- `make bump VERSION=1.7.0` across all 19 version sites (including the five lockfiles, per #877's fix).
- The 1.7.0 CHANGELOG section, which `release.yml` extracts as the release body. Headlines: the four new analysis operations (#1097), API key scopes (#1055), signed raster tile templates (#1059), internal dataset visibility (#1029/#976), the antimeridian rework, and backup globals capture (#1027).

## API impacts called out

- Antimeridian-crossing extent bboxes are now RFC 7946 spec form (west > east) at dataset and collection endpoints (#1040, #1060).
- `GET /tiles/raster-auth-check/` removed from the contract and both SDKs (#957/#1046).

## Upgrade note

Backup container must restart once post-upgrade to pick up the globals-dump cycle; documented in the changelog's upgrade notes.

## Verification

- `make version-check`: all 19 sites agree on 1.7.0.
- Pre-release plan (`.planning/v1.7.0-prerelease-test-PLAN.md`) §§0-7 all pass on `8340ef1ea`: full backend/frontend/e2e/drift gates, fresh install (INST-01 verbatim `.env.example`), v1.6.1→v1.7.0 upgrade with data survival, RUNBOOK restore of a v1.6.1 backup onto the upgraded stack, curl + browser smoke suites, CLI/MCP checks, parquet guards, backup globals cycle.
- Known issues shipping as-is are listed in the changelog: #1104, #1103, #1099, #903, #651, #1105.

https://claude.ai/code/session_01PnJqoYvwnHaFT3w4E9zNvE