### PR TITLE
fix(catalog): access-check lineage prose per requester

### DIFF
--- a/backend/app/modules/catalog/authorization.py
+++ b/backend/app/modules/catalog/authorization.py
@@ -11,7 +11,9 @@ Relocated from the deleted auth visibility module (Phase 213).
 """
 
 import enum
+import re
 import uuid
+from collections.abc import Iterable, Sequence
 from typing import Any
 
 from fastapi import HTTPException, status
@@ -238,6 +240,193 @@ async def visible_derived_from(
         for dependent in dependent_params:
             params.pop(dependent, None)
     return {**derived_from, "params": params}
+
+
+# fix(#1103): the phrases a redacted lineage sentence is left with. The layer
+# form is the GENERATOR's own fallback for a title it could not read (see
+# _operation_phrase in processing/analysis/provenance.py), so a redacted
+# sentence reads exactly like one whose second layer had no title — the
+# redaction is not itself a signal.
+#
+# Deliberately not the dataset's id. _DATASET_ID_PARAMS above exists because an
+# id the requester cannot resolve is still a disclosure worth withholding, and
+# putting it in the prose would route around the redaction that drops it from
+# the reference.
+_REDACTED_SOURCE_TITLE = "another dataset"
+_REDACTED_LAYER_TITLE = "another layer"
+
+# Every title the generator writes is quoted, and nothing else in the sentence
+# is: distances, field names, the actor and the date all render bare.
+_QUOTED_TITLE_RE = re.compile(r'"[^"]*"')
+
+
+def _provenance_dataset_ids(derived_from: dict) -> list[uuid.UUID | None]:
+    """The datasets a lineage sentence can name, in the order it names them.
+
+    The source first, then the second layer, mirroring how build_lineage_sentence
+    assembles the phrase. ``None`` marks an id that cannot be parsed, which the
+    caller treats as inaccessible.
+    """
+    params = derived_from.get("params") or {}
+    raw_ids = [derived_from.get("dataset_id")]
+    raw_ids += [
+        params[key] for key in _DATASET_ID_PARAMS if params.get(key) is not None
+    ]
+
+    parsed: list[uuid.UUID | None] = []
+    for raw in raw_ids:
+        try:
+            parsed.append(uuid.UUID(str(raw)))
+        except (TypeError, ValueError):
+            parsed.append(None)
+    return parsed
+
+
+async def _accessible_dataset_ids(
+    db: AsyncSession,
+    dataset_ids: Iterable[uuid.UUID],
+    user: Identity | None,
+    user_roles: set[str],
+) -> set[uuid.UUID]:
+    """The subset of ``dataset_ids`` this requester may read, in one query.
+
+    The list-shaped form of the same rule ``check_dataset_access`` applies per
+    dataset: both delegate to PermissionExtension, whose ``filter_visible`` and
+    ``can_access_dataset`` are written and changed as a pair (see #929/#930).
+    A batch is what makes the redaction affordable on a page of results — one
+    statement for the whole page rather than one per referenced dataset.
+
+    An id that no longer resolves to a dataset is simply absent from the result:
+    access to it cannot be established, so the caller withholds.
+    """
+    wanted = set(dataset_ids)
+    if not wanted:
+        return set()
+
+    from app.modules.catalog.datasets.domain.models import (
+        Dataset,
+        DatasetGrant,
+        Record,
+    )
+
+    stmt = (
+        select(Dataset.id)
+        .join(Record, Record.id == Dataset.record_id)
+        .where(Dataset.id.in_(wanted))
+    )
+    stmt = apply_visibility_filter(stmt, user, user_roles, Record, DatasetGrant)
+    rows = await db.execute(stmt)
+    return {row for row in rows.scalars() if row in wanted}
+
+
+def _redact_quoted_titles(
+    summary: str, dataset_ids: Sequence[uuid.UUID | None], hidden_slots: set[int]
+) -> str:
+    """Replace the quoted titles at ``hidden_slots`` with a neutral phrase.
+
+    Slots are positional: the generator emits the source's title first and the
+    second layer's after it, so span N belongs to ``dataset_ids[N]``. That
+    alignment only holds while the sentence has exactly one quoted span per
+    referenced dataset — a source whose title was already unreadable renders as
+    a bare phrase and shifts every later span onto the wrong dataset. When the
+    counts disagree, every quoted title goes: over-redacting a sentence nobody
+    can align is the safe direction, and it also covers a title that itself
+    contained a quote character.
+    """
+    span_count = len(_QUOTED_TITLE_RE.findall(summary))
+    if span_count != len(dataset_ids):
+        hidden_slots = set(range(span_count))
+
+    slot = -1
+
+    def _replace(match: re.Match[str]) -> str:
+        nonlocal slot
+        slot += 1
+        if slot not in hidden_slots:
+            return match.group(0)
+        return _REDACTED_SOURCE_TITLE if slot == 0 else _REDACTED_LAYER_TITLE
+
+    return _QUOTED_TITLE_RE.sub(_replace, summary)
+
+
+async def visible_lineage_summaries(
+    db: AsyncSession,
+    records: Sequence[Any],
+    user: Identity | None,
+    user_roles: set[str],
+) -> dict[uuid.UUID, str | None]:
+    """Lineage prose per record, with unreachable datasets' titles redacted.
+
+    fix(#1103): ``records.lineage_summary`` is written once at materialize time
+    and was served raw to everyone who could see the OUTPUT — the dataset
+    response, the OGC record properties, and the three DCAT exports all read the
+    column. For an analysis output the sentence names its source and, since
+    #765's clip and #1097's three overlay operations, the second layer's title
+    too. So a public clip of a public layer against a PRIVATE mask published
+    that mask's title, and the fact that it exists, to every viewer — the
+    disclosure ``visible_derived_from`` deliberately prevents for the mask's id,
+    arriving through a channel that had no redaction.
+
+    Prose has no per-requester form on its own, so this is the per-requester
+    form: the sentence stays, its entry survives (that a derived dataset HAS
+    provenance is not the secret), and only the titles of datasets this
+    requester could not open are replaced. Ids are not substituted in — see
+    _REDACTED_SOURCE_TITLE.
+
+    Records with no ``derived_from`` are returned untouched. Their lineage is
+    hand-written or inherited from ingest rather than assembled from other
+    datasets' titles, which is also what keeps this cheap: the query below runs
+    only for the analysis outputs on the page.
+
+    The bound worth stating: ``lineage_summary`` is editable metadata. An owner
+    who rewrites the sentence and types a private layer's name into it has
+    published that name themselves, exactly as they would by typing it into the
+    summary field (see apply_analysis_provenance). This redacts what the
+    generator wrote.
+    """
+    referenced: dict[uuid.UUID, list[uuid.UUID | None]] = {}
+    for record in records:
+        if record.lineage_summary and record.derived_from:
+            referenced[record.id] = _provenance_dataset_ids(record.derived_from)
+
+    accessible = await _accessible_dataset_ids(
+        db,
+        {
+            dataset_id
+            for ids in referenced.values()
+            for dataset_id in ids
+            if dataset_id is not None
+        },
+        user,
+        user_roles,
+    )
+
+    summaries: dict[uuid.UUID, str | None] = {}
+    for record in records:
+        summary = record.lineage_summary
+        dataset_ids = referenced.get(record.id)
+        if summary is None or not dataset_ids:
+            summaries[record.id] = summary
+            continue
+        hidden = {
+            slot
+            for slot, dataset_id in enumerate(dataset_ids)
+            if dataset_id is None or dataset_id not in accessible
+        }
+        summaries[record.id] = (
+            _redact_quoted_titles(summary, dataset_ids, hidden) if hidden else summary
+        )
+    return summaries
+
+
+async def visible_lineage_summary(
+    db: AsyncSession,
+    record: Any,
+    user: Identity | None,
+    user_roles: set[str],
+) -> str | None:
+    """One record's access-checked lineage prose. See visible_lineage_summaries."""
+    return (await visible_lineage_summaries(db, [record], user, user_roles))[record.id]
 
 
 async def check_dataset_write_access(

--- a/backend/app/modules/catalog/authorization.py
+++ b/backend/app/modules/catalog/authorization.py
@@ -334,16 +334,19 @@ def _redact_quoted_titles(
 
     Slots are positional: the generator emits the source's title first and the
     second layer's after it, so span N belongs to ``dataset_ids[N]``. That
-    alignment only holds while the sentence has exactly one quoted span per
-    referenced dataset — a source whose title was already unreadable renders as
-    a bare phrase and shifts every later span onto the wrong dataset, and a
-    title that itself contains ``"`` splits into several spans with its middle
-    OUTSIDE them. When the counts disagree the sentence has no boundary the
-    redaction can trust — replacing only the detected spans would leave those
-    stranded fragments readable — so the entire sentence is replaced.
+    alignment only holds while every referenced dataset contributed exactly one
+    clean quoted span, and the check for it counts quote CHARACTERS, not spans:
+    the generator writes two quotes per title, and an embedded quote can only
+    add, so ``count('"') == 2 * len(dataset_ids)`` holds iff no title contained
+    a quote and no title fell back to a bare unnamed phrase. A span count is
+    not the same test — fix(#1108 review): a title with an ODD number of
+    embedded quotes (``Flood "Zone``) yields exactly one span per dataset, so
+    the span counts agree while the span boundaries sit inside the hidden
+    title, and slot-by-slot replacement strands part of it in the clear.
+    Unalignable prose has no boundary the redaction can trust, so the entire
+    sentence is replaced.
     """
-    span_count = len(_QUOTED_TITLE_RE.findall(summary))
-    if span_count != len(dataset_ids):
+    if summary.count('"') != 2 * len(dataset_ids):
         return _REDACTED_SUMMARY
 
     slot = -1

--- a/backend/app/modules/catalog/authorization.py
+++ b/backend/app/modules/catalog/authorization.py
@@ -11,7 +11,6 @@ Relocated from the deleted auth visibility module (Phase 213).
 """
 
 import enum
-import re
 import uuid
 from collections.abc import Iterable, Sequence
 from typing import Any
@@ -242,30 +241,24 @@ async def visible_derived_from(
     return {**derived_from, "params": params}
 
 
-# fix(#1103): the phrases a redacted lineage sentence is left with. The layer
-# form is the GENERATOR's own fallback for a title it could not read (see
-# _operation_phrase in processing/analysis/provenance.py), so a redacted
-# sentence reads exactly like one whose second layer had no title — the
-# redaction is not itself a signal.
+# fix(#1103): the sentence a restricted requester gets instead of the stored
+# prose. Deliberately not the dataset's id — _DATASET_ID_PARAMS above exists
+# because an id the requester cannot resolve is still a disclosure worth
+# withholding, and putting it in the prose would route around the redaction
+# that drops it from the reference.
 #
-# Deliberately not the dataset's id. _DATASET_ID_PARAMS above exists because an
-# id the requester cannot resolve is still a disclosure worth withholding, and
-# putting it in the prose would route around the redaction that drops it from
-# the reference.
-_REDACTED_SOURCE_TITLE = "another dataset"
-_REDACTED_LAYER_TITLE = "another layer"
-
-# fix(#1108 review): the whole-sentence replacement for prose whose quoted
-# spans cannot be aligned with the referenced datasets. A hidden title that
-# itself contains a quote character corrupts the span boundaries, so a
-# span-by-span redaction can leave fragments of that title BETWEEN the spans
-# it replaces. Misaligned prose has no trustworthy structure to edit; the only
-# safe partial disclosure is none.
+# fix(#1108 review): the replacement is ALWAYS the whole sentence — the prose
+# is never edited span-by-span. Three review rounds each produced a working
+# forgery against in-place editing: an unnamed source shifts every quoted span
+# onto the wrong dataset; a title with embedded quotes (odd or even) corrupts
+# the span boundaries so fragments of the hidden title survive between them;
+# and quote characters in NON-title free text (an actor name) can compensate
+# for a missing title so even a quote-character count reads as aligned. The
+# sentence interleaves attacker-influenced free text with the secrets, so no
+# delimiter arithmetic over it is trustworthy. The unforgeable rule is binary:
+# a requester who can read every referenced dataset gets the prose verbatim,
+# and one who cannot gets this constant — never any byte of the stored text.
 _REDACTED_SUMMARY = "Derived from another dataset."
-
-# Every title the generator writes is quoted, and nothing else in the sentence
-# is: distances, field names, the actor and the date all render bare.
-_QUOTED_TITLE_RE = re.compile(r'"[^"]*"')
 
 
 def _provenance_dataset_ids(derived_from: dict) -> list[uuid.UUID | None]:
@@ -327,40 +320,6 @@ async def _accessible_dataset_ids(
     return {row for row in rows.scalars() if row in wanted}
 
 
-def _redact_quoted_titles(
-    summary: str, dataset_ids: Sequence[uuid.UUID | None], hidden_slots: set[int]
-) -> str:
-    """Replace the quoted titles at ``hidden_slots`` with a neutral phrase.
-
-    Slots are positional: the generator emits the source's title first and the
-    second layer's after it, so span N belongs to ``dataset_ids[N]``. That
-    alignment only holds while every referenced dataset contributed exactly one
-    clean quoted span, and the check for it counts quote CHARACTERS, not spans:
-    the generator writes two quotes per title, and an embedded quote can only
-    add, so ``count('"') == 2 * len(dataset_ids)`` holds iff no title contained
-    a quote and no title fell back to a bare unnamed phrase. A span count is
-    not the same test — fix(#1108 review): a title with an ODD number of
-    embedded quotes (``Flood "Zone``) yields exactly one span per dataset, so
-    the span counts agree while the span boundaries sit inside the hidden
-    title, and slot-by-slot replacement strands part of it in the clear.
-    Unalignable prose has no boundary the redaction can trust, so the entire
-    sentence is replaced.
-    """
-    if summary.count('"') != 2 * len(dataset_ids):
-        return _REDACTED_SUMMARY
-
-    slot = -1
-
-    def _replace(match: re.Match[str]) -> str:
-        nonlocal slot
-        slot += 1
-        if slot not in hidden_slots:
-            return match.group(0)
-        return _REDACTED_SOURCE_TITLE if slot == 0 else _REDACTED_LAYER_TITLE
-
-    return _QUOTED_TITLE_RE.sub(_replace, summary)
-
-
 async def visible_lineage_summaries(
     db: AsyncSession,
     records: Sequence[Any],
@@ -380,21 +339,24 @@ async def visible_lineage_summaries(
     arriving through a channel that had no redaction.
 
     Prose has no per-requester form on its own, so this is the per-requester
-    form: the sentence stays, its entry survives (that a derived dataset HAS
-    provenance is not the secret), and only the titles of datasets this
-    requester could not open are replaced. Ids are not substituted in — see
-    _REDACTED_SOURCE_TITLE.
+    form, and it is deliberately all-or-nothing (see _REDACTED_SUMMARY for the
+    three forgeries that killed span editing): a requester who can open every
+    dataset the provenance references gets the sentence exactly as stored, and
+    one who cannot gets the neutral constant. The entry itself survives either
+    way — that a derived dataset HAS provenance is not the secret.
 
     Records with no ``derived_from`` are returned untouched. Their lineage is
     hand-written or inherited from ingest rather than assembled from other
     datasets' titles, which is also what keeps this cheap: the query below runs
     only for the analysis outputs on the page.
 
-    The bound worth stating: ``lineage_summary`` is editable metadata. An owner
-    who rewrites the sentence and types a private layer's name into it has
-    published that name themselves, exactly as they would by typing it into the
-    summary field (see apply_analysis_provenance). This redacts what the
-    generator wrote.
+    The all-or-nothing rule is also what makes owner-edited prose safe to
+    serve: ``lineage_summary`` is editable metadata, and edited free text can
+    embed anything, so it is never partially rewritten — a full-access viewer
+    reads it verbatim (an owner who types a private layer's name into it has
+    published that name themselves, see apply_analysis_provenance), and a
+    restricted viewer gets the constant, because prose that CANNOT be verified
+    clean is withheld whole rather than edited by guesswork.
     """
     referenced: dict[uuid.UUID, list[uuid.UUID | None]] = {}
     for record in records:
@@ -420,14 +382,11 @@ async def visible_lineage_summaries(
         if summary is None or not dataset_ids:
             summaries[record.id] = summary
             continue
-        hidden = {
-            slot
-            for slot, dataset_id in enumerate(dataset_ids)
-            if dataset_id is None or dataset_id not in accessible
-        }
-        summaries[record.id] = (
-            _redact_quoted_titles(summary, dataset_ids, hidden) if hidden else summary
+        any_hidden = any(
+            dataset_id is None or dataset_id not in accessible
+            for dataset_id in dataset_ids
         )
+        summaries[record.id] = _REDACTED_SUMMARY if any_hidden else summary
     return summaries
 
 

--- a/backend/app/modules/catalog/authorization.py
+++ b/backend/app/modules/catalog/authorization.py
@@ -255,6 +255,14 @@ async def visible_derived_from(
 _REDACTED_SOURCE_TITLE = "another dataset"
 _REDACTED_LAYER_TITLE = "another layer"
 
+# fix(#1108 review): the whole-sentence replacement for prose whose quoted
+# spans cannot be aligned with the referenced datasets. A hidden title that
+# itself contains a quote character corrupts the span boundaries, so a
+# span-by-span redaction can leave fragments of that title BETWEEN the spans
+# it replaces. Misaligned prose has no trustworthy structure to edit; the only
+# safe partial disclosure is none.
+_REDACTED_SUMMARY = "Derived from another dataset."
+
 # Every title the generator writes is quoted, and nothing else in the sentence
 # is: distances, field names, the actor and the date all render bare.
 _QUOTED_TITLE_RE = re.compile(r'"[^"]*"')
@@ -328,14 +336,15 @@ def _redact_quoted_titles(
     second layer's after it, so span N belongs to ``dataset_ids[N]``. That
     alignment only holds while the sentence has exactly one quoted span per
     referenced dataset — a source whose title was already unreadable renders as
-    a bare phrase and shifts every later span onto the wrong dataset. When the
-    counts disagree, every quoted title goes: over-redacting a sentence nobody
-    can align is the safe direction, and it also covers a title that itself
-    contained a quote character.
+    a bare phrase and shifts every later span onto the wrong dataset, and a
+    title that itself contains ``"`` splits into several spans with its middle
+    OUTSIDE them. When the counts disagree the sentence has no boundary the
+    redaction can trust — replacing only the detected spans would leave those
+    stranded fragments readable — so the entire sentence is replaced.
     """
     span_count = len(_QUOTED_TITLE_RE.findall(summary))
     if span_count != len(dataset_ids):
-        hidden_slots = set(range(span_count))
+        return _REDACTED_SUMMARY
 
     slot = -1
 

--- a/backend/app/modules/catalog/collections/router.py
+++ b/backend/app/modules/catalog/collections/router.py
@@ -14,7 +14,11 @@ from app.platform.cache.tiles import invalidate_catalog_cache
 from app.core.identity import Identity
 from app.modules.auth.dependencies import get_optional_user, require_permission
 from app.modules.auth.models import User
-from app.modules.catalog.authorization import check_dataset_access, get_user_roles
+from app.modules.catalog.authorization import (
+    check_dataset_access,
+    get_user_roles,
+    visible_lineage_summaries,
+)
 from app.modules.catalog.collections.schemas import (
     AddDatasetsResponse,
     CollectionAddDatasetsRequest,
@@ -437,7 +441,17 @@ async def get_collection_datasets_endpoint(
         rows = await db.execute(select(User).where(User.id.in_(actor_ids)))
         actor_map = {u.id: u for u in rows.scalars()}
 
+    # fix(#1103): one visibility query for the page, not one per row.
+    lineage = await visible_lineage_summaries(
+        db, [d.record for d in datasets], user, user_roles
+    )
+
     return DatasetListResponse(
-        datasets=[dataset_to_response(d, actors_by_id=actor_map) for d in datasets],
+        datasets=[
+            dataset_to_response(
+                d, actors_by_id=actor_map, lineage_summary=lineage[d.record_id]
+            )
+            for d in datasets
+        ],
         total=total,
     )

--- a/backend/app/modules/catalog/datasets/api/router.py
+++ b/backend/app/modules/catalog/datasets/api/router.py
@@ -27,6 +27,7 @@ from app.modules.catalog.authorization import (
     check_dataset_access_or_anonymous,
     check_dataset_write_access,
     get_user_roles,
+    visible_lineage_summary,
 )
 from app.modules.catalog.datasets.domain.helpers import (
     dataset_to_response,
@@ -143,6 +144,13 @@ async def create_empty_dataset_endpoint(
         dataset,
         actors_by_id=actors_by_id,
         base_url=await get_dataset_service_url(db, request=request),
+        # fix(#1103): access-checked prose. A dataset created here has no
+        # provenance to redact, and the helper says so without a query — the
+        # point of routing every builder through it is that no call site gets
+        # to decide that for itself.
+        lineage_summary=await visible_lineage_summary(
+            db, dataset.record, user, await get_user_roles(db, user)
+        ),
     )
 
 
@@ -292,7 +300,7 @@ async def update_dataset_metadata(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="Dataset not found",
         )
-    await check_dataset_write_access(db, dataset, dataset_id, user)
+    user_roles = await check_dataset_write_access(db, dataset, dataset_id, user)
 
     # fix(#458 E-48): capture the pre-update value so a PATCH that echoes the
     # same tile_columns doesn't roll the tile version / purge the tile cache.
@@ -365,6 +373,12 @@ async def update_dataset_metadata(
         dataset,
         actors_by_id=actors_by_id,
         base_url=await get_dataset_service_url(db, request=request),
+        # fix(#1103): the editor is owner-or-admin here, but "owner of the
+        # output" does not imply access to what it was derived from — a grant
+        # on the source can be revoked after the analysis ran.
+        lineage_summary=await visible_lineage_summary(
+            db, dataset.record, user, user_roles
+        ),
     )
 
 

--- a/backend/app/modules/catalog/datasets/api/router_export.py
+++ b/backend/app/modules/catalog/datasets/api/router_export.py
@@ -30,6 +30,7 @@ from app.modules.catalog.authorization import (
     check_dataset_access,
     check_dataset_access_or_anonymous,
     get_user_roles,
+    visible_lineage_summaries,
 )
 from app.standards.dcat.service import (
     catalog_to_dcat,
@@ -243,6 +244,32 @@ _FEED_OFFSET_Q = Query(
 )
 
 
+async def _visible_lineage(
+    db: AsyncSession,
+    datasets: list[DatasetModel],
+    user: Identity | None,
+) -> dict[uuid.UUID, str | None]:
+    """fix(#1103): access-checked ``dcterms:provenance`` for a page, in one query.
+
+    These feeds serve anonymous requesters, and an analysis output's lineage
+    sentence names the titles of the datasets it was derived from — including a
+    private mask or join layer the requester is not allowed to know exists.
+    The serializers no longer read the column, so a handler that forgets this
+    emits no provenance rather than someone else's title.
+    """
+    user_roles = await get_user_roles(db, user) if user is not None else set()
+    return await visible_lineage_summaries(
+        db, [ds.record for ds in datasets], user, user_roles
+    )
+
+
+async def _visible_record_lineage(
+    db: AsyncSession, dataset: DatasetModel, user: Identity | None
+) -> str | None:
+    """One dataset's access-checked provenance sentence. See _visible_lineage."""
+    return (await _visible_lineage(db, [dataset], user))[dataset.record_id]
+
+
 async def _get_dcat_dataset_for_export(
     db: AsyncSession,
     dataset_id: uuid.UUID,
@@ -286,6 +313,7 @@ async def get_dcat_catalog(
         datasets,
         base_url,
         preferred_languages=preferred_languages,
+        lineage_by_record_id=await _visible_lineage(db, datasets, user),
     )
     completeness = _catalog_completeness(
         datasets,
@@ -318,7 +346,11 @@ async def validate_dcat3_catalog(
     datasets = await _get_visible_dcat_datasets(db, user)
 
     base_url = await get_public_api_url(db, request=request)
-    catalog = catalog_to_dcat(datasets, base_url)
+    catalog = catalog_to_dcat(
+        datasets,
+        base_url,
+        lineage_by_record_id=await _visible_lineage(db, datasets, user),
+    )
     report = validate_dcat3(catalog, "Catalog")
     report.update(
         _catalog_completeness(
@@ -353,6 +385,7 @@ async def get_dcat_us3_catalog(
         datasets,
         base_url,
         catalog_contact_email=settings.dcat_contact_email,
+        lineage_by_record_id=await _visible_lineage(db, datasets, user),
     )
     fallback_fields = [
         dcat_us3_fallback_fields(dataset, settings.dcat_contact_email)
@@ -390,6 +423,7 @@ async def validate_dcat_us3_catalog(
         datasets,
         base_url,
         catalog_contact_email=settings.dcat_contact_email,
+        lineage_by_record_id=await _visible_lineage(db, datasets, user),
     )
     report = validate_dcat_us3(catalog, "Catalog")
     fallback_fields = [
@@ -414,7 +448,11 @@ async def get_geodcat_ap_catalog(
     datasets = await _get_visible_dcat_datasets(db, user, limit=limit, offset=offset)
 
     base_url = await get_public_api_url(db, request=request)
-    catalog = catalog_to_geodcat_ap(datasets, base_url)
+    catalog = catalog_to_geodcat_ap(
+        datasets,
+        base_url,
+        lineage_by_record_id=await _visible_lineage(db, datasets, user),
+    )
     completeness = _catalog_completeness(
         datasets,
         catalog,
@@ -444,7 +482,11 @@ async def validate_geodcat_ap_catalog(
     datasets = await _get_visible_dcat_datasets(db, user)
 
     base_url = await get_public_api_url(db, request=request)
-    catalog = catalog_to_geodcat_ap(datasets, base_url)
+    catalog = catalog_to_geodcat_ap(
+        datasets,
+        base_url,
+        lineage_by_record_id=await _visible_lineage(db, datasets, user),
+    )
     report = validate_geodcat_ap(catalog, "Catalog")
     report.update(
         _catalog_completeness(
@@ -474,7 +516,11 @@ async def validate_dcat3_record(
     dataset = await _get_dcat_dataset_for_export(db, dataset_id, user)
 
     base_url = await get_public_api_url(db, request=request)
-    dcat = record_to_dcat(dataset, base_url)
+    dcat = record_to_dcat(
+        dataset,
+        base_url,
+        lineage_summary=await _visible_record_lineage(db, dataset, user),
+    )
     report = validate_dcat3(dcat, "Dataset")
     fallback_fields = dcat_fallback_fields(dataset)
     report.update(
@@ -503,6 +549,7 @@ async def get_dcat_record(
         dataset,
         base_url,
         preferred_languages=preferred_languages,
+        lineage_summary=await _visible_record_lineage(db, dataset, user),
     )
     fallback_fields = dcat_fallback_fields(dataset, preferred_languages)
     return JSONResponse(
@@ -535,6 +582,7 @@ async def validate_dcat_us3_record(
         dataset,
         base_url,
         catalog_contact_email=settings.dcat_contact_email,
+        lineage_summary=await _visible_record_lineage(db, dataset, user),
     )
     report = validate_dcat_us3(dcat, "Dataset")
     fallback_fields = dcat_us3_fallback_fields(dataset, settings.dcat_contact_email)
@@ -570,6 +618,7 @@ async def get_dcat_us3_record(
         dataset,
         base_url,
         catalog_contact_email=settings.dcat_contact_email,
+        lineage_summary=await _visible_record_lineage(db, dataset, user),
     )
     fallback_fields = dcat_us3_fallback_fields(dataset, settings.dcat_contact_email)
     _ensure_conformant_dcat_us3(dcat, "Dataset")
@@ -600,7 +649,11 @@ async def validate_geodcat_ap_record(
     dataset = await _get_dcat_dataset_for_export(db, dataset_id, user)
 
     base_url = await get_public_api_url(db, request=request)
-    geodcat = record_to_geodcat_ap(dataset, base_url)
+    geodcat = record_to_geodcat_ap(
+        dataset,
+        base_url,
+        lineage_summary=await _visible_record_lineage(db, dataset, user),
+    )
     report = validate_geodcat_ap(geodcat, "Dataset")
     fallback_fields = geodcat_ap_fallback_fields(dataset)
     report.update(
@@ -627,7 +680,11 @@ async def get_geodcat_ap_record(
     dataset = await _get_dcat_dataset_for_export(db, dataset_id, user)
 
     base_url = await get_public_api_url(db, request=request)
-    geodcat = record_to_geodcat_ap(dataset, base_url)
+    geodcat = record_to_geodcat_ap(
+        dataset,
+        base_url,
+        lineage_summary=await _visible_record_lineage(db, dataset, user),
+    )
     fallback_fields = geodcat_ap_fallback_fields(dataset)
 
     return JSONResponse(

--- a/backend/app/modules/catalog/datasets/domain/helpers.py
+++ b/backend/app/modules/catalog/datasets/domain/helpers.py
@@ -130,6 +130,7 @@ def dataset_to_response(
     base_url: str | None = None,
     stac_assets=None,
     derived_from: dict | None = None,
+    lineage_summary: str | None = None,
 ) -> DatasetResponse:
     """Convert a Dataset ORM object to a DatasetResponse schema."""
     record = dataset.record
@@ -209,7 +210,13 @@ def dataset_to_response(
         last_edited_at=last_edited.timestamp,
         collections=collections,
         record_status=record.record_status,
-        lineage_summary=record.lineage_summary,
+        # fix(#1103): passed in already access-checked, like derived_from below
+        # and for the same reason — an analysis output's lineage sentence names
+        # the titles of the datasets it was built from, and a caller with no
+        # requester in hand cannot decide whether this requester may read them.
+        # Reading record.lineage_summary here instead is what leaked them; the
+        # structural guard in tests/test_analysis_provenance.py keeps it out.
+        lineage_summary=lineage_summary,
         # feat(#765): passed in already access-checked (the detail path calls
         # visible_derived_from). Not read off the record here: the list
         # builders share this function and would need a per-row check on the

--- a/backend/app/modules/catalog/datasets/domain/service_query.py
+++ b/backend/app/modules/catalog/datasets/domain/service_query.py
@@ -148,6 +148,13 @@ async def get_datasets_list(
         for row in sc_result.all():
             source_counts[row.vrt_dataset_id] = row.cnt
 
+    # fix(#1103): one visibility query for the page, not one per row.
+    from app.modules.catalog.authorization import visible_lineage_summaries
+
+    lineage = await visible_lineage_summaries(
+        db, [d.record for d in datasets], user, user_roles
+    )
+
     response_list = [
         dataset_to_response(
             d,
@@ -156,6 +163,7 @@ async def get_datasets_list(
             is_admin=is_admin,
             source_count=source_counts.get(str(d.id)),
             base_url=base_url,
+            lineage_summary=lineage[d.record_id],
         )
         for d in datasets
     ]
@@ -255,7 +263,10 @@ async def get_dataset_detail(
         user_roles = await get_user_roles(db, user) if user is not None else set()
     is_admin = "admin" in user_roles
 
-    from app.modules.catalog.authorization import visible_derived_from
+    from app.modules.catalog.authorization import (
+        visible_derived_from,
+        visible_lineage_summary,
+    )
 
     response = dataset_to_response(
         dataset,
@@ -270,6 +281,10 @@ async def get_dataset_detail(
         # source dataset.
         derived_from=await visible_derived_from(
             db, dataset.record.derived_from, user, user_roles
+        ),
+        # fix(#1103): the prose names the same datasets the reference points at.
+        lineage_summary=await visible_lineage_summary(
+            db, dataset.record, user, user_roles
         ),
     )
     # fix(#430 codex r18): genericity probe (helpers.py) keeps all draw modes.

--- a/backend/app/modules/catalog/search/router.py
+++ b/backend/app/modules/catalog/search/router.py
@@ -22,6 +22,8 @@ from app.modules.catalog.authorization import (
     apply_visibility_filter,
     check_dataset_access_or_anonymous,
     get_user_roles,
+    visible_lineage_summaries,
+    visible_lineage_summary,
 )
 from app.modules.catalog.datasets.domain.models import (
     Dataset,
@@ -236,6 +238,11 @@ async def _handle_search(
         extent_geojson_map,
     ) = await _bulk_fetch_dataset_metadata(db, datasets)
 
+    # fix(#1103): one visibility query for the page, not one per row.
+    lineage = await visible_lineage_summaries(
+        db, [d.record for d in datasets], user, user_roles
+    )
+
     features = [
         dataset_to_ogc_record(
             d,
@@ -245,6 +252,7 @@ async def _handle_search(
             spatial_extent_geojson=extent_geojson_map.get(str(d.id)),
             public_app_url=public_app_url,
             preferred_languages=preferred_languages,
+            lineage_summary=lineage[d.record_id],
         )
         for d in datasets
     ]
@@ -1200,7 +1208,7 @@ async def get_collection_item(
         )
 
     # Single visibility check (raises 404 if access denied)
-    await check_dataset_access_or_anonymous(db, dataset, record_id, user)
+    user_roles = await check_dataset_access_or_anonymous(db, dataset, record_id, user)
 
     # Query DatasetAsset rows for STAC assets
     stac_asset_rows = [
@@ -1240,6 +1248,11 @@ async def get_collection_item(
         raster_meta=item_raster_meta,
         public_app_url=public_app_url,
         preferred_languages=parse_accept_languages(request),
+        # fix(#1103): the requester passed the check above; the datasets this
+        # one was derived from are checked on their own.
+        lineage_summary=await visible_lineage_summary(
+            db, dataset.record, user, user_roles
+        ),
     )
     return JSONResponse(
         content=content,

--- a/backend/app/modules/catalog/search/service_records.py
+++ b/backend/app/modules/catalog/search/service_records.py
@@ -187,12 +187,20 @@ def dataset_to_ogc_record(
     spatial_extent_geojson: str | None = None,
     public_app_url: str | None = None,
     preferred_languages: Sequence[str] | None = None,
+    lineage_summary: str | None = None,
 ) -> dict:
     """Convert a Dataset ORM object to an OGC Record GeoJSON Feature dict.
 
     ``public_app_url`` is threaded to :func:`build_assets` so the raster/VRT
     ``raster_tiles`` asset href uses the app origin (see that function's
     docstring); all other assets/links remain on ``public_api_url``.
+
+    fix(#1103): ``lineage_summary`` arrives access-checked from the caller
+    (``visible_lineage_summary``) rather than being read off the record, because
+    an analysis output's lineage names the titles of the datasets it was derived
+    from and this function has no requester to check them against. Omitted when
+    the caller does not supply it: a missing sentence is recoverable, a leaked
+    one is not.
     """
     record = dataset.record
     localized = select_localized_record_text(record, preferred_languages)
@@ -349,7 +357,7 @@ def dataset_to_ogc_record(
             ),
             "time": record_time,
             # ISO governance fields (API-01)
-            "lineage": record.lineage_summary,
+            "lineage": lineage_summary,
             "update_frequency": record.update_frequency,
             "constraints": (
                 {"usage": record.usage_constraints, "access": record.access_constraints}

--- a/backend/app/standards/dcat/service.py
+++ b/backend/app/standards/dcat/service.py
@@ -7,7 +7,8 @@ W3C DCAT 3 Recommendation: https://www.w3.org/TR/vocab-dcat-3/
 from __future__ import annotations
 
 import structlog
-from collections.abc import Sequence
+import uuid
+from collections.abc import Mapping, Sequence
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING
 
@@ -247,6 +248,7 @@ def record_to_dcat(
     *,
     include_context: bool = True,
     preferred_languages: Sequence[str] | None = None,
+    lineage_summary: str | None = None,
 ) -> dict:
     """Serialize a Dataset (with loaded record relationships) to DCAT 3 JSON-LD.
 
@@ -255,6 +257,11 @@ def record_to_dcat(
         base_url: Absolute base URL (e.g. ``http://localhost:8000``).
         include_context: Include ``@context`` in output. Set to False for
             individual entries within a catalog feed to avoid duplication.
+        lineage_summary: ``dcterms:provenance``, already access-checked by the
+            caller (``visible_lineage_summary``). fix(#1103): not read off the
+            record — an analysis output's lineage names the titles of the
+            datasets it was derived from, and this feed is served to anonymous
+            requesters. Omitted when absent.
 
     Returns:
         A plain dict suitable for JSON serialization as JSON-LD.
@@ -312,9 +319,9 @@ def record_to_dcat(
     if record.license is not None:
         result["dcterms:license"] = record.license
 
-    if record.lineage_summary is not None:
+    if lineage_summary is not None:
         result["dcterms:provenance"] = {
-            "@value": record.lineage_summary,
+            "@value": lineage_summary,
             "@language": source_lang,
         }
 
@@ -427,6 +434,7 @@ def catalog_to_dcat(
     base_url: str,
     *,
     preferred_languages: Sequence[str] | None = None,
+    lineage_by_record_id: Mapping[uuid.UUID, str | None] | None = None,
 ) -> dict:
     """Serialize a list of visible datasets to a DCAT 3 Catalog JSON-LD dict.
 
@@ -441,12 +449,14 @@ def catalog_to_dcat(
     Returns:
         A DCAT Catalog dict with nested dataset entries (without individual @context).
     """
+    lineage = lineage_by_record_id or {}
     entries = [
         record_to_dcat(
             ds,
             base_url,
             include_context=False,
             preferred_languages=preferred_languages,
+            lineage_summary=lineage.get(ds.record_id),
         )
         for ds in datasets
     ]

--- a/backend/app/standards/dcat_us/service.py
+++ b/backend/app/standards/dcat_us/service.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from datetime import date, datetime, timezone
 import re
+import uuid
 from typing import TYPE_CHECKING
 
 import structlog
@@ -29,8 +31,15 @@ def record_to_dcat_us3(
     *,
     include_context: bool = True,
     catalog_contact_email: str | None = None,
+    lineage_summary: str | None = None,
 ) -> dict:
-    """Serialize a GeoLens dataset to the DCAT-US Schema v3.0 profile."""
+    """Serialize a GeoLens dataset to the DCAT-US Schema v3.0 profile.
+
+    ``lineage_summary`` arrives access-checked from the caller
+    (``visible_lineage_summary``) rather than off the record — fix(#1103): an
+    analysis output's lineage names the titles of the datasets it was derived
+    from, and this feed is served to anonymous requesters.
+    """
     record = dataset.record
     result: dict = {}
 
@@ -81,8 +90,8 @@ def record_to_dcat_us3(
         # the filter-the-feed posture that silently dropped it from the catalog.
         result["rights"] = [record.usage_constraints]
 
-    if record.lineage_summary is not None:
-        result["provenance"] = [record.lineage_summary]
+    if lineage_summary is not None:
+        result["provenance"] = [lineage_summary]
 
     temporal = _temporal_to_dcat_us3(record)
     if temporal is not None:
@@ -115,6 +124,7 @@ def catalog_to_dcat_us3(
     base_url: str,
     *,
     catalog_contact_email: str | None = None,
+    lineage_by_record_id: Mapping[uuid.UUID, str | None] | None = None,
 ) -> dict:
     """Serialize visible datasets to a DCAT-US 3.0 Catalog document.
 
@@ -124,12 +134,14 @@ def catalog_to_dcat_us3(
     truthful and validation reports the unresolved mandatory field.
     """
     now = datetime.now(timezone.utc).isoformat()
+    lineage = lineage_by_record_id or {}
     entries = [
         record_to_dcat_us3(
             ds,
             base_url,
             include_context=False,
             catalog_contact_email=catalog_contact_email,
+            lineage_summary=lineage.get(ds.record_id),
         )
         for ds in datasets
     ]

--- a/backend/app/standards/geodcat_ap/service.py
+++ b/backend/app/standards/geodcat_ap/service.py
@@ -15,6 +15,8 @@ References:
 from __future__ import annotations
 
 import structlog
+import uuid
+from collections.abc import Mapping
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING
 
@@ -78,6 +80,7 @@ def record_to_geodcat_ap(
     base_url: str,
     *,
     include_context: bool = True,
+    lineage_summary: str | None = None,
 ) -> dict:
     """Serialize a GeoLens dataset to GeoDCAT-AP 2.0.0 JSON-LD.
 
@@ -87,6 +90,11 @@ def record_to_geodcat_ap(
         base_url: Absolute base URL (e.g. ``http://localhost:8000``).
         include_context: Include ``@context``. Set to False for entries nested
             inside a catalog feed to avoid duplicating the context.
+        lineage_summary: ``dcterms:provenance``, already access-checked by the
+            caller (``visible_lineage_summary``). fix(#1103): not read off the
+            record — an analysis output's lineage names the titles of the
+            datasets it was derived from, and this feed is served to anonymous
+            requesters.
 
     Returns:
         A plain dict suitable for JSON serialization as JSON-LD.
@@ -128,10 +136,10 @@ def record_to_geodcat_ap(
         result["dcterms:license"] = record.license
 
     # Lineage → provenance (GeoDCAT-AP: dcterms:provenance / prov:Activity).
-    if record.lineage_summary is not None:
+    if lineage_summary is not None:
         result["dcterms:provenance"] = {
             "@type": "dcterms:ProvenanceStatement",
-            "rdfs:label": {"@value": record.lineage_summary, "@language": lang},
+            "rdfs:label": {"@value": lineage_summary, "@language": lang},
         }
 
     # Maintenance / update frequency (ISO MD_MaintenanceFrequencyCode).
@@ -193,7 +201,12 @@ def record_to_geodcat_ap(
     return {k: v for k, v in result.items() if v is not None}
 
 
-def catalog_to_geodcat_ap(datasets: list[Dataset], base_url: str) -> dict:
+def catalog_to_geodcat_ap(
+    datasets: list[Dataset],
+    base_url: str,
+    *,
+    lineage_by_record_id: Mapping[uuid.UUID, str | None] | None = None,
+) -> dict:
     """Serialize a list of visible datasets to a GeoDCAT-AP Catalog JSON-LD dict.
 
     Args:
@@ -208,8 +221,15 @@ def catalog_to_geodcat_ap(datasets: list[Dataset], base_url: str) -> dict:
     same deterministic title-based fallback as the per-dataset serializer, so
     catalog validation cannot hide published records by filtering them first.
     """
+    lineage = lineage_by_record_id or {}
     entries = [
-        record_to_geodcat_ap(ds, base_url, include_context=False) for ds in datasets
+        record_to_geodcat_ap(
+            ds,
+            base_url,
+            include_context=False,
+            lineage_summary=lineage.get(ds.record_id),
+        )
+        for ds in datasets
     ]
 
     return {

--- a/backend/app/standards/stac/router.py
+++ b/backend/app/standards/stac/router.py
@@ -34,7 +34,11 @@ from app.modules.auth.dependencies import (
     get_optional_user_no_security_schema,
     get_optional_user_or_401,
 )
-from app.modules.catalog.authorization import apply_visibility_filter, get_user_roles
+from app.modules.catalog.authorization import (
+    apply_visibility_filter,
+    get_user_roles,
+    visible_lineage_summary,
+)
 from app.modules.catalog.datasets.domain.models import (
     Dataset,
     DatasetGrant,
@@ -275,6 +279,12 @@ async def _dataset_to_stac_item(
         spatial_extent_geojson=spatial_extent_geojson,
         public_app_url=public_app_url,
         preferred_languages=preferred_languages,
+        # fix(#1103): the prose names the same datasets the derived_from link
+        # below points at, and is gated the same way — per requester, on each
+        # referenced dataset rather than on the output they can already see.
+        lineage_summary=await visible_lineage_summary(
+            db, record, user, user_roles or set()
+        ),
     )
 
     # Re-build assets with storage_provider for presigned URLs

--- a/backend/app/standards/stac/router.py
+++ b/backend/app/standards/stac/router.py
@@ -14,6 +14,7 @@ import re
 import uuid
 from collections.abc import Sequence
 from datetime import datetime, timedelta
+from typing import Any
 
 from urllib.parse import urlencode
 
@@ -37,6 +38,7 @@ from app.modules.auth.dependencies import (
 from app.modules.catalog.authorization import (
     apply_visibility_filter,
     get_user_roles,
+    visible_lineage_summaries,
     visible_lineage_summary,
 )
 from app.modules.catalog.datasets.domain.models import (
@@ -242,6 +244,11 @@ async def _fetch_raster_meta(
     return await fetch_raster_meta_bulk(db, dataset_ids, include_vrt=False)
 
 
+# fix(#1108 review): sentinel distinguishing "the page loop did not precompute
+# lineage" from a precomputed None (a record with no lineage at all).
+_LINEAGE_UNRESOLVED: Any = object()
+
+
 async def _dataset_to_stac_item(
     db: AsyncSession,
     dataset: Dataset,
@@ -256,6 +263,7 @@ async def _dataset_to_stac_item(
     preferred_languages: Sequence[str] | None = None,
     user: Identity | None = None,
     user_roles: set[str] | None = None,
+    lineage_summary: Any = _LINEAGE_UNRESOLVED,
 ) -> dict:
     """Convert a Dataset ORM object to a STAC Item dict with presigned URLs.
 
@@ -282,8 +290,13 @@ async def _dataset_to_stac_item(
         # fix(#1103): the prose names the same datasets the derived_from link
         # below points at, and is gated the same way — per requester, on each
         # referenced dataset rather than on the output they can already see.
-        lineage_summary=await visible_lineage_summary(
-            db, record, user, user_roles or set()
+        # fix(#1108 review): page loops precompute the whole page through
+        # visible_lineage_summaries (one query per page, mirroring PERF-5's
+        # spatial_extent_geojson); only single-item callers resolve here.
+        lineage_summary=(
+            await visible_lineage_summary(db, record, user, user_roles or set())
+            if lineage_summary is _LINEAGE_UNRESOLVED
+            else lineage_summary
         ),
     )
 
@@ -1077,6 +1090,12 @@ async def get_collection_items(
         _assets(), _raster(), _extents()
     )
 
+    # fix(#1108 review): lineage visibility for the whole page in one query
+    # instead of one visible_lineage_summary round trip per item.
+    lineage_map = await visible_lineage_summaries(
+        db, [d.record for d in datasets], user, user_roles or set()
+    )
+
     features = []
     coll_id_str = str(collection_id)
     for dataset in datasets:
@@ -1093,6 +1112,7 @@ async def get_collection_items(
             preferred_languages=parse_accept_languages(request),
             user=user,
             user_roles=user_roles,
+            lineage_summary=lineage_map[dataset.record.id],
         )
         features.append(item)
 
@@ -1577,6 +1597,12 @@ async def _execute_search(
         _assets(), _raster(), _coll_membership()
     )
 
+    # fix(#1108 review): lineage visibility for the whole page in one query
+    # instead of one visible_lineage_summary round trip per item.
+    lineage_map = await visible_lineage_summaries(
+        db, [d.record for d in datasets], user, user_roles or set()
+    )
+
     # Convert to STAC Items
     features = []
     for dataset in datasets:
@@ -1594,6 +1620,7 @@ async def _execute_search(
             preferred_languages=preferred_languages,
             user=user,
             user_roles=user_roles,
+            lineage_summary=lineage_map[dataset.record.id],
         )
         features.append(item)
 

--- a/backend/tests/test_analysis_provenance.py
+++ b/backend/tests/test_analysis_provenance.py
@@ -13,6 +13,7 @@ import ast
 import uuid
 from datetime import datetime, timezone
 from pathlib import Path
+from types import SimpleNamespace
 from typing import NamedTuple
 
 import pytest
@@ -882,10 +883,13 @@ class TestLineageSummaryVisibility:
         lineage = other.json()["lineage_summary"]
         assert clip.mask_title not in lineage
         assert str(clip.mask_id) not in lineage
-        assert "another layer" in lineage
-        # The public source is still named: this redacts per dataset, not per
-        # sentence, so a requester keeps everything they could have looked up.
-        assert clip.source_title in lineage
+        # fix(#1108 review): all-or-nothing — the sentence interleaves
+        # attacker-influenced free text with the titles, so no in-place edit of
+        # it is trustworthy. A viewer missing ANY referenced dataset gets the
+        # constant; the source title they could look up stays available in the
+        # structured derived_from reference, not in prose.
+        assert lineage == "Derived from another dataset."
+        assert clip.source_title not in lineage
 
         admin = await client.get(
             f"/datasets/{clip.output_id}", headers=admin_auth_header
@@ -922,7 +926,7 @@ class TestLineageSummaryVisibility:
         assert clip.source_title not in lineage
         assert clip.mask_title not in lineage
         assert str(clip.source_id) not in lineage
-        assert lineage.startswith("Clipped from another dataset to another layer")
+        assert lineage == "Derived from another dataset."
 
         owner = await client.get(
             f"/datasets/{clip.output_id}", headers=editor_auth_header
@@ -961,7 +965,7 @@ class TestLineageSummaryVisibility:
             assert str(clip.mask_id) not in resp.text, url
             # Redacted, not dropped. Without this a surface that simply stopped
             # serving the sentence would satisfy the two assertions above.
-            assert "another layer" in resp.text, url
+            assert "Derived from another dataset." in resp.text, url
 
         # The feeds carry every visible dataset, so only the negative holds.
         for url in ("/datasets/", "/datasets/dcat/", "/datasets/geodcat-ap/"):
@@ -976,70 +980,53 @@ class TestLineageSummaryVisibility:
         )
         assert clip.mask_title in owner_detail.text
 
-    def test_a_sentence_that_cannot_be_aligned_is_replaced_whole(self):
-        """The positional mapping is only safe while it can be checked.
+    async def test_prose_is_never_edited_only_passed_or_replaced(self):
+        """fix(#1108 review): the forgery family that killed span editing.
 
-        A source whose title was already unreadable renders as a bare phrase, so
-        the mask's title becomes the FIRST quoted span and a slot-by-slot
-        redaction would hand it to a requester who may not see it. Fewer spans
-        than referenced datasets is exactly that case, and the sentence is
-        replaced whole rather than edited by guesswork.
+        Three review rounds each broke an in-place edit of the sentence: an
+        unnamed source shifted every span onto the wrong dataset; embedded
+        quotes in a hidden title (odd or even) corrupted the span boundaries so
+        fragments survived between them; and quote characters in NON-title free
+        text (an actor name) compensated for a missing title so even a
+        quote-character count read as aligned. The sentence interleaves
+        attacker-influenced free text with the secrets, so the rule is binary —
+        and this pins that no shape of stored prose changes it: whatever the
+        text contains, a restricted viewer gets the constant and nothing else.
         """
         from app.modules.catalog.authorization import (
             _REDACTED_SUMMARY,
-            _redact_quoted_titles,
+            visible_lineage_summaries,
         )
 
-        sentence = (
-            'Clipped from an unnamed dataset to "Flood Zone", '
-            "created by admin on 2026-07-31."
-        )
-        redacted = _redact_quoted_titles(sentence, [uuid.uuid4(), uuid.uuid4()], {1})
-        assert "Flood Zone" not in redacted
-        assert redacted == _REDACTED_SUMMARY
-
-    def test_a_hidden_title_containing_a_quote_leaves_no_fragment(self):
-        """fix(#1108 review): a quote INSIDE a hidden title splits the span scan.
-
-        ``"Flood "Zone" map"`` reads as two spans with ``Zone`` stranded between
-        them; redacting span-by-span would keep that fragment readable. The
-        count mismatch such a title always produces must therefore replace the
-        whole sentence, not just the spans it happened to detect.
-        """
-        from app.modules.catalog.authorization import (
-            _REDACTED_SUMMARY,
-            _redact_quoted_titles,
-        )
-
-        sentence = (
-            'Clipped from "Roads" to "Flood "Zone" map", '
-            "created by admin on 2026-07-31."
-        )
-        redacted = _redact_quoted_titles(sentence, [uuid.uuid4(), uuid.uuid4()], {1})
-        assert redacted == _REDACTED_SUMMARY
-        assert "Zone" not in redacted
-        assert "Flood" not in redacted
-
-    def test_an_odd_quote_count_cannot_fake_alignment(self):
-        """fix(#1108 review): an odd embedded quote makes the SPAN counts agree.
-
-        ``"Flood "Zone`` wraps to ``"Flood "Zone"`` — the scan sees ``"Roads"``
-        and ``"Flood "`` and counts two spans for two datasets, so a span-count
-        guard passes while slot 1's replacement strands ``Zone"`` in the clear.
-        Counting quote CHARACTERS (two per clean title, embedded ones only add)
-        is the test that cannot coincide.
-        """
-        from app.modules.catalog.authorization import (
-            _REDACTED_SUMMARY,
-            _redact_quoted_titles,
-        )
-
-        sentence = (
-            'Clipped from "Roads" to "Flood "Zone", created by admin on 2026-07-31.'
-        )
-        redacted = _redact_quoted_titles(sentence, [uuid.uuid4(), uuid.uuid4()], {1})
-        assert redacted == _REDACTED_SUMMARY
-        assert "Zone" not in redacted
+        hidden_mask = uuid.uuid4()
+        adversarial_sentences = [
+            # round 1: even embedded quotes — fragments between spans
+            'Clipped from "Roads" to "Flood "Zone" map", created by admin.',
+            # round 2: odd embedded quote — span counts coincide
+            'Clipped from "Roads" to "Flood "Zone", created by admin.',
+            # round 3: unnamed source + quoted actor — char counts coincide
+            'Clipped from an unnamed dataset to "Secret Zone", created by "bob".',
+            # plain prose, nothing adversarial at all
+            'Clipped from "Roads" to "Secret Zone", created by admin.',
+        ]
+        for sentence in adversarial_sentences:
+            record = SimpleNamespace(
+                id=uuid.uuid4(),
+                lineage_summary=sentence,
+                derived_from={
+                    "operation": "clip",
+                    "dataset_id": str(uuid.uuid4()),
+                    "params": {"mask_dataset_id": str(hidden_mask)},
+                },
+            )
+            # No DB session needed: an unresolvable dataset id is unprovable,
+            # hence hidden — but _accessible_dataset_ids still runs, so give it
+            # a session-shaped refusal by making every id unparseable instead.
+            record.derived_from["dataset_id"] = "not-a-uuid"
+            record.derived_from["params"]["mask_dataset_id"] = "also-not-a-uuid"
+            result = await visible_lineage_summaries(None, [record], None, set())
+            assert result[record.id] == _REDACTED_SUMMARY, sentence
+            assert "Zone" not in result[record.id], sentence
 
     async def test_a_record_with_no_provenance_costs_no_query(self):
         """Hand-written lineage is not assembled from other datasets' titles.

--- a/backend/tests/test_analysis_provenance.py
+++ b/backend/tests/test_analysis_provenance.py
@@ -1020,6 +1020,27 @@ class TestLineageSummaryVisibility:
         assert "Zone" not in redacted
         assert "Flood" not in redacted
 
+    def test_an_odd_quote_count_cannot_fake_alignment(self):
+        """fix(#1108 review): an odd embedded quote makes the SPAN counts agree.
+
+        ``"Flood "Zone`` wraps to ``"Flood "Zone"`` — the scan sees ``"Roads"``
+        and ``"Flood "`` and counts two spans for two datasets, so a span-count
+        guard passes while slot 1's replacement strands ``Zone"`` in the clear.
+        Counting quote CHARACTERS (two per clean title, embedded ones only add)
+        is the test that cannot coincide.
+        """
+        from app.modules.catalog.authorization import (
+            _REDACTED_SUMMARY,
+            _redact_quoted_titles,
+        )
+
+        sentence = (
+            'Clipped from "Roads" to "Flood "Zone", created by admin on 2026-07-31.'
+        )
+        redacted = _redact_quoted_titles(sentence, [uuid.uuid4(), uuid.uuid4()], {1})
+        assert redacted == _REDACTED_SUMMARY
+        assert "Zone" not in redacted
+
     async def test_a_record_with_no_provenance_costs_no_query(self):
         """Hand-written lineage is not assembled from other datasets' titles.
 

--- a/backend/tests/test_analysis_provenance.py
+++ b/backend/tests/test_analysis_provenance.py
@@ -976,16 +976,19 @@ class TestLineageSummaryVisibility:
         )
         assert clip.mask_title in owner_detail.text
 
-    def test_a_sentence_that_cannot_be_aligned_loses_every_title(self):
+    def test_a_sentence_that_cannot_be_aligned_is_replaced_whole(self):
         """The positional mapping is only safe while it can be checked.
 
         A source whose title was already unreadable renders as a bare phrase, so
         the mask's title becomes the FIRST quoted span and a slot-by-slot
         redaction would hand it to a requester who may not see it. Fewer spans
-        than referenced datasets is exactly that case, and it redacts all of
-        them rather than guessing.
+        than referenced datasets is exactly that case, and the sentence is
+        replaced whole rather than edited by guesswork.
         """
-        from app.modules.catalog.authorization import _redact_quoted_titles
+        from app.modules.catalog.authorization import (
+            _REDACTED_SUMMARY,
+            _redact_quoted_titles,
+        )
 
         sentence = (
             'Clipped from an unnamed dataset to "Flood Zone", '
@@ -993,7 +996,29 @@ class TestLineageSummaryVisibility:
         )
         redacted = _redact_quoted_titles(sentence, [uuid.uuid4(), uuid.uuid4()], {1})
         assert "Flood Zone" not in redacted
-        assert redacted.startswith("Clipped from an unnamed dataset to another dataset")
+        assert redacted == _REDACTED_SUMMARY
+
+    def test_a_hidden_title_containing_a_quote_leaves_no_fragment(self):
+        """fix(#1108 review): a quote INSIDE a hidden title splits the span scan.
+
+        ``"Flood "Zone" map"`` reads as two spans with ``Zone`` stranded between
+        them; redacting span-by-span would keep that fragment readable. The
+        count mismatch such a title always produces must therefore replace the
+        whole sentence, not just the spans it happened to detect.
+        """
+        from app.modules.catalog.authorization import (
+            _REDACTED_SUMMARY,
+            _redact_quoted_titles,
+        )
+
+        sentence = (
+            'Clipped from "Roads" to "Flood "Zone" map", '
+            "created by admin on 2026-07-31."
+        )
+        redacted = _redact_quoted_titles(sentence, [uuid.uuid4(), uuid.uuid4()], {1})
+        assert redacted == _REDACTED_SUMMARY
+        assert "Zone" not in redacted
+        assert "Flood" not in redacted
 
     async def test_a_record_with_no_provenance_costs_no_query(self):
         """Hand-written lineage is not assembled from other datasets' titles.

--- a/backend/tests/test_analysis_provenance.py
+++ b/backend/tests/test_analysis_provenance.py
@@ -9,8 +9,11 @@ Requirements:
   - Docker database must be running (docker compose up db)
 """
 
+import ast
 import uuid
-from datetime import datetime
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import NamedTuple
 
 import pytest
 from httpx import AsyncClient
@@ -18,7 +21,10 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.modules.catalog.datasets.domain.models import Dataset, Record, RecordKeyword
-from app.processing.analysis.provenance import build_lineage_sentence
+from app.processing.analysis.provenance import (
+    build_derived_from,
+    build_lineage_sentence,
+)
 from app.processing.analysis.tasks import _materialize
 from app.standards.stac.serializer import _build_stac_links
 
@@ -755,3 +761,320 @@ class TestStacDerivedFromLink:
         assert (
             await _visible_derived_from_id(test_db_session, record, None, set())
         ) is None
+
+
+class _ClipOutput(NamedTuple):
+    """A published output whose stored lineage names two other datasets."""
+
+    source_id: uuid.UUID
+    source_title: str
+    mask_id: uuid.UUID
+    mask_title: str
+    output_id: uuid.UUID
+    sentence: str
+
+
+async def _published_clip_output(
+    session: AsyncSession,
+    owner_id: uuid.UUID,
+    *,
+    source_visibility: str = "public",
+    mask_visibility: str = "private",
+) -> _ClipOutput:
+    """Register the record state a clip materialize leaves behind.
+
+    The sentence and the reference come from the real generators rather than a
+    hand-typed string: the redaction is only worth anything against what
+    ``apply_analysis_provenance`` actually writes. The analysis itself is not
+    re-run here — the write path has its own tests above, and this is a read
+    path.
+    """
+    source = await _create_polygon_dataset(
+        session, created_by=owner_id, visibility=source_visibility
+    )
+    mask = await _create_polygon_dataset(
+        session, created_by=owner_id, visibility=mask_visibility
+    )
+    output = await _create_polygon_dataset(
+        session, created_by=owner_id, visibility="public"
+    )
+
+    source_title = f"Parcels {uuid.uuid4().hex[:6]}"
+    mask_title = f"Flood Zone {uuid.uuid4().hex[:6]}"
+    source_record = await _record_of(session, source)
+    mask_record = await _record_of(session, mask)
+    source_record.title = source_title
+    mask_record.title = mask_title
+
+    params = {"mask_source": "layer", "mask_dataset_id": str(mask.id)}
+    created_at = datetime(2026, 7, 31, tzinfo=timezone.utc)
+    sentence = build_lineage_sentence(
+        operation="clip",
+        source_title=source_title,
+        params=params,
+        actor="owner",
+        created_at=created_at,
+        mask_title=mask_title,
+    )
+    output_record = await _record_of(session, output)
+    output_record.lineage_summary = sentence
+    output_record.derived_from = build_derived_from(
+        source_dataset_id=str(source.id),
+        operation="clip",
+        params=params,
+        created_at=created_at,
+    )
+    await session.commit()
+
+    return _ClipOutput(
+        source_id=source.id,
+        source_title=source_title,
+        mask_id=mask.id,
+        mask_title=mask_title,
+        output_id=output.id,
+        sentence=sentence,
+    )
+
+
+class TestLineageSummaryVisibility:
+    """fix(#1103): the prose is stored once; the redaction is per requester.
+
+    ``lineage_summary`` names the TITLE of every dataset an analysis output was
+    built from, and it was served raw to everyone who could see the output — so
+    a published clip of a public layer against a private mask told every viewer
+    that mask's name and that it exists. That is the disclosure
+    ``visible_derived_from`` prevents for the mask's ID, arriving by a channel
+    that had no redaction.
+    """
+
+    async def test_a_private_masks_title_reaches_only_requesters_who_can_open_it(
+        self,
+        client: AsyncClient,
+        test_db_session: AsyncSession,
+        admin_auth_header: dict,
+        editor_auth_header: dict,
+        viewer_auth_header: dict,
+    ):
+        """Three requesters, one stored sentence.
+
+        The owner ran the analysis and can open both layers, so they get the
+        sentence as written. The viewer can open the output and the public
+        source but not the mask, so only the mask's title goes — and it is
+        replaced by the phrase the generator itself uses for a title it could
+        not read, not by the mask's id, which _DATASET_ID_PARAMS withholds for
+        the same reason. An admin is not filtered at all.
+        """
+        owner_id = uuid.UUID(
+            (await client.get("/auth/me/", headers=editor_auth_header)).json()["id"]
+        )
+        clip = await _published_clip_output(test_db_session, owner_id)
+
+        owner = await client.get(
+            f"/datasets/{clip.output_id}", headers=editor_auth_header
+        )
+        assert owner.status_code == 200, owner.text
+        assert owner.json()["lineage_summary"] == clip.sentence
+
+        other = await client.get(
+            f"/datasets/{clip.output_id}", headers=viewer_auth_header
+        )
+        assert other.status_code == 200, other.text
+        lineage = other.json()["lineage_summary"]
+        assert clip.mask_title not in lineage
+        assert str(clip.mask_id) not in lineage
+        assert "another layer" in lineage
+        # The public source is still named: this redacts per dataset, not per
+        # sentence, so a requester keeps everything they could have looked up.
+        assert clip.source_title in lineage
+
+        admin = await client.get(
+            f"/datasets/{clip.output_id}", headers=admin_auth_header
+        )
+        assert admin.status_code == 200, admin.text
+        assert admin.json()["lineage_summary"] == clip.sentence
+
+    async def test_a_private_source_title_goes_with_it(
+        self,
+        client: AsyncClient,
+        test_db_session: AsyncSession,
+        editor_auth_header: dict,
+        viewer_auth_header: dict,
+    ):
+        """The source is a dataset the requester may not reach either.
+
+        ``visible_derived_from`` already drops the whole reference in this case;
+        the prose keeps its shape and loses both titles.
+        """
+        owner_id = uuid.UUID(
+            (await client.get("/auth/me/", headers=editor_auth_header)).json()["id"]
+        )
+        clip = await _published_clip_output(
+            test_db_session, owner_id, source_visibility="private"
+        )
+
+        other = await client.get(
+            f"/datasets/{clip.output_id}", headers=viewer_auth_header
+        )
+        assert other.status_code == 200, other.text
+        payload = other.json()
+        assert payload["derived_from"] is None
+        lineage = payload["lineage_summary"]
+        assert clip.source_title not in lineage
+        assert clip.mask_title not in lineage
+        assert str(clip.source_id) not in lineage
+        assert lineage.startswith("Clipped from another dataset to another layer")
+
+        owner = await client.get(
+            f"/datasets/{clip.output_id}", headers=editor_auth_header
+        )
+        assert owner.json()["lineage_summary"] == clip.sentence
+
+    async def test_no_read_surface_serves_the_hidden_title(
+        self,
+        client: AsyncClient,
+        test_db_session: AsyncSession,
+        editor_auth_header: dict,
+        viewer_auth_header: dict,
+    ):
+        """Every payload that carries the sentence, not just the dataset page.
+
+        The issue is that ``lineage_summary`` is read by five serializers — the
+        dataset response, the OGC record properties, and the three DCAT
+        profiles — and a fix that only covers the one the bug was reported
+        against leaves the same title on a catalog feed an anonymous harvester
+        can pull.
+        """
+        owner_id = uuid.UUID(
+            (await client.get("/auth/me/", headers=editor_auth_header)).json()["id"]
+        )
+        clip = await _published_clip_output(test_db_session, owner_id)
+
+        for url in (
+            f"/datasets/{clip.output_id}",
+            f"/datasets/{clip.output_id}/dcat/",
+            f"/datasets/{clip.output_id}/geodcat-ap/",
+            f"/collections/datasets/items/{clip.output_id}",
+        ):
+            resp = await client.get(url, headers=viewer_auth_header)
+            assert resp.status_code == 200, f"{url}: {resp.text}"
+            assert clip.mask_title not in resp.text, url
+            assert str(clip.mask_id) not in resp.text, url
+            # Redacted, not dropped. Without this a surface that simply stopped
+            # serving the sentence would satisfy the two assertions above.
+            assert "another layer" in resp.text, url
+
+        # The feeds carry every visible dataset, so only the negative holds.
+        for url in ("/datasets/", "/datasets/dcat/", "/datasets/geodcat-ap/"):
+            resp = await client.get(url, headers=viewer_auth_header)
+            assert resp.status_code == 200, f"{url}: {resp.text}"
+            assert clip.mask_title not in resp.text, url
+            assert str(clip.mask_id) not in resp.text, url
+
+        # ...and the owner still gets the prose on the same surfaces.
+        owner_detail = await client.get(
+            f"/datasets/{clip.output_id}/dcat/", headers=editor_auth_header
+        )
+        assert clip.mask_title in owner_detail.text
+
+    def test_a_sentence_that_cannot_be_aligned_loses_every_title(self):
+        """The positional mapping is only safe while it can be checked.
+
+        A source whose title was already unreadable renders as a bare phrase, so
+        the mask's title becomes the FIRST quoted span and a slot-by-slot
+        redaction would hand it to a requester who may not see it. Fewer spans
+        than referenced datasets is exactly that case, and it redacts all of
+        them rather than guessing.
+        """
+        from app.modules.catalog.authorization import _redact_quoted_titles
+
+        sentence = (
+            'Clipped from an unnamed dataset to "Flood Zone", '
+            "created by admin on 2026-07-31."
+        )
+        redacted = _redact_quoted_titles(sentence, [uuid.uuid4(), uuid.uuid4()], {1})
+        assert "Flood Zone" not in redacted
+        assert redacted.startswith("Clipped from an unnamed dataset to another dataset")
+
+    async def test_a_record_with_no_provenance_costs_no_query(self):
+        """Hand-written lineage is not assembled from other datasets' titles.
+
+        It is also the common case by a wide margin: passing ``None`` for the
+        session proves the redaction never reaches the database for a record
+        with no ``derived_from``, which is what makes it affordable on a page
+        of results.
+        """
+        from app.modules.catalog.authorization import visible_lineage_summaries
+
+        record = Record(
+            id=uuid.uuid4(),
+            title="Plain",
+            lineage_summary="Compiled from the 2024 field survey.",
+        )
+        assert await visible_lineage_summaries(None, [record], None, set()) == {
+            record.id: "Compiled from the 2024 field survey."
+        }
+
+    def test_an_unparseable_provenance_id_counts_as_inaccessible(self):
+        """Access to it cannot be established, so its title is withheld."""
+        from app.modules.catalog.authorization import _provenance_dataset_ids
+
+        assert _provenance_dataset_ids({"dataset_id": "not-a-uuid"}) == [None]
+
+    def test_no_read_path_serves_lineage_summary_unchecked(self):
+        """Structural: only the redaction may read the column for a payload.
+
+        The failure mode is silence — a new serializer reads
+        ``record.lineage_summary``, the payload looks correct, and someone
+        else's private layer is named in it. Every serializer takes the prose as
+        an argument now, so a caller that forgets emits no lineage instead.
+
+        Additions to the allowlist are fine when the read is not a
+        requester-facing payload; say which, and why, in the value.
+        """
+        allowed = {
+            "app/modules/catalog/authorization.py": (
+                "the redaction itself — visible_lineage_summaries"
+            ),
+            "app/modules/catalog/search/service_filters.py": (
+                "Record.lineage_summary as a SQL expression in the FTS filter; "
+                "it selects rows, it does not serialize a value"
+            ),
+            "app/modules/catalog/validation/service.py": (
+                "VAL-01 completeness — tests presence, never emits the value"
+            ),
+            "app/processing/ingest/metadata.py": (
+                "metadata completeness scoring on the record's own fields"
+            ),
+            "app/processing/ai/metadata_service.py": (
+                "the suggestion prompt for the record's own editor, who is "
+                "owner-or-admin on it"
+            ),
+            "app/processing/embeddings/tasks.py": (
+                "embedding index text; the vector is not served back as prose"
+            ),
+            "app/processing/embeddings/backfill.py": (
+                "embedding index text; the vector is not served back as prose"
+            ),
+        }
+
+        app_root = Path(__file__).resolve().parents[1] / "app"
+        offenders: list[str] = []
+        for path in sorted(app_root.rglob("*.py")):
+            rel = f"app/{path.relative_to(app_root).as_posix()}"
+            if rel in allowed:
+                continue
+            tree = ast.parse(path.read_text(encoding="utf-8"))
+            for node in ast.walk(tree):
+                if (
+                    isinstance(node, ast.Attribute)
+                    and node.attr == "lineage_summary"
+                    and isinstance(node.ctx, ast.Load)
+                ):
+                    offenders.append(f"{rel}:{node.lineno}")
+
+        assert not offenders, (
+            "these read lineage_summary off a record instead of taking the "
+            "access-checked value from visible_lineage_summary(), which is how "
+            "a private layer's title reaches a requester who cannot open it "
+            f"(#1103): {offenders}"
+        )

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -955,7 +955,13 @@ def test_decomposed_service_modules_stay_within_size_budgets() -> None:
         # feat(#765): +7 — the detail response resolves derived_from through
         # visible_derived_from, so a private source is never disclosed via a
         # derived dataset. Cap 397 -> 404, still no headroom.
-        "backend/app/modules/catalog/datasets/domain/service_query.py": 404,
+        # fix(#1103): +15 — the same treatment for the PROSE. Both builders in
+        # this module now resolve lineage_summary through
+        # visible_lineage_summary(ies), which is what stops a derived dataset
+        # from naming a source or mask layer the requester cannot open. The
+        # list builder takes the batch form deliberately: one visibility query
+        # for the page rather than one per row. Cap 404 -> 419, no headroom.
+        "backend/app/modules/catalog/datasets/domain/service_query.py": 419,
         # Phase 276 CODE-02: chat_*.py sub-modules are all under the 350
         # default (largest is chat_actions.py at ~245 LOC). No explicit
         # per-file overrides needed; default applies.
@@ -1359,7 +1365,13 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # ST_AsGeoJSON(ST_Envelope(ST_Collect(...))) plus its GeoJSON coordinate
     # fold onto rollup_bbox_columns()/rollup_bbox(), which also retires the
     # module's last json import. Cap lowered 1432 -> 1427, still exact.
-    "backend/app/modules/catalog/search/router.py": 1427,
+    # fix(#1103): +13 — the OGC record's `lineage` property is access-checked
+    # per requester now (the sentence names the titles of the datasets an
+    # analysis output was derived from). The item endpoint keeps the roles
+    # check_dataset_access_or_anonymous already resolved; the list endpoint
+    # takes the batch form, one visibility query per page. Cap 1427 -> 1440,
+    # still exact.
+    "backend/app/modules/catalog/search/router.py": 1440,
     # fix(#474): negotiate localized STAC record text; fix(#475) adds the
     # unassigned Collection and matching HTTP Link navigation. fix(#506): keep
     # validated STAC item responses wire-compatible with serializer output.
@@ -1376,7 +1388,10 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # source against the same published+visible query the item endpoints serve
     # from, and user/user_roles are threaded to the four item builders that
     # feed it. Cap 1789 -> 1833, still exact.
-    "backend/app/standards/stac/router.py": 1833,
+    # fix(#1103): +10 — the STAC item's lineage property is gated the same way
+    # as its derived_from link, on the user/user_roles already threaded here.
+    # Cap 1833 -> 1843, still exact.
+    "backend/app/standards/stac/router.py": 1843,
     # Central tenant-bound scope resolution replaced duplicated inline logic.
     # fix(#836): +1 — the RASTER_FAMILY_RECORD_TYPES import that replaces four
     # pasted family literals. Same +1 on the stac and search routers.

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -1391,7 +1391,11 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # fix(#1103): +10 — the STAC item's lineage property is gated the same way
     # as its derived_from link, on the user/user_roles already threaded here.
     # Cap 1833 -> 1843, still exact.
-    "backend/app/standards/stac/router.py": 1843,
+    # fix(#1108 review): +27 — the two item-page loops precompute lineage
+    # visibility for the whole page (one query, mirroring PERF-5's
+    # spatial_extent_geojson) instead of one round trip per item at limit=200.
+    # Cap 1843 -> 1870, still exact.
+    "backend/app/standards/stac/router.py": 1870,
     # Central tenant-bound scope resolution replaced duplicated inline logic.
     # fix(#836): +1 — the RASTER_FAMILY_RECORD_TYPES import that replaces four
     # pasted family literals. Same +1 on the stac and search routers.


### PR DESCRIPTION
## Problem

`lineage_summary` on a materialized analysis output (provenance, #1045/#1097) is written once at materialize time with the titles the *owner* could see, then served verbatim to any requester who can read the derived dataset — through the dataset detail/list endpoints, OGC records, STAC, and all three DCAT feeds (the anonymous-readable ones included). A public clip against a PRIVATE mask published that mask's title, and the fact that it exists, to every viewer — the exact disclosure `visible_derived_from` already prevents for the mask's *id*, arriving through a channel that had no redaction.

## Fix

Serialization-time gating in `catalog/authorization.py`: `visible_lineage_summaries(db, records, user, user_roles)` resolves every dataset a record's `derived_from` references (source + `mask_dataset_id`/`join_dataset_id`) through one `apply_visibility_filter`-ed query per page, then applies a deliberately **all-or-nothing** rule:

- a requester who can read **every** referenced dataset gets the stored sentence byte-for-byte (this includes owner-edited prose, which is never rewritten);
- a requester who cannot gets the neutral constant `Derived from another dataset.` — never any byte of the stored text.

Serializers no longer read `record.lineage_summary` directly — they take the checked value as a parameter, so a call site that forgets emits **no** lineage rather than someone else's title, and an AST guard test fails any future unchecked `Load`-context read. All read surfaces are covered: dataset detail + list, create-empty + metadata PATCH responses, collections, OGC records (list + item), STAC (with page-level batching — one visibility query per items page, mirroring the module's PERF-5 precompute pattern), DCAT, DCAT-US, GeoDCAT-AP.

### Why all-or-nothing, not per-title redaction

Per-title span editing was the first design, and review adversarially broke three successive versions of it: an unnamed source shifts every quoted span onto the wrong dataset; a hidden title containing quote characters (odd or even counts) corrupts the span boundaries so fragments of it survive between the replaced spans; and quote characters in NON-title free text (an actor name) can compensate for a missing title so even a quote-character invariant reads as aligned. The common cause: the sentence interleaves attacker-influenced free text with the protected titles, so no delimiter arithmetic over it is trustworthy. The span parser is deleted rather than patched a fourth time; the binary rule has no alignment to forge.

Two consequences, stated plainly:

- A partial-access viewer (can see the source, not the mask) loses the source title *from the prose*; they keep it in the structured `derived_from` reference, which remains per-dataset. Over-redaction is the recorded safe direction in this module.
- The redacted phrase is a constant, not the dataset's id: `_DATASET_ID_PARAMS` exists because an unresolvable id is itself a disclosure worth withholding, and prose that included it would route around the redaction that drops it from the reference.

## Verification

- `pytest tests/test_analysis_provenance.py` → 30 passed: three-user matrix (owner verbatim / restricted viewer gets exactly the constant / admin verbatim), private-source variant, an all-surfaces test (detail, DCAT, GeoDCAT, OGC item + the three feeds), a forgery-family regression test pinning all three review payloads plus plain prose to the constant, a `db=None` proof that records without `derived_from` cost zero queries, and the AST no-unchecked-read guard
- Non-vacuity: with the gating neutered, the integration tests fail with the private title present in the payload
- `-k stac` → 187 passed; datasets/collections/search/DCAT/GeoDCAT/OGC-enrichment/provenance-responses → 197 passed; `tests/test_layering.py` → 36 passed (stac router cap 1843→1870 for the page batching, with rationale; three caps raised by the original change)
- `tests/test_rule1_structural.py` + `test_rule2_structural.py` → 82 passed
- `scripts/dump_openapi.py --check` → no drift (`lineage_summary` stays `string | null` everywhere)
- `ruff check` / `ruff format --check` clean

Closes #1103

https://claude.ai/code/session_01PnJqoYvwnHaFT3w4E9zNvE
