### PR TITLE
test(analysis): finish the backend analysis coverage gaps and rehome the sync tests

### DIFF
--- a/backend/tests/test_analysis_materialize.py
+++ b/backend/tests/test_analysis_materialize.py
@@ -2616,48 +2616,6 @@ class TestMaterializeWorker:
         # Same transaction, ahead of the CTAS it protects.
         assert executed.index(hashaggs[0]) < executed.index(ctas[0])
 
-    def test_timeout_message_names_the_budget_that_fired(self, monkeypatch):
-        """fix(#1013 review): the two budgets are independently configurable
-        now, so a registration timeout quoting the materialize budget would
-        send an operator to tune the setting that did not fire."""
-        from sqlalchemy.exc import OperationalError
-
-        from app.core.config import settings
-        from app.processing.analysis.tasks import _user_error_message
-
-        monkeypatch.setattr(settings, "analysis_materialize_timeout_seconds", 300)
-        monkeypatch.setattr(settings, "analysis_registration_timeout_seconds", 900)
-        exc = OperationalError(
-            "SELECT 1", {}, Exception("canceling statement due to statement timeout")
-        )
-
-        assert "300s" in _user_error_message(exc)
-        assert "900s" not in _user_error_message(exc)
-        assert "900s" in _user_error_message(exc, registered=True)
-        assert "300s" not in _user_error_message(exc, registered=True)
-
-    def test_analysis_timeouts_track_their_settings(self, monkeypatch):
-        """fix(#1013): the budgets are operator settings now, and they are read
-        at call time — a module-level snapshot would freeze whatever the
-        settings object held when this module was first imported."""
-        from app.core.config import settings
-
-        from app.processing.analysis.tasks import registration_timeout
-
-        # Set the baseline rather than asserting the shipped defaults: settings
-        # is a module-level singleton, so an ANALYSIS_*_TIMEOUT_SECONDS in the
-        # environment or the root .env would already have overridden them and
-        # the "before" assertions would fail for a reason unrelated to the
-        # behaviour under test.
-        monkeypatch.setattr(settings, "analysis_materialize_timeout_seconds", 300)
-        monkeypatch.setattr(settings, "analysis_registration_timeout_seconds", 600)
-        assert materialize_timeout() == "300s"
-        assert registration_timeout() == "600s"
-        monkeypatch.setattr(settings, "analysis_materialize_timeout_seconds", 1200)
-        monkeypatch.setattr(settings, "analysis_registration_timeout_seconds", 1800)
-        assert materialize_timeout() == "1200s"
-        assert registration_timeout() == "1800s"
-
     async def test_ctas_scopes_work_mem_to_its_transaction(
         self,
         test_db_session: AsyncSession,
@@ -2766,58 +2724,6 @@ class TestMaterializeWorker:
         # The parallelism pin exists to protect the work_mem ceiling, so it
         # must not fire when there is no ceiling to protect.
         assert not [s for s in executed if "max_parallel_workers_per_gather" in s]
-
-    def test_work_mem_is_divided_across_worker_slots(self, monkeypatch):
-        """fix(#1012): the budget is per worker PROCESS, so parallel job slots
-        share it — otherwise raising WORKER_CONCURRENCY silently multiplies the
-        db container's exposure."""
-        from app.core.config import settings
-
-        # Set the baseline rather than asserting the shipped default: settings
-        # is a module-level singleton, so ANALYSIS_MATERIALIZE_WORK_MEM_MB in
-        # the environment would otherwise decide this test's outcome.
-        monkeypatch.setattr(settings, "analysis_materialize_work_mem_mb", 64)
-        monkeypatch.setattr(settings, "worker_concurrency", 1)
-        assert _materialize_work_mem() == "64MB"
-        monkeypatch.setattr(settings, "worker_concurrency", 4)
-        assert _materialize_work_mem() == "16MB"
-        # Divided in kB so the budget is never exceeded by rounding: 64MB
-        # across 128 slots is 512kB each, not 1MB each (which would be 128MB
-        # against a 64MB budget). No clamp to the bundled 8MB default either —
-        # this process cannot read the connected cluster's work_mem, so it
-        # cannot know whether such a floor preserves that value or raises it.
-        monkeypatch.setattr(settings, "worker_concurrency", 128)
-        assert _materialize_work_mem() == "512kB"
-        # Sub-megabyte shares are expressed in kB rather than rounded.
-        monkeypatch.setattr(settings, "analysis_materialize_work_mem_mb", 1)
-        monkeypatch.setattr(settings, "worker_concurrency", 8)
-        assert _materialize_work_mem() == "128kB"
-        # A share below PostgreSQL's 64kB minimum cannot reach here: it is
-        # refused at boot (test_config.py), because neither the minimum nor
-        # falling back to the cluster's value honours the budget.
-
-    def test_work_mem_ceiling_is_operator_configurable(self, monkeypatch):
-        """fix(#1012 review): the safe value depends on DB_MEM_LIMIT and on how
-        many worker services consume the ingest queue, neither of which this
-        process can see — DB_MEM_LIMIT is a compose mem_limit and is never in
-        this container's environment. A hardcoded ceiling was therefore only
-        valid for the default 2 GB single-worker deployment, and could OOM a
-        smaller database or a scaled-out one."""
-        from app.core.config import settings
-
-        monkeypatch.setattr(settings, "worker_concurrency", 1)
-        monkeypatch.setattr(settings, "analysis_materialize_work_mem_mb", 16)
-        assert _materialize_work_mem() == "16MB"
-        monkeypatch.setattr(settings, "analysis_materialize_work_mem_mb", 256)
-        assert _materialize_work_mem() == "256MB"
-        # A deliberately small value is honoured, not clamped up: an external
-        # cluster may be tuned below the bundled 8MB, and a floor advertised as
-        # "leaves the cluster value alone" would silently raise it.
-        monkeypatch.setattr(settings, "analysis_materialize_work_mem_mb", 4)
-        assert _materialize_work_mem() == "4MB"
-        # 0 is the opt-out: no override at all.
-        monkeypatch.setattr(settings, "analysis_materialize_work_mem_mb", 0)
-        assert _materialize_work_mem() is None
 
     async def test_worker_rechecks_size_caps_before_ctas(
         self,
@@ -4283,3 +4189,109 @@ class TestUserErrorMessage:
     def test_domain_errors_pass_through(self):
         msg = _user_error_message(ValueError("Analysis produced no features to save"))
         assert "no features" in msg
+
+    def test_timeout_message_names_the_budget_that_fired(self, monkeypatch):
+        """fix(#1013 review): the two budgets are independently configurable
+        now, so a registration timeout quoting the materialize budget would
+        send an operator to tune the setting that did not fire."""
+        from sqlalchemy.exc import OperationalError
+
+        from app.core.config import settings
+        from app.processing.analysis.tasks import _user_error_message
+
+        monkeypatch.setattr(settings, "analysis_materialize_timeout_seconds", 300)
+        monkeypatch.setattr(settings, "analysis_registration_timeout_seconds", 900)
+        exc = OperationalError(
+            "SELECT 1", {}, Exception("canceling statement due to statement timeout")
+        )
+
+        assert "300s" in _user_error_message(exc)
+        assert "900s" not in _user_error_message(exc)
+        assert "900s" in _user_error_message(exc, registered=True)
+        assert "300s" not in _user_error_message(exc, registered=True)
+
+    def test_analysis_timeouts_track_their_settings(self, monkeypatch):
+        """fix(#1013): the budgets are operator settings now, and they are read
+        at call time — a module-level snapshot would freeze whatever the
+        settings object held when this module was first imported."""
+        from app.core.config import settings
+
+        from app.processing.analysis.tasks import registration_timeout
+
+        # Set the baseline rather than asserting the shipped defaults: settings
+        # is a module-level singleton, so an ANALYSIS_*_TIMEOUT_SECONDS in the
+        # environment or the root .env would already have overridden them and
+        # the "before" assertions would fail for a reason unrelated to the
+        # behaviour under test.
+        monkeypatch.setattr(settings, "analysis_materialize_timeout_seconds", 300)
+        monkeypatch.setattr(settings, "analysis_registration_timeout_seconds", 600)
+        assert materialize_timeout() == "300s"
+        assert registration_timeout() == "600s"
+        monkeypatch.setattr(settings, "analysis_materialize_timeout_seconds", 1200)
+        monkeypatch.setattr(settings, "analysis_registration_timeout_seconds", 1800)
+        assert materialize_timeout() == "1200s"
+        assert registration_timeout() == "1800s"
+
+
+# ---------------------------------------------------------------------------
+# work_mem budgeting (pure, no DB)
+# ---------------------------------------------------------------------------
+
+
+class TestMaterializeWorkMem:
+    """fix(#1085): the sync half of the #1012 work_mem tests. Their async
+    siblings stay in TestMaterializeWorker, which runs _materialize against a
+    real table; these only read settings, so they belong beside the other
+    pure ones rather than in a class of DB-backed tests."""
+
+    def test_work_mem_is_divided_across_worker_slots(self, monkeypatch):
+        """fix(#1012): the budget is per worker PROCESS, so parallel job slots
+        share it — otherwise raising WORKER_CONCURRENCY silently multiplies the
+        db container's exposure."""
+        from app.core.config import settings
+
+        # Set the baseline rather than asserting the shipped default: settings
+        # is a module-level singleton, so ANALYSIS_MATERIALIZE_WORK_MEM_MB in
+        # the environment would otherwise decide this test's outcome.
+        monkeypatch.setattr(settings, "analysis_materialize_work_mem_mb", 64)
+        monkeypatch.setattr(settings, "worker_concurrency", 1)
+        assert _materialize_work_mem() == "64MB"
+        monkeypatch.setattr(settings, "worker_concurrency", 4)
+        assert _materialize_work_mem() == "16MB"
+        # Divided in kB so the budget is never exceeded by rounding: 64MB
+        # across 128 slots is 512kB each, not 1MB each (which would be 128MB
+        # against a 64MB budget). No clamp to the bundled 8MB default either —
+        # this process cannot read the connected cluster's work_mem, so it
+        # cannot know whether such a floor preserves that value or raises it.
+        monkeypatch.setattr(settings, "worker_concurrency", 128)
+        assert _materialize_work_mem() == "512kB"
+        # Sub-megabyte shares are expressed in kB rather than rounded.
+        monkeypatch.setattr(settings, "analysis_materialize_work_mem_mb", 1)
+        monkeypatch.setattr(settings, "worker_concurrency", 8)
+        assert _materialize_work_mem() == "128kB"
+        # A share below PostgreSQL's 64kB minimum cannot reach here: it is
+        # refused at boot (test_config.py), because neither the minimum nor
+        # falling back to the cluster's value honours the budget.
+
+    def test_work_mem_ceiling_is_operator_configurable(self, monkeypatch):
+        """fix(#1012 review): the safe value depends on DB_MEM_LIMIT and on how
+        many worker services consume the ingest queue, neither of which this
+        process can see — DB_MEM_LIMIT is a compose mem_limit and is never in
+        this container's environment. A hardcoded ceiling was therefore only
+        valid for the default 2 GB single-worker deployment, and could OOM a
+        smaller database or a scaled-out one."""
+        from app.core.config import settings
+
+        monkeypatch.setattr(settings, "worker_concurrency", 1)
+        monkeypatch.setattr(settings, "analysis_materialize_work_mem_mb", 16)
+        assert _materialize_work_mem() == "16MB"
+        monkeypatch.setattr(settings, "analysis_materialize_work_mem_mb", 256)
+        assert _materialize_work_mem() == "256MB"
+        # A deliberately small value is honoured, not clamped up: an external
+        # cluster may be tuned below the bundled 8MB, and a floor advertised as
+        # "leaves the cluster value alone" would silently raise it.
+        monkeypatch.setattr(settings, "analysis_materialize_work_mem_mb", 4)
+        assert _materialize_work_mem() == "4MB"
+        # 0 is the opt-out: no override at all.
+        monkeypatch.setattr(settings, "analysis_materialize_work_mem_mb", 0)
+        assert _materialize_work_mem() is None

--- a/backend/tests/test_analysis_materialize.py
+++ b/backend/tests/test_analysis_materialize.py
@@ -231,6 +231,12 @@ class TestMaterializeEndpoint:
         job = await test_db_session.get(IngestJob, uuid.UUID(data["job_id"]))
         assert job is not None
         assert job.status == "pending"
+        # fix(#789): the enqueue stamps a step (ux(#698)) so a pending job reads
+        # as "queued" rather than as a broken one. Load-bearing since #703 put
+        # analysis below the default priority: a queued job now waits behind
+        # uploads by design, sometimes for minutes, and this stamp is the only
+        # honest "waiting" signal the UI has to distinguish that from a stall.
+        assert job.current_step == "queued"
         # Request params ride the job row so Admin → Jobs can diagnose runs.
         meta = (job.user_metadata or {}).get("analysis", {})
         assert meta["operation"] == "buffer"

--- a/backend/tests/test_analysis_preview.py
+++ b/backend/tests/test_analysis_preview.py
@@ -778,6 +778,12 @@ class TestAnalysisPreviewEndpoint:
             # so a preview fired while a chat query holds it must read as
             # "try again", not as a server fault.
             ("query_busy", 429),
+            # fix(#789): #1014 added a second 429 category after this test
+            # landed covering only four. Server-at-capacity is deliberately
+            # distinct from query_busy so the message is not relabelled as the
+            # per-user one — same status, different text, so the pair only
+            # stays honest if both are exercised.
+            ("query_at_capacity", 429),
             ("query_timeout", 422),
             ("query_data_error", 422),
             # Anything unmapped falls through the .get default. query_failed
@@ -819,6 +825,18 @@ class TestAnalysisPreviewEndpoint:
         # user_message is the sandbox's already-sanitized text, so it is what
         # the caller reads on every branch including the 500 fallback.
         assert resp.json()["detail"] == message
+
+    def test_every_sandbox_status_category_is_parametrized(self):
+        """fix(#789): the parametrize above is a hand-kept list, so #1014's new
+        category joined the mapping and simply went untested — four of five,
+        still green. Pin the mapping's key set: adding a category now fails
+        here until it is given a case above."""
+        assert set(router_analysis._SANDBOX_STATUS) == {
+            "query_busy",
+            "query_at_capacity",
+            "query_timeout",
+            "query_data_error",
+        }
 
     async def test_truncation_at_feature_cap(
         self,


### PR DESCRIPTION
## Problem

Two small test-suite gaps, both in the same file family, so they land together.

**#789** was re-scoped to backend pytest only, and three of its four items already shipped in #1030 (verified: `fix(#789)` docstrings at `test_analysis_materialize.py:149` and `:1084`, and `test_analysis_preview.py:803`). Item 4 was never done, and a fifth gap opened after item 2 landed.

- The enqueue path stamps `job.current_step = "queued"`, and nothing asserted it. That stamp carries weight because #703 put analysis below the default job priority, so a queued analysis job now waits behind uploads by design. The stamp is the only signal that separates "waiting as intended" from "stuck".
- `_SANDBOX_STATUS` gained a `query_at_capacity` category in #1014, after item 2's parametrize was written against the four that existed then. The new category simply went untested and the suite stayed green.

**#1085** had two sync unit tests of `_user_error_message` sitting in `TestMaterializeWorker`, which is otherwise async tests running `_materialize` against a real table.

## Fix

For #789, assert the `queued` stamp at enqueue, add the missing category to the parametrize, and pin the mapping itself. The new `test_every_sandbox_status_category_is_parametrized` asserts the key set of `_SANDBOX_STATUS`, so the next category added fails here until someone gives it a case. That is the part worth keeping: the hand-kept parametrize is what let #1014's category slip through, and one more entry would not have stopped it happening again.

For #1085, move the tests into `TestUserErrorMessage`, bodies unchanged.

Four tests moved, not the two the issue names. Its second acceptance clause is that `TestMaterializeWorker` contains only async tests, and two `work_mem` tests were also sync. Those went to a new `TestMaterializeWorkMem` class rather than into `TestUserErrorMessage`, since they test a different function. `TestMaterializeWorker` is now 0 sync and 39 async, confirmed by walking the AST rather than by reading.

The four moved bodies are byte-identical to their originals, checked by extracting each function from both commits and comparing the strings.

## Why this shape

The `current_step` assertion is load-bearing rather than decorative. `current_step` is `Mapped[str | None]`, nullable with no column default, and `create_ingest_job` never writes it, so the router at `router_analysis.py:688` is the only writer on this path. Remove the stamp and the assertion fails on `None`.

`_SANDBOX_STATUS` has four keys and exactly one consumer, at `router_analysis.py:404`, so there is no second call path where the mapping could be read differently.

## Correction to the #789 issue body

The body says item 4 is "still gated on #695, which is open". That is wrong in both halves. The `current_step` stamp exists today, and the #695 below-default-priority assertions are also already landed at `test_analysis_materialize.py:227-230`. Nothing here was gated on anything.

## Verification

```
cd backend
# full suite, required by #1085 (its failure mode is invisible to a single-file run)
uv run pytest -n 4 --dist loadgroup
#   6829 passed, 83 skipped, 270 warnings in 696.59s

uv run pytest tests/test_analysis_materialize.py tests/test_analysis_preview.py
#   158 passed
uv run pytest tests/test_layering.py -q     # 36 passed
uv run ruff check .                          # All checks passed
uv run ruff format --check .                 # 875 files already formatted
```

The relocated tests were re-run by node ID to confirm the move, not just re-read: all four pass in their new classes. Every symbol they reference was already a module-level import, so class membership never affected resolution.

Closes #789
Closes #1085