### PR TITLE
chore(release): v1.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,54 @@ and releases use semantic versioning.
 
 ## [Unreleased]
 
+## [1.7.1] - 2026-08-02
+
+### Fixed
+
+- **Analysis provenance no longer names datasets the requester cannot see
+  (#1103).** `lineage_summary` is now access-checked per requester on every
+  read surface that serves it — dataset detail and lists, OGC records, STAC,
+  and the three DCAT feeds, including the anonymous ones. A requester who can
+  read every referenced dataset gets the stored sentence unchanged; anyone
+  else gets a neutral placeholder rather than any part of the stored text.
+- **Curved geometries work end to end (#1104).** `geom_4326` is now always
+  linear: ingest densifies arcs in the source CRS before reprojecting,
+  migration 0034 backfills existing rows for registered datasets, and
+  registering a table with a pre-existing `geom_4326` linearizes it on the
+  way in. Vector tiles, feature reads, and every analysis operation now work
+  on MultiSurface/CompoundCurve sources; the curved original stays in `geom`.
+  The migration skips columns it cannot rewrite (stored generated columns,
+  legacy constraint declarations) and names each one in an operator warning
+  instead of blocking the upgrade.
+- **A malformed paint value can no longer break a shared map (#1069).**
+  Legacy `stops` values are shape-checked at write time (422), and
+  `GET /maps/{id}/style.json` drops a bad stored layer with a warning instead
+  of failing the whole document. MapLibre expressions that merely contain a
+  `stops` key as data are unaffected.
+- **Dataset visibility changes are refused only when someone is actually
+  stranded (#1073).** The guard now judges each shared audience on its own
+  instead of over-refusing: narrowing visibility when every active user
+  already holds a grant, or when no one else is active, goes through. Under a
+  non-default permission extension the conservative refusal is kept, since
+  the community query cannot see viewers an overlay admits.
+- **Style copy/paste keeps fill-color and fill-pattern mutually exclusive
+  (#923).** The paste merge resolves the fill pair through the same rule the
+  editor applies, and the colour a pasted pattern displaces is stashed so a
+  later switch back to "None" restores the pasted style's colour, not the
+  target's old one.
+- Registered tables with Socrata-style column names (`:id`) read correctly
+  through feature endpoints, and registering a table whose generated
+  `geom_4326` yields curved values is refused with the cause.
+
+### Changed
+
+- **The CLI can drive spatial joins (#1105).** `geolens analysis preview` and
+  `materialize` gained `--join-dataset-id` and `--join-fields`, the
+  `--operation` help lists every server operation (dissolve is
+  materialize-only), and a missing `--join-dataset-id` fails fast with the
+  server's wording. The CLI now requires the 1.7.0 SDK, the first whose
+  analysis models carry the join fields.
+
 ## [1.7.0] - 2026-08-01
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1654,7 +1654,8 @@ regression-covered fixes:
 - Initial public release of the GeoLens catalog, API, map builder, CLI, SDKs,
   Docker development stack, and public documentation entrypoints.
 
-[Unreleased]: https://github.com/geolens-io/geolens/compare/v1.7.0...HEAD
+[Unreleased]: https://github.com/geolens-io/geolens/compare/v1.7.1...HEAD
+[1.7.1]: https://github.com/geolens-io/geolens/compare/v1.7.0...v1.7.1
 [1.7.0]: https://github.com/geolens-io/geolens/compare/v1.6.1...v1.7.0
 [1.6.1]: https://github.com/geolens-io/geolens/compare/v1.6.0...v1.6.1
 [1.6.0]: https://github.com/geolens-io/geolens/compare/v1.5.1...v1.6.0

--- a/backend/app/api/main.py
+++ b/backend/app/api/main.py
@@ -590,7 +590,7 @@ _is_production = settings.is_production
 # no metadata to read. We fall back to the current published line so import never
 # crashes. Keep this fallback in lockstep with backend/pyproject.toml — it is one
 # of the sites `make bump` rewrites.
-_FALLBACK_APP_VERSION = "1.7.0"
+_FALLBACK_APP_VERSION = "1.7.1"
 
 
 def _resolve_app_version() -> str:

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -17792,7 +17792,7 @@
     "summary": "PostGIS-native geospatial data catalog with OGC API Features and Records support",
     "termsOfService": "https://github.com/geolens-io/geolens/blob/main/LICENSE",
     "title": "GeoLens API",
-    "version": "1.7.0"
+    "version": "1.7.1"
   },
   "openapi": "3.1.0",
   "paths": {

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geolens-backend"
-version = "1.7.0"
+version = "1.7.1"
 description = "PostGIS-native GIS data catalog"
 # Docker image (Dockerfile) ships python:3.14-slim (see the Dockerfile FROM for
 # the exact patch pin) as the project's tested runtime.

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -850,7 +850,7 @@ wheels = [
 
 [[package]]
 name = "geolens-backend"
-version = "1.7.0"
+version = "1.7.1"
 source = { virtual = "." }
 dependencies = [
     { name = "alembic" },

--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "geolens-cli"
-version = "1.7.0"
+version = "1.7.1"
 description = "Apache-2.0 command-line interface for the GeoLens API. Login, scan, publish, and export STAC against any GeoLens instance."
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/docs-contract.json
+++ b/docs-contract.json
@@ -1,6 +1,6 @@
 {
   "_comment": "Canonical cross-surface facts for the GeoLens README, marketing site (getgeolens.com/src), and docs site (getgeolens.com/docs). Validated against scripts/install.sh + backend/pyproject.toml by scripts/check_docs_contract.py (geolens CI). The getgeolens.com repo vendors a copy and enforces the same `forbidden` list in its own CI. See docs-internal/DOC-CONSISTENCY-STRATEGY for the full design. Edit a fact ONCE here (and in its canonical source) — the gates make every surface follow.",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "install": {
     "oneLiner": "curl -fsSL https://getgeolens.com/install.sh | sh",
     "sourceBuild": "bash scripts/install.sh",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "1.7.0",
+      "version": "1.7.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.7.0",
+  "version": "1.7.1",
   "type": "module",
   "license": "Apache-2.0",
   "author": "Carto Concepts, LLC",

--- a/mcp/pyproject.toml
+++ b/mcp/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "geolens-mcp"
-version = "1.7.0"
+version = "1.7.1"
 description = "Apache-2.0 read-only Model Context Protocol (MCP) server for GeoLens. Lets coding agents discover datasets, inspect schemas, and ask spatial questions against any GeoLens instance."
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/mcp/uv.lock
+++ b/mcp/uv.lock
@@ -225,7 +225,7 @@ wheels = [
 
 [[package]]
 name = "geolens"
-version = "1.7.0"
+version = "1.7.1"
 source = { editable = "../sdks/python" }
 dependencies = [
     { name = "attrs" },
@@ -242,7 +242,7 @@ requires-dist = [
 
 [[package]]
 name = "geolens-mcp"
-version = "1.7.0"
+version = "1.7.1"
 source = { editable = "." }
 dependencies = [
     { name = "geolens" },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "geolens",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "geolens",
-      "version": "1.7.0",
+      "version": "1.7.1",
       "license": "Apache-2.0",
       "devDependencies": {
         "@axe-core/playwright": "^4.12.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "geolens",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "private": true,
   "license": "Apache-2.0",
   "author": "Carto Concepts, LLC",

--- a/sdks/python/.openapi-python-client.yaml
+++ b/sdks/python/.openapi-python-client.yaml
@@ -4,7 +4,7 @@ project_name_override: geolens
 package_name_override: geolens
 # Rewritten on every `make sdks` run by scripts/sync_sdk_versions.py to match
 # backend/openapi.json info.version. Do not edit by hand.
-package_version_override: 1.7.0
+package_version_override: 1.7.1
 
 # Cleaner enum output (matches our pydantic v2 backend's enum emission).
 literal_enums: true

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "geolens"
-version = "1.7.0"
+version = "1.7.1"
 description = "Auto-generated Python SDK for the GeoLens API. Typed clients with Bearer + API-key auth helpers."
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/sdks/typescript/package-lock.json
+++ b/sdks/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@geolens/sdk",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@geolens/sdk",
-      "version": "1.7.0",
+      "version": "1.7.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@hey-api/client-fetch": "0.13.1"

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@geolens/sdk",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "description": "Auto-generated TypeScript SDK for the GeoLens API. Typed clients with Bearer + API-key auth helpers.",
   "license": "Apache-2.0",
   "author": "Carto Concepts, LLC",


### PR DESCRIPTION
Patch release: six fixes on 1.7.0's shipped surfaces — #1103 lineage visibility (information disclosure on anonymous feeds), #1104 curved geometries end to end (ingest + migration 0034 + registration), #1069 malformed paint bounding, #1073 visibility-guard precision, #923 paste exclusivity, #1105 CLI spatial join. All landed via PRs #1107-#1113 with codex review; pre-tag smoke on a fresh stack with full showcase seed passed (curl suite + anonymous browser render of Restless Earth and Manhattan).

Verification: `make version-check` — 19 sites at 1.7.1; changelog section present.

https://claude.ai/code/session_01PnJqoYvwnHaFT3w4E9zNvE