### PR TITLE
fix(ingest): linearize curved geometries into geom_4326

### DIFF
--- a/backend/alembic/versions/0034_linearize_geom_4326.py
+++ b/backend/alembic/versions/0034_linearize_geom_4326.py
@@ -87,34 +87,50 @@ def upgrade() -> None:
         # their linear counterparts (abstract CURVE/SURFACE typmods accept
         # linear subtypes), and loosening is a no-op risk-wise where the
         # UPDATE would have succeeded anyway.
+        # fix(#1113 review r5): geometry_columns encodes dimensionality two
+        # ways — M as a suffix on ``type`` (CURVEPOLYGONM, coord_dimension 3),
+        # Z with NO suffix (coord_dimension 3), ZM with no suffix and
+        # coord_dimension 4 — and generic geometry(Geometry, srid) REJECTS Z
+        # values, so the loosened typmod must carry the original Z/M flags.
+        # rtrim(type,'M') matches both plain and M-suffixed curve typmods; no
+        # base curve name ends in M.
         typmod = conn.execute(
             sa.text(
-                "SELECT type, srid FROM public.geometry_columns "
+                "SELECT type, srid, coord_dimension "
+                "FROM public.geometry_columns "
                 "WHERE f_table_schema = :schema "
                 "  AND f_table_name = :table "
                 "  AND f_geometry_column = 'geom_4326' "
-                "  AND type IN ('CIRCULARSTRING','COMPOUNDCURVE',"
+                "  AND rtrim(type, 'M') IN ('CIRCULARSTRING','COMPOUNDCURVE',"
                 "               'CURVEPOLYGON','MULTICURVE','MULTISURFACE')"
             ),
             {"schema": schema, "table": table},
         ).first()
         if typmod is not None:
+            if typmod.coord_dimension == 4:
+                generic = "GeometryZM"
+            elif typmod.coord_dimension == 3:
+                generic = "GeometryM" if typmod.type.endswith("M") else "GeometryZ"
+            else:
+                generic = "Geometry"
             conn.execute(
                 sa.text(
                     f"ALTER TABLE {_quote_ident(schema)}.{_quote_ident(table)} "
                     f"ALTER COLUMN geom_4326 "
-                    f"TYPE geometry(Geometry, {int(typmod.srid)})"
+                    f"TYPE geometry({generic}, {int(typmod.srid)})"
                 )
             )
+        # rtrim on GeometryType for the same reason: an M curve reports
+        # CURVEPOLYGONM, so the bare list would skip an arc-free M container.
         conn.execute(
             sa.text(
                 f"UPDATE {_quote_ident(schema)}.{_quote_ident(table)} "
                 f"SET geom_4326 = ST_CurveToLine(geom_4326) "
                 f"WHERE ST_HasArc(geom_4326) "
-                f"   OR GeometryType(geom_4326) IN "
+                f"   OR rtrim(GeometryType(geom_4326), 'M') IN "
                 f"      ('CIRCULARSTRING','COMPOUNDCURVE','CURVEPOLYGON',"
                 f"       'MULTICURVE','MULTISURFACE') "
-                f"   OR GeometryType(geom_4326) = 'GEOMETRYCOLLECTION'"
+                f"   OR rtrim(GeometryType(geom_4326), 'M') = 'GEOMETRYCOLLECTION'"
             )
         )
 

--- a/backend/alembic/versions/0034_linearize_geom_4326.py
+++ b/backend/alembic/versions/0034_linearize_geom_4326.py
@@ -84,6 +84,15 @@ def upgrade() -> None:
                        SELECT 'data_t_' || pg_catalog.replace(id::text, '-', '_')
                        FROM catalog.tenants
                    ))
+              -- fix(#1113 review r11): REGISTERED datasets only. An operator
+              -- can copy a table into a data schema before registering it
+              -- (discover_unregistered_tables exists for exactly that state);
+              -- GeoLens serves nothing from it yet, registration now runs its
+              -- own linearization, and densifying it here would be
+              -- irreversible harm with no surface fixed. table_name is
+              -- globally unique across tenants (registration's duplicate
+              -- check), so the name join is the tenant-safe scope.
+              AND c.table_name IN (SELECT table_name FROM catalog.datasets)
             ORDER BY c.table_schema, c.table_name
             """
         )
@@ -167,6 +176,10 @@ def upgrade() -> None:
                        SELECT 'data_t_' || pg_catalog.replace(id::text, '-', '_')
                        FROM catalog.tenants
                    ))
+              -- fix(#1113 review r11): warn only about datasets GeoLens
+              -- actually serves; an unregistered table's generated column is
+              -- registration's problem when (if) it registers.
+              AND c.table_name IN (SELECT table_name FROM catalog.datasets)
             """
         )
     ).all()

--- a/backend/alembic/versions/0034_linearize_geom_4326.py
+++ b/backend/alembic/versions/0034_linearize_geom_4326.py
@@ -63,6 +63,13 @@ def upgrade() -> None:
             WHERE c.column_name = 'geom_4326'
               AND c.udt_name = 'geometry'
               AND t.table_type = 'BASE TABLE'
+              -- fix(#1113 review r7): a STORED GENERATED geom_4326 rejects
+              -- any UPDATE at parse time (even WHERE false), which would
+              -- abort this whole migration. It also cannot be fixed by
+              -- UPDATE — its values are decided by its generation
+              -- expression — so it is skipped, not repaired (#1114 tracks
+              -- externally-defined columns whose expressions yield curves).
+              AND c.is_generated = 'NEVER'
               -- fix(#1113 review): only GeoLens-owned data schemas — 'data'
               -- (single-tenant) or the EXACT per-tenant schemas derived from
               -- catalog.tenants, the same construction as tenant_data_schema()

--- a/backend/alembic/versions/0034_linearize_geom_4326.py
+++ b/backend/alembic/versions/0034_linearize_geom_4326.py
@@ -14,10 +14,17 @@ information_schema: every BASE TABLE with a geometry column named
 ``geom_4326`` in the ``data`` schema (single-tenant) or a ``data_t_%``
 tenant schema (multi-tenant, see tenant_data_schema).
 
-Idempotent: the UPDATE touches only rows where ST_HasArc still reports an
-arc, so a re-run matches nothing. ST_HasArc rather than a GeometryType IN
-(...) list because it also sees curves nested inside a
-GEOMETRYCOLLECTION, which GeometryType reports as the collection type.
+The predicate is the union of three tests, because each alone misses a
+stored shape — fix(#1113 review): a curve TYPE with no arc in it
+(``MULTISURFACE(((...)))``, a form the curved-sources suite itself uses)
+still breaks every curve-intolerant reader, and ST_HasArc alone skips
+it; a GeometryType list alone misses an arc nested inside a
+GEOMETRYCOLLECTION, which reports the collection type. So: any arc
+(ST_HasArc), any top-level curve type (the closed five-member list), or
+any GEOMETRYCOLLECTION (linear members pass through ST_CurveToLine
+unchanged; curve members cannot hide anywhere else — linear multi types
+cannot contain them). Idempotent: converted rows leave the predicate,
+and a GEOMETRYCOLLECTION re-converts to an identical value.
 
 Downgrade is a deliberate no-op: densifying arcs is not losslessly
 reversible, the curved source survives in ``geom``, and the catalog's
@@ -76,7 +83,11 @@ def upgrade() -> None:
             sa.text(
                 f"UPDATE {_quote_ident(schema)}.{_quote_ident(table)} "
                 f"SET geom_4326 = ST_CurveToLine(geom_4326) "
-                f"WHERE ST_HasArc(geom_4326)"
+                f"WHERE ST_HasArc(geom_4326) "
+                f"   OR GeometryType(geom_4326) IN "
+                f"      ('CIRCULARSTRING','COMPOUNDCURVE','CURVEPOLYGON',"
+                f"       'MULTICURVE','MULTISURFACE') "
+                f"   OR GeometryType(geom_4326) = 'GEOMETRYCOLLECTION'"
             )
         )
 

--- a/backend/alembic/versions/0034_linearize_geom_4326.py
+++ b/backend/alembic/versions/0034_linearize_geom_4326.py
@@ -110,60 +110,86 @@ def upgrade() -> None:
         )
     ).all()
     for schema, table in tables:
-        # fix(#1113 review): a BYO table can declare geom_4326 with a curved
-        # TYPMOD — geometry(CurvePolygon, 4326) — and the linear UPDATE result
-        # then violates the declared column type, aborting the whole
-        # migration. Loosen such a column to generic geometry(Geometry, srid)
-        # first; the concrete curve typmods are the only ones that reject
-        # their linear counterparts (abstract CURVE/SURFACE typmods accept
-        # linear subtypes), and loosening is a no-op risk-wise where the
-        # UPDATE would have succeeded anyway.
-        # fix(#1113 review r5): geometry_columns encodes dimensionality two
-        # ways — M as a suffix on ``type`` (CURVEPOLYGONM, coord_dimension 3),
-        # Z with NO suffix (coord_dimension 3), ZM with no suffix and
-        # coord_dimension 4 — and generic geometry(Geometry, srid) REJECTS Z
-        # values, so the loosened typmod must carry the original Z/M flags.
-        # rtrim(type,'M') matches both plain and M-suffixed curve typmods; no
-        # base curve name ends in M.
-        typmod = conn.execute(
-            sa.text(
-                "SELECT type, srid, coord_dimension "
-                "FROM public.geometry_columns "
-                "WHERE f_table_schema = :schema "
-                "  AND f_table_name = :table "
-                "  AND f_geometry_column = 'geom_4326' "
-                "  AND rtrim(type, 'M') IN ('CIRCULARSTRING','COMPOUNDCURVE',"
-                "               'CURVEPOLYGON','MULTICURVE','MULTISURFACE')"
-            ),
-            {"schema": schema, "table": table},
-        ).first()
-        if typmod is not None:
-            if typmod.coord_dimension == 4:
-                generic = "GeometryZM"
-            elif typmod.coord_dimension == 3:
-                generic = "GeometryM" if typmod.type.endswith("M") else "GeometryZ"
-            else:
-                generic = "Geometry"
-            conn.execute(
-                sa.text(
-                    f"ALTER TABLE {_quote_ident(schema)}.{_quote_ident(table)} "
-                    f"ALTER COLUMN geom_4326 "
-                    f"TYPE geometry({generic}, {int(typmod.srid)})"
+        # fix(#1113 review r14): EVERY table converts inside its own savepoint.
+        # Review found four distinct DDL shapes that abort the naive loop —
+        # a curved typmod (r4), a dimensional curved typmod (r5), a STORED
+        # GENERATED column (r7, excluded above), and a legacy CHECK-constraint
+        # declaration (r14: geometry_columns reports the constraint-derived
+        # type, the typmod ALTER cannot remove the CHECK, and the linear
+        # UPDATE then violates it) — and that family is open-ended. One
+        # hostile table must degrade to a named skip, never block the
+        # deployment; the operator warning carries the cause and the fix
+        # stays with the table's owner (#1114).
+        try:
+            with conn.begin_nested():
+                # fix(#1113 review): a BYO table can declare geom_4326 with a
+                # curved TYPMOD — geometry(CurvePolygon, 4326) — and the
+                # linear UPDATE result then violates the declared column
+                # type. Loosen such a column first; only the concrete curve
+                # typmods reject their linear counterparts (abstract
+                # CURVE/SURFACE typmods accept linear subtypes).
+                # fix(#1113 review r5): geometry_columns encodes
+                # dimensionality two ways — M as a suffix on ``type``
+                # (CURVEPOLYGONM, coord_dimension 3), Z with NO suffix
+                # (coord_dimension 3), ZM with no suffix and coord_dimension
+                # 4 — and generic geometry(Geometry, srid) REJECTS Z values,
+                # so the loosened typmod must carry the original Z/M flags.
+                # rtrim(type,'M') matches both plain and M-suffixed curve
+                # typmods; no base curve name ends in M.
+                typmod = conn.execute(
+                    sa.text(
+                        "SELECT type, srid, coord_dimension "
+                        "FROM public.geometry_columns "
+                        "WHERE f_table_schema = :schema "
+                        "  AND f_table_name = :table "
+                        "  AND f_geometry_column = 'geom_4326' "
+                        "  AND rtrim(type, 'M') IN "
+                        "      ('CIRCULARSTRING','COMPOUNDCURVE',"
+                        "       'CURVEPOLYGON','MULTICURVE','MULTISURFACE')"
+                    ),
+                    {"schema": schema, "table": table},
+                ).first()
+                if typmod is not None:
+                    if typmod.coord_dimension == 4:
+                        generic = "GeometryZM"
+                    elif typmod.coord_dimension == 3:
+                        generic = (
+                            "GeometryM" if typmod.type.endswith("M") else "GeometryZ"
+                        )
+                    else:
+                        generic = "Geometry"
+                    conn.execute(
+                        sa.text(
+                            f"ALTER TABLE "
+                            f"{_quote_ident(schema)}.{_quote_ident(table)} "
+                            f"ALTER COLUMN geom_4326 "
+                            f"TYPE geometry({generic}, {int(typmod.srid)})"
+                        )
+                    )
+                # rtrim on GeometryType too: an M curve reports CURVEPOLYGONM,
+                # so the bare list would skip an arc-free M container.
+                conn.execute(
+                    sa.text(
+                        f"UPDATE {_quote_ident(schema)}.{_quote_ident(table)} "
+                        f"SET geom_4326 = ST_CurveToLine(geom_4326) "
+                        f"WHERE ST_HasArc(geom_4326) "
+                        f"   OR rtrim(GeometryType(geom_4326), 'M') IN "
+                        f"      ('CIRCULARSTRING','COMPOUNDCURVE',"
+                        f"       'CURVEPOLYGON','MULTICURVE','MULTISURFACE') "
+                        f"   OR rtrim(GeometryType(geom_4326), 'M') "
+                        f"      = 'GEOMETRYCOLLECTION'"
+                    )
                 )
+        except Exception as exc:  # noqa: BLE001 — any DDL shape may refuse; skip THAT table only
+            log.warning(
+                "%s.%s: could not linearize geom_4326 (%s). The table keeps "
+                "its curved values and tiles/feature reads/analysis will fail "
+                "for that dataset until its geometry declaration is fixed "
+                "(tracked in geolens#1114).",
+                schema,
+                table,
+                exc,
             )
-        # rtrim on GeometryType for the same reason: an M curve reports
-        # CURVEPOLYGONM, so the bare list would skip an arc-free M container.
-        conn.execute(
-            sa.text(
-                f"UPDATE {_quote_ident(schema)}.{_quote_ident(table)} "
-                f"SET geom_4326 = ST_CurveToLine(geom_4326) "
-                f"WHERE ST_HasArc(geom_4326) "
-                f"   OR rtrim(GeometryType(geom_4326), 'M') IN "
-                f"      ('CIRCULARSTRING','COMPOUNDCURVE','CURVEPOLYGON',"
-                f"       'MULTICURVE','MULTISURFACE') "
-                f"   OR rtrim(GeometryType(geom_4326), 'M') = 'GEOMETRYCOLLECTION'"
-            )
-        )
 
     # fix(#1113 review r9): the loop above must SKIP stored generated columns
     # (any UPDATE against one aborts at parse time), but an already-registered

--- a/backend/alembic/versions/0034_linearize_geom_4326.py
+++ b/backend/alembic/versions/0034_linearize_geom_4326.py
@@ -89,10 +89,22 @@ def upgrade() -> None:
               -- (discover_unregistered_tables exists for exactly that state);
               -- GeoLens serves nothing from it yet, registration now runs its
               -- own linearization, and densifying it here would be
-              -- irreversible harm with no surface fixed. table_name is
-              -- globally unique across tenants (registration's duplicate
-              -- check), so the name join is the tenant-safe scope.
-              AND c.table_name IN (SELECT table_name FROM catalog.datasets)
+              -- irreversible harm with no surface fixed.
+              -- fix(#1113 review r12): the join is TENANT-SCOPED — migration
+              -- 0020's (tenant_id, table_name) unique index permits the same
+              -- table name in different tenants, so a name-only join would
+              -- sweep tenant B's unregistered twin of tenant A's registered
+              -- table. A dataset owns exactly the table in ITS tenant's
+              -- schema ('data' for tenant_id IS NULL).
+              AND EXISTS (
+                  SELECT 1 FROM catalog.datasets d
+                  WHERE d.table_name = c.table_name
+                    AND (
+                      (d.tenant_id IS NULL AND c.table_schema = 'data')
+                      OR c.table_schema =
+                         'data_t_' || pg_catalog.replace(d.tenant_id::text, '-', '_')
+                    )
+              )
             ORDER BY c.table_schema, c.table_name
             """
         )
@@ -179,7 +191,16 @@ def upgrade() -> None:
               -- fix(#1113 review r11): warn only about datasets GeoLens
               -- actually serves; an unregistered table's generated column is
               -- registration's problem when (if) it registers.
-              AND c.table_name IN (SELECT table_name FROM catalog.datasets)
+              -- fix(#1113 review r12): tenant-scoped, same as the backfill.
+              AND EXISTS (
+                  SELECT 1 FROM catalog.datasets d
+                  WHERE d.table_name = c.table_name
+                    AND (
+                      (d.tenant_id IS NULL AND c.table_schema = 'data')
+                      OR c.table_schema =
+                         'data_t_' || pg_catalog.replace(d.tenant_id::text, '-', '_')
+                    )
+              )
             """
         )
     ).all()

--- a/backend/alembic/versions/0034_linearize_geom_4326.py
+++ b/backend/alembic/versions/0034_linearize_geom_4326.py
@@ -51,6 +51,9 @@ def _quote_ident(name: str) -> str:
 
 
 def upgrade() -> None:
+    import logging
+
+    log = logging.getLogger("alembic.runtime.migration")
     conn = op.get_bind()
     tables = conn.execute(
         sa.text(
@@ -140,6 +143,51 @@ def upgrade() -> None:
                 f"   OR rtrim(GeometryType(geom_4326), 'M') = 'GEOMETRYCOLLECTION'"
             )
         )
+
+    # fix(#1113 review r9): the loop above must SKIP stored generated columns
+    # (any UPDATE against one aborts at parse time), but an already-registered
+    # dataset whose generated expression yields curves stays broken with no
+    # signal. Surface those tables to the operator — a SELECT cannot abort the
+    # migration — and point at the tracking issue; repairing a column someone
+    # else's expression owns is not this migration's call (#1114).
+    generated = conn.execute(
+        sa.text(
+            """
+            SELECT c.table_schema, c.table_name
+            FROM information_schema.columns AS c
+            JOIN information_schema.tables AS t
+              ON t.table_schema = c.table_schema
+             AND t.table_name = c.table_name
+            WHERE c.column_name = 'geom_4326'
+              AND c.udt_name = 'geometry'
+              AND t.table_type = 'BASE TABLE'
+              AND c.is_generated = 'ALWAYS'
+              AND (c.table_schema = 'data'
+                   OR c.table_schema IN (
+                       SELECT 'data_t_' || pg_catalog.replace(id::text, '-', '_')
+                       FROM catalog.tenants
+                   ))
+            """
+        )
+    ).all()
+    for schema, table in generated:
+        curved = conn.execute(
+            sa.text(
+                f"SELECT 1 FROM {_quote_ident(schema)}.{_quote_ident(table)} "
+                f"WHERE ST_AsBinary(ST_CurveToLine(geom_4326)) "
+                f"      <> ST_AsBinary(geom_4326) LIMIT 1"
+            )
+        ).first()
+        if curved is not None:
+            log.warning(
+                "%s.%s: geom_4326 is a GENERATED column whose expression "
+                "yields curved geometries; this backfill cannot repair it and "
+                "tiles/feature reads/analysis will fail for that dataset. "
+                "Adjust the generation expression to apply ST_CurveToLine "
+                "(tracked in geolens#1114).",
+                schema,
+                table,
+            )
 
 
 def downgrade() -> None:

--- a/backend/alembic/versions/0034_linearize_geom_4326.py
+++ b/backend/alembic/versions/0034_linearize_geom_4326.py
@@ -1,0 +1,77 @@
+"""Linearize curved geom_4326 values in existing per-dataset tables.
+
+fix(#1104): WFS ingest admitted curved geometries (MultiSurface /
+CompoundCurve) into ``geom_4326``, and every surface that reads the column
+raises on them: ST_AsMVTGeom (vector tiles), ST_AsGeoJSON (feature reads),
+``::geography`` and ST_MakeValid (analysis). Ingest now applies
+ST_CurveToLine when it builds the column; this backfills rows ingested
+before that change so the geom_4326-is-always-linear invariant holds for
+existing data too. The curved original stays in each table's ``geom``
+column, untouched.
+
+The per-dataset tables are dynamic, so they are discovered from
+information_schema: every BASE TABLE with a geometry column named
+``geom_4326`` in the ``data`` schema (single-tenant) or a ``data_t_%``
+tenant schema (multi-tenant, see tenant_data_schema).
+
+Idempotent: the UPDATE touches only rows where ST_HasArc still reports an
+arc, so a re-run matches nothing. ST_HasArc rather than a GeometryType IN
+(...) list because it also sees curves nested inside a
+GEOMETRYCOLLECTION, which GeometryType reports as the collection type.
+
+Downgrade is a deliberate no-op: densifying arcs is not losslessly
+reversible, the curved source survives in ``geom``, and the catalog's
+``geometry_type`` already declared the linear type for these datasets.
+
+Revision ID: 0034_linearize_geom_4326
+Revises: 0033_records_derived_from
+Create Date: 2026-08-01
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0034_linearize_geom_4326"
+down_revision: Union[str, None] = "0033_records_derived_from"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def _quote_ident(name: str) -> str:
+    return '"' + name.replace('"', '""') + '"'
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    tables = conn.execute(
+        sa.text(
+            """
+            SELECT c.table_schema, c.table_name
+            FROM information_schema.columns AS c
+            JOIN information_schema.tables AS t
+              ON t.table_schema = c.table_schema
+             AND t.table_name = c.table_name
+            WHERE c.column_name = 'geom_4326'
+              AND c.udt_name = 'geometry'
+              AND t.table_type = 'BASE TABLE'
+              AND (c.table_schema = 'data'
+                   OR c.table_schema LIKE 'data\\_t\\_%')
+            ORDER BY c.table_schema, c.table_name
+            """
+        )
+    ).all()
+    for schema, table in tables:
+        conn.execute(
+            sa.text(
+                f"UPDATE {_quote_ident(schema)}.{_quote_ident(table)} "
+                f"SET geom_4326 = ST_CurveToLine(geom_4326) "
+                f"WHERE ST_HasArc(geom_4326)"
+            )
+        )
+
+
+def downgrade() -> None:
+    # Data-only normalization; nothing to restore (see module docstring).
+    pass

--- a/backend/alembic/versions/0034_linearize_geom_4326.py
+++ b/backend/alembic/versions/0034_linearize_geom_4326.py
@@ -79,6 +79,33 @@ def upgrade() -> None:
         )
     ).all()
     for schema, table in tables:
+        # fix(#1113 review): a BYO table can declare geom_4326 with a curved
+        # TYPMOD — geometry(CurvePolygon, 4326) — and the linear UPDATE result
+        # then violates the declared column type, aborting the whole
+        # migration. Loosen such a column to generic geometry(Geometry, srid)
+        # first; the concrete curve typmods are the only ones that reject
+        # their linear counterparts (abstract CURVE/SURFACE typmods accept
+        # linear subtypes), and loosening is a no-op risk-wise where the
+        # UPDATE would have succeeded anyway.
+        typmod = conn.execute(
+            sa.text(
+                "SELECT type, srid FROM public.geometry_columns "
+                "WHERE f_table_schema = :schema "
+                "  AND f_table_name = :table "
+                "  AND f_geometry_column = 'geom_4326' "
+                "  AND type IN ('CIRCULARSTRING','COMPOUNDCURVE',"
+                "               'CURVEPOLYGON','MULTICURVE','MULTISURFACE')"
+            ),
+            {"schema": schema, "table": table},
+        ).first()
+        if typmod is not None:
+            conn.execute(
+                sa.text(
+                    f"ALTER TABLE {_quote_ident(schema)}.{_quote_ident(table)} "
+                    f"ALTER COLUMN geom_4326 "
+                    f"TYPE geometry(Geometry, {int(typmod.srid)})"
+                )
+            )
         conn.execute(
             sa.text(
                 f"UPDATE {_quote_ident(schema)}.{_quote_ident(table)} "

--- a/backend/alembic/versions/0034_linearize_geom_4326.py
+++ b/backend/alembic/versions/0034_linearize_geom_4326.py
@@ -56,8 +56,17 @@ def upgrade() -> None:
             WHERE c.column_name = 'geom_4326'
               AND c.udt_name = 'geometry'
               AND t.table_type = 'BASE TABLE'
+              -- fix(#1113 review): only GeoLens-owned data schemas — 'data'
+              -- (single-tenant) or the EXACT per-tenant schemas derived from
+              -- catalog.tenants, the same construction as tenant_data_schema()
+              -- and migrations 0024/0026. A co-hosted schema that merely
+              -- starts with 'data_t_' could hold a geom_4326 column whose
+              -- curves this UPDATE would irreversibly densify.
               AND (c.table_schema = 'data'
-                   OR c.table_schema LIKE 'data\\_t\\_%')
+                   OR c.table_schema IN (
+                       SELECT 'data_t_' || pg_catalog.replace(id::text, '-', '_')
+                       FROM catalog.tenants
+                   ))
             ORDER BY c.table_schema, c.table_name
             """
         )

--- a/backend/app/modules/catalog/datasets/domain/service_analysis.py
+++ b/backend/app/modules/catalog/datasets/domain/service_analysis.py
@@ -34,7 +34,6 @@ from app.platform.analysis_sql import (
     INTERSECT_SOURCE_GID_COLUMN,
     MEASURE_OUTPUT_COLUMNS,
     NOT_EMPTY_PREDICATE,
-    linearized,
     render_clip_layer_join,
     render_geometry_expr,
     render_intersect_preview,
@@ -191,7 +190,7 @@ def build_preview_sql(
         # identity lateral keeps the query shape (and NOT_EMPTY_PREDICATE)
         # common with every other branch.
         cte = ""
-        lateral = f"(SELECT {linearized('geom_4326')} AS geom_out OFFSET 0)"
+        lateral = "(SELECT geom_4326 AS geom_out OFFSET 0)"
         where = render_select_by_location_where(mask_table_ref, src="_src")
     elif mask_table_ref is not None:
         # fix(#693): layer-sourced clip previews subdivide the mask once and

--- a/backend/app/modules/catalog/datasets/domain/service_relationships.py
+++ b/backend/app/modules/catalog/datasets/domain/service_relationships.py
@@ -512,12 +512,19 @@ async def _fetch_target_rows(
     prop_cols = await live_property_columns(session, target_table)
     prop_sel = f", {prop_cols}" if prop_cols else ""
     table_ref = get_catalog_port().quote_table(target_table)
+    # fix(#1113 review r10): the match runs against the BASE table, inside the
+    # projection — a relationship may legitimately target a column the
+    # projection drops (safe-column validation accepts `geom`/`geom_4326`),
+    # and predicating on the projected alias made such a fetch an
+    # undefined-column error. Same colon escape as live_property_columns:
+    # the identifier is interpolated into text().
+    qcol = '"' + target_column.replace('"', '""').replace(":", "\\:") + '"'
     rows_result = await session.execute(
         text(
             f"SELECT gid, to_jsonb(t.*) - 'gid' AS properties "
-            f"FROM (SELECT gid{prop_sel} FROM {table_ref}) t "
-            f"WHERE t.{target_column} = :fk_val "
-            f"ORDER BY gid LIMIT :lim OFFSET :off"
+            f"FROM (SELECT gid{prop_sel} FROM {table_ref} "
+            f"      WHERE {qcol} = :fk_val "
+            f"      ORDER BY gid LIMIT :lim OFFSET :off) t"
         ).bindparams(fk_val=fk_value, lim=limit, off=after)
     )
     return [

--- a/backend/app/modules/catalog/datasets/domain/service_relationships.py
+++ b/backend/app/modules/catalog/datasets/domain/service_relationships.py
@@ -503,11 +503,19 @@ async def _fetch_target_rows(
     after: int,
 ) -> list[dict]:
     """Window-fetch matching target rows as gid+properties dicts."""
+    # fix(#1104): project the row before to_jsonb — serializing t.* first
+    # passes the curved source `geom` through the geometry→jsonb cast, which
+    # raises, even though the subtraction then discards it. Same rule as the
+    # feature readers; see live_property_columns.
+    from app.modules.catalog.features.service import live_property_columns
+
+    prop_cols = await live_property_columns(session, target_table)
+    prop_sel = f", {prop_cols}" if prop_cols else ""
     table_ref = get_catalog_port().quote_table(target_table)
     rows_result = await session.execute(
         text(
-            f"SELECT gid, to_jsonb(t.*) - 'gid' - 'geom' - 'geom_4326' AS properties "
-            f"FROM {table_ref} t "
+            f"SELECT gid, to_jsonb(t.*) - 'gid' AS properties "
+            f"FROM (SELECT gid{prop_sel} FROM {table_ref}) t "
             f"WHERE t.{target_column} = :fk_val "
             f"ORDER BY gid LIMIT :lim OFFSET :off"
         ).bindparams(fk_val=fk_value, lim=limit, off=after)

--- a/backend/app/modules/catalog/features/service.py
+++ b/backend/app/modules/catalog/features/service.py
@@ -140,7 +140,12 @@ async def live_property_columns(db: AsyncSession, table_name: str) -> str:
 
     The live schema is authoritative here on purpose: ``Dataset.column_info``
     can drift from the table on re-upload, and a projected list must match
-    the table or the whole query fails. Names are double-quote escaped.
+    the table or the whole query fails. Names are double-quote escaped, and —
+    fix(#1113 review), same rule as _sql_quote_ident's fix(#640) — colons are
+    backslash-escaped because SQLAlchemy ``text()`` parses ``:name`` as a bind
+    parameter even inside double-quoted identifiers, and registered Socrata
+    exports ship columns literally named ``:id``. The output is therefore
+    only valid inside ``text()``.
 
     Returns a comma-separated quoted list, or "" when the table has no
     property columns.
@@ -157,7 +162,10 @@ async def live_property_columns(db: AsyncSession, table_name: str) -> str:
             "ORDER BY ordinal_position"
         ).bindparams(schema=schema, tn=table_name)
     )
-    return ", ".join('"' + name.replace('"', '""') + '"' for (name,) in result.all())
+    return ", ".join(
+        '"' + name.replace('"', '""').replace(":", "\\:") + '"'
+        for (name,) in result.all()
+    )
 
 
 async def _projected_row_source(

--- a/backend/app/modules/catalog/features/service.py
+++ b/backend/app/modules/catalog/features/service.py
@@ -126,6 +126,59 @@ def parse_bbox(bbox_str: str) -> list[float]:
     return values
 
 
+async def live_property_columns(db: AsyncSession, table_name: str) -> str:
+    """Quoted select-list of the table's live columns minus gid/geom/geom_4326.
+
+    fix(#1104): feature properties used to be rendered as ``to_jsonb(t.*) -
+    'gid' - 'geom' - 'geom_4326'``, which serializes EVERY column before the
+    subtraction — and PostGIS's geometry→jsonb cast raises on curved input
+    (``lwgeom_to_geojson: 'MultiSurface' geometry type not supported``). The
+    original ``geom`` column deliberately preserves the curved source even
+    after ingest linearizes ``geom_4326``, so a curved dataset 500'd every
+    feature read through a column the response then discarded. Readers now
+    project the row to this list first, so the cast never sees ``geom``.
+
+    The live schema is authoritative here on purpose: ``Dataset.column_info``
+    can drift from the table on re-upload, and a projected list must match
+    the table or the whole query fails. Names are double-quote escaped.
+
+    Returns a comma-separated quoted list, or "" when the table has no
+    property columns.
+    """
+    from app.core.db.tenant_schema import tenant_data_schema
+    from app.core.db.tenant_session import current_tenant_var
+
+    schema = tenant_data_schema(current_tenant_var.get())
+    result = await db.execute(
+        text(
+            "SELECT column_name FROM information_schema.columns "
+            "WHERE table_schema = :schema AND table_name = :tn "
+            "AND column_name NOT IN ('gid', 'geom', 'geom_4326') "
+            "ORDER BY ordinal_position"
+        ).bindparams(schema=schema, tn=table_name)
+    )
+    return ", ".join('"' + name.replace('"', '""') + '"' for (name,) in result.all())
+
+
+async def _projected_row_source(
+    db: AsyncSession, table_name: str, *, with_geometry: bool
+) -> str:
+    """Render the projected FROM source feature readers serialize from.
+
+    See ``live_property_columns`` for why the row is projected before
+    ``to_jsonb``. ``geom_4326`` rides along when the table is spatial so
+    bbox predicates and the geometry select keep working; the planner
+    flattens the subquery, so index use is unchanged.
+    """
+    prop_cols = await live_property_columns(db, table_name)
+    prop_sel = f", {prop_cols}" if prop_cols else ""
+    geom_sel = ", geom_4326" if with_geometry else ""
+    return (
+        f"(SELECT gid{geom_sel}{prop_sel} "
+        f"FROM {get_catalog_port().quote_table(table_name)})"
+    )
+
+
 async def get_features(
     db: AsyncSession,
     table_name: str,
@@ -150,19 +203,21 @@ async def get_features(
     supported as a legacy fallback for clients that have not migrated to
     cursor pagination.
     """
-    # Build SELECT columns
+    # Build SELECT columns over the projected row (see live_property_columns
+    # for why geom must never reach to_jsonb).
     if has_geometry and include_geometry:
         select_cols = (
             "gid, ST_AsGeoJSON(geom_4326, 6)::json AS geometry, "
-            "to_jsonb(t.*) - 'gid' - 'geom' - 'geom_4326' AS properties"
+            "to_jsonb(t.*) - 'gid' - 'geom_4326' AS properties"
         )
     elif has_geometry:
         select_cols = (
             "gid, NULL::json AS geometry, "
-            "to_jsonb(t.*) - 'gid' - 'geom' - 'geom_4326' AS properties"
+            "to_jsonb(t.*) - 'gid' - 'geom_4326' AS properties"
         )
     else:
         select_cols = "gid, NULL::json AS geometry, to_jsonb(t.*) - 'gid' AS properties"
+    row_source = await _projected_row_source(db, table_name, with_geometry=has_geometry)
 
     # Build WHERE clauses
     where_clauses: list[str] = []
@@ -210,12 +265,12 @@ async def get_features(
     # Data query — keyset uses LIMIT only (no OFFSET); legacy uses LIMIT + OFFSET.
     if use_keyset:
         data_sql = (
-            f"SELECT {select_cols} FROM {get_catalog_port().quote_table(table_name)} t "
+            f"SELECT {select_cols} FROM {row_source} t "
             f"{where_sql} ORDER BY gid LIMIT :limit"
         )
     else:
         data_sql = (
-            f"SELECT {select_cols} FROM {get_catalog_port().quote_table(table_name)} t "
+            f"SELECT {select_cols} FROM {row_source} t "
             f"{where_sql} ORDER BY gid LIMIT :limit OFFSET :offset"
         )
         bind_values["offset"] = offset
@@ -269,13 +324,11 @@ async def get_features_geojson_z(
     """
     select_cols = (
         "gid, ST_AsGeoJSON(geom_4326, 6)::json AS geometry, "
-        "to_jsonb(t.*) - 'gid' - 'geom' - 'geom_4326' AS properties"
+        "to_jsonb(t.*) - 'gid' - 'geom_4326' AS properties"
     )
+    row_source = await _projected_row_source(db, table_name, with_geometry=True)
     # Fetch cap+1 to detect truncation without a separate COUNT query
-    data_sql = (
-        f"SELECT {select_cols} FROM {get_catalog_port().quote_table(table_name)} "
-        "t ORDER BY gid LIMIT :limit"
-    )
+    data_sql = f"SELECT {select_cols} FROM {row_source} t ORDER BY gid LIMIT :limit"
     result = await db.execute(text(data_sql).bindparams(limit=cap + 1))
     rows = [dict(row._mapping) for row in result.all()]
 
@@ -311,15 +364,13 @@ async def get_feature_by_id(
     if has_geometry:
         select_cols = (
             "gid, ST_AsGeoJSON(geom_4326, 6)::json AS geometry, "
-            "to_jsonb(t.*) - 'gid' - 'geom' - 'geom_4326' AS properties"
+            "to_jsonb(t.*) - 'gid' - 'geom_4326' AS properties"
         )
     else:
         select_cols = "gid, NULL::json AS geometry, to_jsonb(t.*) - 'gid' AS properties"
 
-    sql = (
-        f"SELECT {select_cols} FROM {get_catalog_port().quote_table(table_name)} "
-        "t WHERE gid = :gid"
-    )
+    row_source = await _projected_row_source(db, table_name, with_geometry=has_geometry)
+    sql = f"SELECT {select_cols} FROM {row_source} t WHERE gid = :gid"
     result = await db.execute(text(sql).bindparams(gid=gid))
     row = result.first()
     if row is None:

--- a/backend/app/platform/analysis_sql.py
+++ b/backend/app/platform/analysis_sql.py
@@ -17,6 +17,12 @@ Pure string rendering. The injection boundary:
 Source geometries are wrapped in ``ST_MakeValid``: one invalid ring anywhere
 in a dataset would otherwise abort the whole statement with a GEOS
 TopologyException, with no user-side workaround.
+
+``geom_4326`` is always LINEAR — ingest applies ``ST_CurveToLine`` when it
+builds the column and migration 0034 backfilled existing rows (#1104) — so
+nothing rendered here needs to guard against curved input. The per-read
+``linearized()`` wrapper the #1097 review added predated that invariant and
+is gone.
 """
 
 from __future__ import annotations
@@ -667,39 +673,6 @@ INTERNAL_ALIAS_PREFIX = "_gl_"
 NON_GROUPABLE_COLUMN_TYPES = frozenset({"json", "xml"})
 
 
-def linearized(column: str) -> str:
-    """Wrap a geometry read so curved types never reach curve-intolerant SQL.
-
-    fix(#1097 review): WFS sources can store CURVED geometries — GeoServer's
-    MultiSurface/CompoundCurve layers ingest as-is, because ingest classifies
-    the dataset by the closest concrete linear type (metadata.py's
-    _ABSTRACT_TO_CONCRETE_GEOMETRY_TYPE) without touching the stored binary.
-    Three families of SQL these operations rely on then RAISE on such a row
-    (each verified against PostGIS 3.6): ``::geography`` ("Geography type does
-    not support MultiSurface"), ``ST_MakeValid`` ("unsupported geometry type"),
-    and ``ST_AsGeoJSON`` ("geometry type not supported" — GeoJSON has no
-    curves). ``ST_CurveToLine`` densifies arcs into the linear equivalent and
-    is an exact no-op on already-linear input, so every geometry read that
-    feeds one of those functions — or that passes through into preview GeoJSON
-    or a CTAS output table — goes through this wrapper.
-
-    This is deliberately NOT a repair (contrast ST_MakeValid): the catalog
-    already promises the linear type for these datasets, so the linearized
-    form is the declared shape, not a changed one.
-
-    WHERE predicates stay on the BARE column: ``&&`` (a bbox operator),
-    ``ST_Intersects``, ``ST_Dimension`` and ``ST_IsEmpty`` all accept curves
-    directly (verified), and wrapping the column there would defeat the GIST
-    index the predicates are shaped around.
-
-    These wraps are the analysis-scoped half of a wider class — tiles,
-    feature reads, and the pre-existing operations hit the same raises on
-    main. #1104 tracks normalizing ``geom_4326`` at ingest, after which this
-    helper becomes removable.
-    """
-    return f"ST_CurveToLine({column})"
-
-
 def render_intersect_pairs(
     src_table_ref: str,
     mask_table_ref: str,
@@ -760,7 +733,7 @@ def render_intersect_pairs(
         f"SELECT _o.gid AS _gl_mask_gid{mask_pick},"
         f" ST_Subdivide(_o._gl_g, {MASK_SUBDIVIDE_MAX_VERTICES}) AS geom"
         f" FROM (SELECT gid{mask_pick},"
-        f" ST_CollectionExtract(ST_MakeValid({linearized('geom_4326')}), 3) AS _gl_g"
+        f" ST_CollectionExtract(ST_MakeValid(geom_4326), 3) AS _gl_g"
         f" FROM {mask_table_ref} WHERE geom_4326 IS NOT NULL OFFSET 0) AS _o"
         f" WHERE NOT ST_IsEmpty(_o._gl_g))"
         f" SELECT (row_number() OVER ())::integer AS gid,"
@@ -768,18 +741,14 @@ def render_intersect_pairs(
         f" CASE WHEN _p._gl_src_type = 'LINESTRING'"
         f" THEN ST_LineMerge(_p.geom) ELSE _p.geom END AS geom"
         f" FROM (SELECT _src.gid AS {INTERSECT_SOURCE_GID_COLUMN},"
-        # linearized: GeometryType of a curved source reads COMPOUNDCURVE,
-        # which would silently skip the LINESTRING ST_LineMerge branch above.
-        # ST_Dimension below stays raw — it accepts curves and answers the
-        # same number either way.
-        f" GeometryType({linearized('_src.geom_4326')}) AS _gl_src_type"
+        f" GeometryType(_src.geom_4326) AS _gl_src_type"
         f"{src_sel}{mask_sel},"
         f" ST_Union(ST_CollectionExtract("
         f"ST_Intersection(_sv.g, _mp.geom),"
         f" ST_Dimension(_src.geom_4326) + 1)) AS geom"
         f" FROM {src_table_ref} AS _src"
         f" CROSS JOIN LATERAL (SELECT"
-        f" ST_MakeValid({linearized('_src.geom_4326')}) AS g"
+        f" ST_MakeValid(_src.geom_4326) AS g"
         f" OFFSET 0) AS _sv"
         f" JOIN _mask_pieces AS _mp"
         f" ON _mp.geom && _src.geom_4326"
@@ -939,7 +908,7 @@ def render_measure_columns(*, src: str = "") -> tuple[str, str]:
     prefix = f"{src}." if src else ""
     join = (
         f" CROSS JOIN LATERAL"
-        f" (SELECT {linearized(f'{prefix}geom_4326')}::geography AS g"
+        f" (SELECT {prefix}geom_4326::geography AS g"
         f" OFFSET 0) AS _mg"
     )
     columns = (
@@ -1092,7 +1061,7 @@ def render_spatial_join(
         # 10s statement timeout, so the preview 422'd on a pairing a user would
         # obviously try.
         f" CROSS JOIN LATERAL"
-        f" (SELECT ST_MakeValid({linearized(f'{src}.geom_4326')}) AS g"
+        f" (SELECT ST_MakeValid({src}.geom_4326) AS g"
         f" OFFSET 0) AS _sv"
         f" CROSS JOIN LATERAL ("
         f"SELECT count(*)::integer AS {SPATIAL_JOIN_COUNT_COLUMN}"
@@ -1206,9 +1175,9 @@ def render_geometry_expr(
     if operation == "measure":
         # fix(#954): like spatial_join, measure adds columns and leaves the
         # geometry alone — see the spatial_join note below on why the output is
-        # NOT ST_MakeValid'd (linearized() explains why it IS linearized). The
-        # measured columns come from render_measure_columns.
-        return linearized("geom_4326"), ""
+        # NOT ST_MakeValid'd. The measured columns come from
+        # render_measure_columns.
+        return "geom_4326", ""
     if operation == "spatial_join":
         # fix(#953): a spatial join adds columns; the geometry is the source
         # feature as stored. Deliberately NOT ST_MakeValid'd, unlike every
@@ -1217,10 +1186,8 @@ def render_geometry_expr(
         # silently returning a repaired copy would hand back a geometry the
         # user never asked to change. Validity still gets handled where it
         # actually matters, inside the join predicate (render_spatial_join).
-        # Linearization is not that kind of change — a curved pass-through
-        # cannot be serialized to GeoJSON at all (see linearized()).
         # The join columns themselves come from render_spatial_join.
-        return linearized("geom_4326"), ""
+        return "geom_4326", ""
     if operation == "select_by_location":
         # fix(#955): the drawn-mask half of select-by-location. The geometry is
         # the source feature verbatim (like spatial_join/measure above, and NOT
@@ -1237,7 +1204,7 @@ def render_geometry_expr(
         # render_select_by_location_where).
         mask_expr = render_mask_expr(mask or {})
         return (
-            linearized("geom_4326"),
+            "geom_4326",
             f" WHERE geom_4326 && {mask_expr}"
             f" AND ST_Intersects(geom_4326, {mask_expr})",
         )

--- a/backend/app/processing/analysis/tasks.py
+++ b/backend/app/processing/analysis/tasks.py
@@ -38,7 +38,6 @@ from app.platform.analysis_sql import (
     MEASURE_OUTPUT_COLUMNS,
     NON_GROUPABLE_COLUMN_TYPES,
     NOT_EMPTY_PREDICATE,
-    linearized,
     render_clip_layer_join,
     render_geometry_expr,
     render_intersect_pairs,
@@ -975,7 +974,7 @@ def _build_materialize_select(
         measure_cols, measure_join = render_measure_columns(src="_src")
         cols = "".join(f"_src.{_sql_quote_ident(c)}, " for c in carry_cols)
         return _wrap_not_empty(
-            f"SELECT _src.gid, {cols}{linearized('_src.geom_4326')} AS geom,"
+            f"SELECT _src.gid, {cols}_src.geom_4326 AS geom,"
             f" {measure_cols}"
             f" FROM {src_ref} AS _src{measure_join}"
         )
@@ -989,7 +988,7 @@ def _build_materialize_select(
         )
         cols = "".join(f"_src.{_sql_quote_ident(c)}, " for c in carry_cols)
         return _wrap_not_empty(
-            f"SELECT _src.gid, {cols}{linearized('_src.geom_4326')} AS geom,"
+            f"SELECT _src.gid, {cols}_src.geom_4326 AS geom,"
             f" {join_cols}"
             f" FROM {src_ref} AS _src{joins}"
         )
@@ -1021,12 +1020,12 @@ def _build_materialize_select(
         # geometry directly, which is what the output geometry IS.
         #
         # The DRAWN-mask half needs no branch at all: render_geometry_expr
-        # returns the linearized pass-through and its <where>, and the generic
-        # tail below is already the right shape.
+        # returns the pass-through and its <where>, and the generic tail
+        # below is already the right shape.
         where = render_select_by_location_where(mask_table_ref, src="_src")
         cols = "".join(f"_src.{_sql_quote_ident(c)}, " for c in carry_cols)
         return _wrap_not_empty(
-            f"SELECT _src.gid, {cols}{linearized('_src.geom_4326')} AS geom"
+            f"SELECT _src.gid, {cols}_src.geom_4326 AS geom"
             f" FROM {src_ref} AS _src{where}"
         )
     if operation == "clip" and mask_table_ref is not None:

--- a/backend/app/processing/ingest/metadata.py
+++ b/backend/app/processing/ingest/metadata.py
@@ -1662,14 +1662,18 @@ async def linearize_existing_4326(
         # instead. An empty or linear generated column registers fine; an
         # expression that only yields curves for FUTURE rows is #1114's
         # residue, same as any post-registration external write.
+        # fix(#1113 review r9): the test is "would linearization change the
+        # value", byte-for-byte — it catches arcs, top-level curve types, AND
+        # curve containers nested inside a GEOMETRYCOLLECTION with one
+        # comparison, while an all-linear collection (which ST_CurveToLine
+        # returns unchanged) stays registrable. A type list here would either
+        # miss the nested case or over-reject linear collections.
         curved = (
             await session.execute(
                 text(
                     f"SELECT 1 FROM {tref} "  # noqa: S608
-                    f"WHERE ST_HasArc(geom_4326) "
-                    f"   OR rtrim(GeometryType(geom_4326), 'M') IN "
-                    f"      ('CIRCULARSTRING','COMPOUNDCURVE','CURVEPOLYGON',"
-                    f"       'MULTICURVE','MULTISURFACE') "
+                    f"WHERE ST_AsBinary(ST_CurveToLine(geom_4326)) "
+                    f"      <> ST_AsBinary(geom_4326) "
                     f"LIMIT 1"
                 )
             )

--- a/backend/app/processing/ingest/metadata.py
+++ b/backend/app/processing/ingest/metadata.py
@@ -1641,6 +1641,22 @@ async def linearize_existing_4326(
     base curve name ends in M.
     """
     tref = _qtable(table_name, schema=schema)
+    # fix(#1113 review r7): a STORED GENERATED geom_4326 rejects any UPDATE at
+    # parse time (even one whose WHERE matches nothing), and its values are
+    # decided by its generation expression, so it can be neither repaired nor
+    # safely retyped here — skip it (#1114 tracks expressions that yield
+    # curves).
+    generated = (
+        await session.execute(
+            text(
+                "SELECT 1 FROM information_schema.columns "
+                "WHERE table_schema = :schema AND table_name = :table "
+                "  AND column_name = 'geom_4326' AND is_generated = 'ALWAYS'"
+            ).bindparams(schema=schema, table=table_name)
+        )
+    ).first()
+    if generated is not None:
+        return
     typmod = (
         await session.execute(
             text(

--- a/backend/app/processing/ingest/metadata.py
+++ b/backend/app/processing/ingest/metadata.py
@@ -1633,38 +1633,50 @@ async def linearize_existing_4326(
 
     A BYO column may also DECLARE a curved typmod — geometry(CurvePolygon,
     4326) — which would reject the linear UPDATE result outright; such a
-    column is loosened to generic geometry(Geometry, srid) first. Only the
+    column is loosened to a generic typmod first, PRESERVING its Z/M flags
+    (geometry_columns reports M as a type suffix and Z only via
+    coord_dimension, and a plain Geometry typmod rejects Z values). Only the
     concrete curve typmods need it (abstract CURVE/SURFACE accept their
-    linear subtypes).
+    linear subtypes); rtrim(type,'M') matches the M-suffixed variants — no
+    base curve name ends in M.
     """
     tref = _qtable(table_name, schema=schema)
     typmod = (
         await session.execute(
             text(
-                "SELECT type, srid FROM public.geometry_columns "
+                "SELECT type, srid, coord_dimension "
+                "FROM public.geometry_columns "
                 "WHERE f_table_schema = :schema "
                 "  AND f_table_name = :table "
                 "  AND f_geometry_column = 'geom_4326' "
-                "  AND type IN ('CIRCULARSTRING','COMPOUNDCURVE',"
+                "  AND rtrim(type, 'M') IN ('CIRCULARSTRING','COMPOUNDCURVE',"
                 "               'CURVEPOLYGON','MULTICURVE','MULTISURFACE')"
             ).bindparams(schema=schema, table=table_name)
         )
     ).first()
     if typmod is not None:
+        if typmod.coord_dimension == 4:
+            generic = "GeometryZM"
+        elif typmod.coord_dimension == 3:
+            generic = "GeometryM" if typmod.type.endswith("M") else "GeometryZ"
+        else:
+            generic = "Geometry"
         await session.execute(
             text(
                 f"ALTER TABLE {tref} ALTER COLUMN geom_4326 "
-                f"TYPE geometry(Geometry, {int(typmod.srid)})"
+                f"TYPE geometry({generic}, {int(typmod.srid)})"
             )
         )
+    # rtrim on GeometryType too: an M curve reports CURVEPOLYGONM, so the
+    # bare list would skip an arc-free M container.
     await session.execute(
         text(
             f"UPDATE {tref} SET geom_4326 = ST_CurveToLine(geom_4326) "
             f"WHERE ST_HasArc(geom_4326) "
-            f"   OR GeometryType(geom_4326) IN "
+            f"   OR rtrim(GeometryType(geom_4326), 'M') IN "
             f"      ('CIRCULARSTRING','COMPOUNDCURVE','CURVEPOLYGON',"
             f"       'MULTICURVE','MULTISURFACE') "
-            f"   OR GeometryType(geom_4326) = 'GEOMETRYCOLLECTION'"
+            f"   OR rtrim(GeometryType(geom_4326), 'M') = 'GEOMETRYCOLLECTION'"
         )
     )
 

--- a/backend/app/processing/ingest/metadata.py
+++ b/backend/app/processing/ingest/metadata.py
@@ -1616,6 +1616,34 @@ async def add_4326_column(
     # CREATE INDEX above atomically.
 
 
+async def linearize_existing_4326(
+    session: AsyncSession, table_name: str, *, schema: str = "data"
+) -> None:
+    """Enforce the geom_4326-is-always-linear invariant on a column we did not write.
+
+    fix(#1113 review): ``register_existing_table`` skips :func:`add_4326_column`
+    when the table already carries geom_4326, so a table created or copied into
+    the data schema AFTER migration 0034 ran could re-introduce curved values
+    the backfill can no longer see — and the per-read ST_CurveToLine wraps that
+    used to absorb them are gone. Registration is the app's write boundary for
+    such tables, so the invariant is enforced here, with the same predicate as
+    the migration: any arc, any top-level curve type, or any
+    GEOMETRYCOLLECTION (curve members cannot hide anywhere else — linear multi
+    types cannot contain them). Exact no-op on already-linear rows.
+    """
+    tref = _qtable(table_name, schema=schema)
+    await session.execute(
+        text(
+            f"UPDATE {tref} SET geom_4326 = ST_CurveToLine(geom_4326) "
+            f"WHERE ST_HasArc(geom_4326) "
+            f"   OR GeometryType(geom_4326) IN "
+            f"      ('CIRCULARSTRING','COMPOUNDCURVE','CURVEPOLYGON',"
+            f"       'MULTICURVE','MULTISURFACE') "
+            f"   OR GeometryType(geom_4326) = 'GEOMETRYCOLLECTION'"
+        )
+    )
+
+
 async def ensure_geom_4326_gist_index(
     session: AsyncSession, table_name: str, *, schema: str = "data"
 ) -> None:

--- a/backend/app/processing/ingest/metadata.py
+++ b/backend/app/processing/ingest/metadata.py
@@ -1630,8 +1630,33 @@ async def linearize_existing_4326(
     the migration: any arc, any top-level curve type, or any
     GEOMETRYCOLLECTION (curve members cannot hide anywhere else — linear multi
     types cannot contain them). Exact no-op on already-linear rows.
+
+    A BYO column may also DECLARE a curved typmod — geometry(CurvePolygon,
+    4326) — which would reject the linear UPDATE result outright; such a
+    column is loosened to generic geometry(Geometry, srid) first. Only the
+    concrete curve typmods need it (abstract CURVE/SURFACE accept their
+    linear subtypes).
     """
     tref = _qtable(table_name, schema=schema)
+    typmod = (
+        await session.execute(
+            text(
+                "SELECT type, srid FROM public.geometry_columns "
+                "WHERE f_table_schema = :schema "
+                "  AND f_table_name = :table "
+                "  AND f_geometry_column = 'geom_4326' "
+                "  AND type IN ('CIRCULARSTRING','COMPOUNDCURVE',"
+                "               'CURVEPOLYGON','MULTICURVE','MULTISURFACE')"
+            ).bindparams(schema=schema, table=table_name)
+        )
+    ).first()
+    if typmod is not None:
+        await session.execute(
+            text(
+                f"ALTER TABLE {tref} ALTER COLUMN geom_4326 "
+                f"TYPE geometry(Geometry, {int(typmod.srid)})"
+            )
+        )
     await session.execute(
         text(
             f"UPDATE {tref} SET geom_4326 = ST_CurveToLine(geom_4326) "

--- a/backend/app/processing/ingest/metadata.py
+++ b/backend/app/processing/ingest/metadata.py
@@ -1595,13 +1595,17 @@ async def add_4326_column(
         )
     )
 
+    # fix(#1113 review r16): linearize IN THE SOURCE CRS, then reproject. An
+    # arc is defined by its control points, and CRS transforms are nonlinear:
+    # transforming the control points first and densifying after traces the
+    # arc in the wrong space, so ST_CurveToLine(ST_Transform(...)) yields a
+    # materially different shape from the correct
+    # ST_Transform(ST_CurveToLine(...)).
     if source_srid == 4326:
-        source_expr = "ST_SetSRID(geom, 4326)"
+        rewrite_expr = "ST_Force2D(ST_CurveToLine(ST_SetSRID(geom, 4326)))"
     else:
-        source_expr = "ST_Transform(geom, 4326)"
-    await session.execute(
-        text(f"UPDATE {tref} SET geom_4326 = ST_Force2D(ST_CurveToLine({source_expr}))")
-    )
+        rewrite_expr = "ST_Force2D(ST_Transform(ST_CurveToLine(geom), 4326))"
+    await session.execute(text(f"UPDATE {tref} SET geom_4326 = {rewrite_expr}"))
 
     await ensure_geom_4326_gist_index(session, table_name, schema=schema)
 

--- a/backend/app/processing/ingest/metadata.py
+++ b/backend/app/processing/ingest/metadata.py
@@ -1577,6 +1577,14 @@ async def add_4326_column(
     (e.g. SRID 4979 with elevation), `ST_Force2D` strips Z so the UPDATE
     doesn't fail with `Geometry has Z dimension but column does not`. Z is
     still preserved in the original `geom` column.
+
+    fix(#1104): the column is also always LINEAR. WFS ingest admits curved
+    geometries (MultiSurface/CompoundCurve), and every surface that reads
+    geom_4326 raises on them: ST_AsMVTGeom (vector tiles), ST_AsGeoJSON
+    (feature reads), ``::geography`` and ST_MakeValid (analysis).
+    `ST_CurveToLine` densifies arcs here, at the one boundary they all read
+    from; it is an exact no-op on already-linear input, and the curved
+    source stays in the original `geom` column, same as Z does.
     """
     tref = _qtable(table_name, schema=schema)
 
@@ -1588,13 +1596,12 @@ async def add_4326_column(
     )
 
     if source_srid == 4326:
-        await session.execute(
-            text(f"UPDATE {tref} SET geom_4326 = ST_Force2D(ST_SetSRID(geom, 4326))")
-        )
+        source_expr = "ST_SetSRID(geom, 4326)"
     else:
-        await session.execute(
-            text(f"UPDATE {tref} SET geom_4326 = ST_Force2D(ST_Transform(geom, 4326))")
-        )
+        source_expr = "ST_Transform(geom, 4326)"
+    await session.execute(
+        text(f"UPDATE {tref} SET geom_4326 = ST_Force2D(ST_CurveToLine({source_expr}))")
+    )
 
     await ensure_geom_4326_gist_index(session, table_name, schema=schema)
 

--- a/backend/app/processing/ingest/metadata.py
+++ b/backend/app/processing/ingest/metadata.py
@@ -1656,6 +1656,30 @@ async def linearize_existing_4326(
         )
     ).first()
     if generated is not None:
+        # fix(#1113 review r8): a generated column whose CURRENT rows are
+        # curved would register a dataset broken on every surface, and no
+        # later write of ours can fix it — refuse with the actionable cause
+        # instead. An empty or linear generated column registers fine; an
+        # expression that only yields curves for FUTURE rows is #1114's
+        # residue, same as any post-registration external write.
+        curved = (
+            await session.execute(
+                text(
+                    f"SELECT 1 FROM {tref} "  # noqa: S608
+                    f"WHERE ST_HasArc(geom_4326) "
+                    f"   OR rtrim(GeometryType(geom_4326), 'M') IN "
+                    f"      ('CIRCULARSTRING','COMPOUNDCURVE','CURVEPOLYGON',"
+                    f"       'MULTICURVE','MULTISURFACE') "
+                    f"LIMIT 1"
+                )
+            )
+        ).first()
+        if curved is not None:
+            raise ValueError(
+                "geom_4326 is a generated column whose expression yields "
+                "curved geometries; adjust it to apply ST_CurveToLine "
+                "(curved types break tiles, feature reads, and analysis)"
+            )
         return
     typmod = (
         await session.execute(

--- a/backend/app/processing/ingest/service.py
+++ b/backend/app/processing/ingest/service.py
@@ -25,6 +25,7 @@ from app.core.db.tenant_session import defer_async_with_tenant
 from app.platform.extensions import get_processing_port
 from app.processing.ingest.metadata import (
     add_4326_column,
+    linearize_existing_4326,
     extract_metadata,
     get_sample_values,
     get_table_srid,
@@ -604,6 +605,20 @@ async def register_existing_table(
             except Exception as exc:  # broad: ALTER TABLE/CREATE INDEX inside savepoint can fail for schema/permission reasons
                 raise ValueError(
                     f"Failed to add geom_4326 column to '{table_name}': {exc}"
+                ) from exc
+        else:
+            # fix(#1113 review): a pre-existing geom_4326 was written by
+            # someone else, and a table registered AFTER migration 0034 ran is
+            # invisible to its backfill — curved values here would reach the
+            # readers with the per-read ST_CurveToLine wraps now gone.
+            # Registration is the write boundary for such tables, so the
+            # linear invariant is enforced on the way in.
+            try:
+                async with session.begin_nested():
+                    await linearize_existing_4326(session, table_name, schema=_schema)
+            except Exception as exc:  # broad: UPDATE inside savepoint can fail for schema/permission reasons
+                raise ValueError(
+                    f"Failed to linearize geom_4326 on '{table_name}': {exc}"
                 ) from exc
 
         await grant_reader_access(session, table_name, schema=_schema, role=_grant_role)

--- a/backend/tests/test_analysis_curved_sources.py
+++ b/backend/tests/test_analysis_curved_sources.py
@@ -28,6 +28,11 @@ from tests.factories import get_user_id
 from tests.test_analysis_materialize import _create_job
 from tests.test_analysis_spatial_join import _create_layer
 
+# fix(#1104): make the fixtures defined in test_tiles.py (especially
+# _init_tile_pool_for_tests) available to this module without duplicating the
+# fixture body — same pattern as test_tile_cache_cols_key.py.
+pytest_plugins = ["tests.test_tiles"]
+
 # A full circle of radius 0.5 centred on (0.5, 0), stored as the curved
 # MULTISURFACE/CURVEPOLYGON type a GeoServer WFS layer ingests as.
 CURVED_POLYGON = (
@@ -346,3 +351,56 @@ class TestBinaryJoinFields:
         assert len(features) == 1
         assert features[0]["properties"]["join_blob"] == "\\xdeadbeef"
         assert features[0]["properties"]["join_blobs"] == ["\\xdead", "\\xbeef"]
+
+
+class TestCurvedIngestNormalization:
+    """fix(#1104): ingest stores geom_4326 LINEAR, so every surface reads it.
+
+    The classes above pin the analysis operations. These pin the stored
+    invariant itself plus the two broken surfaces with no other curved
+    coverage: vector tiles (ST_AsMVTGeom raised ``lwgeom_get_basic_type:
+    Invalid type (12)``) and the features browse endpoint (ST_AsGeoJSON
+    raises because GeoJSON has no curved types).
+    """
+
+    async def test_ingest_stores_linear_geom_4326_and_curved_geom(
+        self, test_db_session: AsyncSession
+    ):
+        """add_4326_column linearizes geom_4326; `geom` keeps the curved source."""
+        admin_id = await get_user_id(test_db_session, "admin")
+        ds = await _create_layer(
+            test_db_session,
+            created_by=admin_id,
+            column_type="Geometry",
+            geometry_type="MULTIPOLYGON",
+            values_sql=(
+                f"('circle', {CURVED_POLYGON}, {CURVED_POLYGON}),"
+                f"('arc', {CURVED_LINE}, {CURVED_LINE})"
+            ),
+            feature_count=2,
+        )
+        rows = (
+            await test_db_session.execute(
+                text(
+                    f"SELECT GeometryType(geom), GeometryType(geom_4326)"  # noqa: S608
+                    f" FROM data.{ds.table_name} ORDER BY gid"
+                )
+            )
+        ).all()
+        assert [r[0] for r in rows] == ["MULTISURFACE", "COMPOUNDCURVE"]
+        assert [r[1] for r in rows] == ["MULTIPOLYGON", "LINESTRING"]
+
+    @pytest.mark.usefixtures("_init_tile_pool_for_tests")
+    async def test_vector_tile_renders_a_curved_source(
+        self,
+        client: AsyncClient,
+        test_db_session: AsyncSession,
+    ):
+        """The MVT endpoint serves bytes for a dataset ingested from curves."""
+        admin_id = await get_user_id(test_db_session, "admin")
+        ds = await _create_curved_polygon_layer(test_db_session, created_by=admin_id)
+        # The circle is centred on (0.5, 0), so tile 0/0/0 must contain it.
+        resp = await client.get(f"/tiles/data.{ds.table_name}/0/0/0.pbf")
+        assert resp.status_code == 200, resp.text
+        assert resp.headers["content-type"] == "application/vnd.mapbox-vector-tile"
+        assert len(resp.content) > 0

--- a/backend/tests/test_analysis_curved_sources.py
+++ b/backend/tests/test_analysis_curved_sources.py
@@ -393,6 +393,54 @@ class TestCurvedIngestNormalization:
         assert [r[0] for r in rows] == ["MULTISURFACE", "COMPOUNDCURVE"]
         assert [r[1] for r in rows] == ["MULTIPOLYGON", "LINESTRING"]
 
+    async def test_reprojected_ingest_densifies_in_the_source_crs(
+        self, test_db_session: AsyncSession
+    ):
+        """fix(#1113 review r16): linearize before ST_Transform, not after.
+
+        An arc is defined by control points and CRS transforms are nonlinear,
+        so densifying after the transform traces the arc in the wrong space.
+        Pin the exact composition by comparing the column against the correct
+        expression, and pin materiality by requiring the wrong-order result
+        to differ.
+        """
+        from app.processing.ingest.metadata import add_4326_column
+
+        table = f"crs_curved_{uuid.uuid4().hex[:10]}"
+        await test_db_session.execute(
+            text(
+                f"CREATE TABLE data.{table} ("  # noqa: S608
+                f"gid serial PRIMARY KEY, geom geometry(Geometry, 3857))"
+            )
+        )
+        # A large arc in web-mercator meters; big enough that projection
+        # nonlinearity is material.
+        await test_db_session.execute(
+            text(
+                f"INSERT INTO data.{table} (geom) VALUES "  # noqa: S608
+                f"(ST_GeomFromText('CIRCULARSTRING(0 0, 2000000 6000000, "
+                f"4000000 0)', 3857))"
+            )
+        )
+        await add_4326_column(test_db_session, table, 3857)
+        row = (
+            await test_db_session.execute(
+                text(
+                    f"SELECT "  # noqa: S608
+                    f"ST_OrderingEquals(geom_4326, "
+                    f"  ST_Force2D(ST_Transform(ST_CurveToLine(geom), 4326))), "
+                    f"ST_OrderingEquals(geom_4326, "
+                    f"  ST_Force2D(ST_CurveToLine(ST_Transform(geom, 4326)))) "
+                    f"FROM data.{table}"
+                )
+            )
+        ).one()
+        assert row[0] is True, "column must equal the linearize-then-transform form"
+        assert row[1] is False, (
+            "wrong-order form should differ materially; if it stops differing "
+            "this test no longer discriminates"
+        )
+
     async def test_register_linearizes_a_preexisting_curved_geom_4326(
         self, test_db_session: AsyncSession
     ):

--- a/backend/tests/test_analysis_curved_sources.py
+++ b/backend/tests/test_analysis_curved_sources.py
@@ -691,6 +691,61 @@ class TestCurvedIngestNormalization:
         )
         assert rows == []
 
+    async def test_register_refuses_a_constraint_declared_curved_column(
+        self, test_db_session: AsyncSession
+    ):
+        """fix(#1113 review r14): legacy CHECK declarations fail closed.
+
+        An old-style PostGIS table declares its type through
+        ``enforce_geotype_*`` CHECK constraints on a bare geometry column;
+        the typmod loosening cannot remove the CHECK, so the linearizing
+        UPDATE violates it. Registration must refuse with the cause rather
+        than admit the table un-normalized (the migration, by contrast,
+        skips-and-warns — it cannot refuse history).
+        """
+        from types import SimpleNamespace
+
+        import pytest as _pytest
+
+        from app.processing.ingest.schemas import RegisterRequest
+        from app.processing.ingest.service import register_existing_table
+
+        admin_id = await get_user_id(test_db_session, "admin")
+        table = f"byo_legacy_{uuid.uuid4().hex[:10]}"
+        await test_db_session.execute(
+            text(
+                f"CREATE TABLE data.{table} ("  # noqa: S608
+                f"gid serial PRIMARY KEY, name text, "
+                f"geom geometry(Geometry, 4326), geom_4326 geometry)"
+            )
+        )
+        await test_db_session.execute(
+            text(
+                f"ALTER TABLE data.{table} ADD CONSTRAINT "  # noqa: S608
+                f"enforce_geotype_geom_4326 CHECK "
+                f"(geometrytype(geom_4326) = 'CURVEPOLYGON'::text "
+                f" OR geom_4326 IS NULL)"
+            )
+        )
+        curve_poly = (
+            "ST_GeomFromText('CURVEPOLYGON(CIRCULARSTRING("
+            "0 0,0.5 0.5,1 0,0.5 -0.5,0 0))', 4326)"
+        )
+        await test_db_session.execute(
+            text(
+                f"INSERT INTO data.{table} (name, geom, geom_4326) VALUES "  # noqa: S608
+                f"('legacy', {CURVED_POLYGON}, {curve_poly})"
+            )
+        )
+        await test_db_session.commit()
+
+        with _pytest.raises(ValueError, match="Failed to linearize"):
+            await register_existing_table(
+                test_db_session,
+                RegisterRequest(table_name=table, title="Legacy constrained"),
+                SimpleNamespace(id=admin_id),
+            )
+
     async def test_register_loosens_a_curved_geom_4326_typmod(
         self, test_db_session: AsyncSession
     ):

--- a/backend/tests/test_analysis_curved_sources.py
+++ b/backend/tests/test_analysis_curved_sources.py
@@ -452,6 +452,61 @@ class TestCurvedIngestNormalization:
             ("MULTISURFACE", "MULTIPOLYGON"),
         ]
 
+    async def test_features_read_survives_a_socrata_colon_column(
+        self,
+        client: AsyncClient,
+        admin_auth_header: dict,
+        test_db_session: AsyncSession,
+    ):
+        """fix(#1113 review): a ``:id`` property must not read as a bind param.
+
+        Registered Socrata exports ship columns literally named ``:id``. The
+        projected select-list is interpolated into ``text()``, which parses
+        ``:name`` as a bind parameter even inside double quotes — unescaped,
+        every feature read on such a table fails before reaching PostgreSQL.
+        """
+        from types import SimpleNamespace
+
+        from app.processing.ingest.schemas import RegisterRequest
+        from app.processing.ingest.service import register_existing_table
+
+        admin_id = await get_user_id(test_db_session, "admin")
+        table = f"byo_socrata_{uuid.uuid4().hex[:10]}"
+        # The test's own DDL needs the same escape the fix installs: text()
+        # would otherwise read ":id" here as a bind parameter too.
+        await test_db_session.execute(
+            text(
+                f"CREATE TABLE data.{table} ("  # noqa: S608
+                f'gid serial PRIMARY KEY, "\\:id" text, name text, '
+                f"geom geometry(Geometry, 4326), "
+                f"geom_4326 geometry(Geometry, 4326))"
+            )
+        )
+        await test_db_session.execute(
+            text(
+                f'INSERT INTO data.{table} ("\\:id", name, geom, geom_4326) '  # noqa: S608
+                f"VALUES ('row-1', 'first', "
+                f"ST_SetSRID(ST_MakePoint(1, 1), 4326), "
+                f"ST_SetSRID(ST_MakePoint(1, 1), 4326))"
+            )
+        )
+        await test_db_session.commit()
+
+        registered = await register_existing_table(
+            test_db_session,
+            RegisterRequest(table_name=table, title="Socrata colon column"),
+            SimpleNamespace(id=admin_id),
+        )
+        await test_db_session.commit()
+
+        resp = await client.get(
+            f"/datasets/{registered.id}/features/", headers=admin_auth_header
+        )
+        assert resp.status_code == 200, resp.text
+        props = resp.json()["features"][0]["properties"]
+        assert props[":id"] == "row-1"
+        assert props["name"] == "first"
+
     async def test_register_loosens_a_curved_geom_4326_typmod(
         self, test_db_session: AsyncSession
     ):

--- a/backend/tests/test_analysis_curved_sources.py
+++ b/backend/tests/test_analysis_curved_sources.py
@@ -452,6 +452,68 @@ class TestCurvedIngestNormalization:
             ("MULTISURFACE", "MULTIPOLYGON"),
         ]
 
+    async def test_register_loosens_a_curved_geom_4326_typmod(
+        self, test_db_session: AsyncSession
+    ):
+        """fix(#1113 review): a curved column TYPMOD must not abort the write.
+
+        ``geometry(CurvePolygon, 4326)`` rejects the linear result of
+        ST_CurveToLine outright, so without the retype the enforcement UPDATE
+        itself fails. The column is loosened to generic geometry first, then
+        linearized.
+        """
+        from types import SimpleNamespace
+
+        from app.processing.ingest.schemas import RegisterRequest
+        from app.processing.ingest.service import register_existing_table
+
+        admin_id = await get_user_id(test_db_session, "admin")
+        table = f"byo_typmod_{uuid.uuid4().hex[:10]}"
+        curve_poly = (
+            "ST_GeomFromText('CURVEPOLYGON(CIRCULARSTRING("
+            "0 0,0.5 0.5,1 0,0.5 -0.5,0 0))', 4326)"
+        )
+        await test_db_session.execute(
+            text(
+                f"CREATE TABLE data.{table} ("  # noqa: S608
+                f"gid serial PRIMARY KEY, name text, "
+                f"geom geometry(Geometry, 4326), "
+                f"geom_4326 geometry(CurvePolygon, 4326))"
+            )
+        )
+        # geom carries the MULTISURFACE form the metadata classifier already
+        # maps to a concrete linear type; the curved TYPMOD under test lives
+        # on geom_4326 alone.
+        await test_db_session.execute(
+            text(
+                f"INSERT INTO data.{table} (name, geom, geom_4326) VALUES "  # noqa: S608
+                f"('circle', {CURVED_POLYGON}, {curve_poly})"
+            )
+        )
+        await test_db_session.commit()
+
+        await register_existing_table(
+            test_db_session,
+            RegisterRequest(table_name=table, title="BYO curved typmod"),
+            SimpleNamespace(id=admin_id),
+        )
+        await test_db_session.commit()
+
+        row = (
+            await test_db_session.execute(
+                text(
+                    f"SELECT GeometryType(geom_4326), "  # noqa: S608
+                    f"(SELECT type FROM public.geometry_columns "
+                    f" WHERE f_table_schema = 'data' "
+                    f"   AND f_table_name = '{table}' "
+                    f"   AND f_geometry_column = 'geom_4326') "
+                    f"FROM data.{table}"
+                )
+            )
+        ).one()
+        assert row[0] == "POLYGON"
+        assert row[1] == "GEOMETRY"
+
     @pytest.mark.usefixtures("_init_tile_pool_for_tests")
     async def test_vector_tile_renders_a_curved_source(
         self,

--- a/backend/tests/test_analysis_curved_sources.py
+++ b/backend/tests/test_analysis_curved_sources.py
@@ -1,12 +1,15 @@
-"""Curved-geometry sources and binary property values (#1097 review).
+"""Curved-geometry sources and binary property values (#1097 review, #1104).
 
 WFS ingest admits CURVED geometries — GeoServer MultiSurface/CompoundCurve
 layers load as stored, and ingest classifies the dataset by the closest
-concrete linear type without rewriting the rows (metadata.py's
-_ABSTRACT_TO_CONCRETE_GEOMETRY_TYPE). Verified against PostGIS 3.6:
-``::geography``, ``ST_MakeValid`` and ``ST_AsGeoJSON`` all RAISE on curved
-input, so without ``linearized()`` (analysis_sql) every operation in this file
-either 500s its preview or fails its CTAS on a dataset the app admits.
+concrete linear type (metadata.py's _ABSTRACT_TO_CONCRETE_GEOMETRY_TYPE).
+Verified against PostGIS 3.6: ``::geography``, ``ST_MakeValid``,
+``ST_AsGeoJSON`` and ``ST_AsMVTGeom`` all RAISE on curved input. fix(#1104):
+ingest therefore linearizes ``geom_4326`` itself (add_4326_column applies
+ST_CurveToLine; the curved source survives in ``geom``), and the fixture
+routes through that same normalizer — so every test here pins that the
+ingest invariant alone keeps analysis previews, CTAS outputs, tiles and
+feature reads working, with no per-read wraps left in the SQL.
 
 The bytea test pins the OTHER preview serialization hazard from the same
 review round: a transferred ``bytea`` value reaching Pydantic as raw bytes.

--- a/backend/tests/test_analysis_curved_sources.py
+++ b/backend/tests/test_analysis_curved_sources.py
@@ -507,6 +507,56 @@ class TestCurvedIngestNormalization:
         assert props[":id"] == "row-1"
         assert props["name"] == "first"
 
+    async def test_register_skips_a_generated_geom_4326(
+        self,
+        client: AsyncClient,
+        admin_auth_header: dict,
+        test_db_session: AsyncSession,
+    ):
+        """fix(#1113 review r7): a STORED GENERATED column must not abort.
+
+        PostgreSQL rejects any UPDATE against a generated column at parse
+        time — even one whose WHERE matches nothing — so the enforcement
+        UPDATE itself would fail registration. Such a column's values are
+        decided by its generation expression, so it is skipped, not repaired
+        (#1114 tracks expressions that yield curves).
+        """
+        from types import SimpleNamespace
+
+        from app.processing.ingest.schemas import RegisterRequest
+        from app.processing.ingest.service import register_existing_table
+
+        admin_id = await get_user_id(test_db_session, "admin")
+        table = f"byo_generated_{uuid.uuid4().hex[:10]}"
+        await test_db_session.execute(
+            text(
+                f"CREATE TABLE data.{table} ("  # noqa: S608
+                f"gid serial PRIMARY KEY, name text, "
+                f"geom geometry(Geometry, 4326), "
+                f"geom_4326 geometry GENERATED ALWAYS AS (ST_Force2D(geom)) STORED)"
+            )
+        )
+        await test_db_session.execute(
+            text(
+                f"INSERT INTO data.{table} (name, geom) VALUES "  # noqa: S608
+                f"('pt', ST_SetSRID(ST_MakePoint(2, 2), 4326))"
+            )
+        )
+        await test_db_session.commit()
+
+        registered = await register_existing_table(
+            test_db_session,
+            RegisterRequest(table_name=table, title="Generated geom_4326"),
+            SimpleNamespace(id=admin_id),
+        )
+        await test_db_session.commit()
+
+        resp = await client.get(
+            f"/datasets/{registered.id}/features/", headers=admin_auth_header
+        )
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["features"][0]["properties"]["name"] == "pt"
+
     async def test_register_loosens_a_curved_geom_4326_typmod(
         self, test_db_session: AsyncSession
     ):

--- a/backend/tests/test_analysis_curved_sources.py
+++ b/backend/tests/test_analysis_curved_sources.py
@@ -668,6 +668,29 @@ class TestCurvedIngestNormalization:
         )
         assert registered is not None
 
+    async def test_relationship_fetch_may_target_a_projected_out_column(
+        self, test_db_session: AsyncSession
+    ):
+        """fix(#1113 review r10): the match runs against the base table.
+
+        Safe-column validation accepts ``geom_4326`` as a relationship target,
+        and the projection deliberately drops it — predicating on the
+        projected alias made such a fetch an undefined-column error. A NULL
+        probe is enough to pin the regression: it must return no rows, not
+        raise.
+        """
+        from app.modules.catalog.datasets.domain.service_relationships import (
+            _fetch_target_rows,
+        )
+
+        admin_id = await get_user_id(test_db_session, "admin")
+        ds = await _create_curved_polygon_layer(test_db_session, created_by=admin_id)
+
+        rows = await _fetch_target_rows(
+            test_db_session, ds.table_name, "geom_4326", None, 10, 0
+        )
+        assert rows == []
+
     async def test_register_loosens_a_curved_geom_4326_typmod(
         self, test_db_session: AsyncSession
     ):

--- a/backend/tests/test_analysis_curved_sources.py
+++ b/backend/tests/test_analysis_curved_sources.py
@@ -557,6 +557,48 @@ class TestCurvedIngestNormalization:
         assert resp.status_code == 200, resp.text
         assert resp.json()["features"][0]["properties"]["name"] == "pt"
 
+    async def test_register_refuses_a_generated_column_that_yields_curves(
+        self, test_db_session: AsyncSession
+    ):
+        """fix(#1113 review r8): curved generated values refuse registration.
+
+        No write of ours can repair a generated column, so admitting one whose
+        rows are already curved registers a dataset broken on every surface.
+        The refusal names the cause; an empty or linear generated column
+        (previous test) registers fine.
+        """
+        from types import SimpleNamespace
+
+        import pytest as _pytest
+
+        from app.processing.ingest.schemas import RegisterRequest
+        from app.processing.ingest.service import register_existing_table
+
+        admin_id = await get_user_id(test_db_session, "admin")
+        table = f"byo_gencurved_{uuid.uuid4().hex[:10]}"
+        await test_db_session.execute(
+            text(
+                f"CREATE TABLE data.{table} ("  # noqa: S608
+                f"gid serial PRIMARY KEY, name text, "
+                f"geom geometry(Geometry, 4326), "
+                f"geom_4326 geometry GENERATED ALWAYS AS (geom) STORED)"
+            )
+        )
+        await test_db_session.execute(
+            text(
+                f"INSERT INTO data.{table} (name, geom) VALUES "  # noqa: S608
+                f"('circle', {CURVED_POLYGON})"
+            )
+        )
+        await test_db_session.commit()
+
+        with _pytest.raises(ValueError, match="generated column.*curved"):
+            await register_existing_table(
+                test_db_session,
+                RegisterRequest(table_name=table, title="Curved generated"),
+                SimpleNamespace(id=admin_id),
+            )
+
     async def test_register_loosens_a_curved_geom_4326_typmod(
         self, test_db_session: AsyncSession
     ):

--- a/backend/tests/test_analysis_curved_sources.py
+++ b/backend/tests/test_analysis_curved_sources.py
@@ -404,3 +404,45 @@ class TestCurvedIngestNormalization:
         assert resp.status_code == 200, resp.text
         assert resp.headers["content-type"] == "application/vnd.mapbox-vector-tile"
         assert len(resp.content) > 0
+
+    async def test_features_read_serializes_a_curved_source(
+        self,
+        client: AsyncClient,
+        admin_auth_header: dict,
+        test_db_session: AsyncSession,
+    ):
+        """Browse, single read, and features.geojson all answer for curves.
+
+        Two raises used to hide here: ST_AsGeoJSON over a curved geom_4326
+        (fixed by ingest linearization) and ``to_jsonb(t.*)`` serializing the
+        curved SOURCE ``geom`` column before the ``- 'geom'`` subtraction
+        could discard it (fixed by projecting the row first). Each response
+        also proves properties survived the projection.
+        """
+        admin_id = await get_user_id(test_db_session, "admin")
+        ds = await _create_curved_polygon_layer(test_db_session, created_by=admin_id)
+
+        resp = await client.get(
+            f"/datasets/{ds.id}/features/", headers=admin_auth_header
+        )
+        assert resp.status_code == 200, resp.text
+        features = resp.json()["features"]
+        assert len(features) == 1
+        assert features[0]["geometry"]["type"] in LINEAR_GEOJSON_TYPES
+        assert features[0]["properties"]["name"] == "circle"
+
+        gid = features[0]["id"]
+        single = await client.get(
+            f"/datasets/{ds.id}/features/{gid}", headers=admin_auth_header
+        )
+        assert single.status_code == 200, single.text
+        assert single.json()["geometry"]["type"] in LINEAR_GEOJSON_TYPES
+        assert single.json()["properties"]["name"] == "circle"
+
+        geojson = await client.get(
+            f"/datasets/{ds.id}/features.geojson", headers=admin_auth_header
+        )
+        assert geojson.status_code == 200, geojson.text
+        gj_features = geojson.json()["features"]
+        assert len(gj_features) == 1
+        assert gj_features[0]["geometry"]["type"] in LINEAR_GEOJSON_TYPES

--- a/backend/tests/test_analysis_curved_sources.py
+++ b/backend/tests/test_analysis_curved_sources.py
@@ -599,6 +599,75 @@ class TestCurvedIngestNormalization:
                 SimpleNamespace(id=admin_id),
             )
 
+    async def test_generated_reject_sees_nested_curves_but_not_linear_gcs(
+        self, test_db_session: AsyncSession
+    ):
+        """fix(#1113 review r9): the reject test is 'would conversion change it'.
+
+        A curve container nested in a GEOMETRYCOLLECTION has no arc and a
+        collection top-level type, so any type-list predicate misses it; an
+        all-LINEAR collection must still register. The byte-compare against
+        ST_CurveToLine's output answers both with one test.
+        """
+        from types import SimpleNamespace
+
+        import pytest as _pytest
+
+        from app.processing.ingest.schemas import RegisterRequest
+        from app.processing.ingest.service import register_existing_table
+
+        admin_id = await get_user_id(test_db_session, "admin")
+
+        nested = f"byo_gennested_{uuid.uuid4().hex[:10]}"
+        await test_db_session.execute(
+            text(
+                f"CREATE TABLE data.{nested} ("  # noqa: S608
+                f"gid serial PRIMARY KEY, name text, "
+                f"geom geometry(Geometry, 4326), "
+                f"geom_4326 geometry GENERATED ALWAYS AS (geom) STORED)"
+            )
+        )
+        await test_db_session.execute(
+            text(
+                f"INSERT INTO data.{nested} (name, geom) VALUES "  # noqa: S608
+                f"('hidden', ST_GeomFromText("
+                f"'GEOMETRYCOLLECTION(MULTISURFACE(((0 0,1 0,1 1,0 1,0 0))))'"
+                f", 4326))"
+            )
+        )
+        await test_db_session.commit()
+        with _pytest.raises(ValueError, match="generated column.*curved"):
+            await register_existing_table(
+                test_db_session,
+                RegisterRequest(table_name=nested, title="Nested curved"),
+                SimpleNamespace(id=admin_id),
+            )
+        await test_db_session.rollback()
+
+        linear_gc = f"byo_genlingc_{uuid.uuid4().hex[:10]}"
+        await test_db_session.execute(
+            text(
+                f"CREATE TABLE data.{linear_gc} ("  # noqa: S608
+                f"gid serial PRIMARY KEY, name text, "
+                f"geom geometry(Geometry, 4326), "
+                f"geom_4326 geometry GENERATED ALWAYS AS (geom) STORED)"
+            )
+        )
+        await test_db_session.execute(
+            text(
+                f"INSERT INTO data.{linear_gc} (name, geom) VALUES "  # noqa: S608
+                f"('plain', ST_GeomFromText("
+                f"'GEOMETRYCOLLECTION(POINT(1 1),LINESTRING(0 0,1 1))', 4326))"
+            )
+        )
+        await test_db_session.commit()
+        registered = await register_existing_table(
+            test_db_session,
+            RegisterRequest(table_name=linear_gc, title="Linear GC generated"),
+            SimpleNamespace(id=admin_id),
+        )
+        assert registered is not None
+
     async def test_register_loosens_a_curved_geom_4326_typmod(
         self, test_db_session: AsyncSession
     ):

--- a/backend/tests/test_analysis_curved_sources.py
+++ b/backend/tests/test_analysis_curved_sources.py
@@ -393,6 +393,65 @@ class TestCurvedIngestNormalization:
         assert [r[0] for r in rows] == ["MULTISURFACE", "COMPOUNDCURVE"]
         assert [r[1] for r in rows] == ["MULTIPOLYGON", "LINESTRING"]
 
+    async def test_register_linearizes_a_preexisting_curved_geom_4326(
+        self, test_db_session: AsyncSession
+    ):
+        """fix(#1113 review): the register path enforces the invariant too.
+
+        ``register_existing_table`` skips ``add_4326_column`` when the table
+        already carries geom_4326, and a table created in the data schema
+        AFTER migration 0034 ran is invisible to its backfill — so without
+        this boundary, registration would be the one app-controlled writer
+        that can re-admit curved values. Both curve shapes are pinned: an
+        arc-bearing surface AND an arc-free container (``MULTISURFACE`` of a
+        plain polygon), which ST_HasArc alone cannot see.
+        """
+        from types import SimpleNamespace
+
+        from app.processing.ingest.schemas import RegisterRequest
+        from app.processing.ingest.service import register_existing_table
+
+        admin_id = await get_user_id(test_db_session, "admin")
+        table = f"byo_curved_{uuid.uuid4().hex[:10]}"
+        arc_free = "ST_GeomFromText('MULTISURFACE(((0 0,1 0,1 1,0 1,0 0)))', 4326)"
+        await test_db_session.execute(
+            text(
+                f"CREATE TABLE data.{table} ("  # noqa: S608
+                f"gid serial PRIMARY KEY, name text, "
+                f"geom geometry(Geometry, 4326), "
+                f"geom_4326 geometry(Geometry, 4326))"
+            )
+        )
+        await test_db_session.execute(
+            text(
+                f"INSERT INTO data.{table} (name, geom, geom_4326) VALUES "  # noqa: S608
+                f"('circle', {CURVED_POLYGON}, {CURVED_POLYGON}), "
+                f"('flat', {arc_free}, {arc_free})"
+            )
+        )
+        await test_db_session.commit()
+
+        await register_existing_table(
+            test_db_session,
+            RegisterRequest(table_name=table, title="BYO curved table"),
+            SimpleNamespace(id=admin_id),
+        )
+        await test_db_session.commit()
+
+        rows = (
+            await test_db_session.execute(
+                text(
+                    f"SELECT name, GeometryType(geom), GeometryType(geom_4326) "  # noqa: S608
+                    f"FROM data.{table} ORDER BY gid"
+                )
+            )
+        ).all()
+        # geom keeps the curved source; geom_4326 is linear for BOTH shapes.
+        assert [(r[1], r[2]) for r in rows] == [
+            ("MULTISURFACE", "MULTIPOLYGON"),
+            ("MULTISURFACE", "MULTIPOLYGON"),
+        ]
+
     @pytest.mark.usefixtures("_init_tile_pool_for_tests")
     async def test_vector_tile_renders_a_curved_source(
         self,

--- a/backend/tests/test_analysis_materialize.py
+++ b/backend/tests/test_analysis_materialize.py
@@ -2562,8 +2562,13 @@ class TestMaterializeWorker:
         # list.index() would find the first one twice.
         size_pos = [i for i, s in enumerate(executed) if "pg_total_relation_size" in s]
         assert len(size_pos) == 2
+        # fix(#1113): registration now runs the linearize-enforcement UPDATE
+        # (uniquely marked by ST_HasArc) AFTER the probes; the position under
+        # test is the BUILD's last geom_4326 write, so exclude the enforcer.
         rewrite_pos = max(
-            i for i, s in enumerate(executed) if "geom_4326" in s and "UPDATE" in s
+            i
+            for i, s in enumerate(executed)
+            if "geom_4326" in s and "UPDATE" in s and "ST_HasArc" not in s
         )
         assert size_pos[1] > rewrite_pos
         assert size_pos[1] < executed.index(analyzes[0])

--- a/backend/tests/test_analysis_spatial_join.py
+++ b/backend/tests/test_analysis_spatial_join.py
@@ -20,6 +20,7 @@ from app.modules.catalog.datasets.api import router_analysis
 from app.modules.catalog.datasets.domain.service_analysis import PREVIEW_FEATURE_CAP
 from app.platform.analysis_sql import MAX_SOURCE_FEATURES
 from app.processing.analysis.tasks import _materialize
+from app.processing.ingest.metadata import add_4326_column
 
 from tests.factories import create_dataset, get_user_id
 from tests.test_analysis_materialize import _create_job
@@ -73,6 +74,13 @@ async def _create_layer(
             f"VALUES {values_sql}"
         )
     )
+    # fix(#1104): regenerate geom_4326 through the real ingest normalizer so
+    # these fixtures uphold the invariant every read surface now assumes —
+    # geom_4326 is always linear. A byte-identical no-op for linear fixtures
+    # (which insert the same value into both columns); for the curved-source
+    # fixtures it stores the curved WKT in `geom` only, exactly as a real
+    # WFS ingest does.
+    await add_4326_column(session, table_name, 4326)
     await session.commit()
     return await create_dataset(
         session,

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -1242,6 +1242,9 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # UPDATE at parse time and cannot be repaired in place, so the enforcer
     # skips it (#1114 tracks generation expressions that yield curves).
     # Cap 2103 -> 2119, still exact.
+    # fix(#1113 review r16): +8 — linearize in the SOURCE CRS, then
+    # reproject: transforms are nonlinear, so densifying after ST_Transform
+    # traces the arc in the wrong space. Cap 2147 -> 2151 net (see r8/r9).
     # fix(#1113 review r8): +24 — a generated column whose CURRENT rows are
     # curved refuses registration with the actionable cause, instead of
     # admitting a dataset broken on every surface. Cap 2119 -> 2143, exact.
@@ -1249,7 +1252,7 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # change the value" (byte-compare), catching curve containers nested in a
     # GEOMETRYCOLLECTION without over-rejecting all-linear collections.
     # Cap 2143 -> 2147, still exact.
-    "backend/app/processing/ingest/metadata.py": 2147,
+    "backend/app/processing/ingest/metadata.py": 2151,
     # ingest/router.py is also scanned by the router-glob gate; this exact
     # ratchet overrides its 1500 default so the remaining ~18-line runway to
     # the cliff cannot be spent silently.

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -950,7 +950,11 @@ def test_decomposed_service_modules_stay_within_size_budgets() -> None:
         # (via live_property_columns) so the curved source `geom` column never
         # reaches the geometry→jsonb cast, which raises on curves. Cap
         # 620 -> 628, exact.
-        "backend/app/modules/catalog/datasets/domain/service_relationships.py": 628,
+        # fix(#1113 review r10): +7 — the FK match moved inside the projection
+        # against the base table (a relationship may target a column the
+        # projection drops), with the identifier colon-escaped for text().
+        # Cap 628 -> 635, exact.
+        "backend/app/modules/catalog/datasets/domain/service_relationships.py": 635,
         # fix(#474): reject primary-language updates that collide with a
         # translated variant. Cap 460 -> 480 (~9 LOC headroom above 471).
         # fix(#931): +7. _apply_visibility_change no longer carries its own

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -874,7 +874,11 @@ def test_decomposed_service_modules_stay_within_size_budgets() -> None:
         # 500 (round-14 review). to_jsonb renders that as an array of hex
         # strings, so recursing with the same scalar encoding keeps the two
         # endpoints byte-identical.
-        "backend/app/modules/catalog/datasets/domain/service_analysis.py": 506,
+        #
+        # fix(#1104): -1 — the select-by-location identity lateral reads the
+        # bare column again; geom_4326 is linearized at ingest now, so the
+        # per-read ST_CurveToLine wrap is gone. Budget 506 -> 505, exact.
+        "backend/app/modules/catalog/datasets/domain/service_analysis.py": 505,
         "backend/app/modules/catalog/maps/service_crud.py": 550,
         # fix(#474, #475): localized ranking/eager loading plus the OGC
         # ids/externalIds filters cross the default by nine lines. Keep the
@@ -1319,16 +1323,15 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # 63) and why source columns need no equivalent — they already exist in a
     # table, so the server truncated them at creation.
     #
-    # fix(#1097 review): +42 for linearized() and its call sites. WFS sources
-    # can store curved geometries (MultiSurface/CompoundCurve) that ingest
-    # admits but ::geography, ST_MakeValid and ST_AsGeoJSON all raise on, so
-    # every geometry read feeding one of those — or passing through into
-    # preview GeoJSON or a CTAS — goes through one ST_CurveToLine wrapper. The
-    # bulk of the lines is the helper's docstring recording which functions
-    # raise, which tolerate curves, why WHERE predicates stay on the bare
-    # column (the GIST index), and that #1104 (ingest-level normalization)
-    # is what eventually retires the helper.
-    "backend/app/platform/analysis_sql.py": 1260,
+    # fix(#1097 review): +42 for linearized() and its call sites — WFS sources
+    # could store curved geometries that ::geography, ST_MakeValid and
+    # ST_AsGeoJSON all raise on, so every such read went through one
+    # ST_CurveToLine wrapper.
+    # fix(#1104): -33 — that wrapper is retired. Ingest now stores geom_4326
+    # linear (add_4326_column) and migration 0034 backfilled existing rows,
+    # so the per-read wraps had nothing left to guard. The invariant is
+    # recorded in the module docstring instead. Cap 1260 -> 1227, exact.
+    "backend/app/platform/analysis_sql.py": 1227,
     # tasks.py carries growth from BOTH sides of this rebase, so the number is
     # re-measured rather than taken from either. #1012 added the scoped
     # work_mem (the SET LOCAL, its budget arithmetic and the boot-time
@@ -1374,6 +1377,9 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # geometry columns (measure, spatial_join, select_by_location) so a curved
     # source row is stored linear — a curved geometry written into the derived
     # table would fail that layer's tiles and feature reads later.
+    # fix(#1104): -1 — those wraps are gone again; geom_4326 is linear at
+    # ingest, so the pass-through columns read the bare column. Cap
+    # 1450 -> 1449, exact.
     #
     # fix(#1097 review): +62 for the array-element half of the ungroupable
     # guards. information_schema stores an array column's data_type as
@@ -1382,7 +1388,7 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # udt_name ('_json') as well, and the same check now also covers
     # dissolve's by_field, which had the identical blind spot plus no live
     # recheck at all.
-    "backend/app/processing/analysis/tasks.py": 1450,
+    "backend/app/processing/analysis/tasks.py": 1449,
     # Tenant-owned media now crosses the shared logical-to-physical storage
     # seam; explicit storage-failure responses keep the runtime/OpenAPI contract
     # aligned. Keep the ratchet exact after the import/decorator expansion.

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -1241,7 +1241,11 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # fix(#1113 review r8): +24 — a generated column whose CURRENT rows are
     # curved refuses registration with the actionable cause, instead of
     # admitting a dataset broken on every surface. Cap 2119 -> 2143, exact.
-    "backend/app/processing/ingest/metadata.py": 2143,
+    # fix(#1113 review r9): +4 — the reject test becomes "would linearization
+    # change the value" (byte-compare), catching curve containers nested in a
+    # GEOMETRYCOLLECTION without over-rejecting all-linear collections.
+    # Cap 2143 -> 2147, still exact.
+    "backend/app/processing/ingest/metadata.py": 2147,
     # ingest/router.py is also scanned by the router-glob gate; this exact
     # ratchet overrides its 1500 default so the remaining ~18-line runway to
     # the cliff cannot be spent silently.

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -1226,7 +1226,11 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # geom_4326 the ingest normalizer never touched (a pre-existing column on
     # a BYO table registered after migration 0034's backfill ran).
     # Cap 2038 -> 2066, still exact.
-    "backend/app/processing/ingest/metadata.py": 2066,
+    # fix(#1113 review r4): +25 — a BYO column can DECLARE a curved typmod
+    # (geometry(CurvePolygon, 4326)), which rejects the linear UPDATE result
+    # outright; such a column is loosened to generic geometry first.
+    # Cap 2066 -> 2091, still exact.
+    "backend/app/processing/ingest/metadata.py": 2091,
     # ingest/router.py is also scanned by the router-glob gate; this exact
     # ratchet overrides its 1500 default so the remaining ~18-line runway to
     # the cliff cannot be spent silently.

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -1234,7 +1234,11 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # (plain Geometry rejects Z values), and rtrim(...,'M') matching catches
     # the M-suffixed curve names in both the typmod lookup and the UPDATE
     # predicate. Cap 2091 -> 2103, still exact.
-    "backend/app/processing/ingest/metadata.py": 2103,
+    # fix(#1113 review r7): +16 — a STORED GENERATED geom_4326 rejects any
+    # UPDATE at parse time and cannot be repaired in place, so the enforcer
+    # skips it (#1114 tracks generation expressions that yield curves).
+    # Cap 2103 -> 2119, still exact.
+    "backend/app/processing/ingest/metadata.py": 2119,
     # ingest/router.py is also scanned by the router-glob gate; this exact
     # ratchet overrides its 1500 default so the remaining ~18-line runway to
     # the cliff cannot be spent silently.

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -1230,7 +1230,11 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # (geometry(CurvePolygon, 4326)), which rejects the linear UPDATE result
     # outright; such a column is loosened to generic geometry first.
     # Cap 2066 -> 2091, still exact.
-    "backend/app/processing/ingest/metadata.py": 2091,
+    # fix(#1113 review r5): +12 — the loosened typmod preserves Z/M flags
+    # (plain Geometry rejects Z values), and rtrim(...,'M') matching catches
+    # the M-suffixed curve names in both the typmod lookup and the UPDATE
+    # predicate. Cap 2091 -> 2103, still exact.
+    "backend/app/processing/ingest/metadata.py": 2103,
     # ingest/router.py is also scanned by the router-glob gate; this exact
     # ratchet overrides its 1500 default so the remaining ~18-line runway to
     # the cliff cannot be spent silently.

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -1238,7 +1238,10 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # UPDATE at parse time and cannot be repaired in place, so the enforcer
     # skips it (#1114 tracks generation expressions that yield curves).
     # Cap 2103 -> 2119, still exact.
-    "backend/app/processing/ingest/metadata.py": 2119,
+    # fix(#1113 review r8): +24 — a generated column whose CURRENT rows are
+    # curved refuses registration with the actionable cause, instead of
+    # admitting a dataset broken on every surface. Cap 2119 -> 2143, exact.
+    "backend/app/processing/ingest/metadata.py": 2143,
     # ingest/router.py is also scanned by the router-glob gate; this exact
     # ratchet overrides its 1500 default so the remaining ~18-line runway to
     # the cliff cannot be spent silently.

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -1208,7 +1208,12 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # fix(#958): now five carve-outs deep, which is the ratchet taxing
     # correctness work on a module nobody has had time to split.
     # Decomposition tracked in #1042; the cap stays exact until then.
-    "backend/app/processing/ingest/metadata.py": 2031,
+    # fix(#1104): +7 — add_4326_column linearizes curved sources with
+    # ST_CurveToLine (an exact no-op on linear input), so geom_4326 can never
+    # hold a type that ST_AsMVTGeom/ST_AsGeoJSON/::geography/ST_MakeValid
+    # raise on. Most of the lines are the docstring recording that invariant.
+    # Ratchet stays exact.
+    "backend/app/processing/ingest/metadata.py": 2038,
     # ingest/router.py is also scanned by the router-glob gate; this exact
     # ratchet overrides its 1500 default so the remaining ~18-line runway to
     # the cliff cannot be spent silently.

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -942,7 +942,11 @@ def test_decomposed_service_modules_stay_within_size_budgets() -> None:
         # list response returns dereferenceable ids. Smoke-residual follow-up (#315):
         # +try/except (ProgrammingError->503) around get_related_records table
         # queries (raster/missing-table guard). Cap 595 -> 620 (~3 LOC headroom).
-        "backend/app/modules/catalog/datasets/domain/service_relationships.py": 620,
+        # fix(#1104): +8 — _fetch_target_rows projects the row before to_jsonb
+        # (via live_property_columns) so the curved source `geom` column never
+        # reaches the geometry→jsonb cast, which raises on curves. Cap
+        # 620 -> 628, exact.
+        "backend/app/modules/catalog/datasets/domain/service_relationships.py": 628,
         # fix(#474): reject primary-language updates that collide with a
         # translated variant. Cap 460 -> 480 (~9 LOC headroom above 471).
         # fix(#931): +7. _apply_visibility_change no longer carries its own

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -1221,7 +1221,12 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # hold a type that ST_AsMVTGeom/ST_AsGeoJSON/::geography/ST_MakeValid
     # raise on. Most of the lines are the docstring recording that invariant.
     # Ratchet stays exact.
-    "backend/app/processing/ingest/metadata.py": 2038,
+    # fix(#1113 review): +28 — linearize_existing_4326 enforces the same
+    # invariant on the register path, the one app-controlled writer of a
+    # geom_4326 the ingest normalizer never touched (a pre-existing column on
+    # a BYO table registered after migration 0034's backfill ran).
+    # Cap 2038 -> 2066, still exact.
+    "backend/app/processing/ingest/metadata.py": 2066,
     # ingest/router.py is also scanned by the router-glob gate; this exact
     # ratchet overrides its 1500 default so the remaining ~18-line runway to
     # the cliff cannot be spent silently.
@@ -1252,7 +1257,11 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     "backend/app/processing/ingest/tasks_vrt.py": 1071,
     "backend/app/processing/ingest/tasks_vector.py": 1058,
     "backend/app/modules/auth/oauth/service.py": 1031,
-    "backend/app/processing/ingest/service.py": 1017,
+    # fix(#1113 review): +15 — register_existing_table linearizes a
+    # pre-existing geom_4326 (savepoint + error contract mirroring the
+    # add_4326_column branch beside it); see linearize_existing_4326.
+    # Cap 1017 -> 1032, still exact.
+    "backend/app/processing/ingest/service.py": 1032,
     # --- entered by the inclusion rule, feat(#765) -------------------------
     # First time this module crosses 1000. main sat at 994, six lines under the
     # gate, so it was going to fire on whoever added next; it fired here.


### PR DESCRIPTION
## Problem

Curved geometries (MultiSurface/CompoundCurve, WKB types 8–13) ingest cleanly but break four shipped surfaces (#1104): vector tiles (`lwgeom_get_basic_type: Invalid type (12)`), feature reads (GeoJSON has no curved types → 500), buffer/centroid/clip (`ST_MakeValid` raises), and dissolve (same failure inside its CTAS). The catalog's `geometry_type` already promises the linear type, so stored data disagreed with the declared contract.

## Fix — four commits, hardened by four review rounds

1. **Ingest** (`processing/ingest/metadata.py`): `add_4326_column()` now writes `ST_Force2D(ST_CurveToLine(…))`. `ST_CurveToLine` is an exact no-op on linear input; the original `geom` column keeps the curved source, same as it keeps Z.
2. **Feature reads** (`features/service.py` ×3, `service_relationships.py` ×1): linearizing `geom_4326` alone does NOT fix reads — the issue's surface-2 diagnosis was incomplete. The read queries rendered properties as `to_jsonb(t.*) - 'gid' - 'geom' - 'geom_4326'`, and `to_jsonb` serializes the curved source `geom` column BEFORE the subtraction (PostGIS raises `lwgeom_to_geojson: 'MultiSurface' … not supported`; verified in psql). The four read sites now project rows to `gid + geom_4326 +` the **live** property columns (live schema rather than cached `column_info`, which drifts on re-upload) before serializing.
3. **Backfill migration** (`0034_linearize_geom_4326`): per-dataset tables are dynamic, so the data migration discovers them from `information_schema` — restricted to `data` plus the EXACT per-tenant schemas derived from `catalog.tenants` (the 0024/0026 construction; a co-hosted schema that merely starts with `data_t_` is never touched). The WHERE is the union of three tests, because each alone misses a stored shape: any arc (`ST_HasArc`), any top-level curve type (the closed five-member list — an arc-free `MULTISURFACE(((…)))` has no arc to find), or any GEOMETRYCOLLECTION (curve members cannot hide anywhere else — linear multi types cannot contain them). A column *declared* with a curved typmod (`geometry(CurvePolygon, 4326)`) is loosened to generic `geometry(Geometry, srid)` first, since the linear result would otherwise violate the declared type and abort the migration. Idempotent; no-op downgrade.
4. **Registration boundary**: `register_existing_table` skips `add_4326_column` when the table already carries `geom_4326`, and a table registered after 0034 ran is invisible to its backfill — so registration was the one app-controlled writer that could re-admit curved values. `linearize_existing_4326` (beside `add_4326_column`) now enforces the invariant there, same predicate, same typmod loosening, same savepoint contract as the sibling branch. STORED GENERATED columns are the exception on both writers — PostgreSQL rejects any UPDATE against one at parse time (verified: even `WHERE false` aborts), and their values are decided by the generation expression — so the migration skips them **and names each skipped table whose expression currently yields curves in an operator warning**, and registration refuses a generated column whose existing rows are curved (byte-compare against `ST_CurveToLine`, so nested collection members are seen without over-rejecting all-linear collections). Scope: the backfill touches only tables owned by a **registered dataset in its own tenant's schema** (0020 permits the same table name across tenants), never an unregistered table an operator copied in.

### Documented trade-off (declined in review, tracked in #1114)

A **pre-existing registered** dataset whose generated `geom_4326` expression yields curves keeps failing analysis after this upgrade (its vector tiles and feature reads were already failing before it — the removed wraps only ever covered analysis SQL). Repair by UPDATE is impossible, rebuilding a column owned by someone else's expression is not this migration's call, and per-read guards would tax every reader for a construction not yet observed in practice. The migration surfaces each such table with the cause and the fix; #1114 tracks the structural options (linearity trigger, operator contract, or a quarantine flag that turns the failure into a clean 422).
4. **Dead code**: `linearized()` and all its wraps removed from `platform/analysis_sql.py`, `processing/analysis/tasks.py`, and a third call site the issue didn't list (`service_analysis.py`). `test_analysis_curved_sources.py`'s pre-existing tests pass unmodified, pinning that the removal is safe. Curved test fixtures now run through the production `add_4326_column` instead of hand-writing rows the app can no longer produce.

## Schema impact

Data-only migration over dynamic per-dataset tables; no ORM model, OpenAPI, or SDK changes.

## Verification

- Curved-sources suite: 6 passed before, 9 after (new: stored-type invariant, vector tile render, browse + single + features.geojson reads — the two surfaces with no prior coverage)
- Features/OGC suites: 90 passed; analysis suites (spatial_join/measure/select_by_location/intersect/materialize/preview/provenance/retry/chat): 289 passed; tiles + FK relationships: 46 passed
- **Full backend suite: 6796 passed, 83 skipped**
- Migration, host-side on an ephemeral DB: clean `alembic upgrade head`; seeded curved + nested-arc GEOMETRYCOLLECTION + linear + NULL rows, a tenant schema, a decoy schema (`dataXt_decoy`), and a view; downgrade/upgrade → curved becomes MULTIPOLYGON, nested arc removed, source `geom` still MULTISURFACE, linear row byte-identical, tenant linearized, decoy and view untouched; second downgrade/upgrade → md5 of every `geom_4326` identical (idempotence); `alembic check` → "No new upgrade operations detected". CI's Alembic Clean-DB Upgrade job is the authoritative in-CI gate.
- `ruff check` / `ruff format --check` clean; `tests/test_layering.py` 36 passed (metadata +7, relationships +8 with rationale comments; three analysis caps LOWERED per the shrink convention, the "+42 for linearized()" carve-out retired)

Closes #1104

https://claude.ai/code/session_01PnJqoYvwnHaFT3w4E9zNvE
