### PR TITLE
fix(maps): shape-check paint stops and bound malformed rows at export

### DIFF
--- a/backend/app/modules/catalog/maps/schemas.py
+++ b/backend/app/modules/catalog/maps/schemas.py
@@ -1,6 +1,7 @@
 import json
 import re
 import uuid
+from collections.abc import Iterator
 from datetime import datetime, timezone
 from enum import Enum
 from typing import Annotated, Any, TypedDict
@@ -166,6 +167,67 @@ def _validate_style_dict(v: dict | None) -> dict | None:
         raise ValueError(
             f"Style configuration too large (>{_MAX_STYLE_DICT_BYTES} bytes serialized)"
         )
+    return v
+
+
+def _iter_style_dict_nodes(value: Any) -> Iterator[dict]:
+    """Yield every dict node inside a style value, without recursing.
+
+    An iterative walk on purpose: the payload is caller-supplied JSON, so a
+    recursive walk would add a RecursionError path on deeply nested input.
+    """
+    stack: list[Any] = [value]
+    while stack:
+        node = stack.pop()
+        if isinstance(node, dict):
+            yield node
+            stack.extend(node.values())
+        elif isinstance(node, list):
+            stack.extend(node)
+
+
+def _validate_maplibre_style_dict(v: dict | None) -> dict | None:
+    """Size-cap a paint/layout dict, then shape-check any legacy ``stops``.
+
+    fix(#1069): ``paint`` and ``layout`` are open dicts because MapLibre's
+    property surface is large and dynamic, and until this issue the only bound
+    on them was the serialized size above. That let structurally nonsense values
+    persist — ``{"fill-pattern": {"stops": 1}}`` and
+    ``{"fill-pattern": {"stops": "a-string"}}`` were both accepted — and wait to
+    raise inside whatever serializer next descends into them, which turns stored
+    data into a 500 on the shared ``GET /maps/{id}/style.json`` for every
+    consumer of that map. A string is the nastiest of the two, because iterating
+    it yields one character at a time instead of raising.
+
+    ``stops`` only, deliberately. Validating every paint value against the
+    property it sits on is the raster paint-key-allowlist problem and is out of
+    scope here; ``stops`` is checkable without a per-property table because the
+    legacy MapLibre function shape is the same everywhere: a list of
+    ``[input, output]`` pairs. An empty list is left alone — nothing can iterate
+    its way into a failure.
+
+    Paint and layout only. ``style_config`` keeps the size cap alone, because
+    the builder writes its own ``stops`` there with a different shape
+    (``style_config.builder.lineGradient.stops`` is a list of
+    ``{position, color}`` objects), and it is never handed to MapLibre.
+
+    Rows written before this check are unaffected — the read side bounds them
+    instead, in ``build_maplibre_style``.
+    """
+    _validate_style_dict(v)
+    if v is None:
+        return v
+    for node in _iter_style_dict_nodes(v):
+        if "stops" not in node:
+            continue
+        stops = node["stops"]
+        if not isinstance(stops, list) or any(
+            not isinstance(stop, (list, tuple)) or len(stop) != 2 for stop in stops
+        ):
+            raise ValueError(
+                "Invalid MapLibre style value: 'stops' must be a list of "
+                "[input, output] pairs"
+            )
     return v
 
 
@@ -643,8 +705,8 @@ class MapLayerInput(BaseModel):
         ),
     )
 
-    _validate_paint = field_validator("paint")(_validate_style_dict)
-    _validate_layout = field_validator("layout")(_validate_style_dict)
+    _validate_paint = field_validator("paint")(_validate_maplibre_style_dict)
+    _validate_layout = field_validator("layout")(_validate_maplibre_style_dict)
     # builder-audit #338 P2-05: validate label_config bounds/enums via LabelConfig but
     # keep the stored value a plain dict so downstream JSONB assignment is
     # unchanged (see _validate_label_config_dict).
@@ -674,7 +736,7 @@ class MapLayerInput(BaseModel):
         # so frontend-normalized camelCase keys don't persist as a separate
         # schema after layer duplication. See canonicalize_builder_style_config.
         self.style_config = canonicalize_builder_style_config(self.style_config)
-        _validate_style_dict(self.paint)
+        _validate_maplibre_style_dict(self.paint)
         _validate_style_dict(self.style_config)
         return self
 
@@ -703,8 +765,8 @@ class MapLayerPatch(BaseModel):
     )
     show_in_legend: bool | None = None
 
-    _validate_paint = field_validator("paint")(_validate_style_dict)
-    _validate_layout = field_validator("layout")(_validate_style_dict)
+    _validate_paint = field_validator("paint")(_validate_maplibre_style_dict)
+    _validate_layout = field_validator("layout")(_validate_maplibre_style_dict)
     # builder-audit #338 P2-05: validate label_config bounds/enums via LabelConfig but
     # keep the stored value a plain dict so downstream JSONB assignment is
     # unchanged (see _validate_label_config_dict).

--- a/backend/app/modules/catalog/maps/schemas.py
+++ b/backend/app/modules/catalog/maps/schemas.py
@@ -1,7 +1,6 @@
 import json
 import re
 import uuid
-from collections.abc import Iterator
 from datetime import datetime, timezone
 from enum import Enum
 from typing import Annotated, Any, TypedDict
@@ -170,22 +169,6 @@ def _validate_style_dict(v: dict | None) -> dict | None:
     return v
 
 
-def _iter_style_dict_nodes(value: Any) -> Iterator[dict]:
-    """Yield every dict node inside a style value, without recursing.
-
-    An iterative walk on purpose: the payload is caller-supplied JSON, so a
-    recursive walk would add a RecursionError path on deeply nested input.
-    """
-    stack: list[Any] = [value]
-    while stack:
-        node = stack.pop()
-        if isinstance(node, dict):
-            yield node
-            stack.extend(node.values())
-        elif isinstance(node, list):
-            stack.extend(node)
-
-
 def _validate_maplibre_style_dict(v: dict | None) -> dict | None:
     """Size-cap a paint/layout dict, then shape-check any legacy ``stops``.
 
@@ -206,6 +189,13 @@ def _validate_maplibre_style_dict(v: dict | None) -> dict | None:
     ``[input, output]`` pairs. An empty list is left alone — nothing can iterate
     its way into a failure.
 
+    Direct property values only — fix(#1109 review): a ``stops`` key can also
+    appear as plain DATA inside an expression operand, e.g.
+    ``["get", "stops", ["literal", {"stops": 5}]]``, which MapLibre accepts.
+    The legacy-function shape has meaning only as the property's own value,
+    and that is also the only position the style.json serializer descends
+    into, so nested dicts are none of this check's business.
+
     Paint and layout only. ``style_config`` keeps the size cap alone, because
     the builder writes its own ``stops`` there with a different shape
     (``style_config.builder.lineGradient.stops`` is a list of
@@ -217,8 +207,8 @@ def _validate_maplibre_style_dict(v: dict | None) -> dict | None:
     _validate_style_dict(v)
     if v is None:
         return v
-    for node in _iter_style_dict_nodes(v):
-        if "stops" not in node:
+    for node in v.values():
+        if not isinstance(node, dict) or "stops" not in node:
             continue
         stops = node["stops"]
         if not isinstance(stops, list) or any(

--- a/backend/app/modules/catalog/maps/style_json.py
+++ b/backend/app/modules/catalog/maps/style_json.py
@@ -77,6 +77,14 @@ _HILLSHADE_PAINT_KEYS = {
 # to also be constructed with `lineMetrics: true` (set by `build_maplibre_style`).
 _LINE_GRADIENT_SOURCE_TYPES = {"vector", "geojson"}
 _BUILDER_KEY_ALIASES = BUILDER_SNAKE_TO_CAMEL_KEYS
+# fix(#1069): what a malformed stored style value raises when a serializer
+# descends into it — iterating an int, unpacking a string, subscripting a
+# scalar, `.get`-ing a non-dict, hashing a list into a set membership test.
+# Deliberately NOT `Exception`: `_tile_url_for_layer` raises RuntimeError when a
+# hosted deployment has no tenant context, and that must stay fail-closed rather
+# than degrade into a quietly missing layer. Data-shape errors degrade; control
+# errors propagate.
+_MALFORMED_STYLE_ERRORS = (AttributeError, IndexError, KeyError, TypeError, ValueError)
 logger = logging.getLogger(__name__)
 
 
@@ -1391,25 +1399,54 @@ def _strip_builtin_fill_pattern(layer: dict[str, Any]) -> None:
     )
 
 
+def _validate_emitted_layer(layer: dict[str, Any]) -> None:
+    """Strip non-spec paint/layout properties from ONE emitted layer in place."""
+    layer_type = layer.get("type")
+    if layer_type == "fill":
+        _strip_builtin_fill_pattern(layer)
+    paint_allowed = _PAINT_PROPERTIES_BY_TYPE.get(layer_type)
+    if paint_allowed is not None:
+        _strip_unknown_properties(layer, "paint", paint_allowed)
+    layout_allowed = _LAYOUT_PROPERTIES_BY_TYPE.get(layer_type)
+    if layout_allowed is not None:
+        _strip_unknown_properties(layer, "layout", layout_allowed)
+    # Type-contract check runs after the name allowlist on every typed layer.
+    _strip_wrong_typed_values(layer, "paint")
+
+
 def _validate_emitted_style(style: dict[str, Any]) -> None:
     """Strip non-spec paint/layout properties from every emitted layer in place."""
     layers = style.get("layers")
     if not isinstance(layers, list):
         return
+    kept: list[Any] = []
+    dropped = False
     for layer in layers:
-        if not isinstance(layer, dict):
-            continue
-        layer_type = layer.get("type")
-        if layer_type == "fill":
-            _strip_builtin_fill_pattern(layer)
-        paint_allowed = _PAINT_PROPERTIES_BY_TYPE.get(layer_type)
-        if paint_allowed is not None:
-            _strip_unknown_properties(layer, "paint", paint_allowed)
-        layout_allowed = _LAYOUT_PROPERTIES_BY_TYPE.get(layer_type)
-        if layout_allowed is not None:
-            _strip_unknown_properties(layer, "layout", layout_allowed)
-        # Type-contract check runs after the name allowlist on every typed layer.
-        _strip_wrong_typed_values(layer, "paint")
+        if isinstance(layer, dict):
+            try:
+                _validate_emitted_layer(layer)
+            except _MALFORMED_STYLE_ERRORS:
+                # fix(#1069): this pass reads stored paint, and a stored paint
+                # value can be structurally nonsense for the property it sits on
+                # (writes were only size-bounded until #1069). #1054's
+                # intermediate revision read `fill-pattern` composites here and
+                # would have turned every such row into a 500 on the SHARED
+                # style endpoint. One bad layer degrades the document it is in;
+                # it does not take the document down. Only the failing entry is
+                # dropped — a companion of a dropped primary is left in place
+                # rather than hunted down, since the document is already
+                # degraded and the companion still renders.
+                logger.warning(
+                    "Dropping emitted style layer %r: its stored paint/layout "
+                    "could not be validated",
+                    layer.get("id"),
+                    exc_info=True,
+                )
+                dropped = True
+                continue
+        kept.append(layer)
+    if dropped:
+        style["layers"] = kept
 
 
 def build_maplibre_style(
@@ -1424,13 +1461,32 @@ def build_maplibre_style(
     style_layers: list[dict[str, Any]] = []
     for layer in sorted(layers, key=lambda item: item.sort_order):
         source_id = f"geolens-{_safe_id(str(layer.dataset_id))}"
-        if source_id not in sources:
-            sources[source_id] = _source_for_layer(layer)
-        else:
-            _append_cluster_source_metadata(sources[source_id], layer)
-        style_layers.extend(
-            _style_layer_for_map_layer(layer, source_id, mvt_source_layer_prefix)
-        )
+        # fix(#1069): the same bound as `_validate_emitted_style`, one stage
+        # earlier. Serializing a row whose paint/layout is malformed for the
+        # property it sits on must not 500 `GET /maps/{id}/style.json` for every
+        # consumer of a shared map — the layer is dropped from the document and
+        # the rest of the map still exports. The source is only registered once
+        # its layer serializes, so a dropped layer leaves no orphan behind.
+        try:
+            emitted = _style_layer_for_map_layer(
+                layer, source_id, mvt_source_layer_prefix
+            )
+            if source_id in sources:
+                _append_cluster_source_metadata(sources[source_id], layer)
+                new_source = None
+            else:
+                new_source = _source_for_layer(layer)
+        except _MALFORMED_STYLE_ERRORS:
+            logger.warning(
+                "Dropping map layer %s from the exported style: its stored "
+                "paint/layout could not be serialized",
+                layer.id,
+                exc_info=True,
+            )
+            continue
+        if new_source is not None:
+            sources[source_id] = new_source
+        style_layers.extend(emitted)
 
     # Set lineMetrics: true on vector sources whose layers need line-gradient rendering.
     # Per D-01 detection rule, "needs" means paint['line-gradient'] OR builder.lineGradient.

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -1166,7 +1166,10 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # `style_config` is deliberately excluded — the builder writes its own
     # `stops` there in a different shape, so checking it would 422 every
     # line-gradient save. Ratchet stays exact.
-    "backend/app/modules/catalog/maps/schemas.py": 1379,
+    # fix(#1109 review): -10 — the nested-dict walker is gone; the check reads
+    # direct property values only, because a `stops` key inside an expression
+    # operand is data, not a legacy function. Cap 1379 -> 1369, still exact.
+    "backend/app/modules/catalog/maps/schemas.py": 1369,
     # fix(#888): +117. `clip_to_mercator_bounds` used to lose data twice over
     # in silence — it clipped away everything east of lon 180 in a 0..360
     # source, and it reduced valid polar geometry to EMPTY without telling

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -1082,7 +1082,19 @@ _OPEN_CORE_SIZE_CAPS: dict[str, int] = {
     # BEFORE #917's strip runs, so a builder-patterned polygon exports the colour
     # the user chose instead of brand blue (EDIT-05 means paint never carries one).
     # fix(#910, codex P2): +5 — the seed accepts an explicit `fill-color: null` too.
-    "backend/app/modules/catalog/maps/style_json.py": 1559,
+    # fix(#1069): +56 — the read-side bound on malformed stored style values.
+    # Writes are shape-checked now, but that does nothing about the rows already
+    # in the database, and a serializer that descends into one of them 500s the
+    # SHARED style endpoint from stored data rather than from the request. Two
+    # guards, because the two stages that read stored paint are separate: the
+    # per-layer serialize loop in `build_maplibre_style`, and the emitted-layer
+    # pass now split out as `_validate_emitted_layer` — which is where #1054's
+    # intermediate revision actually walked `fill-pattern` composites. Roughly
+    # half the lines are the write-up of why the catch is a named data-shape
+    # tuple and not `Exception`: `_tile_url_for_layer` raises RuntimeError with
+    # no tenant context, and swallowing that would turn a fail-closed refusal
+    # into a quietly missing layer in a hosted export.
+    "backend/app/modules/catalog/maps/style_json.py": 1615,
     "backend/app/modules/catalog/maps/style_import.py": 450,
     "backend/app/modules/catalog/maps/style_sanitizers.py": 200,
     "backend/app/modules/catalog/maps/router_assets.py": 126,
@@ -1144,7 +1156,17 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # thumbnail cache version split out of updated_at. Ratchet stays exact.
     # fix(#910): +1 on top of that, the fillColorSaved entry in the authoritative
     # builder camelCase->snake_case table.
-    "backend/app/modules/catalog/maps/schemas.py": 1317,
+    # fix(#1069): +62 — the write-time shape check on `paint`/`layout`. Those
+    # fields were bounded by serialized size alone, so `{"fill-pattern":
+    # {"stops": 1}}` persisted and waited to raise inside whatever serializer
+    # next descended into it. Only `stops` is checked, because it is the one
+    # shape checkable without a per-property paint table (per-property
+    # validation is the raster paint-key-allowlist problem, tracked separately).
+    # Most of the lines are the docstring recording that scope decision and why
+    # `style_config` is deliberately excluded — the builder writes its own
+    # `stops` there in a different shape, so checking it would 422 every
+    # line-gradient save. Ratchet stays exact.
+    "backend/app/modules/catalog/maps/schemas.py": 1379,
     # fix(#888): +117. `clip_to_mercator_bounds` used to lose data twice over
     # in silence — it clipped away everything east of lon 180 in a 0..360
     # source, and it reduced valid polar geometry to EMPTY without telling

--- a/backend/tests/test_maps.py
+++ b/backend/tests/test_maps.py
@@ -22,7 +22,7 @@ from app.modules.audit.models import AuditLog
 from app.modules.auth.models import User
 from app.modules.catalog.datasets.domain.models import Dataset, Record
 from app.modules.catalog.maps.models import Map, MapLayer
-from app.modules.catalog.maps.schemas import MapLayerDiffRequest
+from app.modules.catalog.maps.schemas import MapLayerDiffRequest, MapLayerInput
 from app.processing.raster.models import RasterAsset
 
 from tests.factories import create_dataset, get_user_id
@@ -243,6 +243,70 @@ def test_layer_diff_schema_rejects_invalid_style_payload() -> None:
                 ]
             }
         )
+
+
+# fix(#1069): `paint` and `layout` were bounded by serialized size alone, so a
+# value that is structurally nonsense for the property it sits on persisted and
+# waited to raise inside whatever serializer next descended into it — a 500 on
+# the shared `GET /maps/{id}/style.json` produced by stored data rather than by
+# the request. `stops` is the one shape checkable without a per-property table.
+MALFORMED_STOPS_PAINTS = [
+    {"fill-pattern": {"stops": 1}},
+    {"fill-pattern": {"stops": "a-string"}},
+]
+
+
+@pytest.mark.parametrize("paint", MALFORMED_STOPS_PAINTS)
+def test_layer_schemas_reject_malformed_stops(paint) -> None:
+    """Both the full-save input and the diff patch reject the same shapes."""
+    with pytest.raises(ValidationError, match="must be a list of"):
+        MapLayerInput.model_validate({"dataset_id": str(uuid.uuid4()), "paint": paint})
+
+    with pytest.raises(ValidationError, match="must be a list of"):
+        MapLayerDiffRequest.model_validate(
+            {"updated": [{"id": str(uuid.uuid4()), "layout": paint}]}
+        )
+
+
+def test_layer_schema_keeps_a_well_formed_legacy_function() -> None:
+    """The check is on shape, not on the presence of `stops`.
+
+    A legacy MapLibre function object is valid input and must survive, or the
+    fix trades a 500 for a rejected save.
+    """
+    function_value = {
+        "property": "kind",
+        "type": "categorical",
+        "stops": [["a", "icon-a"], ["b", "icon-b"]],
+        "default": "icon-a",
+    }
+    layer = MapLayerInput.model_validate(
+        {"dataset_id": str(uuid.uuid4()), "paint": {"fill-pattern": function_value}}
+    )
+    assert layer.paint == {"fill-pattern": function_value}
+
+
+def test_style_config_stops_are_not_shape_checked() -> None:
+    """`style_config` keeps the size cap alone.
+
+    The builder writes its own `stops` there with a different shape, and it is
+    never handed to MapLibre — shape-checking it would 422 every line-gradient
+    save.
+    """
+    builder_gradient = {
+        "builder": {
+            "lineGradient": {
+                "stops": [
+                    {"position": 0.0, "color": "#0000ff"},
+                    {"position": 1.0, "color": "#00ff00"},
+                ]
+            }
+        }
+    }
+    layer = MapLayerInput.model_validate(
+        {"dataset_id": str(uuid.uuid4()), "style_config": builder_gradient}
+    )
+    assert layer.style_config == builder_gradient
 
 
 async def _create_map(
@@ -2167,6 +2231,87 @@ class TestMapLayers:
         assert data["visible"] is True
         assert data["opacity"] == 1.0
         assert "id" in data
+
+    @pytest.mark.parametrize("paint", MALFORMED_STOPS_PAINTS)
+    async def test_add_layer_rejects_malformed_stops(
+        self,
+        client: AsyncClient,
+        admin_auth_header: dict,
+        test_db_session,
+        paint,
+    ):
+        """fix(#1069): POST /maps/{id}/layers answers 422, not 201-then-500."""
+        admin_id = await get_user_id(test_db_session, "admin")
+        ds = await create_dataset(test_db_session, created_by=admin_id)
+        created = await _create_map(client, admin_auth_header)
+
+        resp = await client.post(
+            f"/maps/{created['id']}/layers",
+            json={"dataset_id": str(ds.id), "paint": paint},
+            headers=admin_auth_header,
+        )
+
+        assert resp.status_code == 422, resp.text
+        assert "must be a list of" in resp.text
+
+    async def test_style_json_drops_a_malformed_stored_layer_instead_of_500ing(
+        self,
+        client: AsyncClient,
+        admin_auth_header: dict,
+        test_db_session,
+    ):
+        """fix(#1069): rows written before the write-time check are still stored.
+
+        Shape-validating new writes does nothing about the rows already in the
+        database, so the read side has to bound them too. The layer's paint is
+        seeded straight into the table — the API would refuse it now — and the
+        serializer is made to descend into it the way #1054's intermediate
+        revision did. The shared style endpoint must answer 200 without that
+        layer rather than 500 for every consumer of the map.
+
+        (Asserted on behaviour, not on captured logs: `caplog` sees no structlog
+        records in this suite.)
+        """
+        from app.modules.catalog.maps import style_json
+
+        admin_id = await get_user_id(test_db_session, "admin")
+        bad_ds = await create_dataset(test_db_session, created_by=admin_id)
+        good_ds = await create_dataset(test_db_session, created_by=admin_id)
+        created = await _create_map(client, admin_auth_header)
+        map_id = created["id"]
+
+        for dataset in (bad_ds, good_ds):
+            resp = await client.post(
+                f"/maps/{map_id}/layers",
+                json={"dataset_id": str(dataset.id)},
+                headers=admin_auth_header,
+            )
+            assert resp.status_code == 201, resp.text
+            if dataset is bad_ds:
+                bad_layer_id = resp.json()["id"]
+
+        stored = await test_db_session.get(MapLayer, uuid.UUID(bad_layer_id))
+        stored.paint = {"fill-pattern": {"stops": 1}}
+        await test_db_session.commit()
+
+        real_clean_paint = style_json._clean_paint
+
+        def clean_paint_reading_patterns(paint):
+            pattern = (paint or {}).get("fill-pattern")
+            if isinstance(pattern, dict):
+                list(pattern["stops"])
+            return real_clean_paint(paint)
+
+        with patch.object(style_json, "_clean_paint", clean_paint_reading_patterns):
+            style_resp = await client.get(
+                f"/maps/{map_id}/style.json", headers=admin_auth_header
+            )
+
+        assert style_resp.status_code == 200, style_resp.text
+        style = style_resp.json()
+        assert f"layer-{bad_layer_id}" not in {entry["id"] for entry in style["layers"]}
+        assert f"geolens-{bad_ds.id}" not in style["sources"]
+        assert f"geolens-{good_ds.id}" in style["sources"]
 
     async def test_add_dem_layer_persists_hillshade_render_mode(
         self,

--- a/backend/tests/test_maps.py
+++ b/backend/tests/test_maps.py
@@ -286,6 +286,21 @@ def test_layer_schema_keeps_a_well_formed_legacy_function() -> None:
     assert layer.paint == {"fill-pattern": function_value}
 
 
+def test_expression_operands_are_not_shape_checked() -> None:
+    """fix(#1109 review): `stops` inside an expression operand is plain data.
+
+    MapLibre accepts ``["get", "stops", ["literal", {"stops": 5}]]`` — the
+    literal object is a lookup subject, not a legacy function, and the
+    style.json serializer never descends into it. Walking every nested dict
+    would 422 this valid authored style on save and on import.
+    """
+    expression = ["get", "stops", ["literal", {"stops": 5}]]
+    layer = MapLayerInput.model_validate(
+        {"dataset_id": str(uuid.uuid4()), "paint": {"circle-radius": expression}}
+    )
+    assert layer.paint == {"circle-radius": expression}
+
+
 def test_style_config_stops_are_not_shape_checked() -> None:
     """`style_config` keeps the size cap alone.
 

--- a/backend/tests/test_maps_style_json.py
+++ b/backend/tests/test_maps_style_json.py
@@ -2351,3 +2351,64 @@ def test_a_composite_fill_pattern_is_left_exactly_as_authored(pattern):
     style = build_maplibre_style(_map(), [_polygon_layer_with_pattern(pattern)])
 
     assert _fill_paint(style)["fill-pattern"] == pattern
+
+
+# fix(#1069): the read-side bound. Writes are shape-checked now (see
+# `_validate_maplibre_style_dict` in maps/schemas.py), but rows written before
+# that check are still in the database, and validating new writes does nothing
+# about them. Both tests below install a serializer that DOES descend into a
+# `fill-pattern` composite — which is what #1054's intermediate revision did,
+# and what the next serializer to walk a paint value will do — and assert the
+# blast radius is the one bad layer rather than the whole shared document.
+
+
+def _descend_into_stops(value):
+    """A reader that walks a legacy function value. `{"stops": 1}` raises here."""
+    if isinstance(value, dict) and "stops" in value:
+        return any(
+            output in style_json._BUILTIN_FILL_PATTERN_IDS
+            for _, output in value["stops"]
+        )
+    return isinstance(value, str) and value in style_json._BUILTIN_FILL_PATTERN_IDS
+
+
+def test_a_layer_that_cannot_be_serialized_is_dropped_not_500(monkeypatch):
+    """A malformed row costs its own layer, not the document."""
+    real_clean_paint = style_json._clean_paint
+
+    def clean_paint_reading_patterns(paint):
+        _descend_into_stops((paint or {}).get("fill-pattern"))
+        return real_clean_paint(paint)
+
+    monkeypatch.setattr(style_json, "_clean_paint", clean_paint_reading_patterns)
+    bad = _polygon_layer_with_pattern({"stops": 1})
+    good = _layer(label_config=None)
+
+    style = build_maplibre_style(_map(), [bad, good])
+
+    assert [entry["id"] for entry in style["layers"]] == [f"layer-{good.id}"]
+    # The source is registered only once its layer serializes, so the dropped
+    # layer leaves no orphan source (and no signed tile URL) behind.
+    assert f"geolens-{bad.dataset_id}" not in style["sources"]
+    assert f"geolens-{good.dataset_id}" in style["sources"]
+
+
+def test_a_layer_that_cannot_be_validated_is_dropped_not_500(monkeypatch):
+    """The same bound at the later stage, where #1054's near-miss actually was.
+
+    `_validate_emitted_style` reads stored paint too, so guarding only the
+    serializer would have left this path able to 500 the endpoint. Only the
+    failing entry is dropped here: the polygon's outline companion carries its
+    own generated paint and still renders, so it is deliberately left in place.
+    """
+    monkeypatch.setattr(
+        style_json, "_references_builtin_fill_pattern", _descend_into_stops
+    )
+    bad = _polygon_layer_with_pattern({"stops": "geolens-fill-grid"})
+    good = _layer(label_config=None)
+
+    style = build_maplibre_style(_map(), [bad, good])
+
+    emitted = {entry["id"] for entry in style["layers"]}
+    assert f"layer-{bad.id}" not in emitted
+    assert f"layer-{good.id}" in emitted


### PR DESCRIPTION
## Problem

`_validate_style_dict` in `maps/schemas.py` checks only serialized size (64KB), so structurally-nonsense paint values persist — `{"fill-pattern": {"stops": 1}}` and `{"fill-pattern": {"stops": "a-string"}}` are both accepted today — and wait to 500 the shared `GET /maps/{id}/style.json` endpoint when a serializer descends into them. Full background in #1069.

## Fix

Both halves of the decided remedy, in this order:

1. **Bound the damage at read time.** The style.json build now catches per-layer data-shape errors (`AttributeError, IndexError, KeyError, TypeError, ValueError` — deliberately not `except Exception`: `_tile_url_for_layer` raises `RuntimeError` to refuse hosted-style emission without tenant context, and swallowing that would turn a fail-closed refusal into a silently missing layer) and drops that layer's override with a logged warning instead of 500ing the whole document. Two guard stages, because two stages read stored paint: the emit loop (drops the layer and its companions) and `_validate_emitted_style` (drops only the failing emitted entry, so a broken fill primary keeps its outline companion, which carries its own generated paint).
2. **Write-time shape check for `stops` only.** In `paint`/`layout` on `MapLayerInput` and `MapLayerPatch`, a `stops` value that is not a list of `[value, output]` pairs is rejected with 422. No full per-property paint validation — that is the raster paint-key-allowlist problem and stays out of scope. `style_config` is deliberately excluded: `style_config.builder.lineGradient.stops` is legitimately a list of `{position, color}` objects, and shape-checking it would 422 every line-gradient save (pinned by test).

Side effect worth knowing: style *import* constructs `MapLayerInput` directly, so an imported style carrying malformed `stops` now returns 400 instead of persisting a row that would later break style.json. Consistent with the existing 64KB-cap rejection on that path.

An empty `stops: []` is still accepted (vacuously a list of pairs); rejecting it would be stricter than #1069 asks.

## Verification

- Full backend suite (host, `pytest -n 4`): **6802 passed, 83 skipped**
- New tests: both literal payloads above → 422 at the schema and over HTTP; a malformed row seeded directly in the DB → style.json 200 with that layer dropped; per-stage unit tests for both read-side guards; non-regression tests for valid stops and for `style_config` gradients
- Negative check: with the guards stashed, all three read-time tests fail (the DB-seeded one as a 500) — the tests bite
- `pytest tests/test_layering.py` → 36 passed (`style_json.py` and `schemas.py` caps raised with rationale comments)
- `ruff check` / `ruff format --check` clean; `scripts/dump_openapi.py --check` → no drift; pre-commit hooks all passed

Closes #1069

https://claude.ai/code/session_01PnJqoYvwnHaFT3w4E9zNvE
