### PR TITLE
chore(frontend): document three invalidators whose liveness is not local

### DIFF
--- a/frontend/src/components/builder/hooks/use-builder-save.ts
+++ b/frontend/src/components/builder/hooks/use-builder-save.ts
@@ -81,6 +81,16 @@ function doCapture(map: MaplibreMap, mapId: string, queryClient: ReturnType<type
       // 400×250 thumbnail — unchanged behavior
       const thumb = cropResize(srcCanvas, 400, 250);
       uploadThumbnail(mapId, thumb.toDataURL('image/jpeg', 0.7)).then(() => {
+        // chore(#1021): this refetches nothing on the builder route, and that is
+        // expected rather than a bug. maps.all is ['maps'] while the builder mounts
+        // useMap, which is ['map', id], a different root string. The target is the
+        // MapsPage browse list (['maps', params]), whose MapCard renders
+        // thumbnail_url/thumbnail_updated_at: that entry is cached but unmounted
+        // while you are in the builder, so marking it stale here is what gets the new
+        // thumbnail on screen when the user navigates back. Do not "helpfully" add
+        // maps.detail. The builder reads thumbnail_url only as the hasThumbnail
+        // auto-capture gate, which shouldAutoCapture's module-level LRU has already
+        // settled by the time this upload resolves.
         queryClient.invalidateQueries({ queryKey: queryKeys.maps.all });
       }).catch(() => {
         // Silent failure for thumbnails

--- a/frontend/src/components/collections/CollectionCreateDialog.tsx
+++ b/frontend/src/components/collections/CollectionCreateDialog.tsx
@@ -48,6 +48,13 @@ export function CollectionCreateDialog({ open, onOpenChange }: CollectionCreateD
       // Invalidate + refetch all collection queries so the list updates
       // before the dialog closes. Use predicate to match any key starting
       // with 'collections' since prefix matching may not catch parameterized keys.
+      // chore(#1021): the sweep itself duplicates the identical predicate that
+      // useCreateCollection already runs in its own onSuccess, so the marking-stale
+      // half is redundant wherever this dialog is mounted. What this call adds is the
+      // `await`, which holds the dialog open until the refetch lands, and that only
+      // does work on CollectionsPage where a collections query is active. This dialog
+      // is also mounted globally from Navbar, where nothing is active and the await
+      // resolves immediately. Keep it for the CollectionsPage path.
       await qc.invalidateQueries({
         predicate: (query) =>
           Array.isArray(query.queryKey) && query.queryKey[0] === 'collections',

--- a/frontend/src/hooks/__tests__/use-config-ops.test.ts
+++ b/frontend/src/hooks/__tests__/use-config-ops.test.ts
@@ -55,6 +55,16 @@ describe('useImportConfig', () => {
     expect(invalidateQueries).toHaveBeenCalledWith({
       queryKey: queryKeys.admin.aiStatus,
     });
+    // chore(#1021): maps.aiAvailability pairs with admin.aiStatus above and is NOT
+    // dead, though it reads that way. useAIAvailability mounts it only when
+    // useAIStatusReader() is false, and under the stored role matrix every config-ops
+    // admin is also a status reader. But capabilities resolve through
+    // PermissionExtension (me_permissions in backend/app/modules/auth/router.py), not
+    // the stored matrix, so an enterprise overlay can grant manage_settings and
+    // use_ai_chat without manage_users. That operator mounts this query and owns the
+    // entry. The line was deleted once on the matrix-only reading and restored after
+    // the codex P2 on #1121 — do not delete it again on the strength of this
+    // assertion being mockable.
     expect(invalidateQueries).toHaveBeenCalledWith({
       queryKey: queryKeys.maps.aiAvailability,
     });

--- a/frontend/src/hooks/use-config-ops.ts
+++ b/frontend/src/hooks/use-config-ops.ts
@@ -65,9 +65,40 @@ export function useImportConfig() {
     mutationFn: ({ data, mode, previewToken }) =>
       importConfig(data, mode, previewToken),
     onSuccess: (result) => {
+      // chore(#1021): AdminConfigOpsPage mounts no useQuery of its own, so none of
+      // these entries is populated by this surface. That alone does not make them
+      // inert: invalidateQueries marks a cached-but-unmounted entry stale and it
+      // refetches on next mount, which is exactly how the Settings tabs and the login
+      // page pick the import up. The test is whether an entry can exist in THIS
+      // user's client at all, and for each key below one can.
       queryClient.invalidateQueries({ queryKey: queryKeys.settings.all });
       queryClient.invalidateQueries({ queryKey: queryKeys.authConfig.config });
+      // chore(#1021): the login page's OAuth buttons. The sibling admin surfaces that
+      // mutate the same providers (SettingsAuthTab, SamlProvidersSection) invalidate
+      // only settingsOAuth.providers and miss this key. That gap is #1117, the inverse
+      // of this issue, and is not fixed here.
       queryClient.invalidateQueries({ queryKey: queryKeys.authConfig.oauthProviders });
+      // chore(#1021): the two AI-readiness keys below are a mutually-exclusive PAIR,
+      // not a duplicate. useAIAvailability mounts admin.aiStatus when
+      // useAIStatusReader() is true and maps.aiAvailability when it is false, so at
+      // most one holds an entry in a given session and each covers an operator class
+      // the other misses. Deleting either half silently drops one of them.
+      //
+      // The second line reads as dead, and that reading is wrong. The argument for
+      // dead goes: config-ops gates on useSettingsAdmin(), and
+      // validate_permission_matrix (backend/app/modules/auth/permissions.py) grants
+      // manage_settings to `admin` alone while refusing to let that role drop
+      // manage_users, so every config-ops admin is also a status reader. That argument
+      // got this line deleted once and had to be reverted. It holds only for the
+      // STORED matrix, which is not the capability authority: me_permissions
+      // (backend/app/modules/auth/router.py) resolves every capability through
+      // PermissionExtension.check_permission, and that is what usePermissions() reads.
+      // An enterprise overlay can therefore grant manage_settings and use_ai_chat
+      // without manage_users. That operator reaches config-ops with canReadStatus
+      // false, mounts maps.aiAvailability, and owns the entry this line invalidates.
+      // Community deployments use DefaultPermissionExtension, which does read the
+      // stored matrix, which is exactly why the line looks dead by default. See the
+      // codex P2 on #1121.
       queryClient.invalidateQueries({ queryKey: queryKeys.admin.aiStatus });
       queryClient.invalidateQueries({ queryKey: queryKeys.maps.aiAvailability });
 


### PR DESCRIPTION
## Problem

A component can call a shared cache invalidator that looks like it participates in cross-surface invalidation while the cache it names can never hold an entry for that caller. The call does nothing, no test fails, and the behaviour it was meant to provide is quietly absent. The known instance survived four or more releases.

The sweep covered 151 `invalidateQueries` sites plus the 5 hooks wrapping one. Nothing high severity, three worth documenting. All three `useInvalidateTileTokens` call sites named in the issue came back live and are unchanged.

## What this changes

No behaviour. Three comments, one test assertion documented, and nothing removed.

That is a different outcome from where this PR started, and the reason is worth recording, because it is the issue's own thesis biting the people auditing for it.

## The site that looks dead and is not

`useImportConfig` invalidates both `admin.aiStatus` and `maps.aiAvailability`. They are a mutually exclusive pair: `useAIAvailability` mounts one when `useAIStatusReader()` is true and the other when it is false, so at most one holds an entry per session and each covers an operator class the other misses.

The second line reads as dead. The argument goes: config-ops gates on `useSettingsAdmin()`, and `validate_permission_matrix` grants `manage_settings` to `admin` alone while refusing to let that role drop `manage_users`, so every config-ops admin is also a status reader and the key can never hold an entry.

**That argument is wrong, and it got the line deleted in an earlier revision of this PR.** It holds only for the stored role matrix, which is not the capability authority. `me_permissions` (`backend/app/modules/auth/router.py`) resolves every capability through `PermissionExtension.check_permission`, and that is what `usePermissions()` reads. An enterprise overlay can grant `manage_settings` and `use_ai_chat` without `manage_users`. That operator reaches config-ops with `canReadStatus` false, mounts `maps.aiAvailability`, and owns the entry the line invalidates.

Community deployments use `DefaultPermissionExtension`, which does read the stored matrix, which is exactly why the line looks dead by default.

The line is restored and the call site now carries the whole argument, including the version that is wrong, so the next reader does not re-derive the mistake. Credit to the codex P2 on this PR for catching the deletion.

## Two live cross-surface calls documented

`use-builder-save.ts` and `CollectionCreateDialog.tsx` both invalidate caches their own surface does not mount, and both are correct. "This surface does not mount the query" is not grounds to call a site inert: `invalidateQueries` marks a cached-but-unmounted entry stale and it refetches on next mount, which is how the Settings tabs and the login page pick up an import. The test is whether an entry can exist in that user's client at all.

## Related

`authConfig.oauthProviders` is invalidated here but missed by the sibling admin surfaces that mutate the same providers (`SettingsAuthTab`, `SamlProvidersSection`), which invalidate only `settingsOAuth.providers`. That is the inverse class, a cache needing invalidation with no invalidator, tracked as #1117. Not fixed here.

## Note for the next sweep

The lesson generalises beyond these three sites. A site's liveness is not readable from the file it lives in, and for anything permission-gated it is not readable from the stored role matrix either, because the extension seam can produce capability combinations the matrix refuses to store. Two reviewers reasoned from the matrix and both concluded wrongly.

## Verification

```
cd frontend
npm run lint          # clean
npm run typecheck     # clean
npm run test:coverage
npx vitest run src/hooks/__tests__/use-config-ops.test.ts   # 3 passed
```

Closes #1021