### PR TITLE
fix(catalog): refuse visibility changes only when a viewer is actually stranded

### DIFF
--- a/backend/app/modules/catalog/maps/service_public.py
+++ b/backend/app/modules/catalog/maps/service_public.py
@@ -95,12 +95,28 @@ _SHARED_MAP_AUDIENCES = ("public", "internal")
 # properly needs a new protocol method and an EXTENSION_API_VERSION bump, so it
 # is tracked separately rather than folded into a visibility fix.
 #
-# The failure direction is why deferring it is safe. Narrowing the real audience
-# only ever makes this guard MORE conservative: it can refuse a move that
-# strands nobody, never permit one that strands someone. So an overlay inherits
-# a refusal that lies, not a silent break — the same class as the grant and
-# publication-status cases above, and the reason those were worth fixing rather
-# than urgent. See #1068 for the shape of the seam change.
+# The two overlay directions do NOT fail the same way, and this paragraph said
+# they did until the guard stopped being rank-only. `_stranded_viewer_exists`
+# reads `users`/`user_roles` directly rather than going through
+# `filter_visible`, and its answer is what makes this function `return []`, so
+# the community answer can now be permissive as well as conservative:
+#
+#   NARROWING overlay (ABAC excluding some active non-owner users) — the query
+#   finds a user the overlay would have excluded, the guard refuses, and nobody
+#   was actually stranded. A refusal that lies, which is the safe direction and
+#   the same class as the grant and publication-status cases above.
+#
+#   WIDENING overlay (extra visible rows OR'd in — the additive shape SLOT-02's
+#   wrap-don't-replace rule is written for, and what `PermissionExtension`'s own
+#   docstring offers as "advanced RBAC, ABAC, or row-level filters") — the
+#   community query finds nobody stranded, the guard returns [], the change
+#   applies, and a user the overlay HAD granted access to silently loses the
+#   layer. That is the break this guard exists to prevent, reappearing one level
+#   up.
+#
+# Both need the seam, and neither is fixable here: `filter_visible` and
+# `can_access_dataset` take a CONCRETE user, and a map's audience is a set with
+# no representative member to pass them. See #1068 for the protocol method.
 #
 # fix(#931 codex r1): `restricted` is a PARTIAL audience, not an absent one.
 # Treating it as unreachable made `restricted -> private` look like it stranded
@@ -229,20 +245,33 @@ async def find_maps_broken_by_dataset_visibility(
     # fix(#931 codex r5): the rank narrowing says the audience COULD shrink;
     # whether anyone is standing in the part being cut is a separate question.
     #
-    # A public map is the one case needing no lookup, and only when the dataset
-    # was public: anonymous visitors see nothing else, they always exist, and
-    # they are never a row in `users`. A public map losing a dataset that was
-    # already non-public strands only signed-in viewers, so it asks the same
-    # question an internal map does.
-    anonymous_stranded = "public" in audiences and old_visibility == "public"
-    if not anonymous_stranded:
-        old_reaches_all = old_visibility in ("public", "internal")
-        if old_reaches_all:
-            cut = "ungranted" if new_visibility == "restricted" else "any"
-        else:
-            cut = "granted"
-        if not await _stranded_viewer_exists(session, dataset_id, owner_id, slice_=cut):
-            return []
+    # fix(#931 codex r6): asked PER AUDIENCE. A public map losing a public
+    # dataset always strands its anonymous visitors — they see nothing else,
+    # always exist, and are never a row in `users` — but that says nothing about
+    # the internal map beside it, whose viewers may all hold grants. Answering
+    # once for both listed maps that were not stranded, sending the operator to
+    # remove a layer from a map that renders fine.
+    signed_in_stranded: bool | None = None
+    stranded: list[str] = []
+    for visibility in audiences:
+        if visibility == "public" and old_visibility == "public":
+            stranded.append(visibility)
+            continue
+        if signed_in_stranded is None:
+            # The same question whichever map asks it: the dataset's own
+            # audience, so it is resolved once and reused.
+            if old_visibility in ("public", "internal"):
+                cut = "ungranted" if new_visibility == "restricted" else "any"
+            else:
+                cut = "granted"
+            signed_in_stranded = await _stranded_viewer_exists(
+                session, dataset_id, owner_id, slice_=cut
+            )
+        if signed_in_stranded:
+            stranded.append(visibility)
+    if not stranded:
+        return []
+    audiences = stranded
     stmt = (
         select(Map.name)
         .select_from(MapLayer)

--- a/backend/app/modules/catalog/maps/service_public.py
+++ b/backend/app/modules/catalog/maps/service_public.py
@@ -27,7 +27,11 @@ from app.modules.catalog.maps.service_shared import (
 )
 from app.modules.embed_tokens.models import EmbedToken
 from app.modules.embed_tokens.service import resolve_embed_scope_for_map
-from app.platform.extensions import get_catalog_port
+from app.platform.extensions import (
+    DefaultPermissionExtension,
+    get_catalog_port,
+    get_permission_extension,
+)
 
 if TYPE_CHECKING:
     from fastapi import Request
@@ -258,15 +262,30 @@ async def find_maps_broken_by_dataset_visibility(
             stranded.append(visibility)
             continue
         if signed_in_stranded is None:
-            # The same question whichever map asks it: the dataset's own
-            # audience, so it is resolved once and reused.
-            if old_visibility in ("public", "internal"):
-                cut = "ungranted" if new_visibility == "restricted" else "any"
+            # fix(#1111 review): the community query below mirrors
+            # DefaultPermissionExtension's grants+ladder exactly, so its answer
+            # is authoritative only while that default IS the permission
+            # authority. A registered overlay can additively widen a dataset's
+            # audience (the SLOT-02 wrap shape), and a viewer only the overlay
+            # admits is invisible to this query — under the rank-only #1056
+            # guard such a viewer was protected by the over-refusal, so
+            # permitting on community math here would strip that accidental
+            # protection. Until #1068 lets the seam answer audience questions,
+            # a non-default authority keeps the conservative refusal.
+            # `type(...) is` on purpose: a subclassing overlay must not read
+            # as the default.
+            if type(get_permission_extension()) is not DefaultPermissionExtension:
+                signed_in_stranded = True
             else:
-                cut = "granted"
-            signed_in_stranded = await _stranded_viewer_exists(
-                session, dataset_id, owner_id, slice_=cut
-            )
+                # The same question whichever map asks it: the dataset's own
+                # audience, so it is resolved once and reused.
+                if old_visibility in ("public", "internal"):
+                    cut = "ungranted" if new_visibility == "restricted" else "any"
+                else:
+                    cut = "granted"
+                signed_in_stranded = await _stranded_viewer_exists(
+                    session, dataset_id, owner_id, slice_=cut
+                )
         if signed_in_stranded:
             stranded.append(visibility)
     if not stranded:

--- a/backend/app/modules/catalog/maps/service_public.py
+++ b/backend/app/modules/catalog/maps/service_public.py
@@ -108,45 +108,55 @@ _SHARED_MAP_AUDIENCES = ("public", "internal")
 _DATASET_AUDIENCE_RANK = {"private": 0, "restricted": 1, "internal": 2, "public": 3}
 
 
-def _reach_rank(
-    map_visibility: str, dataset_visibility: str, *, restricted_has_grants: bool
-) -> int:
-    """How much of ``map_visibility``'s audience the dataset reaches.
+def _reach_rank(map_visibility: str, dataset_visibility: str) -> int:
+    """How much of ``map_visibility``'s audience the dataset COULD reach.
 
     An internal map's audience is every signed-in user, and both ``internal``
     and ``public`` reach all of them — so the two tie there, which is what makes
     the public-to-internal move safe on an internal map and not on a public one.
 
-    fix(#931 codex r2): ``restricted`` only outranks ``private`` when grants
-    actually exist. A restricted dataset with no ``DatasetGrant`` rows — the
-    state you land in by flipping an ungranted dataset to restricted — reaches
-    nobody beyond its owner and admins, who keep access afterwards either way.
-    Ranking it 1 unconditionally blocked ``restricted -> private`` on a map
-    nothing was stranded on, which is a refusal that lies to the user.
+    This is the upper bound, not the answer. A drop here says the audience
+    narrows; whether anyone is standing in the part being cut is a separate
+    question that :func:`_stranded_viewer_exists` asks against real accounts.
     """
     rank = _DATASET_AUDIENCE_RANK.get(dataset_visibility, 0)
-    if dataset_visibility == "restricted" and not restricted_has_grants:
-        rank = _DATASET_AUDIENCE_RANK["private"]
     if map_visibility == "internal":
         return min(rank, _DATASET_AUDIENCE_RANK["internal"])
     return rank
 
 
-async def _has_affected_grant_holders(
-    session: AsyncSession, dataset_id: uuid.UUID, owner_id: uuid.UUID | None
+async def _stranded_viewer_exists(
+    session: AsyncSession,
+    dataset_id: uuid.UUID,
+    owner_id: uuid.UUID | None,
+    *,
+    slice_: str,
 ) -> bool:
-    """Whether a grant on this dataset reaches anyone who would LOSE access.
+    """Does a real viewer sit in the audience a change is about to remove?
 
-    fix(#931 codex r3): a grant row is not an audience. A grant to an empty
-    role reaches nobody, and a grant whose only members are the dataset's owner
-    or an admin reaches nobody who loses anything — the owner keeps access
-    through the creator exemption and an admin bypasses the filter entirely. So
-    the question is not "does a grant exist" but "does a grant reach a user who
-    is neither", and only that user can be stranded by a move to private.
+    fix(#931 codex r5): a rank DROP is not the same as someone losing access.
+    The rank says how wide the audience could be; this asks whether anyone is
+    actually in the part being cut. Both directions were wrong without it:
+    `internal -> restricted` was refused even when every active user is in a
+    granted role, and `internal -> private` was refused on an instance whose
+    only other accounts are admins.
 
-    fix(#931 codex r2): queried only when ``restricted`` is one of the two
-    visibilities in play, so the ordinary public/internal/private moves cost
-    nothing extra.
+    ``slice_`` names the part being cut, and there are three:
+    ``"granted"`` for `restricted -> private`, which drops the grant holders;
+    ``"ungranted"`` for `internal -> restricted`, which drops everyone no grant
+    reaches; and ``"any"`` for `internal -> private`, which drops all of them.
+
+    The exclusions are the same in both cases and are what make this a question
+    about real viewers. The owner keeps access through the creator exemption
+    and an admin bypasses the filter, so neither is ever stranded. And the
+    account must be able to authenticate at all: `get_optional_user` rejects a
+    non-active user before they can render a layer, so pending, suspended and
+    deactivated accounts are not an audience. Both columns are tested,
+    mirroring `auth/dependencies.py`'s
+    `not user.is_active or user.status != "active"` — the
+    `chk_users_status_active_consistency` CHECK keeps them equal, so this is one
+    test written the way the gate writes it rather than two, and the mirror
+    cannot drift.
     """
     from app.modules.auth.models import Role, User, UserRole
     from app.modules.catalog.datasets.domain.models import DatasetGrant
@@ -156,28 +166,23 @@ async def _has_affected_grant_holders(
         .join(Role, Role.id == UserRole.role_id)
         .where(Role.name == "admin")
     )
-    stmt = (
+    granted_user_ids = (
         select(UserRole.user_id)
         .join(DatasetGrant, DatasetGrant.role_id == UserRole.role_id)
-        # fix(#931 codex r4): the grant holder must be an account that can
-        # actually authenticate. `get_optional_user` rejects an inactive user
-        # before they can render a layer, so a grant whose only members are
-        # pending, suspended or deactivated reaches nobody — counting them made
-        # the guard block a move that strands no current viewer.
-        #
-        # Both columns, mirroring `auth/dependencies.py`'s
-        # `not user.is_active or user.status != "active"` exactly. The
-        # `chk_users_status_active_consistency` CHECK keeps them equal, so this
-        # is not two tests today — it is one test written the way the gate
-        # writes it, so the two cannot drift apart later.
-        .join(User, User.id == UserRole.user_id)
+        .where(DatasetGrant.dataset_id == dataset_id)
+    )
+    stmt = (
+        select(User.id)
         .where(User.is_active.is_(True))
         .where(User.status == "active")
-        .where(DatasetGrant.dataset_id == dataset_id)
-        .where(UserRole.user_id.notin_(admin_user_ids))
+        .where(User.id.notin_(admin_user_ids))
     )
+    if slice_ == "granted":
+        stmt = stmt.where(User.id.in_(granted_user_ids))
+    elif slice_ == "ungranted":
+        stmt = stmt.where(User.id.notin_(granted_user_ids))
     if owner_id is not None:
-        stmt = stmt.where(UserRole.user_id != owner_id)
+        stmt = stmt.where(User.id != owner_id)
     return (await session.execute(stmt.limit(1))).scalar_one_or_none() is not None
 
 
@@ -213,23 +218,31 @@ async def find_maps_broken_by_dataset_visibility(
     # rank comparison here would invent a 422 for a move that costs nothing.
     if record_status != "published":
         return []
-    restricted_has_grants = False
-    if "restricted" in (old_visibility, new_visibility):
-        restricted_has_grants = await _has_affected_grant_holders(
-            session, dataset_id, owner_id
-        )
     audiences = [
         visibility
         for visibility in _SHARED_MAP_AUDIENCES
-        if _reach_rank(
-            visibility, new_visibility, restricted_has_grants=restricted_has_grants
-        )
-        < _reach_rank(
-            visibility, old_visibility, restricted_has_grants=restricted_has_grants
-        )
+        if _reach_rank(visibility, new_visibility)
+        < _reach_rank(visibility, old_visibility)
     ]
     if not audiences:
         return []
+    # fix(#931 codex r5): the rank narrowing says the audience COULD shrink;
+    # whether anyone is standing in the part being cut is a separate question.
+    #
+    # A public map is the one case needing no lookup, and only when the dataset
+    # was public: anonymous visitors see nothing else, they always exist, and
+    # they are never a row in `users`. A public map losing a dataset that was
+    # already non-public strands only signed-in viewers, so it asks the same
+    # question an internal map does.
+    anonymous_stranded = "public" in audiences and old_visibility == "public"
+    if not anonymous_stranded:
+        old_reaches_all = old_visibility in ("public", "internal")
+        if old_reaches_all:
+            cut = "ungranted" if new_visibility == "restricted" else "any"
+        else:
+            cut = "granted"
+        if not await _stranded_viewer_exists(session, dataset_id, owner_id, slice_=cut):
+            return []
     stmt = (
         select(Map.name)
         .select_from(MapLayer)

--- a/backend/tests/test_datasets.py
+++ b/backend/tests/test_datasets.py
@@ -679,7 +679,7 @@ class TestUpdateMetadata:
 
     @staticmethod
     @asynccontextmanager
-    async def _only_admins_active(test_db_session):
+    async def _only_admins_active(test_db_session, keep: set | None = None):
         """Temporarily leave the admin accounts as the only active users.
 
         The per-worker DB persists across tests, so earlier ones leave live
@@ -687,6 +687,9 @@ class TestUpdateMetadata:
         audience" has to remove them — and RESTORE them, or it silently rewrites
         the world for every test that runs after it in the same worker. Ask me
         how I know.
+
+        ``keep`` spares the named user ids, for a test whose claim is "the only
+        active non-admins are these" rather than "there are none".
         """
         from app.modules.auth.models import Role, User, UserRole
 
@@ -695,17 +698,12 @@ class TestUpdateMetadata:
             .join(Role, Role.id == UserRole.role_id)
             .where(Role.name == "admin")
         )
-        strays = (
-            (
-                await test_db_session.execute(
-                    select(User).where(
-                        User.is_active.is_(True), User.id.notin_(admin_ids)
-                    )
-                )
-            )
-            .scalars()
-            .all()
+        stray_stmt = select(User).where(
+            User.is_active.is_(True), User.id.notin_(admin_ids)
         )
+        if keep:
+            stray_stmt = stray_stmt.where(User.id.notin_(keep))
+        strays = (await test_db_session.execute(stray_stmt)).scalars().all()
         saved = [(u, u.is_active, u.status) for u in strays]
         for user, _, _ in saved:
             user.is_active = False
@@ -746,6 +744,51 @@ class TestUpdateMetadata:
             resp = await client.patch(
                 f"/datasets/{ds.id}",
                 json={"visibility": "private"},
+                headers=admin_auth_header,
+            )
+
+        assert resp.status_code == 200, resp.text
+
+    async def test_internal_to_restricted_does_not_block_when_everyone_is_granted(
+        self,
+        client: AsyncClient,
+        admin_auth_header: dict,
+        viewer_auth_header: dict,
+        test_db_session,
+    ):
+        """fix(#1073): `internal -> restricted` when every active user holds a grant.
+
+        The slice this move cuts is the users no grant reaches. Once the
+        context manager suspends the strays, the fixture viewer is the only
+        active non-admin — and the grant below reaches them, so the cut slice
+        is empty and a refusal would strand nobody. The mirror below is the
+        same move with the same viewer ungranted, and it must still block.
+        """
+        from app.modules.auth.models import Role, UserRole
+        from app.modules.catalog.datasets.domain.models import DatasetGrant
+
+        admin_id = await _get_user_id(test_db_session, "admin")
+        ds = await self._dataset_on_map(
+            test_db_session,
+            admin_id,
+            dataset_visibility="internal",
+            map_visibility="internal",
+            map_name="Everyone Granted Map",
+        )
+        viewer_id = uuid.UUID(
+            (await client.get("/auth/me/", headers=viewer_auth_header)).json()["id"]
+        )
+        role = Role(name=f"granted-all-{uuid.uuid4().hex[:8]}")
+        test_db_session.add(role)
+        await test_db_session.flush()
+        test_db_session.add(UserRole(user_id=viewer_id, role_id=role.id))
+        test_db_session.add(DatasetGrant(dataset_id=ds.id, role_id=role.id))
+        await test_db_session.commit()
+
+        async with self._only_admins_active(test_db_session, keep={viewer_id}):
+            resp = await client.patch(
+                f"/datasets/{ds.id}",
+                json={"visibility": "restricted"},
                 headers=admin_auth_header,
             )
 

--- a/backend/tests/test_datasets.py
+++ b/backend/tests/test_datasets.py
@@ -676,6 +676,93 @@ class TestUpdateMetadata:
         )
         assert allowed.status_code == 200, allowed.text
 
+    async def test_internal_to_private_does_not_block_when_no_one_else_is_active(
+        self,
+        client: AsyncClient,
+        admin_auth_header: dict,
+        test_db_session,
+    ):
+        """fix(#931 codex r5): a rank drop is not the same as someone losing access.
+
+        No `viewer_auth_header` here, so the only accounts are the admin owner
+        and other admins — all of whom keep access either way. The internal
+        audience the move removes is empty, so refusing would be a refusal that
+        lies. Deactivate any stray non-admin left by an earlier test in this
+        worker, since the per-worker DB persists.
+        """
+        from app.modules.auth.models import Role, User, UserRole
+
+        admin_ids = (
+            select(UserRole.user_id)
+            .join(Role, Role.id == UserRole.role_id)
+            .where(Role.name == "admin")
+        )
+        strays = (
+            (
+                await test_db_session.execute(
+                    select(User).where(
+                        User.is_active.is_(True), User.id.notin_(admin_ids)
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+        for stray in strays:
+            stray.is_active = False
+            stray.status = "suspended"
+        await test_db_session.commit()
+
+        admin_id = await _get_user_id(test_db_session, "admin")
+        ds = await self._dataset_on_map(
+            test_db_session,
+            admin_id,
+            dataset_visibility="internal",
+            map_visibility="internal",
+            map_name="No Other Viewers Map",
+        )
+
+        resp = await client.patch(
+            f"/datasets/{ds.id}",
+            json={"visibility": "private"},
+            headers=admin_auth_header,
+        )
+
+        assert resp.status_code == 200, resp.text
+
+    async def test_internal_to_restricted_blocks_when_someone_is_ungranted(
+        self,
+        client: AsyncClient,
+        admin_auth_header: dict,
+        viewer_auth_header: dict,
+        test_db_session,
+    ):
+        """The mirror: an active user no grant reaches DOES lose the layer.
+
+        `viewer_auth_header` mints an active non-admin with no grant on this
+        dataset, so narrowing `internal -> restricted` strands them and the
+        refusal is honest.
+        """
+        assert viewer_auth_header  # the fixture's account is the stranded viewer
+        admin_id = await _get_user_id(test_db_session, "admin")
+        map_name = "Ungranted Viewer Map"
+        ds = await self._dataset_on_map(
+            test_db_session,
+            admin_id,
+            dataset_visibility="internal",
+            map_visibility="internal",
+            map_name=map_name,
+        )
+
+        resp = await client.patch(
+            f"/datasets/{ds.id}",
+            json={"visibility": "restricted"},
+            headers=admin_auth_header,
+        )
+
+        assert resp.status_code == 422
+        assert map_name in resp.json()["detail"]
+
     async def test_an_unpublished_dataset_never_blocks(
         self,
         client: AsyncClient,

--- a/backend/tests/test_datasets.py
+++ b/backend/tests/test_datasets.py
@@ -794,6 +794,70 @@ class TestUpdateMetadata:
 
         assert resp.status_code == 200, resp.text
 
+    async def test_precision_yields_to_conservative_under_a_permission_overlay(
+        self,
+        client: AsyncClient,
+        admin_auth_header: dict,
+        viewer_auth_header: dict,
+        test_db_session,
+        monkeypatch,
+    ):
+        """fix(#1111 review): a non-default permission authority disables precision.
+
+        The stranded-viewer query mirrors DefaultPermissionExtension's
+        grants+ladder, so its answer is authoritative only while that default IS
+        the permission authority. An overlay that additively widens a dataset's
+        audience (the SLOT-02 wrap shape) admits viewers the query cannot see —
+        under the rank-only #1056 guard they were protected by the
+        over-refusal, and permitting on community math would strip that.
+        Same setup as the everyone-granted permit above; the only difference is
+        a registered non-default authority, and the move must refuse again.
+        `type(...) is` gates it, so even a subclass of the default counts as an
+        overlay.
+        """
+        from app.modules.auth.models import Role, UserRole
+        from app.modules.catalog.datasets.domain.models import DatasetGrant
+        from app.modules.catalog.maps import service_public
+        from app.platform.extensions import DefaultPermissionExtension
+
+        class _WrappedAuthority(DefaultPermissionExtension):
+            """Stand-in for an enterprise wrap of the default authority."""
+
+        monkeypatch.setattr(
+            service_public,
+            "get_permission_extension",
+            lambda: _WrappedAuthority(),
+        )
+
+        admin_id = await _get_user_id(test_db_session, "admin")
+        map_name = f"Overlay Conservative Map {uuid.uuid4().hex[:6]}"
+        ds = await self._dataset_on_map(
+            test_db_session,
+            admin_id,
+            dataset_visibility="internal",
+            map_visibility="internal",
+            map_name=map_name,
+        )
+        viewer_id = uuid.UUID(
+            (await client.get("/auth/me/", headers=viewer_auth_header)).json()["id"]
+        )
+        role = Role(name=f"granted-all-{uuid.uuid4().hex[:8]}")
+        test_db_session.add(role)
+        await test_db_session.flush()
+        test_db_session.add(UserRole(user_id=viewer_id, role_id=role.id))
+        test_db_session.add(DatasetGrant(dataset_id=ds.id, role_id=role.id))
+        await test_db_session.commit()
+
+        async with self._only_admins_active(test_db_session, keep={viewer_id}):
+            resp = await client.patch(
+                f"/datasets/{ds.id}",
+                json={"visibility": "restricted"},
+                headers=admin_auth_header,
+            )
+
+        assert resp.status_code == 422, resp.text
+        assert map_name in resp.text
+
     async def test_internal_to_restricted_blocks_when_someone_is_ungranted(
         self,
         client: AsyncClient,

--- a/backend/tests/test_datasets.py
+++ b/backend/tests/test_datasets.py
@@ -897,6 +897,7 @@ class TestUpdateMetadata:
         self,
         client: AsyncClient,
         admin_auth_header: dict,
+        viewer_auth_header: dict,
         test_db_session,
         dataset_visibility: str,
         map_visibility: str,
@@ -910,7 +911,16 @@ class TestUpdateMetadata:
         only, and its caller gated on ``old == public``, so an internal map was
         invisible to both halves. Once #930 made ``internal`` a real dataset
         rung the rule became a matrix, and each row here is one cell of it.
+
+        fix(#1073): the guard stopped refusing on a rank drop alone, so a
+        blocked row needs a real viewer standing in the slice being cut.
+        Without this fixture the rows borrowed whatever active accounts earlier
+        tests left on the worker DB — true in file order, false when a row runs
+        first on a fresh worker. The permit rows are indifferent to one more
+        ungranted viewer: their maps are unshared, their grants unreachable, or
+        their ranks never drop.
         """
+        assert viewer_auth_header  # the fixture's account is the stranded viewer
         admin_id = await _get_user_id(test_db_session, "admin")
         map_name = f"Strand {map_visibility} {dataset_visibility} {new_visibility}"
         ds = await self._dataset_on_map(

--- a/backend/tests/test_datasets.py
+++ b/backend/tests/test_datasets.py
@@ -10,6 +10,7 @@ Requirements:
 """
 
 import uuid
+from contextlib import asynccontextmanager
 
 import pytest
 from httpx import AsyncClient
@@ -676,19 +677,16 @@ class TestUpdateMetadata:
         )
         assert allowed.status_code == 200, allowed.text
 
-    async def test_internal_to_private_does_not_block_when_no_one_else_is_active(
-        self,
-        client: AsyncClient,
-        admin_auth_header: dict,
-        test_db_session,
-    ):
-        """fix(#931 codex r5): a rank drop is not the same as someone losing access.
+    @staticmethod
+    @asynccontextmanager
+    async def _only_admins_active(test_db_session):
+        """Temporarily leave the admin accounts as the only active users.
 
-        No `viewer_auth_header` here, so the only accounts are the admin owner
-        and other admins — all of whom keep access either way. The internal
-        audience the move removes is empty, so refusing would be a refusal that
-        lies. Deactivate any stray non-admin left by an earlier test in this
-        worker, since the per-worker DB persists.
+        The per-worker DB persists across tests, so earlier ones leave live
+        `viewer_<hex>` accounts behind. A test asserting "nobody else is in the
+        audience" has to remove them — and RESTORE them, or it silently rewrites
+        the world for every test that runs after it in the same worker. Ask me
+        how I know.
         """
         from app.modules.auth.models import Role, User, UserRole
 
@@ -708,11 +706,33 @@ class TestUpdateMetadata:
             .scalars()
             .all()
         )
-        for stray in strays:
-            stray.is_active = False
-            stray.status = "suspended"
+        saved = [(u, u.is_active, u.status) for u in strays]
+        for user, _, _ in saved:
+            user.is_active = False
+            user.status = "suspended"
         await test_db_session.commit()
+        try:
+            yield
+        finally:
+            for user, was_active, was_status in saved:
+                user.is_active = was_active
+                user.status = was_status
+            await test_db_session.commit()
 
+    async def test_internal_to_private_does_not_block_when_no_one_else_is_active(
+        self,
+        client: AsyncClient,
+        admin_auth_header: dict,
+        test_db_session,
+    ):
+        """fix(#931 codex r5): a rank drop is not the same as someone losing access.
+
+        No `viewer_auth_header` here, so the only accounts are the admin owner
+        and other admins — all of whom keep access either way. The internal
+        audience the move removes is empty, so refusing would be a refusal that
+        lies. Deactivate any stray non-admin left by an earlier test in this
+        worker, since the per-worker DB persists.
+        """
         admin_id = await _get_user_id(test_db_session, "admin")
         ds = await self._dataset_on_map(
             test_db_session,
@@ -722,11 +742,12 @@ class TestUpdateMetadata:
             map_name="No Other Viewers Map",
         )
 
-        resp = await client.patch(
-            f"/datasets/{ds.id}",
-            json={"visibility": "private"},
-            headers=admin_auth_header,
-        )
+        async with self._only_admins_active(test_db_session):
+            resp = await client.patch(
+                f"/datasets/{ds.id}",
+                json={"visibility": "private"},
+                headers=admin_auth_header,
+            )
 
         assert resp.status_code == 200, resp.text
 
@@ -762,6 +783,53 @@ class TestUpdateMetadata:
 
         assert resp.status_code == 422
         assert map_name in resp.json()["detail"]
+
+    async def test_only_the_stranded_map_is_named_when_audiences_differ(
+        self,
+        client: AsyncClient,
+        admin_auth_header: dict,
+        test_db_session,
+    ):
+        """fix(#931 codex r6): each audience is judged on its own.
+
+        A public dataset on BOTH a public and an internal map, moving to
+        private. The public map strands its anonymous visitors and must be
+        named. The internal map strands nobody — the only active accounts here
+        are the admin owner and other admins, all of whom keep access — so
+        naming it would send the operator to remove a layer from a map that
+        renders fine.
+        """
+        admin_id = await _get_user_id(test_db_session, "admin")
+        ds = await self._dataset_on_map(
+            test_db_session,
+            admin_id,
+            dataset_visibility="public",
+            map_visibility="public",
+            map_name="Anonymous Strands Here",
+        )
+        internal_map = Map(
+            name="Internal Strands Nobody",
+            visibility="internal",
+            created_by=admin_id,
+        )
+        test_db_session.add(internal_map)
+        await test_db_session.flush()
+        test_db_session.add(
+            MapLayer(map_id=internal_map.id, dataset_id=ds.id, sort_order=0)
+        )
+        await test_db_session.commit()
+
+        async with self._only_admins_active(test_db_session):
+            resp = await client.patch(
+                f"/datasets/{ds.id}",
+                json={"visibility": "private"},
+                headers=admin_auth_header,
+            )
+
+        assert resp.status_code == 422
+        detail = resp.json()["detail"]
+        assert "Anonymous Strands Here" in detail
+        assert "Internal Strands Nobody" not in detail
 
     async def test_an_unpublished_dataset_never_blocks(
         self,

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -904,7 +904,12 @@ def test_decomposed_service_modules_stay_within_size_budgets() -> None:
         # the layer in silence. #930 made the rule a matrix, so the helper
         # compares the before and after audiences instead of listing
         # forbidden target values. Cap 735 -> 918, exact.
-        "backend/app/modules/catalog/maps/service_public.py": 918,
+        # fix(#1111 review): +19 — precision defers to the conservative
+        # refusal whenever a non-default PermissionExtension is registered:
+        # the stranded-viewer query mirrors only the default's grants+ladder,
+        # so an additive overlay's viewers are invisible to it (#1068 tracks
+        # the seam-aware answer). Cap 918 -> 937, exact.
+        "backend/app/modules/catalog/maps/service_public.py": 937,
         "backend/app/modules/catalog/search/service_records.py": 500,
         # fix(#448): +~40 LOC — query-embedding hot-path deadline (asyncio.wait_for
         # wrapper) + the gated/approximated vector-only match COUNT in

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -903,8 +903,8 @@ def test_decomposed_service_modules_stay_within_size_budgets() -> None:
         # so the flip succeeded and every signed-in viewer of that map lost
         # the layer in silence. #930 made the rule a matrix, so the helper
         # compares the before and after audiences instead of listing
-        # forbidden target values. Cap 735 -> 889, exact.
-        "backend/app/modules/catalog/maps/service_public.py": 889,
+        # forbidden target values. Cap 735 -> 918, exact.
+        "backend/app/modules/catalog/maps/service_public.py": 918,
         "backend/app/modules/catalog/search/service_records.py": 500,
         # fix(#448): +~40 LOC — query-embedding hot-path deadline (asyncio.wait_for
         # wrapper) + the gated/approximated vector-only match COUNT in

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -903,8 +903,8 @@ def test_decomposed_service_modules_stay_within_size_budgets() -> None:
         # so the flip succeeded and every signed-in viewer of that map lost
         # the layer in silence. #930 made the rule a matrix, so the helper
         # compares the before and after audiences instead of listing
-        # forbidden target values. Cap 735 -> 876, exact.
-        "backend/app/modules/catalog/maps/service_public.py": 876,
+        # forbidden target values. Cap 735 -> 889, exact.
+        "backend/app/modules/catalog/maps/service_public.py": 889,
         "backend/app/modules/catalog/search/service_records.py": 500,
         # fix(#448): +~40 LOC — query-embedding hot-path deadline (asyncio.wait_for
         # wrapper) + the gated/approximated vector-only match COUNT in


### PR DESCRIPTION
## Problem

#1056 shipped `find_maps_broken_by_dataset_visibility` strictly-conservative, and #1073 enumerates the three over-refusals users hit on 1.7.0: a visibility narrowing is refused even when every active user already holds a grant, when no one but the owner and admins is active, and when only one of several shared maps actually strands anyone (the message then names them all). Small self-hosted operators hit refusals that strand nobody.

## Fix

Land the precision form already written for #931: `_reach_rank` becomes an upper bound only, and the decision moves to `_stranded_viewer_exists`, which judges **each shared audience on its own** with three slices (anonymous, authenticated-ungranted, granted) instead of one cross-map rank comparison. A change is refused only when a concrete viewer of a concrete map loses access.

Tests pin the acceptance boundary from both sides: all three enumerated over-refusals are now PERMITTED (`…does_not_block_when_everyone_is_granted`, `…when_no_one_else_is_active`, `only_the_stranded_map_is_named…`), and every refusal case from #1056's suite still REFUSES (public-map block, grant-reaching-real-viewer block, the active-grant-holder half of the inactive test, the five blocked matrix rows, plus a new ungranted-viewer mirror).

Two test-only hardenings rode along, found while landing:

- The matrix test's three blocked internal-audience rows relied on stray active accounts left by earlier tests on the shared worker DB — alone on a fresh DB all three returned 200, so under `-n 4` a worker whose first test was a blocked row would flake. The stranded viewer is now a fact of the test (`viewer_auth_header`), and the permit rows were verified indifferent to the extra viewer.
- The "everyone already granted" permit direction had no test at all; `_only_admins_active` gained an optional `keep` set to express it.

## Why this needs its own review (carried from #1073, verbatim)

1. "**A widening overlay can strand a viewer silently.** `_stranded_viewer_exists` reads `users`/`user_roles` directly rather than through `filter_visible`, so an overlay that ORs in extra visible rows — the additive shape SLOT-02's wrap-don't-replace rule is written for — finds nobody stranded in the community query, the guard returns `[]`, and a user the overlay had granted loses the layer. See #1068."
2. "**The first version of this shipped a defect within one round.** An `anonymous_stranded` shortcut was computed once and reused across maps. Caught in review; the per-audience form above is the fix. Worth knowing that this reasoning has already been wrong once."

Risk 1 is now closed structurally rather than only documented. The stranded-viewer query mirrors `DefaultPermissionExtension`'s grants+ladder, so its answer is authoritative *only while that default is the permission authority*. When any other authority is registered, the guard keeps the conservative #1056 refusal for every rank-narrowed audience — so a viewer only an additive overlay admits can never be stranded by community math that cannot see them. The check is type identity, not `isinstance`, so a subclassing wrap also counts as an overlay. The full seam-aware answer (asking the extension whether its effective audience contains a stranded viewer) still belongs to #1068; that API does not exist yet, and inventing it here is how this guard's first draft went wrong.

The #1068 seam was also checked at landing time: `platform/extensions/protocols.py` and `defaults_extensions.py` are unchanged since the #1056 merge, and no audience-level permission API has landed or moved.

Risk 2 stands as written — it is history, not a live hazard, and worth carrying so the next change to this reasoning starts appropriately suspicious.

## Verification

- `pytest tests/test_datasets.py` → 59 passed, serially and under CI's `-n 4` (including the overlay-defers-to-conservative test, which registers a wrapped authority over the everyone-granted scenario and asserts it 422s again)
- `TestUpdateMetadata` alone on a fresh ephemeral DB → 23 passed (the order-dependency repro is gone)
- `pytest tests/test_maps.py` → 170 passed; `tests/test_layering.py` → 36 passed (caps 876 → 918 → 937, exact, each with rationale)
- `ruff check` / `ruff format --check` clean

Closes #1073

https://claude.ai/code/session_01PnJqoYvwnHaFT3w4E9zNvE
