### PR TITLE
feat(cli): add spatial-join flags to analysis preview and materialize

### DIFF
--- a/cli/geolens_cli/analysis.py
+++ b/cli/geolens_cli/analysis.py
@@ -10,6 +10,12 @@ unchanged rather than validated against a literal here, so the generated
 enum stays the single authority and a new backend operation reaches the CLI
 with the next ``make sdks`` instead of a second list to keep in step (#685).
 
+The single exception is ``_require_join_dataset`` below, which copies one
+requiredness rule because it is really about a flag name the CLI owns — see
+its docstring (#1105). The operation list is still not copied; the help
+strings in main.py that name it are held to the SDK enum by
+cli/tests/test_analysis.py rather than by a check at call time.
+
 OCCLI-06 invariant: zero direct ``httpx`` / ``requests`` imports — every HTTP
 call goes through the generated SDK functions.
 """
@@ -59,16 +65,50 @@ def require_finite(value: Optional[float], flag: str) -> Optional[float]:
     return value
 
 
-def _mask_dataset_arg(mask_dataset_id: Optional[str]) -> Any:
-    """Coerce a mask dataset id to the UUID the SDK models declare."""
+def _dataset_id_arg(dataset_id: Optional[str], flag: str) -> Any:
+    """Coerce a dataset-id option to the UUID the SDK models declare."""
     from geolens.types import UNSET
 
-    if not mask_dataset_id:
+    if not dataset_id:
         return UNSET
     try:
-        return UUID(mask_dataset_id)
+        return UUID(dataset_id)
     except ValueError as exc:
-        raise ValueError(f"--mask-dataset is not a valid id: {mask_dataset_id}") from exc
+        raise ValueError(f"{flag} is not a valid id: {dataset_id}") from exc
+
+
+def parse_join_fields(raw: Optional[str]) -> Optional[list[str]]:
+    """Split ``--join-fields`` on commas, dropping the whitespace around them.
+
+    One comma-separated flag rather than a repeatable one because the columns
+    are a set the server validates as a unit — it rejects the whole list if a
+    name repeats or is missing from the join layer.
+    """
+    if raw is None:
+        return None
+    fields = [part.strip() for part in raw.split(",") if part.strip()]
+    if not fields:
+        raise ValueError("--join-fields needs at least one column name")
+    return fields
+
+
+def _require_join_dataset(operation: str, join_dataset_id: Optional[str]) -> None:
+    """Reject a spatial_join with no join layer before it reaches the wire.
+
+    fix(#1105): the one server rule this module copies, and deliberately so.
+    The operation list stays uncopied (see the module docstring), but this
+    condition is about a flag the CLI owns the name of: without it the request
+    comes back 422 and ``unwrap`` reports it as a generic failure (exit 1),
+    naming the JSON field ``join_dataset_id`` the user never typed. The
+    server's rule is ``_require_analysis_params`` in
+    backend/app/modules/catalog/datasets/domain/schemas.py; the wording below
+    mirrors it and adds the flag that supplies it.
+    """
+    if operation == "spatial_join" and not join_dataset_id:
+        raise ValueError(
+            "spatial_join requires join_dataset_id: "
+            "pass --join-dataset-id <dataset-id>"
+        )
 
 
 def build_preview_request(
@@ -76,6 +116,8 @@ def build_preview_request(
     *,
     distance_meters: Optional[float] = None,
     mask_dataset_id: Optional[str] = None,
+    join_dataset_id: Optional[str] = None,
+    join_fields: Optional[str] = None,
 ) -> Any:
     """Build an AnalysisPreviewRequest, omitting the params that were not given.
 
@@ -86,11 +128,15 @@ def build_preview_request(
     from geolens.models.analysis_preview_request import AnalysisPreviewRequest
     from geolens.types import UNSET
 
+    _require_join_dataset(operation, join_dataset_id)
     distance_meters = require_finite(distance_meters, "--distance")
+    parsed_join_fields = parse_join_fields(join_fields)
     return AnalysisPreviewRequest(
         operation=operation,  # type: ignore[arg-type]  # the SDK enum is the authority
         distance_meters=UNSET if distance_meters is None else distance_meters,
-        mask_dataset_id=_mask_dataset_arg(mask_dataset_id),
+        mask_dataset_id=_dataset_id_arg(mask_dataset_id, "--mask-dataset"),
+        join_dataset_id=_dataset_id_arg(join_dataset_id, "--join-dataset-id"),
+        join_fields=UNSET if parsed_join_fields is None else parsed_join_fields,
     )
 
 
@@ -101,18 +147,24 @@ def build_materialize_request(
     distance_meters: Optional[float] = None,
     mask_dataset_id: Optional[str] = None,
     by_field: Optional[str] = None,
+    join_dataset_id: Optional[str] = None,
+    join_fields: Optional[str] = None,
 ) -> Any:
     """Build an AnalysisMaterializeRequest. See build_preview_request on UNSET."""
     from geolens.models.analysis_materialize_request import AnalysisMaterializeRequest
     from geolens.types import UNSET
 
+    _require_join_dataset(operation, join_dataset_id)
     distance_meters = require_finite(distance_meters, "--distance")
+    parsed_join_fields = parse_join_fields(join_fields)
     return AnalysisMaterializeRequest(
         operation=operation,  # type: ignore[arg-type]  # the SDK enum is the authority
         title=title,
         distance_meters=UNSET if distance_meters is None else distance_meters,
-        mask_dataset_id=_mask_dataset_arg(mask_dataset_id),
+        mask_dataset_id=_dataset_id_arg(mask_dataset_id, "--mask-dataset"),
         by_field=UNSET if by_field is None else by_field,
+        join_dataset_id=_dataset_id_arg(join_dataset_id, "--join-dataset-id"),
+        join_fields=UNSET if parsed_join_fields is None else parsed_join_fields,
     )
 
 

--- a/cli/geolens_cli/main.py
+++ b/cli/geolens_cli/main.py
@@ -811,7 +811,11 @@ def analysis_preview(
         str,
         typer.Option(
             "--operation",
-            help="buffer, centroid or clip (the server rejects anything else)",
+            help=(
+                "buffer, centroid, clip, spatial_join, measure, "
+                "select_by_location or intersect (the server rejects anything "
+                "else; dissolve is materialize-only)"
+            ),
         ),
     ],
     distance: Annotated[
@@ -822,7 +826,27 @@ def analysis_preview(
         Optional[str],
         typer.Option(
             "--mask-dataset",
-            help="Polygon dataset id whose features form the clip mask (clip only)",
+            help=(
+                "Polygon dataset id supplying the second layer (clip and "
+                "select_by_location; required for intersect)"
+            ),
+        ),
+    ] = None,
+    join_dataset_id: Annotated[
+        Optional[str],
+        typer.Option(
+            "--join-dataset-id",
+            help="Dataset id to join against (spatial_join only; required for it)",
+        ),
+    ] = None,
+    join_fields: Annotated[
+        Optional[str],
+        typer.Option(
+            "--join-fields",
+            help=(
+                "Comma-separated columns to copy from the matched join "
+                "feature, prefixed 'join_' in the output (spatial_join only)"
+            ),
         ),
     ] = None,
     compact: Annotated[
@@ -850,6 +874,8 @@ def analysis_preview(
             operation,
             distance_meters=distance,
             mask_dataset_id=mask_dataset,
+            join_dataset_id=join_dataset_id,
+            join_fields=join_fields,
         )
     except ValueError as exc:
         state.output.error(str(exc))
@@ -875,7 +901,11 @@ def analysis_materialize(
         str,
         typer.Option(
             "--operation",
-            help="buffer, centroid, clip or dissolve (the server rejects anything else)",
+            help=(
+                "buffer, centroid, clip, dissolve, spatial_join, measure, "
+                "select_by_location or intersect (the server rejects anything "
+                "else)"
+            ),
         ),
     ],
     title: Annotated[
@@ -889,12 +919,32 @@ def analysis_materialize(
         Optional[str],
         typer.Option(
             "--mask-dataset",
-            help="Polygon dataset id whose features form the clip mask (clip only)",
+            help=(
+                "Polygon dataset id supplying the second layer (clip and "
+                "select_by_location; required for intersect)"
+            ),
         ),
     ] = None,
     by_field: Annotated[
         Optional[str],
         typer.Option("--by-field", help="Group-by column (dissolve only)"),
+    ] = None,
+    join_dataset_id: Annotated[
+        Optional[str],
+        typer.Option(
+            "--join-dataset-id",
+            help="Dataset id to join against (spatial_join only; required for it)",
+        ),
+    ] = None,
+    join_fields: Annotated[
+        Optional[str],
+        typer.Option(
+            "--join-fields",
+            help=(
+                "Comma-separated columns to copy from the matched join "
+                "feature, prefixed 'join_' in the output (spatial_join only)"
+            ),
+        ),
     ] = None,
     wait: Annotated[
         bool,
@@ -943,6 +993,8 @@ def analysis_materialize(
             distance_meters=distance,
             mask_dataset_id=mask_dataset,
             by_field=by_field,
+            join_dataset_id=join_dataset_id,
+            join_fields=join_fields,
         )
     except ValueError as exc:
         state.output.error(str(exc))

--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -37,7 +37,11 @@ dependencies = [
   # geolens.api.datasets_analysis; `geolens analysis` raises
   # ModuleNotFoundError against anything older, and 1.2.0 satisfied the old
   # floor.
-  "geolens>=1.5.0,<2.0.0",
+  # fix(#1107 review): 1.7.0 is the first SDK whose analysis request models
+  # define join_dataset_id/join_fields; the builders pass those keywords
+  # unconditionally, so a 1.5/1.6 SDK raises TypeError on every analysis
+  # command, not just spatial_join.
+  "geolens>=1.7.0,<2.0.0",
 ]
 
 [project.optional-dependencies]

--- a/cli/tests/test_analysis.py
+++ b/cli/tests/test_analysis.py
@@ -90,11 +90,149 @@ class TestRequestBuilders:
     def test_an_unknown_operation_is_passed_through_untouched(self) -> None:
         """The SDK's generated enum is the authority (#685). A CLI-side list
         would have to be updated for every new backend operation, and would
-        reject one the server already supports."""
+        reject one the server already supports.
+
+        The operation named here is deliberately one no enum has: it used to
+        be spatial_join, which the server has since gained, so the test stopped
+        exercising the pass-through it is named for (#1105)."""
         from geolens_cli.analysis import build_preview_request
 
-        body = build_preview_request("spatial_join").to_dict()
-        assert body["operation"] == "spatial_join"
+        body = build_preview_request("voronoi").to_dict()
+        assert body["operation"] == "voronoi"
+
+    def test_spatial_join_preview_sends_the_join_layer_and_its_columns(self) -> None:
+        from geolens_cli.analysis import build_preview_request
+
+        join = "0f0f0f0f-1111-4222-8333-444444444444"
+        body = build_preview_request(
+            "spatial_join", join_dataset_id=join, join_fields="name, pop_2020"
+        ).to_dict()
+        assert body == {
+            "operation": "spatial_join",
+            "join_dataset_id": join,
+            "join_fields": ["name", "pop_2020"],
+        }
+
+    def test_spatial_join_materialize_sends_the_join_layer(self) -> None:
+        from geolens_cli.analysis import build_materialize_request
+
+        join = "0f0f0f0f-1111-4222-8333-444444444444"
+        body = build_materialize_request(
+            "spatial_join", "Parcels with tracts", join_dataset_id=join
+        ).to_dict()
+        assert body == {
+            "operation": "spatial_join",
+            "title": "Parcels with tracts",
+            "join_dataset_id": join,
+        }
+
+    def test_the_join_layer_is_omitted_for_every_other_operation(self) -> None:
+        """Unset beats null — see build_preview_request."""
+        from geolens_cli.analysis import build_preview_request
+
+        body = build_preview_request("centroid").to_dict()
+        assert "join_dataset_id" not in body
+        assert "join_fields" not in body
+
+    def test_a_spatial_join_without_a_join_dataset_is_rejected(self) -> None:
+        """fix(#1105): the server answers this 422, which unwrap reports as a
+        generic failure naming a JSON field the user never typed."""
+        from geolens_cli.analysis import (
+            build_materialize_request,
+            build_preview_request,
+        )
+
+        with pytest.raises(ValueError, match="--join-dataset-id"):
+            build_preview_request("spatial_join")
+        with pytest.raises(ValueError, match="--join-dataset-id"):
+            build_materialize_request("spatial_join", "Joined")
+
+    def test_a_malformed_join_dataset_id_names_its_own_flag(self) -> None:
+        from geolens_cli.analysis import build_preview_request
+
+        with pytest.raises(ValueError, match=r"--join-dataset-id is not a valid id"):
+            build_preview_request("spatial_join", join_dataset_id="not-a-uuid")
+
+    @pytest.mark.parametrize(
+        "raw,expected",
+        [
+            ("name", ["name"]),
+            (" name , pop ", ["name", "pop"]),
+            ("name,,pop", ["name", "pop"]),
+        ],
+    )
+    def test_join_fields_split_on_commas(self, raw: str, expected: list) -> None:
+        from geolens_cli.analysis import parse_join_fields
+
+        assert parse_join_fields(raw) == expected
+
+    def test_join_fields_with_no_column_names_is_rejected(self) -> None:
+        from geolens_cli.analysis import parse_join_fields
+
+        with pytest.raises(ValueError, match="at least one column"):
+            parse_join_fields(" , ")
+
+
+# ---------------------------------------------------------------------------
+# Operation help text
+# ---------------------------------------------------------------------------
+
+
+class TestOperationHelp:
+    """fix(#1105): `--operation` help named three operations while the server
+    took eight, so spatial_join and measure were invisible from the CLI.
+
+    The list stays a literal rather than being derived from the generated enum,
+    because Typer resolves help at import time and reading the enum there would
+    make every `geolens --help` pay for an eager SDK import. These tests are
+    what keeps the literal honest instead: adding a backend operation fails
+    here until the help names it.
+    """
+
+    def _operation_help(self, command_name: str) -> str:
+        from typer.main import get_command
+
+        from geolens_cli.main import app
+
+        analysis = get_command(app).commands["analysis"]
+        command = analysis.commands[command_name]
+        param = next(p for p in command.params if p.name == "operation")
+        return param.help or ""
+
+    def test_preview_help_names_every_operation_the_sdk_accepts(self) -> None:
+        from geolens.models.analysis_preview_request_operation import (
+            ANALYSIS_PREVIEW_REQUEST_OPERATION_VALUES,
+        )
+
+        help_text = self._operation_help("preview")
+        missing = [
+            op
+            for op in sorted(ANALYSIS_PREVIEW_REQUEST_OPERATION_VALUES)
+            if op not in help_text
+        ]
+        assert not missing, f"--operation help omits {missing}: {help_text}"
+
+    def test_materialize_help_names_every_operation_the_sdk_accepts(self) -> None:
+        from geolens.models.analysis_materialize_request_operation import (
+            ANALYSIS_MATERIALIZE_REQUEST_OPERATION_VALUES,
+        )
+
+        help_text = self._operation_help("materialize")
+        missing = [
+            op
+            for op in sorted(ANALYSIS_MATERIALIZE_REQUEST_OPERATION_VALUES)
+            if op not in help_text
+        ]
+        assert not missing, f"--operation help omits {missing}: {help_text}"
+
+    def test_preview_help_does_not_offer_the_materialize_only_operation(self) -> None:
+        """dissolve creates a dataset; there is no preview endpoint for it."""
+        from geolens.models.analysis_preview_request_operation import (
+            ANALYSIS_PREVIEW_REQUEST_OPERATION_VALUES,
+        )
+
+        assert "dissolve" not in ANALYSIS_PREVIEW_REQUEST_OPERATION_VALUES
+        assert "materialize-only" in self._operation_help("preview")
 
     def test_a_malformed_mask_dataset_id_is_rejected_before_the_request(self) -> None:
         from geolens_cli.analysis import build_preview_request
@@ -219,6 +357,62 @@ class TestAnalysisPreviewCli:
         )
         assert result.exit_code == 2, result.output
 
+    def test_a_spatial_join_without_a_join_dataset_exits_2_naming_the_flag(
+        self, runner, tmp_xdg_home, mock_keyring, monkeypatch
+    ) -> None:
+        """fix(#1105): the flag exists now, so the miss is a usage error the
+        CLI can name rather than a 422 that exits 1."""
+        from geolens_cli.main import app
+
+        _seed_login("https://x.example.com", mock_keyring)
+
+        def _must_not_post(*args, **kwargs):  # pragma: no cover - failure path
+            raise AssertionError("the request must not reach the server")
+
+        monkeypatch.setattr("geolens_cli.analysis.run_preview", _must_not_post)
+
+        result = runner.invoke(
+            app,
+            ["analysis", "preview", "ds-1", "--operation", "spatial_join"],
+        )
+        assert result.exit_code == 2, result.output
+        assert "--join-dataset-id" in result.output
+
+    def test_a_spatial_join_sends_the_join_layer_and_its_columns(
+        self, runner, tmp_xdg_home, mock_keyring, monkeypatch
+    ) -> None:
+        from geolens_cli.main import app
+
+        _seed_login("https://x.example.com", mock_keyring)
+        sent: dict = {}
+
+        def _capture(client, dataset_id, request):
+            sent.update(request.to_dict())
+            return _FakePreview()
+
+        monkeypatch.setattr("geolens_cli.analysis.run_preview", _capture)
+
+        join = "0f0f0f0f-1111-4222-8333-444444444444"
+        result = runner.invoke(
+            app,
+            [
+                "analysis",
+                "preview",
+                "ds-1",
+                "--operation",
+                "spatial_join",
+                "--join-dataset-id",
+                join,
+                "--join-fields",
+                "name,pop_2020",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        assert sent == {
+            "operation": "spatial_join",
+            "join_dataset_id": join,
+            "join_fields": ["name", "pop_2020"],
+        }
 
     def test_no_instance_exits_with_the_auth_code(
         self, runner, tmp_xdg_home, mock_keyring
@@ -263,6 +457,77 @@ class TestAnalysisMaterializeCli:
         )
         assert result.exit_code == 0, result.output
         assert "/datasets/ds-new" in result.output
+
+    def test_a_spatial_join_reaches_the_materialize_endpoint(
+        self, runner, tmp_xdg_home, mock_keyring, monkeypatch
+    ) -> None:
+        """fix(#1105): spatial_join was undrivable from the CLI — there was no
+        flag to carry the join layer."""
+        from geolens_cli.main import app
+
+        _seed_login("https://x.example.com/api", mock_keyring)
+        sent: dict = {}
+
+        def _capture(client, dataset_id, request):
+            sent.update(request.to_dict())
+            return _FakeJob()
+
+        monkeypatch.setattr("geolens_cli.analysis.run_materialize", _capture)
+        monkeypatch.setattr(
+            "geolens_cli.publish.resolve_dataset_id", lambda c, j, **kw: "ds-new"
+        )
+
+        join = "0f0f0f0f-1111-4222-8333-444444444444"
+        result = runner.invoke(
+            app,
+            [
+                "analysis",
+                "materialize",
+                "ds-1",
+                "--operation",
+                "spatial_join",
+                "--title",
+                "Parcels with tracts",
+                "--join-dataset-id",
+                join,
+                "--join-fields",
+                "name",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        assert sent == {
+            "operation": "spatial_join",
+            "title": "Parcels with tracts",
+            "join_dataset_id": join,
+            "join_fields": ["name"],
+        }
+
+    def test_a_spatial_join_without_a_join_dataset_exits_2(
+        self, runner, tmp_xdg_home, mock_keyring, monkeypatch
+    ) -> None:
+        from geolens_cli.main import app
+
+        _seed_login("https://x.example.com/api", mock_keyring)
+
+        def _must_not_post(*args, **kwargs):  # pragma: no cover - failure path
+            raise AssertionError("the request must not reach the server")
+
+        monkeypatch.setattr("geolens_cli.analysis.run_materialize", _must_not_post)
+
+        result = runner.invoke(
+            app,
+            [
+                "analysis",
+                "materialize",
+                "ds-1",
+                "--operation",
+                "spatial_join",
+                "--title",
+                "Joined",
+            ],
+        )
+        assert result.exit_code == 2, result.output
+        assert "--join-dataset-id" in result.output
 
     def test_no_wait_reports_the_job_id_without_polling(
         self, runner, tmp_xdg_home, mock_keyring, monkeypatch

--- a/cli/tests/test_exit_codes.py
+++ b/cli/tests/test_exit_codes.py
@@ -48,7 +48,12 @@ class TestRemainingStubsExitWithUsage:
     publish is asserted in test_publish_unit.py::TestPublishCli.
     """
 
-    def test_export_stac_stub_exits_2(self, runner) -> None:
+    def test_export_stac_stub_exits_2(self, runner, tmp_xdg_home) -> None:
+        # fix(#1105): tmp_xdg_home, because without it this reads the
+        # developer's real config. It passes in CI, where there is none, and on
+        # a machine with a logged-in instance it reaches the host keychain and
+        # blocks on the OS access prompt — hanging the whole `make cli-test`
+        # run, not just this test.
         result = runner.invoke(app, ["export", "stac", "abc"])
         assert result.exit_code == 2
 


### PR DESCRIPTION
## Problem

`geolens analysis preview --help` and `materialize --help` still say the server accepts only `buffer`, `centroid`, `clip`, and neither command has a way to pass `join_dataset_id` / `join_fields` — so spatial join, a headline 1.7.0 feature, cannot be driven from the CLI at all. The server rejects a spatial join without `join_dataset_id` (`_require_analysis_params` in `backend/app/modules/catalog/datasets/domain/schemas.py`).

## Fix

- Help text now names every operation the SDK enum accepts. Preview lists its seven and notes that `dissolve` is materialize-only (that split is in the server `Literal` and the generated SDK enum, not a CLI choice); materialize lists all eight. The stale `--mask-dataset` help ("clip only") got the same staleness fix: clip / select_by_location / required-for-intersect.
- Both commands gained `--join-dataset-id` and `--join-fields` (comma-split, trimmed, all-empty rejected), forwarded to the existing request builders only when set.
- Client-side check: `--operation spatial_join` without `--join-dataset-id` exits 2 with `spatial_join requires join_dataset_id: pass --join-dataset-id <dataset-id>`, mirroring the server's wording, instead of a round-trip 422.
- `_mask_dataset_arg` generalized to `_dataset_id_arg(value, flag)` so each flag names itself in its own error.

No generated SDK files touched — `join_dataset_id`/`join_fields` already exist on both generated request models, so no OpenAPI/SDK regeneration was needed.

One test-only fixture fix rode along: `cli/tests/test_exit_codes.py::test_export_stac_stub_exits_2` took no `tmp_xdg_home`, so it read the developer's real config and could hang for 20+ minutes on the macOS keychain prompt (`SecItemCopyMatching`). Adding the fixture makes it hermetic; CI behavior is unchanged.

## Verification

- `cd cli && uv run --extra dev python -m pytest -q` → 282 passed (14 new)
- `make cli-test` → 282 passed (CLI unit) + 8 passed, 2 skipped (backend round-trip), exit 0
- Live against the dev stack: missing flag → exit 2 with the message above; with flags → spatial_join preview returns a FeatureCollection with `join_count`/`join_*` properties; bad column → server's 422 surfaced, exit 1
- A help-vs-enum guard test fails the next time the backend adds an operation, so the help text cannot go stale silently again (deriving the list at runtime would force an eager SDK import on every `geolens --help`; Typer resolves help at import time).

Closes #1105

https://claude.ai/code/session_01PnJqoYvwnHaFT3w4E9zNvE
