### PR TITLE
fix(security): bound the URL redaction scheme prefix against quadratic backtracking

### DIFF
--- a/backend/app/core/url_redaction.py
+++ b/backend/app/core/url_redaction.py
@@ -7,7 +7,14 @@ from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
 
 REDACTED_QUERY_VALUE = "<redacted>"
 REDACTED_USERINFO = "redacted"
-URL_LIKE_RE = re.compile(r"(?:(?:[A-Za-z0-9_+.-]+:)?https?://)[^\s\"'<>]+")
+# fix(#1116): the optional scheme prefix is bounded to 64 characters, which is
+# longer than any registered URI scheme. An unbounded `+` here is ambiguous
+# against the `https?` that follows, so a long run of prefix-class characters
+# that never completes a match made the engine retry every prefix length at
+# every start position — O(n²) on a fallback that is fed GDAL stderr and
+# uploaded-VRT paths. A longer prefix still redacts: the match simply starts
+# later in the string and still spans the whole URL.
+URL_LIKE_RE = re.compile(r"(?:(?:[A-Za-z0-9_+.-]{1,64}:)?https?://)[^\s\"'<>]+")
 
 SENSITIVE_QUERY_PARAMS = frozenset(
     {

--- a/backend/tests/test_url_redaction_sec.py
+++ b/backend/tests/test_url_redaction_sec.py
@@ -1,5 +1,7 @@
 """Security tests for URL query credential rejection/redaction."""
 
+import time
+
 import pytest
 from pydantic import ValidationError
 
@@ -43,6 +45,72 @@ def test_redact_url_credentials_empty_host_terminates_and_masks(value: str) -> N
     # It must terminate and still mask the secret.
     redacted = redact_url_credentials(value)
     assert "secret" not in redacted
+
+
+# fix(#1116): URL_LIKE_RE's optional scheme prefix used an unbounded `+`, which
+# is ambiguous against the `https?` that follows. A long run of prefix-class
+# characters that never completes a match made the engine retry every prefix
+# length at every start position — O(n²). Free text reaches that fallback from
+# GDAL/ogr2ogr stderr and uploaded-VRT <SourceFilename> values, so the run is
+# attacker-influenced. Measured in-pytest on this commit (pytest --durations, not
+# a standalone bench): the 200 KB run below takes 0.03s with the {1,64} bound and
+# 33s without it, so the threshold has ~65x headroom for a slow CI runner while
+# staying far out of reach for the quadratic form. Keep that figure in-pytest — a
+# standalone bench reports a rosier 0.02s/~86x, which is not what governs whether
+# this test flakes.
+REDOS_INPUT_CHARS = 200_000
+REDOS_THRESHOLD_S = 2.0
+
+
+# Deliberately NOT marked @pytest.mark.perf. backend/pyproject.toml:163 sets
+# addopts = "-m 'not perf' --dist loadgroup", so that marker deselects a test from
+# both `make test` and CI — adding it here would ship a ReDoS guard that never
+# runs. This test costs 0.03s, so it does not need the marker that the genuinely
+# slow perf-suite tests carry.
+def test_redact_url_credentials_stays_linear_on_hostile_alphanumeric_run() -> None:
+    hostile = "a" * REDOS_INPUT_CHARS
+
+    start = time.perf_counter()
+    result = redact_url_credentials(hostile)
+    elapsed = time.perf_counter() - start
+
+    # Nothing here looks like a URL, so it must come back untouched. Asserting
+    # this keeps the timing check honest: a regex that matched nothing at all
+    # would be fast but would stop redacting.
+    assert result == hostile
+    assert elapsed < REDOS_THRESHOLD_S, (
+        f"redacting {REDOS_INPUT_CHARS} non-URL characters took {elapsed:.2f}s "
+        f"(threshold {REDOS_THRESHOLD_S}s) — the URL_LIKE_RE scheme prefix is "
+        "backtracking quadratically again"
+    )
+
+
+@pytest.mark.parametrize("prefix_len", [1, 63, 64, 65, 200, 5_000])
+def test_redact_url_credentials_masks_userinfo_behind_long_scheme_prefix(
+    prefix_len: int,
+) -> None:
+    # fix(#1116): bounding the scheme prefix must not let a credential escape
+    # when the GDAL-style prefix is longer than the bound. It cannot: the match
+    # just starts later in the string and still covers the whole URL.
+    value = "A" * prefix_len + ":https://user:secret@example.com/cog.tif"
+
+    redacted = redact_url_credentials(value)
+
+    assert "secret" not in redacted
+    assert "redacted@example.com" in redacted
+
+
+def test_redact_url_credentials_masks_url_after_long_free_text_run() -> None:
+    # fix(#1116): the bounded prefix must still find a credential URL sitting
+    # behind a long run of prefix-class characters (the GDAL-stderr shape).
+    value = "a" * 100_000 + " https://user:secret@example.com/x?token=t0ken"
+
+    redacted = redact_url_credentials(value)
+
+    assert "secret" not in redacted
+    assert "t0ken" not in redacted
+    assert "redacted@example.com" in redacted
+    assert "token=%3Credacted%3E" in redacted
 
 
 def test_redact_query_credentials_preserves_non_sensitive_query() -> None:


### PR DESCRIPTION
## Problem

`URL_LIKE_RE` in `backend/app/core/url_redaction.py` left the optional scheme prefix unbounded:

```python
URL_LIKE_RE = re.compile(r"(?:(?:[A-Za-z0-9_+.-]+:)?https?://)[^\s\"'<>]+")
```

That prefix is ambiguous against the `https?` that follows it. Given a long run of prefix-class characters that never completes a match, the engine retries every prefix length at every start position, which is quadratic in the input. CodeQL alert #38 flags it as `py/polynomial-redos`, and it is the one alert in the current backlog that is real rather than noise.

The regex only runs on the scheme-less free-text fallback, but that path takes attacker-influenced input. `processing/ingest/validation.py` calls `redact_url_credentials(raw_path)[:200]` at three sites where `raw_path` is the `<SourceFilename>` of a user-uploaded VRT, and the truncation happens after the regex, so it protects nothing. `catalog/sources/preview.py` hands over untruncated `ogrinfo` stderr.

Impact is worker and API CPU exhaustion. No data is exposed.

## Fix

Bound the quantifier to `{1,64}`, which is longer than any registered URI scheme.

A prefix longer than 64 characters still gets redacted. The prefix group is optional, so the match simply starts later in the string and still spans the whole URL. Tests pin that at 65, 200 and 5,000 characters so the fix cannot regress into dropping credentials it used to mask.

Measured on this branch, substituting over a run of `a` characters:

| input | unbounded | bounded |
|---|---|---|
| 10,000 | 0.085s | 0.0012s |
| 25,000 | 0.525s | 0.0032s |
| 50,000 | 2.098s | 0.0061s |

The old form quadruples for each doubling of input. The new one scales linearly.

## Why this shape

The issue also offers a defensive `[:100_000]` cap on the input handed to the fallback. That is not in this change. With the bound in place, 200 KB of hostile input redacts in roughly 0.02 seconds, so the cap would buy nothing measurable, and truncating the input carries its own risk: a cut landing mid-URL could leave a credential on the far side of the boundary and defeat the redaction this module exists to perform. Trading a fixed DoS for a possible disclosure is the wrong direction.

## Verification

```
cd backend
uv run pytest tests/test_url_redaction_sec.py -q     # 26 passed
uv run pytest tests/test_layering.py -q              # 36 passed
uv run ruff check .                                  # All checks passed
uv run ruff format --check .                         # 875 files already formatted
```

The timing regression test asserts the returned string as well as the elapsed time, so a regex that matched nothing at all would be fast and would still fail. Its threshold sits about 80x above the measured bounded time, which keeps it decisive on a loaded runner without being tuned to a number that will flake.

Closes #1116