### PR TITLE
fix(builder): resolve the fill pair inside the style paste merge

### DIFF
--- a/frontend/src/components/builder/hooks/__tests__/use-builder-layers.style-clipboard.test.ts
+++ b/frontend/src/components/builder/hooks/__tests__/use-builder-layers.style-clipboard.test.ts
@@ -263,6 +263,36 @@ describe('useBuilderLayers — handleBulkApplyStyle (ENH-03)', () => {
       expect(updated.paint['fill-color']).toBe('#abc');
     });
 
+    // fix(#923): the other paste direction. The pair is symmetric, and the merge that
+    // strands the loser is the same one, so both directions have to be pinned.
+    it('lets a pasted pattern displace the target solid colour', async () => {
+      const src = makeMockLayer({
+        id: 'src', dataset_geometry_type: 'Polygon',
+        paint: { 'fill-pattern': 'geolens-fill-dots' },
+        style_config: { builder: { fillColorSaved: '#ff0000' } } as StyleConfig, sort_order: 0,
+      });
+      const solid = makeMockLayer({
+        id: 'solid', dataset_geometry_type: 'Polygon',
+        paint: { 'fill-color': '#0000ff' }, style_config: null, sort_order: 1,
+      });
+      const { result } = renderBuilderLayers(makeMapData([src, solid]));
+      await waitForInit();
+
+      act(() => {
+        result.current.handleCopyStyle('src');
+      });
+      act(() => {
+        result.current.handlePasteStyle('solid');
+      });
+
+      const updated = result.current.localLayers.find((l) => l.id === 'solid')!;
+      expect('fill-color' in updated.paint).toBe(false);
+      expect(updated.paint['fill-pattern']).toBe('geolens-fill-dots');
+      // The copied source colour is the one None has to bring back, not the target's
+      // displaced blue.
+      expect(updated.style_config?.builder?.fillColorSaved).toBe('#ff0000');
+    });
+
     it('drops the target pattern when a data-driven colour style is applied over it', async () => {
       const src = makeMockLayer({
         id: 'src', dataset_geometry_type: 'Polygon',

--- a/frontend/src/components/builder/hooks/use-bulk-layer-actions.ts
+++ b/frontend/src/components/builder/hooks/use-bulk-layer-actions.ts
@@ -40,13 +40,17 @@ type SyncStyleConfigToMap = (
  * fix(#910/#918, codex P2): bulk apply-style, with the EDIT-05 fill exclusions the
  * style-editor funnel applies.
  *
- * `applyCopiedStyleToLayer` merges the copied paint over the target's, so a copied
- * `fill-pattern` lands beside a `fill-color` the target kept (and a copied colour
- * ramp lands beside a pattern the target kept). Bulk apply reaches neither
- * `handleStyleConfigChange` nor `handlePasteStyle`, so without this it persisted the
- * pair EDIT-05 forbids: MapLibre drew one key while the legend and saved JSON
- * claimed the other. Returns the exclusions alongside the layer because the live
- * map needs them for the imperative clear.
+ * Bulk apply reaches neither `handleStyleConfigChange` nor `handlePasteStyle`, so this
+ * is the only boundary the rule can be enforced at for this path: without it, the pair
+ * EDIT-05 forbids persisted and MapLibre drew one key while the legend and saved JSON
+ * claimed the other. Returns the exclusions alongside the layer because the live map
+ * needs them for the imperative clear.
+ *
+ * fix(#923): `applyCopiedStyleToLayer` now resolves the fill pair inside the merge, so
+ * the paint arriving here can no longer carry both keys — re-running the resolver is
+ * idempotent. The wrapper stays because the exclusions are more than the paint: this is
+ * where the displaced colour is stashed (read off the target's previous paint) and where
+ * a classification the resolved paint no longer backs is reconciled away.
  */
 function applyStyleExcludingFillCollisions(
   layer: MapLayerResponse,

--- a/frontend/src/lib/builder/__tests__/layer-style-clipboard.test.ts
+++ b/frontend/src/lib/builder/__tests__/layer-style-clipboard.test.ts
@@ -8,6 +8,7 @@
  *  - applyCopiedStyleToLayer is pure (no source mutation), merges paint + replaces
  *    style_config, never carries identity fields into the target
  *  - polygon→polygon round-trip preserves categories + colors + breaks
+ *  - #923: the merge never emits fill-color AND fill-pattern together
  */
 
 import { describe, it, expect } from 'vitest';
@@ -191,5 +192,107 @@ describe('layer-style-clipboard — applyCopiedStyleToLayer', () => {
 
     expect(result.style_config).toEqual(styleConfig);
     expect(result.paint['fill-color']).toBe('#ffffff');
+  });
+});
+
+// fix(#923): the paste merge preserves target-only paint keys on purpose, which is what
+// let the loser of the fill pair survive — a copied pattern landing beside the target's
+// colour (and the reverse). MapLibre gives the pattern precedence either way, so the map
+// drew one key while the legend, the editor and the saved JSON reported the other.
+describe('layer-style-clipboard — applyCopiedStyleToLayer fill exclusions (#923)', () => {
+  const patternedSource = () =>
+    extractCopyableStyle(
+      makeLayer({ id: 'src', dataset_geometry_type: 'Polygon', paint: { 'fill-pattern': 'geolens-fill-dots' } }),
+    );
+  const solidSource = () =>
+    extractCopyableStyle(
+      makeLayer({ id: 'src', dataset_geometry_type: 'Polygon', paint: { 'fill-color': '#abcdef' } }),
+    );
+
+  it('drops the target fill-color when a patterned style is pasted over it', () => {
+    const target = makeLayer({
+      id: 'tgt',
+      dataset_geometry_type: 'Polygon',
+      paint: { 'fill-color': '#0000ff', 'fill-opacity': 0.6 },
+    });
+
+    const result = applyCopiedStyleToLayer(target, patternedSource());
+
+    expect('fill-color' in result.paint).toBe(false);
+    expect(result.paint['fill-pattern']).toBe('geolens-fill-dots');
+    // The target-only key the merge exists to preserve is untouched.
+    expect(result.paint['fill-opacity']).toBe(0.6);
+    // Still pure: the colour is dropped from the RESULT, not from the target.
+    expect(target.paint['fill-color']).toBe('#0000ff');
+  });
+
+  it('drops the target fill-pattern when a solid-colour style is pasted over it', () => {
+    const target = makeLayer({
+      id: 'tgt',
+      dataset_geometry_type: 'Polygon',
+      paint: { 'fill-pattern': 'geolens-fill-hatch', 'fill-opacity': 0.4 },
+    });
+
+    const result = applyCopiedStyleToLayer(target, solidSource());
+
+    expect('fill-pattern' in result.paint).toBe(false);
+    expect(result.paint['fill-color']).toBe('#abcdef');
+    expect(result.paint['fill-opacity']).toBe(0.4);
+    expect(target.paint['fill-pattern']).toBe('geolens-fill-hatch');
+  });
+
+  it('lets a copied data-driven colour ramp displace the target pattern', () => {
+    const ramp = ['match', ['get', 'zone'], 'a', '#e41a1c', '#377eb8'];
+    const copied = extractCopyableStyle(
+      makeLayer({
+        id: 'src',
+        dataset_geometry_type: 'Polygon',
+        paint: { 'fill-color': ramp },
+        style_config: {
+          mode: 'categorical',
+          column: 'zone',
+          ramp: 'Set2',
+          categories: [{ value: 'a', color: '#e41a1c' }],
+        },
+      }),
+    );
+    const target = makeLayer({ id: 'tgt', dataset_geometry_type: 'Polygon', paint: { 'fill-pattern': 'geolens-fill-grid' } });
+
+    const result = applyCopiedStyleToLayer(target, copied);
+
+    expect('fill-pattern' in result.paint).toBe(false);
+    expect(result.paint['fill-color']).toEqual(ramp);
+  });
+
+  it('changes nothing but the copied keys when the target carries neither fill key', () => {
+    const target = makeLayer({
+      id: 'tgt',
+      dataset_geometry_type: 'Polygon',
+      paint: { 'fill-opacity': 0.4, 'fill-outline-color': '#333333' },
+    });
+
+    const result = applyCopiedStyleToLayer(target, solidSource());
+
+    expect(result.paint).toEqual({
+      'fill-opacity': 0.4,
+      'fill-outline-color': '#333333',
+      'fill-color': '#abcdef',
+    });
+  });
+
+  // A null fill key is NOT the same as an absent one: an imported or API-authored layer
+  // can carry `fill-pattern: null`, which MapLibre reads as no pattern. Reading that as a
+  // collision would delete the colour the user just pasted.
+  it('treats an inactive `fill-pattern: null` on the target as no pattern at all', () => {
+    const target = makeLayer({
+      id: 'tgt',
+      dataset_geometry_type: 'Polygon',
+      paint: { 'fill-pattern': null, 'fill-color': '#0000ff' },
+    });
+
+    const result = applyCopiedStyleToLayer(target, solidSource());
+
+    expect(result.paint['fill-color']).toBe('#abcdef');
+    expect(result.paint['fill-pattern']).toBeNull();
   });
 });

--- a/frontend/src/lib/builder/__tests__/layer-style-clipboard.test.ts
+++ b/frontend/src/lib/builder/__tests__/layer-style-clipboard.test.ts
@@ -226,6 +226,53 @@ describe('layer-style-clipboard — applyCopiedStyleToLayer fill exclusions (#92
     expect(target.paint['fill-color']).toBe('#0000ff');
   });
 
+  it('stashes the SOURCE colour a copied pattern displaces, not the target colour (#1110 review)', () => {
+    // An imported or API-authored source can carry both an active pattern and a
+    // raw string colour with no fillColorSaved. The paste resolution is the only
+    // step that still sees that colour — if it is not stashed here, the write
+    // boundary re-resolves an already pattern-only paint and stashes the
+    // TARGET's old colour, so a later pattern→None restores the wrong one.
+    const copied = extractCopyableStyle(
+      makeLayer({
+        id: 'src',
+        dataset_geometry_type: 'Polygon',
+        paint: { 'fill-pattern': 'geolens-fill-dots', 'fill-color': '#ff0000' },
+        style_config: {},
+      }),
+    );
+    const target = makeLayer({
+      id: 'tgt',
+      dataset_geometry_type: 'Polygon',
+      paint: { 'fill-color': '#00ff00' },
+    });
+
+    const result = applyCopiedStyleToLayer(target, copied);
+
+    expect('fill-color' in result.paint).toBe(false);
+    expect(result.paint['fill-pattern']).toBe('geolens-fill-dots');
+    expect(result.style_config?.builder?.fillColorSaved).toBe('#ff0000');
+  });
+
+  it('keeps a fillColorSaved the copied style already carries (#1110 review)', () => {
+    const copied = extractCopyableStyle(
+      makeLayer({
+        id: 'src',
+        dataset_geometry_type: 'Polygon',
+        paint: { 'fill-pattern': 'geolens-fill-dots', 'fill-color': '#ff0000' },
+        style_config: { builder: { fillColorSaved: '#123456' } },
+      }),
+    );
+    const target = makeLayer({
+      id: 'tgt',
+      dataset_geometry_type: 'Polygon',
+      paint: { 'fill-color': '#00ff00' },
+    });
+
+    const result = applyCopiedStyleToLayer(target, copied);
+
+    expect(result.style_config?.builder?.fillColorSaved).toBe('#123456');
+  });
+
   it('drops the target fill-pattern when a solid-colour style is pasted over it', () => {
     const target = makeLayer({
       id: 'tgt',

--- a/frontend/src/lib/builder/layer-style-clipboard.ts
+++ b/frontend/src/lib/builder/layer-style-clipboard.ts
@@ -25,10 +25,13 @@
  */
 
 import type { GeometryTypeName, MapLayerResponse, StyleConfig } from '@/types/api';
-// fix(#923): the EDIT-05 fill exclusions, imported rather than restated. `resolveFillExclusions`
-// is a pure function that happens to live beside the style-editor funnel's hook; a second copy of
-// the rule here is exactly how the paste end and the editor end drift apart again.
-import { resolveFillExclusions } from '@/components/builder/hooks/use-layer-map-sync';
+// fix(#923): the EDIT-05 fill exclusions, imported rather than restated. Both are pure functions
+// that happen to live beside the style-editor funnel's hook; a second copy of the rule here is
+// exactly how the paste end and the editor end drift apart again.
+import {
+  resolveFillExclusions,
+  stashExcludedFillColor,
+} from '@/components/builder/hooks/use-layer-map-sync';
 
 export type GeometryStyleClass = 'polygon' | 'line' | 'point' | 'other';
 
@@ -120,15 +123,19 @@ export function applyCopiedStyleToLayer(
     ...deepClone(copied.paint),
   };
   const styleConfig = copied.style_config ? deepClone(copied.style_config) : null;
+  // fix(#1110 review): stash in the same breath as the resolution. A copied style
+  // can carry BOTH an active pattern and a raw string colour (imported or
+  // API-authored, no fillColorSaved); the resolution drops that colour here, so
+  // this is the only place that still knows it. Deferring the stash to the write
+  // boundary loses it — the boundary re-resolves an already pattern-only paint
+  // against the TARGET's previous paint and would stash the target's old colour,
+  // so a later pattern→None click restores the wrong one. `stashExcludedFillColor`
+  // writes only when `fillColorSaved` is undefined, so a stash the copied style
+  // already carries wins, and the boundary's re-run cannot overwrite this one.
+  const resolution = resolveFillExclusions(styleConfig, mergedPaint, targetPaint);
   return {
     ...target,
-    // Only the resolved paint is taken here. The other two halves of the exclusions —
-    // stashing the displaced colour and reconciling a classification the paint no longer
-    // backs — belong to the write boundary that owns the layer's config (applyLayerUpdate
-    // for a paste, applyStyleExcludingFillCollisions for a bulk apply), and both still
-    // run on the way through. Re-resolving there is idempotent: this paint no longer
-    // collides, and the displaced colour is read back off the target's previous paint.
-    paint: resolveFillExclusions(styleConfig, mergedPaint, targetPaint).paint,
-    style_config: styleConfig,
+    paint: resolution.paint,
+    style_config: stashExcludedFillColor(styleConfig, resolution),
   };
 }

--- a/frontend/src/lib/builder/layer-style-clipboard.ts
+++ b/frontend/src/lib/builder/layer-style-clipboard.ts
@@ -3,8 +3,9 @@
  *
  * Extract a geometry-compatible style snapshot from one layer and apply it to a
  * geometry-compatible target. These functions are PURE: no React, no MapLibre
- * map instance, no I/O. The hook layer (use-builder-layers.ts) owns the session
- * clipboard ref + live-map sync; this module only computes new layer objects.
+ * map instance, no I/O (the one cross-module import below is a pure function too).
+ * The hook layer (use-builder-layers.ts) owns the session clipboard ref + live-map
+ * sync; this module only computes new layer objects.
  *
  * Geometry-class portability: a polygon style (fill-color, fill-opacity,
  * data-driven categories) is only meaningful on another polygon layer; pasting
@@ -24,6 +25,10 @@
  */
 
 import type { GeometryTypeName, MapLayerResponse, StyleConfig } from '@/types/api';
+// fix(#923): the EDIT-05 fill exclusions, imported rather than restated. `resolveFillExclusions`
+// is a pure function that happens to live beside the style-editor funnel's hook; a second copy of
+// the rule here is exactly how the paste end and the editor end drift apart again.
+import { resolveFillExclusions } from '@/components/builder/hooks/use-layer-map-sync';
 
 export type GeometryStyleClass = 'polygon' | 'line' | 'point' | 'other';
 
@@ -91,18 +96,39 @@ export function isStyleCompatible(copied: CopiedStyle, target: MapLayerResponse)
  *
  * Layer-identity fields on the target (id / dataset_id / display_name / …) are
  * left untouched.
+ *
+ * fix(#923): the merge is what makes a paste collide. A target-only `fill-pattern`
+ * survives a copied `fill-color` and vice versa, and paint carrying both breaks EDIT-05:
+ * MapLibre gives the pattern precedence while the legend, the editor and the saved JSON
+ * all report the colour. Preserving target-only keys is the whole point of the merge
+ * (tile params, outline settings), so the fill family is resolved AFTER it, through the
+ * same `resolveFillExclusions` the style-editor funnel and bulk apply-style call.
+ *
+ * That rule is a provenance diff, which is why the target's own paint is passed as the
+ * baseline: whichever fill key the merge just introduced is the one the copied style
+ * asserted, so the other one goes. Note it reads keys as ACTIVE, not merely present — a
+ * target carrying `fill-pattern: null` (imported or API-authored) has no pattern to
+ * defend and must not swallow the pasted colour.
  */
 export function applyCopiedStyleToLayer(
   target: MapLayerResponse,
   copied: CopiedStyle,
 ): MapLayerResponse {
+  const targetPaint: Record<string, unknown> = target.paint ?? {};
   const mergedPaint: Record<string, unknown> = {
-    ...(target.paint ?? {}),
+    ...targetPaint,
     ...deepClone(copied.paint),
   };
+  const styleConfig = copied.style_config ? deepClone(copied.style_config) : null;
   return {
     ...target,
-    paint: mergedPaint,
-    style_config: copied.style_config ? deepClone(copied.style_config) : null,
+    // Only the resolved paint is taken here. The other two halves of the exclusions —
+    // stashing the displaced colour and reconciling a classification the paint no longer
+    // backs — belong to the write boundary that owns the layer's config (applyLayerUpdate
+    // for a paste, applyStyleExcludingFillCollisions for a bulk apply), and both still
+    // run on the way through. Re-resolving there is idempotent: this paint no longer
+    // collides, and the displaced colour is read back off the target's previous paint.
+    paint: resolveFillExclusions(styleConfig, mergedPaint, targetPaint).paint,
+    style_config: styleConfig,
   };
 }


### PR DESCRIPTION
## Problem

`applyCopiedStyleToLayer` in `lib/builder/layer-style-clipboard.ts` merges the copied paint over the target paint and returns the raw merge, so a paste could carry both `fill-color` and `fill-pattern` — the collision #1022 made mutually exclusive at the editor boundary (#923).

## Fix

The paste merge now resolves the fill pair before returning: `applyCopiedStyleToLayer` routes its merged paint through `resolveFillExclusions` — the same shared implementation the editor's commit boundary uses — with the target paint as the provenance baseline. No fourth copy of the classification; signature and return type unchanged.

Honest scope note: this is a hardening, not a live-repro fix. #923 was verified before #1022 landed, and #1022's commit-boundary rule already resolves both current consumers of the merge (single paste via `applyLayerUpdate`'s normalize, bulk apply via `applyStyleExcludingFillCollisions`) — traced through the provenance diff in both directions. What this PR changes is the pure function itself, which is what the issue asks for ("so the rule has one home"): the next consumer of `applyCopiedStyleToLayer` inherits the rule instead of depending on its caller remembering it. The stale docblock on the bulk wrapper claiming the merge strands the loser key is corrected to say what the wrapper still exists for (stash + classification reconcile + the imperative map clear).

The issue's follow-up item ("swap the inline copy in `use-layer-map-sync.ts` to import the new helper") is moot in this shape — `use-layer-map-sync.ts` holds the single implementation and the clipboard imports it; there is nothing left to swap.

## Verification

- New tests (`layer-style-clipboard.test.ts`, 5 cases): pattern-over-color clears the color; color-over-pattern clears the pattern; a copied data-driven ramp displaces the pattern; a target with neither fill key is untouched apart from the copied keys; `fill-pattern: null` on the target does not swallow a pasted color (null ≠ absent in this code)
- Hook-level test: pasting a patterned style onto a solid layer leaves no `fill-color` in paint and keeps the source's `fillColorSaved` (the solid→patterned direction was already pinned by #1022)
- Negative control: with the source change stashed, 3 of the 5 new cases fail — the tests are not vacuous
- Live-map clear re-verified rather than assumed: with paint pre-resolved, `syncOwnedPaintProperties` (`clearMissing: true`, both fill keys in `FILL_OWNED_PAINT_PROPERTIES`) clears the absent key on the map; pinned upstream by `layer-adapters.test.ts`
- `npm run build` / `lint` / `typecheck` / `test:coverage` (369 files, 4519 tests) / `test:i18n` all pass; no new `t()` keys

Closes #923

https://claude.ai/code/session_01PnJqoYvwnHaFT3w4E9zNvE
